### PR TITLE
fix(compiler): a `my enum` declared in a block is lexical to it

### DIFF
--- a/news/2026-08/supply-block-enum-lexical.md
+++ b/news/2026-08/supply-block-enum-lexical.md
@@ -1,0 +1,73 @@
+# A `my enum` declared in a block is lexical to it
+
+`my enum E <A B>` binds four names — the enum type and every variant — and in
+Raku all four are lexicals of the declaring block, exactly like `my $x`. mutsu
+treated none of them that way: the compiler recorded only `Stmt::VarDecl` names
+as a block's own declarations, so an enum's names were invisible to every scope
+mechanism built on that record.
+
+Two symptoms followed, and the first was the top blocker for Cro's HTTP parsers.
+
+## The variant lost to an outer symbol inside a `whenever` callback
+
+`Cro::HTTP::ResponseParser` and `Cro::HTTP::RequestParser` are both shaped like
+
+```raku
+supply {
+    my enum Expecting <StatusLine Header Body>;
+    whenever $in -> $packet { ... $expecting = Header ... }
+}
+```
+
+next to a `Cro::HTTP::Header` class, whose short name `Header` is bound in the
+env. A `whenever` callback is dispatched later, from the *emitting* thread, whose
+ambient env is the main script's — so names the enclosing `supply { }` body owns
+have to be installed with overwrite when the callback runs. That list
+(`exec_whenever_scope_op`'s `owned_lexicals`) is derived from the block's own
+`my` declarations, so the enum variants were not on it and `Header` resolved to
+the class. Both parsers died with `X::Undeclared::Symbols: Header`.
+
+The declaration now records its type and variant names in
+`CompiledCode::my_declared_sym`, which puts them on that list. Reduced to plain
+mutsu:
+
+```raku
+class Hdr2 { }
+my $src = Supplier.new;
+my $out = supply {
+    my enum E <X Hdr2 Y>;
+    whenever $src.Supply { emit Hdr2.WHAT.^name }   # was Hdr2, now E
+};
+```
+
+`t/http-response-parser.rakutest` went from 129 passing subtests to 143 of 158,
+and `t/http-request-parser.rakutest` — which used to abort at test 108 — now
+plans 295 and passes 264.
+
+## The variant outlived its block
+
+The mirror image: the binding leaked *out*, so a same-named outer symbol stayed
+clobbered for the rest of the program.
+
+```raku
+class Zed { }
+{ my enum E <Zed Q>; }
+say Zed.^name;      # raku: Zed   mutsu was: E
+```
+
+Three exit paths each dropped it for a different reason, and all three are fixed:
+`BlockScope` restoration consults the runtime `block_declared_vars` set, which
+`RegisterEnum` now adds a `my enum`'s names to; the two compiled-call merges
+(`vm_call_light`, `vm_call_named_inner`) skip only names with a callee *local
+slot*, which an enum name never gets, so they consult a new
+`CompiledCode::my_declared_enum_sym` as well.
+
+That new set exists because these names are lexical yet slotless: every bareword
+read of one looks like a free variable to `compute_free_vars`, and free-var
+status is exactly what exempts a name from the closure-exit writeback filters.
+They are subtracted from `free_var_syms` instead.
+
+Pinned by `t/supply-block-enum-lexical.t`. One boundary remains — a name a
+`whenever` callback installs authoritatively is not removed when the callback
+returns, so it is still bound after the `react` block — recorded in
+`todo/tickets/whenever-owned-lexical-outlives-the-react-block.md`.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3360,7 +3360,32 @@ impl Compiler {
                 let name_idx = self.code.add_constant(Value::str(module.clone()));
                 self.code.emit(OpCode::NeedModule(name_idx));
             }
-            Stmt::EnumDecl { .. } => {
+            Stmt::EnumDecl {
+                name,
+                variants,
+                is_my,
+                ..
+            } => {
+                // A `my enum` binds its type name AND every variant name lexically
+                // in this block, exactly like a `my` variable — so record them as
+                // the block's own declarations. That is what makes them survive
+                // into a `whenever` callback of the enclosing `supply { … }` body
+                // (they are installed with overwrite as `authoritative_captures`)
+                // instead of losing to a same-named outer binding when the callback
+                // runs from the emitting thread's env: `supply { my enum E
+                // <StatusLine Header Body>; whenever … { … Header … } }` resolved
+                // `Header` to a file-scope `class …::Header` alias. It also stops
+                // the binding leaking back to the caller on block exit, which is
+                // what the same set already does for `my $x`.
+                if *is_my {
+                    self.code.my_declared_sym.insert(*name);
+                    self.code.my_declared_enum_sym.insert(*name);
+                    for (variant, _) in variants {
+                        let sym = Symbol::intern(variant);
+                        self.code.my_declared_sym.insert(sym);
+                        self.code.my_declared_enum_sym.insert(sym);
+                    }
+                }
                 let idx = self.code.add_stmt(stmt.clone());
                 self.code.emit(OpCode::RegisterEnum(idx));
             }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1935,6 +1935,14 @@ pub(crate) struct CompiledCode {
     /// var (used before its declaration, so it refers to the outer binding)
     /// keeps the writeback.
     pub(crate) my_declared_sym: rustc_hash::FxHashSet<Symbol>,
+    /// The subset of `my_declared_sym` bound by a `my enum` — its type name and
+    /// every variant name. Unlike a `my` variable these get no local slot, so
+    /// every bareword read of one looks like a free variable to
+    /// `compute_free_vars`; that free-var status would then exempt them from the
+    /// very writeback filter `my_declared_sym` exists for. They are subtracted
+    /// from `free_var_syms` instead, which is also what keeps them resolving to
+    /// the block's own binding inside a `whenever` callback.
+    pub(crate) my_declared_enum_sym: rustc_hash::FxHashSet<Symbol>,
     /// Free variables this code (and its nested closures) reference from an
     /// enclosing scope: names used via GetGlobal-family ops that are not this
     /// code's own locals. For a closure body this is the set of captured
@@ -2325,6 +2333,7 @@ impl CompiledCode {
             dup_named_locals: Vec::new(),
             is_supply_block_body: false,
             my_declared_sym: rustc_hash::FxHashSet::default(),
+            my_declared_enum_sym: rustc_hash::FxHashSet::default(),
             free_var_syms: Vec::new(),
             free_var_parent_slots: Vec::new(),
             upvalue_parent_slots: Vec::new(),
@@ -3640,6 +3649,14 @@ impl CompiledCode {
         }
         self.needs_cell_escaping_our_sub = nceos.into_iter().collect();
         self.needs_cell_escaping_our_sub_free = nceos_free.into_iter().collect();
+        // A `my enum`'s type and variant names are this code's OWN lexical
+        // bindings, but they get no local slot, so every bareword read of one
+        // landed in `free` above. Left there, the free-var exemption in the
+        // closure-exit writeback filters would push the block-private binding
+        // back onto a same-named caller lexical. See `my_declared_enum_sym`.
+        if !self.my_declared_enum_sym.is_empty() {
+            free.retain(|sym| !self.my_declared_enum_sym.contains(sym));
+        }
         self.free_var_syms = free.into_iter().collect();
         self.outer_ref_names = outer_ref_names;
         self.free_var_writes = free_writes.into_iter().collect();

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -361,7 +361,12 @@ impl Interpreter {
                     {
                         continue;
                     }
-                    if !cf.is_callee_local_sym(*k) {
+                    // A `my enum` the callee declared is one of its own lexicals
+                    // too, but it gets no local slot, so `is_callee_local_sym`
+                    // does not see it and the binding leaked into the caller —
+                    // clobbering a same-named outer symbol for the rest of the
+                    // program.
+                    if !cf.is_callee_local_sym(*k) && !cf.code.my_declared_enum_sym.contains(k) {
                         self.env_mut().insert_sym(*k, v.clone());
                     }
                 }
@@ -384,7 +389,8 @@ impl Interpreter {
                             || k.with_str(|s| s.starts_with('?'))
                             || (bang_is_callee_private
                                 && k.with_str(crate::runtime::utils::is_routine_scoped_error_var))
-                            || cf.is_callee_local_sym(*k))
+                            || cf.is_callee_local_sym(*k)
+                            || cf.code.my_declared_enum_sym.contains(k))
                     });
                 }
             }

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -535,6 +535,11 @@ impl Interpreter {
                 }
                 if restored_env.contains_key_sym(*k)
                     && !cf.is_callee_local_sym(*k)
+                    // A `my enum` this body declared is its own lexical, but it
+                    // gets no local slot, so `is_callee_local_sym` misses it and
+                    // the binding overwrote a same-named caller symbol for the
+                    // rest of the program.
+                    && !cf.code.my_declared_enum_sym.contains(k)
                     && !k.with_str(|s| {
                         rw_sources.contains(s)
                             // Per-call-site index-rw temps are frame-internal;

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -27,7 +27,7 @@ impl Interpreter {
             name,
             variants,
             is_export,
-            is_my: _,
+            is_my,
             base_type,
             language_version,
         } = stmt
@@ -36,6 +36,18 @@ impl Interpreter {
                 self,
                 register_enum_decl(&name.resolve(), variants, *is_export, base_type.as_deref(),)
             )?;
+            // A `my enum` is lexical: its type name and every variant name die
+            // with the enclosing block, so record them the way `DeclareVar`
+            // records a `my $x`. Block exit otherwise propagated the variant
+            // bindings outwards and a same-named outer symbol stayed clobbered
+            // for the rest of the program (`{ my enum E <Zed> }; Zed` answered
+            // the enum value rather than the file-scope `class Zed`).
+            if *is_my && let Some(set) = self.block_declared_vars.last_mut() {
+                set.insert(*name);
+                for (variant, _) in variants {
+                    set.insert(crate::symbol::Symbol::intern(variant));
+                }
+            }
             // Store language revision metadata from the version captured at parse time
             if !name.resolve().is_empty() {
                 self.store_language_revision_from_version(&name.resolve(), language_version);

--- a/t/supply-block-enum-lexical.t
+++ b/t/supply-block-enum-lexical.t
@@ -1,0 +1,57 @@
+use Test;
+
+plan 8;
+
+# A `my enum` binds its type name AND every variant name lexically in the block
+# that declares it, so those names must (a) win over a same-named outer symbol
+# inside that block and everything nested in it, and (b) not survive the block.
+
+# --- (a) inside a `supply { }` body and its `whenever` callbacks.
+#
+# The callback is dispatched later from the emitting thread, whose ambient env
+# is the main script's -- an outer binding that merely shares a variant's name
+# must not win there. This is the shape Cro's request/response parsers use:
+# `supply { my enum Expecting <StatusLine Header Body>; whenever ... }` next to
+# a `Cro::HTTP::Header` class.
+
+class SBEL-Header { }
+
+my $src = Supplier.new;
+my $out = supply {
+    my enum SBEL-State <Start SBEL-Header Done>;
+    is SBEL-Header.WHAT.^name, 'SBEL-State',
+        'the variant wins over the file-scope class in the supply body';
+    whenever $src.Supply -> $n {
+        emit SBEL-Header.WHAT.^name;
+        emit SBEL-Header.key;
+        emit Done.value;
+    }
+};
+
+my @got;
+react {
+    whenever $out -> $v { @got.push($v); done if @got == 3 }
+    whenever Promise.in(5) { done }
+    whenever Promise.in(0.2) { $src.emit(1) }
+}
+
+is @got[0], 'SBEL-State', 'and inside the whenever callback too';
+is @got[1], 'SBEL-Header', 'the variant is the enum value, not the class';
+is @got[2], 2, 'a later variant keeps its ordinal';
+
+# --- (b) the binding dies with its block.
+
+class SBEL-Outer { }
+
+{
+    my enum SBEL-Block <SBEL-Outer Q>;
+    is SBEL-Outer.WHAT.^name, 'SBEL-Block', 'the variant wins inside the block';
+}
+is SBEL-Outer.^name, 'SBEL-Outer', 'and the outer class is intact after the block';
+
+class SBEL-Sub { }
+sub sbel-f() { my enum SBEL-InSub <SBEL-Sub Q2>; SBEL-Sub.WHAT.^name }
+is sbel-f(), 'SBEL-InSub', 'the variant wins inside the sub body';
+is SBEL-Sub.^name, 'SBEL-Sub', 'and the outer class is intact after the call';
+
+done-testing;

--- a/todo/tickets/whenever-owned-lexical-outlives-the-react-block.md
+++ b/todo/tickets/whenever-owned-lexical-outlives-the-react-block.md
@@ -1,0 +1,49 @@
+# A `whenever` callback's owned lexical is left behind in the ambient env
+
+A `supply { }` body's `my` declarations are its own lexicals, and the `whenever`
+callbacks nested in it capture them as `authoritative_captures` (installed with
+overwrite on entry, so they win over a same-named caller lexical when the
+callback is dispatched from the emitting thread — `exec_whenever_scope_op`'s
+`owned_lexicals`). The install is never undone: after the `react` block finishes,
+the name is still bound in the main script's env.
+
+```raku
+class Zed { }
+my $src = Supplier.new;
+my $out = supply {
+    my enum E <Zed R>;
+    whenever $src.Supply { emit Zed.WHAT.^name }
+};
+react {
+    whenever $out -> $v { say $v; done }          # E        (correct)
+    whenever Promise.in(0.2) { $src.emit(1) }
+}
+say Zed.WHAT.^name;   # raku: Zed   mutsu: E
+```
+
+A `my $x` in the same position hides the symptom rather than avoiding it: the
+caller reads `$x` from its own local *slot*, so a polluted env entry is never
+consulted. A name with no slot — an enum type or variant, a `constant`, a
+lexical type — has only the env entry, so the leak is visible.
+
+## Where it comes from
+
+`Interpreter::run_whenever_with_value` (`src/runtime/subtest.rs`) builds each
+callback with `Value::make_sub_owning(..., owned_lexicals)`. Every exit merge
+correctly refuses to write an owned name *back* to the caller
+(`is_body_private` in `src/runtime/resolution_call_sub.rs` checks
+`data.authoritative_captures`), but nothing removes the entry the authoritative
+install itself put there. The callback runs with the emitting thread's env, which
+for an in-process `Supplier` is the main script's.
+
+The fix is to restore each authoritatively-installed name to its pre-entry value
+(or remove it) when the callback returns, which means recording the pre-install
+value alongside the install rather than only the name.
+
+## Related
+
+`t/supply-block-enum-lexical.t` pins the resolution half of this (an enum
+declared in a supply body wins inside the whenever callback) and the block/sub
+non-leak halves, but deliberately does not assert the post-`react` state.
+`todo/deep/supply-block-lexicals-alias-the-caller.md` covers the wider aliasing
+question this sits inside.


### PR DESCRIPTION
`my enum E <A B>` binds the enum type and every variant name, and in Raku all of
them are lexicals of the declaring block. mutsu recorded only `Stmt::VarDecl`
names as a block's own declarations, so an enum's names were invisible to every
scope mechanism built on that record.

**Inward.** A `whenever` callback is dispatched later, from the *emitting*
thread, whose ambient env is the main script's — so names the enclosing
`supply { }` body owns must be installed with overwrite when it runs. Enum names
were not on that list, so the shape both Cro HTTP parsers use

```raku
supply {
    my enum Expecting <StatusLine Header Body>;
    whenever $in -> $packet { ... Header ... }
}
```

resolved `Header` to the `Cro::HTTP::Header` class and died with
`X::Undeclared::Symbols: Header`.

**Outward.** The binding survived its block and clobbered a same-named outer
symbol for the rest of the program — `{ my enum E <Zed> }; Zed` answered the
variant rather than the file-scope `class Zed`. Three exit paths dropped it
independently: the `BlockScope` restore, and the two compiled-call merges, which
skip only names that have a callee *local slot*.

## Changes

- The compile arm records the type and variant names in
  `CompiledCode::my_declared_sym` — what feeds the `whenever` owned-lexical list
  and the closure-exit writeback filters.
- `RegisterEnum` adds them to the runtime `block_declared_vars` set, so block
  exit restores the outer binding.
- `vm_call_light` / `vm_call_named_inner` consult a new
  `CompiledCode::my_declared_enum_sym`, since an enum name never gets a slot.
- That same set is subtracted from `free_var_syms`: a slotless lexical looks like
  a free variable to `compute_free_vars`, and free-var status is exactly what
  exempts a name from those filters.

## Effect on the Cro suite

| file | before | after |
| --- | --- | --- |
| `t/http-response-parser.rakutest` | 129 passing | 143 / 158 |
| `t/http-request-parser.rakutest` | 93 / 108, aborting | 264 / 295 |

## Testing

`t/supply-block-enum-lexical.t` (new, verified against `raku`) pins both
directions. Full `prove t/` is green; `cargo clippy -- -D warnings` and
`cargo fmt --check` pass.

One boundary is left open and recorded in
`todo/tickets/whenever-owned-lexical-outlives-the-react-block.md`: a name a
`whenever` callback installs authoritatively is not removed when the callback
returns, so it is still bound after the `react` block. A `my $x` hides that
symptom (the caller reads its own slot); a slotless name does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)