### PR TITLE
fix: two regex engine bugs — Cro::Core uri.rakutest 1652/1652

### DIFF
--- a/news/2026-07/cro-uri-regex-fixes.md
+++ b/news/2026-07/cro-uri-regex-fixes.md
@@ -1,0 +1,33 @@
+# Cro::Core uri.rakutest 1652/1652 — two regex engine fixes
+
+`uri.rakutest`, the largest file in the vendored Cro::Core suite, went from
+1633/1652 to **fully green** with two general regex-engine repairs (both
+raku-verified and pinned by new `t/` tests):
+
+## Escaped `\]` inside a `[...]` group closed the group early
+
+The non-capturing-group scanner counted `[`/`]` without honoring backslash
+escapes, so Cro::Uri's IPv4address rule
+`<.dec-octet> ** 4 % "." [<?[/#?:\]]> || $]` sliced the group at the char
+class's escaped `\]`, leaving a stray `>` that failed the whole regex parse
+("Unrecognized regex metacharacter >"). Every IPv4 host-class check and all
+IPv6-with-embedded-IPv4 parses (`::FFFF:129.144.52.38`, via `ls32` →
+`IPv4address`) failed on this one bug — 18 of the 19 remaining failures.
+Pin: `t/regex-group-escaped-bracket.t`.
+
+## Zero-match `[...]?` group dropped nested list captures to Nil
+
+When an optional group matches zero times, raku still renders a name under a
+nested LIST quantifier as an empty list: `'/' [ <segment-nz> [ '/' <segment>
+]* ]?` matching `/` leaves `$<segment>` = `[]` (while `$<segment-nz>`, under
+only the `?`, stays Nil). mutsu left both Nil — and since `@$Nil` iterates
+once, Cro::Uri's path-absolute action appended a bogus separator:
+`parse-ref('/')` produced path `//`, breaking `$base.add('/')` resolution.
+The `?` zero paths now mark names found under nested `*`/`+`/`**`/`%`
+quantifiers as quantified (empty-list) captures.
+Pin: `t/regex-optional-group-list-captures.t`.
+
+With this, the Cro::Core suite stands at: iri 35/35, mediatype 87/87,
+message-with-body 6/6, composer 134/134, connection-state 11/11, policy 6/6,
+**uri 1652/1652**. Remaining: connection-conditional (state per-clone deep
+ticket) and tcp `:nodelay` (in-memory socket fd design ticket).

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -84,6 +84,43 @@ impl Interpreter {
         }
     }
 
+    /// Collect names that sit under a nested LIST quantifier (`*`, `+`, `**`,
+    /// `%`-separated) inside `atom`. When an enclosing `?` group matches zero
+    /// times, raku still renders those names as EMPTY LISTS (`'/' [ <seg-nz>
+    /// [ '/' <seg> ]* ]?` matching "/" leaves `$<seg>` = []), while names
+    /// under only `?`/unquantified positions stay absent (Nil).
+    fn collect_nested_list_quantified_names(atom: &RegexAtom, out: &mut HashSet<String>) {
+        let visit_tok = |tok: &RegexToken, out: &mut HashSet<String>| {
+            let is_list = matches!(
+                tok.quant,
+                RegexQuant::ZeroOrMore
+                    | RegexQuant::OneOrMore
+                    | RegexQuant::Repeat(..)
+                    | RegexQuant::RepeatCode(_)
+            ) || tok.separator.is_some();
+            if is_list {
+                out.extend(Self::collect_quantified_names_for_token(tok));
+            } else {
+                Self::collect_nested_list_quantified_names(&tok.atom, out);
+            }
+        };
+        match atom {
+            RegexAtom::Group(pat) => {
+                for tok in &pat.tokens {
+                    visit_tok(tok, out);
+                }
+            }
+            RegexAtom::Alternation(alts) | RegexAtom::SequentialAlternation(alts) => {
+                for alt in alts {
+                    for tok in &alt.tokens {
+                        visit_tok(tok, out);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Collect all named capture names from a regex token.
     pub(super) fn collect_quantified_names_for_token(token: &RegexToken) -> HashSet<String> {
         let mut names = HashSet::new();
@@ -486,6 +523,11 @@ impl Interpreter {
                 // An unmatched `(x)?` reserves `zo_stride` Nil positional slots
                 // so following captures keep their index (`(a)?(b)` → $0=Nil,$1=b).
                 let zo_stride = count_capture_groups(&token.atom);
+                // Names under a nested list quantifier render as empty lists
+                // even when this `?` group matches zero times (see
+                // `collect_nested_list_quantified_names`).
+                let mut zo_list_names = HashSet::new();
+                Self::collect_nested_list_quantified_names(&token.atom, &mut zo_list_names);
                 let mut candidates = self.regex_match_atom_all_with_capture_in_pkg(
                     &token.atom,
                     ctx.chars,
@@ -499,6 +541,9 @@ impl Interpreter {
                         // Atom didn't match — commit to "zero" (no match).
                         let m = store.mark();
                         store.reserve_nil(zo_stride);
+                        for n in &zo_list_names {
+                            store.insert_named_quantified(n.clone());
+                        }
                         let stop = self.walk_tokens(ctx, idx + 1, pos, store, matches);
                         store.rewind(m);
                         return stop;
@@ -509,6 +554,9 @@ impl Interpreter {
                     // Frugal: prefer zero matches — try zero first.
                     let m = store.mark();
                     store.reserve_nil(zo_stride);
+                    for n in &zo_list_names {
+                        store.insert_named_quantified(n.clone());
+                    }
                     let stop = self.walk_tokens(ctx, idx + 1, pos, store, matches);
                     store.rewind(m);
                     if stop {
@@ -530,6 +578,9 @@ impl Interpreter {
                     // Greedy: the zero candidate is tried last.
                     let m = store.mark();
                     store.reserve_nil(zo_stride);
+                    for n in &zo_list_names {
+                        store.insert_named_quantified(n.clone());
+                    }
                     let stop = self.walk_tokens(ctx, idx + 1, pos, store, matches);
                     store.rewind(m);
                     if stop {

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -3111,8 +3111,16 @@ impl Interpreter {
                     // Parse as alternation: [a|b|c]
                     let mut group_pattern = String::new();
                     let mut depth = 1;
-                    for ch in chars.by_ref() {
-                        if ch == '[' {
+                    while let Some(ch) = chars.next() {
+                        if ch == '\\' {
+                            // An escaped character never affects bracket depth:
+                            // `[<?[\]]>||$]` must not close the group at the
+                            // char class's escaped `\]` (Cro::Uri IPv4address).
+                            group_pattern.push(ch);
+                            if let Some(esc) = chars.next() {
+                                group_pattern.push(esc);
+                            }
+                        } else if ch == '[' {
                             depth += 1;
                             group_pattern.push(ch);
                         } else if ch == ']' {

--- a/t/regex-group-escaped-bracket.t
+++ b/t/regex-group-escaped-bracket.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A backslash-escaped character inside a [...] group must not affect the
+# group's bracket depth: `[<?[\]]>||$]` closes at the final `]`, not at the
+# char class's escaped `\]` (Cro::Uri's IPv4address rule).
+ok "x" ~~ /x [<?[\]]> || $]/, 'lookahead class with escaped ] inside a group, end-anchored branch';
+nok "x/" ~~ /^x [<?[\]]> || $]/, 'the group really is a lookahead-or-end, not a literal';
+ok "x]" ~~ /x [<?[\]]> || $] ./, 'the lookahead branch matches before ]';
+
+# The Cro::Uri IPv4address shape: separated quantifier + lookahead-or-end group.
+my regex dec-octet {
+    | <[0..9]>
+    | <[1..9]> <[0..9]>
+    | "1" <[0..9]> <[0..9]>
+    | "2" <[0..4]> <[0..9]>
+    | "25" <[0..5]>
+}
+my regex ipv4 { <.dec-octet> ** 4 % "." [<?[/#?:\]]> || $] }
+ok "127.0.0.1" ~~ /^<ipv4>$/, 'IPv4address matches at end of string';
+ok "127.0.0.1:80" ~~ /^<ipv4>/, 'IPv4address matches before a colon';
+nok "127.0.0.1x" ~~ /^<ipv4>/, 'IPv4address rejects a trailing word char';

--- a/t/regex-optional-group-list-captures.t
+++ b/t/regex-optional-group-list-captures.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+plan 6;
+
+# When a `[...]?` group matches ZERO times, a name under a nested LIST
+# quantifier (`*`/`+`) inside it still renders as an EMPTY LIST, while a name
+# under only the `?` stays absent (Nil). Cro::Uri's path-absolute action
+# iterates `@$<segment>` — with Nil that loop runs once and appended a bogus
+# '/' (parse-ref('/') returned path '//').
+grammar G {
+    token TOP { "/" [ <seg> [ "/" <seg2> ]* ]? }
+    token seg { \w+ }
+    token seg2 { \w+ }
+}
+
+my $m = G.parse("/");
+ok $m.defined, 'bare "/" parses';
+nok $m<seg>.defined, 'name directly under ? stays undefined at zero matches';
+is-deeply $m<seg2>, [], 'name under a nested * renders as an empty list';
+
+my $m2 = G.parse("/a");
+is ~$m2<seg>, 'a', 'one-match ? group captures the direct subrule';
+is-deeply $m2<seg2>, [], 'inner * with zero iterations is an empty list';
+
+my $m3 = G.parse("/a/b");
+is ~$m3<seg2>[0], 'b', 'inner * with one iteration is a one-element list';


### PR DESCRIPTION
Two general regex-engine repairs that take the vendored Cro::Core `uri.rakutest` from 1633/1652 to fully green. Both raku-verified and pinned.

## Escaped `\]` inside a `[...]` group closed the group early

The non-capturing-group scanner counted `[`/`]` without honoring backslash escapes, so Cro::Uri's IPv4address rule `<.dec-octet> ** 4 % "." [<?[/#?:\]]> || $]` sliced the group at the char class's escaped `\]`, leaving a stray `>` that failed the whole regex parse. Every IPv4 host-class check and all IPv6-with-embedded-IPv4 parses (via `ls32` → `IPv4address`) failed on this one bug — 18 of the 19 remaining failures. Pin: `t/regex-group-escaped-bracket.t`

## Zero-match `[...]?` group dropped nested list captures to Nil

When an optional group matches zero times, raku still renders a name under a nested LIST quantifier as an empty list: `'/' [ <segment-nz> [ '/' <segment> ]* ]?` matching `/` leaves `$<segment>` = `[]` (while `$<segment-nz>`, under only the `?`, stays Nil). mutsu left both Nil — and since `@$Nil` iterates once, Cro::Uri's path-absolute action appended a bogus separator: `parse-ref('/')` produced path `//`, breaking `$base.add('/')`. The `?` zero paths now mark names under nested `*`/`+`/`**`/`%` quantifiers as quantified (empty-list) captures. Pin: `t/regex-optional-group-list-captures.t`

## Verification

- All 93 whitelisted `roast/S05-*` files pass (5524 tests)
- Cro::Core suite now: iri 35/35, mediatype 87/87, message-with-body 6/6, composer 134/134, connection-state 11/11, policy 6/6, **uri 1652/1652**. Remaining: connection-conditional (state per-clone deep ticket), tcp `:nodelay` (in-memory socket fd design ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)