### PR TITLE
fix: NativeLibs battery suite green — ten general fixes behind it (#5558, #5557)

### DIFF
--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -78,7 +78,12 @@ MIME::Base64	basic.rakutest
 MIME::Base64	binary-and-long-line.rakutest
 MIME::Base64	oneline.rakutest
 MIME::Base64	rfc4648-test-vector.rakutest
+NativeHelpers::Blob	00-trivial.t
 NativeHelpers::Blob	99-my-meta.t
+NativeLibs	01-basic.t
+NativeLibs	02-cannon-name.t
+NativeLibs	10-search.t
+NativeLibs	20-compile.t
 OpenSSL	01-basic.rakutest
 OpenSSL	03-rsa.rakutest
 OpenSSL	04-crypt.rakutest

--- a/docs/batteries/testsuite-gate.md
+++ b/docs/batteries/testsuite-gate.md
@@ -47,7 +47,15 @@ MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh --update
 The harness runs each suite against the **bundled** library (`-I
 vendor/zef/lib`, `-I modules/OpenSSL/lib`, …) — the clone provides only the
 `t/` tests. A test file "passes" when it emits a TAP plan and every planned test
-is `ok` with no `not ok`.
+is `ok`, counting a `not ok … # TODO …` as passing.
+
+A `# TODO` failure is an *expected* failure — TAP says the suite still passes,
+and `prove` agrees. Upstream suites use it for assertions that depend on the
+host: `NativeLibs`' `10-search.t` marks its "is there a versioned
+`libmysqlclient`?" probe TODO, and raku fails that subtest on this machine too.
+Counting it as a failure would make such a file ungateable even at exact parity
+with raku. The verdict line reports the count (`PASS(1 todo)`) so a file quietly
+turning its whole plan into TODOs is still visible.
 
 The harness unconditionally sets `DBIISH_WRITE_TEST=YES` (harmless for every
 other battery, which doesn't read it): without it, `DBIish`'s own

--- a/news/2026-07/nativelibs-battery-suite-green.md
+++ b/news/2026-07/nativelibs-battery-suite-green.md
@@ -1,0 +1,190 @@
+# `NativeLibs`' upstream test suite passes in full
+
+`NativeLibs` (0.0.9, 96 dependents in the fez index) is bundled as a runtime
+dependency of the `DBIish` database battery, but none of its four upstream test
+files was in the release gate's baseline: only 1 of the 9 files across it and
+`NativeHelpers::Blob` passed. All four `NativeLibs` files now pass, and so does
+`NativeHelpers::Blob`'s `00-trivial.t` — the gate's baseline goes from 132 to 137
+files (closing [#5558](https://github.com/tokuhirom/mutsu/issues/5558), and
+[#5557](https://github.com/tokuhirom/mutsu/issues/5557) as far as it can go).
+
+Every fix below is a general interpreter or compatibility fix, not a
+`NativeLibs`-shaped patch — rung 2 of the
+[adoption policy](../../BATTERIES.md#1-adoption-policy--community-first-adopt-as-is).
+
+## `$*VM.config` was nearly empty
+
+It carried three keys (`name`, `be`, `nativecall_backend`). Missing among them
+was **`osname`**, which `NativeLibs` uses to switch its entire library-naming
+scheme:
+
+```raku
+given $*VM.config<osname>.lc {
+    when 'linux'|'freebsd' { ... }
+    when 'darwin'          { ... }
+}
+```
+
+An undefined key matched nothing, so on Linux the whole platform section was
+skipped in silence: `02-cannon-name.t` planned 10 tests and ran zero. Also
+missing was the **C toolchain** MoarVM records (`cc`, `cflags`, `ccshared`,
+`ccout`, `obj`, `ld`, `ldshared`, `ldflags`, `ldlibs`, `ldout`, `dll`), which
+`NativeLibs::Compile` joins into a `shell()` command line to build a companion
+`.so` for a binding.
+
+mutsu is not built by a C compiler the way MoarVM is, so there is no recorded
+build config to echo back. `src/runtime/io_sysinfo_vm_config.rs` reports a
+working *host* toolchain instead — which is what the consumers actually want the
+keys for — and lets `CC` / `LD` / `CFLAGS` from the environment win, so an
+alternate toolchain can still be selected. Pinned by `t/vm-config-toolchain.t`,
+which also asserts that `config<dll>` (a sprintf pattern) agrees with
+`$*VM.platform-library-name`.
+
+## `platform-library-name` mangled any path with a directory
+
+It decorated the whole string rather than the basename, so `/bar/foo` became
+`lib/bar/foo.so` instead of `/bar/libfoo.so`. Rakudo decorates the basename, puts
+the directory back, and makes the result absolute whenever the input carried any
+directory at all (`./foo` → `$*CWD/libfoo.so`) — which is exactly what makes the
+"load the `.so` I just built next to me" idiom work. Pinned by
+`t/platform-library-name-path.t`.
+
+## Package-qualified multi dispatch ignored optional parameters
+
+```raku
+module M {
+    our proto sub f(|) { * }
+    multi sub f(Str $l, Version $v = Version) { ... }
+    multi sub f(Str $l, Cool $c) { ... }
+}
+M::f('foo');   # No matching candidates for proto sub: M::f
+```
+
+Candidates are registered under keys built from their *declared* arity, so a call
+that omits a defaulted trailing parameter never matches the exact-arity keys. The
+bare-name resolution path has had a fallback for this for a long time; the
+package-qualified path did not, so a qualified call could not reach a candidate
+that the identical bare call resolved fine. Both qualified paths
+(`resolve_function_with_types` and `resolve_proto_candidate_with_types`) now share
+one `qualified_flexible_arity_candidates` fallback.
+
+## A native sub called through a code object ran its `{ * }` stub
+
+`NativeLibs` picks between the dyncall and libffi symbol lookups by *value*:
+
+```raku
+with (is-win ?? &GetProcAddress !! dyncall ?? &dlFindSymbol !! &dlsym)(|c) { ... }
+```
+
+The two VM call opcodes check the `is native` registry by name, but a call
+through a code object resolves the callee as a value and never consulted it — so
+the sub ran its literal `{ * }` body and returned the Whatever `*`, failing its
+own return-type check. `call_sub_value` and `vm_call_on_value` now try the same
+name-keyed native dispatch first.
+
+## `nativecast(<Signature>, $ptr)` was not implemented
+
+Attaching a signature to a function pointer obtained at runtime is the only way a
+`dlsym`ed symbol becomes callable:
+
+```raku
+$dll.symbol('sin', :(num64 --> num64))(pi / 2);   # 1
+```
+
+`src/runtime/nativecall_fnptr.rs` builds a `NativeCallSpec` from the signature and
+registers it under a synthetic key, so every existing name-keyed dispatch path
+handles the result with no further plumbing; `NativeCallSpec` gained an `entry`
+field that bypasses library/symbol resolution. Both routes are pinned by
+`t/nativecall-signature-cast.t`.
+
+## `constant Foo = Int` was not usable as a type
+
+C bindings spell their platform types this way — `constant HANDLE = uint32;
+sub GetProcessHeap(--> HANDLE) is native('kernel32') { * }` — and Raku accepts
+the alias anywhere a type name goes. mutsu's compile-time signature validator
+rejected it outright ("Invalid typename" / "Type 'HANDLE' is not declared"), so
+the whole declaration failed to compile. The alias is now recognized, but only
+when it points at some *other* resolvable type: a `package` binds its own name to
+itself, and `my package A {}; sub foo(A $a)` must stay
+`X::Parameter::BadType`. Pinned by `t/constant-type-alias.t` (including all three
+negative cases).
+
+## `our proto sub` was invisible in its package's stash
+
+```raku
+module M { our proto sub f(|) { * }; multi sub f(Int) { 1 } }
+M::.keys          # was ()          raku: (&f)
+::('M::&f')       # was a Failure
+```
+
+Two causes. Protos live in their own registry, which the package-stash builder
+never scanned; and each bare `multi` candidate marked `M::f` `my`-scoped, which
+hid the name however the proto was declared. A proto is the one *visible* name of
+a multi (its candidates are lexical), so `our` on it publishes the whole routine:
+`Stmt::ProtoDecl` now carries `is_our`, and an explicit `our` marking wins over
+the `my` marking of the same name. A bare (non-`our`) proto still stays lexical,
+matching Rakudo. Pinned by `t/our-proto-package-stash.t`.
+
+## `NativeCall`'s export list was empty
+
+mutsu implements NativeCall inside the VM, so `use NativeCall` loads no Raku
+module — but the module's export surface is introspectable in Rakudo, and
+`NativeLibs` copies the whole `NativeCall::EXPORT::ALL` stash into its own
+`UNIT::EXPORT` so that its users get NativeCall transitively. With an empty stash
+that re-export silently did nothing. Three gaps closed along the way, all
+general:
+
+- `NativeCall`'s export names are registered (`register_nativecall_exports`), and
+  `::('NativeCall')` resolves to the package.
+- A module that exports anything gains an `EXPORT` member in its own stash, and
+  an EXPORT package always lists the `ALL` tag. Without those, walking
+  `Mod::EXPORT::ALL` one component at a time failed even though the whole name
+  resolved.
+- `NCexports::{$_}` on a lexical bound to a package now reads *that package's*
+  stash rather than looking for a package literally named `NCexports`.
+
+Pinned by `t/nativecall-export-stash.t`.
+
+## `:v<…>` was not accepted as short for `:ver<…>`
+
+`use-ok 'NativeLibs:v<0.0.9>'` could not find the module: only `ver`, `auth` and
+`api` were recognized as distribution selectors, so `:v<0.0.9>` was taken as part
+of the module *name*. Pinned by `t/use-version-short-adverb.t`.
+
+## A `when` block's value was warned about as sink context
+
+`when`/`default` succeed out of the enclosing topicalizer with their final
+statement's value, so it is not sunk — Rakudo warns for `if True { 1 }` but not
+for `when 'a' { 1 }`. mutsu warned for both, and because the analysis is
+compile-time the warning fired even on a branch that never runs: a Linux-only
+test file emitted a spurious "Useless use of constant string … in sink context"
+for the `when 'darwin' { skip-rest, "Tests missing" }` arm it skipped. Statements
+*before* the last one are still sunk. Pinned by
+`t/when-block-value-not-sunk.t`.
+
+## Gate harness: a `# TODO` failure is not a failure
+
+`NativeLibs`' `10-search.t` marks its "is there a versioned `libmysqlclient`?"
+probe TODO, and raku fails that subtest on this machine too. TAP (and `prove`)
+treat a `not ok … # TODO` as an expected failure; the battery gate counted it as
+a real one, which made the file ungateable at exact parity with raku. The harness
+now excludes TODO failures from its verdict and reports the count
+(`PASS(1 todo)`), so a file quietly turning its whole plan into TODOs stays
+visible.
+
+## What is still blocked
+
+`NativeHelpers::Blob`'s `01-basic.t` (8/24) and `03-pointer.t` (0/10) both stop at
+the same wall: a `CArray[T]` constructed from Raku has no C storage, so its
+`.REPR` is `P6opaque` and it has no address to `nativecast` from. That is
+**ADR-0015 P3** (native-backed Raku-side `CArray[T]` / `array[T]`), a designed but
+unstarted phase — see
+[`todo/deep/nativehelpers-blob-moarvm-guts.md`](../../todo/deep/nativehelpers-blob-moarvm-guts.md),
+which now records exactly which files and subtests it gates. `02-cstruct.t` is
+not whitelistable at all: raku itself fails two of its tests here.
+
+One narrower fix landed in this area anyway, because `NativeHelpers::Blob`'s
+signatures need it: an unparameterized `CArray` constraint now accepts a
+`CArray[T]` — parameterization narrows a type rather than replacing it, so
+`isa-ok $au, CArray` and `sub carray-is-managed(CArray:D \arr)` both work.
+Pinned by `t/carray-base-type-match.t`.

--- a/scripts/battery-testsuite.sh
+++ b/scripts/battery-testsuite.sh
@@ -75,18 +75,30 @@ fetch_commit() {
 # that) and reach for fixtures by RELATIVE path, e.g. OpenSSL's 03-rsa does
 # `slurp 't/key.pem'`. Running from the mutsu repo root instead made such files
 # die before their first test and be miscounted as library failures.
+# A `not ok N - desc # TODO reason` line is an *expected* failure: TAP says the
+# suite still passes, and `prove` agrees. Upstream suites use it for assertions
+# that depend on the host (NativeLibs' 10-search only finds a versioned
+# `libmysqlclient` on some distros), so counting it as a failure would make a file
+# ungateable even at exact parity with raku — which fails the same subtest.
 run_one() {
   local workdir="$1"; shift
-  local out planned nok okc
+  local out planned nok okc todo
   out="$(cd "$workdir" && timeout 120 "$MUTSU_BIN" "$@" 2>&1)"
   planned="$(printf '%s\n' "$out" | grep -oE '^1\.\.[0-9]+' | head -1 | cut -d. -f3)"
   nok="$(printf '%s\n' "$out" | grep -cE '^not ok')"
   okc="$(printf '%s\n' "$out" | grep -cE '^ok ')"
-  if [ -n "$planned" ] && [ "$nok" -eq 0 ] && [ "$okc" -eq "$planned" ]; then
-    echo "PASS"
+  todo="$(printf '%s\n' "$out" | grep -ciE '^not ok.*# *TODO')"
+  if [ -n "$planned" ] \
+     && [ "$((nok - todo))" -eq 0 ] \
+     && [ "$((okc + todo))" -eq "$planned" ]; then
+    if [ "$todo" -gt 0 ]; then
+      echo "PASS($todo todo)"
+    else
+      echo "PASS"
+    fi
     return 0
   fi
-  echo "FAIL(ok=$okc/${planned:-?},notok=$nok)"
+  echo "FAIL(ok=$okc/${planned:-?},notok=$nok,todo=$todo)"
   return 1
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1046,6 +1046,11 @@ pub(crate) enum Stmt {
         /// whose `{*}` dispatches to the matching multi method candidate,
         /// rather than a package-level proto sub.
         is_method: bool,
+        /// True for `our proto sub`. The proto is the one *visible* name of a
+        /// multi (its candidates are lexical), so `our` on it makes the whole
+        /// routine a package symbol: `module M { our proto sub f(|) {*} }` puts
+        /// `&f` in `M::` and `::('M::&f')` resolves.
+        is_our: bool,
     },
     Let {
         name: String,

--- a/src/parser/sink_warn.rs
+++ b/src/parser/sink_warn.rs
@@ -262,10 +262,27 @@ fn walk_stmt(stmt: &Stmt, nil_hint: bool) {
             walk_stmts(then_branch, false);
             walk_stmts(else_branch, false);
         }
-        Stmt::When { body, .. } | Stmt::Default(body) => walk_stmts(body, false),
+        // A `when`/`default` block's final statement is the block's *value* —
+        // `when` succeeds out of the enclosing topicalizer with it — so it is not
+        // sunk. Rakudo warns for `if True { 1 }` but not for `when 'a' { 1 }`,
+        // and mutsu warned for both; the spurious warning fired even on a branch
+        // that never ran (`when 'darwin' { skip-rest, "…" }` in a Linux-only
+        // test file). Everything before the last statement is still sunk.
+        Stmt::When { body, .. } | Stmt::Default(body) => walk_stmts(sunk_prefix(body), false),
         // Everything else (declarations, calls, say/print, assignments, and the
         // bodies of subs/classes/etc.) is not analysed for sink warnings.
         _ => {}
+    }
+}
+
+/// The statements of `body` that are genuinely in sink context when the block's
+/// final statement is its value: everything up to (and not including) the last
+/// real statement. Trailing bookkeeping markers (`SetLine`) are not statements
+/// and are kept out of the reckoning.
+fn sunk_prefix(body: &[Stmt]) -> &[Stmt] {
+    match body.iter().rposition(|s| !matches!(s, Stmt::SetLine(_))) {
+        Some(last) => &body[..last],
+        None => body,
     }
 }
 

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -37,5 +37,7 @@ pub(crate) use role_decl::skip_optional_role_args;
 pub(super) use class_decl::{also_trait_stmt, class_decl_body};
 pub(crate) use class_decl::{anon_class_decl, augment_class_decl, class_decl};
 pub(super) use grammar_module::{does_decl, grammar_decl, module_decl, token_decl, trusts_decl};
-pub(super) use package_decl::{package_decl, package_decl_my, proto_decl, unit_module_stmt};
+pub(super) use package_decl::{
+    package_decl, package_decl_my, proto_decl, proto_decl_scoped, unit_module_stmt,
+};
 pub(super) use role_decl::role_decl;

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -521,6 +521,11 @@ pub(crate) fn package_decl_with_scope(input: &str, is_my: bool) -> PResult<'_, S
 
 /// Parse `proto` declaration.
 pub(crate) fn proto_decl(input: &str) -> PResult<'_, Stmt> {
+    proto_decl_scoped(input, false)
+}
+
+/// `proto` declaration, `is_our` set for the `our proto ...` spelling.
+pub(crate) fn proto_decl_scoped(input: &str, is_our: bool) -> PResult<'_, Stmt> {
     let rest = keyword("proto", input).ok_or_else(|| PError::expected("proto declaration"))?;
     let (rest, _) = ws1(rest)?;
     // proto token | proto rule | proto sub | proto method
@@ -576,6 +581,7 @@ pub(crate) fn proto_decl(input: &str) -> PResult<'_, Stmt> {
                     .map(|(n, _)| n.clone())
                     .collect(),
                 is_method,
+                is_our,
             },
         ));
     }
@@ -594,6 +600,7 @@ pub(crate) fn proto_decl(input: &str) -> PResult<'_, Stmt> {
                 .map(|(n, _)| n.clone())
                 .collect(),
             is_method,
+            is_our,
         },
     ))
 }

--- a/src/parser/stmt/decl/mod.rs
+++ b/src/parser/stmt/decl/mod.rs
@@ -30,7 +30,7 @@ use crate::value::Value;
 
 use super::sub::parse_type_constraint_expr;
 use super::{
-    class::{module_decl, package_decl_my, proto_decl, role_decl},
+    class::{module_decl, package_decl_my, proto_decl_scoped, role_decl},
     keyword, parse_assign_expr_or_comma, parse_statement_modifier,
 };
 

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -14,7 +14,7 @@ use super::my_decl_helpers::{
     check_invalid_type_smiley, parse_optional_type_constraint, parse_sigilless_decl,
     parse_typed_constant, try_dot_twigil_attr,
 };
-use super::{parse_char, proto_decl};
+use super::{parse_char, proto_decl_scoped};
 use crate::ast::{Expr, Stmt};
 
 use super::super::sub::parse_type_constraint_expr;
@@ -137,7 +137,7 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
             rest = after_ws;
             // Fall through to normal variable parsing below
         } else {
-            return proto_decl(rest);
+            return proto_decl_scoped(rest, is_our);
         }
     }
 

--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -338,6 +338,12 @@ impl Interpreter {
                     tags.extend(tagset.iter().cloned());
                 }
             }
+            // `ALL` is always a member of an EXPORT package — it is the
+            // everything-tag, not a tag any symbol is declared with, so it never
+            // appears in the collected tag sets. Leaving it out made
+            // `::('Mod::EXPORT::ALL')` (resolved one component at a time) fail on
+            // the last step even though the whole name resolves.
+            tags.insert("ALL".to_string());
             let mut symbols: HashMap<String, Value> = HashMap::new();
             for tag in tags {
                 symbols.insert(
@@ -406,6 +412,40 @@ impl Interpreter {
             // Skip my-scoped subs (they should not appear in the package stash)
             let fq_base = format!("{}::{}", package_name, base);
             if self.is_my_scoped_package_item(&fq_base) {
+                continue;
+            }
+            symbols
+                .entry(format!("&{base}"))
+                .or_insert_with(|| Value::routine_parts(def.package, def.name, false));
+        }
+
+        // A module that exports anything has an `EXPORT` member in its stash
+        // (`module Foo { our sub bar is export {} }` gives `Foo::.keys` ==
+        // `(&bar EXPORT)` in Rakudo). Without it, walking a name one component
+        // at a time — which is what `::('Foo::EXPORT::ALL')` does — stopped at
+        // `EXPORT` even though `Foo::EXPORT::ALL` resolves when spelled whole.
+        if self.exported_subs.contains_key(package_name.as_str())
+            || self.exported_vars.contains_key(package_name.as_str())
+        {
+            symbols.entry("EXPORT".to_string()).or_insert_with(|| {
+                Value::package(Symbol::intern(&format!("{package_name}::EXPORT")))
+            });
+        }
+
+        // A `proto sub` is held in its own registry, not in `functions`, so the
+        // loop above never saw it — `module M { our proto sub f(|) {*} }` had an
+        // empty stash and `::('M::&f')` was a Failure. Its candidates are not
+        // stash members in Rakudo either (a bare `multi` is lexical); the proto
+        // is the one visible name, and it is visible exactly when it is `our`.
+        for (key, def) in &self.registry().proto_functions {
+            let key_s = key.resolve();
+            let Some(base) = Self::stash_member_tail(&key_s, &package_name) else {
+                continue;
+            };
+            if base.is_empty() || base.contains("::") || base.contains(':') {
+                continue;
+            }
+            if self.is_my_scoped_package_item(&format!("{}::{}", package_name, base)) {
                 continue;
             }
             symbols

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -296,7 +296,7 @@ impl crate::runtime::Interpreter {
     /// Whether a *field* of type `name` occupies one pointer inside an
     /// enclosing CStruct: any class NativeCall holds by reference, i.e. one
     /// declared `is repr('CStruct')`, `'CPointer'` or `'CUnion'`.
-    fn is_native_handle_class(&self, name: &str) -> bool {
+    pub(crate) fn is_native_handle_class(&self, name: &str) -> bool {
         let short = name.rsplit("::").next().unwrap_or(name);
         let reg = self.registry();
         [
@@ -611,6 +611,16 @@ impl crate::runtime::Interpreter {
                 "nativecast() expects 2 arguments, got {}",
                 args.len()
             ))));
+        }
+        // `nativecast(:(num64 --> num64), $ptr)` — cast a raw C function pointer
+        // to a *signature*, yielding something callable. This is how a symbol
+        // looked up at runtime becomes a usable routine (`NativeLibs`'
+        // `Loader.symbol($name, :(num64 --> num64))`), so there is no `is native`
+        // declaration and no symbol name to bind — only the address.
+        if let ValueView::Instance { class_name, id, .. } = args[0].view()
+            && class_name.resolve() == "Signature"
+        {
+            return Some(self.native_callable_from_signature(id, &args[1]));
         }
         let target = match args[0].view() {
             ValueView::Package(n) => n.resolve().to_string(),

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -270,6 +270,16 @@ impl Interpreter {
             if let Some(def) = self.choose_best_matching_candidate(name, arg_values, candidates) {
                 return Some((*def).clone());
             }
+            // Same flexible-arity fallback the qualified branch of
+            // `resolve_function_with_types` uses: a candidate with an
+            // optional/defaulted/slurpy positional is registered under its
+            // declared arity, not the call's.
+            let flexible = self.qualified_flexible_arity_candidates(name);
+            if !flexible.is_empty()
+                && let Some(def) = self.choose_best_matching_candidate(name, arg_values, flexible)
+            {
+                return Some((*def).clone());
+            }
             return None;
         }
         self.resolve_function_with_types(name, arg_values)

--- a/src/runtime/dispatch_resolve.rs
+++ b/src/runtime/dispatch_resolve.rs
@@ -35,6 +35,39 @@ impl Interpreter {
         None
     }
 
+    /// Candidates for a package-qualified `name` that can absorb a call whose
+    /// positional count differs from their declared one — i.e. those with an
+    /// optional / defaulted / slurpy positional parameter — gathered across ALL
+    /// registered arities, sorted most-specific first.
+    ///
+    /// Multi candidates are registered under `Pkg::name/<arity>…` keys built
+    /// from the *declared* parameter count, so a call that omits a defaulted
+    /// trailing parameter never matches the exact-arity keys. The bare-name
+    /// path has long had this fallback; the qualified path did not, so
+    /// `NativeLibs::cannon-name('foo')` could not reach
+    /// `multi cannon-name(Str $l, Version $v = Version)` even though the
+    /// identical bare call resolved fine.
+    pub(super) fn qualified_flexible_arity_candidates(
+        &self,
+        name: &str,
+    ) -> Vec<(String, Arc<FunctionDef>)> {
+        let prefix = format!("{}/", name);
+        let mut candidates: Vec<(String, Arc<FunctionDef>)> =
+            self.registry()
+                .functions
+                .iter()
+                .filter(|(k, def)| {
+                    k.resolve().starts_with(&prefix)
+                        && def.param_defs.iter().any(|p| {
+                            !p.named && (p.optional_marker || p.default.is_some() || p.slurpy)
+                        })
+                })
+                .map(|(k, def)| (k.resolve(), def.clone()))
+                .collect();
+        self.sort_candidates_by_specificity(&mut candidates);
+        candidates
+    }
+
     pub(super) fn resolve_function_with_arity(
         &self,
         name: &str,
@@ -169,6 +202,14 @@ impl Interpreter {
                 {
                     return Some(def);
                 }
+            }
+            // A candidate whose declared arity differs from the call's because a
+            // trailing parameter is optional/defaulted/slurpy.
+            let flexible = self.qualified_flexible_arity_candidates(name);
+            if !flexible.is_empty()
+                && let Some(def) = self.choose_best_matching_candidate(name, arg_values, flexible)
+            {
+                return Some(def);
             }
             if let Some(def) = self
                 .registry()

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -192,6 +192,30 @@ fn collect_declared_type_names_with(
                 }
                 collect_declared_type_names_with(interp, extra_dirs, body, out, packages, classes);
             }
+            // `constant HANDLE = uint32;` aliases a type, and the alias is usable
+            // wherever a type name is (`sub GetProcessHeap(--> HANDLE)`, which is
+            // how C bindings spell their platform types). Only a bare-name RHS
+            // counts: `constant TAU = 6.28` names a value, not a type, and must
+            // stay rejected as a parameter type. Whether the bare name really
+            // resolves to a type is not decided here — this pre-pass only records
+            // that the *alias* exists, exactly as it does for a `class`.
+            Stmt::VarDecl {
+                name,
+                expr: crate::ast::Expr::BareWord(target),
+                custom_traits,
+                ..
+            } if custom_traits.iter().any(|(t, _)| t == "__constant")
+                && name.starts_with(|c: char| c.is_ascii_uppercase() || c.is_ascii_lowercase())
+                && !name.starts_with(['$', '@', '%', '&']) =>
+            {
+                // Record only when the target itself looks like a type name, so a
+                // `constant Foo = bareword-sub-call` is not mistaken for a type.
+                if interp.is_none_or(|i| i.is_resolvable_type(target) || i.has_type(target))
+                    || crate::runtime::nativecall::CType::from_type_name(target).is_some()
+                {
+                    insert_declared_name(out, name);
+                }
+            }
             Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
                 collect_declared_type_names_with(interp, extra_dirs, body, out, packages, classes);
             }

--- a/src/runtime/io_sysinfo.rs
+++ b/src/runtime/io_sysinfo.rs
@@ -376,12 +376,10 @@ impl Interpreter {
         attrs.insert("desc".to_string(), Value::str_from("mutsu virtual machine"));
         // osname mirrors the build-time OS name MoarVM exposes via `$*VM.osname`
         // (e.g. "linux", "darwin", "mswin32"); zef branches on it (tar/CLI).
-        let osname = match std::env::consts::OS {
-            "macos" => "darwin",
-            "windows" => "mswin32",
-            other => other,
-        };
-        attrs.insert("osname".to_string(), Value::str_from(osname));
+        attrs.insert(
+            "osname".to_string(),
+            Value::str_from(super::io_sysinfo_vm_config::osname()),
+        );
         attrs.insert("precomp-ext".to_string(), Value::str_from("mutsu"));
         attrs.insert("precomp-target".to_string(), Value::str_from("mutsu"));
         attrs.insert("prefix".to_string(), Value::str_from("mutsu"));
@@ -389,23 +387,10 @@ impl Interpreter {
         let mut props = HashMap::new();
         props.insert("name".to_string(), Value::str_from("mutsu"));
         attrs.insert("properties".to_string(), Value::hash(props));
-        // config: a non-empty hash so the value is truthy.
-        let mut config = HashMap::new();
-        config.insert("name".to_string(), Value::str_from("mutsu"));
-        // be: 0 for little-endian, 1 for big-endian (matches Rakudo's $*VM.config<be>)
-        let be_val = if cfg!(target_endian = "big") {
-            "1"
-        } else {
-            "0"
-        };
-        config.insert("be".to_string(), Value::str_from(be_val));
-        // nativecall_backend names the FFI implementation behind NativeCall.
-        // Modules branch on it to decide whether the dyncall-only extensions are
-        // available (`NativeLibs` does `$*VM.config<nativecall_backend> eq
-        // 'dyncall'`); mutsu's is libffi, which is also what a modern MoarVM
-        // reports, and reading it must not warn about an undefined value.
-        config.insert("nativecall_backend".to_string(), Value::str_from("libffi"));
-        attrs.insert("config".to_string(), Value::hash(config));
+        attrs.insert(
+            "config".to_string(),
+            Value::hash(super::io_sysinfo_vm_config::vm_config()),
+        );
         Value::make_instance(Symbol::intern("VM"), attrs)
     }
 

--- a/src/runtime/io_sysinfo_vm_config.rs
+++ b/src/runtime/io_sysinfo_vm_config.rs
@@ -1,0 +1,122 @@
+//! `$*VM.config` — the build-configuration hash MoarVM exposes.
+//!
+//! Raku modules read this hash for two very different kinds of information:
+//!
+//! 1. *Facts about the running VM* (`osname`, `be`, `nativecall_backend`) used
+//!    to branch platform-specific code. `NativeLibs` switches its whole
+//!    library-naming scheme on `config<osname>`, so a missing key silently
+//!    disables every platform branch rather than failing loudly.
+//! 2. *The C toolchain the VM itself was built with* (`cc`, `cflags`, `ld`, …).
+//!    `NativeLibs::Compile` joins these into a `shell()` command line to build
+//!    a companion `.so` for a NativeCall binding. mutsu is not built by a C
+//!    compiler in the way MoarVM is, so there is no recorded build config to
+//!    echo back; report a working *host* toolchain instead — that is what the
+//!    consumers actually need the keys for, and `CC`/`LD`/`CFLAGS` from the
+//!    environment still win so a cross/alternate toolchain can be selected.
+//!
+//! Everything is a `Str`, matching MoarVM (even `be`, which is `"0"`/`"1"`).
+
+use crate::value::Value;
+use std::collections::HashMap;
+
+/// The `osname` MoarVM reports: its own build-time OS name, not uname's.
+pub(crate) fn osname() -> &'static str {
+    match std::env::consts::OS {
+        "macos" => "darwin",
+        "windows" => "mswin32",
+        other => other,
+    }
+}
+
+fn env_or(key: &str, fallback: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+/// Build the `$*VM.config` hash.
+pub(crate) fn vm_config() -> HashMap<String, Value> {
+    let os = std::env::consts::OS;
+    let is_darwin = os == "macos";
+    let is_windows = os == "windows";
+
+    // Toolchain defaults per platform. `cc`/`ld` are the same driver on unix;
+    // MoarVM records the shared-library flags separately because linking a
+    // loadable module needs `-shared` (`-dynamiclib` on darwin) on top of the
+    // position-independent compile flags.
+    let (cc, ccshared, ldshared, obj, out) = if is_windows {
+        ("cl", "", "/LD", ".obj", "/Fe")
+    } else if is_darwin {
+        (
+            "cc",
+            "-fPIC",
+            "-dynamiclib -undefined dynamic_lookup",
+            ".o",
+            "-o ",
+        )
+    } else {
+        ("cc", "-fPIC", "-shared -fPIC", ".o", "-o ")
+    };
+
+    let mut config = HashMap::new();
+    let mut set = |k: &str, v: String| {
+        config.insert(k.to_string(), Value::str(v));
+    };
+
+    set("name", "mutsu".to_string());
+    set("osname", osname().to_string());
+    // be: 0 for little-endian, 1 for big-endian.
+    set(
+        "be",
+        if cfg!(target_endian = "big") {
+            "1"
+        } else {
+            "0"
+        }
+        .to_string(),
+    );
+    // nativecall_backend names the FFI implementation behind NativeCall.
+    // Modules branch on it to decide whether the dyncall-only extensions are
+    // available (`NativeLibs` does `$*VM.config<nativecall_backend> eq
+    // 'dyncall'`); mutsu's is libffi, which is also what a modern MoarVM
+    // reports, and reading it must not warn about an undefined value.
+    set("nativecall_backend", "libffi".to_string());
+
+    // --- C toolchain (see the module docs for why these are host values) ---
+    set("cc", env_or("CC", cc));
+    set("ccswitch", "-c".to_string());
+    set("ccshared", env_or("CFLAGS_SHARED", ccshared));
+    set("ccout", out.to_string());
+    set("cflags", env_or("CFLAGS", "-O2"));
+    set("obj", obj.to_string());
+    set("exe", if is_windows { ".exe" } else { "" }.to_string());
+    set("ld", env_or("LD", cc));
+    set("ldshared", env_or("LDFLAGS_SHARED", ldshared));
+    set("ldflags", env_or("LDFLAGS", ""));
+    set(
+        "ldlibs",
+        env_or("LIBS", if is_windows { "" } else { "-lm" }),
+    );
+    set("ldout", out.to_string());
+    let load_ext = if is_windows {
+        ".dll"
+    } else if is_darwin {
+        ".dylib"
+    } else {
+        ".so"
+    };
+    // `dll` is a *sprintf pattern* mapping a bare library name to its shared
+    // object filename (MoarVM records `lib%s.so`); `$*VM.platform-library-name`
+    // is defined in terms of it.
+    set(
+        "dll",
+        if is_windows {
+            "%s.dll".to_string()
+        } else {
+            format!("lib%s{load_ext}")
+        },
+    );
+
+    config
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -174,6 +174,7 @@ mod class_introspection;
 pub(crate) use class_introspection::UserMethodOrAccessor;
 pub(crate) mod cstruct_layout;
 mod decl_types;
+pub(crate) mod nativecall_fnptr;
 pub(crate) use self::decl_types::*;
 pub(crate) mod deprecation;
 pub(crate) mod did_you_mean;
@@ -201,6 +202,7 @@ mod io_pod_config;
 mod io_pod_entries;
 mod io_pod_table;
 mod io_sysinfo;
+mod io_sysinfo_vm_config;
 mod iterator_protocol;
 pub(crate) mod json;
 mod lock_reentry;
@@ -1427,6 +1429,9 @@ pub struct Interpreter {
     /// Fully-qualified names of `my`-scoped classes/subs inside packages.
     /// These should NOT appear in the parent package's stash.
     my_scoped_package_items: HashSet<String>,
+    /// Names published by an explicit `our` declaration; wins over
+    /// `my_scoped_package_items` (see `mark_our_scoped_package_item`).
+    our_scoped_package_items: HashSet<String>,
     /// Stack of lexically-scoped class names per block scope depth.
     /// When a block scope exits, classes registered in that scope get suppressed.
     lexical_class_scopes: Vec<Vec<String>>,

--- a/src/runtime/native_methods/system.rs
+++ b/src/runtime/native_methods/system.rs
@@ -166,6 +166,32 @@ impl Interpreter {
 
     // --- VM ---
 
+    /// `$path.absolute` for a path that need not exist: prepend `$*CWD` when it
+    /// is relative and fold away `.` / `..` components lexically (no `realpath`,
+    /// so nothing is resolved through symlinks and a missing file is fine).
+    fn absolute_lexical_path(path: &std::path::Path) -> String {
+        use std::path::Component;
+        let absolute = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            match std::env::current_dir() {
+                Ok(cwd) => cwd.join(path),
+                Err(_) => path.to_path_buf(),
+            }
+        };
+        let mut out = std::path::PathBuf::new();
+        for comp in absolute.components() {
+            match comp {
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    out.pop();
+                }
+                other => out.push(other),
+            }
+        }
+        out.to_string_lossy().to_string()
+    }
+
     pub(in crate::runtime) fn native_vm(
         &mut self,
         attributes: &AttrMap,
@@ -220,14 +246,32 @@ impl Interpreter {
                     .map(|v| v.to_string_value())
                     // `Version.new(5).Str` is `5`, but a `Version` gists as `v5`.
                     .map(|s| s.strip_prefix('v').unwrap_or(&s).to_string());
+                // Rakudo decorates only the BASENAME and puts the directory back
+                // afterwards: `'/bar/foo'.IO` becomes `/bar/libfoo.so`, not
+                // `lib/bar/foo.so`. A name that carries any directory at all is
+                // additionally made absolute (`'./foo'` -> `$*CWD/libfoo.so`),
+                // which is what makes `NativeLibs`' "load the .so I just built
+                // next to me" idiom work.
+                let path = std::path::Path::new(&name);
+                let basename = path
+                    .file_name()
+                    .map(|s| s.to_string_lossy().to_string())
+                    .unwrap_or_else(|| name.clone());
+                let has_dir = basename != name;
                 let platform_name = match (cfg!(target_os = "macos"), cfg!(windows), version) {
-                    (true, _, Some(v)) => format!("lib{name}.{v}.dylib"),
-                    (true, _, None) => format!("lib{name}.dylib"),
-                    (_, true, _) => format!("{name}.dll"),
-                    (_, _, Some(v)) => format!("lib{name}.so.{v}"),
-                    (_, _, None) => format!("lib{name}.so"),
+                    (true, _, Some(v)) => format!("lib{basename}.{v}.dylib"),
+                    (true, _, None) => format!("lib{basename}.dylib"),
+                    (_, true, _) => format!("{basename}.dll"),
+                    (_, _, Some(v)) => format!("lib{basename}.so.{v}"),
+                    (_, _, None) => format!("lib{basename}.so"),
                 };
-                Ok(self.make_io_path_instance(&platform_name))
+                let full = if has_dir {
+                    let dir = path.parent().unwrap_or(std::path::Path::new("."));
+                    Self::absolute_lexical_path(&dir.join(&platform_name))
+                } else {
+                    platform_name
+                };
+                Ok(self.make_io_path_instance(&full))
             }
             "gist" | "Str" => {
                 let name = attributes

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -112,6 +112,11 @@ pub struct NativeCallSpec {
     /// name so the returned address is wrapped in an instance of that class
     /// (rather than a bare `Pointer`). `None` for a plain `Pointer` return.
     pub ret_struct: Option<String>,
+    /// A already-resolved function entry point, bypassing `library`/`symbol`
+    /// lookup. Set by `nativecast(<Signature>, $ptr)`, which turns a raw C
+    /// function pointer obtained at runtime (`dlsym`) into something callable —
+    /// there is no symbol name to look up, only the address.
+    pub entry: Option<usize>,
 }
 
 /// Candidate OS library file names for a `is native(<arg>)` argument, applying
@@ -253,17 +258,28 @@ pub fn call_native_with_out_args(
         )));
     }
 
-    let (lib, lib_name) = load_declared_library(&spec.library)?;
-    let func_ptr: *const std::ffi::c_void = unsafe {
-        let sym: libloading::Symbol<*const std::ffi::c_void> =
-            lib.get(spec.symbol.as_bytes()).map_err(|e| {
-                RuntimeError::new(format!(
-                    "NativeCall: symbol '{}' not found in '{lib_name}': {e}",
-                    spec.symbol
-                ))
-            })?;
-        // The symbol's address IS the function entry point.
-        *sym.into_raw()
+    let func_ptr: *const std::ffi::c_void = match spec.entry {
+        // `nativecast(<Signature>, $ptr)`: the entry point is the address itself.
+        Some(addr) if addr != 0 => addr as *const std::ffi::c_void,
+        Some(_) => {
+            return Err(RuntimeError::new(
+                "NativeCall: cannot call through a NULL function pointer",
+            ));
+        }
+        None => {
+            let (lib, lib_name) = load_declared_library(&spec.library)?;
+            unsafe {
+                let sym: libloading::Symbol<*const std::ffi::c_void> =
+                    lib.get(spec.symbol.as_bytes()).map_err(|e| {
+                        RuntimeError::new(format!(
+                            "NativeCall: symbol '{}' not found in '{lib_name}': {e}",
+                            spec.symbol
+                        ))
+                    })?;
+                // The symbol's address IS the function entry point.
+                *sym.into_raw()
+            }
+        }
     };
 
     // Owners that must outlive the libffi call (boxed scalars and CStrings the

--- a/src/runtime/nativecall_fnptr.rs
+++ b/src/runtime/nativecall_fnptr.rs
@@ -1,0 +1,159 @@
+//! `nativecast(<Signature>, $ptr)` — turn a raw C function pointer into a
+//! callable Raku routine.
+//!
+//! An `is native` sub binds a *named* symbol in a library at declaration time.
+//! But a binding that looks a symbol up itself — `dlsym`, or Windows'
+//! `GetProcAddress` — ends up holding only an address, and needs to attach a
+//! signature to it after the fact. `NativeLibs::Loader.symbol` is exactly this:
+//!
+//! ```raku
+//! my $dll = NativeLibs::Loader.load('libm.so.6');
+//! say $dll.symbol('sin', :(num64 --> num64))(pi / 2);   # 1
+//! ```
+//!
+//! The result is represented as a `Routine` value whose name is a synthetic key
+//! into `native_call_specs`, so every call path that already dispatches a native
+//! sub by name (the two VM call opcodes, `call_sub_value`, `vm_call_on_value`)
+//! handles it with no further plumbing.
+
+use crate::runtime::Interpreter;
+use crate::runtime::nativecall::{CType, NativeCallSpec, ParamSpec};
+use crate::symbol::Symbol;
+use crate::value::{RuntimeError, Value};
+
+/// Prefix of the synthetic `native_call_specs` key. Not a legal Raku identifier
+/// (`#`), so it can never collide with a declared sub.
+const FNPTR_KEY_PREFIX: &str = "__mutsu_native_fnptr#";
+
+impl Interpreter {
+    /// Build a callable for the C function at `ptr`'s address, marshalled per
+    /// the signature registered under Signature instance `sig_id`.
+    pub(crate) fn native_callable_from_signature(
+        &mut self,
+        sig_id: u64,
+        ptr: &Value,
+    ) -> Result<Value, RuntimeError> {
+        let Some(info) = crate::value::signature::lookup_sig_info(sig_id) else {
+            return Err(RuntimeError::new(
+                "nativecast(): cannot recover the signature to cast to",
+            ));
+        };
+        let addr = crate::runtime::nativecall::value_c_address(ptr);
+        if addr == 0 {
+            return Err(RuntimeError::new(
+                "nativecast(): cannot cast a NULL pointer to a Signature",
+            ));
+        }
+
+        let mut params = Vec::with_capacity(info.params.len());
+        for p in &info.params {
+            // A `--> T`-only signature has no parameters; an invocant slot in a
+            // cast signature is not a C argument (there is no invocant to pass).
+            if p.is_invocant {
+                continue;
+            }
+            let Some(tc) = p.type_constraint.as_deref() else {
+                return Err(RuntimeError::new(format!(
+                    "nativecast(): parameter '{}' has no type, so it cannot be marshalled to C",
+                    p.name
+                )));
+            };
+            params.push(self.param_spec_for_native_type(tc, p.traits.iter().any(|t| t == "rw"))?);
+        }
+
+        // `Mu` is what a signature with no `-->` reports, and it means "no
+        // declared return type" here, i.e. C `void`.
+        let ret_name = info.return_type.as_deref().filter(|t| *t != "Mu");
+        let (ret, ret_struct) = match ret_name {
+            None => (CType::Void, None),
+            Some(rt) => {
+                let spec = self.param_spec_for_native_type(rt, false)?;
+                let ret_struct = if spec.ct == CType::Pointer && self.is_cstruct_class(rt) {
+                    Some(rt.rsplit("::").next().unwrap_or(rt).to_string())
+                } else {
+                    None
+                };
+                (spec.ct, ret_struct)
+            }
+        };
+
+        let key = format!("{FNPTR_KEY_PREFIX}{addr:x}");
+        self.native_call_specs.insert(
+            key.clone(),
+            NativeCallSpec {
+                library: None,
+                symbol: key.clone(),
+                params,
+                ret,
+                ret_struct,
+                entry: Some(addr),
+            },
+        );
+        Ok(Value::routine_parts(
+            Symbol::intern("GLOBAL"),
+            Symbol::intern(&key),
+            false,
+        ))
+    }
+
+    /// Map one signature type name to its C marshalling spec, resolving
+    /// `constant` type aliases and treating a CStruct-ish class as a pointer —
+    /// the same rules `register_native_call_routine` applies to a declared
+    /// `is native` signature.
+    fn param_spec_for_native_type(
+        &mut self,
+        type_name: &str,
+        is_rw: bool,
+    ) -> Result<ParamSpec, RuntimeError> {
+        let base = type_name
+            .strip_suffix(":D")
+            .or_else(|| type_name.strip_suffix(":U"))
+            .or_else(|| type_name.strip_suffix(":_"))
+            .unwrap_or(type_name);
+        let resolved = self.resolve_native_type_alias(base);
+        let base = resolved.as_str();
+        if let Some(inner) = base
+            .strip_prefix("CArray[")
+            .and_then(|s| s.strip_suffix(']'))
+        {
+            let inner = self.resolve_native_type_alias(inner);
+            let Some(elem) = CType::from_type_name(&inner) else {
+                return Err(RuntimeError::new(format!(
+                    "nativecast(): CArray element type '{inner}' cannot be marshalled to C"
+                )));
+            };
+            return Ok(ParamSpec {
+                ct: CType::CArray,
+                is_rw,
+                elem: Some(elem),
+            });
+        }
+        if base == "CArray" {
+            return Ok(ParamSpec {
+                ct: CType::CArray,
+                is_rw,
+                elem: None,
+            });
+        }
+        // A typed `Pointer[T]` is still one pointer.
+        let stem = base.split_once('[').map_or(base, |(b, _)| b);
+        if let Some(ct) = CType::from_type_name(stem) {
+            return Ok(ParamSpec {
+                ct,
+                is_rw,
+                elem: None,
+            });
+        }
+        // Any class held by reference in C (a CStruct / CPointer handle).
+        if self.is_cstruct_class(base) || self.is_native_handle_class(base) {
+            return Ok(ParamSpec {
+                ct: CType::Pointer,
+                is_rw,
+                elem: None,
+            });
+        }
+        Err(RuntimeError::new(format!(
+            "nativecast(): type '{type_name}' cannot be marshalled to C"
+        )))
+    }
+}

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -246,6 +246,7 @@ impl Interpreter {
                 || declared_types.contains(tc)
                 || self.is_resolvable_type(tc)
                 || self.has_type(tc)
+                || self.is_type_alias_constant(tc)
                 || matches!(tc, "Inf" | "NaN" | "True" | "False" | "Empty")
                 || crate::env::global_base_contains(tc)
             {
@@ -298,6 +299,35 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Is `name` a `constant` bound to a type object — i.e. an alias usable
+    /// wherever a type name is?
+    ///
+    /// `constant Foo = Int;` / `constant HANDLE = uint32;` puts a type object in
+    /// the lexical scope, and Raku accepts the alias in a signature
+    /// (`sub f(Foo $x --> Foo)`). C bindings lean on this heavily — the
+    /// `NativeHelpers::Blob` tests declare `constant HANDLE = uint32` and return
+    /// `--> HANDLE` — so rejecting the alias made the whole declaration fail to
+    /// compile. Held as a *type object* value, so a plain env lookup identifies
+    /// it: an alias is a `Package` value, unlike an ordinary constant.
+    ///
+    /// The binding must point at some *other* type. A `package`/`module` binds
+    /// its own name to itself, and `my package A {}; sub foo(A $a)` is
+    /// X::Parameter::BadType in Raku ("insufficiently type-like") — treating it
+    /// as an alias here would swallow that error.
+    pub(crate) fn is_type_alias_constant(&self, name: &str) -> bool {
+        let Some(value) = self.get_env_with_main_alias(name) else {
+            return false;
+        };
+        let ValueView::Package(target) = value.view() else {
+            return false;
+        };
+        let target = target.resolve();
+        target != name
+            && (self.is_resolvable_type(&target)
+                || self.has_type(&target)
+                || crate::runtime::nativecall::CType::from_type_name(&target).is_some())
+    }
+
     /// Reject a sub return type (`--> NoSuchType` / `returns NoSuchType`) that
     /// names a type unknown to this compilation unit -> X::Undeclared (with
     /// `what` => "Type", `symbol` => the bad name). Mirrors the parameter-type
@@ -340,6 +370,7 @@ impl Interpreter {
             || declared_types.contains(rt)
             || self.is_resolvable_type(rt)
             || self.has_type(rt)
+            || self.is_type_alias_constant(rt)
         {
             return Ok(());
         }
@@ -1091,8 +1122,17 @@ impl Interpreter {
         params: &[String],
         param_defs: &[ParamDef],
         body: &[Stmt],
+        is_our: bool,
     ) -> Result<(), RuntimeError> {
         let key = format!("{}::{}", self.current_package(), name);
+        // `our proto sub f(|) {*}` makes the whole multi a package symbol. Its
+        // candidates are declared bare (`multi sub f(...)`) and each of those
+        // marks `Pkg::f` my-scoped, which would hide the routine from the
+        // package stash however the proto was declared — so record the
+        // our-visibility up front and let it win.
+        if is_our && self.current_package() != "GLOBAL" {
+            self.mark_our_scoped_package_item(key.clone());
+        }
         if self
             .registry()
             .functions

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -62,6 +62,60 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("Promise"), attrs)
     }
 
+    /// The declared name of a callable value, for looking it up in name-keyed
+    /// registries. `None` for anonymous blocks/closures.
+    pub(crate) fn callable_value_name(func: &Value) -> Option<String> {
+        let (package, name) = match func.view() {
+            ValueView::Routine { package, name, .. } => (package.resolve(), name.resolve()),
+            ValueView::Sub(data) => (data.package.resolve(), data.name.resolve()),
+            _ => return None,
+        };
+        if name.is_empty() {
+            return None;
+        }
+        if package.is_empty() || package == "GLOBAL" {
+            Some(name.to_string())
+        } else {
+            Some(format!("{package}::{name}"))
+        }
+    }
+
+    /// Dispatch `name` over C FFI if it is a registered `is native` sub.
+    /// `Ok(None)` means "not a native sub" — the caller continues normally.
+    ///
+    /// Unlike the VM opcode paths this does not write `is rw` out-parameters
+    /// back to a caller *slot* (there is no `CompiledCode` here to address one);
+    /// it writes them into `env` and records the name, which the enclosing VM
+    /// frame drains on return.
+    pub(crate) fn try_dispatch_native_by_name(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> Result<Option<Value>, RuntimeError> {
+        let Some(mut spec) = self.native_call_specs.get(name).cloned().or_else(|| {
+            name.rsplit_once("::")
+                .and_then(|(_, short)| self.native_call_specs.get(short).cloned())
+        }) else {
+            return Ok(None);
+        };
+        self.resolve_native_ret_struct(&mut spec);
+        let call_args: Vec<Value> = args
+            .iter()
+            .filter(|a| !Self::is_callsite_line_marker(a))
+            .cloned()
+            .collect();
+        let (result, out_args) =
+            crate::runtime::nativecall::call_native_with_out_args(&spec, &call_args)?;
+        for (idx, val) in out_args {
+            if let ValueView::VarRef { name, .. } = call_args[idx].view() {
+                let n = name.resolve().to_string();
+                self.env_mut().insert(n.clone(), val);
+                self.pending_rw_writeback_sources.push(n);
+            }
+        }
+        Ok(Some(result))
+    }
+
     pub(crate) fn call_sub_value(
         &mut self,
         func: Value,
@@ -76,6 +130,19 @@ impl Interpreter {
             },
             _ => func,
         };
+        // NativeCall: a sub declared `is native(...)` has a `{ * }` stub for a
+        // body, so reaching that body at all is a bug — it must be dispatched
+        // over C FFI instead. The two VM call opcodes check `native_call_specs`
+        // by name, but a call through a code object (`my &f = &dlsym; f(|c)`,
+        // which is how `NativeLibs` picks between the dyncall and libffi symbol
+        // lookups) resolves the callee as a value and never consulted them, so
+        // it ran the stub and returned `*`.
+        if !self.native_call_specs.is_empty()
+            && let Some(name) = Self::callable_value_name(&func)
+            && let Some(result) = self.try_dispatch_native_by_name(&name, &args)?
+        {
+            return Ok(result);
+        }
         if let ValueView::Routine {
             package,
             name,

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -252,9 +252,20 @@ impl Interpreter {
         self.my_scoped_package_items.insert(fq_name);
     }
 
+    /// Mark a fully-qualified name as explicitly `our`-scoped, overriding any
+    /// `my`-scoped marking of the same name. Needed where one Raku routine is
+    /// registered from several declarations of differing scope: an
+    /// `our proto sub` publishes the name while each bare `multi` candidate
+    /// would otherwise mark it lexical.
+    pub(crate) fn mark_our_scoped_package_item(&mut self, fq_name: String) {
+        self.my_scoped_package_items.remove(&fq_name);
+        self.our_scoped_package_items.insert(fq_name);
+    }
+
     /// Check if a fully-qualified name is `my`-scoped within its parent package.
     pub(crate) fn is_my_scoped_package_item(&self, fq_name: &str) -> bool {
         self.my_scoped_package_items.contains(fq_name)
+            && !self.our_scoped_package_items.contains(fq_name)
     }
 
     pub(crate) fn is_name_suppressed(&self, name: &str) -> bool {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2191,6 +2191,7 @@ impl Interpreter {
             poisoned_enum_aliases: HashMap::new(),
             enum_scope_names: vec![Vec::new()],
             my_scoped_package_items: HashSet::new(),
+            our_scoped_package_items: HashSet::new(),
             lexical_class_scopes: Vec::new(),
             lexical_class_sites: HashMap::new(),
             lexical_class_owner_scopes: Vec::new(),

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -66,19 +66,28 @@ impl Interpreter {
     }
 
     /// Split `Name:auth<zef:foo>:ver<0.0.20+>` into the bare module name and
-    /// its distribution selectors. The parser only appends the three dist
-    /// adverbs (`ver`/`auth`/`api`) in this literal angle form, so the split is
+    /// its distribution selectors. The parser only appends the dist adverbs
+    /// (`ver`/`auth`/`api`) in this literal angle form, so the split is
     /// unambiguous: a `::`-qualified name never contains a lone `:`.
+    ///
+    /// `:v<…>` is Raku's short spelling of `:ver<…>` and normalizes to it. The
+    /// two never collide: the trailing `<` makes `:v<` and `:ver<` distinct
+    /// patterns.
     pub(crate) fn split_dist_selectors(module: &str) -> (&str, Vec<(String, String)>) {
         let mut selectors = Vec::new();
         let mut bare_end = module.len();
-        for key in ["ver", "auth", "api"] {
+        for (key, canonical) in [
+            ("ver", "ver"),
+            ("v", "ver"),
+            ("auth", "auth"),
+            ("api", "api"),
+        ] {
             let pat = format!(":{}<", key);
             if let Some(pos) = module.find(&pat) {
                 bare_end = bare_end.min(pos);
                 let after = &module[pos + pat.len()..];
                 if let Some(end) = after.find('>') {
-                    selectors.push((key.to_string(), after[..end].to_string()));
+                    selectors.push((canonical.to_string(), after[..end].to_string()));
                 }
             }
         }
@@ -180,6 +189,12 @@ impl Interpreter {
         let env_snapshot: HashSet<Symbol> = self.env.keys().copied().collect();
         let func_keys_before: HashSet<Symbol> = self.registry().functions.keys().copied().collect();
 
+        // NativeCall loads no Raku module here (the machinery is in the VM), but
+        // its export list is a real introspectable surface that other modules
+        // read and re-export — see `register_nativecall_exports`.
+        if module == "NativeCall" {
+            self.register_nativecall_exports();
+        }
         let result = if module == "Test"
             || matches!(
                 module,

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -154,6 +154,65 @@ impl Interpreter {
         }
     }
 
+    /// Publish `NativeCall`'s export list.
+    ///
+    /// mutsu implements NativeCall inside the VM, so `use NativeCall` loads no
+    /// Raku module — but the module's *export surface* is introspectable in
+    /// Rakudo (`NativeCall::EXPORT::ALL`) and real bindings read it: `NativeLibs`
+    /// re-exports the whole stash into its own `UNIT::EXPORT` so that its users
+    /// get NativeCall transitively. With no entries, that stash was empty and
+    /// the re-export silently did nothing.
+    ///
+    /// The list is Rakudo's `NativeCall.rakumod` / `NativeCall::Types` export
+    /// set: the trait that makes a sub native, the four helper routines, and the
+    /// C type objects.
+    pub(crate) fn register_nativecall_exports(&mut self) {
+        const SUBS: [&str; 6] = [
+            "trait_mod:<is>",
+            "nativecast",
+            "nativesizeof",
+            "cglobal",
+            "explicitly-manage",
+            "refresh",
+        ];
+        const TYPES: [&str; 11] = [
+            "Pointer",
+            "OpaquePointer",
+            "CArray",
+            "void",
+            "bool",
+            "long",
+            "longlong",
+            "ulong",
+            "ulonglong",
+            "size_t",
+            "ssize_t",
+        ];
+        if self.exported_subs.contains_key("NativeCall") {
+            return;
+        }
+        for name in SUBS {
+            self.register_exported_sub("NativeCall".to_string(), name.to_string(), Vec::new());
+        }
+        // `guess_library_name` is a routine, but it is spelled `&…` by consumers
+        // and lives with the types in Rakudo's export map; registering it in both
+        // sets keeps either spelling resolvable.
+        self.register_exported_sub(
+            "NativeCall".to_string(),
+            "guess_library_name".to_string(),
+            Vec::new(),
+        );
+        for name in TYPES {
+            self.register_exported_var("NativeCall".to_string(), name.to_string(), Vec::new());
+        }
+        // `::('NativeCall')` must resolve to the package rather than failing:
+        // `NativeLibs`' own `EXPORT` sub passes `NativeCall` through as a value.
+        self.env.insert(
+            "NativeCall".to_string(),
+            Value::package(Symbol::intern("NativeCall")),
+        );
+    }
+
     pub(crate) fn import_module(
         &mut self,
         module: &str,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -348,6 +348,7 @@ impl Interpreter {
             poisoned_enum_aliases: self.poisoned_enum_aliases.clone(),
             enum_scope_names: self.enum_scope_names.clone(),
             my_scoped_package_items: self.my_scoped_package_items.clone(),
+            our_scoped_package_items: self.our_scoped_package_items.clone(),
             lexical_class_scopes: self.lexical_class_scopes.clone(),
             lexical_class_sites: self.lexical_class_sites.clone(),
             lexical_class_owner_scopes: self.lexical_class_owner_scopes.clone(),

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -548,6 +548,26 @@ impl Interpreter {
                 true
             };
         }
+        // An *unparameterized* `CArray` constraint accepts any `CArray[T]`: the
+        // parameterization only narrows the type (`isa-ok $au, CArray` and
+        // `sub carray-is-managed(CArray:D \arr)` in NativeHelpers::Blob both
+        // spell it bare). The value side is either a native Array carrying a
+        // `CArray[...]` declared type or a `nativecast`ed handle whose element
+        // type lives in its class name; neither reduces to the `&'static`
+        // `value_type_name` ("Array" / the class name) the generic tail compares.
+        if constraint == "CArray" {
+            if let ValueView::Instance { class_name, .. } = value.view() {
+                let cn = class_name.resolve();
+                return cn == "CArray" || cn.starts_with("CArray[");
+            }
+            if matches!(value.view(), ValueView::Array(..)) {
+                return self.container_type_metadata(value).is_some_and(|m| {
+                    m.declared_type
+                        .as_deref()
+                        .is_some_and(|d| d == "CArray" || d.starts_with("CArray["))
+                });
+            }
+        }
         if let Some((base, inner)) = Self::parse_generic_constraint(constraint) {
             match base {
                 "array" => {

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -28,6 +28,18 @@ impl Interpreter {
         if constraint == value_type {
             return true;
         }
+        // A parameterized type is-a its base type: `CArray[uint8] ~~ CArray`,
+        // `Array[Int] ~~ Array`, `Pointer[uint16] ~~ Pointer`. The base name is
+        // the type; the parameterization only narrows it. (The reverse is not
+        // true — a bare `CArray` value does not satisfy `CArray[uint8]` — and the
+        // parameterized-vs-parameterized comparison is handled by the callers
+        // that know how to match the inner types.)
+        if !constraint.contains('[')
+            && let Some((value_base, _)) = value_type.split_once('[')
+            && value_base == constraint
+        {
+            return true;
+        }
         // Qualified name matching: GH2613::R1 should match R1 and vice versa.
         // When one name is qualified (contains ::) and the other is a short name,
         // check if the short name matches the last component of the qualified name.

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -442,6 +442,17 @@ impl Interpreter {
             target
         };
 
+        // NativeCall: a sub declared `is native(...)` carries a `{ * }` stub
+        // body, so it must be dispatched over C FFI no matter how the callsite
+        // reached it — including through a code object (`my &f = &dlsym; f(...)`).
+        // See `try_dispatch_native_by_name`.
+        if !self.native_call_specs.is_empty()
+            && let Some(name) = Self::callable_value_name(&target)
+            && let Some(result) = self.try_dispatch_native_by_name(&name, &args)?
+        {
+            return Ok(result);
+        }
+
         // A WalkList is invoked (`$x.WALK(...)()`) by calling each candidate on
         // the original invocant, forwarding any arguments.
         if let ValueView::Instance { class_name, .. } = target.view()

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -450,7 +450,7 @@ impl Interpreter {
         Some(self.locals.get(idx)?.clone())
     }
 
-    pub(super) fn get_env_with_main_alias(&self, name: &str) -> Option<Value> {
+    pub(crate) fn get_env_with_main_alias(&self, name: &str) -> Option<Value> {
         // Raku allows underscore variants of kebab-case identifiers
         // (e.g. $*EXECUTABLE_NAME is equivalent to $*EXECUTABLE-NAME).
         // Try the kebab-case equivalent first if the name contains underscores.

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -526,6 +526,7 @@ impl Interpreter {
             params,
             ret,
             ret_struct,
+            entry: None,
         };
         if let Some(class_name) = invocant_class {
             // Both spellings: the declaration is package-qualified while a
@@ -700,6 +701,7 @@ impl Interpreter {
             is_export,
             custom_traits,
             is_method,
+            is_our,
             ..
         } = stmt
         {
@@ -715,7 +717,7 @@ impl Interpreter {
             // pattern, SBOM::CycloneDX). Skip the package-level registration for
             // method protos; the method-table path already handles them.
             if !*is_method {
-                self.register_proto_decl(&name_str, params, param_defs, body)?;
+                self.register_proto_decl(&name_str, params, param_defs, body, *is_our)?;
             }
             if *is_export {
                 self.register_proto_decl_as_global(&name_str, params, param_defs, body)?;

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -411,8 +411,20 @@ impl Interpreter {
             && package != "MY"
             && !package.is_empty()
         {
+            // A lexical bound to a *type object* names that package:
+            // `my \NCexports = ::('NativeCall::EXPORT::ALL'); NCexports::{$_}`
+            // must read the bound package's stash, not a package literally
+            // called "NCexports". Only a `Package` value redirects — any other
+            // binding leaves the literal-name reading intact.
+            let target = self
+                .get_env_with_main_alias(package)
+                .and_then(|v| match v.view() {
+                    ValueView::Package(sym) => Some(sym.resolve().to_string()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| package.to_string());
             self.stack
-                .push(loan_env!(self, package_stash_value(package)));
+                .push(loan_env!(self, package_stash_value(&target)));
             return;
         }
 

--- a/t/carray-base-type-match.t
+++ b/t/carray-base-type-match.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+use NativeCall;
+
+# Parameterization narrows a type; it does not replace it. A `CArray[uint8]`
+# is-a `CArray`, so the unparameterized spelling — which is what
+# `NativeHelpers::Blob` uses in `isa-ok $au, CArray` and in the signature
+# `sub carray-is-managed(CArray:D \arr)` — must accept it.
+
+plan 9;
+
+my $a = CArray[uint8].new;
+$a[3] = 0;   # force allocation
+
+ok $a ~~ CArray, 'a CArray[T] instance smartmatches the bare CArray';
+ok $a ~~ CArray[uint8], 'and its own parameterization';
+nok $a ~~ CArray[int16], 'but not a different parameterization';
+nok 42 ~~ CArray, 'a non-array is not a CArray';
+nok [1, 2] ~~ CArray, 'a plain Array is not a CArray';
+
+# The type-object level, too.
+ok CArray[uint8] ~~ CArray, 'CArray[T] the type object is-a CArray';
+ok Array[Int] ~~ Array, 'the same rule holds for Array[T]';
+nok CArray ~~ CArray[uint8], 'the relation is not symmetric';
+
+# A `CArray:D` parameter must bind a parameterized CArray. (Only the tail of
+# the name is checked: Rakudo reports the fully-qualified
+# `NativeCall::Types::CArray[uint8]`.)
+sub takes-carray(CArray:D \arr) { arr.WHAT.^name }
+ok takes-carray($a).ends-with('CArray[uint8]'),
+   'a CArray[T] binds a bare CArray:D parameter';
+
+# vim: expandtab shiftwidth=4

--- a/t/constant-type-alias.t
+++ b/t/constant-type-alias.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+use NativeCall;
+
+# `constant Foo = Int` binds a type object, and Raku accepts the alias anywhere
+# a type name goes. C bindings rely on it for platform types
+# (`constant HANDLE = uint32; sub GetProcessHeap(--> HANDLE) is native(...)`).
+# mutsu's compile-time signature validator rejected the alias outright, so the
+# whole declaration failed with "Invalid typename" / "Type ... is not declared".
+
+plan 6;
+
+constant MyInt = Int;
+constant HANDLE = uint32;
+
+sub takes(MyInt $x --> MyInt) { $x + 1 }
+is takes(41), 42, 'a constant type alias works as a parameter and return type';
+
+sub native-ret(--> HANDLE) is native('nosuchlib') { * }
+ok &native-ret.defined, 'a native return type spelled as a constant alias compiles';
+
+sub native-arg(HANDLE $h --> uint32) is native('nosuchlib') { * }
+ok &native-arg.defined, 'a native parameter type spelled as a constant alias compiles';
+
+# The alias must not swallow the errors it sits next to.
+throws-like 'sub bad(NoSuchTypeAtAll $x) { }', X::Parameter::InvalidType,
+    'an undeclared parameter type is still rejected';
+throws-like 'sub bad(--> NoSuchTypeAtAll) { }', X::Undeclared,
+    'an undeclared return type is still rejected';
+throws-like 'my package P {}; sub bad(P $x) { }', X::Parameter::BadType,
+    'a package parameter type is still X::Parameter::BadType';
+
+# vim: expandtab shiftwidth=4

--- a/t/nativecall-export-stash.t
+++ b/t/nativecall-export-stash.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+use NativeCall;
+
+# mutsu implements NativeCall inside the VM, so `use NativeCall` loads no Raku
+# module — but the module's export list is a real, introspectable surface.
+# `NativeLibs` copies the whole `NativeCall::EXPORT::ALL` stash into its own
+# `UNIT::EXPORT` so that its users get NativeCall transitively; with an empty
+# stash that re-export silently did nothing.
+
+plan 8;
+
+ok ::('NativeCall') !~~ Failure, "::('NativeCall') resolves to the package";
+
+my \exports = ::('NativeCall::EXPORT::ALL');
+ok exports !~~ Failure, "::('NativeCall::EXPORT::ALL') resolves";
+
+# A sigilless binding to a package names that package: the stash subscript must
+# follow the *binding*, not look for a package literally called "exports".
+ok exports::{'&nativecast'}:exists, 'the routine exports are listed';
+ok exports::{'&trait_mod:<is>'}:exists, 'the `is native` trait is listed';
+ok exports::{'Pointer'}:exists, 'the type exports are listed';
+nok exports::{'&no-such-export'}:exists, 'an unexported name is absent';
+
+my @want = <&trait_mod:<is> &nativecast &nativesizeof &cglobal &explicitly-manage
+            &refresh &guess_library_name
+            Pointer OpaquePointer CArray void bool long longlong ulong ulonglong size_t>;
+my @missing = @want.grep({ !(exports::{$_}:exists) });
+is @missing.join(' '), '', 'the whole documented export set is present';
+
+# A user module's own stash gains an EXPORT member the same way.
+module Exporter { our sub exported() is export { } }
+ok Exporter::.keys.sort.join(' ') eq '&exported EXPORT',
+   "a module that exports anything has an EXPORT stash member";
+
+# vim: expandtab shiftwidth=4

--- a/t/nativecall-signature-cast.t
+++ b/t/nativecall-signature-cast.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+use NativeCall;
+
+# Two ways a NativeCall binding reaches C that do not go through a plain
+# `is native` call site:
+#
+#  1. Calling a declared native sub through a *code object* (`my &f = &g; f()`).
+#     `NativeLibs::Loader.symbol` picks between `dlFindSymbol` and `dlsym` that
+#     way; running the `{ * }` stub instead returned the Whatever `*`.
+#  2. `nativecast(<Signature>, $ptr)` — attaching a signature to a function
+#     pointer looked up at runtime, which is what makes such a symbol callable
+#     at all.
+
+plan 7;
+
+sub getpid(--> int32) is native { * }
+
+my $direct = getpid();
+ok $direct > 0, 'a direct native call works';
+
+my &via-ref = &getpid;
+is via-ref(), $direct, 'calling a native sub through a code object dispatches to C';
+is (&getpid)(), $direct, 'calling a native sub through an inline code object works too';
+
+my @through-map = (1,).map({ &getpid })».();
+is @through-map[0], $direct, 'a native code object called from a closure dispatches to C';
+
+# Cast a function pointer to a signature. `dlsym`/`dlopen` are in the process
+# already (mutsu links libc), so look up a libm symbol through them.
+sub dlopen(Str, uint32 --> Pointer) is native { * }
+sub dlsym(Pointer, Str --> Pointer) is native { * }
+
+my $libm = dlopen($*VM.platform-library-name('m'.IO, :version(Version.new(6))).Str, 0x102);
+if $libm.defined && +$libm != 0 {
+    my $sym = dlsym($libm, 'cos');
+    ok +$sym != 0, 'dlsym found a symbol';
+    my $cos = nativecast(:(num64 --> num64), $sym);
+    ok $cos ~~ Callable, 'nativecast to a Signature yields something callable';
+    is-approx $cos(0e0), 1e0, 'the cast function pointer calls through to C';
+} else {
+    skip 'no versioned libm on this system', 3;
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/our-proto-package-stash.t
+++ b/t/our-proto-package-stash.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# A `proto` is the one *visible* name of a multi — its candidates are lexical.
+# So `our` on the proto publishes the whole routine as a package symbol, even
+# though every `multi` candidate is declared bare. mutsu held protos in a
+# separate registry that the package stash never scanned, and each bare
+# candidate additionally marked the name `my`-scoped, so `M::` was empty and
+# `::('M::&f')` returned a Failure.
+
+plan 8;
+
+module WithOurProto {
+    our proto sub f(|) { * }
+    multi sub f(Int $x) { "int:$x" }
+    multi sub f(Str $x) { "str:$x" }
+
+    # A defaulted trailing parameter: the candidate is registered under its
+    # declared arity, so a qualified call omitting it must still find it.
+    our proto sub g(|) { * }
+    multi sub g(Str $a, Version $v = Version) { "one:$a:{$v.^name}" }
+    multi sub g(Str $a, Cool $c) { "two:$a:$c" }
+}
+
+module WithBareProto {
+    proto sub h(|) { * }
+    multi sub h(Int $x) { $x }
+}
+
+is WithOurProto::.keys.sort.join(' '), '&f &g', 'an our proto is a package stash member';
+ok WithOurProto::{'&f'}:exists, 'the proto is reachable by stash subscript';
+ok ::('WithOurProto::&f') !~~ Failure, "::('Pkg::&proto') resolves";
+
+is WithBareProto::.keys.join(' '), '', 'a bare (non-our) proto stays lexical';
+ok ::('WithBareProto::&h') ~~ Failure, "::('Pkg::&bare-proto') is a Failure";
+
+is WithOurProto::f(7), 'int:7', 'qualified dispatch still picks the Int candidate';
+is WithOurProto::g('foo', 2), 'two:foo:2', 'qualified dispatch with both args';
+is WithOurProto::g('foo'), 'one:foo:Version',
+   'qualified dispatch reaches a candidate whose trailing parameter is defaulted';
+
+# vim: expandtab shiftwidth=4

--- a/t/platform-library-name-path.t
+++ b/t/platform-library-name-path.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# `$*VM.platform-library-name` decorates only the BASENAME and puts the
+# directory back afterwards. Decorating the whole string produced the nonsense
+# `lib/bar/foo.so` for `/bar/foo`, so a binding that loads a `.so` it built next
+# to itself (`NativeLibs::Compile`) got an unopenable path. A name that carries
+# any directory is additionally made absolute.
+#
+# (Deciding whether a name is *already* decorated is the caller's job — see
+# `NativeLibs::cannon-name`, which checks `.extension` first.)
+
+plan 5;
+
+sub pl($p, |c) { $*VM.platform-library-name($p.IO, |c).Str }
+
+my $win = $*DISTRO.is-win;
+my $ext = $win ?? '.dll' !! ($*VM.osname eq 'darwin' ?? '.dylib' !! '.so');
+my $pre = $win ?? '' !! 'lib';
+
+is pl('foo'), "{$pre}foo$ext", 'a bare stem stays relative and is decorated';
+is pl('/bar/foo'), "/bar/{$pre}foo$ext", 'an absolute path decorates only the basename';
+is pl('./foo'), $*CWD.add("{$pre}foo$ext").Str, 'a CWD-relative path is made absolute';
+is pl('a/b/foo'), $*CWD.add("a/b/{$pre}foo$ext").Str,
+   'a nested relative path keeps its directory and is made absolute';
+
+# `:version` names an ABI-versioned library: after the extension on Linux,
+# before it on macOS, and not at all on Windows.
+my $want = $win               ?? "foo$ext"
+        !! $*VM.osname eq 'darwin' ?? "libfoo.2$ext"
+        !!                           "libfoo{$ext}.2";
+is pl('foo', :version(Version.new(2))), $want, 'the ABI version is placed per platform';
+
+# vim: expandtab shiftwidth=4

--- a/t/use-version-short-adverb.t
+++ b/t/use-version-short-adverb.t
@@ -1,0 +1,16 @@
+use v6;
+use Test;
+
+# `:v<…>` is Raku's short spelling of the `:ver<…>` distribution selector, so
+# `use-ok 'NativeLibs:v<0.0.9>'` must behave exactly like the long form.
+# mutsu only knew `ver`/`auth`/`api`, so the short form was taken as part of the
+# module *name* and never found.
+
+plan 4;
+
+use-ok 'Test::Util::ServerPort';
+use-ok 'Test::Util::ServerPort:ver<0.0.5>';
+use-ok 'Test::Util::ServerPort:v<0.0.5>';
+use-ok 'Test::Util::ServerPort:v<0.0.5>:auth<github:jonathanstowe>';
+
+# vim: expandtab shiftwidth=4

--- a/t/vm-config-toolchain.t
+++ b/t/vm-config-toolchain.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# `$*VM.config` is not a decorative hash: NativeLibs switches its whole
+# library-naming scheme on `config<osname>` and builds a C command line out of
+# the toolchain keys. A missing key made every platform branch silently fall
+# through instead of failing loudly.
+
+plan 11;
+
+my $c = $*VM.config;
+
+isa-ok $c, Hash, 'config is a Hash';
+
+ok $c<osname>.defined, 'config<osname> is defined';
+is $c<osname>, $*VM.osname, 'config<osname> agrees with $*VM.osname';
+ok $c<osname> ~~ /^ <[a..z0..9]>+ $/, "config<osname> is a bare lowercase name ({$c<osname>})";
+
+ok $c<be> eq '0' | '1', 'config<be> is the string 0 or 1';
+ok $c<nativecall_backend>.defined, 'config<nativecall_backend> is defined';
+
+# The C toolchain keys. Every one of them is joined into a shell command by
+# NativeLibs::Compile, so an undefined value would stringify to a warning and
+# produce a broken command line.
+my @toolchain = <cc ccshared cflags ccout obj ld ldshared ldflags ldlibs ldout dll>;
+my @missing = @toolchain.grep({ !$c{$_}.defined });
+is @missing.join(' '), '', 'every C toolchain key is defined';
+ok $c<cc>.chars > 0, 'config<cc> names a compiler';
+is $c<ccout>, $c<ldout>, 'ccout and ldout agree (both are the -o switch)';
+
+# `dll` is a sprintf pattern: exactly one %s, and it must produce the same
+# name `platform-library-name` does for a bare stem.
+ok $c<dll>.contains('%s'), 'config<dll> is a sprintf pattern';
+is sprintf($c<dll>, 'foo'), $*VM.platform-library-name('foo'.IO).Str,
+   'config<dll> agrees with platform-library-name';
+
+# vim: expandtab shiftwidth=4

--- a/t/when-block-value-not-sunk.t
+++ b/t/when-block-value-not-sunk.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+use Test::Util;
+
+# A `when`/`default` block's final statement is the block's *value* (`when`
+# succeeds out of the enclosing topicalizer with it), so it is not in sink
+# context. Rakudo warns for `if True { 1 }` but not for `when 'a' { 1 }`.
+# mutsu warned for both — and, being a compile-time analysis, it warned even for
+# a branch that never runs, so a Linux-only test file emitted a spurious
+# "Useless use of constant string ... in sink context" for the `when 'darwin'`
+# arm it skipped.
+
+plan 4;
+
+my $when-value = q:to/CODE/;
+    given "a" {
+        when "a" { 1 }
+        when "b" { 2, "hello" }
+    }
+    say "done";
+    CODE
+
+my $default-value = q:to/CODE/;
+    given "z" {
+        when "a" { 1 }
+        default  { "unused" }
+    }
+    say "done";
+    CODE
+
+# Only the LAST statement is the value; earlier ones are still sunk.
+my $when-prefix = q:to/CODE/;
+    given "a" {
+        when "a" { "wasted"; 1 }
+    }
+    say "done";
+    CODE
+
+# An `if` block is different: Rakudo does warn there, so we must keep doing so.
+my $if-value = q:to/CODE/;
+    if True { 1 }
+    say "done";
+    CODE
+
+is_run $when-value, { out => "done\n", err => '' }, 'a when block value is not sunk';
+is_run $default-value, { out => "done\n", err => '' }, 'a default block value is not sunk';
+is_run $when-prefix, { out => "done\n", err => /'sink context'/ }, 'a non-final statement in a when block is still sunk';
+is_run $if-value, { out => "done\n", err => /'sink context'/ }, 'an if block value is still sunk';
+
+# vim: expandtab shiftwidth=4

--- a/todo/deep/nativehelpers-blob-moarvm-guts.md
+++ b/todo/deep/nativehelpers-blob-moarvm-guts.md
@@ -282,6 +282,31 @@ code as-is and grow mutsu's core, with private reimplementation as a last resort
 15 further distributions in the fez index depend on `NativeHelpers::Blob`
 directly, so the module itself is the thing worth making work.
 
+## What this still blocks in the battery gate (measured 2026-07-30)
+
+Issue #5557 asked for `NativeHelpers::Blob`'s upstream tests to be whitelisted.
+Two of the four went in; the other two are blocked here, on **ADR-0015 P3**
+(native-backed Raku-side `CArray[T]`), and not on anything smaller:
+
+| file | status | why |
+| --- | --- | --- |
+| `99-my-meta.t` | whitelisted (was already) | |
+| `00-trivial.t` | **whitelisted 2026-07-30** | needed `constant HANDLE = uint32` to be usable as a signature type |
+| `01-basic.t` | blocked at test 9 (8/24 pass) | `carray-from-blob($a):managed` builds a Raku-side `CArray[T]`, whose `.REPR` is `P6opaque`, so `BODY_OF` refuses it |
+| `03-pointer.t` | blocked at test 1 (0/10) | `nativecast(Pointer[uint16], CArray[uint16].new(…))` — a Raku-side `CArray` carries no C address, so `.deref` reads address 0 |
+| `02-cstruct.t` | **not whitelistable at all** | raku itself fails its tests 13 and 15 on this machine, so it can never be an all-green gate entry (it also needs a C compiler at test time) |
+
+One smaller gap sits behind `01-basic.t` test 6 and is independent of P3: an
+*unmanaged* `CArray` (a `nativecast` handle) has no known length, so `.elems`
+must throw; mutsu returns a number. Fixing it alone does not unblock the file.
+
+Re-measure with:
+
+```sh
+MUTSU_BIN=target/release/mutsu BATTERIES_LOCK=<lock-with-just-this-battery> \
+  BATTERIES_WHITELIST=/dev/null scripts/battery-testsuite.sh
+```
+
 ## Note on the diagnostic
 
 The first line mutsu prints for these files is


### PR DESCRIPTION
Closes #5558. Advances #5557 as far as it can go (see "What is still blocked").

`NativeLibs` (0.0.9, 96 dependents in the fez index) is bundled as a runtime
dependency of the `DBIish` database battery, but none of its four upstream test
files was in the release gate's baseline — across it and `NativeHelpers::Blob`
only **1 of 9** files passed. Now **6 of 9** do, and the gate's whole baseline
goes from **132 to 137** files.

Every fix below is a general interpreter or compatibility fix, not a
`NativeLibs`-shaped patch (rung 2 of the adoption policy). Full write-up in
`news/2026-07/nativelibs-battery-suite-green.md`.

## Fixes

| # | Fix | Pin |
| --- | --- | --- |
| 1 | **`$*VM.config` was nearly empty** — three keys. `osname` was missing, and `NativeLibs` switches its entire library-naming scheme on it, so on Linux the whole platform section was skipped in silence (`02-cannon-name.t` planned 10 tests and ran zero). The C toolchain MoarVM records (`cc`, `cflags`, `ld`, `dll`, …) was missing too; `NativeLibs::Compile` joins those into a `shell()` command line. mutsu now reports a working *host* toolchain, with `CC`/`LD`/`CFLAGS` able to override. | `t/vm-config-toolchain.t` |
| 2 | **`platform-library-name` mangled any path with a directory** — `/bar/foo` became `lib/bar/foo.so` instead of `/bar/libfoo.so`. Rakudo decorates only the basename, restores the directory, and absolutizes when one was given. | `t/platform-library-name-path.t` |
| 3 | **Package-qualified multi dispatch ignored optional parameters** — `M::f('foo')` could not reach `multi f(Str, Version $v = Version)`. Candidates are keyed by *declared* arity and only the bare-name path had the flexible-arity fallback. | `t/our-proto-package-stash.t` |
| 4 | **A native sub called through a code object ran its `{ * }` stub** — `my &f = &dlsym; f(\|c)` (how `NativeLibs` picks between the dyncall and libffi lookups) returned the Whatever `*`. | `t/nativecall-signature-cast.t` |
| 5 | **`nativecast(<Signature>, \$ptr)` was not implemented** — attaching a signature to a runtime-resolved function pointer is the only way a `dlsym`ed symbol becomes callable. | `t/nativecall-signature-cast.t` |
| 6 | **`constant HANDLE = uint32` was not usable as a type** — the compile-time validator rejected the alias, so a whole `is native` declaration failed to compile. | `t/constant-type-alias.t` |
| 7 | **`our proto sub` was invisible in its package's stash** — protos live in a registry the stash never scanned, *and* each bare `multi` candidate marked the name `my`-scoped. `Stmt::ProtoDecl` now carries `is_our`; an explicit `our` wins. A bare proto still stays lexical, matching Rakudo. | `t/our-proto-package-stash.t` |
| 8 | **`NativeCall`'s export list was empty** — `NativeLibs` copies the whole `NativeCall::EXPORT::ALL` stash into its own `UNIT::EXPORT`, and that silently did nothing. Three general gaps closed with it: a module that exports anything gains an `EXPORT` stash member; an EXPORT package always lists `ALL`; and `Alias::{...}` on a lexical bound to a package reads *that package's* stash. | `t/nativecall-export-stash.t` |
| 9 | **`:v<…>` was not short for `:ver<…>`** in a distribution selector. | `t/use-version-short-adverb.t` |
| 10 | **A `when` block's value was warned about as sink context** — `when`/`default` succeed out of the topicalizer with their last statement's value. Because the analysis is compile-time, the spurious warning fired even on a branch that never runs. | `t/when-block-value-not-sunk.t` |

Plus one narrower NativeCall fix `NativeHelpers::Blob`'s signatures need: an
unparameterized `CArray` constraint now accepts a `CArray[T]` — parameterization
narrows a type rather than replacing it (`t/carray-base-type-match.t`).

## Gate harness

A `not ok … # TODO …` is an *expected* failure per TAP, and `prove` agrees, but
the battery gate counted it as a real one. `NativeLibs`' `10-search.t` marks its
"is there a versioned `libmysqlclient`?" probe TODO and **raku fails that subtest
too**, so the file was ungateable at exact parity. The harness now excludes TODO
failures and reports the count (`PASS(1 todo)`), so a file quietly turning its
plan into TODOs stays visible.

## What is still blocked

`NativeHelpers::Blob`'s `01-basic.t` (8/24) and `03-pointer.t` (0/10) stop at the
same wall: a `CArray[T]` constructed from Raku has no C storage, so its `.REPR`
is `P6opaque` and it has no address to `nativecast` from. That is **ADR-0015 P3**
(native-backed Raku-side `CArray[T]`/`array[T]`), a designed but unstarted phase.
`02-cstruct.t` is not whitelistable at all — raku itself fails two of its tests
on this machine. `todo/deep/nativehelpers-blob-moarvm-guts.md` now records exactly
which files and subtests P3 gates.

## Verification

- `make test` — 2611 files, 24839 tests, PASS
- `make roast` — 1435 files, 218774 tests, PASS
- `scripts/battery-testsuite.sh` (enforce mode) — 137/144, GATE PASSED
- Every new `t/` file was run under **raku** as well and passes identically there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)