### PR TITLE
feat(ci): a required Miri gate for the GC's aliased container writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       docs-only: ${{ steps.detect.outputs.docs-only }}
+      gc-value: ${{ steps.detect.outputs.gc-value }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -54,6 +55,12 @@ jobs:
           result=$(scripts/ci-docs-only.sh)
           echo "docs-only=$result" >> "$GITHUB_OUTPUT"
           echo "docs-only=$result"
+          # Second, independent question for the `miri` job below: does this
+          # change touch the GC / container-value code whose aliased-write
+          # soundness ADR-0013 pins? Same script, opposite fail-safe default.
+          gc=$(scripts/ci-docs-only.sh --gc-value)
+          echo "gc-value=$gc" >> "$GITHUB_OUTPUT"
+          echo "gc-value=$gc"
         env:
           GH_TOKEN: ${{ github.token }}
           # GITHUB_EVENT_NAME / GITHUB_SHA / GITHUB_REPOSITORY come from the
@@ -306,6 +313,97 @@ jobs:
           scripts/battery-testsuite.sh
         env:
           MUTSU_BIN: target/release/mutsu
+
+  # ADR-0013 §4 phase 4: the acceptance gate for the GC's aliased-write
+  # soundness. What ADR-0013 shipped is an *argument* about borrow provenance —
+  # a `Gc` payload lives in a `GcBox`'s `UnsafeCell`, so the aliased `&mut` that
+  # container mutation hands out has valid provenance. No ordinary test can see
+  # that: a provenance violation is UB that happens to work, so `make test` and
+  # the whole roast suite stay green either way. Miri turns the argument into a
+  # check, and a future refactor can invalidate the argument with no observable
+  # failure — which is why this is a REQUIRED check and not an informational
+  # one. An informational job on a repo where every PR auto-merges is a job
+  # nobody reads.
+  #
+  # It is expensive (~20-25 min, most of it compiling the crate to MIR), so it
+  # is gated on the `gc-value` classification: only a change under `src/gc/**`
+  # or `src/value/**` (plus this workflow and the classifier itself) can affect
+  # the property, which is ~8% of merges measured over the last 300. Like the
+  # docs-only skip above this must be a job-level `if:`, never a workflow-level
+  # `paths` filter — a check run that is never created stays pending forever and
+  # blocks the merge it was supposed to guard.
+  miri:
+    needs: changes
+    if: needs.changes.outputs.gc-value == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      # Miri only ships on nightly, and the nightly must be PINNED: an unpinned
+      # `nightly` silently changes the interpreter (and its Stacked Borrows
+      # model) under the job, which would turn a toolchain update into what
+      # looks like a soundness regression — on a required check. Bump this
+      # deliberately, in its own PR, and read the diff in Miri's behaviour.
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2026-08-01
+          components: miri, rust-src
+
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci-miri"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: cargo miri setup
+        run: cargo miri setup
+
+      # `--no-default-features --features native` drops the two things Miri
+      # fundamentally cannot execute: the Cranelift JIT (it emits real machine
+      # code) and FFI calls. Neither is reachable from the subset below.
+      #
+      # `gc::` selects the collector and `Gc` primitive tests, including
+      # `gc_contents_mut_writes_through_a_shared_node` — the exact aliased-write
+      # shape ADR-0013 made sound — and, because the filter is a substring
+      # match, `value::value_gc::` too, which is the container side. Measured
+      # 2026-08-02: 47 pass, 5 ignored, ~19s of interpretation (the wall clock is
+      # dominated by compiling the crate to MIR). It also selects
+      # `gc::soundness_smoke` (the VM-level half), which is
+      # `#[cfg_attr(miri, ignore)]` for now because `Interpreter::new()` shells
+      # out and Miri cannot spawn a process; see
+      # todo/tickets/magic-vars-should-be-built-lazily.md.
+      #
+      # Two limits worth knowing before trusting a green run: Miri reports
+      # `integer-to-pointer cast` on the NaN-boxed `Value`, so provenance
+      # checking is precise for typed `Gc<T>` paths and best-effort through the
+      # `Value` layer (`-Zmiri-strict-provenance` is unavailable to us for the
+      # same reason); and the `Mixin` overrides map is still `Arc`-backed, a
+      # live provenance violation no test in this subset reaches.
+      #
+      # `--test-threads=1` keeps a failure attributable to a single test.
+      #
+      # ── If a test makes this job too slow, mark it `#[cfg_attr(miri, ignore)]`
+      # ── rather than dropping the subset or loosening the gate.
+      # Miri interprets every step, so a test that hammers a race (threads ×
+      # tens of thousands of iterations) can run for hours where it takes
+      # milliseconds natively. `concurrent_buffer_and_drain_never_wraps_the_approx_count`
+      # in `src/gc/gc_ptr.rs` is the worked example: 200k allocations across four
+      # threads against a spinning drainer, ignored under Miri with a comment
+      # saying why. Two conditions make that legitimate — say both in the
+      # comment you leave:
+      #   1. the property the test defends is NOT aliased-write provenance (the
+      #      one thing this gate exists for), and
+      #   2. something else still runs it natively (gc-stress, `make test`).
+      # If a test IS about provenance and is too slow, shrink the test — do not
+      # ignore it.
+      - name: cargo miri test (GC / container subset)
+        env:
+          # The GC's stats and verify hooks read the clock and the environment.
+          MIRIFLAGS: -Zmiri-disable-isolation
+        run: |
+          cargo miri test --no-default-features --features native \
+            --lib gc:: -- --test-threads=1
 
   wasm-e2e:
     # Skipped on a documentation-only change — see the `changes` job.

--- a/docs/adr/0013-container-interior-mutability-cellvalue.md
+++ b/docs/adr/0013-container-interior-mutability-cellvalue.md
@@ -287,12 +287,47 @@ files** (the inventory's 54/20 has drifted up as new mutation paths reuse the pr
 drift is expected and harmless now that the primitive is sound, but it means the number in
 `docs/gc-contents-mut-inventory.md` is a snapshot, not a budget).
 
-**❌ Not shipped — §4 phase 4, the Miri gate.** There is no `miri` job in
-`.github/workflows/`. This matters more than a normal missing test: what shipped is an
-*argument* about borrow provenance, and an argument of that kind is precisely what a future
-refactor can invalidate without any observable failure. Until the gate exists, this ADR's
-definition of done is unmet. The toolchain note in §4 still applies (pin a nightly whose
-feature set matches the crate's stabilized-feature usage); start informational, then blocking.
+**⚠️ Correction (2026-08-02, same day): "fixed at every call site at once" is wrong by one
+call site.** The `UnsafeCell`-in-`GcBox` fix covers every `Gc`-managed container, which is all
+of them **except `Mixin`**: `ValueRepr::Mixin(Arc<Value>, Arc<HashMap<String, Value>>)`
+(`src/value/mod.rs`) never migrated to the GC, and `$type.^set_name(...)` writes its overrides
+map in place through `arc_contents_mut` (`src/runtime/methods_classhow_dispatch.rs:109`). An
+`Arc` payload has no `UnsafeCell`, so that one site is still the original provenance violation.
+`aliased_mut.rs` compounded the error by documenting `arc_contents_mut` as "currently unused".
+Tracked in `todo/tickets/mixin-overrides-aliased-write-is-still-arc.md`; found by writing the
+Miri gate below, which is exactly the kind of thing the gate exists to surface.
+
+**✅ Shipped, blocking — §4 phase 4, the Miri gate.** ci.yml's `miri` job runs
+`cargo miri test --no-default-features --features native --lib gc::` (JIT and FFI dropped —
+Miri cannot execute either) on a **pinned** nightly: Miri is nightly-only, and an unpinned
+nightly would turn a toolchain update into what looks like a soundness regression. It is a
+**required status check**, not an informational one — on a repository where every PR
+auto-merges, an informational job is a job nobody reads. Cost is controlled by the trigger, not
+by weakening the check: the job is gated on a `gc-value` classification (`scripts/ci-docs-only.sh
+--gc-value`) so it runs only for changes under `src/gc/**` / `src/value/**`, ~8% of merges
+measured over the last 300, and is *skipped* (which branch protection counts as success)
+otherwise.
+
+**Its current reach is the primitive, not yet the VM.** All 33 `gc::` unit tests are Miri-clean,
+including `gc_contents_mut_writes_through_a_shared_node`, which is the exact aliased-write shape
+this ADR made sound. The interpreter-level half — `gc::soundness_smoke`, four tiny Raku programs
+run through a real `Interpreter` so Miri watches the VM take an aliased `&mut` into a shared node
+while other handles are live — exists but is `#[cfg_attr(miri, ignore)]`: `Interpreter::new()`
+shells out to `uname`/`hostname` while building `$*DISTRO`/`$*KERNEL`, and Miri cannot spawn a
+process. `todo/tickets/magic-vars-should-be-built-lazily.md` unblocks it; dropping that
+`cfg_attr` is what answers §4's warning that a primitive-only run "mostly re-proves std's
+`UnsafeCell` guarantee".
+
+**Two limits to state honestly.** (1) Miri reports `integer-to-pointer cast` on the NaN-boxed
+`Value` (ADR-0005), so it falls back to permissive provenance for pointers recovered from the
+box: checking is precise for the typed `Gc<T>` paths the unit tests exercise and best-effort
+through the `Value` layer. `-Zmiri-strict-provenance` is not available to us for the same reason.
+(2) One race-hammer test (`concurrent_buffer_and_drain_never_wraps_the_approx_count`, 200k
+allocations across four threads) is ignored under Miri because it would not finish; it defends
+counter ordering, not provenance, and gc-stress still runs it natively.
+
+This ADR is therefore closed **except** for the `Mixin` correction above, which the gate cannot
+see today (no test in the subset reaches `^set_name`).
 
 **Deferred by decision, not by omission** — problem §1.3-2, the narrow cross-thread race on a
 genuinely shared node, remains routed to ADR-0001 layer 3c (§5 open question 2). The safety

--- a/news/2026-08/miri-gate-closes-adr-0013.md
+++ b/news/2026-08/miri-gate-closes-adr-0013.md
@@ -1,0 +1,70 @@
+# A Miri gate for the GC's aliased writes — and the one call site it proved was still UB
+
+[ADR-0013](../../docs/adr/0013-container-interior-mutability-cellvalue.md) fixed the provenance UB
+in the GC's aliased container writes by putting the payload in a `GcBox`'s `UnsafeCell`, so the
+`&mut` that `gc_contents_mut` hands out has valid provenance even while other `Gc` handles read the
+same node. What it shipped, though, was an **argument**. No ordinary test can see the difference: a
+provenance violation is UB that happens to work, so `make test` and the whole roast suite stay green
+either way. §4 phase 4 of the ADR therefore named a Miri run as the definition of done, and that
+phase had never been built.
+
+It is built now, as ci.yml's `miri` job.
+
+## The gate
+
+`cargo miri test --no-default-features --features native --lib gc::` on a pinned nightly. The
+feature set drops the two things Miri fundamentally cannot execute — the Cranelift JIT, which emits
+real machine code, and FFI. The nightly is pinned deliberately: Miri only ships on nightly, and an
+unpinned one would silently change the interpreter (and its Stacked Borrows model) under the job,
+turning a toolchain update into what looks like a soundness regression.
+
+It is a **required status check**, not an informational one. On a repository where every PR
+auto-merges, a `continue-on-error` job is a job nobody reads. Cost is controlled by the trigger
+instead: `changes` now also classifies whether a change touches `src/gc/**` or `src/value/**`
+(`scripts/ci-docs-only.sh --gc-value`, with its own self-test cases), and the job is gated on that —
+23 of the last 300 merges, ~8%. The classification must be a job-level `if:` rather than a
+workflow-level `paths` filter for the same reason the docs-only skip is: a check run that is never
+created stays pending forever and blocks the merge it was supposed to guard. The `--gc-value`
+classifier's fail-safe direction is the opposite of the docs-only one — an undeterminable diff runs
+the check, because a skipped soundness check is a silently-unchecked merge while a needless one only
+costs runner minutes.
+
+Result on the current tree: **47 pass, 0 fail, 5 ignored**, about 19 seconds of interpretation
+(wall clock is dominated by compiling the crate to MIR). The subset covers the collector, the `Gc`
+primitive — including `gc_contents_mut_writes_through_a_shared_node`, the exact aliased-write shape
+ADR-0013 made sound — and, since the filter is a substring match, `value::value_gc` as well.
+
+## What writing it found
+
+Rewriting `src/value/aliased_mut.rs`'s module header (it still described the provenance violation as
+live and named Track B as the future fix, both false since ADR-0013) meant deleting the primitives it
+documented as unused. The compiler disagreed: `arc_contents_mut` has a **live call site**.
+
+`Mixin` is the one container variant that never migrated to the GC —
+`ValueRepr::Mixin(Arc<Value>, Arc<HashMap<String, Value>>)` — and `$type.^set_name(...)` writes its
+overrides map in place through `Arc::as_ptr as *mut`. An `Arc` payload has no `UnsafeCell`, so that
+one site is still exactly the violation ADR-0013 removed everywhere else. ADR-0013 §8's claim that
+the fix landed "at every call site at once" is wrong by one, and has been corrected in place;
+`todo/tickets/mixin-overrides-aliased-write-is-still-arc.md` carries the repro and the two ways out.
+The gate cannot see it yet — no test in the subset reaches `^set_name` — which is itself worth
+knowing about a gate.
+
+## What the gate does not cover, stated plainly
+
+- **The VM's real call sites.** `src/gc/soundness_smoke.rs` adds four tiny Raku programs run through
+  a real `Interpreter`, so Miri would watch the VM take an aliased `&mut` into a shared node while
+  other handles are live — the coverage §4 warned a primitive-only run lacks. They are
+  `#[cfg_attr(miri, ignore)]` today: `Interpreter::new()` eagerly builds `$*DISTRO`/`$*KERNEL` by
+  shelling out to `uname -r` (twice, through two separate `OnceLock`s), `uname -m` and `hostname`,
+  and Miri cannot spawn a process. `todo/tickets/magic-vars-should-be-built-lazily.md` fixes that at
+  the root — those are process constants and should be delayed until first access and then cached,
+  which also removes three `fork`/`exec`s from every `mutsu` startup.
+- **Precision through the NaN box.** Miri reports `integer-to-pointer cast` on `Value` (ADR-0005) and
+  falls back to permissive provenance for pointers recovered from the box, so checking is precise for
+  typed `Gc<T>` paths and best-effort through the `Value` layer. `-Zmiri-strict-provenance` is
+  unavailable to us for the same reason.
+- **One race-hammer test.** `concurrent_buffer_and_drain_never_wraps_the_approx_count` (200k
+  allocations across four threads against a spinning drainer) does not finish under Miri and is
+  ignored there. It defends counter ordering, not provenance, and gc-stress still runs it natively.
+  The workflow documents that escape hatch and the two conditions that make it legitimate, so the
+  next person who hits a slow test does not instead weaken the gate.

--- a/scripts/ci-docs-only.sh
+++ b/scripts/ci-docs-only.sh
@@ -19,6 +19,16 @@
 #   scripts/ci-docs-only.sh              # classify the current CI event
 #   scripts/ci-docs-only.sh --self-test  # verify the classifier (runs in CI)
 #   printf 'a\nb\n' | scripts/ci-docs-only.sh --classify   # classify a list
+#
+# It also answers the inverse question for the Miri gate (ADR-0013 §4 phase 4),
+# which is expensive (~25 min) and only meaningful for GC/container code:
+#
+#   scripts/ci-docs-only.sh --gc-value                     # classify the event
+#   printf 'a\nb\n' | scripts/ci-docs-only.sh --classify-gc-value
+#
+# Same fail-safe discipline, opposite default: an unclassifiable diff prints
+# `true` there, because a skipped soundness check is a silently-unchecked merge
+# while a needless one only costs runner minutes.
 
 set -u
 
@@ -57,6 +67,39 @@ classify() {
     echo false
   else
     echo true
+  fi
+}
+
+# The Miri gate's trigger: does this change touch the GC / container-value code
+# whose aliased-write soundness ADR-0013 pins? `src/gc/**` is the collector and
+# the `Gc` primitive; `src/value/**` is every container representation that
+# takes an aliased in-place write. The workflow and this classifier count too --
+# a change to either must re-run the thing it controls.
+is_gc_value_path() {
+  case "$1" in
+    src/gc/*|src/value/*) return 0 ;;
+    .github/workflows/ci.yml|scripts/ci-docs-only.sh) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Reads file paths on stdin. Empty input => `true`: an undeterminable diff must
+# run the check, not skip it (the opposite default from `classify`, because the
+# consequences are reversed -- see the header).
+classify_gc_value() {
+  local saw_any=0 path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    saw_any=1
+    if is_gc_value_path "$path"; then
+      echo true
+      return
+    fi
+  done
+  if [ "$saw_any" -eq 0 ]; then
+    echo true
+  else
+    echo false
   fi
 }
 
@@ -117,6 +160,28 @@ self_test() {
   check false 'Cargo manifest'          Cargo.toml
   check false 'empty diff'              ''
 
+  check_gc() { # check_gc <expected> <label> <files...>
+    local expected="$1" label="$2"; shift 2
+    local got
+    got=$(printf '%s\n' "$@" | classify_gc_value)
+    if [ "$got" != "$expected" ]; then
+      echo "not ok - gc/$label (expected $expected, got $got)" >&2
+      failures=$((failures + 1))
+    else
+      echo "ok - gc/$label"
+    fi
+  }
+
+  check_gc true  'gc primitive'          src/gc/gc_ptr.rs
+  check_gc true  'container value'       src/value/aliased_mut.rs
+  check_gc true  'gc among others'       src/vm/vm.rs src/gc/collect.rs
+  check_gc true  'the workflow itself'   .github/workflows/ci.yml
+  check_gc true  'this classifier'       scripts/ci-docs-only.sh
+  check_gc true  'empty diff'            ''
+  check_gc false 'unrelated src'         src/vm/vm.rs src/parser/mod.rs
+  check_gc false 'docs only'             PLAN.md docs/adr/0013-x.md
+  check_gc false 'value in another tree' modules/URI/lib/value.rakumod
+
   if [ "$failures" -ne 0 ]; then
     echo "ci-docs-only self-test: $failures failure(s)" >&2
     return 1
@@ -125,14 +190,28 @@ self_test() {
 }
 
 case "${1:-}" in
-  --self-test) self_test; exit $? ;;
-  --classify)  classify; exit 0 ;;
+  --self-test)          self_test; exit $? ;;
+  --classify)           classify; exit 0 ;;
+  --classify-gc-value)  classify_gc_value; exit 0 ;;
 esac
 
 files=$(changed_files 2>/dev/null)
+count=$(printf '%s\n' "$files" | grep -c .)
+
+if [ "${1:-}" = "--gc-value" ]; then
+  # A truncated diff must read as "run it" here, the opposite of the docs-only
+  # guard below.
+  if [ "$count" -gt 300 ]; then
+    echo true
+    exit 0
+  fi
+  printf '%s\n' "$files" | classify_gc_value
+  exit 0
+fi
+
 # Guard against a huge diff: pagination or the API cap could truncate it, and a
 # truncated list must never read as "docs only".
-if [ "$(printf '%s\n' "$files" | grep -c .)" -gt 300 ]; then
+if [ "$count" -gt 300 ]; then
   echo false
   exit 0
 fi

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -1578,6 +1578,12 @@ mod tests {
     /// with overflow"). Hammer push against a concurrent drainer: no thread
     /// may panic, and once quiescent the count must return exactly to zero.
     #[test]
+    // Not under Miri: 200k allocations across four threads against a spinning
+    // drainer is a race *hammer*, and Miri interprets every one of those steps
+    // — it does not finish in any useful time. The property it defends
+    // (counter ordering) is also not the one the Miri gate is for (aliased-write
+    // provenance, ADR-0013), and gc-stress still runs it natively on every PR.
+    #[cfg_attr(miri, ignore)]
     fn concurrent_buffer_and_drain_never_wraps_the_approx_count() {
         let _serial = lock_buffer_tests();
         // Clear any leftover candidates so the final assertion is exact.

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -22,6 +22,8 @@ mod collect;
 mod gc_ptr;
 mod root_visitor;
 mod safepoint;
+#[cfg(test)]
+mod soundness_smoke;
 mod stw;
 
 pub(crate) use collect::collect_at_program_end;

--- a/src/gc/soundness_smoke.rs
+++ b/src/gc/soundness_smoke.rs
@@ -1,0 +1,86 @@
+//! Interpreter-level smoke tests whose only purpose is to be run **under Miri**
+//! (ADR-0013 §4 phase 4, `.github/workflows/miri.yml`).
+//!
+//! The `gc_ptr` unit tests prove the primitive in isolation; run under Miri they
+//! mostly re-prove std's `UnsafeCell` guarantee. What the acceptance gate
+//! actually needs is Miri watching a *real* execution path — the VM taking an
+//! aliased `&mut` into a shared container node through
+//! [`crate::gc::gc_contents_mut`] while other `Gc` handles to that node are
+//! live. That is the shape ADR-0013 made sound, and the shape a future refactor
+//! could silently un-sound.
+//!
+//! So each test below runs a tiny Raku program that forces a container mutation
+//! to be visible through an alias — the exact case `Gc::make_mut` cannot express
+//! (it would COW and sever the alias). Under a normal build these are ordinary,
+//! fast assertions; under Miri they are the provenance check.
+//!
+//! Keep them **small**. Miri is orders of magnitude slower than native, and the
+//! job runs them on every `src/gc/**` and `src/value/**` change.
+//!
+//! # Currently `#[cfg_attr(miri, ignore)]` — blocked on lazy magic vars
+//!
+//! They do not run under Miri *yet*, so today they are ordinary native tests and
+//! the Miri gate covers the primitive only. The blocker is not the container
+//! code: `Interpreter::new()` eagerly builds `$*DISTRO` / `$*KERNEL`, which
+//! shells out to `uname -r`, `uname -m` and `hostname`, and Miri cannot spawn a
+//! process ("unsupported operation: can't call foreign function
+//! `posix_spawnattr_init`"). Startup dies before reaching any container code.
+//!
+//! `todo/tickets/magic-vars-should-be-built-lazily.md` fixes that at the root
+//! (build those instances on first access, not at startup — which is also a
+//! startup-cost win for every `mutsu` invocation). Drop the `cfg_attr` here when
+//! it lands: that is what upgrades the gate from "the primitive is sound" to
+//! "the VM's real call sites obey the primitive's contract".
+
+#[cfg(test)]
+mod tests {
+    use crate::Interpreter;
+
+    fn run(src: &str) -> String {
+        let mut interp = Interpreter::new();
+        match interp.run(src) {
+            Ok(out) => out,
+            Err(e) => panic!("program failed: {}", e.message),
+        }
+    }
+
+    /// `:=` binds a second name to the *same* array node; a push through the
+    /// binding must be visible through the original. That write is the aliased
+    /// `gc_contents_mut` path (`strong_count > 1`, so `gc_data_mut` takes the
+    /// aliased branch rather than `make_mut`).
+    #[test]
+    #[cfg_attr(miri, ignore)] // see the module header: blocked on lazy magic vars
+    fn a_push_through_an_array_binding_is_visible_through_the_original() {
+        let out = run("my @a = 1, 2; my @b := @a; @b.push(3); say @a.elems; say @a[2];");
+        assert_eq!(out.trim(), "3\n3");
+    }
+
+    /// The hash counterpart: an insert through a bound alias reaches the
+    /// original node.
+    #[test]
+    #[cfg_attr(miri, ignore)] // see the module header: blocked on lazy magic vars
+    fn an_insert_through_a_hash_binding_is_visible_through_the_original() {
+        let out = run("my %h = a => 1; my %g := %h; %g<b> = 2; say %h.elems; say %h<b>;");
+        assert_eq!(out.trim(), "2\n2");
+    }
+
+    /// Capturing an array by value into a list keeps the same node (Raku list
+    /// containers do not copy), so a later push is observable through the
+    /// captured copy — the aliasing case the COW branch must not take.
+    #[test]
+    #[cfg_attr(miri, ignore)] // see the module header: blocked on lazy magic vars
+    fn a_captured_array_still_sees_a_later_push() {
+        let out = run("my @a = 1; my $l = (0, @a); @a.push(2); say $l[1].elems;");
+        assert_eq!(out.trim(), "2");
+    }
+
+    /// A cyclic structure exercises the collector's own `&mut` paths (the
+    /// fixup sites that carry the `strong_count == 1` uniqueness assertion) in
+    /// addition to the mutation path.
+    #[test]
+    #[cfg_attr(miri, ignore)] // see the module header: blocked on lazy magic vars
+    fn a_self_referential_array_builds_and_collects() {
+        let out = run("my @a = 1, 2; @a.push(@a); say @a.elems;");
+        assert_eq!(out.trim(), "3");
+    }
+}

--- a/src/value/aliased_mut.rs
+++ b/src/value/aliased_mut.rs
@@ -1,91 +1,79 @@
-//! The single audited choke point for *aliased, in-place* mutation of a
-//! shared `crate::gc::Gc<ArrayData>` / `Arc<HashData>` container.
+//! Shared-aware mutable access to a `Gc`-managed container's backing data.
 //!
 //! # Why this exists
 //!
-//! mutsu represents `Value::Array`/`Value::Hash` as `crate::gc::Gc<ArrayData>` /
-//! `Arc<HashData>` copy-on-write containers that nonetheless carry a *shared
+//! mutsu represents `Value::Array` / `Value::Hash` as `crate::gc::Gc<ArrayData>` /
+//! `Gc<HashData>` copy-on-write containers that nonetheless carry a *shared
 //! identity*: when a container is bound (`:=`), pushed to through an alias, or
 //! grown through a `ContainerRef`, the mutation must be visible through **every**
-//! holder of the same `Arc` (Raku container semantics). `Arc::get_mut` /
-//! `Arc::make_mut` cannot express that — `get_mut` returns `None` the moment the
-//! `Arc` is aliased (which is exactly when we need the shared write), and
+//! holder of the same node (Raku container semantics). `Gc::get_mut` /
+//! `Gc::make_mut` cannot express that — `get_mut` returns `None` the moment the
+//! node is aliased (which is exactly when we need the shared write), and
 //! `make_mut` clones, severing the alias. So the in-place write through the
-//! shared `Arc`'s contents is fundamental, not an optimization.
+//! shared node's contents is fundamental, not an optimization.
 //!
-//! Before this module those writes were ~35 scattered, hand-rolled
-//! `unsafe { &mut *(Arc::as_ptr(arc) as *mut _) }` blocks, several carrying the
-//! *incorrect* `// SAFETY: mutsu is single-threaded` justification (ANALYSIS
-//! §2.3: `clone_for_thread` + `thread::spawn` can move a clone of the same `Arc`
-//! onto another OS thread, so "single-threaded" is false). Concentrating them
-//! here gives one audited primitive, one accurate safety contract, and — most
-//! importantly — **one site to change** when arrays/hashes gain interior
-//! mutability (first-class container cells / PLAN.md Track B), which is what
-//! actually removes the underlying unsoundness.
+//! [`gc_data_mut`] is the routing decision on top of that: aliased ⇒ write
+//! through the shared node, unique ⇒ plain `make_mut`. The unsafe primitive it
+//! routes to lives in the GC ([`crate::gc::gc_contents_mut`]) — there is exactly
+//! one such primitive in the codebase, and this module does not duplicate it.
 //!
-//! # ⚠️ Known unsoundness (tracked, not removed here)
+//! # Soundness posture (ADR-0013)
 //!
-//! Writing through a pointer derived from `Arc::as_ptr` (a `*const T`) is a
-//! provenance violation under Stacked/Tree Borrows even single-threaded, and a
-//! genuine data race when the same `Arc` is shared across threads. This module
-//! **concentrates and honestly documents** that pre-existing unsoundness; it does
-//! not fix it. The real fix is wrapping the mutated collections in interior
-//! mutability (`UnsafeCell` / a lock) once arrays/hashes become first-class
-//! `ContainerRef` cells. Until then, this is the deliberate, single, auditable
-//! choke point — do not reintroduce ad-hoc `Arc::as_ptr as *mut` casts elsewhere.
-
-use std::sync::Arc;
+//! The old `unsafe { &mut *(Arc::as_ptr(arc) as *mut _) }` shape was a provenance
+//! violation under Stacked/Tree Borrows even single-threaded. That is **fixed**:
+//! since [ADR-0013](../../../docs/adr/0013-container-interior-mutability-cellvalue.md)
+//! a `Gc` payload lives in the `GcBox`'s `UnsafeCell`, so `Gc::as_ptr` hands back
+//! an interior-mutable pointer and the aliased `&mut` has valid provenance. The
+//! fix landed at the primitive, so every call site became sound at once — there
+//! is no per-container migration and, contrary to what this header used to say,
+//! Track B is not the fix (ADR-0001 §7).
+//!
+//! What remains deferred, by decision rather than omission, is the **narrow
+//! cross-thread race** on a genuinely shared node (ADR-0013 §1.3-2 → ADR-0001
+//! layer 3c): concurrent structural mutation must stay routed through the
+//! synchronized shared-store lanes, and nothing mechanically checks that.
+//!
+//! # ⚠️ One container is still `Arc`-backed, so its aliased write is still UB
+//!
+//! ADR-0013 fixed the provenance for `Gc`-managed containers. [`arc_contents_mut`]
+//! below is the `Arc` counterpart and it has **one live call site**: the
+//! `ValueView::Mixin` overrides map (`ValueRepr::Mixin(Arc<Value>,
+//! Arc<HashMap<String, Value>>)`), written in place by `$type.^set_name(...)`.
+//! An `Arc` payload has no `UnsafeCell`, so deriving `&mut` from `Arc::as_ptr`
+//! there is the same provenance violation ADR-0013 removed everywhere else.
+//! Tracked in `todo/tickets/mixin-overrides-aliased-write-is-still-arc.md`.
+//!
+//! Do not add new `as_ptr as *mut` casts: for a `Gc` container route the write
+//! through the GC primitive, and do not give a new container the `Arc` shape
+//! that forces this one.
 
 /// Returns a `&mut T` aliasing the contents of a shared `Arc<T>`, for a
-/// deliberate aliased in-place mutation of an `ArrayData`/`HashData` container.
+/// deliberate aliased in-place mutation of a still-`Arc`-backed container.
 ///
 /// The returned borrow is tied to the lifetime of the `&Arc<T>` argument, so the
-/// `&mut` cannot outlive the handle it came from (a small improvement over the
-/// raw `Arc::as_ptr as *mut` casts this replaces, which produced an unbounded
-/// pointer).
+/// `&mut` cannot outlive the handle it came from (a small improvement over a raw
+/// `Arc::as_ptr as *mut` cast, which produces an unbounded pointer).
 ///
 /// # Safety
 ///
 /// The caller must guarantee that for the entire lifetime of the returned `&mut`:
 ///
 /// * **No aliasing borrow is live.** No other reference (`&T` or `&mut T`) into
-///   the same `Arc`'s contents may exist while this `&mut` is held. In practice
-///   this means: read what you need out first, then take this borrow, then write,
-///   and do not re-enter the VM (which could observe the container) while the
-///   borrow is held.
-/// * **No concurrent access from another thread.** See the module-level "Known
-///   unsoundness" note — this obligation is *currently violable* for containers
-///   captured into a spawned thread, and that gap is intentionally left for the
-///   first-class-container (Track B) work to close.
+///   the same `Arc`'s contents may exist while this `&mut` is held. In practice:
+///   read what you need out first, then take this borrow, then write, and do not
+///   re-enter the VM (which could observe the container) while it is held.
+/// * **No concurrent access from another thread.**
 ///
-/// This function does not, and cannot, check these obligations; it is the
-/// single place where the project's container-aliasing invariant is trusted.
-///
-/// Currently unused: `Value::Hash` and `Value::Array` — the only containers that
-/// took an aliased in-place write — are now `Gc`-managed and go through
-/// [`crate::gc::gc_contents_mut`]. Kept (allow dead_code) as the audited
-/// primitive for any future still-`Arc` container that needs the same write.
-#[allow(clippy::mut_from_ref, dead_code)]
-pub(crate) unsafe fn arc_contents_mut<T>(arc: &Arc<T>) -> &mut T {
+/// Beyond those, note that this cast is **itself** a provenance violation — see
+/// the module header's "One container is still `Arc`-backed" section. It has a
+/// single live call site (the `Mixin` overrides map); every other aliased
+/// container write goes through [`crate::gc::gc_contents_mut`], which is sound.
+/// Do not add a second call site: give the container the `Gc` shape instead.
+#[allow(clippy::mut_from_ref)]
+pub(crate) unsafe fn arc_contents_mut<T>(arc: &std::sync::Arc<T>) -> &mut T {
     // SAFETY: delegated to the caller per the contract above. This is the only
     // `Arc::as_ptr as *mut` cast in the codebase.
-    unsafe { &mut *(Arc::as_ptr(arc) as *mut T) }
-}
-
-/// The [`Gc<T>`] analogue of [`arc_contents_mut`], for GC-migrated containers
-/// (§11 step 5). Same aliased-in-place-mutation contract and same safety
-/// obligations — see this module's docs and [`arc_contents_mut`]. `Gc::as_ptr`
-/// yields the pointee address inside the backing `Arc`, which this casts to
-/// `*mut` for the shared write.
-///
-/// Dead until the first `Value` container variant is `Gc`-managed (§11 step 5c);
-/// added now alongside the other `Gc` Arc-drop-in prerequisites.
-#[allow(clippy::mut_from_ref, dead_code)]
-pub(crate) unsafe fn gc_contents_mut<T: crate::gc::Trace + 'static>(
-    gc: &crate::gc::Gc<T>,
-) -> &mut T {
-    // SAFETY: delegated to the caller per the same contract as arc_contents_mut.
-    unsafe { &mut *(crate::gc::Gc::as_ptr(gc) as *mut T) }
+    unsafe { &mut *(std::sync::Arc::as_ptr(arc) as *mut T) }
 }
 
 /// Shared-aware mutable access to a container's backing data for a mutation
@@ -101,9 +89,10 @@ pub(crate) unsafe fn gc_contents_mut<T: crate::gc::Trace + 'static>(
 ///
 /// # Safety (inherited)
 ///
-/// The aliased branch is [`gc_contents_mut`] — the caller must uphold the
-/// same contract: no other borrow into this node live for the duration of
-/// the returned `&mut`, and no concurrent access from another thread.
+/// The aliased branch is [`crate::gc::gc_contents_mut`] — the caller must uphold
+/// the same contract: no other borrow into this node is dereferenced for the
+/// lifetime of the returned `&mut`, and concurrent structural mutation from
+/// another thread stays routed through the synchronized shared-store lanes.
 pub(crate) fn gc_data_mut<T: crate::gc::Trace + Clone + 'static>(
     gc: &mut crate::gc::Gc<T>,
 ) -> &mut T {
@@ -111,7 +100,7 @@ pub(crate) fn gc_data_mut<T: crate::gc::Trace + Clone + 'static>(
         // SAFETY: audited aliased in-place container write per the module
         // contract; callers keep no competing borrow live across the returned
         // `&mut` (single-threaded VM mutation paths).
-        unsafe { gc_contents_mut(gc) }
+        unsafe { crate::gc::gc_contents_mut(gc) }
     } else {
         crate::gc::Gc::make_mut(gc)
     }

--- a/todo/tickets/magic-vars-should-be-built-lazily.md
+++ b/todo/tickets/magic-vars-should-be-built-lazily.md
@@ -1,0 +1,67 @@
+# `$*KERNEL` / `$*DISTRO` should be built lazily and cached, not eagerly at every startup
+
+Found 2026-08-02 while adding the Miri gate (ADR-0013 §4 phase 4): the gate's interpreter-level
+smoke tests could not run because `Interpreter::new()` spawns processes.
+
+## What happens today
+
+`Interpreter::new()` → `init_io_environment` (`src/runtime/io_env.rs:86`) eagerly constructs
+`$*DISTRO`, `$*PERL`, `$*RAKU`, `$*VM` and `$*KERNEL` and hoists them into the process-global env
+base tier (`IMMUTABLE_BASE_DYNAMICS`, `src/runtime/mod.rs`). Constructing them **shells out**:
+
+| site | spawns |
+| --- | --- |
+| `make_distro_instance` (linux arm), `src/runtime/io_sysinfo.rs:154` | `uname -r` |
+| `make_kernel_instance`, `io_sysinfo.rs:428` | `uname -r` **again**, via a second `OnceLock` |
+| `make_kernel_instance`, `io_sysinfo.rs:440` | `uname -m` |
+| `make_kernel_instance`, `io_sysinfo.rs:470` | `hostname` |
+| `make_distro_instance` (macos arm), `io_sysinfo.rs:116/122/128` | `sw_vers` ×3 |
+
+So every `mutsu` invocation — including every `prove` test process and every `mzef` subprocess —
+pays three `fork`/`exec`s on Linux (four on macOS) for data that most programs never read. The
+project's headline metric is startup time (0.04× raku), which makes this the wrong place to be
+eager. The values are process constants, so they should be **delayed until first access and then
+cached**, which is what Rakudo effectively does.
+
+Note also the duplication: kernel release is fetched twice through two separate `OnceLock`s
+(`DISTRO_UNAME_R` and `UNAME_R`), which is a "1 operation = 1 implementation" violation on its own.
+
+## Why it blocks the Miri gate
+
+Miri cannot spawn a process (`unsupported operation: can't call foreign function
+`posix_spawnattr_init``), so `Interpreter::new()` aborts under Miri before reaching any container
+code. That is why `src/gc/soundness_smoke.rs`'s four tests — the ones that would let Miri watch the
+VM take an aliased `&mut` into a shared container node — are `#[cfg_attr(miri, ignore)]` today, and
+the gate currently covers the `Gc` primitive only. ADR-0013 §4 explicitly warned that a
+primitive-only Miri run "mostly re-proves std's `UnsafeCell` guarantee", so closing this ticket is
+what gives the gate its full value.
+
+(A second, smaller Miri blocker sits in `local_timezone_offset_secs()`, `src/runtime/mod.rs`: it
+calls `libc::time` / `libc::localtime_r`, which Miri also cannot call. Its existing contract already
+says "returns 0 if the offset cannot be determined", so extending that arm with `not(miri)` is a
+one-line fix to do at the same time.)
+
+## Two slices, in order
+
+1. **Cheap and independent: stop shelling out at all.** Replace the `uname -r` / `uname -m` pair
+   with one `libc::uname(2)` call (one syscall, no fork) behind a single cached helper used by both
+   `make_distro_instance` and `make_kernel_instance`, and replace `hostname` with
+   `libc::gethostname`. This fixes the duplication and removes the fork/exec from startup even
+   before laziness lands. Keep the current shell-outs as the fallback for platforms without the
+   syscall, and give the `miri`/`wasm32` arm `/proc/sys/kernel/osrelease` +
+   `std::env::consts::ARCH` (verified equal to `uname -r` on Linux).
+2. **The real fix: delay construction.** Do not build these instances in `init_io_environment`;
+   materialize on first read and cache. The awkward part is *where* the hook goes: these live in the
+   process-global base tier (`crate::env::set_global_base`, a `OnceLock` set once at startup), and
+   env lookup falls overlay → parent chain → base tier with no miss hook. Either give the base tier
+   a lazy-materialization entry point, or leave the names out of it and let the dynamic-var read
+   path (`get_dynamic_handle` and the VM's dynamic read) construct-and-insert on demand. Whichever
+   is chosen, the cache must stay process-wide so repeated reads do not re-run the syscalls, and it
+   must be safe under the threaded lanes that share the base tier.
+
+## Pins
+
+`roast/S02-magicals/KERNEL.t` and `DISTRO.t` require every field to be truthy, and
+`roast/S32-io/IO-Socket-INET.t:337` matches `$*KERNEL.release` against `/Microsoft/` for WSL
+detection — so the data must stay correct, not just cheap. `t/base-tier-magic-vars.t` pins the
+base-tier hoisting itself.

--- a/todo/tickets/mixin-overrides-aliased-write-is-still-arc.md
+++ b/todo/tickets/mixin-overrides-aliased-write-is-still-arc.md
@@ -1,0 +1,64 @@
+# The `Mixin` overrides map is still `Arc`-backed, so its aliased write is still provenance UB
+
+Found 2026-08-02 while adding the Miri gate that closes ADR-0013.
+
+## The claim that turned out to be wrong
+
+[ADR-0013](../../docs/adr/0013-container-interior-mutability-cellvalue.md) §8 records the provenance
+fix as "fixed at every call site at once", on the reasoning that the `UnsafeCell` went into
+`GcBox.value`, so every `Gc<T>` became interior-mutable at the primitive. `src/value/aliased_mut.rs`
+agreed, documenting its `arc_contents_mut` as "Currently unused … kept as the audited primitive for
+any future still-`Arc` container".
+
+Both are wrong by one call site. `arc_contents_mut` has a **live caller**:
+
+```
+src/runtime/methods_classhow_dispatch.rs:109
+    let map = unsafe { crate::value::arc_contents_mut(overrides) };
+    map.insert("__mutsu_type_name__".to_string(), Value::str(new_name.clone()));
+```
+
+## Root cause
+
+`Mixin` is the one container variant that never migrated to the GC:
+
+```rust
+// src/value/mod.rs:1354
+Mixin(Arc<Value>, Arc<HashMap<String, Value>>),
+```
+
+A plain `Arc<T>` payload has **no `UnsafeCell`**, so `&mut *(Arc::as_ptr(arc) as *mut T)` derives a
+`&mut` from a `*const` — exactly the Stacked/Tree Borrows violation ADR-0013 removed everywhere else.
+The write itself is semantically wanted (`$type.^set_name($name)` must be visible through every alias
+of the mixed-in object, matching Rakudo's in-place mutation of the anonymous metaobject); it is the
+*representation* that makes it unsound.
+
+## Repro
+
+```raku
+my $obj = 42 but role { method greet { 'hi' } };
+$obj.^set_name('Greeter');
+say $obj.^name;    # Greeter
+```
+
+Under `cargo miri test` this path reports a Stacked Borrows error; under a normal build it works and
+no test fails, which is precisely why it survived.
+
+## Why it is not a one-liner
+
+`Mixin`'s overrides map is read on hot paths (`.^name`, method-override lookup), so the fix has to
+keep reads cheap:
+
+- **Give `Mixin` the `Gc` shape** (`Gc<HashMap<String, Value>>`) so the write can route through the
+  sound `crate::gc::gc_contents_mut`. Needs a `Trace` impl and touches the NaN-box tagging for the
+  variant — the same migration every other container already had.
+- Or **stop mutating in place**: have `^set_name` rebuild the mixin value and write it back through
+  the variable, which changes the aliasing semantics the current code deliberately relies on.
+
+The first is the one that matches the rest of the codebase. Until it lands, keep the honest warning in
+`aliased_mut.rs`'s module header and **do not add a second `arc_contents_mut` call site**.
+
+## Gate
+
+The Miri job (`.github/workflows/miri.yml`) is informational at first partly because of this: the
+GC/container subset it runs must be clean before the job can become blocking.


### PR DESCRIPTION
ADR-0013 fixed the provenance UB in the GC's aliased container writes (payload into a `GcBox`'s `UnsafeCell`, so the `&mut` from `gc_contents_mut` has valid provenance while other `Gc` handles read the node). What it shipped was an **argument**: a provenance violation is UB that happens to work, so `make test` and the whole roast suite stay green either way. §4 phase 4 named a Miri run as the definition of done, and that phase had never been built.

## The gate

`cargo miri test --no-default-features --features native --lib gc::` on a **pinned** nightly, as ci.yml's `miri` job.

- The feature set drops the two things Miri fundamentally cannot execute: the Cranelift JIT (real machine code) and FFI.
- The nightly pin is deliberate — an unpinned nightly changes the interpreter and its Stacked Borrows model under the job, turning a toolchain update into what looks like a soundness regression, on a required check.
- **Required, not informational.** On a repo where every PR auto-merges, `continue-on-error` is a job nobody reads. Cost is controlled by the trigger instead: `changes` gained a `gc-value` output (`scripts/ci-docs-only.sh --gc-value`, with self-test cases) and the job is gated on it — **23 of the last 300 merges, ~8%**. It has to be a job-level `if:` and not a workflow-level `paths` filter, or the check run is never created and the PR stays pending forever — the same trap the docs-only skip documents. The classifier's fail-safe direction is the *opposite* of docs-only: an undeterminable diff runs the check, because a skipped soundness check is a silently-unchecked merge.

Measured on this tree: **47 pass, 0 fail, 5 ignored, ~19s** of interpretation (wall clock is dominated by compiling the crate to MIR).

## Writing it found a live UB site

Rewriting `src/value/aliased_mut.rs`'s header (it still described the provenance violation as live and named Track B as the fix — both false since ADR-0013) meant deleting the primitives it documented as unused. The compiler disagreed: **`arc_contents_mut` has a live call site**.

`Mixin` is the one container variant that never migrated to the GC — `ValueRepr::Mixin(Arc<Value>, Arc<HashMap<String, Value>>)` — and `$type.^set_name(...)` writes its overrides map in place through `Arc::as_ptr as *mut`, with no `UnsafeCell` behind it. So ADR-0013 §8's "fixed at every call site at once" is wrong by one. Corrected in place; repro and the two ways out in `todo/tickets/mixin-overrides-aliased-write-is-still-arc.md`. The gate cannot see it yet (no test in the subset reaches `^set_name`), which is itself worth knowing about a gate.

## What it does not cover, stated plainly

- **The VM's real call sites.** `src/gc/soundness_smoke.rs` adds four tiny Raku programs run through a real `Interpreter` — the coverage §4 warned a primitive-only run lacks. `#[cfg_attr(miri, ignore)]` for now: `Interpreter::new()` eagerly builds `$*DISTRO`/`$*KERNEL` by shelling out to `uname -r` (twice, via two separate `OnceLock`s), `uname -m` and `hostname`, and Miri cannot spawn a process. Root fix — delay those process constants to first access and cache them, which also removes three `fork`/`exec`s from every `mutsu` startup — is `todo/tickets/magic-vars-should-be-built-lazily.md`.
- **Precision through the NaN box.** Miri reports `integer-to-pointer cast` on `Value` and falls back to permissive provenance, so checking is precise for typed `Gc<T>` paths and best-effort above them. `-Zmiri-strict-provenance` is unavailable to us for the same reason.
- **One race-hammer test** (`concurrent_buffer_and_drain_never_wraps_the_approx_count`, 200k allocations across four threads) does not finish under Miri and is ignored there. The workflow documents that escape hatch *and* the two conditions that make it legitimate — the property is not provenance, and something else still runs it natively — so the next slow test does not get "fixed" by weakening the gate.

## After merge

`miri` still has to be added to the ruleset's required status checks (currently `test` / `wasm-e2e` / `gc-stress` / `changes`). Doing that before this lands would block every open PR on a job that does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)