### PR TITLE
fix(vm): a `supply { }` transform between a live source and a react streams

### DIFF
--- a/news/2026-08/react-whenever-chained-live-supply.md
+++ b/news/2026-08/react-whenever-chained-live-supply.md
@@ -1,0 +1,63 @@
+# A `supply { }` transform between a live source and a react now streams
+
+`react { whenever supply { whenever $live { emit … } } { … } }` — a `supply { }`
+transform placed between a live source and a react — delivered nothing. This is
+the shape every Cro pipeline stage has (`Cro::Transform.transformer` returns
+exactly such a supply), so no Cro pipeline could carry a value.
+
+```raku
+my $s = Supplier.new;
+my $out = supply { whenever $s.Supply -> $x { emit "got-$x" } };
+react {
+    whenever $out -> $v { say "GOT $v"; done }
+    whenever Promise.in(1) { $s.emit(1) }
+    whenever Promise.in(5) { say "TIMEOUT"; done }
+}
+# was: TIMEOUT      now: GOT got-1
+```
+
+The inner supply body *ran*, and its `whenever` *fired* — only the `emit` was
+lost. Tapping the same supply with `.tap` worked; only the react `whenever` path
+was broken.
+
+## Root cause
+
+The react loop's on-demand branch registers a `StreamConsumer` keyed by the
+supply's emitter id, whose `consumer_cb` is the outer `whenever`'s callback. That
+is what routes an `emit` inside the supply body downstream. The body is then run
+once, and the `whenever` registrations it produced are turned into
+`ReactSubscription`s that the event loop polls.
+
+But the `StreamConsumer` was truncated off the stack *before* the event loop
+started. So the first, synchronous pass worked and everything afterwards was
+dropped on the floor: when the inner subscription fired later, its body's `emit`
+found no consumer for the emitter id.
+
+Two consequences had to be handled once the consumer survives:
+
+- `try_stream_emit` has to **swallow** a `done` raised by the consumer callback,
+  because the emitting body still needs to unwind; it records
+  `StreamConsumer::done` instead. With the consumer now alive during the loop,
+  the drive loop checks that flag each poll and ends the react.
+- A *chained* transform (`supply { whenever supply { … } { … } }`) still failed:
+  `value_to_react_subscription` returns `None` for an on-demand source, so the
+  middle stage fell through to `replay_inner_static_subscription`, which replays
+  it once. A nested `supply { }` source now gets the full treatment — its own
+  emitter id, its own `StreamConsumer` routing to the `whenever` body that
+  consumes it, and its inner registrations turned into subscriptions in turn,
+  recursing for another stage (`register_nested_on_demand_source`, bounded at 32
+  stages by the same runaway-nesting guard `drive_inner_supply_to_consumer` uses).
+
+## Changes
+
+- `src/vm/vm_react_loop.rs`: the react's `StreamConsumer`s live until the event
+  loop returns (`stream_base`), and a nested on-demand source is wired up rather
+  than replayed.
+- `src/vm/vm_react_supply_helpers.rs`: new `register_nested_on_demand_source`,
+  the recursive stage-wiring helper.
+- `src/vm/vm_react_subscriptions.rs`: the drive loop honours a `done` recorded on
+  a `StreamConsumer`.
+
+Pinned by `t/react-whenever-chained-live-supply.t` (4 cases: single stage, `done`
+from the outer body, a stage declared in a method, and two chained stages), which
+passes identically under `raku`.

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -147,6 +147,12 @@ impl Interpreter {
         // Each entry is a tuple of (receiver_key, callback) stored as Values
         // We need to reconstruct the actual receivers
         let mut react_subs: Vec<ReactSubscription> = Vec::new();
+        // Lowest `supply_stream_consumers` index this react registered. The
+        // consumers stay registered for the whole event loop: an inner
+        // `whenever` of a `supply { }` source keeps firing after the body has
+        // been run once, and its `emit` reaches the outer whenever's callback
+        // only while that supply's StreamConsumer is still on the stack.
+        let mut stream_base: Option<usize> = None;
 
         for sub_val in &subscriptions {
             if let ValueView::Array(items, ..) = sub_val.view()
@@ -249,6 +255,7 @@ impl Interpreter {
                                 done: false,
                             });
                             let stream_idx = self.supply_stream_consumers.len() - 1;
+                            stream_base.get_or_insert(stream_idx);
                             let (od_res, emitted, body_ran_done) = loan_env!(
                                 self,
                                 run_on_demand_body(on_demand_cb.clone(), Some(emitter_supplier_id),)
@@ -266,7 +273,8 @@ impl Interpreter {
                             if let Err(od_err) = od_res
                                 && !od_err.is_react_done()
                             {
-                                self.supply_stream_consumers.truncate(stream_idx);
+                                self.supply_stream_consumers
+                                    .truncate(stream_base.unwrap_or(stream_idx));
                                 return Err(crate::runtime::Interpreter::wrap_react_died(od_err));
                             }
                             // If the streaming consumer signalled `done`, the
@@ -274,7 +282,8 @@ impl Interpreter {
                             // its LAST callbacks and stop (don't set up the inner
                             // subscriptions or keep polling).
                             if streamed_done {
-                                self.supply_stream_consumers.truncate(stream_idx);
+                                self.supply_stream_consumers
+                                    .truncate(stream_base.unwrap_or(stream_idx));
                                 let last_cbs = items
                                     .get(2)
                                     .and_then(crate::runtime::Interpreter::value_array_items)
@@ -307,6 +316,16 @@ impl Interpreter {
                                     if let Some(mut rsub) = self.value_to_react_subscription(&v) {
                                         rsub.on_demand_done = Some(done_promise.clone());
                                         react_subs.push(rsub);
+                                    } else if let Some(early) = self
+                                        .register_nested_on_demand_source(&v, &mut react_subs, 0)?
+                                    {
+                                        // A chained `supply { }` stage: wired up
+                                        // with its own emitter so the pipeline
+                                        // streams rather than being replayed once.
+                                        if early {
+                                            early_done = true;
+                                            break;
+                                        }
                                     } else if self.replay_inner_static_subscription(&v)?
                                         == Some(true)
                                     {
@@ -317,8 +336,14 @@ impl Interpreter {
                                     let _ = self.call_react_callback(&callback.clone(), vec![v]);
                                 }
                             }
-                            self.supply_stream_consumers.truncate(stream_idx);
+                            // NOTE: the StreamConsumer registered above is left in
+                            // place — it is truncated after the event loop (see
+                            // `stream_base`), so a value arriving later on an inner
+                            // `whenever`'s live source can still be re-emitted to
+                            // this whenever's callback.
                             if early_done {
+                                self.supply_stream_consumers
+                                    .truncate(stream_base.unwrap_or(stream_idx));
                                 return Ok(());
                             }
                             // Supply.on-demand(..., closing => { ... }): the
@@ -411,6 +436,10 @@ impl Interpreter {
             }
         }
 
-        self.drive_react_subscriptions_nested(react_subs, SupplyDrivePolicy::React)
+        let result = self.drive_react_subscriptions_nested(react_subs, SupplyDrivePolicy::React);
+        if let Some(base) = stream_base {
+            self.supply_stream_consumers.truncate(base);
+        }
+        result
     }
 }

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -290,6 +290,14 @@ impl Interpreter {
                     return Ok(());
                 }
             }
+            // A `done` raised by a whenever body that was fed through a
+            // StreamConsumer (an `emit` inside a `supply { }` source re-routed to
+            // the outer whenever's callback) is recorded as `StreamConsumer::done`
+            // rather than propagated — `try_stream_emit` has to swallow it so the
+            // emitting body can unwind. Honour it here: `done` ends the react.
+            if self.supply_stream_consumers.iter().any(|c| c.done) {
+                break 'react_loop;
+            }
             // Phase 1: deliver all queued supplier events in push (= emit)
             // order, honouring per-supplier done/quit.
             if self.dispatch_waker_events(waker, react_subs, &mut progressed)? {

--- a/src/vm/vm_react_supply_helpers.rs
+++ b/src/vm/vm_react_supply_helpers.rs
@@ -47,6 +47,128 @@ impl Interpreter {
         None
     }
 
+    /// Wire a nested `supply { ... }` source — a transform *stage* — into the
+    /// react subscription list, so a multi-stage pipeline streams.
+    ///
+    /// `sub_val` is a `whenever` registration `[Supply, callback, last?, quit?]`
+    /// whose source is itself an on-demand supply. The stage gets its own
+    /// emitter id and `StreamConsumer`, so an `emit` in its body reaches the
+    /// `whenever` body that consumes it, and the `whenever` registrations its
+    /// body produced become ReactSubscriptions in turn — recursing when one of
+    /// *those* is another `supply { }` stage.
+    ///
+    /// Returns `None` when `sub_val` is not an on-demand registration (the
+    /// caller falls back to `replay_inner_static_subscription`), or
+    /// `Some(early_done)` once the stage is wired up.
+    pub(super) fn register_nested_on_demand_source(
+        &mut self,
+        sub_val: &Value,
+        react_subs: &mut Vec<ReactSubscription>,
+        depth: usize,
+    ) -> Result<Option<bool>, RuntimeError> {
+        // Same runaway-nesting guard as `drive_inner_supply_to_consumer`: a
+        // transform sub reused twice in one pipeline shares an emitter binding.
+        if depth > 32 {
+            return Ok(None);
+        }
+        let ValueView::Array(items, ..) = sub_val.view() else {
+            return Ok(None);
+        };
+        if items.len() < 2 {
+            return Ok(None);
+        }
+        let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = items[0].view()
+        else {
+            return Ok(None);
+        };
+        if class_name != "Supply" {
+            return Ok(None);
+        }
+        let attrs = attributes.as_map();
+        // A source with a live channel or supplier is already handled by
+        // `value_to_react_subscription`; only a pure `supply { }` body lands here.
+        let Some(on_demand_cb) = attrs.get("on_demand_callback").cloned() else {
+            return Ok(None);
+        };
+        let callback = items[1].clone();
+        let last_callbacks = items
+            .get(2)
+            .and_then(crate::runtime::Interpreter::value_array_items)
+            .unwrap_or_default();
+
+        let emitter_supplier_id = next_supplier_id();
+        let done_promise = crate::value::SharedPromise::new();
+        crate::runtime::native_methods::supplier_register_promise(
+            emitter_supplier_id,
+            done_promise.clone(),
+        );
+        self.supply_stream_consumers.push(StreamConsumer {
+            supplier_id: emitter_supplier_id,
+            consumer_cb: callback.clone(),
+            done: false,
+        });
+        let stream_idx = self.supply_stream_consumers.len() - 1;
+        let (res, emitted, _) = loan_env!(
+            self,
+            run_on_demand_body(on_demand_cb, Some(emitter_supplier_id))
+        );
+        let streamed_done = self
+            .supply_stream_consumers
+            .get(stream_idx)
+            .map(|c| c.done)
+            .unwrap_or(false);
+        if let Err(e) = res
+            && !e.is_react_done()
+        {
+            self.supply_stream_consumers.truncate(stream_idx);
+            return Err(crate::runtime::Interpreter::wrap_react_died(e));
+        }
+        if streamed_done {
+            self.supply_stream_consumers.truncate(stream_idx);
+            return Ok(Some(true));
+        }
+        // The StreamConsumer stays registered for the life of the react (the
+        // outer loop truncates it), so values arriving later on this stage's own
+        // upstream still flow through it.
+        for v in emitted {
+            if crate::runtime::Interpreter::is_supply_subscription_registration(&v) {
+                if let Some(mut rsub) = self.value_to_react_subscription(&v) {
+                    rsub.on_demand_done = Some(done_promise.clone());
+                    react_subs.push(rsub);
+                } else if let Some(early) =
+                    self.register_nested_on_demand_source(&v, react_subs, depth + 1)?
+                {
+                    if early {
+                        return Ok(Some(true));
+                    }
+                } else if self.replay_inner_static_subscription(&v)? == Some(true) {
+                    return Ok(Some(true));
+                }
+            } else {
+                match self.call_react_callback(&callback.clone(), vec![v]) {
+                    Err(e) if e.is_react_done() => return Ok(Some(true)),
+                    other => {
+                        other?;
+                    }
+                }
+            }
+        }
+        let close_cbs = Self::extract_supply_on_close_callbacks(&attrs);
+        if !close_cbs.is_empty() || !last_callbacks.is_empty() {
+            react_subs.push(ReactSubscription {
+                close_callbacks: close_cbs,
+                last_callbacks,
+                on_demand_done: Some(done_promise),
+                ..ReactSubscription::new(callback)
+            });
+        }
+        Ok(Some(false))
+    }
+
     /// Replay static supply values (non-streaming supplies)
     /// Replay a static supply's values through a `whenever` callback, honouring
     /// the loop-control signals the body may raise: `done` ends the react

--- a/t/react-whenever-chained-live-supply.t
+++ b/t/react-whenever-chained-live-supply.t
@@ -1,0 +1,88 @@
+use Test;
+
+plan 4;
+
+# `react { whenever supply { whenever $live { emit ... } } { ... } }` -- a
+# `supply { }` transform placed between a live source and a react. This is the
+# shape every Cro pipeline stage has. Values that arrive on the *inner* source
+# after the supply body has run once must still reach the outer whenever.
+
+{
+    my $s = Supplier.new;
+    my $transformed = supply {
+        whenever $s.Supply -> $x { emit "got-$x" }
+    };
+    my @seen;
+    react {
+        whenever $transformed -> $v {
+            @seen.push($v);
+            done if @seen == 2;
+        }
+        whenever Promise.in(0.2) { $s.emit(1); $s.emit(2) }
+        whenever Promise.in(10) { done }
+    }
+    is-deeply @seen, ['got-1', 'got-2'],
+        'values emitted after the transform body ran reach the outer whenever';
+}
+
+# `done` raised by the outer whenever body must end the react even though the
+# value came through the transform (the emit path has to swallow the signal so
+# the emitting body can unwind, so the loop has to notice it separately).
+{
+    my $s = Supplier.new;
+    my $transformed = supply {
+        whenever $s.Supply -> $x { emit $x * 2 }
+    };
+    my $after = False;
+    react {
+        whenever $transformed -> $v {
+            done;
+        }
+        whenever Promise.in(0.2) { $s.emit(21) }
+        whenever Promise.in(10) { $after = True; done }
+    }
+    nok $after, '`done` in the outer whenever body ends the react promptly';
+}
+
+# The same, but with the transform declared inside a method -- the shape
+# Cro::Transform.transformer has.
+{
+    class Doubler {
+        method transformer(Supply $in) {
+            supply {
+                whenever $in -> $x { emit $x * 2 }
+            }
+        }
+    }
+    my $s = Supplier.new;
+    my $out = Doubler.new.transformer($s.Supply);
+    my @seen;
+    react {
+        whenever $out -> $v {
+            @seen.push($v);
+            done if @seen == 3;
+        }
+        whenever Promise.in(0.2) { $s.emit($_) for 1..3 }
+        whenever Promise.in(10) { done }
+    }
+    is-deeply @seen, [2, 4, 6], 'a transform declared in a method streams too';
+}
+
+# Two transforms chained -- a pipeline, not a single stage.
+{
+    my $s = Supplier.new;
+    my $one = supply { whenever $s.Supply -> $x { emit $x + 1 } };
+    my $two = supply { whenever $one -> $x { emit $x * 10 } };
+    my @seen;
+    react {
+        whenever $two -> $v {
+            @seen.push($v);
+            done if @seen == 2;
+        }
+        whenever Promise.in(0.2) { $s.emit(1); $s.emit(2) }
+        whenever Promise.in(10) { done }
+    }
+    is-deeply @seen, [20, 30], 'two chained transforms both stream';
+}
+
+done-testing;


### PR DESCRIPTION
`react { whenever supply { whenever $live { emit … } } { … } }` — a `supply { }` transform placed between a live source and a react — delivered nothing. This is the shape **every Cro pipeline stage** has (`Cro::Transform.transformer` returns exactly such a supply), so no Cro pipeline could carry a value.

```raku
my $s = Supplier.new;
my $out = supply { whenever $s.Supply -> $x { emit "got-$x" } };
react {
    whenever $out -> $v { say "GOT $v"; done }
    whenever Promise.in(1) { $s.emit(1) }
    whenever Promise.in(5) { say "TIMEOUT"; done }
}
# was: TIMEOUT      now: GOT got-1
```

The inner supply body *ran*, and its `whenever` *fired* — only the `emit` was lost. Tapping the same supply with `.tap` worked; only the react `whenever` path was broken.

## Root cause

The react loop's on-demand branch registers a `StreamConsumer` keyed by the supply's emitter id, whose `consumer_cb` is the outer `whenever`'s callback. That is what routes an `emit` inside the supply body downstream. The body is then run once and the `whenever` registrations it produced become `ReactSubscription`s that the event loop polls.

But the `StreamConsumer` was truncated off the stack **before** the event loop started. So the first, synchronous pass worked and everything afterwards was dropped on the floor: when the inner subscription fired later, its body's `emit` found no consumer for the emitter id.

Two consequences had to be handled once the consumer survives:

- `try_stream_emit` has to **swallow** a `done` raised by the consumer callback, because the emitting body still needs to unwind; it records `StreamConsumer::done` instead. With the consumer now alive during the loop, the drive loop checks that flag each poll and ends the react.
- A **chained** transform (`supply { whenever supply { … } { … } }`) still failed: `value_to_react_subscription` returns `None` for an on-demand source, so the middle stage fell through to `replay_inner_static_subscription`, which replays it once. A nested `supply { }` source now gets the full treatment — its own emitter id, its own `StreamConsumer` routing to the `whenever` body that consumes it, and its inner registrations turned into subscriptions in turn, recursing for another stage (`register_nested_on_demand_source`, bounded at 32 stages by the same runaway-nesting guard `drive_inner_supply_to_consumer` uses).

## Verification

- New pin `t/react-whenever-chained-live-supply.t` (4 cases: single stage, `done` from the outer body, a stage declared in a method, two chained stages) — passes identically under `raku`.
- `make test`: 2772 files / 26383 tests PASS.
- `scripts/battery-testsuite.sh`: 153/158 GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)