### PR TITLE
fix(cli): an option-parsing error follows rakudo (ADR-0017)

### DIFF
--- a/docs/adr/0017-cli-option-errors-follow-rakudo.md
+++ b/docs/adr/0017-cli-option-errors-follow-rakudo.md
@@ -1,0 +1,120 @@
+# ADR-0017: A command-line *option* error follows rakudo — message, stream, and a zero exit status
+
+- **Status**: Accepted
+- **Date**: 2026-08-02
+- **Deciders**: tokuhirom, Claude
+- **Related**: `src/main.rs` (`illegal_option`, `print_negation_error`, the argument loop),
+  `t/cli-option-errors.t`, `roast/S19-command-line/arguments.t`,
+  `roast/S19-command-line-options/04-negation.t`,
+  `todo/tickets/retire-native-test-util-overrides.md`.
+
+## 1. Context
+
+mutsu's CLI treated any argument it did not recognise as the program file. So
+
+```
+$ mutsu --nosucharg=foo foo.raku
+Could not open --nosucharg=foo. Failed to stat file: no such file or directory
+$ echo $?
+1
+```
+
+and a malformed negation exited non-zero:
+
+```
+$ mutsu -/hv
+SORRY! Option '-/hv' cannot be negated
+$ echo $?
+1
+```
+
+Two roast files assert on this, through `Test::Util`'s `is_run`:
+
+- `S19-command-line/arguments.t` test 6 — `is_run(Str, :args['--nosucharg=foo', 'foo.raku'],
+  { out => '' }, 'Unknown options do not spit warnings to stdout')`
+- `S19-command-line-options/04-negation.t` tests 2 and 3 — `:args['-/hv']` and
+  `:args['--/target', 'foo']`, each expecting
+  `out => rx/"SORRY" .+ "cannot be negated"/, err => ''`
+
+Neither names a status, but `is_run` supplies one:
+
+```raku
+%expected<status> = 0 if
+    not %expected<status>:exists
+    and (not %expected<err>:exists or %expected<err> ~~ Str and %expected<err> eq '');
+```
+
+so both files require **exit 0**. They passed only because mutsu's *native*
+reimplementation of `is_run` did not apply that default; under the real
+`Test::Util` module they fail. That is the immediate trigger — these are two of
+the files blocking `todo/tickets/retire-native-test-util-overrides.md`.
+
+## 2. What rakudo actually does
+
+Measured with rakudo 2026.06. **Measure the exit status directly** — an earlier
+pass through this read `rc=0` everywhere because the command was piped into
+`head`, and the shell reported *`head`'s* status:
+
+| invocation | stdout | stderr | status |
+| --- | --- | --- | --- |
+| `raku nosuchfile.raku` | — | `Could not open nosuchfile.raku. Failed to stat file: …` | **1** |
+| `raku --nosucharg=foo foo.raku` | — | `Illegal option --nosucharg` + usage | **0** |
+| `raku --zzz` | — | `Illegal option --zzz` + usage | **0** |
+| `raku -z` | — | `No such option -z` + usage | **0** |
+| `raku -/hv` | — | `Grouped options '-/hv' contain '/', …` + usage | **0** |
+
+The rule is narrower than "rakudo exits 0 on errors": an error *parsing the
+option list* is status 0, and a program-level failure — including a program file
+that cannot be opened — is not. mutsu already agreed on the missing-file case
+(status 1); it disagreed only about option parsing.
+
+## 3. Decision
+
+Follow rakudo for option-parsing errors:
+
+- an unrecognised option before the source is an **option error**, not a
+  filename: `Illegal option --name` for a long option (naming it without its
+  `=value`), `No such option -x` for a short one, followed by the usage text,
+  **all on stderr**, exit status **0**;
+- a malformed negation keeps mutsu's existing `SORRY! Option '…' cannot be
+  negated` wording **on stdout** and now also exits **0**;
+- `--` is honoured as end-of-switches, so a program file may begin with a dash;
+- a program file that cannot be opened is unchanged: message on stderr, exit
+  status **1**.
+
+The negation message stays on stdout deliberately. rakudo prints its own to
+stderr and therefore *fails* `04-negation.t` — the whole block is marked
+`#?rakudo todo ''`. The roast file is the spec here, and it asks for the message
+on stdout with an empty stderr; mutsu already satisfied that half and there is no
+reason to regress to rakudo's implementation wart when the spec text disagrees
+with it.
+
+## 4. Consequences
+
+- `roast/S19-command-line/arguments.t` and
+  `roast/S19-command-line-options/04-negation.t` pass under the real
+  `Test::Util`, taking that ticket's residue from 4 files to 2.
+- An unknown switch is now rejected instead of being silently taken for the
+  program file, which is a real usability gain: `mutsu --dump-bytcode foo.raku`
+  used to report "Could not open --dump-bytcode".
+- **The cost, stated plainly: `mutsu --typo file.raku` exits 0.** A shell script
+  that checks `$?` cannot tell a typo'd switch from a successful run. This is a
+  known rakudo wart and we are adopting it knowingly, because the alternative is
+  to diverge from the reference implementation on the exact behaviour two spec
+  tests pin. It is contained: it applies only to option parsing. Every other
+  failure path — parse errors, runtime errors, test failures, an unopenable
+  program file — keeps its non-zero status.
+- If this bites in practice, the reversal is a two-line change in
+  `illegal_option` / `print_negation_error`, and it would have to be recorded as
+  a superseding ADR together with whatever happens to the two roast files.
+
+## 5. Alternatives considered
+
+- **Keep exit 1 and leave the two roast files failing.** Rejected: they are
+  spec tests, and leaving them failing also leaves the `Test::Util` provider
+  retirement blocked on something that is not a bug in the provider.
+- **Keep exit 1 and special-case `is_run`.** Rejected outright — that is a
+  test-specific hack, which the project bans.
+- **Exit 0 for *every* CLI error, including a missing program file.** Rejected:
+  rakudo does not do that (status 1, measured above), and it would throw away a
+  genuinely useful signal for no spec benefit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,5 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0013](0013-container-interior-mutability-cellvalue.md) | Container interior mutability — kill the `gc_contents_mut` provenance UB with a `GcCell` newtype | Proposed |
 | [0014](0014-make-test-runs-tap-on-debug-binary.md) | `make test` runs the TAP (`t/`) suite on the debug binary, not release | Accepted |
 | [0015](0015-native-backed-container-storage-and-repr-bodies.md) | Native-backed container storage and synthesised REPR bodies (`BODY_OF`) | Accepted |
+| [0016](0016-span-based-captures-and-lazy-match.md) | Span-based regex captures and lazily materialized `Match` objects | Proposed |
+| [0017](0017-cli-option-errors-follow-rakudo.md) | A command-line *option* error follows rakudo — message, stream, and a zero exit status | Accepted |

--- a/news/2026-08/cli-option-errors-follow-rakudo.md
+++ b/news/2026-08/cli-option-errors-follow-rakudo.md
@@ -1,0 +1,51 @@
+# A command-line option error follows rakudo
+
+mutsu's CLI treated any argument it did not recognise as the program file, so a
+typo'd switch produced a nonsensical error and a malformed negation exited
+non-zero:
+
+```
+$ mutsu --nosucharg=foo foo.raku
+Could not open --nosucharg=foo. Failed to stat file: no such file or directory   # exit 1
+$ mutsu -/hv
+SORRY! Option '-/hv' cannot be negated                                           # exit 1
+```
+
+Two roast files pin this through `Test::Util`'s `is_run`
+(`S19-command-line/arguments.t` test 6, `S19-command-line-options/04-negation.t`
+tests 2 and 3). Neither names a status, but `is_run` defaults one to 0 whenever
+`err` is absent or empty — so both require **exit 0**. They passed only because
+mutsu's *native* reimplementation of `is_run` did not apply that default.
+
+Measured against rakudo 2026.06, the rule is narrower than "rakudo exits 0 on
+errors": an error *parsing the option list* is status 0, while a program-level
+failure — including a program file that cannot be opened — is not. mutsu already
+agreed on the missing-file case; it disagreed only about option parsing.
+
+So mutsu now:
+
+- rejects an unrecognised option instead of taking it for a filename —
+  `Illegal option --name` for a long one (named without its `=value`),
+  `No such option -x` for a short one, each followed by the usage text, all on
+  stderr, exit 0;
+- exits 0 from a malformed negation, keeping the message on stdout, which is
+  what `04-negation.t` asks for (rakudo prints its own to stderr and fails that
+  file — the block is `#?rakudo todo ''`);
+- honours `--` as end-of-switches, so a program file may begin with a dash;
+- still exits 1 when the program file cannot be opened.
+
+The cost is stated plainly in the ADR: `mutsu --typo file.raku` now exits 0, so a
+script checking `$?` cannot distinguish a typo'd switch from a clean run. That is
+a known rakudo wart, adopted knowingly and contained to option parsing — every
+other failure path keeps its non-zero status. The reasoning, the measurements,
+and the rejected alternatives are in
+[ADR-0017](../../docs/adr/0017-cli-option-errors-follow-rakudo.md).
+
+A methodological note worth repeating: the first pass at this measurement read
+`rc=0` for *every* rakudo invocation, because the commands were piped into
+`head` and the shell reported `head`'s status. The real table only appeared once
+each command was run without a pipeline. Measure the thing you are actually
+asking about.
+
+Pin: `t/cli-option-errors.t`. With this in,
+`todo/tickets/retire-native-test-util-overrides.md`'s residue drops to 2 files.

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,15 @@ fn print_error(prefix: &str, err: &RuntimeError, source: Option<&str>, program_n
 }
 
 fn print_help(program: &str) {
+    print!("{}", usage_text(program));
+}
+
+fn usage_text(program: &str) -> String {
+    let mut out = String::new();
+    macro_rules! println {
+        () => { out.push('\n') };
+        ($($arg:tt)*) => {{ out.push_str(&format!($($arg)*)); out.push('\n'); }};
+    }
     println!("Usage: {} [OPTIONS] [FILE | -e CODE]", program);
     println!();
     println!("Options:");
@@ -42,11 +51,33 @@ fn print_help(program: &str) {
     println!("  MUTSU_CRASH_DIR");
     println!("                 Directory to write crash reports to");
     println!("                 (default: tmp/crash)");
+    out
 }
 
+/// A command-line option that cannot be negated. The message goes to *stdout*
+/// and the process ends **successfully** — see `docs/adr/0017` for why an
+/// option-parsing error is not a failure exit.
 fn print_negation_error(option: &str) -> ! {
     println!("SORRY! Option '{}' cannot be negated", option);
-    std::process::exit(1);
+    std::process::exit(0);
+}
+
+/// An option mutsu does not know, reported the way rakudo reports it: the
+/// message and the usage text on *stderr*, exit status **0** (ADR-0017). Long
+/// options are named without their `=value` part, matching
+/// `Illegal option --nosucharg` for `--nosucharg=foo`.
+///
+/// Without this, an unknown `--switch` fell through to "this must be the
+/// program file" and died with `Could not open --switch`.
+fn illegal_option(program: &str, arg: &str) -> ! {
+    if let Some(long) = arg.strip_prefix("--") {
+        let name = long.split('=').next().unwrap_or(long);
+        eprintln!("Illegal option --{}", name);
+    } else {
+        eprintln!("No such option {}", arg);
+    }
+    eprint!("{}", usage_text(program));
+    std::process::exit(0);
 }
 
 fn handle_negated_short_option(
@@ -261,12 +292,18 @@ fn run_main() {
                 std::process::exit(1);
             }
             preload_modules.push(module.to_string());
-        } else {
-            filtered_args.push(arg.clone());
-            // If this looks like a filename (not a flag), mark source as seen
-            if !arg.starts_with('-') || arg == "-" {
+        } else if arg == "--" {
+            // End of switches: whatever follows is the program file (and then
+            // its own arguments), even if it starts with a dash.
+            if let Some(file) = iter.next() {
+                filtered_args.push(file.clone());
                 seen_source = true;
             }
+        } else if arg.starts_with('-') && arg != "-" {
+            illegal_option(&args[0], arg);
+        } else {
+            filtered_args.push(arg.clone());
+            seen_source = true;
         }
     }
 

--- a/t/cli-option-errors.t
+++ b/t/cli-option-errors.t
@@ -1,0 +1,49 @@
+use Test;
+
+# ADR-0017: an error *parsing the option list* follows rakudo -- the message and
+# usage go to stderr, and the process exits 0. A program-level failure (a
+# program file that cannot be opened) is unchanged and still exits 1.
+#
+# Before this, an unrecognised switch fell through to "this must be the program
+# file" and died with `Could not open --nosucharg=foo`, exit 1.
+
+plan 12;
+
+my $script = $*TMPDIR.child("mutsu-cli-opt-{$*PID}.raku");
+$script.spurt: "say 42\n";
+LEAVE try $script.unlink;
+
+sub mutsu(*@args) {
+    my $proc = run $*EXECUTABLE.absolute, |@args, :out, :err;
+    my $out = $proc.out.slurp(:close);
+    my $err = $proc.err.slurp(:close);
+    ($proc.exitcode, $out, $err);
+}
+
+my ($status, $out, $err) = mutsu('--nosucharg=foo', 'foo.raku');
+is $status, 0, 'an unknown long option exits 0';
+is $out, '', '... writes nothing to stdout';
+ok $err.starts-with("Illegal option --nosucharg\n"),
+    '... and names it on stderr without its =value';
+
+($status, $out, $err) = mutsu('-z');
+is $status, 0, 'an unknown short option exits 0';
+ok $err.starts-with("No such option -z\n"), '... with rakudo\'s short-option wording';
+
+# A malformed negation keeps its message on stdout (which is what
+# roast/S19-command-line-options/04-negation.t asks for) and exits 0.
+($status, $out, $err) = mutsu('-/hv');
+is $status, 0, 'a malformed negation exits 0';
+like $out, /'SORRY' .+ 'cannot be negated'/, '... reporting it on stdout';
+is $err, '', '... and leaving stderr empty';
+
+# `--` ends the switches, so the program file may begin with a dash.
+($status, $out, $err) = mutsu('--', $script.absolute);
+is $status, 0, '-- ends the switch list';
+is $out, "42\n", '... and what follows is the program file';
+
+# A program file that cannot be opened is NOT an option error: still exit 1.
+($status, $out, $err) = mutsu('no-such-file-here.raku');
+is $status, 1, 'an unopenable program file still exits 1';
+ok $err.contains('Could not open no-such-file-here.raku'),
+    '... reporting it on stderr';

--- a/todo/tickets/retire-native-test-util-overrides.md
+++ b/todo/tickets/retire-native-test-util-overrides.md
@@ -51,17 +51,17 @@ also fixed — they are why the count below is 7 rather than 9:
 - `bail-out` emitted "Bail out!" but exited 0 instead of 255
   (`news/2026-08/bail-out-exits-255.md`).
 
-## Measured residue: 5 files, 3 causes (2026-08-02)
+## Measured residue: 2 files, 2 causes (2026-08-02)
 
-With the guard widened, 223 of the 228 files pass. None of the five is a
+With the guard widened, 226 of the 228 files pass. Neither of the two is a
 `Test::Util` incompatibility — each is a mutsu gap the native override was
-hiding. Take them one at a time; the flip lands once they are all closed.
+hiding. Take them one at a time; the flip lands once they are both closed.
 
 | files | cause |
 | --- | --- |
 | ~~`S24-testing/12-subtest-todo.t`~~ | **DONE** — the failure-diagnostic stream was chosen by nesting depth rather than by whether the failure was TODO'd, and every stderr diagnostic was emitted twice. `news/2026-08/tap-failure-diagnostics-pick-the-stream-rakudo-picks.md`. |
-| `S19-command-line-options/04-negation.t` (2, 3), `S19-command-line/arguments.t` (6) | **CLI option handling**: mutsu exits 1 where raku exits with a different status for a malformed/negated short option, and writes an unknown-option warning to the wrong stream. |
-| `S26-documentation/02-paragraph.t` (28) | **`--doc=Text` is not recognised**: mutsu treats it as the program file ("Could not open --doc=Text"). The real `is_run` passes it through `:compiler-args`. |
+| ~~`S19-command-line-options/04-negation.t` (2, 3), `S19-command-line/arguments.t` (6)~~ | **DONE** — an unrecognised switch was taken for the program file, and an option-parsing error exited 1 where rakudo exits 0. Decision recorded in [ADR-0017](../../docs/adr/0017-cli-option-errors-follow-rakudo.md); `news/2026-08/cli-option-errors-follow-rakudo.md`. |
+| ~~`S26-documentation/02-paragraph.t` (28)~~ | **DONE** — `--doc=Text` was not recognised (and `E<...>` was not decoded inside `=begin pod`). `news/2026-08/doc-equals-renderer-and-entities-in-begin-pod.md`. |
 | `S03-operators/repeat.t` (56), `S16-io/words.t` (11) | one `warns-like` whose message does not match, and `words()` without arguments not reading `$*ARGFILES` — each an ordinary single-assertion gap. |
 
 One difference is *not* in that list because nothing currently asserts on it,


### PR DESCRIPTION
mutsu's CLI treated any argument it did not recognise as the program file, so a
typo'd switch produced a nonsensical error, and a malformed negation exited
non-zero:

```
$ mutsu --nosucharg=foo foo.raku
Could not open --nosucharg=foo. Failed to stat file: ...   # exit 1
$ mutsu -/hv
SORRY! Option '-/hv' cannot be negated                      # exit 1
```

Two roast files pin this through `Test::Util`'s `is_run`
(`S19-command-line/arguments.t` test 6, `S19-command-line-options/04-negation.t`
tests 2-3). Neither names a status, but `is_run` supplies one:

```raku
%expected<status> = 0 if
    not %expected<status>:exists
    and (not %expected<err>:exists or %expected<err> ~~ Str and %expected<err> eq '');
```

so both require **exit 0**. They passed only because mutsu's *native*
reimplementation of `is_run` did not apply that default.

## What rakudo actually does

Measured against rakudo 2026.06 — the rule is narrower than "rakudo exits 0 on
errors":

| invocation | stderr | status |
| --- | --- | --- |
| `raku nosuchfile.raku` | `Could not open nosuchfile.raku. …` | **1** |
| `raku --nosucharg=foo foo.raku` | `Illegal option --nosucharg` + usage | **0** |
| `raku --zzz` | `Illegal option --zzz` + usage | **0** |
| `raku -z` | `No such option -z` + usage | **0** |
| `raku -/hv` | grouped-negation message + usage | **0** |

An error *parsing the option list* is status 0; a program-level failure —
including an unopenable program file — is not. mutsu already agreed on the
missing-file case; it disagreed only about option parsing.

*(Methodological note: the first pass at this table read `rc=0` everywhere,
because the commands were piped into `head` and the shell reported **head's**
status. The real numbers only appeared once each command ran without a
pipeline.)*

## Decision

- an unrecognised option is rejected instead of taken for a filename:
  `Illegal option --name` for a long one (named without its `=value`),
  `No such option -x` for a short one, each followed by the usage text, all on
  stderr, exit 0;
- a malformed negation exits 0, keeping its message on **stdout** — which is what
  `04-negation.t` asks for. rakudo prints its own to stderr and therefore *fails*
  that file (the block is `#?rakudo todo ''`); the roast file is the spec here and
  mutsu already satisfied that half, so there is no reason to regress to the
  implementation wart;
- `--` is honoured as end-of-switches, so a program file may begin with a dash;
- an unopenable program file still exits 1.

**The cost, stated plainly: `mutsu --typo file.raku` now exits 0**, so a script
checking `$?` cannot distinguish a typo'd switch from a clean run. That is a
known rakudo wart, adopted knowingly and contained to option parsing — every
other failure path keeps its non-zero status. The context, the measurements and
the rejected alternatives are recorded in
[ADR-0017](docs/adr/0017-cli-option-errors-follow-rakudo.md), as requested.

There is a real gain too: an unknown switch is now reported as such instead of
being silently taken for the program file (`mutsu --dump-bytcode foo.raku` used
to say "Could not open --dump-bytcode").

## Effect on the Test::Util retirement

Takes the measured residue in `todo/tickets/retire-native-test-util-overrides.md`
from 4 files to **2** (verified by temporarily flipping the guard and running the
S19 files, then reverting). What remains is one `warns-like` message mismatch and
`words()` not reading `$*ARGFILES`.

## Testing

`make test` PASS (2762 files / 26321 tests). Roast `S19-command-line/`,
`S19-command-line-options/{03,04}`, `S26-documentation/` (33 files) PASS.

Pin: `t/cli-option-errors.t` (12 assertions covering both option-error shapes,
`--`, and the unchanged missing-file status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)