### PR TITLE
fix(runtime): a reflected Signature keeps its literal parameters, and answers `.ACCEPTS`

### DIFF
--- a/news/2026-08/signature-accepts-literal-param.md
+++ b/news/2026-08/signature-accepts-literal-param.md
@@ -1,0 +1,45 @@
+# A reflected Signature keeps its literal parameters, and answers `.ACCEPTS`
+
+Two related gaps around signature-versus-capture matching:
+
+```raku
+my $sig = :('greet', $name);
+say \('other', 'world') ~~ $sig;   # Rakudo: False    mutsu: True
+say $sig.ACCEPTS(\('greet', 'x')); # Rakudo: True     mutsu: X::Method::NotFound
+```
+
+A literal parameter constrains the **value**. The parser already records it
+(`SigParam::literal_value`) and multi dispatch already honours it — `multi
+f('greet', $n)` versus `multi f('bye', $n)` picks correctly — but the code that
+matches a *reflected* signature against a capture only checked the parameter's
+type constraint, which for `'greet'` is the `Str` the parser inferred from the
+literal. So any two-positional capture whose first element was a `Str` matched.
+
+`Signature.ACCEPTS` was missing entirely: the smartmatch arm implemented
+`$capture ~~ $signature`, but the explicit method form fell through to
+`X::Method::NotFound` (the generic `Mu.ACCEPTS` fallback only backs plain
+scalars).
+
+## Fix
+
+- `sig_param_matches_value` rejects a candidate that is not equal to the
+  parameter's `literal_value`, before the type check.
+- `Signature.ACCEPTS($capture)` dispatches to the existing smartmatch arm.
+
+## Why it matters
+
+This is Cro's route dispatcher. `compile-route` emits a bind check into the
+generated path matcher:
+
+```
+<?{ my $han = @handlers[0]; $han.signature.ACCEPTS($cap) || !(@*BIND-FAILS.push(...)) }>
+```
+
+for any route whose signature has a constraint — which includes every literal
+path segment, i.e. every route of the form `get -> 'greet', $name { … }`. Without
+`.ACCEPTS` the assertion threw; with a literal-blind `.ACCEPTS` it would have
+matched the wrong route.
+
+`t/signature-accepts-literal-param.t` pins both halves with ten assertions,
+passing unmodified under Rakudo, including that ordinary dispatch through a
+literal parameter is unchanged.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -108,6 +108,17 @@ impl Interpreter {
         {
             return self.dispatch_match_method(args[0].clone(), std::slice::from_ref(&target));
         }
+        // `Signature.ACCEPTS($capture)` is `$capture ~~ $signature` — the explicit
+        // form of the bind test. Cro's route matcher calls it directly
+        // (`$handler.signature.ACCEPTS($cap)`), and the smartmatch arm already
+        // implements it; without this it threw X::Method::NotFound.
+        if method == "ACCEPTS"
+            && args.len() == 1
+            && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Signature")
+        {
+            let matched = self.smart_match(&args[0], &target);
+            return Ok(Value::truth(matched));
+        }
         // `Mu.ACCEPTS`: every value can be smart-matched against, and `$x.ACCEPTS($y)` is
         // just `$y ~~ $x`. The builtins carry their own ACCEPTS for the container types
         // (Range, Set, Bag, Pair, ...) and a user class may define one, so this only backs

--- a/src/runtime/seq_helpers/signature_helpers.rs
+++ b/src/runtime/seq_helpers/signature_helpers.rs
@@ -176,6 +176,16 @@ impl Interpreter {
         candidate: &Value,
         param: &SigParam,
     ) -> bool {
+        // A literal parameter (`:('greet', $name)`) constrains the VALUE, not just
+        // the type the parser inferred from it. Dispatch already honours this; the
+        // reflected signature has to as well, or `\('other', 'x') ~~ :('greet', $n)`
+        // is True because both are `Str` (Cro's route matcher does exactly this
+        // check through `$handler.signature.ACCEPTS($cap)`).
+        if let Some(literal) = &param.literal_value
+            && candidate != literal
+        {
+            return false;
+        }
         if let Some(constraint) = &param.type_constraint
             && !self.type_matches_value(constraint, candidate)
         {

--- a/t/signature-accepts-literal-param.t
+++ b/t/signature-accepts-literal-param.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 10;
+
+# A literal parameter constrains the VALUE, not just the type the parser infers
+# from it. Dispatch already honoured this; the reflected Signature did not, so
+# a capture that only agreed on the type matched.
+
+my $sig = :('greet', $name);
+
+ok  (\('greet', 'world') ~~ $sig), "a capture with the literal matches";
+nok (\('other', 'world') ~~ $sig), "a capture with a different Str does not";
+nok (\('greet')          ~~ $sig), "too few positionals does not match";
+
+# The same check through the explicit method form.
+ok  $sig.ACCEPTS(\('greet', 'world')), "Signature.ACCEPTS agrees on a match";
+nok $sig.ACCEPTS(\('other', 'world')), "Signature.ACCEPTS agrees on a mismatch";
+
+# Numeric and boolean literals, not just strings.
+my $nums = :(0, $rest);
+ok  (\(0, 'x') ~~ $nums), "an Int literal parameter matches its value";
+nok (\(1, 'x') ~~ $nums), "and rejects a different Int";
+
+# A signature taken off a real routine keeps the literal too.
+my &b = -> 'greet', $name { "hi $name" };
+ok  &b.signature.ACCEPTS(\('greet', 'world')), "a block's signature keeps the literal";
+nok &b.signature.ACCEPTS(\('bye', 'world')), "and rejects a non-matching capture";
+
+# Dispatch itself is unchanged.
+is &b('greet', 'world'), "hi world", "calling through the literal still works";

--- a/todo/deep/cro-http-request-hang-short-name-env-pollution.md
+++ b/todo/deep/cro-http-request-hang-short-name-env-pollution.md
@@ -29,13 +29,33 @@ route {
 and the serializer are all fine — the failure is specific to a route that binds
 segments.
 
-Likely the same `compile-route` machinery as the fixed bug, one layer further
-in: for a route with positional parameters the generated matcher's `$form-cap`
-block builds `Capture.new(:list(@segs[...]), :hash(%unpacks))` from `@segs`, and
-`$bind-check` may add a `<?{ … $han.signature.ACCEPTS($cap) … }>` assertion. So
-the suspects are the `:my @segs` array lexical inside the matcher (the fix
-landed for scalars — check that an `@`-sigil `:my` survives the same paths), and
-the signature-`ACCEPTS`-on-a-Capture assertion.
+The signature-`ACCEPTS`-on-a-Capture half of this is now fixed
+(`news/2026-08/signature-accepts-literal-param.md`: `Signature.ACCEPTS` existed
+only as a smartmatch, and a reflected signature ignored its literal parameters).
+The route still does not match, and there is a **minimal standalone repro**.
+
+## Minimal repro: a `:my @a = <scalar :my>.method` loses its elements
+
+Instrumenting the router shows `$request.path ~~ $!path-matcher` returning no
+match for `/greet/world`. Reduced from the real generated matcher
+(`tmp/rxroute3.p6`), the smallest differing case is:
+
+```raku
+class Req { method path-segments() { <greet world> } }
+my $*CRO-ROUTER-REQUEST = Req.new;
+my $rx = EVAL q{regex { ^ :my $req = $*CRO-ROUTER-REQUEST;
+                        :my @segs = $req.path-segments;
+                        [ '/' 'greet' '/' <-[/]>+: { make @segs.elems } | <!> ] $ }};
+say ("/greet/world" ~~ $rx).ast;   # Rakudo: 2    mutsu: 1
+```
+
+so `Capture.new(:list(@segs), …)` gets one element instead of two, the bind
+check rejects the route, and no handler runs. Each ingredient works on its own —
+an array `:my` from a plain array or a sub call is fine, a two-declarator chain
+(`:my $r = …; :my @s = $r.segs;`) is fine outside a group, and a `make` block
+reading an array `:my` is fine — so the trigger is the combination with the
+`[ … | <!> ]` alternation group (which re-seeds the in-regex lexicals for its
+sub-pattern via `InlineVarsSeed`). Start there.
 
 ## Repro
 


### PR DESCRIPTION
```raku
my $sig = :('greet', $name);
say \('other', 'world') ~~ $sig;   # Rakudo: False    mutsu: True
say $sig.ACCEPTS(\('greet', 'x')); # Rakudo: True     mutsu: X::Method::NotFound
```

A literal parameter constrains the **value**. The parser already records it
(`SigParam::literal_value`) and multi dispatch already honours it — `multi
f('greet', $n)` versus `multi f('bye', $n)` picks correctly — but the code that
matches a *reflected* signature against a capture only checked the parameter's
type constraint, which for `'greet'` is the `Str` the parser inferred from the
literal. So any two-positional capture whose first element was a `Str` matched.

`Signature.ACCEPTS` was missing entirely: the smartmatch arm implemented
`$capture ~~ $signature`, but the explicit method form fell through to
`X::Method::NotFound` (the generic `Mu.ACCEPTS` fallback only backs plain
scalars).

## Fix

- `sig_param_matches_value` rejects a candidate that is not equal to the
  parameter's `literal_value`, before the type check.
- `Signature.ACCEPTS($capture)` dispatches to the existing smartmatch arm.

## Why it matters

This is Cro's route dispatcher. `compile-route` emits a bind check into the
generated path matcher:

```
<?{ my $han = @handlers[0]; $han.signature.ACCEPTS($cap) || !(@*BIND-FAILS.push(...)) }>
```

for any route whose signature has a constraint — which includes every literal
path segment, i.e. every route of the form `get -> 'greet', $name { … }`. Without
`.ACCEPTS` the assertion threw; with a literal-blind `.ACCEPTS` it would have
matched the wrong route.

## Tests

`t/signature-accepts-literal-param.t` — ten assertions, **passing unmodified
under Rakudo**: the literal matches and rejects for both `~~` and `.ACCEPTS`,
Int literals as well as Str, a signature taken off a real routine keeps the
literal, and ordinary dispatch through a literal parameter is unchanged.

Local gates, all green:

- `make test` — 2723 files / 26037 tests PASS
- `make roast` — 1435 files / 218774 tests PASS
- `scripts/battery-testsuite.sh` — `GATE PASSED` (153/158)

## Cro

`todo/deep/cro-http-request-hang-short-name-env-pollution.md` is updated with the
next blocker for parameterized routes, now reduced to a minimal standalone repro:
inside an alternation group, a `:my @a = $scalar.method` reading a preceding
`:my` declarator loses its elements (`.elems` is 1 instead of 2), so the route's
Capture is built wrong and the bind check rejects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)