### PR TITLE
fix(parser): a custom declarator accepts a `my`/`our` scope prefix

### DIFF
--- a/news/2026-08/scoped-custom-declarator.md
+++ b/news/2026-08/scoped-custom-declarator.md
@@ -1,0 +1,32 @@
+# A custom declarator accepts a `my`/`our` scope prefix
+
+A declarator registered through a module's `EXPORTHOW::DECLARE` block — the
+`monitor` keyword `OO::Monitors` installs, for instance — parsed only in its
+bare form. Writing `my monitor Counter { ... }` died at parse time with
+`X::Syntax::Malformed: Malformed my (did you mean to declare a sigilless \var
+or $var?)`.
+
+The two paths had drifted apart. `class::declare_decl` walks the registered
+keyword table (`declare_keyword_names()`) and hands the match to
+`class_decl_body`, tagging the result with the `__mutsu_declare_how` marker
+trait so registration can attach the declarator's HOW. The scope-prefixed path,
+`decl::my_decl_dispatch::try_keyword_dispatch`, was a hardcoded if-chain of
+built-in keywords (`class`, `grammar`, `role`, `module`, `package`, `subset`,
+`constant`, `regex`/`token`/`rule`) that had never heard of the registry. Worse,
+`decl::my_decl` is dispatched *before* `class::declare_decl` in `STMT_PARSERS`
+and fails fatally, so there was no fall-through: an unknown keyword after `my`
+went straight to the sigil check and raised the malformed-declaration error.
+
+`try_keyword_dispatch` now consults `declare_keyword_names()` as its last
+resort, after every built-in keyword, so a module cannot shadow `class` or
+`role` by registering a declarator with one of those names. The match is parsed
+with `class_decl_body(rest, !is_our)` — lexical for `my`, package-scoped for
+`our` — and carries the same `__mutsu_declare_how` trait as the bare form.
+
+This was the load barrier for `Cro::HTTP::Client`, which declares
+`my monitor ConnectionCache { ... }`: the module failed to parse, and with it
+five of the upstream suite's test files (`http-auth-basic`,
+`http-auth-basic-with-session`, `http-middleware`, `http-session-inmemory`,
+`http-session-persistent`). All five now load and reach real Cro runtime code.
+
+Pinned by `t/scoped-custom-declarator.t`, which passes identically under raku.

--- a/src/parser/stmt/decl/my_decl_dispatch.rs
+++ b/src/parser/stmt/decl/my_decl_dispatch.rs
@@ -7,7 +7,7 @@ use super::{
     class_decl_body, method_decl_body, method_decl_body_my, module_decl, package_decl_my,
     parse_statement_modifier, role_decl, sub_decl_body,
 };
-use crate::ast::Stmt;
+use crate::ast::{Expr, Stmt};
 use crate::symbol::Symbol;
 use crate::value::Value;
 
@@ -277,6 +277,25 @@ pub(super) fn try_keyword_dispatch(
             return parse_statement_modifier(rest, stmt).map(Some);
         }
         return Ok(Some((rest, stmt)));
+    }
+
+    // my/our <declarator> Name { ... } for a declarator registered through a
+    // `use`d module's EXPORTHOW::DECLARE block (e.g. OO::Monitors' `monitor`).
+    // Checked after every built-in keyword above, so a module cannot shadow
+    // `class`/`role`/`subset`/.... Mirrors the unscoped `class::declare_decl`.
+    for kw in super::super::simple::declare_keyword_names() {
+        let Some(r) = keyword(&kw, rest) else {
+            continue;
+        };
+        let (r, _) = ws1(r)?;
+        let (r, mut stmt) = class_decl_body(r, !is_our)?;
+        if let Stmt::ClassDecl { custom_traits, .. } = &mut stmt {
+            custom_traits.push((
+                "__mutsu_declare_how".to_string(),
+                Some(Expr::Literal(Value::str(kw))),
+            ));
+        }
+        return Ok(Some((r, stmt)));
     }
 
     Ok(None)

--- a/t/scoped-custom-declarator.t
+++ b/t/scoped-custom-declarator.t
@@ -1,0 +1,32 @@
+use Test;
+use lib 'modules/OO-Monitors/lib';
+use OO::Monitors;
+
+plan 6;
+
+# A declarator registered through EXPORTHOW::DECLARE works with a `my`/`our`
+# scope prefix, not just bare. Cro::HTTP::Client declares `my monitor
+# ConnectionCache { ... }`, which used to be a fatal "Malformed my".
+my monitor Counter {
+    has $.n is rw = 0;
+    method bump() { $!n = $!n + 1; $!n }
+}
+
+my $c = Counter.new;
+is $c.bump, 1, 'my monitor: method call works';
+is $c.bump, 2, 'my monitor: state is kept';
+is Counter.HOW.^name, 'MetamodelX::MonitorHOW', 'my monitor gets the declarator HOW';
+
+our monitor Shared {
+    has $.label;
+}
+is Shared.new(label => 'x').label, 'x', 'our monitor works too';
+is Shared.HOW.^name, 'MetamodelX::MonitorHOW', 'our monitor gets the declarator HOW';
+
+# A `my`-scoped declarator is lexical to its block.
+{
+    my monitor Inner { has $.v }
+    # no-op; just checking it parses and constructs
+    Inner.new(v => 1);
+}
+nok ::("Inner").defined, 'my monitor is lexical to its block';


### PR DESCRIPTION
A declarator registered through a module's `EXPORTHOW::DECLARE` block — the `monitor` keyword `OO::Monitors` installs — parsed only in its bare form. `my monitor Counter { ... }` died at parse time with `X::Syntax::Malformed: Malformed my (did you mean to declare a sigilless \var or $var?)`.

`class::declare_decl` walks the registered keyword table (`declare_keyword_names()`), but the scope-prefixed path `decl::my_decl_dispatch::try_keyword_dispatch` was a hardcoded if-chain of built-in keywords that had never heard of the registry. And since `decl::my_decl` is dispatched *before* `class::declare_decl` in `STMT_PARSERS` and fails fatally, there was no fall-through.

`try_keyword_dispatch` now consults `declare_keyword_names()` as its **last** resort, after every built-in keyword, so a module cannot shadow `class`/`role`/... by registering a declarator with one of those names. The match is parsed with `class_decl_body(rest, !is_our)` — lexical for `my`, package-scoped for `our` — and carries the same `__mutsu_declare_how` marker trait as the bare form.

## Why it matters

This was the load barrier for `Cro::HTTP::Client`, which declares `my monitor ConnectionCache { ... }`. The whole module failed to parse, taking five upstream Cro::HTTP test files with it (`http-auth-basic`, `http-auth-basic-with-session`, `http-middleware`, `http-session-inmemory`, `http-session-persistent`). All five now load and reach real Cro runtime code.

## Testing

- New pin `t/scoped-custom-declarator.t` (6 subtests), which passes identically under raku.
- `make test`: PASS (2734 files, 26105 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)