### PR TITLE
docs: re-run the Test-vendoring sweep, and measure what cmp-ok actually needs

### DIFF
--- a/todo/tickets/caller-lexical-indirect-operator-lookup.md
+++ b/todo/tickets/caller-lexical-indirect-operator-lookup.md
@@ -58,3 +58,42 @@ The pseudo-package machinery mutsu already has (`CALLER::`, `OUTER::`,
 handles *static* names. This ticket is about the `::("...")` indirect form and
 about operator names specifically; a general `&CALLER::LEXICAL::($name)` for
 ordinary sub names is the easier half and is worth doing first.
+
+## Measured (2026-08-01): three independent pieces, and one of them is free
+
+`&`-sigil indirect lookup through a pseudo-package does not work *at all* today
+— not just for operators. It does not even reach the "no such symbol" answer:
+
+```
+$ mutsu -e 'sub f($a,$b) {$a*$b}; my $m = &MY::("f"); say $m(2,3)'
+Impossible coercion from 'Int' into 'Any': no acceptable coercion method found
+$ raku  -e 'sub f($a,$b) {$a*$b}; my $m = &MY::("f"); say $m(2,3)'
+6
+```
+
+So the work splits into three:
+
+1. **`&PSEUDO::("name")` must resolve at all.** The `&` + `SymbolicDeref` path
+   yields something that is not callable, hence the coercion error above. This
+   is the "easier half" named earlier and is a prerequisite for the rest.
+   `Interpreter::resolve_indirect_type_name`
+   (`src/runtime/accessors_stash.rs:142`) already strips a leading `&` and
+   returns `resolve_code_var`, so the gap is upstream of it: the pseudo-package
+   prefix is passed through as part of the name (`LEXICAL::infix:<+>`) instead
+   of selecting a scope.
+2. **Operator names must resolve — but the callable already exists.** `&infix:<+>`
+   as a *static* term works today (`my &f = &infix:<+>; say f(2,3)` prints 5), so
+   there is a mechanism that turns a built-in operator into a `Sub` value; the
+   indirect form only has to reach it. This is much cheaper than the original
+   note implied.
+3. **`LEXICAL::` has to include the setting.** `&MY::("infix:<+>")` is correctly
+   "no such symbol" in raku too — `infix:<+>` is not in the caller's own pad, it
+   is in CORE, and `LEXICAL::` reaches it because the lexical chain ends at the
+   setting. mutsu's `&LEXICAL::(...)` currently answers `(Any)` rather than
+   walking out that far.
+
+Absence-is-a-`Failure` is *already* implemented for the direct form
+(`no_such_symbol_failure` in the same file returns an `X::NoSuchSymbol` Failure,
+which is why `raku`'s own `say $m` on a missing name throws while `$m.defined`
+answers False). Once (1) routes through that function the third requirement
+comes along for free.

--- a/todo/tickets/callframe-line-and-file-come-from-different-frames.md
+++ b/todo/tickets/callframe-line-and-file-come-from-different-frames.md
@@ -1,0 +1,58 @@
+# `callframe(N)` takes its `.file` from the frame and its `.line` from the VM
+
+`push_caller_env` (`src/runtime/runtime_caller_env.rs`) builds each
+`CallFrameEntry` from two unrelated sources:
+
+```rust
+let file = self.executing_source_file().unwrap_or_default();  // the routine stack
+let line = self.cur_source_line;                              // the VM's line tracker
+```
+
+`executing_source_file` answers "which file was the currently-executing routine
+defined in" by walking the routine stack, while `cur_source_line` is whatever
+statement marker the VM last passed. Those two agree for an ordinary call, but
+not when the routine stack's top frame belongs to a block whose body is not what
+the VM is currently executing — the frame then reports one file and a line
+number belonging to a different one.
+
+`$?FILE` was equally wrong before `news/2026-08/module-file-var-and-callframe.md`
+(it named the running script rather than the defining file), so the pair was
+*consistently* wrong and this mismatch was invisible. It is not a regression from
+that change — the rendered output is byte-identical — but it is now the
+remaining half of the same problem.
+
+## Repro
+
+Under rakudo's real `Test.rakumod` (aliased as `Test2`, see
+`todo/tickets/vendor-real-test-module.md`), a `throws-like` whose inner
+`right exception type` subtest fails reports:
+
+```
+    not ok 2 - right exception type (X::Assignment::RO)
+    # Failed test 'right exception type (X::Assignment::RO)'
+    # at t/dotassign-store-and-container-topic.t line 666
+```
+
+`t/dotassign-store-and-container-topic.t` is 106 lines long. Line 666 is in
+`Test.rakumod` — it is the `ok $type_ok, "right exception type (...)"` call
+inside `throws-like`. So `proclaim`'s location walk stopped at a frame whose
+`.file` is the test script and whose `.line` came from the module.
+
+Three files in the 1-in-9 sweep sample show it, all through `throws-like`:
+`t/dotassign-store-and-container-topic.t`,
+`t/export-bareword-tag-undeclared.t`, `t/method-private-errors.t`,
+plus `t/obsolete-diamond.t`.
+
+## What a fix has to do
+
+Record the line on the same frame the file comes from. `RoutineFrame` already
+carries a call-site `line`/`file` pair *and* a `def_file`; what is missing is the
+defining-frame's *current* line, i.e. where inside that routine control sits at
+the moment a nested call is made. That is exactly what `cur_source_line` holds
+while that routine is the one running, so the natural shape is to save/restore
+it per routine frame rather than reading the global at push time.
+
+Beware the second-order effect: `pop_caller_env` restores `cur_source_line` from
+the popped entry, so the entry's `line` is load-bearing for the caller's own line
+tracking, not only for `callframe`. Splitting the two uses (a `restore_line` and
+a `report_line`) is probably cleaner than trying to make one value serve both.

--- a/todo/tickets/local-tests-rely-on-a-lenient-native-is.md
+++ b/todo/tickets/local-tests-rely-on-a-lenient-native-is.md
@@ -1,0 +1,51 @@
+# Some `t/` files assert against mutsu's lenient native `is`, not against Raku's
+
+Found while re-running the Test-vendoring bulk sweep
+(`todo/tickets/vendor-real-test-module.md`). These are **test-file** bugs, not
+interpreter bugs: rakudo's real `Test.rakumod` fails them, and so does `raku`
+itself, because mutsu's native `is` stringifies its arguments more eagerly than
+Raku's does.
+
+## The two shapes
+
+**A type object compared against its gist spelling.** `is Point.WHAT, '(Point)'`
+passes under mutsu's native provider and fails everywhere else, because Raku's
+`is` compares `$got.Str` — and a type object's `.Str` is the empty string with a
+warning, not its `.gist`:
+
+```
+$ raku -e 'use Test; plan 1; class Point {}; is Point.WHAT, "(Point)", "what"'
+1..1
+not ok 1 - what
+# expected: '(Point)'
+#      got: (Point)
+```
+
+`.gist` (or `.^name`, or `isa-ok`) is what these assertions actually mean.
+
+**A lazy `Seq` compared against its reified contents.** `is $fh.lines, 'A B C'`
+passes natively and gives `'(...)'` under the real module — again matching Raku,
+which does not reify a lazy sequence to stringify it. `is $fh.lines.join(' '),
+'A B C'` (or `is-deeply` against a list) is the assertion that survives.
+
+## Affected files
+
+From the 1-in-9 sample (301 of 2717 `t/` files), six regressed on this alone:
+
+| file | failing assertions |
+| --- | --- |
+| `t/typed-container-what.t` | 9 |
+| `t/is-lazy-io-lines.t` | 2 |
+| `t/class-basic.t` | 1 |
+| `t/class.t` | 1 |
+| `t/enum.t` | 1 |
+| `t/float-num.t` | 1 |
+
+At that sample rate the whole suite holds roughly 50 such files. They are not
+blocking anything today — they only surface when step 3 of the vendoring plan
+swaps mutsu's provider for the real module — but they have to be corrected
+before that swap, and each correction makes the test *more* faithful to Raku, so
+none of them needs to wait for it.
+
+The cheapest way to enumerate the rest is to re-run the sweep over the full set
+rather than the 1-in-9 sample (`tmp/sweep.sh 1`, see the vendoring ticket).

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -121,10 +121,44 @@ when a signature is ambiguous).
 the END-phaser fix. The residue lined up exactly with the two tickets open at
 that point — 30 files on the `$?FILE`/`callframe` failure-report path and 7 on
 `No such method 'file'` — plus ~8 single-file `not ok`s that are ordinary
-pre-existing gaps rather than `Test` differences. Both of those signatures are
-the `$?FILE`/`callframe` bug, now fixed, so **re-run the sweep**: it is the
-cheapest way to see whether step 3 (flipping `runtime_module.rs`) is safe to
-attempt.
+pre-existing gaps rather than `Test` differences.
+
+### Re-run after the `$?FILE`/`callframe` fix (2026-08-01)
+
+Same 1-in-9 sample, with `news/2026-08/module-file-var-and-callframe.md` in.
+Scripts this time: `tmp/sweep.sh` (runs each sampled file twice from the same
+path — verbatim, and with `use Test;` rewritten to `use Test2;`) and
+`tmp/sweep-analyze.sh`. Note the analysis deliberately does **not** compare the
+two runs byte-for-byte: the real module is routinely *more* faithful than the
+native provider (richer `throws-like` subtests, `'<code>' died` descriptions
+instead of `code dies`), so the question is whether a file that passed still
+passes.
+
+| | files |
+| --- | --- |
+| pass under both | **285 / 301** |
+| regress under the real module | 15 |
+| fail under both (pre-existing) | 1 |
+
+None of the 15 is an unfixed `Test` incompatibility:
+
+- **6 files** assert against mutsu's *lenient* native `is` — `is Point.WHAT,
+  '(Point)'` and `is $fh.lines, 'A B C'` fail under `raku` too. These are test
+  files to correct, tracked in
+  `todo/tickets/local-tests-rely-on-a-lenient-native-is.md` (~50 files suite-wide
+  at this sample rate).
+- **4 files** hit `callframe` reporting a frame's `.file` and `.line` from
+  different sources (`# at t/foo.t line 666` for a 106-line file), all through
+  `throws-like` — `todo/tickets/callframe-line-and-file-come-from-different-frames.md`.
+  The rendered output is byte-identical to before the `$?FILE` fix, so this is
+  the remaining half of that problem rather than a regression.
+- The rest are ordinary single-assertion gaps unrelated to `Test`
+  (`orelse` short-circuiting inside a listop argument, `nextsame`+`where`
+  ordering, a `:v<>` version adverb import).
+
+So step 3 is close: what stands between here and flipping `runtime_module.rs` is
+`cmp-ok` (below) plus a pass over the lenient-`is` test files. Run the sweep over
+the *full* set (`tmp/sweep.sh 1`) rather than the sample before attempting it.
 
 One is left:
 


### PR DESCRIPTION
The bulk sweep in `todo/tickets/vendor-real-test-module.md` asked to be re-run
once the `$?FILE`/`callframe` fix (#5660) landed, since 37 of its 46 residual
files carried that signature.

Re-ran it over the same 1-in-9 sample (301 of 2717 `t/` files):

| | files |
| --- | --- |
| pass under both the native provider and the genuine upstream module | **285 / 301** (was 255) |
| regress under the real module | 15 |
| fail under both (pre-existing) | 1 |

The analysis deliberately does *not* compare the two runs byte-for-byte — the
real module is routinely **more** faithful than mutsu's native provider (richer
`throws-like` subtests, `'<code>' died` descriptions rather than `code dies`) —
so the question asked is whether a file that passed still passes.

None of the 15 regressions is an unfixed `Test` incompatibility, and both
recurring shapes are filed as their own tickets:

- **`todo/tickets/local-tests-rely-on-a-lenient-native-is.md`** — 6 files assert
  against mutsu's *lenient* native `is`: `is Point.WHAT, '(Point)'` and
  `is $fh.lines, 'A B C'` fail under `raku` too, because Raku's `is` compares
  `.Str` and does not reify a lazy `Seq`. Test files to correct (~50 suite-wide
  at this sample rate), and each correction makes the test more faithful, so
  none has to wait for the vendoring.
- **`todo/tickets/callframe-line-and-file-come-from-different-frames.md`** — 4
  files, all through `throws-like`, report `# at t/foo.t line 666` for a
  106-line file. `push_caller_env` takes the frame's `file` from the routine
  stack and its `line` from the VM's line tracker. The rendered output is
  byte-identical to before #5660, so this is the remaining half of that problem
  rather than a regression from it.

The rest are ordinary single-assertion gaps unrelated to `Test` (`orelse`
short-circuiting inside a listop argument, `nextsame`+`where` ordering, a
`:v<>` version adverb import).

## `cmp-ok` is cheaper than the ticket assumed

Also measured what `&CALLER::LEXICAL::("infix:<$op>")` actually needs. The
`&`-sigil indirect lookup does not work for *any* name today — it does not even
reach the "no such symbol" answer:

```
$ mutsu -e 'sub f($a,$b) {$a*$b}; my $m = &MY::("f"); say $m(2,3)'
Impossible coercion from 'Int' into 'Any': no acceptable coercion method found
$ raku  -e 'sub f($a,$b) {$a*$b}; my $m = &MY::("f"); say $m(2,3)'
6
```

Meanwhile the two halves the ticket flagged as hard are already there:
`&infix:<+>` as a static term yields a working callable, and
`no_such_symbol_failure` already returns the `X::NoSuchSymbol` Failure that the
module's `//` fallback chain depends on. So the operator half comes along for
free once the `&`-sigil indirect path reaches the existing machinery; what is
genuinely missing is that path plus `LEXICAL::` walking out to the setting.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)