### PR TITLE
fix(runtime): `.new` ignores a named argument that names no attribute

### DIFF
--- a/news/2026-08/new-ignores-undeclared-named-args.md
+++ b/news/2026-08/new-ignores-undeclared-named-args.md
@@ -1,0 +1,57 @@
+# `.new` ignores a named argument that names no attribute
+
+Raku's default `BUILDALL` only initialises **declared** attributes. A named
+argument to `.new` that names none is silently ignored — it never becomes part
+of the object. mutsu stored it in the instance's attribute map instead. The key
+was invisible to `.^attributes` and to attribute access (`$!bogus` still failed
+to compile, `.^can` still returned nothing), which is why it went unnoticed for
+so long — but the instance equality behind `eqv` / `===` compares the raw
+attribute map, so an object carrying a stray key never matched an otherwise
+identical one:
+
+```raku
+class C { has Int $.x }
+say C.new(x => 1) eqv C.new(x => 1, bogus => 2);   # raku: True    mutsu: False
+```
+
+Construction now drops such an argument, at all three sites that fold named
+args into the map: the native default-constructor fast path
+(`build_native_default_instance`), the interpreter's generic `dispatch_new`, and
+`dispatch_bless`.
+
+## Why it is gated
+
+Dropping unconditionally would break mutsu's **built-in attribute-bag classes**.
+`X::AdHoc.new(payload => …)`, `X::TypeCheck::Binding.new(got => …, expected =>
+…)` and every other built-in exception type are registered with an *empty*
+attribute list and rely on the permissive bag; a user class with a built-in base
+(`is Exception`, `is Supplier`, …) inherits attributes — `message`, `payload` —
+that the registry does not know about either.
+
+So the drop is gated on a new memoised `NativeCtorPlan::attrs_fully_known`: the
+class declares at least one attribute, and every type in its MRO other than the
+universal roots (`Any`/`Mu`/`Cool`) is a registered class **or role** (role
+attributes are flattened into `ClassDef::attributes` at composition time, so a
+known role is as complete as a known class). `Exception` anywhere in the MRO
+disqualifies the class outright. Being part of the ctor plan, the check costs one
+already-cached bool per construction.
+
+## Effect
+
+Upstream `Cro::HTTP2::FrameParser` splats a header hash carrying
+`conn => $packet.connection` into every frame class, none of which declares a
+`conn` attribute:
+
+```raku
+Cro::HTTP2::Frame::Data.new(padding-length => ($padding-length // UInt),
+                            data => Buf.new($payload), |%header);
+```
+
+Every parsed frame therefore carried a stray `conn` key and compared unequal to
+the frame the test built by hand, so `is-deeply $frame, $result` failed with two
+identical-looking gists on both sides. That was the remaining half of
+`t/http2-frame-parser.rakutest`'s failures, and the same `|%header` splat feeds
+`Headers`, `Priority`, `RstStream`, `Settings`, `PushPromise`, `Ping`, `GoAway`,
+`WindowUpdate` and `Continuation`.
+
+Pin: `t/new-ignores-undeclared-named-args.t` (also passes under `raku`).

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -464,6 +464,11 @@ impl Interpreter {
                             Self::coerce_attr_value_by_sigil(value.clone(), sigil),
                         )
                     }
+                    // Raku's default BUILDALL ignores a named argument that names
+                    // no attribute; storing it would make `eqv` compare a key the
+                    // object is not supposed to have. See
+                    // `NativeCtorPlan::attrs_fully_known`.
+                    None if plan.attrs_fully_known => None,
                     None => attributes.insert(key.clone(), value.clone()),
                 };
                 // An attribute the caller supplied never gets its initializer.

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -274,6 +274,7 @@ impl Interpreter {
             has_smiley,
             has_custom_bless,
             has_container_defaults,
+            attrs_fully_known,
         ) = if registered {
             let class_attrs = std::sync::Arc::new(self.collect_class_attributes(cn_resolved));
             let type_constraints =
@@ -320,6 +321,26 @@ impl Interpreter {
                 });
             }
             let has_custom_bless = self.has_user_method(cn_resolved, "bless");
+            // See `NativeCtorPlan::attrs_fully_known`. Roles are flattened into
+            // `ClassDef::attributes` at composition time, so only the MRO's
+            // classes need to be registered for the attribute set to be complete.
+            // Two extra guards keep the built-in attribute-bag classes permissive:
+            // an `Exception` anywhere in the MRO (`message`/`payload`/`got`/… are
+            // not declared anywhere), and a class that declares no attribute at
+            // all (every built-in `X::…` type is registered with an empty
+            // attribute list and used purely as a bag).
+            let attrs_fully_known = !class_attrs.is_empty() && {
+                let registry = self.registry();
+                mro.iter().all(|cls| {
+                    cls != "Exception"
+                        && (matches!(cls.as_str(), "Any" | "Mu" | "Cool")
+                            || registry.classes.contains_key(cls)
+                            // A composed role shows up in the MRO; its attributes
+                            // are flattened into `class_attrs`, so a known role is
+                            // just as complete as a known class.
+                            || registry.roles.contains_key(cls))
+                })
+            };
             // Does any `is default(...)` element default exist keyed by this
             // class? `apply_container_attribute_defaults` looks defaults up by
             // the receiver class name only, so a key with a matching class is
@@ -342,11 +363,13 @@ impl Interpreter {
                 has_smiley,
                 has_custom_bless,
                 has_container_defaults,
+                attrs_fully_known,
             )
         } else {
             (
                 std::sync::Arc::new(Vec::new()),
                 std::sync::Arc::new(HashMap::new()),
+                false,
                 false,
                 false,
                 false,
@@ -399,6 +422,7 @@ impl Interpreter {
             has_build,
             has_tweak,
             has_smiley,
+            attrs_fully_known,
             has_custom_bless,
             has_container_defaults,
             attr_is_types,

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -53,6 +53,12 @@ impl Interpreter {
                 && self.is_attribute_buildable(cn_resolved, key)
             {
                 let key_sym = attr_idx_of(key).map(|i| plan.attr_syms[i]);
+                // Raku's default BUILDALL ignores a named argument that names no
+                // attribute; storing it would make `eqv` compare a key the object
+                // is not supposed to have. See `NativeCtorPlan::attrs_fully_known`.
+                if key_sym.is_none() && plan.attrs_fully_known {
+                    continue;
+                }
                 match sigil_of(key) {
                     '@' | '%' => {
                         // A `%`-attribute bound to a non-Hash object is

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1677,6 +1677,13 @@ impl Interpreter {
                 // Attribute type constraints (MRO-wide), used to coerce a provided
                 // value for a coercion-typed attribute (`has Int() $.x`).
                 let attr_type_constraints = self.collect_attribute_type_constraints(class_key);
+                // Raku's default BUILDALL ignores a named argument that names no
+                // attribute; storing it would make `eqv` compare a key the object
+                // is not supposed to have. Only when the class's attribute set is
+                // fully known — see `NativeCtorPlan::attrs_fully_known`.
+                let attrs_fully_known = self
+                    .native_ctor_plan(crate::symbol::Symbol::intern(class_key))
+                    .attrs_fully_known;
                 // First, collect constructor args into attrs
                 self.env = saved_default_env.clone();
                 let class_mro = self.class_mro(class_key);
@@ -1720,6 +1727,7 @@ impl Interpreter {
                         ValueView::Pair(k, v) => {
                             if !build_owned_attrs.contains(k.as_str())
                                 && self.is_attribute_buildable(class_key, k)
+                                && (!attrs_fully_known || sigil_map.contains_key(k.as_str()))
                             {
                                 let sigil = sigil_map.get(k).copied().unwrap_or('$');
                                 let mut value = v.clone();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -493,6 +493,22 @@ pub(crate) struct NativeCtorPlan {
     pub(crate) has_build: bool,
     pub(crate) has_tweak: bool,
     pub(crate) has_smiley: bool,
+    /// True when this class's attribute set is FULLY known to the registry:
+    /// the class is user-declared and every type in its MRO other than the
+    /// universal roots (`Any`/`Mu`/`Cool`) is user-declared too.
+    ///
+    /// Raku's default `BUILDALL` only initialises DECLARED attributes and
+    /// silently ignores a named argument that names none — upstream
+    /// `Cro::HTTP2::FrameParser` relies on that, splatting a `conn => …` header
+    /// into every frame class. mutsu used to stash such a stray key in the
+    /// instance's attribute map, where `.^attributes` never showed it but
+    /// `eqv`/`===` compared it, so a parsed frame never matched an otherwise
+    /// identical one built by hand. Construction drops the stray key when this
+    /// is true. It has to be false for a class with a BUILTIN base (`is
+    /// Exception`, `is Supplier`, …): those keep attributes of their own
+    /// outside the registry (`message`, `payload`, …) that construction must
+    /// still accept.
+    pub(crate) attrs_fully_known: bool,
     /// A user-defined (or role-composed) public `bless` method anywhere in the
     /// MRO — such a class must take the interpreter's generic dispatch instead
     /// of the native `bless` fork.

--- a/t/new-ignores-undeclared-named-args.t
+++ b/t/new-ignores-undeclared-named-args.t
@@ -1,0 +1,50 @@
+use Test;
+
+plan 8;
+
+# Raku's default BUILDALL only initialises DECLARED attributes; a named
+# argument that names no attribute is silently ignored, not stashed on the
+# object. Two objects that differ only in such a stray argument are `eqv`.
+
+class C {
+    has Int $.x;
+}
+is C.new(x => 1, bogus => 2).x, 1, 'an undeclared named arg is accepted';
+ok C.new(x => 1) eqv C.new(x => 1, bogus => 2),
+    'an undeclared named arg does not make the object different';
+is C.new(x => 1, bogus => 2).^attributes.elems, 1,
+    'no attribute is added for it';
+
+# Splatting a hash of headers over several classes is the real-world shape
+# (Cro::HTTP2::FrameParser passes `conn => …` to every frame class).
+role R {
+    has Int $.flags;
+}
+class D does R {
+    has Blob $.data;
+}
+my %header = flags => 0, conn => 'connection-object';
+ok D.new(data => Buf.new, |%header) eqv D.new(data => Buf.new, flags => 0),
+    'a splatted extra named arg is ignored through a composed role';
+
+# A class with a BUILTIN base keeps the permissive attribute bag: `Exception`
+# holds `message`/`payload` that are declared nowhere in the registry.
+class E is Exception {
+    has $.code;
+    method message() { "code $!code" }
+}
+is E.new(code => 7).message, 'code 7', 'an Exception subclass still builds';
+is X::AdHoc.new(payload => 'boom').payload, 'boom',
+    'a built-in exception type still takes its undeclared payload';
+
+# Declared attributes are unaffected.
+class F {
+    has $.a;
+    has @.b;
+    has %.c;
+}
+my $f = F.new(a => 1, b => [2, 3], c => {d => 4}, nope => 5);
+is "$f.a() {$f.b.join(',')} {$f.c<d>}", '1 2,3 4',
+    'declared attributes of every sigil still build';
+ok F.new(a => 1, nope => 5) eqv F.new(a => 1),
+    'the stray arg does not survive alongside empty containers';


### PR DESCRIPTION
Raku's default `BUILDALL` only initialises **declared** attributes. A named
argument to `.new` that names none is silently ignored — it never becomes part of
the object. mutsu stored it in the instance's attribute map instead. The key was
invisible to `.^attributes`, to `.^can` and to attribute access (`$!bogus` still
failed to compile), which is why it went unnoticed — but the instance equality
behind `eqv` / `===` compares the raw attribute map, so an object carrying a
stray key never matched an otherwise identical one:

```raku
class C { has Int $.x }
say C.new(x => 1) eqv C.new(x => 1, bogus => 2);   # raku: True    mutsu: False
```

All three sites that fold named args into the map now drop such an argument: the
native default-constructor fast path (`build_native_default_instance`), the
interpreter's generic `dispatch_new`, and `dispatch_bless`.

### Why it is gated

Dropping unconditionally would break mutsu's **built-in attribute-bag classes**.
`X::AdHoc.new(payload => …)`, `X::TypeCheck::Binding.new(got => …, expected => …)`
and every other built-in exception type are registered with an *empty* attribute
list and rely on the permissive bag; a user class with a built-in base
(`is Exception`, `is Supplier`, …) inherits attributes — `message`, `payload` —
that the registry does not know about either.

So the drop is gated on a new memoised `NativeCtorPlan::attrs_fully_known`:

- the class declares at least one attribute, **and**
- every type in its MRO other than `Any`/`Mu`/`Cool` is a registered class **or
  role** (role attributes are flattened into `ClassDef::attributes` at
  composition time, so a known role is as complete as a known class), **and**
- `Exception` does not appear in the MRO.

Being part of the ctor plan, this costs one already-cached bool per construction.

### Effect

Upstream `Cro::HTTP2::FrameParser` splats a header hash carrying
`conn => $packet.connection` into every frame class, none of which declares a
`conn` attribute:

```raku
Cro::HTTP2::Frame::Data.new(padding-length => ($padding-length // UInt),
                            data => Buf.new($payload), |%header);
```

Every parsed frame therefore carried a stray `conn` key and compared unequal to
the one the test built by hand, so `is-deeply $frame, $result` failed with two
identical-looking gists on both sides. The same `|%header` splat feeds `Headers`,
`Priority`, `RstStream`, `Settings`, `PushPromise`, `Ping`, `GoAway`,
`WindowUpdate` and `Continuation`.

Pin: `t/new-ignores-undeclared-named-args.t` (also passes under `raku`).
`make test` is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)