### PR TITLE
fix(parser): a declared type beats the quoting language

### DIFF
--- a/news/2026-08/declared-type-beats-quote-lang.md
+++ b/news/2026-08/declared-type-beats-quote-lang.md
@@ -1,0 +1,47 @@
+# A declared type beats the quoting language
+
+A role or class named `Q` is ordinary Raku, and mutsu accepted it as a bareword
+type everywhere except on the right of `does`, where the `Q` quoting language
+won and ate the rest of the statement list:
+
+```raku
+role Q { }
+class C { }
+my $c = C.new;
+$c does Q;
+say "MARK1";
+say "MARK2";
+```
+
+raku prints `MARK1` then `MARK2`; mutsu printed only `MARK2`. The AST showed
+why —
+
+```
+Expr(Binary { left: Var("c"), op: Ident("does"),
+              right: Literal(Str("\nsay \"MARK1\"")) })
+```
+
+— `Q;` was read as a `Q`-quote delimited by `;`, swallowing everything up to the
+next `;`. The swallowed statement still *executed* when the operand was
+evaluated, so a one-liner like `$c does Q; say $c ~~ Q` looked correct while
+being parsed completely wrong. That made it an unusually good liar: it only
+showed up as a missing line when two statements followed.
+
+raku's rule is that a declared symbol wins over the quoting construct. With
+nothing declared, `raku -e 'say Q;abc;'` prints `abc` (a `Q`-quote); adding
+`role Q { }` makes the same source complain that the routine `abc` is
+undeclared, because `Q` is now the role and `abc;` is a separate statement.
+
+`big_q_string` and `q_string` now apply that rule: they take the leading
+alphabetic word and bail out when it is a user-declared type
+(`is_user_declared_type`), letting the term parser resolve the name. The guard
+is uniform across the whole family, so `class qw { }` behaves the same way,
+and an undeclared `q`/`qq`/`Q`/`qw` is still the quoting language.
+
+Only the `does` right-hand side actually mis-parsed — a type constraint,
+`Q.new`, `my Q $v` and a smartmatch RHS all resolved `Q` correctly already — but
+the fix belongs in the quote parsers rather than in `does`, because that is
+where the ambiguity is decided.
+
+Pinned by `t/declared-type-beats-quote-lang.t`, which passes identically under
+raku.

--- a/src/parser/primary/string/q_string.rs
+++ b/src/parser/primary/string/q_string.rs
@@ -18,6 +18,17 @@ pub(crate) fn big_q_string(input: &str) -> PResult<'_, Expr> {
     if rest.starts_with("::") {
         return Err(PError::expected("Q string"));
     }
+    // A declared symbol wins over the quoting language, as it does in raku:
+    // with `role Q { }` in scope, `$c does Q; say "x";` is a `does` against the
+    // role, not a `Q`-quote delimited by `;` that swallows the next statement.
+    // (`raku -e 'say Q;abc;'` prints `abc`; adding `role Q {}` makes it complain
+    // that the routine `abc` is undeclared.)
+    let word_end = input
+        .find(|c: char| !c.is_ascii_alphabetic())
+        .unwrap_or(input.len());
+    if crate::parser::stmt::simple::is_user_declared_type(&input[..word_end]) {
+        return Err(PError::expected("Q string"));
+    }
 
     // Parse fused adverbs (Qs, Qa, Qb, etc.)
     let mut flags = QuoteFlags::bare_q_big();
@@ -170,6 +181,15 @@ pub(crate) fn q_string(input: &str) -> PResult<'_, Expr> {
     };
 
     if !input.starts_with('q') {
+        return Err(PError::expected("q string"));
+    }
+    // A declared symbol wins over the quoting language, as in raku — see the
+    // note in `big_q_string`. `class qw { }` is unusual but legal, and once
+    // declared, `qw` is that type everywhere.
+    let word_end = input
+        .find(|c: char| !c.is_ascii_alphabetic())
+        .unwrap_or(input.len());
+    if crate::parser::stmt::simple::is_user_declared_type(&input[..word_end]) {
         return Err(PError::expected("q string"));
     }
     let mut after_q = &input[1..];

--- a/t/declared-type-beats-quote-lang.t
+++ b/t/declared-type-beats-quote-lang.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 6;
+
+# A declared symbol wins over the quoting language, as in raku. `Q` used to be
+# lexed as a Q-quote delimited by `;`, which swallowed the following statement:
+# `$c does Q; say "MARK";` parsed as `$c does Q(";\nsay \"MARK\"")`.
+role Q { }
+role Qw { }
+class C { }
+
+my @log;
+
+my $c = C.new;
+$c does Q;
+@log.push('after-does');
+
+is @log.elems, 1, 'the statement after `does Q;` is not swallowed';
+ok $c ~~ Q, 'the role was mixed in';
+is Q.^name, 'Q', 'a role named Q keeps its name';
+
+# The same for the fused word-quote spellings.
+sub takes(Qw $x) { 'typed' }
+is takes(C.new does Qw), 'typed', 'a role named Qw is usable as a type';
+
+# An *undeclared* quote word is still the quoting language. (`Q` and `Qw` are
+# declared above, so `Q[...]` is now role parameterisation — in raku too.)
+is q{plain}, 'plain', 'q{...} still quotes';
+is qw<a b c>.join('-'), 'a-b-c', 'qw<> still word-quotes';

--- a/todo/deep/does-does-not-mutate-the-object.md
+++ b/todo/deep/does-does-not-mutate-the-object.md
@@ -1,0 +1,79 @@
+# `does` copies instead of mutating the object
+
+Raku's `does` operator mixes a role into *the object*, so every reference to it
+sees the mixin. (`but` is the copying one.) mutsu instead builds a fresh
+`ValueRepr::Mixin` wrapper and rebinds the left-hand variable, so any other
+reference to the same object is unaffected:
+
+```raku
+role Marker { }
+class C { }
+my $x = C.new;
+my $y = $x;
+$y does Marker;
+say $y ~~ Marker;   # raku: True    mutsu: True
+say $x ~~ Marker;   # raku: True    mutsu: False   <-- the divergence
+```
+
+Passing through a routine loses it entirely, because the callee rebinds only its
+own parameter:
+
+```raku
+sub apply($p) { $p does Marker }
+my $c = C.new;
+apply($c);
+say $c ~~ Marker;   # raku: True    mutsu: False
+```
+
+## Why it matters
+
+This is the root blocker under
+[`todo/tickets/parameter-trait-mixin-does-not-persist.md`](../tickets/parameter-trait-mixin-does-not-persist.md),
+and therefore under Cro::HTTP's router. Every custom parameter trait in
+`Cro::HTTP::Router` is written exactly like the routine case above:
+
+```raku
+multi trait_mod:<is>(Parameter:D $param, :$query! --> Nil) is export {
+    $param does Cro::HTTP::Router::Query;
+}
+```
+
+`check_param_custom_traits` (`src/vm/vm_register_sub_ops.rs`) now calls that
+candidate with a real `Parameter` at declaration time, but the mixin dies with
+the callee's binding, so mutsu has no way to learn *which* roles a trait
+applied. The declared return type is `--> Nil`, so reading the call's result
+does not help either. Until `does` mutates, there is nothing to record onto the
+`SigParam`, and a route declared `get -> 'search', :$min-price is query = 0 { }`
+cannot be told apart from an ordinary named parameter.
+
+## Why it is deep
+
+`ValueRepr::Mixin(Arc<Value>, Arc<HashMap<String, Value>>)` is a *wrapper*: the
+mixin lives outside the instance, so it cannot be shared by other references to
+the same `Instance`. Making `does` mutate means moving the mixin state inside
+the instance — a role list (and attribute overrides) reachable through the
+instance's own `Gc`, updated in place — and then teaching every consumer to read
+it there: `~~` / `type_matches_value`, `.^name` (`C+{Marker}`), `.^roles`,
+`.^mro`, method dispatch (mixin methods must win over the class's), `.raku` /
+`.gist`, serialization, and the `but` operator, which must keep copying.
+
+Two shapes to consider:
+
+1. Keep `Mixin` for non-`Instance` values (an `Int` or `Str` genuinely cannot be
+   mutated in place) and add in-instance role state used only for `Instance` /
+   `CustomTypeInstance`. Smaller blast radius, but two mechanisms to keep in
+   sync — the kind of dual mechanism the working agreements warn about.
+2. Give every mixable value an identity that `does` can mutate. Cleaner, much
+   larger, and interacts with the NaN-boxed representation and ADR-0001's
+   container/scalar type filter.
+
+Whichever shape wins, the parameter-trait consumer above needs a second step
+after it: record the roles a trait applied onto the `SigParam`, so the
+`Parameter` objects `.signature.params` re-materializes carry them.
+
+## Related, found while investigating
+
+`$c does Q;` — where `Q` is an ordinary role name — mis-lexes as the `Q` quoting
+language and swallows the rest of the statement; see
+[`todo/tickets/bareword-Q-after-does-lexes-as-quote.md`](../tickets/bareword-Q-after-does-lexes-as-quote.md).
+Unrelated to the semantics above, but it makes any `does Q` repro lie.


### PR DESCRIPTION
A role or class named `Q` is ordinary Raku, and mutsu accepted it as a bareword type everywhere except on the right of `does`, where the `Q` quoting language won and ate the rest of the statement list:

```raku
role Q { }
class C { }
my $c = C.new;
$c does Q;
say "MARK1";
say "MARK2";
```

raku prints `MARK1` then `MARK2`; mutsu printed only `MARK2`. The AST showed why:

```
Expr(Binary { left: Var("c"), op: Ident("does"),
              right: Literal(Str("\nsay \"MARK1\"")) })
```

`Q;` was read as a `Q`-quote delimited by `;`, swallowing everything up to the next `;`. The swallowed statement still *executed* when the operand was evaluated, so a one-liner like `$c does Q; say $c ~~ Q` looked correct while being parsed completely wrong — it only surfaced as a missing line when two statements followed.

## The rule

raku resolves a declared symbol before the quoting construct. With nothing declared, `raku -e 'say Q;abc;'` prints `abc`; adding `role Q { }` makes the same source complain that the routine `abc` is undeclared.

`big_q_string` and `q_string` now apply that rule: take the leading alphabetic word and bail out when it is a user-declared type (`is_user_declared_type`), letting the term parser resolve the name. The guard is uniform across the whole `q`/`qq`/`Q`/`qw`/… family, and an undeclared quote word still quotes.

Only the `does` right-hand side actually mis-parsed — a type constraint, `Q.new`, `my Q $v` and a smartmatch RHS all resolved `Q` correctly already — but the fix belongs in the quote parsers, because that is where the ambiguity is decided.

## Also included (docs)

Two findings recorded from the same investigation, both blockers on Cro::HTTP's router:

- `todo/deep/does-does-not-mutate-the-object.md` — `does` copies instead of mutating the object, so a role mixed in inside a routine is invisible to the caller. This is what stops mutsu from learning which roles `multi trait_mod:<is>(Parameter:D $param, :$query!) { $param does Query }` applied.
- `todo/tickets/parameter-trait-mixin-does-not-persist.md` (added in #5695) is the consumer-side half.

## Testing

- New pin `t/declared-type-beats-quote-lang.t` (6 subtests), which passes identically under raku.
- `make test`: PASS (2736 files, 26119 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)