### PR TITLE
vm: preserve captured outer container cells

### DIFF
--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -448,7 +448,12 @@ impl Compiler {
         cf.precompute_param_name_syms();
         cf.detect_inner_subs();
         cf.compute_declared_locals();
-        // Contribute this directly-nested named sub's WRITE set to the enclosing
+        // Contribute this directly-nested named sub's cell-requiring capture set
+        // to the enclosing scope. Besides writes, a scalar fed to WrapVarRef
+        // (`key => $value`, `Pair.new(..., $value)`, captures/list aliases) must
+        // retain the captured variable's container identity across the routine
+        // boundary. A named sub has no runtime closure-creation point, so box
+        // these at the owner's declaration just like named-sub writes.
         // scope so `compute_free_vars` can flag the locals it mutates as
         // `needs_cell_named_sub` (the VM then boxes them at their declaration site
         // for cross-call accumulation through a shared cell — see
@@ -460,6 +465,32 @@ impl Compiler {
         // (e.g. a user `trait_mod:<is>` pushing to an outer `@names`) is boxed too.
         let mut nf_writes = cf.code.free_var_writes.clone();
         nf_writes.extend(cf.code.free_var_container_writes.iter().copied());
+        for pair in cf.code.ops.windows(2) {
+            let (OpCode::GetGlobal(name_idx), OpCode::WrapVarRef(wrapped_idx)) =
+                (&pair[0], &pair[1])
+            else {
+                continue;
+            };
+            if name_idx != wrapped_idx {
+                continue;
+            }
+            if let Some(crate::value::ValueView::Str(name)) =
+                cf.code.constants.get(*name_idx as usize).map(Value::view)
+            {
+                let sym = crate::symbol::Symbol::intern(&name);
+                if !cf.code.container_ref_capture_syms.contains(&sym) {
+                    cf.code.container_ref_capture_syms.push(sym);
+                }
+                if let Some(parent_slot) = self.local_map.get(name.as_str()).copied()
+                    && !self
+                        .code
+                        .needs_cell_named_sub_ref_slots
+                        .contains(&parent_slot)
+                {
+                    self.code.needs_cell_named_sub_ref_slots.push(parent_slot);
+                }
+            }
+        }
         self.code
             .named_sub_captures
             .push((nf_writes, cf.code.needs_cell_named_sub_free.clone()));

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2081,6 +2081,14 @@ pub(crate) struct CompiledCode {
     /// at their declaration site (`box_decl_local_cell`). Distinct from
     /// `needs_cell_locals` (closure-driven) — see `named_sub_captures`.
     pub(crate) needs_cell_named_sub: Vec<Symbol>,
+    /// Exact owner slots whose containers are captured by `WrapVarRef` in a
+    /// directly nested named sub. Kept slot-addressed so a same-named lexical in
+    /// another block is not boxed at its declaration site.
+    pub(crate) needs_cell_named_sub_ref_slots: Vec<u32>,
+    /// Free variables whose raw container is consumed by `WrapVarRef`. Runtime
+    /// reference wrapping may read a captured env cell only for this explicit
+    /// set; ordinary same-named env cells must not override a shadow value.
+    pub(crate) container_ref_capture_syms: Vec<Symbol>,
     /// Named-sub writes of a NON-own (ancestor) lexical, bubbled up so the ancestor
     /// that declares the local folds it into its own `needs_cell_named_sub`
     /// (mirrors `needs_cell_free_vars` for closures).
@@ -2477,6 +2485,8 @@ impl CompiledCode {
             free_var_container_writes: Vec::new(),
             named_sub_captures: Vec::new(),
             needs_cell_named_sub: Vec::new(),
+            needs_cell_named_sub_ref_slots: Vec::new(),
+            container_ref_capture_syms: Vec::new(),
             needs_cell_named_sub_free: Vec::new(),
             escaping_our_sub_captures: Vec::new(),
             needs_cell_escaping_our_sub: Vec::new(),

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -560,9 +560,22 @@ impl Interpreter {
     /// taken from the chunk's pre-interned constant symbols: no `String`, no
     /// hashing.
     pub(super) fn exec_wrap_var_ref_op(&mut self, code: &CompiledCode, name_idx: u32) {
-        let value = self.stack.pop().unwrap_or(Value::NIL);
-        self.stack
-            .push(Value::varref(code.const_sym(name_idx), value, None));
+        let mut value = self.stack.pop().unwrap_or(Value::NIL);
+        // GetGlobal intentionally dereferences a captured cell for ordinary
+        // value reads. WrapVarRef is different: it denotes the variable's
+        // container (`key => $outer`, `Pair.new(..., $outer)`, rw args), so keep
+        // the raw captured cell when one exists in the lexical environment.
+        // This is the no-local-slot half of capture_var_cell: an outer lexical
+        // cannot be found in the callee's `code.locals`, but its creator slot and
+        // this env entry share the same ContainerRef.
+        let sym = code.const_sym(name_idx);
+        if code.container_ref_capture_syms.contains(&sym)
+            && let Some(captured) = self.env().get_sym(sym)
+            && captured.is_container_ref()
+        {
+            value = captured.clone();
+        }
+        self.stack.push(Value::varref(sym, value, None));
     }
 
     /// Validate and coerce a value for native integer type assignment.

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -497,6 +497,13 @@ impl Interpreter {
                     if is_block_declared {
                         if owned_slots.contains(&idx) {
                             self.locals[idx] = Value::NIL;
+                        } else {
+                            // The block-entry shadow prelude clears the formerly
+                            // visible outer slot before initializing the fresh
+                            // declaration slot. Restore that exact outer slot;
+                            // never broadcast the value into the owned slot.
+                            self.locals[idx] =
+                                restored_env.get(name).cloned().unwrap_or(Value::NIL);
                         }
                     } else {
                         self.locals[idx] = restored_env.get(name).cloned().unwrap_or(Value::NIL);

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -240,7 +240,9 @@ impl Interpreter {
         // closures are boxed precisely at their creation op, so reusing that set
         // here would over-box unrelated same-named locals (same-named `my` locals
         // share one slot) and break e.g. `let`-restore in a sibling block.
-        let box_decl = self.vardecl_context && !code.needs_cell_named_sub.is_empty();
+        let box_decl = self.vardecl_context
+            && (!code.needs_cell_named_sub.is_empty()
+                || !code.needs_cell_named_sub_ref_slots.is_empty());
         // An `our sub` declared in a bare block captures this local but outlives the
         // block (it lives in the package registry, with no closure env). Box the
         // local AND persist the cell so a call after the block reads the live value.
@@ -251,8 +253,11 @@ impl Interpreter {
             self.sync_our_package_var_from_local(code, idx as usize);
             self.mirror_attr_local_to_cell(code, idx as usize);
             if box_decl
-                && let Some(sym) = code.locals_sym.get(idx as usize)
-                && code.needs_cell_named_sub.contains(sym)
+                && (code
+                    .locals_sym
+                    .get(idx as usize)
+                    .is_some_and(|sym| code.needs_cell_named_sub.contains(sym))
+                    || code.needs_cell_named_sub_ref_slots.contains(&idx))
             {
                 self.box_decl_local_cell(code, idx as usize);
             }

--- a/t/captured-outer-pair-container-alias.t
+++ b/t/captured-outer-pair-container-alias.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 6;
+
+{
+    my $value = 1;
+    sub make-pair() { key => $value }
+    my $pair = make-pair();
+    is $pair.value, 1, 'fat arrow reads the captured outer scalar';
+    $value = 2;
+    is $pair.value, 2, 'fat-arrow Pair retains the captured outer container';
+    $pair.value = 3;
+    is $value, 3, 'fat-arrow Pair writes through to the captured outer scalar';
+}
+
+{
+    my $value = 10;
+    sub make-pair() { Pair.new('key', $value) }
+    my $pair = make-pair();
+    is $pair.value, 10, 'Pair.new reads the captured outer scalar';
+    $value = 20;
+    is $pair.value, 20, 'Pair.new retains the captured outer container';
+    $pair.value = 30;
+    is $value, 30, 'Pair.new writes through to the captured outer scalar';
+}


### PR DESCRIPTION
## Summary
- record named-sub `WrapVarRef` captures against their exact creator-frame slots
- box those declaration slots so captured outer Pair values retain container identity
- preserve raw captured cells only for statically identified reference captures
- restore non-owned shadowed BlockScope slots without broadcasting into owned slots
- add fat-arrow and `Pair.new` captured-outer alias regression coverage

## Test evidence
- targeted closure/container/env-writeback TAP: 20 files, 181 tests passed
- focused BlockScope/shadow TAP: 4 files, 28 tests passed
- `cargo clippy -- -D warnings`
- `cargo fmt --all`

Stacked on #5759.