### PR TITLE
perf(regex): collapse positional capture axis into Vec<PosSlot> (ADR-0016 P4 L1)

### DIFF
--- a/src/builtins/split.rs
+++ b/src/builtins/split.rs
@@ -317,15 +317,11 @@ fn separator_value(m: &SplitMatch) -> Value {
         } else {
             (m.from as i64, m.to as i64)
         };
-        Value::make_match_object_full(
+        Value::make_match_object_with_captures(
             from,
             to,
             &m.positional_captures,
             &HashMap::new(),
-            &HashMap::new(),
-            &[],
-            &[],
-            &[],
             target,
         )
     } else {

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -439,9 +439,6 @@ impl Interpreter {
             &[],
             &std::collections::HashMap::new(),
             &std::collections::HashMap::new(),
-            &[],
-            &[],
-            &[],
             crate::runtime::MatchTarget::new(text),
         )
     }

--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -173,9 +173,6 @@ impl Interpreter {
                         &[],
                         &HashMap::new(),
                         &HashMap::new(),
-                        &[],
-                        &[],
-                        &[],
                         crate::runtime::MatchTarget::new(&fmt),
                     )));
                 }

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -487,7 +487,8 @@ impl Interpreter {
                 return Ok(self.make_parse_failure_value(&text, captures.to));
             }
             for (i, v) in captures.positional.iter().enumerate() {
-                self.env.insert(i.to_string(), Value::str(v.clone()));
+                self.env
+                    .insert(i.to_string(), Value::str(captures.slot_text(v)));
             }
             let alias_map = std::mem::take(&mut captures.capture_alias_map);
             let match_obj = Value::make_match_object_full_q(
@@ -496,9 +497,6 @@ impl Interpreter {
                 &captures.positional,
                 &captures.named,
                 &captures.named_subcaps,
-                &captures.positional_subcaps,
-                &captures.positional_quantified,
-                &captures.positional_nil,
                 gtarget,
                 &captures.named_quantified,
             );
@@ -627,9 +625,6 @@ impl Interpreter {
             &caps.positional,
             &caps.named,
             &caps.named_subcaps,
-            &caps.positional_subcaps,
-            &caps.positional_quantified,
-            &caps.positional_nil,
             caps.target_or_new(text),
             &caps.named_quantified,
         )
@@ -644,9 +639,6 @@ impl Interpreter {
             &kids.positional,
             &kids.named,
             &kids.named_subcaps,
-            &kids.positional_subcaps,
-            &kids.positional_quantified,
-            &kids.positional_nil,
             target.clone(),
             &kids.named_quantified,
         )

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -169,9 +169,6 @@ impl Interpreter {
                         &c.positional,
                         &c.named,
                         &c.named_subcaps,
-                        &c.positional_subcaps,
-                        &c.positional_quantified,
-                        &c.positional_nil,
                         c.target_or_new(&text),
                     )
                 })
@@ -215,9 +212,6 @@ impl Interpreter {
                 &captures.positional,
                 &captures.named,
                 &captures.named_subcaps,
-                &captures.positional_subcaps,
-                &captures.positional_quantified,
-                &captures.positional_nil,
                 mtarget,
             );
             // Set positional capture env vars ($0, $1, ...) from match object

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -97,9 +97,6 @@ impl Interpreter {
                 &c.positional,
                 &c.named,
                 &c.named_subcaps,
-                &c.positional_subcaps,
-                &c.positional_quantified,
-                &c.positional_nil,
                 c.target_or_new(text),
             )
         };
@@ -463,9 +460,6 @@ impl Interpreter {
                         &captures.positional,
                         &captures.named,
                         &captures.named_subcaps,
-                        &captures.positional_subcaps,
-                        &captures.positional_quantified,
-                        &captures.positional_nil,
                         captures.target_or_new(&text),
                     );
                     self.env.insert("/".to_string(), match_obj);

--- a/src/runtime/methods_string_subst_repl.rs
+++ b/src/runtime/methods_string_subst_repl.rs
@@ -23,10 +23,10 @@ impl Interpreter {
             if let Some(caps) = captures
                 && !caps.positional.is_empty()
             {
-                let expanded = crate::vm::vm_string_regex_ops::expand_capture_refs(
-                    replacement_str,
-                    &caps.positional,
-                );
+                let texts: Vec<String> =
+                    caps.positional.iter().map(|s| caps.slot_text(s)).collect();
+                let expanded =
+                    crate::vm::vm_string_regex_ops::expand_capture_refs(replacement_str, &texts);
                 return Ok(cased(expanded));
             }
             return Ok(cased(replacement_str.to_string()));
@@ -63,9 +63,6 @@ impl Interpreter {
                 &captures.positional,
                 &captures.named,
                 &captures.named_subcaps,
-                &captures.positional_subcaps,
-                &captures.positional_quantified,
-                &captures.positional_nil,
                 captures.target_or_new(orig_text.unwrap_or_default()),
             );
             self.env.insert("/".to_string(), match_obj.clone());
@@ -80,7 +77,11 @@ impl Interpreter {
                 // per-iteration matches as `$N`; the flat slot only holds the
                 // last iteration's text (t/uri-unescape shape:
                 // `.subst(:g, /['%' (<.xdigit>**2)]+/, -> $/ { $0.flatmap... })`).
-                let value = if let Some(Some(qlist)) = captures.positional_quantified.get(i) {
+                let value = if let Some(qlist) = captures
+                    .positional
+                    .get(i)
+                    .and_then(|slot| slot.quantified.as_ref())
+                {
                     let t = captures.target_or_new(orig_text.unwrap_or_default());
                     Value::array(
                         qlist
@@ -91,8 +92,8 @@ impl Interpreter {
                 } else if let Some(Some((a, b))) = captures.positional_slots.get(i) {
                     let t = captures.target_or_new(orig_text.unwrap_or_default());
                     Value::str(t.span_str(*a, *b))
-                } else if let Some(capture) = captures.positional.get(i) {
-                    Value::str(capture.clone())
+                } else if let Some(slot) = captures.positional.get(i) {
+                    Value::str(captures.slot_text(slot))
                 } else {
                     Value::NIL
                 };

--- a/src/runtime/methods_trans.rs
+++ b/src/runtime/methods_trans.rs
@@ -585,7 +585,12 @@ impl Interpreter {
                         {
                             best_len = caps.to - i;
                             let matched: String = chars[i..caps.to].iter().collect();
-                            best_captures = Some(caps.positional.clone());
+                            best_captures = Some(
+                                caps.positional
+                                    .iter()
+                                    .map(|slot| caps.slot_text(slot))
+                                    .collect::<Vec<String>>(),
+                            );
                             best_closure = Some((closure.clone(), matched));
                             found = true;
                         }

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -244,22 +244,30 @@ impl Interpreter {
         for (k, v) in &caps.regex_vars {
             env.push((k.clone(), v.clone()));
         }
+        // The engine-scope subject: derives `$0…` texts from the live
+        // accumulator's spans (the accumulator's own `target` is only set at
+        // engine exit).
+        let live_target = super::regex_helpers::current_match_target()
+            .unwrap_or_else(|| MatchTarget::new(matched_so_far));
         // Set positional capture variables ($0, $1, etc.)
-        for (i, val) in caps.positional.iter().enumerate() {
-            env.push((i.to_string(), Value::str(val.clone())));
+        for (i, slot) in caps.positional.iter().enumerate() {
+            env.push((
+                i.to_string(),
+                Value::str(live_target.span_str(slot.from, slot.to)),
+            ));
         }
         // Build `$/` as a proper Match object so `$/.Str`/`$/.lc`/`~$/` yield the
         // matched-so-far text (not just an array of positional captures). A
         // `<?{ … $/.lc … }>` assertion inside a `token` relies on this (the card
         // grammar's dup check does `%*PLAYED{$/.lc}++`). `$/[n]` still indexes the
         // positional captures on the Match object.
-        let cursor = Value::make_match_object_with_captures(
+        let cursor = Value::make_match_object_full(
             caps.match_from as i64,
             (caps.match_from + matched_so_far.chars().count()) as i64,
             &caps.positional,
             &caps.named,
-            super::regex_helpers::current_match_target()
-                .unwrap_or_else(|| MatchTarget::new(matched_so_far)),
+            &HashMap::new(),
+            live_target,
         );
         // `$¢` is the current match state at this point in the pattern — the same
         // object as `$/` here (`/ .{ $c = $¢ } /` must leave `$c` with a usable
@@ -389,9 +397,6 @@ impl Interpreter {
             &caps.positional,
             &caps.named,
             &caps.named_subcaps,
-            &caps.positional_subcaps,
-            &caps.positional_quantified,
-            &caps.positional_nil,
             target,
             &caps.named_quantified,
         );
@@ -522,9 +527,6 @@ impl Interpreter {
             &kids.positional,
             &kids.named,
             &kids.named_subcaps,
-            &kids.positional_subcaps,
-            &kids.positional_quantified,
-            &kids.positional_nil,
             target,
             &kids.named_quantified,
         );

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -394,12 +394,7 @@ impl Interpreter {
         // a child's code block accumulates into this match's binding (the
         // `:my %*PLAYED = (); <card>+` shape) rather than a sibling match's.
         let declared_keys = self.install_fresh_rule_dynvars(rule_name);
-        self.reduce_child_axes(
-            &mut caps.named_subcaps,
-            &mut caps.positional_subcaps,
-            &mut caps.positional_quantified,
-            target,
-        );
+        self.reduce_child_axes(&mut caps.named_subcaps, &mut caps.positional, target);
         if caps.code_blocks.is_empty() {
             // Even with no code blocks of its own, a declaring match must record
             // what its binding holds — its action still reads it, and a sibling
@@ -417,9 +412,6 @@ impl Interpreter {
             &caps.positional,
             &caps.named,
             &caps.named_subcaps,
-            &caps.positional_subcaps,
-            &caps.positional_quantified,
-            &caps.positional_nil,
             super::regex_helpers::target_or_empty(target),
             &caps.named_quantified,
         );
@@ -438,12 +430,7 @@ impl Interpreter {
     ) {
         let declared_keys = self.install_fresh_rule_dynvars(rule_name);
         if let Some(kids) = node.children.as_deref_mut() {
-            self.reduce_child_axes(
-                &mut kids.named_subcaps,
-                &mut kids.positional_subcaps,
-                &mut kids.positional_quantified,
-                target,
-            );
+            self.reduce_child_axes(&mut kids.named_subcaps, &mut kids.positional, target);
         }
         let has_blocks = node
             .children
@@ -470,9 +457,6 @@ impl Interpreter {
             &kids.positional,
             &kids.named,
             &kids.named_subcaps,
-            &kids.positional_subcaps,
-            &kids.positional_quantified,
-            &kids.positional_nil,
             super::regex_helpers::target_or_empty(target),
             &kids.named_quantified,
         );
@@ -486,8 +470,7 @@ impl Interpreter {
     fn reduce_child_axes(
         &mut self,
         named_subcaps: &mut HashMap<String, Vec<Arc<CapNode>>>,
-        positional_subcaps: &mut [Option<Arc<CapNode>>],
-        positional_quantified: &mut [Option<Vec<QuantifiedCaptureEntry>>],
+        positional: &mut [PosSlot],
         target: Option<&MatchTarget>,
     ) {
         // The walk mutates a node only to take/run its code blocks (writing
@@ -513,15 +496,14 @@ impl Interpreter {
                 self.reduce_cap_node_for_rule(sc, target, Some(&child_rule));
             }
         }
-        for sc in positional_subcaps.iter_mut().flatten() {
-            if skip_untouched && !Self::subtree_has_code_blocks(sc) {
-                continue;
+        for slot in positional.iter_mut() {
+            if let Some(sc) = slot.subcap.as_mut()
+                && (!skip_untouched || Self::subtree_has_code_blocks(sc))
+            {
+                crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
+                self.reduce_cap_node_for_rule(Arc::make_mut(sc), target, None);
             }
-            crate::vm::vm_stats::record_regex_cap_makemut(Arc::strong_count(sc) > 1);
-            self.reduce_cap_node_for_rule(Arc::make_mut(sc), target, None);
-        }
-        for pq in positional_quantified.iter_mut().flatten() {
-            for entry in pq.iter_mut() {
+            for entry in slot.quantified.iter_mut().flatten() {
                 if let Some(sc) = entry.2.as_mut() {
                     if skip_untouched && !Self::subtree_has_code_blocks(sc) {
                         continue;
@@ -606,17 +588,16 @@ impl Interpreter {
             .values()
             .flatten()
             .any(|sc| Self::subtree_has_code_blocks(sc))
-            || kids
-                .positional_subcaps
-                .iter()
-                .flatten()
-                .any(|sc| Self::subtree_has_code_blocks(sc))
-            || kids
-                .positional_quantified
-                .iter()
-                .flatten()
-                .flatten()
-                .any(|e| e.2.as_deref().is_some_and(Self::subtree_has_code_blocks))
+            || kids.positional.iter().any(|slot| {
+                slot.subcap
+                    .as_deref()
+                    .is_some_and(Self::subtree_has_code_blocks)
+                    || slot
+                        .quantified
+                        .iter()
+                        .flatten()
+                        .any(|e| e.2.as_deref().is_some_and(Self::subtree_has_code_blocks))
+            })
     }
 
     /// The rule name a `named_subcaps` key stands for. A silent-action capture

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -688,9 +688,6 @@ pub(super) fn remap_caps_spans_offset(
         caps.from = m(caps.from);
         caps.to = m(caps.to);
     }
-    for (a, b) in caps.positional_offsets.iter_mut() {
-        (*a, *b) = (m(*a), m(*b));
-    }
     for slot in caps.positional_slots.iter_mut().flatten() {
         slot.0 = m(slot.0);
         slot.1 = m(slot.1);
@@ -698,10 +695,26 @@ pub(super) fn remap_caps_spans_offset(
     for sc in caps.named_subcaps.values_mut().flatten() {
         remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
     }
-    for sc in caps.positional_subcaps.iter_mut().flatten() {
+    for slot in caps.positional.iter_mut() {
+        remap_pos_slot(slot, pos_map, orig_len, offset);
+    }
+}
+
+/// Remap one positional slot's spans (its own, its subcap tree, and every
+/// quantified iteration entry).
+pub(super) fn remap_pos_slot(
+    slot: &mut PosSlot,
+    pos_map: &[usize],
+    orig_len: usize,
+    offset: usize,
+) {
+    let m = |p: usize| map_pos(p, pos_map, orig_len) + offset;
+    slot.from = m(slot.from);
+    slot.to = m(slot.to);
+    if let Some(sc) = &mut slot.subcap {
         remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
     }
-    for entry in caps.positional_quantified.iter_mut().flatten().flatten() {
+    for entry in slot.quantified.iter_mut().flatten() {
         entry.0 = m(entry.0);
         entry.1 = m(entry.1);
         if let Some(sc) = &mut entry.2 {
@@ -727,20 +740,8 @@ pub(super) fn remap_cap_node_spans(
     for sc in children.named_subcaps.values_mut().flatten() {
         remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
     }
-    for sc in children.positional_subcaps.iter_mut().flatten() {
-        remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
-    }
-    for entry in children
-        .positional_quantified
-        .iter_mut()
-        .flatten()
-        .flatten()
-    {
-        entry.0 = m(entry.0);
-        entry.1 = m(entry.1);
-        if let Some(sc) = &mut entry.2 {
-            remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
-        }
+    for slot in children.positional.iter_mut() {
+        remap_pos_slot(slot, pos_map, orig_len, offset);
     }
 }
 
@@ -882,10 +883,6 @@ pub(super) fn merge_regex_captures(
         dst.capture_alias_map.insert(k, v);
     }
     dst.positional.append(&mut src.positional);
-    dst.positional_subcaps.append(&mut src.positional_subcaps);
-    dst.positional_quantified
-        .append(&mut src.positional_quantified);
-    dst.positional_offsets.append(&mut src.positional_offsets);
     dst.code_blocks.append(&mut src.code_blocks);
     for (k, v) in src.hash_captures.drain() {
         dst.hash_captures.entry(k).or_default().extend(v);
@@ -965,10 +962,10 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
         // reserves its own Nil slot (see `reserve_nil_capture_slots`), so both
         // `(y)?`→Nil and `(z)*`→[] coexist at their correct positions.
         for _ in 0..stride {
-            caps.positional.push(String::new());
-            caps.positional_subcaps.push(None);
-            caps.positional_quantified.push(Some(Vec::new()));
-            caps.positional_offsets.push((0, 0));
+            caps.positional.push(PosSlot {
+                quantified: Some(Vec::new()),
+                ..Default::default()
+            });
         }
         return;
     }
@@ -984,79 +981,61 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
         return;
     }
 
-    // Collect entries per group
-    let mut folded_positional = Vec::with_capacity(stride);
-    let mut folded_offsets = Vec::with_capacity(stride);
-    let mut folded_subcaps = Vec::with_capacity(stride);
-    let mut folded_quantified: Vec<Option<Vec<QuantifiedCaptureEntry>>> =
-        Vec::with_capacity(stride);
-
+    // Collect entries per group; the last iteration's span/subcap become the
+    // folded slot's "representative" values for backref purposes.
+    let mut folded: Vec<PosSlot> = Vec::with_capacity(stride);
     for group in 0..stride {
         let mut list: Vec<QuantifiedCaptureEntry> = Vec::with_capacity(iterations);
         for iter in 0..iterations {
             let idx = base_len + iter * stride + group;
-            let subcap = if idx < caps.positional_subcaps.len() {
-                caps.positional_subcaps[idx].clone()
-            } else {
-                None
-            };
-            let (from, to) = if idx < caps.positional_offsets.len() {
-                caps.positional_offsets[idx]
-            } else {
-                (0, caps.positional[idx].chars().count())
-            };
-            list.push((from, to, subcap));
+            let slot = &caps.positional[idx];
+            list.push((slot.from, slot.to, slot.subcap.clone()));
         }
-        // Use the last iteration's values as the "representative" for backref purposes
-        let last_idx = base_len + (iterations - 1) * stride + group;
-        folded_positional.push(caps.positional[last_idx].clone());
         let last = list.last().unwrap();
-        folded_offsets.push((last.0, last.1));
-        folded_subcaps.push(last.2.clone());
-        folded_quantified.push(Some(list));
+        folded.push(PosSlot {
+            from: last.0,
+            to: last.1,
+            subcap: last.2.clone(),
+            quantified: Some(list),
+            nil: false,
+        });
     }
 
     // Replace entries from base_len onward
     caps.positional.truncate(base_len);
-    caps.positional.extend(folded_positional);
-    caps.positional_subcaps.truncate(base_len);
-    caps.positional_subcaps.extend(folded_subcaps);
-    // Ensure positional_quantified is the right length
-    while caps.positional_quantified.len() < base_len {
-        caps.positional_quantified.push(None);
-    }
-    caps.positional_quantified.truncate(base_len);
-    caps.positional_quantified.extend(folded_quantified);
-    // Keep the offsets axis aligned: the representative slot carries the last
-    // iteration's span.
-    caps.positional_offsets.truncate(base_len);
-    while caps.positional_offsets.len() < base_len {
-        caps.positional_offsets.push((0, 0));
-    }
-    caps.positional_offsets.extend(folded_offsets);
+    caps.positional.extend(folded);
+}
+
+/// Materialize the positional slots' texts through the engine's subject —
+/// the snapshot a `CodeBlockContext` carries (ADR-0016 P4). Built at snapshot
+/// time from the same `chars` the spans were recorded against, so the
+/// semantics match the pre-P4 stored-text axis exactly.
+pub(super) fn pos_slot_texts(slots: &[PosSlot], chars: &[char]) -> Vec<String> {
+    slots
+        .iter()
+        .map(|slot| {
+            let from = slot.from.min(chars.len());
+            let to = slot.to.min(chars.len()).max(from);
+            chars[from..to].iter().collect()
+        })
+        .collect()
 }
 
 /// Reserve `stride` index-stable Nil slots for an unmatched optional capture
 /// group (`(x)?` that matched zero times). The slots render as `Nil` in the
 /// resulting Match (Raku: `(a)?(b)` on "b" yields `$0 = Nil`, `$1 = b`).
-///
-/// `positional_nil` is padded with `false` up to the current `positional` length
-/// before the `true` entries are pushed, so the matched captures that precede
-/// this group (which never touch `positional_nil`) stay index-aligned.
 pub(super) fn reserve_nil_capture_slots(caps: &mut RegexCaptures, stride: usize) {
     if stride == 0 {
         return;
     }
-    while caps.positional_nil.len() < caps.positional.len() {
-        caps.positional_nil.push(false);
-    }
     let at = caps.to;
     for _ in 0..stride {
-        caps.positional.push(String::new());
-        caps.positional_subcaps.push(None);
-        caps.positional_quantified.push(None);
-        caps.positional_offsets.push((at, at));
-        caps.positional_nil.push(true);
+        caps.positional.push(PosSlot {
+            from: at,
+            to: at,
+            nil: true,
+            ..Default::default()
+        });
     }
 }
 

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -87,15 +87,6 @@ impl Interpreter {
                         .named_quantified
                         .extend(inner_caps.named_quantified.drain());
                     new_caps.positional.append(&mut inner_caps.positional);
-                    new_caps
-                        .positional_offsets
-                        .append(&mut inner_caps.positional_offsets);
-                    new_caps
-                        .positional_subcaps
-                        .append(&mut inner_caps.positional_subcaps);
-                    new_caps
-                        .positional_quantified
-                        .append(&mut inner_caps.positional_quantified);
                     new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                     indexed.push((i, next, new_caps));
                 }
@@ -138,15 +129,6 @@ impl Interpreter {
                         .named_quantified
                         .extend(inner_caps.named_quantified.drain());
                     new_caps.positional.append(&mut inner_caps.positional);
-                    new_caps
-                        .positional_offsets
-                        .append(&mut inner_caps.positional_offsets);
-                    new_caps
-                        .positional_subcaps
-                        .append(&mut inner_caps.positional_subcaps);
-                    new_caps
-                        .positional_quantified
-                        .append(&mut inner_caps.positional_quantified);
                     new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                     group.push((next, new_caps));
                 }
@@ -207,18 +189,7 @@ impl Interpreter {
                 new_caps
                     .named_quantified
                     .extend(inner_caps.named_quantified.drain());
-                for v in inner_caps.positional.drain(..) {
-                    new_caps.positional.push(v);
-                }
-                new_caps
-                    .positional_offsets
-                    .append(&mut inner_caps.positional_offsets);
-                new_caps
-                    .positional_subcaps
-                    .append(&mut inner_caps.positional_subcaps);
-                new_caps
-                    .positional_quantified
-                    .append(&mut inner_caps.positional_quantified);
+                new_caps.positional.append(&mut inner_caps.positional);
                 new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                 // A `<(` / `)>` capture marker inside the group sets the match
                 // boundaries for the whole pattern; propagate it out of the group.
@@ -272,7 +243,6 @@ impl Interpreter {
             for (end, inner_caps) in
                 self.regex_match_ends_from_caps_in_pkg(pattern, chars, pos, pkg)
             {
-                let captured: String = chars[pos..end].iter().collect();
                 let mut new_caps = RegexCaptures::default();
                 let mut inner_caps = inner_caps;
                 // Named captures appearing inside a positional capture group belong
@@ -285,12 +255,12 @@ impl Interpreter {
                 let mut subcap = inner_caps;
                 subcap.from = pos;
                 subcap.to = end;
-                new_caps.positional.push(captured);
-                new_caps.positional_offsets.push((pos, end));
-                new_caps
-                    .positional_subcaps
-                    .push(Some(std::sync::Arc::new(subcap.into_cap_node())));
-                new_caps.positional_quantified.push(None);
+                new_caps.positional.push(PosSlot {
+                    from: pos,
+                    to: end,
+                    subcap: Some(std::sync::Arc::new(subcap.into_cap_node())),
+                    ..Default::default()
+                });
                 out.push((end, new_caps));
             }
             // Reverse the inner match order so the outer LIFO stack
@@ -312,18 +282,7 @@ impl Interpreter {
                     for (k, v) in inner_caps.named.drain() {
                         new_caps.named.entry(k).or_default().extend(v);
                     }
-                    for v in inner_caps.positional.drain(..) {
-                        new_caps.positional.push(v);
-                    }
-                    new_caps
-                        .positional_offsets
-                        .append(&mut inner_caps.positional_offsets);
-                    new_caps
-                        .positional_subcaps
-                        .append(&mut inner_caps.positional_subcaps);
-                    new_caps
-                        .positional_quantified
-                        .append(&mut inner_caps.positional_quantified);
+                    new_caps.positional.append(&mut inner_caps.positional);
                     new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                     out.push((end, new_caps));
                 }

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -68,15 +68,6 @@ impl Interpreter {
                             new_caps.capture_alias_map.insert(k, v);
                         }
                         new_caps.positional.extend(inner_caps.positional);
-                        new_caps
-                            .positional_offsets
-                            .append(&mut inner_caps.positional_offsets);
-                        new_caps
-                            .positional_subcaps
-                            .append(&mut inner_caps.positional_subcaps);
-                        new_caps
-                            .positional_quantified
-                            .append(&mut inner_caps.positional_quantified);
                         // Propagate a `<(` / `)>` capture marker set inside the group.
                         if inner_caps.capture_start.is_some() {
                             new_caps.capture_start = inner_caps.capture_start;
@@ -133,15 +124,6 @@ impl Interpreter {
                             new_caps.capture_alias_map.insert(k, v);
                         }
                         new_caps.positional.append(&mut inner_caps.positional);
-                        new_caps
-                            .positional_offsets
-                            .append(&mut inner_caps.positional_offsets);
-                        new_caps
-                            .positional_subcaps
-                            .append(&mut inner_caps.positional_subcaps);
-                        new_caps
-                            .positional_quantified
-                            .append(&mut inner_caps.positional_quantified);
                         new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                         new_caps.regex_vars.extend(inner_caps.regex_vars);
                         let replace = best
@@ -183,15 +165,6 @@ impl Interpreter {
                             new_caps.named.entry(k).or_default().extend(v);
                         }
                         new_caps.positional.append(&mut inner_caps.positional);
-                        new_caps
-                            .positional_offsets
-                            .append(&mut inner_caps.positional_offsets);
-                        new_caps
-                            .positional_subcaps
-                            .append(&mut inner_caps.positional_subcaps);
-                        new_caps
-                            .positional_quantified
-                            .append(&mut inner_caps.positional_quantified);
                         new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                         new_caps.regex_vars.extend(inner_caps.regex_vars);
                         return Some((next, new_caps));
@@ -261,23 +234,22 @@ impl Interpreter {
                 if let Some((end, inner_caps)) =
                     self.regex_match_end_from_caps_in_pkg(pattern, chars, pos, pkg)
                 {
-                    let captured: String = chars[pos..end].iter().collect();
                     let mut new_caps = RegexCaptures::default();
                     // Named captures appearing inside a positional capture group
                     // belong to that group's sub-Match (`$/[0]<name>`), NOT to the
                     // parent Match's top-level named captures (`$/<name>`). They are
-                    // therefore preserved only in `positional_subcaps` below, and
+                    // therefore preserved only in the slot's subcap below, and
                     // are intentionally NOT merged into the parent `named` map.
                     // Store inner captures as subcaptures of this group
                     let mut subcap = inner_caps.clone();
                     subcap.from = pos;
                     subcap.to = end;
-                    new_caps.positional.push(captured);
-                    new_caps.positional_offsets.push((pos, end));
-                    new_caps
-                        .positional_subcaps
-                        .push(Some(std::sync::Arc::new(subcap.into_cap_node())));
-                    new_caps.positional_quantified.push(None);
+                    new_caps.positional.push(PosSlot {
+                        from: pos,
+                        to: end,
+                        subcap: Some(std::sync::Arc::new(subcap.into_cap_node())),
+                        ..Default::default()
+                    });
                     return Some((end, new_caps));
                 }
                 return None;
@@ -356,7 +328,10 @@ impl Interpreter {
                     code: code.clone(),
                     named: current_caps.named.clone(),
                     matched_so_far,
-                    positional: current_caps.positional.clone(),
+                    positional: super::regex_helpers::pos_slot_texts(
+                        &current_caps.positional,
+                        chars,
+                    ),
                 };
                 // If eager code block collection is enabled, push immediately
                 // so the block is captured even if the overall match fails later.
@@ -388,18 +363,9 @@ impl Interpreter {
                         self.regex_match_end_from_caps_in_pkg(&parsed, chars, pos, &pkg)
                     {
                         let mut new_caps = RegexCaptures::default();
-                        for v in &inner_caps.positional {
-                            new_caps.positional.push(v.clone());
-                        }
                         new_caps
-                            .positional_offsets
-                            .extend(inner_caps.positional_offsets.iter().copied());
-                        new_caps
-                            .positional_subcaps
-                            .extend(inner_caps.positional_subcaps.clone());
-                        new_caps
-                            .positional_quantified
-                            .extend(inner_caps.positional_quantified.clone());
+                            .positional
+                            .extend(inner_caps.positional.iter().cloned());
                         for (k, v) in &inner_caps.named {
                             new_caps
                                 .named
@@ -428,26 +394,32 @@ impl Interpreter {
             }
             RegexAtom::Backref(idx) => {
                 // A quantified slot's reference text is the concatenation of
-                // every iteration's span; a plain slot keeps its stored text.
-                let ref_chars: Option<Vec<char>> =
-                    if let Some(Some(qlist)) = current_caps.positional_quantified.get(*idx) {
-                        let mut v = Vec::new();
-                        for (a, b, _) in qlist {
-                            let (a, b) = (*a.min(&chars.len()), *b.min(&chars.len()));
-                            v.extend_from_slice(&chars[a..b.max(a)]);
-                        }
-                        Some(v)
+                // every iteration's span; a plain slot's is its own span. Both
+                // compare against the same `chars` the spans were recorded in,
+                // so no text is materialized (ADR-0016 P4).
+                let slot = current_caps.positional.get(*idx)?;
+                let mut cursor = pos;
+                let compare_span = |a: usize, b: usize, cursor: &mut usize| -> bool {
+                    let (a, b) = (a.min(chars.len()), b.min(chars.len()));
+                    let (a, b) = (a, b.max(a));
+                    let len = b - a;
+                    if *cursor + len <= chars.len() && chars[*cursor..*cursor + len] == chars[a..b]
+                    {
+                        *cursor += len;
+                        true
                     } else {
-                        current_caps
-                            .positional
-                            .get(*idx)
-                            .map(|t| t.chars().collect())
-                    };
-                if let Some(ref_chars) = ref_chars
-                    && pos + ref_chars.len() <= chars.len()
-                    && chars[pos..pos + ref_chars.len()] == ref_chars[..]
-                {
-                    return Some((pos + ref_chars.len(), RegexCaptures::default()));
+                        false
+                    }
+                };
+                let ok = if let Some(qlist) = &slot.quantified {
+                    qlist
+                        .iter()
+                        .all(|(a, b, _)| compare_span(*a, *b, &mut cursor))
+                } else {
+                    compare_span(slot.from, slot.to, &mut cursor)
+                };
+                if ok {
+                    return Some((cursor, RegexCaptures::default()));
                 }
                 return None;
             }

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -213,21 +213,20 @@ impl Interpreter {
         // (Named captures always start with a letter/underscore, so an
         // all-digit name can only come from `$N=`.)
         if let Ok(forced_idx) = name.parse::<usize>() {
-            let captured: String = chars[from..to].iter().collect();
             // Drop the auto-positional entry a capturing group atom produced;
             // the alias decides this capture's index explicitly.
             if matches!(token.atom, RegexAtom::CaptureGroup(_))
                 && store.caps().positional.len() > pos_base
             {
-                store.truncate_positional_4(pos_base);
+                store.truncate_positional(pos_base);
             }
             while store.caps().positional.len() < forced_idx {
-                store.push_positional(String::new(), None, None, (0, 0));
+                store.push_positional(PosSlot::default());
             }
             if store.caps().positional.len() == forced_idx {
-                store.push_positional(captured, None, None, (from, to));
+                store.push_positional(PosSlot::span(from, to));
             } else {
-                store.overwrite_positional(forced_idx, captured, (from, to));
+                store.overwrite_positional(forced_idx, PosSlot::span(from, to));
             }
             return;
         }
@@ -250,11 +249,10 @@ impl Interpreter {
         {
             group_subcap = store
                 .caps()
-                .positional_subcaps
+                .positional
                 .get(pos_base)
-                .cloned()
-                .flatten();
-            store.truncate_positional_3(pos_base);
+                .and_then(|slot| slot.subcap.clone());
+            store.truncate_positional(pos_base);
         }
         store.push_named(name, captured.clone());
         // `@<name>=` array-sigil alias forces list context: mark the name as
@@ -338,26 +336,31 @@ impl Interpreter {
             let caps = store.caps();
             // Count how many new positional captures this atom produced
             let new_count = caps.positional.len().saturating_sub(pos_base);
-            // Look for inner subcaptures in positional_subcaps
+            // Look for inner subcaptures on the group's slot
             let subcap_idx = if new_count >= 1 {
                 pos_base
             } else {
-                caps.positional_subcaps.len()
+                caps.positional.len()
             };
-            let inner_positionals = if subcap_idx < caps.positional_subcaps.len() {
-                caps.positional_subcaps[subcap_idx]
-                    .as_ref()
-                    .map(|sc| &sc.kids().positional)
-            } else {
-                None
+            let inner_positionals = caps
+                .positional
+                .get(subcap_idx)
+                .and_then(|slot| slot.subcap.as_ref())
+                .map(|sc| &sc.kids().positional);
+            // The inner slots' text derives from their spans through the same
+            // `chars` this pattern level is matching against (ADR-0016 P4).
+            let slot_text = |slot: &PosSlot| -> String {
+                let a = slot.from.min(chars.len());
+                let b = slot.to.min(chars.len()).max(a);
+                chars[a..b].iter().collect()
             };
             if let Some(inner) = inner_positionals {
                 if inner.len() >= 2 {
                     // Two+ inner subcaptures: first = key, second = value
-                    (inner[0].clone(), Some(inner[1].clone()))
+                    (slot_text(&inner[0]), Some(slot_text(&inner[1])))
                 } else if inner.len() == 1 {
                     // One inner subcapture: it is the key, no value
-                    (inner[0].clone(), None)
+                    (slot_text(&inner[0]), None)
                 } else {
                     // No inner subcaptures in subcaps: use matched text
                     let k: String = chars[from..to].iter().collect();

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -378,16 +378,22 @@ impl Interpreter {
                 stripped_min
             };
             for start in search_start..=stripped_chars.len() {
-                if let Some((end, caps)) = self.regex_match_end_from_caps_in_pkg(
+                if let Some((end, mut caps)) = self.regex_match_end_from_caps_in_pkg(
                     &stripped_parsed,
                     &stripped_chars,
                     start,
                     &pkg,
                 ) {
+                    // Remap the capture spans back to original-subject space so
+                    // the derived texts keep their combining marks (pre-P4 the
+                    // stored text axis returned mark-stripped text here).
+                    for slot in caps.positional.iter_mut() {
+                        super::regex_helpers::remap_pos_slot(slot, &pos_map, orig_len, 0);
+                    }
                     return Some((
                         map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len),
                         map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len),
-                        caps.positional,
+                        super::regex_helpers::pos_slot_texts(&caps.positional, &orig_chars),
                     ));
                 }
             }
@@ -407,7 +413,7 @@ impl Interpreter {
                 return Some((
                     caps.capture_start.unwrap_or(start),
                     caps.capture_end.unwrap_or(end),
-                    caps.positional,
+                    super::regex_helpers::pos_slot_texts(&caps.positional, &orig_chars),
                 ));
             }
         }

--- a/src/runtime/regex/regex_match_sep.rs
+++ b/src/runtime/regex/regex_match_sep.rs
@@ -400,48 +400,39 @@ impl Interpreter {
         sep_stride: usize,
     ) {
         // Positional captures: atom groups occupy the first `atom_stride` slots,
-        // separator groups the next `sep_stride`.
-        for g in 0..atom_stride {
+        // separator groups the next `sep_stride`. The folded slot keeps the
+        // last iteration's span/subcap as its representative values.
+        let fold_group = |sources: &[&RegexCaptures], g: usize| -> PosSlot {
             let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
-            let mut last_text = String::new();
-            let mut last_sub: Option<std::sync::Arc<CapNode>> = None;
-            for ac in atom_caps {
-                if let Some(text) = ac.positional.get(g) {
-                    let (from, to) = ac.positional_offsets.get(g).copied().unwrap_or((0, 0));
-                    let sub = ac.positional_subcaps.get(g).cloned().flatten();
-                    list.push((from, to, sub.clone()));
-                    last_text = text.clone();
-                    last_sub = sub;
+            for src in sources {
+                if let Some(slot) = src.positional.get(g) {
+                    list.push((slot.from, slot.to, slot.subcap.clone()));
                 }
             }
-            let last_span = list.last().map(|(a, b, _)| (*a, *b)).unwrap_or((0, 0));
-            caps.positional.push(last_text);
-            caps.positional_subcaps.push(last_sub);
-            caps.positional_quantified.push(Some(list));
-            caps.positional_offsets.push(last_span);
+            let (from, to, subcap) = list
+                .last()
+                .map(|(a, b, sc)| (*a, *b, sc.clone()))
+                .unwrap_or((0, 0, None));
+            PosSlot {
+                from,
+                to,
+                subcap,
+                quantified: Some(list),
+                nil: false,
+            }
+        };
+        let atom_refs: Vec<&RegexCaptures> = atom_caps.iter().collect();
+        for g in 0..atom_stride {
+            let slot = fold_group(&atom_refs, g);
+            caps.positional.push(slot);
         }
         let mut all_sep: Vec<&RegexCaptures> = sep_caps.iter().collect();
         if let Some(ts) = trailing_sep {
             all_sep.push(ts);
         }
         for g in 0..sep_stride {
-            let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
-            let mut last_text = String::new();
-            let mut last_sub: Option<std::sync::Arc<CapNode>> = None;
-            for sc in &all_sep {
-                if let Some(text) = sc.positional.get(g) {
-                    let (from, to) = sc.positional_offsets.get(g).copied().unwrap_or((0, 0));
-                    let sub = sc.positional_subcaps.get(g).cloned().flatten();
-                    list.push((from, to, sub.clone()));
-                    last_text = text.clone();
-                    last_sub = sub;
-                }
-            }
-            let last_span = list.last().map(|(a, b, _)| (*a, *b)).unwrap_or((0, 0));
-            caps.positional.push(last_text);
-            caps.positional_subcaps.push(last_sub);
-            caps.positional_quantified.push(Some(list));
-            caps.positional_offsets.push(last_span);
+            let slot = fold_group(&all_sep, g);
+            caps.positional.push(slot);
         }
         // Named captures: merge every iteration's named captures (as arrays).
         for src in atom_caps.iter().chain(all_sep.iter().copied()) {

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -528,13 +528,22 @@ impl Interpreter {
 
     pub(super) fn make_regex_eval_env(&self, caps: &RegexCaptures) -> Env {
         let mut env = self.env.clone();
-        for (i, val) in caps.positional.iter().enumerate() {
-            env.insert(i.to_string(), Value::str(val.clone()));
+        // Mid-match capture texts derive from the engine-scope subject
+        // (ADR-0016 P4); the live accumulator's own `target` is unset.
+        let live_target = super::regex_helpers::current_match_target();
+        let slot_text = |slot: &crate::runtime::PosSlot| -> String {
+            live_target
+                .as_ref()
+                .map(|t| t.span_str(slot.from, slot.to))
+                .unwrap_or_default()
+        };
+        for (i, slot) in caps.positional.iter().enumerate() {
+            env.insert(i.to_string(), Value::str(slot_text(slot)));
         }
         let match_list: Vec<Value> = caps
             .positional
             .iter()
-            .map(|s| Value::str(s.clone()))
+            .map(|s| Value::str(slot_text(s)))
             .collect();
         env.insert("/".to_string(), Value::array(match_list));
         for (k, v) in &caps.named {

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -112,9 +112,6 @@ impl Interpreter {
             &caps.positional,
             &caps.named,
             &caps.named_subcaps,
-            &caps.positional_subcaps,
-            &caps.positional_quantified,
-            &caps.positional_nil,
             target,
             &caps.named_quantified,
         );
@@ -200,9 +197,6 @@ impl Interpreter {
             &[],
             &HashMap::new(),
             &HashMap::new(),
-            &[],
-            &[],
-            &[],
             MatchTarget::from_chars(chars),
             &HashSet::new(),
         );

--- a/src/runtime/regex/regex_trail.rs
+++ b/src/runtime/regex/regex_trail.rs
@@ -25,38 +25,23 @@ pub(super) enum MapId {
     HashCap,
 }
 
-/// Saved tails for a positional-block truncation (values moved out, moved
-/// back on rewind). Boxed to keep `Undo` small.
+/// Saved tail for a positional truncation (slots moved out, moved back on
+/// rewind). Boxed to keep `Undo` small.
 pub(super) struct PosTailRec {
-    p_at: usize,
-    p: Vec<String>,
-    sc_at: usize,
-    sc: Vec<Option<Arc<CapNode>>>,
-    q_at: usize,
-    q: Vec<Option<Vec<QuantifiedCaptureEntry>>>,
-    off_at: usize,
-    off: Vec<(usize, usize)>,
+    at: usize,
+    slots: Vec<PosSlot>,
 }
 
 pub(super) enum Undo {
-    /// Truncate the positional block back to these lengths (undoes appends).
-    PosLens {
-        p: usize,
-        sc: usize,
-        q: usize,
-        off: usize,
-        nil: usize,
-    },
-    /// Restore previously truncated positional tails (truncate to `*_at`,
-    /// then re-extend with the saved values).
+    /// Truncate the positional slots back to this length (undoes appends).
+    PosLen(usize),
+    /// Restore a previously truncated positional tail (truncate to `at`,
+    /// then re-extend with the saved slots).
     PosTail(Box<PosTailRec>),
-    /// Restore a single overwritten positional entry (`$N=` alias writes).
+    /// Restore a single overwritten positional slot (`$N=` alias writes).
     PosOverwrite {
         idx: usize,
-        text: Option<String>,
-        sc: Option<Option<Arc<CapNode>>>,
-        q: Option<Option<Vec<QuantifiedCaptureEntry>>>,
-        off: Option<(usize, usize)>,
+        slot: Box<PosSlot>,
     },
     /// Truncate `map[key]` to `len`; remove the key if it was newly created.
     MapVecTrunc {
@@ -122,50 +107,17 @@ impl CapStore {
             let rec = self.trail.pop().expect("trail entry");
             let caps = &mut self.caps;
             match rec {
-                Undo::PosLens { p, sc, q, off, nil } => {
-                    caps.positional.truncate(p);
-                    caps.positional_subcaps.truncate(sc);
-                    caps.positional_quantified.truncate(q);
-                    caps.positional_offsets.truncate(off);
-                    caps.positional_nil.truncate(nil);
+                Undo::PosLen(len) => {
+                    caps.positional.truncate(len);
                 }
                 Undo::PosTail(rec) => {
                     let r = *rec;
-                    caps.positional.truncate(r.p_at);
-                    caps.positional.extend(r.p);
-                    caps.positional_subcaps.truncate(r.sc_at);
-                    caps.positional_subcaps.extend(r.sc);
-                    caps.positional_quantified.truncate(r.q_at);
-                    caps.positional_quantified.extend(r.q);
-                    caps.positional_offsets.truncate(r.off_at);
-                    caps.positional_offsets.extend(r.off);
+                    caps.positional.truncate(r.at);
+                    caps.positional.extend(r.slots);
                 }
-                Undo::PosOverwrite {
-                    idx,
-                    text,
-                    sc,
-                    q,
-                    off,
-                } => {
-                    if let Some(text) = text
-                        && idx < caps.positional.len()
-                    {
-                        caps.positional[idx] = text;
-                    }
-                    if let Some(sc) = sc
-                        && idx < caps.positional_subcaps.len()
-                    {
-                        caps.positional_subcaps[idx] = sc;
-                    }
-                    if let Some(q) = q
-                        && idx < caps.positional_quantified.len()
-                    {
-                        caps.positional_quantified[idx] = q;
-                    }
-                    if let Some(off) = off
-                        && idx < caps.positional_offsets.len()
-                    {
-                        caps.positional_offsets[idx] = off;
+                Undo::PosOverwrite { idx, slot } => {
+                    if idx < caps.positional.len() {
+                        caps.positional[idx] = *slot;
                     }
                 }
                 Undo::MapVecTrunc {
@@ -223,16 +175,10 @@ impl CapStore {
         }
     }
 
-    /// Record the current positional-block lengths so appends since this point
-    /// can be undone by truncation.
+    /// Record the current positional length so appends since this point can
+    /// be undone by truncation.
     fn record_pos_lens(&mut self) {
-        self.trail.push(Undo::PosLens {
-            p: self.caps.positional.len(),
-            sc: self.caps.positional_subcaps.len(),
-            q: self.caps.positional_quantified.len(),
-            off: self.caps.positional_offsets.len(),
-            nil: self.caps.positional_nil.len(),
-        });
+        self.trail.push(Undo::PosLen(self.caps.positional.len()));
     }
 
     fn record_named_key(&mut self, key: &str) {
@@ -277,10 +223,9 @@ impl CapStore {
     /// Apply a candidate delta (a `RegexCaptures` built relative to an empty
     /// baseline) to the store, recording undo. Merges exactly the fields the
     /// old by-value merge paths handled: named/named_subcaps/named_quantified,
-    /// capture_alias_map, the positional block (incl. offsets), code_blocks,
-    /// hash_captures, regex_vars, capture markers, and sym.
-    /// `positional_nil`/`positional_slots` and the per-level metadata
-    /// (matched/from/to/match_from) are intentionally NOT merged.
+    /// capture_alias_map, the positional slots, code_blocks, hash_captures,
+    /// regex_vars, capture markers, and sym. `positional_slots` and the
+    /// per-level metadata (from/to/match_from) are intentionally NOT merged.
     pub(super) fn merge_delta(&mut self, mut delta: RegexCaptures) {
         for (k, v) in delta.named.drain() {
             self.record_named_key(&k);
@@ -296,22 +241,9 @@ impl CapStore {
         for (k, v) in delta.capture_alias_map.drain() {
             self.insert_alias(k, v);
         }
-        if !delta.positional.is_empty()
-            || !delta.positional_subcaps.is_empty()
-            || !delta.positional_quantified.is_empty()
-            || !delta.positional_offsets.is_empty()
-        {
+        if !delta.positional.is_empty() {
             self.record_pos_lens();
             self.caps.positional.append(&mut delta.positional);
-            self.caps
-                .positional_subcaps
-                .append(&mut delta.positional_subcaps);
-            self.caps
-                .positional_quantified
-                .append(&mut delta.positional_quantified);
-            self.caps
-                .positional_offsets
-                .append(&mut delta.positional_offsets);
         }
         if !delta.code_blocks.is_empty() {
             self.trail
@@ -378,90 +310,34 @@ impl CapStore {
             .push(entry);
     }
 
-    /// Append one positional entry (text + subcap + quantified + offsets).
-    pub(super) fn push_positional(
-        &mut self,
-        text: String,
-        subcap: Option<Arc<CapNode>>,
-        quantified: Option<Vec<QuantifiedCaptureEntry>>,
-        offsets: (usize, usize),
-    ) {
+    /// Append one positional slot.
+    pub(super) fn push_positional(&mut self, slot: PosSlot) {
         self.record_pos_lens();
-        self.caps.positional.push(text);
-        self.caps.positional_subcaps.push(subcap);
-        self.caps.positional_quantified.push(quantified);
-        self.caps.positional_offsets.push(offsets);
+        self.caps.positional.push(slot);
     }
 
-    /// Truncate the positional text/subcap/quantified vecs to `to`, saving the
-    /// removed tails so rewind can restore them (the `$<name>=(...)` alias
-    /// surgery drops the group's auto-positional entry). `positional_offsets`
-    /// is left untouched, mirroring the old named-alias path.
-    pub(super) fn truncate_positional_3(&mut self, to: usize) {
-        let p = split_off_clamped(&mut self.caps.positional, to);
-        let sc = split_off_clamped(&mut self.caps.positional_subcaps, to);
-        let q = split_off_clamped(&mut self.caps.positional_quantified, to);
+    /// Truncate the positional slots to `to`, saving the removed tail so
+    /// rewind can restore it (the `$<name>=(...)` / `$N=` alias surgery drops
+    /// the group's auto-positional entry).
+    pub(super) fn truncate_positional(&mut self, to: usize) {
+        let slots = split_off_clamped(&mut self.caps.positional, to);
         self.trail.push(Undo::PosTail(Box::new(PosTailRec {
-            p_at: self.caps.positional.len(),
-            p,
-            sc_at: self.caps.positional_subcaps.len(),
-            sc,
-            q_at: self.caps.positional_quantified.len(),
-            q,
-            off_at: self.caps.positional_offsets.len(),
-            off: Vec::new(),
+            at: self.caps.positional.len(),
+            slots,
         })));
     }
 
-    /// Truncate all four positional vecs to `to` (the `$N=` alias path).
-    pub(super) fn truncate_positional_4(&mut self, to: usize) {
-        let p = split_off_clamped(&mut self.caps.positional, to);
-        let sc = split_off_clamped(&mut self.caps.positional_subcaps, to);
-        let q = split_off_clamped(&mut self.caps.positional_quantified, to);
-        let off = split_off_clamped(&mut self.caps.positional_offsets, to);
-        self.trail.push(Undo::PosTail(Box::new(PosTailRec {
-            p_at: self.caps.positional.len(),
-            p,
-            sc_at: self.caps.positional_subcaps.len(),
-            sc,
-            q_at: self.caps.positional_quantified.len(),
-            q,
-            off_at: self.caps.positional_offsets.len(),
-            off,
-        })));
-    }
-
-    /// Overwrite the positional entry at `idx` (`$N=` re-assigning an existing
-    /// slot), saving the previous values.
-    pub(super) fn overwrite_positional(&mut self, idx: usize, text: String, off: (usize, usize)) {
+    /// Overwrite the positional slot at `idx` (`$N=` re-assigning an existing
+    /// slot), saving the previous value.
+    pub(super) fn overwrite_positional(&mut self, idx: usize, slot: PosSlot) {
         let caps = &mut self.caps;
-        let prev_text = if idx < caps.positional.len() {
-            Some(std::mem::replace(&mut caps.positional[idx], text))
-        } else {
-            None
-        };
-        let prev_off = if idx < caps.positional_offsets.len() {
-            Some(std::mem::replace(&mut caps.positional_offsets[idx], off))
-        } else {
-            None
-        };
-        let prev_sc = if idx < caps.positional_subcaps.len() {
-            Some(caps.positional_subcaps[idx].take())
-        } else {
-            None
-        };
-        let prev_q = if idx < caps.positional_quantified.len() {
-            Some(caps.positional_quantified[idx].take())
-        } else {
-            None
-        };
-        self.trail.push(Undo::PosOverwrite {
-            idx,
-            text: prev_text,
-            sc: prev_sc,
-            q: prev_q,
-            off: prev_off,
-        });
+        if idx < caps.positional.len() {
+            let prev = std::mem::replace(&mut caps.positional[idx], slot);
+            self.trail.push(Undo::PosOverwrite {
+                idx,
+                slot: Box::new(prev),
+            });
+        }
     }
 
     /// Trailed `reserve_nil_capture_slots` (unmatched `(x)?` Nil reservation).
@@ -478,32 +354,16 @@ impl CapStore {
         if stride == 0 {
             return;
         }
-        // Save the whole tail from base_len (clamped per vec) so rewind can
-        // restore the unfolded state exactly, including the padding fold adds.
-        let p = split_off_clamped(&mut self.caps.positional, base_len);
-        let sc = split_off_clamped(&mut self.caps.positional_subcaps, base_len);
-        let q = split_off_clamped(&mut self.caps.positional_quantified, base_len);
-        let off = split_off_clamped(&mut self.caps.positional_offsets, base_len);
+        // Save the whole tail from base_len so rewind can restore the
+        // unfolded state exactly, then re-extend with clones for fold to
+        // consume. Rewind truncates to the cut point (removing whatever fold
+        // produced above it) and re-extends the saved tail.
+        let slots = split_off_clamped(&mut self.caps.positional, base_len);
         let rec = PosTailRec {
-            p_at: self.caps.positional.len(),
-            p,
-            sc_at: self.caps.positional_subcaps.len(),
-            sc,
-            q_at: self.caps.positional_quantified.len(),
-            q,
-            off_at: self.caps.positional_offsets.len(),
-            off,
+            at: self.caps.positional.len(),
+            slots,
         };
-        // Re-extend with clones for fold to consume; the saved originals are
-        // the undo. Rewind truncates each vec to its `*_at` cut point (removing
-        // whatever fold produced above it) and re-extends the saved tail,
-        // restoring the exact unfolded state.
-        self.caps.positional.extend(rec.p.iter().cloned());
-        self.caps.positional_subcaps.extend(rec.sc.iter().cloned());
-        self.caps
-            .positional_quantified
-            .extend(rec.q.iter().cloned());
-        self.caps.positional_offsets.extend(rec.off.iter().cloned());
+        self.caps.positional.extend(rec.slots.iter().cloned());
         self.trail.push(Undo::PosTail(Box::new(rec)));
         super::regex_helpers::fold_quantified_captures(&mut self.caps, base_len, stride);
     }
@@ -520,15 +380,12 @@ fn split_off_clamped<T>(v: &mut Vec<T>, at: usize) -> Vec<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::RegexCaptures;
+    use super::super::super::{PosSlot, RegexCaptures};
     use super::CapStore;
 
     fn store_with_base() -> CapStore {
         let mut init = RegexCaptures::default();
-        init.positional.push("a".to_string());
-        init.positional_subcaps.push(None);
-        init.positional_quantified.push(None);
-        init.positional_offsets.push((0, 1));
+        init.positional.push(PosSlot::span(0, 1));
         init.named
             .entry("x".to_string())
             .or_default()
@@ -537,8 +394,14 @@ mod tests {
     }
 
     fn assert_base(store: &CapStore) {
-        assert_eq!(store.caps().positional, vec!["a".to_string()]);
-        assert_eq!(store.caps().positional_offsets, vec![(0, 1)]);
+        assert_eq!(store.caps().positional.len(), 1);
+        assert_eq!(
+            (
+                store.caps().positional[0].from,
+                store.caps().positional[0].to
+            ),
+            (0, 1)
+        );
         assert_eq!(store.caps().named.len(), 1);
         assert_eq!(store.caps().named["x"], vec!["v".to_string()]);
         assert!(store.caps().named_subcaps.is_empty());
@@ -551,10 +414,7 @@ mod tests {
         let mut store = store_with_base();
         let m = store.mark();
         let mut delta = RegexCaptures::default();
-        delta.positional.push("b".to_string());
-        delta.positional_subcaps.push(None);
-        delta.positional_quantified.push(None);
-        delta.positional_offsets.push((1, 2));
+        delta.positional.push(PosSlot::span(1, 2));
         delta
             .named
             .entry("x".to_string())
@@ -584,12 +444,18 @@ mod tests {
     fn truncate_and_overwrite_rewind() {
         let mut store = store_with_base();
         let m = store.mark();
-        store.push_positional("b".to_string(), None, None, (1, 2));
-        store.truncate_positional_4(0);
+        store.push_positional(PosSlot::span(1, 2));
+        store.truncate_positional(0);
         assert!(store.caps().positional.is_empty());
-        store.push_positional("c".to_string(), None, None, (5, 6));
-        store.overwrite_positional(0, "z".to_string(), (9, 9));
-        assert_eq!(store.caps().positional, vec!["z".to_string()]);
+        store.push_positional(PosSlot::span(5, 6));
+        store.overwrite_positional(0, PosSlot::span(9, 9));
+        assert_eq!(
+            (
+                store.caps().positional[0].from,
+                store.caps().positional[0].to
+            ),
+            (9, 9)
+        );
         store.rewind(m);
         assert_base(&store);
     }
@@ -599,16 +465,22 @@ mod tests {
         let mut store = store_with_base();
         let m = store.mark();
         // Two iterations of a 1-stride capture: entries at idx 1 and 2.
-        store.push_positional("b".to_string(), None, None, (1, 2));
-        store.push_positional("c".to_string(), None, None, (2, 3));
+        store.push_positional(PosSlot::span(1, 2));
+        store.push_positional(PosSlot::span(2, 3));
         let mf = store.mark();
         store.fold_quantified(1, 1);
         assert_eq!(store.caps().positional.len(), 2); // folded into one slot
-        assert!(store.caps().positional_quantified[1].is_some());
+        assert!(store.caps().positional[1].quantified.is_some());
         store.rewind(mf);
         assert_eq!(store.caps().positional.len(), 3);
-        assert_eq!(store.caps().positional[2], "c");
-        assert!(store.caps().positional_quantified[2].is_none());
+        assert_eq!(
+            (
+                store.caps().positional[2].from,
+                store.caps().positional[2].to
+            ),
+            (2, 3)
+        );
+        assert!(store.caps().positional[2].quantified.is_none());
         store.rewind(m);
         assert_base(&store);
     }

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -42,6 +42,39 @@ pub(crate) struct CodeBlockContext {
 /// goes through `Arc::make_mut`, which is free while the entry is still unshared.
 pub(crate) type QuantifiedCaptureEntry = (usize, usize, Option<Arc<CapNode>>);
 
+/// One positional capture slot (ADR-0016 P4) — the collapse of the five
+/// parallel positional vectors (`positional` text ‖ `positional_subcaps` ‖
+/// `positional_quantified` ‖ `positional_offsets` ‖ `positional_nil`) into a
+/// single axis. The captured text derives from the span through the shared
+/// subject; the alignment invariants the parallel vectors asserted in comments
+/// are now structural.
+#[derive(Clone, Default)]
+pub(crate) struct PosSlot {
+    /// The recorded span (char offsets, absolute in the engine's subject).
+    pub(crate) from: usize,
+    pub(crate) to: usize,
+    /// Inner captures from a nested group's own pattern run.
+    pub(crate) subcap: Option<Arc<CapNode>>,
+    /// When the group was quantified (e.g. `(\w)+`), all iteration matches;
+    /// the slot then renders as an Array of Match objects. `Some(vec![])`
+    /// marks a zero-iteration quantified capture (renders as an empty list).
+    pub(crate) quantified: Option<Vec<QuantifiedCaptureEntry>>,
+    /// An *unmatched optional* capture (`(x)?` that matched zero times),
+    /// rendered as `Nil` rather than an empty Match.
+    pub(crate) nil: bool,
+}
+
+impl PosSlot {
+    /// A plain matched slot: span only.
+    pub(crate) fn span(from: usize, to: usize) -> Self {
+        PosSlot {
+            from,
+            to,
+            ..Default::default()
+        }
+    }
+}
+
 /// Prefix marking a `named_subcaps` entry as a *silent action capture*: the
 /// match of a silent subrule (`<.foo>`) that is hidden from `.hash` but whose
 /// grammar action method (and its descendants') must still fire. The prefix is a
@@ -84,10 +117,10 @@ pub(crate) struct CapChildren {
     pub(crate) named_subcaps: HashMap<String, Vec<Arc<CapNode>>>,
     pub(crate) named_quantified: HashSet<String>,
     pub(crate) capture_alias_map: HashMap<String, String>,
-    pub(crate) positional: Vec<String>,
-    pub(crate) positional_subcaps: Vec<Option<Arc<CapNode>>>,
-    pub(crate) positional_quantified: Vec<Option<Vec<QuantifiedCaptureEntry>>>,
-    pub(crate) positional_nil: Vec<bool>,
+    /// Positional captures as span-bearing slots (ADR-0016 P4). Unlike the
+    /// pre-P4 parallel vectors, the span survives onto the stored node — the
+    /// text-only leaf fallback (fabricated `0..len` offsets) is gone.
+    pub(crate) positional: Vec<PosSlot>,
     /// Inline `{ … }` code blocks recorded on this node, run once at reduce time.
     pub(crate) code_blocks: Vec<CodeBlockContext>,
     /// What this rule's own `:my $*x` declarations held at this match's reduce
@@ -134,6 +167,11 @@ impl RegexCaptures {
             .unwrap_or_default()
     }
 
+    /// A positional slot's text through the published subject (ADR-0016 P4).
+    pub(crate) fn slot_text(&self, slot: &PosSlot) -> String {
+        self.span_text(slot.from, slot.to)
+    }
+
     /// Convert this accumulator into the immutable stored node it describes
     /// (ADR-0016 P2). Consumes the accumulator; drops the accumulator-only
     /// fields nothing reads through a stored node (`hash_captures`,
@@ -145,9 +183,6 @@ impl RegexCaptures {
             || !self.named_quantified.is_empty()
             || !self.capture_alias_map.is_empty()
             || !self.positional.is_empty()
-            || !self.positional_subcaps.is_empty()
-            || !self.positional_quantified.is_empty()
-            || !self.positional_nil.is_empty()
             || !self.code_blocks.is_empty()
             || !self.regex_vars.is_empty();
         let children = has_children.then(|| {
@@ -157,9 +192,6 @@ impl RegexCaptures {
                 named_quantified: self.named_quantified,
                 capture_alias_map: self.capture_alias_map,
                 positional: self.positional,
-                positional_subcaps: self.positional_subcaps,
-                positional_quantified: self.positional_quantified,
-                positional_nil: self.positional_nil,
                 code_blocks: self.code_blocks,
                 regex_vars: self.regex_vars,
             })
@@ -181,25 +213,14 @@ pub(crate) struct RegexCaptures {
     /// Nested sub-captures for named subrule matches. Key is capture name,
     /// value is inner captures from the subrule (parallel to entries in `named`).
     pub(crate) named_subcaps: HashMap<String, Vec<Arc<CapNode>>>,
-    pub(crate) positional: Vec<String>,
-    /// Nested sub-captures for positional capture groups. Each entry corresponds
-    /// to the same index in `positional` and holds inner captures from nested groups.
-    pub(crate) positional_subcaps: Vec<Option<Arc<CapNode>>>,
-    /// When a capture group is quantified (e.g. `(\w)+`), this parallel vec
-    /// stores the list of all iteration matches for that positional index.
-    /// When `Some`, the positional slot should be rendered as an Array of Match objects.
-    pub(crate) positional_quantified: Vec<Option<Vec<QuantifiedCaptureEntry>>>,
-    /// Character offsets (start, end) for each entry in `positional`.
-    pub(crate) positional_offsets: Vec<(usize, usize)>,
-    /// Marks a positional slot as an *unmatched optional* capture (`(x)?` that
-    /// matched zero times) which must render as `Nil` (not an empty Match). Only
-    /// the zero-match reservation arms set entries here; they pad with `false` up
-    /// to the current `positional` length before pushing `true`, so matched
-    /// captures (which never touch this vec) stay aligned. The Match builder reads
-    /// it via `.get(i)` — a missing/`false` entry renders normally.
-    pub(crate) positional_nil: Vec<bool>,
+    /// Positional captures as span-bearing slots (ADR-0016 P4): span, nested
+    /// subcaptures, quantified iteration lists, and the Nil marker in one axis.
+    pub(crate) positional: Vec<PosSlot>,
     /// Unnamed capture slots by capture index (for $0, $1, ...) as recorded
-    /// spans, where `None` represents an unmatched capture.
+    /// spans, where `None` represents an unmatched capture. A separate
+    /// numbering axis from `positional` (it has `None` holes where
+    /// `positional` has no entry at all); written only by the pcre2/`:P5`
+    /// path.
     pub(crate) positional_slots: Vec<Option<(usize, usize)>>,
     pub(crate) from: usize,
     pub(crate) to: usize,

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -47,15 +47,7 @@ impl Interpreter {
             captures
                 .positional
                 .iter()
-                .enumerate()
-                .map(|(i, s)| {
-                    let (from, to) = captures
-                        .positional_offsets
-                        .get(i)
-                        .copied()
-                        .unwrap_or((0, s.chars().count()));
-                    make_capture_match(s, from, to)
-                })
+                .map(|slot| make_capture_match(&captures.slot_text(slot), slot.from, slot.to))
                 .collect()
         };
         attrs.insert("list".to_string(), Value::array(positional));
@@ -287,17 +279,16 @@ impl Interpreter {
                     &c.positional,
                     &c.named,
                     &c.named_subcaps,
-                    &c.positional_subcaps,
-                    &c.positional_quantified,
-                    &c.positional_nil,
                     c.target_or_new(orig),
                 )
             })
             .collect::<Vec<_>>();
         self.env.insert("/".to_string(), Value::array(slash_list));
         if let Some(first) = selected.first() {
+            let t = first.target_or_new(orig);
             for (i, cap) in first.positional.iter().enumerate() {
-                self.env.insert(i.to_string(), Value::str(cap.clone()));
+                self.env
+                    .insert(i.to_string(), Value::str(t.span_str(cap.from, cap.to)));
             }
         }
     }
@@ -429,10 +420,8 @@ impl Interpreter {
         for idx in 1..locs.len() {
             if names.get(idx).is_some_and(Option::is_none) {
                 if let Some((start, end)) = locs.get(idx) {
-                    let captured = text.get(start..end)?.to_string();
                     let (cs, ce) = (to_char(start), to_char(end));
-                    out.positional.push(captured);
-                    out.positional_offsets.push((cs, ce));
+                    out.positional.push(crate::runtime::PosSlot::span(cs, ce));
                     out.positional_slots.push(Some((cs, ce)));
                 } else {
                     out.positional_slots.push(None);
@@ -484,12 +473,11 @@ impl Interpreter {
             for idx in 1..locs.len() {
                 if names.get(idx).is_some_and(Option::is_none) {
                     if let Some((c_start, c_end)) = locs.get(idx) {
-                        let Some(captured) = text.get(c_start..c_end) else {
+                        if text.get(c_start..c_end).is_none() {
                             continue;
-                        };
-                        item.positional.push(captured.to_string());
+                        }
                         let (cs, ce) = (to_char(c_start), to_char(c_end));
-                        item.positional_offsets.push((cs, ce));
+                        item.positional.push(crate::runtime::PosSlot::span(cs, ce));
                         item.positional_slots.push(Some((cs, ce)));
                     } else {
                         item.positional_slots.push(None);

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -245,16 +245,18 @@ impl Interpreter {
                     if let Some(mut captures) = self.regex_match_with_captures(&pat, &text) {
                         // Set positional captures before executing code blocks
                         for (i, v) in captures.positional.iter().enumerate() {
-                            self.env.insert(i.to_string(), Value::str(v.clone()));
+                            self.env
+                                .insert(i.to_string(), Value::str(captures.slot_text(v)));
                         }
                         // Reduce-time inline actions (children first).
                         let starget = captures.target_or_new(&text);
                         self.reduce_regex_captures_made(&mut captures, Some(&starget));
-                        let match_obj = Value::make_match_object_with_captures(
+                        let match_obj = Value::make_match_object_full(
                             captures.from as i64,
                             captures.to as i64,
                             &captures.positional,
                             &captures.named,
+                            &HashMap::new(),
                             starget,
                         );
                         self.env.insert("/".to_string(), match_obj);
@@ -330,11 +332,12 @@ impl Interpreter {
                                 junc_values.push(Value::NIL);
                             } else {
                                 let cap = &non_overlapping[idx - 1];
-                                let match_obj = Value::make_match_object_with_captures(
+                                let match_obj = Value::make_match_object_full(
                                     cap.from as i64,
                                     cap.to as i64,
                                     &cap.positional,
                                     &cap.named,
+                                    &HashMap::new(),
                                     cap.target_or_new(&text),
                                 );
                                 junc_values.push(match_obj);
@@ -709,7 +712,8 @@ impl Interpreter {
                     }
                     // Set positional captures as strings first (needed by code blocks)
                     for (i, v) in captures.positional.iter().enumerate() {
-                        self.env.insert(i.to_string(), Value::str(v.clone()));
+                        self.env
+                            .insert(i.to_string(), Value::str(captures.slot_text(v)));
                     }
                     // Clear any previous `made` value before executing code blocks
                     self.env.remove("made");
@@ -732,9 +736,6 @@ impl Interpreter {
                         &captures.positional,
                         &named_with_hash,
                         &captures.named_subcaps,
-                        &captures.positional_subcaps,
-                        &captures.positional_quantified,
-                        &captures.positional_nil,
                         starget,
                         &captures.named_quantified,
                     );

--- a/src/value/match_lazy.rs
+++ b/src/value/match_lazy.rs
@@ -130,13 +130,12 @@ impl MatchNode {
         let pos_vals: Vec<Value> = kids
             .positional
             .iter()
-            .enumerate()
-            .map(|(i, s)| {
+            .map(|slot| {
                 // An unmatched optional capture (`(x)?` zero match) renders as Nil.
-                if kids.positional_nil.get(i) == Some(&true) {
+                if slot.nil {
                     return Value::Nil;
                 }
-                if let Some(Some(qlist)) = kids.positional_quantified.get(i) {
+                if let Some(qlist) = &slot.quantified {
                     let arr: Vec<Value> = qlist
                         .iter()
                         .map(|(qfrom, qto, subcap)| {
@@ -148,10 +147,13 @@ impl MatchNode {
                         .collect();
                     return Value::array(arr);
                 }
-                if let Some(Some(subcap)) = kids.positional_subcaps.get(i) {
+                if let Some(subcap) = &slot.subcap {
                     return self.lazy_child(subcap);
                 }
-                text_leaf_match(s, &self.target)
+                // ADR-0016 P4: every slot carries its span, so a subcap-less
+                // leaf renders with its REAL offsets (pre-P4 this was the
+                // text-only fallback with fabricated `0..len`).
+                span_leaf_match(slot.from, slot.to, &self.target)
             })
             .collect();
 
@@ -167,7 +169,7 @@ impl MatchNode {
                     {
                         return self.lazy_child(sc);
                     }
-                    text_leaf_match(s, &self.target)
+                    Value::text_leaf_match(s, &self.target)
                 })
                 .collect();
             if vals.len() == 1 && !kids.named_quantified.contains(key) {
@@ -249,22 +251,25 @@ fn span_leaf_match(from: usize, to: usize, target: &MatchTarget) -> Value {
     Value::make_instance(match_class_symbol(), attrs)
 }
 
-/// Eager leaf Match for a TEXT-ONLY capture entry (no stored `CapNode`).
-/// Survives only for text-axis entries with no aligned span carrier — every
-/// leaf the matcher stores today carries a span-bearing `CapNode`, so this
-/// fires only on exploded-builder callers that still pass bare text. The
-/// span is unrecoverable here (P3 retired the position search), so it is
-/// reported as `0..chars` of the captured text itself.
-fn text_leaf_match(s: &str, target: &MatchTarget) -> Value {
-    crate::vm::vm_stats::record_regex_match_leaf(true);
-    let mut attrs = AttrMap::new();
-    attrs.insert("str", Value::str(s.to_string()));
-    attrs.insert("from", Value::Int(0));
-    attrs.insert("to", Value::Int(s.chars().count() as i64));
-    attrs.insert("list", Value::array(Vec::new()));
-    attrs.insert("named", Value::hash(HashMap::new()));
-    attrs.insert("orig", Value::str_arc(Arc::clone(target.text())));
-    Value::make_instance(match_class_symbol(), attrs)
+impl Value {
+    /// Eager leaf Match for a TEXT-ONLY capture entry (no recorded span).
+    /// ADR-0016 P4 removed the stored text axis, so the matcher never
+    /// produces these; it survives only for the exploded text-carrier builder
+    /// (`make_match_object_with_captures`) whose sources (transliteration
+    /// callbacks, code-block snapshots) genuinely have no offsets. The span
+    /// is unrecoverable here, so it is reported as `0..chars` of the captured
+    /// text itself.
+    pub(crate) fn text_leaf_match(s: &str, target: &MatchTarget) -> Value {
+        crate::vm::vm_stats::record_regex_match_leaf(true);
+        let mut attrs = AttrMap::new();
+        attrs.insert("str", Value::str(s.to_string()));
+        attrs.insert("from", Value::Int(0));
+        attrs.insert("to", Value::Int(s.chars().count() as i64));
+        attrs.insert("list", Value::array(Vec::new()));
+        attrs.insert("named", Value::hash(HashMap::new()));
+        attrs.insert("orig", Value::str_arc(Arc::clone(target.text())));
+        Value::make_instance(match_class_symbol(), attrs)
+    }
 }
 
 impl Value {

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -570,24 +570,27 @@ impl Value {
         Value::make_instance(Symbol::intern("Instant"), attrs)
     }
 
-    /// Create a Match object with positional captures.
+    /// Create a Match object from TEXT-ONLY positional captures (no spans).
+    /// The exploded-builder convenience for carriers that never recorded
+    /// offsets (transliteration callbacks, code-block snapshots); each text
+    /// renders as an eager leaf Match reporting `0..len`, same as pre-P4.
+    /// Span-bearing callers use `make_match_object_full` instead.
     pub(crate) fn make_match_object_with_captures(
         from: i64,
         to: i64,
-        positional: &[String],
+        positional_texts: &[String],
         named: &HashMap<String, Vec<String>>,
         target: crate::runtime::MatchTarget,
     ) -> Self {
-        Self::make_match_object_full(
-            from,
-            to,
-            positional,
-            named,
-            &HashMap::new(),
-            &[],
-            &[],
-            &[],
-            target,
-        )
+        let m = Self::make_match_object_full(from, to, &[], named, &HashMap::new(), target.clone());
+        if positional_texts.is_empty() {
+            return m;
+        }
+        let list: Vec<Value> = positional_texts
+            .iter()
+            .map(|s| Value::text_leaf_match(s, &target))
+            .collect();
+        m.match_with_attrs(vec![("list", Value::array(list))])
+            .unwrap_or(m)
     }
 }

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -6,12 +6,9 @@ impl Value {
     pub(crate) fn make_match_object_full(
         from: i64,
         to: i64,
-        positional: &[String],
+        positional: &[crate::runtime::PosSlot],
         named: &HashMap<String, Vec<String>>,
         named_subcaps: &HashMap<String, Vec<std::sync::Arc<crate::runtime::CapNode>>>,
-        positional_subcaps: &[Option<std::sync::Arc<crate::runtime::CapNode>>],
-        positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
-        positional_nil: &[bool],
         target: crate::runtime::MatchTarget,
     ) -> Self {
         Self::make_match_object_full_q(
@@ -20,9 +17,6 @@ impl Value {
             positional,
             named,
             named_subcaps,
-            positional_subcaps,
-            positional_quantified,
-            positional_nil,
             target,
             &HashSet::new(),
         )
@@ -31,35 +25,29 @@ impl Value {
     /// Like make_match_object_full but with named_quantified tracking.
     ///
     /// ADR-0016 P5: this no longer builds an eager `Instance` tree. It
-    /// synthesizes a top-level `CapNode` from the exploded capture axes and
+    /// synthesizes a top-level `CapNode` from the capture axes and
     /// returns a lazy `Match` value (`ValueRepr::Match`); the Instance-shaped
     /// attribute map materializes on first observation, one level at a time
     /// (see `value::match_lazy`). The synthesized top node deliberately
     /// carries no `sym`/`action_name`/`ast`/`regex_vars`/`capture_alias_map`
     /// — the pre-P5 builder never surfaced those on the top-level Match.
     ///
-    /// ADR-0016 P3: matched text is not passed or stored; `.Str` derives
-    /// from the span through `target`.
+    /// ADR-0016 P3/P4: matched text is not passed or stored; `.Str` and every
+    /// positional capture derive from recorded spans through `target`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn make_match_object_full_q(
         from: i64,
         to: i64,
-        positional: &[String],
+        positional: &[crate::runtime::PosSlot],
         named: &HashMap<String, Vec<String>>,
         named_subcaps: &HashMap<String, Vec<std::sync::Arc<crate::runtime::CapNode>>>,
-        positional_subcaps: &[Option<std::sync::Arc<crate::runtime::CapNode>>],
-        positional_quantified: &[Option<Vec<crate::runtime::QuantifiedCaptureEntry>>],
-        positional_nil: &[bool],
         target: crate::runtime::MatchTarget,
         named_quantified: &HashSet<String>,
     ) -> Self {
         let has_children = !named.is_empty()
             || !named_subcaps.is_empty()
             || !named_quantified.is_empty()
-            || !positional.is_empty()
-            || !positional_subcaps.is_empty()
-            || !positional_quantified.is_empty()
-            || !positional_nil.is_empty();
+            || !positional.is_empty();
         let children = has_children.then(|| {
             Box::new(crate::runtime::CapChildren {
                 named: named.clone(),
@@ -67,9 +55,6 @@ impl Value {
                 named_quantified: named_quantified.clone(),
                 capture_alias_map: HashMap::new(),
                 positional: positional.to_vec(),
-                positional_subcaps: positional_subcaps.to_vec(),
-                positional_quantified: positional_quantified.to_vec(),
-                positional_nil: positional_nil.to_vec(),
                 code_blocks: Vec::new(),
                 regex_vars: HashMap::new(),
             })

--- a/src/vm/vm_native_subst.rs
+++ b/src/vm/vm_native_subst.rs
@@ -163,15 +163,11 @@ impl Interpreter {
         // single match).
         let target = crate::runtime::MatchTarget::new(text);
         let make_match = |start: usize, end: usize, caps: &[String]| {
-            Value::make_match_object_full(
+            Value::make_match_object_with_captures(
                 start as i64,
                 end as i64,
                 caps,
                 &HashMap::new(),
-                &HashMap::new(),
-                &[],
-                &[],
-                &[],
                 target.clone(),
             )
         };

--- a/src/vm/vm_subst_apply.rs
+++ b/src/vm/vm_subst_apply.rs
@@ -11,15 +11,11 @@ impl Interpreter {
         end: usize,
         positional: &[String],
     ) -> Value {
-        Value::make_match_object_full(
+        Value::make_match_object_with_captures(
             start as i64,
             end as i64,
             positional,
             &std::collections::HashMap::new(),
-            &std::collections::HashMap::new(),
-            &[],
-            &[],
-            &[],
             crate::runtime::MatchTarget::new(text),
         )
     }
@@ -261,15 +257,11 @@ impl Interpreter {
                 .unwrap_or(&[]);
             // Bind `$/` to a Match object for this match, and `$0`, `$1`, ...
             // to the positional captures.
-            let match_obj = Value::make_match_object_full(
+            let match_obj = Value::make_match_object_with_captures(
                 *start as i64,
                 *end as i64,
                 caps,
                 &std::collections::HashMap::new(),
-                &std::collections::HashMap::new(),
-                &[],
-                &[],
-                &[],
                 crate::runtime::MatchTarget::new(text),
             );
             self.env_mut().insert("/".to_string(), match_obj);


### PR DESCRIPTION
Replace the five parallel positional collections (text / subcaps /
quantified / offsets / nil) on both RegexCaptures and CapChildren with a
single Vec<PosSlot> { from, to, subcap, quantified, nil }:

- The span now survives onto stored capture nodes (positional_offsets was
  dropped by into_cap_node), so subcap-less positional leaves render with
  their REAL .from/.to instead of the fabricated 0..len of the retired
  text-leaf fallback.
- The stored positional text axis is gone; every reader derives text from
  the recorded span through the shared MatchTarget / engine chars.
- Backrefs ($0 / $<name> positional side) compare spans against the
  engine's chars directly - alloc-free, same space as the match.
- Trail undo vocabulary shrinks: PosLens{5 lengths} -> PosLen(len),
  4-vec PosTailRec -> one slot vec, per-field PosOverwrite -> one slot;
  the truncate_positional_3/_4 asymmetry and the positional_nil padding
  invariant disappear structurally.
- fold_quantified_captures / reserve_nil_capture_slots /
  append_separated_captures rewritten on slots; the fold's 0..len span
  fabrication fallback is gone.
- CodeBlockContext.positional stays a text snapshot, but is materialized
  from spans at its single construction site (same engine space).
- make_match_object_full(_q) takes &[PosSlot]; text-only carriers
  (transliteration callbacks, vm subst $N vecs, SplitMatch) go through
  make_match_object_with_captures, which renders eager 0..len text
  leaves exactly as before.
- Under :m / :i-fold, positional capture texts read through consumers
  (subst $N interpolation, find-first captures) now derive from the
  original subject like the subcap axis has since P3a, instead of the
  stripped/folded engine space.

positional_slots (the pcre2/:P5 numbering axis with None holes) stays
separate by design.

Verified: cargo test 628, t/ 24923, whitelisted S05 roast 93 files all
pass; clippy/fmt clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Tokuhiro Matsuno <tokuhirom@gmail.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>