### PR TITLE
fix(exceptions): typed exceptions carry the attributes rakudo declares

### DIFF
--- a/news/2026-08/typed-exceptions-carry-their-attributes.md
+++ b/news/2026-08/typed-exceptions-carry-their-attributes.md
@@ -1,0 +1,44 @@
+# Typed exceptions carry the attributes rakudo declares
+
+Naming the class is only half of a typed exception. `throws-like 'qr/a/',
+X::Obsolete, old => rx/<<qr>>/, replacement => rx/<<rx>>/` reads *attributes*,
+and mutsu raised most of these classes as a bare `"X::Type: message"` string —
+so the class matched, the attribute call died with
+`No such method 'old' for invocant of type 'X::Obsolete'`, and the whole file
+aborted at that point.
+
+Five classes gained their attributes, each derived the way rakudo derives them
+so the message and the attributes cannot disagree:
+
+| class | attributes | raised by |
+| --- | --- | --- |
+| `X::Obsolete` | `.old`, `.replacement` | every Perl 5 construct the parser rejects |
+| `X::Syntax::Variable::MissingInitializer` | `.type`, `.what`, `.implicit` | a `:D` declaration with no value |
+| `X::Syntax::WithoutElse` | `.keyword` | `without … else/elsif/orwith` |
+| `X::Comp::Trait::Scope` | `.type`, `.subtype`, `.declaring`, `.scope`, `.supported` | `is export` on a `my`-scoped variable |
+| `X::Adverb` | `.unexpected`, `.what`, `.source` | an adverb `grep` does not accept |
+
+`X::Obsolete` was the bulk of it: 20 raise sites across the parser each wrote
+their own message, and none but three carried `old`/`replacement`. They now all
+go through one `PError::obsolete(old, replacement)`, which builds the exception
+from `RuntimeError::obsolete` — the single place the class's message shape is
+spelled out — so a new obsolete-syntax rejection cannot forget the attributes.
+`PError::from_typed` is the general bridge: a parse-time raise of any class
+reuses the `RuntimeError` constructor rather than re-deriving the message.
+
+Rendered messages moved closer to rakudo's as a side effect, since rakudo builds
+them from the same two strings: `Unsupported use of . to concatenate strings. In
+Raku please use: ~.` instead of `Perl . is dead. Please use ~ to concatenate
+strings.`, and a pragma-implied `:D` now says `Variable definition of type Int:D
+(implicit :D by pragma) needs to be given an initializer`.
+
+Found under `MUTSU_REAL_TEST=1` — mutsu's native `throws-like` never called the
+attribute accessors, so nothing exercised them. Five whitelisted roast files
+aborted mid-plan on this and now run to completion under the real `Test`:
+`S04-declarations/smiley.t`, `S04-statements/with.t`, `S11-modules/import.t`,
+`S32-list/grep.t`, and `S32-exceptions/misc2.t` (which then reaches a separate
+gap — `X::Syntax::Pod::BeginWithoutIdentifier` has no `.filename`, i.e. the
+`X::Comp` file/line metadata, tracked in the vendoring ticket).
+
+Pin: `t/typed-exception-attributes.t`, whose 16 assertions pass byte-identically
+under `raku`.

--- a/src/parser/expr/postfix/helpers.rs
+++ b/src/parser/expr/postfix/helpers.rs
@@ -1,7 +1,6 @@
 use crate::ast::{Expr, Stmt};
 use crate::parser::helpers::is_non_breaking_space;
 use crate::parser::parse_result::PError;
-use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
 use crate::value::{Value, ValueView};
 
@@ -70,19 +69,10 @@ pub(crate) fn extract_range_negative_end(expr: &Expr) -> Option<String> {
 
 /// Build a fatal X::Obsolete parse error for negative subscripts.
 pub(crate) fn make_negative_subscript_error(neg_val: &str) -> PError {
-    let old = format!("a negative {} subscript to index from the end", neg_val);
-    let replacement = format!("a function such as *{}", neg_val);
-    let message = format!(
-        "X::Obsolete: Unsupported use of {}. In Raku please use: {}.",
-        old, replacement
-    );
-    let err = crate::value::RuntimeError::obsolete(&old, &replacement);
-    let mut attrs = std::collections::HashMap::new();
-    attrs.insert("old".to_string(), Value::str(old));
-    attrs.insert("replacement".to_string(), Value::str(replacement));
-    attrs.insert("message".to_string(), Value::str(err.message.clone()));
-    let exception = Value::make_instance(Symbol::intern("X::Obsolete"), attrs);
-    PError::fatal_with_exception(message, Box::new(exception))
+    PError::obsolete(
+        &format!("a negative {neg_val} subscript to index from the end"),
+        &format!("a function such as *{neg_val}"),
+    )
 }
 
 /// Check if a character is valid inside an angle-bracket word key (`<key>`).

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -604,8 +604,9 @@ fn postfix_expr_loop_from(
             }
         }
         if rest.starts_with("->") {
-            return Err(PError::fatal(
-                "X::Obsolete: Perl -> is dead. Please use '.' instead.".to_string(),
+            return Err(PError::obsolete(
+                "-> as postfix",
+                "either . to call a method, or whitespace to delimit a pointy block",
             ));
         }
         // `:exists` / `:!exists` on a bare named match capture (`$<foo>:exists`)
@@ -686,11 +687,7 @@ fn postfix_expr_loop_from(
                 if trimmed.starts_with(['"', '\'', '$', '@', '%'])
                     || trimmed.starts_with(|c: char| c.is_ascii_digit())
                 {
-                    return Err(PError::fatal(
-                        "X::Obsolete: Unsupported use of . to concatenate strings; \
-                         in Raku please use ~"
-                            .to_string(),
-                    ));
+                    return Err(PError::obsolete(". to concatenate strings", "~"));
                 }
             }
             expr = auto_invoke_bareword_method_target(expr);

--- a/src/parser/expr/precedence/comparison.rs
+++ b/src/parser/expr/precedence/comparison.rs
@@ -19,11 +19,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
             || after.starts_with("m/")
             || after.starts_with("m ")
         {
-            return Err(PError::fatal_at(
-                "X::Obsolete: Unsupported use of =~ to do pattern matching; in Raku please use ~~"
-                    .to_string(),
-                r,
-            ));
+            return Err(PError::obsolete_at("=~ to do pattern matching", "~~", r));
         }
     }
     if r.starts_with("!~") && !r.starts_with("!~~") {
@@ -33,9 +29,9 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
             || after.starts_with("m/")
             || after.starts_with("m ")
         {
-            return Err(PError::fatal_at(
-                "X::Obsolete: Unsupported use of !~ to do pattern matching; in Raku please use !~~"
-                    .to_string(),
+            return Err(PError::obsolete_at(
+                "!~ to do negated pattern matching",
+                "!~~",
                 r,
             ));
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -796,7 +796,13 @@ is_run q<use lib '> ~ $pkg-path ~ q<'; use GH2897-B; (^3).map( { my-counter } ).
     fn parse_program_rejects_explicit_do_block_with_postfix_for() {
         let src = r#"my $i; do { $i++ } for 1..3;"#;
         let err = parse_program(src).expect_err("expected do...for parse error");
-        assert!(err.message.contains("X::Obsolete"), "{err:?}");
+        // The class lives in the attached exception object, not in the message
+        // text — see `PError::obsolete`.
+        let class = match err.exception.as_ref().map(|ex| ex.view()) {
+            Some(crate::value::ValueView::Instance { class_name, .. }) => class_name.to_string(),
+            _ => String::new(),
+        };
+        assert_eq!(class, "X::Obsolete", "{err:?}");
     }
 
     #[test]

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -80,6 +80,41 @@ impl PError {
         }
     }
 
+    /// Build the fatal `X::Obsolete` parse error for a Perl 5 construct.
+    ///
+    /// `old` names the construct and `replacement` the Raku spelling; rakudo
+    /// renders both into the message *and* exposes them as `.old`/`.replacement`,
+    /// which `throws-like 'qr/a/', X::Obsolete, old => …, replacement => …`
+    /// reads. Every obsolete-syntax rejection goes through here so none of them
+    /// arrives as a bare message with no attributes to match on.
+    pub fn obsolete(old: &str, replacement: &str) -> Self {
+        Self::from_typed(crate::value::RuntimeError::obsolete(old, replacement))
+    }
+
+    /// Turn a typed [`crate::value::RuntimeError`] into a fatal parse error that
+    /// keeps its exception object.
+    ///
+    /// The `RuntimeError` constructors in `src/value/error_typed.rs` are the one
+    /// place a given `X::` class's attributes and message are spelled out; a
+    /// parse-time raise of the same class goes through here instead of
+    /// re-deriving them, so the two cannot drift apart. A caller must pass a
+    /// *typed* error — an untyped one degrades to a plain fatal message.
+    pub fn from_typed(err: crate::value::RuntimeError) -> Self {
+        let message = err.message.clone();
+        match err.exception {
+            Some(exception) => Self::fatal_with_exception(message, exception),
+            None => Self::fatal(message),
+        }
+    }
+
+    /// [`Self::obsolete`] that also records the failure position (`input` is the
+    /// unconsumed rest at the error site), like [`Self::fatal_at`].
+    pub fn obsolete_at(old: &str, replacement: &str, input: &str) -> Self {
+        let mut err = Self::obsolete(old, replacement);
+        err.remaining_len = Some(input.len());
+        err
+    }
+
     /// Get the formatted message string (used by tests).
     #[allow(dead_code)]
     pub fn message(&self) -> String {

--- a/src/parser/primary/container/angle_words.rs
+++ b/src/parser/primary/container/angle_words.rs
@@ -65,11 +65,10 @@ fn parse_quote_word_list<'a>(
     // A bare *empty* `<>` is the obsolete Perl diamond. `< >` (with whitespace)
     // is a legal empty `List`, so only the truly-empty form errors.
     if reject_lt_operators && content.is_empty() {
-        return Err(crate::parser::stmt::control::make_obsolete_error(
+        return Err(crate::parser::parse_result::PError::obsolete(
             "<>",
-            None,
-            "Unsupported use of <>. In Raku please use: lines() to read input, \
-             ('') to represent a null string or () to represent an empty list.",
+            "lines() to read input, ('') to represent a null string or () to \
+             represent an empty list",
         ));
     }
     if quoted_words {

--- a/src/parser/primary/container/sigil_context.rs
+++ b/src/parser/primary/container/sigil_context.rs
@@ -153,8 +153,8 @@ pub(crate) fn itemized_brace_expr(input: &str) -> PResult<'_, Expr> {
         ))
     } else {
         // ${expr} where expr is not a hash is Perl 5 scalar dereference syntax
-        Err(crate::parser::parse_result::PError::fatal(
-            "X::Obsolete: Unsupported use of ${expr}. In Raku please use: $(expr).".to_string(),
+        Err(crate::parser::parse_result::PError::obsolete(
+            "${expr}", "$(expr)",
         ))
     }
 }

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -207,10 +207,9 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             // only the bare `new Foo` / `new Foo(...)` indirect form is C++ syntax.
             && (!tail.starts_with(':') || tail.starts_with("::"))
         {
-            return Err(PError::fatal(
-                "X::Obsolete: Unsupported use of C++ constructor syntax.  \
-                 In Raku please use: method call syntax."
-                    .to_string(),
+            return Err(PError::obsolete(
+                "C++ constructor syntax",
+                "method call syntax",
             ));
         }
     }
@@ -320,11 +319,9 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     // routine call instead (e.g. `sub undef {}; undef()`), so only flag the
     // bare-term use.
     if name == "undef" && !rest.starts_with('(') {
-        return Err(crate::parser::stmt::control::make_obsolete_error(
-            "undef",
-            None,
-            "X::Obsolete: Unsupported use of undef as a value. \
-             In Raku please use: an appropriate type object such as Any.",
+        return Err(PError::obsolete(
+            "undef as a value",
+            "an appropriate type object such as Any",
         ));
     }
 
@@ -465,11 +462,10 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 let (r_ws, _) = ws(r)?;
                 for kw in &["while", "until", "for", "given"] {
                     if keyword(kw, r_ws).is_some() {
-                        return Err(PError::raw(
-                            format!(
-                                "X::Obsolete: Unsupported use of do...{kw}. In Raku please use: repeat...while or repeat...until."
-                            ),
-                            Some(r_ws.len()),
+                        return Err(PError::obsolete_at(
+                            &format!("do...{kw}"),
+                            "repeat...while or repeat...until",
+                            r_ws,
                         ));
                     }
                 }
@@ -1846,11 +1842,14 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
     // bare ..." (e.g. `ord.Cool`). A real call (`ord $x` / `ord('A')`) parses as
     // a listop/call before reaching this fallback, so it is unaffected.
     if is_terminator_or_dot && matches!(name.as_str(), "ord" | "chr" | "lc" | "uc" | "abs") {
-        return Err(PError::fatal(format!(
-            "X::Obsolete: Unsupported use of bare \"{name}\".  In Raku please use: \
-             .{name} if you meant to call it as a method on $_, or use an explicit \
-             invocant or argument."
-        )));
+        return Err(PError::obsolete(
+            &format!("bare \"{name}\""),
+            &format!(
+                ".{name} if you meant to call it as a method on $_, or use an \
+                 explicit invocant or argument, or use &{name} to refer to the \
+                 function as a noun"
+            ),
+        ));
     }
 
     // Method-like: .new, .elems etc. is handled at expression level

--- a/src/parser/primary/ident/term_literals.rs
+++ b/src/parser/primary/ident/term_literals.rs
@@ -346,10 +346,7 @@ pub(crate) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
             // rand() and rand(N) are Perl 5 syntax — throw X::Obsolete
             let after_ws = after;
             if after_ws.starts_with('(') {
-                return Err(PError::fatal(
-                    "X::Obsolete: Unsupported use of rand().  In Raku please use: rand."
-                        .to_string(),
-                ));
+                return Err(PError::obsolete("rand()", "rand"));
             }
             return Ok((
                 &input[4..],

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -95,17 +95,12 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
         || input.starts_with("y{")
         || input.starts_with("y|")
     {
-        return Err(PError::fatal(
-            "X::Obsolete: Unsupported use of y///. In Raku please use: tr///.".to_string(),
-        ));
+        return Err(PError::obsolete("y///", "tr///"));
     }
 
     // qr// is obsolete Perl 5 syntax — reject with X::Obsolete
     if input.starts_with("qr/") || input.starts_with("qr{") || input.starts_with("qr[") {
-        return Err(PError::fatal(
-            "X::Obsolete: Unsupported use of qr for regex quoting. In Raku please use: rx//."
-                .to_string(),
-        ));
+        return Err(PError::obsolete("qr for regex quoting", "rx//"));
     }
 
     // rx/pattern/ or rx{pattern}

--- a/src/parser/primary/var/sigil_vars.rs
+++ b/src/parser/primary/var/sigil_vars.rs
@@ -204,9 +204,7 @@ pub(crate) fn array_var(input: &str) -> PResult<'_, Expr> {
         && let Ok((_r2, inner)) = crate::parser::primary::misc::block_or_hash_expr(rest)
         && !matches!(inner, crate::ast::Expr::Hash(_))
     {
-        return Err(PError::fatal(
-            "X::Obsolete: Unsupported use of @{expr}. In Raku please use: @(expr).".to_string(),
-        ));
+        return Err(PError::obsolete("@{expr}", "@(expr)"));
     }
     // Handle @<name> — list coercion of a named capture variable from $/
     // (e.g., after a regex match, @<fie> gives the positional elements of $<fie>)

--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -416,10 +416,7 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             || after.starts_with("m/")
             || after.starts_with("m ")
         {
-            return Err(PError::fatal(
-                "X::Obsolete: Unsupported use of =~ to do pattern matching; in Raku please use ~~"
-                    .to_string(),
-            ));
+            return Err(PError::obsolete("=~ to do pattern matching", "~~"));
         }
     }
     // Simple assignment

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -68,23 +68,6 @@ fn condition_expr(input: &str) -> PResult<'_, Expr> {
     }
 }
 
-/// Build a fatal, structured `X::Obsolete` parse error carrying `old` /
-/// `replacement` attributes so that `throws-like` can match them.
-pub(in crate::parser) fn make_obsolete_error(
-    old: &str,
-    replacement: Option<&str>,
-    message: &str,
-) -> PError {
-    let mut attrs = std::collections::HashMap::new();
-    attrs.insert("old".to_string(), Value::str(old.to_string()));
-    if let Some(rep) = replacement {
-        attrs.insert("replacement".to_string(), Value::str(rep.to_string()));
-    }
-    attrs.insert("message".to_string(), Value::str(message.to_string()));
-    let exception = Value::make_instance(crate::symbol::Symbol::intern("X::Obsolete"), attrs);
-    PError::fatal_with_exception(message.to_string(), Box::new(exception))
-}
-
 /// Detect the Perl 5 `for my $x (LIST) { }` foreach pattern: a `my`/`our`/
 /// `state` declaration of a single variable immediately followed by a
 /// parenthesized list. In Raku the topic variable goes in a pointy block

--- a/src/parser/stmt/control/for_loops.rs
+++ b/src/parser/stmt/control/for_loops.rs
@@ -18,11 +18,7 @@ pub(crate) fn foreach_stmt(input: &str) -> PResult<'_, Stmt> {
     if rest.starts_with('(') || rest.starts_with(';') || rest.trim_start().is_empty() {
         return Err(PError::expected("foreach (obsolete) check"));
     }
-    Err(make_obsolete_error(
-        "'foreach'",
-        Some("'for'"),
-        "X::Obsolete: Unsupported use of 'foreach'. In Raku please use: 'for'.",
-    ))
+    Err(PError::obsolete("'foreach'", "'for'"))
 }
 
 /// Return true if `expr` is (or ends in) a bare brace block — used to detect a
@@ -177,11 +173,7 @@ fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stm
     // C-style `for (init; test; incr) { }` is obsolete — Raku uses `loop`.
     // Detected by a top-level `;` inside the parenthesized iterable.
     if rest.starts_with('(') && paren_has_toplevel_semicolon(rest) {
-        return Err(make_obsolete_error(
-            "C-style \"for\"",
-            Some("\"loop\""),
-            "X::Obsolete: Unsupported use of C-style \"for\". In Raku please use: \"loop\".",
-        ));
+        return Err(PError::obsolete("C-style \"for\"", "\"loop\""));
     }
     // Try to detect `<->` (rw pointy block) before the expression parser
     // consumes the `<` as a comparison operator.

--- a/src/parser/stmt/control/with_stmt.rs
+++ b/src/parser/stmt/control/with_stmt.rs
@@ -295,10 +295,9 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     if is_without {
         for kw in &["else", "orwith", "elsif"] {
             if keyword(kw, rest).is_some() {
-                return Err(PError::fatal(format!(
-                    "X::Syntax::WithoutElse: '{}' is not allowed on 'without'",
-                    kw
-                )));
+                return Err(PError::from_typed(
+                    crate::value::RuntimeError::without_else(kw),
+                ));
             }
         }
     }

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -469,10 +469,13 @@ fn parse_variable_traits<'a>(
             }
             if trait_name == "export" {
                 if !is_our {
-                    return Err(PError::fatal(
-                        "X::Comp::Trait::Scope: Trait 'is export' not allowed on my-scoped variable"
-                            .to_string(),
-                    ));
+                    return Err(PError::from_typed(crate::value::RuntimeError::trait_scope(
+                        "is",
+                        "export",
+                        "variable",
+                        "my",
+                        &["our"],
+                    )));
                 }
                 has_export_trait = true;
                 let (r3, tags) = parse_export_trait_tags(r2)?;

--- a/src/parser/stmt/simple/io_stmts.rs
+++ b/src/parser/stmt/simple/io_stmts.rs
@@ -25,13 +25,14 @@ fn check_io_func_followed_by_loop<'a>(name: &str, rest_after_ws: &'a str) -> PRe
                 || next_char == Some('\t')
                 || next_char == Some('\n')
             {
-                return Err(PError::fatal(format!(
-                    "X::Obsolete: Unsupported use of bare \"{}\". \
-                     In Raku please use: .{} if you meant to call it as a method on $_, \
-                     or use an explicit invocant or argument, \
-                     or use &{} to refer to the function as a noun.",
-                    name, name, name
-                )));
+                return Err(PError::obsolete(
+                    &format!("bare \"{name}\""),
+                    &format!(
+                        ".{name} if you meant to call it as a method on $_, or use \
+                         an explicit invocant or argument, or use &{name} to refer \
+                         to the function as a noun"
+                    ),
+                ));
             }
         }
     }

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -201,17 +201,20 @@ impl Interpreter {
                 ValueView::Pair(key, value) if key == "p" => has_p = value.truthy(),
                 ValueView::Pair(key, value) if key == "v" => {
                     if !value.truthy() {
-                        return Err(RuntimeError::new(
-                            "X::Adverb: Unexpected adverb 'v' passed to grep",
+                        return Err(RuntimeError::unexpected_adverb(
+                            &["v".to_string()],
+                            "grep",
+                            crate::runtime::utils::value_type_name(&target),
                         ));
                     }
                     // :v is the default behavior, just ignore when truthy
                 }
                 ValueView::Pair(key, _) => {
-                    return Err(RuntimeError::new(format!(
-                        "X::Adverb: Unexpected adverb '{}'",
-                        key
-                    )));
+                    return Err(RuntimeError::unexpected_adverb(
+                        &[key.to_string()],
+                        "grep",
+                        crate::runtime::utils::value_type_name(&target),
+                    ));
                 }
                 _ => positional_args.push(arg.clone()),
             }

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -237,8 +237,10 @@ impl Interpreter {
         let saved_topic = self.env.get("_").cloned();
         let trimmed = code.trim();
         if trimmed == "<>" || trimmed == "<STDIN>" {
-            return Err(RuntimeError::new(
-                "X::Obsolete: The degenerate case <> and old angle forms like <STDIN> are disallowed.",
+            return Err(RuntimeError::obsolete(
+                trimmed,
+                "lines() to read input, ('') to represent a null string or () to \
+                 represent an empty list",
             ));
         }
         let previous_pod = self.env.get("=pod").cloned();

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -176,6 +176,95 @@ impl RuntimeError {
         Self::typed("X::Obsolete", attrs)
     }
 
+    /// X::Syntax::Variable::MissingInitializer - a `:D` declaration with no value.
+    ///
+    /// `.type` is the declared type as written (`Int:D`) and `.what` names the
+    /// kind of declaration; `throws-like 'my Int:D $a',
+    /// X::Syntax::Variable::MissingInitializer, type => 'Int:D'` reads both.
+    /// `implicit` is set when the `:D` was not written but came from a
+    /// `use variables :D` pragma; rakudo then says so in the message too.
+    pub(crate) fn missing_initializer(
+        type_display: &str,
+        what: &str,
+        implicit: Option<&str>,
+    ) -> Self {
+        let implicit_note = implicit.map_or(String::new(), |i| format!(" (implicit {i})"));
+        let msg = format!(
+            "Variable definition of type {type_display}{implicit_note} needs to be given an initializer"
+        );
+        let mut attrs = HashMap::new();
+        attrs.insert("type".to_string(), Value::str(type_display.to_string()));
+        attrs.insert("what".to_string(), Value::str(what.to_string()));
+        if let Some(i) = implicit {
+            attrs.insert("implicit".to_string(), Value::str(i.to_string()));
+        }
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        Self::typed("X::Syntax::Variable::MissingInitializer", attrs)
+    }
+
+    /// X::Syntax::WithoutElse - `without` followed by an `else`-family keyword.
+    pub(crate) fn without_else(keyword: &str) -> Self {
+        let msg = format!("\"without\" does not take \"{keyword}\", please rewrite using \"with\"");
+        let mut attrs = HashMap::new();
+        attrs.insert("keyword".to_string(), Value::str(keyword.to_string()));
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        Self::typed("X::Syntax::WithoutElse", attrs)
+    }
+
+    /// X::Comp::Trait::Scope - a trait applied under a scope that does not take it.
+    ///
+    /// `type`/`subtype` split the trait (`is` / `export`), `declaring` names what
+    /// carries it, `scope` the declarator used, and `supported` the list of
+    /// declarators that would have worked — all four are matched by
+    /// `roast/S11-modules/import.t`.
+    pub(crate) fn trait_scope(
+        trait_type: &str,
+        subtype: &str,
+        declaring: &str,
+        scope: &str,
+        supported: &[&str],
+    ) -> Self {
+        let supported_list = supported.join(", ");
+        let msg = format!(
+            "Can't apply trait '{trait_type} {subtype}' on a {scope} scoped {declaring}. \
+             Only {supported_list} scoped {declaring}s are supported."
+        );
+        let mut attrs = HashMap::new();
+        attrs.insert("type".to_string(), Value::str(trait_type.to_string()));
+        attrs.insert("subtype".to_string(), Value::str(subtype.to_string()));
+        attrs.insert("declaring".to_string(), Value::str(declaring.to_string()));
+        attrs.insert("scope".to_string(), Value::str(scope.to_string()));
+        attrs.insert(
+            "supported".to_string(),
+            Value::array(
+                supported
+                    .iter()
+                    .map(|s| Value::str(s.to_string()))
+                    .collect(),
+            ),
+        );
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        Self::typed("X::Comp::Trait::Scope", attrs)
+    }
+
+    /// X::Adverb - an adverb the callee does not accept.
+    ///
+    /// `.unexpected` is a *list* of the offending adverb names (rakudo hands it a
+    /// Seq), `.what` the routine and `.source` the invocant type.
+    pub(crate) fn unexpected_adverb(unexpected: &[String], what: &str, source: &str) -> Self {
+        let names = unexpected.join("', '");
+        let msg = format!("Unexpected adverb '{names}' passed to {what} on '{source}'.");
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "unexpected".to_string(),
+            Value::array(unexpected.iter().map(|s| Value::str(s.clone())).collect()),
+        );
+        attrs.insert("what".to_string(), Value::str(what.to_string()));
+        attrs.insert("source".to_string(), Value::str(source.to_string()));
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        Self::typed("X::Adverb", attrs)
+    }
+
     /// X::Immutable - Cannot modify an immutable value
     pub(crate) fn immutable(typename: &str, method: &str) -> Self {
         let msg = format!("Cannot call '{}' on an immutable '{}'", method, typename);

--- a/src/vm/vm_misc_typecheck.rs
+++ b/src/vm/vm_misc_typecheck.rs
@@ -179,10 +179,16 @@ impl Interpreter {
             // type does. Only raise MissingInitializer when one is truly required;
             // otherwise the Nil (type-object) default is allowed at declaration.
             if self.constraint_requires_initializer(constraint) {
-                return Err(RuntimeError::new(format!(
-                    "X::Syntax::Variable::MissingInitializer: Variable definition of type {} needs to be given an initializer",
-                    constraint
-                )));
+                // A `:D` the source did not write came from `use variables :D`
+                // (that is exactly what `apply_variables_pragma` rewrote), and
+                // rakudo reports it as `implicit`.
+                let implicit = (constraint != raw_constraint)
+                    .then(|| format!("{} by pragma", self.variables_pragma));
+                return Err(RuntimeError::missing_initializer(
+                    constraint,
+                    "variable",
+                    implicit.as_deref(),
+                ));
             }
             return Ok(());
         }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1163,10 +1163,14 @@ impl Interpreter {
                 // require an initializer — only an explicit `:D` smiley on the
                 // declared type does. Skip when no initializer is required.
                 if self.constraint_requires_initializer(&constraint) {
-                    return Err(RuntimeError::new(format!(
-                        "X::Syntax::Variable::MissingInitializer: Variable definition of type {} needs to be given an initializer",
-                        constraint
-                    )));
+                    // The constraint reached here already stored (the declaration
+                    // applied any `use variables` pragma), so `implicit` cannot be
+                    // recovered at this site — the TypeCheck opcode path reports it.
+                    return Err(RuntimeError::missing_initializer(
+                        &constraint,
+                        "variable",
+                        None,
+                    ));
                 }
             }
             // A `:=` bind stores a `ContainerRef` cell (e.g. `my Offset $o := @a[$i]`

--- a/t/typed-exception-attributes.t
+++ b/t/typed-exception-attributes.t
@@ -1,0 +1,55 @@
+use Test;
+
+plan 16;
+
+# A typed exception must carry the attributes rakudo declares for it, not just
+# a message that happens to name the class: `throws-like` matches on them.
+
+# X::Obsolete: `.old` / `.replacement` on every obsolete-syntax rejection.
+throws-like 'qr/a/', X::Obsolete,
+    old => 'qr for regex quoting', replacement => 'rx//', 'qr// is obsolete';
+throws-like 'y/a/b/', X::Obsolete,
+    old => 'y///', replacement => 'tr///', 'y/// is obsolete';
+throws-like 'my $a; my $b; $a . $b', X::Obsolete,
+    old => '. to concatenate strings', replacement => '~', '. concatenation is obsolete';
+throws-like 'foreach 1, 2 { }', X::Obsolete,
+    old => "'foreach'", replacement => "'for'", 'foreach is obsolete';
+throws-like 'undef', X::Obsolete,
+    old => 'undef as a value', 'undef is obsolete';
+throws-like 'new Foo()', X::Obsolete,
+    old => 'C++ constructor syntax', replacement => 'method call syntax',
+    'indirect construction is obsolete';
+throws-like 'rand()', X::Obsolete,
+    old => 'rand()', replacement => 'rand', 'rand() is obsolete';
+throws-like '<>', X::Obsolete, old => '<>', 'the diamond is obsolete';
+throws-like 'my $a; $a =~ /x/', X::Obsolete,
+    old => '=~ to do pattern matching', replacement => '~~', '=~ is obsolete';
+
+# X::Syntax::Variable::MissingInitializer: `.type`, `.what`, and `.implicit`
+# when the `:D` came from a pragma rather than the source.
+throws-like 'my Int:D $a', X::Syntax::Variable::MissingInitializer,
+    type => 'Int:D', what => 'variable', ':D declaration needs an initializer';
+throws-like 'use variables :D; my Int $a', X::Syntax::Variable::MissingInitializer,
+    type => 'Int:D', implicit => ':D by pragma',
+    'a pragma-implied :D says so';
+
+# X::Syntax::WithoutElse: `.keyword`.
+throws-like 'without 1 {} else {}', X::Syntax::WithoutElse,
+    keyword => 'else', 'without/else names the keyword';
+throws-like 'without 1 {} orwith 1 {}', X::Syntax::WithoutElse,
+    keyword => 'orwith', 'without/orwith names the keyword';
+
+# X::Comp::Trait::Scope: the trait, what carries it, and the scopes that work.
+throws-like 'module H { my $x is export = 42 }', X::Comp::Trait::Scope,
+    type => 'is', subtype => 'export', declaring => 'variable', scope => 'my',
+    'is export on a my-scoped variable';
+
+# X::Adverb: `.unexpected` is a list, `.what` the routine, `.source` the invocant.
+{
+    my @list = 1, 2, 3;
+    throws-like { @list.grep(Mu, :asdfblargs) }, X::Adverb,
+        unexpected => *.contains('asdfblargs'), what => 'grep',
+        'an unexpected adverb names itself';
+    throws-like { @list.grep(Mu, :!v) }, X::Adverb,
+        what => 'grep', 'a negated :v is unexpected too';
+}

--- a/todo/tickets/compile-errors-that-name-no-exception-class.md
+++ b/todo/tickets/compile-errors-that-name-no-exception-class.md
@@ -15,6 +15,17 @@ $ raku  -e 'try { EVAL q{sub f() returns { }} }; say $!.^name'
 $ mutsu -e 'try { EVAL q{sub f() returns { }} }; say $!.^name'
 ```
 
+**Re-measured 2026-08-03: six of the seven now pass** under `MUTSU_REAL_TEST=1`
+(`t/return-constraint-malformed.t`, `t/name-null.t`, `t/radix-literals.t`,
+`t/unicode-identifiers.t`, `t/modifier-cond-ending-in-block.t`,
+`t/block-lexical-scope.t`) — later exception-class work closed them without the
+individual passes this table anticipated. Only `t/out-of-range-scalar-index.t`
+still fails, and not for the reason listed: it reaches `X::OutOfRange` correctly
+but the class has no `.comment` attribute, and rakudo's `DateTime` range errors
+are `X::Temporal::OutOfRange` with `.what`/`.got`/`.range`/`.comment`. That is
+the same shape as `news/2026-08/typed-exceptions-carry-their-attributes.md`, so
+what is left here is an attribute pass, not a classing pass.
+
 | file | first failing assertion | class raku raises |
 | --- | --- | --- |
 | ~~`t/bind-to-whatever-index.t`~~ | ~~binding `[*-1]` of an empty array~~ | **done** — `news/2026-08/bind-slice-is-a-real-exception-class.md` |


### PR DESCRIPTION
Naming the class is only half of a typed exception. `throws-like 'qr/a/', X::Obsolete, old => rx/<<qr>>/, replacement => rx/<<rx>>/` reads *attributes*, and mutsu raised most of these classes as a bare `"X::Type: message"` string — so the class matched, the attribute call died with `No such method 'old' for invocant of type 'X::Obsolete'`, and the whole file aborted there.

Five classes gained their attributes, each derived the way rakudo derives them so the message and the attributes cannot disagree:

| class | attributes | raised by |
| --- | --- | --- |
| `X::Obsolete` | `.old`, `.replacement` | every Perl 5 construct the parser rejects |
| `X::Syntax::Variable::MissingInitializer` | `.type`, `.what`, `.implicit` | a `:D` declaration with no value |
| `X::Syntax::WithoutElse` | `.keyword` | `without … else/elsif/orwith` |
| `X::Comp::Trait::Scope` | `.type`, `.subtype`, `.declaring`, `.scope`, `.supported` | `is export` on a `my`-scoped variable |
| `X::Adverb` | `.unexpected`, `.what`, `.source` | an adverb `grep` does not accept |

`X::Obsolete` was the bulk of it: 20 raise sites across the parser each wrote their own message and all but three carried no `old`/`replacement`. They now all go through one `PError::obsolete(old, replacement)`, which builds the exception from `RuntimeError::obsolete` — the single place the class's message shape is spelled out — so a new obsolete-syntax rejection cannot forget the attributes. `PError::from_typed` is the general bridge: a parse-time raise of any class reuses the `RuntimeError` constructor instead of re-deriving the message.

Rendered messages moved closer to rakudo's as a side effect, since rakudo builds them from the same two strings — `Unsupported use of . to concatenate strings. In Raku please use: ~.` instead of `Perl . is dead. Please use ~ to concatenate strings.`, and a pragma-implied `:D` now says `Variable definition of type Int:D (implicit :D by pragma) needs to be given an initializer`.

## How it was found

Under `MUTSU_REAL_TEST=1`. mutsu's native `throws-like` never calls the attribute accessors, so nothing exercised them. Five whitelisted roast files aborted mid-plan on exactly this and now run to completion under the real `Test`: `S04-declarations/smiley.t`, `S04-statements/with.t`, `S11-modules/import.t`, `S32-list/grep.t`, and `S32-exceptions/misc2.t` (which then reaches a separate gap — `X::Syntax::Pod::BeginWithoutIdentifier` has no `.filename`, i.e. the `X::Comp` file/line metadata).

## Testing

- `t/typed-exception-attributes.t` (new) — 16 assertions, byte-identical output under `raku`
- `make test`: `Files=2787, Tests=26514 ... Result: PASS`
- the 37 whitelisted roast files mentioning any of the changed messages/classes: `Files=37, Tests=5469 ... Result: PASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)