### PR TITLE
docs(batteries): survey the web-framework slot; re-assess Cro reachability

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -109,6 +109,13 @@ section.
       MIME::Base64 / HTTP::Server::Tiny / Tubu (sync WAF) / DBIish (SQLite) / NativeCall.
       Use "a web blog can be written with the bundle alone" as the selection criterion (the HTTP
       client gap needs investigation).
+- [ ] **Web-framework slot** — surveyed 2026-07-31, no winner bundled yet:
+      [docs/batteries/web-framework.md](docs/batteries/web-framework.md). Humming-Bird (MIT,
+      active, pure-Raku, IO::Socket::Async + react/whenever) is the short-term battery candidate —
+      one parser ticket (`todo/tickets/brace-subscript-after-call-and-parens.md`) gates most of its
+      suite gap. Cro (61 dependents, raku baseline 28/28, mutsu 1/28) is the mid-term north star:
+      no `nqp` left in its chain; blockers are ticketed, ordinary compat work + a `monitor` shim.
+      Note this supersedes the "Cro = nqp territory" reading of the 2026-06 scouting notes.
 - [ ] **Vendoring mechanism**: vendor the bundled modules into the source tree (e.g. `modules/`) so
       an installed mutsu resolves them with no extra configuration (make `MUTSULIB` have a built-in
       default, or register a standard lib path in `Interpreter::new()` — same pattern as

--- a/docs/batteries/http-client.md
+++ b/docs/batteries/http-client.md
@@ -122,6 +122,12 @@ services (HTTP client + server, WebSockets, TLS, routing) on the
 in the whole Cro stack, and its TLS relies on `IO::Socket::Async::SSL` (async +
 OpenSSL) which mutsu has no foundation for. Overkill for "make one request."
 
+> **Update 2026-07-31:** the "no foundation" claim is stale — mutsu now bundles
+> and drives the `OpenSSL` binding (sync TLS battery), and a measured
+> re-assessment of the whole Cro chain (no `nqp` left upstream; concrete,
+> ticketed blockers) is in [web-framework.md](web-framework.md). The *rejection
+> for the HTTP-client slot* stands; Cro's reachability picture changed.
+
 ### Homegrown curl-shellout client — rejected
 
 A mutsu-specific client driving system `curl` via `Proc::Async` (the pattern the

--- a/docs/batteries/web-framework.md
+++ b/docs/batteries/web-framework.md
@@ -1,0 +1,131 @@
+# Battery survey: web framework
+
+**Status: surveyed, no winner bundled yet — the survey's output is a work list
+(as predicted by [selection-method.md](selection-method.md) §5).**
+
+Date: 2026-07-31. Method: [selection-method.md](selection-method.md) — field
+enumerated from the fez index (7711 entries; recency taken from the CDN
+tarball `Last-Modified`, since the fez index carries no dates), licenses and
+reverse-dependency counts from the same index, then every candidate's own
+upstream test suite run under `raku` (2026.06) first and mutsu (release)
+second, from the dist's own directory, one `prove` per file.
+
+This is the slot the batteries yardstick points at directly: *"a small web
+blog can be written with the bundle alone"* (BATTERIES.md §2).
+
+## The field
+
+Frameworks registered on fez with a release in the last ~3 years:
+
+| Candidate | Ver | Last release | License | Runtime deps character | Dependents |
+| --- | --- | --- | --- | --- | --- |
+| **Cro::HTTP** (+ Core/TLS/WebApp) | 0.8.9.1 | 2024-01 (WebApp 2025-01) | Artistic-2.0 | OO::Monitors, IO::Socket::Async::SSL→OpenSSL, 9 more | **61** |
+| **Humming-Bird** | 4.1.0 | 2026-07 | MIT | 9 pure-Raku dists (JSON::Fast, HTTP::Status, MIME::Types, …); Cro::HTTP::Client only in integration tests + one APM plugin | 1 |
+| **Air** | 0.1.9 | 2026-02 | Artistic-2.0 | hard-depends on Cro::HTTP + Cro::WebApp + Cromponent | 9 (own plugins) |
+| **MVC::Keayl** | 0.9.1 | 2026-07 | Artistic-2.0 | Cro::HTTP + OpenSSL + Digest::SHA1::Native + own ORM/HAML | 1 |
+| **Web::App** | 0.9.2 | 2026-01 | Artistic-2.0 | PSGI, SCGI, FastCGI, HTTP::Easy, MIME::Types (all pure) | 1 |
+| **Router::Right** (router only) | 0.0.61 | 2024-08 | Artistic-2.0 | P5quotemeta | 1 |
+| Crolite / Cromponent | 0.0.1 / 0.0.9 | 2026-01 / 2025-01 | Artistic-2.0 | Cro-stack accessories | 0 / 1 |
+
+Out of scope: Hiker (2021), Web::App::MVC (2022) — no release in 3 years;
+Bailador, Hematite — not on fez. `HTTP::Easy` (2026-01, PSGI server) is
+Web::App's engine, surveyed with it.
+
+Ecosystem standing is lopsided: **Cro::HTTP has 61 dependents** — it is the de
+facto standard, and Air/MVC::Keayl/Cromponent/Crolite are all built on it.
+Humming-Bird is the only actively-maintained framework that is pure Raku all
+the way down.
+
+## Measured suite results (2026-07-31)
+
+`raku` column measured first per the method; a file counts as passing only
+when prove accepts its TAP. mutsu = release build, `timeout 60` per test.
+
+| Suite | raku | mutsu | Dominant mutsu blocker |
+| --- | --- | --- | --- |
+| Humming-Bird t/ (14 files) | 10/14 (a) | 5/14 | one parser bug, see below |
+| Router::Right (3) | 3/3 | 0/3 | real subtest failures (uninitialized-Any warnings; unreduced) |
+| Web::App (1) | 1/1 | 1/1 | — |
+| HTTP::Easy (1) | 1/1 | 1/1 | — |
+| OO::Monitors (5) | 5/5 | 0/5 | `monitor` declarator (EXPORTHOW::DECLARE) unimplemented |
+| Cro::Core (9) | 9/9 | 1/9 | `Cro::Service.start` missing, `.message` on List, 3 subtest-level failures |
+| Cro::HTTP (28) | **28/28** (b) | 1/28 | the two tickets below gate nearly everything |
+
+(a) 4 files (`t/07`–`t/10`) fail under raku itself with a duplicate-import
+collision (`use Humming-Bird::Core` + `use Humming-Bird::Glue`) — dead
+upstream, not a mutsu target. So the reachable HB baseline is 10.
+(b) With its deps properly `zef install`ed. Running deps from `-I` source
+trees breaks `OpenSSL::NativeLib`'s `%?RESOURCES` handling under raku too —
+survey with installed deps or you will under-measure the baseline (this
+survey's first pass read 5/28 for exactly that reason).
+
+### The two bugs that gate most of the field
+
+1. **[`todo/tickets/brace-subscript-after-call-and-parens.md`](../../todo/tickets/brace-subscript-after-call-and-parens.md)**
+   — `routes{'/'}` / `($a // $b){$key}` postcircumfix `{}` mis-parsed as a
+   block/hash argument. Gates 5 of Humming-Bird's 6 mutsu-attributable
+   failures **and** `use Cro::HTTP::Router` (parse error at Router.pm6:188).
+   One fix, two frameworks.
+2. **[`todo/tickets/cro-bodyserializers-required-method-false-positive.md`](../../todo/tickets/cro-bodyserializers-required-method-false-positive.md)**
+   — false "Method 'serialize' must be implemented" on a proto/multi
+   implementation; blocks `Cro::HTTP::Request`/`Response` load.
+
+## Cro reachability — the 2026-07 re-assessment
+
+Earlier project notes ("Cro = nqp/CStruct territory", 2026-06 ecosystem
+scouting; "IO::Socket::Async::SSL … which mutsu has no foundation for",
+[http-client.md](http-client.md)) are **stale**. Measured against the current
+releases:
+
+- **No `use nqp` anywhere** in Cro::Core / Cro::HTTP / Cro::TLS / OO::Monitors
+  / Log::Timeline / HTTP::HPACK. The only `nqp::` in the whole chain is one
+  `nqp::sha1` line in `OpenSSL::NativeLib` (a resources-path helper).
+- **NativeCall surfaces are small and known**: the OpenSSL binding (~94
+  `is native` functions — and mutsu already bundles and drives `OpenSSL` for
+  the sync TLS battery) and one `setsockopt` in `Cro::Core`'s TCP_NODELAY.
+- **`monitor` (OO::Monitors) is needed by only 3 Cro::HTTP files** — Client,
+  CookieJar, Session::InMemory. The server-side core does not use it. It is
+  the one genuine `deep_guts` item (EXPORTHOW::DECLARE + a MetamodelX
+  metaclass), and would need the "narrow per-feature shim" the
+  [guts survey](../ecosystem-guts-dependency-survey.md) recommends —
+  a built-in `monitor` declarator, not a general slang layer.
+- Probes on today's mutsu: `Cro::Message` loads and composes as a role;
+  `Cro::TCP`, `Cro::Uri`, `Cro::MediaType`, `Cro::HTTP::BodyParsers` all
+  `use` cleanly. What remains is ordinary pure-Raku compatibility work of the
+  kind every battery campaign has consisted of — plus, for the async server
+  path, real `IO::Socket::Async` + supply-pipeline load (mutsu's S17 layer
+  gets its first production-shaped workout).
+
+## Leaning: two tracks, Humming-Bird first
+
+- **Short term — Humming-Bird is the battery candidate.** MIT, actively
+  maintained (2026-07), pure-Raku dep closure of which most is already
+  bundled or proven on mutsu, server built directly on
+  `IO::Socket::Async.listen` + `react whenever` (implemented territory), and
+  the suite gap to the 10/14 baseline is essentially one parser ticket. Its
+  weakness is ecosystem standing (1 dependent) — it earns the slot by being
+  *reachable*, not by being the standard.
+- **Mid term — Cro is the compatibility north star for this slot**, the same
+  role zef plays for the module pipeline: 61 dependents, and Air (the most
+  interesting modern DX, HTMX-oriented, 2026-02) plus the rest of the Cro
+  ring all become reachable if and only if Cro::HTTP runs. Do not bundle Cro
+  yet; treat "Cro::HTTP suite green under mutsu" as a campaign target measured
+  by this survey's harness, starting with the two tickets above, then
+  `Cro::Service.start`, then a built-in `monitor`.
+- **Rejected for the slot**: Web::App/HTTP::Easy (healthy and tiny, but a
+  synchronous PSGI/SCGI/FastCGI design from the pre-async era with 1
+  dependent; its suites already pass — keep as a compat data point, not a
+  battery); MVC::Keayl (Cro-gated *and* single-author stack with its own ORM);
+  Air/Cromponent/Crolite (Cro-gated — revisit after Cro); Router::Right
+  (not a framework; its 0/3 is a real mutsu bug cluster worth fixing but the
+  dist doesn't fill the slot).
+
+## Reproduction
+
+Survey harness (fetch + closure of `-I` paths + per-file prove) lives in the
+session scratchpad, pattern identical to `tmp/tmpl-survey.sh` from the
+template-slot survey; re-derive from [selection-method.md](selection-method.md)
+§3. Key detail for Cro::HTTP: `zef install --/test JSON::Fast OO::Monitors
+Base64 HTTP::HPACK IO::Path::ChildSecure JSON::JWT DateTime::Parse
+Crypt::Random Log::Timeline IO::Socket::Async::SSL Cro::Core Cro::TLS` first,
+then run each `t/*.t` with only `-I <dist>/lib`.

--- a/todo/tickets/brace-subscript-after-call-and-parens.md
+++ b/todo/tickets/brace-subscript-after-call-and-parens.md
@@ -1,0 +1,42 @@
+# Postcircumfix `{ }` not applied to sub-call results or parenthesized expressions
+
+In Raku, an identifier or a closing paren followed **immediately** (no
+whitespace) by `{ ... }` is a hash subscript on the value, not a block/hash
+argument. mutsu mis-parses both shapes:
+
+```raku
+sub routes() { {a=>1} }
+say routes{"a"};          # raku: 1
+                          # mutsu: {a => Nil}   (treats {"a"} as a hash-composer argument)
+
+my %h = b => 2;
+say (%h // %h){"b"};      # raku: 2
+                          # mutsu: prints %h and warns "Useless use of constant string"
+                          #        ({"b"} becomes a separate sinked block)
+```
+
+When the sub has a non-zero arity the first shape dies with
+`Too many positionals passed; expected 0 arguments but got more`. In statement
+context inside a class body, the second shape escalates to a parse error
+(`===SORRY!=== expected statement`), which is how it was found.
+
+The `[ ]` postcircumfix is NOT affected: `(@a || @a)[0]` works.
+
+## Impact (found by the 2026-07-31 web-framework survey)
+
+- **Humming-Bird 4.1.0**: 5 of its 6 mutsu-attributable failing test files
+  (`t/01,04,05,06,13`) die on `routes{'/'}{GET}` — this single fix should
+  take the suite from 5/14 to ~10/14 (the raku baseline; 4 files fail under
+  raku itself with a duplicate-import error).
+- **Cro::HTTP::Router** (`lib/Cro/HTTP/Router.pm6:188`): fails to parse at
+  `($!flattened-plugin-config // $!plugin-config){$key}.List` — this blocks
+  `use Cro::HTTP::Router` entirely, i.e. the whole Cro server-side DX.
+
+## Where
+
+Parser postfix handling: after parsing a term (function call without parens,
+or a parenthesized expression), a `{` with **no preceding whitespace** must
+continue the postfix chain as a hash subscript, exactly like `[` does today.
+Whitespace before `{` keeps the current block/hash-argument meaning.
+
+Repro: `target/debug/mutsu -e 'sub routes() { {a=>1} }; say routes{"a"}'`

--- a/todo/tickets/cro-bodyserializers-required-method-false-positive.md
+++ b/todo/tickets/cro-bodyserializers-required-method-false-positive.md
@@ -1,0 +1,42 @@
+# False "Method 'serialize' must be implemented" loading Cro::HTTP::BodySerializers
+
+Loading the real `Cro::HTTP::BodySerializers` (Cro::HTTP 0.8.9.1) under mutsu
+dies at module load with:
+
+```
+Method 'serialize' must be implemented by Cro::HTTP::BodySerializer::WWWFormUrlEncoded
+because it is required by roles: Cro::BodySerializer, Cro::HTTP::BodySerializer.
+  in block <unit> at .../lib/Cro/HTTP/BodySerializers.pm6 line 88
+```
+
+The class *does* implement it, as `proto method serialize(... --> Supply) {*}`
+plus two `multi method serialize` candidates (line 88 is the proto). The role
+requirement check does not count this proto/multi pair as an implementation in
+this module's context.
+
+This blocks `use Cro::HTTP::Request` / `Cro::HTTP::Response` (both pull in
+BodySerializers), i.e. most of Cro::HTTP, even though `Cro::Core` modules load
+fine.
+
+## Reduced repros all pass individually
+
+Same pattern as the `HTTP::Tiny` interaction bug recorded in
+`docs/batteries/http-client.md` — needs dedicated isolation:
+
+- one-file `role R { method f() { ... } }` + `class C does R { proto/multi f }` → OK
+- two-module chain (`role A` in module 1; `role B does A` + consuming class
+  with proto/multi in module 2) → OK
+- with `--> Str`-style return constraints on role stub, proto, and multis → OK
+
+Likely relevant differences in the real module: the base role
+(`Cro::BodySerializer`) comes from a separate dist (`Cro::Core`), the file
+defines several sibling classes implementing plain `method serialize` before
+the proto/multi one, and the stub signature carries typed params from yet
+another module (`Cro::HTTP::Message`).
+
+Repro (with the Cro sources fetched from fez):
+
+```
+target/debug/mutsu -I <cro-core>/lib -I <cro-http>/lib \
+  -e 'use Cro::HTTP::BodySerializers; say "ok"'
+```


### PR DESCRIPTION
## Summary

Surveys the **web-framework battery slot** per `docs/batteries/selection-method.md`: enumerate fez frameworks with a release in the last ~3 years, collect license / deps / reverse-dependency metrics, then run each candidate's upstream test suite under raku (baseline) first and mutsu (release) second.

| Suite | raku | mutsu |
| --- | --- | --- |
| Humming-Bird (14 files) | 10/14 | 5/14 |
| Cro::HTTP (28) | **28/28** | 1/28 |
| Cro::Core (9) | 9/9 | 1/9 |
| OO::Monitors (5) | 5/5 | 0/5 |
| Router::Right (3) | 3/3 | 0/3 |
| Web::App / HTTP::Easy | 1/1 each | 1/1 each |

## Cro re-assessment

The 2026-06 "Cro = nqp/CStruct territory" reading is **stale** and is corrected in the record (plus an update note in `http-client.md` and a pointer in `PLAN.md` B1): the current Cro chain has **zero `use nqp`**, its NativeCall surface is the already-bundled OpenSSL binding + one setsockopt, and `monitor` gates only 3 client-side files.

## Tickets filed (the two bugs gating most of the field)

- `todo/tickets/brace-subscript-after-call-and-parens.md` — `routes{'/'}` / `(a // b){$k}` postcircumfix `{}` mis-parsed as a block argument; gates 5 Humming-Bird files **and** `use Cro::HTTP::Router`.
- `todo/tickets/cro-bodyserializers-required-method-false-positive.md` — false required-method error on a proto/multi implementation; blocks `Cro::HTTP::Request`/`Response`.

## Leaning

Short term: **Humming-Bird** (MIT, 2026-07 release, pure-Raku deps, IO::Socket::Async + react/whenever). Mid term: **Cro as the slot's compatibility north star** (61 dependents; Air / MVC::Keayl / Cromponent all sit on it).

Docs-only diff — heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)