### PR TITLE
perf(runtime): cache BUILD/TWEAK construction phase plans per class

### DIFF
--- a/src/runtime/ctor_phase_plan.rs
+++ b/src/runtime/ctor_phase_plan.rs
@@ -1,0 +1,296 @@
+use super::*;
+use crate::value::AttrMap;
+
+/// How a `fail` raised inside a construction-phase step is surfaced to the
+/// caller of the phase runner. The three modes preserve the (historically
+/// asymmetric) behaviors of the pre-plan phase loops verbatim:
+/// `run_tweak_phase` turned a `fail` from any step into a `Failure` return
+/// value via `fail_error_to_failure_value`; `run_build_phase` propagated a
+/// role-step `fail` as an error but wrapped a class-step `fail` in an inline
+/// X::AdHoc `Failure` (without the pending-failure registration); the bless
+/// BUILD phase propagated everything.
+pub(super) enum PhaseFail {
+    Propagate,
+    TweakFailure,
+    BuildFailure,
+}
+
+impl Interpreter {
+    /// Build the pre-derived step list for one construction phase (`BUILD` or
+    /// `TWEAK`) of `cn`: the base-first MRO walk, the per-level registry
+    /// probes, the role-submethod ordering, and the 6.c/6.e skip decisions —
+    /// everything the phase loops used to re-derive on every construction and
+    /// that is a pure function of the class shape. Cached on `NativeCtorPlan`
+    /// (same invalidation sites as the rest of the plan).
+    ///
+    /// The class/role language revisions are read at plan-build time (first
+    /// construction). The parser-version fallback for a class with no
+    /// `language-revision` metadata is therefore frozen at that point; that
+    /// matches the class's declaration context in every non-contrived case
+    /// (the revision is a property of the declaration, not the construction).
+    pub(super) fn build_construction_phase_steps(
+        &mut self,
+        cn: &str,
+        method_name: &str,
+    ) -> Vec<ConstructionPhaseStep> {
+        let mro = self.class_mro(cn);
+        let class_lang_rev = self
+            .type_metadata
+            .get(cn)
+            .and_then(|m| m.get("language-revision"))
+            .map(|v| v.to_string_value())
+            .unwrap_or_else(|| {
+                let version = crate::parser::current_language_version();
+                if let Some(rest) = version.strip_prefix("6.") {
+                    rest.chars().next().unwrap_or('c').to_string()
+                } else {
+                    "c".to_string()
+                }
+            });
+        let class_is_6e = class_lang_rev != "c";
+        let mut steps = Vec::new();
+        for mro_class in mro.iter().rev().map(|s| s.as_str()) {
+            if mro_class == "Any" || mro_class == "Mu" {
+                continue;
+            }
+            // Skip role entries in MRO
+            if self.registry().roles.contains_key(mro_class)
+                && !self.registry().classes.contains_key(mro_class)
+            {
+                continue;
+            }
+            // Does the class itself declare the submethod (not role-composed)?
+            let class_has_own = self
+                .registry()
+                .classes
+                .get(mro_class)
+                .and_then(|def| def.methods.get(method_name))
+                .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
+                .unwrap_or(false);
+            // Role-composed submethods, with the same 6.c/6.e rules as the
+            // former per-construction loops:
+            // - Always call role submethods (both 6.c and 6.e classes)
+            // - In 6.c: if the class has its own submethod, skip same-revision
+            //   (6.c) role submethods, but still call 6.e+ ones
+            // - In 6.e+: always call all role submethods
+            let role_order = self.ordered_role_submethods_for_class(mro_class, method_name);
+            for (role_name, method_def) in role_order {
+                let role_base = role_name
+                    .split_once('[')
+                    .map(|(b, _)| b)
+                    .unwrap_or(&role_name);
+                let role_lang_rev = self
+                    .type_metadata
+                    .get(role_base)
+                    .and_then(|m| m.get("language-revision"))
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_else(|| "c".to_string());
+                if !class_is_6e && class_has_own && role_lang_rev == "c" {
+                    continue;
+                }
+                steps.push(ConstructionPhaseStep::Role {
+                    role_name,
+                    def: method_def,
+                });
+            }
+            // The class's own candidate at this level (own submethod, or a
+            // role-composed regular method) — dispatched with `mro_class` as
+            // the receiver, exactly as before.
+            let has_non_submethod = self
+                .registry()
+                .classes
+                .get(mro_class)
+                .and_then(|def| def.methods.get(method_name))
+                .map(|overloads| {
+                    overloads
+                        .iter()
+                        .any(|md| md.role_origin.is_none() || !md.is_my)
+                })
+                .unwrap_or(false);
+            if has_non_submethod {
+                let pinned = self.try_pin_phase_candidate(mro_class, method_name);
+                steps.push(ConstructionPhaseStep::Class {
+                    mro_class: mro_class.to_string(),
+                    pinned,
+                });
+            }
+        }
+        steps
+    }
+
+    /// Pin the phase candidate for a `Class` step when full method resolution
+    /// is provably equivalent to "run this one def": exactly one visible
+    /// non-multi candidate declared on the class itself, with none of the
+    /// features the resolver's speculative match or the dispatch wrapper
+    /// machinery would act on. Mirrors the resolver's single-visible-candidate
+    /// fast return (`resolve_method_with_owner_impl`) plus the
+    /// `run_instance_method_celled` remaining-candidates skip
+    /// (`count_visible_method_candidates <= 1`). Anything more exotic returns
+    /// `None` and keeps the full resolution path.
+    fn try_pin_phase_candidate(&mut self, mro_class: &str, method_name: &str) -> Option<MethodDef> {
+        let overloads = self
+            .registry()
+            .get_method_overloads(mro_class, method_name)?;
+        let mut visible = overloads.iter().filter(|d| !d.is_private);
+        let only = visible.next()?;
+        if visible.next().is_some() {
+            return None;
+        }
+        if only.is_multi
+            || !(only.is_my || only.is_submethod)
+            || only.delegation.is_some()
+            || only.deprecated_message.is_some()
+        {
+            return None;
+        }
+        if !only.param_defs.iter().all(|pd| {
+            pd.where_constraint.is_none()
+                && pd.type_constraint.is_none()
+                && pd.sub_signature.is_none()
+        }) {
+            return None;
+        }
+        // A second visible candidate anywhere in the MRO (e.g. an inherited
+        // non-submethod of the same name) needs the dispatch frame for
+        // `nextsame` — keep the full path.
+        if self.count_visible_method_candidates(mro_class, method_name) > 1 {
+            return None;
+        }
+        let mut def = only.clone();
+        // Compile once at plan build instead of per construction.
+        if def.compiled_code.is_none() {
+            let dist = self.resolve_package_distribution(mro_class);
+            Self::compile_method_def_in_place_with_dist(&mut def, mro_class, dist);
+            def.compiled_code.as_ref()?;
+        }
+        Some(def)
+    }
+
+    /// Run one construction phase (`BUILD`/`TWEAK`) over the plan's pre-derived
+    /// steps against `inv`'s shared attribute cell (base-first MRO order —
+    /// every step sees and mutates the same live object). `args` are the
+    /// constructor's named arguments, passed through to each submethod.
+    ///
+    /// The probe map handed to the dispatch layer is the plan's shared
+    /// attribute-name skeleton (names -> Nil) whenever the live cell carries no
+    /// sigilless-alias metadata: every consumer on that path reads only the key
+    /// set (`attr_twigil_local`, the attr-defaults key loop, the alias scans),
+    /// so the per-construction whole-cell `to_map()` value clone is skipped.
+    /// With alias metadata present, the live map is re-materialized before
+    /// every step, exactly as the former `refresh_probe` loops did.
+    pub(super) fn run_construction_phase_steps(
+        &mut self,
+        class_name: Symbol,
+        inv: &Value,
+        args: &[Value],
+        method_name: &str,
+        role_fail: PhaseFail,
+        class_fail: PhaseFail,
+    ) -> Result<Result<(), Value>, RuntimeError> {
+        let Some(cell) = Self::self_instance_attrs(inv) else {
+            return Ok(Ok(()));
+        };
+        let plan = self.native_ctor_plan(class_name);
+        let steps = if method_name == "BUILD" {
+            plan.build_steps.clone()
+        } else {
+            plan.tweak_steps.clone()
+        };
+        if steps.is_empty() {
+            return Ok(Ok(()));
+        }
+        let live_has_alias = cell
+            .as_map()
+            .keys()
+            .any(|k| k.starts_with("__mutsu_attr_alias::"));
+        let mut probe_owned: Option<AttrMap> = None;
+        let cn = class_name.resolve();
+        for step in steps.iter() {
+            if live_has_alias {
+                probe_owned = Some(cell.to_map());
+            }
+            let probe: &AttrMap = probe_owned.as_ref().unwrap_or(&plan.probe_skeleton);
+            let (outcome, fail_mode) = match step {
+                ConstructionPhaseStep::Role { role_name, def } => (
+                    self.run_resolved_method_celled(
+                        &cn,
+                        role_name,
+                        method_name,
+                        def.clone(),
+                        probe,
+                        args.to_vec(),
+                        Some(inv.clone()),
+                    ),
+                    &role_fail,
+                ),
+                ConstructionPhaseStep::Class { mro_class, pinned } => {
+                    // The pinned direct run must stay equivalent to full
+                    // dispatch: a wrap chain or a NativeCall method descriptor
+                    // registered after plan build re-routes through the full
+                    // path (both are runtime-global prefilters there too).
+                    let r = if let Some(def) = pinned
+                        && self.native_call_specs.is_empty()
+                        && !self.has_any_wrap_chains()
+                    {
+                        self.push_method_samewith_context(
+                            mro_class,
+                            method_name,
+                            args,
+                            Some(inv.clone()),
+                        );
+                        let r = self.run_resolved_method_celled(
+                            mro_class,
+                            mro_class,
+                            method_name,
+                            def.clone(),
+                            probe,
+                            args.to_vec(),
+                            Some(inv.clone()),
+                        );
+                        self.pop_method_samewith_context();
+                        r
+                    } else {
+                        self.run_instance_method_celled(
+                            mro_class,
+                            probe,
+                            method_name,
+                            args.to_vec(),
+                            Some(inv.clone()),
+                        )
+                    };
+                    (r, &class_fail)
+                }
+            };
+            match outcome {
+                Ok((_v, updated)) => {
+                    if let Some(m) = updated {
+                        cell.commit_attrs(m);
+                    }
+                }
+                Err(err) if err.is_fail() && !matches!(fail_mode, PhaseFail::Propagate) => {
+                    let failure = match fail_mode {
+                        PhaseFail::TweakFailure => self.fail_error_to_failure_value(&err),
+                        PhaseFail::BuildFailure => {
+                            // Historical `.new` BUILD behavior: inline X::AdHoc
+                            // wrap without the pending-failure registration.
+                            let ex = if let Some(exception) = err.exception {
+                                *exception
+                            } else {
+                                let mut ex_attrs = HashMap::new();
+                                ex_attrs.insert("message".to_string(), Value::str(err.message));
+                                Value::make_instance(Symbol::intern("X::AdHoc"), ex_attrs)
+                            };
+                            let mut failure_attrs = HashMap::new();
+                            failure_attrs.insert("exception".to_string(), ex);
+                            Value::make_instance(Symbol::intern("Failure"), failure_attrs)
+                        }
+                        PhaseFail::Propagate => unreachable!(),
+                    };
+                    return Ok(Err(failure));
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(Ok(()))
+    }
+}

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -555,118 +555,16 @@ impl Interpreter {
         inv: &Value,
         args: &[Value],
     ) -> Result<(), RuntimeError> {
-        let Some(cell) = Self::self_instance_attrs(inv) else {
-            return Ok(());
-        };
-        let mut probe_attrs = cell.to_map();
-        let refresh_probe = probe_attrs
-            .keys()
-            .any(|k| k.starts_with("__mutsu_attr_alias::"));
-        let mro = self.class_mro(&class_name.resolve());
-        // Determine the class's language revision for submethod dispatch rules.
-        let class_lang_rev = self
-            .type_metadata
-            .get(&class_name.resolve())
-            .and_then(|m| m.get("language-revision"))
-            .map(|v| v.to_string_value())
-            .unwrap_or_else(|| {
-                let version = crate::parser::current_language_version();
-                if let Some(rest) = version.strip_prefix("6.") {
-                    rest.chars().next().unwrap_or('c').to_string()
-                } else {
-                    "c".to_string()
-                }
-            });
-        let class_is_6e = class_lang_rev != "c";
-        for mro_class in mro.iter().rev().map(|s| s.as_str()) {
-            if mro_class == "Any" || mro_class == "Mu" {
-                continue;
-            }
-            // Skip role entries in MRO
-            if self.registry().roles.contains_key(mro_class)
-                && !self.registry().classes.contains_key(mro_class)
-            {
-                continue;
-            }
-            // Check if the class itself has a BUILD submethod
-            let class_has_own_build = self
-                .registry()
-                .classes
-                .get(mro_class)
-                .and_then(|def| def.methods.get("BUILD"))
-                .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
-                .unwrap_or(false);
-            // Call BUILD submethods from composed roles.
-            // Rules:
-            // - Always call role BUILD submethods (both 6.c and 6.e classes)
-            // - In 6.c: if class has own BUILD, skip role submethods from same
-            //   revision (6.c), but still call submethods from other revisions (6.e+)
-            // - In 6.e+: always call all role submethods regardless
-            let role_order = self.ordered_role_submethods_for_class(mro_class, "BUILD");
-            for (role_name, method_def) in role_order {
-                // Determine the role's language revision
-                let role_base = role_name
-                    .split_once('[')
-                    .map(|(b, _)| b)
-                    .unwrap_or(&role_name);
-                let role_lang_rev = self
-                    .type_metadata
-                    .get(role_base)
-                    .and_then(|m| m.get("language-revision"))
-                    .map(|v| v.to_string_value())
-                    .unwrap_or_else(|| "c".to_string());
-                // In 6.c class with own BUILD: skip 6.c role submethods
-                if !class_is_6e && class_has_own_build && role_lang_rev == "c" {
-                    continue;
-                }
-                if refresh_probe {
-                    probe_attrs = cell.to_map();
-                }
-                let (_v, updated) = self.run_resolved_method_celled(
-                    &class_name.resolve(),
-                    &role_name,
-                    "BUILD",
-                    method_def,
-                    &probe_attrs,
-                    args.to_vec(),
-                    Some(inv.clone()),
-                )?;
-                if let Some(m) = updated {
-                    cell.commit_attrs(m);
-                }
-            }
-            // Call the class's BUILD if it has one that wasn't already handled
-            // by ordered_role_submethods_for_class. Role submethods (is_my=true,
-            // role_origin=Some) were already called above. Regular methods
-            // (is_my=false) from roles still need to go through run_instance_method.
-            let has_non_submethod_build = self
-                .registry()
-                .classes
-                .get(mro_class)
-                .and_then(|def| def.methods.get("BUILD"))
-                .map(|overloads| {
-                    overloads
-                        .iter()
-                        .any(|md| md.role_origin.is_none() || !md.is_my)
-                })
-                .unwrap_or(false);
-            if has_non_submethod_build {
-                if refresh_probe {
-                    probe_attrs = cell.to_map();
-                }
-                let (_v, updated) = self.run_instance_method_celled(
-                    mro_class,
-                    &probe_attrs,
-                    "BUILD",
-                    args.to_vec(),
-                    Some(inv.clone()),
-                )?;
-                if let Some(m) = updated {
-                    cell.commit_attrs(m);
-                }
-            }
-        }
-        Ok(())
+        // Both fail modes Propagate -> the runner never returns `Ok(Err(..))`.
+        self.run_construction_phase_steps(
+            class_name,
+            inv,
+            args,
+            "BUILD",
+            super::ctor_phase_plan::PhaseFail::Propagate,
+            super::ctor_phase_plan::PhaseFail::Propagate,
+        )
+        .map(|_| ())
     }
 
     /// Run the TWEAK phase of construction: invoke every TWEAK submethod (own and
@@ -686,126 +584,16 @@ impl Interpreter {
         inv: &Value,
         tweak_args: &[Value],
     ) -> Result<Result<(), Value>, RuntimeError> {
-        let Some(cell) = Self::self_instance_attrs(inv) else {
-            return Ok(Ok(()));
-        };
-        let mut probe_attrs = cell.to_map();
-        let refresh_probe = probe_attrs
-            .keys()
-            .any(|k| k.starts_with("__mutsu_attr_alias::"));
-        let cn = class_name.resolve();
-        let mro = self.class_mro(&cn);
-        let class_lang_rev = self
-            .type_metadata
-            .get(&cn)
-            .and_then(|m| m.get("language-revision"))
-            .map(|v| v.to_string_value())
-            .unwrap_or_else(|| {
-                let version = crate::parser::current_language_version();
-                if let Some(rest) = version.strip_prefix("6.") {
-                    rest.chars().next().unwrap_or('c').to_string()
-                } else {
-                    "c".to_string()
-                }
-            });
-        let class_is_6e = class_lang_rev != "c";
-        for mro_class in mro.iter().rev().map(|s| s.as_str()) {
-            if mro_class == "Any" || mro_class == "Mu" {
-                continue;
-            }
-            // Skip role entries in MRO
-            if self.registry().roles.contains_key(mro_class)
-                && !self.registry().classes.contains_key(mro_class)
-            {
-                continue;
-            }
-            // Check if the class itself has a TWEAK submethod
-            let class_has_own_tweak = self
-                .registry()
-                .classes
-                .get(mro_class)
-                .and_then(|def| def.methods.get("TWEAK"))
-                .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
-                .unwrap_or(false);
-            // Call TWEAK submethods from composed roles (same rules as BUILD)
-            let role_order = self.ordered_role_submethods_for_class(mro_class, "TWEAK");
-            for (role_name, method_def) in role_order {
-                let role_base = role_name
-                    .split_once('[')
-                    .map(|(b, _)| b)
-                    .unwrap_or(&role_name);
-                let role_lang_rev = self
-                    .type_metadata
-                    .get(role_base)
-                    .and_then(|m| m.get("language-revision"))
-                    .map(|v| v.to_string_value())
-                    .unwrap_or_else(|| "c".to_string());
-                // In 6.c class with own TWEAK: skip 6.c role submethods
-                if !class_is_6e && class_has_own_tweak && role_lang_rev == "c" {
-                    continue;
-                }
-                if refresh_probe {
-                    probe_attrs = cell.to_map();
-                }
-                match self.run_resolved_method_celled(
-                    &cn,
-                    &role_name,
-                    "TWEAK",
-                    method_def,
-                    &probe_attrs,
-                    tweak_args.to_vec(),
-                    Some(inv.clone()),
-                ) {
-                    Ok((_v, updated)) => {
-                        if let Some(m) = updated {
-                            cell.commit_attrs(m);
-                        }
-                    }
-                    // `fail` inside TWEAK yields a Failure `.new` returns, not an
-                    // error (Raku: the Failure only throws when the object is used).
-                    Err(err) if err.is_fail() => {
-                        return Ok(Err(self.fail_error_to_failure_value(&err)));
-                    }
-                    Err(err) => return Err(err),
-                }
-            }
-            // Call the class's TWEAK if it has one that wasn't already handled
-            // by ordered_role_submethods_for_class. Same logic as BUILD above.
-            let has_non_submethod_tweak = self
-                .registry()
-                .classes
-                .get(mro_class)
-                .and_then(|def| def.methods.get("TWEAK"))
-                .map(|overloads| {
-                    overloads
-                        .iter()
-                        .any(|md| md.role_origin.is_none() || !md.is_my)
-                })
-                .unwrap_or(false);
-            if has_non_submethod_tweak {
-                if refresh_probe {
-                    probe_attrs = cell.to_map();
-                }
-                match self.run_instance_method_celled(
-                    mro_class,
-                    &probe_attrs,
-                    "TWEAK",
-                    tweak_args.to_vec(),
-                    Some(inv.clone()),
-                ) {
-                    Ok((_v, updated)) => {
-                        if let Some(m) = updated {
-                            cell.commit_attrs(m);
-                        }
-                    }
-                    Err(err) if err.is_fail() => {
-                        return Ok(Err(self.fail_error_to_failure_value(&err)));
-                    }
-                    Err(err) => return Err(err),
-                }
-            }
-        }
-        Ok(Ok(()))
+        // `fail` inside TWEAK yields a Failure `.new` returns, not an error
+        // (Raku: the Failure only throws when the object is used).
+        self.run_construction_phase_steps(
+            class_name,
+            inv,
+            tweak_args,
+            "TWEAK",
+            super::ctor_phase_plan::PhaseFail::TweakFailure,
+            super::ctor_phase_plan::PhaseFail::TweakFailure,
+        )
     }
 
     /// Run the BUILD phase of construction: invoke every BUILD submethod (own and
@@ -824,124 +612,16 @@ impl Interpreter {
         inv: &Value,
         build_args: &[Value],
     ) -> Result<Result<(), Value>, RuntimeError> {
-        let Some(cell) = Self::self_instance_attrs(inv) else {
-            return Ok(Ok(()));
-        };
-        let mut probe_attrs = cell.to_map();
-        let refresh_probe = probe_attrs
-            .keys()
-            .any(|k| k.starts_with("__mutsu_attr_alias::"));
-        let cn = class_name.resolve();
-        let mro = self.class_mro(&cn);
-        let class_lang_rev = self
-            .type_metadata
-            .get(&cn)
-            .and_then(|m| m.get("language-revision"))
-            .map(|v| v.to_string_value())
-            .unwrap_or_else(|| {
-                let version = crate::parser::current_language_version();
-                if let Some(rest) = version.strip_prefix("6.") {
-                    rest.chars().next().unwrap_or('c').to_string()
-                } else {
-                    "c".to_string()
-                }
-            });
-        let class_is_6e = class_lang_rev != "c";
-        for mro_class in mro.iter().rev().map(|s| s.as_str()) {
-            if mro_class == "Any" || mro_class == "Mu" {
-                continue;
-            }
-            if self.registry().roles.contains_key(mro_class)
-                && !self.registry().classes.contains_key(mro_class)
-            {
-                continue;
-            }
-            let class_has_own_build = self
-                .registry()
-                .classes
-                .get(mro_class)
-                .and_then(|def| def.methods.get("BUILD"))
-                .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
-                .unwrap_or(false);
-            let role_order = self.ordered_role_submethods_for_class(mro_class, "BUILD");
-            for (role_name, method_def) in role_order {
-                let role_base = role_name
-                    .split_once('[')
-                    .map(|(b, _)| b)
-                    .unwrap_or(&role_name);
-                let role_lang_rev = self
-                    .type_metadata
-                    .get(role_base)
-                    .and_then(|m| m.get("language-revision"))
-                    .map(|v| v.to_string_value())
-                    .unwrap_or_else(|| "c".to_string());
-                if !class_is_6e && class_has_own_build && role_lang_rev == "c" {
-                    continue;
-                }
-                if refresh_probe {
-                    probe_attrs = cell.to_map();
-                }
-                let (_v, updated) = self.run_resolved_method_celled(
-                    &cn,
-                    &role_name,
-                    "BUILD",
-                    method_def,
-                    &probe_attrs,
-                    build_args.to_vec(),
-                    Some(inv.clone()),
-                )?;
-                if let Some(m) = updated {
-                    cell.commit_attrs(m);
-                }
-            }
-            let has_non_submethod_build = self
-                .registry()
-                .classes
-                .get(mro_class)
-                .and_then(|def| def.methods.get("BUILD"))
-                .map(|overloads| {
-                    overloads
-                        .iter()
-                        .any(|md| md.role_origin.is_none() || !md.is_my)
-                })
-                .unwrap_or(false);
-            if has_non_submethod_build {
-                if refresh_probe {
-                    probe_attrs = cell.to_map();
-                }
-                match self.run_instance_method_celled(
-                    mro_class,
-                    &probe_attrs,
-                    "BUILD",
-                    build_args.to_vec(),
-                    Some(inv.clone()),
-                ) {
-                    Ok((_v, updated)) => {
-                        if let Some(m) = updated {
-                            cell.commit_attrs(m);
-                        }
-                    }
-                    Err(err) if err.is_fail() => {
-                        // `fail` inside BUILD yields a Failure, not an error.
-                        let ex = if let Some(exception) = err.exception {
-                            *exception
-                        } else {
-                            let mut ex_attrs = HashMap::new();
-                            ex_attrs.insert("message".to_string(), Value::str(err.message));
-                            Value::make_instance(Symbol::intern("X::AdHoc"), ex_attrs)
-                        };
-                        let mut failure_attrs = HashMap::new();
-                        failure_attrs.insert("exception".to_string(), ex);
-                        return Ok(Err(Value::make_instance(
-                            Symbol::intern("Failure"),
-                            failure_attrs,
-                        )));
-                    }
-                    Err(err) => return Err(err),
-                }
-            }
-        }
-        Ok(Ok(()))
+        // Historical asymmetry preserved: a role-submethod `fail` propagates as
+        // an error, a class-step `fail` becomes the returned `Failure`.
+        self.run_construction_phase_steps(
+            class_name,
+            inv,
+            build_args,
+            "BUILD",
+            super::ctor_phase_plan::PhaseFail::Propagate,
+            super::ctor_phase_plan::PhaseFail::BuildFailure,
+        )
     }
 
     /// Dispatch Enum .new — should throw X::Constructor::BadType.

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -360,6 +360,25 @@ impl Interpreter {
                 .map(|(n, ..)| crate::symbol::Symbol::intern(n))
                 .collect::<Vec<_>>(),
         );
+        // Pre-derive the BUILD/TWEAK phase step lists and the attribute-name
+        // probe skeleton (runtime/ctor_phase_plan.rs) — pure class-shape data
+        // the construction phases otherwise re-derive per construction.
+        let build_steps = std::sync::Arc::new(if registered && has_build {
+            self.build_construction_phase_steps(cn_resolved, "BUILD")
+        } else {
+            Vec::new()
+        });
+        let tweak_steps = std::sync::Arc::new(if registered && has_tweak {
+            self.build_construction_phase_steps(cn_resolved, "TWEAK")
+        } else {
+            Vec::new()
+        });
+        let probe_skeleton = std::sync::Arc::new(
+            attr_syms
+                .iter()
+                .map(|s| (*s, Value::NIL))
+                .collect::<crate::value::AttrMap>(),
+        );
         let plan = std::sync::Arc::new(super::NativeCtorPlan {
             is_cunion,
             eligible,
@@ -371,6 +390,9 @@ impl Interpreter {
             has_smiley,
             has_custom_bless,
             has_container_defaults,
+            build_steps,
+            tweak_steps,
+            probe_skeleton,
         });
         // Don't freeze a plan for a class that is not (yet) registered: e.g. a
         // role punned to a class on first use would otherwise keep a stale

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -171,6 +171,7 @@ mod calls;
 mod class;
 mod class_dispatch;
 mod class_introspection;
+mod ctor_phase_plan;
 pub(crate) use class_introspection::UserMethodOrAccessor;
 pub(crate) mod cstruct_layout;
 mod decl_types;
@@ -467,6 +468,37 @@ pub(crate) struct NativeCtorPlan {
     /// so the whole scan (its keys `Vec` plus the `(String, String)` registry-key
     /// allocs) is skipped. The overwhelmingly common case.
     pub(crate) has_container_defaults: bool,
+    /// Pre-derived BUILD/TWEAK phase step lists (`runtime/ctor_phase_plan.rs`):
+    /// the base-first MRO walk, per-level registry probes, role-submethod
+    /// ordering, and 6.c/6.e skip decisions that the construction phases
+    /// re-derived on every single construction. Empty when `has_build` /
+    /// `has_tweak` is false.
+    pub(crate) build_steps: Arc<Vec<ConstructionPhaseStep>>,
+    pub(crate) tweak_steps: Arc<Vec<ConstructionPhaseStep>>,
+    /// Attribute-name skeleton (declared attr names -> Nil) usable as the
+    /// phase-dispatch probe map when the live cell carries no sigilless-alias
+    /// metadata: every consumer on that path reads only the key set (see
+    /// `run_construction_phase_steps`), so the per-construction whole-cell
+    /// `to_map()` value clone is skipped.
+    pub(crate) probe_skeleton: Arc<crate::value::AttrMap>,
+}
+
+/// One pre-derived step of a construction phase (BUILD or TWEAK) — see
+/// `NativeCtorPlan::{build_steps, tweak_steps}`.
+pub(crate) enum ConstructionPhaseStep {
+    /// A role-composed submethod at this MRO level, with its owning role and
+    /// already-collected def (what `ordered_role_submethods_for_class`
+    /// re-derived per construction).
+    Role { role_name: String, def: MethodDef },
+    /// The class's own candidate at this MRO level, dispatched with
+    /// `mro_class` as the receiver. `pinned` carries the single simple
+    /// candidate when dispatch may bypass method resolution (the common
+    /// `submethod TWEAK` shape); `None` keeps the full
+    /// `run_instance_method_celled` path.
+    Class {
+        mro_class: String,
+        pinned: Option<MethodDef>,
+    },
 }
 
 /// Kind of declaration a doc comment is attached to.


### PR DESCRIPTION
First slice (S1) of `todo/tickets/bench-ctor-construction-parity.md` — bench-ctor is the only benchmark slower than raku on the bench CI (1.17-1.35x).

## What

The construction phases (`run_build_phase` / `run_tweak_phase` / `run_bless_build_phase`) re-derived, on EVERY construction:
- the full base-first MRO walk with per-level registry probes,
- `ordered_role_submethods_for_class` (role expansion + dedup),
- class/role language-revision metadata strings,
- an unconditional whole-cell `to_map()` probe clone (all attribute values),
- and a full method resolution per class-level BUILD/TWEAK call.

All of that is a pure function of the class shape, so it is now pre-derived into `NativeCtorPlan` (same invalidation sites):
- an ordered per-phase step list with the 6.c/6.e skip decisions baked in,
- the single simple candidate **pinned** — resolution bypassed (mirrors the resolver's single-visible-candidate fast return; wrap-chain / NativeCall prefilters stay runtime checks so later registration re-routes through the full path),
- the candidate compiled once at plan build instead of per construction,
- a shared attribute-name **probe skeleton** (names → Nil) replacing the per-construction `to_map()` whenever the live cell has no sigilless-alias metadata (every consumer on that path — `attr_twigil_local`, the attr-defaults loop, the alias scans — reads only the key set).

The three near-identical phase loops collapse into one shared runner (`runtime/ctor_phase_plan.rs`, net -350 duplicated lines), preserving the historical fail-handling asymmetries verbatim (tweak Failure / build role-propagate + class X::AdHoc wrap / bless propagate).

## Measured

- `MUTSU_VM_STATS` on bench-ctor: resolver-path TWEAK dispatches 10000 → 0 (2/construction eliminated); GC candidate dedup hits −55k (~11/construction, the probe-clone churn).
- Local wall-clock is within noise (~2%); the remaining dispatch cost is the full-path frame setup / `%_` binding / attributive-param machinery — next slices (S2+) in the ticket.

## Verified

- Full local `make test` (24916 tests) and `make roast` (218774 tests): PASS.
- Targeted S12-construction / S12-attributes / S12-class / S14-roles whitelist sweep: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)