### PR TITLE
fix(strict): a declared binding is not an undeclared write

### DIFF
--- a/news/2026-08/strict-does-not-reject-a-declared-bind.md
+++ b/news/2026-08/strict-does-not-reject-a-declared-bind.md
@@ -1,0 +1,33 @@
+# `use strict` no longer rejects two forms of declared binding
+
+`use strict` decides "is this variable declared?" at the `SetGlobal` opcode by
+asking whether `env` holds the name. Two declarations do not put their name in
+`env` at all, so writing them was reported as a write to an undeclared variable:
+
+- **A multi-parameter `for` head.** `for %h.kv -> $k, $v { … }` desugars to two
+  plain assignments at the top of the loop body (`build_for_bind_stmts`); a
+  single-parameter head is bound by the `ForLoop` opcode itself, which is why
+  only the multi-parameter form failed. Every sigil was affected —
+  `for @pairs -> @x, @y` died the same way.
+- **A module's own file-scope `my`, written from a routine two frames deep.**
+  Since `news/2026-08/module-file-scope-lexical-is-not-the-callers.md` such a
+  scalar lives in the compunit-lexical store rather than under an `env` key, so
+  the `env`-only test cannot see it. The write itself already went to the right
+  place; only the declaration check disagreed.
+
+Both are now exempt: the compiler records a multi-parameter loop head's names in
+`CompiledCode::param_bind_names` (compile-time data, consulted only on the cold
+strict path, so no extra opcode runs per iteration), and the check consults the
+compunit-lexical store through `has_unit_scope_lexical` before deciding a name
+is undeclared. An undeclared write is still rejected, and loop parameters are
+still block-scoped.
+
+Found under `MUTSU_REAL_TEST=1`, where both bugs fire at once:
+`roast/S02-names/strict.t` and `roast/S02-lexical-conventions/comments.t` aborted
+mid-file with `Variable '$time_after' is not declared` raised *inside*
+`Test.rakumod`'s own `_diag` — `$time_after` being the module's file-scope `my
+int`, reached from `throws-like` → `subtest` → `_diag`, while the test file's own
+`use strict` block was in effect. `strict.t` now passes all 7 tests under the
+real module; `comments.t` runs its full plan of 51 instead of aborting at 3.
+
+Pin: `t/strict-declared-bind-forms.t` (with `t/lib/StrictNestedLexical.rakumod`).

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1938,6 +1938,14 @@ impl Compiler {
                 let mut bind_prefix: Vec<Stmt> = Vec::new();
                 if !bind_stmts.is_empty() {
                     bind_prefix = bind_stmts;
+                    // The loop signature DECLARES these names; the binds below are
+                    // plain assignments, so record them for `use strict` (see
+                    // `CompiledCode::param_bind_names`).
+                    for p in params {
+                        if !self.code.param_bind_names.contains(p) {
+                            self.code.param_bind_names.push(p.clone());
+                        }
+                    }
                     // After binding multi-param variables, mark them readonly
                     // (unless the block uses `<->` or `is rw`).
                     // Skip @-sigil and %-sigil params: they bind to a mutable

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1837,6 +1837,17 @@ pub(crate) struct CompiledCode {
     /// Maps local slot indices to qualified package names for `our` variables.
     /// Used by BlockScope restoration to sync local slots from their global values.
     pub(crate) our_locals: Vec<(usize, String)>,
+    /// Names this chunk *binds as parameters* through a by-name store rather than
+    /// a local slot — today the multi-parameter `for` head (`for %h.kv -> $k, $v`),
+    /// whose binds the compiler desugars to plain assignments at the top of the
+    /// loop body (`build_for_bind_stmts`).
+    ///
+    /// Such a name is declared by the loop signature, but nothing in the emitted
+    /// `SetGlobal` says so, which made `use strict` reject the bind itself as a
+    /// write to an undeclared variable. Recorded here (compile-time data, read
+    /// only on the cold strict-check path) instead of spending an extra opcode
+    /// per parameter per iteration to carry the fact at runtime.
+    pub(crate) param_bind_names: Vec<String>,
     /// Scalar locals declared with a `:=` bind (`my $x := EXPR`). Such a binding
     /// is immutable — the local is never reassigned — so its captured snapshot in
     /// a closure can never go stale, even when the local is also handed to a call
@@ -2314,6 +2325,7 @@ impl CompiledCode {
             plain_locals: Vec::new(),
             state_locals: Vec::new(),
             our_locals: Vec::new(),
+            param_bind_names: Vec::new(),
             scalar_bind_locals: Vec::new(),
             param_local_slots: Vec::new(),
             lex_scopes: Vec::new(),

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -416,6 +416,18 @@ impl Interpreter {
         None
     }
 
+    /// True when `name` resolves to a file-scope lexical of the compunit the
+    /// running routine belongs to — the non-cloning predicate form of
+    /// [`Self::unit_scope_lexical`].
+    ///
+    /// `use strict` needs this: such a name is declared, but its home is this
+    /// store rather than `env` (that is the whole point of the store), so an
+    /// `env`-only "is it declared?" test rejects a module writing its own
+    /// file-scope `my` from any frame that does not also carry it in `env`.
+    pub(super) fn has_unit_scope_lexical(&self, name: &str) -> bool {
+        self.unit_lexical_slot(name).is_some()
+    }
+
     /// True when `name` is a file-scope lexical of `pkg`'s own compunit.
     ///
     /// A routine of that compunit writing such a name is writing its module's own

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -915,12 +915,19 @@ impl Interpreter {
                 // (an expression-position `my` — `ok my $x = 7, 'desc'` — compiles
                 // to MarkVarDeclContext + SetGlobal when no local slot exists), so
                 // `use strict` must not reject it as an undeclared write.
+                // A file-scope `my` of the running routine's own compunit lives in
+                // `unit_lexicals`, not `env` (that is the store's purpose — see
+                // `unit_scope_lexical`), so an `env`-only test reports a module
+                // writing its own module-level lexical as undeclared. It is
+                // declared; the write below goes to the same store.
                 if self.strict_mode
                     && !self.vardecl_context
                     && !is_attr_twigil
                     && !is_internal_temp
                     && !name.contains("::")
                     && !self.env().contains_key(&name)
+                    && !self.has_unit_scope_lexical(&name)
+                    && !code.param_bind_names.iter().any(|n| n == &name)
                 {
                     return Err(self.strict_undeclared_error(&name));
                 }

--- a/t/lib/StrictNestedLexical.rakumod
+++ b/t/lib/StrictNestedLexical.rakumod
@@ -1,0 +1,11 @@
+unit module StrictNestedLexical;
+
+# A file-scope lexical of this compunit: it lives in the compunit-lexical store,
+# not in the loading scope's `env`.
+my $counter = 0;
+
+sub inner() { $counter = $counter + 1 }
+
+# Two levels deep: `inner` is reached from another routine of this module, not
+# from the script, which is what used to lose the declaration.
+sub bump() is export { inner(); $counter }

--- a/t/strict-declared-bind-forms.t
+++ b/t/strict-declared-bind-forms.t
@@ -1,0 +1,51 @@
+use Test;
+use lib 't/lib';
+
+plan 7;
+
+# `use strict` must not reject a write to a name that IS declared, but whose
+# declaration the by-name store cannot see.
+
+# 1-3: a multi-parameter `for` head declares its parameters. The binds are
+# desugared to plain assignments at the top of the loop body, so nothing in the
+# emitted store said "this is a declaration".
+{
+    use strict;
+
+    my %h = a => 1;
+    my @seen;
+    for %h.kv -> $k, $v { @seen.push("$k=$v") }
+    is @seen.join(','), 'a=1', 'scalar multi-param for head binds under strict';
+
+    my @pairs = [1, 2], [3, 4];
+    my @firsts;
+    for @pairs -> @x, @y { @firsts.push(@x[0] ~ @y[0]) }
+    is @firsts.join(','), '13', 'array multi-param for head binds under strict';
+
+    my @flat = 1, 2, 3, 4;
+    my $sum = 0;
+    for @flat -> $a, $b { $sum += $a * $b }
+    is $sum, 14, 'flat list consumed two at a time under strict';
+}
+
+# 4-5: the loop parameters are still block-scoped, and an undeclared write
+# elsewhere is still rejected.
+{
+    use strict;
+    my $k = 'outer';
+    my @a = 1, 2;
+    for @a -> $k, $v { }
+    is $k, 'outer', 'for parameters do not clobber a same-named outer lexical';
+    throws-like '{ use strict; $totally_undeclared = 1 }', X::Undeclared,
+        'an undeclared write is still rejected under strict';
+}
+
+# 6-7: a module routine writing its own file-scope `my`, reached two frames
+# deep, while the *caller* is strict. The lexical lives in the compunit store
+# rather than the caller's env, so an env-only declaration test rejected it.
+use StrictNestedLexical;
+{
+    use strict;
+    is bump(), 1, 'module routine writes its own file-scope lexical under strict';
+    is bump(), 2, 'and the write lands in the module lexical';
+}


### PR DESCRIPTION
`use strict` decides "is this variable declared?" at the `SetGlobal` opcode by asking whether `env` holds the name. Two declarations do not put their name in `env` at all, so writing them was reported as a write to an undeclared variable:

- **A multi-parameter `for` head.** `for %h.kv -> $k, $v { … }` desugars to two plain assignments at the top of the loop body (`build_for_bind_stmts`); a single-parameter head is bound by the `ForLoop` opcode itself, which is why only the multi-parameter form failed. Every sigil was affected — `for @pairs -> @x, @y` died the same way.

  ```
  $ mutsu -e 'use strict; my %h = a => 1; for %h.kv -> $k, $v { say "$k $v" }'
  X::Undeclared: Variable '$k' is not declared. Did you mean 'K'?
  ```

- **A module's own file-scope `my`, written from a routine two frames deep.** Since `news/2026-08/module-file-scope-lexical-is-not-the-callers.md` such a scalar lives in the compunit-lexical store rather than under an `env` key, so the `env`-only test cannot see it. The write itself already went to the right place; only the declaration check disagreed.

## Fix

The compiler records a multi-parameter loop head's names in `CompiledCode::param_bind_names` — compile-time data, consulted only on the cold strict path, so no extra opcode runs per parameter per iteration — and the check consults the compunit-lexical store through `has_unit_scope_lexical` before deciding a name is undeclared. An undeclared write is still rejected and loop parameters are still block-scoped (both pinned).

## How it was found

Under `MUTSU_REAL_TEST=1` both bugs fire at once inside the real `Test.rakumod`: `_diag` writes the module's file-scope `my int $time_after`, reached from `throws-like` → `subtest`, while the test file's own `use strict` block is in effect. `roast/S02-names/strict.t` and `roast/S02-lexical-conventions/comments.t` aborted mid-file with `Variable '$time_after' is not declared` raised *inside* the module. `strict.t` now passes all 7 tests under the real module; `comments.t` runs its full plan of 51 instead of aborting at 3 (its remaining 4 failures are an unrelated exception-class gap).

## Testing

- `t/strict-declared-bind-forms.t` (new, with `t/lib/StrictNestedLexical.rakumod`) — byte-identical output under `raku`
- `make test`: `Files=2786, Tests=26498 ... Result: PASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)