### PR TITLE
fix(runtime): a bare type name resolves through its enclosing packages

### DIFF
--- a/news/2026-08/bare-type-name-under-a-package.md
+++ b/news/2026-08/bare-type-name-under-a-package.md
@@ -1,0 +1,45 @@
+# A bare type name resolves through its enclosing packages in call position too
+
+A `class` or `role` declared under a non-`GLOBAL` package registers
+package-qualified — `M::C` for a `class C` inside `module M` — which is what
+raku does as well. mutsu already resolved a *bare* reference to it in
+type-object position by walking outward through the enclosing packages
+(`bare_name_packages`, the same chain bare *routine* lookup uses). Two other
+positions did not:
+
+- **Call position.** `C("x")` is a coercion and `99 but R("x")` initializes a
+  role's single public attribute; both key the registry by the name as written,
+  so from inside `M` they died with `Unknown function: C`.
+- **`augment`.** `augment class C` / `augment role R` inside `M` looked up the
+  bare name, found nothing, and reported `X::Augment::NoSuchType` — for a type
+  that exists and, being a role, should have earned
+  `X::Syntax::Augment::Illegal` instead.
+
+Both now go through one `resolve_bare_type_name` helper.
+
+## The chain is consulted before the unqualified name
+
+Innermost package first, unqualified last. That is raku's precedence for a
+lexically inner declaration, and getting it backwards is not academic: with the
+unqualified key checked first, a stale global `R` left in the registry by an
+*earlier* `EVAL` in the same process shadowed the `M::R` the current unit had
+just declared, so `throws-like 'my role R { }; 99 but R("wrong")',
+X::Role::Initialization` quietly succeeded against the previous test's role
+instead of failing against this one. The first draft of this change had exactly
+that bug and the vendored-`Test` sweep caught it.
+
+## Effect
+
+Found through the Test-vendoring sweep (`todo/tickets/vendor-real-test-module.md`),
+where the calling module is `Test` itself: `EVAL $code, context => ...` from
+inside `Test.rakumod` runs the snippet under package `Test`, so a snippet that
+declares its own type could not then refer to it. Four `t/` files go green under
+the aliased upstream module — `role-initialization.t`, `augment-role-anon.t`,
+`augment-nosuchtype.t`, `eval-type-decl-and-phaser-message.t`.
+
+The other half of that problem — `.package-name` reporting `Test2::Foo` where
+raku reports `Foo`, which needs `EVAL`'s `context` argument to be honoured — is
+still open in `todo/deep/eval-context-argument-is-ignored.md`.
+
+Pinned by `t/bare-type-name-under-a-package.t`, whose 7 assertions are green
+under `raku` too.

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -712,6 +712,14 @@ impl Interpreter {
             return Err(err);
         }
 
+        // A bare type name in call position may name a package-qualified
+        // declaration: `EVAL 'my role R { has $.x }; 99 but R("ok")'` running
+        // under `unit module M` registers `M::R`, and the snippet's own `R(...)`
+        // still has to find it. Resolve once here, before every branch below
+        // that keys the registry by `name`.
+        let qualified_type = self.resolve_bare_type_name(name);
+        let name: &str = qualified_type.as_deref().unwrap_or(name);
+
         // Invoking a *class* type object coerces: `Foo($x)` is `Foo.COERCE($x)`
         // when the class defines COERCE, else `Foo.new($x)`, else
         // X::Coerce::Impossible — the same protocol the role branch below

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -19,8 +19,14 @@ impl Interpreter {
             "Blob",
             "Buf",
         ];
+        // A role declared under a non-GLOBAL package registers package-qualified
+        // (`M::R`), so `augment role R` inside that package has to resolve the
+        // bare name the same way every other bare type reference does --
+        // otherwise an existing role reports X::Augment::NoSuchType instead of
+        // the X::Syntax::Augment::Illegal that a *closed* role earns.
         let exists = self.registry().roles.contains_key(name)
             || self.registry().classes.contains_key(name)
+            || self.resolve_bare_type_name(name).is_some()
             || crate::runtime::utils::is_known_type_constraint(name)
             || BUILTIN_ROLES.contains(&name);
         if exists {
@@ -59,6 +65,10 @@ impl Interpreter {
         does_roles: &[String],
     ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
+        // `augment class C` inside a non-GLOBAL package names the qualified
+        // declaration `M::C`, the same as every other bare type reference.
+        let qualified = self.resolve_bare_type_name(name);
+        let name: &str = qualified.as_deref().unwrap_or(name);
         // Check if the class exists (user-defined or builtin)
         let is_builtin = !self.registry().classes.contains_key(name);
         if is_builtin {

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -5,6 +5,38 @@ impl Interpreter {
         self.registry().classes.contains_key(name)
     }
 
+    /// The registry key a *bare* type name resolves to, when it is not already
+    /// one.
+    ///
+    /// A `class`/`role` declared under a non-`GLOBAL` package registers
+    /// package-qualified (`Mod::C`) — which matches raku — so a bare `C` in
+    /// *call* position (`C("x")` is a coercion, `99 but R("x")` initializes a
+    /// role's single public attribute) has to walk the same outward package
+    /// chain that bare *routine* lookup walks. Type-object position already did;
+    /// only the call path stopped at the unqualified name and reported "Unknown
+    /// function: C".
+    ///
+    /// The chain is consulted **before** the unqualified key, innermost first,
+    /// because that is the precedence raku gives a lexically inner declaration.
+    /// Consulting the bare name first would let a stale global `R` — say from an
+    /// earlier `EVAL` in the same process — shadow the `Mod::R` the current unit
+    /// just declared.
+    ///
+    /// Returns `None` when the name is already qualified or when nothing along
+    /// the chain matches; the caller then keeps the bare name.
+    pub(crate) fn resolve_bare_type_name(&self, name: &str) -> Option<String> {
+        if name.contains("::") {
+            return None;
+        }
+        self.bare_name_packages().into_iter().find_map(|pkg| {
+            if pkg == "GLOBAL" {
+                return None;
+            }
+            let key = format!("{}::{}", pkg.split("::&").next().unwrap_or(&pkg), name);
+            (self.has_class(&key) || self.has_role(&key)).then_some(key)
+        })
+    }
+
     /// True when `name` was declared via the `package`/`module` declarator (and
     /// is therefore not type-like enough to constrain a variable/parameter).
     /// Used to raise X::Syntax::Variable::BadType / X::Parameter::BadType instead

--- a/t/bare-type-name-under-a-package.t
+++ b/t/bare-type-name-under-a-package.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A class or role declared under a non-GLOBAL package registers
+# package-qualified (`M::C`) -- which is what raku does too. Type-object
+# position already resolved a bare reference to it by walking outward through
+# the enclosing packages; *call* position and `augment` did not, and reported
+# "Unknown function: C" / X::Augment::NoSuchType instead.
+
+plan 7;
+
+module M {
+    class C {
+        has $.v;
+        method new($v) { self.bless(:$v) }
+    }
+    role R { has $.x }
+    our sub coerce-it()   { C("x") }
+    our sub role-init()   { 99 but R("ok") }
+    our sub augment-it()  { EVAL 'use MONKEY-TYPING; augment class C { method extra { 7 } }' }
+}
+
+is M::coerce-it().v, 'x',
+    'a bare class name coerces from inside its own package';
+
+is M::role-init().x, 'ok',
+    'a bare role name initializes its single public attribute';
+
+is M::C.^name, 'M::C',
+    'the declaration really is package-qualified';
+
+# `augment` resolves the same way.
+use MONKEY-SEE-NO-EVAL;
+lives-ok { M::augment-it() },
+    'augment finds the package-qualified class by its bare name';
+is M::C.new('y').extra, 7,
+    'and the augmented method is there';
+
+# A genuinely absent type is still X::Augment::NoSuchType.
+throws-like 'use MONKEY-TYPING; augment class NoSuchClassAtAll { }',
+    X::Augment::NoSuchType,
+    'an absent class still reports NoSuchType';
+
+# The GLOBAL case is unchanged.
+class Top { has $.v; method new($v) { self.bless(:$v) } }
+is Top("z").v, 'z', 'a GLOBAL class still coerces by its bare name';

--- a/todo/deep/eval-context-argument-is-ignored.md
+++ b/todo/deep/eval-context-argument-is-ignored.md
@@ -76,7 +76,15 @@ Pin candidates: the two `t/` files above under the real `Test` module, plus a
 direct `t/eval-context-package.t` built from the `FatalMod` repro, which is
 green under `raku`.
 
-## A sibling bug in the same area: the package-qualified name stops resolving
+## A sibling bug in the same area: the package-qualified name stops resolving — FIXED
+
+**Resolved** in `news/2026-08/bare-type-name-under-a-package.md`: a bare type
+name now walks the enclosing packages in call position and in `augment`, not
+just in type-object position. Kept below because it is the half of this problem
+that is *not* about `context`, and because the distinction is what makes the
+remaining half legible: the snippet can find its own types again, but they are
+still *named* after the calling module, which is what `context` is supposed to
+change.
 
 Independent of `context`, and worth fixing first because it is narrower. When
 EVAL runs under a non-`GLOBAL` package, a type the snippet declares registers


### PR DESCRIPTION
A `class` or `role` declared under a non-`GLOBAL` package registers package-qualified — `M::C` for a `class C` inside `module M` — which is what raku does as well. mutsu already resolved a *bare* reference to it in **type-object** position by walking outward through the enclosing packages (`bare_name_packages`, the same chain bare *routine* lookup uses). Two other positions did not:

- **Call position.** `C("x")` is a coercion and `99 but R("x")` initializes a role's single public attribute; both key the registry by the name as written, so from inside `M` they died with `Unknown function: C`.
- **`augment`.** `augment class C` / `augment role R` inside `M` looked up the bare name, found nothing, and reported `X::Augment::NoSuchType` — for a type that exists and, being a role, should have earned `X::Syntax::Augment::Illegal` instead.

Both now go through one `resolve_bare_type_name` helper.

## The chain is consulted before the unqualified name

Innermost package first, unqualified last. That is raku's precedence for a lexically inner declaration, and getting it backwards is not academic: with the unqualified key checked first, a stale global `R` left in the registry by an **earlier `EVAL` in the same process** shadowed the `M::R` the current unit had just declared, so `throws-like 'my role R { }; 99 but R("wrong")', X::Role::Initialization` quietly *succeeded* against the previous test's role instead of failing against this one. The first draft of this change had exactly that bug and the vendored-`Test` sweep caught it.

## Effect

Found through the Test-vendoring sweep (`todo/tickets/vendor-real-test-module.md`), where the calling module is `Test` itself: `EVAL $code, context => ...` from inside `Test.rakumod` runs the snippet under package `Test`, so a snippet that declares its own type could not then refer to it. **Four `t/` files go green under the aliased upstream module** — `role-initialization.t`, `augment-role-anon.t`, `augment-nosuchtype.t`, `eval-type-decl-and-phaser-message.t`.

The other half of that problem — `.package-name` reporting `Test2::Foo` where raku reports `Foo`, which needs `EVAL`'s `context` argument to be honoured — stays open in `todo/deep/eval-context-argument-is-ignored.md`, now updated to say which half is done and why the distinction matters.

## Testing

- `t/bare-type-name-under-a-package.t` — 7 assertions, **green under `raku` too**.
- `make test`: `Files=2727, Tests=26066 … Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)