### PR TITLE
docs(todo): state plainly that the magic vars are not lazy yet

### DIFF
--- a/todo/tickets/magic-vars-should-be-built-lazily.md
+++ b/todo/tickets/magic-vars-should-be-built-lazily.md
@@ -24,6 +24,18 @@ platform pays the instance construction. The project's headline metric is startu
 which makes this the wrong place to be eager. The values are process constants, so they should be
 **delayed until first access and then cached**, which is what Rakudo effectively does.
 
+Nothing here is lazy yet — "cached" in slice 1 means *once per process*, not *on demand*. The
+one-line repro: `strace -f -e trace=uname ./target/debug/mutsu -e 'say 1'` still shows one `uname`,
+for a program that never touches `$*KERNEL` or `$*DISTRO`.
+
+**Measure before choosing a design.** Which of the three rows above dominates is *unmeasured*. The
+`uname(2)` is ~1µs, so the plausible-but-unverified guess is that the instance construction (five
+Instances, Version parses, a 32-element signal array, the `vm_config` hash) outweighs it on Linux
+while macOS is dominated by `sw_vers`. If that holds, slice 2's payoff is in skipping the
+*construction*, not the syscall — which also decides how much base-tier surgery is worth it. Profile
+a release/`--profile profiling` startup first (see PERFORMANCE.md's note that document-worthy numbers
+come from the bench CI, not local runs).
+
 Note that laziness subsumes the macOS problem: `sw_vers` only runs if the program actually reads
 `$*DISTRO`. Replacing it with a `SystemVersion.plist` read is the alternative, but it cannot be
 verified from this workspace (no macOS host), and the current shell-out is at least known-correct.


### PR DESCRIPTION
Docs-only, one ticket.

Slice 1 (#5775) replaced three `fork`/`exec`s with one cached `uname(2)`, and "cached" is easy to misread as "on demand". It is not: `OnceLock` only prevents a *second* call, and the first still runs from `Interpreter::new()`. The ticket now says so plainly and records the one-line repro:

```
strace -f -e trace=uname ./target/debug/mutsu -e 'say 1'   # one uname, for a program that never reads $*KERNEL
```

It also flags something the ticket previously implied without saying: **which of the three remaining eager costs dominates is unmeasured.** The syscall is ~1µs, so the plausible-but-unverified guess is that instance construction (five Instances, Version parses, a 32-element signal array, the `vm_config` hash) outweighs it on Linux while macOS is dominated by `sw_vers` ×3. If that holds, slice 2's payoff is in skipping the *construction* rather than the syscall — which in turn decides how much base-tier surgery is worth doing. Profile before choosing a design.

No code change; slice 2 stays deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)