### PR TITLE
fix(test): `t/` files asserted against a lenient native `is`

### DIFF
--- a/news/2026-08/test-files-asserted-against-a-lenient-is.md
+++ b/news/2026-08/test-files-asserted-against-a-lenient-is.md
@@ -1,0 +1,47 @@
+# 19 `t/` files asserted against mutsu's lenient native `is`, not against Raku
+
+mutsu's native `Test` provider stringifies `is`'s arguments more eagerly than
+Raku's does, so a family of assertions in `t/` passed under mutsu and nowhere
+else — not under rakudo's real `Test.rakumod`, and not under `raku`. They are
+**test-file** bugs, and each correction makes the test more faithful, so none of
+them had to wait for the Test-vendoring flip
+(`todo/tickets/vendor-real-test-module.md`).
+
+Three shapes, 40 assertions, 19 files. Every corrected file was verified three
+ways — mutsu's native provider, the aliased upstream `Test.rakumod`, and `raku`:
+
+**A type object compared against its gist spelling** — 35 assertions in 15
+files. `is 42.WHAT, '(Int)'` compares `$got.Str`, and a type object's `.Str` is
+the empty string with a warning, not its `.gist`. All of them now read
+`is 42.WHAT.gist, '(Int)'`, matching `t/type-objects.t`, which already had it
+right.
+
+`t/lock.t` was the one exception: it wanted the *qualified* name, and `.gist` of
+a nested type object is its short name in raku too (`Lock::Async.WHAT.gist` is
+`(Async)`, in both implementations). It asks `.^name` instead.
+
+**`Empty` compared against `Nil`** — 4 assertions in 4 files. `andthen` and
+`notandthen` yield `Empty`, an empty `Slip`, when they skip their RHS; so does a
+routine whose body ends in a statement-modifier `if` that does not fire, which
+is what `t/operator-adverbs.t`'s user-defined `infix:<->` does. `is $x, Nil`
+passed natively and failed under `raku`; `is-deeply $x, Empty` holds under both.
+
+## One real compiler bug fell out of it
+
+Correcting `t/new-operators.t` to expect `Empty` made it fail under mutsu — for
+real this time. The compiler's `andthen` arm loads an empty `Slip` when it skips
+its RHS, but the `notandthen` arm right below it loaded `Nil`
+(`src/compiler/expr_binary.rs`). So `10 notandthen 42` was a one-element list in
+list context where raku's vanishes. The `notandthen` arm now loads the same
+empty `Slip` its sibling does.
+
+This is the pattern the whole lenient-`is` pass is worth doing for: the loose
+assertion was hiding a genuine divergence, and tightening it surfaced the bug
+immediately.
+
+## Effect on the sweep
+
+These 19 files were the bulk of the sweep's "`raku` fails it too" bucket (27
+files). Eight remain in that bucket and are *not* this problem — they are listed
+for individual triage in
+`todo/tickets/local-tests-rely-on-a-lenient-native-is.md`.

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -433,7 +433,11 @@ impl Compiler {
                 self.code.emit(OpCode::CallDefined);
                 let jump_undef = self.code.emit(OpCode::JumpIfFalse(0));
                 self.code.emit(OpCode::Pop);
-                self.code.emit(OpCode::LoadNil);
+                // Skipping the RHS yields `Empty` -- an empty Slip -- exactly as
+                // the `andthen` arm above does. `Nil` here made `10 notandthen
+                // 42` a one-element list in list context instead of vanishing.
+                let empty_idx = self.code.add_constant(Value::slip(vec![]));
+                self.code.emit(OpCode::LoadConst(empty_idx));
                 let jump_end = self.code.emit(OpCode::Jump(0));
                 self.code.patch_jump(jump_undef);
                 self.code.emit(OpCode::Pop);

--- a/t/anon-class-what-gist.t
+++ b/t/anon-class-what-gist.t
@@ -4,7 +4,7 @@ plan 3;
 
 my $c = class { };
 is $c.WHAT.gist, "()", "anonymous class WHAT.gist does not leak internal name";
-is $c.WHAT, "()", "anonymous class WHAT stringifies as anonymous type object";
+is $c.WHAT.gist, "()", "anonymous class WHAT stringifies as anonymous type object";
 
 my $obj = $c.new;
 is $obj.WHAT.gist, "()", "instance WHAT.gist for anonymous class is anonymous";

--- a/t/class-basic.t
+++ b/t/class-basic.t
@@ -12,7 +12,7 @@ my $p = Point.new(x => 3, y => 4);
 ok $p.defined, 'instance is defined';
 is $p.x, 3, 'public attribute x accessor';
 is $p.y, 4, 'public attribute y accessor';
-is $p.WHAT, '(Point)', '.WHAT returns class name';
+is $p.WHAT.gist, '(Point)', '.WHAT returns class name';
 
 # Method declaration
 class Greeter {

--- a/t/class.t
+++ b/t/class.t
@@ -13,7 +13,7 @@ is $p.x, 3, "public attribute x";
 is $p.y, 4, "public attribute y";
 
 # .WHAT returns (ClassName)
-is $p.WHAT, "(Point)", ".WHAT";
+is $p.WHAT.gist, "(Point)", ".WHAT";
 
 # .isa checks
 ok $p.isa("Point"), ".isa with own class";

--- a/t/complex.t
+++ b/t/complex.t
@@ -6,7 +6,7 @@ is 2i, Complex.new(0, 2), "2i literal";
 isa-ok 2i, Complex, "2i is Complex";
 
 # Construction via arithmetic
-is (3+4i).WHAT, "(Complex)", "3+4i is Complex";
+is (3+4i).WHAT.gist, "(Complex)", "3+4i is Complex";
 is (3+4i).re, 3, "real part";
 is (3+4i).im, 4, "imaginary part";
 

--- a/t/compound-assign-ops.t
+++ b/t/compound-assign-ops.t
@@ -23,7 +23,7 @@ plan 17;
 # andthen=
 {
     my $x = 3; $x andthen= 5; is $x, 5, 'andthen= when defined assigns RHS';
-    my $y = Int; $y andthen= 5; is $y, '(Int)', 'andthen= when undefined keeps LHS';
+    my $y = Int; $y andthen= 5; is $y.gist, '(Int)', 'andthen= when undefined keeps LHS';
 }
 
 # +<=  (bit shift left assign)

--- a/t/enum.t
+++ b/t/enum.t
@@ -23,7 +23,7 @@ is 0 + Day::Sun, 0, "0 + Day::Sun is 0";
 is 0 + Day::Wed, 3, "0 + Day::Wed is 3";
 
 # .WHAT
-is Day::Sun.WHAT, "(Day)", ".WHAT returns enum type name";
+is Day::Sun.WHAT.gist, "(Day)", ".WHAT returns enum type name";
 
 # .raku
 is Day::Mon.raku, "Day::Mon", ".raku returns qualified name";

--- a/t/float-num.t
+++ b/t/float-num.t
@@ -1,7 +1,7 @@
 use Test;
 plan 8;
 
-is 3.14.WHAT, "(Rat)", "decimal literal type is Rat";
+is 3.14.WHAT.gist, "(Rat)", "decimal literal type is Rat";
 ok 1.5 + 2.5 == 4, "float addition";
 ok 3.0 * 2.0 == 6, "float multiplication";
 ok 1.5 < 2.5, "float less than";

--- a/t/junction.t
+++ b/t/junction.t
@@ -3,17 +3,17 @@ plan 30;
 
 # --- Junction construction ---
 my $a = any(1, 2, 3);
-is $a.WHAT, "(Junction)", "any() returns a Junction";
-is $a.elems.WHAT, "(Junction)", "any() junction .elems auto-threads to Junction";
+is $a.WHAT.gist, "(Junction)", "any() returns a Junction";
+is $a.elems.WHAT.gist, "(Junction)", "any() junction .elems auto-threads to Junction";
 
 my $b = all(1, 2, 3);
-is $b.WHAT, "(Junction)", "all() returns a Junction";
+is $b.WHAT.gist, "(Junction)", "all() returns a Junction";
 
 my $c = one(1, 2, 3);
-is $c.WHAT, "(Junction)", "one() returns a Junction";
+is $c.WHAT.gist, "(Junction)", "one() returns a Junction";
 
 my $d = none(1, 2, 3);
-is $d.WHAT, "(Junction)", "none() returns a Junction";
+is $d.WHAT.gist, "(Junction)", "none() returns a Junction";
 
 # --- .gist / .Str ---
 is $a.gist, "any(1, 2, 3)", ".gist shows junction contents";
@@ -47,7 +47,7 @@ ok 2 ~~ any(1, 2, 3), "2 ~~ any(1,2,3) is True";
 nok 5 ~~ any(1, 2, 3), "5 ~~ any(1,2,3) is False";
 
 # --- Arithmetic auto-threading ---
-is (1 + any(2, 3)).WHAT, "(Junction)", "junction arithmetic keeps junction type";
+is (1 + any(2, 3)).WHAT.gist, "(Junction)", "junction arithmetic keeps junction type";
 ok 1 + any(2, 3) == 4, "addition threads over RHS junction";
 ok 6 % any(2, 3) == 0, "modulo threads over RHS junction";
 ok all(4, 6) % 2 == 0, "modulo threads over LHS junction";

--- a/t/lock.t
+++ b/t/lock.t
@@ -3,7 +3,7 @@ use Test;
 plan 10;
 
 my $lock = Lock.new;
-is $lock.WHAT, "(Lock)", "Lock.new returns a Lock";
+is $lock.WHAT.gist, "(Lock)", "Lock.new returns a Lock";
 
 $lock.lock;
 pass "lock acquires lock";
@@ -22,7 +22,9 @@ my $cond = $lock.condition;
 ok $cond.defined, "condition returns a condition variable";
 
 my $async-lock = Lock::Async.new;
-is $async-lock.WHAT, "(Lock::Async)", "Lock::Async.new returns a Lock::Async";
+# `.gist` of a nested type object is its SHORT name (`(Async)`) in Raku, so the
+# fully-qualified name has to come from `.^name`.
+is $async-lock.^name, "Lock::Async", "Lock::Async.new returns a Lock::Async";
 
 $lock.protect({
     my $ready = True;

--- a/t/misc-builtins.t
+++ b/t/misc-builtins.t
@@ -1,9 +1,9 @@
 use Test;
 plan 8;
 
-is 42.WHAT, "(Int)", ".WHAT Int";
-is "hello".WHAT, "(Str)", ".WHAT Str";
-is True.WHAT, "(Bool)", ".WHAT Bool";
+is 42.WHAT.gist, "(Int)", ".WHAT Int";
+is "hello".WHAT.gist, "(Str)", ".WHAT Str";
+is True.WHAT.gist, "(Bool)", ".WHAT Bool";
 ok not False, "not operator";
 ok so True, "so operator";
 is elems([1, 2, 3]), 3, "elems function";

--- a/t/native-array-decl.t
+++ b/t/native-array-decl.t
@@ -5,19 +5,19 @@ plan 8;
 {
     my int @a;
     ok @a ~~ array[int], 'my int @a smartmatches native array[int]';
-    is @a.WHAT, '(array[int])', 'my int @a WHAT keeps native array type';
+    is @a.WHAT.gist, '(array[int])', 'my int @a WHAT keeps native array type';
     is @a.raku, 'array[int].new()', 'my int @a raku keeps native array type';
 }
 
 {
     my @a of num;
     ok @a ~~ array[num], 'my @a of num smartmatches native array[num]';
-    is @a.WHAT, '(array[num])', 'my @a of num WHAT keeps native array type';
+    is @a.WHAT.gist, '(array[num])', 'my @a of num WHAT keeps native array type';
 }
 
 {
     my @a := array[str].new('a', 'b');
     ok @a ~~ array[str], 'array[str].new smartmatches native array[str]';
-    is @a.WHAT, '(array[str])', 'array[str].new WHAT keeps native array type';
+    is @a.WHAT.gist, '(array[str])', 'array[str].new WHAT keeps native array type';
     is @a.raku, "array[str].new(\"a\", \"b\")", 'array[str].new raku keeps native array type';
 }

--- a/t/new-operators.t
+++ b/t/new-operators.t
@@ -50,7 +50,9 @@ is (1.5 max 2.5), 2.5, 'infix max with Num';
 
 # andthen basic
 is (42 andthen 100), 100, 'andthen with defined lhs returns rhs';
-is (Nil andthen 100), Nil, 'andthen with Nil lhs returns Nil';
+# `andthen` / `notandthen` yield `Empty` -- an empty Slip -- when they skip
+# their RHS, not `Nil`.
+is-deeply (Nil andthen 100), Empty, 'andthen with Nil lhs returns Empty';
 
 # orelse basic
 is (Nil orelse 42), 42, 'orelse with Nil lhs returns rhs';
@@ -58,7 +60,7 @@ is (10 orelse 42), 10, 'orelse with defined lhs returns lhs';
 
 # notandthen basic
 is (Nil notandthen 42), 42, 'notandthen with Nil lhs returns rhs';
-is (10 notandthen 42), Nil, 'notandthen with defined lhs returns Nil';
+is-deeply (10 notandthen 42), Empty, 'notandthen with defined lhs returns Empty';
 
 # chained orelse
 is (Nil orelse Nil orelse 42), 42, 'chained orelse';

--- a/t/operator-adverbs.t
+++ b/t/operator-adverbs.t
@@ -24,7 +24,9 @@ $applies = 'zilch';
 is $applies, '1**', 'right-assoc chain: adverb applies to the outermost (leftmost) **';
 
 # user overrides of builtin tokens dispatch even without adverbs
-is (5 - 2), Nil, 'user infix:<-> overrides native Int-Int';
+# The user `infix:<->` body is a statement-modifier `if` that does not fire
+# here, so its value is `Empty` -- an empty Slip -- not `Nil`.
+is-deeply (5 - 2), Empty, 'user infix:<-> overrides native Int-Int';
 sub infix:<*>($a, $b) { 'u*' }
 is (2 * 3), 'u*', 'user infix:<*> overrides native Int-Int';
 is (2 ** 3), 0, 'user infix:<**> overrides native pow';

--- a/t/orelse-andthen-mixin-defined.t
+++ b/t/orelse-andthen-mixin-defined.t
@@ -11,7 +11,8 @@ plan 7;
 {
     my Int $i = 1 but role { method defined { False } };
     is ($i orelse "z"), "z", 'orelse runs RHS when the mixin role .defined is False';
-    is ($i andthen "yes"), Nil, 'andthen skips RHS when the mixin role .defined is False';
+    # Skipping the RHS yields `Empty` (an empty Slip), not `Nil`.
+    is-deeply ($i andthen "yes"), Empty, 'andthen skips RHS when the mixin role .defined is False';
     is ($i notandthen "no"), "no", 'notandthen runs RHS when the mixin role .defined is False';
 }
 

--- a/t/pair-type.t
+++ b/t/pair-type.t
@@ -4,7 +4,7 @@ plan 4;
 my $p = pair("name", "Alice");
 is $p.key, "name", "pair key";
 is $p.value, "Alice", "pair value";
-is $p.WHAT, "(Pair)", "pair WHAT";
+is $p.WHAT.gist, "(Pair)", "pair WHAT";
 
 my $p2 = pair("age", 30);
 is $p2.value, 30, "pair with int value";

--- a/t/rat.t
+++ b/t/rat.t
@@ -6,7 +6,7 @@ isa-ok 1/4, Rat, "Int / Int produces Rat";
 isa-ok Rat.new(1, 4), Rat, "Rat.new produces Rat";
 
 # .WHAT
-is (1/4).WHAT, "(Rat)", "Rat.WHAT";
+is (1/4).WHAT.gist, "(Rat)", "Rat.WHAT";
 
 # GCD reduction
 is (2/4).nude.join(","), "1,2", "2/4 reduces to 1/2";

--- a/t/set.t
+++ b/t/set.t
@@ -41,7 +41,7 @@ my @p = $s.pairs;
 is @p.elems, 3, ".pairs has 3 elements";
 
 # .WHAT
-is $s.WHAT, "(Set)", ".WHAT returns (Set)";
+is $s.WHAT.gist, "(Set)", ".WHAT returns (Set)";
 
 # .gist
 ok $s.gist.contains("Set"), ".gist contains 'Set'";
@@ -89,7 +89,7 @@ my @bkv = $b.kv;
 is @bkv.elems, 6, "bag .kv has 6 elements";
 
 # .WHAT
-is $b.WHAT, "(Bag)", ".WHAT returns (Bag)";
+is $b.WHAT.gist, "(Bag)", ".WHAT returns (Bag)";
 
 # Truthiness
 ok ?$b, "non-empty bag is truthy";
@@ -113,7 +113,7 @@ is $m<a>, 3, "mix subscript returns weight for 'a'";
 is $m<z>, 0, "mix subscript returns 0 for missing";
 
 # .WHAT
-is $m.WHAT, "(Mix)", ".WHAT returns (Mix)";
+is $m.WHAT.gist, "(Mix)", ".WHAT returns (Mix)";
 
 # Truthiness
 ok ?$m, "non-empty mix is truthy";

--- a/t/typed-container-what.t
+++ b/t/typed-container-what.t
@@ -3,25 +3,25 @@ plan 9;
 
 {
     my Int @a;
-    is @a.WHAT, '(Array[Int])', 'typed array WHAT keeps element type';
-    is @a[0].WHAT, '(Int)', 'typed array missing element defaults to type object';
+    is @a.WHAT.gist, '(Array[Int])', 'typed array WHAT keeps element type';
+    is @a[0].WHAT.gist, '(Int)', 'typed array missing element defaults to type object';
 }
 
 {
     my Int %h;
-    is %h.WHAT, '(Hash[Int])', 'typed hash WHAT keeps value type';
-    is %h<a>.WHAT, '(Int)', 'typed hash missing key defaults to value type object';
+    is %h.WHAT.gist, '(Hash[Int])', 'typed hash WHAT keeps value type';
+    is %h<a>.WHAT.gist, '(Int)', 'typed hash missing key defaults to value type object';
 }
 
 {
     my %h{Str} of Int;
-    is %h.WHAT, '(Hash[Int,Str])', 'typed hash with key type keeps both constraints';
+    is %h.WHAT.gist, '(Hash[Int,Str])', 'typed hash with key type keeps both constraints';
 }
 
 {
     my $a = Array[Int].new;
-    is $a.WHAT, '(Array[Int])', 'Array[Int].new carries parametric WHAT';
-    is $a[0].WHAT, '(Int)', 'Array[Int].new missing element defaults to Int';
+    is $a.WHAT.gist, '(Array[Int])', 'Array[Int].new carries parametric WHAT';
+    is $a[0].WHAT.gist, '(Int)', 'Array[Int].new missing element defaults to Int';
 }
 
 {
@@ -29,6 +29,6 @@ plan 9;
     class H is Hash {}
     my $a = A[Int].new;
     my $h = H[Int].new;
-    is $a.WHAT, '(A[Int])', 'parametric array subclass WHAT is preserved';
-    is $h.WHAT, '(H[Int])', 'parametric hash subclass WHAT is preserved';
+    is $a.WHAT.gist, '(A[Int])', 'parametric array subclass WHAT is preserved';
+    is $h.WHAT.gist, '(H[Int])', 'parametric hash subclass WHAT is preserved';
 }

--- a/t/version.t
+++ b/t/version.t
@@ -3,7 +3,7 @@ plan 19;
 
 # Basic version literal
 is v1.2.3, '1.2.3', 'version literal stringifies';
-is (v1.2.3).WHAT, '(Version)', 'version literal is Version type';
+is (v1.2.3).WHAT.gist, '(Version)', 'version literal is Version type';
 
 # Version with + and - trailing markers. (A trailing marker is only a version
 # character when NOT followed by a word char — an internal `-` before a word,

--- a/todo/tickets/local-tests-rely-on-a-lenient-native-is.md
+++ b/todo/tickets/local-tests-rely-on-a-lenient-native-is.md
@@ -1,4 +1,4 @@
-# Some `t/` files assert against mutsu's lenient native `is`, not against Raku's
+# Some `t/` files assert against mutsu's lenient native `is`, not against Raku
 
 Found while re-running the Test-vendoring bulk sweep
 (`todo/tickets/vendor-real-test-module.md`). These are **test-file** bugs, not
@@ -6,7 +6,7 @@ interpreter bugs: rakudo's real `Test.rakumod` fails them, and so does `raku`
 itself, because mutsu's native `is` stringifies its arguments more eagerly than
 Raku's does.
 
-## The two shapes
+## The shapes
 
 **A type object compared against its gist spelling.** `is Point.WHAT, '(Point)'`
 passes under mutsu's native provider and fails everywhere else, because Raku's
@@ -28,45 +28,41 @@ passes natively and gives `'(...)'` under the real module — again matching Rak
 which does not reify a lazy sequence to stringify it. `is $fh.lines.join(' '),
 'A B C'` (or `is-deeply` against a list) is the assertion that survives.
 
-## Affected files
+**`Empty` compared against `Nil`.** `andthen` / `notandthen` yield `Empty` — an
+empty `Slip` — when they skip their RHS, and so does a routine whose body ends in
+a statement-modifier `if` that does not fire. `is $x, Nil` passes natively and
+fails under the real module *and* under `raku`; `is-deeply $x, Empty` is the
+assertion that holds.
 
-From the 1-in-9 sample (301 of 2717 `t/` files), six regressed on this alone:
+## Corrected (2026-08-01)
 
-| file | failing assertions |
+`news/2026-08/test-files-asserted-against-a-lenient-is.md` — 19 files, 40
+assertions, each verified three ways (mutsu's native provider, the aliased
+upstream `Test.rakumod`, and `raku`):
+
+- 35 `is <expr>.WHAT, '(Type)'` assertions across 15 files became
+  `is <expr>.WHAT.gist, ...`.
+- `t/lock.t` wanted a *qualified* name, which `.gist` does not give (`.gist` of
+  `Lock::Async` is `(Async)` in raku too), so it asks `.^name` instead.
+- 4 `is …, Nil` assertions across 4 files became `is-deeply …, Empty`. One of
+  them exposed a real compiler bug — `notandthen` loaded `Nil` instead of the
+  empty `Slip` its `andthen` sibling loads — which is fixed in the same change.
+
+## Still open
+
+Eight files from the sweep's "raku fails it too" bucket are **not** this
+problem and need individual triage; several look like real gaps that only the
+strict module exposes:
+
+| file | first failure under the real module |
 | --- | --- |
-| `t/typed-container-what.t` | 9 |
-| `t/is-lazy-io-lines.t` | 2 |
-| `t/class-basic.t` | 1 |
-| `t/class.t` | 1 |
-| `t/enum.t` | 1 |
-| `t/float-num.t` | 1 |
+| `begin-phaser-begintime.t` | `right exception type (X::AdHoc)` for a die in `INIT` |
+| `listop-arg-loose-logical-precedence.t` | `orelse` does not short-circuit on a true listop result |
+| `method-private-errors.t` | `.calling-package` of `X::Method::Private::Permission` |
+| `placeholder-named-in-method-do.t` | `%_` in a mainline `do {}` is not `X::Placeholder` |
+| `pod-begin-without-identifier.t` | `X::Syntax::Pod::BeginWithoutIdentifier` not raised |
+| `use-version-short-adverb.t` | `Test::Util::ServerPort` cannot be `use`-d with a `:v<>` adverb |
+| `variable-traits.t` | `X::Comp::Trait::Unknown` not raised |
+| `vm-panic-boundary.t` | a VM panic escapes as a Rust panic under the real module |
 
-At that sample rate the whole suite holds roughly 50 such files. They are not
-blocking anything today — they only surface when step 3 of the vendoring plan
-swaps mutsu's provider for the real module — but they have to be corrected
-before that swap, and each correction makes the test *more* faithful to Raku, so
-none of them needs to wait for it.
-
-## The full enumeration (2026-08-01)
-
-The full sweep has since been run (`tmp/sweep-full.sh`, see the vendoring
-ticket), and `tmp/sweep-raku-check.sh` splits its regressions by whether `raku`
-also fails the file. That bucket holds **29** files, not the ~50 the sample rate
-suggested:
-
-`anon-class-what-gist.t`, `begin-phaser-begintime.t`, `class-basic.t`,
-`class.t`, `complex.t`, `compound-assign-ops.t`, `cpp-constructor-syntax.t`,
-`dotassign-store-and-container-topic.t`, `enum.t`, `float-num.t`, `junction.t`,
-`listop-arg-loose-logical-precedence.t`, `lock.t`, `method-private-errors.t`,
-`misc-builtins.t`, `native-array-decl.t`, `new-operators.t`,
-`operator-adverbs.t`, `orelse-andthen-mixin-defined.t`, `pair-type.t`,
-`placeholder-named-in-method-do.t`, `pod-begin-without-identifier.t`, `rat.t`,
-`set.t`, `typed-container-what.t`, `use-version-short-adverb.t`,
-`variable-traits.t`, `version.t`, `vm-panic-boundary.t`.
-
-**The bucket is not purely lenient-`is`.** Four of them (`enum.t`,
-`placeholder-named-in-method-do.t`, `variable-traits.t`, `version.t`) do not
-even compile under `raku` — they exercise mutsu-specific syntax, so "`raku`
-fails it" says nothing about the assertion style. Check each file individually
-before rewriting it; the two shapes above are the ones to correct, and anything
-else in the list is a different finding.
+Re-run `tmp/sweep-full.sh` after each to re-measure.


### PR DESCRIPTION
mutsu's native `Test` provider stringifies `is`'s arguments more eagerly than Raku's does, so a family of assertions in `t/` passed under mutsu and nowhere else — not under rakudo's real `Test.rakumod`, and not under `raku`. These are **test-file** bugs, and each correction makes the test more faithful, so none of them had to wait for the Test-vendoring flip (`todo/tickets/vendor-real-test-module.md`).

Three shapes, 40 assertions, 19 files. Every corrected file is verified **three ways** — mutsu's native provider, the aliased upstream `Test.rakumod`, and `raku`:

- **A type object compared against its gist spelling** — 35 assertions in 15 files. `is` compares `$got.Str`, and a type object's `.Str` is the empty string with a warning, not its `.gist`:
  ```
  $ raku -e 'use Test; plan 1; class Point {}; is Point.WHAT, "(Point)", "what"'
  not ok 1 - what
  # expected: '(Point)'
  #      got: (Point)
  ```
  All of them now read `is <expr>.WHAT.gist, '(Type)'`, matching `t/type-objects.t`, which already had it right.
- **`t/lock.t`** was the one exception: it wanted the *qualified* name, and `.gist` of a nested type object is its short name in raku too (`Lock::Async.WHAT.gist` is `(Async)`, in both implementations). It asks `.^name` instead.
- **`Empty` compared against `Nil`** — 4 assertions in 4 files. `andthen` / `notandthen` yield `Empty`, an empty `Slip`, when they skip their RHS; so does a routine whose body ends in a statement-modifier `if` that does not fire, which is what `t/operator-adverbs.t`'s user-defined `infix:<->` does. `is-deeply $x, Empty` holds under both implementations.

## One real compiler bug fell out of it

Correcting `t/new-operators.t` to expect `Empty` made it fail under mutsu — for real this time. The compiler's `andthen` arm loads an empty `Slip` when it skips its RHS, but the `notandthen` arm right below it loaded `Nil` (`src/compiler/expr_binary.rs`), so `10 notandthen 42` was a one-element list in list context where raku's vanishes. Fixed here, because tightening the assertion is what exposed it — which is the point of the whole pass.

## Scope

These 19 files were the bulk of the sweep's "`raku` fails it too" bucket (27 files). The eight that remain are *not* this problem — `X::Placeholder`, `X::Comp::Trait::Unknown`, a VM panic escaping under the real module, and so on — and are listed for individual triage in `todo/tickets/local-tests-rely-on-a-lenient-native-is.md`.

## Testing

- `make test`: `Files=2722, Tests=26025 … Result: PASS`.
- `tmp/check-files.sh` over all 19 corrected files: `native alias raku` for every one (the five that still report `RAKU-FAIL` do so on *other*, pre-existing assertions in the same file, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)