### PR TITLE
fix(runtime): a callee's parameter is not a shared variable

### DIFF
--- a/news/2026-08/a-callee-parameter-is-not-a-shared-variable.md
+++ b/news/2026-08/a-callee-parameter-is-not-a-shared-variable.md
@@ -1,0 +1,56 @@
+# A callee's parameter no longer clobbers the caller's after a thread has run
+
+Two routines that merely happen to use the same parameter name aliased each
+other once any thread had run. The callee's argument replaced the caller's
+value:
+
+```raku
+sub inner($desc) { say "inner $desc" }
+sub outer($desc) { await start { inner("c") }; say "outer desc=$desc" }
+outer("OUTER");
+```
+
+```
+$ raku                    $ mutsu (before)
+inner c                   inner c
+outer desc=OUTER          outer desc=c
+```
+
+Remove the `await start { … }` and mutsu is correct; give the two routines
+different parameter names and mutsu is correct. Only the combination fails.
+
+## Cause
+
+Spawning a thread turns on the cross-thread shared store (`shared_vars`), which
+is keyed by **bare name**. `sync_env_from_locals*` mirrors a frame's local slots
+into `env`, and `set_shared_var_sym` forwards any name the store already holds
+back into it and marks it dirty; the next `await` pulls every dirty name into
+the parent's env. `outer`'s `$desc` had seeded the store at spawn time, so
+`inner`'s parameter — a completely different binding that happens to share the
+key — overwrote it.
+
+`exec_set_var_dynamic_op` already handles the same hazard for `my`: while the
+store is active, a re-declaration is a fresh binding shadowing whatever the
+store holds, so the name goes into `thread_redeclared_vars` and its writes stay
+thread-local. A **parameter is the same thing** — a fresh per-invocation binding
+— and was not marked. `call_compiled_function_named_inner` now marks the
+routine's scalar parameter names right after `bind_function_args_values`, with
+the same exclusions the `my` case uses: `@`/`%` names back the atomic element
+stores and must keep propagating, `&` names are routines, and `$_`/`self` are
+already excluded from the store's seeding.
+
+## What it fixes
+
+Found while measuring roast under the vendored `Test.rakumod`
+(`todo/tickets/vendor-real-test-module.md`). The real module has
+`multi sub subtest(&subtests, $desc = '')` and `sub pass($desc = '')`, so a
+subtest whose body does `await $p.then: { pass "a"; pass "b"; pass "c" }`
+reported `ok 1 - c` where rakudo reports `ok 1 - planless threaded` —
+`t/subtest-threaded-pass-count.t`. It is also expected to account for most of
+`todo/tickets/retire-native-test-tap.md`'s "the tap callback collected nothing"
+group, where the emit runs on a timer or scheduler thread.
+
+Pinned by `t/thread-callee-param-does-not-clobber-caller.t`, which also asserts
+the two things the mark must *not* break: a lexical the thread genuinely closes
+over still crosses the boundary, and an `is rw` parameter still writes back to
+its caller's container. It passes under `raku` too.

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -199,6 +199,33 @@ impl Interpreter {
                 }
             }
         };
+        // A parameter is a fresh per-invocation binding, exactly like the `my`
+        // that `exec_set_var_dynamic_op` marks: while the cross-thread shared
+        // store is active its writes must stay thread-local instead of leaking
+        // to the parent through the name-keyed store. Without this, two
+        // routines that merely happen to share a parameter name alias each
+        // other once a thread has run — `sub inner($desc) {...}` called from
+        // inside `await start {...}` in `sub outer($desc) {...}` left `outer`'s
+        // `$desc` holding `inner`'s argument (`t/thread-callee-param-does-not-
+        // clobber-caller.t`). Scalars only, for the same reason as the `my`
+        // case: `@`/`%` names back the atomic element stores and `&` names are
+        // routines.
+        if self.shared_vars_active {
+            for pd in &cf.param_defs {
+                let name = pd.name.as_str();
+                if name.is_empty()
+                    || name == "_"
+                    || name == "self"
+                    || name.starts_with('@')
+                    || name.starts_with('%')
+                    || name.starts_with('&')
+                {
+                    continue;
+                }
+                self.thread_redeclared_vars
+                    .insert(name.trim_start_matches('$').to_string());
+            }
+        }
         self.prepare_definite_return_slot(return_spec.as_deref());
 
         // Raku: $! is scoped per routine — fresh Nil on entry.

--- a/t/thread-callee-param-does-not-clobber-caller.t
+++ b/t/thread-callee-param-does-not-clobber-caller.t
@@ -1,0 +1,46 @@
+use Test;
+
+# A parameter is a fresh per-invocation binding. Once a thread has run, the
+# cross-thread shared store is active and keyed by bare name, so two routines
+# that merely happen to share a parameter name aliased each other: the callee's
+# argument replaced the caller's when the call went through a thread boundary.
+
+plan 5;
+
+{
+    sub inner($desc) { $desc }
+    sub outer($desc) { await start { inner("inner-value") }; $desc }
+    is outer("outer-value"), 'outer-value',
+        'a callee parameter does not clobber the caller of the same name';
+}
+
+{
+    sub inner2($desc) { $desc }
+    sub outer2() { my $desc = 'outer-value'; await start { inner2("inner-value") }; $desc }
+    is outer2(), 'outer-value',
+        "a callee parameter does not clobber the caller's `my` of the same name";
+}
+
+{
+    sub inner3($desc) { $desc }
+    sub outer3(&body, $desc) { body(); $desc }
+    is outer3({ await start { inner3("inner-value") } }, 'outer-value'), 'outer-value',
+        'the same, through a callback parameter';
+}
+
+# The shared store still does its job: a lexical the thread genuinely closes
+# over is written through.
+{
+    my $shared = 'before';
+    await start { $shared = 'after' };
+    is $shared, 'after', 'a captured lexical still crosses the thread boundary';
+}
+
+# A parameter passed `is rw` still writes back to its caller's container.
+{
+    sub bump($n is rw) { $n = $n + 1 }
+    my $count = 0;
+    await start { 1 };
+    bump($count);
+    is $count, 1, 'an is-rw parameter still writes back after a thread has run';
+}


### PR DESCRIPTION
Two routines that merely happen to use the same parameter name aliased each other once any thread had run. The callee's argument replaced the caller's value:

```raku
sub inner($desc) { say "inner $desc" }
sub outer($desc) { await start { inner("c") }; say "outer desc=$desc" }
outer("OUTER");
```

| | raku | mutsu (before) |
| --- | --- | --- |
| | `inner c` / `outer desc=OUTER` | `inner c` / `outer desc=c` |

Remove the `await start { … }` and mutsu is correct; give the two routines different parameter names and mutsu is correct. Only the combination fails.

## Cause

Spawning a thread turns on the cross-thread shared store (`shared_vars`), which is keyed by **bare name**. `sync_env_from_locals*` mirrors a frame's local slots into `env`, `set_shared_var_sym` forwards any name the store already holds back into it and marks it dirty, and the next `await` pulls every dirty name into the parent's env. `outer`'s `$desc` had seeded the store at spawn time, so `inner`'s parameter — a different binding that happens to share the key — overwrote it.

`exec_set_var_dynamic_op` already handles exactly this hazard for `my`: while the store is active, a re-declaration is a fresh binding shadowing whatever the store holds, so the name goes into `thread_redeclared_vars` and its writes stay thread-local. **A parameter is the same thing** and was not marked. `call_compiled_function_named_inner` now marks the routine's scalar parameter names right after `bind_function_args_values`, with the `my` case's exclusions: `@`/`%` names back the atomic element stores and must keep propagating, `&` names are routines, and `$_`/`self` are already excluded from the store's seeding.

## What it fixes

Found while measuring roast under the vendored `Test.rakumod` (`todo/tickets/vendor-real-test-module.md`). The real module has `multi sub subtest(&subtests, $desc = '')` and `sub pass($desc = '')`, so a subtest whose body does `await $p.then: { pass "a"; pass "b"; pass "c" }` reported `ok 1 - c` where rakudo reports `ok 1 - planless threaded` (`t/subtest-threaded-pass-count.t`). It should also account for most of `todo/tickets/retire-native-test-tap.md`'s "the tap callback collected nothing" group, where the emit runs on a timer or scheduler thread.

## Tests

- New pin `t/thread-callee-param-does-not-clobber-caller.t` — the three shapes of the bug, plus the two things the mark must *not* break: a lexical the thread genuinely closes over still crosses the boundary, and an `is rw` parameter still writes back to its caller's container. It passes under `raku` as well.
- `make test`: `Files=2770, Tests=26365 … Result: PASS`.
- Local spot check of the 218 whitelisted `S17-*` / `integration/` roast files (release, `-j6`): `Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)