### PR TITLE
fix(parser): bind no-whitespace postcircumfix { } on call results and parenthesized expressions

### DIFF
--- a/docs/batteries/web-framework.md
+++ b/docs/batteries/web-framework.md
@@ -80,6 +80,12 @@ releases:
 - **No `use nqp` anywhere** in Cro::Core / Cro::HTTP / Cro::TLS / OO::Monitors
   / Log::Timeline / HTTP::HPACK. The only `nqp::` in the whole chain is one
   `nqp::sha1` line in `OpenSSL::NativeLib` (a resources-path helper).
+  *Correction (same day, found by load-probing after the brace-subscript fix):*
+  that claim covers the 7 dists' own code, but Log::Timeline **eagerly loads**
+  its `CBOR::Simple` output backend, which is an `nqp_ops_only` dist (buffer
+  read/write ops). That makes the nqp-op subset a real, bounded prerequisite
+  for loading Cro::HTTP — see
+  [`todo/tickets/cbor-simple-nqp-buf-ops.md`](../../todo/tickets/cbor-simple-nqp-buf-ops.md).
 - **NativeCall surfaces are small and known**: the OpenSSL binding (~94
   `is native` functions — and mutsu already bundles and drives `OpenSSL` for
   the sync TLS battery) and one `setsockopt` in `Cro::Core`'s TCP_NODELAY.

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1625,10 +1625,15 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
         // Treat this as Type.new(...) for package/type barewords.
         // But NOT for sigilless variables (term symbols like \h), which should use
         // hash subscript semantics instead. Also NOT for `self` which uses hash subscript.
+        // Also NOT for known routines: `routes{'/'}` is a hash subscript on the
+        // call result (raku binds a no-whitespace `{` as postcircumfix), so a
+        // declared or imported sub falls through to the Index arm below.
         if rest.starts_with('{')
             && matches!(&expr, Expr::BareWord(name) if {
                 name != "self"
                 && crate::parser::stmt::simple::match_user_declared_term_symbol(name).is_none()
+                && !crate::parser::stmt::simple::is_user_declared_sub(name)
+                && !crate::parser::is_imported_function(name)
             })
         {
             let r = &rest[1..];
@@ -1758,6 +1763,15 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     | Expr::Literal(_)
                     | Expr::DoStmt(_)
                     | Expr::Grouped(_)
+                    // A parenthesized binary expression is returned UNWRAPPED by
+                    // paren_expr (only barewords/vars/feeds/junctions keep their
+                    // Grouped shell), so `($a // $b){$key}` reaches this arm as a
+                    // bare Binary. raku applies postcircumfix `{ }` to any
+                    // parenthesized term (Cro::HTTP::Router relies on it); without
+                    // this the `{$key}` was left behind as a separate block
+                    // statement — a parse error in statement position.
+                    | Expr::Binary { .. }
+                    | Expr::Ternary { .. }
                     // A hash literal `%(...)` is a term and may be directly
                     // subscripted: `%(a=>1,b=>2){"a"}` is `1`. (Angle subscript
                     // `%(...)<a>` already works because that handler is

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1460,6 +1460,12 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         && !r.starts_with(',')
         && !rest.starts_with('.')
         && !rest.starts_with('[')
+        // A `{` with NO whitespace after the name is a postcircumfix hash
+        // subscript on the call result (`routes{'/'}` is `routes(){'/'}` —
+        // Humming-Bird's route table), not a hash-composer argument. Leave the
+        // bareword for the postfix loop's Index arm. `routes {'/'}` (spaced)
+        // still parses as a listop argument below.
+        && !rest.starts_with('{')
         && !(ws_consumed_unspace && r.starts_with('.') && !r.starts_with(".."))
         && !is_unspace_before_postfix(r)
     {

--- a/t/brace-subscript-postfix.t
+++ b/t/brace-subscript-postfix.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# Postcircumfix {} with no leading whitespace binds as a hash subscript on
+# sub-call results and parenthesized expressions (raku semantics).
+# Regression pins for todo/tickets/brace-subscript-after-call-and-parens.md:
+# `routes{'/'}` (Humming-Bird) and `($a // $b){$key}` (Cro::HTTP::Router).
+
+plan 9;
+
+enum HTTPMethod <GET POST>;
+sub local-routes() { { '/' => { GET => 'get-handler' } } }
+
+is local-routes{'/'}{GET}, 'get-handler', 'brace subscript on no-paren sub call result chains';
+is local-routes(){'/'}{GET}, 'get-handler', 'brace subscript on parenized sub call result chains';
+
+# The imported-sub path goes through the listop call parser, which must also
+# treat a no-whitespace `{` as a subscript (the Humming-Bird `routes{'/'}` shape).
+use lib 't/lib';
+use BraceSubscriptRoutes;
+is routes{'/'}{'GET'}, 'imported-handler', 'imported sub call result subscripts';
+
+my %a = x => 1;
+my %b;
+# NB: an empty hash is still defined, so `//` yields its LHS: (%b // %a){'x'}
+# is %b{'x'} (Any) in raku too. Use the defined-operand shapes below.
+is (%a // %b){'x'}, 1, 'brace subscript on parenthesized // expression';
+nok ((%b // %a){'x'}).defined, '// yields defined LHS; subscript miss is Any (raku parity)';
+
+my %h = a => 42;
+is (True ?? %h !! %b){'a'}, 42, 'brace subscript on parenthesized ternary';
+
+# .List on the subscript result (the exact Cro::HTTP::Router shape)
+my %cfg = k => (1, 2);
+is-deeply (%cfg // %b){'k'}.List, (1, 2), 'subscript result method call chains (Router.pm6:188 shape)';
+
+# Whitespace before the brace still means a block/hash argument, not a subscript.
+sub takes-hash(%h) { %h<key> }
+is takes-hash({ key => 'v' }), 'v', 'explicit hash arg in parens still works';
+
+# A statement block after a parenthesized condition keeps working.
+my $side = 0;
+if (1) { $side = 1 }
+is $side, 1, 'if with parenthesized condition and spaced block unaffected';
+
+done-testing;

--- a/t/lib/BraceSubscriptRoutes.rakumod
+++ b/t/lib/BraceSubscriptRoutes.rakumod
@@ -1,0 +1,5 @@
+unit module BraceSubscriptRoutes;
+
+sub routes(--> Hash:D) is export {
+    { '/' => { 'GET' => 'imported-handler' } }
+}

--- a/todo/tickets/cbor-simple-nqp-buf-ops.md
+++ b/todo/tickets/cbor-simple-nqp-buf-ops.md
@@ -1,0 +1,44 @@
+# CBOR::Simple needs the nqp buffer op family — gates Log::Timeline, and therefore Cro::HTTP
+
+Found while probing `use Cro::HTTP::Router` after the brace-subscript parser
+fix. The load chain is:
+
+```
+Cro::HTTP::Router → Cro::HTTP::Response → ... → Cro::HTTP::LogTimelineSchema
+  → Log::Timeline            (Log/Timeline.rakumod line 2 eagerly does)
+  → Log::Timeline::Output::CBORSequence
+  → CBOR::Simple             ← dies: "Unsupported nqp:: op: nqp::bitor_i" (line 124)
+```
+
+So the web-framework survey's "no `use nqp` anywhere in the Cro chain" claim
+holds for the 7 dists' own code but misses this **transitive** dep:
+Log::Timeline (a hard dep of Cro::HTTP) eagerly loads its CBOR output backend,
+and `CBOR::Simple` is a classic `nqp_ops_only` dist. Its op histogram
+(`grep -o 'nqp::[a-z_0-9]*' lib/CBOR/Simple.rakumod | sort | uniq -c`):
+
+- hot: `istype` (45), `add_i` (41), `writeuint` (40), `readuint` (24),
+  `const` (24), `islt_i` (19), `while` (18), `decont` (17)
+- bit ops: `bitshiftl_i` (13), `bitor_i` (11), `bitand_i` (4), `bitshiftr_i` (1)
+- buf ops: `bindpos_i`/`bindpos_n`/`atpos_i`/`atpos_n`, `setelems`, `slice`,
+  `splice`, `writenum`/`readnum`, `writeint`/`readint`
+- misc: `iseq_i`/`isle_i`/`iseq_n`/`isne_n`, `isnanorinf`, `p6box_s`,
+  `decode`, `elems`, `stmts`/`if` (control flow)
+
+mutsu already dispatches a supported nqp subset
+(`src/runtime/builtins_operators_fallback.rs` — the error text is the
+fallthrough), so this is an *extension* of an existing mechanism, not a new
+layer. The integer/bit/comparison ops are trivial; the work is the
+`readuint`/`writeuint`(+int/num) family with `nqp::const` endian/size flags
+over Buf/Blob, plus `nqp::while`/`nqp::stmts` control-flow forms if they are
+not already handled.
+
+Until this lands, `use Cro::HTTP::<anything that touches Request/Response>`
+cannot even load under mutsu regardless of other fixes. (Workaround options
+considered and rejected: patching the vendored Log::Timeline violates the
+never-edit-vendored rule; a fake CBOR::Simple shim violates rung-3 policy.)
+
+Repro (deps fetched from fez/REA as in the survey):
+
+```
+target/debug/mutsu -I <log-timeline>/lib -I <cbor-simple>/lib -e 'use Log::Timeline; say "ok"'
+```

--- a/todo/tickets/cro-bodyserializers-required-method-false-positive.md
+++ b/todo/tickets/cro-bodyserializers-required-method-false-positive.md
@@ -34,6 +34,21 @@ defines several sibling classes implementing plain `method serialize` before
 the proto/multi one, and the stub signature carries typed params from yet
 another module (`Cro::HTTP::Message`).
 
+## Hypothesis (from reading `src/runtime/registration.rs` ~line 267)
+
+The composition check satisfies a stub only when a concrete candidate passes
+`method_signatures_match(required, candidate)`. The Cro::Core stub is
+`method serialize(Cro::Message $message, $body --> Supply)` while the class
+proto/multis type the first parameter as the *narrower* `Cro::HTTP::Message`
+(and the multis use `@body` / `%body`), so every candidate fails the signature
+match → `local_matches == 0` → false error. All my reduced repros used
+*identical* parameter types on stub and implementation, which is why they
+passed. Rakudo satisfies a role requirement by NAME (the signature is
+advisory), so the fix is likely to relax `method_signatures_match` here (or
+count any same-named concrete/proto as satisfying the stub). Untested — verify
+with a repro where the stub and the implementing proto/multi differ in a
+positional parameter's type constraint.
+
 Repro (with the Cro sources fetched from fez):
 
 ```


### PR DESCRIPTION
## Summary

Implements `todo/tickets/brace-subscript-after-call-and-parens.md` (filed by the web-framework survey, #5598): raku binds a **no-whitespace** `{ }` after a term as a hash subscript, but three mutsu parse paths dropped it:

1. **Listop call path** (`identifier_call.rs`): an imported sub like Humming-Bird's `routes{'/'}` consumed `{'/'}` as a hash-composer *argument* → "Too many positionals passed; expected 0 arguments". A no-whitespace `{` now leaves the bareword for the postfix Index arm; `routes {'/'}` (spaced) still parses as an argument.
2. **`Type{...}` constructor shorthand** (`loop_.rs`): swallowed the same shape for locally-declared subs. Known routines (declared or imported) now fall through to the subscript arm.
3. **Postfix hash-index arm** (`loop_.rs`): rejected parenthesized binary/ternary targets because `paren_expr` returns them unwrapped, so `($a // $b){$key}.List` — the exact `Cro::HTTP::Router` line-188 shape — escalated to a parse error in statement position. `Expr::Binary`/`Expr::Ternary` are now accepted subscript targets.

## Measured effect

- **Humming-Bird upstream suite: 5/14 → 9/14** (raku baseline 10/14; the remaining gap is unrelated smaller bugs, e.g. a `$var` X::Undeclared in t/03).
- **`use Cro::HTTP::Router` now parses**, surfacing the next real blocker: `Log::Timeline` eagerly loads `CBOR::Simple`, an nqp-buffer-ops dist — filed as `todo/tickets/cbor-simple-nqp-buf-ops.md` with a matching correction to the survey record's "no nqp in the chain" claim.
- Pin: `t/brace-subscript-postfix.t` — **9/9 under mutsu and under raku**.
- Local `make test`: all 2622 files pass; clippy/fmt clean.

Also records the signature-match hypothesis (from reading `registration.rs`) in the BodySerializers false-positive ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)