### PR TITLE
compiler: bake for-loop source slots

### DIFF
--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -269,6 +269,8 @@ impl Compiler {
         self.suppress_list_var_alias = true;
         self.compile_expr(&normalized_iterable);
         self.suppress_list_var_alias = saved_suppress;
+        let source_container_local = Self::for_iterable_source_name(iterable)
+            .and_then(|name| self.local_map.get(&name).copied());
         if let Some(source_name) = Self::for_iterable_source_name(iterable) {
             let source_slot = self.local_map.get(source_name.as_str()).copied();
             let source_idx = self.code.add_constant(Value::str(source_name));
@@ -291,6 +293,7 @@ impl Compiler {
                 param_idx,
                 param_local,
                 topic_local,
+                source_container_local,
                 body_end: 0,
                 label: label.clone(),
                 arity,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2031,6 +2031,8 @@ impl Compiler {
                 };
                 let source_var_names = Self::for_iterable_var_names(iterable);
                 let source_var_locals = self.for_source_var_locals(&source_var_names);
+                let source_container_local = Self::for_iterable_source_name(iterable)
+                    .and_then(|name| self.local_map.get(&name).copied());
                 // When the block parameter has a type constraint other than Mu
                 // or Junction, junction items should be autothreaded (expanded
                 // into their eigenstates).
@@ -2048,6 +2050,7 @@ impl Compiler {
                             param_idx,
                             param_local,
                             topic_local,
+                            source_container_local,
                             body_end: 0,
                             label: label.clone(),
                             arity,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -182,6 +182,10 @@ pub(crate) struct ForLoopSpec {
     /// exit, exactly as `exec_given_op` does for `given`/`with`. Only set for an
     /// implicit-topic loop (a named parameter does not rebind `$_`).
     pub(crate) topic_local: Option<u32>,
+    /// Local slot that owns the iterable container (`$b` in `for $b.pairs`,
+    /// `%h` in `for %h.values`). Pair/value alias writeback reaches this source
+    /// through env today, so ADR-0018 keeps exactly this slot synchronized.
+    pub(crate) source_container_local: Option<u32>,
     pub(crate) body_end: u32,
     pub(crate) label: Option<String>,
     pub(crate) arity: u32,
@@ -2704,11 +2708,15 @@ impl CompiledCode {
             match op {
                 OpCode::ForLoop(spec) => {
                     has_for_loop = true;
-                    for slot in [spec.param_local, spec.topic_local]
-                        .into_iter()
-                        .flatten()
-                        .chain(spec.source_var_locals.iter().flatten().copied())
-                        .chain(spec.single_array_source_local)
+                    for slot in [
+                        spec.param_local,
+                        spec.topic_local,
+                        spec.source_container_local,
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .chain(spec.source_var_locals.iter().flatten().copied())
+                    .chain(spec.single_array_source_local)
                     {
                         if let Some(needed) = for_loop_slots.get_mut(slot as usize) {
                             *needed = true;
@@ -3033,8 +3041,7 @@ impl CompiledCode {
         // some carrier state by name; keep that consumer-local fallback until
         // the next layer replaces its restore with baked slots. This is no
         // longer a frame-wide fallback merely because a stored body is present.
-        if !self.env_consumer_slots.for_loop.is_empty()
-            || !self.env_consumer_slots.block_scope.is_empty()
+        if !self.env_consumer_slots.block_scope.is_empty()
             || !self.env_consumer_slots.block_local_scope.is_empty()
         {
             self.needs_env_sync
@@ -3044,10 +3051,16 @@ impl CompiledCode {
             for slot in 0..n {
                 self.needs_env_sync[slot] |= self
                     .env_consumer_slots
-                    .gather
+                    .for_loop
                     .get(slot)
                     .copied()
                     .unwrap_or(false)
+                    || self
+                        .env_consumer_slots
+                        .gather
+                        .get(slot)
+                        .copied()
+                        .unwrap_or(false)
                     || self
                         .env_consumer_slots
                         .whenever


### PR DESCRIPTION
## Problem

ForLoop writeback still needed frame-wide env publication because transformed iterables such as $b.pairs and %h.values did not expose their owner slot to consumer analysis.

## Approach

Bake source_container_local into ForLoopSpec and include it with param, topic, per-element source, and live-array slots. ForLoop now uses its precise consumer bitmap; only block restore remains conservative.

## Tests

- 9 targeted TAP files, 115 assertions
- cargo clippy -- -D warnings
- cargo fmt --all -- --check