### PR TITLE
fix(runtime): .bless on a role type object puns the role like .new does

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -333,6 +333,19 @@ impl Interpreter {
                 "getcodename requires a concrete code object",
             ));
         }
+        // `.bless` on a ROLE type object puns the role, exactly like `.new`
+        // does — Cro's composer builds its service as
+        // `$service-type.bless(:@components)` with the `Cro::Service` role as
+        // the default service type, and without the pun the instance carried
+        // the role's name but none of its methods (`.start` missing).
+        {
+            let cn = class_name.resolve();
+            if !self.registry().classes.contains_key(cn.as_str())
+                && self.registry().roles.contains_key(cn.as_str())
+            {
+                self.ensure_role_punned_to_class(&cn);
+            }
+        }
         // Initialize with default attribute values. The attribute defs and the
         // BUILD/TWEAK probes come from the cached per-class NativeCtorPlan
         // (shape-only data, invalidated with the dispatch caches) instead of

--- a/t/role-bless-pun.t
+++ b/t/role-bless-pun.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+# `.bless` on a ROLE type object puns the role into a class, exactly like
+# `.new` does. Cro's composer builds its service object as
+# `$service-type.bless(:@components)` where the default service type is the
+# `Cro::Service` ROLE — without the pun the instance carried the role's name
+# but none of its methods (`.start` was "No such method").
+
+plan 5;
+
+role Service {
+    has @.components is required;
+    has $!started;
+
+    method start(--> Str) { $!started = True; "started" }
+    method running(--> Bool) { ?$!started }
+}
+
+my $svc = Service.bless(components => [1, 2, 3]);
+is $svc.^name, 'Service', 'blessed role instance carries the role name';
+is $svc.components.elems, 3, 'bless named args populate role attributes';
+is $svc.start, 'started', 'role methods are callable on the blessed instance';
+ok $svc.running, 'private role attributes work through role methods';
+ok $svc ~~ Service, 'the blessed instance smartmatches the role';
+
+done-testing;


### PR DESCRIPTION
## Summary

Cro campaign slice 4 (follow-up to #5599/#5601/#5602/#5604). Cro's composer instantiates its service as `$service-type.bless(:@components)` — and the **default service type is the `Cro::Service` role**. `dispatch_bless` took the invocant's name as a class directly, so the instance carried the role's name but none of its methods (`.start` → X::Method::NotFound). A role invocant now routes through `ensure_role_punned_to_class` first, the same pun `.new` performs.

## Verification

- Pin: `t/role-bless-pun.t` — **5/5 under mutsu and raku** (name, attributes, methods, private attrs, smartmatch).
- Cro::Core `t/composer.t`: aborted at subtest 8 → **86 passing subtests** (the remainder hangs on live connection-manager supply pipelines — the next campaign item).
- Local `make test`: all 2627 files pass; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)