### PR TITLE
feat: make Cro-style route DSL blocks work end-to-end

### DIFF
--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -401,61 +401,7 @@ fn scan_module_source(source: &str) -> ModuleScanResult {
     let mut enum_values: Vec<String> = transitive_enum_values;
     collect_module_enum_values(&stmts, &mut enum_values);
     let mut exports: HashMap<String, InlineModuleExport> = HashMap::new();
-    for stmt in &stmts {
-        match stmt {
-            Stmt::SubDecl {
-                name,
-                is_export,
-                export_tags,
-                associativity,
-                precedence_trait,
-                is_test_assertion,
-                ..
-            } if *is_export => {
-                // Only include subs that are in the DEFAULT or MANDATORY export tags.
-                // Subs tagged only with custom tags (e.g. :others) should not be
-                // imported by a plain `use Module`.
-                if export_tags
-                    .iter()
-                    .any(|t| t == "DEFAULT" || t == "MANDATORY")
-                {
-                    let precedence = precedence_trait.as_ref().and_then(|(trait_name, ref_op)| {
-                        resolve_op_precedence(ref_op).map(|ref_level| match trait_name.as_str() {
-                            "tighter" => ref_level + 5,
-                            "looser" => ref_level - 5,
-                            _ => ref_level,
-                        })
-                    });
-                    let resolved = name.resolve();
-                    exports.insert(
-                        resolved.clone(),
-                        InlineModuleExport {
-                            name: resolved,
-                            precedence,
-                            associativity: associativity.clone(),
-                            is_test_assertion: *is_test_assertion,
-                        },
-                    );
-                }
-            }
-            Stmt::ProtoDecl {
-                name, is_export, ..
-            } if *is_export => {
-                // ProtoDecl doesn't carry export_tags; proto declarations with
-                // `is export` default to DEFAULT so always include them.
-                let resolved = name.resolve();
-                exports
-                    .entry(resolved.clone())
-                    .or_insert(InlineModuleExport {
-                        name: resolved,
-                        precedence: None,
-                        associativity: None,
-                        is_test_assertion: false,
-                    });
-            }
-            _ => {}
-        }
-    }
+    collect_exported_subs(&stmts, &mut exports);
     // Fallback scan for modules that use syntax not yet fully covered by parse_program_partial.
     // This keeps imported exported-callables discoverable for statement-call parsing.
     for (name, is_test_assertion) in extract_exported_names_fallback(source) {
@@ -588,6 +534,74 @@ fn collect_module_type_names_under(stmts: &[Stmt], prefix: &str, out: &mut Vec<S
                 collect_module_type_names_under(body, &composed, out);
                 out.push(composed);
                 out.push(name);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Collect `is export` sub/proto declarations from a statement list,
+/// recursing into `module`/`package` (and class/role) bodies: exported subs
+/// routinely live inside a `module Foo { ... }` block (e.g. Cro::HTTP::Router's
+/// `multi route(&route-definition) is export`). The regex fallback misses the
+/// bare-`multi` form (no `sub` keyword), so the AST walk must see them.
+fn collect_exported_subs(stmts: &[Stmt], exports: &mut HashMap<String, InlineModuleExport>) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::SubDecl {
+                name,
+                is_export,
+                export_tags,
+                associativity,
+                precedence_trait,
+                is_test_assertion,
+                ..
+            } if *is_export => {
+                // Only include subs that are in the DEFAULT or MANDATORY export tags.
+                // Subs tagged only with custom tags (e.g. :others) should not be
+                // imported by a plain `use Module`.
+                if export_tags
+                    .iter()
+                    .any(|t| t == "DEFAULT" || t == "MANDATORY")
+                {
+                    let precedence = precedence_trait.as_ref().and_then(|(trait_name, ref_op)| {
+                        resolve_op_precedence(ref_op).map(|ref_level| match trait_name.as_str() {
+                            "tighter" => ref_level + 5,
+                            "looser" => ref_level - 5,
+                            _ => ref_level,
+                        })
+                    });
+                    let resolved = name.resolve();
+                    exports.insert(
+                        resolved.clone(),
+                        InlineModuleExport {
+                            name: resolved,
+                            precedence,
+                            associativity: associativity.clone(),
+                            is_test_assertion: *is_test_assertion,
+                        },
+                    );
+                }
+            }
+            Stmt::ProtoDecl {
+                name, is_export, ..
+            } if *is_export => {
+                // ProtoDecl doesn't carry export_tags; proto declarations with
+                // `is export` default to DEFAULT so always include them.
+                let resolved = name.resolve();
+                exports
+                    .entry(resolved.clone())
+                    .or_insert(InlineModuleExport {
+                        name: resolved,
+                        precedence: None,
+                        associativity: None,
+                        is_test_assertion: false,
+                    });
+            }
+            Stmt::Package { body, .. }
+            | Stmt::ClassDecl { body, .. }
+            | Stmt::RoleDecl { body, .. } => {
+                collect_exported_subs(body, exports);
             }
             _ => {}
         }

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -234,6 +234,58 @@ impl Interpreter {
             .cloned()
     }
 
+    /// Resolve a bare free-variable name through the enclosing package chain
+    /// (`M::R` -> `M`): a method of class `M::R` declared inside `module M`
+    /// lexically sees M's `our` variables and package-block `my` lexicals
+    /// (e.g. Cro::HTTP::Router's `our $link-plugin` read from RouteSet
+    /// methods). For each package prefix, the `our` store, the qualified env
+    /// key, and the `package_lexicals` store are consulted in that order.
+    /// Callers use this AFTER the live env misses, so an in-scope binding
+    /// always wins. Never falls through to the bare (GLOBAL) name — the
+    /// lexical alias for `our` is block-scoped.
+    pub(super) fn package_chain_var_fallback(&self, name: &str) -> Option<Value> {
+        if name.contains("::") {
+            return None;
+        }
+        let cur = self.current_package();
+        if cur.is_empty() || cur == "GLOBAL" || cur.contains("::&") {
+            return None;
+        }
+        let bare_first = name.trim_start_matches(['$', '@', '%', '&']);
+        let first_ch = bare_first.chars().next()?;
+        if matches!(first_ch, '_' | '/' | '!' | '?' | '*' | '.' | '=') || first_ch.is_ascii_digit()
+        {
+            return None;
+        }
+        let (sigil, rest) = match name.as_bytes().first() {
+            Some(b'$' | b'@' | b'%' | b'&') => (&name[..1], &name[1..]),
+            _ => ("", name),
+        };
+        let cur = cur.to_string();
+        let mut pkg: &str = &cur;
+        loop {
+            let candidate = format!("{sigil}{pkg}::{rest}");
+            if let Some(v) = self.get_our_var(&candidate).cloned() {
+                return Some(v);
+            }
+            if let Some(v) = self.get_env_with_main_alias(&candidate) {
+                return Some(v);
+            }
+            if let Some(v) = self
+                .package_lexicals
+                .get(pkg)
+                .and_then(|m| m.get(name))
+                .cloned()
+            {
+                return Some(v);
+            }
+            match pkg.rsplit_once("::") {
+                Some((parent, _)) => pkg = parent,
+                None => return None,
+            }
+        }
+    }
+
     /// Return the value of a bare package-block `my` lexical (`package P { my $x;
     /// sub f { $x } }`) recorded in `package_lexicals` by `exec_package_scope_op`.
     /// This store is the *authoritative* lexical scope a package's named subs close
@@ -988,6 +1040,18 @@ impl Interpreter {
             // sibling's. The per-write mirror (`flush_local_to_env`) keeps env
             // tracking the live slot instead. All-false with the gate off.
             if code.dup_named_locals.get(i).copied().unwrap_or(false) {
+                continue;
+            }
+            // Do not CREATE an env entry from a Nil slot: a package block's own
+            // lexical (`module M { our $plugin = ... }`) is deliberately dropped
+            // from env at scope exit (`exec_package_scope_op`) and its local slot
+            // restored to the pre-entry value (Nil). Broadcasting that Nil would
+            // resurrect the dropped name as a stale env shadow that later wins
+            // over the package-store fallbacks (a method of `M::R` reading
+            // `$plugin` got Nil instead of `M`'s `our` value). Updating an
+            // EXISTING entry with Nil stays allowed — only key creation is
+            // suppressed.
+            if self.locals[i].is_nil() && !self.env().contains_key(name) {
                 continue;
             }
             self.set_env_with_main_alias(name, self.locals[i].clone());

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -392,67 +392,13 @@ impl Interpreter {
                         }
                         self.get_env_with_main_alias(bare)
                     })
-                    .or_else(|| {
-                        // Bare-name fallback: when looking up an unqualified
-                        // name (e.g. `msg` or `$msg`) inside a routine whose
-                        // current_package is a real package (e.g. `Gee`), try
-                        // resolving via the package's `our` store. This makes
-                        // `our $msg` accessible from `our sub talk { $msg }`
-                        // when `talk` is invoked from outside the package.
-                        if name.contains("::") {
-                            return None;
-                        }
-                        let cur = self.current_package().to_string();
-                        if cur.is_empty() || cur == "GLOBAL" || cur.contains("::&") {
-                            return None;
-                        }
-                        // Skip special names that shouldn't be package-qualified.
-                        let bare_first = name.trim_start_matches(['$', '@', '%', '&']);
-                        if bare_first.is_empty() {
-                            return None;
-                        }
-                        let first_ch = bare_first.chars().next().unwrap();
-                        if matches!(first_ch, '_' | '/' | '!' | '?' | '*' | '.' | '=')
-                            || first_ch.is_ascii_digit()
-                        {
-                            return None;
-                        }
-                        let candidate = if let Some(rest) = name.strip_prefix('$') {
-                            format!("${cur}::{rest}")
-                        } else if let Some(rest) = name.strip_prefix('@') {
-                            format!("@{cur}::{rest}")
-                        } else if let Some(rest) = name.strip_prefix('%') {
-                            format!("%{cur}::{rest}")
-                        } else if let Some(rest) = name.strip_prefix('&') {
-                            format!("&{cur}::{rest}")
-                        } else {
-                            format!("{cur}::{name}")
-                        };
-                        self.get_our_var(&candidate)
-                            .cloned()
-                            .or_else(|| self.get_env_with_main_alias(&candidate))
-                    })
-                    .or_else(|| {
-                        // Package-block `my` lexical fallback: a named sub defined in
-                        // a `package Foo { my $x = ...; sub f { $x } }` block closes
-                        // over `$x`, but the block scope is dropped on exit and named
-                        // registry subs have no per-sub closure env. When `f` runs
-                        // by-name `current_package` is `Foo`, so resolve the miss via
-                        // the per-package store recorded by `exec_package_scope_op`.
-                        // Gated on `current_package` so it never leaks to bare refs
-                        // after the block (those run under `GLOBAL`).
-                        if name.contains("::") {
-                            return None;
-                        }
-                        let cur = self.current_package().to_string();
-                        if cur.is_empty() || cur == "GLOBAL" {
-                            return None;
-                        }
-                        self.package_lexicals
-                            .get(&cur)
-                            .and_then(|m| m.get(name))
-                            .cloned()
-                    })
+                    // Bare-name package-chain fallback: `our` variables and
+                    // package-block `my` lexicals of the enclosing package
+                    // chain (a named sub's `current_package` is its package; a
+                    // method's is its owner class, whose qualified name walks
+                    // up to the enclosing module). See
+                    // `package_chain_var_fallback`.
+                    .or_else(|| self.package_chain_var_fallback(name))
                     // Anonymous state variable (`$`): fall back to persisted
                     // state so the value survives across closure calls.
                     .or_else(|| self.anon_state_value(name))

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -39,10 +39,16 @@ impl Interpreter {
             match self.upvalues.get(index as usize) {
                 Some(Some(v)) => v.clone(),
                 // `None` entry (non-cell capture) or out-of-range (non-standard
-                // path): read the captured scalar live from env by name.
+                // path): read the captured scalar live from env by name. A
+                // method body has no upvalue array installed, so a free read of
+                // an enclosing module's `our`/block lexical lands here — resolve
+                // an env miss through the enclosing package chain
+                // (`package_chain_var_fallback`), mirroring GetGlobal.
                 _ => {
                     let name = Self::const_str(code, name_idx);
-                    self.get_env_with_main_alias(name).unwrap_or(Value::NIL)
+                    self.get_env_with_main_alias(name)
+                        .or_else(|| self.package_chain_var_fallback(name))
+                        .unwrap_or(Value::NIL)
                 }
             }
         };

--- a/t/lib/RouteBlockDsl.rakumod
+++ b/t/lib/RouteBlockDsl.rakumod
@@ -1,0 +1,33 @@
+module RouteBlockDsl {
+    # The Cro::HTTP::Router shape: module-body `our` initialized by a sub that
+    # news a class declared later, read back from a nested class's method.
+    our $plugin = reg('link');
+
+    class Key {
+        has Str $.id is required;
+    }
+
+    class Runner {
+        method !inner() {
+            describe($plugin, 'cfg')
+        }
+        method go() {
+            self!inner
+        }
+    }
+
+    sub reg(Str $id) {
+        RouteBlockDsl::Key.new(:$id)
+    }
+
+    sub describe(RouteBlockDsl::Key $key, $config) {
+        "got:" ~ $key.id ~ ":" ~ $config
+    }
+
+    # A bare `multi` (no `sub` keyword) DSL entry point, as Cro::HTTP::Router's
+    # `multi route(&route-definition, Str :$name) is export`.
+    multi dsl-run(&definition, Str :$name) is export {
+        definition();
+        "dsl:" ~ ($name // 'anon') ~ ":" ~ RouteBlockDsl::Runner.new.go
+    }
+}

--- a/t/route-block-dsl.t
+++ b/t/route-block-dsl.t
@@ -1,0 +1,29 @@
+use v6;
+use lib 't/lib';
+use RouteBlockDsl;
+use Test;
+
+plan 4;
+
+# A bare `multi name(...) is export` inside a `module ... { }` block must be
+# known to the importer's parser as a callable, so the listop-with-block form
+# parses as a call (Cro::HTTP::Router's `route { ... }`). Previously only
+# `sub`/`multi sub` forms were discovered, and `dsl-run { ... }` parsed as a
+# bareword followed by an orphan block.
+my $ran = False;
+my $result = dsl-run { $ran = True };
+ok $ran, 'block argument of an imported bare-multi DSL sub runs';
+
+# The module-body `our $plugin` must be visible from a method of a class
+# declared in the same module body, including after the module scope has
+# exited (resolved through the enclosing package chain, and not shadowed by
+# a stale Nil flushed at module-load frame exit).
+is $result, 'dsl:anon:got:link:cfg',
+    'method of nested class reads module-body our var';
+
+is dsl-run(:name<n1>, { 1 }), 'dsl:n1:got:link:cfg',
+    'named arg still binds alongside the block';
+
+# Direct method call from the importer, after load.
+is RouteBlockDsl::Runner.new.go, 'got:link:cfg',
+    'module our var readable from method called by importer';


### PR DESCRIPTION
## Summary

Stacked on #5658. Three fixes that together make `use Cro::HTTP::Router; my $app = route { get -> { content "text/plain", "hi" } }` evaluate to a `Cro::HTTP::Router::RouteSet`:

1. **Parser — discover bare-`multi` exports inside module blocks.** The AST-side export scan only looked at top-level statements, and the regex fallback requires the `sub` keyword, so `module M { multi route(&d, Str :$name) is export }` was invisible to the importer's parser: `route { ... }` parsed as a bareword followed by an orphan block ("No matching candidates for proto sub: route"). The scan now recurses into module/package/class/role bodies (`collect_exported_subs`).

2. **VM — resolve bare free-variable reads through the enclosing package chain** (`M::R` → `M`; new `package_chain_var_fallback`, used by the GetGlobal slow-path fallbacks and the GetUpvalue env fallback). A method of a class declared inside `module M` lexically sees M's `our` variables and package-block `my` lexicals, but the fallbacks only consulted the exact `current_package` (the owner class), so RouteSet methods read `$link-plugin` as Nil.

3. **VM — don't let the end-of-frame `sync_env_from_locals` CREATE an env entry from a Nil local slot.** A package block's own lexical is dropped from env at scope exit and its local slot restored to the pre-entry Nil; broadcasting that Nil at module-load frame exit resurrected the dropped name as a stale env shadow that won over the package-store fallbacks. Updating an existing entry with Nil stays allowed — only key creation is suppressed.

## Testing

- New `t/route-block-dsl.t` + fixture `t/lib/RouteBlockDsl.rakumod` reproducing the exact Cro::HTTP::Router shape (bare-multi DSL export, module-body `our` initialized before the class it constructs, read back from a nested class's private method) — 4/4, identical under `raku`.
- `make test`: all 25762 tests pass.
- Targeted roast: S10-packages (scope, joined-namespaces, export, use-with-class), S14-roles/parameterized-basic, S12-class/declaration-order — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)