### PR TITLE
fix(vm): a qualified role does not steal a built-in type name

### DIFF
--- a/news/2026-08/qualified-role-short-name-builtin-guard.md
+++ b/news/2026-08/qualified-role-short-name-builtin-guard.md
@@ -1,0 +1,32 @@
+# A qualified role no longer steals a built-in type's short name
+
+Declaring `role Cro::HTTP::Middleware::Pair { }` anywhere in a process made the
+bare name `Pair` resolve to that role. `("a" => 1) ~~ Pair` became `False`,
+`$p.WHAT =:= Pair` became `False`, and every `when Pair` in every module
+silently fell through to `default`.
+
+A `class`/`role` declared with an already-qualified name registers a short-name
+alias in the env, so that code inside `unit module M` can refer to its own
+`M::R1` as bare `R1`. `exec_register_class_op` has always skipped that alias
+when the short name is a built-in type — the comment there cites
+`my class X::Roast::Channel` not being allowed to capture bare `Channel`.
+`exec_register_role_op` grew the same alias without the guard, so roles could do
+exactly what classes were forbidden from doing.
+
+The role path now shares the guard (`!Self::is_builtin_type(&short)`). The alias
+still installs for a non-built-in short name, which is the case it exists for.
+
+Two things made the fallout wide. `hoist_type_decl_shells` emits a
+`RegisterRole` shell for every non-lexical role at the *head* of the compilation
+unit, so the poisoning alias landed before the mainline ran — a role declared
+textually below a `when Pair` still broke it. And bareword resolution consults
+the env before the built-in types (`exec_var_get_op` returns a `Package` whose
+name differs from the bareword), so the alias won every lookup.
+
+Found while running the upstream `Cro::HTTP` suite: `Cro::HTTP::Router`'s
+`delegate` died with `Must pass one or more Pairs to 'delegate', not a Pair` —
+a message that is only possible when `.^name` says `Pair` and `when Pair`
+disagrees. `Cro::HTTP::Middleware::Pair` was the role in question.
+
+Pinned by `t/qualified-role-does-not-shadow-builtin.t`, which passes identically
+under raku.

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -558,7 +558,11 @@ impl Interpreter {
                     .rsplit_once("::")
                     .map(|(_, s)| s.to_string())
                     .unwrap_or_else(|| qualified_name.clone());
-                if !short.is_empty() && short != qualified_name {
+                // Do not shadow built-in types (e.g. `role Cro::HTTP::Middleware::Pair`
+                // must not make the bare name `Pair` resolve to the user role, which
+                // would break every `when Pair` in the process). Mirrors the same
+                // guard on the class path above.
+                if !short.is_empty() && short != qualified_name && !Self::is_builtin_type(&short) {
                     self.env_mut().entry_or_insert_with(short, || {
                         Value::package(Symbol::intern(&qualified_name))
                     });

--- a/t/qualified-role-does-not-shadow-builtin.t
+++ b/t/qualified-role-does-not-shadow-builtin.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 8;
+
+# A `role` declared with an already-qualified name registers its short name in
+# the env so later code in the same module can use it bare. That must NOT
+# happen when the short name is a built-in type: `role Cro::HTTP::Middleware::Pair`
+# used to make every bare `Pair` in the process resolve to the user role, so
+# `("a" => 1) ~~ Pair` was False and `when Pair` never matched.
+role My::Deep::Pair { }
+role My::Deep::Helper { }
+
+class Uses::My::Deep::Helper does My::Deep::Helper { }
+
+my $p = "a" => 1;
+
+is $p.^name, 'Pair', 'a Pair is still a Pair';
+ok $p ~~ Pair, 'a Pair smartmatches the built-in Pair';
+ok $p.WHAT =:= Pair, 'bare Pair is the built-in type object';
+
+my $matched = do given $p {
+    when Pair { 'Pair' }
+    default   { 'default' }
+};
+is $matched, 'Pair', 'when Pair matches a Pair';
+
+# The same guard applies to other built-ins commonly used as a trailing name.
+role Some::Where::Str { }
+role Some::Where::Int { }
+ok "x" ~~ Str, 'bare Str is still the built-in Str';
+ok 1 ~~ Int, 'bare Int is still the built-in Int';
+
+# The qualified role itself is unaffected by the guard.
+ok My::Deep::Pair.HOW.defined, 'the qualified role is still declared';
+ok Uses::My::Deep::Helper.new ~~ My::Deep::Helper, 'the qualified role still composes';


### PR DESCRIPTION
Declaring `role Cro::HTTP::Middleware::Pair { }` anywhere in a process made the bare name `Pair` resolve to that role. `("a" => 1) ~~ Pair` became `False`, `$p.WHAT =:= Pair` became `False`, and every `when Pair` in every module silently fell through to `default`.

A `class`/`role` declared with an already-qualified name registers a short-name alias in the env, so code inside `unit module M` can refer to its own `M::R1` as bare `R1`. `exec_register_class_op` has always skipped that alias when the short name is a built-in type (its comment cites `my class X::Roast::Channel` not being allowed to capture bare `Channel`). `exec_register_role_op` grew the same alias **without** the guard. It now shares it.

Two things made the fallout wide:

- `hoist_type_decl_shells` emits a `RegisterRole` shell for every non-lexical role at the *head* of the compilation unit, so the poisoning alias landed before the mainline ran — a role declared textually *below* a `when Pair` still broke it.
- Bareword resolution consults the env before the built-in types (`exec_var_get_op` returns a `Package` whose name differs from the bareword), so the alias won every lookup.

## How it was found

Running the upstream `Cro::HTTP` suite: `Cro::HTTP::Router`'s `delegate` died with `Must pass one or more Pairs to 'delegate', not a Pair` — a message only possible when `.^name` says `Pair` and `when Pair` disagrees. The culprit was `Cro::HTTP::Middleware::Pair`.

## Testing

- New pin `t/qualified-role-does-not-shadow-builtin.t` (8 subtests), which passes identically under raku.
- `make test`: PASS (2734 files, 26107 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)