### PR TITLE
docs(adr): record ADR-0016 P4 bench CI results

### DIFF
--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -336,6 +336,16 @@ comments).
   and `:m`/`:i`-fold capture texts read through consumers derive from the
   original subject rather than the stripped/folded engine space.
 
+*Measured (bench CI, `bench-history.tsv`, `bench-yaml-parse` ÷ `int-arith`):*
+P5 merge 25.65 → P3a intermediate **27.33** (the text vectors' cost: +6.5%
+normalized, larger than the local +2–3% estimate) → P4 layer 1 **24.21**
+(−11.4% vs P3a — the intermediate regression fully recovered, net −5.6% vs
+P5) → layer 2 **24.13** (flat; yaml-parse capture traffic is
+positional-dominated, so the named-side collect removal is below noise —
+layer 2's value is the structural cleanup). Raw wall clock on the L2 runner:
+0.9168 s, the campaign's first sub-second parse (from ~4.07 s at campaign
+start). The grammar-parse pair stayed inside its 0.29–0.33 noise band.
+
 **P5 — Lazy `Match`.** First a pure refactor: funnel the `class_name == "Match"`
 consumer sites through accessor helpers (`match_str` / `match_span` / `match_list` /
 `match_named`) with no behavior change. Then swap the representation behind them to


### PR DESCRIPTION
Appends the bench CI measurements to ADR-0016's P4 section (int-arith-normalized `bench-yaml-parse`, per the bench-data protocol):

| point | normalized |
|---|---:|
| P5 merge (`fa2400a49`) | 25.65 |
| P3a intermediate (`c45060894`) | 27.33 (+6.5%) |
| P4 layer 1 (`96f4142ad`) | **24.21** (−11.4% vs P3a, net −5.6% vs P5) |
| P4 layer 2 (`b2d1dc64f`) | 24.13 (flat) |

The P3a intermediate regression is fully recovered by layer 1, confirming the ADR's projection that the residual capture-site text collects were the cost. Layer 2 is flat on this workload (positional-dominated captures); its value is the structural cleanup. Raw wall clock on the L2 runner is 0.9168 s — the campaign's first sub-second parse, from ~4.07 s at campaign start.

Docs-only PR (heavy CI jobs skip by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)