### PR TITLE
fix(vm): `.cache` makes a lazy IO-lines Seq repeatable

### DIFF
--- a/news/2026-08/cache-makes-a-lazy-io-lines-seq-repeatable.md
+++ b/news/2026-08/cache-makes-a-lazy-io-lines-seq-repeatable.md
@@ -1,0 +1,36 @@
+# `.cache` makes a lazy IO-lines `Seq` repeatable
+
+`.cache` is the one method that makes a `Seq` *repeatable* in rakudo: after it,
+the Seq serves its cached elements instead of throwing "The iterator of this Seq
+is already in use/consumed by another Seq". Measured, `.list` and `.List` do
+**not** — they consume like any other method — so the contract is narrower than
+it looks.
+
+mutsu's lazy IO-lines value (`ValueView::LazyIoLines`, what `$path.lines` /
+`$path.words` / `words()` over `$*ARGFILES` return) records only a `consumed`
+flag. The mut-path method opcode forced it, used the reified `Seq` for the call,
+and dropped it — leaving the *receiver variable* holding a spent value. So the
+very next method call on the same variable died:
+
+```raku
+my $words = $file.words;
+$words.cache;
+say $words.List;    # The iterator of this Seq is already in use/consumed …
+```
+
+`.cache` now stores the reified `Seq` back over the named receiver, which is
+exactly the caching contract. Every other method deliberately does not write
+back: a Seq consumed by `.map` really is spent.
+
+The consumer is `Test::Util`'s `is-eqv`, whose `Seq:D, Seq:D` candidate opens
+with `$got.cache; $expected.cache;` and only then compares — so under the real
+module `roast/S16-io/words.t`'s `words() without args uses $*ARGFILES`
+assertion died before it could compare anything.
+
+Pin: `t/seq-cache-makes-io-lines-repeatable.t`, verified under both
+implementations.
+
+One related laxity is *not* fixed here and is worth knowing about: mutsu does not
+throw when a Seq consumed by a non-caching method (`$s.map(...)` then `$s.List`)
+is reused, where rakudo does. That is a missing error, not a wrong result, and it
+is independent of the caching contract above.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -522,7 +522,22 @@ impl Interpreter {
                 method.as_str(),
                 "kv" | "iterator" | "lazy" | "WHAT" | "^name" | "does" | "isa"
             ) {
-            self.force_if_lazy_io_lines(target)?
+            let forced = self.force_if_lazy_io_lines(target)?;
+            // `.cache` is what makes a Seq *repeatable* in rakudo — after it the
+            // Seq serves its cached elements instead of throwing "already in use
+            // /consumed". (Measured: `.list`/`.List` do NOT; they consume like
+            // any other method.) mutsu's lazy IO-lines value only records
+            // "consumed", so forcing it here and dropping the result on the
+            // floor left the receiver variable holding a spent value, and the
+            // very next method call on it died. Store the reified Seq back over
+            // the receiver so the caching contract holds. Every other method
+            // deliberately does NOT write back: a Seq consumed by `.map` really
+            // is spent.
+            if method == "cache" && !target_name.is_empty() {
+                self.env_mut().insert(target_name.clone(), forced.clone());
+                self.record_caller_var_writeback(&target_name);
+            }
+            forced
         } else {
             target
         };

--- a/t/seq-cache-makes-io-lines-repeatable.t
+++ b/t/seq-cache-makes-io-lines-repeatable.t
@@ -1,0 +1,32 @@
+use Test;
+
+# `.cache` is what makes a Seq *repeatable* in rakudo: after it, the Seq serves
+# its cached elements instead of throwing "The iterator of this Seq is already
+# in use/consumed by another Seq". (Only `.cache` -- `.list`/`.List` consume
+# like any other method.) mutsu's lazy IO-lines value only recorded "consumed",
+# so forcing it and dropping the result left the receiver variable holding a
+# spent value, and the very next method call on it died -- which is what
+# `Test::Util`'s `is-eqv` does (`$got.cache; $expected.cache;` and only then
+# compares), and why `roast/S16-io/words.t`'s `$*ARGFILES` assertion failed
+# under the real module.
+
+plan 5;
+
+my $file = $*TMPDIR.child("mutsu-seq-cache-{$*PID}.txt");
+$file.spurt: "foo bar\nmeow moo\n";
+LEAVE try $file.unlink;
+
+my $words = $file.words;
+$words.cache;
+is-deeply $words.List, <foo bar meow moo>.List, '.cache makes a words Seq repeatable';
+is-deeply $words.List, <foo bar meow moo>.List, '... and it stays repeatable';
+is-deeply $words.elems, 4, '... and the cached Seq still answers .elems';
+
+my $lines = $file.lines;
+$lines.cache;
+is-deeply $lines.List, ('foo bar', 'meow moo').List, '.cache does the same for lines';
+
+# The shape `is-eqv` uses: cache, then compare.
+my $again = $file.words;
+$again.cache;
+ok $again eqv <foo bar meow moo>.Seq, 'a cached Seq compares eqv';

--- a/todo/deep/inline-control-handler-from-a-non-call-op.md
+++ b/todo/deep/inline-control-handler-from-a-non-call-op.md
@@ -1,0 +1,83 @@
+# A resumable warning raised from a non-call opcode runs its CONTROL handler twice and loses its writes
+
+`raise_resumable_warning` → `try_resume_safe_control_inline` is the mechanism
+that lets a `warn` raised deep in a call chain reach a
+`CONTROL { when CX::Warn { … .resume } }` handler and then *resume* at the raise
+site. It works when the raise happens inside a **call** — a native method, a
+builtin, a routine — which is how
+`news/2026-08/a-warning-resumes-at-its-raise-site.md` fixed `Int.Numeric`.
+
+It does **not** work when the raise happens inside a plain arithmetic opcode.
+
+## Minimal repro
+
+```raku
+sub g {
+    my ($d, $m) = False;
+    { "x" x Int }();
+    CONTROL { when CX::Warn { say "HANDLER"; $d = True; $m = .message; .resume } }
+    say "d=$d m=$m";
+}
+g();
+```
+
+Swap `"x" x Int` for `Int.Numeric` and it prints `HANDLER` once and
+`d=True m=Use of uninitialized value of type Int in numeric context`.
+
+As written — with the warning routed through `raise_resumable_warning` from
+`exec_string_repeat_op` (`src/vm/vm_arith_int_ops.rs`) — it prints:
+
+```
+HANDLER
+HANDLER
+d=False m=
+```
+
+**The handler body runs twice and neither of its writes reaches `g`'s frame.**
+A `gdb` breakpoint on the raise site confirms the *raise* happens exactly once,
+so the second `HANDLER` is the CONTROL block's own bytecode range being executed
+a second time as `g`'s frame continues — the inline run does not leave the frame
+in the state the normal "skip over the CONTROL declaration" path expects.
+
+## Why it is not just a missing call
+
+`try_resume_safe_control_inline` rebuilds the installing frame's locals from
+`env`, runs the handler's bytecode range, then flushes changed slots back to
+`env` and records them in `pending_rw_writeback_sources` for
+`apply_pending_rw_writeback`. That drain runs at *call* boundaries. A raise from
+an arithmetic opcode has no call boundary between the raise and the installing
+frame, and the operand stack is mid-instruction (the op has popped its operands
+but not pushed its result) while the handler's bytecode runs on that same stack.
+
+## Status
+
+**Not applied.** The change was written and reverted: with it, the warning is
+*silently swallowed* (nothing on stderr, handler writes lost), which is strictly
+worse than today's behaviour, where `exec_string_repeat_op` calls
+`write_warn_to_stderr` directly — the message is printed but no `CONTROL`
+handler ever sees it.
+
+## What it blocks
+
+`roast/S03-operators/repeat.t` test 56, under the real `Test::Util`:
+
+```raku
+warns-like { 'x' x Int }, *.contains('uninitialized' & 'numeric'),
+    'using an unitialized value in repeat count throws';
+```
+
+It is one of the last two files in
+`todo/tickets/retire-native-test-util-overrides.md`. There are two other
+`write_warn_to_stderr` sites with the same shape (the `xx` twin at
+`vm_arith_int_ops.rs`, and the pair in `runtime/builtins_operators_repeat.rs`),
+so a fix covers all four.
+
+## Where to start
+
+Find why the CONTROL range executes a second time — instrument
+`try_resume_safe_control_inline`'s `run_range(&code, control_begin, end, &fns)`
+and compare the `ip` the enclosing frame resumes at against the non-inline path.
+The fix is probably to make the *op-level* raise site behave like a call
+boundary (drain `pending_rw_writeback_sources` and re-establish the frame's
+`ip`/stack invariants), which is the same "op-level warn sites need a call-like
+boundary" problem the `raise_resumable_warning` doc comment describes.


### PR DESCRIPTION
`.cache` is the one method that makes a `Seq` *repeatable* in rakudo: after it
the Seq serves its cached elements instead of throwing "The iterator of this Seq
is already in use/consumed by another Seq". Measured, `.list` and `.List` do
**not** — they consume like any other method — so the contract is narrower than
it looks:

```
$ raku -e 'my $s = "/etc/hostname".IO.lines; $s.list; say $s.List.raku'
The iterator of this Seq is already in use/consumed by another Seq …
$ raku -e 'my $s = "/etc/hostname".IO.lines; $s.cache; say $s.List.raku'
("pop-os",)
```

mutsu's `ValueView::LazyIoLines` (what `$path.lines`, `$path.words` and
`words()` over `$*ARGFILES` return) records only a `consumed` flag. The mut-path
method opcode forced it, used the reified `Seq` for the call and dropped it —
leaving the *receiver variable* holding a spent value, so the very next method
call on the same variable died:

```raku
my $words = $file.words;
$words.cache;
say $words.List;    # The iterator of this Seq is already in use/consumed …
```

`.cache` now stores the reified Seq back over the named receiver, which is
exactly the caching contract. Every other method deliberately does not write
back: a Seq consumed by `.map` really is spent.

## Why it matters

`Test::Util`'s `is-eqv` opens its `Seq:D, Seq:D` candidate with
`$got.cache; $expected.cache;` and only then compares, so under the real module
`roast/S16-io/words.t`'s `words() without args uses $*ARGFILES` assertion died
before it could compare anything. That file now passes with the guard widened,
taking `todo/tickets/retire-native-test-util-overrides.md`'s residue to **one**
file. (The ticket's count is not edited here — #5728 was still in flight when
this branch was cut, and the two would conflict on the same table.)

## The last one is recorded, not fixed

`todo/deep/inline-control-handler-from-a-non-call-op.md`: a resumable warning
raised from a plain arithmetic opcode (`'x' x Int`) runs its `CONTROL` handler
**twice** and loses the handler's writes, so `warns-like { 'x' x Int }`
(`roast/S03-operators/repeat.t` test 56) never sees it. The obvious change —
routing that site through `raise_resumable_warning`, as
`news/2026-08/a-warning-resumes-at-its-raise-site.md` did for call sites — was
written and **measured to be worse**: the warning is swallowed entirely, where
today it is at least printed. It was reverted; the file records the repro, the
`gdb` finding that the *raise* happens exactly once, and where to start.

## Known laxity, deliberately not touched

mutsu still does not throw when a Seq consumed by a non-caching method
(`$s.map(...)` then `$s.List`) is reused, where rakudo does. That is a missing
error rather than a wrong result, and it is independent of the caching contract
above — noted in the news entry.

## Testing

`make test` PASS (2763 files / 26318 tests). Roast `S16-io/`, `S32-io/`
(70 files) PASS; `roast/S16-io/words.t` verified 11/11 under the temporarily
widened guard, then reverted.

Pin: `t/seq-cache-makes-io-lines-repeatable.t`, verified under both
implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)