### PR TITLE
fix(runtime): a compile error keeps its exception class

### DIFF
--- a/news/2026-08/typed-exception-class-from-the-message-convention.md
+++ b/news/2026-08/typed-exception-class-from-the-message-convention.md
@@ -1,0 +1,48 @@
+# A compile-time error keeps its exception class instead of collapsing to `X::AdHoc`
+
+`throws-like` and a typed `CATCH { when X::Foo {…} }` both dispatch on the
+exception's *class*. mutsu raised most compile-time errors as an untyped
+`RuntimeError` whose message merely *spelled* the class — `"X::Obsolete:
+Unsupported use of . to concatenate strings; in Raku please use ~"` — and the
+untyped-error path wrapped that whole string in an `X::AdHoc`. The type was
+right there in the text and nothing read it:
+
+```
+$ mutsu -e 'try { EVAL q{"a" . "b"} }; say $!.^name; say $!.message'
+X::AdHoc
+X::Obsolete: Unsupported use of . to concatenate strings; in Raku please use ~
+
+$ raku -e 'try { EVAL q{"a" . "b"} }; say $!.^name; say $!.message'
+X::Obsolete
+Unsupported use of . to concatenate strings. In Raku please use: ~.
+```
+
+`RuntimeError::exception_value()` now makes the `"X::Type: text"` convention
+real: it prefers a structured exception the error already carries, then splits
+the convention out of the message, and only then falls back to `X::AdHoc`. A
+name is accepted only when every `::`-separated segment looks like a type name,
+so `die 'X:: is the exception namespace'` stays an `X::AdHoc` with its sentence
+intact. The class name is dropped from the resulting `.message`, matching raku.
+
+The same function replaces four hand-rolled copies of the
+`e.exception … else X::AdHoc` fallback (`vm_try_catch_ops`, two in
+`vm_misc_scope`, `fail_error_to_failure_value`), so the rule now lives in one
+place rather than being restated at each conversion site.
+
+## Why it surfaced now
+
+mutsu's *native* `Test` provider matched `throws-like`'s expected type against
+the message text, so these assertions passed anyway. rakudo's real
+`Test.rakumod` uses `nqp::istype`, which does not. The full Test-vendoring sweep
+(`todo/tickets/vendor-real-test-module.md`) ran every `t/*.t` file twice — once
+against the native provider and once against the vendored upstream module — and
+this single root cause accounted for 29 of the 57 files that regressed under the
+real module while passing under `raku`. **20 of those 29 are cleared by this
+change** — the whole sweep goes from 86 regressions to 64, and from 2617 to 2641
+files passing under both. The remaining 9 are errors whose message does not name
+a class at all (a parse failure reported as `Confused. parse error at …` where
+raku raises `X::Syntax::Malformed`), which is a separate piece of work.
+
+Pinned by `t/typed-exception-class-of-compile-errors.t`, green under `raku` too;
+3 of its 14 assertions fail without the change (the other 11 pass either way,
+because the native provider is lenient — which is the whole point).

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -209,11 +209,7 @@ impl Interpreter {
     }
 
     pub(crate) fn fail_error_to_failure_value(&self, err: &RuntimeError) -> Value {
-        let exception = err.exception.as_deref().cloned().unwrap_or_else(|| {
-            let mut attrs = std::collections::HashMap::new();
-            attrs.insert("message".to_string(), Value::str(err.message.clone()));
-            Value::make_instance(Symbol::intern("X::AdHoc"), attrs)
-        });
+        let exception = err.exception_value();
         let mut failure_attrs = std::collections::HashMap::new();
         failure_attrs.insert("exception".to_string(), exception);
         // When UNDO phasers ran for this fail, the Failure is marked as handled

--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -153,6 +153,58 @@ impl RuntimeError {
         Value::make_instance(Symbol::intern("Failure"), failure_attrs)
     }
 
+    /// Split a message written in the `"X::Type: text"` convention into its
+    /// class name and text. Hundreds of call sites spell a typed exception that
+    /// way in a plain untyped `RuntimeError`; this is what makes the convention
+    /// real instead of decorative. A message that is only a class name
+    /// (`"X::Match::Bool"`) counts too — its text is the class name, matching
+    /// what `typed()` does when no `message` attribute is supplied.
+    fn split_typed_message_convention(message: &str) -> Option<(&str, &str)> {
+        if !message.starts_with("X::") {
+            return None;
+        }
+        let (name, text) = match message.find(": ") {
+            Some(i) => (&message[..i], &message[i + 2..]),
+            None => (message, message),
+        };
+        // Every `::`-separated segment has to look like a type name, so an
+        // ordinary sentence that merely opens with `X::` is left alone.
+        let well_formed = name.split("::").all(|seg| {
+            seg.starts_with(|c: char| c.is_ascii_uppercase())
+                && seg.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        });
+        well_formed.then_some((name, text))
+    }
+
+    /// The exception object this error presents to `CATCH` / `$!` /
+    /// `throws-like`. Prefers a structured exception the error already carries,
+    /// then the `"X::Type: text"` message convention, and finally `X::AdHoc` —
+    /// the class a bare `die "msg"` produces in Raku. `X::AdHoc` IS-A
+    /// `Exception`, so `isa-ok $!, Exception` still matches an untyped error.
+    pub(crate) fn exception_value(&self) -> Value {
+        self.exception_value_with_backtrace(None)
+    }
+
+    /// `exception_value`, plus a `backtrace` attribute for a legacy error that
+    /// only carries its backtrace as a string. Ignored when the error already
+    /// has a structured exception, which carries its own.
+    pub(crate) fn exception_value_with_backtrace(&self, backtrace: Option<Value>) -> Value {
+        if let Some(ex) = self.exception.as_ref() {
+            return (**ex).clone();
+        }
+        let (class_name, text) = Self::split_typed_message_convention(&self.message)
+            .unwrap_or(("X::AdHoc", self.message.as_str()));
+        let mut attrs = HashMap::new();
+        attrs.insert("message".to_string(), Value::str_from(text));
+        if let Some(line) = self.line() {
+            attrs.insert("line".to_string(), Value::int(line as i64));
+        }
+        if let Some(bt) = backtrace {
+            attrs.insert("backtrace".to_string(), bt);
+        }
+        Value::make_instance(Symbol::intern(class_name), attrs)
+    }
+
     /// Create a typed exception error with the given class name and attributes.
     /// This is the general-purpose constructor for structured exceptions.
     pub(crate) fn typed(class_name: &str, attrs: HashMap<String, Value>) -> Self {

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -289,14 +289,7 @@ impl Interpreter {
         if let Err(ref e) = body_result
             && Self::is_exceptional_block_exit(e)
         {
-            let err_val = if let Some(ex) = e.exception.as_ref() {
-                *ex.clone()
-            } else {
-                let mut exc_attrs = std::collections::HashMap::new();
-                exc_attrs.insert("message".to_string(), Value::str(e.message.clone()));
-                // Untyped runtime error -> X::AdHoc (see vm_control_ops.rs).
-                Value::make_instance(crate::symbol::Symbol::intern("X::AdHoc"), exc_attrs)
-            };
+            let err_val = e.exception_value();
             self.env_mut().insert("!".to_string(), err_val.clone());
             for (i, name) in code.locals.iter().enumerate() {
                 if name == "!" {
@@ -343,14 +336,7 @@ impl Interpreter {
             if let Err(ref e) = body_result
                 && Self::is_exceptional_block_exit(e)
             {
-                let err_val = if let Some(ex) = e.exception.as_ref() {
-                    *ex.clone()
-                } else {
-                    let mut exc_attrs = std::collections::HashMap::new();
-                    exc_attrs.insert("message".to_string(), Value::str(e.message.clone()));
-                    // Untyped runtime error -> X::AdHoc (see vm_control_ops.rs).
-                    Value::make_instance(crate::symbol::Symbol::intern("X::AdHoc"), exc_attrs)
-                };
+                let err_val = e.exception_value();
                 self.env_mut().insert("!".to_string(), err_val.clone());
                 // Also update the local slot for $! if present
                 for (i, name) in code.locals.iter().enumerate() {

--- a/src/vm/vm_try_catch_ops.rs
+++ b/src/vm/vm_try_catch_ops.rs
@@ -341,26 +341,11 @@ impl Interpreter {
                     return Err(e);
                 }
                 self.stack.truncate(saved_depth);
-                let err_val = if let Some(ex) = e.exception.as_ref() {
-                    *ex.clone()
-                } else {
-                    let mut exc_attrs = std::collections::HashMap::new();
-                    exc_attrs.insert("message".to_string(), Value::str(e.message.clone()));
-                    if let Some(line) = e.line() {
-                        exc_attrs.insert("line".to_string(), Value::int(line as i64));
-                    }
-                    if let Some(bt) = e.backtrace() {
-                        // Build a Backtrace object from the string for
-                        // legacy errors that only have a string backtrace.
-                        let bt_val = Self::backtrace_value_from_string(bt);
-                        exc_attrs.insert("backtrace".to_string(), bt_val);
-                    }
-                    // An untyped runtime error surfaces as X::AdHoc in Raku (the
-                    // class a bare `die "msg"` produces), not the abstract base
-                    // Exception. X::AdHoc IS-A Exception, so `throws-like
-                    // ..., Exception` / `isa-ok $!, Exception` still match.
-                    Value::make_instance(Symbol::intern("X::AdHoc"), exc_attrs)
-                };
+                // Build a Backtrace object from the string for legacy errors
+                // that only have a string backtrace.
+                let err_val = e.exception_value_with_backtrace(
+                    e.backtrace().map(Self::backtrace_value_from_string),
+                );
                 let saved_topic = self.env().get("_").cloned();
                 // Per Raku semantics `$!` is only *updated* to the exception when it
                 // propagates out of the `try` unhandled (swallowed by the implicit

--- a/t/typed-exception-class-of-compile-errors.t
+++ b/t/typed-exception-class-of-compile-errors.t
@@ -1,0 +1,57 @@
+use Test;
+
+plan 14;
+
+# A compile-time error caught from EVAL must present its real exception class,
+# not a generic X::AdHoc. `throws-like` and a `CATCH`/`when` both dispatch on
+# the type, so an error that only spells its class inside the message text is
+# indistinguishable from `die "..."`.
+
+throws-like { EVAL q{"a" . "b"} }, X::Obsolete, 'the . concatenation braino';
+throws-like { EVAL q{<>} }, X::Obsolete, 'the degenerate diamond';
+throws-like { EVAL q{$& = 1} }, X::Syntax::Perl5Var, 'a Perl 5 special variable';
+throws-like { EVAL q{my $x is readonly = 1} }, X::Comp::Trait::Unknown,
+    'an unknown variable trait';
+
+# The message keeps only the text: the class name is not repeated in it.
+{
+    my $e = (try { EVAL q{"a" . "b"} }, $!).tail;
+    isa-ok $e, X::Obsolete, 'caught in $! with its class';
+    nok $e.message.starts-with('X::'), 'the class name is not part of the message';
+    ok $e.message.contains('concatenate'), 'and the text survives';
+}
+
+# A CATCH block dispatches on the type.
+{
+    my $seen;
+    {
+        EVAL q{$& = 1};
+        CATCH {
+            when X::Syntax::Perl5Var { $seen = 'perl5var' }
+            default { $seen = 'default' }
+        }
+    }
+    is $seen, 'perl5var', 'a typed when matches a compile error';
+}
+
+# An untyped error is still X::AdHoc, which IS-A Exception.
+{
+    my $e = (try { die 'plain failure' }, $!).tail;
+    isa-ok $e, X::AdHoc, 'an untyped die is X::AdHoc';
+    is $e.message, 'plain failure', 'with its message intact';
+    isa-ok $e, Exception, 'and X::AdHoc IS-A Exception';
+}
+
+# A sentence that merely opens with `X::` is not a class name.
+{
+    my $e = (try { die 'X:: is the exception namespace' }, $!).tail;
+    isa-ok $e, X::AdHoc, 'a message that only mentions X:: stays X::AdHoc';
+    is $e.message, 'X:: is the exception namespace', 'and is not truncated';
+}
+
+# The same rule reaches a Failure produced by `fail`.
+{
+    sub obsolete-ish { fail X::Obsolete.new(old => '.', replacement => '~') }
+    my $f = obsolete-ish;
+    isa-ok $f.exception, X::Obsolete, 'a failed Failure keeps its class';
+}

--- a/todo/tickets/compile-errors-that-name-no-exception-class.md
+++ b/todo/tickets/compile-errors-that-name-no-exception-class.md
@@ -1,0 +1,37 @@
+# Compile errors that name no exception class at all
+
+`news/2026-08/typed-exception-class-from-the-message-convention.md` made the
+`"X::Type: text"` message convention real, so an error that *spells* its class
+now presents it. These nine do not spell one — they raise a bare
+`Confused. parse error at …` (or an unrelated class) where raku raises a
+specific one, so `throws-like` cannot match and a typed `CATCH` cannot dispatch.
+
+Found by the full Test-vendoring sweep (`todo/tickets/vendor-real-test-module.md`);
+each is a file that `raku` passes and mutsu fails only under the real `Test`
+module. Reproduce one with:
+
+```
+$ raku  -e 'try { EVAL q{sub f() returns { }} }; say $!.^name'
+$ mutsu -e 'try { EVAL q{sub f() returns { }} }; say $!.^name'
+```
+
+| file | first failing assertion | class raku raises |
+| --- | --- | --- |
+| `t/bind-to-whatever-index.t` | binding `[*-1]` of an empty array | `X::Bind::Slice` |
+| `t/indexed-bind-in-expression.t` | a Whatever-index bind | `X::Bind::Slice` |
+| `t/return-constraint-malformed.t` | a malformed return constraint | `X::Syntax::Malformed` |
+| `t/name-null.t` | a type name with a null component | `X::Syntax::Name::Null` |
+| `t/radix-literals.t` | no numerals in an octal literal | `X::Syntax::Confused` |
+| `t/unicode-identifiers.t` | a non-ASCII digit starting an identifier | `X::Syntax::Variable::Numeric` |
+| `t/modifier-cond-ending-in-block.t` | a non-block condition followed by a bare statement | `X::Syntax::Confused` |
+| `t/out-of-range-scalar-index.t` | a scalar string index out of range | `X::OutOfRange` |
+| `t/block-lexical-scope.t` | chained `our`/`my` in a block does not leak | `X::Undeclared::Symbols` |
+
+The fix per case is to raise the error with `RuntimeError::typed_msg` (or one of
+the dedicated constructors in `src/value/error_typed.rs`) instead of a bare
+message. They are independent of each other, so this is a bag of small slices rather than
+one change. The right-hand column is the class the file's own `throws-like`
+names, and `raku` passes every one of these files, so it is the class raku
+actually raises — but check the exact message text against `raku` before
+writing one, since these constructors carry more than a class name
+(`X::Bind::Slice` has `.type`, `X::OutOfRange` has `.range`/`.got`).

--- a/todo/tickets/local-tests-rely-on-a-lenient-native-is.md
+++ b/todo/tickets/local-tests-rely-on-a-lenient-native-is.md
@@ -47,5 +47,26 @@ swaps mutsu's provider for the real module — but they have to be corrected
 before that swap, and each correction makes the test *more* faithful to Raku, so
 none of them needs to wait for it.
 
-The cheapest way to enumerate the rest is to re-run the sweep over the full set
-rather than the 1-in-9 sample (`tmp/sweep.sh 1`, see the vendoring ticket).
+## The full enumeration (2026-08-01)
+
+The full sweep has since been run (`tmp/sweep-full.sh`, see the vendoring
+ticket), and `tmp/sweep-raku-check.sh` splits its regressions by whether `raku`
+also fails the file. That bucket holds **29** files, not the ~50 the sample rate
+suggested:
+
+`anon-class-what-gist.t`, `begin-phaser-begintime.t`, `class-basic.t`,
+`class.t`, `complex.t`, `compound-assign-ops.t`, `cpp-constructor-syntax.t`,
+`dotassign-store-and-container-topic.t`, `enum.t`, `float-num.t`, `junction.t`,
+`listop-arg-loose-logical-precedence.t`, `lock.t`, `method-private-errors.t`,
+`misc-builtins.t`, `native-array-decl.t`, `new-operators.t`,
+`operator-adverbs.t`, `orelse-andthen-mixin-defined.t`, `pair-type.t`,
+`placeholder-named-in-method-do.t`, `pod-begin-without-identifier.t`, `rat.t`,
+`set.t`, `typed-container-what.t`, `use-version-short-adverb.t`,
+`variable-traits.t`, `version.t`, `vm-panic-boundary.t`.
+
+**The bucket is not purely lenient-`is`.** Four of them (`enum.t`,
+`placeholder-named-in-method-do.t`, `variable-traits.t`, `version.t`) do not
+even compile under `raku` — they exercise mutsu-specific syntax, so "`raku`
+fails it" says nothing about the assertion style. Check each file individually
+before rewriting it; the two shapes above are the ones to correct, and anything
+else in the list is a different finding.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -159,13 +159,44 @@ None of the 15 is an unfixed `Test` incompatibility:
   (`orelse` short-circuiting inside a listop argument, `nextsame`+`where`
   ordering, a `:v<>` version adverb import).
 
-So step 3 is close: what stands between here and flipping `runtime_module.rs` is
-a pass over the lenient-`is` test files. Run the sweep over the *full* set
-(`tmp/sweep.sh 1`) rather than the sample before attempting it.
-
 `cmp-ok`, the last blocked assertion, was fixed on 2026-08-01 —
 `news/2026-08/caller-lexical-indirect-operator-lookup.md`. Its output is now
 byte-identical to `raku`'s, failing assertions included.
+
+### Full sweep, all 2717 files (2026-08-01)
+
+The sample above is superseded. `tmp/sweep-full.sh` is the parallel (`xargs -P`)
+variant of `tmp/sweep.sh` with no stride; the analysis is the same
+`tmp/sweep-analyze.sh`. Two further scripts split the residue:
+`tmp/sweep-classify.sh` reports each regressed file's **first** failing line (a
+plain diff is misleading here — the real module emits *extra* `ok` lines, so the
+first `>` line of a diff is usually noise), and `tmp/sweep-raku-check.sh` runs
+each regressed file under `raku` to say whether the file itself is wrong.
+
+| | before the typed-exception fix | after |
+| --- | --- | --- |
+| pass under both | 2617 | **2641 / 2717** |
+| regress under the real module | 86 | **64** |
+| passes only under the real module | 1 | 1 |
+| fail under both (pre-existing) | 13 | 12 |
+
+Splitting the 86 by `raku`'s own verdict: **29 files `raku` also fails** (the
+test file is wrong — mostly the lenient-`is` shapes of
+`todo/tickets/local-tests-rely-on-a-lenient-native-is.md`, though a few are
+files `raku` cannot even parse because they exercise mutsu-specific syntax, so
+that bucket is not purely lenient-`is`), and **57 files `raku` passes** — real
+mutsu gaps that only the strict module exposes.
+
+Of those 57, **29 were one root cause**: a compile-time error arriving as
+`X::AdHoc` because its class was spelled only inside the message text.
+`news/2026-08/typed-exception-class-from-the-message-convention.md` fixed 20 of
+them. The other 9 are errors whose message names no class at all (`Confused.
+parse error at …` where raku raises `X::Syntax::Malformed` /
+`X::Bind::Slice` / …) — worth its own pass.
+
+So what stands between here and flipping `runtime_module.rs` is that residue
+plus a pass over the lenient-`is` test files. Re-run `tmp/sweep-full.sh` to
+re-measure after each.
 
 ## Blocker found while doing step 1: the native provider shadows an import — FIXED
 


### PR DESCRIPTION
`throws-like` and a typed `CATCH { when X::Foo {…} }` both dispatch on the
exception's **class**. mutsu raised most compile-time errors as an untyped
`RuntimeError` whose message merely *spelled* the class, and the untyped-error
path wrapped that whole string in an `X::AdHoc`. The type was right there in the
text and nothing read it:

```
$ mutsu -e 'try { EVAL q{"a" . "b"} }; say $!.^name; say $!.message'
X::AdHoc
X::Obsolete: Unsupported use of . to concatenate strings; in Raku please use ~

$ raku -e 'try { EVAL q{"a" . "b"} }; say $!.^name; say $!.message'
X::Obsolete
Unsupported use of . to concatenate strings. In Raku please use: ~.
```

`RuntimeError::exception_value()` now makes the `"X::Type: text"` convention
real: it prefers a structured exception the error already carries, then splits
the convention out of the message, and only then falls back to `X::AdHoc`. A
name is accepted only when every `::`-separated segment looks like a type name,
so `die 'X:: is the exception namespace'` stays an `X::AdHoc` with its sentence
intact. The class name is dropped from the resulting `.message`, matching raku.

The same function **replaces four hand-rolled copies** of the
`e.exception … else X::AdHoc` fallback (`vm_try_catch_ops`, two in
`vm_misc_scope`, `fail_error_to_failure_value`), so the rule lives in one place
rather than being restated at each conversion site.

## Why it surfaced now

mutsu's *native* `Test` provider matches `throws-like`'s expected type against
the message text, so these assertions passed anyway; rakudo's real
`Test.rakumod` uses `nqp::istype`, which does not. The full Test-vendoring sweep
(`todo/tickets/vendor-real-test-module.md`, now run over all 2717 `t/` files
rather than a 1-in-9 sample) showed this one root cause accounted for **29 of
the 57** files that regress under the real module while passing under `raku`.

| | before | after |
| --- | --- | --- |
| pass under both | 2617 | **2641 / 2717** |
| regress under the real module | 86 | **64** |
| fail under both (pre-existing) | 13 | 12 |

The 9 stragglers of that family — errors whose message names no class at all
(`Confused. parse error at …` where raku raises `X::Syntax::Malformed`) — are
filed as `todo/tickets/compile-errors-that-name-no-exception-class.md` with the
expected class per case.

## Testing

- New pin `t/typed-exception-class-of-compile-errors.t` (14 assertions), green
  under `raku` too. 3 of the 14 fail without this change; the other 11 pass
  either way because the native provider is lenient — which is the point.
- `make test`: 2717 files, 25923 tests, PASS.
- The 481 whitelisted roast files mentioning `throws-like`/`CATCH`/`X::`: PASS
  (`S32-io/spurt.t` needed the documented stale-`temp-file-RT-126006-test`
  cleanup, and `integration/weird-errors.t` was OOM-killed under `-j4`; both
  pass on their own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)