### PR TITLE
fix(parser): `item` parses as a listop, so `item [1,2,3]` keeps its argument

### DIFF
--- a/news/2026-08/item-is-a-listop.md
+++ b/news/2026-08/item-is-a-listop.md
@@ -1,0 +1,28 @@
+# `item` parses as a listop, so `item [1,2,3]` keeps its argument
+
+`item` was missing from the parser's listop table, so only the parenthesized
+form worked. Written paren-less it swallowed nothing: `item [1, 2, 3]` parsed as
+a bare word `item` with the array literal stranded, and `@vars.push: item [...]`
+pushed the **string** `"item"`.
+
+```raku
+my @v; @v.push: item [1,2,3]; say @v.raku
+# raku:  [[1, 2, 3],]
+# mutsu: ["item"]
+```
+
+Found in rakudo's own `Test.rakumod`, which saves and restores its module state
+around every `subtest` exactly that way:
+
+```raku
+sub _push_vars { @vars.push: item [$subtest_callable_type, $num_of_tests_run, …] }
+sub _pop_vars  { ($subtest_callable_type, $num_of_tests_run, …) = @(@vars.pop) }
+```
+
+so each `subtest` restored garbage and the outer test counter fell back to 1 —
+the fourth general interpreter bug on the way to running the genuine upstream
+module (`todo/tickets/vendor-real-test-module.md`). The list assignment in
+`_pop_vars` was fine all along; only the snapshot was.
+
+Pinned by `t/item-listop.t`, which includes the save/restore shape and a guard
+that a bareword `item => 1` pair key still parses. Passes under `raku` too.

--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -228,6 +228,11 @@ pub(crate) fn is_listop(name: &str) -> bool {
             | "times"
             | "undefine"
             | "unlink"
+            // `item $x` / `item [1,2,3]` — the item-context coercion. Without
+            // it, `@vars.push: item [...]` (rakudo's own Test.rakumod saves its
+            // state that way) parsed `item` as a bare word and dropped the
+            // array literal entirely.
+            | "item"
     ) || is_expr_listop(name)
 }
 

--- a/t/item-listop.t
+++ b/t/item-listop.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+# `item` was missing from the parser's listop table, so the paren-less form
+# dropped its argument: `item [1,2,3]` parsed as the bare word `item` with the
+# array literal stranded, and `@vars.push: item [...]` pushed the string
+# "item". `item($x)` (with parens) always worked, which is why it went
+# unnoticed.
+#
+# rakudo's own Test.rakumod saves its module state that way
+#     sub _push_vars { @vars.push: item [$num_of_tests_run, ...] }
+# so every `subtest` restored garbage and the outer test counter reset to 1
+# (todo/tickets/vendor-real-test-module.md).
+
+plan 9;
+
+is (item [1, 2, 3]).raku, '$[1, 2, 3]', 'item on an array literal itemizes it';
+is (item 5), 5, 'item on a literal is the literal';
+my $x = 3;
+is (item $x), 3, 'item on a variable is its value';
+is item(5), 5, 'the parenthesized form is unchanged';
+
+my @v;
+@v.push: item [1, 2, 3];
+is @v.elems, 1, 'an itemized array pushes as ONE element';
+is-deeply @(@v.pop), [1, 2, 3], 'and comes back out as the array';
+
+# The save/restore shape from Test.rakumod: push a snapshot of several
+# variables, clobber them, then restore by list assignment.
+my @saved;
+my ($a, $b, $c) = 1, 2, 'x';
+@saved.push: item [$a, $b, $c];
+($a, $b, $c) = 9, 99, 'y';
+is "$a $b $c", '9 99 y', 'the variables really were clobbered';
+($a, $b, $c) = @(@saved.pop);
+is "$a $b $c", '1 2 x', 'and the snapshot restores every one of them';
+
+# `item` stays available as an ordinary identifier elsewhere.
+my %h = item => 1;
+is %h<item>, 1, 'a bareword `item` pair key still parses as a pair';


### PR DESCRIPTION
Fourth general bug on the way to running rakudo's real `Test.rakumod`
(`todo/tickets/vendor-real-test-module.md`), and independent of it.

## The bug

`item` was missing from the parser's listop table, so only the parenthesized
form worked. Written paren-less it swallowed nothing — the argument was simply
dropped:

```raku
my @v; @v.push: item [1,2,3]; say @v.raku
# raku:  [[1, 2, 3],]
# mutsu: ["item"]        <- the bare word, array literal stranded

say (item [1,2,3]).raku
# raku:  $[1, 2, 3]
# mutsu: ===SORRY!===
```

## Where it came from

rakudo's `Test.rakumod` saves and restores its whole module state around every
`subtest` exactly that way:

```raku
sub _push_vars { @vars.push: item [$subtest_callable_type, $num_of_tests_run, …] }
sub _pop_vars  { ($subtest_callable_type, $num_of_tests_run, …) = @(@vars.pop) }
```

so each `subtest` restored garbage and the outer test counter fell back to 1.
The list assignment in `_pop_vars` was fine all along; only the snapshot was.

## The fix

Add `item` to `is_listop`. It is an ordinary one-argument coercion routine like
the `elems` / `defined` / `so` already there, and those already take a `[...]`
argument correctly — nothing else about the gate changes.

## Tests

`t/item-listop.t` (9) — the paren-less forms, the parenthesized form for
contrast, the full `_push_vars`/`_pop_vars` save/restore shape, and a guard that
a bareword `item => 1` pair key still parses as a pair. Passes under `raku` too.

`make test` green. The **full roast whitelist** (1435 files, run through
`scripts/run-roast-test.sh` as `make roast` does) is green on this branch.