### PR TITLE
fix(runtime): an EVAL'd `my` stays scoped to the EVAL

### DIFF
--- a/news/2026-08/eval-my-stays-scoped-to-the-eval.md
+++ b/news/2026-08/eval-my-stays-scoped-to-the-eval.md
@@ -1,0 +1,40 @@
+# An EVAL'd `my` no longer clobbers a same-named caller lexical
+
+```raku
+my $a = 10;
+EVAL 'my $a = 999';
+say $a;          # mutsu printed 999; raku prints 10
+```
+
+A `my` inside EVAL'd code is lexically scoped to that EVAL. mutsu already knew
+this for *new* names — `parse_and_eval_with_operators` snapshotted the plain
+user-lexical keys present before the snippet ran and dropped any the snippet
+introduced, so `EVAL 'my $y'; $y` stayed undeclared. But when the caller already
+used the name, the declaration **shadowed** it, and mutsu's shared env has one
+entry per name: the declaration overwrote the caller's value in place, and the
+key already existed so nothing removed it afterwards.
+
+Two changes fix it:
+
+- The snippet's parsed AST is walked for the names it declares with `my`
+  (`collect_eval_declared_lexical_keys`, skipping `our`/`state`/dynamics and not
+  descending into routine or class bodies, whose lexicals live in their own
+  frame). The caller's value for exactly those names is snapshotted before the
+  run and restored afterwards. A plain assignment — `EVAL '$a = 999'`, which
+  *must* write through to the caller — is not a declaration and is untouched.
+- The post-EVAL lexical cleanup now runs whatever the snippet did. It used to sit
+  behind `?` on the evaluation result, so a snippet that *threw* skipped it
+  entirely. That is the common case in practice: `throws-like 'my $x = 999; die
+  "x"', Exception` is a standard assertion shape, and under the vendored upstream
+  `Test.rakumod` it left `$x` at 999 in the file that called it.
+
+Pinned by `t/eval-my-shadows-caller-lexical.t` — scalar, array and hash shapes,
+with and without a throw, through a closure frame and through a routine frame,
+plus the assignment case that must still write through and the EVAL's own view of
+its declaration. Six of its ten assertions fail without the fix.
+
+Found while running `t/` against the vendored upstream `Test.rakumod`
+(`todo/tickets/vendor-real-test-module.md`): the real `throws-like` EVALs its
+string argument, so `t/throws-like-outer-var-writeback.t`'s "a fresh `my` inside
+`throws-like` does not clobber the caller" read 999. That file now passes under
+`MUTSU_REAL_TEST=1`.

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -126,6 +126,22 @@ impl Interpreter {
                     })
                     .copied()
                     .collect();
+                // Removing only the *new* keys is not enough: a `my` whose name the
+                // caller already uses SHADOWS it, and the shared env has one entry
+                // per name, so the declaration overwrites the caller's value in
+                // place. `my $a = 10; EVAL 'my $a = 999'; say $a` printed 999.
+                // Collect the names this snippet declares and snapshot exactly
+                // those, so they are restored afterwards while a plain assignment
+                // (`EVAL '$a = 999'`, which must write through) is untouched.
+                let eval_shadowed: Vec<(crate::symbol::Symbol, Option<Value>)> =
+                    Self::collect_eval_declared_lexical_keys(&stmts)
+                        .into_iter()
+                        .map(|key| {
+                            let sym = crate::symbol::Symbol::intern(&key);
+                            let prev = self.env.get_sym(sym).cloned();
+                            (sym, prev)
+                        })
+                        .collect();
                 // Snapshot stubs already pending in the outer unit. Class/package
                 // decls install at BEGIN time in raku, so an outer stub that is
                 // defined later in the file is NOT undefined from the EVAL's view;
@@ -142,26 +158,33 @@ impl Interpreter {
                 // private call in the EVAL'd string errors even if a preceding
                 // `return` would short-circuit it at runtime.
                 self.validate_private_calls_against_self(&stmts)?;
-                let value = self.eval_block_value_opts(&stmts, true)?;
-                if self.eval_result_is_unresolved_bareword(&stmts, &value) {
-                    return Err(RuntimeError::undeclared_symbols("Undeclared name"));
+                // The lexical cleanup below has to run whatever the snippet did, so
+                // carry the outcome instead of `?`-ing out of the middle: a
+                // `my` in code that then *dies* (`throws-like 'my $x = 1; die …'`
+                // is a common assertion shape) is still EVAL-scoped.
+                let mut outcome = self.eval_block_value_opts(&stmts, true);
+                if let Ok(value) = &outcome
+                    && self.eval_result_is_unresolved_bareword(&stmts, value)
+                {
+                    outcome = Err(RuntimeError::undeclared_symbols("Undeclared name"));
                 }
-                self.check_unresolved_stubs_excluding(&eval_pre_stubs)?;
+                if outcome.is_ok()
+                    && let Err(e) = self.check_unresolved_stubs_excluding(&eval_pre_stubs)
+                {
+                    outcome = Err(e);
+                }
                 // When the last statement is an assignment, the VM pops the
                 // value from the stack, so eval_block_value returns Nil/Any.
                 // In Raku, EVAL returns the value of the last expression,
                 // which for assignments is the assigned value.
-                let value = if value.is_nil()
-                    || matches!(value.view(), ValueView::Package(name) if name == "Any")
+                if let Ok(value) = &mut outcome
+                    && (value.is_nil()
+                        || matches!(value.view(), ValueView::Package(name) if name == "Any"))
+                    && let Some(Stmt::Assign { name, .. }) = stmts.last()
+                    && let Some(assigned) = self.env.get(name).cloned()
                 {
-                    if let Some(Stmt::Assign { name, .. }) = stmts.last() {
-                        self.env.get(name).cloned().unwrap_or(value)
-                    } else {
-                        value
-                    }
-                } else {
-                    value
-                };
+                    *value = assigned;
+                }
                 // Drop the EVAL's own `my` lexicals (plain user lexical keys that
                 // did not exist before) so they don't leak into the caller's pad.
                 let leaked: Vec<crate::symbol::Symbol> = self
@@ -178,7 +201,19 @@ impl Interpreter {
                 for key in leaked {
                     self.env.remove_sym(key);
                 }
-                Ok(value)
+                // Restore the caller's value for each name the snippet re-declared,
+                // so the EVAL's `my` stayed scoped to the EVAL.
+                for (sym, prev) in eval_shadowed {
+                    match prev {
+                        Some(v) => {
+                            self.env.insert_sym(sym, v);
+                        }
+                        None => {
+                            self.env.remove_sym(sym);
+                        }
+                    }
+                }
+                outcome
             }
             Err(parse_err) => {
                 // BEGIN blocks should execute even when a later parse error occurs.
@@ -194,6 +229,66 @@ impl Interpreter {
                 Err(parse_err)
             }
         }
+    }
+
+    /// The env keys of the `my` lexicals an EVAL'd snippet declares, in the form
+    /// the environment uses (scalars sigil-less, `@`/`%` keeping their sigil).
+    ///
+    /// Only plain `my` declarations count: `our` is package-scoped and `state`
+    /// keeps its own cell, and neither shadows a caller lexical the way a `my`
+    /// does. Nested blocks and loop bodies are walked (a `my` there is even more
+    /// clearly EVAL-scoped), but routine/class bodies are not — their lexicals
+    /// live in their own frame and never reach the caller's pad by this route.
+    fn collect_eval_declared_lexical_keys(stmts: &[Stmt]) -> HashSet<String> {
+        fn env_key(name: &str) -> Option<String> {
+            let name = name.strip_prefix('\\').unwrap_or(name);
+            let key = match name.strip_prefix('$') {
+                // Scalars are stored sigil-less (`$a` -> `"a"`).
+                Some(bare) => bare,
+                None => name,
+            };
+            crate::env::is_plain_user_lexical(key).then(|| key.to_string())
+        }
+        fn walk(stmts: &[Stmt], out: &mut HashSet<String>) {
+            for stmt in stmts {
+                match stmt {
+                    Stmt::VarDecl {
+                        name,
+                        is_state,
+                        is_our,
+                        is_dynamic,
+                        ..
+                    } => {
+                        if !*is_state
+                            && !*is_our
+                            && !*is_dynamic
+                            && let Some(key) = env_key(name)
+                        {
+                            out.insert(key);
+                        }
+                    }
+                    Stmt::For { body, .. }
+                    | Stmt::While { body, .. }
+                    | Stmt::Loop { body, .. }
+                    | Stmt::Block(body)
+                    | Stmt::SyntheticBlock(body)
+                    | Stmt::Default(body)
+                    | Stmt::Catch(body) => walk(body, out),
+                    Stmt::If {
+                        then_branch,
+                        else_branch,
+                        ..
+                    } => {
+                        walk(then_branch, out);
+                        walk(else_branch, out);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let mut out = HashSet::new();
+        walk(stmts, &mut out);
+        out
     }
 
     /// When EVAL is called inside a class body, method declarations should be

--- a/t/eval-my-shadows-caller-lexical.t
+++ b/t/eval-my-shadows-caller-lexical.t
@@ -1,0 +1,55 @@
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# A `my` inside EVAL'd code is scoped to that EVAL. When the caller happens to
+# use the same name the declaration SHADOWS it, so the caller's variable must be
+# untouched — including when the snippet then throws, which is the shape
+# `throws-like 'my $x = ...; die ...'` produces.
+
+plan 10;
+
+my $a = 10;
+EVAL 'my $a = 999';
+is $a, 10, 'EVAL my does not clobber a same-named caller scalar';
+
+my $b = 10;
+try { EVAL 'my $b = 999; die "boom"' };
+is $b, 10, 'and not when the snippet dies either';
+
+my $c = 10;
+try { EVAL 'my $c = 999; my $extra = 1; die "boom"' };
+is $c, 10, 'a second declaration in the snippet changes nothing';
+
+# A plain assignment still writes through — that is not a declaration.
+my $d = 10;
+EVAL '$d = 999';
+is $d, 999, 'EVAL assignment to a caller scalar still writes through';
+
+my $e = 10;
+try { EVAL '$e = 999; die "boom"' };
+is $e, 999, 'partial work before a throw survives';
+
+# Containers take the same rule.
+my @arr = 1, 2;
+try { EVAL 'my @arr = 7, 8, 9; die "boom"' };
+is-deeply @arr, [1, 2], 'EVAL my does not clobber a same-named caller array';
+
+my %h = a => 1;
+try { EVAL 'my %h = b => 2; die "boom"' };
+is-deeply %h, {a => 1}, 'EVAL my does not clobber a same-named caller hash';
+
+# The declaration is still visible *inside* the EVAL, and is its value.
+is EVAL('my $f = 42; $f'), 42, 'the EVAL sees its own declaration';
+
+# It must not leak as a new name either (the pre-existing rule).
+my $g = 10;
+{
+    my $s = sub { try { EVAL 'my $g = 999; die "boom"' } };
+    $s();
+}
+is $g, 10, 'a closure frame between the caller and the EVAL changes nothing';
+
+sub via-routine($code) { try { EVAL $code } }
+my $h = 10;
+via-routine('my $h = 999; die "boom"');
+is $h, 10, 'a routine frame between the caller and the EVAL changes nothing';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -325,21 +325,26 @@ Exit status was measured for the first time and is already faithful — a failin
 assertion exits 1, a short plan exits 255 — which is what `prove` reads, so
 step 3 does not need work there.
 
-### Triaged, 18 left (2026-08-02)
+### Triaged, 17 left (2026-08-02)
 
 `module-file-var-and-callframe.t` now passes, and so does `leave-in-if-branch.t`
 — its `@events = ()` between assertions was silently dropped because the real
 module's `is-deeply` is a *module routine*, making `is-deeply @events, [...]` a
 statement call with a named argument, which severed the caller's container cell
 (`news/2026-08/named-arg-statement-call-keeps-the-caller-cell.md`, pin
-`t/named-arg-stmt-call-keeps-caller-cell.t`). The other 18 all read
+`t/named-arg-stmt-call-keeps-caller-cell.t`). So does
+`throws-like-outer-var-writeback.t` — the real `throws-like` EVALs its string
+argument, and an EVAL'd `my` clobbered a same-named caller lexical (it was NOT
+a native-provider-shaped pin after all;
+`news/2026-08/eval-my-stays-scoped-to-the-eval.md`, pin
+`t/eval-my-shadows-caller-lexical.t`). The other 17 all read
 `native / real=FAIL / raku` — rakudo runs the *same module* over the same file
 successfully, so the difference is genuinely in mutsu.
 
 | group | files | note |
 | --- | --- | --- |
 | exception-class hierarchy | `block-lexical-scope.t`, `gate-b-callee-name-collision-and-deref-capture.t`, `undeclared-when-type.t` | all fail on `right exception type (X::Undeclared / X::Comp::Group)` — one cause, `todo/deep/exception-class-hierarchy-is-mostly-unregistered.md` |
-| the pin asserts *native-provider* behaviour | `qualified-call-does-not-alias-builtin.t` (asserts `Test::ok(1)` **dies** — under the real module `Test::ok` legitimately exists), `test-assertion-line-number.t`, `throws-like-outer-var-writeback.t` | re-point the test file; not an interpreter gap |
+| the pin asserts *native-provider* behaviour | `qualified-call-does-not-alias-builtin.t` (asserts `Test::ok(1)` **dies** — under the real module `Test::ok` legitimately exists), `test-assertion-line-number.t` | re-point the test file; not an interpreter gap |
 | deferred `Seq` reification destroys the value | `is-lazy-io-lines.t` | `todo/deep/deferred-seq-materialization-destroys-the-original.md` — the real `is` opens with `$got.defined`, which guts a lazy `.lines` |
 | individual gaps | `bigrat-sort-compare.t` (`cmp-ok` calls `infix:«<»` as a *routine value*; FatRat vs Num answers differently there than the compiled operator), `proxy-list-transparency.t` (`is-deeply` does not FETCH `Proxy` list elements — reports `$(Proxy, Proxy)`), `emit-done-controlflow.t`, `error-reporting-quality.t`, `group-of.t`, `handles-proto-dispatch-mut-invocant.t`, `io-cathandle-lazy.t`, `multi-where-otf-dispatch.t`, `subscript-adverbs.t`, `throws-like-gather-sink.t`, `whatever-code-fixes.t` | one at a time |
 


### PR DESCRIPTION
```raku
my $a = 10;
EVAL 'my $a = 999';
say $a;          # mutsu printed 999; raku prints 10
```

## Root cause

A `my` inside EVAL'd code is lexically scoped to that EVAL. mutsu already knew this
for *new* names — `parse_and_eval_with_operators` snapshots the plain user-lexical
keys present before the snippet runs and drops any the snippet introduced, so
`EVAL 'my $y'; $y` stays undeclared. But when the caller already used the name, the
declaration **shadowed** it, and mutsu's shared env has one entry per name: the
declaration overwrote the caller's value in place, and the key already existed so
nothing removed it afterwards.

A second half made it worse in exactly the shape that matters: the post-EVAL
lexical cleanup sat behind `?` on the evaluation result, so a snippet that *threw*
skipped it entirely. `throws-like 'my $x = 999; die "x"', Exception` is a standard
assertion shape.

## Fix

- Walk the snippet's parsed AST for the names it declares with `my`
  (`collect_eval_declared_lexical_keys`; skips `our`/`state`/dynamics and does not
  descend into routine or class bodies, whose lexicals live in their own frame),
  snapshot the caller's value for exactly those names, and restore them afterwards.
  A plain assignment — `EVAL '$a = 999'`, which *must* write through — is not a
  declaration and is untouched.
- Carry the evaluation outcome instead of `?`-ing out of the middle, so the cleanup
  runs on the throwing path too.

## Tests

- `t/eval-my-shadows-caller-lexical.t` — scalar/array/hash, with and without a
  throw, through a closure frame and through a routine frame, plus the assignment
  case that must still write through and the EVAL's own view of its declaration.
  **6 of its 10 assertions fail without the fix**; all 10 pass under `raku`.
- `make test`: `Files=2742, Tests=26150 … Result: PASS`.
- The 293 whitelisted roast files that mention `EVAL`, on a release build:
  `Files=293, Tests=23095 … Result: PASS`.

Found running `t/` against the vendored upstream `Test.rakumod`
(`todo/tickets/vendor-real-test-module.md`): the real `throws-like` EVALs its
string argument, so `t/throws-like-outer-var-writeback.t`'s "a fresh `my` inside
`throws-like` does not clobber the caller" read 999. That file now passes under
`MUTSU_REAL_TEST=1` — and it turned out not to be a native-provider-shaped pin
after all, which the ledger update records. 17 regressions left in that campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)