### PR TITLE
fix(for): a multi-param loop parameter no longer inherits a stale type constraint

### DIFF
--- a/news/2026-08/for-multi-param-stale-type-constraint.md
+++ b/news/2026-08/for-multi-param-stale-type-constraint.md
@@ -1,0 +1,66 @@
+# A `for -> $k, $v` loop no longer inherits an unrelated lexical's type
+
+A multi-parameter `for` loop rejected values whose type had nothing to do with
+the loop:
+
+```raku
+sub declares-typed-v() { my Int $v = 42; $v }
+say declares-typed-v();
+
+for ("content-length", 10, "transfer-encoding", "identity") -> $k, $v {
+    say "$k=$v";
+}
+# content-length=10
+# Type check failed in assignment to $v; expected Int but got Str ("identity")
+```
+
+Any `my Int $v` / `state Int $v` / `our Int $v` *anywhere in the program* —
+including in an unrelated module the script merely loaded — constrained every
+subsequent `-> $k, $v` loop parameter.
+
+## Root cause
+
+The single-parameter form (`for @a -> $x`) binds natively in the VM. The
+multi-parameter form does not: `build_for_bind_stmts`
+(`src/compiler/mod.rs`) emits a plain `Stmt::Assign` per parameter into the body
+prefix, and `SetLocal` type-checks an assignment against
+`var_type_constraint(name)` — a **name-keyed, not block-scoped** map. A
+parameter is a fresh binding that shadows whatever the name meant outside, so
+inheriting that entry was wrong.
+
+## Fix
+
+`exec_for_loop_body` now saves each `multi_param_names` entry's constraint,
+clears it for the duration of the loop, and restores it afterwards — the same
+contract `bind_param_type_constraint` gives an untyped routine parameter, minus
+the permanent loss of the enclosing lexical's type (an outer `my Int $v` is still
+enforced once the loop has exited).
+
+Pin: `t/for-multi-param-type-constraint.t` (6 tests, green under `raku` too).
+
+## How it was found
+
+The vendored Cro::HTTP suite's `t/http-rawbodyparserselector.rakutest` could not
+run a single test: it died in
+
+```raku
+for %headers.kv -> $k, $v { $resp.append-header($k, $v) }
+```
+
+with `expected Int but got Str ("chunked")`. The `Int` came from
+`OpenSSL::Stack`'s `state Int $v = OpenSSL::Version::version_num()`, three
+modules away. That file now passes 10/10.
+
+## Left open
+
+Two related findings from the same investigation are filed rather than fixed
+here, because each is its own piece of work:
+
+- `todo/tickets/for-multi-param-shadow-clobbers-outer-lexical.md` — the loop
+  parameter also clobbers the enclosing lexical's *value* (`my $v = "outer"; for
+  (1,2) -> $k, $v { }; say $v` prints the uninitialized element). The env-side
+  save/restore is already there; the local-slot half needs the shadowing slot
+  resolution worked out first.
+- `todo/tickets/for-loop-multi-param-types-unenforced.md` — declared parameter
+  types on a multi-parameter loop (`-> Str $k, Int $v`) are parsed and then
+  ignored. `ForLoopSpec` carries no per-parameter constraint for the VM to check.

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -213,6 +213,34 @@ impl Interpreter {
                 (name.clone(), val, was_readonly, sigilless_ro)
             })
             .collect();
+        // A multi-parameter loop (`-> $k, $v`) binds its parameters with plain
+        // assignments emitted into the body prefix (`build_for_bind_stmts`), and
+        // `SetLocal` type-checks an assignment against the *name-keyed* constraint
+        // map. That map is not block-scoped, so an unrelated `my Int $v` anywhere
+        // in the program made `-> $k, $v` reject every non-Int value
+        // ("Type check failed in assignment to $v; expected Int"). A parameter is
+        // a fresh binding that shadows whatever the name meant outside, so clear
+        // the constraint for the duration of the loop and restore it after — the
+        // same contract `bind_param_type_constraint` gives an untyped routine
+        // parameter, minus the permanent loss of the enclosing lexical's type.
+        // (The single-param form binds natively and never had this problem.)
+        //
+        // Loop parameter types themselves are still unenforced: `ForLoopSpec`
+        // carries no per-parameter constraint. See
+        // `todo/tickets/for-loop-multi-param-types-unenforced.md`.
+        let saved_multi_param_types: Vec<(String, Option<String>)> = spec
+            .multi_param_names
+            .iter()
+            .map(|name| {
+                let tc = loan_env!(self, var_type_constraint(name));
+                (name.clone(), tc)
+            })
+            .collect();
+        for (name, tc) in &saved_multi_param_types {
+            if tc.is_some() {
+                self.vm_set_var_type_constraint(name, None);
+            }
+        }
         // Save the single named loop param (`for ... -> $x`) too, so a loop in a
         // called sub that reuses the same variable name does not clobber an outer
         // loop's binding of that name (the env keys these by bare name). Skip
@@ -754,6 +782,12 @@ impl Interpreter {
                 self.env_mut().insert(sigilless_key, ro_val);
             } else {
                 self.env_mut().remove(&sigilless_key);
+            }
+        }
+        // Restore the enclosing type constraint each multi-param name shadowed.
+        for (name, tc) in saved_multi_param_types {
+            if tc.is_some() {
+                self.vm_set_var_type_constraint(&name, tc);
             }
         }
         // Defer restoring the single named loop param's prior binding until

--- a/t/for-multi-param-type-constraint.t
+++ b/t/for-multi-param-type-constraint.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# A multi-parameter `for` loop (`-> $k, $v`) binds its parameters with plain
+# assignments emitted into the body prefix, and an assignment is type-checked
+# against the interpreter's *name-keyed* constraint map. That map is not
+# block-scoped, so an unrelated `my Int $v` / `state Int $v` anywhere in the
+# program made every `-> $k, $v` loop reject non-Int values with
+# "Type check failed in assignment to $v; expected Int".
+#
+# Found via the vendored Cro::HTTP suite: OpenSSL::Stack's `state Int $v` broke
+# `for %headers.kv -> $k, $v { $resp.append-header($k, $v) }` in
+# t/http-rawbodyparserselector.rakutest, which could not run a single test.
+
+plan 6;
+
+sub declares-typed-v() { my Int $v = 42; $v }
+is declares-typed-v(), 42, "the typed lexical itself still works";
+
+my @seen;
+for ("content-length", 10, "transfer-encoding", "identity") -> $k, $v {
+    @seen.push("$k=$v");
+}
+is @seen.join("|"), "content-length=10|transfer-encoding=identity",
+    "a multi-param loop binds values of any type after an unrelated typed lexical";
+
+sub state-typed-v() { state Int $v = 7; $v }
+is state-typed-v(), 7, "a state-typed lexical still works";
+
+my @seen2;
+for ("a", 1, "b", "two") -> $k, $v { @seen2.push("$k=$v") }
+is @seen2.join("|"), "a=1|b=two",
+    "a `state Int \$v` elsewhere does not constrain a loop parameter either";
+
+# The enclosing lexical keeps its own constraint after the loop has shadowed it.
+my Int $v = 1;
+for (1, 2) -> $k, $v { }
+dies-ok { $v = "boom" }, "the shadowed outer `my Int \$v` is still type-checked after the loop";
+lives-ok { $v = 5 }, "...and still accepts an Int";
+
+done-testing;

--- a/todo/tickets/for-loop-multi-param-types-unenforced.md
+++ b/todo/tickets/for-loop-multi-param-types-unenforced.md
@@ -1,0 +1,46 @@
+# A multi-parameter `for` loop does not enforce its parameter types
+
+```raku
+for ("a", 1, "b", "two") -> Str $k, Int $v { say "$k=$v" }
+# raku:  a=1
+#        Type check failed in binding to parameter '$v'; expected Int but got Str ("two")
+# mutsu: a=1
+#        b=two
+```
+
+Declared types on the parameters of a multi-parameter pointy block are accepted
+by the parser and then ignored at run time. The single-parameter form
+(`for @a -> Int $x`) is unaffected — only the multi-param path.
+
+## Where it is
+
+`ForLoopSpec` (`src/opcode.rs`) carries `multi_param_names: Vec<String>` and no
+per-parameter constraint, so the VM has nothing to check against. The compiler
+*does* have them: `params_def: &[crate::ast::ParamDef]` is in scope where the
+`ForLoop` opcode is emitted (`src/compiler/stmt.rs`, the `multi_param_names`
+field), each with its `type_constraint`.
+
+The bindings themselves are plain `Stmt::Assign`s built by
+`build_for_bind_stmts` (`src/compiler/mod.rs`), which drop the constraint
+entirely.
+
+## Shape of the fix
+
+Add a parallel `multi_param_type_constraints: Vec<Option<String>>` to
+`ForLoopSpec`, populate it from `params_def`, and have `exec_for_loop_body` call
+`bind_param_type_constraint(name, tc)` per parameter instead of the blanket clear
+introduced by `news/2026-08/for-multi-param-stale-type-constraint.md` (which
+clears the stale name-keyed constraint and restores it after the loop). That
+gives both the shadowing semantics and the enforcement in one place.
+
+Two things to get right:
+
+- The error must be a *binding* failure (`X::TypeCheck::Binding::Parameter`,
+  "Type check failed in binding to parameter '$v'"), not the assignment error the
+  `SetLocal` path would produce.
+- Coercion types (`Str(Cool) $v`) and `is rw` / sigilless (`\v`) parameters must
+  keep working; the clear-and-restore currently applies to every name in
+  `multi_param_names`.
+
+Keep `size_of::<OpCode>() <= 48` in mind — `ForLoopSpec` is already boxed, so a
+new `Vec` field is free there.

--- a/todo/tickets/for-multi-param-shadow-clobbers-outer-lexical.md
+++ b/todo/tickets/for-multi-param-shadow-clobbers-outer-lexical.md
@@ -1,0 +1,43 @@
+# A multi-parameter `for` loop clobbers the enclosing lexical it shadows
+
+```raku
+my $v = "outer";
+for (1, 2) -> $k, $v { say "in loop $k $v" }   # in loop 1 2
+say "after: $v";                               # raku: outer
+                                               # mutsu: (uninitialized Any)
+```
+
+The loop parameter is a fresh binding that shadows the enclosing `my $v` only
+for the duration of the block; after the loop the outer value must be back.
+
+## Where it is
+
+`exec_for_loop_body` (`src/vm/vm_for_loop_body.rs`) already saves and restores
+each `spec.multi_param_names` entry — but only its **env** entry and its readonly
+flags. A compiler-scoped `my $v` lives in a *local slot* and is not necessarily
+mirrored into env, so `self.env().get("v")` returns `None` at save time, the
+restore takes the `env.remove(name)` branch, and the slot keeps the loop's last
+iteration value.
+
+The obvious patch — also save `self.locals[find_local_slot(code, name)]` and put
+it back — does **not** work as written: `find_local_slot` uses
+`code.locals.iter().position(...)` (first match) while shadowing needs
+`rposition`, and the loop parameter and the shadowed outer lexical may or may not
+share a slot depending on how `build_for_bind_stmts` compiled the binding
+(`Stmt::Assign` vs `Stmt::VarDecl`). It was tried and reverted while fixing
+`news/2026-08/for-multi-param-stale-type-constraint.md`; the restore ran (slot 0,
+correct saved value) yet the post-loop read still saw the loop value, so the
+post-loop `GetLocal` resolves a *different* slot. Working out which slot each
+side owns is the actual work here.
+
+## Why it matters
+
+Same family as the shared-lane container escape
+(`news/2026-08/threaded-array-mutation-escapes-to-the-caller.md`): a fresh
+binding silently becoming the enclosing one. It is easy to hit in ordinary code
+(`for %h.kv -> $k, $v` inside a routine that already has a `$v`), and it is
+silent — no error, just a wrong value later.
+
+Pin when fixed: extend `t/for-multi-param-type-constraint.t` with the value-
+restore cases (typed and untyped, `$`/`@`/`%` sigils, nested loops reusing a
+name).


### PR DESCRIPTION
## Problem

```raku
sub declares-typed-v() { my Int $v = 42; $v }
say declares-typed-v();

for ("content-length", 10, "transfer-encoding", "identity") -> $k, $v {
    say "$k=$v";
}
# content-length=10
# Type check failed in assignment to $v; expected Int but got Str ("identity")
```

Any `my Int $v` / `state Int $v` / `our Int $v` **anywhere in the program** — including in an unrelated module the script merely loaded — constrained every subsequent `-> $k, $v` loop parameter.

`for @a -> $x` binds natively in the VM and is unaffected. The multi-parameter form binds with plain `Stmt::Assign`s emitted into the body prefix by `build_for_bind_stmts`, and `SetLocal` type-checks an assignment against `var_type_constraint(name)` — a **name-keyed, not block-scoped** map.

## Fix

A parameter is a fresh binding that shadows whatever the name meant outside, so `exec_for_loop_body` saves each `multi_param_names` entry's constraint, clears it for the duration of the loop, and restores it afterwards. That is the contract `bind_param_type_constraint` already gives an untyped routine parameter, minus its permanent loss of the enclosing lexical's type — an outer `my Int $v` is still enforced once the loop has exited (pinned).

## How it was found

The vendored Cro::HTTP suite's `t/http-rawbodyparserselector.rakutest` could not run a single test: it died in `for %headers.kv -> $k, $v { $resp.append-header($k, $v) }` with `expected Int but got Str ("chunked")`. The `Int` came from `OpenSSL::Stack`'s `state Int $v = OpenSSL::Version::version_num()`, three modules away. **That file now passes 10/10** (was 0). The rest of the suite tally is unchanged.

## Testing

- New pin `t/for-multi-param-type-constraint.t` (6 tests) — green under `raku` too.
- `make test`: PASS (2805 files, 26635 tests).

## Deliberately left open

Two adjacent findings from the same investigation are filed as tickets rather than fixed here, because each is its own piece of work:

- `todo/tickets/for-multi-param-shadow-clobbers-outer-lexical.md` — the loop parameter also clobbers the shadowed lexical's **value** (`my $v = "outer"; for (1,2) -> $k, $v { }; say $v` prints the uninitialized element). The env-side save/restore already exists; the local-slot half was attempted and reverted here — `find_local_slot` uses `position` where shadowing needs `rposition`, and the post-loop `GetLocal` resolves a different slot than the one restored. Working out the slot ownership is the real task.
- `todo/tickets/for-loop-multi-param-types-unenforced.md` — declared parameter types on a multi-param loop (`-> Str $k, Int $v`) are parsed and then ignored; `ForLoopSpec` carries no per-parameter constraint. Fixing that subsumes this PR's blanket clear with a per-parameter `bind_param_type_constraint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)