### PR TITLE
compiler: restore captured bindings after shadows

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -236,6 +236,10 @@ pub(crate) struct Compiler {
     /// degrade to the literal name string once the creating frame is gone
     /// (escaping closure / `.^add_method`).
     enclosing_sigilless: std::collections::HashSet<String>,
+    /// Local names visible in enclosing compiled frames. A same-named local
+    /// declaration in this compiler shadows a captured binding even though the
+    /// outer binding has no slot in this chunk.
+    enclosing_local_names: std::collections::HashSet<String>,
     /// Placeholder params (`^p` caret-form) an interpret-path caller has
     /// already bound in env before re-compiling this body — see
     /// `seed_prebound_placeholders`.
@@ -358,6 +362,7 @@ impl Compiler {
             outer_constant_names: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
             enclosing_sigilless: std::collections::HashSet::new(),
+            enclosing_local_names: std::collections::HashSet::new(),
             prebound_placeholder_params: std::collections::HashSet::new(),
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),
@@ -599,6 +604,10 @@ impl Compiler {
             .extend(self.sigilless_locals.iter().cloned());
         sub.enclosing_sigilless
             .extend(self.enclosing_sigilless.iter().cloned());
+        sub.enclosing_local_names
+            .extend(self.local_map.keys().cloned());
+        sub.enclosing_local_names
+            .extend(self.enclosing_local_names.iter().cloned());
     }
 
     /// Bake the scope chain visible right here into the code chunk, and return
@@ -719,7 +728,16 @@ impl Compiler {
             // Only a genuine ancestor shadow needs the outer slot restored on exit.
             frame.insert(
                 name.to_string(),
-                if is_ancestor_shadow { prev } else { None },
+                if is_ancestor_shadow {
+                    prev
+                } else if prev.is_none() && self.enclosing_local_names.contains(name) {
+                    // Cross-frame shadow: no outer slot exists in this chunk.
+                    // u32::MAX is a compile-time-only sentinel telling scope exit
+                    // to remove the dead child mapping and resume GetGlobal.
+                    Some(u32::MAX)
+                } else {
+                    None
+                },
             );
         }
         slot
@@ -879,7 +897,11 @@ impl Compiler {
         // `block_declared_vars` machinery keeps enforcing out-of-scope errors.
         for (name, prev) in frame {
             if let Some(outer_slot) = prev {
-                self.local_map.insert(name, outer_slot);
+                if outer_slot == u32::MAX {
+                    self.local_map.remove(&name);
+                } else {
+                    self.local_map.insert(name, outer_slot);
+                }
             }
         }
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2413,6 +2413,20 @@ impl CompiledCode {
         }
     }
 
+    fn mark_same_named_slot_peers(&self, slots: &mut [bool]) {
+        let selected_names: std::collections::HashSet<&str> = slots
+            .iter()
+            .enumerate()
+            .filter(|(_, selected)| **selected)
+            .map(|(slot, _)| self.locals[slot].as_str())
+            .collect();
+        for (slot, name) in self.locals.iter().enumerate() {
+            if selected_names.contains(name.as_str()) {
+                slots[slot] = true;
+            }
+        }
+    }
+
     fn mark_closure_parent_slots(&self, cc_idx: u32, slots: &mut [bool]) {
         let Some(cc) = self.closure_compiled_codes.get(cc_idx as usize) else {
             return;
@@ -2802,6 +2816,16 @@ impl CompiledCode {
                 }
                 _ => {}
             }
+        }
+        // A block declaration's entry prelude may clear the previously visible
+        // same-named outer slot. Block exit restores that exact peer from env,
+        // so every simultaneously live peer is a dependency of this consumer —
+        // still a precise duplicate-name subset, never a frame-wide blanket.
+        if has_block_scope {
+            self.mark_same_named_slot_peers(&mut block_scope_slots);
+        }
+        if has_block_local_scope {
+            self.mark_same_named_slot_peers(&mut block_local_scope_slots);
         }
         if has_for_loop {
             self.env_consumer_slots.for_loop = for_loop_slots;
@@ -4074,6 +4098,18 @@ impl CompiledCode {
     ///   capture is boxed into a shared `ContainerRef` cell, which the snapshot
     ///   clones), so reads stay coherent without any write-back.
     pub(crate) fn compute_upvalues(&mut self, runtime_bound: &std::collections::HashSet<Symbol>) {
+        // Phase-1 indexed upvalues require the standard closure-dispatch path to
+        // install the aligned array. Inline block scopes handed to thread clones,
+        // and runtime-split whenever/LAST/QUIT callbacks, can execute through
+        // carrier paths without that array. Keep their reads as GetGlobal over
+        // the already-precise captured env; this does not widen env sync or
+        // restore the removed captures_env_by_name blanket.
+        if !self.env_consumer_slots.block_scope.is_empty()
+            || !self.env_consumer_slots.block_local_scope.is_empty()
+            || !self.env_consumer_slots.whenever.is_empty()
+        {
+            return;
+        }
         let own: std::collections::HashSet<&str> = self.locals.iter().map(|s| s.as_str()).collect();
         let written: std::collections::HashSet<Symbol> = self
             .free_var_writes

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -451,7 +451,11 @@ impl Interpreter {
         let Some(cc) = cc else {
             return self.clone_env();
         };
-        if crate::opcode::reflective_name_access_possible() {
+        if crate::opcode::reflective_name_access_possible()
+            || !cc.env_consumer_slots.block_scope.is_empty()
+            || !cc.env_consumer_slots.block_local_scope.is_empty()
+            || !cc.env_consumer_slots.whenever.is_empty()
+        {
             let mut flat = self.clone_env();
             // Even when capturing the whole env by name, a slot-only local (a
             // pointy-block/sub parameter that this frame never mirrors into `env`,


### PR DESCRIPTION
## Summary
- extend BlockScope consumer bitmaps only to simultaneously-live same-named slot peers needed for exact outer restoration
- distinguish cross-frame lexical shadows from first declarations and remove the dead child-slot mapping on scope exit
- keep a consumer-local capture-boundary fallback for BlockScope/Whenever carrier paths whose callback free-var inventory is not yet complete
- preserve precise per-store `needs_env_sync`; the removed `captures_env_by_name` flag and frame-wide sync blanket remain removed

## CI failure addressed
The same seven TAP files failed in test, gc-stress, and jit-stress on #5759.

## Test evidence
- CI failure set, normal: 7 files / 54 tests passed
- CI failure set, `MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`: 7 files / 54 tests passed
- CI failure set, `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2`: 7 files / 54 tests passed
- closure/container/writeback regression set: 16 files / 142 tests passed
- `cargo clippy -- -D warnings`
- `cargo fmt --all`

Stacked on #5759.