### PR TITLE
fix(runtime): a class-body `my` is a lexical of that body, not a global

### DIFF
--- a/news/2026-08/class-body-my-lexical-scope.md
+++ b/news/2026-08/class-body-my-lexical-scope.md
@@ -1,0 +1,57 @@
+# A class-body `my` is a lexical of that body, not a global
+
+`class C { my $x = ...; method m { $x } }` declares `$x` in the class body's
+lexical scope. mutsu bound it under its bare name in the *enclosing* env and
+left it there, which made every class-body static a de facto global: the next
+class body declaring the same name simply overwrote it.
+
+Worse, the damage was silent and retroactive. `inject_class_body_statics` — the
+mechanism that makes a method see its own class's statics — only filled names the
+method env did **not** already have, precisely so a parameter would take
+precedence. With the leaked binding sitting in the env, that filter fired on it,
+so the *first* class's methods read the *second* class's value:
+
+```raku
+class A { my constant @defaults = <a b>;   method get() { @defaults } }
+class B { my constant @defaults = <x y z>; method get() { @defaults } }
+say A.get;   # raku: (a b)   mutsu was: (x y z)
+```
+
+Cro declares four `my constant @defaults`, one per body-parser and
+body-serializer selector class. The last one loaded won, so every *body parser*
+lookup walked the *serializer* list and died with "Too few positionals passed;
+expected 2 arguments but got 1" — `Cro::BodySerializer.is-applicable` takes a
+message and a body, `Cro::BodyParser.is-applicable` only a message. Nothing in
+Cro could decode a response body.
+
+## The fix
+
+The authoritative copy of a class-body static already lives in
+`package_lexicals[C]`, recorded when the body finishes. Two changes make that
+store load-bearing rather than a mirror:
+
+- The bare env binding is restored to whatever the enclosing scope had (or
+  removed) when the class body ends — the same treatment
+  `news/2026-08/class-body-type-scope.md` gave nested type names. Only names the
+  body genuinely `my`-declared are unbound: the recorded set deliberately
+  over-approximates, and for a `unit class` it also picks up everything the
+  body's own `use` statements imported. Unbinding *those* broke HTTP::UserAgent,
+  whose `unit class HTTP::UserAgent; use HTTP::UserAgent::Common;` supplies the
+  `%useragents` that the exported `get-ua` reads (caught by the batteries gate,
+  not by `make test`).
+- `inject_class_body_statics` now injects unconditionally, and both method
+  dispatch paths call it *before* `self` and the parameters are bound. A
+  parameter of the same name still wins — it simply overwrites — while a caller
+  lexical that merely shares the name no longer shadows the class's own lexical.
+  The method body is inside the statics' scope; the calling frame's binding is
+  visible there only because mutsu's env is flattened.
+
+## Effect
+
+`t/http-response-parser.rakutest` and `t/http-request-parser.rakutest` now get
+past body decoding entirely: the request parser's plan grew from 295 to 306 as
+whole groups of previously-dead assertions (`.hash gives back Hash with 3
+elements`, `Can index associatively`, the `application/x-www-form-urlencoded`
+and JSON body suites) started running.
+
+Pinned by `t/class-body-my-lexical-scope.t`, verified against `raku`.

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -2758,8 +2758,38 @@ impl Interpreter {
                 marks.insert(bare.clone());
             }
             let store = self.package_lexicals.entry(name.to_string()).or_default();
+            // Only the names this body genuinely `my`-declared are unbound below.
+            // `body_lexicals` deliberately over-approximates — for a `unit class`
+            // it also picks up everything the body's own `use` statements imported
+            // (`unit class HTTP::UserAgent; use HTTP::UserAgent::Common;` brings in
+            // that module's `%useragents`). Recording those as statics is harmless;
+            // *unbinding* them is not, and it broke the exported `get-ua` that
+            // reads `%useragents`.
+            let mut static_names = Vec::with_capacity(body_lexicals.len());
             for (bare, v) in body_lexicals {
+                if declared_statics.contains(bare.as_str()) {
+                    static_names.push(bare.clone());
+                }
                 store.insert(bare, v);
+            }
+            // The class body is these names' whole scope. Leaving the bare
+            // binding in the env made every class-body `my` a de facto global:
+            // the next class body declaring the same name overwrote it, and the
+            // FIRST class's methods then read the SECOND class's value. Cro has
+            // four `my constant @defaults`, one per selector class, so every
+            // body-parser lookup ran the body *serializer* list. Restore each name
+            // to whatever the enclosing scope had — the authoritative copy now
+            // lives in `package_lexicals`, which method dispatch injects.
+            for bare in static_names {
+                match saved_env.get(&bare) {
+                    Some(previous) => {
+                        let previous = previous.clone();
+                        self.env.insert(bare, previous);
+                    }
+                    None => {
+                        self.env.remove(&bare);
+                    }
+                }
             }
         }
         // A type declared inside this class body (`class Outer { my class Inner

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -270,12 +270,18 @@ impl Interpreter {
     /// resolves them, regardless of the call-site env. Values are pulled fresh
     /// from `package_lexicals` on each method entry, so a prior call's assignment
     /// (persisted there by `writeback_package_scope_var`, since dispatch sets
-    /// `current_package` to the class) is reflected. Only names not already bound
-    /// in the method env (params/attrs/`self` take precedence) are injected. This
-    /// is the load-bearing half of the fix for a class registered inside a
-    /// transient frame (`require` in a sub), whose body env — and thus its statics
-    /// — is gone by the time a method runs. Returns without work when the class has
-    /// no statics (the overwhelmingly common case).
+    /// `current_package` to the class) is reflected. This is the load-bearing half
+    /// of the fix for a class registered inside a transient frame (`require` in a
+    /// sub), whose body env — and thus its statics — is gone by the time a method
+    /// runs. Returns without work when the class has no statics (the overwhelmingly
+    /// common case).
+    ///
+    /// Injection is UNCONDITIONAL, and both call sites run it *before* `self` and
+    /// the parameters are bound: those overwrite it and so still take precedence,
+    /// while a caller lexical that merely shares the name does not. The method body
+    /// is inside the statics' lexical scope, so a same-named binding from the
+    /// calling frame — visible here only because the env is flattened — must never
+    /// shadow them.
     pub(crate) fn inject_class_body_statics(&mut self, class_name: &str) {
         let Some(statics) = self.package_lexicals.get(class_name) else {
             return;
@@ -285,7 +291,6 @@ impl Interpreter {
         }
         let to_inject: Vec<(String, Value)> = statics
             .iter()
-            .filter(|(k, _)| !self.env.contains_key(k.as_str()))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         for (k, v) in to_inject {

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -536,6 +536,13 @@ impl Interpreter {
             }
         }
 
+        // Make class-body `my` statics visible to every read path in the body.
+        // Injected BEFORE parameter binding so a parameter of the same name still
+        // wins (it simply overwrites), while an unrelated CALLER lexical that
+        // happens to share the name does not: the statics are the class's own
+        // lexicals and the method body is inside their scope.
+        self.inject_class_body_statics(owner_class);
+
         // Bind method parameters
         let rw_bindings = match loan_env!(
             self,
@@ -554,10 +561,6 @@ impl Interpreter {
         };
 
         // Initialize locals from env
-        // Make class-body `my` statics visible to every read path in the body
-        // (params/self inserted above take precedence). No-op unless the owner
-        // class declared statics.
-        self.inject_class_body_statics(owner_class);
         self.locals = vec![Value::NIL; cc.locals.len()];
         for (i, local_name) in cc.locals.iter().enumerate() {
             if let Some(val) = self.env().get(local_name) {
@@ -1219,6 +1222,11 @@ impl Interpreter {
         // GetGlobal in non-compiled paths). Skip self, params, attrs, and other
         // method-local vars since all reads go through GetLocal.
         let skip_env_setup = can_skip_merge && cc.closure_compiled_codes.is_empty();
+        // Make class-body `my` statics visible to every read path in the body.
+        // Injected BEFORE `self`/params are inserted so those still win, while an
+        // unrelated CALLER lexical sharing the name does not — the statics are the
+        // class's own lexicals and the method body is inside their scope.
+        self.inject_class_body_statics(owner_class);
         if skip_env_setup {
             let env = self.env_mut();
             env.insert("self".to_string(), base.clone());
@@ -1291,11 +1299,6 @@ impl Interpreter {
         if let Some(slurpy) = &implicit_named_slurpy {
             self.env_mut().insert("%_".to_string(), slurpy.clone());
         }
-
-        // Make class-body `my` statics visible to every read path in the body
-        // (params/self already inserted above take precedence). No-op unless the
-        // owner class declared statics.
-        self.inject_class_body_statics(owner_class);
 
         // A method installed via `.^add_method` with a closure literal
         // (`method { $captured }`) carries the frozen creating-scope env so its

--- a/t/class-body-my-lexical-scope.t
+++ b/t/class-body-my-lexical-scope.t
@@ -1,0 +1,62 @@
+use Test;
+
+plan 9;
+
+# A `my` (or `my constant`) declaration in a class body is a lexical of that
+# body: its methods see it, and nothing outside does. Binding it under its bare
+# name in the enclosing env instead made every class-body static a de facto
+# global, so the next class body declaring the same name overwrote it and the
+# FIRST class's methods started reading the SECOND class's value.
+#
+# Cro has four `my constant @defaults`, one per body-parser/serializer selector
+# class, which is how a body-parser lookup ended up running the serializer list.
+
+class CBML-A {
+    my constant @defaults = <a b>;
+    method get() { @defaults }
+}
+class CBML-B {
+    my constant @defaults = <x y z>;
+    method get() { @defaults }
+}
+
+is CBML-A.get.join(','), 'a,b', 'the first class keeps its own constant';
+is CBML-B.get.join(','), 'x,y,z', 'and the second has its own';
+
+class CBML-C {
+    my $secret = 'c';
+    method get() { $secret }
+}
+class CBML-D {
+    my $secret = 'd';
+    method get() { $secret }
+}
+
+is CBML-C.get, 'c', 'a plain `my` static is per-class too';
+is CBML-D.get, 'd', 'and the later declaration does not steal it';
+
+# The static stays mutable across calls, and the writeback is per class.
+class CBML-Counter {
+    my $n = 0;
+    method bump() { $n++; $n }
+}
+CBML-Counter.bump;
+is CBML-Counter.bump, 2, 'a class-body static keeps its value across calls';
+
+# It does not escape the class body.
+class CBML-Hidden { my $hidden = 'inside'; method get() { $hidden } }
+is CBML-Hidden.get, 'inside', 'the method sees it';
+nok $::('hidden').defined, 'and it is not bound in the enclosing scope';
+
+# A method parameter of the same name shadows the static, as any inner `my`
+# would; a caller lexical of the same name does not.
+class CBML-Shadow {
+    my $v = 'static';
+    method with-param($v) { $v }
+    method plain() { $v }
+}
+my $v = 'caller';
+is CBML-Shadow.with-param('param'), 'param', 'a parameter shadows the static';
+is CBML-Shadow.plain, 'static', 'a same-named caller lexical does not';
+
+done-testing;


### PR DESCRIPTION
`class C { my $x = ...; method m { $x } }` declares `$x` in the class body's
lexical scope. mutsu bound it under its bare name in the *enclosing* env and left
it there, which made every class-body static a de facto global: the next class
body declaring the same name simply overwrote it.

The damage was silent and retroactive. `inject_class_body_statics` — what makes a
method see its own class's statics — only filled names the method env did **not**
already have, precisely so a parameter would take precedence. With the leaked
binding sitting in the env, that filter fired on it, so the *first* class's
methods read the *second* class's value:

```raku
class A { my constant @defaults = <a b>;   method get() { @defaults } }
class B { my constant @defaults = <x y z>; method get() { @defaults } }
say A.get;   # raku: (a b)   mutsu: (x y z)
```

Cro declares four `my constant @defaults`, one per body-parser and
body-serializer selector class. The last one loaded won, so every *body parser*
lookup walked the *serializer* list and died with "Too few positionals passed;
expected 2 arguments but got 1" — `Cro::BodySerializer.is-applicable` takes a
message and a body, `Cro::BodyParser.is-applicable` only a message. Nothing in
Cro could decode a response body.

## Changes

The authoritative copy already lives in `package_lexicals[C]`, recorded when the
body finishes. Two changes make that store load-bearing rather than a mirror:

- The bare env binding is restored to whatever the enclosing scope had (or
  removed) when the class body ends — the same treatment #5745 gave nested type
  names. **Only names the body genuinely `my`-declared are unbound**: the
  recorded set deliberately over-approximates, and for a `unit class` it also
  picks up everything the body's own `use` statements imported. Unbinding those
  broke HTTP::UserAgent, whose `unit class HTTP::UserAgent; use
  HTTP::UserAgent::Common;` supplies the `%useragents` its exported `get-ua`
  reads — caught by the batteries gate, which `make test` does not run.
- `inject_class_body_statics` injects unconditionally, and both method-dispatch
  paths call it *before* `self` and the parameters are bound. A parameter of the
  same name still wins (it overwrites), while a caller lexical that merely shares
  the name no longer shadows the class's own lexical. The method body is inside
  the statics' scope; the calling frame's binding is visible there only because
  mutsu's env is flattened.

## Effect on the Cro suite

Body decoding works end to end now. `t/http-request-parser.rakutest`'s plan grows
from 295 to 306 as whole groups of previously-dead assertions start running —
`.hash gives back Hash with 3 elements`, `Can index associatively`, the
`application/x-www-form-urlencoded` and JSON body suites.

## Testing

`t/class-body-my-lexical-scope.t` (new, verified against `raku`) covers both
directions plus the parameter/caller-lexical precedence rules. Full `prove t/` is
green, `cargo clippy -- -D warnings` and `cargo fmt --check` pass, and
`scripts/battery-testsuite.sh` reports `GATE PASSED` at 153/158 (one better than
before this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)