### PR TITLE
fix(runtime): an array alias survives a thread having run

### DIFF
--- a/news/2026-08/array-alias-survives-a-thread.md
+++ b/news/2026-08/array-alias-survives-a-thread.md
@@ -1,0 +1,54 @@
+# An array alias survives a thread having run
+
+Once any thread had run, a plain-lexical `@a.push` in the *main* thread was
+routed through the cross-thread `__mutsu_atomic_arr::` store — unconditionally,
+because `shared_vars_active` is set at the first spawn and never goes back to
+false. That store is keyed by NAME, so the push detached the array from every
+other binding of the same container:
+
+```raku
+sub aliased() {
+    my @a; my @b; my $cond = False;
+    my @t := $cond ?? @b !! @a;   # @t and @a are the same container
+    @a.push("via-a");
+    @t.push("via-t");
+    @a.join(",")
+}
+say aliased();          # via-a,via-t
+await start { 42 };
+say aliased();          # was: via-t   (the @a push landed under a different key)
+```
+
+`@t =:= @a` still reported `True` — the bind itself was fine. The `@a` push
+went to `__mutsu_atomic_arr::@a` while `@t` kept holding the original `Gc`
+node, so each binding saw only its own writes. Any program that spawns a thread
+once — every Cro application — ran the rest of its life this way.
+
+## The fix
+
+`exec_array_push_op` now takes the name-keyed store only when the frame can
+actually be racing: it is a worker thread (where serializing concurrent appends
+is the whole point), or the name is *genuinely shared* — it already has an
+authoritative `__mutsu_atomic_arr::` entry, or the base name is bound in the
+cross-thread store because a spawn happened while that lexical was live. This
+is the gate `assign_array_elem_to_shared_var` already applied to element
+assignment; the push path is now consistent with it.
+
+The worker-thread arm is deliberately kept unconditional. `append`/`prepend`/
+`unshift`/`splice` seed and use the atomic entry there, and reads prefer it once
+it exists, so a `push` that skipped the store would be silently lost by the next
+`append` — the zef `populate-distributions` bug pinned by
+`t/hyper-array-mutators.t`.
+
+Pinned by `t/array-alias-after-thread.t`, which also re-checks that concurrent
+`start { @shared.push($i) }` still merges without losing an element.
+
+## Why it mattered
+
+`Cro::HTTP::Router` compiles each route's segment matcher with
+`my @matcher-target := $param.optional ?? @segments-optional !! @segments-required;`
+followed by `@matcher-target.push(...)`. Once a route block had actually served
+a request (which runs the handler in a `start`), every subsequent route block
+lost every segment it pushed, so `get -> 'product' { … }` compiled to a matcher
+with no path segment. With this and the single-literal-parameter fix,
+`t/http-router.rakutest` goes from 31 of 51 passing subtests to 49.

--- a/src/runtime/builtins_atomic_shared.rs
+++ b/src/runtime/builtins_atomic_shared.rs
@@ -270,6 +270,20 @@ impl Interpreter {
     /// entry (created by a prior shared push/extend/CAS). Once it exists,
     /// reads prefer it, so every subsequent mutation must go through
     /// `shared_array_mutate` or it is silently lost.
+    /// Whether `@arr` is *genuinely shared* across threads: it already has an
+    /// authoritative `__mutsu_atomic_arr::` entry, or the base name itself is
+    /// bound in the cross-thread store (seeded when a thread was spawned while
+    /// this lexical was live). A name that is in neither is frame-local, and
+    /// routing its mutations through the name-keyed store would detach it from
+    /// every other binding of the same container.
+    pub(crate) fn array_name_is_shared(&self, arr_name: &str) -> bool {
+        self.atomic_array_entry_exists(arr_name)
+            || self
+                .shared_vars
+                .get(arr_name)
+                .is_some_and(|v| matches!(v.view(), ValueView::Array(..)))
+    }
+
     pub(crate) fn atomic_array_entry_exists(&self, arr_name: &str) -> bool {
         let atomic_key = format!("__mutsu_atomic_arr::{arr_name}");
         matches!(

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -98,9 +98,20 @@ impl Interpreter {
             }
             // Only a plain lexical `@name` (not an attribute `@!x`/`@.x` or other
             // twigil'd form) has a single shared identity across threads, so only
-            // it may funnel into the name-keyed atomic shared store.
+            // it may funnel into the name-keyed atomic shared store — and only
+            // when this frame can actually be racing: a worker thread (where the
+            // whole point is to serialize concurrent appends), or a name that is
+            // GENUINELY shared already. The store is keyed by NAME, so routing a
+            // *main-thread* frame-local `my @a` through it detaches it from every
+            // other binding of the same container — a `my @t := @a` alias keeps
+            // the original node while the push lands under
+            // `__mutsu_atomic_arr::@a`. `shared_vars_active` never goes back to
+            // false, so without this gate every array push in a program that once
+            // spawned a thread is name-keyed. Mirrors the "genuinely shared" gate
+            // `assign_array_elem_to_shared_var` already applies.
             if matches!(target.view(), ValueView::Array(..) | ValueView::Nil)
                 && Self::is_plain_lexical_array_name(target_name)
+                && (self.is_thread_clone() || self.array_name_is_shared(target_name))
             {
                 let items = match val.view() {
                     ValueView::Slip(items) => items.to_vec(),

--- a/t/array-alias-after-thread.t
+++ b/t/array-alias-after-thread.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+plan 6;
+
+# The cross-thread array store is keyed by NAME, and `shared_vars_active` never
+# goes back to false once a thread has run. Routing every plain-lexical `@a.push`
+# through that store therefore detached a frame-local array from every other
+# binding of the same container: `my @t := @a` kept the original node while the
+# push landed under `__mutsu_atomic_arr::@a`. Only a genuinely-shared name (or a
+# worker thread, where serializing concurrent appends is the point) may use it.
+
+sub aliased($tag) {
+    my @a;
+    my @b;
+    my $cond = False;
+    # A non-trivial RHS binds by value, so the alias is pure container identity.
+    my @t := $cond ?? @b !! @a;
+    @a.push("via-a");
+    @t.push("via-t");
+    @a.join(",")
+}
+
+is aliased("before"), "via-a,via-t", 'a ternary-bound array alias shares pushes';
+
+# Spawning (and awaiting) a thread must not change that.
+is (await start { 42 }), 42, 'a start block runs';
+
+is aliased("after"), "via-a,via-t",
+    'the alias still shares pushes after a thread has run';
+
+# The same for a direct bind, and for an array declared before the thread ran.
+{
+    my @src;
+    my @alias := @src;
+    await start { 1 };
+    @src.push("x");
+    @alias.push("y");
+    is @src.join(","), "x,y", 'a direct alias shares pushes after a thread ran';
+}
+
+# A genuinely shared array still merges concurrent pushes.
+{
+    my @shared;
+    await Promise.allof((^4).map: -> $i { start { @shared.push($i) } });
+    is @shared.elems, 4, 'concurrent pushes to a shared array all land';
+    is @shared.sort.join(","), "0,1,2,3", 'and none of them is lost';
+}


### PR DESCRIPTION
Once any thread had run, a plain-lexical `@a.push` in the **main** thread was
routed through the cross-thread `__mutsu_atomic_arr::` store — unconditionally,
because `shared_vars_active` is set at the first spawn and never goes back to
false. That store is keyed by NAME, so the push detached the array from every
other binding of the same container:

```raku
sub aliased() {
    my @a; my @b; my $cond = False;
    my @t := $cond ?? @b !! @a;   # @t and @a are the same container
    @a.push("via-a");
    @t.push("via-t");
    @a.join(",")
}
say aliased();          # via-a,via-t
await start { 42 };
say aliased();          # was: via-t
```

`@t =:= @a` still reported `True` — the bind itself was fine. The `@a` push
went to `__mutsu_atomic_arr::@a` while `@t` kept holding the original `Gc`
node, so each binding only ever saw its own writes. Any program that spawns a
thread once — every Cro application — ran the rest of its life this way.

### The fix

`exec_array_push_op` now takes the name-keyed store only when the frame can
actually be racing: it is a worker thread (where serializing concurrent appends
is the whole point), or the name is *genuinely shared* — it already has an
authoritative `__mutsu_atomic_arr::` entry, or the base name is bound in the
cross-thread store because a spawn happened while that lexical was live. This
is the gate `assign_array_elem_to_shared_var` already applied to element
assignment; the push path is now consistent with it.

The worker-thread arm is deliberately kept unconditional: `append` / `prepend` /
`unshift` / `splice` seed and use the atomic entry there, and reads prefer it
once it exists, so a `push` that skipped the store would be silently lost by the
next `append` — the zef `populate-distributions` bug pinned by
`t/hyper-array-mutators.t` (which caught exactly that during development).

### Why it mattered

`Cro::HTTP::Router` compiles each route's segment matcher with
`my @matcher-target := $param.optional ?? @segments-optional !! @segments-required;`
followed by `@matcher-target.push(...)`. Once a route block had actually served
a request (the handler runs in a `start`), every subsequent route block lost
every segment it pushed, so `get -> 'product' { … }` compiled to a matcher with
no path segment. Together with #5729, `t/http-router.rakutest` goes from 31 of
51 passing subtests to 49.

### Tests

- New `t/array-alias-after-thread.t` (6 assertions, all pass under `raku`),
  which also re-checks that concurrent `start { @shared.push($i) }` still merges
  without losing an element.
- `make test` green; `roast/S17*` + `roast/S32-array*` whitelist green locally
  on a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
