### PR TITLE
fix: unbreak the bundled-library gate (main CI has been red since #5608)

### DIFF
--- a/news/2026-08/native-int-coerce-methods-are-cool-only.md
+++ b/news/2026-08/native-int-coerce-methods-are-cool-only.md
@@ -1,0 +1,43 @@
+# `.^can('bool')` no longer answers yes for every value
+
+Raku spells the native integer types as coercion methods on `Cool`: `300.int8`
+is `44`, `"300".byte` is `44`. mutsu implemented that by treating *any* native
+integer type name as a 0-arg method on *any* value — the check was
+`is_native_int_type(method)`, over the same list the type system uses.
+
+Two things were wrong with reusing that list. It contains the C-width aliases
+`NativeCall::Types` exports (`long`, `ulong`, `size_t`, `bool`, ...) and
+`atomicint`, none of which Rakudo declares a method for — `42.bool` is
+"No such method 'bool' for invocant of type 'Int'. Did you mean any of these:
+'Bool'?". And the methods live on `Cool`, so a value that is not Cool has none
+of them; `Pair` is the case that mattered.
+
+Reporting a method that does not exist is not a harmless extra. `.^can` probes
+native dispatch, so `$anything.^can('bool')` answered yes, and the shape
+
+```raku
+sub visit($context, Str:D $field) {
+    if $context{$field}.defined { $context{$field} }
+    elsif $context.^can($field) { $context."$field"() }
+}
+```
+
+— probe, then fall through to the next candidate — stopped falling through.
+`Template::Mustache`'s context lookup is exactly that shape, walking a stack of
+`Pair` frames until one has the field. Asked for `bool` on a frame that did not
+have it, `visit` returned `0` (the coercion's parse-failure default) instead of
+`Nil`; `0` is `.defined`, so the caller took it and stopped walking, and the
+section rendered as false.
+
+The bug surfaced as **nondeterminism**, which is why it took a while to place:
+the frame order comes from hash iteration, so whether the frame carrying the
+field came first decided the outcome. `92-specs-file.rakutest` failed roughly
+half its runs, and identical module trees at two paths appeared to disagree.
+
+The coercion-method names are now their own list — `int8`..`uint64`, `byte`,
+`int`, `uint`, the ones Rakudo actually declares — and the arm is gated on the
+invocant being `Cool`. `42.int8` and `"42".byte` still work, `42.^can('bool')`
+and `(a => 1).^can('int8')` are both empty, and Template::Mustache's
+`92-specs-file` passes every run. Pinned by
+`t/native-int-coerce-methods-are-cool-only.t`, whose 14 assertions also pass
+unmodified under rakudo.

--- a/news/2026-08/nativecall-helpers-are-not-reexported.md
+++ b/news/2026-08/nativecall-helpers-are-not-reexported.md
@@ -1,0 +1,49 @@
+# A module that uses NativeCall no longer re-exports its helpers
+
+mutsu has no `NativeCall.rakumod` to import from: the five helper routines
+(`cglobal`, `nativecast`, `nativesizeof`, `explicitly-manage`, `refresh`) are
+spliced into every compunit whose source names them, as a prelude. Since
+[#5609](../2026-07/nativecall-exports-are-module-routines.md) each was declared
+`is export`, which was load-bearing rather than decorative: a prelude is spliced
+into the *host* compunit, so inside a `unit module M` a plain `our sub` registers
+as `M::nativecast` — invisible to a method body running under some other package,
+which is exactly the shape `NativeHelpers::Pointer` has.
+
+The workaround had the side effect its own ticket predicted
+([`todo/deep/module-package-sub-invisible-from-method-body.md`](../../todo/deep/module-package-sub-invisible-from-method-body.md)):
+a module that merely *uses* NativeCall re-exported the helper to whoever used
+*it*. raku does not — `use NativeLibs; say &nativecast.defined` is an undeclared
+routine there — and the difference was not cosmetic. The re-exported copy landed
+in the importer's scope as `GLOBAL::nativecast`, and the next compunit that used
+NativeCall then tried to declare its own spliced copy under the same key:
+
+```
+Redeclaration of routine 'nativecast'. Did you mean to declare a multi-sub?
+  in block <unit> at .../DBDish/SQLCipher/Connection.rakumod line 1
+```
+
+`DBDish::SQLCipher` is exactly that shape — it `use`s `NativeLibs` (which calls
+`nativecast` internally) and then loads `DBDish::SQLCipher::Connection` (which
+calls `nativecast` itself). Every DBIish SQLCipher test file died on it, which is
+what the bundled-library gate had been reporting since the helpers stopped being
+builtins. `DBDish::SQLite` escaped only because its `Connection.rakumod` happens
+not to call any NativeCall helper.
+
+The fix separates the two things `is export` was doing. The prelude declarations
+drop `is export` and are stamped instead with an internal `__mutsu_prelude`
+trait, following the `__our_scoped` / `__lexical_hoist` marker convention (a
+`__`-prefixed trait is already excluded from `has_user_custom_traits`, so
+registration never mistakes it for a user trait). A routine carrying that marker
+registers under `GLOBAL` rather than the host compunit's package — the same thing
+the `GLOBAL::` prefix already does for the prelude's `Pointer` / `void` /
+`NativeCall::CStr` classes — and enters no module's export map. Because every
+such compunit carries an identical copy, the first registration wins and the rest
+return `Unchanged` instead of colliding.
+
+So `use NativeLibs` no longer brings `nativecast` with it, a method body that
+never declared the helper still reaches it, and the five SQLCipher files pass
+again. What is still not raku-exact is that a *process* which loads any compunit
+using NativeCall makes the helper globally callable; that is inherent to the
+prelude-splicing model and is what the deep ticket's lexical-resolution fix
+removes. Pinned by `t/nativecall-helpers-are-not-reexported.t`, whose first two
+assertions run unmodified under rakudo.

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -642,8 +642,13 @@ pub(crate) fn native_method_0arg(
     if method == "nl-out" {
         return Some(Ok(Value::str_from("\n")));
     }
-    // Native int coercer methods (.byte(), .int8(), .uint16(), etc.)
-    if runtime::native_types::is_native_int_type(method) {
+    // Native int coercer methods (.byte(), .int8(), .uint16(), etc.). Rakudo
+    // declares these on `Cool`, so a `Pair` — which is not Cool — has no such
+    // method; answering one here made `.^can('bool')` true for every value and
+    // broke callers that probe `.^can($field)` before trying the next
+    // candidate. `bool` and the C-width aliases are not coercion methods at all
+    // (see `is_native_int_coerce_method`).
+    if runtime::native_types::is_native_int_coerce_method(method) && target.isa_check("Cool") {
         return Some(raku_repr::native_int_coerce_method(target, method));
     }
     // Uni types: override .chars, .codes, .comb to work on codepoints

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2032,6 +2032,14 @@ impl Default for Interpreter {
     }
 }
 
+/// Internal trait marking a routine that came from a prelude spliced into the
+/// host compunit rather than from its source. Such a routine registers under
+/// `GLOBAL` (so a method body under any package reaches it by bare name) and
+/// enters no module's export map. Marker traits are `__`-prefixed by
+/// convention, which is how registration tells them from a user trait — see
+/// `has_user_custom_traits` in `registration_sub`.
+pub(crate) const PRELUDE_SUB_TRAIT: &str = "__mutsu_prelude";
+
 /// Immutable process-constant magic/dynamic variables hoisted into the shared
 /// env base tier (see `Interpreter::new`). These hold the same value for the
 /// whole process and are never reassigned/removed by normal programs, so they

--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -43,6 +43,27 @@ pub(crate) fn is_native_int_type(name: &str) -> bool {
     NATIVE_INT_TYPES.contains(&name)
 }
 
+/// The native integer types that are also spelled as a *coercion method* on
+/// `Cool` — `42.int8`, `"42".byte`. This is a strict subset of
+/// [`NATIVE_INT_TYPES`]: the C-width aliases `NativeCall::Types` exports
+/// (`long`, `size_t`, `bool`, ...) and `atomicint` name a type but have no
+/// method of that name, so `42.bool` is "No such method" in Rakudo just as
+/// `42.Bool` is not spelled `bool`.
+///
+/// Keeping the two lists apart is not pedantry: a stray coercion method makes
+/// `.^can` answer yes for the name on *every* value, and code that probes
+/// `$obj.^can($field)` before falling back — the shape
+/// `Template::Mustache`'s context lookup has — then calls a method that
+/// silently answers 0 instead of moving on to the next candidate.
+const NATIVE_INT_COERCE_METHODS: &[&str] = &[
+    "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "byte", "int", "uint",
+];
+
+/// Whether `name` is spelled as a native-integer coercion method on `Cool`.
+pub(crate) fn is_native_int_coerce_method(name: &str) -> bool {
+    NATIVE_INT_COERCE_METHODS.contains(&name)
+}
+
 /// Returns true if `name` is a native array element type.
 pub(crate) fn is_native_array_element_type(name: &str) -> bool {
     is_native_int_type(name) || matches!(name, "num" | "num32" | "num64" | "str")

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -533,6 +533,47 @@ impl Interpreter {
         if !multi {
             self.empty_sig_proto_names.remove(&Symbol::intern(name));
         }
+        // A prelude routine spliced into a host compunit (mutsu's NativeCall
+        // helpers) belongs to no package the host declares: it registers under
+        // `GLOBAL` so a method body running under any package can call it by
+        // bare name, exactly as the prelude's `GLOBAL::`-prefixed classes do.
+        // Registering it under the host's own package instead would leave it
+        // invisible to those bodies, which is what the `is export` workaround
+        // used to paper over — at the cost of re-exporting it to every importer
+        // (see `NATIVECALL_SUB_PRELUDES`).
+        if custom_traits
+            .iter()
+            .any(|(t, _)| t == crate::runtime::PRELUDE_SUB_TRAIT)
+        {
+            let global_key = Symbol::intern(&format!("GLOBAL::{}", name));
+            // Every compunit that uses NativeCall carries its own copy of the
+            // declaration, and they are identical by construction, so the first
+            // one wins and the rest are no-ops rather than redeclarations.
+            if self.registry().functions.contains_key(&global_key) {
+                return Ok(SubRegisterOutcome::Unchanged);
+            }
+            if self.current_package() != "GLOBAL" {
+                let saved = self.current_package();
+                self.set_current_package("GLOBAL".to_string());
+                let outcome = self.register_sub_decl_fp(
+                    name,
+                    params,
+                    param_defs,
+                    return_type,
+                    associativity,
+                    body,
+                    multi,
+                    is_rw,
+                    is_raw,
+                    is_test_assertion,
+                    supersede,
+                    custom_traits,
+                    site_fingerprint,
+                );
+                self.set_current_package(saved);
+                return outcome;
+            }
+        }
         let is_method_value_decl = custom_traits
             .iter()
             .any(|(t, _)| t == "__mutsu_method_decl");

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -87,14 +87,24 @@ class GLOBAL::NativeCall::CStr {
 /// Injected per entry, so a program that declares its own `sub refresh` keeps
 /// the other four (see `inject_nativecall_subs_prelude`).
 ///
-/// Every one is `is export`, as Rakudo declares them (`is export(:DEFAULT)`).
-/// That is load-bearing here and not decoration: a prelude is spliced into the
-/// host compunit, so inside a `unit module M` a plain `our sub` registers as
-/// `M::nativesizeof` — invisible to a method body running under some other
-/// package, which is exactly the shape `NativeHelpers::Pointer` has (it
-/// `^add_method`s onto `NativeCall::Types::Pointer` and calls `nativesizeof`
-/// from inside). `is export` also registers the routine globally, which is what
-/// the `GLOBAL::` prefix does for the prelude's classes.
+/// None is `is export`, even though Rakudo declares them `is export(:DEFAULT)`:
+/// a prelude is spliced into the *host* compunit, so an `is export` here would
+/// make every module that merely *uses* NativeCall re-export the helper to
+/// whoever uses *it*. Raku does not (`use NativeLibs` leaves `nativecast`
+/// undeclared), and the difference is not cosmetic — the re-exported copy
+/// collides with the host's own injected copy, which is a hard
+/// `X::Redeclaration`.
+///
+/// They still have to be reachable by bare name from a method body running
+/// under some other package, which is the shape `NativeHelpers::Pointer` has
+/// (it `^add_method`s onto `NativeCall::Types::Pointer` and calls
+/// `nativesizeof` from inside). That is what the `__mutsu_prelude` marker
+/// `inject_nativecall_subs_prelude` stamps on each declaration buys: the
+/// routine registers under `GLOBAL` rather than the host package — the same
+/// thing the `GLOBAL::` prefix does for the prelude's classes — without
+/// entering any module's export map. See
+/// `todo/deep/module-package-sub-invisible-from-method-body.md` for the
+/// underlying lexical-resolution gap that makes the marker necessary.
 ///
 /// - `cglobal`: the `Proxy` is the contract, not an implementation detail. The
 ///   documented behaviour is that the returned object "redirects all its
@@ -116,7 +126,7 @@ pub(super) const NATIVECALL_SUB_PRELUDES: &[(&str, &str)] = &[
     (
         "cglobal",
         r#"
-our sub cglobal($libname, $symbol, $target-type) is export is rw {
+our sub cglobal($libname, $symbol, $target-type) is rw {
     Proxy.new(
         FETCH => -> $ { __mutsu_cglobal_fetch($libname, $symbol, $target-type) },
         STORE => -> $, $ { die "Writing to C globals NYI" }
@@ -127,19 +137,19 @@ our sub cglobal($libname, $symbol, $target-type) is export is rw {
     (
         "nativecast",
         r#"
-our sub nativecast($target-type, $source) is export { __mutsu_nativecast($target-type, $source) }
+our sub nativecast($target-type, $source) { __mutsu_nativecast($target-type, $source) }
 "#,
     ),
     (
         "nativesizeof",
         r#"
-our sub nativesizeof($obj) is export { __mutsu_nativesizeof($obj) }
+our sub nativesizeof($obj) { __mutsu_nativesizeof($obj) }
 "#,
     ),
     (
         "explicitly-manage",
         r#"
-our sub explicitly-manage(Str $str, :$encoding = 'utf8') is export {
+our sub explicitly-manage(Str $str, :$encoding = 'utf8') {
     NativeCall::CStr.new(:address(__mutsu_explicitly_manage($str.encode($encoding))))
 }
 "#,
@@ -147,7 +157,7 @@ our sub explicitly-manage(Str $str, :$encoding = 'utf8') is export {
     (
         "refresh",
         r#"
-our sub refresh($obj) is export { 1 }
+our sub refresh($obj) { 1 }
 "#,
     ),
 ];

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -73,6 +73,13 @@ impl Interpreter {
     ///
     /// Each entry is gated on its own name, so a program that declares its own
     /// `sub refresh` (a common enough name) still receives the other four.
+    ///
+    /// Each declaration is stamped with the internal `__mutsu_prelude` trait,
+    /// which registers it under `GLOBAL` instead of the host compunit's package
+    /// and keeps it out of that module's export map. Without the stamp a module
+    /// that merely *uses* NativeCall would re-export the helper to its own
+    /// importers, and the re-exported copy collides with the importer's own
+    /// injected copy as an `X::Redeclaration` (see [`NATIVECALL_SUB_PRELUDES`]).
     pub(super) fn inject_nativecall_subs_prelude(source: &str, stmts: &mut Vec<Stmt>) {
         if !source.contains("NativeCall") {
             return;
@@ -83,9 +90,11 @@ impl Interpreter {
             NATIVECALL_SUB_PRELUDES
                 .iter()
                 .map(|(_, src)| {
-                    crate::parse_dispatch::parse_source(src)
+                    let mut stmts = crate::parse_dispatch::parse_source(src)
                         .map(|(s, _)| s)
-                        .unwrap_or_default()
+                        .unwrap_or_default();
+                    Self::mark_prelude_subs(&mut stmts);
+                    stmts
                 })
                 .collect()
         });
@@ -100,6 +109,22 @@ impl Interpreter {
         }
         prelude.append(stmts);
         *stmts = prelude;
+    }
+
+    /// Stamp every routine declaration in a parsed prelude with the internal
+    /// `__mutsu_prelude` trait. Marker traits are `__`-prefixed by convention
+    /// (`__our_scoped`, `__lexical_hoist`) so registration can tell them from a
+    /// user trait and never tries to apply one as a role.
+    fn mark_prelude_subs(stmts: &mut [Stmt]) {
+        for stmt in stmts {
+            match stmt {
+                Stmt::SubDecl { custom_traits, .. } => {
+                    custom_traits.push((crate::runtime::PRELUDE_SUB_TRAIT.to_string(), None));
+                }
+                Stmt::SyntheticBlock(inner) => Self::mark_prelude_subs(inner),
+                _ => {}
+            }
+        }
     }
 
     /// Whether `stmts` already declares a mainline `sub <name>`, which an

--- a/t/lib/NativeCallHelperPeer.rakumod
+++ b/t/lib/NativeCallHelperPeer.rakumod
@@ -1,0 +1,10 @@
+unit class NativeCallHelperPeer;
+
+# The second half of the collision: another compunit that uses NativeCall and
+# calls the same helper, so it receives its own spliced copy of the routine. If
+# `NativeCallHelperUser` re-exported `nativecast` into the importer's scope,
+# loading this one after it died with "Redeclaration of routine 'nativecast'".
+
+use NativeCall;
+
+method cast($type, $ptr) { nativecast($type, $ptr) }

--- a/t/lib/NativeCallHelperUser.rakumod
+++ b/t/lib/NativeCallHelperUser.rakumod
@@ -1,0 +1,15 @@
+unit module NativeCallHelperUser;
+
+# A module that merely *uses* NativeCall and calls one of its helper routines.
+# Rakudo's NativeCall exports `nativecast`; this module does not, and must not
+# re-export it to whoever uses this one. mutsu splices the helper into the host
+# compunit as a prelude, so getting that wrong is easy — and the consequence is
+# not just an extra symbol: the re-exported copy collides with the importer's
+# own spliced copy as a hard X::Redeclaration.
+#
+# Shaped after NativeLibs' `Searcher.find`, which is what made every DBIish
+# SQLCipher test file die.
+
+use NativeCall;
+
+our sub cast-through($type, $ptr) is export { nativecast($type, $ptr) }

--- a/t/native-int-coerce-methods-are-cool-only.t
+++ b/t/native-int-coerce-methods-are-cool-only.t
@@ -1,0 +1,27 @@
+# `42.int8` / `"42".byte` are coercion methods Rakudo declares on `Cool`. mutsu
+# answered them for every native integer *type* name and on every value, so
+# `.^can('bool')` was true for anything at all. Code that probes
+# `$obj.^can($field)` before moving on to the next candidate — which is exactly
+# what Template::Mustache's context lookup does — then called a method that
+# silently answered 0 instead of missing, and the answer depended on hash order,
+# so a section rendered empty about half the time.
+#
+# Every assertion here also passes unmodified under rakudo.
+use Test;
+plan 14;
+
+# The Raku-native integer types are coercion methods, on Cool values.
+is 300.int8, 44, 'Int.int8 coerces';
+is "300".byte, 44, 'Str.byte coerces';
+ok (42.^can('int8')), 'Int can int8';
+ok ("42".^can('byte')), 'Str can byte';
+ok ((1, 2).^can('int8')), 'List is Cool, so it can int8';
+
+# The NativeCall::Types C-width aliases name a type but are not methods.
+for <bool long ulong longlong ulonglong size_t ssize_t atomicint> -> $name {
+    nok (42.^can($name)), "Int cannot $name -- it is a type, not a method";
+}
+
+# ...and a value that is not Cool has none of them. `Pair` is the one that bit
+# us: the Mustache context stack is a stack of Pairs.
+nok ((a => 1).^can('int8')), 'Pair is not Cool, so it cannot int8';

--- a/t/nativecall-helpers-are-not-reexported.t
+++ b/t/nativecall-helpers-are-not-reexported.t
@@ -1,0 +1,36 @@
+# NativeCall's helper routines are spliced into every compunit that uses them
+# (mutsu has no NativeCall.rakumod to import them from). A module that merely
+# *uses* NativeCall must not therefore re-export them: raku leaves `nativecast`
+# undeclared after `use NativeLibs`, and in mutsu the re-exported copy collided
+# with the importer's own spliced copy as a hard X::Redeclaration — which is
+# what made every DBIish SQLCipher test file die.
+#
+# The first two assertions are the regression proper and pass under rakudo too.
+# The last two call through `is native('c')`, which rakudo cannot resolve on a
+# host where `libc.so` is a linker script rather than a shared object, so only
+# mutsu runs them.
+use Test;
+use NativeCall;
+use lib $?FILE.IO.parent.add('lib').Str;
+
+plan 4;
+
+# Loading both is the regression: the second compunit brings its own copy of
+# `nativecast`, which used to clash with the one leaked out of the first.
+lives-ok { EVAL 'use NativeCallHelperUser; use NativeCallHelperPeer; 1' },
+    'two modules that each use NativeCall load together';
+
+use NativeCallHelperUser;
+use NativeCallHelperPeer;
+
+# The module's own export still arrives.
+ok defined(&cast-through), 'the module exports its own routine';
+
+# And it works: the helper is reachable from the module's body even though the
+# module declares it in no package of its own.
+sub c_getenv(Str --> Pointer) is native('c') is symbol('getenv') { * }
+ok cast-through(Str, c_getenv('PATH')).chars > 0,
+    'the module body reaches the helper it never declared';
+
+ok NativeCallHelperPeer.new.cast(Str, c_getenv('PATH')).chars > 0,
+    'and so does a method body in another compunit';

--- a/todo/deep/module-package-sub-invisible-from-method-body.md
+++ b/todo/deep/module-package-sub-invisible-from-method-body.md
@@ -49,15 +49,23 @@ see `NativeHelpers::Pointer`'s own routines.
 ## Why it has not been noticed more
 
 Because most of what module method bodies call is either a builtin (always
-resolvable, whatever the package) or an `is export` routine (which is *also*
-registered globally, so the `GLOBAL` step of the walk finds it). Only a
+resolvable, whatever the package) or an `is export` routine (which the importer
+then installs globally, so the `GLOBAL` step of the walk finds it). Only a
 package-scoped, non-exported routine falls in the hole — and `is export` is the
-workaround every affected place has reached for so far, including mutsu's own
-NativeCall prelude (see
-[`news/2026-07/nativecall-exports-are-module-routines.md`](../../news/2026-07/nativecall-exports-are-module-routines.md),
-where the five NativeCall helpers had to be marked `is export` for exactly this
-reason). That workaround is wrong in one visible way: it also re-exports the
-routine to whoever `use`s the module, which Raku would not.
+workaround every affected place has reached for so far.
+
+mutsu's own NativeCall prelude used it and was bitten by exactly the predicted
+side effect: re-exporting the routine to whoever `use`s the module, which Raku
+would not. That broke every DBIish SQLCipher file with an `X::Redeclaration`
+(the re-exported copy collided with the importer's own spliced copy) and has
+since been replaced by a narrower mechanism — the `__mutsu_prelude` marker
+trait, which registers the routine under `GLOBAL` directly instead of routing
+global visibility through an export
+([`news/2026-08/nativecall-helpers-are-not-reexported.md`](../../news/2026-08/nativecall-helpers-are-not-reexported.md)).
+That marker is available only to preludes mutsu splices in itself, so an
+ordinary module still has `is export` (or an explicit `Module::name(...)`) as
+its only spelling, and a prelude-injected helper is still visible process-wide
+once any compunit loads it — both of which this ticket's fix removes.
 
 ## Why this is large
 

--- a/todo/tickets/version-shaped-sub-name-is-lexed-as-a-version.md
+++ b/todo/tickets/version-shaped-sub-name-is-lexed-as-a-version.md
@@ -1,0 +1,34 @@
+# A `v`-plus-digits sub name is lexed as a Version literal
+
+A routine whose name looks like a version literal cannot be called:
+
+```raku
+sub v1($x) { "called-$x" }
+say v1(5);      # raku: called-5
+                # mutsu: No such method 'CALL-ME' for invocant of type 'Version'
+```
+
+The declaration itself is accepted; only the *call* misparses. `v1` at a term
+position is lexed as the `Version` literal `v1`, and the following `(5)` then
+reads as an invocation of that Version, hence the `CALL-ME` error. `v2`, `v10`
+and every other `v` + digits spelling behave the same.
+
+Raku's version literal is a term, so a bare `v1` in term position genuinely *is*
+`Version.new("1")` there too — but a name that has been *declared as a routine*
+wins, and an identifier followed by `(` is a call regardless. mutsu decides
+before consulting the declared-routine set.
+
+Names of this shape are not exotic: `v1`/`v2` are natural for a versioned API
+helper, and a test that names its subject `v1`/`v2`/`v3` (a very common habit
+when writing several small variants of the same probe) silently fails in a way
+that looks like a runtime bug rather than a lexing one. Found while reducing
+the Template::Mustache `visit` failure, where three probe subs named `v1`-`v3`
+all died with `CALL-ME` and briefly looked like a `^can` problem of their own.
+
+The neighbouring lexer trap is already documented in
+`news/2026-07/tls-openssl-battery.md`: the version lexer treats `-` as a
+trailing marker only, so `v4-split` is an identifier. This is the same
+term-vs-identifier decision made too early, on the digits side.
+
+Affected: the version-literal term in the parser's term dispatch (`v` followed
+by digits) — it needs to lose to a declared routine, and to a following `(`.


### PR DESCRIPTION
`main`'s CI has failed on every push since #5608. The failing step is the
`test` job's **Bundled-library test suites** gate, which a PR skips unless it
touches the batteries — so both regressions landed green and only showed up
post-merge. Two independent bugs, one commit each.

## 1. A module that uses NativeCall re-exported its helpers

mutsu has no `NativeCall.rakumod` to import from, so the five helper routines
are spliced into every compunit whose source names them. Since #5609 each was
declared `is export`, which was load-bearing rather than decorative: a prelude
is spliced into the *host* compunit, so inside a `unit module M` a plain
`our sub` registers as `M::nativecast` — invisible to a method body running
under some other package.

That workaround had the side effect
[its own ticket predicted](todo/deep/module-package-sub-invisible-from-method-body.md).
A module that merely *uses* NativeCall re-exported the helper to whoever used
it; raku does not (`use NativeLibs; say &nativecast.defined` is an undeclared
routine there), and the difference was not cosmetic — the re-exported copy
landed in the importer's scope as `GLOBAL::nativecast`, and the next compunit
that used NativeCall then tried to declare its own spliced copy under the same
key:

```
Redeclaration of routine 'nativecast'. Did you mean to declare a multi-sub?
  in block <unit> at .../DBDish/SQLCipher/Connection.rakumod line 1
```

`DBDish::SQLCipher` is exactly that shape — it `use`s `NativeLibs` (which calls
`nativecast` internally) and then loads `DBDish::SQLCipher::Connection` (which
calls `nativecast` itself). All five DBIish SQLCipher files died on it.
`DBDish::SQLite` escaped only because its `Connection.rakumod` happens not to
call any NativeCall helper.

The fix separates the two things `is export` was doing. The prelude
declarations drop it and are stamped instead with an internal `__mutsu_prelude`
trait, following the `__our_scoped` / `__lexical_hoist` marker convention. A
routine carrying that marker registers under `GLOBAL` rather than the host
compunit's package — the same thing the `GLOBAL::` prefix already does for the
prelude's `Pointer` / `void` / `NativeCall::CStr` classes — and enters no
module's export map. Every such compunit carries an identical copy, so the
first registration wins and the rest return `Unchanged` instead of colliding.

## 2. `.^can('bool')` answered yes for every value

Raku spells the native integer types as coercion methods on `Cool` (`300.int8`
is `44`). mutsu implemented that by treating *any* native integer type name as
a 0-arg method on *any* value, reusing the same list the type system uses.

That list also holds the C-width aliases `NativeCall::Types` exports (`long`,
`size_t`, `bool`, …) and `atomicint`, none of which Rakudo declares a method
for — `42.bool` is "No such method". And the methods live on `Cool`, so a value
that is not Cool has none of them.

Reporting a method that does not exist is not harmless: `.^can` probes native
dispatch, so `$anything.^can('bool')` answered yes, and the shape

```raku
if $context{$field}.defined { $context{$field} }
elsif $context.^can($field) { $context."$field"() }
```

— probe, then fall through to the next candidate — stopped falling through.
`Template::Mustache`'s context lookup is exactly that, walking a stack of
`Pair` frames until one has the field. Asked for `bool` on a frame without it,
the lookup returned `0` (the coercion's parse-failure default) rather than
`Nil`; `0` is `.defined`, so the caller took it and stopped walking, and the
section rendered as false. It surfaced as **nondeterminism**, since the frame
order comes from hash iteration: `92-specs-file.rakutest` failed about half its
runs, and identical module trees at two paths appeared to disagree.

The coercion-method names are now their own list — the ones Rakudo declares —
and the arm is gated on the invocant being `Cool`.

## Verification

- **Bundled-library gate: `GATE PASSED`, 139/144 files (was 133/144), zero regressions.**
- `make test`: 2658 files / 25295 tests, `Result: PASS`.
- New pins, all also passing under rakudo:
  `t/nativecall-helpers-are-not-reexported.t` (4),
  `t/native-int-coerce-methods-are-cool-only.t` (14).
- Existing `t/nativecall-exports-are-routines.t` still 15/15.

A third commit records a side finding as a ticket rather than fixing it here: a
`v`-plus-digits sub name (`sub v1 {...}; v1(5)`) is lexed as a `Version`
literal, so the call dies with `CALL-ME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)