### PR TITLE
vm: restore whenever-owned lexical captures

### DIFF
--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1097,6 +1097,15 @@ impl Interpreter {
                     && *k != self_sym
                     && !rw_sources.contains(k)
                     && !param_names.contains(k)
+                    // A runtime-built callback (notably a `whenever` body)
+                    // force-installs these captured bindings so they beat an
+                    // unrelated same-named caller lexical.  That install is
+                    // call-private, not a mutation of the caller binding.  A
+                    // callback containing `emit` has `cc.has_calls`, so it takes
+                    // this broad writeback path even when the authoritative
+                    // binding was only read; never replay that installed value
+                    // into the ambient caller env on return.
+                    && !data.authoritative_captures.contains(k)
                     && (restored_env.contains_key_sym(*k)
                         || captured_names.contains(k)
                         || (meta_possible

--- a/t/supply-block-enum-lexical.t
+++ b/t/supply-block-enum-lexical.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 8;
+plan 9;
 
 # A `my enum` binds its type name AND every variant name lexically in the block
 # that declares it, so those names must (a) win over a same-named outer symbol
@@ -38,6 +38,8 @@ react {
 is @got[0], 'SBEL-State', 'and inside the whenever callback too';
 is @got[1], 'SBEL-Header', 'the variant is the enum value, not the class';
 is @got[2], 2, 'a later variant keeps its ordinal';
+is SBEL-Header.^name, 'SBEL-Header',
+    'the callback does not leave its authoritative variant in the caller env';
 
 # --- (b) the binding dies with its block.
 


### PR DESCRIPTION
## Problem
A runtime-built `whenever` callback force-installed supply-body-owned lexical names, then its broad VM closure writeback copied those call-private bindings into a same-named ambient caller binding.

## Approach
Exclude `authoritative_captures` from the VM closure caller-writeback scan. Add a regression showing an enum variant wins inside the callback while the outer class is restored after `react`.

## Tests
- `prove -e target/debug/mutsu t/supply-block-enum-lexical.t`
- same test with GC verification
- same test with JIT threshold 2
- focused 4-file closure/shadow/whenever suite (24 tests)
- `cargo clippy -- -D warnings`
- `cargo fmt --all`