### PR TITLE
fix(parser): `=begin` at end of input has no identifier either

### DIFF
--- a/news/2026-08/pod-begin-at-end-of-input.md
+++ b/news/2026-08/pod-begin-at-end-of-input.md
@@ -1,0 +1,48 @@
+# `=begin` at end of input, and `lives-ok` takes a `Callable`
+
+Two more findings from the Test-vendoring sweep
+(`todo/tickets/vendor-real-test-module.md`), one an interpreter fix and two test
+files corrected.
+
+## `=begin` with no identifier, at end of input
+
+`=begin` with no block name is `X::Syntax::Pod::BeginWithoutIdentifier`. mutsu
+raised it when the `=begin` was followed by more source, but not when it was the
+very last thing the parser saw — there the directive was not recognised as Pod
+at all and the unit failed with a generic parse error.
+
+That case is not exotic, because **`EVAL` trims its argument**: `EVAL "=begin\n"`
+reaches the parser as a bare `=begin`, which is exactly the shape
+`throws-like "=begin\n", X::Syntax::Pod::BeginWithoutIdentifier` produces. The
+end-of-input arm now raises the same typed error the rest-of-line check does,
+and both share one builder.
+
+raku distinguishes the two spellings — with no trailing newline it does not read
+`=begin` as a Pod directive at all and reports an infix `=` in term position —
+but mutsu cannot, because the trim has already erased the difference by the time
+the parser runs. Matching the newline form is the useful half: it is the one real
+source ever contains, and it is what every assertion against this error is
+written as.
+
+## Two test files that asserted more than Raku does
+
+- **`t/pod-begin-without-identifier.t`** asserted that `"say 1; =begin\nsay 2;"`
+  is `X::Syntax::Pod::BeginWithoutIdentifier`. A Pod directive has to *start a
+  line*, so raku reads that `=begin` as an infix `=` in term position instead.
+  The `=begin` gets its own line now, which is what the assertion meant.
+- **`t/variable-traits.t`** called `lives-ok` with a `Str`. `lives-ok` takes a
+  `Callable`; the string form is `eval-lives-ok`, and raku rejects the call at
+  compile time (*Calling lives-ok(Str, Str) will never work*). mutsu's native
+  provider accepted it. It was the only such call in the whole of `t/`.
+
+Both files are green under `raku` now, as is `t/pod-begin-at-end-of-input.t`,
+which pins the parser fix.
+
+## What still keeps `t/variable-traits.t` red under the real module
+
+`Test.rakumod` exports `multi sub trait_mod:<is>(Routine:D $r,
+:$test-assertion!)`. Once that is imported, mutsu routes *every* `is` trait
+through user multi-dispatch, so an unknown trait comes back as `X::Multi::NoMatch`
+("Cannot resolve caller trait_mod:<is>(Any:D)") instead of falling back to the
+built-in handling and its `X::Comp::Trait::Unknown`. Recorded in
+`todo/tickets/user-trait-mod-multi-shadows-builtin-traits.md`.

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -162,6 +162,19 @@ fn skip_declarator_doc_comment(input: &str) -> Option<&str> {
     }
 }
 
+/// `X::Syntax::Pod::BeginWithoutIdentifier` — a `=begin` with no block name.
+fn pod_begin_without_identifier_error() -> PError {
+    let msg =
+        "=begin must be followed by an identifier; (did you mean \"=begin pod\"?)".to_string();
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+    let ex = crate::value::Value::make_instance(
+        crate::symbol::Symbol::intern("X::Syntax::Pod::BeginWithoutIdentifier"),
+        attrs,
+    );
+    PError::fatal_with_exception(msg, Box::new(ex))
+}
+
 /// Parse and skip a Pod block.
 /// Handles `=begin ... =end`, `=for ...`, `=head ...`, `=item ...`, `=comment ...`, etc.
 fn pod_block(input: &str) -> PResult<'_, &str> {
@@ -183,6 +196,19 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
         if !ch.is_whitespace() {
             return Err(PError::expected("pod directive"));
         }
+    } else if keyword == "begin" {
+        // `=begin` as the very last thing in the source has no identifier
+        // either, so it is the same compile error as `=begin\n`. This arm
+        // exists because EVAL trims its argument: `EVAL "=begin\n"` reaches the
+        // parser as a bare `=begin` and used to fall out as a generic parse
+        // failure rather than X::Syntax::Pod::BeginWithoutIdentifier.
+        //
+        // raku distinguishes the two — with no trailing newline it does not read
+        // `=begin` as a Pod directive at all and reports an infix `=` in term
+        // position — but mutsu cannot, because the trim has already erased the
+        // difference by the time the parser runs. Matching the newline form is
+        // the useful half: it is the one real source ever contains.
+        return Err(pod_begin_without_identifier_error());
     } else {
         return Err(PError::expected("pod directive"));
     }
@@ -195,15 +221,7 @@ fn pod_block(input: &str) -> PResult<'_, &str> {
         let target = begin_line.split_whitespace().next().unwrap_or("");
         // `=begin` must be followed by an identifier (the block name).
         if target.is_empty() {
-            let msg = "=begin must be followed by an identifier; (did you mean \"=begin pod\"?)"
-                .to_string();
-            let mut attrs = std::collections::HashMap::new();
-            attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
-            let ex = crate::value::Value::make_instance(
-                crate::symbol::Symbol::intern("X::Syntax::Pod::BeginWithoutIdentifier"),
-                attrs,
-            );
-            return Err(PError::fatal_with_exception(msg, Box::new(ex)));
+            return Err(pod_begin_without_identifier_error());
         }
         let is_table = target == "table";
         let mut remaining = rest.get(begin_line_end + 1..).unwrap_or_default();

--- a/t/pod-begin-at-end-of-input.t
+++ b/t/pod-begin-at-end-of-input.t
@@ -1,0 +1,24 @@
+use Test;
+
+# `=begin` with no block name is X::Syntax::Pod::BeginWithoutIdentifier. That
+# already held when the `=begin` was followed by more source, but mutsu's EVAL
+# trims its argument -- so `EVAL "=begin\n"` arrived at the parser as a bare
+# `=begin` at end of input, which fell out as a generic parse failure instead.
+
+plan 5;
+
+throws-like "=begin\n", X::Syntax::Pod::BeginWithoutIdentifier,
+    'a =begin with no identifier';
+
+throws-like "=begin   \n", X::Syntax::Pod::BeginWithoutIdentifier,
+    'trailing spaces are not an identifier';
+
+throws-like "=begin\n=end\n", X::Syntax::Pod::BeginWithoutIdentifier,
+    'nor is a following =end';
+
+throws-like "say 1;\n=begin\nsay 2;", X::Syntax::Pod::BeginWithoutIdentifier,
+    'it is reported when it is not the first statement';
+
+# A named block is unaffected.
+is EVAL("=begin pod\nHello\n=end pod\n42"), 42,
+    'a named =begin pod block still parses';

--- a/t/pod-begin-without-identifier.t
+++ b/t/pod-begin-without-identifier.t
@@ -7,7 +7,9 @@ throws-like "=begin\n", X::Syntax::Pod::BeginWithoutIdentifier;
 throws-like "=begin   \n", X::Syntax::Pod::BeginWithoutIdentifier;
 
 # The error propagates even when the bare `=begin` is not the first statement.
-throws-like "say 1; =begin\nsay 2;", X::Syntax::Pod::BeginWithoutIdentifier;
+# A Pod directive has to start a line -- `say 1; =begin` is an infix `=` in term
+# position in Raku, not a Pod block -- so the `=begin` gets its own line here.
+throws-like "say 1;\n=begin\nsay 2;", X::Syntax::Pod::BeginWithoutIdentifier;
 
 # `=begin pod ... =end pod` is valid and produces no runtime output.
 is EVAL("=begin pod\nHello\n=end pod\n42"), 42,

--- a/t/variable-traits.t
+++ b/t/variable-traits.t
@@ -8,7 +8,8 @@ throws-like q[my $a is readonly = 5;], X::Comp::Trait::Unknown,
 throws-like q[(my $a is readonly) = 5;], X::Comp::Trait::Unknown,
     q[parenthesized declaration also rejects unsupported variable trait];
 
-lives-ok q[my $a is default(41) = 42;], q[supported variable trait parses];
+# `lives-ok` takes a Callable; the string form is `eval-lives-ok`.
+eval-lives-ok q[my $a is default(41) = 42;], q[supported variable trait parses];
 
 throws-like q[my $a is definitely-invalid = 5;], X::Comp::Trait::Unknown,
     q[unknown variable trait is rejected];

--- a/todo/tickets/handled-failure-still-throws-when-sunk.md
+++ b/todo/tickets/handled-failure-still-throws-when-sunk.md
@@ -1,0 +1,50 @@
+# A `Failure` that `.defined` handled still throws when it is sunk
+
+Calling `.defined` (or `.Bool`, `.so`, ...) on a `Failure` *handles* it: the
+Failure stops being live, and sinking it afterwards is a no-op. mutsu marks it
+handled for some purposes but the trailing-value check of a block does not
+respect the mark:
+
+```
+$ raku  -e 'my $f = "foo"[2]; $f.defined; try { $f }; say (defined $!) ?? "died" !! "lived"'
+lived
+$ mutsu -e 'my $f = "foo"[2]; $f.defined; try { $f }; say (defined $!) ?? "died" !! "lived"'
+died
+```
+
+No `EVAL` and no module are involved — `"foo"[2]` produces the `Failure`
+directly. The same shape one level down also throws:
+
+```raku
+my &c = { my $f = "foo"[2]; $f.defined; $f };
+try { c() }        # mutsu throws, raku lives
+```
+
+## Why it matters
+
+rakudo's `Test.rakumod` writes `lives-ok` as
+
+```raku
+multi sub lives-ok(Callable $code, $reason = '') is export {
+    try { $code(); }
+    my $ok = proclaim((not defined $!), $reason) or _diag($!);
+    ...
+}
+```
+
+so any `lives-ok { ... }` whose block ends in a handled `Failure` is reported as
+*died*. That is what keeps two assertions of
+`t/statement-call-sinks-its-value.t` red under the aliased upstream module
+(`todo/tickets/vendor-real-test-module.md`) while they pass under mutsu's native
+provider and under `raku`.
+
+## Where to look
+
+`failure_to_runtime_error_if_unhandled` is the shared predicate; `OpCode::
+ThrowIfFailure` (the block/routine trailing-value check, `vm_exec_dispatch.rs`)
+and `OpCode::SinkPop` both call it. The question is whether `.defined` on a
+`Failure` actually sets the handled flag on the *same* value the caller still
+holds, or on a clone — mutsu's `Value` is `Arc`-backed, so a method that
+reconstructs the instance rather than mutating it in place would leave the
+original live. Check `.Bool` / `.so` / `.not` / `defined($f)` (the sub form)
+too; raku handles the Failure for all of them.

--- a/todo/tickets/local-tests-rely-on-a-lenient-native-is.md
+++ b/todo/tickets/local-tests-rely-on-a-lenient-native-is.md
@@ -48,21 +48,36 @@ upstream `Test.rakumod`, and `raku`):
   them exposed a real compiler bug — `notandthen` loaded `Nil` instead of the
   empty `Slip` its `andthen` sibling loads — which is fixed in the same change.
 
+## A third shape: `lives-ok` takes a `Callable`
+
+`t/variable-traits.t` passed a `Str` to `lives-ok`. The string form is
+`eval-lives-ok`; raku rejects the call at compile time (*Calling lives-ok(Str,
+Str) will never work*), and mutsu's native provider accepted it. It was the only
+such call in the whole of `t/` — corrected in
+`news/2026-08/pod-begin-at-end-of-input.md`, which also fixed
+`t/pod-begin-without-identifier.t` for asserting that a mid-line `=begin` is a
+Pod directive (raku reads it as an infix `=` in term position; a Pod directive
+has to start a line).
+
 ## Still open
 
-Eight files from the sweep's "raku fails it too" bucket are **not** this
-problem and need individual triage; several look like real gaps that only the
-strict module exposes:
+Six files from the sweep's "raku fails it too" bucket are **not** this problem
+and need individual triage. In each of them `raku` fails for a reason unrelated
+to `is`'s leniency — mutsu-specific syntax it cannot parse, or a module it
+cannot find — so the `raku` verdict says nothing about the assertion style and
+each has to be read on its own:
 
 | file | first failure under the real module |
 | --- | --- |
 | `begin-phaser-begintime.t` | `right exception type (X::AdHoc)` for a die in `INIT` |
-| `listop-arg-loose-logical-precedence.t` | `orelse` does not short-circuit on a true listop result |
+| `listop-arg-loose-logical-precedence.t` | `orelse` does not short-circuit on a true listop result (`raku` passes this one) |
 | `method-private-errors.t` | `.calling-package` of `X::Method::Private::Permission` |
 | `placeholder-named-in-method-do.t` | `%_` in a mainline `do {}` is not `X::Placeholder` |
-| `pod-begin-without-identifier.t` | `X::Syntax::Pod::BeginWithoutIdentifier` not raised |
 | `use-version-short-adverb.t` | `Test::Util::ServerPort` cannot be `use`-d with a `:v<>` adverb |
-| `variable-traits.t` | `X::Comp::Trait::Unknown` not raised |
 | `vm-panic-boundary.t` | a VM panic escapes as a Rust panic under the real module |
+
+`t/variable-traits.t` is out of this bucket but still red under the real module,
+for a cause of its own:
+`todo/tickets/user-trait-mod-multi-shadows-builtin-traits.md`.
 
 Re-run `tmp/sweep-full.sh` after each to re-measure.

--- a/todo/tickets/user-trait-mod-multi-shadows-builtin-traits.md
+++ b/todo/tickets/user-trait-mod-multi-shadows-builtin-traits.md
@@ -1,0 +1,35 @@
+# A user `trait_mod:<is>` multi shadows every built-in trait
+
+rakudo's `Test.rakumod` exports one:
+
+```raku
+multi sub trait_mod:<is>(Routine:D $r, :$test-assertion!) is export { ... }
+```
+
+In Raku that candidate simply joins the multi; the built-in candidates are still
+there, so an unrecognised trait still reaches the fallback that raises
+`X::Comp::Trait::Unknown`. In mutsu, importing it makes **every** `is` trait
+dispatch through user multi-dispatch, and an unknown trait comes back as the
+dispatch failure instead:
+
+```
+# with `use Test2;` (the aliased upstream Test.rakumod) in scope
+my $a is definitely-invalid = 5;
+# mutsu: X::Multi::NoMatch -- Cannot resolve caller trait_mod:<is>(Any:D);
+#        none of these signatures matches: ...
+# raku:  X::Comp::Trait::Unknown -- Unknown variable trait 'is definitely-invalid'
+```
+
+Without the import mutsu gets it right, so the built-in path is fine; what is
+missing is the fallback *from* user dispatch back to it. A user `trait_mod:<is>`
+that matches nothing should not consume the trait.
+
+Reproduce with `mutsu -I tmp/core -e 'use Test2; my $a is definitely-invalid = 5'`
+(see the vendoring ticket for how `tmp/core/Test2.rakumod` is produced), or under
+the alias with `t/variable-traits.t`, which this keeps red under the real module
+even after `news/2026-08/pod-begin-at-end-of-input.md` corrected the file's own
+`lives-ok` bug.
+
+The same shape presumably applies to `trait_mod:<does>` / `<of>` / `<returns>`
+and to a user `trait_mod:<is>` from any other module — `Test` is just the one
+that surfaced it.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -235,9 +235,47 @@ in that 30 and are worth taking before the individual gaps:
   `X::Syntax::Augment::Illegal` (arrives as `X::Augment::NoSuchType`), and
   `X::Phaser::PrePost` with an empty `.message`.
 
-So what stands between here and flipping `runtime_module.rs` is those, plus a
-pass over the lenient-`is` test files. Re-run `tmp/sweep-full.sh` to re-measure
-after each.
+### Re-measured after the lenient-`is` pass (2026-08-01)
+
+| | at the start of the day | now |
+| --- | --- | --- |
+| pass under both | 2617 | **2675 / 2725** |
+| regress under the real module | 86 | **37** |
+| passes only under the real module | 1 | 1 |
+| fail under both (pre-existing) | 13 | 12 |
+
+The 37 split **6 that `raku` also fails** and **31 real gaps**. The test-file
+bucket is essentially exhausted: what remains in it
+(`begin-phaser-begintime.t`, `method-private-errors.t`,
+`listop-arg-loose-logical-precedence.t`, `placeholder-named-in-method-do.t`,
+`use-version-short-adverb.t`, `vm-panic-boundary.t`) fails under `raku` for
+reasons unrelated to `is`'s leniency — mutsu-specific syntax, a module `raku`
+cannot find — and is listed for individual triage in
+`todo/tickets/local-tests-rely-on-a-lenient-native-is.md`.
+
+Three of the 31 are `t/` files this campaign *added* as pins, failing under the
+alias on shapes their own subject does not cover:
+`eval-type-decl-and-phaser-message.t` and `role-initialization.t` on the
+EVAL-package problem below, and `statement-call-sinks-its-value.t` on
+`todo/tickets/handled-failure-still-throws-when-sunk.md`.
+
+Open systemic causes, in the order worth taking them:
+
+1. **`todo/deep/eval-context-argument-is-ignored.md`** — an EVAL'd snippet's own
+   types are named after the calling *module* (`Test2::Foo`) and its bare
+   references to them stop resolving. Blocks `attribute-undeclared.t`,
+   `composition-not-composable.t`, `role-initialization.t`,
+   `augment-role-anon.t`, `eval-type-decl-and-phaser-message.t`.
+2. **`todo/tickets/handled-failure-still-throws-when-sunk.md`** — `.defined` does
+   not stop a `Failure` from throwing when the block that returns it is sunk, so
+   `lives-ok`'s `try { $code() }` reports *died*.
+3. **`todo/tickets/user-trait-mod-multi-shadows-builtin-traits.md`** — importing
+   `Test`'s `trait_mod:<is>` makes every `is` trait dispatch through user
+   multi-dispatch, so an unknown trait is `X::Multi::NoMatch`.
+4. **`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`** —
+   `X::Undeclared::Symbols ~~ X::Undeclared` and friends.
+
+Re-run `tmp/sweep-full.sh` to re-measure after each.
 
 ## Blocker found while doing step 1: the native provider shadows an import — FIXED
 


### PR DESCRIPTION
`=begin` with no block name is `X::Syntax::Pod::BeginWithoutIdentifier`. mutsu raised it when the `=begin` was followed by more source, but not when it was the very last thing the parser saw — there the directive was not recognised as Pod at all and the unit failed with a generic parse error.

That case is not exotic, because **`EVAL` trims its argument**: `EVAL "=begin\n"` reaches the parser as a bare `=begin`, which is exactly the shape `throws-like "=begin\n", X::Syntax::Pod::BeginWithoutIdentifier` produces. The end-of-input arm now raises the same typed error the rest-of-line check does, and both share one builder.

raku distinguishes the two spellings — with no trailing newline it does not read `=begin` as a Pod directive at all and reports an infix `=` in term position — but mutsu cannot, because the trim has already erased the difference by the time the parser runs. Matching the newline form is the useful half: it is the one real source ever contains, and it is what every assertion against this error is written as. Noted in the code.

## Two test files that asserted more than Raku does

- **`t/pod-begin-without-identifier.t`** asserted that `"say 1; =begin\nsay 2;"` is `X::Syntax::Pod::BeginWithoutIdentifier`. A Pod directive has to *start a line*, so raku reads that `=begin` as an infix `=` in term position instead. The `=begin` gets its own line now, which is what the assertion meant.
- **`t/variable-traits.t`** called `lives-ok` with a `Str`. `lives-ok` takes a `Callable`; the string form is `eval-lives-ok`, and raku rejects the call at compile time (*Calling lives-ok(Str, Str) will never work*). mutsu's native provider accepted it. It was the only such call in the whole of `t/`.

## Two findings recorded rather than fixed

- `todo/tickets/user-trait-mod-multi-shadows-builtin-traits.md` — `Test.rakumod` exports `multi sub trait_mod:<is>(Routine:D $r, :$test-assertion!)`, and importing it makes *every* `is` trait dispatch through user multi-dispatch, so an unknown trait comes back as `X::Multi::NoMatch` instead of `X::Comp::Trait::Unknown`. This is what still keeps `t/variable-traits.t` red under the real module.
- `todo/tickets/handled-failure-still-throws-when-sunk.md` — `my $f = "foo"[2]; $f.defined; try { $f }` throws in mutsu and lives in raku. No `EVAL` or module involved. It matters because `Test.rakumod`'s `lives-ok` is `try { $code(); }`, so any block ending in a handled `Failure` is reported as *died*.

## Sweep status

Re-measured with everything landed today (`tmp/sweep-full.sh`): **2675 / 2725** files pass under both mutsu's native provider and the aliased upstream `Test.rakumod`, up from 2617 this morning; regressions are down from 86 to **37**. The ticket now lists the four open systemic causes in the order worth taking them.

## Testing

- `t/pod-begin-at-end-of-input.t` — 5 assertions, **green under `raku` too**; so are both corrected files.
- `make test`: `Files=2726, Tests=26054 … Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)