### PR TITLE
fix(runtime): `IO::Socket::Async.connect` opens a real outbound TCP connection

### DIFF
--- a/news/2026-08/io-socket-async-real-outbound-connect.md
+++ b/news/2026-08/io-socket-async-real-outbound-connect.md
@@ -52,6 +52,6 @@ Two neighbouring defects surfaced while writing that test and are filed
 separately:
 `todo/tickets/supply-lines-drops-channel-backed-supplies.md` (`.lines` emits
 nothing on a real-TCP Supply) and
-`todo/tickets/proc-async-stdout-is-not-incremental.md` (`Proc::Async` output
+`todo/tickets/procasync-stdout-is-not-incremental.md` (`Proc::Async` output
 arrives only when the child exits, which is why the test hands the port over
 through a file).

--- a/news/2026-08/io-socket-async-real-outbound-connect.md
+++ b/news/2026-08/io-socket-async-real-outbound-connect.md
@@ -1,0 +1,57 @@
+# `IO::Socket::Async.connect` opens a real outbound TCP connection
+
+`IO::Socket::Async.connect` used to consult *only* the in-process listener
+registry. If no listener in the same interpreter owned the target address it did
+not attempt anything — it simply broke the Promise:
+
+```raku
+# with any external server listening on 31417
+await IO::Socket::Async.connect('127.0.0.1', 31417);
+# was: Failed to connect to '127.0.0.1:31417'
+```
+
+So no mutsu program could talk to a server in another process, while
+`IO::Socket::INET` (the synchronous socket) connected fine and
+`IO::Socket::Async.listen` already bound a real `TcpListener`. The asynchronous
+client half was the only simulated piece.
+
+## Changes
+
+- `dispatch_socket_async_connect` now falls back to a real
+  `TcpStream::connect_timeout` when no in-process listener owns the address. The
+  resulting socket is tagged `tcp-real` and registered with
+  `register_tcp_stream`, which is exactly the shape the *accepted* side of a real
+  connection already had — so `.Supply`, `.Supply(:bin)`, `.print`, `.write`,
+  `.close` and `.native-descriptor` all work through the existing `tcp-real`
+  paths in `socket_async_conn.rs` with no new plumbing.
+- Every address the host resolves to is tried in turn, so `localhost` on a
+  dual-stack box still connects when only one family has a listener.
+- A failed connect now breaks the Promise with an `X::AdHoc`, not a bare `Str`:
+  a consumer that catches it may `.rethrow` it, which Cro's pipeline QUIT handler
+  does.
+- `Tap.close` on a listener is now **synchronous**. The accept thread polls a
+  closed flag every 10ms, so the OS socket stayed bound for a moment after the
+  Tap was closed. That was invisible while `connect` was in-memory only (the
+  registry entry vanished at once), but with a real connect a client could still
+  connect to a just-closed listener. The accept thread now drops the listener and
+  raises a `stopped` flag, and `set_listener_closed` waits for it (bounded at 2s
+  so a wedged thread cannot hang the interpreter).
+
+## Impact
+
+This unblocks `Cro::HTTP::Client` — every Cro round-trip test drives it — and any
+program that speaks to an external service over an async socket. The mutsu Cro
+*server* already served real HTTP correctly (verified with `curl`); the client
+half could not open a connection at all.
+
+Pinned by `t/io-socket-async-real-connect.t`, which starts a helper listener in a
+*separate process* (an in-process one would take the in-memory path), connects to
+it, checks the socket has a real OS file descriptor, and round-trips bytes.
+
+Two neighbouring defects surfaced while writing that test and are filed
+separately:
+`todo/tickets/supply-lines-drops-channel-backed-supplies.md` (`.lines` emits
+nothing on a real-TCP Supply) and
+`todo/tickets/proc-async-stdout-is-not-incremental.md` (`Proc::Async` output
+arrives only when the child exits, which is why the test hands the port over
+through a file).

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -285,12 +285,81 @@ impl Interpreter {
             // Keep the promise with the client socket directly
             promise.keep(client_socket, String::new(), String::new());
         } else {
-            // Break the promise on connection failure
-            let err_msg = format!("Failed to connect to '{}:{}'", host, port);
-            let _ = promise.try_break(Value::str(err_msg));
+            // No in-process listener owns this address, so this is an ordinary
+            // outbound connection: open a real TCP stream. `.listen` already
+            // binds a real `TcpListener`, and the accepted (server) side of a
+            // real connection is driven by the `tcp-real` paths in
+            // `socket_async_conn.rs`; the client side is the same shape, so it
+            // reuses all of that plumbing.
+            match Self::connect_real_tcp(&host, port) {
+                Ok(socket) => {
+                    let conn_id = super::super::native_methods::next_async_socket_id();
+                    let local = socket.local_addr().ok();
+                    let peer = socket.peer_addr().ok();
+                    super::super::native_methods::state::register_tcp_stream(conn_id, socket);
+                    let mut attrs = HashMap::new();
+                    attrs.insert("conn-id".to_string(), Value::int(conn_id as i64));
+                    attrs.insert("tcp-real".to_string(), Value::TRUE);
+                    attrs.insert(
+                        "socket-host".to_string(),
+                        Value::str(
+                            local
+                                .map(|a| a.ip().to_string())
+                                .unwrap_or_else(|| "0.0.0.0".to_string()),
+                        ),
+                    );
+                    attrs.insert(
+                        "socket-port".to_string(),
+                        Value::int(local.map(|a| a.port()).unwrap_or(0) as i64),
+                    );
+                    attrs.insert("peer-host".to_string(), Value::str(host.clone()));
+                    attrs.insert(
+                        "peer-port".to_string(),
+                        Value::int(peer.map(|a| a.port()).unwrap_or(port) as i64),
+                    );
+                    attrs.insert("enc".to_string(), Value::str(enc));
+                    promise.keep(
+                        Value::make_instance(Symbol::intern("IO::Socket::Async"), attrs),
+                        String::new(),
+                        String::new(),
+                    );
+                }
+                Err(e) => {
+                    // Break with a real exception, not a Str: a consumer that
+                    // catches the failure may `.rethrow` it (Cro's pipeline
+                    // QUIT handler does).
+                    let mut ex_attrs = HashMap::new();
+                    ex_attrs.insert(
+                        "message".to_string(),
+                        Value::str(format!("Failed to connect to '{}:{}': {}", host, port, e)),
+                    );
+                    let _ = promise
+                        .try_break(Value::make_instance(Symbol::intern("X::AdHoc"), ex_attrs));
+                }
+            }
         };
 
         Ok(Value::promise(promise))
+    }
+
+    /// Open a real outbound TCP connection for `IO::Socket::Async.connect`.
+    /// Every resolved address is tried in turn, so a host that resolves to both
+    /// IPv6 and IPv4 (`localhost` on a dual-stack box) still connects when only
+    /// one family has a listener.
+    fn connect_real_tcp(host: &str, port: u16) -> std::io::Result<std::net::TcpStream> {
+        let addr = format!("{}:{}", host, port);
+        let addrs: Vec<_> = addr.to_socket_addrs()?.collect();
+        let mut last_err = std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            format!("no addresses found for '{}'", addr),
+        );
+        for sock_addr in addrs {
+            match std::net::TcpStream::connect_timeout(&sock_addr, Duration::from_secs(10)) {
+                Ok(s) => return Ok(s),
+                Err(e) => last_err = e,
+            }
+        }
+        Err(last_err)
     }
 
     /// IO::Socket::Async.bind-udp($host, $port)

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -347,6 +347,11 @@ impl Interpreter {
                 // Set up a closed flag for the accept thread
                 let closed_flag = Arc::new(AtomicBool::new(false));
                 register_listener_closed_flag(listener_id, closed_flag.clone());
+                // Raised by the accept thread once it has dropped the OS
+                // listener, so `Tap.close` can wait for the port to be free
+                // again instead of returning while it is still accepting.
+                let stopped_flag = Arc::new(AtomicBool::new(false));
+                register_listener_stopped_flag(listener_id, stopped_flag.clone());
 
                 // Create a supply channel so the react event loop can
                 // receive accepted connections
@@ -428,6 +433,11 @@ impl Interpreter {
                             }
                         }
                     }
+                    // Free the port *before* acknowledging, so a `Tap.close`
+                    // that waits on this flag can rely on the listener being
+                    // gone once it returns.
+                    drop(tcp_listener);
+                    stopped_flag.store(true, Ordering::SeqCst);
                 });
 
                 // Build a Supply instance that the react event loop can subscribe to

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -956,12 +956,48 @@ pub(in crate::runtime) fn register_listener_closed_flag(listener_id: u64, flag: 
     }
 }
 
+/// Map of listener_id -> Arc<AtomicBool> that the accept thread raises once it
+/// has dropped the OS listener. `set_listener_closed` waits on it so closing a
+/// Tap actually stops listening before it returns.
+type ListenerStoppedMap = std::sync::Mutex<HashMap<u64, Arc<AtomicBool>>>;
+
+fn listener_stopped_map() -> &'static ListenerStoppedMap {
+    static MAP: OnceLock<ListenerStoppedMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+pub(in crate::runtime) fn register_listener_stopped_flag(listener_id: u64, flag: Arc<AtomicBool>) {
+    if let Ok(mut map) = listener_stopped_map().lock() {
+        map.insert(listener_id, flag);
+    }
+}
+
 #[allow(dead_code)]
 pub(in crate::runtime) fn set_listener_closed(listener_id: u64) {
+    let mut closed_any = false;
     if let Ok(map) = listener_closed_map().lock()
         && let Some(flag) = map.get(&listener_id)
     {
         flag.store(true, Ordering::SeqCst);
+        closed_any = true;
+    }
+    if !closed_any {
+        return;
+    }
+    // Closing a Tap must stop the listener *synchronously*: the OS socket stays
+    // bound until the accept thread notices the flag and drops it, and until
+    // then a `connect` to that port still succeeds (a real TCP connect, since
+    // `dispatch_socket_async_connect` no longer requires an in-process
+    // listener). Wait for the accept thread's acknowledgement, bounded so a
+    // wedged thread cannot hang the interpreter.
+    let stopped = listener_stopped_map()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&listener_id).cloned());
+    let Some(stopped) = stopped else { return };
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while !stopped.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
+        crate::gc::block_quiescent(|| std::thread::sleep(std::time::Duration::from_millis(1)));
     }
 }
 

--- a/t/io-socket-async-real-connect.t
+++ b/t/io-socket-async-real-connect.t
@@ -1,0 +1,66 @@
+use Test;
+
+plan 5;
+
+# `IO::Socket::Async.connect` must open a real outbound TCP connection when the
+# target is not an in-process listener. Previously it only ever looked in the
+# in-process listener registry and broke the Promise for anything else, so no
+# mutsu program could talk to a server in another process.
+
+# A separate process is the only way to prove the connection is a real socket:
+# an in-process listener takes the in-memory path instead. The port travels
+# through a file rather than the child's stdout, so the handshake only depends
+# on the filesystem.
+my $port-file = $*TMPDIR.add("mutsu-real-connect-{$*PID}.port");
+my $child = q:to/CODE/;
+    my $listener = IO::Socket::Async.listen('127.0.0.1', 0);
+    my $tap = $listener.tap(-> $conn {
+        $conn.Supply.tap(-> $text { $conn.print("echo: $text") });
+    });
+    my $port = await $tap.socket-port;
+    @*ARGS[0].IO.spurt("$port\n");
+    sleep 30;
+    CODE
+
+my $server = Proc::Async.new($*EXECUTABLE.absolute, '-e', $child, $port-file.absolute);
+my $started = $server.start;
+
+my $port = 0;
+for ^300 {
+    if $port-file.e {
+        my $text = $port-file.slurp.trim;
+        if $text {
+            $port = $text.Int;
+            last;
+        }
+    }
+    sleep 0.1;
+}
+
+ok $port > 0, "helper server reported a port ($port)";
+
+my $conn = await IO::Socket::Async.connect('127.0.0.1', $port);
+ok $conn.defined, 'connect to an out-of-process listener succeeds';
+isa-ok $conn, IO::Socket::Async, 'the kept value is an IO::Socket::Async';
+
+# A real socket has a real OS file descriptor; the in-memory pair reports -1.
+ok $conn.native-descriptor > 0, 'a real connection has an OS file descriptor';
+
+my $reply = Promise.new;
+react {
+    whenever $conn.Supply -> $text {
+        $reply.keep($text.trim);
+        done;
+    }
+    whenever start { $conn.print("hello\n") } { }
+    whenever Promise.in(20) { done }
+}
+is ($reply ?? $reply.result !! ''), 'echo: hello',
+    'bytes travel over the real connection in both directions';
+
+$conn.close;
+$server.kill;
+await Promise.anyof($started, Promise.in(5));
+$port-file.unlink if $port-file.e;
+
+done-testing;

--- a/todo/tickets/procasync-stdout-is-not-incremental.md
+++ b/todo/tickets/procasync-stdout-is-not-incremental.md
@@ -1,0 +1,37 @@
+# `Proc::Async` stdout/stderr arrive only when the child exits
+
+A tap on `Proc::Async`'s `.stdout` receives nothing until the child process
+terminates, and then receives the whole output as a single chunk. Rakudo streams
+it as the child writes.
+
+```raku
+my $p = Proc::Async.new($*EXECUTABLE.absolute, '-e',
+    q{$*OUT.print("EARLY\n"); $*OUT.flush; sleep 4; $*OUT.print("LATE\n");});
+$p.stdout.tap(-> $c { say "[{now.Int}] OUT: $c" });
+my $s = $p.start;
+say "[{now.Int}] started";
+await Promise.anyof($s, Promise.in(15));
+```
+
+mutsu prints `started` at T, then one `OUT: EARLY\nLATE` at T+4. raku prints
+`OUT: EARLY` at T and `OUT: LATE` at T+4.
+
+## Why it matters
+
+Any handshake where the parent has to read something from a still-running child
+deadlocks. The concrete case: a test that starts a helper server in a child
+process, has the child report the ephemeral port it bound, and then connects to
+it. `t/io-socket-async-real-connect.t` had to route the port through a file
+instead, which is the workaround, not the fix.
+
+It also means `.stdout.lines` can never fire early — and `.lines` on that Supply
+does not fire at all, which is a separate bug
+(`todo/tickets/supply-lines-drops-channel-backed-supplies.md`).
+
+## Where to look
+
+The Proc::Async implementation collects the child's output rather than pumping
+it into the Supply as it is read; the reader needs to become a streaming reader
+that emits each chunk, in the same shape as the real-TCP socket reader thread in
+`src/runtime/native_methods/socket_async_conn.rs`
+(`async_socket_supply_real_tcp`), which does emit incrementally.

--- a/todo/tickets/supply-lines-drops-channel-backed-supplies.md
+++ b/todo/tickets/supply-lines-drops-channel-backed-supplies.md
@@ -1,0 +1,54 @@
+# `Supply.lines` silently drops every value from a channel-backed Supply
+
+`.lines` works on a Supply whose values arrive through the *supplier* registry
+(`Supplier.new.Supply`), but emits nothing at all for a Supply whose values
+arrive through a **supply channel** — the shape used by real TCP sockets and by
+the listener's accept stream.
+
+```raku
+# server side, run with a client sending "hello\n"
+react {
+    whenever IO::Socket::Async.listen('127.0.0.1', 31441) -> $conn {
+        whenever $conn.Supply       -> $t { say "text: $t" }   # fires
+        whenever $conn.Supply(:bin) -> $b { say "bin: $b" }    # fires
+        whenever $conn.Supply.lines -> $l { say "line: $l" }   # never fires
+    }
+}
+```
+
+The client side is affected identically, which is why
+`t/io-socket-async-real-connect.t` uses the plain text `.Supply` rather than the
+more natural `.lines`.
+
+## Root cause
+
+`native_supply_dispatch.rs`'s `"lines"` arm builds the derived Supply with a
+**fresh** `supply_id` (`next_supply_id()`) and `live => False`, carrying the
+source's id only as an inert `parent_supply_id` attribute. For a supplier-backed
+source it also copies `supplier_id`, which is what makes that case work — the
+derived supply is still registered against the same supplier.
+
+A real-TCP `.Supply` has no `supplier_id`. Its values are pushed down a channel
+registered in `supply_channel_map()` under the source's `supply_id`, and the tap
+path drains that channel by looking up `supply_id`. The derived lines Supply's
+new id has no channel, so the tap has nothing to drain and the parent's channel
+is never taken.
+
+## Fix sketch
+
+The derived supply must stay attached to the source's channel, and the line
+splitting has to happen as chunks are drained rather than up front:
+
+- keep the source's `supply_id` on the derived Supply (or teach the drain path
+  to follow `parent_supply_id`), and
+- have the drain path honour the existing `is_lines` / `line_chomp` attributes,
+  buffering a partial trailing line between chunks the same way
+  `split_supply_chunks_into_lines` does for a static value list.
+
+The buffering detail matters: a TCP read boundary can land mid-line, so a
+per-chunk split without carry-over would emit truncated lines.
+
+## Repro
+
+`tmp/srv2.log` / `tmp/srv4.log` in the session that filed this (recreate from the
+snippet above — `tmp/` is gitignored).


### PR DESCRIPTION
`IO::Socket::Async.connect` consulted **only** the in-process listener registry. If no listener in the same interpreter owned the target address it did not attempt anything — it simply broke the Promise:

```raku
# with any external server listening on 31417
await IO::Socket::Async.connect('127.0.0.1', 31417);
# was: Failed to connect to '127.0.0.1:31417'
```

So no mutsu program could talk to a server in another process, while `IO::Socket::INET` (the synchronous socket) connected fine and `IO::Socket::Async.listen` already bound a real `TcpListener`. The asynchronous client half was the only simulated piece.

## Changes

- `dispatch_socket_async_connect` falls back to a real `TcpStream::connect_timeout` when no in-process listener owns the address. The socket is tagged `tcp-real` and registered with `register_tcp_stream` — exactly the shape the *accepted* side of a real connection already had, so `.Supply`, `.Supply(:bin)`, `.print`, `.write`, `.close` and `.native-descriptor` all work through the existing `tcp-real` paths in `socket_async_conn.rs` with no new plumbing.
- Every address the host resolves to is tried in turn, so `localhost` on a dual-stack box connects when only one family has a listener.
- A failed connect breaks the Promise with an `X::AdHoc`, not a bare `Str`, so a consumer can `.rethrow` it (Cro's pipeline QUIT handler does).
- **`Tap.close` on a listener is now synchronous.** The accept thread polls a closed flag every 10ms, so the OS socket stayed bound for a moment after the Tap was closed. That was invisible while `connect` was in-memory only (the registry entry vanished at once), but with a real connect a client could still reach a just-closed listener — `t/supply-whenever-listener-tap.t`'s last assertion caught it. The accept thread now drops the listener and raises a `stopped` flag that `set_listener_closed` waits on, bounded at 2s so a wedged thread cannot hang the interpreter.

## Impact

This unblocks `Cro::HTTP::Client` — every Cro round-trip test drives it. The mutsu Cro *server* already serves real HTTP correctly (verified against `curl`); the client half could not open a connection at all.

## Verification

- New pin `t/io-socket-async-real-connect.t` (5 tests), which starts a helper listener in a **separate process** (an in-process one takes the in-memory path), connects, checks for a real OS file descriptor and round-trips bytes. Passes identically under `raku`.
- `make test`: 2769 files / 26362 tests PASS.
- `scripts/battery-testsuite.sh`: 153/158 GATE PASSED.

Two neighbouring defects surfaced while writing the test and are filed as tickets rather than fixed here: `Supply.lines` emits nothing on a channel-backed (real-TCP) Supply, and `Proc::Async` output arrives only when the child exits (which is why the test hands the port over through a file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)