### PR TITLE
fix(parser): `note("hi")` is a call, not bare `note` plus a stray statement

### DIFF
--- a/news/2026-08/note-with-parens.md
+++ b/news/2026-08/note-with-parens.md
@@ -1,0 +1,31 @@
+# `note("hi")` printed "Noted" and warned about a string in sink context
+
+`note` with an attached parenthesis was not a call at all:
+
+```raku
+note("hi");     # raku: writes "hi" to stderr
+                # mutsu: wrote "Noted", then
+                #   Useless use of constant string "hi" in sink context
+```
+
+`note_stmt` matched the keyword and then, finding no whitespace to start an
+argument list, fell through to its no-argument form (bare `note` is legal and
+prints `Noted`). It returned `Stmt::Note(vec![])` with `("hi")` still unconsumed,
+so statement dispatch parsed the leftover as its own statement.
+
+`say`, `print` and `put` do not have the problem because they have no
+no-argument form: their `ws1` fails on `say(...)`, the statement parser bails,
+and dispatch reaches the general call parser — `note` is in
+`BUILTIN_FUNCTION_NAMES` too, so all it needed was the same bail-out.
+`note_stmt` now returns an error when the keyword is immediately followed by
+`(`.
+
+A space still means the listop form, so `note ("a", "b")` keeps passing one
+`List` argument (stderr `(a b)`) while `note("a", "b")` passes two — matching
+raku in both cases.
+
+Found while instrumenting Cro::HTTP's router: a debug `note($msg)` added to a
+vendored module printed `Noted` instead of the message, which is a fine way to
+lose an afternoon.
+
+Pinned by `t/note-with-parens.t` (checked against raku).

--- a/src/parser/stmt/simple/io_stmts.rs
+++ b/src/parser/stmt/simple/io_stmts.rs
@@ -98,6 +98,15 @@ pub(crate) fn put_stmt(input: &str) -> PResult<'_, Stmt> {
 pub(crate) fn note_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("note", input).ok_or_else(|| PError::expected("note statement"))?;
     shadowed_by_user_sub("note")?;
+    // `note(...)` — parenthesis attached, no space — is an ordinary call, not the
+    // listop statement. Bail out so statement dispatch reaches the general call
+    // parser, exactly as `say(...)` does (`say_stmt` gets there by failing its
+    // `ws1`). Without this, `note` fell through to the no-argument form below and
+    // left `("hi")` behind as a separate statement, so `note("hi")` printed
+    // "Noted" and warned about a string in sink context.
+    if rest.starts_with('(') {
+        return Err(PError::expected("note call with parentheses"));
+    }
     // `note` with no arguments is valid (prints "Noted\n")
     if let Ok((rest2, _)) = ws1(rest) {
         // Check for colon invocant syntax: `note EXPR:` or `note EXPR: arg1, arg2`

--- a/t/note-with-parens.t
+++ b/t/note-with-parens.t
@@ -1,0 +1,34 @@
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+plan 6;
+
+# `note(...)` with the parenthesis attached is an ordinary call. mutsu's
+# `note` statement parser tolerated a missing argument list, so it matched the
+# no-argument form and left `("hi")` behind as a separate statement: the program
+# printed "Noted" and warned about a string in sink context.
+
+is_run 'note("hi")',
+    { out => '', err => "hi\n", status => 0 },
+    'note(ARG) writes its argument to stderr';
+
+is_run 'my $x = "a"; note($x)',
+    { out => '', err => "a\n", status => 0 },
+    'note(VAR) writes the variable to stderr';
+
+is_run 'note "hi"',
+    { out => '', err => "hi\n", status => 0 },
+    'the listop form is unchanged';
+
+is_run 'note',
+    { out => '', err => "Noted\n", status => 0 },
+    'bare note still prints Noted';
+
+is_run 'note()',
+    { out => '', err => "Noted\n", status => 0 },
+    'note() with an empty argument list prints Noted';
+
+is_run 'note ("a", "b")',
+    { out => '', err => "(a b)\n", status => 0 },
+    'a space before the paren still passes one List argument';


### PR DESCRIPTION
```raku
note("hi");     # raku:  writes "hi" to stderr
                # mutsu: wrote "Noted", then
                #   Useless use of constant string "hi" in sink context
```

`note_stmt` matched the keyword and then, finding no whitespace to start an
argument list, fell through to its no-argument form (bare `note` is legal and
prints `Noted`). It returned `Stmt::Note(vec![])` with `("hi")` still unconsumed,
so statement dispatch parsed the leftover as its own statement.

`say`, `print` and `put` do not have the problem only because they have no
no-argument form: their `ws1` fails on `say(...)`, the statement parser bails,
and dispatch reaches the general call parser. `note` is in
`BUILTIN_FUNCTION_NAMES` too, so all it needed was the same bail-out when the
keyword is immediately followed by `(`.

A space still selects the listop form, so `note ("a", "b")` keeps passing one
`List` argument (stderr `(a b)`) while `note("a", "b")` passes two — matching raku
in both cases.

Found while instrumenting Cro::HTTP's router: a debug `note($msg)` added to a
vendored module printed `Noted` instead of the message.

## Testing

- `t/note-with-parens.t` — 6 `is_run` cases, all checked against raku
  (`note(ARG)`, `note(VAR)`, the listop form, bare `note`, `note()`, and the
  space-before-paren List form).
- Full local TAP suite: 2751 files / 26213 tests PASS.
- Roast slice `S04-`/`S06-`/`S16-`: 208 files / 5482 tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)