### PR TITLE
test: clean stale spurt fixture before roast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,9 @@ The prose list here is *context* (why each historical flake happened, and the de
 - `roast/S02-types/hash.t`, `roast/S09-typed-arrays/hashes.t` — the "CI-load-sensitive timeout" label is stale: both complete in ~0.3s on a release build now. A failure here is real — see triage below.
 - `t/io-socket-recv-limit.t` — the "fails under `-j4` load" label was wrong: it was a deterministic **port collision**. `IO::Socket::Async.listen(host, 0)` did not let the OS assign an ephemeral port; it substituted one from a process-local counter seeded identically in every process, so concurrent mutsu processes all asked for the same port and whichever bound second died. On top of that, this file and `t/io-socket-async-bin.t` both hardcoded 19995 (serial: 5/5 PASS, `-j2`: 5/5 FAIL). Fixed in #4512 — port 0 now reaches `bind()`, and the test asks the tap for the port it got. **Never hardcode a port in a new test**: listen on 0 and read `.socket-port`.
 
-Also: before a local `make roast`, `rm -f temp-file-RT-126006-test` — a stale temp file left by an interrupted `roast/S32-io/spurt.t` makes that test abort with "cannot run test while file ... exists".
+`make roast` removes `temp-file-RT-126006-test` before starting: a stale copy
+left by an interrupted `roast/S32-io/spurt.t` would otherwise make that test
+abort with "cannot run test while file ... exists".
 
 ### Triaging a suspected-flaky failure — don't mislabel a real bug
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ check-flaky-list:
 
 roast:
 	@mkdir -p tmp
+	@rm -f temp-file-RT-126006-test
 	(cargo build --release && MUTSU_BIN=$(MUTSU_BIN) prove -j$(PROVE_JOBS) -e 'scripts/run-roast-test.sh' $(shell cat roast-whitelist.txt)) 2>&1 | tee tmp/make-roast.log
 
 check-roast-whitelist:

--- a/news/2026-08/roast-cleans-stale-spurt-fixture.md
+++ b/news/2026-08/roast-cleans-stale-spurt-fixture.md
@@ -1,0 +1,5 @@
+# Clean stale spurt fixture before roast
+
+An interrupted `roast/S32-io/spurt.t` run can leave its fixed-name temporary
+file behind, causing the next otherwise clean `make roast` to abort. The roast
+target now removes that known fixture before starting the suite.


### PR DESCRIPTION
## Problem

An interrupted `roast/S32-io/spurt.t` can leave `temp-file-RT-126006-test` behind. A later `make roast` then aborts that file before exercising its tests.

## Approach

Remove that exact known fixture at the start of the `roast` Make target and update the repository guidance.

## Test evidence

- `make -n roast` shows cleanup before the release build and prove invocation
- After manual cleanup, `roast/S32-io/spurt.t` passes all 62 tests