### PR TITLE
fix(vm): a NativeCall prelude helper is not a block-lexical sub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,36 +279,28 @@ jobs:
       # v0.19.0 release run down with it. The pin tests in `t/` only cover bugs
       # already found; this is the net for the unknown ones.
       #
-      # It runs here on a push to `main` (attributing drift to a commit within
-      # minutes) and on a PR that touches the batteries themselves — a whitelist
-      # edit, a re-pin in batteries.lock, a change to a shipped `modules/` tree
-      # or to the gate script. It deliberately does NOT run on an ordinary PR:
-      # it clones 17 upstream repositories, and the merge path should not depend
-      # on that. Cost when it does run is small — the suites themselves take
-      # ~75s, and this job has already built the release binary for roast.
-      - name: Should the bundled-library gate run?
-        id: batteries
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          changed="$(gh pr diff "${{ github.event.pull_request.number }}" --name-only)"
-          if printf '%s\n' "$changed" | grep -qE '^(batteries\.lock|batteries-whitelist\.txt|batteries-exclude\.txt|scripts/battery-testsuite\.sh|modules/|vendor/zef/)'; then
-            echo "  PR touches the batteries — running the gate."
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "  PR does not touch the batteries — the gate runs post-merge."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
+      # It runs on EVERY run of this job — every PR and every push to `main`.
+      #
+      # It used to run only post-merge and on a PR that touched the batteries
+      # themselves, on the reasoning that an ordinary PR's merge path should not
+      # depend on cloning 17 upstream repositories. That reasoning was wrong in
+      # practice, and the failure mode is worse than the one it avoided: a
+      # general interpreter change lands green, breaks a bundled library, and
+      # the breakage is only discovered by the *next* batteries-touching PR,
+      # which is then blocked by a regression it did not cause. That is exactly
+      # what happened to `DBIish/01-basic.rakutest` — the block-lexical-sub
+      # escape hatch took NativeCall's prelude helpers with it, dropping the
+      # suite from 35/35 to 27/35 (news/2026-08/prelude-helper-not-block-lexical.md).
+      # `make test` cannot catch these: the pin tests in `t/` only cover bugs
+      # already found, and this is the net for the unknown ones.
+      #
+      # The cost is small: the suites take ~75s, this job has already built the
+      # release binary for roast, and a documentation-only PR skips the whole
+      # job anyway (see the `changes` job).
       - name: Bundled-library test suites
-        if: steps.batteries.outputs.run == 'true'
         # libssl for the OpenSSL / IO::Socket::SSL batteries' NativeCall at
-        # runtime; installed here rather than in the job's apt step so an
-        # ordinary PR does not pay for it.
+        # runtime; installed here rather than in the job's apt step so the
+        # cost lands next to the step that needs it.
         run: |
           sudo apt-get install -y libssl-dev
           scripts/battery-testsuite.sh

--- a/docs/batteries/testsuite-gate.md
+++ b/docs/batteries/testsuite-gate.md
@@ -30,14 +30,19 @@ took the v0.19.0 release run down (the tag was pushed, the publish was skipped).
 The `test` job in `ci.yml` therefore also runs the gate on a push to `main`,
 which attributes drift to a commit within minutes of the merge.
 
-**On a PR — only when the PR is about the batteries.** The same step runs on a
-pull request that touches `batteries.lock`, `batteries-whitelist.txt`,
-`batteries-exclude.txt`, `scripts/battery-testsuite.sh`, a shipped `modules/`
-tree, or `vendor/zef/` — the changes whose whole point is to move the baseline.
-An ordinary PR skips it: the run clones 17 upstream repositories, and the merge
-path should not depend on the network. Cost when it does run is small (~75s of
-suites; the job has already built the release binary for roast), so this does
-not lengthen ordinary CI at all.
+**On every PR.** The gate used to be skipped on an ordinary pull request — it
+clones 17 upstream repositories, and the merge path was not supposed to depend
+on the network. That trade turned out to be the wrong way round. Post-merge
+detection tells you a battery broke, but by then the breakage is on `main`, and
+the person who finds it is whoever next opens a batteries-touching PR — blocked
+by a regression they did not cause, on a branch where it is hardest to attribute.
+`DBIish/01-basic.rakutest` went from 35/35 to 27/35 exactly that way
+(`news/2026-08/prelude-helper-not-block-lexical.md`): the offending PR did not
+touch `modules/`, so its own CI never ran the gate.
+
+So it runs on every PR now. The cost is what it always was — ~75s of suites, on
+a job that has already built the release binary for roast — and a
+documentation-only PR skips the whole job anyway.
 
 The pin tests under `t/` are not a substitute. They cover bugs that have already
 been found; the gate is the net for the ones that have not.
@@ -51,7 +56,7 @@ been found; the gate is the net for the ones that have not.
 | `batteries-exclude.txt` | Files the gate must never run, same `name<TAB>testfile` shape. Skipped in both modes, so they can neither block a release nor enter the baseline. |
 | `scripts/battery-testsuite.sh` | The harness. Fetches each suite at its pinned commit, runs it against the bundled library, and enforces (or, with `--update`, regenerates) the whitelist. |
 | `release.yml` `batteries` job | Runs the harness on every release build; `needs` gates the publish job. |
-| `ci.yml` `test` job, last two steps | Runs the same harness post-merge on `main`, and on a PR that touches the batteries. The `Should the bundled-library gate run?` step holds the path filter. |
+| `ci.yml` `test` job, last step | Runs the same harness on every PR and every push to `main`. No path filter — see "On every PR" above for why. |
 
 ## Running it
 

--- a/news/2026-08/prelude-helper-not-block-lexical.md
+++ b/news/2026-08/prelude-helper-not-block-lexical.md
@@ -1,0 +1,58 @@
+# A NativeCall prelude helper is not a block-lexical sub, and the batteries gate now runs on every PR
+
+`DBIish/01-basic.rakutest` dropped from 35/35 to 27/35 in the bundled-library
+gate: three assertions around `DBIish.install-driver('mysql')` began failing
+with
+
+```
+Cannot load native library 'libmariadb.so.0'
+```
+
+where upstream expects a soft failure — `install-driver` succeeds and the
+absence of the client library shows up only in `.version`, which is why the
+suite's next assertion is `pass "Library not installed"`.
+
+## Root cause
+
+`inject_nativecall_subs_prelude` prepends `cglobal`, `nativecast`,
+`nativesizeof`, `explicitly-manage` and `refresh` to any compunit whose source
+mentions `NativeCall`. Each is stamped with the internal `__mutsu_prelude`
+trait, which registers it under `GLOBAL` rather than the host compunit's
+package: every module carries an identical copy and only the first registration
+wins.
+
+The block-lexical-sub escape hatch added in
+`news/2026-08/regex-anchored-my-initializer-and-escaping-sub.md` took them
+anyway. It stores a `Sub` value — with the declaring scope's env captured —
+under a reserved key so a closure that outlives its block can still call the
+routine. Applied to a prelude helper that meant one env-captured copy of
+`cglobal` per NativeCall-using module, and the *last* one loaded answered every
+later call. DBIish's mysql driver therefore probed its library through the
+SQLite driver's scope.
+
+The gate already had three conditions, each learned from a regression (not the
+plain `&name`, not inside `EVAL`, not exported). This is the fourth, and it
+shares the `is_export` one's reasoning: an interface routine is not lexical to a
+block.
+
+Release-only, because the failure is a wrong *closure env* rather than a wrong
+answer — a debug build happened to reach a working copy. Pinned by
+`t/prelude-helper-not-block-lexical.t`, which drives the shape in a subprocess
+with the module directories on `-I`; the shape is delicate (reaching DBIish
+through the bundled-battery path, or naming the loop variable instead of using
+the topic, both hide it), so the pin was checked in both directions: it fails on
+the unfixed binary and passes on the fixed one.
+
+## The gate now runs on every PR
+
+The regression reached `main` green. The bundled-library gate ran post-merge and
+on PRs that touch the batteries — and the offending PR touched neither
+`modules/` nor the gate's other paths, so its own CI never ran it. Post-merge
+detection then put the breakage in front of whoever next opened a
+batteries-touching PR, blocked by a regression they did not cause, on the branch
+where it is hardest to attribute.
+
+`ci.yml` therefore drops the path filter: the gate runs on every PR and every
+push to `main`. The cost is what it always was — roughly 75 seconds of suites on
+a job that has already built the release binary for roast — and a
+documentation-only PR skips the whole job regardless.

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -318,6 +318,21 @@ impl Interpreter {
                 // `require M <quux>`'s missing-symbol detection
                 // (roast/S11-modules/require.t 11).
                 && !*is_export
+                // A prelude-injected helper (`cglobal`, `nativecast`,
+                // `nativesizeof`, ... — see `inject_nativecall_subs_prelude`)
+                // is an ambient GLOBAL routine, not a block-lexical one: every
+                // compunit that so much as mentions NativeCall carries its own
+                // identical copy, and only the first registration wins. Taking
+                // the escape hatch stored one env-captured copy per module and
+                // let the *last* module loaded answer a later `cglobal` call
+                // with its own closure env, so DBIish's mysql driver probed the
+                // library through the SQLite driver's scope and died with
+                // "Cannot load native library 'libmariadb.so.0'" where it
+                // should have soft-failed. Same reasoning as the `is_export`
+                // gate above: an interface routine is not lexical to a block.
+                && !custom_traits
+                    .iter()
+                    .any(|(t, _)| t == crate::runtime::PRELUDE_SUB_TRAIT)
                 && !*multi
                 && name_expr.is_none()
                 && !resolved_name.contains("::")

--- a/t/prelude-helper-not-block-lexical.t
+++ b/t/prelude-helper-not-block-lexical.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+# A NativeCall prelude helper (`cglobal`, `nativecast`, `nativesizeof`,
+# `explicitly-manage`, `refresh` -- see `inject_nativecall_subs_prelude`) is an
+# ambient GLOBAL routine: every compunit that so much as mentions NativeCall
+# carries its own identical copy, and only the first registration wins.
+#
+# The block-lexical-sub escape hatch used to take them anyway, storing one
+# env-captured copy per module under its reserved key. The *last* module loaded
+# then answered a later `cglobal` call with its own closure env, so DBIish's
+# mysql driver probed the library through the SQLite driver's scope and threw
+#
+#     Cannot load native library 'libmariadb.so.0'
+#
+# where upstream expects a soft failure -- `install-driver` must succeed and the
+# absence of the client library show up only in `.version`. It took DBIish's
+# whitelisted `01-basic.rakutest` from 35/35 to 27/35 in the bundled-library
+# gate, and `make test` never saw it.
+#
+# Run in a subprocess with the module directories on `-I`, which is how the gate
+# invokes the upstream suite: the shape is delicate, and reaching DBIish through
+# the bundled-battery path resolves `cglobal` from a different scope and hides
+# the bug. The topic-variable `for` is load-bearing for the same reason --
+# rewriting it to a named parameter, or putting an assertion between the two
+# installs, also hides it.
+
+plan 1;
+
+my $root = $*PROGRAM.parent(2);
+my @inc = <modules/DBIish/lib modules/NativeLibs/lib modules/NativeHelpers-Blob/lib>
+    .map({ '-I' , $root.add($_).absolute })
+    .flat;
+
+my $code = q:to/CODE/;
+    use Test;
+    plan 2;
+    use DBIish;
+    for <SQLite mysql> {
+        my $drv;
+        lives-ok { $drv = DBIish.install-driver($_); }, "install '$_'";
+    }
+    CODE
+
+is_run $code,
+    { status => 0, out => "1..2\nok 1 - install 'SQLite'\nok 2 - install 'mysql'\n" },
+    :compiler-args(@inc),
+    'a driver loaded after another still probes its own library';


### PR DESCRIPTION
**`main` is currently red on this.** `DBIish/01-basic.rakutest` dropped from 35/35 to 27/35 in the bundled-library gate: three assertions around `DBIish.install-driver('mysql')` began failing with

```
Cannot load native library 'libmariadb.so.0'
```

where upstream expects a *soft* failure — `install-driver` succeeds and the absence of the client library shows up only in `.version`, which is why the suite's next assertion is `pass "Library not installed"`.

Bisected by building each candidate's `src/` at release and running the suite: `18aa8f3f1` (#5690) gives 35/35, `129754297` (#5677, `fix(regex): an anchored :my initializer dispatches; a block-lexical sub escapes`) gives 27/35.

## Root cause

`inject_nativecall_subs_prelude` prepends `cglobal`, `nativecast`, `nativesizeof`, `explicitly-manage` and `refresh` to any compunit whose *source mentions* `NativeCall`. Each is stamped with the internal `__mutsu_prelude` trait, which registers it under `GLOBAL` rather than the host compunit's package: every module carries an identical copy and only the first registration wins.

The block-lexical-sub escape hatch took them anyway. It stores a `Sub` value — with the declaring scope's env captured — under a reserved key so a closure that outlives its block can still call the routine. Applied to a prelude helper that meant **one env-captured copy of `cglobal` per NativeCall-using module**, and the *last* one loaded answered every later call. DBIish's mysql driver therefore probed its library through the SQLite driver's scope. (Confirmed by instrumenting the fallback: the only name it ever resolved in that run was `cglobal`, twice.)

The hatch already had three gates, each learned from a regression (not the plain `&name`, not inside `EVAL`, not exported). This is the fourth, and it shares the `is_export` one's reasoning: an interface routine is not lexical to a block.

## …and the gate now runs on every PR

The regression reached `main` green. The bundled-library gate ran post-merge and on PRs that touch the batteries — and #5677 touched neither `modules/` nor the gate's other paths, so **its own CI never ran the gate**. Post-merge detection then put the breakage in front of whoever next opened a batteries-touching PR (#5691), blocked by a regression they did not cause, on the branch where it is hardest to attribute.

`ci.yml` therefore drops the path filter: the gate runs on every PR and every push to `main`. The cost is what it always was — ~75s of suites on a job that has already built the release binary for roast — and a documentation-only PR skips the whole job regardless.

## Testing

- New pin `t/prelude-helper-not-block-lexical.t`. The shape is delicate (reaching DBIish through the bundled-battery path, or naming the loop variable instead of using the topic, both hide the bug), so it drives the upstream shape in a subprocess with the module directories on `-I`, and it was **checked in both directions**: it fails on the unfixed binary and passes on the fixed one.
- `make test`: `Files=2736, Tests=26114`, Result: PASS.
- Local bundled-library gate: `GATE PASSED`, 153/158 test files.
- #5677's own pins (`t/regex-my-initializer-and-escaping-sub.t`, `t/cross-module-short-name-types.t`, `t/undeclared-routine-compile-time.t`, `t/nativecall-sqlite.t`) all still pass.

Release-only, because the failure is a wrong *closure env* rather than a wrong answer — a debug build happened to reach a working copy, which is why `make test` never saw it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)