### PR TITLE
perf(regex): split stored captures into lightweight CapNode (ADR-0016 P2)

### DIFF
--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -232,6 +232,16 @@ alone is 0.04 s of its ~4.07 s, so it is not module-load dominated.)
 collapses its child collections to a single `None` (`children: Option<Box<CapChildren>>`),
 which is where the order-of-magnitude shrink comes from; it also takes the
 `Vec<(usize, RegexCaptures)>` candidate-list memmove with it.
+**Landed 2026-07-31** (`news/2026-07/regex-capnode-split.md`): `CapNode` =
+`matched`/`from`/`to`/`sym`/`action_name`/`ast` + `children: Option<Box<CapChildren>>`,
+≤112 bytes for a leaf (pinned by `cap_node_size_guard`); conversion via
+`RegexCaptures::into_cap_node()` at the ~10 storage sites; the reduce walk and the
+failed-parse replay recurse over `CapNode`; the accumulator-only fields
+(`hash_captures`, `positional_slots`, `positional_offsets`, capture markers,
+`match_from`) are dropped at conversion — nothing ever read them through a stored node.
+Note: the candidate lists themselves still move `RegexCaptures` deltas (ADR-0007's
+delta protocol); their per-delta cost now shrinks with P4's axis collapse rather than
+with this phase.
 **Start by counting the reduce-walk copies** (see P1's measurement note — guessing at
 this already cost one rejected hypothesis): every `Arc::make_mut` on a *stored* node is a
 deep copy whenever anything else holds a handle, and `snapshot()` alone is enough to make

--- a/news/2026-07/regex-capnode-split.md
+++ b/news/2026-07/regex-capnode-split.md
@@ -1,0 +1,40 @@
+# Stored regex captures split into lightweight `CapNode`s (ADR-0016 P2)
+
+`RegexCaptures` used to play two roles at once: the regex engine's *mutable
+accumulator* for the pattern run in progress, and the *immutable stored node*
+behind every `Arc<RegexCaptures>` sub-capture. A stored node only needs its
+span, text, dispatch metadata (`sym`/`action_name`/`ast`), and — rarely —
+children; it got all 14 fields anyway: 5 `HashMap`s, 1 `HashSet`, 7 `Vec`s and
+a `String`, ~600 zeroed bytes per node, moved by value through candidate lists
+and cloned per complete match. For a leaf-heavy grammar parse (YAMLish produces
+one leaf capture per matched character in a run of spaces) that shape was a
+large part of the allocator floor a clean profile shows (~23-28%).
+
+This lands ADR-0016 **P2**: a new `CapNode` — `matched`/`from`/`to`/`sym`/
+`action_name`/`ast` plus `children: Option<Box<CapChildren>>` — is now the
+stored-node type on all three sub-capture axes (`named_subcaps`,
+`positional_subcaps`, quantified entries) and in the `REDUCED_SUBRULES` replay
+log. A leaf collapses every child collection into a single `None`, taking a
+stored leaf from ~600 bytes to under 112 (pinned by `cap_node_size_guard`).
+`RegexCaptures` remains the accumulator only; conversion happens once per
+stored node (`into_cap_node()`) at the ~10 sites that previously wrapped an
+accumulator in an `Arc`. Fields nothing ever read through a stored node
+(`hash_captures`, `positional_slots`, `positional_offsets`, capture markers,
+`match_from`) are dropped at conversion instead of being carried around.
+
+The reduce-time walk (`reduce_regex_captures_made`) and the failed-parse
+action replay now recurse over `CapNode` directly; the block-running body and
+the children-first descent are shared helpers (`reduce_run_code_blocks`,
+`reduce_child_axes`) between the accumulator top level and stored nodes, and
+`subtree_has_code_blocks` answers `false` for a leaf in one branch instead of
+scanning three empty collections.
+
+No observable semantics change. Validated locally with the full `t/` suite
+(24,921 tests) and a full `make roast` run before push. Perf is to be judged
+from `bench-history.tsv` on the `bench-data` branch per the standing rule —
+the structural claim (leaf nodes shrink ~5x, `RegexCaptures::default()` zeroes
+much less per candidate) holds regardless.
+
+Next phases: P3 (spans + shared `MatchTarget` subject, killing the Match
+builder's position search), P4 (one list per axis + interned names), P5 (lazy
+`Match` materialization).

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -644,6 +644,24 @@ impl Interpreter {
         )
     }
 
+    /// [`Self::match_object_from_captures`] for a stored capture node.
+    fn match_object_from_cap_node(node: &CapNode, text: &str) -> Value {
+        let kids = node.kids();
+        Value::make_match_object_full_q(
+            node.matched.clone(),
+            node.from as i64,
+            node.to as i64,
+            &kids.positional,
+            &kids.named,
+            &kids.named_subcaps,
+            &kids.positional_subcaps,
+            &kids.positional_quantified,
+            &kids.positional_nil,
+            Some(text),
+            &kids.named_quantified,
+        )
+    }
+
     /// Run the actions over the match tree of a parse that FAILED because the
     /// start rule covered only part of the input: Rakudo dispatched every one of
     /// them at reduce time, including the start rule's own. Anything that reduced
@@ -698,7 +716,7 @@ impl Interpreter {
         if entries.is_empty() {
             return Ok(());
         }
-        let outside: Vec<(String, std::sync::Arc<RegexCaptures>)> = entries
+        let outside: Vec<(String, std::sync::Arc<CapNode>)> = entries
             .into_iter()
             .filter(|(_, caps)| {
                 !covered.is_some_and(|(from, to)| caps.from >= from && caps.to <= to)
@@ -708,7 +726,7 @@ impl Interpreter {
         // `token a { <b> }` where both cover the same text) keep the LAST logged
         // one, which is the outer rule: the matcher recurses, so children are
         // logged before their parent.
-        let maximal: Vec<&(String, std::sync::Arc<RegexCaptures>)> = outside
+        let maximal: Vec<&(String, std::sync::Arc<CapNode>)> = outside
             .iter()
             .enumerate()
             .filter(|(i, (_, e))| {
@@ -725,8 +743,8 @@ impl Interpreter {
         let mut result = Ok(());
         for (rule, caps) in maximal {
             let mut caps = (**caps).clone();
-            self.reduce_regex_captures_made(&mut caps, Some(text));
-            let match_obj = Self::match_object_from_captures(&caps, text);
+            self.reduce_cap_node_for_rule(&mut caps, Some(text), None);
+            let match_obj = Self::match_object_from_cap_node(&caps, text);
             let dispatch = Self::get_action_name(&match_obj).unwrap_or_else(|| rule.clone());
             if let Err(e) = self.invoke_grammar_actions(match_obj, actions, &dispatch) {
                 result = Err(e);

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -473,7 +473,7 @@ impl Interpreter {
     /// any `$*` dynamic-var writes it makes into the reduce-time overlay. The
     /// scratch is seeded with the overlay's current values so the action sees the
     /// latest dynamic state; only vars whose value actually changes are published.
-    fn run_reduce_time_action(&self, sub: &RegexCaptures, rule_name: &str, actions: Value) {
+    fn run_reduce_time_action(&self, sub: &CapNode, rule_name: &str, actions: Value) {
         // Run on an INDEPENDENT deep copy of the actions object so any `self`
         // attribute the action mutates does not leak into the real actions
         // object — the authoritative post-parse action pass will run again and is
@@ -509,18 +509,19 @@ impl Interpreter {
             }
             _ => actions.clone(),
         };
+        let kids = sub.kids();
         let match_obj = Value::make_match_object_full_q(
             sub.matched.clone(),
             sub.from as i64,
             sub.to as i64,
-            &sub.positional,
-            &sub.named,
-            &sub.named_subcaps,
-            &sub.positional_subcaps,
-            &sub.positional_quantified,
-            &sub.positional_nil,
+            &kids.positional,
+            &kids.named,
+            &kids.named_subcaps,
+            &kids.positional_subcaps,
+            &kids.positional_quantified,
+            &kids.positional_nil,
             None,
-            &sub.named_quantified,
+            &kids.named_quantified,
         );
         let mut scratch = Interpreter {
             env: self.env.clone(),

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -411,47 +411,12 @@ impl Interpreter {
         // a child's code block accumulates into this match's binding (the
         // `:my %*PLAYED = (); <card>+` shape) rather than a sibling match's.
         let declared_keys = self.install_fresh_rule_dynvars(rule_name);
-        // The walk mutates a node only to take/run its code blocks (writing
-        // `ast`) or to record per-rule dynvar bindings. A subtree with no code
-        // blocks anywhere — the overwhelmingly common case for a leaf-heavy
-        // grammar parse — is left byte-identical, so descending into it through
-        // `Arc::make_mut` would only deep-copy shared nodes (each is already in
-        // `REDUCED_SUBRULES` and/or a `snapshot()`) for nothing. Skip those
-        // subtrees outright. Only sound when no rule declares `:my $*x` dynvars
-        // (a declaring rule must run even without blocks); such grammars are
-        // rare and keep the full walk.
-        let skip_untouched = self.grammar_rule_dynvar_decls.is_empty();
-        // Children first so a parent block reading a child's `.made` sees it.
-        for (key, scs) in caps.named_subcaps.iter_mut() {
-            let child_rule = Self::reduce_child_rule_name(key);
-            for sc in scs.iter_mut() {
-                if skip_untouched && !Self::subtree_has_code_blocks(sc) {
-                    continue;
-                }
-                crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
-                let sc = Arc::make_mut(sc);
-                let child_rule = sc.action_name.clone().unwrap_or(child_rule.clone());
-                self.reduce_regex_captures_made_for_rule(sc, orig, Some(&child_rule));
-            }
-        }
-        for sc in caps.positional_subcaps.iter_mut().flatten() {
-            if skip_untouched && !Self::subtree_has_code_blocks(sc) {
-                continue;
-            }
-            crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
-            self.reduce_regex_captures_made(Arc::make_mut(sc), orig);
-        }
-        for pq in caps.positional_quantified.iter_mut().flatten() {
-            for entry in pq.iter_mut() {
-                if let Some(sc) = entry.3.as_mut() {
-                    if skip_untouched && !Self::subtree_has_code_blocks(sc) {
-                        continue;
-                    }
-                    crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
-                    self.reduce_regex_captures_made(Arc::make_mut(sc), orig);
-                }
-            }
-        }
+        self.reduce_child_axes(
+            &mut caps.named_subcaps,
+            &mut caps.positional_subcaps,
+            &mut caps.positional_quantified,
+            orig,
+        );
         if caps.code_blocks.is_empty() {
             // Even with no code blocks of its own, a declaring match must record
             // what its binding holds — its action still reads it, and a sibling
@@ -460,9 +425,9 @@ impl Interpreter {
             return;
         }
         // Build this node's Match so `$<name>` can carry the children's asts. The
-        // block's `$/` still comes from its own matched-so-far context (below), so
-        // a mid-rule `{ … $/ … }` sees the prefix — only the child `.made` values
-        // read via `$<name>` / `$<name>».made` come from here.
+        // block's `$/` still comes from its own matched-so-far context (inside
+        // `reduce_run_code_blocks`), so a mid-rule `{ … $/ … }` sees the prefix —
+        // only the child `.made` values read via `$<name>` come from here.
         let node_match = Value::make_match_object_full_q(
             caps.matched.clone(),
             caps.from as i64,
@@ -476,6 +441,126 @@ impl Interpreter {
             orig,
             &caps.named_quantified,
         );
+        let blocks = std::mem::take(&mut caps.code_blocks);
+        caps.ast = self.reduce_run_code_blocks(blocks, node_match);
+        self.record_rule_dynvars(caps, &declared_keys);
+    }
+
+    /// [`Self::reduce_regex_captures_made_for_rule`] for a stored capture node
+    /// (ADR-0016 P2: stored nodes are `CapNode`, not accumulators).
+    pub(in crate::runtime) fn reduce_cap_node_for_rule(
+        &mut self,
+        node: &mut CapNode,
+        orig: Option<&str>,
+        rule_name: Option<&str>,
+    ) {
+        let declared_keys = self.install_fresh_rule_dynvars(rule_name);
+        if let Some(kids) = node.children.as_deref_mut() {
+            self.reduce_child_axes(
+                &mut kids.named_subcaps,
+                &mut kids.positional_subcaps,
+                &mut kids.positional_quantified,
+                orig,
+            );
+        }
+        let has_blocks = node
+            .children
+            .as_deref()
+            .is_some_and(|k| !k.code_blocks.is_empty());
+        if !has_blocks {
+            // Even with no code blocks of its own, a declaring match must record
+            // what its binding holds — its action still reads it, and a sibling
+            // that DOES have a block would otherwise decide the value.
+            if !declared_keys.is_empty() {
+                self.record_cap_node_dynvars(node, &declared_keys);
+            }
+            return;
+        }
+        // Build this node's Match so `$<name>` can carry the children's asts.
+        let (matched, from, to) = (node.matched.clone(), node.from, node.to);
+        let kids = node
+            .children
+            .as_deref_mut()
+            .expect("has_blocks implies kids");
+        let node_match = Value::make_match_object_full_q(
+            matched,
+            from as i64,
+            to as i64,
+            &kids.positional,
+            &kids.named,
+            &kids.named_subcaps,
+            &kids.positional_subcaps,
+            &kids.positional_quantified,
+            &kids.positional_nil,
+            orig,
+            &kids.named_quantified,
+        );
+        let blocks = std::mem::take(&mut kids.code_blocks);
+        node.ast = self.reduce_run_code_blocks(blocks, node_match);
+        self.record_cap_node_dynvars(node, &declared_keys);
+    }
+
+    /// The children-first part of the reduce walk, shared between the top-level
+    /// accumulator and stored `CapNode`s (their child axes are the same types).
+    fn reduce_child_axes(
+        &mut self,
+        named_subcaps: &mut HashMap<String, Vec<Arc<CapNode>>>,
+        positional_subcaps: &mut [Option<Arc<CapNode>>],
+        positional_quantified: &mut [Option<Vec<QuantifiedCaptureEntry>>],
+        orig: Option<&str>,
+    ) {
+        // The walk mutates a node only to take/run its code blocks (writing
+        // `ast`) or to record per-rule dynvar bindings. A subtree with no code
+        // blocks anywhere — the overwhelmingly common case for a leaf-heavy
+        // grammar parse — is left byte-identical, so descending into it through
+        // `Arc::make_mut` would only deep-copy shared nodes (each is already in
+        // `REDUCED_SUBRULES` and/or a `snapshot()`) for nothing. Skip those
+        // subtrees outright. Only sound when no rule declares `:my $*x` dynvars
+        // (a declaring rule must run even without blocks); such grammars are
+        // rare and keep the full walk.
+        let skip_untouched = self.grammar_rule_dynvar_decls.is_empty();
+        // Children first so a parent block reading a child's `.made` sees it.
+        for (key, scs) in named_subcaps.iter_mut() {
+            let child_rule = Self::reduce_child_rule_name(key);
+            for sc in scs.iter_mut() {
+                if skip_untouched && !Self::subtree_has_code_blocks(sc) {
+                    continue;
+                }
+                crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
+                let sc = Arc::make_mut(sc);
+                let child_rule = sc.action_name.clone().unwrap_or(child_rule.clone());
+                self.reduce_cap_node_for_rule(sc, orig, Some(&child_rule));
+            }
+        }
+        for sc in positional_subcaps.iter_mut().flatten() {
+            if skip_untouched && !Self::subtree_has_code_blocks(sc) {
+                continue;
+            }
+            crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
+            self.reduce_cap_node_for_rule(Arc::make_mut(sc), orig, None);
+        }
+        for pq in positional_quantified.iter_mut().flatten() {
+            for entry in pq.iter_mut() {
+                if let Some(sc) = entry.3.as_mut() {
+                    if skip_untouched && !Self::subtree_has_code_blocks(sc) {
+                        continue;
+                    }
+                    crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
+                    self.reduce_cap_node_for_rule(Arc::make_mut(sc), orig, None);
+                }
+            }
+        }
+    }
+
+    /// Run one node's inline `{ … }` code blocks against its reduced Match and
+    /// return the produced `make` value. Shared by the accumulator and
+    /// `CapNode` reduce paths; the caller supplies `node_match` (built from its
+    /// own fields) and stores the returned `ast`.
+    fn reduce_run_code_blocks(
+        &mut self,
+        blocks: Vec<CodeBlockContext>,
+        node_match: Value,
+    ) -> Option<Value> {
         // Named captures carrying a child `.made` (from the recursion above).
         let ast_named: Vec<(String, Value)> =
             if let ValueView::Instance { attributes, .. } = node_match.view() {
@@ -489,7 +574,6 @@ impl Interpreter {
             } else {
                 Vec::new()
             };
-        let blocks = std::mem::take(&mut caps.code_blocks);
         let saved_match = self.env.get("/").cloned();
         // Fresh `make` slot for this node (do not inherit a sibling's value).
         self.env.remove("made");
@@ -525,32 +609,36 @@ impl Interpreter {
             }
             self.eval_regex_code_block_body(&stmts);
         }
-        caps.ast = self.env.get("made").cloned();
-        self.record_rule_dynvars(caps, &declared_keys);
+        let ast = self.env.get("made").cloned();
         if let Some(m) = saved_match {
             self.env.insert("/".to_string(), m);
         }
+        ast
     }
 
     /// Read-only pre-check for the reduce walk: does this stored capture
     /// subtree contain any inline `{ … }` code blocks? When it does not (and no
     /// rule declares dynvars — checked by the caller), the walk would leave the
     /// subtree byte-identical, so the caller skips it instead of deep-copying
-    /// shared `Arc` nodes via `make_mut`.
-    fn subtree_has_code_blocks(caps: &RegexCaptures) -> bool {
-        if !caps.code_blocks.is_empty() {
+    /// shared `Arc` nodes via `make_mut`. A leaf (`children: None`) answers in
+    /// one branch.
+    fn subtree_has_code_blocks(node: &CapNode) -> bool {
+        let Some(kids) = node.children.as_deref() else {
+            return false;
+        };
+        if !kids.code_blocks.is_empty() {
             return true;
         }
-        caps.named_subcaps
+        kids.named_subcaps
             .values()
             .flatten()
             .any(|sc| Self::subtree_has_code_blocks(sc))
-            || caps
+            || kids
                 .positional_subcaps
                 .iter()
                 .flatten()
                 .any(|sc| Self::subtree_has_code_blocks(sc))
-            || caps
+            || kids
                 .positional_quantified
                 .iter()
                 .flatten()
@@ -608,6 +696,15 @@ impl Interpreter {
         for key in keys {
             if let Some(v) = self.env.get(key).cloned() {
                 caps.regex_vars.insert(key.clone(), v);
+            }
+        }
+    }
+
+    /// [`Self::record_rule_dynvars`] for a stored capture node.
+    fn record_cap_node_dynvars(&mut self, node: &mut CapNode, keys: &[String]) {
+        for key in keys {
+            if let Some(v) = self.env.get(key).cloned() {
+                node.kids_mut().regex_vars.insert(key.clone(), v);
             }
         }
     }

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -185,14 +185,14 @@ const REDUCED_SUBRULE_LOG_CAP: usize = 20_000;
 #[derive(Default)]
 pub(crate) struct ReducedSubruleLog {
     /// `(rule name to dispatch the action under, that rule's captures)`.
-    entries: Vec<(String, std::sync::Arc<RegexCaptures>)>,
+    entries: Vec<(String, std::sync::Arc<CapNode>)>,
     /// De-dups `(rule, from, to)`: mutsu's matcher enumerates every candidate end
     /// position of a subrule, so the same reduce is often produced repeatedly.
     seen: std::collections::HashSet<(String, usize, usize)>,
 }
 
 impl ReducedSubruleLog {
-    pub(crate) fn into_entries(self) -> Vec<(String, std::sync::Arc<RegexCaptures>)> {
+    pub(crate) fn into_entries(self) -> Vec<(String, std::sync::Arc<CapNode>)> {
         self.entries
     }
 }
@@ -201,7 +201,7 @@ impl ReducedSubruleLog {
 /// No-op unless an action-driven parse is live, and never while the matcher is
 /// only *measuring* a declarative prefix or probing the failure position
 /// (ADR-0009: those passes must have no observable side effects).
-pub(crate) fn record_reduced_subrule(rule: &str, caps: &std::sync::Arc<RegexCaptures>) {
+pub(crate) fn record_reduced_subrule(rule: &str, caps: &std::sync::Arc<CapNode>) {
     if LTM_DECLARATIVE_MODE.with(Cell::get) || CODE_ATOMS_INERT.with(Cell::get) {
         return;
     }
@@ -233,7 +233,7 @@ impl ReducedSubruleGuard {
     }
 
     /// Take the entries logged so far, leaving a fresh empty log in place.
-    pub(crate) fn take_entries() -> Vec<(String, std::sync::Arc<RegexCaptures>)> {
+    pub(crate) fn take_entries() -> Vec<(String, std::sync::Arc<CapNode>)> {
         REDUCED_SUBRULES.with(|slot| {
             let mut slot = slot.borrow_mut();
             match slot.as_mut() {

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -280,7 +280,7 @@ impl Interpreter {
                 new_caps.positional.push(captured);
                 new_caps
                     .positional_subcaps
-                    .push(Some(std::sync::Arc::new(subcap)));
+                    .push(Some(std::sync::Arc::new(subcap.into_cap_node())));
                 new_caps.positional_quantified.push(None);
                 out.push((end, new_caps));
             }
@@ -729,7 +729,7 @@ impl Interpreter {
                 if is_alias {
                     subcap.action_name = Some(spec.lookup_name.clone());
                 }
-                let subcap = std::sync::Arc::new(subcap);
+                let subcap = std::sync::Arc::new(subcap.into_cap_node());
                 // This subrule has just REDUCED. Log it so a parse that fails
                 // overall can still run its action, the way Rakudo (which
                 // dispatches at reduce time) does — see `REDUCED_SUBRULES`.
@@ -754,7 +754,7 @@ impl Interpreter {
                         .named_subcaps
                         .entry(spec.lookup_name.clone())
                         .or_default()
-                        .push(std::sync::Arc::new(orig_subcap));
+                        .push(std::sync::Arc::new(orig_subcap.into_cap_node()));
                     new_caps
                         .named
                         .entry(spec.lookup_name.clone())
@@ -792,7 +792,7 @@ impl Interpreter {
                     crate::runtime::SILENT_ACTION_MARKER_PREFIX,
                     spec.lookup_name
                 );
-                let subcap = std::sync::Arc::new(subcap);
+                let subcap = std::sync::Arc::new(subcap.into_cap_node());
                 super::regex_helpers::record_reduced_subrule(&spec.lookup_name, &subcap);
                 new_caps
                     .named_subcaps

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -267,7 +267,7 @@ impl Interpreter {
                     new_caps.positional.push(captured);
                     new_caps
                         .positional_subcaps
-                        .push(Some(std::sync::Arc::new(subcap)));
+                        .push(Some(std::sync::Arc::new(subcap.into_cap_node())));
                     new_caps.positional_quantified.push(None);
                     return Some((end, new_caps));
                 }
@@ -652,7 +652,7 @@ impl Interpreter {
                     .as_deref()
                     .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                 if let Some(capture_name) = capture_name {
-                    let subcap = RegexCaptures {
+                    let subcap = CapNode {
                         matched: captured.clone(),
                         from: pos,
                         to: end,
@@ -677,7 +677,7 @@ impl Interpreter {
                         new_caps
                             .capture_alias_map
                             .insert(capture_name.to_string(), spec.lookup_name.clone());
-                        let subcap2 = RegexCaptures {
+                        let subcap2 = CapNode {
                             matched: captured.clone(),
                             from: pos,
                             to: end,
@@ -725,7 +725,7 @@ impl Interpreter {
                     .as_deref()
                     .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                 if let Some(capture_name) = capture_name {
-                    let subcap = RegexCaptures {
+                    let subcap = CapNode {
                         matched: captured.clone(),
                         from: pos,
                         to: end,

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -240,7 +240,7 @@ impl Interpreter {
         // captures (named subrules etc.) so e.g. `$<family>=(<ident>)` keeps
         // `$<family><ident>` accessible — otherwise truncating the group's
         // positional entry would discard its nested subcapture.
-        let mut group_subcap: Option<std::sync::Arc<RegexCaptures>> = None;
+        let mut group_subcap: Option<std::sync::Arc<CapNode>> = None;
         if matches!(token.atom, RegexAtom::CaptureGroup(_))
             && store.caps().positional.len() > pos_base
         {
@@ -299,17 +299,15 @@ impl Interpreter {
                 let gsm = std::sync::Arc::make_mut(&mut gs);
                 gsm.from = from;
                 gsm.to = to;
-                gsm.match_from = from;
                 gsm.matched = captured.clone();
                 gs
             } else if let Some(sc) = subrule_subcap {
                 sc
             } else {
-                std::sync::Arc::new(RegexCaptures {
+                std::sync::Arc::new(CapNode {
                     from,
                     to,
                     matched: captured.clone(),
-                    match_from: from,
                     ..Default::default()
                 })
             };
@@ -347,7 +345,7 @@ impl Interpreter {
             let inner_positionals = if subcap_idx < caps.positional_subcaps.len() {
                 caps.positional_subcaps[subcap_idx]
                     .as_ref()
-                    .map(|sc| &sc.positional)
+                    .map(|sc| &sc.kids().positional)
             } else {
                 None
             };
@@ -707,7 +705,7 @@ impl Interpreter {
                     subcap.matched = captured.clone();
                     subcap.from = current;
                     subcap.to = end;
-                    let subcap = std::sync::Arc::new(subcap);
+                    let subcap = std::sync::Arc::new(subcap.into_cap_node());
                     // This subrule iteration has REDUCED — log it for the
                     // failed-parse action replay, exactly as the general
                     // `build_named_candidates_from_inner` path does.

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -354,7 +354,7 @@ impl Interpreter {
                     best.named_subcaps
                         .entry(spec.lookup_name.clone())
                         .or_default()
-                        .push(std::sync::Arc::new(subcap));
+                        .push(std::sync::Arc::new(subcap.into_cap_node()));
                 }
                 return Some(best);
             }

--- a/src/runtime/regex/regex_match_sep.rs
+++ b/src/runtime/regex/regex_match_sep.rs
@@ -404,7 +404,7 @@ impl Interpreter {
         for g in 0..atom_stride {
             let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
             let mut last_text = String::new();
-            let mut last_sub: Option<std::sync::Arc<RegexCaptures>> = None;
+            let mut last_sub: Option<std::sync::Arc<CapNode>> = None;
             for ac in atom_caps {
                 if let Some(text) = ac.positional.get(g) {
                     let (from, to) = ac.positional_offsets.get(g).copied().unwrap_or((0, 0));
@@ -426,7 +426,7 @@ impl Interpreter {
         for g in 0..sep_stride {
             let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
             let mut last_text = String::new();
-            let mut last_sub: Option<std::sync::Arc<RegexCaptures>> = None;
+            let mut last_sub: Option<std::sync::Arc<CapNode>> = None;
             for sc in &all_sep {
                 if let Some(text) = sc.positional.get(g) {
                     let (from, to) = sc.positional_offsets.get(g).copied().unwrap_or((0, 0));

--- a/src/runtime/regex/regex_trail.rs
+++ b/src/runtime/regex/regex_trail.rs
@@ -31,7 +31,7 @@ pub(super) struct PosTailRec {
     p_at: usize,
     p: Vec<String>,
     sc_at: usize,
-    sc: Vec<Option<Arc<RegexCaptures>>>,
+    sc: Vec<Option<Arc<CapNode>>>,
     q_at: usize,
     q: Vec<Option<Vec<QuantifiedCaptureEntry>>>,
     off_at: usize,
@@ -54,7 +54,7 @@ pub(super) enum Undo {
     PosOverwrite {
         idx: usize,
         text: Option<String>,
-        sc: Option<Option<Arc<RegexCaptures>>>,
+        sc: Option<Option<Arc<CapNode>>>,
         q: Option<Option<Vec<QuantifiedCaptureEntry>>>,
         off: Option<(usize, usize)>,
     },
@@ -349,7 +349,7 @@ impl CapStore {
             .push(val);
     }
 
-    pub(super) fn push_named_subcap(&mut self, key: &str, sub: Arc<RegexCaptures>) {
+    pub(super) fn push_named_subcap(&mut self, key: &str, sub: Arc<CapNode>) {
         self.record_named_sub_key(key);
         self.caps
             .named_subcaps
@@ -382,7 +382,7 @@ impl CapStore {
     pub(super) fn push_positional(
         &mut self,
         text: String,
-        subcap: Option<Arc<RegexCaptures>>,
+        subcap: Option<Arc<CapNode>>,
         quantified: Option<Vec<QuantifiedCaptureEntry>>,
         offsets: (usize, usize),
     ) {
@@ -620,7 +620,10 @@ mod tests {
         store.push_named("k", "1".to_string());
         let m2 = store.mark();
         store.push_named("k", "2".to_string());
-        store.push_named_subcap("k", std::sync::Arc::new(RegexCaptures::default()));
+        store.push_named_subcap(
+            "k",
+            std::sync::Arc::new(super::super::super::CapNode::default()),
+        );
         store.rewind(m2);
         assert_eq!(store.caps().named["k"], vec!["1".to_string()]);
         assert!(store.caps().named_subcaps.is_empty());

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -38,7 +38,7 @@ pub(crate) struct CodeBlockContext {
 /// copy of the whole sub-match tree. A completed sub-match is effectively
 /// immutable once stored; the rare post-store tweak (e.g. setting `action_name`)
 /// goes through `Arc::make_mut`, which is free while the entry is still unshared.
-pub(crate) type QuantifiedCaptureEntry = (String, usize, usize, Option<Arc<RegexCaptures>>);
+pub(crate) type QuantifiedCaptureEntry = (String, usize, usize, Option<Arc<CapNode>>);
 
 /// Prefix marking a `named_subcaps` entry as a *silent action capture*: the
 /// match of a silent subrule (`<.foo>`) that is hidden from `.hash` but whose
@@ -47,16 +47,121 @@ pub(crate) type QuantifiedCaptureEntry = (String, usize, usize, Option<Arc<Regex
 /// entries never collide with user captures and are trivially filtered.
 pub(crate) const SILENT_ACTION_MARKER_PREFIX: &str = "\u{1}silent\u{1}";
 
+/// An immutable **stored capture node** — what an `Arc<…>` sub-capture is
+/// (ADR-0016 P2). Distinct from [`RegexCaptures`], the engine's *mutable
+/// accumulator* for the pattern run in progress: a completed sub-match needs
+/// only its span, text, dispatch metadata, and (rarely) children, so storing
+/// the full 14-collection accumulator per node cost ~600 zeroed bytes per
+/// leaf. A leaf `CapNode` (the overwhelmingly common case — e.g. one per
+/// matched character in a quantified `<str=space>` run) collapses every child
+/// collection into a single `None`.
+///
+/// The rare post-store mutation (the reduce walk writing `ast`/`regex_vars`)
+/// still goes through `Arc::make_mut`, same as before the split.
+#[derive(Clone, Default)]
+pub(crate) struct CapNode {
+    pub(crate) matched: String,
+    pub(crate) from: usize,
+    pub(crate) to: usize,
+    /// The winning :sym<> variant name, if this match was from a protoregex.
+    pub(crate) sym: Option<String>,
+    /// The original rule name when this capture was stored under an alias.
+    pub(crate) action_name: Option<String>,
+    /// The AST value produced by this node's inline `{ make … }` code block(s),
+    /// computed at reduce time. `None` when the rule ran no `make`.
+    pub(crate) ast: Option<Value>,
+    /// Child captures + per-node reduce state. `None` for a leaf with no
+    /// captures, no code blocks, and no metadata — the size win of the split.
+    pub(crate) children: Option<Box<CapChildren>>,
+}
+
+/// The non-leaf payload of a [`CapNode`]: child captures on both axes plus the
+/// per-node reduce-time state. Boxed so a leaf node pays one `None` word.
+#[derive(Clone, Default)]
+pub(crate) struct CapChildren {
+    pub(crate) named: HashMap<String, Vec<String>>,
+    pub(crate) named_subcaps: HashMap<String, Vec<Arc<CapNode>>>,
+    pub(crate) named_quantified: HashSet<String>,
+    pub(crate) capture_alias_map: HashMap<String, String>,
+    pub(crate) positional: Vec<String>,
+    pub(crate) positional_subcaps: Vec<Option<Arc<CapNode>>>,
+    pub(crate) positional_quantified: Vec<Option<Vec<QuantifiedCaptureEntry>>>,
+    pub(crate) positional_nil: Vec<bool>,
+    /// Inline `{ … }` code blocks recorded on this node, run once at reduce time.
+    pub(crate) code_blocks: Vec<CodeBlockContext>,
+    /// What this rule's own `:my $*x` declarations held at this match's reduce
+    /// (see `Interpreter::record_rule_dynvars`).
+    pub(crate) regex_vars: HashMap<String, Value>,
+}
+
+impl CapNode {
+    /// Immutable child access: an empty default when this node is a leaf.
+    pub(crate) fn kids(&self) -> &CapChildren {
+        static EMPTY: std::sync::OnceLock<CapChildren> = std::sync::OnceLock::new();
+        self.children
+            .as_deref()
+            .unwrap_or_else(|| EMPTY.get_or_init(CapChildren::default))
+    }
+
+    /// Mutable child access, materializing the payload on first use.
+    pub(crate) fn kids_mut(&mut self) -> &mut CapChildren {
+        self.children.get_or_insert_with(Default::default)
+    }
+}
+
+impl RegexCaptures {
+    /// Convert this accumulator into the immutable stored node it describes
+    /// (ADR-0016 P2). Consumes the accumulator; drops the accumulator-only
+    /// fields nothing reads through a stored node (`hash_captures`,
+    /// `positional_slots`, `capture_start`/`capture_end`, `match_from`). The
+    /// child payload is allocated only when something would go in it.
+    pub(crate) fn into_cap_node(self) -> CapNode {
+        let has_children = !self.named.is_empty()
+            || !self.named_subcaps.is_empty()
+            || !self.named_quantified.is_empty()
+            || !self.capture_alias_map.is_empty()
+            || !self.positional.is_empty()
+            || !self.positional_subcaps.is_empty()
+            || !self.positional_quantified.is_empty()
+            || !self.positional_nil.is_empty()
+            || !self.code_blocks.is_empty()
+            || !self.regex_vars.is_empty();
+        let children = has_children.then(|| {
+            Box::new(CapChildren {
+                named: self.named,
+                named_subcaps: self.named_subcaps,
+                named_quantified: self.named_quantified,
+                capture_alias_map: self.capture_alias_map,
+                positional: self.positional,
+                positional_subcaps: self.positional_subcaps,
+                positional_quantified: self.positional_quantified,
+                positional_nil: self.positional_nil,
+                code_blocks: self.code_blocks,
+                regex_vars: self.regex_vars,
+            })
+        });
+        CapNode {
+            matched: self.matched,
+            from: self.from,
+            to: self.to,
+            sym: self.sym,
+            action_name: self.action_name,
+            ast: self.ast,
+            children,
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct RegexCaptures {
     pub(crate) named: HashMap<String, Vec<String>>,
     /// Nested sub-captures for named subrule matches. Key is capture name,
     /// value is inner captures from the subrule (parallel to entries in `named`).
-    pub(crate) named_subcaps: HashMap<String, Vec<Arc<RegexCaptures>>>,
+    pub(crate) named_subcaps: HashMap<String, Vec<Arc<CapNode>>>,
     pub(crate) positional: Vec<String>,
     /// Nested sub-captures for positional capture groups. Each entry corresponds
     /// to the same index in `positional` and holds inner captures from nested groups.
-    pub(crate) positional_subcaps: Vec<Option<Arc<RegexCaptures>>>,
+    pub(crate) positional_subcaps: Vec<Option<Arc<CapNode>>>,
     /// When a capture group is quantified (e.g. `(\w)+`), this parallel vec
     /// stores the list of all iteration matches for that positional index.
     /// When `Some`, the positional slot should be rendered as an Array of Match objects.
@@ -106,6 +211,36 @@ pub(crate) struct RegexCaptures {
     /// `$<sub>».made` resolve in a parent inline action and post-parse. `None`
     /// when the rule ran no `make`.
     pub(crate) ast: Option<Value>,
+}
+
+#[cfg(test)]
+mod cap_node_tests {
+    use super::*;
+
+    /// ADR-0016 P2: a stored leaf capture node must stay a handful of words —
+    /// that is the entire point of the `CapNode`/`RegexCaptures` split (a
+    /// stored leaf used to cost the full ~600-byte accumulator). If a change
+    /// pushes `CapNode` past this, move the new field into `CapChildren`.
+    #[test]
+    fn cap_node_size_guard() {
+        assert!(
+            std::mem::size_of::<CapNode>() <= 112,
+            "CapNode grew to {} bytes",
+            std::mem::size_of::<CapNode>()
+        );
+    }
+
+    /// A leaf conversion must not allocate a child payload.
+    #[test]
+    fn into_cap_node_leaf_has_no_children() {
+        let mut caps = RegexCaptures::default();
+        caps.matched = "x".to_string();
+        caps.from = 3;
+        caps.to = 4;
+        let node = caps.into_cap_node();
+        assert!(node.children.is_none());
+        assert_eq!((node.from, node.to), (3, 4));
+    }
 }
 
 #[derive(Clone)]

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -9,8 +9,8 @@ impl Value {
         to: i64,
         positional: &[String],
         named: &HashMap<String, Vec<String>>,
-        named_subcaps: &HashMap<String, Vec<std::sync::Arc<crate::runtime::RegexCaptures>>>,
-        positional_subcaps: &[Option<std::sync::Arc<crate::runtime::RegexCaptures>>],
+        named_subcaps: &HashMap<String, Vec<std::sync::Arc<crate::runtime::CapNode>>>,
+        positional_subcaps: &[Option<std::sync::Arc<crate::runtime::CapNode>>],
         positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
         positional_nil: &[bool],
         orig: Option<&str>,
@@ -38,8 +38,8 @@ impl Value {
         to: i64,
         positional: &[String],
         named: &HashMap<String, Vec<String>>,
-        named_subcaps: &HashMap<String, Vec<std::sync::Arc<crate::runtime::RegexCaptures>>>,
-        positional_subcaps: &[Option<std::sync::Arc<crate::runtime::RegexCaptures>>],
+        named_subcaps: &HashMap<String, Vec<std::sync::Arc<crate::runtime::CapNode>>>,
+        positional_subcaps: &[Option<std::sync::Arc<crate::runtime::CapNode>>],
         positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
         positional_nil: &[bool],
         orig: Option<&str>,
@@ -89,23 +89,21 @@ impl Value {
             Value::make_instance(Symbol::intern("Match"), attrs)
         }
 
-        /// Build a Match object from a RegexCaptures, recursively handling subcaptures.
-        fn make_subcap_match(
-            caps: &crate::runtime::RegexCaptures,
-            orig_ctx: Option<OrigCtx>,
-        ) -> Value {
+        /// Build a Match object from a stored CapNode, recursively handling subcaptures.
+        fn make_subcap_match(caps: &crate::runtime::CapNode, orig_ctx: Option<OrigCtx>) -> Value {
             let search_start = caps.from;
-            let pos_vals: Vec<Value> = caps
+            let kids = caps.kids();
+            let pos_vals: Vec<Value> = kids
                 .positional
                 .iter()
                 .enumerate()
                 .map(|(i, s)| {
                     // An unmatched optional capture (`(x)?` zero match) renders as Nil.
-                    if caps.positional_nil.get(i) == Some(&true) {
+                    if kids.positional_nil.get(i) == Some(&true) {
                         return Value::Nil;
                     }
                     // Check if this positional entry is a quantified list
-                    if let Some(Some(qlist)) = caps.positional_quantified.get(i) {
+                    if let Some(Some(qlist)) = kids.positional_quantified.get(i) {
                         let arr: Vec<Value> = qlist
                             .iter()
                             .map(|(text, from, to, subcap)| {
@@ -130,15 +128,15 @@ impl Value {
                         return Value::array(arr);
                     }
                     // Recursively build nested Match objects for positional subcaptures
-                    if let Some(Some(subcap)) = caps.positional_subcaps.get(i) {
+                    if let Some(Some(subcap)) = kids.positional_subcaps.get(i) {
                         return make_subcap_match(subcap, orig_ctx);
                     }
                     make_capture_match(s, orig_ctx, search_start)
                 })
                 .collect();
             let mut sub_named: HashMap<String, Value> = HashMap::new();
-            for (key, values) in &caps.named {
-                let subcaps_for_key = caps.named_subcaps.get(key);
+            for (key, values) in &kids.named {
+                let subcaps_for_key = kids.named_subcaps.get(key);
                 let vals: Vec<Value> = values
                     .iter()
                     .enumerate()
@@ -151,14 +149,14 @@ impl Value {
                         make_capture_match(s, orig_ctx, search_start)
                     })
                     .collect();
-                if vals.len() == 1 && !caps.named_quantified.contains(key) {
+                if vals.len() == 1 && !kids.named_quantified.contains(key) {
                     sub_named.insert(key.clone(), vals[0].clone());
                 } else {
                     sub_named.insert(key.clone(), Value::real_array(vals));
                 }
             }
             // For quantified named captures that matched zero times, insert empty arrays
-            for qname in &caps.named_quantified {
+            for qname in &kids.named_quantified {
                 sub_named
                     .entry(qname.clone())
                     .or_insert_with(|| Value::real_array(Vec::new()));
@@ -169,7 +167,7 @@ impl Value {
             // build them into a `silent_caps` array for the grammar action walk.
             // Each subcap's `action_name` carries the rule name to dispatch on.
             let mut silent_caps_vals: Vec<Value> = Vec::new();
-            for (key, scs) in &caps.named_subcaps {
+            for (key, scs) in &kids.named_subcaps {
                 if key.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
                     for sc in scs {
                         silent_caps_vals.push(make_subcap_match(sc, orig_ctx));
@@ -206,16 +204,16 @@ impl Value {
             // reduce. The action walk re-installs them around this node's action
             // so a per-match dynamic variable is not read as the last match's
             // value (see `Interpreter::reduce_regex_captures_made_for_rule`).
-            if !caps.regex_vars.is_empty() {
-                let vars: HashMap<String, Value> = caps
+            if !kids.regex_vars.is_empty() {
+                let vars: HashMap<String, Value> = kids
                     .regex_vars
                     .iter()
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect();
                 attrs.insert("reduce_time_vars".to_string(), Value::hash(vars));
             }
-            if !caps.capture_alias_map.is_empty() {
-                let alias_hash: HashMap<String, Value> = caps
+            if !kids.capture_alias_map.is_empty() {
+                let alias_hash: HashMap<String, Value> = kids
                     .capture_alias_map
                     .iter()
                     .map(|(k, v)| (k.clone(), Value::str(v.clone())))


### PR DESCRIPTION
## Summary

Lands **ADR-0016 P2** (`docs/adr/0016-span-based-captures-and-lazy-match.md`): the immutable stored capture node is split out of the engine's mutable accumulator.

- New `CapNode` (`matched`/`from`/`to`/`sym`/`action_name`/`ast` + `children: Option<Box<CapChildren>>`) replaces `Arc<RegexCaptures>` on all three sub-capture axes (`named_subcaps`, `positional_subcaps`, quantified entries) and in the `REDUCED_SUBRULES` failed-parse replay log.
- A leaf node — the overwhelmingly common case; e.g. one node per matched character in a quantified `<str=space>` run — collapses every child collection into a single `None`: **~600 zeroed bytes → ≤112** (pinned by `cap_node_size_guard`).
- Conversion happens once per stored node (`RegexCaptures::into_cap_node()`) at the ~10 sites that previously wrapped an accumulator in an `Arc`. Fields nothing ever read through a stored node (`hash_captures`, `positional_slots`, `positional_offsets`, capture markers, `match_from`) are dropped at conversion.
- The reduce-time walk and the failed-parse action replay recurse over `CapNode`; the children-first descent and the block-running body are shared helpers (`reduce_child_axes`, `reduce_run_code_blocks`). `subtree_has_code_blocks` answers `false` for a leaf in one branch.

No observable semantics change intended. Perf magnitude to be judged from `bench-history.tsv` on `bench-data` per the standing rule; the structural claim (leaf shrink, less `RegexCaptures::default()` zeroing per candidate) holds regardless.

## Test plan

- Full local `t/` suite: **24,921 tests PASS** (debug)
- Full local `make roast`: **1435 files / 218,774 tests PASS** (release)
- New unit tests: `cap_node_size_guard`, `into_cap_node_leaf_has_no_children`
- Pinned regex/grammar tests (`t/regex-subrule-absolute-position.t`, `t/grammar-reduce-time-dynvar.t`, `t/yaml-battery.t`, …) PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)