### PR TITLE
fix(regex): a `:my` lexical reaches its `make` block

### DIFF
--- a/news/2026-08/regex-my-lexical-in-make-block.md
+++ b/news/2026-08/regex-my-lexical-in-make-block.md
@@ -1,0 +1,67 @@
+# A regex `:my` lexical reaches its `make` block — and Cro serves a request
+
+A regex's own `:my`/`:let` lexical was invisible to any code block containing
+`make`:
+
+```raku
+my $m = "a" ~~ / :my $x = 9; 'a' { make (0, $x) } /;
+say $m.ast;    # Rakudo: (0, 9)    mutsu: (0, Nil)
+```
+
+An inline block (`{ say $x }`) read it fine; only the `make`-bearing one saw
+`Nil`. That is Cro's route dispatcher exactly: `Cro::HTTP::Router` builds its
+path matcher by `EVAL`ing a regex of the shape
+
+```
+regex { ^ :my $req = …; :my @segs = …; :my $cap; [ … { … $cap = Capture.new(…) } … { make ($index, $cap) } … ] $ }
+```
+
+so every matched route reduced with `$cap` unset, `RouteHandler.invoke` failed
+its `Capture $args` type check inside a `supply`, the failure was swallowed, and
+the HTTP client hung with no response.
+
+## Root cause
+
+Two mechanisms have to meet, and neither knew about the other.
+
+A declarative `:my` at the front of a pattern is **hoisted out** of the pattern
+before matching (`parse_regex_declarative_prefix`), evaluated into `env`, and
+restored as soon as the match returns. A code block that runs *inline* during
+matching therefore just reads it from `env` — which is why the inline case
+worked and looked like the feature was implemented.
+
+A block containing `make` does **not** run inline: it needs the ordering the
+bottom-up reduce walk gives, so it is recorded as a `CodeBlockContext` and
+replayed later. By then the hoisted lexical has been restored out of `env`, and
+`CodeBlockContext` carried no lexical state of its own — so the block read an
+unset variable.
+
+## Fix
+
+- `CodeBlockContext` gains `regex_vars`: the in-regex lexicals as they stood at
+  the block's textual position, captured when the block is recorded.
+- A successful match carries the hoisted declarative lexicals on its captures, so
+  the reduce walk can reinstall them.
+- `reduce_run_code_blocks` (and the eager-block replay) installs those lexicals
+  around each replayed block and restores the caller's own same-named bindings
+  afterwards, threading a block's writes forward to the next block — the same
+  ordering the inline path gets from `RegexCaptures::regex_vars`.
+
+A `:my $*x` is deliberately excluded from all of this: it is a *dynamic*
+variable owned by the per-rule dynvar machinery
+(`install_fresh_rule_dynvars`), which intentionally leaves its write installed
+for the action walk that follows. Snapshotting and restoring it around a block
+would undo that — `t/grammar-per-match-dynvar-action.t` catches it, and
+`is_dynamic_regex_var_key` now draws the line in one place.
+
+`t/regex-my-lexical-in-make-block.t` pins the behaviour with seven assertions,
+passing unmodified under Rakudo.
+
+## Cro
+
+With this and the owner-scoped nested-type fix
+(`news/2026-08/nested-type-short-name-owner-scope.md`), **Cro serves a real HTTP
+request under mutsu**: `Cro::HTTP::Server` + `route { get -> { content … } }`
+answers `curl` with a complete `200 OK` response. A route with path segment
+parameters (`get -> 'greet', $name { … }`) still hangs; that is tracked in
+`todo/deep/cro-http-request-hang-short-name-env-pollution.md`.

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -229,13 +229,91 @@ impl Interpreter {
         &mut self,
         code_blocks: &[CodeBlockContext],
     ) {
+        // Reduce-time writes to the regex's own `:my`/`:let` lexicals. Each block
+        // carries the snapshot its match position had; a later block must see what
+        // an earlier replayed block wrote on top of that, exactly as the inline
+        // path threads writes forward through `RegexCaptures::regex_vars`.
+        let mut live_regex_vars: HashMap<String, Value> = HashMap::new();
         for ctx in code_blocks {
             let Some(stmts) = self.parse_regex_code_cached(&ctx.code) else {
                 continue;
             };
             self.setup_regex_code_block_env(ctx);
+            let saved = self.install_ctx_regex_vars(ctx, &HashMap::new(), &live_regex_vars);
             let body_result = self.eval_regex_code_block_body(&stmts);
+            self.restore_ctx_regex_vars(&mut live_regex_vars, saved);
             self.park_regex_code_block_error(body_result);
+        }
+    }
+
+    /// The match-wide in-regex lexicals a deferred code block should start from,
+    /// minus the per-rule dynamic variables `install_fresh_rule_dynvars` already
+    /// installed. Those are deliberately left in place for the action walk that
+    /// follows (t/grammar-per-match-dynvar-action.t), so they must not be saved
+    /// and restored around the block the way a `:my` lexical is.
+    fn block_base_vars(
+        vars: &HashMap<String, Value>,
+        declared_keys: &[String],
+    ) -> HashMap<String, Value> {
+        if declared_keys.is_empty() {
+            return vars.clone();
+        }
+        vars.iter()
+            .filter(|(k, _)| !declared_keys.contains(k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+
+    /// Install the regex's own `:my`/`:let` lexicals for a deferred code block, so
+    /// it reads what they held rather than an outer same-named variable.
+    ///
+    /// Three sources, weakest first: `base` (the whole match's lexicals — a
+    /// declarative `:my` at the front of the pattern is hoisted out and lives
+    /// there), the block's own snapshot at its textual position, and `live` —
+    /// writes an earlier deferred block of the same reduce already made.
+    ///
+    /// Returns the caller's own same-named bindings for
+    /// [`Self::restore_ctx_regex_vars`] to put back.
+    fn install_ctx_regex_vars(
+        &mut self,
+        ctx: &CodeBlockContext,
+        base: &HashMap<String, Value>,
+        live: &HashMap<String, Value>,
+    ) -> Vec<(String, Option<Value>)> {
+        let mut effective: HashMap<&String, &Value> = base.iter().collect();
+        effective.extend(ctx.regex_vars.iter());
+        let overrides: Vec<(&String, &Value)> = live
+            .iter()
+            .filter(|(k, _)| effective.contains_key(k))
+            .collect();
+        effective.extend(overrides);
+        let saved: Vec<(String, Option<Value>)> = effective
+            .keys()
+            .map(|k| ((*k).clone(), self.env.get(k.as_str()).cloned()))
+            .collect();
+        for (k, v) in effective {
+            self.env.insert(k.clone(), v.clone());
+        }
+        saved
+    }
+
+    /// Harvest the block's writes to the in-regex lexicals into `live` (so the
+    /// next deferred block sees them) and restore the caller's own bindings.
+    fn restore_ctx_regex_vars(
+        &mut self,
+        live: &mut HashMap<String, Value>,
+        saved: Vec<(String, Option<Value>)>,
+    ) {
+        for (k, _) in &saved {
+            if let Some(now) = self.env.get(k) {
+                live.insert(k.clone(), now.clone());
+            }
+        }
+        for (k, orig) in saved {
+            match orig {
+                Some(v) => self.env.insert(k, v),
+                None => self.env.remove(&k),
+            };
         }
     }
 
@@ -439,7 +517,8 @@ impl Interpreter {
             super::regex_helpers::target_or_empty(target),
         );
         let blocks = std::mem::take(&mut caps.code_blocks);
-        caps.ast = self.reduce_run_code_blocks(blocks, node_match);
+        let base_vars = Self::block_base_vars(&caps.regex_vars, &declared_keys);
+        caps.ast = self.reduce_run_code_blocks(blocks, node_match, &base_vars);
         self.record_rule_dynvars(caps, &declared_keys);
     }
 
@@ -482,7 +561,8 @@ impl Interpreter {
             super::regex_helpers::target_or_empty(target),
         );
         let blocks = std::mem::take(&mut kids.code_blocks);
-        node.ast = self.reduce_run_code_blocks(blocks, node_match);
+        let base_vars = Self::block_base_vars(&kids.regex_vars, &declared_keys);
+        node.ast = self.reduce_run_code_blocks(blocks, node_match, &base_vars);
         self.record_cap_node_dynvars(node, &declared_keys);
     }
 
@@ -544,6 +624,7 @@ impl Interpreter {
         &mut self,
         blocks: Vec<CodeBlockContext>,
         node_match: Value,
+        base_vars: &HashMap<String, Value>,
     ) -> Option<Value> {
         // Named captures carrying a child `.made` (from the recursion above).
         let named_v = node_match.match_named();
@@ -557,6 +638,9 @@ impl Interpreter {
         let saved_match = self.env.get("/").cloned();
         // Fresh `make` slot for this node (do not inherit a sibling's value).
         self.env.remove("made");
+        // Reduce-time writes to the regex's own `:my`/`:let` lexicals, threaded
+        // from one deferred block to the next (see `install_ctx_regex_vars`).
+        let mut live_regex_vars: HashMap<String, Value> = HashMap::new();
         for ctx in &blocks {
             let Some(stmts) = self.parse_regex_code_cached(&ctx.code) else {
                 continue;
@@ -583,7 +667,9 @@ impl Interpreter {
                     self.env.insert("\u{00A2}".to_string(), updated);
                 }
             }
+            let saved_vars = self.install_ctx_regex_vars(ctx, base_vars, &live_regex_vars);
             let body_result = self.eval_regex_code_block_body(&stmts);
+            self.restore_ctx_regex_vars(&mut live_regex_vars, saved_vars);
             self.park_regex_code_block_error(body_result);
         }
         let ast = self.env.get("made").cloned();

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -163,6 +163,13 @@ impl Drop for EnclosingRegexVarsGuard {
     }
 }
 
+/// Is this env key a dynamic variable (`$*x` is stored as `*x`; `@*a` / `%*h`
+/// keep their sigil)? Such a name declared by an in-regex `:my` belongs to the
+/// per-rule dynvar machinery, not to the regex-lexical snapshot/restore.
+pub(crate) fn is_dynamic_regex_var_key(key: &str) -> bool {
+    key.starts_with('*') || key.starts_with("@*") || key.starts_with("%*")
+}
+
 /// Publish a `:my`/`:let` scalar name to the sub-pattern parses that follow it.
 pub(crate) fn declare_enclosing_regex_var(name: &str) {
     ENCLOSING_REGEX_VARS.with(|s| {

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -326,6 +326,17 @@ impl Interpreter {
                         &current_caps.positional,
                         chars,
                     ),
+                    // Lexicals only. A `:my $*x` is a dynamic variable owned by
+                    // the per-rule dynvar machinery, which deliberately leaves
+                    // its write installed for the action walk — snapshotting and
+                    // restoring it around the block would undo that
+                    // (t/grammar-per-match-dynvar-action.t).
+                    regex_vars: current_caps
+                        .regex_vars
+                        .iter()
+                        .filter(|(k, _)| !super::regex_helpers::is_dynamic_regex_var_key(k))
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
                 };
                 // If eager code block collection is enabled, push immediately
                 // so the block is captured even if the overall match fails later.
@@ -487,6 +498,25 @@ impl Interpreter {
                         }
                         if !self.env.contains_key_sym(*k) || self.env.get_sym(*k) != Some(v) {
                             new_caps.regex_vars.insert(k.resolve(), v.clone());
+                        }
+                    }
+                    // The env diff above only sees a *change*. The scratch env is
+                    // cloned from this one, so a declaration whose write reached
+                    // the shared storage compares equal and is missed — which left
+                    // the lexical out of `regex_vars` entirely. It then only worked
+                    // for blocks that run inline (they read the write from `env`);
+                    // a `make`-bearing block, which runs on the reduce walk long
+                    // after that write is gone, saw nothing. Record what the
+                    // declaration itself introduced, by name.
+                    for stmt in stmts.iter() {
+                        let Stmt::VarDecl { name, .. } = stmt else {
+                            continue;
+                        };
+                        if name == "_" || new_caps.regex_vars.contains_key(name) {
+                            continue;
+                        }
+                        if let Some(v) = interp.env.get(name) {
+                            new_caps.regex_vars.insert(name.clone(), v.clone());
                         }
                     }
                     return Some((pos, new_caps));

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -447,9 +447,32 @@ impl Interpreter {
             }
         }
 
-        let result = self.regex_match_with_captures_core(&remaining_pattern, text);
+        let mut result = self.regex_match_with_captures_core(&remaining_pattern, text);
         let matched = result.is_some();
         self.registry_mut().token_defs = saved_token_defs;
+        // A declarative `:my`/`:let` lexical is hoisted out of the pattern and
+        // evaluated into `env` above, so an inline `{ … }` block reads it straight
+        // from there. A `make`-bearing block does not run inline — it is replayed
+        // on the reduce walk, which happens after this function has restored `env`
+        // below. Carry the values on the captures so the replay can reinstall them
+        // (`install_ctx_regex_vars`); without this `/ :my $c = 1; … { make $c } /`
+        // reduces with `$c` unset.
+        if let Some(caps) = result.as_mut() {
+            for name in restore_always.keys().chain(restore_on_fail.keys()) {
+                // A `:my $*x` is a DYNAMIC variable, not a regex lexical: the
+                // per-rule dynvar machinery (`install_fresh_rule_dynvars`) owns it
+                // and deliberately leaves it installed for the action walk. Only
+                // the plain lexicals belong here.
+                if super::regex_helpers::is_dynamic_regex_var_key(name)
+                    || caps.regex_vars.contains_key(name)
+                {
+                    continue;
+                }
+                if let Some(v) = self.env.get(name).cloned() {
+                    caps.regex_vars.insert(name.clone(), v);
+                }
+            }
+        }
         self.restore_env_entries(restore_always);
         if !matched {
             self.restore_env_entries(restore_on_fail);

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -29,6 +29,12 @@ pub(crate) struct CodeBlockContext {
     pub(crate) named: HashMap<String, Vec<String>>,
     pub(crate) matched_so_far: String,
     pub(crate) positional: Vec<String>,
+    /// The regex's own `:my`/`:let` lexicals as they stood at this block's
+    /// textual position. A `make`-bearing block runs on the reduce-time walk,
+    /// long after the match state that held them is gone, so the values have to
+    /// travel with the block — otherwise `/ :my $c; … { $c = 1 } { make $c } /`
+    /// reduces with `$c` unset.
+    pub(crate) regex_vars: HashMap<String, Value>,
 }
 
 /// A single entry in a quantified capture list: (from, to, subcaptures).

--- a/t/regex-my-lexical-in-make-block.t
+++ b/t/regex-my-lexical-in-make-block.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 7;
+
+# A regex's own `:my` lexical must be visible to a `make`-bearing code block.
+# Such a block does not run inline during matching — it is replayed on the
+# reduce walk, after the match state that held the lexical is gone — so its
+# value has to travel with the block.
+
+my $m1 = "a" ~~ / :my $x = 9; 'a' { make (0, $x) } /;
+is-deeply $m1.ast, (0, 9), "a make block sees a :my initializer";
+
+my $m2 = "a" ~~ / :my $y; 'a' { $y = 42 } { make (1, $y) } /;
+is-deeply $m2.ast, (1, 42), "a make block sees what an earlier block assigned";
+
+my $m3 = "a" ~~ / :my $z = 1; 'a' { $z = $z + 1 } { make $z } /;
+is $m3.ast, 2, "the assignment is applied on top of the initializer";
+
+# Two make blocks in sequence: the second sees the first's write.
+my $m4 = "a" ~~ / :my $w = 1; 'a' { make $w } { $w = 5; make $w } /;
+is $m4.ast, 5, "a later make block sees an earlier make block's write";
+
+# Inside an alternation group, and with a non-trivial value.
+my $m5 = "b" ~~ / :my $c; [ 'b' { $c = Capture.new(:list(1, 2)) } { make (7, $c) } | 'z' ] /;
+is $m5.ast[0], 7, "the group's make block reduces with the right index";
+is-deeply $m5.ast[1].list, (1, 2), "and carries the Capture the block built";
+
+# (Whether a `:my` of the same name as an enclosing lexical writes through to it
+# is deliberately not asserted here — Rakudo does write through, and that edge is
+# not what this file pins.)
+
+# Inline blocks keep working alongside the deferred one.
+my @seen;
+my $m6 = "a" ~~ / :my $v = 3; 'a' { @seen.push($v) } { make $v } /;
+is-deeply (@seen, $m6.ast), ([3], 3), "inline and make blocks agree on the value";

--- a/todo/deep/cro-http-request-hang-short-name-env-pollution.md
+++ b/todo/deep/cro-http-request-hang-short-name-env-pollution.md
@@ -1,106 +1,93 @@
-# Cro HTTP request round-trip: the request is parsed and emitted, then never reaches the route handler
+# Cro: a route with path-segment parameters still hangs
 
 ## Where the Cro campaign stands (updated 2026-08-01)
 
-`use Cro::HTTP::Router`, `route { get -> { ... } }`, `use Cro::HTTP::Server`,
-`Cro::HTTP::Server.new(:host, :port, :application($app)).start` / `.stop` all
-work (#5658, #5666, #5668). The request parser now works too: with the
-owner-scoped nested-type fix (`news/2026-08/nested-type-short-name-owner-scope.md`)
-`Cro::HTTP::Header.parse` resolves its class-body `my grammar Header` again even
-with `Cro::HTTP::Router` loaded, so the request line and every header line parse
-and `Cro::HTTP::RequestParser` reaches `emit $request`.
+**Cro now serves a real HTTP request under mutsu.** `Cro::HTTP::Server` with
+`route { get -> { content 'text/plain', 'Hello from mutsu' } }` answers `curl`
+with a complete `200 OK` response, against pristine upstream Cro sources. Two
+general interpreter fixes got it there:
 
-Serving an actual HTTP request still does NOT complete: after the parser emits
-the request, the route handler is never entered and
-`Cro::HTTP::ResponseSerializer`'s `whenever $response-stream` never fires, so no
-bytes are written and the client times out with 0 bytes received.
+- `news/2026-08/nested-type-short-name-owner-scope.md` — a class's nested type
+  keeps its short name after another module registers the same name, so
+  `Cro::HTTP::Header.parse` reaches its class-body `my grammar Header` again with
+  `Cro::HTTP::Router` loaded. This unblocked header parsing.
+- `news/2026-08/regex-my-lexical-in-make-block.md` — a regex `:my` lexical is
+  visible to a `make`-bearing code block, so the router's `EVAL`ed path matcher
+  reduces with its `$cap` Capture set. This unblocked route dispatch.
 
-Repro (scratch clones under `tmp/cro-work/`, `-I` list in
-`tmp/cro-work/inc-paths.txt`; clone `cro-core`, `cro-http`, `cro-tls`,
+What still fails: a route whose signature takes **path segments**.
+
+```raku
+route {
+    get -> { content 'text/plain', 'ok' }                    # works
+    get -> 'greet', $name { content 'text/plain', "hi $name" }  # hangs
+}
+```
+
+`GET /greet/world` never produces a response (curl times out with 0 bytes).
+`GET /` on the same server still answers correctly, so the server, the parser
+and the serializer are all fine — the failure is specific to a route that binds
+segments.
+
+Likely the same `compile-route` machinery as the fixed bug, one layer further
+in: for a route with positional parameters the generated matcher's `$form-cap`
+block builds `Capture.new(:list(@segs[...]), :hash(%unpacks))` from `@segs`, and
+`$bind-check` may add a `<?{ … $han.signature.ACCEPTS($cap) … }>` assertion. So
+the suspects are the `:my @segs` array lexical inside the matcher (the fix
+landed for scalars — check that an `@`-sigil `:my` survives the same paths), and
+the signature-`ACCEPTS`-on-a-Capture assertion.
+
+## Repro
+
+Scratch clones live under `tmp/cro-work/` with the `-I` list in
+`tmp/cro-work/inc-paths.txt`. Clone `croservices/cro-{core,http,tls}`,
 `jnthn/raku-log-timeline`, `retupmoca/P6-JSON-JWT`, `japhb/CBOR-Simple`,
-`japhb/TinyFloats`, `jnthn/p6-io-socket-async-ssl` — everything else is a
-bundled battery):
+`japhb/TinyFloats`, `jnthn/p6-io-socket-async-ssl`; everything else Cro depends
+on is already a bundled battery.
 
 ```
-timeout 200 target/debug/mutsu $(cat tmp/cro-work/inc-paths.txt) tmp/cro-server-request.p6
+timeout 200 target/debug/mutsu $(cat tmp/cro-work/inc-paths.txt) tmp/cro-clean.p6
 ```
 
-(zsh note: expand `inc-paths.txt` inline with `$(cat ...)`; a `$VAR` expansion
-is not word-split and collapses every `-I` into one argument.)
+(zsh note: expand `inc-paths.txt` inline with `$(cat …)`; a `$VAR` expansion is
+not word-split and collapses every `-I` into one argument.)
 
-Instrumented trace (add `note` lines directly to the scratch clones):
+## Also still open: a module-global short name beats an inner-scope enum value
 
-```
-server started
-DBG packet 78 bytes
-DBG loop expecting=RequestLine
-DBG loop expecting=
-DBG header-line [Host: 127.0.0.1:31415]
-DBG header-line [User-Agent: curl/8.5.0]
-DBG header-line [Accept: */*]
-DBG emitting request (no body)
-                       <- route handler's "DBG handler entered" never prints
-                       <- ResponseSerializer's "DBG serializer got response" never prints
-curl exit: 28 (timed out, 0 bytes received)
-```
-
-So the remaining break is in the stage between the parser's `emit $request` and
-the `route` block's handler — the Cro pipeline connection (`Cro.compose` /
-`Cro::ConnectionManager`) or `Cro::HTTP::Router`'s own transformer supply.
-
-## Still open: a module-global short name beats an inner-scope enum value
-
-Visible in the trace above as the empty `DBG loop expecting=` lines.
 `Cro::HTTP::RequestParser.transformer` declares, inside its `supply` block,
 `my enum Expecting <RequestLine Header Body>`, and does `$expecting = Header`.
 `RequestLine` resolves to the enum value correctly, but `Header` resolves to
 `Cro::HTTP::Router::Header` — the *role* — because registering that role bound
-the bare short name `Header` in the ONE global env, and that binding wins over
-the enum value declared in an inner lexical scope.
+the bare short name `Header` in the ONE global env, and that binding wins over an
+enum value declared in an inner lexical scope.
 
-It happens not to break this particular request (`when Header` compares the same
-wrong value on both sides, so the header branch is still taken, and a bodyless
-GET never evaluates `when Body`), but it is wrong: `$expecting == Body` on a type
-object and the `Body` branch can never match.
+It happens not to break a request today (`when Header` compares the same wrong
+value on both sides, so the header branch is still taken, and a bodyless GET
+never evaluates `when Body`), but it is wrong: `$expecting == Body` on a type
+object, and the `Body` branch can never match. **A request with a body is
+therefore a likely next failure.**
 
-This is the residue of the original diagnosis and the part the fix above did NOT
-address. Short names of package-scoped types are inserted into the ONE global env
-at registration time, so a later module's type of the same short name outranks an
-inner-scope declaration in an earlier one. The owner-package-chain probe
-introduced by the fix covers the case where the *owner class* is asking; it
-cannot cover a same-named lexical declaration (an enum value, a `my` type) in an
-unrelated scope, because that declaration is not reachable from any owner chain.
-
-The real fix is to stop registering short-name aliases in the global env across
-module boundaries and keep them per-module, the way the parser's scan does — the
-same architecture gap as `package_chain_var_fallback` (#5658) but for TYPE names.
-
-## Why the two obvious guards are not enough (both tried, reverted)
-
-- Guarding `unsuppress_name` to bare-name registrations only (so
-  `Cro::HTTP::Router::Header` keeps the suppression alive) moves the failure to
-  the enum case above: the suppressed-name branch's local-declaration carve-out
-  (vm_var_get_ops.rs) only tolerates a non-Package env value, and by then env
-  "Header" holds the Router role's Package, so the read throws
-  X::Undeclared::Symbols instead. (Superseded: the landed fix keeps the
-  suppression semantics untouched and adds a separate never-cleared
-  `class_scoped_short_names` set instead.)
-- Guarding the `"parse"|"subparse"|"parsefile"`-on-Package arm in
-  `methods_dispatch_match.rs` with `has_user_method_including_role` is correct in
-  itself (a class with its own `parse` method must not fall into grammar
-  dispatch) but does not fix this bug — the target had already resolved to the
-  wrong type by then.
+The owner-package-chain probe that landed covers the case where the *owner class*
+is asking; it cannot cover a same-named lexical declaration (an enum value, a
+`my` type) in an unrelated scope, because that declaration is not reachable from
+any owner chain. The real fix is to stop registering short-name aliases in the
+global env across module boundaries and keep them per-module, the way the
+parser's scan does — the same architecture gap as `package_chain_var_fallback`
+(#5658) but for TYPE names.
 
 ## Debugging techniques that worked (reuse these)
 
 - `tmp/cro-work` holds plain `git clone`s, not vendored sources — add
-  `note "DBG: ..."` lines directly to them to bisect the pipeline stage
+  `note "DBG: …"` lines directly to them to bisect the pipeline stage
   (TCP accept -> conn Supply emit -> RequestParser packet -> req-line ->
-  header-line -> emit request -> route handler -> ResponseSerializer).
-- The raw socket path is healthy: an `IO::Socket::Async` echo server plus an
-  external `curl` round-trips fine.
-- Drive the client with `run 'curl', '-sS', '-i', '-m', '20', ...` from the same
-  script so the server process terminates on its own (and gdb can attach).
-- `rust-gdb -batch` breakpoints on the three "Unknown method value dispatch"
-  sites (methods_grammar.rs / methods_instance_ops.rs /
-  methods_classhow_dispatch.rs) found the guilty one immediately last time.
+  header-line -> emit request -> router -> routing outcome -> handler.invoke ->
+  ResponseSerializer). `git -C tmp/cro-work/cro-http checkout -- .` reverts them.
+- Printing the router's `($handler-idx, $args) = .ast` is what exposed the
+  `$args = Any` that should have been a `Capture` — a one-line `note` on the
+  value a `make` produced, rather than guessing at the regex engine.
+- Drive the client with `run 'curl', '-sS', '-m', '20', …` from the same script
+  so the server process terminates on its own.
+- `rust-gdb -batch` breakpoints beat `eprintln!` here: breaking on
+  `parse_regex_code_cached` and printing its `code` argument showed which regex
+  code blocks actually ran, and a backtrace from `eval_regex_inline_code` showed
+  the pattern with the `:my` already stripped out — which *was* the bug.


### PR DESCRIPTION
A regex's own `:my`/`:let` lexical was invisible to any code block containing
`make`:

```raku
my $m = "a" ~~ / :my $x = 9; 'a' { make (0, $x) } /;
say $m.ast;    # Rakudo: (0, 9)    mutsu: (0, Nil)
```

An inline block (`{ say $x }`) read it fine; only the `make`-bearing one saw
`Nil`. That is Cro's route dispatcher exactly — `Cro::HTTP::Router` builds its
path matcher by `EVAL`ing a regex of the shape

```
regex { ^ :my $req = …; :my @segs = …; :my $cap;
        [ … { … $cap = Capture.new(…) } … { make ($index, $cap) } … ] $ }
```

so every matched route reduced with `$cap` unset, `RouteHandler.invoke` failed
its `Capture $args` type check inside a `supply`, the failure was swallowed, and
the HTTP client hung with no response.

## Root cause

Two mechanisms have to meet, and neither knew about the other.

A declarative `:my` at the front of a pattern is **hoisted out** of the pattern
before matching (`parse_regex_declarative_prefix`), evaluated into `env`, and
restored as soon as the match returns. A code block that runs *inline* during
matching therefore just reads it from `env` — which is why the inline case worked
and the feature looked implemented.

A block containing `make` does **not** run inline: it needs the ordering the
bottom-up reduce walk gives, so it is recorded as a `CodeBlockContext` and
replayed later. By then the hoisted lexical has been restored out of `env`, and
`CodeBlockContext` carried no lexical state of its own.

## Fix

- `CodeBlockContext` gains `regex_vars`: the in-regex lexicals as they stood at
  the block's textual position, captured when the block is recorded.
- A successful match carries the hoisted declarative lexicals on its captures, so
  the reduce walk can reinstall them.
- `reduce_run_code_blocks` (and the eager-block replay) installs those lexicals
  around each replayed block and restores the caller's own same-named bindings
  afterwards, threading a block's writes forward to the next block — the same
  ordering the inline path gets from `RegexCaptures::regex_vars`.

A `:my $*x` is deliberately excluded from all of this: it is a *dynamic* variable
owned by the per-rule dynvar machinery (`install_fresh_rule_dynvars`), which
intentionally leaves its write installed for the action walk that follows.
Snapshotting and restoring it around a block would undo that —
`t/grammar-per-match-dynvar-action.t` catches it, and `is_dynamic_regex_var_key`
now draws the line in one place.

## Tests

`t/regex-my-lexical-in-make-block.t` — seven assertions, **passing unmodified
under Rakudo**: a make block sees a `:my` initializer, sees what an earlier block
assigned, composes with the initializer, sees an earlier *make* block's write,
works inside an alternation group with a non-trivial value, and agrees with an
inline block on the value.

Local gates, all green:

- `make test` — 2721 files / 26011 tests PASS
- `make roast` — 1435 files / 218774 tests PASS
- `scripts/battery-testsuite.sh` — `GATE PASSED` (153/158)

## Cro

With this and #5675, **Cro serves a real HTTP request under mutsu**:
`Cro::HTTP::Server` + `route { get -> { content 'text/plain', … } }` answers
`curl` with a complete `200 OK`, against pristine upstream Cro sources. A route
with path-segment parameters (`get -> 'greet', $name { … }`) still hangs;
`todo/deep/cro-http-request-hang-short-name-env-pollution.md` is rewritten to
that narrowed state, with the suspects and the repro recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)