### PR TITLE
perf(dispatch): stop charging a surcharge for calling a block-local sub

### DIFF
--- a/news/2026-08/block-local-sub-call-path.md
+++ b/news/2026-08/block-local-sub-call-path.md
@@ -66,6 +66,15 @@ C/B goes from **1.66x to 1.03x** — the declaration site no longer changes what
 general call-path deficit against raku that `todo/deep/interpreter-call-path-in-hot-loops.md` tracks
 (rows A and B) is untouched; only the block-local surcharge is gone.
 
+## What it does *not* fix
+
+`MUTSU_REAL_TEST=1 roast/S04-declarations/state.t` — the file that motivated looking here — is
+410.0 G instructions before and 409.1 G after (**-0.2%**, i.e. nothing). Its hot loop is
+`lives-ok { for ^2000000 { $ = foo } }` and `foo` is declared at *file* scope, so it is row B plus
+the `&code`-through-a-module-sub multiplier, not row C. The vendored-`Test` campaign is blocked on
+the **general** per-call cost (row B is still ~13.8x raku), not on the declaration site. Recorded in
+`todo/deep/interpreter-call-path-in-hot-loops.md` so it is not re-chased.
+
 Pinned by `t/block-local-sub-dispatch.t`, which covers what the widened cache could break: sibling
 blocks re-declaring the same name, a block-local sub shadowing a file-scope one and the file-scope
 one coming back afterwards, the same shape reached through a closure argument, and a block-local sub

--- a/news/2026-08/block-local-sub-call-path.md
+++ b/news/2026-08/block-local-sub-call-path.md
@@ -1,0 +1,72 @@
+# Calling a block-local sub no longer costs 1.7x more than calling a file-scope one
+
+`todo/deep/interpreter-call-path-in-hot-loops.md` recorded a measurement that looked like a bug
+rather than a general "calls are expensive" result: a 1M-iteration loop calling a one-line sub was
+**1.7x slower when the callee was declared inside the calling block** than when the identical body
+was declared at file scope (3.8x with a zero-arg callee). Nothing about invoking a routine should
+depend on where it was declared, and it is not a corner case — roast bodies and `Test.rakumod`'s own
+helpers declare subs inside blocks constantly, and every `lives-ok`/`throws-like`/`subtest` body is
+exactly this shape.
+
+## What was actually happening
+
+A routine declared inside a block *is* compiled ahead of time, but its `compiled_fns` key is
+namespaced by the enclosing closure (`GLOBAL::&<closure>/7::inner-fn/1#6367421e45ed0903`), and
+bare-name resolution at the callsite probes `GLOBAL::inner-fn/1#...`. The probe misses, so the
+routine is compiled again on the fly from its `FunctionDef` AST and dispatched through
+`otf_call_cache` — the third of the three name-keyed caches in `exec_call_func_op`, and the one with
+no fast path attached to it.
+
+`perf diff` between the two shapes (`taskset`-pinned, `cpu_core/cycles/u`) put `memmove` at the top
+of the delta with **+15%** of the whole run, plus fresh `malloc`/`free`, `hash_one` and `memcmp`
+traffic that the file-scope shape never paid. The causes, in order of size:
+
+- **The OTF cache moved the body in and out of its `HashMap` around every call.** The hot path did
+  `otf_call_cache.remove(&name)` -> call -> `insert(...)` purely to release its borrow on `self`. A
+  `CompiledFunction` embeds a whole `CompiledCode` (~1 kB of `Vec`/`HashMap` headers), so that was
+  two struct memcpys plus a rehash *per call*. That is the `memmove`.
+- **Every call re-derived the callsite analysis.** `is_light_call_eligible`,
+  `is_positional_light_call_eligible`, the junction/slip scans, the container-share checks and the
+  arg-source decode are properties of the callee (or of the arguments), and the two caches above it
+  precompute exactly this — but the OTF path recomputed all of it on every call before landing in
+  the very same `call_compiled_function_positional_light`.
+- Two smaller ones on the same path: `has_multi_candidates_cached` took the name as a `&str` and
+  re-`intern`ed it (a string hash per call) even though the callsite already holds the pre-interned
+  `Symbol`, and the argument buffer was a fresh `drain(..).collect()` instead of the pooled
+  `Vec<Value>` the light paths use.
+
+## The fix
+
+`pos_light_call_cache` — the ultra-fast positional cache checked first in `exec_call_func_op` — now
+holds a `PosLightTarget` that is either a key into `compiled_fns` (as before) or an
+`Arc<CompiledFunction>` for an OTF-compiled body, package-keyed the same way `otf_call_cache` is.
+The OTF path promotes into it the moment it establishes that the callee is positional-light
+eligible, so the *second* and every later call to a block-local sub takes the same single fused
+scan + light call that a file-scope sub takes. `otf_call_cache` and `otf_compile_cache` hold
+`Arc<CompiledFunction>` too, so releasing the borrow on `self` is a refcount bump and the entry
+stays in the table; `has_multi_candidates_cached_sym` takes the pre-interned `Symbol`; and the OTF
+path borrows the pooled args buffer.
+
+Dropping the remove/insert also fixed a latent eviction bug: a callee with inner subs failed the
+`!cf.has_inner_subs` guard *after* its entry had already been removed, so it was thrown away and
+re-OTF-compiled on the next call, forever.
+
+## Result
+
+Retired instructions (`perf stat -e instructions:u`, core-pinned, release, 1M iterations), which are
+load-independent and therefore the honest metric on a busy machine:
+
+| shape | before | after |
+| --- | --- | --- |
+| A `$n = $n + 1` | 2.04 G | 2.04 G |
+| B `$n = outer-fn($n)`, callee at file scope | 5.52 G | 5.54 G |
+| C same, callee declared **inside the calling block** | **9.20 G** | **5.70 G** |
+
+C/B goes from **1.66x to 1.03x** — the declaration site no longer changes what a call costs. The
+general call-path deficit against raku that `todo/deep/interpreter-call-path-in-hot-loops.md` tracks
+(rows A and B) is untouched; only the block-local surcharge is gone.
+
+Pinned by `t/block-local-sub-dispatch.t`, which covers what the widened cache could break: sibling
+blocks re-declaring the same name, a block-local sub shadowing a file-scope one and the file-scope
+one coming back afterwards, the same shape reached through a closure argument, and a block-local sub
+closing over a loop variable.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -853,6 +853,32 @@ pub(crate) struct EndPhaser {
     pub(crate) dead_keys: NameSet,
 }
 
+/// What a name in `pos_light_call_cache` resolves to.
+///
+/// Both variants denote a body that `is_positional_light_call_eligible` has
+/// already accepted for this name, so the hot `CallFunc` path can dispatch to
+/// `call_compiled_function_positional_light` without re-running the eligibility
+/// and argument-shape analysis. They differ only in who owns the body.
+#[derive(Debug, Clone)]
+pub(crate) enum PosLightTarget {
+    /// A body the compiler emitted ahead of time; it lives in `compiled_fns`
+    /// and is re-validated against its fingerprint on each hit.
+    Compiled { key: Symbol, fingerprint: u64 },
+    /// A body compiled on the fly from its `FunctionDef` AST — the shape every
+    /// routine declared inside a block takes, because its `compiled_fns` key is
+    /// namespaced by the enclosing closure and bare-name resolution cannot
+    /// reach it. Before this variant existed, such a call could never reach the
+    /// ultra-fast path: it hit `otf_call_cache` further down `exec_call_func_op`
+    /// and re-derived the callsite analysis on every single call, which made a
+    /// block-local sub 1.7x more expensive to call than an identical file-scope
+    /// one. `callsite_package` mirrors `otf_call_cache`'s package keying (the
+    /// same bare name means different routines in different packages).
+    Otf {
+        callsite_package: Symbol,
+        cf: Arc<CompiledFunction>,
+    },
+}
+
 pub struct Interpreter {
     env: Env,
     /// Program output sink — stdout/stderr buffers, the immediate-flush flag,
@@ -1869,7 +1895,7 @@ pub struct Interpreter {
     /// force the scan when it moved.
     pub(crate) inline_control_env_writes: u64,
     pub(crate) local_bind_pairs: Vec<(usize, usize)>,
-    pub(crate) otf_compile_cache: HashMap<u64, CompiledFunction>,
+    pub(crate) otf_compile_cache: HashMap<u64, Arc<CompiledFunction>>,
     /// Compiled bodies of subs defined in `use`d modules, captured at module-load
     /// time and keyed by the sub's body/signature fingerprint. Unlike the per-call
     /// `otf_compile_cache` (which a worker thread starts *empty* — every thread
@@ -1906,7 +1932,7 @@ pub struct Interpreter {
     pub(crate) fn_base_name_cache_gen: u64,
     pub(crate) light_call_cache: rustc_hash::FxHashMap<Symbol, (Symbol, u64)>,
     pub(crate) light_call_cache_gen: u64,
-    pub(crate) pos_light_call_cache: rustc_hash::FxHashMap<Symbol, (Symbol, u64)>,
+    pub(crate) pos_light_call_cache: rustc_hash::FxHashMap<Symbol, PosLightTarget>,
     pub(crate) pos_light_call_cache_gen: u64,
     /// Bare names that appear as a `&`-sigil parameter in some registered sub
     /// (e.g. `foo` from `sub callit(&foo) {...}`). A call to such a name may be
@@ -2053,7 +2079,16 @@ pub struct Interpreter {
     /// `once`); reading `current_package()` at the callsite instead would give
     /// the caller's package, which only happened to agree while every module sub
     /// registered into GLOBAL.
-    pub(crate) otf_call_cache: rustc_hash::FxHashMap<Symbol, (Symbol, Symbol, CompiledFunction)>,
+    /// The body is `Arc`-shared, not owned by value: the hot dispatch path in
+    /// `exec_call_func_op` used to `remove()` the entry, run the call, and
+    /// `insert()` it back purely to avoid holding a borrow on `self`. A
+    /// `CompiledFunction` embeds a whole `CompiledCode` (~1 kB of `Vec`/`HashMap`
+    /// headers), so that round trip memcpy'd the struct out of and back into the
+    /// table on EVERY call — it profiled as the single largest cost of calling a
+    /// block-local sub (`memmove` alone was 15% of the run). Cloning the `Arc`
+    /// is one refcount bump and leaves the table untouched.
+    pub(crate) otf_call_cache:
+        rustc_hash::FxHashMap<Symbol, (Symbol, Symbol, Arc<CompiledFunction>)>,
     pub(crate) otf_call_cache_gen: u64,
     pub(crate) check_phaser_depth: u32,
     /// Depth of `with_nested_registers` re-entry (nested VM runs: closure

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -19,15 +19,23 @@ impl Interpreter {
     /// Cached version of the Interpreter-native [`Self::has_multi_candidates`].
     /// Uses `fn_resolve_gen` for invalidation so it's O(1) on cache hit.
     pub(super) fn has_multi_candidates_cached(&mut self, name: &str) -> bool {
+        self.has_multi_candidates_cached_sym(Symbol::intern(name))
+    }
+
+    /// `has_multi_candidates_cached` for a callsite that already holds the
+    /// name's pre-interned `Symbol` (every `CallFunc` does, via
+    /// `CompiledCode::const_sym`). The cache is `Symbol`-keyed, so taking the
+    /// `&str` form only to re-`intern` it hashed the name string on every call —
+    /// it profiled as the `hash_one` + `memcmp` pair on the OTF dispatch path.
+    pub(super) fn has_multi_candidates_cached_sym(&mut self, sym: Symbol) -> bool {
         if self.multi_candidates_cache_gen != self.fn_resolve_gen {
             self.multi_candidates_cache.clear();
             self.multi_candidates_cache_gen = self.fn_resolve_gen;
         }
-        let sym = Symbol::intern(name);
         if let Some(&cached) = self.multi_candidates_cache.get(&sym) {
             return cached;
         }
-        let result = self.has_multi_candidates(name);
+        let result = self.has_multi_candidates(&sym.resolve());
         self.multi_candidates_cache.insert(sym, result);
         result
     }
@@ -120,7 +128,7 @@ impl Interpreter {
     pub(super) fn otf_compile_function_def(
         &mut self,
         def: &crate::ast::FunctionDef,
-    ) -> CompiledFunction {
+    ) -> Arc<CompiledFunction> {
         let pkg = def.package.resolve();
         let fingerprint =
             crate::ast::function_body_fingerprint(&def.params, &def.param_defs, &def.body);
@@ -176,7 +184,8 @@ impl Interpreter {
         cf.precompute_param_name_syms();
         cf.detect_inner_subs();
         cf.compute_declared_locals();
-        self.otf_compile_cache.insert(cache_key, cf.clone());
+        let cf = Arc::new(cf);
+        self.otf_compile_cache.insert(cache_key, Arc::clone(&cf));
         cf
     }
 
@@ -213,7 +222,7 @@ impl Interpreter {
             // the same package this (uncached) call does.
             let cur_pkg_sym = self.current_package_sym();
             self.otf_call_cache
-                .insert(name_sym, (cur_pkg_sym, def.package, cf.clone()));
+                .insert(name_sym, (cur_pkg_sym, def.package, Arc::clone(&cf)));
             self.otf_call_cache_gen = self.fn_resolve_gen;
         }
 

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -330,10 +330,31 @@ impl Interpreter {
             let name_str = Self::const_str(code, name_idx);
             let name_sym = code.const_sym(name_idx);
             if self.pos_light_call_cache_gen == self.fn_resolve_gen {
-                if let Some((cached_key, cached_fp)) = self.pos_light_call_cache.get(&name_sym)
-                    && let Some(cf) = compiled_fns.get(cached_key)
-                    && cf.fingerprint == *cached_fp
-                {
+                // An OTF-compiled body is owned by the cache rather than by
+                // `compiled_fns`, so take an `Arc` handle to it and let the
+                // borrow on `self` end before the call below.
+                let mut otf_hold: Option<Arc<CompiledFunction>> = None;
+                let cur_pkg_sym = self.current_package_sym();
+                let cached: Option<&CompiledFunction> =
+                    match self.pos_light_call_cache.get(&name_sym) {
+                        Some(crate::runtime::PosLightTarget::Compiled { key, fingerprint }) => {
+                            let (key, fingerprint) = (*key, *fingerprint);
+                            compiled_fns
+                                .get(&key)
+                                .filter(|cf| cf.fingerprint == fingerprint)
+                        }
+                        Some(crate::runtime::PosLightTarget::Otf {
+                            callsite_package,
+                            cf,
+                        }) => {
+                            if *callsite_package == cur_pkg_sym {
+                                otf_hold = Some(Arc::clone(cf));
+                            }
+                            None
+                        }
+                        None => None,
+                    };
+                if let Some(cf) = cached.or(otf_hold.as_deref()) {
                     let arity_usize = arity as usize;
                     if self.stack.len() >= arity_usize {
                         // One fused pass over the args (J4d): junction detection
@@ -481,8 +502,10 @@ impl Interpreter {
         // OTF-compiled function cache check: for user-defined functions that
         // were compiled on-the-fly (not in compiled_fns), use the cached
         // compiled form to avoid the expensive interpreter fallback.
-        // We take() the CF from the cache to avoid holding a borrow on self,
-        // then put it back after the call.
+        // The body is `Arc`-shared, so releasing the borrow on `self` costs one
+        // refcount bump; the entry stays in the table (it used to be `remove`d
+        // and re-`insert`ed around every call, memcpying a ~1 kB
+        // `CompiledFunction` twice per call — see `otf_call_cache`'s doc).
         if !skip_name_caches {
             let name_str = Self::const_str(code, name_idx);
             let name_sym = code.const_sym(name_idx);
@@ -496,21 +519,28 @@ impl Interpreter {
                 // from the package it was resolved under (PLAN 8.22): a `unit
                 // module Foo`'s non-exported sub must not stay callable by its
                 // bare name once control returns to the consumer's GLOBAL scope.
-                // Peek the package before removing so a mismatch leaves the entry
-                // in place for the package that does own it.
+                // A package mismatch leaves the entry in place for the package
+                // that does own it.
                 let cur_pkg_sym = self.current_package_sym();
-                if !self.has_multi_candidates_cached(name_str)
-                    && self
+                if !self.has_multi_candidates_cached_sym(name_sym)
+                    && let Some((def_pkg_sym, cf)) = self
                         .otf_call_cache
                         .get(&name_sym)
-                        .is_some_and(|(pkg, _, _)| *pkg == cur_pkg_sym)
-                    && let Some((_, def_pkg_sym, cf)) = self.otf_call_cache.remove(&name_sym)
+                        .filter(|(pkg, _, _)| *pkg == cur_pkg_sym)
+                        .map(|(_, def_pkg, cf)| (*def_pkg, Arc::clone(cf)))
                     && !cf.has_inner_subs
                 {
                     let arity_usize = arity as usize;
                     if self.stack.len() >= arity_usize && !self.stack_args_have_slip(arity_usize) {
                         let start = self.stack.len() - arity_usize;
-                        let args: Vec<Value> = self.stack.drain(start..).collect();
+                        // Pooled args buffer (mirrors the two light-call cached
+                        // paths above): `drain(..).collect()` was one malloc/free
+                        // per call on this path, which every block-local sub call
+                        // takes. Only the cold `call_compiled_function_named` arm
+                        // consumes the `Vec`; the light arms borrow it and it goes
+                        // back to the pool below.
+                        let mut args = self.take_locals_from_pool(0);
+                        args.extend(self.stack.drain(start..));
 
                         // Extract callsite line for deprecation tracking
                         let cl = crate::runtime::Interpreter::peek_callsite_line(&args);
@@ -547,6 +577,21 @@ impl Interpreter {
                             && !named_share
                             && Self::is_positional_light_call_eligible(&cf, name_str)
                         {
+                            // Promote to the ultra-fast positional cache at the
+                            // top of this function, so the next call skips this
+                            // whole preamble (eligibility re-analysis, arg-source
+                            // decode, junction/slip/share re-scans) instead of
+                            // re-deriving it per call. `has_junction` /
+                            // `stack_args_have_slip` / the share checks above are
+                            // per-CALL properties, and that path re-checks all of
+                            // them in its own fused scan before dispatching.
+                            self.pos_light_call_cache.insert(
+                                name_sym,
+                                crate::runtime::PosLightTarget::Otf {
+                                    callsite_package: cur_pkg_sym,
+                                    cf: Arc::clone(&cf),
+                                },
+                            );
                             self.call_compiled_function_positional_light(
                                 &cf,
                                 &args,
@@ -565,7 +610,7 @@ impl Interpreter {
                             self.set_pending_call_arg_sources(decoded_sources);
                             let r = self.call_compiled_function_named(
                                 &cf,
-                                args,
+                                std::mem::take(&mut args),
                                 compiled_fns,
                                 &pkg,
                                 name_str,
@@ -577,9 +622,7 @@ impl Interpreter {
                             }
                             r
                         };
-                        // Put CF back in cache
-                        self.otf_call_cache
-                            .insert(name_sym, (cur_pkg_sym, def_pkg_sym, cf));
+                        self.recycle_locals(args);
                         let result = result?;
                         // Slice F: drain this frame's recorded captured-outer
                         // writes, plus (env_dirty-gated) reconcile to catch a
@@ -593,10 +636,6 @@ impl Interpreter {
                         // return merge. No blanket mark needed.
                         return Ok(());
                     }
-                    // Put CF back if we couldn't use it (stack underflow, or a Slip
-                    // arg that must be flattened by the slow path below).
-                    self.otf_call_cache
-                        .insert(name_sym, (cur_pkg_sym, def_pkg_sym, cf));
                 }
             } else {
                 self.otf_call_cache.clear();
@@ -1096,8 +1135,13 @@ impl Interpreter {
                     if !self.pos_light_call_cache.contains_key(&name_sym) {
                         for (key, func) in compiled_fns {
                             if std::ptr::eq(func, cf) {
-                                self.pos_light_call_cache
-                                    .insert(name_sym, (*key, cf.fingerprint));
+                                self.pos_light_call_cache.insert(
+                                    name_sym,
+                                    crate::runtime::PosLightTarget::Compiled {
+                                        key: *key,
+                                        fingerprint: cf.fingerprint,
+                                    },
+                                );
                                 break;
                             }
                         }

--- a/t/block-local-sub-dispatch.t
+++ b/t/block-local-sub-dispatch.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 9;
+
+# A routine declared inside a block is compiled on the fly and dispatched
+# through the name-keyed OTF caches. Those caches are keyed by the bare name
+# and the callsite package, so re-declaring the same name in a sibling block
+# must invalidate them -- otherwise the second block's calls would run the
+# first block's body.
+
+{
+    sub f($x) { $x + 1 }
+    is f(10), 11, 'block-local sub returns its own body (first block)';
+    is f(10), 11, 'a repeated call to a block-local sub is stable';
+}
+{
+    sub f($x) { $x + 100 }
+    is f(10), 110, 'a sibling block re-declaring the name gets its own body';
+}
+
+# A file-scope sub shadowed by a block-local one of the same name: the outer
+# body must come back once the block is left.
+sub outer($x) { $x * 2 }
+is outer(10), 20, 'file-scope sub before the shadowing block';
+{
+    sub outer($x) { $x * 3 }
+    is outer(10), 30, 'block-local sub shadows the file-scope one';
+}
+is outer(10), 20, 'the file-scope sub is visible again after the block';
+
+# The same shape reached through a closure argument -- what every
+# `lives-ok { ... }` / `subtest { ... }` body looks like.
+sub run-it(&body) { body() }
+is run-it({ sub g($x) { $x - 1 }; g(5) }), 4, 'block-local sub inside a passed closure';
+is run-it({ sub g($x) { $x - 2 }; g(5) }), 3, 'a second closure re-declaring it is not aliased';
+
+# A block-local sub closing over the loop variable must observe each
+# iteration's value, not the one captured on the first (cache-populating) call.
+my @out;
+for 1..3 -> $i {
+    sub loopy($x) { $x + $i }
+    @out.push(loopy(10));
+}
+is @out.join(','), '11,12,13', 'block-local sub sees the current loop binding';

--- a/todo/deep/interpreter-call-path-in-hot-loops.md
+++ b/todo/deep/interpreter-call-path-in-hot-loops.md
@@ -71,12 +71,13 @@ Two things stand out, and the second is the new one:
 - The per-call cost is ~340 ns (B) on top of a ~140 ns/iteration loop, so a call is worth ~3
   arithmetic iterations. raku's B/C are *faster* than its A because its optimizer inlines the callee
   outright; mutsu's JIT bails at the call boundary (see above), so the gap is the whole call path.
-- **C is 1.7× slower per call than B for an identical body and arity.** Nothing about invoking a sub
-  should depend on where it was declared, so that 1.7× is pure mutsu-internal overhead on
-  block-local routine declarations — and it is not a corner case: roast bodies and `Test.rakumod`'s
-  own helpers declare subs inside blocks constantly. With a zero-arg callee the same comparison was
-  1259 ms vs 4843 ms, i.e. **3.8×**. Start here; it is the one part of this ticket that looks like a
-  bug rather than a general "calls are expensive".
+- ~~**C is 1.7× slower per call than B for an identical body and arity.**~~ **Fixed** — see
+  `news/2026-08/block-local-sub-call-path.md`. A routine declared inside a block is OTF-compiled and
+  was dispatched through `otf_call_cache`, which re-derived the whole callsite analysis on every
+  call and moved a ~1 kB `CompiledFunction` in and out of a `HashMap` around each one. Measured by
+  retired instructions (`perf stat instructions:u`, 1M iterations, release): C went **9.20 G → 5.70 G**
+  against B's 5.54 G, i.e. from **1.66×** B to **1.03×**. The remaining rows (A/B vs raku) are
+  unchanged — that is the general call-path cost this ticket still tracks.
 
 Passing the block through a *module* sub (`sub s-amp(&code) { code() }`, imported) adds a further
 ~1.5× on top of every row — which is exactly the shape every `lives-ok`/`throws-like`/`subtest` body

--- a/todo/deep/interpreter-call-path-in-hot-loops.md
+++ b/todo/deep/interpreter-call-path-in-hot-loops.md
@@ -84,6 +84,16 @@ Passing the block through a *module* sub (`sub s-amp(&code) { code() }`, importe
 takes under the vendored `Test`, and is why the real module inflates heavy roast files past the
 30 s per-file budget (`todo/tickets/vendor-real-test-module.md`).
 
+**Measured negative result (2026-08-03): fixing the block-local surcharge did NOT move the
+real-`Test` files.** `MUTSU_REAL_TEST=1 MUTSU_FUDGE=1 mutsu roast/S04-declarations/state.t` is
+410.0 G retired instructions before the fix and 409.1 G after (-0.2%). That is expected in hindsight
+and worth writing down so nobody re-chases it: `state.t`'s hot loop is
+`lives-ok { for ^2000000 { $ = foo } }`, whose callee `foo` is declared at **file scope** — it is
+row B plus the module-sub indirection, not row C. The remaining real-`Test` deficit is therefore the
+general per-call cost (row B, ~340 ns/call, 13.8× raku) plus the `&code`-through-a-module-sub
+multiplier, and *that* is what the vendored-`Test` campaign is blocked on. Attack row B next, not
+the declaration site.
+
 ### Trap: raku will delete your benchmark
 
 `for ^1000000 { $n = f($n) }` with `$n` never read afterwards measures nothing under raku — its


### PR DESCRIPTION
## The bug-shaped measurement

`todo/deep/interpreter-call-path-in-hot-loops.md` recorded that a 1M-iteration loop calling a
one-line sub was **1.7x slower when the callee was declared inside the calling block** than when the
identical body was declared at file scope (3.8x with a zero-arg callee). Nothing about invoking a
routine should depend on where it was declared — and it is not a corner case: every
`lives-ok`/`throws-like`/`subtest` body under the vendored `Test` takes exactly this shape.

## Root cause

A routine declared inside a block *is* compiled ahead of time, but its `compiled_fns` key is
namespaced by the enclosing closure (`GLOBAL::&<closure>/7::inner-fn/1#6367421e45ed0903`) while
bare-name resolution at the callsite probes `GLOBAL::inner-fn/1#...`. The probe misses, so the
routine is compiled *again* on the fly from its AST and dispatched through `otf_call_cache` — the
one name-keyed cache in `exec_call_func_op` with no fast path attached to it.

`perf diff` between the two shapes (core-pinned, `cpu_core/cycles/u`) put `memmove` at the top of
the delta with **15% of the whole run**:

- The OTF path did `otf_call_cache.remove(&name)` → call → `insert(...)` purely to release its
  borrow on `self`. A `CompiledFunction` embeds a whole `CompiledCode` (~1 kB of `Vec`/`HashMap`
  headers), so that was two struct memcpys plus a rehash **per call**.
- It then re-derived the entire callsite analysis — both eligibility predicates, the junction/slip
  scans, the container-share checks, the arg-source decode — on every call, before landing in the
  very same `call_compiled_function_positional_light` the cached paths reach directly.
- Two smaller ones on the same path: `has_multi_candidates_cached` re-`intern`ed the name (a string
  hash per call) although the callsite already holds the pre-interned `Symbol`, and the args buffer
  was a fresh `drain(..).collect()` rather than the pooled `Vec<Value>` the light paths use.

## The fix

`pos_light_call_cache` — the ultra-fast positional cache checked first in `exec_call_func_op` — now
holds a `PosLightTarget` that is either a key into `compiled_fns` (as before) or an
`Arc<CompiledFunction>` for an OTF-compiled body, package-keyed the same way `otf_call_cache` is.
The OTF path promotes into it the moment it establishes positional-light eligibility, so the second
and every later call to a block-local sub takes the same single fused scan + light call a
file-scope sub takes. `otf_call_cache`/`otf_compile_cache` hold `Arc<CompiledFunction>` so releasing
the borrow on `self` is a refcount bump and the entry stays in the table.

Dropping the remove/insert also fixes a latent eviction bug: a callee with inner subs failed the
`!cf.has_inner_subs` guard *after* its entry had already been removed, so it was thrown away and
re-OTF-compiled on the next call, forever.

## Result

Retired instructions (`perf stat -e instructions:u`, core-pinned, release, 1M iterations) — the
machine is busy, so this is the load-independent metric:

| shape | before | after |
| --- | --- | --- |
| A `$n = $n + 1` | 2.04 G | 2.04 G |
| B `$n = outer-fn($n)`, callee at file scope | 5.52 G | 5.54 G |
| C same, callee declared **inside the calling block** | **9.20 G** | **5.70 G** |

C/B: **1.66x → 1.03x**. The general call-path deficit against raku that
`todo/deep/interpreter-call-path-in-hot-loops.md` tracks (rows A and B) is untouched.

## Testing

- New pin `t/block-local-sub-dispatch.t` (9 tests, verified against `raku` too) covering what a
  widened name-keyed cache could break: sibling blocks re-declaring the same name, a block-local sub
  shadowing a file-scope one and the file-scope one coming back afterwards, the same shape reached
  through a closure argument, and a block-local sub closing over a loop variable.
- `make test` — PASS (2789 files, 26527 tests).
- `make roast` — PASS (1435 files, 218774 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)