### PR TITLE
fix(parser): a parse failure carries an `X::Syntax::` class

### DIFF
--- a/news/2026-08/parse-failures-carry-a-syntax-exception-class.md
+++ b/news/2026-08/parse-failures-carry-a-syntax-exception-class.md
@@ -1,0 +1,66 @@
+# A parse failure carries an `X::Syntax::` class instead of collapsing to `X::AdHoc`
+
+`news/2026-08/typed-exception-class-from-the-message-convention.md` made the
+`"X::Type: text"` message convention real, which typed every compile-time error
+whose message already *spelled* its class. What it could not reach were the
+errors that name no class at all — a parse failure reported as `Confused. parse
+error at line 1, column 1: expected ...`, where raku raises a specific
+`X::Syntax::` class. `throws-like` and a typed `CATCH { when X::Syntax::… {…} }`
+both dispatch on the class, so those assertions still failed.
+
+## The catch-all
+
+A parse failure is a *syntax* error, and raku's catch-all for a construct it
+cannot describe more precisely is `X::Syntax::Confused` — which is also what
+mutsu's own message has always said. `RuntimeError`'s untyped fallback now picks
+its class from the structured `code` metadata rather than from the message text:
+a `ParseUnparsed` / `ParseExpected` / `ParseGeneric` error with no structured
+exception and no message convention becomes `X::Syntax::Confused`; everything
+else stays `X::AdHoc`, the class a bare `die "msg"` produces. Both IS-A
+`Exception`, so `isa-ok $!, Exception` matches either way. The compile-time sites
+that raise something more specific (`X::Undeclared::Symbols`,
+`X::Comp::WheneverOutOfScope`, `X::Redeclaration::Outer`, `X::Comp::AdHoc`)
+already attach a structured exception and never reach the fallback.
+
+## The specific shapes
+
+Three constructs raku names precisely were reaching the parser's generic
+"expected ..." path, so the catch-all alone would have mistyped them:
+
+- **A `-->` return constraint that is not last in the signature.**
+  `sub f (--> Bool, Int $y)` and `sub f ($x; --> Bool; Int $y)` only produced
+  `expected ')'`, because the return-constraint parser returned as soon as it had
+  read the type and left the stray tail to the caller. The signature-final
+  position now checks that the constraint is followed by the closing `)` and
+  otherwise raises `X::Syntax::Malformed` with raku's wording, *Malformed return
+  value (return constraints only allowed at the end of the signature)*. The `;`
+  and `;;` multidimensional branches learned to read a `-->` at all, which is how
+  the third shape above reaches that check instead of trying to parse `-->` as a
+  parameter.
+- **A variable name opening with a digit of a non-ASCII script.** `my $১০kinds`
+  is `X::Syntax::Variable::Numeric` in raku; mutsu's check was
+  `is_ascii_digit`, so only `my $0` was caught. The rule is about the digit
+  property, not the encoding.
+- **A variable name opening with a combining mark.** `my $̈a` is a malformed
+  declarator (`X::Syntax::Malformed`, *Malformed my*), not a confusing one.
+- **A null component in a bareword qualified name.** `$a::::b` and `@a::::b`
+  already raised `X::Syntax::Name::Null` through `qualified_ident`, but
+  `Foo::::Bar` is parsed by the bareword type-name path in `primary/ident`,
+  which qualifies names of its own and fell through to a generic *identifier
+  after '::'*. It now shares the same error builder.
+
+## Effect on the Test-vendoring sweep
+
+Measured against the unmodified upstream `Test.rakumod` under the `Test2` alias
+(`todo/tickets/vendor-real-test-module.md`): of the 7 files still failing on an
+exception *class*, **5 are cleared** — `modifier-cond-ending-in-block.t`,
+`radix-literals.t`, `return-constraint-malformed.t`, `unicode-identifiers.t`,
+`name-null.t`. The two that remain are different root causes, not missing
+classes: `block-lexical-scope.t` wants `X::Undeclared::Symbols ~~ X::Undeclared`
+(the unregistered-hierarchy problem of
+`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`) and
+`out-of-range-scalar-index.t` fails on `use fatal` inside a string-form
+`throws-like`, where the code does not die at all.
+
+Pinned by `t/parse-failure-syntax-exception-class.t`, whose 12 assertions are
+green under `raku` too.

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1117,6 +1117,13 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         let mut r = rest;
         while r.starts_with("::") {
             let after = &r[2..];
+            // `Foo::::Bar` — an empty component between `::` separators is a
+            // null name component. The sigilled forms (`$a::::b`) are rejected
+            // by `qualified_ident`; a bareword type name reaches here instead,
+            // and used to fall through to the generic "identifier after '::'".
+            if after.starts_with("::") {
+                return Err(crate::parser::stmt::name_null_error_pub());
+            }
             if let Some(after_brace) = after.strip_prefix('{') {
                 let (r2, _) = ws(after_brace)?;
                 let (r2, key_expr) = expression(r2)?;

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -259,12 +259,24 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
         // not consumed by `var_name`, so check the post-sigil text directly.
         if sigil == b'$' {
             let after = &rest[1..];
-            // `my $0`, `my $123` — numeric variables cannot be declared.
-            if after.starts_with(|c: char| c.is_ascii_digit()) {
+            // `my $0`, `my $123` — numeric variables cannot be declared. The
+            // rule is about the digit *property*, not about ASCII: `my $১০kinds`
+            // opens with Bengali digits and Raku rejects it the same way.
+            if after.starts_with(|c: char| c.is_numeric()) {
                 return Err(illegal_my_var_error(
                     "X::Syntax::Variable::Numeric",
                     "Cannot declare a numeric variable",
                     &[],
+                ));
+            }
+            // `my $<combining mark>a` — an identifier may not open with a
+            // combining mark, and Raku reports the declarator itself as
+            // malformed rather than blaming the character.
+            if after.starts_with(unicode_normalization::char::is_combining_mark) {
+                return Err(illegal_my_var_error(
+                    "X::Syntax::Malformed",
+                    &format!("Malformed {}", scope_name),
+                    &[("what", scope_name)],
                 ));
             }
             // `my $<a>` — match variables cannot be declared.

--- a/src/parser/stmt/idents.rs
+++ b/src/parser/stmt/idents.rs
@@ -80,7 +80,7 @@ pub(crate) fn parse_raku_ident<'a>(input: &'a str) -> PResult<'a, &'a str> {
 /// Parse a qualified identifier (Foo::Bar::Baz).
 /// `X::Syntax::Name::Null` — a qualified name with an empty component, e.g.
 /// `Foo::::Bar` or `$a::::b`.
-fn name_null_error() -> PError {
+pub(super) fn name_null_error() -> PError {
     let msg = "Name component may not be null".to_string();
     let mut attrs = std::collections::HashMap::new();
     attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -54,10 +54,11 @@ pub(super) use stmtlist::{block_inner, stmt_list_partial};
 // original `pub(super)` visibility (consumed by `primary`/`expr`).
 pub(super) use pub_shims::{
     constant_decl_pub, for_stmt_pub, given_stmt_pub, ident_pub, if_stmt_pub, labeled_loop_stmt_pub,
-    lazy_for_stmt_pub, let_stmt_pub, loop_stmt_pub, my_decl_expr_pub, parse_param_list_pub,
-    parse_param_list_with_return_pub, parse_pointy_param_pub, parse_return_type_annotation_pub,
-    parse_sub_name_pub, parse_sub_traits_pub, statement_pub, sub_decl_body_pub,
-    sub_decl_with_semicolon_mode_pub, temp_stmt_pub, until_stmt_pub, while_stmt_pub, with_stmt_pub,
+    lazy_for_stmt_pub, let_stmt_pub, loop_stmt_pub, my_decl_expr_pub, name_null_error_pub,
+    parse_param_list_pub, parse_param_list_with_return_pub, parse_pointy_param_pub,
+    parse_return_type_annotation_pub, parse_sub_name_pub, parse_sub_traits_pub, statement_pub,
+    sub_decl_body_pub, sub_decl_with_semicolon_mode_pub, temp_stmt_pub, until_stmt_pub,
+    while_stmt_pub, with_stmt_pub,
 };
 
 thread_local! {

--- a/src/parser/stmt/pub_shims.rs
+++ b/src/parser/stmt/pub_shims.rs
@@ -72,6 +72,12 @@ pub(crate) fn constant_decl_pub(input: &str) -> PResult<'_, Stmt> {
     decl::constant_decl(input)
 }
 
+/// Public accessor for the null-name-component error (used by the bareword
+/// type-name parser in `primary/ident`, which qualifies names of its own).
+pub(crate) fn name_null_error_pub() -> super::PError {
+    idents::name_null_error()
+}
+
 /// Public accessor for statement (used by primary.rs for do-statement expressions).
 pub(crate) fn statement_pub(input: &str) -> PResult<'_, Stmt> {
     statement(input)

--- a/src/parser/stmt/sub/return_type.rs
+++ b/src/parser/stmt/sub/return_type.rs
@@ -7,6 +7,40 @@ pub(crate) fn skip_return_type_annotation(input: &str) -> Result<&str, PError> {
     Ok(rest)
 }
 
+/// Raku's compile-time error for a `-->` return constraint that is not the last
+/// element of the signature: `sub f (--> Int, $x)`, `sub f ($x; --> Int; $y)`.
+/// Without it the stray tail only reached the caller's `expected ')'`, which
+/// collapses into a generic parse failure and loses the class `throws-like` and
+/// a typed `CATCH` dispatch on.
+fn malformed_return_value_error() -> PError {
+    const WHAT: &str = "return value (return constraints only allowed at the end of the signature)";
+    let message = format!("Malformed {}", WHAT);
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert(
+        "message".to_string(),
+        crate::value::Value::str(message.clone()),
+    );
+    attrs.insert(
+        "what".to_string(),
+        crate::value::Value::str(WHAT.to_string()),
+    );
+    let exception = crate::value::Value::make_instance(
+        crate::symbol::Symbol::intern("X::Syntax::Malformed"),
+        attrs,
+    );
+    PError::fatal_with_exception(message, Box::new(exception))
+}
+
+/// `parse_return_type_annotation` for the signature-final position: the
+/// constraint has to be followed by the closing `)` of the signature.
+fn parse_final_return_type_annotation(input: &str) -> PResult<'_, String> {
+    let (rest, rt) = parse_return_type_annotation(input)?;
+    if !rest.starts_with(')') {
+        return Err(malformed_return_value_error());
+    }
+    Ok((rest, rt))
+}
+
 /// Parse a return type annotation (--> Type) and return both remainder and type name.
 pub(crate) fn parse_return_type_annotation(input: &str) -> PResult<'_, String> {
     let (rest, _) = ws(input)?;
@@ -170,7 +204,7 @@ pub(crate) fn parse_param_list_with_return_inner(
         return Ok((rest, (params, None)));
     }
     if let Some(stripped) = rest.strip_prefix("-->") {
-        let (r, rt) = parse_return_type_annotation(stripped)?;
+        let (r, rt) = parse_final_return_type_annotation(stripped)?;
         return Ok((r, (params, Some(rt))));
     }
     if let Some(r) = rest.strip_prefix(";;") {
@@ -200,7 +234,7 @@ pub(crate) fn parse_param_list_with_return_inner(
         // A typed invocant may be followed directly by the return constraint:
         // `method m(Foo:D: --> Str)` has no positional params after the invocant.
         if let Some(stripped) = rest.strip_prefix("-->") {
-            let (r, rt) = parse_return_type_annotation(stripped)?;
+            let (r, rt) = parse_final_return_type_annotation(stripped)?;
             return Ok((r, (params, Some(rt))));
         }
         let (r, mut p) = parse_single_param(rest)?;
@@ -221,6 +255,11 @@ pub(crate) fn parse_param_list_with_return_inner(
             if r.starts_with(')') {
                 mark_params_as_invocant(&mut params);
                 return Ok((r, (params, return_type)));
+            }
+            if let Some(stripped) = r.strip_prefix("-->") {
+                let (r, rt) = parse_final_return_type_annotation(stripped)?;
+                mark_params_as_invocant(&mut params);
+                return Ok((r, (params, Some(rt))));
             }
             let (r, mut p) = parse_single_param(r)?;
             p.multi_invocant = multi_invocant;
@@ -254,7 +293,7 @@ pub(crate) fn parse_param_list_with_return_inner(
             // Handle --> return type after invocant marker
             if let Some(stripped) = r.strip_prefix("-->") {
                 mark_params_as_invocant(&mut params);
-                let (r, rt) = parse_return_type_annotation(stripped)?;
+                let (r, rt) = parse_final_return_type_annotation(stripped)?;
                 return_type = Some(rt);
                 return Ok((r, (params, return_type)));
             }
@@ -268,6 +307,10 @@ pub(crate) fn parse_param_list_with_return_inner(
             let (r, _) = ws(r)?;
             if r.starts_with(')') {
                 return Ok((r, (params, return_type)));
+            }
+            if let Some(stripped) = r.strip_prefix("-->") {
+                let (r, rt) = parse_final_return_type_annotation(stripped)?;
+                return Ok((r, (params, Some(rt))));
             }
             let (r, mut p) = parse_single_param(r)?;
             p.multi_invocant = multi_invocant;
@@ -287,7 +330,7 @@ pub(crate) fn parse_param_list_with_return_inner(
         }
         if !r.starts_with(',') {
             if let Some(stripped) = r.strip_prefix("-->") {
-                let (r, rt) = parse_return_type_annotation(stripped)?;
+                let (r, rt) = parse_final_return_type_annotation(stripped)?;
                 return_type = Some(rt);
                 return Ok((r, (params, return_type)));
             }
@@ -299,7 +342,7 @@ pub(crate) fn parse_param_list_with_return_inner(
             return Ok((r, (params, return_type)));
         }
         if let Some(stripped) = r.strip_prefix("-->") {
-            let (r, rt) = parse_return_type_annotation(stripped)?;
+            let (r, rt) = parse_final_return_type_annotation(stripped)?;
             return_type = Some(rt);
             return Ok((r, (params, return_type)));
         }

--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -176,11 +176,31 @@ impl RuntimeError {
         well_formed.then_some((name, text))
     }
 
+    /// The class to fall back on when the error carries neither a structured
+    /// exception nor the `"X::Type: text"` message convention.
+    ///
+    /// A bare `die "msg"` produces `X::AdHoc` in Raku, so that is the default.
+    /// But an error the parser raised is a *syntax* error, and Raku's catch-all
+    /// for one it cannot describe more precisely is `X::Syntax::Confused` —
+    /// which is also what mutsu's own message says ("Confused. parse error at
+    /// ..."). The decision reads the structured `code` rather than the message
+    /// text, so it does not depend on that wording. Sites that raise a more
+    /// specific compile-time class (`X::Undeclared::Symbols`,
+    /// `X::Comp::WheneverOutOfScope`, ...) already attach a structured
+    /// exception and never reach here.
+    ///
+    /// Both classes IS-A `Exception`, so `isa-ok $!, Exception` still matches.
+    fn untyped_exception_class(&self) -> &'static str {
+        match self.code() {
+            Some(code) if code.is_parse() => "X::Syntax::Confused",
+            _ => "X::AdHoc",
+        }
+    }
+
     /// The exception object this error presents to `CATCH` / `$!` /
     /// `throws-like`. Prefers a structured exception the error already carries,
-    /// then the `"X::Type: text"` message convention, and finally `X::AdHoc` —
-    /// the class a bare `die "msg"` produces in Raku. `X::AdHoc` IS-A
-    /// `Exception`, so `isa-ok $!, Exception` still matches an untyped error.
+    /// then the `"X::Type: text"` message convention, and finally the untyped
+    /// fallback class above.
     pub(crate) fn exception_value(&self) -> Value {
         self.exception_value_with_backtrace(None)
     }
@@ -193,7 +213,7 @@ impl RuntimeError {
             return (**ex).clone();
         }
         let (class_name, text) = Self::split_typed_message_convention(&self.message)
-            .unwrap_or(("X::AdHoc", self.message.as_str()));
+            .unwrap_or((self.untyped_exception_class(), self.message.as_str()));
         let mut attrs = HashMap::new();
         attrs.insert("message".to_string(), Value::str_from(text));
         if let Some(line) = self.line() {

--- a/t/parse-failure-syntax-exception-class.t
+++ b/t/parse-failure-syntax-exception-class.t
@@ -1,0 +1,54 @@
+use Test;
+
+# A parse failure is a *syntax* error, so it carries an X::Syntax:: class that
+# `throws-like` and a typed `CATCH { when ... }` can dispatch on. Raku's
+# catch-all for a construct it cannot describe more precisely is
+# X::Syntax::Confused; specific shapes get the class Raku names for them.
+
+plan 12;
+
+# The catch-all.
+throws-like q:to/CODE/, X::Syntax::Confused,
+    my @b = 1, 2;
+    say 1 if @b.elems
+    say 2
+    CODE
+    'two terms in a row is X::Syntax::Confused';
+
+throws-like 'say 1 ]', X::Syntax::Confused,
+    'an unexpected closing bracket is X::Syntax::Confused';
+
+# A bareword type name gets the same null-component check the sigilled forms
+# (`$a::::b`) already had.
+throws-like 'Foo::::Bar.new', X::Syntax::Name::Null,
+    'a bareword type name may not have a null component';
+
+# A `-->` return constraint is only legal as the last element of a signature.
+throws-like 'sub foo (--> Bool, Int $y) { True }', X::Syntax::Malformed,
+    'a return constraint before a parameter is malformed';
+
+throws-like 'sub foo ($x, --> Bool, Int $y) { True }', X::Syntax::Malformed,
+    'a return constraint in the middle of the parameters is malformed';
+
+throws-like 'sub foo ($x; --> Bool; Int $y) { True }', X::Syntax::Malformed,
+    'the same across a multidimensional `;` signature';
+
+# The legal shapes still parse.
+lives-ok { EVAL 'sub ok1 ($x, $y --> Bool) { True }' },
+    'a trailing return constraint still works';
+lives-ok { EVAL 'sub ok2 (--> Bool) { True }' },
+    'a signature that is only a return constraint still works';
+lives-ok { EVAL 'sub ok3 (@a; @b) { @a.elems + @b.elems }' },
+    'a multidimensional `;` signature still works';
+
+# A variable name may not open with a digit -- of any script -- nor with a
+# combining mark.
+throws-like 'my $10kinds', X::Syntax::Variable::Numeric,
+    'an ASCII-digit-initial variable cannot be declared';
+
+throws-like qq{my \$\c[BENGALI DIGIT ONE]\c[BENGALI DIGIT ZERO]kinds},
+    X::Syntax::Variable::Numeric,
+    'a non-ASCII-digit-initial variable cannot be declared either';
+
+throws-like qq{my \$\c[COMBINING DIAERESIS]a;}, X::Syntax::Malformed,
+    'a combining mark may not open an identifier';

--- a/todo/tickets/use-fatal-lost-in-a-string-form-throws-like.md
+++ b/todo/tickets/use-fatal-lost-in-a-string-form-throws-like.md
@@ -1,0 +1,54 @@
+# `use fatal` inside a string-form `throws-like` does not take effect
+
+Found while re-running the Test-vendoring sweep
+(`todo/tickets/vendor-real-test-module.md`). Under rakudo's real
+`Test.rakumod`, the string form of `throws-like` reports that the code did not
+die at all:
+
+```
+$ cat tmp/fatal-probe.raku
+use Test2;
+plan 2;
+throws-like 'use fatal; "foo"[2]', X::OutOfRange, 'string form';
+throws-like { use fatal; "foo"[2] }, X::OutOfRange, 'block form';
+
+$ mutsu -I tmp/core tmp/fatal-probe.raku
+    not ok 1 - 'use fatal; "foo"[2]' died      # raku: ok
+ok 2 - block form                              # the block form is fine
+```
+
+`"foo"[2]` returns a `Failure`; `use fatal` is what turns it into a throw. The
+block form works, so `use fatal` itself is not the problem — the string form is.
+
+This is the last of the seven `t/` files that regressed under the real module on
+an exception-classing signature; the other six were fixed by
+`news/2026-08/typed-exception-class-from-the-message-convention.md` and
+`news/2026-08/parse-failures-carry-a-syntax-exception-class.md`. It is the only
+one that is not about the *class* of the exception — nothing is thrown.
+
+## What has been ruled out
+
+`Test.rakumod`'s string branch is
+
+```raku
+EVAL $code, context => $caller-context;
+```
+
+inside the `subtest { ... }` block, with `$caller-context` from
+`$*THROWS-LIKE-CONTEXT // CALLER::`. Each of these narrower shapes **does**
+throw correctly, so none of them is the cause on its own:
+
+- `try { EVAL $c }` in the mainline
+- `sub f($code) { EVAL $code }` — plain, from a sub
+- `sub f($code) { my $ctx = CALLER::; EVAL $code, context => $ctx }` — with an
+  explicit context
+- the same two shapes exported from a module (`tmp/core/FatalMod.rakumod`)
+
+So the loss needs the remaining ingredient the real module adds: the `EVAL` runs
+inside a `subtest` block that also carries a `CATCH { default { ... } }`. The
+next step is to reproduce it with a hand-written `subtest`-plus-`CATCH` wrapper
+and find where the pragma stops being applied to the EVAL'd unit — most likely a
+place where the enclosing block's compilation is re-entered and the `fatal`
+pragma is read from the wrong unit.
+
+Affected test file: `t/out-of-range-scalar-index.t` (its first two assertions).

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -194,9 +194,25 @@ them. The other 9 are errors whose message names no class at all (`Confused.
 parse error at …` where raku raises `X::Syntax::Malformed` /
 `X::Bind::Slice` / …) — worth its own pass.
 
-So what stands between here and flipping `runtime_module.rs` is that residue
-plus a pass over the lenient-`is` test files. Re-run `tmp/sweep-full.sh` to
-re-measure after each.
+### The exception-class residue is closed (2026-08-01)
+
+That pass is done. The 9 split into three unrelated causes and all but one are
+fixed:
+
+| cause | files | fix |
+| --- | --- | --- |
+| `X::Bind::Slice` was never registered, so its own `.new` did not exist | 2 | `news/2026-08/bind-slice-is-a-real-exception-class.md` |
+| a parse failure had no class at all — the parser's generic `Confused. parse error at …` | 5 | `news/2026-08/parse-failures-carry-a-syntax-exception-class.md` |
+| `use fatal` inside a *string-form* `throws-like` never throws | 1 | open: `todo/tickets/use-fatal-lost-in-a-string-form-throws-like.md` |
+
+The one file left over (`t/block-lexical-scope.t`) is not an exception-classing
+bug at all: it wants `X::Undeclared::Symbols ~~ X::Undeclared`, i.e. the
+unregistered-hierarchy problem of
+`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`.
+
+So what stands between here and flipping `runtime_module.rs` is those two open
+records plus a pass over the lenient-`is` test files. Re-run `tmp/sweep-full.sh`
+to re-measure after each.
 
 ## Blocker found while doing step 1: the native provider shadows an import — FIXED
 


### PR DESCRIPTION
`news/2026-08/typed-exception-class-from-the-message-convention.md` made the `"X::Type: text"` message convention real, which typed every compile-time error whose message already *spelled* its class. What it could not reach were the errors that name no class at all — a parse failure reported as `Confused. parse error at line 1, column 1: expected ...`, where raku raises a specific `X::Syntax::` class. `throws-like` and a typed `CATCH { when X::Syntax::… {…} }` both dispatch on the class, so those assertions still failed.

## The catch-all

A parse failure is a *syntax* error, and raku's catch-all for a construct it cannot describe more precisely is `X::Syntax::Confused` — which is also what mutsu's own message has always said. `RuntimeError`'s untyped fallback now picks its class from the structured `code` metadata rather than from the message text: a `ParseUnparsed` / `ParseExpected` / `ParseGeneric` error with no structured exception and no message convention becomes `X::Syntax::Confused`; everything else stays `X::AdHoc`. Both IS-A `Exception`, so `isa-ok $!, Exception` matches either way. The compile-time sites that raise something more specific (`X::Undeclared::Symbols`, `X::Comp::WheneverOutOfScope`, `X::Redeclaration::Outer`, `X::Comp::AdHoc`) already attach a structured exception and never reach the fallback.

## The specific shapes

Four constructs raku names precisely were reaching the parser's generic "expected ..." path, so the catch-all alone would have mistyped them:

- **A `-->` return constraint that is not last in the signature.** `sub f (--> Bool, Int $y)` only produced `expected ')'`. The signature-final position now checks that the constraint is followed by the closing `)` and otherwise raises `X::Syntax::Malformed` with raku's wording. The `;` / `;;` multidimensional branches learned to read a `-->` at all, which is how `sub f ($x; --> Bool; Int $y)` reaches that check instead of trying to parse `-->` as a parameter.
- **A variable name opening with a digit of a non-ASCII script.** `my $১০kinds` is `X::Syntax::Variable::Numeric`; the check was `is_ascii_digit`, but the rule is about the digit property, not the encoding.
- **A variable name opening with a combining mark.** `my $̈a` is a malformed declarator (*Malformed my*), not a confusing one.
- **A null component in a bareword qualified name.** `$a::::b` already raised `X::Syntax::Name::Null` through `qualified_ident`; `Foo::::Bar` is parsed by the bareword type-name path, which qualifies names of its own and fell through to a generic *identifier after '::'*. It now shares the same error builder.

## Effect on the Test-vendoring sweep

Measured against the unmodified upstream `Test.rakumod` under the `Test2` alias (`todo/tickets/vendor-real-test-module.md`): of the 7 `t/` files still failing on an exception *class*, **5 are cleared** — `modifier-cond-ending-in-block.t`, `radix-literals.t`, `return-constraint-malformed.t`, `unicode-identifiers.t`, `name-null.t`.

The two left over are different root causes, not missing classes, and both are recorded: `block-lexical-scope.t` wants `X::Undeclared::Symbols ~~ X::Undeclared` (`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`), and `out-of-range-scalar-index.t` fails because `use fatal` inside a string-form `throws-like` never throws — filed as `todo/tickets/use-fatal-lost-in-a-string-form-throws-like.md` with the shapes already ruled out.

## Testing

- `t/parse-failure-syntax-exception-class.t` — 12 assertions, **green under `raku` too**.
- `make test`: `Files=2721, Tests=26016 … Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)