### PR TITLE
fix(parser): keep Missing block from over-claiming, and keep the failure position

### DIFF
--- a/news/2026-08/missing-block-is-a-syntax-missing.md
+++ b/news/2026-08/missing-block-is-a-syntax-missing.md
@@ -30,14 +30,9 @@ to its next gap (`my $x =` wants `X::Syntax::Malformed`).
 `@arr [0]` fails before any block alternative is reached, and rakudo's
 "Missing block" there comes from a different rule.
 
-Two things had to give way for it:
+Three things had to give way for it, all of them found by roast rather than
+predicted:
 
-- **`X::Syntax::Missing` ranks last among classified diagnoses.** "A block was
-  required here" is the weakest thing the parser can say — a block is an
-  alternative almost everywhere — so any other named class describes the
-  construct better. Without the ranking, `sub twigil:<@>() { }` reported
-  `X::Syntax::Missing` instead of the `X::Syntax::Extension::Category` a sibling
-  alternative had diagnosed.
 - **mutsu's native `throws-like` recognised a parse failure by the words "parse
   error" in its message.** A failure the parser diagnoses precisely says only
   what is wrong ("Missing block"), so that substring test stopped firing and
@@ -45,5 +40,20 @@ Two things had to give way for it:
   the leniency that lets any parse failure match an `X::Syntax` type when no
   structured exception is attached. It now reads the structured parse `code`
   instead, the way its own `X::Comp` branch already did.
+- **"Missing block" counts as a diagnosis only when the block was the *primary*
+  expectation** — the first alternative at that position. It is the weakest
+  thing the parser can say, since a block is an alternative almost everywhere:
+  `say 1 ]` fails with a hundred alternatives of which "block" is merely one,
+  and rakudo calls that `X::Syntax::Confused`. Any *other* named class also
+  outranks it, so `sub twigil:<@>() { }` keeps the
+  `X::Syntax::Extension::Category` a sibling alternative diagnosed.
+- **The failure position had to be carried through.** The statement-list loop
+  supplies it when it wraps a failed statement's error; propagating a classified
+  error instead skipped the wrapper, so `parse_program` had no line or column to
+  report and the CLI lost its `------>` snippet. The propagation now fills the
+  position in.
+
+The rendered message drops the class prefix, so a `===SORRY!===` reads
+`Missing block` exactly as rakudo's does; `$!.^name` is where the class shows up.
 
 Pin: `t/missing-block-exception.t` (passes verbatim under `raku`).

--- a/src/error_render.rs
+++ b/src/error_render.rs
@@ -12,6 +12,12 @@ use crate::value::RuntimeError;
 ///   "Confused. parse error at line 1, column 1: expected expected statement ..."
 /// We extract a cleaner version for display.
 fn short_parse_message(msg: &str) -> String {
+    // A message written in the `"X::Type: text"` convention already *is* the
+    // diagnosis; rakudo prints only the text ("Missing block"), with the class
+    // reachable through `$!`. Drop the class prefix for display.
+    if let Some((_, text)) = RuntimeError::split_typed_message_convention(msg) {
+        return text.to_string();
+    }
     // Remember the "Confused" marker: rakudo renders "Confused" as the SORRY
     // message body and roast checks stderr for it (S02-one-pass-parsing/misc.t),
     // so it is re-prefixed onto the simplified message below.

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -15,6 +15,15 @@ pub(super) struct PError {
 /// Sentinel prefix for fatal (non-recoverable) parse errors.
 pub(super) const FATAL_PREFIX: &str = "FATAL:";
 
+/// The diagnosis rakudo gives whenever a block was required and not found —
+/// `X::Syntax::Missing` with `what => 'block'`, rendered "Missing block". It
+/// covers the opening brace (`if 1; 2`, `sub foo-($x) {}`) and the closing one
+/// (`{my $x = 2;`) alike. Spelled in the `"X::Type: text"` convention so the
+/// class survives to `$!`
+/// (`news/2026-08/parse-error-keeps-its-exception-class.md`), and treated
+/// specially by [`PError::typed_convention_message`].
+pub(crate) const MISSING_BLOCK: &str = "X::Syntax::Missing: Missing block";
+
 impl PError {
     /// Check if this is a fatal (non-recoverable) parse error.
     pub fn is_fatal(&self) -> bool {
@@ -121,10 +130,30 @@ impl PError {
     /// that would otherwise flatten this error into a generic "expected …"
     /// description should propagate it instead. Losing it downgrades the
     /// exception to `X::Syntax::Confused`.
+    ///
+    /// [`MISSING_BLOCK`] is special-cased twice over, because "a block was
+    /// required here" is the weakest diagnosis the parser has — a block is an
+    /// alternative almost everywhere:
+    ///
+    /// * any *other* named class describes the construct better and wins;
+    /// * on its own it counts only when the block was the *primary* expectation
+    ///   at this position, i.e. the first alternative. `say 1 ]` fails with a
+    ///   hundred alternatives of which "block" is merely one, and rakudo calls
+    ///   that `X::Syntax::Confused`, not `X::Syntax::Missing`.
     pub fn typed_convention_message(&self) -> Option<&str> {
-        self.messages.iter().find_map(|m| {
-            crate::value::RuntimeError::split_typed_message_convention(m).map(|_| m.as_str())
-        })
+        fn typed(m: &str) -> Option<&str> {
+            crate::value::RuntimeError::split_typed_message_convention(m).map(|_| m)
+        }
+        self.messages
+            .iter()
+            .filter(|m| m.as_str() != MISSING_BLOCK)
+            .find_map(|m| typed(m))
+            .or_else(|| {
+                self.messages
+                    .first()
+                    .filter(|m| m.as_str() == MISSING_BLOCK)
+                    .map(|m| m.as_str())
+            })
     }
 
     /// Get the formatted message string (used by tests).

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod sub_param;
 pub(crate) mod word_logical_split;
 
 use super::memo::{MemoEntry, MemoStats, ParseMemo};
-use super::parse_result::{PError, PResult, parse_char, update_best_error};
+use super::parse_result::{MISSING_BLOCK, PError, PResult, parse_char, update_best_error};
 use std::cell::RefCell;
 use std::collections::HashMap;
 

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -19,13 +19,6 @@ pub(crate) fn block(input: &str) -> PResult<'_, Vec<Stmt>> {
     result
 }
 
-/// The diagnosis rakudo gives whenever a block was required and not found —
-/// `X::Syntax::Missing` with `what => 'block'`, rendered "Missing block". It
-/// covers the opening brace (`if 1; 2`, `sub foo-($x) {}`) and the closing one
-/// (`{my $x = 2;`) alike. Spelled in the `"X::Type: text"` convention so the
-/// class survives to `$!` (`news/2026-08/parse-error-keeps-its-exception-class.md`).
-pub(crate) const MISSING_BLOCK: &str = "X::Syntax::Missing: Missing block";
-
 pub(crate) fn block_inner(input: &str) -> PResult<'_, Vec<Stmt>> {
     let (input, stmts) = stmt_list_with_mode(input, false, true)?;
     let (input, _) = ws(input)?;
@@ -408,6 +401,11 @@ pub(crate) fn stmt_list_with_mode(
                 // longer string and leave the failure classed
                 // `X::Syntax::Confused`.
                 if e.typed_convention_message().is_some() {
+                    // The wrapper below is also what supplied the failure
+                    // position; keep it so `parse_program` can still report a
+                    // line and column (and the CLI its `------>` snippet).
+                    let mut e = e;
+                    e.remaining_len.get_or_insert(r.len());
                     return Err(e);
                 }
                 let consumed = input.len() - r.len();


### PR DESCRIPTION
Three follow-ups to #5794, all found by re-measuring rather than predicted.

**1. "Missing block" counts only when the block was the *primary* expectation.**
It is the weakest thing the parser can say — a block is an alternative almost
everywhere. `say 1 ]` fails with a hundred alternatives of which "block" is merely
one, and rakudo calls that `X::Syntax::Confused`. It now counts only as the *first*
alternative at the failure position, and any other named class outranks it, so
`sub twigil:<@>() { }` keeps the `X::Syntax::Extension::Category` a sibling
alternative diagnosed.

This is the ranking #5794's second commit message described — **it never actually
reached the tree**. A `git checkout HEAD -- src/parser/` while bisecting discarded
the edit, and only its `throws-like` half was committed. The news file is corrected
here too.

**2. The failure position had to be carried through.** The statement-list loop
supplies it when it wraps a failed statement's error; #5791 propagates a classified
error *instead of* that wrapper, so `parse_program` had no line or column and the
CLI lost its `------>` snippet:

```
# before this PR
Confused. parse error: expected use statement or import statement or ...   (no position)
```

The propagation now fills the position in.

**3. A classified message renders without its class prefix**, so a `===SORRY!===`
reads exactly as rakudo's:

```
$ mutsu -e 'if 1; 2'          $ raku -e 'if 1; 2'
===SORRY!=== …                ===SORRY!=== …
Missing block                 Missing block
at -e:1                       at -e:1
```

`$!.^name` is where the class shows up.

- `make test` PASS.
- Full `make roast` (release, 1435 files) PASS locally.
- `t/parse-failure-syntax-exception-class.t` (which asserts `say 1 ]` is
  `X::Syntax::Confused`) is what caught (1).

Part of `todo/tickets/vendor-real-test-module.md` step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)