### PR TITLE
docs(todo): triage the 19 files the real `Test` module still fails

### DIFF
--- a/todo/deep/deferred-seq-materialization-destroys-the-original.md
+++ b/todo/deep/deferred-seq-materialization-destroys-the-original.md
@@ -1,0 +1,98 @@
+# Materializing a deferred `Seq` destroys the value it was asked about
+
+A second method call on the same `Seq` throws, where raku answers:
+
+```
+$ cat tmp/lz.raku
+my $p = "tmp/lz.txt".IO;
+$p.spurt("A\nB\nC\n");
+my $g = $p.open(:r).lines;
+say "Str 1: '" ~ $g.Str ~ "'";
+say "Str 2: '" ~ $g.Str ~ "'";
+
+$ raku tmp/lz.raku
+Str 1: 'A B C'
+Str 2: 'A B C'
+
+$ mutsu tmp/lz.raku
+Str 1: 'A B C'
+The iterator of this Seq is already in use/consumed by another Seq ...
+```
+
+Merely *asking about* the value is enough — `.defined` alone destroys it:
+
+```
+my $g = $p.open(:r).lines;
+say $g.defined;      # True
+say $g.Str;          # raku: 'A B C'   mutsu: X::Seq::Consumed
+```
+
+## Where
+
+`src/runtime/methods_call_dispatch.rs`, the deferred-iterator arm. `IO::Handle.lines`
+(and every other `Seq.new(<Iterator>)` producer — see
+`news/2026-08/…deferred-seq-reification…`) stores the iterator without pulling.
+When a method arrives, the arm pulls every item into a **new** `Arc`, builds a
+**new** `Seq`, and re-dispatches the method on that:
+
+```rust
+if !matches!(method, "cache" | "sink" | "raku" | "perl") {
+    let items_arc = items.clone();
+    if let Some(iterator) = crate::value::seq_take_deferred_iter(&items_arc) {
+        ... pull every item into `pulled_items` ...
+        let new_seq = Value::seq_arc(std::sync::Arc::new(pulled_items));
+        // cached state is transferred; the ITEMS are not
+        return self.call_method_with_values(new_seq, method, args);
+    }
+}
+```
+
+`seq_take_deferred_iter` removes the iterator from the side table, and the pulled
+items land in a different `Arc`. The variable the user still holds therefore ends
+up with an empty item list and no iterator — indistinguishable from a consumed
+`Seq`, which is exactly what the next call reports.
+
+## Why raku does not have this problem
+
+rakudo's `Seq.Str` (and `.gist`, `.raku`, …) go through `self.cache`, which
+reifies **into the Seq itself**. The iterator is consumed once; the Seq keeps the
+values, so every later access — of any kind — reads them back. Only *iterating*
+a Seq twice is an error there, and `.Str` is not iterating.
+
+## Why it matters now
+
+rakudo's real `Test.rakumod` opens `is` with
+
+```raku
+multi sub is(Mu $got, Mu:D $expected, $desc = '') is export {
+    if $got.defined {                 # <-- destroys a deferred Seq here
+        my $test = ... $got eq $expected;
+```
+
+so `is $fh.lines, <A B C>` compares an already-gutted Seq and reports
+`got: '(...)'`. It is one of the remaining gaps in
+`todo/tickets/vendor-real-test-module.md` (`t/is-lazy-io-lines.t`), and any
+`t/` file that hands a lazy `.lines` to the real module will hit it.
+
+## The fix, and why it is not a one-liner
+
+The sound fix is to reify **in place**: write the pulled items back through the
+original `Arc` so every alias of the value sees them, and mark the Seq cached,
+rather than building a fresh `Seq` and abandoning the old one. That is the same
+shape as the `arc_contents_mut` / `gc_contents_mut` chokepoint work, and it wants
+that machinery rather than a local hack.
+
+Two narrower options were tried and rejected:
+
+- **Exempting `.defined`/`.DEFINITE` from the materialize path** (their answer
+  cannot depend on the contents, so it is a correct restriction on its own) does
+  *not* fix the ticket: the very next call, `$got eq $expected`, materializes and
+  the diagnostic still renders `(...)`. It also had no observable effect on the
+  `.defined`-then-`.Str` repro above, which suggests `.defined` on a deferred Seq
+  reaches the reification through a different path — worth locating before
+  touching this arm at all.
+- **Transferring the pulled items to the old `Arc` after the fact** is the same
+  in-place write, just spelled less honestly; do the real thing.
+
+Pin candidates: the two-call repro above, `.defined`-then-`.Str`, and
+`t/is-lazy-io-lines.t` under `MUTSU_REAL_TEST=1`.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -325,6 +325,25 @@ Exit status was measured for the first time and is already faithful — a failin
 assertion exits 1, a short plan exits 255 — which is what `prove` reads, so
 step 3 does not need work there.
 
+### Triaged, 19 left (2026-08-02)
+
+`module-file-var-and-callframe.t` now passes. The other 19 all read
+`native / real=FAIL / raku` — rakudo runs the *same module* over the same file
+successfully, so the difference is genuinely in mutsu.
+
+| group | files | note |
+| --- | --- | --- |
+| exception-class hierarchy | `block-lexical-scope.t`, `gate-b-callee-name-collision-and-deref-capture.t`, `undeclared-when-type.t` | all fail on `right exception type (X::Undeclared / X::Comp::Group)` — one cause, `todo/deep/exception-class-hierarchy-is-mostly-unregistered.md` |
+| the pin asserts *native-provider* behaviour | `qualified-call-does-not-alias-builtin.t` (asserts `Test::ok(1)` **dies** — under the real module `Test::ok` legitimately exists), `test-assertion-line-number.t`, `throws-like-outer-var-writeback.t` | re-point the test file; not an interpreter gap |
+| deferred `Seq` reification destroys the value | `is-lazy-io-lines.t` | `todo/deep/deferred-seq-materialization-destroys-the-original.md` — the real `is` opens with `$got.defined`, which guts a lazy `.lines` |
+| individual gaps | `bigrat-sort-compare.t` (`cmp-ok` calls `infix:«<»` as a *routine value*; FatRat vs Num answers differently there than the compiled operator), `proxy-list-transparency.t` (`is-deeply` does not FETCH `Proxy` list elements — reports `$(Proxy, Proxy)`), `emit-done-controlflow.t`, `error-reporting-quality.t`, `group-of.t`, `handles-proto-dispatch-mut-invocant.t`, `io-cathandle-lazy.t`, `leave-in-if-branch.t`, `multi-where-otf-dispatch.t`, `subscript-adverbs.t`, `throws-like-gather-sink.t`, `whatever-code-fixes.t` | one at a time |
+
+`tmp/recheck.sh <file>.t …` runs the named files native / real / raku and is the
+per-file tool; `scripts/test-module-sweep.sh` is the full measurement. Note the
+per-file harness must create a `tmp/` under its working directory — several of
+these files spurt fixtures there, and without it they die before their first
+assertion and read as a false pass.
+
 ## Blocker found while doing step 1: the native provider shadows an import — FIXED
 
 **Resolved** (`news/2026-08/imported-test-routines-beat-the-native-provider.md`,


### PR DESCRIPTION
Re-measured the `Test`-vendoring campaign's residue on current `main`, running each file three ways (mutsu's native provider / `MUTSU_REAL_TEST=1` / `raku`). `module-file-var-and-callframe.t` now passes; the other **19 all read `native / real=FAIL / raku`** — rakudo runs the *same module* over the *same file* successfully, so the difference is genuinely in mutsu, not in the module.

Grouped in `todo/tickets/vendor-real-test-module.md`:

| group | files |
| --- | --- |
| exception-class hierarchy (one cause) | `block-lexical-scope.t`, `gate-b-callee-name-collision-and-deref-capture.t`, `undeclared-when-type.t` |
| the pin asserts *native-provider* behaviour, not an interpreter gap | `qualified-call-does-not-alias-builtin.t`, `test-assertion-line-number.t`, `throws-like-outer-var-writeback.t` |
| deferred `Seq` reification (new deep finding) | `is-lazy-io-lines.t` |
| individual gaps | the remaining 12 |

`qualified-call-does-not-alias-builtin.t` is the clearest of the second group: it asserts `Test::ok(1)` **dies**, which is only true while `Test` is intercepted and registers no routines. Under the real module `Test::ok` legitimately exists.

## New: `todo/deep/deferred-seq-materialization-destroys-the-original.md`

Materializing a deferred `Seq` pulls its items into a **new** `Arc` and abandons the old one, so the value the caller still holds is left with an empty item list and no iterator — indistinguishable from a consumed `Seq`.

```
my $g = $p.open(:r).lines;
say $g.Str;   # raku: 'A B C'   mutsu: 'A B C'
say $g.Str;   # raku: 'A B C'   mutsu: X::Seq::Consumed
```

`.defined` alone is enough to destroy it, which is exactly how the real `Test`'s `is` — it opens with `if $got.defined` — turns `is $fh.lines, <A B C>` into `got: '(...)'`. rakudo has no such problem: its `Seq.Str` reifies through `.cache`, *into the Seq itself*, so every later access reads the values back.

The sound fix is in-place reification (write the pulled items back through the original `Arc` and mark the Seq cached), which wants the `arc_contents_mut`/`gc_contents_mut` chokepoint machinery rather than a local hack. Two narrower attempts were tried and are recorded with why they fall short — notably that exempting `.defined`/`.DEFINITE` from the materialize path is correct on its own but does not fix the ticket, *and* had no observable effect on the repro, which suggests `.defined` reaches reification by a different route that should be located first. Recorded rather than guessed at, so the next pass does not repeat them.

Documentation only — no interpreter change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)