### PR TITLE
fix: whenever-body `next` signal mapping + Raku's line-ending-block rule

### DIFF
--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -499,17 +499,65 @@ fn postfix_expr_inner(input: &str, allow_ws_dot: bool) -> PResult<'_, Expr> {
         rest
     };
 
-    postfix_expr_loop(rest, expr, allow_ws_dot)
+    // Raku's line-ending-block rule: a closing `}` that is the last thing on
+    // its line terminates the statement, so a `.method` on the NEXT line is a
+    // new (topic) statement, not a chained call. `supply { ... }\n.append(...)`
+    // inside a `given` must call `.append` on the topic (Cro's serializer
+    // tests do exactly this); a `}`-final hash composer behaves the same in
+    // rakudo, while a `)`-final call keeps chaining across the newline.
+    let consumed = &input[..input.len() - rest.len()];
+    postfix_expr_loop_from(rest, expr, allow_ws_dot, brace_newline_state(consumed))
 }
 
-fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PResult<'_, Expr> {
+/// For a just-consumed source span: `(ends in \`}\`, that \`}\` was already
+/// followed by a newline inside the span)`. The parser sometimes consumes the
+/// trailing whitespace (newline included) together with the block, so the
+/// newline may sit either inside the consumed span or ahead in the remainder.
+pub(in crate::parser) fn brace_newline_state(consumed: &str) -> (bool, bool) {
+    let trimmed = consumed.trim_end();
+    let brace = trimmed.ends_with('}');
+    let newline_after = consumed[trimmed.len()..].contains('\n');
+    (brace, newline_after)
+}
+
+fn postfix_expr_loop(rest: &str, expr: Expr, allow_ws_dot: bool) -> PResult<'_, Expr> {
+    postfix_expr_loop_from(rest, expr, allow_ws_dot, (false, false))
+}
+
+fn postfix_expr_loop_from(
+    mut rest: &str,
+    mut expr: Expr,
+    allow_ws_dot: bool,
+    brace_state: (bool, bool),
+) -> PResult<'_, Expr> {
+    let (mut brace_final, mut newline_after_brace) = brace_state;
+    let mut last_iter_start: Option<&str> = None;
     loop {
+        // A postfix op consumed in the previous iteration moves the
+        // "does the expression end in `}` at end of line" state along:
+        // `.map({...})` ends in `)` (keeps chaining), `.map: {...}` ends in
+        // `}` (statement ends at the newline).
+        if let Some(prev) = last_iter_start {
+            let consumed_len = prev.len() - rest.len();
+            if consumed_len > 0 {
+                (brace_final, newline_after_brace) = brace_newline_state(&prev[..consumed_len]);
+            }
+        }
+        last_iter_start = Some(rest);
         // Allow whitespace before dotty postfix call in expression context:
         // e.g. `^3 .map: { ... }`.
         if allow_ws_dot {
             let (r_ws, _) = ws(rest)?;
             if r_ws.starts_with('.') && !r_ws.starts_with("..") {
-                rest = r_ws;
+                // A `}`-final expression followed by a newline ended its
+                // statement (see `postfix_expr_inner`) — do not chain. The
+                // newline is either already inside the consumed span or in
+                // the whitespace being skipped here.
+                let crossed_newline =
+                    newline_after_brace || rest[..rest.len() - r_ws.len()].contains('\n');
+                if !(brace_final && crossed_newline) {
+                    rest = r_ws;
+                }
             }
         }
 

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -505,8 +505,23 @@ fn postfix_expr_inner(input: &str, allow_ws_dot: bool) -> PResult<'_, Expr> {
     // inside a `given` must call `.append` on the topic (Cro's serializer
     // tests do exactly this); a `}`-final hash composer behaves the same in
     // rakudo, while a `)`-final call keeps chaining across the newline.
-    let consumed = &input[..input.len() - rest.len()];
-    postfix_expr_loop_from(rest, expr, allow_ws_dot, brace_newline_state(consumed))
+    let brace_state = consumed_span(input, rest).map_or((false, false), brace_newline_state);
+    postfix_expr_loop_from(rest, expr, allow_ws_dot, brace_state)
+}
+
+/// The span of `input` consumed to reach `rest`, IF `rest` really is a suffix
+/// slice of `input` — checked by pointer provenance, not byte lengths. A
+/// sub-parser can hand back a remainder from elsewhere in the source (the
+/// heredoc reader resumes after the terminator line, e.g. `q:to /结束/;`), and
+/// a `input.len() - rest.len()` subtraction then lands mid-char and panics.
+pub(in crate::parser) fn consumed_span<'a>(input: &'a str, rest: &str) -> Option<&'a str> {
+    let start = input.as_ptr() as usize;
+    let rest_start = rest.as_ptr() as usize;
+    if rest_start >= start && rest_start + rest.len() == start + input.len() {
+        Some(&input[..rest_start - start])
+    } else {
+        None
+    }
 }
 
 /// For a just-consumed source span: `(ends in \`}\`, that \`}\` was already
@@ -537,11 +552,11 @@ fn postfix_expr_loop_from(
         // "does the expression end in `}` at end of line" state along:
         // `.map({...})` ends in `)` (keeps chaining), `.map: {...}` ends in
         // `}` (statement ends at the newline).
-        if let Some(prev) = last_iter_start {
-            let consumed_len = prev.len() - rest.len();
-            if consumed_len > 0 {
-                (brace_final, newline_after_brace) = brace_newline_state(&prev[..consumed_len]);
-            }
+        if let Some(prev) = last_iter_start
+            && let Some(consumed) = consumed_span(prev, rest)
+            && !consumed.is_empty()
+        {
+            (brace_final, newline_after_brace) = brace_newline_state(consumed);
         }
         last_iter_start = Some(rest);
         // Allow whitespace before dotty postfix call in expression context:

--- a/src/parser/expr/postfix/mod.rs
+++ b/src/parser/expr/postfix/mod.rs
@@ -18,5 +18,6 @@ pub(in crate::parser::expr) use loop_::{postfix_expr_tight_pub, prefix_expr};
 
 pub(crate) use call_method::{QuotedMethodName, parse_quoted_method_name};
 pub(in crate::parser) use helpers::is_angle_key_char;
+pub(in crate::parser) use loop_::brace_newline_state;
 pub(in crate::parser) use loop_::postfix_expr_continue;
 pub(crate) use loop_::without_pending_prefix;

--- a/src/parser/expr/postfix/mod.rs
+++ b/src/parser/expr/postfix/mod.rs
@@ -18,6 +18,6 @@ pub(in crate::parser::expr) use loop_::{postfix_expr_tight_pub, prefix_expr};
 
 pub(crate) use call_method::{QuotedMethodName, parse_quoted_method_name};
 pub(in crate::parser) use helpers::is_angle_key_char;
-pub(in crate::parser) use loop_::brace_newline_state;
 pub(in crate::parser) use loop_::postfix_expr_continue;
 pub(crate) use loop_::without_pending_prefix;
+pub(in crate::parser) use loop_::{brace_newline_state, consumed_span};

--- a/src/parser/expr/precedence_meta_ops/arith.rs
+++ b/src/parser/expr/precedence_meta_ops/arith.rs
@@ -243,8 +243,11 @@ fn prefix_expr_with_ws_dot(input: &str) -> PResult<'_, Expr> {
     // NEXT line is a new (topic) statement, not a chained call
     // (`supply { ... }\n.append-header(...)` inside a `given` — Cro's
     // serializer tests; a `}`-final hash composer behaves the same in rakudo).
-    let consumed = &input[..input.len() - rest.len()];
-    let (brace_final, newline_inside) = crate::parser::expr::postfix::brace_newline_state(consumed);
+    let (brace_final, newline_inside) = crate::parser::expr::postfix::consumed_span(input, rest)
+        .map_or(
+            (false, false),
+            crate::parser::expr::postfix::brace_newline_state,
+        );
     if brace_final {
         let (after_ws, _) = ws(rest)?;
         let crossed_newline = newline_inside || rest[..rest.len() - after_ws.len()].contains('\n');

--- a/src/parser/expr/precedence_meta_ops/arith.rs
+++ b/src/parser/expr/precedence_meta_ops/arith.rs
@@ -238,6 +238,20 @@ pub(crate) fn additive_expr(input: &str) -> PResult<'_, Expr> {
 /// while `-1 * -1 . abs` parses as `-1 * ((-1).abs)` (ws-dot tighter than *).
 fn prefix_expr_with_ws_dot(input: &str) -> PResult<'_, Expr> {
     let (rest, expr) = prefix_expr(input)?;
+    // Raku's line-ending-block rule: an expression whose consumed text ends
+    // with `}` at end of line terminates the statement, so a `.method` on the
+    // NEXT line is a new (topic) statement, not a chained call
+    // (`supply { ... }\n.append-header(...)` inside a `given` — Cro's
+    // serializer tests; a `}`-final hash composer behaves the same in rakudo).
+    let consumed = &input[..input.len() - rest.len()];
+    let (brace_final, newline_inside) = crate::parser::expr::postfix::brace_newline_state(consumed);
+    if brace_final {
+        let (after_ws, _) = ws(rest)?;
+        let crossed_newline = newline_inside || rest[..rest.len() - after_ws.len()].contains('\n');
+        if crossed_newline && after_ws.starts_with('.') && !after_ws.starts_with("..") {
+            return Ok((rest, expr));
+        }
+    }
     postfix_expr_continue(rest, expr)
 }
 

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -84,6 +84,13 @@ impl Interpreter {
                                     if err.is_return() || err.return_value.is_some() {
                                         return Err(err);
                                     }
+                                    // `next` inside a whenever body skips the rest
+                                    // of the body for THIS value (Rakudo maps it to
+                                    // a control exception the supply machinery
+                                    // absorbs) — it is not a supply failure.
+                                    if err.is_next() {
+                                        continue;
+                                    }
                                     // Route errors from tap callbacks to the
                                     // supplier's quit handlers (e.g. die inside
                                     // a whenever body in a supply block).
@@ -535,6 +542,13 @@ impl Interpreter {
                                     // consumes it — it is not a supply failure.
                                     if err.is_return() || err.return_value.is_some() {
                                         return Err(err);
+                                    }
+                                    // `next` inside a whenever body skips the rest
+                                    // of the body for THIS value (Rakudo maps it to
+                                    // a control exception the supply machinery
+                                    // absorbs) — it is not a supply failure.
+                                    if err.is_next() {
+                                        continue;
                                     }
                                     // Route errors from tap callbacks to the
                                     // supplier's quit handlers.

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -862,6 +862,10 @@ impl Interpreter {
                         match self.call_sub_value(tap_cb.clone(), vec![v.clone()], true) {
                             Ok(_) => {}
                             Err(err) if err.is_react_done() || err.is_last() => break,
+                            // `next` inside a whenever body (this tap callback is
+                            // the body when a chained on-demand supply drives it)
+                            // skips the rest of the body for THIS value only.
+                            Err(err) if err.is_next() => {}
                             Err(err) => return Err(err),
                         }
                     }

--- a/t/heredoc-multibyte-terminator.t
+++ b/t/heredoc-multibyte-terminator.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+# A heredoc whose terminator contains multi-byte characters must not break the
+# postfix parser's line-ending-block-rule bookkeeping: the heredoc reader
+# resumes AFTER the terminator line, so the remainder is not a suffix of the
+# expression fragment being parsed, and a byte-length subtraction sliced
+# mid-char and panicked (roast/S02-literals/quoting.t line 357).
+
+plan 3;
+
+my $t = q:to /结束/;
+Hello, World
+结束
+is $t, "Hello, World\n", 'q:to with a multi-byte terminator parses and yields the body';
+
+my $u = q:to /END/;
+plain
+END
+is $u, "plain\n", 'ASCII terminator still works';
+
+# The line-ending-block rule itself still holds after a heredoc.
+my $x = do given 42 { $_ }
+is $x, 42, 'given block after heredoc parses';

--- a/t/line-ending-block-statement.t
+++ b/t/line-ending-block-statement.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 5;
+
+# Raku's line-ending-block rule: a closing `}` that is the last thing on its
+# line terminates the statement, so a `.method` on the NEXT line starts a new
+# (topic) statement instead of chaining onto the block. A `)`-final call
+# keeps chaining across the newline. Cro's serializer tests rely on this:
+#   my $body-stream = supply { ... }
+#   .append-header(...);   # topic call on the surrounding given, NOT the Supply
+
+# 1. supply block + next-line .method = topic method call.
+my $topic-hit = False;
+class LEBS-C { method m() { $topic-hit = True } }
+given LEBS-C.new {
+    my $x = supply {
+        emit 1;
+    }
+    .m;
+    isa-ok $x, Supply, 'the declared variable got the supply, not the chain result';
+}
+ok $topic-hit, 'next-line .method after supply block ran on the topic';
+
+# 2. `}`-final hash composer behaves the same (matches rakudo).
+my $h = { a => 1 }
+.keys;
+isa-ok $h, Hash, 'hash composer at end of line ends the statement';
+
+# 3. `)`-final expression keeps chaining across the newline.
+my @r = (1, 2, 3).map({ $_ * 2 })
+.grep({ $_ > 2 });
+is @r.join(","), "4,6", 'paren-final call still chains across the newline';
+
+# 4. Same-line chaining on a block is unaffected.
+is { b => 2 }.keys.join(","), "b", 'same-line .method on a hash composer still chains';

--- a/t/whenever-next-signal.t
+++ b/t/whenever-next-signal.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 4;
+
+# `next` inside a whenever body skips the rest of the body for THIS value
+# only (Rakudo absorbs the control exception in the supply machinery). It
+# must not surface as a supply failure / quit. Cro::HTTP::ResponseSerializer
+# uses `next` to short-circuit bodyless (204) responses.
+
+# Supplier-backed source (live emit dispatch).
+my $in1 = Supplier.new;
+my @got1;
+my $quit1 = False;
+(supply {
+    whenever $in1.Supply -> $v {
+        if $v == 1 { emit "one"; next; }
+        emit "other:$v";
+    }
+}).tap: -> $x { @got1.push($x) }, quit => -> $ex { $quit1 = True };
+$in1.emit(1);
+$in1.emit(2);
+is @got1.join(","), "one,other:2", 'next in whenever body (live source) skips per value';
+nok $quit1, 'no quit fired for the live source';
+
+# Chained on-demand source (the supply drive loop path).
+my @got2;
+my $quit2 = False;
+(supply {
+    whenever (supply { emit 1; emit 2; }) -> $v {
+        if $v == 1 { emit "one"; next; }
+        emit "other:$v";
+    }
+}).tap: -> $x { @got2.push($x) }, quit => -> $ex { $quit2 = True };
+is @got2.join(","), "one,other:2", 'next in whenever body (on-demand source) skips per value';
+nok $quit2, 'no quit fired for the on-demand source';


### PR DESCRIPTION
Two more Cro::HTTP-surfaced general fixes; `http-response-serializer.rakutest` now passes **7/7** (was: aborting on the first response with `X::ControlFlow`).

## The two fixes

1. **`next` inside a whenever body** skips the rest of the body for THIS value (Rakudo absorbs the control exception in the supply machinery). Both supplier-emit dispatch sites and the chained on-demand supply drive loop treated it as an error and routed it to quit / the caller — Cro::HTTP::ResponseSerializer's bodyless-response short-circuit (`emit ...; next;` for 204s) killed the whole pipeline. Pin: `t/whenever-next-signal.t`.

2. **Raku's line-ending-block rule**: a closing `}` that is the last thing on its line terminates the statement, so a `.method` on the NEXT line is a new (topic) statement, not a chained call. mutsu chained it:

   ```raku
   given $response {
       my $body-stream = supply { ... }
       .append-header('Content-type', 'text/plain');   # topic call in Rakudo
   }
   ```

   called `.append-header` on the **Supply** instead of the topic (the Cro serializer tests' exact shape). Implemented at the postfix loop (with per-iteration `}`-final tracking so `.map: {...}` ends the statement at a newline while `.map({...})` keeps chaining) and at `prefix_expr_with_ws_dot`, which re-entered chaining without block knowledge. A `}`-final hash composer now also ends the statement — verified against Rakudo (`my $x = { a => 1 }\n.keys` leaves `$x` a Hash and calls `.keys` on the topic). Pin: `t/line-ending-block-statement.t`.

## Verification

- `make test` green locally (debug binary).
- 2 new pin tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)