### PR TITLE
fix(vm): an END phaser sees the final value of a live lexical

### DIFF
--- a/news/2026-08/end-phaser-sees-live-lexicals.md
+++ b/news/2026-08/end-phaser-sees-live-lexicals.md
@@ -1,0 +1,77 @@
+# An END phaser sees the final value of a live lexical
+
+Raku's `END` is a closure over its enclosing lexical scope, so it observes the
+*final* value of every lexical it mentions. mutsu's `Env` is value-keyed rather
+than cell-keyed, so a registered END carries a captured copy of the env instead
+of a reference; the exit-time merge in `run.rs` then had to decide, per key,
+whether the captured copy or the live env was authoritative. It decided by
+comparing values:
+
+```rust
+// Overlay with captured value only if the captured value differs from the
+// original -- this indicates the captured value comes from a different
+// lexical scope (e.g. { my $a = 42; END { ... } }).
+if v != orig_v { self.env.insert_sym(*k, v.clone()); }
+```
+
+"Different value" is not evidence of "different variable", though — it is just
+as easily evidence that the *same* variable was assigned after the phaser was
+registered. So any lexical mutated after an END saw its registration-time value
+resurrected at exit:
+
+```raku
+# EndLive.rakumod
+unit module EndLive;
+my int $count;
+sub bump() is export { $count = $count + 1 }
+END { say "count=$count" }
+```
+
+`use EndLive; bump; bump; bump;` printed `count=0` instead of `count=3`.
+
+## Where it surfaced
+
+Rakudo's real `Test.rakumod` counts tests in exactly that shape — a module-scoped
+`my int $num_of_tests_run` bumped by `proclaim` — and its `END` block re-checks
+the count against the plan. Running the unmodified upstream module (step 2 of
+`todo/tickets/vendor-real-test-module.md`) therefore ended roughly a seventh of
+the sampled `t/` files with a spurious
+
+```
+# You planned 9 tests, but ran 6
+```
+
+and exit status 255, even though all nine `ok` lines had been emitted with the
+right numbers. The `ok` lines were printed from `proclaim`, which read the live
+value; only the END block read the resurrected copy. `lives-ok` / `dies-ok` were
+the usual trigger, because they are what pushed the counter far enough past the
+captured value for the mismatch to be visible.
+
+## The fix
+
+Decide on *identity*, not on value. `EndPhaser` is now a named struct carrying a
+`dead_keys` set alongside its body, env and package. A key enters `dead_keys` at
+the one moment that actually establishes "the captured copy is the last
+surviving binding of this name": when the declaring scope dies. The block-scope
+exit path already refreshed captured envs for phasers registered inside the
+block (`update_end_phaser_envs`); it now also hands that call the block's
+`block_declared` set, which is precisely the names the scope takes with it.
+
+At exit, the captured copy wins only for a key that is absent from the live env
+or listed in `dead_keys`. Every other captured name still refers to a live
+variable, so the live value wins — including mutations made after registration.
+`{ my $a = 42; END { say $a } }` still prints 42 with an outer `my $a = 1` in
+scope, because `$a` was frozen when the inner block ended.
+
+Pinned by `t/end-phaser-live-lexical.t`, whose five cases all produce identical
+output under `raku`. In the step-2 survey sample (301 `t/` files run against the
+vendored upstream `Test`), fully-clean files went from 198 to 255; the
+"planned N but ran M" family went from ~40 files to one.
+
+## Still open
+
+An `END` registered inside a sub, closing over that sub's *own* lexical, still
+reports the registration-time value: `sub f { my $x = 5; END { say $x }; $x = 7 }`
+prints 5 where Rakudo prints 7. That is the same bug family at a different scope
+— the named-sub return path has several exits and does not yet freeze/refresh —
+and is filed as `todo/tickets/end-phaser-in-a-sub-frame.md`.

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -49,7 +49,12 @@ impl Interpreter {
     pub(crate) fn push_end_phaser(&mut self, body: Vec<Stmt>) {
         let captured_env = self.env.clone();
         let package = self.current_package();
-        self.end_phasers.push((body, captured_env, package));
+        self.end_phasers.push(super::EndPhaser {
+            body,
+            env: captured_env,
+            package,
+            dead_keys: crate::runtime::NameSet::default(),
+        });
     }
 
     /// Return the number of currently registered END phasers.
@@ -57,16 +62,31 @@ impl Interpreter {
         self.end_phasers.len()
     }
 
-    /// Update captured envs for END phasers registered since `start_idx`
-    /// with the current values from the given env.  This ensures that END
-    /// phasers see final variable values rather than stale copies captured
-    /// at registration time (e.g., inside closures or block scopes).
-    pub(crate) fn update_end_phaser_envs(&mut self, start_idx: usize, current_env: &Env) {
+    /// Freeze the END phasers registered since `start_idx` against a scope that
+    /// is about to die: refresh their captured values from that scope's final
+    /// env, and record `dying` as the keys the scope takes with it.
+    ///
+    /// A frozen key is the *only* surviving binding of that name for this
+    /// phaser, so at exit it wins over any live same-named variable further out
+    /// (`{ my $a = 42; END { say $a } }`). A key that is not frozen still names
+    /// a live variable, and the live value — including mutations made after
+    /// registration — is what the phaser must see.
+    pub(crate) fn update_end_phaser_envs(
+        &mut self,
+        start_idx: usize,
+        current_env: &Env,
+        dying: &crate::runtime::NameSet,
+    ) {
         for phaser in self.end_phasers[start_idx..].iter_mut() {
-            let captured = &mut phaser.1;
+            let captured = &mut phaser.env;
             for (k, v) in current_env {
                 if captured.contains_key_sym(*k) {
                     captured.insert_sym(*k, v.clone());
+                }
+            }
+            for k in dying {
+                if captured.contains_key_sym(*k) {
+                    phaser.dead_keys.insert(*k);
                 }
             }
         }
@@ -81,7 +101,7 @@ impl Interpreter {
         current_env: &Env,
     ) {
         for phaser in self.end_phasers.iter_mut() {
-            let captured = &mut phaser.1;
+            let captured = &mut phaser.env;
             for k in keys {
                 if captured.contains_key(k)
                     && let Some(v) = current_env.get(k)

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -107,8 +107,8 @@ impl Interpreter {
     /// stacks, and closure-capture overrides.
     fn visit_lexical_envs(&self, visitor: &mut dyn RootVisitor) {
         self.env.visit_values(visitor);
-        for (_, env, _) in &self.end_phasers {
-            env.visit_values(visitor);
+        for phaser in &self.end_phasers {
+            phaser.env.visit_values(visitor);
         }
         for env in self.closure_env_overrides.values() {
             env.visit_values(visitor);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -780,6 +780,31 @@ pub(crate) struct BuildWriteFrame {
     pub(crate) written: HashSet<crate::symbol::Symbol>,
 }
 
+/// A registered `END` phaser, held until program exit.
+///
+/// Raku's `END` is a closure over its enclosing lexical scope, so it must see
+/// the *final* value of every lexical it mentions. mutsu's `Env` is value-keyed
+/// rather than cell-keyed, so the body carries a captured copy instead; keeping
+/// that copy faithful is what `dead_keys` is for (see its doc comment).
+#[derive(Clone)]
+pub(crate) struct EndPhaser {
+    pub(crate) body: Vec<crate::ast::Stmt>,
+    /// The lexical env as of the moment the declaring scope died (or as of
+    /// registration, for a scope that is still alive at program exit).
+    pub(crate) env: Env,
+    /// The declaring package. END bodies run at program exit, long after
+    /// `current_package` has returned to GLOBAL — a phaser declared in a
+    /// `unit module Foo` must still see `Foo`'s routines by their bare names.
+    pub(crate) package: String,
+    /// Keys whose declaring scope has since died. At exit the captured value is
+    /// the only surviving one, so it must win over a live same-named variable
+    /// in an enclosing scope — `{ my $a = 42; END { say $a } }` prints 42 even
+    /// when an outer `my $a = 1` is what the exit-time env holds. Every other
+    /// captured key names a variable that is *still alive*, so the live value
+    /// wins and a later mutation is visible, as it is in Raku.
+    pub(crate) dead_keys: NameSet,
+}
+
 pub struct Interpreter {
     env: Env,
     /// Program output sink — stdout/stderr buffers, the immediate-flush flag,
@@ -972,11 +997,8 @@ pub struct Interpreter {
     /// a local before running the module body (so a transitive `use` inside the
     /// body cannot see them) and hands them to the module's `sub EXPORT`.
     pub(crate) pending_use_export_args: Option<Vec<Value>>,
-    /// Registered END phasers: `(body, captured lexical env, declaring package)`.
-    /// The package is captured because END bodies run at program exit, long after
-    /// `current_package` has returned to GLOBAL — a phaser declared in a
-    /// `unit module Foo` must still see `Foo`'s routines by their bare names.
-    end_phasers: Vec<(Vec<Stmt>, Env, String)>,
+    /// Registered END phasers, in registration order (they run in reverse).
+    end_phasers: Vec<EndPhaser>,
     /// Tracks END phaser site_ids to ensure each is registered only once.
     end_phaser_sites: HashSet<u64>,
     chroot_root: Option<PathBuf>,

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -627,35 +627,27 @@ impl Interpreter {
             // should propagate) and stale captured values (which should not
             // override live values).
             let original_env = self.env.clone();
-            for (body, captured_env, package) in phasers.iter().rev() {
+            for phaser in phasers.iter().rev() {
+                let (body, captured_env, package) = (&phaser.body, &phaser.env, &phaser.package);
                 // Track which keys are being added from captured env
                 // (not already present) so we can remove them after.
                 let mut overlay_keys: Vec<String> = Vec::new();
-                // Overlay captured lexical env on top of current env.
-                // For keys already in the current env, only overlay if the
-                // key was NOT in the original env (meaning it was injected
-                // by a prior END phaser's overlay, not a live program
-                // variable).  This preserves live values and prior-END
-                // modifications while still providing access to captured
-                // lexicals from dead scopes.
+                // Overlay the captured lexical env on top of the current one.
+                // The captured copy only wins for a name whose declaring scope
+                // is gone: either it is absent from the exit-time env entirely,
+                // or it was frozen when its scope died (`dead_keys`), so the
+                // live same-named variable is a *different* one. Every other
+                // captured name still refers to a live variable, and Raku's
+                // END — a closure over the container — sees that variable's
+                // final value, so the live value wins there.
                 for (k, v) in captured_env.iter() {
                     if !self.env.contains_key_sym(*k) {
                         overlay_keys.push(k.resolve());
                         self.env.insert_sym(*k, v.clone());
-                    } else if let Some(orig_v) = original_env.get_sym(*k) {
-                        // Key exists in both current and original env.
-                        // Overlay with captured value only if the captured
-                        // value differs from the original — this indicates
-                        // the captured value comes from a different lexical
-                        // scope (e.g. { my $a = 42; END { ... } }).
-                        if v != orig_v {
-                            self.env.insert_sym(*k, v.clone());
-                        }
-                        // If captured == original, it's the same variable —
-                        // keep the current (possibly mutated) value.
-                    } else {
-                        // Key was added by a prior END phaser's overlay.
-                        // Override with this phaser's captured value.
+                    } else if phaser.dead_keys.contains(k) || !original_env.contains_key_sym(*k) {
+                        // Frozen (dead declaring scope), or a key injected by a
+                        // prior END phaser's overlay — this phaser's capture is
+                        // the authoritative value either way.
                         self.env.insert_sym(*k, v.clone());
                     }
                 }

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -373,7 +373,7 @@ impl Interpreter {
         // be removed from env when the block scope is restored below).
         if self.end_phaser_count() > end_phaser_count_before {
             let current = self.env().clone();
-            self.update_end_phaser_envs(end_phaser_count_before, &current);
+            self.update_end_phaser_envs(end_phaser_count_before, &current, &block_declared);
         }
         let current_env = self.env().clone();
         let mut restored_env = saved_env.clone();

--- a/t/end-phaser-live-lexical.t
+++ b/t/end-phaser-live-lexical.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# An END phaser is a closure over its enclosing lexical scope, so it must see
+# the *final* value of every lexical it mentions -- not a copy taken when the
+# phaser was registered. The captured copy only wins for a name whose declaring
+# scope has since died, where it is the last surviving binding.
+#
+# The regression this pins: a module-scoped lexical mutated by the module's own
+# subs read back at its registration-time value inside the module's END block,
+# because the exit-time merge treated "captured value differs from the live one"
+# as proof that the two were different variables. Rakudo's real Test.rakumod
+# counts tests in exactly that shape, so its END reported "You planned N tests,
+# but ran M" on any file that called lives-ok/dies-ok.
+
+plan 5;
+
+my $dir = $*TMPDIR.child("mutsu-end-live-{$*PID}");
+$dir.mkdir;
+END { try { .unlink for $dir.dir; $dir.rmdir } }
+
+sub run-snippet($name, $source) {
+    my $file = $dir.child($name);
+    $file.spurt($source);
+    my $proc = run($*EXECUTABLE, $file.absolute, :out, :err);
+    my $out = $proc.out.slurp(:close);
+    $proc.err.slurp(:close);
+    $out.trim
+}
+
+# 1. A module lexical mutated through the module's own subs.
+my $mod = 'unit module EndLive;
+my int $count;
+sub bump() is export { $count = $count + 1 }
+END { say "count=$count" }
+';
+$dir.child('EndLive.rakumod').spurt($mod);
+
+my $use-mod = 'use lib "' ~ $dir.absolute ~ '";
+use EndLive;
+bump; bump; bump;
+';
+is run-snippet('mod.raku', $use-mod), 'count=3',
+    'an END in a module sees the module lexical final value';
+
+# 2. A mainline lexical mutated after the END was registered.
+my $mainline = 'my $b = 1;
+END { say "b=$b" }
+$b = 9;
+';
+is run-snippet('main.raku', $mainline), 'b=9',
+    'an END sees a mainline lexical mutated after registration';
+
+# 3. A dead block scope still wins over a live outer variable of the same name.
+my $dead = 'my $a = 1;
+{ my $a = 42; END { say "a=$a" } }
+';
+is run-snippet('dead.raku', $dead), 'a=42',
+    'an END in a dead block scope keeps that scope binding';
+
+# 4. Registration happens once even when the enclosing sub runs repeatedly, and
+#    the surviving phaser reads the shared lexical's final value.
+my $twice = 'my $n = 0;
+sub f { $n = $n + 1; END { say "n=$n" } }
+f(); f();
+';
+is run-snippet('twice.raku', $twice), 'n=2',
+    'an END registered inside a repeated sub runs once with the final value';
+
+# 5. Two ENDs run last-registered-first and share the live lexical, so the
+#    second one's write is visible to the first.
+my $lifo = 'my $d = 1;
+END { say "first d=$d" }
+END { say "second d=$d"; $d = 50 }
+$d = 7;
+';
+is run-snippet('lifo.raku', $lifo).lines.join('|'), 'second d=7|first d=50',
+    'ENDs run LIFO over one shared live lexical';

--- a/todo/tickets/end-phaser-in-a-sub-frame.md
+++ b/todo/tickets/end-phaser-in-a-sub-frame.md
@@ -1,0 +1,65 @@
+# An END phaser inside a sub reports its own frame's lexical at registration time
+
+```raku
+sub f { my $x = 5; END { say "x=$x" }; $x = 7 }
+f();
+```
+
+Rakudo prints `x=7`; mutsu prints `x=5`.
+
+This is the residue of `news/2026-08/end-phaser-sees-live-lexicals.md`. That fix
+made an END phaser read the *live* value of any lexical whose scope is still
+alive, and freeze the captured copy of any name whose declaring scope died — but
+it only wired the freeze/refresh into one scope-death site: the block-scope exit
+in `src/vm/vm_misc_scope.rs`, which hands `update_end_phaser_envs` the block's
+`block_declared` set.
+
+A sub frame dies elsewhere. `src/vm/vm_call_named_inner.rs` restores the caller
+env at three separate exits (lines ~121, ~186, and the main path at ~436-557,
+which itself forks into a `ptr_eq` fast path and a merge path), and
+`src/vm/vm_closure_dispatch.rs` restores at ~1160 where it refreshes only the
+closure's *captured* names (`update_end_phaser_envs_for_keys`) — a name the
+closure declared itself is not among them. So a phaser registered during a call
+never has its capture refreshed against the frame's final state, and the frame's
+own locals are never frozen.
+
+## What the fix looks like
+
+Same shape as the block-scope site, applied to the sub/closure return:
+
+1. Record `end_phaser_count()` when the frame is pushed.
+2. Just before the frame's env is swapped out — one insertion point ahead of
+   `let frame = self.pop_call_frame();` covers both branches of the main path —
+   call `update_end_phaser_envs(count_before, self.env(), &dying)` with `dying`
+   being the frame's own declared names (`cc.locals` plus the bound parameter
+   names, minus anything captured from an enclosing scope).
+3. Repeat for the early-exit paths at ~121 and ~186, or hoist them so they share
+   one exit.
+
+Both are guarded by `end_phaser_count() > count_before`, so a program with no
+END phaser pays one integer compare per call.
+
+## Why it was not done in the same PR
+
+The named-sub return path is the hottest code in the VM and has several exits
+with subtly different env-merge rules (`pop_caller_env` vs
+`pop_caller_env_with_writeback`, rw-binding application, the `ptr_eq` fast path).
+Getting the `dying` set wrong there does not fail loudly — it silently freezes a
+name that is still alive, which resurrects a stale value at exit: the exact class
+of bug the parent fix removed. It deserves its own PR and its own roast run.
+
+Nothing in the vendored upstream `Test.rakumod` depends on this shape (its END
+reads module-scoped lexicals, which the parent fix already covers), so it does
+not block `todo/tickets/vendor-real-test-module.md`.
+
+## Repro
+
+```bash
+printf 'sub f { my $x = 5; END { say "x=$x" }; $x = 7 }\nf();\n' > tmp/end-sub.raku
+raku tmp/end-sub.raku                    # x=7
+timeout 20 target/debug/mutsu tmp/end-sub.raku   # x=5
+```
+
+Case 3 of `t/end-phaser-live-lexical.t` is deliberately the *repeated-sub*
+variant (a shared outer lexical), not this one; add the sub-frame case to that
+file when this is fixed.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -75,8 +75,9 @@ of diffs at once. Sequence it deliberately:
 2. Vendor `Test.rakumod` verbatim to `modules/Rakudo-Core/lib/Test.rakumod` but
    **do not** remove the interception yet; exercise it under a temporary alias
    against a representative sample of `t/` and roast. **IN PROGRESS** — the
-   alias exercise has been run by hand (see "Where the alias stands" below) and
-   found four general interpreter bugs, all fixed, plus two that are not: an
+   alias exercise has been run both by hand (see "Where the alias stands" below)
+   and as a bulk sweep over a 1-in-9 sample of `t/` (see "Bulk sweep" below).
+   Five general interpreter bugs found and fixed, plus two that are not: an
    unimplemented `&CALLER::LEXICAL::("infix:<…>")`
    (`todo/tickets/caller-lexical-indirect-operator-lookup.md`) and a wrong
    `$?FILE`/`callframe` inside a module
@@ -96,7 +97,7 @@ the happy path already works**: `plan`, `ok`, `nok`, `is`, `isnt`, `is-deeply`,
 `like`, `unlike`, `isa-ok`, `does-ok`, `can-ok`, `dies-ok`, `lives-ok`,
 `is-approx`, `eval-dies-ok`, `eval-lives-ok`, `throws-like`, `subtest`, `todo`,
 `skip`, `pass`, `done-testing` — including nested subtests and the outer
-counter surviving them. Four general bugs were found and fixed getting there:
+counter surviving them. Five general bugs were found and fixed getting there:
 
 | what | fix |
 | --- | --- |
@@ -104,6 +105,25 @@ counter surviving them. Four general bugs were found and fixed getting there:
 | mutsu's native Test provider overruling the module's own routines | `news/2026-08/imported-test-routines-beat-the-native-provider.md` |
 | `proclaim !($got ~~ $rx), $desc` losing its argument list (forward-declared sub, prefix-`!` argument) | `news/2026-08/listop-argument-may-start-with-a-boolean-prefix.md` |
 | `@vars.push: item [...]` dropping the array, so every `subtest` restored garbage | `news/2026-08/item-is-a-listop.md` |
+| the module's `END` reading `$num_of_tests_run` at its registration-time value, so the plan check reported "You planned 9 tests, but ran 6" on a file that had emitted all nine `ok` lines | `news/2026-08/end-phaser-sees-live-lexicals.md` |
+
+## Bulk sweep (2026-08-01)
+
+The by-hand exercise above finds what the happy path needs; a bulk sweep finds
+what the *distribution* of real test files needs. Method: rewrite each `t/*.t`
+file's `use Test;` to `use Test2;`, run it with `-I tmp/core`, and classify the
+first failing line — over a 1-in-9 sample, 301 of 2704 files. Throwaway scripts:
+`tmp/core/classify.sh` (alias run + signature) and `tmp/core/sweep.sh` (diffs the
+aliased run against the same file's native-`Test` run, which is what you want
+when a signature is ambiguous).
+
+**198 / 301 files fully clean** at the start of the sweep, **255 / 301** after
+the END-phaser fix. The residue lines up exactly with the two open tickets above
+— 30 files on the `$?FILE`/`callframe` failure-report path and 7 on
+`No such method 'file'` — plus ~8 single-file `not ok`s that are ordinary
+pre-existing gaps rather than `Test` differences. Re-run the sweep after either
+open ticket lands; it is the cheapest way to see whether step 3 (flipping
+`runtime_module.rs`) is safe to attempt.
 
 Two are left, each with its own ticket:
 


### PR DESCRIPTION
Raku's `END` is a closure over its enclosing lexical scope, so it observes the *final* value of every lexical it mentions. mutsu's `Env` is value-keyed rather than cell-keyed, so a registered END carries a captured copy of the env; the exit-time merge in `run.rs` then decided, per key, whether the copy or the live env was authoritative — by comparing values:

```rust
// Overlay with captured value only if the captured value differs from the
// original -- this indicates the captured value comes from a different
// lexical scope (e.g. { my $a = 42; END { ... } }).
if v != orig_v { self.env.insert_sym(*k, v.clone()); }
```

"Different value" is not evidence of "different variable". It is just as easily evidence that the *same* variable was assigned after the phaser was registered, so any lexical mutated after an END saw its registration-time value resurrected at exit:

```raku
# EndLive.rakumod
unit module EndLive;
my int $count;
sub bump() is export { $count = $count + 1 }
END { say "count=$count" }
```

`use EndLive; bump; bump; bump;` printed `count=0` instead of `count=3`.

## The fix

Decide on *identity*, not on value. `EndPhaser` is now a named struct carrying a `dead_keys` set alongside its body, env and package. A key enters `dead_keys` at the one moment that actually establishes "the captured copy is the last surviving binding of this name": when the declaring scope dies. The block-scope exit path already refreshed captured envs for phasers registered inside the block; it now also hands that call the block's `block_declared` set, which is precisely the names the scope takes with it.

At exit, the captured copy wins only for a key absent from the live env or listed in `dead_keys`. Every other captured name still refers to a live variable, so the live value wins — including mutations made after registration. `{ my $a = 42; END { say $a } }` still prints 42 with an outer `my $a = 1` in scope, because `$a` was frozen when the inner block ended.

## Where it surfaced

Rakudo's real `Test.rakumod` counts tests in exactly that shape — a module-scoped `my int $num_of_tests_run` bumped by `proclaim` — and its `END` re-checks the count against the plan. Running the unmodified upstream module (step 2 of `todo/tickets/vendor-real-test-module.md`) ended roughly a seventh of the sampled `t/` files with a spurious

```
# You planned 9 tests, but ran 6
```

and exit 255, even though all nine `ok` lines had been emitted with the right numbers — `proclaim` read the live value, only the END block read the resurrected copy.

In that survey (301 `t/` files run against the vendored upstream `Test`) fully-clean files went from **198 to 255**, and the "planned N but ran M" family went from ~40 files to one. The survey's findings and the two remaining root causes are written up in `todo/tickets/vendor-real-test-module.md`.

## Tests

`t/end-phaser-live-lexical.t` — five cases (module lexical, mainline lexical mutated after registration, dead block scope shadowing an outer name, repeated sub, LIFO ordering over a shared lexical), all producing identical output under `raku`.

Local `make test` (2704 files, 25762 tests) and `make roast` (1435 files, 218774 tests) both PASS.

## Still open

An `END` registered inside a sub, closing over that sub's *own* lexical, still reports the registration-time value: `sub f { my $x = 5; END { say $x }; $x = 7 }` prints 5 where Rakudo prints 7. Same bug family at a scope this PR does not reach — the named-sub return path has several exits and getting its dying-key set wrong would silently resurrect stale values, so it gets its own PR: `todo/tickets/end-phaser-in-a-sub-frame.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)