### PR TITLE
feat(nqp): implement the process ops rakudo's real Test.rakumod needs

### DIFF
--- a/news/2026-08/nqp-process-ops-for-the-real-test-module.md
+++ b/news/2026-08/nqp-process-ops-for-the-real-test-module.md
@@ -1,0 +1,49 @@
+# The `nqp::` process ops rakudo's real `Test.rakumod` needs
+
+mutsu provides `Test` natively (`src/runtime/test_functions/`), which is
+BATTERIES.md rung 3 — a private dialect of a module that upstream ships as
+ordinary Raku source. `todo/tickets/vendor-real-test-module.md` measured what
+stands between mutsu and running the genuine `rakudo-2026.06/lib/Test.rakumod`
+verbatim: the file already parses and loads, and the only thing it needs is a
+handful of thin `nqp::` ops. This lands them.
+
+Implemented in a new `src/runtime/nqp_ops_process.rs` (the process /
+introspection half of the value-op table; `nqp_ops.rs` keeps the arithmetic,
+buffer and file-handle ops and was at the 500-line limit):
+
+| op | what it is |
+| --- | --- |
+| `getstdout` / `getstderr` / `getstdin` | the **process** standard handles, found by target in the VM's handle table rather than through `$*OUT`/`$*ERR`/`$*IN` — nqp code reaches for them precisely to bypass a dynamic override |
+| `setbuffersizefh` | set a handle's output buffer capacity (`0` = unbuffered), the same state Raku's `$fh.out-buffer = $n` sets, so pending bytes are flushed first |
+| `time` | wall clock as integer **nanoseconds** since the epoch (MoarVM's `time`, which replaced the float-valued `time_n`) |
+| `eqaddr` | object identity as an int `0`/`1` — the relation `=:=` already implements |
+| `can` | int `0`/`1`: does this object have that method (the low-level `$obj.^can`) |
+| `join` / `split` | literal join/split over an nqp list, no regex and no Raku `split` adverbs |
+
+`can`, `join`, `split` and `time` each collide with a same-named Raku builtin of
+*different* semantics, so they are real full-name `nqp::` arms rather than a
+relaxation of the aliasing guard in `builtins_operators_fallback.rs` — the guard
+that made an unimplemented op fail loudly instead of silently answering with
+Raku semantics stays exactly as strict as it was.
+
+One parser-side fix came with them: a no-paren zero-argument `nqp::` term used
+to be special-cased for `nqp::gethostname` alone, so bare `nqp::time` — which
+`Test.rakumod` writes on 40-odd lines — raised "Could not find symbol '&time' in
+'nqp'". The whole reserved `nqp::` namespace now dispatches through the op
+table in term position; an op mutsu does not implement still fails loudly.
+
+With these, the unmodified upstream `Test.rakumod` runs on mutsu:
+
+```
+$ mutsu -I <dir> -e 'use Test2; plan 3; ok 1, "ok works"; is 2+2, 4, "is works"; is "a", "a", "str"'
+1..3
+ok 1 - ok works
+ok 2 - is works
+ok 3 - str
+```
+
+(`Test2` is the upstream file with only `unit module Test;` renamed, to bypass
+mutsu's `use Test` interception.) Pinned by `t/nqp-process-ops.t`. The ops are
+independently useful — `getstdout`/`getstderr`/`eqaddr`/`can` show up in other
+real distributions — and swapping the `Test` implementation itself is
+deliberately left to later steps of the ticket.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -174,6 +174,7 @@ mod class_dispatch;
 mod class_introspection;
 mod ctor_phase_plan;
 mod nqp_ops;
+mod nqp_ops_process;
 pub(crate) use class_introspection::UserMethodOrAccessor;
 pub(crate) mod cstruct_layout;
 mod decl_types;

--- a/src/runtime/nqp_ops.rs
+++ b/src/runtime/nqp_ops.rs
@@ -496,7 +496,9 @@ impl Interpreter {
                 }
             }
 
-            _ => return None,
+            // The process/introspection half of the table lives in its own
+            // module (file-size limit); an op neither knows still errors.
+            _ => return self.call_nqp_op_process(op, args),
         })
     }
 }

--- a/src/runtime/nqp_ops_process.rs
+++ b/src/runtime/nqp_ops_process.rs
@@ -1,0 +1,162 @@
+//! The process/introspection half of the `nqp::` value-op table.
+//!
+//! Split out of [`nqp_ops`](super::nqp_ops) (which stays focused on native
+//! arithmetic, buffers and low-level file handles) to keep both files under the
+//! 500-line limit. Reached from the same dispatch point: `call_nqp_op` falls
+//! through to `call_nqp_op_process` before the loud unsupported-op error.
+//!
+//! The driver is rakudo's own `lib/Test.rakumod`, which mutsu still provides
+//! natively (`runtime/test_functions.rs`). Running the genuine upstream module
+//! instead needs exactly these ops — see
+//! `todo/tickets/vendor-real-test-module.md`. Note that `can`, `join`, `split`
+//! and `time` all collide with same-named Raku builtins of *different*
+//! semantics, which is why they are implemented here under their full `nqp::`
+//! name rather than by relaxing the aliasing guard in
+//! `builtins_operators_fallback.rs`.
+
+use crate::runtime::{Interpreter, IoHandleTarget, RuntimeError};
+use crate::value::{Value, ValueView};
+
+impl Interpreter {
+    /// Try a process-level / introspection `nqp::` op. `None` means "not an op
+    /// this table knows"; the caller then raises the unsupported-op error.
+    pub(crate) fn call_nqp_op_process(
+        &mut self,
+        op: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        Some(match op {
+            // -- the process's standard handles --
+            // These are the *process* streams, deliberately not the `$*OUT` /
+            // `$*ERR` dynamic variables: a caller that swapped `$*OUT` for a
+            // capture object still gets the real stdout here, which is the
+            // whole reason nqp code reaches for them (Test.rakumod unbuffers
+            // the real streams so TAP output cannot be reordered).
+            "getstdout" => Ok(self.std_handle(IoHandleTarget::Stdout)),
+            "getstderr" => Ok(self.std_handle(IoHandleTarget::Stderr)),
+            "getstdin" => Ok(self.std_handle(IoHandleTarget::Stdin)),
+
+            // nqp::setbuffersizefh($fh, $size) — set the handle's output
+            // buffer capacity (0 = unbuffered) and return the handle. Maps
+            // onto the same state as Raku's `$fh.out-buffer = $size`, so any
+            // pending bytes are flushed before the capacity changes.
+            "setbuffersizefh" => {
+                let fh = args.first().cloned().unwrap_or(Value::NIL);
+                let size = args
+                    .get(1)
+                    .and_then(Self::parse_out_buffer_size)
+                    .unwrap_or(0);
+                match self.with_handle_mut(&fh, |state| state.out_buffer_setting(Some(Some(size))))
+                {
+                    Ok(_) => Ok(fh),
+                    Err(e) => Err(e),
+                }
+            }
+
+            // nqp::time — wall clock as an integer number of NANOseconds since
+            // the epoch (MoarVM's `time`, which replaced the older float-valued
+            // `time_n`).
+            "time" => Ok(Value::int(Self::epoch_nanos())),
+
+            // nqp::eqaddr($a, $b) — object identity as an int 0/1. Same
+            // relation as Raku's `=:=`, which is already identity over the
+            // container-kind values and by-name over type objects.
+            "eqaddr" => Ok(Value::int(i64::from(crate::runtime::values_identical(
+                args.first().unwrap_or(&Value::NIL),
+                args.get(1).unwrap_or(&Value::NIL),
+            )))),
+
+            // nqp::can($obj, $name) — int 0/1: does this object have a method
+            // of that name (the low-level form of `$obj.^can($name)`).
+            "can" => {
+                let target = args.first().cloned().unwrap_or(Value::NIL);
+                let name = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
+                let found = !self.collect_can_methods(&target, &name).is_empty();
+                Ok(Value::int(i64::from(found)))
+            }
+
+            // nqp::join($sep, $list) / nqp::split($sep, $str) — string join and
+            // split over an nqp list. Plain literal separators, no regex and no
+            // Raku `split` adverbs: `nqp::split("", $s)` yields the characters,
+            // splitting the empty string yields the empty list, and every
+            // separator occurrence produces a field (so trailing empties are
+            // kept).
+            "join" => {
+                let sep = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                let parts = args.get(1).map(Self::nqp_list_strings).unwrap_or_default();
+                Ok(Value::str(parts.join(&sep)))
+            }
+            "split" => {
+                let sep = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                let target = args.get(1).map(|v| v.to_string_value()).unwrap_or_default();
+                let parts: Vec<Value> = if target.is_empty() {
+                    Vec::new()
+                } else if sep.is_empty() {
+                    target.chars().map(|c| Value::str(c.to_string())).collect()
+                } else {
+                    target
+                        .split(&sep)
+                        .map(|s| Value::str(s.to_string()))
+                        .collect()
+                };
+                Ok(Value::array(parts))
+            }
+
+            _ => return None,
+        })
+    }
+
+    /// Wall clock in nanoseconds since the Unix epoch, saturating rather than
+    /// wrapping (an `i64` of nanoseconds runs out in the year 2262).
+    fn epoch_nanos() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX))
+            .unwrap_or(0)
+    }
+
+    /// The process-level handle for one of the standard streams: the handle
+    /// registered by `init_io_environment`, found by target rather than by the
+    /// `$*OUT`/`$*ERR`/`$*IN` dynamic variables (which a caller may have
+    /// rebound). Lowest id wins, so it is the one created at startup.
+    fn std_handle(&mut self, target: IoHandleTarget) -> Value {
+        let existing = {
+            let table = self.io_handles();
+            table
+                .map
+                .iter()
+                .filter(|(_, state)| state.target == target)
+                .map(|(id, _)| *id)
+                .min()
+        };
+        match existing {
+            Some(id) => self.make_handle_instance(id),
+            // No startup handle (a bare embedding of the interpreter): make one
+            // rather than handing back a Nil the caller cannot use.
+            None => {
+                let mode = match target {
+                    IoHandleTarget::Stdin => crate::runtime::IoHandleMode::Read,
+                    _ => crate::runtime::IoHandleMode::Write,
+                };
+                self.create_handle(target, mode, None)
+            }
+        }
+    }
+
+    /// The elements of an nqp list as strings. nqp's `join` takes a VM list;
+    /// mutsu represents one as an ordinary `Array`/`List` value, and a single
+    /// non-list value counts as a one-element list.
+    fn nqp_list_strings(value: &Value) -> Vec<String> {
+        match value.view() {
+            ValueView::Array(items, _) => items.iter().map(|v| v.to_string_value()).collect(),
+            ValueView::Slip(items) => items.iter().map(|v| v.to_string_value()).collect(),
+            _ => vec![value.to_string_value()],
+        }
+    }
+}

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -313,10 +313,14 @@ impl Interpreter {
         } else if name.starts_with("Metamodel::") {
             // Meta-object protocol type objects
             Value::package(Symbol::intern(name))
-        } else if name == "nqp::gethostname" {
+        } else if name.starts_with("nqp::") {
             // A no-paren 0-arg `nqp::`-op term dispatches through the builtin nqp
             // compat layer, not the qualified symbol lookup below (which would
-            // raise "Could not find symbol '&gethostname' in 'nqp'").
+            // raise "Could not find symbol '&gethostname' in 'nqp'"). This holds
+            // for the whole reserved `nqp::` namespace, not just the one op that
+            // first needed it: `nqp::time` is written without parentheses all
+            // over rakudo's own `Test.rakumod`. An op mutsu does not implement
+            // still fails loudly in the unsupported-op guard.
             self.call_function(name, Vec::new())?
         } else if name.contains("::") {
             // Check if this is an access to a non-existent enum variant

--- a/t/nqp-process-ops.t
+++ b/t/nqp-process-ops.t
@@ -1,0 +1,81 @@
+use v6;
+use Test;
+use nqp;
+
+# The process/introspection `nqp::` ops. Rakudo's own `lib/Test.rakumod` is
+# written against exactly these (plus the arithmetic ones mutsu already had),
+# so they are what stands between mutsu and running the genuine upstream Test
+# module instead of its native reimplementation — see
+# todo/tickets/vendor-real-test-module.md.
+#
+# `can`, `join`, `split` and `time` all collide with same-named Raku builtins
+# of DIFFERENT semantics, so each one is checked here against its nqp meaning,
+# not its Raku namesake's.
+
+plan 25;
+
+# -- nqp::time: integer nanoseconds since the epoch --------------------------
+
+my $t = nqp::time;
+isa-ok $t, Int, 'nqp::time returns an Int';
+ok $t > 1_700_000_000_000_000_000, 'nqp::time counts NANOseconds since the epoch';
+ok nqp::time() >= $t, 'nqp::time is monotone across two readings';
+
+# Written without parentheses all over Test.rakumod, so the no-paren term form
+# has to reach the op rather than a qualified-symbol lookup.
+my $bare = nqp::time;
+isa-ok $bare, Int, 'the no-paren `nqp::time` term form works';
+
+# -- nqp::getstdout / getstderr / getstdin + setbuffersizefh -----------------
+
+# MoarVM hands back an opaque `BOOTIO`; mutsu has no such type and uses the
+# same `IO::Handle` its own `$*OUT` is, so these three assertions are
+# deliberately mutsu-specific. Everything a caller does with the result —
+# `setbuffersizefh` here, `.print`/`.say` elsewhere — works either way.
+my $out = nqp::getstdout();
+isa-ok $out, IO::Handle, 'nqp::getstdout returns a handle';
+isa-ok nqp::getstderr(), IO::Handle, 'nqp::getstderr returns a handle';
+isa-ok nqp::getstdin(), IO::Handle, 'nqp::getstdin returns a handle';
+is nqp::getstdout().native-descriptor, 1, 'nqp::getstdout is the process stdout (fd 1)';
+is nqp::getstderr().native-descriptor, 2, 'nqp::getstderr is the process stderr (fd 2)';
+
+# These are the PROCESS streams, deliberately not the dynamic variables: nqp
+# code reaches for them precisely to bypass an override.
+{
+    my $*OUT = class { method print(|c) { } };
+    is nqp::getstdout().native-descriptor, 1,
+        'nqp::getstdout is the process stdout even when $*OUT is rebound';
+}
+
+# What Test.rakumod does with them: unbuffer, so TAP output cannot be reordered.
+nqp::setbuffersizefh(nqp::getstdout(), 0);
+is nqp::getstdout().out-buffer, 0, 'nqp::setbuffersizefh(fh, 0) unbuffers the handle';
+nqp::setbuffersizefh(nqp::getstdout(), 4096);
+is nqp::getstdout().out-buffer, 4096, 'and a non-zero size sets that capacity';
+nqp::setbuffersizefh(nqp::getstdout(), 0);
+
+# -- nqp::eqaddr: object identity --------------------------------------------
+
+is nqp::eqaddr(Int, Int), 1, 'nqp::eqaddr is 1 for the same type object';
+is nqp::eqaddr(Int, Str), 0, 'and 0 for different type objects';
+is nqp::eqaddr(Mu, Mu), 1, 'nqp::eqaddr(Mu, Mu) — the shape `is` uses';
+my @a;
+is nqp::eqaddr(@a, @a), 1, 'the same container is identical to itself';
+is nqp::eqaddr([1], [1]), 0, 'two equal-but-distinct containers are not';
+
+# -- nqp::can: does this object have that method -----------------------------
+
+is nqp::can(1, 'raku'), 1, 'nqp::can finds a method the object has';
+is nqp::can(1, 'no-such-method-here'), 0, 'and answers 0 for one it does not';
+class NqpCanTarget { method mine() { 42 } }
+is nqp::can(NqpCanTarget.new, 'mine'), 1, 'nqp::can sees a user-defined method';
+is nqp::can(NqpCanTarget.new, 'yours'), 0, 'and not one that was never defined';
+
+# -- nqp::join / nqp::split: literal, over an nqp list ------------------------
+
+is nqp::join('-', nqp::split(',', 'a,b,c')), 'a-b-c', 'nqp::split then nqp::join round-trips';
+is nqp::join('|', nqp::split('', 'abc')), 'a|b|c', 'an empty separator splits into characters';
+is nqp::join('|', nqp::split("\n", "a\n")), 'a|', 'a trailing separator keeps the empty field';
+# The exact `diag` shape from Test.rakumod: indent every line of a message.
+is nqp::join("\n# ", nqp::split("\n", "one\ntwo")), "one\n# two",
+    'the `diag` indentation idiom from Test.rakumod';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -62,8 +62,16 @@ implementation swaps the foundation the entire suite stands on, so a subtle
 difference in `is`/`is-deeply`/`todo`/`subtest` semantics shows up as thousands
 of diffs at once. Sequence it deliberately:
 
-1. Implement the 9 ops, each with a `t/nqp-*.t` pin. They are independently
-   useful — `getstdout`/`getstderr`/`eqaddr`/`can` show up in other real dists.
+1. ~~Implement the 9 ops, each with a `t/nqp-*.t` pin. They are independently
+   useful — `getstdout`/`getstderr`/`eqaddr`/`can` show up in other real
+   dists.~~ **DONE** — `src/runtime/nqp_ops_process.rs`, pinned by
+   `t/nqp-process-ops.t`
+   (`news/2026-08/nqp-process-ops-for-the-real-test-module.md`). One extra fix
+   was needed: a no-paren zero-arg `nqp::` term was special-cased for
+   `gethostname` alone, so bare `nqp::time` — written on ~40 lines of
+   `Test.rakumod` — raised "Could not find symbol '&time' in 'nqp'". With the
+   ops in, `plan`/`ok`/`is`/`isnt`/`is-deeply`/`subtest` from the unmodified
+   upstream file all produce correct TAP.
 2. Vendor `Test.rakumod` verbatim to `modules/Rakudo-Core/lib/Test.rakumod` but
    **do not** remove the interception yet; exercise it under a temporary alias
    against a representative sample of `t/` and roast.
@@ -73,6 +81,37 @@ of diffs at once. Sequence it deliberately:
    thing and already loaded from source — check it still composes.
 
 Do not start this in the same PR as anything else.
+
+## Blocker found while doing step 1: the native provider shadows an import
+
+Step 2's "exercise it under a temporary alias" does not work yet, and the
+reason is a general bug rather than anything about `Test`. `exec_call`
+(`src/runtime/calls.rs:301`) dispatches every name in
+`is_test_function_name()` to `call_test_function` **before** user-routine
+resolution and **without any gate at all** — not even the
+`loaded_modules.contains("Test")` gate its sibling in
+`builtins_operators_fallback.rs:230` applies. So a module that exports its own
+`ok`/`is`/`plan`/... is silently overruled by mutsu's native TAP routines:
+
+```
+$ mutsu -I tmp/core -e 'use Test2; plan 3; ok 1, "first"; zlike("hi", /h/, "z"); ok 1, "third"'
+1..3            # module's plan
+ok 1 - first    # mutsu's NATIVE ok  <-- wrong routine
+ok 1 - zlike    # module's zlike -> module's proclaim, its own counter at 1
+ok 2 - third    # native ok again
+```
+
+The two implementations then keep separate counters, which looks exactly like a
+stale module lexical and costs an hour to misdiagnose — the tell is that the
+module's own `proclaim` is entered only once. `like`/`unlike` are not affected
+only because their argument shapes make the native handler decline.
+
+The fix is the rule from
+`news/2026-07/qualified-call-no-longer-aliases-a-builtin.md`: decide on
+*whether a declaration exists*, not on whether the name is a builtin. A
+user-declared or imported routine must win over the native provider. Do this
+before step 2 — with `use Test` intercepted natively there is no declaration to
+compete with, so the guard cannot regress the ordinary path.
 
 ## Reproducing the measurement in one minute
 


### PR DESCRIPTION
Step 1 of `todo/tickets/vendor-real-test-module.md`.

mutsu provides `Test` natively (`src/runtime/test_functions/`), which is
BATTERIES.md rung 3 applied to a module upstream ships as ordinary Raku
source. The ticket measured that `rakudo-2026.06/lib/Test.rakumod` already
parses and loads on mutsu and needs only a handful of thin `nqp::` ops to
actually run. This PR lands those ops with a pin. **Nothing about the `Test`
provider itself changes yet** — that is deliberately a later step.

## What is implemented

New `src/runtime/nqp_ops_process.rs` (the process/introspection half of the
value-op table; `nqp_ops.rs` was already at the 500-line limit):

| op | what it is |
| --- | --- |
| `getstdout` / `getstderr` / `getstdin` | the **process** standard handles, found by target in the VM handle table rather than through `$*OUT`/`$*ERR`/`$*IN` — nqp code reaches for them precisely to bypass a dynamic override |
| `setbuffersizefh` | set a handle's output buffer capacity (`0` = unbuffered), the same state `$fh.out-buffer = $n` sets, so pending bytes flush first |
| `time` | wall clock as integer **nanoseconds** since the epoch |
| `eqaddr` | object identity as an int `0`/`1` — the relation `=:=` implements |
| `can` | int `0`/`1`: does this object have that method |
| `join` / `split` | literal join/split over an nqp list, no regex and no Raku `split` adverbs |

`can`, `join`, `split` and `time` each collide with a same-named Raku builtin
of *different* semantics, so they are real full-name `nqp::` arms rather than a
relaxation of the aliasing guard in `builtins_operators_fallback.rs`; that
guard stays exactly as strict as it was.

## One parser-side fix

A no-paren zero-argument `nqp::` term was special-cased for `nqp::gethostname`
alone, so bare `nqp::time` — written on ~40 lines of `Test.rakumod` — raised
`Could not find symbol '&time' in 'nqp'`. The whole reserved `nqp::` namespace
now dispatches through the op table in term position. An op mutsu does not
implement still fails loudly.

## Result

With these, the unmodified upstream file runs:

```
$ mutsu -I <dir> -e 'use Test2; plan 3; ok 1, "ok works"; is 2+2, 4, "is works"; is "a","a","str"'
1..3
ok 1 - ok works
ok 2 - is works
ok 3 - str
```

`plan`/`ok`/`nok`/`is`/`isnt`/`is-deeply`/`subtest` all produce correct TAP.

## Tests

`t/nqp-process-ops.t` (25 assertions) pins each op against its **nqp** meaning,
including the `diag` indentation idiom `Test.rakumod` uses and the fact that
`getstdout` ignores a rebound `$*OUT`. `make test` is green (the only failure
locally is an unrelated untracked WIP file from an earlier session).

The second commit marks step 1 of the ticket done and records the blocker step
1 surfaced: `exec_call` dispatches every `is_test_function_name()` name to the
native TAP routines before user-routine resolution and without any gate, so a
module exporting its own `ok`/`is`/`plan` is silently overruled. That is a
separate general bug and gets its own PR.