### PR TITLE
docs: PLAN.md is an outline again (1072 -> 221 lines)

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -23,7 +23,7 @@ Method:
 
 mutsu is a Rust implementation of a minimal Raku-compatible interpreter. The roast
 whitelist stands at **1435 / 1464 (98.0%)**, up from rev10's 1433/1464 — and that near-flat
-number is the point: **roast has been mined out since rev10** (PLAN §4), so a year's worth
+number is the point: **roast has been mined out since rev10** (PLAN §3), so a year's worth
 of the project's velocity now shows up in places roast does not measure. The 1096 commits
 since rev10 went almost entirely into (a) the raku-differential compatibility sweep
 (≈100 `news/2026-08/` entries, one general fix each), (b) the batteries campaign — real
@@ -100,7 +100,7 @@ the AST (re-verified 2026-08-02):
 - **Module-sub OTF compile gate** (`def_is_otf_compilable_module_single`,
   `vm/vm_call_func_ops.rs:1991`): unchanged since rev10. The residual exclusions are
   mechanism-level — `state`, sigilless `\x` params, `is encoded(...)`, `start` — each with a
-  documented blocker (PLAN §3).
+  documented blocker (`todo/tickets/otf-compilation-gate-leftovers.md`).
 
 ### 1.2 Closure upvalues — Phase 1 only, unchanged since rev5
 
@@ -132,8 +132,9 @@ One occurrence of any of those five ops in a frame makes **every** local an env-
 target. The blanket is not removable one consumer at a time: block-scope restore re-pulls
 locals from env by name, the loop mechanism writes the loop var to both slot and env,
 `MakeGather`/`WheneverScope` stash a body in `stmt_pool` and run it by name against the live
-env, and closure capture reads free vars from the same mirror. PLAN §5 item 0 records four
-independent mechanisms that a standalone removal deterministically broke.
+env, and closure capture reads free vars from the same mirror.
+`todo/deep/needs-env-sync-blanket-removal.md` records four independent mechanisms that a
+standalone removal deterministically broke.
 
 **The reason this ranks higher in rev11 than in rev10 is not performance.** It is that the
 open correctness tickets in `todo/` cluster on this one mechanism — see §2.4.
@@ -231,7 +232,9 @@ Two structural observations:
 2. **B2b's "custom HOW inheritance is campaign-sized" verdict is partly obsolete.** PLAN
    §B2b still describes HOW subclassing as unbuilt; the OO::Monitors campaign built a
    meaningful part of it. What remains unbuilt is the NQP/QAST/slang layer Test::Async needs,
-   which is a *different* claim. PLAN §B2b should be re-scoped, not simply left deferred.
+   which is a *different* claim. That scouting result now lives in
+   `docs/ecosystem-guts-dependency-survey.md` (PLAN's §1 B2b was dropped 2026-08-02 —
+   Test::Async is not a bundle candidate), and it is the claim to re-scope.
 
 ### 1.10 Representation campaigns — one complete, one half-finished
 
@@ -314,7 +317,8 @@ be silent.
 - **Recursive start/await hang** (deterministic) and **Supply detached-worker panics are
   swallowed** (QUIT propagation unimplemented) — both unchanged since rev10.
 - **No thread pool at all**: 20 `spawn_user_thread` sites, each reserving 256 MiB
-  (`runtime/builtins_system.rs:9`). PLAN §6 measured the consequences (50 idle `cue(:every)`
+  (`runtime/builtins_system.rs:9`). `todo/deep/shared-worker-pool-adr.md` measured the
+  consequences (50 idle `cue(:every)`
   timers → 52 threads / +16.4 GB VmSize). The decision this needs — what `await` does to a
   pooled worker, given mutsu has no continuations — is still an **unwritten Proposed ADR**.
 
@@ -337,9 +341,10 @@ Findings that reduce to it:
   one of the five blanket triggers.
 - `todo/tickets/forward-captured-code-var-snapshot.md` — a forward-captured `&`-lexical is
   snapshotted as `Nil`.
-- PLAN §6's "a joined `start` block writes its stale captured env back over a variable
-  declared after it", where PLAN itself already concludes the fix "belongs with the
-  cell-based capture work, not a special case at the call sites".
+- `todo/tickets/inline-start-blocks-clobber-a-later-declared-variable.md` — "a joined `start`
+  block writes its stale captured env back over a variable declared after it", where the
+  ticket itself already concludes the fix "belongs with the cell-based capture work, not a
+  special case at the call sites".
 
 Each has been triaged as "not a small slice" *individually*, which is the signature of a
 shared mechanism. Fixing them one at a time is not merely slow — each local fix adds another
@@ -401,7 +406,7 @@ No test-specific hardcoded outputs found (re-checked). Two derivation shortcuts 
   container tags, so the unit cost is low, but the growth is a code-shape signal, not just a
   perf one.
 - **`unwrap`/`expect`/`panic!`/`unreachable!` ≈ 1908 (+119)** and **`#[allow(` 178 (+8)**.
-  PLAN §8.3's "mutsu must never Rust-panic on any input" goal is in tension with a metric
+  PLAN §6's "mutsu must never Rust-panic on any input" goal is in tension with a metric
   that has risen every revision.
 - Allocation-failure aborts on user-sized allocations remain guarded via `try_reserve`.
 
@@ -451,7 +456,7 @@ The ranking rule, stated so it can be argued with:
 | 1 | **The env-writeback / lexical-slot fused campaign** — `captures_env_by_name` blanket → precise per-slot sync for its five consumers → `BlockScope` restore → closure capture cells (§1.3, §1.2, §2.4) | **correctness** + perf | Re-ranked from rev10's "top perf lever" to "the largest correctness cluster": at least seven open `todo/` findings reduce to this one mechanism, each individually triaged as "not a small slice". Fixing them separately is not merely slow — each local fix adds another consumer of the mirror. Needs a Proposed ADR first (five mechanisms are known to break on a standalone change). |
 | 2 | **Finish ADR-0015 P3b** (`array[T]` behind the `ArrayData::items` accessor chokepoint) (§1.10) | representation | The one genuinely half-migrated representation left: `Buf`/`CArray` are native-backed with honest `.REPR`/`.WHERE`, `array[T]` is not. The chokepoint refactor is the shared prerequisite, and P3b is simultaneously the fix for roast's shaped-native `array-shapes.t` T36-38 — the last roast item with real leverage. |
 | 3 | **Declaration registration → bytecode, and dispatch-entry consolidation into one type×method table** (§1.1, §3.3; retires §4-1's hand tables) | design | Was a standing "medium" item; the MOP campaign (§1.9) turned it into a *growth surface* — the user HOW protocol now runs inside AST-walking registration (`registration_class_decl.rs` 2882 lines), and `"elems"`-style scattered name matching spread from 8 files to 33. Every further batteries/MOP feature pays interest here, so the cost of deferring is rising rather than flat. |
-| 4 | **Exception-class hierarchy registration** (124 core `X::` classes unregistered, `todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`) | design | A registry/data-model job, not a pile of small fixes, and the prerequisite for PLAN §8.4 error/exception parity — the QA axis that replaced roast as the compatibility signal. |
+| 4 | **Exception-class hierarchy registration** (124 core `X::` classes unregistered, `todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`) | design | A registry/data-model job, not a pile of small fixes, and the prerequisite for PLAN §6 error/exception parity — the QA axis that replaced roast as the compatibility signal. |
 | 5 | **Close ADR-0013**: add the Miri job (informational → blocking), correct the stale unsoundness docs in `value/aliased_mut.rs`, then take the layer-3c cross-thread-race decision explicitly (§2.1) | soundness verification | The mechanism is fixed; the *check* that keeps it fixed does not exist. What shipped is an argument about borrow provenance, and that is exactly the kind of thing a later refactor invalidates with no observable failure. Cheap relative to that risk. |
 | 6 | **Concurrency substrate**: write the shared worker-pool Proposed ADR (still unwritten), then the `Proc::Async` stress segfault, Supply panic → QUIT, and WASM `start`/`Channel` degradation (§2.3) | robustness | 20 spawn sites × 256 MiB is a structural resource decision currently being made by default. Within this row the segfault outranks the rest — a crash is categorically worse than a wrong answer. |
 | 7 | **Guard the ADR-0016 invariant** (§1.10): a `view()`-based variant probe materializes a lazy `Match`. Add a debug counter or lint rather than leaving it as prose | correctness (regression prevention) | Small, but it protects a campaign that just finished; unguarded invariants of this shape are how completed migrations quietly un-finish. |
@@ -460,7 +465,7 @@ The ranking rule, stated so it can be argued with:
 | 10 | **Hygiene, treated as a trend not a chore**: `runtime/mod.rs` re-slim (2495, flagged 4 revisions running), the 300/80 file-size population, the `unwrap`/`clone` slopes, the stale-doc corrections (§5, §6) | hygiene | Every metric here has worsened monotonically for three revisions, which means the current practice is not the stated rule. The actionable form is to fix the trend on files that #1-#4 touch anyway, and to decide deliberately whether the 500-line rule still stands. |
 
 Explicitly **not** ranked as architecture work in rev11: roast whitelist chasing (mined out,
-PLAN §4), and perf levers with no goal-item consumer (PLAN §5 header). Both remain available
+PLAN §3), and perf levers with no goal-item consumer (PLAN §4 header). Both remain available
 as opportunistic work when an item above happens to unblock them.
 
 ---
@@ -488,7 +493,8 @@ Actions taken in this revision (each ADR updated in place with a progress/outcom
 
 Two **missing** ADRs are worth writing, and are listed here rather than drafted unilaterally:
 
-1. **A shared worker pool** — PLAN §6 has specified its content in detail for over two weeks
+1. **A shared worker pool** — `todo/deep/shared-worker-pool-adr.md` has specified its content
+   in detail for over two weeks
    ("the central question is not pool sizing — it is what `await` does to a pooled worker"),
    and the decision is being made by default in the meantime (20 spawn sites, 256 MiB each).
 2. **The batteries adoption policy** — "grow the interpreter until the real upstream module

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,1072 +1,221 @@
 # PLAN.md — mutsu implementation plan
 
-> This file lists **only unfinished work**. Completed work moves to [news/](news/).
-> See [news/](news/) for past logs, [PERFORMANCE.md](PERFORMANCE.md) for performance details,
-> and [TODO_roast/BLOCKERS.md](TODO_roast/BLOCKERS.md) for roast failure analysis.
+> **This file is an outline of unfinished work — nothing more.** Each item says *what* is left and
+> *where the detail lives*; it does not carry investigation notes, measurements, or progress logs.
 >
-> **Last updated 2026-07-16 — priority reset: performance is NOT the mzef blocker.**
-> mzef already works functionally: `zef info Zef` runs to completion against the real fez index
-> (7648 dists), populate is ~6.5s, and the constructor microbench already **beats** raku (0.57×).
-> Perf tuning (§5) is therefore **polish, not a blocker** — it had been getting picked up
-> autonomously session after session past the point of usefulness. **The active mzef frontier is
-> functional, not performance:** (A) network fetch over robust async TLS from `https://360.zef.pm/`,
-> and (B) the real install + build/test pipeline (`mzef` binary shim + vendoring zef itself and its
-> deps + config). See §1 B2. §5 stays as a reference of levers/measurements but is **de-prioritized**;
-> before starting any §5 item, ask "does mzef need this to work?" — if not, don't.
+> | kind of information | where it lives |
+> |---|---|
+> | completed work | [news/](news/) — one file per accomplishment |
+> | open findings, small | [todo/tickets/](todo/tickets/) — one file per finding |
+> | open findings, deep | [todo/deep/](todo/deep/) — needs design or an ADR |
+> | architectural decisions | [docs/adr/](docs/adr/) |
+> | roast failure analysis | [TODO_roast/BLOCKERS.md](TODO_roast/BLOCKERS.md) |
+> | performance numbers | the bench CI (`bench-data` branch), [PERFORMANCE.md](PERFORMANCE.md) |
 >
-> **Earlier (2026-07-14)**:
-> §4 was rewritten based on full measurement. The items listed in the old §4 (negation meta / hyper assignment /
-> `augment class` / `A::B.new` / file test / PRE·POST / signature type checks / lazy-seq ④) are
-> **all already implemented**; instead, it turned out that **the 41 `integration/` files (real-program
-> compatibility, all perfect-score under raku) had been missing from the BLOCKERS table**.
-> §5 reflects the work consumed by #4492–#4495.
-> The canonical record of completed work is [news/2026-07.md](news/2026-07.md) plus the per-entry files under
-> [news/2026-07/](news/2026-07/) (new entries land there, one file each, to avoid merge conflicts). The redefinition of the goal
-> ("**a batteries-included Raku implementation**") and the full restructuring happened on 2026-07-05
-> (the old completion notes are in the [news/2026-06.md](news/2026-06.md) archive section and news/2026-07.md).
+> Do **not** append progress notes here. A new file under `todo/` or `news/` conflicts with nothing
+> on merge; an append to this file conflicts with every other in-flight PR.
 
 ## Goal — a batteries-included Raku implementation
 
-Build a **Raku language interpreter where installing mutsu alone gives you a well-documented
-standard bundled library, so you can write practical code immediately**.
+Build a **Raku interpreter where installing mutsu alone gives you a well-documented standard bundled
+library, so you can write practical code immediately** — the Raku version of the positioning bun took
+for JavaScript. The official Rakudo ecosystem has no batteries-included distribution, and that gap is
+mutsu's unique position. Four components:
 
-The Raku version of the positioning bun took for JavaScript (runtime + package manager + standard
-tooling in a single fast binary). The official Rakudo ecosystem has no batteries-included
-distribution, and that gap is mutsu's unique position. Four components:
+1. **Fast-startup compatible interpreter** — maintain and expand raku compatibility. → §3
+2. **Standard bundled libraries (batteries)**, every one documented. → §1
+3. **Bundled package manager `mzef`**, vendoring the real Zef. → §1 B2
+4. **Substrate quality** — GC (done, default on), JIT (done, default on), performance, error
+   messages. → §2 / §4
 
-1. **Fast-startup compatible interpreter** — startup 0.04x vs raku; roast whitelist 1384. With CLI
-   tools and script execution as the main battleground, maintain and expand raku compatibility. → §3 / §4
-2. **Standard bundled libraries (batteries)** — bundle JSON / HTTP / templates / DB / file utilities
-   etc., so they work with a plain `use` right after install. **Every library gets documentation**. → §1
-3. **Bundled package manager `mzef`** (vendoring the real Zef) — anything not covered by the bundle
-   can be fetched from the fez ecosystem. → §1 B2
-4. **Substrate quality** — GC (table stakes; **done, default on**), performance, error messages. → §2 / §5
+### Standing rules
 
-## How to read this document
-
-- **§1 Batteries** is the main effort, directly tied to the goal: bundle selection, vendoring,
-  documentation, mzef, distribution.
-- **§2 Phase B** is fully complete: layer 3a (GC), layer 3b (NaN-boxing), and layer 4 JIT
-  (J1–J5 + all J4d slices, **default on**, ADR-0004 closed 2026-07-15).
-- **§3 substrate / §4 roast / §5 perf / §6 concurrency & structure** are the remaining substrate-quality items.
-- **The roast frontier in §4 is `integration/` (real-program compatibility; all 41 files perfect-score under raku)**
-  — established by the 2026-07-14 full measurement. For individual files and root-cause clusters see
-  [TODO_roast/BLOCKERS.md](TODO_roast/BLOCKERS.md).
-
-### Phase structure (ADR-0001)
-
-Beyond catching up with raku on performance and compatibility, **GC and JIT are the next big jumps**.
-An interpreter without GC is considered "defective" and nobody will use it — GC is table stakes.
-The order and approach are decided in
-[docs/adr/0001-gc-strategy-and-phasing.md](docs/adr/0001-gc-strategy-and-phasing.md).
-**On 2026-07-03, Phase A completion (roast goal met) was confirmed and the GC start was decided**
-([ADR-0002](docs/adr/0002-phase-a-gate-reassessment.md)). Key points:
-
-| Phase | Content | Where in this document |
-|---|---|---|
-| **A. Catch up** | Match raku on compatibility + speed (**done — ADR-0002**) | Only leftovers in §3 / §4 / §5 |
-| **B. Value-representation rework + GC** | Layer 3a (Track B + cycle collector, integrated) and layer 3b NaN-boxing **both done** (2026-07-12 #4469; `Value` 48→8B) | §2 |
-| **C. JIT** | Unique advantage (**done** — J1–J5 + J4d, default on, ADR-0004 closed 2026-07-15) | §5 Lever 4 |
-
-- **GC comes before JIT** (the JIT is built on top of a GC-ready foundation).
-- **Approach = cycle collector on Arc (non-moving + refcount; level 1 adopted)**. Scalar variants are
-  excluded from GC by a type filter — numeric/string hot paths pay zero cost. Performance comes from
-  the JIT, not from GC.
-- **Track B is fused with GC (layer 3a). Do NOT start it standalone.** NaN-boxing is groundwork for
-  the JIT (layer 3b); biased refcounting is layer 3c.
-- Batteries (§1) can proceed in parallel with GC (compatibility, module, and distribution work does
-  not depend on the Value representation).
-
-### 🚫 Standing rule: keep "1 operation = 1 implementation" (user policy 2026-06-07)
-
-The execution engine is unified into a single `Interpreter` struct (= the bytecode VM).
-Do **not** implement the same Raku operation in multiple places:
-
-1. Write new implementations and fixes **exactly once**, in the VM/native layer (`src/vm/` plus pure
-   native `src/builtins/`).
-2. When another call path (EVAL / embedded `{}` blocks in regexes, etc.) needs the same processing,
-   **delegate** to the single native implementation.
-3. When you find a duplicate, make the native implementation canonical and delete the duplicated copy.
+- **1 operation = 1 implementation** (user policy 2026-06-07). Write each Raku operation exactly once
+  in the VM/native layer (`src/vm/` + `src/builtins/`); other call paths (EVAL, embedded regex
+  blocks) **delegate** to it. When you find a duplicate, make the native one canonical and delete the
+  copy.
+- **Phase order is fixed by [ADR-0001](docs/adr/0001-gc-strategy-and-phasing.md)**: A (catch up) →
+  A' → B (value representation + GC) → C (JIT). A, B and C have all landed; read the ADR before
+  touching GC, Track B, NaN-boxing, or JIT.
+- **Bundling policy is [BATTERIES.md](BATTERIES.md)**: adopt the upstream module verbatim and grow
+  mutsu until it runs. Providing a module "natively" is banned going forward.
 
 ---
 
-## 1. 🔋 Batteries — standard bundled libraries and distribution (goal-critical, main effort)
+## 1. 🔋 Batteries — bundled libraries and distribution (main effort)
 
-Modules with a proven working record (details in [news/2026-06.md](news/2026-06.md)): JSON native
-(`to-json`/`from-json` #3402) / Template::Mustache / File::Temp / File::Directory::Tree /
-HTTP::Parser / MIME::Base64 / HTTP::Server::Tiny (end-to-end HTTP serving) /
-DBIish (bundled SQLite battery) / NativeCall MVP (real SQLite CRUD round-trip) / zef CLI.
+22 libraries are vendored under `modules/` and resolved with zero configuration; the release-time
+gate runs their upstream suites against the shipped copies
+([docs/batteries/testsuite-gate.md](docs/batteries/testsuite-gate.md)) and is **all-green, so a drop
+below the whitelisted baseline is a regression to fix, not a baseline to accept**. Adding a battery
+re-opens work: whitelist what passes with `scripts/battery-testsuite.sh --update`, then close the
+gaps with general interpreter fixes.
 
-Right now these merely "work" — the three pillars of **bundling, documentation, and continuity
-guarantees** are all missing. To call ourselves batteries-included we need all three — that is this
-section.
+### B1. Bundle set and documentation
 
-### B1. Finalize the bundle set, vendoring, documentation
+- [ ] **Finalize the bundle list.** Selection criterion: "a web blog can be written with the bundle
+      alone". Method and per-battery selection records:
+      [docs/batteries/](docs/batteries/), [BATTERIES.md](BATTERIES.md).
+- [ ] **Web-framework slot: make Cro run** — the campaign that fills the last hole in that criterion.
+      Target, rationale, and gate order: [docs/batteries/web-framework.md](docs/batteries/web-framework.md).
+- [ ] **Documentation per battery** — a usage document (no install needed, API, examples) for each
+      bundled library. "Well-documented" is an explicit goal requirement, so this is mandatory when
+      adding a module.
+- [ ] **Working-module regression CI** (report-only, on main push; user policy 2026-06-28):
+      continuously detect whether modules that once worked keep working.
 
-- [ ] **Finalize the bundle list**. First candidates (based on working record):
-      JSON (native built-in) / Template::Mustache / File::Temp / File::Directory::Tree / HTTP::Parser /
-      MIME::Base64 / HTTP::Server::Tiny / DBIish (SQLite) / NativeCall (the web-framework slot
-      is the Cro campaign below, not a homegrown framework).
-      Use "a web blog can be written with the bundle alone" as the selection criterion (the HTTP
-      client gap needs investigation).
-- [ ] **Web-framework slot: make Cro run** — surveyed 2026-07-31
-      ([docs/batteries/web-framework.md](docs/batteries/web-framework.md)); target updated the same
-      day (user decision): go straight for **Cro** (61 dependents, raku baseline 28/28) rather than
-      Humming-Bird (upstream fails 4/14 of its own suite under current raku; 1 dependent — kept as
-      a compat data point at its 10/14 raku baseline). Gate order after the #5599 brace-subscript
-      and role-stub name-based-satisfaction fixes: `CBOR::Simple` nqp ops
-      (`todo/tickets/cbor-simple-nqp-buf-ops.md`, gates `use Cro::HTTP::Router` via Log::Timeline),
-      then `Cro::Service.start`, then a built-in `monitor` declarator for client/session files.
-      This supersedes the "Cro = nqp territory" reading of the 2026-06 scouting notes.
-- [ ] **Vendoring mechanism**: vendor the bundled modules into the source tree (e.g. `modules/`) so
-      an installed mutsu resolves them with no extra configuration (make `MUTSULIB` have a built-in
-      default, or register a standard lib path in `Interpreter::new()` — same pattern as
-      `add_default_site_repo()`). Also verify consistency with the precomp cache.
-- [ ] **Documentation**: a usage document per bundled library (overview; the fact that no install is
-      needed; API reference; example code). Location: `docs/batteries/` (or starting from a top-level
-      `BATTERIES.md`). "Well-documented" is an explicit goal requirement, so documentation is
-      mandatory when adding a module.
-- [ ] **Working-module regression CI** (non-blocking for PRs; detects on main push; user policy
-      2026-06-28): continuously detect whether modules that once "worked" keep working. A harness
-      that `use`s each known module plus a smoke test (load, representative method, `zef --help`
-      output match). External dists are either `zef fetch`ed in CI or vendored. Failures are
-      report-only (a red run does not stop main). Once the bundle set is fixed, its smoke tests
-      become the battery quality gate as-is.
-- [x] **★ Close the bundled-library test-suite gaps — DONE 2026-07-25, baseline 18/18.**
-      (user policy 2026-07-24.) The release-time gate runs every battery's upstream suite against
-      the shipped library (`scripts/battery-testsuite.sh`, `batteries.lock`,
-      `batteries-whitelist.txt`; see [docs/batteries/testsuite-gate.md](docs/batteries/testsuite-gate.md)).
-      It landed at 11/18 and every remaining gap is now closed — OpenSSL 7/7, Zef 10/10,
-      IO::Socket::SSL 1/1 — entirely through general mutsu fixes, none library-specific. **The gate
-      is now all-green, so a drop below 18/18 is a pure regression to fix, not a baseline to
-      accept.** Adding a new battery is what re-opens work here: whitelist what passes with
-      `scripts/battery-testsuite.sh --update`, then close its gaps the same way. Details in
-      `news/2026-07/`.
+### B2. mzef — the bundled package manager
 
-### B2. mzef — an `mzef` package manager bundling the real Zef (north-star; user policy 2026-06-28)
+Installing mutsu gives you `mzef`, which drives **upstream Zef itself** (`vendor/zef/`) — also the
+project's strongest compatibility north star. Install, fetch, dependency resolution, and the test
+phase all work end to end.
 
-Vision: **installing mutsu gives you the `mzef` command**. The implementation does **not reimplement
-Zef — it uses Zef itself** (upstream). Since zef is a huge real Raku program, it is also the
-**strongest compatibility north star** (many general bug fixes originating from zef have already
-landed — see news).
-
-Current state (details in news/2026-06.md and news/2026-07.md): ✅ CLI load + command dispatch
-(`zef --help`/`--version` work) / ✅ the CompUnit::Repository install→use bridge
-(`repository-for-name` well-known names, automatic default site-repo registration, pinned by
-`t/compunit-repository-for-name.t`). Remaining:
-
-- [ ] **Blockers to end-to-end execution of the real zef binary (major progress in the 2026-07-12 session)**:
-      the old 2 bugs are resolved ((a) %-sigil Associative bind = #4452 / (b) parser error = no longer
-      reproduces). Landed the same day: #4457 (classify pair-iteration / hash-init contained-Pair /
-      IO::Path.child concatenation),
-      #4460 (grammar token static fold — `REQUIRE.parse` went from ~70x vs raku → **1.1x**),
-      #4462 (`Version.parts/.plus/.whatever` — the true cause of candidate-version matching),
-      **#4466 (★root fix of the former biggest blocker: on worker threads, append/prepend/pop/shift/
-      splice on shared arrays bypassed the `__mutsu_atomic_arr::` store and were silently lost — the
-      true cause of the "%-hash attribute push loss" was that populate's
-      `append @short-names-to-index` was wiped out entirely. See news/2026-07.md)**.
-      → **`zef info Zef` works completely — unmodified upstream, hyper enabled, GC default on, real
-      fez index (7648 dists) — all the way to Identity/Provides/Depends output** (stable across 2
-      release runs; pin t/hyper-array-mutators.t).
-      Current frontier:
-      1. populate performance: the former "3-5 min" was dominated by an MRO dispatch bug, fixed
-         2026-07-15 (accessor-MRO-shadowing PR): `Zef::Distribution.name` dispatched to the parent
-         DependencySpecification's `method name` (a full REQUIRE identity-grammar parse per call,
-         ~4ms) instead of the child's `has $.name` accessor. Second fix same day
-         (definite-return-eval PR): every return from a `--> Nil` routine (e.g.
-         Zef::Distribution's TWEAK) paid a full string EVAL whose setup clones the entire class
-         registry twice; constant specs (Nil/True/False/Empty/pi/int) are now constructed
-         directly. Third fix (wrap-chain-prefilter PR): every slow-path instance call
-         (bless/TWEAK) Debug-traversed method-body ASTs looking for `.wrap` chains that don't
-         exist; gated behind `has_any_wrap_chains()` + `Arc::ptr_eq` candidate matching.
-         Combined with #4559 (subrule memoization): full fez populate = **6.5s** release
-         (raku ~1-2.8s). Fourth fix (native-bless PR): `bless` no longer routes through the
-         interpreter's generic method-dispatch scan — the VM forks it straight to
-         `dispatch_bless`, which now reuses the cached per-class `NativeCtorPlan` (attribute
-         defs + BUILD/TWEAK probes, incl. 6.e role submethods) instead of re-collecting the
-         class shape per call; ctor microbench (benchmarks/bench-ctor.raku) 0.35 → 0.31s release,
-         **2.9x → 2.2x** vs raku. Fifth round (2026-07-15, #4571/#4573/#4575/#4576 —
-         see news/2026-07.md): single-visible-candidate fast return in method
-         resolution (skips the speculative match for the BUILD/TWEAK dispatch shape),
-         and the construction phases thread the constructed instance's shared
-         attribute cell (no more per-step AttrMap clones / phantom intermediate
-         instances; also a raku-compat fix — `self` inside BUILD/TWEAK IS the returned
-         object). bench-ctor 0.341 → 0.299s local. Remaining (per-dist): the
-         attributive-named-param full env path of TWEAK (`:%!meta` forces
-         `call_compiled_method`'s full env setup + merge — §5 item 0 / §1.5 territory),
-         MakePair/named-arg re-materialization (`|%_` slip), Symbol intern/as_str
-         traffic in dispatch signatures.
-      2. Nested `.raku` rendering: an Instance inside a collection renders as `Sp()` (type-object
-         style) (`(C.new,).raku` → raku gives `(C.new(...),)`). The value itself is fine
-         (semantically harmless; display only).
-      3. `zef list --installed` runs to exit 0 with no output (reasonable while the mutsu-side site
-         repo is empty).
-      4. ~~Small index-name-count difference~~ RESOLVED 2026-07-15: the 3 missing keys were the same
-         accessor bug (`.name` returned the identity-grammar parse result instead of the attribute;
-         dists whose name fails to parse were dropped). mutsu now indexes 9259/9259 keys, exactly
-         matching raku.
-      5. (Watch) the old observation "with GC on, the 2nd Ecosystems reads an empty `$!name`" did not
-         reproduce in 2 release runs after #4466. If it recurs, investigate independently as
-         GC × thread state corruption.
-- [ ] Known small difference: coercion of CLI numeric strings to `Int $n` is more eager than raku
-      (`7` matches `MAIN(Int $n,…)`; raku falls back to slurpy). In practice the mutsu behavior is
-      more intuitive.
-- [x] **network fetch** — done. **No native TLS was needed**: zef shells out to the system
-      `curl`/`wget` and mutsu drives that via `Proc::Async`, so the old "robust async TLS is the
-      biggest prerequisite" assumption was simply wrong. Concurrent multi-candidate fetch works as of
-      #4658 (ADR-0010).
-- [x] **Real install** — done for a dependency-free dist: a real fez dist downloads, extracts,
-      installs into the site repo and is then `use`-able (#4655). Verify with a **non-bundled** dist
-      (`JSON::OptIn`); `use JSON::Fast` succeeds without any install because mutsu bundles it.
-- [x] **A dist WITH dependencies** — done: `zef install --/test Test::META` installs all 13 dists
-      end-to-end (resolution #4650, concurrent fetch #4658, concurrent extract fixed on top of
-      ADR-0010), and `use Test::META` resolves from the site repo afterwards.
-- [x] **Test-phase frontier closed (2026-07-19)**: on a fresh HOME, `zef install Test::META` with
-      tests ON (no `--force-test`) runs every dependency suite concurrently, reports
-      **Testing [OK] for all of them — including JSON::Fast — and completes the install** (exit 0,
-      `use Test::META` loads from the fresh site repo). The five JSON::Fast parity PRs
-      (#4762/#4765/#4768/#4770/#4777) took that suite 3/14 → **14/14 files**; the last one added
-      `augment class DateTime/Date` on builtin native classes (an augmented `multi method new`
-      candidate participates in construction dispatch, falling back to the native ctor on
-      no-match), Instant-as-ISO-string serialization, and the hyper `»=~=«`/`»=:=«` fix.
-- [x] **An `mzef` binary shim + zef vendoring — done (2026-07-19)**: zef 1.1.3
-      (`ugexe/zef@0aa54f5`, Artistic-2.0) is vendored **in-repo** at `vendor/zef/` (lib + bin +
-      resources + LICENSE/META6 for attribution; upstream `t/`/`xt/`/`.github`/precomp excluded).
-      A second cargo binary `mzef` (`src/bin/mzef.rs`) is a thin re-exec shim: it resolves the
-      vendored zef tree (exe-relative candidates `../share/mutsu/zef` / `../lib/mutsu/zef` /
-      `../../vendor/zef`, or `$MZEF_ZEF_HOME`) and the sibling `mutsu` interpreter, then runs
-      `mutsu -I <zef>/lib <zef>/bin/zef <args>` (`$MZEF_MUTSU_BIN` overrides the interpreter path).
-      config resolves from the vendored `resources/config.json` via `%?RESOURCES<config.json>`;
-      installs land in mutsu's default site repo under `$HOME`. Verified E2E on a fresh HOME:
-      `mzef install JSON::OptIn` (tests ON) → `Testing [OK]` → `Installing` → `use JSON::OptIn`
-      loads. Pin: `tests/mzef_shim.rs`; provenance/license: `vendor/README.md`. Remaining for B3:
-      package `vendor/zef` → `<prefix>/share/mutsu/zef` alongside the two binaries in the release
-      artifact (the shim already looks there first).
-
-**`docs/mzef-install-pipeline.md` is the live tracker** — phase table, what each fix unblocked, and
-the current frontier with its next steps. Read it before picking up mzef work.
-
-### B2b. Test::Async / custom Metamodel HOW inheritance (deferred campaign — NOT on the mzef critical path)
-
-**Decision (user, 2026-07-18): handled as its own section, decoupled from the B2 test-phase
-frontier.** Test::Async (vrurg's async test framework, used by newer ecosystem dists) is blocked on
-**custom Metamodel HOW inheritance**: `'Test::Async::Metamodel::BundleHOW' cannot inherit from
-'Metamodel::ParametricRoleHOW' because it is unknown`. That is a real MOP feature — user-visible
-subclasses of the built-in metamodel classes (ParametricRoleHOW / ClassHOW), with mutsu's role/class
-machinery dispatching through the user's HOW overrides — and is **campaign-sized** (multiple
-sessions).
-
-- **Why deferred**: the mzef install pipeline's dependency chain (JSON::* / META6 / URI /
-  License::SPDX / Test::META) does not use Test::Async, so the "mzef installs real dists with tests
-  on" milestone does not need it. Spending the campaign now would delay the mzef return for zero
-  pipeline gain.
-- **Scouting done (2026-07-19) — the decision is (b), and B2b stays deferred on cost/benefit.**
-  Test::Async needs far more than "custom HOW inheritance": its `EXPORT` installs a **grammar slang**
-  (`define_slang` + custom `package_declarator:sym<test-bundle>` tokens that swap the role HOW mid-parse
-  via `set_how`), builds `QAST` nodes, and drives the `$*W` World / `NQPHLL` — the MoarVM compiler-guts
-  layer mutsu deliberately lacks. So **(a) real HOW-subclass dispatch is necessary but nowhere near
-  sufficient**; only **(b) a narrow per-declarator shim** (parse `test-bundle`/`test-hub`/`test-reporter`
-  as built-in role declarations with native bundle wiring, ignoring the NQP `EXPORT` grammar) is viable,
-  and it is still multi-session. Combined with the payoff: **Test::Async has 8 reverse-deps in the whole
-  fez ecosystem (1573 dists), all `test-depends` only, concentrated in one author's dists.**
-- **Ecosystem-wide justification for deferring the NQP layer generally**: a 150-dist random sample
-  (see [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md),
-  reproduce with `scripts/ecosystem-guts-survey.py`) finds only **~5% of dists are genuinely
-  compiler-guts blocked** (QAST/slang/macros/`Metamodel::Primitives`), vs **~81% pure Raku** and
-  **~9% NativeCall** (a separate layer mutsu already has an MVP of). The high-leverage work is B1/B4
-  over that ~90%, not an NQP/slang subsystem for the ~5% tail.
-- **Start trigger** (if a bundle-candidate module ever hard-depends on Test::Async): start from the (b)
-  shim above — prototype the `test-bundle` declarator as a built-in parse rule plus a native
-  BundleHOW-equivalent; do not attempt the general NQP/QAST/slang machinery.
-- Prerequisite groundwork already landed: `::?CLASS` param fixes (#4669). Detail and error text:
-  `docs/mzef-install-pipeline.md` "Test-phase frontier" history block.
+- [ ] **Live tracker: [docs/mzef-install-pipeline.md](docs/mzef-install-pipeline.md)** — phase table,
+      what each fix unblocked, and the current frontier. Read it before picking up mzef work.
 
 ### B3. Distribution and tooling
 
-- [x] **Binary distribution — release pipeline wired (2026-07-19)**: `release.yml` (on `v*` tag
-      push, or `workflow_dispatch` for a build-only smoke test) builds **both** `mutsu` and `mzef`
-      per target and packages a self-contained tarball — `bin/mutsu`, `bin/mzef`,
-      `share/mutsu/zef/...` at the archive root — so mise's github backend finds `bin/` with zero
-      config and `mzef` resolves the bundled zef via `../share/mutsu/zef`. Install:
-      `mise use -g github:tokuhirom/mutsu` → both commands on PATH (README "Install"). Matrix is
-      `fail-fast: false`; **Linux x64/arm64 are required, macOS is `continue-on-error`** (best-effort
-      — the pre-existing libffi Mach-O CFI build failure that had made *every* release since v0.3.1
-      publish nothing is thereby prevented from blocking the Linux artifacts). **Confirmed live on
-      the v0.8.0 tag (2026-07-19)**: the Release run published `linux-x64`/`linux-arm64`/`macos-x64`
-      tarballs + SHA256SUMS (macos-arm64 failed on libffi, tolerated), and
-      `mise exec github:tokuhirom/mutsu@0.8.0` downloaded/verified/extracted it and ran **both**
-      `mutsu` and `mzef` from `<install>/bin/` with the bundled zef resolved at
-      `<install>/share/mutsu/zef` — no env. Remaining: the **macOS arm64 libffi** build (upstream
-      Clang-17+ CFI issue; macos-x64 builds fine, only arm64 fails; needs a libffi/libffi-sys bump or
-      a system-libffi build — unverifiable from Linux, so deferred).
-- [x] **Container image (2026-07-19)**: `Dockerfile` (two-stage — `rust:1.93-bookworm` builder →
-      `debian:bookworm-slim` runtime carrying only the `mutsu`/`mzef` binaries, the bundled zef tree
-      at `/usr/local/share/mutsu/zef`, and zef's shell-out tools curl/git/tar/unzip + libpcre2) and
-      `.github/workflows/docker.yml` publish a multi-arch (amd64+arm64, native per-arch runners +
-      manifest merge) image to `ghcr.io/tokuhirom/mutsu` on `v*` tags (`:X.Y.Z`/`:latest`) and main
-      (`:main`). Try: `docker run --rm -it ghcr.io/tokuhirom/mutsu`. `.dockerignore` keeps the build
-      context tiny (ignore-all + re-include src/Cargo/vendor).
-- [ ] REPL / Debugger / native binary output / public WASM playground.
+Release tarballs (4 targets), the GHCR container image, and `mise use -g github:tokuhirom/mutsu` all
+work; see the CLAUDE.md "mzef package manager and distribution" section.
 
-### B4. Remaining module-compatibility blockers (the base of batteries)
+- [ ] REPL / debugger / native binary output / public WASM playground.
 
-- [ ] **★Real-dist compatibility sweep (systematic, dashboard-driven)** — actually
-      run real fez-ecosystem dists under mutsu and fix the general bugs they surface.
-      Live ledger: [`docs/dist-compat-sweep.md`](../docs/dist-compat-sweep.md)
-      (regenerate: `scripts/dist-compat-sweep.py`; **sandboxed via `bwrap` — no net,
-      read-only FS, throwaway HOME**, since dist code runs arbitrary load-time code).
-      **Re-run 2026-07-25 (same n=60 / seed 20260719): 19 load_ok, 20 missing_dep,
-      and only 6 real mutsu failures (2 parse_error, 3 runtime_error, 1 timeout)** —
-      the original "~half hit a real mutsu bug on `use` alone" figure is stale.
-      Cleared since: the `?? !!` "assignment too loose" guard was firing on a valid
-      tight `.=` (news/2026-07/ternary-branch-accepts-dot-assign.md), and a trailing
-      comma before a statement modifier failed to parse, which was the whole
-      `UpRooted` blocker (news/2026-07/trailing-comma-before-statement-modifier.md;
-      all 24 of its modules load now). Also fixed: a `unit role` body's `use` ran
-      *after* the role composed, so `also does` failed with `Unknown role` even for
-      a role that existed — the `PDF::Class` blocker
-      (news/2026-07/unit-role-body-use-hoisted-before-composition.md).
-      **Remaining from that run — only 1 is mutsu's:** `String::Utils` needs
-      `nqp::` ops. **Measured 2026-07-26: do NOT build an `nqp::` layer** — the
-      20% reverse-dependency weight it appears to carry is dominated by
-      `JSON::Fast`, which mutsu already *bundles*, so implementing its 42 missing
-      ops would change nothing observable; and per dist the op set is a threshold
-      function (80% of a module's ops still leaves it dead) spanning thunk-taking
-      control ops and a null sentinel. Bundling the few nqp-heavy hub modules is
-      much cheaper. The one real `nqp::` demand found was **`nqp::sha1`, which
-      blocked the vendored zef install path** (`Zef::Distribution.id`) — now
-      implemented (news/2026-07/nqp-sha1.md); `Zef::Distribution.id` matches
-      rakudo's digest exactly. Details and the measurements:
-      `news/2026-07/nqp-op-layer-measured-and-rejected.md`. The other four
-      were **mis-classified**, each verified against `raku -I lib`:
-      `PDF::Class` and `Qwiratry::Test` merely lack an uninstalled dependency
-      (`PDF::COS`, `Qwiratry::Query::Slang` — raku cannot load them here either),
-      and mutsu reported a downstream symptom instead of "Could not find", which
-      the role fix above corrects for the `PDF::Class` shape;
-      `RakudoContainerfileBuilder` and `Raku::Pod::Render` both **load fine** but
-      export a `MAIN`, which `-e 'use M'` then dispatches — the first prints its
-      usage (raku exits 2 doing the same), the second runs `npm`/`git` and so
-      hangs under the no-net sandbox. **That probe is fixed:** the sweep now runs
-      `use M; exit 0`, which suppresses MAIN dispatch — and making *that* work was
-      a real mutsu bug of its own (`exit` ran MAIN afterwards, printing usage and
-      exiting 2 where raku exits 0;
-      news/2026-07/exit-skips-main-dispatch.md). Re-running with it,
-      `RakudoContainerfileBuilder` is `load_ok` and `Raku::Pod::Render`'s
-      `InstallAtomHighlighter` is too; the latter then stops on a genuinely absent
-      `URI` dependency, and the bare `X::Comp::Group: Missing block` it used to
-      report now names the culprit and the line
-      (news/2026-07/gobbled-block-error-names-and-locates.md).
-      **Standing rule when reading a sweep: verify any non-`missing_dep` bucket
-      against `raku -I lib` before treating it as a mutsu bug — 4 of 6 here were
-      not, and two "reproductions" reduced from a truncated prefix turned out to
-      be invalid Raku that raku rejects too.**
-      **★The `--run-tests` axis is the sharper frontier — work it next.** Running
-      each loading dist's own suite with raku as the baseline (2026-07-25, same
-      sample): of 28 `load_ok` dists only **7 pass their suite, 5 fail, 14 die**
-      (27% of graded). One is already fixed — `Prime::Factor` needed multi dispatch
-      to honour a named parameter's aliases
-      (news/2026-07/multi-dispatch-honours-named-param-aliases.md) and now matches
-      raku across all four of its files. The remaining 18, with three already
-      triaged (`String::Splice` ×2, `Text::Sorensen`, `Locale::Dates`), are in
-      `todo/tickets/dist-test-suite-failures-batch.md`. This is the
-      execution counterpart of the signal-only
-      [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md)
-      and the highest-leverage way to widen the batteries base. Workflow per bug:
-      minimal repro → general fix → `t/` pin → PR → re-check with `--only <Dist>`.
-- [ ] **NativeCall remainder**: ~~① `CArray[uint8]`, `CArray[Str]`~~ (done — CArray[T] is a
-      constructible/indexable native-backed buffer, marshalled to a `T*` / `char**` argument with
-      out-array writeback; `t/nativecall-carray.t`) ~~② `is repr('CStruct')` structs~~ (done for the
-      common case — a CStruct is an **opaque native handle passed by pointer**: a return is wrapped in
-      a defined instance of the declared class carrying the C address, an argument reads that address;
-      also `Blob`/`Buf` byte-buffer args with out-buffer writeback, and `is native(&sub)` code-object
-      library names. This is what made the genuine OpenSSL + IO::Socket::SSL binding run a real
-      `https://` GET — see news/2026-07/openssl-battery-https.md. Still TODO: **by-value** CStructs
-      (field-layout marshalling, not a pointer)) ③ callbacks (generic C callbacks). Not yet: a
-      *returned* `CArray[T]` is surfaced as the raw `Pointer` it carries (no length to reify a Raku
-      array), and `.^name` reads `CArray[uint8]` rather than raku's `NativeCall::Types::CArray[uint8]`.
-      Everything from the MVP up to real SQLite CRUD is done (news/2026-06.md archive section).
-- [ ] **Remaining 2 blockers for full Humming-Bird serving** (LOAD + LISTEN + accept + decode works;
-      #3549): **B1** = leakage of `var_type_constraint` from typed parameters to same-named caller
-      lexicals (the proper fix scopes the global name-keyed HashMap at call boundaries;
-      env-authoritative-ization is not possible because it breaks subset-6e). **B2** = a detached
-      `start{react{whenever $chan{}}}` is not driven unless awaited = the concurrency-scheduling
-      campaign. Details = memory `session-24-humming-bird-loads`.
-- [ ] **Remainder from the HTTP::Server::Tiny deep dive**: keep-alive consecutive requests, chunked
-      request bodies, and `done`/`last` control signals inside `whenever $conn.Supply(...)` (the tap
-      callback runs on a worker thread, disconnected from the react control-flow frame). These do not
-      fire in the default configuration, so basic serving is unaffected.
-- [ ] Stored Regex `<$var>` lexical capture loss (found via the retired Tubu fixture; separate axis).
-- 📌 **Correction (2026-07-27): the "`MoarVM::Guts::REPRs` is a de-facto wall" verdict recorded here
-  (investigation conclusion = news/2026-06.md) is false.** The guts module loads, and the
-  off-the-shelf `DBDish::SQLite` passes 8 of `DBIish`'s 9 files at raku parity without going near
-  `BODY_OF`. What is genuinely left is the `mysql` driver, which needs a stable native buffer behind
-  `Blob`/`array`/`CArray` — designed in
-  [ADR-0015](docs/adr/0015-native-backed-container-storage-and-repr-bodies.md) (Accepted), findings in
-  `todo/deep/nativehelpers-blob-moarvm-guts.md`. **P2 (native-backed `Buf`/`Blob`) landed 2026-07-28**
-  and `pointer-to(Blob)` now works; the two follow-on bugs (a ternary then-branch enum value, and a
-  hyper not descending into an itemized list) are fixed too, so `DBIish` is at raku parity on all
-  nine files. **P3a (native-backed Raku-side `CArray[T]`) landed 2026-07-30** — `.REPR`/`.WHERE` are
-  honest, a native call is handed the array's own bytes, and `NativeHelpers::Blob`'s `01-basic.t`
-  (24/24) and `03-pointer.t` (10/10) joined the battery gate
-  ([news](news/2026-07/carray-native-storage.md)). Still open: **P3b** (`array[T]`, which needs the
-  `ArrayData::items` accessor chokepoint first, and is also the fix for `array-shapes.t` T36-38) and
-  **P3c** (reference-element `CArray[Str]`/`CArray[Pointer]`, parity polish — no bundled dist needs
-  C to write one).
+### B4. Module-compatibility frontier (the base of batteries)
+
+- [ ] **★Real-dist compatibility sweep** — run real fez dists under mutsu and fix the general bugs
+      they surface. Ledger: [docs/dist-compat-sweep.md](docs/dist-compat-sweep.md). **The `--run-tests`
+      axis is the sharper frontier**: running each loading dist's own suite with raku as the baseline.
+      Open batch: [todo/tickets/dist-test-suite-failures-batch.md](todo/tickets/dist-test-suite-failures-batch.md).
+      Per bug: minimal repro → general fix → `t/` pin → PR.
+      **Standing rule when reading a sweep**: verify any non-`missing_dep` bucket against
+      `raku -I lib` before treating it as a mutsu bug — most turn out not to be.
+- [ ] **Do NOT build an `nqp::` op layer** (measured 2026-07-26 — `news/2026-07/nqp-op-layer-measured-and-rejected.md`).
+      The reverse-dependency weight is dominated by modules mutsu already bundles, and per dist the
+      op set is a threshold function. Implement an individual op when a real dist needs it (as
+      `nqp::sha1` was for zef).
+- [ ] **NativeCall surface gaps** — inventory in
+      [todo/tickets/nativecall-surface-gaps.md](todo/tickets/nativecall-surface-gaps.md); native-backed
+      `array[T]` / reference-element `CArray` are ADR-0015 P3b/P3c.
+- [ ] Other open module-compat findings are individual files under
+      [todo/tickets/](todo/tickets/) and [todo/deep/](todo/deep/).
 
 ---
 
-## 2. ★ Phase B: GC → NaN-boxing → JIT — the headline layers are DONE; a soundness tail remains
+## 2. Substrate — GC, NaN-boxing, JIT: landed; soundness tail remains
 
-**All four headline layers landed.** What is left is *not* another layer — it is the GC
-**soundness tail** (unsafe raw-pointer writes) plus minor perf/hardening. Do not restart a
-"GC campaign" from scratch; work the tail below in order.
+| layer | status |
+|---|---|
+| 3a — cycle collector on `Arc`, type-filtered | ✅ default on (ADR-0003) |
+| 3b — NaN-boxing (`Value` 48→8B) | ✅ done |
+| 4 — JIT (Cranelift) | ✅ default on (ADR-0004 closed) |
+| 3c — biased refcount | 🧊 frozen; measured-trigger only |
 
-| Layer | Status |
-|-------|--------|
-| 3a — cycle collector on `Arc`, type-filtered | ✅ done, default on (2026-07-05, ADR-0003) |
-| 3b — NaN-boxing (`size_of::<Value>()` 48→8B) | ✅ done (2026-07-12, #4467 B-guards / #4469 B-flip; benches 5–9% faster = gate met) |
-| 4 — JIT (Cranelift) | ✅ done, default on (2026-07-15, all 6 J4d slices, ADR-0004 closed) |
-| 3c — biased refcount | 🧊 frozen (measured-trigger only; gc-post-3a-roadmap §4) |
+Do **not** restart a "GC campaign". What is left:
 
-History/details in [news/2026-07.md](news/2026-07.md). JIT bench numbers come from the bench CI
-(`bench-data` branch; `+jit` series from #4480). The remaining interpreter/JIT shared fixed cost
-(SetLocal env-mirror) is the §6 lexical-slot campaign, not a GC item.
-
-### 2.1 GC soundness tail — the real remaining GC work
-
-The `gc::gc_contents_mut` / `Gc::{get,make}_mut` primitive writes through `Arc::as_ptr as
-*mut` — a provenance violation (Rust UB) + a data race when the target is genuinely shared.
-This is the only GC work with real payoff left; it is **soundness**, medium impact.
-
-**✅ Step 1 (inventory) DONE (2026-07-20)** — [docs/gc-contents-mut-inventory.md](docs/gc-contents-mut-inventory.md).
-Every production site was read and classified. Decisive result — **54 sites / 20 files**:
-**(a) provably-unique = 3** (cyclic-structure construction on freshly-created nodes),
-**(b) make_mut-COW-coverable = 0**, **(c) needs first-class cell = 51**, (?) = 0. Every guarded
-site *already* routes the unique case to `make_mut` and reserves `gc_contents_mut` strictly for
-the shared+identity case. So:
-
-- **`make_mut`-COW is a dead end** — it can retire zero sites. The earlier "route easy clusters
-  through COW" idea is empty; do not pursue it.
-- **✅ Step 2 (the 3 (a) sites) DONE (2026-07-20)**: `debug_assert_eq!(strong_count(), 1)` added
-  before each aliased `&mut` in `vm_var_assign_ops.rs` (fixup_circular_hash / replace_array_refs_in_value /
-  fixup_circular_array_refs) to document provable uniqueness. Zero behavior change (debug-only assert);
-  the truly-unaudited surface is now just the 51 (c) core.
-- **✅ Step 3 — the (c) sites: PROVENANCE UB FIXED (ADR-0013, landed).** Not the deferred
-      `CellValue` campaign this entry used to describe: per
-      [ADR-0013](docs/adr/0013-container-interior-mutability-cellvalue.md) §7 the `UnsafeCell`
-      was placed in `GcBox.value` (`src/gc/gc_ptr.rs:166`) instead of wrapping each container
-      payload, so **every** `Gc<T>` is interior-mutable at the primitive and all the aliased-write
-      sites became provenance-sound *with no call-site or `Value`-representation churn*. The
-      per-container migration and the `GcCell` newtype were dropped; the fusion-with-Track-B
-      premise no longer applies (ADR-0001 §7).
-- [ ] **Step 3b — close ADR-0013: the Miri gate (§4 phase 4) is still missing.** There is no
-      `miri` job in `.github/workflows/`, so the soundness claim above rests on an argument, not
-      a check. Add it informational-first, then blocking (pin a nightly matching the crate's
-      stabilized-feature usage). Also correct `src/value/aliased_mut.rs`'s module header, which
-      still documents the provenance violation as live and names Track B as the future fix — both
-      false since ADR-0013. The narrow cross-thread race stays deferred to layer 3c by decision.
-- **✅ Step 4 (independent) DONE (2026-07-20)** — hardened the buffered-clone / uniqueness
-      invariant. `Gc::verify_unique_for_aliased_mut` machine-checks the `strong == 1 ⟹ unique`
-      argument that `make_mut` / `get_mut` and the three (a) `gc_contents_mut` sites rely on, by
-      asserting the backing `Arc`'s strong count equals the GC-visible `header.strong` at the moment
-      an aliased `&mut` is taken (they move in lockstep for every live handle; the candidate buffer
-      holds only `Weak`, so a divergence means a live reference the `strong == 1` fast path assumes
-      away). Reports via the same non-fatal `VERIFY FAIL` stderr line the collector uses (gc-stress
-      CI greps for it). Compiled out in release; verify-gated (`MUTSU_GC_VERIFY=1`), and skipped when
-      `collecting()` or `other_mutators_active()` so it is a hard signal only under the single-threaded
-      gc-stress CI and never trips a benign transient collector clone in a multithreaded verify run.
-      Pins: `gc_ptr` unit tests `arc_and_gc_strong_counts_stay_in_lockstep` /
-      `erased_clone_makes_arc_exceed_gc_strong`.
-
-### 2.2 Lower-priority GC follow-ups (profile-driven; defer under 2.1)
-
-- [ ] **3b-2 clone-traffic pruning** (`gc-post-3a-roadmap` §3.3): clone/drop is now an 8B copy,
-      so reduce needless clones themselves (overlaps the ~9k `.clone()` inventory). Profile-driven.
-- [ ] **Layer 3a hardening H1–H5** (`gc-post-3a-roadmap`): suppressing grammar-parse candidate
-      pushes (~510k/200-parse) is unstarted — the real harm (memory retention) was already fixed
-      via `Weak`, so this is optimization, not a leak fix.
+- [ ] **Close ADR-0013 — the Miri gate**:
+      [todo/tickets/miri-gate-for-adr-0013.md](todo/tickets/miri-gate-for-adr-0013.md).
+- [ ] Profile-driven GC follow-ups (clone-traffic pruning, layer-3a hardening H1–H5):
+      `docs/gc-post-3a-roadmap.md`. Optimization, not correctness.
+- [ ] OTF compilation-gate leftovers:
+      [todo/tickets/otf-compilation-gate-leftovers.md](todo/tickets/otf-compilation-gate-leftovers.md).
 
 ---
 
-## 3. 🔴 substrate — removing the multi-dispatch tree-walk fallback (leftovers)
+## 3. roast — at its ceiling; no cluster left to attack
 
-The major campaigns (single-store unification, tree-walk interpreter removal, first-class containers,
-state ownership, multi-dispatch VM-ization, **module-sub OTF gate relaxation #4427→#4429→#4431→#4437**)
-are complete ([news/2026-06.md](news/2026-06.md) / [news/2026-07.md](news/2026-07.md)). The gate
-itself = `def_is_otf_compilable_module_single` (`vm/vm_call_func_ops.rs`). The frontier of
-"just remove the gate and experiment" is exhausted; every remaining task requires **mechanism work**:
+The whitelist stands at **1435 / 1464**. `integration/` — the real-Raku-program files closest to the
+project goal — is **fully whitelisted**. Per
+[TODO_roast/BLOCKERS.md](TODO_roast/BLOCKERS.md), nearly every remaining file is *non-goal* (rakudo
+itself fails), *no oracle* (local raku SORRYs), or *awaiting infrastructure* (6.e generics).
 
-- [ ] **OTF for `start` = per-call capture cells**: when a recursive sub's start closure captures a
-      param, the re-bind of the recursive call clobbers the captured value, so this is excluded
-      wholesale (regression pin = `t/start-block-return-value.t` test 3; proof of infeasibility and
-      history = news/2026-07.md).
-- [ ] **OTF for sigilless scalar (`\x`) params**: caller writeback of raw aliases across EVAL needs a
-      mechanism equivalent to #4091 (`is rw` compile-time caller slot)
-      (FAIL pin = `t/sigilless-params.t` "sigilless aliases are writable through EVAL calls").
-- Intentionally excluded (decided not to do): default-param builtin-shadow single candidate
-  (name-cache pollution risk; user policy) / `is encoded(...)` (NativeCall; zero practical harm) /
-  `state` sharing across signature alternates (kept as an interpreter boundary).
+**Implication for planning: roast is no longer the productive axis.** Prefer §1, §4, §5 or §6; pick
+up a roast file only when another change happens to unblock it.
+
+- [ ] Language-feature gaps that no roast file whitelists (multi-line feeds, the remaining typed
+      exceptions, `exits-ok`, `:D`/`:U` DefiniteHow):
+      [todo/tickets/remaining-language-feature-gaps.md](todo/tickets/remaining-language-feature-gaps.md).
 
 ---
 
-## 4. 🟢 roast backlog — `integration/` is DONE; what remains is 33 mostly-unachievable files
+## 4. perf — de-prioritized polish
 
-The whitelist stands at **1430 / 1463** (2026-07-17) = **33 files** not whitelisted. The
-authoritative detailed table is [TODO_roast/BLOCKERS.md](TODO_roast/BLOCKERS.md).
+mutsu beats raku on the whole roast whitelist and on every benchmark, so **do not pick up a perf item
+just because the profile shows a hot symbol** — first confirm a goal item needs it. Levers, targets
+and the measurement protocol: [ADR-0006](docs/adr/0006-baseline-interpreter-optimizations.md),
+[docs/perf-callpath-scouting.md](docs/perf-callpath-scouting.md); canonical numbers come from the
+bench CI, never a local run.
 
-**`integration/` is fully whitelisted (0 remaining).** That was this section's headline
-target — "the bulk of the non-whitelisted files is the 41 `integration/` files", the real
-Raku programs closest to the project goal. The last one, `advent2013-day18.t`, landed
-2026-07-17 ([ADR-0009](docs/adr/0009-regex-code-assertion-execution-model.md)). The former
-①(stack overflow) / ②(unparseable) / ③(hang) / ④(error-message) clusters are all cleared —
-history in [news/2026-07.md](news/2026-07.md).
-
-**Re-measured 2026-07-27** — the 32 remaining, by area: `6.c/` 4, `S02-names` (pseudo-package)
-3, `S12-*` 6, `S05-*` 5, `S32-str` 1, `S10-packages` 2, `S06-advanced` 2, `APPENDICES` 2,
-`roast/t/` 2 (roast's own Perl 5 tooling — non-goal by definition), and 5 singletons.
-
-**There is no cluster left to attack.** Per the BLOCKERS.md classification nearly all of
-these are *non-goal* (rakudo itself fails), *no oracle* (local raku SORRYs, so the correct
-answer cannot be confirmed), or *awaiting infrastructure* (6.e generics for
-`S02-types/generics.t`). The genuinely ★achievable ones are few and each
-needs its own unrelated feature:
-
-- [ ] `6.c/APPENDICES/A04-experimental/01-misc.t` — 16/19. `:D`/`:U` DefiniteHow coercion.
-
-**Implication for planning: roast is no longer the productive axis.** Prefer §1 (Batteries /
-mzef), §5 (perf) or §6 (concurrency / structural refactoring). Pick up a roast file only when
-a §1/§5/§6 change happens to unblock it.
-
-The only real feature gaps left in the S\* series (they do not directly lead to whitelisting):
-
-- [ ] Multi-line feed: feeds spanning lines with a leading `==>` (blocked by the
-      `!ws_before.contains('\n')` guard in `parse_list_infix_loop`). `ff`/`fff` and single-line feeds
-      are done. `==>>`/`<<==` and `~<`/`~>` are unimplemented/unspecified in rakudo itself = cannot
-      be started.
-- [ ] Remaining typed-exception gaps: strict-mode undeclared-variable detection / cross-EVAL
-      detection of class redeclaration / X::Redeclaration::Outer (compile-time scope analysis). All
-      non-trivial, and none whitelists a roast file on its own.
-
-### Gaps surfaced by the `raku-doc` update to `468a767f` (2026-07-07)
-
-Audited the whole `raku-doc` diff `6c879bc7..468a767f` (see `vendor.lock` / `docs/vendoring.md`)
-for newly-documented language features. Everything documented in the update is **already
-implemented** — parameterised regexes (`my regex r ($x) {…}` called as `<r: arg>` and `<r(arg)>`),
-and `Instant.from-posix` / `.to-posix` / `.Date` / `.DateTime` all match raku — **except one**:
-
-- [ ] `exits-ok($code, $exit, $reason)` — new `Test` routine (`Type/Test.rakudoc`): passes if the
-      code exits with the given exit code. Implement alongside the sibling `dies-ok` / `lives-ok`
-      Test routines (Test-module handler, not a core builtin — it is not in `perl-func.rakudoc`).
-      Note: no roast file uses it (not in upstream roast HEAD either), so this is Test-completeness /
-      batteries polish, **not** a roast-whitelisting lever.
-
-### Vendored `roast` bumped `7f2d7508` → `b2cbe8a4` (2026-06-12) — DONE 2026-07-18
-
-The roast bump landed. All four prerequisite feature clusters were implemented first (plan A,
-no whitelist regression), then `scripts/update-vendor.sh roast b2cbe8a4` re-vendored the tree
-(33 files: 1 new, 32 modified). All 28 whitelisted-and-changed files still pass; no whitelist
-edits were needed. The clusters, now merged:
-
-- ✅ **① List-of-overlapping-needles `index`** — #4710.
-- ✅ **② Immutable QuantHash RO errors** — `:delete`/`DELETE-KEY`/`ASSIGN-KEY` on immutable
-      Bag/Mix throw `X::Assignment::RO`. Shipped in the bump PR (behavior change).
-- ✅ **③ 6.e sprintf flag combinations** — sign-before-prefix, radix-flag rules, `#` forced
-      decimal point, string zero-pad. `v6e_active()`-gated so 6.d is byte-identical. Shipped in
-      the bump PR (behavior change).
-- ✅ **④ `.assuming` priming signature gist** — #4722.
-
-**Remaining after the bump:** the new `S02-types/quanthash.t` stays non-whitelisted — it needs
-`.^parameterize` on Set/Bag/Mix (parameterized QuantHash types), tracked in
-[TODO_roast/BLOCKERS.md](TODO_roast/BLOCKERS.md).
+- [ ] **The one axis where mutsu is genuinely slower than raku** — the interpreter function-call path
+      in hot loops (the JIT bails at the call boundary):
+      [todo/deep/interpreter-call-path-in-hot-loops.md](todo/deep/interpreter-call-path-in-hot-loops.md).
+- [ ] **The `needs_env_sync` blanket** — the last structural piece of dual-store decoupling, a fused
+      campaign: [todo/deep/needs-env-sync-blanket-removal.md](todo/deep/needs-env-sync-blanket-removal.md).
+- [ ] Grammar/regex per-subrule ceremony (~25× vs raku per matched character; the exponential and
+      accumulated-state halves are fixed):
+      [ADR-0007](docs/adr/0007-grammar-parse-trail-matcher.md) §Implementation outcome.
+- [ ] Opcode leftovers: [docs/opcode-design-review.md](docs/opcode-design-review.md) §2/§5/§6.
+- [ ] Biased reference counting (ADR-0001 layer 3c) — frozen; start only on a measured trigger and an
+      updated ADR.
 
 ---
 
-## 5. perf — execution speed (measurement-driven; MUTSU_VM_STATS / timed roast)
+## 5. Concurrency and structural refactoring
 
-> **De-prioritized 2026-07-16 (see header).** mutsu already beats raku on the whole roast whitelist
-> and on every benchmark here, and mzef's ctor path is faster than raku — **performance is not what is
-> blocking mzef.** This section is kept as a reference of levers and measurements, but do **not** pick
-> up a §5 item just because the profile shows a hot symbol: first confirm mzef (or another goal item)
-> actually needs it. The remaining big lever is biased reference counting (§ Lever 6 / ADR-0001 layer
-> 3c) — a multi-week, high-risk campaign that would shave the inherent per-clone atomic-refcount cost;
-> it is explicitly **not** required for mzef and should only be started as a deliberate, ADR-updating
-> decision, not autonomously. (2026-07-16 investigation: the nanbox ~20% is dominated by the two
-> atomic refcount ops per `Gc` clone / two per drop, inherent to the dual-count Bacon-Rajan-on-Arc
-> design; the drop side is already optimized; cheap wins are exhausted.)
-
-**Completed levers** (details = news/2026-06.md / news/2026-07.md): method-call hot path round 1
-(#3853/#3857/#3859/#3867/#3870) / removal of the per-call env deep clone via single-store
-unification / the malloc clusters from `Value` clone/drop and attribute materialization
-(#4447 / #4451 / #4494 — attributes became `AttrMap` = `FxHashMap<Symbol, Value>`, and the
-`__memcmp_avx2` 5.2% in the profile disappeared) / **Lever 2 NaN-boxing** (ADR-0001 layer
-3b, #4467/#4469; `Value` 48→8B). Remaining levers:
-
-- **Lever 3: threaded dispatch — frozen** (user-approved 2026-07-06;
-      [ADR-0004](docs/adr/0004-jit-strategy.md) §2.5 J0): JIT Tier A takes the same gain — larger —
-      by removing the dispatch loop, so avoid double investment. Revive only if the JIT fails.
-- **Lever 4: JIT (Cranelift) = ADR-0001 layer 4 — done** (J1–J5 + all 6 J4d slices; default on;
-      gate judgment included — **ADR-0004 closed** (see the 2026-07-15 addendum)).
-      Lever 5: skipping type-constraint checks in tight loops was mostly recovered by J3's
-      `type_matches_value` fast accept. Canonical bench numbers = the bench-data branch
-      (`+jit` series).
-- [ ] **Lever 6: biased reference counting = ADR-0001 layer 3c (independent perf work, post-GC)**.
-      Frozen — the only start trigger is "atomic inc/dec remains near the top of the profile after
-      JIT J4 completes" (gc-post-3a-roadmap §4).
-- [ ] **Lever 7: baseline (classical) bytecode optimizations = [ADR-0006](docs/adr/0006-baseline-interpreter-optimizations.md)**.
-      Orthogonal to the JIT (it shortens the executed opcode sequence itself).
-      **§2.1 constant folding (#4485), §2.4 constant-pool dedup (#4486), §2.2 `constant` inlining +
-      constant-condition DCE (#4487), §2.3-a declaration-sequence fusion (#4488), and §2.3-b
-      `SetSourceLine` removal (#4489) are done** (contents and numbers per slice = news/2026-07.md).
-      Remaining:
-      - **★Lesson learned here = reducing opcode count ≠ reducing time** (measurement protocol =
-        [ADR-0006 §"Measurement protocol for implementation slices"](docs/adr/0006-baseline-interpreter-optimizations.md)).
-        `SetSourceLine` was 21% of executed opcodes (fib) but the cheapest single-store op, so the
-        time saving was an order of magnitude smaller (**-3.4% instructions**; JIT path ±0). Worse,
-        the implementation that added a refresh to every instruction was a **+7.8% instruction**
-        deficit. Before touching the remaining administrative ops (`SetVarDynamic` 500k,
-        `CheckReadOnly` 100k), **first confirm with perf retired instructions (`instructions:u` +
-        `taskset` core pinning — otherwise it wobbles 8%) that they actually consume time**. If it's
-        a miss, don't chase it.
-      - [ ] **§2.3-c remaining administrative ops (`SetVarDynamic`, `CheckReadOnly`)** — start only
-            after passing the pre-measurement gate above.
-- [ ] **★The next perf target is what the profile shows — "allocation, hashing, env" (not the opcode
-      histogram)**. **Order of attack, root causes, and gates are already researched in
-      [docs/perf-callpath-scouting.md](docs/perf-callpath-scouting.md).**
-      The table below is from `perf record -e cycles:u` on release, JIT on (default configuration),
-      pinned to a P-core (2026-07-13, after #4489), and is **the evidence that drove #4492–#4495**.
-      Now that those have landed (readonly deep clone, sigilless-key `format!`, and attribute
-      `String` keys are removed), **the table is stale = re-profile before starting the next item**:
-
-      | bench-fib (call-heavy) | % | bench-class (object-heavy) | % |
-      |---|---|---|---|
-      | `call_compiled_function_positional_light` | 10.9 | `malloc`+`_int_malloc`+`_int_free`+`malloc_consolidate` | **19.5** |
-      | `_int_free`+`_int_malloc` | **11.8** | `__memcmp_avx2` (attribute-name `String` key comparison) | 5.2 |
-      | `Env::scoped_child` | 5.4 | `nanbox::gc_op`+`Gc::drop` | 7.7 |
-      | **JIT native code itself** | *5.7* | `exec_call_method_mut_op` | 2.7 |
-      | `Env::get_sym` | 4.4 | `AttrReadGuard::drop` | 2.3 |
-      | **SipHash `Hasher::write`** | 4.1 | | |
-      | `hashbrown RawTable::clone` (env table duplication) | 3.7 | | |
-
-      Reading: in fib, **the JIT-generated native code only runs 5.7% of the time — allocation
-      (11.8%) + hashing / env table duplication (12%+) + the call path (10.9%) dominate**. In
-      bench-class **the allocator alone is ~20%**, plus attribute-name `String` key comparison
-      (memcmp 5.2%).
-
-      **Consumed by 2026-07-14 (details = news/2026-07.md)**: allocation-free per-call readonly
-      snapshots and return merge (#4492 — **bench-fib -32.3% / bench-tak -23.9%**) / pre-interning of
-      sigilless-alias and readonly env keys (#4493 — num-arith -21.6% / bench-mandelbrot -14.9%) /
-      `Symbol`-keyed attributes (#4494 — ✅ above) / stopping per-declaration/per-store metadata key
-      rebuilding (#4495 — time-parts -37.2% / bench-mandelbrot -33.7%) /
-      **removal of intern, SipHash, and COW from the declaration path (`my $x = ...`)**
-      (#4506/#4507/#4508 — time-parts went from **1.17 → 0.62 vs raku with JIT on**, and even
-      interpreter-only from 1.46 → 0.93, beating raku. Breakdown = latching the placeholder `^name`
-      probe, using the pre-interned Symbol that `flush_local_to_env` was discarding, removing the
-      re-intern/String allocation in `SetVarDynamic`, avoiding `Arc::make_mut` on absent-key
-      deletion, removing the SipHash probe on empty maps, and `Symbol`-keying the
-      declaration-tracking set. Along the way, **~310 lines of the unreachable `simple_locals` fast
-      path were deleted** (scalar locals are stored without sigils, so `name.starts_with('$')` was
-      always false = it had never executed)).
-
-      **★Re-baseline 2026-07-15 (roast-wide raku-vs-mutsu wall-clock, `scripts/roast-speed-diff.sh`
-      over the 1358 runnable whitelisted tests):** mutsu beats raku (Rakudo 2022.12) on ~1348/1358
-      tests, usually 2–30× (fast startup + JIT). The **only** files where mutsu is meaningfully
-      *slower* (clean single-run ratios, release):
-      `S04-declarations/state.t` **4.2×** (`for ^2000000 { $ = foo }`), `S06-signature/named-parameters.t`
-      **2.6×** (`for ^1000000 { foo(:color($_)) }`), `S07-iterators/range-iterator.t` **1.7×**,
-      `S12-methods/private.t` **1.6×**. Isolated micro-repro: a 1M-iteration loop calling a sub is
-      **1.85× slower** than raku positional / **2.6× slower** with a named arg. **All of these converge
-      on one root: the interpreter function-call path in hot loops.** The JIT *bails at the call
-      boundary* (proven: positional 1M loop is `MUTSU_JIT=on` 0.74s ≈ `off` 0.72s — JIT does nothing),
-      so any loop that calls a sub runs the interpreter call path, whose profile is **~15% malloc/free
-      churn per call** (frame + named-args structure + `Env::cow_mut` + `Arc::drop_slow`) plus per-call
-      `current_package`/`Env::get_sym`/param-binding (`exec_set_local_op_inner`). Named args add
-      disproportionate cost (mutsu **+46%** vs raku **+6%**) = a `String`-keyed named-args structure
-      rebuilt every call. **This is the highest-value perf target** — it hits real spec tests and the
-      most common real-world shape (a loop that calls a sub), unlike the two items below which polish
-      benchmarks mutsu already wins. (`bench-grammar-parse`'s synthetic 6.4× gap does NOT surface in
-      the roast whitelist — the whitelisted grammar tests are not pathological.) See memory
-      `project_roast_speed_measurement`.
-
-      **Remaining (in order of attack)**:
-      -1. **★Function-call path in hot loops (NEW top priority, from the re-baseline above)** — reduce
-         the per-call allocation churn: reuse the call frame / named-args storage, cut `Arc::drop_slow`
-         on teardown, cache `current_package`, and avoid rebuilding the `String`-keyed named-args
-         structure each call (intern the param names, bind by `Symbol`/slot). Because the JIT bails at
-         calls, this is interpreter-path work that no amount of JIT progress will subsume. Pins:
-         `roast/S04-declarations/state.t`, `roast/S06-signature/named-parameters.t`; micro-repro in the
-         re-baseline note. **Update 2026-07-21:** the light-call path
-         (`call_compiled_function_light_spec`, `vm_call_light_typed.rs`) is *already* heavily J4d-tuned
-         — pooled callee locals (`take_locals_from_pool`, no per-call `Vec` alloc), `std::mem::take` of
-         caller locals, and **frame reuse** that skips the env clone when the caller's overlay is still
-         the shared-empty singleton. So the remaining churn is concentrated in the **named / slow**
-         path (`call_compiled_function_named` — `args.to_vec()` + the `String`-keyed named-args
-         structure), not the positional light path; target that path specifically. **This whole item is
-         §5 polish and de-prioritized per the priority reset at the top of this file** — before picking
-         it up, confirm it unblocks a goal item (it does not unblock mzef).
-      0. **★Removing the `needs_env_sync` blanket (a dedicated-session fused campaign; NOT a
-         standalone change — see the four-mechanism breakage below)** — currently `captures_env_by_name`
-         (true if the frame contains even one
-         `ForLoop`/`BlockScope`/`BlockLocalScope`/`MakeGather`/`WheneverScope`) **makes every local in
-         the frame an env mirror target**, so locals never read by name — like a loop body's `my $ts` —
-         are written to env on every store. **Update 2026-07-21:** the *per-store* half of this — the
-         `exec_set_local_op_inner` tail env write for plain lexicals — was gated permanently by the
-         `(B)` gate (#4942 flip → #4980 removal, now unconditional for `!captures_env_by_name` frames),
-         so `while`/`loop` bodies already benefit (-10–16% on a JIT-bailed while-5M loop). **What
-         remains is precisely the `captures_env_by_name` blanket**, and its immediate perf payoff for
-         the common case is small: the loop body compiles **inline into the same frame as the `ForLoop`
-         op** (`stmt.rs` emits body ops right after `ForLoop`, `body_end` marks the range), so a `for`
-         body's accumulator slots get blanket-synced — yet dropping `ForLoop` from
-         `captures_env_by_name` measured **±0%** (memory), because the loop mechanism writes the loop
-         var to *both* slot and env (`vm_for_loop_body.rs:243/251`) and a pure arithmetic body reads its
-         accumulators from slots, not env. The lever is really the fused precise-ification (per-slot,
-         not per-frame) of the block-restore / loop / gather / whenever / closure-capture consumers, not
-         a `ForLoop`-only drop. Given PLAN's priority reset (perf is de-prioritized §5 polish), this is
-         **not a near-term item**. **Update 2026-07-15 (probed, then clean-reverted):** the actual
-         per-store cost is the *unconditional* env write at the tail of `exec_set_local_op_inner`
-         (`vm_var_assign_set_local.rs`, `set_env_plain_lexical`/`set_env_with_main_alias`) — NOT
-         `flush_local_to_env`, which is already gated on `needs_env_sync` (so the `env_flushes`
-         counter reads 0 and does not surface this; measure by wall-clock). Gating that tail write on
-         `needs_env_sync || reflective` won ~7% on a JIT-bailed `time-parts` loop but **deterministically
-         broke four independent mechanisms** (each pinned by an existing test), confirming this is a
-         fused campaign, not a standalone change:
-         (a) **block-scope restore** — `exec_block_scope_op` reverts `self.locals` to the pre-block
-             snapshot then **re-pulls every local from env by name**, so an outer var mutated inside a
-             bare `{ }` reverts to its pre-block value without the env seed (`my $x=1;{$x=2};say $x`
-             printed `(Any)`). `BlockScope`/`BlockLocalScope` frames therefore still need the blanket;
-             note a loop-body `if { }` stays *inline* (no `BlockScope`) unless the branch declares its
-             own `my` (`BlockLocalScope`), so most hot loops are unaffected.
-         (b) **cross-thread closure capture / `cas`** — a `%h` captured by a `Thread.start` body and
-             mutated via `cas` needs its shared-var cell established through env by name; the gate lost
-             it (`tests/gc_stress.rs::dead_sweep_bounds_threaded_mutation_memory`, sum=2 vs 800).
-             Folding `closure_compiled_codes` free vars + `op_arg_sources_idx` (rw-arg sinks) +
-             `op_container_mutate_const_idx` into `needs_env_sync` fixes this axis.
-         (c) **★method-call caller-local coherence × JIT inline `GetLocal` (the decider; diagnosis
-             CORRECTED 2026-07-15)** — `tests/jit_diff.rs::hot_method_body_compiles_and_matches`
-             (`my $c=…; for ^30 { $c.bump() }`). The earlier "the JIT reads the outer lexical from env"
-             claim was **wrong** — proven by unconditionally skipping *only* `$c`'s env write: the JIT
-             run still prints the right answer, because `$c` is read via `GetLocal(0)` from its slot,
-             not from env. The real gatekeeper is **method-call specific** (a positional *sub* call in
-             the same JIT-hot loop is fine): the method path keeps caller-local coherence through env
-             (`vm_call_method_ops.rs` `drain_and_reconcile_after_cached_call`), so once the gate makes
-             `$c` env-absent, the first `bump()` leaves `$c`'s slot in a state the JIT's Tier-B **inline**
-             `GetLocal` (which bypasses `exec_get_local_op`) reads as `Any`, while the interpreter's
-             `exec_get_local_op` still reads it correctly — so it only surfaces under `MUTSU_JIT_THRESHOLD=1`
-             (JIT off / default threshold pass). Fixing it is load-bearing method-dispatch work.
-         (d) **currying/priming capture** — `roast/S06-currying/positional.t` aborts at test 157
-             (cause not yet isolated; likely the same method/dispatch env-reconcile as (c)).
-         So it is **a campaign fused with §1.3/§1.5, §6 (`BlockScope`'s `self.locals.clone()`), and the
-         method-dispatch env-based caller-local reconcile** (memory: a standalone change has a track
-         record of breaking 5 mechanisms). Note scalar locals are stored **sigil-less** (`"c"`, not
-         `"$c"`) — relevant when instrumenting. See memory `project_needs_env_sync_blanket_removal`.
-      1. ~~**Remove SipHash from `compiled_fns`**~~ **— DONE (verified stale 2026-07-21).** The
-         function table is already `pub(crate) type CompiledFns = rustc_hash::FxHashMap<Symbol,
-         CompiledFunction>` (`opcode.rs:4057`) — **the FxHashMap + `Symbol`-key migration has
-         landed**, so the light-call cache no longer pays SipHash + a name `memcmp`. The only residual
-         from the original three-step plan is "store the callee itself in the cache to eliminate the
-         second lookup": the light path does two FxHash lookups per call
-         (`light_call_cache.get(name_sym)` then `compiled_fns.get(cached_key)` +
-         fingerprint check — `vm_call_func_ops.rs:146-148`). FxHash is cheap (proven by #4976: "FxHash
-         is instruction-neutral, ~8% only via cache"), so caching the callee directly is **low-value**
-         and would need `compiled_fns` to hold `Arc<CompiledFunction>` (a borrow-checker workaround) —
-         not worth it. Consider this item closed.
-      2. **Remove the callsite-line marker** (scouting §2.3 — `peek_callsite_line`
-         (`runtime/call_helpers.rs:194`) scans args on every call). **Investigated 2026-07-21:
-         lower ROI / higher risk than it looks.** The `__mutsu_test_callsite_line => N` marker is a Pair
-         attached by the parser (`attach_test_callsite_line`, `listop.rs`) **only** to
-         `is_test_assertion_callable` names (`is`/`ok`/`throws-like`/…). Those calls — with or without
-         parens — always compile to `ExecCallPairs` (verified via `--dump-bytecode`), which keeps the
-         marker in-band and does **not** run the `peek_callsite_line` on the CallFunc/CallFuncNamed
-         light paths. So the `peek_callsite_line(&args)` calls in `vm_call_func_ops.rs` (:173/425/473/
-         610/1095) effectively never find a marker on a *regular* sub call — the scan is dead work
-         there. BUT removing it is **not** a clean win: (i) the `expr_call.rs:1161-1162` comment
-         explicitly designs the CallFuncNamed path to carry the marker in-band ("must remain an in-band
-         pair for `peek_callsite_line`"), so a flag-free removal needs certainty the CallFuncNamed path
-         is never marker-carrying — gating instead means threading a `has_callsite_marker` bool through
-         CallFunc/CallFuncNamed (+ their many match sites), high churn for a few-ns/call win; (ii)
-         deriving the line from the op's ip via the `op_lines` table (`CompiledCode::line_at`, #4489)
-         is unsafe for **line-exactness** — the marker captures the *parse-time* line, which differs
-         from the op's recorded line on multi-line assertions, and `test-assertion-line-number.t` pins
-         the exact number. **Deferred as not worth the churn/risk.**
-      3. **Lexical-scope slot campaign** (scouting §2.2; §6's "remove the full locals clone/restore
-         in `BlockScope`") — the core fix that eliminates per-call env materialization itself.
-         Suited to a dedicated session.
-- [ ] **Opcode leftovers ([docs/opcode-design-review.md](docs/opcode-design-review.md) §2/§5/§6;
-      continuation of #4279)**: move the inline `Option<String>` payloads (labels etc. —
-      `Last`/`Next`/`Redo`/loop family/`SmartMatchExpr.lhs_var`) to constant-pool `Option<u32>`
-      (bring `OpCode` under 48B) / measured reduction of per-instruction fixed costs
-      (`current_code` raw-pointer store, `trace_log!` check) / fix the encoding where `Jump(i32)`
-      carries an absolute index / merge specialized ops driven by a per-opcode histogram
-      (`ContainerEq`×4, `IndexAssign*`×6 — driven by data, not aesthetics).
-- [ ] Regexes: reduce `RegexCaptures.clone()` per quantifier iteration. **Update 2026-07-15:
-      the exponential half of this item is FIXED** — ratcheted (`token`/`rule`) separated
-      quantifiers (`* %`) are now possessive (single greedy chain, Rakudo semantics), and
-      ratcheted quantifiers over alternation atoms skip the bounded backtracking expansion:
-      the `S04-exceptions/exceptions-alternatives.t` JSON parse went **12.6s → ~0.9s**
-      (was ~3.6×/pair exponential, now linear), and the capture-heavy alternation case
-      `[ (<[ac]>) | (<[bc]>) ]*` over 40 chars went 372ms → 3.5ms. Pinned by
-      `t/regex-sep-quantifier-ratchet.t`; tracked by `benchmarks/bench-grammar-parse.raku`
-      (mutsu ~5.9s vs raku ~0.5s, **~12×**). **Update 2026-07-15 (2): the Named-subrule
-      per-call ceremony is also FIXED** — subrule resolution+parse is memoized per
-      (pkg, name) in `PARSED_TOKEN_CANDIDATES` (invalidated by `TOKEN_DEFS_GEN`, same
-      discipline as `REGEX_PARSE_CACHE`): the per-reference registry walk
-      (`collect_token_patterns_for_scope` scanned every `token_defs` key), the per-candidate
-      `parse_regex` probe, the singular matcher's scratch sub-interpreter + tail-text
-      `String` copy, and the all-path's `tail.to_vec()` are all gone; the singular arm now
-      matches in place and wraps via the shared `build_named_candidates_from_inner`
-      (capture markers / silent-subrule action channel now behave identically on both
-      paths). bench-grammar-parse **5.9s → ~2.2s (~2.7×)**; nested `matrix` case 3.0s →
-      1.0s. **Update 2026-07-15 (3): nested sub-captures are now shared behind `Arc`
-      (#4586)** — `named_subcaps` / `positional_subcaps` / quantified-capture entries hold
-      `Arc<RegexCaptures>` instead of an owned `RegexCaptures`, so cloning a parent caps at
-      each DFS stack push (and every separated/repetition-quantifier fold) is a refcount
-      bump rather than a recursive deep copy of the whole sub-match tree. Profile:
-      `RegexCaptures::clone`+drop ~10% → ~4% of samples; bench-grammar-parse ~9% faster
-      (1.51s → 1.37s), a deep nested-JSON doc ~4-10% faster. Pinned by
-      `t/regex-nested-subcaps-sharing.t`.
-      **Update 2026-07-16 (4): the trail matcher (ADR-0007, Accepted) is LANDED (#4591)** —
-      the engine walks tokens depth-first over ONE mutable `RegexCaptures` store per
-      pattern level with an undo-log (`regex_trail.rs`: mark/apply-delta/rewind); atom
-      producers return deltas relative to an empty baseline instead of cloning the
-      accumulated caps per candidate, and quantifier chains grow/shrink on the store with
-      a mark per iteration. Per-step capture cost is O(delta), never O(accumulated).
-      Measured (local release A/B): deep bench ~×1.25 (memmove 15.4%→7.5% of samples,
-      `RegexCaptures::clone` 2.1%→1.0%), shallow ~×1.2.
-      **Remaining: per-subrule ceremony — still ~25× vs raku per matched character.**
-      The residual profile (~36% allocator + spread) is a constant cost per subrule
-      invocation, NOT accumulated-state churn: candidate `Vec`s + captured-text `String`s
-      + `Arc<RegexCaptures>` subcap allocs, HashMap+SipHash traffic on the caps maps
-      (~3%), a **runtime regex re-parse path** visible in-profile
-      (`parse_regex_uncached` + LTM expansion ~4% — bypasses `PARSED_TOKEN_CANDIDATES` /
-      `REGEX_PARSE_CACHE` somewhere; find it first, likely the cheapest big win),
-      `RegexCaptures::default` zeroing (~2%), one `snapshot()` per complete inner end.
-      Next slices: memoize the residual re-parse; FxHash (or a small-vec map) for the
-      caps maps; box cold `RegexCaptures` fields (shrinks default/memmove); intern trail
-      undo-record keys. Details in
-      **[docs/adr/0007-grammar-parse-trail-matcher.md](docs/adr/0007-grammar-parse-trail-matcher.md)**
-      §Implementation outcome. Bench: `benchmarks/bench-grammar-parse.raku` (shallow) +
-      `benchmarks/bench-grammar-parse-deep.raku` (deep).
-- Targets (numbers from bench CI, main `c8955d2e`, 2026-07-13; parentheses = JIT-on series):
-  method-call <1.5x (✅ 1.19x / jit 1.16x), bench-class <1.5x (✅ 1.02x / jit 1.00x),
-  fib <10x (✅ **0.82x / jit 0.65x**), bench-fib (with type constraints) <2x
-  (✅ **1.78x / jit 1.39x**), int-arith **0.47x / jit 0.43x**.
+- [ ] **Write a Proposed ADR for a shared worker pool** — mutsu spawns a thread per task at all 19
+      `spawn_user_thread` sites; the design fork is what `await` does to a pooled worker:
+      [todo/deep/shared-worker-pool-adr.md](todo/deep/shared-worker-pool-adr.md).
+- [ ] **Remove the full locals clone/restore in `BlockScope`** — the final move of the lexical-scope
+      slot campaign and the perf core: [docs/lexical-scope-slot-campaign.md](docs/lexical-scope-slot-campaign.md).
+      A load-bearing refactor entangled with `$OUTER::`, GC roots, and env resync; suited to a
+      dedicated session.
+- [ ] Semaphore / non-blocking await / lock contention (S17; hard; separate axis).
+- [ ] Propagate Supply detached-worker panics to QUIT (currently swallowed).
+- [ ] Derive `.^methods` / `.can` from the real dispatch table; split out the roast fudge logic; split
+      files over 500 lines.
+- [ ] **Improve error-message quality and bring edge-case panics to zero** — driven by roast
+      pass/fail: `integration/error-reporting.t` and `weird-errors.t` for quality, and the
+      deep-recursion `fatal runtime error: stack overflow` process abort for crashes.
+- Individual concurrency bugs are files under [todo/tickets/](todo/tickets/) and
+  [todo/deep/](todo/deep/).
 
 ---
 
-## 6. Concurrency (Track C leftovers) and structural refactoring (independent; mid-to-long term)
+## 6. QA & finalization — the compatibility gap roast no longer sees
 
-- [ ] **ADR-0008 push-delivery follow-ups** (the core landed in #4636 and the first two follow-up
-      slices in #4638 / #4639, 2026-07-17; see docs/adr/0008-push-based-supply-event-delivery.md
-      and news/2026-07.md). What is left:
-  - [ ] **Write a Proposed ADR for a shared worker pool** (groundwork done 2026-07-17; all figures
-        below are release builds on main 159a30cb0, 12 cores, raku 2026.06 on the same host).
-        mutsu has no pool at all: it spawns a thread per task at each of the **19
-        `spawn_user_thread` sites** (`ThreadPoolScheduler` is a bare type name in
-        `runtime_init.rs:67` with nothing behind it). What that costs:
+roast is mined out (§3), so the defects that remain are by definition the ones it does not exercise.
+The backbone is **differential testing against the reference `raku`**: any program where mutsu and
+raku disagree is a candidate defect, found objectively rather than guessed.
 
-        | probe | mutsu | raku |
-        |---|---|---|
-        | 500 × trivial `start {}` | 0.232–0.262s | 0.051–0.07s |
-        | 50 idle `cue(:every(60))` | RSS +20.7 MB, **VmSize +16.4 GB**, threads 2→**52** | RSS +4.3 MB, VmSize +25 MB, threads 2→**5** |
-        | 200 × `start { sleep 2 }` | 2.09s (unbounded concurrency) | 6.1s (bounded, 3 batches) |
-        | nested `start`+`await`, depth 500 | 0.99s (500 real OS threads) | **0.12s** |
+**Labor split (load-bearing).** Discovery, minimal-repro reduction, and triage are wide, mechanical
+and parallelizable — farm them out. Interpreter **fixes stay under tighter control**: a breadth-first
+agent is exactly what adds the slow-path fallbacks and test-specific hacks this repo forbids. The
+deliverable of a discovery campaign is a **ranked backlog of minimal repros grouped by root cause**,
+not a pile of speculative fixes.
 
-        **The ADR's central question is not pool sizing — it is what `await` does to a pooled
-        worker.** raku's `max_threads` defaults to 96 here (8 × cpu-cores) and genuinely-blocking
-        tasks *do* serialize against it (200 × `sleep 2` takes 6.1s, not 2s), yet nested `await` at
-        depth 500 does **not** deadlock on those 96 workers: Rakudo's `await` yields a MoarVM
-        continuation (`$*AWAITER`) and hands the worker back. mutsu has no continuations, so a
-        **bounded pool + blocking `await` deadlocks** (depth-500 pins every worker). The ADR must
-        choose between (a) an **elastic** pool that grows on starvation, Rakudo-supervisor-style —
-        which still re-explodes to ~500 threads on that shape, so it wins for idle `cue`/short tasks
-        but not there — and (b) continuation-ifying `await`, a VM-scale project.
+**Align the language version.** Local raku is 6.d-default; docs may use 6.e. Prefer the stronger
+signal "mutsu differs from raku **and** from the documented expectation" over a raw raku diff.
 
-        Other decisions the ADR must record:
-        - **Stack tiering.** `spawn_user_thread` reserves 256 MiB (`builtins_system.rs:9`) for
-          deep-recursion headroom. Five sites (`Proc::Async` ×4, `signal_watcher.rs:47`) take that
-          stack while running **no user VM code** — they only need GC registration, so
-          reclassifying them to `spawn_gc_helper_thread` is free. Conversely 256 MiB *reserved* per
-          pooled worker makes the steady-state pool size an address-space decision.
-        - **Task-boundary invariants.** `clone_for_thread` (`runtime_thread.rs:8`) is per-*task*,
-          not per-thread — a pooled worker cannot reuse the previous task's `Interpreter`. Likewise
-          `drop_thread_local_gc_state` (`value/mod.rs:553`) must run **between tasks**, or task N's
-          pending DESTROYs leak into task N+1 while the thread stays registered. `WorkerGuard`'s
-          drop order (drain → `mark_thread_registered(false)` → `exit_mutator_worker`,
-          `builtins_system.rs:65-80`) becomes a task-boundary rule rather than a thread-exit one.
-        - **★The biggest correctness risk**: an idle pooled worker parked on a raw `recv()` is
-          permanently non-quiescent and would defeat **every** STW in the process — strictly worse
-          than today. The task-queue wait must use `stw_aware_wait` / `block_quiescent`.
-        - **An argument in favour**: `preregister_worker_quiescent` and `notify_worker_exit`
-          (`stw.rs:141/195`) exist *only* to survive spawn/exit churn; a pool makes
-          `mutator_worker_count()` near-constant and both near-moot.
-        - The shape to mirror is `interval_timer.rs` (leaked `OnceLock` state + one long-lived
-          registered driver + actions run with the heap lock released). Its stated contract
-          (`:13-14`, `:160`) is that actions must never run user VM code on the driver thread, and
-          its escape hatch is "spawn a worker" — exactly where the pool slots in.
-
-        Only once that lands does `cue(:every)` become a timer entry that enqueues onto the pool
-        (skipping a tick while the previous iteration still runs). Today an `:every` cue owns a
-        thread for its whole lifetime (`scheduler.rs:286` → `scheduler_run_every_loop`,
-        `:415-446`), which is what the 16.4 GB / 52-thread row above measures; `:in`/`:at` delays
-        already moved onto the deadline heap in #4638. Moving `:every` onto the timer *without* a
-        pool would be a regression: every iteration runs user VM code, so the heap would have to
-        spawn a fresh 256 MiB worker plus a `clone_for_thread` per tick.
-  - [ ] Watch CI for the residual under-load syntax.t flake (1 notok in 18 loaded runs locally,
-        unreproduced in 14 follow-ups; raku's own fixed-sleep tests also wobble at that load).
-- [ ] **Remainder of true sharing for state/lexical aggregates**: only the lost-update on
-      high-contention concurrent "structural" inserts (real rakudo crashes with a MoarVM oops on the
-      same shape = outside the language guarantee. mutsu doesn't break, which is an advantage — keep
-      as out-of-spec = effectively a decision not to do it). The cell-ification itself was completed
-      in Track B slices 2+3 and T6 (news/2026-07.md; pin = the 18 tests in
-      t/state-aggregate-shared-cell.t).
-- [ ] Semaphore / nonblocking await / lock contention (S17; hard; separate axis).
-- [ ] **★A joined `start` block writes its stale captured env back over a variable declared after
-      it** (found 2026-07-23 while testing WASM concurrency; reproduces on `main`, so it is not a
-      WASM artefact):
-
-      ```raku
-      my $p = Promise.allof(start { 1 }, start { 2 }); await $p; say $p.WHAT;   # Nil (raku: (Promise))
-      my @p = (start { 1 }, start { 2 }); my $q = Promise.anyof(@p); await $q;  # $q survives
-      ```
-
-      Two or more `start` blocks written **inline as arguments** each capture the enclosing env at a
-      point where `$p` does not exist yet (so it reads as `Nil`); joining them writes that snapshot
-      back wholesale and clobbers the now-assigned `$p`. One inline `start` does not trip it, and
-      binding the promises to a variable first avoids it — i.e. it is the blanket env writeback, the
-      same mechanism as the `named-sub free-var shadow` / dual-store family, not a `Promise` bug.
-      The fix belongs with the cell-based capture work above (write back only what the thread
-      actually mutated), not with a special case at the `allof`/`anyof` call sites.
-- ✅ Eliminate raw-pointer aliased writes — **done via ADR-0013** (the `UnsafeCell` moved into
-      `GcBox`, so `gc::gc_contents_mut` / `Gc::{get,make}_mut` derive interior-mutable provenance).
-      What is left is verification, tracked as §2.1 Step 3b (the Miri gate) — not another
-      inventory.
-- [ ] **★Remove the full locals clone/restore in `BlockScope`** (the final move of the lexical-scope
-      slot campaign [docs/lexical-scope-slot-campaign.md](docs/lexical-scope-slot-campaign.md);
-      **the perf core** — the root of the malloc/free churn and `Env::get_sym` shown by the #4489
-      profile; see §5): remove the `self.locals.clone()` in `exec_block_scope_op`. A load-bearing
-      refactor entangled with the `$OUTER::` runtime snapshot, GC roots, and env resync — suited to a
-      dedicated session. The preliminaries (S1–S17 slot burn-in + shadow-slot default ON) are done
-      (news/2026-07.md).
-- [ ] Separating the error/control channels: consolidating the bool flags into `enum Control` and
-      shrinking `RuntimeError` (cold Box-ing; `result_large_err` 23→0) is done. The remaining
-      structural separation of "carrying control flow via `Result::Err`" is low priority now that
-      the practical harm is gone (ANALYSIS rev8 §2.2).
-- [ ] Propagate Supply detached-worker panics to QUIT (currently swallowed; ANALYSIS §5).
-- [ ] Derive `.^methods`/`.can` from the real dispatch table / split out the roast fudge logic /
-      split files over 500 lines.
-- [ ] **Hygiene-trend inventory (ANALYSIS rev8 §5/§6)**: re-slim the re-bloated `runtime/mod.rs`
-      (1932→2118 lines) / review the increases from GC and Track B churn: `.clone()` 9022 (+1322),
-      `unwrap` family 1643 (+167), `#[allow(` 157 (+19).
-- [ ] **Improve error-message quality / bring edge-case panics and crashes to 0** — not an abstract
-      goal: it turned out (2026-07-14) that it **can be driven by roast pass/fail**: quality =
-      `integration/error-reporting.t` (mutsu 4/33, raku 33/33) and `weird-errors.t`;
-      crashes = **the deep-recursion `fatal runtime error: stack overflow` (process abort; 4 files)**
-      is the concrete target. → §4 / BLOCKERS.md §integration.
+- [ ] **Doc-example differential sweep** — harness and triage rules:
+      [docs/qa-doc-diff-harness.md](docs/qa-doc-diff-harness.md); backlog:
+      [docs/doc-diff-backlog.md](docs/doc-diff-backlog.md). Start a resumed campaign with a fresh
+      full-corpus sweep on current `main`; never trust an older survey after fixes merged.
+- [ ] **Per-type method-coverage matrix** — harness landed (`scripts/method-coverage.raku`); run the
+      full-corpus triage and fold the per-type hole list into the backlog.
+- [ ] **Panic-zero sweep** — mutsu must never Rust-panic or process-abort on any input. Extend with
+      parser fuzzing driven through the same harness with a "did it panic?" oracle.
+- [ ] **Error / exception parity** — differential-test that mutsu throws the right `X::` type with a
+      matching message and payload, not merely that it fails. Corpus: `Type/X*.rakudoc`.
 
 ---
-
-## 8. QA & finalization — closing the compatibility gap roast no longer sees
-
-**Why this section exists.** roast is mined out (§4: the whitelist is at its ceiling and the 33
-remaining files are mostly non-goal / no-oracle). The compatibility defects that are *left* are, by
-definition, the ones roast does not exercise. Finalization therefore needs signals **orthogonal to
-roast**. The backbone is **differential testing against the reference `raku`** (Rakudo, installed on
-the dev box and in CI): any program where mutsu and raku disagree is a candidate defect, found
-objectively rather than by a model's guess. `raku-doc` is **one corpus among several**, not the
-campaign itself.
-
-**Labor split (load-bearing).** Discovery, minimal-repro reduction, and triage are wide, mechanical,
-and parallelizable — farm them out to cheap models / subagents to produce a **ranked backlog of
-minimal repros grouped by root cause**. Interpreter **fixes stay under tighter control**: a
-breadth-first agent is exactly what tends to add the slow-path fallbacks / hardcoded results /
-test-specific hacks that this repo forbids (see the standing rules and CLAUDE.md). The deliverable of
-a discovery campaign is the backlog, not a pile of speculative fixes.
-
-**Cross-cutting caveat for every differential item below — align the language version.** Local raku is
-6.d-default (Rakudo 2026.06); doc/example code may use 6.e or version-tagged features (e.g. `exits-ok`
-was "effective with Rakudo 2026.01"). Prefer the stronger signal **"mutsu differs from raku AND from
-the documented expectation"** over a raw raku diff, so version skew and aspirational docs do not flood
-the backlog.
-
-### 8.1 Differential harness (the backbone)
-
-`scripts/doc-diff-harness.raku` compares extracted `raku-doc` examples under `raku` and
-`mutsu`; `scripts/doc-diff-sweep.sh` runs the corpus in parallel. Usage and triage rules are in
-[docs/qa-doc-diff-harness.md](docs/qa-doc-diff-harness.md). The ranked backlog and its committed
-minimal-repro reports live in [docs/doc-diff-backlog.md](docs/doc-diff-backlog.md) and
-[docs/doc-diff-sweep/](docs/doc-diff-sweep/).
-
-A fresh full-corpus sweep on the current `main` is the first step when resuming this campaign;
-do not trust an older survey after fixes have merged. Remaining known findings include:
-
-  - Niche/parser one-offs (lower priority): extended identifiers in variable names
-    (`my $foo:bar<baz>`), Win32 `IO::Path` backslash semantics, `Thread.run`/`Thread.start`,
-    declarator-pod `.WHY` on a `&sub`, `X::AdHoc+{X::Promise::Broken}` role-mixin in `.^name`.
-  - **`&f` re-materializes a fresh Sub per mention** (found 2026-07-23 by the generic-WHERE
-    slice): `sub f() {1}; &f.WHICH` differs across two mentions (`Sub|27` then `Sub|29`;
-    raku: stable) because `sub_value_from_function_def` builds a new `SubData` (fresh id +
-    fresh env snapshot) on every `resolve_code_var`. `&f === &f` masks it via fingerprint
-    comparison, and `&f.WHERE` inherits the instability. A stable per-`FunctionDef` identity
-    interacts with wrap-chain ids (`wrap_chains` is keyed by `data.id`) — not a small slice.
-
-### 8.2 Documented-surface coverage (doc examples + method matrix)
-
-- [ ] **Doc-example diff**: extract runnable examples from `raku-doc` — many carry a
-      ` # OUTPUT: «…»` annotation that is a built-in oracle — and run them through 8.1. This is the
-      structured, objective form of "read the docs to find gaps"; do **not** do the read-and-guess
-      form. Complements the one-shot `raku-doc` audits already recorded in §4.
-- [ ] **Per-type method-coverage matrix** — **harness landed** (`scripts/method-coverage.raku`,
-      2026-07-22): extracts every `=head2 method/routine` from `Type/*.rakudoc` and probes both
-      interpreters with a dynamic call across several argument shapes; a hole = mutsu answers
-      "No such method" on every shape where raku dispatches (`^can` is unusable on both sides —
-      raku over-answers via Any/Cool inheritance, mutsu under/over-answers). Crashing probes are
-      isolated by a PROBE/RES retry protocol and reported as `crash` (§8.3 findings for free).
-      Output: `tmp/method-coverage.tsv` + `tmp/method-coverage-summary.md`. First findings:
-      `Cool.Version` (fixed with the harness PR), `.subst-mutate` unreachable via a *dynamic*
-      method call (any CallMethodMut-opcode-only method — the dynamic path never routes to the
-      mut-op table), `Mu.return`/`Mu.emit` probe crashes. TODO: run the full-corpus triage and
-      fold the per-type hole list into `docs/doc-diff-backlog.md`.
-
-### 8.3 Robustness — zero panics / crashes
-
-- [ ] **Panic-zero sweep**: mutsu must never Rust-panic or process-abort on any input. Concrete known
-      target: the deep-recursion `fatal runtime error: stack overflow` process abort (§6; 4 roast
-      files). Extend with **parser fuzzing** (malformed / adversarial / oversized input) driven through
-      8.1 with a "did it panic?" oracle. Track under the existing `roast-panic` category
-      (`scripts/roast-history.sh`) plus a dedicated fuzz corpus.
-
-### 8.4 Behaviour under real code & error parity
-
-- [ ] **Real-module corpus**: run real ecosystem modules and their own test suites (the zef *upstream*
-      track is exhausted, but broader rea/CPAN dists are not). Real code exercises meaner shapes than
-      doc examples — parser, exceptions, containers. Overlaps with §1 (batteries) and the mzef
-      north-star.
-- [ ] **Error / exception parity** (extends the §6 error-message-quality item): differential-test that
-      mutsu throws the **right `X::` type** with a matching message / payload, not merely that it
-      fails. Corpus = `Type/X*.rakudoc` + `throws-like`-style assertions. Good QA is "fails
-      correctly", not only "works".
-
-### Ad-hoc discovered findings now live in `todo/`, not here
-
-Bugs and gaps found in passing (the former 8.15 / 8.18 / 8.20 / 8.21 / 8.22
-entries) are recorded one file per finding under `todo/tickets/` (small,
-self-contained) and `todo/deep/` (needs design) — see `todo/README.md`. A new
-file conflicts with nothing on merge, which is exactly what appending them
-here did not manage. PLAN.md keeps planned strategic / campaign work.
-
 
 ## Metrics
 
 | Metric | Current | Target |
-|------|------|------|
-| **Bundled libraries (vendored + documented)** | **0** (10+ with working record still in t/lib or fetched externally) | **10+ bundled, all documented** |
-| mzef | CLI startup + dispatch ✅ / install→use bridge ✅ / **`zef info` works fully on the real fez index ✅** (#4466) | Real install with the real zef binary (remaining = populate performance, network fetch (TLS), vendoring) |
-| Binary distribution | none | Single-command install via mise / GitHub Releases |
-| Whitelist | **1384** (of 1463 total .t files; 79 remaining) | 1300+ ✅ achieved. Next target: the 41 `integration/` files (§4) |
-| GC | **default on ✅** (2026-07-05; ADR-0003) | Achieved (remaining perf goes to layer 3b) |
-| JIT | **default on ✅** (2026-07-13); J4d complete = **ADR-0004 closed** (2026-07-15) | Achieved |
-| fib(25) vs raku | **0.82x / jit 0.65x** (bench CI `c8955d2e`, 2026-07-13) | <10x ✅ |
-| method-call vs raku | **1.19x / jit 1.16x** (same) | <1.5x ✅ |
-| bench-class vs raku | **1.02x / jit 1.00x** (same) | <1.5x ✅ |
-| bench-fib (with type constraints) vs raku | **1.78x / jit 1.39x** (same) | <2x ✅ |
-| Startup time vs raku | **0.04x** | 0.04x ✅ maintain |
-| Tree-walk fallback (methods/functions) | **~1% / ~18.6% (mostly carrier)** | 0% (excluding carrier) |
+|---|---|---|
+| Bundled libraries | **22 vendored**, upstream suites gated at release | 10+ bundled, all documented |
+| mzef | install / fetch / resolution / test phase all work E2E | Full pipeline on the real fez index |
+| Binary distribution | 4 release targets + GHCR image + mise ✅ | Achieved |
+| roast whitelist | **1435 / 1464** | Achieved; remainder is mostly non-goal |
+| GC / JIT | **default on** ✅ | Achieved |
+| Startup vs raku | **0.04×** | maintain |
+| fib / method-call / bench-class vs raku | all under target (bench CI) | maintain |

--- a/docs/ecosystem-guts-dependency-survey.md
+++ b/docs/ecosystem-guts-dependency-survey.md
@@ -52,6 +52,33 @@ on it, **all as `test-depends` only** (needed to run those dists' own test
 suites, never at runtime/install), and concentrated in one author's (vrurg)
 ecosystem.
 
+### Test::Async scouting result (2026-07-19) — kept here since PLAN.md no longer carries it
+
+Test::Async is **not planned for bundling** (user decision; PLAN.md's §1 B2b was
+dropped 2026-08-02). The scouting conclusion is preserved because it is the
+concrete evidence for the `deep_guts` classification above:
+
+- The visible blocker is custom Metamodel HOW inheritance —
+  `'Test::Async::Metamodel::BundleHOW' cannot inherit from
+  'Metamodel::ParametricRoleHOW' because it is unknown`. That *is* a real MOP
+  feature (user-visible subclasses of the built-in metamodel classes, with
+  mutsu's role/class machinery dispatching through the user's HOW overrides).
+- But it is **necessary and nowhere near sufficient**: Test::Async's `EXPORT`
+  installs a **grammar slang** (`define_slang` plus custom
+  `package_declarator:sym<test-bundle>` tokens that swap the role HOW mid-parse
+  via `set_how`), builds `QAST` nodes, and drives the `$*W` World / `NQPHLL` —
+  the MoarVM compiler-guts layer mutsu deliberately lacks.
+- So the only viable route is **(b) a narrow per-declarator shim**: parse
+  `test-bundle` / `test-hub` / `test-reporter` as built-in role declarations with
+  native bundle wiring, ignoring the NQP `EXPORT` grammar. It is still
+  multi-session work.
+- **Start trigger**, if a bundle-candidate module ever hard-depends on
+  Test::Async: start from the (b) shim; do **not** attempt the general
+  NQP/QAST/slang machinery.
+- Prerequisite groundwork that already landed: the `::?CLASS` parameter fixes
+  (#4669). Error text and history:
+  [`mzef-install-pipeline.md`](mzef-install-pipeline.md) "Test-phase frontier".
+
 ## Interpretation
 
 - **The genuinely guts-blocked tail is small: ~5%** (at most ~10% if you count

--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -295,10 +295,12 @@ generally:
 new pass/fail count.~~ Done 2026-07-18 — see the per-suite standing at the
 top of this section (10 PASS / 1 FAIL).
 
-**Test::Async is out of scope for this frontier** (PLAN.md §1 B5): its
-blocker is custom Metamodel HOW inheritance
-(`Metamodel::ParametricRoleHOW`), a campaign-sized MOP feature that the
-mzef dependency chain does not need.
+**Test::Async is out of scope for this frontier**: its blocker is custom
+Metamodel HOW inheritance (`Metamodel::ParametricRoleHOW`), a campaign-sized
+MOP feature that the mzef dependency chain does not need. It is **not a bundle
+candidate** (user decision; PLAN.md's §1 B2b was dropped 2026-08-02) — the full
+scouting result and the start trigger, should one ever appear, are in
+[`ecosystem-guts-dependency-survey.md`](ecosystem-guts-dependency-survey.md).
 
 Still open (load-side leftovers):
 

--- a/news/2026-08/plan-md-is-an-outline.md
+++ b/news/2026-08/plan-md-is-an-outline.md
@@ -1,0 +1,45 @@
+# PLAN.md is an outline again (1072 → 221 lines)
+
+PLAN.md had grown to 1072 lines. Its own header said it lists "only unfinished work", but in
+practice each item had accreted the full history of how it got where it is: measurement tables,
+profile snapshots, "Update 2026-07-15 (3)" chains, four-mechanism breakage analyses, and long lists
+of PR numbers for work that had already shipped. Finding the actual open question in a section meant
+reading several screens of narrative first, and every parallel PR that touched it conflicted.
+
+That is the same problem the per-entry `news/YYYY-MM/` and `todo/` files already solved, applied one
+level up. So PLAN.md is now **an outline and nothing else** (user decision, 2026-08-02): each item
+says what is left and links to where the detail lives. A table at the top of the file states the
+split — completed work in `news/`, open findings in `todo/tickets/` and `todo/deep/`, decisions in
+`docs/adr/`, roast analysis in `TODO_roast/BLOCKERS.md`, numbers in the bench CI — and the file
+carries an explicit instruction not to append progress notes to it.
+
+Nothing was dropped on the floor. The analysis that was only recorded in PLAN.md moved into new
+files, each of which now owns its subject:
+
+- `todo/deep/needs-env-sync-blanket-removal.md` — the `captures_env_by_name` blanket and the four
+  independent mechanisms (block-scope restore, cross-thread `cas` capture, method-call caller-local
+  coherence × the JIT's inline `GetLocal`, currying) that a standalone removal deterministically
+  broke.
+- `todo/deep/interpreter-call-path-in-hot-loops.md` — the roast-wide wall-clock re-baseline, the four
+  files where mutsu is slower than raku, and why the remaining churn is the named-argument path.
+- `todo/deep/shared-worker-pool-adr.md` — the measured groundwork for the pool ADR, including the
+  central fork (a bounded pool plus blocking `await` deadlocks, because mutsu has no continuations).
+- `todo/tickets/` gained files for the Miri gate that closes ADR-0013, the OTF gate's two remaining
+  exclusions, the HTTP::Server::Tiny async remainder, the language-feature gaps that no roast file
+  whitelists, and three bugs that were re-verified against `raku` while extracting them: inline
+  `start` blocks clobbering a later-declared variable, `&f` re-materializing a fresh `Sub` per
+  mention, and a stored regex losing its defining scope's lexicals when it escapes the sub.
+
+Two sections left rather than moved. **§1 B2b (Test::Async)** is gone because Test::Async is not a
+bundle candidate — its scouting result (custom Metamodel HOW inheritance is necessary but nowhere
+near sufficient; only a narrow per-declarator shim is viable; 8 of 1573 dists depend on it, all
+`test-depends`) now lives with the ecosystem survey that classified it, in
+`docs/ecosystem-guts-dependency-survey.md`. And the **vendoring mechanism** item was simply stale:
+22 batteries are vendored under `modules/` and resolved with zero configuration by
+`resolve_bundled_lib_paths`, with `BATTERIES.md` as the policy and a release-time suite gate — that
+work is done, so the checkbox went away instead of being re-worded.
+
+The metrics table was re-derived from the tree rather than carried forward: 22 bundled libraries (it
+still claimed 0), the roast whitelist at 1435/1464, and binary distribution shipping rather than
+"none". `ANALYSIS.md` and `docs/mzef-install-pipeline.md` were updated to point at the new homes
+instead of the old section numbers.

--- a/todo/deep/interpreter-call-path-in-hot-loops.md
+++ b/todo/deep/interpreter-call-path-in-hot-loops.md
@@ -1,0 +1,71 @@
+# The interpreter function-call path is the one place mutsu is slower than raku
+
+Extracted from PLAN.md §5 (2026-08-02). This is the only *measured* perf axis where mutsu loses to
+raku on real spec tests, so it is worth keeping even though §5 as a whole is de-prioritized polish.
+
+## The measurement
+
+Roast-wide raku-vs-mutsu wall-clock re-baseline (2026-07-15, `scripts/roast-speed-diff.sh` over the
+1358 runnable whitelisted tests, release): mutsu beats raku (Rakudo 2022.12) on ~1348/1358 tests,
+usually 2–30× (fast startup + JIT). The **only** files where mutsu is meaningfully *slower* (clean
+single-run ratios):
+
+| file | ratio | shape |
+| --- | --- | --- |
+| `S04-declarations/state.t` | **4.2×** | `for ^2000000 { $ = foo }` |
+| `S06-signature/named-parameters.t` | **2.6×** | `for ^1000000 { foo(:color($_)) }` |
+| `S07-iterators/range-iterator.t` | 1.7× | |
+| `S12-methods/private.t` | 1.6× | |
+
+Isolated micro-repro: a 1M-iteration loop calling a sub is **1.85× slower** than raku positional,
+**2.6× slower** with a named argument.
+
+## Root cause
+
+All of these converge on the interpreter function-call path in hot loops. **The JIT bails at the
+call boundary** — proven: a positional 1M loop is `MUTSU_JIT=on` 0.74s ≈ `off` 0.72s, i.e. the JIT
+does nothing there — so any loop that calls a sub runs the interpreter call path, whose profile is
+~15% malloc/free churn per call (frame + named-args structure + `Env::cow_mut` + `Arc::drop_slow`)
+plus per-call `current_package` / `Env::get_sym` / param binding (`exec_set_local_op_inner`).
+
+Named arguments add disproportionate cost (mutsu **+46%** vs raku **+6%**): a `String`-keyed
+named-args structure is rebuilt on every call.
+
+## Where the work actually is (2026-07-21 update)
+
+The **light positional** path (`call_compiled_function_light_spec`, `vm_call_light_typed.rs`) is
+already heavily J4d-tuned — pooled callee locals (`take_locals_from_pool`, no per-call `Vec` alloc),
+`std::mem::take` of caller locals, and frame reuse that skips the env clone when the caller's overlay
+is still the shared-empty singleton. So the remaining churn is concentrated in the **named / slow**
+path (`call_compiled_function_named`: `args.to_vec()` plus the `String`-keyed named-args structure).
+Target that specifically: intern the parameter names and bind by `Symbol`/slot.
+
+## Related, already closed
+
+- **Remove SipHash from `compiled_fns`** — done. The table is
+  `FxHashMap<Symbol, CompiledFunction>` (`opcode.rs`), so the light-call cache pays neither SipHash
+  nor a name `memcmp`. The residual "cache the callee itself to skip the second lookup" idea is
+  low-value (FxHash is instruction-neutral per #4976) and would force `compiled_fns` to hold
+  `Arc<CompiledFunction>`; do not pursue.
+- **Remove the callsite-line marker** — investigated 2026-07-21 and **deferred as not worth the
+  churn**. `peek_callsite_line` (`runtime/call_helpers.rs`) scans args on every call, but the
+  `__mutsu_test_callsite_line => N` Pair is attached by the parser only to
+  `is_test_assertion_callable` names, and those always compile to `ExecCallPairs`, so the scan is
+  dead work on the CallFunc/CallFuncNamed light paths. Removing it is still not clean: the
+  CallFuncNamed path is *designed* to carry the marker in-band (`expr_call.rs`), and deriving the
+  line from the op's ip via `op_lines` breaks line-exactness (the marker captures the *parse-time*
+  line, which differs on multi-line assertions — `test-assertion-line-number.t` pins the number).
+
+## Prerequisite
+
+The deeper fix (removing per-call env materialization) is the lexical-scope slot campaign —
+[docs/lexical-scope-slot-campaign.md](../../docs/lexical-scope-slot-campaign.md) and
+[needs-env-sync-blanket-removal.md](needs-env-sync-blanket-removal.md).
+
+## Measurement protocol
+
+Confirm with `perf` retired instructions (`instructions:u` + `taskset` core pinning — otherwise it
+wobbles 8%) that a candidate actually consumes time. **Reducing opcode count ≠ reducing time**: the
+`SetSourceLine` removal was 21% of executed opcodes on fib but only -3.4% instructions (±0 on the
+JIT path), and a first implementation that refreshed on every instruction was a +7.8% deficit. See
+[ADR-0006](../../docs/adr/0006-baseline-interpreter-optimizations.md) §"Measurement protocol".

--- a/todo/deep/needs-env-sync-blanket-removal.md
+++ b/todo/deep/needs-env-sync-blanket-removal.md
@@ -1,0 +1,78 @@
+# The `needs_env_sync` / `captures_env_by_name` blanket, and why removing it is a fused campaign
+
+Extracted from PLAN.md §5 (2026-08-02) so the analysis survives PLAN.md's slimming. This is the
+last structural piece of the dual-store (locals ↔ env) decoupling, and it has a track record of
+breaking several unrelated mechanisms when attempted as a standalone change.
+
+## Root cause
+
+`captures_env_by_name` is true if a frame contains even one of
+`ForLoop` / `BlockScope` / `BlockLocalScope` / `MakeGather` / `WheneverScope`. When it is true,
+**every local in that frame becomes an env-mirror target**, so locals that are never read by name —
+a loop body's `my $ts`, an accumulator — are still written to env on every store. It is a
+per-*frame* approximation of a per-*slot* property.
+
+The *per-store* half of the problem is already gone: the `exec_set_local_op_inner` tail env write
+for plain lexicals was gated permanently by the `(B)` gate (#4942 flip → #4980 removal, now
+unconditional for `!captures_env_by_name` frames), which is why `while` / `loop` bodies already
+benefit (-10–16% on a JIT-bailed 5M-iteration while loop). What remains is precisely the blanket.
+
+## Why it is large
+
+The immediate payoff for the common case is *small*, and the mechanism is fused with several
+others:
+
+- A `for` body compiles **inline into the same frame** as the `ForLoop` op (`stmt.rs` emits the
+  body ops right after `ForLoop`; `body_end` marks the range), so the body's accumulator slots get
+  blanket-synced — yet simply dropping `ForLoop` from `captures_env_by_name` measured **±0%**,
+  because the loop mechanism writes the loop variable to *both* slot and env
+  (`vm_for_loop_body.rs:243/251`) and a pure arithmetic body reads its accumulators from slots, not
+  env. The lever is the fused precise-ification (per-slot, not per-frame) of the block-restore /
+  loop / gather / whenever / closure-capture consumers — not a `ForLoop`-only drop.
+
+- A 2026-07-15 probe gated the *unconditional* env write at the tail of `exec_set_local_op_inner`
+  (`vm_var_assign_set_local.rs`, `set_env_plain_lexical` / `set_env_with_main_alias`) on
+  `needs_env_sync || reflective`. Note this tail write, **not** `flush_local_to_env`, is the real
+  per-store cost — `flush_local_to_env` is already gated on `needs_env_sync`, so the `env_flushes`
+  counter reads 0 and never surfaces it (measure by wall-clock). The gate won ~7% on a JIT-bailed
+  `time-parts` loop and **deterministically broke four independent mechanisms**, each pinned by an
+  existing test:
+
+  1. **Block-scope restore.** `exec_block_scope_op` reverts `self.locals` to the pre-block snapshot
+     and then **re-pulls every local from env by name**, so without the env seed an outer variable
+     mutated inside a bare `{ }` reverts to its pre-block value (`my $x=1; {$x=2}; say $x` printed
+     `(Any)`). `BlockScope` / `BlockLocalScope` frames therefore still need the blanket. A loop-body
+     `if { }` stays *inline* (no `BlockScope`) unless the branch declares its own `my`
+     (`BlockLocalScope`), so most hot loops are unaffected.
+  2. **Cross-thread closure capture / `cas`.** A `%h` captured by a `Thread.start` body and mutated
+     via `cas` needs its shared-variable cell established through env by name; the gate lost it
+     (`tests/gc_stress.rs::dead_sweep_bounds_threaded_mutation_memory`, sum=2 vs 800). Folding
+     `closure_compiled_codes` free vars + `op_arg_sources_idx` (rw-arg sinks) +
+     `op_container_mutate_const_idx` into `needs_env_sync` fixes this axis.
+  3. **Method-call caller-local coherence × JIT inline `GetLocal` (the decider).**
+     `tests/jit_diff.rs::hot_method_body_compiles_and_matches` (`my $c=…; for ^30 { $c.bump() }`).
+     The earlier "the JIT reads the outer lexical from env" diagnosis was **wrong** — proven by
+     unconditionally skipping only `$c`'s env write: the JIT run still prints the right answer,
+     because `$c` is read via `GetLocal(0)` from its slot. The real gatekeeper is **method-call
+     specific** (a positional *sub* call in the same JIT-hot loop is fine): the method path keeps
+     caller-local coherence through env (`vm_call_method_ops.rs`
+     `drain_and_reconcile_after_cached_call`), so once the gate makes `$c` env-absent, the first
+     `bump()` leaves `$c`'s slot in a state the JIT's Tier-B **inline** `GetLocal` (which bypasses
+     `exec_get_local_op`) reads as `Any`, while the interpreter's `exec_get_local_op` still reads it
+     correctly — so it surfaces only under `MUTSU_JIT_THRESHOLD=1`. Fixing it is load-bearing
+     method-dispatch work.
+  4. **Currying / priming capture.** `roast/S06-currying/positional.t` aborts at test 157 (cause not
+     isolated; likely the same method-dispatch env reconcile as (3)).
+
+So this is a campaign fused with the lexical-slot work
+([docs/lexical-scope-slot-campaign.md](../../docs/lexical-scope-slot-campaign.md), whose core move
+is removing the `self.locals.clone()` in `exec_block_scope_op`) and with the method-dispatch
+env-based caller-local reconcile.
+
+## Notes for whoever picks it up
+
+- Scalar locals are stored **sigil-less** (`"c"`, not `"$c"`) — relevant when instrumenting, and the
+  reason a probe keyed on `"$_"` never fires for the topic (its env key is `"_"`).
+- The probe above was clean-reverted; there is no half-landed state to unwind.
+- Priority: this is perf polish. mutsu already beats raku on the whole roast whitelist and on every
+  bench; confirm it unblocks a goal item before starting.

--- a/todo/deep/shared-worker-pool-adr.md
+++ b/todo/deep/shared-worker-pool-adr.md
@@ -1,0 +1,68 @@
+# Write a Proposed ADR for a shared worker pool
+
+Extracted from PLAN.md §6 (2026-08-02). The groundwork below was measured 2026-07-17 on release
+builds of main `159a30cb0`, 12 cores, raku 2026.06 on the same host. The deliverable is a *Proposed
+ADR*, not an implementation — the central question is a design fork, not a tuning parameter.
+
+## The gap
+
+mutsu has no thread pool at all: it spawns a thread per task at each of the **19 `spawn_user_thread`
+sites**, and `ThreadPoolScheduler` is a bare type name in `runtime_init.rs` with nothing behind it.
+What that costs:
+
+| probe | mutsu | raku |
+|---|---|---|
+| 500 × trivial `start {}` | 0.232–0.262s | 0.051–0.07s |
+| 50 idle `cue(:every(60))` | RSS +20.7 MB, **VmSize +16.4 GB**, threads 2→**52** | RSS +4.3 MB, VmSize +25 MB, threads 2→**5** |
+| 200 × `start { sleep 2 }` | 2.09s (unbounded concurrency) | 6.1s (bounded, 3 batches) |
+| nested `start`+`await`, depth 500 | 0.99s (500 real OS threads) | **0.12s** |
+
+## The central question: what does `await` do to a pooled worker?
+
+raku's `max_threads` defaults to 96 here (8 × cpu-cores) and genuinely-blocking tasks *do* serialize
+against it (200 × `sleep 2` takes 6.1s, not 2s) — yet nested `await` at depth 500 does **not**
+deadlock on those 96 workers: Rakudo's `await` yields a MoarVM continuation (`$*AWAITER`) and hands
+the worker back.
+
+mutsu has no continuations, so a **bounded pool + blocking `await` deadlocks** (depth-500 pins every
+worker). The ADR must choose between:
+
+- **(a) an elastic pool** that grows on starvation, Rakudo-supervisor-style — which still re-explodes
+  to ~500 threads on that shape, so it wins for idle `cue` / short tasks but not there; or
+- **(b) continuation-ifying `await`** — a VM-scale project.
+
+## Other decisions the ADR must record
+
+- **Stack tiering.** `spawn_user_thread` reserves 256 MiB (`builtins_system.rs`) for deep-recursion
+  headroom. Five sites (`Proc::Async` ×4, `signal_watcher.rs`) take that stack while running **no
+  user VM code** — they only need GC registration, so reclassifying them to
+  `spawn_gc_helper_thread` is free. Conversely, 256 MiB *reserved* per pooled worker makes the
+  steady-state pool size an address-space decision.
+- **Task-boundary invariants.** `clone_for_thread` (`runtime_thread.rs`) is per-*task*, not
+  per-thread — a pooled worker cannot reuse the previous task's `Interpreter`. Likewise
+  `drop_thread_local_gc_state` (`value/mod.rs`) must run **between tasks**, or task N's pending
+  DESTROYs leak into task N+1 while the thread stays registered. `WorkerGuard`'s drop order
+  (drain → `mark_thread_registered(false)` → `exit_mutator_worker`) becomes a task-boundary rule
+  rather than a thread-exit one.
+- **★The biggest correctness risk**: an idle pooled worker parked on a raw `recv()` is permanently
+  non-quiescent and would defeat **every** STW in the process — strictly worse than today. The
+  task-queue wait must use `stw_aware_wait` / `block_quiescent`.
+- **An argument in favour**: `preregister_worker_quiescent` and `notify_worker_exit` (`stw.rs`) exist
+  *only* to survive spawn/exit churn; a pool makes `mutator_worker_count()` near-constant and both
+  near-moot.
+- The shape to mirror is `interval_timer.rs` (leaked `OnceLock` state + one long-lived registered
+  driver + actions run with the heap lock released). Its stated contract is that actions must never
+  run user VM code on the driver thread, and its escape hatch is "spawn a worker" — exactly where the
+  pool slots in.
+
+## What it unblocks
+
+Only once the ADR lands does `cue(:every)` become a timer entry that enqueues onto the pool (skipping
+a tick while the previous iteration still runs). Today an `:every` cue owns a thread for its whole
+lifetime (`scheduler.rs` → `scheduler_run_every_loop`), which is what the 16.4 GB / 52-thread row
+above measures; `:in`/`:at` delays already moved onto the deadline heap in #4638. Moving `:every`
+onto the timer *without* a pool would be a regression: every iteration runs user VM code, so the heap
+would have to spawn a fresh 256 MiB worker plus a `clone_for_thread` per tick.
+
+Context: [ADR-0008](../../docs/adr/0008-push-based-supply-event-delivery.md) (push delivery; the core
+landed in #4636, follow-up slices #4638 / #4639).

--- a/todo/tickets/code-var-mention-remakes-the-sub.md
+++ b/todo/tickets/code-var-mention-remakes-the-sub.md
@@ -1,0 +1,31 @@
+# `&f` re-materializes a fresh `Sub` on every mention, so its identity is unstable
+
+Extracted from PLAN.md §8.1 (2026-08-02); found 2026-07-23 by the generic-`WHERE` slice and
+re-verified on `main` 2026-08-02.
+
+## Repro
+
+```raku
+sub f() { 1 }
+say &f.WHICH;   # mutsu: Sub|27
+say &f.WHICH;   # mutsu: Sub|29     raku: the same value both times
+```
+
+## Root cause
+
+`sub_value_from_function_def` builds a **new** `SubData` (fresh id + fresh env snapshot) on every
+`resolve_code_var`, so each mention of `&f` is a different object. `&f === &f` masks the bug because
+identity there is decided by a fingerprint comparison rather than the id, and `&f.WHERE` inherits the
+same instability.
+
+## Why it is not a small slice
+
+A stable per-`FunctionDef` identity interacts with the wrap-chain machinery: `wrap_chains` is keyed
+by `data.id`, so making the id stable changes which wraps a given code object sees. The fix has to
+decide where the canonical `Sub` value for a `FunctionDef` lives (and when its env snapshot is
+refreshed) before the id can be reused.
+
+## Affected files
+
+`src/runtime/` code-variable resolution (`resolve_code_var`, `sub_value_from_function_def`), and the
+wrap-chain registry keyed by `SubData::id`.

--- a/todo/tickets/http-server-tiny-async-serving-remainder.md
+++ b/todo/tickets/http-server-tiny-async-serving-remainder.md
@@ -1,0 +1,31 @@
+# HTTP::Server::Tiny — the async-serving remainder
+
+Extracted from PLAN.md §1 B4 (2026-08-02). Basic serving works end to end; these three do not fire in
+the default configuration, which is why they are still open.
+
+1. **Keep-alive consecutive requests** on one connection.
+2. **Chunked request bodies**.
+3. **`done` / `last` control signals inside `whenever $conn.Supply(...)`** — the tap callback runs on
+   a worker thread, disconnected from the `react` control-flow frame, so a control signal raised
+   there does not reach the block that owns the `react`.
+
+(3) is the general one: it is the same worker-thread-vs-control-frame disconnect as the other
+`whenever` tickets ([whenever-owned-lexical-outlives-the-react-block.md](whenever-owned-lexical-outlives-the-react-block.md),
+[schedule-on-whenever-env-loss.md](schedule-on-whenever-env-loss.md)), and it is what
+[ADR-0008](../../docs/adr/0008-push-based-supply-event-delivery.md) set the delivery model for.
+
+## Related, separate
+
+**Full Humming-Bird serving** (LOAD + LISTEN + accept + decode already work, #3549) has two blockers
+of its own:
+
+- **B1** — leakage of `var_type_constraint` from typed parameters to same-named *caller* lexicals.
+  The proper fix scopes the global name-keyed HashMap at call boundaries; making env authoritative is
+  not possible because it breaks subset-6e.
+- **B2** — a detached `start { react { whenever $chan { } } }` is not driven unless awaited: the
+  concurrency-scheduling campaign, i.e. [shared-worker-pool-adr.md](../deep/shared-worker-pool-adr.md).
+
+Humming-Bird is **not** the web-framework target any more (Cro is — see
+[docs/batteries/web-framework.md](../../docs/batteries/web-framework.md)), so B1/B2 matter as
+general interpreter bugs, not as a battery gate. B1 in particular is a plain correctness bug worth
+fixing on its own.

--- a/todo/tickets/inline-start-blocks-clobber-a-later-declared-variable.md
+++ b/todo/tickets/inline-start-blocks-clobber-a-later-declared-variable.md
@@ -1,0 +1,31 @@
+# Two inline `start` blocks write their stale captured env over a variable declared after them
+
+Extracted from PLAN.md §6 (2026-08-02); found 2026-07-23 while testing WASM concurrency, and
+re-verified on `main`2026-08-02 — it is not a WASM artefact.
+
+## Repro
+
+```raku
+my $p = Promise.allof(start { 1 }, start { 2 }); await $p; say $p.WHAT;
+# mutsu: Nil        raku: (Promise)
+
+my @p = (start { 1 }, start { 2 }); my $q = Promise.anyof(@p); await $q;
+# $q survives
+```
+
+## Root cause
+
+Two or more `start` blocks written **inline as arguments** each capture the enclosing env at a point
+where `$p` does not exist yet, so their snapshot records it as `Nil`. Joining them writes that
+snapshot back wholesale, clobbering the now-assigned `$p`.
+
+One inline `start` does not trip it, and binding the promises to a variable first avoids it — i.e.
+this is the blanket env writeback, the same mechanism as the `named-sub free-var shadow` /
+dual-store family, **not** a `Promise` bug.
+
+## The fix belongs elsewhere
+
+With the cell-based capture work (write back only what the thread actually mutated), not as a
+special case at the `allof` / `anyof` call sites. See
+[needs-env-sync-blanket-removal.md](../deep/needs-env-sync-blanket-removal.md) and
+[closure-env-capture-cost.md](../deep/closure-env-capture-cost.md).

--- a/todo/tickets/miri-gate-for-adr-0013.md
+++ b/todo/tickets/miri-gate-for-adr-0013.md
@@ -1,0 +1,32 @@
+# Close ADR-0013: add the Miri gate, and fix the stale `aliased_mut.rs` header
+
+Extracted from PLAN.md §2.1 (2026-08-02).
+
+[ADR-0013](../../docs/adr/0013-container-interior-mutability-cellvalue.md) fixed the provenance UB in
+the GC's aliased writes: per §7 the `UnsafeCell` was placed in `GcBox.value` (`src/gc/gc_ptr.rs`)
+instead of wrapping each container payload, so **every** `Gc<T>` is interior-mutable at the primitive
+and all the aliased-write sites (`gc::gc_contents_mut`, `Gc::{get,make}_mut`) became
+provenance-sound, with no call-site or `Value`-representation churn.
+
+Two loose ends remain:
+
+1. **The Miri gate (ADR-0013 §4 phase 4) is missing.** There is no `miri` job in
+   `.github/workflows/`, so the soundness claim rests on an argument rather than a check. Add it
+   informational-first, then blocking; pin a nightly matching the crate's stabilized-feature usage.
+
+2. **`src/value/aliased_mut.rs`'s module header is stale** — it still documents the provenance
+   violation as live and names Track B as the future fix. Both have been false since ADR-0013
+   (Track B is no longer fused with this work either, per ADR-0001 §7). Rewrite the header.
+
+The narrow cross-thread data race (an aliased write to a genuinely shared target) stays deferred to
+layer 3c by decision — it is not what this ticket closes.
+
+## Background already settled (do not redo)
+
+The 2026-07-20 inventory ([docs/gc-contents-mut-inventory.md](../../docs/gc-contents-mut-inventory.md))
+read and classified every production site — **54 sites / 20 files**: provably-unique = 3,
+`make_mut`-COW-coverable = **0**, needs-first-class-cell = 51. So "route easy clusters through COW"
+is a dead end; it can retire zero sites. The three provably-unique sites carry
+`debug_assert_eq!(strong_count(), 1)`, and `Gc::verify_unique_for_aliased_mut` machine-checks the
+`strong == 1 ⟹ unique` argument under `MUTSU_GC_VERIFY=1` (pins: `gc_ptr` unit tests
+`arc_and_gc_strong_counts_stay_in_lockstep` / `erased_clone_makes_arc_exceed_gc_strong`).

--- a/todo/tickets/nativecall-surface-gaps.md
+++ b/todo/tickets/nativecall-surface-gaps.md
@@ -71,3 +71,20 @@ done
   [`news/2026-07/cstruct-handles-carry-their-registered-name.md`](../../news/2026-07/cstruct-handles-carry-their-registered-name.md).
 - **By-value CStructs and callbacks** — recorded in `runtime/nativecall.rs`'s
   module docs as follow-up work; no dist in the batteries needs them yet.
+  (Argument-position CStructs work: a struct is an opaque native handle passed
+  by pointer, which is what made the genuine OpenSSL + IO::Socket::SSL binding
+  run a real `https://` GET — see
+  [`news/2026-07/openssl-battery-https.md`](../../news/2026-07/openssl-battery-https.md).
+  What is missing is **by-value** field-layout marshalling and generic C
+  callbacks.)
+- **A *returned* `CArray[T]` is surfaced as the raw `Pointer` it carries** —
+  there is no length with which to reify a Raku array, so the return is handed
+  back as the pointer instead of an indexable `CArray`. Rakudo returns a
+  `CArray` you can index (reading past the end is the caller's problem).
+- **Native-backed `array[T]` (ADR-0015 P3b) and reference-element
+  `CArray[Str]`/`CArray[Pointer]` (P3c)** are tracked in
+  [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md),
+  not here. P3b also fixes `array-shapes.t` T36-38.
+
+(This section absorbs PLAN.md's former "§1 B4 NativeCall remainder" bullet,
+2026-08-02 — the plan file keeps the outline, the inventory lives here.)

--- a/todo/tickets/otf-compilation-gate-leftovers.md
+++ b/todo/tickets/otf-compilation-gate-leftovers.md
@@ -1,0 +1,26 @@
+# OTF (module-sub on-the-fly compilation) gate — the two remaining exclusions
+
+Extracted from PLAN.md §3 (2026-08-02). The module-sub OTF gate relaxation campaign
+(#4427 → #4429 → #4431 → #4437) is complete; the gate itself is
+`def_is_otf_compilable_module_single` (`src/vm/vm_call_func_ops.rs`). The frontier of "just remove
+the gate and experiment" is exhausted — each remaining exclusion needs mechanism work first.
+
+## 1. `start` blocks — needs per-call capture cells
+
+When a recursive sub's `start` closure captures a parameter, the re-bind of the recursive call
+clobbers the captured value, so `start` is excluded wholesale. Regression pin:
+`t/start-block-return-value.t` test 3. The proof of infeasibility and the history are in
+`news/2026-07.md`. The real fix is per-call capture cells — the same cell-based capture work as
+[needs-env-sync-blanket-removal.md](../deep/needs-env-sync-blanket-removal.md).
+
+## 2. Sigilless scalar (`\x`) parameters — needs a caller-slot mechanism
+
+Caller writeback of raw aliases across `EVAL` needs a mechanism equivalent to #4091 (the `is rw`
+compile-time caller slot). FAIL pin: `t/sigilless-params.t`, "sigilless aliases are writable through
+EVAL calls".
+
+## Intentionally excluded (decided not to do)
+
+- **Default-param builtin-shadow single candidate** — name-cache pollution risk (user policy).
+- **`is encoded(...)`** — NativeCall; zero practical harm.
+- **`state` sharing across signature alternates** — kept as an interpreter boundary.

--- a/todo/tickets/remaining-language-feature-gaps.md
+++ b/todo/tickets/remaining-language-feature-gaps.md
@@ -1,0 +1,43 @@
+# Remaining language-feature gaps that no roast file whitelists
+
+Extracted from PLAN.md §4 (2026-08-02). These are real spec gaps, but none of them flips a roast
+file to passing on its own — which is why they never got picked up. Grouped here so they stay
+visible without occupying the plan outline.
+
+## 1. Multi-line feeds
+
+A feed spanning lines with a leading `==>` does not parse. The blocker is the
+`!ws_before.contains('\n')` guard in `parse_list_infix_loop`. Single-line feeds and `ff` / `fff` are
+done.
+
+```raku
+my @r = (1, 2, 3)
+    ==> map({ $_ * 2 })
+    ==> sort();
+```
+
+`==>>` / `<<==` and `~<` / `~>` are unimplemented/unspecified **in Rakudo itself**, so they cannot be
+started (no oracle).
+
+## 2. Typed-exception gaps needing compile-time scope analysis
+
+- strict-mode undeclared-variable detection
+- cross-`EVAL` detection of class redeclaration
+- `X::Redeclaration::Outer`
+
+All three need compile-time scope analysis that mutsu does not currently perform; each is
+non-trivial on its own.
+
+## 3. `exits-ok($code, $exit, $reason)`
+
+A `Test` routine documented in `raku-doc/doc/Type/Test.rakudoc` (effective with Rakudo 2026.01) that
+mutsu does not provide: passes if the code exits with the given exit code. Implement alongside the
+sibling `dies-ok` / `lives-ok` — in the **Test-module handler**, not as a core builtin (it is not in
+`perl-func.rakudoc`). No roast file uses it (not in upstream roast HEAD either), so this is
+Test-completeness / batteries polish.
+
+## 4. `:D` / `:U` DefiniteHow coercion
+
+`6.c/APPENDICES/A04-experimental/01-misc.t` sits at 16/19 on this (`Target:D(Source:U)`). Tracked
+with the file in [TODO_roast/BLOCKERS.md](../../TODO_roast/BLOCKERS.md); listed here only so the
+feature name is searchable.

--- a/todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md
+++ b/todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md
@@ -1,0 +1,47 @@
+# A stored regex loses its defining scope's lexicals when it escapes the sub
+
+Extracted from PLAN.md §1 B4 (2026-08-02) and re-verified on `main` the same day. Originally found
+while running the (now-retired) Tubu web framework; it is a general interpreter bug on its own axis.
+
+## Repro
+
+```raku
+sub make() {
+    my $word = 'abc';
+    return rx/ $word /;
+}
+my $r = make();
+say ("xx abc yy" ~~ $r).defined;   # mutsu: False    raku: True
+```
+
+The regex is built inside `make`, interpolates the lexical `$word`, and is then returned. By the
+time it runs, mutsu no longer resolves `$word`, so the match fails. `b07ee6627`
+("feat(runtime): a regex literal captures its defining scope") fixed the same-scope case; this
+escaping-the-frame case still fails, so the capture is not surviving the frame teardown.
+
+## Second, related divergence in the same area
+
+A stored regex used as a `<$var>` assertion leaks its inner captures into the *outer* match's
+positional slots:
+
+```raku
+my $inner = rx/ (\d+) /;
+my $outer = rx/ 'n=' <$inner> /;
+"n=123" ~~ $outer;
+say ($/[0] // 'undef');   # mutsu: ｢123｣     raku: undef
+```
+
+In Rakudo a `<$var>` assertion does not publish the sub-regex's positional captures into the calling
+match (both agree that `$/{'$inner'}` is undefined). mutsu splices them in as `$/[0]`.
+
+## Affected files
+
+`src/runtime/regex.rs` / `regex_parse*.rs` (assertion handling for `<$var>`), and whatever performs
+the defining-scope capture for a regex literal (see `b07ee6627` and
+`news/2026-08/regex-literal-captures-defining-scope.md` if present).
+
+## Why it is not a one-liner
+
+The first half is the closure-capture-lifetime family (the captured env must outlive the frame that
+built the regex, like a `Sub`'s closure), and the second half is capture-namespace plumbing through
+assertion invocation — two different mechanisms that happen to meet in the same construct.


### PR DESCRIPTION
PLAN.md had grown to 1072 lines. Its own header said it lists "only unfinished work", but each item had accreted the full history of how it got there: measurement tables, profile snapshots, `Update 2026-07-15 (3)` chains, four-mechanism breakage analyses, and PR numbers for work that already shipped. Finding the actual open question meant reading several screens of narrative first, and every parallel PR that touched it conflicted.

**PLAN.md is now an outline and nothing else** (user decision, 2026-08-02): each item says what is left and links to where the detail lives. A table at the top states the split — `news/` for completed work, `todo/tickets/` + `todo/deep/` for open findings, `docs/adr/` for decisions, `TODO_roast/BLOCKERS.md` for roast, the bench CI for numbers — plus an explicit instruction not to append progress notes to it.

## Nothing was dropped

The analysis that existed **only** in PLAN.md moved into files that own their subject:

| new file | what it carries |
| --- | --- |
| `todo/deep/needs-env-sync-blanket-removal.md` | the `captures_env_by_name` blanket and the four independent mechanisms a standalone removal deterministically broke |
| `todo/deep/interpreter-call-path-in-hot-loops.md` | the roast-wide wall-clock re-baseline, the four files where mutsu loses to raku, and why the churn is the named-arg path |
| `todo/deep/shared-worker-pool-adr.md` | the measured pool groundwork and the central fork (bounded pool + blocking `await` deadlocks — mutsu has no continuations) |
| `todo/tickets/miri-gate-for-adr-0013.md` | the missing Miri job + the stale `aliased_mut.rs` header |
| `todo/tickets/otf-compilation-gate-leftovers.md` | the OTF gate's two remaining exclusions |
| `todo/tickets/http-server-tiny-async-serving-remainder.md` | keep-alive / chunked bodies / `done` inside `whenever`, plus the Humming-Bird B1/B2 bugs |
| `todo/tickets/remaining-language-feature-gaps.md` | multi-line feeds, typed-exception gaps, `exits-ok`, `:D`/`:U` coercion |

Three of the extracted bugs were **re-verified against `raku` while writing them up**, so each ticket carries a fresh repro:

- inline `start` blocks clobber a variable declared after them (`Promise.allof(start {1}, start {2})` → mutsu `Nil`, raku `(Promise)`)
- `&f` re-materializes a fresh `Sub` per mention (`Sub|27` then `Sub|29`; raku is stable)
- a stored regex loses its defining scope's lexicals once it escapes the sub (`rx/ $word /` returned from a sub stops matching)

The **NativeCall remainder** folded into the existing `todo/tickets/nativecall-surface-gaps.md` inventory rather than becoming a new file.

## Two sections left rather than moved

- **Test::Async (former §1 B2b)** — not a bundle candidate, so it has no place in the plan. Its scouting result (custom Metamodel HOW inheritance is necessary but nowhere near sufficient; only a narrow per-declarator shim is viable; 8 of 1573 dists depend on it, all `test-depends`) moved to `docs/ecosystem-guts-dependency-survey.md`, the survey that classified it as `deep_guts`.
- **"Vendoring mechanism"** — simply stale. 22 batteries are vendored under `modules/` and resolved with zero configuration by `resolve_bundled_lib_paths`, with `BATTERIES.md` as policy and a release-time suite gate. Done, so the checkbox went away instead of being re-worded.

## Also

Metrics were re-derived from the tree instead of carried forward: **22** bundled libraries (the table still claimed 0), whitelist **1435/1464**, distribution shipping rather than "none". `ANALYSIS.md` and `docs/mzef-install-pipeline.md` now point at the new homes instead of the old section numbers. All relative links in the new PLAN.md were checked to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)