### PR TITLE
fix(runtime): a named-arg statement call keeps the caller's container cell

### DIFF
--- a/news/2026-08/named-arg-statement-call-keeps-the-caller-cell.md
+++ b/news/2026-08/named-arg-statement-call-keeps-the-caller-cell.md
@@ -1,0 +1,59 @@
+# A statement-level call with a named argument no longer severs the caller's container cell
+
+A whole-container assignment could be silently lost:
+
+```raku
+my @arr;
+my sub push-one() { @arr.push('x') }   # closure capture -> shared container cell
+push-one();
+
+takes-container @arr, ['x'], 'reason', opt => 1;   # statement call, named arg
+@arr = ();                                          # <- silently a no-op
+say @arr.raku;                                      # ["x"]  (raku: [])
+```
+
+Every condition was needed: the caller's variable had to be a closure-captured
+lexical (so it lives in a shared `ContainerRef` cell), it had to be passed to the
+routine, and the call had to be a *statement* carrying a *named* argument. Drop
+any one of them — call it in expression position, pass positionals only, or take
+the closure away — and the assignment worked.
+
+## Why
+
+A statement-level `Stmt::Call` whose argument list contains a named argument
+compiles to `OpCode::ExecCallPairs`, which dispatches through the interpreter's
+`exec_call` rather than the VM's `CallFunc` path. On return `exec_call` writes
+each aliased container parameter back to the caller via
+`apply_rw_bindings_to_env`.
+
+That writeback already knew not to *replace* a caller entry holding a live
+`ContainerRef` — it writes the value through the cell so aliases survive — but the
+guard only fired when the incoming value was a plain container
+(`&& !updated.is_container_ref()`). An aliased container argument (compiled as
+`WrapVarRef`) binds the parameter through a **fresh cell of its own**, so the
+incoming value *was* a `ContainerRef`, the guard declined, and the callee's cell
+was stored into the caller's env entry.
+
+The caller's local slot still held the original cell. From that point the name had
+two cells: `@arr = ()` emptied the slot's cell, while `GetArrayVar` — which reads
+env before locals — found the callee's copy, still holding the pre-call contents.
+Any read that re-synced the two (a method call on the variable, for instance) hid
+the problem, which is why inserting a `say @arr` before the assignment made it
+disappear.
+
+## The fix
+
+`apply_rw_bindings_to_env` now unwraps an incoming cell and writes its value
+*through* the caller's cell, keeping the caller's cell identity in every case
+(and short-circuiting when both sides are already the same cell). The rule is now
+unconditional: the caller's binding cell is never replaced, only written through.
+
+Pinned by `t/named-arg-stmt-call-keeps-caller-cell.t` (with
+`t/lib/NamedArgStmtCall.rakumod`), which covers the array and hash shapes plus
+the positional-only statement call that always worked.
+
+Found while running `t/` against the vendored upstream `Test.rakumod`
+(`todo/tickets/vendor-real-test-module.md`): the real module's `is-deeply` is a
+module routine, so `is-deeply @events, [...]` is exactly this call shape, and
+`t/leave-in-if-branch.t`'s `@events = ()` between assertions never took effect.
+That file now passes under `MUTSU_REAL_TEST=1`.

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -365,8 +365,23 @@ impl Interpreter {
                 // so post-return `$val++` / `$a = …` keep observing one container.
                 if let Some(ValueView::ContainerRef(arc)) =
                     target_env.get(source_name).map(Value::view)
-                    && !updated.is_container_ref()
                 {
+                    // The param's final value may itself be a *different* cell: an
+                    // aliased container argument (`WrapVarRef`) binds the param
+                    // through a fresh cell of its own. Storing that cell into the
+                    // caller's entry replaces the caller's cell, severing it from
+                    // the local slot and from every closure that captured the name
+                    // — a later `@a = ()` then writes the old cell while a by-name
+                    // read finds the new one and reports the pre-call contents.
+                    // Unwrap it and write the value through the caller's cell too.
+                    if let ValueView::ContainerRef(incoming) = updated.view() {
+                        if crate::gc::Gc::ptr_eq(&arc, &incoming) {
+                            continue;
+                        }
+                        let inner = incoming.lock().unwrap().clone();
+                        *arc.lock().unwrap() = inner;
+                        continue;
+                    }
                     *arc.lock().unwrap() = updated;
                     continue;
                 }

--- a/t/lib/NamedArgStmtCall.rakumod
+++ b/t/lib/NamedArgStmtCall.rakumod
@@ -1,0 +1,8 @@
+unit module NamedArgStmtCall;
+
+# A module routine that takes a container into a plain `$` parameter and also
+# accepts named arguments, so a statement-level call to it carries a Pair and
+# compiles to the named-argument statement-call opcode.
+sub takes-container($got, $expected, $reason = '', *%opts) is export {
+    $got.elems
+}

--- a/t/named-arg-stmt-call-keeps-caller-cell.t
+++ b/t/named-arg-stmt-call-keeps-caller-cell.t
@@ -1,0 +1,48 @@
+use lib 't/lib';
+use Test;
+use NamedArgStmtCall;
+
+# A statement-level call carrying a named argument dispatches through the
+# interpreter's statement-call path, which writes each aliased container
+# parameter back to the caller on return. When the caller's variable is a
+# closure-captured lexical it lives in a shared container cell, and the
+# writeback used to *replace* that cell with the callee's own alias cell —
+# severing the caller's local slot from the name. A later whole-container
+# assignment then wrote the old cell while a by-name read found the new one,
+# so the assignment looked silently lost.
+
+plan 6;
+
+my @arr;
+my sub push-one() { @arr.push('x') }
+push-one();
+
+takes-container @arr, ['x'], 'reason', opt => 1;
+@arr = ();
+is @arr.elems, 0, 'whole-array assignment after a named-arg statement call takes effect';
+
+push-one();
+is-deeply @arr, ['x'], 'the closure and the caller still share one container';
+
+@arr = <p q>;
+is-deeply @arr, ['p', 'q'], 'a later list assignment is visible by name too';
+
+# The same for a hash.
+my %h;
+my sub set-one() { %h<a> = 1 }
+set-one();
+
+takes-container %h, {a => 1}, 'reason', opt => 1;
+%h = ();
+is %h.elems, 0, 'whole-hash assignment after a named-arg statement call takes effect';
+
+set-one();
+is-deeply %h, {a => 1}, 'the closure and the caller still share one hash';
+
+# A positional-only statement call was always fine; keep it pinned.
+my @plain;
+my sub push-plain() { @plain.push('y') }
+push-plain();
+takes-container @plain, ['y'], 'reason';
+@plain = ();
+is @plain.elems, 0, 'positional statement call keeps the caller container assignable';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -325,9 +325,14 @@ Exit status was measured for the first time and is already faithful — a failin
 assertion exits 1, a short plan exits 255 — which is what `prove` reads, so
 step 3 does not need work there.
 
-### Triaged, 19 left (2026-08-02)
+### Triaged, 18 left (2026-08-02)
 
-`module-file-var-and-callframe.t` now passes. The other 19 all read
+`module-file-var-and-callframe.t` now passes, and so does `leave-in-if-branch.t`
+— its `@events = ()` between assertions was silently dropped because the real
+module's `is-deeply` is a *module routine*, making `is-deeply @events, [...]` a
+statement call with a named argument, which severed the caller's container cell
+(`news/2026-08/named-arg-statement-call-keeps-the-caller-cell.md`, pin
+`t/named-arg-stmt-call-keeps-caller-cell.t`). The other 18 all read
 `native / real=FAIL / raku` — rakudo runs the *same module* over the same file
 successfully, so the difference is genuinely in mutsu.
 
@@ -336,7 +341,7 @@ successfully, so the difference is genuinely in mutsu.
 | exception-class hierarchy | `block-lexical-scope.t`, `gate-b-callee-name-collision-and-deref-capture.t`, `undeclared-when-type.t` | all fail on `right exception type (X::Undeclared / X::Comp::Group)` — one cause, `todo/deep/exception-class-hierarchy-is-mostly-unregistered.md` |
 | the pin asserts *native-provider* behaviour | `qualified-call-does-not-alias-builtin.t` (asserts `Test::ok(1)` **dies** — under the real module `Test::ok` legitimately exists), `test-assertion-line-number.t`, `throws-like-outer-var-writeback.t` | re-point the test file; not an interpreter gap |
 | deferred `Seq` reification destroys the value | `is-lazy-io-lines.t` | `todo/deep/deferred-seq-materialization-destroys-the-original.md` — the real `is` opens with `$got.defined`, which guts a lazy `.lines` |
-| individual gaps | `bigrat-sort-compare.t` (`cmp-ok` calls `infix:«<»` as a *routine value*; FatRat vs Num answers differently there than the compiled operator), `proxy-list-transparency.t` (`is-deeply` does not FETCH `Proxy` list elements — reports `$(Proxy, Proxy)`), `emit-done-controlflow.t`, `error-reporting-quality.t`, `group-of.t`, `handles-proto-dispatch-mut-invocant.t`, `io-cathandle-lazy.t`, `leave-in-if-branch.t`, `multi-where-otf-dispatch.t`, `subscript-adverbs.t`, `throws-like-gather-sink.t`, `whatever-code-fixes.t` | one at a time |
+| individual gaps | `bigrat-sort-compare.t` (`cmp-ok` calls `infix:«<»` as a *routine value*; FatRat vs Num answers differently there than the compiled operator), `proxy-list-transparency.t` (`is-deeply` does not FETCH `Proxy` list elements — reports `$(Proxy, Proxy)`), `emit-done-controlflow.t`, `error-reporting-quality.t`, `group-of.t`, `handles-proto-dispatch-mut-invocant.t`, `io-cathandle-lazy.t`, `multi-where-otf-dispatch.t`, `subscript-adverbs.t`, `throws-like-gather-sink.t`, `whatever-code-fixes.t` | one at a time |
 
 `tmp/recheck.sh <file>.t …` runs the named files native / real / raku and is the
 per-file tool; `scripts/test-module-sweep.sh` is the full measurement. Note the


### PR DESCRIPTION
A whole-container assignment could be silently lost:

```raku
my @arr;
my sub push-one() { @arr.push('x') }   # closure capture -> shared container cell
push-one();

takes-container @arr, ['x'], 'reason', opt => 1;   # statement call, named arg
@arr = ();                                          # <- silently a no-op
say @arr.raku;                                      # ["x"]  (raku: [])
```

Every condition was needed: the caller's variable had to be a closure-captured
lexical (so it lives in a shared `ContainerRef` cell), it had to be passed to the
routine, and the call had to be a *statement* carrying a *named* argument. Call it
in expression position, pass positionals only, or drop the closure, and the
assignment worked.

## Root cause

A statement-level `Stmt::Call` with a named argument compiles to
`OpCode::ExecCallPairs`, which dispatches through the interpreter's `exec_call`
instead of the VM's `CallFunc` path. On return `exec_call` writes each aliased
container parameter back to the caller via `apply_rw_bindings_to_env`.

That writeback already knew not to *replace* a caller entry holding a live
`ContainerRef` — it writes the value through the cell so aliases survive — but the
guard only fired when the incoming value was a plain container
(`&& !updated.is_container_ref()`). An aliased container argument (compiled as
`WrapVarRef`) binds the parameter through a **fresh cell of its own**, so the
incoming value *was* a `ContainerRef`, the guard declined, and the callee's cell
was stored into the caller's env entry.

The caller's local slot still held the original cell, so the name then had two
cells: `@arr = ()` emptied the slot's cell, while `GetArrayVar` — which reads env
before locals — found the callee's copy, still holding the pre-call contents. Any
read that re-synced the two hid the problem, which is why inserting a `say @arr`
before the assignment made it disappear. Verified by printing cell identity at the
call boundary: `slot=cell@…9bb0 / env=cell@…9bb0` before, `slot=cell@…9bb0 /
env=cell@…77350` after.

## Fix

`apply_rw_bindings_to_env` now unwraps an incoming cell and writes its value
*through* the caller's cell (short-circuiting when both sides are already the same
cell), so the caller's cell identity is never replaced. The rule is unconditional
now: the caller's binding cell is only ever written through.

## Tests

- `t/named-arg-stmt-call-keeps-caller-cell.t` (+ `t/lib/NamedArgStmtCall.rakumod`)
  — array and hash shapes plus the positional-only statement call that always
  worked. Confirmed to fail 4/6 on the unfixed build and pass under `raku`.
- `make test`: `Files=2743, Tests=26156 … Result: PASS`.

Found running `t/` against the vendored upstream `Test.rakumod`
(`todo/tickets/vendor-real-test-module.md`): the real module's `is-deeply` is a
module routine, so `is-deeply @events, [...]` is exactly this call shape, and
`t/leave-in-if-branch.t`'s `@events = ()` between assertions never took effect.
That file now passes under `MUTSU_REAL_TEST=1` — 18 regressions left in that
campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)