### PR TITLE
perf(regex): collapse named capture axis into NamedSlot map (ADR-0016 P4 L2)

### DIFF
--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -303,6 +303,38 @@ vectors disappear with P4.
 `Vec<PosSlot>` and `HashMap<Symbol, Vec<Arc<CapNode>>>`, and shrink the trail's undo
 vocabulary accordingly (the alignment invariants become structural rather than asserted in
 comments).
+**Landed 2026-07-31 in two stacked layers**
+(`news/2026-07/regex-positional-axis-posslot.md`, `.../regex-named-axis-namedslot.md`):
+
+- *Layer 1 (positional)*: the five parallel positional collections became
+  `Vec<PosSlot { from, to, subcap, quantified, nil }>` on both the accumulator
+  and `CapChildren`. The spans now SURVIVE onto stored nodes —
+  `into_cap_node` used to drop `positional_offsets`, which is why the builder
+  had a text-leaf fallback fabricating `0..len`; that fallback is retired for
+  matcher output (leaves report real `.from`/`.to`). Backrefs compare spans
+  against the engine's `chars` (alloc-free). Trail undo:
+  `PosLens{5}` → `PosLen`, 4-vec `PosTailRec` → one slot vec. Net −265 lines.
+- *Layer 2 (named)*: the three named collections became
+  `HashMap<String, NamedSlot { nodes: Vec<Arc<CapNode>>, quantified: bool }>`.
+  Every write site had a span in scope (verified by inventory before coding),
+  so text-only entries became span-bearing leaf nodes; the
+  `sub_count < name_count` alignment repair in `store_apply_named_capture`
+  and the silent-marker side channel's separate map disappear structurally.
+  `$<name>` backrefs are span compares. `make_match_object_full_q`'s
+  `named_quantified` parameter is gone (the flag lives in the slot), and the
+  `named`/`named_subcaps`/`named_quantified` builder-argument triple is one
+  map.
+- `CodeBlockContext` keeps its text snapshot shape, but both axes are
+  materialized from spans at its single construction site (same engine
+  space, so semantics are unchanged); `hash_captures` (accumulator-only) and
+  `positional_slots` (the pcre2 numbering axis) stay separate by design.
+- Capture names remain `String` keys — interning them to `Symbol`s needs a
+  Symbol-keyed hash map on the Match render path and is deferred as a
+  follow-up optimization, not part of the axis collapse.
+- Behavior changes, all corrective toward raku and consistent with what P3a
+  did for the subcap axis: subcap-less capture leaves report real offsets,
+  and `:m`/`:i`-fold capture texts read through consumers derive from the
+  original subject rather than the stripped/folded engine space.
 
 **P5 — Lazy `Match`.** First a pure refactor: funnel the `class_name == "Match"`
 consumer sites through accessor helpers (`match_str` / `match_span` / `match_list` /

--- a/news/2026-07/regex-named-axis-namedslot.md
+++ b/news/2026-07/regex-named-axis-namedslot.md
@@ -1,0 +1,35 @@
+# Regex named capture axis collapsed into `NamedSlot` (ADR-0016 P4, layer 2)
+
+Following the positional-axis collapse (layer 1), the named capture state —
+`named: HashMap<String, Vec<String>>` (captured text) ‖ `named_subcaps:
+HashMap<String, Vec<Arc<CapNode>>>` ‖ `named_quantified: HashSet<String>` —
+became one map: `HashMap<String, NamedSlot { nodes: Vec<Arc<CapNode>>,
+quantified: bool }>`, on both the accumulator and stored capture nodes.
+
+A site inventory before coding established the two facts the design needed:
+every named-text write site has a span in scope (so text-only entries could
+become span-bearing leaf `CapNode`s), and the pre-P4 text/subcap maps were
+NOT guaranteed aligned — the engine carried an explicit repair
+(`sub_count < name_count` back-fill in `store_apply_named_capture`) plus four
+divergence classes (silent-marker subcap-only entries, text-only builtin
+captures, merge paths that dropped subcaps, quantified-only keys). The single
+axis makes all of that structural: one node per entry, the quantified flag on
+the slot, the repair deleted, and the merge paths that silently dropped
+subcaps now carry full nodes.
+
+The stored named text axis is gone with layer 1's machinery: readers derive
+text from node spans through the shared subject; `$<name>` backreferences are
+alloc-free span comparisons; `CodeBlockContext.named` keeps its text-snapshot
+shape but is materialized from spans at its single construction site. The
+Match builder's exploded `named`/`named_subcaps`/`named_quantified` argument
+triple is a single map parameter, which also retired the
+`make_match_object_full_q` variant, and the render loop is driven by slot
+nodes instead of aligning two maps by index. Silent-action captures
+(`<.foo>`) keep their marker-prefixed keys inside the same map and stay
+hidden from `.hash`.
+
+`hash_captures` (`%<name>=(...)`, accumulator-only) is untouched, and capture
+names remain `String` keys — interning to `Symbol`s is a separate follow-up.
+
+Verified: `cargo test` 628, `t/` 24923, whitelisted S05 roast (93 files), and
+a full local `make roast` all pass; clippy/fmt clean.

--- a/news/2026-07/regex-positional-axis-posslot.md
+++ b/news/2026-07/regex-positional-axis-posslot.md
@@ -1,0 +1,42 @@
+# Regex positional capture axis collapsed into `Vec<PosSlot>` (ADR-0016 P4, layer 1)
+
+The regex engine's positional capture state was five parallel collections —
+`positional` (captured text) ‖ `positional_subcaps` ‖ `positional_quantified` ‖
+`positional_offsets` ‖ `positional_nil` — kept index-aligned by padding
+invariants asserted only in comments, on both the mutable accumulator
+(`RegexCaptures`) and the stored capture node (`CapChildren`). PR #5592
+collapses them into a single axis, `Vec<PosSlot { from, to, subcap,
+quantified, nil }>`.
+
+The load-bearing change is that the span now survives onto stored nodes:
+`into_cap_node` used to drop `positional_offsets`, so a subcap-less stored
+leaf had no offsets anywhere and the Match builder fabricated `0..len` from
+the captured text. With the slot carrying its span, that text-leaf fallback is
+retired for matcher output — positional capture leaves report their real
+`.from`/`.to` — and the stored text axis is deleted outright; every reader
+derives text from the recorded span through the shared `MatchTarget` (or the
+engine's `chars`). Backreferences (`$0` inside a pattern) became alloc-free
+span comparisons against the same `chars` the match runs in.
+
+The trail's undo vocabulary shrank with the axis: `PosLens` recorded five
+lengths, now one; the four-vector `PosTailRec` is one slot vector; the
+`truncate_positional_3`/`_4` asymmetry and the `positional_nil` padding loop
+are gone because the invariants are structural now. `fold_quantified_captures`
+and `reserve_nil_capture_slots` rewrote to a fraction of their size, and the
+fold's `(0, len)` span-fabrication fallback disappeared.
+
+Deliberate non-changes: `positional_slots` (the pcre2/`:P5` numbering axis,
+which has `None` holes) stays separate; `CodeBlockContext.positional` keeps
+its text-snapshot shape but is materialized from spans at its single
+construction site in the same engine space; text-only carriers
+(transliteration callbacks, vm-subst `$N` vectors, `SplitMatch`) keep their
+`Vec<String>` shape via `make_match_object_with_captures`.
+
+Corrective behavior changes (toward raku, consistent with P3a's precedent for
+the subcap axis): real leaf offsets as above, and under `:m`/`:i` multi-char
+folds the capture texts read through consumers (subst `$N` interpolation,
+find-first capture lists) now derive from the original subject instead of the
+mark-stripped/case-folded engine space.
+
+Net −265 lines. Verified: `cargo test` 628, `t/` 24923, and a full local
+`make roast` (1435 files, 218774 tests) all pass.

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -343,7 +343,7 @@ impl Interpreter {
                     } else {
                         for (_, _, caps) in &mut matches {
                             if !caps.code_blocks.is_empty()
-                                || caps.named_subcaps.values().any(|v| !v.is_empty())
+                                || caps.named.values().any(|slot| !slot.nodes.is_empty())
                             {
                                 let ct = caps.target_or_new(&text);
                                 self.reduce_regex_captures_made(caps, Some(&ct));
@@ -437,7 +437,6 @@ impl Interpreter {
             start as i64,
             end as i64,
             &[],
-            &std::collections::HashMap::new(),
             &std::collections::HashMap::new(),
             crate::runtime::MatchTarget::new(text),
         )

--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -172,7 +172,6 @@ impl Interpreter {
                         len,
                         &[],
                         &HashMap::new(),
-                        &HashMap::new(),
                         crate::runtime::MatchTarget::new(&fmt),
                     )));
                 }

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -491,14 +491,12 @@ impl Interpreter {
                     .insert(i.to_string(), Value::str(captures.slot_text(v)));
             }
             let alias_map = std::mem::take(&mut captures.capture_alias_map);
-            let match_obj = Value::make_match_object_full_q(
+            let match_obj = Value::make_match_object_full(
                 captures.from as i64,
                 captures.to as i64,
                 &captures.positional,
                 &captures.named,
-                &captures.named_subcaps,
                 gtarget,
-                &captures.named_quantified,
             );
             let match_obj = {
                 let mut updates: Vec<(&str, Value)> = Vec::new();
@@ -619,28 +617,24 @@ impl Interpreter {
     /// Build the Match object a capture node describes, with `orig` set to the
     /// whole parse text so `.orig`/`.prematch` work on it.
     fn match_object_from_captures(caps: &RegexCaptures, text: &str) -> Value {
-        Value::make_match_object_full_q(
+        Value::make_match_object_full(
             caps.from as i64,
             caps.to as i64,
             &caps.positional,
             &caps.named,
-            &caps.named_subcaps,
             caps.target_or_new(text),
-            &caps.named_quantified,
         )
     }
 
     /// [`Self::match_object_from_captures`] for a stored capture node.
     fn match_object_from_cap_node(node: &CapNode, target: &MatchTarget) -> Value {
         let kids = node.kids();
-        Value::make_match_object_full_q(
+        Value::make_match_object_full(
             node.from as i64,
             node.to as i64,
             &kids.positional,
             &kids.named,
-            &kids.named_subcaps,
             target.clone(),
-            &kids.named_quantified,
         )
     }
 

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -168,7 +168,6 @@ impl Interpreter {
                         c.to as i64,
                         &c.positional,
                         &c.named,
-                        &c.named_subcaps,
                         c.target_or_new(&text),
                     )
                 })
@@ -211,7 +210,6 @@ impl Interpreter {
                 to,
                 &captures.positional,
                 &captures.named,
-                &captures.named_subcaps,
                 mtarget,
             );
             // Set positional capture env vars ($0, $1, ...) from match object

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -96,7 +96,6 @@ impl Interpreter {
                 c.to as i64,
                 &c.positional,
                 &c.named,
-                &c.named_subcaps,
                 c.target_or_new(text),
             )
         };
@@ -459,7 +458,6 @@ impl Interpreter {
                         captures.to as i64,
                         &captures.positional,
                         &captures.named,
-                        &captures.named_subcaps,
                         captures.target_or_new(&text),
                     );
                     self.env.insert("/".to_string(), match_obj);

--- a/src/runtime/methods_string_subst_repl.rs
+++ b/src/runtime/methods_string_subst_repl.rs
@@ -62,7 +62,6 @@ impl Interpreter {
                 captures.to as i64,
                 &captures.positional,
                 &captures.named,
-                &captures.named_subcaps,
                 captures.target_or_new(orig_text.unwrap_or_default()),
             );
             self.env.insert("/".to_string(), match_obj.clone());

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -266,8 +266,7 @@ impl Interpreter {
             (caps.match_from + matched_so_far.chars().count()) as i64,
             &caps.positional,
             &caps.named,
-            &HashMap::new(),
-            live_target,
+            live_target.clone(),
         );
         // `$¢` is the current match state at this point in the pattern — the same
         // object as `$/` here (`/ .{ $c = $¢ } /` must leave `$c` with a usable
@@ -292,16 +291,25 @@ impl Interpreter {
             HashMap::new()
         };
 
-        // Set named captures
-        for (k, v) in &caps.named {
+        // Set named captures (texts derive from spans through the engine-scope
+        // subject; silent marker keys stay hidden).
+        for (k, slot) in &caps.named {
+            if k.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
+                continue;
+            }
             if let Some(m) = made_named.get(k) {
                 env.push((format!("<{}>", k), m.clone()));
                 continue;
             }
-            let value = if v.len() == 1 {
-                Value::str(v[0].clone())
+            let texts: Vec<String> = slot
+                .nodes
+                .iter()
+                .map(|n| live_target.span_str(n.from, n.to))
+                .collect();
+            let value = if texts.len() == 1 {
+                Value::str(texts.into_iter().next().unwrap())
             } else {
-                Value::array(v.iter().cloned().map(Value::str).collect())
+                Value::array(texts.into_iter().map(Value::str).collect())
             };
             env.push((format!("<{}>", k), value));
         }
@@ -391,14 +399,12 @@ impl Interpreter {
         // unreachable in practice — this only runs from inside a match).
         let target =
             super::regex_helpers::current_match_target().unwrap_or_else(|| MatchTarget::new(""));
-        let full = Value::make_match_object_full_q(
+        let full = Value::make_match_object_full(
             caps.from as i64,
             caps.to as i64,
             &caps.positional,
             &caps.named,
-            &caps.named_subcaps,
             target,
-            &caps.named_quantified,
         );
         let named_v = full.match_named();
         let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) else {
@@ -466,9 +472,9 @@ impl Interpreter {
             .clone()
             .unwrap_or_else(|| rule_name.clone());
         let Some(sub) = new_caps
-            .named_subcaps
+            .named
             .get(&cap_name)
-            .and_then(|v| v.last())
+            .and_then(|slot| slot.nodes.last())
             .cloned()
         else {
             return;
@@ -521,14 +527,12 @@ impl Interpreter {
         // `run_named_capture_actions`).
         let target =
             super::regex_helpers::current_match_target().unwrap_or_else(|| MatchTarget::new(""));
-        let match_obj = Value::make_match_object_full_q(
+        let match_obj = Value::make_match_object_full(
             sub.from as i64,
             sub.to as i64,
             &kids.positional,
             &kids.named,
-            &kids.named_subcaps,
             target,
-            &kids.named_quantified,
         );
         let mut scratch = Interpreter {
             env: self.env.clone(),

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -394,7 +394,7 @@ impl Interpreter {
         // a child's code block accumulates into this match's binding (the
         // `:my %*PLAYED = (); <card>+` shape) rather than a sibling match's.
         let declared_keys = self.install_fresh_rule_dynvars(rule_name);
-        self.reduce_child_axes(&mut caps.named_subcaps, &mut caps.positional, target);
+        self.reduce_child_axes(&mut caps.named, &mut caps.positional, target);
         if caps.code_blocks.is_empty() {
             // Even with no code blocks of its own, a declaring match must record
             // what its binding holds — its action still reads it, and a sibling
@@ -406,14 +406,12 @@ impl Interpreter {
         // block's `$/` still comes from its own matched-so-far context (inside
         // `reduce_run_code_blocks`), so a mid-rule `{ … $/ … }` sees the prefix —
         // only the child `.made` values read via `$<name>` come from here.
-        let node_match = Value::make_match_object_full_q(
+        let node_match = Value::make_match_object_full(
             caps.from as i64,
             caps.to as i64,
             &caps.positional,
             &caps.named,
-            &caps.named_subcaps,
             super::regex_helpers::target_or_empty(target),
-            &caps.named_quantified,
         );
         let blocks = std::mem::take(&mut caps.code_blocks);
         caps.ast = self.reduce_run_code_blocks(blocks, node_match);
@@ -430,7 +428,7 @@ impl Interpreter {
     ) {
         let declared_keys = self.install_fresh_rule_dynvars(rule_name);
         if let Some(kids) = node.children.as_deref_mut() {
-            self.reduce_child_axes(&mut kids.named_subcaps, &mut kids.positional, target);
+            self.reduce_child_axes(&mut kids.named, &mut kids.positional, target);
         }
         let has_blocks = node
             .children
@@ -451,14 +449,12 @@ impl Interpreter {
             .children
             .as_deref_mut()
             .expect("has_blocks implies kids");
-        let node_match = Value::make_match_object_full_q(
+        let node_match = Value::make_match_object_full(
             from as i64,
             to as i64,
             &kids.positional,
             &kids.named,
-            &kids.named_subcaps,
             super::regex_helpers::target_or_empty(target),
-            &kids.named_quantified,
         );
         let blocks = std::mem::take(&mut kids.code_blocks);
         node.ast = self.reduce_run_code_blocks(blocks, node_match);
@@ -469,7 +465,7 @@ impl Interpreter {
     /// accumulator and stored `CapNode`s (their child axes are the same types).
     fn reduce_child_axes(
         &mut self,
-        named_subcaps: &mut HashMap<String, Vec<Arc<CapNode>>>,
+        named: &mut HashMap<String, NamedSlot>,
         positional: &mut [PosSlot],
         target: Option<&MatchTarget>,
     ) {
@@ -484,9 +480,9 @@ impl Interpreter {
         // rare and keep the full walk.
         let skip_untouched = self.grammar_rule_dynvar_decls.is_empty();
         // Children first so a parent block reading a child's `.made` sees it.
-        for (key, scs) in named_subcaps.iter_mut() {
+        for (key, slot) in named.iter_mut() {
             let child_rule = Self::reduce_child_rule_name(key);
-            for sc in scs.iter_mut() {
+            for sc in slot.nodes.iter_mut() {
                 if skip_untouched && !Self::subtree_has_code_blocks(sc) {
                     continue;
                 }
@@ -584,9 +580,9 @@ impl Interpreter {
         if !kids.code_blocks.is_empty() {
             return true;
         }
-        kids.named_subcaps
+        kids.named
             .values()
-            .flatten()
+            .flat_map(|slot| slot.nodes.iter())
             .any(|sc| Self::subtree_has_code_blocks(sc))
             || kids.positional.iter().any(|slot| {
                 slot.subcap

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -692,7 +692,11 @@ pub(super) fn remap_caps_spans_offset(
         slot.0 = m(slot.0);
         slot.1 = m(slot.1);
     }
-    for sc in caps.named_subcaps.values_mut().flatten() {
+    for sc in caps
+        .named
+        .values_mut()
+        .flat_map(|slot| slot.nodes.iter_mut())
+    {
         remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
     }
     for slot in caps.positional.iter_mut() {
@@ -737,7 +741,11 @@ pub(super) fn remap_cap_node_spans(
     let Some(children) = node.children.as_deref_mut() else {
         return;
     };
-    for sc in children.named_subcaps.values_mut().flatten() {
+    for sc in children
+        .named
+        .values_mut()
+        .flat_map(|slot| slot.nodes.iter_mut())
+    {
         remap_cap_node_spans(std::sync::Arc::make_mut(sc), pos_map, orig_len, offset);
     }
     for slot in children.positional.iter_mut() {
@@ -873,12 +881,8 @@ pub(super) fn merge_regex_captures(
     mut src: RegexCaptures,
 ) -> RegexCaptures {
     for (k, v) in src.named.drain() {
-        dst.named.entry(k).or_default().extend(v);
+        dst.named.entry(k).or_default().merge(v);
     }
-    for (k, v) in src.named_subcaps.drain() {
-        dst.named_subcaps.entry(k).or_default().extend(v);
-    }
-    dst.named_quantified.extend(src.named_quantified.drain());
     for (k, v) in src.capture_alias_map.drain() {
         dst.capture_alias_map.insert(k, v);
     }
@@ -1013,12 +1017,37 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
 pub(super) fn pos_slot_texts(slots: &[PosSlot], chars: &[char]) -> Vec<String> {
     slots
         .iter()
-        .map(|slot| {
-            let from = slot.from.min(chars.len());
-            let to = slot.to.min(chars.len()).max(from);
-            chars[from..to].iter().collect()
+        .map(|slot| span_chars_text(slot.from, slot.to, chars))
+        .collect()
+}
+
+/// [`pos_slot_texts`] for the named axis: the per-name text lists a
+/// `CodeBlockContext` snapshot carries. Silent-action marker keys never had
+/// text entries pre-P4 and are skipped.
+pub(super) fn named_slot_texts(
+    named: &HashMap<String, NamedSlot>,
+    chars: &[char],
+) -> HashMap<String, Vec<String>> {
+    named
+        .iter()
+        .filter(|(k, _)| !k.starts_with(SILENT_ACTION_MARKER_PREFIX))
+        .map(|(k, slot)| {
+            (
+                k.clone(),
+                slot.nodes
+                    .iter()
+                    .map(|n| span_chars_text(n.from, n.to, chars))
+                    .collect(),
+            )
         })
         .collect()
+}
+
+/// One span's text through a chars slice, clamped.
+fn span_chars_text(from: usize, to: usize, chars: &[char]) -> String {
+    let from = from.min(chars.len());
+    let to = to.min(chars.len()).max(from);
+    chars[from..to].iter().collect()
 }
 
 /// Reserve `stride` index-stable Nil slots for an unmatched optional capture

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -78,14 +78,8 @@ impl Interpreter {
                 {
                     let mut new_caps = RegexCaptures::default();
                     for (k, v) in inner_caps.named.drain() {
-                        new_caps.named.entry(k).or_default().extend(v);
+                        new_caps.named.entry(k).or_default().merge(v);
                     }
-                    for (k, v) in inner_caps.named_subcaps.drain() {
-                        new_caps.named_subcaps.entry(k).or_default().extend(v);
-                    }
-                    new_caps
-                        .named_quantified
-                        .extend(inner_caps.named_quantified.drain());
                     new_caps.positional.append(&mut inner_caps.positional);
                     new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                     indexed.push((i, next, new_caps));
@@ -120,14 +114,8 @@ impl Interpreter {
                 for (next, mut inner_caps) in inner_matches {
                     let mut new_caps = RegexCaptures::default();
                     for (k, v) in inner_caps.named.drain() {
-                        new_caps.named.entry(k).or_default().extend(v);
+                        new_caps.named.entry(k).or_default().merge(v);
                     }
-                    for (k, v) in inner_caps.named_subcaps.drain() {
-                        new_caps.named_subcaps.entry(k).or_default().extend(v);
-                    }
-                    new_caps
-                        .named_quantified
-                        .extend(inner_caps.named_quantified.drain());
                     new_caps.positional.append(&mut inner_caps.positional);
                     new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                     group.push((next, new_caps));
@@ -181,14 +169,8 @@ impl Interpreter {
             {
                 let mut new_caps = RegexCaptures::default();
                 for (k, v) in inner_caps.named.drain() {
-                    new_caps.named.entry(k).or_default().extend(v);
+                    new_caps.named.entry(k).or_default().merge(v);
                 }
-                for (k, v) in inner_caps.named_subcaps.drain() {
-                    new_caps.named_subcaps.entry(k).or_default().extend(v);
-                }
-                new_caps
-                    .named_quantified
-                    .extend(inner_caps.named_quantified.drain());
                 new_caps.positional.append(&mut inner_caps.positional);
                 new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                 // A `<(` / `)>` capture marker inside the group sets the match
@@ -280,7 +262,7 @@ impl Interpreter {
                 {
                     let mut new_caps = RegexCaptures::default();
                     for (k, v) in inner_caps.named.drain() {
-                        new_caps.named.entry(k).or_default().extend(v);
+                        new_caps.named.entry(k).or_default().merge(v);
                     }
                     new_caps.positional.append(&mut inner_caps.positional);
                     new_caps.code_blocks.append(&mut inner_caps.code_blocks);
@@ -386,7 +368,7 @@ impl Interpreter {
                     // returns items in the same order as input (HIGHEST FIRST).
                     // Caller expects LOWEST FIRST, so reverse.
                     let mut result = Self::build_named_candidates_from_inner(
-                        seed, pos, chars, &spec, None, // no sym_key for seed
+                        seed, pos, &spec, None, // no sym_key for seed
                     );
                     result.reverse();
                     return result;
@@ -518,7 +500,7 @@ impl Interpreter {
                 // the same order (one-to-one), so result is HIGHEST FIRST.
                 // Caller expects LOWEST FIRST, so reverse.
                 let mut result =
-                    Self::build_named_candidates_from_inner(best_raw, pos, chars, &spec, None);
+                    Self::build_named_candidates_from_inner(best_raw, pos, &spec, None);
                 result.reverse();
                 result
             } else {
@@ -649,7 +631,6 @@ impl Interpreter {
     pub(super) fn build_named_candidates_from_inner(
         inner_matches: Vec<(usize, RegexCaptures)>,
         pos: usize,
-        chars: &[char],
         spec: &NamedRegexLookupSpec,
         sym_key: Option<&String>,
     ) -> Vec<(usize, RegexCaptures)> {
@@ -667,7 +648,6 @@ impl Interpreter {
                 // the subrule used no markers, so this is a no-op otherwise.
                 let cs = inner_caps.capture_start.unwrap_or(pos).clamp(pos, end);
                 let ce = inner_caps.capture_end.unwrap_or(end).clamp(cs, end);
-                let captured: String = chars[cs..ce].iter().collect();
                 let mut subcap = inner_caps;
                 subcap.from = cs;
                 subcap.to = ce;
@@ -711,15 +691,11 @@ impl Interpreter {
                 // dispatches at reduce time) does — see `REDUCED_SUBRULES`.
                 super::regex_helpers::record_reduced_subrule(&spec.lookup_name, &subcap);
                 new_caps
-                    .named_subcaps
-                    .entry(capture_name.to_string())
-                    .or_default()
-                    .push(subcap);
-                new_caps
                     .named
                     .entry(capture_name.to_string())
                     .or_default()
-                    .push(captured.clone());
+                    .nodes
+                    .push(subcap);
                 if is_alias {
                     new_caps
                         .capture_alias_map
@@ -727,17 +703,13 @@ impl Interpreter {
                 }
                 if let Some(orig_subcap) = original_subcap {
                     new_caps
-                        .named_subcaps
-                        .entry(spec.lookup_name.clone())
-                        .or_default()
-                        .push(std::sync::Arc::new(orig_subcap.into_cap_node()));
-                    new_caps
                         .named
                         .entry(spec.lookup_name.clone())
                         .or_default()
-                        .push(captured);
+                        .nodes
+                        .push(std::sync::Arc::new(orig_subcap.into_cap_node()));
                 }
-            } else if !inner_caps.named.is_empty() || !inner_caps.named_subcaps.is_empty() {
+            } else if !inner_caps.named.is_empty() {
                 // Silent subrule (`<.foo>`) that contains nested captures. The
                 // subrule is hidden from `.hash`, but its OWN action method must
                 // still fire (Rakudo dispatches actions at reduce time regardless
@@ -768,11 +740,7 @@ impl Interpreter {
                 );
                 let subcap = std::sync::Arc::new(subcap.into_cap_node());
                 super::regex_helpers::record_reduced_subrule(&spec.lookup_name, &subcap);
-                new_caps
-                    .named_subcaps
-                    .entry(marker)
-                    .or_default()
-                    .push(subcap);
+                new_caps.named.entry(marker).or_default().nodes.push(subcap);
             } else {
                 // Childless silent subrule (`<.ws>`, `<.CRLF>`, `<.sym>`, ...): no
                 // nested captures and (in practice) no action of interest, so keep

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -56,14 +56,8 @@ impl Interpreter {
                     .map(|(next, mut inner_caps)| {
                         let mut new_caps = RegexCaptures::default();
                         for (k, v) in inner_caps.named.drain() {
-                            new_caps.named.entry(k).or_default().extend(v);
+                            new_caps.named.entry(k).or_default().merge(v);
                         }
-                        for (k, v) in inner_caps.named_subcaps.drain() {
-                            new_caps.named_subcaps.entry(k).or_default().extend(v);
-                        }
-                        new_caps
-                            .named_quantified
-                            .extend(inner_caps.named_quantified.drain());
                         for (k, v) in inner_caps.capture_alias_map.drain() {
                             new_caps.capture_alias_map.insert(k, v);
                         }
@@ -112,14 +106,8 @@ impl Interpreter {
                     {
                         let mut new_caps = RegexCaptures::default();
                         for (k, v) in inner_caps.named.drain() {
-                            new_caps.named.entry(k).or_default().extend(v);
+                            new_caps.named.entry(k).or_default().merge(v);
                         }
-                        for (k, v) in inner_caps.named_subcaps.drain() {
-                            new_caps.named_subcaps.entry(k).or_default().extend(v);
-                        }
-                        new_caps
-                            .named_quantified
-                            .extend(inner_caps.named_quantified.drain());
                         for (k, v) in inner_caps.capture_alias_map.drain() {
                             new_caps.capture_alias_map.insert(k, v);
                         }
@@ -162,7 +150,7 @@ impl Interpreter {
                     {
                         let mut new_caps = RegexCaptures::default();
                         for (k, v) in inner_caps.named.drain() {
-                            new_caps.named.entry(k).or_default().extend(v);
+                            new_caps.named.entry(k).or_default().merge(v);
                         }
                         new_caps.positional.append(&mut inner_caps.positional);
                         new_caps.code_blocks.append(&mut inner_caps.code_blocks);
@@ -326,7 +314,7 @@ impl Interpreter {
                 let mut new_caps = RegexCaptures::default();
                 let ctx = CodeBlockContext {
                     code: code.clone(),
-                    named: current_caps.named.clone(),
+                    named: super::regex_helpers::named_slot_texts(&current_caps.named, chars),
                     matched_so_far,
                     positional: super::regex_helpers::pos_slot_texts(
                         &current_caps.positional,
@@ -371,7 +359,7 @@ impl Interpreter {
                                 .named
                                 .entry(k.clone())
                                 .or_default()
-                                .extend(v.clone());
+                                .merge(v.clone());
                         }
                         return Some((end, new_caps));
                     }
@@ -424,17 +412,18 @@ impl Interpreter {
                 return None;
             }
             RegexAtom::NamedBackref(name) => {
-                let ref_text = current_caps
+                // Span comparison against the engine's own chars — same
+                // alloc-free scheme as the positional Backref (ADR-0016 P4).
+                let node = current_caps
                     .named
                     .get(name.as_str())
-                    .and_then(|vals| vals.last())
-                    .cloned();
-                if let Some(ref_text) = ref_text {
-                    let ref_chars: Vec<char> = ref_text.chars().collect();
-                    if pos + ref_chars.len() <= chars.len()
-                        && chars[pos..pos + ref_chars.len()] == ref_chars[..]
-                    {
-                        return Some((pos + ref_chars.len(), RegexCaptures::default()));
+                    .and_then(|slot| slot.nodes.last());
+                if let Some(node) = node {
+                    let (a, b) = (node.from.min(chars.len()), node.to.min(chars.len()));
+                    let (a, b) = (a, b.max(a));
+                    let len = b - a;
+                    if pos + len <= chars.len() && chars[pos..pos + len] == chars[a..b] {
+                        return Some((pos + len, RegexCaptures::default()));
                     }
                 }
                 return None;
@@ -565,7 +554,6 @@ impl Interpreter {
                     return Self::build_named_candidates_from_inner(
                         vec![(inner_end, inner_caps)],
                         pos,
-                        chars,
                         &spec,
                         None,
                     )
@@ -596,12 +584,16 @@ impl Interpreter {
                 }
                 let mut new_caps = RegexCaptures::default();
                 if !spec.silent {
-                    let captured: String = chars[pos..end].iter().collect();
                     new_caps
                         .named
                         .entry(spec.lookup_name.to_string())
                         .or_default()
-                        .push(captured);
+                        .nodes
+                        .push(std::sync::Arc::new(CapNode {
+                            from: pos,
+                            to: end,
+                            ..Default::default()
+                        }));
                 }
                 return Some((end, new_caps));
             }
@@ -634,27 +626,16 @@ impl Interpreter {
             {
                 let end = pos + 1;
                 let mut new_caps = RegexCaptures::default();
-                let captured: String = chars[pos..end].iter().collect();
                 let capture_name = spec
                     .capture_name
                     .as_deref()
                     .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                 if let Some(capture_name) = capture_name {
-                    let subcap = CapNode {
-                        from: pos,
-                        to: end,
-                        ..Default::default()
-                    };
-                    new_caps
-                        .named_subcaps
-                        .entry(capture_name.to_string())
-                        .or_default()
-                        .push(std::sync::Arc::new(subcap));
                     new_caps
                         .named
                         .entry(capture_name.to_string())
                         .or_default()
-                        .push(captured.clone());
+                        .merge(NamedSlot::leaf(pos, end));
                     // For <foo=alpha>, also capture under the original name.
                     // For <foo=.alpha>, the dot suppresses the original name.
                     if spec.capture_name.is_some()
@@ -664,21 +645,11 @@ impl Interpreter {
                         new_caps
                             .capture_alias_map
                             .insert(capture_name.to_string(), spec.lookup_name.clone());
-                        let subcap2 = CapNode {
-                            from: pos,
-                            to: end,
-                            ..Default::default()
-                        };
-                        new_caps
-                            .named_subcaps
-                            .entry(spec.lookup_name.to_string())
-                            .or_default()
-                            .push(std::sync::Arc::new(subcap2));
                         new_caps
                             .named
                             .entry(spec.lookup_name.to_string())
                             .or_default()
-                            .push(captured);
+                            .merge(NamedSlot::leaf(pos, end));
                     }
                 }
                 return Some((end, new_caps));
@@ -705,27 +676,16 @@ impl Interpreter {
                 }
                 let end = pos + 1;
                 let mut new_caps = RegexCaptures::default();
-                let captured: String = chars[pos..end].iter().collect();
                 let capture_name = spec
                     .capture_name
                     .as_deref()
                     .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
                 if let Some(capture_name) = capture_name {
-                    let subcap = CapNode {
-                        from: pos,
-                        to: end,
-                        ..Default::default()
-                    };
-                    new_caps
-                        .named_subcaps
-                        .entry(capture_name.to_string())
-                        .or_default()
-                        .push(std::sync::Arc::new(subcap));
                     new_caps
                         .named
                         .entry(capture_name.to_string())
                         .or_default()
-                        .push(captured);
+                        .merge(NamedSlot::leaf(pos, end));
                 }
                 return Some((end, new_caps));
             }
@@ -787,14 +747,13 @@ impl Interpreter {
                     return None;
                 }
                 if chars[pos..pos + name_chars.len()] == name_chars[..] {
-                    let captured: String = name_chars.iter().collect();
                     let mut new_caps = RegexCaptures::default();
                     let capture_name = spec.capture_name.unwrap_or(literal);
                     new_caps
                         .named
                         .entry(capture_name)
                         .or_default()
-                        .push(captured);
+                        .merge(NamedSlot::leaf(pos, pos + name_chars.len()));
                     return Some((pos + name_chars.len(), new_caps));
                 }
                 None

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -198,7 +198,6 @@ impl Interpreter {
     /// `pos_base` is the store's positional length at token start.
     fn store_apply_named_capture(
         store: &mut CapStore,
-        chars: &[char],
         token: &RegexToken,
         from: usize,
         to: usize,
@@ -230,7 +229,6 @@ impl Interpreter {
             }
             return;
         }
-        let captured: String = chars[from..to].iter().collect();
         // A named capture group `$<x>=(...)` aliases the group to the name and
         // does NOT consume a positional number (Raku: `/$<x>=(\w)(\d)/` makes
         // `$<x>` the \w and `$0` the \d). When this named token's atom is itself
@@ -254,69 +252,61 @@ impl Interpreter {
                 .and_then(|slot| slot.subcap.clone());
             store.truncate_positional(pos_base);
         }
-        store.push_named(name, captured.clone());
+        // The alias entry is one span-bearing node (ADR-0016 P4): the pinned
+        // group subcap when the atom is a capturing group; for an aliased
+        // subrule call (`$<pl> = <G::list>`) the called rule's full sub-match
+        // tree, which the rule already merged into the store under its own
+        // capture key (Raku keeps BOTH captures — `$/.keys` is `(G::list pl)`);
+        // else a minimal span carrier, which keeps `.from`/`.to` exact even
+        // for a zero-width match (`$<delim>=<[a..z]>*` matching empty).
+        let subrule_subcap = if group_subcap.is_none()
+            && let RegexAtom::Named(atom_name) = &token.atom
+        {
+            let spec = Self::parse_named_regex_lookup_spec(atom_name);
+            let own_key = spec
+                .capture_name
+                .clone()
+                .or_else(|| (!spec.silent).then(|| spec.lookup_name.clone()));
+            own_key
+                .and_then(|k| store.caps().named.get(&k)?.nodes.last().cloned())
+                .filter(|sc| sc.from == from && sc.to == to)
+        } else {
+            None
+        };
+        let sub = if let Some(mut gs) = group_subcap.take() {
+            // Keep the group's nested captures, but pin the span to the
+            // aliased group's extent.
+            let gsm = std::sync::Arc::make_mut(&mut gs);
+            gsm.from = from;
+            gsm.to = to;
+            gs
+        } else if let Some(sc) = subrule_subcap {
+            sc
+        } else {
+            std::sync::Arc::new(CapNode {
+                from,
+                to,
+                ..Default::default()
+            })
+        };
+        store.push_named_node(name, sub);
         // `@<name>=` array-sigil alias forces list context: mark the name as
         // quantified so the Match builder always presents it as a List, even
         // for a single non-quantified capture (`@<foo>=(.(.))` → `[«bc»]`).
         if token.force_list_capture {
             store.insert_named_quantified(name.clone());
         }
-        // Record a minimal sub-capture carrying the exact (from, to) span so
-        // the Match object gets the right offsets even for a zero-width match
-        // (e.g. `$<delim>=<[a..z]>*` matching empty). Without this the Match
-        // builder falls back to searching for the captured text, which yields
-        // offset 0 for an empty string and breaks `.caps`/`.chunks` ordering.
-        // Only do this when no richer sub-capture already aligns with this
-        // entry, so subrule-aliased captures keep their nested structure.
-        let name_count = store.caps().named.get(name).map(Vec::len).unwrap_or(0);
-        let sub_count = store
-            .caps()
-            .named_subcaps
-            .get(name)
-            .map(Vec::len)
-            .unwrap_or(0);
-        if sub_count < name_count {
-            // An aliased subrule call (`$<pl> = <G::list>`) must carry the
-            // called rule's full sub-match tree, not just its text: the rule
-            // already merged its rich subcap into the store under its own
-            // capture key, so clone that entry (span-checked) for the alias.
-            // Raku keeps BOTH captures (`$/.keys` is `(G::list pl)`).
-            let subrule_subcap = if group_subcap.is_none()
-                && let RegexAtom::Named(atom_name) = &token.atom
-            {
-                let spec = Self::parse_named_regex_lookup_spec(atom_name);
-                let own_key = spec
-                    .capture_name
-                    .clone()
-                    .or_else(|| (!spec.silent).then(|| spec.lookup_name.clone()));
-                own_key
-                    .and_then(|k| store.caps().named_subcaps.get(&k)?.last().cloned())
-                    .filter(|sc| sc.from == from && sc.to == to)
-            } else {
-                None
-            };
-            let sub = if let Some(mut gs) = group_subcap.take() {
-                // Keep the group's nested captures, but pin the span to the
-                // aliased group's extent.
-                let gsm = std::sync::Arc::make_mut(&mut gs);
-                gsm.from = from;
-                gsm.to = to;
-                gs
-            } else if let Some(sc) = subrule_subcap {
-                sc
-            } else {
+        // Also capture under the secondary name (e.g., original builtin class name
+        // when using `$<alias>=<builtin_class>` syntax).
+        if let Some(secondary) = token.secondary_named_capture.as_ref() {
+            store.push_named_node(
+                secondary,
                 std::sync::Arc::new(CapNode {
                     from,
                     to,
                     ..Default::default()
-                })
-            };
-            store.push_named_subcap(name, sub);
-        }
-        // Also capture under the secondary name (e.g., original builtin class name
-        // when using `$<alias>=<builtin_class>` syntax).
-        if let Some(secondary) = token.secondary_named_capture.as_ref() {
-            store.push_named(secondary, captured);
+                }),
+            );
         }
     }
 
@@ -449,7 +439,7 @@ impl Interpreter {
             for (next, delta) in cands.into_iter().rev() {
                 let m = store.mark();
                 store.merge_delta(delta);
-                Self::store_apply_named_capture(store, ctx.chars, token, pos, next, pos_base);
+                Self::store_apply_named_capture(store, token, pos, next, pos_base);
                 let stop = self.walk_tokens(ctx, idx + 1, next, store, matches);
                 store.rewind(m);
                 if stop {
@@ -482,7 +472,7 @@ impl Interpreter {
                 for (next, delta) in candidates.into_iter().rev() {
                     let m = store.mark();
                     store.merge_delta(delta);
-                    Self::store_apply_named_capture(store, ctx.chars, token, pos, next, pos_base);
+                    Self::store_apply_named_capture(store, token, pos, next, pos_base);
                     Self::store_apply_hash_capture(store, ctx.chars, token, pos, next, pos_base);
                     let stop = self.walk_tokens(ctx, idx + 1, next, store, matches);
                     store.rewind(m);
@@ -528,7 +518,7 @@ impl Interpreter {
                 for (next, delta) in candidates.into_iter().rev() {
                     let m = store.mark();
                     store.merge_delta(delta);
-                    Self::store_apply_named_capture(store, ctx.chars, token, pos, next, pos_base);
+                    Self::store_apply_named_capture(store, token, pos, next, pos_base);
                     Self::store_apply_hash_capture(store, ctx.chars, token, pos, next, pos_base);
                     let stop = self.walk_tokens(ctx, idx + 1, next, store, matches);
                     store.rewind(m);
@@ -705,7 +695,6 @@ impl Interpreter {
                     break;
                 }
                 if !capture_name.is_empty() {
-                    let captured: String = ctx.chars[current..end].iter().collect();
                     let mut subcap = inner_caps;
                     subcap.from = current;
                     subcap.to = end;
@@ -714,8 +703,7 @@ impl Interpreter {
                     // failed-parse action replay, exactly as the general
                     // `build_named_candidates_from_inner` path does.
                     super::regex_helpers::record_reduced_subrule(&capture_name, &subcap);
-                    store.push_named_subcap(&capture_name, subcap);
-                    store.push_named(&capture_name, captured);
+                    store.push_named_node(&capture_name, subcap);
                 }
                 current = end;
                 count += 1;
@@ -767,7 +755,7 @@ impl Interpreter {
             return None;
         }
         store.merge_delta(delta);
-        Self::store_apply_named_capture(store, ctx.chars, token, current, next, pos_base);
+        Self::store_apply_named_capture(store, token, current, next, pos_base);
         let hash_base = if hash_per_iter {
             iter_pos_base
         } else {
@@ -978,7 +966,7 @@ impl Interpreter {
             let iter_pos_base = store.caps().positional.len();
             let m = store.mark();
             store.merge_delta(delta);
-            Self::store_apply_named_capture(store, ctx.chars, token, current, next, pos_base);
+            Self::store_apply_named_capture(store, token, current, next, pos_base);
             Self::store_apply_hash_capture(store, ctx.chars, token, current, next, iter_pos_base);
             // Greedy: recurse deeper first, then stop at this length.
             // Frugal: the mirror — stop here first, then grow deeper.

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -7,7 +7,7 @@ impl Interpreter {
     /// STABLE sort, which preserves DFS priority order (highest priority first).
     fn full_match_rank(m: &(usize, RegexCaptures)) -> (usize, usize, usize, usize) {
         let (end, caps) = m;
-        let total_named: usize = caps.named.values().map(|v| v.len()).sum();
+        let total_named: usize = caps.named.values().map(|v| v.nodes.len()).sum();
         (
             *end,
             caps.positional.len(),

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -318,16 +318,9 @@ impl Interpreter {
                     .unwrap_or(0);
                 let mut caps = self.regex_match_with_captures(&sub_pat, text);
                 self.set_current_package(saved_pkg);
-                if let Some(mut caps) = caps.take() {
+                if let Some(caps) = caps.take() {
                     if caps.from != 0 || caps.to != text.chars().count() {
                         continue;
-                    }
-                    if !spec.silent {
-                        let whole = caps.matched_text();
-                        caps.named
-                            .entry(spec.lookup_name.clone())
-                            .or_default()
-                            .push(whole);
                     }
                     // LTM: prefer longer declarative prefix match;
                     // if equal, prefer longer overall match
@@ -352,9 +345,10 @@ impl Interpreter {
                 if !spec.silent {
                     let mut subcap = best.clone();
                     subcap.sym = best_sym;
-                    best.named_subcaps
+                    best.named
                         .entry(spec.lookup_name.clone())
                         .or_default()
+                        .nodes
                         .push(std::sync::Arc::new(subcap.into_cap_node()));
                 }
                 return Some(best);

--- a/src/runtime/regex/regex_match_sep.rs
+++ b/src/runtime/regex/regex_match_sep.rs
@@ -80,7 +80,9 @@ impl Interpreter {
             }
             let assemble = |trailing: Option<&RegexCaptures>, end: usize| {
                 let mut caps = RegexCaptures::default();
-                caps.named_quantified.extend(names.iter().cloned());
+                for n in names.iter() {
+                    caps.named.entry(n.clone()).or_default().quantified = true;
+                }
                 Self::append_separated_captures(
                     &mut caps,
                     atom_caps,
@@ -113,7 +115,9 @@ impl Interpreter {
         // empty Match (`load-yaml("{}")` is an empty Hash, not `{"" => Any}`).
         if min == 0 {
             let mut caps = RegexCaptures::default();
-            caps.named_quantified.extend(names.iter().cloned());
+            for n in names.iter() {
+                caps.named.entry(n.clone()).or_default().quantified = true;
+            }
             out.push((start, caps));
         }
         out.reverse();
@@ -221,8 +225,9 @@ impl Interpreter {
             // an empty list rather than one empty Match (see the twin comment in
             // `match_separated_quantifier`).
             let mut caps = RegexCaptures::default();
-            caps.named_quantified
-                .extend(Self::collect_quantified_names_for_token(token));
+            for n in Self::collect_quantified_names_for_token(token) {
+                caps.named.entry(n).or_default().quantified = true;
+            }
             return vec![(start, caps)];
         }
         let atom_stride = count_capture_groups(&token.atom);
@@ -234,7 +239,9 @@ impl Interpreter {
             .sum();
         let names = Self::collect_quantified_names_for_token(token);
         let mut caps = RegexCaptures::default();
-        caps.named_quantified.extend(names.iter().cloned());
+        for n in names.iter() {
+            caps.named.entry(n.clone()).or_default().quantified = true;
+        }
         // Trailing separator for `%%`: Rakudo consumes it greedily, and
         // ratchet commits to that single choice.
         let mut end = cur;
@@ -437,14 +444,9 @@ impl Interpreter {
         // Named captures: merge every iteration's named captures (as arrays).
         for src in atom_caps.iter().chain(all_sep.iter().copied()) {
             for (k, v) in &src.named {
-                caps.named.entry(k.clone()).or_default().extend(v.clone());
-                caps.named_quantified.insert(k.clone());
-            }
-            for (k, v) in &src.named_subcaps {
-                caps.named_subcaps
-                    .entry(k.clone())
-                    .or_default()
-                    .extend(v.clone());
+                let slot = caps.named.entry(k.clone()).or_default();
+                slot.merge(v.clone());
+                slot.quantified = true;
             }
             for (k, v) in &src.hash_captures {
                 caps.hash_captures

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -547,10 +547,20 @@ impl Interpreter {
             .collect();
         env.insert("/".to_string(), Value::array(match_list));
         for (k, v) in &caps.named {
-            let value = if v.len() == 1 {
-                Value::str(v[0].clone())
+            let texts: Vec<String> = v
+                .nodes
+                .iter()
+                .map(|n| {
+                    live_target
+                        .as_ref()
+                        .map(|t| t.span_str(n.from, n.to))
+                        .unwrap_or_default()
+                })
+                .collect();
+            let value = if texts.len() == 1 {
+                Value::str(texts.into_iter().next().unwrap())
             } else {
-                Value::array(v.iter().cloned().map(Value::str).collect())
+                Value::array(texts.into_iter().map(Value::str).collect())
             };
             env.insert(format!("<{}>", k), value);
         }

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -9,7 +9,6 @@
 //! `$meth($cursor)` (roast integration/advent2011-day07.t).
 
 use std::cell::RefCell;
-use std::collections::HashSet;
 
 use super::super::*;
 use super::regex_helpers::NamedRegexLookupSpec;
@@ -106,14 +105,12 @@ impl Interpreter {
             return Ok(Value::NIL);
         };
         caps.target = Some(target.clone());
-        let m = Value::make_match_object_full_q(
+        let m = Value::make_match_object_full(
             pos as i64,
             end as i64,
             &caps.positional,
             &caps.named,
-            &caps.named_subcaps,
             target,
-            &caps.named_quantified,
         );
         LAST_TOKEN_METHOD_MATCH.with(|slot| {
             *slot.borrow_mut() = Some(TokenMethodMatch {
@@ -191,14 +188,12 @@ impl Interpreter {
         if !matches!(meth.view(), ValueView::Sub(_)) {
             return None;
         }
-        let cursor = Value::make_match_object_full_q(
+        let cursor = Value::make_match_object_full(
             pos as i64,
             pos as i64,
             &[],
             &HashMap::new(),
-            &HashMap::new(),
             MatchTarget::from_chars(chars),
-            &HashSet::new(),
         );
         let mut call_args = vec![cursor];
         call_args.extend(arg_values.iter().cloned());
@@ -250,7 +245,6 @@ impl Interpreter {
         Some(Self::build_named_candidates_from_inner(
             vec![(to_abs, inner_caps)],
             pos,
-            chars,
             spec,
             sym.as_ref(),
         ))

--- a/src/runtime/regex/regex_trail.rs
+++ b/src/runtime/regex/regex_trail.rs
@@ -17,14 +17,6 @@
 
 use super::super::*;
 
-/// Which string-keyed multi-map a `MapVec` undo record refers to.
-#[derive(Clone, Copy)]
-pub(super) enum MapId {
-    Named,
-    NamedSub,
-    HashCap,
-}
-
 /// Saved tail for a positional truncation (slots moved out, moved back on
 /// rewind). Boxed to keep `Undo` small.
 pub(super) struct PosTailRec {
@@ -43,15 +35,20 @@ pub(super) enum Undo {
         idx: usize,
         slot: Box<PosSlot>,
     },
-    /// Truncate `map[key]` to `len`; remove the key if it was newly created.
-    MapVecTrunc {
-        which: MapId,
+    /// Restore a named slot: remove the key if it was newly created, else
+    /// truncate its nodes to `len` and restore the quantified flag.
+    NamedTrunc {
+        key: String,
+        len: usize,
+        present: bool,
+        quantified: bool,
+    },
+    /// Truncate `hash_captures[key]` to `len`; remove a newly created key.
+    HashCapTrunc {
         key: String,
         len: usize,
         present: bool,
     },
-    /// Remove a `named_quantified` entry that this frame inserted.
-    NamedQuantRemove(String),
     /// Restore a `capture_alias_map` entry (None = remove).
     AliasRestore {
         key: String,
@@ -120,36 +117,25 @@ impl CapStore {
                         caps.positional[idx] = *slot;
                     }
                 }
-                Undo::MapVecTrunc {
-                    which,
+                Undo::NamedTrunc {
                     key,
                     len,
                     present,
-                } => match which {
-                    MapId::Named => {
-                        if !present {
-                            caps.named.remove(&key);
-                        } else if let Some(v) = caps.named.get_mut(&key) {
-                            v.truncate(len);
-                        }
+                    quantified,
+                } => {
+                    if !present {
+                        caps.named.remove(&key);
+                    } else if let Some(slot) = caps.named.get_mut(&key) {
+                        slot.nodes.truncate(len);
+                        slot.quantified = quantified;
                     }
-                    MapId::NamedSub => {
-                        if !present {
-                            caps.named_subcaps.remove(&key);
-                        } else if let Some(v) = caps.named_subcaps.get_mut(&key) {
-                            v.truncate(len);
-                        }
+                }
+                Undo::HashCapTrunc { key, len, present } => {
+                    if !present {
+                        caps.hash_captures.remove(&key);
+                    } else if let Some(v) = caps.hash_captures.get_mut(&key) {
+                        v.truncate(len);
                     }
-                    MapId::HashCap => {
-                        if !present {
-                            caps.hash_captures.remove(&key);
-                        } else if let Some(v) = caps.hash_captures.get_mut(&key) {
-                            v.truncate(len);
-                        }
-                    }
-                },
-                Undo::NamedQuantRemove(key) => {
-                    caps.named_quantified.remove(&key);
                 }
                 Undo::AliasRestore { key, prev } => match prev {
                     Some(v) => {
@@ -182,28 +168,15 @@ impl CapStore {
     }
 
     fn record_named_key(&mut self, key: &str) {
-        let (len, present) = match self.caps.named.get(key) {
-            Some(v) => (v.len(), true),
-            None => (0, false),
+        let (len, present, quantified) = match self.caps.named.get(key) {
+            Some(slot) => (slot.nodes.len(), true, slot.quantified),
+            None => (0, false, false),
         };
-        self.trail.push(Undo::MapVecTrunc {
-            which: MapId::Named,
+        self.trail.push(Undo::NamedTrunc {
             key: key.to_string(),
             len,
             present,
-        });
-    }
-
-    fn record_named_sub_key(&mut self, key: &str) {
-        let (len, present) = match self.caps.named_subcaps.get(key) {
-            Some(v) => (v.len(), true),
-            None => (0, false),
-        };
-        self.trail.push(Undo::MapVecTrunc {
-            which: MapId::NamedSub,
-            key: key.to_string(),
-            len,
-            present,
+            quantified,
         });
     }
 
@@ -212,8 +185,7 @@ impl CapStore {
             Some(v) => (v.len(), true),
             None => (0, false),
         };
-        self.trail.push(Undo::MapVecTrunc {
-            which: MapId::HashCap,
+        self.trail.push(Undo::HashCapTrunc {
             key: key.to_string(),
             len,
             present,
@@ -229,14 +201,9 @@ impl CapStore {
     pub(super) fn merge_delta(&mut self, mut delta: RegexCaptures) {
         for (k, v) in delta.named.drain() {
             self.record_named_key(&k);
-            self.caps.named.entry(k).or_default().extend(v);
-        }
-        for (k, v) in delta.named_subcaps.drain() {
-            self.record_named_sub_key(&k);
-            self.caps.named_subcaps.entry(k).or_default().extend(v);
-        }
-        for k in delta.named_quantified.drain() {
-            self.insert_named_quantified(k);
+            let slot = self.caps.named.entry(k).or_default();
+            slot.nodes.extend(v.nodes);
+            slot.quantified |= v.quantified;
         }
         for (k, v) in delta.capture_alias_map.drain() {
             self.insert_alias(k, v);
@@ -272,27 +239,23 @@ impl CapStore {
         }
     }
 
-    pub(super) fn push_named(&mut self, key: &str, val: String) {
+    /// Append one span-bearing entry under a capture name.
+    pub(super) fn push_named_node(&mut self, key: &str, sub: Arc<CapNode>) {
         self.record_named_key(key);
         self.caps
             .named
             .entry(key.to_string())
             .or_default()
-            .push(val);
-    }
-
-    pub(super) fn push_named_subcap(&mut self, key: &str, sub: Arc<CapNode>) {
-        self.record_named_sub_key(key);
-        self.caps
-            .named_subcaps
-            .entry(key.to_string())
-            .or_default()
+            .nodes
             .push(sub);
     }
 
+    /// Mark a name as quantified (renders as an Array even for 0/1 entries).
     pub(super) fn insert_named_quantified(&mut self, name: String) {
-        if self.caps.named_quantified.insert(name.clone()) {
-            self.trail.push(Undo::NamedQuantRemove(name));
+        let already = self.caps.named.get(&name).is_some_and(|s| s.quantified);
+        if !already {
+            self.record_named_key(&name);
+            self.caps.named.entry(name).or_default().quantified = true;
         }
     }
 
@@ -380,7 +343,7 @@ fn split_off_clamped<T>(v: &mut Vec<T>, at: usize) -> Vec<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::{PosSlot, RegexCaptures};
+    use super::super::super::{NamedSlot, PosSlot, RegexCaptures};
     use super::CapStore;
 
     fn store_with_base() -> CapStore {
@@ -389,7 +352,7 @@ mod tests {
         init.named
             .entry("x".to_string())
             .or_default()
-            .push("v".to_string());
+            .merge(NamedSlot::leaf(0, 1));
         CapStore::new(init)
     }
 
@@ -403,8 +366,8 @@ mod tests {
             (0, 1)
         );
         assert_eq!(store.caps().named.len(), 1);
-        assert_eq!(store.caps().named["x"], vec!["v".to_string()]);
-        assert!(store.caps().named_subcaps.is_empty());
+        assert_eq!(store.caps().named["x"].nodes.len(), 1);
+        assert!(!store.caps().named["x"].quantified);
         assert!(store.caps().capture_start.is_none());
         assert!(store.caps().sym.is_none());
     }
@@ -419,25 +382,22 @@ mod tests {
             .named
             .entry("x".to_string())
             .or_default()
-            .push("v2".to_string());
-        delta
-            .named
-            .entry("y".to_string())
-            .or_default()
-            .push("w".to_string());
-        delta.named_quantified.insert("y".to_string());
+            .merge(NamedSlot::leaf(2, 3));
+        let y = delta.named.entry("y".to_string()).or_default();
+        y.merge(NamedSlot::leaf(3, 4));
+        y.quantified = true;
         delta.capture_start = Some(3);
         delta.sym = Some("s".to_string());
         store.merge_delta(delta);
         assert_eq!(store.caps().positional.len(), 2);
-        assert_eq!(store.caps().named["x"].len(), 2);
-        assert_eq!(store.caps().named["y"], vec!["w".to_string()]);
-        assert!(store.caps().named_quantified.contains("y"));
+        assert_eq!(store.caps().named["x"].nodes.len(), 2);
+        assert_eq!(store.caps().named["y"].nodes.len(), 1);
+        assert!(store.caps().named["y"].quantified);
         assert_eq!(store.caps().capture_start, Some(3));
         assert_eq!(store.caps().sym.as_deref(), Some("s"));
         store.rewind(m);
         assert_base(&store);
-        assert!(!store.caps().named_quantified.contains("y"));
+        assert!(!store.caps().named.contains_key("y"));
     }
 
     #[test]
@@ -489,16 +449,19 @@ mod tests {
     fn nested_marks_rewind_in_order() {
         let mut store = store_with_base();
         let m1 = store.mark();
-        store.push_named("k", "1".to_string());
-        let m2 = store.mark();
-        store.push_named("k", "2".to_string());
-        store.push_named_subcap(
+        store.push_named_node(
             "k",
             std::sync::Arc::new(super::super::super::CapNode::default()),
         );
+        let m2 = store.mark();
+        store.push_named_node(
+            "k",
+            std::sync::Arc::new(super::super::super::CapNode::default()),
+        );
+        store.insert_named_quantified("k".to_string());
         store.rewind(m2);
-        assert_eq!(store.caps().named["k"], vec!["1".to_string()]);
-        assert!(store.caps().named_subcaps.is_empty());
+        assert_eq!(store.caps().named["k"].nodes.len(), 1);
+        assert!(!store.caps().named["k"].quantified);
         store.rewind(m1);
         assert!(!store.caps().named.contains_key("k"));
     }

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -10,7 +10,7 @@
 //! `runtime` via `pub(crate) use self::regex_types::*`).
 
 use crate::value::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -75,6 +75,39 @@ impl PosSlot {
     }
 }
 
+/// One named capture's entries (ADR-0016 P4) — the collapse of the three
+/// parallel named collections (`named` text map ‖ `named_subcaps` ‖
+/// `named_quantified`). Every entry is a span-bearing capture node; the
+/// captured text derives from the node's span through the shared subject.
+#[derive(Clone, Default)]
+pub(crate) struct NamedSlot {
+    pub(crate) nodes: Vec<Arc<CapNode>>,
+    /// The name was captured under a quantifier (or `@<name>=` forced list):
+    /// the Match presents it as an Array even for zero or one entries.
+    pub(crate) quantified: bool,
+}
+
+impl NamedSlot {
+    /// A slot holding one span-only leaf entry.
+    pub(crate) fn leaf(from: usize, to: usize) -> Self {
+        NamedSlot {
+            nodes: vec![Arc::new(CapNode {
+                from,
+                to,
+                ..Default::default()
+            })],
+            quantified: false,
+        }
+    }
+
+    /// Fold another slot's entries into this one (capture-merge semantics:
+    /// entries append, the quantified flag is sticky).
+    pub(crate) fn merge(&mut self, other: NamedSlot) {
+        self.nodes.extend(other.nodes);
+        self.quantified |= other.quantified;
+    }
+}
+
 /// Prefix marking a `named_subcaps` entry as a *silent action capture*: the
 /// match of a silent subrule (`<.foo>`) that is hidden from `.hash` but whose
 /// grammar action method (and its descendants') must still fire. The prefix is a
@@ -113,9 +146,11 @@ pub(crate) struct CapNode {
 /// per-node reduce-time state. Boxed so a leaf node pays one `None` word.
 #[derive(Clone, Default)]
 pub(crate) struct CapChildren {
-    pub(crate) named: HashMap<String, Vec<String>>,
-    pub(crate) named_subcaps: HashMap<String, Vec<Arc<CapNode>>>,
-    pub(crate) named_quantified: HashSet<String>,
+    /// Named captures as span-bearing slots (ADR-0016 P4): capture nodes and
+    /// the quantified flag in one axis. Silent-action captures (`<.foo>`)
+    /// live under `SILENT_ACTION_MARKER_PREFIX`-prefixed keys and are hidden
+    /// from `.hash`.
+    pub(crate) named: HashMap<String, NamedSlot>,
     pub(crate) capture_alias_map: HashMap<String, String>,
     /// Positional captures as span-bearing slots (ADR-0016 P4). Unlike the
     /// pre-P4 parallel vectors, the span survives onto the stored node — the
@@ -179,8 +214,6 @@ impl RegexCaptures {
     /// child payload is allocated only when something would go in it.
     pub(crate) fn into_cap_node(self) -> CapNode {
         let has_children = !self.named.is_empty()
-            || !self.named_subcaps.is_empty()
-            || !self.named_quantified.is_empty()
             || !self.capture_alias_map.is_empty()
             || !self.positional.is_empty()
             || !self.code_blocks.is_empty()
@@ -188,8 +221,6 @@ impl RegexCaptures {
         let children = has_children.then(|| {
             Box::new(CapChildren {
                 named: self.named,
-                named_subcaps: self.named_subcaps,
-                named_quantified: self.named_quantified,
                 capture_alias_map: self.capture_alias_map,
                 positional: self.positional,
                 code_blocks: self.code_blocks,
@@ -209,10 +240,9 @@ impl RegexCaptures {
 
 #[derive(Clone, Default)]
 pub(crate) struct RegexCaptures {
-    pub(crate) named: HashMap<String, Vec<String>>,
-    /// Nested sub-captures for named subrule matches. Key is capture name,
-    /// value is inner captures from the subrule (parallel to entries in `named`).
-    pub(crate) named_subcaps: HashMap<String, Vec<Arc<CapNode>>>,
+    /// Named captures as span-bearing slots (ADR-0016 P4). Keyed by capture
+    /// name; silent-action captures use `SILENT_ACTION_MARKER_PREFIX` keys.
+    pub(crate) named: HashMap<String, NamedSlot>,
     /// Positional captures as span-bearing slots (ADR-0016 P4): span, nested
     /// subcaptures, quantified iteration lists, and the Nil marker in one axis.
     pub(crate) positional: Vec<PosSlot>,
@@ -239,8 +269,6 @@ pub(crate) struct RegexCaptures {
     pub(crate) regex_vars: HashMap<String, Value>,
     /// The winning :sym<> variant name, if this match was from a protoregex.
     pub(crate) sym: Option<String>,
-    /// Named captures from quantified tokens — always stored as arrays in Match.
-    pub(crate) named_quantified: HashSet<String>,
     /// For aliased captures like `<str=.str_escape>`, maps capture name to
     /// original rule name for grammar action dispatch.
     pub(crate) capture_alias_map: HashMap<String, String>,

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -53,11 +53,15 @@ impl Interpreter {
         attrs.insert("list".to_string(), Value::array(positional));
         let mut named = HashMap::new();
         for (k, v) in &captures.named {
+            if k.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
+                continue;
+            }
             let vals: Vec<Value> = v
+                .nodes
                 .iter()
-                .map(|s| make_capture_match(s, 0, s.chars().count()))
+                .map(|n| make_capture_match(&captures.span_text(n.from, n.to), n.from, n.to))
                 .collect();
-            if vals.len() == 1 {
+            if vals.len() == 1 && !v.quantified {
                 named.insert(k.clone(), vals[0].clone());
             } else {
                 named.insert(k.clone(), Value::array(vals));
@@ -278,7 +282,6 @@ impl Interpreter {
                     c.to as i64,
                     &c.positional,
                     &c.named,
-                    &c.named_subcaps,
                     c.target_or_new(orig),
                 )
             })
@@ -429,11 +432,11 @@ impl Interpreter {
                 continue;
             }
             if let (Some(Some(name)), Some((start, end))) = (names.get(idx), locs.get(idx)) {
-                let captured = text.get(start..end)?.to_string();
+                text.get(start..end)?;
                 out.named
                     .entry(name.to_string())
                     .or_default()
-                    .push(captured);
+                    .merge(NamedSlot::leaf(to_char(start), to_char(end)));
             }
         }
         Some(out)
@@ -486,13 +489,13 @@ impl Interpreter {
                 }
                 if let (Some(Some(name)), Some((c_start, c_end))) = (names.get(idx), locs.get(idx))
                 {
-                    let Some(captured) = text.get(c_start..c_end) else {
+                    if text.get(c_start..c_end).is_none() {
                         continue;
-                    };
+                    }
                     item.named
                         .entry(name.to_string())
                         .or_default()
-                        .push(captured.to_string());
+                        .merge(NamedSlot::leaf(to_char(c_start), to_char(c_end)));
                 }
             }
             // Advance past the match (at least 1 byte to avoid infinite loop)

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -256,15 +256,22 @@ impl Interpreter {
                             captures.to as i64,
                             &captures.positional,
                             &captures.named,
-                            &HashMap::new(),
                             starget,
                         );
                         self.env.insert("/".to_string(), match_obj);
                         for (k, v) in &captures.named {
-                            let value = if v.len() == 1 {
-                                Value::str(v[0].clone())
+                            if k.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
+                                continue;
+                            }
+                            let texts: Vec<String> = v
+                                .nodes
+                                .iter()
+                                .map(|n| captures.span_text(n.from, n.to))
+                                .collect();
+                            let value = if texts.len() == 1 {
+                                Value::str(texts[0].clone())
                             } else {
-                                Value::array(v.iter().cloned().map(Value::str).collect())
+                                Value::array(texts.into_iter().map(Value::str).collect())
                             };
                             self.env.insert(format!("<{}>", k), value);
                         }
@@ -337,7 +344,6 @@ impl Interpreter {
                                     cap.to as i64,
                                     &cap.positional,
                                     &cap.named,
-                                    &HashMap::new(),
                                     cap.target_or_new(&text),
                                 );
                                 junc_values.push(match_obj);
@@ -545,7 +551,7 @@ impl Interpreter {
                 let mut selected = selected;
                 for cap in &mut selected {
                     if !cap.code_blocks.is_empty()
-                        || cap.named_subcaps.values().any(|v| !v.is_empty())
+                        || cap.named.values().any(|slot| !slot.nodes.is_empty())
                     {
                         let ct = cap.target_or_new(&text);
                         self.reduce_regex_captures_made(cap, Some(&ct));
@@ -724,20 +730,16 @@ impl Interpreter {
                     // Merge hash captures into named for Match object
                     let mut named_with_hash = captures.named.clone();
                     for hash_name in captures.hash_captures.keys() {
-                        // Don't overwrite existing named captures
-                        if !named_with_hash.contains_key(hash_name) {
-                            // Store placeholder so make_match_object_full creates the key
-                            named_with_hash.insert(hash_name.clone(), Vec::new());
-                        }
+                        // Don't overwrite existing named captures; an empty
+                        // placeholder slot makes the builder create the key.
+                        named_with_hash.entry(hash_name.clone()).or_default();
                     }
-                    let match_obj = Value::make_match_object_full_q(
+                    let match_obj = Value::make_match_object_full(
                         captures.from as i64,
                         captures.to as i64,
                         &captures.positional,
                         &named_with_hash,
-                        &captures.named_subcaps,
                         starget,
-                        &captures.named_quantified,
                     );
                     // Apply hash captures: set named entries to Hash values
                     if !captures.hash_captures.is_empty()

--- a/src/value/match_lazy.rs
+++ b/src/value/match_lazy.rs
@@ -157,43 +157,25 @@ impl MatchNode {
             })
             .collect();
 
+        // Silent-action captures: hidden `<.foo>` subrule matches (stored
+        // under a marker-prefixed key). Absent from `.hash`, but the grammar
+        // action walk fires their action methods via `silent_caps`.
         let mut sub_named: HashMap<String, Value> = HashMap::new();
-        for (key, values) in &kids.named {
-            let subcaps_for_key = kids.named_subcaps.get(key);
-            let vals: Vec<Value> = values
-                .iter()
-                .enumerate()
-                .map(|(i, s)| {
-                    if let Some(scs) = subcaps_for_key
-                        && let Some(sc) = scs.get(i)
-                    {
-                        return self.lazy_child(sc);
-                    }
-                    Value::text_leaf_match(s, &self.target)
-                })
-                .collect();
-            if vals.len() == 1 && !kids.named_quantified.contains(key) {
-                sub_named.insert(key.clone(), vals[0].clone());
-            } else {
-                sub_named.insert(key.clone(), Value::real_array(vals));
-            }
-        }
-        // Quantified named captures that matched zero times render as empty arrays.
-        for qname in &kids.named_quantified {
-            sub_named
-                .entry(qname.clone())
-                .or_insert_with(|| Value::real_array(Vec::new()));
-        }
-
-        // Silent-action captures: hidden `<.foo>` subrule matches (stored under
-        // a marker key in `named_subcaps`). Absent from `named`/`.hash`, but the
-        // grammar action walk fires their action methods via `silent_caps`.
         let mut silent_caps_vals: Vec<Value> = Vec::new();
-        for (key, scs) in &kids.named_subcaps {
+        for (key, slot) in &kids.named {
             if key.starts_with(SILENT_ACTION_MARKER_PREFIX) {
-                for sc in scs {
+                for sc in &slot.nodes {
                     silent_caps_vals.push(self.lazy_child(sc));
                 }
+                continue;
+            }
+            let vals: Vec<Value> = slot.nodes.iter().map(|sc| self.lazy_child(sc)).collect();
+            if vals.len() == 1 && !slot.quantified {
+                sub_named.insert(key.clone(), vals[0].clone());
+            } else {
+                // Quantified names (including zero-iteration ones) and
+                // multi-entry captures render as arrays.
+                sub_named.insert(key.clone(), Value::real_array(vals));
             }
         }
 
@@ -328,12 +310,15 @@ impl Value {
             return None;
         }
         let kids = node.cap.kids();
-        let has_named = !kids.named.is_empty() || !kids.named_quantified.is_empty();
+        let has_named = kids
+            .named
+            .keys()
+            .any(|k| !k.starts_with(SILENT_ACTION_MARKER_PREFIX));
         let has_list = !kids.positional.is_empty();
         let has_silent = kids
-            .named_subcaps
+            .named
             .iter()
-            .any(|(k, scs)| k.starts_with(SILENT_ACTION_MARKER_PREFIX) && !scs.is_empty());
+            .any(|(k, slot)| k.starts_with(SILENT_ACTION_MARKER_PREFIX) && !slot.nodes.is_empty());
         Some((!has_named && !has_list && !has_silent, node.cap.sym.clone()))
     }
 }
@@ -391,9 +376,13 @@ mod tests {
         let mut caps = RegexCaptures::default();
         caps.from = 0;
         caps.to = 2;
-        caps.named.insert("x".to_string(), vec!["b".to_string()]);
-        caps.named_subcaps
-            .insert("x".to_string(), vec![Arc::clone(&child)]);
+        caps.named.insert(
+            "x".to_string(),
+            crate::runtime::NamedSlot {
+                nodes: vec![Arc::clone(&child)],
+                quantified: false,
+            },
+        );
         let parent = Value::lazy_match(Arc::new(caps.into_cap_node()), MatchTarget::new("ab"));
         let named = parent.match_named().expect("named hash");
         let child_val = match named.view() {

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -582,15 +582,36 @@ impl Value {
         named: &HashMap<String, Vec<String>>,
         target: crate::runtime::MatchTarget,
     ) -> Self {
-        let m = Self::make_match_object_full(from, to, &[], named, &HashMap::new(), target.clone());
-        if positional_texts.is_empty() {
+        let m = Self::make_match_object_full(from, to, &[], &HashMap::new(), target.clone());
+        if positional_texts.is_empty() && named.is_empty() {
             return m;
         }
-        let list: Vec<Value> = positional_texts
-            .iter()
-            .map(|s| Value::text_leaf_match(s, &target))
-            .collect();
-        m.match_with_attrs(vec![("list", Value::array(list))])
-            .unwrap_or(m)
+        let mut updates: Vec<(&str, Value)> = Vec::new();
+        if !positional_texts.is_empty() {
+            let list: Vec<Value> = positional_texts
+                .iter()
+                .map(|s| Value::text_leaf_match(s, &target))
+                .collect();
+            updates.push(("list", Value::array(list)));
+        }
+        if !named.is_empty() {
+            let named_vals: HashMap<String, Value> = named
+                .iter()
+                .map(|(k, texts)| {
+                    let vals: Vec<Value> = texts
+                        .iter()
+                        .map(|s| Value::text_leaf_match(s, &target))
+                        .collect();
+                    let v = if vals.len() == 1 {
+                        vals[0].clone()
+                    } else {
+                        Value::real_array(vals)
+                    };
+                    (k.clone(), v)
+                })
+                .collect();
+            updates.push(("named", Value::hash(named_vals)));
+        }
+        m.match_with_attrs(updates).unwrap_or(m)
     }
 }

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -1,28 +1,7 @@
 use super::*;
 
 impl Value {
-    /// Create a Match object with positional captures and the shared subject.
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn make_match_object_full(
-        from: i64,
-        to: i64,
-        positional: &[crate::runtime::PosSlot],
-        named: &HashMap<String, Vec<String>>,
-        named_subcaps: &HashMap<String, Vec<std::sync::Arc<crate::runtime::CapNode>>>,
-        target: crate::runtime::MatchTarget,
-    ) -> Self {
-        Self::make_match_object_full_q(
-            from,
-            to,
-            positional,
-            named,
-            named_subcaps,
-            target,
-            &HashSet::new(),
-        )
-    }
-
-    /// Like make_match_object_full but with named_quantified tracking.
+    /// Create a Match object with captures and the shared subject.
     ///
     /// ADR-0016 P5: this no longer builds an eager `Instance` tree. It
     /// synthesizes a top-level `CapNode` from the capture axes and
@@ -33,26 +12,20 @@ impl Value {
     /// — the pre-P5 builder never surfaced those on the top-level Match.
     ///
     /// ADR-0016 P3/P4: matched text is not passed or stored; `.Str` and every
-    /// positional capture derive from recorded spans through `target`.
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn make_match_object_full_q(
+    /// capture derive from recorded spans through `target`. The pre-P4
+    /// exploded axes (named text map ‖ subcaps ‖ quantified set, four
+    /// positional vecs) are gone — both axes arrive as span-bearing slots.
+    pub(crate) fn make_match_object_full(
         from: i64,
         to: i64,
         positional: &[crate::runtime::PosSlot],
-        named: &HashMap<String, Vec<String>>,
-        named_subcaps: &HashMap<String, Vec<std::sync::Arc<crate::runtime::CapNode>>>,
+        named: &HashMap<String, crate::runtime::NamedSlot>,
         target: crate::runtime::MatchTarget,
-        named_quantified: &HashSet<String>,
     ) -> Self {
-        let has_children = !named.is_empty()
-            || !named_subcaps.is_empty()
-            || !named_quantified.is_empty()
-            || !positional.is_empty();
+        let has_children = !named.is_empty() || !positional.is_empty();
         let children = has_children.then(|| {
             Box::new(crate::runtime::CapChildren {
                 named: named.clone(),
-                named_subcaps: named_subcaps.clone(),
-                named_quantified: named_quantified.clone(),
                 capture_alias_map: HashMap::new(),
                 positional: positional.to_vec(),
                 code_blocks: Vec::new(),


### PR DESCRIPTION
Replace the three parallel named collections (named text map /
named_subcaps / named_quantified set) on both RegexCaptures and
CapChildren with a single HashMap<String, NamedSlot>:

  struct NamedSlot { nodes: Vec<Arc<CapNode>>, quantified: bool }

- Every named-text write site had a span in scope (verified by inventory
  before coding), so text-only entries (builtin <ws>/<alpha>/unicode-
  property/literal-fallback captures, secondary aliases, the pcre2 :P5
  path) become span-bearing leaf CapNodes; the stored named text axis is
  gone and readers derive text from node spans through the shared
  MatchTarget.
- The text/subcap alignment machinery disappears structurally: the
  sub_count < name_count back-fill repair in store_apply_named_capture,
  the index-pairing render loop, and the merge paths that silently
  dropped subcaps (they now carry full nodes).
- $<name> backreferences compare spans against the engine's chars -
  alloc-free, same scheme as the positional side.
- Silent-action captures keep their marker-prefixed keys inside the one
  map and stay hidden from .hash.
- Trail undo: MapVecTrunc{Named,NamedSub} + NamedQuantRemove collapse to
  one NamedTrunc record that restores nodes length and quantified flag.
- make_match_object_full_q is retired - the quantified flag lives in the
  slot, and the builder takes one named map instead of the exploded
  triple. CodeBlockContext.named keeps its text-snapshot shape,
  materialized from spans at its single construction site.
- hash_captures (accumulator-only) and capture-name String keys are
  unchanged; Symbol interning is a separate follow-up.

Also updates ADR-0016's P4 section and adds the per-layer news entries.

Verified: cargo test 628, t/ 24923, whitelisted S05 roast 93 files, and
a full local make roast (1435 files, 218774 tests) all pass;
clippy/fmt clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Tokuhiro Matsuno <tokuhirom@gmail.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>