### PR TITLE
refactor(match): Match accessor seam + funnel scattered scalar readers (ADR-0016 P5 step 1)

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -146,9 +146,8 @@ pub(super) fn cool_instance_numeric(target: &Value) -> Option<f64> {
     };
     match class_name.resolve().as_str() {
         "IO::Path" => target.to_string_value().trim().parse::<f64>().ok(),
-        "Match" => attributes
-            .as_map()
-            .get("str")
+        "Match" => target
+            .match_str_value()
             .and_then(|v| v.to_string_value().trim().parse::<f64>().ok()),
         "StrDistance" => {
             let before = attributes

--- a/src/builtins/methods_0arg/match_helpers.rs
+++ b/src/builtins/methods_0arg/match_helpers.rs
@@ -79,22 +79,12 @@ fn value_raku_repr(val: &Value) -> String {
 
 /// Extract the `from` position from a Match object value.
 pub(super) fn match_value_from(val: &Value) -> i64 {
-    if let ValueView::Instance { attributes, .. } = val.view()
-        && let Some(ValueView::Int(n)) = attributes.as_map().get("from").map(Value::view)
-    {
-        return n;
-    }
-    0
+    val.match_from().unwrap_or(0)
 }
 
 /// Extract the `to` position from a Match object value.
 pub(super) fn match_value_to(val: &Value) -> i64 {
-    if let ValueView::Instance { attributes, .. } = val.view()
-        && let Some(ValueView::Int(n)) = attributes.as_map().get("to").map(Value::view)
-    {
-        return n;
-    }
-    0
+    val.match_to().unwrap_or(0)
 }
 
 /// Collect all captures from a Match object sorted by position.

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1761,18 +1761,10 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
     {
         match method {
             "from" => {
-                return Some(Ok(attributes
-                    .as_map()
-                    .get("from")
-                    .cloned()
-                    .unwrap_or(Value::int(0))));
+                return Some(Ok(Value::int(target.match_from().unwrap_or(0))));
             }
             "to" | "pos" => {
-                return Some(Ok(attributes
-                    .as_map()
-                    .get("to")
-                    .cloned()
-                    .unwrap_or(Value::int(0))));
+                return Some(Ok(Value::int(target.match_to().unwrap_or(0))));
             }
             "gist" => {
                 // Full Match gist: corner-quoted text plus positional/named
@@ -1781,28 +1773,20 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(Value::str(gist)));
             }
             "Str" => {
-                return Some(Ok(attributes
-                    .as_map()
-                    .get("str")
-                    .cloned()
-                    .unwrap_or(Value::str(String::new()))));
+                return Some(Ok(target
+                    .match_str_value()
+                    .unwrap_or_else(|| Value::str(String::new()))));
             }
             "Bool" => {
                 // A failed `.subparse` Match is falsy; every other Match is truthy.
-                let ok = !attributes
-                    .as_map()
-                    .get("__failed_match__")
-                    .is_some_and(|v| v.truthy());
-                return Some(Ok(Value::truth(ok)));
+                return Some(Ok(Value::truth(!target.match_is_failed())));
             }
             "orig" | "target" => {
                 // `.target` is the original string the match ran against; for an
                 // ordinary Match it is identical to `.orig`.
-                return Some(Ok(attributes
-                    .as_map()
-                    .get("orig")
-                    .cloned()
-                    .unwrap_or(Value::str(String::new()))));
+                return Some(Ok(target
+                    .match_orig()
+                    .unwrap_or_else(|| Value::str(String::new()))));
             }
             "raku" | "perl" => {
                 return Some(Ok(Value::str(match_helpers::match_raku_repr(
@@ -1810,17 +1794,13 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 ))));
             }
             "list" | "Array" => {
-                return Some(Ok(attributes
-                    .as_map()
-                    .get("list")
-                    .cloned()
+                return Some(Ok(target
+                    .match_list()
                     .unwrap_or_else(|| Value::array(Vec::new()))));
             }
             "hash" | "Hash" => {
-                return Some(Ok(attributes
-                    .as_map()
-                    .get("named")
-                    .cloned()
+                return Some(Ok(target
+                    .match_named()
                     .unwrap_or_else(|| Value::hash(HashMap::new()))));
             }
             "keys" => {
@@ -1927,19 +1907,12 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(Value::int(count as i64)));
             }
             "ast" | "made" => {
-                return Some(Ok(attributes
-                    .as_map()
-                    .get("ast")
-                    .cloned()
-                    .unwrap_or(Value::NIL)));
+                return Some(Ok(target.match_ast().unwrap_or(Value::NIL)));
             }
             "prematch" => {
-                if let Some(orig_val) = attributes.as_map().get("orig") {
+                if let Some(orig_val) = target.match_orig() {
                     let orig = orig_val.to_string_value();
-                    let from = match attributes.as_map().get("from").map(Value::view) {
-                        Some(ValueView::Int(n)) => n as usize,
-                        _ => 0,
-                    };
+                    let from = target.match_from().unwrap_or(0).max(0) as usize;
                     let chars: Vec<char> = orig.chars().collect();
                     let pre: String = chars[..from.min(chars.len())].iter().collect();
                     return Some(Ok(Value::str(pre)));
@@ -1947,12 +1920,9 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(Value::str(String::new())));
             }
             "postmatch" => {
-                if let Some(orig_val) = attributes.as_map().get("orig") {
+                if let Some(orig_val) = target.match_orig() {
                     let orig = orig_val.to_string_value();
-                    let to = match attributes.as_map().get("to").map(Value::view) {
-                        Some(ValueView::Int(n)) => n as usize,
-                        _ => 0,
-                    };
+                    let to = target.match_to().unwrap_or(0).max(0) as usize;
                     let chars: Vec<char> = orig.chars().collect();
                     let post: String = chars[to.min(chars.len())..].iter().collect();
                     return Some(Ok(Value::str(post)));

--- a/src/runtime/builtins_operators_coerce.rs
+++ b/src/runtime/builtins_operators_coerce.rs
@@ -35,14 +35,7 @@ impl Interpreter {
             return Err(err);
         }
         // Match coerces to Numeric via its matched string.
-        if let ValueView::Instance {
-            class_name,
-            attributes,
-            ..
-        } = value.view()
-            && class_name == "Match"
-            && let Some(str_val) = attributes.as_map().get("str")
-        {
+        if let Some(str_val) = value.match_str_value() {
             let s = str_val.to_string_value();
             let s = s.trim();
             if let Ok(i) = s.parse::<i64>() {

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -764,13 +764,7 @@ impl Interpreter {
 
     /// Extract `action_name` from a Match object (set for aliased captures).
     pub(crate) fn get_action_name(match_obj: &Value) -> Option<String> {
-        if let ValueView::Instance { attributes, .. } = match_obj.view()
-            && let Some(ValueView::Str(action_name)) =
-                attributes.as_map().get("action_name").map(Value::view)
-        {
-            return Some(action_name.to_string());
-        }
-        None
+        match_obj.match_action_name()
     }
 
     /// Dispatch this level's own silent-action captures: hidden `<.foo>`
@@ -788,16 +782,7 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         if let Some(ValueView::Array(silent_arr, _)) = attrs.get("silent_caps").map(Value::view) {
             let mut items: Vec<Value> = silent_arr.iter().cloned().collect();
-            items.sort_by_key(|m| {
-                if let ValueView::Instance { attributes, .. } = m.view()
-                    && let Some(ValueView::Int(from)) =
-                        attributes.as_map().get("from").map(Value::view)
-                {
-                    from
-                } else {
-                    0
-                }
-            });
+            items.sort_by_key(|m| m.match_from().unwrap_or(0));
             for item in items {
                 let dispatch_name = Self::get_action_name(&item).unwrap_or_default();
                 self.invoke_grammar_actions(item, actions, &dispatch_name)?;

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -645,12 +645,18 @@ impl Interpreter {
             }
             Ok(v) => {
                 // A defined Match/Cursor return advances the parse by its extent.
-                if let ValueView::Instance { attributes, .. } = v.view()
-                    && let Some(to) = attributes
-                        .as_map()
-                        .get("to")
-                        .and_then(|t| t.as_int())
-                        .filter(|&t| t >= 0)
+                // (Match goes through the seam; a non-Match cursor-like instance
+                // with a `to` attribute also counts.)
+                if let Some(to) = v
+                    .match_to()
+                    .or_else(|| {
+                        if let ValueView::Instance { attributes, .. } = v.view() {
+                            attributes.as_map().get("to").and_then(|t| t.as_int())
+                        } else {
+                            None
+                        }
+                    })
+                    .filter(|&t| t >= 0)
                 {
                     let end = pos + to as usize;
                     if end <= chars.len() {

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -51,22 +51,13 @@ impl Interpreter {
             return None;
         }
         // Cursor: a Match instance (orig + to = current position) or a plain Str.
-        let (text, pos) = match args.first().map(Value::view) {
-            Some(ValueView::Instance {
-                class_name,
-                attributes,
-                ..
-            }) if class_name.resolve() == "Match" => {
-                let attrs = attributes.as_map();
-                let orig = attrs.get("orig").map(|v| v.to_string_value())?;
-                let to = attrs
-                    .get("to")
-                    .and_then(|v| v.as_int())
-                    .filter(|t| *t >= 0)
-                    .unwrap_or(0) as usize;
+        let (text, pos) = match args.first() {
+            Some(m) if m.is_match_instance() => {
+                let orig = m.match_orig().map(|v| v.to_string_value())?;
+                let to = m.match_to().filter(|t| *t >= 0).unwrap_or(0) as usize;
                 (orig, to)
             }
-            Some(ValueView::Str(s)) => (s.to_string(), 0usize),
+            Some(v) if matches!(v.view(), ValueView::Str(_)) => (v.to_string_value(), 0usize),
             _ => return None,
         };
         Some(self.run_token_method_at(pkg, name, &args[1..], &text, pos))
@@ -229,17 +220,19 @@ impl Interpreter {
             }
         };
         let side = LAST_TOKEN_METHOD_MATCH.with(|slot| slot.borrow_mut().take());
-        // The wrapper must return a Match/cursor; read its extent.
-        let to_abs = if let ValueView::Instance { attributes, .. } = result.view() {
-            attributes
-                .as_map()
-                .get("to")
-                .and_then(|t| t.as_int())
-                .filter(|&t| t >= pos as i64 && t <= chars.len() as i64)
-                .map(|t| t as usize)
-        } else {
-            None
-        };
+        // The wrapper must return a Match/cursor; read its extent. A non-Match
+        // cursor-like instance (user class with a `to` attribute) also counts.
+        let to_abs = result
+            .match_to()
+            .or_else(|| {
+                if let ValueView::Instance { attributes, .. } = result.view() {
+                    attributes.as_map().get("to").and_then(|t| t.as_int())
+                } else {
+                    None
+                }
+            })
+            .filter(|&t| t >= pos as i64 && t <= chars.len() as i64)
+            .map(|t| t as usize);
         let Some(to_abs) = to_abs else {
             return Some(Vec::new());
         };

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -401,12 +401,11 @@ impl Interpreter {
 
     /// Get the match continuation position from `$/.to`, defaulting to 0.
     pub(in crate::runtime) fn get_match_to_position(&self) -> usize {
-        if let Some(ValueView::Instance { attributes, .. }) = self.env.get("/").map(Value::view)
-            && let Some(ValueView::Int(to)) = attributes.as_map().get("to").map(Value::view)
-        {
-            return to as usize;
-        }
-        0
+        self.env
+            .get("/")
+            .and_then(Value::match_to)
+            .map(|to| to as usize)
+            .unwrap_or(0)
     }
 
     #[cfg(feature = "pcre2")]

--- a/src/runtime/utils/compare.rs
+++ b/src/runtime/utils/compare.rs
@@ -99,11 +99,9 @@ pub(crate) fn to_float_value(val: &Value) -> Option<f64> {
             attributes,
             ..
         } if class_name == "Instant" => attributes.as_map().get("value").and_then(to_float_value),
-        ValueView::Instance {
-            class_name,
-            attributes,
-            ..
-        } if class_name == "Match" => attributes.as_map().get("str").and_then(to_float_value),
+        ValueView::Instance { class_name, .. } if class_name == "Match" => {
+            val.match_str_value().as_ref().and_then(to_float_value)
+        }
         ValueView::Instance { attributes, .. } => attributes
             .as_map()
             .get("__mutsu_int_value")

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -700,14 +700,9 @@ impl Value {
                 .get("WHICH")
                 .map(|v: &Value| v.to_string_value())
                 .unwrap_or_else(|| format!("{}()", class_name)),
-            ValueView::Instance {
-                class_name,
-                attributes,
-                ..
-            } if class_name == "Match" => attributes
-                .as_map()
-                .get("str")
-                .map(|v: &Value| v.to_string_value())
+            ValueView::Instance { class_name, .. } if class_name == "Match" => self
+                .match_str_value()
+                .map(|v| v.to_string_value())
                 .unwrap_or_default(),
             ValueView::Instance {
                 class_name,

--- a/src/value/match_view.rs
+++ b/src/value/match_view.rs
@@ -1,0 +1,85 @@
+//! ADR-0016 P5 seam: accessor helpers for the `Match` representation.
+//!
+//! Every consumer that reads a Raku `Match` object's internals goes through
+//! these `Value` methods instead of pattern-matching the `Instance` shape
+//! inline. This is the pure-refactor half of P5: once all consumers use the
+//! seam, the representation behind it can swap to a dedicated lazy repr
+//! (`ValueRepr::Match`) without touching the consumers again. The inventory
+//! of sites is `todo/deep/adr0016-p5-match-consumer-inventory.md`.
+//!
+//! Accessors return owned `Value`s (an `Arc`/`Gc` bump) or plain scalars —
+//! never references into the attribute map — so their signatures survive the
+//! repr swap.
+
+use super::*;
+
+impl Value {
+    /// Is this value a `Match` instance (regex match object)?
+    pub(crate) fn is_match_instance(&self) -> bool {
+        matches!(self.view(), ValueView::Instance { class_name, .. } if class_name == "Match")
+    }
+
+    /// Read one attribute of a `Match` instance. `None` when `self` is not a
+    /// Match or the attribute is absent. The internal funnel every public
+    /// accessor below goes through.
+    fn match_attr(&self, name: &str) -> Option<Value> {
+        match self.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "Match" => attributes.as_map().get(name).cloned(),
+            _ => None,
+        }
+    }
+
+    /// The matched text (`.Str`) as a `Value`, usually `Value::Str`.
+    pub(crate) fn match_str_value(&self) -> Option<Value> {
+        self.match_attr("str")
+    }
+
+    /// The match's start offset (`.from`). `None` when not a Match.
+    pub(crate) fn match_from(&self) -> Option<i64> {
+        self.match_attr("from")?.as_int()
+    }
+
+    /// The match's end offset (`.to`). `None` when not a Match.
+    pub(crate) fn match_to(&self) -> Option<i64> {
+        self.match_attr("to")?.as_int()
+    }
+
+    /// The whole subject string the match ran against (`.orig`).
+    pub(crate) fn match_orig(&self) -> Option<Value> {
+        self.match_attr("orig")
+    }
+
+    /// The positional-capture list (`.list`), an array `Value`.
+    pub(crate) fn match_list(&self) -> Option<Value> {
+        self.match_attr("list")
+    }
+
+    /// The named-capture hash (`.hash`), a hash `Value`.
+    pub(crate) fn match_named(&self) -> Option<Value> {
+        self.match_attr("named")
+    }
+
+    /// The `make`-produced value (`.made`/`.ast`).
+    pub(crate) fn match_ast(&self) -> Option<Value> {
+        self.match_attr("ast")
+    }
+
+    /// Whether this is a failed `.subparse` Match (defined but falsy).
+    pub(crate) fn match_is_failed(&self) -> bool {
+        self.match_attr("__failed_match__")
+            .is_some_and(|v| v.truthy())
+    }
+
+    /// The original rule name for grammar action dispatch, set on aliased
+    /// captures (`<x=rule>`).
+    pub(crate) fn match_action_name(&self) -> Option<String> {
+        match self.match_attr("action_name")?.view() {
+            ValueView::Str(s) => Some(s.to_string()),
+            _ => None,
+        }
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -434,6 +434,8 @@ mod error;
 mod error_construct;
 mod error_typed;
 mod guards;
+/// ADR-0016 P5 seam: `Match`-representation accessor helpers.
+mod match_view;
 /// NaN-boxed 8-byte representation core (3b-1 step B): the packed word that
 /// IS the `Value` storage. The only module that knows the bit layout.
 mod nanbox;

--- a/src/value/types_truthy.rs
+++ b/src/value/types_truthy.rs
@@ -89,12 +89,7 @@ impl Value {
                     return false;
                 }
                 // A failed `.subparse` Match is falsy (but still defined).
-                if class_name == "Match"
-                    && attributes
-                        .as_map()
-                        .get("__failed_match__")
-                        .is_some_and(|v| v.truthy())
-                {
+                if class_name == "Match" && self.match_is_failed() {
                     return false;
                 }
                 // Buf/Blob: truthy when non-empty

--- a/src/value/value_eq.rs
+++ b/src/value/value_eq.rs
@@ -2,17 +2,18 @@ use super::*;
 
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
-        let match_equals_pair_array =
-            |attrs: &crate::gc::Gc<InstanceAttrs>, arr: &crate::gc::Gc<ArrayData>| {
-                if arr.len() != 2 {
-                    return false;
-                }
-                let map = attrs.as_map();
-                let (Some(from), Some(matched)) = (map.get("from"), map.get("str")) else {
-                    return false;
-                };
-                arr[0] == *from && arr[1] == *matched
+        let match_equals_pair_array = |m: &Value, arr: &Value| {
+            let Some(items) = arr.as_list_items() else {
+                return false;
             };
+            if items.len() != 2 {
+                return false;
+            }
+            let (Some(from), Some(matched)) = (m.match_from(), m.match_str_value()) else {
+                return false;
+            };
+            items[0] == Value::int(from) && items[1] == matched
+        };
         match (self.view(), other.view()) {
             (ValueView::Int(a), ValueView::Int(b)) => a == b,
             (ValueView::BigInt(a), ValueView::BigInt(b)) => *a == *b,
@@ -217,22 +218,16 @@ impl PartialEq for Value {
                     ..
                 },
             ) => a == b && *aa == *ba,
-            (
-                ValueView::Instance {
-                    class_name,
-                    attributes,
-                    ..
-                },
-                ValueView::Array(items, ..),
-            ) if class_name == "Match" => match_equals_pair_array(&attributes, &items),
-            (
-                ValueView::Array(items, ..),
-                ValueView::Instance {
-                    class_name,
-                    attributes,
-                    ..
-                },
-            ) if class_name == "Match" => match_equals_pair_array(&attributes, &items),
+            (ValueView::Instance { class_name, .. }, ValueView::Array(..))
+                if class_name == "Match" =>
+            {
+                match_equals_pair_array(self, other)
+            }
+            (ValueView::Array(..), ValueView::Instance { class_name, .. })
+                if class_name == "Match" =>
+            {
+                match_equals_pair_array(other, self)
+            }
             (
                 ValueView::Junction {
                     kind: ak,

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -458,13 +458,8 @@ impl Value {
                     .unwrap_or(0.0)
             }
             // Match coerces to Numeric via its matched string
-            ValueView::Instance {
-                class_name,
-                attributes,
-                ..
-            } if class_name == "Match" => attributes
-                .as_map()
-                .get("str")
+            ValueView::Instance { class_name, .. } if class_name == "Match" => self
+                .match_str_value()
                 .map(|v| v.to_string_value().trim().parse::<f64>().unwrap_or(0.0))
                 .unwrap_or(0.0),
             // A numeric allomorph (IntStr/NumStr/RatStr) numifies to its inner value.

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -179,19 +179,12 @@ impl Interpreter {
         // Stringy-then-Str method-dispatch ceremony below. Only a user augment
         // of `Match.Stringy`/`Match.Str` (or a `prefix:<~>` overload, already
         // checked above) could observe the difference — gate on those.
-        if let ValueView::Instance {
-            class_name,
-            attributes,
-            ..
-        } = val.view()
-            && class_name == "Match"
+        if val.is_match_instance()
             && !self.has_user_method("Match", "Stringy")
             && !self.has_user_method("Match", "Str")
         {
-            let s = attributes
-                .as_map()
-                .get("str")
-                .cloned()
+            let s = val
+                .match_str_value()
                 .unwrap_or_else(|| Value::str(String::new()));
             self.stack.push(s);
             return Ok(());


### PR DESCRIPTION
## Summary

First implementation step of ADR-0016 **P5**'s pure-refactor half, guided by the inventory landed in #5580.

- New `src/value/match_view.rs`: `Value`-level accessors for the `Match` representation (`is_match_instance`, `match_str_value`, `match_from`/`match_to`, `match_orig`, `match_list`, `match_named`, `match_ast`, `match_is_failed`, `match_action_name`). Accessors return owned `Value`s/scalars — never references into the attribute map — so their signatures survive the planned repr swap (`ValueRepr::Match`).
- Funnels the **scattered** scalar-reader sites through the seam: display, `Value` equality (Match == [from, str] pair-array), truthiness (failed `.subparse`), the numeric coercions (`compare.rs`, `builtins_operators_coerce`, `dispatch_core_math`, the `vm_misc_coerce` Str fast path, `Value::to_f64`), the regex engine's cursor-extent reads (Match via the seam; non-Match cursor-like instances keep the generic attribute read), `get_match_to_position`, `get_action_name`, the silent-caps sort, and the `methods_0arg` Match dispatch scalar arms.
- Match-centric modules the final swap rewrites wholesale (`match_gist`, `match_caps`/`match_chunks`, `match_raku_repr`, the builders, the grammar action walk) deliberately keep inline access for now.

Pure refactor — no behavior change intended.

## Test plan

- Full local `t/` suite: **24,921 tests PASS**
- Full local `make roast`: **1435 files / 218,774 tests PASS** (release)
- `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)