### PR TITLE
fix(numeric): radix literal with no fraction is an Int; big rationals answer .abs

### DIFF
--- a/news/2026-08/radix-literal-int-and-big-rational-methods.md
+++ b/news/2026-08/radix-literal-int-and-big-rational-methods.md
@@ -1,0 +1,55 @@
+# A radix literal with no fraction is an Int, and a big rational answers `.abs`
+
+Two independent gaps, found together because the first produced the value that
+tripped the second. Both surfaced in `roast/S02-literals/radix.t` under the real
+`Test` module, where the file aborted at test 61 of 158 with
+
+```
+No such method 'abs' for invocant of type 'Rat'
+  in sub is-approx at .../Test.rakumod line 304
+```
+
+## The radix literal
+
+`:16<dead_beef*16**8>` was a `Rat` in mutsu and an `Int` in rakudo. mutsu built
+every radix literal that had a fraction *or* an exponent as a rational and left
+it that way.
+
+Rakudo's rule (`radcalc`) is not "the value came out integral" — it is whether
+the **fractional digits evaluate to zero**:
+
+| literal | rakudo |
+| --- | --- |
+| `:10<2.0>` | `Int 2` — even though the plain literal `2.0` is a `Rat` |
+| `:16<f*16**1>` | `Int 240` |
+| `:16<dead_beef*16**8>` | `Int 16045690981097406464` |
+| `:16<f.8*16**2>` | `Rat 3968` — integral, but the fraction was not zero |
+| `:16<dead_beef.face>` | `Rat` |
+
+mutsu now decides the same way, in the parser's generic-radix path. Note the
+asymmetry is real and deliberate on rakudo's side: the *runtime* string forms
+(`:10("2.0")`, `"2.0".parse-base(10)`) stay `Rat`, and mutsu already matched
+there.
+
+## The big rational
+
+A rational whose numerator outgrows `i64` is a `BigRat`, a separate `ValueView`
+variant from `Rat`. The 0-arg numeric method dispatch knew nothing about it, so
+`.abs`, `.sign` and `.sqrt` all declined and were reported as
+`No such method 'abs' for invocant of type 'Rat'` — the type name says `Rat`,
+which is exactly why this reads as impossible. Worse, `.Int` did not decline: it
+answered `(n / d).to_i64().unwrap_or(i64::MAX)`, so
+`(16045690981097406464/1).Int` silently returned `9223372036854775807`.
+
+All four are fixed; `.Int` now returns the exact big integer through
+`Value::from_bigint`, which normalizes back to `Int` when it fits.
+
+## Effect
+
+`roast/S32-str/parse-base.t` and `roast/S32-num/fatrat.t` now pass completely
+under the real `Test` module, and `roast/S02-literals/radix.t` runs all 158
+tests instead of aborting at 61 (two unrelated parse-error-classification
+failures remain: `:0<...>` and a bare `:2` should be rejected).
+
+Pin: `t/radix-literal-int-and-bigrat-methods.t` — all sixteen assertions also
+pass under `raku`.

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -99,7 +99,9 @@ fn numeric_to_int(target: &Value) -> Option<Value> {
         ValueView::BigRat(_, d) if d.is_zero() => {
             RuntimeError::divide_by_zero_failure_for_method("Int", "Rational")
         }
-        ValueView::BigRat(n, d) => Value::int((n / d).to_i64().unwrap_or(i64::MAX)),
+        // Truncating a big rational must not silently clamp to `i64::MAX` —
+        // `(16045690981097406464/1).Int` is that integer, not 9223372036854775807.
+        ValueView::BigRat(n, d) => Value::from_bigint(n / d),
         ValueView::Complex(r, _) => Value::int(r as i64),
         _ => return None,
     })
@@ -738,10 +740,8 @@ pub(super) fn dispatch(
                         "Int", "Rational",
                     ))));
                 }
-                ValueView::BigRat(n, d) if !d.is_zero() => {
-                    use num_traits::ToPrimitive;
-                    Value::int((n / d).to_i64().unwrap_or(i64::MAX))
-                }
+                // Do not clamp: a big rational's truncation is a big integer.
+                ValueView::BigRat(n, d) if !d.is_zero() => Value::from_bigint(n / d),
                 ValueView::Str(s) => {
                     if s.trim().is_empty() {
                         // An empty or whitespace-only string coerces to 0, like

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -453,6 +453,9 @@ pub(super) fn dispatch(
             ValueView::Int(i) => Some(Ok(Value::num((i as f64).sqrt()))),
             ValueView::Num(f) => Some(Ok(Value::num(f.sqrt()))),
             ValueView::Rat(n, d) if d != 0 => Some(Ok(Value::num((n as f64 / d as f64).sqrt()))),
+            ValueView::BigRat(n, d) if !num_traits::Zero::is_zero(d) => {
+                Some(Ok(Value::num(crate::value::bigrat_to_f64(n, d).sqrt())))
+            }
             ValueView::Complex(r, i) => {
                 let mag = (r * r + i * i).sqrt();
                 let re = ((mag + r) / 2.0).sqrt();

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -207,6 +207,10 @@ pub(super) fn dispatch(
                 ValueView::Num(f) => Value::num(f.abs()),
                 ValueView::Rat(n, d) => Value::rat_raw(n.abs(), d),
                 ValueView::FatRat(n, d) => Value::fat_rat_raw(n.abs(), d),
+                // A rational whose numerator outgrew `i64` is a `BigRat`, not a
+                // `Rat`; without this arm every numeric method below declines
+                // and the call reports "No such method 'abs'".
+                ValueView::BigRat(n, d) => Value::bigrat(n.magnitude().clone().into(), d.clone()),
                 ValueView::Complex(r, i) => Value::num((r * r + i * i).sqrt()),
                 ValueView::Bool(b) => Value::int(if b { 1 } else { 0 }),
                 _ => return Some(None),
@@ -389,6 +393,23 @@ pub(super) fn dispatch(
                     } else {
                         let sign = n.signum() * d.signum();
                         Value::int(sign)
+                    }
+                }
+                ValueView::BigRat(n, d) => {
+                    use num_bigint::Sign;
+                    let sign_of = |b: &num_bigint::BigInt| match b.sign() {
+                        Sign::Plus => 1i64,
+                        Sign::Minus => -1,
+                        Sign::NoSign => 0,
+                    };
+                    if d.sign() == Sign::NoSign {
+                        match n.sign() {
+                            Sign::Plus => Value::int(1),
+                            Sign::Minus => Value::int(-1),
+                            Sign::NoSign => Value::num(f64::NAN),
+                        }
+                    } else {
+                        Value::int(sign_of(n) * sign_of(d))
                     }
                 }
                 ValueView::BigInt(n) => {

--- a/src/parser/primary/number.rs
+++ b/src/parser/primary/number.rs
@@ -607,6 +607,7 @@ pub(super) fn generic_radix(input: &str) -> PResult<'_, Expr> {
             .unwrap_or_else(|| num_bigint::BigInt::from(0_i64))
     };
     let frac_scale = base_big.pow(frac_clean.len() as u32);
+    let frac_is_zero = num_traits::Zero::is_zero(&frac_value);
     let mut numerator = int_value * &frac_scale + frac_value;
     let mut denominator = frac_scale;
 
@@ -618,6 +619,20 @@ pub(super) fn generic_radix(input: &str) -> PResult<'_, Expr> {
         } else {
             denominator *= scale;
         }
+    }
+
+    // A generic radix *literal* whose fractional digits are all zero is an Int,
+    // even though the same digits written as a plain literal would be a Rat
+    // (`:10<2.0>` is `Int 2`; `2.0` is `Rat 2`) — rakudo's `radcalc` decides on
+    // whether the fraction evaluates to zero, not on whether the final value is
+    // integral, which is why `:16<f.8*16**2>` stays `Rat` despite being 3968.
+    // Without this, `:16<dead_beef*16**8>` came out a Rat big enough to be a
+    // BigRat, and every numeric method that only knows `Rat` declined on it.
+    if frac_is_zero && num_traits::Zero::is_zero(&(&numerator % &denominator)) {
+        return Ok((
+            &r[close_pos + 1..],
+            Expr::Literal(crate::value::Value::from_bigint(numerator / denominator)),
+        ));
     }
 
     Ok((

--- a/t/radix-literal-int-and-bigrat-methods.t
+++ b/t/radix-literal-int-and-bigrat-methods.t
@@ -1,0 +1,40 @@
+use Test;
+
+# Two independent gaps found together in roast/S02-literals/radix.t.
+#
+# 1. A generic radix *literal* whose fractional digits are all zero is an Int,
+#    even though the same digits as a plain literal would be a Rat. Rakudo's
+#    `radcalc` decides on whether the fraction evaluates to zero, not on
+#    whether the final value happens to be integral — which is why
+#    `:16<f.8*16**2>` stays Rat despite being 3968.
+# 2. A rational whose numerator outgrew i64 is a BigRat, and the numeric
+#    methods only knew Rat, so `.abs` / `.sign` / `.sqrt` reported
+#    "No such method ... for invocant of type 'Rat'" and `.Int` silently
+#    clamped to i64::MAX.
+
+plan 16;
+
+# --- 1. radix literal types ---------------------------------------------
+
+is :10<2.0>.WHAT.^name,   'Int', ':10<2.0> is an Int';
+is :10<2.0>,              2,     ':10<2.0> is 2';
+is :2<1.0>.WHAT.^name,    'Int', ':2<1.0> is an Int';
+is :16<f*16**1>.WHAT.^name, 'Int', 'a radix literal with an exponent and no fraction is an Int';
+is :16<f*16**1>,          240,   ':16<f*16**1> is 240';
+is :16<dead_beef*16**8>.WHAT.^name, 'Int', 'an exponent past i64 range is still an Int';
+is :16<dead_beef*16**8>,  16045690981097406464, 'and carries the exact value';
+
+# A non-zero fraction stays a Rat even when the exponent makes it integral.
+is :16<f.8*16**2>.WHAT.^name, 'Rat', 'a non-zero fraction stays a Rat';
+is :16<f.8*16**2>,        3968,  'and still has the right value';
+is :10<2.5>.WHAT.^name,   'Rat', ':10<2.5> is a Rat';
+
+# --- 2. numeric methods on a big rational --------------------------------
+
+my $big = 16045690981097406464/1;
+is $big.abs,  16045690981097406464, '.abs on a big rational';
+is (-$big).abs, 16045690981097406464, '.abs of a negative big rational';
+is $big.sign, 1,  '.sign on a big rational';
+is (-$big).sign, -1, '.sign of a negative big rational';
+is $big.Int,  16045690981097406464, '.Int does not clamp to i64::MAX';
+is-approx $big.sqrt, 4005707300.976621, '.sqrt on a big rational';


### PR DESCRIPTION
Two independent gaps, found together because the first produced the value that
tripped the second. Both surfaced in `roast/S02-literals/radix.t` under the real
`Test` module, where the file aborted at test 61 of 158 with

```
No such method 'abs' for invocant of type 'Rat'
  in sub is-approx at .../Test.rakumod line 304
```

## The radix literal

`:16<dead_beef*16**8>` was a `Rat` in mutsu and an `Int` in rakudo. Rakudo's
rule (`radcalc`) is not "the value came out integral" — it is whether the
**fractional digits evaluate to zero**:

| literal | rakudo |
| --- | --- |
| `:10<2.0>` | `Int 2` — even though the plain literal `2.0` is a `Rat` |
| `:16<f*16**1>` | `Int 240` |
| `:16<dead_beef*16**8>` | `Int 16045690981097406464` |
| `:16<f.8*16**2>` | `Rat 3968` — integral, but the fraction was not zero |
| `:16<dead_beef.face>` | `Rat` |

The parser's generic-radix path now decides the same way. The asymmetry is real
and deliberate on rakudo's side: the *runtime* string forms (`:10("2.0")`,
`"2.0".parse-base(10)`) stay `Rat`, and mutsu already matched there.

## The big rational

A rational whose numerator outgrows `i64` is a `BigRat`, a separate
`ValueView` variant from `Rat`. The 0-arg numeric dispatch knew nothing about
it, so `.abs`, `.sign` and `.sqrt` declined and were reported as
`No such method 'abs' for invocant of type 'Rat'` — the type name says `Rat`,
which is exactly why this reads as impossible. `.Int` did not decline but
clamped: `(16045690981097406464/1).Int` silently answered `9223372036854775807`.
It now returns the exact big integer via `Value::from_bigint`.

## Effect

`roast/S32-str/parse-base.t` and `roast/S32-num/fatrat.t` now pass completely
under the real `Test` module, and `roast/S02-literals/radix.t` runs all 158
tests instead of aborting at 61 (two unrelated parse-error-classification
failures remain: `:0<...>` and a bare `:2` should be rejected).

Local `make test` and `make roast` both PASS.

Pin: `t/radix-literal-int-and-bigrat-methods.t` — all sixteen assertions also
pass under `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)