### PR TITLE
perf(regex): stop deep-copying shared capture subtrees in the reduce walk

### DIFF
--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -411,21 +411,43 @@ impl Interpreter {
         // a child's code block accumulates into this match's binding (the
         // `:my %*PLAYED = (); <card>+` shape) rather than a sibling match's.
         let declared_keys = self.install_fresh_rule_dynvars(rule_name);
+        // The walk mutates a node only to take/run its code blocks (writing
+        // `ast`) or to record per-rule dynvar bindings. A subtree with no code
+        // blocks anywhere — the overwhelmingly common case for a leaf-heavy
+        // grammar parse — is left byte-identical, so descending into it through
+        // `Arc::make_mut` would only deep-copy shared nodes (each is already in
+        // `REDUCED_SUBRULES` and/or a `snapshot()`) for nothing. Skip those
+        // subtrees outright. Only sound when no rule declares `:my $*x` dynvars
+        // (a declaring rule must run even without blocks); such grammars are
+        // rare and keep the full walk.
+        let skip_untouched = self.grammar_rule_dynvar_decls.is_empty();
         // Children first so a parent block reading a child's `.made` sees it.
         for (key, scs) in caps.named_subcaps.iter_mut() {
             let child_rule = Self::reduce_child_rule_name(key);
             for sc in scs.iter_mut() {
+                if skip_untouched && !Self::subtree_has_code_blocks(sc) {
+                    continue;
+                }
+                crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
                 let sc = Arc::make_mut(sc);
                 let child_rule = sc.action_name.clone().unwrap_or(child_rule.clone());
                 self.reduce_regex_captures_made_for_rule(sc, orig, Some(&child_rule));
             }
         }
         for sc in caps.positional_subcaps.iter_mut().flatten() {
+            if skip_untouched && !Self::subtree_has_code_blocks(sc) {
+                continue;
+            }
+            crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
             self.reduce_regex_captures_made(Arc::make_mut(sc), orig);
         }
         for pq in caps.positional_quantified.iter_mut().flatten() {
             for entry in pq.iter_mut() {
                 if let Some(sc) = entry.3.as_mut() {
+                    if skip_untouched && !Self::subtree_has_code_blocks(sc) {
+                        continue;
+                    }
+                    crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
                     self.reduce_regex_captures_made(Arc::make_mut(sc), orig);
                 }
             }
@@ -508,6 +530,32 @@ impl Interpreter {
         if let Some(m) = saved_match {
             self.env.insert("/".to_string(), m);
         }
+    }
+
+    /// Read-only pre-check for the reduce walk: does this stored capture
+    /// subtree contain any inline `{ … }` code blocks? When it does not (and no
+    /// rule declares dynvars — checked by the caller), the walk would leave the
+    /// subtree byte-identical, so the caller skips it instead of deep-copying
+    /// shared `Arc` nodes via `make_mut`.
+    fn subtree_has_code_blocks(caps: &RegexCaptures) -> bool {
+        if !caps.code_blocks.is_empty() {
+            return true;
+        }
+        caps.named_subcaps
+            .values()
+            .flatten()
+            .any(|sc| Self::subtree_has_code_blocks(sc))
+            || caps
+                .positional_subcaps
+                .iter()
+                .flatten()
+                .any(|sc| Self::subtree_has_code_blocks(sc))
+            || caps
+                .positional_quantified
+                .iter()
+                .flatten()
+                .flatten()
+                .any(|e| e.3.as_deref().is_some_and(Self::subtree_has_code_blocks))
     }
 
     /// The rule name a `named_subcaps` key stands for. A silent-action capture

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -717,6 +717,18 @@ impl Interpreter {
                     && !spec.alias_replaces_original
                     && capture_name != spec.lookup_name;
                 let original_subcap = also_under_original.then(|| subcap.clone());
+                // For an aliased capture (`<x=rule>`), record the original rule
+                // name for grammar action dispatch BEFORE the node is wrapped in
+                // an Arc and shared (`record_reduced_subrule` clones the handle):
+                // writing it afterwards through `Arc::make_mut` deep-copied the
+                // whole descendant subtree for every aliased subrule capture.
+                // The alias copy carries it; the original-name copy (cloned just
+                // above) keeps `action_name: None`, same as before.
+                let is_alias = spec.capture_name.is_some() && capture_name != spec.lookup_name;
+                let mut subcap = subcap;
+                if is_alias {
+                    subcap.action_name = Some(spec.lookup_name.clone());
+                }
                 let subcap = std::sync::Arc::new(subcap);
                 // This subrule has just REDUCED. Log it so a parse that fails
                 // overall can still run its action, the way Rakudo (which
@@ -732,15 +744,10 @@ impl Interpreter {
                     .entry(capture_name.to_string())
                     .or_default()
                     .push(captured.clone());
-                if spec.capture_name.is_some() && capture_name != spec.lookup_name {
+                if is_alias {
                     new_caps
                         .capture_alias_map
                         .insert(capture_name.to_string(), spec.lookup_name.clone());
-                    if let Some(subcaps) = new_caps.named_subcaps.get_mut(capture_name)
-                        && let Some(last) = subcaps.last_mut()
-                    {
-                        std::sync::Arc::make_mut(last).action_name = Some(spec.lookup_name.clone());
-                    }
                 }
                 if let Some(orig_subcap) = original_subcap {
                     new_caps

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -109,6 +109,27 @@ static GC_PAUSE_NS_TOTAL: AtomicU64 = AtomicU64::new(0);
 static GC_PAUSE_NS_MAX: AtomicU64 = AtomicU64::new(0);
 static GC_ROOTS_SCANNED: AtomicU64 = AtomicU64::new(0);
 
+// ADR-0016 P2 diagnostics: how often a stored regex capture node
+// (`Arc<RegexCaptures>`) is mutated through `Arc::make_mut` while shared
+// (strong_count > 1), which deep-clones the entire descendant subtree. The
+// `TOTAL` counter is every such make_mut; `SHARED` is the subset that actually
+// copied. These quantify the reduce-walk / alias-action_name copy cost the
+// CapNode split (ADR-0016 P2) removes structurally.
+static REGEX_CAP_MAKEMUT_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REGEX_CAP_MAKEMUT_SHARED: AtomicU64 = AtomicU64::new(0);
+
+/// Record one `Arc::make_mut` on a stored regex capture node; `shared` means
+/// the node had other holders (strong_count > 1) so make_mut deep-copied it.
+#[inline]
+pub(crate) fn record_regex_cap_makemut(shared: bool) {
+    if enabled() {
+        REGEX_CAP_MAKEMUT_TOTAL.fetch_add(1, Ordering::Relaxed);
+        if shared {
+            REGEX_CAP_MAKEMUT_SHARED.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 // JIT (ADR-0004 layer 4) counters: how many chunks compiled to native code,
 // how many body executions entered native code, and how many chunks bailed
 // out (contain a not-yet-supported opcode; see `jit_bailout_by_opcode` for
@@ -413,6 +434,11 @@ pub(crate) fn dump() {
     let gc_threshold = crate::gc::gc_current_size_threshold();
     eprintln!(
         "[mutsu vm-stats] gc: collections={gc_collections} candidate_pushes={gc_candidate_pushes} dedup_hits={gc_dedup_hits} reclaimed_nodes={gc_reclaimed_nodes} reclaimed_cycles={gc_reclaimed_cycles} pause_ns_total={gc_pause_ns_total} pause_ns_max={gc_pause_ns_max} roots_scanned={gc_roots_scanned} gc_threshold={gc_threshold}"
+    );
+    let cap_makemut_total = REGEX_CAP_MAKEMUT_TOTAL.load(Ordering::Relaxed);
+    let cap_makemut_shared = REGEX_CAP_MAKEMUT_SHARED.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] regex-captures: cap_makemut={cap_makemut_total} shared_deep_copies={cap_makemut_shared}"
     );
     let jit_compiles = JIT_COMPILES.load(Ordering::Relaxed);
     let jit_entries = JIT_ENTRIES.load(Ordering::Relaxed);


### PR DESCRIPTION
ADR-0016 P2 groundwork. Per the ADR's instruction (**count, don't guess**), this adds a `MUTSU_VM_STATS` counter pair (`cap_makemut`/`shared_deep_copies`) and then removes what it found.

## Measured

On `benchmarks/bench-yaml-parse.raku` (debug build, counters are optimization-level-independent):

| | cap_makemut | shared_deep_copies |
|---|---:|---:|
| before | 40,455 | 40,297 |
| after | 2 | **0** |

Every reduce-walk `Arc::make_mut` was a deep copy of the entire descendant subtree, because stored capture nodes are always shared (with `REDUCED_SUBRULES` and/or a `snapshot()`).

## Fixes

1. **`build_named_candidates_from_inner`**: set `action_name` on an aliased subrule capture **before** `Arc::new` / `record_reduced_subrule` share the node, instead of writing it through `Arc::make_mut` afterwards — that write was a guaranteed subtree copy per aliased capture (e.g. YAMLish's `<str=single-bare>`). The original-name duplicate keeps `action_name: None`, same as before.
2. **`reduce_regex_captures_made_for_rule`**: skip subtrees containing no inline `{ … }` code blocks (read-only pre-check), valid when no rule declares `:my $*x` dynvars. The walk leaves such subtrees byte-identical, so descending through `Arc::make_mut` only paid for deep copies.

Wall-clock on the yaml bench is unchanged — ADR-0016 anticipated this class may sit below measurement noise. This slice removes the copies structurally before the bigger P2/P3 phases so they stop polluting future profiles.

## Verified

- `prove` on all 139 `t/grammar-*.t` + `t/regex-*.t` + `t/yaml-battery.t` files: PASS (1134 tests)
- `cargo clippy -- -D warnings`, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)