### PR TITLE
fix(vm): a for loop binds its own topic even when `$_` has a local slot

### DIFF
--- a/news/2026-08/for-loop-topic-shadows-topic-param.md
+++ b/news/2026-08/for-loop-topic-shadows-topic-param.md
@@ -1,0 +1,49 @@
+# A `for` loop binds its own topic even when `$_` has a local slot
+
+A `for` block binds `$_` as its own implicit parameter, so it shadows any
+enclosing topic. mutsu got that right — except when the enclosing frame held
+`$_` in a **local slot**, which is what a routine's `$_` *parameter* produces:
+
+```raku
+sub f($_) {
+    for 1, 2, 3 { say $_ }      # raku: 1 2 3    mutsu: 99 99 99
+}
+f(99);
+```
+
+The loop bound its item into `env["_"]` only. But when `$_` occupies a local
+slot the compiler emits `GetLocal(slot)` for every read of `$_` in the frame,
+including inside the loop body, and the slot still held the argument. The topic
+of every iteration was therefore the routine's, not the loop's.
+
+`exec_given_op` had already solved exactly this for `given`/`with` (it mirrors
+the topic into the slot on entry and restores it on exit), which is why `given`
+and `map` were unaffected and only `for` diverged.
+
+The three `for` implementations — the general body loop, the integer-range fast
+path, and the two lazy/gather paths — now mirror each item into the topic slot
+alongside the `env` write, and restore the entry value on every exit path
+(normal, `last`/`next`, error), the same set of exits `restore_loop_topic`
+already covered for the env half. The slot is compiler-baked as
+`ForLoopSpec::topic_local` rather than resolved by a name scan at loop entry, so
+a loop in a frame without a `_` local (the overwhelmingly common case) pays
+nothing. It is deliberately distinct from `param_local`, which is the *named*
+loop parameter's slot: a `for @a -> $x { }` does not rebind `$_`, and folding
+the two would have flipped `writes_back_topic` and broken `$_ = X for @a`.
+
+Found while running the upstream Cro suite: `Cro::HTTP2::FrameSerializer` writes
+its frame header through
+
+```raku
+method !form-header(Cro::HTTP2::Frame $_) {
+    ...
+    for 16, 8...0 { $buf[$i] = ($num +> $_) +& 0xFF; $i++; }
+}
+```
+
+— a `$_` parameter with a `for` loop over the shift widths. Every shift used the
+frame object's slot instead of the loop's, so each length and stream-identifier
+byte came out as `$num +> 0`: a DATA frame of one byte serialized as
+`1,1,1,0,0,1,1,1,1,97` instead of `0,0,1,0,0,0,0,0,1,97`.
+
+Pin: `t/for-topic-shadows-topic-param.t` (also passes under `raku`).

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -278,6 +278,11 @@ impl Compiler {
         let param_local = param
             .as_ref()
             .and_then(|p| self.local_map.get(p.as_str()).copied());
+        // Only an implicit-topic loop rebinds `$_`; see `ForLoopSpec::topic_local`.
+        let topic_local = param
+            .is_none()
+            .then(|| self.local_map.get("_").copied())
+            .flatten();
         let source_var_names = Self::for_iterable_var_names(iterable);
         let source_var_locals = self.for_source_var_locals(&source_var_names);
         let loop_idx = self
@@ -285,6 +290,7 @@ impl Compiler {
             .emit(OpCode::ForLoop(Box::new(crate::opcode::ForLoopSpec {
                 param_idx,
                 param_local,
+                topic_local,
                 body_end: 0,
                 label: label.clone(),
                 arity,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1987,6 +1987,12 @@ impl Compiler {
                 let param_local = param
                     .as_ref()
                     .and_then(|p| self.local_map.get(p.as_str()).copied());
+                // Only an implicit-topic loop rebinds `$_`; see
+                // `ForLoopSpec::topic_local`.
+                let topic_local = param
+                    .is_none()
+                    .then(|| self.local_map.get("_").copied())
+                    .flatten();
                 let kv_mode = has_rw && Self::for_iterable_is_kv(iterable);
                 // Names of the loop's multi-params whose value is written back to
                 // the source each iteration. Only a *genuinely rw* param writes
@@ -2041,6 +2047,7 @@ impl Compiler {
                         .emit(OpCode::ForLoop(Box::new(crate::opcode::ForLoopSpec {
                             param_idx,
                             param_local,
+                            topic_local,
                             body_end: 0,
                             label: label.clone(),
                             arity,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -170,6 +170,18 @@ impl CompoundBaseOp {
 pub(crate) struct ForLoopSpec {
     pub(crate) param_idx: Option<u32>,
     pub(crate) param_local: Option<u32>,
+    /// Local slot the frame holds for the TOPIC (`_`), when it has one — a
+    /// `sub f ($_) { … }` parameter or a `my $_`. Distinct from `param_local`,
+    /// which is the *named* loop parameter's slot.
+    ///
+    /// A `for` block binds `$_` as its own implicit parameter, but mutsu keeps
+    /// the loop topic in `env`. When the enclosing frame also has a `_` slot the
+    /// body reads that slot (`GetLocal`), so the loop's topic went unseen and
+    /// `sub f($_) { for 1,2,3 { say $_ } }` printed the argument three times.
+    /// The loop mirrors each item into this slot and restores the entry value on
+    /// exit, exactly as `exec_given_op` does for `given`/`with`. Only set for an
+    /// implicit-topic loop (a named parameter does not rebind `$_`).
+    pub(crate) topic_local: Option<u32>,
     pub(crate) body_end: u32,
     pub(crate) label: Option<String>,
     pub(crate) arity: u32,

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -7,8 +7,13 @@ impl Interpreter {
     /// loop's topic must never survive into the enclosing scope. mutsu keeps the
     /// topic in env, so every exit path (normal, `last`/`next`, error) restores
     /// the value captured before the loop, or removes the key when there was
-    /// none.
-    pub(super) fn restore_loop_topic(&mut self, saved: Option<Value>) {
+    /// none. `saved_local` additionally restores the topic's *local slot* when
+    /// the frame has one — see [`Interpreter::save_loop_topic_local`].
+    pub(super) fn restore_loop_topic(
+        &mut self,
+        saved: Option<Value>,
+        saved_local: Option<(usize, Value)>,
+    ) {
         match saved {
             Some(v) => {
                 self.env_mut().insert("_".to_string(), v);
@@ -17,6 +22,29 @@ impl Interpreter {
                 self.env_mut().remove("_");
             }
         }
+        if let Some((slot, v)) = saved_local {
+            self.locals[slot] = v;
+        }
+    }
+
+    /// The frame's local slot for `$_` (compiler-baked in
+    /// [`ForLoopSpec::topic_local`]), together with its value on loop entry —
+    /// `None` when the topic has no slot in this frame, which is the common case.
+    ///
+    /// `code.locals` positions never move within a frame, so the slot index
+    /// stays valid across the body.
+    pub(super) fn save_loop_topic_local(&mut self, spec: &ForLoopSpec) -> Option<(usize, Value)> {
+        let slot = spec.topic_local? as usize;
+        Some((slot, self.locals.get(slot)?.clone()))
+    }
+
+    /// Bind the loop's implicit topic: `env["_"]` plus the frame's topic slot
+    /// when it has one (see [`Interpreter::save_loop_topic_local`]).
+    pub(super) fn set_loop_topic(&mut self, topic_local: Option<usize>, val: Value) {
+        if let Some(slot) = topic_local {
+            self.locals[slot] = val.clone();
+        }
+        self.env_mut().insert("_".to_string(), val);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -93,6 +121,10 @@ impl Interpreter {
         // implicit parameter), so the enclosing `$_` is restored on every exit —
         // normal, `last`/`next`, and error.
         let saved_topic = self.env().get("_").cloned();
+        // The topic's local slot, when this frame has one (see
+        // `save_loop_topic_local`): the loop must mirror each item into it.
+        let saved_topic_local = self.save_loop_topic_local(spec);
+        let topic_local = saved_topic_local.as_ref().map(|(s, _)| *s);
         let saved_topic_source = self.topic_source_var.take();
         let saved_quanthash_bind = std::mem::take(&mut self.quanthash_bind_params);
         // The tagged source name plus its compile-time-baked local slot (§1.5):
@@ -260,7 +292,7 @@ impl Interpreter {
             // Only set $_ when no named parameter is given (for @list { ... })
             // When -> $k is used, $_ should remain from the enclosing scope
             if param_name.is_none() {
-                self.env_mut().insert("_".to_string(), item.clone());
+                self.set_loop_topic(topic_local, item.clone());
             }
             if let Some(ref name) = param_name {
                 self.env_mut().insert(name.clone(), item.clone());
@@ -469,7 +501,7 @@ impl Interpreter {
                     }
                     Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         if param_name.is_none() {
-                            self.env_mut().insert("_".to_string(), item.clone());
+                            self.set_loop_topic(topic_local, item.clone());
                         }
                         if let Some(ref name) = param_name {
                             self.env_mut().insert(name.clone(), item.clone());
@@ -521,7 +553,7 @@ impl Interpreter {
                             if let Some(ref mut coll) = collected {
                                 Self::collect_loop_value(coll, v.clone());
                             } else {
-                                self.env_mut().insert("_".to_string(), v.clone());
+                                self.set_loop_topic(topic_local, v.clone());
                                 // Push return value on stack so enclosing compiled
                                 // closures can see it as the block result.
                                 self.stack.push(v);
@@ -652,7 +684,7 @@ impl Interpreter {
                         }
                         self.topic_source_var = saved_topic_source;
                         self.quanthash_bind_params = saved_quanthash_bind.clone();
-                        self.restore_loop_topic(saved_topic);
+                        self.restore_loop_topic(saved_topic, saved_topic_local);
                         self.pop_loop_local_scope(code);
                         return Err(e);
                     }
@@ -667,7 +699,7 @@ impl Interpreter {
                         {
                             self.unmark_readonly(name);
                         }
-                        self.restore_loop_topic(saved_topic.clone());
+                        self.restore_loop_topic(saved_topic.clone(), saved_topic_local.clone());
                         self.pop_loop_local_scope(code);
                         return Err(e);
                     }
@@ -756,7 +788,7 @@ impl Interpreter {
         }
         self.topic_source_var = saved_topic_source;
         self.quanthash_bind_params = saved_quanthash_bind.clone();
-        self.restore_loop_topic(saved_topic);
+        self.restore_loop_topic(saved_topic, saved_topic_local);
         if let Some(coll) = collected {
             let mut coll = coll;
             for (idx, name) in deferred_container_refs {

--- a/src/vm/vm_for_loop_intrange.rs
+++ b/src/vm/vm_for_loop_intrange.rs
@@ -23,6 +23,10 @@ impl Interpreter {
                 _ => unreachable!("ForLoop param must be a string constant"),
             });
         let saved_topic = self.env().get("_").cloned();
+        // The topic's local slot, when this frame has one (see
+        // `save_loop_topic_local`): the loop must mirror each item into it.
+        let saved_topic_local = self.save_loop_topic_local(spec);
+        let topic_local = saved_topic_local.as_ref().map(|(s, _)| *s);
         let saved_topic_source = self.topic_source_var.take();
         let was_topic_readonly = self.is_readonly("_");
 
@@ -134,6 +138,15 @@ impl Interpreter {
             if let Some(sym) = topic_sym {
                 self.env_mut().insert_sym(sym, item.clone());
             }
+            // The topic's own local slot (a `sub f ($_) {…}` parameter), which
+            // the body reads via `GetLocal` — see `save_loop_topic_local`. This
+            // is NOT `spec.param_local` (that is the *named* loop parameter's
+            // slot); an implicit-topic loop has none.
+            if param_name.is_none()
+                && let Some(slot) = topic_local
+            {
+                self.locals[slot] = item.clone();
+            }
             if let Some(sym) = param_sym {
                 self.env_mut().insert_sym(sym, item.clone());
                 if let Some(alias) = caret_alias_sym {
@@ -167,7 +180,7 @@ impl Interpreter {
                     }
                     Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         if param_name.is_none() {
-                            self.env_mut().insert("_".to_string(), item.clone());
+                            self.set_loop_topic(topic_local, item.clone());
                         }
                         if let Some(ref name) = param_name {
                             self.env_mut().insert(name.clone(), item.clone());
@@ -184,7 +197,7 @@ impl Interpreter {
                             && Self::label_matches(&e.label, &spec.label) =>
                     {
                         if let Some(v) = e.return_value {
-                            self.env_mut().insert("_".to_string(), v.clone());
+                            self.set_loop_topic(topic_local, v.clone());
                             self.stack.push(v);
                         }
                         break 'for_loop;
@@ -243,7 +256,7 @@ impl Interpreter {
                             self.unmark_readonly("_");
                         }
                         self.topic_source_var = saved_topic_source;
-                        self.restore_loop_topic(saved_topic);
+                        self.restore_loop_topic(saved_topic, saved_topic_local);
                         // Gather suspend: pop (body resumes and re-pushes).
                         self.pop_loop_local_scope(code);
                         return Err(e);
@@ -257,7 +270,7 @@ impl Interpreter {
                         if !was_topic_readonly {
                             self.unmark_readonly("_");
                         }
-                        self.restore_loop_topic(saved_topic.clone());
+                        self.restore_loop_topic(saved_topic.clone(), saved_topic_local.clone());
                         self.pop_loop_local_scope(code);
                         return Err(e);
                     }
@@ -282,7 +295,7 @@ impl Interpreter {
             self.unmark_readonly("_");
         }
         self.topic_source_var = saved_topic_source;
-        self.restore_loop_topic(saved_topic);
+        self.restore_loop_topic(saved_topic, saved_topic_local);
         // Defer restoring the named loop param's prior binding to the paired
         // `RestoreForParam` opcode (after the post/LAST phasers), matching
         // `exec_for_loop_body`. Only reached on normal completion / `last` /

--- a/src/vm/vm_for_loop_lazy.rs
+++ b/src/vm/vm_for_loop_lazy.rs
@@ -40,6 +40,10 @@ impl Interpreter {
                 _ => unreachable!("ForLoop param must be a string constant"),
             });
         let saved_topic = self.env().get("_").cloned();
+        // The topic's local slot, when this frame has one (see
+        // `save_loop_topic_local`): the loop must mirror each item into it.
+        let saved_topic_local = self.save_loop_topic_local(spec);
+        let topic_local = saved_topic_local.as_ref().map(|(s, _)| *s);
         let saved_topic_source = self.topic_source_var.take();
         let was_topic_readonly = self.is_readonly("_");
 
@@ -87,7 +91,7 @@ impl Interpreter {
 
             self.topic_source_var = None;
             if param_name.is_none() {
-                self.env_mut().insert("_".to_string(), item.clone());
+                self.set_loop_topic(topic_local, item.clone());
             }
             if let Some(ref name) = param_name {
                 self.env_mut().insert(name.clone(), item.clone());
@@ -119,7 +123,7 @@ impl Interpreter {
                     }
                     Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         if param_name.is_none() {
-                            self.env_mut().insert("_".to_string(), item.clone());
+                            self.set_loop_topic(topic_local, item.clone());
                         }
                         if let Some(ref name) = param_name {
                             self.env_mut().insert(name.clone(), item.clone());
@@ -190,7 +194,7 @@ impl Interpreter {
                             self.unmark_readonly("_");
                         }
                         self.topic_source_var = saved_topic_source;
-                        self.restore_loop_topic(saved_topic);
+                        self.restore_loop_topic(saved_topic, saved_topic_local);
                         return Err(e);
                     }
                     Err(e) => {
@@ -202,7 +206,7 @@ impl Interpreter {
                         if !was_topic_readonly {
                             self.unmark_readonly("_");
                         }
-                        self.restore_loop_topic(saved_topic.clone());
+                        self.restore_loop_topic(saved_topic.clone(), saved_topic_local.clone());
                         return Err(e);
                     }
                 }
@@ -221,7 +225,7 @@ impl Interpreter {
             self.unmark_readonly("_");
         }
         self.topic_source_var = saved_topic_source;
-        self.restore_loop_topic(saved_topic);
+        self.restore_loop_topic(saved_topic, saved_topic_local);
         Ok(())
     }
 
@@ -250,6 +254,10 @@ impl Interpreter {
         let _writes_back_topic =
             spec.param_idx.is_none() && spec.param_local.is_none() && spec.arity <= 1;
         let saved_topic = self.env().get("_").cloned();
+        // The topic's local slot, when this frame has one (see
+        // `save_loop_topic_local`): the loop must mirror each item into it.
+        let saved_topic_local = self.save_loop_topic_local(spec);
+        let topic_local = saved_topic_local.as_ref().map(|(s, _)| *s);
         let saved_topic_source = self.topic_source_var.take();
         let mut collected = if spec.collect { Some(Vec::new()) } else { None };
         let stack_base = if spec.collect {
@@ -299,7 +307,7 @@ impl Interpreter {
 
             // Set up parameters
             if param_name.is_none() {
-                self.env_mut().insert("_".to_string(), item.clone());
+                self.set_loop_topic(topic_local, item.clone());
             }
             if let Some(ref name) = param_name {
                 self.env_mut().insert(name.clone(), item.clone());
@@ -342,7 +350,7 @@ impl Interpreter {
                     }
                     Err(e) if e.is_redo() && Self::label_matches(&e.label, &spec.label) => {
                         if param_name.is_none() {
-                            self.env_mut().insert("_".to_string(), item.clone());
+                            self.set_loop_topic(topic_local, item.clone());
                         }
                         if let Some(ref name) = param_name {
                             self.env_mut().insert(name.clone(), item.clone());
@@ -364,7 +372,7 @@ impl Interpreter {
                         {
                             self.unmark_readonly(name);
                         }
-                        self.restore_loop_topic(saved_topic.clone());
+                        self.restore_loop_topic(saved_topic.clone(), saved_topic_local.clone());
                         return Err(e);
                     }
                 }
@@ -381,7 +389,7 @@ impl Interpreter {
             self.unmark_readonly(name);
         }
         self.topic_source_var = saved_topic_source;
-        self.restore_loop_topic(saved_topic);
+        self.restore_loop_topic(saved_topic, saved_topic_local);
         if let Some(coll) = collected {
             self.stack.push(Value::array(coll));
         }

--- a/t/for-topic-shadows-topic-param.t
+++ b/t/for-topic-shadows-topic-param.t
@@ -1,0 +1,70 @@
+use Test;
+
+plan 6;
+
+# A `for` block binds `$_` as its own implicit parameter, so it must shadow an
+# enclosing `$_` — including one that came from a routine's `$_` PARAMETER,
+# which occupies a local slot the loop used to leave untouched.
+
+sub topic-values() {
+    my @b;
+    for 1, 2, 3 { @b.push($_) }
+    @b;
+}
+is topic-values().join(','), '1,2,3', 'a plain for loop binds the topic';
+
+sub param-topic($_) {
+    my @b;
+    for 1, 2, 3 { @b.push($_) }
+    @b;
+}
+is param-topic(99).join(','), '1,2,3', 'a for loop shadows a `$_` parameter';
+
+sub param-topic-restored($_) {
+    my @b;
+    @b.push($_);
+    for 1, 2 { @b.push($_) }
+    @b.push($_);
+    @b;
+}
+is param-topic-restored(99).join(','), '99,1,2,99',
+    'the `$_` parameter is restored after the loop';
+
+# A nested for loop rebinds and restores the topic at each level.
+sub nested-topic($_) {
+    my @b;
+    for 1, 2 -> $outer {
+        for 'a', 'b' { @b.push("$outer$_") }
+    }
+    @b.push($_);
+    @b;
+}
+is nested-topic(99).join(','), '1a,1b,2a,2b,99',
+    'a nested for loop rebinds the topic at each level';
+
+# The same through `given`/`when`, where the topic is re-bound twice.
+class Shifter {
+    method !bytes($_) {
+        my @b;
+        given $_ {
+            when Int {
+                my $num = 1;
+                for 16, 8...0 { @b.push(($num +> $_) +& 0xFF) }
+            }
+        }
+        @b;
+    }
+    method go() { self!bytes(5) }
+}
+is Shifter.go.join(','), '0,0,1',
+    'a for loop inside a when block binds its own topic';
+
+# A range-driven loop takes a different VM path; check it too.
+sub param-topic-range($_) {
+    my @b;
+    for 1..3 { @b.push($_) }
+    @b.push($_);
+    @b;
+}
+is param-topic-range(99).join(','), '1,2,3,99',
+    'a range for loop shadows and restores a `$_` parameter';


### PR DESCRIPTION
A `for` block binds `$_` as its own implicit parameter, so it shadows any
enclosing topic. mutsu got that right — except when the enclosing frame held
`$_` in a **local slot**, which is what a routine's `$_` *parameter* produces:

```raku
sub f($_) {
    for 1, 2, 3 { say $_ }      # raku: 1 2 3    mutsu: 99 99 99
}
f(99);
```

The loop bound its item into `env["_"]` only. But when `$_` occupies a local slot
the compiler emits `GetLocal(slot)` for every read of `$_` in the frame,
including inside the loop body, and that slot still held the argument — so the
topic of every iteration was the routine's, not the loop's.

`exec_given_op` had already solved exactly this for `given`/`with` (mirror the
topic into the slot on entry, restore on exit), which is why `given` and `map`
were unaffected and only `for` diverged.

### The fix

All three `for` implementations — the general body loop, the integer-range fast
path, and the two lazy/gather paths — now mirror each item into the topic slot
alongside the `env` write, and restore the entry value on every exit path
(normal, `last`/`next`, error), the same set `restore_loop_topic` already covered
for the env half.

The slot is compiler-baked as `ForLoopSpec::topic_local` rather than resolved by
a name scan at loop entry, so a loop in a frame without a `_` local (the
overwhelmingly common case) pays nothing. It is deliberately **distinct from
`param_local`**, which is the *named* loop parameter's slot: `for @a -> $x { }`
does not rebind `$_`, and folding the two would have flipped `writes_back_topic`
and broken `$_ = X for @a`.

### Where it came from

Upstream `Cro::HTTP2::FrameSerializer` writes its frame header with

```raku
method !form-header(Cro::HTTP2::Frame $_) {
    ...
    for 16, 8...0 { $buf[$i] = ($num +> $_) +& 0xFF; $i++; }
}
```

— a `$_` parameter with a `for` loop over the shift widths. Every shift used the
frame object's slot instead of the loop's, so a one-byte DATA frame serialized as
`1,1,1,0,0,1,1,1,1,97` instead of `0,0,1,0,0,0,0,0,1,97`.

Pin: `t/for-topic-shadows-topic-param.t` (also passes under `raku`). `make test`
is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)