### PR TITLE
fix(runtime): an undeclared variable is X::Undeclared, not X::Undeclared::Symbols

### DIFF
--- a/news/2026-08/undeclared-variable-is-not-undeclared-symbols.md
+++ b/news/2026-08/undeclared-variable-is-not-undeclared-symbols.md
@@ -1,0 +1,81 @@
+# An undeclared variable is `X::Undeclared`, not `X::Undeclared::Symbols`
+
+Rakudo splits the two undeclared-symbol exception classes by *what the symbol
+is*, not by when the failure was noticed:
+
+| source | class | message |
+| --- | --- | --- |
+| `$undeclared` | `X::Undeclared` | `Variable '$undeclared' is not declared` |
+| `zzz()` | `X::Undeclared::Symbols` | `Undeclared routine:\n    zzz used at line 1` |
+
+The two are **not related**: they share the `X::Comp` *role*, not a superclass,
+so `X::Undeclared::Symbols ~~ X::Undeclared` is `False`. Answering with the
+wrong one is therefore directly visible to `throws-like`, which is how this
+surfaced — under the vendored upstream `Test` module
+(`todo/tickets/vendor-real-test-module.md`) two files failed on
+`right exception type (X::Undeclared)` where mutsu had produced
+`X::Undeclared::Symbols`.
+
+Two independent causes, both now fixed.
+
+## The VM's variable read used the wrong class
+
+mutsu already raised a well-formed `X::Undeclared` from the CHECK-time scan
+(`src/runtime/system_eval_vars.rs`) and from the regex-interpolation paths. But
+the VM's own fallback — the read of a local slot whose name is in no env
+(`src/vm/vm_var_assign_local_get.rs`) — hand-rolled a message string tagged
+`X::Undeclared::Symbols:`, and it reported the env key verbatim, which for a
+scalar carries no sigil:
+
+```
+$ mutsu -e 'try { { our $sa2 = my $sb2 = 42; }; ($sa2, $sb2) }; say $!.^name; say $!.message'
+X::Undeclared::Symbols
+Variable 'sa2' is not declared
+```
+
+That shape reaches the VM rather than the CHECK-time scan whenever the scan's
+conservative declaration collection has already seen the name — here the
+chained `our $sa2 = my $sb2 = 42` inside a block. So the same program text
+produced one class or the other depending on which path noticed it.
+
+The site now builds a real typed exception via a new
+`RuntimeError::undeclared_variable()`, which carries `what`, `symbol`, `name`,
+`post`, `highexpect` and `suggestions` the way the CHECK-time path does, and
+restores the sigil:
+
+```
+X::Undeclared
+Variable '$sa2' is not declared
+```
+
+## Calling a CORE term constant is the variable-shaped error
+
+`e`, `pi`, `tau`, `i`, `Inf`, `NaN`, `True` and `False` are terms, not
+routines. Calling one is not "nobody declared this name" — the symbol exists,
+it just does not exist under the `&` sigil — so rakudo reports
+`X::Undeclared` naming `&e`:
+
+```
+$ raku -e 'try EVAL q[e()]; say $!.^name, "  ", $!.message.lines[0]'
+X::Undeclared  Variable '&e' is not declared. Perhaps you forgot a 'sub' if
+```
+
+whereas an entirely unknown `zzz()` gets the CHECK-time
+`X::Undeclared::Symbols`. mutsu answered `X::Undeclared::Symbols: Unknown
+function: e` for all eight names. The runtime call fallback now recognises the
+set (`CORE_TERM_CONSTANTS` in `src/runtime/undeclared_routines.rs`) and raises
+`X::Undeclared` for `&name`. `now`, `time` and `rand` are deliberately not in
+the set — they are real routines, and rakudo does answer
+`X::Undeclared::Symbols` for `now()` and `time()`.
+
+Pin: `t/undeclared-symbol-exception-class.t`, which passes unchanged under
+`raku`. This freed `t/block-lexical-scope.t` and
+`t/gate-b-callee-name-collision-and-deref-capture.t` under the real `Test`
+module, taking that ledger from 15 regressions to 13.
+
+Worth recording for the next triage: both files had been filed under
+`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md` on the strength
+of the failure text mentioning two `X::Undeclared*` names. Neither was a
+hierarchy-registration problem — mutsu was simply raising the wrong class, and
+registering `X::Undeclared::Symbols` under `X::Undeclared` would have been
+actively wrong, since raku says they are unrelated.

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -1036,6 +1036,12 @@ impl Interpreter {
             return self.eval_call_on_value(sub_val, args.to_vec());
         }
 
+        // A CORE term constant called as a routine is `X::Undeclared` naming
+        // `&name`, not the undeclared-routine class -- see CORE_TERM_CONSTANTS.
+        if crate::runtime::undeclared_routines::CORE_TERM_CONSTANTS.contains(&name) {
+            return Err(RuntimeError::undeclared_variable(&format!("&{name}")));
+        }
+
         let suggestions = self.suggest_routine_names(name);
         Err(RuntimeError::undeclared_routine_symbols(
             name,

--- a/src/runtime/undeclared_routines.rs
+++ b/src/runtime/undeclared_routines.rs
@@ -21,6 +21,19 @@ use std::collections::HashSet;
 
 use super::Interpreter;
 
+/// Core *term* constants: names that resolve to a value in CORE but are not
+/// routines. Calling one of them is not the same error as calling a name
+/// nobody declared — the symbol exists, it just does not exist under the `&`
+/// sigil — so rakudo answers `X::Undeclared` naming `&e` ("Variable '&e' is
+/// not declared") where an entirely unknown `zzz()` gets the CHECK-time
+/// `X::Undeclared::Symbols`. The two classes are unrelated (`X::Comp` is a
+/// role, not a superclass), so `throws-like 'e()', X::Undeclared` sees the
+/// difference.
+///
+/// `now`, `time` and `rand` are deliberately absent: they are real routines.
+pub(crate) const CORE_TERM_CONSTANTS: &[&str] =
+    &["e", "i", "pi", "tau", "Inf", "NaN", "True", "False"];
+
 /// Native (lowercase) type names that may appear in call position as
 /// coercions/constructors (`int8(...)`) without being routine declarations.
 const NATIVE_TYPE_NAMES: &[&str] = &[

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -17,6 +17,37 @@ impl RuntimeError {
         Self::typed("X::Undeclared", attrs)
     }
 
+    /// X::Undeclared for a *variable* read that found no declaration.
+    ///
+    /// Rakudo splits the two undeclared families by what the symbol is, not by
+    /// when it was noticed: a variable is `X::Undeclared` (`Variable '$x' is
+    /// not declared`) and a bareword/routine is `X::Undeclared::Symbols`
+    /// (`Undeclared routine:\n    zzz used at line 1`). `$x ~~ X::Undeclared`
+    /// is False for the Symbols variant — the two classes share the `X::Comp`
+    /// role, not a superclass — so answering with the wrong one is visible to
+    /// `throws-like`.
+    ///
+    /// `name` is an env key, which for scalars carries no sigil; the reported
+    /// symbol always does.
+    pub(crate) fn undeclared_variable(name: &str) -> Self {
+        let symbol = match name.as_bytes().first() {
+            Some(b'$' | b'@' | b'%' | b'&') => name.to_string(),
+            _ => format!("${name}"),
+        };
+        let mut attrs = HashMap::new();
+        attrs.insert("what".to_string(), Value::str("Variable".to_string()));
+        attrs.insert("symbol".to_string(), Value::str(symbol.clone()));
+        attrs.insert("name".to_string(), Value::str(symbol.clone()));
+        attrs.insert("post".to_string(), Value::str(symbol.clone()));
+        attrs.insert("highexpect".to_string(), Value::array(vec![]));
+        attrs.insert("suggestions".to_string(), Value::array(vec![]));
+        attrs.insert(
+            "message".to_string(),
+            Value::str(format!("Variable '{symbol}' is not declared")),
+        );
+        Self::typed("X::Undeclared", attrs)
+    }
+
     /// X::Undeclared::Symbols - Undeclared name (symbols variant)
     pub(crate) fn undeclared_symbols(message: impl Into<String>) -> Self {
         Self::typed_msg("X::Undeclared::Symbols", message)

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -245,9 +245,7 @@ impl Interpreter {
                 return Err(err);
             }
             if !is_internal && !is_special && !is_private_attr && !self.env().contains_key(name) {
-                return Err(RuntimeError::new(format!(
-                    "X::Undeclared::Symbols: Variable '{name}' is not declared"
-                )));
+                return Err(RuntimeError::undeclared_variable(name));
             }
             // `is default(...)`: return the default value instead of Nil.
             if let Some(def) = self.var_default(name) {

--- a/t/undeclared-symbol-exception-class.t
+++ b/t/undeclared-symbol-exception-class.t
@@ -1,0 +1,49 @@
+use Test;
+
+# Rakudo splits the two undeclared families by what the symbol *is*, not by
+# when it was noticed:
+#
+#   $undeclared      -> X::Undeclared           "Variable '$undeclared' is not declared"
+#   zzz()            -> X::Undeclared::Symbols  "Undeclared routine:\n    zzz used at line 1"
+#
+# and the two classes are unrelated -- they share the `X::Comp` *role*, not a
+# superclass -- so `X::Undeclared::Symbols ~~ X::Undeclared` is False and
+# answering with the wrong one is visible to `throws-like`.
+#
+# mutsu's runtime read of an undeclared variable used to answer
+# X::Undeclared::Symbols with the X::Undeclared message text, and it dropped
+# the sigil from the reported symbol.
+
+plan 9;
+
+nok X::Undeclared::Symbols ~~ X::Undeclared,
+    'the two undeclared classes are not related';
+
+throws-like '{ my $inner = 42 }; $inner', X::Undeclared,
+    'a block lexical read from outside is X::Undeclared';
+
+# The chained form escapes the compile-time scan and is caught by the VM's
+# variable read instead -- the same class has to come out of both paths.
+throws-like '{ our $sa2 = my $sb2 = 42 }; ($sa2, $sb2)', X::Undeclared,
+    'a chained our/my block lexical is X::Undeclared too',
+    symbol => '$sa2';
+
+throws-like 'my @a = 1; { my @b = 2 }; @b', X::Undeclared,
+    'an undeclared array keeps its sigil',
+    symbol => '@b';
+
+throws-like 'zzz()', X::Undeclared::Symbols,
+    'a routine nobody declared is X::Undeclared::Symbols';
+
+# A CORE term constant exists as a symbol -- just not under the `&` sigil --
+# so calling it is the variable-shaped error, naming `&e`.
+throws-like 'e()', X::Undeclared,
+    'calling a CORE term constant is X::Undeclared',
+    symbol => '&e';
+
+throws-like 'my $e = e; e()', X::Undeclared,
+    'and a same-named lexical does not change that';
+
+throws-like 'pi()', X::Undeclared, 'pi() likewise', symbol => '&pi';
+
+throws-like 'True()', X::Undeclared, 'True() likewise', symbol => '&True';

--- a/todo/deep/exception-class-hierarchy-is-mostly-unregistered.md
+++ b/todo/deep/exception-class-hierarchy-is-mostly-unregistered.md
@@ -67,6 +67,16 @@ So the work is:
    match on the class *name*, so the payoff is concentrated in the sites where
    mutsu constructs the exception itself.
 
+A worked example of why step 3 comes first: three files in the Test-vendoring
+sweep were filed here because their failure text named two `X::Undeclared*`
+classes. Two of them (`block-lexical-scope.t`,
+`gate-b-callee-name-collision-and-deref-capture.t`) were not hierarchy problems
+at all — mutsu raised the *wrong class* for an undeclared variable and for a
+call to a CORE term constant
+(`news/2026-08/undeclared-variable-is-not-undeclared-symbols.md`). Registering
+`X::Undeclared::Symbols` under `X::Undeclared` to "fix" them would have baked in
+inheritance raku does not have. Read the failure, do not pattern-match the name.
+
 Step 3 is worth doing first as a cheap sanity check: on the full Test-vendoring
 sweep only 2 of the 9 remaining regressions are caused by an unregistered class,
 so this is a correctness-of-the-type-system task rather than a

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -325,7 +325,7 @@ Exit status was measured for the first time and is already faithful — a failin
 assertion exits 1, a short plan exits 255 — which is what `prove` reads, so
 step 3 does not need work there.
 
-### Triaged, 15 left (2026-08-02)
+### Triaged, 15 left (2026-08-02), then 13
 
 `module-file-var-and-callframe.t` now passes, and so does `leave-in-if-branch.t`
 — its `@events = ()` between assertions was silently dropped because the real
@@ -345,7 +345,7 @@ successfully, so the difference is genuinely in mutsu.
 
 | group | files | note |
 | --- | --- | --- |
-| exception-class hierarchy | `block-lexical-scope.t`, `gate-b-callee-name-collision-and-deref-capture.t`, `undeclared-when-type.t` | all fail on `right exception type (X::Undeclared / X::Comp::Group)` — one cause, `todo/deep/exception-class-hierarchy-is-mostly-unregistered.md` |
+| ~~exception-class hierarchy~~ | ~~`block-lexical-scope.t`, `gate-b-callee-name-collision-and-deref-capture.t`~~, `undeclared-when-type.t` | **not one cause, and not the hierarchy ticket.** The first two were mutsu raising the *wrong class*: an undeclared variable read and a call to a CORE term constant both answered `X::Undeclared::Symbols` where raku answers `X::Undeclared` (the two are unrelated — `X::Comp` is a role, not a superclass — so registering one under the other would have been wrong). Fixed: `news/2026-08/undeclared-variable-is-not-undeclared-symbols.md`. `undeclared-when-type.t` is separate: `when SomeUndeclaredType` is `X::Comp::Group` in raku (a *parse* failure, "needs parens to avoid gobbling block") and `X::Undeclared::Symbols` in mutsu |
 | the pin asserts *native-provider* behaviour | `qualified-call-does-not-alias-builtin.t` (asserts `Test::ok(1)` **dies** — under the real module `Test::ok` legitimately exists), `test-assertion-line-number.t` | re-point the test file; not an interpreter gap |
 | deferred `Seq` reification destroys the value | `is-lazy-io-lines.t` | `todo/deep/deferred-seq-materialization-destroys-the-original.md` — the real `is` opens with `$got.defined`, which guts a lazy `.lines` |
 | individual gaps | `bigrat-sort-compare.t` (`cmp-ok` calls `infix:«<»` as a *routine value*; FatRat vs Num answers differently there than the compiled operator), `proxy-list-transparency.t` (`is-deeply` does not FETCH `Proxy` list elements — reports `$(Proxy, Proxy)`), `emit-done-controlflow.t`, `error-reporting-quality.t`, `group-of.t`, `io-cathandle-lazy.t` (**aborts with a stack overflow** under the real module: `.cache` on a lazy Seq still answers `Seq`, so `is-deeply`'s Seq-narrowing candidate re-dispatches to itself forever — `todo/deep/cache-on-a-lazy-seq-must-not-answer-seq.md`), `subscript-adverbs.t`, `throws-like-gather-sink.t` (+ part of `emit-done-controlflow.t`: `todo/deep/eval-context-frame-owns-the-return-target.md`), `whatever-code-fixes.t` | one at a time |


### PR DESCRIPTION
Rakudo splits the two undeclared-symbol exception classes by **what the symbol is**, not by when the failure was noticed:

| source | class | message |
| --- | --- | --- |
| `$undeclared` | `X::Undeclared` | `Variable '$undeclared' is not declared` |
| `zzz()` | `X::Undeclared::Symbols` | `Undeclared routine:\n    zzz used at line 1` |

The two are **not related** — they share the `X::Comp` *role*, not a superclass — so `X::Undeclared::Symbols ~~ X::Undeclared` is `False`, and answering with the wrong one is directly visible to `throws-like`. This surfaced under the vendored upstream `Test` module (`todo/tickets/vendor-real-test-module.md`), where two files failed on `right exception type (X::Undeclared)`.

Two independent causes.

### The VM's variable read used the wrong class

mutsu already raised a well-formed `X::Undeclared` from the CHECK-time scan and from the regex-interpolation paths, but the VM's own fallback (`src/vm/vm_var_assign_local_get.rs`) hand-rolled a message string tagged `X::Undeclared::Symbols:` and reported the env key verbatim, which for a scalar carries no sigil:

```
$ mutsu -e 'try { { our $sa2 = my $sb2 = 42; }; ($sa2, $sb2) }; say $!.^name; say $!.message'
X::Undeclared::Symbols
Variable 'sa2' is not declared
```

That shape reaches the VM rather than the CHECK-time scan whenever the scan's conservative declaration collection has already seen the name — here the chained `our $sa2 = my $sb2 = 42` inside a block — so the same program text produced one class or the other depending on which path noticed it. It now builds a real typed exception via a new `RuntimeError::undeclared_variable()`, carrying `what` / `symbol` / `name` / `post` / `highexpect` / `suggestions` the way the CHECK-time path does, and restoring the sigil.

### Calling a CORE term constant is the variable-shaped error

`e`, `pi`, `tau`, `i`, `Inf`, `NaN`, `True`, `False` are terms, not routines. Calling one is not "nobody declared this name" — the symbol exists, it just does not exist under the `&` sigil — so rakudo answers `X::Undeclared` naming `&e`, whereas an entirely unknown `zzz()` gets the CHECK-time `X::Undeclared::Symbols`. mutsu answered `X::Undeclared::Symbols: Unknown function: e` for all eight. `now` / `time` / `rand` are deliberately out of the set: they are real routines, and rakudo does answer `X::Undeclared::Symbols` for `now()` and `time()`.

### Verification

- New pin `t/undeclared-symbol-exception-class.t` — passes unchanged under `raku`.
- `make test`: `Files=2747, Tests=26188`, `Result: PASS`.
- The 22 whitelisted roast files that mention `X::Undeclared*` all still pass.
- Frees `t/block-lexical-scope.t` and `t/gate-b-callee-name-collision-and-deref-capture.t` under the real `Test` module: that ledger goes 15 → 13.

### Triage note

Both files had been filed under `todo/deep/exception-class-hierarchy-is-mostly-unregistered.md` because the failure text named two `X::Undeclared*` classes. Neither was a hierarchy-registration problem, and registering `X::Undeclared::Symbols` under `X::Undeclared` to "fix" them would have baked in inheritance raku does not have. Both tickets are updated with that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)