### PR TITLE
fix(runtime): silence unused-variable warning for lock name in release builds

### DIFF
--- a/src/runtime/lock_reentry.rs
+++ b/src/runtime/lock_reentry.rs
@@ -129,11 +129,11 @@ pub(crate) struct ReentrantReadGuard<'a, T> {
 }
 
 impl<'a, T> ReentrantReadGuard<'a, T> {
-    pub(crate) fn new(lock: &'a std::sync::RwLock<T>, name: &'static str) -> Self {
+    pub(crate) fn new(lock: &'a std::sync::RwLock<T>, _name: &'static str) -> Self {
         #[cfg(debug_assertions)]
         let lock_id = lock as *const _ as usize;
         #[cfg(debug_assertions)]
-        reentry_check::enter_read(lock_id, name);
+        reentry_check::enter_read(lock_id, _name);
         // Acquire only after the reentry check, so a would-be deadlock panics
         // instead of hanging on the blocking `.read()`.
         let inner = lock.read().unwrap();
@@ -169,11 +169,11 @@ pub(crate) struct ReentrantWriteGuard<'a, T> {
 }
 
 impl<'a, T> ReentrantWriteGuard<'a, T> {
-    pub(crate) fn new(lock: &'a std::sync::RwLock<T>, name: &'static str) -> Self {
+    pub(crate) fn new(lock: &'a std::sync::RwLock<T>, _name: &'static str) -> Self {
         #[cfg(debug_assertions)]
         let lock_id = lock as *const _ as usize;
         #[cfg(debug_assertions)]
-        reentry_check::enter_write(lock_id, name);
+        reentry_check::enter_write(lock_id, _name);
         let inner = lock.write().unwrap();
         Self {
             inner,


### PR DESCRIPTION
Release builds (`cargo build --release` / `cargo check --release`) emitted:

```
warning: unused variable: `name`
   --> src/runtime/lock_reentry.rs:132:55
   --> src/runtime/lock_reentry.rs:172:55
```

The `name` parameter of `ReentrantReadGuard::new` / `ReentrantWriteGuard::new` is only consumed inside `#[cfg(debug_assertions)]` reentry-check calls, so with debug assertions off the parameter is unused. The pre-commit `cargo clippy -- -D warnings` runs on the dev profile (where the parameter IS used), which is why this slipped through.

Fix: rename the parameter to `_name` per the compiler suggestion. Debug builds still pass it through to the reentry checker for located panic messages; release builds are now warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)