### PR TITLE
fix(compiler): placeholder in a chained comparison no longer dies in subset where blocks

### DIFF
--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -6,9 +6,37 @@ impl Compiler {
         // used directly inside it cannot be captured -> X::Placeholder::Block.
         // Exception: inside a method, the legacy argument variables `%_` / `@_`
         // refer to the method's implicit `*%_` / `*@_` slurpy and are valid here.
+        // Exception: a placeholder that is already a bound parameter of the
+        // ENCLOSING block — its local exists in `local_map` — is attached, not
+        // stray. The chained-comparison desugar (`{ 0 <= $^p <= 5 }`) wraps the
+        // body in a compiler-generated DoBlock inside the very AnonSubParams
+        // that owns `^p`; dying here broke every subset/where written that way
+        // (Cro::Core's `Cro::Port`). Pin: t/subset-where-placeholder-chain.t.
         if let Some(ph) = crate::ast::collect_unattached_placeholders(body)
             .into_iter()
-            .find(|ph| !(self.lexically_in_method && (ph == "%_" || ph == "@_")))
+            .find(|ph| {
+                if self.lexically_in_method && (ph == "%_" || ph == "@_") {
+                    return false;
+                }
+                // A CARET placeholder (`$^p`) already bound as the enclosing
+                // block's parameter is attached, not stray: the local exists in
+                // `local_map` (same-compiler case), or the interpret-path
+                // caller bound it in env and seeded `prebound_placeholder_params`
+                // (re-entrant block eval — `call_sub_value` → `eval_block_value`
+                // re-compiles the body alone). The chained-comparison desugar
+                // (`{ 0 <= $^p <= 5 }`) wraps the body in a compiler-generated
+                // DoBlock inside the very block that owns `^p`; dying here broke
+                // every subset/where written that way (Cro::Core's `Cro::Port`).
+                // Pin: t/subset-where-placeholder-chain.t. The `%_`/`@_` implicit
+                // slurpies keep the strict rule (only a METHOD provides them) —
+                // pin: t/placeholder-named-in-method-do.t.
+                let bare = ph.trim_start_matches(['$', '@', '%', '&']);
+                let attached_caret = bare.starts_with('^')
+                    && (self.local_map.contains_key(ph.as_str())
+                        || self.local_map.contains_key(bare)
+                        || self.prebound_placeholder_params.contains(bare));
+                !attached_caret
+            })
         {
             let err = Self::placeholder_scope_error("block", &ph);
             let idx = self.code.add_constant(err);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -236,6 +236,10 @@ pub(crate) struct Compiler {
     /// degrade to the literal name string once the creating frame is gone
     /// (escaping closure / `.^add_method`).
     enclosing_sigilless: std::collections::HashSet<String>,
+    /// Placeholder params (`^p` caret-form) an interpret-path caller has
+    /// already bound in env before re-compiling this body — see
+    /// `seed_prebound_placeholders`.
+    pub(super) prebound_placeholder_params: std::collections::HashSet<String>,
     /// Set true immediately before compiling a *synthesized* `Stmt::Block`
     /// (an if/while/loop/control branch body the compiler wraps at compile time,
     /// not a genuine source `{ ... }`). The `Stmt::Block` arm consumes it to
@@ -354,6 +358,7 @@ impl Compiler {
             outer_constant_names: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
             enclosing_sigilless: std::collections::HashSet::new(),
+            prebound_placeholder_params: std::collections::HashSet::new(),
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),
             current_distribution: None,
@@ -566,6 +571,23 @@ impl Compiler {
     /// call it. No-op for the common empty case.
     pub(crate) fn seed_enclosing_sigilless(&mut self, names: &[String]) {
         self.enclosing_sigilless.extend(names.iter().cloned());
+    }
+
+    /// Seed the placeholder parameters an interpret-path caller has already
+    /// BOUND (in env) before re-compiling a block body with a fresh compiler
+    /// (`call_sub_value` → `eval_block_value`). The body of
+    /// `{ 0 <= $^p <= 5 }` reaches that fresh compiler as bare statements —
+    /// the chained-comparison desugar wraps them in a compiler-generated
+    /// DoBlock, whose stray-placeholder check would otherwise die on `$^p`
+    /// even though the closure's own signature bound it. Stored caret-form
+    /// (`^p`), sigil stripped, matching `collect_unattached_placeholders`.
+    pub(crate) fn seed_prebound_placeholders(&mut self, params: &[String]) {
+        for p in params {
+            let bare = p.trim_start_matches(['$', '@', '%', '&']);
+            if bare.starts_with('^') {
+                self.prebound_placeholder_params.insert(bare.to_string());
+            }
+        }
     }
 
     fn inherit_enclosing_scopes(&self, sub: &mut Compiler) {

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -544,7 +544,16 @@ impl Interpreter {
                     .map(|pd| pd.name.clone())
                     .collect(),
             );
+            let saved_eval_placeholders = std::mem::replace(
+                &mut self.pending_eval_placeholder_params,
+                def.params
+                    .iter()
+                    .filter(|p| p.trim_start_matches(['$', '@', '%', '&']).starts_with('^'))
+                    .cloned()
+                    .collect(),
+            );
             let result = self.eval_block_value_with_pre_post(&def.body);
+            self.pending_eval_placeholder_params = saved_eval_placeholders;
             self.pending_eval_sigilless = saved_eval_sigilless;
             self.set_current_package(saved_package);
             self.routine_stack.pop();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1025,6 +1025,10 @@ pub struct Interpreter {
     /// attr.get_value(self) }`). Seeded right before the eval and consumed by the
     /// fresh compiler's `enclosing_sigilless`. Empty except across that call.
     pending_eval_sigilless: Vec<String>,
+    /// Placeholder params (e.g. `^p`) the current interpret-path sub call has
+    /// bound in env, seeded into `compile_block_value_opts`'s fresh compiler
+    /// so its stray-placeholder checks know they are attached.
+    pending_eval_placeholder_params: Vec<String>,
     /// PredictiveIterator backing a `Seq.new(iterator)`, keyed by the Seq's
     /// Arc pointer (`seq_id`). Kept off the scoped `env` so the association
     /// survives sub/block returns between Seq creation and `.tail`/`.Numeric`

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -572,7 +572,21 @@ impl Interpreter {
                     })
                     .unwrap_or_default(),
             );
+            // Tell the fresh-compiler body path which PLACEHOLDER params this
+            // call has bound (`{ 0 <= $^p <= 5 }` called as a subset `where`
+            // predicate), so the chained-comparison DoBlock's stray-placeholder
+            // check does not die on an attached one. Restored right after; a
+            // nested call sets and restores its own.
+            let saved_eval_placeholders = std::mem::replace(
+                &mut self.pending_eval_placeholder_params,
+                data.params
+                    .iter()
+                    .filter(|p| p.trim_start_matches(['$', '@', '%', '&']).starts_with('^'))
+                    .cloned()
+                    .collect(),
+            );
             let body_result = self.eval_block_value(&data.body);
+            self.pending_eval_placeholder_params = saved_eval_placeholders;
             self.frame_authoritative = saved_frame_auth;
             let result = match body_result {
                 Err(mut e) if e.is_leave => {

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -111,6 +111,7 @@ impl Interpreter {
         // sigilless parameters (`\attr`) as lexical captures rather than
         // barewords. The fresh compiler otherwise has no signature context.
         compiler.seed_enclosing_sigilless(&self.pending_eval_sigilless);
+        compiler.seed_prebound_placeholders(&self.pending_eval_placeholder_params);
         let scope = if let Some(frame) = self.routine_stack.last() {
             // Set enclosing_package to the clean package name so that
             // $?PACKAGE resolves to the package, not the mangled routine

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2099,6 +2099,7 @@ impl Interpreter {
             module_packages: HashMap::new(),
             closure_env_overrides: HashMap::new(),
             pending_eval_sigilless: Vec::new(),
+            pending_eval_placeholder_params: Vec::new(),
             predictive_seq_iters: HashMap::new(),
             protect_block_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -363,6 +363,7 @@ impl Interpreter {
             module_packages: self.module_packages.clone(),
             closure_env_overrides: self.closure_env_overrides.clone(),
             pending_eval_sigilless: Vec::new(),
+            pending_eval_placeholder_params: Vec::new(),
             predictive_seq_iters: self.predictive_seq_iters.clone(),
             protect_block_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),

--- a/t/subset-where-placeholder-chain.t
+++ b/t/subset-where-placeholder-chain.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# A subset `where` block written with a placeholder inside a CHAINED
+# comparison — `where { 0 <= $^port <= 0xFFFF }`, Cro::Core's Cro::Port —
+# died with X::Placeholder::Block: the chained-comparison desugar wraps the
+# body in a compiler-generated DoBlock, and its stray-placeholder check did
+# not know the enclosing closure's signature (or, on the re-entrant
+# block-eval lane, the caller's env binding) had attached the placeholder.
+
+plan 8;
+
+my $f = { 0 <= $^p <= 5 };
+ok $f(3), 'chained comparison with placeholder in a plain block (in range)';
+nok $f(9), 'chained comparison with placeholder in a plain block (out of range)';
+
+subset Port of Int where { 0 <= $^port <= 0xFFFF };
+ok 31313 ~~ Port, 'subset where-block placeholder chain matches in-range';
+nok 70000 ~~ Port, 'subset where-block placeholder chain rejects out-of-range';
+nok -1 ~~ Port, 'subset where-block placeholder chain rejects negative';
+
+my Port $p = 8080;
+is $p, 8080, 'typed declaration through the subset works';
+
+class Listener {
+    has Port $.port is required;
+}
+is Listener.new(port => 31313).port, 31313, 'attribute typed with the subset accepts a valid value';
+throws-like { Listener.new(port => 70000) }, Exception,
+    'attribute typed with the subset rejects an invalid value';
+
+done-testing;


### PR DESCRIPTION
## Summary

Cro campaign slice 3 (follow-up to #5599/#5601/#5602): `subset Cro::Port of Int where { 0 <= $^port <= 0xFFFF }` — Cro::Core's port type, used as an attribute type by `Cro::TCP` — died with `X::Placeholder::Block`. The chained-comparison desugar wraps the block body in a compiler-generated `DoBlock`, and its stray-placeholder check did not know the placeholder was attached.

Two lanes fixed:

1. **Same-compiler lane** — the enclosing block owns `^p` (its local is in `local_map`): skip the die for a caret placeholder in scope.
2. **Re-entrant block-eval lane** (`call_sub_value` → `eval_block_value`, how a subset `where` predicate is invoked) — the body is re-compiled alone by a fresh compiler, so the caller now passes its env-bound placeholder params via `pending_eval_placeholder_params` (same pattern as `pending_eval_sigilless`), seeded as `prebound_placeholder_params`. Also seeded on the named-function fallback lane.

The exemption is strictly for **caret** placeholders: `%_`/`@_` keep the old method-only rule — the first version let `sub f { do { %_ } }` compile, and `t/placeholder-named-in-method-do.t` caught it (fixed before commit).

## Verification

- Pin: `t/subset-where-placeholder-chain.t` — **8/8 under mutsu and raku** (plain block, smartmatch both ways, typed declaration, typed attribute accept/reject).
- `t/placeholder-named-in-method-do.t` stays green (7/7).
- Cro::Core `t/tcp.t` moves past its immediate abort to 14 passing subtests (remainder needs live TCP listener work).
- Local `make test`: all 2626 files pass; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)