### PR TITLE
docs: ticket a fatal-signal crash reporter so the next SIGSEGV yields evidence

### DIFF
--- a/todo/deep/procasync-stress-segv.md
+++ b/todo/deep/procasync-stress-segv.md
@@ -93,6 +93,11 @@ no Rust changes at all — so the crash cannot have been introduced by that diff
 2. It very likely will *not* reproduce standalone (see above) — so prefer a CI-side approach: enable
    core dumps in the `test` job, or add a sanitizer/`gdb`-attached variant, rather than burning local
    cycles on a loop that has already come up empty 22 times.
+   **The cheapest version of that is already specced:
+   [todo/tickets/crash-report-on-fatal-signal.md](../tickets/crash-report-on-fatal-signal.md)** — an
+   in-process fatal-signal handler that records the fault address, pid and argv. It answers the
+   parent-vs-child question below at zero steady-state cost, and is worth landing before anything
+   heavier.
 3. Only quarantine it in `flaky-tests.txt` if the evidence standard in `docs/flaky-test-policy.md` is
    actually met — and note that a *crash* is a poor quarantine candidate, since retrying hides a real
    memory-safety bug rather than tolerating benign non-determinism.

--- a/todo/tickets/crash-report-on-fatal-signal.md
+++ b/todo/tickets/crash-report-on-fatal-signal.md
@@ -1,0 +1,74 @@
+# Write a crash report when the interpreter dies of a fatal signal
+
+When mutsu segfaults, CI tells us nothing beyond `Wstat: 11 (Signal: SEGV)`. That is what happened
+to `roast/S17-procasync/stress.t` (see [procasync-stress-segv.md](../deep/procasync-stress-segv.md)):
+a rare crash on CI, not reproducible locally in 22 attempts, and the wait status alone left two basic
+questions unanswered — *which* process faulted (the `.t` file's interpreter, or the subprocess
+`is_run` had spawned?) and *where*. A crash that rare has to yield its evidence the one time it
+fires; there is no second chance to attach a debugger.
+
+## What to build
+
+Install a handler for the fatal signals (SIGSEGV, SIGBUS, SIGILL, SIGFPE, SIGABRT) at startup and
+have it write a per-process crash report, then re-raise so the wait status is unchanged.
+
+- **Use `sigaltstack` + `sigaction` with `SA_ONSTACK`.** The alternate stack is not optional: a
+  stack-overflow SIGSEGV leaves no stack for the handler to run on, and without it the handler simply
+  never runs.
+- **Write to a file, not stderr** — `tmp/crash/<pid>.txt` or similar. Under `prove` the output is
+  merged and captured, and in the motivating case the TAP stream was already derailed; a file
+  survives regardless.
+- **Record, at minimum:**
+  - signal number and `si_addr` (the fault address) — distinguishes a null deref from a freed/garbage
+    pointer at a glance
+  - **pid and argv** — this alone answers the parent-vs-`is_run`-child question that the procasync
+    note had to leave open
+  - the faulting thread's id/name
+  - a backtrace (best effort, see below)
+- **Re-raise the original signal** after writing, restoring the default disposition, so the exit
+  status and any core dump behaviour stay exactly as they are today.
+
+`libc` is already a dependency of the default `native` feature, so no new crate is strictly required
+(the `backtrace` crate would be if we want `trace_unsynchronized`).
+
+## Cost
+
+Two syscalls at startup and nothing else until a crash. Gate it behind `MUTSU_CRASH_REPORT=1` (set in
+CI) if even that is unwanted in the shipped binary — but the steady-state cost is genuinely nil, so
+default-on is defensible.
+
+## Known limitations — do not oversell this
+
+- **The handler is not async-signal-safe.** `std::backtrace::Backtrace::force_capture()` allocates
+  and takes locks, so if the fault happened inside the allocator the handler can deadlock or fault
+  again. Mitigate with `alarm(10)` before capturing (a wedged handler still dies) and/or the
+  `backtrace` crate's `trace_unsynchronized`. Accept that the backtrace is best-effort; the signal
+  number, fault address, pid and argv are the parts that will reliably land, and they are already
+  more than we have today.
+- **`[profile.release]` sets `debug = false`** (deliberately — full debuginfo costs ~250MB per binary
+  and ~70s of link time, see the comment in `Cargo.toml`). So symbolication in the build that
+  `make roast` actually runs will be poor. Do **not** flip `debug = 1` as part of this ticket: ship
+  the handler first, look at what a real report contains, and only then weigh line tables against
+  binary size, build time, and the risk that changing the build perturbs the timing of a
+  concurrency Heisenbug.
+- **This is instrumentation, not a fix.** At roughly one occurrence in several dozen CI runs, nothing
+  happens until the bug next appears. The value is that the next occurrence produces an answer
+  instead of another dead end.
+
+## CI wiring
+
+Small: `ci.yml` already has the pattern. Add an `if: failure()` step that cats any
+`tmp/crash/*.txt` into a log group and an `actions/upload-artifact` step alongside the existing
+`roast-log` upload.
+
+## Follow-ons (separate tickets, not this one)
+
+- **Core dumps in CI.** GHA runners have sudo, so `ulimit -c unlimited` plus a `kernel.core_pattern`
+  override (Ubuntu's apport must be displaced) would let a failure step run
+  `gdb -batch -ex 'thread apply all bt'` and upload the text. The advantage over the in-process
+  handler is *all* threads' stacks, which matters for a concurrency bug. Same debuginfo caveat.
+- **A sanitizer job.** A scheduled (not per-PR) workflow running the S17 subset in a loop under
+  `-Zsanitizer=address` would name the exact bad access, which is what actually root-causes a
+  GC/concurrency bug. Materially more work: nightly toolchain, a 2-3x slowdown that may stop the race
+  reproducing at all, triage of the GC's deliberate raw-pointer writes, and suppressions for
+  libffi/native calls. Worth doing only once there is a reason to believe it will fire.


### PR DESCRIPTION
When mutsu segfaults, CI tells us nothing beyond `Wstat: 11 (Signal: SEGV)`. That is exactly what happened to `roast/S17-procasync/stress.t` (#5585, #5587): a crash that is not reproducible locally in 22 attempts, leaving two basic questions unanswered — *which* process faulted (the `.t` file's interpreter, or the subprocess `is_run` spawned?) and *where*. At roughly one occurrence in several dozen CI runs, there is no second chance to attach a debugger; the one time it fires has to produce evidence.

The ticket specs the cheap layer: a `sigaltstack` + `sigaction` handler for the fatal signals that writes `tmp/crash/<pid>.txt` (signal number, `si_addr`, pid and argv, faulting thread, best-effort backtrace) and then re-raises so the wait status and core-dump behaviour are unchanged. `libc` is already in the default `native` feature, the alternate stack is called out as non-optional (a stack-overflow SEGV has no stack left for the handler), and the report goes to a **file** rather than stderr because `prove` captures output and the TAP stream was already derailed in the motivating case. CI wiring is one `if: failure()` step next to the existing `roast-log` upload.

It is deliberately explicit about what this does **not** buy:

- the handler is **not async-signal-safe** — `Backtrace::force_capture()` allocates, so a fault inside the allocator can wedge it; the backtrace is best-effort while the signal/address/pid/argv are the parts that reliably land
- `[profile.release]` sets `debug = false` on purpose (~250MB binary, ~70s link time), so symbolication in the build `make roast` runs will be poor — the ticket says **not** to flip it here, but to look at a real report first and weigh it against perturbing a concurrency Heisenbug
- this is **instrumentation, not a fix**: nothing happens until the bug next appears

Core dumps in CI and a sanitizer job are recorded as heavier follow-ons with their costs stated, rather than folded into this slice. Also linked from the procasync deep note.

Docs only — no implementation in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)