### PR TITLE
fix(role): run a punned role's BUILD and TWEAK submethods

### DIFF
--- a/news/2026-07/role-pun-runs-build-and-tweak.md
+++ b/news/2026-07/role-pun-runs-build-and-tweak.md
@@ -1,0 +1,93 @@
+# A punned role now runs its BUILD and TWEAK submethods
+
+`R.new` on a role puns it into a class and constructs. mutsu's pun path skipped
+the role's own `submethod BUILD` and `submethod TWEAK` entirely, so every
+attribute they would have initialised stayed unset:
+
+```raku
+role R { has %.h; submethod BUILD(--> Nil) { %!h{"a"} = 1 } }
+say R.new.h.raku;          # was: {}   raku: {:a(1)}
+```
+
+Composing the same role into a class (`class C does R { }`) ran them correctly,
+so this was specific to punning. It was the top blocker of the **Cro::Core**
+suite: `Cro::Policy::Timeout` is a parameterized role whose `BUILD` fills a
+`Real() %.phases` hash from the role's `%phase-defaults` parameter, and Cro
+instantiates it as a pun — with `BUILD` skipped, every phase lookup answered
+`Any`.
+
+## The pun stopped reproducing construction
+
+The cause was a second implementation. `dispatch_new` recognised a role type
+object and built the instance by hand — collecting attributes from the role and
+its parents, evaluating defaults, type-checking supplied values, tagging typed
+containers — as a parallel copy of what the class construction path does. The
+copy had drifted: it never grew the BUILD/TWEAK phases, and it was behind on
+`is required` and coercion-typed attributes too.
+
+It is gone. The pun now composes the role into a class of the same name and
+re-enters `.new` on *that*, so construction is the ordinary class construction:
+attribute seeding, `is required`, coercion types, the BUILD phase, the
+initializers BUILD left alone, and the TWEAK phase, in that order. A
+re-entrancy guard (`role_pun_construction`) makes the second entry take the
+class path instead of recognising the name as a role again, and the pun is
+withdrawn afterwards so the name stays a role. Three behaviours came back for
+free:
+
+```raku
+role T { has Int $.i is required }
+try { T.new };            # was: an instance   now: X::Attribute::Required
+role U { has Int() $.i }
+say U.new(i => "42").i;   # was: "42"          now: 42
+role V { has $.x = 5; submethod TWEAK(--> Nil) { $!x = $!x + 1 } }
+say V.new.x;              # was: 5             now: 6
+```
+
+## Three bugs the delegation exposed
+
+**The pun's methods did not say they came from the role.** The pun class is
+built by copying the role's methods into a class shell, and the copies kept
+`role_origin: None` — the marker that distinguishes a composed method from one
+the class declares itself. The construction phases then found the role's `BUILD`
+twice, once as the composed-role submethod and once as an apparently
+class-declared candidate, and ran it twice (`submethod BUILD { @!a.push(1) }`
+punned to `[1, 1]`). Real `does` composition tags them, which is why it never
+doubled; the copying pun now tags them the same way.
+
+**An itemized array type argument was spread.** `R[[1, 2]]` parameterises
+`role R[@l]` with one argument, but the subscript spread any array index into
+one type argument per element, so it passed two — matching no candidate's arity
+at all, which left `@l` bound to the bare `1`. Only a comma list (`R[Int, Str]`)
+spreads now; `ArrayKind` already carried the distinction between `(1, 2)` and
+`[1, 2]`.
+
+**Withdrawing a pun left its construction plan behind.** Construction puns the
+role only for the duration and then drops the `ClassDef` again, but the plan
+cached under that name — the one that decides a class is simple enough for the
+native fast path — survived. The next `R.new` matched that stale plan before
+reaching the role branch at all and built a plain instance with no role mixin
+markers, so every method call on it died with "No such method". Only the *first*
+construction in a program produced a working object. The withdrawal is now one
+helper (`withdraw_role_pun`) that drops the plan with the class, shared by all
+three sites that had been spelling it out.
+
+Parameterized puns reach the same construction path as bare ones. The
+name-driven route (`ensure_parametric_role_pun_class`) still handles a
+parameterisation whose arguments have a faithful spelling in a type name; the
+fallback for those that do not — a Hash or Array argument, which is exactly the
+Cro case — now binds the matched candidate's type parameters through the real
+signature binder and constructs through the pun class, instead of building an
+attribute-less instance whose state lived only in mixin markers.
+
+## Pin
+
+`t/role-pun-build-tweak.t` (23 tests), every assertion checked against Rakudo
+v2026.06: BUILD and TWEAK on scalar/array/hash attributes, each running exactly
+once, their ordering against attribute initializers, named-argument binding,
+composition still behaving, the four parameterisation shapes (type, value, hash
+and array arguments), and a repeated construction keeping both its role methods
+and its BUILD.
+
+The sibling finding — that a pun should not construct *at all* for a plain
+method call — is unaffected and still tracked in
+`todo/tickets/role-pun-should-not-construct.md`.

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -111,12 +111,161 @@ impl Interpreter {
         Ok(instance)
     }
 
+    /// Tag a freshly constructed punned-role instance with the mixin markers the
+    /// rest of the runtime keys off: `__mutsu_role__<role>` (this instance does
+    /// the role) and one `__mutsu_attr__<name>` per attribute, plus the role's
+    /// language revision. The markers are seeds — the instance's own attribute
+    /// cell stays the store of record, and the accessor / "is this a role mixin"
+    /// paths refresh from it — so they are taken after construction, with
+    /// whatever BUILD and TWEAK left behind.
+    ///
+    /// A value that is not an instance of the punned role (a `Failure` from a
+    /// failing TWEAK, say) is passed through untouched. `extra` carries the
+    /// markers only a *parameterised* pun needs (the type arguments, the matched
+    /// candidate's role id and its bound parameters).
+    fn mark_punned_role_instance(
+        &mut self,
+        role: Symbol,
+        value: Value,
+        extra: HashMap<String, Value>,
+    ) -> Value {
+        let role_name = role.resolve();
+        let attrs: Vec<(String, Value)> = match value.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name.resolve() == role_name => attributes
+                .as_map()
+                .iter()
+                .map(|(name, attr)| (name.resolve(), attr.clone()))
+                .collect(),
+            _ => return value,
+        };
+        let mut mixins = extra;
+        mixins.insert(format!("__mutsu_role__{}", role_name), Value::TRUE);
+        for (name, attr) in attrs {
+            mixins.insert(format!("__mutsu_attr__{}", name), attr);
+        }
+        // The language revision comes from the parameterless candidate (this is
+        // bare role punning) so `^language-revision` reports the revision of the
+        // module the role was declared in, not the last-registered candidate's.
+        // A parameterised pun has already supplied its *matched* candidate's
+        // revision through `extra`, which must win over that.
+        if mixins.contains_key("__mutsu_language_revision") {
+            return Value::mixin(value, mixins);
+        }
+        let bare_lang_ver = self
+            .registry()
+            .role_candidates
+            .get(&role_name)
+            .and_then(|candidates| {
+                candidates
+                    .iter()
+                    .find(|c| c.type_params.is_empty())
+                    .map(|c| c.language_version.clone())
+            })
+            .or_else(|| {
+                self.type_metadata
+                    .get(&role_name)
+                    .and_then(|m| m.get("language-revision"))
+                    .map(|v| format!("6.{}", v.to_string_value()))
+            });
+        if let Some(ver) = bare_lang_ver {
+            let revision: String = if let Some(letter) = ver.strip_prefix("6.") {
+                letter.chars().next().unwrap_or('c').to_string()
+            } else {
+                "c".to_string()
+            };
+            mixins.insert(
+                "__mutsu_language_revision".to_string(),
+                Value::str(revision),
+            );
+        }
+        Value::mixin(value, mixins)
+    }
+
+    /// Withdraw the class a role was punned to for one construction, so the name
+    /// goes back to being a role.
+    ///
+    /// Dropping the `ClassDef` is not enough: the pun made the name look like an
+    /// ordinary class, and a *construction plan* for it was cached under that
+    /// name. Left behind, the next `R.new` matched the stale plan on the native
+    /// fast path and built a plain instance — no role mixin markers, so every
+    /// method call on it failed with "No such method". Only the first
+    /// construction in a program worked.
+    fn withdraw_role_pun(&mut self, role_name: &str) {
+        self.registry_mut().classes.remove(role_name);
+        self.registry_mut().hidden_classes.remove(role_name);
+        self.registry_mut().class_composed_roles.remove(role_name);
+        self.clear_private_zeroarg_method_cache();
+        self.native_ctor_plan_cache.clear();
+    }
+
+    /// Bind a parameterised role's type arguments to its type parameters and
+    /// return the resulting name -> value map, for `class_role_param_bindings`.
+    ///
+    /// This is signature binding, not a positional zip: `role R[@l]` slurps its
+    /// arguments into `@l` and `role R[%d]` takes a hash whole, so `R[[1, 2]]`
+    /// must see `@l` as `[1, 2]` rather than as its first element. Running the
+    /// real binder — the same one the candidate search used to decide this
+    /// candidate matches — is what gets that right. It runs against a scratch
+    /// env that is restored afterwards; a candidate with no parameter defs (or
+    /// one that fails to bind, which the search should already have excluded)
+    /// falls back to the positional pairing.
+    fn bind_role_type_params(
+        &mut self,
+        param_defs: &[crate::ast::ParamDef],
+        param_names: &[String],
+        type_args: &[Value],
+    ) -> rustc_hash::FxHashMap<String, Value> {
+        let mut bindings: rustc_hash::FxHashMap<String, Value> = Default::default();
+        if !param_defs.is_empty() {
+            let names: Vec<String> = param_defs.iter().map(|pd| pd.name.clone()).collect();
+            let saved_env = self.env.clone();
+            let bound = self
+                .bind_function_args_values(param_defs, &names, type_args)
+                .is_ok();
+            if bound {
+                for (i, name) in names.iter().enumerate() {
+                    let Some(value) = self.env.get(name).cloned() else {
+                        continue;
+                    };
+                    // Key by the role's declared parameter spelling, which is
+                    // what consumers of `class_role_param_bindings` put back
+                    // into the env for the role body to read. It is not always
+                    // the signature parameter's own name, so both are recorded
+                    // when they differ.
+                    bindings.insert(param_names.get(i).unwrap_or(name).clone(), value.clone());
+                    bindings.insert(name.clone(), value);
+                }
+            }
+            self.env = saved_env;
+            if bound {
+                return bindings;
+            }
+        }
+        for (name, arg) in param_names.iter().cloned().zip(type_args.iter().cloned()) {
+            bindings.insert(name, arg);
+        }
+        bindings
+    }
+
     pub(super) fn dispatch_new(
         &mut self,
         target: Value,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
-        if let ValueView::Package(_) = target.view() {
+        // A role with defaulted type parameters materialises to its default
+        // parameterisation before constructing — but not while it is already
+        // constructing through its own pun, where re-materialising would send
+        // the delegation below straight back here forever.
+        if let ValueView::Package(name) = target.view()
+            && !self
+                .role_pun_construction
+                .iter()
+                .any(|n| n == &name.resolve())
+        {
             let materialized = self.materialize_default_parametric_role(target.clone())?;
             if materialized != target {
                 return self.dispatch_new(materialized, args);
@@ -258,6 +407,12 @@ impl Interpreter {
             self.ensure_role_punned_to_class(&base_name_str);
             let mut selected_role = self.registry().roles.get(&base_name_str).cloned();
             let mut matched_lang_version: Option<String> = None;
+            // The matched candidate's parameter *signature*, not just the names:
+            // binding the type arguments is real signature binding (a `@l`
+            // parameter slurps, `%d` takes the hash whole), so the pun below
+            // re-runs the same binder the candidate search used rather than
+            // zipping names to arguments positionally.
+            let mut selected_param_defs: Vec<crate::ast::ParamDef> = Vec::new();
             let mut selected_param_names = self
                 .registry()
                 .role_type_params
@@ -343,22 +498,13 @@ impl Interpreter {
                 matching.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
                 if let Some((candidate, _, _)) = matching.into_iter().next() {
                     selected_param_names = candidate.type_params.clone();
+                    selected_param_defs = candidate.type_param_defs.clone();
                     matched_lang_version = Some(candidate.language_version.clone());
                     selected_role = Some(candidate.role_def.clone());
                 }
             }
             if let Some(role) = selected_role {
                 let role_id = role.role_id;
-                let mut named_args: HashMap<String, Value> = HashMap::new();
-                let mut positional_args: Vec<Value> = Vec::new();
-                for arg in &args {
-                    if let ValueView::Pair(key, value) = arg.view() {
-                        named_args.insert(key.clone(), value.clone());
-                    } else {
-                        positional_args.push(arg.clone());
-                    }
-                }
-
                 let mut mixins = HashMap::new();
                 mixins.insert(format!("__mutsu_role__{}", base_name), Value::TRUE);
                 mixins.insert(
@@ -377,25 +523,6 @@ impl Interpreter {
                         type_arg.clone(),
                     );
                 }
-                let saved_role_param_env = self.env.clone();
-                for (param_name, type_arg) in selected_param_names.iter().zip(type_args.iter()) {
-                    self.env.insert(param_name.clone(), type_arg.clone());
-                }
-                for (idx, (attr_name, _is_public, default_expr, _, _, _, _)) in
-                    role.attributes.iter().enumerate()
-                {
-                    let value = if let Some(v) = named_args.get(attr_name) {
-                        v.clone()
-                    } else if let Some(v) = positional_args.get(idx) {
-                        v.clone()
-                    } else if let Some(expr) = default_expr {
-                        self.eval_block_value(&[Stmt::Expr(expr.clone())])?
-                    } else {
-                        Value::NIL
-                    };
-                    mixins.insert(format!("__mutsu_attr__{}", attr_name), value);
-                }
-                self.env = saved_role_param_env;
                 // Embed language revision in mixin metadata so
                 // ^language-revision on the punned instance returns
                 // the revision of the matched candidate.
@@ -410,10 +537,52 @@ impl Interpreter {
                         Value::str(revision),
                     );
                 }
-                return Ok(Value::mixin(
-                    Value::make_instance(base_name, HashMap::new()),
-                    mixins,
-                ));
+                // Construct through the *base* role's pun class, with the
+                // matched candidate's type parameters bound for the duration, so
+                // this arrives at the same construction path as every other pun
+                // — attribute seeding, defaults and the BUILD/TWEAK phases.
+                //
+                // `ensure_parametric_role_pun_class` above is the better route
+                // and handles most parameterisations, but it is name-driven and
+                // gives up when an argument has no faithful spelling in a type
+                // name. A Hash argument is exactly that case, and it is the one
+                // that matters: `Cro::Policy::Timeout[%(...)]` fills its
+                // `%.phases` from the parameter inside `BUILD`, so before this
+                // the pun answered `Any` for every phase.
+                let pre_existing_class = self.registry().classes.contains_key(&base_name_str);
+                self.ensure_role_punned_to_class(&base_name_str);
+                let saved_bindings = self
+                    .registry()
+                    .class_role_param_bindings
+                    .get(&base_name_str)
+                    .cloned();
+                let bindings = self.bind_role_type_params(
+                    &selected_param_defs,
+                    &selected_param_names,
+                    type_args,
+                );
+                self.registry_mut()
+                    .class_role_param_bindings
+                    .insert(base_name_str.clone(), bindings);
+                self.role_pun_construction.push(base_name_str.clone());
+                let constructed = self.dispatch_new(Value::package(base_name), args.clone());
+                self.role_pun_construction.pop();
+                match saved_bindings {
+                    Some(saved) => {
+                        self.registry_mut()
+                            .class_role_param_bindings
+                            .insert(base_name_str.clone(), saved);
+                    }
+                    None => {
+                        self.registry_mut()
+                            .class_role_param_bindings
+                            .remove(&base_name_str);
+                    }
+                }
+                if !pre_existing_class {
+                    self.withdraw_role_pun(&base_name_str);
+                }
+                return Ok(self.mark_punned_role_instance(base_name, constructed?, mixins));
             }
         }
 
@@ -1217,7 +1386,15 @@ impl Interpreter {
                     return Ok(self.tag_container_metadata(result, info));
                 }
             }
-            let role = self.registry().roles.get(&class_name.resolve()).cloned();
+            // Not `if let ... else`: the role branch is skipped entirely while
+            // this very role is constructing through its own pun (see the
+            // delegation at the end of the branch), so the re-entry falls
+            // through to the class path below instead of looping here.
+            let role = if self.role_pun_construction.iter().any(|n| n == &cn_resolved) {
+                None
+            } else {
+                self.registry().roles.get(&cn_resolved).cloned()
+            };
             if let Some(role) = role {
                 // Check for attribute conflicts detected during role composition
                 if let Some((attr_name, role_a, role_b)) = role.attribute_conflicts.first() {
@@ -1239,10 +1416,7 @@ impl Interpreter {
                         args.clone(),
                         None,
                     );
-                    self.registry_mut().classes.remove(&role_name);
-                    self.registry_mut().hidden_classes.remove(&role_name);
-                    self.registry_mut().class_composed_roles.remove(&role_name);
-                    self.clear_private_zeroarg_method_cache();
+                    self.withdraw_role_pun(&role_name);
                     match dispatched {
                         Ok((result, _)) => {
                             if let ValueView::Instance {
@@ -1268,172 +1442,41 @@ impl Interpreter {
                         Err(e) => return Err(e),
                     }
                 }
-                let mut named_args: HashMap<String, Value> = HashMap::new();
-                let mut positional_args: Vec<Value> = Vec::new();
-                for arg in &args {
-                    if let ValueView::Pair(key, value) = arg.view() {
-                        named_args.insert(key.clone(), value.clone());
-                    } else {
-                        positional_args.push(arg.clone());
-                    }
-                }
-                if !positional_args.is_empty() {
-                    return Err(constructor_positional_error(&class_name.resolve()));
-                }
-
-                // Collect attributes from this role and all composed parent roles
-                let mut all_attributes = role.attributes.clone();
-                let mut visited = vec![class_name.resolve()];
-                if let Some(parent_names) = self
-                    .registry()
-                    .role_parents
-                    .get(&class_name.resolve())
-                    .cloned()
+                if args
+                    .iter()
+                    .any(|a| !matches!(a.view(), ValueView::Pair(..)))
                 {
-                    let mut role_stack: Vec<String> = parent_names;
-                    while let Some(parent_role_name) = role_stack.pop() {
-                        if !visited.contains(&parent_role_name) {
-                            visited.push(parent_role_name.clone());
-                            if let Some(parent_role) =
-                                self.registry().roles.get(&parent_role_name).cloned()
-                            {
-                                for attr in &parent_role.attributes {
-                                    if !all_attributes.iter().any(|a| a.0 == attr.0) {
-                                        all_attributes.push(attr.clone());
-                                    }
-                                }
-                            }
-                            if let Some(grandparents) =
-                                self.registry().role_parents.get(&parent_role_name).cloned()
-                            {
-                                for gp_name in &grandparents {
-                                    if !visited.contains(gp_name) {
-                                        role_stack.push(gp_name.clone());
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    return Err(constructor_positional_error(&cn_resolved));
                 }
-
-                // The declared types of those attributes, keyed by attribute name.
-                // A role records them per (role, attr) since it has no ClassDef
-                // to hold `attribute_types`; parent roles are folded in first so
-                // this role's own declaration wins on a name clash.
-                let role_attr_types: HashMap<String, String> = {
-                    let cn = class_name.resolve();
-                    let mut m: HashMap<String, String> = HashMap::new();
-                    for owner in visited.iter().rev() {
-                        let base = owner.split_once('[').map(|(b, _)| b).unwrap_or(owner);
-                        for ((r, attr), tc) in &self.registry().role_attribute_types {
-                            if r == base {
-                                m.insert(attr.clone(), tc.replace("::?CLASS", &cn));
-                            }
-                        }
-                    }
-                    m
-                };
-
-                let mut mixins = HashMap::new();
-                mixins.insert(format!("__mutsu_role__{}", class_name), Value::TRUE);
-                // The attribute values go into the punned instance's own cell, not
-                // only into `__mutsu_attr__` mixin markers: that cell is what a
-                // private access (`$!parent`) inside a role method reads and
-                // writes, so it has to be the store of record. The markers are
-                // still written, as the accessor path and the "is this a role
-                // mixin" checks key off them, but they are seeds — a read prefers
-                // the cell whenever the cell has the attribute.
-                let mut instance_attrs: HashMap<String, Value> = HashMap::new();
-                for (attr_name, _is_public, default_expr, _, _, sigil, _) in &all_attributes {
-                    let supplied = if let Some(v) = named_args.get(attr_name) {
-                        Some(v.clone())
-                    } else if let Some(expr) = default_expr {
-                        Some(self.eval_block_value(&[Stmt::Expr(expr.clone())])?)
-                    } else {
-                        None
-                    };
-                    // A punned role type-checks its attributes exactly like the
-                    // consuming-class path (`enforce_attribute_where_constraints`):
-                    // the constraint lives in `role_attribute_types` because the
-                    // role has no ClassDef of its own at declaration time. As
-                    // there, a `@`/`%` constraint names the *element* type and is
-                    // enforced at element assignment, not here.
-                    if let Some(value) = supplied.as_ref()
-                        && !value.is_nil()
-                        && *sigil != '@'
-                        && *sigil != '%'
-                        && let Some(tc) = role_attr_types.get(attr_name)
-                        && (tc.starts_with(char::is_uppercase) || tc.starts_with("::"))
-                        && !self.type_matches_value(tc, value)
-                        && !self.is_container_subclass(tc)
-                    {
-                        return Err(crate::runtime::utils::type_check_assignment_typed_error(
-                            &format!("$!{}", attr_name),
-                            tc,
-                            value,
-                        ));
-                    }
-                    // Every attribute is seeded into the cell, containers
-                    // included: an unsupplied `@`/`%` seeds an empty container
-                    // rather than `Nil`, matching what the class path's
-                    // `seed_attr_value` produces, so `%!h<k> = 1` inside a role
-                    // method has something to write to. The marker keeps the same
-                    // value; the cell is the store of record and the marker-side
-                    // paths refresh from it.
-                    let seeded = match supplied {
-                        Some(v) => v,
-                        None if *sigil == '@' => Value::real_array(Vec::new()),
-                        None if *sigil == '%' => Value::hash(HashMap::new()),
-                        None => Value::NIL,
-                    };
-                    // Tag the container with its declared element/key types, the
-                    // same way the class path's `seed_attr_value` does — without
-                    // it a `has Callable %!c{Mu:U}` in a punned role is a plain
-                    // hash, so type-object keys collide on the empty string.
-                    let seeded = if matches!(sigil, '@' | '%')
-                        && let Some(tc) = role_attr_types.get(attr_name)
-                    {
-                        self.finalize_typed_container_attr(attr_name, *sigil, &tc.clone(), seeded)?
-                    } else {
-                        seeded
-                    };
-                    mixins.insert(format!("__mutsu_attr__{}", attr_name), seeded.clone());
-                    instance_attrs.insert(attr_name.clone(), seeded);
+                // Punning constructs through the ordinary *class* path: compose
+                // the role into a class of the same name and re-enter `.new` on
+                // it, so attribute seeding, `is required`, coercion-typed
+                // attributes and -- the reason this delegation exists -- the
+                // BUILD and TWEAK phases behave exactly as they do for
+                // `class C does R { }`.
+                //
+                // Reproducing construction here instead had drifted from the
+                // class path it was a copy of: BUILD and TWEAK were never run at
+                // all, so a role that initialises its attributes in BUILD punned
+                // to an object with them unset. `Cro::Policy::Timeout` fills its
+                // `%.phases` from a role parameter that way and is instantiated
+                // as a pun, which is how this was found.
+                //
+                // The pun is withdrawn afterwards unless the name was already a
+                // class, so the role stays a role -- the same bookkeeping the
+                // `new`-declaring branch above performs.
+                let pre_existing_class = self.registry().classes.contains_key(&cn_resolved);
+                self.ensure_role_punned_to_class(&cn_resolved);
+                self.role_pun_construction.push(cn_resolved.clone());
+                let constructed = self.dispatch_new(target.clone(), args.clone());
+                self.role_pun_construction.pop();
+                if !pre_existing_class {
+                    self.withdraw_role_pun(&cn_resolved);
                 }
-                // Embed language revision from the matching candidate
-                // (no-params for bare role punning) so ^language-revision
-                // returns the correct value for this role's origin module.
-                let cn_str = class_name.resolve();
-                let bare_lang_ver = self
-                    .registry()
-                    .role_candidates
-                    .get(&cn_str)
-                    .and_then(|candidates| {
-                        candidates
-                            .iter()
-                            .find(|c| c.type_params.is_empty())
-                            .map(|c| c.language_version.clone())
-                    })
-                    .or_else(|| {
-                        self.type_metadata
-                            .get(&cn_str)
-                            .and_then(|m| m.get("language-revision"))
-                            .map(|v| format!("6.{}", v.to_string_value()))
-                    });
-                if let Some(ver) = bare_lang_ver {
-                    let revision: String = if let Some(letter) = ver.strip_prefix("6.") {
-                        letter.chars().next().unwrap_or('c').to_string()
-                    } else {
-                        "c".to_string()
-                    };
-                    mixins.insert(
-                        "__mutsu_language_revision".to_string(),
-                        Value::str(revision),
-                    );
-                }
-                return Ok(Value::mixin(
-                    Value::make_instance(*class_name, instance_attrs),
-                    mixins,
+                return Ok(self.mark_punned_role_instance(
+                    *class_name,
+                    constructed?,
+                    HashMap::new(),
                 ));
             }
             // CUnion repr classes use byte-overlay construction

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1391,6 +1391,12 @@ pub struct Interpreter {
     /// specific (an ambiguous dispatch). Consumed by the caller to raise an
     /// `X::Multi::Ambiguous` error instead of silently picking one.
     pub(crate) dispatch_ambiguous: bool,
+    /// Roles whose `.new` is currently constructing through their pun. `.new` on
+    /// a role composes it into a class of the same name and re-enters
+    /// `dispatch_new` to run *that class's* constructor; the role name is pushed
+    /// here for the duration so the re-entry takes the class path instead of
+    /// recognising the name as a role again and looping.
+    pub(crate) role_pun_construction: Vec<String>,
     /// Ids currently being rendered by `Mu.rakuseen($id, &code)` — the
     /// cyclic-structure guard for `.raku`/`.gist`. A repeated id means a cycle:
     /// `rakuseen` returns a backreference name instead of re-running `&code`

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -744,9 +744,33 @@ impl Interpreter {
             Some(r) => r.clone(),
             None => return,
         };
+        // A method copied into the pun still *came from* the role, and has to
+        // say so: `role_origin` is how the rest of the runtime tells a composed
+        // method from one the class declares itself. Left unset, the pun's
+        // construction phases counted the role's `BUILD`/`TWEAK` twice — once as
+        // the composed-role submethod (`class_composed_roles` below finds it)
+        // and again as an apparently class-declared candidate, so a
+        // `submethod BUILD { @!a.push(1) }` punned to `[1, 1]`. Real `does`
+        // composition tags them the same way, which is why it never doubled.
+        let tag_role_origin = |owner: &str, defs: &[MethodDef]| -> Vec<MethodDef> {
+            defs.iter()
+                .map(|md| {
+                    let mut md = md.clone();
+                    if md.original_role.is_none() {
+                        md.original_role = md.role_origin.clone();
+                    }
+                    md.role_origin = Some(owner.to_string());
+                    md
+                })
+                .collect()
+        };
         // Collect attributes and methods from the role itself and all composed parent roles
         let mut all_attributes = role_def.attributes.clone();
-        let mut all_methods: HashMap<String, Vec<MethodDef>> = role_def.methods.clone();
+        let mut all_methods: HashMap<String, Vec<MethodDef>> = role_def
+            .methods
+            .iter()
+            .map(|(name, defs)| (name.clone(), tag_role_origin(role_name, defs)))
+            .collect();
         let mut all_wildcard_handles = role_def.wildcard_handles.clone();
         let mut composed_roles_list = vec![role_name.to_string()];
         if let Some(parent_names) = self.registry().role_parents.get(role_name).cloned() {
@@ -766,7 +790,7 @@ impl Interpreter {
                             all_methods
                                 .entry(method_name.clone())
                                 .or_default()
-                                .extend(method_defs.clone());
+                                .extend(tag_role_origin(&parent_role_name, method_defs));
                         }
                         for wh in &parent_role.wildcard_handles {
                             if !all_wildcard_handles.contains(wh) {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2171,6 +2171,7 @@ impl Interpreter {
             encoding_registry: Self::builtin_encodings(),
             skip_pseudo_method_native: None,
             dispatch_ambiguous: false,
+            role_pun_construction: Vec::new(),
             rakuseen_active: Vec::new(),
             rakuseen_cycle_hit: std::collections::HashSet::new(),
             raku_leaf_active: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -460,6 +460,7 @@ impl Interpreter {
             encoding_registry: self.encoding_registry.clone(),
             skip_pseudo_method_native: None,
             dispatch_ambiguous: false,
+            role_pun_construction: Vec::new(),
             rakuseen_active: Vec::new(),
             rakuseen_cycle_hit: std::collections::HashSet::new(),
             raku_leaf_active: Vec::new(),

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1938,8 +1938,13 @@ impl Interpreter {
             }
             // Role parameterization: e.g. R1[C1] → ParametricRole
             (ValueView::Package(name), _) if self.is_role(&name.resolve()) => {
+                // Only a comma list spreads into several type arguments
+                // (`R[Int, Str]`). An itemized array is ONE argument —
+                // `R[[1, 2]]` parameterises `role R[@l]` with `[1, 2]`, and
+                // spreading it made that two arguments, which then matched no
+                // candidate's arity at all.
                 let type_args = match index.view() {
-                    ValueView::Array(items, ..) => items.to_vec(),
+                    ValueView::Array(items, crate::value::ArrayKind::List) => items.to_vec(),
                     _ => vec![index.clone()],
                 };
                 Value::parametric_role(name, type_args)

--- a/t/role-pun-build-tweak.t
+++ b/t/role-pun-build-tweak.t
@@ -1,0 +1,107 @@
+use Test;
+
+plan 23;
+
+# `R.new` puns the role into a class and constructs. That construction is the
+# ordinary class construction, so the role's BUILD and TWEAK submethods run --
+# exactly once each, in the same order and with the same relationship to
+# attribute initializers as `class C does R { }`. Every expectation below was
+# checked against Rakudo v2026.06.
+
+# --- BUILD ---------------------------------------------------------------
+
+role BuildsHash { has %.h; submethod BUILD(--> Nil) { %!h{"a"} = 1 } }
+is-deeply BuildsHash.new.h, {a => 1}, 'BUILD fills a punned hash attribute';
+
+role BuildsScalar { has $.s; submethod BUILD(--> Nil) { $!s = 7 } }
+is BuildsScalar.new.s, 7, 'BUILD assigns a punned scalar attribute';
+
+role BuildsArray { has @.a; submethod BUILD(--> Nil) { @!a.push(1); @!a.push(2) } }
+is-deeply BuildsArray.new.a, [1, 2], 'BUILD pushes onto a punned array attribute';
+
+# The pun must not run the submethod twice -- it is reachable both as the
+# punned class's own method and as a composed-role submethod.
+my $build-runs = 0;
+role CountsBuild { submethod BUILD(--> Nil) { $build-runs++ } }
+CountsBuild.new;
+is $build-runs, 1, 'BUILD runs exactly once for a pun';
+
+my $tweak-runs = 0;
+role CountsTweak { submethod TWEAK(--> Nil) { $tweak-runs++ } }
+CountsTweak.new;
+is $tweak-runs, 1, 'TWEAK runs exactly once for a pun';
+
+role NamedBuild { has $.a; has $.b; submethod BUILD(:$!a) { $!b = "b:" ~ $!a } }
+is NamedBuild.new(a => 3).b, 'b:3', 'BUILD binds a named constructor argument';
+
+# --- TWEAK ---------------------------------------------------------------
+
+role TweaksHash { has %.h; submethod TWEAK(--> Nil) { %!h{"a"} = 1 } }
+is-deeply TweaksHash.new.h, {a => 1}, 'TWEAK fills a punned hash attribute';
+
+role TweakDefaults { has $.x; submethod TWEAK { $!x //= "tweaked" } }
+is TweakDefaults.new.x, 'tweaked', 'TWEAK sees an unsupplied attribute';
+is TweakDefaults.new(x => 'given').x, 'given', 'TWEAK sees a supplied attribute';
+
+# --- ordering against attribute initializers -----------------------------
+
+# BUILD runs BEFORE the initializers, and an attribute BUILD wrote does not
+# then get its initializer; TWEAK runs after, so it sees the initialized value.
+role BuildBeatsDefault { has $.x = 5; submethod BUILD(--> Nil) { $!x = 9 } }
+is BuildBeatsDefault.new.x, 9, 'BUILD wins over an attribute initializer';
+
+role TweakSeesDefault { has $.x = 5; submethod TWEAK(--> Nil) { $!x = $!x + 1 } }
+is TweakSeesDefault.new.x, 6, 'TWEAK sees the initialized value';
+
+role TweakSeesTypedDefault { has Int $.i = 2; submethod TWEAK(--> Nil) { $!i = $!i * 10 } }
+is TweakSeesTypedDefault.new.i, 20, 'TWEAK sees a typed initialized value';
+
+# --- composition is unaffected -------------------------------------------
+
+role Shared { has @.a; submethod BUILD(--> Nil) { @!a.push(1) } }
+class Consumer does Shared { }
+is-deeply Consumer.new.a, [1], 'a composed role still runs BUILD once';
+is-deeply Shared.new.a, [1], 'and the same role punned runs it once too';
+
+# --- parameterized roles -------------------------------------------------
+
+role FromTypeParam[::T] { has $.x; submethod BUILD(--> Nil) { $!x = T.^name } }
+is FromTypeParam[Int].new.x, 'Int', 'BUILD sees a type parameter';
+
+role FromValueParam[$v] { has $.x; submethod BUILD(--> Nil) { $!x = $v } }
+is FromValueParam[7].new.x, 7, 'BUILD sees a value parameter';
+
+# A Hash argument has no faithful spelling in a type name, so this
+# parameterisation takes a different pun route than the two above.
+role FromHashParam[%d] {
+    has %.h;
+    submethod BUILD(--> Nil) { for %d.kv -> $k, $v { %!h{$k} = $v } }
+}
+is-deeply FromHashParam[%(a => 1)].new.h, {a => 1},
+    'BUILD sees a hash parameter';
+
+role FromArrayParam[@l] { has @.a; submethod BUILD(--> Nil) { @!a = @l } }
+is-deeply FromArrayParam[[1, 2]].new.a, [1, 2],
+    'BUILD sees an array parameter, unflattened';
+
+role TweaksFromParam[$v] { has $.x; submethod TWEAK(--> Nil) { $!x = $v * 2 } }
+is TweaksFromParam[4].new.x, 8, 'TWEAK sees a value parameter';
+
+# An itemized array is ONE type argument, not one per element: spreading it
+# left `role R[@l]` with two arguments and matching no candidate at all.
+role ArrayParamElems[@l] { method n { @l.elems } }
+is ArrayParamElems[[1, 2]].new.n, 2, 'an array type argument is a single argument';
+
+role HashParamKeys[%d] { method n { %d.keys.sort.join(",") } }
+is HashParamKeys[%(a => 1, b => 2)].new.n, 'a,b', 'a hash type argument survives punning';
+
+# --- the pun is per-construction ------------------------------------------
+
+# Constructing withdraws the pun again, and a construction *plan* cached under
+# that name has to go with it: a stale one made every construction after the
+# first take the plain-class fast path, losing the role entirely.
+role Repeatable { has @.a; submethod BUILD(--> Nil) { @!a.push(1) }; method m { 'm' } }
+my $first = Repeatable.new;
+my $second = Repeatable.new;
+is $second.m, 'm', 'a second pun construction still has the role methods';
+is-deeply $second.a, [1], 'and still ran BUILD';


### PR DESCRIPTION
`R.new` puns a role into a class and constructs. The pun path skipped the role's own `submethod BUILD` and `submethod TWEAK` entirely, so every attribute they would have initialised stayed unset:

```raku
role R { has %.h; submethod BUILD(--> Nil) { %!h{"a"} = 1 } }
say R.new.h.raku;          # was: {}   raku: {:a(1)}
```

Composing the same role into a class (`class C does R { }`) ran them correctly, so this was specific to punning. It was the top blocker of the **Cro::Core** suite: `Cro::Policy::Timeout` is a parameterized role whose `BUILD` fills a `Real() %.phases` hash from the role's `%phase-defaults` parameter, and Cro instantiates it as a pun — with `BUILD` skipped, every phase lookup answered `Any`.

## The pun stopped reproducing construction

The cause was a second implementation. `dispatch_new` recognised a role type object and built the instance by hand — collecting attributes from the role and its parents, evaluating defaults, type-checking supplied values, tagging typed containers — as a parallel copy of the class construction path. The copy had drifted: it never grew the BUILD/TWEAK phases, and it was behind on `is required` and coercion-typed attributes too.

It is gone (−167 lines). The pun now composes the role into a class of the same name and re-enters `.new` on *that*, so construction is the ordinary class construction: attribute seeding, `is required`, coercion types, the BUILD phase, the initializers BUILD left alone, and the TWEAK phase, in that order. A re-entrancy guard (`role_pun_construction`) makes the second entry take the class path instead of recognising the name as a role again, and the pun is withdrawn afterwards so the name stays a role. Three behaviours came back for free:

```raku
role T { has Int $.i is required }
try { T.new };            # was: an instance   now: X::Attribute::Required
role U { has Int() $.i }
say U.new(i => "42").i;   # was: "42"          now: 42
role V { has $.x = 5; submethod TWEAK(--> Nil) { $!x = $!x + 1 } }
say V.new.x;              # was: 5             now: 6
```

## Three bugs the delegation exposed

**The pun's methods did not say they came from the role.** The pun class is built by copying the role's methods into a class shell, and the copies kept `role_origin: None` — the marker that distinguishes a composed method from one the class declares itself. The construction phases then found the role's `BUILD` twice, once as the composed-role submethod and once as an apparently class-declared candidate, and ran it twice (`submethod BUILD { @!a.push(1) }` punned to `[1, 1]`). Real `does` composition tags them, which is why it never doubled.

**An itemized array type argument was spread.** `R[[1, 2]]` parameterises `role R[@l]` with one argument, but the subscript spread any array index into one type argument per element, so it passed two — matching no candidate's arity at all, which left `@l` bound to the bare `1`. Only a comma list (`R[Int, Str]`) spreads now; `ArrayKind` already carried the distinction between `(1, 2)` and `[1, 2]`.

**Withdrawing a pun left its construction plan behind.** Construction puns the role only for the duration and then drops the `ClassDef` again, but the plan cached under that name — the one that decides a class is simple enough for the native fast path — survived. The next `R.new` matched that stale plan before reaching the role branch at all and built a plain instance with no role mixin markers, so every method call on it died with "No such method". Only the *first* construction in a program produced a working object. Withdrawal is now one helper (`withdraw_role_pun`) that drops the plan with the class, shared by the three sites that had been spelling it out.

## Parameterized puns

They reach the same construction path as bare ones. The name-driven route (`ensure_parametric_role_pun_class`) still handles a parameterisation whose arguments have a faithful spelling in a type name; the fallback for those that do not — a Hash or Array argument, which is exactly the Cro case — now binds the matched candidate's type parameters through the real signature binder (`role R[@l]` slurps, `role R[%d]` takes the hash whole) and constructs through the pun class, instead of building an attribute-less instance whose state lived only in mixin markers.

## Pin

`t/role-pun-build-tweak.t` (23 tests), **every assertion checked against Rakudo v2026.06 first**: BUILD and TWEAK on scalar/array/hash attributes, each running exactly once, their ordering against attribute initializers, named-argument binding, composition still behaving, the four parameterisation shapes (type, value, hash and array arguments), and a repeated construction keeping both its role methods and its BUILD.

The Cro shape itself was reproduced standalone and matches Rakudo output exactly.

## Verification

- `make test`: 2633 files, 25079 tests, **Result: PASS**
- `cargo clippy -- -D warnings`, `cargo fmt`: clean
- Two regressions this change caused mid-flight (an infinite recursion in `t/role-decl-adverbs-signature.t`, and `t/role-pun-private-attribute.t`) are what surfaced the stale-plan bug above; both pass now.

The sibling finding — that a pun should not construct *at all* for a plain method call — is unaffected and still tracked in `todo/tickets/role-pun-should-not-construct.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)