### PR TITLE
perf(modules): stop re-reading and re-parsing module sources on the warm load path

### DIFF
--- a/news/2026-07/warm-module-load-no-reparse.md
+++ b/news/2026-07/warm-module-load-no-reparse.md
@@ -1,0 +1,42 @@
+# Warm module load no longer re-reads or re-parses module sources
+
+`news/2026-07/module-export-scan-cache.md` left a residual: a fully warm
+(precompiled) `use Template::HAML` still ran 0.29s against raku's 0.21s, with
+strace showing 105 `.rakumod` opens for 30 modules. The parser's export scan
+was already down to one open per file; the rest was the runtime load path
+doing per-module work that a warm load does not need:
+
+- `load_module` read the module source and ran a full `parse_program_partial`
+  over it — even on a precomp hit — just to extract exported operator names
+  (`infix:<..>` etc.) for EVAL visibility. The names are now extracted by
+  walking the statements `parse_module_source` already returns, which are
+  identical for a fresh parse and a cache hit, so the extra read and the whole
+  parse are gone.
+- Precomp validation re-read the source to compute the content hash, a few
+  lines after `parse_module_source` had read the same bytes into memory.
+  `load_cached_unit` now accepts the already-read source and hashes it
+  in-memory; the hash function is unchanged, so existing cache entries stay
+  valid. (The `require` path still passes `None` and reads from disk — it has
+  no source in scope on a hit.)
+- `interpreter_version()` stat'ed the interpreter binary (`current_exe` +
+  metadata) on every validation to build the version stamp; it is now memoized
+  in a `OnceLock` since the exe mtime cannot change mid-process.
+
+## Results (release build, 2026-07-30, Template::HAML dist)
+
+| | before | after | raku |
+| --- | --- | --- | --- |
+| `use Template::HAML` (warm precomp) | 0.29s | **0.21s** | 0.21s |
+| `.rakumod` file opens per load | 105 | **53** | — |
+
+Warm module load now matches raku. The remaining ~53 opens are one parse-time
+export-scan read plus one runtime read per module, both fundamental to the
+current design (the runtime read feeds the `no precompilation` directive scan
+and the content-hash validation).
+
+Pinned by `precomp::tests::in_memory_source_validates_like_disk_read`; the
+EVAL-sees-imported-operators behavior stays pinned by
+`t/import-operator-method.t`, and cold/warm operator visibility was verified
+by hand against raku. Investigating this also surfaced a pre-existing
+EVAL-closure import bug, recorded in
+`todo/tickets/eval-closure-loses-imported-subs-after-scope-pop.md`.

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -91,19 +91,26 @@ fn interpreter_version() -> String {
     // 10: `BufStorage`'s element descriptor became `ElemKind` (ADR-0015 P3),
     // so its third field serializes as an enum rather than a bool.
     const CACHE_FORMAT_VERSION: u32 = 10;
-    let exe_stamp = std::env::current_exe()
-        .and_then(fs::metadata)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    format!(
-        "{}+cf{}+exe{}",
-        env!("CARGO_PKG_VERSION"),
-        CACHE_FORMAT_VERSION,
-        exe_stamp
-    )
+    // The exe mtime cannot change while this process runs, so stat it once —
+    // every cache validation used to re-stat the (large) binary per module.
+    static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    VERSION
+        .get_or_init(|| {
+            let exe_stamp = std::env::current_exe()
+                .and_then(fs::metadata)
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            format!(
+                "{}+cf{}+exe{}",
+                env!("CARGO_PKG_VERSION"),
+                CACHE_FORMAT_VERSION,
+                exe_stamp
+            )
+        })
+        .clone()
 }
 
 /// Whether the cache is on unless a caller turns it off.
@@ -216,8 +223,12 @@ fn decode_config() -> impl bincode::config::Config {
 
 /// Try to load a cached compilation unit for the given source file.
 ///
+/// `source` is the file's content when the caller has already read it —
+/// content-hash validation then hashes the in-memory bytes instead of
+/// re-reading the file. Pass `None` to read from disk.
+///
 /// Returns `Some(unit)` if a valid cache entry exists, `None` otherwise.
-pub(crate) fn load_cached_unit(source_path: &Path) -> Option<CachedUnit> {
+pub(crate) fn load_cached_unit(source_path: &Path, source: Option<&str>) -> Option<CachedUnit> {
     let canonical = source_path.canonicalize().ok()?;
     let dir = cache_dir()?;
     let hash = path_hash(&canonical);
@@ -279,7 +290,10 @@ pub(crate) fn load_cached_unit(source_path: &Path) -> Option<CachedUnit> {
         let _ = fs::remove_file(&cache_file);
         return None;
     };
-    let current_hash = source_content_hash(source_path)?;
+    let current_hash = match source {
+        Some(code) => content_hash(code.as_bytes()),
+        None => source_content_hash(source_path)?,
+    };
     if expected_hash != current_hash {
         let _ = fs::remove_file(&cache_file);
         return None;
@@ -427,9 +441,15 @@ fn source_mtime_nanos(path: &Path) -> Option<u128> {
 
 fn source_content_hash(path: &Path) -> Option<u64> {
     let bytes = fs::read(path).ok()?;
+    Some(content_hash(&bytes))
+}
+
+/// Hash source bytes the same way `source_content_hash` does, so an in-memory
+/// hash validates against an entry written from a disk read (and vice versa).
+fn content_hash(bytes: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
     bytes.hash(&mut hasher);
-    Some(hasher.finish())
+    hasher.finish()
 }
 
 #[cfg(test)]
@@ -457,7 +477,7 @@ mod tests {
 
         // Save and load
         save_cached_unit(&source, &stmts, &ParseEffects::default());
-        let loaded = load_cached_unit(&source);
+        let loaded = load_cached_unit(&source, None);
         assert!(loaded.is_some(), "cache should return Some");
         let loaded = loaded.unwrap().stmts;
         assert_eq!(loaded.len(), 2);
@@ -474,6 +494,31 @@ mod tests {
     }
 
     #[test]
+    fn in_memory_source_validates_like_disk_read() {
+        // Callers that already read the source pass it in; the content-hash
+        // check must accept the same bytes and reject different ones without
+        // consulting the file.
+        let stmts = vec![Stmt::Say(vec![Expr::Literal(Value::int(1))])];
+
+        let dir = tempdir("memhash");
+        let source = dir.join("test-mem.rakumod");
+        let code = "say 1;\n";
+        fs::write(&source, code).unwrap();
+
+        save_cached_unit(&source, &stmts, &ParseEffects::default());
+        assert!(
+            load_cached_unit(&source, Some(code)).is_some(),
+            "in-memory bytes matching the file must validate"
+        );
+        assert!(
+            load_cached_unit(&source, Some("say 2;\n")).is_none(),
+            "in-memory bytes differing from cache-time content must miss"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn cache_invalidated_on_mtime_change() {
         let stmts = vec![Stmt::Say(vec![Expr::Literal(Value::int(1))])];
 
@@ -485,7 +530,7 @@ mod tests {
         }
 
         save_cached_unit(&source, &stmts, &ParseEffects::default());
-        assert!(load_cached_unit(&source).is_some());
+        assert!(load_cached_unit(&source, None).is_some());
 
         // Touch the file (update mtime)
         std::thread::sleep(std::time::Duration::from_secs(2));
@@ -495,7 +540,7 @@ mod tests {
         }
 
         // Cache should now be invalid
-        assert!(load_cached_unit(&source).is_none());
+        assert!(load_cached_unit(&source, None).is_none());
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -554,7 +599,7 @@ mod tests {
         fs::write(&cache_file, &data).unwrap();
 
         // Stale version → cache must be rejected (and removed).
-        assert!(load_cached_unit(&source).is_none());
+        assert!(load_cached_unit(&source, None).is_none());
         assert!(!cache_file.exists(), "stale cache file should be removed");
 
         let _ = fs::remove_dir_all(&dir);
@@ -578,7 +623,7 @@ mod tests {
         }
 
         save_cached_unit(&source, &stmts, &effects);
-        let loaded = load_cached_unit(&source).expect("cache should return Some");
+        let loaded = load_cached_unit(&source, None).expect("cache should return Some");
         assert_eq!(loaded.effects, effects);
 
         let _ = fs::remove_dir_all(&dir);
@@ -599,7 +644,7 @@ mod tests {
         }
 
         save_cached_unit(&source, &stmts, &ParseEffects::default());
-        assert!(load_cached_unit(&source).is_some());
+        assert!(load_cached_unit(&source, None).is_some());
 
         // Rewrite the entry claiming a different source path, as a path-hash
         // collision would produce.
@@ -623,7 +668,7 @@ mod tests {
         fs::write(&cache_file, &data).unwrap();
 
         assert!(
-            load_cached_unit(&source).is_none(),
+            load_cached_unit(&source, None).is_none(),
             "an entry naming another source must not be served"
         );
 
@@ -652,7 +697,7 @@ mod tests {
 
         save_cached_unit(&source, &stmts, &ParseEffects::default());
         assert!(
-            load_cached_unit(&source).is_some(),
+            load_cached_unit(&source, None).is_some(),
             "control: entry is valid"
         );
 
@@ -680,7 +725,7 @@ mod tests {
         fs::write(&cache_file, &data).unwrap();
 
         assert!(
-            load_cached_unit(&source).is_none(),
+            load_cached_unit(&source, None).is_none(),
             "a corrupt entry must read as a cache miss"
         );
 

--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -115,7 +115,7 @@ impl Interpreter {
         // Try loading from precompilation cache. A hit skips the parse, so replay
         // the parser state it would have produced (see `precomp::ParseEffects`).
         let stmts = if self.precomp_enabled {
-            if let Some(unit) = crate::precomp::load_cached_unit(&path) {
+            if let Some(unit) = crate::precomp::load_cached_unit(&path, None) {
                 crate::parser::set_current_language_version(&unit.effects.language_version);
                 for warning in &unit.effects.warnings {
                     self.write_warn_to_stderr(warning);

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -373,16 +373,15 @@ impl Interpreter {
         None
     }
 
-    /// Parse a module source file, using the precompilation cache when available.
-    /// Returns (stmts, was_precompiled).
     /// Extract operator sub names (infix:<..>, prefix:<..>, etc.) that a
     /// module exports with `is export` (DEFAULT or MANDATORY tag). Used by
     /// `load_module` to populate `imported_operator_names` so EVAL can see
     /// operators from imported modules without seeing non-exported subs.
-    fn extract_module_exported_operator_names(source: &str) -> Vec<String> {
-        let (stmts, _) = crate::parser::parse_program_partial(source);
+    /// Walks the already-parsed statements (fresh or from the precomp cache)
+    /// rather than re-reading and re-parsing the source file.
+    fn extract_module_exported_operator_names(stmts: &[crate::ast::Stmt]) -> Vec<String> {
         let mut out = Vec::new();
-        for stmt in &stmts {
+        for stmt in stmts {
             if let crate::ast::Stmt::SubDecl {
                 name,
                 is_export,
@@ -408,6 +407,8 @@ impl Interpreter {
         out
     }
 
+    /// Parse a module source file, using the precompilation cache when available.
+    /// Returns (stmts, was_precompiled).
     pub(super) fn parse_module_source(
         &mut self,
         module: &str,
@@ -428,7 +429,9 @@ impl Interpreter {
         // replayed from the entry — otherwise the module's mainline runs under
         // the *importer's* language revision and the module's warnings never
         // appear. See `precomp::ParseEffects`.
-        if precomp_eligible && let Some(unit) = crate::precomp::load_cached_unit(source_path) {
+        if precomp_eligible
+            && let Some(unit) = crate::precomp::load_cached_unit(source_path, Some(&code))
+        {
             crate::parser::set_current_language_version(&unit.effects.language_version);
             for warning in &unit.effects.warnings {
                 self.write_warn_to_stderr(warning);
@@ -580,12 +583,6 @@ impl Interpreter {
         let (source_path, inst_dist_json) = self
             .resolve_module_path(module)
             .ok_or_else(|| RuntimeError::unsatisfied_dependency(module))?;
-        // Track operator subs exported by this module so EVAL can see them.
-        if let Ok(source) = fs::read_to_string(&source_path) {
-            for name in Self::extract_module_exported_operator_names(&source) {
-                self.imported_operator_names.insert(name);
-            }
-        }
         // Detect distribution context for $?DISTRIBUTION.
         // For installed modules (inst# paths), use the dist JSON directly.
         // Otherwise fall back to META6.json detection.
@@ -640,6 +637,10 @@ impl Interpreter {
         // into the caller's language version.
         let saved_language_version = crate::parser::current_language_version();
         let (stmts, _precompiled) = self.parse_module_source(module, &source_path)?;
+        // Track operator subs exported by this module so EVAL can see them.
+        for name in Self::extract_module_exported_operator_names(&stmts) {
+            self.imported_operator_names.insert(name);
+        }
         // Validate any `package EXPORTHOW { ... }` directives before running the
         // module: a member named `<directive>::<declarator>` must use a known
         // directive (DECLARE/SUPERSEDE/COMPOSE), else X::EXPORTHOW::InvalidDirective.

--- a/todo/tickets/eval-closure-loses-imported-subs-after-scope-pop.md
+++ b/todo/tickets/eval-closure-loses-imported-subs-after-scope-pop.md
@@ -1,0 +1,46 @@
+# Closure returned from EVAL loses subs imported by a `use` inside the EVAL
+
+`Template::HAML`'s `t/0040-haml-render.rakutest` aborts with
+`Unknown function: haml-indent` ("planned 2, ran 0", exit 255). This is a
+pre-existing deterministic bug: it reproduces identically on v0.20.0
+(1b1fa6112), on #5565, and on #5566, with and without precomp
+(`MUTSU_PRECOMP=0`), so it is unrelated to the export-scan cache work. raku
+passes the file. (The 0.33s timing recorded for this file in
+`news/2026-07/module-export-scan-cache.md` was wall-clock of the aborting run —
+the exit status was not checked at the time.)
+
+## Minimal repro (verified 2026-07-30, raku prints 14)
+
+```raku
+# OpMod.rakumod:  unit module OpMod; sub exported-fn(Int $n --> Int) is export { $n * 2 }
+use MONKEY-SEE-NO-EVAL;
+my $f = EVAL 'use OpMod; sub (Int $n) { exported-fn($n) }';
+say $f(7);   # mutsu: "Unknown function: exported-fn" / raku: 14
+```
+
+The narrower shapes all work: `EVAL 'use OpMod; exported-fn(7)'` (call inside
+the EVAL) is fine, and a closure over a sub imported by the *outer* scope is
+fine. The failure needs all three: the `use` is inside the EVAL, the EVAL
+returns a closure, and the closure is called after the EVAL scope is gone.
+
+## Root-cause direction
+
+Same family as the import-scope pop bugs: when the EVAL's import scope is
+popped, the bare imported name (`exported-fn`) is dropped from the function
+registry — correctly, for the *importer's* scope — but the closure created
+inside that scope should still resolve it lexically. #5566 fixed the class
+variant (qualified class names retained across the pop) and functions already
+retain `::`-qualified keys, but a bare imported sub name referenced only from
+an escaping closure has nothing to keep it alive. The likely fix direction is
+the escape-gate approach used for block-scoped `my sub` leaking (capture or
+pin the resolution for closures that escape the scope), not blanket retention.
+
+## How this bites Template::HAML
+
+`DirectCodegen.rakumod` line 90 does `EVAL $body` where the generated `$body`
+starts with `use Template::HAML::DirectEmit;` (line 846) and defines the
+render sub, which calls DirectEmit's exported `haml-indent`. The render sub is
+called later, after the EVAL has returned, so the first render dies. Blocks
+`t/0040-haml-render.rakutest` (and any HAML render via the direct-codegen
+path); dist at `tmp/haml-perf/dist` (from
+`~/.cache/mutsu-dist-sweep/T_EM_TEMPLATE_HAML_*.tar.gz`).


### PR DESCRIPTION
## Summary

Follow-up to #5565: the residual 1.3x on a fully warm (precompiled) `use Template::HAML` (0.29s vs raku 0.21s) was the runtime load path, not the parser scan. Three per-module wastes removed:

- **`load_module` no longer re-reads + fully re-parses the module source** to extract exported operator names for EVAL visibility. The names are extracted by walking the statements `parse_module_source` already returns — identical for a fresh parse and a precomp hit — so the warm path pays no parse at all.
- **Precomp content-hash validation no longer re-reads the source**: `load_cached_unit` accepts the already-read source and hashes the in-memory bytes. The hash function is unchanged, so existing cache entries stay valid. The `require` path passes `None` and keeps its disk-read behavior.
- **`interpreter_version()` is memoized** in a `OnceLock` — it stat'ed the interpreter binary per module validation.

## Results (release, Template::HAML dist, 30 modules)

| | before | after | raku |
| --- | --- | --- | --- |
| warm `use Template::HAML` | 0.29s | **0.21s** | 0.21s |
| `.rakumod` opens per load | 105 | **53** | — |

## Testing

- New unit test `precomp::tests::in_memory_source_validates_like_disk_read` pins the in-memory hash path (accept matching bytes, reject mismatched).
- `make test` PASS (2618 files / 24916 tests + 623 unit tests).
- All 28 whitelisted S10/S11 roast files PASS.
- EVAL operator visibility verified cold+warm against raku (`t/import-operator-method.t` stays green).

Also files `todo/tickets/eval-closure-loses-imported-subs-after-scope-pop.md`: investigating HAML's `t/0040-haml-render.rakutest` abort turned out to be a pre-existing bug (reproduces on v0.20.0, precomp-independent) where a closure returned from EVAL loses subs imported by a `use` inside the EVAL — minimal repro in the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)