### PR TITLE
fix(vm): closures resolve their captured lexical self across env tiers

### DIFF
--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -432,6 +432,17 @@ impl Interpreter {
                 }
                 new_env.insert_sym(*k, v.clone());
             }
+            // `self` may live in a PARENT tier of the captured env: the loop
+            // above iterates the own tier only (`Env::iter` does not walk the
+            // chain, unlike `get`), so the lexical-self install in the loop
+            // never fires for a closure captured under a scoped overlay — a
+            // supply block created in `Sink.sinker` and driven from another
+            // object's method read `$!attr` off that other object. Resolve
+            // through the tier-walking get and force-install (self is lexical;
+            // a method's own invocant is bound from its args after this).
+            if let Some(captured_self) = closure_base_env.get("self").cloned() {
+                new_env.insert("self".to_string(), captured_self);
+            }
             self.env = new_env.clone();
             // Check for empty signature: a pointy block `-> { }` or sub with no
             // params that doesn't use @_/%_ must reject positional arguments.

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -266,6 +266,15 @@ impl Interpreter {
                 self.env_mut().entry_or_insert_sym(*k, v.clone());
             }
         }
+        // `self` may live in a PARENT tier of the captured env: the loop above
+        // iterates the own tier only (`Env::iter` does not walk the chain,
+        // unlike `get`), so the lexical-self install in the loop never fires
+        // for a closure captured under a scoped overlay. Resolve through the
+        // tier-walking get and force-install (interpreter-path twin in
+        // `call_sub_value`).
+        if let Some(captured_self) = data.env.get("self").cloned() {
+            self.env_mut().insert("self".to_string(), captured_self);
+        }
         // A closure's free variables are lexically bound in its captured env, so an
         // *authoritative* capture must OVERWRITE whatever the caller env happens to
         // hold under the same name. The frame env is a scoped child of the

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -451,6 +451,7 @@ impl Interpreter {
             // then hold `$_` at the outer topic instead of binding it to the
             // element (`*.map({ $_ })` saw the whole list, not each item).
             flat.remove_sym(Symbol::intern("__mutsu_callable_type"));
+            self.materialize_frame_self_into_capture(code, &mut flat);
             return flat;
         }
         let free: std::collections::HashSet<Symbol> = cc.free_var_syms.iter().copied().collect();
@@ -487,7 +488,25 @@ impl Interpreter {
                 env.insert_sym(*sym, val.clone());
             }
         }
+        self.materialize_frame_self_into_capture(code, &mut env);
         env
+    }
+
+    /// `self` is lexical: a closure created inside a method body must capture
+    /// that method's invocant. On the fast method path (skip_env_setup) `self`
+    /// lives ONLY in a local slot, so the env-based capture above misses it and
+    /// a later `$.attr`/`$!attr` in the closure body resolved against whatever
+    /// `self` the *invoking* frame happened to carry — a supply block created
+    /// in `Sink.sinker` and tapped from another object's method read `$!sum`
+    /// off that other object (Cro::Service.start's assembled pipeline).
+    fn materialize_frame_self_into_capture(&self, code: &CompiledCode, env: &mut Env) {
+        if env.get("self").is_none()
+            && let Some(slot) = code.locals.iter().position(|n| n == "self")
+            && let Some(val) = self.locals.get(slot)
+            && !val.is_nil()
+        {
+            env.insert("self".to_string(), val.clone());
+        }
     }
 
     /// Build the closure's upvalue array (aligned with `cc.upvalue_syms`) from the

--- a/t/closure-captured-self-parent-tier.t
+++ b/t/closure-captured-self-parent-tier.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 2;
+
+# `self` is lexical, and the capture may hold it in a PARENT tier of the
+# closure's captured env (the creating method ran under a scoped overlay).
+# The closure-entry env merges iterate the captured env's own tier only
+# (`Env::iter` does not walk the chain, unlike `get`), so the lexical-self
+# force-install never fired for such captures: a supply block created inside
+# `Sink.sinker` and tapped from ANOTHER object's method resolved `$!sum`
+# against that other object (P6opaque: no such attribute '$!sum' on type
+# Driver) — Cro::Service.start's assembled pipeline hit exactly this.
+
+class Msg { has $.v }
+class Snk {
+    has Int $.sum = 0;
+    method sinker($in) { supply { whenever $in -> $m { $!sum += $m.v } } }
+}
+class Driver {
+    method tap-it($s) { $s.tap }
+}
+
+my $src = supply { emit Msg.new(v => 5); emit Msg.new(v => 8) };
+my $sink = Snk.new;
+my $s = $sink.sinker($src);
+lives-ok { Driver.new.tap-it($s) },
+    'tapping from another object\'s method does not misresolve $!attr';
+is $sink.sum, 13, 'the whenever body accumulated into ITS OWN object';

--- a/todo/tickets/cro-connection-manager-live-pipeline.md
+++ b/todo/tickets/cro-connection-manager-live-pipeline.md
@@ -1,0 +1,34 @@
+# Connection-manager per-connection pipelines treat live supplies as cold (Cro::Core composer.rakutest 87-88 + trailing hang)
+
+With #5605/#5608/#5611 and the closure-self/parent-tier fix in, Cro::Core's
+`t/composer.rakutest` reaches 86/88, failing only the connection-manager
+message-flow tests and hanging after the last one (exit 124).
+
+Scenario (composer.rakutest ~line 470-520): `Cro.compose($conn-source,
+TestUppercaseTransform)` produces a service whose connection manager builds a
+per-connection pipeline: `connection.incoming` (a live `Supplier`-backed
+supply) → transform (`supply { whenever $input { emit ... } }`) → the
+connection's replier sink (`whenever $input { $!replier.emit(.body);
+LAST $!replier.emit('(closed)') }`).
+
+Observed: `$response-channel-a.receive` gets `'(closed)'` instead of `'BBQ'`
+— the replier sink's `whenever` saw ZERO messages and its LAST phaser fired
+immediately. The message is emitted into the connection's `$!send` Supplier
+*after* the pipeline is assembled, so the pipeline must stay LIVE; instead
+the per-connection pipeline assembly (which happens inside the connection
+manager's own `whenever` body, i.e. inside a running supply callback) takes
+a cold/finite replay path: 0 buffered values → done → LAST.
+
+The trailing process hang after test 86 (before these fixes: after 88) is
+likely the same machinery: a per-connection driver waiting on something that
+never completes.
+
+Where to look: the supply-block tap path's marker handling in
+`native_supply_mut_methods.rs` (live supplier-backed sources ARE handled when
+the tap happens at "top level", so the difference is assembling/tapping from
+within a whenever callback — `supply_emit_buffer` frames / `react_active`
+state at that moment), and `run_whenever_with_value`'s react-mode vs
+non-react-mode branches.
+
+Repro: run the vendored suite `tmp`-extract of Cro::Core:
+`target/debug/mutsu -I lib t/composer.rakutest` (tests 87-88).


### PR DESCRIPTION
A closure's captured env may hold `self` in a PARENT tier (the creating method ran under a scoped overlay), but both closure-entry merges — the VM closure dispatch and the interpreter-path `call_sub_value` — iterate the captured env's own tier only (`Env::iter` does not walk the chain, unlike `get`). The lexical-self force-install therefore never fired for such captures: a supply block created inside `Sink.sinker` and tapped from ANOTHER object's method resolved `$!sum` against that other object (`P6opaque: no such attribute '$!sum' on type Driver`).

`Cro::Service.start`'s assembled pipeline hits exactly this: vendored Cro::Core `t/composer.rakutest` goes 83 -> **86**/88 (the three "Starting service processes all messages" family failures disappear).

Also materializes a slot-only `self` (fast method path, skip_env_setup) into the closure capture itself, so a closure created on that path carries its invocant like the slow path does.

Diagnosed with env-gated instrumentation: the captured env showed `self=Snk` via `get()` while the merge loop never saw the key — `Env`'s iterator yields the own tier only.

The remaining connection-manager live-pipeline failures (composer 87/88 + trailing hang) are recorded in `todo/tickets/cro-connection-manager-live-pipeline.md`.

Pin: `t/closure-captured-self-parent-tier.t` (verified against raku). Local `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)