### PR TITLE
vm: close precise gather sync gaps

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2431,8 +2431,21 @@ impl CompiledCode {
         let Some(cc) = self.closure_compiled_codes.get(cc_idx as usize) else {
             return;
         };
-        for slot in cc.free_var_parent_slots.iter().flatten() {
-            if let Some(needed) = slots.get_mut(*slot as usize) {
+        for (idx, sym) in cc.free_var_syms.iter().enumerate() {
+            // A self-referential stored body can be analyzed while its binding
+            // initializer is still being compiled (`my @a := gather { ... @a
+            // ... }`), leaving the baked parent slot absent even though the
+            // declaration slot is already present in this frame. Resolve that
+            // exact same-name slot here; it is still a per-consumer slot, not a
+            // frame-wide fallback.
+            let slot = cc
+                .free_var_parent_slots
+                .get(idx)
+                .copied()
+                .flatten()
+                .map(|slot| slot as usize)
+                .or_else(|| sym.with_str(|name| self.locals.iter().rposition(|n| n == name)));
+            if let Some(needed) = slot.and_then(|slot| slots.get_mut(slot)) {
                 *needed = true;
             }
         }

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -263,6 +263,10 @@ impl Interpreter {
         self.gather_items.pop()
     }
 
+    pub(crate) fn current_gather_items(&self) -> Vec<Value> {
+        self.gather_items.last().cloned().unwrap_or_default()
+    }
+
     pub(crate) fn push_gather_take_limit(&mut self, limit: Option<usize>) {
         self.gather_take_limits.push(limit);
     }

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1105,7 +1105,9 @@ impl Interpreter {
                     // this broad writeback path even when the authoritative
                     // binding was only read; never replay that installed value
                     // into the ambient caller env on return.
-                    && !data.authoritative_captures.contains(k)
+                    && (!data.authoritative_captures.contains(k)
+                        || cc.free_var_writes.contains(k)
+                        || cc.free_var_container_writes.contains(k))
                     && (restored_env.contains_key_sym(*k)
                         || captured_names.contains(k)
                         || (meta_possible

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -556,6 +556,20 @@ impl Interpreter {
                     *ip += 1;
                     return Ok(());
                 }
+                // A `:=`-bound gather may read the array currently being
+                // produced. MakeGather tags that exact self-reference; expose
+                // the live take collector instead of recursively forcing the
+                // LazyList (or reading its pre-declaration env snapshot).
+                if self
+                    .env()
+                    .get(&format!("__mutsu_gather_self_ref::{name}"))
+                    .is_some()
+                {
+                    self.stack
+                        .push(Value::real_array(self.current_gather_items()));
+                    *ip += 1;
+                    return Ok(());
+                }
                 let val = self
                     .get_env_with_main_alias(name)
                     .or_else(|| self.get_local_by_bare_name(code, name))

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -81,6 +81,31 @@ impl Interpreter {
             self.box_captured_lexicals(code, &analysis_cc);
             let mut env = self.env().clone();
             env.insert("__mutsu_lazylist_from_gather".to_string(), Value::TRUE);
+            // A forward aggregate free var with no baked parent slot is the
+            // self-reference in a binding initializer (`my @a := gather {
+            // ... @a ... }`). Tag it before the LazyList is built; GetArrayVar
+            // then exposes the live take collector while this gather is being
+            // forced, instead of reading the pre-declaration Any snapshot.
+            if let Some(analysis) = &analysis_cc {
+                for (i, sym) in analysis.free_var_syms.iter().enumerate() {
+                    let has_baked_slot = analysis
+                        .free_var_parent_slots
+                        .get(i)
+                        .copied()
+                        .flatten()
+                        .is_some();
+                    let is_forward_aggregate = !has_baked_slot
+                        && sym.with_str(|name| {
+                            (name.starts_with('@') || name.starts_with('%'))
+                                && code.locals.iter().any(|local| local == name)
+                        });
+                    if is_forward_aggregate {
+                        sym.with_str(|name| {
+                            env.insert(format!("__mutsu_gather_self_ref::{name}"), Value::TRUE);
+                        });
+                    }
+                }
+            }
             // Compile the gather body to bytecode for Interpreter-native forcing.
             // A `sub` declared in the body is lexical to it, so compile through a
             // `Stmt::Block` (whose `BlockScope` restores the routine registry) when there

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -470,11 +470,19 @@ impl Interpreter {
     fn sync_state_locals(&mut self, code: &CompiledCode) {
         for (slot, key) in &code.state_locals {
             let local_name = &code.locals[*slot];
-            let val = self
-                .env()
-                .get(local_name)
-                .cloned()
-                .unwrap_or_else(|| self.locals[*slot].clone());
+            // A slot-only state local has no current env mirror under the
+            // precise-sync regime; an older declaration seed may still be
+            // present there.  Persist the authoritative slot in that case.
+            // Name-based consumers are folded into `needs_env_sync` and retain
+            // the env-first path for their out-of-slot mutations.
+            let val = if code.needs_env_sync.get(*slot).copied().unwrap_or(true) {
+                self.env()
+                    .get(local_name)
+                    .cloned()
+                    .unwrap_or_else(|| self.locals[*slot].clone())
+            } else {
+                self.locals[*slot].clone()
+            };
             let scoped_key = self.scoped_state_key(key);
             self.set_state_var(scoped_key, val);
         }

--- a/t/scoped-overlay-gather.t
+++ b/t/scoped-overlay-gather.t
@@ -7,7 +7,7 @@ use Test;
 # runs under a scoped overlay whose parent is the gather's captured env; its
 # writes land in the overlay and side effects on captured/outer vars propagate.
 
-plan 10;
+plan 11;
 
 # --- basic gather ---
 my @g = gather { take $_ * 2 for 1..5 };
@@ -18,6 +18,14 @@ my $count = 0;
 my @h = gather { for 1..3 { $count++; take $count } };
 is @h.List, (1, 2, 3), 'gather body sees mutated captured var';
 is $count, 3, 'captured var mutation persists after gather force';
+
+my @dups = 1, 2, 2, 3, 3, 3;
+my @uniq = gather for @dups {
+    state $previous = take $_;
+    next if $_ === $previous;
+    $previous = take $_;
+}
+is @uniq, (1, 2, 3), 'gather for preserves a state lexical across iterations';
 
 # --- lazy gather + slice forces the coroutine path ---
 my @lazy = lazy gather { my $i = 0; loop { take $i++ } };


### PR DESCRIPTION
## Problem
Removing the frame-wide env-sync blanket exposed two gather-specific dependencies: slot-only `state` persistence read a stale env seed, and a forward/self-referential bound gather (`my @a := gather { ... @a ... }`) had no baked parent slot or live prefix view. The previous authoritative-capture cleanup also needed to preserve genuine free-var writes.

## Approach
- Persist slot-only state variables from their authoritative local slot.
- Resolve missing stored-body parent slots by exact same-name slot identity.
- Tag forward aggregate gather self-references and expose the live take prefix in `GetArrayVar`.
- Exclude only read-only authoritative installs; retain actual free-var/container writes.

## Tests
- focused TAP + full `roast/S04-statements/gather.t`: 59 tests
- same 59 tests with GC verification
- same 59 tests with JIT threshold 2
- `cargo clippy -- -D warnings`
- `cargo fmt --all`