### PR TITLE
fix(parser): a pointy block with one literal parameter keeps its constraint

### DIFF
--- a/news/2026-08/pointy-single-literal-parameter.md
+++ b/news/2026-08/pointy-single-literal-parameter.md
@@ -1,0 +1,32 @@
+# A pointy block with one literal parameter keeps its constraint
+
+`-> 'about' { … }` reported an unconstrained `Any` parameter, while
+`-> 'company', 'careers' { … }` was correct:
+
+```raku
+say (-> 'about' { }).signature;              # was :($__literal__), now :(Str)
+say (-> 'about' { }).signature.params[0].constraints.ACCEPTS('about');  # was False
+```
+
+The parser has two shapes for a pointy block. Two or more parameters build an
+`Expr::AnonSubParams` carrying full `ParamDef`s; exactly one parameter takes a
+name-only `Expr::Lambda` fast path whenever the parameter is "simple". That
+`simple_single` gate already excluded traits, shaped constraints, named/slurpy/
+optional forms, defaults, type constraints, `where`, sub-signatures and `@_`/
+`%_` — but not `literal_value`, which the `Lambda` form has nowhere to put. So
+a single literal parameter silently lost its constraint. Adding
+`first.literal_value.is_none()` to the gate routes it through `AnonSubParams`
+like every other non-simple parameter.
+
+Pinned by `t/pointy-single-literal-param.t`.
+
+This was the second of the two bugs that kept `Cro::HTTP`'s router from
+compiling its route matchers: `Cro::HTTP::Router` builds a route's URL segment
+matcher from `$param.constraints`, so every single-segment route
+(`get -> 'product' { … }`) compiled to a matcher with no segment at all.
+
+The related gap that a literal parameter is not *enforced* at bind time
+(`(-> 'about' { })('nope')` still runs the body — in Rakudo it throws
+`X::TypeCheck::Binding::Parameter`) is recorded in
+`todo/tickets/literal-parameters-are-not-enforced-at-bind.md`; it is a
+dispatch-wide question, not specific to this path.

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -193,6 +193,12 @@ pub(crate) fn arrow_lambda(input: &str) -> PResult<'_, Expr> {
         }
         let simple_single = first.traits.is_empty()
             && first.shape_constraints.is_none()
+            // A literal parameter (`-> 'about' { … }`) carries its constraint in
+            // `literal_value`, which the name-only `Lambda` form cannot hold —
+            // the block would then accept ANY argument, and its `.signature`
+            // would report no constraint (Cro's router compiles a route's URL
+            // segments from exactly that constraint).
+            && first.literal_value.is_none()
             && !first.named
             && !first.slurpy
             && !first.double_slurpy

--- a/t/pointy-single-literal-param.t
+++ b/t/pointy-single-literal-param.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+plan 8;
+
+# A pointy block with exactly ONE parameter took a name-only fast path that
+# cannot carry the parameter's literal value, so `-> 'about' { … }` lost its
+# constraint entirely: it reported an unconstrained `Any` parameter, while two
+# or more literals already worked. (Cro's router compiles a route's URL segments
+# from exactly that constraint.)
+
+{
+    my $b = -> 'about' { "hit" };
+    my $p = $b.signature.params[0];
+    is $p.type.^name, 'Str', 'a single literal parameter is typed Str';
+    ok $p.constraints.ACCEPTS('about'), 'and carries the literal as a constraint';
+    nok $p.constraints.ACCEPTS('nope'), 'which rejects a different string';
+    ok $b.signature.ACCEPTS(\('about')), 'the signature accepts the literal';
+    nok $b.signature.ACCEPTS(\('nope')), 'and rejects anything else';
+    is $b("about"), "hit", 'the block still runs';
+}
+
+{
+    my $b = -> 'company', 'careers' { "two" };
+    ok $b.signature.params[0].constraints.ACCEPTS('company')
+        && $b.signature.params[1].constraints.ACCEPTS('careers'),
+        'two literal parameters keep their constraints';
+}
+
+# A plain single parameter is unchanged.
+{
+    my $b = -> $x { $x * 2 };
+    is $b(21), 42, 'an ordinary single parameter still binds';
+}

--- a/todo/tickets/literal-parameters-are-not-enforced-at-bind.md
+++ b/todo/tickets/literal-parameters-are-not-enforced-at-bind.md
@@ -1,0 +1,39 @@
+# A literal parameter is not enforced when the routine is called
+
+A parameter written as a literal (`sub f("a") { }`, `-> 'about' { }`) constrains
+the argument: Rakudo throws `X::TypeCheck::Binding::Parameter` when the argument
+is not that literal. mutsu records the literal (`ParamDef::literal_value`) and
+reports it correctly through introspection — `.signature.params[0].constraints`,
+`Signature.ACCEPTS` and multi-dispatch candidate selection all honour it — but
+the *binder* ignores it, so a direct call binds any argument:
+
+```raku
+sub f("a") { "hit" }
+say f("a");   # hit   (both)
+say f("b");   # raku: X::TypeCheck::Binding::Parameter; mutsu: hit
+```
+
+Same for a pointy block: `(-> 'about' { })('nope')` runs the body.
+
+## Why it is not a one-liner
+
+The obvious fix — "throw when `literal_value` is set and the argument differs" —
+has to be placed so that it does NOT break `multi` dispatch, where a
+literal-parameter candidate that does not match must be *skipped* in favour of
+the next candidate rather than dying. The binder is shared between the
+single-candidate call path and the per-candidate trial bind, so the check needs
+a mode (or has to live only on the committed path, after candidate selection).
+`proto`/`only` and `where`-constrained parameters raise the same question, so
+the fix should cover the whole "argument fails a parameter's constraint at bind
+time" family rather than special-casing literals.
+
+## Affected files
+
+- `src/vm/` parameter binding (`bind_params`-family) and
+  `src/runtime/` dispatch (`calls.rs` / `dispatch.rs`) for the multi path.
+- `ParamDef::literal_value` is set in `src/parser/stmt/sub_param/`.
+
+Introspection is already correct as of
+`t/pointy-single-literal-param.t` (which pins the `.signature` half, fixed in
+`news/2026-08/pointy-single-literal-parameter.md`); this ticket is only about
+enforcement at call time.


### PR DESCRIPTION
`-> 'about' { … }` reported an unconstrained `Any` parameter, while
`-> 'company', 'careers' { … }` was already correct:

```raku
say (-> 'about' { }).signature;   # was :($__literal__), now :(Str)
say (-> 'about' { }).signature.params[0].constraints.ACCEPTS('about');  # was False
```

The parser has two shapes for a pointy block. Two or more parameters build an
`Expr::AnonSubParams` carrying full `ParamDef`s; exactly one parameter takes a
name-only `Expr::Lambda` fast path whenever the parameter is "simple". That
`simple_single` gate already excluded traits, shaped constraints, named /
slurpy / optional forms, defaults, type constraints, `where`, sub-signatures
and `@_`/`%_` — but not `literal_value`, which the `Lambda` form has nowhere to
put. Adding `first.literal_value.is_none()` routes a literal parameter through
`AnonSubParams` like every other non-simple parameter.

### Why it mattered

This is one of the two bugs that kept `Cro::HTTP`'s router from compiling its
route matchers: `Cro::HTTP::Router` builds a route's URL segment matcher from
`$param.constraints`, so every single-segment route (`get -> 'product' { … }`)
compiled to a matcher with no path segment at all.

### Tests

- New `t/pointy-single-literal-param.t` (8 assertions, all pass under `raku`).
- `make test` green.

### Follow-up recorded

A literal parameter is still not *enforced* at bind time
(`(-> 'about' { })('nope')` runs the body; Rakudo throws
`X::TypeCheck::Binding::Parameter`). That is a dispatch-wide question — a
non-matching `multi` candidate must be skipped rather than die — so it is
filed as `todo/tickets/literal-parameters-are-not-enforced-at-bind.md` instead
of being hacked into this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
