### PR TITLE
fix(dispatch): a callee's slurpy parameter no longer overwrites the caller's

### DIFF
--- a/news/2026-08/slurpy-parameter-does-not-leak-to-the-caller.md
+++ b/news/2026-08/slurpy-parameter-does-not-leak-to-the-caller.md
@@ -1,0 +1,52 @@
+# A callee's slurpy parameter no longer overwrites the caller's
+
+`roast/S24-testing/fails-like.t` aborted under the real `Test` module with
+
+```
+No such method 'instead' for invocant of type 'X::Match::Bool'
+```
+
+which reads like a missing exception attribute — the family
+`news/2026-08/typed-exceptions-carry-their-attributes.md` had just been through.
+It is not. `X::Match::Bool` has no `.instead` in rakudo either; the test asks
+`throws-like`'s matcher loop for `.message`, and mutsu asked for `.instead`
+because by the time the loop ran, `throws-like`'s `*%matcher` held the matcher of
+a *different* routine.
+
+## What happened
+
+`Test.rakumod` nests two routines that both end their signature with the same
+slurpy named parameter:
+
+```raku
+sub throws-like($code, $ex_type, $reason?, *%matcher) { ...
+    subtest { ... CATCH { default { ... for %matcher.kv -> $k, $v { $ex."$k"() } ... } } }
+}
+sub fails-like(\test where Callable:D|Str:D, $ex-type, $reason?, *%matcher) { ... }
+```
+
+The test runs `throws-like` with `message => *.contains('instead')` over code
+that calls `fails-like(..., :instead)`. `fails-like` throws, `throws-like`'s
+`CATCH` runs — and `%matcher` there was `{instead}`, the callee's.
+
+The tree-walk return merge in `call_function_def` propagates the callee's
+variables back into the caller's env for every name the caller also has
+(`routine_writeback_excluded_names` lists what to leave behind). `@`/`%`
+parameters were deliberately *not* excluded, because such a parameter is
+normally the caller's own container and its mutations have to be visible after
+the call. A slurpy is never that container: `bind_function_args_values` builds a
+fresh `Array`/`Hash` out of the leftover arguments, so the merge could only ever
+clobber an unrelated caller lexical of the same name. Slurpy (`*@a`, `*%h`) and
+non-flattening slurpy (`**@a`) parameters are now excluded; a plain `%h`
+parameter still writes back.
+
+## Why it only showed up in a module
+
+A sigilless parameter (`\test`) keeps a module sub off the OTF-compiled call
+path, so `fails-like` runs through this tree-walk fallback in the first place.
+The same two routines written in a plain script never reach the merge and never
+showed the bug — which is why the signature, not the module, is what the
+bisection kept pointing at.
+
+Pin: `t/slurpy-param-does-not-leak-to-caller.t` (with `t/lib/SlurpyLeak.rakumod`).
+`roast/S24-testing/fails-like.t` now passes under `MUTSU_REAL_TEST=1`.

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -63,8 +63,20 @@ impl Interpreter {
             .param_defs
             .iter()
             .filter_map(|pd| {
-                if pd.name.is_empty() || pd.name.starts_with('@') || pd.name.starts_with('%') {
+                if pd.name.is_empty() {
                     None
+                } else if pd.name.starts_with('@') || pd.name.starts_with('%') {
+                    // An `@`/`%` parameter is normally the caller's own container,
+                    // so the return merge propagates the callee's mutations back
+                    // under that name. A *slurpy* one never is: the binder builds
+                    // a fresh Array/Hash out of the leftover arguments
+                    // (`bind_function_args_values`), so writing it back only
+                    // clobbers a same-named lexical of the caller. That is how
+                    // `Test.rakumod`'s `throws-like(..., *%matcher)` came back
+                    // from a nested `fails-like(..., *%matcher)` holding the
+                    // callee's matcher and then called `.instead` on the wrong
+                    // exception (roast S24-testing/fails-like.t).
+                    (pd.slurpy || pd.double_slurpy).then(|| pd.name.clone())
                 } else if let Some(name) = pd.name.strip_prefix(':') {
                     Some(name.to_string())
                 } else {

--- a/t/lib/SlurpyLeak.rakumod
+++ b/t/lib/SlurpyLeak.rakumod
@@ -1,0 +1,42 @@
+unit module SlurpyLeak;
+
+# A sigilless parameter keeps a module sub off the OTF-compiled call path, so it
+# runs through the tree-walk fallback whose return merge writes the callee's
+# `@`/`%` variables back into the caller under the same name. A *slurpy* one is
+# never the caller's container -- the binder builds a fresh Array/Hash out of the
+# leftover arguments -- so writing it back only clobbers a same-named caller
+# lexical. `Test.rakumod`'s `throws-like(..., *%matcher)` hit exactly that when
+# the code it ran called `fails-like(..., *%matcher)`.
+
+sub run-block(&blk) { blk() }
+
+sub inner-named(\code, $type, *%matcher) is export {
+    die "inner saw: " ~ %matcher.keys.sort.join(',');
+}
+
+sub outer-named($code, *%matcher) is export {
+    my $seen;
+    run-block {
+        CATCH { default { $seen = %matcher.keys.sort.join(','); } }
+        $code();
+    }
+    $seen;
+}
+
+sub inner-positional(\code, $type, *@rest) is export {
+    die "inner saw: " ~ @rest.join(',');
+}
+
+sub outer-positional($code, *@rest) is export {
+    my $seen;
+    run-block {
+        CATCH { default { $seen = @rest.join(','); } }
+        $code();
+    }
+    $seen;
+}
+
+# A non-slurpy `%h` parameter still writes back: it is the caller's own Hash.
+sub mutate-hash(\code, %h) is export {
+    %h<added> = 1;
+}

--- a/t/slurpy-param-does-not-leak-to-caller.t
+++ b/t/slurpy-param-does-not-leak-to-caller.t
@@ -1,0 +1,31 @@
+use lib 't/lib';
+use Test;
+
+# A callee's *slurpy* parameter must not survive into the caller's frame. The
+# tree-walk return merge propagates a callee's `@`/`%` variables back to a
+# same-named caller lexical (that is how a `%h` parameter's mutations reach the
+# caller), but a slurpy is built fresh by the binder out of the leftover
+# arguments, so propagating it just overwrites an unrelated caller binding.
+#
+# Reached through a module sub with a sigilless parameter, which is what keeps
+# such a routine on the tree-walk fallback in the first place. The symptom in
+# the wild: `Test.rakumod`'s `throws-like($code, $type, *%matcher)` came back
+# from a nested `fails-like(..., *%matcher)` holding the *callee's* matcher, so
+# its CATCH called `.instead` on an exception that only has `.message`
+# (roast S24-testing/fails-like.t).
+
+plan 3;
+
+use SlurpyLeak;
+
+is outer-named({ inner-named(sub {}, Int, :instead) }, message => 1),
+    'message',
+    "a callee's *%slurpy does not overwrite the caller's same-named slurpy";
+
+is outer-positional({ inner-positional(sub {}, Int, 'callee') }, 'caller'),
+    'caller',
+    "a callee's *@slurpy does not overwrite the caller's same-named slurpy";
+
+my %h = :start(1);
+mutate-hash(sub {}, %h);
+is %h<added>, 1, 'a non-slurpy %h parameter still writes its mutations back';


### PR DESCRIPTION
The tree-walk return merge in `call_function_def` propagates a callee's `@`/`%`
variables back into the caller's env under the same name — that is how a `%h`
parameter's mutations become visible after the call, so `@`/`%` names were
deliberately left out of `routine_writeback_excluded_names`.

A **slurpy** parameter is never the caller's container: `bind_function_args_values`
builds a fresh `Array`/`Hash` out of the leftover arguments. Merging it back could
only clobber an unrelated same-named caller lexical.

`Test.rakumod` hit exactly that. `throws-like($code, $ex_type, $reason?, *%matcher)`
runs the tested code inside a `subtest` whose `CATCH` walks `%matcher` — and when
that code calls `fails-like(\test where Callable:D|Str:D, $ex-type, $reason?, *%matcher)`,
the callee's matcher came back in its place. `roast/S24-testing/fails-like.t` then
aborted with

```
No such method 'instead' for invocant of type 'X::Match::Bool'
```

which reads like a missing exception attribute but is the wrong `%matcher` key
being asked for. (`X::Match::Bool` has no `.instead` in rakudo either; the test
matches on `.message`.)

The routine only reaches the tree-walk fallback because its sigilless `\test`
parameter keeps a module sub off the OTF-compiled call path — which is why the
same two routines in a plain script never showed the bug.

Slurpy (`*@a`, `*%h`) and double-slurpy (`**@a`) parameters are now excluded from
the merge; a plain `%h` parameter still writes back (pinned).

- Pin: `t/slurpy-param-does-not-leak-to-caller.t` + `t/lib/SlurpyLeak.rakumod`
  (verified to fail on the unfixed build).
- `roast/S24-testing/fails-like.t` passes under `MUTSU_REAL_TEST=1`.
- `make test` PASS.

Part of `todo/tickets/vendor-real-test-module.md` step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)