### PR TITLE
docs(todo): measure roast under the real Test module — 343 of 1435 regress

### DIFF
--- a/todo/tickets/callee-parameter-overwrites-caller-after-a-thread-ran.md
+++ b/todo/tickets/callee-parameter-overwrites-caller-after-a-thread-ran.md
@@ -1,0 +1,56 @@
+# A callee's parameter overwrites the caller's same-named one once a thread has run
+
+Two module-level routines that happen to use the same parameter name share a
+lexical slot across the call once the inner call has gone through a thread
+boundary. The caller's value is replaced by the callee's.
+
+## Minimal repro (no `Test`, no threads visible in the module)
+
+```raku
+# lib/M.rakumod
+unit module M;
+sub inner($desc) is export { say "inner $desc" }
+sub outer(&body, $desc) is export { body(); say "outer desc=$desc" }
+```
+
+```raku
+# repro.raku
+use M;
+outer { my $p = Promise.new;
+        start { $p.keep(True) };
+        await $p.then: { inner("c") } }, "OUTER";
+```
+
+```
+$ raku  -Ilib repro.raku      $ mutsu -I lib repro.raku
+inner c                       inner c
+outer desc=OUTER              outer desc=c          <-- wrong
+```
+
+Drop the `Promise`/`start`/`.then` and call `inner("c")` directly from the block
+and mutsu is correct, so the trigger is the callee running on (or after) another
+thread, not the nesting.
+
+## Why it matters
+
+- `t/subtest-threaded-pass-count.t` regresses under `MUTSU_REAL_TEST=1` for
+  exactly this reason. The real `Test.rakumod` has
+  `multi sub subtest(&subtests, $desc = '')` and `sub pass($desc = '')`; a
+  `subtest` whose body does `await $p.then: { pass "a"; pass "b"; pass "c" }`
+  reports `ok 1 - c` where rakudo reports `ok 1 - planless threaded`.
+- It is the most likely cause of five of the six regressions in
+  `todo/tickets/retire-native-test-tap.md`, where a tap callback's
+  `@res.push($_)` collects nothing (`got: []`) when the emit runs on a timer or
+  scheduler thread — the same "a thread ran, the outer frame's lexical is not
+  what it was" family.
+
+## Where to look
+
+The same area as `354cd623f` ("an array alias survives a thread having run")
+and the `shared_vars` scalar lane described in
+`todo/deep/*` around the worker-pool work: `src/runtime/runtime_thread.rs`
+clones the interpreter per thread and the env is merged back on join, and a
+module-level routine's parameters live in the module's env rather than a frame
+slot, so two routines of the same module that share a parameter name share the
+key. The `$desc` here is *not* a module lexical in Raku — it is a parameter, so
+the merge must not treat it as shared state.

--- a/todo/tickets/retire-native-test-tap.md
+++ b/todo/tickets/retire-native-test-tap.md
@@ -1,0 +1,80 @@
+# Retire the native `Test::Tap` provider — 44 roast files, 6 real bugs behind it
+
+`use Test::Tap` is a native no-op in `src/runtime/runtime_module.rs`:
+
+```rust
+} else if module == "Test::Tap" {
+    // Handle Test::Tap as built-in
+    Ok(())
+}
+```
+
+so `roast/packages/Test-Helpers/lib/Test/Tap.rakumod` is never loaded and
+`tap-ok` is answered by `src/runtime/test_functions/tap_ok.rs`. This is a
+rung-3 native provider in the sense of `docs/BATTERIES.md`, and the same kind of
+thing `Pod::To::Text` and the `monitor` declarator were retired for.
+
+It is also a hard blocker for `todo/tickets/vendor-real-test-module.md` step 3.
+Under `MUTSU_REAL_TEST=1` the 44 whitelisted files that `use Test::Tap` keep two
+counters — the module's `plan`/`ok` and the native `tap-ok` — so each reports
+`# You planned N tests, but ran 0` at END even though every `ok` line printed
+correctly. That is the `S17-supply` cluster, the single largest group in the 343
+roast regressions measured on 2026-08-02.
+
+Note this is **not** the `user_test_decl_beats_native` guard: `tap-ok` is
+already in `TEST_MODULE_EXPORTS`, so the guard *is* consulted and declines only
+because there is no declaration to find — the module was never loaded. Widening
+the guard (`todo/tickets/retire-native-test-util-overrides.md`) does not touch
+this.
+
+## What deleting the arm buys, and what it costs
+
+Deleting the arm is enough for the module to load: all 44 files resolve
+`Test::Tap` through the dist directory their `use lib $*PROGRAM.parent(2).add(
+"packages/Test-Helpers")` points at (mutsu reads `META6.json` `provides`), and
+`roast/S17-supply/elems.t` then passes under *both* providers.
+
+**6 of the 44 regress under the default native provider**, because the real
+`tap-ok` asserts with the real `is-deeply` where mutsu's native one was lenient.
+All six pass under `raku`, so all six are real mutsu bugs the provider was
+hiding. They fall into two causes:
+
+| cause | files | shape |
+| --- | --- | --- |
+| a tap callback's `@res.push($_)` collects nothing when the emit runs on a timer/scheduler thread | `S17-supply/classify.t`, `categorize.t`, `interval.t`, `merge.t`, `reduce.t` | `# expected: [0, 1, 2, 3, 4]` / `# got: []` |
+| `Supply.rotor` emits `List`s where rakudo emits `Array`s | `S17-supply/rotor.t` | `# expected: [[1, 2, 3], …]` / `# got: [(1, 2, 3), …]` |
+
+The first is very likely the same cross-thread lexical family as
+`t/subtest-threaded-pass-count.t`, whose minimal repro needs no `Test` at all:
+
+```raku
+# lib/M.rakumod
+unit module M;
+sub inner($desc) is export { say "inner $desc" }
+sub outer(&body, $desc) is export { body(); say "outer desc=$desc" }
+```
+```raku
+use M;
+outer { my $p = Promise.new; start { $p.keep(True) };
+        await $p.then: { inner("c") } }, "OUTER";
+```
+
+`raku` prints `outer desc=OUTER`; mutsu prints `outer desc=c` — the callee's
+same-named parameter overwrites the caller's after a thread has run.
+
+## Order of work
+
+1. Fix the two causes above (they are general bugs; pin each in `t/`).
+2. Delete the `module == "Test::Tap"` arm.
+3. Decide what to do with `src/runtime/test_functions/tap_ok.rs` and the
+   `"tap-ok"` entries in `TEST_MODULE_EXPORTS` / `is_test_function_name` /
+   `compile_consts.rs` — with the module loading, the native handler is only
+   reachable when it is *not* loaded, which is no longer a case roast has.
+
+Measure with the 44 files directly:
+
+```bash
+grep -rl 'use Test::Tap' roast/ | grep '\.t$' | sort > tmp/taptests.txt
+comm -12 tmp/taptests.txt <(sort roast-whitelist.txt) > tmp/taptests-wl.txt
+MUTSU_BIN=target/release/mutsu prove -j6 -e 'scripts/run-roast-test.sh' $(cat tmp/taptests-wl.txt)
+```

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -420,3 +420,82 @@ further down the file. When it runs clean, step 2 above is done.
 Beware when re-measuring which ops are missing: **the shell here is zsh**, which
 does not word-split a plain `$var`, so `ops=$(...); for op in $ops` silently
 iterates once. Use `... | while read op` or `$(...)` directly in the `for`.
+
+## Step 3 is much further away than the `t/` sweep implies: roast, measured (2026-08-02)
+
+Every measurement above is over `t/`. **roast had never been run under
+`MUTSU_REAL_TEST=1`**, and roast is the larger consumer — 1435 whitelisted
+files, all of them standing on `Test`. Measured on `fdc4ea69d` (release build,
+`prove -j6`, the same per-file timeouts `make roast` uses):
+
+```bash
+MUTSU_REAL_TEST=1 MUTSU_BIN=target/release/mutsu \
+  prove -j6 -e 'scripts/run-roast-test.sh' $(cat roast-whitelist.txt)
+```
+
+| | files |
+| --- | --- |
+| whitelisted (all pass under the native provider — `main` is protected) | 1435 |
+| **regress under the real `Test`** | **343** |
+
+So step 3 cannot be "flip `runtime_module.rs` and expect the first `make roast`
+to be the review": that flip regresses 24% of the whitelist. The `t/` residue
+(21 files, of which 5 `raku` also fails) is not a proxy for it.
+
+### What the 343 are
+
+Split by whether the file loads a roast helper module:
+
+| | files |
+| --- | --- |
+| uses `Test::Util` or `Test::Tap` (269 whitelisted files do) | 159 |
+| uses neither | 184 |
+
+**The helper-module intercept is not the dominant cause.** Flipping
+`user_test_decl_beats_native` from `is_test_module_export` to
+`is_test_function_name` — the one-line retirement in
+`todo/tickets/retire-native-test-util-overrides.md` — was measured on top of
+`MUTSU_REAL_TEST=1`: **343 → 315** (32 files fixed, 4 newly broken). Worth
+having, but it is a tenth of the problem, not the problem.
+
+The 184 non-helper files are ordinary interpreter gaps that only the strict
+module exposes, in the same distribution the `t/` sweep found: 30 abort
+mid-file with a plan mismatch (`# You planned N tests, but ran M`, each from its
+own cause — an unresolved symbol, `skip` rejecting a non-integer count, …), the
+rest are single assertions.
+
+### `Test::Tap` is a second native provider, and retiring it is its own slice
+
+`use Test::Tap` is a native no-op (`runtime_module.rs`), exactly like `use Test`
+— the real `roast/packages/Test-Helpers/lib/Test/Tap.rakumod` is never loaded,
+and `tap-ok` is answered by `src/runtime/test_functions/tap_ok.rs`. That is why
+44 whitelisted files (the `S17-supply` cluster) report `You planned N tests, but
+ran 0` under the real `Test`: the native `tap-ok` and the module keep separate
+counters. It is *not* the `user_test_decl_beats_native` guard — `tap-ok` is
+already in `TEST_MODULE_EXPORTS`, so the guard is consulted and correctly
+declines only because no declaration exists to find.
+
+Deleting the `module == "Test::Tap"` arm makes all 44 load the real module, and
+`elems.t` then passes under both providers. But **6 of the 44 regress under the
+*native* provider** once the real `tap-ok` runs, because it asserts with the
+real `is-deeply` where mutsu's native `tap-ok` was lenient:
+
+| file | what the real `tap-ok` exposes |
+| --- | --- |
+| `S17-supply/rotor.t` | `Supply.rotor` emits `List`s where rakudo emits `Array`s — `[(1,2,3)]` vs `[[1,2,3]]` |
+| `S17-supply/classify.t`, `categorize.t`, `interval.t`, `merge.t`, `reduce.t` | the tap callback's `@res.push($_)` collects **nothing** (`got: []`) when the emit runs on a timer/scheduler thread |
+
+Both are real bugs (`raku` passes all six), so the retirement is a slice that
+has to fix them first — see `todo/tickets/retire-native-test-tap.md`.
+
+### The order this implies
+
+1. Land the individual interpreter gaps the strict module exposes — the 184
+   non-helper roast files and the `t/` residue are the same kind of work.
+2. `todo/tickets/retire-native-test-tap.md` (44 files, 6 real bugs behind it).
+3. `todo/tickets/retire-native-test-util-overrides.md` (worth 32 roast files on
+   top of the real `Test`; already 227/228 on its own `t/`-side measurement).
+4. Only then step 3.
+
+Re-measure with the command at the top of this section, not with
+`scripts/test-module-sweep.sh` alone.


### PR DESCRIPTION
Every measurement in `todo/tickets/vendor-real-test-module.md` so far was over `t/`. **roast had never been run under `MUTSU_REAL_TEST=1`** — and roast is the larger consumer: 1435 whitelisted files, all of them standing on `Test`.

```bash
MUTSU_REAL_TEST=1 MUTSU_BIN=target/release/mutsu \
  prove -j6 -e 'scripts/run-roast-test.sh' $(cat roast-whitelist.txt)
```

| | files |
| --- | --- |
| whitelisted (all pass under the native provider) | 1435 |
| **regress under the real `Test`** | **343** |

So step 3 cannot be "flip `runtime_module.rs` and expect the first `make roast` to be the review" — that flip regresses 24% of the whitelist. The `t/` residue (21 files, 5 of which `raku` also fails) is not a proxy for it.

## What the 343 are

159 load a roast helper module (`Test::Util` / `Test::Tap`); 184 do not. **The helper intercept is not the dominant cause** — flipping `user_test_decl_beats_native` to `is_test_function_name`, the one-line retirement in `todo/tickets/retire-native-test-util-overrides.md`, was measured on top of `MUTSU_REAL_TEST=1` and moves 343 → 315 (32 fixed, 4 newly broken). Worth having, a tenth of the problem.

## Two tickets the measurement turned up

- **`todo/tickets/retire-native-test-tap.md`** — `use Test::Tap` is a *second* native no-op provider in `runtime_module.rs`, so the real `Tap.rakumod` never loads and `tap-ok` is answered natively. That is why the 44-file `S17-supply` cluster reports `You planned N tests, but ran 0`: two counters. (Not the guard — `tap-ok` is already in `TEST_MODULE_EXPORTS`, so the guard is consulted and declines only because no declaration exists to find.) Deleting the arm loads the real module and fixes `elems.t` under both providers, but 6 of the 44 then regress under the *native* provider because the real `tap-ok` asserts with the real `is-deeply`. All six pass under `raku`, so all six are real bugs the provider was hiding.
- **`todo/tickets/callee-parameter-overwrites-caller-after-a-thread-ran.md`** — the general bug behind five of those six and behind `t/subtest-threaded-pass-count.t`. Three-line module repro, no `Test` involved:

  ```raku
  unit module M;
  sub inner($desc) is export { say "inner $desc" }
  sub outer(&body, $desc) is export { body(); say "outer desc=$desc" }
  ```
  ```raku
  outer { my $p = Promise.new; start { $p.keep(True) };
          await $p.then: { inner("c") } }, "OUTER";
  ```
  `raku` prints `outer desc=OUTER`; mutsu prints `outer desc=c`.

## Order this implies

1. The individual gaps the strict module exposes (184 roast files + the `t/` residue).
2. Retire `Test::Tap` (44 files, 6 real bugs behind it).
3. Retire the `Test::Util` overrides (32 roast files on top of the real `Test`).
4. Only then step 3.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)