### PR TITLE
fix(parser): a declared enum value never gobbles a block as a listop arg

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1646,8 +1646,17 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             .map(|(_, t)| t)
             .unwrap_or(name.as_str());
         let short_name_is_type = short_name.starts_with(|c: char| c.is_ascii_uppercase());
-        let hyphen_forward_call =
-            !is_user_sub && !name_is_declared_type && !short_name_is_type && name.contains('-');
+        // A declared enum *value* is a complete nullary term, never a
+        // forward-referenced sub: `%streams{$_}.state !~~ header-c { ... }`
+        // (Cro::HTTP2::GeneralParser) must leave the block to the enclosing
+        // `if`, exactly like the declared-type exclusion above.
+        let name_is_enum_value = crate::parser::stmt::simple::is_user_declared_enum_value(&name)
+            || crate::runtime::utils::is_builtin_enum_value(&name);
+        let hyphen_forward_call = !is_user_sub
+            && !name_is_declared_type
+            && !short_name_is_type
+            && !name_is_enum_value
+            && name.contains('-');
         if is_user_prefix_sub {
             if let Ok((r2, arg)) = expression_no_sequence(r) {
                 return Ok((r2, make_call_expr(call_name.clone(), input, vec![arg])));

--- a/t/enum-value-kebab-no-block-gobble.t
+++ b/t/enum-value-kebab-no-block-gobble.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A hyphenated bareword that is not a declared sub is speculatively parsed as
+# a forward-referenced listop call, gobbling a following block as its
+# argument. A declared enum *value* is a complete nullary term, so the block
+# must be left to the enclosing construct (Cro::HTTP2::GeneralParser's
+# `if ... || %streams{...}.state !~~ header-c { ... }`).
+enum State <header-init header-c data>;
+
+my $x = 5;
+if $x !~~ header-c {
+    pass 'if-cond ending in !~~ kebab-enum-value keeps its block';
+}
+else {
+    flunk 'if-cond ending in !~~ kebab-enum-value keeps its block';
+}
+
+if $x ~~ header-c {
+    flunk 'smartmatch against kebab enum value in if-cond';
+}
+else {
+    pass 'smartmatch against kebab enum value in if-cond';
+}
+
+if header-c {
+    pass 'bare kebab enum value as whole if-cond';
+}
+else {
+    flunk 'bare kebab enum value as whole if-cond';
+}
+
+my $hits = 0;
+while $x !~~ header-c {
+    $hits++;
+    last;
+}
+is $hits, 1, 'while-cond ending in kebab enum value runs its block';
+
+# Multi-line condition with leading || continuation, the exact Cro shape.
+class Stream { has State $.state is rw }
+my %streams = 5 => Stream.new(state => header-init);
+if $x > 3
+|| %streams{$x}.state !~~ header-c {
+    pass 'multi-line || continuation with kebab enum smartmatch';
+}
+else {
+    flunk 'multi-line || continuation with kebab enum smartmatch';
+}


### PR DESCRIPTION
## Summary

A hyphenated bareword that is not a declared sub is speculatively parsed as a forward-referenced listop call (`do-thing { ... }` where `do-thing` is defined later), gobbling a following block as its argument. A declared enum **value** is a complete nullary term, so the block must be left to the enclosing construct. Cro::HTTP2::GeneralParser's

```raku
if .stream-identifier > $curr-sid
|| %streams{.stream-identifier}.state !~~ header-c { ... }
```

failed to parse with "Unexpected block in infix position" (`header-c` is a value of `enum State <header-init header-c data>`), blocking `use Cro::HTTP::Server` — which now loads to completion.

The fix adds an enum-value exclusion (user-declared and builtin) to the `hyphen_forward_call` heuristic in `identifier_call.rs`, mirroring the existing declared-type exclusion.

## Testing

- New `t/enum-value-kebab-no-block-gobble.t` (5 tests: `if`/`while` conditions ending in kebab enum values with `~~`/`!~~`, bare enum value as whole condition, and the exact multi-line `||` continuation shape from Cro) — identical output under `raku`.
- `make test`: all 25845 tests pass.
- `use Cro::HTTP::Server` (with the Cro tree from the dist sweep) loads to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)