### PR TITLE
docs: re-measure the real-Test roast residue and the call-path deficit

### DIFF
--- a/todo/deep/interpreter-call-path-in-hot-loops.md
+++ b/todo/deep/interpreter-call-path-in-hot-loops.md
@@ -56,6 +56,40 @@ Target that specifically: intern the parameter names and bind by `Symbol`/slot.
   line from the op's ip via `op_lines` breaks line-exactness (the marker captures the *parse-time*
   line, which differs on multi-line assertions — `test-assertion-line-number.t` pins the number).
 
+## Re-measured 2026-08-03, and it is worse than the 1.85× above says
+
+Driving the same shapes with the result *used* (see the trap below), release build, 1M iterations:
+
+| shape | mutsu | raku | ratio |
+| --- | --- | --- | --- |
+| A `$n = $n + 1` | 143 ms | 53 ms | 2.7× |
+| B `$n = outer-fn($n)`, `outer-fn` declared at file scope | 484 ms | 35 ms | **13.8×** |
+| C same, but the sub is declared **inside the calling block** | 840 ms | 34 ms | **24.7×** |
+
+Two things stand out, and the second is the new one:
+
+- The per-call cost is ~340 ns (B) on top of a ~140 ns/iteration loop, so a call is worth ~3
+  arithmetic iterations. raku's B/C are *faster* than its A because its optimizer inlines the callee
+  outright; mutsu's JIT bails at the call boundary (see above), so the gap is the whole call path.
+- **C is 1.7× slower per call than B for an identical body and arity.** Nothing about invoking a sub
+  should depend on where it was declared, so that 1.7× is pure mutsu-internal overhead on
+  block-local routine declarations — and it is not a corner case: roast bodies and `Test.rakumod`'s
+  own helpers declare subs inside blocks constantly. With a zero-arg callee the same comparison was
+  1259 ms vs 4843 ms, i.e. **3.8×**. Start here; it is the one part of this ticket that looks like a
+  bug rather than a general "calls are expensive".
+
+Passing the block through a *module* sub (`sub s-amp(&code) { code() }`, imported) adds a further
+~1.5× on top of every row — which is exactly the shape every `lives-ok`/`throws-like`/`subtest` body
+takes under the vendored `Test`, and is why the real module inflates heavy roast files past the
+30 s per-file budget (`todo/tickets/vendor-real-test-module.md`).
+
+### Trap: raku will delete your benchmark
+
+`for ^1000000 { $n = f($n) }` with `$n` never read afterwards measures nothing under raku — its
+optimizer removes the loop, and B/C come back at 8–13 ms, i.e. *faster than an empty arithmetic
+loop*. That reads as a 140–370× mutsu deficit and is an artifact. Always return the accumulator
+from the benchmarked block and print it.
+
 ## Prerequisite
 
 The deeper fix (removing per-call env materialization) is the lexical-scope slot campaign —

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -560,6 +560,58 @@ group is 2 files (`Unknown role: CN`; `Did you mean 'flat'?`), and 71 abort with
 no diagnostic line at all. So from here it is one gap at a time rather than
 another leverage play. Two starting points worth naming:
 
+### Re-measured 2026-08-03, and a quarter of the residue is a *timeout* class
+
+Two fixes landed against the 255
+(`news/2026-08/strict-does-not-reject-a-declared-bind.md`,
+`news/2026-08/typed-exceptions-carry-their-attributes.md`), and the sweep was
+re-run on `b9affee86`: **248 / 1435**. But re-running each of those 248 **alone**
+with a 120 s timeout shows **64 of them pass** — so the honest count is
+
+| | files |
+| --- | --- |
+| genuine failures | **185** |
+| pass alone, fail under `prove -j6` | 64 |
+
+That second bucket is not flakiness in the usual sense and must not be
+quarantined: it is the real module's per-assertion cost. **10 of the 64 exceed
+the 30 s per-file budget even with the machine to themselves** (22–61 s:
+`S04-declarations/state.t`, `S03-buf/read-write-bits.t`, and the six
+`sprintf-*.t`), and the other 54 are the same effect under contention.
+
+Two different causes hide in there, and they need different answers:
+
+- `S32-str/sprintf-d.t` — 0.9 s native, **22.2 s** real, **19.1 s raku**. mutsu
+  is as fast as rakudo here; the file is simply 4565 interpreted `Test`
+  assertions. Nothing to fix in the interpreter — the roast runner needs a
+  bigger budget for these files once the switch flips.
+- `S04-declarations/state.t` — 3.7 s native, **61.8 s** real, **0.9 s raku**, a
+  67× deficit. Its `lives-ok { … for ^2000000 { $ = foo } }` takes 2.9 s under
+  the native provider and 40.3 s under the module's, for byte-identical user
+  code. Isolated: a block invoked through an imported sub costs ~1.5× more per
+  iteration, and a callee declared *inside* that block costs another 1.7–3.8×.
+  Recorded in `todo/deep/interpreter-call-path-in-hot-loops.md`; that is the
+  real blocker of the two.
+
+So step 3 needs the call path as well as the 185 correctness gaps.
+
+### Named starting points (from the 2026-08-03 abort classification)
+
+- ~~`S02-names/strict.t` / `S02-lexical-conventions/comments.t`~~ **DONE** —
+  `news/2026-08/strict-does-not-reject-a-declared-bind.md`.
+- ~~six files aborting on a missing exception attribute~~ **DONE** —
+  `news/2026-08/typed-exceptions-carry-their-attributes.md`. Two of that family
+  are left: `X::Match::Bool` has no `.instead` (`S24-testing/fails-like.t`) and
+  `X::Syntax::Pod::BeginWithoutIdentifier` has no `.filename`
+  (`S32-exceptions/misc2.t`) — the latter is the `X::Comp` file/line metadata
+  rather than a per-class attribute.
+- `skip() was passed a non-integer number of tests` — still open; the shape that
+  triggers it is not any of the ordinary `skip 'reason', N` forms (all of those
+  were checked against the real module and pass), so find the file from the
+  sweep rather than guessing.
+
+### (superseded) the 2026-08-03 pre-fix notes
+
 - `S02-names/strict.t` and `S02-lexical-conventions/comments.t` abort with
   `X::Undeclared: Variable '$time_after' is not declared` raised *inside*
   `Test.rakumod`'s own `_diag`, reached through `throws-like` → `subtest`. Both


### PR DESCRIPTION
Two corrections to what the ledger claimed, both measured today.

## The residue is 185 real failures, not 248

The `MUTSU_REAL_TEST=1` sweep over the whitelist reports **248 / 1435** after today's two fixes. But re-running each of those 248 **alone** with a 120 s timeout shows **64 of them pass**:

| | files |
| --- | --- |
| genuine failures | **185** |
| pass alone, fail under `prove -j6` | 64 |

That second bucket is not ordinary flakiness and must not be quarantined — it is the real module's per-assertion cost. Ten of the 64 exceed the 30 s per-file budget *with the machine to themselves* (22–61 s). Two different causes hide there:

- `S32-str/sprintf-d.t` — 0.9 s native, **22.2 s** real, **19.1 s raku**. mutsu is as fast as rakudo; the file is simply 4565 interpreted `Test` assertions. The roast runner needs a bigger budget for these once the switch flips; there is nothing to fix in the interpreter.
- `S04-declarations/state.t` — 3.7 s native, **61.8 s** real, **0.9 s raku**. Its `lives-ok { … for ^2000000 { $ = foo } }` takes 2.9 s under the native provider and 40.3 s under the module's, for byte-identical user code.

## The call-path deficit is bigger than the ticket said, and one part of it looks like a bug

Same shapes with the result used, release, 1M iterations:

| shape | mutsu | raku | ratio |
| --- | --- | --- | --- |
| `$n = $n + 1` | 143 ms | 53 ms | 2.7× |
| `$n = outer-fn($n)` (file-scope callee) | 484 ms | 35 ms | 13.8× |
| same, callee declared **inside the calling block** | 840 ms | 34 ms | 24.7× |

The last row is 1.7× the one above it for an identical body and arity (3.8× with a zero-arg callee). Nothing about invoking a sub should depend on where it was declared, so that multiplier is pure mutsu-internal overhead on block-local routine declarations — and roast bodies and `Test.rakumod`'s own helpers declare subs inside blocks constantly. `todo/deep/interpreter-call-path-in-hot-loops.md` now names it as the place to start.

Passing the block through an imported sub adds a further ~1.5× on top of every row, which is exactly the shape every `lives-ok`/`throws-like`/`subtest` body takes under the vendored `Test`.

## And the trap that produced a wrong first reading

`for ^1000000 { $n = f($n) }` with `$n` never read afterwards measures nothing under raku — its optimizer removes the loop, and the call rows come back *faster than an empty arithmetic loop*. That reads as a 140–370× mutsu deficit and is an artifact. Both documents now say to return the accumulator and print it.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)