### PR TITLE
fix(parser): a diagnosed parse error keeps its exception class

### DIFF
--- a/news/2026-08/parse-error-keeps-its-exception-class.md
+++ b/news/2026-08/parse-error-keeps-its-exception-class.md
@@ -1,0 +1,45 @@
+# A diagnosed parse error keeps its exception class
+
+The parser already recognises a good number of constructs precisely enough to
+name the Raku exception class that rejects them, using the `"X::Type: text"`
+message convention that `news/2026-08/typed-exception-class-from-the-message-convention.md`
+made load-bearing:
+
+```rust
+return Err(PError::expected_at(
+    "X::Syntax::CannotMeta: Cannot do . because it is too fiddly",
+    r,
+));
+```
+
+The class did not survive the trip out. Two layers flattened it:
+
+1. The statement-list loop (`parser/stmt/stmtlist.rs`) stringifies a failed
+   statement's error into `"expected statement at line N (after M stmts): {e} —
+   near: …"`, so the classified message became a *substring* of a longer one.
+2. `parse_program` then wrapped that in `"Confused. parse error at line L,
+   column C: …"`.
+
+The convention only fires on a message that *starts* with `X::`, so what user
+code saw was `X::Syntax::Confused` with the real diagnosis quoted somewhere in
+the middle of an "expected A or B or C or …" list.
+
+Both layers now propagate a classified alternative instead of flattening it.
+Every message merged into a `PError` shares the same furthest failure position
+(`update_best_error` merges only at an equal score), so a message that names a
+class describes *this* failure and is strictly better than the generic wrapper.
+An error with no such alternative is unchanged — it still renders "Confused."
+and classes as `X::Syntax::Confused`.
+
+This was the largest single cluster in the real-`Test` roast residue: 17 of the
+145 files that lost individual assertions did so on `throws-like … , X::Syntax::…`
+(`todo/tickets/vendor-real-test-module.md`). It closes the `X::Syntax::CannotMeta`
+group — `roast/S03-metaops/not.t`, `roast/S03-metaops/zip.t` and
+`roast/S03-operators/is-divisible-by.t` now pass under `MUTSU_REAL_TEST=1`, and
+`roast/S03-metaops/cross.t` and `roast/S03-operators/arith.t` get past it (both
+are left on an unrelated `Test::Util` `group-of` failure). The `X::Comp::Group`
+and `X::Syntax::Missing` groups are untouched: mutsu does not raise those classes
+at all yet, which is separate work.
+
+Pin: `t/parse-error-keeps-its-exception-class.t`, which also pins that the
+undiagnosed fallback is still `X::Syntax::Confused`.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -396,7 +396,24 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
                 let tail = &source[consumed..];
                 let near_offset = consumed + leading_ws_bytes(tail);
                 let (line_num, col_num) = line_col_at_offset(source, near_offset);
-                if let Some(context) = near_snippet(tail, 60) {
+                // One of the alternatives that failed here may have diagnosed the
+                // input precisely and named its Raku exception class in the
+                // `"X::Type: text"` convention (`X::Syntax::CannotMeta: Cannot do
+                // . because it is too fiddly`). Every message merged into a
+                // `PError` shares the same furthest failure position
+                // (`update_best_error` only merges at an equal score), so such a
+                // message describes *this* failure and is strictly better than
+                // the generic "Confused." wrapper — which would otherwise bury it
+                // inside an "expected A or B or …" list and leave the exception
+                // classed `X::Syntax::Confused`.
+                if let Some(typed) = e.typed_convention_message() {
+                    Err(with_parse_hint(RuntimeError::with_location(
+                        typed.to_string(),
+                        RuntimeErrorCode::ParseExpected,
+                        line_num,
+                        col_num,
+                    )))
+                } else if let Some(context) = near_snippet(tail, 60) {
                     Err(with_parse_hint(RuntimeError::with_location(
                         format!(
                             "Confused. parse error at line {}, column {}: {} — near: {:?}",

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -115,6 +115,18 @@ impl PError {
         err
     }
 
+    /// The first alternative written in the `"X::Type: text"` convention, if
+    /// any. Such a message is a *diagnosis* — the parser recognised the
+    /// construct and knows which Raku exception class rejects it — so a caller
+    /// that would otherwise flatten this error into a generic "expected …"
+    /// description should propagate it instead. Losing it downgrades the
+    /// exception to `X::Syntax::Confused`.
+    pub fn typed_convention_message(&self) -> Option<&str> {
+        self.messages.iter().find_map(|m| {
+            crate::value::RuntimeError::split_typed_message_convention(m).map(|_| m.as_str())
+        })
+    }
+
     /// Get the formatted message string (used by tests).
     #[allow(dead_code)]
     pub fn message(&self) -> String {

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -393,6 +393,14 @@ pub(crate) fn stmt_list_with_mode(
                 if e.is_fatal() {
                     return Err(e);
                 }
+                // An alternative that named its exception class diagnosed this
+                // input precisely; flattening it into the "expected statement at
+                // line N: …" description below would bury the class inside a
+                // longer string and leave the failure classed
+                // `X::Syntax::Confused`.
+                if e.typed_convention_message().is_some() {
+                    return Err(e);
+                }
                 let consumed = input.len() - r.len();
                 let line_num = input[..consumed].matches('\n').count() + 1;
                 let context: String = r.chars().take(80).collect();

--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -159,7 +159,7 @@ impl RuntimeError {
     /// real instead of decorative. A message that is only a class name
     /// (`"X::Match::Bool"`) counts too — its text is the class name, matching
     /// what `typed()` does when no `message` attribute is supplied.
-    fn split_typed_message_convention(message: &str) -> Option<(&str, &str)> {
+    pub(crate) fn split_typed_message_convention(message: &str) -> Option<(&str, &str)> {
         if !message.starts_with("X::") {
             return None;
         }

--- a/t/parse-error-keeps-its-exception-class.t
+++ b/t/parse-error-keeps-its-exception-class.t
@@ -1,0 +1,36 @@
+use Test;
+
+# A parse error that the parser diagnosed precisely spells its Raku exception
+# class in the `"X::Type: text"` message convention. Such a diagnosis used to be
+# flattened twice on the way out -- the statement-list loop stringified it into
+# "expected statement at line N: ..." and `parse_program` wrapped that in
+# "Confused. parse error at ...: expected A or B or ..." -- so the class was
+# buried in a sentence and the exception arrived as the catch-all
+# `X::Syntax::Confused`. Both layers now propagate the classified alternative.
+#
+# roast/S03-metaops/{cross,not,zip}.t and S03-operators/is-divisible-by.t all
+# assert these classes through `throws-like`.
+
+plan 6;
+
+sub class-of($code) {
+    try { EVAL $code };
+    $!.^name;
+}
+
+is class-of('3 X. list'), 'X::Syntax::CannotMeta',
+    'a dotty infix under a metaoperator is X::Syntax::CannotMeta';
+is class-of('1 !% 2'), 'X::Syntax::CannotMeta',
+    'negating a non-iffy infix is X::Syntax::CannotMeta';
+is class-of('1 !+ 2'), 'X::Syntax::CannotMeta',
+    'negating + is X::Syntax::CannotMeta';
+is class-of('3 X. "foo"'), 'X::Obsolete',
+    'the Perl 5 concat operator is X::Obsolete, not Confused';
+
+# The classified message must not lose its own text, and a failure the parser
+# genuinely cannot describe still falls back to X::Syntax::Confused.
+try { EVAL '1 !% 2' };
+ok $!.message.contains('not iffy enough'), 'the diagnosis text survives';
+
+is class-of('1 1'), 'X::Syntax::Confused',
+    'an undiagnosed parse failure is still X::Syntax::Confused';


### PR DESCRIPTION
The parser recognises a fair number of constructs precisely enough to name the
Raku exception class that rejects them, using the `"X::Type: text"` message
convention that `news/2026-08/typed-exception-class-from-the-message-convention.md`
made load-bearing:

```rust
return Err(PError::expected_at(
    "X::Syntax::CannotMeta: Cannot do . because it is too fiddly",
    r,
));
```

The class did not survive the trip out. Two layers flattened it:

1. the statement-list loop stringified the failed statement's error into
   `"expected statement at line N (after M stmts): {e} — near: …"`, so the
   classified message became a *substring* of a longer one;
2. `parse_program` then wrapped that in `"Confused. parse error at …"`.

The convention only fires on a message that *starts* with `X::`, so user code
saw `X::Syntax::Confused` with the real diagnosis quoted somewhere inside an
"expected A or B or C or …" list:

```
# Expected: X::Syntax::CannotMeta
# Got:      X::Syntax::Confused
# Exception message: Confused. parse error at line 1, column 1: expected expected
#   statement at line 1 (after 0 stmts): expected expression statement or
#   X::Syntax::CannotMeta: Cannot do . because it is too fiddly — near: "3 X. list"
```

Both layers now propagate a classified alternative instead of flattening it.
Every message merged into a `PError` shares the same furthest failure position
(`update_best_error` merges only at an equal score), so a message that names a
class describes *that* failure and is strictly better than the generic wrapper.
An error with no such alternative is unchanged — still "Confused." and still
`X::Syntax::Confused`.

This was the largest single cluster in the real-`Test` roast residue (17 of the
145 files that lose individual assertions fail on `throws-like …, X::Syntax::…`,
`todo/tickets/vendor-real-test-module.md`). Under `MUTSU_REAL_TEST=1`:
`roast/S03-metaops/not.t`, `roast/S03-metaops/zip.t` and
`roast/S03-operators/is-divisible-by.t` now pass; `roast/S03-metaops/cross.t` and
`roast/S03-operators/arith.t` get past it and are left on an unrelated
`Test::Util` `group-of` failure.

- Pin: `t/parse-error-keeps-its-exception-class.t` (verified to fail on the
  unfixed build; also passes verbatim under `raku`, and pins the undiagnosed
  fallback still being `X::Syntax::Confused`).
- `make test` PASS.
- The whitelisted `roast/S02*`–`S05*` subset (438 files) under the native
  provider shows no new failures; the four exit-124 files are the known
  debug-build timeouts (`Failed: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)