### PR TITLE
perf(regex): lazy Match representation (ADR-0016 P5 repr swap)

### DIFF
--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -297,6 +297,29 @@ cover 55 of the 72; three more close the set (`match_ast`, `match_meta`,
 builder-side swap is cheap; the rebuilders need a `with_ast(...)`-style copy-on-write
 helper first, and the one in-place mutator (`smart_match.rs`) must convert to the
 rebuild pattern.
+**Landed 2026-07-31** (`news/2026-07/regex-lazy-match-repr.md`): the repr is
+`ValueRepr::Match(Gc<MatchNode>)` where `MatchNode = { orig: Option<Arc<String>>,
+cap: Arc<CapNode>, id, attrs: OnceLock<Gc<InstanceAttrs>> }`. Rather than adding a
+`ValueView::Match` arm (which would have forced every consumer to change), `view()`
+materializes the memoized one-level attribute map and presents
+`ValueView::Instance("Match")` — so consumers are unchanged and laziness is
+preserved exactly where the seam accessors and tag probes keep `view()` from
+running. Children materialize as lazy Matches themselves (one `Gc` alloc each).
+The action walk skips actionless nodes via a capture-node peek and runs
+leaf actions (`make ~$/` per char, the YAMLish shape) against the lazy `$/`,
+applying `make` as a fresh lazy node. Two consequences worth recording:
+(1) the "grammar-action walk materializes only where `has_user_method` says so"
+plan met reality — YAMLish DOES define per-char leaf actions (`space`,
+`single-bare`), so the win there came from the leaf-action fast path, not from
+skipping; (2) keeping a lazy value alive across generic dispatch required
+converting ~20 `matches!(v.view(), …)` variant probes into pure tag probes —
+a `view()`-based "is it an X?" check is now an anti-pattern anywhere a lazy
+Match can flow. Measured by instrumentation: leaf materializations on a YAMLish
+parse fell 1807 → 15; local interleaved A/B (idle box): `bench-yaml-parse`
+1.31 s → 0.87 s (≈ −34 %), bench CI to confirm.
+The reduce walk (`reduce_cap_node_for_rule` code-block replay) and the failed
+partial-parse replay still build eager Matches for `$/` inside in-regex code
+blocks — small counts, unchanged semantics.
 
 ## Consequences
 

--- a/news/2026-07/regex-lazy-match-repr.md
+++ b/news/2026-07/regex-lazy-match-repr.md
@@ -1,0 +1,45 @@
+# Lazy `Match` representation (ADR-0016 P5 repr swap)
+
+The regex/grammar `Match` object is no longer built eagerly. A match now
+produces `ValueRepr::Match(Gc<MatchNode>)` — a NaN-box kind holding the shared
+subject string (`Arc<String>`) and the stored capture node (`Arc<CapNode>`,
+which the matcher already built) plus a memoized `OnceLock<Gc<InstanceAttrs>>`.
+The Instance-shaped attribute map materializes on first `view()` decode, ONE
+level at a time: child captures become lazy `Match` values themselves, so a
+subtree nobody observes never allocates anything.
+
+Because `view()` presents a lazy Match as `ValueView::Instance("Match")`,
+every unconverted consumer keeps working unchanged — the P5 seam
+(`match_view.rs`) answers scalar reads (`.from`/`.to`/`.Str`/`.made`/`.orig`)
+straight from the capture node without materializing, and the three
+`make_match_object_*` builders now just synthesize a top-level `CapNode` from
+the exploded capture axes.
+
+The grammar-action walk gained two structural fast paths:
+
+- an **actionless node** (no action method for its rule) is skipped without
+  materializing anything — checked against the capture node via
+  `match_walk_peek`;
+- a **childless leaf WITH an action** (YAMLish's per-character
+  `method space($/) { make ~$/ }` shape) runs its action with the lazy Match
+  as `$/` and applies the `make` by building a fresh lazy node carrying the
+  `ast` — no `InstanceAttrs` is ever created for it. The rule's reduce-time
+  `:my $*x` bindings are re-installed around the action, same as the main
+  walk (pinned by `t/grammar-per-match-dynvar-action.t`).
+
+Keeping the leaf lazy across the action call required sweeping the dispatch
+path's variant probes: ~20 sites that pattern-matched `value.view()` just to
+ask "is this a Pair / Junction / Proxy / VarRef / ContainerRef / Seq / …?"
+now use pure tag probes (`is_string_pair_value()` etc., one NaN-box page
+compare) that cannot materialize a lazy Match — measured by instrumenting
+`MatchNode` materialization on a YAMLish parse: leaf materializations fell
+from 1807 (every leaf) to 15.
+
+GC: `Gc<MatchNode>` is a collector node whose only traced edge is the
+memoized materialization; the `Arc<CapNode>` payload is treated as externally
+rooted per the shared-wrapper rule (conservative). `gc_trace` yields the node
+handle via a tag probe so a collect can never trigger materialization.
+
+Local interleaved A/B on an idle box (release, 5×5): `bench-yaml-parse`
+1.31 s → 0.87 s (**≈ −34 %**). Authoritative numbers come from the bench CI
+(`bench-history.tsv`) once merged, per the standing measurement policy.

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -308,6 +308,32 @@ pub(crate) fn native_method_0arg(
     let method = method_sym.resolve();
     let method = method.as_str();
 
+    // Lazy-Match scalar fast path: these arms are semantically identical to
+    // the Match block far below, but answered here straight from the capture
+    // node so the probe gauntlet in between (each a `view()`, which would
+    // materialize the Match) never runs. Structural methods (`gist`, `list`,
+    // `hash`, `caps`, ...) fall through and materialize as before.
+    if target.is_lazy_match_value() {
+        match method {
+            "from" => return Some(Ok(Value::int(target.match_from().unwrap_or(0)))),
+            "to" | "pos" => return Some(Ok(Value::int(target.match_to().unwrap_or(0)))),
+            "Str" => {
+                return Some(Ok(target
+                    .match_str_value()
+                    .unwrap_or_else(|| Value::str(String::new()))));
+            }
+            "Bool" => return Some(Ok(Value::truth(!target.match_is_failed()))),
+            "orig" | "target" => {
+                return Some(Ok(target
+                    .match_orig()
+                    .unwrap_or_else(|| Value::str(String::new()))));
+            }
+            "ast" | "made" => return Some(Ok(target.match_ast().unwrap_or(Value::NIL))),
+            "Capture" | "clone" => return Some(Ok(target.clone())),
+            _ => {}
+        }
+    }
+
     // Scalar containers are transparent for method dispatch (except .VAR and
     // .raku/.perl). `.raku`/`.perl` must see the `Scalar` wrapper so an itemized
     // aggregate shows its `$` sigil (`${a=>1}.raku` → `${:a(1)}`); decontainer-

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -149,6 +149,11 @@ impl Interpreter {
         &self,
         value: &Value,
     ) -> Option<RuntimeError> {
+        // A lazy Match is never a Failure — tag probe, so the per-capture
+        // `~$match` path cannot materialize it here.
+        if value.is_lazy_match_value() {
+            return None;
+        }
         let ValueView::Instance {
             class_name,
             attributes,

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -166,9 +166,7 @@ impl Interpreter {
 
     pub(super) fn builtin_slurp(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         // Check if first arg is a named pair (not a positional path)
-        let first_is_pair = args
-            .first()
-            .is_none_or(|v| matches!(v.view(), ValueView::Pair(..)));
+        let first_is_pair = args.first().is_none_or(|v| v.is_string_pair_value());
         // If no positional path argument, slurp from $*ARGFILES
         if first_is_pair {
             let argfiles = self.env.get("$*ARGFILES").cloned().unwrap_or(Value::NIL);

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -38,6 +38,11 @@ impl Interpreter {
     /// Auto-FETCH a Proxy value. If the value is a Proxy, call its FETCH callback.
     /// Used when a Proxy-bound variable is read in value context.
     pub(crate) fn auto_fetch_proxy(&mut self, value: &Value) -> Result<Value, RuntimeError> {
+        // Tag probe first: a `view()` on a lazy Match would materialize it
+        // just to see it is not a Proxy.
+        if !value.is_proxy_value() {
+            return Ok(value.clone());
+        }
         if let ValueView::Proxy { fetcher, .. } = value.view() {
             if fetcher.is_nil() {
                 return Ok(Value::NIL);

--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -29,7 +29,7 @@ impl Interpreter {
     ) -> RuntimeError {
         let arg_types = args
             .iter()
-            .filter(|v| !matches!(v.view(), ValueView::Pair(..)))
+            .filter(|v| !v.is_string_pair_value())
             .map(super::value_type_name)
             .collect::<Vec<_>>()
             .join(", ");

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -124,7 +124,7 @@ impl Interpreter {
                 if is_binding_param {
                     let type_names: Vec<String> = args
                         .iter()
-                        .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
+                        .filter(|a| !a.is_string_pair_value())
                         .map(|a| super::value_type_name(a).to_string())
                         .collect();
                     let mut err = RuntimeError::new(format!(

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -167,10 +167,7 @@ impl Interpreter {
         args: &[Value],
         current_def: &FunctionDef,
     ) -> Vec<Arc<FunctionDef>> {
-        let arity = args
-            .iter()
-            .filter(|v| !matches!(v.view(), ValueView::Pair(..)))
-            .count();
+        let arity = args.iter().filter(|v| !v.is_string_pair_value()).count();
         let search_pkgs = self.bare_name_packages();
         let typed_prefixes: Vec<String> = search_pkgs
             .iter()

--- a/src/runtime/dispatch_resolve.rs
+++ b/src/runtime/dispatch_resolve.rs
@@ -175,7 +175,7 @@ impl Interpreter {
         // Arity counts only positional args, excluding named args (Pair values)
         let arity = arg_values
             .iter()
-            .filter(|v| !matches!(v.view(), ValueView::Pair(..)))
+            .filter(|v| !v.is_string_pair_value())
             .count();
         // The proto's signature gates the whole dispatch: `proto bar {*}`
         // declares an empty signature, so any call with positional arguments
@@ -191,7 +191,7 @@ impl Interpreter {
         {
             let type_names: Vec<String> = arg_values
                 .iter()
-                .filter(|v| !matches!(v.view(), ValueView::Pair(..)))
+                .filter(|v| !v.is_string_pair_value())
                 .map(crate::value::types::what_type_name)
                 .collect();
             let msg = format!(

--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -47,7 +47,7 @@ impl Interpreter {
             let data = if data.is_none() {
                 let positional: Vec<Value> = args
                     .iter()
-                    .filter(|arg| !matches!(arg.view(), ValueView::Pair(..)))
+                    .filter(|arg| !arg.is_string_pair_value())
                     .cloned()
                     .collect();
                 if positional.is_empty() {

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -697,13 +697,17 @@ impl Interpreter {
             return Ok(Value::junction(kind, results));
         }
         if Self::should_autothread_method(method)
-            && let Some((idx, kind, values)) =
-                args.iter()
-                    .enumerate()
-                    .find_map(|(idx, arg)| match arg.view() {
-                        ValueView::Junction { kind, values } => Some((idx, kind, values.clone())),
-                        _ => None,
-                    })
+            && let Some((idx, kind, values)) = args.iter().enumerate().find_map(|(idx, arg)| {
+                // Tag probe first: a `view()` on a lazy Match would
+                // materialize it just to see it is not a Junction.
+                if !arg.is_junction_value() {
+                    return None;
+                }
+                match arg.view() {
+                    ValueView::Junction { kind, values } => Some((idx, kind, values.clone())),
+                    _ => None,
+                }
+            })
         {
             let mut results = Vec::with_capacity(values.len());
             for value in values.iter() {

--- a/src/runtime/methods_collection.rs
+++ b/src/runtime/methods_collection.rs
@@ -11,6 +11,11 @@ impl Interpreter {
 
     /// Check if a value is lazy/infinite and cannot be coerced to a QuantHash.
     pub(crate) fn is_lazy_for_coerce(value: &Value) -> bool {
+        // Tag probe: this guard runs per dispatched method call, and a
+        // `view()` on a lazy Match would materialize it.
+        if value.is_lazy_match_value() {
+            return false;
+        }
         match value.view() {
             ValueView::LazyList(_) => true,
             ValueView::Array(_, kind) if kind.is_lazy() => true,

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -467,7 +467,7 @@ impl Interpreter {
         if self.class_mro(cn_resolved).iter().any(|n| n == "Array") {
             let elems: Vec<Value> = args
                 .iter()
-                .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
+                .filter(|a| !a.is_string_pair_value())
                 .cloned()
                 .collect();
             if !elems.is_empty() || !attributes.contains_key("__mutsu_array_storage") {

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -782,6 +782,183 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Leaf fast path of [`Self::invoke_grammar_actions`]: run a STILL-LAZY,
+    /// childless Match's action method without materializing its attribute
+    /// map. The env ceremony only has to hide the parent's captures — a
+    /// childless leaf installs no `$<x>`/`$0..` of its own — and a `make`
+    /// from the action becomes a fresh lazy node carrying the `ast`
+    /// (`match_with_ast_lazy`). Per-char leaf actions (`method space($/) {
+    /// make ~$/ }`, the YAMLish shape) hit this for every matched character,
+    /// so it must not touch `InstanceAttrs` at all.
+    fn invoke_leaf_action_lazy(
+        &mut self,
+        match_obj: Value,
+        actions: &mut Value,
+        rule_name: &str,
+        sym_method_name: Option<&str>,
+    ) -> Result<Value, RuntimeError> {
+        self.env.insert("/".to_string(), match_obj.clone());
+        self.env.remove("made");
+        self.action_made = None;
+        // Hide the parent's named/positional captures from the leaf's action.
+        let saved_named_captures: Vec<(Symbol, Value)> = self
+            .env
+            .iter()
+            .filter(|(k, _)| k.starts_with("<") && k.ends_with(">"))
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        for (k, _) in &saved_named_captures {
+            self.env.remove_sym(*k);
+        }
+        let mut saved_positional: Vec<(usize, Option<Value>)> = Vec::new();
+        for i in 0..10 {
+            saved_positional.push((i, self.env.remove(&i.to_string())));
+        }
+        let saved_topic = self.env.get("_").cloned();
+        self.env.insert("_".to_string(), match_obj.clone());
+
+        // Re-install this match's own `:my $*x` bindings with the values they
+        // held when IT reduced — same as the main walk's `reduce_time_vars`
+        // handling, but read straight from the capture node.
+        let saved_reduce_vars: Vec<(String, Option<Value>)> = match_obj
+            .match_reduce_time_vars_lazy()
+            .map(|vars| {
+                vars.into_iter()
+                    .map(|(k, v)| {
+                        let prev = self.env.get(&k).cloned();
+                        self.env.insert(k.clone(), v);
+                        (k, prev)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let actions_class_name = match actions.view() {
+            ValueView::Instance { class_name, .. } => Some(class_name.as_str()),
+            ValueView::Package(name) => Some(name.as_str()),
+            _ => None,
+        };
+        let mut called_action = false;
+        let method_result = if let Some(sym_name) = sym_method_name {
+            let sym_exists = actions_class_name.is_none_or(|cn| self.has_user_method(cn, sym_name));
+            if sym_exists {
+                called_action = true;
+                let result = self.call_method_with_values(
+                    actions.clone(),
+                    sym_name,
+                    vec![match_obj.clone()],
+                );
+                match result {
+                    Err(e) if e.is_method_not_found() => {
+                        if actions_class_name.is_none_or(|cn| self.has_user_method(cn, rule_name)) {
+                            self.call_method_with_values(
+                                actions.clone(),
+                                rule_name,
+                                vec![match_obj.clone()],
+                            )
+                        } else {
+                            Ok(match_obj.clone())
+                        }
+                    }
+                    other => other,
+                }
+            } else if actions_class_name.is_none_or(|cn| self.has_user_method(cn, rule_name)) {
+                called_action = true;
+                self.call_method_with_values(actions.clone(), rule_name, vec![match_obj.clone()])
+            } else {
+                Ok(match_obj.clone())
+            }
+        } else if actions_class_name.is_none_or(|cn| self.has_user_method(cn, rule_name)) {
+            called_action = true;
+            self.call_method_with_values(actions.clone(), rule_name, vec![match_obj.clone()])
+        } else {
+            Ok(match_obj.clone())
+        };
+
+        // Re-read a possibly-mutated actions instance (same as the main walk).
+        if called_action
+            && let ValueView::Instance {
+                class_name: act_cn,
+                id: act_id,
+                ..
+            } = actions.view()
+        {
+            for v in self.env.values() {
+                if let ValueView::Instance {
+                    class_name: cn,
+                    id,
+                    attributes,
+                    ..
+                } = v.view()
+                    && cn == act_cn
+                    && id == act_id
+                {
+                    *actions = Value::instance_parts(cn, attributes.clone(), id);
+                    break;
+                }
+            }
+        }
+
+        if let Some(old_topic) = saved_topic {
+            self.env.insert("_".to_string(), old_topic);
+        } else {
+            self.env.remove("_");
+        }
+        // Restore whatever this match's `:my` bindings shadowed
+        for (k, prev) in saved_reduce_vars {
+            match prev {
+                Some(v) => {
+                    self.env.insert(k, v);
+                }
+                None => {
+                    self.env.remove(&k);
+                }
+            }
+        }
+        {
+            let current_angle_keys: Vec<Symbol> = self
+                .env
+                .keys()
+                .filter(|k| k.starts_with("<") && k.ends_with(">"))
+                .copied()
+                .collect();
+            for k in current_angle_keys {
+                self.env.remove_sym(k);
+            }
+            for (k, v) in saved_named_captures {
+                self.env.insert_sym(k, v);
+            }
+        }
+        for i in 0..10 {
+            self.env.remove(&i.to_string());
+        }
+        for (i, val) in saved_positional {
+            if let Some(v) = val {
+                self.env.insert(i.to_string(), v);
+            }
+        }
+
+        match method_result {
+            Ok(_) => {}
+            Err(e) if e.is_method_not_found() => {
+                // No action method for this rule — silently skip
+            }
+            Err(e) => return Err(e),
+        }
+
+        Ok(match self.action_made.take() {
+            Some(ast) => match match_obj.match_with_ast_lazy(ast.clone()) {
+                Some(v) => v,
+                // The action itself observed `$/` (materializing it) — fall
+                // back to the eager rebuild, same as the main walk.
+                None => match_obj
+                    .match_with_attrs(vec![("ast", ast)])
+                    .unwrap_or(match_obj),
+            },
+            None => match_obj,
+        })
+    }
+
     /// Walk the match tree bottom-up and invoke action methods on the actions object.
     pub(crate) fn invoke_grammar_actions(
         &mut self,
@@ -795,9 +972,25 @@ impl Interpreter {
         // skips the two attribute-map clones, the node rebuild, and the whole
         // env save/restore ceremony below, none of which can have any effect
         // for such a node.
+        let fmt_sym_method = |sym_val: &str| {
+            if sym_val.contains('<') || sym_val.contains('>') {
+                format!("{rule_name}:sym\u{ab}{sym_val}\u{bb}")
+            } else {
+                format!("{rule_name}:sym<{sym_val}>")
+            }
+        };
         let leaf_sym_method: Option<String>;
         let is_actionless_candidate_leaf;
-        if let ValueView::Instance { attributes, .. } = match_obj.view() {
+        if let Some((is_leaf, sym)) = match_obj.match_walk_peek() {
+            // Unmaterialized lazy Match: the leaf check reads the capture
+            // node directly, so an actionless leaf is never materialized.
+            is_actionless_candidate_leaf = is_leaf;
+            leaf_sym_method = if is_leaf {
+                sym.as_deref().map(fmt_sym_method)
+            } else {
+                None
+            };
+        } else if let ValueView::Instance { attributes, .. } = match_obj.view() {
             let amap = attributes.as_map();
             let has_named_children = matches!(
                 amap.get("named").map(Value::view),
@@ -811,13 +1004,7 @@ impl Interpreter {
             if !has_named_children && !has_list_children && !has_silent {
                 is_actionless_candidate_leaf = true;
                 leaf_sym_method = match amap.get("sym_variant").map(Value::view) {
-                    Some(ValueView::Str(sym_val)) => {
-                        Some(if sym_val.contains('<') || sym_val.contains('>') {
-                            format!("{rule_name}:sym\u{ab}{}\u{bb}", &*sym_val)
-                        } else {
-                            format!("{rule_name}:sym<{}>", &*sym_val)
-                        })
-                    }
+                    Some(ValueView::Str(sym_val)) => Some(fmt_sym_method(&sym_val)),
                     _ => None,
                 };
             } else {
@@ -842,6 +1029,16 @@ impl Interpreter {
                     return Ok(match_obj);
                 }
             }
+            // A still-lazy childless leaf WITH an action: run it without
+            // materializing the attribute map.
+            if match_obj.match_walk_peek().is_some() {
+                return self.invoke_leaf_action_lazy(
+                    match_obj,
+                    actions,
+                    rule_name,
+                    leaf_sym_method.as_deref(),
+                );
+            }
         }
         let (class_name, attributes) = if let ValueView::Instance {
             class_name,
@@ -863,17 +1060,19 @@ impl Interpreter {
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
-            children.sort_by_key(|(_, v)| {
-                if let ValueView::Instance { attributes, .. } = v.view()
-                    && let Some(ValueView::Int(from)) =
-                        attributes.as_map().get("from").map(Value::view)
-                {
-                    return from;
-                }
-                0
-            });
+            // `match_from` is the non-materializing seam read — a lazy child
+            // is not forced just to be sorted.
+            children.sort_by_key(|(_, v)| v.match_from().unwrap_or(0));
             for (child_name, child_match) in children {
-                if let ValueView::Array(items, meta) = child_match.view() {
+                // Probe Match first (non-materializing); only non-Match values
+                // (arrays of per-iteration Matches) go through `view()`.
+                if child_match.is_match_instance() {
+                    let dispatch_name =
+                        Self::get_action_name(&child_match).unwrap_or_else(|| child_name.clone());
+                    let updated_child =
+                        self.invoke_grammar_actions(child_match, actions, &dispatch_name)?;
+                    updated_named.insert(child_name, updated_child);
+                } else if let ValueView::Array(items, meta) = child_match.view() {
                     let mut updated_items = Vec::with_capacity(items.len());
                     for item in items.as_ref() {
                         let dispatch_name =
@@ -913,26 +1112,35 @@ impl Interpreter {
             let mut updated_list = Vec::with_capacity(pos_arr.len());
             let mut changed = false;
             for item in pos_arr.as_ref() {
-                let updated_item = match item.view() {
-                    // A quantified group `(...)*`: an Array of per-iteration Matches.
-                    ValueView::Array(items, imeta) => {
-                        let mut updated_items = Vec::with_capacity(items.len());
-                        for it in items.as_ref() {
-                            let dispatch_name = Self::get_action_name(it).unwrap_or_default();
-                            let updated =
-                                self.invoke_grammar_actions(it.clone(), actions, &dispatch_name)?;
-                            updated_items.push(updated);
+                // Probe Match first (non-materializing, covers lazy children).
+                let updated_item = if item.is_match_instance() {
+                    let dispatch_name = Self::get_action_name(item).unwrap_or_default();
+                    self.invoke_grammar_actions(item.clone(), actions, &dispatch_name)?
+                } else {
+                    match item.view() {
+                        // A quantified group `(...)*`: an Array of per-iteration Matches.
+                        ValueView::Array(items, imeta) => {
+                            let mut updated_items = Vec::with_capacity(items.len());
+                            for it in items.as_ref() {
+                                let dispatch_name = Self::get_action_name(it).unwrap_or_default();
+                                let updated = self.invoke_grammar_actions(
+                                    it.clone(),
+                                    actions,
+                                    &dispatch_name,
+                                )?;
+                                updated_items.push(updated);
+                            }
+                            Value::array_with_kind(
+                                crate::gc::Gc::new(crate::value::ArrayData::new(updated_items)),
+                                imeta,
+                            )
                         }
-                        Value::array_with_kind(
-                            crate::gc::Gc::new(crate::value::ArrayData::new(updated_items)),
-                            imeta,
-                        )
+                        ValueView::Instance { .. } => {
+                            let dispatch_name = Self::get_action_name(item).unwrap_or_default();
+                            self.invoke_grammar_actions(item.clone(), actions, &dispatch_name)?
+                        }
+                        _ => item.clone(),
                     }
-                    ValueView::Instance { .. } => {
-                        let dispatch_name = Self::get_action_name(item).unwrap_or_default();
-                        self.invoke_grammar_actions(item.clone(), actions, &dispatch_name)?
-                    }
-                    _ => item.clone(),
                 };
                 changed = true;
                 updated_list.push(updated_item);

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -119,10 +119,7 @@ impl Interpreter {
         // (`C`/`D`/`KC`/`KD` i.e. NFC/NFD/NFKC/NFKD). Rakudo `#?rakudo skip`s the
         // normalization-form parameter ("We do not handle NDF yet"); mutsu
         // applies it (roast S32-str/encode.t "encoding to UTF-8, with NFD").
-        let positionals: Vec<&Value> = args
-            .iter()
-            .filter(|v| !matches!(v.view(), ValueView::Pair(..)))
-            .collect();
+        let positionals: Vec<&Value> = args.iter().filter(|v| !v.is_string_pair_value()).collect();
         let encoding = positionals
             .first()
             .map(|v| v.to_string_value())
@@ -192,7 +189,7 @@ impl Interpreter {
             let default_encoding = if is_wide { "utf-16" } else { "utf-8" };
             let encoding = args
                 .iter()
-                .find(|v| !matches!(v.view(), ValueView::Pair(..)))
+                .find(|v| !v.is_string_pair_value())
                 .map(|v| v.to_string_value())
                 .unwrap_or_else(|| default_encoding.to_string());
             let replacement = Self::named_value(args, "replacement").map(|v| {

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -122,6 +122,25 @@ impl Interpreter {
         is_pseudo_method: bool,
     ) -> bool {
         let _ = args;
+        // Lazy-Match head branch: the chain below reads `target.view()`
+        // repeatedly, which would materialize a lazy Match per method call.
+        // Its class is statically "Match", so evaluate the Instance arms that
+        // can apply to it directly (the Supply/IO::Handle/Proc::Async/Stash
+        // arms and the Real/Numeric bridge arm can never hit a Match).
+        if target.is_lazy_match_value() {
+            return skip_pseudo
+                || method == "squish"
+                || method == "elems"
+                || (matches!(method, "throw" | "rethrow" | "gist" | "Str" | "Stringy")
+                    && self.exception_render_needs_interpreter(target, "Match"))
+                || self.is_native_method("Match", method)
+                || self.has_user_method("Match", "Bridge")
+                || (!is_pseudo_method
+                    && (self.has_user_method("Match", method)
+                        || self.has_public_accessor("Match", method)
+                        || (self.has_class_level_attr("Match", method)
+                            && !self.has_public_accessor("Match", method))));
+        }
         skip_pseudo
             || method == "squish"
             || (matches!(
@@ -209,6 +228,10 @@ impl Interpreter {
     /// Used so that role-method dispatch on punned role instances takes
     /// precedence over the built-in Cool fallbacks (e.g. `.uc`).
     pub(crate) fn mixin_role_has_method(&self, target: &Value, method: &str) -> bool {
+        // Tag probe first — a `view()` on a lazy Match would materialize it.
+        if !target.is_mixin_value() {
+            return false;
+        }
         let ValueView::Mixin(_, mixins) = target.view() else {
             return false;
         };

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -15,10 +15,7 @@ impl Interpreter {
         // signature binding raises the proper error. (This also covers a BUILD
         // with a positional parameter: `.new` strips positionals before BUILD, so
         // `Foo.new('x', :y)` must die rather than feed 'x' to BUILD.)
-        if args
-            .iter()
-            .any(|a| !matches!(a.view(), ValueView::Pair(..)))
-        {
+        if args.iter().any(|a| !a.is_string_pair_value()) {
             return None;
         }
         // Class-shape facts (attribute defs, MRO-wide type constraints, the

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1084,7 +1084,7 @@ impl Interpreter {
                         let data = if data.is_none() {
                             let positional: Vec<Value> = args
                                 .iter()
-                                .filter(|arg| !matches!(arg.view(), ValueView::Pair(..)))
+                                .filter(|arg| !arg.is_string_pair_value())
                                 .cloned()
                                 .collect();
                             if positional.is_empty() {

--- a/src/runtime/methods_object_native_ctors_buf_num.rs
+++ b/src/runtime/methods_object_native_ctors_buf_num.rs
@@ -178,10 +178,7 @@ impl Interpreter {
         // args are ignored. Two or more positionals resolve to no candidate and
         // must throw X::Multi::NoMatch (roast .../multi-no-match.t) rather than
         // silently taking the first.
-        let positional: Vec<&Value> = args
-            .iter()
-            .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
-            .collect();
+        let positional: Vec<&Value> = args.iter().filter(|a| !a.is_string_pair_value()).collect();
         if positional.len() > 1 {
             return Err(super::methods_signature_errors::make_multi_no_match_error(
                 "new",

--- a/src/runtime/methods_object_native_ctors_io.rs
+++ b/src/runtime/methods_object_native_ctors_io.rs
@@ -426,10 +426,7 @@ impl Interpreter {
             // populates the Capture's positional/named parts; every *other* named
             // arg is dropped (bless ignores unknown attributes), yielding an
             // empty `\()`. A `\(...)` literal is the other way to build one.
-            if args
-                .iter()
-                .any(|a| !matches!(a.view(), ValueView::Pair(..)))
-            {
+            if args.iter().any(|a| !a.is_string_pair_value()) {
                 Some(Err(RuntimeError::new(
                     "Default constructor for 'Capture' only takes named arguments",
                 )))
@@ -509,9 +506,9 @@ impl Interpreter {
     /// dropping top-level `Pair`s strips exactly the named arguments
     /// while preserving every positional pair.
     pub(super) fn strip_named_pair_args(args: Vec<Value>) -> Vec<Value> {
-        if args.iter().any(|a| matches!(a.view(), ValueView::Pair(..))) {
+        if args.iter().any(|a| a.is_string_pair_value()) {
             args.into_iter()
-                .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
+                .filter(|a| !a.is_string_pair_value())
                 .collect()
         } else {
             args

--- a/src/runtime/methods_string_index.rs
+++ b/src/runtime/methods_string_index.rs
@@ -192,7 +192,7 @@ impl Interpreter {
         }
         let mut positional: Vec<Value> = Vec::new();
         for arg in args {
-            if !matches!(arg.view(), ValueView::Pair(..)) {
+            if !arg.is_string_pair_value() {
                 positional.push(arg.clone());
             }
         }

--- a/src/runtime/native_methods/system.rs
+++ b/src/runtime/native_methods/system.rs
@@ -226,7 +226,7 @@ impl Interpreter {
                 // e.g. "foo" -> "libfoo.so" on Linux, "libfoo.dylib" on macOS, "foo.dll" on Windows.
                 let name = args
                     .iter()
-                    .find(|v| !matches!(v.view(), ValueView::Pair(..)))
+                    .find(|v| !v.is_string_pair_value())
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
                 // `:version` names an ABI-versioned library. A distribution ships

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -105,7 +105,7 @@ impl Interpreter {
         }
         let positional_arg_count = args
             .iter()
-            .filter(|arg| !matches!(arg.view(), ValueView::Pair(..)))
+            .filter(|arg| !arg.is_string_pair_value())
             .count();
         let positional_params: Vec<&ParamDef> = param_defs.iter().filter(|pd| !pd.named).collect();
         let has_positional_slurpy = positional_params

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -111,12 +111,7 @@ impl Interpreter {
             let positional_indices: Vec<usize> = args
                 .iter()
                 .enumerate()
-                .filter(|(_, arg)| {
-                    !matches!(
-                        unwrap_varref_value((*arg).clone()).view(),
-                        ValueView::Pair(..)
-                    )
-                })
+                .filter(|(_, arg)| !arg.unwrap_varref().is_string_pair_value())
                 .map(|(idx, _)| idx)
                 .collect();
             let positional_arg_count = positional_indices.len();
@@ -126,12 +121,7 @@ impl Interpreter {
             // parts.
             let named_args: Vec<Value> = args
                 .iter()
-                .filter(|arg| {
-                    matches!(
-                        unwrap_varref_value((*arg).clone()).view(),
-                        ValueView::Pair(..)
-                    )
-                })
+                .filter(|arg| arg.unwrap_varref().is_string_pair_value())
                 .cloned()
                 .collect();
             let remaining_args = |from_positional: usize| -> Vec<Value> {
@@ -579,7 +569,10 @@ impl Interpreter {
             let named_args: Vec<(String, Value)> = args
                 .iter()
                 .filter_map(|a| {
-                    let a = unwrap_varref_value(a.clone());
+                    let a = a.unwrap_varref();
+                    if !a.is_string_pair_value() {
+                        return None;
+                    }
                     if let ValueView::Pair(key, val) = a.view() {
                         Some((key.clone(), val.clone()))
                     } else {
@@ -774,7 +767,7 @@ impl Interpreter {
             filtered_params.iter().filter(|p| !p.named).collect();
         let positional_arg_count = args
             .iter()
-            .filter(|arg| !matches!(arg.view(), ValueView::Pair(..)))
+            .filter(|arg| !arg.is_string_pair_value())
             .count();
         let mut required = 0usize;
         let mut has_positional_slurpy = false;

--- a/src/runtime/types/binding_helpers.rs
+++ b/src/runtime/types/binding_helpers.rs
@@ -91,7 +91,10 @@ impl Interpreter {
     pub(crate) fn implicit_method_named_slurpy(param_defs: &[ParamDef], args: &[Value]) -> Value {
         let mut implicit_named = std::collections::HashMap::new();
         for arg in args.iter() {
-            let unwrapped = unwrap_varref_value(arg.clone());
+            let unwrapped = arg.unwrap_varref();
+            if !unwrapped.is_string_pair_value() {
+                continue;
+            }
             if let ValueView::Pair(key, val) = unwrapped.view() {
                 if key.is_empty() {
                     continue;

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -682,7 +682,7 @@ impl Interpreter {
                     let mut items = Vec::new();
                     while positional_idx < args.len() {
                         let val = unwrap_varref_value(args[positional_idx].clone());
-                        if !matches!(val.view(), ValueView::Pair(..)) {
+                        if !val.is_string_pair_value() {
                             items.push(val);
                         }
                         positional_idx += 1;
@@ -708,7 +708,7 @@ impl Interpreter {
                         let raw_arg = args[positional_idx].clone();
                         positional_idx += 1;
                         let arg = unwrap_varref_value(raw_arg);
-                        if matches!(arg.view(), ValueView::Pair(..)) {
+                        if arg.is_string_pair_value() {
                             // Named arg -- leave for *%_ slurpy; keep scanning.
                             continue;
                         }
@@ -747,7 +747,7 @@ impl Interpreter {
                         let rest: Vec<Value> = args[positional_idx..]
                             .iter()
                             .map(|a| unwrap_varref_value(a.clone()))
-                            .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
+                            .filter(|a| !a.is_string_pair_value())
                             .collect();
                         match rest.as_slice() {
                             [only] => {

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -392,13 +392,21 @@ impl Interpreter {
         // shadows the name (then the full checker below must run its predicate),
         // so it is gated on the subset registry. This skips the long string-
         // compare gauntlet for the ubiquitous `Int $n` / `Point $p` params.
-        let tag_match = match value.view() {
-            ValueView::Int(_) => constraint == "Int",
-            ValueView::Num(_) => constraint == "Num",
-            ValueView::Str(_) => constraint == "Str",
-            ValueView::Bool(_) => constraint == "Bool",
-            ValueView::Instance { class_name, .. } => class_name.as_str() == constraint,
-            _ => false,
+        let tag_match = if value.is_lazy_match_value() {
+            // A lazy Match is always class "Match" — answer the ubiquitous
+            // constraints without materializing it. Unlisted constraints
+            // (subsets, roles) fall through to the full checker below, which
+            // materializes through `view()` as an Instance.
+            matches!(constraint, "Match" | "Any" | "Mu")
+        } else {
+            match value.view() {
+                ValueView::Int(_) => constraint == "Int",
+                ValueView::Num(_) => constraint == "Num",
+                ValueView::Str(_) => constraint == "Str",
+                ValueView::Bool(_) => constraint == "Bool",
+                ValueView::Instance { class_name, .. } => class_name.as_str() == constraint,
+                _ => false,
+            }
         };
         if tag_match && !self.registry().subsets.contains_key(constraint) {
             return true;

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -298,6 +298,14 @@ fn format_rat_str_bigint(numer: &NumBigInt, denom: &NumBigInt, is_fatrat: bool) 
 
 impl Value {
     pub(crate) fn to_string_value(&self) -> String {
+        // Stringifying an unmaterialized lazy Match is just its matched text
+        // (the `str` attribute the eager arm below reads) — skip the
+        // materializing `view()` decode.
+        if let Some(node) = self.0.as_match_node()
+            && node.forced().is_none()
+        {
+            return node.cap.matched.clone();
+        }
         match self.view() {
             // A `VarRef` is a transient binder wrapper: it stringifies as the
             // variable's value.

--- a/src/value/match_lazy.rs
+++ b/src/value/match_lazy.rs
@@ -1,0 +1,427 @@
+//! ADR-0016 P5: the lazily materialized `Match` representation.
+//!
+//! A regex/grammar match no longer eagerly builds a full `Instance("Match")`
+//! attribute tree per capture node. The match VALUE is a
+//! `ValueRepr::Match(Gc<MatchNode>)` holding the shared subject string and the
+//! stored capture node (`Arc<CapNode>`); the Instance-shaped attribute map is
+//! materialized once, on first `view()` decode, and memoized. Materialization
+//! is ONE level deep: child captures become lazy `Match` values themselves, so
+//! a subtree nobody inspects never allocates anything beyond the `CapNode`
+//! the matcher already built.
+//!
+//! Consumers are unchanged: `view()` on a lazy Match forces the memoized map
+//! and presents `ValueView::Instance` exactly as an eager Match. The seam
+//! accessors (`match_view.rs`) answer scalar reads (`.from`, `.Str`, `.made`,
+//! ...) straight from the `CapNode` without forcing. Post-hoc attribute
+//! writes (`match_with_attrs*`) force and rebuild a plain eager Instance,
+//! same as before.
+
+use super::*;
+use crate::runtime::{CapNode, SILENT_ACTION_MARKER_PREFIX};
+use std::sync::OnceLock;
+
+/// Interned class symbol for `Match`.
+pub(in crate::value) fn match_class_symbol() -> Symbol {
+    static SYM: OnceLock<Symbol> = OnceLock::new();
+    *SYM.get_or_init(|| Symbol::intern("Match"))
+}
+
+/// The payload of a lazy `Match` value. See the module doc.
+pub(crate) struct MatchNode {
+    /// The whole subject string (`.orig`), shared by every node of the tree.
+    pub(in crate::value) orig: Option<Arc<String>>,
+    /// The stored capture node this Match presents.
+    pub(in crate::value) cap: Arc<CapNode>,
+    /// Stable instance identity (same id domain as eager `Instance`s).
+    pub(in crate::value) id: u64,
+    /// Memoized materialization, built on first `view()` decode.
+    attrs: OnceLock<crate::gc::Gc<InstanceAttrs>>,
+}
+
+impl std::fmt::Debug for MatchNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MatchNode")
+            .field("id", &self.id)
+            .field("from", &self.cap.from)
+            .field("to", &self.cap.to)
+            .field("forced", &self.attrs.get().is_some())
+            .finish()
+    }
+}
+
+impl MatchNode {
+    pub(in crate::value) fn new(cap: Arc<CapNode>, orig: Option<Arc<String>>) -> Self {
+        Self {
+            orig,
+            cap,
+            id: next_instance_id(),
+            attrs: OnceLock::new(),
+        }
+    }
+
+    /// The memoized attribute node, if already materialized.
+    pub(in crate::value) fn forced(&self) -> Option<&crate::gc::Gc<InstanceAttrs>> {
+        self.attrs.get()
+    }
+
+    /// Force the Instance-shaped materialization (one level deep).
+    pub(in crate::value) fn force_attrs(&self) -> &crate::gc::Gc<InstanceAttrs> {
+        self.attrs.get_or_init(|| {
+            crate::gc::Gc::new(InstanceAttrs::new(
+                match_class_symbol(),
+                self.materialize_map(),
+                self.id,
+                true,
+            ))
+        })
+    }
+
+    /// Sever the memoized `Gc` edge (cycle-collector reclaim).
+    pub(in crate::value) fn take_attrs_for_gc(&mut self) {
+        let _ = self.attrs.take();
+    }
+
+    /// Read one attribute, without forcing when it is derivable from the
+    /// capture node. Structural attributes (`list`, `named`, `silent_caps`,
+    /// `reduce_time_vars`, `capture_alias_map`) force the materialization.
+    pub(in crate::value) fn attr(&self, name: &str) -> Option<Value> {
+        if let Some(attrs) = self.attrs.get() {
+            return attrs.as_map().get(name).cloned();
+        }
+        match name {
+            "str" => Some(Value::str(self.cap.matched.clone())),
+            "from" => Some(Value::Int(self.cap.from as i64)),
+            "to" => Some(Value::Int(self.cap.to as i64)),
+            "orig" => self.orig.as_ref().map(|o| Value::str_arc(Arc::clone(o))),
+            "ast" => self.cap.ast.clone(),
+            "sym_variant" => self.cap.sym.clone().map(Value::str),
+            "action_name" => self.cap.action_name.clone().map(Value::str),
+            // Post-hoc attributes exist only on REBUILT eager Matches (the
+            // rebuild helpers produce plain Instances); a live lazy node
+            // never carries them.
+            "actions" | "__failed_match__" | "pos" => None,
+            _ => self.force_attrs().as_map().get(name).cloned(),
+        }
+    }
+
+    /// A lazy child Match sharing this node's subject.
+    fn lazy_child(&self, sc: &Arc<CapNode>) -> Value {
+        Value::lazy_match(Arc::clone(sc), self.orig.clone())
+    }
+
+    /// Build this node's attribute map — the pre-P5 `make_subcap_match`, with
+    /// recursion replaced by lazy children.
+    fn materialize_map(&self) -> AttrMap {
+        let cap = &*self.cap;
+        if cap.children.is_none() {
+            crate::vm::vm_stats::record_regex_match_leaf(false);
+        }
+        let kids = cap.kids();
+        let search_start = cap.from;
+        // Subject chars for the legacy text-only-leaf position search below,
+        // computed at most once per materialization.
+        let mut chars_cache: Option<Vec<char>> = None;
+
+        let pos_vals: Vec<Value> = kids
+            .positional
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                // An unmatched optional capture (`(x)?` zero match) renders as Nil.
+                if kids.positional_nil.get(i) == Some(&true) {
+                    return Value::Nil;
+                }
+                if let Some(Some(qlist)) = kids.positional_quantified.get(i) {
+                    let arr: Vec<Value> = qlist
+                        .iter()
+                        .map(|(text, qfrom, qto, subcap)| {
+                            if let Some(sc) = subcap {
+                                return self.lazy_child(sc);
+                            }
+                            span_leaf_match(text, *qfrom, *qto, self.orig.as_ref())
+                        })
+                        .collect();
+                    return Value::array(arr);
+                }
+                if let Some(Some(subcap)) = kids.positional_subcaps.get(i) {
+                    return self.lazy_child(subcap);
+                }
+                text_leaf_match(s, self.orig.as_ref(), &mut chars_cache, search_start)
+            })
+            .collect();
+
+        let mut sub_named: HashMap<String, Value> = HashMap::new();
+        for (key, values) in &kids.named {
+            let subcaps_for_key = kids.named_subcaps.get(key);
+            let vals: Vec<Value> = values
+                .iter()
+                .enumerate()
+                .map(|(i, s)| {
+                    if let Some(scs) = subcaps_for_key
+                        && let Some(sc) = scs.get(i)
+                    {
+                        return self.lazy_child(sc);
+                    }
+                    text_leaf_match(s, self.orig.as_ref(), &mut chars_cache, search_start)
+                })
+                .collect();
+            if vals.len() == 1 && !kids.named_quantified.contains(key) {
+                sub_named.insert(key.clone(), vals[0].clone());
+            } else {
+                sub_named.insert(key.clone(), Value::real_array(vals));
+            }
+        }
+        // Quantified named captures that matched zero times render as empty arrays.
+        for qname in &kids.named_quantified {
+            sub_named
+                .entry(qname.clone())
+                .or_insert_with(|| Value::real_array(Vec::new()));
+        }
+
+        // Silent-action captures: hidden `<.foo>` subrule matches (stored under
+        // a marker key in `named_subcaps`). Absent from `named`/`.hash`, but the
+        // grammar action walk fires their action methods via `silent_caps`.
+        let mut silent_caps_vals: Vec<Value> = Vec::new();
+        for (key, scs) in &kids.named_subcaps {
+            if key.starts_with(SILENT_ACTION_MARKER_PREFIX) {
+                for sc in scs {
+                    silent_caps_vals.push(self.lazy_child(sc));
+                }
+            }
+        }
+
+        let mut attrs = AttrMap::new();
+        attrs.insert("str", Value::str(cap.matched.clone()));
+        attrs.insert("from", Value::Int(cap.from as i64));
+        attrs.insert("to", Value::Int(cap.to as i64));
+        attrs.insert("list", Value::array(pos_vals));
+        attrs.insert("named", Value::hash(sub_named));
+        if !silent_caps_vals.is_empty() {
+            attrs.insert("silent_caps", Value::real_array(silent_caps_vals));
+        }
+        if let Some(o) = &self.orig {
+            attrs.insert("orig", Value::str_arc(Arc::clone(o)));
+        }
+        if let Some(sym) = &cap.sym {
+            attrs.insert("sym_variant", Value::str(sym.clone()));
+        }
+        if let Some(action_name) = &cap.action_name {
+            attrs.insert("action_name", Value::str(action_name.clone()));
+        }
+        // Inline `{ make … }` value produced by this subrule at reduce time.
+        if let Some(ast) = &cap.ast {
+            attrs.insert("ast", ast.clone());
+        }
+        // Per-match `:my $*x` values, re-installed around this node's action
+        // by the grammar action walk.
+        if !kids.regex_vars.is_empty() {
+            let vars: HashMap<String, Value> = kids
+                .regex_vars
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            attrs.insert("reduce_time_vars", Value::hash(vars));
+        }
+        if !kids.capture_alias_map.is_empty() {
+            let alias_hash: HashMap<String, Value> = kids
+                .capture_alias_map
+                .iter()
+                .map(|(k, v)| (k.clone(), Value::str(v.clone())))
+                .collect();
+            attrs.insert("capture_alias_map", Value::hash(alias_hash));
+        }
+        attrs
+    }
+}
+
+/// Eager leaf Match for a quantified-capture entry with a recorded span.
+fn span_leaf_match(text: &str, from: usize, to: usize, orig: Option<&Arc<String>>) -> Value {
+    let mut attrs = AttrMap::new();
+    attrs.insert("str", Value::str(text.to_string()));
+    attrs.insert("from", Value::Int(from as i64));
+    attrs.insert("to", Value::Int(to as i64));
+    attrs.insert("list", Value::array(Vec::new()));
+    attrs.insert("named", Value::hash(HashMap::new()));
+    if let Some(o) = orig {
+        attrs.insert("orig", Value::str_arc(Arc::clone(o)));
+    }
+    Value::make_instance(match_class_symbol(), attrs)
+}
+
+/// Eager leaf Match for a TEXT-ONLY capture entry (no stored `CapNode`).
+/// The span is recovered by searching for the text at/after `search_from` —
+/// the pre-P5 legacy path; every leaf the matcher stores today carries a
+/// span-bearing `CapNode`, so this survives only for exploded-builder callers
+/// that still pass bare text.
+fn text_leaf_match(
+    s: &str,
+    orig: Option<&Arc<String>>,
+    chars_cache: &mut Option<Vec<char>>,
+    search_from: usize,
+) -> Value {
+    crate::vm::vm_stats::record_regex_match_leaf(orig.is_some());
+    let (cap_from, cap_to) = if let Some(o) = orig {
+        let haystack = chars_cache.get_or_insert_with(|| o.chars().collect());
+        let needle: Vec<char> = s.chars().collect();
+        let mut found = None;
+        for start in search_from..=haystack.len().saturating_sub(needle.len()) {
+            if haystack[start..start + needle.len()] == needle[..] {
+                found = Some(start as i64);
+                break;
+            }
+        }
+        match found {
+            Some(f) => (f, f + needle.len() as i64),
+            None => (0i64, s.chars().count() as i64),
+        }
+    } else {
+        (0i64, s.chars().count() as i64)
+    };
+    let mut attrs = AttrMap::new();
+    attrs.insert("str", Value::str(s.to_string()));
+    attrs.insert("from", Value::Int(cap_from));
+    attrs.insert("to", Value::Int(cap_to));
+    attrs.insert("list", Value::array(Vec::new()));
+    attrs.insert("named", Value::hash(HashMap::new()));
+    if let Some(o) = orig {
+        attrs.insert("orig", Value::str_arc(Arc::clone(o)));
+    }
+    Value::make_instance(match_class_symbol(), attrs)
+}
+
+impl Value {
+    /// Construct a lazy `Match` from a stored capture node and the shared
+    /// subject string.
+    pub(crate) fn lazy_match(cap: Arc<CapNode>, orig: Option<Arc<String>>) -> Value {
+        Value::from_repr(ValueRepr::Match(crate::gc::Gc::new(MatchNode::new(
+            cap, orig,
+        ))))
+    }
+
+    /// For a still-lazy Match: a fresh lazy Match carrying `ast` (a `make`
+    /// from a grammar action), sharing the subject and cloning the capture
+    /// node. `None` when `self` is eager or already materialized — callers
+    /// fall back to the eager rebuild. Used by the action walk's leaf fast
+    /// path, where the clone is a childless node (cheap).
+    pub(crate) fn match_with_ast_lazy(&self, ast: Value) -> Option<Value> {
+        let node = self.0.as_match_node()?;
+        if node.forced().is_some() {
+            return None;
+        }
+        let mut cap = (*node.cap).clone();
+        cap.ast = Some(ast);
+        Some(Value::lazy_match(Arc::new(cap), node.orig.clone()))
+    }
+
+    /// The per-match `:my $*x` values recorded at reduce time, read straight
+    /// from the capture node of a still-lazy Match (no materialization).
+    /// `None` for eager/materialized Matches or when the rule declared none.
+    /// Used by the action walk's leaf fast path, which must re-install them
+    /// around the leaf's action (same as the main walk's `reduce_time_vars`).
+    pub(crate) fn match_reduce_time_vars_lazy(&self) -> Option<Vec<(String, Value)>> {
+        let node = self.0.as_match_node()?;
+        if node.forced().is_some() {
+            return None;
+        }
+        let kids = node.cap.kids();
+        if kids.regex_vars.is_empty() {
+            return None;
+        }
+        Some(
+            kids.regex_vars
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        )
+    }
+
+    /// Non-forcing peek for the grammar-action walk: for an UNMATERIALIZED
+    /// lazy Match, report `(is_childless_leaf, sym_variant)` straight from the
+    /// capture node. `None` for eager/materialized Matches — the caller falls
+    /// back to reading the attribute map.
+    pub(crate) fn match_walk_peek(&self) -> Option<(bool, Option<String>)> {
+        let node = self.0.as_match_node()?;
+        if node.forced().is_some() {
+            return None;
+        }
+        let kids = node.cap.kids();
+        let has_named = !kids.named.is_empty() || !kids.named_quantified.is_empty();
+        let has_list = !kids.positional.is_empty();
+        let has_silent = kids
+            .named_subcaps
+            .iter()
+            .any(|(k, scs)| k.starts_with(SILENT_ACTION_MARKER_PREFIX) && !scs.is_empty());
+        Some((!has_named && !has_list && !has_silent, node.cap.sym.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::RegexCaptures;
+
+    fn leaf_cap(text: &str, from: usize, to: usize) -> Arc<CapNode> {
+        let mut caps = RegexCaptures::default();
+        caps.matched = text.to_string();
+        caps.from = from;
+        caps.to = to;
+        Arc::new(caps.into_cap_node())
+    }
+
+    #[test]
+    fn lazy_match_scalar_reads_do_not_force() {
+        let m = Value::lazy_match(leaf_cap("ab", 3, 5), Some(Arc::new("xxxab".to_string())));
+        assert!(m.is_match_instance());
+        assert_eq!(m.match_from(), Some(3));
+        assert_eq!(m.match_to(), Some(5));
+        assert_eq!(
+            m.match_str_value().map(|v| v.to_string_value()),
+            Some("ab".to_string())
+        );
+        assert!(m.0.as_match_node().unwrap().forced().is_none());
+    }
+
+    #[test]
+    fn lazy_match_views_as_instance() {
+        let m = Value::lazy_match(leaf_cap("ab", 3, 5), Some(Arc::new("xxxab".to_string())));
+        match m.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } => {
+                assert_eq!(class_name.as_str(), "Match");
+                let map = attributes.as_map();
+                assert_eq!(map.get("str").and_then(Value::as_str), Some("ab"));
+                assert_eq!(map.get("from").and_then(Value::as_int), Some(3));
+            }
+            other => panic!("expected Instance view, got {other:?}"),
+        }
+        assert!(m.0.as_match_node().unwrap().forced().is_some());
+        // Post-force scalar reads come from the forced map and stay coherent.
+        assert_eq!(m.match_from(), Some(3));
+    }
+
+    #[test]
+    fn lazy_match_children_stay_lazy_one_level() {
+        // parent { named: x => child }, child a leaf with a span.
+        let child = leaf_cap("b", 1, 2);
+        let mut caps = RegexCaptures::default();
+        caps.matched = "ab".to_string();
+        caps.from = 0;
+        caps.to = 2;
+        caps.named.insert("x".to_string(), vec!["b".to_string()]);
+        caps.named_subcaps
+            .insert("x".to_string(), vec![Arc::clone(&child)]);
+        let parent = Value::lazy_match(Arc::new(caps.into_cap_node()), None);
+        let named = parent.match_named().expect("named hash");
+        let child_val = match named.view() {
+            ValueView::Hash(h) => h.map.get("x").cloned().expect("x"),
+            other => panic!("expected hash, got {other:?}"),
+        };
+        assert!(child_val.is_match_instance());
+        // The child is itself a lazy, unforced Match.
+        assert!(child_val.0.as_match_node().unwrap().forced().is_none());
+        assert_eq!(child_val.match_from(), Some(1));
+    }
+}

--- a/src/value/match_view.rs
+++ b/src/value/match_view.rs
@@ -14,15 +14,24 @@
 use super::*;
 
 impl Value {
-    /// Is this value a `Match` instance (regex match object)?
+    /// Is this value a `Match` instance (regex match object)? True for both
+    /// the lazy repr (`ValueRepr::Match`, checked WITHOUT materializing) and
+    /// an eager/rebuilt `Instance("Match")`.
     pub(crate) fn is_match_instance(&self) -> bool {
+        if self.0.as_match_node().is_some() {
+            return true;
+        }
         matches!(self.view(), ValueView::Instance { class_name, .. } if class_name == "Match")
     }
 
     /// Read one attribute of a `Match` instance. `None` when `self` is not a
     /// Match or the attribute is absent. The internal funnel every public
-    /// accessor below goes through.
+    /// accessor below goes through. On an unmaterialized lazy Match, scalar
+    /// attributes are answered straight from the capture node.
     fn match_attr(&self, name: &str) -> Option<Value> {
+        if let Some(node) = self.0.as_match_node() {
+            return node.attr(name);
+        }
         match self.view() {
             ValueView::Instance {
                 class_name,

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -435,7 +435,9 @@ mod error_construct;
 mod error_typed;
 mod guards;
 /// ADR-0016 P5 seam: `Match`-representation accessor helpers.
+mod match_lazy;
 mod match_view;
+pub(crate) use match_lazy::MatchNode;
 /// NaN-boxed 8-byte representation core (3b-1 step B): the packed word that
 /// IS the `Value` storage. The only module that knows the bit layout.
 mod nanbox;
@@ -1301,6 +1303,10 @@ pub(in crate::value) enum ValueRepr {
         attributes: crate::gc::Gc<InstanceAttrs>,
         id: u64,
     },
+    /// A lazily materialized regex `Match` (ADR-0016 P5). Presents as an
+    /// `Instance("Match")` through `view()`, which forces the memoized
+    /// one-level materialization — see [`match_lazy`].
+    Match(crate::gc::Gc<MatchNode>),
     Junction {
         kind: JunctionKind,
         values: Arc<Vec<Value>>,

--- a/src/value/nanbox/decode.rs
+++ b/src/value/nanbox/decode.rs
@@ -233,6 +233,7 @@ unsafe fn decode_kind(kind: Kind, bits: u64) -> ValueRepr {
         Kind::BagMut => ValueRepr::Bag(unsafe { take_gc::<BagData>(bits) }, true),
         Kind::MixImm => ValueRepr::Mix(unsafe { take_gc::<MixData>(bits) }, false),
         Kind::MixMut => ValueRepr::Mix(unsafe { take_gc::<MixData>(bits) }, true),
+        Kind::Match => ValueRepr::Match(unsafe { take_gc::<MatchNode>(bits) }),
         Kind::Nil => ValueRepr::Nil,
         Kind::Whatever => ValueRepr::Whatever,
         Kind::HyperWhatever => ValueRepr::HyperWhatever,

--- a/src/value/nanbox/encode.rs
+++ b/src/value/nanbox/encode.rs
@@ -133,6 +133,7 @@ impl NanBox {
                 );
                 pack_gc(Kind::Instance, attributes)
             }
+            ValueRepr::Match(node) => pack_gc(Kind::Match, node),
             ValueRepr::Junction { kind, values } => pack_arc(
                 match kind {
                     JunctionKind::Any => Kind::JunctionAny,

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -168,6 +168,8 @@ pub(in crate::value) enum Kind {
     BagMut,
     MixImm,
     MixMut,
+    /// A lazily materialized regex `Match` (ADR-0016 P5): `Gc<MatchNode>`.
+    Match,
     // -- inline kinds (payload in bits 8..40) --
     Nil,
     Whatever,
@@ -450,6 +452,7 @@ unsafe fn payload_op(kind: Kind, bits: u64, op: PayloadOp) {
             Kind::SetImm | Kind::SetMut => gc_op::<SetData>(bits, op),
             Kind::BagImm | Kind::BagMut => gc_op::<BagData>(bits, op),
             Kind::MixImm | Kind::MixMut => gc_op::<MixData>(bits, op),
+            Kind::Match => gc_op::<MatchNode>(bits, op),
             Kind::Nil
             | Kind::Whatever
             | Kind::HyperWhatever

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -233,6 +233,125 @@ impl NanBox {
         }
     }
 
+    /// Whether this word is a Junction (any flavour) — a pure tag probe.
+    /// Dispatch paths use it to gate their junction auto-threading scans
+    /// without decoding `view()` (which would materialize a lazy Match).
+    #[inline]
+    pub(in crate::value) fn is_junction(&self) -> bool {
+        matches!(
+            classify(self.0.get()),
+            Classified::Kind(
+                Kind::JunctionAny | Kind::JunctionAll | Kind::JunctionOne | Kind::JunctionNone
+            )
+        )
+    }
+
+    /// Whether this word is a `Proxy` — a pure tag probe (same motivation as
+    /// [`Self::is_junction`]).
+    #[inline]
+    pub(in crate::value) fn is_proxy(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::Proxy))
+    }
+
+    /// Whether this word is a string-keyed `Pair` — a pure tag probe (the
+    /// named-argument scans in dispatch use it; same motivation as
+    /// [`Self::is_junction`]).
+    #[inline]
+    pub(in crate::value) fn is_string_pair(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::Pair))
+    }
+
+    /// Whether this word is a `Pair` OR `ValuePair` — a pure tag probe.
+    #[inline]
+    pub(in crate::value) fn is_any_pair(&self) -> bool {
+        matches!(
+            classify(self.0.get()),
+            Classified::Kind(Kind::Pair | Kind::ValuePair)
+        )
+    }
+
+    /// Whether this word is a `VarRef` — a pure tag probe (the binder strips
+    /// this wrapper once per parameter; same motivation as
+    /// [`Self::is_junction`]).
+    #[inline]
+    pub(in crate::value) fn is_varref(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::VarRef))
+    }
+
+    /// Whether this word is a `ContainerRef` — a pure tag probe (checked on
+    /// every `GetLocal`; same motivation as [`Self::is_junction`]).
+    #[inline]
+    pub(in crate::value) fn is_container_ref(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::ContainerRef))
+    }
+
+    /// Whether this word is a `HashEntryRef` — a pure tag probe (checked on
+    /// every `GetLocal`).
+    #[inline]
+    pub(in crate::value) fn is_hash_entry_ref(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::HashEntryRef))
+    }
+
+    /// Whether this word is a `LazyThunk` — a pure tag probe (checked on
+    /// every `GetLocal`).
+    #[inline]
+    pub(in crate::value) fn is_lazy_thunk(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::LazyThunk))
+    }
+
+    /// Whether this word is a `Package` type object — a pure tag probe.
+    #[inline]
+    pub(in crate::value) fn is_package(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::Package))
+    }
+
+    /// Whether this word is a `Mixin` — a pure tag probe.
+    #[inline]
+    pub(in crate::value) fn is_mixin(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::Mixin))
+    }
+
+    /// Whether this word is a `Seq` — a pure tag probe.
+    #[inline]
+    pub(in crate::value) fn is_seq(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::Seq))
+    }
+
+    /// Whether this word is a `LazyList` — a pure tag probe.
+    #[inline]
+    pub(in crate::value) fn is_lazy_list(&self) -> bool {
+        matches!(classify(self.0.get()), Classified::Kind(Kind::LazyList))
+    }
+
+    /// The `MatchNode` pointee if this is a lazy `Match`. The non-forcing
+    /// probe behind the seam accessors' fast paths.
+    #[inline]
+    pub(in crate::value) fn as_match_node(&self) -> Option<&MatchNode> {
+        let bits = self.0.get();
+        match classify(bits) {
+            // SAFETY: Match words carry a Gc<MatchNode>.
+            Classified::Kind(Kind::Match) => Some(unsafe { peek_gc::<MatchNode>(bits) }),
+            _ => None,
+        }
+    }
+
+    /// The erased GC node handle if this is a lazy `Match` — for `gc_trace`,
+    /// which must not go through `view()` (that would materialize the match
+    /// during a collect).
+    #[inline]
+    pub(in crate::value) fn match_node_erased(&self) -> Option<crate::gc::ErasedGc> {
+        let bits = self.0.get();
+        match classify(bits) {
+            Classified::Kind(Kind::Match) => {
+                // SAFETY: Match words carry a Gc<MatchNode>; the handle is
+                // wrapped in ManuallyDrop so the word keeps its reference.
+                let g = ManuallyDrop::new(unsafe { take_gc::<MatchNode>(bits) });
+                Some(g.erased())
+            }
+            _ => None,
+        }
+    }
+
     /// A representation-variant tag for `same_variant`: collapses the kind
     /// space back onto `ValueRepr` discriminants (all six Array kinds are one
     /// variant, IntBoxed is Int, the four Junction kinds are one, etc.).
@@ -256,6 +375,9 @@ impl NanBox {
                 Kind::JunctionAny | Kind::JunctionAll | Kind::JunctionOne | Kind::JunctionNone => {
                     VARIANT_JUNCTION
                 }
+                // A lazy Match presents as an Instance through `view()`, so
+                // variant comparisons group it with Instance.
+                Kind::Match => VARIANT_KIND_BASE + Kind::Instance as u8,
                 other => VARIANT_KIND_BASE + other as u8,
             },
         }
@@ -453,6 +575,17 @@ unsafe fn view_kind<'a>(kind: Kind, bits: u64) -> ValueView<'a> {
                     class_name: attrs.class_name,
                     attributes: gc_guard(bits),
                     id: attrs.id,
+                }
+            }
+            Kind::Match => {
+                // A lazy Match presents as an Instance: force (and memoize)
+                // the one-level materialization. Non-forcing readers use the
+                // seam accessors / `as_match_node` instead of `view()`.
+                let node = peek_gc::<MatchNode>(bits);
+                ValueView::Instance {
+                    class_name: crate::value::match_lazy::match_class_symbol(),
+                    attributes: RefGuard::borrowed(node.force_attrs()),
+                    id: node.id,
                 }
             }
             Kind::ArrayList => ValueView::Array(gc_guard(bits), ArrayKind::List),

--- a/src/value/types_truthy.rs
+++ b/src/value/types_truthy.rs
@@ -35,6 +35,15 @@ impl Value {
     }
 
     pub(crate) fn truthy(&self) -> bool {
+        // An unmaterialized lazy Match is always a successful live match
+        // (failed `.subparse` Matches are rebuilt as eager Instances carrying
+        // `__failed_match__`) — answer without materializing. A boolean test
+        // is the most common observation of `m//` in a condition.
+        if let Some(node) = self.0.as_match_node()
+            && node.forced().is_none()
+        {
+            return true;
+        }
         match self.view() {
             // A `VarRef` is a transient binder wrapper: it is as true as the
             // variable's value.

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -70,6 +70,13 @@ impl Value {
     /// `Gc` node nested inside them is still reached (otherwise the wrapper is an
     /// invisible edge and a cycle through it is missed — an under-collect).
     pub(crate) fn gc_trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        // A lazy Match is a `Gc<MatchNode>` node: yield the handle WITHOUT
+        // going through `view()`, which would materialize the match (allocate)
+        // in the middle of a collect.
+        if let Some(node) = self.0.match_node_erased() {
+            visit(&node);
+            return;
+        }
         // Post-flip, the multi-field payloads (Pair, Scalar, Capture, ...)
         // live behind one shared `Arc<...Box>`: when that box is shared by
         // N > 1 holders, tracing through every holder would over-count its
@@ -375,6 +382,24 @@ impl Trace for MixData {
 
     fn drop_gc_edges(&mut self) {
         self.original_keys = None;
+    }
+}
+
+/// A lazy Match node's only traced edge is its memoized materialization
+/// (`Gc<InstanceAttrs>`). The `Arc<CapNode>` payload can hold `Value`s
+/// (`ast`, `regex_vars`, code-block contexts), but the capture tree is shared
+/// across sibling Matches and the reduce log, so per the shared-wrapper rule
+/// its contents are treated as externally rooted (conservative — a cycle
+/// routed solely through a capture node's `ast` defers, never corrupts; see
+/// [`uniquely_owned`]).
+impl Trace for super::MatchNode {
+    fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+        if let Some(attrs) = self.forced() {
+            visit(&attrs.erased());
+        }
+    }
+    fn drop_gc_edges(&mut self) {
+        self.take_attrs_for_gc();
     }
 }
 

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -92,7 +92,12 @@ impl Value {
         })
     }
     /// The `(name, value, index)` of a [`ValueRepr::VarRef`], or `None`.
+    /// Tag-probe gated: runs once per bound parameter, and a `view()` on a
+    /// lazy Match would materialize it just to see it is not a VarRef.
     pub fn as_varref(&self) -> Option<(Symbol, &Value, Option<u32>)> {
+        if !self.0.is_varref() {
+            return None;
+        }
         match self.view() {
             ValueView::VarRef { name, value, index } => Some((name, value, index)),
             _ => None,
@@ -101,6 +106,9 @@ impl Value {
     /// The value a [`ValueRepr::VarRef`] wraps, or `self` when it is not one.
     /// The binder strips the wrapper here once it has taken the name it needs.
     pub fn unwrap_varref(&self) -> &Value {
+        if !self.0.is_varref() {
+            return self;
+        }
         match self.view() {
             ValueView::VarRef { value, .. } => value,
             _ => self,
@@ -366,8 +374,11 @@ impl Value {
         }
     }
 
+    /// Tag probe (never decodes `view()`): this runs on every `GetLocal`, and
+    /// a `view()` on a lazy Match would materialize it just to see it is not
+    /// a `ContainerRef`.
     pub fn is_container_ref(&self) -> bool {
-        matches!(self.view(), ValueView::ContainerRef(_))
+        self.0.is_container_ref()
     }
 
     /// Autovivify a hash entry: if the key doesn't exist, insert an empty Hash.

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -31,6 +31,14 @@ impl Value {
     }
 
     /// Like make_match_object_full but with named_quantified tracking.
+    ///
+    /// ADR-0016 P5: this no longer builds an eager `Instance` tree. It
+    /// synthesizes a top-level `CapNode` from the exploded capture axes and
+    /// returns a lazy `Match` value (`ValueRepr::Match`); the Instance-shaped
+    /// attribute map materializes on first observation, one level at a time
+    /// (see `value::match_lazy`). The synthesized top node deliberately
+    /// carries no `sym`/`action_name`/`ast`/`regex_vars`/`capture_alias_map`
+    /// — the pre-P5 builder never surfaced those on the top-level Match.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn make_match_object_full_q(
         matched: String,
@@ -45,293 +53,40 @@ impl Value {
         orig: Option<&str>,
         named_quantified: &HashSet<String>,
     ) -> Self {
-        // `orig`'s original string (for the `.orig` attribute, shared via Arc
-        // rather than cloned) and its char vector (for the position search
-        // below) are threaded through as a pair rather than re-derived from
-        // `Option<&str>` at every leaf capture — a match tree can have one
-        // such leaf per matched character (e.g. a quoted scalar's run of
-        // space captures), and re-collecting the WHOLE original string into
-        // a fresh `Vec<char>` (and cloning it into a fresh `String`) at each
-        // one made a single `.parse()` cost O(captures × document length).
-        type OrigCtx<'o> = (&'o std::sync::Arc<String>, &'o [char]);
-
-        fn make_capture_match(s: &str, orig_ctx: Option<OrigCtx>, search_from: usize) -> Value {
-            let mut attrs = HashMap::new();
-            attrs.insert("str".to_string(), Value::str(s.to_string()));
-            // Try to find the captured text's position within the original string
-            crate::vm::vm_stats::record_regex_match_leaf(orig_ctx.is_some());
-            let (cap_from, cap_to) = if let Some((_, haystack)) = orig_ctx {
-                // Search for the captured substring starting from search_from
-                let needle: Vec<char> = s.chars().collect();
-                let mut found_from = 0i64;
-                let mut found = false;
-                for start in search_from..=haystack.len().saturating_sub(needle.len()) {
-                    if haystack[start..start + needle.len()] == needle[..] {
-                        found_from = start as i64;
-                        found = true;
-                        break;
-                    }
-                }
-                if found {
-                    (found_from, found_from + needle.len() as i64)
-                } else {
-                    (0i64, s.chars().count() as i64)
-                }
-            } else {
-                (0i64, s.chars().count() as i64)
-            };
-            attrs.insert("from".to_string(), Value::Int(cap_from));
-            attrs.insert("to".to_string(), Value::Int(cap_to));
-            attrs.insert("list".to_string(), Value::array(Vec::new()));
-            attrs.insert("named".to_string(), Value::hash(HashMap::new()));
-            if let Some((o, _)) = orig_ctx {
-                attrs.insert("orig".to_string(), Value::str_arc(std::sync::Arc::clone(o)));
-            }
-            Value::make_instance(Symbol::intern("Match"), attrs)
-        }
-
-        /// Build a Match object from a stored CapNode, recursively handling subcaptures.
-        fn make_subcap_match(caps: &crate::runtime::CapNode, orig_ctx: Option<OrigCtx>) -> Value {
-            if caps.children.is_none() {
-                crate::vm::vm_stats::record_regex_match_leaf(false);
-            }
-            let search_start = caps.from;
-            let kids = caps.kids();
-            let pos_vals: Vec<Value> = kids
-                .positional
-                .iter()
-                .enumerate()
-                .map(|(i, s)| {
-                    // An unmatched optional capture (`(x)?` zero match) renders as Nil.
-                    if kids.positional_nil.get(i) == Some(&true) {
-                        return Value::Nil;
-                    }
-                    // Check if this positional entry is a quantified list
-                    if let Some(Some(qlist)) = kids.positional_quantified.get(i) {
-                        let arr: Vec<Value> = qlist
-                            .iter()
-                            .map(|(text, from, to, subcap)| {
-                                if let Some(sc) = subcap {
-                                    return make_subcap_match(sc, orig_ctx);
-                                }
-                                let mut a = HashMap::new();
-                                a.insert("str".to_string(), Value::str(text.clone()));
-                                a.insert("from".to_string(), Value::Int(*from as i64));
-                                a.insert("to".to_string(), Value::Int(*to as i64));
-                                a.insert("list".to_string(), Value::array(Vec::new()));
-                                a.insert("named".to_string(), Value::hash(HashMap::new()));
-                                if let Some((o, _)) = orig_ctx {
-                                    a.insert(
-                                        "orig".to_string(),
-                                        Value::str_arc(std::sync::Arc::clone(o)),
-                                    );
-                                }
-                                Value::make_instance(Symbol::intern("Match"), a)
-                            })
-                            .collect();
-                        return Value::array(arr);
-                    }
-                    // Recursively build nested Match objects for positional subcaptures
-                    if let Some(Some(subcap)) = kids.positional_subcaps.get(i) {
-                        return make_subcap_match(subcap, orig_ctx);
-                    }
-                    make_capture_match(s, orig_ctx, search_start)
-                })
-                .collect();
-            let mut sub_named: HashMap<String, Value> = HashMap::new();
-            for (key, values) in &kids.named {
-                let subcaps_for_key = kids.named_subcaps.get(key);
-                let vals: Vec<Value> = values
-                    .iter()
-                    .enumerate()
-                    .map(|(i, s)| {
-                        if let Some(scs) = subcaps_for_key
-                            && let Some(sc) = scs.get(i)
-                        {
-                            return make_subcap_match(sc, orig_ctx);
-                        }
-                        make_capture_match(s, orig_ctx, search_start)
-                    })
-                    .collect();
-                if vals.len() == 1 && !kids.named_quantified.contains(key) {
-                    sub_named.insert(key.clone(), vals[0].clone());
-                } else {
-                    sub_named.insert(key.clone(), Value::real_array(vals));
-                }
-            }
-            // For quantified named captures that matched zero times, insert empty arrays
-            for qname in &kids.named_quantified {
-                sub_named
-                    .entry(qname.clone())
-                    .or_insert_with(|| Value::real_array(Vec::new()));
-            }
-            // Silent-action captures: hidden `<.foo>` subrule matches (stored under
-            // a marker key in `named_subcaps`) that carry nested captures. They are
-            // absent from `named`/`.hash`, but their action methods must fire, so
-            // build them into a `silent_caps` array for the grammar action walk.
-            // Each subcap's `action_name` carries the rule name to dispatch on.
-            let mut silent_caps_vals: Vec<Value> = Vec::new();
-            for (key, scs) in &kids.named_subcaps {
-                if key.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
-                    for sc in scs {
-                        silent_caps_vals.push(make_subcap_match(sc, orig_ctx));
-                    }
-                }
-            }
-            let mut attrs = HashMap::new();
-            attrs.insert("str".to_string(), Value::str(caps.matched.clone()));
-            attrs.insert("from".to_string(), Value::Int(caps.from as i64));
-            attrs.insert("to".to_string(), Value::Int(caps.to as i64));
-            attrs.insert("list".to_string(), Value::array(pos_vals));
-            attrs.insert("named".to_string(), Value::hash(sub_named));
-            if !silent_caps_vals.is_empty() {
-                attrs.insert(
-                    "silent_caps".to_string(),
-                    Value::real_array(silent_caps_vals),
-                );
-            }
-            if let Some((o, _)) = orig_ctx {
-                attrs.insert("orig".to_string(), Value::str_arc(std::sync::Arc::clone(o)));
-            }
-            // Store :sym<> variant name so action dispatch can find it
-            if let Some(ref sym_val) = caps.sym {
-                attrs.insert("sym_variant".to_string(), Value::str(sym_val.clone()));
-            }
-            if let Some(ref action_name) = caps.action_name {
-                attrs.insert("action_name".to_string(), Value::str(action_name.clone()));
-            }
-            // Inline `{ make … }` value produced by this subrule at reduce time.
-            if let Some(ref ast) = caps.ast {
-                attrs.insert("ast".to_string(), ast.clone());
-            }
-            // What this rule's own `:my $*x` declarations held at THIS match's
-            // reduce. The action walk re-installs them around this node's action
-            // so a per-match dynamic variable is not read as the last match's
-            // value (see `Interpreter::reduce_regex_captures_made_for_rule`).
-            if !kids.regex_vars.is_empty() {
-                let vars: HashMap<String, Value> = kids
-                    .regex_vars
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect();
-                attrs.insert("reduce_time_vars".to_string(), Value::hash(vars));
-            }
-            if !kids.capture_alias_map.is_empty() {
-                let alias_hash: HashMap<String, Value> = kids
-                    .capture_alias_map
-                    .iter()
-                    .map(|(k, v)| (k.clone(), Value::str(v.clone())))
-                    .collect();
-                attrs.insert("capture_alias_map".to_string(), Value::hash(alias_hash));
-            }
-            Value::make_instance(Symbol::intern("Match"), attrs)
-        }
-
-        // Built once per `.parse()` (not per leaf capture, see `OrigCtx` above).
-        let orig_arc = orig.map(|o| std::sync::Arc::new(o.to_string()));
-        let orig_chars_vec: Option<Vec<char>> = orig.map(|o| o.chars().collect());
-        let orig_ctx: Option<OrigCtx> = match (&orig_arc, &orig_chars_vec) {
-            (Some(a), Some(c)) => Some((a, c.as_slice())),
-            _ => None,
-        };
-
-        let mut attrs = HashMap::new();
-        attrs.insert("str".to_string(), Value::str(matched));
-        attrs.insert("from".to_string(), Value::Int(from));
-        attrs.insert("to".to_string(), Value::Int(to));
-        if let Some((o, _)) = orig_ctx {
-            attrs.insert("orig".to_string(), Value::str_arc(std::sync::Arc::clone(o)));
-        }
-        let search_start = from as usize;
-        let caps: Vec<Value> = positional
-            .iter()
-            .enumerate()
-            .map(|(i, s)| {
-                // An unmatched optional capture (`(x)?` zero match) renders as Nil.
-                if positional_nil.get(i) == Some(&true) {
-                    return Value::Nil;
-                }
-                // Check if this positional entry is a quantified list
-                if let Some(Some(qlist)) = positional_quantified.get(i) {
-                    let arr: Vec<Value> = qlist
-                        .iter()
-                        .map(|(text, qfrom, qto, subcap)| {
-                            if let Some(sc) = subcap {
-                                return make_subcap_match(sc, orig_ctx);
-                            }
-                            let mut a = HashMap::new();
-                            a.insert("str".to_string(), Value::str(text.clone()));
-                            a.insert("from".to_string(), Value::Int(*qfrom as i64));
-                            a.insert("to".to_string(), Value::Int(*qto as i64));
-                            a.insert("list".to_string(), Value::array(Vec::new()));
-                            a.insert("named".to_string(), Value::hash(HashMap::new()));
-                            if let Some((o, _)) = orig_ctx {
-                                a.insert(
-                                    "orig".to_string(),
-                                    Value::str_arc(std::sync::Arc::clone(o)),
-                                );
-                            }
-                            Value::make_instance(Symbol::intern("Match"), a)
-                        })
-                        .collect();
-                    return Value::array(arr);
-                }
-                // If there are nested subcaptures for this positional capture,
-                // build a full Match object with subcaptures
-                if let Some(Some(subcap)) = positional_subcaps.get(i) {
-                    return make_subcap_match(subcap, orig_ctx);
-                }
-                make_capture_match(s, orig_ctx, search_start)
+        let has_children = !named.is_empty()
+            || !named_subcaps.is_empty()
+            || !named_quantified.is_empty()
+            || !positional.is_empty()
+            || !positional_subcaps.is_empty()
+            || !positional_quantified.is_empty()
+            || !positional_nil.is_empty();
+        let children = has_children.then(|| {
+            Box::new(crate::runtime::CapChildren {
+                named: named.clone(),
+                named_subcaps: named_subcaps.clone(),
+                named_quantified: named_quantified.clone(),
+                capture_alias_map: HashMap::new(),
+                positional: positional.to_vec(),
+                positional_subcaps: positional_subcaps.to_vec(),
+                positional_quantified: positional_quantified.to_vec(),
+                positional_nil: positional_nil.to_vec(),
+                code_blocks: Vec::new(),
+                regex_vars: HashMap::new(),
             })
-            .collect();
-        attrs.insert("list".to_string(), Value::array(caps));
-        let mut named_caps_map: HashMap<String, Value> = HashMap::new();
-        for (key, values) in named {
-            let subcaps_for_key = named_subcaps.get(key);
-            let vals: Vec<Value> = values
-                .iter()
-                .enumerate()
-                .map(|(i, s)| {
-                    if let Some(scs) = subcaps_for_key
-                        && let Some(sc) = scs.get(i)
-                    {
-                        return make_subcap_match(sc, orig_ctx);
-                    }
-                    make_capture_match(s, orig_ctx, search_start)
-                })
-                .collect();
-            if vals.len() == 1 && !named_quantified.contains(key) {
-                named_caps_map.insert(key.clone(), vals[0].clone());
-            } else {
-                named_caps_map.insert(key.clone(), Value::real_array(vals));
-            }
-        }
-        // For quantified named captures that matched zero times, insert empty arrays
-        for qname in named_quantified {
-            named_caps_map
-                .entry(qname.clone())
-                .or_insert_with(|| Value::real_array(Vec::new()));
-        }
-        attrs.insert("named".to_string(), Value::hash(named_caps_map));
-        // Silent-action captures: hidden `<.foo>` subrule matches carrying nested
-        // captures (see make_subcap_match). Build them into a `silent_caps` array
-        // so the grammar action walk fires their (and descendants') actions; they
-        // are deliberately absent from `named`/`.hash`.
-        let mut silent_caps_vals: Vec<Value> = Vec::new();
-        for (key, scs) in named_subcaps {
-            if key.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
-                for sc in scs {
-                    silent_caps_vals.push(make_subcap_match(sc, orig_ctx));
-                }
-            }
-        }
-        if !silent_caps_vals.is_empty() {
-            attrs.insert(
-                "silent_caps".to_string(),
-                Value::real_array(silent_caps_vals),
-            );
-        }
-        Value::make_instance(Symbol::intern("Match"), attrs)
+        });
+        let cap = crate::runtime::CapNode {
+            matched,
+            from: from.max(0) as usize,
+            to: to.max(0) as usize,
+            sym: None,
+            action_name: None,
+            ast: None,
+            children,
+        };
+        Value::lazy_match(
+            std::sync::Arc::new(cap),
+            orig.map(|o| std::sync::Arc::new(o.to_string())),
+        )
     }
 
     pub(crate) fn version_strip_trailing_zeros(parts: &[VersionPart]) -> Vec<VersionPart> {

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -571,6 +571,84 @@ impl Value {
         self.0.is_nil()
     }
 
+    /// Whether this is a Junction (any flavour). A pure tag probe — unlike a
+    /// `view()` match it cannot materialize a lazy Match, so dispatch-path
+    /// junction scans must use this as their gate.
+    #[inline]
+    pub(crate) fn is_junction_value(&self) -> bool {
+        self.0.is_junction()
+    }
+
+    /// Whether this is a `Proxy`. A pure tag probe (see [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_proxy_value(&self) -> bool {
+        self.0.is_proxy()
+    }
+
+    /// Whether this is a string-keyed `Pair` (`ValueView::Pair`). A pure tag
+    /// probe (see [`Self::is_junction_value`]) — dispatch-path named-argument
+    /// scans use it so they cannot materialize a lazy Match.
+    #[inline]
+    pub(crate) fn is_string_pair_value(&self) -> bool {
+        self.0.is_string_pair()
+    }
+
+    /// Whether this is a lazily materialized `Match` (`ValueRepr::Match`). A
+    /// pure tag probe: type-check fast paths use it to answer the ubiquitous
+    /// constraints (`Match`/`Any`/`Mu`) without materializing.
+    #[inline]
+    pub(crate) fn is_lazy_match_value(&self) -> bool {
+        self.0.as_match_node().is_some()
+    }
+
+    /// Whether this is a `Pair` or `ValuePair`. A pure tag probe (see
+    /// [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_any_pair_value(&self) -> bool {
+        self.0.is_any_pair()
+    }
+
+    /// Whether this is a `HashEntryRef`. A pure tag probe (see
+    /// [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_hash_entry_ref_value(&self) -> bool {
+        self.0.is_hash_entry_ref()
+    }
+
+    /// Whether this is a `LazyThunk`. A pure tag probe (see
+    /// [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_lazy_thunk_value(&self) -> bool {
+        self.0.is_lazy_thunk()
+    }
+
+    /// Whether this is a `Package` type object. A pure tag probe (see
+    /// [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_package_value(&self) -> bool {
+        self.0.is_package()
+    }
+
+    /// Whether this is a `Mixin`. A pure tag probe (see
+    /// [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_mixin_value(&self) -> bool {
+        self.0.is_mixin()
+    }
+
+    /// Whether this is a `Seq`. A pure tag probe (see [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_seq_value(&self) -> bool {
+        self.0.is_seq()
+    }
+
+    /// Whether this is a `LazyList`. A pure tag probe (see
+    /// [`Self::is_junction_value`]).
+    #[inline]
+    pub(crate) fn is_lazy_list_value(&self) -> bool {
+        self.0.is_lazy_list()
+    }
+
     /// Whether this is the `Any` type object (`Package("Any")`) — notably the
     /// value an uninitialized untyped scalar declaration seeds (PLAN 8.5
     /// step 3), which container-identity heuristics must treat like the old

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1133,7 +1133,7 @@ impl Interpreter {
             let mut match_args: Vec<Value> = Vec::new();
             let mut positional_seen = 0;
             for arg in &args {
-                if matches!(arg.view(), ValueView::Pair(..)) {
+                if arg.is_string_pair_value() {
                     match_args.push(arg.clone());
                 } else {
                     positional_seen += 1;

--- a/src/vm/vm_call_resolve.rs
+++ b/src/vm/vm_call_resolve.rs
@@ -111,11 +111,7 @@ impl Interpreter {
                 }
             }
         } else {
-            let pos_arity = || {
-                args.iter()
-                    .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
-                    .count()
-            };
+            let pos_arity = || args.iter().filter(|a| !a.is_string_pair_value()).count();
             // Innermost package first, then each enclosing package, then GLOBAL:
             // a method of `NL::Searcher` calling a bare name must reach `NL`'s
             // compiled routine (see `bare_name_packages`). The GLOBAL fallback

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -452,7 +452,11 @@ impl Interpreter {
             // dispatch on the inner value, then write any in-place mutation back
             // THROUGH the cell so the source array observes it and the result
             // array keeps its source aliasing.
-            let hyper_cell = if let ValueView::ContainerRef(cell) = item.view() {
+            // Tag-probed: this runs per element, and a `view()` would
+            // materialize a lazy Match just to see it is not a cell.
+            let hyper_cell = if item.is_container_ref()
+                && let ValueView::ContainerRef(cell) = item.view()
+            {
                 let cell = cell.clone();
                 *item = cell.lock().unwrap().clone();
                 Some(cell)
@@ -471,10 +475,15 @@ impl Interpreter {
                     "DEFINITE" | "WHAT" | "WHO" | "HOW" | "WHY" | "WHICH" | "WHERE" | "VAR"
                 )
             {
-                let class_name = match item.view() {
-                    ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
-                    ValueView::Package(name) => Some(name.resolve()),
-                    _ => None,
+                let class_name = if item.is_lazy_match_value() {
+                    // Lazy Match: class is "Match" — no materialization.
+                    Some("Match".to_string())
+                } else {
+                    match item.view() {
+                        ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
+                        ValueView::Package(name) => Some(name.resolve()),
+                        _ => None,
+                    }
                 };
                 if let Some(cn) = class_name
                     && self.has_user_method(&cn, &method)
@@ -582,13 +591,17 @@ impl Interpreter {
                     // Raku's >> descends into Iterable structures, but stops
                     // if the method is natively defined on the list type
                     // (e.g., .join, .elems, .sort, .reverse, .unique, .squish).
-                    let is_iterable_item = matches!(
-                        item.view(),
-                        ValueView::Array(..)
-                            | ValueView::Seq(..)
-                            | ValueView::Slip(..)
-                            | ValueView::Hash(..)
-                    );
+                    // (Lazy-Match gate: a `view()` here would materialize a
+                    // lazy Match per `».method` element just to see it is not
+                    // an Iterable.)
+                    let is_iterable_item = !item.is_lazy_match_value()
+                        && matches!(
+                            item.view(),
+                            ValueView::Array(..)
+                                | ValueView::Seq(..)
+                                | ValueView::Slip(..)
+                                | ValueView::Hash(..)
+                        );
                     // A qualified dispatch (`».Any::elems`) still names a
                     // plain list-native method once the owner prefix is
                     // stripped, so nodality is decided on the unqualified tail.

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -311,14 +311,14 @@ impl Interpreter {
         // or an Iterable) — those cases fall through to the generic
         // element-wise/base-case handling below.
         if let ValueView::Pair(k, v) = left.view()
-            && !matches!(right.view(), ValueView::Pair(..))
+            && !right.is_string_pair_value()
             && !Self::is_listy(right)
         {
             let new_v = self.hyper_op_pair(op, v, right, dwim_left, dwim_right)?;
             return Ok(Value::pair(k.clone(), new_v));
         }
         if let ValueView::Pair(k, v) = right.view()
-            && !matches!(left.view(), ValueView::Pair(..))
+            && !left.is_string_pair_value()
             && !Self::is_listy(left)
         {
             let new_v = self.hyper_op_pair(op, left, v, dwim_left, dwim_right)?;

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -202,9 +202,7 @@ impl Interpreter {
             // carries a Pair/ValuePair to the full path (which separates named from
             // positional and validates arity via `bind_function_args_values`) keeps
             // that check; the fast path stays for the common all-positional call.
-            let has_named_arg = args
-                .iter()
-                .any(|a| matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)));
+            let has_named_arg = args.iter().any(|a| a.is_any_pair_value());
 
             if !has_named_arg
                 && !has_missing_required

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -132,7 +132,10 @@ impl Interpreter {
         let val = loan_env!(self, auto_fetch_proxy(&val))?;
         // Mu itself has no Str candidate — stringifying it is a hard
         // error (Rakudo dies with `Cannot resolve caller prefix:<~>(Mu:U)`).
-        if let ValueView::Package(name) = val.view()
+        // Tag-probed: `~$match` lands here per capture and a `view()` would
+        // materialize a lazy Match.
+        if val.is_package_value()
+            && let ValueView::Package(name) = val.view()
             && name.resolve() == "Mu"
         {
             return Err(RuntimeError::new(format!(

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -42,7 +42,10 @@ impl Interpreter {
         // the iterator (`materialize_deferred_seq`) before dispatching. `cache`/
         // `raku`/`perl` intentionally keep the Seq lazy (they must NOT pull), so
         // they proceed with the native path.
-        if let ValueView::Seq(items) = target.view()
+        // (The Seq / LazyList probes below are tag-gated: `view()` on a lazy
+        // Match target would materialize it per dispatched method call.)
+        if target.is_seq_value()
+            && let ValueView::Seq(items) = target.view()
             && crate::value::seq_has_deferred_iter(&items)
             && !crate::value::seq_deferred_method_keeps_lazy(method_name.as_str())
         {
@@ -76,7 +79,7 @@ impl Interpreter {
         // the native impl here would materialize the source eagerly — forcing the
         // whole gather body (and its trailing side effects) instead of pulling on
         // demand. Defer.
-        if let ValueView::LazyList(_) = target.view()
+        if target.is_lazy_list_value()
             && Self::is_lazy_pipe_source(target)
             && matches!(method_name.as_str(), "map" | "grep")
         {
@@ -85,7 +88,8 @@ impl Interpreter {
         // A laziness-preserving coercion on a lazy map/grep pipeline returns the
         // pipeline unchanged (it stays pullable). Intercept before the native
         // impl, which would otherwise wrap/empty the pipeline's (empty) cache.
-        if let ValueView::LazyList(ll) = target.view()
+        if target.is_lazy_list_value()
+            && let ValueView::LazyList(ll) = target.view()
             && ll.lazy_pipe.is_some()
             && Self::lazy_pipe_preserving_coercion(method_name.as_str())
         {
@@ -100,7 +104,7 @@ impl Interpreter {
             return Some(Err(err));
         }
         // Early exit for Proxy containers
-        if matches!(target.view(), ValueView::Proxy { .. })
+        if target.is_proxy_value()
             && !matches!(
                 method_name.as_str(),
                 "VAR" | "WHAT" | "WHICH" | "WHERE" | "HOW" | "WHY" | "REPR" | "DEFINITE"
@@ -127,8 +131,31 @@ impl Interpreter {
         if self.mixin_role_has_method(target, &method_name) {
             return None;
         }
+        // Lazy Match: class is statically "Match" — mirror the Instance
+        // bypasses below without materializing. (A Match never matches
+        // Real/Numeric, and the Supply/Supplier arms cannot apply.)
+        if target.is_lazy_match_value() {
+            let is_pure_render = matches!(
+                method_name.as_str(),
+                "gist" | "Str" | "Stringy" | "raku" | "perl"
+            );
+            let render_overridden = is_pure_render && self.has_user_method("Match", &method_name);
+            if (!is_pure_render || render_overridden) && self.has_user_method("Match", "Bridge") {
+                return None;
+            }
+            if matches!(
+                method_name.as_str(),
+                "throw" | "rethrow" | "gist" | "Str" | "Stringy"
+            ) && self.exception_render_needs_interpreter(target, "Match")
+            {
+                return None;
+            }
+            if self.is_native_method("Match", &method_name) {
+                return None;
+            }
+        }
         // Instance-specific bypasses (avoid for non-Instance targets)
-        if matches!(target.view(), ValueView::Instance { .. }) {
+        else if matches!(target.view(), ValueView::Instance { .. }) {
             if let ValueView::Instance { class_name, .. } = target.view() {
                 let cn = class_name.resolve();
                 // Supply methods
@@ -250,8 +277,11 @@ impl Interpreter {
         {
             return None;
         }
-        // Hash-specific bypasses
-        if matches!(target.view(), ValueView::Hash(_)) && args.is_empty() {
+        // Hash-specific bypasses (lazy-Match gate: `view()` would materialize)
+        if !target.is_lazy_match_value()
+            && matches!(target.view(), ValueView::Hash(_))
+            && args.is_empty()
+        {
             let mn = method_name.as_str();
             if (mn == "raku" || mn == "perl" || mn == "keyof")
                 && self.container_type_metadata(target).is_some()
@@ -262,10 +292,11 @@ impl Interpreter {
                 return None;
             }
         }
-        // Typed array .raku/.perl bypass
-        if matches!(target.view(), ValueView::Array(..))
+        // Typed array .raku/.perl bypass (method-name gate first: the `view()`
+        // probe would materialize a lazy Match on every other method call)
+        if matches!(method_name.as_str(), "raku" | "perl")
             && args.is_empty()
-            && matches!(method_name.as_str(), "raku" | "perl")
+            && matches!(target.view(), ValueView::Array(..))
             && self
                 .container_type_metadata(target)
                 .is_some_and(|info| info.value_type != "Any" && info.value_type != "Mu")
@@ -354,13 +385,16 @@ impl Interpreter {
         }
 
         // For Hash values with declared_type "Map", override gist/raku/perl
-        // to use Map.new((...)) format instead of {...} format.
-        if let ValueView::Hash(map) = target.view() {
-            let is_map = matches!(method_name.as_str(), "gist" | "raku" | "perl")
-                && self
-                    .container_type_metadata(target)
-                    .and_then(|info| info.declared_type)
-                    .is_some_and(|dt| dt == "Map");
+        // to use Map.new((...)) format instead of {...} format. (Method-name
+        // gate first: the Hash `view()` probe would materialize a lazy Match
+        // on every other method call.)
+        if matches!(method_name.as_str(), "gist" | "raku" | "perl")
+            && let ValueView::Hash(map) = target.view()
+        {
+            let is_map = self
+                .container_type_metadata(target)
+                .and_then(|info| info.declared_type)
+                .is_some_and(|dt| dt == "Map");
             if is_map {
                 if map.is_empty() {
                     return Some(Ok(Value::str("Map.new".to_string())));

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -141,6 +141,9 @@ impl Interpreter {
         // call and propagated back to env but not to locals), adopt the ContainerRef.
         // Skip for type objects and complex values that should not be replaced.
         if !self.locals[idx].is_container_ref()
+            // A lazy Match counts as an Instance here — probed by tag so this
+            // per-GetLocal check cannot materialize it.
+            && !self.locals[idx].is_lazy_match_value()
             && !matches!(
                 self.locals[idx].view(),
                 ValueView::Package(_)
@@ -180,12 +183,16 @@ impl Interpreter {
         // Resolve a deferred bind token to its current value (Any if the path
         // doesn't exist). The raw local slot is unchanged, so a later write still
         // materializes it; `=:=` reads the raw slot via GetLocalRaw.
-        if let ValueView::HashEntryRef { .. } = val.view() {
+        if val.is_hash_entry_ref_value() {
             self.stack.push(val.hash_entry_read());
             return Ok(());
         }
-        // Force lazy thunks transparently on access
-        if let ValueView::LazyThunk(thunk_data) = val.view() {
+        // Force lazy thunks transparently on access. Both this and the
+        // HashEntryRef resolve above are tag-probed: they run on every
+        // GetLocal, and a `view()` would materialize a lazy Match.
+        if val.is_lazy_thunk_value()
+            && let ValueView::LazyThunk(thunk_data) = val.view()
+        {
             let thunk_data = thunk_data.clone();
             let forced = self.force_lazy_thunk(&thunk_data)?;
             self.stack.push(forced);


### PR DESCRIPTION
ADR-0016 P5, the repr-swap half: the P5 seam (#5581/#5584/#5586) funneled every Match consumer through accessors; this PR swaps the representation behind them.

## What

- **`ValueRepr::Match(Gc<MatchNode>)`** — a new NaN-box kind holding the shared subject string (`Arc<String>`), the stored capture node (`Arc<CapNode>`, which the matcher already built), a stable instance id, and a memoized `OnceLock<Gc<InstanceAttrs>>`.
- **`view()` presents it as `ValueView::Instance("Match")`** by forcing the memoized ONE-level materialization — so all unconverted consumers keep working unchanged. Child captures materialize as lazy Matches themselves: a subtree nobody observes never allocates anything beyond its `CapNode`.
- The three `make_match_object_*` builders now synthesize a top-level `CapNode` from the exploded capture axes and return a lazy value — the eager recursive Instance-tree build is gone.
- The seam accessors answer scalar reads (`.from`/`.to`/`.Str`/`.made`/`.orig`/`.Bool`) straight from the capture node without materializing.

## Grammar-action walk

- An **actionless node** is skipped with zero materialization (capture-node peek).
- A **childless leaf WITH an action** — YAMLish's per-character `method space($/) { make ~$/ }` shape — runs its action against the lazy `$/` without ever creating an `InstanceAttrs`; `make` is applied by rebuilding a fresh lazy node carrying the ast. Reduce-time `:my $*x` bindings are re-installed around the action, same as the main walk (pinned by `t/grammar-per-match-dynvar-action.t`).

## Tag-probe sweep

Keeping a lazy Match lazy across dispatch required converting ~20 `matches!(v.view(), ValueView::X..)` variant probes into pure NaN-box tag probes (`is_string_pair_value()`, `is_junction_value()`, `is_container_ref()`, ...). A `view()`-based "is it an X?" check materializes a lazy Match and is now an anti-pattern on dispatch paths. Measured by instrumenting materialization on a YAMLish parse: **leaf materializations fell 1807 → 15** (the residue is the reduce-time code-block replay, which is semantically required).

## GC

`Gc<MatchNode>` is a collector node whose only traced edge is the memoized materialization; the `Arc<CapNode>` payload is conservatively treated as externally rooted per the shared-wrapper rule. `gc_trace` yields the node handle via a tag probe, so a collect can never trigger materialization.

## Measurements

Local interleaved A/B (idle box, release, 5×5): `bench-yaml-parse` **1.31 s → 0.87 s (≈ −34 %)**. Authoritative numbers come from bench CI (`bench-history.tsv`, int-arith-normalized) after merge.

## Validation

- `cargo test` (628), full `t/` (24,915), and **full local `make roast` (1435 files, 218,774 tests) all PASS**.
- Two real bugs were caught and fixed during development: a `make` lost when the action itself materialized `$/` (falls back to the eager rebuild), and the leaf fast path initially skipping reduce-time dynvar re-installation (caught by the existing pin test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)