### PR TITLE
feat(value): add native storage for array[T]

### DIFF
--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -718,6 +718,14 @@ impl crate::runtime::Interpreter {
         if !matches!(method, "REPR" | "WHERE") {
             return None;
         }
+        if let ValueView::Array(data, _) = target.view()
+            && let Some(body) = data.native_repr_body_address()
+        {
+            return Some(match method {
+                "REPR" => Value::str_from("VMArray"),
+                _ => Value::int(body as i64),
+            });
+        }
         let ValueView::Instance {
             class_name,
             attributes,

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -577,6 +577,7 @@ pub(crate) fn value_c_address(v: &Value) -> usize {
             }
             _ => 0,
         },
+        ValueView::Array(data, _) => data.native_storage_address().unwrap_or(0),
         ValueView::Scalar(inner) => value_c_address(inner),
         ValueView::ContainerRef(cell) => cell.lock().ok().map(|g| value_c_address(&g)).unwrap_or(0),
         ValueView::VarRef { value, .. } => value_c_address(value),
@@ -963,6 +964,7 @@ fn marshal_arg(ps: &ParamSpec, raw: &Value) -> Result<(libffi::middle::Type, Arg
 #[cfg(feature = "libffi")]
 fn buf_storage_node(v: &Value) -> Option<crate::gc::Gc<crate::value::BufData>> {
     match v.view() {
+        ValueView::Array(data, _) => data.native_storage_node(),
         ValueView::Instance { attributes, .. } => {
             crate::value::value_buf::buf_storage_node(&attributes)
         }

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -101,7 +101,18 @@ impl Interpreter {
             }};
         }
         if value
-            .with_array_mut(|arc, _kind| embed_type_info!(arc))
+            .with_array_mut(|arc, _kind| {
+                embed_type_info!(arc);
+                if info
+                    .declared_type
+                    .as_deref()
+                    .is_some_and(|name| name.starts_with("array["))
+                    && crate::runtime::native_types::is_native_array_element_type(&info.value_type)
+                {
+                    crate::gc::ContainerMakeMut::container_make_mut(arc)
+                        .promote_native_storage(&info.value_type);
+                }
+            })
             .is_some()
         {
             return value;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1140,6 +1140,11 @@ pub struct HashData {
 #[derive(Debug, Clone, Default)]
 pub struct ArrayData {
     items: Vec<Value>,
+    /// Native numeric `array[T]` payload, when this array has been promoted
+    /// to ADR-0015 P3b storage. The boxed vector remains a derived cache for
+    /// the legacy collection API and is refreshed by the accessor chokepoint.
+    native_storage: Option<crate::gc::Gc<BufData>>,
+    native_dirty: bool,
     /// Element value-type constraint (e.g. `Int` for `my Int @a`), if any.
     pub value_type: Option<String>,
     /// Key-type constraint — unused for arrays, present so the shared

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -157,6 +157,24 @@ fn encode_elems(elems: &[Value], width: u8, kind: ElemKind) -> Vec<u8> {
     bytes
 }
 
+/// Build the payload node used by a native numeric `array[T]`.
+pub(crate) fn make_native_array_storage(elem_type: &str, elems: &[Value]) -> Option<Gc<BufData>> {
+    let (width, kind) = native_elem_type(elem_type)?;
+    Some(Gc::new(BufData::new(
+        encode_elems(elems, width, kind),
+        width,
+        kind,
+    )))
+}
+
+pub(crate) fn decode_storage(data: &BufData) -> Vec<Value> {
+    decode_elems(data)
+}
+
+pub(crate) fn encode_storage(data: &BufData, elems: &[Value]) -> Vec<u8> {
+    encode_elems(elems, data.width, data.kind)
+}
+
 /// The bit pattern one element occupies, as the `u64` its `width` low bytes
 /// spell. For a float element that is the IEEE-754 encoding at the element
 /// width; for an integer element it is [`elem_to_u64`].

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -151,6 +151,8 @@ impl ArrayData {
     pub fn new(items: Vec<Value>) -> Self {
         ArrayData {
             items,
+            native_storage: None,
+            native_dirty: false,
             value_type: None,
             key_type: None,
             declared_type: None,
@@ -167,22 +169,84 @@ impl ArrayData {
 
     /// Borrow the element vector through the representation chokepoint.
     pub(crate) fn items(&self) -> &Vec<Value> {
+        self.sync_native_items();
         &self.items
     }
 
     /// Mutably borrow the element vector through the representation chokepoint.
     pub(crate) fn items_mut(&mut self) -> &mut Vec<Value> {
+        self.native_dirty = self.native_storage.is_some();
         &mut self.items
+    }
+
+    /// Promote a numeric `array[T]` to the shared native payload node.
+    pub(crate) fn promote_native_storage(&mut self, elem_type: &str) {
+        // A shaped array stores row arrays at this level. Native storage is
+        // promoted per flat numeric array only; encoding a row object as a
+        // scalar would destroy the shape (and its nested values).
+        if self
+            .items
+            .iter()
+            .any(|value| matches!(value.view(), crate::value::ValueView::Array(..)))
+        {
+            return;
+        }
+        if self.native_storage.is_none()
+            && let Some(node) =
+                crate::value::value_buf::make_native_array_storage(elem_type, &self.items)
+        {
+            self.native_storage = Some(node);
+        }
+    }
+
+    pub(crate) fn native_storage_address(&self) -> Option<usize> {
+        self.native_storage
+            .as_ref()
+            .map(|node| node.bytes.as_ptr() as usize)
+    }
+
+    pub(crate) fn native_storage_node(&self) -> Option<crate::gc::Gc<BufData>> {
+        self.native_storage.clone()
+    }
+
+    pub(crate) fn native_repr_body_address(&self) -> Option<usize> {
+        self.native_storage
+            .as_ref()
+            .map(|node| node.body.address(node))
     }
 
     /// Move all elements out through the representation chokepoint.
     pub(crate) fn take_items(&mut self) -> Vec<Value> {
+        self.sync_native_items();
         std::mem::take(&mut self.items)
     }
 
     /// Consume the array data and return its elements.
     pub(crate) fn into_items(self) -> Vec<Value> {
+        self.sync_native_items();
         self.items
+    }
+
+    fn sync_native_items(&self) {
+        let Some(node) = &self.native_storage else {
+            return;
+        };
+        let decoded = if self.native_dirty {
+            let bytes = crate::value::value_buf::encode_storage(node, &self.items);
+            unsafe {
+                let data = crate::value::gc_contents_mut(node);
+                data.bytes.clear();
+                data.bytes.extend_from_slice(&bytes);
+            }
+            self.items.clone()
+        } else {
+            crate::value::value_buf::decode_storage(node)
+        };
+        unsafe {
+            let this = self as *const Self as *mut Self;
+            std::ptr::addr_of_mut!((*this).items).write(decoded);
+            std::ptr::addr_of_mut!((*this).native_dirty).write(false);
+        }
     }
 
     /// Whether index `i` is a hole (a deleted slot or an autovivification

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -447,6 +447,8 @@ impl Trace for ArrayData {
         // Clearing the elements drops every outgoing edge. `&mut self` is
         // supplied by the collector via the backing `Arc` (gc::gc_drop_edges).
         self.items.clear();
+        self.native_storage = None;
+        self.native_dirty = false;
         self.default = None;
     }
 }

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -253,6 +253,8 @@ impl Value {
     pub(crate) fn array_data_like(like: &ArrayData, items: Vec<Value>) -> crate::gc::Gc<ArrayData> {
         crate::gc::Gc::new(ArrayData {
             items,
+            native_storage: like.native_storage.clone(),
+            native_dirty: like.native_dirty,
             value_type: like.value_type.clone(),
             key_type: like.key_type.clone(),
             declared_type: like.declared_type.clone(),

--- a/t/native-array-storage.t
+++ b/t/native-array-storage.t
@@ -1,0 +1,26 @@
+use Test;
+use NativeCall;
+
+class MVMArrayB is repr('CStruct') {
+    has uint64 $.elems;
+    has uint64 $.start;
+    has uint64 $.ssize;
+    has Pointer $.any;
+}
+
+plan 8;
+
+my int @a = 10, 20;
+is @a.REPR, 'VMArray', 'native array reports VMArray';
+ok @a.WHERE > 0, 'native array has a body address';
+my $body = nativecast(MVMArrayB, Pointer.new(@a.WHERE));
+is $body.elems, 2, 'body reports native array element count';
+is $body.start, 0, 'native array body has zero start offset';
+my $payload = nativecast(CArray[int64], $body.any);
+is $payload[0], 10, 'body payload points at array storage';
+$payload[1] = 42;
+is @a[1], 42, 'C writes through retained payload are visible in Raku';
+
+my num @n = 1e0, 2e0;
+is @n.REPR, 'VMArray', 'native num array reports VMArray';
+is @n[1], 2e0, 'native num array remains readable';


### PR DESCRIPTION
## Problem

ADR-0015 P3b requires native numeric array[T] values to own contiguous storage so NativeCall can use the array payload directly. The accessor layer from the lower stack PR is now available, but arrays still reported P6opaque and had no body address.

## Approach

- Reuse BufData and its element encoding for flat numeric array[T] values.
- Promote native arrays during embedded container metadata tagging.
- Expose the existing VMArray body contract for native arrays and route WHERE and native-call address lookup to the payload.
- Keep shaped outer arrays boxed when their elements are row arrays, preserving multidimensional shape semantics.
- Add a retained-payload C write regression test.

## Test evidence

- cargo check --message-format short
- cargo clippy -- -D warnings
- cargo fmt --all
- t/native-array-storage.t
- t/native-typed-arrays.t
- t/shaped-array-type-preservation.t
- t/carray-native-storage.t
- roast/S02-types/array-shapes.t
