### PR TITLE
perf(dispatch): Match Str-coerce fast path + negative-gate call-site scans + accessor query without clones

### DIFF
--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -249,11 +249,28 @@ impl Interpreter {
     }
 
     /// Check if a class has a public attribute accessor for the given name.
+    ///
+    /// The most-derived declaration of an attribute name decides its
+    /// visibility (mirroring `collect_class_attributes`' override-by-name
+    /// merge), so walk the MRO derived-first and stop at the first class
+    /// declaring the name instead of cloning the whole merged attribute list
+    /// per query — this sits on the per-call method-dispatch path.
     pub(crate) fn has_public_accessor(&mut self, class_name: &str, method_name: &str) -> bool {
-        let attrs = self.collect_class_attributes(class_name);
-        attrs
-            .iter()
-            .any(|(attr_name, is_public, ..)| *is_public && attr_name == method_name)
+        let mro = self.class_mro(class_name);
+        for cn in mro.iter() {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str())
+                // Within one class a later same-name declaration overrides an
+                // earlier one (collect_class_attributes' remove-then-push).
+                && let Some((_, is_public, ..)) = class_def
+                    .attributes
+                    .iter()
+                    .rev()
+                    .find(|(n, ..)| n == method_name)
+            {
+                return *is_public;
+            }
+        }
+        false
     }
 
     /// Decide, per MRO level, whether an explicit user method or a public

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -617,9 +617,15 @@ impl Interpreter {
             // this branch prevents regressions where dispatching through
             // `call_sub_value` behaves differently (e.g. dynamic `$*ERR`
             // handling for `note` inside a caller-provided block).
-            if self.has_proto(name_str)
-                || self.has_multi_candidates(name_str)
+            // Pure disjunction — every arm yields `None` — so order it
+            // cheapest-first: the base-name negative gate (#5574) short-
+            // circuits the whole check for a builtin like `make` (no registry
+            // key carries the name, so `has_function` is false), and the
+            // multi-candidates full-map scan runs last, memoized.
+            if !self.fn_base_name_registered(name_str)
                 || !self.has_function(name_str)
+                || self.has_proto(name_str)
+                || self.has_multi_candidates_cached(name_str)
             {
                 None
             } else {

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -200,7 +200,14 @@ impl Interpreter {
             .cloned()
             .map(Self::unwrap_var_ref_value)
             .collect();
-        if self.has_declared_function(name) || self.has_multi_function(name) || self.has_proto(name)
+        // `fn_base_name_registered` is the cheap negative gate (#5574): when no
+        // registry key carries this base name, `has_declared_function` and
+        // `has_multi_function` (a full functions-map scan) cannot match, so a
+        // builtin like `make` skips both. `has_proto` reads a separate map and
+        // stays unguarded.
+        if (self.fn_base_name_registered(name)
+            && (self.has_declared_function(name) || self.has_multi_function(name)))
+            || self.has_proto(name)
         {
             raw_args
         } else {

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -172,6 +172,30 @@ impl Interpreter {
                 return Ok(());
             }
         }
+        // Grammar-hot fast path: `~$match` on a plain `Match` instance is the
+        // dominant Str coercion in grammar-action code (one `~$<key>` per
+        // capture). Match is a builtin class whose `.Str` is the stored `str`
+        // attribute, so read it directly instead of paying the generic
+        // Stringy-then-Str method-dispatch ceremony below. Only a user augment
+        // of `Match.Stringy`/`Match.Str` (or a `prefix:<~>` overload, already
+        // checked above) could observe the difference — gate on those.
+        if let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = val.view()
+            && class_name == "Match"
+            && !self.has_user_method("Match", "Stringy")
+            && !self.has_user_method("Match", "Str")
+        {
+            let s = attributes
+                .as_map()
+                .get("str")
+                .cloned()
+                .unwrap_or_else(|| Value::str(String::new()));
+            self.stack.push(s);
+            return Ok(());
+        }
         // If the value is an Instance, try calling the Stringy method, then Str
         if let ValueView::Instance { .. } = val.view() {
             // Slice F: a user `Stringy`/`Str` method can mutate a captured-outer

--- a/t/str-coerce-match-fastpath.t
+++ b/t/str-coerce-match-fastpath.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+# Pins the `~Match` Str-coercion fast path (exec_str_coerce_op): a plain
+# Match stringifies to its matched text, and a user-defined prefix:<~>
+# overload must still be consulted BEFORE the fast path reads the `str`
+# attribute directly.
+
+plan 5;
+
+my $m = "abcdef" ~~ /b.d/;
+is ~$m, "bcd", 'prefix:<~> on a Match returns the matched string';
+isa-ok ~$m, Str, '~Match yields a Str';
+is "$m", "bcd", 'string interpolation of a Match';
+is ~($m<>), "bcd", '~ on a decontainerized Match';
+
+{
+    multi sub prefix:<~>(Match $x) { "overloaded" }
+    my $n = "xyz" ~~ /y/;
+    is ~$n, "overloaded", 'a user prefix:<~> overload beats the Match fast path';
+}

--- a/todo/tickets/yaml-parse-throughput.md
+++ b/todo/tickets/yaml-parse-throughput.md
@@ -1,5 +1,43 @@
 # Parsing YAML with the bundled `YAMLish` is still ~5-35x slower than raku
 
+**Update (2026-07-31, round 5): ~5x now.** The action-walk call ceremony named
+by round 4 broke down into three independent per-call costs, all removed
+(`benchmarks/bench-yaml-parse.raku`, release, clean idle box: 1.70s → **1.27s**,
+−25%; the 5 upstream YAMLish files run in ~11s total, was ~26s):
+
+- **`~$<key>` Str coercion of a Match paid a two-stage method-dispatch
+  ceremony** (13.9% of the profile): `exec_str_coerce_op` routed every Match
+  instance through `try_compiled_method_or_interpret("Stringy")` →
+  `call_method_with_values` → `should_bypass_native_fastpath` (a ~20-arm
+  predicate chain) → `run_instance_method` → the native handler that finally
+  read the `str` attribute. A grammar action does this once per capture. Now a
+  plain `Match` (no user augment of `Match.Str`/`Stringy`, no `prefix:<~>`
+  overload) reads the `str` attribute directly in the opcode.
+- **Every `make(...)` call re-scanned the whole functions registry twice**
+  (~10%): the lexical-`&name`-override gate in `exec_call_func_op` called the
+  uncached `has_multi_candidates` (full functions-map key scan), and
+  `normalize_call_args_for_target` called `has_multi_function` (same scan) plus
+  `has_declared_function` — for a name (`make`) that is not a registered
+  function at all. Both sites now short-circuit through the #5574
+  `fn_base_name_registered` negative gate (and the override gate checks the
+  cheap `!has_function` before the memoized `has_multi_candidates_cached`).
+- **`has_public_accessor` cloned the class's whole merged attribute list per
+  query** (~4%, on the per-call dispatch path via `call_method_with_values`):
+  `collect_class_attributes` builds and clones a deduplicated
+  `Vec<ClassAttributeDef>` across the MRO. The query now walks the MRO
+  derived-first and stops at the first class declaring the name — same
+  override-by-name semantics, no clones.
+
+Remaining leads, from the round-5 profile: the ceremony *between*
+`call_method_with_values` and the JIT-compiled action body is still ~15-20
+points deep (`dispatch_instance_and_fallback` → `run_instance_method[_celled]`
+→ `call_compiled_method[_fast]` → `vm_jit::try_enter`, each layer shaving
+2-8%); `Interpreter::new` is ~4.7% of the run (~80ms, one-time startup cost of
+every mutsu invocation — a separate lead, not match-time); and the ADR-0016
+P2+ structural work (CapNode split, spans, lazy Match) still stands for the
+allocator/memcmp tail (`_int_free`+`malloc`+`memmove` ≈ 23%,
+`LocalKey::with` TLS ≈ 12%).
+
 **Update (2026-07-30, round 4): ~7x now.** The dominant cost was not the regex
 engine at all — it was the **grammar-action walk's function dispatch**. On
 `benchmarks/bench-yaml-parse.raku` (release, clean idle box), main went


### PR DESCRIPTION
## Summary

Round 5 of the yaml-parse throughput campaign (`todo/tickets/yaml-parse-throughput.md`): the round-4 profile named the grammar-action call ceremony as the next dominant cost. A warm profile (precomp cache properly warmed — the earlier ~19% "module load" reading was a cold-cache artifact) broke it into three independent per-call costs, all removed here.

**`benchmarks/bench-yaml-parse.raku` (release, idle box): 1.70s → 1.27s (−25%)**, raku ratio ~6.9x → ~5.1x. The 5 upstream YAMLish files run in ~11s total (was ~26s), still 81/81.

- **`~$<key>` Str coercion of a Match paid a two-stage method-dispatch ceremony** (13.9% of the profile): `exec_str_coerce_op` routed every Match instance through `try_compiled_method_or_interpret("Stringy")` → `call_method_with_values` → `should_bypass_native_fastpath` (a ~20-arm predicate chain) → `run_instance_method` → the native handler that finally reads the `str` attribute — once per capture in action code. A plain `Match` now reads the attribute directly in the opcode. The `prefix:<~>` overload check stays *ahead* of the fast path, and a user augment of `Match.Str`/`Stringy` falls back to the old path via `has_user_method` (behavior verified identical to main; rakudo SORRYs on that augment anyway). Pin: `t/str-coerce-match-fastpath.t` (also green under raku).

- **Every `make(...)` call re-scanned the whole functions registry twice** (~10%): the lexical-`&name`-override gate in `exec_call_func_op` used the *uncached* `has_multi_candidates` (full functions-map key scan), and `normalize_call_args_for_target` used `has_multi_function` (same scan) plus `has_declared_function` — for a name that is not a registered function at all. Both sites now short-circuit through the #5574 `fn_base_name_registered` negative gate (sound: every predicate they gate only matches keys whose base name equals the query's base name), and the override gate checks the cheap `!has_function` before the memoized `has_multi_candidates_cached`. Both rewrites are pure disjunctions — same outcome, cheaper order.

- **`has_public_accessor` cloned the class's whole merged attribute list per query** (~4%, on the per-call dispatch path): `collect_class_attributes` builds and clones a deduplicated `Vec<ClassAttributeDef>` across the MRO. The query now walks the MRO derived-first and stops at the first class declaring the name — same override-by-name semantics (most-derived declaration decides; within a class the last same-name declaration wins), no clones.

## Verification

- Local full `make test`: 24,916 tests PASS
- Local full `make roast`: 218,774 tests PASS
- YAMLish upstream suite: 81/81 (all 5 files)
- `cargo clippy -- -D warnings` / `cargo fmt --check` clean
- New pin `t/str-coerce-match-fastpath.t` passes under both mutsu and raku

🤖 Generated with [Claude Code](https://claude.com/claude-code)