### PR TITLE
fix(runtime): a plain `sub` in a module is not a package symbol

### DIFF
--- a/news/2026-08/module-sub-is-not-a-package-symbol.md
+++ b/news/2026-08/module-sub-is-not-a-package-symbol.md
@@ -1,0 +1,68 @@
+# A plain `sub` in a module is not reachable under its package name
+
+In Raku a routine declared with a bare `sub` is `my`-scoped, whatever package
+body it sits in. `is export` makes it importable under its short name; it does
+**not** put it in the package stash. Only `our sub` does that:
+
+```
+unit module MScope;
+sub       lex-sub()   is export { "lex" }
+multi sub multi-lex(Int $x) is export { "multi-lex $x" }
+our sub   pkg-sub()   is export { "pkg" }
+```
+
+```
+$ raku -I. -e 'use MScope; say MScope::pkg-sub(); say MScope::lex-sub()'
+pkg
+Could not find symbol '&lex-sub' in 'MScope'
+```
+
+mutsu answered `lex` for the second one, and `multi-lex 1` for the multi. Two
+independent leaks, one per shape.
+
+## The qualified-call retry fired for a package mutsu knows
+
+`call_function_fallback` ends with a package-prefix strip: an unresolved
+`Foo::bar(…)` retries as `bar(…)`. That retry exists so a call qualified with a
+package mutsu never registered still finds its routine, and
+`news/2026-07/qualified-call-no-longer-aliases-a-builtin.md` already gated it on
+*something being declared* under the short name — which is exactly the case
+here, since the routine really is imported. The missing half of the gate is the
+qualifier: when the package is one mutsu **has** registered, the qualified name
+already had its chance through the registry, and stripping the prefix
+resurrects every lexical routine of every loaded module. The retry now runs
+only for an unknown package — the same `is_known_package` predicate that
+already decided whether the error names `Foo::Bar` or `GLOBAL::Foo::Bar`.
+
+## The my-scoped gate sat below the multi candidate scan
+
+`multi sub` survived even that, because the visibility gate was attached to the
+wrong lookup. `dispatch_resolve` checked `is_my_scoped_package_item` on the
+exact-name registry hit — but a multi is registered under `Pkg::name/arity`
+keys, so the exact-name lookup misses by construction and control fell through
+to the arity-keyed candidate scan, which had no gate at all. It handed back the
+very routine the check above had been written to hide. The gate is now the
+first thing the qualified branch does, so every lookup below it inherits the
+decision (and the duplicated copy further down became redundant and was
+removed).
+
+While moving it, the in-package exemption went too: it let `M::lex-sub()`
+resolve from *inside* `M`. Raku does not — a lexical routine is not in the
+stash for anyone, so the qualified form fails there as well, which the pin
+asserts under both implementations.
+
+## Where it came from
+
+`t/qualified-call-does-not-alias-builtin.t` asserts that `Test::ok(1)` dies. It
+was passing under mutsu's native `Test` provider and failing under the vendored
+upstream module (`todo/tickets/vendor-real-test-module.md`), where `Test` is a
+real module with a real `multi sub ok`. It had been filed as "the pin asserts
+native-provider behaviour, re-point the test file". It was not: `raku -e 'use
+Test; Test::ok(1, "q")'` says `Could not find symbol '&ok' in 'Test'` too,
+because rakudo's `Test.rakumod` declares `multi sub ok(...) is export` — a
+lexical. The pin was right and mutsu was wrong.
+
+Pin: `t/module-sub-package-visibility.t` (+ fixture `t/lib/PackageSubScope.rakumod`),
+passing unchanged under `raku`. `make test` and the bundled-library gate
+(`scripts/battery-testsuite.sh`, 153/158) are green. This takes the real-`Test`
+regression ledger from 13 to 12.

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -1001,10 +1001,19 @@ impl Interpreter {
         // not a decoration to be discarded.
         if let Some(pos) = name.rfind("::") {
             let short_name = &name[pos + 2..];
-            if self.qualified_retry_resolves(short_name, args) {
+            let package = &name[..pos];
+            // ... and only when the package really is one mutsu never saw. A
+            // package it *does* know has already had its chance through the
+            // registry, and a plain `sub` in a module is `my`-scoped: raku says
+            // `MScope::lex-sub()` is "Could not find symbol '&lex-sub' in
+            // 'MScope'" even while the same routine is imported and callable
+            // under its short name, and only `our sub` is reachable that way.
+            // Stripping here would resurrect every lexical routine of every
+            // loaded module under its package name.
+            if !self.is_known_package(package) && self.qualified_retry_resolves(short_name, args) {
                 return self.call_function(short_name, args.to_vec());
             }
-            return Err(self.no_such_qualified_symbol(&name[..pos], short_name));
+            return Err(self.no_such_qualified_symbol(package, short_name));
         }
 
         // NativeCall's `explicitly-manage($str)` marks a value's C-side buffer
@@ -1088,6 +1097,18 @@ impl Interpreter {
     /// `Could not find symbol '&index' in 'GLOBAL::Foo::Bar'` (an `X::AdHoc`).
     /// A package raku knows about is named bare — `class C {}; C::foo()` says
     /// `in 'C'` — while one it has never seen is reported under `GLOBAL::`.
+    /// Is `package` a package mutsu actually registered (class, role, module,
+    /// or a declared stub)? An unknown one is what raku reports as
+    /// `GLOBAL::Foo::Bar`, and it is the only case in which a qualified call
+    /// may retry under its short name.
+    fn is_known_package(&self, package: &str) -> bool {
+        !package.is_empty()
+            && (self.has_class(package)
+                || self.has_role(package)
+                || self.registry().package_kinds.contains_key(package)
+                || self.registry().package_stubs.contains(package))
+    }
+
     fn no_such_qualified_symbol(&self, package: &str, short_name: &str) -> RuntimeError {
         // An explicitly written `GLOBAL::` qualifier resolves through the
         // pseudo-package, and raku then names the symbol without its `&` sigil:
@@ -1098,10 +1119,7 @@ impl Interpreter {
             None if package == "GLOBAL" => ("", ""),
             None => (package, "&"),
         };
-        let known = self.has_class(package)
-            || self.has_role(package)
-            || self.registry().package_kinds.contains_key(package)
-            || self.registry().package_stubs.contains(package);
+        let known = self.is_known_package(package);
         let qualified = if package.is_empty() {
             "GLOBAL".to_string()
         } else if known {

--- a/src/runtime/dispatch_resolve.rs
+++ b/src/runtime/dispatch_resolve.rs
@@ -219,23 +219,22 @@ impl Interpreter {
             return None;
         }
         if name.contains("::") {
+            // Block access to my-scoped (non-our) package items. Checked before
+            // the arity-keyed candidate scan below, not only on the exact-name
+            // hit: a `multi sub` is
+            // registered under `Pkg::name/arity` keys, so the exact-name lookup
+            // misses and the scan would hand back the very routine this gate
+            // exists to hide (`MScope::multi-lex(1)` answered where raku says
+            // "Could not find symbol '&multi-lex' in 'MScope'").
+            if self.qualified_name_hidden_here(name) {
+                return None;
+            }
             if let Some(def) = self
                 .registry()
                 .functions
                 .get(&Symbol::intern(name))
                 .cloned()
             {
-                // Block access to my-scoped (non-our) package items from outside
-                // their declaring package.
-                if self.is_my_scoped_package_item(name)
-                    && let Some((pkg_prefix, _)) = name.rsplit_once("::")
-                    && pkg_prefix != self.current_package()
-                    && !self
-                        .current_package()
-                        .starts_with(&format!("{}::", pkg_prefix))
-                {
-                    return None;
-                }
                 return Some(def);
             }
             let prefix = format!("{}/{arity}:", name);
@@ -290,22 +289,14 @@ impl Interpreter {
             {
                 return Some(def);
             }
+            // Visibility was decided by the gate at the top of this branch.
             if let Some(def) = self
                 .registry()
                 .functions
                 .get(&Symbol::intern(name))
                 .cloned()
             {
-                if !self.is_my_scoped_package_item(name) {
-                    return Some(def);
-                } else if let Some((pkg_prefix, _)) = name.rsplit_once("::")
-                    && (pkg_prefix == self.current_package()
-                        || self
-                            .current_package()
-                            .starts_with(&format!("{}::", pkg_prefix)))
-                {
-                    return Some(def);
-                }
+                return Some(def);
             }
             // Try qualifying with the current package prefix when the
             // prefix package is visible in the current scope (i.e., exists

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -276,6 +276,16 @@ impl Interpreter {
             && !self.our_scoped_package_items.contains(fq_name)
     }
 
+    /// Must a call to this qualified name stay unresolved? True for a
+    /// `my`-scoped package item. A plain `sub f` in a module or class body is
+    /// lexical: it is exported and callable under its short name, but it is
+    /// never in the package stash, so raku answers "Could not find symbol '&f'
+    /// in 'M'" for `M::f()` — from *inside* the declaring package as well as
+    /// from outside. Only `our sub f` is a package symbol.
+    pub(crate) fn qualified_name_hidden_here(&self, fq_name: &str) -> bool {
+        fq_name.contains("::") && self.is_my_scoped_package_item(fq_name)
+    }
+
     pub(crate) fn is_name_suppressed(&self, name: &str) -> bool {
         self.suppressed_names.contains(name)
     }

--- a/t/lib/PackageSubScope.rakumod
+++ b/t/lib/PackageSubScope.rakumod
@@ -1,0 +1,18 @@
+unit module PackageSubScope;
+
+# A plain `sub` in a module body is `my`-scoped: exported and callable under
+# its short name, but NOT a package symbol.
+sub lex-sub() is export { "lex" }
+multi sub multi-lex(Int $x) is export { "multi-lex $x" }
+multi sub multi-lex(Str $x) is export { "multi-lex str $x" }
+
+# `our sub` publishes the name in the package stash.
+our sub pkg-sub() is export { "pkg" }
+our proto sub multi-pkg(|) is export {*}
+multi sub multi-pkg(Int $x) { "multi-pkg $x" }
+
+# Not even from inside the package: a lexical routine is never in the stash,
+# so the qualified form does not reach it there either.
+our sub inside-qualified-lex() is export {
+    PackageSubScope::lex-sub()
+}

--- a/t/module-sub-package-visibility.t
+++ b/t/module-sub-package-visibility.t
@@ -1,0 +1,39 @@
+use lib $?FILE.IO.parent.add('lib').Str;
+use Test;
+use PackageSubScope;
+
+# A plain `sub` in a module body is `my`-scoped. It is exported and callable
+# under its short name, but it is NOT a package symbol: raku answers
+#
+#     Could not find symbol '&lex-sub' in 'PackageSubScope'
+#
+# for `PackageSubScope::lex-sub()`. Only `our sub` is reachable that way.
+#
+# mutsu leaked both shapes. A single `sub` leaked through the qualified-call
+# retry, which strips a package prefix and calls the short name -- that retry
+# exists for a package mutsu never registered, and must not fire for one it
+# knows. A `multi sub` leaked one level deeper: multis are registered under
+# `Pkg::name/arity` keys, so the exact-name lookup that carried the
+# my-scoped gate missed, and the arity-keyed candidate scan below it handed
+# back the routine the gate had just refused.
+
+plan 8;
+
+is lex-sub(), 'lex', 'a lexical module sub is importable';
+is multi-lex(1), 'multi-lex 1', 'and so is a lexical multi';
+is pkg-sub(), 'pkg', 'an our sub is importable too';
+
+throws-like { PackageSubScope::lex-sub() }, X::AdHoc,
+    message => /"Could not find symbol '&lex-sub' in 'PackageSubScope'"/,
+    'a lexical module sub is not a package symbol';
+
+throws-like { PackageSubScope::multi-lex(1) }, X::AdHoc,
+    message => /"Could not find symbol '&multi-lex' in 'PackageSubScope'"/,
+    'nor is a lexical multi, whose candidates are arity-keyed';
+
+is PackageSubScope::pkg-sub(), 'pkg', 'an our sub is a package symbol';
+is PackageSubScope::multi-pkg(1), 'multi-pkg 1', 'and so is an our multi';
+
+throws-like { PackageSubScope::inside-qualified-lex() }, X::AdHoc,
+    message => /"Could not find symbol '&lex-sub' in 'PackageSubScope'"/,
+    'not even from inside the package -- a lexical is never in the stash';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -325,7 +325,7 @@ Exit status was measured for the first time and is already faithful — a failin
 assertion exits 1, a short plan exits 255 — which is what `prove` reads, so
 step 3 does not need work there.
 
-### Triaged, 15 left (2026-08-02), then 13
+### Triaged, 15 left (2026-08-02), then 13, then 12
 
 `module-file-var-and-callframe.t` now passes, and so does `leave-in-if-branch.t`
 — its `@events = ()` between assertions was silently dropped because the real
@@ -346,7 +346,7 @@ successfully, so the difference is genuinely in mutsu.
 | group | files | note |
 | --- | --- | --- |
 | ~~exception-class hierarchy~~ | ~~`block-lexical-scope.t`, `gate-b-callee-name-collision-and-deref-capture.t`~~, `undeclared-when-type.t` | **not one cause, and not the hierarchy ticket.** The first two were mutsu raising the *wrong class*: an undeclared variable read and a call to a CORE term constant both answered `X::Undeclared::Symbols` where raku answers `X::Undeclared` (the two are unrelated — `X::Comp` is a role, not a superclass — so registering one under the other would have been wrong). Fixed: `news/2026-08/undeclared-variable-is-not-undeclared-symbols.md`. `undeclared-when-type.t` is separate: `when SomeUndeclaredType` is `X::Comp::Group` in raku (a *parse* failure, "needs parens to avoid gobbling block") and `X::Undeclared::Symbols` in mutsu |
-| the pin asserts *native-provider* behaviour | `qualified-call-does-not-alias-builtin.t` (asserts `Test::ok(1)` **dies** — under the real module `Test::ok` legitimately exists), `test-assertion-line-number.t` | re-point the test file; not an interpreter gap |
+| ~~the pin asserts *native-provider* behaviour~~ | ~~`qualified-call-does-not-alias-builtin.t`~~, `test-assertion-line-number.t` | **the first was mislabelled and the label's reasoning was wrong.** "Under the real module `Test::ok` legitimately exists" is not true: rakudo's `Test.rakumod` declares `multi sub ok(...) is export`, a *lexical*, so `raku -e 'use Test; Test::ok(1,"q")'` says `Could not find symbol '&ok' in 'Test'` exactly as the pin asserts. mutsu leaked every module's lexical `sub`/`multi sub` under its package name. Fixed: `news/2026-08/module-sub-is-not-a-package-symbol.md`. **Verify a "re-point the pin" label against `raku` before believing it** |
 | deferred `Seq` reification destroys the value | `is-lazy-io-lines.t` | `todo/deep/deferred-seq-materialization-destroys-the-original.md` — the real `is` opens with `$got.defined`, which guts a lazy `.lines` |
 | individual gaps | `bigrat-sort-compare.t` (`cmp-ok` calls `infix:«<»` as a *routine value*; FatRat vs Num answers differently there than the compiled operator), `proxy-list-transparency.t` (`is-deeply` does not FETCH `Proxy` list elements — reports `$(Proxy, Proxy)`), `emit-done-controlflow.t`, `error-reporting-quality.t`, `group-of.t`, `io-cathandle-lazy.t` (**aborts with a stack overflow** under the real module: `.cache` on a lazy Seq still answers `Seq`, so `is-deeply`'s Seq-narrowing candidate re-dispatches to itself forever — `todo/deep/cache-on-a-lazy-seq-must-not-answer-seq.md`), `subscript-adverbs.t`, `throws-like-gather-sink.t` (+ part of `emit-done-controlflow.t`: `todo/deep/eval-context-frame-owns-the-return-target.md`), `whatever-code-fixes.t` | one at a time |
 


### PR DESCRIPTION
In Raku a routine declared with a bare `sub` is `my`-scoped, whatever package body it sits in. `is export` makes it importable under its short name; it does **not** put it in the package stash. Only `our sub` does.

```raku
unit module MScope;
sub       lex-sub()         is export { "lex" }
multi sub multi-lex(Int $x) is export { "multi-lex $x" }
our sub   pkg-sub()         is export { "pkg" }
```

```
$ raku -I. -e 'use MScope; say MScope::pkg-sub(); say MScope::lex-sub()'
pkg
Could not find symbol '&lex-sub' in 'MScope'
```

mutsu answered `lex` for the second, and `multi-lex 1` for the multi. Two independent leaks, one per shape.

### The qualified-call retry fired for a package mutsu knows

`call_function_fallback` ends with a package-prefix strip: an unresolved `Foo::bar(…)` retries as `bar(…)`. That retry exists so a call qualified with a package mutsu never registered still finds its routine, and #4-era work already gated it on *something being declared* under the short name — which is exactly the case here, since the routine really is imported. The missing half of the gate is the qualifier: when the package is one mutsu **has** registered, the qualified name already had its chance through the registry, and stripping the prefix resurrects every lexical routine of every loaded module. The retry now runs only for an unknown package, reusing the `is_known_package` predicate that already decided whether the error names `Foo::Bar` or `GLOBAL::Foo::Bar`.

### The my-scoped gate sat below the multi candidate scan

`multi sub` survived even that, because the visibility gate was attached to the wrong lookup. `dispatch_resolve` checked `is_my_scoped_package_item` on the *exact-name* registry hit — but a multi is registered under `Pkg::name/arity` keys, so the exact-name lookup misses by construction and control fell through to the arity-keyed candidate scan, which had no gate at all. It handed back the very routine the check above had been written to hide. The gate is now the first thing the qualified branch does, so every lookup below it inherits the decision; the duplicated copy further down became redundant and was removed.

While moving it, the in-package exemption went too: it let `M::lex-sub()` resolve from *inside* `M`. Raku does not — a lexical routine is in nobody's stash — and the pin asserts that under both implementations.

### Where it came from

`t/qualified-call-does-not-alias-builtin.t` asserts that `Test::ok(1)` dies. It passes under mutsu's native `Test` provider and failed under the vendored upstream module (`todo/tickets/vendor-real-test-module.md`), where `Test` is a real module. It had been filed as *"the pin asserts native-provider behaviour — under the real module `Test::ok` legitimately exists, re-point the test file"*. That reasoning was wrong: rakudo's `Test.rakumod` declares `multi sub ok(...) is export`, a lexical, so

```
$ raku -e 'use Test; plan 1; Test::ok(1, "q")'
Could not find symbol '&ok' in 'Test'
```

The pin was right and mutsu was wrong. Ledger row corrected accordingly.

### Verification

- New pin `t/module-sub-package-visibility.t` + fixture `t/lib/PackageSubScope.rakumod` — passes unchanged under `raku`.
- `make test`: `Files=2749, Tests=26199`, `Result: PASS`.
- Bundled-library gate `scripts/battery-testsuite.sh` (the thing most likely to notice a module-visibility change): **153/158, GATE PASSED**. `mzef --version` still drives vendored zef.
- Whitelisted module/package roast files (`S11-modules/{import,export,need}.t`, `S02-names/our.t`, `S12-class/{lexical,namespaced}.t`, `S06-advanced/lexical-subs.t`, `S06-multi/lexical-multis.t`) all pass.
- Real-`Test` regression ledger: 13 → 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)