### PR TITLE
fix(runtime): a `whenever` body's own `my` lexicals stay private to the block

### DIFF
--- a/news/2026-08/whenever-body-lexical-private.md
+++ b/news/2026-08/whenever-body-lexical-private.md
@@ -1,0 +1,63 @@
+# A `whenever` body's own `my` lexicals stay private to the block
+
+`news/2026-08/supply-block-lexical-privacy.md` made a `supply { my $x … }`
+block's lexicals private. The `whenever` bodies *inside* such a block were still
+leaking their own: a `my` declared in the body was written back into whatever
+scope invoked it — which, for a supply driven from a `start` block, is that
+thread's scope. The leak then rebound a caller lexical of the same name between
+two emits:
+
+```raku
+sub mk($in) {
+    supply {
+        whenever $in -> $packet {
+            my $data = "INNER-" ~ $packet;
+            emit $data;
+        }
+    }
+}
+
+my $data = "OUTER";
+...
+start { $s.emit($data); $s.emit($data); $s.done }
+# raku:  INNER-OUTER|INNER-OUTER
+# mutsu: INNER-OUTER|INNER-INNER-OUTER
+```
+
+The second emit read the *body's* `$data`, not the script's.
+
+The exit merge in `call_sub_value` already skipped names the body declared with
+`my` — but it read them off `SubData::compiled_code`, and a `whenever` callback
+has none: `run_whenever_with_value` builds it from AST, and `call_sub_value`
+compiles that AST on the fly through `eval_block_value`. The compile-time
+`my_declared_sym` existed, just on a chunk the merge could not see.
+
+`eval_block_value_inner` now publishes that set (its own `my` declarations minus
+the names it also uses as free variables) in `Interpreter::last_block_my_declared`,
+written just before it returns, so after a call the value belongs to the
+outermost block that completed — nested blocks publish and are overwritten first.
+`call_sub_value` takes it immediately after the body runs and folds it into the
+existing `is_body_private` test. The rule is unchanged; it just now reaches every
+body, not only those carrying a `CompiledCode`.
+
+## Effect
+
+The eight remaining failures of upstream `t/http2-frame-parser.rakutest` were all
+`test-dying` cases, and none of them was about exception propagation at all.
+`Cro::HTTP2::FrameParser`'s `whenever` body opens with
+
+```raku
+whenever $in -> Cro::TCP::Message $packet {
+    my $data = $buffer ~ $packet.data;
+    ...
+    $data .= subbuf(24);          # consume the HTTP/2 preface
+```
+
+while the test emits its frames from a `start` block holding its own
+`my $data`. After the preface packet the body's `$data` is empty, that empty Buf
+landed on the test's `$data`, and the second emit shipped a zero-byte message —
+so the parser never reached the payload that was supposed to die, and the tap's
+`quit` handler never fired. With the leak closed, the parser dies with
+`X::Cro::HTTP2::Error` as it should.
+
+Pin: `t/whenever-body-lexical-private.t` (also passes under `raku`).

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1097,6 +1097,17 @@ pub struct Interpreter {
     /// the AST, and that copy would otherwise lose the mark. Consumed (taken) on
     /// entry, so a nested block compiled from inside the body does not inherit it.
     pending_supply_block_body: bool,
+    /// Names the block `eval_block_value_inner` most recently FINISHED running
+    /// declared with its own `my` (excluding those it also uses as free
+    /// variables). Written just before that function returns, so after a call
+    /// the value belongs to the outermost block that just completed — nested
+    /// blocks run and publish their own set first, and are overwritten.
+    ///
+    /// `call_sub_value`'s exit merge reads it to keep such names out of the
+    /// caller: a body compiled on the fly from AST (a `whenever` body, a
+    /// `supply` block body) has no `CompiledCode` on its `SubData`, so the
+    /// compile-time `my_declared_sym` is otherwise unreachable from there.
+    last_block_my_declared: Vec<Symbol>,
     /// PredictiveIterator backing a `Seq.new(iterator)`, keyed by the Seq's
     /// Arc pointer (`seq_id`). Kept off the scoped `env` so the association
     /// survives sub/block returns between Seq creation and `.tail`/`.Numeric`

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -637,6 +637,13 @@ impl Interpreter {
                 .is_some_and(|cc| cc.is_supply_block_body);
             let body_result = self.eval_block_value(&data.body);
             self.pending_supply_block_body = false;
+            // The `my` names the body just declared, published by
+            // `eval_block_value_inner`. Taken immediately, before anything below
+            // can run another block and overwrite it. This is how a body with no
+            // `CompiledCode` on its `SubData` — one compiled on the fly from AST,
+            // notably a `whenever` body — still gets the block-private treatment
+            // in the exit merge below.
+            let runtime_body_declared = std::mem::take(&mut self.last_block_my_declared);
             if let Some(p) = saved_anon_pkg {
                 self.set_current_package(p);
             }
@@ -733,6 +740,7 @@ impl Interpreter {
             // `closure_env_overrides` instead.
             let is_body_private = |k: crate::symbol::Symbol| {
                 data.authoritative_captures.contains(&k)
+                    || runtime_body_declared.contains(&k)
                     || body_declared
                         .as_ref()
                         .is_some_and(|(declared, free)| declared.contains(&k) && !free.contains(&k))

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -308,6 +308,18 @@ impl Interpreter {
         // Blocks are scope boundaries for temp/let saves.
         self.restore_let_saves(let_mark);
         self.run_pending_instance_destroys()?;
+        // Publish the block's own `my` declarations for `call_sub_value`'s exit
+        // merge — see `Interpreter::last_block_my_declared`. Written here, after
+        // the body (and every block nested in it) has run, so the outermost
+        // block's set is the one that survives. A name that is ALSO a free var
+        // refers to the outer binding for its pre-declaration uses, so it is not
+        // block-private and stays out.
+        self.last_block_my_declared = code
+            .my_declared_sym
+            .iter()
+            .filter(|sym| !code.free_var_syms.contains(sym))
+            .copied()
+            .collect();
         result.map(|value| {
             // When the block's last statement is a sub declaration, its value is
             // the declared sub — not a leftover topic/`$_` value from an earlier

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2115,6 +2115,7 @@ impl Interpreter {
             pending_eval_sigilless: Vec::new(),
             pending_eval_placeholder_params: Vec::new(),
             pending_supply_block_body: false,
+            last_block_my_declared: Vec::new(),
             predictive_seq_iters: HashMap::new(),
             protect_block_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -373,6 +373,7 @@ impl Interpreter {
             pending_eval_sigilless: Vec::new(),
             pending_eval_placeholder_params: Vec::new(),
             pending_supply_block_body: false,
+            last_block_my_declared: Vec::new(),
             predictive_seq_iters: self.predictive_seq_iters.clone(),
             protect_block_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),

--- a/t/whenever-body-lexical-private.t
+++ b/t/whenever-body-lexical-private.t
@@ -1,0 +1,59 @@
+use Test;
+
+plan 4;
+
+# A `whenever` body is a block: a `my` variable it declares is private to that
+# block and must not be written back into whatever scope invoked it. The body
+# is dispatched by the thread that emits into the supply, so a leak lands in
+# that thread's scope — where it silently rebinds a caller lexical of the same
+# name between two emits.
+
+{
+    sub mk($in) {
+        supply {
+            whenever $in -> $packet {
+                my $data = "INNER-" ~ $packet;
+                emit $data;
+            }
+        }
+    }
+
+    my $data = "OUTER";
+    my $s = Supplier.new;
+    my $done = Promise.new;
+    my @got;
+    mk($s.Supply).tap(-> $v { @got.push($v) }, done => { $done.keep });
+    start {
+        $s.emit($data);
+        $s.emit($data);
+        $s.done;
+    }
+    await Promise.anyof($done, Promise.in(10));
+    is @got.join('|'), 'INNER-OUTER|INNER-OUTER',
+        "the emitter's lexical survives the whenever body's same-named `my`";
+    is $data, 'OUTER', "the whenever body's `my` does not reach the caller";
+}
+
+# The body's own lexical still accumulates across invocations when it is
+# declared by the enclosing supply block rather than the whenever body.
+{
+    sub mk($in) {
+        supply {
+            my $seen = 0;
+            whenever $in -> $x {
+                my $seen-here = $x * 10;
+                $seen += $x;
+                emit "$seen/$seen-here";
+            }
+        }
+    }
+
+    my $seen-here = 'CALLER';
+    my $s = Supplier.new;
+    my @got;
+    mk($s.Supply).tap(-> $v { @got.push($v) });
+    $s.emit(1); $s.emit(2); $s.done;
+    is @got.join('|'), '1/10|3/20',
+        'the supply block lexical accumulates while the body lexical is fresh';
+    is $seen-here, 'CALLER', "the body's `my` did not clobber the caller's";
+}


### PR DESCRIPTION
Follow-up to #5704, which made a `supply { my $x … }` block's lexicals private.
The `whenever` bodies *inside* such a block were still leaking their own: a `my`
declared in the body was written back into whatever scope invoked it — which,
for a supply driven from a `start` block, is that thread's scope. The leak then
rebound a caller lexical of the same name between two emits:

```raku
sub mk($in) {
    supply {
        whenever $in -> $packet {
            my $data = "INNER-" ~ $packet;
            emit $data;
        }
    }
}

my $data = "OUTER";
...
start { $s.emit($data); $s.emit($data); $s.done }
# raku:  INNER-OUTER|INNER-OUTER
# mutsu: INNER-OUTER|INNER-INNER-OUTER
```

The second emit read the *body's* `$data`, not the script's.

### The gap

`call_sub_value`'s exit merge already skipped names the body declared with `my`
— but it read them off `SubData::compiled_code`, and a `whenever` callback has
none: `run_whenever_with_value` builds it from AST, and `call_sub_value` compiles
that AST on the fly through `eval_block_value`. The compile-time
`my_declared_sym` existed all along, just on a chunk the merge could not see.

`eval_block_value_inner` now publishes it (its own `my` declarations minus the
names it also uses as free variables) in `Interpreter::last_block_my_declared`,
written just before it returns — so after a call the value belongs to the
outermost block that completed, nested blocks having published and been
overwritten first. `call_sub_value` takes it immediately after the body runs and
folds it into the existing `is_body_private` test. The rule is unchanged; it just
now reaches every body instead of only those carrying a `CompiledCode`.

### Effect

The eight remaining failures of upstream `t/http2-frame-parser.rakutest` were all
`test-dying` cases — and none of them was about exception propagation.
`Cro::HTTP2::FrameParser`'s `whenever` body opens with

```raku
whenever $in -> Cro::TCP::Message $packet {
    my $data = $buffer ~ $packet.data;
    ...
    $data .= subbuf(24);          # consume the HTTP/2 preface
```

while the test emits its frames from a `start` block holding its own `my $data`.
After the preface packet the body's `$data` is empty, that empty Buf landed on
the test's `$data`, and the second emit shipped a zero-byte message — so the
parser never reached the payload that was supposed to die and the tap's `quit`
handler never fired. With the leak closed it dies with `X::Cro::HTTP2::Error` as
it should.

Pin: `t/whenever-body-lexical-private.t` (also passes under `raku`). `make test`
is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)