### PR TITLE
fix(test): `done-testing` counts tests that ran on other threads

### DIFF
--- a/news/2026-08/done-testing-counts-cross-thread-tests.md
+++ b/news/2026-08/done-testing-counts-cross-thread-tests.md
@@ -1,0 +1,31 @@
+# `done-testing` counts tests that ran on other threads
+
+`done-testing` emits `1..N` for the number of tests that actually ran. It read
+that number from `TestState::ran` — the *local* counter. Once a test has run on a
+spawned thread (a `start` block, a Promise or Supply callback) the authoritative
+count lives in the shared atomic `TestState::shared_ran`, and the main thread's
+`ran` is stale: `next_ran` bumps the atomic but only updates the running
+thread's cloned `ran` field. `TestState::effective_ran()` exists for exactly this
+and was already used by the trailing summary — `done-testing` and its
+plan-matches check were simply not using it.
+
+So a file whose assertions happen inside supply taps emitted a plan for the
+handful of tests the main thread happened to run itself:
+
+```
+ok 1 - HTTP2 frame parser is a transform
+...
+ok 26 - SETTINGS frame with zero content is emitted correctly
+1..3
+# You planned 3 test, but ran 26
+```
+
+Note the summary line already had it right at 26 — only the plan was wrong. The
+file failed on the plan alone, with every one of its 26 assertions passing.
+
+That is upstream Cro's `t/http2-frame-parser.rakutest`, whose every
+`test-example` / `test-dying` assertion runs inside a `.tap` callback driven from
+a `start` block. With this fix (and the supply/whenever lexical-scoping fixes
+that got its assertions passing in the first place) the file is fully green.
+
+Pin: `t/done-testing-counts-cross-thread.t`.

--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -236,17 +236,24 @@ impl Interpreter {
             state.planned.is_some()
         };
         if !already_planned {
+            // `effective_ran`, not the local `ran`: once a test has run on a
+            // spawned thread (a `start` block, a Promise or Supply callback) the
+            // count lives in the shared atomic and this thread's `ran` is stale.
+            // A file whose assertions all happen inside supply taps — upstream
+            // Cro's `t/http2-frame-parser.rakutest` — emitted `1..3` after
+            // running 26 tests, and prove failed it on the plan alone.
             let ran = {
                 let state = self.tap.ensure_state();
-                state.planned = Some(state.ran);
-                state.ran
+                let ran = state.effective_ran();
+                state.planned = Some(ran);
+                ran
             };
             self.emit_output(&format!("1..{}\n", ran));
         }
         // Return True if all tests passed and plan matches, False otherwise
         let state = self.tap.state().unwrap();
         let plan_matches = match state.planned {
-            Some(planned) => planned == state.ran,
+            Some(planned) => planned == state.effective_ran(),
             None => true,
         };
         let all_passed = state.failed == 0 && plan_matches;

--- a/t/done-testing-counts-cross-thread.t
+++ b/t/done-testing-counts-cross-thread.t
@@ -1,0 +1,21 @@
+use Test;
+
+# `done-testing` emits `1..N` for the number of tests that actually ran. Once a
+# test has run on a spawned thread (a `start` block, a Promise or Supply
+# callback) the count lives in a shared atomic, and the main thread's own
+# counter is stale — so the emitted plan must come from the shared one.
+
+ok True, 'main thread test';
+
+my $s = Supplier.new;
+my $done = Promise.new;
+my $n = 0;
+$s.Supply.tap: -> $v {
+    ok $v > 0, "tap test $v";
+    $done.keep if ++$n == 3;
+};
+start { $s.emit($_) for 1..3; $s.done }
+await Promise.anyof($done, Promise.in(10));
+
+# Runs 4 tests in total; prove fails the file unless the trailing plan says 1..4.
+done-testing;


### PR DESCRIPTION
`done-testing` emits `1..N` for the number of tests that actually ran. It read
that number from `TestState::ran` — the **local** counter. Once a test has run on
a spawned thread (a `start` block, a Promise or Supply callback) the
authoritative count lives in the shared atomic `TestState::shared_ran`, and the
main thread's `ran` is stale: `next_ran` bumps the atomic but only updates the
running thread's cloned `ran` field.

`TestState::effective_ran()` exists for exactly this and was already used by the
trailing summary — `done-testing` and its plan-matches check simply were not
using it.

So a file whose assertions happen inside supply taps planned for the handful of
tests the main thread happened to run itself:

```
ok 1 - HTTP2 frame parser is a transform
...
ok 26 - SETTINGS frame with zero content is emitted correctly
1..3
# You planned 3 test, but ran 26
```

Note the summary line already had it right at 26 — only the plan was wrong. The
file failed on the plan alone, with every one of its 26 assertions passing.

That is upstream Cro's `t/http2-frame-parser.rakutest`, whose every
`test-example` / `test-dying` assertion runs inside a `.tap` callback driven from
a `start` block. With this fix — on top of #5704 / #5706 / #5711 / #5712, which
got those assertions passing in the first place — the file is fully green.

Pin: `t/done-testing-counts-cross-thread.t`. `make test` is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)