### PR TITLE
fix: drive Cro's connection-manager pipelines live — composer.rakutest 83 -> 132/133, hang gone

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -440,6 +440,27 @@ impl Interpreter {
     /// the class for some method shapes (class-scoped subs, package lexicals, a
     /// `::`-qualified owner), so fall back to the running method's class.
     pub(crate) fn lexical_closure_package(&self) -> String {
+        // A closure created inside a METHOD body lexically belongs to that
+        // method's class, even when `current_package` still holds the CALLER's
+        // package (method dispatch pushes `method_class_stack` but does not
+        // re-point `current_package`). Walk past block frames to the innermost
+        // routine: if it is a method, its class wins — `start Transform.new`
+        // inside TestConnector.connect must capture TestConnector, not the
+        // Cro::CompositeConnector frame that invoked it (nested-class short
+        // names resolve against the captured package). An innermost SUB frame
+        // keeps the package rules (a module sub called from a method must not
+        // inherit the method's class).
+        for f in self.routine_stack.iter().rev() {
+            if f.is_block {
+                continue;
+            }
+            if f.is_method
+                && let Some(class) = self.method_class_stack.last()
+            {
+                return class.clone();
+            }
+            break;
+        }
         let pkg = self.current_package();
         if (pkg.is_empty() || pkg == "GLOBAL")
             && let Some(class) = self.method_class_stack.last()

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -456,17 +456,79 @@ impl Interpreter {
                                 crate::runtime::builtins_system::spawn_user_thread(move || {
                                     Self::run_supply_act_loop(&mut driver, &rx, &body_cb, 0.0);
                                 });
+                            } else if let ValueView::Instance {
+                                attributes: inner_attrs,
+                                ..
+                            } = inner_supply.view()
+                                && inner_attrs.as_map().contains_key("on_demand_callback")
+                            {
+                                // On-demand whenever source: chain a REAL tap so
+                                // liveness propagates. Materializing the source
+                                // into a snapshot (the old cold replay) treated a
+                                // pipeline whose BOTTOM source is a live Supplier
+                                // as finite — zero buffered values, so the body
+                                // never ran and its LAST phaser fired immediately
+                                // (Cro::ConnectionManager's per-connection
+                                // pipeline emitted '(closed)' before any message
+                                // could flow). A genuinely finite source replays
+                                // synchronously through the chained tap and then
+                                // fires the LAST phasers via its done callback.
+                                // Register the outer tap on the emitter FIRST so
+                                // the body's `$emitter.emit` dispatches live.
+                                if !outer_tap_registered
+                                    && Self::supply_has_active_callback(&tap_cb)
+                                {
+                                    register_supplier_tap(
+                                        emitter_supplier_id,
+                                        tap_cb.clone(),
+                                        delay_seconds,
+                                    );
+                                    outer_tap_registered = true;
+                                }
+                                let last_cbs = Self::value_array_items(&arr[2]).unwrap_or_default();
+                                let quit_cbs = Self::value_array_items(&arr[3]).unwrap_or_default();
+                                let mut tap_args = vec![body_cb.clone()];
+                                if let Some(l) = last_cbs.first() {
+                                    tap_args.push(Value::pair("done".to_string(), l.clone()));
+                                }
+                                if let Some(q) = quit_cbs.first() {
+                                    tap_args.push(Value::pair("quit".to_string(), q.clone()));
+                                }
+                                // TODO: thread the inner Tap into the outer Tap
+                                // handle so closing the outer tap tears down a
+                                // still-live inner pipeline.
+                                if let Err(err) = self.call_method_with_values(
+                                    inner_supply.clone(),
+                                    "tap",
+                                    tap_args,
+                                ) {
+                                    let reason = err
+                                        .exception
+                                        .as_deref()
+                                        .cloned()
+                                        .unwrap_or_else(|| Value::str(err.message.clone()));
+                                    if let Some(ref qf) = quit_cb {
+                                        self.call_supply_quit_handler(qf.clone(), reason)?;
+                                    } else {
+                                        return Err(Self::runtime_error_from_supply_reason(reason));
+                                    }
+                                    return Ok((
+                                        Value::make_instance(Symbol::intern("Tap"), HashMap::new()),
+                                        attrs,
+                                    ));
+                                }
                             } else {
-                                // Cold (supplier-less) whenever source: replay it
-                                // synchronously, capturing the body's emissions so
-                                // they reach the tap subscriber (and do_callbacks)
-                                // via plain_values below, in source order. Before
-                                // this the body's `$emitter.emit` had no registered
-                                // tap and the values were silently dropped. When a
-                                // preceding supplier-backed whenever already
-                                // registered the outer tap on the emitter, the
-                                // emissions were dispatched live during the replay,
-                                // so the captured copies are discarded.
+                                // Cold (supplier-less, non-on-demand) whenever
+                                // source: replay it synchronously, capturing the
+                                // body's emissions so they reach the tap subscriber
+                                // (and do_callbacks) via plain_values below, in
+                                // source order. Before this the body's
+                                // `$emitter.emit` had no registered tap and the
+                                // values were silently dropped. When a preceding
+                                // supplier-backed whenever already registered the
+                                // outer tap on the emitter, the emissions were
+                                // dispatched live during the replay, so the
+                                // captured copies are discarded.
                                 let last_cbs = Self::value_array_items(&arr[2]).unwrap_or_default();
                                 let quit_cbs = Self::value_array_items(&arr[3]).unwrap_or_default();
                                 let (mut captured, unhandled_quit) = self

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -610,7 +610,28 @@ impl Interpreter {
                     .cloned()
                     .collect(),
             );
+            // Package-scoped name resolution: run the body under the closure's
+            // declaring package so nested-class short names and `our`-vars
+            // resolve when the Sub value is invoked from a foreign frame —
+            // mirrors the VM closure dispatch. A `start Transform.new(...)`
+            // inside a method of the class that declares nested `class
+            // Transform` ran its body on a thread whose current package was
+            // the SPAWNING frame's (Cro::CompositeConnector), so the
+            // suppressed nested name did not resolve.
+            let saved_anon_pkg = {
+                let pkg = data.package.resolve();
+                if !pkg.is_empty() && pkg != "GLOBAL" && !pkg.contains("::&") {
+                    let saved = self.current_package().to_string();
+                    self.set_current_package(pkg.to_string());
+                    Some(saved)
+                } else {
+                    None
+                }
+            };
             let body_result = self.eval_block_value(&data.body);
+            if let Some(p) = saved_anon_pkg {
+                self.set_current_package(p);
+            }
             self.pending_eval_placeholder_params = saved_eval_placeholders;
             self.frame_authoritative = saved_frame_auth;
             let result = match body_result {

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1393,6 +1393,12 @@ impl Interpreter {
                     ..
                 },
             ) if rhs_class == "Mu" => lhs_type == "Mu",
+            // A Bool RHS is the match result regardless of the topic — also for
+            // a type-object topic (rakudo: "Smartmatch against True always
+            // matches"). Must precede the Package catch-all below;
+            // Cro::CompositeConnector's BUILD classifies components with
+            // `when $seen-connector` over type-object topics.
+            (ValueView::Package(_), ValueView::Bool(b)) => b,
             // When LHS is a type object (Package), only match same type or type hierarchy
             (ValueView::Package(_), _) => false,
             // When RHS is NaN, check if LHS is also NaN

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -133,9 +133,51 @@ impl Interpreter {
             // source is replayed synchronously so the body's emissions appear
             // in source order. A live (supplier-backed) source cannot be
             // driven synchronously here and is dropped (previously the raw
-            // 4-element marker array leaked through as a value).
+            // 4-element marker array leaked through as a value). Replayed
+            // emissions are processed through the same worklist: a body that
+            // registers a NESTED whenever emits a fresh marker, and a
+            // `whenever <Promise>` source (e.g. a composite connector's
+            // `whenever self!connect(...)`) blocks on the promise and runs
+            // the body with its result — both used to leak the raw marker.
             let mut out = Vec::with_capacity(emitted.len());
-            for item in emitted {
+            let mut queue: std::collections::VecDeque<Value> = emitted.into();
+            while let Some(item) = queue.pop_front() {
+                if Self::is_promise_whenever_marker(&item) {
+                    let ValueView::Array(arr, ..) = item.view() else {
+                        continue;
+                    };
+                    let ValueView::Promise(shared) = arr[0].view() else {
+                        continue;
+                    };
+                    let (result, _, _) = shared.wait();
+                    let broken = shared.status() == "Broken";
+                    let cbs = if broken {
+                        Self::value_array_items(&arr[3]).unwrap_or_default()
+                    } else {
+                        let mut v = vec![arr[1].clone()];
+                        v.extend(Self::value_array_items(&arr[2]).unwrap_or_default());
+                        v
+                    };
+                    if broken && cbs.is_empty() {
+                        return Err(Self::runtime_error_from_supply_reason(result));
+                    }
+                    for (i, cb) in cbs.into_iter().enumerate() {
+                        let args = if i == 0 { vec![result.clone()] } else { vec![] };
+                        self.supply_emit_buffer.push(Vec::new());
+                        let res = self.call_sub_value(cb, args, true);
+                        let captured = self.supply_emit_buffer.pop().unwrap_or_default();
+                        for c in captured.into_iter().rev() {
+                            queue.push_front(c);
+                        }
+                        if let Err(err) = res
+                            && !err.is_react_done()
+                            && !err.is_last()
+                        {
+                            return Err(err);
+                        }
+                    }
+                    continue;
+                }
                 let marker = if let ValueView::Array(arr, ..) = item.view()
                     && arr.len() == 4
                     && matches!(arr[0].view(), ValueView::Instance { class_name, .. } if class_name == "Supply")
@@ -163,9 +205,11 @@ impl Interpreter {
                 }
                 let last_cbs = Self::value_array_items(&last_arr).unwrap_or_default();
                 let quit_cbs = Self::value_array_items(&quit_arr).unwrap_or_default();
-                let (mut captured, unhandled_quit) =
+                let (captured, unhandled_quit) =
                     self.replay_cold_whenever_capture(&source, &body_cb, &last_cbs, &quit_cbs);
-                out.append(&mut captured);
+                for c in captured.into_iter().rev() {
+                    queue.push_front(c);
+                }
                 if let Some(reason) = unhandled_quit {
                     return Err(Self::runtime_error_from_supply_reason(reason));
                 }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -484,7 +484,7 @@ impl Interpreter {
             // A creation-time snapshot goes stale the moment the instance
             // mutates — a `start` block reading `@!before` inside
             // Cro::CompositeConnector.connect saw an empty pre-mutation copy.
-            if k.with_str(|s| Self::is_attr_twigil_env_key(s)) {
+            if k.with_str(Self::is_attr_twigil_env_key) {
                 return false;
             }
             free.contains(&k)

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -451,6 +451,9 @@ impl Interpreter {
             // then hold `$_` at the outer topic instead of binding it to the
             // element (`*.map({ $_ })` saw the whole list, not each item).
             flat.remove_sym(Symbol::intern("__mutsu_callable_type"));
+            // Attribute-twigil keys are per-frame materializations of `self`'s
+            // attributes — never snapshot them (see the filtered branch below).
+            flat.retain(|k, _| !k.with_str(Self::is_attr_twigil_env_key));
             self.materialize_frame_self_into_capture(code, &mut flat);
             return flat;
         }
@@ -475,6 +478,15 @@ impl Interpreter {
             if k.with_str(|s| s == "__mutsu_callable_type") {
                 return false;
             }
+            // Attribute-twigil keys (`!x`, `@!x`, `%.x`, …) are per-frame
+            // materializations of `self`'s attributes, not lexicals: the
+            // closure must read them through its captured `self` at RUN time.
+            // A creation-time snapshot goes stale the moment the instance
+            // mutates — a `start` block reading `@!before` inside
+            // Cro::CompositeConnector.connect saw an empty pre-mutation copy.
+            if k.with_str(|s| Self::is_attr_twigil_env_key(s)) {
+                return false;
+            }
             free.contains(&k)
                 || k.with_str(|s| !crate::env::is_plain_user_lexical(s) && !own_locals.contains(s))
         });
@@ -490,6 +502,18 @@ impl Interpreter {
         }
         self.materialize_frame_self_into_capture(code, &mut env);
         env
+    }
+
+    /// Attribute-twigil env keys (`!x`, `@!x`, `%.x`, …): per-frame
+    /// materializations of `self`'s attributes that a closure capture must NOT
+    /// snapshot (see the capture filter).
+    fn is_attr_twigil_env_key(s: &str) -> bool {
+        let bare = match s.as_bytes().first() {
+            Some(b'@' | b'%' | b'&' | b'$') => &s[1..],
+            _ => s,
+        };
+        let b = bare.as_bytes();
+        matches!(b.first(), Some(b'!') | Some(b'.')) && b.len() > 1 && b[1].is_ascii_alphabetic()
     }
 
     /// `self` is lexical: a closure created inside a method body must capture

--- a/t/closure-package-method-class.t
+++ b/t/closure-package-method-class.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 2;
+
+# A closure created inside a METHOD body lexically belongs to that method's
+# class: nested-class short names must resolve against it no matter which
+# package the method was invoked from. `lexical_closure_package` preferred
+# `current_package` (the CALLER's package — method dispatch does not re-point
+# it), so a `start Inner.new(...)` inside a method invoked from module code
+# captured the module's package and the suppressed nested name died with
+# X::Undeclared::Symbols (Cro::CompositeConnector.connect ->
+# TestConnector.connect -> `start Transform.new`).
+
+module CallerPkg {
+    our sub invoke($obj, %opts) { $obj.make(|%opts) }
+}
+
+class Outer {
+    class Inner {
+        has $.tag;
+    }
+    method make(*%opts) {
+        start Inner.new(tag => %opts<tag>)
+    }
+}
+
+my $p = CallerPkg::invoke(Outer.new, {tag => 'hi'});
+my $inner = await $p;
+is $inner.^name, 'Outer::Inner', 'nested class resolved from the method-declaring class';
+is $inner.tag, 'hi', 'options passed through';

--- a/t/smartmatch-bool-type-object.t
+++ b/t/smartmatch-bool-type-object.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 4;
+
+# A Bool on the smartmatch RHS IS the result, regardless of the topic — also
+# when the topic is a type object. The Package-LHS catch-all returned False
+# for `TypeObject ~~ True`, so Cro::CompositeConnector's BUILD (`when
+# $seen-connector` over type-object components) classified every post-
+# connector component as a "before" transform.
+
+class T { }
+
+ok (T ~~ True), 'type object ~~ True matches';
+nok (T ~~ False), 'type object ~~ False fails';
+
+my $seen = False;
+my @before;
+my @after;
+role Marker { }
+class Conn does Marker { }
+class T1 { }
+class T2 { }
+for T1, Conn, T2 {
+    when Marker { $seen = True; }
+    when $seen { @after.push($_); }
+    default { @before.push($_); }
+}
+is-deeply @before, [T1], 'pre-marker type object lands in before';
+is-deeply @after, [T2], 'post-marker type object lands in after (when $bool matched)';

--- a/t/supply-list-promise-whenever.t
+++ b/t/supply-list-promise-whenever.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 3;
+
+# `.list` on a supply block whose whenever source is a PROMISE must run the
+# body with the promise's result (and nested whenevers registered by that
+# body must be processed too). `supply_get_values` recognized only
+# Supply-source markers, so the raw `[Promise, body, [], []]` subscription
+# marker leaked to the consumer as a value — Cro::CompositeConnector's
+# `establish(...).list` returned the marker instead of the pipeline's
+# messages.
+
+my @simple = (supply {
+    whenever start { 21 } -> $v {
+        emit $v * 2;
+    }
+}).list;
+is-deeply @simple, [42], 'promise whenever replays through .list';
+
+my @nested = (supply {
+    whenever start { 'mid' } -> $got {
+        whenever Supply.from-list('a', 'b') -> $x {
+            emit "$got-$x";
+        }
+    }
+}).list;
+is-deeply @nested, ['mid-a', 'mid-b'], 'nested whenever registered by a promise body is processed';
+
+my @plain = (supply { emit 1; emit 2 }).list;
+is-deeply @plain, [1, 2], 'plain on-demand list unchanged';

--- a/t/supply-whenever-ondemand-live-chain.t
+++ b/t/supply-whenever-ondemand-live-chain.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 3;
+
+# A `whenever` whose source is an ON-DEMAND supply must stay LIVE when that
+# supply's own whenevers sit on live suppliers. The supply-block tap path used
+# to materialize an on-demand source into a value snapshot: zero buffered
+# values, so the body never ran and its LAST phaser fired immediately —
+# Cro::ConnectionManager's per-connection pipeline emitted '(closed)' before
+# any message could flow. The chained-tap arm propagates liveness; a finite
+# source still replays synchronously and fires LAST via its done callback.
+
+my $conn-injection = Supplier.new;
+my $send = Supplier.new;
+
+sub per-conn-pipeline($in) {
+    supply {
+        whenever $in -> $msg {
+            emit "GOT:$msg";
+            LAST emit '(closed)';
+        }
+    }
+}
+
+my @out;
+my $service = supply {
+    whenever $conn-injection.Supply -> $conn {
+        whenever per-conn-pipeline($send.Supply) -> $v {
+            emit $v;
+        }
+    }
+};
+$service.tap({ @out.push($_) });
+
+$conn-injection.emit('conn-a');
+is @out.elems, 0, 'nothing emitted before a message flows (no premature LAST)';
+
+$send.emit('hello');
+is-deeply @out, ['GOT:hello'], 'message flowed through the per-connection pipeline';
+
+$send.done;
+is @out.tail, '(closed)', 'LAST fires when the live source completes';

--- a/todo/tickets/cro-connection-manager-live-pipeline.md
+++ b/todo/tickets/cro-connection-manager-live-pipeline.md
@@ -1,34 +1,44 @@
-# Connection-manager per-connection pipelines treat live supplies as cold (Cro::Core composer.rakutest 87-88 + trailing hang)
+# Cro::Core composer.rakutest: 1 remaining failure (test 133) — thread-side attribute reads see a hollow instance
 
-With #5605/#5608/#5611 and the closure-self/parent-tier fix in, Cro::Core's
-`t/composer.rakutest` reaches 86/88, failing only the connection-manager
-message-flow tests and hanging after the last one (exit 124).
+**Status 2026-07-31 (после the live-pipeline campaign):** composer.rakutest is
+at **132/133, no hang** (was 83 + trailing hang at the start of the slice).
+Landed in the same branch as this ticket update:
 
-Scenario (composer.rakutest ~line 470-520): `Cro.compose($conn-source,
-TestUppercaseTransform)` produces a service whose connection manager builds a
-per-connection pipeline: `connection.incoming` (a live `Supplier`-backed
-supply) → transform (`supply { whenever $input { emit ... } }`) → the
-connection's replier sink (`whenever $input { $!replier.emit(.body);
-LAST $!replier.emit('(closed)') }`).
+- chained-tap arm for ON-DEMAND whenever sources in the supply-block tap path
+  (liveness propagates; the old cold replay snapshotted zero values and fired
+  LAST immediately — the '(closed)' failure and the trailing hang);
+- `supply_get_values` worklist: promise-source whenever markers block on the
+  promise and run the body; nested markers re-queue (composite connector's
+  `establish(...).list` returned the raw marker before);
+- `lexical_closure_package` prefers the method's class when the innermost
+  non-block routine frame is a method (nested-class short names in `start`
+  bodies — `start Transform.new` in TestConnector.connect captured the
+  CALLER's package);
+- Bool smartmatch arm for type-object topics (`when $seen-connector` in
+  Cro::CompositeConnector.BUILD classified everything as "before").
 
-Observed: `$response-channel-a.receive` gets `'(closed)'` instead of `'BBQ'`
-— the replier sink's `whenever` saw ZERO messages and its LAST phaser fired
-immediately. The message is emitted into the connection's `$!send` Supplier
-*after* the pipeline is assembled, so the pipeline must stay LIVE; instead
-the per-connection pipeline assembly (which happens inside the connection
-manager's own `whenever` body, i.e. inside a running supply callback) takes
-a cold/finite replay path: 0 buffered values → done → LAST.
+**Remaining failure (test 133, 'That message is a TestBinaryMessage'):**
+`Cro.compose(TestUppercaseTransform, TestConnector, TestTransform)` →
+`.establish(...).list` applies ONLY the connector's own transform. Root cause
+narrowed with env-gated instrumentation: inside
+`Cro::CompositeConnector.connect`'s `start` block, the attribute reads
+`@!before` / `@!after` resolve against a `self` whose attributes are EMPTY
+(`read_self_attr_cell` = None, env has no materialized key, and the instance
+fallback finds nothing — debug print showed `self-keys=` empty), while the
+same reads on the main thread (`.produces`) see the populated arrays. So the
+start-thread's captured/cloned `self` is a hollow copy of the
+CompositeConnector instance — possibly a pre-BUILD CoW snapshot or a
+deep-copy in `clone_for_thread` that drops attribute contents (scalar
+`$!connector` SURVIVES, arrays do not — suspicious of cell/array handling in
+the thread clone or in the closure self materialization).
 
-The trailing process hang after test 86 (before these fixes: after 88) is
-likely the same machinery: a per-connection driver waiting on something that
-never completes.
+Repro (vendored Cro::Core lib):
+`tmp/subset-repro/conn-probe.raku` variant with a before-transform — or
+directly: `await $comp.connect(prepend => "x")` then `.components.elems`
+(2 expected with one before-transform, observed 1).
 
-Where to look: the supply-block tap path's marker handling in
-`native_supply_mut_methods.rs` (live supplier-backed sources ARE handled when
-the tap happens at "top level", so the difference is assembling/tapping from
-within a whenever callback — `supply_emit_buffer` frames / `react_active`
-state at that moment), and `run_whenever_with_value`'s react-mode vs
-non-react-mode branches.
-
-Repro: run the vendored suite `tmp`-extract of Cro::Core:
-`target/debug/mutsu -I lib t/composer.rakutest` (tests 87-88).
+Also unproven-but-kept in the same branch: closure captures now EXCLUDE
+attribute-twigil env keys (`!x`, `@!x`, `%.x`, …) so attr reads go through the
+live `self` instead of a creation-time snapshot; this did not resolve test
+133 (the hollow-self read happens through the instance fallback too) but is
+the honest semantics.


### PR DESCRIPTION
Five fixes found by driving vendored Cro::Core's `t/composer.rakutest` (83 ok + trailing hang -> **132/133, no hang**):

1. **The supply-block tap path chains a REAL tap for an ON-DEMAND whenever source** instead of materializing it into a value snapshot. The snapshot treated a pipeline whose bottom source is a live Supplier as finite (zero values -> LAST immediately): Cro::ConnectionManager's per-connection pipeline emitted `'(closed)'` before any message could flow, and the process hung at exit. A finite source still replays synchronously through the chained tap and fires LAST via its done callback.

2. **`supply_get_values` processes whenever markers through a worklist**: a promise-source marker blocks on the promise and runs the body with its result, and markers registered by replayed bodies are re-queued. `Cro::CompositeConnector.establish(...).list` returned the raw `[Promise, body, [], []]` marker array before.

3. **`lexical_closure_package` prefers the method's class** when the innermost non-block routine frame is a method: `start Transform.new(...)` inside TestConnector.connect captured the CALLER's package (Cro::CompositeConnector) and the suppressed nested-class short name died with X::Undeclared::Symbols.

4. **Smartmatch with a Bool RHS is that Bool also for a TYPE-OBJECT topic** (the Package-LHS catch-all returned False first): `Cro::CompositeConnector.BUILD`'s `when $seen-connector` classified every post-connector component as a before-transform.

5. **Closure captures exclude attribute-twigil env keys** (`!x`, `@!x`, `%.x`, …): per-frame materializations of self's attributes must be read through the live `self` at run time, not a creation-time snapshot.

The one remaining composer failure (test 133) is root-caused to thread-side attribute reads seeing a hollow instance — analysis in `todo/tickets/cro-connection-manager-live-pipeline.md`.

Pins (all verified against raku): `t/supply-whenever-ondemand-live-chain.t`, `t/supply-list-promise-whenever.t`, `t/closure-package-method-class.t`, `t/smartmatch-bool-type-object.t`. Local `make test` green (t/ 58-file supply/react battery included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)