### PR TITLE
fix(parser): an imported sub shadows the IO builtin of the same name

### DIFF
--- a/news/2026-08/imported-sub-shadows-io-builtin.md
+++ b/news/2026-08/imported-sub-shadows-io-builtin.md
@@ -1,0 +1,21 @@
+# An imported sub shadows the IO builtin of the same name
+
+`say` / `print` / `put` / `note` have a builtin *statement* form in the parser,
+tried before the general listop-call parse. A locally declared `sub say(...)`
+already bailed out of it (`shadowed_by_user_sub`), so the user sub won — but an
+**imported** one did not, because `use`d exports land in the scope's
+`imported_functions` set, not in `user_subs`, and only the latter was consulted.
+
+```raku
+use Cro::HTTP::Router;   # exports the HTTP verb `put`
+put -> 'product' { ... } # parsed as `put(the-block)` — a PRINT, not a route
+```
+
+The lexical scope does not care where a binding came from, so
+`shadowed_by_user_sub` now consults `is_imported_function` as well.
+
+Pinned by `t/imported-sub-shadows-io-builtin.t` (with `t/lib/IOBuiltinShadow.rakumod`).
+
+Concretely, this is why `Cro::HTTP`'s five-verb route set registered only four
+routes: `put -> 'product' { … }` printed the block instead of adding the PUT
+handler, so a PUT request 405'd.

--- a/src/parser/stmt/simple/io_stmts.rs
+++ b/src/parser/stmt/simple/io_stmts.rs
@@ -38,12 +38,17 @@ fn check_io_func_followed_by_loop<'a>(name: &str, rest_after_ws: &'a str) -> PRe
     Ok((rest_after_ws, ()))
 }
 
-/// A user-declared `sub` named like an IO builtin (`say`/`print`/`put`/`note`)
-/// shadows the builtin listop form in its lexical scope: `sub say(...) {...}; say
-/// $x` must call the user sub, not the builtin. Bail out of the builtin-statement
-/// parse so statement dispatch falls through to the general listop-call parser.
+/// A `sub` named like an IO builtin (`say`/`print`/`put`/`note`) shadows the
+/// builtin listop form in its lexical scope: `sub say(...) {...}; say $x` must
+/// call the sub, not the builtin. Bail out of the builtin-statement parse so
+/// statement dispatch falls through to the general listop-call parser.
+///
+/// An *imported* sub shadows it exactly as a locally-declared one does — the
+/// lexical scope does not care where the binding came from. `Cro::HTTP::Router`
+/// exports `put` (the HTTP verb), so `put -> 'product' { … }` inside a `route`
+/// block is a route declaration, not a print.
 fn shadowed_by_user_sub(name: &str) -> PResult<'_, ()> {
-    if is_user_declared_sub(name) {
+    if is_user_declared_sub(name) || is_imported_function(name) {
         return Err(PError::expected("io builtin shadowed by user sub"));
     }
     Ok(("", ()))

--- a/t/imported-sub-shadows-io-builtin.t
+++ b/t/imported-sub-shadows-io-builtin.t
@@ -1,0 +1,36 @@
+use v6;
+use lib 't/lib';
+use Test;
+use IOBuiltinShadow;
+
+plan 5;
+
+# A `sub` named like an IO builtin (`say`/`print`/`put`/`note`) shadows the
+# builtin's listop STATEMENT form in its lexical scope. A locally-declared sub
+# already did; an *imported* one did not, so `put -> 'x' { }` after
+# `use Cro::HTTP::Router` (which exports the HTTP verb `put`) parsed as a print
+# of the block and the route was never registered.
+
+put -> 'product' { 1 }
+is shadow-log(), 'put', 'an imported `put` wins over the IO builtin';
+
+note-it("hello");
+is shadow-log(), 'put,note-it', 'a plain imported sub is unaffected';
+
+# Still callable in every other position.
+put(-> 'other' { 2 });
+is shadow-log(), 'put,note-it,put', 'the parenthesized call form still works';
+
+# A locally-declared sub keeps shadowing (the pre-existing behaviour).
+{
+    my @seen;
+    sub print(*@a) { @seen.push(@a.join('')) }
+    print "local";
+    is @seen.join(','), 'local', 'a locally declared `print` still shadows';
+}
+
+# An unshadowed builtin is untouched.
+{
+    my $out = $*OUT;
+    is $out.WHAT.^name.chars > 0, True, 'the real IO builtins are still there';
+}

--- a/t/lib/IOBuiltinShadow.rakumod
+++ b/t/lib/IOBuiltinShadow.rakumod
@@ -1,0 +1,11 @@
+unit module IOBuiltinShadow;
+
+my @log;
+
+#| Exported under a name that collides with the `put` IO builtin, the way
+#| Cro::HTTP::Router exports the HTTP verb `put`.
+multi put(&handler --> Nil) is export { @log.push('put') }
+
+sub note-it(Str $x --> Nil) is export { @log.push('note-it') }
+
+sub shadow-log() is export { @log.join(',') }


### PR DESCRIPTION
`say` / `print` / `put` / `note` have a builtin *statement* form in the parser,
tried before the general listop-call parse. A locally declared `sub say(...)`
already bailed out of it (`shadowed_by_user_sub`), so the user sub won — but an
**imported** one did not, because `use`d exports land in the scope's
`imported_functions` set, not in `user_subs`, and only the latter was consulted.

```raku
use Cro::HTTP::Router;   # exports the HTTP verb `put`
put -> 'product' { ... } # parsed as `put(the-block)` — a PRINT, not a route
```

The lexical scope does not care where a binding came from, so
`shadowed_by_user_sub` now consults `is_imported_function` as well.

### Why it mattered

Cro's five-verb route set (`get`/`post`/`put`/`delete`/`patch` on the same path)
registered only four routes — the PUT one was never added, so a PUT request
405'd.

### Tests

- New `t/imported-sub-shadows-io-builtin.t` with `t/lib/IOBuiltinShadow.rakumod`
  (5 assertions, all pass under `raku`). Covers the imported-`put` listop form,
  the parenthesized call form, and the pre-existing locally-declared-shadow case.
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
