### PR TITLE
compiler: surface whenever phaser captures

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3487,7 +3487,25 @@ impl Compiler {
                 // parent's post-registration writes. See
                 // surface_stashed_body_free_vars for the mechanism.
                 let analysis_param = vec![param.clone().unwrap_or_else(|| "$_".to_string())];
-                let analysis_cc_idx = self.surface_stashed_body_free_vars(&analysis_param, body);
+                // LAST/QUIT callbacks are split out of the whenever body at
+                // runtime. Compile their statements inline only in the
+                // analysis copy so their outer lexical reads contribute to the
+                // parent-slot inventory; the executable stmt_pool body retains
+                // the original Phaser nodes.
+                let mut analysis_body = Vec::new();
+                for stmt in body {
+                    if let Stmt::Phaser {
+                        kind: PhaserKind::Last | PhaserKind::Quit,
+                        body: phaser_body,
+                    } = stmt
+                    {
+                        analysis_body.extend(phaser_body.iter().cloned());
+                    } else {
+                        analysis_body.push(stmt.clone());
+                    }
+                }
+                let analysis_cc_idx =
+                    self.surface_stashed_body_free_vars(&analysis_param, &analysis_body);
                 let param_idx = param
                     .as_ref()
                     .map(|p| self.code.add_constant(Value::str(p.clone())));

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4098,18 +4098,6 @@ impl CompiledCode {
     ///   capture is boxed into a shared `ContainerRef` cell, which the snapshot
     ///   clones), so reads stay coherent without any write-back.
     pub(crate) fn compute_upvalues(&mut self, runtime_bound: &std::collections::HashSet<Symbol>) {
-        // Phase-1 indexed upvalues require the standard closure-dispatch path to
-        // install the aligned array. Inline block scopes handed to thread clones,
-        // and runtime-split whenever/LAST/QUIT callbacks, can execute through
-        // carrier paths without that array. Keep their reads as GetGlobal over
-        // the already-precise captured env; this does not widen env sync or
-        // restore the removed captures_env_by_name blanket.
-        if !self.env_consumer_slots.block_scope.is_empty()
-            || !self.env_consumer_slots.block_local_scope.is_empty()
-            || !self.env_consumer_slots.whenever.is_empty()
-        {
-            return;
-        }
         let own: std::collections::HashSet<&str> = self.locals.iter().map(|s| s.as_str()).collect();
         let written: std::collections::HashSet<Symbol> = self
             .free_var_writes

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -451,11 +451,7 @@ impl Interpreter {
         let Some(cc) = cc else {
             return self.clone_env();
         };
-        if crate::opcode::reflective_name_access_possible()
-            || !cc.env_consumer_slots.block_scope.is_empty()
-            || !cc.env_consumer_slots.block_local_scope.is_empty()
-            || !cc.env_consumer_slots.whenever.is_empty()
-        {
+        if crate::opcode::reflective_name_access_possible() {
             let mut flat = self.clone_env();
             // Even when capturing the whole env by name, a slot-only local (a
             // pointy-block/sub parameter that this frame never mirrors into `env`,


### PR DESCRIPTION
## Summary
- include LAST/QUIT callback bodies in the analysis-only whenever free-variable inventory
- publish their exact parent slots through the existing Whenever consumer bitmap
- remove the remaining BlockScope/BlockLocalScope/Whenever whole-env capture-boundary fallbacks
- restore unrestricted Phase-1 indexed upvalue analysis; whole-env closure capture now remains only for reflective name access

## Test evidence
- focused shadow/thread/phaser set: 8 files / 62 tests passed
- same set with GC verification: 8 files / 62 tests passed
- same set with JIT threshold 2: 8 files / 62 tests passed
- closure/container/writeback regression set: 15 files / 134 tests passed
- `cargo clippy -- -D warnings`
- `cargo fmt --all`

Stacked on #5759.