### PR TITLE
feat(nativecall): complete the exported type surface, explicitly-manage and refresh

### DIFF
--- a/news/2026-07/nativecall-type-surface.md
+++ b/news/2026-07/nativecall-type-surface.md
@@ -1,0 +1,78 @@
+# NativeCall's type surface is complete, and `explicitly-manage` / `refresh` exist
+
+`use NativeCall` exports a fixed set of type objects and helper routines. An
+inspection of that surface against Rakudo v2026.06 (recorded in
+`todo/tickets/nativecall-surface-gaps.md`) found five holes; this closes all of
+them, and a sixth bug the tests for them turned up.
+
+## The missing type objects
+
+`bool`, `ssize_t` and `OpaquePointer` were simply not declared. Naming one as a
+term degraded to `Str` — what an undeclared bareword becomes — so `nativesizeof(bool)`
+saw a bare string and `$x ~~ OpaquePointer` compared against the wrong type.
+`void` *was* declared, but the prelude carrying it was injected only when the
+source also contained the word `Pointer`, so `use NativeCall; say void.^name`
+did not see it either: one of the four names gated all of them.
+
+- **`bool`** is C's `_Bool`: one byte wide, and *signed*. Rakudo answers `-1`
+  for `my bool $x = -1` and `44` for `= 300`, i.e. exactly `int8`, and it is an
+  integer type there too — a native `bool` return boxes to `Int`, not to `Bool`.
+  It is now a native integer type of that shape, marshalled through the same ABI
+  slot as `int8`, and `CArray[bool]` round-trips a signed byte.
+- **`ssize_t`** is the signed counterpart of `size_t`, 64-bit on every platform
+  mutsu targets.
+- **`OpaquePointer`** is NativeCall's historical spelling of `Pointer`, and an
+  *alias* rather than a subclass — `OpaquePointer === Pointer` is True in Rakudo.
+  A `constant` in the prelude is what preserves that identity; a class of its own
+  would not. It was already accepted in a *signature* (`CType::from_type_name`
+  maps it), so only its use as a term was missing.
+- The prelude gate is now `use NativeCall` alone, so all four type objects
+  arrive together.
+
+## `explicitly-manage` and `refresh`
+
+Both are NativeCall exports rather than builtins, so — like `cglobal` before
+them — the user-visible sub is Raku in the injected prelude and only the
+primitive underneath it is native.
+
+`explicitly-manage($str)` hands a string's C buffer to the callee for good. A
+plain `Str` argument is marshalled into a temporary `char*` that dies with the
+call, which is right for a callee that copies the string and wrong for one that
+*retains* the pointer; `Language/nativecall.rakudoc`'s `set_version` example
+segfaults on its second call for exactly this reason. mutsu now returns a
+`NativeCall::CStr` (Rakudo's own name for the object) carrying the address of a
+deliberately leaked NUL-terminated buffer, and the `Str` parameter marshaller
+hands C that stable address instead of a temporary. The documented `:$encoding`
+is honoured by construction: the prelude calls `Str.encode($encoding)` and the
+native half only takes the bytes.
+
+`refresh($obj)` re-reads a CStruct's fields after C wrote them behind the
+runtime's back. In mutsu there is nothing to re-read — a CStruct instance holds
+only the C address, and every field access reads through it — so this is a
+genuine no-op that returns 1, as Rakudo's `sub refresh($obj --> 1)` does. It
+still has to exist, because bindings call it.
+
+## Two general bugs the tests found
+
+**Every lowercase return type on a sub returned `Nil`.** The compiler decides
+whether `--> spec` names a *definite return value* (a literal or lowercase term
+the sub returns regardless of its body, as in Rakudo's own `--> 1`) or a return
+*type*, and it decided on the first character alone. Raku's native types are
+lowercase too, so `sub f($x --> ulong) { $x }` was read as "return the term
+`ulong`", sank the body and answered `Nil` — for every one of `int`, `num`,
+`str` and the `NativeCall::Types` C-width aliases. Native type names are now
+excluded from that heuristic. (Methods were unaffected, which is why
+`t/native-c-width-int-types.t`'s `method span(ulong $extra --> ulong)` passed
+while the sub form never had.)
+
+**Every `Bool` argument reached C as 0.** `Bool` unboxes to 1/0 in a native
+integer slot — it `does Int` — which is how `True` reaches a C `_Bool` or `int`
+parameter. The native-call argument marshaller went straight to the numeric
+catch-all instead, which has no `Bool` case, so `c_abs(True)` passed 0.
+
+## Pins
+
+`t/nativecall-type-surface.t` and `t/nativecall-explicitly-manage.t`. The latter
+demonstrates the retained-pointer case end to end with libc's `putenv`, which
+POSIX specifies as taking ownership of the caller's string — the same shape as
+the documented `set_version` example, with no test-only shared library needed.

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -8,6 +8,16 @@ impl Compiler {
         body_str.contains("\"@_\"") || body_str.contains("\"%_\"")
     }
 
+    /// Whether `--> spec` names a **definite return value** (a literal or a
+    /// lowercase term the sub returns regardless of its body, as in Rakudo's own
+    /// `sub refresh($obj --> 1)`) rather than a return *type*. A definite return
+    /// makes the body's last expression sink.
+    ///
+    /// Lowercase alone cannot decide it: Raku's native types are lowercase too,
+    /// so `sub f($x --> ulong) { $x }` was read as "return the term `ulong`",
+    /// sank the body and answered Nil for every one of `int`/`num`/`str` and the
+    /// `NativeCall::Types` C-width aliases. Native type names are therefore
+    /// excluded, which is what `is_known_type_constraint` decides.
     pub(super) fn is_definite_return_spec(spec: &str) -> bool {
         let s = spec.trim();
         if s.is_empty() {
@@ -22,7 +32,8 @@ impl Compiler {
             return true;
         }
         matches!(s, "Nil" | "True" | "False" | "Empty" | "pi" | "e" | "tau")
-            || s.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+            || (s.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+                && !crate::runtime::utils::is_known_type_constraint(s))
     }
 
     pub(super) fn emit_nil_value(&mut self) {

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -49,10 +49,10 @@ impl FieldType {
         // "one class, several spellings" problem `cstruct_class_name` documents.
         // `is_known_struct` gets the name as written; it does its own matching.
         Some(match short_base_name(name) {
-            "int8" => FieldType::I8,
+            "int8" | "bool" => FieldType::I8,
             "int16" => FieldType::I16,
             "int32" => FieldType::I32,
-            "int64" | "long" | "longlong" | "int" => FieldType::I64,
+            "int64" | "long" | "longlong" | "ssize_t" | "int" => FieldType::I64,
             "uint8" | "byte" => FieldType::U8,
             "uint16" => FieldType::U16,
             "uint32" => FieldType::U32,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -292,6 +292,7 @@ mod native_supply_mut_methods;
 pub(crate) mod native_types;
 pub(crate) mod nativecall;
 pub(crate) mod nativecall_global;
+pub(crate) mod nativecall_manage;
 pub(crate) mod once_store;
 mod ops_bits;
 mod ops_compare;

--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -30,6 +30,12 @@ pub(crate) const NATIVE_INT_TYPES: &[&str] = &[
     "longlong",
     "ulonglong",
     "size_t",
+    "ssize_t",
+    // `NativeCall::Types::bool` is C's `_Bool`: one byte wide, and *signed* —
+    // Rakudo answers -1 for `my bool $x = -1` and 44 for `= 300`, i.e. exactly
+    // `int8`. It is an integer type there too (a native `bool` return boxes to
+    // `Int`, not to `Bool`).
+    "bool",
 ];
 
 /// Returns true if `name` is a native integer type.
@@ -79,10 +85,11 @@ pub(crate) fn native_int_bounds(type_name: &str) -> Option<(NumBigInt, NumBigInt
             NumBigInt::from(-2147483648i64),
             NumBigInt::from(2147483647i64),
         )),
-        "int64" | "int" | "atomicint" | "long" | "longlong" => Some((
+        "int64" | "int" | "atomicint" | "long" | "longlong" | "ssize_t" => Some((
             NumBigInt::from(-9223372036854775808i64),
             NumBigInt::from(9223372036854775807i64),
         )),
+        "bool" => Some((NumBigInt::from(-128i64), NumBigInt::from(127i64))),
         "uint8" | "byte" => Some((NumBigInt::from(0u64), NumBigInt::from(255u64))),
         "uint16" => Some((NumBigInt::from(0u64), NumBigInt::from(65535u64))),
         "uint32" => Some((NumBigInt::from(0u64), NumBigInt::from(4294967295u64))),
@@ -97,11 +104,11 @@ pub(crate) fn native_int_bounds(type_name: &str) -> Option<(NumBigInt, NumBigInt
 /// Number of bits for each native type.
 fn native_type_bits(type_name: &str) -> Option<u32> {
     match type_name {
-        "int8" | "uint8" | "byte" => Some(8),
+        "int8" | "uint8" | "byte" | "bool" => Some(8),
         "int16" | "uint16" => Some(16),
         "int32" | "uint32" => Some(32),
         "int64" | "uint64" | "int" | "uint" | "long" | "ulong" | "longlong" | "ulonglong"
-        | "size_t" => Some(64),
+        | "size_t" | "ssize_t" => Some(64),
         _ => None,
     }
 }
@@ -110,7 +117,7 @@ fn native_type_bits(type_name: &str) -> Option<u32> {
 fn is_signed_native(type_name: &str) -> bool {
     matches!(
         type_name,
-        "int8" | "int16" | "int32" | "int64" | "int" | "long" | "longlong"
+        "int8" | "int16" | "int32" | "int64" | "int" | "long" | "longlong" | "ssize_t" | "bool"
     )
 }
 

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -56,10 +56,11 @@ impl CType {
     /// Returns `None` for an unrecognized / unsupported type name.
     pub fn from_type_name(name: &str) -> Option<CType> {
         Some(match name {
-            "int8" => CType::I8,
+            // `bool` is C's `_Bool`: one signed byte, same ABI slot as `int8`.
+            "int8" | "bool" => CType::I8,
             "int16" => CType::I16,
             "int32" => CType::I32,
-            "int64" | "long" | "longlong" | "int" | "Int" => CType::I64,
+            "int64" | "long" | "longlong" | "ssize_t" | "int" | "Int" => CType::I64,
             "uint8" | "byte" => CType::U8,
             "uint16" => CType::U16,
             "uint32" => CType::U32,
@@ -853,7 +854,14 @@ fn marshal_arg(ps: &ParamSpec, raw: &Value) -> Result<(libffi::middle::Type, Arg
     let ct = ps.ct;
     let resolved = resolve_arg(raw);
     let v = &resolved;
-    let int = || crate::runtime::to_int(v);
+    // `Bool` unboxes to 1/0 in a native integer slot (it `does Int`), which is
+    // how `True` reaches a C `_Bool`/`int` parameter. Without this it went
+    // through `to_int`'s catch-all and every `Bool` argument arrived as 0.
+    let int = || {
+        crate::runtime::to_int(&crate::runtime::native_types::unbox_bool_to_native_int(
+            v.clone(),
+        ))
+    };
     let num = || crate::runtime::utils::to_float_value(v).unwrap_or(0.0);
     Ok(match ct {
         CType::I8 => (Type::i8(), ArgOwner::I8(int() as i8)),
@@ -879,7 +887,15 @@ fn marshal_arg(ps: &ParamSpec, raw: &Value) -> Result<(libffi::middle::Type, Arg
             // corrupted the heap: OpenSSL's `ERR_error_string($e, Nil)` — where
             // NULL means "use your own static buffer" — writes up to 256 bytes
             // and aborted mutsu with "realloc(): invalid next size".
-            if !crate::runtime::types::value_is_defined(v) {
+            if let Some(addr) = crate::runtime::nativecall_manage::explicitly_managed_address(v) {
+                // An `explicitly-manage`d string: hand C the leaked buffer
+                // itself, so a callee that RETAINS the pointer keeps seeing
+                // live memory after the call returns.
+                (
+                    Type::pointer(),
+                    ArgOwner::Ptr(addr as *const std::ffi::c_void),
+                )
+            } else if !crate::runtime::types::value_is_defined(v) {
                 (Type::pointer(), ArgOwner::Ptr(std::ptr::null()))
             } else {
                 let s = v.to_string_value();

--- a/src/runtime/nativecall_manage.rs
+++ b/src/runtime/nativecall_manage.rs
@@ -1,0 +1,124 @@
+//! `explicitly-manage` — handing a string's C buffer over to the callee.
+//!
+//! ```raku
+//! say set_version(explicitly-manage('1.0.0'));
+//! ```
+//!
+//! A plain `Str` argument is marshalled into a temporary `char*` that lives only
+//! for the duration of the call (`ArgOwner::CStr` in
+//! [`runtime::nativecall`](crate::runtime::nativecall)). That is right for a
+//! callee that copies the string, and wrong for one that *keeps* the pointer —
+//! `Language/nativecall.rakudoc`'s `set_version` example segfaults on the second
+//! call for exactly this reason. `explicitly-manage` is Rakudo's answer: it
+//! returns an object whose buffer "will not be freed by the runtime's garbage
+//! collector", so the C library owns it from then on.
+//!
+//! mutsu models that object as `NativeCall::CStr` (Rakudo's own name for it,
+//! with `repr('CStr')`), declared in the NativeCall prelude and carrying the
+//! address of a **deliberately leaked** NUL-terminated buffer. The user-visible
+//! sub is Raku, in that same prelude — `explicitly-manage` is a NativeCall
+//! export, not a builtin — and only the leak is native. Passing the result
+//! where a `Str` parameter is declared hands C that stable address (see
+//! `explicitly_managed_address`).
+//!
+//! The prelude encodes with `Str.encode($encoding)` before calling in, so the
+//! documented `:$encoding` is honoured by construction rather than assumed to be
+//! UTF-8.
+
+use crate::value::{RuntimeError, Value};
+
+use super::Interpreter;
+
+/// The name the NativeCall prelude's `explicitly-manage` calls to obtain the
+/// leaked buffer's address.
+pub(crate) const EXPLICITLY_MANAGE: &str = "__mutsu_explicitly_manage";
+
+/// The class an explicitly-managed string is wrapped in, matching Rakudo.
+pub(crate) const CSTR_CLASS: &str = "NativeCall::CStr";
+
+impl Interpreter {
+    /// `__mutsu_explicitly_manage($encoded)` — copy an encoded `Blob`'s bytes
+    /// into a fresh, NUL-terminated allocation that is never freed, and return
+    /// its address. `None` for any other function name, so the caller falls
+    /// through to its remaining dispatch.
+    ///
+    /// The leak is the feature: this is the one place in mutsu where memory is
+    /// handed to C permanently, and `nativecall.rakudoc` says so outright —
+    /// "all memory management for explicitly managed strings must be handled by
+    /// the C library itself".
+    pub(crate) fn try_explicitly_manage(
+        &mut self,
+        name: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if name != EXPLICITLY_MANAGE {
+            return None;
+        }
+        if args.len() != 1 {
+            return Some(Err(RuntimeError::new(format!(
+                "explicitly-manage() expects 1 argument, got {}",
+                args.len()
+            ))));
+        }
+        let arg = crate::runtime::types::unwrap_varref_value(args[0].clone());
+        let bytes = match encoded_bytes(&arg) {
+            Some(b) => b,
+            None => {
+                return Some(Err(RuntimeError::new(
+                    "explicitly-manage() expects an encoded Blob",
+                )));
+            }
+        };
+        Some(Ok(Value::int(leak_c_string(&bytes) as i64)))
+    }
+}
+
+/// The bytes of an encoded `Blob`/`Buf`, or `None` when the value is not one.
+fn encoded_bytes(v: &Value) -> Option<Vec<u8>> {
+    use crate::value::ValueView;
+    match v.view() {
+        ValueView::Instance { attributes, .. } => {
+            let node = crate::value::value_buf::buf_storage_node(&attributes)?;
+            Some(node.bytes.clone())
+        }
+        ValueView::Scalar(inner) => encoded_bytes(inner),
+        ValueView::ContainerRef(cell) => cell.lock().ok().and_then(|g| encoded_bytes(&g)),
+        ValueView::VarRef { value, .. } => encoded_bytes(value),
+        _ => None,
+    }
+}
+
+/// Copy `bytes` plus a terminating NUL into an allocation that is intentionally
+/// never freed, and return its address.
+fn leak_c_string(bytes: &[u8]) -> usize {
+    let mut owned = Vec::with_capacity(bytes.len() + 1);
+    owned.extend_from_slice(bytes);
+    owned.push(0);
+    // Leaking is the whole contract; the C library owns this buffer now.
+    Box::leak(owned.into_boxed_slice()).as_ptr() as usize
+}
+
+/// The stable `char*` behind an explicitly-managed string, or `None` when `v` is
+/// not one. Used by the `Str` parameter marshaller so
+/// `f(explicitly-manage($s))` hands C the leaked buffer rather than a temporary.
+pub(crate) fn explicitly_managed_address(v: &Value) -> Option<usize> {
+    use crate::value::ValueView;
+    match v.view() {
+        ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } if class_name.resolve() == CSTR_CLASS => match attributes.as_map().get("address")?.view()
+        {
+            ValueView::Int(a) if a > 0 => Some(a as usize),
+            _ => None,
+        },
+        ValueView::Scalar(inner) => explicitly_managed_address(inner),
+        ValueView::ContainerRef(cell) => cell
+            .lock()
+            .ok()
+            .and_then(|g| explicitly_managed_address(&g)),
+        ValueView::VarRef { value, .. } => explicitly_managed_address(value),
+        _ => None,
+    }
+}

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -56,6 +56,20 @@ class GLOBAL::Pointer {
 # type object to compare against (`ptr.of ~~ void` in NativeHelpers::Blob's
 # `blob-from-pointer`), so an empty class is the whole of it.
 class GLOBAL::void { }
+# `OpaquePointer` is NativeCall's historical spelling of `Pointer`, and Rakudo
+# still exports it -- as an ALIAS, not a subclass (`OpaquePointer === Pointer`
+# is True there). A `constant` is what preserves that identity; a class of its
+# own would not.
+constant OpaquePointer = Pointer;
+# The object `explicitly-manage` returns: a C string whose buffer the callee now
+# owns. Rakudo names it `NativeCall::CStr` and gives it `repr('CStr')`; here the
+# address of the leaked buffer is the whole state (see
+# `runtime::nativecall_manage`).
+class GLOBAL::NativeCall::CStr {
+    has $.address = 0;
+    method gist(--> Str) { 'NativeCall::CStr.new' }
+    method Str(--> Str) { self.gist }
+}
 "#;
 
 /// NativeCall's `cglobal`, which is a module export in Rakudo rather than a
@@ -75,6 +89,26 @@ our sub cglobal($libname, $symbol, $target-type) is rw {
         STORE => -> $, $ { die "Writing to C globals NYI" }
     )
 }
+"#;
+
+/// NativeCall's remaining two exports, `explicitly-manage` and `refresh`. Like
+/// `cglobal` they are module exports rather than builtins, so they live in a
+/// prelude injected alongside the rest of NativeCall's surface.
+///
+/// `explicitly-manage` encodes here rather than in Rust so the documented
+/// `:$encoding` is honoured by construction; the native half is only the leak
+/// (see [`runtime::nativecall_manage`](crate::runtime::nativecall_manage)).
+///
+/// `refresh` re-reads a CStruct's fields after C wrote them behind the
+/// runtime's back. In mutsu there is nothing to re-read: a CStruct instance
+/// holds only the C address, and every field access reads through it
+/// (`cstruct_field_value`), so the fields are never stale. The sub still has to
+/// exist and to return 1, as Rakudo's does, because bindings call it.
+pub(super) const NATIVECALL_MANAGE_PRELUDE: &str = r#"
+our sub explicitly-manage(Str $str, :$encoding = 'utf8') {
+    NativeCall::CStr.new(:address(__mutsu_explicitly_manage($str.encode($encoding))))
+}
+our sub refresh($obj) { 1 }
 "#;
 
 /// Builtin `IO::Socket` role. Raku's socket classes (`IO::Socket::INET`,
@@ -129,6 +163,7 @@ impl Interpreter {
         Self::inject_prelude_roles(&preprocessed, &mut stmts);
         Self::inject_nativecall_prelude(&preprocessed, &mut stmts);
         Self::inject_cglobal_prelude(&preprocessed, &mut stmts);
+        Self::inject_nativecall_manage_prelude(&preprocessed, &mut stmts);
         Self::inject_iosocket_prelude(&preprocessed, &mut stmts);
         let (_pre_ph, enter_ph, success_ph, failure_ph, _post_ph, body_main) =
             self.split_block_phasers(&stmts);

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -466,6 +466,7 @@ impl Interpreter {
         // would otherwise hit an undeclared `Pointer`.
         Self::inject_nativecall_prelude(&preprocessed, &mut stmts);
         Self::inject_cglobal_prelude(&preprocessed, &mut stmts);
+        Self::inject_nativecall_manage_prelude(&preprocessed, &mut stmts);
         Self::inject_iosocket_prelude(&preprocessed, &mut stmts);
 
         // Save to precompilation cache when the module is eligible.

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -1,6 +1,6 @@
 use super::run::{
-    IO_SOCKET_ROLE_PRELUDE, NATIVECALL_CGLOBAL_PRELUDE, NATIVECALL_POINTER_PRELUDE,
-    RATIONAL_ROLE_PRELUDE,
+    IO_SOCKET_ROLE_PRELUDE, NATIVECALL_CGLOBAL_PRELUDE, NATIVECALL_MANAGE_PRELUDE,
+    NATIVECALL_POINTER_PRELUDE, RATIONAL_ROLE_PRELUDE,
 };
 use super::*;
 
@@ -30,13 +30,19 @@ impl Interpreter {
         *stmts = combined;
     }
 
-    /// Prepend the builtin NativeCall `Pointer` class when a program that uses
-    /// NativeCall references `Pointer` without declaring its own. Parsed once
-    /// and cached, like [`inject_prelude_roles`].
+    /// Prepend NativeCall's type objects (`Pointer`, `void`, `OpaquePointer`,
+    /// `NativeCall::CStr`) to a program that uses NativeCall. Parsed once and
+    /// cached, like [`inject_prelude_roles`].
+    ///
+    /// The gate is `use NativeCall` alone, deliberately: keying it on the
+    /// source also naming `Pointer` meant `use NativeCall; say void.^name` --
+    /// or any of the other three -- saw an undeclared bareword, since only one
+    /// of the four names gated all of them.
     pub(super) fn inject_nativecall_prelude(source: &str, stmts: &mut Vec<Stmt>) {
         if !source.contains("NativeCall")
-            || !source.contains("Pointer")
             || source.contains("class Pointer")
+            || source.contains("class void")
+            || source.contains("class OpaquePointer")
         {
             return;
         }
@@ -75,6 +81,33 @@ impl Interpreter {
         static CGLOBAL_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
         let prelude = CGLOBAL_STMTS.get_or_init(|| {
             crate::parse_dispatch::parse_source(NATIVECALL_CGLOBAL_PRELUDE)
+                .map(|(s, _)| s)
+                .unwrap_or_default()
+        });
+        if prelude.is_empty() {
+            return;
+        }
+        let mut combined = prelude.clone();
+        combined.append(stmts);
+        *stmts = combined;
+    }
+
+    /// Prepend NativeCall's `explicitly-manage` / `refresh` when a program that
+    /// uses NativeCall calls one of them without declaring its own.
+    pub(super) fn inject_nativecall_manage_prelude(source: &str, stmts: &mut Vec<Stmt>) {
+        if !source.contains("NativeCall") {
+            return;
+        }
+        let wants_manage =
+            source.contains("explicitly-manage") && !source.contains("sub explicitly-manage");
+        let wants_refresh = source.contains("refresh") && !source.contains("sub refresh");
+        if !wants_manage && !wants_refresh {
+            return;
+        }
+        use std::sync::OnceLock;
+        static MANAGE_STMTS: OnceLock<Vec<Stmt>> = OnceLock::new();
+        let prelude = MANAGE_STMTS.get_or_init(|| {
+            crate::parse_dispatch::parse_source(NATIVECALL_MANAGE_PRELUDE)
                 .map(|(s, _)| s)
                 .unwrap_or_default()
         });

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -98,11 +98,13 @@ pub(crate) fn elem_type(class_name: &str) -> (u8, ElemKind) {
 /// native storage alone cannot do. They keep the boxed representation.
 pub(crate) fn native_elem_type(elem: &str) -> Option<(u8, ElemKind)> {
     Some(match elem {
-        "int8" => (1, ElemKind::Int),
+        // `bool` is C's one-byte, *signed* `_Bool` (`CArray[bool]` round-trips
+        // -1, exactly as `CArray[int8]` does).
+        "int8" | "bool" => (1, ElemKind::Int),
         "int16" => (2, ElemKind::Int),
         "int32" => (4, ElemKind::Int),
         "int64" | "int" | "long" | "longlong" | "ssize_t" => (8, ElemKind::Int),
-        "uint8" | "byte" | "bool" => (1, ElemKind::Uint),
+        "uint8" | "byte" => (1, ElemKind::Uint),
         "uint16" => (2, ElemKind::Uint),
         "uint32" => (4, ElemKind::Uint),
         "uint64" | "uint" | "ulong" | "ulonglong" | "size_t" => (8, ElemKind::Uint),

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1346,6 +1346,10 @@ impl Interpreter {
                     // One fetch behind the `Proxy` NativeCall's `cglobal`
                     // returns (see runtime::nativecall_global).
                     result
+                } else if let Some(result) = self.try_explicitly_manage(name, &args) {
+                    // The leak behind NativeCall's `explicitly-manage`
+                    // (see runtime::nativecall_manage).
+                    result
                 } else if let Some(result) = self.try_native_json_function(name, &args) {
                     // Dispatch JSON::Fast / JSON::Tiny `to-json` / `from-json`
                     // to the native implementation (runtime/json.rs).

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -440,6 +440,8 @@ impl Interpreter {
                 | "longlong"
                 | "ulonglong"
                 | "size_t"
+                | "ssize_t"
+                | "bool"
                 | "num"
                 | "num32"
                 | "num64"

--- a/t/lib-nativecall-surface/NCSurface.rakumod
+++ b/t/lib-nativecall-surface/NCSurface.rakumod
@@ -1,0 +1,16 @@
+unit module NCSurface;
+use NativeCall;
+
+# A `unit module` is where prelude scoping breaks: the runtime package switch is
+# emitted at the top of the unit, so an unqualified prelude declaration would
+# register as `NCSurface::Pointer` and be a different type from the builtin.
+# Every type object and helper must still be the global one here.
+sub surface-names() is export {
+    (bool.^name, ssize_t.^name, void.^name, Pointer.^name)
+}
+
+sub opaque-is-pointer() is export { OpaquePointer === Pointer }
+
+sub managed-name() is export { explicitly-manage('mutsu').^name }
+
+sub refreshed() is export { refresh(1) }

--- a/t/nativecall-explicitly-manage.t
+++ b/t/nativecall-explicitly-manage.t
@@ -1,0 +1,54 @@
+use Test;
+use NativeCall;
+
+# `explicitly-manage($str)` hands a string's C buffer to the callee for good:
+# the returned object's buffer "will not be freed by the runtime's garbage
+# collector" (Language/nativecall.rakudoc). A plain `Str` argument is marshalled
+# into a temporary `char*` that dies with the call, which is right for a callee
+# that copies and wrong for one that RETAINS the pointer.
+#
+# `refresh($obj)` re-reads a CStruct's fields after C wrote them behind the
+# runtime's back. In mutsu a CStruct instance holds only the C address and every
+# field access reads through it, so there is nothing to re-read -- but the sub
+# still has to exist and return 1, because bindings call it.
+#
+# Both are NativeCall exports rather than builtins, like `cglobal`.
+
+plan 14;
+
+ok defined(&explicitly-manage), 'explicitly-manage is a callable routine';
+ok defined(&refresh), 'refresh is a callable routine';
+
+my $managed = explicitly-manage('mutsu');
+is $managed.^name, 'NativeCall::CStr', 'it returns a NativeCall::CStr, as Rakudo does';
+is $managed.gist, 'NativeCall::CStr.new', 'whose gist matches Rakudo';
+isnt $managed.address, 0, 'and which carries a real buffer address';
+
+# The address is stable: the same object keeps naming the same buffer, and two
+# calls allocate two buffers.
+is $managed.address, $managed.address, 'the address does not move';
+isnt explicitly-manage('mutsu').address, $managed.address,
+    'each call allocates its own buffer';
+
+# End to end through a callee that RETAINS the pointer. `putenv` is the
+# canonical one -- POSIX says the string becomes part of the environment, so the
+# caller must not free it. This is the same shape as nativecall.rakudoc's
+# set_version/get_version example.
+sub putenv(Str --> int32) is native('c') { * }
+sub getenv(Str --> Str) is native('c') { * }
+
+is putenv(explicitly-manage('MUTSU_MANAGED_A=first')), 0, 'putenv accepts a managed string';
+is getenv('MUTSU_MANAGED_A'), 'first', 'and the retained buffer is still live afterwards';
+
+is putenv(explicitly-manage('MUTSU_MANAGED_A=second')), 0, 'a second managed string';
+is getenv('MUTSU_MANAGED_A'), 'second', 'replaces the first without disturbing it';
+
+# `:$encoding` is documented, and the encoding happens before the buffer is
+# taken, so a non-UTF-8 request is honoured rather than ignored.
+isnt explicitly-manage('abc', :encoding('utf16')).address, 0,
+    'an explicit :encoding is accepted';
+
+# `refresh` answers 1, as Rakudo's `sub refresh($obj --> 1)` does, and leaves
+# the object it was handed alone.
+is refresh($managed), 1, 'refresh returns 1';
+is $managed.address, $managed.address, 'and does not disturb its argument';

--- a/t/nativecall-type-surface.t
+++ b/t/nativecall-type-surface.t
@@ -1,0 +1,77 @@
+use Test;
+use lib $?FILE.IO.parent.add('lib-nativecall-surface').Str;
+use NativeCall;
+use NCSurface;
+
+# `use NativeCall` exports the whole `NativeCall::Types` set. Three of them were
+# simply not declared -- `bool`, `ssize_t` and `OpaquePointer` -- so naming one
+# as a term degraded to the `Str` an undeclared bareword becomes. `void` was
+# declared but gated on the source ALSO naming `Pointer`, so this file (which
+# does not) would not have seen it either.
+
+plan 24;
+
+# --- bool: C's `_Bool`. One byte, and *signed* -- Rakudo answers -1 for
+# `my bool $x = -1` and 44 for `= 300`, i.e. exactly `int8`. It is an integer
+# type there too (a native `bool` return boxes to Int, not to Bool).
+is bool.^name, 'bool', 'bool is a declared type object, not a bareword Str';
+is nativesizeof(bool), 1, 'nativesizeof(bool) is 1';
+my bool $b = 1;
+is $b, 1, 'a bool scalar holds its value';
+my bool $neg = -1;
+is $neg, -1, 'bool is signed: -1 stays -1';
+my bool $wrap = 300;
+is $wrap, 44, 'bool is one byte: 300 wraps to 44';
+
+my $ba = CArray[bool].new;
+$ba[0] = -1;
+is $ba[0], -1, 'CArray[bool] round-trips a signed byte';
+
+# --- ssize_t: the signed counterpart of size_t, 64-bit on every platform
+# mutsu targets.
+is ssize_t.^name, 'ssize_t', 'ssize_t is a declared type object';
+is nativesizeof(ssize_t), 8, 'nativesizeof(ssize_t) is 8';
+my ssize_t $s = -4096;
+is $s, -4096, 'an ssize_t scalar is signed';
+is nativesizeof(size_t), nativesizeof(ssize_t), 'size_t and ssize_t are the same width';
+
+# --- OpaquePointer: NativeCall's historical spelling of Pointer, and an ALIAS
+# rather than a subclass, so identity holds.
+ok OpaquePointer === Pointer, 'OpaquePointer is Pointer itself, not a subclass';
+my $p = OpaquePointer.new(0);
+ok $p ~~ Pointer, 'an OpaquePointer-constructed object is a Pointer';
+is $p.Int, 0, 'and carries its address';
+ok Pointer.new(7) ~~ OpaquePointer, 'a Pointer smartmatches OpaquePointer';
+
+# --- void: reachable without the file also mentioning `Pointer`.
+is void.^name, 'void', 'void is a declared type object';
+nok void.defined, 'void is a type object';
+
+# All four are usable where a native type is expected: in a signature, as an
+# attribute, and as a CStruct field type.
+class Rec is repr('CStruct') {
+    has bool $.flag;
+    has ssize_t $.offset;
+    has OpaquePointer $.data;
+}
+is nativesizeof(Rec), 24, 'a CStruct lays bool out as one byte (padded to the 8-byte members)';
+
+sub takes-them(bool $f, ssize_t $o --> ssize_t) { $f ?? $o !! -$o }
+is takes-them(1, 5), 5, 'bool and ssize_t parameters bind';
+is takes-them(0, 5), -5, 'and the ssize_t return type is signed';
+
+# `Bool` unboxes to 1/0 in a native integer slot -- which is how `True` reaches
+# a C `_Bool` parameter. Before this it went through the numeric catch-all and
+# every Bool argument arrived as 0.
+sub c_abs(int32 $n --> int32) is native('c') is symbol('abs') { * }
+is c_abs(True), 1, 'a Bool argument unboxes to 1 at the C boundary';
+
+# A `unit module` is where prelude scoping breaks: the runtime package switch is
+# emitted at the top of the unit, so an unqualified prelude declaration would
+# register under the module's package and be a *different* type from the
+# builtin. NCSurface (t/lib-nativecall-surface/) asks from in there.
+is-deeply surface-names(), ('bool', 'ssize_t', 'void', 'Pointer'),
+    'the type objects are the global ones inside a unit module';
+ok opaque-is-pointer(), 'and OpaquePointer is still Pointer there';
+is managed-name(), 'NativeCall::CStr', 'explicitly-manage works inside a unit module';
+is refreshed(), 1, 'and so does refresh';

--- a/todo/tickets/nativecall-surface-gaps.md
+++ b/todo/tickets/nativecall-surface-gaps.md
@@ -12,8 +12,8 @@ code rather than as a campaign.
 | `nativecast` | works, but as a **builtin** and with no `&nativecast` | [`nativecall-exports-are-not-builtins.md`](nativecall-exports-are-not-builtins.md) |
 | `nativesizeof` | same | same |
 | `cglobal` | ✅ done 2026-07-29 | prelude sub over a native fetch |
-| `explicitly-manage` | **missing** | `explicitly-manage($str)` — hands a `Str`'s buffer's lifetime to the callee. Documented in `nativecall.rakudoc` §"Explicit memory management" |
-| `refresh` | **missing** | `refresh($obj)` — re-read a CStruct's fields after C wrote them behind mutsu's back. Under ADR-0015's shared-storage direction this may become a no-op rather than a copy; decide when implementing |
+| `explicitly-manage` | ✅ done 2026-07-31 | prelude sub returning a `NativeCall::CStr` over a deliberately-leaked buffer |
+| `refresh` | ✅ done 2026-07-31 | a genuine no-op returning 1: a mutsu CStruct holds only the C address and every field access reads through it, so its fields are never stale |
 
 `guess_library_name` and `check_routine_sanity` are `:TEST`-tagged in Rakudo and
 are not part of the default surface; no reason to add them.
@@ -21,36 +21,36 @@ are not part of the default surface; no reason to add them.
 ## Type objects
 
 `use NativeCall` exports these as `NativeCall::Types::*`. mutsu answers a short
-name, which is a cosmetic difference (`.^name`), except where the type object
-does not exist at all:
+name, which is a cosmetic difference (`.^name`). Every type object now exists;
+what remains is only that prefix:
 
 | type | mutsu `.^name` | raku `.^name` |
 | --- | --- | --- |
 | `long` / `longlong` / `ulong` / `ulonglong` | `long` / … | `NativeCall::Types::long` / … |
-| `size_t` | `size_t` | `NativeCall::Types::size_t` |
+| `size_t` / `ssize_t` | `size_t` / `ssize_t` | `NativeCall::Types::size_t` / `…::ssize_t` |
+| `bool` | `bool` | `NativeCall::Types::bool` |
 | `void` | `void` | `NativeCall::Types::void` |
 | `CArray` / `Pointer` | `CArray` / `Pointer` | `NativeCall::Types::CArray` / `…::Pointer` |
-| **`bool`** | `Str` — **absent** | `NativeCall::Types::bool` |
-| **`ssize_t`** | `Str` — **absent** | `NativeCall::Types::ssize_t` |
-| **`OpaquePointer`** | `Str` — **absent** | `NativeCall::Types::Pointer` (an alias) |
+| `OpaquePointer` | `Pointer` (an alias, so `OpaquePointer === Pointer`) | `NativeCall::Types::Pointer` (same) |
 
-`Str` here is what an undeclared bareword degrades to, so those three are simply
-not declared. Note `OpaquePointer` *is* accepted in a **signature**
-(`CType::from_type_name` maps it), so only its use as a term is missing — which
-is what `my $p = OpaquePointer;` and `$x ~~ OpaquePointer` need.
+`bool`, `ssize_t` and `OpaquePointer` were **absent** until 2026-07-31 — naming
+one as a term degraded to the `Str` an undeclared bareword becomes — and `void`
+was declared but gated on the source *also* naming `Pointer`. Both are fixed;
+see [`news/2026-07/nativecall-type-surface.md`](../../news/2026-07/nativecall-type-surface.md).
 
-Also note the short-name answers are not merely cosmetic for `void`: the
-`Pointer`/`void` prelude classes are injected **only when the source contains
-"Pointer"** (`inject_nativecall_prelude`), so `use NativeCall; say void.^name`
-alone does not see `void`. Widening that gate is part of the same cleanup as
-[`nativecall-exports-are-not-builtins.md`](nativecall-exports-are-not-builtins.md).
+Renaming the type objects to their `NativeCall::Types::` spelling is the one
+open item here, and it is cosmetic: nothing in the batteries matches on those
+names. It belongs with the cleanup in
+[`nativecall-exports-are-not-builtins.md`](nativecall-exports-are-not-builtins.md),
+since both hinge on NativeCall's surface being a real module rather than ambient
+globals.
 
 ## Reproducing
 
 ```sh
 for t in long longlong ulong ulonglong bool size_t ssize_t void CArray Pointer OpaquePointer; do
   printf '%-14s mutsu=' "$t"
-  mutsu -e "use NativeCall; my \$p = Pointer; say $t.^name" 2>&1 | head -1
+  mutsu -e "use NativeCall; say $t.^name" 2>&1 | head -1
 done
 for f in explicitly-manage refresh nativesizeof nativecast cglobal; do
   printf '%-20s ' "$f"


### PR DESCRIPTION
Closes the NativeCall surface gaps inventoried in `todo/tickets/nativecall-surface-gaps.md` (measured against Rakudo v2026.06), plus a sixth bug the tests for them turned up.

## The missing type objects

`bool`, `ssize_t` and `OpaquePointer` were simply not declared — naming one as a term degraded to the `Str` an undeclared bareword becomes. `void` *was* declared, but the prelude carrying it was injected only when the source also contained the word `Pointer`, so `use NativeCall; say void.^name` did not see it either: one of the four names gated all of them. The gate is now `use NativeCall` alone.

- **`bool`** is C's `_Bool`: one byte wide, and *signed*. Rakudo answers `-1` for `my bool $x = -1` and `44` for `= 300`, i.e. exactly `int8`, and it is an integer type there too (a native `bool` return boxes to `Int`, not to `Bool`).
- **`ssize_t`** is the signed counterpart of `size_t`, 64-bit on every platform mutsu targets.
- **`OpaquePointer`** is an *alias* of `Pointer` rather than a subclass — `OpaquePointer === Pointer` is True in Rakudo — so a `constant` in the prelude is what preserves that identity. It was already accepted in a signature; only its use as a term was missing.

## `explicitly-manage` and `refresh`

Both are NativeCall exports rather than builtins, so — like `cglobal` before them — the user-visible sub is Raku in the injected prelude and only the primitive underneath it is native.

`explicitly-manage($str)` hands a string's C buffer to the callee for good. A plain `Str` argument is marshalled into a temporary `char*` that dies with the call, which is right for a callee that copies and wrong for one that *retains* the pointer; `Language/nativecall.rakudoc`'s `set_version` example segfaults on its second call for exactly this reason. mutsu now returns a `NativeCall::CStr` (Rakudo's own name for the object) carrying the address of a deliberately leaked NUL-terminated buffer, and the `Str` parameter marshaller hands C that stable address. The documented `:\$encoding` is honoured by construction: the prelude calls `Str.encode(\$encoding)` and the native half only takes the bytes.

`refresh(\$obj)` re-reads a CStruct's fields after C wrote them behind the runtime's back. In mutsu there is nothing to re-read — a CStruct instance holds only the C address, and every field access reads through it — so this is a genuine no-op returning 1, as Rakudo's `sub refresh(\$obj --> 1)` does. It still has to exist, because bindings call it.

## Two general bugs the tests found

**Every lowercase return type on a sub returned `Nil`.** The compiler decides whether `--> spec` names a *definite return value* (a literal or lowercase term returned regardless of the body, as in Rakudo's own `--> 1`) or a return *type*, and it decided on the first character alone. Raku's native types are lowercase too, so `sub f(\$x --> ulong) { \$x }` was read as "return the term `ulong`", sank the body and answered `Nil` — for every one of `int`, `num`, `str` and the `NativeCall::Types` C-width aliases. Methods were unaffected, which is why `t/native-c-width-int-types.t`'s `method span(ulong \$extra --> ulong)` passed while the sub form never had.

**Every `Bool` argument reached C as 0.** `Bool` unboxes to 1/0 in a native integer slot (it `does Int`), which is how `True` reaches a C `_Bool`/`int` parameter. The marshaller went straight to the numeric catch-all, which has no `Bool` case.

## Pins

`t/nativecall-type-surface.t` (24 tests, including a `unit module` probe under `t/lib-nativecall-surface/` — a module is where prelude scoping breaks) and `t/nativecall-explicitly-manage.t` (14 tests). The latter demonstrates the retained-pointer case end to end with libc's `putenv`, which POSIX specifies as taking ownership of the caller's string — the same shape as the documented `set_version` example, with no test-only shared library needed.

## Verification

- `make test`: 2628 files, 25037 tests, PASS
- `make roast`: 1435 files, 218774 tests, PASS
- `cargo clippy -- -D warnings`, `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)