### PR TITLE
fix(parser): a parenthesized X/Z meta-op keeps its boundary in argument lists

### DIFF
--- a/src/parser/primary/container/paren.rs
+++ b/src/parser/primary/container/paren.rs
@@ -272,7 +272,16 @@ fn paren_expr_inner(input: &str) -> PResult<'_, Expr> {
                 Expr::AssignExpr { .. }
                     | Expr::IndexAssign { .. }
                     | Expr::MultiDimIndexAssign { .. }
-            ) {
+            )
+            // A parenthesized X/Z meta-op keeps its boundary: the argument-list
+            // lift (`lift_list_infix_in_arg_list`) hoists a BARE meta-op's
+            // preceding comma items into its left operand (list-infix is looser
+            // than the argument comma), but parens close the operand off —
+            // `join "", ("+" X~ @parts)` must keep "" as the separator, not
+            // cross ("", "+") with @parts (Cro::MediaType's subtype action).
+            // The lift only matches an unwrapped MetaOp, so Grouped is enough.
+            || matches!(&result, Expr::MetaOp { meta, .. } if meta == "X" || meta == "Z")
+        {
             Expr::Grouped(Box::new(result))
         } else {
             result

--- a/src/runtime/system_eval_vars.rs
+++ b/src/runtime/system_eval_vars.rs
@@ -158,6 +158,11 @@ impl Interpreter {
             Expr::ArrayLiteral(items) => {
                 items.iter().any(|i| Self::expr_references_var(i, var_name))
             }
+            // Grouped is the transparent parenthesization marker (e.g. a
+            // parenthesized X/Z meta-op keeps it so the arg-list lift leaves
+            // it alone) — look through it, or `my @foo := 1..3, (@foo Z+ 100)`
+            // stops throwing X::Syntax::Variable::Initializer.
+            Expr::Grouped(inner) => Self::expr_references_var(inner, var_name),
             _ => false,
         }
     }

--- a/t/paren-cross-arg-boundary.t
+++ b/t/paren-cross-arg-boundary.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 7;
+
+# A parenthesized X/Z meta-op keeps its boundary in an argument list. The
+# list-infix lift hoists a BARE meta-op's preceding comma items into its left
+# operand (`join "", "+" X~ @l` crosses ("", "+") with @l — list-infix is
+# looser than the argument comma), but parens close the operand off:
+# `join "", ("+" X~ @l)` keeps "" as the separator. Cro::MediaType's subtype
+# action built subtype names with exactly this shape and silently lost every
+# suffix but the last.
+
+my @lit = "a", "b";
+
+is (join "", ("+" X~ @lit)), "+a+b",
+    'parenthesized cross stays one argument';
+is (join "", "+" X~ @lit), "",
+    'unparenthesized cross still lifts the comma items into its left operand';
+
+my @r = "", ("+" X~ @lit);
+is @r.elems, 2, 'comma list keeps the parenthesized cross as one element';
+is @r[0], "", '... and the preceding item intact';
+
+is-deeply (1, ("a" X~ "b"), 2), (1, ("ab",).Seq, 2),
+    'mid-list parenthesized cross unaffected by neighbours';
+is-deeply (1 X~ 2), ("12",).Seq, 'standalone parenthesized cross';
+is-deeply (1, 2 Z+ 10, 20), (11, 22).Seq, 'bare zip still lifts across the comma';


### PR DESCRIPTION
The list-infix lift (`lift_list_infix_in_arg_list`) hoists a bare meta-op's preceding comma items into its left operand — correct for `join "", "+" X~ @l` (list-infix is looser than the argument comma), but wrong when the meta-op was parenthesized: `join "", ("+" X~ @l)` crossed ("", "+") with @l and returned "". The paren finalizer now wraps a parenthesized X/Z meta-op in `Expr::Grouped` (transparent to the compiler); the lift only matches an unwrapped MetaOp, so the boundary holds.

Cro::MediaType's subtype action builds subtype names with exactly this shape: vendored Cro::Core `t/mediatype.rakutest` goes 84/87 -> **87/87**.

7-case pin verified behavior-identical with raku (parenthesized/unparenthesized × positions). Local `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)