### PR TITLE
vm: record env consumer slot sets

### DIFF
--- a/docs/adr/0018-slot-addressed-lexical-capture-and-env-sync.md
+++ b/docs/adr/0018-slot-addressed-lexical-capture-and-env-sync.md
@@ -1,0 +1,128 @@
+# ADR-0018: Slot-addressed lexical capture and precise environment synchronization
+
+- **Status**: Proposed
+- **Date**: 2026-08-02
+- **Deciders**: tokuhirom, Codex
+- **Related**: [ADR-0001](0001-gc-strategy-and-phasing.md), [ADR-0010](0010-cross-thread-lexical-sharing-scope.md), [ADR-0013](0013-container-interior-mutability-cellvalue.md), [ANALYSIS.md](../../ANALYSIS.md) §1.2/§1.3/§2.4, [lexical-scope-slot campaign](../lexical-scope-slot-campaign.md)
+
+## Context
+
+Compiled lexical reads and writes are slot-addressed, but several runtime mechanisms still
+observe or publish those lexicals through the name-keyed `Env`. `CompiledCode` currently
+sets `captures_env_by_name` when it contains any `ForLoop`, `BlockScope`,
+`BlockLocalScope`, `MakeGather`, or `WheneverScope`. That one bit overrides the existing
+per-slot `needs_env_sync` analysis and makes every local an env-mirror target.
+
+The blanket is load-bearing because the five consumers do not yet carry a complete account
+of the slots they observe. Block exit has historically recovered mutations by name, loop
+machinery publishes its parameter and control state through env, gather and whenever execute
+stored bodies against a live env, and closure construction falls back to materializing that
+env. Removing only the blanket deterministically breaks all four mechanism families.
+
+The mirror is also unsound as lexical identity. Two simultaneously-live shadowed bindings
+with the same name collapse to one env key. A nested call can therefore replace a closure's
+capture with a same-named callee parameter, authoritative whenever captures can leak into an
+ambient env, and cross-thread publication needs masks and rollback rules to reconstruct a
+lexical distinction the key cannot represent.
+
+## Decision
+
+The local slot is the authoritative identity and storage location for every compiled lexical.
+`Env` remains the compatibility store for genuinely name-based facilities, but it is not a
+second authoritative copy of a frame.
+
+### Per-consumer slot sets
+
+`CompiledCode` will record the precise local slots required by each of the five consumers.
+The compiler/finalization scan computes those sets from opcode operands, nested compiled-code
+free variables, loop parameters and control carriers, and stored-body metadata. Their union,
+plus reflective access, drives `needs_env_sync`; the presence of a consumer does not fill the
+whole vector.
+
+Every consumer must use its own set when publishing to or importing from env. A missing slot
+in static metadata is conservative for that consumer only: it may request a frame-wide sync
+at the boundary while the migration is Proposed, but it may not silently widen every store in
+the frame. The temporary conservative escape hatch is deleted before this ADR becomes
+Accepted.
+
+### Block restore
+
+`BlockScope` and `BlockLocalScope` restore lexical state by slot identity. A block records the
+slots it owns and the outer slots it may mutate. On exit it clears/restores only owned slots
+and leaves mutations to outer slots in place. It must not reconstruct locals by looking up
+`code.locals[slot]` in env.
+
+Phaser execution uses the same slot map. Exceptional exits, `LEAVE`/`KEEP`/`UNDO`, `let`,
+`temp`, and `$OUTER::` must observe the same binding identities as normal exits.
+
+### Closure capture cells
+
+An escaping mutable lexical is captured as one shared `ContainerRef` cell addressed by its
+creator-frame slot. The creator slot, closure upvalue and any cross-thread descendant share
+that cell. Mutation analysis is only an optimization hint: when mutability cannot be proven
+absent, capture uses a cell. This follows ADR-0001's soundness rule and avoids snapshots whose
+correctness depends on incomplete mutation analysis.
+
+A proven immutable capture may remain an indexed by-value upvalue. Aggregate sigils and rw
+sinks do not opt out of cell capture merely because a generic path is currently
+`ContainerRef`-blind; those paths must be made cell-aware as part of the migration.
+
+Closure invocation resolves indexed captures before any ambient name lookup. Env-by-name is
+retained only for reflective features (`EVAL`, symbolic dereference, `CALLER::`) and system or
+dynamic names that are not ordinary lexical slots.
+
+### Thread sharing
+
+ADR-0010's spawn-lineage store remains the compatibility mechanism during migration. Once a
+captured lexical has a shared cell, thread clones carry the cell by slot-derived capture
+metadata and do not publish that lexical under its bare name. Process-wide internal
+`__mutsu_*` keys remain process-wide as ADR-0010 requires.
+
+## Migration
+
+1. Add regression pins for the env-writeback correctness cluster and counters for blanket and
+   per-consumer synchronization.
+2. Introduce per-consumer slot metadata without changing runtime behavior.
+3. Convert `ForLoop`, `MakeGather`, and `WheneverScope` boundaries to publish only their slot
+   sets; convert `BlockScope` and `BlockLocalScope` restore to slot identity.
+4. Make closure creation and invocation use slot-addressed shared cells, including thread
+   clones and rw/container mutation sinks.
+5. Remove `captures_env_by_name`, the whole-vector `needs_env_sync.fill(true)`, and closure
+   whole-env fallback for ordinary lexicals.
+6. Close the related `todo/` findings only when their reproductions are pinned and pass, then
+   change this ADR to Accepted.
+
+Each step is independently buildable and testable. Ordered implementation layers use stacked
+PRs; no intermediate layer may rely on a higher layer to restore correctness.
+
+## Consequences
+
+- Shadowed lexicals retain distinct identities across blocks, closures, calls and threads.
+- Block cleanup cannot leak or resurrect bindings through a same-named env entry.
+- Closure creation becomes proportional to its captures instead of the size of the ambient
+  environment once the final fallback is removed.
+- Reflective name access still pays an explicit synchronization cost. That boundary is honest:
+  reflection asks for names, while ordinary compiled execution uses slots.
+- The migration touches compiler analysis, scope execution, closure dispatch and concurrency.
+  The wide deterministic regression surface is handled by targeted pins plus CI roast,
+  gc-stress and jit-stress jobs, not by retaining the unsound blanket.
+
+## Rejected alternatives
+
+### Keep `captures_env_by_name` and add local fixes
+
+Rejected. Every fix becomes another consumer of the name mirror and preserves collisions by
+construction.
+
+### Snapshot captured values and write them back on return
+
+Rejected. Separately registered methods, rw arguments and concurrency can mutate a capture in
+ways the current static analysis cannot prove. Copy-out also has no sound ordering for
+concurrent writers.
+
+### Eagerly box every lexical
+
+Rejected. It would make every scalar access pay container indirection and would expand the
+`ContainerRef`-blind surface unnecessarily. Boxing occurs at escape/capture boundaries; an
+uncertain escaping capture is boxed, while a non-escaping local stays a plain slot value.
+

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -269,6 +269,8 @@ impl Compiler {
         self.suppress_list_var_alias = true;
         self.compile_expr(&normalized_iterable);
         self.suppress_list_var_alias = saved_suppress;
+        let source_container_local = Self::for_iterable_source_name(iterable)
+            .and_then(|name| self.local_map.get(&name).copied());
         if let Some(source_name) = Self::for_iterable_source_name(iterable) {
             let source_slot = self.local_map.get(source_name.as_str()).copied();
             let source_idx = self.code.add_constant(Value::str(source_name));
@@ -291,6 +293,7 @@ impl Compiler {
                 param_idx,
                 param_local,
                 topic_local,
+                source_container_local,
                 body_end: 0,
                 label: label.clone(),
                 arity,

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -448,7 +448,12 @@ impl Compiler {
         cf.precompute_param_name_syms();
         cf.detect_inner_subs();
         cf.compute_declared_locals();
-        // Contribute this directly-nested named sub's WRITE set to the enclosing
+        // Contribute this directly-nested named sub's cell-requiring capture set
+        // to the enclosing scope. Besides writes, a scalar fed to WrapVarRef
+        // (`key => $value`, `Pair.new(..., $value)`, captures/list aliases) must
+        // retain the captured variable's container identity across the routine
+        // boundary. A named sub has no runtime closure-creation point, so box
+        // these at the owner's declaration just like named-sub writes.
         // scope so `compute_free_vars` can flag the locals it mutates as
         // `needs_cell_named_sub` (the VM then boxes them at their declaration site
         // for cross-call accumulation through a shared cell — see
@@ -460,6 +465,32 @@ impl Compiler {
         // (e.g. a user `trait_mod:<is>` pushing to an outer `@names`) is boxed too.
         let mut nf_writes = cf.code.free_var_writes.clone();
         nf_writes.extend(cf.code.free_var_container_writes.iter().copied());
+        for pair in cf.code.ops.windows(2) {
+            let (OpCode::GetGlobal(name_idx), OpCode::WrapVarRef(wrapped_idx)) =
+                (&pair[0], &pair[1])
+            else {
+                continue;
+            };
+            if name_idx != wrapped_idx {
+                continue;
+            }
+            if let Some(crate::value::ValueView::Str(name)) =
+                cf.code.constants.get(*name_idx as usize).map(Value::view)
+            {
+                let sym = crate::symbol::Symbol::intern(&name);
+                if !cf.code.container_ref_capture_syms.contains(&sym) {
+                    cf.code.container_ref_capture_syms.push(sym);
+                }
+                if let Some(parent_slot) = self.local_map.get(name.as_str()).copied()
+                    && !self
+                        .code
+                        .needs_cell_named_sub_ref_slots
+                        .contains(&parent_slot)
+                {
+                    self.code.needs_cell_named_sub_ref_slots.push(parent_slot);
+                }
+            }
+        }
         self.code
             .named_sub_captures
             .push((nf_writes, cf.code.needs_cell_named_sub_free.clone()));

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -236,6 +236,10 @@ pub(crate) struct Compiler {
     /// degrade to the literal name string once the creating frame is gone
     /// (escaping closure / `.^add_method`).
     enclosing_sigilless: std::collections::HashSet<String>,
+    /// Local names visible in enclosing compiled frames. A same-named local
+    /// declaration in this compiler shadows a captured binding even though the
+    /// outer binding has no slot in this chunk.
+    enclosing_local_names: std::collections::HashSet<String>,
     /// Placeholder params (`^p` caret-form) an interpret-path caller has
     /// already bound in env before re-compiling this body — see
     /// `seed_prebound_placeholders`.
@@ -358,6 +362,7 @@ impl Compiler {
             outer_constant_names: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
             enclosing_sigilless: std::collections::HashSet::new(),
+            enclosing_local_names: std::collections::HashSet::new(),
             prebound_placeholder_params: std::collections::HashSet::new(),
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),
@@ -599,6 +604,10 @@ impl Compiler {
             .extend(self.sigilless_locals.iter().cloned());
         sub.enclosing_sigilless
             .extend(self.enclosing_sigilless.iter().cloned());
+        sub.enclosing_local_names
+            .extend(self.local_map.keys().cloned());
+        sub.enclosing_local_names
+            .extend(self.enclosing_local_names.iter().cloned());
     }
 
     /// Bake the scope chain visible right here into the code chunk, and return
@@ -719,7 +728,16 @@ impl Compiler {
             // Only a genuine ancestor shadow needs the outer slot restored on exit.
             frame.insert(
                 name.to_string(),
-                if is_ancestor_shadow { prev } else { None },
+                if is_ancestor_shadow {
+                    prev
+                } else if prev.is_none() && self.enclosing_local_names.contains(name) {
+                    // Cross-frame shadow: no outer slot exists in this chunk.
+                    // u32::MAX is a compile-time-only sentinel telling scope exit
+                    // to remove the dead child mapping and resume GetGlobal.
+                    Some(u32::MAX)
+                } else {
+                    None
+                },
             );
         }
         slot
@@ -879,7 +897,11 @@ impl Compiler {
         // `block_declared_vars` machinery keeps enforcing out-of-scope errors.
         for (name, prev) in frame {
             if let Some(outer_slot) = prev {
-                self.local_map.insert(name, outer_slot);
+                if outer_slot == u32::MAX {
+                    self.local_map.remove(&name);
+                } else {
+                    self.local_map.insert(name, outer_slot);
+                }
             }
         }
     }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2031,6 +2031,8 @@ impl Compiler {
                 };
                 let source_var_names = Self::for_iterable_var_names(iterable);
                 let source_var_locals = self.for_source_var_locals(&source_var_names);
+                let source_container_local = Self::for_iterable_source_name(iterable)
+                    .and_then(|name| self.local_map.get(&name).copied());
                 // When the block parameter has a type constraint other than Mu
                 // or Junction, junction items should be autothreaded (expanded
                 // into their eigenstates).
@@ -2048,6 +2050,7 @@ impl Compiler {
                             param_idx,
                             param_local,
                             topic_local,
+                            source_container_local,
                             body_end: 0,
                             label: label.clone(),
                             arity,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3484,7 +3484,7 @@ impl Compiler {
                 // parent's post-registration writes. See
                 // surface_stashed_body_free_vars for the mechanism.
                 let analysis_param = vec![param.clone().unwrap_or_else(|| "$_".to_string())];
-                self.surface_stashed_body_free_vars(&analysis_param, body);
+                let analysis_cc_idx = self.surface_stashed_body_free_vars(&analysis_param, body);
                 let param_idx = param
                     .as_ref()
                     .map(|p| self.code.add_constant(Value::str(p.clone())));
@@ -3503,6 +3503,7 @@ impl Compiler {
                 };
                 self.code.emit(OpCode::WheneverScope {
                     body_idx,
+                    analysis_cc_idx,
                     param_idx,
                     target_var_idx,
                 });

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3487,7 +3487,25 @@ impl Compiler {
                 // parent's post-registration writes. See
                 // surface_stashed_body_free_vars for the mechanism.
                 let analysis_param = vec![param.clone().unwrap_or_else(|| "$_".to_string())];
-                let analysis_cc_idx = self.surface_stashed_body_free_vars(&analysis_param, body);
+                // LAST/QUIT callbacks are split out of the whenever body at
+                // runtime. Compile their statements inline only in the
+                // analysis copy so their outer lexical reads contribute to the
+                // parent-slot inventory; the executable stmt_pool body retains
+                // the original Phaser nodes.
+                let mut analysis_body = Vec::new();
+                for stmt in body {
+                    if let Stmt::Phaser {
+                        kind: PhaserKind::Last | PhaserKind::Quit,
+                        body: phaser_body,
+                    } = stmt
+                    {
+                        analysis_body.extend(phaser_body.iter().cloned());
+                    } else {
+                        analysis_body.push(stmt.clone());
+                    }
+                }
+                let analysis_cc_idx =
+                    self.surface_stashed_body_free_vars(&analysis_param, &analysis_body);
                 let param_idx = param
                     .as_ref()
                     .map(|p| self.code.add_constant(Value::str(p.clone())));

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1782,7 +1782,7 @@ mod const_pool_dedup {
     }
 
     #[test]
-    fn env_consumers_are_recorded_separately_before_blanket_removal() {
+    fn env_consumers_publish_only_their_selected_slots() {
         let mut code = CompiledCode::new();
         code.locals.push("x".to_string());
         code.locals.push("slot_only".to_string());
@@ -1799,7 +1799,32 @@ mod const_pool_dedup {
         assert!(code.env_consumer_slots.block_local_scope.is_empty());
         assert!(code.env_consumer_slots.whenever.is_empty());
         assert!(code.captures_env_by_name);
-        // Runtime behavior is still blanket-compatible in this migration layer.
+        assert_eq!(code.needs_env_sync, vec![true, false]);
+    }
+
+    #[test]
+    fn block_scope_does_not_force_unrelated_slots_into_env_sync() {
+        let mut code = CompiledCode::new();
+        code.locals.push("inside".to_string());
+        code.locals.push("unrelated".to_string());
+        code.ops.push(OpCode::BlockScope {
+            pre_end: 1,
+            enter_end: 1,
+            body_end: 3,
+            keep_start: 3,
+            undo_start: 3,
+            post_start: 3,
+            end: 3,
+            is_bare_block: true,
+        });
+        code.ops.push(OpCode::LoadNil);
+        code.ops.push(OpCode::SetLocalDecl {
+            slot: 0,
+            explicit_init: true,
+        });
+        code.compute_needs_env_sync();
+
+        assert_eq!(code.env_consumer_slots.block_scope, vec![true, false]);
         assert_eq!(code.needs_env_sync, vec![true, false]);
     }
 }
@@ -2355,7 +2380,11 @@ impl CompiledCode {
                 | OpCode::GetArrayVar(idx)
                 | OpCode::GetHashVar(idx)
                 | OpCode::AssignExpr(idx)
-                | OpCode::TopicDotAssign(idx) => Some(*idx),
+                | OpCode::TopicDotAssign(idx)
+                | OpCode::IndexAssignExprNested { name_idx: idx, .. }
+                | OpCode::IndexAssignDeepNested { name_idx: idx, .. }
+                | OpCode::MultiDimIndexAssign { name_idx: idx, .. } => Some(*idx),
+                OpCode::AtomicCompoundVar { name_idx, .. } => Some(*name_idx),
                 _ => None,
             };
             let Some(name_idx) = name_idx else { continue };
@@ -2367,6 +2396,26 @@ impl CompiledCode {
                 if local == name.as_str() {
                     slots[slot] = true;
                 }
+            }
+        }
+    }
+
+    fn mark_local_access_slots(&self, start: usize, end: usize, slots: &mut [bool]) {
+        let end = end.min(self.ops.len());
+        for op in &self.ops[start.min(end)..end] {
+            let slot = match op {
+                OpCode::GetLocal(slot)
+                | OpCode::GetLocalRaw(slot)
+                | OpCode::SetLocal(slot)
+                | OpCode::AssignExprLocal(slot)
+                | OpCode::StateVarInit(slot, _) => Some(*slot),
+                OpCode::GetLocalMetaAssign { slot, .. } | OpCode::SetLocalDecl { slot, .. } => {
+                    Some(*slot)
+                }
+                _ => None,
+            };
+            if let Some(needed) = slot.and_then(|slot| slots.get_mut(slot as usize)) {
+                *needed = true;
             }
         }
     }
@@ -2731,10 +2780,16 @@ impl CompiledCode {
                 OpCode::BlockScope { end, .. } => {
                     has_block_scope = true;
                     self.mark_name_access_slots(op_idx + 1, *end as usize, &mut block_scope_slots);
+                    self.mark_local_access_slots(op_idx + 1, *end as usize, &mut block_scope_slots);
                 }
                 OpCode::BlockLocalScope { body_end, .. } => {
                     has_block_local_scope = true;
                     self.mark_name_access_slots(
+                        op_idx + 1,
+                        *body_end as usize,
+                        &mut block_local_scope_slots,
+                    );
+                    self.mark_local_access_slots(
                         op_idx + 1,
                         *body_end as usize,
                         &mut block_local_scope_slots,
@@ -2796,6 +2851,17 @@ impl CompiledCode {
                 self.dup_named_locals[i] = true;
             }
         }
+        // ForLoop's iteration-local restore still journals shadowed bindings by
+        // name. Publish only the duplicate-name slots that can participate in
+        // that journal; ordinary loop slots are already covered by the baked
+        // source/body bitmap above.
+        if has_for_loop {
+            for (slot, is_duplicate) in self.dup_named_locals.iter().copied().enumerate() {
+                if is_duplicate {
+                    self.env_consumer_slots.for_loop[slot] = true;
+                }
+            }
+        }
         if n == 0 {
             return;
         }
@@ -2826,7 +2892,11 @@ impl CompiledCode {
                 | OpCode::GetArrayVar(idx)
                 | OpCode::GetHashVar(idx)
                 | OpCode::AssignExpr(idx)
-                | OpCode::TopicDotAssign(idx) => Some(*idx),
+                | OpCode::TopicDotAssign(idx)
+                | OpCode::IndexAssignExprNested { name_idx: idx, .. }
+                | OpCode::IndexAssignDeepNested { name_idx: idx, .. }
+                | OpCode::MultiDimIndexAssign { name_idx: idx, .. } => Some(*idx),
+                OpCode::AtomicCompoundVar { name_idx, .. } => Some(*name_idx),
                 _ => None,
             };
             if let Some(idx) = name_idx
@@ -3035,39 +3105,40 @@ impl CompiledCode {
                 self.needs_env_sync.iter_mut().for_each(|b| *b = true);
             }
         }
-        // ADR-0018 staged runtime conversion: gather/whenever already have
-        // complete analysis-closure slot sets, so their precise bitmaps can
-        // drive per-store env publication now. Block/loop cleanup still journals
-        // some carrier state by name; keep that consumer-local fallback until
-        // the next layer replaces its restore with baked slots. This is no
-        // longer a frame-wide fallback merely because a stored body is present.
-        if !self.env_consumer_slots.block_scope.is_empty()
-            || !self.env_consumer_slots.block_local_scope.is_empty()
-        {
-            self.needs_env_sync
-                .iter_mut()
-                .for_each(|needed| *needed = true);
-        } else {
-            for slot in 0..n {
-                self.needs_env_sync[slot] |= self
+        // ADR-0018: each env-by-name consumer now publishes exactly the slots
+        // its analysis selected. Block restore retains lexical slot identity,
+        // so the presence of a block no longer forces a frame-wide blanket.
+        for slot in 0..n {
+            self.needs_env_sync[slot] |= self
+                .env_consumer_slots
+                .for_loop
+                .get(slot)
+                .copied()
+                .unwrap_or(false)
+                || self
                     .env_consumer_slots
-                    .for_loop
+                    .block_scope
                     .get(slot)
                     .copied()
                     .unwrap_or(false)
-                    || self
-                        .env_consumer_slots
-                        .gather
-                        .get(slot)
-                        .copied()
-                        .unwrap_or(false)
-                    || self
-                        .env_consumer_slots
-                        .whenever
-                        .get(slot)
-                        .copied()
-                        .unwrap_or(false);
-            }
+                || self
+                    .env_consumer_slots
+                    .block_local_scope
+                    .get(slot)
+                    .copied()
+                    .unwrap_or(false)
+                || self
+                    .env_consumer_slots
+                    .gather
+                    .get(slot)
+                    .copied()
+                    .unwrap_or(false)
+                || self
+                    .env_consumer_slots
+                    .whenever
+                    .get(slot)
+                    .copied()
+                    .unwrap_or(false);
         }
     }
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1798,7 +1798,6 @@ mod const_pool_dedup {
         assert!(code.env_consumer_slots.block_scope.is_empty());
         assert!(code.env_consumer_slots.block_local_scope.is_empty());
         assert!(code.env_consumer_slots.whenever.is_empty());
-        assert!(code.captures_env_by_name);
         assert_eq!(code.needs_env_sync, vec![true, false]);
     }
 
@@ -1979,10 +1978,8 @@ pub(crate) struct CompiledCode {
     /// Locals that are only accessed via GetLocal don't need env sync,
     /// reducing env size and clone cost.
     pub(crate) needs_env_sync: Vec<bool>,
-    /// Per-consumer lexical-slot synchronization sets. During ADR-0018's first
-    /// migration layer these preserve the old frame-wide behavior; subsequent
-    /// layers narrow each bitmap independently before deleting
-    /// `captures_env_by_name`.
+    /// Per-consumer lexical-slot synchronization sets (ADR-0018). Their union
+    /// contributes to `needs_env_sync` without widening unrelated slots.
     pub(crate) env_consumer_slots: EnvConsumerSlots,
     /// Bitmap: true if local[i]'s NAME occupies more than one `locals` slot —
     /// a genuine inner-block shadow under the `MUTSU_SHADOW_SLOTS` gate (§1.4).
@@ -2224,18 +2221,6 @@ pub(crate) struct CompiledCode {
     /// after every interpreter-native call, which kept such routines
     /// permanently out of the name-keyed call caches by accident.)
     pub(crate) uses_callframe: bool,
-    /// True if this code runs an inline body that reads the frame's lexicals *by
-    /// name* through a path the `free_var_syms` op-scan cannot see: loop/block
-    /// bodies that thread control temps through `env` by name (`ForLoop`,
-    /// `BlockScope`, `BlockLocalScope`), and the two ops that stash a body in the
-    /// `stmt_pool` and compile/run it at runtime against the live env
-    /// (`MakeGather`, `WheneverScope`). For such a frame `free_var_syms` is
-    /// *incomplete*, so two consumers fall back to the whole env: the dual-store
-    /// flush blanket (`compute_needs_env_sync`) marks every local env-synced, and
-    /// the closure upvalue capture (`capture_closure_env`, single-store Slice E)
-    /// snapshots the whole env instead of just the free vars. Set during
-    /// `compute_needs_env_sync`.
-    pub(crate) captures_env_by_name: bool,
     /// True if this code is the body of a `supply { … }` block — the lambda
     /// `Supply.on-demand` is handed, recognised by its generated emitter
     /// parameter (`__mutsu_supply_emitter_N`, see `supply_method_call`).
@@ -2500,7 +2485,6 @@ impl CompiledCode {
             outer_code_var_names: std::collections::HashSet::new(),
             needs_cell_free_vars: Vec::new(),
             has_calls: false,
-            captures_env_by_name: false,
             sub_fingerprints: std::collections::HashMap::new(),
             upvalue_syms: Vec::new(),
             env_only_decls: Vec::new(),
@@ -2834,8 +2818,6 @@ impl CompiledCode {
         if has_whenever {
             self.env_consumer_slots.whenever = whenever_slots;
         }
-        self.captures_env_by_name =
-            has_for_loop || has_block_scope || has_block_local_scope || has_gather || has_whenever;
         // §1.4 shadow slots: flag every slot whose name occupies more than one
         // `locals` slot (a genuine inner-block shadow under MUTSU_SHADOW_SLOTS)
         // so the whole-locals env broadcasts skip them — see `dup_named_locals`.
@@ -4081,12 +4063,9 @@ impl CompiledCode {
     /// index-based upvalues: rewrite their pure-read ops to `GetUpvalue(i)` and
     /// record the captured order in `upvalue_syms`. Must run AFTER
     /// `compute_free_vars` / `compute_needs_env_sync` (it consumes `free_var_syms`,
-    /// `free_var_writes`, `free_var_container_writes`, `captures_env_by_name`).
+    /// `free_var_writes`, `free_var_container_writes`).
     ///
     /// Conservative by design (Phase 1):
-    /// - Skips entirely when `captures_env_by_name` (loop/block/gather/whenever or
-    ///   reflective bodies read lexicals by name through paths the op-scan cannot
-    ///   rewrite).
     /// - A variable is eligible only if it is a plain user lexical, is NEVER
     ///   written anywhere in the closure subtree (not in `free_var_writes` /
     ///   `free_var_container_writes`), and appears in this code's ops only through
@@ -4095,9 +4074,6 @@ impl CompiledCode {
     ///   capture is boxed into a shared `ContainerRef` cell, which the snapshot
     ///   clones), so reads stay coherent without any write-back.
     pub(crate) fn compute_upvalues(&mut self, runtime_bound: &std::collections::HashSet<Symbol>) {
-        if self.captures_env_by_name {
-            return;
-        }
         let own: std::collections::HashSet<&str> = self.locals.iter().map(|s| s.as_str()).collect();
         let written: std::collections::HashSet<Symbol> = self
             .free_var_writes

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1796,7 +1796,7 @@ mod const_pool_dedup {
         assert!(code.env_consumer_slots.whenever.is_empty());
         assert!(code.captures_env_by_name);
         // Runtime behavior is still blanket-compatible in this migration layer.
-        assert_eq!(code.needs_env_sync, vec![true, true]);
+        assert_eq!(code.needs_env_sync, vec![true, false]);
     }
 }
 
@@ -2791,10 +2791,6 @@ impl CompiledCode {
         if n == 0 {
             return;
         }
-        if self.captures_env_by_name {
-            self.needs_env_sync.iter_mut().for_each(|b| *b = true);
-            return;
-        }
         let locals_map: std::collections::HashMap<&str, usize> = self
             .locals
             .iter()
@@ -3029,6 +3025,35 @@ impl CompiledCode {
                 || holds_dynamic_substitution
             {
                 self.needs_env_sync.iter_mut().for_each(|b| *b = true);
+            }
+        }
+        // ADR-0018 staged runtime conversion: gather/whenever already have
+        // complete analysis-closure slot sets, so their precise bitmaps can
+        // drive per-store env publication now. Block/loop cleanup still journals
+        // some carrier state by name; keep that consumer-local fallback until
+        // the next layer replaces its restore with baked slots. This is no
+        // longer a frame-wide fallback merely because a stored body is present.
+        if !self.env_consumer_slots.for_loop.is_empty()
+            || !self.env_consumer_slots.block_scope.is_empty()
+            || !self.env_consumer_slots.block_local_scope.is_empty()
+        {
+            self.needs_env_sync
+                .iter_mut()
+                .for_each(|needed| *needed = true);
+        } else {
+            for slot in 0..n {
+                self.needs_env_sync[slot] |= self
+                    .env_consumer_slots
+                    .gather
+                    .get(slot)
+                    .copied()
+                    .unwrap_or(false)
+                    || self
+                        .env_consumer_slots
+                        .whenever
+                        .get(slot)
+                        .copied()
+                        .unwrap_or(false);
             }
         }
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -182,6 +182,10 @@ pub(crate) struct ForLoopSpec {
     /// exit, exactly as `exec_given_op` does for `given`/`with`. Only set for an
     /// implicit-topic loop (a named parameter does not rebind `$_`).
     pub(crate) topic_local: Option<u32>,
+    /// Local slot that owns the iterable container (`$b` in `for $b.pairs`,
+    /// `%h` in `for %h.values`). Pair/value alias writeback reaches this source
+    /// through env today, so ADR-0018 keeps exactly this slot synchronized.
+    pub(crate) source_container_local: Option<u32>,
     pub(crate) body_end: u32,
     pub(crate) label: Option<String>,
     pub(crate) arity: u32,
@@ -2704,11 +2708,15 @@ impl CompiledCode {
             match op {
                 OpCode::ForLoop(spec) => {
                     has_for_loop = true;
-                    for slot in [spec.param_local, spec.topic_local]
-                        .into_iter()
-                        .flatten()
-                        .chain(spec.source_var_locals.iter().flatten().copied())
-                        .chain(spec.single_array_source_local)
+                    for slot in [
+                        spec.param_local,
+                        spec.topic_local,
+                        spec.source_container_local,
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .chain(spec.source_var_locals.iter().flatten().copied())
+                    .chain(spec.single_array_source_local)
                     {
                         if let Some(needed) = for_loop_slots.get_mut(slot as usize) {
                             *needed = true;
@@ -3033,8 +3041,7 @@ impl CompiledCode {
         // some carrier state by name; keep that consumer-local fallback until
         // the next layer replaces its restore with baked slots. This is no
         // longer a frame-wide fallback merely because a stored body is present.
-        if !self.env_consumer_slots.for_loop.is_empty()
-            || !self.env_consumer_slots.block_scope.is_empty()
+        if !self.env_consumer_slots.block_scope.is_empty()
             || !self.env_consumer_slots.block_local_scope.is_empty()
         {
             self.needs_env_sync
@@ -3044,10 +3051,16 @@ impl CompiledCode {
             for slot in 0..n {
                 self.needs_env_sync[slot] |= self
                     .env_consumer_slots
-                    .gather
+                    .for_loop
                     .get(slot)
                     .copied()
                     .unwrap_or(false)
+                    || self
+                        .env_consumer_slots
+                        .gather
+                        .get(slot)
+                        .copied()
+                        .unwrap_or(false)
                     || self
                         .env_consumer_slots
                         .whenever

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1772,9 +1772,44 @@ mod const_pool_dedup {
             "the index is compile-time scaffolding"
         );
     }
+
+    #[test]
+    fn env_consumers_are_recorded_separately_before_blanket_removal() {
+        let mut code = CompiledCode::new();
+        code.locals.push("x".to_string());
+        code.ops.push(OpCode::MakeGather(0, None));
+        code.compute_needs_env_sync();
+
+        assert_eq!(code.env_consumer_slots.gather, vec![true]);
+        assert!(code.env_consumer_slots.for_loop.is_empty());
+        assert!(code.env_consumer_slots.block_scope.is_empty());
+        assert!(code.env_consumer_slots.block_local_scope.is_empty());
+        assert!(code.env_consumer_slots.whenever.is_empty());
+        assert!(code.captures_env_by_name);
+        assert_eq!(code.needs_env_sync, vec![true]);
+    }
 }
 
 /// A compiled chunk of bytecode.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct EnvConsumerSlots {
+    pub(crate) for_loop: Vec<bool>,
+    pub(crate) block_scope: Vec<bool>,
+    pub(crate) block_local_scope: Vec<bool>,
+    pub(crate) gather: Vec<bool>,
+    pub(crate) whenever: Vec<bool>,
+}
+
+impl EnvConsumerSlots {
+    fn any_consumer(&self) -> bool {
+        self.for_loop.iter().any(|needed| *needed)
+            || self.block_scope.iter().any(|needed| *needed)
+            || self.block_local_scope.iter().any(|needed| *needed)
+            || self.gather.iter().any(|needed| *needed)
+            || self.whenever.iter().any(|needed| *needed)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledCode {
     pub(crate) ops: Vec<OpCode>,
@@ -1915,6 +1950,11 @@ pub(crate) struct CompiledCode {
     /// Locals that are only accessed via GetLocal don't need env sync,
     /// reducing env size and clone cost.
     pub(crate) needs_env_sync: Vec<bool>,
+    /// Per-consumer lexical-slot synchronization sets. During ADR-0018's first
+    /// migration layer these preserve the old frame-wide behavior; subsequent
+    /// layers narrow each bitmap independently before deleting
+    /// `captures_env_by_name`.
+    pub(crate) env_consumer_slots: EnvConsumerSlots,
     /// Bitmap: true if local[i]'s NAME occupies more than one `locals` slot —
     /// a genuine inner-block shadow under the `MUTSU_SHADOW_SLOTS` gate (§1.4).
     /// The name-keyed env can hold only ONE value per name, so the whole-locals
@@ -2330,6 +2370,7 @@ impl CompiledCode {
             has_env_writes: false,
             may_capture_outer_vars: false,
             needs_env_sync: Vec::new(),
+            env_consumer_slots: EnvConsumerSlots::default(),
             dup_named_locals: Vec::new(),
             is_supply_block_body: false,
             my_declared_sym: rustc_hash::FxHashSet::default(),
@@ -2605,18 +2646,41 @@ impl CompiledCode {
         // early return) so zero-local closures wrapping a `whenever`/`gather` are
         // covered too. Recursion-heavy code without these (e.g. `fib`) is
         // unaffected and still skips the per-call flush for its slot-only params.
-        self.captures_env_by_name = self.ops.iter().any(|op| {
-            matches!(
-                op,
-                OpCode::ForLoop(..)
-                    | OpCode::BlockScope { .. }
-                    | OpCode::BlockLocalScope { .. }
-                    | OpCode::MakeGather(..)
-                    | OpCode::WheneverScope { .. }
-            )
-        });
         let n = self.locals.len();
         self.needs_env_sync = vec![false; n];
+        self.env_consumer_slots = EnvConsumerSlots::default();
+        let mut has_for_loop = false;
+        let mut has_block_scope = false;
+        let mut has_block_local_scope = false;
+        let mut has_gather = false;
+        let mut has_whenever = false;
+        for op in &self.ops {
+            match op {
+                OpCode::ForLoop(..) => has_for_loop = true,
+                OpCode::BlockScope { .. } => has_block_scope = true,
+                OpCode::BlockLocalScope { .. } => has_block_local_scope = true,
+                OpCode::MakeGather(..) => has_gather = true,
+                OpCode::WheneverScope { .. } => has_whenever = true,
+                _ => {}
+            }
+        }
+        let blanket = vec![true; n];
+        if has_for_loop {
+            self.env_consumer_slots.for_loop = blanket.clone();
+        }
+        if has_block_scope {
+            self.env_consumer_slots.block_scope = blanket.clone();
+        }
+        if has_block_local_scope {
+            self.env_consumer_slots.block_local_scope = blanket.clone();
+        }
+        if has_gather {
+            self.env_consumer_slots.gather = blanket.clone();
+        }
+        if has_whenever {
+            self.env_consumer_slots.whenever = blanket;
+        }
+        self.captures_env_by_name = self.env_consumer_slots.any_consumer();
         // §1.4 shadow slots: flag every slot whose name occupies more than one
         // `locals` slot (a genuine inner-block shadow under MUTSU_SHADOW_SLOTS)
         // so the whole-locals env broadcasts skip them — see `dup_named_locals`.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1520,6 +1520,10 @@ pub(crate) enum OpCode {
     },
     WheneverScope {
         body_idx: u32,
+        /// Analysis-only compiled form of the stmt-pool body. It is never
+        /// executed, but supplies precise free-variable parent slots to
+        /// ADR-0018's env-consumer analysis.
+        analysis_cc_idx: u32,
         param_idx: Option<u32>,
         target_var_idx: Option<u32>,
     },
@@ -1777,16 +1781,22 @@ mod const_pool_dedup {
     fn env_consumers_are_recorded_separately_before_blanket_removal() {
         let mut code = CompiledCode::new();
         code.locals.push("x".to_string());
-        code.ops.push(OpCode::MakeGather(0, None));
+        code.locals.push("slot_only".to_string());
+        let mut gather_body = CompiledCode::new();
+        gather_body.free_var_parent_slots.push(Some(0));
+        code.closure_compiled_codes
+            .push(std::sync::Arc::new(gather_body));
+        code.ops.push(OpCode::MakeGather(0, Some(0)));
         code.compute_needs_env_sync();
 
-        assert_eq!(code.env_consumer_slots.gather, vec![true]);
+        assert_eq!(code.env_consumer_slots.gather, vec![true, false]);
         assert!(code.env_consumer_slots.for_loop.is_empty());
         assert!(code.env_consumer_slots.block_scope.is_empty());
         assert!(code.env_consumer_slots.block_local_scope.is_empty());
         assert!(code.env_consumer_slots.whenever.is_empty());
         assert!(code.captures_env_by_name);
-        assert_eq!(code.needs_env_sync, vec![true]);
+        // Runtime behavior is still blanket-compatible in this migration layer.
+        assert_eq!(code.needs_env_sync, vec![true, true]);
     }
 }
 
@@ -1798,16 +1808,6 @@ pub(crate) struct EnvConsumerSlots {
     pub(crate) block_local_scope: Vec<bool>,
     pub(crate) gather: Vec<bool>,
     pub(crate) whenever: Vec<bool>,
-}
-
-impl EnvConsumerSlots {
-    fn any_consumer(&self) -> bool {
-        self.for_loop.iter().any(|needed| *needed)
-            || self.block_scope.iter().any(|needed| *needed)
-            || self.block_local_scope.iter().any(|needed| *needed)
-            || self.gather.iter().any(|needed| *needed)
-            || self.whenever.iter().any(|needed| *needed)
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -2337,6 +2337,47 @@ impl ConstKey {
 }
 
 impl CompiledCode {
+    fn mark_name_access_slots(&self, start: usize, end: usize, slots: &mut [bool]) {
+        let end = end.min(self.ops.len());
+        for op in &self.ops[start.min(end)..end] {
+            let name_idx = match op {
+                OpCode::GetGlobal(idx)
+                | OpCode::SetGlobal(idx)
+                | OpCode::SetGlobalRaw(idx)
+                | OpCode::PostIncrement(idx, _)
+                | OpCode::PostDecrement(idx, _)
+                | OpCode::PreIncrement(idx, _)
+                | OpCode::PreDecrement(idx, _)
+                | OpCode::GetArrayVar(idx)
+                | OpCode::GetHashVar(idx)
+                | OpCode::AssignExpr(idx)
+                | OpCode::TopicDotAssign(idx) => Some(*idx),
+                _ => None,
+            };
+            let Some(name_idx) = name_idx else { continue };
+            let Some(ValueView::Str(name)) = self.constants.get(name_idx as usize).map(Value::view)
+            else {
+                continue;
+            };
+            for (slot, local) in self.locals.iter().enumerate() {
+                if local == name.as_str() {
+                    slots[slot] = true;
+                }
+            }
+        }
+    }
+
+    fn mark_closure_parent_slots(&self, cc_idx: u32, slots: &mut [bool]) {
+        let Some(cc) = self.closure_compiled_codes.get(cc_idx as usize) else {
+            return;
+        };
+        for slot in cc.free_var_parent_slots.iter().flatten() {
+            if let Some(needed) = slots.get_mut(*slot as usize) {
+                *needed = true;
+            }
+        }
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             ops: Vec::new(),
@@ -2654,33 +2695,74 @@ impl CompiledCode {
         let mut has_block_local_scope = false;
         let mut has_gather = false;
         let mut has_whenever = false;
-        for op in &self.ops {
+        let mut for_loop_slots = vec![false; n];
+        let mut block_scope_slots = vec![false; n];
+        let mut block_local_scope_slots = vec![false; n];
+        let mut gather_slots = vec![false; n];
+        let mut whenever_slots = vec![false; n];
+        for (op_idx, op) in self.ops.iter().enumerate() {
             match op {
-                OpCode::ForLoop(..) => has_for_loop = true,
-                OpCode::BlockScope { .. } => has_block_scope = true,
-                OpCode::BlockLocalScope { .. } => has_block_local_scope = true,
-                OpCode::MakeGather(..) => has_gather = true,
-                OpCode::WheneverScope { .. } => has_whenever = true,
+                OpCode::ForLoop(spec) => {
+                    has_for_loop = true;
+                    for slot in [spec.param_local, spec.topic_local]
+                        .into_iter()
+                        .flatten()
+                        .chain(spec.source_var_locals.iter().flatten().copied())
+                        .chain(spec.single_array_source_local)
+                    {
+                        if let Some(needed) = for_loop_slots.get_mut(slot as usize) {
+                            *needed = true;
+                        }
+                    }
+                    self.mark_name_access_slots(
+                        op_idx + 1,
+                        spec.body_end as usize,
+                        &mut for_loop_slots,
+                    );
+                }
+                OpCode::BlockScope { end, .. } => {
+                    has_block_scope = true;
+                    self.mark_name_access_slots(op_idx + 1, *end as usize, &mut block_scope_slots);
+                }
+                OpCode::BlockLocalScope { body_end, .. } => {
+                    has_block_local_scope = true;
+                    self.mark_name_access_slots(
+                        op_idx + 1,
+                        *body_end as usize,
+                        &mut block_local_scope_slots,
+                    );
+                }
+                OpCode::MakeGather(_, Some(cc_idx)) => {
+                    has_gather = true;
+                    self.mark_closure_parent_slots(*cc_idx, &mut gather_slots);
+                }
+                OpCode::MakeGather(_, None) => has_gather = true,
+                OpCode::WheneverScope {
+                    analysis_cc_idx, ..
+                } => {
+                    has_whenever = true;
+                    self.mark_closure_parent_slots(*analysis_cc_idx, &mut whenever_slots);
+                }
                 _ => {}
             }
         }
-        let blanket = vec![true; n];
         if has_for_loop {
-            self.env_consumer_slots.for_loop = blanket.clone();
+            self.env_consumer_slots.for_loop = for_loop_slots;
         }
         if has_block_scope {
-            self.env_consumer_slots.block_scope = blanket.clone();
+            self.env_consumer_slots.block_scope = block_scope_slots;
         }
         if has_block_local_scope {
-            self.env_consumer_slots.block_local_scope = blanket.clone();
+            self.env_consumer_slots.block_local_scope = block_local_scope_slots;
         }
         if has_gather {
-            self.env_consumer_slots.gather = blanket.clone();
+            self.env_consumer_slots.gather = gather_slots;
         }
         if has_whenever {
-            self.env_consumer_slots.whenever = blanket;
+            self.env_consumer_slots.whenever = whenever_slots;
         }
-        self.captures_env_by_name = self.env_consumer_slots.any_consumer();
+        self.captures_env_by_name =
+            has_for_loop || has_block_scope || has_block_local_scope || has_gather || has_whenever;
         // §1.4 shadow slots: flag every slot whose name occupies more than one
         // `locals` slot (a genuine inner-block shadow under MUTSU_SHADOW_SLOTS)
         // so the whole-locals env broadcasts skip them — see `dup_named_locals`.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2081,6 +2081,14 @@ pub(crate) struct CompiledCode {
     /// at their declaration site (`box_decl_local_cell`). Distinct from
     /// `needs_cell_locals` (closure-driven) — see `named_sub_captures`.
     pub(crate) needs_cell_named_sub: Vec<Symbol>,
+    /// Exact owner slots whose containers are captured by `WrapVarRef` in a
+    /// directly nested named sub. Kept slot-addressed so a same-named lexical in
+    /// another block is not boxed at its declaration site.
+    pub(crate) needs_cell_named_sub_ref_slots: Vec<u32>,
+    /// Free variables whose raw container is consumed by `WrapVarRef`. Runtime
+    /// reference wrapping may read a captured env cell only for this explicit
+    /// set; ordinary same-named env cells must not override a shadow value.
+    pub(crate) container_ref_capture_syms: Vec<Symbol>,
     /// Named-sub writes of a NON-own (ancestor) lexical, bubbled up so the ancestor
     /// that declares the local folds it into its own `needs_cell_named_sub`
     /// (mirrors `needs_cell_free_vars` for closures).
@@ -2477,6 +2485,8 @@ impl CompiledCode {
             free_var_container_writes: Vec::new(),
             named_sub_captures: Vec::new(),
             needs_cell_named_sub: Vec::new(),
+            needs_cell_named_sub_ref_slots: Vec::new(),
+            container_ref_capture_syms: Vec::new(),
             needs_cell_named_sub_free: Vec::new(),
             escaping_our_sub_captures: Vec::new(),
             needs_cell_escaping_our_sub: Vec::new(),

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4098,18 +4098,6 @@ impl CompiledCode {
     ///   capture is boxed into a shared `ContainerRef` cell, which the snapshot
     ///   clones), so reads stay coherent without any write-back.
     pub(crate) fn compute_upvalues(&mut self, runtime_bound: &std::collections::HashSet<Symbol>) {
-        // Phase-1 indexed upvalues require the standard closure-dispatch path to
-        // install the aligned array. Inline block scopes handed to thread clones,
-        // and runtime-split whenever/LAST/QUIT callbacks, can execute through
-        // carrier paths without that array. Keep their reads as GetGlobal over
-        // the already-precise captured env; this does not widen env sync or
-        // restore the removed captures_env_by_name blanket.
-        if !self.env_consumer_slots.block_scope.is_empty()
-            || !self.env_consumer_slots.block_local_scope.is_empty()
-            || !self.env_consumer_slots.whenever.is_empty()
-        {
-            return;
-        }
         let own: std::collections::HashSet<&str> = self.locals.iter().map(|s| s.as_str()).collect();
         let written: std::collections::HashSet<Symbol> = self
             .free_var_writes

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1787,6 +1787,11 @@ mod const_pool_dedup {
         code.locals.push("x".to_string());
         code.locals.push("slot_only".to_string());
         let mut gather_body = CompiledCode::new();
+        // `free_var_parent_slots` is built by mapping over `free_var_syms`
+        // (`add_closure_code_baked`), so the two are index-aligned and the same
+        // length. Seed both: the slot alone is a state no compiler run produces,
+        // and the consumer-slot fold walks the syms to reach it.
+        gather_body.free_var_syms.push(Symbol::intern("x"));
         gather_body.free_var_parent_slots.push(Some(0));
         code.closure_compiled_codes
             .push(std::sync::Arc::new(gather_body));

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2431,8 +2431,21 @@ impl CompiledCode {
         let Some(cc) = self.closure_compiled_codes.get(cc_idx as usize) else {
             return;
         };
-        for slot in cc.free_var_parent_slots.iter().flatten() {
-            if let Some(needed) = slots.get_mut(*slot as usize) {
+        for (idx, sym) in cc.free_var_syms.iter().enumerate() {
+            // A self-referential stored body can be analyzed while its binding
+            // initializer is still being compiled (`my @a := gather { ... @a
+            // ... }`), leaving the baked parent slot absent even though the
+            // declaration slot is already present in this frame. Resolve that
+            // exact same-name slot here; it is still a per-consumer slot, not a
+            // frame-wide fallback.
+            let slot = cc
+                .free_var_parent_slots
+                .get(idx)
+                .copied()
+                .flatten()
+                .map(|slot| slot as usize)
+                .or_else(|| sym.with_str(|name| self.locals.iter().rposition(|n| n == name)));
+            if let Some(needed) = slot.and_then(|slot| slots.get_mut(slot)) {
                 *needed = true;
             }
         }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2413,6 +2413,20 @@ impl CompiledCode {
         }
     }
 
+    fn mark_same_named_slot_peers(&self, slots: &mut [bool]) {
+        let selected_names: std::collections::HashSet<&str> = slots
+            .iter()
+            .enumerate()
+            .filter(|(_, selected)| **selected)
+            .map(|(slot, _)| self.locals[slot].as_str())
+            .collect();
+        for (slot, name) in self.locals.iter().enumerate() {
+            if selected_names.contains(name.as_str()) {
+                slots[slot] = true;
+            }
+        }
+    }
+
     fn mark_closure_parent_slots(&self, cc_idx: u32, slots: &mut [bool]) {
         let Some(cc) = self.closure_compiled_codes.get(cc_idx as usize) else {
             return;
@@ -2802,6 +2816,16 @@ impl CompiledCode {
                 }
                 _ => {}
             }
+        }
+        // A block declaration's entry prelude may clear the previously visible
+        // same-named outer slot. Block exit restores that exact peer from env,
+        // so every simultaneously live peer is a dependency of this consumer —
+        // still a precise duplicate-name subset, never a frame-wide blanket.
+        if has_block_scope {
+            self.mark_same_named_slot_peers(&mut block_scope_slots);
+        }
+        if has_block_local_scope {
+            self.mark_same_named_slot_peers(&mut block_local_scope_slots);
         }
         if has_for_loop {
             self.env_consumer_slots.for_loop = for_loop_slots;
@@ -4074,6 +4098,18 @@ impl CompiledCode {
     ///   capture is boxed into a shared `ContainerRef` cell, which the snapshot
     ///   clones), so reads stay coherent without any write-back.
     pub(crate) fn compute_upvalues(&mut self, runtime_bound: &std::collections::HashSet<Symbol>) {
+        // Phase-1 indexed upvalues require the standard closure-dispatch path to
+        // install the aligned array. Inline block scopes handed to thread clones,
+        // and runtime-split whenever/LAST/QUIT callbacks, can execute through
+        // carrier paths without that array. Keep their reads as GetGlobal over
+        // the already-precise captured env; this does not widen env sync or
+        // restore the removed captures_env_by_name blanket.
+        if !self.env_consumer_slots.block_scope.is_empty()
+            || !self.env_consumer_slots.block_local_scope.is_empty()
+            || !self.env_consumer_slots.whenever.is_empty()
+        {
+            return;
+        }
         let own: std::collections::HashSet<&str> = self.locals.iter().map(|s| s.as_str()).collect();
         let written: std::collections::HashSet<Symbol> = self
             .free_var_writes

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -263,6 +263,10 @@ impl Interpreter {
         self.gather_items.pop()
     }
 
+    pub(crate) fn current_gather_items(&self) -> Vec<Value> {
+        self.gather_items.last().cloned().unwrap_or_default()
+    }
+
     pub(crate) fn push_gather_take_limit(&mut self, limit: Option<usize>) {
         self.gather_take_limits.push(limit);
     }

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1105,7 +1105,9 @@ impl Interpreter {
                     // this broad writeback path even when the authoritative
                     // binding was only read; never replay that installed value
                     // into the ambient caller env on return.
-                    && !data.authoritative_captures.contains(k)
+                    && (!data.authoritative_captures.contains(k)
+                        || cc.free_var_writes.contains(k)
+                        || cc.free_var_container_writes.contains(k))
                     && (restored_env.contains_key_sym(*k)
                         || captured_names.contains(k)
                         || (meta_possible

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1097,6 +1097,15 @@ impl Interpreter {
                     && *k != self_sym
                     && !rw_sources.contains(k)
                     && !param_names.contains(k)
+                    // A runtime-built callback (notably a `whenever` body)
+                    // force-installs these captured bindings so they beat an
+                    // unrelated same-named caller lexical.  That install is
+                    // call-private, not a mutation of the caller binding.  A
+                    // callback containing `emit` has `cc.has_calls`, so it takes
+                    // this broad writeback path even when the authoritative
+                    // binding was only read; never replay that installed value
+                    // into the ambient caller env on return.
+                    && !data.authoritative_captures.contains(k)
                     && (restored_env.contains_key_sym(*k)
                         || captured_names.contains(k)
                         || (meta_possible

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -205,6 +205,13 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let body_start = *ip + 1;
         let body_end = body_end as usize;
+        let owned_slots: rustc_hash::FxHashSet<usize> = code.ops[body_start..body_end]
+            .iter()
+            .filter_map(|op| match op {
+                OpCode::SetLocalDecl { slot, .. } => Some(*slot as usize),
+                _ => None,
+            })
+            .collect();
         // Snapshot the env keys present before the branch runs so that on exit
         // we can tell a *fresh* block-local `my` (no outer binding of that name)
         // apart from one that merely *shadows* an existing outer binding (which
@@ -268,10 +275,8 @@ impl Interpreter {
                 continue;
             }
             self.env_mut().remove_sym(*sym);
-            for idx in 0..code.locals.len().min(self.locals.len()) {
-                if code.local_sym(idx) == Some(*sym) {
-                    // Fresh declaration's slot is unique to it; its pre-branch
-                    // value is Nil (see the entry comment), so reset to Nil.
+            for &idx in &owned_slots {
+                if idx < self.locals.len() && code.local_sym(idx) == Some(*sym) {
                     self.locals[idx] = Value::NIL;
                 }
             }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4415,6 +4415,7 @@ impl Interpreter {
             }
             OpCode::WheneverScope {
                 body_idx,
+                analysis_cc_idx: _,
                 param_idx,
                 target_var_idx,
             } => {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -556,6 +556,20 @@ impl Interpreter {
                     *ip += 1;
                     return Ok(());
                 }
+                // A `:=`-bound gather may read the array currently being
+                // produced. MakeGather tags that exact self-reference; expose
+                // the live take collector instead of recursively forcing the
+                // LazyList (or reading its pre-declaration env snapshot).
+                if self
+                    .env()
+                    .get(&format!("__mutsu_gather_self_ref::{name}"))
+                    .is_some()
+                {
+                    self.stack
+                        .push(Value::real_array(self.current_gather_items()));
+                    *ip += 1;
+                    return Ok(());
+                }
                 let val = self
                     .get_env_with_main_alias(name)
                     .or_else(|| self.get_local_by_bare_name(code, name))

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -560,9 +560,22 @@ impl Interpreter {
     /// taken from the chunk's pre-interned constant symbols: no `String`, no
     /// hashing.
     pub(super) fn exec_wrap_var_ref_op(&mut self, code: &CompiledCode, name_idx: u32) {
-        let value = self.stack.pop().unwrap_or(Value::NIL);
-        self.stack
-            .push(Value::varref(code.const_sym(name_idx), value, None));
+        let mut value = self.stack.pop().unwrap_or(Value::NIL);
+        // GetGlobal intentionally dereferences a captured cell for ordinary
+        // value reads. WrapVarRef is different: it denotes the variable's
+        // container (`key => $outer`, `Pair.new(..., $outer)`, rw args), so keep
+        // the raw captured cell when one exists in the lexical environment.
+        // This is the no-local-slot half of capture_var_cell: an outer lexical
+        // cannot be found in the callee's `code.locals`, but its creator slot and
+        // this env entry share the same ContainerRef.
+        let sym = code.const_sym(name_idx);
+        if code.container_ref_capture_syms.contains(&sym)
+            && let Some(captured) = self.env().get_sym(sym)
+            && captured.is_container_ref()
+        {
+            value = captured.clone();
+        }
+        self.stack.push(Value::varref(sym, value, None));
     }
 
     /// Validate and coerce a value for native integer type assignment.

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -497,6 +497,13 @@ impl Interpreter {
                     if is_block_declared {
                         if owned_slots.contains(&idx) {
                             self.locals[idx] = Value::NIL;
+                        } else {
+                            // The block-entry shadow prelude clears the formerly
+                            // visible outer slot before initializing the fresh
+                            // declaration slot. Restore that exact outer slot;
+                            // never broadcast the value into the owned slot.
+                            self.locals[idx] =
+                                restored_env.get(name).cloned().unwrap_or(Value::NIL);
                         }
                     } else {
                         self.locals[idx] = restored_env.get(name).cloned().unwrap_or(Value::NIL);

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -199,6 +199,17 @@ impl Interpreter {
         let undo_start = undo_start as usize;
         let post_start = post_start as usize;
         let end = end as usize;
+        // ADR-0018 BlockScope restore: declaration opcodes carry the exact
+        // lexical slot owned by this block. Keep that identity through cleanup
+        // instead of broadcasting a name-keyed env value to every same-named
+        // slot in the frame.
+        let owned_slots: rustc_hash::FxHashSet<usize> = code.ops[pre_start..end]
+            .iter()
+            .filter_map(|op| match op {
+                OpCode::SetLocalDecl { slot, .. } => Some(*slot as usize),
+                _ => None,
+            })
+            .collect();
         let routine_snapshot = self.snapshot_routine_registry();
         let saved_env = self.env().clone();
         // Under shadow slots (default) the block exit uses a targeted Nil-reset of
@@ -478,13 +489,18 @@ impl Interpreter {
             //     which `restored_env` still holds because propagation was skipped
             //     for these names in the loop above.
             for (idx, name) in code.locals.iter().enumerate() {
-                let non_propagating = name == "_"
-                    || name.starts_with('*')
-                    || code
-                        .local_sym(idx)
-                        .is_some_and(|s| block_declared.contains(&s));
+                let is_block_declared = code
+                    .local_sym(idx)
+                    .is_some_and(|s| block_declared.contains(&s));
+                let non_propagating = name == "_" || name.starts_with('*') || is_block_declared;
                 if non_propagating {
-                    self.locals[idx] = restored_env.get(name).cloned().unwrap_or(Value::NIL);
+                    if is_block_declared {
+                        if owned_slots.contains(&idx) {
+                            self.locals[idx] = Value::NIL;
+                        }
+                    } else {
+                        self.locals[idx] = restored_env.get(name).cloned().unwrap_or(Value::NIL);
+                    }
                 }
             }
         }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -426,14 +426,11 @@ impl Interpreter {
     /// drops only the bulk non-free plain user lexicals, which the body provably
     /// cannot reference.
     ///
-    /// Two cases keep the whole-env snapshot (`clone_env`) because `free_var_syms`
-    /// is *not* a complete account of the names the body reads:
-    /// - **reflective** programs (`EVAL` / `CALLER::` / symbolic deref) can read a
-    ///   caller lexical under any name (process-global flag, set at finalize);
-    /// - **`captures_env_by_name`** frames run an inline body that reads lexicals
-    ///   by name through a path the op-scan misses (`whenever`/`gather` bodies
-    ///   stashed in the `stmt_pool`, loop/block control temps) — see the field on
-    ///   [`CompiledCode`].
+    /// Reflective programs (`EVAL` / `CALLER::` / symbolic deref) keep the
+    /// whole-env snapshot because they can read a caller lexical under any name.
+    /// Inline/stored-body consumers no longer widen closure capture: their exact
+    /// dependencies are represented by `free_var_syms` and the per-consumer slot
+    /// sets from ADR-0018.
     ///
     /// **Slice E Part 2 (the upvalue read):** a free variable that is one of *this*
     /// frame's own locals is read straight from the slot store
@@ -454,7 +451,7 @@ impl Interpreter {
         let Some(cc) = cc else {
             return self.clone_env();
         };
-        if cc.captures_env_by_name || crate::opcode::reflective_name_access_possible() {
+        if crate::opcode::reflective_name_access_possible() {
             let mut flat = self.clone_env();
             // Even when capturing the whole env by name, a slot-only local (a
             // pointy-block/sub parameter that this frame never mirrors into `env`,

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -81,6 +81,31 @@ impl Interpreter {
             self.box_captured_lexicals(code, &analysis_cc);
             let mut env = self.env().clone();
             env.insert("__mutsu_lazylist_from_gather".to_string(), Value::TRUE);
+            // A forward aggregate free var with no baked parent slot is the
+            // self-reference in a binding initializer (`my @a := gather {
+            // ... @a ... }`). Tag it before the LazyList is built; GetArrayVar
+            // then exposes the live take collector while this gather is being
+            // forced, instead of reading the pre-declaration Any snapshot.
+            if let Some(analysis) = &analysis_cc {
+                for (i, sym) in analysis.free_var_syms.iter().enumerate() {
+                    let has_baked_slot = analysis
+                        .free_var_parent_slots
+                        .get(i)
+                        .copied()
+                        .flatten()
+                        .is_some();
+                    let is_forward_aggregate = !has_baked_slot
+                        && sym.with_str(|name| {
+                            (name.starts_with('@') || name.starts_with('%'))
+                                && code.locals.iter().any(|local| local == name)
+                        });
+                    if is_forward_aggregate {
+                        sym.with_str(|name| {
+                            env.insert(format!("__mutsu_gather_self_ref::{name}"), Value::TRUE);
+                        });
+                    }
+                }
+            }
             // Compile the gather body to bytecode for Interpreter-native forcing.
             // A `sub` declared in the body is lexical to it, so compile through a
             // `Stmt::Block` (whose `BlockScope` restores the routine registry) when there

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -451,11 +451,7 @@ impl Interpreter {
         let Some(cc) = cc else {
             return self.clone_env();
         };
-        if crate::opcode::reflective_name_access_possible()
-            || !cc.env_consumer_slots.block_scope.is_empty()
-            || !cc.env_consumer_slots.block_local_scope.is_empty()
-            || !cc.env_consumer_slots.whenever.is_empty()
-        {
+        if crate::opcode::reflective_name_access_possible() {
             let mut flat = self.clone_env();
             // Even when capturing the whole env by name, a slot-only local (a
             // pointy-block/sub parameter that this frame never mirrors into `env`,

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -451,7 +451,11 @@ impl Interpreter {
         let Some(cc) = cc else {
             return self.clone_env();
         };
-        if crate::opcode::reflective_name_access_possible() {
+        if crate::opcode::reflective_name_access_possible()
+            || !cc.env_consumer_slots.block_scope.is_empty()
+            || !cc.env_consumer_slots.block_local_scope.is_empty()
+            || !cc.env_consumer_slots.whenever.is_empty()
+        {
             let mut flat = self.clone_env();
             // Even when capturing the whole env by name, a slot-only local (a
             // pointy-block/sub parameter that this frame never mirrors into `env`,

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -470,11 +470,19 @@ impl Interpreter {
     fn sync_state_locals(&mut self, code: &CompiledCode) {
         for (slot, key) in &code.state_locals {
             let local_name = &code.locals[*slot];
-            let val = self
-                .env()
-                .get(local_name)
-                .cloned()
-                .unwrap_or_else(|| self.locals[*slot].clone());
+            // A slot-only state local has no current env mirror under the
+            // precise-sync regime; an older declaration seed may still be
+            // present there.  Persist the authoritative slot in that case.
+            // Name-based consumers are folded into `needs_env_sync` and retain
+            // the env-first path for their out-of-slot mutations.
+            let val = if code.needs_env_sync.get(*slot).copied().unwrap_or(true) {
+                self.env()
+                    .get(local_name)
+                    .cloned()
+                    .unwrap_or_else(|| self.locals[*slot].clone())
+            } else {
+                self.locals[*slot].clone()
+            };
             let scoped_key = self.scoped_state_key(key);
             self.set_state_var(scoped_key, val);
         }

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -520,11 +520,30 @@ impl Interpreter {
                 continue;
             }
             let local_name = &code.locals[*slot];
-            let val = self
-                .env()
-                .get(local_name)
-                .cloned()
-                .unwrap_or_else(|| self.locals[*slot].clone());
+            // Same store-selection rule as the routine-exit sibling in
+            // `vm_closure_dispatch` (see its comment): read whichever store is
+            // authoritative for this slot. Once ADR-0018 narrowed a for-loop
+            // frame's env sync from a frame-wide blanket to the loop's own baked
+            // slots, a plain `state $t` in the body no longer mirrors to env, so
+            // an env-first read persisted the value the DECLARATION seeded and
+            // the accumulation vanished (`gather { for 1..3 { state $t = 0; $t =
+            // $t + 1; take $t } }` yielded 1 1 1). A state var that IS
+            // env-synced keeps its mirror current and may have been written
+            // there by name — a dynamic `s///` replacement bumping it leaves the
+            // slot at the pre-replacement value — so that case still reads env
+            // first.
+            let slot_authoritative = !code.needs_env_sync.get(*slot).copied().unwrap_or(false);
+            let val = if slot_authoritative {
+                self.locals
+                    .get(*slot)
+                    .cloned()
+                    .unwrap_or_else(|| self.env().get(local_name).cloned().unwrap_or(Value::NIL))
+            } else {
+                self.env()
+                    .get(local_name)
+                    .cloned()
+                    .unwrap_or_else(|| self.locals[*slot].clone())
+            };
             let scoped_key = self.scoped_state_key(key);
             self.set_state_var(scoped_key, val);
         }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -240,7 +240,9 @@ impl Interpreter {
         // closures are boxed precisely at their creation op, so reusing that set
         // here would over-box unrelated same-named locals (same-named `my` locals
         // share one slot) and break e.g. `let`-restore in a sibling block.
-        let box_decl = self.vardecl_context && !code.needs_cell_named_sub.is_empty();
+        let box_decl = self.vardecl_context
+            && (!code.needs_cell_named_sub.is_empty()
+                || !code.needs_cell_named_sub_ref_slots.is_empty());
         // An `our sub` declared in a bare block captures this local but outlives the
         // block (it lives in the package registry, with no closure env). Box the
         // local AND persist the cell so a call after the block reads the live value.
@@ -251,8 +253,11 @@ impl Interpreter {
             self.sync_our_package_var_from_local(code, idx as usize);
             self.mirror_attr_local_to_cell(code, idx as usize);
             if box_decl
-                && let Some(sym) = code.locals_sym.get(idx as usize)
-                && code.needs_cell_named_sub.contains(sym)
+                && (code
+                    .locals_sym
+                    .get(idx as usize)
+                    .is_some_and(|sym| code.needs_cell_named_sub.contains(sym))
+                    || code.needs_cell_named_sub_ref_slots.contains(&idx))
             {
                 self.box_decl_local_cell(code, idx as usize);
             }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1752,7 +1752,6 @@ impl Interpreter {
         // term-symbol block and `:=` alias chain below stay unconditional.
         let skip_env_write = !is_bind
             && !is_constant
-            && !code.captures_env_by_name
             && !code.needs_env_sync.get(idx).copied().unwrap_or(true)
             && !crate::opcode::reflective_name_access_possible()
             && Self::term_symbol_from_name(name).is_none();

--- a/t/captured-outer-pair-container-alias.t
+++ b/t/captured-outer-pair-container-alias.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 6;
+
+{
+    my $value = 1;
+    sub make-pair() { key => $value }
+    my $pair = make-pair();
+    is $pair.value, 1, 'fat arrow reads the captured outer scalar';
+    $value = 2;
+    is $pair.value, 2, 'fat-arrow Pair retains the captured outer container';
+    $pair.value = 3;
+    is $value, 3, 'fat-arrow Pair writes through to the captured outer scalar';
+}
+
+{
+    my $value = 10;
+    sub make-pair() { Pair.new('key', $value) }
+    my $pair = make-pair();
+    is $pair.value, 10, 'Pair.new reads the captured outer scalar';
+    $value = 20;
+    is $pair.value, 20, 'Pair.new retains the captured outer container';
+    $pair.value = 30;
+    is $value, 30, 'Pair.new writes through to the captured outer scalar';
+}

--- a/t/scoped-overlay-gather.t
+++ b/t/scoped-overlay-gather.t
@@ -7,7 +7,7 @@ use Test;
 # runs under a scoped overlay whose parent is the gather's captured env; its
 # writes land in the overlay and side effects on captured/outer vars propagate.
 
-plan 10;
+plan 11;
 
 # --- basic gather ---
 my @g = gather { take $_ * 2 for 1..5 };
@@ -18,6 +18,14 @@ my $count = 0;
 my @h = gather { for 1..3 { $count++; take $count } };
 is @h.List, (1, 2, 3), 'gather body sees mutated captured var';
 is $count, 3, 'captured var mutation persists after gather force';
+
+my @dups = 1, 2, 2, 3, 3, 3;
+my @uniq = gather for @dups {
+    state $previous = take $_;
+    next if $_ === $previous;
+    $previous = take $_;
+}
+is @uniq, (1, 2, 3), 'gather for preserves a state lexical across iterations';
 
 # --- lazy gather + slice forces the coroutine path ---
 my @lazy = lazy gather { my $i = 0; loop { take $i++ } };

--- a/t/state-in-loop-body-accumulates.t
+++ b/t/state-in-loop-body-accumulates.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A `state` variable declared inside a loop body accumulates across the
+# iterations of one execution of that loop statement.
+#
+# The loop-body state sync used to read the variable's value back from the
+# name-keyed env. That was only correct because a frame containing a for-loop
+# had every local env-synced by a frame-wide blanket. ADR-0018 narrowed that to
+# the loop's own baked slots, at which point a plain `state $t` no longer
+# mirrored to env and the sync persisted the value the declaration seeded
+# instead of the value the body wrote -- so the accumulation vanished and every
+# iteration saw the initializer again.
+
+{
+    my @g = gather { for 1 .. 3 { state $t = 0; $t = $t + 1; take $t; } };
+    is @g.join(" "), "1 2 3", "state in a gather-wrapped for body accumulates";
+}
+
+{
+    my @g = gather for 1 .. 3 { state $u = 0; $u = $u + 1; take $u; };
+    is @g.join(" "), "1 2 3", "state in a `gather for` statement body accumulates";
+}
+
+{
+    my @seen;
+    for 1 .. 3 { state $s = 0; $s = $s + 1; @seen.push($s); }
+    is @seen.join(" "), "1 2 3", "state in a plain for body accumulates";
+}
+
+{
+    my @seen;
+    my $i = 0;
+    while $i++ < 3 { state $w = 0; $w = $w + 1; @seen.push($w); }
+    is @seen.join(" "), "1 2 3", "state in a while body accumulates";
+}
+
+# The uniq example from S04-control.pod (roast/S04-statements/gather.t): the
+# `state` holds the previous element, so a lost write makes every duplicate
+# get taken again.
+{
+    my @list = 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 6, 6;
+    my @uniq = gather for @list {
+        state $previous = take $_;
+        next if $_ === $previous;
+        $previous = take $_;
+    }
+    is @uniq.join(" "), "1 2 3 4 5 6", "state carries the previous element across iterations";
+}

--- a/t/supply-block-enum-lexical.t
+++ b/t/supply-block-enum-lexical.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 8;
+plan 9;
 
 # A `my enum` binds its type name AND every variant name lexically in the block
 # that declares it, so those names must (a) win over a same-named outer symbol
@@ -38,6 +38,8 @@ react {
 is @got[0], 'SBEL-State', 'and inside the whenever callback too';
 is @got[1], 'SBEL-Header', 'the variant is the enum value, not the class';
 is @got[2], 2, 'a later variant keeps its ordinal';
+is SBEL-Header.^name, 'SBEL-Header',
+    'the callback does not leave its authoritative variant in the caller env';
 
 # --- (b) the binding dies with its block.
 


### PR DESCRIPTION
## Problem

The five env-by-name consumers are represented by one frame-wide captures_env_by_name bit, preventing precise lexical-slot synchronization.

## Approach

- add Proposed ADR-0018 defining slot authority, per-consumer synchronization, block restore, and capture-cell invariants
- add separate consumer bitmaps while preserving current runtime behavior
- pin the migration-layer metadata

## Tests

- cargo check
- cargo test env_consumers_are_recorded_separately_before_blanket_removal