### PR TITLE
feat: unblock Cro::HTTP::Server.new/.start request handling

### DIFF
--- a/src/runtime/native_methods/socket_async_conn.rs
+++ b/src/runtime/native_methods/socket_async_conn.rs
@@ -40,6 +40,22 @@ impl Interpreter {
                 .get("peer-host")
                 .cloned()
                 .unwrap_or_else(|| Value::str_from("0.0.0.0"))),
+            // The OS-level file descriptor of the underlying TCP stream, used
+            // by NativeCall consumers (Cro::TCP::NoDelay's setsockopt). Only
+            // meaningful for real TCP connections; in-memory test sockets have
+            // no descriptor and report -1.
+            "native-descriptor" => {
+                #[cfg(unix)]
+                if is_real_tcp
+                    && let Some(id) = conn_id
+                    && let Some(stream) = get_tcp_stream(id)
+                    && let Ok(s) = stream.lock()
+                {
+                    use std::os::unix::io::AsRawFd;
+                    return Ok(Value::int(s.as_raw_fd() as i64));
+                }
+                Ok(Value::int(-1))
+            }
             "close" if is_real_tcp => {
                 if let Some(id) = conn_id {
                     if let Some(stream) = get_tcp_stream(id)

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -946,6 +946,7 @@ impl Interpreter {
                     "peer-host",
                     "print-to",
                     "write-to",
+                    "native-descriptor",
                 ]
                 .iter()
                 .map(|s| s.to_string())

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -520,6 +520,35 @@ pub(in crate::runtime) fn bind_named_rename_sub_signature(
         if bind_name.is_empty() {
             continue;
         }
+        // An UNSUPPLIED renamed named param arrives here with the outer
+        // param's default (a type object — the outer alias name has no
+        // sigil, so `missing_optional_param_value` cannot see the leaf's).
+        // A sigiled leaf must instead bind its sigil's empty container,
+        // exactly like a plain `:%tls`: `:ssl(:tls(%tls-in))` unsupplied
+        // binds `%tls-in = {}` (Cro::HTTP::Server.new), not an Associative
+        // type error.
+        if matches!(value.view(), ValueView::Package(_)) {
+            if bind_name.starts_with('%') {
+                let empty = Value::hash(std::collections::HashMap::new());
+                if let Some(nested) = &sub_pd.sub_signature {
+                    bind_named_rename_sub_signature(interpreter, nested, &empty)?;
+                } else {
+                    interpreter.bind_param_value(bind_name, empty);
+                    interpreter.set_var_type_constraint(bind_name, sub_pd.type_constraint.clone());
+                }
+                continue;
+            }
+            if bind_name.starts_with('@') {
+                let empty = Value::real_array(Vec::new());
+                if let Some(nested) = &sub_pd.sub_signature {
+                    bind_named_rename_sub_signature(interpreter, nested, &empty)?;
+                } else {
+                    interpreter.bind_param_value(bind_name, empty);
+                    interpreter.set_var_type_constraint(bind_name, sub_pd.type_constraint.clone());
+                }
+                continue;
+            }
+        }
         if let Some(tc) = &sub_pd.type_constraint
             && !interpreter.type_matches_value(tc, value)
         {

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -272,11 +272,21 @@ impl Interpreter {
                 // A `:color(:$colour)` alias chain also declares its inner
                 // variable(s); when the param is unsupplied they must still be
                 // in scope (undefined), else the body's `$colour` read throws.
+                // A sigiled leaf (`:ssl(:tls(%tls-in))`) binds its sigil's
+                // empty container instead of the outer type-object seed,
+                // exactly like a plain `:%tls` (Cro::HTTP::Server.new).
                 for (alias_name, alias_slot) in &npb.alias_binds {
+                    let alias_seed = if alias_name.starts_with('%') {
+                        Value::hash(std::collections::HashMap::new())
+                    } else if alias_name.starts_with('@') {
+                        Value::real_array(Vec::new())
+                    } else {
+                        seed.clone()
+                    };
                     if let Some(slot) = alias_slot {
-                        self.locals[*slot] = seed.clone();
+                        self.locals[*slot] = alias_seed.clone();
                     }
-                    self.env_mut().insert(alias_name.clone(), seed.clone());
+                    self.env_mut().insert(alias_name.clone(), alias_seed);
                 }
                 bind_value!(npb.slot, true, seed);
                 continue;

--- a/t/io-socket-async-native-descriptor.t
+++ b/t/io-socket-async-native-descriptor.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+plan 2;
+
+# Accepted async TCP connections expose the OS file descriptor of the
+# underlying stream (used by NativeCall consumers such as Cro::TCP::NoDelay's
+# setsockopt). Listen on port 0 and read the assigned port from the tap —
+# never hardcode a port.
+
+my $got-fd = Promise.new;
+my $tap = IO::Socket::Async.listen('127.0.0.1', 0).tap(-> $conn {
+    $got-fd.keep($conn.native-descriptor) unless $got-fd;
+    $conn.close;
+});
+my $port = await $tap.socket-port;
+
+my $client = await IO::Socket::Async.connect('127.0.0.1', $port);
+my $fd = await $got-fd;
+ok $fd ~~ Int, 'native-descriptor returns an Int';
+# An in-process loopback pair may be served by mutsu's in-memory transport,
+# which has no OS descriptor and reports -1; a real TCP stream reports a
+# descriptor above the stdio range. Both are Ints and never a stdio fd.
+ok $fd == -1 || $fd > 2, 'descriptor is a real fd or the in-memory sentinel';
+$client.close;
+$tap.close;

--- a/t/named-rename-sigil-param-default.t
+++ b/t/named-rename-sigil-param-default.t
@@ -1,0 +1,23 @@
+use v6;
+use Test;
+
+plan 6;
+
+# An unsupplied renamed named parameter with a sigiled leaf variable must
+# bind the sigil's empty container, exactly like the plain `:%h` form —
+# Cro::HTTP::Server.new's `:ssl(:tls(%tls-in))` binds `%tls-in = {}` when
+# neither :ssl nor :tls is passed.
+
+sub one-alias(:tls(%t)) { %t }
+is-deeply one-alias(), {}, 'unsupplied :tls(%t) binds empty hash';
+is-deeply one-alias(tls => {a => 1}), {a => 1}, 'supplied :tls(%t) binds the hash';
+
+sub two-alias(:ssl(:tls(%tls-in))) { %tls-in }
+is-deeply two-alias(), {}, 'unsupplied :ssl(:tls(%tls-in)) binds empty hash';
+is-deeply two-alias(ssl => {b => 2}), {b => 2}, 'outer alias key still binds';
+
+sub arr-alias(:a(@x)) { @x }
+is-deeply arr-alias(), [], 'unsupplied :a(@x) binds empty array';
+
+sub scalar-alias(:c(:$colour)) { $colour }
+ok scalar-alias() === Any, 'unsupplied scalar alias still binds Any';


### PR DESCRIPTION
## Summary

Two independent fixes hit while driving a Cro HTTP server end-to-end (`route { get -> { ... } }` + `Cro::HTTP::Server.new(...).start`):

1. **Unsupplied renamed named params with sigiled leaves bind the sigil's empty container.** `Cro::HTTP::Server.new`'s `:ssl(:tls(%tls-in))` bound the outer param's default (an `Any` type object) to the `%tls-in` leaf and died with "Type check failed in binding to parameter '%tls-in'; expected Associative, got Package". Now an unsupplied `:tls(%t)` / `:ssl(:tls(%tls-in))` binds `{}` and `:a(@x)` binds `[]`, exactly like the plain `:%h` form — fixed in both the slow binder (`bind_named_rename_sub_signature`) and the VM light-typed call path (`alias_binds` seeding).

2. **`IO::Socket::Async` connections expose `native-descriptor`** (the OS fd of the underlying TCP stream), which NativeCall consumers use — Cro::TCP::NoDelay's `setsockopt(TCP_NODELAY)` died with "No such method 'native-descriptor'". In-memory loopback connections (mutsu's in-process transport) report `-1`.

With these, `Cro::HTTP::Server.new(:host, :port, :application($app)).start` / `.stop` runs to completion. (The actual request round-trip still hangs in the pipeline — next slice.)

## Testing

- New `t/named-rename-sigil-param-default.t` (6 tests, identical under `raku`).
- New `t/io-socket-async-native-descriptor.t` (2 tests; listens on port 0 per the no-hardcoded-port rule; passes under `raku` too).
- `make test`: all 25853 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)