### PR TITLE
test(gc): pin the borrow shapes call sites perform across an aliased write

### DIFF
--- a/news/2026-08/gc-contents-mut-borrow-audit.md
+++ b/news/2026-08/gc-contents-mut-borrow-audit.md
@@ -1,0 +1,68 @@
+# The `gc_contents_mut` borrow audit: 60 of 62 sites cleared, and the rule turns out to be about order
+
+`gc::gc_contents_mut` is the codebase's single aliased-container-write primitive, and it takes
+`&Gc<T>` while returning `&mut T`. That signature means the borrow checker offers **nothing** at its
+62 call sites: keeping a `Deref`'d `&T` alive across the write compiles fine, and it is the one
+failure mode Miri actually catches. `todo/deep/adr-0013-unsafecell-does-not-license-live-shared-borrows.md`
+had asked for an audit of whether any site does that; it was blocked until `gc::soundness_smoke`
+could run under Miri, which it now can.
+
+## Narrowing first, reading second
+
+A site whose `Gc` argument is never mentioned again inside its own block cannot hold a borrow across
+the write and is clear by construction. That is 38 of the 62 outright. Of the rest, most turned out
+to be artifacts of how the code reads: the later mention is the `&mut`'s own field where the
+variable happens to share its name (`data.items` where the argument is also `items`), or it is
+`Gc::make_mut` on the *other* branch of the same aliased-vs-unique `if`.
+
+What remained was a genuine question the whole audit turned on: which operations touch the payload
+and which touch only the `GcBox` header? Real call sites do all of these with the `&mut` still live —
+`fixup_circular_array_refs` holds a `&mut ArrayData` across `result_arc.clone()` *and* across
+passing `&result_arc` to a recursive helper.
+
+## Measuring instead of reasoning
+
+Reasoning says `Gc::clone` bumps `header.strong`, `as_ptr` projects through the `UnsafeCell` with
+`raw_get`, and the counts live in the header, so none of them dereference the payload. But
+"reasoning says" is exactly what the ADR-0013 over-promise was. `src/gc/borrow_shapes.rs` pins it
+instead — probes that fail the moment one of those operations starts going through `Deref`:
+
+| shape | verdict |
+| --- | --- |
+| `Gc::clone` of the same node while the `&mut` is live (self-reference build) | sound |
+| `Gc::as_ptr` while the `&mut` is live (identity comparison) | sound |
+| `Gc::strong_count` / `Gc::ptr_eq` while the `&mut` is live (the routing decision) | sound |
+| whole-payload overwrite whose replacement carries a handle to the node being overwritten | sound |
+| raw pointer derived from the `&mut`, **then** a `Deref` read, **then** a write through the pointer | sound |
+| `&T` Deref'd **before** the write and **used after** it | **UB**, both models |
+
+The last two rows are the same two operations in the two possible orders, and only one order is
+sound. A raw pointer derived first sits *below* a later shared read on the borrow stack, so the read
+pushes above it rather than popping it; a `&T` taken first is popped by the write. So the obligation
+at a call site is not "never touch the node" — it is: **anything carried across the write must be a
+raw pointer or a handle-level operation, and a `Deref`'d `&T` must not be used after it.**
+
+The UB row is deliberately not a test. A test that triggers UB fails the gate rather than
+documenting it, so it lives in the todo file's measurement table; the sound rows are what run in CI.
+
+## Result
+
+No site was found holding a `Deref`'d borrow across its write. Sixty of sixty-two are clear.
+
+The remaining two are `nativecall.rs`'s `marshal_arg` (`CType::Buf`) and `marshal_carray_arg`, the
+only family that lets a pointer derived from the `&mut` outlive the call — it is handed to C and the
+node is retained beside it, so the derived tag must survive an arbitrary window of C-side writes. By
+the table that shape is sound, and it stores only the node and the pointer, never a reference. But
+the Miri job drops FFI on purpose (`--no-default-features --features native`), so the real path can
+never be checked; `nativecall_shape_raw_pointer_survives_a_later_deref` is its stand-in and should
+not be deleted as "not a real call site". Re-examine if that struct ever grows a borrow.
+
+The probes run in the Miri job's first step, which keeps the leak check ON — so the two
+self-referential probes sever their own edge before returning rather than leaving the collector a
+cycle to reclaim.
+
+What is still owed is the ADR-0013 §8 note. The primitive's own doc comment currently repeats the
+over-promise ("valid provenance **even while shared `&` reads via `Deref` are live**") one paragraph
+above a `# Safety` clause that says the opposite — and the measurements back the Safety clause. That
+sentence is what a future call site would read before deciding it may keep a borrow, so the doc fix
+and the ADR note belong together.

--- a/src/gc/borrow_shapes.rs
+++ b/src/gc/borrow_shapes.rs
@@ -1,0 +1,185 @@
+//! Miri-checked probes for the handle operations call sites perform **while a
+//! `gc_contents_mut` `&mut` is live**.
+//!
+//! # Why this module exists
+//!
+//! [`crate::gc::gc_contents_mut`] takes `&Gc<T>` and returns `&mut T`, so the
+//! borrow checker offers **no** protection at its ~62 call sites: keeping a
+//! Deref'd `&T` alive across the write compiles fine and is the one failure mode
+//! Miri actually catches (see
+//! `todo/deep/adr-0013-unsafecell-does-not-license-live-shared-borrows.md`).
+//!
+//! Auditing those sites by hand turns almost entirely on one question: which
+//! operations touch the *payload* and which touch only the `GcBox` header? Real
+//! call sites do all of the following with the `&mut` still live — e.g.
+//! `fixup_circular_array_refs` holds `data: &mut ArrayData` across
+//! `result_arc.clone()` and across passing `&result_arc` to a recursive helper:
+//!
+//! - `Gc::clone` (build a self-reference into the node being written)
+//! - `Gc::as_ptr` (identity comparison against another node)
+//! - `Gc::strong_count` / `Gc::ptr_eq` (the aliased-vs-unique routing decision)
+//!
+//! Reasoning says none of them dereference the payload — `clone` bumps
+//! `header.strong`, `as_ptr` projects through the `UnsafeCell` with
+//! `raw_get`, and the counts live in the header. But "reasoning says" is exactly
+//! what the ADR-0013 over-promise was, so pin it instead: these probes fail
+//! under Miri the moment one of those operations starts going through `Deref`.
+//! That is what lets the audit clear a whole family of call sites mechanically
+//! rather than one careful read at a time.
+//!
+//! A `Deref` **is** a payload access, and holding one across the write is UB —
+//! that shape is deliberately absent here, because a test that triggers UB fails
+//! the gate rather than documenting it. It is recorded in the todo file instead.
+
+#[cfg(test)]
+mod tests {
+    use crate::gc::{ErasedGc, Gc, Trace, gc_contents_mut};
+
+    /// Payload with an edge, so a probe can store a handle to the very node it
+    /// is writing (the self-reference shape `fixup_circular_array_refs` builds).
+    #[derive(Clone)]
+    struct Node {
+        value: i64,
+        edge: Option<Gc<Node>>,
+    }
+
+    impl Trace for Node {
+        fn trace(&self, visit: &mut dyn FnMut(&ErasedGc)) {
+            if let Some(e) = &self.edge {
+                visit(&e.erased());
+            }
+        }
+    }
+
+    fn node(value: i64) -> Gc<Node> {
+        Gc::new(Node { value, edge: None })
+    }
+
+    /// Drop a probe's self-edge before the handle goes out of scope. A
+    /// self-referential node is exactly what the cycle collector exists to
+    /// reclaim, so leaving one alive would make these tests leak — and this
+    /// module runs in the Miri step that keeps the leak check ON (the
+    /// interpreter-level step is the one that must disable it). Severing the
+    /// edge here keeps that check meaningful for the primitive.
+    fn break_cycle(gc: &Gc<Node>) {
+        // SAFETY: no borrow into the payload is live across this write.
+        unsafe { gc_contents_mut(gc) }.edge = None;
+    }
+
+    /// `Gc::clone` while the aliased `&mut` is live. This is the self-reference
+    /// build: the handle produced by the clone is stored *into* the node the
+    /// `&mut` points at.
+    #[test]
+    fn cloning_the_handle_while_the_aliased_mut_is_live() {
+        let gc = node(1);
+        // SAFETY: the probe's whole point is that nothing below dereferences the
+        // payload through another borrow while this `&mut` is live.
+        let data = unsafe { gc_contents_mut(&gc) };
+        data.edge = Some(gc.clone());
+        data.value = 7;
+        assert_eq!(gc.value, 7);
+        assert_eq!(
+            gc.edge.as_ref().unwrap().value,
+            7,
+            "the edge is the node itself"
+        );
+        break_cycle(&gc);
+    }
+
+    /// `Gc::as_ptr` while the aliased `&mut` is live — the identity comparison
+    /// the circular-reference fixups run against every element.
+    #[test]
+    fn taking_as_ptr_while_the_aliased_mut_is_live() {
+        let gc = node(1);
+        let other = node(2);
+        // SAFETY: as above.
+        let data = unsafe { gc_contents_mut(&gc) };
+        let same = Gc::as_ptr(&gc) as usize;
+        let different = Gc::as_ptr(&other) as usize;
+        assert_ne!(same, different);
+        data.value = 7;
+        assert_eq!(gc.value, 7);
+    }
+
+    /// `strong_count` / `ptr_eq` while the aliased `&mut` is live — the routing
+    /// decision `gc_data_mut` and its inlined copies make.
+    #[test]
+    fn reading_the_counts_while_the_aliased_mut_is_live() {
+        let gc = node(1);
+        let alias = gc.clone();
+        // SAFETY: as above.
+        let data = unsafe { gc_contents_mut(&gc) };
+        assert_eq!(Gc::strong_count(&gc), 2);
+        assert!(Gc::ptr_eq(&gc, &alias));
+        data.value = 7;
+        assert_eq!(
+            alias.value, 7,
+            "the shared write is visible through the alias"
+        );
+    }
+
+    /// Payload with a byte buffer, for the FFI-marshalling shape below.
+    #[derive(Clone)]
+    struct BufNode {
+        value: i64,
+        bytes: Vec<u8>,
+    }
+    impl Trace for BufNode {
+        fn trace(&self, _visit: &mut dyn FnMut(&ErasedGc)) {}
+    }
+
+    /// The one structurally different call-site family: `nativecall`'s
+    /// `marshal_arg` (`CType::Buf`) derives a raw pointer *from* the `&mut`,
+    /// hands it to C, and retains the node next to it — so the derived tag has
+    /// to survive an arbitrary window in which the Raku object may be read.
+    ///
+    /// This is the shape that makes the derivation ORDER load-bearing. Measured
+    /// on the pinned toolchain: taking a `&T` **before** the write and using it
+    /// **after** is UB under both Stacked and Tree Borrows, but deriving a raw
+    /// pointer first and reading through `Deref` afterwards is fine — the read
+    /// pushes above the pointer's tag rather than popping it. Reverse the two
+    /// and this becomes the UB case.
+    ///
+    /// The Miri job runs `--no-default-features --features native` to drop FFI,
+    /// so the real `nativecall` path can never be checked directly. This probe
+    /// is the stand-in for it; do not delete it as "not a real call site".
+    #[test]
+    fn nativecall_shape_raw_pointer_survives_a_later_deref() {
+        let gc = Gc::new(BufNode {
+            value: 1,
+            bytes: vec![0u8; 4],
+        });
+        // `marshal_arg`'s CType::Buf arm: derive a raw pointer FROM the `&mut`
+        // and hand it to C, retaining the node next to it.
+        let ptr = unsafe { gc_contents_mut(&gc) }.bytes.as_mut_ptr();
+        // Anything that reads the Raku object during the FFI call Derefs the
+        // node -- a `&T` over the payload.
+        let observed = gc.value;
+        assert_eq!(observed, 1);
+        // C writes through the retained pointer.
+        unsafe { *ptr = 42 };
+        assert_eq!(gc.bytes[0], 42);
+    }
+
+    /// Whole-struct overwrite (`*gc_contents_mut(&x) = new`) where the
+    /// replacement carries a handle to the very node being overwritten — the
+    /// `quanthash_store_preserving_identity` / `array_inplace_reassign` shape.
+    /// The old contents are dropped while a live handle to the node exists, so
+    /// this also checks that dropping the outgoing edge does not free the node
+    /// out from under the write.
+    #[test]
+    fn overwriting_the_whole_payload_with_a_self_referential_value() {
+        let gc = node(1);
+        // Seed an outgoing edge so the overwrite has something to drop.
+        unsafe { gc_contents_mut(&gc) }.edge = Some(node(2));
+        let replacement = Node {
+            value: 7,
+            edge: Some(gc.clone()),
+        };
+        // SAFETY: no borrow into the payload is live across the write.
+        unsafe { *gc_contents_mut(&gc) = replacement };
+        assert_eq!(gc.value, 7);
+        assert_eq!(gc.edge.as_ref().unwrap().value, 7);
+        break_cycle(&gc);
+    }
+}

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -18,6 +18,8 @@
 //!   `Value` reachable from execution state (§11 steps 1-2; verification /
 //!   future tracing infra — the candidate-buffer collector does not consume it).
 
+#[cfg(test)]
+mod borrow_shapes;
 mod collect;
 mod gc_ptr;
 mod root_visitor;

--- a/todo/deep/adr-0013-unsafecell-does-not-license-live-shared-borrows.md
+++ b/todo/deep/adr-0013-unsafecell-does-not-license-live-shared-borrows.md
@@ -86,19 +86,48 @@ below says the opposite and is the accurate one ("no other `&`/`&mut` into this 
 clause. This sentence is load-bearing in the wrong direction: it is what a future call site would
 read before deciding it may keep a borrow. Fix it with the ADR §8 note.
 
-**Finding 2 — the escaping-raw-pointer family is the fragile one, and Miri cannot see it.**
-`src/runtime/nativecall.rs` (`marshal_arg`'s `CType::Buf` arm and `marshal_carray_arg`) derives a
-raw `data_ptr` *from* the `&mut` and hands it to C, retaining the node alongside it:
+**Finding 2 — the rule is about ORDER, and it is now pinned.** `src/gc/borrow_shapes.rs` measures
+the shapes call sites actually perform while the aliased `&mut` is live, on the gate's pinned
+toolchain:
+
+| shape | Stacked | Tree |
+| --- | --- | --- |
+| `Gc::clone` of the same node while the `&mut` is live (self-reference build) | ok | ok |
+| `Gc::as_ptr` while the `&mut` is live (identity comparison) | ok | ok |
+| `Gc::strong_count` / `Gc::ptr_eq` while the `&mut` is live (the aliased-vs-unique routing) | ok | ok |
+| whole-payload overwrite whose replacement carries a handle to the node being overwritten | ok | ok |
+| raw pointer derived from the `&mut`, **then** a `Deref` read, **then** a write through the pointer | ok | ok |
+| `&T` Deref'd **before** the write and **used after** it | **UB** | **UB** |
+
+So the obligation is not "never touch the node" — it is specifically: **anything carried across the
+write must be a raw pointer or a handle-level operation; a `Deref`'d `&T` must not be used after
+it.** `Gc::clone`, `as_ptr` and the counts all touch only the `GcBox` header (or project through
+the `UnsafeCell` with `raw_get`), so they never conflict. The last two rows are the same two
+operations in the two possible orders, and only one order is sound — a raw pointer derived first
+sits *below* a later shared read on the borrow stack, so the read pushes above it rather than
+popping it, whereas a `&T` taken first is popped by the write.
+
+The first four rows are what clears the audit mechanically; the probes fail the moment one of those
+operations starts going through `Deref`.
+
+**Audit result: 60 of 62 sites clear, 2 rest on the FFI argument.** After the narrowing and the
+probes, every site falls into one of: the argument is never mentioned again (38); the later mention
+is the `&mut`'s own field, which happens to share the variable's name (`data.items` where the
+argument is also called `items` — 6); the later mention is `Gc::make_mut` on the *other* branch of
+the same aliased-vs-unique `if` (10); or the later mention is a `Gc::clone` / `as_ptr` cleared by
+the probes above (6). No site was found holding a Deref'd borrow across its write.
+
+The two remaining are `src/runtime/nativecall.rs` (`marshal_arg`'s `CType::Buf` arm and
+`marshal_carray_arg`), the only family that lets a pointer derived from the `&mut` outlive the call:
 
 ```rust
 let data_ptr = unsafe { crate::value::gc_contents_mut(&node) }.bytes.as_mut_ptr();
 (Type::pointer(), ArgOwner::BufBytes { node: Some(node), buf: Vec::new(), data_ptr: ... })
 ```
 
-Every other site takes the `&mut`, writes, and drops it within a few lines. This one lets a pointer
-derived from that `&mut` outlive the call and be written by C over an arbitrary window, while a live
-`Gc` handle to the same node sits next to it. Under Stacked Borrows any Deref of `node` in that
-window pops the derived tag and the C write becomes UB. Whether it is *reachable* needs a read of
-what touches the Buf during an FFI call — but note the Miri job runs `--no-default-features
---features native` precisely to drop FFI, so **the gate will never catch this family**. It needs an
-argument, not a test.
+By the table above this shape is sound — the pointer is derived first and reads through the retained
+node push above it. But the Miri job runs `--no-default-features --features native` precisely to
+drop FFI, so **the real path can never be checked**; `nativecall_shape_raw_pointer_survives_a_later_deref`
+in `borrow_shapes.rs` is the stand-in. What would break it is an intervening `&T` taken before a
+C-side write and used after it, which this code does not do (it stores only `node` and `data_ptr`,
+never a reference). Re-examine if that struct ever grows a borrow.


### PR DESCRIPTION
Completes the audit `todo/deep/adr-0013-unsafecell-does-not-license-live-shared-borrows.md` asked for, which #5775 unblocked by getting `gc::soundness_smoke` running under Miri.

## Why this needed pinning rather than reading

`gc_contents_mut` takes `&Gc<T>` and returns `&mut T`, so **the borrow checker offers nothing** at its 62 call sites: keeping a `Deref`'d `&T` alive across the write compiles fine, and it is the one failure mode Miri actually catches.

The audit turned almost entirely on one question — which operations touch the *payload* and which touch only the `GcBox` header? Real call sites do all of the following with the `&mut` still live; `fixup_circular_array_refs` holds a `&mut ArrayData` across `result_arc.clone()` *and* across passing `&result_arc` to a recursive helper. Reasoning says none of them dereference the payload, but "reasoning says" is exactly what the ADR-0013 over-promise was.

## Measured on the pinned toolchain

| shape | verdict |
| --- | --- |
| `Gc::clone` of the same node while the `&mut` is live (self-reference build) | sound |
| `Gc::as_ptr` while the `&mut` is live (identity comparison) | sound |
| `Gc::strong_count` / `Gc::ptr_eq` while the `&mut` is live (the routing decision) | sound |
| whole-payload overwrite whose replacement carries a handle to the node being overwritten | sound |
| raw pointer derived from the `&mut`, **then** a `Deref` read, **then** a write through the pointer | sound |
| `&T` Deref'd **before** the write and **used after** it | **UB**, Stacked *and* Tree Borrows |

The last two rows are the same two operations in the two possible orders, and only one is sound: a raw pointer derived first sits *below* a later shared read on the borrow stack, so the read pushes above it rather than popping it; a `&T` taken first is popped by the write. So the call-site obligation is not "never touch the node" — it is **anything carried across the write must be a raw pointer or a handle-level operation, and a `Deref`'d `&T` must not be used after it.**

The UB row is deliberately *not* a test: a test that triggers UB fails the gate rather than documenting it, so it lives in the todo file's measurement table.

## Audit result: 60 of 62 clear

No site was found holding a `Deref`'d borrow across its write. The 62 break down as: argument never mentioned again in its block (38); the later mention is the `&mut`'s own field where the variable shares its name — `data.items` where the argument is also `items` (6); the later mention is `Gc::make_mut` on the *other* branch of the same aliased-vs-unique `if` (10); the later mention is a `Gc::clone` / `as_ptr` cleared by the probes (6).

The two remaining are `nativecall.rs`'s `marshal_arg` (`CType::Buf`) and `marshal_carray_arg` — the only family that lets a pointer derived from the `&mut` outlive the call. By the table that shape is sound, and the code stores only the node and the pointer, never a reference. But the Miri job runs `--no-default-features --features native` precisely to drop FFI, so the real path can never be checked; `nativecall_shape_raw_pointer_survives_a_later_deref` is its stand-in and should not be deleted as "not a real call site".

## Notes

- The probes run in the Miri job's **first** step, which keeps the leak check ON, so the two self-referential probes sever their own edge before returning rather than leaving the collector a cycle.
- Verified locally: `cargo miri test --lib gc:: --skip gc::soundness_smoke` → 54 passed, 1 ignored, 17s.
- **Still owed** (deliberately not in this PR): the ADR-0013 §8 note. The primitive's own doc comment repeats the over-promise — "valid provenance *even while shared `&` reads via `Deref` are live*" — one paragraph above a `# Safety` clause that says the opposite, and the measurements back the Safety clause. That sentence is what a future call site would read before deciding it may keep a borrow, so the doc fix and the ADR note belong together in one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)