### PR TITLE
perf(regex): count Match-builder leaf position searches vs span reads (ADR-0016 P3 scoping)

### DIFF
--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -262,6 +262,18 @@ written through the `Arc`.
 Delete `chars[a..b].iter().collect()` at capture sites, the `captured.clone()` duplicates,
 and `make_capture_match`'s search entirely — the Match builder reads the recorded span.
 Fixes the repeated-text offset bug.
+*Measured 2026-07-31 (counted, not guessed — post-P2 `leaf_searches`/`leaf_spans`
+counters under `MUTSU_VM_STATS`):* the position search is **already dead on every
+workload tested** — `bench-yaml-parse` (0 searches / 38,431 span reads), the YAMLish
+battery test, roast S05 capture/global files, and ad-hoc `m:g`/`split`/`subst` shapes
+all report `leaf_searches=0`, because every leaf reaching the builder now carries a
+span-bearing `CapNode` (P2 made the `store_apply_named_capture` carrier the natural
+representation). The pre-P1 "≈4 points of memcmp" attributed to the search no longer
+applies. **P3's value is therefore the text axis itself**, not the search: per stored
+leaf the text is materialized and copied up to three times (`chars[a..b].collect()`
+into `CapNode.matched`, again into the accumulator's `named`/`positional` text vecs,
+again into the Match `str` attribute) — 38k `String` allocations per bench parse.
+The search fallback is retired when the text axis goes.
 
 **P4 — One list per axis + interned names.** Collapse the parallel vectors/maps into
 `Vec<PosSlot>` and `HashMap<Symbol, Vec<Arc<CapNode>>>`, and shrink the trail's undo

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -59,6 +59,7 @@ impl Value {
             let mut attrs = HashMap::new();
             attrs.insert("str".to_string(), Value::str(s.to_string()));
             // Try to find the captured text's position within the original string
+            crate::vm::vm_stats::record_regex_match_leaf(orig_ctx.is_some());
             let (cap_from, cap_to) = if let Some((_, haystack)) = orig_ctx {
                 // Search for the captured substring starting from search_from
                 let needle: Vec<char> = s.chars().collect();
@@ -91,6 +92,9 @@ impl Value {
 
         /// Build a Match object from a stored CapNode, recursively handling subcaptures.
         fn make_subcap_match(caps: &crate::runtime::CapNode, orig_ctx: Option<OrigCtx>) -> Value {
+            if caps.children.is_none() {
+                crate::vm::vm_stats::record_regex_match_leaf(false);
+            }
             let search_start = caps.from;
             let kids = caps.kids();
             let pos_vals: Vec<Value> = kids

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -136,6 +136,13 @@ static GC_ROOTS_SCANNED: AtomicU64 = AtomicU64::new(0);
 // CapNode split (ADR-0016 P2) removes structurally.
 static REGEX_CAP_MAKEMUT_TOTAL: AtomicU64 = AtomicU64::new(0);
 static REGEX_CAP_MAKEMUT_SHARED: AtomicU64 = AtomicU64::new(0);
+// ADR-0016 P3: how many leaf captures the Match builder had to recover a
+// position for by SEARCHING the subject (`make_capture_match` with an orig
+// context), vs. leaves whose span came from a recorded carrier node. The
+// search is O(document) per leaf and semantically wrong for repeated text —
+// P3's goal is to drive `searches` to zero by carrying spans.
+static REGEX_MATCH_LEAF_SEARCHES: AtomicU64 = AtomicU64::new(0);
+static REGEX_MATCH_LEAF_SPANS: AtomicU64 = AtomicU64::new(0);
 
 // Regex embedded-code parse cache (REGEX_CODE_PARSE_CACHE) effectiveness.
 static REGEX_CODE_PARSE_HITS: AtomicU64 = AtomicU64::new(0);
@@ -161,6 +168,18 @@ pub(crate) fn record_regex_cap_makemut(shared: bool) {
         REGEX_CAP_MAKEMUT_TOTAL.fetch_add(1, Ordering::Relaxed);
         if shared {
             REGEX_CAP_MAKEMUT_SHARED.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// A Match-builder leaf capture recovered its offsets by searching the subject
+/// (`searched == true`) or read them from a recorded span (`searched == false`).
+pub(crate) fn record_regex_match_leaf(searched: bool) {
+    if enabled() {
+        if searched {
+            REGEX_MATCH_LEAF_SEARCHES.fetch_add(1, Ordering::Relaxed);
+        } else {
+            REGEX_MATCH_LEAF_SPANS.fetch_add(1, Ordering::Relaxed);
         }
     }
 }
@@ -472,8 +491,10 @@ pub(crate) fn dump() {
     );
     let cap_makemut_total = REGEX_CAP_MAKEMUT_TOTAL.load(Ordering::Relaxed);
     let cap_makemut_shared = REGEX_CAP_MAKEMUT_SHARED.load(Ordering::Relaxed);
+    let leaf_searches = REGEX_MATCH_LEAF_SEARCHES.load(Ordering::Relaxed);
+    let leaf_spans = REGEX_MATCH_LEAF_SPANS.load(Ordering::Relaxed);
     eprintln!(
-        "[mutsu vm-stats] regex-captures: cap_makemut={cap_makemut_total} shared_deep_copies={cap_makemut_shared}"
+        "[mutsu vm-stats] regex-captures: cap_makemut={cap_makemut_total} shared_deep_copies={cap_makemut_shared} leaf_searches={leaf_searches} leaf_spans={leaf_spans}"
     );
     let code_parse_hits = REGEX_CODE_PARSE_HITS.load(Ordering::Relaxed);
     let code_parse_misses = REGEX_CODE_PARSE_MISSES.load(Ordering::Relaxed);


### PR DESCRIPTION
## Summary

Instrumentation + scoping correction for ADR-0016 P3, following the ADR's own rule: **count, don't guess.**

- New `MUTSU_VM_STATS` counters on the `regex-captures` line: `leaf_searches` (Match builder recovered a leaf capture's offsets by searching the subject — the O(document), wrong-for-repeated-text fallback) vs `leaf_spans` (offsets read from a stored `CapNode` span).
- Measured post-P2: **the search is already dead on every workload tested** — `bench-yaml-parse` reports 0 searches / 38,431 span reads; the YAMLish battery, roast S05 capture/global files, and ad-hoc `m:g`/`split`/`subst` shapes all report 0.
- ADR-0016's P3 section updated accordingly: P3's remaining value is removing the **text axis** (a stored leaf's text is materialized/copied up to three times), not the search. The search fallback retires with the text axis.

## Test plan

- `cargo clippy -- -D warnings` clean, counters are `MUTSU_VM_STATS`-gated (zero cost otherwise)
- `t/yaml-battery.t`, `t/regex-subrule-absolute-position.t` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)