### PR TITLE
perf(dispatch): precise fn_resolve_gen bump + frameless-call callframe gate + action-walk early exits

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2030,6 +2030,15 @@ pub(crate) struct CompiledCode {
     /// fast/light call paths, which skip the routine clone-id setup the `once`
     /// store keys on (see `once_scope_key`).
     pub(crate) has_once: bool,
+    /// True if this code observes its caller frame: a `callframe`/`callframes`
+    /// call, or a `CALLER::` pseudo-package read/write op. Set during `emit()`.
+    /// Such a body must be invoked through a frame-pushing call path
+    /// (`push_caller_env`), so the fast/light frameless paths exclude it —
+    /// otherwise `callframe(1)`/`CALLER::` resolve against the *grand*-caller.
+    /// (Historically this was masked by an unconditional `fn_resolve_gen` bump
+    /// after every interpreter-native call, which kept such routines
+    /// permanently out of the name-keyed call caches by accident.)
+    pub(crate) uses_callframe: bool,
     /// True if this code runs an inline body that reads the frame's lexicals *by
     /// name* through a path the `free_var_syms` op-scan cannot see: loop/block
     /// bodies that thread control temps through `env` by name (`ForLoop`,
@@ -2195,6 +2204,7 @@ impl CompiledCode {
             is_routine: false,
             reads_topic: false,
             has_once: false,
+            uses_callframe: false,
             source_line: None,
             is_pointy_block: false,
             has_env_writes: false,
@@ -3755,6 +3765,27 @@ impl CompiledCode {
     pub(crate) fn emit(&mut self, op: OpCode) -> usize {
         if matches!(op, OpCode::OnceExpr { .. }) {
             self.has_once = true;
+        }
+        if !self.uses_callframe {
+            match &op {
+                // A direct `callframe(…)`/`callframes()` call observes the
+                // caller frame; so do the CALLER:: pseudo-package variable ops.
+                OpCode::CallFunc { name_idx, .. } | OpCode::CallFuncNamed { name_idx, .. } => {
+                    if let Some(v) = self.constants.get(*name_idx as usize)
+                        && let ValueView::Str(s) = v.view()
+                        && matches!(s.as_str(), "callframe" | "callframes")
+                    {
+                        self.uses_callframe = true;
+                    }
+                }
+                OpCode::GetCallerVar { .. }
+                | OpCode::SetCallerVar { .. }
+                | OpCode::BindCallerVar { .. }
+                | OpCode::GetCallerOuterVar { .. } => {
+                    self.uses_callframe = true;
+                }
+                _ => {}
+            }
         }
         if !self.has_calls {
             // Every call opcode -- any of these can invoke a callee that writes

--- a/src/runtime/dispatch_resolve.rs
+++ b/src/runtime/dispatch_resolve.rs
@@ -43,6 +43,24 @@ impl Interpreter {
         let base = function_key_base_name(name);
         let base_sym = Symbol::intern(base);
         if let Some(&cached) = self.fn_base_name_cache.get(&base_sym) {
+            // Debug-only staleness audit: recompute and compare, so a
+            // functions-map mutation that missed its `fn_resolve_gen` bump
+            // fails CI's debug `prove t/` with a located panic instead of
+            // surfacing as a silent wrong "Unknown function" in release.
+            #[cfg(debug_assertions)]
+            {
+                let fresh = self
+                    .registry()
+                    .functions
+                    .keys()
+                    .any(|k| function_key_base_name(&k.resolve()) == base);
+                assert_eq!(
+                    fresh, cached,
+                    "stale fn_base_name_cache entry for {name:?} (base {base:?}): \
+                     a registry functions-map mutation missed its fn_resolve_gen \
+                     bump — see fn_base_name_registered in dispatch_resolve.rs"
+                );
+            }
             return cached;
         }
         let found = self

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -795,6 +795,60 @@ impl Interpreter {
         actions: &mut Value,
         rule_name: &str,
     ) -> Result<Value, RuntimeError> {
+        // Fast path: a childless leaf whose rule has no action method — the
+        // overwhelming majority of nodes in a leaf-heavy parse (one node per
+        // matched character in a quoted-scalar run). Returning it untouched
+        // skips the two attribute-map clones, the node rebuild, and the whole
+        // env save/restore ceremony below, none of which can have any effect
+        // for such a node.
+        let leaf_sym_method: Option<String>;
+        let is_actionless_candidate_leaf;
+        if let ValueView::Instance { attributes, .. } = match_obj.view() {
+            let amap = attributes.as_map();
+            let has_named_children = matches!(
+                amap.get("named").map(Value::view),
+                Some(ValueView::Hash(h)) if !h.is_empty()
+            );
+            let has_list_children = matches!(
+                amap.get("list").map(Value::view),
+                Some(ValueView::Array(a, _)) if !a.is_empty()
+            );
+            let has_silent = amap.get("silent_caps").is_some();
+            if !has_named_children && !has_list_children && !has_silent {
+                is_actionless_candidate_leaf = true;
+                leaf_sym_method = match amap.get("sym_variant").map(Value::view) {
+                    Some(ValueView::Str(sym_val)) => {
+                        Some(if sym_val.contains('<') || sym_val.contains('>') {
+                            format!("{rule_name}:sym\u{ab}{}\u{bb}", &*sym_val)
+                        } else {
+                            format!("{rule_name}:sym<{}>", &*sym_val)
+                        })
+                    }
+                    _ => None,
+                };
+            } else {
+                is_actionless_candidate_leaf = false;
+                leaf_sym_method = None;
+            }
+        } else {
+            return Ok(match_obj);
+        }
+        if is_actionless_candidate_leaf {
+            let actions_cn: Option<String> = match actions.view() {
+                ValueView::Instance { class_name, .. } => Some(class_name.to_string()),
+                ValueView::Package(name) => Some(name.to_string()),
+                _ => None,
+            };
+            if let Some(cn) = actions_cn {
+                let sym_hit = leaf_sym_method
+                    .as_deref()
+                    .is_some_and(|s| self.has_user_method(&cn, s));
+                let rule_hit = !rule_name.is_empty() && self.has_user_method(&cn, rule_name);
+                if !sym_hit && !rule_hit {
+                    return Ok(match_obj);
+                }
+            }
+        }
         let (class_name, attributes) = if let ValueView::Instance {
             class_name,
             attributes,
@@ -916,6 +970,44 @@ impl Interpreter {
         // Rebuild match_obj with updated children
         let match_obj = Value::make_instance(class_name, (updated_attrs.clone()).to_map());
 
+        // Interior node with no action method of its own: the children (and
+        // silent captures) above are already dispatched, and none of the env
+        // ceremony below can matter — no method will read `$/`/`$<x>`/`$0…`,
+        // and `make` cannot run. Return the rebuilt node directly. (`$/` is
+        // (re)set by the caller after the walk, so skipping the insert here
+        // does not change what user code observes.)
+        {
+            let no_own_action = {
+                let actions_cn: Option<String> = match actions.view() {
+                    ValueView::Instance { class_name, .. } => Some(class_name.to_string()),
+                    ValueView::Package(name) => Some(name.to_string()),
+                    _ => None,
+                };
+                match actions_cn {
+                    None => false,
+                    Some(cn) => {
+                        let sym_hit =
+                            match updated_attrs.as_map().get("sym_variant").map(Value::view) {
+                                Some(ValueView::Str(sym_val)) => {
+                                    let sym_name = if sym_val.contains('<') || sym_val.contains('>')
+                                    {
+                                        format!("{rule_name}:sym\u{ab}{}\u{bb}", &*sym_val)
+                                    } else {
+                                        format!("{rule_name}:sym<{}>", &*sym_val)
+                                    };
+                                    self.has_user_method(&cn, &sym_name)
+                                }
+                                _ => false,
+                            };
+                        !sym_hit && !self.has_user_method(&cn, rule_name)
+                    }
+                }
+            };
+            if no_own_action {
+                return Ok(match_obj);
+            }
+        }
+
         // Set $/ to this match and try calling actions.{rule_name}(match)
         self.env.insert("/".to_string(), match_obj.clone());
         self.env.remove("made");
@@ -1012,9 +1104,11 @@ impl Interpreter {
             ValueView::Package(name) => Some(name.as_str()),
             _ => None,
         };
+        let mut called_action = false;
         let method_result = if let Some(ref sym_name) = sym_method_name {
             let sym_exists = actions_class_name.is_none_or(|cn| self.has_user_method(cn, sym_name));
             if sym_exists {
+                called_action = true;
                 let result = self.call_method_with_values(
                     actions.clone(),
                     sym_name,
@@ -1036,11 +1130,13 @@ impl Interpreter {
                     other => other,
                 }
             } else if actions_class_name.is_none_or(|cn| self.has_user_method(cn, rule_name)) {
+                called_action = true;
                 self.call_method_with_values(actions.clone(), rule_name, vec![match_obj.clone()])
             } else {
                 Ok(match_obj.clone())
             }
         } else if actions_class_name.is_none_or(|cn| self.has_user_method(cn, rule_name)) {
+            called_action = true;
             self.call_method_with_values(actions.clone(), rule_name, vec![match_obj.clone()])
         } else {
             Ok(match_obj.clone())
@@ -1048,12 +1144,14 @@ impl Interpreter {
 
         // After the method call, if actions is an Instance, its attributes
         // may have been mutated.  Retrieve the updated version from env so
-        // subsequent child/rule calls see the latest state.
-        if let ValueView::Instance {
-            class_name: act_cn,
-            id: act_id,
-            ..
-        } = actions.view()
+        // subsequent child/rule calls see the latest state. Skipped when no
+        // action method was actually invoked — the env scan is O(env) per node.
+        if called_action
+            && let ValueView::Instance {
+                class_name: act_cn,
+                id: act_id,
+                ..
+            } = actions.view()
         {
             for v in self.env.values() {
                 if let ValueView::Instance {

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -288,6 +288,16 @@ impl Interpreter {
         crate::runtime::registry::RegistryReadGuard::new(&self.registry, "registry")
     }
 
+    /// Current registry write generation — bumped on every `registry_mut()`
+    /// acquisition. Lets callers detect "did anything take a registry write
+    /// guard across this call?" (e.g. to invalidate name-keyed resolution
+    /// caches only when the function set could actually have changed).
+    #[inline]
+    pub(crate) fn registry_write_generation(&self) -> u64 {
+        self.registry_write_gen
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Write access to the shared declaration [`Registry`]. Same guard discipline
     /// as [`Self::registry`].
     #[inline]

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -39,6 +39,9 @@ impl Interpreter {
             && !fn_name.is_empty()
             // A `once` needs the clone-id setup only the full call path performs.
             && !cf.code.has_once
+            // A body observing its caller frame (callframe / CALLER::) needs the
+            // frame-pushing path, or introspection resolves to the grand-caller.
+            && !cf.code.uses_callframe
     }
 
     /// Check if a compiled function is eligible for the light call path.
@@ -64,6 +67,8 @@ impl Interpreter {
             && !cf.empty_sig
             // A `once` needs the clone-id setup only the full call path performs.
             && !cf.code.has_once
+            // callframe / CALLER:: need the frame-pushing path (see fast path).
+            && !cf.code.uses_callframe
             && !cf.param_defs.is_empty()
             && cf.param_defs.iter().any(|pd| pd.named)
             && cf.param_defs.iter().all(|pd| {
@@ -115,6 +120,8 @@ impl Interpreter {
             && !cf.has_inner_subs
             // A `once` needs the clone-id setup only the full call path performs.
             && !cf.code.has_once
+            // callframe / CALLER:: need the frame-pushing path (see fast path).
+            && !cf.code.uses_callframe
             // Only allow return types that light_return_type_check can handle
             && cf
                 .return_type

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1421,14 +1421,22 @@ impl Interpreter {
                     // env. With the Any seed (PLAN 8.5 step 3) the slot holds
                     // a real value, so the writeback must be explicit
                     // (t/require-expression.t `BEGIN try EVAL`).
+                    let reg_gen_before = self.registry_write_generation();
                     let carrier_saved = self.begin_carrier();
                     let result = self.vm_call_function(name, args);
                     let written = self.end_carrier(carrier_saved);
                     self.writeback_carrier_writes(code, &written);
                     self.set_pending_call_arg_sources(None);
                     // Interpreter function calls (e.g. `require`) may register
-                    // new subs — invalidate function resolution caches.
-                    self.fn_resolve_gen += 1;
+                    // new subs — invalidate function resolution caches. Only
+                    // when the call actually acquired a registry write guard,
+                    // though: a blanket bump here cleared the name-keyed caches
+                    // after EVERY interpreter-native builtin call (`make`, in a
+                    // grammar-action walk, is one per action), forcing a full
+                    // registry rescan per call.
+                    if self.registry_write_generation() != reg_gen_before {
+                        self.fn_resolve_gen += 1;
+                    }
                     // substr-rw returns a Proxy that must be preserved (not auto-FETCHed)
                     let auto_fetch = name != "substr-rw";
                     let result = result?;

--- a/todo/tickets/yaml-parse-throughput.md
+++ b/todo/tickets/yaml-parse-throughput.md
@@ -1,5 +1,37 @@
 # Parsing YAML with the bundled `YAMLish` is still ~5-35x slower than raku
 
+**Update (2026-07-30, round 4): ~7x now.** The dominant cost was not the regex
+engine at all — it was the **grammar-action walk's function dispatch**. On
+`benchmarks/bench-yaml-parse.raku` (release, clean idle box), main went
+3.95s → **1.73s** across PRs #5573/#5574/#5575, vs raku 0.25s on the same box:
+
+- Reduce-walk `Arc::make_mut` deep copies: 40,297 → 0 (#5573; counted, no
+  wall-clock change — ADR-0016 correctly predicted this class was noise-level).
+- Embedded-code parse cache (`REGEX_CODE_PARSE_CACHE`, #5574): `{…}`/`<?{…}>`/
+  `** {code}` strings parsed once per registry generation.
+- **Negative function-resolution gate** (#5574, the big one, −45%): the action
+  walk resolved `make` (80,240×) and `prefix:<~>` (38,418×) through the full
+  registry-scanning `resolve_function_with_types` walk, failing every time
+  (neither is a registered function). A per-name "does any registry key carry
+  this base name?" memo (`fn_base_name_cache`) short-circuits it.
+- **Precise `fn_resolve_gen` bump** (#5575, −16%): the interpreter-fallback
+  call arm bumped the gen after EVERY native-builtin call, clearing all
+  name-keyed call caches once per `make`; now it bumps only when the call
+  actually acquired a registry write guard. This exposed (and #5575 fixes) a
+  latent bug the churn had been masking: the frameless fast/light call paths
+  ran `callframe`/`CALLER::`-using bodies without pushing a caller frame
+  (new `CompiledCode::uses_callframe` compile-time gate; pin
+  `t/source-line-table.t`).
+- Leaf/interior early-exits in `invoke_grammar_actions` (#5575): childless
+  no-action nodes skip the attribute-map clones, node rebuild and env
+  save/restore ceremony entirely.
+
+Remaining (next session): module load is now ~19% of the bench (YAMLish parse
+per process — raku wins this via precompilation), the action-method call
+ceremony (`call_method_with_values` → `run_instance_method`) is ~50%
+inclusive, and the ADR-0016 P2+ structural work (CapNode split, spans,
+lazy Match) still stands for the allocator/memcmp tail.
+
 The YAML battery is correct — all 5 upstream files (81/81 subtests) pass — but it
 is **slow**, and the cost is in *matching*, not module load. This is the
 match-time twin of `grammar-heavy-module-load-slower-than-raku.md`; that ticket

--- a/todo/tickets/yaml-parse-throughput.md
+++ b/todo/tickets/yaml-parse-throughput.md
@@ -26,11 +26,20 @@ engine at all — it was the **grammar-action walk's function dispatch**. On
   no-action nodes skip the attribute-map clones, node rebuild and env
   save/restore ceremony entirely.
 
-Remaining (next session): module load is now ~19% of the bench (YAMLish parse
-per process — raku wins this via precompilation), the action-method call
-ceremony (`call_method_with_values` → `run_instance_method`) is ~50%
-inclusive, and the ADR-0016 P2+ structural work (CapNode split, spans,
-lazy Match) still stands for the allocator/memcmp tail.
+Remaining (next session): the action-method call ceremony
+(`call_method_with_values` → `run_instance_method`) is ~50% inclusive, and
+the ADR-0016 P2+ structural work (CapNode split, spans, lazy Match) still
+stands for the allocator/memcmp tail.
+
+(A profile taken right after a rebuild shows `load_module`/`parse_program` at
+~19% — that is the **cold first run only**: the disk precomp cache
+(`src/precomp.rs`) keys on the executable's mtime, so every fresh build parses
+each module once and re-caches. Measured warm vs `MUTSU_PRECOMP=0` on the
+bench: 1.72s vs 1.82s, i.e. the whole parse+cache path is ~0.1s (~6%) per
+cold run and ~0 warm; `use YAMLish` alone is 0.02s warm / 0.04s uncached.
+Precomp covers the AST only — token/rule regex-slang bodies still parse
+per process at match time into the in-memory `REGEX_PARSE_CACHE` — but that
+cost is inside the ~0.1s, so on-disk regex precomp is NOT a promising lead.)
 
 The YAML battery is correct — all 5 upstream files (81/81 subtests) pass — but it
 is **slow**, and the cost is in *matching*, not module load. This is the


### PR DESCRIPTION
Follow-up to #5574 on the yaml-parse raku-parity campaign. `benchmarks/bench-yaml-parse.raku` (release, clean idle box): 2.07s → **1.73s** (main was 3.95s two PRs ago; raku 0.25s same box, gap now ~6.9x).

## 1. Precise `fn_resolve_gen` bump

The interpreter-fallback call arm bumped the generation after **every** interpreter-native builtin call ("require may register subs"), clearing all name-keyed resolution caches once per `make` during a grammar-action walk — **40,121 cache clears / 78,543 full registry rescans** on the yaml bench (counted with gdb ignore-counts). It now bumps only when the call actually acquired a registry write guard (`registry_write_generation()` delta): clears drop to **13**.

## 2. `uses_callframe` gate for frameless call paths (bug fix)

The blanket bump had been **masking a real bug**: with caches now persisting, a zero-arg sub whose body calls `callframe()` / reads `CALLER::` could be dispatched through the cached fast/light frameless paths, which skip `push_caller_env` — so `callframe(1)` resolved against the grand-caller (or the synthetic setting frame, line 1). Historically such subs were kept out of the caches *by accident*: their own `callframe` call bumped the gen every time.

New `CompiledCode::uses_callframe` flag (set in `emit()` for `callframe`/`callframes` calls and the `CALLER::` variable ops) excludes such bodies from all three frameless eligibility checks. Pin: `t/source-line-table.t` (failed 4 subtests with the precise bump alone).

## 3. `invoke_grammar_actions` early exits

- A childless leaf whose rule has no action method returns untouched — no attribute-map clones, no node rebuild, no env save/restore ceremony (the dominant node kind in leaf-heavy parses).
- An interior node with no own action method skips the env ceremony after its children are walked.
- The O(env) actions-instance rescan runs only when an action method was actually invoked.

## Cache-soundness hardening

`fn_base_name_cache` gets a **debug-only staleness audit** (recompute + assert on every hit). CI runs `prove t/` on the **debug** binary, so a future functions-map mutation that misses its `fn_resolve_gen` bump fails loudly with a located panic instead of silently mis-resolving in release.

## Verified

- full `prove t/` (24,916 tests) PASS on debug (staleness audit active)
- **full local `make roast` (218,774 tests) PASS** on the release binary (fingerprint-verified to include these changes)
- clippy `-D warnings` / fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)