### PR TITLE
refactor(compiler): lower sub declarations into typed plans

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -139,4 +139,8 @@ each instruction.
 
 ## Implementation status
 
-Not started. This ADR is the bottom layer of the implementation stack.
+Stage 1 is in progress. `RegisterSub` now indexes a typed `CompiledSubDeclPlan` pool rather than
+`CompiledCode::stmt_pool`; all normal, hoisted, nested-`our`, and top-level-method lowering sites use
+the plan, and the VM no longer pattern-matches `Stmt::SubDecl`. The plan still carries
+`legacy_body` for the existing routine-registry adapter. Replacing that field with the compiled
+routine reference is the next declaration slice.

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -340,7 +340,7 @@ impl Compiler {
                     t.starts_with("__") || t == "default" || t.starts_with("DEPRECATED")
                 });
             }
-            let idx = self.code.add_stmt(hoisted);
+            let idx = self.code.add_sub_decl_plan(&hoisted);
             self.code.emit(OpCode::RegisterSub(idx));
         }
     }
@@ -424,7 +424,7 @@ impl Compiler {
                         t.starts_with("__") || t == "default" || t.starts_with("DEPRECATED")
                     });
                 }
-                let idx = self.code.add_stmt(hoisted);
+                let idx = self.code.add_sub_decl_plan(&hoisted);
                 self.code.emit(OpCode::RegisterSub(idx));
             }
         }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -29,6 +29,32 @@ pub(crate) fn shadow_slots_active() -> bool {
     static ACTIVE: OnceLock<bool> = OnceLock::new();
     *ACTIVE.get_or_init(|| std::env::var_os("MUTSU_NO_SHADOW_SLOTS").is_none())
 }
+
+#[cfg(test)]
+mod declaration_plan_tests {
+    use super::Compiler;
+
+    #[test]
+    fn sub_declarations_leave_the_generic_statement_pool() {
+        let (stmts, _) = crate::parse_dispatch::parse_source("sub f($x) { $x + 1 }; f(2)")
+            .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        assert!(!code.sub_decl_plans.is_empty());
+        assert!(
+            code.stmt_pool
+                .iter()
+                .all(|stmt| !matches!(stmt, crate::ast::Stmt::SubDecl { .. })),
+            "compiled sub declarations must not remain executable generic statements"
+        );
+        assert!(code.ops.iter().all(|op| match op {
+            crate::opcode::OpCode::RegisterSub(idx) => {
+                (*idx as usize) < code.sub_decl_plans.len()
+            }
+            _ => true,
+        }));
+    }
+}
 mod const_fold;
 mod expr;
 mod expr_binary;

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3038,7 +3038,7 @@ impl Compiler {
                     self.code.emit(OpCode::Die);
                     return;
                 }
-                let idx = self.code.add_stmt(stmt.clone());
+                let idx = self.code.add_sub_decl_plan(stmt);
                 self.code.emit(OpCode::RegisterSub(idx));
                 if name_expr.is_some() {
                     // Runtime-resolved sub names cannot be keyed reliably in compiled_fns.
@@ -3140,7 +3140,7 @@ impl Compiler {
                     supersede: false,
                     custom_traits: vec![("__mutsu_method_decl".to_string(), None)],
                 };
-                let idx = self.code.add_stmt(lowered);
+                let idx = self.code.add_sub_decl_plan(&lowered);
                 self.code.emit(OpCode::RegisterSub(idx));
                 if name_expr.is_none() {
                     let mut method_params: Vec<String> = vec![

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::ast::{ParamDef, Stmt};
+use crate::ast::{Expr, ParamDef, Stmt};
 use crate::symbol::Symbol;
 use crate::value::{Value, ValueView};
 
@@ -1844,6 +1844,30 @@ pub(crate) struct EnvConsumerSlots {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct CompiledSubDeclPlan {
+    pub(crate) name: Symbol,
+    pub(crate) name_expr: Option<Expr>,
+    pub(crate) params: Vec<String>,
+    pub(crate) param_defs: Vec<ParamDef>,
+    pub(crate) return_type: Option<String>,
+    pub(crate) associativity: Option<String>,
+    pub(crate) signature_alternates: Vec<(Vec<String>, Vec<ParamDef>)>,
+    /// Compatibility payload for the routine registry. Method bodies already execute from
+    /// `CompiledFunction`; this AST is removed when the registry adapter is retired in ADR-0019
+    /// stage 1.
+    pub(crate) legacy_body: Vec<Stmt>,
+    pub(crate) multi: bool,
+    pub(crate) is_rw: bool,
+    pub(crate) is_raw: bool,
+    pub(crate) is_export: bool,
+    pub(crate) export_tags: Vec<String>,
+    pub(crate) is_test_assertion: bool,
+    pub(crate) supersede: bool,
+    pub(crate) custom_traits: Vec<(String, Option<Expr>)>,
+    pub(crate) fingerprint: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct CompiledCode {
     pub(crate) ops: Vec<OpCode>,
     /// Static ip -> source line table, parallel to `ops` (0 = unknown). Replaces
@@ -1863,6 +1887,9 @@ pub(crate) struct CompiledCode {
     /// chunk stops growing, so it costs no memory in the executed code.
     const_index: rustc_hash::FxHashMap<ConstKey, u32>,
     pub(crate) stmt_pool: Vec<Stmt>,
+    /// Typed declaration plans consumed by `RegisterSub`. Unlike `stmt_pool`, every entry is
+    /// known to be a sub declaration, so the VM does not inspect or execute a source statement.
+    pub(crate) sub_decl_plans: Vec<CompiledSubDeclPlan>,
     pub(crate) locals: Vec<String>,
     /// Pre-interned Symbol for each local name. Avoids Symbol::intern()
     /// on every env sync in hot paths.
@@ -2249,14 +2276,6 @@ pub(crate) struct CompiledCode {
     /// declarations genuinely ARE that frame's lexicals and stay shared. Set
     /// during `compute_needs_env_sync`.
     pub(crate) is_supply_block_body: bool,
-    /// Compile-time identity fingerprint for each `Stmt::SubDecl` in `stmt_pool`,
-    /// keyed by its pool index. A `RegisterSub(idx)` opcode re-executes whenever
-    /// its enclosing frame runs (e.g. a `my sub` inside a hot routine), but the
-    /// declaration it installs is constant. The fingerprint lets the registrar
-    /// recognize an idempotent re-registration in O(1) — without re-deriving the
-    /// `FunctionDef` from the AST — and skip perturbing the resolution caches.
-    /// Computed once here at compile time (see `add_stmt`).
-    pub(crate) sub_fingerprints: std::collections::HashMap<u32, u64>,
     /// Ordered list of this closure's read-only plain-lexical free variables that
     /// have been promoted to index-based upvalues. Index `i` in this list is the
     /// operand of the `GetUpvalue(i)` ops that `compute_upvalues` rewrites in
@@ -2475,6 +2494,7 @@ impl CompiledCode {
             constants: Vec::new(),
             const_index: rustc_hash::FxHashMap::default(),
             stmt_pool: Vec::new(),
+            sub_decl_plans: Vec::new(),
             locals: Vec::new(),
             locals_sym: Vec::new(),
             locals_alias_sym: Vec::new(),
@@ -2529,7 +2549,6 @@ impl CompiledCode {
             outer_code_var_names: std::collections::HashSet::new(),
             needs_cell_free_vars: Vec::new(),
             has_calls: false,
-            sub_fingerprints: std::collections::HashMap::new(),
             upvalue_syms: Vec::new(),
             env_only_decls: Vec::new(),
             const_syms: std::sync::OnceLock::new(),
@@ -4651,23 +4670,35 @@ impl CompiledCode {
 
     pub(crate) fn add_stmt(&mut self, stmt: Stmt) -> u32 {
         let idx = self.stmt_pool.len() as u32;
-        // Record a declaration fingerprint for SubDecls so a re-executed
-        // `RegisterSub(idx)` (e.g. a `my sub` inside a hot routine) can be
-        // recognized as an idempotent no-op without re-deriving the FunctionDef.
-        if let Stmt::SubDecl {
+        self.stmt_pool.push(stmt);
+        idx
+    }
+
+    pub(crate) fn add_sub_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+        let Stmt::SubDecl {
+            name,
+            name_expr,
             params,
             param_defs,
-            body,
             return_type,
+            associativity,
+            signature_alternates,
+            body,
             multi,
             is_rw,
             is_raw,
-            name_expr,
+            is_export,
+            export_tags,
+            is_test_assertion,
+            supersede,
+            custom_traits,
             ..
-        } = &stmt
-            && name_expr.is_none()
-        {
-            let fp = crate::ast::sub_registration_fingerprint(
+        } = stmt
+        else {
+            panic!("add_sub_decl_plan expects SubDecl");
+        };
+        let fingerprint = name_expr.is_none().then(|| {
+            crate::ast::sub_registration_fingerprint(
                 params,
                 param_defs,
                 body,
@@ -4675,10 +4706,28 @@ impl CompiledCode {
                 *multi,
                 *is_rw,
                 *is_raw,
-            );
-            self.sub_fingerprints.insert(idx, fp);
-        }
-        self.stmt_pool.push(stmt);
+            )
+        });
+        let idx = self.sub_decl_plans.len() as u32;
+        self.sub_decl_plans.push(CompiledSubDeclPlan {
+            name: *name,
+            name_expr: name_expr.clone(),
+            params: params.clone(),
+            param_defs: param_defs.clone(),
+            return_type: return_type.clone(),
+            associativity: associativity.clone(),
+            signature_alternates: signature_alternates.clone(),
+            legacy_body: body.clone(),
+            multi: *multi,
+            is_rw: *is_rw,
+            is_raw: *is_raw,
+            is_export: *is_export,
+            export_tags: export_tags.clone(),
+            is_test_assertion: *is_test_assertion,
+            supersede: *supersede,
+            custom_traits: custom_traits.clone(),
+            fingerprint,
+        });
         idx
     }
 }

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -396,14 +396,14 @@ impl Interpreter {
             && (ret_val.is_nil()
                 || matches!(ret_val.view(), ValueView::Package(n) if n.resolve() == "Any"))
             && let Some(crate::opcode::OpCode::RegisterSub(idx)) = cf.code.ops.last()
-            && let crate::ast::Stmt::SubDecl {
+            && let Some(crate::opcode::CompiledSubDeclPlan {
                 name: sub_name,
                 params,
                 param_defs,
-                body,
+                legacy_body: body,
                 is_rw,
                 ..
-            } = &cf.code.stmt_pool[*idx as usize]
+            }) = cf.code.sub_decl_plans.get(*idx as usize)
         {
             ret_val = Value::make_sub(
                 Symbol::intern(&self.current_package()),

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -183,8 +183,7 @@ impl Interpreter {
         code: &CompiledCode,
         idx: u32,
     ) -> Result<(), RuntimeError> {
-        let stmt = &code.stmt_pool[idx as usize];
-        if let Stmt::SubDecl {
+        if let Some(crate::opcode::CompiledSubDeclPlan {
             name,
             name_expr,
             params,
@@ -192,7 +191,7 @@ impl Interpreter {
             return_type,
             associativity,
             signature_alternates,
-            body,
+            legacy_body: body,
             multi,
             is_rw,
             is_raw,
@@ -201,8 +200,8 @@ impl Interpreter {
             is_test_assertion,
             supersede,
             custom_traits,
-            ..
-        } = stmt
+            fingerprint: site_fp,
+        }) = code.sub_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(expr) = name_expr {
                 self.vm_eval_block_value(&[Stmt::Expr(expr.clone())])?
@@ -214,7 +213,6 @@ impl Interpreter {
             // Compile-time declaration fingerprint for this site (absent for a
             // runtime-resolved `name_expr` sub), enabling the idempotent
             // re-registration fast path inside `register_sub_decl_fp`.
-            let site_fp = code.sub_fingerprints.get(&idx).copied();
             let outcome = self.loan_env_for(|i| {
                 i.register_sub_decl_fp(
                     &resolved_name,
@@ -229,7 +227,7 @@ impl Interpreter {
                     *is_test_assertion,
                     *supersede,
                     custom_traits,
-                    site_fp,
+                    *site_fp,
                 )
             })?;
             // An idempotent re-registration of an already-installed identical sub


### PR DESCRIPTION
Problem: RegisterSub still indexed the generic AST statement pool. Approach: lower every sub-registration site into a typed CompiledSubDeclPlan pool and make the VM consume that plan directly. Tests: cargo test declaration-plan invariant; targeted TAP 21/21; cargo clippy; make test unit/integration stages green before the local TAP runner was externally terminated mid-suite.