### PR TITLE
fix(runtime): TAP failure diagnostics pick the stream rakudo picks

### DIFF
--- a/news/2026-08/tap-failure-diagnostics-pick-the-stream-rakudo-picks.md
+++ b/news/2026-08/tap-failure-diagnostics-pick-the-stream-rakudo-picks.md
@@ -1,0 +1,46 @@
+# TAP failure diagnostics pick the stream rakudo picks
+
+`Test.rakumod` keeps two output handles, `$todo_output` (stdout) and
+`$failure_output` (stderr), and `_diag` chooses between them with
+
+```raku
+my $is_todo = !$force-stderr && !$force-informative
+    && ($subtest_todo_reason || $num_of_tests_run <= $todo_upto_test_num);
+```
+
+— i.e. **by whether the failure is TODO'd**, either in its own right or because
+the enclosing subtest is. `subtest` captures the latter when it *starts*
+(`my $parent_todo = $todo_reason || $subtest_todo_reason`), so a subtest that
+the parent's `todo 1` covers sends everything under it to stdout.
+
+mutsu chose by nesting depth instead (`!effective_todo && subtest_depth() == 0`),
+which is a decent approximation of that rule — a diagnostic raised inside a
+TODO'd subtest does belong on stdout — but it is wrong for the far more common
+case of an ordinary failure inside an ordinary subtest, which rakudo puts on
+stderr, indented to its subtest level. It also meant a failing subtest never
+emitted its own `# You failed N tests of M`.
+
+Three fixes, all mirroring the module:
+
+- the choice is now `!effective_todo && !subtest_todo_active()`, with
+  `subtest_todo_active` a new stack on `TapState` that mirrors
+  `$subtest_todo_reason` and is pushed at `begin_subtest` from the parent's
+  pending `todo` range (plus the enclosing subtest's own flag, so it is
+  inherited all the way down);
+- a stderr diagnostic carries its own `"    " x depth` indentation, since it
+  bypasses the stdout buffer that `finish_subtest` indents;
+- a failing subtest closes with `# You failed N tests of M` on stderr, unless the
+  subtest itself was TODO'd.
+
+A fourth, unrelated to the stream choice: `emit_test_failure_diag` both pushed
+the message into `stderr_output` *and* `eprint!`ed it, so `flush_stderr_buffer`
+printed every failure diagnostic a second time at exit. It now goes through
+`emit_stderr`, the existing helper that buffers in nested mode and writes
+through otherwise — which also stops the in-process `is_run` from leaking its
+child's diagnostics onto the real stderr.
+
+With this in, `roast/S24-testing/12-subtest-todo.t` passes under the *real*
+`Test::Util` — its `is_run` predicates count `Failed` occurrences per stream —
+and stdout is byte-identical to `raku`'s for the whole file.
+
+Pin: `t/subtest-failure-diag-stream.t`, verified under both implementations.

--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -133,7 +133,16 @@ impl Interpreter {
         };
         self.emit_output(&line);
         if record_failure {
-            let to_stderr = !effective_todo && self.tap.subtest_depth() == 0;
+            // Rakudo splits the two diagnostic streams by whether the failure is
+            // TODO'd, not by how deep it is (`_diag`'s `$is_todo`): a TODO'd
+            // failure's diagnostic goes to `$todo_output` (stdout, so it stays
+            // inside the subtest's TAP block) and a real one to
+            // `$failure_output` (stderr). An assertion counts as TODO'd either
+            // in its own right or because the enclosing subtest is
+            // (`$subtest_todo_reason`, captured when the subtest starts).
+            // Keying on `subtest_depth() == 0` instead put *every* in-subtest
+            // failure diagnostic on stdout.
+            let to_stderr = !effective_todo && !self.tap.subtest_todo_active();
             self.emit_test_failure_diag(desc, to_stderr, detail);
             if !effective_todo
                 && self.tap.subtest_depth() == 0
@@ -176,10 +185,16 @@ impl Interpreter {
         } else {
             format!("at line {}", line_no)
         };
+        // A stdout diagnostic is indented later, when `finish_subtest` renders
+        // the subtest's buffered output. A stderr one bypasses that buffer, so
+        // it has to carry the indentation itself — rakudo indents both.
+        let indent = "    ".repeat(self.tap.subtest_depth());
         let mut emit = |msg: String| {
             if to_stderr {
-                self.output_sink_mut().stderr_output.push_str(&msg);
-                eprint!("{}", msg);
+                // `emit_stderr` buffers in nested mode and writes through
+                // otherwise; doing both duplicated every diagnostic, once at the
+                // raise and once when `flush_stderr_buffer` drained the buffer.
+                self.emit_stderr(&format!("{}{}", indent, msg));
             } else {
                 self.emit_output(&msg);
             }

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -193,10 +193,25 @@ impl Interpreter {
         // under/over-runs, rakudo reports it as a failure with a diagnostic line.
         let plan_mismatch = matches!(subtest_planned, Some(p) if p != subtest_ran);
 
+        // Indentation of the subtest's *own* level, and whether it was TODO'd by
+        // its parent — both captured before `end_subtest` pops back to the
+        // parent's.
+        let subtest_indent = "    ".repeat(self.tap.subtest_depth());
+        let subtest_was_todo = self.tap.subtest_todo_active();
+
         self.tap.set_state(ctx.parent_test_state);
         self.output_sink_mut().output = ctx.parent_output;
         self.halted = ctx.parent_halted;
         self.tap.end_subtest();
+        // Rakudo's subtest closes with its own count on `$failure_output`
+        // (stderr), indented to its level, just as the top-level run does.
+        if subtest_failed > 0 && !subtest_was_todo {
+            let plural = if subtest_failed == 1 { "" } else { "s" };
+            self.emit_stderr(&format!(
+                "{}# You failed {} test{} of {}\n",
+                subtest_indent, subtest_failed, plural, subtest_ran
+            ));
+        }
         let parent_forced_todo_reason = self.tap.state().and_then(|state| {
             let next = state.ran + 1;
             state

--- a/src/runtime/tap_state.rs
+++ b/src/runtime/tap_state.rs
@@ -91,6 +91,12 @@ pub(crate) struct TapState {
     /// Stack tracking whether each nested subtest callable is a Sub (true) or
     /// Block (false). Used by `plan skip-all` to reject Block callables.
     subtest_callable_is_sub: Vec<bool>,
+    /// Stack mirroring rakudo's `$subtest_todo_reason`: whether each nested
+    /// subtest is itself TODO'd by its parent's pending `todo`. rakudo captures
+    /// it when the subtest *starts* (`my $parent_todo = $todo_reason ||
+    /// $subtest_todo_reason`) and `_diag` then routes every diagnostic raised
+    /// under it to `$todo_output` (stdout) rather than `$failure_output`.
+    subtest_todo: Vec<bool>,
     /// Set by `bail-out`; suppresses the trailing plan/summary footer.
     bailed_out: bool,
 }
@@ -144,15 +150,36 @@ impl TapState {
         }
     }
 
+    /// Whether the innermost active subtest is itself TODO'd (directly or
+    /// through an ancestor). False at the top level.
+    pub(crate) fn subtest_todo_active(&self) -> bool {
+        self.subtest_todo.last().copied().unwrap_or(false)
+    }
+
+    /// Whether the *next* test the current state will emit falls inside a
+    /// pending `todo` range — rakudo's `$todo_reason` at the moment a subtest
+    /// starts.
+    pub(crate) fn next_test_is_todo(&self) -> bool {
+        self.state.as_ref().is_some_and(|state| {
+            let next = state.ran + 1;
+            state
+                .force_todo
+                .iter()
+                .any(|range| next >= range.start && next <= range.end)
+        })
+    }
+
     /// Enter a subtest: stash the parent `TestState`, install a fresh one, and
     /// push onto the subtest stack (defaulting the callable kind to Sub).
     /// Returns the parent state to be restored by [`set_state`] on exit.
     pub(crate) fn begin_subtest(&mut self) -> Option<TestState> {
+        let inherits_todo = self.next_test_is_todo() || self.subtest_todo_active();
         let parent = self.state.take();
         self.state = Some(TestState::new());
         self.subtest_depth += 1;
         // Default to true (Sub); callers override via set_subtest_callable_is_sub_last.
         self.subtest_callable_is_sub.push(true);
+        self.subtest_todo.push(inherits_todo);
         parent
     }
 
@@ -161,6 +188,7 @@ impl TapState {
     pub(crate) fn end_subtest(&mut self) {
         self.subtest_depth = self.subtest_depth.saturating_sub(1);
         self.subtest_callable_is_sub.pop();
+        self.subtest_todo.pop();
     }
 
     /// Whether `bail-out` has been called.
@@ -192,6 +220,7 @@ impl TapState {
             state,
             subtest_depth: 0,
             subtest_callable_is_sub: Vec::new(),
+            subtest_todo: Vec::new(),
             bailed_out: false,
         }
     }

--- a/t/subtest-failure-diag-stream.t
+++ b/t/subtest-failure-diag-stream.t
@@ -1,0 +1,45 @@
+use Test;
+
+# Rakudo splits the two TAP diagnostic streams by whether an assertion was
+# TODO'd, not by how deeply nested it is: a TODO'd failure's `# Failed test ...`
+# goes to `$todo_output` (stdout, so it stays inside the subtest's TAP block)
+# and a real failure's goes to `$failure_output` (stderr), indented to its
+# subtest level. A failing subtest also closes with its own
+# `# You failed N tests of M` on stderr.
+#
+# mutsu keyed the choice on `subtest_depth() == 0`, so every in-subtest failure
+# diagnostic landed on stdout, and it emitted each stderr diagnostic twice (once
+# at the raise, once when the buffered stderr was flushed at exit).
+
+plan 6;
+
+sub streams-of(Str:D $code) {
+    my $proc = run $*EXECUTABLE.absolute, '-e', $code, :out, :err;
+    my $out = $proc.out.slurp(:close);
+    my $err = $proc.err.slurp(:close);
+    ($out, $err);
+}
+
+my ($out, $err) = streams-of 'use Test; plan 1; subtest "foos" => { todo 1; ok 0; ok 0 }';
+
+is $out, join("\n",
+        '1..1',
+        '# Subtest: foos',
+        '    not ok 1 -  # TODO 1',
+        '    # Failed test at -e line 1',
+        '    not ok 2 - ',
+        '    1..2',
+        'not ok 1 - foos',
+    ) ~ "\n", 'a subtest keeps only the TODO\'d diagnostic on stdout';
+
+ok $err.contains("    # Failed test at -e line 1\n"),
+    'the real failure\'s diagnostic goes to stderr, indented to its subtest level';
+ok $err.contains("    # You failed 1 test of 2\n"),
+    'the failing subtest closes with its own count on stderr';
+is +$err.comb("# Failed test 'foos'"), 1,
+    'the outer failure diagnostic is emitted exactly once';
+
+# A top-level failure keeps its diagnostic on stderr and out of the TAP stream.
+($out, $err) = streams-of 'use Test; plan 2; ok 0, "a"; ok 1, "b"';
+is $out, "1..2\nnot ok 1 - a\nok 2 - b\n", 'a top-level failure leaves stdout as pure TAP';
+is +$err.comb('# Failed test'), 1, '... and reports it once on stderr';

--- a/todo/tickets/retire-native-test-util-overrides.md
+++ b/todo/tickets/retire-native-test-util-overrides.md
@@ -51,18 +51,25 @@ also fixed — they are why the count below is 7 rather than 9:
 - `bail-out` emitted "Bail out!" but exited 0 instead of 255
   (`news/2026-08/bail-out-exits-255.md`).
 
-## Measured residue: 7 files, 4 causes (2026-08-02)
+## Measured residue: 5 files, 3 causes (2026-08-02)
 
-With the guard widened, 221 of the 228 files pass. None of the seven is a
+With the guard widened, 223 of the 228 files pass. None of the five is a
 `Test::Util` incompatibility — each is a mutsu gap the native override was
 hiding. Take them one at a time; the flip lands once they are all closed.
 
 | files | cause |
 | --- | --- |
-| `S24-testing/12-subtest-todo.t` (test 5) | **A failing assertion's `# Failed test at …` diagnostic goes to stdout inside a subtest.** Rakudo splits it: a *TODO*'d failure's diagnostic goes to stdout (`$todo_output`), a real failure's to stderr (`$failure_output`), and a failing subtest also emits `# You failed N tests of M` to stderr. mutsu puts everything on stdout and omits the subtest summary, so the real `is_run`'s `:out`/`:err` predicates see the wrong split. Compare `raku -e 'use Test; plan 1; subtest "foos" => { todo 1; ok 0; ok 0 }'` with stdout and stderr separated. |
+| ~~`S24-testing/12-subtest-todo.t`~~ | **DONE** — the failure-diagnostic stream was chosen by nesting depth rather than by whether the failure was TODO'd, and every stderr diagnostic was emitted twice. `news/2026-08/tap-failure-diagnostics-pick-the-stream-rakudo-picks.md`. |
 | `S19-command-line-options/04-negation.t` (2, 3), `S19-command-line/arguments.t` (6) | **CLI option handling**: mutsu exits 1 where raku exits with a different status for a malformed/negated short option, and writes an unknown-option warning to the wrong stream. |
 | `S26-documentation/02-paragraph.t` (28) | **`--doc=Text` is not recognised**: mutsu treats it as the program file ("Could not open --doc=Text"). The real `is_run` passes it through `:compiler-args`. |
 | `S03-operators/repeat.t` (56), `S16-io/words.t` (11) | one `warns-like` whose message does not match, and `words()` without arguments not reading `$*ARGFILES` — each an ordinary single-assertion gap. |
+
+One difference is *not* in that list because nothing currently asserts on it,
+but the next `is_run` slice will meet it: a file that ends with test failures
+prints `Runtime error: Test failures` on stderr, which rakudo does not. mutsu's
+`run()` returns the failure as a `RuntimeError` and `main` renders it. The exit
+status is already right (1), so the fix is to set `exit_code` and return `Ok`,
+the way the bailed-out branch now does.
 
 ## Then delete what is dead
 


### PR DESCRIPTION
`Test.rakumod` routes a failure diagnostic by **whether the failure is TODO'd** —
`_diag`'s

```raku
my $is_todo = !$force-stderr && !$force-informative
    && ($subtest_todo_reason || $num_of_tests_run <= $todo_upto_test_num);
my $out = $is_todo || $force-informative ?? $todo_output !! $failure_output;
```

— sending a TODO'd one to stdout (so it stays inside the subtest's TAP block)
and a real one to stderr, indented to its subtest level. `subtest` captures the
enclosing reason when it *starts* (`my $parent_todo = $todo_reason ||
$subtest_todo_reason`), so everything under a subtest the parent's `todo` covers
goes to stdout.

mutsu chose by nesting depth instead (`!effective_todo && subtest_depth() == 0`).
That is right for a TODO'd subtest and wrong for the common case — an ordinary
failure inside an ordinary subtest, which rakudo puts on stderr. A failing
subtest also never emitted its own `# You failed N tests of M`.

Three fixes mirroring the module, plus one unrelated to the stream choice:

- the choice is now `!effective_todo && !subtest_todo_active()`, backed by a new
  `TapState` stack mirroring `$subtest_todo_reason`, pushed at `begin_subtest`
  from the parent's pending `todo` range and inherited by nested subtests;
- a stderr diagnostic carries its own `"    " x depth`, since it bypasses the
  stdout buffer that `finish_subtest` indents;
- a failing subtest closes with `# You failed N tests of M` on stderr, unless it
  was itself TODO'd;
- `emit_test_failure_diag` both pushed into `stderr_output` *and* `eprint!`ed, so
  `flush_stderr_buffer` printed every diagnostic a second time at exit. It now
  goes through `emit_stderr` — the existing buffer-in-nested-mode /
  write-through-otherwise helper — which also stops the in-process `is_run` from
  leaking its child's diagnostics onto the real stderr.

For `use Test; plan 1; subtest "foos" => { todo 1; ok 0; ok 0 }`, stdout is now
byte-identical to `raku`'s and stderr differs only by mutsu's trailing
`Runtime error: Test failures` line (noted in the ticket as the next `is_run`
difference to close).

This takes the residue in `todo/tickets/retire-native-test-util-overrides.md`
from 7 files to 5: `roast/S24-testing/12-subtest-todo.t` now passes under the
*real* `Test::Util`, whose `is_run` predicates count `Failed` occurrences per
stream. It already passed under the native provider and still does.

## Testing

`cargo test` 638 unit tests PASS; `prove t/` 2755 files / 26259 tests PASS.
Targeted roast: `S24-testing/`, `S32-io/`, `S17-supply/` (121 files) PASS.
Verified the residue drop by temporarily flipping the guard and re-running the
eight files, then reverting.

Pin: `t/subtest-failure-diag-stream.t`, verified under both implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)