### PR TITLE
feat(parser): a pointy block can destructure more than one parameter

### DIFF
--- a/news/2026-08/for-multi-destructuring-params.md
+++ b/news/2026-08/for-multi-destructuring-params.md
@@ -1,0 +1,30 @@
+# A pointy block can destructure more than one parameter
+
+`for %h.kv -> [$target, $variant], [$expected, $desc] { ... }` did not parse.
+mutsu reported `X::Syntax::Missing: Missing block`, which is what a `for` loop
+says when no `{` follows its parameter list — and none did, because
+`parse_for_params` handled a `[...]` / `(...)` destructuring pattern only as the
+*whole* parameter list. That branch returned as soon as it closed the bracket,
+leaving `, [$expected, $desc] {` unconsumed.
+
+The same hole existed on the other side: a pattern in a *later* position
+(`-> $a, [$b, $c]`) reached the general multi-parameter loop, which only knew how
+to parse an ordinary parameter.
+
+Both are now one shape. `parse_destructuring_or_plain_param` parses either kind
+of entry, giving a pattern a synthetic `__for_unpack_N` name, and the
+multi-parameter loop uses it for every position. The compiler's destructure
+emission — previously inline in the single-pattern path — became the
+`destructure_binds` closure, applied to each parameter that carries a
+sub-signature *after* the per-element binds have run, so the pattern unpacks a
+value that is already there.
+
+The semantics follow from the existing multi-parameter rule: each entry takes one
+element of the iteration chunk, and a pattern entry then unpacks the element it
+took. So `for (1,2), (3,4) -> [$a,$b], [$c,$d]` runs once with `1234`, while the
+single-pattern `for ((1,2), (3,4)) -> [$a,$b]` still runs twice.
+
+This was the parse blocker on Cro::HTTP's `t/http-router.rakutest`, which walks
+an `Array`-keyed hash exactly that way.
+
+Pinned by `t/for-multi-destructuring-params.t` (checked against raku).

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1130,10 +1130,14 @@ impl Compiler {
         {
             bind_stmts.push(bind_stmt(single_param.clone(), Expr::Var("_".to_string())));
         }
-        if let Some(def) = param_def
-            && let Some(sub_params) = &def.sub_signature
-        {
-            let target_name = param.as_deref().unwrap_or("_").to_string();
+        // Unpack a destructuring pattern out of the value already bound to
+        // `target_name`. Used both for the single-pattern pointy block
+        // (`-> [$a, $b]`, whose target is the whole iteration value) and for each
+        // pattern of a multi-parameter one (`-> [$a, $b], [$c, $d]`, whose
+        // targets are the per-element synthetic params bound further below).
+        let destructure_binds = |target_name: String,
+                                 sub_params: &[crate::ast::ParamDef],
+                                 bind_stmts: &mut Vec<Stmt>| {
             let mut positional_index = 0usize;
             for sub in sub_params {
                 if sub.name.is_empty() {
@@ -1285,6 +1289,15 @@ impl Compiler {
                     positional_index += 1;
                 }
             }
+        };
+        if let Some(def) = param_def
+            && let Some(sub_params) = &def.sub_signature
+        {
+            destructure_binds(
+                param.as_deref().unwrap_or("_").to_string(),
+                sub_params,
+                &mut bind_stmts,
+            );
         }
         // `_.elems` on the per-iteration chunk array — the number of source
         // elements that actually flowed into this batch.
@@ -1394,6 +1407,20 @@ impl Compiler {
         }
         if let Some(stmt) = deferred_topic {
             bind_stmts.push(stmt);
+        }
+        // A multi-parameter pointy block may destructure any of its parameters
+        // (`-> [$target, $variant], [$expected, $desc]`). The parameter itself is
+        // bound from its chunk element above; unpack it now that it holds a value.
+        for (i, def) in params_def.iter().enumerate() {
+            if let Some(sub_params) = &def.sub_signature
+                && let Some(name) = params.get(i)
+            {
+                destructure_binds(
+                    name.strip_prefix('\\').unwrap_or(name).to_string(),
+                    sub_params,
+                    &mut bind_stmts,
+                );
+            }
         }
         // Sigilless multi-params (`-> \k, \v`) are raw bindings that alias the
         // source element directly; in Raku they are writable and modifications

--- a/src/parser/stmt/control/for_params.rs
+++ b/src/parser/stmt/control/for_params.rs
@@ -49,6 +49,12 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
             let (r, sub_params) = super::super::parse_param_list_pub(r)?;
             let (r, _) = ws(r)?;
             let (r, _) = parse_char(r, ')')?;
+            // See the `[` branch below: a comma after the pattern means several
+            // destructuring parameters, one per chunk element.
+            let (after_comma, _) = ws(r)?;
+            if after_comma.starts_with(',') {
+                return parse_multi_destructuring_params(stripped, rw_block);
+            }
             let (r, _) = skip_pointy_return_type(r)?;
             let unpack_name = "__for_unpack".to_string();
             let unpack_def = ParamDef {
@@ -151,6 +157,14 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
                 }
             }
             let (r, _) = parse_char(r, ']')?;
+            // More than one destructuring parameter (`-> [$a, $b], [$c, $d]`)
+            // needs the general multi-parameter path: each pattern binds one
+            // element of the chunk and unpacks it. The single-pattern shape below
+            // instead destructures the whole iteration value.
+            let (after_comma, _) = ws(r)?;
+            if after_comma.starts_with(',') {
+                return parse_multi_destructuring_params(stripped, rw_block);
+            }
             let (r, _) = skip_pointy_return_type(r)?;
             let unpack_name = "__for_unpack".to_string();
             let unpack_def = ParamDef {
@@ -225,7 +239,13 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
             loop {
                 let (r2, _) = parse_char(r, ',')?;
                 let (r2, _) = ws(r2)?;
-                let (r2, next) = parse_for_pointy_param(r2)?;
+                // A later parameter may itself be a destructuring pattern
+                // (`-> $a, [$b, $c]`); it binds one chunk element and unpacks it,
+                // so give it a synthetic name for the compiler to bind first.
+                let (r2, mut next) = parse_destructuring_or_plain_param(r2)?;
+                if next.name.is_empty() {
+                    next.name = format!("__for_unpack_{}", params_def.len());
+                }
                 if next.traits.iter().any(|t| t == "rw") {
                     any_rw = true;
                 }
@@ -263,6 +283,95 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
     } else {
         Ok((input, (None, None, Vec::new(), Vec::new(), false, false)))
     }
+}
+
+/// Parse a pointy parameter list in which at least one parameter is a
+/// destructuring pattern and there is more than one parameter:
+/// `-> [$target, $variant], [$expected, $desc] { ... }`.
+///
+/// Each entry binds one element of the iteration chunk, exactly like an ordinary
+/// multi-parameter pointy block; a pattern entry then unpacks the element it
+/// bound. It gets a synthetic name so the compiler has something to bind to
+/// before destructuring it.
+///
+/// `input` is the text just after the `->` / `<->`.
+fn parse_multi_destructuring_params(input: &str, rw_block: bool) -> PResult<'_, ForParams> {
+    let mut r = input;
+    let mut params = Vec::new();
+    let mut params_def = Vec::new();
+    let mut any_rw = rw_block;
+    loop {
+        let (r2, _) = ws(r)?;
+        let (r2, mut def) = parse_destructuring_or_plain_param(r2)?;
+        if def.sub_signature.is_some() && def.name.is_empty() {
+            def.name = format!("__for_unpack_{}", params_def.len());
+        }
+        if def.traits.iter().any(|t| t == "rw") {
+            any_rw = true;
+        }
+        params.push(if def.sigilless {
+            format!("\\{}", def.name)
+        } else {
+            def.name.clone()
+        });
+        params_def.push(def);
+        let (r2, _) = ws(r2)?;
+        let Some(r3) = r2.strip_prefix(',') else {
+            r = r2;
+            break;
+        };
+        r = r3;
+    }
+    let (r, _) = ws(r)?;
+    let r = if let Some(after_arrow) = r.strip_prefix("-->") {
+        let (after_arrow, _) = super::super::parse_return_type_annotation_pub(after_arrow)?;
+        let (after_arrow, _) = ws(after_arrow)?;
+        after_arrow
+    } else {
+        r
+    };
+    Ok((r, (None, None, params, params_def, any_rw, false)))
+}
+
+/// One entry of a pointy parameter list: a `[...]` / `(...)` destructuring
+/// pattern (returned with an empty name for the caller to fill in) or an
+/// ordinary parameter.
+fn parse_destructuring_or_plain_param(input: &str) -> PResult<'_, ParamDef> {
+    let (open, close) = match input.as_bytes().first() {
+        Some(b'[') => ('[', ']'),
+        Some(b'(') => ('(', ')'),
+        _ => return parse_for_pointy_param(input),
+    };
+    let (r, _) = parse_char(input, open)?;
+    let (r, _) = ws(r)?;
+    let (r, sub_params) = super::super::parse_param_list_pub(r)?;
+    let (r, _) = ws(r)?;
+    let (r, _) = parse_char(r, close)?;
+    Ok((
+        r,
+        ParamDef {
+            name: String::new(),
+            default: None,
+            multi_invocant: true,
+            required: false,
+            named: false,
+            slurpy: false,
+            sigilless: false,
+            type_constraint: None,
+            literal_value: None,
+            sub_signature: Some(sub_params),
+            where_constraint: None,
+            traits: Vec::new(),
+            double_slurpy: false,
+            onearg: false,
+            optional_marker: false,
+            outer_sub_signature: None,
+            code_signature: None,
+            is_invocant: false,
+            shape_constraints: None,
+            block_param: true,
+        },
+    ))
 }
 
 fn parse_for_pointy_param(input: &str) -> PResult<'_, ParamDef> {

--- a/t/for-multi-destructuring-params.t
+++ b/t/for-multi-destructuring-params.t
@@ -1,0 +1,77 @@
+use Test;
+
+plan 8;
+
+# A pointy block may take more than one parameter *and* destructure them:
+# `-> [$a, $b], [$c, $d]` binds one chunk element per pattern and unpacks each.
+# Only a single pattern used to parse; a second one left the `{` unconsumed and
+# the loop reported X::Syntax::Missing.
+
+{
+    my @seen;
+    for (1, 2), (3, 4) -> [$a, $b], [$c, $d] {
+        @seen.push: "$a$b$c$d";
+    }
+    is @seen, ['1234'], 'two bracket patterns unpack their own element';
+}
+
+{
+    my @seen;
+    for (1, 2), (3, 4) -> ($a, $b), ($c, $d) {
+        @seen.push: "$a$b$c$d";
+    }
+    is @seen, ['1234'], 'two paren patterns unpack their own element';
+}
+
+{
+    my @seen;
+    for (1, 2), 3 -> [$a, $b], $c {
+        @seen.push: "$a$b$c";
+    }
+    is @seen, ['123'], 'a pattern mixes with a plain parameter';
+}
+
+{
+    my @seen;
+    for 1, (2, 3) -> $a, [$b, $c] {
+        @seen.push: "$a$b$c";
+    }
+    is @seen, ['123'], 'a plain parameter mixes with a pattern';
+}
+
+# More than one iteration: the chunk advances two elements at a time.
+{
+    my @seen;
+    for (1, 2), (3, 4), (5, 6), (7, 8) -> [$a, $b], [$c, $d] {
+        @seen.push: "$a$b-$c$d";
+    }
+    is @seen, ['12-34', '56-78'], 'the loop batches by the parameter count';
+}
+
+# The shape the Cro router test uses: an Array-keyed hash walked with .kv.
+{
+    my %h{Array} = ['/outer', 1] => ['a', 'first'];
+    my @seen;
+    for %h.kv -> [$target, $variant], [$body, $desc] {
+        @seen.push: "$target $variant $body $desc";
+    }
+    is @seen, ['/outer 1 a first'], 'Array-keyed hash .kv destructures both sides';
+}
+
+# A single pattern still destructures the whole iteration value.
+{
+    my @seen;
+    for ((1, 2), (3, 4)) -> [$a, $b] {
+        @seen.push: "$a$b";
+    }
+    is @seen, ['12', '34'], 'one pattern still unpacks the whole element';
+}
+
+# Named destructuring works per pattern too.
+{
+    my @seen;
+    for %(:a(1)), %(:b(2)) -> (:$a), (:$b) {
+        @seen.push: "{$a // 'x'}{$b // 'y'}";
+    }
+    is @seen, ['12'], 'named patterns unpack their own element';
+}


### PR DESCRIPTION
`for %h.kv -> [$target, $variant], [$expected, $desc] { ... }` did not parse.
mutsu reported `X::Syntax::Missing: Missing block` — which is what a `for` loop
says when no `{` follows its parameter list, and none did: `parse_for_params`
handled a `[...]` / `(...)` destructuring pattern only as the *whole* parameter
list, and that branch returned as soon as it closed the bracket, leaving
`, [$expected, $desc] {` unconsumed.

The mirror hole existed too: a pattern in a *later* position (`-> $a, [$b, $c]`)
reached the general multi-parameter loop, which only knew how to parse an
ordinary parameter.

## The fix

- `parse_destructuring_or_plain_param` parses either kind of entry, giving a
  pattern a synthetic `__for_unpack_N` name so the compiler has something to bind
  before unpacking it. The multi-parameter loop uses it for every position.
- The compiler's destructure emission, previously inline in the single-pattern
  path, became the `destructure_binds` closure. It is applied to each parameter
  that carries a sub-signature *after* the per-element binds have run, so the
  pattern unpacks a value that is already there.

Semantics follow from the existing multi-parameter rule — each entry takes one
element of the iteration chunk, and a pattern entry then unpacks the element it
took:

```raku
for (1,2), (3,4) -> [$a,$b], [$c,$d] { }   # runs once:  1234
for ((1,2), (3,4)) -> [$a,$b] { }          # runs twice: 12, 34
```

This was the parse blocker on Cro::HTTP's `t/http-router.rakutest`, which walks
an `Array`-keyed hash exactly that way; it now gets 19 tests in before hitting an
unrelated blocker.

## Testing

- `t/for-multi-destructuring-params.t` — 8 cases, every one checked against raku
  (bracket/paren patterns, patterns mixed with plain params in either order,
  batching across iterations, named patterns, and the single-pattern shape still
  unpacking the whole element).
- Full local TAP suite: 2751 files / 26215 tests PASS.
- Roast slice `S04-`/`S06-`/`S12-`/`S14-`/`S32-list`: 346 files / 9045 tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)