### PR TITLE
fix(parser): an exported `sub term:<foo>` is a term in the importing file

### DIFF
--- a/news/2026-08/exported-term-sub.md
+++ b/news/2026-08/exported-term-sub.md
@@ -1,0 +1,27 @@
+# An exported `sub term:<foo>` is a term in the importing file
+
+A `sub term:<foo>` makes a bareword `foo` a call to it. A locally declared one
+already worked; an *exported* one did not. `apply_module_exports` registers an
+export as a user operator only when its name is one of the operator categories,
+and `is_operator_sub_name` listed `infix:` / `prefix:` / `postfix:` /
+`circumfix:` / `postcircumfix:` but not `term:`. So the export's term symbol was
+never registered and the bareword parsed as a plain string:
+
+```raku
+use Cro::HTTP::Router;   # exports term:<request> and term:<response>
+say request;             # was: the Str "request"
+                         # now: X::Cro::HTTP::Router::OnlyInHandler
+```
+
+(The inline-`module` import path — `import_inline_module_exports` — already
+registered every export's callable term symbol unconditionally, so only the
+file-module path was affected.)
+
+Pinned by `t/exported-term-sub.t` with `t/lib/ExportedTerm.rakumod`.
+
+With this, `Cro::HTTP`'s `t/http-router.rakutest` is **fully green (52/52)** — up
+from 19-then-abort at the start of the day, via
+`news/2026-08/regex-literals-are-closures.md`,
+`news/2026-08/pointy-single-literal-parameter.md`,
+`news/2026-08/array-alias-survives-a-thread.md` and
+`news/2026-08/imported-sub-shadows-io-builtin.md`.

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -167,6 +167,10 @@ fn is_operator_sub_name(name: &str) -> bool {
         || name.starts_with("postfix:<")
         || name.starts_with("circumfix:<")
         || name.starts_with("postcircumfix:<")
+        // An exported `sub term:<foo>` makes a bareword `foo` a call to it.
+        // Without registering the term symbol the importer parses `foo` as a
+        // plain bareword string (Cro exports `term:<request>`/`term:<response>`).
+        || name.starts_with("term:<")
 }
 
 /// Record exported subs from an inline `module Name { ... }` block.

--- a/t/exported-term-sub.t
+++ b/t/exported-term-sub.t
@@ -1,0 +1,25 @@
+use v6;
+use lib 't/lib';
+use Test;
+use ExportedTerm;
+
+plan 5;
+
+# An exported `sub term:<foo>` makes a bareword `foo` in the importing file a
+# call to it. Only the operator categories (infix/prefix/postfix/circumfix/
+# postcircumfix) were registered from a module's export list, so `term:<...>`
+# fell through and the bareword parsed as a plain string.
+# (Cro::HTTP::Router exports `term:<request>` and `term:<response>`; without
+# this, `request` outside a handler evaluated to the string "request" instead
+# of throwing X::Cro::HTTP::Router::OnlyInHandler.)
+
+is answer, 42, 'a bareword calls the imported term sub';
+is answer + 1, 43, 'and composes as an ordinary term in an expression';
+isnt answer, 'answer', 'it is not parsed as a bareword string';
+
+{
+    my $*STATE = 'live';
+    is current-state, 'live', 'the term sub runs at each use, seeing the dynamic scope';
+}
+
+dies-ok { current-state }, 'and it really is a call — it can throw';

--- a/t/lib/ExportedTerm.rakumod
+++ b/t/lib/ExportedTerm.rakumod
@@ -1,0 +1,11 @@
+unit module ExportedTerm;
+
+our $*STATE;
+
+#| A term the importer should be able to write as a bareword, the way
+#| Cro::HTTP::Router exports `term:<request>` / `term:<response>`.
+sub term:<answer>() is export { 42 }
+
+sub term:<current-state>() is export {
+    $*STATE // die "current-state is only usable with \$*STATE set"
+}


### PR DESCRIPTION
A `sub term:<foo>` makes a bareword `foo` a call to it. A locally declared one
already worked; an **exported** one did not. `apply_module_exports` registers an
export as a user operator only when its name is one of the operator categories,
and `is_operator_sub_name` listed `infix:` / `prefix:` / `postfix:` /
`circumfix:` / `postcircumfix:` but not `term:`, so the export's term symbol was
never registered and the bareword parsed as a plain string:

```raku
use Cro::HTTP::Router;   # exports term:<request> and term:<response>
say request;             # was: the Str "request"
                         # now: X::Cro::HTTP::Router::OnlyInHandler
```

The inline-`module` import path (`import_inline_module_exports`) already
registered every export's callable term symbol unconditionally, so only the
file-module path was affected.

### Why it mattered

With this, `Cro::HTTP`'s `t/http-router.rakutest` is **fully green (52/52)** —
up from 19-then-abort at the start of the day, via #5723 (regex literals are
closures), #5729 (single literal parameter), #5730 (array alias survives a
thread) and #5731 (imported sub shadows the IO builtin).

### Tests

- New `t/exported-term-sub.t` with `t/lib/ExportedTerm.rakumod` (5 assertions,
  all pass under `raku`) — bareword call, use in an expression, not-a-string,
  re-evaluated per use (dynamic scope), and that it can throw.
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
