### PR TITLE
feat(parser): a parameter may carry a custom `is` trait

### DIFF
--- a/news/2026-08/custom-parameter-traits.md
+++ b/news/2026-08/custom-parameter-traits.md
@@ -1,0 +1,52 @@
+# A parameter may carry a custom `is` trait
+
+`sub search(:$min-price is query = 0) { }` was a fatal parse error —
+`Can't use unknown trait 'is' -> 'query' in a parameter declaration` — because
+the parser matched every parameter trait against a fixed list of six names
+(`rw`, `readonly`, `copy`, `required`, `raw`, `encoded`). Raku has no such list:
+a parameter trait is legal whenever some `trait_mod:<is>` candidate accepts a
+`Parameter`, and `Cro::HTTP::Router` declares four of them —
+
+```raku
+multi trait_mod:<is>(Parameter:D $param, :$query! --> Nil) is export {
+    $param does Cro::HTTP::Router::Query;
+}
+```
+
+— for `query`, `header`, `cookie` and `auth`.
+
+Whether a name is legal is not knowable at parse time, so the check moved to the
+declaration site, mirroring how a *sub*-level custom trait is already handled in
+`exec_register_proto_sub_op`. `Interpreter::check_param_custom_traits` walks the
+`ParamDef`s (recursing into sub-signatures), builds a real `Parameter` value for
+each parameter carrying a non-built-in trait, and dispatches
+`trait_mod:<is>($param, :$name)`. A dispatch failure is reported as raku's
+unknown-trait error, so `sub oh-noes($gack is nonesuch) { }` still dies with a
+message naming the trait (`roast/S06-traits/misc.t`). It runs at every site that
+turns a signature into a callable: `RegisterSub`, `MakeLambda`, and
+`MakeAnonSubParams` — the last is what a bare `-> ... { }` in argument position
+compiles to, which is exactly the shape of a Cro route handler.
+
+Two supporting changes:
+
+- `parse_for_params` (loop variables, and a bare pointy block in argument
+  position) keeps a parse-time check, because a loop parameter's traits are
+  lowered away and never reach a declaration site. It now accepts an unknown
+  name once the parser has seen a `trait_mod:<is>` declaration or import — the
+  parse-time approximation of "some candidate might accept it".
+- An imported `trait_mod:<is>` is now registered into the importing scope's
+  known-sub set. It is not an operator sub, so it needs none of the
+  precedence/term machinery `is_operator_sub_name` gates; it just has to be
+  *visible* for the check above.
+
+This clears the parse barrier on the upstream Cro::HTTP router suite:
+`router-auth.rakutest` now runs instead of failing to compile, and
+`http-router.rakutest` and `http-router-named-urls.t` get much further.
+
+Still missing, and tracked in
+`todo/tickets/parameter-trait-mixin-does-not-persist.md`: the `does` mixin a
+trait applies is dropped, because `.signature.params` re-materializes a fresh
+`Parameter` from the `ParamDef` on every access. Cro reads the mixin back when
+generating a route matcher, so `is query` parameters do not yet route.
+
+Pinned by `t/custom-parameter-trait.t`, which passes under raku too.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -26,9 +26,10 @@ pub use stmt::simple::{
     clear_parser_lib_paths, set_parser_lib_paths, set_parser_program_path, set_parser_source_file,
 };
 
+pub(crate) use expr::precedence::lower_feed_node;
 /// Lower a deferred `Expr::Feed` node into its executable (sink-call) form.
 /// Re-exported for the compiler's `Expr::Feed` arm.
-pub(crate) use expr::precedence::lower_feed_node;
+pub(crate) use stmt::sub::is_builtin_param_trait;
 
 /// Descend a feed chain to its textually-leftmost operand slot — for splitting a
 /// declaration/assignment that binds tighter than the feed.

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -9,7 +9,7 @@ mod pub_shims;
 pub(super) mod simple;
 pub(crate) mod simple_expr_stmt;
 mod stmtlist;
-mod sub;
+pub(crate) mod sub;
 pub(crate) mod sub_param;
 pub(crate) mod word_logical_split;
 

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -122,6 +122,13 @@ fn apply_module_exports(exports: &[InlineModuleExport]) {
     for export in exports {
         // Register operator subs into user_subs so that the parser's
         // prefix/infix/postfix/circumfix matchers pick them up.
+        // An imported `trait_mod:<is>` is what makes a custom parameter trait
+        // (`:$x is query`) legal, so the parser has to know it was imported
+        // before it decides whether an unknown trait name is an error. It is not
+        // an operator sub — it needs none of the precedence/term machinery below.
+        if export.name.starts_with("trait_mod:<") {
+            register_user_sub(&export.name);
+        }
         if is_operator_sub_name(&export.name) {
             register_user_sub(&export.name);
             register_user_callable_term_symbol(&export.name);

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -21,7 +21,7 @@ mod traits;
 // --- Re-exports preserving each function's original visibility. ---
 
 // Signature/parameter validation (param_validate.rs).
-pub(crate) use param_validate::placeholder_overrides_signature_error;
+pub(crate) use param_validate::{is_builtin_param_trait, placeholder_overrides_signature_error};
 pub(super) use param_validate::{
     literal_value_from_expr, validate_param_trait, validate_param_trait_pub,
     validate_signature_params,

--- a/src/parser/stmt/sub/param_validate.rs
+++ b/src/parser/stmt/sub/param_validate.rs
@@ -47,28 +47,49 @@ pub(crate) fn skip_optional_trait_arg(input: &str) -> &str {
     input
 }
 
-/// Public wrapper for `validate_param_trait` used by control.rs.
+/// Trait validation for a pointy-block parameter parsed by `parse_for_params`
+/// (`for`/`with`/`while` loop variables, and a bare `-> ... { }` in argument
+/// position).
+///
+/// A loop parameter's traits are lowered away at compile time — only `is copy`
+/// has an effect — so unlike a signature parameter there is no declaration site
+/// that could later dispatch a user `trait_mod:<is>`. The unknown-trait error
+/// therefore has to be raised here, at parse time, or not at all. It is raised
+/// only when the parser has not seen a `trait_mod:<is>` declaration or import,
+/// which is the parse-time approximation of "no candidate could accept it".
 pub(crate) fn validate_param_trait_pub<'a>(
     trait_name: &str,
     existing_traits: &[String],
     input: &'a str,
 ) -> PResult<'a, ()> {
+    if !is_builtin_param_trait(trait_name)
+        && !super::super::simple::is_user_declared_sub("trait_mod:<is>")
+    {
+        return Err(PError::fatal(format!(
+            "Can't use unknown trait 'is' -> '{trait_name}' in a parameter declaration"
+        )));
+    }
     validate_param_trait(trait_name, existing_traits, input)
 }
 
-/// Validate a parameter trait name, returning a fatal parse error for unknown traits.
-/// Also warns on duplicate traits.
+/// True for a trait the signature machinery understands natively. Anything else
+/// is a *custom* parameter trait, legal only when a user `trait_mod:<is>` accepts
+/// a `Parameter`; that can only be known at declaration time, so the check lives
+/// in the VM (`check_param_custom_traits`), not here.
+pub(crate) fn is_builtin_param_trait(trait_name: &str) -> bool {
+    VALID_PARAM_TRAITS.contains(&trait_name) || trait_name == "invocant"
+}
+
+/// Parse-time handling of a parameter trait name. An unknown name is NOT a parse
+/// error: `multi trait_mod:<is>(Parameter:D $p, :$query!)` makes `is query` legal
+/// (Cro::HTTP::Router declares exactly that for `query`/`header`/`cookie`/`auth`).
+/// The declaration-time check that some `trait_mod:<is>` actually accepts it runs
+/// in the VM. Also warns on duplicate traits.
 pub(crate) fn validate_param_trait<'a>(
     trait_name: &str,
     existing_traits: &[String],
     input: &'a str,
 ) -> PResult<'a, ()> {
-    if !VALID_PARAM_TRAITS.contains(&trait_name) {
-        return Err(PError::fatal(format!(
-            "Can't use unknown trait 'is' -> '{}' in a parameter declaration",
-            trait_name
-        )));
-    }
     if existing_traits.iter().any(|t| t == trait_name) {
         add_parse_warning(format!(
             "Potential difficulties:\n    Duplicate 'is {}' trait",

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -551,6 +551,12 @@ fn extract_twigil(name: &str) -> &str {
     }
 }
 
+/// One `Parameter` instance for a single declared parameter. Used at declaration
+/// time to hand a custom parameter trait (`:$x is query`) to `trait_mod:<is>`.
+pub(crate) fn make_parameter_value_from_param_def(p: &ParamDef) -> Value {
+    sig_param_to_parameter_instance(&param_def_to_sig_param(p))
+}
+
 #[allow(dead_code)]
 pub(crate) fn make_params_value_from_param_defs(params: &[ParamDef]) -> Value {
     let sig_params: Vec<SigParam> = params.iter().map(param_def_to_sig_param).collect();

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -192,6 +192,7 @@ impl Interpreter {
             ..
         } = stmt
         {
+            self.check_param_custom_traits(param_defs)?;
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -3,6 +3,49 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
+    /// A parameter may carry a trait the signature machinery does not know
+    /// (`sub f($x is nonesuch)`). That is legal only when some user
+    /// `trait_mod:<is>` accepts a `Parameter` — Cro::HTTP::Router declares
+    /// `multi trait_mod:<is>(Parameter:D $param, :$query!)` and friends. The
+    /// parser therefore records the name instead of rejecting it, and the
+    /// declaration site checks it here, the same way a *sub*-level custom trait
+    /// is checked in `exec_register_proto_sub_op`.
+    pub(crate) fn check_param_custom_traits(
+        &mut self,
+        params: &[crate::ast::ParamDef],
+    ) -> Result<(), RuntimeError> {
+        for p in params.iter() {
+            for trait_name in &p.traits {
+                if crate::parser::is_builtin_param_trait(trait_name) {
+                    continue;
+                }
+                let unknown = || {
+                    RuntimeError::new(format!(
+                        "Can't use unknown trait 'is' -> '{trait_name}' in a parameter declaration."
+                    ))
+                };
+                if !self.has_proto("trait_mod:<is>") && !self.has_multi_candidates("trait_mod:<is>")
+                {
+                    return Err(unknown());
+                }
+                // Hand the candidate a real Parameter, the way raku does. A
+                // dispatch failure means no candidate accepts this trait name,
+                // which is raku's compile-time "unknown trait" error.
+                let param_val = crate::value::signature::make_parameter_value_from_param_def(p);
+                let named_arg = Value::pair(trait_name.clone(), Value::TRUE);
+                loan_env!(
+                    self,
+                    call_function("trait_mod:<is>", vec![param_val, named_arg])
+                )
+                .map_err(|_| unknown())?;
+            }
+            if let Some(subs) = &p.sub_signature {
+                self.check_param_custom_traits(subs)?;
+            }
+        }
+        Ok(())
+    }
+
     pub(super) fn exec_make_lambda_op(
         &mut self,
         code: &CompiledCode,
@@ -21,6 +64,7 @@ impl Interpreter {
             ..
         } = stmt
         {
+            self.check_param_custom_traits(param_defs)?;
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
@@ -154,6 +198,7 @@ impl Interpreter {
             } else {
                 name.resolve()
             };
+            self.check_param_custom_traits(param_defs)?;
             // Compile-time declaration fingerprint for this site (absent for a
             // runtime-resolved `name_expr` sub), enabling the idempotent
             // re-registration fast path inside `register_sub_decl_fp`.

--- a/t/custom-parameter-trait.t
+++ b/t/custom-parameter-trait.t
@@ -1,0 +1,34 @@
+use Test;
+
+plan 7;
+
+# A parameter may carry a trait name the signature machinery does not know, as
+# long as some `trait_mod:<is>` accepts a Parameter. Cro::HTTP::Router declares
+# `multi trait_mod:<is>(Parameter:D $param, :$query!)` and friends, and its route
+# handlers are written `get -> 'search', :$min-price is query = 0 { ... }`.
+my @applied;
+multi trait_mod:<is>(Parameter:D $param, :$query! --> Nil) {
+    @applied.push($param.name);
+}
+
+sub search(:$min-price is query = 0, :$max-price is query = Inf) {
+    "$min-price..$max-price"
+}
+
+is search(), '0..Inf', 'a sub with custom parameter traits is callable';
+is search(min-price => 3), '3..Inf', 'its named arguments still bind';
+ok @applied.grep('$min-price'), 'trait_mod:<is> ran for the first parameter';
+ok @applied.grep('$max-price'), 'trait_mod:<is> ran for the second parameter';
+
+# The same on a pointy block, which is how Cro route handlers are written.
+my $handler = -> 'search', :$min-price is query = 0 { "got $min-price" };
+is $handler('search', min-price => 7), 'got 7', 'a pointy block takes custom parameter traits';
+
+# A trait no trait_mod can accept is still an error, at the declaration.
+throws-like { EVAL 'sub oh-noes($gack is nonesuch) { }' }, Exception,
+    'an unknown parameter trait still dies',
+    message => /nonesuch/;
+
+# A built-in parameter trait keeps working next to a custom one.
+sub mixed($x is copy, :$y is query = 1) { $x = $x + $y; $x }
+is mixed(1), 2, 'is copy still works alongside a custom trait';

--- a/todo/tickets/parameter-trait-mixin-does-not-persist.md
+++ b/todo/tickets/parameter-trait-mixin-does-not-persist.md
@@ -1,0 +1,60 @@
+# A `does` mixin applied by a parameter trait does not persist
+
+`multi trait_mod:<is>(Parameter:D $param, :$query!) { $param does Query }` now
+runs at declaration time (see `news/2026-08/custom-parameter-traits.md`), but the
+role it mixes in is thrown away. Reading the parameter back gives a plain
+`Parameter`:
+
+```raku
+role Q { }
+multi trait_mod:<is>(Parameter:D $p, :$query!) { $p does Q }
+sub f(:$mp is query) { }
+say &f.signature.params[0].^name;      # raku: Parameter+{Q}   mutsu: Parameter
+say &f.signature.params[0] ~~ Q;       # raku: True            mutsu: False
+```
+
+Mixing in directly has the same result, so the gap is not specific to traits:
+
+```raku
+role Q { }
+sub f(:$mp) { }
+my $p = &f.signature.params[0];
+$p does Q;
+say $p.^name;   # raku: Parameter+{Q}   mutsu: Parameter.new
+say $p ~~ Q;    # raku: True            mutsu: False
+```
+
+## Root cause
+
+There is no stored `Parameter` object to mix into. `Signature.params` is built
+by `make_params_value_with_owner` (`src/value/signature.rs`), which maps each
+`SigParam` through `sig_param_to_parameter_instance` — a fresh `Instance` with
+attributes derived from the `ParamDef`, constructed on every access. A mixin
+applied to one of those instances dies with it. The declaration-time trait
+dispatch added in `check_param_custom_traits`
+(`src/vm/vm_register_sub_ops.rs`) has the same problem from the other side: it
+builds a throwaway `Parameter` to hand to the candidate.
+
+## Why it matters
+
+`Cro::HTTP::Router::RouteSet!generate-route-matcher` walks `$sig.params` and
+tests `$param ~~ Cro::HTTP::Router::Query` (and `::Header`, `::Cookie`,
+`::Auth`) to decide how to unpack a request. With the mixin dropped, every such
+parameter looks like an ordinary named parameter, so a route declared
+`get -> 'search', :$min-price is query = 0 { }` does not route. That is the
+remaining blocker on `http-router.rakutest`, `router-auth.rakutest` and
+`http-router-named-urls.t` after the parse fix.
+
+## Sketch of a fix
+
+Either (a) record the applied roles back onto the `SigParam` at declaration time
+and re-mix them whenever a `Parameter` instance is materialized — cheap, and
+correct for the `does`-only traits real modules write, but it re-runs nothing
+else the trait body did; or (b) materialize each signature's `Parameter` objects
+once, cache them alongside the registered `SigInfo` (`register_sig_info` already
+keys on the Signature instance id), and hand out the cached values so a mixin
+sticks. (b) is the honest version and also fixes the direct-`does` case above.
+
+Note that `.signature` itself is re-derived in several places; whichever route
+is taken, the identity of `Parameter` objects has to become stable enough that
+`$sig.params[0] === $sig.params[0]` holds, which it currently does not.


### PR DESCRIPTION
`sub search(:$min-price is query = 0) { }` was a fatal parse error — `Can't use unknown trait 'is' -> 'query' in a parameter declaration` — because the parser matched every parameter trait against a fixed list of six names (`rw`, `readonly`, `copy`, `required`, `raw`, `encoded`).

Raku has no such list: a parameter trait is legal whenever some `trait_mod:<is>` candidate accepts a `Parameter`. `Cro::HTTP::Router` declares four of them:

```raku
multi trait_mod:<is>(Parameter:D $param, :$query! --> Nil) is export {
    $param does Cro::HTTP::Router::Query;
}
```

## What changed

Whether a name is legal is not knowable at parse time, so the check moved to the declaration site, mirroring how a *sub*-level custom trait is already handled in `exec_register_proto_sub_op`. `Interpreter::check_param_custom_traits` walks the `ParamDef`s (recursing into sub-signatures), builds a real `Parameter` for each parameter carrying a non-built-in trait, and dispatches `trait_mod:<is>($param, :$name)`. A dispatch failure is reported as raku's unknown-trait error, so `sub oh-noes($gack is nonesuch) { }` still dies with a message naming the trait (`roast/S06-traits/misc.t`).

It runs at every site that turns a signature into a callable: `RegisterSub`, `MakeLambda`, and `MakeAnonSubParams` — the last is what a bare `-> ... { }` in argument position compiles to, which is exactly the shape of a Cro route handler.

Two supporting changes:

- `parse_for_params` (loop variables, and a bare pointy block in argument position) keeps a **parse-time** check, because a loop parameter's traits are lowered away and never reach a declaration site. It now accepts an unknown name once the parser has seen a `trait_mod:<is>` declaration or import.
- An imported `trait_mod:<is>` is registered into the importing scope's known-sub set. It is not an operator sub, so it needs none of the precedence/term machinery `is_operator_sub_name` gates — it just has to be visible for the check above.

## Effect on Cro

Clears the parse barrier on the upstream router suite: `router-auth.rakutest` now runs instead of failing to compile, and `http-router.rakutest` / `http-router-named-urls.t` get much further.

**Still missing** (`todo/tickets/parameter-trait-mixin-does-not-persist.md`): the `does` mixin a trait applies is dropped, because `.signature.params` re-materializes a fresh `Parameter` from the `ParamDef` on every access. Cro reads that mixin back when generating a route matcher, so `is query` parameters do not route yet.

## Testing

- New pin `t/custom-parameter-trait.t` (7 subtests), which passes under raku too.
- `make test`: PASS (2734 files, 26106 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)