### PR TITLE
fix(ci): collect crash reports from subprocesses that start in another directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
     # than GNU ld. mold is installed in the "Install prove" step below.
     env:
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      # Absolute, so every mutsu in the process tree reports to the one place
+      # the crash-report step collects. See the note on that step below.
+      MUTSU_CRASH_DIR: ${{ github.workspace }}/tmp/crash
     steps:
       - uses: actions/checkout@v7
         with:
@@ -231,8 +234,18 @@ jobs:
       - name: Crash reports (fatal signals)
         # A `Wstat: 11 (Signal: SEGV)` line in the summary above names neither
         # the process that faulted nor the place. src/crash_report/ writes one
-        # tmp/crash/<pid>.txt per crashed process; print them here so the
-        # answer is in the job log the first time the crash fires.
+        # <pid>.txt per crashed process; print them here so the answer is in
+        # the job log the first time the crash fires.
+        #
+        # This covers every mutsu in the job — any t/ or roast file's own
+        # interpreter, and any subprocess it spawned (each writes its own
+        # report, told apart by pid and argv). That is why the job env sets an
+        # ABSOLUTE MUTSU_CRASH_DIR: the default `tmp/crash` is resolved against
+        # each process's startup working directory, so a subprocess spawned
+        # with `:cwd`, or one inheriting a `chdir`, would drop its report in
+        # some temp directory this step never looks at. Verified: with the
+        # relative default, a `run(..., :cwd(...))` child's report lands under
+        # that cwd instead.
         if: failure()
         run: scripts/report-crash-reports.sh
 
@@ -391,6 +404,9 @@ jobs:
       # S17-lowlevel/thread.t sat at ~24s against the 30s GC-off budget and
       # timed out on a loaded runner the first time this step ran blocking.
       MUTSU_ROAST_TIMEOUT_SCALE: "2"
+      # Absolute, so every mutsu in the process tree reports to the one place
+      # the crash-report step collects.
+      MUTSU_CRASH_DIR: ${{ github.workspace }}/tmp/crash
       # Link with mold (installed below); shared with the other native jobs.
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
@@ -527,6 +543,9 @@ jobs:
     env:
       MUTSU_JIT: "on"
       MUTSU_JIT_THRESHOLD: "2"
+      # Absolute, so every mutsu in the process tree reports to the one place
+      # the crash-report step collects.
+      MUTSU_CRASH_DIR: ${{ github.workspace }}/tmp/crash
       # Link with mold (installed below); shared with the other native jobs.
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:

--- a/news/2026-07/crash-report-absolute-dir-in-ci.md
+++ b/news/2026-07/crash-report-absolute-dir-in-ci.md
@@ -1,0 +1,31 @@
+# Crash reports from subprocesses now reach CI's collection step
+
+The [fatal-signal crash report](crash-report-on-fatal-signal.md) works for every mutsu in a job — any
+`t/` or roast file's own interpreter, and any subprocess it spawned, each writing its own
+`<pid>.txt` told apart by pid and argv. Verified end to end: a parent that spawns a crashing child
+survives with exit 0 while the child leaves a report naming *its* argv, which is precisely the
+parent-vs-`is_run`-child question the procasync note could not answer.
+
+One case escaped collection, though. The default report directory `tmp/crash` is *relative*, and it
+is resolved against each process's **startup** working directory. A later `chdir` therefore cannot
+move it — that part was already right — but a process that *starts* somewhere else does not report
+where CI looks:
+
+```
+$ mutsu -e 'run($*EXECUTABLE, ..., :cwd("tmp/elsewhere"))'   # child faults
+tmp/crash/                       -> does not exist
+tmp/elsewhere/tmp/crash/1704623.txt   <- the report, where nothing collects it
+```
+
+The same happens to a child that inherits a parent's `chdir`. Both shapes occur in the suite, and a
+subprocess crash is exactly what the feature exists to attribute — so losing it would have hollowed
+out the interesting half of the coverage.
+
+The fix is one line per job: `MUTSU_CRASH_DIR` is now exported as an **absolute** path
+(`${{ github.workspace }}/tmp/crash`) in the `test`, `gc-stress` and `jit-stress` jobs. Environment
+is inherited down the process tree, so every descendant — however it was spawned and wherever it
+starts — writes into the single directory the crash-report step prints and uploads.
+
+`tests/crash_report.rs` pins the property: a mutsu started in a different working directory with an
+absolute `MUTSU_CRASH_DIR` reports into that directory, records its own `cwd` in the report, and
+writes nothing under the directory it ran in.

--- a/src/crash_report/mod.rs
+++ b/src/crash_report/mod.rs
@@ -32,6 +32,13 @@
 //! `[profile.release]` sets `debug = false` — but the raw frame addresses can
 //! still be resolved offline with `addr2line -f -e target/release/mutsu`.
 //!
+//! The default `tmp/crash` is resolved against the process's **startup**
+//! working directory, so a later `chdir` cannot move it — but a process that
+//! *starts* elsewhere (a subprocess spawned with `:cwd`, or one inheriting a
+//! parent's `chdir`) writes its report under that directory instead. A harness
+//! that collects reports from one place must therefore export an absolute
+//! `MUTSU_CRASH_DIR`, which every descendant inherits; CI does exactly that.
+//!
 //! This is instrumentation, not a fix: it buys nothing until the next crash,
 //! and then it buys an answer instead of another dead end.
 

--- a/tests/crash_report.rs
+++ b/tests/crash_report.rs
@@ -114,6 +114,47 @@ fn reporting_can_be_switched_off() {
     );
 }
 
+/// A process that starts in some other directory must still report into an
+/// absolute `MUTSU_CRASH_DIR`.
+///
+/// This is the property CI depends on. The default `tmp/crash` is relative to
+/// each process's startup working directory, so a subprocess spawned with
+/// `:cwd` — or one inheriting a parent's `chdir` — would otherwise drop its
+/// report somewhere the collection step never looks, and the crash of a
+/// subprocess is exactly the case this whole feature exists to attribute.
+#[test]
+fn an_absolute_report_dir_survives_a_different_working_directory() {
+    let base = std::env::temp_dir().join(format!("mutsu-crash-test-cwd-{}", std::process::id()));
+    let elsewhere = base.join("elsewhere");
+    let reports = base.join("reports");
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&elsewhere).expect("failed to create working directory");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_mutsu"))
+        .args(["-e", "say 'sentinel-marker'"])
+        .current_dir(&elsewhere)
+        .env("MUTSU_CRASH_SELFTEST", "segv")
+        .env("MUTSU_CRASH_DIR", &reports)
+        .output()
+        .expect("failed to spawn mutsu")
+        .status;
+    assert_eq!(status.signal(), Some(libc::SIGSEGV));
+
+    let report = read_report(&reports);
+    assert_eq!(field(&report, "signal:"), "11 (SIGSEGV)");
+    // cwd is recorded too, so a report found here still says where it ran.
+    assert!(
+        field(&report, "cwd:").contains("elsewhere"),
+        "cwd line should record the process's own working directory:\n{report}"
+    );
+    assert!(
+        !elsewhere.join("tmp").exists(),
+        "an absolute MUTSU_CRASH_DIR must not also write under the cwd"
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
 /// An ordinary, non-crashing run must leave no trace: the report directory is
 /// created from inside the handler, never at startup.
 #[test]


### PR DESCRIPTION
Follow-up to #5603, closing a gap found while checking the obvious question: *does this also tell us
when some other test segfaults?*

Yes — the handler is process-wide and installed at startup, so every mutsu in a job writes its own
report: any `t/` or roast file's interpreter, and any subprocess it spawned. Verified end to end that
a parent spawning a crashing child survives with exit 0 while the child leaves a report naming *its*
argv, which is exactly the parent-vs-`is_run`-child question the procasync note could not answer.

**But one shape escaped collection.** The default `tmp/crash` is relative, resolved against each
process's *startup* working directory. A later `chdir` cannot move it (already correct), but a
process that *starts* elsewhere reports elsewhere:

```
$ mutsu -e 'run($*EXECUTABLE, ..., :cwd("tmp/elsewhere"))'   # child faults
tmp/crash/                            -> does not exist
tmp/elsewhere/tmp/crash/1704623.txt   <- the report, where nothing collects it
```

Same for a child inheriting a parent's `chdir`. Both shapes occur in the suite, and a subprocess
crash is precisely what the feature exists to attribute — so losing it would have hollowed out the
interesting half of the coverage.

## Fix

Export `MUTSU_CRASH_DIR` as an **absolute** path (`${{ github.workspace }}/tmp/crash`) in the `test`,
`gc-stress` and `jit-stress` jobs. Environment is inherited down the process tree, so every
descendant — however spawned, wherever it starts — writes into the single directory the crash-report
step prints and uploads. Verified locally: with the absolute value set, the `:cwd` child's report
lands in the collected directory and nothing is written under its own cwd.

## Test

`tests/crash_report.rs` gains a case pinning the property CI now depends on: a mutsu started in a
different working directory with an absolute `MUTSU_CRASH_DIR` reports into that directory, records
its own `cwd` in the report, and writes nothing under the directory it ran in.

The module docs now state the resolution rule explicitly, so the next harness that collects reports
knows to export an absolute path rather than rediscovering this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
