### PR TITLE
feat(modules): vendor rakudo's real `Test.rakumod` behind `MUTSU_REAL_TEST=1`

### DIFF
--- a/modules/Rakudo-Core/META6.json
+++ b/modules/Rakudo-Core/META6.json
@@ -6,7 +6,8 @@
   "license": "Artistic-2.0",
   "perl": "6.d",
   "provides": {
-    "Pod::To::Text": "lib/Pod/To/Text.rakumod"
+    "Pod::To::Text": "lib/Pod/To/Text.rakumod",
+    "Test": "lib/Test.rakumod"
   },
   "depends": [],
   "source-url": "https://github.com/rakudo/rakudo.git"

--- a/modules/Rakudo-Core/README.md
+++ b/modules/Rakudo-Core/README.md
@@ -19,8 +19,26 @@ genuine upstream implementation instead of reimplementing it natively.
 | Module          | Upstream path             | md5 of the imported file           |
 | --------------- | ------------------------- | ---------------------------------- |
 | `Pod::To::Text` | `lib/Pod/To/Text.rakumod` | `3903bd3642ee99500a4ca67782fc5055`  |
+| `Test`          | `lib/Test.rakumod`        | `f34dec45d52ad099c37f42fdbd93e277`  |
 
 (`LICENSE` is `rakudo-2026.06/LICENSE`, md5 `18740546821e33d23e8809da70d4a79a`.)
+
+### `Test` is vendored but not yet the default
+
+`Test` is here because it is measurably reachable
+(`todo/tickets/vendor-real-test-module.md`), but `use Test` still resolves to
+mutsu's native TAP provider by default. Every `t/` file and every roast file
+stands on `Test`, so swapping the implementation swaps the foundation of the
+whole suite; step 3 of that ticket flips it once the residue is gone. Until
+then set **`MUTSU_REAL_TEST=1`** to load this file instead:
+
+```
+MUTSU_REAL_TEST=1 mutsu t/some-test.t
+```
+
+The switch replaced the throwaway `unit module Test2;` rename the exercise ran
+under before, so the file under test is now the unmodified upstream one that
+ships in the repository. Pinned by `t/vendored-real-test-module.t`.
 
 ## Why this directory exists
 
@@ -32,8 +50,10 @@ a module that never needed it — unlike `JSON::Fast`, the real `Pod::To::Text` 
 Bundling the real file replaces the private dialect with the upstream behaviour
 and turns any remaining gap into an interpreter bug we can fix.
 
-Other Rakudo core modules mutsu still provides natively (`Test`, `NativeCall`,
-`experimental`, `newline`, ...) belong here too, once the interpreter runs them.
+Other Rakudo core modules mutsu still provides natively (`NativeCall`,
+`experimental`, `newline`, ...) belong here too, once the interpreter runs them —
+except `NativeCall`, measured on 2026-08-01 as genuinely out of reach
+(`todo/deep/nativecall-cannot-be-vendored.md`).
 
 ## Updating
 

--- a/modules/Rakudo-Core/lib/Test.rakumod
+++ b/modules/Rakudo-Core/lib/Test.rakumod
@@ -1,0 +1,953 @@
+use MONKEY-GUTS;          # Allow NQP ops.
+
+unit module Test;
+# Copyright (C) 2007 - 2026 Yet Another Society
+
+# settable from outside
+my int $raku_test_times =
+  ?(%*ENV<RAKU_TEST_TIMES> // %*ENV<PERL6_TEST_TIMES>);
+my int $die_on_fail =
+  ?(%*ENV<RAKU_TEST_DIE_ON_FAIL> // %*ENV<PERL6_TEST_DIE_ON_FAIL>);
+
+# global state
+my @vars;
+my $indents = "";
+
+# variables to keep track of our tests
+my $subtest_callable_type;
+my int $num_of_tests_run;
+my int $num_of_tests_failed;
+my int $todo_upto_test_num;
+my $todo_reason;
+my $num_of_tests_planned;
+my int $no_plan;
+my int $time_before;
+my int $time_after;
+my int $subtest_level;
+my $subtest_todo_reason;
+my int $pseudo_fails; # number of untodoed failed tests inside a todoed subtest
+
+# Output should always go to real stdout/stderr, not to any dynamic overrides.
+my $output;
+my $failure_output;
+my $todo_output;
+
+## If done-testing hasn't been run when we hit our END block, we need to know
+## so that it can be run. This allows compatibility with old tests that use
+## plans and don't call done-testing.
+my int $done_testing_has_been_run = 0;
+
+# make sure we have initializations
+_init_vars();
+
+sub _init_io {
+    nqp::setbuffersizefh(nqp::getstdout(), 0);
+    nqp::setbuffersizefh(nqp::getstderr(), 0);
+    $output         = $PROCESS::OUT;
+    $failure_output = $PROCESS::ERR;
+    $todo_output    = $PROCESS::OUT;
+}
+
+sub MONKEY-SEE-NO-EVAL() is export { 1 }
+
+## test functions
+
+our sub output is rw {
+    $output
+}
+
+our sub failure_output is rw {
+    $failure_output
+}
+
+our sub todo_output is rw {
+    $todo_output
+}
+
+multi sub trait_mod:<is>(Routine:D $r, :$test-assertion!) is export {
+    $r.^mixin( role is-test-assertion {
+        method is-test-assertion(--> True) { }
+    }) if $test-assertion;
+}
+
+proto sub plan ($?, Cool :$skip-all) {*}
+
+my class X::SubtestsSkipped is Exception {}
+
+multi sub plan (Cool:D :skip-all($reason)!) {
+    _init_io() unless $output;
+    $output.say: $indents ~ "1..0 # Skipped: $reason";
+
+    exit unless $subtest_level; # just exit if we're not in a subtest
+
+    # but if we are, adjust the vars, so the output matches up with zero
+    # planned tests, all passsing. Also, check the subtest's Callable is
+    # something we can actually return from.
+
+    $subtest_callable_type === Sub|Method
+        or die "Must give `subtest` a (Sub) or a (Method) to be able to use "
+            ~ "`skip-all` plan inside, but you gave a "
+            ~ $subtest_callable_type.gist;
+
+    $done_testing_has_been_run = 1;
+    $num_of_tests_failed = $num_of_tests_planned = $num_of_tests_run = 0;
+    X::SubtestsSkipped.new.throw
+}
+
+# "plan 'no_plan';" is now "plan *;"
+# It is also the default if nobody calls plan at all
+multi sub plan($number_of_tests) is export {
+    _init_io() unless $output;
+
+    my str $str-message;
+
+    if $number_of_tests ~~ ::Whatever {
+        $no_plan = 1;
+    }
+    else {
+        $num_of_tests_planned = $number_of_tests;
+        $no_plan = 0;
+
+        $str-message ~= $indents ~ '1..' ~ $number_of_tests;
+    }
+    # Get two successive timestamps to say how long it takes to read the
+    # clock, and to let the first test timing work just like the rest.
+    # These readings should be made with the expression now.to-posix[0],
+    # but its execution time when tried in the following two lines is a
+    # lot slower than the non portable nqp::time_n.
+    $time_before = nqp::time;
+    $time_after  = nqp::time;
+    $str-message ~= "\n$indents# between two timestamps " ~ ceiling(($time_after-$time_before)*1_000_000) ~ ' microseconds'
+        if nqp::iseq_i($raku_test_times,1);
+
+    $output.say: $str-message;
+
+    # Take one more reading to serve as the begin time of the first test
+    $time_before = nqp::time;
+}
+
+multi sub pass($desc = '') is export {
+    $time_after = nqp::time;
+    my $ok = proclaim(1, $desc);
+    $time_before = nqp::time;
+    $ok;
+}
+
+multi sub ok(Mu $cond, $desc = '') is export {
+    $time_after = nqp::time;
+    my $ok = proclaim($cond, $desc);
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub nok(Mu $cond, $desc = '') is export {
+    $time_after = nqp::time;
+    my $ok = proclaim(!$cond, $desc);
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub is(Mu $got, Mu:U $expected, $desc = '') is export {
+    $time_after = nqp::time;
+    my $ok;
+    if $got.defined { # also hack to deal with Failures
+        $ok = proclaim(False, $desc);
+        _diag "expected: ($expected.^name())\n"
+            ~ "     got: '$got'";
+    }
+    else {
+        # infix:<===> can't handle Mu's
+        my $test = nqp::eqaddr($expected.WHAT, Mu)
+            ?? nqp::eqaddr($got.WHAT, Mu)
+                !! nqp::eqaddr($got.WHAT, Mu)
+                    ?? False
+                    !! $got === $expected;
+
+        $ok = proclaim($test, $desc);
+        if !$test {
+            _diag "expected: ($expected.^name())\n"
+                ~ "     got: ($got.^name())";
+        }
+    }
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub is(Mu $got, Mu:D $expected, $desc = '') is export {
+    $time_after = nqp::time;
+    my $ok;
+    if $got.defined { # also hack to deal with Failures
+        # infix:<eq> can't handle Mu's
+        my $test = nqp::eqaddr($expected.WHAT, Mu)
+            ?? nqp::eqaddr($got.WHAT, Mu)
+                !! nqp::eqaddr($got.WHAT, Mu)
+                    ?? False
+                    !! $got eq $expected;
+        $ok = proclaim($test, $desc);
+        if !$test {
+            if try    $got     .Str.subst(/\s/, '', :g)
+                   eq $expected.Str.subst(/\s/, '', :g)
+            {
+                # only white space differs, so better show it to the user
+                _diag "expected: $expected.raku()\n"
+                    ~ "     got: $got.raku()";
+            }
+            else {
+                 try { # if the type support Stringification
+                      # note: we can't use ^can('Str') as Buf error in its Str method itself
+                    _diag "expected: '$expected'\n"
+                    ~ "     got: '$got'";
+                    True;
+                } or do {
+                    _diag "expected: $expected.raku()\n"
+                    ~ "     got: $got.raku()";
+                }
+            }
+        }
+    }
+    else {
+        $ok = proclaim(False, $desc);
+        _diag "expected: '$expected'\n"
+            ~ "     got: ($got.^name())";
+    }
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub isnt(Mu $got, Mu:U $expected, $desc = '') is export {
+    $time_after = nqp::time;
+    my $ok;
+    if $got.defined { # also hack to deal with Failures
+        $ok = proclaim(True, $desc);
+    }
+    else {
+        my $test = $got !=== $expected;
+        $ok = proclaim($test, $desc);
+        if !$test {
+            _diag "expected: anything except '$expected.raku()'\n"
+                ~ "     got: '$got.raku()'";
+        }
+    }
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub isnt(Mu $got, Mu:D $expected, $desc = '') is export {
+    $time_after = nqp::time;
+    my $ok;
+    if $got.defined { # also hack to deal with Failures
+        my $test = $got ne $expected;
+        $ok = proclaim($test, $desc);
+        if !$test {
+            _diag "expected: anything except '$expected.raku()'\n"
+                ~ "     got: '$got.raku()'";
+        }
+    }
+    else {
+        $ok = proclaim(True, $desc);
+    }
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub cmp-ok(Mu $got is raw, $op, Mu $expected is raw, $desc = '') is export {
+    $time_after = nqp::time;
+    $got.defined if nqp::istype($got, Failure); # Hack to deal with Failures
+    my $ok;
+
+    # the three labeled &CALLERS below are as follows:
+    #  #1 handles ops that don't have '<' or '>'
+    #  #2 handles ops that don't have '«' or '»'
+    #  #3 handles all the rest by escaping '<' and '>' with backslashes.
+    #     Note: #3 doesn't eliminate #1, as #3 fails with '<' operator
+    my $matcher = nqp::istype($op, Callable) ?? $op
+        !! &CALLER::LEXICAL::("infix:<$op>") #1
+            // &CALLER::LEXICAL::("infix:«$op»") #2
+            // &CALLER::LEXICAL::("infix:<$op.subst(/<?before <[<>]>>/, "\\", :g)>"); #3
+
+    if $matcher {
+        $ok = proclaim($matcher($got,$expected), $desc);
+        if !$ok {
+            my $expected-desc = stringify $expected;
+            my      $got-desc = stringify $got;
+            _diag "expected: $expected-desc\n"
+                ~ " matcher: '" ~ ($matcher.?name || $matcher.^name) ~ "'\n"
+                ~ "     got: $got-desc";
+        }
+    }
+    else {
+        $ok = proclaim(False, $desc);
+        _diag "Could not use '$op.raku()' as a comparator." ~ (
+            ' If you are trying to use a meta operator, pass it as a '
+            ~ "Callable instead of a string: \&[$op]"
+            unless nqp::istype($op, Callable)
+        );
+    }
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+sub bail-out ($desc?) is export {
+    _init_io() unless $output;
+    $output.put: join ' ', 'Bail out!', ($desc if $desc);
+    $done_testing_has_been_run = 1;
+    exit 255;
+}
+
+# We're picking and choosing which tolerance to use here, to make it easier
+# to test numbers close to zero, yet maintain relative tolerance elsewhere.
+# For example, relative tolerance works equally well with regular and huge,
+# but once we go down to zero, things break down: is-approx sin(τ), 0; would
+# fail, because the computed relative tolerance is 1. For such cases, absolute
+# tolerance is better suited, so we DWIM in the no-tol version of the sub.
+multi sub is-approx(Numeric $got, Numeric $expected, $desc = '') is export {
+    $expected.abs < 1e-6
+        ?? is-approx-calculate($got, $expected, 1e-5, Nil, $desc) # abs-tol
+        !! is-approx-calculate($got, $expected, Nil, 1e-6, $desc) # rel-tol
+}
+
+multi sub is-approx(
+    Numeric $got, Numeric $expected, Numeric $abs-tol, $desc = ''
+) is export {
+    is-approx-calculate($got, $expected, $abs-tol, Nil, $desc);
+}
+
+multi sub is-approx(
+    Numeric $got, Numeric $expected, $desc = '', Numeric :$rel-tol is required
+) is export {
+    is-approx-calculate($got, $expected, Nil, $rel-tol, $desc);
+}
+
+multi sub is-approx(
+    Numeric $got, Numeric $expected, $desc = '', Numeric :$abs-tol is required
+) is export {
+    is-approx-calculate($got, $expected, $abs-tol, Nil, $desc);
+}
+
+multi sub is-approx(
+    Numeric $got, Numeric $expected, $desc = '',
+    Numeric :$rel-tol is required, Numeric :$abs-tol is required
+) is export {
+    is-approx-calculate($got, $expected, $abs-tol, $rel-tol, $desc);
+}
+
+sub is-approx-calculate (
+    $got,
+    $expected,
+    $abs-tol where { !.defined or $_ >= 0 },
+    $rel-tol where { !.defined or $_ >= 0 },
+    $desc,
+) {
+    $time_after = nqp::time;
+
+    my Bool    ($abs-tol-ok, $rel-tol-ok) = True, True;
+    my Numeric ($abs-tol-got, $rel-tol-got);
+    if $abs-tol.defined {
+        $abs-tol-got = abs($got - $expected);
+        $abs-tol-ok = $abs-tol-got <= $abs-tol;
+    }
+    if $rel-tol.defined {
+        if max($got.abs, $expected.abs) -> $max {
+            $rel-tol-got = abs($got - $expected) / $max;
+            $rel-tol-ok = $rel-tol-got <= $rel-tol;
+        }
+        else {
+            # if $max is zero, then both $got and $expected are zero
+            # and so our relative difference is also zero
+            $rel-tol-got = 0;
+        }
+    }
+
+    my $ok = proclaim($abs-tol-ok && $rel-tol-ok, $desc);
+    unless $ok {
+            _diag "    expected approximately: $expected\n"
+                ~ "                       got: $got";
+
+        unless $abs-tol-ok {
+            _diag "maximum absolute tolerance: $abs-tol\n"
+                ~ "actual absolute difference: $abs-tol-got";
+        }
+        unless $rel-tol-ok {
+            _diag "maximum relative tolerance: $rel-tol\n"
+                ~ "actual relative difference: $rel-tol-got";
+        }
+    }
+
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub todo($reason, $count = 1) is export {
+    $time_after = nqp::time;
+    $todo_upto_test_num = $num_of_tests_run + $count;
+    # Adding a space to not backslash the # TODO
+    $todo_reason = " # TODO $reason";
+    $time_before = nqp::time;
+}
+
+proto  sub skip(|) is export {*}
+multi sub skip() {
+    $time_after = nqp::time;
+    proclaim(1, '', "# SKIP");
+    $time_before = nqp::time;
+}
+multi sub skip($reason, $count = 1) {
+    $time_after = nqp::time;
+    die "skip() was passed a non-integer number of tests.  Did you get the arguments backwards or use a non-integer number?" if $count !~~ Int;
+    my $i = 1;
+    while $i <= $count { proclaim(1, $reason, "# SKIP "); $i = $i + 1; }
+    $time_before = nqp::time;
+}
+
+sub skip-rest($reason = '<unknown>') is export {
+    $time_after = nqp::time;
+    die "A plan is required in order to use skip-rest"
+      if nqp::iseq_i($no_plan,1);
+    skip($reason, $num_of_tests_planned - $num_of_tests_run);
+    $time_before = nqp::time;
+}
+
+proto sub subtest(|) is export {*}
+multi sub subtest(*%_ where *.elems == 1) {
+    subtest(.value, .key) with %_.pairs.head
+}
+multi sub subtest(Pair $what) {
+    subtest($what.value,$what.key)
+}
+multi sub subtest($desc, &subtests) {
+    subtest(&subtests,$desc)
+}
+multi sub subtest(&subtests, $desc = '') {
+    _diag "Subtest" ~ ($desc ?? ": " ~ $desc !! ''), :force-informative;
+    my $parent_todo = $todo_reason || $subtest_todo_reason;
+    _push_vars();
+    _init_vars();
+    $subtest_todo_reason   = $parent_todo;
+    $subtest_callable_type = &subtests.WHAT;
+    $indents ~= "    ";
+    $subtest_level++;
+    {
+        subtests();
+        CATCH {
+            when X::SubtestsSkipped {
+                # Subtests all skipped
+            }
+        }
+    }
+    $subtest_level--;
+    done-testing() if nqp::iseq_i($done_testing_has_been_run,0);
+    my $status = $num_of_tests_failed == 0
+        && $num_of_tests_planned == $num_of_tests_run
+        && $pseudo_fails == 0;
+    _pop_vars;
+    $indents .= chop(4);
+    proclaim($status,$desc) or ($die_on_fail and die-on-fail);
+}
+
+sub diag($message) is export {
+    # Always send user-triggered diagnostics to STDERR. This prevents
+    # cases of confusion of where diag() has to send its ouput when
+    # we are in the middle of TODO tests
+    _diag $message, :force-stderr;
+}
+
+sub _diag($message, :$force-stderr, :$force-informative) {
+    _init_io() unless $output;
+    my $is_todo = !$force-stderr && !$force-informative
+        && ($subtest_todo_reason || $num_of_tests_run <= $todo_upto_test_num);
+    my $out     = $is_todo || $force-informative ?? $todo_output !! $failure_output;
+
+    $time_after = nqp::time;
+    my $str-message = nqp::join(
+        "\n$indents# ", nqp::split("\n", "$indents# $message")
+    );
+    $out.say: $str-message;
+    $time_before = nqp::time;
+}
+
+# In earlier Perls, this is spelled "sub fail"
+multi sub flunk($reason = '') is export {
+    $time_after = nqp::time;
+    my $ok = proclaim(0, $reason);
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub isa-ok(
+    Mu $var, Mu $type, $desc = "The object is-a '$type.raku()'"
+) is export {
+    $time_after = nqp::time;
+    my $ok = ($type ~~ Str:D
+                ?? proclaim($var.isa($type), $desc)
+                !! proclaim(nqp::istype($var, $type.WHAT), $desc))
+        or _diag('Actual type: ' ~ $var.^name);
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub does-ok(
+    Mu $var, Mu $type, $desc = "The object does role '$type.raku()'"
+) is export {
+    $time_after = nqp::time;
+    my $ok = proclaim($var.does($type), $desc)
+        or _diag([~] 'Type: ',  $var.^name, " doesn't do role ", $type.raku);
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub can-ok(
+    Mu $var, Str $meth,
+    $desc = ($var.defined ?? "An object of type '" !! "The type '")
+        ~ "$var.WHAT.raku()' can do the method '$meth'"
+) is export {
+    $time_after = nqp::time;
+    my $ok = proclaim($var.^can($meth), $desc);
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub like(
+    Str() $got, Regex:D $expected,
+    $desc = "text matches $expected.raku()"
+) is export {
+    $time_after = nqp::time;
+    my $ok := proclaim $got ~~ $expected, $desc
+        or _diag "expected a match with: $expected.raku()\n"
+               ~ "                  got: $got.raku()";
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub unlike(
+    Str() $got, Regex:D $expected,
+    $desc = "text does not match $expected.raku()"
+) is export {
+    $time_after = nqp::time;
+    my $ok := proclaim !($got ~~ $expected), $desc
+        or _diag "expected no match with: $expected.raku()\n"
+               ~ "                   got: $got.raku()";
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub use-ok(Str $code, $desc = "$code module can be use-d ok") is export {
+    $time_after = nqp::time;
+    try {
+        EVAL ( "use $code" );
+    }
+    my $ok = proclaim((not defined $!), $desc) or _diag($!);
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub dies-ok(Callable $code, $reason = '') is export {
+    $time_after = nqp::time;
+    my $death = 1;
+    try {
+        $code();
+        $death = 0;
+    }
+    my $ok = proclaim( $death, $reason );
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub exit-ok(|c) is export is DEPRECATED("exits-ok") {
+    exits-ok(|c)
+}
+multi sub exits-ok(
+        &code,
+  Int:D $exit = 0,
+  Str:D $desc = "Checking for exit($exit)"
+) is export {
+    my $got;
+    my $seen = False;
+    my &*EXIT = { $seen = True; $got = $_ }
+    $time_after = nqp::time;
+    code();
+    my $ok = proclaim($seen && $got == $exit, $desc);
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub lives-ok(Callable $code, $reason = '') is export {
+    $time_after = nqp::time;
+    try {
+        $code();
+    }
+    my $ok = proclaim((not defined $!), $reason) or _diag($!);
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub eval-dies-ok(Str $code, $reason = '') is export {
+    $time_after = nqp::time;
+    my $ee = eval_exception($code);
+    my $ok = proclaim( $ee.defined, $reason );
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+multi sub eval-lives-ok(Str $code, $reason = '') is export {
+    $time_after = nqp::time;
+    my $ee = eval_exception($code);
+    my $ok = proclaim((not defined $ee), $reason)
+        or _diag("Error: $ee");
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+######################################################################
+# The fact that is-deeply converts Seq args to Lists is actually a bug
+# that ended up being too-much-pain-for-little-gain to fix. Using Seqs
+# breaks ~65 tests in 6.c-errata and likely breaks a lot of module
+# tests as well. So... for the foreseeable future we decided to leave it
+# as is. If a user really wants to ensure Seq comparison, there's always
+# `cmp-ok` with `eqv` op.
+# https://irclogs.raku.org/perl6-dev/2017-05-04.html#15:38-0001
+######################################################################
+multi sub is-deeply(Seq:D $got, Seq:D $expected, $reason = '') is export {
+    is-deeply $got.cache, $expected.cache, $reason;
+}
+multi sub is-deeply(Seq:D $got, Mu $expected, $reason = '') is export {
+    is-deeply $got.cache, $expected, $reason;
+}
+multi sub is-deeply(Mu $got, Seq:D $expected, $reason = '') is export {
+    is-deeply $got, $expected.cache, $reason;
+}
+multi sub is-deeply(Mu $got, Mu $expected, $reason = '') is export {
+    $time_after = nqp::time;
+    my $test = _is_deeply( $got, $expected );
+    my $ok = proclaim($test, $reason);
+    if !$test {
+        my $got_perl      = try { $got.raku };
+        my $expected_perl = try { $expected.raku };
+        if $got_perl.defined && $expected_perl.defined {
+            _diag "expected: $expected_perl\n"
+                ~ "     got: $got_perl";
+        }
+    }
+    $time_before = nqp::time;
+    $ok or ($die_on_fail and die-on-fail) or $ok;
+}
+
+sub throws-like($code, $ex_type, $reason?, *%matcher) is export {
+    for %matcher.kv -> $k, $v {
+        if $v.DEFINITE && $v ~~ Bool {
+            X::Match::Bool.new(:type(".$k")).throw;
+        }
+    }
+    my $caller-context = $*THROWS-LIKE-CONTEXT // CALLER::; # Don't guess our caller context, know it!
+    subtest {
+        plan 2 + %matcher.keys.elems;
+        my $msg;
+        if $code ~~ Callable {
+            $msg = 'code dies';
+            $code()
+        } else {
+            $msg = "'$code' died";
+            EVAL $code, context => $caller-context;
+        }
+        flunk $msg;
+        skip 'Code did not die, can not check exception', 1 + %matcher.elems;
+        CATCH {
+            default {
+                pass $msg;
+                my $ex := $_;
+                my $type_ok = $ex ~~ $ex_type;
+                if !$type_ok && $ex_type ~~ X::Comp && $ex ~~ X::Comp::Group {
+                    # Compile time exceptions may be found in a group if the compiler reports
+                    # more than one problem.
+                    with ($_.panic, |$_.sorrows).first($ex_type) -> $nested-ex {
+                        $ex := $nested-ex;
+                        $type_ok = True;
+                    }
+                }
+                ok $type_ok , "right exception type ($ex_type.^name())";
+                if $type_ok {
+                    for %matcher.kv -> $k, $v {
+                        my $got is default(Nil) = $ex."$k"();
+                        my $ok = $got ~~ $v;
+                        ok $ok, ".$k matches $v.gist()";
+                        unless $ok {
+                            _diag "Expected: " ~ ($v ~~ Str ?? $v !! $v.raku)
+                              ~ "\nGot:      $got";
+                        }
+                    }
+                } else {
+                    _diag "Expected: $ex_type.^name()\n"
+                        ~ "Got:      $ex.^name()\n"
+                        ~ "Exception message: $ex.message()";
+                    skip 'wrong exception type', %matcher.elems;
+                }
+            }
+        }
+    }, $reason // "did we throws-like $ex_type.^name()?";
+}
+
+sub fails-like (
+    \test where Callable:D|Str:D, $ex-type, $reason?, *%matcher
+) is export {
+    for %matcher.kv -> $k, $v {
+        if $v.DEFINITE && $v ~~ Bool {
+            X::Match::Bool.new(:type(".$k")).throw;
+        }
+    }
+    my $*THROWS-LIKE-CONTEXT = CALLER::;
+    subtest sub {
+        plan 2;
+        CATCH { default {
+            with "expected code to fail but it threw {.^name} instead" {
+                .&flunk;
+                .&skip;
+                return False;
+            }
+        }}
+        my $res = test ~~ Callable ?? test.() !! test.EVAL;
+        isa-ok $res, Failure, 'code returned a Failure';
+        throws-like { $res.sink }, $ex-type,
+            'Failure threw when sunk', |%matcher,
+    }, $reason // "did we fails-like $ex-type.^name()?"
+}
+
+sub _is_deeply(Mu $got, Mu $expected) {
+    $got eqv $expected;
+}
+
+
+## 'private' subs
+
+sub die-on-fail {
+    if !$todo_reason && !$subtest_level && nqp::iseq_i($die_on_fail,1) {
+        _diag 'Test failed. Stopping test suite, because the '
+          ~ (%*ENV<RAKU_TEST_DIE_ON_FAIL> ?? 'RAKU' !! 'PERL6')
+          ~ "_TEST_DIE_ON_FAIL\n"
+          ~ 'environmental variable is set to a true value.';
+        exit 255;
+    }
+
+    $todo_reason = '' if $todo_upto_test_num == $num_of_tests_run;
+
+    False;
+}
+
+sub eval_exception($code) {
+    try {
+        EVAL ($code);
+    }
+    $!;
+}
+
+# Stringifies values passed to &cmp-ok.
+sub stringify(Mu $obj is raw --> Str:D) {
+    (try $obj.raku if nqp::can($obj, 'raku'))
+        // ($obj.gist if nqp::can($obj, 'gist'))
+        // ($obj.HOW.name($obj) if nqp::can($obj.HOW, 'name'))
+        // '?'
+}
+
+# Take $cond as Mu so we don't thread with Junctions:
+sub proclaim(
+  Bool(Mu) $cond,
+  $desc is copy,
+  $unescaped-prefix = ''
+) is hidden-from-backtrace {
+    _init_io() unless $output;
+    # exclude the time spent in proclaim from the test time
+    $num_of_tests_run = $num_of_tests_run + 1;
+
+    my $tap = $indents;
+    unless $cond {
+        $tap ~= "not ";
+
+        $num_of_tests_failed = $num_of_tests_failed + 1
+            unless $num_of_tests_run <= $todo_upto_test_num;
+
+        $pseudo_fails = $pseudo_fails + 1 if $subtest_todo_reason;
+    }
+
+    # TAP parsers do not like '#' in the description, they'd miss the '# TODO'
+    # So, adding a ' \' before it.
+    $desc = $desc
+    ??  nqp::join("\n$indents# ", # prefix newlines with `#`
+            nqp::split("\n",
+                nqp::join(' \\#', # escape `#`
+                    nqp::split('#', $desc.Str))))
+    !! '';
+
+    $tap ~= $todo_reason && $num_of_tests_run <= $todo_upto_test_num
+        ?? "ok $num_of_tests_run - $unescaped-prefix$desc$todo_reason"
+        !! (! $cond && $subtest_todo_reason)
+            ?? "ok $num_of_tests_run - $unescaped-prefix$desc$subtest_todo_reason"
+            !! "ok $num_of_tests_run - $unescaped-prefix$desc";
+
+    $tap ~= ("\n$indents# t=" ~ ceiling(($time_after - $time_before)*1_000_000))
+        if nqp::iseq_i($raku_test_times,1);
+
+    $output.say: $tap;
+
+    unless $cond {
+        my $caller;
+        # sub proclaim is not called directly, so 2 is minimum level
+        my int $level = 1;
+
+        # Walk past frames inside this file. Compare in both directions
+        # because `$?FILE` and `$caller.file` end up in opposite
+        # absolute/relative shapes depending on which frontend built
+        # rakudo and which Repository loaded Test.rakumod:
+        #   RakuAST-built:           $?FILE relative (cwd-stripped, see
+        #                            relative-source-filename in
+        #                            src/Raku/ast/compunit.rakumod);
+        #                            $caller.file absolute.
+        #   legacy-built / install:  $?FILE absolute; $caller.file is
+        #                            the Installation-repo form
+        #                            `core#sources/<sha1> (Test)`,
+        #                            i.e. shorter than $?FILE.
+        # In both cases one string is a suffix of the other, so a
+        # bidirectional ends-with is what we want. The original
+        # `$?FILE.ends-with($caller.file)` alone was right for the
+        # legacy/install path but bailed at the first Test.rakumod
+        # frame under RakuAST, attributing every failure to
+        # Test.rakumod itself.
+        repeat {
+            $caller = callframe(++$level);
+        } while $?FILE.ends-with($caller.file)
+             || $caller.file.ends-with($?FILE);
+
+        # initial level for reporting
+        my $tester = $caller;
+
+        repeat {
+            ($caller = callframe($level++)) or last;
+            my \code := $caller.code;
+            $tester = callframe($level)  # the next one should be reported
+                if nqp::can(code,'is-test-assertion');  # must use nqp
+        } until !$caller.file || $caller.file.ends-with('.nqp');
+
+        # the final place we want to report from
+        _diag $desc
+          ?? "Failed test '$desc'\nat $tester.file() line $tester.line()"
+          !! "Failed test at $tester.file() line $tester.line()";
+    }
+
+    # must clear this between tests
+    $todo_reason = ''
+        if $todo_upto_test_num == $num_of_tests_run
+            and nqp::iseq_i($die_on_fail,0);
+
+    $cond
+}
+
+sub done-testing(-->Bool:D) is export {
+    my $return = True;
+    _init_io() unless $output;
+    $done_testing_has_been_run = 1;
+
+    if nqp::iseq_i($no_plan,1) {
+        $num_of_tests_planned = $num_of_tests_run;
+        $output.say: $indents ~ "1..$num_of_tests_planned";
+    }
+
+    if ($num_of_tests_planned or $num_of_tests_run)
+        && ($num_of_tests_planned != $num_of_tests_run) {
+        _diag("You planned $num_of_tests_planned test"
+            ~ ($num_of_tests_planned == 1 ?? '' !! 's')
+            ~ ", but ran $num_of_tests_run");
+        $return = False;
+    }
+    if $num_of_tests_failed && ! $subtest_todo_reason {
+        _diag("You failed $num_of_tests_failed test"
+            ~ ($num_of_tests_failed == 1 ?? '' !! 's')
+            ~ " of $num_of_tests_run");
+        $return = False;
+    }
+    $return;
+}
+
+sub _init_vars {
+    $subtest_callable_type = Mu;
+    $num_of_tests_run     = 0;
+    $num_of_tests_failed  = 0;
+    $todo_upto_test_num   = 0;
+    $todo_reason          = '';
+    $num_of_tests_planned = Any;
+    $no_plan              = 1;
+    $time_before          = 0;
+    $time_after           = 0;
+    $done_testing_has_been_run = 0;
+    $pseudo_fails         = 0;
+    $subtest_todo_reason  = '';
+}
+
+sub _push_vars {
+    @vars.push: item [
+      $subtest_callable_type,
+      $num_of_tests_run,
+      $num_of_tests_failed,
+      $todo_upto_test_num,
+      $todo_reason,
+      $num_of_tests_planned,
+      $no_plan,
+      $time_before,
+      $time_after,
+      $done_testing_has_been_run,
+      $pseudo_fails,
+      $subtest_todo_reason,
+    ];
+}
+
+sub _pop_vars {
+    (
+      $subtest_callable_type,
+      $num_of_tests_run,
+      $num_of_tests_failed,
+      $todo_upto_test_num,
+      $todo_reason,
+      $num_of_tests_planned,
+      $no_plan,
+      $time_before,
+      $time_after,
+      $done_testing_has_been_run,
+      $pseudo_fails,
+      $subtest_todo_reason,
+    ) = @(@vars.pop);
+}
+
+END {
+    ## In planned mode, people don't necessarily expect to have to call done-testing
+    ## So call it for them if they didn't
+    done-testing
+      if nqp::iseq_i($done_testing_has_been_run,0)
+      && nqp::iseq_i($no_plan,0);
+
+    .?close unless $_ === $*OUT || $_ === $*ERR
+      for $output, $failure_output, $todo_output;
+
+    exit($num_of_tests_failed min 254) if $num_of_tests_failed > 0;
+
+    exit(255)
+      if nqp::iseq_i($no_plan,0)
+      && ($num_of_tests_planned or $num_of_tests_run)
+      &&  $num_of_tests_planned != $num_of_tests_run;
+}
+
+=begin pod
+
+=head1 NAME
+
+Test - Rakudo Testing Library
+
+=head1 SYNOPSIS
+
+  use Test;
+
+=head1 DESCRIPTION
+
+Please check the section Language/testing of the doc repository.
+If you have 'p6doc' installed, you can do 'p6doc Language/testing'.
+
+You can also check the documentation about testing in Raku online on L<https://docs.raku.org/language/testing>.
+
+=end pod
+
+# vim: expandtab shiftwidth=4

--- a/news/2026-08/test-module-vendored-behind-a-switch.md
+++ b/news/2026-08/test-module-vendored-behind-a-switch.md
@@ -1,0 +1,79 @@
+# Rakudo's real `Test.rakumod` is vendored, behind `MUTSU_REAL_TEST=1`
+
+The upstream `Test` module now ships in the repository at
+`modules/Rakudo-Core/lib/Test.rakumod`, vendored verbatim from the
+`rakudo-2026.06` release tarball (md5 `f34dec45d52ad099c37f42fdbd93e277`,
+recorded in that directory's README alongside `Pod::To::Text`). `use Test` still
+resolves to mutsu's native TAP provider by default; **`MUTSU_REAL_TEST=1`** loads
+the vendored file instead.
+
+This is step 2 of `todo/tickets/vendor-real-test-module.md`, and the switch is
+what step 2 asks for: exercise the real module *without* removing the
+interception. Every `t/` file and every roast file stands on `Test`, so swapping
+the implementation swaps the foundation of the whole suite; step 3 flips it once
+the residue is gone.
+
+## What the switch replaces
+
+The exercise previously ran under a throwaway copy in gitignored `tmp/`, with
+`unit module Test;` rewritten to `unit module Test2;` to dodge the interception —
+a measurement that died with the container and that nobody else could reproduce.
+The vendored file is byte-identical to that copy apart from the rename, so the
+whole alias sweep was genuinely testing the verbatim upstream file; it is now in
+the repository, and `scripts/test-module-sweep.sh` drives it with the env var.
+
+## Placing the file is not automatically inert
+
+The parse-time module scan (`find_module_file`) is filename-based and searches
+the bundled-battery paths, so it can see a vendored `Test.rakumod` even while the
+runtime interception is untouched. Measured before relying on it: 300 sampled
+`t/` files produced byte-identical output with and without the file present.
+
+## The general bug the switch exposed
+
+Three files passed under the old alias and failed under the switch. There are
+two dispatch paths into the native TAP provider, and only `exec_call` had the
+"an imported declaration wins over the native provider" guard added in
+`news/2026-08/imported-test-routines-beat-the-native-provider.md`;
+`call_function_fallback` did not. A source that merely *mentions* `NativeCall` —
+in a comment is enough — gets NativeCall's prelude injected, and that is enough
+to send a listop call down the other path. There the native `plan` answered,
+recording a plan nobody ran against, so `finish()` reported
+
+```
+# You planned 14 test, but ran 0
+```
+
+on a file whose fourteen assertions had all passed and all printed. The two
+implementations kept separate counters, exactly the failure shape the first fix
+was written for. Both paths now decide on whether a *declaration* exists, not on
+whether the name is a builtin.
+
+Under the alias the bug was invisible: `use Test2` never puts `Test` in
+`loaded_modules`, so the native gate was shut and the mis-dispatch fell through
+to the module anyway. Running the real module under its real name is what made
+it observable.
+
+Both guards now go through one helper, `user_test_decl_beats_native`, which also
+carries the single exception the rule needs: `skip` is both a Test directive and
+a Raku list routine, so a user `multi skip($n, +values)` accepts
+`skip 'reason', 2` on signature alone. It keeps the shape-based disambiguation
+(`skip_call_is_list_skip`) the three `skip` dispatch sites already apply —
+without it, `t/skip-user-multi-shadows-test.t`'s `subtest` lost its TAP SKIP
+directive to the user's list routine.
+
+## Where the campaign stands
+
+The full sweep after this and `news/2026-08/eval-context-argument.md`:
+
+| | at the start of 2026-08-01 | now |
+| --- | --- | --- |
+| pass under both | 2617 | **2693 / 2732** |
+| regress under the real module | 86 | **26** |
+| passes only under the real module | 1 | 1 |
+| fail under both (pre-existing) | 13 | 12 |
+
+The 26 split 6 that `raku` also fails (test files to correct) and 20 real mutsu
+gaps. Exit status was checked for the first time and is already faithful: a
+failing assertion exits 1 and a short plan exits 255, which is what `prove`
+reads.

--- a/scripts/test-module-sweep.sh
+++ b/scripts/test-module-sweep.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Run every t/*.t twice -- once with mutsu's native TAP provider and once with
+# the vendored upstream Test.rakumod (MUTSU_REAL_TEST=1) -- and report which
+# files regress under the real module.
+#
+# This is the measurement that drives step 2 of
+# `todo/tickets/vendor-real-test-module.md`. It replaces the throwaway
+# `unit module Test2;` rename the exercise ran under before: the file under
+# test is now the unmodified upstream one vendored at
+# `modules/Rakudo-Core/lib/Test.rakumod`.
+#
+# The two runs are deliberately NOT compared byte-for-byte. The real module is
+# routinely *more* faithful than the native provider (richer `throws-like`
+# subtests, `'<code>' died` descriptions instead of `code dies`), so the
+# question is whether a file that passed still passes.
+#
+# Usage: scripts/test-module-sweep.sh [jobs]     (default 4)
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 1
+JOBS="${1:-4}"
+MUTSU="${MUTSU_BIN:-$ROOT/target/debug/mutsu}"
+WORK="$ROOT/tmp/test-module-sweep"
+
+rm -rf "$WORK"
+mkdir -p "$WORK/t"
+# The test files reach for their fixtures as 't/lib/...', relative to cwd, so
+# the copies live under a directory that keeps the same shape.
+ln -sfn "$ROOT/t/lib" "$WORK/t/lib"
+
+run_one() {
+    local f="$1" name
+    name="$(basename "$f")"
+    cp "$f" "$WORK/t/$name"
+    ( cd "$WORK" && MUTSU_REAL_TEST= timeout 90 "$MUTSU" -I "$ROOT/t/lib" "t/$name" \
+        > "$WORK/$name.native" 2>&1 )
+    ( cd "$WORK" && MUTSU_REAL_TEST=1 timeout 90 "$MUTSU" -I "$ROOT/t/lib" "t/$name" \
+        > "$WORK/$name.real" 2>&1 )
+}
+export -f run_one
+export ROOT WORK MUTSU
+
+ls t/*.t | xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {}
+
+passes() { ! grep -qE '^(not ok|Runtime error|Parse error|===SORRY)' "$1"; }
+
+both=0 regressed=0 real_only=0 neither=0
+: > "$WORK/regressions.txt"
+for n in "$WORK"/*.native; do
+    name="$(basename "$n" .native)"
+    r="$WORK/$name.real"
+    if passes "$n" && passes "$r"; then both=$((both + 1))
+    elif passes "$n"; then
+        regressed=$((regressed + 1))
+        {
+            echo "=== $name"
+            grep -m4 -E '^(not ok|Runtime error|Parse error|===SORRY|# Failed)' "$r"
+        } >> "$WORK/regressions.txt"
+    elif passes "$r"; then real_only=$((real_only + 1))
+    else neither=$((neither + 1))
+    fi
+done
+
+echo "pass under both:                   $both"
+echo "regressed under the real Test:     $regressed"
+echo "passes only under the real Test:   $real_only"
+echo "fail under both (pre-existing):    $neither"
+echo "regression detail: $WORK/regressions.txt"

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -227,8 +227,21 @@ impl Interpreter {
                 )));
             }
         }
-        if (self.loaded_modules.contains("Test")
-            || self.loaded_modules.iter().any(|m| m.starts_with("Test::")))
+        // Same rule as the `exec_call` guard (`calls.rs`): a module that exports
+        // its own `ok`/`is`/`plan`/... beats mutsu's native TAP provider, and the
+        // decision is made on whether a *declaration* exists, not on whether the
+        // name is a builtin. This is the second dispatch path into the native
+        // provider, and it was missing the guard — so a call that reached the
+        // fallback here (a listop whose name did not resolve to a compiled
+        // function at the call site) was answered natively even though the real
+        // `Test.rakumod` had exported one. The two implementations then kept
+        // separate counters: under `MUTSU_REAL_TEST=1` the native `plan` recorded
+        // a plan nobody ran against, and `finish()` reported "You planned 14
+        // test, but ran 0" on a file whose assertions had all passed.
+        let user_declared = self.user_test_decl_beats_native(name, args);
+        if !user_declared
+            && (self.loaded_modules.contains("Test")
+                || self.loaded_modules.iter().any(|m| m.starts_with("Test::")))
             && let Some(result) = self.call_test_function(name, args)?
         {
             return Ok(result);

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -321,8 +321,7 @@ impl Interpreter {
         // is a separate provider retirement that needs `Proc::Async` output taps
         // and `IO::Path ~~ IO::Path` fixed first — see
         // todo/tickets/retire-native-test-util-overrides.md.
-        let user_declared = crate::runtime::is_test_module_export(name)
-            && self.user_function_matches_call(name, &args);
+        let user_declared = self.user_test_decl_beats_native(name, &args);
         if !user_declared && let Some(result) = self.call_test_function(name, &args)? {
             return Ok(result);
         }

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -900,6 +900,27 @@ impl Interpreter {
     /// Check if a user-defined function with the given name can accept the
     /// given args (arity + type check). Used to decide whether a user-defined
     /// sub should shadow a same-named builtin.
+    /// Whether a declaration of `name` should beat mutsu's native TAP provider
+    /// for this call. Shared by the two dispatch paths into that provider
+    /// (`exec_call` and `call_function_fallback`) so they agree.
+    ///
+    /// The rule is the one from the qualified-call guard: decide on whether a
+    /// *declaration* exists, not on whether the name is a builtin. `skip` is the
+    /// single exception, because it is both a Test directive and a Raku list
+    /// routine — a user `multi skip($n, +values)` accepts `skip 'reason', 2` on
+    /// signature alone, so the name needs the same shape-based disambiguation
+    /// the three `skip` dispatch sites already apply
+    /// (`t/skip-user-multi-shadows-test.t`).
+    pub(crate) fn user_test_decl_beats_native(&mut self, name: &str, args: &[Value]) -> bool {
+        if !crate::runtime::is_test_module_export(name) {
+            return false;
+        }
+        if name == "skip" && !Self::skip_call_is_list_skip(args) {
+            return false;
+        }
+        self.user_function_matches_call(name, args)
+    }
+
     pub(crate) fn user_function_matches_call(&mut self, name: &str, args: &[Value]) -> bool {
         if !self.has_function(name) && !self.has_multi_function(name) {
             return false;

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -1,6 +1,24 @@
 use super::*;
 
 impl Interpreter {
+    /// Whether `use Test` should load the vendored upstream `Test.rakumod`
+    /// (`modules/Rakudo-Core/lib/Test.rakumod`) instead of being recognized as a
+    /// no-op that leaves mutsu's native TAP provider in charge.
+    ///
+    /// Step 2 of `todo/tickets/vendor-real-test-module.md` calls for exercising
+    /// the real module *without* removing the interception, because every `t/`
+    /// file and every roast file stands on `Test`: swapping the implementation
+    /// swaps the foundation of the whole suite, and a subtle difference in
+    /// `is`/`is-deeply`/`todo`/`subtest` shows up as thousands of diffs at once.
+    /// Until step 3 flips it for good, `MUTSU_REAL_TEST=1` is how the real module
+    /// is driven — the sweep tooling uses it, and it replaces the throwaway
+    /// `unit module Test2;` rename the exercise ran under before.
+    pub(crate) fn real_test_module_enabled() -> bool {
+        std::env::var("MUTSU_REAL_TEST")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    }
+
     /// Save current function/class keys for lexical import scoping.
     pub(crate) fn push_import_scope(&mut self) {
         let func_keys: HashSet<Symbol> = self.registry().functions.keys().copied().collect();
@@ -203,7 +221,7 @@ impl Interpreter {
         if module == "NativeCall" {
             self.register_nativecall_exports();
         }
-        let result = if module == "Test"
+        let result = if (module == "Test" && !Self::real_test_module_enabled())
             || matches!(
                 module,
                 "strict"

--- a/t/vendored-real-test-module.t
+++ b/t/vendored-real-test-module.t
@@ -1,0 +1,61 @@
+use v6;
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+plan 9;
+
+# `MUTSU_REAL_TEST=1` makes `use Test` load the vendored upstream
+# `Test.rakumod` (modules/Rakudo-Core/lib/) instead of being recognized as a
+# no-op that leaves mutsu's native TAP provider in charge. Step 2 of
+# `todo/tickets/vendor-real-test-module.md`: exercise the real module without
+# yet swapping the foundation the whole suite stands on.
+
+my $vendored = $*PROGRAM.parent(2).add("modules/Rakudo-Core/lib/Test.rakumod");
+ok $vendored.e, 'the upstream Test.rakumod is vendored in the repository';
+like $vendored.slurp, /'unit module Test;'/,
+    'the vendored file is the upstream module, unrenamed';
+
+# A decisive probe for *which* implementation answered: the module exports its
+# own `MONKEY-SEE-NO-EVAL`, which the native provider has no equivalent of. The
+# child inherits `%*ENV`, so each half sets the switch it wants.
+my $probe = 'use Test; plan 1; is MONKEY-SEE-NO-EVAL(), 1, "module export";';
+my $plain = 'use Test; plan 2; ok 1, "a"; is 1+1, 2, "b";';
+
+# --- switch off: the native provider answers ---
+%*ENV<MUTSU_REAL_TEST>:delete;
+
+is_run $plain, { status => 0, out => "1..2\nok 1 - a\nok 2 - b\n", err => '' },
+    'the native provider emits plain TAP';
+# rakudo has no native provider to fall back to -- its `Test` *is* this module --
+# so only mutsu can assert the negative half of the probe.
+if $*RAKU.compiler.name eq 'mutsu' {
+    is_run $probe, { status => 255 },
+        'the native provider has no MONKEY-SEE-NO-EVAL export';
+} else {
+    skip 'no native Test provider to distinguish from', 1;
+}
+
+# --- switch on: the vendored upstream module answers ---
+%*ENV<MUTSU_REAL_TEST> = '1';
+
+is_run $plain, { status => 0, out => "1..2\nok 1 - a\nok 2 - b\n", err => '' },
+    'the vendored module emits the same plain TAP';
+is_run $probe, { status => 0, out => /'ok 1 - module export'/ },
+    'the vendored module supplies its own exports';
+
+# `prove` reads the exit status, so the vendored module's own END must set it.
+is_run 'use Test; plan 2; ok 1, "a"; ok 0, "b";', { status => 1 },
+    'a failing assertion exits 1 under the vendored module';
+is_run 'use Test; plan 3; ok 1, "a";', { status => 255 },
+    'a short plan exits 255 under the vendored module';
+
+# There are two dispatch paths into the native TAP provider, and only one of
+# them had the "an imported declaration wins" guard. A source that merely
+# *mentions* NativeCall gets its prelude injected, which is enough to send a
+# listop call down the other path -- where the native `plan` recorded a plan
+# nobody ran against, so `finish()` reported "You planned 2 test, but ran 0"
+# on a file whose assertions had all passed.
+is_run "# NativeCall\nuse Test; plan 2; ok 1, 'a'; ok 1, 'b';",
+    { status => 0, out => "1..2\nok 1 - a\nok 2 - b\n", err => '' },
+    'the module answers on the fallback dispatch path too';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -73,9 +73,12 @@ of diffs at once. Sequence it deliberately:
    ops in, `plan`/`ok`/`is`/`isnt`/`is-deeply`/`subtest` from the unmodified
    upstream file all produce correct TAP.
 2. Vendor `Test.rakumod` verbatim to `modules/Rakudo-Core/lib/Test.rakumod` but
-   **do not** remove the interception yet; exercise it under a temporary alias
-   against a representative sample of `t/` and roast. **IN PROGRESS** — the
-   alias exercise has been run both by hand (see "Where the alias stands" below)
+   **do not** remove the interception yet; exercise it against a representative
+   sample of `t/` and roast. **IN PROGRESS** — the file is now vendored (md5
+   `f34dec45d52ad099c37f42fdbd93e277`, `news/2026-08/test-module-vendored-behind-a-switch.md`)
+   and driven by **`MUTSU_REAL_TEST=1`**, which replaced the throwaway
+   `unit module Test2;` rename; the sweep is `scripts/test-module-sweep.sh`.
+   The exercise has been run both by hand (see "Where the alias stands" below)
    and as a bulk sweep over a 1-in-9 sample of `t/` (see "Bulk sweep" below).
    Seven general interpreter bugs found and fixed; **every assertion of the
    unmodified upstream module now runs**, `cmp-ok` included
@@ -282,7 +285,45 @@ Open systemic causes, in the order worth taking them:
    `X::Undeclared::Symbols ~~ X::Undeclared` and friends. Blocks
    `block-lexical-scope.t`.
 
-Re-run `tmp/sweep-full.sh` to re-measure after each.
+Re-run `scripts/test-module-sweep.sh` to re-measure after each.
+
+### Re-measured under the real switch, not the alias (2026-08-02)
+
+With `news/2026-08/eval-context-argument.md` and the vendoring in
+(`news/2026-08/test-module-vendored-behind-a-switch.md`):
+
+| | at the start of 2026-08-01 | now |
+| --- | --- | --- |
+| pass under both | 2617 | **2693 / 2732** |
+| regress under the real module | 86 | **26** |
+| passes only under the real module | 1 | 1 |
+| fail under both (pre-existing) | 13 | 12 |
+
+The 26 split **6 that `raku` also fails** — `listop-arg-loose-logical-precedence.t`,
+`use-version-short-adverb.t`, `begin-phaser-begintime.t`,
+`method-private-errors.t`, `vm-panic-boundary.t`,
+`placeholder-named-in-method-do.t`, all in
+`todo/tickets/local-tests-rely-on-a-lenient-native-is.md`'s individual-triage
+list — and **20 real mutsu gaps**:
+
+```
+bigrat-sort-compare.t      block-lexical-scope.t     emit-done-controlflow.t
+error-reporting-quality.t  group-of.t                io-cathandle-lazy.t
+is-lazy-io-lines.t         leave-in-if-branch.t      multi-where-otf-dispatch.t
+proxy-list-transparency.t  subscript-adverbs.t       throws-like-gather-sink.t
+undeclared-when-type.t     whatever-code-fixes.t     handles-proto-dispatch-mut-invocant.t
+gate-b-callee-name-collision-and-deref-capture.t     module-file-var-and-callframe.t
+qualified-call-does-not-alias-builtin.t              test-assertion-line-number.t
+throws-like-outer-var-writeback.t
+```
+
+Several of the last group are mutsu's *own* pins, written against the native
+provider's wording or its `throws-like` shape; those are files to re-point at
+the real module rather than interpreter gaps. Triage each before assuming a bug.
+
+Exit status was measured for the first time and is already faithful — a failing
+assertion exits 1, a short plan exits 255 — which is what `prove` reads, so
+step 3 does not need work there.
 
 ## Blocker found while doing step 1: the native provider shadows an import — FIXED
 


### PR DESCRIPTION
The upstream `Test` module now ships in the repository at `modules/Rakudo-Core/lib/Test.rakumod`, vendored verbatim from the `rakudo-2026.06` release tarball (md5 `f34dec45d52ad099c37f42fdbd93e277`, recorded in that directory's README alongside `Pod::To::Text`). `use Test` still resolves to mutsu's native TAP provider by default; **`MUTSU_REAL_TEST=1`** loads the vendored file instead.

This is step 2 of `todo/tickets/vendor-real-test-module.md`, and the switch is what step 2 asks for: exercise the real module *without* removing the interception. Every `t/` file and every roast file stands on `Test`, so swapping the implementation swaps the foundation of the whole suite; step 3 flips it once the residue is gone.

## What the switch replaces

The exercise previously ran under a throwaway copy in gitignored `tmp/`, with `unit module Test;` rewritten to `unit module Test2;` to dodge the interception — a measurement that died with the container and that nobody else could reproduce. The vendored file is byte-identical to that copy apart from the rename, so the whole alias sweep was genuinely testing the verbatim upstream file; it is now in the repository, and `scripts/test-module-sweep.sh` drives it with the env var.

## Placing the file is not automatically inert

The parse-time module scan (`find_module_file`) is filename-based and searches the bundled-battery paths, so it can see a vendored `Test.rakumod` even while the runtime interception is untouched. Measured before relying on it: **300 sampled `t/` files produce byte-identical output** with and without the file present.

## The general bug the switch exposed

Three files passed under the old alias and failed under the switch. There are two dispatch paths into the native TAP provider, and only `exec_call` had the "an imported declaration wins over the native provider" guard added in `news/2026-08/imported-test-routines-beat-the-native-provider.md`; `call_function_fallback` did not. A source that merely *mentions* `NativeCall` — in a comment is enough — gets NativeCall's prelude injected, and that is enough to send a listop call down the other path. There the native `plan` answered, recording a plan nobody ran against, so `finish()` reported

```
# You planned 14 test, but ran 0
```

on a file whose fourteen assertions had all passed and all printed. The two implementations kept separate counters, exactly the failure shape the first fix was written for.

Under the alias the bug was invisible: `use Test2` never puts `Test` in `loaded_modules`, so the native gate was shut and the mis-dispatch fell through to the module anyway. Running the real module under its real name is what made it observable.

Both guards now go through one helper, `user_test_decl_beats_native`, which also carries the single exception the rule needs: `skip` is both a Test directive and a Raku list routine, so a user `multi skip($n, +values)` accepts `skip 'reason', 2` on signature alone. It keeps the shape-based disambiguation (`skip_call_is_list_skip`) the three `skip` dispatch sites already apply — without it, `t/skip-user-multi-shadows-test.t`'s `subtest` lost its TAP SKIP directive to the user's list routine (caught by `make test`, fixed here).

## Where the campaign stands

Full sweep, with this and #5690 in:

| | at the start of 2026-08-01 | now |
| --- | --- | --- |
| pass under both | 2617 | **2693 / 2732** |
| regress under the real module | 86 | **26** |
| passes only under the real module | 1 | 1 |
| fail under both (pre-existing) | 13 | 12 |

The 26 split 6 that `raku` also fails (test files to correct) and 20 real mutsu gaps, both enumerated in the ticket. Exit status was measured for the first time and is already faithful — a failing assertion exits 1, a short plan exits 255 — which is what `prove` reads.

## Testing

- New pin `t/vendored-real-test-module.t` (9 assertions), green under `raku` and mutsu alike. It runs each probe with the switch off *and* on, so a change that quietly stops loading the vendored file fails loudly instead of passing on the native provider.
- `make test`: `Files=2733, Tests=26105`, Result: PASS.
- Equivalence check: 274 files (the 26 regressions + 250 sampled) give the same verdict under the switch as under the old alias, apart from two files that now *pass* (`is-lazy-io-lines.t`, `module-file-var-and-callframe.t` — both assert on `$?FILE`/`callframe`, which the alias rename perturbed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)