### PR TITLE
docs: the REPL and the WASM playground already ship

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -76,9 +76,12 @@ phase all work end to end.
 ### B3. Distribution and tooling
 
 Release tarballs (4 targets), the GHCR container image, and `mise use -g github:tokuhirom/mutsu` all
-work; see the CLAUDE.md "mzef package manager and distribution" section.
+work; see the CLAUDE.md "mzef package manager and distribution" section. The **REPL** (`--repl`,
+`src/repl.rs`, plus the in-browser one at `site/repl.html`) and the **public WASM playground**
+(`site/playground.html`, deployed to GitHub Pages by `.github/workflows/pages.yml`) both ship.
 
-- [ ] REPL / debugger / native binary output / public WASM playground.
+- [ ] Debugger.
+- [ ] Native binary output.
 
 ### B4. Module-compatibility frontier (the base of batteries)
 


### PR DESCRIPTION
PLAN.md's B3 bullet still listed `REPL / debugger / native binary output / public WASM playground` as a single unfinished item. Two of the four already ship:

- **REPL** — `--repl` (`src/repl.rs`, `src/repl_core.rs`), pinned by `roast/S19-command-line/repl.t`, plus an in-browser one at `site/repl.html`.
- **Public WASM playground** — `site/playground.html`, built with `wasm-pack` and deployed to GitHub Pages by `.github/workflows/pages.yml`.

So B3 now records both as shipping alongside the release tarballs / container image / mise install, and leaves only **debugger** and **native binary output** as open items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)