### PR TITLE
fix(parser): a paren-less call argument may start with `!` or `?`

### DIFF
--- a/news/2026-08/listop-argument-may-start-with-a-boolean-prefix.md
+++ b/news/2026-08/listop-argument-may-start-with-a-boolean-prefix.md
@@ -1,0 +1,37 @@
+# A paren-less call argument may start with `!` or `?`
+
+A no-paren call whose first argument starts with a boolean prefix operator lost
+its entire argument list when the sub was declared *later* in the file:
+
+```raku
+sub caller-first { later !1, 2 }
+sub later($x, $y) { say "$x $y" }
+caller-first;   # raku: "False 2"
+                # mutsu: Calling later() ... Too few positionals passed; got 0
+```
+
+A forward reference does not satisfy `is_user_sub` at the point the call is
+parsed, so the parse falls through to the "does the next token start a term?"
+gate. That gate listed sigils, digits, quotes, `(`, hyper-prefix operators and
+slips — but not a boolean prefix. `later !1, 2` therefore parsed as *two*
+statements: a bare `later` term, and an unrelated `(!1, 2)` list. The same call
+written after the declaration always worked, which is why this survived.
+
+`!` and `?` are now accepted when the very next byte is a sigil, `(`, a quote or
+a digit. That is safe where a bare `+`/`-` is not (`pi - 1` must stay a
+subtraction): every Raku infix beginning with `!` or `?` continues with an
+operator character (`!=`, `!==`, `!~~`, `!=:=`, `??`, `?|`, `?&`, `?^`), and the
+negation-metaoperator forms (`!eq`, `!eqv`, `!before`) continue with a letter,
+so requiring a term character right after excludes all of them. Pinned by
+`t/listop-bool-prefix-arg.t`, which guards the infixes too and passes under
+`raku`.
+
+Found in rakudo's own `Test.rakumod`, where `unlike` is
+
+```raku
+my $ok := proclaim !($got ~~ $expected), $desc
+```
+
+with `proclaim` defined 200 lines further down — the third general interpreter
+bug on the way to running the genuine upstream module
+(`todo/tickets/vendor-real-test-module.md`).

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -49,6 +49,26 @@ fn starts_hyper_prefix_op(s: &str) -> bool {
     rest.starts_with('\u{00AB}') || rest.starts_with("<<")
 }
 
+/// A boolean prefix (`!` or `?`) directly followed by a term-starting
+/// sigil/paren/literal is an unambiguous argument start, so
+/// `proclaim !($got ~~ $rx), $desc` parses as a call even when `proclaim` is
+/// declared further down the file (a *forward*-declared sub does not satisfy
+/// `is_user_sub` at this point, so it falls through to this term-start gate).
+///
+/// Nothing else can appear here: every Raku infix that begins with `!` or `?`
+/// continues with an operator character (`!=`, `!==`, `!~~`, `!=:=`, `??`,
+/// `?|`, `?&`, `?^`), and the negation metaoperator forms (`!eq`, `!eqv`,
+/// `!before`) continue with a letter. Requiring the very next byte to be a
+/// sigil, an opening paren, a quote or a digit excludes all of them.
+fn starts_bool_prefix_arg(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix(['!', '?']) else {
+        return false;
+    };
+    rest.as_bytes().first().is_some_and(|b| {
+        matches!(b, b'(' | b'$' | b'@' | b'%' | b'&' | b'\'' | b'"') || b.is_ascii_digit()
+    })
+}
+
 /// A slip prefix (`|`) directly followed by a term-starting sigil/paren is an
 /// unambiguous argument start, so `unique |$x` / `min |@a` parse as a call with
 /// a flattened argument rather than reading `|` as the infix any-junction. The
@@ -1675,6 +1695,7 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             // (A bare `+`/`-` is left out on purpose: `pi - 1` must stay a
             // subtraction, which needs term-vs-listop knowledge we lack here.)
             || starts_hyper_prefix_op(r)
+            || starts_bool_prefix_arg(r)
             || starts_slip_prefix_arg(r)
             || starts_with_term_keyword(r)
             // A quote construct (`q:to/END/`, `qw<>`, `Q/…/`, …) starts a term,

--- a/t/listop-bool-prefix-arg.t
+++ b/t/listop-bool-prefix-arg.t
@@ -1,0 +1,55 @@
+use v6;
+use Test;
+
+# A paren-less call whose first argument starts with a boolean prefix (`!` or
+# `?`) used to lose its whole argument list when the sub is declared LATER in
+# the file. `is_user_sub` is false at that point, so the parse falls through to
+# the "does the next token start a term?" gate, which listed `$`, `@`, digits,
+# quotes, `(` ... but not a prefix operator. `later !1, 2` therefore parsed as
+# two statements — a bare `later` term and an unrelated `(!1, 2)` list — and the
+# call died with "Too few positionals passed ... got 0".
+#
+# rakudo's own Test.rakumod hits this in `unlike`:
+#     my $ok := proclaim !($got ~~ $expected), $desc
+# with `proclaim` defined 200 lines further down
+# (todo/tickets/vendor-real-test-module.md).
+#
+# `!`/`?` are safe to add where a bare `+`/`-` is not: every Raku infix starting
+# with them continues with an operator character (`!=`, `!~~`, `??`, `?|`, ...)
+# and the negation metaops (`!eq`) continue with a letter, so requiring a sigil,
+# paren, quote or digit right after excludes all of them.
+
+plan 12;
+
+my $one = 1;
+
+sub call-bang-paren  { later-a !($one == 2), 'b' }
+sub call-bang-lit    { later-a !1, 'b' }
+sub call-bang-var    { later-a !$one, 'b' }
+sub call-query-paren { later-a ?($one == 2), 'b' }
+sub call-query-var   { later-a ?$one, 'b' }
+sub call-query-lit   { later-a ?0, 'b' }
+
+sub later-a($x, $y) { "$x.raku()/$y" }
+
+is call-bang-paren,  'Bool::True/b',  'prefix ! on a paren group opens the argument list';
+is call-bang-lit,    'Bool::False/b', 'prefix ! on a literal does too';
+is call-bang-var,    'Bool::False/b', 'prefix ! on a variable does too';
+is call-query-paren, 'Bool::False/b', 'prefix ? on a paren group does too';
+is call-query-var,   'Bool::True/b',  'prefix ? on a variable does too';
+is call-query-lit,   'Bool::False/b', 'prefix ? on a literal does too';
+
+# A sub declared BEFORE the call always worked; keep it that way.
+sub later-b($x, $y) { "$x.raku()/$y" }
+is (later-b !$one, 'b'), 'Bool::False/b', 'a backwards reference is unchanged';
+
+# Regression guards: the infixes that start with the same characters must not be
+# swallowed as a prefixed argument.
+is (5 != 3), True, 'infix != still parses';
+is (5 !~~ Str), True, 'infix !~~ still parses';
+is (1 ?| 0), True, 'infix ?| still parses';
+is ($one == 1 ?? 'yes' !! 'no'), 'yes', 'the ?? !! ternary still parses';
+
+# `elems - 1` style: a bare `-`/`+` stays an infix on a term, deliberately not
+# covered by this gate.
+is (pi - 1).Int, 2, 'a bare - after a term is still subtraction';


### PR DESCRIPTION
Third general bug on the way to running rakudo's real `Test.rakumod`
(`todo/tickets/vendor-real-test-module.md`), and independent of it.

## The bug

A no-paren call whose first argument starts with a boolean prefix operator lost
its **entire** argument list when the sub was declared *later* in the file:

```raku
sub caller-first { later !1, 2 }
sub later($x, $y) { say "$x $y" }
caller-first;
# raku:  False 2
# mutsu: Calling later() will never work with declared signature ($x, $y)
#          Too few positionals passed; expected 2 arguments but got 0
```

A forward reference does not satisfy `is_user_sub` at the point the call is
parsed, so the parse falls through to the "does the next token start a term?"
gate in `identifier_call.rs`. That gate lists sigils, digits, quotes, `(`,
hyper-prefix operators and slips — but not a boolean prefix. `later !1, 2`
therefore parsed as *two* statements: a bare `later` term and an unrelated
`(!1, 2)` list. The same call written after the declaration always worked, which
is why it survived.

## The fix

Accept `!`/`?` when the very next byte is a sigil, `(`, a quote or a digit.

That is safe where a bare `+`/`-` is not (the gate's existing comment explains
why `pi - 1` must stay a subtraction): every Raku infix beginning with `!` or
`?` continues with an **operator** character — `!=`, `!==`, `!~~`, `!=:=`, `??`,
`?|`, `?&`, `?^` — and the negation-metaoperator forms (`!eq`, `!eqv`,
`!before`) continue with a **letter**. Requiring a term character immediately
after excludes all of them.

## Where it came from

rakudo's `Test.rakumod` writes `unlike` as

```raku
my $ok := proclaim !($got ~~ $expected), $desc
```

with `proclaim` defined 200 lines further down, so `unlike` was the first
assertion of the real module that mutsu could not call.

## Tests

`t/listop-bool-prefix-arg.t` (12) — the six prefixed-argument shapes, a
backwards reference for contrast, and regression guards that `!=`, `!~~`, `?|`,
the `?? !!` ternary and a bare infix `-` after a term still parse. Passes under
`raku` too.

`make test` green. The **full roast whitelist** (1435 files) was run locally on
this branch and is green.