### PR TITLE
fix(runtime): an END phaser's exit does not overrule the exit in flight

### DIFF
--- a/news/2026-08/end-phaser-exit-does-not-overrule-an-exit-in-flight.md
+++ b/news/2026-08/end-phaser-exit-does-not-overrule-an-exit-in-flight.md
@@ -1,0 +1,47 @@
+# An END phaser's `exit` no longer overrules the exit already in flight
+
+Rakudo latches the process status at the *first* `exit`. An `exit` raised while
+one is already unwinding — an END phaser's own `exit` in a program that already
+said `exit 42` — still ends the block it runs in, but it neither overwrites the
+status nor stops the END phasers that have not run yet.
+
+mutsu did the opposite on both counts. `exit` unconditionally wrote
+`self.exit_code`, and an END phaser that called it left `halted` set, which the
+END runner read as "stop", so every phaser that had not run yet was skipped:
+
+```raku
+END { say "A" }
+END { say "B"; exit 7 }
+exit 42;
+```
+
+| | raku | mutsu (before) |
+| --- | --- | --- |
+| output | `B` `A` | `B` |
+| status | 42 | 7 |
+
+The fix is rakudo's `the-end-is-nigh` latch, as an `exit_status_locked` flag on
+the interpreter. `finish` sets it when the END phasers are entered because the
+program is already exiting, and sets it again after any phaser that calls
+`exit`; `builtin_exit` keeps the current `exit_code` instead of the requested one
+while it is held. Separately, the END runner now clears `halted` after each
+phaser, so an `exit` inside one ends *that* phaser without cancelling its
+siblings — which is what rakudo does whether or not the status changes hands.
+
+## Why it surfaced
+
+`todo/tickets/vendor-real-test-module.md`. The real `Test.rakumod` ends with
+
+```raku
+exit($num_of_tests_failed min 254) if $num_of_tests_failed > 0;
+```
+
+in its END block, so under `MUTSU_REAL_TEST=1` *every* explicit `exit` in a test
+file with a failing assertion came back as 1. That is exactly what
+`Test::Util`'s `is_run ..., :255status` reads, so `t/die-on-fail.t` — which
+asserts rakudo's documented `RAKU_TEST_DIE_ON_FAIL` behaviour, `exit 255` from
+`Test`'s own `die-on-fail` — failed under the real module while passing under
+mutsu's native provider.
+
+The bug itself has nothing to do with `Test`: the repro above uses no modules at
+all. Pinned by `t/end-phaser-exit-latch.t`, which passes under `raku` too.

--- a/scripts/test-module-sweep.sh
+++ b/scripts/test-module-sweep.sh
@@ -36,6 +36,10 @@ run_one() {
         > "$WORK/$name.native" 2>&1 )
     ( cd "$WORK" && MUTSU_REAL_TEST=1 timeout 90 "$MUTSU" -I "$ROOT/t/lib" "t/$name" \
         > "$WORK/$name.real" 2>&1 )
+    # A failing file exits non-zero, and a short plan exits 255 -- which xargs
+    # treats as "abort the whole run". The exit status is not the signal here;
+    # the captured output is.
+    return 0
 }
 export -f run_one
 export ROOT WORK MUTSU

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -275,6 +275,14 @@ impl Interpreter {
             Some(_) => args.first().unwrap().to_f64() as i64,
             _ => 0,
         };
+        // An `exit` raised while the process is already exiting (an END phaser's
+        // own `exit`) still unwinds, but the status was decided by the first
+        // one — rakudo's `the-end-is-nigh` latch. See `finish`.
+        let code = if self.exit_status_locked {
+            self.exit_code
+        } else {
+            code
+        };
         self.halted = true;
         self.exit_code = code;
         // Signal any sleeping threads that the process should exit.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -863,6 +863,12 @@ pub struct Interpreter {
     tap: TapState,
     halted: bool,
     exit_code: i64,
+    /// Set while the END phasers run for a program that is already exiting, and
+    /// once any END phaser has itself called `exit`. A further `exit` still
+    /// unwinds but leaves [`Self::exit_code`] alone — rakudo latches the process
+    /// status at the first `exit` (`the-end-is-nigh`), so `exit 42; END { exit 7 }`
+    /// exits 42. See `Interpreter::finish` and `builtin_exit`.
+    exit_status_locked: bool,
     /// Body fingerprints (see [`crate::ast::function_body_fingerprint`]) of MAIN
     /// candidates declared `is hidden-from-USAGE`. Such a candidate is skipped
     /// when generating the usage message (but still participates in dispatch).

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -785,6 +785,16 @@ impl Interpreter {
         // where completed thread output is not lost.
         self.drain_shared_thread_output();
         if !self.end_phasers.is_empty() {
+            // Rakudo latches the process status at the *first* `exit`
+            // (`the-end-is-nigh`): an `exit` raised while one is already
+            // unwinding still ends the block it runs in, but it neither
+            // overwrites the status nor stops the END phasers that have not run
+            // yet. So `END { exit 7 }` decides the status of a program that ends
+            // on its own, and is status-inert in a program that already said
+            // `exit 42` — while the *other* END phasers run either way.
+            let exit_already_requested = self.halted;
+            let saved_exit_lock = self.exit_status_locked;
+            self.exit_status_locked = exit_already_requested;
             // Clear halted flag so END phasers can execute even after exit()
             self.halted = false;
             let phasers = self.end_phasers.clone();
@@ -828,6 +838,14 @@ impl Interpreter {
                 }
                 let body_result = self.run_block(body);
                 self.set_current_package(saved_package);
+                if self.halted {
+                    // This phaser called `exit`. Whatever status it asked for is
+                    // settled now (either it was the first `exit` and owns the
+                    // status, or the lock already held it); let the remaining
+                    // phasers run instead of inheriting the halt.
+                    self.exit_status_locked = true;
+                    self.halted = false;
+                }
                 body_result?;
                 // Remove only the overlay keys (captured lexicals not in
                 // the current scope), keeping mutations to shared variables.
@@ -835,6 +853,11 @@ impl Interpreter {
                     self.env.remove(k);
                 }
             }
+            // Restore the halt for anything downstream that reads it, then drop
+            // the status lock: `finish` also runs for a nested in-process
+            // program (`is_run`), whose interpreter goes on being used.
+            self.halted = exit_already_requested || self.exit_status_locked;
+            self.exit_status_locked = saved_exit_lock;
         }
         self.run_pending_instance_destroys()?;
         // Print deprecation report to stderr at program exit

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1816,6 +1816,7 @@ impl Interpreter {
             tap: TapState::default(),
             halted: false,
             exit_code: 0,
+            exit_status_locked: false,
             main_hidden_from_usage: std::collections::HashSet::new(),
             explicit_run_main: false,
             nested_mode: false,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -300,6 +300,7 @@ impl Interpreter {
             tap: self.tap.clone_for_thread(),
             halted: false,
             exit_code: 0,
+            exit_status_locked: false,
             main_hidden_from_usage: self.main_hidden_from_usage.clone(),
             explicit_run_main: self.explicit_run_main,
             nested_mode: self.nested_mode,

--- a/t/end-phaser-exit-latch.t
+++ b/t/end-phaser-exit-latch.t
@@ -1,0 +1,34 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test;
+use Test::Util;
+
+# Rakudo latches the process status at the *first* `exit`. An `exit` raised
+# while one is already unwinding -- an END phaser's own `exit` in a program
+# that already said `exit N` -- still ends the block it runs in, but it neither
+# overwrites the status nor stops the END phasers that have not run yet.
+
+plan 6;
+
+is_run 'END { say "A"; exit 7 }; exit 42;',
+    { :out("A\n"), :42status },
+    'an END phaser cannot overwrite the status of an exit already in flight';
+
+is_run 'END { say "A"; exit 7 }; say "main";',
+    { :out("main\nA\n"), :7status },
+    'an END phaser does set the status of a program that ends on its own';
+
+is_run 'END { say "A1"; exit 7; say "A2" }; exit 42;',
+    { :out("A1\n"), :42status },
+    'the status-inert exit still ends the phaser body';
+
+is_run 'END { say "A" }; END { say "B"; exit 7 }; exit 42;',
+    { :out("B\nA\n"), :42status },
+    'an END phaser exit does not skip the END phasers still to run';
+
+is_run 'END { say "A" }; END { say "B"; exit 7 }; say "main";',
+    { :out("main\nB\nA\n"), :7status },
+    'the remaining phasers run after an exit that does set the status';
+
+is_run 'END { say "A"; exit 3 }; END { say "B"; exit 7 }; say "main";',
+    { :out("main\nB\nA\n"), :7status },
+    'the first exit wins when two END phasers both exit';


### PR DESCRIPTION
Rakudo latches the process status at the *first* `exit` (`the-end-is-nigh`). An `exit` raised while one is already unwinding — an END phaser's own `exit` in a program that already said `exit 42` — still ends the block it runs in, but it neither overwrites the status nor stops the END phasers that have not run yet.

mutsu did the opposite on both counts. `exit` unconditionally wrote `exit_code`, and an END phaser that called it left `halted` set, which the END runner read as "stop", so every sibling phaser that had not run yet was skipped.

```raku
END { say "A" }
END { say "B"; exit 7 }
exit 42;
```

| | raku | mutsu (before) | mutsu (after) |
| --- | --- | --- | --- |
| output | `B` `A` | `B` | `B` `A` |
| status | 42 | 7 | 42 |

## The fix

An `exit_status_locked` flag on the interpreter. `finish` holds it while running the END phasers of a program that is already exiting, and re-arms it after any phaser that itself calls `exit`; `builtin_exit` keeps the current `exit_code` instead of the requested one while it is held. Separately the END runner clears `halted` after each phaser, so an `exit` inside one ends *that* phaser without cancelling its siblings — which rakudo does whether or not the status changes hands.

## Why it surfaced

`todo/tickets/vendor-real-test-module.md`. The real `Test.rakumod` ends its END block with `exit($num_of_tests_failed min 254) if $num_of_tests_failed > 0;`, so under `MUTSU_REAL_TEST=1` *every* explicit `exit` in a test file with a failing assertion came back as 1. That is exactly what `Test::Util`'s `is_run ..., :255status` reads, so `t/die-on-fail.t` — which asserts rakudo's documented `RAKU_TEST_DIE_ON_FAIL` behaviour (`Test`'s own `die-on-fail` does `exit 255`) — failed under the real module while passing under the native provider. The bug itself involves no modules at all.

## Tests

- New pin `t/end-phaser-exit-latch.t`, six cases covering both directions of the latch and the sibling-phaser rule. It passes under `raku` as well as mutsu.
- `make test`: `Files=2768, Tests=26355 … Result: PASS`.
- `t/die-on-fail.t` now reads `native / real / raku` in the vendoring sweep's per-file harness.

Also fixes `scripts/test-module-sweep.sh` aborting the whole sweep when a file exits 255 — `xargs` treats that status as fatal, which silently truncated the measurement at 50 of 2767 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)