### PR TITLE
refactor(match): funnel scattered list/named structure readers through the seam (ADR-0016 P5 step 2)

### DIFF
--- a/src/builtins/map_hash_coerce.rs
+++ b/src/builtins/map_hash_coerce.rs
@@ -168,17 +168,11 @@ pub(crate) fn to_hash(target: Value, check_odd: bool) -> Result<Value, RuntimeEr
             }),
             |w| w.clone(),
         )),
-        ValueView::Instance {
-            class_name,
-            attributes,
-            ..
-        } if class_name == "Match" => {
+        ValueView::Instance { class_name, .. } if class_name == "Match" => {
             // %($/) returns the named captures hash.
-            if let Some(named) = attributes.as_map().get("named") {
-                Ok(named.clone())
-            } else {
-                Ok(Value::hash(HashMap::new()))
-            }
+            Ok(target
+                .match_named()
+                .unwrap_or_else(|| Value::hash(HashMap::new())))
         }
         _ => {
             if check_odd {

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1759,6 +1759,8 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
     } = target.view()
         && class_name == "Match"
     {
+        let list_v = target.match_list();
+        let named_v = target.match_named();
         match method {
             "from" => {
                 return Some(Ok(Value::int(target.match_from().unwrap_or(0))));
@@ -1805,16 +1807,12 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             }
             "keys" => {
                 let mut keys = Vec::new();
-                if let Some(ValueView::Array(list, _)) =
-                    attributes.as_map().get("list").map(Value::view)
-                {
+                if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
                     for i in 0..list.len() {
                         keys.push(Value::int(i as i64));
                     }
                 }
-                if let Some(ValueView::Hash(named)) =
-                    attributes.as_map().get("named").map(Value::view)
-                {
+                if let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) {
                     let mut sorted: Vec<&String> = named.keys().collect();
                     sorted.sort();
                     for k in sorted {
@@ -1825,9 +1823,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             }
             "values" => {
                 let mut vals = Vec::new();
-                if let Some(ValueView::Array(list, _)) =
-                    attributes.as_map().get("list").map(Value::view)
-                {
+                if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
                     // A quantified positional capture (`( ... )*` — $0 is an
                     // Array of per-iteration Matches) flattens into the value
                     // list, matching raku's Seq flattening: `$m.values` over
@@ -1840,9 +1836,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                         }
                     }
                 }
-                if let Some(ValueView::Hash(named)) =
-                    attributes.as_map().get("named").map(Value::view)
-                {
+                if let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) {
                     let mut sorted: Vec<(&String, &Value)> = named.iter().collect();
                     sorted.sort_by_key(|(k, _)| (*k).clone());
                     for (_, v) in sorted {
@@ -1853,16 +1847,12 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             }
             "pairs" => {
                 let mut pairs = Vec::new();
-                if let Some(ValueView::Array(list, _)) =
-                    attributes.as_map().get("list").map(Value::view)
-                {
+                if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
                     for (i, v) in list.iter().enumerate() {
                         pairs.push(Value::pair(i.to_string(), v.clone()));
                     }
                 }
-                if let Some(ValueView::Hash(named)) =
-                    attributes.as_map().get("named").map(Value::view)
-                {
+                if let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) {
                     let mut sorted: Vec<(&String, &Value)> = named.iter().collect();
                     sorted.sort_by_key(|(k, _)| (*k).clone());
                     for (k, v) in sorted {
@@ -1873,9 +1863,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             }
             "kv" => {
                 let mut kv = Vec::new();
-                if let Some(ValueView::Array(list, _)) =
-                    attributes.as_map().get("list").map(Value::view)
-                {
+                if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
                     for (i, v) in list.iter().enumerate() {
                         kv.push(Value::int(i as i64));
                         // A quantified capture's Array flattens after its key
@@ -1887,9 +1875,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                         }
                     }
                 }
-                if let Some(ValueView::Hash(named)) =
-                    attributes.as_map().get("named").map(Value::view)
-                {
+                if let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) {
                     let mut sorted: Vec<(&String, &Value)> = named.iter().collect();
                     sorted.sort_by_key(|(k, _)| (*k).clone());
                     for (k, v) in sorted {
@@ -1900,7 +1886,7 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(Value::array(kv)));
             }
             "elems" => {
-                let count = match attributes.as_map().get("list").map(Value::view) {
+                let count = match list_v.as_ref().map(Value::view) {
                     Some(ValueView::Array(list, _)) => list.len(),
                     _ => 0,
                 };

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -498,13 +498,10 @@ pub(crate) fn native_method_1arg(
                         let ch = s.chars().nth(idx).map(|c| Value::str(c.to_string()));
                         Some(Ok(ch.unwrap_or(Value::NIL)))
                     }
-                    ValueView::Instance {
-                        class_name,
-                        attributes,
-                        ..
-                    } if class_name == "Match" => {
+                    ValueView::Instance { class_name, .. } if class_name == "Match" => {
+                        let list_v = target.match_list();
                         if let Some(ValueView::Array(positional, ..)) =
-                            attributes.as_map().get("list").map(Value::view)
+                            list_v.as_ref().map(Value::view)
                         {
                             return Some(Ok(positional.get(idx).cloned().unwrap_or(Value::NIL)));
                         }

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -848,8 +848,9 @@ impl Interpreter {
         {
             if class_name == "Match" {
                 let key = args[0].to_string_value();
+                let named_v = target.match_named();
                 let exists = matches!(
-                    attributes.as_map().get("named").map(Value::view),
+                    named_v.as_ref().map(Value::view),
                     Some(ValueView::Hash(named)) if named.contains_key(key.as_str())
                 );
                 return Some(Ok(Value::truth(exists)));
@@ -877,17 +878,12 @@ impl Interpreter {
         target: &Value,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
-        if let ValueView::Instance {
-            class_name,
-            attributes,
-            ..
-        } = target.view()
-            && class_name == "Match"
-        {
+        if target.is_match_instance() {
             let idx = crate::runtime::to_int(&args[0]);
+            let list_v = target.match_list();
             let exists = idx >= 0
                 && matches!(
-                    attributes.as_map().get("list").map(Value::view),
+                    list_v.as_ref().map(Value::view),
                     Some(ValueView::Array(items, ..)) if (idx as usize) < items.len()
                 );
             return Some(Ok(Value::truth(exists)));
@@ -1018,18 +1014,10 @@ impl Interpreter {
             // `$match.AT-KEY("name")` — named-capture lookup, mirroring the
             // `$match<name>` postcircumfix. Routed here by hyper method calls such
             // as `@<chars>».<spaces>`, which dispatch `.AT-KEY` per element.
-            (
-                ValueView::Instance {
-                    class_name,
-                    attributes,
-                    ..
-                },
-                idx,
-            ) if class_name == "Match" => {
+            (ValueView::Instance { class_name, .. }, idx) if class_name == "Match" => {
                 let key = idx.to_string_value();
-                if let Some(ValueView::Hash(named)) =
-                    attributes.as_map().get("named").map(Value::view)
-                {
+                let named_v = target.match_named();
+                if let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) {
                     Some(Ok(named.get(key.as_str()).cloned().unwrap_or(Value::NIL)))
                 } else {
                     Some(Ok(Value::NIL))

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -223,19 +223,15 @@ impl Interpreter {
                 Some(&text),
             );
             // Set positional capture env vars ($0, $1, ...) from match object
-            if let ValueView::Instance { attributes, .. } = match_obj.view()
-                && let Some(ValueView::Array(list, _)) =
-                    attributes.as_map().get("list").map(Value::view)
-            {
+            let list_v = match_obj.match_list();
+            if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
                 for (i, v) in list.iter().enumerate() {
                     self.env.insert(i.to_string(), v.clone());
                 }
             }
             // Set named capture env vars from match object
-            if let ValueView::Instance { attributes, .. } = match_obj.view()
-                && let Some(ValueView::Hash(named_hash)) =
-                    attributes.as_map().get("named").map(Value::view)
-            {
+            let named_v = match_obj.match_named();
+            if let Some(ValueView::Hash(named_hash)) = named_v.as_ref().map(Value::view) {
                 for (k, v) in named_hash.iter() {
                     self.env.insert(format!("<{}>", k), v.clone());
                 }

--- a/src/runtime/methods_string_subst_repl.rs
+++ b/src/runtime/methods_string_subst_repl.rs
@@ -100,10 +100,8 @@ impl Interpreter {
             if positional_len == 0 {
                 self.env.insert("0".to_string(), Value::NIL);
             }
-            if let ValueView::Instance { attributes, .. } = match_obj.view()
-                && let Some(ValueView::Hash(named_hash)) =
-                    attributes.as_map().get("named").map(Value::view)
-            {
+            let named_v = match_obj.match_named();
+            if let Some(ValueView::Hash(named_hash)) = named_v.as_ref().map(Value::view) {
                 for (k, v) in named_hash.iter() {
                     self.env.insert(format!("<{}>", k), v.clone());
                 }

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -390,11 +390,8 @@ impl Interpreter {
             None,
             &caps.named_quantified,
         );
-        let ValueView::Instance { attributes, .. } = full.view() else {
-            return out;
-        };
-        let attr_map = attributes.as_map();
-        let Some(ValueView::Hash(named)) = attr_map.get("named").map(Value::view) else {
+        let named_v = full.match_named();
+        let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) else {
             return out;
         };
         let mut scratch = Interpreter {

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -562,18 +562,14 @@ impl Interpreter {
         node_match: Value,
     ) -> Option<Value> {
         // Named captures carrying a child `.made` (from the recursion above).
-        let ast_named: Vec<(String, Value)> =
-            if let ValueView::Instance { attributes, .. } = node_match.view() {
-                match attributes.as_map().get("named").map(Value::view) {
-                    Some(ValueView::Hash(named_hash)) => named_hash
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect(),
-                    _ => Vec::new(),
-                }
-            } else {
-                Vec::new()
-            };
+        let named_v = node_match.match_named();
+        let ast_named: Vec<(String, Value)> = match named_v.as_ref().map(Value::view) {
+            Some(ValueView::Hash(named_hash)) => named_hash
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+            _ => Vec::new(),
+        };
         let saved_match = self.env.get("/").cloned();
         // Fresh `make` slot for this node (do not inherit a sibling's value).
         self.env.remove("made");

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -107,10 +107,8 @@ impl Interpreter {
             self.env.insert("0".to_string(), Value::NIL);
         }
         // Set named capture env vars from the match object's named hash
-        if let ValueView::Instance { attributes, .. } = match_obj.view()
-            && let Some(ValueView::Hash(named_hash)) =
-                attributes.as_map().get("named").map(Value::view)
-        {
+        let named_v = match_obj.match_named();
+        if let Some(ValueView::Hash(named_hash)) = named_v.as_ref().map(Value::view) {
             for (k, v) in named_hash.iter() {
                 self.env.insert(format!("<{}>", k), v.clone());
             }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -771,20 +771,16 @@ impl Interpreter {
                         attributes.insert("ast".to_string(), made_val);
                     }
                     // Upgrade positional capture env vars ($0, $1, ...) to Match objects
-                    if let ValueView::Instance { attributes, .. } = match_obj.view()
-                        && let Some(ValueView::Array(list, _)) =
-                            attributes.as_map().get("list").map(Value::view)
-                    {
+                    let list_v = match_obj.match_list();
+                    if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
                         for (i, v) in list.iter().enumerate() {
                             self.env.insert(i.to_string(), v.clone());
                         }
                     }
                     // Set named capture env vars from the match object's named hash
                     // so subcapture-aware Match objects are used (not plain strings)
-                    if let ValueView::Instance { attributes, .. } = match_obj.view()
-                        && let Some(ValueView::Hash(named_hash)) =
-                            attributes.as_map().get("named").map(Value::view)
-                    {
+                    let named_v = match_obj.match_named();
+                    if let Some(ValueView::Hash(named_hash)) = named_v.as_ref().map(Value::view) {
                         for (k, v) in named_hash.iter() {
                             self.env.insert(format!("<{}>", k), v.clone());
                         }

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -219,17 +219,11 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
             ))
         }
         ValueView::Nil => Value::hash(HashMap::new()),
-        ValueView::Instance {
-            class_name,
-            attributes,
-            ..
-        } if class_name == "Match" => {
+        ValueView::Instance { class_name, .. } if class_name == "Match" => {
             // %($/) returns the named captures hash
-            if let Some(named) = attributes.as_map().get("named") {
-                named.clone()
-            } else {
-                Value::hash(HashMap::new())
-            }
+            value
+                .match_named()
+                .unwrap_or_else(|| Value::hash(HashMap::new()))
         }
         _ => {
             let mut map = HashMap::new();

--- a/src/vm/vm_smartmatch_ops.rs
+++ b/src/vm/vm_smartmatch_ops.rs
@@ -277,14 +277,9 @@ impl Interpreter {
             | ValueView::RaceSeq(items)
             | ValueView::Slip(items) => Value::int(items.len() as i64),
             ValueView::Capture { positional, .. } => Value::int(positional.len() as i64),
-            ValueView::Instance {
-                class_name,
-                attributes,
-                ..
-            } if class_name == "Match" => {
-                if let Some(ValueView::Array(items, _)) =
-                    attributes.as_map().get("list").map(Value::view)
-                {
+            ValueView::Instance { class_name, .. } if class_name == "Match" => {
+                let list_v = value.match_list();
+                if let Some(ValueView::Array(items, _)) = list_v.as_ref().map(Value::view) {
                     Value::int(items.len() as i64)
                 } else {
                     Value::int(1)

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1028,17 +1028,11 @@ impl Interpreter {
                     v
                 }
             }
-            (
-                ValueView::Instance {
-                    class_name,
-                    attributes,
-                    ..
-                },
-                ValueView::Array(keys, ..),
-            ) if class_name == "Match" => {
-                if let Some(ValueView::Hash(named)) =
-                    attributes.as_map().get("named").map(Value::view)
-                {
+            (ValueView::Instance { class_name, .. }, ValueView::Array(keys, ..))
+                if class_name == "Match" =>
+            {
+                let named_v = target.match_named();
+                if let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) {
                     Value::array(
                         keys.iter()
                             .map(|k| {
@@ -1051,35 +1045,23 @@ impl Interpreter {
                     Value::array(vec![Value::NIL; keys.len()])
                 }
             }
-            (
-                ValueView::Instance {
-                    class_name,
-                    attributes,
-                    ..
-                },
-                ValueView::Str(key),
-            ) if class_name == "Match" => {
-                if let Some(ValueView::Hash(named)) =
-                    attributes.as_map().get("named").map(Value::view)
-                {
+            (ValueView::Instance { class_name, .. }, ValueView::Str(key))
+                if class_name == "Match" =>
+            {
+                let named_v = target.match_named();
+                if let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) {
                     named.get(key.as_str()).cloned().unwrap_or(Value::NIL)
                 } else {
                     Value::NIL
                 }
             }
-            (
-                ValueView::Instance {
-                    class_name,
-                    attributes,
-                    ..
-                },
-                ValueView::Int(i),
-            ) if class_name == "Match" => {
+            (ValueView::Instance { class_name, .. }, ValueView::Int(i))
+                if class_name == "Match" =>
+            {
+                let list_v = target.match_list();
                 if i < 0 {
                     Value::NIL
-                } else if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("list").map(Value::view)
-                {
+                } else if let Some(ValueView::Array(items, ..)) = list_v.as_ref().map(Value::view) {
                     items.get(i as usize).cloned().unwrap_or(Value::NIL)
                 } else {
                     Value::NIL


### PR DESCRIPTION
## Summary

Continues #5581 (ADR-0016 P5 pure refactor): the scattered sites that read a Match's `list`/`named` structure now go through `match_list()`/`match_named()`.

- `$/` subscripts in `vm_var_index_ops` (string key, int index, key-array slice), `vm_smartmatch_ops` elems, `EXISTS-KEY`/`EXISTS-POS`/`AT-KEY` in `methods_dispatch_match3`, `AT-POS` in `dispatch_1arg`
- `%($/)` coercions (`coerce_containers`, `map_hash_coerce`)
- Capture env-var installation after a match (`methods_match_dispatch`, `methods_string_subst_repl`, `seq_helpers/regex_captures`, `smart_match`)
- `run_named_capture_actions` (`regex_eval`) and the reduce walk's `ast_named` extraction (`regex_eval_repeat`)
- The `methods_0arg` Match dispatch `keys`/`values`/`pairs`/`kv`/`elems` arms (seam locals hoisted once per call)

Generic-instance sites serving non-Match cursor-like objects, the rebuild/mutate sites (`with_ast` helper territory), and Match-centric modules the final repr swap rewrites wholesale keep inline access — tracked in `todo/deep/adr0016-p5-match-consumer-inventory.md`. Net −83 lines.

Pure refactor, no behavior change intended.

## Test plan

- Full local `t/` suite: **24,921 tests PASS**
- Full local `make roast`: **1435 files / 218,774 tests PASS** (release)
- `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)