### PR TITLE
fix(runtime): `emit` reaches the supply from a nested sub

### DIFF
--- a/news/2026-08/emit-from-a-nested-sub.md
+++ b/news/2026-08/emit-from-a-nested-sub.md
@@ -1,0 +1,62 @@
+# `emit` reaches the supply from a nested sub
+
+`emit` is caught by the innermost *dynamically* enclosing `supply`, not the
+lexically enclosing one, so a routine that is not written inside the block still
+emits into it when called from within:
+
+```raku
+sub e($x) { emit $x }
+supply { e(1); emit 2 }     # raku emits 1 then 2
+```
+
+mutsu emitted only `2`. The value from the nested sub vanished silently — no
+error, no warning, just a missing item.
+
+The cause was the lowering. `supply { ... }` is compiled by binding an emitter
+`Supplier` as the body's parameter (`__mutsu_supply_emitter_<id>`) and
+rewriting every `emit x` **written in the body** to
+`$__mutsu_supply_emitter_N.emit(x)`. A sub's body is not rewritten — a TODO in
+`rewrite_supply_stmt` had recorded exactly this, noting that rewriting it
+surfaced a closure-capture gap, so nested-sub `emit` was left as a runtime
+no-op. The bare `emit` builtin then raised `CX::Emit`, which nothing downstream
+of a sub call catches.
+
+The fix drops the lexical approach for that case and makes the emitter
+dynamically available, which is what raku's control-exception semantics amount
+to:
+
+- `Interpreter::active_supply_emitters` is a stack of the emitter `Supplier`s
+  whose supply code is currently running.
+- `run_on_demand_body` pushes the emitter it just built around the body call, so
+  a sub called from the body finds it.
+- `call_supply_tap` wraps the tap/`whenever` callback invocations in
+  `native_supplier_methods`. It recovers the emitter from the callback's own
+  captured env (the callback *is* written inside the supply block, so it
+  captured `__mutsu_supply_emitter_<id>`) and pushes it for the duration of the
+  call. An unrelated tap callback has no such lexical and pushes nothing.
+- The `emit` builtin now emits through the top of that stack, falling back to
+  the on-demand emit buffer, and only raises `CX::Emit` when there is no
+  enclosing supply at all — which is still what a `CONTROL` block observes.
+
+This covers all four shapes: `emit` in the body, in a sub declared in the body,
+in a sub declared outside it, and in a sub called from a `whenever` over either
+a static `Supply` or a live `Supplier`.
+
+## Effect on Cro
+
+`Cro::HTTP2::GeneralParser` emits every parsed message through a helper declared
+inside its `supply` block:
+
+```raku
+sub emit-response($sid, $message) {
+    with %push-promises-by-promised-id{$sid}:delete { .set-response($message) }
+    else { emit $message }
+}
+```
+
+so the entire HTTP/2 layer produced nothing at all. Against the upstream suite:
+`http2-request-parser` goes from 0 passing to 60 of 64, `http2-response-parser`
+from 0/2 to 8 passing with a clean exit, `http2-request-serializer` from 4 to 8,
+and `http2-frame-serializer` from 3 subtests reached to 13.
+
+Pinned by `t/emit-from-a-nested-sub.t`, which passes identically under raku.

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -856,9 +856,26 @@ impl Interpreter {
                 }
             }
             "emit" => {
-                // Top-level `emit` outside a supply block raises a CX::Emit
-                // control exception that a CONTROL block can observe.
                 let value = args.first().cloned().unwrap_or(Value::NIL);
+                // `emit` is caught by the innermost *dynamically* enclosing
+                // supply, not the lexically enclosing one: a sub declared
+                // outside a supply block still emits into it when called from
+                // inside (raku prints `1, 2` for
+                // `sub e($x) { emit $x }; supply { e(1); emit 2 }`). The
+                // parser's `supply` rewrite only reaches `emit` written
+                // directly in the body, so route through the active emit
+                // buffer here — the same buffer the `.emit` method form uses.
+                if let Some(emitter) = self.active_supply_emitters.last().cloned() {
+                    return self
+                        .call_method_with_values(emitter, "emit", vec![value])
+                        .map(|_| Value::NIL);
+                }
+                if let Some(buf) = self.supply_emit_buffer.last_mut() {
+                    buf.push(value);
+                    return Ok(Value::NIL);
+                }
+                // Outside any supply block this is a CX::Emit control
+                // exception that a CONTROL block can observe.
                 Err(RuntimeError::emit_signal(value))
             }
             "return" => {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1369,6 +1369,15 @@ pub struct Interpreter {
     /// per-match `:my $*FINAL` is not read as the last match's value.
     pub(crate) grammar_rule_dynvar_decls: HashMap<String, Vec<String>>,
     pub(super) supply_emit_buffer: Vec<Vec<Value>>,
+    /// Emitter `Supplier`s of the `supply` blocks whose code is currently on the
+    /// stack, innermost last. `emit` is caught by the innermost *dynamically*
+    /// enclosing supply, so a `sub` that is not lexically inside the block still
+    /// emits into it when called from within — the parser's `supply` rewrite
+    /// (`emit x` -> `$__mutsu_supply_emitter_N.emit(x)`) only reaches `emit`
+    /// written directly in the body, and a nested sub's closure never captured
+    /// the emitter. Pushed around a `whenever` body invoked as a live-supplier
+    /// tap, where the emitter is recovered from the callback's captured env.
+    pub(super) active_supply_emitters: Vec<Value>,
     /// `whenever <Promise>` sources inside a `supply` block, rewritten to a
     /// stand-in supplier and waiting to be armed. A supplier keeps no backlog,
     /// so the promise must not be armed until the consumer has registered the

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -76,7 +76,7 @@ impl Interpreter {
                         match action {
                             SupplierEmitAction::Call(tap, emitted, delay_seconds) => {
                                 Self::sleep_for_supply_delay(delay_seconds);
-                                if let Err(err) = self.call_sub_value(tap, vec![emitted], true) {
+                                if let Err(err) = self.call_supply_tap(tap, vec![emitted], true) {
                                     // A `return` inside the tap callback targets the
                                     // callback's lexically enclosing routine: propagate
                                     // the signal unchanged so that routine's call frame
@@ -192,7 +192,7 @@ impl Interpreter {
                                         ds_action
                                     {
                                         Self::sleep_for_supply_delay(delay_seconds);
-                                        let _ = self.call_sub_value(tap, vec![emitted], true);
+                                        let _ = self.call_supply_tap(tap, vec![emitted], true);
                                     }
                                 }
                             }
@@ -212,7 +212,7 @@ impl Interpreter {
                                         ) = ds_action
                                         {
                                             Self::sleep_for_supply_delay(delay_seconds);
-                                            let _ = self.call_sub_value(tap, vec![emitted], true);
+                                            let _ = self.call_supply_tap(tap, vec![emitted], true);
                                         }
                                     }
                                 }
@@ -245,7 +245,7 @@ impl Interpreter {
                                         ) = da
                                         {
                                             Self::sleep_for_supply_delay(delay_seconds);
-                                            let _ = self.call_sub_value(tap, vec![emitted], true);
+                                            let _ = self.call_supply_tap(tap, vec![emitted], true);
                                         }
                                     }
                                 }
@@ -278,7 +278,7 @@ impl Interpreter {
                                         ) = da
                                         {
                                             Self::sleep_for_supply_delay(delay_seconds);
-                                            let _ = self.call_sub_value(tap, vec![emitted], true);
+                                            let _ = self.call_supply_tap(tap, vec![emitted], true);
                                         }
                                     }
                                 }
@@ -338,7 +338,7 @@ impl Interpreter {
                             if let SupplierEmitAction::Call(tap, emitted, delay_seconds) = ds_action
                             {
                                 Self::sleep_for_supply_delay(delay_seconds);
-                                let _ = self.call_sub_value(tap, vec![emitted], true);
+                                let _ = self.call_supply_tap(tap, vec![emitted], true);
                             }
                         }
                         supplier_done(dsid);
@@ -347,10 +347,10 @@ impl Interpreter {
                         }
                     }
                     for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
-                        let _ = self.call_sub_value(tap, vec![emitted], true);
+                        let _ = self.call_supply_tap(tap, vec![emitted], true);
                     }
                     for (tap, emitted) in flush_supplier_words_taps(supplier_id) {
-                        let _ = self.call_sub_value(tap, vec![emitted], true);
+                        let _ = self.call_supply_tap(tap, vec![emitted], true);
                     }
                     for done_cb in take_supplier_done_callbacks(supplier_id) {
                         self.invoke_done_callback(done_cb)?;
@@ -414,10 +414,10 @@ impl Interpreter {
                     supplier_quit(supplier_id, reason.clone());
                     close_supplier_channel_taps(supplier_id, Some(reason.clone()));
                     for (tap, emitted) in flush_supplier_line_taps(supplier_id) {
-                        self.call_sub_value(tap, vec![emitted], true)?;
+                        self.call_supply_tap(tap, vec![emitted], true)?;
                     }
                     for (tap, emitted) in flush_supplier_words_taps(supplier_id) {
-                        self.call_sub_value(tap, vec![emitted], true)?;
+                        self.call_supply_tap(tap, vec![emitted], true)?;
                     }
                     let (_, _, quit_reason) = supplier_snapshot(supplier_id);
                     if let Some(reason) = quit_reason {
@@ -535,7 +535,7 @@ impl Interpreter {
                         match action {
                             SupplierEmitAction::Call(tap, emitted, delay_seconds) => {
                                 Self::sleep_for_supply_delay(delay_seconds);
-                                if let Err(err) = self.call_sub_value(tap, vec![emitted], true) {
+                                if let Err(err) = self.call_supply_tap(tap, vec![emitted], true) {
                                     // A `return` inside the tap callback targets the
                                     // callback's lexically enclosing routine: propagate
                                     // the signal unchanged so that routine's call frame
@@ -642,7 +642,7 @@ impl Interpreter {
                                         ds_action
                                     {
                                         Self::sleep_for_supply_delay(delay_seconds);
-                                        self.call_sub_value(tap, vec![emitted], true)?;
+                                        self.call_supply_tap(tap, vec![emitted], true)?;
                                     }
                                 }
                             }
@@ -662,7 +662,7 @@ impl Interpreter {
                                         ) = ds_action
                                         {
                                             Self::sleep_for_supply_delay(delay_seconds);
-                                            self.call_sub_value(tap, vec![emitted], true)?;
+                                            self.call_supply_tap(tap, vec![emitted], true)?;
                                         }
                                     }
                                 }
@@ -695,7 +695,7 @@ impl Interpreter {
                                         ) = da
                                         {
                                             Self::sleep_for_supply_delay(delay_seconds);
-                                            let _ = self.call_sub_value(tap, vec![emitted], true);
+                                            let _ = self.call_supply_tap(tap, vec![emitted], true);
                                         }
                                     }
                                 }
@@ -728,7 +728,7 @@ impl Interpreter {
                                         ) = da
                                         {
                                             Self::sleep_for_supply_delay(delay_seconds);
-                                            let _ = self.call_sub_value(tap, vec![emitted], true);
+                                            let _ = self.call_supply_tap(tap, vec![emitted], true);
                                         }
                                     }
                                 }
@@ -789,7 +789,7 @@ impl Interpreter {
                             if let SupplierEmitAction::Call(tap, emitted, delay_seconds) = ds_action
                             {
                                 Self::sleep_for_supply_delay(delay_seconds);
-                                self.call_sub_value(tap, vec![emitted], true)?;
+                                self.call_supply_tap(tap, vec![emitted], true)?;
                             }
                         }
                         // Propagate done to downstream batch suppliers
@@ -807,10 +807,10 @@ impl Interpreter {
                         }
                     }
                     for (tap, emitted) in flush_supplier_line_taps(sid) {
-                        self.call_sub_value(tap, vec![emitted], true)?;
+                        self.call_supply_tap(tap, vec![emitted], true)?;
                     }
                     for (tap, emitted) in flush_supplier_words_taps(sid) {
-                        self.call_sub_value(tap, vec![emitted], true)?;
+                        self.call_supply_tap(tap, vec![emitted], true)?;
                     }
                     for done_cb in take_supplier_done_callbacks(sid) {
                         self.invoke_done_callback(done_cb)?;
@@ -882,10 +882,10 @@ impl Interpreter {
                     let sid = supplier_id as u64;
                     close_supplier_channel_taps(sid, Some(reason.clone()));
                     for (tap, emitted) in flush_supplier_line_taps(sid) {
-                        self.call_sub_value(tap, vec![emitted], true)?;
+                        self.call_supply_tap(tap, vec![emitted], true)?;
                     }
                     for (tap, emitted) in flush_supplier_words_taps(sid) {
-                        self.call_sub_value(tap, vec![emitted], true)?;
+                        self.call_supply_tap(tap, vec![emitted], true)?;
                     }
                     // Run any `whenever` QUIT phasers first. If one handles the
                     // exception (a when/default matched, or it called done), the

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2169,6 +2169,7 @@ impl Interpreter {
             let_saves: Vec::new(),
             grammar_rule_dynvar_decls: HashMap::new(),
             supply_emit_buffer: Vec::new(),
+            active_supply_emitters: Vec::new(),
             pending_promise_whenever_arms: Vec::new(),
             supply_emit_timed_buffer: Vec::new(),
             supply_stream_consumers: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -451,6 +451,7 @@ impl Interpreter {
             let_saves: Vec::new(),
             grammar_rule_dynvar_decls: HashMap::new(),
             supply_emit_buffer: Vec::new(),
+            active_supply_emitters: Vec::new(),
             pending_promise_whenever_arms: Vec::new(),
             supply_emit_timed_buffer: Vec::new(),
             supply_stream_consumers: Vec::new(),

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -6,6 +6,35 @@ use crate::symbol::Symbol;
 use crate::value::AttrMap;
 
 impl Interpreter {
+    /// Call a `whenever`/tap callback with the callback's own supply emitter
+    /// made dynamically visible, so a bare `emit` inside a *sub* the callback
+    /// calls reaches the right supply. The emitter is the
+    /// `__mutsu_supply_emitter_<id>` lexical the parser binds as the on-demand
+    /// body's parameter; a callback written inside a `supply` block captures it,
+    /// while an unrelated tap callback does not and pushes nothing.
+    pub(crate) fn call_supply_tap(
+        &mut self,
+        tap: Value,
+        args: Vec<Value>,
+        propagate_return: bool,
+    ) -> Result<Value, RuntimeError> {
+        let emitter = tap.as_sub().and_then(|data| {
+            data.env
+                .keys()
+                .find(|k| k.with_str(|s| s.starts_with("__mutsu_supply_emitter_")))
+                .and_then(|k| data.env.get_sym(*k).cloned())
+        });
+        let pushed = emitter.is_some();
+        if let Some(e) = emitter {
+            self.active_supply_emitters.push(e);
+        }
+        let res = self.call_sub_value(tap, args, propagate_return);
+        if pushed {
+            self.active_supply_emitters.pop();
+        }
+        res
+    }
+
     /// Phase A of the on-demand supply runtime, shared by `tap`/`act`, the react
     /// event loop, `await`/`.Promise`, and `supply_get_values`. Builds an emitter
     /// `Supplier` (with a `supplier_id` when `emitter_supplier_id` is `Some`), runs
@@ -28,7 +57,11 @@ impl Interpreter {
         });
         self.supply_emit_buffer.push(Vec::new());
         let done_before = supplier_done_count();
+        // A bare `emit` reached from a *sub* called by the body is not rewritten
+        // to `$emitter.emit(...)`, so it needs the emitter dynamically.
+        self.active_supply_emitters.push(emitter.clone());
         let result = self.call_sub_value(on_demand_cb, vec![emitter], false);
+        self.active_supply_emitters.pop();
         let body_ran_done = supplier_done_count() > done_before;
         let emitted = self.supply_emit_buffer.pop().unwrap_or_default();
         (result, emitted, body_ran_done)

--- a/t/emit-from-a-nested-sub.t
+++ b/t/emit-from-a-nested-sub.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 5;
+
+# `emit` is caught by the innermost *dynamically* enclosing supply, not the
+# lexically enclosing one. A sub declared outside a supply block still emits
+# into it when called from inside.
+sub outer-emit($x) { emit $x * 10 }
+
+sub collect($supply) {
+    my @got;
+    $supply.tap(-> $v { @got.push($v) }, done => { @got.push('done') });
+    @got.join(',')
+}
+
+is collect(supply { emit 1; emit 2 }), '1,2,done',
+    'emit written directly in the body';
+
+is collect(supply { sub e($x) { emit $x }; e(1); emit 2 }), '1,2,done',
+    'emit inside a sub declared in the body';
+
+is collect(supply { outer-emit(1); emit 2 }), '10,2,done',
+    'emit inside a sub declared outside the block';
+
+is collect(supply { whenever Supply.from-list(1, 2) { outer-emit($_) } }), '10,20,done',
+    'emit from a sub called by a whenever over a static supply';
+
+# The live-Supplier path dispatches the whenever body as a tap callback, which
+# is where Cro::HTTP2::GeneralParser's `emit-response` helper runs.
+my $s = Supplier.new;
+my @got;
+supply {
+    whenever $s.Supply { outer-emit($_) }
+}.tap(-> $v { @got.push($v) }, done => { @got.push('done') });
+$s.emit(1);
+$s.emit(2);
+$s.done;
+is @got.join(','), '10,20,done',
+    'emit from a sub called by a whenever over a live Supplier';


### PR DESCRIPTION
`emit` is caught by the innermost *dynamically* enclosing `supply`, not the lexically enclosing one:

```raku
sub e($x) { emit $x }
supply { e(1); emit 2 }     # raku emits 1 then 2
```

mutsu emitted only `2` — the value from the nested sub vanished silently, no error, no warning.

## Cause

`supply { ... }` is lowered by binding an emitter `Supplier` as the body's parameter (`__mutsu_supply_emitter_<id>`) and rewriting every `emit x` **written in the body** to `$__mutsu_supply_emitter_N.emit(x)`. A sub's body is not rewritten — a TODO in `rewrite_supply_stmt` recorded exactly this, noting that rewriting it surfaced a closure-capture gap, so nested-sub `emit` was left a runtime no-op. The bare `emit` builtin then raised `CX::Emit`, which nothing downstream of a sub call catches.

## Fix

Make the emitter dynamically available, which is what raku's control-exception semantics amount to:

- `Interpreter::active_supply_emitters` — a stack of the emitter `Supplier`s whose supply code is currently running.
- `run_on_demand_body` pushes the emitter it just built around the body call.
- `call_supply_tap` wraps the tap / `whenever` callback invocations in `native_supplier_methods`. It recovers the emitter from the callback's own captured env — the callback *is* written inside the supply block, so it captured `__mutsu_supply_emitter_<id>` — and pushes it for the duration of the call. An unrelated tap callback has no such lexical and pushes nothing.
- The `emit` builtin emits through the top of that stack, falls back to the on-demand emit buffer, and raises `CX::Emit` only when there is no enclosing supply at all (still what a `CONTROL` block observes).

Covers all four shapes: `emit` in the body, in a sub declared in the body, in a sub declared outside it, and in a sub called from a `whenever` over either a static `Supply` or a live `Supplier`.

## Effect on Cro

`Cro::HTTP2::GeneralParser` emits every parsed message through a helper declared inside its `supply` block:

```raku
sub emit-response($sid, $message) {
    with %push-promises-by-promised-id{$sid}:delete { .set-response($message) }
    else { emit $message }
}
```

so the entire HTTP/2 layer produced nothing at all. Against the upstream suite:

| file | before | after |
| --- | --- | --- |
| `http2-request-parser` | 0 passing | **60 of 64** |
| `http2-response-parser` | 0 of 2 | **8 passing, clean exit** |
| `http2-request-serializer` | 4 | **8** |
| `http2-frame-serializer` | 3 subtests reached | **13** |

## Testing

- New pin `t/emit-from-a-nested-sub.t` (5 subtests), which passes identically under raku.
- `make test`: PASS (2735 files, 26113 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)