### PR TITLE
fix(runtime): an imported test routine beats the native Test provider

### DIFF
--- a/news/2026-08/imported-test-routines-beat-the-native-provider.md
+++ b/news/2026-08/imported-test-routines-beat-the-native-provider.md
@@ -1,0 +1,45 @@
+# An imported `ok`/`is`/`plan` beats mutsu's native Test provider
+
+mutsu implements the `Test` module natively (`src/runtime/test_functions/`) and
+intercepts `use Test`, so no `.rakumod` is ever loaded for it. The
+statement-call path (`exec_call`) dispatched **every** name in
+`is_test_function_name()` to those Rust routines *before* resolving user
+routines, and without any gate at all — not even the
+`loaded_modules.contains("Test")` check its sibling in
+`builtins_operators_fallback.rs` applies. A module that exports its own `ok` was
+therefore silently overruled.
+
+It is a nasty failure to diagnose, because the two implementations then keep
+separate counters. Loading rakudo's real `Test.rakumod` under an alias produced:
+
+```
+1..3
+ok 1 - first     <- mutsu's native handler
+ok 1 - like      <- the module's own routine, its own counter
+ok 2 - third     <- the native handler again
+```
+
+which reads as a stale module lexical, not as two live implementations. The
+module's own `proclaim` being entered exactly once is the tell.
+
+The rule applied is the one from
+`news/2026-07/qualified-call-no-longer-aliases-a-builtin.md`: decide on whether
+a **declaration** exists, not on whether the name is a builtin. An imported or
+user-declared routine that can accept the call's arguments now wins. `use Test`
+registers no routines, so the ordinary path has nothing to compete with and is
+unchanged — pinned both ways by `t/test-fn-import-shadow.t`.
+
+The guard is scoped to the `Test` module's own export list, which moved to
+`runtime::TEST_MODULE_EXPORTS` as the single copy (the parser and
+`system_eval_string` each had their own identical literal; a name present in one
+list and missing from another would now dispatch inconsistently, so one copy is
+load-bearing rather than tidy). `is_test_function_name` is deliberately wider —
+it also covers roast's `Test::Util` / `Test::Tap` helpers, which come from
+modules that really are loaded from source. Widening the guard to those too was
+measured (all 228 whitelisted roast files that `use Test::Util`) and needs two
+unrelated fixes first; both are written up in
+`todo/tickets/retire-native-test-util-overrides.md`.
+
+This is a prerequisite for step 2 of `todo/tickets/vendor-real-test-module.md`:
+exercising the genuine upstream `Test.rakumod` under a temporary alias only
+means anything once the alias's routines actually run.

--- a/news/2026-08/junction-thread-absorbs-a-matching-when.md
+++ b/news/2026-08/junction-thread-absorbs-a-matching-when.md
@@ -1,0 +1,28 @@
+# A matching `when` no longer aborts the rest of a `Junction.THREAD` loop
+
+`Junction.THREAD` calls its block once per eigenstate. A matching `when` inside
+that block leaves *the block* with a `succeed` control signal — but `.THREAD`'s
+loop propagated it as an ordinary error, so the remaining eigenstates were
+skipped and the enclosing routine unwound with the `when` body's value.
+
+```raku
+sub collect(Junction $j) {
+    my @seen;
+    $j.THREAD: {
+        when Junction { @seen.push: 'J' }
+        @seen.push: $_;
+    }
+    @seen;
+}
+say collect(any(all(1, 2), 3));   # raku: [J 3]   mutsu, before: never returned normally
+```
+
+Every other loop construct already absorbs `succeed` and continues with the next
+iteration (see the `for` body in `vm_for_loop_body.rs`); `.THREAD` now does the
+same. `for` over the same values was correct throughout, which is why this
+stayed hidden.
+
+It surfaced through roast's `Test::Util`, whose `is-deeply-junction` guts a
+junction with exactly this shape — recursively, so a nested `any(all(1,2), 3)`
+came back as just the `all` part. Pinned by `t/junction-thread-when.t`, which
+passes under `raku` as well.

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -645,41 +645,9 @@ fn is_default_export_from_regex_match_group(caps: &regex::Captures, group: usize
     }
 }
 
-/// Functions exported by `use Test`.
-/// Test functions are implemented natively in Rust (`test_functions.rs`),
-/// not loaded from a `.rakumod` file, so they must be hardcoded here.
-const TEST_EXPORTS: &[&str] = &[
-    "ok",
-    "nok",
-    "is",
-    "isnt",
-    "is-deeply",
-    "is-approx",
-    "cmp-ok",
-    "like",
-    "unlike",
-    "isa-ok",
-    "does-ok",
-    "can-ok",
-    "lives-ok",
-    "dies-ok",
-    "exits-ok",
-    "eval-lives-ok",
-    "eval-dies-ok",
-    "throws-like",
-    "fails-like",
-    "pass",
-    "flunk",
-    "skip",
-    "skip-rest",
-    "todo",
-    "diag",
-    "plan",
-    "done-testing",
-    "bail-out",
-    "subtest",
-    "use-ok",
-    "force_todo",
-    "force-todo",
-    "tap-ok",
-];
+/// Functions exported by `use Test`, re-exported from the runtime so the
+/// parser and the dispatcher cannot drift apart. Test functions are implemented
+/// natively in Rust (`runtime/test_functions/`), not loaded from a `.rakumod`
+/// file, so the set has to be spelled out somewhere; that somewhere is
+/// `runtime::TEST_MODULE_EXPORTS`.
+use crate::runtime::TEST_MODULE_EXPORTS as TEST_EXPORTS;

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -297,8 +297,33 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let (args, callsite_line) = self.sanitize_call_args(&args);
         self.test_pending_callsite_line = callsite_line;
-        // Delegate test functions to the unified test_functions.rs
-        if let Some(result) = self.call_test_function(name, &args)? {
+        // Delegate test functions to the unified test_functions.rs — unless a
+        // user routine of that name is declared and can take these arguments.
+        //
+        // This dispatch runs *before* user-routine resolution, so without the
+        // guard mutsu's native TAP routines silently overrule a module that
+        // exports its own `ok`/`is`/`plan`/... The two implementations then keep
+        // separate counters, which looks exactly like a stale module lexical:
+        // rakudo's real `Test.rakumod`, loaded under an alias, emitted `ok 1`
+        // for its first *and* second assertion because every other one had been
+        // answered by the native handler. `use Test` is intercepted natively and
+        // registers no routines, so the ordinary path has no declaration to
+        // compete with and is unaffected.
+        //
+        // Decide on whether a *declaration* exists, not on whether the name is a
+        // builtin — same rule as the qualified-call guard
+        // (news/2026-07/qualified-call-no-longer-aliases-a-builtin.md).
+        //
+        // Scoped to the `Test` module's own export list, NOT to every name in
+        // `is_test_function_name` (which also covers roast's `Test::Util` /
+        // `Test::Tap` helpers). Those modules really are loaded from source, so
+        // mutsu's natives override live declarations there today; flipping that
+        // is a separate provider retirement that needs `Proc::Async` output taps
+        // and `IO::Path ~~ IO::Path` fixed first — see
+        // todo/tickets/retire-native-test-util-overrides.md.
+        let user_declared = crate::runtime::is_test_module_export(name)
+            && self.user_function_matches_call(name, &args);
+        if !user_declared && let Some(result) = self.call_test_function(name, &args)? {
             return Ok(result);
         }
         match name {

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -174,6 +174,16 @@ impl Interpreter {
                     for value in values.iter() {
                         match self.call_sub_value(code.clone(), vec![value.clone()], false) {
                             Ok(_) => {}
+                            // A matching `when` inside the block leaves that
+                            // block with `succeed`. That ends the *eigenstate's*
+                            // iteration, not the THREAD loop — every loop
+                            // construct absorbs it the same way (see the `for`
+                            // body in vm_for_loop_body.rs). Propagating it
+                            // aborted the remaining eigenstates and unwound the
+                            // enclosing routine: Test::Util's
+                            // `is-deeply-junction` guts only the first
+                            // eigenstate of `any(all(1,2), 3)` without this.
+                            Err(e) if e.is_succeed() => {}
                             Err(e) => return Some(Err(e)),
                         }
                     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -366,6 +366,7 @@ mod system_eval_vars;
 mod system_introspect;
 mod tap_state;
 mod test_functions;
+pub(crate) use test_functions::{TEST_MODULE_EXPORTS, is_test_module_export};
 pub(crate) mod thread_compat;
 pub(crate) mod types;
 mod undeclared_routines;

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -173,42 +173,9 @@ impl Interpreter {
     }
 
     pub(crate) fn collect_eval_imported_function_names(&self) -> Vec<String> {
-        const TEST_EXPORTS: &[&str] = &[
-            "ok",
-            "nok",
-            "is",
-            "isnt",
-            "is-deeply",
-            "is-approx",
-            "cmp-ok",
-            "like",
-            "unlike",
-            "isa-ok",
-            "does-ok",
-            "can-ok",
-            "lives-ok",
-            "dies-ok",
-            "exits-ok",
-            "eval-lives-ok",
-            "eval-dies-ok",
-            "throws-like",
-            "fails-like",
-            "pass",
-            "flunk",
-            "skip",
-            "skip-rest",
-            "todo",
-            "diag",
-            "plan",
-            "done-testing",
-            "bail-out",
-            "subtest",
-            "use-ok",
-            "force_todo",
-            "force-todo",
-            "tap-ok",
-        ];
-        TEST_EXPORTS
+        // The `Test` module's own exports; the single copy lives in
+        // runtime::test_functions so the parser, EVAL and `exec_call` agree.
+        crate::runtime::TEST_MODULE_EXPORTS
             .iter()
             .map(|name| (*name).to_string())
             .collect()

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -11,6 +11,62 @@ mod util;
 use super::*;
 use crate::value::ValueView;
 
+/// The names `use Test` brings into scope — the export list of the `Test`
+/// module itself, which mutsu provides natively (`use Test` is intercepted, so
+/// no `.rakumod` is ever loaded and no routine is ever registered under these
+/// names).
+///
+/// The single copy: the parser registers exactly this set as `Test`'s exports,
+/// `system_eval_string` reports it as EVAL-visible, and `exec_call` uses it to
+/// decide when an *imported* routine of the same name must beat the native
+/// provider. Keeping one list is what makes that last decision sound — a name
+/// in one copy and not another would be dispatched inconsistently.
+///
+/// This is deliberately narrower than [`Interpreter::is_test_function_name`],
+/// which also covers the `Test::Util` / `Test::Tap` helpers. Those come from
+/// modules that really are loaded from source, so overriding them natively is a
+/// separate provider with its own retirement path.
+pub(crate) const TEST_MODULE_EXPORTS: &[&str] = &[
+    "ok",
+    "nok",
+    "is",
+    "isnt",
+    "is-deeply",
+    "is-approx",
+    "cmp-ok",
+    "like",
+    "unlike",
+    "isa-ok",
+    "does-ok",
+    "can-ok",
+    "lives-ok",
+    "dies-ok",
+    "exits-ok",
+    "eval-lives-ok",
+    "eval-dies-ok",
+    "throws-like",
+    "fails-like",
+    "pass",
+    "flunk",
+    "skip",
+    "skip-rest",
+    "todo",
+    "diag",
+    "plan",
+    "done-testing",
+    "bail-out",
+    "subtest",
+    "use-ok",
+    "force_todo",
+    "force-todo",
+    "tap-ok",
+];
+
+/// Whether `name` is one of the `Test` module's own exports.
+pub(crate) fn is_test_module_export(name: &str) -> bool {
+    TEST_MODULE_EXPORTS.contains(&name)
+}
+
 impl Interpreter {
     pub(crate) fn sync_eval_definition_state(&mut self, nested: &Interpreter) {
         self.type_metadata = nested.type_metadata.clone();

--- a/t/junction-thread-when.t
+++ b/t/junction-thread-when.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+# A matching `when` inside a `.THREAD` block leaves *that block* with `succeed`.
+# `.THREAD`'s loop propagated the signal instead of absorbing it, so the
+# remaining eigenstates were skipped and the enclosing routine unwound with the
+# `when` body's value. Every other loop construct already absorbs it (see the
+# `for` body in vm_for_loop_body.rs), and `for` over the same values was correct
+# throughout, which is why this stayed hidden.
+#
+# Found via roast's Test::Util `is-deeply-junction`, whose `junction-guts`
+# helper is written exactly this way: it gutted only the first eigenstate of
+# `any(all(1,2), 3)`.
+
+plan 6;
+
+sub collect(Junction $j) {
+    my @seen;
+    $j.THREAD: {
+        when Junction { @seen.push: 'J' }
+        @seen.push: $_;
+    }
+    @seen;
+}
+
+is-deeply collect(any(all(1, 2), 3)), ['J', 3],
+    'a matching `when` does not abort the rest of the THREAD loop';
+is-deeply collect(any(3, all(1, 2))), [3, 'J'],
+    'and not when the matching eigenstate comes last either';
+is-deeply collect(any(all(1, 2), all(3, 4))), ['J', 'J'],
+    'every eigenstate is visited when they all match';
+is-deeply collect(any(1, 2, 3)), [1, 2, 3],
+    'a block whose `when` never matches is unchanged';
+
+# The `when` body calling a routine was the shape that first showed the bug:
+# the leaked signal unwound the *caller* too, so `guts` returned early.
+sub guts(Junction $j) {
+    $j.gist ~~ /^ $<type>=(\w+)/;
+    my $type := ~$<type>;
+    my @g;
+    $j.THREAD: {
+        when Junction { @g.push: guts $_ }
+        @g.push: $_;
+    }
+    [$type, @g.sort.List]
+}
+
+is-deeply guts(any(all(1, 2), 3)), ['any', (3, ['all', (1, 2)])],
+    'a recursive gutting of a nested junction sees both eigenstates';
+is-deeply guts(all('a', 'b')), ['all', ('a', 'b')],
+    'and a flat junction still guts correctly';

--- a/t/lib/ShadowingTap.rakumod
+++ b/t/lib/ShadowingTap.rakumod
@@ -1,0 +1,25 @@
+unit module ShadowingTap;
+
+# A module that exports routines named exactly like the Test module's, to pin
+# that mutsu's *native* Test provider does not overrule an imported routine.
+# Every routine here prefixes its output so the pin can tell which
+# implementation answered the call. Used by t/test-fn-import-shadow.t.
+
+my $count = 0;
+
+multi sub plan($n) is export { say "MINE plan $n" }
+
+multi sub ok(Mu $cond, $desc = '') is export {
+    $count = $count + 1;
+    say $cond ?? "MINE ok $count - $desc" !! "MINE not ok $count - $desc";
+    ?$cond;
+}
+
+multi sub is(Mu $got, Mu $expected, $desc = '') is export {
+    $count = $count + 1;
+    say $got eqv $expected ?? "MINE ok $count - $desc" !! "MINE not ok $count - $desc";
+}
+
+sub diag($message) is export { say "MINE diag $message" }
+
+sub done-testing() is export { say "MINE done, ran $count" }

--- a/t/test-fn-import-shadow.t
+++ b/t/test-fn-import-shadow.t
@@ -1,0 +1,64 @@
+use v6;
+use Test;
+
+# mutsu provides the `Test` module natively (`src/runtime/test_functions/`), and
+# the statement-call path dispatched every name in `is_test_function_name()` to
+# those Rust routines BEFORE resolving user routines, and without any gate. So a
+# module exporting its own `ok`/`is`/... was silently overruled: the call went to
+# mutsu's TAP implementation instead.
+#
+# It is a nasty failure to diagnose, because the two implementations then keep
+# separate counters. Loading rakudo's real Test.rakumod under an alias produced
+#
+#     1..3
+#     ok 1 - first     <- native handler
+#     ok 1 - like      <- the module's own routine, its own counter
+#     ok 2 - third     <- native handler again
+#
+# which reads as a stale module lexical rather than as two live implementations.
+# (todo/tickets/vendor-real-test-module.md)
+#
+# The rule is the one from the qualified-call guard: decide on whether a
+# *declaration* exists, not on whether the name is a builtin. `use Test` is
+# intercepted natively and registers no routines, so the ordinary path has
+# nothing to compete with and is unaffected -- pinned below too.
+#
+# Run in a subprocess: importing the fixture here would shadow the very `ok`
+# this file's own assertions use.
+
+plan 6;
+
+my $exe = $*EXECUTABLE;
+
+sub run-snippet($code) {
+    my $r = run($exe, '-I', 't/lib', '-e', $code, :out, :err);
+    my $out = $r.out.slurp(:close);
+    my $err = $r.err.slurp(:close);
+    $r.exitcode == 0 ?? $out.trim !! "$out.trim() [exit {$r.exitcode}] $err.trim()"
+}
+
+is run-snippet('use ShadowingTap; ok 1, "a"; ok 0, "b"; done-testing'),
+    "MINE ok 1 - a\nMINE not ok 2 - b\nMINE done, ran 2",
+    'an imported `ok` wins over the native Test provider';
+
+is run-snippet('use ShadowingTap; plan 2; is 2, 2, "x"; is 1, 2, "y"'),
+    "MINE plan 2\nMINE ok 1 - x\nMINE not ok 2 - y",
+    'so do an imported `plan` and `is`';
+
+is run-snippet('use ShadowingTap; diag "hello"'), 'MINE diag hello',
+    'and an imported `diag`, which writes to stdout here rather than stderr';
+
+# The counters must stay in one implementation: the bug showed up as the
+# module's own counter falling behind because half the calls never reached it.
+is run-snippet('use ShadowingTap; ok 1, "a"; is 1, 1, "b"; ok 1, "c"; done-testing'),
+    "MINE ok 1 - a\nMINE ok 2 - b\nMINE ok 3 - c\nMINE done, ran 3",
+    'a mix of imported test routines shares one counter';
+
+# Regression guard: the ordinary `use Test` path is untouched.
+is run-snippet('use Test; plan 2; ok 1, "native"; is 3, 3, "native too"'),
+    "1..2\nok 1 - native\nok 2 - native too",
+    'plain `use Test` still reaches the native provider';
+
+is run-snippet('use Test; plan 1; ok 1, "still numbered from the native counter"'),
+    "1..1\nok 1 - still numbered from the native counter",
+    'and keeps numbering its own tests';

--- a/todo/tickets/retire-native-test-util-overrides.md
+++ b/todo/tickets/retire-native-test-util-overrides.md
@@ -1,0 +1,69 @@
+# Retire the native `Test::Util` / `Test::Tap` overrides — two bugs stand in the way
+
+`exec_call` now lets an *imported* routine beat mutsu's native Test provider,
+but only for the `Test` module's own export list
+(`runtime::TEST_MODULE_EXPORTS`). The rest of `Interpreter::is_test_function_name`
+— roast's `Test::Util` and `Test::Tap` helpers (`is_run`, `doesn't-hang`,
+`is-path`, `is-eqv`, `is-deeply-junction`, `make-temp-file`, `make-temp-dir`,
+`make-temp-path`, `group-of`, `doesn't-warn`, `warns-like`, `test-iter-opt`, …)
+— still dispatches to the native implementation *even though the module is
+really loaded from source* (`roast/packages/Test-Helpers/lib/Test/Util.rakumod`).
+
+That override is a live rung-3 provider over a module mutsu can already parse
+and load, so it should go the same way `Pod::To::Text` did. It was measured on
+2026-08-01 by widening the guard to every `is_test_function_name` name and
+running all 228 whitelisted roast files that `use Test::Util`. Exactly **two**
+files broke, each for one general interpreter bug:
+
+## 1. `IO::Path ~~ IO::Path` is always False (`roast/S32-io/io-path.t`)
+
+Test::Util's `is-path` is `cmp-ok $got.resolve, '~~', $exp.resolve, $desc`.
+
+```raku
+my $a = IO::Path::Unix.new('/foo/').add('bar');
+my $b = IO::Path::Unix.new('/foo/bar');
+say $a.resolve.raku eq $b.resolve.raku;   # True in both
+say $a.resolve ~~ $b.resolve;             # raku: True   mutsu: False
+```
+
+Rakudo's `IO::Path.ACCEPTS(IO::Path:D)` compares `.absolute`; mutsu falls
+through to a generic instance smartmatch. This one is small and independent of
+everything else here.
+
+## 2. A `Proc::Async` output tap is only drained by `await`-ing *that* promise (`roast/S17-supply/interval.t`)
+
+Test::Util's `doesn't-hang` accumulates the child's output in a `.stdout.tap`
+closure and then does `await Promise.anyof: Promise.in($wait), $prog.start`. On
+mutsu the tap never fires, so the `:out(/'Did not hang'/)` check sees `''`:
+
+```raku
+my $p = Proc::Async.new: $*EXECUTABLE.absolute, '-e', 'say "B"';
+my $s = '';
+$p.stdout.tap: -> $a { $s ~= $a };
+my $pr = $p.start;
+await Promise.anyof: Promise.in(10), $pr;
+say $s.raku;        # raku: "B\n"   mutsu: ""
+sleep 1; say $s.raku;   # mutsu: still "" — it is not a race
+await $pr; say $s.raku; # mutsu: "B\n" — the tap fires *here*
+```
+
+This is by construction: `native_supply_mut_methods.rs` marks a Proc::Async
+output supply `proc_output` and deliberately does **not** start a live-channel
+consumer for it, because delivery happens once, later, in `replay_proc_taps` —
+which is called only from `await`/`.result` when the awaited promise's own
+result is a `Proc` (`builtins_system_async.rs`, `methods_promise.rs`). A
+composite (`Promise.anyof`/`allof`) has no `Proc` result, so nothing replays.
+
+The shallow fix is to teach the composite to replay its components' proc taps.
+The real fix is that a tap should be *push*-delivered as the reader thread
+produces output, the way ADR-0008 made the other supplies push-based (#4636) —
+the "replay at await" design is what makes `.tap` observably different from
+`react`/`whenever` on the same stream. Beware `S17-procasync/basic.t` test 37,
+which the current comment cites as the reason delivery happens exactly once.
+
+## Order
+
+Fix 1 first (self-contained), then 2 (needs a design call, possibly an ADR
+amendment to 0008), then widen the guard in `runtime/calls.rs` from
+`is_test_module_export` to `is_test_function_name` and delete the native
+overrides that are then dead. `t/test-fn-import-shadow.t` is the pin to extend.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -82,10 +82,17 @@ of diffs at once. Sequence it deliberately:
 
 Do not start this in the same PR as anything else.
 
-## Blocker found while doing step 1: the native provider shadows an import
+## Blocker found while doing step 1: the native provider shadows an import — FIXED
 
-Step 2's "exercise it under a temporary alias" does not work yet, and the
-reason is a general bug rather than anything about `Test`. `exec_call`
+**Resolved** (`news/2026-08/imported-test-routines-beat-the-native-provider.md`,
+pin `t/test-fn-import-shadow.t`): an imported routine now beats the native
+provider for the `Test` module's own export list, so step 2's temporary alias
+runs its own routines. The `Test::Util` / `Test::Tap` half of the same rule is
+deferred to `todo/tickets/retire-native-test-util-overrides.md`, which does not
+block this ticket. Kept below because the symptom is so easy to misread.
+
+Step 2's "exercise it under a temporary alias" did not work, and the
+reason was a general bug rather than anything about `Test`. `exec_call`
 (`src/runtime/calls.rs:301`) dispatches every name in
 `is_test_function_name()` to `call_test_function` **before** user-routine
 resolution and **without any gate at all** — not even the
@@ -106,12 +113,11 @@ stale module lexical and costs an hour to misdiagnose — the tell is that the
 module's own `proclaim` is entered only once. `like`/`unlike` are not affected
 only because their argument shapes make the native handler decline.
 
-The fix is the rule from
+The fix was the rule from
 `news/2026-07/qualified-call-no-longer-aliases-a-builtin.md`: decide on
-*whether a declaration exists*, not on whether the name is a builtin. A
-user-declared or imported routine must win over the native provider. Do this
-before step 2 — with `use Test` intercepted natively there is no declaration to
-compete with, so the guard cannot regress the ordinary path.
+*whether a declaration exists*, not on whether the name is a builtin. With
+`use Test` intercepted natively there is no declaration to compete with, so the
+guard cannot regress the ordinary path.
 
 ## Reproducing the measurement in one minute
 


### PR DESCRIPTION
Prerequisite for step 2 of `todo/tickets/vendor-real-test-module.md`, found
while doing step 1.

## The bug

`exec_call` (`src/runtime/calls.rs`) dispatched **every** name in
`is_test_function_name()` to mutsu's native Test routines *before* resolving
user routines, and without any gate at all — not even the
`loaded_modules.contains("Test")` check its sibling in
`builtins_operators_fallback.rs` applies. A module that exports its own
`ok`/`is`/`plan` was silently overruled.

It is nasty to diagnose, because the two implementations then keep separate
counters. Loading rakudo's real `Test.rakumod` under an alias produced:

```
1..3
ok 1 - first     <- mutsu's native handler
ok 1 - like      <- the module's own routine, its own counter
ok 2 - third     <- the native handler again
```

which reads as a stale module lexical rather than as two live implementations.
The tell is that the module's own `proclaim` is entered exactly once.

## The fix

The rule from `news/2026-07/qualified-call-no-longer-aliases-a-builtin.md`:
decide on whether a **declaration** exists, not on whether the name is a
builtin. `use Test` is intercepted natively and registers no routines, so the
ordinary path has nothing to compete with and is unchanged (pinned both ways).

The guard is scoped to the `Test` module's own export list, which becomes the
single copy in `runtime::TEST_MODULE_EXPORTS` — the parser and
`system_eval_string` each carried an identical literal, and with this guard a
name present in one list and missing from another would dispatch
inconsistently, so one copy is load-bearing rather than tidy.

`is_test_function_name` stays wider on purpose: it also covers roast's
`Test::Util` / `Test::Tap` helpers, whose modules really are loaded from source,
so mutsu's natives override live declarations there. Widening the guard to
those too **was measured** — all 228 whitelisted roast files that `use
Test::Util` — and breaks exactly two files, each for one unrelated general bug
(`IO::Path ~~ IO::Path` always False; a `Proc::Async` output tap only drained by
`await`-ing that promise, not a composite). Both are written up with repros in
the new `todo/tickets/retire-native-test-util-overrides.md`.

## Second fix, surfaced by that measurement

A matching `when` inside a `Junction.THREAD` block leaves *that block* with
`succeed`; `.THREAD`'s loop propagated the signal instead of absorbing it, so
the remaining eigenstates were skipped and the enclosing routine unwound with
the `when` body's value. Every other loop construct already absorbs it (see the
`for` body in `vm_for_loop_body.rs`). `for` over the same values was correct
throughout, which is why it stayed hidden. It is real regardless of the guard's
scope, so it is fixed here.

## Tests

- `t/test-fn-import-shadow.t` (6) — imported `ok`/`is`/`plan`/`diag` win and
  share one counter; plain `use Test` still reaches the native provider. Runs
  the cases in a subprocess, because importing the fixture would shadow the very
  `ok` the file's own assertions use.
- `t/junction-thread-when.t` (6) — passes under `raku` as well.
- `make test` green; all 228 whitelisted `use Test::Util` roast files green.