### PR TITLE
feat(mop): EXPORTHOW::DECLARE declarators + HOW-driven class registration

### DIFF
--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -238,7 +238,15 @@ impl Compiler {
             // Bind the scalar placeholder to the (unflattened) condition value.
             self.emit_set_named_var(ph);
         }
-        self.compile_stmts_value(then_branch);
+        // A branch with ENTER/LEAVE/KEEP/UNDO phasers is a real block scope:
+        // its LEAVE must fire when the branch exits, with the branch value
+        // still delivered on the stack (OO::Monitors' method wrapper unlocks
+        // its monitor lock in a LEAVE inside `if SELF.DEFINITE { ... }`).
+        if Self::has_block_enter_leave_phasers(then_branch) {
+            self.compile_phaser_block_scope(then_branch, true);
+        } else {
+            self.compile_stmts_value(then_branch);
+        }
         let jump_end = self.code.emit(OpCode::Jump(0));
         self.code.patch_jump(jump_else);
         if needs_cond_value {
@@ -248,6 +256,8 @@ impl Compiler {
         if else_branch.is_empty() {
             let empty_idx = self.code.add_constant(Value::slip(vec![]));
             self.code.emit(OpCode::LoadConst(empty_idx));
+        } else if Self::has_block_enter_leave_phasers(else_branch) {
+            self.compile_phaser_block_scope(else_branch, true);
         } else {
             self.compile_stmts_value(else_branch);
         }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1765,7 +1765,12 @@ impl Compiler {
                     // Bind the scalar placeholder to the (unflattened) condition value.
                     self.emit_set_named_var(ph);
                 }
-                if Self::body_mutates_topic(then_branch) {
+                if Self::has_block_enter_leave_phasers(then_branch) {
+                    // A branch with ENTER/LEAVE/KEEP/UNDO phasers is a real
+                    // block scope: its LEAVE must fire when the branch exits
+                    // (OO::Monitors unlocks its monitor lock this way).
+                    self.compile_phaser_block_scope(then_branch, false);
+                } else if Self::body_mutates_topic(then_branch) {
                     self.synthetic_block_body = true;
                     self.compile_stmt(&Stmt::Block(then_branch.clone()));
                 } else if Self::branch_declares_block_local(then_branch) {
@@ -1788,6 +1793,8 @@ impl Compiler {
                     }
                     if else_branch.len() == 1 && matches!(else_branch[0], Stmt::If { .. }) {
                         self.compile_stmt(&else_branch[0]);
+                    } else if Self::has_block_enter_leave_phasers(else_branch) {
+                        self.compile_phaser_block_scope(else_branch, false);
                     } else if Self::body_mutates_topic(else_branch) {
                         self.synthetic_block_body = true;
                         self.compile_stmt(&Stmt::Block(else_branch.clone()));

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -34,7 +34,9 @@ pub(crate) use package_decl::{
 
 // Public entry points — preserve each function's original visibility.
 pub(super) use class_decl::{also_trait_stmt, class_decl_body};
-pub(crate) use class_decl::{anon_class_decl, augment_class_decl, class_decl, monitor_decl};
+pub(crate) use class_decl::{
+    anon_class_decl, augment_class_decl, class_decl, declare_decl, monitor_decl,
+};
 pub(super) use grammar_module::{does_decl, grammar_decl, module_decl, token_decl, trusts_decl};
 pub(super) use package_decl::{
     package_decl, package_decl_my, proto_decl, proto_decl_scoped, unit_module_stmt,

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -145,6 +145,29 @@ pub(crate) fn monitor_decl(input: &str) -> PResult<'_, Stmt> {
     Ok((rest, stmt))
 }
 
+/// Parse a declarator registered through a `use`d module's EXPORTHOW::DECLARE
+/// block (`my package EXPORTHOW { package DECLARE { constant kw = SomeHOW } }`):
+/// `kw Name { ... }` parses exactly like `class`, and the resulting ClassDecl
+/// carries a `__mutsu_declare_how` marker trait naming the keyword, so
+/// registration can attach the declarator's HOW to the class.
+pub(crate) fn declare_decl(input: &str) -> PResult<'_, Stmt> {
+    for kw in super::super::simple::declare_keyword_names() {
+        let Some(rest) = keyword(&kw, input) else {
+            continue;
+        };
+        let (rest, _) = ws1(rest)?;
+        let (rest, mut stmt) = class_decl_body(rest, false)?;
+        if let Stmt::ClassDecl { custom_traits, .. } = &mut stmt {
+            custom_traits.push((
+                "__mutsu_declare_how".to_string(),
+                Some(Expr::Literal(Value::str(kw))),
+            ));
+        }
+        return Ok((rest, stmt));
+    }
+    Err(PError::expected("declare declaration"))
+}
+
 /// Parse `augment class ClassName { ... }` declaration (monkey-patching).
 /// Also handles `augment role RoleName { ... }` (always illegal — roles are
 /// closed) and the anonymous form `augment class { ... }` (X::Anon::Augment).

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -117,6 +117,7 @@ const STMT_PARSERS: &[StmtParser] = &[
     class::anon_class_decl,
     class::class_decl,
     class::monitor_decl,
+    class::declare_decl,
     class::role_decl,
     class::grammar_decl,
     class::module_decl,

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -42,6 +42,7 @@ pub use lib_paths::{clear_parser_lib_paths, set_parser_lib_paths, set_parser_pro
 // `pub(crate)` re-exports.
 pub(crate) use compile_consts::is_imported_function;
 pub(crate) use registry::{current_language_version, set_current_language_version};
+pub(crate) use registry::{declare_keyword_names, register_declare_keyword};
 pub(crate) use registry::{enable_monitor_decl, monitor_decl_enabled};
 
 // `pub(super)` re-exports.
@@ -70,9 +71,10 @@ pub(in crate::parser) use pragma_preseed::{
     set_eval_user_sub_preseed,
 };
 pub(in crate::parser) use registry::{
-    lookup_custom_infix_precedence, lookup_postfix_precedence, lookup_prefix_precedence,
-    lookup_user_infix_assoc, register_op_precedence, register_user_infix_assoc, register_user_sub,
-    register_user_test_assertion_sub, reset_user_subs, resolve_op_precedence,
+    declare_keywords_snapshot, lookup_custom_infix_precedence, lookup_postfix_precedence,
+    lookup_prefix_precedence, lookup_user_infix_assoc, register_op_precedence,
+    register_user_infix_assoc, register_user_sub, register_user_test_assertion_sub,
+    reset_user_subs, resolve_op_precedence, restore_declare_keywords,
     set_eval_language_version_preseed,
 };
 pub(in crate::parser) use user_ops::{
@@ -170,6 +172,12 @@ thread_local! {
     /// Whether the `monitor` declarator is recognized — enabled by
     /// `use OO::Monitors` (mutsu provides the monitor semantics natively).
     static MONITOR_DECL_ENABLED: RefCell<bool> = const { RefCell::new(false) };
+    /// Declarator keywords registered by a `use`d module's EXPORTHOW::DECLARE
+    /// (`my package EXPORTHOW { package DECLARE { constant kw = SomeHOW } }`):
+    /// keyword → HOW type name. Unit-scoped: cleared on parser reset and
+    /// saved/restored around nested module scans (same discipline as
+    /// MONITOR_DECL_ENABLED).
+    static DECLARE_KEYWORDS: RefCell<HashMap<String, String>> = RefCell::new(HashMap::new());
     /// Language version the EVAL'd unit starts at, instead of the 6.d default.
     /// EVAL inherits the caller's language revision in rakudo (`use v6.e.PREVIEW;
     /// EVAL 'sprintf("%#x", -256)'` yields `-0x100`), and a `use vX` inside the

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -12,6 +12,10 @@ struct ModuleScanResult {
     exports: Vec<InlineModuleExport>,
     type_names: Vec<String>,
     enum_values: Vec<String>,
+    /// EXPORTHOW::DECLARE declarator keywords the module exports, as
+    /// `(keyword, HOW type name)` pairs. A `use` of the module makes each
+    /// keyword parse as a class-like declarator for the rest of the unit.
+    declare_keywords: Vec<(String, String)>,
 }
 
 thread_local! {
@@ -88,6 +92,9 @@ pub(crate) fn register_module_exports(module: &str) {
     if let Some(scan) = scan {
         apply_scan_types(&scan);
         apply_module_exports(&scan.exports);
+        for (keyword, how_type) in &scan.declare_keywords {
+            register_declare_keyword(keyword, how_type);
+        }
     }
 }
 
@@ -345,6 +352,9 @@ fn scan_module_source(source: &str) -> ModuleScanResult {
     // parse's reset would clobber (`use OO::Monitors; monitor Foo {...}`
     // scans the module between the `use` and the declaration).
     let saved_monitor_decl = monitor_decl_enabled();
+    // Same for the EXPORTHOW::DECLARE keyword table — restored wholesale, so
+    // keywords the scanned module itself imports stay lexical to that module.
+    let saved_declare_keywords = declare_keywords_snapshot();
     let (stmts, _) = crate::parser::parse_program_partial(source);
     // A `package X::Foo { }` block installs its contents into GLOBAL, so the
     // types it declares are visible to whoever loads the module — including
@@ -379,6 +389,7 @@ fn scan_module_source(source: &str) -> ModuleScanResult {
     if saved_monitor_decl {
         enable_monitor_decl();
     }
+    restore_declare_keywords(saved_declare_keywords);
     // Collect the module's declared type names (classes/roles/enums/grammars)
     // for the importer's scope. A `use`d module makes its `our`-scoped and
     // exported types visible to the importer, but mutsu loads modules at run
@@ -462,10 +473,52 @@ fn scan_module_source(source: &str) -> ModuleScanResult {
 
     let mut result: Vec<InlineModuleExport> = exports.into_values().collect();
     result.sort_by(|a, b| a.name.cmp(&b.name));
+    let mut declare_keywords = Vec::new();
+    collect_exporthow_declare(&stmts, &mut declare_keywords);
     ModuleScanResult {
         exports: result,
         type_names,
         enum_values,
+        declare_keywords,
+    }
+}
+
+/// Collect `(keyword, HOW type name)` pairs from a scanned module's
+/// `my package EXPORTHOW { package DECLARE { constant kw = SomeHOW } }`
+/// blocks. A `constant` inside a package parses as an our-scoped VarDecl
+/// carrying the `__constant` marker trait, with the HOW type name as a
+/// bareword initializer. Descends into non-EXPORTHOW packages so a
+/// `unit module Foo;`-wrapped EXPORTHOW block is found too.
+fn collect_exporthow_declare(stmts: &[Stmt], out: &mut Vec<(String, String)>) {
+    for stmt in stmts {
+        let Stmt::Package { name, body, .. } = stmt else {
+            continue;
+        };
+        if name.resolve() != "EXPORTHOW" {
+            collect_exporthow_declare(body, out);
+            continue;
+        }
+        for inner in body {
+            let Stmt::Package { name, body, .. } = inner else {
+                continue;
+            };
+            if name.resolve() != "DECLARE" {
+                continue;
+            }
+            for decl in body {
+                if let Stmt::VarDecl {
+                    name,
+                    expr,
+                    custom_traits,
+                    ..
+                } = decl
+                    && custom_traits.iter().any(|(t, _)| t == "__constant")
+                    && let Expr::BareWord(how_type) = expr
+                {
+                    out.push((name.clone(), how_type.clone()));
+                }
+            }
+        }
     }
 }
 

--- a/src/parser/stmt/simple/registry.rs
+++ b/src/parser/stmt/simple/registry.rs
@@ -185,6 +185,7 @@ pub(crate) fn reset_user_subs() {
         }
     });
     MONITOR_DECL_ENABLED.with(|v| *v.borrow_mut() = false);
+    DECLARE_KEYWORDS.with(|m| m.borrow_mut().clear());
 }
 
 /// Seed the language version an EVAL's nested parse starts at. `None` restores
@@ -209,6 +210,32 @@ pub(crate) fn enable_monitor_decl() {
 
 pub(crate) fn monitor_decl_enabled() -> bool {
     MONITOR_DECL_ENABLED.with(|v| *v.borrow())
+}
+
+/// Register an EXPORTHOW::DECLARE declarator keyword (from a `use`d module's
+/// scan) for the rest of the compilation unit: `keyword Name { ... }` then
+/// parses like `class` with the declarator's HOW protocol driving registration.
+pub(crate) fn register_declare_keyword(keyword: &str, how_type: &str) {
+    DECLARE_KEYWORDS.with(|m| {
+        m.borrow_mut()
+            .insert(keyword.to_string(), how_type.to_string());
+    });
+}
+
+/// The currently registered EXPORTHOW::DECLARE declarator keywords.
+pub(crate) fn declare_keyword_names() -> Vec<String> {
+    DECLARE_KEYWORDS.with(|m| m.borrow().keys().cloned().collect())
+}
+
+/// Snapshot / restore the DECLARE keyword table around a nested module scan
+/// (the nested parse's reset clears it, and any keywords the scanned module
+/// itself imports are lexical to that module, not to the importer).
+pub(in crate::parser) fn declare_keywords_snapshot() -> HashMap<String, String> {
+    DECLARE_KEYWORDS.with(|m| m.borrow().clone())
+}
+
+pub(in crate::parser) fn restore_declare_keywords(saved: HashMap<String, String>) {
+    DECLARE_KEYWORDS.with(|m| *m.borrow_mut() = saved);
 }
 
 pub(crate) fn current_language_version() -> String {

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -740,13 +740,21 @@ impl Interpreter {
         let grammar_parse_override = matches!(method_name, "parse" | "subparse" | "parsefile")
             && self.class_is_grammar(receiver_class)
             && self.has_user_method(receiver_class, method_name);
+        // A user BUILDALL/POPULATE/clone (e.g. installed by a custom HOW via
+        // `add_method` — OO::Monitors) likewise needs an MRO frame even as a
+        // single candidate, so its `callsame` reaches the NATIVE base
+        // implementation (`native_mu_base_next_candidate`: the built instance
+        // for BUILDALL/POPULATE, the native attribute-copying clone for clone).
+        let mu_base_override = matches!(method_name, "BUILDALL" | "POPULATE" | "clone")
+            && self.has_user_method(receiver_class, method_name);
+        let native_base_override = grammar_parse_override || mu_base_override;
         // Fast path: a name with at most one *structural* dispatch candidate across
         // the MRO can never produce a deferral frame (arg-matching only reduces the
         // candidate count), so skip the per-call `resolve_all_methods_with_owner`
         // MRO walk + MethodDef clones. The structural shape depends only on
         // (class, method), so it is memoized in `dispatch_multi_candidate` and
         // invalidated with the other method caches on any registry change.
-        if !grammar_parse_override
+        if !native_base_override
             && !self.has_multiple_dispatch_candidates(receiver_class, method_name)
         {
             return false;
@@ -758,9 +766,9 @@ impl Interpreter {
         // per-call `function_body_fingerprint` work below — which Debug-traverses the
         // whole method body AST to derive a candidate identity — for the overwhelmingly
         // common single-method case. Mirrors `push_multi_dispatch_frame`'s `<= 1` guard.
-        // A grammar parse override still pushes a frame (empty `remaining`) so its
-        // `nextsame`/`nextwith` reaches the native fallback.
-        if !grammar_parse_override && all_candidates.len() <= 1 {
+        // A grammar parse / Mu-base override still pushes a frame (empty
+        // `remaining`) so its `nextsame`/`nextwith` reaches the native fallback.
+        if !native_base_override && all_candidates.len() <= 1 {
             return false;
         }
         // Identify the chosen candidate and skip exactly that one
@@ -781,7 +789,7 @@ impl Interpreter {
             }
             remaining.push((owner.resolve(), def));
         }
-        let pushed = !remaining.is_empty() || grammar_parse_override;
+        let pushed = !remaining.is_empty() || native_base_override;
         if pushed {
             let rw_params = chosen
                 .as_ref()

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -145,6 +145,50 @@ impl Interpreter {
             }
             // mutsu has no method cache to publish; the default is a no-op.
             "publish_method_cache" => Some(Ok(Value::NIL)),
+            // `callsame` from a user `new_type` override (OO::Monitors'
+            // MonitorHOW) while a DECLARE'd class is being registered: the
+            // native part of `new_type` — creating and registering the type —
+            // has already run, so the base candidate simply returns the type
+            // object under registration.
+            "new_type" => self.pending_declare_new_type.clone().map(Ok),
+            // Any other native ClassHOW metamethod (`add_method`, `compose`,
+            // `add_attribute`, `attributes`, ...) is the final base candidate
+            // when the user MRO is exhausted — same routing as the direct
+            // native fallback for methods a user HOW does not override.
+            _ if Self::is_classhow_method(&method_name) => {
+                Some(self.dispatch_classhow_method(&method_name, args))
+            }
+            _ => None,
+        }
+    }
+
+    /// When a user BUILDALL/POPULATE/clone method (typically installed by a
+    /// custom HOW's `add_method` — OO::Monitors) exhausts the user MRO via
+    /// `callsame`/`nextsame`, provide the NATIVE Mu base behavior as the final
+    /// candidate: the already-built instance for BUILDALL/POPULATE (mutsu's
+    /// native build ran before the user hook — see `run_user_buildall_hook`),
+    /// and the native attribute-copying clone for `clone`.
+    fn native_mu_base_next_candidate(
+        &mut self,
+        override_args: Option<&[Value]>,
+    ) -> Option<Result<Value, RuntimeError>> {
+        let method_name = self.samewith_context_stack.last().map(|(n, _)| n.clone())?;
+        if !matches!(method_name.as_str(), "BUILDALL" | "POPULATE" | "clone") {
+            return None;
+        }
+        let frame = self.method_dispatch_stack.last()?;
+        let frame_args = frame.args.clone();
+        let invocant = self
+            .env
+            .get("self")
+            .cloned()
+            .unwrap_or_else(|| frame.invocant.clone());
+        match method_name.as_str() {
+            "BUILDALL" | "POPULATE" => Some(Ok(invocant)),
+            "clone" => {
+                let args: Vec<Value> = override_args.map(<[Value]>::to_vec).unwrap_or(frame_args);
+                self.native_instance_clone_value(&invocant, &args)
+            }
             _ => None,
         }
     }
@@ -324,6 +368,10 @@ impl Interpreter {
                     // implementation as the last candidate before giving up.
                     let result = if let Some(res) =
                         self.native_grammar_parse_next_candidate(override_args.as_deref())
+                    {
+                        res?
+                    } else if let Some(res) =
+                        self.native_mu_base_next_candidate(override_args.as_deref())
                     {
                         res?
                     } else {

--- a/src/runtime/metamodel.rs
+++ b/src/runtime/metamodel.rs
@@ -294,19 +294,14 @@ impl Interpreter {
             return Ok(());
         }
         let instance = self.call_method_with_values(how_type, "new", Vec::new())?;
-        let has_user_find_method = self
-            .registry()
-            .classes
-            .get(&how_class)
-            .map(|cd| cd.mro.clone())
-            .unwrap_or_default()
-            .iter()
-            .any(|c| {
-                self.registry()
-                    .classes
-                    .get(c.as_str())
-                    .is_some_and(|cd| cd.methods.contains_key("find_method"))
-            });
+        // `class_mro` computes and caches the MRO on demand — `ClassDef::mro`
+        // itself is lazily filled and still empty right after a module load.
+        let has_user_find_method = self.class_mro(&how_class).iter().any(|c| {
+            self.registry()
+                .classes
+                .get(c.as_str())
+                .is_some_and(|cd| cd.methods.contains_key("find_method"))
+        });
         let mut reg = self.registry_mut();
         reg.class_how_values
             .insert(grammar_name.to_string(), instance.clone());
@@ -338,13 +333,9 @@ impl Interpreter {
         if !self.registry().classes.contains_key(&how_class) {
             return Ok(false);
         }
-        let mro = self
-            .registry()
-            .classes
-            .get(&how_class)
-            .map(|cd| cd.mro.clone())
-            .unwrap_or_default();
-        let has_user_compose = mro.iter().any(|c| {
+        // `class_mro` computes and caches the MRO on demand — `ClassDef::mro`
+        // itself is lazily filled and still empty right after a module load.
+        let has_user_compose = self.class_mro(&how_class).iter().any(|c| {
             self.registry()
                 .classes
                 .get(c.as_str())
@@ -355,5 +346,111 @@ impl Interpreter {
             .class_how_values
             .insert(class_name.to_string(), instance);
         Ok(has_user_compose)
+    }
+
+    /// Whether the (user) class of the installed HOW instance for `class_name`
+    /// defines `method_name` anywhere in its MRO.
+    fn declare_how_has_user_method(&mut self, how_val: &Value, method_name: &str) -> bool {
+        let ValueView::Instance {
+            class_name: how_class,
+            ..
+        } = how_val.view()
+        else {
+            return false;
+        };
+        self.class_mro(&how_class.resolve()).iter().any(|c| {
+            self.registry()
+                .classes
+                .get(c.as_str())
+                .is_some_and(|cd| cd.methods.contains_key(method_name))
+        })
+    }
+
+    /// Drive the user HOW protocol for a DECLARE'd class right after its
+    /// native registration (Rakudo's World does the same calls during
+    /// compilation): the HOW's `new_type` override runs with `callsame`
+    /// resolving to the already-registered type object, then `add_method`
+    /// runs for every method declared in the body — the override typically
+    /// `.wrap`s the method (landing in `method_wrap_chains` via the Method
+    /// object's owner markers) and re-adds it through the fully-qualified
+    /// native `self.Metamodel::ClassHOW::add_method`, which is a no-op for an
+    /// already-registered method. The user `compose` hook is NOT called here —
+    /// the caller queues it via `pending_class_compose` so it runs after the
+    /// class's custom `is` traits, like the EXPORTHOW `class` mapping.
+    pub(crate) fn declare_drive_how_protocol(
+        &mut self,
+        class_name: &str,
+    ) -> Result<(), RuntimeError> {
+        let Some(how_val) = self.registry().class_how_values.get(class_name).cloned() else {
+            return Ok(());
+        };
+        let type_obj = Value::package(Symbol::intern(class_name));
+        if self.declare_how_has_user_method(&how_val, "new_type") {
+            self.pending_declare_new_type = Some(type_obj.clone());
+            let result = self.call_method_with_values(
+                how_val.clone(),
+                "new_type",
+                vec![Value::pair(
+                    "name".to_string(),
+                    Value::str(class_name.to_string()),
+                )],
+            );
+            self.pending_declare_new_type = None;
+            result?;
+        }
+        if self.declare_how_has_user_method(&how_val, "add_method") {
+            // The declared (public, non-multi) methods, sorted for a
+            // deterministic protocol order. Each is passed as a Method object
+            // carrying its owner markers so a `.wrap` inside the user
+            // `add_method` becomes a class-keyed wrap chain.
+            let mut method_names: Vec<String> = self
+                .registry()
+                .classes
+                .get(class_name)
+                .map(|cd| {
+                    cd.methods
+                        .iter()
+                        .filter(|(_, overloads)| {
+                            overloads.first().is_some_and(|first| {
+                                !first.is_private && !first.is_submethod && !first.is_multi
+                            })
+                        })
+                        .map(|(name, _)| name.clone())
+                        .collect()
+                })
+                .unwrap_or_default();
+            method_names.sort();
+            for method_name in method_names {
+                let Some(overloads) = self
+                    .registry()
+                    .classes
+                    .get(class_name)
+                    .and_then(|cd| cd.methods.get(&method_name).cloned())
+                else {
+                    continue;
+                };
+                let Some(first) = overloads.first() else {
+                    continue;
+                };
+                let method_obj = self.make_method_object_with_owner(
+                    &method_name,
+                    first,
+                    false,
+                    first.return_type.clone(),
+                    Some(&overloads),
+                    Some(class_name),
+                );
+                self.call_method_with_values(
+                    how_val.clone(),
+                    "add_method",
+                    vec![
+                        type_obj.clone(),
+                        Value::str(method_name.clone()),
+                        method_obj,
+                    ],
+                )?;
+            }
+        }
+        Ok(())
     }
 }

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -662,6 +662,39 @@ impl Interpreter {
                     .filter(|pd| !pd.is_invocant)
                     .cloned()
                     .collect();
+                // A NAMED invocant other than `self` (`anon method (Mu \SELF:
+                // |) {...}` — OO::Monitors' POPULATE hook) is dropped from the
+                // params like any invocant, but the body refers to it by name,
+                // so prepend a `SELF := self` binding and let the dispatch
+                // recompile the adjusted body on demand.
+                let named_invocant: Option<String> = sub_data
+                    .param_defs
+                    .iter()
+                    .find(|pd| pd.is_invocant)
+                    .map(|pd| pd.name.trim_start_matches(['$', '\\']).to_string())
+                    .filter(|n| !n.is_empty() && n != "self");
+                let (method_body, method_compiled) = match named_invocant {
+                    Some(inv_name) => {
+                        let mut body = vec![
+                            crate::ast::Stmt::VarDecl {
+                                name: inv_name.clone(),
+                                expr: crate::ast::Expr::BareWord("self".to_string()),
+                                type_constraint: None,
+                                is_state: false,
+                                is_our: false,
+                                is_dynamic: false,
+                                is_export: false,
+                                export_tags: Vec::new(),
+                                custom_traits: Vec::new(),
+                                where_constraint: None,
+                            },
+                            crate::ast::Stmt::MarkSigillessReadonly(inv_name),
+                        ];
+                        body.extend(sub_data.body.iter().cloned());
+                        (body, None)
+                    }
+                    None => (sub_data.body.clone(), sub_data.compiled_code.clone()),
+                };
                 // The name list has to lose the invocant too, not just
                 // `param_defs`: dispatch binds arguments positionally against
                 // `params`, so leaving `self` in it shifted every argument by one
@@ -685,7 +718,7 @@ impl Interpreter {
                 let def = MethodDef {
                     params: filtered_params,
                     param_defs: filtered_param_defs,
-                    body: std::sync::Arc::new(sub_data.body.clone()),
+                    body: std::sync::Arc::new(method_body),
                     is_rw: sub_data.is_rw,
                     is_private: false,
                     is_multi: false,
@@ -693,7 +726,7 @@ impl Interpreter {
                     role_origin: None,
                     original_role: None,
                     return_type: None,
-                    compiled_code: sub_data.compiled_code.clone(),
+                    compiled_code: method_compiled,
                     delegation: None,
                     is_default: false,
                     deprecated_message: None,

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -527,7 +527,42 @@ impl Interpreter {
                 Err(failure) => return Ok(failure),
             }
         }
+        // `bless` also runs a user BUILDALL/POPULATE (Rakudo: bless calls
+        // BUILDALL) — see `run_user_buildall_hook` for the semantics.
+        self.run_user_buildall_hook(cn_resolved, &inv, &args)?;
         Ok(inv)
+    }
+
+    /// Run a USER-defined `BUILDALL` (or `POPULATE`) method on a freshly
+    /// constructed instance. Rakudo's construction always goes through
+    /// BUILDALL; mutsu builds natively, so a user BUILDALL — most commonly one
+    /// a custom HOW installed via `add_method` (OO::Monitors seeds the monitor
+    /// lock attribute there) — is called after the native build, and its
+    /// `callsame` resolves to the built instance via
+    /// `native_mu_base_next_candidate`.
+    pub(crate) fn run_user_buildall_hook(
+        &mut self,
+        class_key: &str,
+        instance: &Value,
+        args: &[Value],
+    ) -> Result<(), RuntimeError> {
+        let has_user = |zelf: &mut Self, m: &str| {
+            zelf.class_mro(class_key).iter().any(|c| {
+                zelf.registry()
+                    .classes
+                    .get(c.as_str())
+                    .is_some_and(|cd| cd.methods.contains_key(m))
+            })
+        };
+        let method = if has_user(self, "BUILDALL") {
+            "BUILDALL"
+        } else if has_user(self, "POPULATE") {
+            "POPULATE"
+        } else {
+            return Ok(());
+        };
+        self.call_method_with_values(instance.clone(), method, args.to_vec())?;
+        Ok(())
     }
 
     /// Native `bless` entry for the VM: dispatch straight to `dispatch_bless`,

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -393,6 +393,9 @@ impl Interpreter {
                         let obj = args.first().ok_or_else(|| {
                             RuntimeError::new("Attribute.get_value expects an object argument")
                         })?;
+                        // The object may arrive wrapped in a Scalar container
+                        // (a `$`-bound alias of the instance); read through it.
+                        let obj = obj.clone().deref_container();
                         let attr_name = attributes
                             .as_map()
                             .get("__mutsu_attr_name")
@@ -423,10 +426,15 @@ impl Interpreter {
                             .get("__mutsu_attr_name")
                             .map(|v| v.to_string_value())
                             .unwrap_or_default();
+                        // Write through a Scalar container wrapper: the shared
+                        // attribute cell of the underlying instance is what the
+                        // object's methods read (a silent no-op here loses e.g.
+                        // OO::Monitors' lock installation).
+                        let obj = args[0].clone().deref_container();
                         if let ValueView::Instance {
                             attributes: obj_attrs,
                             ..
-                        } = args[0].view()
+                        } = obj.view()
                         {
                             let mut updated = obj_attrs.to_map();
                             updated.insert(attr_name, new_val);
@@ -1177,35 +1185,10 @@ impl Interpreter {
                     .cloned()
                     .unwrap_or(Value::NIL));
             }
-            if method == "clone" {
-                let mut attrs: AttrMap = attributes.to_map();
-                // A slot promoted to a `ContainerRef` cell (a `:=`-bound
-                // attribute) must not leak its cell into the clone: snapshot
-                // the inner value so a write to the clone's attribute stays
-                // invisible to the original (raku clones get fresh containers).
-                for v in attrs.values_mut() {
-                    if matches!(v.view(), ValueView::ContainerRef(_)) {
-                        let taken = std::mem::replace(v, Value::NIL);
-                        *v = taken.deref_container();
-                    }
-                }
-                // Build sigil map from class attributes to coerce values properly
-                let class_attrs_info = self.collect_class_attributes(&class_name.resolve());
-                let sigil_map: HashMap<String, char> = class_attrs_info
-                    .iter()
-                    .map(|(name, _, _, _, _, sigil, _)| (name.clone(), *sigil))
-                    .collect();
-                let cn = class_name.resolve();
-                for arg in &args {
-                    if let ValueView::Pair(key, boxed) = arg.view()
-                        && self.is_attribute_buildable(&cn, key)
-                    {
-                        let sigil = sigil_map.get(key.as_str()).copied().unwrap_or('$');
-                        let coerced = Self::coerce_attr_value_by_sigil(boxed.clone(), sigil);
-                        attrs.insert(key.clone(), coerced);
-                    }
-                }
-                return Ok(Value::make_instance(class_name, attrs));
+            if method == "clone"
+                && let Some(result) = self.native_instance_clone_value(&target, &args)
+            {
+                return result;
             }
             if method == "Bool"
                 && args.is_empty()
@@ -2539,6 +2522,54 @@ impl Interpreter {
             }
         }
         parts
+    }
+
+    /// The native attribute-copying clone of an `Instance` value, with `:attr(v)`
+    /// twiddle args applied. Shared between the direct `.clone` dispatch arm and
+    /// the `callsame` base candidate of a user `clone` override
+    /// (`native_mu_base_next_candidate`). `None` when the value is not an
+    /// Instance.
+    pub(super) fn native_instance_clone_value(
+        &mut self,
+        target: &Value,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = target.view()
+        else {
+            return None;
+        };
+        let mut attrs: AttrMap = attributes.to_map();
+        // A slot promoted to a `ContainerRef` cell (a `:=`-bound
+        // attribute) must not leak its cell into the clone: snapshot
+        // the inner value so a write to the clone's attribute stays
+        // invisible to the original (raku clones get fresh containers).
+        for v in attrs.values_mut() {
+            if matches!(v.view(), ValueView::ContainerRef(_)) {
+                let taken = std::mem::replace(v, Value::NIL);
+                *v = taken.deref_container();
+            }
+        }
+        // Build sigil map from class attributes to coerce values properly
+        let class_attrs_info = self.collect_class_attributes(&class_name.resolve());
+        let sigil_map: HashMap<String, char> = class_attrs_info
+            .iter()
+            .map(|(name, _, _, _, _, sigil, _)| (name.clone(), *sigil))
+            .collect();
+        let cn = class_name.resolve();
+        for arg in args {
+            if let ValueView::Pair(key, boxed) = arg.view()
+                && self.is_attribute_buildable(&cn, key)
+            {
+                let sigil = sigil_map.get(key.as_str()).copied().unwrap_or('$');
+                let coerced = Self::coerce_attr_value_by_sigil(boxed.clone(), sigil);
+                attrs.insert(key.clone(), coerced);
+            }
+        }
+        Some(Ok(Value::make_instance(class_name, attrs)))
     }
 
     /// Whether a routine body is exactly a yada stub (`...`/`!!!`/`???`), which

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -2278,6 +2278,16 @@ impl Interpreter {
                         );
                     }
                 }
+                // A user BUILDALL/POPULATE (typically installed through a
+                // custom HOW's `add_method` — OO::Monitors seeds the monitor
+                // lock there) runs after the native build; its `callsame`
+                // resolves to the already-built instance as the base
+                // candidate (`native_mu_base_next_candidate`).
+                // TODO: Rakudo's BUILDALL *replaces* the build plan (a user
+                // BUILDALL that never calls back skips attribute
+                // initialization entirely); running it post-build is an
+                // additive approximation.
+                self.run_user_buildall_hook(class_key, &instance, &args)?;
                 return Ok(instance);
             }
         }
@@ -2319,8 +2329,18 @@ impl Interpreter {
                                     "name" => {
                                         let n = value.to_string_value();
                                         attrs.insert("name".to_string(), value.clone());
-                                        attrs
-                                            .insert("__mutsu_attr_name".to_string(), Value::str(n));
+                                        // Storage key is the BARE name (sigil+twigil
+                                        // stripped), matching `^add_attribute`'s class
+                                        // slots and every other Attribute builder — so
+                                        // `get_value`/`set_value` read and write the
+                                        // instance's actual attribute slot.
+                                        let bare = n
+                                            .trim_start_matches(|c: char| "$.!@%&".contains(c))
+                                            .to_string();
+                                        attrs.insert(
+                                            "__mutsu_attr_name".to_string(),
+                                            Value::str(bare),
+                                        );
                                     }
                                     "type" => {
                                         attrs.insert("type".to_string(), value.clone());

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -442,6 +442,17 @@ impl Interpreter {
             }
         }
 
+        // A fully-qualified call naming a builtin metamodel ancestor
+        // (`self.Metamodel::ClassHOW::add_method($type, $name, $meth)` in a
+        // user HOW override — OO::Monitors' MonitorHOW): dispatch to the
+        // native ClassHOW metamethod implementation. The MRO membership check
+        // above guarantees the receiver really inherits from the metamodel
+        // class, and an overriding user method does not recurse (the qualified
+        // spelling names the parent implementation on purpose).
+        if Self::is_metamodel_class_name(qualifier) && Self::is_classhow_method(actual_method) {
+            return Some(self.dispatch_classhow_method(actual_method, args));
+        }
+
         // Last resort: the qualifier is a NATIVE builtin ancestor (verified in the
         // MRO above) whose method is Rust-implemented rather than a user method —
         // e.g. `self.IO::Path::slurp` from a class that `is IO::Path`. Dispatch it

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1451,6 +1451,12 @@ pub struct Interpreter {
     /// `samewith_depth` ties each entry to its samewith frame so the shared
     /// pop helper knows whether the top entry belongs to the frame being popped.
     metamodel_dispatch_stack: Vec<(usize, String, String, Vec<Value>)>,
+    /// The type object of the DECLARE'd class whose registration is currently
+    /// driving the user HOW protocol (`new_type` → `add_method`* → `compose`).
+    /// A `callsame` from a user `new_type` override returns it as the base
+    /// candidate — the native part of `new_type` (creating and registering the
+    /// type) has already run by the time the user hook is called.
+    pending_declare_new_type: Option<Value>,
     /// Wrap chains: sub_id -> stack of (handle_id, wrapper_sub). Outermost is last.
     wrap_chains: HashMap<u64, Vec<(u64, Value)>>,
     /// Maps sub_id to function name for named call wrap chain lookup.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2185,6 +2185,7 @@ impl Interpreter {
             raku_leaf_active: Vec::new(),
             raku_leaf_cycle_hit: std::collections::HashSet::new(),
             pending_proxy_subclass_attr: None,
+            pending_declare_new_type: None,
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),
             samewith_context_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -473,6 +473,7 @@ impl Interpreter {
             raku_leaf_active: Vec::new(),
             raku_leaf_cycle_hit: std::collections::HashSet::new(),
             pending_proxy_subclass_attr: None,
+            pending_declare_new_type: None,
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),
             samewith_context_stack: Vec::new(),

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -438,6 +438,20 @@ impl Interpreter {
             }
         }
 
+        // A method installed via `.^add_method` with a closure literal
+        // (`anon method { $captured }` — OO::Monitors' POPULATE hook) carries
+        // the frozen creating-scope env so its captures still resolve after
+        // that scope is gone. Merge those names in (self/params inserted
+        // above/below win). Mirrors the same merge in the fast path.
+        if let Some(captured) = &method_def.captured_env {
+            let env = self.env_mut();
+            for (sym, val) in captured.iter() {
+                if !env.contains_key_sym(*sym) {
+                    env.insert_sym(*sym, val.clone());
+                }
+            }
+        }
+
         // Skip invocant param, bind remaining
         let mut bind_params = Vec::new();
         let mut bind_param_defs = Vec::new();

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -1,5 +1,6 @@
 //! Type-declaration registration ops: enum / class / augment / role / subset.
 use super::*;
+use crate::ast::Expr;
 use crate::symbol::Symbol;
 
 impl Interpreter {
@@ -292,6 +293,33 @@ impl Interpreter {
                 crate::runtime::native_methods::register_monitor_class(&storage_name);
             }
 
+            // A class declared with an EXPORTHOW::DECLARE declarator (the
+            // `__mutsu_declare_how` marker trait carries the keyword): attach
+            // an instance of the declarator's HOW type — installed by the
+            // `use`d module as the EXPORTHOW::DECLARE::<keyword> constant — as
+            // the class's meta-object, drive the HOW registration protocol
+            // (`new_type`, `add_method` per declared method), and queue the
+            // user `compose` to run after the custom `is` traits (same
+            // protocol as the EXPORTHOW `class` metaclass mapping below).
+            if let Some((_, Some(Expr::Literal(kw)))) = custom_traits
+                .iter()
+                .find(|(t, _)| t == "__mutsu_declare_how")
+            {
+                let keyword = kw.to_string_value();
+                let how_type =
+                    self.get_env_with_main_alias(&format!("EXPORTHOW::DECLARE::{}", keyword));
+                if let Some(how_type) = how_type {
+                    let has_user_compose =
+                        self.install_custom_class_how(&storage_name, how_type)?;
+                    self.declare_drive_how_protocol(&storage_name)?;
+                    if has_user_compose {
+                        self.registry_mut()
+                            .pending_class_compose
+                            .push(storage_name.clone());
+                    }
+                }
+            }
+
             // Dispatch custom `is` traits via trait_mod:<is> if defined.
             // Merge explicitly parsed custom_traits with deferred_traits
             // (unknown lowercase parents deferred from register_class_decl).
@@ -301,7 +329,7 @@ impl Interpreter {
                 let type_obj = Value::package(Symbol::intern(&storage_name));
                 // Dispatch explicitly parsed custom traits (with args)
                 for (trait_name, trait_arg) in custom_traits {
-                    if trait_name == "__mutsu_monitor" {
+                    if trait_name == "__mutsu_monitor" || trait_name == "__mutsu_declare_how" {
                         continue;
                     }
                     let trait_value = if let Some(arg_expr) = trait_arg {

--- a/t/exporthow-declare-keyword.t
+++ b/t/exporthow-declare-keyword.t
@@ -1,0 +1,36 @@
+use lib 't/lib';
+use Test;
+
+# EXPORTHOW::DECLARE — a `use`d module can register a NEW class-like
+# declarator keyword:
+#   my package EXPORTHOW { package DECLARE { constant shouter = SomeHOW } }
+# The importing unit then parses `shouter Name { ... }` like `class`, the
+# declared type's .HOW is an instance of the module's HOW type, and a user
+# `compose` override on that HOW runs after registration (here: wrapping
+# every local method to uppercase its result). This is the generic mechanism
+# behind OO::Monitors' `monitor` declarator.
+
+use DeclareShout;
+
+plan 6;
+
+shouter Greeter {
+    method greet() { "hello" }
+    method part(Str $name) { "bye, " ~ $name }
+}
+
+is Greeter.new.greet, "HELLO",
+    'a method of a DECLARE-declared class went through the HOW compose wrap';
+is Greeter.new.part("ann"), "BYE, ANN",
+    'the compose wrap applies to every local method (args pass through)';
+ok Greeter.HOW ~~ MetamodelX::ShoutHOW,
+    ".HOW of a DECLARE'd class is an instance of the module's HOW type";
+is Greeter.HOW.^name, 'MetamodelX::ShoutHOW',
+    '.HOW.^name reports the custom HOW class';
+
+# An ordinary class in the same unit is untouched by the declarator.
+class Plain {
+    method greet() { "hello" }
+}
+is Plain.new.greet, "hello", 'a plain class in the same unit is unaffected';
+nok Plain.HOW ~~ MetamodelX::ShoutHOW, 'a plain class keeps the native HOW';

--- a/t/exporthow-declare-monitor-protocol.t
+++ b/t/exporthow-declare-monitor-protocol.t
@@ -1,0 +1,32 @@
+use lib 't/lib';
+use Test;
+
+# The full HOW registration protocol for an EXPORTHOW::DECLARE'd class,
+# in the exact shape OO::Monitors uses (see DeclareMonitorish.rakumod):
+# new_type/callsame, add_attribute via the HOW, add_method wrap + the
+# fully-qualified native re-add, compose's method_table probe + anon-method
+# BUILDALL/POPULATE install, and the constructor running the user BUILDALL
+# so the HOW-added attribute is initialized before any method runs.
+
+use DeclareMonitorish;
+
+plan 5;
+
+traced Greeter {
+    has $.name;
+    method hi() { "hi, " ~ $.name }
+    method motto() { "salve" }
+}
+
+my $g = Greeter.new(name => 'ann');
+my $attr = Greeter.^attributes.first(*.name eq '$!TRACE-log');
+ok $attr.defined, 'the HOW-added attribute exists on the class (^attributes)';
+is $attr.get_value($g), 'init;',
+    'the compose-installed POPULATE ran at construction and seeded the attribute';
+
+is $g.hi, 'hi, ann', 'a wrapped method still returns its original result';
+is $attr.get_value($g), 'init;hi;/hi;',
+    'the add_method wrapper ran around the call (enter + LEAVE both fired)';
+
+# Type-object calls take the non-DEFINITE path of the wrapper.
+is Greeter.motto, 'salve', 'a type-object method call passes through the wrapper';

--- a/t/leave-in-if-branch.t
+++ b/t/leave-in-if-branch.t
@@ -1,0 +1,45 @@
+use Test;
+
+# LEAVE (and friends) inside an `if`/`else` branch fire when the branch
+# exits — in both statement position and value position (a sub's trailing
+# `if`). OO::Monitors unlocks its per-instance lock in a LEAVE inside
+# `if SELF.DEFINITE { ... }`; before this fix the phaser never ran there,
+# so the lock stayed held and any cross-thread call deadlocked.
+
+plan 6;
+
+my @events;
+
+sub value-if($flag) {
+    if $flag {
+        @events.push('enter-then');
+        LEAVE @events.push('leave-then');
+        42
+    }
+    else {
+        @events.push('enter-else');
+        LEAVE @events.push('leave-else');
+        0
+    }
+}
+
+is value-if(True), 42, 'value-position if branch still delivers its value';
+is-deeply @events, [<enter-then leave-then>],
+    'LEAVE in the then-branch fired at branch exit (value position)';
+
+@events = ();
+is value-if(False), 0, 'value-position else branch still delivers its value';
+is-deeply @events, [<enter-else leave-else>],
+    'LEAVE in the else-branch fired at branch exit (value position)';
+
+@events = ();
+sub stmt-if($flag) {
+    if $flag {
+        LEAVE @events.push('leave-stmt');
+        @events.push('body');
+    }
+    return 'done';
+}
+is stmt-if(True), 'done', 'statement-position if still runs';
+is-deeply @events, [<body leave-stmt>],
+    'LEAVE in a statement-position if branch fired at branch exit';

--- a/t/lib/DeclareMonitorish.rakumod
+++ b/t/lib/DeclareMonitorish.rakumod
@@ -1,0 +1,62 @@
+# A monitor-shaped EXPORTHOW::DECLARE HOW exercising the full registration
+# protocol mutsu drives for a DECLARE'd class: `new_type` (callsame resolves
+# to the registered type) + `add_attribute` through the HOW, `add_method`
+# wrapping every method and re-adding it via the fully-qualified native
+# `self.Metamodel::ClassHOW::add_method`, and `compose` installing a
+# BUILDALL/POPULATE pair via `anon method` (whose `callsame` resolves to the
+# built instance). Mirrors OO::Monitors' MetamodelX::MonitorHOW.
+class MetamodelX::TraceHOW is Metamodel::ClassHOW {
+    has $!trace-attr;
+
+    method new_type(|) {
+        my \type = callsame();
+        type.HOW.setup-trace(type);
+        type
+    }
+
+    method setup-trace(Mu \type) {
+        $!trace-attr = Attribute.new(
+            name => '$!TRACE-log',
+            type => Str,
+            package => type
+        );
+        self.add_attribute(type, $!trace-attr);
+    }
+
+    method add_method(Mu \type, $name, $meth) {
+        unless $name eq 'BUILDALL' | 'POPULATE' | 'clone' {
+            $meth.wrap: -> \SELF, | {
+                if SELF.DEFINITE {
+                    my $log = $!trace-attr.get_value(SELF);
+                    $!trace-attr.set_value(SELF, $log ~ $name ~ ";");
+                    LEAVE $!trace-attr.set_value(SELF, $!trace-attr.get_value(SELF) ~ "/" ~ $name ~ ";");
+                    callsame
+                }
+                else {
+                    callsame
+                }
+            }
+        }
+        self.Metamodel::ClassHOW::add_method(type, $name, $meth);
+    }
+
+    method compose(Mu \type) {
+        my %methods := self.method_table(type);
+        my $trace-attr := $!trace-attr;
+        unless %methods<POPULATE>:exists or %methods<BUILDALL>:exists {
+            my $method := anon method POPULATE(Mu \SELF: |) {
+                $trace-attr.set_value(SELF, "init;");
+                callsame;
+            }
+            self.add_method(type, 'BUILDALL', $method);
+            self.add_method(type, 'POPULATE', $method);
+        }
+        self.Metamodel::ClassHOW::compose(type);
+    }
+}
+
+my package EXPORTHOW {
+    package DECLARE {
+        constant traced = MetamodelX::TraceHOW;
+    }
+}

--- a/t/lib/DeclareShout.rakumod
+++ b/t/lib/DeclareShout.rakumod
@@ -1,0 +1,14 @@
+class MetamodelX::ShoutHOW is Metamodel::ClassHOW {
+    method compose(Mu \type) {
+        for self.methods(type, :local) -> $m {
+            $m.wrap(-> \SELF, | { callsame().uc });
+        }
+        callsame
+    }
+}
+
+my package EXPORTHOW {
+    package DECLARE {
+        constant shouter = MetamodelX::ShoutHOW;
+    }
+}


### PR DESCRIPTION
## Summary

A `use`d module can now register a NEW class-like declarator keyword via `my package EXPORTHOW { package DECLARE { constant kw = SomeHOW } }`, and a DECLARE'd class drives its registration through the user HOW protocol — the machinery that lets the real OO::Monitors run verbatim (stopgap retired in the next PR of this stack, #5649).

### EXPORTHOW::DECLARE (parser)
- The module scan collects `(keyword, HOW type)` pairs; a generic `declare_decl` parser (generalizing the hardcoded `monitor_decl`) parses `kw Name { ... }` like `class` and tags the ClassDecl with the keyword. Unit-scoped keyword table, restored wholesale around nested scans.

### HOW-driven registration (runtime)
- `declare_drive_how_protocol`: user `new_type` (callsame resolves to the registered type), `add_method` per declared method (override `.wrap`s the Method object → `method_wrap_chains`, then re-adds via the fully-qualified native `self.Metamodel::ClassHOW::add_method`), queued user `compose`.
- New bridges: FQ `self.Metamodel::ClassHOW::<meth>` dispatch; callsame base candidates for every native ClassHOW metamethod; user BUILDALL/POPULATE runs at construction (`run_user_buildall_hook`) with callsame resolving to the built instance; user `clone`'s callsame reaches the native attribute-copying clone.

### General bugs fixed (each surfaced by the real module)
- **LEAVE/ENTER in an `if`/`else` branch never fired** (statement and value position) — OO::Monitors unlocks in a LEAVE inside `if SELF.DEFINITE { }`, so the lock stayed held and cross-thread calls deadlocked.
- Slow-path `call_compiled_method` dropped an added method's captured creating-scope env (fast path already merged it).
- `^add_method` lost a NAMED invocant binding (`anon method (Mu \SELF: |)`).
- `Attribute.new` get_value/set_value used the sigiled name as the storage key (every other Attribute builder uses the bare name) and silently no-opped on a Scalar-wrapped object.
- `install_custom_class_how` read the lazily-filled `ClassDef::mro` directly, so a module-loaded HOW's user `compose` was never detected.

## Tests
- `t/exporthow-declare-keyword.t`, `t/exporthow-declare-monitor-protocol.t` (full MonitorHOW-shaped protocol), `t/leave-in-if-branch.t`.
- Upstream OO::Monitors suite (5 files, 9 subtests incl. 4-thread serialization) passes verbatim through this path locally.
- `make test` (2694 files) green; risk-area roast (S04-phasers / S12-construction / S12-attributes / S12-introspection / S12-meta / wrap, 50 files, 1196 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
