### PR TITLE
fix(runtime): close the two blockers on retiring the native Test::Util provider

### DIFF
--- a/news/2026-08/a-warning-resumes-at-its-raise-site.md
+++ b/news/2026-08/a-warning-resumes-at-its-raise-site.md
@@ -1,0 +1,43 @@
+# A resumable warning is settled where it is raised
+
+`warn` has been settled at its raise site for a while: `builtin_warn` prints and
+returns inline when no `CONTROL` handler is active, and runs a resume-safe
+handler inline otherwise, so the deep computation continues exactly where the
+warning came from. `raise_resumable_warning` is the shared entry point for that,
+and its doc comment already warned that op-level warn sites must use it rather
+than returning a bare `warn_signal_with_resume` error — because the unwinding
+signal carries its resume value in `return_value`, which a routine boundary
+applies as an explicit `return`, silently abandoning the rest of the body.
+
+Several sites did exactly that anyway. `Int.Numeric`, `Nil.Str`, `Nil.abs` and
+friends are *pure* native methods with no `&mut Interpreter`, so returning the
+error was their only option; two interpreter-side sites (a role-composed
+`Numeric` type object, and the generic type-object numeric coercion) simply had
+not been converted. The result:
+
+```raku
+sub g {
+    my ($did, $msg) = False;
+    { Int.Numeric }();
+    say "after call";                      # never ran
+    CONTROL { when CX::Warn { $did = True; $msg = .message; .resume } }
+    say "g did=$did msg=$msg";             # never ran
+}
+```
+
+The handler fired, but `.resume` had no raise site to return to, so the rest of
+`g`'s body was lost. An explicit `warn "boom"` in the same position worked.
+
+The pure natives are now settled at their single dispatch chokepoint:
+`Interpreter::try_native_method` (the `&mut self` caller of
+`native_method_0arg`/`_1arg`/`_2arg`) re-raises a `warn_signal_with_resume`
+result through `raise_resumable_warning`. The two interpreter-side sites call it
+directly. When no resume-safe handler is active the fallback is the same
+unwinding signal as before, so nothing changes for `CATCH`-style handlers.
+
+This is roast `Test::Util`'s `warns-like` shape: it calls the code and then
+declares `CONTROL { when CX::Warn { … .resume } }` in the same block, so under
+the real module every `warns-like { Int.Numeric }` — nine of them in
+`S02-literals/allomorphic.t` alone — produced no test at all.
+
+Pin: `t/warn-resumes-at-the-raise-site.t`, byte-compatible with `raku`.

--- a/news/2026-08/bail-out-exits-255.md
+++ b/news/2026-08/bail-out-exits-255.md
@@ -1,0 +1,15 @@
+# `bail-out` exits 255
+
+Rakudo's `Test.rakumod` ends `bail-out` with `exit 255` right after emitting the
+`Bail out!` line. mutsu's native provider emitted the line, set the interpreter's
+`halted` flag and marked the TAP state as bailed out — and then returned a clean
+`Ok(())` from the run loop, so the process exited 0. `prove` therefore read a
+bailing-out file as a successful run, and `Test::Util`'s
+`is_run ..., :255status` — which is what `roast/S24-testing/7-bail_out.t`
+asserts on all four of its subtests — saw status 0.
+
+The bailed-out early return now sets `exit_code = 255` before returning, which
+is the same channel the "planned N but ran M" dubious case already used.
+
+Pin: `t/bail-out-exit-status.t` (both the bare and the `bail-out "reason"`
+forms, checking status and the emitted output), byte-compatible with `raku`.

--- a/news/2026-08/composite-promise-replays-its-proc-taps.md
+++ b/news/2026-08/composite-promise-replays-its-proc-taps.md
@@ -1,0 +1,44 @@
+# A `Proc::Async` tap is replayed through a composite promise too
+
+mutsu delivers a `Proc::Async` output tap once, later, on the main thread:
+`native_supply_mut_methods.rs` deliberately does not start a live-channel
+consumer for a proc output supply, and `replay_proc_taps` flushes the collected
+output when the process's promise is awaited. The hook fired on an `await` /
+`.result` whose *result* was a `Proc` — which is only true of the promise
+`$proc.start` returns.
+
+That made the standard "run it, but give up after N seconds" idiom deliver
+nothing, because a `Promise.anyof`/`allof` composite resolves to a plain `True`:
+
+```raku
+my $p = Proc::Async.new: $*EXECUTABLE.absolute, '-e', 'say "B"';
+my $s = '';
+$p.stdout.tap: -> $a { $s ~= $a };
+my $pr = $p.start;
+await Promise.anyof: Promise.in(10), $pr;
+say $s.raku;        # raku: "B\n"   mutsu: ""
+await $pr; say $s.raku; # mutsu: "B\n" — the tap fired only here
+```
+
+`Promise.allof` already recorded its source promises in a registry (the react
+driver waits on them to settle a `whenever Promise.allof(...)`). That registry
+now records `anyof`'s sources as well, tagged with which combinator produced
+them, and `await`/`.result` walk it: for a promise whose own result is not a
+`Proc`, every source that has *already settled* gets its taps replayed, and the
+walk recurses so a composite of composites works. A still-`Planned` source is
+skipped deliberately — waiting on it would reintroduce the hang the composite
+exists to avoid. The kind tag keeps the react driver's behaviour byte-identical:
+it blocks on the full source list only for `allof`.
+
+This is the shallow fix. The real one is push-delivery for proc output supplies,
+the way ADR-0008 made the other supplies push-based (#4636); the "replay at
+await" design is what makes `.tap` observably different from `react`/`whenever`
+on the same stream. But it closes the second of the two blockers in
+`todo/tickets/retire-native-test-util-overrides.md`: `Test::Util`'s
+`doesn't-hang` collects the child's output in a `.stdout.tap` closure and then
+does exactly the `await Promise.anyof: Promise.in($wait), $prog.start` above.
+
+Pin: `t/composite-promise-replays-proc-taps.t` (anyof, allof, `.result` on the
+composite, and a `whenever Promise.allof` regression guard). Note the filename
+avoids a `proc-async-*` prefix — `.gitignore` claims that pattern for the
+scratch files `S17-procasync` tests leave behind.

--- a/news/2026-08/io-path-accepts-is-inherited-by-its-spec-subclasses.md
+++ b/news/2026-08/io-path-accepts-is-inherited-by-its-spec-subclasses.md
@@ -1,0 +1,31 @@
+# `IO::Path.ACCEPTS` is inherited by the SPEC-variant subclasses
+
+Rakudo declares `ACCEPTS` on `IO::Path`, so `IO::Path::Unix`, `::Win32`,
+`::Cygwin` and `::QNX` inherit it. mutsu's smartmatch arms — both the pure
+value-level one (`vm/vm_smart_match.rs`) and the interpreter-level one
+(`runtime/seq_helpers/smart_match.rs`) — guarded on the *exact* class name
+`IO::Path`, so any comparison involving a subclass instance fell through to the
+generic instance arm and answered `False`:
+
+```raku
+my $a = IO::Path::Unix.new('/foo/').add('bar');
+my $b = IO::Path::Unix.new('/foo/bar');
+say $a.resolve.raku eq $b.resolve.raku;   # True in both
+say $a.resolve ~~ $b.resolve;             # raku: True   mutsu: False
+```
+
+Four arms in each file were affected: `IO::Path ~~ IO::Path`, `Cool ~~
+IO::Path`, `IO::Path ~~ Str`, and the file-test adverbs (`$path ~~ :e`, `:d`,
+`:f`, …), which are candidates on `IO::Path` too. All eight now test membership
+of the built-in family through the existing
+`Interpreter::is_io_path_lexical_class` predicate, which is the same set the
+native path-method fast path already uses.
+
+The concrete consumer is `Test::Util`'s `is-path`, which is
+`cmp-ok $got.resolve, '~~', $exp.resolve, $desc` — under the real Test::Util
+module (as opposed to mutsu's native override of it) that assertion could never
+pass. It was one of the two blockers listed in
+`todo/tickets/retire-native-test-util-overrides.md`.
+
+Pin: `t/io-path-accepts-subclass.t`, which asserts the same ten comparisons
+under `raku` and mutsu.

--- a/src/runtime/builtins_system_async.rs
+++ b/src/runtime/builtins_system_async.rs
@@ -319,16 +319,10 @@ impl Interpreter {
                         // Raku wraps the broken Promise's cause in X::Await::Died.
                         return Err(self.await_died_error(result));
                     }
-                    // Replay deferred Proc::Async taps
-                    if let ValueView::Instance {
-                        class_name,
-                        attributes,
-                        ..
-                    } = result.view()
-                        && class_name == "Proc"
-                    {
-                        self.replay_proc_taps(&attributes);
-                    }
+                    // Replay deferred Proc::Async taps — the promise's own Proc
+                    // result, or those of a settled component of an
+                    // allof/anyof composite.
+                    self.replay_settled_proc_taps(&shared, &result);
                     let result = Self::unwrap_async_status_result(result)?;
                     results.push(result);
                     // Sync shared variables after each thread completes

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -318,9 +318,9 @@ impl Interpreter {
         // `is_test_function_name` (which also covers roast's `Test::Util` /
         // `Test::Tap` helpers). Those modules really are loaded from source, so
         // mutsu's natives override live declarations there today; flipping that
-        // is a separate provider retirement that needs `Proc::Async` output taps
-        // and `IO::Path ~~ IO::Path` fixed first — see
-        // todo/tickets/retire-native-test-util-overrides.md.
+        // is a separate provider retirement — see
+        // todo/tickets/retire-native-test-util-overrides.md, which now tracks
+        // the seven roast files the widened guard exposes.
         let user_declared = self.user_test_decl_beats_native(name, &args);
         if !user_declared && let Some(result) = self.call_test_function(name, &args)? {
             return Ok(result);

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -530,7 +530,11 @@ impl Interpreter {
                     type_name
                 );
                 let new_val = self.call_method_with_values(target.clone(), "new", vec![])?;
-                return Err(RuntimeError::warn_signal_with_resume(msg, new_val));
+                // Settle the warning here, at the raise site: an unwinding
+                // `warn_signal_with_resume` carries its resume value in
+                // `return_value`, which the enclosing routine boundary applies
+                // as an explicit `return`.
+                return self.raise_resumable_warning(&msg, new_val);
             }
         }
 

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -258,6 +258,46 @@ impl Interpreter {
         }
     }
 
+    /// Replay the deferred `Proc::Async` taps that a settled promise stands for.
+    ///
+    /// The direct case is a promise whose own result is the `Proc` — that is
+    /// `$proc.start`, and it is what `await $promise` / `$promise.result` see.
+    /// A `Promise.allof`/`anyof` composite resolves to a plain `True`, so its
+    /// components' taps would never be replayed even though awaiting the
+    /// composite is exactly how `Test::Util`'s `doesn't-hang` (and any
+    /// "run it, but give up after N seconds" idiom) waits for the child. Walk
+    /// the registered sources and replay every one that has already settled;
+    /// a still-`Planned` source has produced no `Proc` yet, and re-awaiting it
+    /// here would reintroduce the hang the composite exists to avoid.
+    pub(in crate::runtime) fn replay_settled_proc_taps(
+        &mut self,
+        promise: &crate::value::SharedPromise,
+        result: &Value,
+    ) {
+        if let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = result.view()
+            && class_name == "Proc"
+        {
+            self.replay_proc_taps(&attributes);
+            return;
+        }
+        let Some((_, sources)) =
+            super::super::native_methods::take_promise_combinator_sources(promise)
+        else {
+            return;
+        };
+        for source in sources {
+            if !source.is_resolved() {
+                continue;
+            }
+            let (source_result, _, _) = source.wait();
+            self.replay_settled_proc_taps(&source, &source_result);
+        }
+    }
+
     /// Replay deferred Proc::Async taps on the main thread.
     /// Called when a Proc result is retrieved via .result or await.
     pub(in crate::runtime) fn replay_proc_taps(

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2003,7 +2003,11 @@ impl Interpreter {
                             "Use of uninitialized value of type {} in numeric context",
                             name
                         );
-                        Err(RuntimeError::warn_signal_with_resume(msg, Value::int(0)))
+                        // Settled at the raise site — see
+                        // `raise_resumable_warning`: an unwinding
+                        // `warn_signal_with_resume` would be applied as an
+                        // explicit `return` by the enclosing routine boundary.
+                        self.raise_resumable_warning(&msg, Value::int(0))
                     }
                 } else {
                     Err(RuntimeError::new(format!(

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -150,16 +150,10 @@ impl Interpreter {
                     err.exception = Some(Box::new(ex));
                     Err(err)
                 } else {
-                    // Replay deferred taps for Proc::Async results
-                    if let ValueView::Instance {
-                        class_name,
-                        attributes,
-                        ..
-                    } = result.view()
-                        && class_name == "Proc"
-                    {
-                        self.replay_proc_taps(&attributes);
-                    }
+                    // Replay deferred taps for Proc::Async results — the
+                    // promise's own, or those of a settled component of an
+                    // allof/anyof composite.
+                    self.replay_settled_proc_taps(shared, &result);
                     Ok(result)
                 }
             }

--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -232,7 +232,11 @@ impl Interpreter {
                 Ok(p) => p,
                 Err(e) => return Some(Err(e)),
             };
-            super::native_methods::register_promise_combinator_sources(&promise, promises.clone());
+            super::native_methods::register_promise_combinator_sources(
+                &promise,
+                super::native_methods::PromiseCombinator::Allof,
+                promises.clone(),
+            );
             if promises.is_empty() {
                 promise.keep(Value::TRUE, String::new(), String::new());
                 return Some(Ok(ret));
@@ -268,6 +272,15 @@ impl Interpreter {
                 promise.keep(Value::TRUE, String::new(), String::new());
                 return Some(Ok(ret));
             }
+            // Record the sources so that awaiting the composite can still replay
+            // the deferred `Proc::Async` taps of whichever source has settled —
+            // an `anyof` result is a plain `True`, so the `Proc`-result hook in
+            // `await` would otherwise never fire.
+            super::native_methods::register_promise_combinator_sources(
+                &promise,
+                super::native_methods::PromiseCombinator::Anyof,
+                promises.clone(),
+            );
             // Resolve on the first input to settle, via each input's
             // `on_resolve` waiter queue — no polling thread. `try_keep` makes
             // the first resolver win and later ones no-ops.

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -41,8 +41,9 @@ pub(in crate::runtime) use state::{
 };
 // Supplier registry accessors driven by the VM-side react/supply loop.
 pub(crate) use state::{
-    next_supplier_id, supplier_register_promise, supplier_sink_register, supplier_sink_unregister,
-    supplier_sinks_register_batch, supplier_snapshot, take_promise_combinator_sources,
+    PromiseCombinator, next_supplier_id, supplier_register_promise, supplier_sink_register,
+    supplier_sink_unregister, supplier_sinks_register_batch, supplier_snapshot,
+    take_promise_combinator_sources,
 };
 pub(in crate::runtime) use state_lock::next_lock_id;
 pub(in crate::runtime) use state_lock::next_semaphore_id;

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -47,7 +47,18 @@ fn supply_enc_map() -> &'static SupplyEncMap {
     MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
-type PromiseCombinatorMap = std::sync::Mutex<HashMap<usize, Vec<SharedPromise>>>;
+/// Which combinator produced a composite promise. `Promise.allof` settles once
+/// every source has settled, `Promise.anyof` on the first one — the react driver
+/// may only block on the whole source list for `allof`, while deferred
+/// `Proc::Async` tap replay applies to both.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum PromiseCombinator {
+    Allof,
+    Anyof,
+}
+
+type PromiseCombinatorMap =
+    std::sync::Mutex<HashMap<usize, (PromiseCombinator, Vec<SharedPromise>)>>;
 
 fn promise_combinator_map() -> &'static PromiseCombinatorMap {
     static MAP: OnceLock<PromiseCombinatorMap> = OnceLock::new();
@@ -351,7 +362,7 @@ pub(in crate::runtime) fn visit_supply_state_roots(visitor: &mut dyn crate::gc::
         }
     }
     if let Ok(map) = promise_combinator_map().lock() {
-        for promises in map.values() {
+        for (_, promises) in map.values() {
             for p in promises {
                 visitor.visit_value(&Value::promise(p.clone()));
             }
@@ -830,16 +841,17 @@ pub(in crate::runtime) fn get_supply_enc(supply_id: u64) -> Option<String> {
 
 pub(in crate::runtime) fn register_promise_combinator_sources(
     promise: &SharedPromise,
+    kind: PromiseCombinator,
     sources: Vec<SharedPromise>,
 ) {
     if let Ok(mut map) = promise_combinator_map().lock() {
-        map.insert(promise.id(), sources);
+        map.insert(promise.id(), (kind, sources));
     }
 }
 
 pub(crate) fn take_promise_combinator_sources(
     promise: &SharedPromise,
-) -> Option<Vec<SharedPromise>> {
+) -> Option<(PromiseCombinator, Vec<SharedPromise>)> {
     if let Ok(mut map) = promise_combinator_map().lock() {
         map.remove(&promise.id())
     } else {

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -843,6 +843,10 @@ impl Interpreter {
             self.output_sink_mut().stderr_output.push('\n');
         }
         if self.tap.bailed_out() {
+            // Rakudo's `bail-out` ends the process with status 255 (`Test.rakumod`
+            // does `exit 255` after emitting "Bail out!"), which is what `prove`
+            // and `Test::Util`'s `is_run ..., :255status` read.
+            self.exit_code = 255;
             return Ok(());
         }
         if let Some(state) = self.tap.state() {

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -840,7 +840,7 @@ impl Interpreter {
                     ..
                 },
                 ValueView::Pair(key, val),
-            ) if class_name == "IO::Path"
+            ) if Self::is_io_path_lexical_class(class_name.as_str())
                 && val.as_bool().is_some()
                 && matches!(
                     key.as_str(),
@@ -1489,7 +1489,9 @@ impl Interpreter {
                     attributes: attrs_b,
                     ..
                 },
-            ) if cn_a == "IO::Path" && cn_b == "IO::Path" => {
+            ) if Self::is_io_path_lexical_class(cn_a.as_str())
+                && Self::is_io_path_lexical_class(cn_b.as_str()) =>
+            {
                 let (path_a, cwd_a) = Self::io_path_attrs_for_accepts(&attrs_a);
                 let (path_b, cwd_b) = Self::io_path_attrs_for_accepts(&attrs_b);
                 Self::io_path_cleanup_absolute(&path_a, &cwd_a)
@@ -1503,7 +1505,7 @@ impl Interpreter {
                     attributes: attrs_b,
                     ..
                 },
-            ) if cn_b == "IO::Path"
+            ) if Self::is_io_path_lexical_class(cn_b.as_str())
                 && !matches!(
                     left.view(),
                     ValueView::Junction { .. }
@@ -1635,7 +1637,9 @@ impl Interpreter {
             // IO::Path ~~ Str: compare path string representation with string.
             // In Raku, Str.ACCEPTS(IO::Path) stringifies the IO::Path and compares.
             // This handles cases like `dir().grep("filename")` after chdir.
-            (ValueView::Instance { class_name: cn, .. }, ValueView::Str(_)) if cn == "IO::Path" => {
+            (ValueView::Instance { class_name: cn, .. }, ValueView::Str(_))
+                if Self::is_io_path_lexical_class(cn.as_str()) =>
+            {
                 left.to_string_value() == right.to_string_value()
             }
             // Instance ~~ Type or other: identity check (false)

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -1,7 +1,41 @@
 use super::*;
 
 impl Interpreter {
+    /// Dispatch a pure native method, then settle any resumable warning it
+    /// raised *at the raise site*.
+    ///
+    /// A pure native method has no `&mut Interpreter`, so the only way it can
+    /// signal `Use of uninitialized value ...` / `Use of Nil in ... context` is
+    /// to return `RuntimeError::warn_signal_with_resume`. Letting that unwind is
+    /// wrong twice over: the resume value rides in `return_value`, which the
+    /// enclosing routine boundary applies as an explicit `return` (abandoning
+    /// the rest of the body), and a `CONTROL { when CX::Warn { … .resume } }`
+    /// handler further up has no raise site left to resume into. `warns-like
+    /// { Int.Numeric }, …` — roast's `Test::Util` idiom — lost every statement
+    /// after the call that way.
+    ///
+    /// [`raise_resumable_warning`](Self::raise_resumable_warning) is the shared
+    /// settle path: print-and-resume when no CONTROL handler is active, run a
+    /// resume-safe handler inline, and otherwise fall back to the same
+    /// unwinding signal as before.
     pub(super) fn try_native_method(
+        &mut self,
+        target: &Value,
+        method_sym: crate::symbol::Symbol,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let result = self.try_native_method_raw(target, method_sym, args);
+        if let Some(Err(e)) = &result
+            && e.is_warn()
+            && let Some(resume) = e.return_value.clone()
+        {
+            let message = e.message.clone();
+            return Some(self.raise_resumable_warning(&message, resume));
+        }
+        result
+    }
+
+    fn try_native_method_raw(
         &mut self,
         target: &Value,
         method_sym: crate::symbol::Symbol,

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -12,7 +12,7 @@
 //! `$s.done` raced the poll).
 use super::*;
 use crate::runtime::native_methods::{
-    SupplyEvent, supplier_sink_unregister, supplier_sinks_register_batch,
+    PromiseCombinator, SupplyEvent, supplier_sink_unregister, supplier_sinks_register_batch,
     take_promise_combinator_sources,
 };
 use crate::runtime::subtest::{ReactSubscription, SupplyDrivePolicy};
@@ -376,8 +376,14 @@ impl Interpreter {
                     react_subs[si].done = true;
                     continue;
                 }
+                // A `whenever Promise.allof(...)` settles only once every source
+                // has, so waiting on the sources is what drives it. `anyof` also
+                // registers its sources (for deferred `Proc::Async` tap replay),
+                // but blocking on all of them would defeat its whole point — let
+                // it fall through to the ordinary receiver poll.
                 if let Some(promise) = react_subs[si].promise.clone()
-                    && let Some(sources) = take_promise_combinator_sources(&promise)
+                    && let Some((kind, sources)) = take_promise_combinator_sources(&promise)
+                    && kind == PromiseCombinator::Allof
                 {
                     for source in sources {
                         source.result_blocking();

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -15,6 +15,16 @@ fn io_path_cleanup_absolute(path: &str, cwd: &str) -> String {
     }
 }
 
+/// Whether `class_name` names the built-in `IO::Path` family — `IO::Path` plus
+/// its SPEC-variant subclasses. Rakudo declares `ACCEPTS` (and the file-test
+/// `:e`/`:d`/… candidates) on `IO::Path`, so every subclass inherits them;
+/// matching the exact name only made `IO::Path::Unix.new('/foo/').add('bar') ~~
+/// IO::Path::Unix.new('/foo/bar')` fall through to the generic instance
+/// comparison and answer False.
+fn is_io_path_family(class_name: &crate::symbol::Symbol) -> bool {
+    Interpreter::is_io_path_lexical_class(class_name.as_str())
+}
+
 /// Extract path and CWD from IO::Path attributes.
 fn io_path_attrs(attrs: &crate::gc::Gc<crate::value::InstanceAttrs>) -> (String, String) {
     let path = attrs
@@ -241,7 +251,7 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
                 attributes: attrs_b,
                 ..
             },
-        ) if cn_a == "IO::Path" && cn_b == "IO::Path" => {
+        ) if is_io_path_family(&cn_a) && is_io_path_family(&cn_b) => {
             let (path_a, cwd_a) = io_path_attrs(&attrs_a);
             let (path_b, cwd_b) = io_path_attrs(&attrs_b);
             Some(
@@ -479,7 +489,7 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
                 ..
             },
             ValueView::Pair(key, val),
-        ) if class_name == "IO::Path"
+        ) if is_io_path_family(&class_name)
             && matches!(val.view(), ValueView::Bool(_))
             && matches!(
                 key.as_str(),
@@ -588,7 +598,7 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
                 attributes: attrs_b,
                 ..
             },
-        ) if cn_b == "IO::Path" && !needs_interpreter_lhs(left) => {
+        ) if is_io_path_family(&cn_b) && !needs_interpreter_lhs(left) => {
             let lhs_str = left.to_string_value();
             let (path_b, cwd_b) = io_path_attrs(&attrs_b);
             let cwd = std::env::current_dir()
@@ -603,7 +613,9 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
         // IO::Path ~~ Str: compare path string representation with string.
         // In Raku, Str.ACCEPTS(IO::Path) stringifies the IO::Path and compares.
         // This handles cases like `dir().grep("filename")` after chdir.
-        (ValueView::Instance { class_name: cn, .. }, ValueView::Str(s)) if cn == "IO::Path" => {
+        (ValueView::Instance { class_name: cn, .. }, ValueView::Str(s))
+            if is_io_path_family(&cn) =>
+        {
             Some(left.to_string_value() == s.as_str())
         }
 

--- a/t/bail-out-exit-status.t
+++ b/t/bail-out-exit-status.t
@@ -1,0 +1,23 @@
+use Test;
+
+# Rakudo's `bail-out` ends the process with status 255 (`Test.rakumod` does
+# `exit 255` right after emitting the "Bail out!" line). mutsu emitted the line
+# but exited 0, so `prove` -- and `Test::Util`'s `is_run ..., :255status` --
+# read a bailing-out file as a clean run.
+
+plan 4;
+
+sub run-snippet(Str:D $code) {
+    my $proc = run $*EXECUTABLE.absolute, '-e', $code, :out, :err;
+    my $out = $proc.out.slurp(:close);
+    $proc.err.slurp(:close);
+    ($proc.exitcode, $out);
+}
+
+my ($status, $out) = run-snippet 'use Test; ok 1, "runs"; bail-out; done-testing';
+is $status, 255, 'bail-out exits 255';
+is $out, "ok 1 - runs\nBail out!\n", '... after emitting the assertions and the bail line';
+
+($status, $out) = run-snippet 'use Test; ok 1, "runs"; bail-out "some reason";';
+is $status, 255, 'bail-out with a description exits 255 too';
+is $out, "ok 1 - runs\nBail out! some reason\n", '... and names the reason';

--- a/t/composite-promise-replays-proc-taps.t
+++ b/t/composite-promise-replays-proc-taps.t
@@ -1,0 +1,40 @@
+use Test;
+
+# A Proc::Async output tap used to be delivered only by awaiting *that* process's
+# own promise, because the replay hook fired on an `await` whose result was a
+# `Proc`. `Promise.anyof`/`allof` resolve to a plain `True`, so the
+# "run it, but give up after N seconds" idiom -- which is how Test::Util's
+# `doesn't-hang` waits for the child -- saw an empty tap buffer.
+
+plan 4;
+
+sub run-and-collect(&wait-for) {
+    my $p = Proc::Async.new: $*EXECUTABLE.absolute, '-e', 'say "B"';
+    my $out = '';
+    $p.stdout.tap: -> $chunk { $out ~= $chunk };
+    my $started = $p.start;
+    wait-for($started);
+    $out;
+}
+
+is run-and-collect(-> $pr { await Promise.anyof: Promise.in(30), $pr }), "B\n",
+    'a tap is delivered by awaiting a Promise.anyof over the process promise';
+
+is run-and-collect(-> $pr { await Promise.allof: $pr }), "B\n",
+    'a tap is delivered by awaiting a Promise.allof over the process promise';
+
+is run-and-collect(-> $pr { (Promise.anyof: Promise.in(30), $pr).result }), "B\n",
+    '.result on the composite delivers it too';
+
+# `whenever Promise.allof(...)` must still settle only once every source has --
+# the composite registry is shared with that driver.
+my $order = '';
+react {
+    my $a = start { $order ~= 'a' };
+    my $b = start { $order ~= 'b' };
+    whenever Promise.allof($a, $b) {
+        $order ~= '!';
+        done;
+    }
+}
+is $order.chars, 3, 'whenever Promise.allof still waits for every source';

--- a/t/io-path-accepts-subclass.t
+++ b/t/io-path-accepts-subclass.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Rakudo declares ACCEPTS (and the file-test adverb candidates) on IO::Path, so
+# every SPEC-variant subclass inherits them. mutsu's smartmatch arms matched the
+# exact class name `IO::Path` only, which made every comparison between two
+# `IO::Path::Unix` objects fall through to the generic instance comparison and
+# answer False -- Test::Util's `is-path` (`cmp-ok $got.resolve, '~~',
+# $exp.resolve`) never passed.
+
+plan 10;
+
+my $a = IO::Path::Unix.new('/foo/').add('bar');
+my $b = IO::Path::Unix.new('/foo/bar');
+
+ok $a ~~ $b, 'IO::Path::Unix ACCEPTS an equal IO::Path::Unix';
+ok $a.resolve ~~ $b.resolve, '... and so do their resolved forms';
+nok $a ~~ IO::Path::Unix.new('/foo/baz'), 'a different path does not match';
+
+# The plain class keeps working, and the two mix.
+ok IO::Path.new('/foo/bar') ~~ IO::Path.new('/foo/./bar'),
+    'IO::Path ACCEPTS an equal IO::Path';
+ok IO::Path.new('/foo/bar') ~~ $b, 'IO::Path ACCEPTS an equal subclass instance';
+ok $a ~~ IO::Path.new('/foo/bar'), 'a subclass instance ACCEPTS an equal IO::Path';
+
+# Cool ~~ IO::Path::Unix stringifies the LHS and compares absolute paths.
+ok '/foo/bar' ~~ $b, 'Str ~~ IO::Path::Unix compares absolute paths';
+
+# IO::Path::Unix ~~ Str stringifies the path.
+ok $b ~~ '/foo/bar', 'IO::Path::Unix ~~ Str compares the path string';
+
+# The file-test adverbs are inherited too.
+my $self = IO::Path::Unix.new($*PROGRAM.absolute);
+ok $self ~~ :e, 'IO::Path::Unix ~~ :e sees an existing file';
+nok IO::Path::Unix.new('/no/such/file/here') ~~ :e,
+    'IO::Path::Unix ~~ :e is False for a missing file';

--- a/t/warn-resumes-at-the-raise-site.t
+++ b/t/warn-resumes-at-the-raise-site.t
@@ -1,0 +1,43 @@
+use Test;
+
+# A resumable warning raised by a *native* coercion (`Int.Numeric`, `Nil.Str`,
+# ...) used to be signalled by returning `warn_signal_with_resume` and letting it
+# unwind. That is wrong twice over: the resume value rides in the error's
+# `return_value`, which the enclosing routine boundary applies as an explicit
+# `return`, and a `CONTROL { when CX::Warn { ... .resume } }` handler further up
+# has no raise site left to resume into. The warning is now settled where it is
+# raised. roast's `Test::Util` leans on exactly this shape in `warns-like`.
+
+plan 8;
+
+sub caught-by-control(&code) {
+    my ($did, $msg, $reached) = False, '', False;
+    code();
+    $reached = True;
+    CONTROL { when CX::Warn { $did = True; $msg = .message; .resume } }
+    ($did, $msg, $reached);
+}
+
+# An explicit `warn` already worked; keep it pinned as the reference shape.
+my ($did, $msg, $reached) = caught-by-control { warn "boom" };
+ok $did, 'an explicit warn reaches the CONTROL handler';
+is $msg.lines[0], 'boom', '... with its message';
+ok $reached, '... and the statement after the raise still runs';
+
+# A native numeric coercion on a bare type object.
+($did, $msg, $reached) = caught-by-control { Int.Numeric };
+ok $did, 'a native numeric coercion reaches the CONTROL handler';
+is $msg, 'Use of uninitialized value of type Int in numeric context',
+    '... with rakudo\'s wording';
+ok $reached, '... and the statement after the raise still runs';
+
+# The coercion still resumes with its value when nothing handles the warning.
+my $n = quietly Int.Numeric;
+is-deeply $n, 0, 'an unhandled numeric coercion resumes with 0';
+
+# A user class that composes Numeric without defining its own .Numeric warns
+# and resumes with .new -- the same raise site, reached through the interpreter.
+my class CustomNumeric does Numeric { method new { 42 } }
+($did, $msg, $reached) = caught-by-control { CustomNumeric.Numeric };
+ok $did && $reached,
+    'a role-composed Numeric type object warns and resumes at the raise site';

--- a/todo/tickets/retire-native-test-util-overrides.md
+++ b/todo/tickets/retire-native-test-util-overrides.md
@@ -1,69 +1,74 @@
-# Retire the native `Test::Util` / `Test::Tap` overrides — two bugs stand in the way
+# Retire the native `Test::Util` / `Test::Tap` overrides — the two original blockers are fixed, seven roast files stand in the way
 
-`exec_call` now lets an *imported* routine beat mutsu's native Test provider,
-but only for the `Test` module's own export list
-(`runtime::TEST_MODULE_EXPORTS`). The rest of `Interpreter::is_test_function_name`
-— roast's `Test::Util` and `Test::Tap` helpers (`is_run`, `doesn't-hang`,
-`is-path`, `is-eqv`, `is-deeply-junction`, `make-temp-file`, `make-temp-dir`,
-`make-temp-path`, `group-of`, `doesn't-warn`, `warns-like`, `test-iter-opt`, …)
-— still dispatches to the native implementation *even though the module is
-really loaded from source* (`roast/packages/Test-Helpers/lib/Test/Util.rakumod`).
+`exec_call` lets an *imported* routine beat mutsu's native Test provider, but
+only for the `Test` module's own export list (`runtime::TEST_MODULE_EXPORTS`).
+The rest of `Interpreter::is_test_function_name` — roast's `Test::Util` and
+`Test::Tap` helpers (`is_run`, `doesn't-hang`, `is-path`, `is-eqv`,
+`is-deeply-junction`, `make-temp-file`, `make-temp-dir`, `make-temp-path`,
+`group-of`, `doesn't-warn`, `warns-like`, …) — still dispatches to the native
+implementation *even though the module is really loaded from source*
+(`roast/packages/Test-Helpers/lib/Test/Util.rakumod`).
 
 That override is a live rung-3 provider over a module mutsu can already parse
-and load, so it should go the same way `Pod::To::Text` did. It was measured on
-2026-08-01 by widening the guard to every `is_test_function_name` name and
-running all 228 whitelisted roast files that `use Test::Util`. Exactly **two**
-files broke, each for one general interpreter bug:
+and load, so it should go the same way `Pod::To::Text` did.
 
-## 1. `IO::Path ~~ IO::Path` is always False (`roast/S32-io/io-path.t`)
+## The flip is a one-line change; what gates it is the residue
 
-Test::Util's `is-path` is `cmp-ok $got.resolve, '~~', $exp.resolve, $desc`.
-
-```raku
-my $a = IO::Path::Unix.new('/foo/').add('bar');
-my $b = IO::Path::Unix.new('/foo/bar');
-say $a.resolve.raku eq $b.resolve.raku;   # True in both
-say $a.resolve ~~ $b.resolve;             # raku: True   mutsu: False
+```rust
+// src/runtime/registration.rs, user_test_decl_beats_native
+if !crate::runtime::is_test_module_export(name) {   // -> Self::is_test_function_name(name)
+    return false;
+}
 ```
 
-Rakudo's `IO::Path.ACCEPTS(IO::Path:D)` compares `.absolute`; mutsu falls
-through to a generic instance smartmatch. This one is small and independent of
-everything else here.
+Re-measure by flipping that line and running the 228 whitelisted roast files
+that `use Test::Util`:
 
-## 2. A `Proc::Async` output tap is only drained by `await`-ing *that* promise (`roast/S17-supply/interval.t`)
-
-Test::Util's `doesn't-hang` accumulates the child's output in a `.stdout.tap`
-closure and then does `await Promise.anyof: Promise.in($wait), $prog.start`. On
-mutsu the tap never fires, so the `:out(/'Did not hang'/)` check sees `''`:
-
-```raku
-my $p = Proc::Async.new: $*EXECUTABLE.absolute, '-e', 'say "B"';
-my $s = '';
-$p.stdout.tap: -> $a { $s ~= $a };
-my $pr = $p.start;
-await Promise.anyof: Promise.in(10), $pr;
-say $s.raku;        # raku: "B\n"   mutsu: ""
-sleep 1; say $s.raku;   # mutsu: still "" — it is not a race
-await $pr; say $s.raku; # mutsu: "B\n" — the tap fires *here*
+```bash
+while read -r f; do grep -q "use Test::Util" "$f" && echo "$f"; done \
+    < roast-whitelist.txt > tmp/testutil-files.txt
+MUTSU_FUDGE=1 prove -j4 -e 'target/debug/mutsu' - < tmp/testutil-files.txt
 ```
 
-This is by construction: `native_supply_mut_methods.rs` marks a Proc::Async
-output supply `proc_output` and deliberately does **not** start a live-channel
-consumer for it, because delivery happens once, later, in `replay_proc_taps` —
-which is called only from `await`/`.result` when the awaited promise's own
-result is a `Proc` (`builtins_system_async.rs`, `methods_promise.rs`). A
-composite (`Promise.anyof`/`allof`) has no `Proc` result, so nothing replays.
+## The two original blockers are fixed (2026-08-02)
 
-The shallow fix is to teach the composite to replay its components' proc taps.
-The real fix is that a tap should be *push*-delivered as the reader thread
-produces output, the way ADR-0008 made the other supplies push-based (#4636) —
-the "replay at await" design is what makes `.tap` observably different from
-`react`/`whenever` on the same stream. Beware `S17-procasync/basic.t` test 37,
-which the current comment cites as the reason delivery happens exactly once.
+1. ~~`IO::Path ~~ IO::Path` is always False~~ — the smartmatch arms matched the
+   exact class name, so every `IO::Path::Unix` comparison (which is what
+   `is-path`'s `cmp-ok $got.resolve, '~~', $exp.resolve` produces) fell through
+   to the generic instance arm.
+   `news/2026-08/io-path-accepts-is-inherited-by-its-spec-subclasses.md`.
+2. ~~A `Proc::Async` output tap is only drained by `await`-ing *that*
+   promise~~ — `doesn't-hang` awaits a `Promise.anyof` composite, whose result
+   is a plain `True`, so the `Proc`-result replay hook never fired.
+   `news/2026-08/composite-promise-replays-its-proc-taps.md`.
 
-## Order
+Two more general bugs were found by flipping the guard and measuring, and are
+also fixed — they are why the count below is 7 rather than 9:
 
-Fix 1 first (self-contained), then 2 (needs a design call, possibly an ADR
-amendment to 0008), then widen the guard in `runtime/calls.rs` from
-`is_test_module_export` to `is_test_function_name` and delete the native
-overrides that are then dead. `t/test-fn-import-shadow.t` is the pin to extend.
+- a resumable warning raised by a native coercion unwound instead of being
+  settled at the raise site, so `warns-like { Int.Numeric }` lost every
+  statement after the call (`news/2026-08/a-warning-resumes-at-its-raise-site.md`);
+- `bail-out` emitted "Bail out!" but exited 0 instead of 255
+  (`news/2026-08/bail-out-exits-255.md`).
+
+## Measured residue: 7 files, 4 causes (2026-08-02)
+
+With the guard widened, 221 of the 228 files pass. None of the seven is a
+`Test::Util` incompatibility — each is a mutsu gap the native override was
+hiding. Take them one at a time; the flip lands once they are all closed.
+
+| files | cause |
+| --- | --- |
+| `S24-testing/12-subtest-todo.t` (test 5) | **A failing assertion's `# Failed test at …` diagnostic goes to stdout inside a subtest.** Rakudo splits it: a *TODO*'d failure's diagnostic goes to stdout (`$todo_output`), a real failure's to stderr (`$failure_output`), and a failing subtest also emits `# You failed N tests of M` to stderr. mutsu puts everything on stdout and omits the subtest summary, so the real `is_run`'s `:out`/`:err` predicates see the wrong split. Compare `raku -e 'use Test; plan 1; subtest "foos" => { todo 1; ok 0; ok 0 }'` with stdout and stderr separated. |
+| `S19-command-line-options/04-negation.t` (2, 3), `S19-command-line/arguments.t` (6) | **CLI option handling**: mutsu exits 1 where raku exits with a different status for a malformed/negated short option, and writes an unknown-option warning to the wrong stream. |
+| `S26-documentation/02-paragraph.t` (28) | **`--doc=Text` is not recognised**: mutsu treats it as the program file ("Could not open --doc=Text"). The real `is_run` passes it through `:compiler-args`. |
+| `S03-operators/repeat.t` (56), `S16-io/words.t` (11) | one `warns-like` whose message does not match, and `words()` without arguments not reading `$*ARGFILES` — each an ordinary single-assertion gap. |
+
+## Then delete what is dead
+
+Once the guard covers every `is_test_function_name`, the native `Test::Util` /
+`Test::Tap` handlers only run for a file that calls those helpers *without*
+loading the module. Several `t/*.t` files do exactly that today (e.g.
+`t/io-handle-lock.t`, `t/supply-list.t`), so deleting the natives means adding
+the missing `use Test::Util` to them first — worth doing, since raku would
+reject those files as written. `t/test-fn-import-shadow.t` is the pin to extend.


### PR DESCRIPTION
Investigating why `t/group-of.t` regresses under the real `Test` module turned up
the real cause: `group-of` is a `Test::Util` export, and mutsu's native TAP
provider still overrules the module's own routine for every name in
`is_test_function_name` outside `TEST_MODULE_EXPORTS`. Widening that guard was
gated on two general bugs (`todo/tickets/retire-native-test-util-overrides.md`).
Both are fixed here, along with two more the measurement exposed.

## `IO::Path.ACCEPTS` is inherited by the SPEC-variant subclasses

Rakudo declares `ACCEPTS` (and the `:e`/`:d`/`:f`… file-test candidates) on
`IO::Path`, so `IO::Path::Unix`/`::Win32`/`::Cygwin`/`::QNX` inherit them. All
eight smartmatch arms — four in the pure VM path, four in the interpreter path —
guarded on the exact class name, so any subclass comparison fell through to the
generic instance arm:

```raku
my $a = IO::Path::Unix.new('/foo/').add('bar');
my $b = IO::Path::Unix.new('/foo/bar');
say $a.resolve ~~ $b.resolve;    # raku: True   mutsu: False
```

`Test::Util`'s `is-path` is `cmp-ok $got.resolve, '~~', $exp.resolve, $desc`, so
it could never pass under the real module.

## A `Proc::Async` tap is replayed through a composite promise too

The replay hook fired on an `await`/`.result` whose *result* was a `Proc` — only
true of the promise `$proc.start` returns. `Promise.anyof`/`allof` resolve to a
plain `True`, so the "run it, but give up after N seconds" idiom (exactly how
`doesn't-hang` waits) delivered nothing. The combinator-sources registry, which
`allof` already populated for the react driver, now records `anyof` as well and
carries the combinator kind; `await`/`.result` walk it and replay every source
that has *already settled* (a still-`Planned` one is skipped on purpose —
waiting on it would reintroduce the hang the composite exists to avoid). The
kind tag keeps the react driver byte-identical: it blocks on the full source
list only for `allof`.

This is the shallow fix; the real one is push-delivery for proc output supplies
per ADR-0008.

## A resumable warning is settled where it is raised

`raise_resumable_warning`'s doc comment already warned that op-level warn sites
must not return a bare `warn_signal_with_resume` — the resume value rides in
`return_value`, which a routine boundary applies as an explicit `return`.
Several sites did anyway (the pure natives had no `&mut Interpreter`; two
interpreter-side ones were simply unconverted):

```raku
sub g {
    my ($did, $msg) = False;
    { Int.Numeric }();
    say "after call";                      # never ran
    CONTROL { when CX::Warn { $did = True; $msg = .message; .resume } }
}
```

The handler fired but `.resume` had no raise site to return to. The pure natives
are now settled at their single `&mut self` chokepoint (`try_native_method`);
the two interpreter sites call it directly. With no resume-safe handler the
fallback is the same unwinding signal as before. `warns-like { Int.Numeric }` —
nine of them in `S02-literals/allomorphic.t` alone — produced no test at all
under the real module.

## `bail-out` exits 255

Rakudo's `bail-out` is `exit 255`. mutsu emitted `Bail out!` and returned a clean
run, so `prove` — and `is_run …, :255status`, which all four subtests of
`S24-testing/7-bail_out.t` assert — read status 0.

## What is deliberately *not* here

The guard widening itself. Measured over the 228 whitelisted roast files that
`use Test::Util`, it leaves **7 failing** — none a `Test::Util` incompatibility,
all mutsu gaps the override was hiding: subtest failure diagnostics written to
stdout instead of stderr, CLI option handling in two `S19-command-line*` files,
`--doc=Text` not recognised, and two single-assertion gaps. Each is now recorded
with its cause and repro in the ticket, so the flip is a one-line change once
they are closed.

## Testing

`make test` PASS (2755 files, 26238 tests). Targeted roast: `S24-testing/`,
`S17-supply/`, `S17-procasync/`, `S02-literals/allomorphic.t`,
`S03-operators/repeat.t` (87 files) PASS; `S32-io/`, `S16-io/`, `S02-types/`
PASS once a stale `temp-file-RT-126006-test` from an earlier interrupted run is
removed (`make roast` does this itself). Four new pins, each verified
byte-compatible with `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)