### PR TITLE
feat: native-backed CArray[T] — ADR-0015 P3a, plus three general bugs behind it

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -398,7 +398,13 @@ sessions).
   `todo/deep/nativehelpers-blob-moarvm-guts.md`. **P2 (native-backed `Buf`/`Blob`) landed 2026-07-28**
   and `pointer-to(Blob)` now works; the two follow-on bugs (a ternary then-branch enum value, and a
   hyper not descending into an itemized list) are fixed too, so `DBIish` is at raku parity on all
-  nine files. P3 (Raku-side `CArray[T]` / `array[T]`) is still open.
+  nine files. **P3a (native-backed Raku-side `CArray[T]`) landed 2026-07-30** — `.REPR`/`.WHERE` are
+  honest, a native call is handed the array's own bytes, and `NativeHelpers::Blob`'s `01-basic.t`
+  (24/24) and `03-pointer.t` (10/10) joined the battery gate
+  ([news](news/2026-07/carray-native-storage.md)). Still open: **P3b** (`array[T]`, which needs the
+  `ArrayData::items` accessor chokepoint first, and is also the fix for `array-shapes.t` T36-38) and
+  **P3c** (reference-element `CArray[Str]`/`CArray[Pointer]`, parity polish — no bundled dist needs
+  C to write one).
 
 ---
 

--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -79,6 +79,8 @@ MIME::Base64	binary-and-long-line.rakutest
 MIME::Base64	oneline.rakutest
 MIME::Base64	rfc4648-test-vector.rakutest
 NativeHelpers::Blob	00-trivial.t
+NativeHelpers::Blob	01-basic.t
+NativeHelpers::Blob	03-pointer.t
 NativeHelpers::Blob	99-my-meta.t
 NativeLibs	01-basic.t
 NativeLibs	02-cannon-name.t

--- a/docs/adr/0015-native-backed-container-storage-and-repr-bodies.md
+++ b/docs/adr/0015-native-backed-container-storage-and-repr-bodies.md
@@ -184,6 +184,27 @@ Each phase is independently useful and independently shippable.
 - **P3 — native-backed Raku-side `CArray[T]` and `array[T]`.** The same node for
   the two remaining containers. **Retires the per-call copy-in/copy-out and the
   out-array writeback in `marshal_carray_arg`.**
+  - **P3a — `CArray[T]` (landed).** A `CArray` over a *native numeric* `T` is a
+    storage-backed instance sharing `BufData` and the whole `value_buf` accessor
+    layer; the node's element descriptor became an `ElemKind` so `num32`/`num64`
+    elements fit. `.REPR` answers `CArray`, `.WHERE` a `CArrayB` block, and a
+    native call is handed the array's own bytes. Element types that are
+    **references** (`CArray[Str]`, `CArray[Pointer]`, a nested `CArray`, a CStruct
+    class) keep the boxed representation and the per-call `char**` build: their
+    bytes are an address, and reading one back means materialising the object it
+    points at, which contiguous bytes alone cannot do (MoarVM keeps a parallel
+    `child` table for exactly this). They go on under-reporting `P6opaque`, which
+    is the safe direction under the ordering rule below. `array[T]` was NOT part
+    of this slice.
+  - **P3b — `array[T]` (open).** The same node again, but the container is a
+    `Value::Array`, not an instance, so the accessor-chokepoint step P2 did for
+    `Buf`'s ~104 `"bytes"` touches has to be done for `ArrayData::items` first.
+    Independently the fix for the native-typed shaped-array defect
+    (`array-shapes.t` T36-38).
+  - **P3c — reference-element `CArray` (open, optional).** Storing `char*`
+    elements natively, with the array owning the `CString`s, would retire the
+    `CArrayStr` marshal path too. No bundled dist needs C to *write* a
+    `CArray[Str]`, so this is parity polish rather than a blocker.
 
 **Ordering rule (safety-critical): `.REPR` truthfulness for a kind must land in
 the same slice as that kind's body, never before it.** The moment `.REPR` says
@@ -286,11 +307,16 @@ the identity hash and a binding dereferenced garbage).
    would make mutsu *stricter* than the implementation these modules were written
    against, at the cost of holding dead blocks alive. Revisit only if a real dist
    trips on it.
-4. **Does `array[T]` ride in P3?** ✅ **RESOLVED: yes.** It is the same node and
-   the same marshalling path, and it is independently the fix for the native-typed
-   shaped-array defect (`array-shapes.t` T36-38: broken coercion, ~150× slower
-   than it should be) — which is the same "boxed where it should be native"
-   problem seen from the other side.
+4. **Does `array[T]` ride in P3?** ✅ **RESOLVED: yes** — but *after* `CArray`, not
+   with it (see the P3a/P3b split in §2.1, made when P3a landed). It is the same
+   node and the same marshalling path, and it is independently the fix for the
+   native-typed shaped-array defect (`array-shapes.t` T36-38: broken coercion,
+   ~150× slower than it should be) — which is the same "boxed where it should be
+   native" problem seen from the other side. What separates the two is the
+   *container*: a `CArray` could become a storage-backed instance and reuse
+   `Buf`'s accessor layer as-is, whereas `array[T]` is a `Value::Array`, so its
+   `ArrayData::items` touches need the same chokepoint step P2 did for `Buf`
+   first.
 5. **How far does `.REPR` truthfulness go?** ✅ **RESOLVED: exactly the four kinds
    that get bodies**, everything else stays `P6opaque`. Answering honestly for
    every type (`P6int`, `P6num`, `P6str`, …) has no known consumer, and under the
@@ -315,10 +341,15 @@ P0 is unblocked and self-contained; P1 follows it; P2 is the campaign. Concretel
 - **P2** the node, the two accessors, the ~91 `"bytes"` sites, `MVMArrayB`,
   `.REPR = VMArray`, delete `nativecall_pin.rs`. Acceptance: `DBIish` `01-basic`
   reaches raku parity (35/35) and the battery test-suite gate stays green.
-- **P3** the same node for `CArray[T]` / `array[T]`; delete the copy-in/copy-out
-  in `marshal_carray_arg`. Acceptance: `t/nativecall-carray.t` unchanged and
-  green, plus a test that C writes through a retained pointer are visible in Raku
-  with no intervening call.
+- **P3a** (landed) the same node for `CArray[T]`; the numeric copy-in/copy-out in
+  `marshal_carray_arg` is bypassed for every storage-backed argument. Acceptance,
+  all met: `t/nativecall-carray.t` unchanged and green; `t/carray-native-storage.t`
+  pins that a C write through a *retained* pointer is visible in Raku with no
+  intervening call; `NativeHelpers::Blob`'s `01-basic.t` (24/24) and `03-pointer.t`
+  (10/10) joined the battery gate.
+- **P3b** the same node for `array[T]`, behind the `ArrayData::items` accessor
+  chokepoint. Acceptance: `pointer-to(array:D)` works and `array-shapes.t` T36-38
+  pass at native speed.
 
 *Status is `Accepted`. If the judgment changes later, supersede this ADR rather
 than rewriting it.*

--- a/docs/nativecall-repr-bodies.md
+++ b/docs/nativecall-repr-bodies.md
@@ -58,7 +58,7 @@ synthesised on demand.
 | REPR | body | mutsu's answer |
 | --- | --- | --- |
 | `VMArray` | `{u64 elems; u64 start; u64 ssize; void* any}` | a `Buf`/`Blob` with element storage |
-| `CArray` | `{void* storage; void** child; i32 managed; i32 allocated; i32 elems}` | a `nativecast`ed `CArray` handle |
+| `CArray` | `{void* storage; void** child; i32 managed; i32 allocated; i32 elems}` | a `nativecast`ed `CArray` handle, and a native-backed `CArray[T]` |
 | `CStruct` | `{void* cstruct; void** child_objs}` | a `nativecast`ed CStruct/CUnion handle |
 
 `start` is **always 0**: mutsu's element storage never has an unused prefix, so
@@ -67,8 +67,14 @@ synthesised on demand.
 For the two handle kinds the body is a zero-filled block whose first word is the
 handle's address — byte-identical to both layouts, since every later word of an
 unmanaged cast is zero (`managed`, `allocated` and `elems` are all 0, which is
-exactly what an unmanaged `CArray` handle *is*). For a `Buf` the block is real
-and per-object; see below.
+exactly what an unmanaged `CArray` handle *is*). For a `Buf`, and for a
+`CArray[T]` mutsu allocated itself, the block is real and per-object; see below.
+
+A **native-backed `CArray[T]`** — one built in Raku over a native numeric element
+type — fills its `CArrayB` for real: `storage` is its element bytes, `elems` and
+`allocated` its length and capacity, `managed` is 1 (owning its memory is what
+having storage *means*), and `child` is always NULL, because the element types that
+would need a child table keep the boxed representation (see the last section).
 
 ### 3. `.WHERE` is stable for the object's lifetime
 
@@ -96,8 +102,9 @@ Raku-side write to a buffer that does **not** grow it past its allocation writes
 
 ## What a native call is handed
 
-A `Blob`/`Buf` argument declared as a C `void*` is passed **its own storage
-address**. Nothing is copied in and nothing is copied back:
+A `Blob`/`Buf` or native-backed `CArray[T]` argument declared as a C `void*` (or a
+`T*`) is passed **its own storage address**. Nothing is copied in and nothing is
+copied back:
 
 - a callee filling an out-buffer (`SSL_read`, `mysql_stmt_fetch`) writes into
   the Raku object, so there is no sync point to get wrong — and, critically, no
@@ -110,7 +117,12 @@ address**. Nothing is copied in and nothing is copied back:
 
 This replaced a per-object mirror (`runtime/nativecall_pin.rs`, deleted) that
 could keep a retained pointer alive but could never observe a write it did not
-mediate.
+mediate — and, for `CArray`, a per-call copy-in/copy-out that could only reflect a
+write made *during* the call.
+
+`nativecast(Pointer[T], $carray)` reinterprets that same element address, which is
+what makes `NativeHelpers::Pointer`'s arithmetic (`.succ`/`.pred`/`.add`/`+`) walk
+a Raku-built array.
 
 ## Residual unsafety
 
@@ -127,7 +139,12 @@ Everything else answers `P6opaque`, on purpose (ADR-0015 §5, open question 5):
 each honest answer is a promise that a body exists behind it, and that is not a
 promise to make idly. In particular:
 
-- a **CStruct constructed in Raku** (`Rec.new`) has no C storage yet — that is
-  ADR-0015's P3;
-- a Raku-side **`CArray[T]`** and **`array[T]`** — likewise P3;
+- a **CStruct constructed in Raku** (`Rec.new`) has no C storage yet;
+- a Raku-side **`array[T]`** — ADR-0015's P3b;
+- a **`CArray[T]` whose element type is a reference**: `CArray[Str]`,
+  `CArray[Pointer]`, a nested `CArray[CArray[…]]`, a CStruct element. Their
+  elements are addresses of other objects, so reading one back means materialising
+  the object it points at, which contiguous bytes alone cannot express — MoarVM
+  keeps its parallel `child` table for exactly this. They keep the boxed
+  representation and the per-call `char**` build (ADR-0015's P3c);
 - an ordinary class, which also keeps its identity-derived `.WHERE`.

--- a/news/2026-07/carray-native-storage.md
+++ b/news/2026-07/carray-native-storage.md
@@ -1,0 +1,109 @@
+# `CArray[T]` stops being a copy and becomes the memory C writes
+
+A `CArray[T]` was an `Array` of boxed elements, and every native call built a
+fresh C block from it on the way in and read the block back on the way out. That
+copy is correct only for a callee that writes into the buffer *during* the call.
+`NativeHelpers::Blob`'s managed `carray-from-blob` does this instead:
+
+```raku
+my \arr = CArray[t].new;
+arr[$bb.elems - 1] = 0;             # force allocation
+memcpy(BODY_OF(arr).storage, $bb.realstart, …);   # write, later, through the address
+```
+
+There is no call boundary between taking the address and the write, so there was
+no point at which a copy could have been synced back — and no address to take in
+the first place: a Raku-side `CArray`'s `.REPR` was `P6opaque` and its `.WHERE`
+was a hash of its identity.
+
+A `CArray` over a **native numeric** element type is now a storage-backed
+instance, exactly as a `Buf` has been since
+[P2](buf-native-byte-node.md): its elements are contiguous bytes in a payload-only
+[`BufData`] node, `.REPR` answers `CArray`, `.WHERE` answers a `CArrayB` block
+describing that storage, and a native call is handed the array's own bytes. This
+is [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
+P3a.
+
+## What made it small
+
+P2 had already built everything except the class-name filter. The node, the
+encode/decode boundary, the in-place write discipline (write *through* an unshared
+node so an address stays valid), and the whole `value_buf` accessor layer are
+shared verbatim; `value_carray` adds ~40 lines — the filter, construction, and the
+`CArrayB` body — and `is_native_elems_class` widens the dozen element-storage
+gates (indexing, assignment, `.elems`, `.list`, `.of`, iteration) that used to say
+`is_buf_or_blob_class`.
+
+Two things had to generalise. The node's element descriptor was a `signed: bool`,
+which cannot express `CArray[num64]`, so it became an `ElemKind` of
+`Uint`/`Int`/`Float`. And four hand-inlined copies of the Buf class-name ladder —
+`.list`, `.List`, `.Capture`, and the one iteration methods use — were collapsed
+into the shared predicate on the way past.
+
+## Reference-typed elements deliberately keep the boxed form
+
+`CArray[Str]`, `CArray[Pointer]`, a nested `CArray[CArray[…]]` and a CStruct
+element are **addresses of other objects**. Their bytes are a pointer, and reading
+one back means materialising the object it points at, which contiguous bytes alone
+cannot do — MoarVM keeps a parallel `child` table for exactly this. Those keep the
+`Array` representation and the per-call `char**` build, and go on under-reporting
+`.REPR` as `P6opaque`, which is the safe direction: ADR-0015 §2.1's ordering rule
+is that an honest `.REPR` is a promise that a body exists behind `.WHERE`. A
+node-backed array therefore never has children, and `CArrayB.child` is always
+NULL.
+
+## Three general bugs found behind the same two test files
+
+None is about `CArray`; all three were blocking `NativeHelpers::Blob`'s
+`03-pointer.t`, which is `NativeHelpers::Pointer`'s whole test suite.
+
+**A list infix is looser than the argument comma — except in a `.= new:` list.**
+`my CArray[uint16] $a .= new: 10, 20 ... 100` built `10, 20, 21, 22, …`: the
+colon-argument list was parsed one argument at a time, so the sequence's seed was
+only its *last* element (`10, (20 ... 100)`) instead of the whole comma level.
+The ordinary postfix `.method: …` path had had this lift for a while; the four
+`.=` sites (declaration, assignment statement, `has` default, `constant`) each
+carried their own byte-identical copy of the argument loop, which is how all four
+came to be missing it. They share one implementation now, and it lifts the `Z`/`X`
+meta-ops too.
+
+**`^add_method` on a qualified class name added to a stub nobody consults.**
+`NativeHelpers::Pointer` builds all of NativeCall's pointer arithmetic with
+`NativeCall::Types::Pointer.^add_method('add', …)`, while the prelude registers
+`Pointer` under its short name and tags every handle with it. The long name was
+not a registered class, so `add_method` created a fresh stub, populated it, and
+nothing ever looked there: `.add` was "no such method" and `.succ`/`.pred` fell
+through to the *numeric* successor, advancing a `Pointer[uint16]` by one byte
+instead of one element.
+
+**An added method's invocant was counted as a parameter.** `method (Pointer:D:
+Int $off)` filtered the invocant out of `param_defs` but not out of the positional
+name list dispatch binds against, so every argument shifted by one and the last
+parameter was unbound — `Variable 'off' is not declared`.
+
+Plus one parity gap in the same file: `isa-ok $p.succ, Pointer[uint16]` failed
+because a typed pointer keeps its parameterisation in an `of` attribute rather
+than in its class name (deliberately, so every `Pointer` method keeps working), and
+the type check never looked there.
+
+## Results
+
+`NativeHelpers::Blob`'s `01-basic.t` (24/24, was 8/24) and `03-pointer.t` (10/10,
+was 0/10) joined the battery gate, closing the last two files of
+[issue #5557](https://github.com/tokuhirom/mutsu/issues/5557) that could be
+closed — `02-cstruct.t` is not whitelistable at all, because raku itself fails its
+tests 13 and 15 on this machine. The unmanaged-`CArray` gap noted in that issue is
+fixed on the way past: a `nativecast`ed handle has no length to report, so
+`.elems` throws Rakudo's "Don't know how many elements a C array returned from a
+library" instead of answering 0.
+
+Parity gained beyond the two files: growing a `CArray` by element assignment
+zero-fills (it left `Any` holes), `.list` is a `List` rather than an `Array`, and
+`CArray[num32]`/`CArray[num64]` elements read back as `Num`s.
+
+`array[T]` is **not** part of this — it is P3b, and it needs a different first
+step, because it is a `Value::Array` rather than an instance, so its
+`ArrayData::items` touches need the accessor chokepoint P2 built for `Buf`'s.
+
+Pins: `t/carray-native-storage.t`, `t/colon-args-list-infix-precedence.t`,
+`t/add-method-qualified-and-invocant.t`.

--- a/src/builtins/iterator_construct.rs
+++ b/src/builtins/iterator_construct.rs
@@ -26,7 +26,7 @@ fn blob_elements(target: &Value) -> Option<Vec<Value>> {
     else {
         return None;
     };
-    if !crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) {
+    if !crate::runtime::utils::is_native_elems_class(&class_name.resolve()) {
         return None;
     }
     Some(crate::value::value_buf::buf_elems_or_empty(&attributes))

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -296,18 +296,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 class_name,
                 attributes,
                 ..
-            } if {
-                let cn = class_name.resolve();
-                cn == "Buf"
-                    || cn == "Blob"
-                    || cn == "utf8"
-                    || cn == "utf16"
-                    || cn.starts_with("Buf[")
-                    || cn.starts_with("Blob[")
-                    || cn.starts_with("buf")
-                    || cn.starts_with("blob")
-            } =>
-            {
+            } if crate::runtime::utils::is_native_elems_class(&class_name.resolve()) => {
                 if let Some(list) = crate::value::value_buf::buf_elems_as_array(
                     &attributes.as_map(),
                     crate::value::ArrayKind::List,
@@ -549,18 +538,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     class_name,
                     attributes,
                     ..
-                } if {
-                    let cn = class_name.resolve();
-                    cn == "Buf"
-                        || cn == "Blob"
-                        || cn == "utf8"
-                        || cn == "utf16"
-                        || cn.starts_with("Buf[")
-                        || cn.starts_with("Blob[")
-                        || cn.starts_with("buf")
-                        || cn.starts_with("blob")
-                } =>
-                {
+                } if crate::runtime::utils::is_native_elems_class(&class_name.resolve()) => {
                     Some(Ok(wrap(crate::value::value_buf::buf_elems_or_empty(
                         &attributes,
                     ))))
@@ -831,18 +809,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             class_name,
             attributes,
             ..
-        } if {
-            let cn = class_name.resolve();
-            cn == "Buf"
-                || cn == "Blob"
-                || cn == "utf8"
-                || cn == "utf16"
-                || cn.starts_with("Buf[")
-                || cn.starts_with("Blob[")
-                || cn.starts_with("buf")
-                || cn.starts_with("blob")
-        } =>
-        {
+        } if crate::runtime::utils::is_native_elems_class(&class_name.resolve()) => {
             let positional = crate::value::value_buf::buf_elems_or_empty(&attributes);
             Ok(Value::capture(positional, HashMap::new()))
         }

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -31,7 +31,7 @@ pub(super) fn dispatch(
                     class_name,
                     attributes,
                     ..
-                } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
+                } if crate::runtime::utils::is_native_elems_class(&class_name.resolve()) => {
                     let len = buf_len_or_zero(&attributes);
                     Some(Ok(Value::int(len as i64 - 1)))
                 }

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -127,7 +127,19 @@ pub(super) fn dispatch(
                     class_name,
                     attributes,
                     ..
-                } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
+                } if crate::runtime::utils::is_native_elems_class(&class_name.resolve()) => {
+                    // An **unmanaged** `CArray` — a `nativecast`ed handle, which
+                    // carries a bare C address and no storage of its own — has no
+                    // length to report, and Rakudo throws rather than answering 0.
+                    // `NativeHelpers::Blob`'s `01-basic.t` asserts exactly that
+                    // (`dies-ok { $au.elems }`) before going on to use `:size`.
+                    if !crate::value::value_buf::has_buf_elems(&attributes)
+                        && attributes.contains_key("address")
+                    {
+                        return Some(Some(Err(crate::value::RuntimeError::new(
+                            "Don't know how many elements a C array returned from a library",
+                        ))));
+                    }
                     Value::int(crate::value::value_buf::buf_len_or_zero(&attributes) as i64)
                 }
                 ValueView::Channel(_) => {

--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -552,7 +552,7 @@ pub(super) fn dispatch(
             // — DBDish::Pg's `escapeBytea` sizes its buffer with
             // `nativesizeof($buf.of)`.
             ValueView::Instance { class_name, .. }
-                if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) =>
+                if crate::runtime::utils::is_native_elems_class(&class_name.resolve()) =>
             {
                 Some(Ok(Value::package(Symbol::intern(
                     &crate::value::value_buf::buf_elem_type_name(&class_name.resolve()),
@@ -580,7 +580,7 @@ pub(super) fn dispatch(
                     || n.starts_with("MixHash[")
                 {
                     Some(Ok(Value::package(Symbol::intern("Real"))))
-                } else if crate::runtime::utils::is_buf_or_blob_class(&n) {
+                } else if crate::runtime::utils::is_native_elems_class(&n) {
                     // The type object answers `.of` too (`Buf.of` is `(uint8)`).
                     Some(Ok(Value::package(Symbol::intern(
                         &crate::value::value_buf::buf_elem_type_name(&n),

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -514,7 +514,9 @@ pub(crate) fn native_method_1arg(
                         class_name,
                         attributes,
                         ..
-                    } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
+                    } if crate::runtime::utils::is_native_elems_class(&class_name.resolve())
+                        && crate::value::value_buf::has_buf_elems(&attributes) =>
+                    {
                         if let Some(b) =
                             crate::value::value_buf::with_buf_elems(&attributes, |items| {
                                 items.get(idx).cloned().unwrap_or(Value::int(0))

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -99,4 +99,4 @@ pub(crate) use sink::{
     parse_assign_expr_or_comma, parse_assign_expr_or_comma_no_word_logical,
     rewrite_scalar_assignment_rhs_as_sink, rewrite_scalar_assignment_stmt_as_sink,
 };
-pub(crate) use try_assign::parse_colon_method_arg;
+pub(crate) use try_assign::parse_colon_args;

--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -352,37 +352,7 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             (r, a)
         } else if r_before_ws.starts_with(':') && !r_before_ws.starts_with("::") {
             // Colon-arg syntax: .=method: arg, arg2 (no space before colon)
-            let r = &r_before_ws[1..];
-            let (r, _) = ws(r)?;
-            let (r, first_arg) = parse_colon_method_arg(r)?;
-            let mut args = vec![first_arg];
-            let mut r_inner = r;
-            loop {
-                let (r2, _) = ws(r_inner)?;
-                // Adjacent colonpairs without comma
-                if r2.starts_with(':')
-                    && !r2.starts_with("::")
-                    && let Ok((r3, arg)) = crate::parser::primary::misc::colonpair_expr(r2)
-                {
-                    args.push(arg);
-                    r_inner = r3;
-                    continue;
-                }
-                if !r2.starts_with(',') {
-                    break;
-                }
-                let r2 = &r2[1..];
-                let (r2, _) = ws(r2)?;
-                // Handle trailing comma before ';' or '}'
-                if r2.starts_with(';') || r2.starts_with('}') || r2.is_empty() {
-                    r_inner = r2;
-                    break;
-                }
-                let (r2, next) = parse_colon_method_arg(r2)?;
-                args.push(next);
-                r_inner = r2;
-            }
-            (r_inner, args)
+            crate::parser::stmt::assign::parse_colon_args(r_before_ws)?
         } else if r.starts_with(':') && !r.starts_with("::") {
             // Fake-infix adverb form: .=method :key<val> (space before colon)
             let mut args = Vec::new();

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -12,6 +12,61 @@ pub(crate) fn parse_colon_method_arg(input: &str) -> PResult<'_, Expr> {
     expression(input)
 }
 
+/// Parse the whole colon-argument list of a `.=method: a, b` call. `input` must
+/// start at the `:`.
+///
+/// The one place this list is parsed. It used to be four byte-identical inline
+/// loops (declaration, assignment statement, `has` default, `constant`), which is
+/// how the list-infix lift below came to be missing from all of them while the
+/// ordinary postfix `.method: …` path had it.
+pub(crate) fn parse_colon_args(input: &str) -> PResult<'_, Vec<Expr>> {
+    let r = &input[1..];
+    let (r, _) = ws(r)?;
+    // Raku's list-infix operators are LOOSER than the comma separating the
+    // arguments, so `.= new: 10, 20 ... 100` is ONE sequence argument whose seed
+    // is the whole comma level — exactly as `(10, 20 ... 100)` in parens. Parsed
+    // per-argument, the seed was only the *last* element, so
+    // `my CArray[uint16] $a .= new: 10, 20 ... 100` (NativeHelpers::Blob's
+    // `03-pointer.t`) built 10, 20, 21, 22, … instead of 10, 20, 30, ….
+    if let Some(result) = crate::parser::primary::try_parse_sequence_arg_list(r) {
+        let (r_seq, seq) = result?;
+        return Ok((r_seq, vec![seq]));
+    }
+    let (r, first_arg) = parse_colon_method_arg(r)?;
+    let mut args = vec![first_arg];
+    let mut r_inner = r;
+    loop {
+        let (r2, _) = ws(r_inner)?;
+        // Adjacent colonpairs without comma.
+        if r2.starts_with(':')
+            && !r2.starts_with("::")
+            && let Ok((r3, arg)) = crate::parser::primary::misc::colonpair_expr(r2)
+        {
+            args.push(arg);
+            r_inner = r3;
+            continue;
+        }
+        if !r2.starts_with(',') {
+            break;
+        }
+        let r2 = &r2[1..];
+        let (r2, _) = ws(r2)?;
+        // Trailing comma before `;` or `}`.
+        if r2.starts_with(';') || r2.starts_with('}') || r2.is_empty() {
+            r_inner = r2;
+            break;
+        }
+        let (r2, next) = parse_colon_method_arg(r2)?;
+        args.push(next);
+        r_inner = r2;
+    }
+    // The same looser-than-comma rule for the `Z`/`X` meta-ops and `minmax`.
+    Ok((
+        r_inner,
+        crate::parser::primary::lift_list_infix_in_arg_list(args),
+    ))
+}
+
 /// Try to parse a single assignment expression: $var op= expr or $var = expr.
 /// Returns the expression as Expr::AssignExpr.
 pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr> {
@@ -260,37 +315,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
             }
         } else if r_before_ws.starts_with(':') && !r_before_ws.starts_with("::") {
             // Colon-arg syntax: .=method: arg, arg2 (no space before colon)
-            let r = &r[1..];
-            let (r, _) = ws(r)?;
-            let (r, first_arg) = parse_colon_method_arg(r)?;
-            let mut args = vec![first_arg];
-            let mut r_inner = r;
-            loop {
-                let (r2, _) = ws(r_inner)?;
-                // Adjacent colonpairs without comma
-                if r2.starts_with(':')
-                    && !r2.starts_with("::")
-                    && let Ok((r3, arg)) = crate::parser::primary::misc::colonpair_expr(r2)
-                {
-                    args.push(arg);
-                    r_inner = r3;
-                    continue;
-                }
-                if !r2.starts_with(',') {
-                    break;
-                }
-                let r2 = &r2[1..];
-                let (r2, _) = ws(r2)?;
-                // Handle trailing comma before ';' or '}'
-                if r2.starts_with(';') || r2.starts_with('}') || r2.is_empty() {
-                    r_inner = r2;
-                    break;
-                }
-                let (r2, next) = parse_colon_method_arg(r2)?;
-                args.push(next);
-                r_inner = r2;
-            }
-            (r_inner, args)
+            parse_colon_args(r)?
         } else if r.starts_with(':') && !r.starts_with("::") {
             // Fake-infix adverb form: .=method :key<val> (space before colon)
             let mut args = Vec::new();

--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -123,7 +123,7 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
             let r = r.strip_prefix(')').ok_or_else(|| PError::expected(")"))?;
             (r, args)
         } else if r_before_ws.starts_with(':') && !r_before_ws.starts_with("::") {
-            super::my_decl_assign::parse_colon_args(r_before_ws)?
+            crate::parser::stmt::assign::parse_colon_args(r_before_ws)?
         } else if r.starts_with(':') && !r.starts_with("::") {
             super::my_decl_assign::parse_fake_infix_adverbs(r)?
         } else {

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -7,7 +7,6 @@ use super::helpers::{
     parse_array_shape_suffix, shaped_array_new_expr, shaped_array_new_with_data_expr,
 };
 use super::method_decl_body;
-use super::parse_colon_method_arg;
 use super::parse_decl_type_constraint;
 use crate::ast::{Expr, Stmt};
 use crate::symbol::Symbol;
@@ -720,36 +719,7 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
             let (r, _) = parse_char(r, ')')?;
             (r, args)
         } else if rest.starts_with(':') && !rest.starts_with("::") {
-            let r = &rest[1..];
-            let (r, _) = ws(r)?;
-            let (r, first_arg) = parse_colon_method_arg(r)?;
-            let mut args = vec![first_arg];
-            let mut r_inner = r;
-            loop {
-                let (r2, _) = ws(r_inner)?;
-                if r2.starts_with(':')
-                    && !r2.starts_with("::")
-                    && let Ok((r3, arg)) = crate::parser::primary::misc::colonpair_expr(r2)
-                {
-                    args.push(arg);
-                    r_inner = r3;
-                    continue;
-                }
-                if !r2.starts_with(',') {
-                    break;
-                }
-                let r2 = &r2[1..];
-                let (r2, _) = ws(r2)?;
-                // Handle trailing comma before ';' or '}'
-                if r2.starts_with(';') || r2.starts_with('}') || r2.is_empty() {
-                    r_inner = r2;
-                    break;
-                }
-                let (r2, next) = parse_colon_method_arg(r2)?;
-                args.push(next);
-                r_inner = r2;
-            }
-            (r_inner, args)
+            crate::parser::stmt::assign::parse_colon_args(rest)?
         } else {
             (rest, Vec::new())
         };

--- a/src/parser/stmt/decl/mod.rs
+++ b/src/parser/stmt/decl/mod.rs
@@ -39,18 +39,6 @@ use super::{
     class_decl_body, method_decl_body, method_decl_body_my, parse_comma_or_expr, sub_decl_body,
 };
 
-/// Parse a single argument in colon method-call syntax (.method: arg1, arg2).
-/// Tries colonpair first (:name, :$var, :!flag, :0port), then expression.
-fn parse_colon_method_arg(input: &str) -> PResult<'_, Expr> {
-    if input.starts_with(':')
-        && !input.starts_with("::")
-        && let Ok(result) = crate::parser::primary::misc::colonpair_expr(input)
-    {
-        return Ok(result);
-    }
-    expression(input)
-}
-
 fn parse_decl_type_constraint(input: &str) -> Option<(&str, String)> {
     let (mut rest, mut type_name) = parse_type_constraint_expr(input)?;
     loop {

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -7,8 +7,8 @@ use super::helpers::shaped_array_new_with_data_expr;
 use super::my_decl::MyDeclState;
 use super::{
     consume_scalar_decl_trailing_comma, default_decl_expr, method_decl_body,
-    parse_assign_expr_or_comma, parse_colon_method_arg, parse_comma_chained_decls,
-    parse_statement_modifier, rewrite_decl_assignment_or_chain, wrap_with_will_leave,
+    parse_assign_expr_or_comma, parse_comma_chained_decls, parse_statement_modifier,
+    rewrite_decl_assignment_or_chain, wrap_with_will_leave,
 };
 use crate::ast::{AssignOp, Expr, Stmt};
 use crate::symbol::Symbol;
@@ -574,7 +574,7 @@ fn handle_method_call_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         (r, args)
     } else if rest.starts_with(':') && !rest.starts_with("::") {
         // Colon invocant form (no space before ':'): .=method: arg
-        parse_colon_args(rest)?
+        crate::parser::stmt::assign::parse_colon_args(rest)?
     } else if rest_ws.starts_with(':') && !rest_ws.starts_with("::") {
         // Fake-infix adverb form (space before ':'): .=method :key<val> :key2<val2>
         parse_fake_infix_adverbs(rest_ws)?
@@ -667,41 +667,6 @@ fn handle_method_call_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         return parse_statement_modifier(rest, stmt);
     }
     Ok((rest, stmt))
-}
-
-/// Parse colon-style method arguments.
-pub(super) fn parse_colon_args(input: &str) -> PResult<'_, Vec<Expr>> {
-    let r = &input[1..];
-    let (r, _) = ws(r)?;
-    let (r, first_arg) = parse_colon_method_arg(r)?;
-    let mut args = vec![first_arg];
-    let mut r_inner = r;
-    loop {
-        let (r2, _) = ws(r_inner)?;
-        // Adjacent colonpairs without comma
-        if r2.starts_with(':')
-            && !r2.starts_with("::")
-            && let Ok((r3, arg)) = crate::parser::primary::misc::colonpair_expr(r2)
-        {
-            args.push(arg);
-            r_inner = r3;
-            continue;
-        }
-        if !r2.starts_with(',') {
-            break;
-        }
-        let r2 = &r2[1..];
-        let (r2, _) = ws(r2)?;
-        // Handle trailing comma before ';' or '}'
-        if r2.starts_with(';') || r2.starts_with('}') || r2.is_empty() {
-            r_inner = r2;
-            break;
-        }
-        let (r2, next) = parse_colon_method_arg(r2)?;
-        args.push(next);
-        r_inner = r2;
-    }
-    Ok((r_inner, args))
 }
 
 /// Parse fake-infix adverb arguments: `:key<val> :key2<val2>`.

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -4,9 +4,9 @@ use super::super::super::parse_result::{PError, PResult, take_while1};
 use super::super::{keyword, qualified_ident};
 use super::constant_subset::constant_decl;
 use super::helpers::{parse_sigilless_decl_name, register_term_symbol_from_decl_name};
-use super::my_decl_assign::parse_colon_args;
 use super::{parse_decl_type_constraint, parse_statement_modifier};
 use crate::ast::{Expr, Stmt};
+use crate::parser::stmt::assign::parse_colon_args;
 use crate::symbol::Symbol;
 use crate::value::Value;
 

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -88,7 +88,9 @@ fn interpreter_version() -> String {
     // or when `CacheMetadata` / `ParseEffects` gain or lose a field.
     // 9: `Value` gained `BufStorage` (ADR-0015 P2), which also shifted the
     // serialized `SerValue` discriminants after `Array`.
-    const CACHE_FORMAT_VERSION: u32 = 9;
+    // 10: `BufStorage`'s element descriptor became `ElemKind` (ADR-0015 P3),
+    // so its third field serializes as an enum rather than a bool.
+    const CACHE_FORMAT_VERSION: u32 = 10;
     let exe_stamp = std::env::current_exe()
         .and_then(fs::metadata)
         .and_then(|m| m.modified())

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -294,20 +294,10 @@ impl Interpreter {
             attributes,
             ..
         } = v.view()
+            && crate::runtime::utils::is_native_elems_class(&class_name.resolve())
+            && let Some(bytes) = crate::value::value_buf::buf_elems(&attributes)
         {
-            let cn = class_name.resolve();
-            let is_blob = cn == "Buf"
-                || cn == "Blob"
-                || cn == "utf8"
-                || cn == "utf16"
-                || cn == "utf32"
-                || cn.starts_with("Buf[")
-                || cn.starts_with("Blob[")
-                || cn.starts_with("buf")
-                || cn.starts_with("blob");
-            if is_blob && let Some(bytes) = crate::value::value_buf::buf_elems(&attributes) {
-                return Some(bytes);
-            }
+            return Some(bytes);
         }
         None
     }

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -727,6 +727,20 @@ impl crate::runtime::Interpreter {
                 _ => Value::int(body as i64),
             });
         }
+        // A native-backed `CArray[T]` (ADR-0015 P3). Same shape as the buffer
+        // above, a different REPR body: `NativeHelpers::Blob`'s `pointer-to`
+        // reads `$bb.storage` off a `CArrayB` where a `Blob`'s reads
+        // `$bb.realstart` off an `MVMArrayB`. An array whose element type is a
+        // reference (`CArray[Str]`) has no storage node and so keeps
+        // `P6opaque`, which is the safe direction (§2.1).
+        if crate::value::value_carray::is_native_carray_class(&class_name.resolve())
+            && let Some(body) = crate::value::value_carray::carray_repr_body_address(&attributes)
+        {
+            return Some(match method {
+                "REPR" => Value::str_from("CArray"),
+                _ => Value::int(body as i64),
+            });
+        }
         let addr = match attributes.as_map().get("address").map(|v| v.view()) {
             Some(ValueView::Int(a)) if a > 0 => a as usize,
             _ => return None,

--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -249,6 +249,17 @@ impl Interpreter {
                 }
             }
         }
+        // A `CArray[T]` over a native numeric `T` is a storage-backed instance,
+        // not an `Array` of boxed elements: its bytes are the memory C is handed
+        // a pointer into, and they are what its `.WHERE` describes (ADR-0015
+        // P3). Reference-typed elements (`CArray[Str]`, `CArray[Pointer]`, a
+        // nested `CArray`) keep the boxed form — see
+        // `value::value_carray::native_elem_type`.
+        if base_class_name == "CArray"
+            && crate::value::value_carray::is_native_carray_class(&class_name.resolve())
+        {
+            return Ok(crate::value::value_carray::make_carray(class_name, items));
+        }
         let mut result = if matches!(base_class_name, "Array" | "array" | "CArray") {
             // A CArray is a mutable, element-assignable buffer like a native
             // `array`, so build a real (mutable) Array, not an immutable List.

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -630,6 +630,24 @@ impl Interpreter {
                         return Err(RuntimeError::new("add_method target must be a type object"));
                     }
                 };
+                // A **qualified spelling of an already-registered class** adds to
+                // that class, not to a fresh stub under the long name.
+                // `NativeHelpers::Pointer` adds pointer arithmetic with
+                // `NativeCall::Types::Pointer.^add_method('add', …)`, while the
+                // prelude registers `Pointer` under its short name and tags every
+                // handle with it — so the stub was created, populated, and never
+                // consulted, leaving `.add` "no such method" and `.succ`/`.pred`
+                // falling through to the numeric successor.
+                let class_name = match class_name.rsplit("::").next() {
+                    Some(short)
+                        if short != class_name
+                            && !self.registry().classes.contains_key(&class_name)
+                            && self.registry().classes.contains_key(short) =>
+                    {
+                        short.to_string()
+                    }
+                    _ => class_name,
+                };
                 let method_name = args[1].to_string_value();
                 let method_value = args[2].clone();
                 let ValueView::Sub(sub_data) = method_value.view() else {
@@ -644,8 +662,28 @@ impl Interpreter {
                     .filter(|pd| !pd.is_invocant)
                     .cloned()
                     .collect();
+                // The name list has to lose the invocant too, not just
+                // `param_defs`: dispatch binds arguments positionally against
+                // `params`, so leaving `self` in it shifted every argument by one
+                // and left the last parameter undeclared — `method (Pointer:D:
+                // Int $off) { … $off … }` died with "Variable 'off' is not
+                // declared" (`NativeHelpers::Pointer`'s `add`).
+                let invocant_names: HashSet<&str> = sub_data
+                    .param_defs
+                    .iter()
+                    .filter(|pd| pd.is_invocant)
+                    .map(|pd| pd.name.as_str())
+                    .collect();
+                let filtered_params: Vec<String> = sub_data
+                    .params
+                    .iter()
+                    .filter(|p| {
+                        !invocant_names.contains(p.trim_start_matches(['$', '@', '%', '&']))
+                    })
+                    .cloned()
+                    .collect();
                 let def = MethodDef {
-                    params: sub_data.params.clone(),
+                    params: filtered_params,
                     param_defs: filtered_param_defs,
                     body: std::sync::Arc::new(sub_data.body.clone()),
                     is_rw: sub_data.is_rw,

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -103,28 +103,18 @@ impl Interpreter {
             attributes,
             ..
         } = target.view()
+            && crate::runtime::utils::is_native_elems_class(&class_name.resolve())
         {
-            let cn = class_name.resolve();
-            if cn == "Buf"
-                || cn == "Blob"
-                || cn == "utf8"
-                || cn == "utf16"
-                || cn.starts_with("Buf[")
-                || cn.starts_with("Blob[")
-                || cn.starts_with("buf")
-                || cn.starts_with("blob")
-            {
-                if let Some(list) = crate::value::value_buf::buf_elems_as_array(
-                    &attributes.as_map(),
-                    crate::value::ArrayKind::List,
-                ) {
-                    return Ok(list);
-                }
-                return Ok(Value::array_with_kind(
-                    crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
-                    crate::value::ArrayKind::List,
-                ));
+            if let Some(list) = crate::value::value_buf::buf_elems_as_array(
+                &attributes.as_map(),
+                crate::value::ArrayKind::List,
+            ) {
+                return Ok(list);
             }
+            return Ok(Value::array_with_kind(
+                crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
+                crate::value::ArrayKind::List,
+            ));
         }
         // A genuinely-lazy list (`(1…∞).List`) must STAY lazy: materializing it
         // would lose the infinite tail (and `.elems`/`eqv` must still throw

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -560,12 +560,22 @@ fn make_struct_value(class: &str, addr: usize) -> Value {
 pub(crate) fn value_c_address(v: &Value) -> usize {
     match v.view() {
         ValueView::Int(i) => i as usize,
-        ValueView::Instance { attributes, .. } => {
-            match attributes.as_map().get("address").map(Value::view) {
-                Some(ValueView::Int(i)) => i as usize,
-                _ => 0,
+        ValueView::Instance {
+            attributes,
+            class_name,
+            ..
+        } => match attributes.as_map().get("address").map(Value::view) {
+            Some(ValueView::Int(i)) => i as usize,
+            // A native-backed `CArray[T]` carries no `address` attribute: it
+            // *owns* its storage, and the pointer C gets is that storage
+            // (ADR-0015 P3). This is what `nativecast(Pointer[uint16], $carray)`
+            // reinterprets — `NativeHelpers::Pointer`'s whole test file walks the
+            // result with `.succ`/`.deref`.
+            _ if crate::value::value_carray::is_native_carray_class(&class_name.resolve()) => {
+                crate::value::value_carray::carray_storage_address(&attributes).unwrap_or(0)
             }
-        }
+            _ => 0,
+        },
         ValueView::Scalar(inner) => value_c_address(inner),
         ValueView::ContainerRef(cell) => cell.lock().ok().map(|g| value_c_address(&g)).unwrap_or(0),
         ValueView::VarRef { value, .. } => value_c_address(value),
@@ -967,6 +977,35 @@ fn marshal_carray_arg(
         if !crate::runtime::types::value_is_defined(&resolved) {
             return Ok((Type::pointer(), ArgOwner::Ptr(std::ptr::null())));
         }
+    }
+    // A native-backed `CArray[T]` is passed as a `void*` **to its own element
+    // storage** (ADR-0015 P3), exactly as a `Blob`/`Buf` is under P2: nothing is
+    // copied in and nothing is copied back, so a callee that fills the array
+    // needs no sync point and one that retains the pointer keeps seeing live
+    // memory. The copy this replaces was correct only for a callee that wrote
+    // *during* the call — `NativeHelpers::Blob`'s `carray-from-blob(:managed)`
+    // `memcpy`s into `BODY_OF(arr).storage` afterwards, with no call boundary at
+    // which a copy could have been synced back.
+    //
+    // A `Buf` handed to a `CArray[T]` parameter lands here too, and handing over
+    // its storage is equally right — the copy path could not see one at all and
+    // passed an empty buffer.
+    if let Some(node) = buf_storage_node(&resolve_arg(raw)) {
+        // SAFETY: audited aliased in-place container write (see
+        // `value::aliased_mut`) — this is the pointer C writes through, and the
+        // `node` held in the owner keeps the allocation alive for at least the
+        // duration of the call. No Rust borrow into the buffer is live across it.
+        let data_ptr = unsafe { crate::value::gc_contents_mut(&node) }
+            .bytes
+            .as_mut_ptr();
+        return Ok((
+            Type::pointer(),
+            ArgOwner::BufBytes {
+                node: Some(node),
+                buf: Vec::new(),
+                data_ptr: data_ptr as *const std::ffi::c_void,
+            },
+        ));
     }
     // An unparameterized `CArray` parameter carries no element type in the
     // signature, so take it from the argument itself (`CArray[int32].new` tags

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -616,6 +616,39 @@ impl Interpreter {
                     }
                     return false;
                 }
+                // NativeCall `Pointer[T]`: the parameterisation is NOT in the
+                // class name — a typed pointer stays an ordinary `Pointer`
+                // instance and remembers `T` in an `of` attribute, so that every
+                // `Pointer` method keeps working (see `try_nativecast`). So the
+                // element type is read from there, resolving a `constant` alias on
+                // the declared side exactly as the `CArray` arm does.
+                // `NativeHelpers::Pointer`'s pointer arithmetic returns these, and
+                // `isa-ok $p.succ, Pointer[uint16]` is what checks them.
+                "Pointer" => {
+                    let ValueView::Instance {
+                        class_name,
+                        attributes,
+                        ..
+                    } = value.view()
+                    else {
+                        return false;
+                    };
+                    let name = class_name.resolve();
+                    if name.rsplit("::").next() != Some("Pointer") {
+                        return false;
+                    }
+                    let Some(of) = attributes.as_map().get("of").map(|v| match v.view() {
+                        ValueView::Package(n) => n.resolve(),
+                        _ => v.to_string_value(),
+                    }) else {
+                        // An untyped `Pointer` is `Pointer[void]`; it matches a
+                        // parameterised constraint only when that asks for `void`.
+                        return self.resolved_type_capture_name(inner) == "void";
+                    };
+                    let want = self.resolved_type_capture_name(inner);
+                    let want = self.type_alias_target(&want).unwrap_or(want);
+                    return want == of || Self::type_matches(&want, &of);
+                }
                 "Array" | "List" | "Positional" => {
                     if let ValueView::Array(items, ..) = value.view() {
                         // Prefer the container's declared element type when known

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -214,6 +214,19 @@ pub(crate) fn is_buf_or_blob_class(cn: &str) -> bool {
     is_buf_like_class(cn) || is_blob_like_class(cn)
 }
 
+/// Whether instances of `cn` keep their elements in a native storage node — a
+/// `Buf`/`Blob`, or a native-backed `CArray[T]` (ADR-0015 P2 and P3).
+///
+/// This is the predicate for the *element-storage mechanics* an accessor in
+/// [`crate::value::value_buf`] serves: indexing, assignment, `.elems`, `.list`,
+/// iteration. It is deliberately **not** the predicate for anything that means
+/// "is a byte string": a `CArray` is not a `Blob`, so `.decode`, `.subbuf`,
+/// the `write-*` families, the hex `.gist` and the `Buf`/`Blob` type checks all
+/// keep the narrower [`is_buf_or_blob_class`] gate.
+pub(crate) fn is_native_elems_class(cn: &str) -> bool {
+    is_buf_or_blob_class(cn) || crate::value::value_carray::is_native_carray_class(cn)
+}
+
 /// Normalize Buf/Blob type aliases to canonical form.
 pub(crate) fn normalize_buf_type_name(name: &str) -> String {
     match name {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -292,8 +292,33 @@ pub(crate) fn seq_sink(arc_ptr: &Arc<Vec<Value>>) {
 /// Shared mutable attribute storage for Proxy subclasses.
 pub(crate) type ProxySubclassAttrs = Arc<Mutex<HashMap<String, Value>>>;
 
+/// How the bytes of one element read back out of a [`BufData`] node.
+///
+/// The node stores bytes; this is what says whether those bytes spell an
+/// unsigned integer, a two's-complement signed one, or an IEEE float. It
+/// started as a single `signed: bool` — enough for `Buf`/`Blob`, whose element
+/// types are all integers — and became an enum for ADR-0015 P3, because a
+/// `CArray[num64]` shares this node and its elements are `Num`s.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) enum ElemKind {
+    /// `uint8` … `uint64`, and every plain `Buf`/`Blob`/`utf8`/`utf16`.
+    Uint,
+    /// `int8` … `int64`: sign-extended from the element's own width on the way
+    /// out.
+    Int,
+    /// `num32` / `num64`: the bytes are an IEEE-754 float of the element width.
+    Float,
+}
+
+impl ElemKind {
+    /// Whether an element reads back sign-extended.
+    pub(crate) fn is_signed(self) -> bool {
+        matches!(self, ElemKind::Int)
+    }
+}
+
 /// The element storage of a `Buf`/`Blob`, as contiguous native bytes
-/// (ADR-0015 P2).
+/// (ADR-0015 P2), and of a native-backed `CArray[T]` (P3).
 ///
 /// This is a **payload-only** GC node: it holds no `Value`s, so it cannot take
 /// part in a cycle, `Trace` is an empty body, and ADR-0001's container type
@@ -316,24 +341,30 @@ pub(crate) struct BufData {
     pub bytes: Vec<u8>,
     /// Bytes per element: 1, 2, 4 or 8.
     pub width: u8,
-    /// Whether an element reads back as signed (`Blob[int8]`) or unsigned
-    /// (`Blob[uint8]`, and every plain `Buf`/`Blob`/`utf8`/`utf16`).
-    pub signed: bool,
-    /// The synthesised `VMArray` REPR body, allocated on first `.WHERE` and
-    /// owned by this node — see [`value_buf_repr::ReprBody`].
+    /// How those bytes read back — see [`ElemKind`].
+    pub kind: ElemKind,
+    /// The synthesised REPR body, allocated on first `.WHERE` and owned by this
+    /// node — see [`value_buf_repr::ReprBody`]. Which layout it holds is decided
+    /// by the *container* asking (`MVMArrayB` for a `Buf`, `CArrayB` for a
+    /// `CArray`), not by the node.
     pub body: value_buf_repr::ReprBody,
 }
 
 impl BufData {
     /// A buffer node over `bytes`, with no REPR body yet: the body block is
     /// allocated the first time something asks for the buffer's `.WHERE`.
-    pub(crate) fn new(bytes: Vec<u8>, width: u8, signed: bool) -> BufData {
+    pub(crate) fn new(bytes: Vec<u8>, width: u8, kind: ElemKind) -> BufData {
         BufData {
             bytes,
             width,
-            signed,
+            kind,
             body: value_buf_repr::ReprBody::default(),
         }
+    }
+
+    /// The number of elements the node holds.
+    pub(crate) fn elems(&self) -> usize {
+        self.bytes.len() / (self.width.max(1) as usize)
     }
 }
 
@@ -418,6 +449,7 @@ mod value_async;
 /// `Buf`/`Blob` element storage — the accessor chokepoint (ADR-0015 P2).
 pub(crate) mod value_buf;
 pub(crate) mod value_buf_repr;
+pub(crate) mod value_carray;
 mod value_collections;
 mod value_enum;
 mod value_eq;

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -33,7 +33,7 @@ enum SerValue {
     Array(Vec<SerValue>, ArrayKind),
     /// `Buf`/`Blob` element storage: the bytes plus the element type, so a
     /// precompiled `constant $CRLF = Buf.new(13, 10)` round-trips.
-    BufStorage(Vec<u8>, u8, bool),
+    BufStorage(Vec<u8>, u8, crate::value::ElemKind),
     Hash(HashMap<String, SerValue>),
     Rat(i64, i64),
     FatRat(i64, i64),
@@ -150,7 +150,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
         // does, serialize the variable's value.
         ValueView::VarRef { value, .. } => value_to_ser(value),
         ValueView::RakuAst(_) => Err("cannot serialize a RakuAST node".to_string()),
-        ValueView::BufStorage(b) => Ok(SerValue::BufStorage(b.bytes.clone(), b.width, b.signed)),
+        ValueView::BufStorage(b) => Ok(SerValue::BufStorage(b.bytes.clone(), b.width, b.kind)),
         ValueView::Int(n) => Ok(SerValue::Int(n)),
         ValueView::BigInt(n) => Ok(SerValue::BigInt((**n).clone())),
         ValueView::Num(n) => Ok(SerValue::Num(n)),
@@ -352,8 +352,8 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
 fn ser_to_value(sv: SerValue) -> Value {
     match sv {
         SerValue::Int(n) => Value::Int(n),
-        SerValue::BufStorage(bytes, width, signed) => Value::from_repr(ValueRepr::BufStorage(
-            crate::gc::Gc::new(crate::value::BufData::new(bytes, width, signed)),
+        SerValue::BufStorage(bytes, width, kind) => Value::from_repr(ValueRepr::BufStorage(
+            crate::gc::Gc::new(crate::value::BufData::new(bytes, width, kind)),
         )),
         SerValue::BigInt(n) => Value::BigInt(Arc::new(n)),
         SerValue::Num(n) => Value::Num(n),

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -46,7 +46,7 @@
 //! the companion class-name filter: this module answers "what is in there", not
 //! "is this a Buf".
 
-use super::{AttrMap, BufData, InstanceAttrs, Value, ValueRepr, ValueView};
+use super::{AttrMap, BufData, ElemKind, InstanceAttrs, Value, ValueRepr, ValueView};
 use crate::gc::Gc;
 use crate::symbol::Symbol;
 
@@ -60,16 +60,56 @@ const ELEMS_ATTR: &str = "bytes";
 // The node, and the encode/decode across it.
 // ---------------------------------------------------------------------------
 
-/// The element type of a `Buf`/`Blob`-shaped class: bytes per element, and
-/// whether an element reads back signed.
+/// The element type of a storage-backed class: bytes per element, and how an
+/// element reads back.
 ///
-/// Recovered from the class name, which is where Raku puts it (`Blob[int8]`).
-/// This is the *only* place that reading stops — from here on the type travels
-/// in the node, which is what lets `Blob[int8].new(-1)[0]` answer `-1`.
-fn elem_type(class_name: &str) -> (u8, bool) {
+/// Recovered from the class name, which is where Raku puts it (`Blob[int8]`,
+/// `CArray[num64]`). This is the *only* place that reading stops — from here on
+/// the type travels in the node, which is what lets `Blob[int8].new(-1)[0]`
+/// answer `-1`.
+///
+/// A spelled-out element type goes through the [`native_elem_type`] table; a
+/// short name that only encodes a width (`buf16`, `utf8`, bare `Buf`) falls back
+/// to the width and signedness its spelling implies.
+pub(crate) fn elem_type(class_name: &str) -> (u8, ElemKind) {
+    if let Some(inner) = class_name
+        .split_once('[')
+        .and_then(|(_, rest)| rest.strip_suffix(']'))
+        && let Some(desc) = native_elem_type(inner)
+    {
+        return desc;
+    }
     // `uint` contains `int`, so the unsigned test has to come first.
-    let signed = !class_name.contains("uint") && class_name.contains("int");
-    (buf_elem_width(class_name) as u8, signed)
+    let kind = if !class_name.contains("uint") && class_name.contains("int") {
+        ElemKind::Int
+    } else {
+        ElemKind::Uint
+    };
+    (buf_elem_width(class_name) as u8, kind)
+}
+
+/// The width and read-back kind of a **native numeric** element type, by the
+/// name Raku spells it with. `None` for anything that is not one — `Str`,
+/// `Pointer`, a nested `CArray[...]`, a CStruct class — which is exactly the
+/// filter deciding whether a `CArray[T]` gets native storage (ADR-0015 P3).
+///
+/// Elements of those other types are *references*: their bytes are an address,
+/// and reading one back means materialising the object it points at, which
+/// native storage alone cannot do. They keep the boxed representation.
+pub(crate) fn native_elem_type(elem: &str) -> Option<(u8, ElemKind)> {
+    Some(match elem {
+        "int8" => (1, ElemKind::Int),
+        "int16" => (2, ElemKind::Int),
+        "int32" => (4, ElemKind::Int),
+        "int64" | "int" | "long" | "longlong" | "ssize_t" => (8, ElemKind::Int),
+        "uint8" | "byte" | "bool" => (1, ElemKind::Uint),
+        "uint16" => (2, ElemKind::Uint),
+        "uint32" => (4, ElemKind::Uint),
+        "uint64" | "uint" | "ulong" | "ulonglong" | "size_t" => (8, ElemKind::Uint),
+        "num32" => (4, ElemKind::Float),
+        "num64" | "num" => (8, ElemKind::Float),
+        _ => return None,
+    })
 }
 
 /// One element as the unsigned integer its bytes spell.
@@ -106,13 +146,28 @@ fn elem_to_u64(v: &Value) -> u64 {
 }
 
 /// Elements to the contiguous little-endian bytes the node stores.
-fn encode_elems(elems: &[Value], width: u8) -> Vec<u8> {
+fn encode_elems(elems: &[Value], width: u8, kind: ElemKind) -> Vec<u8> {
     let w = width as usize;
     let mut bytes = Vec::with_capacity(elems.len() * w);
     for v in elems {
-        bytes.extend_from_slice(&elem_to_u64(v).to_le_bytes()[..w]);
+        bytes.extend_from_slice(&elem_bits(v, width, kind).to_le_bytes()[..w]);
     }
     bytes
+}
+
+/// The bit pattern one element occupies, as the `u64` its `width` low bytes
+/// spell. For a float element that is the IEEE-754 encoding at the element
+/// width; for an integer element it is [`elem_to_u64`].
+fn elem_bits(v: &Value, width: u8, kind: ElemKind) -> u64 {
+    if kind != ElemKind::Float {
+        return elem_to_u64(v);
+    }
+    let f = crate::runtime::utils::to_float_value(v).unwrap_or(0.0);
+    if width == 4 {
+        (f as f32).to_bits() as u64
+    } else {
+        f.to_bits()
+    }
 }
 
 /// The node's bytes back to elements.
@@ -127,24 +182,33 @@ fn decode_elems(data: &BufData) -> Vec<Value> {
         .map(|chunk| {
             let mut raw = [0u8; 8];
             raw[..w].copy_from_slice(chunk);
-            let u = u64::from_le_bytes(raw);
-            if data.signed {
-                // Sign-extend from the element's own width.
-                let shift = 64 - w * 8;
-                Value::int(((u << shift) as i64) >> shift)
-            } else if w == 8 && u > i64::MAX as u64 {
-                Value::bigint(num_bigint::BigInt::from(u))
-            } else {
-                Value::int(u as i64)
-            }
+            decode_elem_bits(u64::from_le_bytes(raw), data.width, data.kind)
         })
         .collect()
 }
 
+/// One element's bit pattern back to the `Value` its type spells.
+fn decode_elem_bits(u: u64, width: u8, kind: ElemKind) -> Value {
+    let w = width as usize;
+    match kind {
+        ElemKind::Float if w == 4 => Value::num(f32::from_bits(u as u32) as f64),
+        ElemKind::Float => Value::num(f64::from_bits(u)),
+        ElemKind::Int => {
+            // Sign-extend from the element's own width.
+            let shift = 64 - w * 8;
+            Value::int(((u << shift) as i64) >> shift)
+        }
+        ElemKind::Uint if w == 8 && u > i64::MAX as u64 => {
+            Value::bigint(num_bigint::BigInt::from(u))
+        }
+        ElemKind::Uint => Value::int(u as i64),
+    }
+}
+
 /// The storage `Value` a buffer instance keeps under [`ELEMS_ATTR`].
-fn storage_value(bytes: Vec<u8>, width: u8, signed: bool) -> Value {
+fn storage_value(bytes: Vec<u8>, width: u8, kind: ElemKind) -> Value {
     Value::from_repr(ValueRepr::BufStorage(Gc::new(BufData::new(
-        bytes, width, signed,
+        bytes, width, kind,
     ))))
 }
 
@@ -227,10 +291,10 @@ pub(crate) fn bytes_to_elems(bytes: &[u8]) -> Vec<Value> {
 /// Store `elems` into a map being built or updated, then handed to
 /// `make_instance` / `commit_attrs`.
 pub(crate) fn set_buf_elems(map: &mut AttrMap, class_name: Symbol, elems: Vec<Value>) {
-    let (width, signed) = elem_type(&class_name.resolve());
+    let (width, kind) = elem_type(&class_name.resolve());
     map.insert(
         ELEMS_ATTR,
-        storage_value(encode_elems(&elems, width), width, signed),
+        storage_value(encode_elems(&elems, width, kind), width, kind),
     );
 }
 
@@ -247,7 +311,7 @@ pub(crate) fn set_buf_elems(map: &mut AttrMap, class_name: Symbol, elems: Vec<Va
 /// A **shared** node is replaced instead: `.Buf`/`.Blob` re-tag one buffer's
 /// storage under another name without copying it, and Raku's copy semantics
 /// mean a write to one must not be seen by the other.
-fn put_bytes(attrs: &InstanceAttrs, bytes: Vec<u8>, width: u8, signed: bool) {
+fn put_bytes(attrs: &InstanceAttrs, bytes: Vec<u8>, width: u8, kind: ElemKind) {
     {
         let map = attrs.as_map();
         if let Some(node) = node_in(&map)
@@ -264,11 +328,11 @@ fn put_bytes(attrs: &InstanceAttrs, bytes: Vec<u8>, width: u8, signed: bool) {
             data.bytes.clear();
             data.bytes.extend_from_slice(&bytes);
             data.width = width;
-            data.signed = signed;
+            data.kind = kind;
             return;
         }
     }
-    attrs.insert(ELEMS_ATTR, storage_value(bytes, width, signed));
+    attrs.insert(ELEMS_ATTR, storage_value(bytes, width, kind));
 }
 
 /// Mutate the elements in place through the shared cell, without decoding the
@@ -281,13 +345,13 @@ pub(crate) fn with_buf_elems_mut<R>(
     // this one needs no class name: decode, hand `f` the elements, re-encode at
     // the width the buffer already has.
     let map = attrs.as_map();
-    let (mut elems, width, signed) = {
+    let (mut elems, width, kind) = {
         let node = node_in(&map)?;
-        (decode_elems(&node), node.width, node.signed)
+        (decode_elems(&node), node.width, node.kind)
     };
     drop(map);
     let out = f(&mut elems);
-    put_bytes(attrs, encode_elems(&elems, width), width, signed);
+    put_bytes(attrs, encode_elems(&elems, width, kind), width, kind);
     Some(out)
 }
 
@@ -326,9 +390,21 @@ pub(crate) fn buf_elems_as_array(map: &AttrMap, kind: super::ArrayKind) -> Optio
 /// stays `P6opaque` — under-reporting is safe, claiming `VMArray` without a body
 /// behind it is not.
 pub(crate) fn buf_repr_body_address(attrs: &InstanceAttrs) -> Option<usize> {
+    with_storage_node(attrs, |node| node.body.address(node))
+}
+
+/// Run `f` over the storage node itself, holding the attribute read guard for
+/// the call. `None` (without calling `f`) when there is no element storage.
+///
+/// The node-level entry point for the containers that share this storage but not
+/// its REPR body — see [`super::value_carray`].
+pub(crate) fn with_storage_node<R>(
+    attrs: &InstanceAttrs,
+    f: impl FnOnce(&BufData) -> R,
+) -> Option<R> {
     let map = attrs.as_map();
     let node = node_in(&map)?;
-    Some(node.body.address(&node))
+    Some(f(&node))
 }
 
 /// This buffer's storage node, with a reference of its own.
@@ -375,8 +451,7 @@ pub(crate) fn buf_len(attrs: &InstanceAttrs) -> Option<usize> {
 /// [`buf_len`] against an attribute map already in hand. A division, not a
 /// decode: the node's byte count divided by its element width.
 pub(crate) fn buf_len_in(map: &AttrMap) -> Option<usize> {
-    let node = node_in(map)?;
-    Some(node.bytes.len() / node.width as usize)
+    Some(node_in(map)?.elems())
 }
 
 /// [`buf_len`] with an absent buffer read as empty.
@@ -472,9 +547,12 @@ pub(crate) fn buf_elem_type_name(class_name: &str) -> String {
     {
         return inner.to_string();
     }
-    let (width, signed) = elem_type(class_name);
+    let (width, kind) = elem_type(class_name);
     let bits = width as usize * 8;
-    if signed {
+    if kind == ElemKind::Float {
+        return format!("num{bits}");
+    }
+    if kind.is_signed() {
         format!("int{bits}")
     } else {
         format!("uint{bits}")
@@ -604,7 +682,7 @@ mod tests {
         let node = node_in(&map).expect("node");
         assert_eq!(node.bytes, vec![0x70, 0x11]); // little-endian
         assert_eq!(node.width, 2);
-        assert!(!node.signed);
+        assert_eq!(node.kind, ElemKind::Uint);
     }
 
     /// The element type used to live only in the class-name string, so every
@@ -643,10 +721,39 @@ mod tests {
     #[test]
     fn element_type_reads_signedness_off_the_name() {
         for name in ["Buf", "Blob", "utf8", "utf16", "Buf[uint8]", "Blob[uint64]"] {
-            assert!(!elem_type(name).1, "{name} should be unsigned");
+            assert_eq!(
+                elem_type(name).1,
+                ElemKind::Uint,
+                "{name} should be unsigned"
+            );
         }
         for name in ["Blob[int8]", "Buf[int16]", "Buf[int64]"] {
-            assert!(elem_type(name).1, "{name} should be signed");
+            assert_eq!(elem_type(name).1, ElemKind::Int, "{name} should be signed");
+        }
+    }
+
+    /// A `CArray[num64]` shares this node, so the element kind has to carry
+    /// "these bytes are a float" — the `signed: bool` it replaced could not.
+    #[test]
+    fn float_elements_round_trip_through_the_node() {
+        for (name, width) in [("CArray[num64]", 8), ("CArray[num32]", 4)] {
+            let b = make_buf(
+                Symbol::intern(name),
+                vec![Value::num(1.5), Value::num(-2.25)],
+            );
+            let attrs = attrs_of(&b);
+            {
+                let map = attrs.as_map();
+                let node = node_in(&map).expect("node");
+                assert_eq!(node.width, width, "{name}");
+                assert_eq!(node.kind, ElemKind::Float, "{name}");
+                assert_eq!(node.bytes.len(), 2 * width as usize, "{name}");
+            }
+            assert_eq!(
+                buf_elems(&attrs),
+                Some(vec![Value::num(1.5), Value::num(-2.25)]),
+                "{name}"
+            );
         }
     }
 

--- a/src/value/value_buf_repr.rs
+++ b/src/value/value_buf_repr.rs
@@ -1,4 +1,6 @@
-//! The synthesised `VMArray` REPR body of a `Buf`/`Blob` (ADR-0015 P2).
+//! The synthesised REPR bodies of the storage-backed containers: `VMArray` for
+//! a `Buf`/`Blob` (ADR-0015 P2) and `CArray` for a native-backed `CArray[T]`
+//! (P3).
 //!
 //! `NativeHelpers::Blob`'s `pointer-to` — the thing `DBDish::mysql` needs to
 //! hand a C library an out-buffer — does not ask mutsu for an address directly.
@@ -53,6 +55,40 @@ struct MVMArrayB {
     any: usize,
 }
 
+/// MoarVM's `CArray` REPR body, laid out exactly as `MoarVM::Guts::REPRs`
+/// declares it.
+///
+/// `managed` is what tells `NativeHelpers::Blob` whether the array owns its
+/// memory and therefore knows its own length: it is 1 for a `CArray[T]` built
+/// in Raku — which is what having a node at all means — and 0 for a
+/// `nativecast`ed handle, whose body comes from the zero block
+/// `nativecall::native_object_where` hands out instead.
+///
+/// `child` stays NULL: it is MoarVM's table of the *object* elements of a
+/// `CArray[Str]`/`CArray[CStruct]`, and those element types keep the boxed
+/// representation (see `value_buf::native_elem_type`), so a node-backed array
+/// never has any.
+#[repr(C)]
+#[derive(Default, Debug)]
+struct CArrayB {
+    storage: usize,
+    child: usize,
+    managed: i32,
+    allocated: i32,
+    elems: i32,
+}
+
+/// The block a node hands out, in the layout its *container* asks for.
+///
+/// A node belongs to exactly one container, so which layout it is asked for
+/// never changes over its lifetime; the enum exists because `Buf` and `CArray`
+/// share the node and MoarVM gives them different bodies.
+#[derive(Debug)]
+enum Block {
+    VMArray(Box<MVMArrayB>),
+    CArray(Box<CArrayB>),
+}
+
 /// A buffer's REPR body block: absent until something asks for the buffer's
 /// `.WHERE`, then allocated once and refreshed in place.
 ///
@@ -61,11 +97,11 @@ struct MVMArrayB {
 /// and so must start with no block of its own, and two buffers holding the same
 /// bytes are equal whether or not either has ever been handed to C.
 #[derive(Default)]
-pub(crate) struct ReprBody(Mutex<Option<Box<MVMArrayB>>>);
+pub(crate) struct ReprBody(Mutex<Option<Block>>);
 
 impl ReprBody {
-    /// The address of `node`'s REPR body, refreshed from the node's current
-    /// storage.
+    /// The address of `node`'s `VMArray` body, refreshed from the node's current
+    /// storage — a `Buf`/`Blob`'s `.WHERE`.
     ///
     /// Stable for the node's lifetime: the block is boxed once and only its
     /// contents change afterwards, so a C structure that captured the address
@@ -74,13 +110,52 @@ impl ReprBody {
     pub(crate) fn address(&self, node: &BufData) -> usize {
         let width = node.width.max(1) as usize;
         let mut slot = self.0.lock().unwrap_or_else(|e| e.into_inner());
-        let block = slot.get_or_insert_with(Box::default);
+        let block = match slot.get_or_insert_with(|| Block::VMArray(Box::default())) {
+            Block::VMArray(b) => b,
+            // Cannot happen: the container decides the layout and never changes
+            // its mind. Re-tagging rather than panicking keeps a future caller
+            // that gets it wrong reading a well-formed block of the layout it
+            // asked for.
+            other => {
+                *other = Block::VMArray(Box::default());
+                match other {
+                    Block::VMArray(b) => b,
+                    _ => unreachable!(),
+                }
+            }
+        };
         block.elems = (node.bytes.len() / width) as u64;
         // Always 0: mutsu's storage never has an unused prefix, so
         // `realstart == any` and the module's `+$!start` branch is dead.
         block.start = 0;
         block.ssize = (node.bytes.capacity() / width) as u64;
         block.any = node.bytes.as_ptr() as usize;
+        (&raw const **block) as usize
+    }
+
+    /// The address of `node`'s `CArray` body — a native-backed `CArray[T]`'s
+    /// `.WHERE`. Same allocate-once-refresh-in-place contract as
+    /// [`Self::address`].
+    pub(crate) fn carray_address(&self, node: &BufData) -> usize {
+        let width = node.width.max(1) as usize;
+        let mut slot = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        let block = match slot.get_or_insert_with(|| Block::CArray(Box::default())) {
+            Block::CArray(b) => b,
+            other => {
+                *other = Block::CArray(Box::default());
+                match other {
+                    Block::CArray(b) => b,
+                    _ => unreachable!(),
+                }
+            }
+        };
+        block.storage = node.bytes.as_ptr() as usize;
+        block.child = 0;
+        // A node exists only for an array mutsu allocated, which is exactly
+        // what `managed` means.
+        block.managed = 1;
+        block.allocated = (node.bytes.capacity() / width) as i32;
+        block.elems = (node.bytes.len() / width) as i32;
         (&raw const **block) as usize
     }
 }
@@ -118,11 +193,30 @@ mod tests {
     fn the_body_has_moarvms_layout() {
         assert_eq!(std::mem::size_of::<MVMArrayB>(), 32);
         assert_eq!(std::mem::align_of::<MVMArrayB>(), 8);
+        // `{void*; void**; i32; i32; i32}` — two pointers then three `int32`s,
+        // the last of which is tail-padded to the pointer alignment.
+        assert_eq!(std::mem::size_of::<CArrayB>(), 32);
+        assert_eq!(std::mem::align_of::<CArrayB>(), 8);
+    }
+
+    /// A native-backed `CArray[T]` is `managed`, knows its own length, and
+    /// points at its own storage — the three words `NativeHelpers::Blob` reads.
+    #[test]
+    fn the_carray_block_describes_the_nodes_storage() {
+        let node = BufData::new(vec![1, 2, 3, 4], 2, crate::value::ElemKind::Uint);
+        let addr = node.body.carray_address(&node);
+        // SAFETY: the address is of a live `Box` owned by `node`.
+        let block = unsafe { &*(addr as *const CArrayB) };
+        assert_eq!(block.storage, node.bytes.as_ptr() as usize);
+        assert_eq!(block.managed, 1);
+        assert_eq!(block.elems, 2, "four bytes at width two");
+        assert_eq!(block.child, 0);
+        assert_eq!(node.body.carray_address(&node), addr, "the block stays put");
     }
 
     #[test]
     fn the_block_describes_the_nodes_storage() {
-        let node = BufData::new(vec![1, 2, 3, 4], 2, false);
+        let node = BufData::new(vec![1, 2, 3, 4], 2, crate::value::ElemKind::Uint);
         let addr = node.body.address(&node);
         // SAFETY: the address is of a live `Box` owned by `node`.
         let block = unsafe { &*(addr as *const MVMArrayB) };
@@ -135,7 +229,7 @@ mod tests {
     /// buffer is asked again — or, later, when its storage is reallocated.
     #[test]
     fn the_block_address_is_stable_and_refreshed() {
-        let mut node = BufData::new(vec![7], 1, false);
+        let mut node = BufData::new(vec![7], 1, crate::value::ElemKind::Uint);
         let first = node.body.address(&node);
         assert_eq!(node.body.address(&node), first);
 
@@ -152,7 +246,7 @@ mod tests {
     /// block — and still compares equal.
     #[test]
     fn a_clone_starts_without_a_block_and_still_compares_equal() {
-        let node = BufData::new(vec![1], 1, false);
+        let node = BufData::new(vec![1], 1, crate::value::ElemKind::Uint);
         node.body.address(&node);
         let copy = node.clone();
         assert!(copy.body.0.lock().unwrap().is_none());

--- a/src/value/value_carray.rs
+++ b/src/value/value_carray.rs
@@ -1,0 +1,127 @@
+//! Native-backed `CArray[T]` element storage (ADR-0015 P3).
+//!
+//! A `CArray[T]` used to be a `Value::Array` of boxed elements, and every native
+//! call **copied** it into a fresh C block on the way in and copied the block
+//! back out on the way out. That copy is correct only when the callee writes
+//! into the buffer *during* the call: `NativeHelpers::Blob`'s
+//! `carray-from-blob(:managed)` builds a `CArray`, takes `BODY_OF(arr).storage`
+//! and `memcpy`s into it later, with no call boundary in between and so no point
+//! at which a copy could be synced back. The array also had no address to hand
+//! out at all — its `.REPR` was `P6opaque` and its `.WHERE` was the identity
+//! hash.
+//!
+//! So a `CArray[T]` whose elements are a **native numeric type** is now the same
+//! thing a `Buf` is: a `Value::Instance` whose storage attribute holds a
+//! [`BufData`](super::BufData) node of contiguous bytes. It shares that node,
+//! its accessor layer ([`super::value_buf`]) and its element encode/decode
+//! verbatim — this module adds only what is specific to `CArray`: the class-name
+//! filter, construction, and the `CArray` REPR body.
+//!
+//! **Element types that are references keep the boxed representation.**
+//! `CArray[Str]`, `CArray[Pointer]`, a nested `CArray[CArray[…]]` and a CStruct
+//! element are addresses of other objects, and reading one back means
+//! materialising the object it points at — which contiguous bytes alone cannot
+//! do (MoarVM keeps a parallel `child` table for exactly this reason). Those stay
+//! `Value::Array`, keep the per-call `char**` marshalling, and go on
+//! under-reporting `.REPR` as `P6opaque`, which is the safe direction: ADR-0015
+//! §2.1's ordering rule is that an honest `.REPR` is a promise that a body exists
+//! behind `.WHERE`.
+
+use super::{InstanceAttrs, Value};
+use crate::symbol::Symbol;
+
+/// Whether `class_name` is a `CArray` parameterised with a native numeric
+/// element type — the arrays that get native storage.
+///
+/// The name arrives in several spellings (`CArray[uint8]`, and
+/// package-qualified as `NativeCall::Types::CArray[uint8]` or
+/// `Foo::CArray[uint8]` when the declaration was read inside a module), so the
+/// base is matched on its last `::` component, the same "one class, several
+/// spellings" problem `cstruct_layout::short_base_name` documents.
+pub(crate) fn is_native_carray_class(class_name: &str) -> bool {
+    carray_elem_type_name(class_name)
+        .is_some_and(|elem| super::value_buf::native_elem_type(elem).is_some())
+}
+
+/// The element type name of a `CArray[T]` class name (`CArray[uint8]` →
+/// `uint8`), or `None` if this is not a parameterised `CArray` at all.
+pub(crate) fn carray_elem_type_name(class_name: &str) -> Option<&str> {
+    let (base, rest) = class_name.split_once('[')?;
+    let base = base.rsplit("::").next().unwrap_or(base);
+    if base != "CArray" {
+        return None;
+    }
+    rest.strip_suffix(']')
+}
+
+/// A fresh native-backed `CArray[T]` holding `elems`.
+///
+/// The elements are encoded at the class's element width by the same
+/// [`super::value_buf`] path a `Buf` uses, so an out-of-range or non-`Int`
+/// element is coerced exactly as it would be there.
+pub(crate) fn make_carray(class_name: Symbol, elems: Vec<Value>) -> Value {
+    super::value_buf::make_buf(class_name, elems)
+}
+
+/// The address of this array's synthesised `CArray` REPR body, which is what its
+/// `.WHERE` answers.
+///
+/// `None` for an instance with no element storage, whose `.REPR` therefore stays
+/// `P6opaque` — under-reporting is safe, claiming `CArray` without a body behind
+/// it is not (ADR-0015 §2.1).
+pub(crate) fn carray_repr_body_address(attrs: &InstanceAttrs) -> Option<usize> {
+    super::value_buf::with_storage_node(attrs, |node| node.body.carray_address(node))
+}
+
+/// The address of this array's **elements** — the pointer a C function receives,
+/// and what `nativecast(Pointer[T], $carray)` reinterprets.
+///
+/// Not the same address as [`carray_repr_body_address`]: that one is the
+/// `CArrayB` block *describing* the storage, and this is the storage itself
+/// (the block's `storage` word). Valid until the array is resized or dies —
+/// ADR-0015 §2 contract 3, the same guarantee Rakudo's `VMArray` offers.
+pub(crate) fn carray_storage_address(attrs: &InstanceAttrs) -> Option<usize> {
+    super::value_buf::with_storage_node(attrs, |node| node.bytes.as_ptr() as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_native_element_types_get_storage() {
+        for name in [
+            "CArray[uint8]",
+            "CArray[int32]",
+            "CArray[num64]",
+            "NativeCall::Types::CArray[uint16]",
+        ] {
+            assert!(is_native_carray_class(name), "{name} should be native");
+        }
+        // Reference-typed elements, and things that are not a `CArray` at all.
+        for name in [
+            "CArray[Str]",
+            "CArray[Pointer]",
+            "CArray[MyStruct]",
+            "CArray",
+            "Buf[uint8]",
+            "Array[Int]",
+        ] {
+            assert!(!is_native_carray_class(name), "{name} should not be native");
+        }
+    }
+
+    #[test]
+    fn elements_round_trip_through_the_node() {
+        let a = make_carray(Symbol::intern("CArray[int32]"), vec![Value::int(-7)]);
+        let attrs = match a.view() {
+            super::super::ValueView::Instance { attributes, .. } => attributes,
+            _ => panic!("expected an instance"),
+        };
+        assert_eq!(
+            super::super::value_buf::buf_elems(&attrs),
+            Some(vec![Value::int(-7)])
+        );
+        assert!(carray_repr_body_address(&attrs).is_some());
+    }
+}

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -825,7 +825,13 @@ impl Interpreter {
             }) = self.env().get(&var_name).map(Value::view)
         {
             let cn = class_name.resolve();
-            if crate::runtime::utils::is_buf_or_blob_class(&cn) {
+            // Storage-backed instances only. An **unmanaged** `CArray` — a
+            // `nativecast`ed handle — shares the class-name shape but keeps its
+            // elements in C memory, so it must fall through to the address path
+            // below; writing through this one would silently drop the assignment.
+            if crate::runtime::utils::is_native_elems_class(&cn)
+                && crate::value::value_buf::has_buf_elems(&attributes)
+            {
                 if crate::runtime::utils::is_blob_like_class(&cn) {
                     return Err(RuntimeError::assignment_ro(Some("Blob")));
                 }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1203,7 +1203,7 @@ impl Interpreter {
                 | ValueView::RangeExcl(..)
                 | ValueView::RangeExclStart(..)
                 | ValueView::RangeExclBoth(..),
-            ) if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
+            ) if crate::runtime::utils::is_native_elems_class(&class_name.resolve()) => {
                 if let Some(bytes) = buf_elems(&attributes) {
                     let len = bytes.len() as i64;
                     let (start, end_incl) = match index.view() {
@@ -1750,7 +1750,7 @@ impl Interpreter {
                 // bytes; a Match (and other positional instances) count their
                 // `list` of positional captures so `$/[*-1]` resolves `*-1` to
                 // the last capture (`m/ (\d) <?{ $/[*-1] < 5 }> /`).
-                let len = if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) {
+                let len = if crate::runtime::utils::is_native_elems_class(&class_name.resolve()) {
                     buf_len_or_zero(&attributes) as i64
                 } else if let Some(ValueView::Array(list, ..)) =
                     attributes.as_map().get("list").map(Value::view)

--- a/t/add-method-qualified-and-invocant.t
+++ b/t/add-method-qualified-and-invocant.t
@@ -1,0 +1,57 @@
+use Test;
+
+# `^add_method` on a **qualified spelling** of an already-registered class must
+# add the method to that class, not to a fresh stub nobody consults.
+# `NativeHelpers::Pointer` builds all of NativeCall's pointer arithmetic this way
+# (`NativeCall::Types::Pointer.^add_method('add', …)`), while the prelude
+# registers `Pointer` under its short name and tags every handle with it — so the
+# methods landed on an unreachable stub, `.add` was "no such method", and
+# `.succ`/`.pred` fell through to the numeric successor (advancing by one *byte*).
+#
+# And an added method's invocant must not be counted as a parameter: `method
+# (Pointer:D: Int $off)` bound `$off` to nothing and died with "Variable 'off' is
+# not declared".
+
+use NativeCall;
+
+plan 11;
+
+# --- The invocant is not a parameter ---
+class Plain {}
+Plain.^add_method('two', method ($a, $b) { "$a-$b" });
+is Plain.new.two(1, 2), '1-2', 'positional parameters of an added method bind';
+
+Plain.^add_method('typed', method (Plain:D: Int $off) { $off * 3 });
+is Plain.new.typed(4), 12, 'an explicit invocant is not counted as a parameter';
+
+Plain.^add_method('named-invocant', method (Plain:D $self: Str $s) { $s.uc });
+is Plain.new.named-invocant('hi'), 'HI', 'a named explicit invocant is dropped too';
+
+Plain.^add_method('none', method () { 'nullary' });
+is Plain.new.none, 'nullary', 'a nullary added method still works';
+
+# --- A qualified spelling reaches the registered class ---
+class Short {}
+Short.^add_method('here', method () { 'short' });
+is Short.new.here, 'short', 'the unqualified spelling works as before';
+
+# `Any` is registered under its short name; add through a qualified spelling and
+# the instance — tagged with the short name — must still find it.
+NativeCall::Types::Pointer.^add_method('mutsu-probe', method () { 'found' });
+my $p = Pointer.new(1024);
+is $p.mutsu-probe, 'found', 'a qualified spelling adds to the registered class';
+
+# --- Pointer arithmetic, the reason the two bugs above mattered ---
+use NativeHelpers::Pointer;
+
+my $a = CArray[uint16].new(10, 20, 30, 40);
+my $base = nativecast(Pointer[uint16], $a);
+is $base.deref, 10,                     'the cast pointer reads element 0';
+is $base.succ.deref, 20,                '.succ advances by one *element*, not one byte';
+is $base.add(2).deref, 30,              '.add(n) advances by n elements';
+is $base.add(3).pred.deref, 30,         '.pred goes back one element';
+
+# `isa-ok $p.succ, Pointer[uint16]` — a typed pointer keeps its parameterisation
+# in an `of` attribute rather than in its class name, so the type check has to
+# read it from there.
+ok $base.succ ~~ Pointer[uint16],       'an arithmetic result matches Pointer[T]';

--- a/t/carray-native-storage.t
+++ b/t/carray-native-storage.t
@@ -1,0 +1,79 @@
+use Test;
+
+# A `CArray[T]` over a native numeric `T` keeps its elements in contiguous C
+# memory (ADR-0015 P3), so it can answer `.REPR`/`.WHERE` honestly, hand a native
+# call a pointer into its own storage, and be reinterpreted by `nativecast`.
+#
+# The pointer C is given is the array's own memory: a callee that writes into it
+# needs no sync point, and one that keeps the pointer keeps seeing live data. The
+# per-call copy this replaced could only reflect writes made *during* the call.
+
+use NativeCall;
+
+plan 25;
+
+# --- The representation is honest, and it has a real address ---
+my $u = CArray[uint16].new(10, 20, 30);
+is $u.REPR, 'CArray',                'a native-backed CArray reports its REPR';
+ok $u.WHERE > 0,                     'and has a real body address';
+isnt $u.WHERE, $u.WHERE + 1,         'sanity: WHERE is a number';
+is $u.WHERE, $u.WHERE,               'the body address is stable';
+
+# Element types that are *references* keep the boxed representation, and go on
+# under-reporting `P6opaque` — an honest name is a promise that a body exists.
+is CArray[Str].new('a').REPR, 'P6opaque',
+    'a reference-element CArray keeps under-reporting its REPR';
+
+# --- Elements round-trip at the declared width, signedness and kind ---
+is CArray[int8].new(-1)[0], -1,      'signed elements read back signed';
+is CArray[uint8].new(-1)[0], 255,    'unsigned elements read back unsigned';
+is CArray[int32].new(-70000)[0], -70000, 'a wide signed element keeps its range';
+is CArray[num64].new(1.5e0, -2.25e0)[1], -2.25e0, 'num64 elements are Nums';
+is CArray[num32].new(0.5e0)[0], 0.5e0, 'num32 elements are Nums';
+is CArray[num64].new(1.5e0).of, num64, '.of is the element type';
+
+# Growing on element assignment zero-fills, as C memory does — the boxed
+# representation left `Any` holes.
+my $g = CArray[uint8].new;
+$g[3] = 7;
+is $g.elems, 4,                      'element assignment grows the array';
+is-deeply $g.list, (0, 0, 0, 7),     'the gap is zeros, not Any holes';
+
+# --- The pointer handed out is the array's own storage ---
+my $p = nativecast(Pointer[uint16], $u);
+is $p.deref, 10,                     'nativecast(Pointer[T], $carray) points at element 0';
+is $p.of, uint16,                    'and remembers the element type it was cast to';
+
+# A native call is handed that same pointer, so a write C makes is a write to
+# the Raku object with nothing copied back.
+sub c_memcpy(CArray[uint8] $dst, CArray[uint8] $src, size_t $n) returns Pointer
+    is native('c') is symbol('memcpy') { * }
+my $dst = CArray[uint8].new(0, 0, 0, 0);
+c_memcpy($dst, CArray[uint8].new(9, 8, 7, 6), 4);
+is-deeply $dst.list, (9, 8, 7, 6),   'a callee writes straight into the array';
+
+# The interesting case the copy could not serve: C keeps the pointer and writes
+# through it *later*, with no call boundary in between. `memcpy` into an address
+# taken before the write stands in for `NativeHelpers::Blob`'s managed
+# `carray-from-blob`.
+sub c_memcpy_p(Pointer $dst, CArray[uint8] $src, size_t $n) returns Pointer
+    is native('c') is symbol('memcpy') { * }
+my $late = CArray[uint8].new(0, 0, 0);
+my $addr = nativecast(Pointer[uint8], $late);
+c_memcpy_p($addr, CArray[uint8].new(1, 2, 3), 3);
+is-deeply $late.list, (1, 2, 3),     'a write through a retained pointer is visible';
+
+# An ordinary Raku-side write does not move the storage, so a pointer taken
+# earlier stays valid (ADR-0015 contract 3).
+$late[0] = 42;
+is nativecast(Pointer[uint8], $late).Int, $addr.Int,
+    'a same-size write keeps the storage in place';
+is $addr.deref, 42,                  'and the old pointer sees the new value';
+
+# --- Positional behaviour is unchanged by the representation ---
+is $u.elems, 3,                      '.elems counts elements';
+is-deeply $u.list, (10, 20, 30),     '.list is a List of the elements';
+is $u.end, 2,                        '.end is the last index';
+is-deeply (gather for @$u { take $_ }), (10, 20, 30), 'it iterates';
+ok $u ~~ CArray[uint16],             'it smartmatches its parametric type';
+nok $u ~~ CArray[uint32],            'and not a different element type';

--- a/t/colon-args-list-infix-precedence.t
+++ b/t/colon-args-list-infix-precedence.t
@@ -1,0 +1,64 @@
+use Test;
+
+# Raku's list-infix operators (the sequence operators `...`/`…`, and the `Z`/`X`
+# meta-ops) are LOOSER than the comma separating a call's arguments, so in
+# `.= new: 10, 20 ... 100` the whole comma level `10, 20` is the sequence's seed
+# and the call receives ONE argument.
+#
+# The `.method: args` colon form used to parse each comma-separated argument on
+# its own, which split the seed: `10, (20 ... 100)` built 10, 20, 21, 22, … .
+# The four `.=` sites (declaration, assignment statement, `has` default,
+# `constant`) each had their own copy of the argument loop and all four were
+# missing the lift; they share one implementation now.
+
+plan 12;
+
+# --- Declaration form ---
+my Array $a .= new: 10, 20 ... 50;
+is-deeply $a.List, (10, 20, 30, 40, 50), 'my Type $x .= new: seed, seed ... limit';
+
+my Array $desc .= new: 50, 40 ... 10;
+is-deeply $desc.List, (50, 40, 30, 20, 10), 'a descending sequence';
+
+my Array $geo .= new: 1, 2, 4 ... 32;
+is-deeply $geo.List, (1, 2, 4, 8, 16, 32), 'a three-element geometric seed';
+
+# --- Assignment-statement form ---
+my $b = Array;
+$b .= new: 10, 20 ... 50;
+is-deeply $b.List, (10, 20, 30, 40, 50), '$x .= new: seed, seed ... limit';
+
+# --- Ordinary colon-arg lists keep their per-argument meaning ---
+my Array $plain .= new: 1, 2, 3;
+is-deeply $plain.List, (1, 2, 3), 'a comma list without a list infix is untouched';
+
+my Array $one .= new: 7;
+is-deeply $one.List, (7,), 'a single argument is untouched';
+
+# --- `has` attribute default ---
+class WithSeq {
+    has Array $.seq .= new: 5, 10 ... 25;
+    has Array $.plain .= new: 1, 2;
+}
+is-deeply WithSeq.new.seq.List, (5, 10, 15, 20, 25), 'has $.x .= new: … in a class body';
+is-deeply WithSeq.new.plain.List, (1, 2), 'and an ordinary list beside it';
+
+# --- The Z/X meta-ops obey the same precedence ---
+my Array $zipped .= new: 1, 2 Z 10, 20;
+is-deeply $zipped.List.map(*.List).List, ((1, 10), (2, 20)),
+    'Z is looser than the argument comma too';
+
+# --- Named arguments and adverbs still parse ---
+class Named {
+    has $.x;
+    has $.y;
+}
+my Named $n .= new: x => 1, y => 2;
+is $n.x ~ $n.y, '12', 'named arguments in a colon-arg list';
+
+my Array $shaped .= new: :shape(3);
+is $shaped.elems, 3, 'a colonpair argument in a colon-arg list';
+
+# --- The postfix method-call form, which already had the lift, still agrees ---
+is-deeply (Array.new: 10, 20 ... 50).List, (10, 20, 30, 40, 50),
+    'Type.new: … agrees with .= new: …';

--- a/todo/deep/nativehelpers-blob-moarvm-guts.md
+++ b/todo/deep/nativehelpers-blob-moarvm-guts.md
@@ -292,13 +292,18 @@ Two of the four went in; the other two are blocked here, on **ADR-0015 P3**
 | --- | --- | --- |
 | `99-my-meta.t` | whitelisted (was already) | |
 | `00-trivial.t` | **whitelisted 2026-07-30** | needed `constant HANDLE = uint32` to be usable as a signature type |
-| `01-basic.t` | blocked at test 9 (8/24 pass) | `carray-from-blob($a):managed` builds a Raku-side `CArray[T]`, whose `.REPR` is `P6opaque`, so `BODY_OF` refuses it |
-| `03-pointer.t` | blocked at test 1 (0/10) | `nativecast(Pointer[uint16], CArray[uint16].new(…))` — a Raku-side `CArray` carries no C address, so `.deref` reads address 0 |
+| `01-basic.t` | **whitelisted 2026-07-30, 24/24** | ADR-0015 P3a (native-backed `CArray[T]`) |
+| `03-pointer.t` | **whitelisted 2026-07-30, 10/10** | P3a, plus three general bugs behind it (colon-arg list-infix precedence, `^add_method` on a qualified name, an added method's invocant counted as a parameter) |
 | `02-cstruct.t` | **not whitelistable at all** | raku itself fails its tests 13 and 15 on this machine, so it can never be an all-green gate entry (it also needs a C compiler at test time) |
 
-One smaller gap sits behind `01-basic.t` test 6 and is independent of P3: an
-*unmanaged* `CArray` (a `nativecast` handle) has no known length, so `.elems`
-must throw; mutsu returns a number. Fixing it alone does not unblock the file.
+Both are landed — see
+[news/2026-07/carray-native-storage.md](../../news/2026-07/carray-native-storage.md).
+The `01-basic.t` test 6 gap recorded here (an *unmanaged* `CArray` has no known
+length, so `.elems` must throw rather than answer 0) went with them.
+
+**What is left of this finding** is the `Buf` half that P2 already answered, plus
+P3b (`array[T]`, needed for `pointer-to(array:D)`) and P3c (reference-element
+`CArray`) — see ADR-0015 §2.1.
 
 Re-measure with:
 


### PR DESCRIPTION
## What

A `CArray[T]` over a **native numeric** element type stops being an `Array` of boxed elements and becomes a storage-backed instance holding contiguous C bytes — the same payload-only `BufData` node a `Buf` has held since [ADR-0015](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0015-native-backed-container-storage-and-repr-bodies.md) P2. This is **P3a**.

The copy it replaces was correct only for a callee that writes into the buffer *during* the call. `NativeHelpers::Blob`'s managed `carray-from-blob` does this instead:

```raku
my \arr = CArray[t].new;
arr[$bb.elems - 1] = 0;                            # force allocation
memcpy(BODY_OF(arr).storage, $bb.realstart, …);    # write, later, through the address
```

There is no call boundary between taking the address and the write — and there was no address to take: `.REPR` was `P6opaque` and `.WHERE` a hash of the identity.

Now `.REPR` answers `CArray`, `.WHERE` a real `CArrayB` block (`storage`/`elems`/`allocated` filled, `managed` 1), `nativecast(Pointer[T], $carray)` reinterprets the element address, and a native call is handed the array's own bytes.

## Why it is a small diff

P2 had already built everything except the class-name filter. The node, the element encode/decode boundary, the write-*through*-an-unshared-node discipline (what keeps an escaped address valid) and the whole `value_buf` accessor layer are reused verbatim. `src/value/value_carray.rs` adds the filter, construction and the body; `is_native_elems_class` widens the dozen element-storage gates (indexing, assignment, `.elems`, `.list`, `.of`, iteration), and **four hand-inlined copies of the Buf class-name ladder collapse into it**.

Two generalisations were needed: the node's element descriptor was a `signed: bool`, which cannot express `CArray[num64]`, so it became an `ElemKind` of `Uint`/`Int`/`Float` (precomp cache version bumped to 10); and `ReprBody` now hands out either an `MVMArrayB` or a `CArrayB`, decided by the container asking.

## Reference-typed elements deliberately keep the boxed form

`CArray[Str]`, `CArray[Pointer]`, a nested `CArray[CArray[…]]` and a CStruct element are **addresses of other objects**: reading one back means materialising the pointee, which contiguous bytes alone cannot do (MoarVM keeps a parallel `child` table for exactly this). They keep the `Array` representation and the per-call `char**` build, and go on under-reporting `P6opaque` — the safe direction under ADR-0015 §2.1's ordering rule. So a node-backed array never has children and `CArrayB.child` is always NULL. Recorded as P3c.

`array[T]` is **not** in this PR: it is a `Value::Array`, not an instance, so it needs the `ArrayData::items` accessor chokepoint P2 built for `Buf`'s `"bytes"` touches. Recorded as P3b, together with the `array-shapes.t` T36-38 payoff.

## Three general bugs found behind the same two test files

None is about `CArray`; all three blocked `NativeHelpers::Pointer`'s whole test suite.

1. **A list infix is looser than the argument comma — except in a `.= new:` list.** `my CArray[uint16] $a .= new: 10, 20 ... 100` built `10, 20, 21, 22, …`: the colon-argument list was parsed one argument at a time, so the sequence's seed was only its last element. The ordinary postfix `.method: …` path had had this lift for a while; the **four `.=` sites** (declaration, assignment statement, `has` default, `constant`) each carried their own byte-identical copy of the argument loop, which is how all four came to be missing it. They share one implementation now, which lifts `Z`/`X` too.
2. **`^add_method` on a qualified class name populated a stub nobody consults.** `NativeCall::Types::Pointer.^add_method('add', …)` — how `NativeHelpers::Pointer` builds all of NativeCall's pointer arithmetic — did not reach the prelude's short-named `Pointer` that every handle is tagged with, so `.add` was "no such method" and `.succ`/`.pred` fell through to the *numeric* successor, advancing a `Pointer[uint16]` by one byte instead of one element.
3. **An added method's invocant was counted as a parameter.** `method (Pointer:D: Int $off)` filtered the invocant out of `param_defs` but not out of the positional name list dispatch binds against, so `$off` was unbound (`Variable 'off' is not declared`).

Plus one parity gap: `isa-ok $p.succ, Pointer[uint16]` failed because a typed pointer keeps its parameterisation in an `of` attribute rather than in its class name (deliberately, so every `Pointer` method keeps working), and the type check never read it from there.

## Results

| file | before | after |
| --- | --- | --- |
| `NativeHelpers::Blob` `01-basic.t` | 8/24 | **24/24, whitelisted** |
| `NativeHelpers::Blob` `03-pointer.t` | 0/10 | **10/10, whitelisted** |
| battery gate | 137/144 | **139/144, PASSED** |

That closes everything closeable in #5557 — `02-cstruct.t` is not whitelistable at all, because raku itself fails its tests 13 and 15 on this machine. The unmanaged-`CArray` gap noted in that issue went with it: a `nativecast`ed handle has no length, so `.elems` throws Rakudo's *"Don't know how many elements a C array returned from a library"* rather than answering 0.

Parity gained beyond the two files: growing a `CArray` by element assignment zero-fills (it left `Any` holes), `.list` is a `List` rather than an `Array`, and `CArray[num32]`/`CArray[num64]` elements read back as `Num`s.

## Testing

- New pins: `t/carray-native-storage.t` (25 tests, incl. a C write through a *retained* pointer with no intervening call), `t/colon-args-list-infix-precedence.t` (12, green under raku too), `t/add-method-qualified-and-invocant.t` (11, green under raku too).
- `make test` PASS (2611 files, 24839 tests) and `make roast` PASS (1435 files, 218774 tests) locally — the latter run because this touches type resolution and the parser.
- Full battery gate run locally: GATE PASSED, 139/144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)