### PR TITLE
refactor(match): rebuild helpers for Match attribute writes (ADR-0016 P5 step 3)

### DIFF
--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2171,27 +2171,11 @@ impl Interpreter {
             return result;
         }
         // Match.make
-        if let ValueView::Instance {
-            class_name,
-            attributes,
-            id,
-        } = target.view()
-            && class_name == "Match"
-            && method == "make"
+        if method == "make"
+            && let Some(updated) =
+                target.match_with_ast_keeping_id(args.first().cloned().unwrap_or(Value::NIL))
         {
             let value = args.first().cloned().unwrap_or(Value::NIL);
-            let attrs = crate::value::InstanceAttrs::clone(&attributes);
-            attrs.insert("ast".to_string(), value.clone());
-            let updated = Value::instance_parts(
-                class_name,
-                crate::gc::Gc::new(crate::value::InstanceAttrs::new(
-                    class_name,
-                    (attrs).to_map(),
-                    id,
-                    false,
-                )),
-                id,
-            );
             self.env.insert("/".to_string(), updated);
             self.env.insert("made".to_string(), value.clone());
             self.action_made = Some(value.clone());

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -501,35 +501,26 @@ impl Interpreter {
                 Some(&text),
                 &captures.named_quantified,
             );
-            let match_obj = if let ValueView::Instance {
-                class_name,
-                attributes,
-                ..
-            } = match_obj.view()
-            {
-                let attrs = attributes.as_ref().clone();
+            let match_obj = {
+                let mut updates: Vec<(&str, Value)> = Vec::new();
                 if let Some(ast) = self.env.get("made").cloned() {
-                    attrs.insert("ast".to_string(), ast);
+                    updates.push(("ast", ast));
                 }
                 if let Some(ref act) = actions_obj {
-                    attrs.insert("actions".to_string(), act.clone());
+                    updates.push(("actions", act.clone()));
                 }
                 if !alias_map.is_empty() {
                     let alias_hash: HashMap<String, Value> = alias_map
                         .iter()
                         .map(|(k, v)| (k.clone(), Value::str(v.clone())))
                         .collect();
-                    attrs.insert("capture_alias_map".to_string(), Value::hash(alias_hash));
+                    updates.push(("capture_alias_map", Value::hash(alias_hash)));
                 }
-                Value::make_instance(class_name, (attrs).to_map())
-            } else {
-                match_obj
+                match_obj.match_with_attrs(updates).unwrap_or(match_obj)
             };
             // Set named capture env vars from match object
-            if let ValueView::Instance { attributes, .. } = match_obj.view()
-                && let Some(ValueView::Hash(named_hash)) =
-                    attributes.as_map().get("named").map(Value::view)
-            {
+            let named_v = match_obj.match_named();
+            if let Some(ValueView::Hash(named_hash)) = named_v.as_ref().map(Value::view) {
                 for (k, v) in named_hash.iter() {
                     self.env.insert(format!("<{}>", k), v.clone());
                 }

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -252,18 +252,9 @@ impl Interpreter {
                 &[],
                 &HashMap::new(),
             );
-            if let ValueView::Instance {
-                class_name,
-                attributes,
-                ..
-            } = match_obj.view()
-            {
-                let attrs = attributes.as_ref().clone();
-                attrs.insert("ast".to_string(), ast.clone());
-                Value::make_instance(class_name, (attrs).to_map())
-            } else {
-                match_obj
-            }
+            match_obj
+                .match_with_attrs(vec![("ast", ast.clone())])
+                .unwrap_or(match_obj)
         };
         // Build the named-capture submatches once, so they can be installed BOTH
         // as `$<name>` variables AND into the `$/` match object's `named`
@@ -306,20 +297,12 @@ impl Interpreter {
             &[],
             &HashMap::new(),
         );
-        let match_obj = if let ValueView::Instance {
-            class_name,
-            attributes,
-            ..
-        } = match_obj.view()
-        {
-            let attrs = attributes.as_ref().clone();
-            attrs.insert("named".to_string(), Value::hash(named_map));
+        let match_obj = {
+            let mut updates = vec![("named", Value::hash(named_map))];
             if !pos_list.is_empty() {
-                attrs.insert("list".to_string(), Value::array(pos_list));
+                updates.push(("list", Value::array(pos_list)));
             }
-            Value::make_instance(class_name, attrs.to_map())
-        } else {
-            match_obj
+            match_obj.match_with_attrs(updates).unwrap_or(match_obj)
         };
         self.env.insert("/".to_string(), match_obj.clone());
         // Set up $¢ (current match cursor) — same as $/ for in-progress match
@@ -590,18 +573,14 @@ impl Interpreter {
             // from the block's matched-so-far context (mid-rule `{ … $/ … }`).
             if !ast_named.is_empty()
                 && let Some(cur) = self.env.get("/").cloned()
-                && let ValueView::Instance {
-                    class_name,
-                    attributes,
-                    ..
-                } = cur.view()
             {
-                let attrs = attributes.as_ref().clone();
                 let named_hash: HashMap<String, Value> = ast_named.iter().cloned().collect();
-                attrs.insert("named".to_string(), Value::hash(named_hash));
-                let updated = Value::make_instance(class_name, attrs.to_map());
-                self.env.insert("/".to_string(), updated.clone());
-                self.env.insert("\u{00A2}".to_string(), updated);
+                if let Some(updated) =
+                    cur.match_with_attrs(vec![("named", Value::hash(named_hash))])
+                {
+                    self.env.insert("/".to_string(), updated.clone());
+                    self.env.insert("\u{00A2}".to_string(), updated);
+                }
             }
             self.eval_regex_code_block_body(&stmts);
         }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -758,18 +758,25 @@ impl Interpreter {
                         });
                     }
                     // If the original value is not a Str, store the original value
-                    // as the `orig` attribute so .orig preserves the type
-                    if left.as_str().is_none()
-                        && let ValueView::Instance { attributes, .. } = match_obj.view()
-                    {
-                        attributes.insert("orig".to_string(), left.clone());
+                    // as the `orig` attribute so .orig preserves the type; if
+                    // `make` was called in a code block, set the ast attribute.
+                    // (This was the one site that mutated a live Match's
+                    // attributes in place; the identity-keeping rebuild is
+                    // equivalent — the object is freshly built and unshared.)
+                    let mut updates: Vec<(&str, Value)> = Vec::new();
+                    if left.as_str().is_none() {
+                        updates.push(("orig", left.clone()));
                     }
-                    // If `make` was called in a code block, set the ast attribute
-                    if let Some(made_val) = self.env.get("made").cloned()
-                        && let ValueView::Instance { attributes, .. } = match_obj.view()
-                    {
-                        attributes.insert("ast".to_string(), made_val);
+                    if let Some(made_val) = self.env.get("made").cloned() {
+                        updates.push(("ast", made_val));
                     }
+                    let match_obj = if updates.is_empty() {
+                        match_obj
+                    } else {
+                        match_obj
+                            .match_with_attrs_keeping_id(updates)
+                            .unwrap_or(match_obj)
+                    };
                     // Upgrade positional capture env vars ($0, $1, ...) to Match objects
                     let list_v = match_obj.match_list();
                     if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {

--- a/src/value/match_view.rs
+++ b/src/value/match_view.rs
@@ -82,4 +82,57 @@ impl Value {
             _ => None,
         }
     }
+
+    /// A Match equal to `self` with the given attributes replaced — the
+    /// rebuild pattern every post-hoc attribute write (`.made`/`ast`,
+    /// `actions`, `capture_alias_map`, `orig`, `named`, `list`) uses.
+    /// `None` when `self` is not a Match. The rebuilt Match is a fresh
+    /// instance (new identity), same as the inline clone-insert-rebuild
+    /// sites this replaces.
+    pub(crate) fn match_with_attrs(&self, updates: Vec<(&str, Value)>) -> Option<Value> {
+        match self.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "Match" => {
+                let attrs = attributes.as_ref().clone();
+                for (k, v) in updates {
+                    attrs.insert(k.to_string(), v);
+                }
+                Some(Value::make_instance(class_name, attrs.to_map()))
+            }
+            _ => None,
+        }
+    }
+
+    /// [`Self::match_with_attrs`], but preserving the instance identity —
+    /// `Match.make` writes the updated Match back under the SAME id, because
+    /// consumers re-read live objects by `(class, id)` match (see the grammar
+    /// action walk). `None` when `self` is not a Match.
+    pub(crate) fn match_with_attrs_keeping_id(&self, updates: Vec<(&str, Value)>) -> Option<Value> {
+        match self.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                id,
+            } if class_name == "Match" => {
+                let attrs = InstanceAttrs::clone(&attributes);
+                for (k, v) in updates {
+                    attrs.insert(k.to_string(), v);
+                }
+                Some(Value::instance_parts(
+                    class_name,
+                    crate::gc::Gc::new(InstanceAttrs::new(class_name, attrs.to_map(), id, false)),
+                    id,
+                ))
+            }
+            _ => None,
+        }
+    }
+
+    /// A Match with `.ast` set, preserving the instance identity (`Match.make`).
+    pub(crate) fn match_with_ast_keeping_id(&self, ast: Value) -> Option<Value> {
+        self.match_with_attrs_keeping_id(vec![("ast", ast)])
+    }
 }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1110,28 +1110,9 @@ impl Interpreter {
         }
         // Handle Match.make — must mutate the Match instance's `ast` attribute
         // and write the modified Match back to the variable.
-        if method == "make"
-            && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Match")
-        {
+        if method == "make" && target.is_match_instance() {
             let value = args.into_iter().next().unwrap_or(Value::NIL);
-            if let ValueView::Instance {
-                class_name,
-                attributes,
-                id,
-            } = target.view()
-            {
-                let attrs = crate::value::InstanceAttrs::clone(&attributes);
-                attrs.insert("ast".to_string(), value.clone());
-                let updated = Value::instance_parts(
-                    class_name,
-                    crate::gc::Gc::new(crate::value::InstanceAttrs::new(
-                        class_name,
-                        (attrs).to_map(),
-                        id,
-                        false,
-                    )),
-                    id,
-                );
+            if let Some(updated) = target.match_with_ast_keeping_id(value.clone()) {
                 self.env_mut().insert(target_name.to_string(), updated);
                 self.env_mut().insert("made".to_string(), value.clone());
                 self.action_made = Some(value.clone());


### PR DESCRIPTION
## Summary

Third seam slice for ADR-0016 P5 (after #5581, #5584): the copy-on-write half.

- `Value::match_with_attrs(updates)` — the clone-insert-rebuild pattern (fresh identity), and `match_with_attrs_keeping_id` / `match_with_ast_keeping_id` — same-instance-id rebuilds (`Match.make` writes back under the id consumers use to re-read live objects).
- Funnels the rebuild sites: the grammar parse `ast`/`actions`/`capture_alias_map` rebuild (`methods_grammar`), the code-block `$/` construction and ast-carrying `$/` fold (`regex_eval_repeat` ×3), and the near-duplicate `Match.make` twins (`methods_call_dispatch` + `vm_call_method_mut_ops`) — now one helper.
- Converts the **one site that mutated a live Match's attributes in place** (`smart_match` `orig`/`ast`) to the identity-keeping rebuild — the object is freshly built and unshared there, so the rebuild is equivalent. No in-place Match mutation remains outside the action walk.
- The action-walk's `updated_attrs` rebuild stays inline: it rebuilds from walk-local state, not from the Match itself, and is rewritten wholesale by the repr swap.

Pure refactor, no behavior change intended.

## Test plan

- Full local `t/` suite: **24,921 tests PASS**
- Full local `make roast`: **1435 files / 218,774 tests PASS** (release)
- `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)