### PR TITLE
docs: record what is left before rakudo's real Test module can be vendored

### DIFF
--- a/todo/tickets/caller-lexical-indirect-operator-lookup.md
+++ b/todo/tickets/caller-lexical-indirect-operator-lookup.md
@@ -1,0 +1,60 @@
+# `&CALLER::LEXICAL::("infix:<+>")` — indirect symbol lookup of an operator
+
+An indirect (computed-name) symbol lookup through the `CALLER::LEXICAL::`
+pseudo-package throws instead of resolving, and throws instead of returning a
+`Failure` when the symbol genuinely does not exist.
+
+```
+$ mutsu -e 'my $m = &CALLER::LEXICAL::("infix:<+>"); say $m.WHAT; say $m(2,3)'
+No such symbol 'LEXICAL::infix:<+>'
+  in block <unit> at -e line 1
+
+$ raku -e 'my $m = &CALLER::LEXICAL::("infix:<+>"); say $m.WHAT; say $m(2,3)'
+(Sub+{is-pure})
+5
+```
+
+Two separate things are missing:
+
+1. **Resolution.** `&CALLER::LEXICAL::("<string>")` should look the name up in
+   the caller's lexical scope, and an operator's canonical name
+   (`infix:<+>`, `infix:«le»`, …) has to resolve to the routine that implements
+   it — including mutsu's built-in operators, which are not ordinary registered
+   subs.
+2. **Absence is a `Failure`, not a throw.** raku returns an undefined `Failure`
+   for a name that is not there, which is what makes the `//` fallback chain
+   below work at all. mutsu raises immediately, so the chain never gets to try
+   its second and third forms.
+
+## Why it matters
+
+It is how rakudo's `Test.rakumod` turns `cmp-ok`'s string operator into a
+callable:
+
+```raku
+my $matcher = nqp::istype($op, Callable) ?? $op
+    !! &CALLER::LEXICAL::("infix:<$op>")                                     #1
+        // &CALLER::LEXICAL::("infix:«$op»")                                 #2
+        // &CALLER::LEXICAL::("infix:<$op.subst(/<?before <[<>]>>/, "\\", :g)>"); #3
+```
+
+The three forms exist precisely because #1 cannot express `<` and `>`; each is
+expected to *fail softly* so the next is tried. On mutsu the first one throws:
+
+```
+$ mutsu -I tmp/core -e 'use Test2; plan 1; cmp-ok 3, "<", 5, "cmp-ok"'
+No such symbol 'LEXICAL::infix:<\<>'
+  in sub cmp-ok at tmp/core/Test2.rakumod line 266
+```
+
+`cmp-ok` is the only assertion of the genuine upstream module that is blocked on
+this — everything else in the happy path already runs
+(`todo/tickets/vendor-real-test-module.md`).
+
+## Note on scope
+
+The pseudo-package machinery mutsu already has (`CALLER::`, `OUTER::`,
+`SETTING::`, `DYNAMIC::` are recognized in `is_interpreter_handled_function`)
+handles *static* names. This ticket is about the `::("...")` indirect form and
+about operator names specifically; a general `&CALLER::LEXICAL::($name)` for
+ordinary sub names is the easier half and is worth doing first.

--- a/todo/tickets/file-var-and-callframe-inside-a-module.md
+++ b/todo/tickets/file-var-and-callframe-inside-a-module.md
@@ -1,0 +1,92 @@
+# `$?FILE` inside a module names the main script, and `callframe` skips the module's frames
+
+Two related gaps in mutsu's compile-time file constant and its runtime frame
+stack. Together they defeat any routine that answers "where was I called from,
+outside my own file" — the standard shape for a test-assertion library's failure
+report.
+
+## Repro
+
+`tmp/core/CF2.rakumod`:
+
+```raku
+unit module CF2;
+
+sub inner-report() {
+    my int $level = 1;
+    say "MODULE \$?FILE = {$?FILE}";
+    loop {
+        my $f = callframe(++$level);
+        say "level $level: ", ($f.defined ?? "{$f.file} line {$f.line}" !! "(undefined)");
+        last if $level > 5 || !$f.defined;
+    }
+}
+
+sub report() is export { inner-report }
+```
+
+driven by `use CF2; report;`:
+
+```
+--- mutsu ---
+MODULE $?FILE = tmp/core/cf2.raku
+level 2: tmp/core/cf2.raku line 2
+level 3: tmp/core/cf2.raku line 1
+level 4: (undefined)
+
+--- raku ---
+MODULE $?FILE = /home/…/tmp/core/CF2.rakumod (CF2)
+level 2: /home/…/tmp/core/CF2.rakumod (CF2) line 13
+level 3: tmp/core/cf2.raku line 2
+level 4: tmp/core/cf2.raku line 1
+level 5: NQP::src/HLL/Compiler.nqp line 197
+level 6: NQP::src/HLL/Compiler.nqp line 423
+```
+
+1. **`$?FILE` is the main script inside a module.** It must be the file the
+   enclosing compilation unit was compiled from.
+2. **`callframe($n)` skips the module's own frames.** `report` (a frame in
+   `CF2.rakumod`) does not appear at all; level 2 is already the caller script.
+   Frame *lines* are also off by one against raku in a plain single-file chain
+   (`sub middle { inner }` reports the `inner` call site, not the `middle` one).
+3. `callframe` past the outermost frame returns an undefined value; raku keeps
+   going into the compiler's own frames. That difference is defensible on its
+   own, but callers written against raku (see below) walk until `.file` stops
+   matching, so an undefined value where raku still has a frame turns into a
+   `No such method 'file' for invocant of type 'Any'`.
+
+## Why it matters
+
+rakudo's `Test.rakumod` reports a failing test's location with exactly this
+walk (`sub proclaim`):
+
+```raku
+repeat {
+    $caller = callframe(++$level);
+} while $?FILE.ends-with($caller.file)
+     || $caller.file.ends-with($?FILE);
+```
+
+With `$?FILE` equal to the *script* rather than to `Test.rakumod`, the very
+first comparison matches the script frame, so the loop walks off the end of the
+stack and dies on `Any.file`. Running the genuine upstream module therefore
+works for every passing assertion and dies on the first failing one — see
+`todo/tickets/vendor-real-test-module.md`.
+
+```
+$ mutsu -I tmp/core -e 'use Test2; plan 1; ok 0, "deliberate failure"'
+1..1
+not ok 1 - deliberate failure
+No such method 'file' for invocant of type 'Any'
+  in sub proclaim at tmp/core/Test2.rakumod line 813
+```
+
+raku prints `# Failed test 'deliberate failure'` / `# at … line 3` instead.
+
+## Notes
+
+`$?FILE` is already correct for `--dump-ast`-visible mainline code and for the
+backtrace frames mutsu prints on an exception (`t/backtrace-module-file.t` pins
+that a sub defined in a used module reports the *module* file), so the module
+path is available at the point the constant is folded — the two mechanisms just
+do not share it. Start there rather than by changing `callframe`.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -74,13 +74,50 @@ of diffs at once. Sequence it deliberately:
    upstream file all produce correct TAP.
 2. Vendor `Test.rakumod` verbatim to `modules/Rakudo-Core/lib/Test.rakumod` but
    **do not** remove the interception yet; exercise it under a temporary alias
-   against a representative sample of `t/` and roast.
+   against a representative sample of `t/` and roast. **IN PROGRESS** — the
+   alias exercise has been run by hand (see "Where the alias stands" below) and
+   found four general interpreter bugs, all fixed, plus two that are not: an
+   unimplemented `&CALLER::LEXICAL::("infix:<…>")`
+   (`todo/tickets/caller-lexical-indirect-operator-lookup.md`) and a wrong
+   `$?FILE`/`callframe` inside a module
+   (`todo/tickets/file-var-and-callframe-inside-a-module.md`). Those two are
+   what remains before the file is worth vendoring.
 3. Only then flip `runtime_module.rs`, and expect the first full `make roast` to
    be the real review.
 4. `Test::Util` (roast's helper, `roast/packages/Test-Helpers/`) is a separate
    thing and already loaded from source — check it still composes.
 
 Do not start this in the same PR as anything else.
+
+## Where the alias stands (2026-08-01)
+
+Driving the unmodified upstream file under the `Test2` alias, **everything in
+the happy path already works**: `plan`, `ok`, `nok`, `is`, `isnt`, `is-deeply`,
+`like`, `unlike`, `isa-ok`, `does-ok`, `can-ok`, `dies-ok`, `lives-ok`,
+`is-approx`, `eval-dies-ok`, `eval-lives-ok`, `throws-like`, `subtest`, `todo`,
+`skip`, `pass`, `done-testing` — including nested subtests and the outer
+counter surviving them. Four general bugs were found and fixed getting there:
+
+| what | fix |
+| --- | --- |
+| the `nqp::` ops it needs, and bare `nqp::time` in term position | `news/2026-08/nqp-process-ops-for-the-real-test-module.md` |
+| mutsu's native Test provider overruling the module's own routines | `news/2026-08/imported-test-routines-beat-the-native-provider.md` |
+| `proclaim !($got ~~ $rx), $desc` losing its argument list (forward-declared sub, prefix-`!` argument) | `news/2026-08/listop-argument-may-start-with-a-boolean-prefix.md` |
+| `@vars.push: item [...]` dropping the array, so every `subtest` restored garbage | `news/2026-08/item-is-a-listop.md` |
+
+Two are left, each with its own ticket:
+
+- `cmp-ok` needs `&CALLER::LEXICAL::("infix:<$op>")` —
+  `todo/tickets/caller-lexical-indirect-operator-lookup.md`. It is the only
+  assertion still blocked.
+- A **failing** test dies in `proclaim`'s location report, because `$?FILE`
+  inside a module is the main script and `callframe` skips the module's frames
+  — `todo/tickets/file-var-and-callframe-inside-a-module.md`. Every passing
+  assertion is fine; the first failure raises
+  `No such method 'file' for invocant of type 'Any'`. This one is
+  load-bearing: a test framework that cannot report a failure is not usable.
+
+Neither is Test-specific, so both are worth fixing on their own terms.
 
 ## Blocker found while doing step 1: the native provider shadows an import — FIXED
 

--- a/todo/tickets/yamlish-grammar-layer.md
+++ b/todo/tickets/yamlish-grammar-layer.md
@@ -1,0 +1,42 @@
+# YAMLish fails in the YAML grammar itself (the layer after the dispatch blocker)
+
+Split out of `todo/tickets/yamlish-grammar-parse-dispatch.md` on 2026-07-26.
+That ticket's blocker is gone — the module loads, `Grammar.parse(...)` dispatches
+correctly, and the `.HOW` residue it also recorded is fixed
+(`news/2026-07/grammar-how-metaclass.md`). `YAMLish` now fails further in.
+
+## Measured 2026-07-26 (YAMLish 0.1.3 from the REA archive, `mutsu -I lib`)
+
+| file | ok | not ok |
+| --- | --- | --- |
+| `t/anchor-alias.rakutest` | 0 | 2 |
+| `t/basic.rakutest` | 0 | 7 |
+| `t/p5-tests.rakutest` | 1 | 8 |
+| `t/roundtrip.rakutest` | 9 | 13 |
+| `t/test-harness.rakutest` | 16 | 25 |
+
+`test-harness` reports `Couldn't parse YAML: Couldn't parse YAML`, i.e. the
+grammar's own failure path, so the parse is reaching real input and rejecting it
+rather than dying on a dispatch or load error.
+
+Get the dist with:
+
+```
+curl -sS https://raw.githubusercontent.com/raku/REA/main/META.json \
+  | python3 -c "import sys,json;[print(x['source-url']) for x in json.load(sys.stdin) if x.get('name')=='YAMLish' and x.get('version')=='0.1.3']"
+```
+
+## Why it is not a ticket-sized fix yet
+
+The YAML grammar is `lib/YAMLish.rakumod:150–783` — large, action-heavy, and
+almost certainly failing on several independent constructs rather than one. It
+needs the same treatment that worked for `Template::Mojo`: reduce the *real*
+grammar by deleting constructs until a small repro falls out, one failing shape
+at a time, rather than theorising from the first error line. Start with
+`basic.rakutest` (7 failures, no anchors/aliases involved) since it exercises
+the simplest documents.
+
+## Context
+
+`YAMLish` is the battery candidate for YAML (`docs/batteries/yaml.md`). Blockers
+#1 and #1.5 were fixed earlier; #2 (this file's parent) is now fixed too.


### PR DESCRIPTION
Documentation-only follow-up to today's four fixes.

Drove the unmodified upstream `rakudo-2026.06/lib/Test.rakumod` under a
temporary alias (step 2 of `todo/tickets/vendor-real-test-module.md`). **The
whole happy path already works** — `plan`, `ok`, `nok`, `is`, `isnt`,
`is-deeply`, `like`, `unlike`, `isa-ok`, `does-ok`, `can-ok`, `dies-ok`,
`lives-ok`, `is-approx`, `eval-dies-ok`, `eval-lives-ok`, `throws-like`,
`subtest`, `todo`, `skip`, `pass`, `done-testing`, including nested subtests and
the outer counter surviving them.

Two gaps remain. Both are general interpreter bugs rather than anything
Test-specific, so each gets its own ticket with a standalone repro:

- **`todo/tickets/caller-lexical-indirect-operator-lookup.md`** —
  `&CALLER::LEXICAL::("infix:<+>")` throws instead of resolving, and throws
  instead of returning a `Failure` when the symbol is absent. `cmp-ok`'s
  three-way `//` fallback chain therefore never gets past its first form, and
  `cmp-ok` is the only assertion still blocked.
- **`todo/tickets/file-var-and-callframe-inside-a-module.md`** — `$?FILE` inside
  a module names the *main script*, and `callframe($n)` skips the module's own
  frames. `proclaim`'s "where did this fail" walk compares the two, so it runs
  off the end of the stack and dies on `Any.file`. Every *passing* assertion is
  fine; the first **failing** one raises
  `No such method 'file' for invocant of type 'Any'`. Load-bearing: a test
  framework that cannot report a failure is not usable.

The vendoring ticket itself gains a "Where the alias stands" section with a
table of what was already fixed today (the `nqp::` process ops, the native
provider shadowing an import, the prefix-`!` listop argument, and `item` as a
listop) and marks step 2 in progress.