### PR TITLE
docs(todo): record the real-Test step-1 clusters and two new findings

### DIFF
--- a/todo/deep/loop-control-signal-is-not-catchable.md
+++ b/todo/deep/loop-control-signal-is-not-catchable.md
@@ -1,0 +1,86 @@
+# A `next`/`last`/`redo` with no enclosing loop is not catchable
+
+In rakudo a loop-control statement that finds no loop to act on becomes an
+ordinary, catchable exception at the point it is raised:
+
+```raku
+try { my $i; { $i++; next; $i--; } };
+say $!.^name;      # X::ControlFlow
+say $!.message;    # next without loop construct
+say $!.illegal;    # next
+say $!.enclosing;  # loop construct
+```
+
+mutsu raises `RuntimeError::next_signal()` — a control signal, not an exception —
+and `try`/`CATCH` deliberately let control signals through
+(`vm_try_catch_ops.rs`, the `is_last() || is_next() || is_redo() || …` arm). The
+signal therefore escapes every handler and only surfaces at the top of the
+program as `Runtime error: X::ControlFlow`, uncatchable:
+
+```
+$ mutsu -e 'say (try { my $i; { $i++; next } }).^name'
+Runtime error: X::ControlFlow
+```
+
+## Why the obvious fixes are wrong
+
+`try` cannot decide this on its own, and neither can the compiler:
+
+- **A control signal legitimately crosses routine and `EVAL` boundaries.**
+  `sub f { next }; for 1..3 { f() }` iterates three times in rakudo *and* in
+  mutsu, and so does `for 1..3 { EVAL 'next' }` — measured 2026-08-03. So
+  neither the routine boundary nor the `EVAL` boundary may convert the signal.
+- **Compile-time "there is no lexically enclosing loop" is not sufficient**, for
+  the same reason: the loop that handles the signal is usually in another
+  routine entirely.
+- **Converting at the top of the interpreter loop** (the way an uncaught
+  `CX::Return` becomes `X::ControlFlow::Return` in `vm_run_loop.rs`) fixes the
+  top-level *message* but not catchability: by then the `try` has already passed
+  the signal on, and unwinding is one-way.
+
+The only correct discriminator is the *dynamic* one rakudo uses: is there a
+loop-control handler anywhere up the dynamic chain right now? mutsu has no such
+registry — every loop construct handles the signal ad hoc by matching
+`Err(e) if e.is_next()` on its body's result.
+
+## What it would take
+
+An `Interpreter::loop_handler_depth` counter, incremented for the dynamic extent
+of every construct that handles a loop-control signal and consulted at the raise
+site (throw a real `X::ControlFlow` when it is zero, exactly as
+`react_done_signal()` already pre-builds its `X::ControlFlow` for the `done`
+case). The catch sites to instrument, from
+`git grep -l 'is_next()\|is_last()\|is_redo()'`, span 22 files:
+
+```
+runtime/builtins_collection_deepmap.rs  runtime/builtins_reduce.rs
+runtime/calls.rs                        runtime/methods_collection_ops/grep.rs
+runtime/methods_seq_dispatch.rs         runtime/native_supplier_methods.rs
+runtime/native_supply_mut_methods.rs    runtime/resolution_map_grep.rs
+runtime/resolution_map_grep_rw.rs       runtime/sequence.rs
+runtime/supply_promise.rs               vm/vm_control_ops.rs
+vm/vm_for_loop_body.rs                  vm/vm_for_loop_intrange.rs
+vm/vm_for_loop_lazy.rs                  vm/vm_helpers_lazy_pull.rs
+vm/vm_loop_cstyle_repeat.rs             vm/vm_misc_block.rs
+vm/vm_react_loop.rs                     vm/vm_react_subscriptions.rs
+vm/vm_react_supply_helpers.rs           vm/vm_try_catch_ops.rs
+```
+
+The sweep has to be **complete**: a missed site turns a `next` that construct
+would have handled into a thrown `X::ControlFlow`, silently breaking that loop.
+That is a compatibility regression, not just a missing feature, which is why
+this is filed as a deep item rather than done piecemeal. Deterministic, so roast
+catches it — but the whole sweep belongs in one PR.
+
+## What it blocks
+
+Three whitelisted roast files fail under `MUTSU_REAL_TEST=1` on this alone
+(the real `Test`'s `throws-like` runs its argument inside a `subtest`'s `CATCH`,
+which the signal walks straight through, aborting the file):
+
+- `roast/S04-statements/do.t` — `throws-like 'my $i; { $i++; next; $i--; }', X::ControlFlow`
+- `roast/S04-statements/redo.t`
+- `roast/S04-blocks-and-statements/pointy.t`
+
+mutsu's native `throws-like` special-cases control signals, which is why the
+same files pass under the native provider today.

--- a/todo/tickets/use-inside-a-block-leaks-to-the-enclosing-scope.md
+++ b/todo/tickets/use-inside-a-block-leaks-to-the-enclosing-scope.md
@@ -1,0 +1,65 @@
+# `use` inside a block leaks its imports to the enclosing scope
+
+In raku an import is lexical to the block that asked for it:
+
+```raku
+{
+    use Test;
+    say "inside: ", &ok.defined;   # True
+}
+say "outside: ", &ok.defined;      # ===SORRY!=== Undeclared routine: ok
+```
+
+mutsu answers `True` both times. There *is* a scoping mechanism —
+`push_import_scope` / `pop_import_scope` in `runtime/runtime_module.rs` snapshot
+and restore the function/class registries around a block — but the imported
+names also land in `env` as `&ok`-style entries, and those are not rolled back.
+
+## Where it bites
+
+`roast/S32-list/skip.t` (whitelisted, fails under `MUTSU_REAL_TEST=1`) opens
+with a deliberately selective import so that the *core* `skip` routine stays
+visible, because `Test` exports one of its own:
+
+```raku
+# By default, Test exports a "skip" sub, which interferes with the "skip"
+# functionality we want to test here.  Hence the selective import here.
+BEGIN my (&plan, &subtest, &is, &is-deeply, &throws-like) = do {
+    use Test;
+    (&plan, &subtest, &is, &is-deeply, &throws-like)
+}
+```
+
+With the leak, `Test`'s `skip` is in scope after the `do` block, so
+`skip(5, $list)` reaches the TAP directive and the file aborts with
+
+```
+skip() was passed a non-integer number of tests.  Did you get the arguments
+backwards or use a non-integer number?
+```
+
+Under mutsu's native provider the file happens to pass, because the native
+`skip` handler disambiguates the list-skip shape
+(`skip_call_is_list_skip`) — the leak is invisible until the real module is in
+charge and no such shape check exists.
+
+## Minimal repro
+
+```raku
+$ cat > /tmp/x.raku <<'EOF'
+{ use Test; }
+say &ok.defined;
+EOF
+$ raku /tmp/x.raku    # ===SORRY!=== Undeclared routine: ok
+$ mutsu /tmp/x.raku   # True
+```
+
+## Why it is not a one-liner
+
+The registry half is already scoped; the `env` half is the whole job, and it has
+to distinguish an imported alias (drop on scope exit) from a module's own
+qualified definition (keep — `pop_import_scope` already documents that
+distinction for the registry, because a sibling block's later `use` re-imports
+from those). `use` also drives pragma state (`strict_mode`, `fatal_mode`,
+`monkey_typing`, `newline_mode`), which the same snapshot already restores, so
+the change is confined to the symbol side.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -600,15 +600,73 @@ So step 3 needs the call path as well as the 185 correctness gaps.
 - ~~`S02-names/strict.t` / `S02-lexical-conventions/comments.t`~~ **DONE** —
   `news/2026-08/strict-does-not-reject-a-declared-bind.md`.
 - ~~six files aborting on a missing exception attribute~~ **DONE** —
-  `news/2026-08/typed-exceptions-carry-their-attributes.md`. Two of that family
-  are left: `X::Match::Bool` has no `.instead` (`S24-testing/fails-like.t`) and
-  `X::Syntax::Pod::BeginWithoutIdentifier` has no `.filename`
-  (`S32-exceptions/misc2.t`) — the latter is the `X::Comp` file/line metadata
-  rather than a per-class attribute.
-- `skip() was passed a non-integer number of tests` — still open; the shape that
-  triggers it is not any of the ordinary `skip 'reason', N` forms (all of those
-  were checked against the real module and pass), so find the file from the
-  sweep rather than guessing.
+  `news/2026-08/typed-exceptions-carry-their-attributes.md`. One of that family
+  is left: `X::Syntax::Pod::BeginWithoutIdentifier` has no `.filename`
+  (`S32-exceptions/misc2.t`) — that one is the `X::Comp` file/line metadata
+  rather than a per-class attribute. The other, "`X::Match::Bool` has no
+  `.instead`" (`S24-testing/fails-like.t`), **was not an attribute gap at all**:
+  rakudo has no `.instead` there either, and the test matches on `.message`.
+  mutsu asked for `.instead` because `throws-like`'s `*%matcher` had been
+  overwritten by the nested `fails-like`'s
+  (`news/2026-08/slurpy-parameter-does-not-leak-to-the-caller.md`). A missing-method
+  error inside `Test.rakumod` is as likely to be the *wrong value* as a missing
+  method — check what the module thinks it is holding first.
+- ~~`skip() was passed a non-integer number of tests`~~ — found: the file is
+  `roast/S32-list/skip.t`, and it is not a `skip`-shape problem. The file
+  deliberately imports selectively (`BEGIN my (&plan, …) = do { use Test; … }`)
+  so that the *core* `skip` routine stays visible, and mutsu leaks a `use` inside
+  a block into the enclosing scope, so `Test`'s `skip` answered instead. That is
+  the general bug to fix (`use` is lexically scoped in raku); it is not on the
+  `skip` implementation at all.
+
+### Classifying the 145 assertion-losers, and the clusters it found (2026-08-03)
+
+The 185 genuine failures split 40 mid-file aborts and 145 files that merely lose
+assertions. Classifying the 145 by their *first* `not ok` (`tmp/classify-assert.sh`,
+run under `xargs -P4`) turns them into something workable — and one cluster
+dominates:
+
+| first failing assertion | files |
+| --- | --- |
+| `right exception type (X::…)` | **17** |
+| everything else | 128, a long tail of one-offs |
+
+Splitting that 17 by the class asked for: `X::Syntax::CannotMeta` 6,
+`X::Comp::Group` 5, `X::Syntax::Missing` 4, `X::UnitScope::Invalid` 2,
+`X::Syntax::NonAssociative` 2, then singletons.
+
+**`X::Syntax::CannotMeta` and friends were not missing at all** — the parser had
+already diagnosed the construct precisely and named the class in the message, and
+two layers of error flattening buried it
+(`news/2026-08/parse-error-keeps-its-exception-class.md`). Do not read a
+"right exception type" failure as "mutsu does not raise that class" before
+checking whether the diagnosis is already in the message text.
+
+Landed against this residue on 2026-08-03:
+
+| fix | what it freed |
+| --- | --- |
+| `news/2026-08/slurpy-parameter-does-not-leak-to-the-caller.md` — a callee's `*%slurpy` overwrote the caller's same-named binding, so `throws-like`'s `%matcher` came back holding `fails-like`'s | `S24-testing/fails-like.t` |
+| `news/2026-08/parse-error-keeps-its-exception-class.md` — a classified parse diagnosis survives the "Confused." wrapper | `S03-metaops/not.t`, `S03-metaops/zip.t`, `S03-operators/is-divisible-by.t` |
+| `news/2026-08/pair-subsignature-dispatch.md` — dispatch could not match `Pair (:key(…), :value(…))`, so `Test::Util`'s `group-of` lost to the native provider | `S03-metaops/cross.t`, `S03-operators/arith.t` (with the above) |
+| `news/2026-08/missing-block-is-a-syntax-missing.md` — a required-but-absent block is `X::Syntax::Missing` | `S04-statements/if.t`, `S02-names/identifier.t` |
+
+Still open in the named clusters:
+
+- **`X::Comp::Group` (5 files)** — mutsu never groups compile-time errors, so a
+  `throws-like …, X::Comp::Group` has nothing to match. Needs the sorrows/panic
+  collection rakudo's `X::Comp::Group` carries, not a message tweak.
+- **`X::Syntax::Missing`, the remainder** — `S04-statements/terminator.t` moved on
+  to wanting `X::Syntax::Malformed` for `my $x =`, and
+  `S02-lexical-conventions/minimal-whitespace.t`'s `@arr [0]` fails before any
+  block alternative is reached (rakudo's "Missing block" there comes from a
+  different rule).
+- **`X::ControlFlow` (3 files: `S04-statements/do.t`, `redo.t`,
+  `S04-blocks-and-statements/pointy.t`)** — a `next`/`last`/`redo` with no
+  enclosing loop is a control *signal* in mutsu, which `try`/`CATCH` deliberately
+  passes through, so it is uncatchable. Filed as
+  `todo/deep/loop-control-signal-is-not-catchable.md`: the only correct fix is a
+  dynamic loop-handler depth, and the sweep has to be complete to be safe.
 
 ### (superseded) the 2026-08-03 pre-fix notes
 


### PR DESCRIPTION
Follow-up documentation for today's `todo/tickets/vendor-real-test-module.md` step-1 work
(#5790, #5791, #5792, #5794).

**The residue is now classified.** The 185 genuine failures split 40 mid-file aborts and
145 files that merely lose assertions; classifying the 145 by their *first* `not ok` shows
one cluster of any size — **17 files fail on `right exception type (X::…)`** — and a long
tail of one-offs. The ticket records the split by class and what landed against it.

The lesson worth keeping: those were mostly **not** "mutsu does not raise that class".
The parser had already diagnosed the construct and named the class in its message; two
layers of error flattening buried it (#5791).

Two findings get their own files:

- `todo/deep/loop-control-signal-is-not-catchable.md` — `next`/`last`/`redo` with no
  enclosing loop is a control *signal*, which `try`/`CATCH` passes through by design,
  so it is uncatchable (rakudo raises a catchable `X::ControlFlow`). Measured that
  neither the routine boundary nor the `EVAL` boundary may convert it, so the only
  correct fix is a dynamic loop-handler depth touching 22 files — and it has to be
  complete, since a missed catch site silently breaks that construct's loop. Blocks
  `S04-statements/{do,redo}.t` and `S04-blocks-and-statements/pointy.t`.
- `todo/tickets/use-inside-a-block-leaks-to-the-enclosing-scope.md` — the registry half
  of import scoping is already handled by `push_import_scope`/`pop_import_scope`; the
  `env` half is not.

That second one **closes the ticket's open "`skip() was passed a non-integer number of
tests`" item as mis-attributed**: the file is `roast/S32-list/skip.t`, which imports
selectively *on purpose* so the core `skip` stays visible, and the leak is what puts
`Test`'s `skip` in scope. Nothing to fix on `skip` itself.

Also corrects the "`X::Match::Bool` has no `.instead`" item — rakudo has no such method
either and the test matches on `.message`; mutsu asked for the wrong key because
`throws-like`'s `*%matcher` had been overwritten by a nested call (#5790).

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)