### PR TITLE
perf(dispatch): negative function-resolution gate + regex embedded-code parse cache

### DIFF
--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -169,6 +169,8 @@ impl Interpreter {
             &before_function_keys,
             main_exported,
         );
+        // Invalidate name-keyed resolution caches.
+        self.fn_resolve_gen += 1;
 
         if let Some(pkg) = package_hint
             && !pkg.is_empty()
@@ -192,6 +194,8 @@ impl Interpreter {
             for (alias, def) in fn_aliases {
                 self.registry_mut().functions.insert(alias, def);
             }
+            // Invalidate name-keyed resolution caches.
+            self.fn_resolve_gen += 1;
 
             let mut env_aliases: Vec<(String, Value)> = Vec::new();
             for (name, value) in &self.env {
@@ -303,6 +307,7 @@ impl Interpreter {
         for k in leaked {
             functions.remove(&k);
         }
+        // NOTE: callers must bump `fn_resolve_gen` after this (no `self` here).
     }
 
     fn import_single_require_symbol(&mut self, module: &str, symbol: &str) -> bool {
@@ -341,6 +346,8 @@ impl Interpreter {
             for (k, v) in function_entries {
                 self.registry_mut().functions.insert(k, v);
             }
+            // Invalidate name-keyed resolution caches.
+            self.fn_resolve_gen += 1;
             return found
                 || self
                     .registry()

--- a/src/runtime/dispatch_resolve.rs
+++ b/src/runtime/dispatch_resolve.rs
@@ -1,6 +1,59 @@
 use super::*;
 
+/// The *base name* a registry function key stands for: the key minus its
+/// package prefix and its arity/type suffix. `"Pkg::foo/2:Int,Str"` → `"foo"`,
+/// `"GLOBAL::infix:</>/2"` → `"infix:</>"`, `"foo"` → `"foo"`.
+///
+/// The arity suffix is the RIGHTMOST `/` immediately followed by an ASCII
+/// digit (`/2`, `/3:Int`, `/1__m…`); an operator name's own `/` (as in
+/// `infix:</>`) is never digit-followed, so it survives. The same extraction
+/// is applied to both registry keys and query names, so any exotic spelling
+/// degrades to a consistent (never wrong) bucket.
+fn function_key_base_name(key: &str) -> &str {
+    let bytes = key.as_bytes();
+    let mut end = key.len();
+    let mut i = key.len();
+    while i > 1 {
+        i -= 1;
+        if bytes[i - 1] == b'/' && bytes[i].is_ascii_digit() {
+            end = i - 1;
+            break;
+        }
+    }
+    let head = &key[..end];
+    match head.rfind("::") {
+        Some(p) => &head[p + 2..],
+        None => head,
+    }
+}
+
 impl Interpreter {
+    /// Whether ANY registered function key carries `name`'s base name — a
+    /// cheap negative gate for [`Self::resolve_function_with_types`]. When
+    /// this is `false`, no lookup pattern in the resolver (qualified, typed,
+    /// arity-keyed, flexible-arity, package-searched) can possibly match, so
+    /// the resolver returns `None` without walking the registry. Memoized per
+    /// name in `fn_base_name_cache`, invalidated by `fn_resolve_gen` (bumped
+    /// on every function registration/removal).
+    pub(crate) fn fn_base_name_registered(&mut self, name: &str) -> bool {
+        if self.fn_base_name_cache_gen != self.fn_resolve_gen {
+            self.fn_base_name_cache.clear();
+            self.fn_base_name_cache_gen = self.fn_resolve_gen;
+        }
+        let base = function_key_base_name(name);
+        let base_sym = Symbol::intern(base);
+        if let Some(&cached) = self.fn_base_name_cache.get(&base_sym) {
+            return cached;
+        }
+        let found = self
+            .registry()
+            .functions
+            .keys()
+            .any(|k| function_key_base_name(&k.resolve()) == base);
+        self.fn_base_name_cache.insert(base_sym, found);
+        found
+    }
+
     pub(super) fn sort_candidates_by_specificity(
         &self,
         candidates: &mut [(String, Arc<FunctionDef>)],
@@ -100,6 +153,7 @@ impl Interpreter {
         name: &str,
         arg_values: &[Value],
     ) -> Option<Arc<FunctionDef>> {
+        crate::vm::vm_stats::record_function_full_resolve(name);
         // Arity counts only positional args, excluding named args (Pair values)
         let arity = arg_values
             .iter()
@@ -137,6 +191,13 @@ impl Interpreter {
                 attrs,
             )));
             self.set_pending_dispatch_error(err);
+            return None;
+        }
+        // Negative gate: if no registry key carries this base name at all, no
+        // candidate scan below can match — skip the whole walk. This is the
+        // common case for interpreter-native builtins (`make`, `prefix:<~>`,
+        // …) that are dispatched *after* a failed user-function resolution.
+        if !self.fn_base_name_registered(name) {
             return None;
         }
         if name.contains("::") {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1712,6 +1712,14 @@ pub struct Interpreter {
     pub(crate) fn_resolve_cache_gen: u64,
     pub(crate) multi_candidates_cache: rustc_hash::FxHashMap<Symbol, bool>,
     pub(crate) multi_candidates_cache_gen: u64,
+    /// Per-name memo of "does ANY registry function key carry this base name?"
+    /// (`fn_base_name_registered`). `false` lets `resolve_function_with_types`
+    /// return `None` without scanning the whole functions map — the common case
+    /// for interpreter-native builtins like `make` / `prefix:<~>`, which
+    /// otherwise pay a full failed candidate walk on every call. Guarded by
+    /// `fn_resolve_gen` like `multi_candidates_cache`.
+    pub(crate) fn_base_name_cache: rustc_hash::FxHashMap<Symbol, bool>,
+    pub(crate) fn_base_name_cache_gen: u64,
     pub(crate) light_call_cache: rustc_hash::FxHashMap<Symbol, (Symbol, u64)>,
     pub(crate) light_call_cache_gen: u64,
     pub(crate) pos_light_call_cache: rustc_hash::FxHashMap<Symbol, (Symbol, u64)>,

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -1,6 +1,41 @@
 use super::super::*;
 
 impl Interpreter {
+    /// Parse a main-slang code string embedded in a regex (`{ … }` block,
+    /// `<?{ … }>` assertion, `<{ … }>` interpolation, `** {code}` quantifier,
+    /// `:my` declaration) through the thread-local `REGEX_CODE_PARSE_CACHE`.
+    /// These strings are re-evaluated per cursor position in the hot match
+    /// loop, and the parse of a given string is deterministic under a fixed
+    /// declaration registry — so a cache hit (keyed by the string, guarded by
+    /// `registry_write_gen`) is a refcount bump instead of a full re-parse.
+    /// Returns `None` when the code does not parse (not cached — the caller
+    /// treats it as a no-op/no-match either way).
+    pub(in crate::runtime) fn parse_regex_code_cached(
+        &self,
+        code: &str,
+    ) -> Option<Arc<Vec<crate::ast::Stmt>>> {
+        use crate::runtime::regex_parse::REGEX_CODE_PARSE_CACHE;
+        let cur_gen = self
+            .registry_write_gen
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if let Some(hit) = REGEX_CODE_PARSE_CACHE.with(|c| {
+            c.borrow()
+                .get(code)
+                .and_then(|(g, stmts)| (*g == cur_gen).then(|| Arc::clone(stmts)))
+        }) {
+            crate::vm::vm_stats::record_regex_code_parse(true);
+            return Some(hit);
+        }
+        crate::vm::vm_stats::record_regex_code_parse(false);
+        let (stmts, _) = crate::parse_dispatch::parse_source(code).ok()?;
+        let stmts = Arc::new(stmts);
+        REGEX_CODE_PARSE_CACHE.with(|c| {
+            c.borrow_mut()
+                .insert(code.to_string(), (cur_gen, Arc::clone(&stmts)));
+        });
+        Some(stmts)
+    }
+
     /// Copy the declaration registry (functions / proto_functions / token_defs)
     /// from `self` into a freshly-built sub-interpreter used for regex/grammar
     /// evaluation. `self` and `target` have distinct registry `Arc`s, so this is
@@ -91,7 +126,7 @@ impl Interpreter {
         // Set $_ to the match target string. After `make_regex_eval_env`, which
         // installs the `:my`/`:let` lexicals — the topic must win over them.
         env.insert("_".to_string(), Value::str(target.to_string()));
-        let (stmts, _) = crate::parse_dispatch::parse_source(code).ok()?;
+        let stmts = self.parse_regex_code_cached(code)?;
         let mut interp = Interpreter {
             env,
             current_package: Arc::new(RwLock::new(self.current_package())),
@@ -197,9 +232,8 @@ impl Interpreter {
         matched_so_far: &str,
         writes_back_to_caller: bool,
     ) -> (Option<Value>, HashMap<String, Value>) {
-        let (stmts, _) = match crate::parse_dispatch::parse_source(code) {
-            Ok(result) => result,
-            Err(_) => return (None, HashMap::new()),
+        let Some(stmts) = self.parse_regex_code_cached(code) else {
+            return (None, HashMap::new());
         };
         // The bindings to install for the body, and to restore afterwards.
         let mut env: Vec<(String, Value)> = Vec::new();
@@ -268,7 +302,7 @@ impl Interpreter {
         // `my $card = …` would clobber a same-named variable in the enclosing
         // scope — day18's assertion declares exactly that.
         let mut scoped: Vec<String> = env.iter().map(|(k, _)| k.clone()).collect();
-        for stmt in &stmts {
+        for stmt in stmts.iter() {
             if let Stmt::VarDecl { name, .. } = stmt
                 && !scoped.contains(name)
             {

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -11,7 +11,7 @@ impl Interpreter {
         code: &str,
         caps: &RegexCaptures,
     ) -> Option<(usize, Option<usize>)> {
-        let (stmts, _) = crate::parse_dispatch::parse_source(code).ok()?;
+        let stmts = self.parse_regex_code_cached(code)?;
         let env = self.make_regex_eval_env(caps);
         let mut interp = Interpreter {
             env,
@@ -230,7 +230,7 @@ impl Interpreter {
         code_blocks: &[CodeBlockContext],
     ) {
         for ctx in code_blocks {
-            let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&ctx.code) else {
+            let Some(stmts) = self.parse_regex_code_cached(&ctx.code) else {
                 continue;
             };
             self.setup_regex_code_block_env(ctx);
@@ -494,7 +494,7 @@ impl Interpreter {
         // Fresh `make` slot for this node (do not inherit a sibling's value).
         self.env.remove("made");
         for ctx in &blocks {
-            let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&ctx.code) else {
+            let Some(stmts) = self.parse_regex_code_cached(&ctx.code) else {
                 continue;
             };
             self.setup_regex_code_block_env(ctx);
@@ -589,7 +589,7 @@ impl Interpreter {
             let Some(key) = Self::dynamic_decl_var_key(decl) else {
                 continue;
             };
-            if let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&format!("{decl};")) {
+            if let Some(stmts) = self.parse_regex_code_cached(&format!("{decl};")) {
                 let _ = self.eval_block_value(&stmts);
             }
             // A `$`-sigil dynamic variable lives in env WITHOUT its sigil

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -484,7 +484,7 @@ impl Interpreter {
             }
             RegexAtom::VarDecl { code } => {
                 let source = format!("{};", code);
-                if let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&source) {
+                if let Some(stmts) = self.parse_regex_code_cached(&source) {
                     let mut interp = Interpreter {
                         env: self.env.clone(),
                         current_package: Arc::new(RwLock::new(self.current_package())),

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -412,7 +412,7 @@ impl Interpreter {
             }
             if !handled_state_postfix && !handled_direct_assign {
                 let eval_src = stmt_src.clone();
-                let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&eval_src) else {
+                let Some(stmts) = self.parse_regex_code_cached(&eval_src) else {
                     self.registry_mut().token_defs = saved_token_defs;
                     self.restore_env_entries(restore_always);
                     self.restore_env_entries(restore_on_fail);

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -624,7 +624,7 @@ impl Interpreter {
                 .or(Some(Value::NIL));
         }
         let source = format!("({expr_src});");
-        let (stmts, _) = crate::parse_dispatch::parse_source(&source).ok()?;
+        let stmts = self.parse_regex_code_cached(&source)?;
         let mut interp = Interpreter {
             env: self.make_regex_eval_env(caps),
             current_package: Arc::new(RwLock::new(self.current_package())),

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -39,7 +39,25 @@ thread_local! {
     /// parse is picked up.
     pub(crate) static REGEX_PARSE_CACHE: RefCell<HashMap<String, (u64, std::sync::Arc<RegexPattern>)>> =
         RefCell::new(HashMap::new());
+
+    /// Memoization cache for the *main-slang* code strings evaluated during
+    /// regex matching: `{ … }` side-effect blocks, `<?{ … }>`/`<!{ … }>`
+    /// assertions, `<{ … }>` closure interpolations, `** {code}` quantifier
+    /// blocks, and `:my $x = …;` declarations. These are evaluated per cursor
+    /// position / per iteration in the hot match loop, and re-parsing the same
+    /// short string from source each time made the Raku parser (not the regex
+    /// engine) the dominant cost of a grammar parse (~30% of samples on the
+    /// yaml bench). The parse result is deterministic for a given source string
+    /// under a fixed declaration registry, so entries record the interpreter's
+    /// `registry_write_gen`: any routine/operator (re)registration invalidates
+    /// them, the same discipline as `REGEX_PARSE_CACHE`'s `TOKEN_DEFS_GEN`.
+    pub(crate) static REGEX_CODE_PARSE_CACHE: RefCell<HashMap<String, CachedCodeParse>> =
+        RefCell::new(HashMap::new());
 }
+
+/// A `REGEX_CODE_PARSE_CACHE` entry: the `registry_write_gen` the code string
+/// was parsed under, and the parsed statements.
+pub(crate) type CachedCodeParse = (u64, std::sync::Arc<Vec<crate::ast::Stmt>>);
 
 /// Generation counter for the grammar-token registry (`Registry.token_defs`).
 /// Bumped on every token (re)definition / wholesale restore; used to invalidate

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -2247,6 +2247,8 @@ impl Interpreter {
                             Symbol::intern(&qualified_name),
                             std::sync::Arc::new(func_def),
                         );
+                        // Invalidate name-keyed resolution caches.
+                        self.fn_resolve_gen += 1;
                     }
                     // `my method` registers as a lexically-scoped function
                     // (callable as `name(invocant)` inside the class body)
@@ -2332,6 +2334,8 @@ impl Interpreter {
                             Symbol::intern(&qualified_name),
                             std::sync::Arc::new(func_def),
                         );
+                        // Invalidate name-keyed resolution caches.
+                        self.fn_resolve_gen += 1;
                         // Mark as my-scoped so it doesn't appear in the package stash
                         self.mark_my_scoped_package_item(qualified_name);
                     }

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -595,6 +595,8 @@ impl Interpreter {
                     .map(|(_, arc)| arc.clone())
             {
                 self.registry_mut().functions.insert(fq_sym, cached);
+                // Invalidate name-keyed resolution caches.
+                self.fn_resolve_gen += 1;
                 self.registered_fn_fingerprints.insert(fq_sym, site_fp);
                 if pkg != "GLOBAL" {
                     self.mark_my_scoped_package_item(fq);
@@ -833,6 +835,8 @@ impl Interpreter {
                 let resolved = key.resolve();
                 resolved != lexical_single && !resolved.starts_with(&lexical_multi_prefix)
             });
+            // Invalidate name-keyed resolution caches.
+            self.fn_resolve_gen += 1;
         }
         if let Some(assoc) = associativity {
             self.operator_assoc.insert(name.to_string(), assoc.clone());
@@ -921,6 +925,8 @@ impl Interpreter {
                 self.registered_fn_fingerprints.remove(&fq_sym);
             }
             self.registry_mut().functions.insert(fq_sym, arc);
+            // Invalidate name-keyed resolution caches.
+            self.fn_resolve_gen += 1;
         }
         // If this is an our-scoped sub, also store it in the persistent our_scoped_functions
         // so it survives block scope restoration.
@@ -1148,6 +1154,8 @@ impl Interpreter {
             let resolved = existing.resolve();
             resolved != key && !resolved.starts_with(&prefix)
         });
+        // Invalidate name-keyed resolution caches.
+        self.fn_resolve_gen += 1;
         self.registry_mut().proto_subs.insert(key);
         let fq = format!("{}::{}", self.current_package(), name);
         // `proto bar {*}` declares an empty signature; record it so dispatch

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -290,6 +290,8 @@ impl Interpreter {
                 reg.proto_subs = saved_proto_subs;
                 reg.proto_functions = saved_proto_functions;
             }
+            // Invalidate name-keyed resolution caches.
+            self.fn_resolve_gen += 1;
             self.operator_assoc = saved_operator_assoc;
             self.user_declared_infix_ops = saved_user_declared_infix_ops;
         }

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -719,6 +719,8 @@ impl Interpreter {
                 &before_function_keys,
                 main_exported,
             );
+            // Invalidate name-keyed resolution caches.
+            self.fn_resolve_gen += 1;
             // If the module defined `sub EXPORT`, call it with the `use` args and
             // install the symbols it returns into the caller's scope.
             self.apply_module_export(export_args.unwrap_or_default())?;

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2262,6 +2262,8 @@ impl Interpreter {
             fn_resolve_cache_gen: 0,
             multi_candidates_cache: Default::default(),
             multi_candidates_cache_gen: 0,
+            fn_base_name_cache: Default::default(),
+            fn_base_name_cache_gen: 0,
             light_call_cache: Default::default(),
             light_call_cache_gen: 0,
             pos_light_call_cache: Default::default(),

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -435,6 +435,8 @@ impl Interpreter {
                         })
                         .copied()
                         .collect();
+                    // Invalidate name-keyed resolution caches (keys renamed).
+                    self.fn_resolve_gen += 1;
                     for mk in multi_keys {
                         let removed = self.registry_mut().functions.remove(&mk);
                         if let Some(def) = removed {
@@ -492,6 +494,8 @@ impl Interpreter {
             for k in non_exported_op_globals {
                 self.registry_mut().functions.remove(&k);
             }
+            // Invalidate name-keyed resolution caches.
+            self.fn_resolve_gen += 1;
 
             // Remove GLOBAL:: sub aliases that were leaked by sub hoisting during
             // this module load, are NOT exported, and shadow a core builtin.
@@ -540,6 +544,8 @@ impl Interpreter {
                 for k in leaked_globals {
                     self.registry_mut().functions.remove(&k);
                 }
+                // Invalidate name-keyed resolution caches.
+                self.fn_resolve_gen += 1;
             }
 
             self.loaded_modules.insert(module.to_string());

--- a/src/runtime/runtime_module_export_sub.rs
+++ b/src/runtime/runtime_module_export_sub.rs
@@ -54,6 +54,8 @@ impl Interpreter {
             let ks = key.resolve();
             ks != "EXPORT" && !ks.ends_with("::EXPORT")
         });
+        // Invalidate name-keyed resolution caches.
+        self.fn_resolve_gen += 1;
     }
 
     /// Install the symbols named by an `EXPORT` return value. Accepts a single

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -421,6 +421,9 @@ impl Interpreter {
                     self.registry_mut().functions.insert(k, v);
                 }
             }
+            // Function set changed: invalidate the name-keyed resolution caches
+            // (multi_candidates_cache / fn_base_name_cache).
+            self.fn_resolve_gen += 1;
 
             let proto_entries: Vec<(Symbol, Arc<FunctionDef>)> = self
                 .registry()

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -555,6 +555,8 @@ impl Interpreter {
             fn_resolve_cache_gen: 0,
             multi_candidates_cache: Default::default(),
             multi_candidates_cache_gen: 0,
+            fn_base_name_cache: Default::default(),
+            fn_base_name_cache_gen: 0,
             light_call_cache: Default::default(),
             light_call_cache_gen: 0,
             pos_light_call_cache: Default::default(),

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -63,6 +63,8 @@ impl Interpreter {
             mut type_metadata,
             var_type_constraints,
         } = snapshot;
+        // Invalidate name-keyed resolution caches (functions restored wholesale).
+        self.fn_resolve_gen += 1;
         {
             let mut registry = self.registry_mut();
             registry.functions = functions;

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -67,6 +67,25 @@ fn opcode_histogram()
     HIST.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Per-name histogram of `resolve_function_with_types` invocations (the full
+/// registry-scanning resolution walk). Only populated when stats are on. This
+/// is the empirical basis for resolution-caching work: a name with thousands
+/// of entries here is paying the candidate scan per call.
+fn function_full_resolve_by_name() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_NAME: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_NAME.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one `resolve_function_with_types` invocation.
+#[inline]
+pub(crate) fn record_function_full_resolve(name: &str) {
+    if enabled()
+        && let Ok(mut map) = function_full_resolve_by_name().lock()
+    {
+        *map.entry(name.to_string()).or_insert(0) += 1;
+    }
+}
+
 /// Per-name histogram of method calls that entered the slow-path resolver dispatch
 /// `run_instance_method` (resolve candidate + frame setup + env clone). §B #3680
 /// deleted the tree-walk of the method body, so these now execute the body as
@@ -502,6 +521,24 @@ pub(crate) fn dump() {
             "[mutsu vm-stats] opcodes executed total={} distinct={} (top {}): {}",
             total,
             map.len(),
+            top.len(),
+            top.join(" ")
+        );
+    }
+    if let Ok(map) = function_full_resolve_by_name().lock()
+        && !map.is_empty()
+    {
+        let total: u64 = map.values().sum();
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] function-full-resolve total={} by name (top {}): {}",
+            total,
             top.len(),
             top.join(" ")
         );

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -118,6 +118,22 @@ static GC_ROOTS_SCANNED: AtomicU64 = AtomicU64::new(0);
 static REGEX_CAP_MAKEMUT_TOTAL: AtomicU64 = AtomicU64::new(0);
 static REGEX_CAP_MAKEMUT_SHARED: AtomicU64 = AtomicU64::new(0);
 
+// Regex embedded-code parse cache (REGEX_CODE_PARSE_CACHE) effectiveness.
+static REGEX_CODE_PARSE_HITS: AtomicU64 = AtomicU64::new(0);
+static REGEX_CODE_PARSE_MISSES: AtomicU64 = AtomicU64::new(0);
+
+/// Record one lookup in the regex embedded-code parse cache.
+#[inline]
+pub(crate) fn record_regex_code_parse(hit: bool) {
+    if enabled() {
+        if hit {
+            REGEX_CODE_PARSE_HITS.fetch_add(1, Ordering::Relaxed);
+        } else {
+            REGEX_CODE_PARSE_MISSES.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 /// Record one `Arc::make_mut` on a stored regex capture node; `shared` means
 /// the node had other holders (strong_count > 1) so make_mut deep-copied it.
 #[inline]
@@ -439,6 +455,11 @@ pub(crate) fn dump() {
     let cap_makemut_shared = REGEX_CAP_MAKEMUT_SHARED.load(Ordering::Relaxed);
     eprintln!(
         "[mutsu vm-stats] regex-captures: cap_makemut={cap_makemut_total} shared_deep_copies={cap_makemut_shared}"
+    );
+    let code_parse_hits = REGEX_CODE_PARSE_HITS.load(Ordering::Relaxed);
+    let code_parse_misses = REGEX_CODE_PARSE_MISSES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] regex-code-parse-cache: hits={code_parse_hits} misses={code_parse_misses}"
     );
     let jit_compiles = JIT_COMPILES.load(Ordering::Relaxed);
     let jit_entries = JIT_ENTRIES.load(Ordering::Relaxed);


### PR DESCRIPTION
Two slices toward the yaml-parse-throughput ticket (raku-parity campaign), measured on `benchmarks/bench-yaml-parse.raku` (release, clean idle box):

| binary | median |
|---|---:|
| main (post-#5573) | 3.78s |
| + these two slices | **2.09s (−45%)** |

## 1. Negative gate for function resolution (`fn_base_name_cache`)

`resolve_function_with_types` scanned the entire registry functions map several times per call even when the name has **no registered candidates at all** — the common case for interpreter-native builtins dispatched after a failed user-function resolution. A new `MUTSU_VM_STATS` histogram (`function-full-resolve`) counted **118,675** such walks on the yaml bench: `make`=80,240, `prefix:<~>`=38,418 (both from the grammar-action walk).

A per-name memo now answers "does ANY registry key carry this base name?" in O(1) (base name = key minus package prefix and arity suffix; the same extraction applied to keys and queries, so exotic spellings degrade to consistent no-op buckets, never wrong results). When false, the resolver returns `None` without the walk.

**Soundness**: the memo is guarded by `fn_resolve_gen` — which was only bumped on a few registration paths. This PR adds the missing bumps at every `functions` insert/remove/retain/wholesale-restore site (registration_sub, registration_class_decl, module export/import/require, subtest snapshot restore, EVAL scope restore). That also hardens the pre-existing `multi_candidates_cache`, which had the same latent staleness.

## 2. Embedded-code parse cache (`REGEX_CODE_PARSE_CACHE`)

The main-slang code strings evaluated during regex matching (`{…}` blocks, `<?{…}>` assertions, `<{…}>` interpolations, `** {code}` quantifiers, `:my` declarations) were re-parsed from source per evaluation. They are now memoized per registry generation; hits/misses observable via `MUTSU_VM_STATS`.

## Verified

- full `prove t/` (debug): **24,916 tests PASS**
- `benchmarks/bench-yaml-parse.raku` output unchanged (2 sections, 3 rows)
- clippy `-D warnings` / fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)