### PR TITLE
fix(vm): a class's nested type keeps its short name across modules

### DIFF
--- a/news/2026-08/nested-type-short-name-owner-scope.md
+++ b/news/2026-08/nested-type-short-name-owner-scope.md
@@ -1,0 +1,58 @@
+# A class's nested type keeps its short name when another module registers the same name
+
+A type declared inside a class body (`class Outer { my grammar Header { ... } }`)
+was reachable from `Outer`'s own methods under the bare short name `Header`, but
+only until *some other* module registered an unrelated type of the same short
+name. After that, the bareword silently resolved to the foreign type.
+
+This is what stalled the Cro battery. `Cro::HTTP::Header` is a class whose body
+holds `my grammar Header`, and its `method parse` calls the bare `Header.parse`.
+Loading `Cro::HTTP::Router` — which declares `package Cro::HTTP::Router { role
+Header { } }` — made every subsequent `Cro::HTTP::Header.parse` dispatch to the
+*Router role*, which has no `parse` method, so it fell into grammar dispatch,
+found no `TOP` token, and died with "Unknown method value dispatch (fallback
+disabled): parse". Cro's request parser caught that as `bad-request('Malformed
+header')`, quit the supply, and the HTTP client hung with no response.
+
+## Root cause
+
+Bareword resolution for a nested type's short name went through
+`resolve_suppressed_type`, which probes the owner package chain
+(`current_package`, the method-class stack, the class under construction) for
+`<owner>::<short-name>`. That probe was gated on the name being in
+`suppressed_names` — the set that also drives "this bare name is undeclared
+outside its owner". Registering a type clears the suppression for its own short
+name (`unsuppress_name`), because a fresh declaration must be usable inside its
+own body. So an unrelated `Cro::HTTP::Router::Header` registration cleared the
+suppression that `Cro::HTTP::Header`'s nested grammar had installed, and with it
+the owner-chain probe for *every* class that owned a nested `Header`.
+
+The suppression set was doing double duty: recording undeclared-ness (which is
+correctly per-declaration and revocable) and recording "this short name belongs
+to some owner package" (which stays true for the rest of the program).
+
+## Fix
+
+Split the second fact into its own set, `class_scoped_short_names`, populated at
+the same site that calls `suppress_name` for a class-body-nested type, and never
+cleared. `resolve_suppressed_type` now runs its owner-chain probe when the name
+is in *either* set, and the bareword opcode no longer pre-gates the call on the
+suppression set.
+
+The probe still only succeeds when `<current owner>::<name>` is a real type, so a
+scope with no nested type of that name is unaffected: a module-body `my enum
+Expecting <RequestLine Header Body>` inside a *different* class still reads
+`Header` as its enum value, because that class owns no nested `Header`.
+
+`t/nested-type-short-name-owner-scope.t` pins the behaviour (nine assertions,
+passing unmodified under Rakudo): the owner's nested grammar survives a foreign
+same-named role, two classes with same-named nested classes each see their own,
+and a same-named enum value is not displaced.
+
+## Cro status after this
+
+`Cro::HTTP::Header.parse` now works with `Cro::HTTP::Router` loaded, and Cro's
+request parser gets through the request line and all header lines and emits the
+request. The end-to-end HTTP round-trip still does not complete; the remaining
+blocker is recorded in
+`todo/deep/cro-http-request-hang-short-name-env-pollution.md`.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1513,6 +1513,14 @@ pub struct Interpreter {
     method_fallbacks: HashMap<String, Vec<(Value, Value)>>,
     /// Names suppressed by `anon class`. These bare words should error as undeclared.
     suppressed_names: HashSet<String>,
+    /// Short names of types declared *inside a class body* (`class Outer { grammar
+    /// Inner {...} }` records `Inner`). Unlike `suppressed_names` this set is never
+    /// cleared: it records the fact that the short name belongs to some owner
+    /// package, which stays true for the rest of the program even after another
+    /// module registers an unrelated type of the same short name. It gates the
+    /// owner-package-chain probe in `resolve_suppressed_type`, so a method body
+    /// keeps seeing its own class's nested type (see `resolve_suppressed_type`).
+    class_scoped_short_names: HashSet<String>,
     /// Bare enum variant names poisoned by redeclaration from different enums.
     /// Maps bare name -> latest enum package name.
     poisoned_enum_aliases: HashMap<String, String>,

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -125,6 +125,14 @@ impl Interpreter {
         self.suppressed_names.remove(name);
     }
 
+    /// Record that `name` is the short name of a type declared inside a class
+    /// body, so bareword resolution keeps probing the owner package chain for it
+    /// even after `unsuppress_name` clears the suppression (see
+    /// `class_scoped_short_names`).
+    pub(crate) fn register_class_scoped_short_name(&mut self, name: &str) {
+        self.class_scoped_short_names.insert(name.to_string());
+    }
+
     /// Push a new lexical class scope frame.
     pub(crate) fn push_lexical_class_scope(&mut self) {
         self.lexical_class_scopes.push(Vec::new());
@@ -313,11 +321,20 @@ impl Interpreter {
         }
     }
 
-    /// Resolve a suppressed nested class short name to its qualified form.
-    /// For example, if `Frog` is suppressed and we are inside class `Forest`,
-    /// this returns `Some("Forest::Frog")` if `Forest::Frog` is a known type.
+    /// Resolve a nested class short name to its qualified form through the owner
+    /// package chain. For example, if we are inside class `Forest`, this returns
+    /// `Some("Forest::Frog")` for `Frog` if `Forest::Frog` is a known type.
+    ///
+    /// The probe runs for a name that is either currently suppressed *or* was ever
+    /// registered as a class-body-scoped short name. The latter is what keeps a
+    /// method body seeing its own class's nested type after an unrelated module
+    /// registers a same-named type: registering `Some::Other::Header` calls
+    /// `unsuppress_name("Header")` and binds the short name in the global env, so
+    /// gating on the suppression set alone made `Header.parse` inside
+    /// `Cro::HTTP::Header` dispatch to the foreign type instead of the class's own
+    /// `my grammar Header`.
     pub(crate) fn resolve_suppressed_type(&self, name: &str) -> Option<String> {
-        if !self.suppressed_names.contains(name) {
+        if !self.suppressed_names.contains(name) && !self.class_scoped_short_names.contains(name) {
             return None;
         }
         // Check current package

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2201,6 +2201,7 @@ impl Interpreter {
             method_wrap_chains: HashMap::new(),
             method_fallbacks: HashMap::new(),
             suppressed_names: HashSet::new(),
+            class_scoped_short_names: HashSet::new(),
             poisoned_enum_aliases: HashMap::new(),
             enum_scope_names: vec![Vec::new()],
             my_scoped_package_items: HashSet::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -488,6 +488,7 @@ impl Interpreter {
             method_wrap_chains: self.method_wrap_chains.clone(),
             method_fallbacks: self.method_fallbacks.clone(),
             suppressed_names: self.suppressed_names.clone(),
+            class_scoped_short_names: self.class_scoped_short_names.clone(),
             poisoned_enum_aliases: self.poisoned_enum_aliases.clone(),
             enum_scope_names: self.enum_scope_names.clone(),
             my_scoped_package_items: self.my_scoped_package_items.clone(),

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -62,6 +62,7 @@ impl Interpreter {
                 nested.user_declared_infix_ops = self.user_declared_infix_ops.clone();
                 nested.set_current_package(self.current_package());
                 nested.suppressed_names = self.suppressed_names.clone();
+                nested.class_scoped_short_names = self.class_scoped_short_names.clone();
                 nested.lexical_class_scopes = self.lexical_class_scopes.clone();
                 nested.var_dynamic_flags = self.var_dynamic_flags.clone();
                 nested.restore_var_type_constraints(self.snapshot_var_type_constraints());

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -261,6 +261,11 @@ impl Interpreter {
                 .unwrap_or(false);
             if qualified_name != resolved_name && !resolved_name.contains("::") && parent_is_class {
                 self.suppress_name(&resolved_name);
+                // ... and remember the short name permanently, so a later
+                // same-named type in an unrelated module (which clears the
+                // suppression) cannot steal bareword resolution from this
+                // class's own methods.
+                self.register_class_scoped_short_name(&resolved_name);
                 // Register the short name in the lexical env so it resolves
                 // within the enclosing class scope (e.g. `Frog` inside `Forest`).
                 let env = self.env_mut();

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -60,15 +60,14 @@ impl Interpreter {
             && name.ends_with('>')
         {
             Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(name), false)
-        } else if self.is_name_suppressed(name)
-            && let Some(qualified) = self.resolve_suppressed_type(name)
-        {
-            // Inside the parent class of the suppressed nested class the short
-            // name resolves to the qualified name (e.g. Frog -> Forest::Frog) —
-            // and it wins over a same-named entry the CALLER's scope may have
-            // leaked into env (`Header.parse` inside Cro::HTTP::Header must be
-            // the lexical grammar even when the caller has an enum value
-            // `Header` in scope).
+        } else if let Some(qualified) = self.resolve_suppressed_type(name) {
+            // Inside the parent class of the nested class the short name resolves
+            // to the qualified name (e.g. Frog -> Forest::Frog) — and it wins over
+            // a same-named entry that another scope leaked into env (`Header.parse`
+            // inside Cro::HTTP::Header must be the lexical grammar even when the
+            // caller has an enum value `Header` in scope, and even after an
+            // unrelated `Cro::HTTP::Router::Header` role registration cleared the
+            // suppression).
             Value::package(Symbol::intern(&qualified))
         } else if self.is_name_suppressed(name)
             // A LOCAL declaration wins over an unrelated module's suppressed

--- a/t/nested-type-short-name-owner-scope.t
+++ b/t/nested-type-short-name-owner-scope.t
@@ -1,0 +1,68 @@
+use Test;
+
+plan 9;
+
+# A type declared inside a class body is reachable from that class's own methods
+# under its short name, and stays reachable after an unrelated package registers
+# a type of the same short name. The short name is inserted into the global env
+# at registration time, so without owner-package-chain resolution the later
+# registration would steal the bareword from the earlier class's method bodies.
+
+class Outer {
+    my grammar Header {
+        token TOP { \d+ }
+    }
+
+    method parse-it(Str $s) {
+        Header.parse($s);
+    }
+}
+
+package Elsewhere {
+    role Header {
+        method tag() { "role" }
+    }
+}
+
+ok Outer.parse-it("123"), "the class's own nested grammar still parses";
+is Outer.parse-it("123").Str, "123", "and returns the expected match";
+nok Outer.parse-it("abc"), "a non-match is still a non-match";
+is Elsewhere::Header.tag, "role", "the unrelated same-named role is unaffected";
+
+# A nested class of the same short name in another class is per-owner: each
+# method body sees its own.
+class Box {
+    class Item {
+        method who() { "box-item" }
+    }
+    method make() { Item.new.who }
+}
+
+class Crate {
+    class Item {
+        method who() { "crate-item" }
+    }
+    method make() { Item.new.who }
+}
+
+is Box.make, "box-item", "Box sees its own nested Item";
+is Crate.make, "crate-item", "Crate sees its own nested Item";
+
+# A same-named enum value declared in an unrelated scope must not be displaced by
+# the nested type: the enum's owner has no nested type of that name, so the
+# bareword resolves to the enum value there.
+my enum Expecting <RequestLine Header Body>;
+
+class Consumer {
+    method state-of($e) {
+        given $e {
+            when Header { "header" }
+            when Body { "body" }
+            default { "other" }
+        }
+    }
+}
+
+is Consumer.state-of(Header), "header", "the enum value wins where no nested type owns the name";
+is Consumer.state-of(Body), "body", "the sibling enum value still matches";
+is Consumer.state-of(RequestLine), "other", "a non-matching enum value falls through";

--- a/todo/deep/cro-http-request-hang-short-name-env-pollution.md
+++ b/todo/deep/cro-http-request-hang-short-name-env-pollution.md
@@ -1,97 +1,106 @@
-# Cro HTTP request round-trip hangs: cross-module short-name env pollution breaks `Header.parse`
+# Cro HTTP request round-trip: the request is parsed and emitted, then never reaches the route handler
 
-## Where the Cro campaign stands
+## Where the Cro campaign stands (updated 2026-08-01)
 
 `use Cro::HTTP::Router`, `route { get -> { ... } }`, `use Cro::HTTP::Server`,
 `Cro::HTTP::Server.new(:host, :port, :application($app)).start` / `.stop` all
-work (#5658, #5666, #5668). Serving an actual HTTP request does NOT: the
-connection is accepted, the request bytes reach `Cro::HTTP::RequestParser`, the
-request line and the first header line parse — and then the request dies inside
-the parser, so no response is ever written and the client hangs.
+work (#5658, #5666, #5668). The request parser now works too: with the
+owner-scoped nested-type fix (`news/2026-08/nested-type-short-name-owner-scope.md`)
+`Cro::HTTP::Header.parse` resolves its class-body `my grammar Header` again even
+with `Cro::HTTP::Router` loaded, so the request line and every header line parse
+and `Cro::HTTP::RequestParser` reaches `emit $request`.
 
-Repro (environment prepared under `tmp/cro-work/`, see
-`handoff-cro-http-router-load` memory):
+Serving an actual HTTP request still does NOT complete: after the parser emits
+the request, the route handler is never entered and
+`Cro::HTTP::ResponseSerializer`'s `whenever $response-stream` never fires, so no
+bytes are written and the client times out with 0 bytes received.
+
+Repro (scratch clones under `tmp/cro-work/`, `-I` list in
+`tmp/cro-work/inc-paths.txt`; clone `cro-core`, `cro-http`, `cro-tls`,
+`jnthn/raku-log-timeline`, `retupmoca/P6-JSON-JWT`, `japhb/CBOR-Simple`,
+`japhb/TinyFloats`, `jnthn/p6-io-socket-async-ssl` — everything else is a
+bundled battery):
 
 ```
-timeout 90 target/debug/mutsu $(cat tmp/cro-work/inc-paths.txt) tmp/cro-server-request.p6
+timeout 200 target/debug/mutsu $(cat tmp/cro-work/inc-paths.txt) tmp/cro-server-request.p6
 ```
 
 (zsh note: expand `inc-paths.txt` inline with `$(cat ...)`; a `$VAR` expansion
 is not word-split and collapses every `-I` into one argument.)
 
-## Root cause chain (fully diagnosed, deterministic, main thread)
+Instrumented trace (add `note` lines directly to the scratch clones):
 
-1. `Cro::HTTP::Header` (Header.rakumod) contains a class-body lexical grammar:
-   `class Cro::HTTP::Header { my grammar Header { ... } ... method parse(...) }`.
-   `method parse` calls bare `Header.parse($value)` — the lexical grammar.
-2. `Cro::HTTP::Router::Roles` declares `package Cro::HTTP::Router { role Header {} ... }`.
-   Registering that role does two things to the GLOBAL env/state:
-   - `exec_register_role_op` calls `unsuppress_name("Header")`
-     (vm_typedecl_ops.rs:~499), which deletes the suppression that
-     `Cro::HTTP::Header`'s nested grammar registration had installed
-     (`suppress_name` in `exec_register_class_op`, parent-is-class branch).
-     The suppressed-name branch in `exec_get_bare_word_op`
-     (vm_var_get_ops.rs:63-72) — whose comment cites this exact
-     `Header.parse` case — therefore no longer fires.
-   - the short name `Header` in env ends up bound to the *Router* role's
-     package.
-3. When a request arrives, `Cro::HTTP::Header.parse` runs (its compiled method
-   was found fine), its body's bare `Header` resolves through env to
-   `Cro::HTTP::Router::Header`, `.parse` on that role has no user method, so it
-   falls into `dispatch_package_parse` (grammar machinery), finds no TOP token,
-   and dies "Unknown method value dispatch (fallback disabled): parse". The
-   RequestParser's header CATCH converts that to `bad-request('Malformed
-   header')`, the supply quits, and no response is written.
+```
+server started
+DBG packet 78 bytes
+DBG loop expecting=RequestLine
+DBG loop expecting=
+DBG header-line [Host: 127.0.0.1:31415]
+DBG header-line [User-Agent: curl/8.5.0]
+DBG header-line [Accept: */*]
+DBG emitting request (no body)
+                       <- route handler's "DBG handler entered" never prints
+                       <- ResponseSerializer's "DBG serializer got response" never prints
+curl exit: 28 (timed out, 0 bytes received)
+```
 
-gdb backtrace confirming step 3 (frame #12 = the user method executing, frame
-#0 = the wrong grammar dispatch):
-`dispatch_package_parse(package_name="Cro::HTTP::Router::Header", method="parse")`
-← `dispatch_method_by_name_1` ← ... ← `call_compiled_method(receiver="Cro::HTTP::Header", method="parse")`.
+So the remaining break is in the stage between the parser's `emit $request` and
+the `route` block's handler — the Cro pipeline connection (`Cro.compose` /
+`Cro::ConnectionManager`) or `Cro::HTTP::Router`'s own transformer supply.
+
+## Still open: a module-global short name beats an inner-scope enum value
+
+Visible in the trace above as the empty `DBG loop expecting=` lines.
+`Cro::HTTP::RequestParser.transformer` declares, inside its `supply` block,
+`my enum Expecting <RequestLine Header Body>`, and does `$expecting = Header`.
+`RequestLine` resolves to the enum value correctly, but `Header` resolves to
+`Cro::HTTP::Router::Header` — the *role* — because registering that role bound
+the bare short name `Header` in the ONE global env, and that binding wins over
+the enum value declared in an inner lexical scope.
+
+It happens not to break this particular request (`when Header` compares the same
+wrong value on both sides, so the header branch is still taken, and a bodyless
+GET never evaluates `when Body`), but it is wrong: `$expecting == Body` on a type
+object and the `Body` branch can never match.
+
+This is the residue of the original diagnosis and the part the fix above did NOT
+address. Short names of package-scoped types are inserted into the ONE global env
+at registration time, so a later module's type of the same short name outranks an
+inner-scope declaration in an earlier one. The owner-package-chain probe
+introduced by the fix covers the case where the *owner class* is asking; it
+cannot cover a same-named lexical declaration (an enum value, a `my` type) in an
+unrelated scope, because that declaration is not reachable from any owner chain.
+
+The real fix is to stop registering short-name aliases in the global env across
+module boundaries and keep them per-module, the way the parser's scan does — the
+same architecture gap as `package_chain_var_fallback` (#5658) but for TYPE names.
 
 ## Why the two obvious guards are not enough (both tried, reverted)
 
 - Guarding `unsuppress_name` to bare-name registrations only (so
-  `Cro::HTTP::Router::Header` keeps the suppression alive) moves the failure:
-  `Cro::HTTP::RequestParser` itself declares `my enum Expecting <RequestLine
-  Header Body>` and its `when Header { }` reads bare `Header` as the ENUM
-  VALUE. The suppressed-name branch's local-declaration carve-out
-  (vm_var_get_ops.rs:73-90) only tolerates a non-Package env value, and by
-  then env "Header" holds the Router role's Package (pollution again), so the
-  read throws X::Undeclared::Symbols instead.
+  `Cro::HTTP::Router::Header` keeps the suppression alive) moves the failure to
+  the enum case above: the suppressed-name branch's local-declaration carve-out
+  (vm_var_get_ops.rs) only tolerates a non-Package env value, and by then env
+  "Header" holds the Router role's Package, so the read throws
+  X::Undeclared::Symbols instead. (Superseded: the landed fix keeps the
+  suppression semantics untouched and adds a separate never-cleared
+  `class_scoped_short_names` set instead.)
 - Guarding the `"parse"|"subparse"|"parsefile"`-on-Package arm in
-  `methods_dispatch_match.rs` with `has_user_method_including_role` is correct
-  in itself (a class with its own `parse` method must not fall into grammar
-  dispatch) but does not fix this bug — the target has already resolved to the
+  `methods_dispatch_match.rs` with `has_user_method_including_role` is correct in
+  itself (a class with its own `parse` method must not fall into grammar
+  dispatch) but does not fix this bug — the target had already resolved to the
   wrong type by then.
-
-## The real problem
-
-Short names of nested/package-scoped types are inserted into the ONE global
-env at registration time (`exec_register_class_op` short-name binding, role
-registration's equivalent), and later modules overwrite or unsuppress them.
-Bare type-name resolution inside a method body should be LEXICAL: the
-declaring module's own scope (class-body lexicals like `my grammar Header`,
-module-body enum values like `Expecting`'s `Header`) must win over another
-module's same-short-name type, and each module should see its own view.
-
-That is the same architecture gap as `package_chain_var_fallback` (#5658) but
-for TYPE names, with the extra twist that env short-name aliases from
-unrelated modules currently WIN over the owner package chain. A candidate
-design: on bareword type resolution, probe the current package chain
-(`Cro::HTTP::Header::Header` from current_package/method-class stack) BEFORE
-the bare env alias, and stop registering short-name aliases in the global env
-across module boundaries (keep them per-module, like the parser's scan does).
-The suppression set is a partial, name-global approximation of this and keeps
-needing exceptions; per-module resolution would subsume it.
 
 ## Debugging techniques that worked (reuse these)
 
-- tmp/cro-work is a scratch copy — add `note "DBG: ..."` lines directly to the
-  vendored Cro sources to bisect the pipeline stage (TCP accept → conn Supply
-  emit → RequestParser packet → req-line → header-line → CATCH).
-- The raw socket path is healthy: tmp/raw-tcp-server.p6 (IO::Socket::Async +
-  external curl) round-trips fine.
-- Make the server script terminate for gdb by giving curl `-m 3`.
+- `tmp/cro-work` holds plain `git clone`s, not vendored sources — add
+  `note "DBG: ..."` lines directly to them to bisect the pipeline stage
+  (TCP accept -> conn Supply emit -> RequestParser packet -> req-line ->
+  header-line -> emit request -> route handler -> ResponseSerializer).
+- The raw socket path is healthy: an `IO::Socket::Async` echo server plus an
+  external `curl` round-trips fine.
+- Drive the client with `run 'curl', '-sS', '-i', '-m', '20', ...` from the same
+  script so the server process terminates on its own (and gdb can attach).
 - `rust-gdb -batch` breakpoints on the three "Unknown method value dispatch"
   sites (methods_grammar.rs / methods_instance_ops.rs /
-  methods_classhow_dispatch.rs) found the guilty one immediately.
+  methods_classhow_dispatch.rs) found the guilty one immediately last time.


### PR DESCRIPTION
A type declared inside a class body (`class Outer { my grammar Header {...} }`)
was reachable from `Outer`'s own methods as the bareword `Header`, but only until
*some other* module registered an unrelated type of the same short name. After
that the bareword silently resolved to the foreign type.

This is what stalled the Cro battery. `Cro::HTTP::Header` holds `my grammar
Header` in its class body and its `method parse` calls the bare `Header.parse`.
Loading `Cro::HTTP::Router` — which declares `package Cro::HTTP::Router { role
Header { } }` — made every subsequent `Cro::HTTP::Header.parse` dispatch to the
Router *role*, which has no `parse`, so it fell into grammar dispatch, found no
`TOP` token and died with "Unknown method value dispatch (fallback disabled):
parse". Cro's request parser caught that as `bad-request('Malformed header')`,
quit the supply, and the HTTP client hung with no response.

## Root cause

Bareword resolution for a nested type's short name goes through
`resolve_suppressed_type`, which probes the owner package chain
(`current_package`, the method-class stack, the class under construction) for
`<owner>::<short-name>`. The probe was gated on the name being in
`suppressed_names` — the set that also drives "this bare name is undeclared
outside its owner". That set is revocable by design: registering a type calls
`unsuppress_name` for its own short name, because a fresh declaration must be
usable inside its own body. So an unrelated `Cro::HTTP::Router::Header`
registration cleared the suppression `Cro::HTTP::Header`'s nested grammar had
installed, and with it the owner-chain probe for *every* class that owned a
nested `Header`.

The suppression set was doing double duty: recording undeclared-ness (correctly
per-declaration and revocable) and recording "this short name belongs to some
owner package" (which stays true for the rest of the program).

## Fix

Split the second fact into its own set, `class_scoped_short_names`, populated at
the same site that calls `suppress_name` for a class-body-nested type, and never
cleared. `resolve_suppressed_type` runs its owner-chain probe when the name is in
*either* set, and the bareword opcode no longer pre-gates the call on the
suppression set.

The probe still only succeeds when `<current owner>::<name>` is a real type, so a
scope owning no nested type of that name is unaffected: a module-body `my enum
Expecting <RequestLine Header Body>` in a different class still reads `Header` as
its enum value.

## Tests

`t/nested-type-short-name-owner-scope.t` — nine assertions, **passing unmodified
under Rakudo**: the owner's nested grammar survives a foreign same-named role,
two classes with same-named nested classes each see their own, and a same-named
enum value is not displaced.

Local gates, all green:

- `make test` — 2719 files / 25995 tests PASS
- `make roast` — 1435 files / 218774 tests PASS
- `scripts/battery-testsuite.sh` — `GATE PASSED` (153/158)

## Cro status after this

`Cro::HTTP::Header.parse` now works with `Cro::HTTP::Router` loaded, and Cro's
request parser gets through the request line and every header line and emits the
request. The end-to-end round-trip still does not complete — the request never
reaches the route handler — and that narrowed blocker is re-recorded in
`todo/deep/cro-http-request-hang-short-name-env-pollution.md`, together with the
remaining "a module-global short name beats an inner-scope enum value" residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)