### PR TITLE
feat(cli): accept `--doc=module`, and decode `E<...>` inside `=begin pod`

### DIFF
--- a/news/2026-08/doc-equals-renderer-and-entities-in-begin-pod.md
+++ b/news/2026-08/doc-equals-renderer-and-entities-in-begin-pod.md
@@ -1,0 +1,40 @@
+# `--doc=module`, and `E<...>` inside `=begin pod`
+
+Rakudo spells the Pod renderer selection `--doc=module`, meaning
+`Pod::To::[module]`. mutsu only accepted the bare `--doc`, so the whole
+`--doc=Text` token fell through to the "this must be the program file" branch
+and died with `Could not open --doc=Text`. That is what
+`roast/S26-documentation/02-paragraph.t`'s last assertion — an `is_run` with
+`:compiler-args['--doc=Text']` — hit, and it is the sort of failure that reads
+as a Pod bug when it is really argument parsing.
+
+`--doc=Text` now selects the doc renderer mutsu has (its `--doc` output *is*
+Pod::To::Text's). Any other module name is reported the way rakudo reports a
+renderer it cannot load:
+
+```
+===SORRY!===
+Could not find Pod::To::Nonesuch
+```
+
+rather than being mistaken for a filename.
+
+Fixing the option surfaced a second, unrelated bug behind it: `E<...>` is a Pod
+formatting code wherever it appears, but only the `=for pod` branch of
+`doc_mode`'s renderer decoded it. A `=begin pod` block emitted its lines
+verbatim, so
+
+```raku
+=begin pod
+Hello E<alpha>
+=end pod
+```
+
+rendered as literal `Hello E<alpha>` under `--doc` where rakudo renders
+`Hello α`. Headings and `=item` text had the same hole. All three now go
+through `decode_pod_entities`.
+
+Pin: `t/doc-renderer-option.t`, verified under both implementations. With this
+in, `roast/S26-documentation/02-paragraph.t` passes under the real
+`Test::Util`, taking the residue in
+`todo/tickets/retire-native-test-util-overrides.md` to 4 files.

--- a/src/doc_mode.rs
+++ b/src/doc_mode.rs
@@ -223,7 +223,7 @@ fn render_begin_pod_blocks(source: &str) -> String {
                     let heading = rest
                         .trim_start_matches(|c: char| c.is_ascii_digit())
                         .trim_start();
-                    output.push_str(heading);
+                    output.push_str(&decode_pod_entities(heading));
                     output.push('\n');
                     i += 1;
                     continue;
@@ -234,7 +234,7 @@ fn render_begin_pod_blocks(source: &str) -> String {
                         .trim_start_matches(|c: char| c.is_ascii_digit())
                         .trim_start();
                     output.push_str("  * ");
-                    output.push_str(text);
+                    output.push_str(&decode_pod_entities(text));
                     output.push('\n');
                     i += 1;
                     continue;
@@ -243,7 +243,11 @@ fn render_begin_pod_blocks(source: &str) -> String {
                     i += 1;
                     continue;
                 }
-                output.push_str(lines[i].trim_end());
+                // `E<...>` is a Pod formatting code wherever it appears, not
+                // only inside `=for pod` — the `=begin pod` branch used to emit
+                // the line verbatim, so `=begin pod`/`Hello E<alpha>` rendered
+                // as literal `Hello E<alpha>`.
+                output.push_str(&decode_pod_entities(lines[i].trim_end()));
                 output.push('\n');
                 i += 1;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ fn print_help(program: &str) {
     println!("  --dump-ast     Dump the AST instead of executing");
     println!("  --dump-bytecode  Dump compiled bytecode instead of executing");
     println!("  --doc          Render Pod documentation from the source");
+    println!("  --doc=module   Render it with Pod::To::[module] (only Text)");
     println!("  --repl         Start the interactive REPL");
     println!("  --no-precomp   Disable module precompilation cache");
     println!("  -h, --help     Show this help message");
@@ -182,6 +183,20 @@ fn run_main() {
             dump_bytecode = true;
         } else if arg == "--doc" {
             doc_mode = true;
+        } else if let Some(renderer) = arg.strip_prefix("--doc=") {
+            // `--doc=module` selects `Pod::To::[module]` (rakudo's spelling).
+            // mutsu's `--doc` renderer *is* Pod::To::Text, so `Text` is the one
+            // name it can honour; anything else names a module it does not
+            // have, which rakudo reports as a compile-time "Could not find".
+            // Without this arm the whole `--doc=Text` token was taken for the
+            // program file ("Could not open --doc=Text").
+            if renderer == "Text" {
+                doc_mode = true;
+            } else {
+                eprintln!("===SORRY!===");
+                eprintln!("Could not find Pod::To::{}", renderer);
+                return;
+            }
         } else if arg == "--repl" {
             repl_flag = true;
         } else if arg == "--no-precomp" {

--- a/t/doc-renderer-option.t
+++ b/t/doc-renderer-option.t
@@ -1,0 +1,37 @@
+use Test;
+
+# rakudo spells the Pod renderer selection `--doc=module`, meaning
+# `Pod::To::[module]`. mutsu only had the bare `--doc`, so the whole
+# `--doc=Text` token fell through to the "this is the program file" branch and
+# died with "Could not open --doc=Text" -- which is what
+# `roast/S26-documentation/02-paragraph.t`'s last assertion (an `is_run` with
+# `:compiler-args['--doc=Text']`) saw.
+
+plan 4;
+
+my $pod-file = $*TMPDIR.child("mutsu-doc-renderer-{$*PID}.raku");
+$pod-file.spurt: qq:to/SRC/;
+    =begin pod
+    Hello E<alpha>
+    =end pod
+    SRC
+LEAVE try $pod-file.unlink;
+
+sub mutsu(*@args) {
+    my $proc = run $*EXECUTABLE.absolute, |@args, :out, :err;
+    my $out = $proc.out.slurp(:close);
+    my $err = $proc.err.slurp(:close);
+    ($proc.exitcode, $out, $err);
+}
+
+my ($status, $out, $err) = mutsu('--doc=Text', $pod-file.absolute);
+is $status, 0, '--doc=Text runs the Pod renderer';
+is $out.trim, 'Hello α', '... and renders the same text --doc does';
+
+# An unknown renderer names a module mutsu does not have; rakudo reports that as
+# a compile-time "Could not find Pod::To::...", not as a missing program file.
+($status, $out, $err) = mutsu('--doc=Nonesuch', $pod-file.absolute);
+ok $err.contains('Could not find Pod::To::Nonesuch'),
+    'an unknown renderer names the module it could not find';
+nok $err.contains('Could not open'),
+    '... rather than treating the option as the program file';


### PR DESCRIPTION
Rakudo spells the Pod renderer selection `--doc=module`, meaning
`Pod::To::[module]`. mutsu only accepted the bare `--doc`, so the whole
`--doc=Text` token fell through to the "this must be the program file" branch
and died with `Could not open --doc=Text`. That is what
`roast/S26-documentation/02-paragraph.t`'s last assertion — an `is_run` with
`:compiler-args['--doc=Text']` — hits, and it reads as a Pod bug when it is
really argument parsing.

`--doc=Text` now selects the renderer mutsu has (its `--doc` output *is*
Pod::To::Text's). Any other module name is reported the way rakudo reports a
renderer it cannot load:

```
===SORRY!===
Could not find Pod::To::Nonesuch
```

rather than being mistaken for a filename.

## The bug behind it

Fixing the option surfaced a second, unrelated one: `E<...>` is a Pod formatting
code wherever it appears, but only the `=for pod` branch of `doc_mode`'s
renderer decoded it. A `=begin pod` block emitted its lines verbatim, so

```raku
=begin pod
Hello E<alpha>
=end pod
```

rendered as literal `Hello E<alpha>` under `--doc` where rakudo renders
`Hello α`. Headings and `=item` text had the same hole. All three now go through
`decode_pod_entities`.

## Effect on the Test::Util retirement

Takes the measured residue in `todo/tickets/retire-native-test-util-overrides.md`
from 5 files to 4 — verified by temporarily flipping the guard and running
`roast/S26-documentation/02-paragraph.t` (28/28 PASS under the real
`Test::Util`), then reverting. The ticket's count is updated in the
sibling PR #5725 to avoid a conflict on the same table.

## Testing

`make test` PASS (2761 files / 26302 tests). `roast/S26-documentation/`
(27 files) PASS.

Pin: `t/doc-renderer-option.t`, verified under both implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)