### PR TITLE
fix(runtime): `X::Bind::Slice` is a real exception class

### DIFF
--- a/news/2026-08/bind-slice-is-a-real-exception-class.md
+++ b/news/2026-08/bind-slice-is-a-real-exception-class.md
@@ -1,0 +1,42 @@
+# `X::Bind::Slice` is a real exception class
+
+Binding to a Whatever subscript (`@a[*-1] := 42`) is illegal, and mutsu's
+compiler already emitted the right throw for it — `die X::Bind::Slice.new`. The
+class was never registered, so `.new` did not exist on it and the throw itself
+failed with a different exception:
+
+```
+$ mutsu -e 'try { my @a; @a[*-1] := 42 }; say $!.^name'
+X::Method::NotFound
+```
+
+Registering it makes the raise land, and the raise site now passes the same
+attributes rakudo's carries, so the whole exception matches:
+
+```
+$ mutsu -e 'try { my @a; @a[*-1] := 42 }; say $!.^name; say $!.message; say $!.type.^name'
+X::Bind::Slice
+Cannot bind to Array slice
+Array
+```
+
+byte-identical to `raku`'s answer for the same program.
+
+**It is registered under `Exception`, not `X::Bind`.** Despite the name,
+`X::Bind::Slice ~~ X::Bind` is False in rakudo — `.^parents(:local)` is plain
+`Exception`. The namespace-prefix rule that would have suggested `X::Bind` is
+wrong more often than right across the `X::` hierarchy, because rakudo carries
+the shared behaviour in roles rather than superclasses; that is written up, with
+the measurements, in
+`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md` — 124 core `X::`
+classes are still unregistered and the sweep needed to fix them is a design
+question, not a mechanical one.
+
+Found by the full Test-vendoring sweep
+(`todo/tickets/compile-errors-that-name-no-exception-class.md`): mutsu's native
+`Test` provider was lenient enough to accept the wrong class, rakudo's real
+`Test.rakumod` is not. Two of the nine files in that ticket
+(`t/bind-to-whatever-index.t`, `t/indexed-bind-in-expression.t`) are cleared.
+The first of those grew four assertions covering `.message`, `.type`, the
+non-inheritance from `X::Bind`, and direct construction; it is green under
+`raku` too.

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -483,12 +483,29 @@ impl Compiler {
                 ..
             }
         ) {
+            // A Whatever index is always positional, so the sliced container is
+            // an Array. `type` and `message` mirror what rakudo's exception
+            // carries (`X::Bind::Slice.new(type => Array).message` is
+            // "Cannot bind to Array slice").
             self.compile_expr(&Expr::Call {
                 name: Symbol::intern("die"),
                 args: vec![Expr::MethodCall {
                     target: Box::new(Expr::BareWord("X::Bind::Slice".to_string())),
                     name: Symbol::intern("new"),
-                    args: vec![],
+                    args: vec![
+                        Expr::Binary {
+                            left: Box::new(Expr::Literal(Value::str("type".to_string()))),
+                            op: TokenKind::FatArrow,
+                            right: Box::new(Expr::BareWord("Array".to_string())),
+                        },
+                        Expr::Binary {
+                            left: Box::new(Expr::Literal(Value::str("message".to_string()))),
+                            op: TokenKind::FatArrow,
+                            right: Box::new(Expr::Literal(Value::str(
+                                "Cannot bind to Array slice".to_string(),
+                            ))),
+                        },
+                    ],
                     modifier: None,
                     quoted: false,
                 }],

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1733,6 +1733,10 @@ impl Interpreter {
         // X::Bind
         register_x("X::Bind", "Exception");
         register_x("X::Bind::NativeType", "X::Bind");
+        // Despite the name, `X::Bind::Slice` does not inherit `X::Bind` in
+        // rakudo — its only parent is `Exception` (`.^parents(:local)`), and
+        // `X::Bind::Slice ~~ X::Bind` is False there.
+        register_x("X::Bind::Slice", "Exception");
 
         // X::StubCode
         register_x("X::StubCode", "Exception");

--- a/t/bind-to-whatever-index.t
+++ b/t/bind-to-whatever-index.t
@@ -4,7 +4,7 @@
 # variable-index bind stay valid.
 use Test;
 
-plan 7;
+plan 11;
 
 throws-like { my @a; @a[*-1] := 42 }, X::Bind::Slice,
     'binding [*-1] of an empty array throws X::Bind::Slice';
@@ -12,6 +12,17 @@ throws-like { my @a = 1, 2, 3; @a[*-1] := 42 }, X::Bind::Slice,
     'binding [*-1] of a non-empty array throws X::Bind::Slice';
 throws-like { my @a = 1, 2, 3; @a[*-2] := 42 }, X::Bind::Slice,
     'binding [*-2] throws X::Bind::Slice';
+
+# The exception is a real type, carrying the attributes rakudo's does. It is
+# NOT a subtype of X::Bind despite the name — its only parent is Exception.
+{
+    my $e = (try { my @a; @a[*-1] := 42 }, $!).tail;
+    is $e.message, 'Cannot bind to Array slice', 'the message names the container type';
+    is $e.type.^name, 'Array', '.type is the sliced container type';
+    nok $e ~~ X::Bind, 'X::Bind::Slice does not inherit X::Bind';
+    isa-ok X::Bind::Slice.new(type => Array), X::Bind::Slice,
+        'and the class can be constructed directly';
+}
 
 # Valid binds are unaffected.
 {

--- a/todo/deep/exception-class-hierarchy-is-mostly-unregistered.md
+++ b/todo/deep/exception-class-hierarchy-is-mostly-unregistered.md
@@ -1,0 +1,73 @@
+# 124 core `X::` exception classes are not registered as types
+
+mutsu registers 77 `X::` classes in `src/runtime/runtime_init.rs` (the
+`register_x(name, parent)` block). It *raises* far more than that: every one of
+the 124 core exception classes below appears in mutsu's own source, but none is
+a real type, so `.new` on it does not exist.
+
+```
+$ mutsu -e 'say X::Bind::Slice.new.^name'
+X::Method::NotFound: Unknown method value dispatch (fallback disabled): new on X::Bind::Slice
+$ raku  -e 'say X::Bind::Slice.new.^name'
+X::Bind::Slice
+```
+
+That is not only a user-facing gap. mutsu's own compiler emits
+`X::Bind::Slice.new(...)` (`src/compiler/expr_closure.rs`), so the *raise* fails
+with `X::Method::NotFound` and `throws-like … , X::Bind::Slice` sees the wrong
+class — `t/bind-to-whatever-index.t` and `t/indexed-bind-in-expression.t` both
+fail this way under rakudo's real `Test` module
+(`todo/tickets/vendor-real-test-module.md`).
+
+## How the list was measured
+
+Every `X::…` name used as an expected type in a `throws-like` / `isa-ok` /
+`fails-like` across `t/` and `roast/` (217 names), minus those whose `.new`
+already works, minus those `raku` does not have either (test-local classes such
+as `X::Boom`, `X::Meow`) — leaving 124. All 137 failures had the identical
+signature (`Unknown method … new on <class>`), i.e. every one is *unregistered*
+rather than merely fussy about its attributes.
+
+## Why this needs design, not a mechanical sweep
+
+The obvious rule — parent = the longest `::`-prefix that is itself registered —
+is **wrong more often than right**, so applying it would bake false inheritance
+into the type system. Measured against raku:
+
+| child | namespace prefix | is it really an ancestor? |
+| --- | --- | --- |
+| `X::IO::Mkdir` | `X::IO` | yes |
+| `X::Comp::Trait::Unknown` | `X::Comp` | yes |
+| `X::Syntax::Perl5Var` | `X::Syntax` | yes |
+| `X::Bind::Slice` | `X::Bind` | **no** |
+| `X::Numeric::DivideByZero` | `X::Numeric` | **no** |
+| `X::Parameter::RW` | `X::Parameter` | **no** |
+| `X::Attribute::Required` | `X::Attribute` | **no** |
+| `X::Placeholder::Block` | `X::Placeholder` | **no** |
+| `X::Syntax::Malformed::Elsif` | `X::Syntax::Malformed` | **no** |
+| `X::Str::Sprintf::Directives::BadType` | `X::Str::Sprintf::Directives` | **no** |
+
+The reason is structural: in rakudo the shared behaviour is carried by **roles**
+(`X::Comp`, `X::Syntax`, `X::OS`, …), not by superclasses —
+`.^parents(:local)` is plain `Exception` for 117 of the 124. mutsu's
+`register_x` takes a single parent name and synthesises an MRO from it, so it
+can only approximate a role. Where the approximation happens to match (the
+existing `X::Syntax::*` entries) it is fine; where it does not, registering
+under the prefix would make `$ex ~~ X::Bind` answer True when raku says False.
+
+So the work is:
+
+1. Decide how `register_x` should express role-style membership — either extend
+   it with a `does` list that feeds the same `mro`/`istype` answer, or keep the
+   single parent and derive it from raku's real `.^mro ∪ .^roles` per class
+   rather than from the name.
+2. Generate the 124 entries from that decision (the raw data is cheap to
+   re-derive: `raku -e 'say X::Foo.^mro.map(*.^name); say X::Foo.^roles.map(*.^name)'`).
+3. Only then check what it unblocks — most `throws-like` assertions already
+   match on the class *name*, so the payoff is concentrated in the sites where
+   mutsu constructs the exception itself.
+
+Step 3 is worth doing first as a cheap sanity check: on the full Test-vendoring
+sweep only 2 of the 9 remaining regressions are caused by an unregistered class,
+so this is a correctness-of-the-type-system task rather than a
+sweep-clearing one, and it should be sized accordingly.

--- a/todo/tickets/compile-errors-that-name-no-exception-class.md
+++ b/todo/tickets/compile-errors-that-name-no-exception-class.md
@@ -17,8 +17,8 @@ $ mutsu -e 'try { EVAL q{sub f() returns { }} }; say $!.^name'
 
 | file | first failing assertion | class raku raises |
 | --- | --- | --- |
-| `t/bind-to-whatever-index.t` | binding `[*-1]` of an empty array | `X::Bind::Slice` |
-| `t/indexed-bind-in-expression.t` | a Whatever-index bind | `X::Bind::Slice` |
+| ~~`t/bind-to-whatever-index.t`~~ | ~~binding `[*-1]` of an empty array~~ | **done** — `news/2026-08/bind-slice-is-a-real-exception-class.md` |
+| ~~`t/indexed-bind-in-expression.t`~~ | ~~a Whatever-index bind~~ | **done** — same |
 | `t/return-constraint-malformed.t` | a malformed return constraint | `X::Syntax::Malformed` |
 | `t/name-null.t` | a type name with a null component | `X::Syntax::Name::Null` |
 | `t/radix-literals.t` | no numerals in an octal literal | `X::Syntax::Confused` |


### PR DESCRIPTION
Binding to a Whatever subscript (`@a[*-1] := 42`) is illegal, and mutsu's
compiler already emitted the right throw for it — `die X::Bind::Slice.new`. The
class was never registered, so `.new` did not exist on it and **the throw itself
failed with a different exception**:

```
$ mutsu -e 'try { my @a; @a[*-1] := 42 }; say $!.^name'
X::Method::NotFound
```

Registering it makes the raise land, and the raise site now passes the same
attributes rakudo's carries:

```
$ mutsu -e 'try { my @a; @a[*-1] := 42 }; say $!.^name; say $!.message; say $!.type.^name'
X::Bind::Slice
Cannot bind to Array slice
Array
```

— byte-identical to `raku`'s answer for the same program.

**It is registered under `Exception`, not `X::Bind`.** Despite the name,
`X::Bind::Slice ~~ X::Bind` is False in rakudo (`.^parents(:local)` is plain
`Exception`). The namespace-prefix rule that would have suggested `X::Bind` is
wrong more often than right across the `X::` hierarchy, because rakudo carries
the shared behaviour in **roles** rather than superclasses:

| child | namespace prefix | really an ancestor? |
| --- | --- | --- |
| `X::IO::Mkdir` | `X::IO` | yes |
| `X::Syntax::Perl5Var` | `X::Syntax` | yes |
| `X::Bind::Slice` | `X::Bind` | **no** |
| `X::Numeric::DivideByZero` | `X::Numeric` | **no** |
| `X::Parameter::RW` | `X::Parameter` | **no** |
| `X::Placeholder::Block` | `X::Placeholder` | **no** |

So the other 123 unregistered core classes are **not** swept in here. That
measurement, and why it needs a design decision (mutsu's `register_x` takes a
single parent and cannot express a role), is filed as
`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`.

## Testing

- `t/bind-to-whatever-index.t` grows four assertions (`.message`, `.type`, the
  non-inheritance from `X::Bind`, direct construction) — 11/11 under `raku` too.
- `make test`: 2719 files, 25973 tests, PASS.
- 70 related whitelisted roast files (`S02-names`, `S12-*`, `S04`/`S32-exceptions`): PASS.
- Under the aliased real `Test.rakumod`, `t/bind-to-whatever-index.t` and
  `t/indexed-bind-in-expression.t` now run clean — two of the nine files in
  `todo/tickets/compile-errors-that-name-no-exception-class.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)