### PR TITLE
fix(runtime): drive whenever-Listener supply blocks under plain tap; unify supplier-id namespace; lexical self in interpreter closures

### DIFF
--- a/news/2026-07/supply-whenever-listener-lexical-self.md
+++ b/news/2026-07/supply-whenever-listener-lexical-self.md
@@ -1,0 +1,40 @@
+# Supply-block whenever over TCP listeners; lexical `self` in interpreter closures
+
+Three fixes that move Cro::Core's `t/tcp.rakutest` from 14 to 21+ passing
+tests (from aborting at the first real-socket test to completing both
+`Server connection` subtests), found by driving the vendored Cro::Core suite:
+
+1. **`whenever IO::Socket::Async.listen(...)` inside a `supply` block now
+   works under a plain `.tap`.** The listener's subscription marker was a
+   2-element array that only the react event loop understood; the supply-block
+   tap path recognises only 4-element `[source, body, [LAST…], [QUIT…]]`
+   markers, so the marker leaked to the tap as a plain emitted value and the
+   whenever body never ran. The marker now uses the standard 4-element shape,
+   and the supply-block tap path gained a channel-backed arm: a worker thread
+   drains the accept channel and drives the whenever body, whose
+   `$emitter.emit(...)` reaches the outer tap through the emitter supplier.
+   The outer Tap also carries the listener handle so closing it stops the OS
+   listener (`Cro::TCP::Listener.incoming` semantics).
+
+2. **In-memory socket supplies no longer collide with real Suppliers.**
+   `async_socket_supply_in_memory` (and the UDP twin) stamped their Supply's
+   `supplier_id` attribute with an id from `next_supply_id()` — a separate
+   counter from `next_supplier_id()`, both starting at 1. A genuine
+   `Supplier.new` with the same number cross-delivered its emissions into the
+   socket's tap (Cro::TCP::Message objects arriving on a client's
+   `.Supply(:bin)` tap). Both sites now allocate from the supplier counter.
+
+3. **`self` is lexical in the interpreter closure path.** The `merge_all`
+   captured-env merge in `call_sub_value` used don't-overwrite for `self`, so
+   a natively invoked callback (a whenever body dispatched from a supplier tap
+   or the in-process connect path) resolved `$.attr` against whatever `self`
+   the caller env last leaked — the second `Cro::TCP::Listener` in a process
+   read `$.nodelay` off a `Cro::TCP::Replier` and died (swallowed), hanging
+   the test. The VM closure dispatch already force-installed the captured
+   `self` (the DBDish lesson); the interpreter path now mirrors it.
+
+Remaining in tcp.rakutest: the `:nodelay` subtest needs `.native-descriptor`
+on in-memory sockets (`todo/tickets/in-memory-socket-native-descriptor.md`).
+
+Pins: `t/supply-whenever-listener-tap.t`, `t/supplier-id-socket-collision.t`,
+`t/closure-lexical-self-native-dispatch.t`.

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -436,6 +436,11 @@ impl Interpreter {
                 supply_attrs.insert("taps".to_string(), Value::array(Vec::new()));
                 supply_attrs.insert("live".to_string(), Value::TRUE);
                 supply_attrs.insert("supply_id".to_string(), Value::int(supply_id as i64));
+                // Carry the listener handle on the Supply so a downstream
+                // consumer (the supply-block tap path) can point its Tap at
+                // the OS listener — closing that outer tap must stop
+                // listening, exactly like closing the Tap returned here.
+                supply_attrs.insert("listener-id".to_string(), Value::int(listener_id as i64));
                 let supply_val = Value::make_instance(Symbol::intern("Supply"), supply_attrs);
 
                 // If we are inside a react block, register the subscription so the
@@ -447,7 +452,18 @@ impl Interpreter {
                 // TcpStream, so a client on the main thread sees the data over the
                 // OS socket).
                 if !self.supply_emit_buffer.is_empty() {
-                    let sub = Value::array(vec![supply_val, callback]);
+                    // Same 4-element shape as every other whenever subscription
+                    // marker ([source, body, [LAST…], [QUIT…]]) so the supply-
+                    // block tap path recognises it; a 2-element array fell
+                    // through as a plain emitted value there. The listener
+                    // whenever's own LAST/QUIT phasers are not routed here.
+                    // TODO: thread them through run_whenever_with_value.
+                    let sub = Value::array(vec![
+                        supply_val,
+                        callback,
+                        Value::array(Vec::new()),
+                        Value::array(Vec::new()),
+                    ]);
                     if let Some(last) = self.supply_emit_buffer.last_mut() {
                         last.push(sub);
                     }
@@ -529,7 +545,10 @@ impl Interpreter {
             "Supply" => {
                 let id =
                     udp_id.ok_or_else(|| RuntimeError::new("Missing UDP socket id for Supply"))?;
-                let supply_id = next_supply_id();
+                // Stamped as `supplier_id` below, so allocate from the supplier
+                // counter (see async_socket_supply_in_memory for the collision
+                // this avoids).
+                let supply_id = next_supplier_id();
                 register_async_supply(
                     supply_id,
                     AsyncSocketSupplyState {

--- a/src/runtime/native_methods/socket_async_conn.rs
+++ b/src/runtime/native_methods/socket_async_conn.rs
@@ -175,7 +175,15 @@ impl Interpreter {
             .map(|v| v.to_string_value())
             .or_else(|| attributes.get("enc").map(Value::to_string_value))
             .unwrap_or_else(|| "utf-8".to_string());
-        let supply_id = next_supply_id();
+        // This id is stamped into the Supply's `supplier_id` attribute and every
+        // downstream registration (register_supplier_tap, supplier_done, emit)
+        // keys the SUPPLIER registry with it — so it must come from the supplier
+        // counter. Allocating from `next_supply_id()` (a separate counter, also
+        // starting at 1) collided with a genuine `Supplier.new` of the same
+        // number, cross-delivering that supplier's emissions to this socket's
+        // tap (seen as Cro::TCP::Message objects arriving on a client's
+        // `.Supply(:bin)` tap).
+        let supply_id = next_supplier_id();
         register_async_supply(
             supply_id,
             AsyncSocketSupplyState {

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -413,6 +413,49 @@ impl Interpreter {
                                 {
                                     whenever_on_close.extend(cbs.iter().cloned());
                                 }
+                            } else if let ValueView::Instance {
+                                attributes: inner_attrs,
+                                ..
+                            } = inner_supply.view()
+                                && let Some(ValueView::Int(chan_sid)) =
+                                    inner_attrs.as_map().get("supply_id").map(Value::view)
+                                && let Some(rx) = take_supply_channel(chan_sid as u64)
+                            {
+                                // Live channel-backed whenever source (e.g.
+                                // `whenever IO::Socket::Async.listen(...)` inside a
+                                // supply block). The react event loop drains such
+                                // channels itself; a bare `.tap` has no loop, so
+                                // drive the whenever body from a worker thread. The
+                                // body's `$emitter.emit(...)` dispatches through the
+                                // emitter supplier's registered taps, which is how
+                                // emitted values reach `tap_cb` from that thread.
+                                if !outer_tap_registered
+                                    && Self::supply_has_active_callback(&tap_cb)
+                                {
+                                    register_supplier_tap(
+                                        emitter_supplier_id,
+                                        tap_cb.clone(),
+                                        delay_seconds,
+                                    );
+                                    outer_tap_registered = true;
+                                }
+                                if let Some(ref qf) = quit_cb {
+                                    register_supplier_quit_callback(
+                                        emitter_supplier_id,
+                                        qf.clone(),
+                                    );
+                                }
+                                // Point the outer Tap at the OS listener so
+                                // `$tap.close` stops listening (Raku closes the
+                                // upstream source when the downstream tap closes).
+                                if let Some(lid) = inner_attrs.as_map().get("listener-id") {
+                                    tap_handle_attrs.insert("listener-id".to_string(), lid.clone());
+                                }
+                                let mut driver = self.clone_for_thread();
+                                let body_cb = body_cb.clone();
+                                crate::runtime::builtins_system::spawn_user_thread(move || {
+                                    Self::run_supply_act_loop(&mut driver, &rx, &body_cb, 0.0);
+                                });
                             } else {
                                 // Cold (supplier-less) whenever source: replay it
                                 // synchronously, capturing the body's emissions so

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -411,6 +411,20 @@ impl Interpreter {
                     new_env.insert_sym(*k, v.clone());
                     continue;
                 }
+                // `self` is LEXICAL in Raku: a block has no invocant of its own,
+                // so `self`/`$.attr` inside it resolves to the enclosing method's
+                // invocant — the one this closure captured. The merge_all
+                // don't-overwrite below made it *dynamic* instead: a natively
+                // invoked callback (a `whenever` body dispatched from a supplier
+                // tap or the in-process connect path) ran against whatever `self`
+                // the caller env last leaked — e.g. Cro::TCP::Listener.incoming's
+                // whenever body read `$.nodelay` off a Cro::TCP::Replier. Mirrors
+                // the VM closure dispatch's force-install; a method's own invocant
+                // is bound from its args after this merge, so it still wins.
+                if k.with_str(|s| s == "self") {
+                    new_env.insert_sym(*k, v.clone());
+                    continue;
+                }
                 // Caller-priority: a `Proxy` FETCH body (and the other
                 // native-invoked callbacks that pass `merge_all`) must see the
                 // CURRENT value of a captured lexical its STORE twin mutates

--- a/t/closure-lexical-self-native-dispatch.t
+++ b/t/closure-lexical-self-native-dispatch.t
@@ -1,0 +1,69 @@
+use Test;
+
+plan 3;
+
+# `self` is lexical: a whenever body must resolve `$.attr` against the object
+# whose method created it, no matter which env the native dispatch (supplier
+# tap, in-process connect) happens to run under. The merge_all env merge in
+# call_sub_value used don't-overwrite for `self`, so once another object's
+# closure had leaked its `self` into the main env, the NEXT listener's
+# whenever body read `$.attr` off the wrong object and died — swallowed, so
+# the test just hung (Cro::TCP tcp.rakutest subtest 2, "$.nodelay" read off a
+# Cro::TCP::Replier).
+
+sub free-port() {
+    my $t = IO::Socket::Async.listen('127.0.0.1', 0).tap(-> $c { $c.close });
+    my $p = await $t.socket-port;
+    $t.close;
+    $p
+}
+
+class Lis {
+    has Str $.tag is required;
+    has Int $.port is required;
+    method incoming() {
+        supply {
+            whenever IO::Socket::Async.listen('127.0.0.1', $!port) -> $socket {
+                emit $.tag;
+            }
+        }
+    }
+}
+
+class Polluter {
+    has $.x = 'wrong-self';
+    method run($trigger) {
+        supply {
+            whenever $trigger {
+                # the nested whenever-over-Promise is what leaks this
+                # method's `self` into the dispatching env
+                whenever Promise.kept('k') { }
+                emit $.x;
+            }
+        }
+    }
+}
+
+my $p1 = free-port();
+my $l1 = Lis.new(tag => 'one', port => $p1);
+my $c1 = Channel.new;
+my $t1 = $l1.incoming.tap({ $c1.send($_) });
+my $cl1 = await IO::Socket::Async.connect('127.0.0.1', $p1);
+is $c1.receive, 'one', 'first listener whenever body reads its own $.tag';
+$cl1.close;
+$t1.close;
+
+my $sup = Supplier.new;
+my @polluted;
+Polluter.new.run($sup.Supply).tap({ @polluted.push($_) });
+$sup.emit('go');
+is @polluted, ['wrong-self'], 'polluter supply ran (leaking its self)';
+
+my $p2 = free-port();
+my $l2 = Lis.new(tag => 'two', port => $p2);
+my $c2 = Channel.new;
+my $t2 = $l2.incoming.tap({ $c2.send($_) });
+my $cl2 = await IO::Socket::Async.connect('127.0.0.1', $p2);
+is $c2.receive, 'two', 'second listener whenever body still reads ITS $.tag, not the leaked self';
+$cl2.close;
+$t2.close;

--- a/t/supplier-id-socket-collision.t
+++ b/t/supplier-id-socket-collision.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 2;
+
+# In-memory async-socket supplies used to stamp their Supply's `supplier_id`
+# attribute with an id from the *supply* counter — a separate sequence from
+# `Supplier.new`'s supplier counter, both starting at 1. A genuine Supplier
+# with the same number then cross-delivered its emissions straight into the
+# socket's tap (Cro::TCP messages showing up on a client's .Supply(:bin) tap).
+# Spray enough Suppliers that any namespace overlap would cross-deliver.
+
+sub free-port() {
+    my $t = IO::Socket::Async.listen('127.0.0.1', 0).tap(-> $c { $c.close });
+    my $p = await $t.socket-port;
+    $t.close;
+    $p
+}
+
+my $port = free-port();
+my $server-conns = Channel.new;
+my $tap = IO::Socket::Async.listen('127.0.0.1', $port).tap({ $server-conns.send($_) });
+my $client = await IO::Socket::Async.connect('127.0.0.1', $port);
+my @client-got;
+$client.Supply(:bin).tap({ @client-got.push($_) });
+my $server-socket = $server-conns.receive;
+
+for ^200 {
+    my $s = Supplier.new;
+    $s.Supply.tap({ ; });
+    $s.emit("stray-$_");
+}
+sleep 0.2;
+is @client-got.elems, 0, 'no foreign Supplier emission reached the socket tap';
+
+$server-socket.write('real'.encode('utf-8'));
+my $deadline = now + 5;
+sleep 0.05 until @client-got || now > $deadline;
+is @client-got.head.decode('utf-8'), 'real', 'the socket tap still receives its own bytes';
+
+$client.close;
+$tap.close;

--- a/t/supply-whenever-listener-tap.t
+++ b/t/supply-whenever-listener-tap.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 5;
+
+# `whenever IO::Socket::Async.listen(...)` inside a `supply` block, consumed by
+# a plain `.tap` (no react loop). The listener's subscription marker used to be
+# a 2-element array that only the react event loop understood: the supply-block
+# tap path recognises only 4-element markers, so the marker itself leaked to
+# the tap as a spurious emission and the whenever body never ran (Cro::TCP
+# Listener.incoming, tcp.rakutest test 15).
+
+sub free-port() {
+    my $t = IO::Socket::Async.listen('127.0.0.1', 0).tap(-> $c { $c.close });
+    my $p = await $t.socket-port;
+    $t.close;
+    $p
+}
+
+class Wrap { has $.socket is required }
+
+my $port = free-port();
+my $incoming = supply {
+    whenever IO::Socket::Async.listen('127.0.0.1', $port) -> $socket {
+        emit Wrap.new(:$socket);
+    }
+}
+
+my $conns = Channel.new;
+my $tap = $incoming.tap({ $conns.send($_) });
+my $client = await IO::Socket::Async.connect('127.0.0.1', $port);
+my $got = $conns.receive;
+ok $got ~~ Wrap, 'whenever body ran and emitted the wrapper object';
+ok $got.socket ~~ IO::Socket::Async, 'the accepted socket was bound to the whenever parameter';
+nok $conns.poll, 'no spurious emission before it (the old marker leak)';
+
+my $client2 = await IO::Socket::Async.connect('127.0.0.1', $port);
+ok $conns.receive ~~ Wrap, 'second connection emitted too';
+
+$client.close;
+$client2.close;
+$tap.close;
+dies-ok { await IO::Socket::Async.connect('127.0.0.1', $port) },
+    'closing the outer tap stops the listener';

--- a/todo/tickets/in-memory-socket-native-descriptor.md
+++ b/todo/tickets/in-memory-socket-native-descriptor.md
@@ -1,0 +1,38 @@
+# In-memory async sockets have no native-descriptor (blocks Cro::TCP :nodelay path)
+
+`IO::Socket::Async.connect` to an in-process listener creates an **in-memory**
+socket pair (`dispatch_socket_async_connect`), not a real TCP connection. Such a
+socket has no OS file descriptor, so `.native-descriptor` is unimplemented.
+Cro::TCP::NoDelay's `nodelay($socket)` calls
+`$socket.native-descriptor` and then NativeCall `setsockopt(...)` on it, so
+`Cro::TCP::Listener.new(:nodelay)`'s accept path dies inside the `whenever`
+body (the error is swallowed by the listener-callback dispatch) and
+`t/tcp.rakutest` subtest "Server connection with Listener options :nodelay"
+hangs waiting for the connection that was never emitted.
+
+Repro (with Cro::Core's lib):
+
+```raku
+use Cro::TCP;
+my $lis = Cro::TCP::Listener.new(port => 31313, :nodelay);
+my $conns = Channel.new;
+my $tap = $lis.incoming.tap({ $conns.send($_) });
+my $client = await IO::Socket::Async.connect('localhost', 31313);
+my $sc = $conns.receive;   # hangs: whenever body died in nodelay($socket)
+```
+
+Options considered:
+
+- Returning a fake fd (-1 or a dummy) makes `setsockopt` fail with EBADF and the
+  Cro code `die`s — worse than missing.
+- Backing each in-memory pair with a real `socketpair(2)` just to have valid
+  fds would satisfy `setsockopt`, but the data still flows through the
+  in-memory channels, so the fd is a lie with real cost.
+- The architecturally honest fix is to make localhost `connect` use the real
+  `TcpListener` (real accept, real fds, real byte streams) and reserve the
+  in-memory simulation for targets without sockets (wasm). That is a sizable
+  campaign: the in-memory supply/write/close plumbing in
+  `socket_async_conn.rs` is load-bearing for many S17/io tests today.
+
+Affected: `tmp`-vendored Cro::Core `t/tcp.rakutest` subtest 3+ (`:nodelay`),
+any real NativeCall use of `.native-descriptor` on async sockets.


### PR DESCRIPTION
Three fixes found by driving Cro::Core's vendored `t/tcp.rakutest` (14 -> 21+ subtests; previously aborted at the first real-socket test, now completes both `Server connection` subtests):

1. **`whenever IO::Socket::Async.listen(...)` inside a `supply` block now works under a plain `.tap`** (the `Cro::TCP::Listener.incoming` shape). The listener pushed a 2-element subscription marker that only the react event loop understood; the supply-block tap path recognises only 4-element `[source, body, [LAST...], [QUIT...]]` markers, so the marker leaked to the tap as a plain emitted value and the whenever body never ran. The marker now uses the standard 4-element shape, and the supply-block tap path gained a channel-backed arm: a worker thread drains the accept channel and drives the whenever body, whose `$emitter.emit(...)` reaches the outer tap through the emitter supplier. The outer Tap carries the listener handle so closing it stops the OS listener.

2. **In-memory socket supplies no longer collide with real Suppliers.** `async_socket_supply_in_memory` (and the UDP twin) stamped their Supply's `supplier_id` attribute with an id from `next_supply_id()` — a separate counter from `next_supplier_id()`, both starting at 1. A genuine `Supplier.new` with the same number cross-delivered its emissions into the socket's tap (Cro::TCP::Message objects arriving on a client's `.Supply(:bin)` tap). Both sites now allocate from the supplier counter.

3. **`self` is lexical in the interpreter closure path.** The `merge_all` captured-env merge in `call_sub_value` used don't-overwrite for `self`, so a natively invoked callback (a whenever body dispatched from a supplier tap or the in-process connect path) resolved `$.attr` against whatever `self` the caller env last leaked — the second `Cro::TCP::Listener` in a process read `$.nodelay` off a `Cro::TCP::Replier` and died (swallowed), hanging the suite. The VM closure dispatch already force-installs the captured `self` (the DBDish lesson); the interpreter path now mirrors it.

All three pins were verified to fail (or hang) on a build with the respective fix reverted.

Remaining in tcp.rakutest: the `:nodelay` subtest needs `.native-descriptor` on in-memory sockets — recorded in `todo/tickets/in-memory-socket-native-descriptor.md`.

Pins: `t/supply-whenever-listener-tap.t`, `t/supplier-id-socket-collision.t`, `t/closure-lexical-self-native-dispatch.t`. Local `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)