### PR TITLE
docs: ANALYSIS rev11 and an ADR-ledger progress review

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -3,72 +3,76 @@
 This document is an **architecture and soundness review** of the mutsu codebase —
 "how much of the design is in order, and what debt remains" — not a bug tracker.
 
-First edition: 2026-06-03. Revision history through rev8 (2026-07-06) is in git; each
+First edition: 2026-06-03. Revision history through rev10 (2026-07-19) is in git; each
 rev's resolved findings are archived in the news files
-([news/2026-07.md](news/2026-07.md) "ANALYSIS.md rev9/rev10 — resolved-item archive"
-holds both the pre-rev8 archive and everything closed since).
-**rev10: 2026-07-19 — re-verified against HEAD (#4811) after 259 commits since rev9;
-the `integration/` frontier is fully cleared, deep-recursion is fixed, a RakuAST model
-layer (§1.7) landed, and hygiene metrics were re-measured. Resolved items moved to news.**
+([news/2026-07.md](news/2026-07.md) "ANALYSIS.md rev9/rev10 — resolved-item archive").
+**rev11: 2026-08-02 — re-verified against HEAD (`c65835e13`) after 1096 commits since
+rev10. Three things changed the architecture picture: ADR-0013 landed (the
+`gc_contents_mut` provenance UB is gone at the primitive), a bundled-module layer
+(`modules/`, 22 vendored dists) and a user-facing MOP (EXPORTHOW::DECLARE) became
+first-class subsystems, and ADR-0016 completed the regex capture/`Match` representation
+rework. §7 is re-prioritized accordingly, and §8 is a new ADR-ledger review.**
 
 Method:
-- subsystem-level close reading by survey agents
-- per-claim verification on the live tree
-
-Every finding carries a `file:line` reference. Reproducible defects were actually run.
+- subsystem-level close reading, re-verified per claim on the live tree
+- every finding carries a `file:line` reference
 
 ---
 
 ## 0. Summary
 
 mutsu is a Rust implementation of a minimal Raku-compatible interpreter. The roast
-whitelist stands at **1433 / 1464 (97.9%)**, up from rev9's 1391/1463. The former
-frontier — `integration/` (real Raku programs) — is **fully whitelisted (0 remaining)
-as of 2026-07-17**; roast is no longer the productive axis (BLOCKERS.md: "No cluster
-remains"). Active work has moved to the RakuAST model layer (§1.7) and PLAN.md §1/§5/§6.
-No test-specific hardcoded outputs were found.
+whitelist stands at **1435 / 1464 (98.0%)**, up from rev10's 1433/1464 — and that near-flat
+number is the point: **roast has been mined out since rev10** (PLAN §4), so a year's worth
+of the project's velocity now shows up in places roast does not measure. The 1096 commits
+since rev10 went almost entirely into (a) the raku-differential compatibility sweep
+(≈100 `news/2026-08/` entries, one general fix each), (b) the batteries campaign — real
+upstream modules vendored and run verbatim — and (c) two representation campaigns
+(ADR-0015 native-backed storage, ADR-0016 span-based captures).
 
-Overall assessment as of rev10:
+Overall assessment as of rev11:
 
-- **The execution stack is complete in outline**: a single bytecode VM (the tree-walk
-  interpreter, dual variable store, and tree-walk method bodies are all long gone), a
-  **cycle-collecting GC, default-on** (ADR-0003), an **8-byte NaN-boxed `Value`**
-  (layer 3b, #4469), and a **Cranelift JIT, default-on** (ADR-0004 J5, #4482). The
-  remaining tree-walk is declaration registration and dispatch-resolver entries, not
-  body execution (§1.1). A **RakuAST model layer** (ADR-0011, §1.7) landed on top of
-  this stack since rev9: `Q[…].AST` reads out a RakuAST tree and `EVAL($tree)` lowers it
-  back through the *same* compiler — no second execution engine.
-- **Performance vs raku flipped from deficit to surplus.** Bench CI (2026-07-14, main
-  `827fdb0e`, vs Rakudo v2022.12 on the same runner): fib 0.59x (JIT 0.48x),
-  method-call 0.89x, bench-class 0.84x, bench-fib 1.15x (JIT 0.92x), bench-tak+jit
-  1.02x; most other benches ≤0.5x. Every rev8 gap (bench-fib 3.2x, method-call 2.7x,
-  bench-class 2.3x) is closed. Caveat: the runner's Rakudo is v2022.12.
-- **Quality gates are thick**: CI = `test` (clippy -D warnings, cargo test, t/ TAP,
-  roast) + blocking `gc-stress` + blocking `jit-stress` + `wasm-e2e`; bench CI records
-  history on every main push. Size guards pin `Value` ≤8B and `OpCode` ≤48B; drift
-  tests (`t/can-methods-drift.t`) catch structural regressions.
-- **Soundness debt is localized**: raw-pointer aliased writes survive behind
-  `gc::gc_contents_mut` / `Gc::{get,make}_mut` (~59 call sites across 25 files, up from
-  rev9's ~53/21, §2.1); the GC's buffered-clone/uniqueness invariant is still mostly
-  prose (§2.1). The rev9 "deep recursion aborts the process" hole is **fixed**: the
-  interpreter now runs on a 256 MB-stack thread (`main.rs:99`) and the three pure-recursion
-  integration tests pass; only the memory-bound `deep-recursion-initing-native-array.t`
-  still aborts, and that is a typed-shaped-array coercion issue, not Rust-stack recursion
-  (§2.3).
-- **Negative hygiene trends continue, faster than rev9's slope** (GC/NaN-box/JIT/RakuAST
-  churn): `unwrap/expect/panic!/unreachable!` 1759→**1789**, `#[allow(` 165→**170**,
-  files >500 lines 210→**239** (>1000: 57→**62**), `runtime/mod.rs` 2309→**2470** lines
-  (the rev9 "needs another facade slim-down" flag is now overdue). `.clone()` 8947→**9056**;
-  each is an 8-byte NaN-box copy, but useless-clone pruning (3b-2) remains open (§5).
+- **The execution stack is complete and, since rev10, no longer has a known
+  provenance-UB hole.** Single bytecode VM; cycle-collecting GC default-on (ADR-0003);
+  8-byte NaN-boxed `Value` (ADR-0005); Cranelift JIT default-on (ADR-0004, closed).
+  **ADR-0013 landed**: the payload of every `Gc<T>` now lives in an `UnsafeCell` inside
+  `GcBox` (`gc/gc_ptr.rs:166`), so the ~59 deliberate aliased container writes derive a
+  `&mut` with valid interior-mutable provenance (`gc_ptr.rs:774`) instead of casting a
+  `*const`. What rev10 called the #2 roadmap item is mechanically fixed; what remains is
+  *verification* (no Miri gate exists) and the narrow cross-thread race deferred to
+  layer 3c (§2.1).
+- **Two subsystems that did not exist in rev10 are now load-bearing**: a **bundled-module
+  layer** (`modules/`, 22 vendored upstream dists + `vendor/zef`, gated by a release-time
+  upstream-test-suite run) and a **user-facing MOP** (`EXPORTHOW::DECLARE` declarator
+  registry + HOW-driven class registration, `runtime/metamodel.rs`). Both are described in
+  §1.8/§1.9 — and both push load onto the one subsystem that is still tree-walking
+  (declaration registration, §1.1).
+- **One representation campaign finished, one did not.** ADR-0016 (span-based captures +
+  lazy `Match`) landed all five phases in four days at the end of July and corrected five
+  real compatibility bugs on the way; it left behind one unenforced invariant (a `view()`
+  probe materializes a lazy `Match`). ADR-0015 stopped after P3a: `Buf`/`CArray` are
+  native-backed, `array[T]` is not, and the accessor chokepoint that would unify them is
+  unbuilt (§1.10).
+- **Performance remains a surplus, not a problem.** At HEAD the bench CI ratio vs Rakudo is
+  below 1.0 on every benchmark except `bench-ctor` (1.21), `bench-tak` (1.06) and
+  interpreter-only `bench-fib` (0.98). Per PLAN's 2026-07-16 priority reset, perf is polish;
+  this revision therefore ranks architectural items by **debt shape and dependency**, not by
+  profile share.
+- **Hygiene trends keep worsening, and faster than rev10's slope**: files >500 lines
+  239→**300**, >1000 62→**80**, `runtime/mod.rs` 2470→**2495**, `unwrap/expect/panic!/
+  unreachable!` 1789→**1908**, `#[allow(` 170→**178**, `.clone()` 9056→**10192**. Three
+  consecutive revisions have flagged `runtime/mod.rs`; it has never been slimmed.
 
-None of the remaining issues is of the "the basic design is broken" kind; they are
-design/soundness/maintainability debt.
+None of the remaining issues is of the "the basic design is broken" kind. The shape of the
+debt has changed, though: rev10's top item was *soundness* (raw-pointer writes), and that is
+now mechanically closed. rev11's top items are **half-finished migrations** (§1.10) and one
+**mechanism that many open correctness bugs share a root in** (§1.3 / §2.4).
 
 Where to look first:
-- §1: what architectural work remains
+- §1: what architectural work remains (§1.8-§1.10 are new)
 - §2: open correctness/soundness issues
-- §4: hardcode and drift risks
-- §7: prioritized roadmap
+- §7: prioritized roadmap — the main deliverable of this revision
+- §8: ADR ledger review
 
 ---
 
@@ -76,213 +80,270 @@ Where to look first:
 
 ### 1.1 Remaining tree-walk — declaration registration and dispatch entries only
 
-User-code bodies (subs, methods, blocks) execute exclusively as bytecode. What still
-walks the AST (re-verified 2026-07-15):
+User-code bodies (subs, methods, blocks) execute exclusively as bytecode. What still walks
+the AST (re-verified 2026-08-02):
 
 - **Declaration registration**: `register_class_decl`
-  (`runtime/registration_class_decl.rs:210`), `register_sub_decl`
-  (`runtime/registration_sub.rs:407`), `register_role_decl`
-  (`runtime/registration_role.rs:210`) run off `Register*` opcodes
-  (`opcode.rs:1328-1336`, dispatched at `vm_exec_dispatch.rs:4137-4209`). Class system,
-  MRO, and role composition are uncompiled — but this is registration, not body
-  execution.
-- **Dispatch resolver entries**: multi/submethod and `samewith`/`nextsame` enter
-  through `run_instance_method` (`runtime/class_dispatch.rs:11`); bodies are compiled.
-  A **sound multi-method resolution cache + `fast_method_cache`**
-  (`vm/vm_call_method_compiled_cache.rs:111-154`, invalidated on new declarations) now
-  amortizes the resolver, so what remains is entry-point consolidation (§3.3), not
-  caching.
+  (`runtime/registration_class_decl.rs:419`), `register_sub_decl`
+  (`runtime/registration_sub.rs:438`), `register_role_decl`
+  (`runtime/registration_role.rs:257`) run off `Register*` opcodes. Class system, MRO and
+  role composition are uncompiled — registration, not body execution.
+  **This is no longer a static amount of debt.** The MOP campaign (§1.9) hung the user HOW
+  protocol off exactly this path: `declare_drive_how_protocol` drives `new_type` /
+  `add_method` / `compose` against a user metaobject from inside AST-walking registration,
+  and `registration_class_decl.rs` has grown to 2882 lines. Every future MOP feature adds
+  to a tree-walk that has been flagged since rev5.
+- **Dispatch resolver entries**: multi/submethod and `samewith`/`nextsame` enter through
+  `run_instance_method` (`runtime/class_dispatch.rs:52`, plus a `_celled` variant at `:90`);
+  bodies are compiled. The sound multi-method resolution cache + `fast_method_cache` still
+  amortize the resolver, so what remains is entry-point consolidation (§3.3).
 - **Module-sub OTF compile gate** (`def_is_otf_compilable_module_single`,
-  `vm/vm_call_func_ops.rs:1852`): after the relaxation campaign
-  (#4427→#4429→#4431→#4437) the residual exclusions are mechanism-level, each with a
-  known blocker: `state` (would sever the shared state cell, `:1879-1883`), sigilless
-  `\x` params (caller-alias writeback across EVAL needs a #4091-style compile-time
-  caller slot, `:1793-1800`), `is encoded(...)` (NativeCall marshalling, `:1878`), and
-  `start` (recursive-capture clobber; an AST predicate cannot see recursion,
-  `:1944-1962`).
+  `vm/vm_call_func_ops.rs:1991`): unchanged since rev10. The residual exclusions are
+  mechanism-level — `state`, sigilless `\x` params, `is encoded(...)`, `start` — each with a
+  documented blocker (PLAN §3).
 
 ### 1.2 Closure upvalues — Phase 1 only, unchanged since rev5
 
-`compute_upvalues` is still the conservative Phase 1 (`opcode.rs:3021-3068`): only
-pure scalar reads of already-shared `ContainerRef` cells are promoted to indexed
-`GetUpvalue` (`opcode.rs:259`); writes, RW ops, `@`/`%`/`&` sigils are excluded, and
-the pass bails entirely under `captures_env_by_name` (`opcode.rs:3039`). Out-of-range
-indices fall back to live env-by-name reads (`vm_closure_dispatch.rs:508`) — always
-sound. Phase 2 (value-izing read-only constant captures, write paths, env-copy
-removal) stays blocked on general captured-lexical cell-ification; the rev5 soundness
-walls still stand: value snapshots are unsound (compile-time mutation analysis misses
-role/class-method writes and rw-arg sinks — the `S12-construction/roles-6e.t` flake),
-and blanket cell-ification of read-only captures breaks ContainerRef-blind paths and
-deadlocks per-iteration × cross-thread (#2749).
+`compute_upvalues` (`opcode.rs:3832`) is still the conservative Phase 1: only pure scalar
+reads of already-shared `ContainerRef` cells are promoted to indexed `GetUpvalue`; writes,
+RW ops and `@`/`%`/`&` sigils are excluded, and the pass bails entirely under
+`captures_env_by_name`. Out-of-range indices fall back to live env-by-name reads — always
+sound. Phase 2 stays blocked on general captured-lexical cell-ification, and the rev5
+soundness walls still stand (value snapshots are unsound because compile-time mutation
+analysis is incomplete; blanket cell-ification of read-only captures breaks
+ContainerRef-blind paths). This is one of the three consumers that §1.3 must move together.
 
-### 1.3 Lexical-scope slots — shadow slots default ON; the clone endgame remains
+### 1.3 Lexical-scope slots — precise per-slot sync exists; the blanket is the endgame
 
-Big status change since rev8: the §1.4 campaign
-([docs/lexical-scope-slot-campaign.md](docs/lexical-scope-slot-campaign.md)) landed
-all slot bakes S1–S17, and **shadow slots are default ON since 2026-07-12** — a full
-toggle-ON whitelist survey (1379 files) found zero genuine regressions.
-`shadow_slots_active()` is opt-out via `MUTSU_NO_SHADOW_SLOTS`
-(`compiler/mod.rs:27-31`); `declare_local` mints fresh/ancestor-shadow slots by
-default and keeps the legacy shared-slot branch for the escape hatch
-(`compiler/mod.rs:545-601`).
+Shadow slots have been default-ON since 2026-07-12, the whole-`locals` per-block clones are
+gone (rev10 slices 1-3), and `needs_env_sync` is now a genuine **per-slot** `Vec<bool>`
+computed by `compute_needs_env_sync` (`opcode.rs:2534`): a slot is marked only if some op
+reads or writes that name by name (`opcode.rs:2680-2690`), plus the closure-free-var fold.
 
-What remains is the endgame that motivated the campaign:
+What remains is the blanket that overrides all of it:
 
-- **By-name slot resolution is still load-bearing**: `resolve_local_slot` prefers the
-  baked slot but falls back to `find_local_slot(code, name)`
-  (`vm_env_helpers.rs:1200-1214`), and several writeback callers still pass `None`
-  (e.g. `vm_for_loop_dispatch.rs:307-310`, `vm_loop_writeback.rs:23-24`).
-- **The whole-`locals` per-block clones are gone** (slices 1-3, 2026-07-19):
-  `BlockLocalScope` (#4818), the `$OUTER::` snapshot (#4821), and the `BlockScope`
-  whole-array restore (#4827) each dropped their `locals`-vec clone for a targeted
-  Nil-reset of the block's fresh declarations — the headline cost the campaign
-  existed to delete. The compile-time `block_declared_slots` bake the 2026-07-12
-  probe anticipated proved unnecessary (the runtime `block_declared` name set plus a
-  not-in-`saved_env` test isolates fresh declarations).
-- **The `needs_env_sync` blanket** — the one remaining piece of the endgame.
-  `captures_env_by_name` returns true if the frame
-  contains any `ForLoop`/`BlockScope`/`MakeGather`/`WheneverScope`, mirroring *every*
-  local to env on each store. Removing it precisely requires un-name-keying block
-  restore, loop shadow save/restore, and closure capture **simultaneously** — one
-  fused campaign with this section and §1.2 (PLAN §5 item 0; single-mechanism attempts
-  are known to break five writeback mechanisms).
+```
+self.captures_env_by_name = ops.any(ForLoop | BlockScope | BlockLocalScope
+                                    | MakeGather | WheneverScope)   // opcode.rs:2608
+if self.captures_env_by_name { needs_env_sync.fill(true); return }  // opcode.rs:2648
+```
 
-### 1.4 Optimizer and opcode set — baseline passes exist now; remainder is measured
+One occurrence of any of those five ops in a frame makes **every** local an env-mirror
+target. The blanket is not removable one consumer at a time: block-scope restore re-pulls
+locals from env by name, the loop mechanism writes the loop var to both slot and env,
+`MakeGather`/`WheneverScope` stash a body in `stmt_pool` and run it by name against the live
+env, and closure capture reads free vars from the same mirror. PLAN §5 item 0 records four
+independent mechanisms that a standalone removal deterministically broke.
 
-rev8's "no constant folding / DCE / peephole" is obsolete: ADR-0006 landed literal
-constant folding (#4485), constant-pool dedup (#4486), `constant` inlining +
-constant-condition DCE (#4487), declaration-marker fusion (#4488), and replaced the
-`SetSourceLine` opcode with a static ip→line table (#4489). The instruction set keeps
-its 2026-07-06 audit verdict "shape is sound"
-([docs/opcode-design-review.md](docs/opcode-design-review.md)); `OpCode` stays ≤48B
-(`opcode.rs:1507-1508`).
+**The reason this ranks higher in rev11 than in rev10 is not performance.** It is that the
+open correctness tickets in `todo/` cluster on this one mechanism — see §2.4.
 
-Remaining, all measurement-gated:
+### 1.4 Optimizer and opcode set — baseline passes exist; the remainder is measurement-gated
 
-- The **"opcode count ≠ time" lesson** (#4489): `SetSourceLine` was 21% of executed
-  opcodes on fib but the cheapest possible op — deleting it bought -3.4% instructions,
-  and one refresh-everywhere variant was a +7.8% regression. The surviving
-  administrative ops (`SetVarDynamic` ~500k, `CheckReadOnly` ~100k) must clear a
-  retired-instructions (`instructions:u`, core-pinned) gate before anyone touches them
-  (ADR-0006 measurement protocol).
-- Inline `Option<String>` payloads (`Last`/`Next`/`Redo`/loop labels,
-  `SmartMatchExpr.lhs_var`) → constant-pool `Option<u32>`; per-instruction constant
-  costs (`current_code` raw-pointer store, `trace_log!` check); `Jump(i32)` carrying
-  an absolute index; histogram-driven consolidation of syntax-shaped specialized ops
-  (`ContainerEq`×4, `IndexAssign*`×6).
+ADR-0006's adopted measures all landed (constant folding, constant-pool dedup, `constant`
+inlining + constant-condition DCE, declaration-marker fusion, `SetSourceLine` removal).
+`OpCode` stays ≤48B (`opcode.rs:1722`), `Value` ≤8B (`value/mod.rs:2186`), and a `CapNode`
+leaf is size-guarded too (`runtime/regex_types.rs:309`).
 
-### 1.5 JIT (new since rev8) — default on; ADR-0004 complete
+Remaining, all gated on ADR-0006's measurement protocol: the surviving administrative ops
+(`SetVarDynamic`, `CheckReadOnly`), inline `Option<String>` payloads → constant-pool
+`Option<u32>`, `Jump(i32)` carrying an absolute index, and histogram-driven consolidation of
+syntax-shaped specialized ops. The "opcode count ≠ time" lesson (#4489) still governs.
 
-A Cranelift JIT (ADR-0004) landed as J1–J5 and is **default-on since 2026-07-13**
-(#4482; `src/vm/vm_jit*.rs`, 7 files ≈2000 lines; blocking `jit-stress` CI job).
-Tier A translates hot opcode chunks into helper-call sequences; Tier B inlines
-NaN-box tag-dispatched Int/Num arithmetic (including div/mod, #4503) into native code.
+### 1.5 JIT — default on; ADR-0004 closed
 
-- **J4d (Tier B variable-op inlining) is done and ADR-0004 is closed** (#4543).
-  It landed as six profile-driven slices: inline GetLocal + lock-free hot-range
-  cache (#4527), the SetLocal-mirror intern-chain removal (#4528), an
-  allocation-free light-call ceremony (#4529), FxHashed dispatch tables + fused
-  arg scans (#4534), caller-env-frame reuse via a CoW write latch (#4537), and
-  the readonly-set Arc snapshot → mutation journal (#4540). fib+jit reached a
-  0.28 raku ratio (from 0.34). The int-loop "5-10x" ratio gate was re-judged
-  obsolete (the old-interpreter denominator shrank with the shared-cost cuts);
-  the absolute target — int-arith+jit ≈ 0.16-0.18x raku (~5.5x faster) — is met.
-- **The profile says the JIT is not yet the bottleneck's owner**: on fib (release,
-  JIT on) native code runs only ~5.7% of cycles; allocation (~11.8%), hashing/env
-  table cloning (~12%), and the call path (~10.9%) dominate
-  (PLAN §5 table, 2026-07-13). The next perf lever is therefore §1.3's env work, not
-  more JIT coverage.
+Unchanged since rev10: Tier A translates hot opcode chunks into helper-call sequences, Tier B
+inlines NaN-box tag-dispatched Int/Num arithmetic. All six J4d slices landed and ADR-0004 is
+closed. The structural note from rev10 still holds and matters for §7: **the JIT bails at the
+call boundary**, so a loop that calls a sub runs the interpreter call path — no amount of JIT
+coverage subsumes §1.3.
 
-### 1.6 Parser (good) and pseudo-slangs — unchanged
+### 1.6 Parser and pseudo-slangs — plus a real declarator registry
 
 Hand-written scannerless recursive descent; precedence handling is textbook-clean
-(`parser/expr/precedence.rs`); `memo.rs` gives packrat-style backtracking relief.
-There is no true slang stack: Regex bodies are scanned as raw text at parse time
-(`parser/primary/regex/scan.rs`) and structurally parsed at runtime; Pod is skipped
-by the parser and rebuilt from raw source at runtime (`runtime/io_pod_blocks.rs:4`).
-Real user-defined grammar/token/rule slang switching remains future work.
+(`parser/expr/precedence.rs`); `memo.rs` gives packrat-style backtracking relief. There is
+still **no true slang stack**: regex bodies are scanned as raw text at parse time
+(`parser/primary/regex/scan.rs`) and structurally parsed at runtime; Pod is skipped by the
+parser and rebuilt from raw source at runtime.
 
-### 1.7 RakuAST model layer (new since rev9) — read+write, no second engine
+New since rev10: the parser carries a **unit-scoped declarator registry**
+(`parser/stmt/simple/registry.rs`, `declare_keyword_names()`), fed by a module's
+`EXPORTHOW::DECLARE` block, and both the bare form (`class::declare_decl`) and the
+scope-prefixed form (`decl::my_decl_dispatch::try_keyword_dispatch`) consult it. That is a
+genuine, if narrow, step toward user-extensible syntax — it extends the *declarator* table,
+not the grammar. It does not change the slang verdict: user-defined grammar/token/rule slang
+switching remains future work, and the registry is deliberately not a general slang
+mechanism.
 
-A RakuAST model layer (ADR-0011) landed as ~37 slices across Phases 4–5 (PRs
-#4729–#4804) and is the single largest new subsystem since rev9 (`src/rakuast/`,
-13 files ≈3200 lines). It has two directions:
+### 1.7 RakuAST model layer — read+write, no second engine
 
-- **Read** (`Q[…].AST`): the internal `Stmt`/`Expr` tree is converted to a RakuAST node
-  tree whose `.gist` is byte-identical to Rakudo's where applicable.
-- **Write** (`EVAL($rakuast)`): `lower(RakuAstNode) -> Stmt/Expr` re-enters the **existing
-  compiler**, so there is no separate interpreter — the model layer is a translation
-  surface, not a new execution engine.
+`src/rakuast/` (5 files, ~3960 lines) converts the internal `Stmt`/`Expr` tree to a RakuAST
+node tree (`Q[…].AST`) and lowers it back through the **same compiler** (`EVAL($tree)`), so
+there is still no second execution engine. ADR-0011's Phase 1-5 work landed broadly; the
+remaining gaps are inventoried in `todo/deep/rakuast-remaining.md` (read-direction
+representation gaps where the parser desugars before conversion, construction of advanced
+parameter forms, a lowering list blocked on representation mismatches, and Phase 6 macros).
 
-Coverage is broad: literals (interpolation, array/hash literals, pairs, `*`, bareword
-types), all common operators + the ternary, the full control-flow set
-(`if`/`elsif`/`unless`/`while`/`until`/`repeat`/`for`/C-style `loop`/`given`-`when`/`do`/
-`try`/`gather`), sub declarations with typed/default/named/slurpy parameters, control-flow
-calls (`return`/`last`/`next`/`die`/`fail`/`take`), and first-class closures. Each slice is
-pinned by a dual-oracle test (`t/rakuast-*.t`) that passes under both mutsu and raku.
-Remaining: Phase 6 (macros / `quasi`), the type registry beyond the covered node set, and
-the two read-only nodes whose raw round-trip diverges from raku (hash literals, the
-Phase-2 read cluster). This work is orthogonal to the roast frontier (0 whitelisted roast
-files use RakuAST) and drives PLAN §RakuAST, not roast.
+**Planning note**: no whitelisted roast file uses RakuAST, and no bundled battery needs it.
+It is the one large campaign in this document with no downstream consumer, which is why §7
+demotes it relative to rev10.
+
+### 1.8 Bundled-module layer (new since rev10) — the batteries architecture
+
+`modules/` holds **22 vendored upstream dists** (Base64, Crypt-Random, DateTime-Parse,
+DBIish, Encode, File-Directory-Tree, File-Temp, HTTP-HPACK, HTTP-Status, HTTP-UserAgent,
+IO-Path-ChildSecure, IO-Socket-SSL, MIME-Base64, NativeHelpers-Blob, NativeLibs, OO-Monitors,
+OpenSSL, Rakudo-Core, Template-Mustache, Test-Util-ServerPort, URI, YAMLish), plus
+`vendor/zef`. Module resolution has a documented precedence chain (`use lib` → `-I` →
+`MUTSULIB` → the `mzef` site repo → bundled batteries), and a release-time gate runs each
+battery's **upstream** test suite (`scripts/battery-testsuite.sh`, `batteries.lock`).
+
+Architecturally this is a policy decision with teeth (BATTERIES.md): **a module is grown into
+by fixing the interpreter (rung 2), never reimplemented natively (rung 3)** — banned by user
+decision 2026-08-01. The consequences are visible in the code: the native `Test::Util` /
+`Test::Tap` overrides were retired (`news/2026-08/retired-native-test-util-overrides.md`),
+`Pod::To::Text` became the real rakudo module, and rakudo's real `Test.rakumod` is now
+vendored behind `MUTSU_REAL_TEST=1` pending the flip.
+
+**Why this belongs in an architecture review**: the vendored suites are now the strictest
+correctness oracle the project has (stricter than roast, which is mined out), and the
+remaining native providers are an explicitly enumerated exception list — currently
+`NativeCall` (measured non-vendorable, `todo/deep/nativecall-cannot-be-vendored.md`),
+`JSON::Fast`, and `Test` (mid-retirement). That exception list is a first-class piece of the
+architecture and should shrink monotonically or be justified in writing.
+
+### 1.9 Metaobject protocol (new since rev10) — user HOWs on top of AST registration
+
+`runtime/metamodel.rs` plus the registration path now implement enough MOP for a real
+ecosystem module to install its own declarator and metaobject:
+`EXPORTHOW::DECLARE::<keyword>` registration, `Metamodel::ClassHOW` subclassing with
+fully-qualified `self.Metamodel::ClassHOW::<meth>` dispatch and `callsame` base candidates,
+user `new_type`/`add_method`/`compose`, a user `BUILDALL`/`POPULATE` hook at construction,
+and a user `clone` reaching the native attribute-copying clone. `OO::Monitors` runs verbatim
+on this (`news/2026-08/exporthow-declare-mop.md`) and the native `monitor` stopgap was
+retired.
+
+Two structural observations:
+
+1. **It is bolted onto the tree-walking registration path** (§1.1). The user protocol is
+   driven from inside `register_class_decl`, so MOP breadth and §1.1's compilation debt are
+   now coupled: each new HOW metamethod is another AST-walking special case.
+2. **B2b's "custom HOW inheritance is campaign-sized" verdict is partly obsolete.** PLAN
+   §B2b still describes HOW subclassing as unbuilt; the OO::Monitors campaign built a
+   meaningful part of it. What remains unbuilt is the NQP/QAST/slang layer Test::Async needs,
+   which is a *different* claim. PLAN §B2b should be re-scoped, not simply left deferred.
+
+### 1.10 Representation campaigns — one complete, one half-finished
+
+- **ADR-0016 (regex captures / `Match`) is complete.** All five phases landed between
+  2026-07-28 and 2026-07-31: absolute positions, the `CapNode` / `RegexCaptures` split
+  (immutable stored node vs. per-run accumulator — a deliberate split, not a dual model), a
+  shared `MatchTarget` with span reads, the one-list-per-axis collapse, and a lazy
+  `ValueRepr::Match(Gc<MatchNode>)`. Along the way it corrected five real compatibility bugs
+  (the four subrule-boundary constructs and search-recovered offsets for repeated text).
+  Residue is deliberate and small: `String` capture-name keys, `CodeBlockContext`'s text
+  snapshot, and eager `Match` construction in the reduce/failed-replay paths.
+  **One standing constraint the whole codebase now inherits**: a `view()`-based
+  "is it an X?" probe materializes a lazy `Match`, so variant probes on paths a `Match` can
+  reach must be tag probes. That is an invariant with no mechanical enforcement — a plausible
+  future regression, and worth a lint or a debug counter.
+- **ADR-0015 (native-backed container storage) is half-finished.** P0/P1/P2/P3a landed
+  (CStruct bodies, native-backed `Buf`/`Blob`, native-backed `CArray[T]`); **P3b**
+  (`array[T]`, which needs the `ArrayData::items` accessor chokepoint and is also the fix for
+  roast's shaped-native `array-shapes.t` T36-38) and P3c (reference-element `CArray`) are
+  open. So `Buf` and `CArray` have honest `.REPR`/`.WHERE` while `array[T]` does not — one
+  concept, two storage models, with the chokepoint refactor that would unify them still
+  unbuilt.
+
+A half-migrated representation is the most expensive shape of debt in this codebase: it
+doubles the surface every unrelated fix must satisfy and silently invites new code to pick
+the old model. That is now a statement about ADR-0015 alone — which is why §7 ranks P3b
+first among the representation items and does not schedule further regex work.
 
 ---
 
 ## 2. Correctness and soundness
 
-### 2.1 GC-era raw-pointer writes — reduced, not eliminated
+### 2.1 GC-era aliased writes — provenance UB fixed (ADR-0013); verification is the gap
 
-The GC itself (layer 3a) is done and default-on; the STW handshake races and worker
-TLS teardown race found in gc-stress were root-caused and fixed (#4410), and the
-2026-07-11 audit sweep (#4414) closed rev8's auditability concerns (stale "default
-off" headers, module-wide `#![allow(dead_code)]`, undocumented `make_mut` ordering).
-What remains:
+**Fixed since rev10.** `GcBox` now stores its payload as `value: UnsafeCell<T>`
+(`gc/gc_ptr.rs:166`), and `Gc::as_ptr` projects through it with `UnsafeCell::raw_get`
+(`gc_ptr.rs:198`). `gc_contents_mut` (`gc_ptr.rs:774`) therefore derives its `&mut` from a
+pointer that carries interior-mutable provenance while shared `&` reads are live — the
+Stacked/Tree-Borrows violation rev10 listed as roadmap item #2 is gone, at every call site
+at once and with no `Value`-representation churn (ADR-0013 §7).
 
-- **The aliased-write mechanism survives.** `gc::gc_contents_mut`
-  (`gc/gc_ptr.rs:660-663`) and `Gc::get_mut`/`make_mut` (`gc_ptr.rs:319-336`/
-  `456-502`) still write through `Arc::as_ptr as *mut` — a provenance violation plus
-  a data race whenever the target is genuinely shared. Track B T4/T5/T6
-  (#4416/#4417/#4418) cut the biggest cluster (`vm_var_assign_index_named.rs` 18→6)
-  but **~59 production call sites remain across 25 files** (rev9: ~53/21 — the count has
-  drifted *up*, not down, as new mutation paths reuse the primitive). Full removal awaits
-  the deferred `CellValue`
-  work ([docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §2). The audited old
-  primitive `arc_contents_mut` is kept dead (`value/aliased_mut.rs:69`), along with a
-  dead duplicate `gc_contents_mut` shim (`aliased_mut.rs:84`).
-- **The uniqueness-vs-buffered-clone invariant is still mostly prose.**
-  `get_mut`/`make_mut` treat `header.strong == 1` as unique while the GC candidate
-  buffer holds uncounted clones (now `Weak`, #4420); correctness rests on buffered
-  entries only being dereferenced at collect safepoints and `Gc::drop` early-returning
-  during collection. #4414 added debug asserts (`gc_ptr.rs:458-461,492`) and a
-  20-line soundness argument for the all-`Relaxed` strong-count re-link in `make_mut`
-  (`gc_ptr.rs:468-483`: the collector reads counts only under the STW SeqCst
-  handshake), but machine checking beyond that exists only under `MUTSU_GC_VERIFY`.
+What is left, in order of tractability:
+
+- **No Miri gate.** ADR-0013 §4 phase 4 defines "done" as a clean `cargo miri test` over the
+  container/GC subset, first informational then blocking. There is **no `miri` job in
+  `.github/workflows/`**. The soundness claim above is therefore an argument, not a check —
+  and the argument is exactly the kind that a borrow-model change can silently invalidate.
+- **The call-site contract is still delegated to the caller.** 59 sites across 24 files
+  (rev10: ~53/21, rev9: ~53/21 — the count keeps drifting *up* as new mutation paths reuse
+  the primitive). Provenance is fixed for all of them, but "no other borrow of this value is
+  dereferenced for the lifetime of the returned borrow" is prose per site.
+- **The cross-thread race is deferred to layer 3c** (ADR-0013 §3, resolved open question 2).
+  Concurrent structural mutation must stay routed through the synchronized shared-store
+  lanes; nothing checks that it does.
+- **Stale documentation actively misleads.** `value/aliased_mut.rs`'s module header still
+  carries a "⚠️ Known unsoundness (tracked, not removed here)" section describing the
+  `Arc::as_ptr` provenance violation as live, and still points at Track B as the future fix
+  — both untrue since ADR-0013. That file's `arc_contents_mut` is dead code kept for audit.
+  A reader looking for the current soundness posture finds the wrong answer first.
 
 ### 2.2 `RuntimeError` as a control channel — cheap now, still cohabiting
 
-`RuntimeError` (`value/error.rs:108`) still carries `return`/`last`/`next`/`take`/
-`emit` through `Result::Err`. The size problem is gone (control bools folded into
-`enum Control`; cold routing fields boxed behind `cold: Option<Box<RuntimeErrorCold>>`,
-`error.rs:85,131`; `result_large_err` allows 0), and NaN-boxing shrank the dominant
-`return_value: Option<Value>` field to 8B. Channel separation itself remains unstarted
-and low priority — note there is no `size_of` guard test for `RuntimeError` (only
-`Value` and `OpCode` are pinned), so a regression here would be silent.
+Unchanged from rev10: `RuntimeError` still carries `return`/`last`/`next`/`take`/`emit`
+through `Result::Err`. The size problem is gone (control bools folded into `enum Control`,
+cold routing fields boxed, `result_large_err` allows 0). Channel separation remains unstarted
+and low priority. Still worth noting: **there is no `size_of` guard test for `RuntimeError`**
+(only `Value`, `OpCode` and the `CapNode` leaf are pinned), so a size regression here would
+be silent.
 
 ### 2.3 Process-level robustness holes
 
-- **Deep Raku recursion — mostly fixed (rev10).** The rev9 "Rust stack overflow aborts
-  the process" hole is closed: the interpreter runs on a dedicated **256 MB-stack thread**
-  (`main.rs:99`), and the three pure-recursion integration tests (`99problems-41-to-50.t`,
-  `99problems-51-to-60.t`, `man-or-boy.t`) now pass — the whole `integration/` frontier is
-  whitelisted (§0). The one residual abort is `deep-recursion-initing-native-array.t`
-  (a 100M-element `my int @a[N;N]`), which core-dumps on **memory**, not Rust-stack depth;
-  it is the shaped-native typed-array coercion issue tracked in BLOCKERS (S02 array-shapes
-  T36-38), not a recursion-mechanism gap. A larger fixed stack is a blunt instrument, not
-  true heap frames / stack growth, so pathologically deep recursion can still overflow —
-  but it is no longer a frontier blocker.
-- **Recursive start/await hang** (2026-07-11, deterministic): after one recursive
-  `start`-chain sub completes, a second two-branch recursive `start` sub hangs —
-  suspected thread-pool worker not released (PLAN §6).
-- **Supply detached-worker panics are swallowed**; QUIT propagation is unimplemented.
+- **Deep recursion** — the interpreter runs on a 256 MB-stack thread (`main.rs:147`) and the
+  pure-recursion integration tests pass. Pathologically deep recursion can still overflow; a
+  larger fixed stack is a blunt instrument, not heap frames.
+- **`Proc::Async` stress segfault** (`todo/deep/procasync-stress-segv.md`) —
+  `roast/S17-procasync/stress.t` segfaults rarely, CI-only so far. A segfault is categorically
+  worse than a failing assertion and should not sit in a `todo/` file indefinitely.
+- **The WASM build traps** on `start` / `Channel` instead of degrading
+  (`todo/deep/wasm-start-and-channel-trap.md`).
+- **Recursive start/await hang** (deterministic) and **Supply detached-worker panics are
+  swallowed** (QUIT propagation unimplemented) — both unchanged since rev10.
+- **No thread pool at all**: 20 `spawn_user_thread` sites, each reserving 256 MiB
+  (`runtime/builtins_system.rs:9`). PLAN §6 measured the consequences (50 idle `cue(:every)`
+  timers → 52 threads / +16.4 GB VmSize). The decision this needs — what `await` does to a
+  pooled worker, given mutsu has no continuations — is still an **unwritten Proposed ADR**.
+
+### 2.4 The env-writeback cluster — many open bugs, one mechanism (new framing in rev11)
+
+rev10 treated §1.3 as a performance item. Re-reading the open `todo/` findings makes a
+stronger case: a large share of the *correctness* backlog shares one root — locals are
+mirrored into a name-keyed env, and consumers write that mirror back wholesale.
+
+Findings that reduce to it:
+
+- `todo/deep/closure-capture-shadowed-by-colliding-callee-parameter.md` — a caller's closure
+  loses its capture to a same-named callee parameter.
+- `todo/deep/captured-outer-pair-container-alias.md` — captured outer variables snapshot in
+  `Pair` values.
+- `todo/deep/closure-env-capture-cost.md` — closure creation materializes the world.
+- `todo/tickets/whenever-owned-lexical-outlives-the-react-block.md`,
+  `todo/tickets/supply-block-lexical-leaks-through-thread-lane.md`,
+  `todo/tickets/schedule-on-whenever-env-loss.md` — `WheneverScope` bodies, which are exactly
+  one of the five blanket triggers.
+- `todo/tickets/forward-captured-code-var-snapshot.md` — a forward-captured `&`-lexical is
+  snapshotted as `Nil`.
+- PLAN §6's "a joined `start` block writes its stale captured env back over a variable
+  declared after it", where PLAN itself already concludes the fix "belongs with the
+  cell-based capture work, not a special case at the call sites".
+
+Each has been triaged as "not a small slice" *individually*, which is the signature of a
+shared mechanism. Fixing them one at a time is not merely slow — each local fix adds another
+consumer of the mirror and makes the eventual campaign harder.
 
 ---
 
@@ -290,112 +351,161 @@ and low priority — note there is no `size_of` guard test for `RuntimeError` (o
 
 ### 3.1 Statement/expression dual compilation of control constructs
 
-Each control construct still has separate stmt-form and expr-form compilers:
-`compile_do_block_expr`/`_scoped`, `compile_do_if_expr_bound`, `compile_do_for_expr`,
-`compile_do_while_expr`, `compile_do_loop_expr` (`compiler/helpers_do_expr.rs:4,63,
-103,160,323,350`) duplicate `stmt.rs` logic with subtle differences — e.g. the
-21-field `ForLoopSpec` construction is maintained twice. Fix: one value-returning
-pass.
+Unchanged: `compiler/helpers_do_expr.rs` (476 lines, 6 `compile_do_*` entry points)
+duplicates `stmt.rs` logic for do/if/for/while/loop in expression position, including a
+21-field `ForLoopSpec` construction maintained twice. Fix remains one value-returning pass.
 
 ### 3.2 Sub declaration registered twice
 
-`SubDecl` both registers an AST body (`RegisterSub`) **and** compiles the body
-(`compile_sub_body`) — the registration side is load-bearing for §1.1's declaration
-registration. Collapses when declaration registration is compiled.
+`SubDecl` both registers an AST body (`RegisterSub`) and compiles the body
+(`compile_sub_body`). Collapses when §1.1's declaration registration is compiled.
 
 ### 3.3 Method dispatch: many entry points, scattered name matching
 
 Entry points remain unconsolidated: `call_method_with_values`
-(`runtime/methods_call_dispatch.rs:15`), `dispatch_method_by_name_{1,2,3}`
-(`runtime/methods_dispatch_match.rs:14`, `match2.rs:8`, `match3.rs:9`),
-`run_instance_method` (`runtime/class_dispatch.rs:11`), `native_method_{0,1,2}arg`
-(`builtins/`). Same-name string matches stay scattered (`"elems"` in 8+ files).
-Resolution *caching* landed (§1.1); the consolidation into a single type×method
-dispatch table has not, and it is also what would let §4-1's method tables be derived
-instead of maintained.
+(`runtime/methods_call_dispatch.rs:50`), `dispatch_method_by_name_{1,2,3}`
+(`runtime/methods_dispatch_match.rs:14` and siblings), `run_instance_method` /
+`run_instance_method_celled` (`runtime/class_dispatch.rs:52,90`), `native_method_{0,1,2}arg`
+(`builtins/`). Same-name string matches stay scattered — `"elems"` appears in **33 files**
+(rev10: 8+). `runtime/methods_call_dispatch.rs` is now 3875 lines.
+
+Consolidation into a single type×method dispatch table is what would also let §4-1's hand
+tables be derived, and what would give §1.9's user HOWs a single place to intercept.
 
 ---
 
 ## 4. Hardcode / drift risks
 
-No test-specific hardcoded outputs found (re-checked at rev8; nothing new since).
-Two known derivation shortcuts remain:
+No test-specific hardcoded outputs found (re-checked). Two derivation shortcuts remain:
 
-1. **`.^methods`/`.^can`/`.^mro` tables are hand-maintained** — but centralized in the
-   single canonical module `builtins/builtin_type_methods.rs` (874 lines), guarded by
-   structural tests and `t/can-methods-drift.t`. True derivation from dispatch awaits
-   §3.3's unified table.
-2. **Parser grammar relaxations for roast** (minor, present):
-   `parser/stmt/decl/helpers.rs:30` (`is List` type-ish traits),
-   `parser/primary/misc/colonpair.rs:73` (Test::Assuming),
-   `parser/stmt/stmtlist.rs:337,394` + `parser/stmt/control.rs:72` (`throws-like`
-   trailing-`)` special form).
+1. **`.^methods`/`.^can`/`.^mro` tables are hand-maintained** — centralized in
+   `builtins/builtin_type_methods.rs` (960 lines, rev10: 874) and guarded by structural tests
+   plus `t/can-methods-drift.t`. True derivation awaits §3.3. The growth rate matters now
+   that §1.9 lets user code introspect through the same surface.
+2. **Parser grammar relaxations for roast** (minor, unchanged): `is List` type-ish traits,
+   the Test::Assuming colonpair, and the `throws-like` trailing-`)` special form.
 
 ---
 
 ## 5. Value model, performance, robustness
 
 - **State outside the value (unchanged)**: Failure handled/pending registries are
-  `thread_local!` (`value/mod.rs:361,398`) and lose registration across thread
-  boundaries; pending DESTROY queues likewise (fire-trigger is GC `Trace::finalize`,
-  double-fire guarded). Seq consumed/cached/lazy state is O(n) linear scans of
-  `OnceLock<Mutex<Vec<Weak>>>` statics (`value/mod.rs:18,25,40`) plus
-  `CONSUMED_LAZYLISTS` (`value/mod.rs:76`). Fragile and slow.
-- **Env**: COW `Arc<FxHashMap<Symbol,Value>>` with a scoped parent-overlay chain
-  capped at `MAX_OVERLAY_DEPTH=16` (`env.rs:303`). The 2026-07-12/14 perf slices
-  (#4463, #4492–#4495, #4506–#4508) removed the worst interning/SipHash/COW churn on
-  the declaration path; the structural remainder is §1.3's `needs_env_sync` blanket
-  and `BlockScope` clone.
-- **`.clone()` ≈ 9056** (rev9: 8947): each is now an 8-byte NaN-box copy
-  (+ refcount for container tags), so the unit cost collapsed, but useless-clone
-  pruning (3b-2 "traffic pruning", gc-post-3a-roadmap §3.3) is still open,
-  profile-driven.
-- **`unwrap`/`expect`/`panic!`/`unreachable!` ≈ 1789 (+30)** and
-  **`#[allow(` 170 (+5)**: mostly invariant asserts/tests, but the upward trend
-  continues and deserves a periodic sweep. (Module-wide `#![allow]`s are gone.)
-- Allocation-failure aborts on user-sized allocations remain guarded via
-  `try_reserve`; remaining aborts are true OOM.
+  `thread_local!` and lose registration across thread boundaries; pending DESTROY queues
+  likewise. Seq consumed/cached/lazy state is O(n) linear scans of `OnceLock<Mutex<Vec<Weak>>>`
+  statics. Fragile and slow; also the root of
+  `todo/deep/cache-on-a-lazy-seq-must-not-answer-seq.md` and
+  `todo/deep/deferred-seq-materialization-destroys-the-original.md`.
+- **Env**: COW `Arc<FxHashMap<Symbol,Value>>` with a scoped parent-overlay chain capped at
+  `MAX_OVERLAY_DEPTH=16` (`env.rs:318`). The structural remainder is §1.3's blanket.
+- **`.clone()` ≈ 10192** (rev10: 9056): each is an 8-byte NaN-box copy plus a refcount for
+  container tags, so the unit cost is low, but the growth is a code-shape signal, not just a
+  perf one.
+- **`unwrap`/`expect`/`panic!`/`unreachable!` ≈ 1908 (+119)** and **`#[allow(` 178 (+8)**.
+  PLAN §8.3's "mutsu must never Rust-panic on any input" goal is in tension with a metric
+  that has risen every revision.
+- Allocation-failure aborts on user-sized allocations remain guarded via `try_reserve`.
 
 ---
 
 ## 6. Repository hygiene
 
-- **500-line rule**: **62 files >1000 lines, 239 files >500** (rev9: 57 / 210).
-  Largest: `vm/vm_exec_dispatch.rs` 4490, `opcode.rs` 4237,
-  `runtime/methods_call_dispatch.rs` 3569, `compiler/stmt.rs` 3424,
-  `vm/vm_var_assign_index_named.rs` 3124 (a new top-5 entry, displacing
-  `runtime/regex_parse_core.rs`). Giant dispatch matches stay intentional exceptions, but
-  `runtime/mod.rs` re-grew to **2470** lines (rev7: 1932 → rev8: 2118 → rev9: 2309) — the
-  facade slim-down flagged three revs running is now overdue.
-- Stale comment references to the old `MUTSU_SHADOW_SLOTS` opt-in gate survive in
-  `opcode.rs:1441,1671,1692` and `vm_register_ops.rs:81,547` — the gate is now the
-  opt-out `MUTSU_NO_SHADOW_SLOTS` (§1.3); worth a doc sweep.
+- **500-line rule**: **80 files >1000 lines, 300 files >500** (rev10: 62 / 239; rev9:
+  57 / 210). Total `src/` is ~427k lines. Largest: `opcode.rs` 4823,
+  `vm/vm_exec_dispatch.rs` 4646, `runtime/methods_call_dispatch.rs` 3875,
+  `compiler/stmt.rs` 3775, `runtime/regex_parse_core.rs` 3698,
+  `vm/vm_var_assign_index_named.rs` 3542, `parser/expr/postfix/loop_.rs` 3260,
+  `runtime/registration_class_decl.rs` 2882. Giant dispatch matches remain intentional
+  exceptions; the other seven are not. `runtime/mod.rs` is **2495** lines (rev7 1932 → rev8
+  2118 → rev9 2309 → rev10 2470) — flagged for four consecutive revisions, never actioned.
+  The rule as written ("split immediately") is not being followed, so either the rule or the
+  practice should change deliberately rather than by drift.
+- **Stale docs that assert the opposite of the code**: `value/aliased_mut.rs`'s unsoundness
+  header (§2.1), and the comment references to the retired `MUTSU_SHADOW_SLOTS` opt-in gate
+  (now the opt-out `MUTSU_NO_SHADOW_SLOTS`).
 
 ---
 
 ## 7. Recommended roadmap (priority order)
 
-rev9's #1 — the deep-recursion process abort — is done (256 MB-stack thread; the
-`integration/` frontier cleared, §2.3). Everything that topped rev8's table (Track B tail
-T4-T6, the GC auditability sweep, NaN-boxing) was already done. Remaining, aligned with
-PLAN.md:
+rev10's #1 (lexical-slot endgame) is still open; rev10's #2 (`gc_contents_mut` UB) is
+mechanically **done** and drops to a verification task. The ordering below is derived from
+debt shape and dependency, not from profile share — per PLAN's 2026-07-16 priority reset,
+performance is polish and is not used as a ranking criterion here.
 
-| # | Item | Kind | Impact |
-|---|------|------|--------|
-| 1 | **Lexical-slot endgame as one fused campaign**: `needs_env_sync` blanket removal → by-name fallback retirement → `BlockScope` full-clone removal (§1.3; also the top remaining perf lever per the fib profile) | correctness + perf | large |
-| 2 | **`gc_contents_mut` residue inventory** (~59 sites, trending *up*; route through cells or `make_mut`-style COW, §2.1) + buffered-clone invariant hardening | soundness (UB) | medium |
-| 3 | **RakuAST completion** (Phase 6 macros/`quasi`, type-registry breadth beyond the covered node set, §1.7) — the largest active campaign | feature | medium |
-| 4 | Scouted perf slices: `compiled_fns` SipHash removal, callsite-line marker removal (PLAN §5 items 1-2) | perf | medium |
-| 5 | Declaration registration → bytecode; dispatch entry consolidation into a type×method table (also retires §4-1's hand tables) (§1.1/§3.3) | design | medium |
-| 6 | Opcode remainder, measurement-gated (§1.4); recursive start/await hang, shaped-native array coercion (§2.3) | perf / robustness | low-medium |
-| 7 | Control-channel separation (§2.2); Supply panic → QUIT (§2.3) | design / robustness | low |
-| 8 | Hygiene: `runtime/mod.rs` re-slim (2470 lines, overdue), file splits (239 >500), clone/unwrap trend sweep, stale gate-name comments (§5/§6) | hygiene | low-medium |
+The ranking rule, stated so it can be argued with:
 
-*(JIT J4d — Tier B variable-op inlining — completed 2026-07-15; ADR-0004 closed, #4543. See §1.5.)*
+1. **First, mechanisms that many open bugs share a root in** — one campaign closes a
+   backlog, whereas N local fixes grow it *and* make the campaign harder, because each fix
+   adds a consumer of the mechanism being replaced.
+2. **Then finish half-migrated representations** — they double the surface every unrelated
+   fix must satisfy and silently recruit new code into the old model.
+3. **Then the subsystem whose deferral cost is rising**, i.e. where new feature work keeps
+   landing on uncompiled/unconsolidated code (declaration registration and dispatch, now
+   carrying the MOP).
+4. **Then close verification gaps on already-fixed soundness** — cheap, and the alternative
+   is an unverified argument that a refactor can silently invalidate.
+5. Long-tail cleanups last — but stop the *trend* items from compounding while doing 1-4.
+
+| # | Item | Kind | Why here |
+|---|------|------|----------|
+| 1 | **The env-writeback / lexical-slot fused campaign** — `captures_env_by_name` blanket → precise per-slot sync for its five consumers → `BlockScope` restore → closure capture cells (§1.3, §1.2, §2.4) | **correctness** + perf | Re-ranked from rev10's "top perf lever" to "the largest correctness cluster": at least seven open `todo/` findings reduce to this one mechanism, each individually triaged as "not a small slice". Fixing them separately is not merely slow — each local fix adds another consumer of the mirror. Needs a Proposed ADR first (five mechanisms are known to break on a standalone change). |
+| 2 | **Finish ADR-0015 P3b** (`array[T]` behind the `ArrayData::items` accessor chokepoint) (§1.10) | representation | The one genuinely half-migrated representation left: `Buf`/`CArray` are native-backed with honest `.REPR`/`.WHERE`, `array[T]` is not. The chokepoint refactor is the shared prerequisite, and P3b is simultaneously the fix for roast's shaped-native `array-shapes.t` T36-38 — the last roast item with real leverage. |
+| 3 | **Declaration registration → bytecode, and dispatch-entry consolidation into one type×method table** (§1.1, §3.3; retires §4-1's hand tables) | design | Was a standing "medium" item; the MOP campaign (§1.9) turned it into a *growth surface* — the user HOW protocol now runs inside AST-walking registration (`registration_class_decl.rs` 2882 lines), and `"elems"`-style scattered name matching spread from 8 files to 33. Every further batteries/MOP feature pays interest here, so the cost of deferring is rising rather than flat. |
+| 4 | **Exception-class hierarchy registration** (124 core `X::` classes unregistered, `todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`) | design | A registry/data-model job, not a pile of small fixes, and the prerequisite for PLAN §8.4 error/exception parity — the QA axis that replaced roast as the compatibility signal. |
+| 5 | **Close ADR-0013**: add the Miri job (informational → blocking), correct the stale unsoundness docs in `value/aliased_mut.rs`, then take the layer-3c cross-thread-race decision explicitly (§2.1) | soundness verification | The mechanism is fixed; the *check* that keeps it fixed does not exist. What shipped is an argument about borrow provenance, and that is exactly the kind of thing a later refactor invalidates with no observable failure. Cheap relative to that risk. |
+| 6 | **Concurrency substrate**: write the shared worker-pool Proposed ADR (still unwritten), then the `Proc::Async` stress segfault, Supply panic → QUIT, and WASM `start`/`Channel` degradation (§2.3) | robustness | 20 spawn sites × 256 MiB is a structural resource decision currently being made by default. Within this row the segfault outranks the rest — a crash is categorically worse than a wrong answer. |
+| 7 | **Guard the ADR-0016 invariant** (§1.10): a `view()`-based variant probe materializes a lazy `Match`. Add a debug counter or lint rather than leaving it as prose | correctness (regression prevention) | Small, but it protects a campaign that just finished; unguarded invariants of this shape are how completed migrations quietly un-finish. |
+| 8 | **Statement/expression dual compilation** (§3.1) and the measurement-gated opcode remainder (§1.4) | design / perf | Genuine duplication, but bounded and stable — it is not growing the way #3 is. |
+| 9 | **RakuAST completion** (`todo/deep/rakuast-remaining.md`, ADR-0011 Phase 6) | feature | Demoted from rev10's #3: no roast file and no bundled battery consumes it, so it is the one large campaign with no downstream dependency. Pick node classes by user impact, as the ticket itself says. |
+| 10 | **Hygiene, treated as a trend not a chore**: `runtime/mod.rs` re-slim (2495, flagged 4 revisions running), the 300/80 file-size population, the `unwrap`/`clone` slopes, the stale-doc corrections (§5, §6) | hygiene | Every metric here has worsened monotonically for three revisions, which means the current practice is not the stated rule. The actionable form is to fix the trend on files that #1-#4 touch anyway, and to decide deliberately whether the 500-line rule still stands. |
+
+Explicitly **not** ranked as architecture work in rev11: roast whitelist chasing (mined out,
+PLAN §4), and perf levers with no goal-item consumer (PLAN §5 header). Both remain available
+as opportunistic work when an item above happens to unblock them.
 
 ---
 
-*Based on static close reading plus live reproduction.*
-*rev10 (2026-07-19): re-verified against HEAD (#4811) after 259 commits; integration
-frontier cleared, deep-recursion fixed, RakuAST layer (§1.7) added, hygiene re-measured;
-resolved items archived to [news/2026-07.md](news/2026-07.md).*
+## 8. ADR ledger review (new in rev11)
+
+Reviewed all 17 ADRs against the tree. The decisions themselves hold up — no ADR was found
+to be *wrong*. The systematic problem is that **an ADR's recorded status drifts from what
+shipped**, because implementation progress is reported in `news/` and PLAN.md but not folded
+back into the ADR that owns the decision. That defeats the ADR's stated purpose (preserving
+the judgment context) for anyone who reads the ADR first.
+
+Actions taken in this revision (each ADR updated in place with a progress/outcome record):
+
+| ADR | Drift found | Action |
+|---|---|---|
+| 0001 GC strategy & phasing | Status still listed §4.2 (trigger) and §4.3 (A' scope) as open; §4.2 was decided by ADR-0003, and layers 3a/3b/4 have all shipped. Its standing guidance "do not start Track B standalone; it is fused with GC" was superseded by ADR-0013 §7, which fixed the same sites at the primitive. | Added §7 "Outcome (2026-08-02)"; status line updated to point at it. |
+| 0007 trail matcher | Recorded its own implementation outcome, but its explicitly deferred "per-subrule ceremony" became ADR-0016 with no forward pointer. | Added the successor link and marked the P2-P3 phasing superseded. |
+| 0011 RakuAST | Status read "Phase 1 implemented (PR #4679); Phases 2-6 pending" while Phases 2-5 had substantially landed across ~37 slices. | Status corrected; pointer to `todo/deep/rakuast-remaining.md` as the live gap list. |
+| 0013 container interior mutability | Status was accurate about the *decision*, but §4's phasing did not record that the primitive change shipped, and the README index still listed it `Proposed`. The undone phase (Miri) was indistinguishable from the done ones. | Added §8 "Implementation status"; index corrected. |
+| 0015 native-backed storage | Phase markers were inline ("landed"/"open") but the status line gave no summary, so the campaign's state required reading the whole ADR. | Status line now carries the P0-P3c state. |
+| 0016 span-based captures | Status `Proposed` while **all five phases** had shipped to `main` — a fully-implemented ADR still labelled as a proposal, which is the most misleading drift found in this review (it invites a reader to re-litigate a decision that is already executed). | Promoted to `Accepted`; the phase state, the deliberate residue, and P5's standing `view()`-probe constraint summarized at the top. |
+| 0003, 0004, 0005, 0006, 0009, 0010, 0012, 0014, 0017 | Accurate; 0004 and 0009 already carry closing addenda. | No change. |
+| 0002 | Historical gate record; still accurate. | No change. |
+
+Two **missing** ADRs are worth writing, and are listed here rather than drafted unilaterally:
+
+1. **A shared worker pool** — PLAN §6 has specified its content in detail for over two weeks
+   ("the central question is not pool sizing — it is what `await` does to a pooled worker"),
+   and the decision is being made by default in the meantime (20 spawn sites, 256 MiB each).
+2. **The batteries adoption policy** — "grow the interpreter until the real upstream module
+   runs verbatim (rung 2); native provision (rung 3) is banned" is a load-bearing,
+   costly-to-reverse decision recorded only in `BATTERIES.md` and CLAUDE.md as a user
+   decision. Its rejected alternative (native reimplementation) and its named exceptions
+   (NativeCall, JSON::Fast, Test) are exactly the "why, and what we rejected" an ADR exists
+   to preserve. The companion measurement — "do not build an `nqp::` op layer" — belongs in
+   the same record.
+
+A third, **the env-writeback campaign** (§7-3), needs a Proposed ADR *before* implementation
+starts, per the repository's own rule for high-blast-radius mechanism changes.
+
+---
+
+*Based on static close reading plus live verification against HEAD.*
+*rev11 (2026-08-02): re-verified against `c65835e13` after 1096 commits; ADR-0013 recorded as
+landed, the bundled-module (§1.8) and MOP (§1.9) subsystems added, the representation
+campaigns (§1.10) and the env-writeback correctness cluster (§2.4) named, §7 re-prioritized
+around the latter, and §8 ADR-ledger review added.*

--- a/PLAN.md
+++ b/PLAN.md
@@ -455,20 +455,20 @@ the shared+identity case. So:
   before each aliased `&mut` in `vm_var_assign_ops.rs` (fixup_circular_hash / replace_array_refs_in_value /
   fixup_circular_array_refs) to document provable uniqueness. Zero behavior change (debug-only assert);
   the truly-unaudited surface is now just the 51 (c) core.
-- [ ] **Step 3 — the 51 (c) sites = a `CellValue` / interior-mutability campaign** (large,
-      high-blast-radius, **not** a slice) — **DEFERRED (user decision 2026-07-20)**. A first-class
-      element cell (`UnsafeCell`/lock inside the container) makes identity-preserving in-place
-      mutation sound without the raw-pointer cast. **Fused with ADR-0001** (Track B / element cells +
-      GC — do not touch the sites twice); needs a Proposed ADR before starting. This is the only path
-      that removes the UB. Deferred because it is a large architectural commitment for a *soundness*
-      (not correctness/feature) payoff, while 3a already closed the leak that made GC table-stakes;
-      the residue is UB-by-letter + a cross-thread data race that has passed gc-stress/S17 so far.
-      **The mechanism framing is now drafted in [ADR-0013](../docs/adr/0013-container-interior-mutability-cellvalue.md)
-      (Proposed)** — a `GcCell` = `UnsafeCell` + debug/verify borrow-flag newtype that converts the
-      51 sites from a raw-pointer cast to a sound aliased borrow (reads stay `&T`, so zero read-path
-      cost; Miri becomes the acceptance gate), rejecting the whole-container lock (read tax +
-      re-entrancy deadlock) and deferring the narrow cross-thread race to layer 3c. On greenlight,
-      flip ADR-0013 to Accepted and begin at its §4 phase 1.
+- **✅ Step 3 — the (c) sites: PROVENANCE UB FIXED (ADR-0013, landed).** Not the deferred
+      `CellValue` campaign this entry used to describe: per
+      [ADR-0013](docs/adr/0013-container-interior-mutability-cellvalue.md) §7 the `UnsafeCell`
+      was placed in `GcBox.value` (`src/gc/gc_ptr.rs:166`) instead of wrapping each container
+      payload, so **every** `Gc<T>` is interior-mutable at the primitive and all the aliased-write
+      sites became provenance-sound *with no call-site or `Value`-representation churn*. The
+      per-container migration and the `GcCell` newtype were dropped; the fusion-with-Track-B
+      premise no longer applies (ADR-0001 §7).
+- [ ] **Step 3b — close ADR-0013: the Miri gate (§4 phase 4) is still missing.** There is no
+      `miri` job in `.github/workflows/`, so the soundness claim above rests on an argument, not
+      a check. Add it informational-first, then blocking (pin a nightly matching the crate's
+      stabilized-feature usage). Also correct `src/value/aliased_mut.rs`'s module header, which
+      still documents the provenance violation as live and names Track B as the future fix — both
+      false since ADR-0013. The narrow cross-thread race stays deferred to layer 3c by decision.
 - **✅ Step 4 (independent) DONE (2026-07-20)** — hardened the buffered-clone / uniqueness
       invariant. `Gc::verify_unique_for_aliased_mut` machine-checks the `strong == 1 ⟹ unique`
       argument that `make_mut` / `get_mut` and the three (a) `gc_contents_mut` sites rely on, by
@@ -939,10 +939,10 @@ unification / the malloc clusters from `Value` clone/drop and attribute material
       same mechanism as the `named-sub free-var shadow` / dual-store family, not a `Promise` bug.
       The fix belongs with the cell-based capture work above (write back only what the thread
       actually mutated), not with a special case at the `allof`/`anyof` call sites.
-- [ ] Eliminate raw-pointer aliased writes: the old `arc_contents_mut` is dead code now, and the
-      production path moved to `gc::gc_contents_mut` / `Gc::{get,make}_mut` (the unsoundness was
-      moved, not resolved — ANALYSIS rev8 §2.1). With Track B T4–T6 done (news/2026-07.md), start
-      from an inventory of what actually remains.
+- ✅ Eliminate raw-pointer aliased writes — **done via ADR-0013** (the `UnsafeCell` moved into
+      `GcBox`, so `gc::gc_contents_mut` / `Gc::{get,make}_mut` derive interior-mutable provenance).
+      What is left is verification, tracked as §2.1 Step 3b (the Miri gate) — not another
+      inventory.
 - [ ] **★Remove the full locals clone/restore in `BlockScope`** (the final move of the lexical-scope
       slot campaign [docs/lexical-scope-slot-campaign.md](docs/lexical-scope-slot-campaign.md);
       **the perf core** — the root of the malloc/free churn and `Env::get_sym` shown by the #4489

--- a/docs/adr/0001-gc-strategy-and-phasing.md
+++ b/docs/adr/0001-gc-strategy-and-phasing.md
@@ -1,6 +1,6 @@
 # ADR-0001: GC adoption — mechanism selection and phasing
 
-- **Status**: Accepted (2026-06-27 — level 1 adopted. The collection-trigger mechanism §4.2 and the A' scope §4.3 remain open)
+- **Status**: Accepted (2026-06-27 — level 1 adopted). **Outcome recorded in §7 (2026-08-02): layers 3a / 3b / 4 have all shipped and are default on; §4.2 was decided by [ADR-0003](0003-default-on-gc-trigger.md); the "Track B is fused with GC, do not start it standalone" rule is superseded by [ADR-0013](0013-container-interior-mutability-cellvalue.md) §7. Only §4.3 (A' scope) and layer 3c remain open.**
 - **Date**: 2026-06-27
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ANALYSIS.md](../../ANALYSIS.md) §2.1 / §1.3 / §5, [PLAN.md](../../PLAN.md) §G(perf) / §I(Track C)
@@ -199,4 +199,45 @@ The deciding factor is that as long as the env HashMap remains on the root path,
 
 ---
 
-*This ADR records the design discussion of 2026-06-27. If the judgment changes, supersede it with a new ADR.*
+---
+
+## 7. Outcome (added 2026-08-02)
+
+This section records what actually shipped against §3's phase plan, so a reader does not
+have to reconstruct it from `news/` and PLAN.md. The *decisions* in §3 are unchanged; only
+their state is reported here.
+
+| Layer | State |
+|---|---|
+| **A. Catch up** (compat + single-thread speed) | ✅ Done — gate assessed in [ADR-0002](0002-phase-a-gate-reassessment.md) (2026-07-03). |
+| **A'. Root consolidation** (§4.3) | ◐ Partly. Shadow slots are default on and the whole-`locals` per-block clones are gone, but env is still on the root path — the `captures_env_by_name` blanket (`opcode.rs:2608`) keeps every local mirrored by name for any frame containing a loop/block/gather/whenever op. This is the open remainder of §4.3, tracked as ANALYSIS §1.3 / §7-3. |
+| **3a. Cycle collector on `Arc`, type-filtered** | ✅ Done, default on (2026-07-05). Trigger mechanism = [ADR-0003](0003-default-on-gc-trigger.md) — **this closes open question §4.2**. |
+| **3a (element cells / Track B half)** | ✅ Resolved differently — see below. |
+| **3b. NaN-boxing** (`size_of::<Value>()` 48→8B) | ✅ Done (2026-07-12), encoding fixed by [ADR-0005](0005-nanbox-representation-encoding.md). |
+| **3c. Biased reference counting** | 🧊 Frozen. Start trigger is unchanged: atomic inc/dec still near the top of the profile after the JIT work. It also owns the deferred cross-thread-race half of ADR-0013. |
+| **4. JIT (Cranelift)** | ✅ Done, default on (2026-07-13); phase plan fulfilled and [ADR-0004](0004-jit-strategy.md) closed (2026-07-15). |
+
+### §5's Track B rule is superseded
+
+§5 told agents: *"Do not start Track B standalone ahead of time. Change the premise to
+integrating it with GC (layer 3a) … one-shot `Arc→Gc` replacement."* The `Arc → Gc`
+replacement shipped; the element-cell half did not, and it was then solved by a **different
+mechanism** than this ADR anticipated: [ADR-0013](0013-container-interior-mutability-cellvalue.md)
+put an `UnsafeCell` in `GcBox` itself, which made all ~59 aliased-write sites
+provenance-sound at the primitive without any per-container migration. So:
+
+- **The "touch the ~79 sites twice" waste argument that motivated the fusion no longer
+  applies** — the sites were not touched at all.
+- **Track-B-style first-class element cells are no longer a prerequisite for soundness.**
+  They remain a *possible* future refinement (per-element identity), but they must be
+  justified on their own merits in a new ADR, not inherited from this one.
+- What genuinely remains of the "one campaign" framing is the **env/lexical** half (A',
+  above), which is a compiler/VM concern, not a GC one.
+
+Agents should therefore read §5's Track B rule as historical. The live guidance is: GC
+mechanism decisions belong to this ADR, container-write soundness to ADR-0013, and the
+lexical-slot/env campaign to its own (not yet written) ADR.
+
+---
+
+*This ADR records the design discussion of 2026-06-27; §7 records the 2026-08-02 outcome. If the judgment changes, supersede it with a new ADR.*

--- a/docs/adr/0007-grammar-parse-trail-matcher.md
+++ b/docs/adr/0007-grammar-parse-trail-matcher.md
@@ -1,6 +1,12 @@
 # ADR-0007: Grammar/regex matcher — cursor + undo-log (trail) to kill capture-threading churn
 
-- **Status**: Accepted (2026-07-16) — implemented in #4591
+- **Status**: Accepted (2026-07-16) — implemented in #4591. **Successor: the "residual
+  per-subrule ceremony" this ADR explicitly deferred (see §Implementation outcome) is decided
+  and fully implemented by [ADR-0016](0016-span-based-captures-and-lazy-match.md) (span-based
+  captures + lazy `Match`, P1–P5 landed 2026-07-28…31).** Read ADR-0016 before touching the
+  capture representation; this ADR's own §Phasing P2/P3 (lazy all-ends generators, removing
+  by-value `RegexCaptures` threading) describe the *pre-ADR-0016* data model and are
+  historical — the trail/`CapStore` mechanism decided here is unchanged and still current.
 - **Context**: PLAN §5 grammar-parse performance. Follows the incremental Arc-shared
   sub-captures slice (#4586) and the exponential/ceremony fixes (#4556, #4559).
 

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -1,6 +1,16 @@
 # ADR-0011: RakuAST — a reflection/model layer over the internal AST, and its phasing
 
-- **Status**: Accepted (2026-07-18). Phase 1 implemented (PR #4679); Phases 2–6 pending.
+- **Status**: Accepted (2026-07-18). **Progress (2026-08-02): Phases 1–5 have substantially
+  landed** across ~37 slices (PRs #4679, #4729–#4804 and successors) — read (`Q[…].AST` +
+  `.gist`), the type-object registry, construction, and `EVAL($tree)` lowering through the
+  existing compiler all work, pinned by dual-oracle `t/rakuast-*.t` files that pass under
+  both mutsu and raku. **Phase 6 (macros / `quasi`) is not started, and each landed phase
+  still has an explicit gap list** — the live inventory is
+  [`todo/deep/rakuast-remaining.md`](../../todo/deep/rakuast-remaining.md) (read-direction
+  representation gaps the parser desugars away, advanced parameter construction, and the
+  lowering constructs blocked on representation mismatches). Note for planning: no roast
+  file and no bundled battery consumes this layer, so its remaining work has no downstream
+  dependency (ANALYSIS §7-9).
 - **Context**: The user asked to implement RakuAST. RakuAST is Raku's user-facing AST
   representation (`RakuAST::*` classes, `Q|...|.AST`, `.DEPARSE`, `EVAL(ast)`, and the
   macro/`quasi` machinery built on top). It has essentially **zero roast payoff today**

--- a/docs/adr/0013-container-interior-mutability-cellvalue.md
+++ b/docs/adr/0013-container-interior-mutability-cellvalue.md
@@ -268,5 +268,45 @@ unchanged; only the pointer it derives now carries interior-mutable provenance.
 
 ---
 
-*This ADR is Accepted (mechanism 2b; placement per §7). If the mechanism judgment changes later,
-supersede this ADR rather than rewriting it.*
+---
+
+## 8. Implementation status (added 2026-08-02)
+
+§4's phasing collapsed per §7, so the campaign is now two items — one shipped, one not. Recorded
+here because the ADR previously gave no way to tell them apart.
+
+**✅ Shipped — the primitive change.** `GcBox` stores its payload as `value: UnsafeCell<T>`
+(`src/gc/gc_ptr.rs:166`); `Gc::as_ptr` projects through it with `UnsafeCell::raw_get` and no
+intermediate reference (`gc_ptr.rs:198`); `Gc`'s `Deref` reads through `UnsafeCell::get`;
+`unsafe impl<T: ?Sized + Sync> Sync for GcBox<T>` restores the pre-cell `Sync` posture
+(`gc_ptr.rs:169-176`). `gc_contents_mut` (`gc_ptr.rs:774`) is byte-identical in body but now
+derives its `&mut` from an interior-mutable pointer, so **problem §1.3-1 (provenance UB) is
+fixed at every call site at once**, with the `Value` representation, the NaN-box encoding and
+all call sites untouched — exactly as §7 predicted. Site count as of 2026-08-02: **59 across 24
+files** (the inventory's 54/20 has drifted up as new mutation paths reuse the primitive; the
+drift is expected and harmless now that the primitive is sound, but it means the number in
+`docs/gc-contents-mut-inventory.md` is a snapshot, not a budget).
+
+**❌ Not shipped — §4 phase 4, the Miri gate.** There is no `miri` job in
+`.github/workflows/`. This matters more than a normal missing test: what shipped is an
+*argument* about borrow provenance, and an argument of that kind is precisely what a future
+refactor can invalidate without any observable failure. Until the gate exists, this ADR's
+definition of done is unmet. The toolchain note in §4 still applies (pin a nightly whose
+feature set matches the crate's stabilized-feature usage); start informational, then blocking.
+
+**Deferred by decision, not by omission** — problem §1.3-2, the narrow cross-thread race on a
+genuinely shared node, remains routed to ADR-0001 layer 3c (§5 open question 2). The safety
+contract on `gc_contents_mut` states the obligation ("concurrent structural mutation from
+another thread remains routed through the synchronized shared-store lanes"), and nothing
+mechanically checks it.
+
+**Documentation debt this ADR created.** `src/value/aliased_mut.rs`'s module header still
+carries a "⚠️ Known unsoundness (tracked, not removed here)" section describing the
+`Arc::as_ptr` provenance violation as live and naming Track B as the future fix. Both
+statements are false since this ADR landed. That header is the first thing a reader looking
+for the current soundness posture finds; correcting it is part of closing this ADR.
+
+---
+
+*This ADR is Accepted (mechanism 2b; placement per §7; status per §8). If the mechanism judgment
+changes later, supersede this ADR rather than rewriting it.*

--- a/docs/adr/0015-native-backed-container-storage-and-repr-bodies.md
+++ b/docs/adr/0015-native-backed-container-storage-and-repr-bodies.md
@@ -3,6 +3,14 @@
 - **Status**: Accepted (2026-07-27 — tokuhirom: *make `DBIish` work even if it means changing mutsu's
   internals; move mutsu itself closer rather than building a compatibility layer that costs
   performance.* All five Open Questions resolved in §5 accordingly.)
+  **Progress (2026-08-02): P0, P1 (CStruct bodies), P2 (native-backed `Buf`/`Blob`, which took
+  `DBIish` to raku parity on all nine files) and P3a (native-backed `CArray[T]`, which put
+  `NativeHelpers::Blob` on the battery gate) have landed. P3b (`array[T]`, which needs the
+  `ArrayData::items` accessor chokepoint first and is also the fix for roast's shaped-native
+  `array-shapes.t` T36-38) and P3c (reference-element `CArray[Str]`/`CArray[Pointer]`, parity
+  polish) are open.** Until P3b lands, `Buf`/`CArray` are native-backed with honest
+  `.REPR`/`.WHERE` while `array[T]` is not — one concept, two storage models (ANALYSIS §1.10 /
+  §7-2).
 - **Date**: 2026-07-27
 - **Deciders**: tokuhirom, Claude
 - **Related**: [ADR-0001](0001-gc-strategy-and-phasing.md) (non-moving GC — what makes a stable address possible at all; the container type filter this ADR extends), [ADR-0013](0013-container-interior-mutability-cellvalue.md) (interior mutability — the write path into a shared container node), [ADR-0005](0005-nanbox-representation-encoding.md) (NaN-boxing — a new container kind must fit the existing tag scheme), [todo/deep/nativehelpers-blob-moarvm-guts.md](../../todo/deep/nativehelpers-blob-moarvm-guts.md) (the finding this ADR answers), [todo/tickets/dbiish-blockers.md](../../todo/tickets/dbiish-blockers.md) ⑨, PLAN.md §1 B1 (database battery) / §1 B4 (NativeCall remainder)

--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -1,6 +1,18 @@
 # ADR-0016: Span-based regex captures and lazily materialized `Match` objects
 
-- **Status**: Proposed (2026-07-28)
+- **Status**: **Accepted (2026-07-28; promoted from Proposed 2026-08-02 — the ADR had shipped
+  while still labelled Proposed).** **All five phases have landed**: P1 absolute positions
+  (2026-07-28), P2 `CapNode`/`RegexCaptures` split (2026-07-31), P3a `MatchTarget` + span reads
+  (2026-07-31), P4 one-list-per-axis in two layers (2026-07-31), P5 lazy
+  `ValueRepr::Match(Gc<MatchNode>)` (2026-07-31). Per-phase outcomes, measurements and the
+  behaviour corrections are recorded inline in §Phasing. **Residue, deliberately deferred and
+  not blocking** — capture names are still `String` keys (interning to `Symbol` needs a
+  Symbol-keyed hash map on the Match render path); `CodeBlockContext` keeps a text snapshot,
+  materialized from spans at its single construction site; and the reduce walk / failed
+  partial-parse replay still build eager `Match` objects for `$/` inside in-regex code blocks
+  (small counts, unchanged semantics). **Standing consequence of P5**: a `view()`-based
+  "is it an X?" probe is an anti-pattern anywhere a lazy `Match` can flow — use a tag probe,
+  or the value is materialized and the laziness is lost.
 - **Context**: ADR-0001 Phase A (single-thread speed catch-up, before GC/JIT).
   Direct follow-on to ADR-0007, which removed the *accumulated-state* clone from the
   matcher and explicitly deferred the remaining "**per-subrule ceremony**" — captured-text

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,13 +13,20 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 - 1 decision = 1 file. `NNNN-kebab-title.md` (sequential numbering).
 - **Status**: `Proposed` (under discussion / awaiting approval) / `Accepted` (final) / `Superseded by ADR-XXXX` (updated).
 - When a decision changes, **do not rewrite the existing ADR** — supersede it with a new ADR and update the old ADR's Status.
+- **Record implementation progress inside the ADR that owns the decision** — a Status suffix
+  for a short state, or an "Outcome" / "Implementation status" section for a phased one.
+  `news/` and PLAN.md are where the *work* is reported; they are not a substitute. An ADR
+  whose recorded state has drifted from what shipped defeats its own purpose: a reader who
+  starts from the ADR either re-litigates a decision that is already executed, or cannot tell
+  which of its phases are done. (The 2026-08-02 ledger review in
+  [ANALYSIS.md §8](../../ANALYSIS.md) found this drift on six of seventeen ADRs.)
 - Written in English (repo-wide English-only documentation rule).
 
 ## Index
 
 | # | Title | Status |
 |---|---|---|
-| [0001](0001-gc-strategy-and-phasing.md) | GC adoption — mechanism selection and phasing | Accepted |
+| [0001](0001-gc-strategy-and-phasing.md) | GC adoption — mechanism selection and phasing | Accepted (layers 3a/3b/4 shipped; outcome in §7) |
 | [0002](0002-phase-a-gate-reassessment.md) | Phase A gate reassessment — confirming the preconditions for starting GC | Accepted |
 | [0003](0003-default-on-gc-trigger.md) | Trigger policy for default-on GC (synchronous + buffer-size threshold + adaptive backoff) | Accepted |
 | [0004](0004-jit-strategy.md) | JIT — mechanism selection and phasing (Cranelift method JIT, no deopt) | Accepted |
@@ -29,10 +36,10 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0008](0008-push-based-supply-event-delivery.md) | Push-based supply event delivery (ReactWaker sinks) | Accepted |
 | [0009](0009-regex-code-assertion-execution-model.md) | Regex code assertions — run inline in the real interpreter, and keep LTM declarative | Accepted |
 | [0010](0010-cross-thread-lexical-sharing-scope.md) | Cross-thread lexical sharing is scoped to a spawn lineage, not the process | Accepted |
-| [0011](0011-rakuast-model-layer-and-phasing.md) | RakuAST — a reflection/model layer over the internal AST, and its phasing | Accepted |
+| [0011](0011-rakuast-model-layer-and-phasing.md) | RakuAST — a reflection/model layer over the internal AST, and its phasing | Accepted (Phases 1–5 landed; Phase 6 open) |
 | [0012](0012-libffi-macos-arm64-vendored-bump.md) | libffi on macOS arm64 — bump the vendored build, do not switch to system libffi | Accepted |
-| [0013](0013-container-interior-mutability-cellvalue.md) | Container interior mutability — kill the `gc_contents_mut` provenance UB with a `GcCell` newtype | Proposed |
+| [0013](0013-container-interior-mutability-cellvalue.md) | Container interior mutability — kill the `gc_contents_mut` provenance UB with a `GcCell` newtype | Accepted (primitive landed; Miri gate outstanding — §8) |
 | [0014](0014-make-test-runs-tap-on-debug-binary.md) | `make test` runs the TAP (`t/`) suite on the debug binary, not release | Accepted |
-| [0015](0015-native-backed-container-storage-and-repr-bodies.md) | Native-backed container storage and synthesised REPR bodies (`BODY_OF`) | Accepted |
-| [0016](0016-span-based-captures-and-lazy-match.md) | Span-based regex captures and lazily materialized `Match` objects | Proposed |
+| [0015](0015-native-backed-container-storage-and-repr-bodies.md) | Native-backed container storage and synthesised REPR bodies (`BODY_OF`) | Accepted (P0–P3a landed; P3b/P3c open) |
+| [0016](0016-span-based-captures-and-lazy-match.md) | Span-based regex captures and lazily materialized `Match` objects | Accepted (P1–P5 all landed) |
 | [0017](0017-cli-option-errors-follow-rakudo.md) | A command-line *option* error follows rakudo — message, stream, and a zero exit status | Accepted |

--- a/news/2026-08/analysis-rev11-and-adr-progress-review.md
+++ b/news/2026-08/analysis-rev11-and-adr-progress-review.md
@@ -1,0 +1,56 @@
+# ANALYSIS.md rev11 and an ADR-ledger progress review
+
+`ANALYSIS.md` was last re-verified at rev10 (2026-07-19). 1096 commits later its
+picture of the architecture had drifted far enough to mislead: it still listed the
+`gc_contents_mut` provenance UB as the #2 roadmap item (fixed since), and it described
+neither of the two subsystems that had become load-bearing in the meantime. rev11
+re-verifies every claim against HEAD (`c65835e13`) and re-derives the roadmap.
+
+## What changed in the picture
+
+- **ADR-0013 landed.** `GcBox` stores its payload in an `UnsafeCell`
+  (`src/gc/gc_ptr.rs:166`), so the ~59 deliberate aliased container writes derive a `&mut`
+  with valid interior-mutable provenance instead of casting a `*const`. rev10's soundness
+  item is mechanically closed; what remains is that **no Miri job exists**, so the claim
+  rests on an argument rather than a check.
+- **Two new subsystems are described for the first time** (§1.8, §1.9): the bundled-module
+  layer (`modules/`, 22 vendored upstream dists gated by their own upstream suites) and the
+  user-facing MOP (`EXPORTHOW::DECLARE` declarator registry, HOW-driven class registration).
+  Both matter architecturally because both push load onto the one subsystem that still
+  walks the AST — declaration registration.
+- **ADR-0016 completed** (all five phases, 2026-07-28…31), leaving one unenforced invariant:
+  a `view()`-based variant probe materializes a lazy `Match`.
+- **ADR-0015 did not** — `Buf`/`CArray` are native-backed, `array[T]` is not.
+
+## The re-prioritization
+
+The roadmap is now derived from debt shape and dependency rather than profile share (per
+PLAN's 2026-07-16 reset, performance is polish). The headline change is that the
+lexical-slot / env-writeback campaign moves to #1 **as a correctness item, not a perf one**:
+§2.4 collects at least seven open `todo/` findings — closure captures shadowed by callee
+parameters, captured-outer `Pair` snapshots, three `whenever`/supply lexical leaks, a
+forward-captured `&`-lexical read as `Nil`, and PLAN §6's `start`-block stale writeback —
+that all reduce to locals being mirrored into a name-keyed env and written back wholesale.
+Each was individually triaged as "not a small slice", which is the signature of a shared
+mechanism; fixing them separately also makes the eventual campaign harder, because every
+local fix adds another consumer of the mirror.
+
+## The ADR ledger
+
+Reviewing all 17 ADRs found no *wrong* decision, but a systematic drift: implementation
+progress gets reported in `news/` and PLAN.md and never folded back into the ADR that owns
+the decision. Six ADRs were updated in place — 0001 (an outcome section; its "Track B is
+fused with GC, do not start it standalone" rule is superseded by ADR-0013 §7), 0007 (a
+forward pointer to its successor), 0011 (Phase 1 → Phases 1–5 landed), 0013 (an
+implementation-status section separating the shipped primitive from the missing Miri gate),
+0015 (P0–P3a landed, P3b/P3c open), and 0016 (`Proposed` → `Accepted`; it had shipped
+completely while still labelled a proposal, which invites a reader to re-litigate an
+executed decision). The index in `docs/adr/README.md` carried its own drift and now records
+per-ADR progress, and the conventions section states the rule that was missing: **record
+implementation progress inside the ADR** — `news/` is where the work is reported, not a
+substitute.
+
+ANALYSIS §8 also names the two decisions that are being made by default and deserve ADRs of
+their own: the shared worker pool (PLAN §6 has specified its content for weeks while 20
+spawn sites × 256 MiB accumulate) and the batteries adoption policy (rung 2 vs. the banned
+rung 3, currently recorded only in `BATTERIES.md` and CLAUDE.md).


### PR DESCRIPTION
`ANALYSIS.md` was last re-verified at rev10 (2026-07-19). 1096 commits later its picture had drifted far enough to mislead — it still listed the `gc_contents_mut` provenance UB as the #2 roadmap item (fixed by ADR-0013), and described neither of the two subsystems that had become load-bearing since. This re-verifies every claim against HEAD (`c65835e13`) and re-derives the roadmap.

## ANALYSIS rev11

- **ADR-0013 recorded as landed** — the `UnsafeCell` lives in `GcBox` (`gc/gc_ptr.rs:166`), so the ~59 aliased container writes derive interior-mutable provenance. Residue: **no Miri job exists**, so the claim rests on an argument rather than a check; plus the layer-3c cross-thread race.
- **Two new subsystems described for the first time**: the bundled-module layer (`modules/`, 22 vendored dists gated by their own upstream suites) and the user-facing MOP (`EXPORTHOW::DECLARE`, HOW-driven registration). Both push load onto the one subsystem still walking the AST.
- **ADR-0016 complete**, leaving one unenforced invariant (a `view()` probe materializes a lazy `Match`); **ADR-0015 half-finished** (`array[T]` is not native-backed).
- **§7 re-prioritized** from debt shape and dependency, not profile share (per PLAN's 2026-07-16 reset). Headline change: the lexical-slot / env-writeback campaign moves to #1 **as a correctness item** — §2.4 collects seven open `todo/` findings that all reduce to locals being mirrored into a name-keyed env and written back wholesale, each individually triaged as "not a small slice".
- Hygiene trends re-measured: files >500 239→300, >1000 62→80, `runtime/mod.rs` 2470→2495 (flagged four revisions running), unwrap-family 1789→1908, `.clone()` 9056→10192.

## ADR review

No decision was found to be wrong. The systematic problem is that progress is reported in `news/` and PLAN.md and never folded back into the ADR that owns the decision, so six of seventeen ADRs had drifted:

| ADR | Drift | Action |
|---|---|---|
| 0001 | Listed §4.2/§4.3 open; §4.2 was decided by ADR-0003 and layers 3a/3b/4 shipped. Its "Track B is fused with GC" rule is superseded by ADR-0013 §7. | Added §7 Outcome |
| 0007 | Its deferred "per-subrule ceremony" became ADR-0016 with no forward pointer | Successor link |
| 0011 | "Phase 1 implemented; Phases 2-6 pending" while Phases 2-5 had landed | Status corrected |
| 0013 | §4 phasing did not distinguish the shipped primitive from the missing Miri gate; index said `Proposed` | Added §8 Implementation status |
| 0015 | Phase state readable only by reading the whole ADR | Status summary |
| 0016 | `Proposed` while **all five phases** had shipped | Promoted to `Accepted` |

`docs/adr/README.md` now records per-ADR progress and states the missing convention: **record implementation progress inside the ADR**. ANALYSIS §8 also names two decisions currently being made by default that deserve ADRs — the shared worker pool, and the batteries rung-2/rung-3 adoption policy.

`PLAN.md`'s GC soundness tail is corrected: Step 3 was marked DEFERRED after it had in fact landed by a different mechanism.

Docs-only, so the four heavy CI jobs skip by design (`scripts/ci-docs-only.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)