### PR TITLE
fix: seven general bugs surfaced by the Cro::HTTP test suite

### DIFF
--- a/src/parser/stmt/control/for_loops.rs
+++ b/src/parser/stmt/control/for_loops.rs
@@ -41,9 +41,33 @@ fn expr_ends_with_block(expr: &Expr) -> bool {
 /// a top-level `;` (the C-style `for (init; test; incr)` obsolete form).
 fn paren_has_toplevel_semicolon(input: &str) -> bool {
     let mut depth = 0i32;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
     let mut chars = input.chars().peekable();
     while let Some(c) = chars.next() {
+        if in_single_quote {
+            match c {
+                '\'' => in_single_quote = false,
+                '\\' => {
+                    chars.next();
+                }
+                _ => {}
+            }
+            continue;
+        }
+        if in_double_quote {
+            match c {
+                '"' => in_double_quote = false,
+                '\\' => {
+                    chars.next();
+                }
+                _ => {}
+            }
+            continue;
+        }
         match c {
+            '\'' => in_single_quote = true,
+            '"' => in_double_quote = true,
             '(' | '[' | '{' => depth += 1,
             ')' | ']' | '}' => {
                 depth -= 1;

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -121,18 +121,23 @@ impl Interpreter {
         name: &str,
         arg_values: &[Value],
     ) -> Result<Option<String>, RuntimeError> {
-        self.eval_token_call_values_at(name, arg_values, 0)
+        Ok(self
+            .eval_token_call_values_at(name, arg_values, 0)?
+            .map(|(pattern, _)| pattern))
     }
 
     /// Like [`eval_token_call_values`], but the LTM candidate filter measures each
     /// candidate's declarative prefix starting at character offset `start_pos`
     /// (for a `:pos(N)`/`:c(N)` subparse) rather than at the start of the subject.
+    /// Returns the winning candidate's pattern together with its `:sym<...>`
+    /// adverb (for a proto token candidate), so a `parse(:rule)` starting
+    /// directly at a proto can dispatch the sym-specific action method.
     pub(super) fn eval_token_call_values_at(
         &mut self,
         name: &str,
         arg_values: &[Value],
         start_pos: usize,
-    ) -> Result<Option<String>, RuntimeError> {
+    ) -> Result<Option<(String, Option<String>)>, RuntimeError> {
         let defs = match self.resolve_token_defs(name) {
             Some(defs) => defs,
             None => return Ok(None),
@@ -158,30 +163,34 @@ impl Interpreter {
         // effects (ADR-0009). For a candidate with no code atom it is a full
         // match — which executes nothing — so the "does this candidate match at
         // all?" filter is unchanged for those.
-        let mut candidates: Vec<(usize, String)> = Vec::new(); // (prefix_match_len, pattern)
+        // (prefix_match_len, pattern, sym adverb of the candidate's def)
+        let mut candidates: Vec<(usize, String, Option<String>)> = Vec::new();
         let mut rejected: Vec<String> = Vec::new();
         for def in defs {
+            let sym = Self::extract_sym_adverb(&def.name.resolve());
             if let Some(pattern) = self.eval_token_def(&def, arg_values)? {
                 if let Some(ref text) = subject {
                     match self.declarative_prefix_match_len(&pattern, text) {
-                        (Some(prefix_match_len), _) => candidates.push((prefix_match_len, pattern)),
+                        (Some(prefix_match_len), _) => {
+                            candidates.push((prefix_match_len, pattern, sym))
+                        }
                         // Measurement stopped at a code atom, so it proves nothing
                         // about whether the candidate matches — keep it (ranked
                         // last) and let the real match decide.
-                        (None, true) => candidates.push((0, pattern)),
+                        (None, true) => candidates.push((0, pattern, sym)),
                         // A fully declarative candidate that does not match at all.
                         (None, false) => rejected.push(pattern),
                     }
                 } else {
-                    candidates.push((0, pattern));
+                    candidates.push((0, pattern, sym));
                 }
             }
         }
         // Sort by declarative prefix match length (longest first). The sort is
         // stable, so an LTM tie falls back to declaration order (as in Rakudo).
         candidates.sort_by_key(|c| std::cmp::Reverse(c.0));
-        if let Some((_, pattern)) = candidates.into_iter().next() {
-            return Ok(Some(pattern));
+        if let Some((_, pattern, sym)) = candidates.into_iter().next() {
+            return Ok(Some((pattern, sym)));
         }
         // Nothing matched declaratively. Normally that is a cheap "this rule
         // cannot match" verdict and the real match is skipped — but during a
@@ -194,7 +203,7 @@ impl Interpreter {
             && self.current_grammar_actions.is_some()
             && !self.has_proto_token(name)
         {
-            return Ok(rejected.pop());
+            return Ok(rejected.pop().map(|p| (p, None)));
         }
         if self.has_proto_token(name) {
             return Err(RuntimeError::new(format!(

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -317,9 +317,9 @@ impl Interpreter {
         let saved_grammar_dynvars = self.establish_grammar_dynamic_vars(package_name);
         let candidate_from = start_pos.or(continue_pos).unwrap_or(0);
         let result = (|| -> Result<Value, RuntimeError> {
-            let pattern =
+            let (pattern, start_rule_sym) =
                 match self.eval_token_call_values_at(&start_rule, &rule_args, candidate_from) {
-                    Ok(Some(pattern)) => pattern,
+                    Ok(Some(pattern_and_sym)) => pattern_and_sym,
                     Ok(None) => {
                         // Check for pending regex error (e.g., <sym> used outside proto regex)
                         if let Some(err) = Self::take_pending_regex_error() {
@@ -505,6 +505,12 @@ impl Interpreter {
                 }
                 if let Some(ref act) = actions_obj {
                     updates.push(("actions", act.clone()));
+                }
+                // A parse that started directly at a proto token (`:rule` naming
+                // a proto) matched via one `:sym<...>` candidate; record it so
+                // action dispatch can call the sym-specific method.
+                if let Some(ref sym) = start_rule_sym {
+                    updates.push(("sym_variant", Value::str(sym.clone())));
                 }
                 if !alias_map.is_empty() {
                     let alias_hash: HashMap<String, Value> = alias_map

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -283,10 +283,14 @@ impl Interpreter {
         // `token linetag { ^^ (\h*) <tag> <?{ $<tag>.made<type> ~~ none(...) }> ... }`).
         // The actions run in a scratch interpreter so the assertion's own
         // `$/`/`$0` env below is not clobbered by the action dispatch.
-        let made_named: HashMap<String, Value> = if code.contains(".made")
-            && let Some(actions0) = self.current_grammar_actions.clone()
-        {
-            self.run_named_capture_actions(caps, actions0)
+        let made_named: HashMap<String, Value> = if code.contains(".made") {
+            if let Some(actions0) = self.current_grammar_actions.clone() {
+                self.run_named_capture_actions(caps, actions0)
+            } else {
+                // No actions: `.made` must still resolve (to Nil) on a Match,
+                // not die with method-not-found on a plain Str capture.
+                self.named_capture_match_objects(caps)
+            }
         } else {
             HashMap::new()
         };
@@ -340,7 +344,7 @@ impl Interpreter {
         // harvest below sees nothing. Same flag the reduce-time replay uses.
         let result = if writes_back_to_caller {
             let before = self.pending_local_updates.len();
-            self.eval_regex_code_block_body(&stmts);
+            let body_result = self.eval_regex_code_block_body(&stmts);
             // The regex's own `:my`/`:let` lexicals are not caller lexicals — they
             // are harvested into `regex_vars` below and must not be written into
             // the caller's slots as well.
@@ -353,7 +357,7 @@ impl Interpreter {
                     .collect();
                 self.pending_local_updates.extend(kept);
             }
-            Ok(Value::NIL)
+            body_result.map(|_| Value::NIL)
         } else {
             let saved_in_block = self.in_regex_code_block;
             self.in_regex_code_block = true;
@@ -379,7 +383,49 @@ impl Interpreter {
                 None => self.env.remove(&k),
             };
         }
-        (result.ok(), writes)
+        // A genuine exception (`die`) inside an embedded `{ … }` / `<?{ … }>`
+        // block propagates out of the whole match in Rakudo — it is not a
+        // mismatch. Park it in the pending slot; the match-entry points
+        // (smartmatch, Grammar.parse, m//) re-raise it after the engine unwinds.
+        let value = match result {
+            Ok(v) => Some(v),
+            Err(e) => {
+                if e.return_value.is_none() {
+                    super::super::regex_parse::PENDING_REGEX_ERROR.with(|slot| {
+                        let mut slot = slot.borrow_mut();
+                        if slot.is_none() {
+                            *slot = Some(e);
+                        }
+                    });
+                }
+                None
+            }
+        };
+        (value, writes)
+    }
+
+    /// Build a Match object for each named capture in `caps` WITHOUT running
+    /// any actions. Used when an embedded code block references `$<x>.made` but
+    /// no `:actions` object is in play: the capture must still be a Match (so
+    /// `.made` answers Nil) rather than the plain Str the fast path installs —
+    /// on a Str, `.made` is a method-not-found, which now propagates as a die.
+    fn named_capture_match_objects(&mut self, caps: &RegexCaptures) -> HashMap<String, Value> {
+        let target =
+            super::regex_helpers::current_match_target().unwrap_or_else(|| MatchTarget::new(""));
+        let full = Value::make_match_object_full(
+            caps.from as i64,
+            caps.to as i64,
+            &caps.positional,
+            &caps.named,
+            target,
+        );
+        let named_v = full.match_named();
+        match named_v.as_ref().map(Value::view) {
+            Some(ValueView::Hash(named)) => {
+                named.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+            }
+            _ => HashMap::new(),
+        }
     }
 
     /// Build a Match object for each named capture in `caps` and run its grammar

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -234,7 +234,21 @@ impl Interpreter {
                 continue;
             };
             self.setup_regex_code_block_env(ctx);
-            self.eval_regex_code_block_body(&stmts);
+            let body_result = self.eval_regex_code_block_body(&stmts);
+            self.park_regex_code_block_error(body_result);
+        }
+    }
+
+    /// Park a `die` from a replayed code block in the pending-regex-error slot
+    /// (first error wins), matching the inline-execution path's behavior.
+    fn park_regex_code_block_error(&self, result: Result<(), RuntimeError>) {
+        if let Err(e) = result {
+            super::super::regex_parse::PENDING_REGEX_ERROR.with(|slot| {
+                let mut slot = slot.borrow_mut();
+                if slot.is_none() {
+                    *slot = Some(e);
+                }
+            });
         }
     }
 
@@ -313,7 +327,13 @@ impl Interpreter {
     /// the env before and recording any changed variable as a pending local
     /// update for the outer VM. Assumes the block's `$/`, `$<name>`, `$0…` etc.
     /// have already been installed in `self.env` by the caller.
-    pub(in crate::runtime) fn eval_regex_code_block_body(&mut self, stmts: &[crate::ast::Stmt]) {
+    /// Returns `Err` when the block threw a genuine exception (a `die`), which
+    /// Rakudo propagates out of the match rather than treating as a mismatch.
+    /// Env writeback still happens before the error is returned.
+    pub(in crate::runtime) fn eval_regex_code_block_body(
+        &mut self,
+        stmts: &[crate::ast::Stmt],
+    ) -> Result<(), RuntimeError> {
         // Snapshot the env by *binding identity* — the cloned `Value` is an Arc
         // bump, and holding it also keeps the old allocation alive so a freed
         // address cannot be recycled into a false "unchanged".
@@ -331,7 +351,7 @@ impl Interpreter {
             self.env.iter().map(|(k, v)| (*k, v.clone())).collect();
         let saved_in_block = self.in_regex_code_block;
         self.in_regex_code_block = true;
-        let _ = self.eval_block_value(stmts);
+        let eval_result = self.eval_block_value(stmts);
         self.in_regex_code_block = saved_in_block;
         // Record changed env variables as pending local updates for the outer VM
         for (k, v) in &self.env {
@@ -352,6 +372,11 @@ impl Interpreter {
                 }
                 self.pending_local_updates.push((name, v.clone()));
             }
+        }
+        // A `return`-carrying error is block control flow, not an exception.
+        match eval_result {
+            Err(e) if e.return_value.is_none() => Err(e),
+            _ => Ok(()),
         }
     }
 
@@ -558,7 +583,8 @@ impl Interpreter {
                     self.env.insert("\u{00A2}".to_string(), updated);
                 }
             }
-            self.eval_regex_code_block_body(&stmts);
+            let body_result = self.eval_regex_code_block_body(&stmts);
+            self.park_regex_code_block_error(body_result);
         }
         let ast = self.env.get("made").cloned();
         if let Some(m) = saved_match {

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -29,6 +29,24 @@ thread_local! {
 }
 
 impl Interpreter {
+    /// An alternation alternative that is a lone plain `{ … }` code block
+    /// (`|| { die "no match" }`). Such a branch matches zero-width and exists
+    /// for its side effects, so evaluating it eagerly during candidate
+    /// collection fires those effects on paths raku never executes — it must
+    /// only run when no other alternative matched.
+    fn is_pure_code_block_alt(alt: &RegexPattern) -> bool {
+        alt.tokens.len() == 1
+            && matches!(alt.tokens[0].quant, RegexQuant::One)
+            && alt.tokens[0].separator.is_none()
+            && matches!(
+                &alt.tokens[0].atom,
+                RegexAtom::CodeAssertion {
+                    is_assertion: false,
+                    ..
+                }
+            )
+    }
+
     /// Try to match `branch` starting at `pos` such that it ends exactly at
     /// `target_end`. Returns the branch's own captures (relative to an empty
     /// baseline) on success. Used by conjunction (`&` / `&&`) matching, where
@@ -71,8 +89,18 @@ impl Interpreter {
 
         if let RegexAtom::Alternation(alternatives) = atom {
             // | (LTM): try all alternatives, longest match wins.
+            //
+            // A side-effect-only alternative (`| { die ... }` — a lone plain
+            // code block) is deferred: it matches zero-width, so it can only
+            // win when NOTHING else matched, and running it eagerly would fire
+            // its side effects (a `die`!) on paths raku never executes.
             let mut indexed: Vec<(usize, usize, RegexCaptures)> = Vec::new();
+            let mut deferred_code: Vec<(usize, &RegexPattern)> = Vec::new();
             for (i, alt) in alternatives.iter().enumerate() {
+                if Self::is_pure_code_block_alt(alt) {
+                    deferred_code.push((i, alt));
+                    continue;
+                }
                 if let Some((next, mut inner_caps)) =
                     self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
                 {
@@ -83,6 +111,21 @@ impl Interpreter {
                     new_caps.positional.append(&mut inner_caps.positional);
                     new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                     indexed.push((i, next, new_caps));
+                }
+            }
+            if indexed.is_empty() {
+                for (i, alt) in deferred_code {
+                    if let Some((next, mut inner_caps)) =
+                        self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
+                    {
+                        let mut new_caps = RegexCaptures::default();
+                        for (k, v) in inner_caps.named.drain() {
+                            new_caps.named.entry(k).or_default().merge(v);
+                        }
+                        new_caps.positional.append(&mut inner_caps.positional);
+                        new_caps.code_blocks.append(&mut inner_caps.code_blocks);
+                        indexed.push((i, next, new_caps));
+                    }
                 }
             }
             indexed.sort_by(|a, b| a.1.cmp(&b.1).then(b.0.cmp(&a.0)));
@@ -107,6 +150,13 @@ impl Interpreter {
             // After pushing to LIFO: alt_0's highest-priority match is on top.
             let mut groups: Vec<Vec<(usize, RegexCaptures)>> = Vec::new();
             for alt in alternatives {
+                // Defer a side-effect-only alternative (`|| { die ... }`): once
+                // an earlier alternative matched, raku never reaches it, so
+                // running it here would fire its side effects spuriously.
+                if Self::is_pure_code_block_alt(alt) && groups.iter().any(|g| !g.is_empty()) {
+                    groups.push(Vec::new());
+                    continue;
+                }
                 let inner_matches = self.regex_match_ends_from_caps_in_pkg(alt, chars, pos, pkg);
                 // inner_matches is in HIGHEST FIRST order (per regex_match_ends_from_caps_in_pkg
                 // convention). Reverse to LOWEST FIRST for our return convention.

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -305,6 +305,12 @@ impl Interpreter {
                 if !super::regex_helpers::code_block_defers_to_reduce(code) {
                     let (_value, writes) =
                         self.eval_regex_inline_code(code, current_caps, &matched_so_far, true);
+                    // The block `die`d: fail the match so the engine unwinds; the
+                    // parked pending error is re-raised at the match entry point.
+                    if super::super::regex_parse::PENDING_REGEX_ERROR.with(|e| e.borrow().is_some())
+                    {
+                        return None;
+                    }
                     let mut new_caps = RegexCaptures::default();
                     new_caps.regex_vars.extend(writes);
                     return Some((pos, new_caps));

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -44,7 +44,7 @@ impl Interpreter {
         out
     }
 
-    pub(super) fn extract_sym_adverb(name: &str) -> Option<String> {
+    pub(in crate::runtime) fn extract_sym_adverb(name: &str) -> Option<String> {
         // Try «» delimiters first (handles values containing '>')
         let french_marker = ":sym\u{ab}";
         if let Some(start_idx) = name.find(french_marker) {

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -2233,8 +2233,7 @@ impl Interpreter {
                                     && !trimmed.starts_with('{')
                                     && !trimmed.starts_with("?{")
                                     && !trimmed.starts_with("!{")
-                                    && trimmed.contains("::")
-                                    && trimmed.contains('=')
+                                    && Self::contains_longname_alias(trimmed)
                                 {
                                     PENDING_REGEX_ERROR.with(|e| {
                                         *e.borrow_mut() = Some(Self::make_longname_alias_error());
@@ -2863,7 +2862,7 @@ impl Interpreter {
                                                     return None;
                                                 }
                                                 // Check for longname aliases
-                                                if trimmed.contains("::") && trimmed.contains('=') {
+                                                if Self::contains_longname_alias(trimmed) {
                                                     PENDING_REGEX_ERROR.with(|e| {
                                                         *e.borrow_mut() =
                                                             Some(Self::make_longname_alias_error());

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -925,6 +925,18 @@ impl Interpreter {
                     format!("{expanded}{sep_rest_str}")
                 };
             }
+            // The atom in front of `**` is NOT a single atom — i.e. the
+            // quantified atom has preceding tokens (`Z "b" ** 2 % "; "`).
+            // Letting the bare-`%` expansion below at it would treat the WHOLE
+            // prefix (`Z"b"**2`) as the repeated atom and mangle the pattern
+            // (the separator was silently dropped between real iterations).
+            // The per-token parser attaches `Repeat` + separator natively at
+            // any token position, so defer to it. (Sigspace still falls
+            // through: the spaced expansion inserts `<ws>` around the
+            // separator, which the native path does not.)
+            if sep_mode.is_some() && !sigspace {
+                return pattern.to_string();
+            }
             // Fall through to let the normal parser handle ** quantifiers
         }
         if !Self::has_unquoted_ltm_separator(pattern) {

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -772,12 +772,23 @@ impl Interpreter {
     }
 
     /// Check if a regex pattern string contains a longname alias
-    /// (e.g., `<IO::File=bar>` or `<::IO::File=bar>`). Returns true if so.
+    /// (e.g., `<IO::File=bar>` or `<::IO::File=bar>`): a `::` in the alias
+    /// position, i.e. before the first `=` that is not a `=>` fat arrow.
+    /// A long name on the RHS (`<dt=Foo::Bar::rule>`) is a legal aliased
+    /// call to a fully-qualified subrule and must NOT be flagged.
     pub(super) fn contains_longname_alias(pattern: &str) -> bool {
-        // Look for <...::...=...> pattern
         let s = pattern.trim();
-        if s.contains("::") && s.contains('=') {
-            return true;
+        let bytes = s.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'=' {
+                if i + 1 < bytes.len() && bytes[i + 1] == b'>' {
+                    i += 2;
+                    continue;
+                }
+                return s[..i].contains("::");
+            }
+            i += 1;
         }
         false
     }

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -451,12 +451,22 @@ impl Interpreter {
         if name.contains("::") || name.is_empty() {
             return name;
         }
-        // A core type name is never shadowed by a package-local declaration
-        // (class registration excludes builtin short names from its aliases for
-        // the same reason), so skip the probe — it would otherwise allocate a
+        // A core type name is normally not shadowed by a package-local
+        // declaration, so skip the probe — it would otherwise allocate a
         // `Owner::Int` candidate for every ordinary attribute on every `.new`.
+        // BUT a user CAN declare e.g. `subset Method of Str` inside a class
+        // (Cro::HTTP::Request does), and that lexically shadows the builtin;
+        // subsets/classes/enums register their short name too, so a few direct
+        // hash probes detect a shadow without the per-package allocation.
         if crate::runtime::Interpreter::is_builtin_type(&name) {
-            return name;
+            let reg = self.registry();
+            let shadowed = reg.subsets.contains_key(&name)
+                || reg.classes.contains_key(&name)
+                || reg.enum_types.contains_key(&name)
+                || reg.roles.contains_key(&name);
+            if !shadowed {
+                return name;
+            }
         }
         let mut pkg = owner;
         loop {

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -451,6 +451,15 @@ impl Interpreter {
             let dim = Self::normalize_multidim_dim(&dims[0]);
             return self.multi_dim_hash_read(&m, &dim, &dims[1..]);
         }
+        // A Seq is positional too: `.map({...})[*;*]` must flatten the mapped
+        // rows, not treat the whole Seq as one scalar element (Cro's HTTP/2
+        // cookie unpacking does exactly this).
+        if let ValueView::Seq(items) | ValueView::HyperSeq(items) | ValueView::RaceSeq(items) =
+            target.view()
+        {
+            let arr = Value::array(items.as_ref().clone());
+            return self.multi_dim_index_read(&arr, dims);
+        }
         // A non-positional value behaves as a single-element list when
         // subscripted in a further dimension: in `(10,20,30)[1,2;0]` each
         // selected scalar is indexed by the trailing `0`, and `20[0]` is `20`

--- a/t/for-paren-string-semicolon.t
+++ b/t/for-paren-string-semicolon.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 4;
+
+# A `for (...)` list whose string elements contain `;` must not be mistaken
+# for the obsolete C-style `for (init; cond; step)` form. The C-style
+# detector's paren scanner was quote-blind, so a semicolon inside a quoted
+# string raised X::Obsolete (seen in Cro::HTTP's cookie tests iterating
+# 'mycookie=raisin; SameSite=Strict' strings).
+
+my @got;
+for ("a;b", "c;d").kv -> $i, $v {
+    @got.push("$i=$v");
+}
+is @got.join(","), "0=a;b,1=c;d", 'for (list).kv with semicolons in strings';
+
+my @single;
+for ('x; y') -> $v {
+    @single.push($v);
+}
+is @single.join("|"), 'x; y', 'single-quoted semicolon element';
+
+# Escaped delimiters and nesting still work.
+my @nested;
+for (("p;q", "r"), ("s",)) -> @pair {
+    @nested.push(@pair.join("+"));
+}
+is @nested.join(","), "p;q+r,s", 'nested parens with semicolon string';
+
+# The genuine C-style form is still rejected.
+throws-like { EVAL 'for (my $i = 0; $i < 3; $i++) { }' }, Exception,
+    message => /'C-style'/,
+    'real C-style for is still X::Obsolete';

--- a/t/grammar-parse-rule-proto-sym-action.t
+++ b/t/grammar-parse-rule-proto-sym-action.t
@@ -1,0 +1,36 @@
+use Test;
+
+plan 3;
+
+# `Grammar.parse($s, :rule<proto-name>, :actions(...))` starting DIRECTLY at a
+# proto token must dispatch the winning candidate's `:sym<...>` action method.
+# Cro::Uri::HTTP.parse-request-target does exactly this with
+# `:rule('request-target')` where request-target is a proto token.
+
+grammar GPRS {
+    proto token t { * }
+    token t:sym<a> { "a" }
+    token t:sym<b> { "b" }
+}
+class GPRS-Actions {
+    method t:sym<a>($/) { make "GOT-A" }
+    method t:sym<b>($/) { make "GOT-B" }
+}
+
+is GPRS.parse("a", :actions(GPRS-Actions), :rule("t")).ast, "GOT-A",
+    'sym<a> action dispatched for :rule proto parse';
+is GPRS.parse("b", :actions(GPRS-Actions), :rule("t")).ast, "GOT-B",
+    'sym<b> action dispatched for :rule proto parse';
+
+# A nested proto subrule still dispatches per-variant (regression guard).
+grammar GPRS2 {
+    token TOP { <t> }
+    proto token t { * }
+    token t:sym<a> { "a" }
+}
+class GPRS2-Actions {
+    method TOP($/) { make $<t>.made }
+    method t:sym<a>($/) { make "NESTED-A" }
+}
+is GPRS2.parse("a", :actions(GPRS2-Actions)).ast, "NESTED-A",
+    'nested proto sym action still dispatched';

--- a/t/regex-code-block-die.t
+++ b/t/regex-code-block-die.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 7;
+
+# A `die` inside an embedded regex `{ ... }` block or `<?{ ... }>` assertion
+# propagates out of the match (Rakudo semantics) instead of being swallowed
+# as a mismatch. And a side-effect-only alternative (`|| { die ... }`) runs
+# ONLY when no earlier alternative matched — Cro::HTTP::Header's grammar uses
+# `|| <valid header> || { die "Malformed header" }` as a parse-failure arm.
+
+grammar GCBD {
+    token TOP { || "a" || { die "boom" } }
+}
+
+# 1. When the first alternative matches, the die arm must NOT run.
+my $m;
+lives-ok { $m = GCBD.parse("a") }, 'matching first alternative skips die arm';
+ok $m.defined, 'parse succeeded';
+
+# 2. When nothing matches, the die arm runs and the exception propagates.
+throws-like { GCBD.parse("b") }, Exception, message => /boom/,
+    'die arm fires when no alternative matches';
+
+# 3. die inside a plain block propagates from a smartmatch too.
+throws-like { "b" ~~ /a|{ die "boom3" }/ }, Exception, message => /boom3/,
+    'die in LTM alternation code arm propagates';
+
+# 4. die inside an assertion propagates.
+throws-like { "a" ~~ /a <?{ die "boom2" }>/ }, Exception, message => /boom2/,
+    'die in code assertion propagates';
+
+# 5. A side-effect block on the winning path still runs inline.
+my $ran = 0;
+ok "ab" ~~ /a { $ran++ } b/, 'match with inline block';
+is $ran, 1, 'inline block ran once';

--- a/t/regex-longname-alias-rhs.t
+++ b/t/regex-longname-alias-rhs.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 5;
+
+# `<alias=Fully::Qualified::rule>` is a legal aliased call to another
+# grammar's rule: the LongName restriction applies only when the ALIAS side
+# (left of `=`) is a long name (`<IO::File=bar>`). Cro::HTTP::Cookie calls
+# `<dt=DateTime::Parse::Grammar::rfc1123-date>` this way.
+
+grammar RLAR-A {
+    token x { "a" }
+}
+grammar RLAR-B {
+    token TOP { <y=RLAR-A::x> }
+}
+
+my $m = RLAR-B.parse("a");
+ok $m.defined, 'aliased fully-qualified subrule call parses';
+is ~$m<y>, 'a', 'capture available under the alias';
+is ~$m{'RLAR-A::x'}, 'a', 'capture also available under the original long name';
+is $m.hash.keys.sort.join(','), 'RLAR-A::x,y', 'both capture keys present';
+
+# The illegal direction (long name as the alias itself) still dies.
+throws-like { EVAL '"a" ~~ /<IO::File=bar>/' },
+    X::Syntax::Regex::Alias::LongName,
+    'long name on the alias side still fails';

--- a/t/regex-sep-quantifier-prefixed.t
+++ b/t/regex-sep-quantifier-prefixed.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 8;
+
+# A `** N % sep` separated quantifier must keep its separator when the
+# quantified atom is NOT the first token of the pattern. The LTM string
+# expansion used to mis-treat the whole prefix as the repeated atom, silently
+# dropping the separator (Cro::HTTP's cookie-header test matches
+# /"Cookie: " [...] ** 3 % '; '/).
+
+ok "Zb; b" ~~ /Z "b" ** 2 % "; "/, 'literal prefix + ** N % sep matches';
+nok "Zbb" ~~ /Z "b" ** 2 % "; "/, 'separator is enforced (no sep, no match)';
+nok "Zb" ~~ /Z "b" ** 2 % "; "/, 'count is enforced';
+ok "Zb; c; a" ~~ /Z ["a"||"b"||"c"] ** 3 % "; "/,
+    'prefix + alternation group ** N % sep';
+ok "X: b; c; a\r\n" ~~ /"X: " ["a"||"b"||"c"] ** 3 % "; " "\r\n"/,
+    'prefix and suffix around ** N % sep';
+
+# First-position forms unchanged.
+ok "b; b" ~~ /"b" ** 2 % "; "/, 'first-position ** N % sep still matches';
+nok "bb" ~~ /"b" ** 2 % "; "/, 'first-position separator still enforced';
+
+# Capturing atom keeps working (native separated path).
+my $m = "1.2.3.4" ~~ /(\d) ** 4 % "."/;
+is $m[0].elems, 4, 'captures fold per iteration with prefix-free sep form';

--- a/t/seq-multidim-flatten.t
+++ b/t/seq-multidim-flatten.t
@@ -1,0 +1,15 @@
+use Test;
+
+plan 3;
+
+# `[*;*]` on a Seq (e.g. a .map result) flattens one level like it does on an
+# Array — the Seq must be treated as positional, not as a single scalar
+# element. Cro::HTTP::Request's HTTP/2 cookie unpacking relies on this:
+# `@headers.map({ .value.split(...).List })[*;*]`.
+
+is ((1, 2), (3, 4)).Seq[*;*].join(","), "1,2,3,4", 'Seq[*;*] flattens';
+
+my @a = <a b>, <c d>;
+is @a.map({ $_ })[*;*].join(","), "a,b,c,d", 'map(...)[*;*] flattens';
+
+is ((1, 2), (3, 4)).Seq[*;0].join(","), "1,3", 'Seq[*;n] selects a column';

--- a/t/subset-shadows-builtin-type.t
+++ b/t/subset-shadows-builtin-type.t
@@ -1,0 +1,18 @@
+use Test;
+
+plan 4;
+
+# A user subset declared inside a class may share its short name with a core
+# type (Cro::HTTP::Request declares `subset Method of Str`); the attribute's
+# declared type must resolve to the lexical subset, not the builtin `Method`.
+
+class SSBT-Req {
+    subset Method of Str where /^<[A..Z]>+$/;
+    has Method $.m is rw;
+}
+
+my $r;
+lives-ok { $r = SSBT-Req.new }, '.new with unset shadowing-subset attribute';
+lives-ok { $r.m = "GET" }, 'assignment satisfying the subset';
+is $r.m, "GET", 'value stored';
+dies-ok { $r.m = "get" }, 'assignment violating the subset predicate dies';


### PR DESCRIPTION
Working through Cro::HTTP's test suite (vendored under `tmp/cro-http`, deps from the Cro::Core/TLS trees plus zef-store modules) surfaced seven independent, general-purpose interpreter bugs. With these fixed, five suite files go fully green:

| file | result |
|---|---|
| http-cookie.rakutest | 51/51 |
| http-response.rakutest | 64/64 |
| http-request.rakutest | 109/109 |
| uri-http.rakutest | 16/16 |
| http2-frame.rakutest | 7/7 |

## The seven fixes

1. **parser — quote-blind C-style `for` detector**: `for ('a; b', 'c').kv -> ...` raised `X::Obsolete: C-style "for"` because the paren scanner counted `;` inside quoted strings. Scanner now tracks quotes. Pin: `t/for-paren-string-semicolon.t`.

2. **regex — `<alias=Fully::Qualified::rule>` is legal**: the `X::Syntax::Regex::Alias::LongName` restriction applies only when the *alias* side (left of `=`) is a long name. `contains_longname_alias` now checks for `::` before the first non-fat-arrow `=`, shared by all three validation sites; the aliased qualified call captures under both keys as in Rakudo. Cro::HTTP::Cookie calls `<dt=DateTime::Parse::Grammar::rfc1123-date>`. Pin: `t/regex-longname-alias-rhs.t` (roast `S05-interpolation/regex-in-variable.t` stays green).

3. **grammar — `:rule<proto>` parse never dispatched `:sym` actions**: `Cro::Uri::HTTP.parse-request-target` parses with `:rule('request-target')` (a proto token); the winning candidate's `request-target:sym<origin-form>` action was never called, so `.ast` was Nil. `eval_token_call_values_at` now reports the winning candidate's sym adverb, stamped as `sym_variant` on the top Match for the existing dispatch to use. Pin: `t/grammar-parse-rule-proto-sym-action.t`.

4. **types — subset may shadow a builtin type name**: `subset Method of Str` inside `Cro::HTTP::Request` + `has Method $.method` failed `.new` with a type-check error because attribute type resolution short-circuited on the builtin name. The fast path now probes the registry short-name maps (three hash lookups) before short-circuiting, so the hot no-shadow path stays allocation-free. Pin: `t/subset-shadows-builtin-type.t`.

5. **regex — `die` in embedded code propagates; `|| { die }` arm is lazy**: a `die` inside `{ ... }` / `<?{ ... }>` was swallowed as a mismatch (Rakudo propagates it). It is now parked in `PENDING_REGEX_ERROR` and re-raised at the match entry points. Complementarily, a side-effect-only alternative — Cro::HTTP::Header's `|| <valid> || { die "Malformed header" }` arm — was evaluated *eagerly* during candidate collection, firing the die on healthy input; it is now deferred and only runs when no other alternative matched. `$<x>.made` in a block without `:actions` now sees a Match (`.made` = Nil) instead of dying on a Str capture. Pin: `t/regex-code-block-die.t`.

6. **regex — `** N % sep` after other tokens dropped its separator**: `/Z "b" ** 2 % "; "/` matched `"Zbb"` and rejected `"Zb; b"` — the bare-`%` LTM string expansion treated the whole prefix `Z"b"**2` as the repeated atom. When the `**`-form's atom is not a single atom (and sigspace is off), the pattern is now left to the per-token parser, which attaches the separator natively at any position. Pin: `t/regex-sep-quantifier-prefixed.t`.

7. **vm — `Seq[*;*]` flattens**: multi-dim indexing on a Seq (Cro's HTTP/2 cookie unpacking does `.map({...})[*;*]`) treated the Seq as one scalar element. Seq/HyperSeq/RaceSeq now read as positional. Pin: `t/seq-multidim-flatten.t`.

## Verification

- `make test` green locally (debug binary).
- S05 + S09 whitelisted roast (115 files, 10341 tests) green locally on the release binary — the regex-engine changes (5, 6) touch shared match paths.
- All 7 new pin tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)