### PR TITLE
fix: three Cro::MessageWithBody blockers — value-method coercion fallback, on-demand whenever replay, colon-block-arg statement termination

### DIFF
--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -204,7 +204,20 @@ fn expr_ends_with_block(expr: &Expr) -> bool {
         | Expr::DynamicMethodCall { args, .. }
         | Expr::Call { args, .. }
         | Expr::UserRoutineCall { args, .. } => {
-            matches!(args.last(), Some(Expr::AnonSub { is_block: true, .. }))
+            // Recurse into the final argument: a block-taking construct that
+            // desugars to a call (`supply { ... }` becomes
+            // `Supply.on-demand(<block>)`) still ends the statement's text with
+            // its `}` — `$msg.set-body-byte-stream: supply { ... }` followed by
+            // a newline must not swallow the next line's `given`/`if` as a
+            // statement modifier (Cro::Core t/message-with-body.rakutest).
+            match args.last() {
+                Some(Expr::AnonSub { is_block: true, .. }) => true,
+                // A lowered block-taking construct carries its user block as a
+                // Lambda (`supply { ... }` -> `Supply.on-demand(<lambda>)`).
+                Some(Expr::Lambda { .. }) => true,
+                Some(last) => expr_ends_with_block(last),
+                None => false,
+            }
         }
         _ => false,
     }

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -752,6 +752,17 @@ impl Interpreter {
                     coercee,
                 );
             }
+            // Raku's coercion protocol also accepts a method named after the
+            // target type on the VALUE: `Promise($supply)` is `$supply.Promise`
+            // when the target declares no COERCE/new for it. This is the branch
+            // built-in targets with native-only constructors land in
+            // (`class_has_method` sees user methods only), e.g.
+            // Cro::MessageWithBody.body-blob's `Promise(supply { ... })`.
+            if args.len() == 1
+                && let Ok(res) = self.call_method_with_values(args[0].clone(), name, vec![])
+            {
+                return Ok(res);
+            }
             let source_type = crate::runtime::value_type_name(&args[0]).to_string();
             let msg = format!(
                 "Impossible coercion from '{}' into '{}': no acceptable coercion method found",

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -505,14 +505,28 @@ impl Interpreter {
         quit_cbs: &[Value],
         last_value: &mut Value,
     ) -> Result<(), RuntimeError> {
-        let values = match source.view() {
+        // Materialize the source through `supply_get_values` (same as
+        // `replay_cold_whenever_capture`): an on-demand source (`whenever $src`
+        // where $src is a stored `supply { emit ... }`) keeps its values behind
+        // `on_demand_callback`, not in a static `values` attribute — reading
+        // only the attribute replayed ZERO values and jumped straight to the
+        // LAST phaser (Cro::MessageWithBody.body-blob awaited an empty Buf).
+        let (values, mut initial_quit): (Vec<Value>, Option<Value>) = match source.view() {
             ValueView::Instance { attributes, .. } => {
-                match attributes.as_map().get("values").map(Value::view) {
-                    Some(ValueView::Array(items, ..)) => items.to_vec(),
-                    _ => Vec::new(),
+                match self.supply_get_values(&attributes.as_map()) {
+                    Ok(items) => (items, None),
+                    Err(err) => (
+                        Vec::new(),
+                        Some(
+                            err.exception
+                                .as_deref()
+                                .cloned()
+                                .unwrap_or_else(|| Value::str(err.message.clone())),
+                        ),
+                    ),
                 }
             }
-            _ => Vec::new(),
+            _ => (Vec::new(), None),
         };
 
         // Capture whatever the given callback `emit`s into `last_value`.
@@ -540,7 +554,7 @@ impl Interpreter {
 
         // Run the body for each source value; force lazy elements so a dying
         // gather surfaces as a quit.
-        let mut quit_reason: Option<Value> = None;
+        let mut quit_reason: Option<Value> = initial_quit.take();
         'replay: for v in values {
             let lazy = if let ValueView::LazyList(ll) = v.view() {
                 Some(ll.clone())

--- a/t/promise-coercion-call.t
+++ b/t/promise-coercion-call.t
@@ -1,0 +1,18 @@
+use Test;
+
+plan 3;
+
+# `Promise($supply)` — Raku's coercion protocol falls back to a method named
+# after the target type on the VALUE (`$supply.Promise`) when the target has
+# no applicable COERCE/new. Built-in targets whose constructors are native
+# land in the user-class coercion branch, which used to go straight to
+# X::Coerce::Impossible (Cro::MessageWithBody.body-blob does
+# `Promise(supply { ... })`).
+
+my $s = supply { emit 1; emit 2; };
+my $p = Promise($s);
+isa-ok $p, Promise, 'Promise($supply) returns a Promise';
+is (await $p), 2, 'the promise keeps with the final emitted value';
+
+throws-like { Promise("not-a-promise-source") }, Exception,
+    'a value with no .Promise method still fails to coerce';

--- a/t/stmt-terminator-colon-block-arg.t
+++ b/t/stmt-terminator-colon-block-arg.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 3;
+
+# A statement whose text ends with a `}` at end of line is self-terminating,
+# including when the block belongs to a lowered block-taking construct passed
+# as a colon argument: `$obj.method: supply { ... }` followed by a newline
+# must NOT swallow the next line's `given`/`if` as a statement modifier.
+# (Cro::Core t/message-with-body.rakutest silently skipped its `given await
+# ... -> $blob { ok ... }` tests this way.)
+
+my class Holder {
+    has $.stream;
+    method set-stream($!stream) { }
+}
+
+my $h = Holder.new;
+$h.set-stream: supply {
+    emit 42;
+}
+given 7 -> $v {
+    is $v, 7, 'given after a colon-supply-arg statement runs as its own statement';
+}
+
+my $ran = False;
+$h.set-stream: supply {
+    emit 1;
+}
+if True {
+    $ran = True;
+}
+ok $ran, 'if after a colon-supply-arg statement runs as its own statement';
+
+ok $h.stream ~~ Supply, 'the colon argument itself still bound correctly';

--- a/t/supply-promise-ondemand-whenever.t
+++ b/t/supply-promise-ondemand-whenever.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 2;
+
+# Awaiting a supply whose `whenever` source is itself a STORED on-demand
+# supply must replay that source's values. `replay_static_whenever_promise`
+# read only the source's static `values` attribute — an on-demand source keeps
+# its values behind `on_demand_callback`, so the body replayed zero values and
+# the LAST phaser emitted the untouched accumulator
+# (Cro::MessageWithBody.body-blob awaited an empty Buf).
+
+my $src = supply {
+    emit Blob.new(1, 2);
+    emit Blob.new(3);
+};
+my $joined-result = await supply {
+    my $joined = Buf.new;
+    whenever $src -> $b {
+        $joined.append($b);
+        LAST emit $joined;
+    }
+}.Promise;
+is-deeply $joined-result.list, (1, 2, 3), 'on-demand whenever source values reach the body';
+
+my $static-result = await supply {
+    my $joined = Buf.new;
+    whenever Supply.from-list(Blob.new(4), Blob.new(5)) -> $b {
+        $joined.append($b);
+        LAST emit $joined;
+    }
+}.Promise;
+is-deeply $static-result.list, (4, 5), 'static whenever source still replays';


### PR DESCRIPTION
Found by driving Cro::Core's `t/message-with-body.rakutest` (1/6 -> **6/6**):

1. **Type coercion calls fall back to a method named after the target type on the value**: `Promise($supply)` is `$supply.Promise` when the target has no applicable COERCE/new. Built-in targets with native-only constructors land in the user-class coercion branch (`class_has_method` sees user methods only), which went straight to X::Coerce::Impossible.

2. **`replay_static_whenever_promise` materializes the whenever source through `supply_get_values`**, like the cold-capture replay already did: an on-demand source (`whenever $src` where $src is a stored `supply { emit ... }`) keeps its values behind `on_demand_callback`, so reading only the static `values` attribute replayed zero values and jumped straight to the LAST phaser — `body-blob` awaited an empty Buf.

3. **A statement whose colon argument is a lowered block-taking construct is self-terminating** at the block's end-of-line `}`: `expr_ends_with_block` now recurses into the final argument and recognizes the lowered Lambda (`supply { ... }` -> `Supply.on-demand(<lambda>)`), so `$msg.set-body-byte-stream: supply { ... }` no longer swallows the next line's `given`/`if` as a statement modifier. The test's `given await ... -> $blob { ok ... }` blocks were being silently skipped this way.

All three pins verified to pass under `raku` as the spec oracle. Local `make test` green. Also advances `t/composer.rakutest` to 83/86-ish together with #5605/#5608.

Pins: `t/promise-coercion-call.t`, `t/supply-promise-ondemand-whenever.t`, `t/stmt-terminator-colon-block-arg.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)