### PR TITLE
refactor(value): funnel ArrayData field access

### DIFF
--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -715,7 +715,7 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                 ValueView::Array(items, ..) => {
                     let mut reversed = (**items).clone();
                     reversed.reverse();
-                    Value::seq(reversed.items)
+                    Value::seq(reversed.into_items())
                 }
                 ValueView::Seq(items) | ValueView::Slip(items) => {
                     let mut reversed = (**items).clone();
@@ -745,7 +745,7 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                 ValueView::Array(items, ..) => {
                     let mut sorted = (**items).clone();
                     sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
-                    Value::seq(sorted.items)
+                    Value::seq(sorted.into_items())
                 }
                 ValueView::Seq(items) | ValueView::Slip(items) => {
                     let mut sorted = (**items).clone();

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -223,7 +223,7 @@ pub(super) fn dispatch(
                             match v.view() {
                                 ValueView::Array(rows, k) => {
                                     let mut d = (**rows).clone();
-                                    for item in d.items.iter_mut() {
+                                    for item in d.items_mut().iter_mut() {
                                         *item = clone_rows(item);
                                     }
                                     Value::array_with_kind(crate::gc::Gc::new(d), k)
@@ -231,7 +231,7 @@ pub(super) fn dispatch(
                                 _ => v.clone(),
                             }
                         }
-                        for item in data.items.iter_mut() {
+                        for item in data.items_mut().iter_mut() {
                             *item = clone_rows(item);
                         }
                     }

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -75,7 +75,7 @@ pub(super) fn dispatch(
                 {
                     crate::runtime::utils::shaped_array_leaves(target)
                 } else {
-                    (**items).clone().items
+                    (**items).clone().into_items()
                 };
                 sorted.sort_by(|a, b| crate::runtime::compare_values(a, b).cmp(&0));
                 Some(Ok(Value::seq(sorted)))
@@ -96,7 +96,7 @@ pub(super) fn dispatch(
                 let mut reversed = (**items).clone();
                 reversed.reverse();
                 // .reverse returns a Seq in Raku, not an Array
-                Some(Ok(Value::seq(reversed.items)))
+                Some(Ok(Value::seq(reversed.into_items())))
             }
             ValueView::Range(a, b)
             | ValueView::RangeExcl(a, b)

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1032,7 +1032,7 @@ impl Compiler {
                         && match expr {
                             Expr::Literal(lit) => match lit.view() {
                                 ValueView::Nil => true,
-                                ValueView::Array(ad, _) => ad.items.is_empty(),
+                                ValueView::Array(ad, _) => ad.items().is_empty(),
                                 _ => false,
                             },
                             Expr::Hash(pairs) => pairs.is_empty(),

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -774,7 +774,7 @@ impl Interpreter {
                     // SAFETY: audited aliased in-place container write (see
                     // value::aliased_mut); no borrow into the node is live.
                     let data = unsafe { crate::value::gc_contents_mut(&items) };
-                    data.items.resize(n, Value::int(0));
+                    data.items_mut().resize(n, Value::int(0));
                     return Ok(target.clone());
                 }
                 Ok(target)

--- a/src/runtime/builtins_atomic_shared.rs
+++ b/src/runtime/builtins_atomic_shared.rs
@@ -60,6 +60,7 @@ impl Interpreter {
             }
             Some(ValueView::Array(a, kind)) => {
                 let mut data = a.as_ref().clone();
+                data.clear_native_storage();
                 for v in data.items_mut().iter_mut() {
                     let taken = std::mem::replace(v, Value::NIL);
                     *v = Self::boxed_elem_cell(taken);
@@ -196,7 +197,11 @@ impl Interpreter {
             return c;
         }
         let (mut data, kind) = match arr.view() {
-            ValueView::Array(a, kind) => (a.as_ref().clone(), kind),
+            ValueView::Array(a, kind) => {
+                let mut data = a.as_ref().clone();
+                data.clear_native_storage();
+                (data, kind)
+            }
             _ => (
                 crate::value::ArrayData::new(Vec::new()),
                 crate::value::ArrayKind::Array,

--- a/src/runtime/builtins_atomic_shared.rs
+++ b/src/runtime/builtins_atomic_shared.rs
@@ -60,7 +60,7 @@ impl Interpreter {
             }
             Some(ValueView::Array(a, kind)) => {
                 let mut data = a.as_ref().clone();
-                for v in data.items.iter_mut() {
+                for v in data.items_mut().iter_mut() {
                     let taken = std::mem::replace(v, Value::NIL);
                     *v = Self::boxed_elem_cell(taken);
                 }
@@ -202,18 +202,18 @@ impl Interpreter {
                 crate::value::ArrayKind::Array,
             ),
         };
-        while data.items.len() <= idx {
-            data.items.push(Self::boxed_elem_cell(Value::int(0)));
+        while data.items().len() <= idx {
+            data.items_mut().push(Self::boxed_elem_cell(Value::int(0)));
         }
         let seed = {
-            let v = &data.items[idx];
+            let v = &data.items()[idx];
             if let ValueView::ContainerRef(c) = v.view() {
                 return c.clone();
             }
             v.clone()
         };
         let cell = crate::gc::Gc::new(std::sync::Mutex::new(seed));
-        data.items[idx] = Value::container_ref(cell.clone());
+        data.items_mut()[idx] = Value::container_ref(cell.clone());
         let updated = Value::array_with_kind(crate::gc::Gc::new(data), kind);
         shared.insert(atomic_key.to_string(), updated.clone());
         drop(shared);

--- a/src/runtime/builtins_collection_deepmap.rs
+++ b/src/runtime/builtins_collection_deepmap.rs
@@ -20,7 +20,7 @@ impl Interpreter {
                     {
                         match single.view() {
                             ValueView::Array(items, _) => {
-                                values = items.as_ref().clone().items;
+                                values = items.as_ref().clone().into_items();
                             }
                             ValueView::Seq(items) | ValueView::Slip(items) => {
                                 values = items.as_ref().clone();
@@ -303,7 +303,8 @@ impl Interpreter {
                                     // SAFETY: aliased in-place mutation of a shared
                                     // container; see `gc_contents_mut`.
                                     unsafe {
-                                        crate::value::gc_contents_mut(&items).items[idx] = new_src;
+                                        crate::value::gc_contents_mut(&items).items_mut()[idx] =
+                                            new_src;
                                     }
                                 }
                                 result.push(v);

--- a/src/runtime/builtins_multidim.rs
+++ b/src/runtime/builtins_multidim.rs
@@ -148,7 +148,7 @@ pub(super) fn multidim_delete(target: &mut Value, indices: &[Value]) -> Value {
     }
     // List/Array as index means "multiple indices in this dimension"
     if let ValueView::Array(idx_items, ..) = head.view() {
-        let idx_list: Vec<Value> = idx_items.as_ref().clone().items;
+        let idx_list: Vec<Value> = idx_items.as_ref().clone().into_items();
         let mut out = Vec::with_capacity(idx_list.len());
         for idx in &idx_list {
             let mut sub_indices = vec![idx.clone()];

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -622,6 +622,21 @@ impl crate::runtime::Interpreter {
                 args.len()
             ))));
         }
+        if let ValueView::Array(array, _) = args[1].view() {
+            let elem_type = array
+                .declared_type
+                .as_deref()
+                .and_then(|name| {
+                    name.strip_prefix("array[")
+                        .and_then(|s| s.strip_suffix(']'))
+                })
+                .or(array.value_type.as_deref());
+            if let Some(elem_type) = elem_type
+                && crate::runtime::native_types::is_native_array_element_type(elem_type)
+            {
+                unsafe { crate::value::gc_contents_mut(&array) }.promote_native_storage(elem_type);
+            }
+        }
         // `nativecast(:(num64 --> num64), $ptr)` — cast a raw C function pointer
         // to a *signature*, yielding something callable. This is how a symbol
         // looked up at runtime becomes a usable routine (`NativeLibs`'
@@ -724,6 +739,28 @@ impl crate::runtime::Interpreter {
             return Some(match method {
                 "REPR" => Value::str_from("VMArray"),
                 _ => Value::int(body as i64),
+            });
+        }
+        if let ValueView::Array(data, _) = target.view()
+            && let Some(elem_type) = data
+                .declared_type
+                .as_deref()
+                .and_then(|name| {
+                    name.strip_prefix("array[")
+                        .and_then(|s| s.strip_suffix(']'))
+                })
+                .or(data.value_type.as_deref())
+            && crate::runtime::native_types::is_native_array_element_type(elem_type)
+        {
+            if method == "WHERE" {
+                unsafe { crate::value::gc_contents_mut(&data) }.promote_native_storage(elem_type);
+                if let Some(body) = data.native_repr_body_address() {
+                    return Some(Value::int(body as i64));
+                }
+            }
+            return Some(match method {
+                "REPR" => Value::str_from("VMArray"),
+                _ => Value::int(data.items().as_ptr() as i64),
             });
         }
         let ValueView::Instance {

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -718,6 +718,14 @@ impl crate::runtime::Interpreter {
         if !matches!(method, "REPR" | "WHERE") {
             return None;
         }
+        if let ValueView::Array(data, _) = target.view()
+            && let Some(body) = data.native_repr_body_address()
+        {
+            return Some(match method {
+                "REPR" => Value::str_from("VMArray"),
+                _ => Value::int(body as i64),
+            });
+        }
         let ValueView::Instance {
             class_name,
             attributes,

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -166,7 +166,7 @@ fn jsonify(val: &Value, opts: &ToJsonOpts, level: usize, out: &mut String) {
                 jsonify(inner, opts, level, out);
             }
         }
-        ValueView::Array(arr, _) => jsonify_seq(&arr.items, opts, level, out),
+        ValueView::Array(arr, _) => jsonify_seq(&arr.items(), opts, level, out),
         ValueView::Seq(items)
         | ValueView::Slip(items)
         | ValueView::HyperSeq(items)

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -166,7 +166,7 @@ fn jsonify(val: &Value, opts: &ToJsonOpts, level: usize, out: &mut String) {
                 jsonify(inner, opts, level, out);
             }
         }
-        ValueView::Array(arr, _) => jsonify_seq(&arr.items(), opts, level, out),
+        ValueView::Array(arr, _) => jsonify_seq(arr.items(), opts, level, out),
         ValueView::Seq(items)
         | ValueView::Slip(items)
         | ValueView::HyperSeq(items)

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -254,9 +254,9 @@ impl Interpreter {
                 let front = matches!(method, "unshift" | "prepend");
                 target.with_array_inplace(|data, _| {
                     if front {
-                        data.items.splice(0..0, vals);
+                        data.items_mut().splice(0..0, vals);
                     } else {
-                        data.items.extend(vals);
+                        data.items_mut().extend(vals);
                     }
                 });
                 Ok(target)
@@ -273,12 +273,12 @@ impl Interpreter {
                 }
                 let removed = target
                     .with_array_inplace(|data, _| {
-                        if data.items.is_empty() {
+                        if data.items().is_empty() {
                             None
                         } else if method == "shift" {
-                            Some(data.items.remove(0))
+                            Some(data.items_mut().remove(0))
                         } else {
-                            data.items.pop()
+                            data.items_mut().pop()
                         }
                     })
                     .flatten();
@@ -303,7 +303,7 @@ impl Interpreter {
         data: &mut crate::value::ArrayData,
         args: &[Value],
     ) -> Vec<Value> {
-        let len = data.items.len();
+        let len = data.items().len();
         let resolve = |v: &Value| -> i64 {
             match v.view() {
                 ValueView::Int(i) => i,
@@ -336,9 +336,9 @@ impl Interpreter {
                 _ => replacement.push(arg.clone()),
             }
         }
-        let removed: Vec<Value> = data.items.drain(start..end).collect();
+        let removed: Vec<Value> = data.items_mut().drain(start..end).collect();
         for (i, item) in replacement.into_iter().enumerate() {
-            data.items.insert(start + i, item);
+            data.items_mut().insert(start + i, item);
         }
         removed
     }

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -188,7 +188,7 @@ impl Interpreter {
         }
         fn flatten_to_list(v: &Value) -> Vec<Value> {
             match v.view() {
-                ValueView::Array(items, ..) => items.as_ref().clone().items,
+                ValueView::Array(items, ..) => items.as_ref().clone().into_items(),
                 ValueView::Seq(items) | ValueView::Slip(items) => items.as_ref().clone(),
                 ValueView::LazyList(ll) => ll.cache.lock().unwrap().clone().unwrap_or_default(),
                 _ => vec![v.clone()],

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -338,7 +338,7 @@ impl Interpreter {
                     && let ValueView::Array(filtered_items, fkind) = filtered.view()
                 {
                     let mut data = (**filtered_items).clone();
-                    data.items = shared_cells;
+                    *data.items_mut() = shared_cells;
                     Value::array_with_kind(crate::gc::Gc::new(data), fkind)
                 } else {
                     filtered

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -235,7 +235,7 @@ impl Interpreter {
                             rule_args = positional.clone();
                         }
                         ValueView::Array(arr, _) => {
-                            rule_args = arr.as_ref().clone().items;
+                            rule_args = arr.as_ref().clone().into_items();
                         }
                         _ => {
                             rule_args = vec![value.clone()];

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2362,7 +2362,7 @@ impl Interpreter {
                 }
                 _ => {}
             }
-            Ok(Value::real_array(items.clone().items))
+            Ok(Value::real_array(items.clone().into_items()))
         }) {
             result
         } else {

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1351,7 +1351,7 @@ impl Interpreter {
                                     // `array_push_in_place` — no live borrow into the items,
                                     // and we do not re-enter the VM while the borrow is held.
                                     let data = unsafe { crate::value::gc_contents_mut(arc_items) };
-                                    data.items.extend(vals);
+                                    data.items_mut().extend(vals);
                                 } else {
                                     crate::gc::Gc::make_mut(arc_items).extend(vals);
                                 }
@@ -1416,9 +1416,9 @@ impl Interpreter {
                                 // Shared backing array: in-place interior mutation (see `push`).
                                 let items = if crate::gc::Gc::strong_count(arc_items) > 1 {
                                     // SAFETY: same contract as `array_push_in_place`.
-                                    unsafe { &mut crate::value::gc_contents_mut(arc_items).items }
+                                    unsafe { crate::value::gc_contents_mut(arc_items).items_mut() }
                                 } else {
-                                    crate::gc::Gc::make_mut(arc_items)
+                                    crate::gc::Gc::make_mut(arc_items).items_mut()
                                 };
                                 if items.is_empty() {
                                     make_empty_array_failure_what("pop", &empty_what)
@@ -1457,9 +1457,9 @@ impl Interpreter {
                             // observes the change. See the `push` branch above.
                             let items = if crate::gc::Gc::strong_count(arc_items) > 1 {
                                 // SAFETY: same contract as `array_push_in_place`.
-                                unsafe { &mut crate::value::gc_contents_mut(arc_items).items }
+                                unsafe { crate::value::gc_contents_mut(arc_items).items_mut() }
                             } else {
-                                crate::gc::Gc::make_mut(arc_items)
+                                crate::gc::Gc::make_mut(arc_items).items_mut()
                             };
                             for (i, arg) in normalized_args.iter().enumerate() {
                                 items.insert(i, arg.clone());
@@ -1491,9 +1491,9 @@ impl Interpreter {
                             // Shared backing array: in-place interior mutation (see `push`).
                             let items = if crate::gc::Gc::strong_count(arc_items) > 1 {
                                 // SAFETY: same contract as `array_push_in_place`.
-                                unsafe { &mut crate::value::gc_contents_mut(arc_items).items }
+                                unsafe { crate::value::gc_contents_mut(arc_items).items_mut() }
                             } else {
-                                crate::gc::Gc::make_mut(arc_items)
+                                crate::gc::Gc::make_mut(arc_items).items_mut()
                             };
                             for (i, arg) in flat_values.iter().enumerate() {
                                 items.insert(i, arg.clone());
@@ -1542,9 +1542,9 @@ impl Interpreter {
                                 // Shared backing array: in-place interior mutation (see `push`).
                                 let items = if crate::gc::Gc::strong_count(arc_items) > 1 {
                                     // SAFETY: same contract as `array_push_in_place`.
-                                    unsafe { &mut crate::value::gc_contents_mut(arc_items).items }
+                                    unsafe { crate::value::gc_contents_mut(arc_items).items_mut() }
                                 } else {
-                                    crate::gc::Gc::make_mut(arc_items)
+                                    crate::gc::Gc::make_mut(arc_items).items_mut()
                                 };
                                 if items.is_empty() {
                                     make_empty_array_failure_what("shift", &empty_what)

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -871,6 +871,20 @@ impl Interpreter {
                                 if !matches!(v.view(), ValueView::Nil)
                                     && !self.type_matches_value(&constraint, v)
                                 {
+                                    let expected_name = self
+                                        .container_type_metadata(&target)
+                                        .and_then(|info| info.declared_type)
+                                        .or_else(|| {
+                                            (self.var_type_constraint(&key).is_none())
+                                                .then(|| "Array".to_string())
+                                        })
+                                        .unwrap_or_else(|| {
+                                            if crate::runtime::native_types::is_native_array_element_type(&constraint) {
+                                                format!("array[{constraint}]")
+                                            } else {
+                                                format!("Array[{constraint}]")
+                                            }
+                                        });
                                     return Err(RuntimeError::typed(
                                         "X::TypeCheck::Splice",
                                         [
@@ -892,9 +906,13 @@ impl Interpreter {
                                             ),
                                             (
                                                 "expected".to_string(),
-                                                Value::package(crate::symbol::Symbol::intern(
-                                                    &constraint,
-                                                )),
+                                                if self.var_type_constraint(&key).is_some() {
+                                                    Value::package(crate::symbol::Symbol::intern(
+                                                        &expected_name,
+                                                    ))
+                                                } else {
+                                                    Value::str(expected_name.clone())
+                                                },
                                             ),
                                         ]
                                         .into_iter()
@@ -925,13 +943,34 @@ impl Interpreter {
                             };
                             for v in &candidates {
                                 if !v.is_nil() && !self.type_matches_value(&constraint, v) {
-                                    return Err(
-                                        crate::runtime::utils::type_check_element_typed_error(
-                                            "@_",
-                                            &constraint,
-                                            v,
-                                        ),
-                                    );
+                                    let expected_name = info
+                                        .declared_type
+                                        .clone()
+                                        .unwrap_or_else(|| {
+                                            if crate::runtime::native_types::is_native_array_element_type(&constraint) {
+                                                format!("array[{constraint}]")
+                                            } else {
+                                                format!("Array[{constraint}]")
+                                            }
+                                        });
+                                    return Err(RuntimeError::typed(
+                                        "X::TypeCheck::Splice",
+                                        [
+                                            ("action".to_string(), Value::str_from("splice")),
+                                            (
+                                                "got".to_string(),
+                                                Value::package(crate::symbol::Symbol::intern(
+                                                    crate::runtime::utils::value_type_name(v),
+                                                )),
+                                            ),
+                                            (
+                                                "expected".to_string(),
+                                                Value::str(expected_name.clone()),
+                                            ),
+                                        ]
+                                        .into_iter()
+                                        .collect(),
+                                    ));
                                 }
                             }
                         }

--- a/src/runtime/methods_mut_rw_attr.rs
+++ b/src/runtime/methods_mut_rw_attr.rs
@@ -171,10 +171,10 @@ impl Interpreter {
                 )));
             }
             let idx = idx as usize;
-            if idx >= data.items.len() {
-                data.items.resize(idx + 1, Value::NIL);
+            if idx >= data.items().len() {
+                data.items_mut().resize(idx + 1, Value::NIL);
             }
-            data.items[idx] = value.clone();
+            data.items_mut()[idx] = value.clone();
             Value::array_with_kind(crate::gc::Gc::new(data), kind)
         } else {
             let key = index_value.to_string_value();

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -660,7 +660,7 @@ impl Interpreter {
                     }
                 }
             }
-            let mut arr = Value::real_array(items.items);
+            let mut arr = Value::real_array(items.into_items());
             arr = self.tag_container_metadata(
                 arr,
                 super::ContainerTypeInfo {

--- a/src/runtime/methods_raku_dispatch.rs
+++ b/src/runtime/methods_raku_dispatch.rs
@@ -173,8 +173,8 @@ impl Interpreter {
         match value.view() {
             ValueView::Array(data, kind) => {
                 let mut rebuilt = ArrayData::clone(&data);
-                let items = std::mem::take(&mut rebuilt.items);
-                rebuilt.items = items
+                let items = rebuilt.take_items();
+                *rebuilt.items_mut() = items
                     .iter()
                     .map(|item| self.expand_raku_leaves(item, active, depth + 1))
                     .collect();

--- a/src/runtime/methods_subscript_protocol.rs
+++ b/src/runtime/methods_subscript_protocol.rs
@@ -82,16 +82,16 @@ impl Interpreter {
         let mut container = target.clone();
         let deleted = container.with_array_mut(|gc, _| {
             let data = crate::value::gc_data_mut(gc);
-            if index >= data.items.len() {
+            if index >= data.items().len() {
                 return Value::NIL;
             }
-            let old = std::mem::replace(&mut data.items[index], Value::NIL);
+            let old = std::mem::replace(&mut data.items_mut()[index], Value::NIL);
             if let Some(initialized) = data.initialized.as_mut() {
                 initialized.remove(&index);
             }
-            while !data.items.is_empty() && data.hole_at(data.items.len() - 1) {
-                let last = data.items.len() - 1;
-                data.items.pop();
+            while !data.items().is_empty() && data.hole_at(data.items().len() - 1) {
+                let last = data.items().len() - 1;
+                data.items_mut().pop();
                 if let Some(set) = data.initialized.as_mut() {
                     set.remove(&last);
                 }

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -439,7 +439,7 @@ pub fn call_native_with_out_args(
         {
             let sz = carray_elem_size(*elem);
             arr.with_array_inplace(|data, _kind| {
-                for (i, cell) in data.items.iter_mut().enumerate() {
+                for (i, cell) in data.items_mut().iter_mut().enumerate() {
                     let off = i * sz;
                     if off + sz <= buf.len() {
                         *cell = decode_carray_elem(*elem, &buf[off..off + sz]);
@@ -1032,7 +1032,7 @@ fn marshal_carray_arg(
         .ok_or_else(|| "CArray parameter is missing its element type".to_string())?;
     let list = match resolve_array_value(raw) {
         Some(arr) => arr
-            .with_array_inplace(|data, _| data.items.clone())
+            .with_array_inplace(|data, _| data.items().clone())
             .unwrap_or_default(),
         // A bare type object / Any becomes a null pointer.
         None => Vec::new(),

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -577,6 +577,7 @@ pub(crate) fn value_c_address(v: &Value) -> usize {
             }
             _ => 0,
         },
+        ValueView::Array(data, _) => data.native_storage_address().unwrap_or(0),
         ValueView::Scalar(inner) => value_c_address(inner),
         ValueView::ContainerRef(cell) => cell.lock().ok().map(|g| value_c_address(&g)).unwrap_or(0),
         ValueView::VarRef { value, .. } => value_c_address(value),
@@ -963,6 +964,7 @@ fn marshal_arg(ps: &ParamSpec, raw: &Value) -> Result<(libffi::middle::Type, Arg
 #[cfg(feature = "libffi")]
 fn buf_storage_node(v: &Value) -> Option<crate::gc::Gc<crate::value::BufData>> {
     match v.view() {
+        ValueView::Array(data, _) => data.native_storage_node(),
         ValueView::Instance { attributes, .. } => {
             crate::value::value_buf::buf_storage_node(&attributes)
         }

--- a/src/runtime/nqp_ops.rs
+++ b/src/runtime/nqp_ops.rs
@@ -263,10 +263,10 @@ impl Interpreter {
                         // value::aliased_mut) — same pattern as deepmap's
                         // element writeback; no borrow into the node is live.
                         let data = unsafe { crate::value::gc_contents_mut(&items) };
-                        if data.items.len() <= idx {
-                            data.items.resize(idx + 1, Value::int(0));
+                        if data.items().len() <= idx {
+                            data.items_mut().resize(idx + 1, Value::int(0));
                         }
-                        data.items[idx] = val.clone();
+                        data.items_mut()[idx] = val.clone();
                         Ok(val)
                     }
                     _ => Err(RuntimeError::new(format!(

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1502,7 +1502,7 @@ impl Interpreter {
                 let expr = variants[0].1.as_ref().unwrap();
                 let v = self.eval_block_value(&[Stmt::Expr(expr.clone())])?;
                 let raw_items: Vec<Value> = match v.view() {
-                    ValueView::Array(items, _) => items.as_ref().clone().items,
+                    ValueView::Array(items, _) => items.as_ref().clone().into_items(),
                     ValueView::Seq(items) | ValueView::Slip(items) => items.as_ref().clone(),
                     ValueView::Hash(map) => map
                         .iter()

--- a/src/runtime/run_prelude.rs
+++ b/src/runtime/run_prelude.rs
@@ -528,7 +528,7 @@ impl Interpreter {
             let is_default = match expr {
                 Expr::Literal(v) => match v.view() {
                     ValueView::Nil => true,
-                    ValueView::Array(d, _) => d.items.is_empty(),
+                    ValueView::Array(d, _) => d.items().is_empty(),
                     _ => false,
                 },
                 Expr::Hash(items) => items.is_empty(),

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -103,15 +103,6 @@ impl Interpreter {
         if value
             .with_array_mut(|arc, _kind| {
                 embed_type_info!(arc);
-                if info
-                    .declared_type
-                    .as_deref()
-                    .is_some_and(|name| name.starts_with("array["))
-                    && crate::runtime::native_types::is_native_array_element_type(&info.value_type)
-                {
-                    crate::gc::ContainerMakeMut::container_make_mut(arc)
-                        .promote_native_storage(&info.value_type);
-                }
             })
             .is_some()
         {

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -101,7 +101,18 @@ impl Interpreter {
             }};
         }
         if value
-            .with_array_mut(|arc, _kind| embed_type_info!(arc))
+            .with_array_mut(|arc, _kind| {
+                embed_type_info!(arc);
+                if info
+                    .declared_type
+                    .as_deref()
+                    .is_some_and(|name| name.starts_with("array["))
+                    && crate::runtime::native_types::is_native_array_element_type(&info.value_type)
+                {
+                    crate::gc::ContainerMakeMut::container_make_mut(arc)
+                        .promote_native_storage(&info.value_type);
+                }
+            })
             .is_some()
         {
             return value;

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -143,10 +143,10 @@ impl Interpreter {
             .with_entry_mut(key, |val| {
                 val.with_array_mut(|arc, kind| {
                     let data = crate::gc::Gc::make_mut(arc);
-                    if idx >= data.items.len() {
-                        data.items.resize(idx + 1, Value::NIL);
+                    if idx >= data.items().len() {
+                        data.items_mut().resize(idx + 1, Value::NIL);
                     }
-                    data.items[idx] = value.clone();
+                    data.items_mut()[idx] = value.clone();
                     if *kind == ArrayKind::List {
                         *kind = ArrayKind::Array;
                     }

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -1687,7 +1687,7 @@ impl Interpreter {
 
             // Collect results, avoiding duplicates at segment boundaries
             let items: Option<Vec<Value>> = match seg_result.view() {
-                ValueView::Array(items, ..) => Some(items.as_ref().clone().items),
+                ValueView::Array(items, ..) => Some(items.as_ref().clone().into_items()),
                 ValueView::LazyList(ll) => ll.cache.lock().unwrap().clone(),
                 _ => None,
             };

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -317,7 +317,7 @@ impl Interpreter {
             // (`@arr[idx]`).
             if let Some((slurpy_key, elem_idx, src_idx)) = decode_slurpy_rw_param(param_name) {
                 let Some(elem) = self.env.get(slurpy_key).and_then(|v| match v.view() {
-                    ValueView::Array(arr, _) => arr.items.get(elem_idx).cloned(),
+                    ValueView::Array(arr, _) => arr.items().get(elem_idx).cloned(),
                     _ => None,
                 }) else {
                     continue;
@@ -332,8 +332,8 @@ impl Interpreter {
                             .and_then(Value::into_array)
                         {
                             let mut data = (*arr).clone();
-                            if i < data.items.len() {
-                                data.items[i] = elem;
+                            if i < data.items().len() {
+                                data.items_mut()[i] = elem;
                                 target_env.insert(
                                     source_name.clone(),
                                     Value::array_with_kind(crate::gc::Gc::new(data), kind),

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -291,7 +291,7 @@ impl Interpreter {
             }
             ValueView::Pair(name, boxed) if self.registry().roles.contains_key(name) => {
                 if let ValueView::Array(args, ..) = boxed.view() {
-                    Some((name.clone(), args.as_ref().clone().items))
+                    Some((name.clone(), args.as_ref().clone().into_items()))
                 } else {
                     None
                 }

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -286,7 +286,7 @@ pub(in crate::runtime) fn named_values_from_unpack_target(
         }
         // A list of Pairs (e.g. `(a => 1, b => 2)`) destructured by named
         // params `(:$a, :$b)` binds each pair's key to its value.
-        ValueView::Array(data, _) => pairs_in_list_to_named(&data.items()),
+        ValueView::Array(data, _) => pairs_in_list_to_named(data.items()),
         ValueView::Seq(items) | ValueView::Slip(items) => pairs_in_list_to_named(&items),
         ValueView::Instance { attributes, .. } => HashMap::from(&*attributes.as_map()),
         _ => std::collections::HashMap::new(),

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -21,7 +21,7 @@ pub(in crate::runtime) fn positional_values_from_unpack_target(value: &Value) ->
         // bound to a single destructuring positional via the single-argument
         // rule. `value_to_list` would otherwise return an itemized list as a
         // single opaque element, which fails the destructuring arity check.
-        ValueView::Array(data, _) => data.items.clone(),
+        ValueView::Array(data, _) => data.items().clone(),
         ValueView::Seq(items) | ValueView::Slip(items) => (**items).clone(),
         _ => crate::runtime::value_to_list(value),
     }
@@ -286,7 +286,7 @@ pub(in crate::runtime) fn named_values_from_unpack_target(
         }
         // A list of Pairs (e.g. `(a => 1, b => 2)`) destructured by named
         // params `(:$a, :$b)` binds each pair's key to its value.
-        ValueView::Array(data, _) => pairs_in_list_to_named(&data.items),
+        ValueView::Array(data, _) => pairs_in_list_to_named(&data.items()),
         ValueView::Seq(items) | ValueView::Slip(items) => pairs_in_list_to_named(&items),
         ValueView::Instance { attributes, .. } => HashMap::from(&*attributes.as_map()),
         _ => std::collections::HashMap::new(),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1145,6 +1145,7 @@ pub struct ArrayData {
     /// the legacy collection API and is refreshed by the accessor chokepoint.
     native_storage: Option<crate::gc::Gc<BufData>>,
     native_dirty: bool,
+    native_snapshot: Option<Vec<u8>>,
     /// Element value-type constraint (e.g. `Int` for `my Int @a`), if any.
     pub value_type: Option<String>,
     /// Key-type constraint — unused for arrays, present so the shared

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1139,7 +1139,7 @@ pub struct HashData {
 /// via pointer reuse.
 #[derive(Debug, Clone, Default)]
 pub struct ArrayData {
-    pub items: Vec<Value>,
+    items: Vec<Value>,
     /// Element value-type constraint (e.g. `Int` for `my Int @a`), if any.
     pub value_type: Option<String>,
     /// Key-type constraint — unused for arrays, present so the shared

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1140,6 +1140,11 @@ pub struct HashData {
 #[derive(Debug, Clone, Default)]
 pub struct ArrayData {
     items: Vec<Value>,
+    /// Native numeric `array[T]` payload, when this array has been promoted
+    /// to ADR-0015 P3b storage. The boxed vector remains a derived cache for
+    /// the legacy collection API and is refreshed by the accessor chokepoint.
+    native_storage: Option<crate::gc::Gc<BufData>>,
+    native_dirty: bool,
     /// Element value-type constraint (e.g. `Int` for `my Int @a`), if any.
     pub value_type: Option<String>,
     /// Key-type constraint — unused for arrays, present so the shared

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -157,6 +157,24 @@ fn encode_elems(elems: &[Value], width: u8, kind: ElemKind) -> Vec<u8> {
     bytes
 }
 
+/// Build the payload node used by a native numeric `array[T]`.
+pub(crate) fn make_native_array_storage(elem_type: &str, elems: &[Value]) -> Option<Gc<BufData>> {
+    let (width, kind) = native_elem_type(elem_type)?;
+    Some(Gc::new(BufData::new(
+        encode_elems(elems, width, kind),
+        width,
+        kind,
+    )))
+}
+
+pub(crate) fn decode_storage(data: &BufData) -> Vec<Value> {
+    decode_elems(data)
+}
+
+pub(crate) fn encode_storage(data: &BufData, elems: &[Value]) -> Vec<u8> {
+    encode_elems(elems, data.width, data.kind)
+}
+
 /// The bit pattern one element occupies, as the `u64` its `width` low bytes
 /// spell. For a float element that is the IEEE-754 encoding at the element
 /// width; for an integer element it is [`elem_to_u64`].

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -165,6 +165,26 @@ impl ArrayData {
         self.value_type.is_some() || self.key_type.is_some() || self.declared_type.is_some()
     }
 
+    /// Borrow the element vector through the representation chokepoint.
+    pub(crate) fn items(&self) -> &Vec<Value> {
+        &self.items
+    }
+
+    /// Mutably borrow the element vector through the representation chokepoint.
+    pub(crate) fn items_mut(&mut self) -> &mut Vec<Value> {
+        &mut self.items
+    }
+
+    /// Move all elements out through the representation chokepoint.
+    pub(crate) fn take_items(&mut self) -> Vec<Value> {
+        std::mem::take(&mut self.items)
+    }
+
+    /// Consume the array data and return its elements.
+    pub(crate) fn into_items(self) -> Vec<Value> {
+        self.items
+    }
+
     /// Whether index `i` is a hole (a deleted slot or an autovivification
     /// gap), as opposed to an explicitly-assigned element. The canonical
     /// predicate mirrored by `:exists`/`:k`/`:p`: a literal `Nil` slot is a
@@ -188,13 +208,13 @@ impl ArrayData {
 impl std::ops::Deref for ArrayData {
     type Target = Vec<Value>;
     fn deref(&self) -> &Vec<Value> {
-        &self.items
+        self.items()
     }
 }
 
 impl std::ops::DerefMut for ArrayData {
     fn deref_mut(&mut self) -> &mut Vec<Value> {
-        &mut self.items
+        self.items_mut()
     }
 }
 

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -151,6 +151,8 @@ impl ArrayData {
     pub fn new(items: Vec<Value>) -> Self {
         ArrayData {
             items,
+            native_storage: None,
+            native_dirty: false,
             value_type: None,
             key_type: None,
             declared_type: None,
@@ -167,22 +169,84 @@ impl ArrayData {
 
     /// Borrow the element vector through the representation chokepoint.
     pub(crate) fn items(&self) -> &Vec<Value> {
+        self.sync_native_items();
         &self.items
     }
 
     /// Mutably borrow the element vector through the representation chokepoint.
     pub(crate) fn items_mut(&mut self) -> &mut Vec<Value> {
+        self.native_dirty = self.native_storage.is_some();
         &mut self.items
+    }
+
+    /// Promote a numeric `array[T]` to the shared native payload node.
+    pub(crate) fn promote_native_storage(&mut self, elem_type: &str) {
+        // A shaped array stores row arrays at this level. Native storage is
+        // promoted per flat numeric array only; encoding a row object as a
+        // scalar would destroy the shape (and its nested values).
+        if self
+            .items
+            .iter()
+            .any(|value| matches!(value.view(), crate::value::ValueView::Array(..)))
+        {
+            return;
+        }
+        if self.native_storage.is_none()
+            && let Some(node) =
+                crate::value::value_buf::make_native_array_storage(elem_type, &self.items)
+        {
+            self.native_storage = Some(node);
+        }
+    }
+
+    pub(crate) fn native_storage_address(&self) -> Option<usize> {
+        self.native_storage
+            .as_ref()
+            .map(|node| node.bytes.as_ptr() as usize)
+    }
+
+    pub(crate) fn native_storage_node(&self) -> Option<crate::gc::Gc<BufData>> {
+        self.native_storage.clone()
+    }
+
+    pub(crate) fn native_repr_body_address(&self) -> Option<usize> {
+        self.native_storage
+            .as_ref()
+            .map(|node| node.body.address(node))
     }
 
     /// Move all elements out through the representation chokepoint.
     pub(crate) fn take_items(&mut self) -> Vec<Value> {
+        self.sync_native_items();
         std::mem::take(&mut self.items)
     }
 
     /// Consume the array data and return its elements.
     pub(crate) fn into_items(self) -> Vec<Value> {
+        self.sync_native_items();
         self.items
+    }
+
+    fn sync_native_items(&self) {
+        let Some(node) = &self.native_storage else {
+            return;
+        };
+        let decoded = if self.native_dirty {
+            let bytes = crate::value::value_buf::encode_storage(node, &self.items);
+            unsafe {
+                let data = crate::value::gc_contents_mut(node);
+                data.bytes.clear();
+                data.bytes.extend_from_slice(&bytes);
+            }
+            self.items.clone()
+        } else {
+            crate::value::value_buf::decode_storage(node)
+        };
+        unsafe {
+            let this = self as *const Self as *mut Self;
+            std::ptr::addr_of_mut!((*this).items).write(decoded);
+            std::ptr::addr_of_mut!((*this).native_dirty).write(false);
+        }
     }
 
     /// Whether index `i` is a hole (a deleted slot or an autovivification

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -153,6 +153,7 @@ impl ArrayData {
             items,
             native_storage: None,
             native_dirty: false,
+            native_snapshot: None,
             value_type: None,
             key_type: None,
             declared_type: None,
@@ -196,6 +197,7 @@ impl ArrayData {
                 crate::value::value_buf::make_native_array_storage(elem_type, &self.items)
         {
             self.native_storage = Some(node);
+            self.native_snapshot = self.native_storage.as_ref().map(|n| n.bytes.clone());
         }
     }
 
@@ -216,6 +218,7 @@ impl ArrayData {
     pub(crate) fn clear_native_storage(&mut self) {
         self.native_storage = None;
         self.native_dirty = false;
+        self.native_snapshot = None;
     }
 
     pub(crate) fn native_repr_body_address(&self) -> Option<usize> {
@@ -240,21 +243,31 @@ impl ArrayData {
         let Some(node) = &self.native_storage else {
             return;
         };
-        let decoded = if self.native_dirty {
-            let bytes = crate::value::value_buf::encode_storage(node, &self.items);
-            unsafe {
-                let data = crate::value::gc_contents_mut(node);
-                data.bytes.clear();
-                data.bytes.extend_from_slice(&bytes);
-            }
-            self.items.clone()
+        let current_bytes = node.bytes.clone();
+        if !self.native_dirty && self.native_snapshot.as_ref() == Some(&current_bytes) {
+            return;
+        }
+        let (bytes, decoded) = if self.native_dirty {
+            (
+                crate::value::value_buf::encode_storage(node, &self.items),
+                self.items.clone(),
+            )
         } else {
-            crate::value::value_buf::decode_storage(node)
+            (
+                current_bytes.clone(),
+                crate::value::value_buf::decode_storage(node),
+            )
         };
+        unsafe {
+            let data = crate::gc::gc_contents_mut(node);
+            data.bytes.clear();
+            data.bytes.extend_from_slice(&bytes);
+        }
         unsafe {
             let this = self as *const Self as *mut Self;
             std::ptr::addr_of_mut!((*this).items).write(decoded);
             std::ptr::addr_of_mut!((*this).native_dirty).write(false);
+            std::ptr::addr_of_mut!((*this).native_snapshot).write(Some(bytes));
         }
     }
 

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -209,6 +209,15 @@ impl ArrayData {
         self.native_storage.clone()
     }
 
+    /// Detach the native payload when a caller is about to replace or reshape
+    /// the boxed element vector.  The vector is authoritative for such a
+    /// reconstruction; retaining the old payload would let the next accessor
+    /// decode stale values back over the new elements.
+    pub(crate) fn clear_native_storage(&mut self) {
+        self.native_storage = None;
+        self.native_dirty = false;
+    }
+
     pub(crate) fn native_repr_body_address(&self) -> Option<usize> {
         self.native_storage
             .as_ref()

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -447,6 +447,8 @@ impl Trace for ArrayData {
         // Clearing the elements drops every outgoing edge. `&mut self` is
         // supplied by the collector via the backing `Arc` (gc::gc_drop_edges).
         self.items.clear();
+        self.native_storage = None;
+        self.native_dirty = false;
         self.default = None;
     }
 }

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -253,6 +253,8 @@ impl Value {
     pub(crate) fn array_data_like(like: &ArrayData, items: Vec<Value>) -> crate::gc::Gc<ArrayData> {
         crate::gc::Gc::new(ArrayData {
             items,
+            native_storage: like.native_storage.clone(),
+            native_dirty: like.native_dirty,
             value_type: like.value_type.clone(),
             key_type: like.key_type.clone(),
             declared_type: like.declared_type.clone(),

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -257,6 +257,7 @@ impl Value {
             // describe the previous vector and must not be carried across.
             native_storage: None,
             native_dirty: false,
+            native_snapshot: None,
             value_type: like.value_type.clone(),
             key_type: like.key_type.clone(),
             declared_type: like.declared_type.clone(),

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -253,8 +253,10 @@ impl Value {
     pub(crate) fn array_data_like(like: &ArrayData, items: Vec<Value>) -> crate::gc::Gc<ArrayData> {
         crate::gc::Gc::new(ArrayData {
             items,
-            native_storage: like.native_storage.clone(),
-            native_dirty: like.native_dirty,
+            // `items` is a rebuilt authoritative vector; an old payload may
+            // describe the previous vector and must not be carried across.
+            native_storage: None,
+            native_dirty: false,
             value_type: like.value_type.clone(),
             key_type: like.key_type.clone(),
             declared_type: like.declared_type.clone(),

--- a/src/vm/vm_arith_int_ops.rs
+++ b/src/vm/vm_arith_int_ops.rs
@@ -116,7 +116,7 @@ impl Interpreter {
             lookup_key.to_string(),
             Value::array_with_kind(crate::gc::Gc::new(items), kind),
         );
-        Ok(Some(result.items))
+        Ok(Some(result.into_items()))
     }
 
     /// Interpreter-native implementation of xx-repeat for thunks.

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1002,12 +1002,12 @@ impl Interpreter {
                         && self.atomic_array_entry_exists(&target_name) =>
                 {
                     let (result, _) = self.shared_array_mutate(&target_name, |data, _| {
-                        if data.items.is_empty() {
+                        if data.items().is_empty() {
                             crate::runtime::utils::make_empty_array_failure_what(&method, "Array")
                         } else if method == "shift" {
-                            data.items.remove(0)
+                            data.items_mut().remove(0)
                         } else {
-                            data.items.pop().unwrap_or(Value::NIL)
+                            data.items_mut().pop().unwrap_or(Value::NIL)
                         }
                     });
                     self.stack.push(result);

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -88,7 +88,7 @@ impl Interpreter {
                     let mut guard = cell.lock().unwrap_or_else(|e| e.into_inner());
                     (*guard).with_array_mut(|arc, _| {
                         let data = crate::gc::Gc::make_mut(arc);
-                        data.items.extend(items);
+                        data.items_mut().extend(items);
                     });
                     let result = guard.clone();
                     drop(guard);
@@ -213,9 +213,9 @@ impl Interpreter {
                         let val = val_slot.take().expect("push value present");
                         match val.view() {
                             ValueView::Slip(slip_items) => {
-                                data.items.extend(slip_items.iter().cloned())
+                                data.items_mut().extend(slip_items.iter().cloned())
                             }
-                            _ => data.items.push(val),
+                            _ => data.items_mut().push(val),
                         }
                     })
                     .is_some();
@@ -274,8 +274,10 @@ impl Interpreter {
             v.with_array_inplace(|data, _| {
                 let val = val_slot.take().expect("push value present");
                 match val.view() {
-                    ValueView::Slip(slip_items) => data.items.extend(slip_items.iter().cloned()),
-                    _ => data.items.push(val),
+                    ValueView::Slip(slip_items) => {
+                        data.items_mut().extend(slip_items.iter().cloned())
+                    }
+                    _ => data.items_mut().push(val),
                 }
             })
         });

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3354,7 +3354,7 @@ impl Interpreter {
                         ValueView::Array(arc, _) => {
                             // SAFETY: aliased in-place clear of a shared container;
                             // see `gc_contents_mut`.
-                            unsafe { crate::value::gc_contents_mut(&arc).items.clear() };
+                            unsafe { crate::value::gc_contents_mut(&arc).items_mut().clear() };
                         }
                         ValueView::Hash(arc) => {
                             // SAFETY: aliased in-place clear; see `gc_contents_mut`.
@@ -3372,7 +3372,7 @@ impl Interpreter {
                     match self.locals[slot].view() {
                         ValueView::Array(arc, _) => {
                             // SAFETY: aliased in-place clear; see `gc_contents_mut`.
-                            unsafe { crate::value::gc_contents_mut(&arc).items.clear() };
+                            unsafe { crate::value::gc_contents_mut(&arc).items_mut().clear() };
                         }
                         ValueView::Hash(arc) => {
                             // SAFETY: aliased in-place clear; see `gc_contents_mut`.

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -27,7 +27,7 @@ impl Interpreter {
     pub(super) fn clear_aggregate_cell(cell: &crate::gc::Gc<std::sync::Mutex<Value>>) {
         let mut guard = cell.lock().unwrap();
         if (*guard)
-            .with_array_mut(|arc, _| crate::gc::Gc::make_mut(arc).items.clear())
+            .with_array_mut(|arc, _| crate::gc::Gc::make_mut(arc).items_mut().clear())
             .is_none()
             && (*guard)
                 .with_hash_mut(|arc| crate::gc::Gc::make_mut(arc).map.clear())

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -874,7 +874,7 @@ impl Interpreter {
                 // `gc_contents_mut`. No borrow into this ArrayData is live
                 // across the write.
                 unsafe {
-                    crate::value::gc_contents_mut(&existing).items = items.clone();
+                    *crate::value::gc_contents_mut(&existing).items_mut() = items.clone();
                 }
                 loan_env!(
                     self,
@@ -1303,7 +1303,7 @@ impl Interpreter {
             // SAFETY: aliased in-place mutation of a shared container; see
             // `gc_contents_mut`.
             unsafe {
-                crate::value::gc_contents_mut(&existing).items = items.clone();
+                *crate::value::gc_contents_mut(&existing).items_mut() = items.clone();
             }
             loan_env!(
                 self,

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -209,7 +209,7 @@ impl Interpreter {
         if !multi_param_names.is_empty() {
             if let ValueView::Array(chunk, _) = item.view() {
                 for (i, name) in multi_param_names.iter().enumerate() {
-                    if let Some(bound) = chunk.items.get(i)
+                    if let Some(bound) = chunk.items().get(i)
                         && changed(name, bound)
                     {
                         return Some(RuntimeError::assignment_ro(Some(name)));
@@ -345,7 +345,7 @@ impl Interpreter {
         // turning `array[int]` into a bare `Array` and breaking later `.WHAT`,
         // `.raku`, and shaped `:delete`-dies behaviour).
         let mut new_data = (*items).clone();
-        new_data.items[actual_idx] = current_topic;
+        new_data.items_mut()[actual_idx] = current_topic;
         let updated_value = Value::array_with_kind(crate::gc::Gc::new(new_data), kind);
         self.write_back_container_source(code, source, source_slot, &raw_source, updated_value);
     }

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -331,7 +331,7 @@ impl Interpreter {
         match val.view() {
             ValueView::Array(arc_vec, kind) => {
                 let mut data = (**arc_vec).clone();
-                for v in data.items.iter_mut() {
+                for v in data.items_mut().iter_mut() {
                     *v = Self::deep_copy_value(v);
                 }
                 Value::array_with_kind(crate::gc::Gc::new(data), kind)

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -74,7 +74,7 @@ impl Interpreter {
                     || self.type_matches_value("Positional", val)
             }
             ValueView::Array(arr, _) => {
-                let items = arr.items.clone();
+                let items = arr.items().clone();
                 items.iter().any(|i| self.json_subject_needs_prepare(i))
             }
             ValueView::Seq(items) | ValueView::Slip(items) => {
@@ -107,7 +107,7 @@ impl Interpreter {
                     return val.clone();
                 };
                 let items: Vec<Value> = match listed.view() {
-                    ValueView::Array(arr, _) => arr.items.clone(),
+                    ValueView::Array(arr, _) => arr.items().clone(),
                     ValueView::Seq(items) | ValueView::Slip(items) => items.to_vec(),
                     _ => return val.clone(),
                 };
@@ -137,7 +137,7 @@ impl Interpreter {
             }
             ValueView::Array(arr, kind) => {
                 let items: Vec<Value> = arr
-                    .items
+                    .items()
                     .iter()
                     .map(|i| self.prepare_to_json_subject(i))
                     .collect();

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -233,10 +233,10 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
         // Array/List ~~ Numeric: a list smart-matched against a number compares
         // numerically (`@a == $n`), and a list's numeric value is its element
         // count — so `[1,2,3] ~~ 3` is True (3 elems), `~~ 2` is False.
-        (ValueView::Array(a, _), ValueView::Int(b)) => Some(a.items.len() as i64 == b),
-        (ValueView::Array(a, _), ValueView::Num(b)) => Some(a.items.len() as f64 == b),
+        (ValueView::Array(a, _), ValueView::Int(b)) => Some(a.items().len() as i64 == b),
+        (ValueView::Array(a, _), ValueView::Num(b)) => Some(a.items().len() as f64 == b),
         (ValueView::Array(a, _), ValueView::Rat(n, d)) => {
-            Some(d != 0 && a.items.len() as i64 * d == n)
+            Some(d != 0 && a.items().len() as i64 * d == n)
         }
 
         // IO::Path ~~ IO::Path: compare by cleanup.absolute

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -484,7 +484,7 @@ impl Interpreter {
         val: &Value,
     ) -> Result<Vec<Value>, RuntimeError> {
         Ok(match val.view() {
-            ValueView::Array(v, ..) => v.as_ref().clone().items,
+            ValueView::Array(v, ..) => v.as_ref().clone().into_items(),
             ValueView::Seq(v) | ValueView::Slip(v) => v.iter().cloned().collect(),
             ValueView::Range(a, b) => {
                 let end = b.min(a.saturating_add(Self::MAX_ASSIGN_SLICE_EXPAND));

--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -32,7 +32,7 @@ impl Interpreter {
                 if let Some(i) = Self::index_to_usize(key) {
                     // SAFETY: aliased in-place mutation of a shared array; see
                     // `gc_contents_mut`.
-                    let v = &mut unsafe { crate::value::gc_contents_mut(&arc) }.items;
+                    let v = unsafe { crate::value::gc_contents_mut(&arc) }.items_mut();
                     Self::autoviv_resize(v, i + 1, Value::NIL)?;
                     Value::assign_element_slot(&mut v[i], val);
                 }

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -658,10 +658,10 @@ impl Interpreter {
                             crate::value::ArrayKind::Array,
                         ),
                     };
-                    if idx_u >= items.items.len() {
-                        items.items.resize(idx_u + 1, Value::NIL);
+                    if idx_u >= items.items().len() {
+                        items.items_mut().resize(idx_u + 1, Value::NIL);
                     }
-                    items.items[idx_u] = val.clone();
+                    items.items_mut()[idx_u] = val.clone();
                     *storage = Value::array_with_kind(crate::gc::Gc::new(items), kind);
                 });
                 self.stack.push(val);
@@ -769,7 +769,7 @@ impl Interpreter {
                     // straight to `*mut Vec<Value>`, assuming `items` sits at
                     // offset 0; this types it properly as `&mut ArrayData`.)
                     let data = unsafe { crate::value::gc_contents_mut(&items) };
-                    data.items[i] = Value::scalar(val.clone());
+                    data.items_mut()[i] = Value::scalar(val.clone());
                     self.stack.push(val);
                     return Ok(());
                 }
@@ -2600,7 +2600,7 @@ impl Interpreter {
         ) {
             let outer_keys: Vec<Value> = match outer_idx.view() {
                 ValueView::Junction { values, .. } => values.as_ref().clone(),
-                ValueView::Array(a, ..) => a.items.to_vec(),
+                ValueView::Array(a, ..) => a.items().to_vec(),
                 _ => unreachable!(),
             };
             // A scalar RHS goes to every junction key; a slice/junction RHS
@@ -2713,7 +2713,7 @@ impl Interpreter {
                 Some(ValueView::Array(arr, ..)) => inner_key
                     .parse::<usize>()
                     .ok()
-                    .and_then(|i| arr.items.get(i).cloned()),
+                    .and_then(|i| arr.items().get(i).cloned()),
                 _ => None,
             };
             self.resolve_whatever_index_for_target(outer_idx, inner_container.as_ref())
@@ -2998,7 +2998,7 @@ impl Interpreter {
         {
             let outer_keys: Vec<Value> = match outermost.view() {
                 ValueView::Junction { values, .. } => values.as_ref().clone(),
-                ValueView::Array(a, ..) => a.items.to_vec(),
+                ValueView::Array(a, ..) => a.items().to_vec(),
                 _ => unreachable!(),
             };
             let vals: Vec<Value> = match (outermost.view(), raw_val_for_junction.view()) {
@@ -3372,7 +3372,7 @@ impl Interpreter {
                         (values.as_ref().clone(), vals)
                     }
                     ValueView::Array(keys, ..) => {
-                        (keys.items.to_vec(), self.assignment_rhs_values(&val)?)
+                        (keys.items().to_vec(), self.assignment_rhs_values(&val)?)
                     }
                     _ => unreachable!(),
                 };
@@ -3443,7 +3443,7 @@ impl Interpreter {
                     // SAFETY: aliased in-place mutation of a shared array so the
                     // change is visible to all holders of the same Arc; see
                     // `gc_contents_mut`.
-                    let v = &mut unsafe { crate::value::gc_contents_mut(&arc) }.items;
+                    let v = unsafe { crate::value::gc_contents_mut(&arc) }.items_mut();
                     Self::autoviv_resize(
                         v,
                         i + 1,

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -164,8 +164,8 @@ impl Interpreter {
                 // Clone the ArrayData so shape/default/type metadata survive;
                 // only the items are rewritten.
                 let mut data = (**items).clone();
-                data.items =
-                    crate::runtime::utils::nil_elems_to_any(std::mem::take(&mut data.items));
+                let old_items = data.take_items();
+                *data.items_mut() = crate::runtime::utils::nil_elems_to_any(old_items);
                 assigned = Value::array_with_kind(crate::gc::Gc::new(data), kind);
             }
             let class_name = match self.locals[idx].view() {

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -661,12 +661,12 @@ impl Interpreter {
             result_arc.verify_unique_for_aliased_mut("fixup_circular_array_refs");
             let data = unsafe { crate::value::gc_contents_mut(&result_arc) };
             for idx in &circular_indices {
-                data.items[*idx] = Value::array_with_kind(result_arc.clone(), *kind);
+                data.items_mut()[*idx] = Value::array_with_kind(result_arc.clone(), *kind);
             }
             for idx in &hash_fixup_indices {
                 let mut seen = Vec::new();
                 Self::replace_array_refs_in_value(
-                    &mut data.items[*idx],
+                    &mut data.items_mut()[*idx],
                     *old_ptr,
                     &result_arc,
                     *kind,
@@ -691,7 +691,7 @@ impl Interpreter {
         let new_ptr = crate::gc::Gc::as_ptr(new_gc) as usize;
         let mut new_data = (**new_gc).clone();
         let mut seen = Vec::new();
-        for item in new_data.items.iter_mut() {
+        for item in new_data.items_mut().iter_mut() {
             Self::replace_array_refs_in_value(item, new_ptr, old_gc, kind, &mut seen);
         }
         // SAFETY: single audited aliased in-place write; `new_data` is a fresh

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -499,10 +499,10 @@ impl Interpreter {
                         crate::value::ArrayKind::Array,
                     ),
                 };
-                if i >= items.items.len() {
-                    items.items.resize(i + 1, Value::NIL);
+                if i >= items.items().len() {
+                    items.items_mut().resize(i + 1, Value::NIL);
                 }
-                items.items[i] = new_val.clone();
+                items.items_mut()[i] = new_val.clone();
                 *st = Value::array_with_kind(crate::gc::Gc::new(items), kind);
             });
             self.stack

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -947,8 +947,8 @@ impl Interpreter {
                 // Clone the ArrayData so shape/default/type metadata survive;
                 // only the items are rewritten.
                 let mut data = (**items).clone();
-                data.items =
-                    crate::runtime::utils::nil_elems_to_any(std::mem::take(&mut data.items));
+                let old_items = data.take_items();
+                *data.items_mut() = crate::runtime::utils::nil_elems_to_any(old_items);
                 assigned = Value::array_with_kind(crate::gc::Gc::new(data), kind);
             }
             // Mark a genuine bound array SLICE (`@slice := @array[1,2]`, §4

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -802,7 +802,7 @@ impl Interpreter {
             // flat List (e.g. `[0,[1,[2,3]]][**]` == `(0,1,2,3)`).
             (ValueView::Array(items, _is_arr), ValueView::HyperWhatever) => {
                 let mut leaves = Vec::new();
-                Self::hyperwhatever_hammer_collect(&items.items, &mut leaves);
+                Self::hyperwhatever_hammer_collect(&items.items(), &mut leaves);
                 Value::array(leaves)
             }
             (ValueView::Array(items, is_arr), ValueView::Int(i)) => {
@@ -2308,7 +2308,7 @@ impl Interpreter {
         for item in items {
             match item.view() {
                 ValueView::Array(data, _) => {
-                    Self::hyperwhatever_hammer_collect(&data.items, out);
+                    Self::hyperwhatever_hammer_collect(&data.items(), out);
                 }
                 _ => out.push(item.clone()),
             }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -802,7 +802,7 @@ impl Interpreter {
             // flat List (e.g. `[0,[1,[2,3]]][**]` == `(0,1,2,3)`).
             (ValueView::Array(items, _is_arr), ValueView::HyperWhatever) => {
                 let mut leaves = Vec::new();
-                Self::hyperwhatever_hammer_collect(&items.items(), &mut leaves);
+                Self::hyperwhatever_hammer_collect(items.items(), &mut leaves);
                 Value::array(leaves)
             }
             (ValueView::Array(items, is_arr), ValueView::Int(i)) => {
@@ -2308,7 +2308,7 @@ impl Interpreter {
         for item in items {
             match item.view() {
                 ValueView::Array(data, _) => {
-                    Self::hyperwhatever_hammer_collect(&data.items(), out);
+                    Self::hyperwhatever_hammer_collect(data.items(), out);
                 }
                 _ => out.push(item.clone()),
             }

--- a/t/native-array-storage.t
+++ b/t/native-array-storage.t
@@ -1,0 +1,26 @@
+use Test;
+use NativeCall;
+
+class MVMArrayB is repr('CStruct') {
+    has uint64 $.elems;
+    has uint64 $.start;
+    has uint64 $.ssize;
+    has Pointer $.any;
+}
+
+plan 8;
+
+my int @a = 10, 20;
+is @a.REPR, 'VMArray', 'native array reports VMArray';
+ok @a.WHERE > 0, 'native array has a body address';
+my $body = nativecast(MVMArrayB, Pointer.new(@a.WHERE));
+is $body.elems, 2, 'body reports native array element count';
+is $body.start, 0, 'native array body has zero start offset';
+my $payload = nativecast(CArray[int64], $body.any);
+is $payload[0], 10, 'body payload points at array storage';
+$payload[1] = 42;
+is @a[1], 42, 'C writes through retained payload are visible in Raku';
+
+my num @n = 1e0, 2e0;
+is @n.REPR, 'VMArray', 'native num array reports VMArray';
+is @n[1], 2e0, 'native num array remains readable';


### PR DESCRIPTION
## Problem

ADR-0015 P3b cannot replace boxed array elements while ArrayData::items is public and directly mutated throughout the runtime.

## Approach

Make the field private and route direct reads, writes, and moves through items, items_mut, take_items, and into_items. Existing Deref implementations also delegate through the accessors, preserving behavior while establishing the first chokepoint layer.

This is the bottom layer of the ADR-0015 P3b stack; the native array[T] representation follows above it.

## Test evidence

- cargo check --message-format short
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- make test was started once but the local execution harness terminated during compilation before producing a result; per repository policy it was not rerun. CI is the full gate.
