### PR TITLE
fix(runtime): a method wrapper's invocant, and `if EXPR -> @a` truthiness

### DIFF
--- a/news/2026-08/wrap-invocant-and-if-pointy-container.md
+++ b/news/2026-08/wrap-invocant-and-if-pointy-container.md
@@ -1,0 +1,102 @@
+# Cro's HTTP client: a wrapper's invocant, and `if EXPR -> @a`
+
+Loading `Cro::HTTP::Client` worked, but the moment a request was made every
+client-side test file died with `No such method 'lock' for invocant of type
+'Any'`, taking six Cro::HTTP suite files down with it (`http-auth-basic`,
+`http-auth-basic-with-session`, `http-session-inmemory`,
+`http-session-persistent`, and the two webtoken files). The message came from
+OO::Monitors' method wrapper, but the monitor machinery was innocent: two
+unrelated general bugs were behind it.
+
+## A method wrapper bound its invocant to the first argument
+
+`OO::Monitors` wraps every method of a `monitor` with
+
+```raku
+$meth.wrap: -> \SELF, | {
+    my $lock = $!lock-attr.get_value(SELF);
+    $lock.lock();
+    ...
+}
+```
+
+A method wrapper is invoked with the invocant *prepended* to the method's own
+arguments, so the wrapper's first parameter is the invocant. mutsu built that
+argument list correctly — but the pending *call-site argument source names*
+(the caller's variable name behind each argument, which the call opcode records
+so an `is rw` / `is raw` / sigilless parameter can alias and write back to it)
+were recorded for the method's arguments only, and were never shifted to
+account for the prepended invocant.
+
+A sigilless parameter re-reads its value from the named source variable rather
+than from the argument slot, so `\SELF` picked up source name `[0]` — which
+named the method's *first argument*, not the invocant. Cro's
+`$!connection-cache.pipeline-for($secure, $host, $port, $http)` therefore ran
+the wrapper with `SELF` bound to `$secure`, a `Bool`, and looked for the
+monitor lock attribute on it. The shape is trivially reproducible with no
+module at all:
+
+```raku
+class C { method who($a, $b) { } }
+C.^lookup('who').wrap: -> \SELF, |c { say SELF.^name; callsame };
+my $x = 1;
+C.new.who(1,  2);   # C   -- literal argument, no source name, so it worked
+C.new.who($x, 2);   # Int -- bare variable argument, and SELF became $x
+```
+
+The fix shifts the pending arg sources by one whenever a wrapper is entered
+with the invocant prepended. A companion problem surfaced immediately: the
+outermost wrapper *consumes* the pending sources when its own signature binds,
+so a `callsame` reaching the wrapped original found none and rejected any
+`is rw` parameter with `X::Parameter::RW`. The wrap-dispatch frame now carries
+the original call's sources and restores them for each callee in the chain
+(shifted again for an inner wrapper, unshifted for the original routine), so
+`E.^lookup('bump').wrap(...)` no longer breaks `method bump($n is rw)`.
+
+Pin: `t/wrap-invocant-arg-source.t`.
+
+## `if EXPR -> @a { }` tested the bound container, not the condition
+
+With the invocant fixed, the next request died on `No such method 'dead' for
+invocant of type 'Any'` inside the connection cache:
+
+```raku
+if $http ne '2' && %!cached-http1{$key} -> @available {
+    while @available {
+        my $pipeline = @available.shift;
+        return $pipeline unless $pipeline.dead;
+    }
+}
+```
+
+`%!cached-http1` was empty, so the condition was an undefined `Any` and the
+branch must not run. mutsu desugared the pointy binding to `my @available =
+EXPR` and then tested `@available` — and `my @a = Any` is a one-element
+`[Any]`, which is *true*. So the block ran, `while @available` was true once,
+and `.shift` handed out the `Any` that `.dead` was then called on. A missing
+hash element is enough to show it:
+
+```raku
+my %h;
+if %h<nope> -> @a { say "entered" } else { say "else" }   # mutsu said "entered"
+```
+
+The condition is now evaluated once into a hidden scalar which is what gets
+tested, and the container is bound (not assigned) *inside* the taken branch —
+binding matters because a pointy parameter aliases its argument, so
+`if %cache<full> -> @avail` sees all three elements rather than a
+one-element array holding the array; and deferring it matters because binding
+a non-`Positional` condition (`if 0 -> @a`) is a type error that must not fire
+when the branch is not entered. All three `if` compilation paths (statement,
+value, and `do`-expression) share the helper, so `elsif` bindings get it too.
+
+Pin: `t/if-pointy-container-param.t`.
+
+## Effect on the Cro::HTTP suite
+
+The four files that produced no TAP output at all now load, plan, and run their
+assertions (`http-auth-basic` and `http-auth-basic-with-session` reach
+`plan 5`; the two session files reach their first assertions), and the client
+completes a request without dying in the connection cache. The remaining
+failures there are the real client/server round-trip, which is the next
+blocker.

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -144,7 +144,31 @@ impl Compiler {
     /// itemizing it into a scalar container (DBIish's `if self._row -> \r
     /// { r.Array }` must not nest the row array), and it reads back as a bare
     /// word rather than a `$`-variable.
-    pub(super) fn compile_if_binding_decl(&mut self, var_name: &str, cond: &Expr) -> Expr {
+    /// The `@`/`%` case additionally returns a declaration the caller must emit
+    /// INSIDE the then-branch (see the comment below), so this returns
+    /// `(test_expr, deferred_container_decl)`.
+    pub(super) fn compile_if_binding_decl(
+        &mut self,
+        var_name: &str,
+        cond: &Expr,
+    ) -> (Expr, Option<(String, Expr)>) {
+        // `if EXPR -> @a { }` / `-> %h { }` tests EXPR itself, not the bound
+        // container. Assigning the condition into an `@`/`%` container changes
+        // its truthiness — `my @a = Any` is a one-element `[Any]`, which is
+        // true — so a missing hash element (`if %cache{$k} -> @avail { }`, Cro's
+        // connection cache) wrongly ran the block and then handed out `Any`.
+        // Evaluate the condition once into a hidden scalar and test that; the
+        // container itself is only bound once the branch is known to be taken,
+        // because binding a non-Positional condition (`if 0 -> @a`) is a type
+        // error that must not fire when the branch is not entered.
+        if var_name.starts_with('@') || var_name.starts_with('%') {
+            let tmp = format!("__mutsu_tmp_if_cond_{}", self.code.constants.len());
+            self.compile_stmt(&Self::plain_var_decl(tmp.clone(), cond.clone()));
+            return (
+                Expr::Var(tmp.clone()),
+                Some((var_name.to_string(), Expr::Var(tmp))),
+            );
+        }
         let (bare_name, read_expr) = if let Some(bare) = var_name.strip_prefix('\\') {
             self.sigilless_locals.insert(bare.to_string());
             (bare.to_string(), Expr::BareWord(bare.to_string()))
@@ -165,7 +189,34 @@ impl Compiler {
             where_constraint: None,
         };
         self.compile_stmt(&var_decl);
-        read_expr
+        (read_expr, None)
+    }
+
+    /// Emit the deferred `@`/`%` pointy-parameter binding returned by
+    /// [`Self::compile_if_binding_decl`]. A pointy parameter BINDS its argument,
+    /// so an `Array` condition becomes that array rather than a single-element
+    /// copy of it (`if %cache{$k} -> @avail` must see all the elements).
+    pub(super) fn compile_if_binding_container_decl(&mut self, decl: &Option<(String, Expr)>) {
+        let Some((name, source)) = decl else { return };
+        self.bind_vardecl = true;
+        self.compile_stmt(&Self::plain_var_decl(name.clone(), source.clone()));
+        self.bind_vardecl = false;
+    }
+
+    /// A `my NAME = EXPR;` declaration with no traits/constraints.
+    fn plain_var_decl(name: String, expr: Expr) -> Stmt {
+        Stmt::VarDecl {
+            name,
+            expr,
+            type_constraint: None,
+            is_state: false,
+            is_our: false,
+            is_dynamic: false,
+            is_export: false,
+            export_tags: vec![],
+            custom_traits: Vec::new(),
+            where_constraint: None,
+        }
     }
 
     pub(super) fn compile_if_value(
@@ -218,8 +269,10 @@ impl Compiler {
         if pointy_topic_scope {
             self.code.emit(OpCode::EnterPointyTopic);
         }
+        let mut deferred_container_decl = None;
         if let Some(var_name) = binding_var {
-            let read_expr = self.compile_if_binding_decl(var_name, cond);
+            let (read_expr, deferred) = self.compile_if_binding_decl(var_name, cond);
+            deferred_container_decl = deferred;
             self.compile_expr(&read_expr);
         } else {
             self.compile_expr(cond);
@@ -230,6 +283,7 @@ impl Compiler {
             self.code.emit(OpCode::Dup);
         }
         let jump_else = self.code.emit(OpCode::JumpIfFalse(0));
+        self.compile_if_binding_container_decl(&deferred_container_decl);
         if needs_at_underscore {
             // Flatten the duplicated condition into @_.
             self.code.emit(OpCode::FlattenSlurpy);

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -157,8 +157,10 @@ impl Compiler {
             None
         };
         let needs_cond_value = needs_at_underscore || cond_placeholder.is_some();
+        let mut deferred_container_decl = None;
         if let Some(var_name) = binding_var {
-            let read_expr = self.compile_if_binding_decl(var_name, cond);
+            let (read_expr, deferred) = self.compile_if_binding_decl(var_name, cond);
+            deferred_container_decl = deferred;
             self.compile_expr(&read_expr);
         } else {
             self.compile_expr(cond);
@@ -167,6 +169,7 @@ impl Compiler {
             self.code.emit(OpCode::Dup);
         }
         let jump_else = self.code.emit(OpCode::JumpIfFalse(0));
+        self.compile_if_binding_container_decl(&deferred_container_decl);
         if needs_at_underscore {
             self.code.emit(OpCode::FlattenSlurpy);
             self.emit_set_named_var("@_");

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1743,10 +1743,12 @@ impl Compiler {
                 if pointy_topic_scope {
                     self.code.emit(OpCode::EnterPointyTopic);
                 }
+                let mut deferred_container_decl = None;
                 if let Some(var_name) = binding_var {
                     // Desugar: if EXPR -> $var { BODY } else { ELSE }
                     // into: { my $var = EXPR; if $var { BODY } else { ELSE } }
-                    let desugared_cond = self.compile_if_binding_decl(var_name, cond);
+                    let (desugared_cond, deferred) = self.compile_if_binding_decl(var_name, cond);
+                    deferred_container_decl = deferred;
                     self.compile_condition_expr(&desugared_cond);
                 } else {
                     self.compile_condition_expr(cond);
@@ -1757,6 +1759,7 @@ impl Compiler {
                     }
                 }
                 let jump_else = self.code.emit(OpCode::JumpIfFalse(0));
+                self.compile_if_binding_container_decl(&deferred_container_decl);
                 if needs_at_underscore {
                     // Flatten the duplicated condition into @_ (like *@ slurpy).
                     self.code.emit(OpCode::FlattenSlurpy);

--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -89,6 +89,10 @@ fn is_simple_if_binding(param: &ParamDef) -> bool {
         && !param.named
         && !param.slurpy
         && !param.double_slurpy
+        // `+@a` (the single-argument rule) is a slurpy too: it must reach the
+        // real signature binder rather than the simple `my @a := COND`
+        // desugar, which cannot apply the one-arg rule.
+        && !param.onearg
         && param.default.is_none()
         && !param.optional_marker
         && param.type_constraint.is_none()

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -249,7 +249,20 @@ impl Interpreter {
         if let Some(frame) = self.wrap_dispatch_stack.last_mut() {
             if let Some(next) = frame.remaining.first().cloned() {
                 frame.remaining.remove(0);
+                let is_override = override_args.is_some();
                 let call_args = override_args.unwrap_or_else(|| frame.args.clone());
+                let is_method_wrap = frame.sub_id == 0;
+                // Restore the original call site's arg-source names: the
+                // outermost wrapper's own binding consumed the pending ones, so
+                // an `is rw` parameter of the next callee (a wrappee or the
+                // original routine) would otherwise have no writable source to
+                // name and die with X::Parameter::RW. `callwith`-style override
+                // args are a different call, so they keep no sources.
+                let frame_arg_sources = frame.arg_sources.clone();
+                let restore_sources = !is_override && frame_arg_sources.is_some();
+                if restore_sources {
+                    self.set_pending_call_arg_sources(frame_arg_sources);
+                }
                 // If this is a method wrap original, separate the invocant
                 // from the args and dispatch as a method call.
                 let result = if let ValueView::Sub(data) = next.view()
@@ -263,6 +276,12 @@ impl Interpreter {
                 } else {
                     // This exact call continues the active wrap chain — it must
                     // run `next` directly, not re-enter the chain from the top.
+                    // An inner *wrapper* sees the same invocant-prepended
+                    // argument list the outermost one did, so its sources need
+                    // the same shift.
+                    if restore_sources && is_method_wrap {
+                        self.shift_arg_sources_for_wrap_invocant();
+                    }
                     if let ValueView::Sub(data) = next.view() {
                         self.wrap_skip_once = Some(data.id);
                     }
@@ -345,8 +364,10 @@ impl Interpreter {
                             sub_id: 0,
                             remaining: wrap_remaining,
                             args: wrap_call_args.clone(),
+                            arg_sources: self.pending_call_arg_sources().cloned(),
                         };
                         self.wrap_dispatch_stack.push(frame);
+                        self.shift_arg_sources_for_wrap_invocant();
                         let result = self.call_sub_value(outermost, wrap_call_args, false);
                         self.wrap_dispatch_stack.pop();
                         let result = result?;

--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -20,6 +20,21 @@ impl Interpreter {
         self.pending_call_arg_sources.as_ref()
     }
 
+    /// A method wrapper (`&m.wrap(-> \SELF, |c { ... })`) is invoked with the
+    /// invocant PREPENDED to the method's arguments, but the pending
+    /// call-site arg-source names were recorded by the call opcode for the
+    /// method's arguments only. Without a shift they are off by one against
+    /// the wrapper's signature, and a sigilless/`is raw`/`is rw` parameter —
+    /// which re-reads its value from the named source variable rather than
+    /// from the argument slot — binds the wrong value: `$obj.m($x, 2)` bound
+    /// the wrapper's `\SELF` to `$x` instead of `$obj` (OO::Monitors' lock
+    /// wrapper then read `$!MONITR-lock` off a Bool).
+    pub(crate) fn shift_arg_sources_for_wrap_invocant(&mut self) {
+        if let Some(sources) = self.pending_call_arg_sources.as_mut() {
+            sources.insert(0, None);
+        }
+    }
+
     pub(crate) fn exec_call_values(
         &mut self,
         name: &str,

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -305,6 +305,7 @@ impl Interpreter {
                 sub_id: 0,
                 remaining: wrap_remaining,
                 args: call_args.clone(),
+                arg_sources: self.pending_call_arg_sources().cloned(),
             };
             let wrapper_id = if let ValueView::Sub(wd) = outermost.view() {
                 Some(wd.id)
@@ -312,6 +313,7 @@ impl Interpreter {
                 None
             };
             self.wrap_dispatch_stack.push(frame);
+            self.shift_arg_sources_for_wrap_invocant();
             let result = self.call_sub_value(outermost, call_args, false);
             self.wrap_dispatch_stack.pop();
             // Propagate closure variable mutations from the wrapper back to

--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -174,6 +174,12 @@ pub(crate) struct WrapDispatchFrame {
     pub(crate) remaining: Vec<Value>,
     /// Original call arguments.
     pub(crate) args: Vec<Value>,
+    /// Call-site source variable names for the *wrapped routine's* arguments
+    /// (for a method wrap: excluding the invocant, which `args` carries at
+    /// index 0). The outermost wrapper consumes the pending arg sources when
+    /// its own signature binds, so `callsame` reaching the original would
+    /// otherwise see none and reject an `is rw` parameter.
+    pub(crate) arg_sources: Option<Vec<Option<String>>>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -222,6 +222,7 @@ impl Interpreter {
                     sub_id: data.id,
                     remaining,
                     args: sanitized_args.clone(),
+                    arg_sources: self.pending_call_arg_sources().cloned(),
                 };
                 let (wrapper_id, wrapper_base_env) = if let ValueView::Sub(wd) = outermost.view() {
                     (Some(wd.id), Some(wd.env.clone()))

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -299,6 +299,7 @@ impl Interpreter {
             sub_id: 0,
             remaining,
             args: call_args.clone(),
+            arg_sources: self.pending_call_arg_sources().cloned(),
         };
         let wrapper_id = if let ValueView::Sub(wd) = outermost.view() {
             Some(wd.id)
@@ -306,6 +307,7 @@ impl Interpreter {
             None
         };
         self.push_wrap_dispatch_frame(frame);
+        self.shift_arg_sources_for_wrap_invocant();
         let result = self.vm_call_sub_value(outermost, call_args, false);
         self.pop_wrap_dispatch_frame();
         // Propagate closure variable mutations from the wrapper back to the

--- a/t/if-pointy-container-param.t
+++ b/t/if-pointy-container-param.t
@@ -1,0 +1,59 @@
+use Test;
+
+plan 12;
+
+# `if EXPR -> @a { }` tests EXPR itself and only BINDS the container when the
+# branch is taken. Assigning the condition into an `@`/`%` container instead
+# changed its truthiness (`my @a = Any` is a one-element `[Any]`, which is
+# true), so a missing hash element ran the block and handed out an `Any`.
+
+my %cache = full => [1, 2, 3], empty => [], zero => 0;
+
+my @seen;
+for <full empty zero missing> -> $k {
+    if %cache{$k} -> @avail {
+        @seen.push($k ~ ':' ~ @avail.elems);
+    }
+    else {
+        @seen.push($k ~ ':else');
+    }
+}
+is @seen.join(' '), 'full:3 empty:else zero:else missing:else',
+        'array pointy tests the condition, not the bound container';
+
+# The pointy parameter binds, so the elements are the condition's own.
+if %cache<full> -> @avail {
+    is @avail.elems, 3, 'bound array has the condition array elements';
+    is @avail[1], 2, 'bound array indexes into the condition array';
+    ok @avail ~~ Positional, 'bound array is Positional';
+}
+else {
+    flunk 'truthy array condition entered the else branch' for ^3;
+}
+
+# Same for a hash-sigil pointy parameter.
+my %outer = inner => { p => 1, q => 2 };
+if %outer<inner> -> %got {
+    is %got<p>, 1, 'bound hash sees the condition hash';
+    is %got.elems, 2, 'bound hash has the condition hash keys';
+}
+else {
+    flunk 'truthy hash condition entered the else branch' for ^2;
+}
+nok (if %outer<absent> -> %got { True }), 'missing hash element is false for a hash pointy';
+
+# Value (expression) position takes the same path.
+my $r = do if %cache<missing> -> @a { 'then' } else { 'else' };
+is $r, 'else', 'value-position if with an array pointy tests the condition';
+my $r2 = do if %cache<full> -> @a { @a.elems } else { 'else' };
+is $r2, 3, 'value-position if with an array pointy binds the container';
+
+# elsif carries its own binding.
+sub pick($v) {
+    if $v -> @a { "then:{@a.elems}" }
+    elsif %cache<full> -> @b { "elsif:{@b.elems}" }
+    else { 'else' }
+}
+is pick([7, 8]), 'then:2', 'array pointy on the if branch';
+is pick(Any), 'elsif:3', 'array pointy on the elsif branch';
+is pick(0), 'elsif:3', 'falsy condition falls through to the elsif';

--- a/t/if-pointy-container-param.t
+++ b/t/if-pointy-container-param.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 12;
+plan 16;
 
 # `if EXPR -> @a { }` tests EXPR itself and only BINDS the container when the
 # branch is taken. Assigning the condition into an `@`/`%` container instead
@@ -57,3 +57,13 @@ sub pick($v) {
 is pick([7, 8]), 'then:2', 'array pointy on the if branch';
 is pick(Any), 'elsif:3', 'array pointy on the elsif branch';
 is pick(0), 'elsif:3', 'falsy condition falls through to the elsif';
+
+# A slurpy array parameter is NOT the plain-container binding above: it has to
+# reach the real signature binder so the slurpy/one-argument rules apply.
+# `+@a` in particular used to look "simple" to the parser and take the plain
+# `my @a := COND` route, which cannot apply the single-argument rule
+# (roast S04-statements/if.t "slurpy parameters on block").
+if 1, 2 -> +@a { is-deeply @a, [1, 2], '+@ applies the single-argument rule' }
+if 42   -> +@a { is-deeply @a, [42],  '+@ with one argument' }
+if 1, 2 -> *@a { is-deeply @a, [1, 2], '*@ flattens the condition list' }
+if 1, 2 -> **@a { is-deeply @a, [(1, 2),], '**@ keeps the condition list intact' }

--- a/t/wrap-invocant-arg-source.t
+++ b/t/wrap-invocant-arg-source.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 8;
+
+# A method wrapper is invoked with the invocant prepended to the method's
+# arguments. The call-site "argument source variable" names recorded by the
+# call opcode cover the method's arguments only, so they must be shifted by
+# one for the wrapper's signature. Without the shift a sigilless (`\SELF`) or
+# `is raw`/`is rw` first parameter -- which re-reads its value from the named
+# source variable rather than from the argument slot -- bound the wrapper's
+# invocant to the FIRST ARGUMENT whenever that argument was a bare variable.
+
+class C {
+    method who($a, $b) { "who({$a},{$b}) on {self.^name}" }
+}
+C.^lookup('who').wrap: -> \SELF, |c {
+    die "wrapper invocant is {SELF.^name}, expected C" unless SELF ~~ C;
+    callsame
+};
+
+my $c = C.new;
+my $x = 1;
+
+is $c.who(1, 2),        'who(1,2) on C', 'literal arguments';
+is $c.who($x, 2),       'who(1,2) on C', 'bare variable as first argument';
+is $c.who(1, $x),       'who(1,1) on C', 'bare variable as second argument';
+is $c.who($x, $x),      'who(1,1) on C', 'bare variables in every position';
+
+# `is raw` first parameter takes the same source-name path.
+class D {
+    method who($a) { "who({$a}) on {self.^name}" }
+}
+D.^lookup('who').wrap: -> $SELF is raw, $a is raw {
+    die "wrapper invocant is {$SELF.^name}, expected D" unless $SELF ~~ D;
+    callsame
+};
+my $d = D.new;
+my $y = 7;
+is $d.who(7),  'who(7) on D', 'is raw wrapper, literal argument';
+is $d.who($y), 'who(7) on D', 'is raw wrapper, bare variable argument';
+
+# The shift must not break writeback through a wrapper: an `is rw` argument
+# still names the caller's variable at its (shifted) position.
+class E {
+    method bump($n is rw) { $n++; 'bumped' }
+}
+E.^lookup('bump').wrap: -> \SELF, |c {
+    die "wrapper invocant is {SELF.^name}, expected E" unless SELF ~~ E;
+    callsame
+};
+my $n = 41;
+is E.new.bump($n), 'bumped', 'rw argument through a wrapper returns';
+is $n, 42, 'rw argument through a wrapper still writes back to the caller';


### PR DESCRIPTION
Two general bugs, both found while making `Cro::HTTP::Client` answer a request.
Six Cro::HTTP suite files died before emitting a single TAP line with
`No such method 'lock' for invocant of type 'Any'`; OO::Monitors was innocent.

## A method wrapper bound its invocant to the first argument

A method wrapper is invoked with the invocant *prepended* to the method's own
arguments, but the pending call-site **arg-source names** — the caller variable
behind each argument, which a sigilless / `is raw` / `is rw` parameter reads its
value from and writes back to — were recorded for the method's arguments only
and were never shifted to account for that prepended invocant.

A sigilless parameter re-reads its value from the named source rather than from
the argument slot, so `-> \SELF, |` bound `SELF` to the source named at index 0
— the method's **first argument** — whenever that argument was a bare variable:

```raku
class C { method who($a, $b) { } }
C.^lookup('who').wrap: -> \SELF, |c { say SELF.^name; callsame };
my $x = 1;
C.new.who(1,  2);   # C   -- literal argument, no source name, so it worked
C.new.who($x, 2);   # Int -- bare variable argument, and SELF became $x
```

`OO::Monitors` wraps every monitor method exactly that way, so Cro's
`$!connection-cache.pipeline-for($secure, $host, $port, $http)` looked for
`$!MONITR-lock` on `$secure`, a `Bool`.

The sources are now shifted by one on entry to a wrapper. A companion problem
surfaced at once: the outermost wrapper *consumes* the pending sources when its
own signature binds, so a `callsame` reaching the wrapped original found none
and rejected any `is rw` parameter with `X::Parameter::RW`. The wrap-dispatch
frame now carries the original call's sources and restores them for each callee
in the chain — shifted again for an inner wrapper, unshifted for the original
routine.

## `if EXPR -> @a { }` tested the bound container, not the condition

The next request died on `No such method 'dead' for invocant of type 'Any'` in
the connection cache: `%!cached-http1` was empty, so the condition was an
undefined `Any` and the branch must not run. mutsu desugared the pointy binding
to `my @available = EXPR` and tested `@available` — and `my @a = Any` is a
one-element `[Any]`, which is **true**. A missing hash element is enough:

```raku
my %h;
if %h<nope> -> @a { say "entered" } else { say "else" }   # mutsu said "entered"
```

The condition now goes into a hidden scalar which is what gets tested, and the
container is **bound** (not assigned) *inside the taken branch*. Binding matters
because a pointy parameter aliases its argument, so `if %cache<full> -> @avail`
sees all three elements instead of a one-element array holding the array;
deferring matters because binding a non-`Positional` condition (`if 0 -> @a`) is
a type error that must not fire when the branch is not entered. All three `if`
compilation paths (statement, value, `do`-expression) share the helper, so
`elsif` bindings get it too.

## Effect

`http-auth-basic`, `http-auth-basic-with-session`, `http-session-inmemory` and
`http-session-persistent` produced **no TAP output at all** before; they now
load, plan and run their assertions. No other Cro::HTTP file regressed.

## Testing

- `make test` — PASS (2783 files, 26476 tests)
- `scripts/battery-testsuite.sh` — GATE PASSED (153/158)
- `roast/S06-advanced/wrap.t` — PASS (90 tests), plus every `t/wrap*.t`
- New pins: `t/wrap-invocant-arg-source.t`, `t/if-pointy-container-param.t`
  (both verified against `raku` first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)