### PR TITLE
docs(todo): two blockers found under the real Test module, and 15 left

### DIFF
--- a/todo/deep/cache-on-a-lazy-seq-must-not-answer-seq.md
+++ b/todo/deep/cache-on-a-lazy-seq-must-not-answer-seq.md
@@ -1,0 +1,60 @@
+# `.cache` on a genuinely-lazy Seq still answers `Seq` — and that crashes `is-deeply`
+
+`Seq.cache` returns the underlying `List`. mutsu returns a `List` for every
+ordinary Seq, but for a *genuinely lazy* one it returns the lazy value unchanged,
+whose `.^name` is `Seq`:
+
+```raku
+my $cat := IO::CatHandle.new: tmpfile("a1\na2"), tmpfile("b1\nb2");
+my $m = $cat.handles.map({ 1 });
+say $m.cache.^name;    # raku: List    mutsu: Seq
+say $m.List.^name;     # raku: List    mutsu: Seq
+```
+
+## Why it is not cosmetic: it aborts the process
+
+The vendored upstream `Test.rakumod` dispatches `is-deeply` through Seq-narrowing
+candidates that peel the laziness off by calling `.cache`:
+
+```raku
+multi sub is-deeply(Seq:D $got, Seq:D $expected, $reason = '') is export {
+    is-deeply $got.cache, $expected.cache, $reason;
+}
+```
+
+If `$got.cache` is still `Seq:D` the call re-dispatches to the *same* candidate,
+forever. Under `MUTSU_REAL_TEST=1`, `t/io-cathandle-lazy.t` does not fail — it
+dies with `fatal runtime error: stack overflow, aborting` and dumps core.
+
+Minimal reproduction (needs no `Test`, ~10 lines): build a lazy Seq as above and
+call `.cache` twice.
+
+## Two separable gaps
+
+1. **`.cache` / `.List` on a genuinely-lazy list.** `methods_0arg/collection.rs`'s
+   `"cache"` arm deliberately keeps a `LazyList` lazy (correct — Rakudo's `.cache`
+   reifies on demand, it does not force), but mutsu has no *lazy List* value: a
+   `LazyList` reports `Seq`. raku's answer is a lazy `List`, so the type changes
+   while the laziness does not. Giving `LazyList` a "this is a List, not a Seq"
+   bit — or a distinct lazy-List representation — is the real fix, and it is a
+   Value-representation question (PLAN §3 lazy-seq).
+2. **`IO::CatHandle.handles` is wrongly lazy, and wrongly an Array.**
+
+   | | raku | mutsu |
+   | --- | --- | --- |
+   | `$cat.handles.^name` | `Seq` | `Array` |
+   | `$cat.handles.is-lazy` | `False` | `True` |
+
+   Fixing this alone would take `t/io-cathandle-lazy.t` out of the crash, but it
+   leaves gap 1 for every genuinely-lazy Seq that reaches `is-deeply`.
+
+Do gap 1; gap 2 is a correctness fix worth doing on its own either way.
+
+## Also in that file (separate, not a crash)
+
+`is-deeply $cat.lines, ("a", "b", "c")` reports `got: ("a", "b", "c").Seq` — the
+real `is-deeply`'s `eqv` compares a Seq against a List and says no, where raku's
+Seq-narrowing candidate has already turned both into Lists. Same root as gap 1.
+
+Found in the vendored-`Test.rakumod` campaign,
+`todo/tickets/vendor-real-test-module.md`.

--- a/todo/tickets/use-fatal-leaks-out-of-a-sub-or-do-block.md
+++ b/todo/tickets/use-fatal-leaks-out-of-a-sub-or-do-block.md
@@ -15,7 +15,12 @@ $ mutsu -e 'my $x = do { use fatal; 1 }; my $f = "bar"[5]; say "soft " ~ $f.^nam
 Index out of range. Is: 5, ...     # do block: leaks
 ```
 
-`raku` keeps all three scoped.
+```
+$ mutsu -e 'my $c = { use fatal; 1 }; $c(); my $f = "bar"[5]; say "soft " ~ $f.^name'
+Index out of range. Is: 5, ...     # closure VALUE: leaks
+```
+
+`raku` keeps all four scoped.
 
 ## Where the working case gets it right
 
@@ -24,7 +29,9 @@ The compiler wraps a *statement* block that contains a `use` in
 `has_use_stmt`), and `push_import_scope` / `pop_import_scope`
 (`runtime/runtime_module.rs`) save and restore `newline_mode`, `strict_mode`,
 `fatal_mode` and `monkey_typing` along with the function/class registries. A
-`sub` body and an `Expr::DoBlock` do not go through that arm.
+`sub` body, an `Expr::DoBlock`, and a closure value's body do not go through
+that arm — they are compiled by `compile_block_raw` / `compile_block_value_opts`,
+which never emit the pair.
 
 Note the arm order in `compiler/stmt.rs`: `has_let_deep` is tested *before*
 `has_use_stmt`, so a block containing both `let` and `use` skips the import
@@ -39,3 +46,23 @@ file). Extending the import scope to routine bodies is a different, wider change
 — `pop_import_scope` also un-registers functions and classes declared since the
 push, and its doc comment records several hard-won exceptions — so it wants its
 own pass and its own roast run rather than riding along.
+
+A narrower option worth weighing first: the leak is only about the *pragma
+flags* (`fatal_mode`, `strict_mode`, `newline_mode`, `monkey_typing`), not
+about the registries `pop_import_scope` also rolls back. A dedicated
+pragma-scope opcode pair around any block/routine body whose statements contain
+a `use`/`no` would fix all four shapes without touching function/class
+registration at all.
+
+## Where it bites
+
+Under `MUTSU_REAL_TEST=1`, `t/whatever-code-fixes.t`:
+
+```raku
+throws-like { use fatal; "a".map: *.Int }, X::Str::Numeric, '...';
+lives-ok { "a".map: *.Int }, 'without fatal, a map of Failures is a soft list';
+```
+
+The real `Test.rakumod` runs the first block as a plain Callable, so its
+`use fatal` escapes and the *next* assertion throws. See
+`todo/tickets/vendor-real-test-module.md`.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -325,7 +325,7 @@ Exit status was measured for the first time and is already faithful — a failin
 assertion exits 1, a short plan exits 255 — which is what `prove` reads, so
 step 3 does not need work there.
 
-### Triaged, 17 left (2026-08-02)
+### Triaged, 15 left (2026-08-02)
 
 `module-file-var-and-callframe.t` now passes, and so does `leave-in-if-branch.t`
 — its `@events = ()` between assertions was silently dropped because the real
@@ -337,7 +337,9 @@ statement call with a named argument, which severed the caller's container cell
 argument, and an EVAL'd `my` clobbered a same-named caller lexical (it was NOT
 a native-provider-shaped pin after all;
 `news/2026-08/eval-my-stays-scoped-to-the-eval.md`, pin
-`t/eval-my-shadows-caller-lexical.t`). The other 17 all read
+`t/eval-my-shadows-caller-lexical.t`). Those two fixes also freed
+`handles-proto-dispatch-mut-invocant.t` and `multi-where-otf-dispatch.t`
+without further work. The other 15 all read
 `native / real=FAIL / raku` — rakudo runs the *same module* over the same file
 successfully, so the difference is genuinely in mutsu.
 
@@ -346,7 +348,7 @@ successfully, so the difference is genuinely in mutsu.
 | exception-class hierarchy | `block-lexical-scope.t`, `gate-b-callee-name-collision-and-deref-capture.t`, `undeclared-when-type.t` | all fail on `right exception type (X::Undeclared / X::Comp::Group)` — one cause, `todo/deep/exception-class-hierarchy-is-mostly-unregistered.md` |
 | the pin asserts *native-provider* behaviour | `qualified-call-does-not-alias-builtin.t` (asserts `Test::ok(1)` **dies** — under the real module `Test::ok` legitimately exists), `test-assertion-line-number.t` | re-point the test file; not an interpreter gap |
 | deferred `Seq` reification destroys the value | `is-lazy-io-lines.t` | `todo/deep/deferred-seq-materialization-destroys-the-original.md` — the real `is` opens with `$got.defined`, which guts a lazy `.lines` |
-| individual gaps | `bigrat-sort-compare.t` (`cmp-ok` calls `infix:«<»` as a *routine value*; FatRat vs Num answers differently there than the compiled operator), `proxy-list-transparency.t` (`is-deeply` does not FETCH `Proxy` list elements — reports `$(Proxy, Proxy)`), `emit-done-controlflow.t`, `error-reporting-quality.t`, `group-of.t`, `handles-proto-dispatch-mut-invocant.t`, `io-cathandle-lazy.t`, `multi-where-otf-dispatch.t`, `subscript-adverbs.t`, `throws-like-gather-sink.t`, `whatever-code-fixes.t` | one at a time |
+| individual gaps | `bigrat-sort-compare.t` (`cmp-ok` calls `infix:«<»` as a *routine value*; FatRat vs Num answers differently there than the compiled operator), `proxy-list-transparency.t` (`is-deeply` does not FETCH `Proxy` list elements — reports `$(Proxy, Proxy)`), `emit-done-controlflow.t`, `error-reporting-quality.t`, `group-of.t`, `io-cathandle-lazy.t` (**aborts with a stack overflow** under the real module: `.cache` on a lazy Seq still answers `Seq`, so `is-deeply`'s Seq-narrowing candidate re-dispatches to itself forever — `todo/deep/cache-on-a-lazy-seq-must-not-answer-seq.md`), `subscript-adverbs.t`, `throws-like-gather-sink.t` (+ part of `emit-done-controlflow.t`: `todo/deep/eval-context-frame-owns-the-return-target.md`), `whatever-code-fixes.t` | one at a time |
 
 `tmp/recheck.sh <file>.t …` runs the named files native / real / raku and is the
 per-file tool; `scripts/test-module-sweep.sh` is the full measurement. Note the


### PR DESCRIPTION
Follow-up bookkeeping for the vendored-`Test.rakumod` campaign, after
#5705 and #5708 landed.

**New — `todo/deep/cache-on-a-lazy-seq-must-not-answer-seq.md`.** `.cache` on a
genuinely-lazy Seq returns the lazy value unchanged, and mutsu has no lazy-*List*
value, so `.^name` stays `Seq` where raku answers `List`. The real Test module's

```raku
multi sub is-deeply(Seq:D $got, Seq:D $expected, $reason = '') {
    is-deeply $got.cache, $expected.cache, $reason;
}
```

therefore re-dispatches to the *same* candidate forever: under `MUTSU_REAL_TEST=1`
`t/io-cathandle-lazy.t` does not fail, it dies with `fatal runtime error: stack
overflow, aborting` and dumps core. The file separates the two gaps — the missing
lazy-List identity (a Value-representation question) and `IO::CatHandle.handles`
being an `Array` marked lazy where raku has a non-lazy `Seq`.

**Extended — `todo/tickets/use-fatal-leaks-out-of-a-sub-or-do-block.md`.** The
pragma leaks out of a *closure value* too, not just a `sub` body and a `do {}`:

```
$ mutsu -e 'my $c = { use fatal; 1 }; $c(); my $f = "bar"[5]; say "soft " ~ $f.^name'
Index out of range. Is: 5, ...
```

Added the missing compiler arm (`compile_block_raw` /
`compile_block_value_opts`), a narrower option worth weighing first (a
pragma-only scope opcode, which avoids the function/class un-registration that
made extending the full import scope risky), and the assertion it breaks in
`t/whatever-code-fixes.t`.

**Ledger — `todo/tickets/vendor-real-test-module.md`.** 17 -> 15 regressions:
the two fixes above also freed `handles-proto-dispatch-mut-invocant.t` and
`multi-where-otf-dispatch.t` with no further work.

Documentation only — the four heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)