### PR TITLE
perf(env): build filtered closure captures without flattening the whole env

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -336,22 +336,6 @@ impl Env {
         }
     }
 
-    /// Build a flat (`parent=None`) env directly from a pre-built overlay map.
-    /// Name lookups still fall through to [`GLOBAL_BASE`] at the tail, so the
-    /// built-in enum constants remain reachable without copying them in. Used by
-    /// the closure-capture upvalue path (single-store Slice E) to materialize a
-    /// snapshot holding only a closure's free variables, the shadow-meta, and the
-    /// system names a body may read through a dedicated opcode — not a flatten of
-    /// every plain user lexical in scope.
-    pub(crate) fn from_symbol_map(map: HashMap<Symbol, Value>) -> Self {
-        Self {
-            inner: Arc::new(map.into_iter().collect()),
-            parent: None,
-            tombstones: None,
-            depth: 0,
-        }
-    }
-
     /// Create a *scoped child* env: an empty overlay that reads through to
     /// `parent` (the whole caller-frame env, itself possibly scoped) and then to
     /// [`GLOBAL_BASE`]. Writes land in the (initially empty) overlay, so the
@@ -491,6 +475,45 @@ impl Env {
                     depth: 0,
                 }
             }
+        }
+    }
+
+    /// Build a flat env holding exactly the entries `keep` accepts, walking
+    /// every tier base-to-leaf (parents first, then each frame's tombstones,
+    /// then its overlay). The visible-per-key result is identical to
+    /// `self.flattened()` followed by a filtered copy — a shadowing leaf entry
+    /// overwrites (or, when rejected, removes) the parent's entry, and a
+    /// tombstoned key does not survive — but no intermediate whole-map clone
+    /// is materialized. This is the closure-capture fast path: `flattened()`
+    /// deep-clones the entire parent-chain map per call, which dominated
+    /// lambda creation inside method frames (`todo/deep/closure-env-capture-cost.md`).
+    /// The base tier (`GLOBAL_BASE`) is — as in `flattened()` — never
+    /// materialized; it stays reachable through the flat env's tail lookup.
+    pub(crate) fn filtered_flat(&self, keep: &dyn Fn(Symbol, &Value) -> bool) -> Env {
+        fn collect(env: &Env, out: &mut SymMap, keep: &dyn Fn(Symbol, &Value) -> bool) {
+            if let Some(parent) = &env.parent {
+                collect(parent, out, keep);
+            }
+            if let Some(tomb) = &env.tombstones {
+                for k in tomb {
+                    out.remove(k);
+                }
+            }
+            for (k, v) in env.inner.iter() {
+                if keep(*k, v) {
+                    out.insert(*k, v.clone());
+                } else {
+                    out.remove(k);
+                }
+            }
+        }
+        let mut out = SymMap::default();
+        collect(self, &mut out, keep);
+        Self {
+            inner: Arc::new(out),
+            parent: None,
+            tombstones: None,
+            depth: 0,
         }
     }
 

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -461,25 +461,22 @@ impl Interpreter {
         // the caller on return (`* ~~ /<$r>/` invoked inside a grep-in-`for`).
         let own_locals: std::collections::HashSet<&str> =
             cc.locals.iter().map(|s| s.as_str()).collect();
-        // Flatten once (same as `clone_env`), then keep only the upvalue set,
-        // shadow-meta, and system names. The base tier (GLOBAL_BASE) is never in
-        // the overlay and stays reachable through the flat env's tail lookup.
-        let flat = self.clone_env();
-        let mut map: std::collections::HashMap<Symbol, Value> = std::collections::HashMap::new();
-        for (k, v) in flat.iter() {
-            // `__mutsu_callable_type` is closure-identity metadata (the
-            // WhateverCode marker), (re)installed on the genuine closure's own env
-            // after capture. Never inherit it, or an ordinary inner block would be
-            // mis-detected as a WhateverCode (see the by-name path above).
+        // Keep only the upvalue set, shadow-meta, and system names, walking the
+        // env tiers directly (`filtered_flat`) — flattening first (`clone_env`)
+        // deep-cloned the entire parent-chain map per lambda creation. The
+        // filter is key-pure, so the tier walk's shadow/tombstone handling is
+        // exactly the flattened view. `__mutsu_callable_type` is
+        // closure-identity metadata (the WhateverCode marker), (re)installed on
+        // the genuine closure's own env after capture — never inherit it, or an
+        // ordinary inner block would be mis-detected as a WhateverCode (see the
+        // by-name path above).
+        let mut env = self.env().filtered_flat(&|k, _v| {
             if k.with_str(|s| s == "__mutsu_callable_type") {
-                continue;
+                return false;
             }
-            let keep = free.contains(k)
-                || k.with_str(|s| !crate::env::is_plain_user_lexical(s) && !own_locals.contains(s));
-            if keep {
-                map.insert(*k, v.clone());
-            }
-        }
+            free.contains(&k)
+                || k.with_str(|s| !crate::env::is_plain_user_lexical(s) && !own_locals.contains(s))
+        });
         // Upvalue read: override this frame's own free-var slots with the live
         // local value. Authoritative even after the closure-driven env flush is
         // gone (a slot-only local is no longer mirrored into `env`).
@@ -487,10 +484,10 @@ impl Interpreter {
             if let Some(slot) = Self::resolve_capture_slot(code, &cc.free_var_parent_slots, i, *sym)
                 && let Some(val) = self.locals.get(slot)
             {
-                map.insert(*sym, val.clone());
+                env.insert_sym(*sym, val.clone());
             }
         }
-        crate::env::Env::from_symbol_map(map)
+        env
     }
 
     /// Build the closure's upvalue array (aligned with `cc.upvalue_syms`) from the


### PR DESCRIPTION
S2b slice of `todo/tickets/bench-ctor-construction-parity.md` (follows #5569/#5570); implements the cheap half of `todo/deep/closure-env-capture-cost.md`.

## What

`capture_closure_env`'s filtered path (every closure whose free-variable scan is complete — the overwhelmingly common case) started with `clone_env()`, which on a scoped method/block frame **deep-clones the entire parent-chain overlay map** (`Env::flattened`), only to filter-copy the kept subset and throw the clone away. Creating the constant WhateverCode `*.flat` inside `Dist.TWEAK` paid an O(program symbols) map clone per construction — ~10% of bench-ctor inclusive — and every hot-loop `.map({...})` / `.grep({...})` closure pays the same tax.

New `Env::filtered_flat`: walk the tiers base-to-leaf (parents first, each frame's tombstones, then its overlay) and copy only the entries the (key-pure) filter accepts; a shadowing leaf entry overwrites — or, when rejected, removes — the parent's entry. The visible-per-key result is exactly `flattened()`-then-filter, with no intermediate whole-map clone and no std→Fx rehash (`from_symbol_map`, now unused, removed). The by-name capture path (reflective / `captures_env_by_name` frames) still flattens, as it must expose the full lexical view.

## Measured (local, min of 5, same box)

- bench-ctor: 255ms → **236ms** (raku: 271ms — mutsu ahead on this bench locally for the first time; CI bench-data will give the authoritative ratio)

## Verified

- Full local `make test` (24916) + `make roast` (218774 tests): PASS with this exact code.
- Closure-focused t/ sweep (closure/whatever/map/grep/gather/lazy/curry, 168 files): PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)