### PR TITLE
perf(startup): probe the host with one uname(2) instead of three subprocesses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,18 +368,18 @@ jobs:
       # shape ADR-0013 made sound — and, because the filter is a substring
       # match, `value::value_gc::` too, which is the container side. Measured
       # 2026-08-02: 47 pass, 5 ignored, ~19s of interpretation (the wall clock is
-      # dominated by compiling the crate to MIR). It also selects
-      # `gc::soundness_smoke` (the VM-level half), which is
-      # `#[cfg_attr(miri, ignore)]` for now because `Interpreter::new()` shells
-      # out and Miri cannot spawn a process; see
-      # todo/tickets/magic-vars-should-be-built-lazily.md.
+      # dominated by compiling the crate to MIR).
       #
-      # Two limits worth knowing before trusting a green run: Miri reports
+      # It runs in TWO steps because only the second half can be leak-checked;
+      # see the step comments below.
+      #
+      # One limit worth knowing before trusting a green run: Miri reports
       # `integer-to-pointer cast` on the NaN-boxed `Value`, so provenance
       # checking is precise for typed `Gc<T>` paths and best-effort through the
       # `Value` layer (`-Zmiri-strict-provenance` is unavailable to us for the
-      # same reason); and the `Mixin` overrides map is still `Arc`-backed, a
-      # live provenance violation no test in this subset reaches.
+      # same reason). The `Mixin` overrides map was the other one until #5771
+      # made it a `Gc<MixinOverrides>` node; `gc::soundness_smoke`'s
+      # `a_mixin_rename_is_visible_through_an_alias` now covers it.
       #
       # `--test-threads=1` keeps a failure attributable to a single test.
       #
@@ -397,13 +397,37 @@ jobs:
       #   2. something else still runs it natively (gc-stress, `make test`).
       # If a test IS about provenance and is too slow, shrink the test — do not
       # ignore it.
-      - name: cargo miri test (GC / container subset)
+      # Step 1 — the primitive and container tests. These allocate only what they
+      # assert on, so Miri's leak check stays ON here: a `Gc` node that outlives
+      # its test is a collector bug worth failing for.
+      - name: cargo miri test (GC / container primitives)
         env:
           # The GC's stats and verify hooks read the clock and the environment.
           MIRIFLAGS: -Zmiri-disable-isolation
         run: |
           cargo miri test --no-default-features --features native \
-            --lib gc:: -- --test-threads=1
+            --lib gc:: -- --test-threads=1 --skip gc::soundness_smoke
+
+      # Step 2 — the VM-level half (`gc::soundness_smoke`): a real `Interpreter`
+      # running a Raku program, so Miri watches the actual `gc_contents_mut` call
+      # sites rather than the primitive alone. This is the coverage ADR-0013 §4
+      # asked for, unblocked once startup stopped shelling out to `uname`.
+      #
+      # `-Zmiri-ignore-leaks` is REQUIRED here and is not a weakening of the
+      # gate: a whole interpreter intentionally leaves memory live at exit —
+      # process-lifetime statics (the env base tier, interned symbols) and
+      # uncollected reference cycles, which is exactly the condition the cycle
+      # collector exists to reclaim on demand rather than at teardown. Leak
+      # reports would drown the provenance errors this job is here to catch.
+      # Aliasing/provenance checking is UNAFFECTED by the flag.
+      #
+      # Measured 2026-08-03: 5 pass, ~245s of interpretation.
+      - name: cargo miri test (VM call sites)
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
+        run: |
+          cargo miri test --no-default-features --features native \
+            --lib gc::soundness_smoke -- --test-threads=1
 
   wasm-e2e:
     # Skipped on a documentation-only change — see the `changes` job.

--- a/news/2026-08/miri-gate-reaches-the-vm-call-sites.md
+++ b/news/2026-08/miri-gate-reaches-the-vm-call-sites.md
@@ -1,0 +1,63 @@
+# The Miri gate now watches the VM's real call sites, and startup stopped forking
+
+ADR-0013 §4 phase 4 added a Miri job to defend the one thing the GC's `UnsafeCell` design depends
+on: that `gc_contents_mut` takes an aliased `&mut` into a shared container node without violating
+provenance. But the job could only run the `Gc` primitive tests. The five interpreter-level tests in
+`src/gc/soundness_smoke.rs` — the ones that make a *real* `Interpreter` execute a Raku program so
+Miri watches the actual mutation sites — were `#[cfg_attr(miri, ignore)]`, because
+`Interpreter::new()` died before reaching any container code. The ADR itself warned that a
+primitive-only run "mostly re-proves std's `UnsafeCell` guarantee".
+
+The blocker had nothing to do with the GC. `$*KERNEL` and `$*DISTRO` were built eagerly at every
+startup, and building them **shelled out**: `uname -r` (twice, through two separate `OnceLock`s in
+two different functions), `uname -m`, and `hostname`. Miri cannot spawn a process
+(`unsupported operation: can't call foreign function 'posix_spawnattr_init'`), so startup aborted.
+
+## One syscall instead of three processes
+
+`src/runtime/io_sysinfo_host.rs` replaces all of it with a single cached `uname(2)`. The struct
+already carries every field that was being fetched separately — `release`, `machine`, and
+`nodename`, which is exactly the string the `hostname` command prints — so the duplication
+disappears along with the fork/exec pairs. Verified with `strace`: a `mutsu -e 'say 1'` start now
+issues only its own `execve` and the VM thread's `clone3`, where it previously spawned three
+subprocesses. Every `prove` test process and every `mzef` subprocess pays that start-up cost, so
+this is a small win repeated constantly.
+
+The values are unchanged, which is the part that matters: `roast/S02-magicals/KERNEL.t` and
+`DISTRO.t` require every field to be truthy, and `roast/S32-io/IO-Socket-INET.t` matches
+`$*KERNEL.release` against `/Microsoft/` to detect WSL. A unit test pins the probed values against
+`/proc/sys/kernel/{osrelease,hostname}`.
+
+## The arm Miri takes
+
+Miri can neither spawn a process nor call a foreign function, but with `-Zmiri-disable-isolation` it
+*can* read a file. So the module's fallback arm — the one used when `libc` is unavailable, and the
+one `cfg(miri)` selects — reads `/proc/sys/kernel/osrelease` and `/proc/sys/kernel/hostname` and
+takes the architecture from `std::env::consts::ARCH`, all verified equal to the `uname` output on
+Linux. `local_timezone_offset_secs()` got the same treatment: a `not(miri)` arm that falls into the
+function's already-documented "offset could not be determined → 0" branch rather than calling
+`libc::localtime_r`.
+
+With those two, a real `Interpreter` builds and runs under Miri. The five smoke tests lost their
+`cfg_attr` and pass: an aliased array push through `:=`, an aliased hash insert, a captured array
+seeing a later push, a `.^set_name` on a mixin reaching every alias (the write that was the last
+`Arc`-backed container mutation until #5771), and a self-referential array that makes the collector
+run its own `&mut` fixup paths.
+
+## Two CI steps, because only one half can be leak-checked
+
+The Miri job now runs the subset in two steps. The primitives keep Miri's leak check on — a `Gc`
+node outliving its test is a collector bug worth failing for. The interpreter-level step adds
+`-Zmiri-ignore-leaks`, which is not a loosening of the gate: a whole interpreter intentionally
+leaves memory live at exit (process-lifetime statics such as the env base tier and interned symbols,
+plus uncollected reference cycles — precisely what the cycle collector exists to reclaim on demand
+rather than at teardown), and those reports would drown the provenance errors the job exists to
+catch. Aliasing and provenance checking are unaffected by the flag. The VM-level step measures ~245s
+of interpretation for its five tests, against a 45-minute job budget.
+
+What remains is the deeper half of `todo/tickets/magic-vars-should-be-built-lazily.md`: these
+instances should be built on *first access*, not at startup at all. macOS still runs `sw_vers` three
+times per start, and laziness — not another syscall substitution — is the fix for that, since a
+program that never reads `$*DISTRO` should pay nothing. The awkward part is that the values live in
+the process-global env base tier, which has no miss hook; the ticket records the two candidate
+designs.

--- a/src/gc/soundness_smoke.rs
+++ b/src/gc/soundness_smoke.rs
@@ -17,20 +17,24 @@
 //! Keep them **small**. Miri is orders of magnitude slower than native, and the
 //! job runs them on every `src/gc/**` and `src/value/**` change.
 //!
-//! # Currently `#[cfg_attr(miri, ignore)]` — blocked on lazy magic vars
+//! # These run under Miri — keep it that way
 //!
-//! They do not run under Miri *yet*, so today they are ordinary native tests and
-//! the Miri gate covers the primitive only. The blocker is not the container
-//! code: `Interpreter::new()` eagerly builds `$*DISTRO` / `$*KERNEL`, which
-//! shells out to `uname -r`, `uname -m` and `hostname`, and Miri cannot spawn a
-//! process ("unsupported operation: can't call foreign function
-//! `posix_spawnattr_init`"). Startup dies before reaching any container code.
+//! They were `#[cfg_attr(miri, ignore)]` until 2026-08-03: `Interpreter::new()`
+//! shelled out to `uname`/`hostname` for `$*KERNEL`/`$*DISTRO` and Miri cannot
+//! spawn a process, so startup died before reaching any container code. That is
+//! fixed at the root (`runtime::io_sysinfo_host` probes the host with one cached
+//! `uname(2)`, and reads `/proc` on the arm Miri takes), which is what upgraded
+//! the gate from "the primitive is sound" to "the VM's real call sites obey the
+//! primitive's contract".
 //!
-//! `todo/tickets/magic-vars-should-be-built-lazily.md` fixes that at the root
-//! (build those instances on first access, not at startup — which is also a
-//! startup-cost win for every `mutsu` invocation). Drop the `cfg_attr` here when
-//! it lands: that is what upgrades the gate from "the primitive is sound" to
-//! "the VM's real call sites obey the primitive's contract".
+//! So: **do not reintroduce a startup path Miri cannot execute** — a foreign
+//! call, a spawned process — without giving it a `not(miri)` arm that keeps the
+//! documented fallback behaviour. If one of these tests starts failing to *run*
+//! rather than failing an assertion, that is the regression to look for.
+//!
+//! The Miri job runs them with `-Zmiri-ignore-leaks`; see the comment in
+//! `.github/workflows/ci.yml` for why a whole-interpreter run cannot be
+//! leak-checked.
 
 #[cfg(test)]
 mod tests {
@@ -49,7 +53,6 @@ mod tests {
     /// `gc_contents_mut` path (`strong_count > 1`, so `gc_data_mut` takes the
     /// aliased branch rather than `make_mut`).
     #[test]
-    #[cfg_attr(miri, ignore)] // see the module header: blocked on lazy magic vars
     fn a_push_through_an_array_binding_is_visible_through_the_original() {
         let out = run("my @a = 1, 2; my @b := @a; @b.push(3); say @a.elems; say @a[2];");
         assert_eq!(out.trim(), "3\n3");
@@ -58,7 +61,6 @@ mod tests {
     /// The hash counterpart: an insert through a bound alias reaches the
     /// original node.
     #[test]
-    #[cfg_attr(miri, ignore)] // see the module header: blocked on lazy magic vars
     fn an_insert_through_a_hash_binding_is_visible_through_the_original() {
         let out = run("my %h = a => 1; my %g := %h; %g<b> = 2; say %h.elems; say %h<b>;");
         assert_eq!(out.trim(), "2\n2");
@@ -68,7 +70,6 @@ mod tests {
     /// containers do not copy), so a later push is observable through the
     /// captured copy — the aliasing case the COW branch must not take.
     #[test]
-    #[cfg_attr(miri, ignore)] // see the module header: blocked on lazy magic vars
     fn a_captured_array_still_sees_a_later_push() {
         let out = run("my @a = 1; my $l = (0, @a); @a.push(2); say $l[1].elems;");
         assert_eq!(out.trim(), "2");
@@ -82,7 +83,6 @@ mod tests {
     /// (through the deleted `arc_contents_mut`) before the overrides map became
     /// a `Gc<MixinOverrides>` node.
     #[test]
-    #[cfg_attr(miri, ignore)] // see the module header: blocked on lazy magic vars
     fn a_mixin_rename_is_visible_through_an_alias() {
         let out = run("my $o = 42 but role :: { method greet { 'hi' } }; \
              my $alias = $o; $o.^set_name('Greeter'); \
@@ -94,7 +94,6 @@ mod tests {
     /// fixup sites that carry the `strong_count == 1` uniqueness assertion) in
     /// addition to the mutation path.
     #[test]
-    #[cfg_attr(miri, ignore)] // see the module header: blocked on lazy magic vars
     fn a_self_referential_array_builds_and_collects() {
         let out = run("my @a = 1, 2; @a.push(@a); say @a.elems;");
         assert_eq!(out.trim(), "3");

--- a/src/runtime/io_sysinfo.rs
+++ b/src/runtime/io_sysinfo.rs
@@ -147,18 +147,7 @@ impl Interpreter {
                 )
             }
             "linux" => {
-                use std::sync::OnceLock;
-                static DISTRO_UNAME_R: OnceLock<String> = OnceLock::new();
-                let kernel_release = DISTRO_UNAME_R
-                    .get_or_init(|| {
-                        Command::new("uname")
-                            .arg("-r")
-                            .output()
-                            .ok()
-                            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                            .unwrap_or_default()
-                    })
-                    .clone();
+                let kernel_release = super::io_sysinfo_host::host_info().release.clone();
                 let mut distro_desc = String::new();
                 if let Ok(content) = std::fs::read_to_string("/etc/os-release") {
                     for line in content.lines() {
@@ -195,18 +184,7 @@ impl Interpreter {
                 )
             }
             _ => {
-                use std::sync::OnceLock;
-                static FALLBACK_UNAME_R: OnceLock<String> = OnceLock::new();
-                let kernel_release = FALLBACK_UNAME_R
-                    .get_or_init(|| {
-                        Command::new("uname")
-                            .arg("-r")
-                            .output()
-                            .ok()
-                            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                            .unwrap_or_default()
-                    })
-                    .clone();
+                let kernel_release = super::io_sysinfo_host::host_info().release.clone();
                 (
                     os.to_string(),
                     "unknown".to_string(),
@@ -395,9 +373,9 @@ impl Interpreter {
     }
 
     pub(super) fn make_kernel_instance() -> Value {
-        use std::sync::OnceLock;
-        static UNAME_R: OnceLock<String> = OnceLock::new();
-        static UNAME_M: OnceLock<String> = OnceLock::new();
+        // One cached `uname(2)` covers release, hardware and hostname; see
+        // `io_sysinfo_host`. This used to be three `fork`/`exec`s per startup.
+        let host = super::io_sysinfo_host::host_info();
 
         let os = std::env::consts::OS;
         let arch = std::env::consts::ARCH;
@@ -409,29 +387,15 @@ impl Interpreter {
             _ => os.to_string(),
         };
 
-        // Kernel release (e.g., "6.18.7-76061807-generic") — cached
-        let release = UNAME_R
-            .get_or_init(|| {
-                Command::new("uname")
-                    .arg("-r")
-                    .output()
-                    .ok()
-                    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                    .unwrap_or_default()
-            })
-            .clone();
+        // Kernel release (e.g., "6.18.7-76061807-generic")
+        let release = host.release.clone();
 
-        // Hardware (e.g., "x86_64") — cached
-        let hardware = UNAME_M
-            .get_or_init(|| {
-                Command::new("uname")
-                    .arg("-m")
-                    .output()
-                    .ok()
-                    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                    .unwrap_or_else(|| arch.to_string())
-            })
-            .clone();
+        // Hardware (e.g., "x86_64")
+        let hardware = if host.machine.is_empty() {
+            arch.to_string()
+        } else {
+            host.machine.clone()
+        };
 
         // Architecture (mapped from Rust's ARCH constant)
         let arch_str = match arch {
@@ -450,17 +414,8 @@ impl Interpreter {
             32
         };
 
-        // Hostname — cached
-        static HOSTNAME: OnceLock<String> = OnceLock::new();
-        let hostname = HOSTNAME
-            .get_or_init(|| {
-                Command::new("hostname")
-                    .output()
-                    .ok()
-                    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                    .unwrap_or_default()
-            })
-            .clone();
+        // Hostname (`uname -n`, the same string the `hostname` command prints)
+        let hostname = host.hostname.clone();
 
         // Version from release string
         let version = Self::parse_version_string(&release);

--- a/src/runtime/io_sysinfo_host.rs
+++ b/src/runtime/io_sysinfo_host.rs
@@ -1,0 +1,154 @@
+//! Host identity (kernel release, machine, hostname), probed once per process
+//! without spawning a subprocess.
+//!
+//! `$*KERNEL` and `$*DISTRO` need `uname -r`, `uname -m` and `hostname`. Shelling
+//! out for them cost three `fork`/`exec`s on every `mutsu` start — paid by every
+//! `prove` test process and every `mzef` subprocess, for data most programs never
+//! read. All three fields come from a single `uname(2)` call (`hostname` prints
+//! the same `nodename` the struct carries), so one syscall replaces the three
+//! processes.
+//!
+//! The fallback path reads `/proc` instead, which is what makes this usable under
+//! Miri: Miri can neither spawn a process nor call a foreign function, but with
+//! `-Zmiri-disable-isolation` it can read a file. That is what lets
+//! `gc::soundness_smoke` build a real `Interpreter` under Miri.
+
+use std::sync::OnceLock;
+
+/// The three host-identity strings, as `uname(2)` reports them.
+pub(crate) struct HostInfo {
+    /// `uname -r` — e.g. `6.18.7-76061807-generic`.
+    pub(crate) release: String,
+    /// `uname -m` — e.g. `x86_64`.
+    pub(crate) machine: String,
+    /// `uname -n` — the same value the `hostname` command prints.
+    pub(crate) hostname: String,
+}
+
+/// Probe the host once and cache it for the life of the process. These are
+/// process constants, so a repeat read must never re-run the syscall.
+pub(crate) fn host_info() -> &'static HostInfo {
+    static HOST_INFO: OnceLock<HostInfo> = OnceLock::new();
+    HOST_INFO.get_or_init(probe)
+}
+
+#[cfg(all(
+    unix,
+    feature = "native",
+    not(miri),
+    not(target_arch = "wasm32"),
+    not(target_os = "macos")
+))]
+fn probe() -> HostInfo {
+    uname_probe().unwrap_or_else(file_probe)
+}
+
+// macOS `uname(2)` is available too, but `machine` there reports the hardware
+// name the same way `uname -m` does, so the same code serves both. Kept as a
+// separate arm only because the non-macOS arm can fall back to `/proc`, which
+// does not exist on macOS.
+#[cfg(all(
+    unix,
+    feature = "native",
+    not(miri),
+    not(target_arch = "wasm32"),
+    target_os = "macos"
+))]
+fn probe() -> HostInfo {
+    uname_probe().unwrap_or_else(empty_probe)
+}
+
+#[cfg(not(all(unix, feature = "native", not(miri), not(target_arch = "wasm32"))))]
+fn probe() -> HostInfo {
+    file_probe()
+}
+
+/// One `uname(2)`: no fork, no exec, no allocation beyond the three strings.
+#[cfg(all(unix, feature = "native", not(miri), not(target_arch = "wasm32")))]
+fn uname_probe() -> Option<HostInfo> {
+    // SAFETY: `utsname` is a plain C struct of byte arrays, so an all-zero value
+    // is a valid initialization, and `uname` only writes into the pointee.
+    unsafe {
+        let mut uts: libc::utsname = std::mem::zeroed();
+        if libc::uname(&mut uts) != 0 {
+            return None;
+        }
+        Some(HostInfo {
+            release: c_field(&uts.release),
+            machine: c_field(&uts.machine),
+            hostname: c_field(&uts.nodename),
+        })
+    }
+}
+
+/// Decode a NUL-terminated `utsname` field. `c_char` is `i8` on x86_64 and `u8`
+/// on aarch64, so cast rather than assume either.
+#[cfg(all(unix, feature = "native", not(miri), not(target_arch = "wasm32")))]
+fn c_field(buf: &[libc::c_char]) -> String {
+    let bytes: Vec<u8> = buf
+        .iter()
+        .take_while(|&&c| c != 0)
+        .map(|&c| c as u8)
+        .collect();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// The no-syscall path: `/proc` carries the same two strings on Linux (verified
+/// equal to `uname -r` / `uname -n`), and `ARCH` is a build-time constant that
+/// matches `uname -m` for the targets mutsu ships.
+fn file_probe() -> HostInfo {
+    fn read_trimmed(path: &str) -> Option<String> {
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+    HostInfo {
+        release: read_trimmed("/proc/sys/kernel/osrelease").unwrap_or_default(),
+        machine: std::env::consts::ARCH.to_string(),
+        hostname: read_trimmed("/proc/sys/kernel/hostname")
+            .or_else(|| std::env::var("HOSTNAME").ok().filter(|s| !s.is_empty()))
+            .unwrap_or_default(),
+    }
+}
+
+#[cfg(all(
+    unix,
+    feature = "native",
+    not(miri),
+    not(target_arch = "wasm32"),
+    target_os = "macos"
+))]
+fn empty_probe() -> HostInfo {
+    HostInfo {
+        release: String::new(),
+        machine: std::env::consts::ARCH.to_string(),
+        hostname: String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_info;
+
+    /// The point of the module: the values must stay *correct*, not just cheap.
+    /// `roast/S02-magicals/KERNEL.t` requires every field to be truthy and
+    /// `roast/S32-io/IO-Socket-INET.t` matches `.release` against `/Microsoft/`
+    /// for WSL detection.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn host_info_matches_proc() {
+        let info = host_info();
+        let osrelease = std::fs::read_to_string("/proc/sys/kernel/osrelease").unwrap();
+        assert_eq!(info.release, osrelease.trim());
+        let hostname = std::fs::read_to_string("/proc/sys/kernel/hostname").unwrap();
+        assert_eq!(info.hostname, hostname.trim());
+        assert!(!info.machine.is_empty());
+    }
+
+    /// Cached: a second call must hand back the same static, not re-probe.
+    #[test]
+    fn host_info_is_cached() {
+        assert!(std::ptr::eq(host_info(), host_info()));
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -121,7 +121,10 @@ fn current_process_id() -> i64 {
 /// Get the local timezone offset in seconds (west-negative, east-positive).
 /// Returns 0 (UTC) on WASM or if the offset cannot be determined.
 pub(crate) fn local_timezone_offset_secs() -> i64 {
-    #[cfg(all(not(target_arch = "wasm32"), feature = "native"))]
+    // Miri cannot call a foreign function, so it takes the documented
+    // "offset could not be determined" arm below rather than aborting the
+    // interpreter it is trying to check.
+    #[cfg(all(not(target_arch = "wasm32"), not(miri), feature = "native"))]
     {
         // Use libc::localtime_r to retrieve the tm_gmtoff field which gives
         // the UTC offset in seconds for the current local timezone.
@@ -132,7 +135,7 @@ pub(crate) fn local_timezone_offset_secs() -> i64 {
             tm.tm_gmtoff
         }
     }
-    #[cfg(not(all(not(target_arch = "wasm32"), feature = "native")))]
+    #[cfg(not(all(not(target_arch = "wasm32"), not(miri), feature = "native")))]
     {
         0
     }
@@ -233,6 +236,7 @@ mod io_pod_entries;
 mod io_pod_heredoc;
 mod io_pod_table;
 mod io_sysinfo;
+mod io_sysinfo_host;
 mod io_sysinfo_vm_config;
 mod iterator_protocol;
 pub(crate) mod json;

--- a/todo/tickets/magic-vars-should-be-built-lazily.md
+++ b/todo/tickets/magic-vars-should-be-built-lazily.md
@@ -3,65 +3,60 @@
 Found 2026-08-02 while adding the Miri gate (ADR-0013 §4 phase 4): the gate's interpreter-level
 smoke tests could not run because `Interpreter::new()` spawns processes.
 
-## What happens today
+**Status 2026-08-03: slice 1 is done** (`src/runtime/io_sysinfo_host.rs`) — startup no longer forks
+at all on Linux, and the Miri blocker is gone (`gc::soundness_smoke` runs under Miri). Slice 2, the
+actual laziness, is still open; what remains is described below.
+
+## What still happens today
 
 `Interpreter::new()` → `init_io_environment` (`src/runtime/io_env.rs:86`) eagerly constructs
 `$*DISTRO`, `$*PERL`, `$*RAKU`, `$*VM` and `$*KERNEL` and hoists them into the process-global env
-base tier (`IMMUTABLE_BASE_DYNAMICS`, `src/runtime/mod.rs`). Constructing them **shells out**:
+base tier (`IMMUTABLE_BASE_DYNAMICS`, `src/runtime/mod.rs`). The remaining eager cost is:
 
-| site | spawns |
+| site | cost |
 | --- | --- |
-| `make_distro_instance` (linux arm), `src/runtime/io_sysinfo.rs:154` | `uname -r` |
-| `make_kernel_instance`, `io_sysinfo.rs:428` | `uname -r` **again**, via a second `OnceLock` |
-| `make_kernel_instance`, `io_sysinfo.rs:440` | `uname -m` |
-| `make_kernel_instance`, `io_sysinfo.rs:470` | `hostname` |
-| `make_distro_instance` (macos arm), `io_sysinfo.rs:116/122/128` | `sw_vers` ×3 |
+| `io_sysinfo_host::host_info()` | one cached `uname(2)` — cheap, but still paid when unread |
+| `make_distro_instance` (macos arm), `io_sysinfo.rs` | `sw_vers` ×3 — **still three `fork`/`exec`s** |
+| every `make_*_instance` | builds Instances, Versions, a 32-element signal array |
 
-So every `mutsu` invocation — including every `prove` test process and every `mzef` subprocess —
-pays three `fork`/`exec`s on Linux (four on macOS) for data that most programs never read. The
-project's headline metric is startup time (0.04× raku), which makes this the wrong place to be
-eager. The values are process constants, so they should be **delayed until first access and then
-cached**, which is what Rakudo effectively does.
+So macOS still pays three processes per `mutsu` start for data most programs never read, and every
+platform pays the instance construction. The project's headline metric is startup time (0.04× raku),
+which makes this the wrong place to be eager. The values are process constants, so they should be
+**delayed until first access and then cached**, which is what Rakudo effectively does.
 
-Note also the duplication: kernel release is fetched twice through two separate `OnceLock`s
-(`DISTRO_UNAME_R` and `UNAME_R`), which is a "1 operation = 1 implementation" violation on its own.
+Note that laziness subsumes the macOS problem: `sw_vers` only runs if the program actually reads
+`$*DISTRO`. Replacing it with a `SystemVersion.plist` read is the alternative, but it cannot be
+verified from this workspace (no macOS host), and the current shell-out is at least known-correct.
 
-## Why it blocks the Miri gate
+## What slice 1 fixed (2026-08-03)
 
-Miri cannot spawn a process (`unsupported operation: can't call foreign function
-`posix_spawnattr_init``), so `Interpreter::new()` aborts under Miri before reaching any container
-code. That is why `src/gc/soundness_smoke.rs`'s four tests — the ones that would let Miri watch the
-VM take an aliased `&mut` into a shared container node — are `#[cfg_attr(miri, ignore)]` today, and
-the gate currently covers the `Gc` primitive only. ADR-0013 §4 explicitly warned that a
-primitive-only Miri run "mostly re-proves std's `UnsafeCell` guarantee", so closing this ticket is
-what gives the gate its full value.
+`uname -r` (×2, through two separate `OnceLock`s), `uname -m` and `hostname` are gone, replaced by
+one cached `uname(2)` in `src/runtime/io_sysinfo_host.rs`; `hostname` was redundant all along
+(`uname -n` is the same string). Verified with `strace`: a `mutsu -e 'say 1'` start now shows only
+its own `execve` and the VM thread's `clone3`.
 
-(A second, smaller Miri blocker sits in `local_timezone_offset_secs()`, `src/runtime/mod.rs`: it
-calls `libc::time` / `libc::localtime_r`, which Miri also cannot call. Its existing contract already
-says "returns 0 if the offset cannot be determined", so extending that arm with `not(miri)` is a
-one-line fix to do at the same time.)
+The module's fallback arm reads `/proc/sys/kernel/{osrelease,hostname}` instead of calling the
+syscall, which is what Miri takes (it can read a file under `-Zmiri-disable-isolation`, but can
+neither spawn a process nor call a foreign function). `local_timezone_offset_secs()` got the same
+treatment — a `not(miri)` arm falling into its existing documented "offset unknown → 0" branch. With
+those two, a real `Interpreter` builds and runs under Miri, so `gc::soundness_smoke`'s five tests
+lost their `#[cfg_attr(miri, ignore)]` and the Miri job now covers the VM's real `gc_contents_mut`
+call sites, not just the `Gc` primitive.
 
-## Two slices, in order
+## Slice 2: delay construction (open)
 
-1. **Cheap and independent: stop shelling out at all.** Replace the `uname -r` / `uname -m` pair
-   with one `libc::uname(2)` call (one syscall, no fork) behind a single cached helper used by both
-   `make_distro_instance` and `make_kernel_instance`, and replace `hostname` with
-   `libc::gethostname`. This fixes the duplication and removes the fork/exec from startup even
-   before laziness lands. Keep the current shell-outs as the fallback for platforms without the
-   syscall, and give the `miri`/`wasm32` arm `/proc/sys/kernel/osrelease` +
-   `std::env::consts::ARCH` (verified equal to `uname -r` on Linux).
-2. **The real fix: delay construction.** Do not build these instances in `init_io_environment`;
-   materialize on first read and cache. The awkward part is *where* the hook goes: these live in the
-   process-global base tier (`crate::env::set_global_base`, a `OnceLock` set once at startup), and
-   env lookup falls overlay → parent chain → base tier with no miss hook. Either give the base tier
-   a lazy-materialization entry point, or leave the names out of it and let the dynamic-var read
-   path (`get_dynamic_handle` and the VM's dynamic read) construct-and-insert on demand. Whichever
-   is chosen, the cache must stay process-wide so repeated reads do not re-run the syscalls, and it
-   must be safe under the threaded lanes that share the base tier.
+Do not build these instances in `init_io_environment`; materialize on first read and cache. The
+awkward part is *where* the hook goes: these live in the process-global base tier
+(`crate::env::set_global_base`, a `OnceLock` set once at startup), and env lookup falls overlay →
+parent chain → base tier with no miss hook. Either give the base tier a lazy-materialization entry
+point, or leave the names out of it and let the dynamic-var read path (`get_dynamic_handle` and the
+VM's dynamic read) construct-and-insert on demand. Whichever is chosen, the cache must stay
+process-wide so repeated reads do not re-run the work, and it must be safe under the threaded lanes
+that share the base tier.
 
 ## Pins
 
 `roast/S02-magicals/KERNEL.t` and `DISTRO.t` require every field to be truthy, and
 `roast/S32-io/IO-Socket-INET.t:337` matches `$*KERNEL.release` against `/Microsoft/` for WSL
 detection — so the data must stay correct, not just cheap. `t/base-tier-magic-vars.t` pins the
-base-tier hoisting itself.
+base-tier hoisting itself, and `io_sysinfo_host`'s unit test pins the probed values against `/proc`.


### PR DESCRIPTION
## What

`$*KERNEL` and `$*DISTRO` were built eagerly at every startup, and building them **shelled out**: `uname -r` (twice, through two separate `OnceLock`s in two different functions), `uname -m`, and `hostname`. Every `mutsu` invocation — including every `prove` test process and every `mzef` subprocess — paid three `fork`/`exec` pairs for data most programs never read.

`runtime::io_sysinfo_host` replaces all of it with a single cached `uname(2)`. The struct already carries every field that was being fetched separately: `release`, `machine`, and `nodename` — the same string the `hostname` command prints, so the duplication disappears along with the subprocesses.

Verified with `strace`: a `mutsu -e 'say 1'` start now issues only its own `execve` and the VM thread's `clone3`, where it previously spawned three subprocesses.

## Why it also unblocks the Miri gate

ADR-0013 §4 phase 4's Miri job could only run the `Gc` primitive tests. The five interpreter-level tests in `src/gc/soundness_smoke.rs` — the ones that make a *real* `Interpreter` execute Raku so Miri watches the actual `gc_contents_mut` sites — were `#[cfg_attr(miri, ignore)]`, because Miri cannot spawn a process and `Interpreter::new()` therefore aborted before reaching any container code. The ADR itself warned a primitive-only run "mostly re-proves std's `UnsafeCell` guarantee".

The module's fallback arm — the one `cfg(miri)` selects — reads `/proc/sys/kernel/{osrelease,hostname}` and takes the architecture from `std::env::consts::ARCH`, all verified equal to the `uname` output on Linux (Miri can read a file under `-Zmiri-disable-isolation`, it just cannot fork or call a foreign function). `local_timezone_offset_secs()` gets the same treatment: a `not(miri)` arm falling into its already-documented "offset could not be determined → 0" branch.

With those two, a real `Interpreter` builds and runs under Miri. The five smoke tests lose their `cfg_attr` and pass (measured locally: 5 passed, ~245s of interpretation).

## Two CI steps, because only one half can be leak-checked

The Miri job now runs the subset in two steps. The primitives keep Miri's leak check **on** — a `Gc` node outliving its test is a collector bug worth failing for. The interpreter-level step adds `-Zmiri-ignore-leaks`, which is **not** a loosening of the gate: a whole interpreter intentionally leaves memory live at exit (process-lifetime statics such as the env base tier and interned symbols, plus uncollected reference cycles — precisely what the cycle collector reclaims on demand rather than at teardown), and those reports would drown the provenance errors the job exists to catch. Aliasing/provenance checking is unaffected by the flag.

The stale note about the `Mixin` overrides map being "still `Arc`-backed" is dropped — #5771 made it a `Gc<MixinOverrides>` node, and `a_mixin_rename_is_visible_through_an_alias` now covers it under Miri.

## Correctness

The values are unchanged, which is the part that matters:

- `roast/S02-magicals/KERNEL.t` and `DISTRO.t` require every field to be truthy — both pass.
- `roast/S32-io/IO-Socket-INET.t` matches `$*KERNEL.release` against `/Microsoft/` for WSL detection.
- A unit test pins the probed values against `/proc/sys/kernel/{osrelease,hostname}`, and a second pins the caching.
- `make test`: PASS.

## What is left open

The deeper half of `todo/tickets/magic-vars-should-be-built-lazily.md` (updated here): these instances should be built on **first access**, not at startup at all. macOS still runs `sw_vers` three times per start, and laziness — not another syscall substitution — is the fix, since a program that never reads `$*DISTRO` should pay nothing. The awkward part is that the values live in the process-global env base tier, which has no miss hook; the ticket records the two candidate designs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)