### PR TITLE
perf(regex): shared MatchTarget subject, drop stored capture text (ADR-0016 P3a)

### DIFF
--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -275,6 +275,30 @@ into `CapNode.matched`, again into the accumulator's `named`/`positional` text v
 again into the Match `str` attribute) — 38k `String` allocations per bench parse.
 The search fallback is retired when the text axis goes.
 
+**P3a landed 2026-07-31** (`news/2026-07/regex-match-target-span-reads.md`): the
+subject became `MatchTarget { text: Arc<String>, chars: Arc<[char]> }`, built once
+per engine entry, published on the returned accumulator
+(`RegexCaptures::target`) and carried by every lazy `MatchNode`; a thread-local
+engine scope covers mid-match synthesis (`<?{ }>` `.made` dispatch, reduce-time
+`$*` actions). On top of it the **stored text axis is gone where a span already
+lived**: `CapNode.matched` and `RegexCaptures.matched` are deleted (readers
+derive text via `span_str`, with an ASCII byte-slice fast path),
+`QuantifiedCaptureEntry` is `(from, to, subcap)`, `positional_slots` is spans
+only, and the P5 leaf position search is retired outright. Landing this
+surfaced that `positional_offsets` was NOT maintained by every positional
+producer (the quantified-fold fallback fabricated `0..len` — exactly the
+Cause-2 class of bug); every push/merge site now keeps the axis aligned.
+Compatibility fixes on the way: `:m`/`:i`-fold captures are remapped to
+original-subject space recursively (sub-captures previously reported derived-
+space offsets and derived-space text — `m:m/ caf (e) s /` on "cafés" now
+captures "é" like raku), and the pcre2 `:P5` path reported byte offsets where
+char offsets were expected. What P3 still owes: the accumulator's
+`named`/`positional` text vectors (and `CodeBlockContext`'s snapshot copies),
+which are structurally the P4 axis collapse — local interleaved A/B shows the
+intermediate state ≈ +2–3 % on `bench-yaml-parse` (the capture-site text
+`collect`s still run, plus span-derived reads), to be recovered when the text
+vectors disappear with P4.
+
 **P4 — One list per axis + interned names.** Collapse the parallel vectors/maps into
 `Vec<PosSlot>` and `HashMap<Symbol, Vec<Arc<CapNode>>>`, and shrink the trail's undo
 vocabulary accordingly (the alignment invariants become structural rather than asserted in
@@ -320,6 +344,10 @@ parse fell 1807 → 15; local interleaved A/B (idle box): `bench-yaml-parse`
 The reduce walk (`reduce_cap_node_for_rule` code-block replay) and the failed
 partial-parse replay still build eager Matches for `$/` inside in-regex code
 blocks — small counts, unchanged semantics.
+*Confirmed by bench CI (int-arith-normalized, `bench-history.tsv`):* the seven
+main-branch points before the P5 merge sit at 38.2–41.8 (`bench-yaml-parse` ÷
+`int-arith`); the P5 merge row (`fa2400a49`) is **25.65** — ≈ −35 %, matching
+the local A/B.
 
 ## Consequences
 

--- a/news/2026-07/regex-match-target-span-reads.md
+++ b/news/2026-07/regex-match-target-span-reads.md
@@ -1,0 +1,41 @@
+# Regex captures: shared MatchTarget subject, stored text axis removed where spans live (ADR-0016 P3a)
+
+The regex engine's captures no longer store their matched text alongside the
+span where a span already exists. A new `MatchTarget { text: Arc<String>,
+chars: Arc<[char]> }` is built once per engine entry point and shared by the
+whole capture tree: the entry publishes it on the returned accumulator
+(`RegexCaptures::target`), every lazy `MatchNode` carries it (so `.orig` is an
+`Arc` bump and `.Str` derives from the recorded span, with an ASCII byte-slice
+fast path), and a thread-local engine scope covers mid-match Match synthesis
+(`<?{ … }>` `.made` dispatch, reduce-time `$*` action runs).
+
+On top of that subject, three stored-text redundancies are deleted outright:
+`CapNode.matched` and `RegexCaptures.matched` (all ~25 `chars[a..b].collect()`
+whole-match writes removed; readers use `span_str`), the `String` element of
+`QuantifiedCaptureEntry` (now `(from, to, subcap)`), and the text in
+`positional_slots`. The P5 leaf position search — recover a leaf's offsets by
+scanning the subject for its text, wrong for repeated text — is retired; every
+leaf that reaches the Match builder carries a recorded span.
+
+Landing this surfaced that `positional_offsets` was not maintained by every
+positional producer: the quantified-capture fold fell back to fabricating
+`0..len` spans (the exact bug class ADR-0016 Cause 2 describes), which stored
+text used to paper over. Every positional push/merge site now keeps the
+offsets axis aligned, pinned by `t/subst-closure-quantified-capture.t`.
+
+Two compatibility fixes came out of deriving text from spans:
+
+- `:m` (ignoremark) and `:i` fold-expansion matches now remap the entire
+  capture tree — including sub-captures — back to original-subject space.
+  Previously sub-captures kept derived-space offsets and derived-space text:
+  `"cafés" ~~ m:m/ caf (e) s /` captured `"e"`; raku (and now mutsu) captures
+  `"é"` with the correct original-space span.
+- The pcre2 `:P5` path reported byte offsets in `.from`/`.to` and the
+  positional axes; they are now char offsets like every other path.
+
+The accumulator's `named`/`positional` text vectors still exist — removing
+them is structurally the P4 axis collapse (`HashMap<Symbol, Vec<Arc<CapNode>>>`
+/ `Vec<PosSlot>`), where the remaining per-capture text `collect`s disappear.
+Local interleaved A/B puts this intermediate state at ≈ +2–3 % on
+`bench-yaml-parse`; the bench-CI history (int-arith-normalized) is the
+authoritative number, and the cost is expected back with P4.

--- a/src/builtins/split.rs
+++ b/src/builtins/split.rs
@@ -305,22 +305,28 @@ fn split_by_strings(
 fn separator_value(m: &SplitMatch) -> Value {
     if m.is_regex {
         use std::collections::HashMap;
-        let orig = if m.orig.is_empty() {
-            None
+        // A separator Match's subject: the whole split subject when known,
+        // else the separator text itself (spans are then 0-based over it).
+        let target = if m.orig.is_empty() {
+            crate::runtime::MatchTarget::new(&m.matched)
         } else {
-            Some(m.orig.as_str())
+            crate::runtime::MatchTarget::new(&m.orig)
+        };
+        let (from, to) = if m.orig.is_empty() {
+            (0, m.matched.chars().count() as i64)
+        } else {
+            (m.from as i64, m.to as i64)
         };
         Value::make_match_object_full(
-            m.matched.clone(),
-            m.from as i64,
-            m.to as i64,
+            from,
+            to,
             &m.positional_captures,
             &HashMap::new(),
             &HashMap::new(),
             &[],
             &[],
             &[],
-            orig,
+            target,
         )
     } else {
         Value::str(m.matched.clone())

--- a/src/runtime/match_target.rs
+++ b/src/runtime/match_target.rs
@@ -1,0 +1,77 @@
+//! ADR-0016 P3: the shared, immutable match subject.
+//!
+//! A regex/grammar match runs against one `MatchTarget`, created at the
+//! engine entry point and shared (two refcount bumps) by the accumulator,
+//! the lazy `Match` tree, and every consumer that derives captured text.
+//! Recorded spans (`from`, `to`) are absolute char indices into `chars`;
+//! captured text is derived on demand via [`MatchTarget::span_str`] instead
+//! of being stored per capture node.
+
+use std::sync::Arc;
+
+/// The subject of a regex match: the same string in both the forms consumers
+/// need. `text` answers `.orig` with an `Arc` bump; `chars` is the char-index
+/// space every recorded span points into, sliced without re-collecting the
+/// subject.
+#[derive(Clone)]
+pub(crate) struct MatchTarget {
+    text: Arc<String>,
+    chars: Arc<[char]>,
+    /// Whole subject is ASCII: char index == byte index, so a span reads as
+    /// a byte slice of `text` (a straight memcpy) instead of re-encoding
+    /// chars one by one.
+    ascii: bool,
+}
+
+impl MatchTarget {
+    pub(crate) fn new(text: &str) -> Self {
+        Self {
+            text: Arc::new(text.to_string()),
+            chars: text.chars().collect(),
+            ascii: text.is_ascii(),
+        }
+    }
+
+    /// A target for a derived match space — the mark-stripped (`:m`) or
+    /// case-folded (`:i`) subject the engine actually matched against. The
+    /// chars ARE the space the engine's spans index into; the text form is
+    /// synthesized from them.
+    pub(crate) fn from_chars(chars: &[char]) -> Self {
+        let text: String = chars.iter().collect();
+        let ascii = text.is_ascii();
+        Self {
+            text: Arc::new(text),
+            chars: chars.into(),
+            ascii,
+        }
+    }
+
+    /// The whole subject as a string (`.orig`).
+    pub(crate) fn text(&self) -> &Arc<String> {
+        &self.text
+    }
+
+    /// The subject as absolute char positions.
+    pub(crate) fn chars(&self) -> &[char] {
+        &self.chars
+    }
+
+    /// The text of a recorded span, clamped to the subject bounds.
+    pub(crate) fn span_str(&self, from: usize, to: usize) -> String {
+        let len = self.chars.len();
+        let a = from.min(len);
+        let b = to.clamp(a, len);
+        if self.ascii {
+            return self.text[a..b].to_string();
+        }
+        self.chars[a..b].iter().collect()
+    }
+}
+
+impl std::fmt::Debug for MatchTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MatchTarget")
+            .field("len", &self.chars.len())
+            .finish()
+    }
+}

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -345,7 +345,8 @@ impl Interpreter {
                             if !caps.code_blocks.is_empty()
                                 || caps.named_subcaps.values().any(|v| !v.is_empty())
                             {
-                                self.reduce_regex_captures_made(caps, Some(&text));
+                                let ct = caps.target_or_new(&text);
+                                self.reduce_regex_captures_made(caps, Some(&ct));
                             }
                         }
                     }
@@ -432,10 +433,7 @@ impl Interpreter {
 
     /// Create a Match object from regex match positions.
     fn create_match_object(&self, text: &str, start: usize, end: usize, _pat: &str) -> Value {
-        let chars: Vec<char> = text.chars().collect();
-        let matched: String = chars[start..end].iter().collect();
         Value::make_match_object_full(
-            matched,
             start as i64,
             end as i64,
             &[],
@@ -444,7 +442,7 @@ impl Interpreter {
             &[],
             &[],
             &[],
-            Some(text),
+            crate::runtime::MatchTarget::new(text),
         )
     }
 

--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -168,7 +168,6 @@ impl Interpreter {
                     let fmt = args.first().map(Value::to_string_value).unwrap_or_default();
                     let len = fmt.chars().count() as i64;
                     return Some(Ok(Value::make_match_object_full(
-                        fmt.clone(),
                         0,
                         len,
                         &[],
@@ -177,7 +176,7 @@ impl Interpreter {
                         &[],
                         &[],
                         &[],
-                        Some(&fmt),
+                        crate::runtime::MatchTarget::new(&fmt),
                     )));
                 }
                 ("Formatter", "CODE") => {

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -413,7 +413,8 @@ impl Interpreter {
                 if let Some(ref mut actions) = actions_obj {
                     match partial_match.take() {
                         Some(mut caps) => {
-                            self.reduce_regex_captures_made(&mut caps, Some(&text));
+                            let pt = caps.target_or_new(&text);
+                            self.reduce_regex_captures_made(&mut caps, Some(&pt));
                             self.dispatch_partial_parse_actions(
                                 &caps,
                                 actions,
@@ -452,7 +453,8 @@ impl Interpreter {
                 // A failed `.subparse` yields a failed Match, not a Failure.
                 return Ok(self.make_failed_match_value(&text, start_pos.unwrap_or(0)));
             };
-            self.reduce_regex_captures_made(&mut captures, Some(&text));
+            let gtarget = captures.target_or_new(&text);
+            self.reduce_regex_captures_made(&mut captures, Some(&gtarget));
             // A subparse must begin at the requested offset (0, or `:pos(N)`);
             // `:c(N)` allows any start >= N, so it is exempt from the check.
             let required_from = start_pos.or(if continue_pos.is_some() {
@@ -489,7 +491,6 @@ impl Interpreter {
             }
             let alias_map = std::mem::take(&mut captures.capture_alias_map);
             let match_obj = Value::make_match_object_full_q(
-                captures.matched,
                 captures.from as i64,
                 captures.to as i64,
                 &captures.positional,
@@ -498,7 +499,7 @@ impl Interpreter {
                 &captures.positional_subcaps,
                 &captures.positional_quantified,
                 &captures.positional_nil,
-                Some(&text),
+                gtarget,
                 &captures.named_quantified,
             );
             let match_obj = {
@@ -621,7 +622,6 @@ impl Interpreter {
     /// whole parse text so `.orig`/`.prematch` work on it.
     fn match_object_from_captures(caps: &RegexCaptures, text: &str) -> Value {
         Value::make_match_object_full_q(
-            caps.matched.clone(),
             caps.from as i64,
             caps.to as i64,
             &caps.positional,
@@ -630,16 +630,15 @@ impl Interpreter {
             &caps.positional_subcaps,
             &caps.positional_quantified,
             &caps.positional_nil,
-            Some(text),
+            caps.target_or_new(text),
             &caps.named_quantified,
         )
     }
 
     /// [`Self::match_object_from_captures`] for a stored capture node.
-    fn match_object_from_cap_node(node: &CapNode, text: &str) -> Value {
+    fn match_object_from_cap_node(node: &CapNode, target: &MatchTarget) -> Value {
         let kids = node.kids();
         Value::make_match_object_full_q(
-            node.matched.clone(),
             node.from as i64,
             node.to as i64,
             &kids.positional,
@@ -648,7 +647,7 @@ impl Interpreter {
             &kids.positional_subcaps,
             &kids.positional_quantified,
             &kids.positional_nil,
-            Some(text),
+            target.clone(),
             &kids.named_quantified,
         )
     }
@@ -732,10 +731,11 @@ impl Interpreter {
             .collect();
         let saved_self = self.env.get("self").cloned();
         let mut result = Ok(());
+        let rtarget = MatchTarget::new(text);
         for (rule, caps) in maximal {
             let mut caps = (**caps).clone();
-            self.reduce_cap_node_for_rule(&mut caps, Some(text), None);
-            let match_obj = Self::match_object_from_cap_node(&caps, text);
+            self.reduce_cap_node_for_rule(&mut caps, Some(&rtarget), None);
+            let match_obj = Self::match_object_from_cap_node(&caps, &rtarget);
             let dispatch = Self::get_action_name(&match_obj).unwrap_or_else(|| rule.clone());
             if let Err(e) = self.invoke_grammar_actions(match_obj, actions, &dispatch) {
                 result = Err(e);

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -164,7 +164,6 @@ impl Interpreter {
                 .iter()
                 .map(|c| {
                     Value::make_match_object_full(
-                        c.matched.clone(),
                         c.from as i64,
                         c.to as i64,
                         &c.positional,
@@ -173,7 +172,7 @@ impl Interpreter {
                         &c.positional_subcaps,
                         &c.positional_quantified,
                         &c.positional_nil,
-                        Some(&text),
+                        c.target_or_new(&text),
                     )
                 })
                 .collect();
@@ -205,13 +204,12 @@ impl Interpreter {
             self.regex_match_with_captures(&pat, &text)
         };
         if let Some(mut captures) = captures {
-            let matched = captures.matched.clone();
             let from = captures.from as i64;
             let to = captures.to as i64;
+            let mtarget = captures.target_or_new(&text);
             // Reduce-time inline actions (children first) commit per-node `.made`.
-            self.reduce_regex_captures_made(&mut captures, Some(&text));
+            self.reduce_regex_captures_made(&mut captures, Some(&mtarget));
             let match_obj = Value::make_match_object_full(
-                matched,
                 from,
                 to,
                 &captures.positional,
@@ -220,7 +218,7 @@ impl Interpreter {
                 &captures.positional_subcaps,
                 &captures.positional_quantified,
                 &captures.positional_nil,
-                Some(&text),
+                mtarget,
             );
             // Set positional capture env vars ($0, $1, ...) from match object
             let list_v = match_obj.match_list();

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -92,7 +92,6 @@ impl Interpreter {
     fn subst_match_var(selected: &[RegexCaptures], text: &str, result_is_list: bool) -> Value {
         let to_match = |c: &RegexCaptures| {
             Value::make_match_object_full(
-                c.matched.clone(),
                 c.from as i64,
                 c.to as i64,
                 &c.positional,
@@ -101,7 +100,7 @@ impl Interpreter {
                 &c.positional_subcaps,
                 &c.positional_quantified,
                 &c.positional_nil,
-                Some(text),
+                c.target_or_new(text),
             )
         };
         if result_is_list {
@@ -424,11 +423,13 @@ impl Interpreter {
                     for captures in &selected {
                         let prefix: String = chars[last_end..captures.from].iter().collect();
                         result.push_str(&prefix);
+                        let matched_text: String =
+                            chars[captures.from..captures.to].iter().collect();
                         let repl = self.eval_subst_replacement_cased(
                             &replacement_val,
                             is_closure,
                             &replacement_str,
-                            &captures.matched,
+                            &matched_text,
                             Some(captures),
                             Some(&text),
                             transforms,
@@ -457,7 +458,6 @@ impl Interpreter {
                 } {
                     // Set $/ to the match object
                     let match_obj = Value::make_match_object_full(
-                        captures.matched.clone(),
                         captures.from as i64,
                         captures.to as i64,
                         &captures.positional,
@@ -466,16 +466,17 @@ impl Interpreter {
                         &captures.positional_subcaps,
                         &captures.positional_quantified,
                         &captures.positional_nil,
-                        Some(&text),
+                        captures.target_or_new(&text),
                     );
                     self.env.insert("/".to_string(), match_obj);
                     let prefix: String = chars[..captures.from].iter().collect();
                     let suffix: String = chars[captures.to..].iter().collect();
+                    let matched_text: String = chars[captures.from..captures.to].iter().collect();
                     let repl = self.eval_subst_replacement_cased(
                         &replacement_val,
                         is_closure,
                         &replacement_str,
-                        &captures.matched,
+                        &matched_text,
                         Some(&captures),
                         Some(&text),
                         transforms,
@@ -551,7 +552,6 @@ impl Interpreter {
                         result.push_str(&text[last_end..start]);
                         let matched_text = &text[start..end];
                         let caps = is_closure.then(|| RegexCaptures {
-                            matched: matched_text.to_string(),
                             from: char_indices[idx].0,
                             to: char_indices[idx].1,
                             ..Default::default()
@@ -575,7 +575,6 @@ impl Interpreter {
                     let end = bpos + pat.as_str().len();
                     let matched_text = &text[bpos..end];
                     let caps = is_closure.then(|| RegexCaptures {
-                        matched: matched_text.to_string(),
                         from: text[..bpos].chars().count(),
                         to: text[..end].chars().count(),
                         ..Default::default()

--- a/src/runtime/methods_string_subst_repl.rs
+++ b/src/runtime/methods_string_subst_repl.rs
@@ -58,7 +58,6 @@ impl Interpreter {
         }
         if let Some(captures) = captures {
             let match_obj = Value::make_match_object_full(
-                captures.matched.clone(),
                 captures.from as i64,
                 captures.to as i64,
                 &captures.positional,
@@ -67,7 +66,7 @@ impl Interpreter {
                 &captures.positional_subcaps,
                 &captures.positional_quantified,
                 &captures.positional_nil,
-                orig_text,
+                captures.target_or_new(orig_text.unwrap_or_default()),
             );
             self.env.insert("/".to_string(), match_obj.clone());
             self.env.insert("$_".to_string(), match_obj.clone());
@@ -82,14 +81,16 @@ impl Interpreter {
                 // last iteration's text (t/uri-unescape shape:
                 // `.subst(:g, /['%' (<.xdigit>**2)]+/, -> $/ { $0.flatmap... })`).
                 let value = if let Some(Some(qlist)) = captures.positional_quantified.get(i) {
+                    let t = captures.target_or_new(orig_text.unwrap_or_default());
                     Value::array(
                         qlist
                             .iter()
-                            .map(|(text, _, _, _)| Value::str(text.clone()))
+                            .map(|(a, b, _)| Value::str(t.span_str(*a, *b)))
                             .collect(),
                     )
-                } else if let Some(Some((capture, _, _))) = captures.positional_slots.get(i) {
-                    Value::str(capture.clone())
+                } else if let Some(Some((a, b))) = captures.positional_slots.get(i) {
+                    let t = captures.target_or_new(orig_text.unwrap_or_default());
+                    Value::str(t.span_str(*a, *b))
                 } else if let Some(capture) = captures.positional.get(i) {
                     Value::str(capture.clone())
                 } else {

--- a/src/runtime/methods_trans.rs
+++ b/src/runtime/methods_trans.rs
@@ -664,11 +664,11 @@ impl Interpreter {
                     .insert(idx.to_string(), Value::str_arc(cap.clone().into()));
             }
             Value::make_match_object_with_captures(
-                matched.to_string(),
                 0,
                 matched.len() as i64,
                 caps,
                 &std::collections::HashMap::new(),
+                crate::runtime::MatchTarget::new(matched),
             )
         } else {
             Value::str(matched.to_string())

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -208,6 +208,7 @@ mod iterator_protocol;
 pub(crate) mod json;
 mod lock_reentry;
 mod main_args;
+mod match_target;
 mod metamodel;
 mod methods;
 mod methods_aggregate_ctor;
@@ -369,6 +370,7 @@ pub(crate) mod value_iterator;
 /// Cooperative scheduler standing in for OS threads in the browser.
 #[cfg(target_arch = "wasm32")]
 pub(crate) mod wasm_sched;
+pub(crate) use self::match_target::MatchTarget;
 pub(crate) use self::output_sink::OutputSink;
 #[allow(unused_imports)]
 pub(crate) use self::output_sink::{OutputSinkReadGuard, OutputSinkWriteGuard};

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -254,11 +254,12 @@ impl Interpreter {
         // grammar's dup check does `%*PLAYED{$/.lc}++`). `$/[n]` still indexes the
         // positional captures on the Match object.
         let cursor = Value::make_match_object_with_captures(
-            matched_so_far.to_string(),
             caps.match_from as i64,
             (caps.match_from + matched_so_far.chars().count()) as i64,
             &caps.positional,
             &caps.named,
+            super::regex_helpers::current_match_target()
+                .unwrap_or_else(|| MatchTarget::new(matched_so_far)),
         );
         // `$¢` is the current match state at this point in the pattern — the same
         // object as `$/` here (`/ .{ $c = $¢ } /` must leave `$c` with a usable
@@ -377,8 +378,12 @@ impl Interpreter {
         mut actions: Value,
     ) -> HashMap<String, Value> {
         let mut out = HashMap::new();
+        // Mid-match synthesis: the accumulator carries no subject yet, so the
+        // subject comes from the live engine scope (empty-subject fallback is
+        // unreachable in practice — this only runs from inside a match).
+        let target =
+            super::regex_helpers::current_match_target().unwrap_or_else(|| MatchTarget::new(""));
         let full = Value::make_match_object_full_q(
-            caps.matched.clone(),
             caps.from as i64,
             caps.to as i64,
             &caps.positional,
@@ -387,7 +392,7 @@ impl Interpreter {
             &caps.positional_subcaps,
             &caps.positional_quantified,
             &caps.positional_nil,
-            None,
+            target,
             &caps.named_quantified,
         );
         let named_v = full.match_named();
@@ -507,8 +512,11 @@ impl Interpreter {
             _ => actions.clone(),
         };
         let kids = sub.kids();
+        // Mid-match synthesis — subject from the live engine scope (see
+        // `run_named_capture_actions`).
+        let target =
+            super::regex_helpers::current_match_target().unwrap_or_else(|| MatchTarget::new(""));
         let match_obj = Value::make_match_object_full_q(
-            sub.matched.clone(),
             sub.from as i64,
             sub.to as i64,
             &kids.positional,
@@ -517,7 +525,7 @@ impl Interpreter {
             &kids.positional_subcaps,
             &kids.positional_quantified,
             &kids.positional_nil,
-            None,
+            target,
             &kids.named_quantified,
         );
         let mut scratch = Interpreter {

--- a/src/runtime/regex/regex_eval_class.rs
+++ b/src/runtime/regex/regex_eval_class.rs
@@ -171,7 +171,9 @@ impl Interpreter {
             None => return Vec::new(),
         };
         let pkg = self.current_package();
-        let chars: Vec<char> = text.chars().collect();
+        let target = MatchTarget::new(text);
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
+        let chars = target.chars();
         let mut results = Vec::new();
         let mut pos = 0;
         while pos <= chars.len() {
@@ -179,21 +181,21 @@ impl Interpreter {
             if parsed.anchor_start {
                 if pos == 0
                     && let Some((end, mut caps)) =
-                        self.regex_match_end_from_caps_in_pkg(&parsed, &chars, 0, &pkg)
+                        self.regex_match_end_from_caps_in_pkg(&parsed, chars, 0, &pkg)
                 {
                     caps.from = caps.capture_start.unwrap_or(0);
                     caps.to = caps.capture_end.unwrap_or(end);
-                    caps.matched = chars[caps.from..caps.to].iter().collect();
+                    caps.target = Some(target.clone());
                     found = Some((0, end, caps));
                 }
             } else {
                 for start in pos..=chars.len() {
                     if let Some((end, mut caps)) =
-                        self.regex_match_end_from_caps_in_pkg(&parsed, &chars, start, &pkg)
+                        self.regex_match_end_from_caps_in_pkg(&parsed, chars, start, &pkg)
                     {
                         caps.from = caps.capture_start.unwrap_or(start);
                         caps.to = caps.capture_end.unwrap_or(end);
-                        caps.matched = chars[caps.from..caps.to].iter().collect();
+                        caps.target = Some(target.clone());
                         found = Some((start, end, caps));
                         break;
                     }

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -246,11 +246,11 @@ impl Interpreter {
         let ast_hint = self.env.get("made").cloned().unwrap_or(Value::NIL);
         let to_match_with_ast = |text: &str, ast: &Value| -> Value {
             let match_obj = Value::make_match_object_with_captures(
-                text.to_string(),
                 0,
                 text.chars().count() as i64,
                 &[],
                 &HashMap::new(),
+                MatchTarget::new(text),
             );
             match_obj
                 .match_with_attrs(vec![("ast", ast.clone())])
@@ -279,11 +279,11 @@ impl Interpreter {
         let mut pos_list: Vec<Value> = Vec::with_capacity(ctx.positional.len());
         for (i, val) in ctx.positional.iter().enumerate() {
             let pos_match = Value::make_match_object_with_captures(
-                val.clone(),
                 0,
                 val.chars().count() as i64,
                 &[],
                 &HashMap::new(),
+                MatchTarget::new(val),
             );
             self.env.insert(i.to_string(), pos_match.clone());
             pos_list.push(pos_match);
@@ -291,11 +291,11 @@ impl Interpreter {
         // Set up $/ as a match object for the matched-so-far text, carrying the
         // named/positional captures so `$/.hash`/`$/.values`/`$/<name>` all work.
         let match_obj = Value::make_match_object_with_captures(
-            ctx.matched_so_far.clone(),
             0,
             ctx.matched_so_far.chars().count() as i64,
             &[],
             &HashMap::new(),
+            MatchTarget::new(&ctx.matched_so_far),
         );
         let match_obj = {
             let mut updates = vec![("named", Value::hash(named_map))];
@@ -371,9 +371,9 @@ impl Interpreter {
     pub(in crate::runtime) fn reduce_regex_captures_made(
         &mut self,
         caps: &mut RegexCaptures,
-        orig: Option<&str>,
+        target: Option<&MatchTarget>,
     ) {
-        self.reduce_regex_captures_made_for_rule(caps, orig, None);
+        self.reduce_regex_captures_made_for_rule(caps, target, None);
     }
 
     /// [`Self::reduce_regex_captures_made`] with the name of the rule this node
@@ -387,7 +387,7 @@ impl Interpreter {
     pub(in crate::runtime) fn reduce_regex_captures_made_for_rule(
         &mut self,
         caps: &mut RegexCaptures,
-        orig: Option<&str>,
+        target: Option<&MatchTarget>,
         rule_name: Option<&str>,
     ) {
         // A fresh binding for THIS match, installed before the subtree reduces so
@@ -398,7 +398,7 @@ impl Interpreter {
             &mut caps.named_subcaps,
             &mut caps.positional_subcaps,
             &mut caps.positional_quantified,
-            orig,
+            target,
         );
         if caps.code_blocks.is_empty() {
             // Even with no code blocks of its own, a declaring match must record
@@ -412,7 +412,6 @@ impl Interpreter {
         // `reduce_run_code_blocks`), so a mid-rule `{ … $/ … }` sees the prefix —
         // only the child `.made` values read via `$<name>` come from here.
         let node_match = Value::make_match_object_full_q(
-            caps.matched.clone(),
             caps.from as i64,
             caps.to as i64,
             &caps.positional,
@@ -421,7 +420,7 @@ impl Interpreter {
             &caps.positional_subcaps,
             &caps.positional_quantified,
             &caps.positional_nil,
-            orig,
+            super::regex_helpers::target_or_empty(target),
             &caps.named_quantified,
         );
         let blocks = std::mem::take(&mut caps.code_blocks);
@@ -434,7 +433,7 @@ impl Interpreter {
     pub(in crate::runtime) fn reduce_cap_node_for_rule(
         &mut self,
         node: &mut CapNode,
-        orig: Option<&str>,
+        target: Option<&MatchTarget>,
         rule_name: Option<&str>,
     ) {
         let declared_keys = self.install_fresh_rule_dynvars(rule_name);
@@ -443,7 +442,7 @@ impl Interpreter {
                 &mut kids.named_subcaps,
                 &mut kids.positional_subcaps,
                 &mut kids.positional_quantified,
-                orig,
+                target,
             );
         }
         let has_blocks = node
@@ -460,13 +459,12 @@ impl Interpreter {
             return;
         }
         // Build this node's Match so `$<name>` can carry the children's asts.
-        let (matched, from, to) = (node.matched.clone(), node.from, node.to);
+        let (from, to) = (node.from, node.to);
         let kids = node
             .children
             .as_deref_mut()
             .expect("has_blocks implies kids");
         let node_match = Value::make_match_object_full_q(
-            matched,
             from as i64,
             to as i64,
             &kids.positional,
@@ -475,7 +473,7 @@ impl Interpreter {
             &kids.positional_subcaps,
             &kids.positional_quantified,
             &kids.positional_nil,
-            orig,
+            super::regex_helpers::target_or_empty(target),
             &kids.named_quantified,
         );
         let blocks = std::mem::take(&mut kids.code_blocks);
@@ -490,7 +488,7 @@ impl Interpreter {
         named_subcaps: &mut HashMap<String, Vec<Arc<CapNode>>>,
         positional_subcaps: &mut [Option<Arc<CapNode>>],
         positional_quantified: &mut [Option<Vec<QuantifiedCaptureEntry>>],
-        orig: Option<&str>,
+        target: Option<&MatchTarget>,
     ) {
         // The walk mutates a node only to take/run its code blocks (writing
         // `ast`) or to record per-rule dynvar bindings. A subtree with no code
@@ -512,7 +510,7 @@ impl Interpreter {
                 crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
                 let sc = Arc::make_mut(sc);
                 let child_rule = sc.action_name.clone().unwrap_or(child_rule.clone());
-                self.reduce_cap_node_for_rule(sc, orig, Some(&child_rule));
+                self.reduce_cap_node_for_rule(sc, target, Some(&child_rule));
             }
         }
         for sc in positional_subcaps.iter_mut().flatten() {
@@ -520,16 +518,16 @@ impl Interpreter {
                 continue;
             }
             crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
-            self.reduce_cap_node_for_rule(Arc::make_mut(sc), orig, None);
+            self.reduce_cap_node_for_rule(Arc::make_mut(sc), target, None);
         }
         for pq in positional_quantified.iter_mut().flatten() {
             for entry in pq.iter_mut() {
-                if let Some(sc) = entry.3.as_mut() {
+                if let Some(sc) = entry.2.as_mut() {
                     if skip_untouched && !Self::subtree_has_code_blocks(sc) {
                         continue;
                     }
                     crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
-                    self.reduce_cap_node_for_rule(Arc::make_mut(sc), orig, None);
+                    self.reduce_cap_node_for_rule(Arc::make_mut(sc), target, None);
                 }
             }
         }
@@ -618,7 +616,7 @@ impl Interpreter {
                 .iter()
                 .flatten()
                 .flatten()
-                .any(|e| e.3.as_deref().is_some_and(Self::subtree_has_code_blocks))
+                .any(|e| e.2.as_deref().is_some_and(Self::subtree_has_code_blocks))
     }
 
     /// The rule name a `named_subcaps` key stands for. A silent-action capture

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -609,12 +609,138 @@ fn strip_marks_class_item(item: &ClassItem) -> ClassItem {
     }
 }
 
+thread_local! {
+    /// The subject of the innermost live engine invocation (ADR-0016 P3).
+    /// Pushed by the public entry points around the engine walk; engine-side
+    /// Match synthesis (reduce-time `$*` actions, `<?{ … }>` `.made`
+    /// dispatch) reads the top, since capture accumulators carry no subject
+    /// until the entry point publishes them. A stack because subrule argument
+    /// evaluation can re-enter the public entry points mid-match.
+    static CURRENT_MATCH_TARGET: RefCell<Vec<MatchTarget>> = const { RefCell::new(Vec::new()) };
+}
+
+/// RAII scope for [`CURRENT_MATCH_TARGET`].
+pub(super) struct MatchTargetScope;
+
+impl MatchTargetScope {
+    pub(super) fn enter(target: MatchTarget) -> Self {
+        CURRENT_MATCH_TARGET.with(|s| s.borrow_mut().push(target));
+        MatchTargetScope
+    }
+}
+
+impl Drop for MatchTargetScope {
+    fn drop(&mut self) {
+        CURRENT_MATCH_TARGET.with(|s| {
+            s.borrow_mut().pop();
+        });
+    }
+}
+
+/// The innermost live engine subject, if any (see [`CURRENT_MATCH_TARGET`]).
+pub(super) fn current_match_target() -> Option<MatchTarget> {
+    CURRENT_MATCH_TARGET.with(|s| s.borrow().last().cloned())
+}
+
+/// An owned subject for a Match builder: the given one, else the live engine
+/// scope's, else an empty subject (unreachable in practice — callers always
+/// run either with an explicit target or inside a live match).
+pub(in crate::runtime) fn target_or_empty(target: Option<&MatchTarget>) -> MatchTarget {
+    target
+        .cloned()
+        .or_else(current_match_target)
+        .unwrap_or_else(|| MatchTarget::new(""))
+}
+
 /// Map a position from stripped char space back to original char space.
 pub(super) fn map_pos(pos: usize, pos_map: &[usize], orig_len: usize) -> usize {
     if pos < pos_map.len() {
         pos_map[pos]
     } else {
         orig_len
+    }
+}
+
+/// Remap every recorded span in a capture tree from a derived match space
+/// (mark-stripped `:m` / case-folded `:i`) back to original char space
+/// (ADR-0016 P3). Captured text derives from spans through the shared
+/// subject, so spans recorded while matching a derived subject must be
+/// translated before the captures are published — including sub-capture
+/// nodes, which the pre-P3 code left in derived space (their stored text
+/// papered over it).
+pub(super) fn remap_caps_spans(caps: &mut RegexCaptures, pos_map: &[usize], orig_len: usize) {
+    remap_caps_spans_offset(caps, pos_map, orig_len, 0);
+}
+
+/// [`remap_caps_spans`] with a base offset added after mapping — for the
+/// engine-internal `:m` branch, which strips a mid-subject SLICE and must
+/// land the spans back at the slice's absolute position. Does not touch
+/// `from`/`to`/`capture_start`/`capture_end` when `offset != 0` (the caller
+/// translates those itself; the accumulator's own span is not yet set there).
+pub(super) fn remap_caps_spans_offset(
+    caps: &mut RegexCaptures,
+    pos_map: &[usize],
+    orig_len: usize,
+    offset: usize,
+) {
+    let m = |p: usize| map_pos(p, pos_map, orig_len) + offset;
+    if offset == 0 {
+        caps.from = m(caps.from);
+        caps.to = m(caps.to);
+    }
+    for (a, b) in caps.positional_offsets.iter_mut() {
+        (*a, *b) = (m(*a), m(*b));
+    }
+    for slot in caps.positional_slots.iter_mut().flatten() {
+        slot.0 = m(slot.0);
+        slot.1 = m(slot.1);
+    }
+    for sc in caps.named_subcaps.values_mut().flatten() {
+        remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+    }
+    for sc in caps.positional_subcaps.iter_mut().flatten() {
+        remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+    }
+    for entry in caps.positional_quantified.iter_mut().flatten().flatten() {
+        entry.0 = m(entry.0);
+        entry.1 = m(entry.1);
+        if let Some(sc) = &mut entry.2 {
+            remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+        }
+    }
+}
+
+/// [`remap_caps_spans`] over a stored capture node, recursively (same offset
+/// semantics as [`remap_caps_spans_offset`], applied to every span).
+pub(super) fn remap_cap_node_spans(
+    node: &mut CapNode,
+    pos_map: &[usize],
+    orig_len: usize,
+    offset: usize,
+) {
+    let m = |p: usize| map_pos(p, pos_map, orig_len) + offset;
+    node.from = m(node.from);
+    node.to = m(node.to);
+    let Some(children) = node.children.as_deref_mut() else {
+        return;
+    };
+    for sc in children.named_subcaps.values_mut().flatten() {
+        remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+    }
+    for sc in children.positional_subcaps.iter_mut().flatten() {
+        remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+    }
+    for entry in children
+        .positional_quantified
+        .iter_mut()
+        .flatten()
+        .flatten()
+    {
+        entry.0 = m(entry.0);
+        entry.1 = m(entry.1);
+        if let Some(sc) = &mut entry.2 {
+            remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
+        }
     }
 }
 
@@ -860,6 +986,7 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
 
     // Collect entries per group
     let mut folded_positional = Vec::with_capacity(stride);
+    let mut folded_offsets = Vec::with_capacity(stride);
     let mut folded_subcaps = Vec::with_capacity(stride);
     let mut folded_quantified: Vec<Option<Vec<QuantifiedCaptureEntry>>> =
         Vec::with_capacity(stride);
@@ -868,7 +995,6 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
         let mut list: Vec<QuantifiedCaptureEntry> = Vec::with_capacity(iterations);
         for iter in 0..iterations {
             let idx = base_len + iter * stride + group;
-            let text = caps.positional[idx].clone();
             let subcap = if idx < caps.positional_subcaps.len() {
                 caps.positional_subcaps[idx].clone()
             } else {
@@ -877,14 +1003,16 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
             let (from, to) = if idx < caps.positional_offsets.len() {
                 caps.positional_offsets[idx]
             } else {
-                (0, text.chars().count())
+                (0, caps.positional[idx].chars().count())
             };
-            list.push((text, from, to, subcap));
+            list.push((from, to, subcap));
         }
         // Use the last iteration's values as the "representative" for backref purposes
+        let last_idx = base_len + (iterations - 1) * stride + group;
+        folded_positional.push(caps.positional[last_idx].clone());
         let last = list.last().unwrap();
-        folded_positional.push(last.0.clone());
-        folded_subcaps.push(last.3.clone());
+        folded_offsets.push((last.0, last.1));
+        folded_subcaps.push(last.2.clone());
         folded_quantified.push(Some(list));
     }
 
@@ -899,10 +1027,13 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
     }
     caps.positional_quantified.truncate(base_len);
     caps.positional_quantified.extend(folded_quantified);
-    // Also truncate offsets if present
-    if caps.positional_offsets.len() > base_len {
-        caps.positional_offsets.truncate(base_len);
+    // Keep the offsets axis aligned: the representative slot carries the last
+    // iteration's span.
+    caps.positional_offsets.truncate(base_len);
+    while caps.positional_offsets.len() < base_len {
+        caps.positional_offsets.push((0, 0));
     }
+    caps.positional_offsets.extend(folded_offsets);
 }
 
 /// Reserve `stride` index-stable Nil slots for an unmatched optional capture

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -88,6 +88,9 @@ impl Interpreter {
                         .extend(inner_caps.named_quantified.drain());
                     new_caps.positional.append(&mut inner_caps.positional);
                     new_caps
+                        .positional_offsets
+                        .append(&mut inner_caps.positional_offsets);
+                    new_caps
                         .positional_subcaps
                         .append(&mut inner_caps.positional_subcaps);
                     new_caps
@@ -135,6 +138,9 @@ impl Interpreter {
                         .named_quantified
                         .extend(inner_caps.named_quantified.drain());
                     new_caps.positional.append(&mut inner_caps.positional);
+                    new_caps
+                        .positional_offsets
+                        .append(&mut inner_caps.positional_offsets);
                     new_caps
                         .positional_subcaps
                         .append(&mut inner_caps.positional_subcaps);
@@ -205,6 +211,9 @@ impl Interpreter {
                     new_caps.positional.push(v);
                 }
                 new_caps
+                    .positional_offsets
+                    .append(&mut inner_caps.positional_offsets);
+                new_caps
                     .positional_subcaps
                     .append(&mut inner_caps.positional_subcaps);
                 new_caps
@@ -274,10 +283,10 @@ impl Interpreter {
                 new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                 // Store inner captures as subcaptures of this group
                 let mut subcap = inner_caps;
-                subcap.matched = captured.clone();
                 subcap.from = pos;
                 subcap.to = end;
                 new_caps.positional.push(captured);
+                new_caps.positional_offsets.push((pos, end));
                 new_caps
                     .positional_subcaps
                     .push(Some(std::sync::Arc::new(subcap.into_cap_node())));
@@ -306,6 +315,9 @@ impl Interpreter {
                     for v in inner_caps.positional.drain(..) {
                         new_caps.positional.push(v);
                     }
+                    new_caps
+                        .positional_offsets
+                        .append(&mut inner_caps.positional_offsets);
                     new_caps
                         .positional_subcaps
                         .append(&mut inner_caps.positional_subcaps);
@@ -698,7 +710,6 @@ impl Interpreter {
                 let ce = inner_caps.capture_end.unwrap_or(end).clamp(cs, end);
                 let captured: String = chars[cs..ce].iter().collect();
                 let mut subcap = inner_caps;
-                subcap.matched = captured.clone();
                 subcap.from = cs;
                 subcap.to = ce;
                 // sym is already set on subcap from raw_out collection loop.
@@ -782,9 +793,7 @@ impl Interpreter {
                 // lost the rule's own action and over-exposed children in `.hash`.
                 let cs = inner_caps.capture_start.unwrap_or(pos).clamp(pos, end);
                 let ce = inner_caps.capture_end.unwrap_or(end).clamp(cs, end);
-                let captured: String = chars[cs..ce].iter().collect();
                 let mut subcap = inner_caps;
-                subcap.matched = captured;
                 subcap.from = cs;
                 subcap.to = ce;
                 if subcap.sym.is_none() && sym_key.is_some() {

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -69,6 +69,9 @@ impl Interpreter {
                         }
                         new_caps.positional.extend(inner_caps.positional);
                         new_caps
+                            .positional_offsets
+                            .append(&mut inner_caps.positional_offsets);
+                        new_caps
                             .positional_subcaps
                             .append(&mut inner_caps.positional_subcaps);
                         new_caps
@@ -131,6 +134,9 @@ impl Interpreter {
                         }
                         new_caps.positional.append(&mut inner_caps.positional);
                         new_caps
+                            .positional_offsets
+                            .append(&mut inner_caps.positional_offsets);
+                        new_caps
                             .positional_subcaps
                             .append(&mut inner_caps.positional_subcaps);
                         new_caps
@@ -177,6 +183,9 @@ impl Interpreter {
                             new_caps.named.entry(k).or_default().extend(v);
                         }
                         new_caps.positional.append(&mut inner_caps.positional);
+                        new_caps
+                            .positional_offsets
+                            .append(&mut inner_caps.positional_offsets);
                         new_caps
                             .positional_subcaps
                             .append(&mut inner_caps.positional_subcaps);
@@ -261,10 +270,10 @@ impl Interpreter {
                     // are intentionally NOT merged into the parent `named` map.
                     // Store inner captures as subcaptures of this group
                     let mut subcap = inner_caps.clone();
-                    subcap.matched = captured.clone();
                     subcap.from = pos;
                     subcap.to = end;
                     new_caps.positional.push(captured);
+                    new_caps.positional_offsets.push((pos, end));
                     new_caps
                         .positional_subcaps
                         .push(Some(std::sync::Arc::new(subcap.into_cap_node())));
@@ -383,6 +392,9 @@ impl Interpreter {
                             new_caps.positional.push(v.clone());
                         }
                         new_caps
+                            .positional_offsets
+                            .extend(inner_caps.positional_offsets.iter().copied());
+                        new_caps
                             .positional_subcaps
                             .extend(inner_caps.positional_subcaps.clone());
                         new_caps
@@ -415,23 +427,27 @@ impl Interpreter {
                 return Some((pos, new_caps));
             }
             RegexAtom::Backref(idx) => {
-                let ref_text =
+                // A quantified slot's reference text is the concatenation of
+                // every iteration's span; a plain slot keeps its stored text.
+                let ref_chars: Option<Vec<char>> =
                     if let Some(Some(qlist)) = current_caps.positional_quantified.get(*idx) {
-                        let mut s = String::new();
-                        for (text, _, _, _) in qlist {
-                            s.push_str(text);
+                        let mut v = Vec::new();
+                        for (a, b, _) in qlist {
+                            let (a, b) = (*a.min(&chars.len()), *b.min(&chars.len()));
+                            v.extend_from_slice(&chars[a..b.max(a)]);
                         }
-                        Some(s)
+                        Some(v)
                     } else {
-                        current_caps.positional.get(*idx).cloned()
+                        current_caps
+                            .positional
+                            .get(*idx)
+                            .map(|t| t.chars().collect())
                     };
-                if let Some(ref_text) = ref_text {
-                    let ref_chars: Vec<char> = ref_text.chars().collect();
-                    if pos + ref_chars.len() <= chars.len()
-                        && chars[pos..pos + ref_chars.len()] == ref_chars[..]
-                    {
-                        return Some((pos + ref_chars.len(), RegexCaptures::default()));
-                    }
+                if let Some(ref_chars) = ref_chars
+                    && pos + ref_chars.len() <= chars.len()
+                    && chars[pos..pos + ref_chars.len()] == ref_chars[..]
+                {
+                    return Some((pos + ref_chars.len(), RegexCaptures::default()));
                 }
                 return None;
             }
@@ -653,7 +669,6 @@ impl Interpreter {
                     .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                 if let Some(capture_name) = capture_name {
                     let subcap = CapNode {
-                        matched: captured.clone(),
                         from: pos,
                         to: end,
                         ..Default::default()
@@ -678,7 +693,6 @@ impl Interpreter {
                             .capture_alias_map
                             .insert(capture_name.to_string(), spec.lookup_name.clone());
                         let subcap2 = CapNode {
-                            matched: captured.clone(),
                             from: pos,
                             to: end,
                             ..Default::default()
@@ -726,7 +740,6 @@ impl Interpreter {
                     .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                 if let Some(capture_name) = capture_name {
                     let subcap = CapNode {
-                        matched: captured.clone(),
                         from: pos,
                         to: end,
                         ..Default::default()

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -167,6 +167,10 @@ impl Interpreter {
                 if let Some(ce) = caps.capture_end.as_mut() {
                     *ce = map_pos(*ce, &pos_map, orig_len) + start;
                 }
+                // Captured spans were recorded in the stripped slice's space;
+                // text derives from spans (ADR-0016 P3), so translate the whole
+                // capture tree back to subject space.
+                super::regex_helpers::remap_caps_spans_offset(caps, &pos_map, orig_len, start);
             }
             return results;
         }
@@ -294,12 +298,11 @@ impl Interpreter {
                 None
             };
             let sub = if let Some(mut gs) = group_subcap.take() {
-                // Keep the group's nested captures, but pin the span/text to
-                // the aliased group's extent.
+                // Keep the group's nested captures, but pin the span to the
+                // aliased group's extent.
                 let gsm = std::sync::Arc::make_mut(&mut gs);
                 gsm.from = from;
                 gsm.to = to;
-                gsm.matched = captured.clone();
                 gs
             } else if let Some(sc) = subrule_subcap {
                 sc
@@ -307,7 +310,6 @@ impl Interpreter {
                 std::sync::Arc::new(CapNode {
                     from,
                     to,
-                    matched: captured.clone(),
                     ..Default::default()
                 })
             };
@@ -702,7 +704,6 @@ impl Interpreter {
                 if !capture_name.is_empty() {
                     let captured: String = ctx.chars[current..end].iter().collect();
                     let mut subcap = inner_caps;
-                    subcap.matched = captured.clone();
                     subcap.from = current;
                     subcap.to = end;
                     let subcap = std::sync::Arc::new(subcap.into_cap_node());

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -30,10 +30,12 @@ impl Interpreter {
     ) -> Option<RegexCaptures> {
         let parsed = self.parse_regex(pattern)?;
         let pkg = self.current_package();
-        let orig_chars: Vec<char> = text.chars().collect();
+        let target = MatchTarget::new(text);
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
+        let orig_chars = target.chars();
 
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(&orig_chars);
+            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
             let mut matches =
@@ -51,15 +53,14 @@ impl Interpreter {
             let (end, mut caps) = matches
                 .into_iter()
                 .find(|(end, _)| *end == stripped_chars.len())?;
-            let from = map_pos(caps.capture_start.unwrap_or(0), &pos_map, orig_len);
-            let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
-            caps.from = from;
-            caps.to = to;
-            caps.matched = orig_chars[from..to].iter().collect();
+            caps.from = caps.capture_start.unwrap_or(0);
+            caps.to = caps.capture_end.unwrap_or(end);
+            super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+            caps.target = Some(target);
             return Some(caps);
         }
 
-        let mut matches = self.regex_match_ends_from_caps_in_pkg(&parsed, &orig_chars, 0, &pkg);
+        let mut matches = self.regex_match_ends_from_caps_in_pkg(&parsed, orig_chars, 0, &pkg);
         if matches.is_empty() {
             return None;
         }
@@ -75,7 +76,7 @@ impl Interpreter {
                 let (end, mut caps) = matches.swap_remove(0);
                 caps.from = caps.capture_start.unwrap_or(0);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.matched = orig_chars[caps.from..caps.to].iter().collect();
+                caps.target = Some(target);
                 *partial = Some(caps);
             }
             return None;
@@ -83,7 +84,7 @@ impl Interpreter {
         let (end, mut caps) = matches.swap_remove(full_idx);
         caps.from = caps.capture_start.unwrap_or(0);
         caps.to = caps.capture_end.unwrap_or(end);
-        caps.matched = orig_chars[caps.from..caps.to].iter().collect();
+        caps.target = Some(target);
         Some(caps)
     }
 
@@ -97,7 +98,9 @@ impl Interpreter {
     ) -> Option<RegexCaptures> {
         let parsed = self.parse_regex(pattern)?;
         let pkg = self.current_package();
-        let orig_chars: Vec<char> = text.chars().collect();
+        let target = MatchTarget::new(text);
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
+        let orig_chars = target.chars();
         if pos > orig_chars.len() {
             return None;
         }
@@ -105,7 +108,7 @@ impl Interpreter {
             return None;
         }
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(&orig_chars);
+            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
             // Find the stripped position corresponding to `pos`
@@ -124,23 +127,18 @@ impl Interpreter {
                     &pkg,
                 )
                 .map(|(end, mut caps)| {
-                    let from = map_pos(
-                        caps.capture_start.unwrap_or(stripped_pos),
-                        &pos_map,
-                        orig_len,
-                    );
-                    let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
-                    caps.from = from;
-                    caps.to = to;
-                    caps.matched = orig_chars[from..to].iter().collect();
+                    caps.from = caps.capture_start.unwrap_or(stripped_pos);
+                    caps.to = caps.capture_end.unwrap_or(end);
+                    super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                    caps.target = Some(target.clone());
                     caps
                 });
         }
-        self.regex_match_end_from_caps_in_pkg(&parsed, &orig_chars, pos, &pkg)
+        self.regex_match_end_from_caps_in_pkg(&parsed, orig_chars, pos, &pkg)
             .map(|(end, mut caps)| {
                 caps.from = caps.capture_start.unwrap_or(pos);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.matched = orig_chars[caps.from..caps.to].iter().collect();
+                caps.target = Some(target.clone());
                 caps
             })
     }
@@ -157,7 +155,9 @@ impl Interpreter {
     ) -> Option<RegexCaptures> {
         let parsed = self.parse_regex(pattern)?;
         let pkg = self.current_package();
-        let orig_chars: Vec<char> = text.chars().collect();
+        let target = MatchTarget::new(text);
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
+        let orig_chars = target.chars();
         if from_pos > orig_chars.len() {
             return None;
         }
@@ -165,7 +165,7 @@ impl Interpreter {
             return None;
         }
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(&orig_chars);
+            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
             let stripped_from = pos_map
@@ -184,11 +184,10 @@ impl Interpreter {
                     start,
                     &pkg,
                 ) {
-                    let from = map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len);
-                    let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
-                    caps.from = from;
-                    caps.to = to;
-                    caps.matched = orig_chars[from..to].iter().collect();
+                    caps.from = caps.capture_start.unwrap_or(start);
+                    caps.to = caps.capture_end.unwrap_or(end);
+                    super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                    caps.target = Some(target.clone());
                     return Some(caps);
                 }
             }
@@ -197,11 +196,11 @@ impl Interpreter {
         let start_pos = if parsed.anchor_start { 0 } else { from_pos };
         for start in start_pos..=orig_chars.len() {
             if let Some((end, mut caps)) =
-                self.regex_match_end_from_caps_in_pkg(&parsed, &orig_chars, start, &pkg)
+                self.regex_match_end_from_caps_in_pkg(&parsed, orig_chars, start, &pkg)
             {
                 caps.from = caps.capture_start.unwrap_or(start);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.matched = orig_chars[caps.from..caps.to].iter().collect();
+                caps.target = Some(target.clone());
                 return Some(caps);
             }
         }
@@ -243,10 +242,12 @@ impl Interpreter {
             return Vec::new();
         };
         let pkg = self.current_package();
-        let orig_chars: Vec<char> = text.chars().collect();
+        let target = MatchTarget::new(text);
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
+        let orig_chars = target.chars();
 
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(&orig_chars);
+            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
             let mut out = Vec::new();
@@ -264,11 +265,10 @@ impl Interpreter {
                     &pkg,
                 );
                 for (end, mut caps) in ends {
-                    let from = map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len);
-                    let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
-                    caps.from = from;
-                    caps.to = to;
-                    caps.matched = orig_chars[from..to].iter().collect();
+                    caps.from = caps.capture_start.unwrap_or(start);
+                    caps.to = caps.capture_end.unwrap_or(end);
+                    super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                    caps.target = Some(target.clone());
                     out.push(caps);
                     if canonical_only {
                         break;
@@ -287,11 +287,11 @@ impl Interpreter {
             starts.extend(0..=orig_chars.len());
         }
         for start in starts {
-            let ends = self.regex_match_ends_from_caps_in_pkg(&parsed, &orig_chars, start, &pkg);
+            let ends = self.regex_match_ends_from_caps_in_pkg(&parsed, orig_chars, start, &pkg);
             for (end, mut caps) in ends {
                 caps.from = caps.capture_start.unwrap_or(start);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.matched = orig_chars[caps.from..caps.to].iter().collect();
+                caps.target = Some(target.clone());
                 out.push(caps);
                 if canonical_only {
                     break;

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::regex_casefold::{casefold_pattern, casefold_text, needs_casefold_expansion};
-use super::regex_helpers::{map_pos, strip_marks_pattern, strip_marks_text};
+use super::regex_helpers::{strip_marks_pattern, strip_marks_text};
 
 impl Interpreter {
     fn parse_regex_declarative_prefix(pattern: &str) -> (Vec<(String, String)>, String) {
@@ -136,23 +136,26 @@ impl Interpreter {
     ) -> Option<RegexCaptures> {
         let parsed = self.parse_regex(pattern)?;
         let pkg = self.current_package();
-        let orig_chars: Vec<char> = text.chars().collect();
+        let target = MatchTarget::new(text);
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
+        let orig_chars = target.chars();
 
         // When :m (ignoremark) is set, strip combining marks from both text and
         // pattern literals, match on stripped forms, then map positions back.
+        // Every recorded span (including sub-captures) is remapped from the
+        // stripped space so captured text derives from the original subject.
         if parsed.ignore_mark {
-            let (stripped_chars, pos_map) = strip_marks_text(&orig_chars);
+            let (stripped_chars, pos_map) = strip_marks_text(orig_chars);
             let stripped_parsed = strip_marks_pattern(&parsed);
             let orig_len = orig_chars.len();
             if stripped_parsed.anchor_start {
                 return self
                     .regex_match_end_from_caps_in_pkg(&stripped_parsed, &stripped_chars, 0, &pkg)
                     .map(|(end, mut caps)| {
-                        let from = map_pos(caps.capture_start.unwrap_or(0), &pos_map, orig_len);
-                        let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
-                        caps.from = from;
-                        caps.to = to;
-                        caps.matched = orig_chars[from..to].iter().collect();
+                        caps.from = caps.capture_start.unwrap_or(0);
+                        caps.to = caps.capture_end.unwrap_or(end);
+                        super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                        caps.target = Some(target.clone());
                         caps
                     });
             }
@@ -163,11 +166,10 @@ impl Interpreter {
                     start,
                     &pkg,
                 ) {
-                    let from = map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len);
-                    let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
-                    caps.from = from;
-                    caps.to = to;
-                    caps.matched = orig_chars[from..to].iter().collect();
+                    caps.from = caps.capture_start.unwrap_or(start);
+                    caps.to = caps.capture_end.unwrap_or(end);
+                    super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                    caps.target = Some(target.clone());
                     return Some(caps);
                 }
             }
@@ -183,8 +185,8 @@ impl Interpreter {
         // in folded space that correspond to the start of an original character's
         // fold expansion. This prevents false matches in the middle of a fold
         // (e.g., matching 't' from the expansion of 'ﬆ' -> 'st').
-        if parsed.ignore_case && needs_casefold_expansion(&orig_chars, &parsed) {
-            let (folded_chars, pos_map) = casefold_text(&orig_chars);
+        if parsed.ignore_case && needs_casefold_expansion(orig_chars, &parsed) {
+            let (folded_chars, pos_map) = casefold_text(orig_chars);
             let folded_parsed = casefold_pattern(&parsed);
             let orig_len = orig_chars.len();
 
@@ -202,11 +204,10 @@ impl Interpreter {
                         if !is_fold_boundary(end_pos) {
                             return None;
                         }
-                        let from = map_pos(caps.capture_start.unwrap_or(0), &pos_map, orig_len);
-                        let to = map_pos(end_pos, &pos_map, orig_len);
-                        caps.from = from;
-                        caps.to = to;
-                        caps.matched = orig_chars[from..to].iter().collect();
+                        caps.from = caps.capture_start.unwrap_or(0);
+                        caps.to = end_pos;
+                        super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                        caps.target = Some(target.clone());
                         Some(caps)
                     });
             }
@@ -226,11 +227,10 @@ impl Interpreter {
                     if !is_fold_boundary(end_pos) {
                         continue;
                     }
-                    let from = map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len);
-                    let to = map_pos(end_pos, &pos_map, orig_len);
-                    caps.from = from;
-                    caps.to = to;
-                    caps.matched = orig_chars[from..to].iter().collect();
+                    caps.from = caps.capture_start.unwrap_or(start);
+                    caps.to = end_pos;
+                    super::regex_helpers::remap_caps_spans(&mut caps, &pos_map, orig_len);
+                    caps.target = Some(target.clone());
                     return Some(caps);
                 }
             }
@@ -240,21 +240,21 @@ impl Interpreter {
         let chars = orig_chars;
         if parsed.anchor_start {
             return self
-                .regex_match_end_from_caps_in_pkg(&parsed, &chars, 0, &pkg)
+                .regex_match_end_from_caps_in_pkg(&parsed, chars, 0, &pkg)
                 .map(|(end, mut caps)| {
                     caps.from = caps.capture_start.unwrap_or(0);
                     caps.to = caps.capture_end.unwrap_or(end);
-                    caps.matched = chars[caps.from..caps.to].iter().collect();
+                    caps.target = Some(target.clone());
                     caps
                 });
         }
         for start in 0..=chars.len() {
             if let Some((end, mut caps)) =
-                self.regex_match_end_from_caps_in_pkg(&parsed, &chars, start, &pkg)
+                self.regex_match_end_from_caps_in_pkg(&parsed, chars, start, &pkg)
             {
                 caps.from = caps.capture_start.unwrap_or(start);
                 caps.to = caps.capture_end.unwrap_or(end);
-                caps.matched = chars[caps.from..caps.to].iter().collect();
+                caps.target = Some(target.clone());
                 return Some(caps);
             }
         }
@@ -323,10 +323,11 @@ impl Interpreter {
                         continue;
                     }
                     if !spec.silent {
+                        let whole = caps.matched_text();
                         caps.named
                             .entry(spec.lookup_name.clone())
                             .or_default()
-                            .push(caps.matched.clone());
+                            .push(whole);
                     }
                     // LTM: prefer longer declarative prefix match;
                     // if equal, prefer longer overall match

--- a/src/runtime/regex/regex_match_sep.rs
+++ b/src/runtime/regex/regex_match_sep.rs
@@ -409,15 +409,16 @@ impl Interpreter {
                 if let Some(text) = ac.positional.get(g) {
                     let (from, to) = ac.positional_offsets.get(g).copied().unwrap_or((0, 0));
                     let sub = ac.positional_subcaps.get(g).cloned().flatten();
-                    list.push((text.clone(), from, to, sub.clone()));
+                    list.push((from, to, sub.clone()));
                     last_text = text.clone();
                     last_sub = sub;
                 }
             }
+            let last_span = list.last().map(|(a, b, _)| (*a, *b)).unwrap_or((0, 0));
             caps.positional.push(last_text);
             caps.positional_subcaps.push(last_sub);
             caps.positional_quantified.push(Some(list));
-            caps.positional_offsets.push((0, 0));
+            caps.positional_offsets.push(last_span);
         }
         let mut all_sep: Vec<&RegexCaptures> = sep_caps.iter().collect();
         if let Some(ts) = trailing_sep {
@@ -431,15 +432,16 @@ impl Interpreter {
                 if let Some(text) = sc.positional.get(g) {
                     let (from, to) = sc.positional_offsets.get(g).copied().unwrap_or((0, 0));
                     let sub = sc.positional_subcaps.get(g).cloned().flatten();
-                    list.push((text.clone(), from, to, sub.clone()));
+                    list.push((from, to, sub.clone()));
                     last_text = text.clone();
                     last_sub = sub;
                 }
             }
+            let last_span = list.last().map(|(a, b, _)| (*a, *b)).unwrap_or((0, 0));
             caps.positional.push(last_text);
             caps.positional_subcaps.push(last_sub);
             caps.positional_quantified.push(Some(list));
-            caps.positional_offsets.push((0, 0));
+            caps.positional_offsets.push(last_span);
         }
         // Named captures: merge every iteration's named captures (as arrays).
         for src in atom_caps.iter().chain(all_sep.iter().copied()) {

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -97,16 +97,16 @@ impl Interpreter {
         };
         // Matched against the whole subject from `pos` (ADR-0016 P1), so the
         // captures this publishes are already in absolute coordinates.
-        let all_chars: Vec<char> = text.chars().collect();
-        let matches = self.regex_match_ends_from_caps_in_pkg(&parsed, &all_chars, pos, pkg);
+        let target = MatchTarget::new(text);
+        let _target_scope = super::regex_helpers::MatchTargetScope::enter(target.clone());
+        let matches = self.regex_match_ends_from_caps_in_pkg(&parsed, target.chars(), pos, pkg);
         // Matches come HIGHEST FIRST: the first entry is the token's best
         // (ratcheted) match, which is what a cursor method call returns.
-        let Some((end, caps)) = matches.into_iter().next() else {
+        let Some((end, mut caps)) = matches.into_iter().next() else {
             return Ok(Value::NIL);
         };
-        let matched: String = all_chars[pos..end].iter().collect();
+        caps.target = Some(target.clone());
         let m = Value::make_match_object_full_q(
-            matched,
             pos as i64,
             end as i64,
             &caps.positional,
@@ -115,7 +115,7 @@ impl Interpreter {
             &caps.positional_subcaps,
             &caps.positional_quantified,
             &caps.positional_nil,
-            Some(text),
+            target,
             &caps.named_quantified,
         );
         LAST_TOKEN_METHOD_MATCH.with(|slot| {
@@ -194,9 +194,7 @@ impl Interpreter {
         if !matches!(meth.view(), ValueView::Sub(_)) {
             return None;
         }
-        let text: String = chars.iter().collect();
         let cursor = Value::make_match_object_full_q(
-            String::new(),
             pos as i64,
             pos as i64,
             &[],
@@ -205,7 +203,7 @@ impl Interpreter {
             &[],
             &[],
             &[],
-            Some(&text),
+            MatchTarget::from_chars(chars),
             &HashSet::new(),
         );
         let mut call_args = vec![cursor];
@@ -249,7 +247,6 @@ impl Interpreter {
                 t.caps
             }
             _ => RegexCaptures {
-                matched: chars[pos..to_abs].iter().collect(),
                 from: pos,
                 to: to_abs,
                 ..RegexCaptures::default()

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -31,14 +31,16 @@ pub(crate) struct CodeBlockContext {
     pub(crate) positional: Vec<String>,
 }
 
-/// A single entry in a quantified capture list: (matched_text, from, to, subcaptures).
+/// A single entry in a quantified capture list: (from, to, subcaptures).
+/// The matched text derives from the span through the shared subject
+/// (ADR-0016 P3).
 ///
 /// The nested sub-captures are held behind an `Arc` so that cloning a parent
 /// `RegexCaptures` during backtracking is a refcount bump rather than a deep
 /// copy of the whole sub-match tree. A completed sub-match is effectively
 /// immutable once stored; the rare post-store tweak (e.g. setting `action_name`)
 /// goes through `Arc::make_mut`, which is free while the entry is still unshared.
-pub(crate) type QuantifiedCaptureEntry = (String, usize, usize, Option<Arc<CapNode>>);
+pub(crate) type QuantifiedCaptureEntry = (usize, usize, Option<Arc<CapNode>>);
 
 /// Prefix marking a `named_subcaps` entry as a *silent action capture*: the
 /// match of a silent subrule (`<.foo>`) that is hidden from `.hash` but whose
@@ -60,7 +62,6 @@ pub(crate) const SILENT_ACTION_MARKER_PREFIX: &str = "\u{1}silent\u{1}";
 /// still goes through `Arc::make_mut`, same as before the split.
 #[derive(Clone, Default)]
 pub(crate) struct CapNode {
-    pub(crate) matched: String,
     pub(crate) from: usize,
     pub(crate) to: usize,
     /// The winning :sym<> variant name, if this match was from a protoregex.
@@ -110,6 +111,29 @@ impl CapNode {
 }
 
 impl RegexCaptures {
+    /// The subject this capture tree was published with (set by the engine
+    /// entry point), else one built fresh from `text` (ADR-0016 P3).
+    pub(crate) fn target_or_new(&self, text: &str) -> crate::runtime::MatchTarget {
+        self.target
+            .clone()
+            .unwrap_or_else(|| crate::runtime::MatchTarget::new(text))
+    }
+
+    /// The whole-match text, derived from the recorded span through the
+    /// published subject (ADR-0016 P3). Empty when no subject was published —
+    /// callers on the engine-entry consumer paths always have one.
+    pub(crate) fn matched_text(&self) -> String {
+        self.span_text(self.from, self.to)
+    }
+
+    /// The text of an arbitrary recorded span through the published subject.
+    pub(crate) fn span_text(&self, from: usize, to: usize) -> String {
+        self.target
+            .as_ref()
+            .map(|t| t.span_str(from, to))
+            .unwrap_or_default()
+    }
+
     /// Convert this accumulator into the immutable stored node it describes
     /// (ADR-0016 P2). Consumes the accumulator; drops the accumulator-only
     /// fields nothing reads through a stored node (`hash_captures`,
@@ -141,7 +165,6 @@ impl RegexCaptures {
             })
         });
         CapNode {
-            matched: self.matched,
             from: self.from,
             to: self.to,
             sym: self.sym,
@@ -175,10 +198,9 @@ pub(crate) struct RegexCaptures {
     /// captures (which never touch this vec) stay aligned. The Match builder reads
     /// it via `.get(i)` — a missing/`false` entry renders normally.
     pub(crate) positional_nil: Vec<bool>,
-    /// Unnamed capture slots by capture index (for $0, $1, ...), where `None`
-    /// represents an unmatched capture.
-    pub(crate) positional_slots: Vec<Option<(String, usize, usize)>>,
-    pub(crate) matched: String,
+    /// Unnamed capture slots by capture index (for $0, $1, ...) as recorded
+    /// spans, where `None` represents an unmatched capture.
+    pub(crate) positional_slots: Vec<Option<(usize, usize)>>,
     pub(crate) from: usize,
     pub(crate) to: usize,
     pub(crate) capture_start: Option<usize>,
@@ -211,6 +233,11 @@ pub(crate) struct RegexCaptures {
     /// `$<sub>».made` resolve in a parent inline action and post-parse. `None`
     /// when the rule ran no `make`.
     pub(crate) ast: Option<Value>,
+    /// The shared subject this match ran against (ADR-0016 P3). Set once by
+    /// the engine entry point on the returned top-level accumulator — the
+    /// engine itself never touches it. Consumers derive captured text from
+    /// recorded spans through it instead of a stored `matched` string.
+    pub(crate) target: Option<crate::runtime::MatchTarget>,
 }
 
 #[cfg(test)]
@@ -219,12 +246,14 @@ mod cap_node_tests {
 
     /// ADR-0016 P2: a stored leaf capture node must stay a handful of words —
     /// that is the entire point of the `CapNode`/`RegexCaptures` split (a
-    /// stored leaf used to cost the full ~600-byte accumulator). If a change
-    /// pushes `CapNode` past this, move the new field into `CapChildren`.
+    /// stored leaf used to cost the full ~600-byte accumulator). P3 removed
+    /// the stored `matched` text (spans + the shared `MatchTarget` derive it),
+    /// shrinking the bound further. If a change pushes `CapNode` past this,
+    /// move the new field into `CapChildren`.
     #[test]
     fn cap_node_size_guard() {
         assert!(
-            std::mem::size_of::<CapNode>() <= 112,
+            std::mem::size_of::<CapNode>() <= 88,
             "CapNode grew to {} bytes",
             std::mem::size_of::<CapNode>()
         );
@@ -234,7 +263,6 @@ mod cap_node_tests {
     #[test]
     fn into_cap_node_leaf_has_no_children() {
         let mut caps = RegexCaptures::default();
-        caps.matched = "x".to_string();
         caps.from = 3;
         caps.to = 4;
         let node = caps.into_cap_node();

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -29,7 +29,7 @@ impl Interpreter {
         };
 
         let mut attrs = HashMap::new();
-        attrs.insert("str".to_string(), Value::str(captures.matched.clone()));
+        attrs.insert("str".to_string(), Value::str(captures.matched_text()));
         attrs.insert("from".to_string(), Value::int(captures.from as i64));
         attrs.insert("to".to_string(), Value::int(captures.to as i64));
         let positional: Vec<Value> = if !captures.positional_slots.is_empty() {
@@ -37,7 +37,9 @@ impl Interpreter {
                 .positional_slots
                 .iter()
                 .map(|slot| match slot {
-                    Some((s, from, to)) => make_capture_match(s, *from, *to),
+                    Some((from, to)) => {
+                        make_capture_match(&captures.span_text(*from, *to), *from, *to)
+                    }
                     None => Value::NIL,
                 })
                 .collect()
@@ -98,7 +100,7 @@ impl Interpreter {
 
         for (i, slot) in captures.positional_slots.iter().enumerate() {
             let value = match slot {
-                Some((capture, from, to)) => make_capture_match(capture, *from, *to),
+                Some((from, to)) => make_capture_match(&captures.span_text(*from, *to), *from, *to),
                 None => Value::NIL,
             };
             self.env.insert(i.to_string(), value);
@@ -280,7 +282,6 @@ impl Interpreter {
                 // the single-match path and `.match(:g)` — the `~~ m:g/.../` path
                 // previously passed `None`, leaving `.orig` empty.
                 Value::make_match_object_full(
-                    c.matched.clone(),
                     c.from as i64,
                     c.to as i64,
                     &c.positional,
@@ -289,7 +290,7 @@ impl Interpreter {
                     &c.positional_subcaps,
                     &c.positional_quantified,
                     &c.positional_nil,
-                    Some(orig),
+                    c.target_or_new(orig),
                 )
             })
             .collect::<Vec<_>>();
@@ -416,19 +417,23 @@ impl Interpreter {
         let mut locs = re.capture_locations();
         let m0 = re.captures_read(&mut locs, text.as_bytes()).ok()??;
         let names = re.capture_names();
+        // pcre2 reports BYTE offsets; recorded spans are char indices into
+        // the shared subject (ADR-0016 P3), so translate at the boundary.
+        let to_char = |b: usize| text.get(..b).map_or(b, |p| p.chars().count());
         let mut out = RegexCaptures {
-            matched: text.get(m0.start()..m0.end())?.to_string(),
-            from: m0.start(),
-            to: m0.end(),
+            from: to_char(m0.start()),
+            to: to_char(m0.end()),
+            target: Some(crate::runtime::MatchTarget::new(text)),
             ..RegexCaptures::default()
         };
         for idx in 1..locs.len() {
             if names.get(idx).is_some_and(Option::is_none) {
                 if let Some((start, end)) = locs.get(idx) {
                     let captured = text.get(start..end)?.to_string();
-                    out.positional.push(captured.clone());
-                    out.positional_offsets.push((start, end));
-                    out.positional_slots.push(Some((captured, start, end)));
+                    let (cs, ce) = (to_char(start), to_char(end));
+                    out.positional.push(captured);
+                    out.positional_offsets.push((cs, ce));
+                    out.positional_slots.push(Some((cs, ce)));
                 } else {
                     out.positional_slots.push(None);
                 }
@@ -459,17 +464,21 @@ impl Interpreter {
         let mut start = 0usize;
         let bytes = text.as_bytes();
         let mut locs = re.capture_locations();
+        // pcre2 reports BYTE offsets; recorded spans are char indices into
+        // the shared subject (ADR-0016 P3), so translate at the boundary.
+        let to_char = |b: usize| text.get(..b).map_or(b, |p| p.chars().count());
+        let target = crate::runtime::MatchTarget::new(text);
         while start <= bytes.len() {
             let Ok(Some(m0)) = re.captures_read_at(&mut locs, bytes, start) else {
                 break;
             };
-            let Some(matched) = text.get(m0.start()..m0.end()) else {
+            if text.get(m0.start()..m0.end()).is_none() {
                 break;
-            };
+            }
             let mut item = RegexCaptures {
-                matched: matched.to_string(),
-                from: m0.start(),
-                to: m0.end(),
+                from: to_char(m0.start()),
+                to: to_char(m0.end()),
+                target: Some(target.clone()),
                 ..RegexCaptures::default()
             };
             for idx in 1..locs.len() {
@@ -479,9 +488,9 @@ impl Interpreter {
                             continue;
                         };
                         item.positional.push(captured.to_string());
-                        item.positional_offsets.push((c_start, c_end));
-                        item.positional_slots
-                            .push(Some((captured.to_string(), c_start, c_end)));
+                        let (cs, ce) = (to_char(c_start), to_char(c_end));
+                        item.positional_offsets.push((cs, ce));
+                        item.positional_slots.push(Some((cs, ce)));
                     } else {
                         item.positional_slots.push(None);
                     }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -248,13 +248,14 @@ impl Interpreter {
                             self.env.insert(i.to_string(), Value::str(v.clone()));
                         }
                         // Reduce-time inline actions (children first).
-                        self.reduce_regex_captures_made(&mut captures, Some(&text));
+                        let starget = captures.target_or_new(&text);
+                        self.reduce_regex_captures_made(&mut captures, Some(&starget));
                         let match_obj = Value::make_match_object_with_captures(
-                            captures.matched.clone(),
                             captures.from as i64,
                             captures.to as i64,
                             &captures.positional,
                             &captures.named,
+                            starget,
                         );
                         self.env.insert("/".to_string(), match_obj);
                         for (k, v) in &captures.named {
@@ -330,11 +331,11 @@ impl Interpreter {
                             } else {
                                 let cap = &non_overlapping[idx - 1];
                                 let match_obj = Value::make_match_object_with_captures(
-                                    cap.matched.clone(),
                                     cap.from as i64,
                                     cap.to as i64,
                                     &cap.positional,
                                     &cap.named,
+                                    cap.target_or_new(&text),
                                 );
                                 junc_values.push(match_obj);
                             }
@@ -543,7 +544,8 @@ impl Interpreter {
                     if !cap.code_blocks.is_empty()
                         || cap.named_subcaps.values().any(|v| !v.is_empty())
                     {
-                        self.reduce_regex_captures_made(cap, Some(&text));
+                        let ct = cap.target_or_new(&text);
+                        self.reduce_regex_captures_made(cap, Some(&ct));
                     }
                 }
                 self.apply_multi_regex_captures(&selected, &text);
@@ -713,7 +715,8 @@ impl Interpreter {
                     self.env.remove("made");
                     // Reduce-time inline actions: run each subrule's `{ make … }`
                     // once (children first) and commit per-node `.made`.
-                    self.reduce_regex_captures_made(&mut captures, Some(&text));
+                    let starget = captures.target_or_new(&text);
+                    self.reduce_regex_captures_made(&mut captures, Some(&starget));
                     // Merge hash captures into named for Match object
                     let mut named_with_hash = captures.named.clone();
                     for hash_name in captures.hash_captures.keys() {
@@ -724,7 +727,6 @@ impl Interpreter {
                         }
                     }
                     let match_obj = Value::make_match_object_full_q(
-                        captures.matched.clone(),
                         captures.from as i64,
                         captures.to as i64,
                         &captures.positional,
@@ -733,7 +735,7 @@ impl Interpreter {
                         &captures.positional_subcaps,
                         &captures.positional_quantified,
                         &captures.positional_nil,
-                        Some(&text),
+                        starget,
                         &captures.named_quantified,
                     );
                     // Apply hash captures: set named entries to Hash values

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -304,7 +304,7 @@ impl Value {
         if let Some(node) = self.0.as_match_node()
             && node.forced().is_none()
         {
-            return node.cap.matched.clone();
+            return node.span_text();
         }
         match self.view() {
             // A `VarRef` is a transient binder wrapper: it stringifies as the

--- a/src/value/match_lazy.rs
+++ b/src/value/match_lazy.rs
@@ -2,12 +2,15 @@
 //!
 //! A regex/grammar match no longer eagerly builds a full `Instance("Match")`
 //! attribute tree per capture node. The match VALUE is a
-//! `ValueRepr::Match(Gc<MatchNode>)` holding the shared subject string and the
-//! stored capture node (`Arc<CapNode>`); the Instance-shaped attribute map is
-//! materialized once, on first `view()` decode, and memoized. Materialization
-//! is ONE level deep: child captures become lazy `Match` values themselves, so
-//! a subtree nobody inspects never allocates anything beyond the `CapNode`
-//! the matcher already built.
+//! `ValueRepr::Match(Gc<MatchNode>)` holding the shared subject
+//! (`MatchTarget`) and the stored capture node (`Arc<CapNode>`); the
+//! Instance-shaped attribute map is materialized once, on first `view()`
+//! decode, and memoized. Materialization is ONE level deep: child captures
+//! become lazy `Match` values themselves, so a subtree nobody inspects never
+//! allocates anything beyond the `CapNode` the matcher already built.
+//!
+//! ADR-0016 P3: capture nodes no longer store matched text — `.Str` is
+//! derived from the recorded span through the shared `MatchTarget`.
 //!
 //! Consumers are unchanged: `view()` on a lazy Match forces the memoized map
 //! and presents `ValueView::Instance` exactly as an eager Match. The seam
@@ -17,7 +20,7 @@
 //! same as before.
 
 use super::*;
-use crate::runtime::{CapNode, SILENT_ACTION_MARKER_PREFIX};
+use crate::runtime::{CapNode, MatchTarget, SILENT_ACTION_MARKER_PREFIX};
 use std::sync::OnceLock;
 
 /// Interned class symbol for `Match`.
@@ -28,8 +31,9 @@ pub(in crate::value) fn match_class_symbol() -> Symbol {
 
 /// The payload of a lazy `Match` value. See the module doc.
 pub(crate) struct MatchNode {
-    /// The whole subject string (`.orig`), shared by every node of the tree.
-    pub(in crate::value) orig: Option<Arc<String>>,
+    /// The shared subject this match ran against, shared by every node of
+    /// the tree. Answers `.orig` and derives `.Str` from the span.
+    pub(in crate::value) target: MatchTarget,
     /// The stored capture node this Match presents.
     pub(in crate::value) cap: Arc<CapNode>,
     /// Stable instance identity (same id domain as eager `Instance`s).
@@ -50,9 +54,9 @@ impl std::fmt::Debug for MatchNode {
 }
 
 impl MatchNode {
-    pub(in crate::value) fn new(cap: Arc<CapNode>, orig: Option<Arc<String>>) -> Self {
+    pub(in crate::value) fn new(cap: Arc<CapNode>, target: MatchTarget) -> Self {
         Self {
-            orig,
+            target,
             cap,
             id: next_instance_id(),
             attrs: OnceLock::new(),
@@ -81,6 +85,11 @@ impl MatchNode {
         let _ = self.attrs.take();
     }
 
+    /// This node's matched text, derived from the recorded span.
+    pub(in crate::value) fn span_text(&self) -> String {
+        self.target.span_str(self.cap.from, self.cap.to)
+    }
+
     /// Read one attribute, without forcing when it is derivable from the
     /// capture node. Structural attributes (`list`, `named`, `silent_caps`,
     /// `reduce_time_vars`, `capture_alias_map`) force the materialization.
@@ -89,10 +98,10 @@ impl MatchNode {
             return attrs.as_map().get(name).cloned();
         }
         match name {
-            "str" => Some(Value::str(self.cap.matched.clone())),
+            "str" => Some(Value::str(self.span_text())),
             "from" => Some(Value::Int(self.cap.from as i64)),
             "to" => Some(Value::Int(self.cap.to as i64)),
-            "orig" => self.orig.as_ref().map(|o| Value::str_arc(Arc::clone(o))),
+            "orig" => Some(Value::str_arc(Arc::clone(self.target.text()))),
             "ast" => self.cap.ast.clone(),
             "sym_variant" => self.cap.sym.clone().map(Value::str),
             "action_name" => self.cap.action_name.clone().map(Value::str),
@@ -106,7 +115,7 @@ impl MatchNode {
 
     /// A lazy child Match sharing this node's subject.
     fn lazy_child(&self, sc: &Arc<CapNode>) -> Value {
-        Value::lazy_match(Arc::clone(sc), self.orig.clone())
+        Value::lazy_match(Arc::clone(sc), self.target.clone())
     }
 
     /// Build this node's attribute map — the pre-P5 `make_subcap_match`, with
@@ -117,10 +126,6 @@ impl MatchNode {
             crate::vm::vm_stats::record_regex_match_leaf(false);
         }
         let kids = cap.kids();
-        let search_start = cap.from;
-        // Subject chars for the legacy text-only-leaf position search below,
-        // computed at most once per materialization.
-        let mut chars_cache: Option<Vec<char>> = None;
 
         let pos_vals: Vec<Value> = kids
             .positional
@@ -134,11 +139,11 @@ impl MatchNode {
                 if let Some(Some(qlist)) = kids.positional_quantified.get(i) {
                     let arr: Vec<Value> = qlist
                         .iter()
-                        .map(|(text, qfrom, qto, subcap)| {
+                        .map(|(qfrom, qto, subcap)| {
                             if let Some(sc) = subcap {
                                 return self.lazy_child(sc);
                             }
-                            span_leaf_match(text, *qfrom, *qto, self.orig.as_ref())
+                            span_leaf_match(*qfrom, *qto, &self.target)
                         })
                         .collect();
                     return Value::array(arr);
@@ -146,7 +151,7 @@ impl MatchNode {
                 if let Some(Some(subcap)) = kids.positional_subcaps.get(i) {
                     return self.lazy_child(subcap);
                 }
-                text_leaf_match(s, self.orig.as_ref(), &mut chars_cache, search_start)
+                text_leaf_match(s, &self.target)
             })
             .collect();
 
@@ -162,7 +167,7 @@ impl MatchNode {
                     {
                         return self.lazy_child(sc);
                     }
-                    text_leaf_match(s, self.orig.as_ref(), &mut chars_cache, search_start)
+                    text_leaf_match(s, &self.target)
                 })
                 .collect();
             if vals.len() == 1 && !kids.named_quantified.contains(key) {
@@ -191,7 +196,7 @@ impl MatchNode {
         }
 
         let mut attrs = AttrMap::new();
-        attrs.insert("str", Value::str(cap.matched.clone()));
+        attrs.insert("str", Value::str(self.span_text()));
         attrs.insert("from", Value::Int(cap.from as i64));
         attrs.insert("to", Value::Int(cap.to as i64));
         attrs.insert("list", Value::array(pos_vals));
@@ -199,9 +204,7 @@ impl MatchNode {
         if !silent_caps_vals.is_empty() {
             attrs.insert("silent_caps", Value::real_array(silent_caps_vals));
         }
-        if let Some(o) = &self.orig {
-            attrs.insert("orig", Value::str_arc(Arc::clone(o)));
-        }
+        attrs.insert("orig", Value::str_arc(Arc::clone(self.target.text())));
         if let Some(sym) = &cap.sym {
             attrs.insert("sym_variant", Value::str(sym.clone()));
         }
@@ -235,66 +238,41 @@ impl MatchNode {
 }
 
 /// Eager leaf Match for a quantified-capture entry with a recorded span.
-fn span_leaf_match(text: &str, from: usize, to: usize, orig: Option<&Arc<String>>) -> Value {
+fn span_leaf_match(from: usize, to: usize, target: &MatchTarget) -> Value {
     let mut attrs = AttrMap::new();
-    attrs.insert("str", Value::str(text.to_string()));
+    attrs.insert("str", Value::str(target.span_str(from, to)));
     attrs.insert("from", Value::Int(from as i64));
     attrs.insert("to", Value::Int(to as i64));
     attrs.insert("list", Value::array(Vec::new()));
     attrs.insert("named", Value::hash(HashMap::new()));
-    if let Some(o) = orig {
-        attrs.insert("orig", Value::str_arc(Arc::clone(o)));
-    }
+    attrs.insert("orig", Value::str_arc(Arc::clone(target.text())));
     Value::make_instance(match_class_symbol(), attrs)
 }
 
 /// Eager leaf Match for a TEXT-ONLY capture entry (no stored `CapNode`).
-/// The span is recovered by searching for the text at/after `search_from` —
-/// the pre-P5 legacy path; every leaf the matcher stores today carries a
-/// span-bearing `CapNode`, so this survives only for exploded-builder callers
-/// that still pass bare text.
-fn text_leaf_match(
-    s: &str,
-    orig: Option<&Arc<String>>,
-    chars_cache: &mut Option<Vec<char>>,
-    search_from: usize,
-) -> Value {
-    crate::vm::vm_stats::record_regex_match_leaf(orig.is_some());
-    let (cap_from, cap_to) = if let Some(o) = orig {
-        let haystack = chars_cache.get_or_insert_with(|| o.chars().collect());
-        let needle: Vec<char> = s.chars().collect();
-        let mut found = None;
-        for start in search_from..=haystack.len().saturating_sub(needle.len()) {
-            if haystack[start..start + needle.len()] == needle[..] {
-                found = Some(start as i64);
-                break;
-            }
-        }
-        match found {
-            Some(f) => (f, f + needle.len() as i64),
-            None => (0i64, s.chars().count() as i64),
-        }
-    } else {
-        (0i64, s.chars().count() as i64)
-    };
+/// Survives only for text-axis entries with no aligned span carrier — every
+/// leaf the matcher stores today carries a span-bearing `CapNode`, so this
+/// fires only on exploded-builder callers that still pass bare text. The
+/// span is unrecoverable here (P3 retired the position search), so it is
+/// reported as `0..chars` of the captured text itself.
+fn text_leaf_match(s: &str, target: &MatchTarget) -> Value {
+    crate::vm::vm_stats::record_regex_match_leaf(true);
     let mut attrs = AttrMap::new();
     attrs.insert("str", Value::str(s.to_string()));
-    attrs.insert("from", Value::Int(cap_from));
-    attrs.insert("to", Value::Int(cap_to));
+    attrs.insert("from", Value::Int(0));
+    attrs.insert("to", Value::Int(s.chars().count() as i64));
     attrs.insert("list", Value::array(Vec::new()));
     attrs.insert("named", Value::hash(HashMap::new()));
-    if let Some(o) = orig {
-        attrs.insert("orig", Value::str_arc(Arc::clone(o)));
-    }
+    attrs.insert("orig", Value::str_arc(Arc::clone(target.text())));
     Value::make_instance(match_class_symbol(), attrs)
 }
 
 impl Value {
     /// Construct a lazy `Match` from a stored capture node and the shared
-    /// subject string.
-    pub(crate) fn lazy_match(cap: Arc<CapNode>, orig: Option<Arc<String>>) -> Value {
+    /// subject.
+    pub(crate) fn lazy_match(cap: Arc<CapNode>, target: MatchTarget) -> Value {
         Value::from_repr(ValueRepr::Match(crate::gc::Gc::new(MatchNode::new(
-            cap, orig,
+            cap, target,
         ))))
     }
 
@@ -310,7 +288,7 @@ impl Value {
         }
         let mut cap = (*node.cap).clone();
         cap.ast = Some(ast);
-        Some(Value::lazy_match(Arc::new(cap), node.orig.clone()))
+        Some(Value::lazy_match(Arc::new(cap), node.target.clone()))
     }
 
     /// The per-match `:my $*x` values recorded at reduce time, read straight
@@ -360,9 +338,8 @@ mod tests {
     use super::*;
     use crate::runtime::RegexCaptures;
 
-    fn leaf_cap(text: &str, from: usize, to: usize) -> Arc<CapNode> {
+    fn leaf_cap(from: usize, to: usize) -> Arc<CapNode> {
         let mut caps = RegexCaptures::default();
-        caps.matched = text.to_string();
         caps.from = from;
         caps.to = to;
         Arc::new(caps.into_cap_node())
@@ -370,7 +347,7 @@ mod tests {
 
     #[test]
     fn lazy_match_scalar_reads_do_not_force() {
-        let m = Value::lazy_match(leaf_cap("ab", 3, 5), Some(Arc::new("xxxab".to_string())));
+        let m = Value::lazy_match(leaf_cap(3, 5), MatchTarget::new("xxxab"));
         assert!(m.is_match_instance());
         assert_eq!(m.match_from(), Some(3));
         assert_eq!(m.match_to(), Some(5));
@@ -383,7 +360,7 @@ mod tests {
 
     #[test]
     fn lazy_match_views_as_instance() {
-        let m = Value::lazy_match(leaf_cap("ab", 3, 5), Some(Arc::new("xxxab".to_string())));
+        let m = Value::lazy_match(leaf_cap(3, 5), MatchTarget::new("xxxab"));
         match m.view() {
             ValueView::Instance {
                 class_name,
@@ -405,15 +382,14 @@ mod tests {
     #[test]
     fn lazy_match_children_stay_lazy_one_level() {
         // parent { named: x => child }, child a leaf with a span.
-        let child = leaf_cap("b", 1, 2);
+        let child = leaf_cap(1, 2);
         let mut caps = RegexCaptures::default();
-        caps.matched = "ab".to_string();
         caps.from = 0;
         caps.to = 2;
         caps.named.insert("x".to_string(), vec!["b".to_string()]);
         caps.named_subcaps
             .insert("x".to_string(), vec![Arc::clone(&child)]);
-        let parent = Value::lazy_match(Arc::new(caps.into_cap_node()), None);
+        let parent = Value::lazy_match(Arc::new(caps.into_cap_node()), MatchTarget::new("ab"));
         let named = parent.match_named().expect("named hash");
         let child_val = match named.view() {
             ValueView::Hash(h) => h.map.get("x").cloned().expect("x"),

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -572,14 +572,13 @@ impl Value {
 
     /// Create a Match object with positional captures.
     pub(crate) fn make_match_object_with_captures(
-        matched: String,
         from: i64,
         to: i64,
         positional: &[String],
         named: &HashMap<String, Vec<String>>,
+        target: crate::runtime::MatchTarget,
     ) -> Self {
         Self::make_match_object_full(
-            matched,
             from,
             to,
             positional,
@@ -588,7 +587,7 @@ impl Value {
             &[],
             &[],
             &[],
-            None,
+            target,
         )
     }
 }

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -1,10 +1,9 @@
 use super::*;
 
 impl Value {
-    /// Create a Match object with positional captures and original string.
+    /// Create a Match object with positional captures and the shared subject.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn make_match_object_full(
-        matched: String,
         from: i64,
         to: i64,
         positional: &[String],
@@ -13,10 +12,9 @@ impl Value {
         positional_subcaps: &[Option<std::sync::Arc<crate::runtime::CapNode>>],
         positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
         positional_nil: &[bool],
-        orig: Option<&str>,
+        target: crate::runtime::MatchTarget,
     ) -> Self {
         Self::make_match_object_full_q(
-            matched,
             from,
             to,
             positional,
@@ -25,7 +23,7 @@ impl Value {
             positional_subcaps,
             positional_quantified,
             positional_nil,
-            orig,
+            target,
             &HashSet::new(),
         )
     }
@@ -39,9 +37,11 @@ impl Value {
     /// (see `value::match_lazy`). The synthesized top node deliberately
     /// carries no `sym`/`action_name`/`ast`/`regex_vars`/`capture_alias_map`
     /// — the pre-P5 builder never surfaced those on the top-level Match.
+    ///
+    /// ADR-0016 P3: matched text is not passed or stored; `.Str` derives
+    /// from the span through `target`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn make_match_object_full_q(
-        matched: String,
         from: i64,
         to: i64,
         positional: &[String],
@@ -50,7 +50,7 @@ impl Value {
         positional_subcaps: &[Option<std::sync::Arc<crate::runtime::CapNode>>],
         positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
         positional_nil: &[bool],
-        orig: Option<&str>,
+        target: crate::runtime::MatchTarget,
         named_quantified: &HashSet<String>,
     ) -> Self {
         let has_children = !named.is_empty()
@@ -75,7 +75,6 @@ impl Value {
             })
         });
         let cap = crate::runtime::CapNode {
-            matched,
             from: from.max(0) as usize,
             to: to.max(0) as usize,
             sym: None,
@@ -83,10 +82,7 @@ impl Value {
             ast: None,
             children,
         };
-        Value::lazy_match(
-            std::sync::Arc::new(cap),
-            orig.map(|o| std::sync::Arc::new(o.to_string())),
-        )
+        Value::lazy_match(std::sync::Arc::new(cap), target)
     }
 
     pub(crate) fn version_strip_trailing_zeros(parts: &[VersionPart]) -> Vec<VersionPart> {

--- a/src/vm/vm_native_subst.rs
+++ b/src/vm/vm_native_subst.rs
@@ -161,10 +161,9 @@ impl Interpreter {
         // a global `.subst` sets it to a List of every Match object (matching
         // `s:g///` and Rakudo's `.subst(:g)` — `$/` is always a List, even for a
         // single match).
+        let target = crate::runtime::MatchTarget::new(text);
         let make_match = |start: usize, end: usize, caps: &[String]| {
-            let matched: String = chars[start..end].iter().collect();
             Value::make_match_object_full(
-                matched,
                 start as i64,
                 end as i64,
                 caps,
@@ -173,7 +172,7 @@ impl Interpreter {
                 &[],
                 &[],
                 &[],
-                Some(text),
+                target.clone(),
             )
         };
         if global {

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -136,11 +136,11 @@ static GC_ROOTS_SCANNED: AtomicU64 = AtomicU64::new(0);
 // CapNode split (ADR-0016 P2) removes structurally.
 static REGEX_CAP_MAKEMUT_TOTAL: AtomicU64 = AtomicU64::new(0);
 static REGEX_CAP_MAKEMUT_SHARED: AtomicU64 = AtomicU64::new(0);
-// ADR-0016 P3: how many leaf captures the Match builder had to recover a
-// position for by SEARCHING the subject (`make_capture_match` with an orig
-// context), vs. leaves whose span came from a recorded carrier node. The
-// search is O(document) per leaf and semantically wrong for repeated text —
-// P3's goal is to drive `searches` to zero by carrying spans.
+// ADR-0016 P3: how many leaf captures reached the Match builder WITHOUT a
+// span carrier (text-axis only — their offsets are reported as 0..len of the
+// captured text, the position search having been retired), vs. leaves whose
+// span came from a recorded carrier node. Non-zero `searches` means an
+// exploded-builder caller still passes bare text.
 static REGEX_MATCH_LEAF_SEARCHES: AtomicU64 = AtomicU64::new(0);
 static REGEX_MATCH_LEAF_SPANS: AtomicU64 = AtomicU64::new(0);
 
@@ -172,8 +172,8 @@ pub(crate) fn record_regex_cap_makemut(shared: bool) {
     }
 }
 
-/// A Match-builder leaf capture recovered its offsets by searching the subject
-/// (`searched == true`) or read them from a recorded span (`searched == false`).
+/// A Match-builder leaf capture arrived without a span carrier (`searched ==
+/// true` — the legacy text-only shape) or read a recorded span (`false`).
 pub(crate) fn record_regex_match_leaf(searched: bool) {
     if enabled() {
         if searched {

--- a/src/vm/vm_subst_apply.rs
+++ b/src/vm/vm_subst_apply.rs
@@ -11,10 +11,7 @@ impl Interpreter {
         end: usize,
         positional: &[String],
     ) -> Value {
-        let chars: Vec<char> = text.chars().collect();
-        let matched: String = chars[start..end].iter().collect();
         Value::make_match_object_full(
-            matched,
             start as i64,
             end as i64,
             positional,
@@ -23,7 +20,7 @@ impl Interpreter {
             &[],
             &[],
             &[],
-            Some(text),
+            crate::runtime::MatchTarget::new(text),
         )
     }
 
@@ -265,7 +262,6 @@ impl Interpreter {
             // Bind `$/` to a Match object for this match, and `$0`, `$1`, ...
             // to the positional captures.
             let match_obj = Value::make_match_object_full(
-                matched_text.to_string(),
                 *start as i64,
                 *end as i64,
                 caps,
@@ -274,7 +270,7 @@ impl Interpreter {
                 &[],
                 &[],
                 &[],
-                Some(text),
+                crate::runtime::MatchTarget::new(text),
             );
             self.env_mut().insert("/".to_string(), match_obj);
             for n in 0..10 {

--- a/t/regex-ignoremark-capture-span.t
+++ b/t/regex-ignoremark-capture-span.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+plan 8;
+
+# ADR-0016 P3: captures under :m (ignoremark) derive their text from spans
+# remapped into ORIGINAL subject space — raku reports the original (marked)
+# text, not the mark-stripped text the engine matched against.
+if "cafés" ~~ m:m/ caf (e) s / {
+    is ~$0, "é", ':m capture reports original (marked) text';
+    is $0.from, 3, ':m capture from is original-space';
+    is $0.to, 4, ':m capture to is original-space';
+}
+else {
+    flunk ':m match failed' for ^3;
+}
+
+# A subrule carrying its own :ignoremark: sub-captures must land at absolute
+# subject positions (the engine matches a mark-stripped SLICE internally).
+grammar IgnCap {
+    token TOP { x <s> }
+    token s   { :ignoremark '"' (\w+) '"' }
+}
+my $m = IgnCap.parse('x"abc"');
+ok $m.defined, 'parse with :ignoremark subrule succeeds';
+is ~$m<s>[0], 'abc', 'capture group inside :ignoremark subrule has right text';
+is $m<s>[0].from, 2, '... and absolute from';
+is $m<s>[0].to, 5, '... and absolute to';
+
+# Marked text inside the ignoremark subrule: still original text out.
+grammar IgnMark {
+    token TOP { <w> }
+    token w   { :ignoremark (ab) }
+}
+my $m2 = IgnMark.parse("áb");
+is ~$m2<w>[0], "áb", 'marked chars survive into the capture text';


### PR DESCRIPTION
## Summary

ADR-0016 P3 ("spans, not text"), first slice: the match subject becomes one shared `MatchTarget { text: Arc<String>, chars: Arc<[char]> }` built per engine entry, and every stored-text redundancy that already had a recorded span is deleted:

- `CapNode.matched` / `RegexCaptures.matched` — gone; readers derive text via `span_str` (ASCII byte-slice fast path). `CapNode` size guard tightens 112 → 88 bytes.
- `QuantifiedCaptureEntry` is now `(from, to, subcap)`; `positional_slots` is spans only.
- The P5 leaf **position search** (recover offsets by scanning the subject for the captured text — wrong for repeated text) is retired outright.
- The `orig: Option<&str>` builder threading is replaced by `MatchTarget` (consumers no longer re-collect the subject); mid-match synthesis (`<?{ }>` `.made` dispatch, reduce-time `$*` actions) reads a thread-local engine scope.

## Compatibility fixes (surfaced by deriving text from spans)

- **`:m` / `:i`-fold captures**: the capture tree is now remapped to original-subject space recursively, including sub-captures. Previously sub-captures kept derived-space offsets and mark-stripped text: `"cafés" ~~ m:m/ caf (e) s /` captured `"e"`; raku (and now mutsu) captures `"é"`. Pinned by `t/regex-ignoremark-capture-span.t` (verified identical under raku).
- **Quantified-capture fold**: fabricated `0..len` spans when `positional_offsets` was missing (the Cause-2 bug class of ADR-0016, previously papered over by stored text). Every positional push/merge site now keeps the offsets axis aligned. Pinned by `t/subst-closure-quantified-capture.t`.
- **pcre2 `:P5`**: reported byte offsets where char offsets were expected.

## What P3 still owes

The accumulator's `named`/`positional` text vectors (and `CodeBlockContext` snapshots) remain — removing them is structurally the P4 axis collapse. Local interleaved A/B puts this intermediate state at ≈ +2–3 % on `bench-yaml-parse` (capture-site text collects still run); expected back with P4. bench CI (int-arith-normalized) is the authoritative number.

## Testing

- `cargo test` (657), full `t/` (24915), full local `make roast` (218774) — all PASS
- `cargo clippy -- -D warnings`, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)