### PR TITLE
fix(modules): scope a `do { use M; ... }` import, and roll back imported protos

### DIFF
--- a/news/2026-08/do-block-import-scope-and-imported-protos.md
+++ b/news/2026-08/do-block-import-scope-and-imported-protos.md
@@ -1,0 +1,74 @@
+# `do { use M; ... }` scopes its import, and an imported `proto` is rolled back with it
+
+An import is lexical to the block that asked for it. mutsu had a mechanism for
+that — `push_import_scope` / `pop_import_scope` around a bare block — but two
+halves were missing, and `roast/S32-list/skip.t` needs both. That file imports
+`Test` selectively, through exactly the shape the two bugs met in:
+
+```raku
+# By default, Test exports a "skip" sub, which interferes with the "skip"
+# functionality we want to test here.  Hence the selective import here.
+BEGIN my (&plan, &subtest, &is, &is-deeply, &throws-like) = do {
+    use Test;
+    (&plan, &subtest, &is, &is-deeply, &throws-like)
+}
+```
+
+## 1. A `do { }` block never opened an import scope
+
+`compile_stmt`'s `Stmt::Block` arm emitted `PushImportScope`/`PopImportScope`
+when the block contained a `use`, but `compile_do_block_expr` did not — so every
+import inside a `do { }` leaked into the enclosing scope. With mutsu's native
+`Test` provider in charge the leak was invisible on this file, because the native
+`skip` handler disambiguates the list-skip shape (`skip_call_is_list_skip`); with
+the real module (`MUTSU_REAL_TEST=1`) the file aborted six assertions in, at
+
+```
+skip() was passed a non-integer number of tests.  Did you get the arguments
+backwards or use a non-integer number?
+  in sub skip at modules/Rakudo-Core/lib/Test.rakumod line 396
+```
+
+## 2. `pop_import_scope` did not roll back the proto tables
+
+Closing the first half exposed the second. `pop_import_scope` restored
+`functions` and `classes`, but an import also writes the two *proto* tables:
+`import_module` inserts the importing package's alias into `proto_functions`
+**and** into the `proto_subs` name set, because `has_proto` reads the latter.
+Neither was snapshotted, so `Test`'s `proto sub skip(|) is export` stayed visible
+as `GLOBAL::skip` after the block exited.
+
+That is not a "wrong routine gets called" bug — `skip` did dispatch to the core
+list routine. It is an *argument-shape* bug. `normalize_call_args_for_target`
+keeps call arguments in their raw, `VarRef`-wrapped form when a user routine of
+that name is declared (so `is rw` can bind through) and unwraps them otherwise.
+The stale proto kept the first branch alive, so `builtin_skip` received `@array`
+as a `VarRef` instead of an `Array`, fell through its flattening match to the
+catch-all arm, and skipped 5 elements of a one-element list:
+
+```
+skip(0, @array)   # (a b c d e f g h,)  — one element, the array itself
+skip(5, @array)   # ()
+```
+
+Both proto tables now use the same keep-rule the function table already used:
+entries added since the push are dropped, except a module's own
+package-qualified definitions (`Test::skip`), which persist so a later
+block-scoped re-`use` in a sibling block still has something to alias. The
+`ImportScopeSnapshot` 6-tuple became a named struct in the process — every symbol
+table an import writes into has to be listed there, and a tuple made that
+list easy to leave incomplete.
+
+`roast/S32-list/skip.t` now passes under both providers (55/55). Pin:
+`t/use-in-do-block-is-scoped.t` with fixture `t/lib/ScopedProtoExport.rakumod`,
+which exports a `proto sub head(|)` that deliberately collides with the core
+`head` listop — the collision is what makes the leak observable without leaning
+on `Test` itself.
+
+## What this did *not* fix
+
+`{ use Test; } say &ok.defined` still answers `True`. That one is not the import
+scope at all: mutsu's native TAP provider is gated on `loaded_modules`, which is
+deliberately never rolled back, so the native `ok` stays reachable whether or not
+the module's own routines are in scope. It disappears with the native provider
+itself (step 3 of `todo/tickets/vendor-real-test-module.md`).

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -78,6 +78,16 @@ impl Compiler {
             self.code.patch_body_end(do_idx);
             return;
         }
+        // An import is lexical to the block that asked for it, and a `do {}`
+        // block is a block: `my (&plan) = do { use Test; (&plan) }` must take
+        // the routines it names as values and leave everything else the module
+        // exports out of the enclosing scope (roast/S32-list/skip.t imports
+        // selectively precisely so the CORE `skip` stays visible). The
+        // statement-form bare block already does this in `Stmt::Block`.
+        let import_scoped = Self::has_use_stmt(body);
+        if import_scoped {
+            self.code.emit(OpCode::PushImportScope);
+        }
         let idx = self.code.emit(OpCode::DoBlockExpr {
             body_end: 0,
             label: label.clone(),
@@ -86,6 +96,9 @@ impl Compiler {
         });
         self.compile_block_inline(body);
         self.code.patch_body_end(idx);
+        if import_scoped {
+            self.code.emit(OpCode::PopImportScope);
+        }
     }
 
     pub(super) fn compile_do_block_expr_scoped(&mut self, body: &[Stmt], label: &Option<String>) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2237,14 +2237,22 @@ pub(crate) type RoutineRegistrySnapshot = (
     rustc_hash::FxHashSet<Symbol>,
 );
 
-pub(crate) type ImportScopeSnapshot = (
-    HashSet<Symbol>,
-    HashSet<String>,
-    NewlineMode,
-    bool,
-    bool,
-    bool,
-);
+/// What a lexical import scope (`{ use Foo; ... }`) restores when it pops: the
+/// registry key sets that existed before the `use`, plus the pragma flags `use`
+/// can flip. Every symbol table an import writes into has to be listed here —
+/// `proto_subs`/`proto_functions` were missing, so an imported `proto sub skip`
+/// stayed visible to `has_proto` after the block and kept `skip(5, @a)` on the
+/// user-routine argument path (VarRef-wrapped) instead of the list builtin's.
+pub(crate) struct ImportScopeSnapshot {
+    pub(crate) functions: HashSet<Symbol>,
+    pub(crate) classes: HashSet<String>,
+    pub(crate) proto_subs: HashSet<String>,
+    pub(crate) proto_functions: HashSet<Symbol>,
+    pub(crate) newline_mode: NewlineMode,
+    pub(crate) strict_mode: bool,
+    pub(crate) fatal_mode: bool,
+    pub(crate) monkey_typing: bool,
+}
 
 impl Default for Interpreter {
     fn default() -> Self {

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -19,32 +19,38 @@ impl Interpreter {
             .unwrap_or(false)
     }
 
-    /// Save current function/class keys for lexical import scoping.
+    /// Save current function/class/proto keys for lexical import scoping.
     pub(crate) fn push_import_scope(&mut self) {
-        let func_keys: HashSet<Symbol> = self.registry().functions.keys().copied().collect();
-        let class_keys: HashSet<String> = self.registry().classes.keys().cloned().collect();
-        self.import_scope_stack.push((
-            func_keys,
-            class_keys,
-            self.newline_mode,
-            self.strict_mode,
-            self.fatal_mode,
-            self.monkey_typing,
-        ));
+        let snapshot = {
+            let reg = self.registry();
+            crate::runtime::ImportScopeSnapshot {
+                functions: reg.functions.keys().copied().collect(),
+                classes: reg.classes.keys().cloned().collect(),
+                proto_subs: reg.proto_subs.iter().cloned().collect(),
+                proto_functions: reg.proto_functions.keys().copied().collect(),
+                newline_mode: self.newline_mode,
+                strict_mode: self.strict_mode,
+                fatal_mode: self.fatal_mode,
+                monkey_typing: self.monkey_typing,
+            }
+        };
+        self.import_scope_stack.push(snapshot);
     }
 
-    /// Restore function/class registries to the last saved snapshot,
+    /// Restore function/class/proto registries to the last saved snapshot,
     /// removing any entries added since the push.
     pub(crate) fn pop_import_scope(&mut self) {
-        if let Some((
-            func_snapshot,
-            class_snapshot,
-            newline_mode,
-            strict_mode,
-            fatal_mode,
-            monkey_typing,
-        )) = self.import_scope_stack.pop()
-        {
+        if let Some(snapshot) = self.import_scope_stack.pop() {
+            let crate::runtime::ImportScopeSnapshot {
+                functions: func_snapshot,
+                classes: class_snapshot,
+                proto_subs: proto_sub_snapshot,
+                proto_functions: proto_fn_snapshot,
+                newline_mode,
+                strict_mode,
+                fatal_mode,
+                monkey_typing,
+            } = snapshot;
             // Remove functions added since the push, EXCEPT a module's own
             // fully-qualified source definitions (`Fancy::Utilities::lolgreet`,
             // `Fancy::Utilities::EXPORT::ALL::lolgreet`). Those persist as long
@@ -71,6 +77,26 @@ impl Interpreter {
             // still removed with the import scope.
             self.registry_mut().classes.retain(|key, _| {
                 class_snapshot.contains(key) || (key.contains("::") && !key.starts_with("GLOBAL::"))
+            });
+            // `proto sub name(|) is export` imports under the importing package
+            // (`GLOBAL::skip`) into BOTH proto tables, and `has_proto` reads the
+            // name set. Left behind, an imported proto kept a bare call on the
+            // user-routine dispatch path after the block exited — which is what
+            // made `roast/S32-list/skip.t`'s selective `do { use Test; ... }`
+            // import still hand `skip(5, @a)` a VarRef-wrapped array instead of
+            // the flattened list the core routine expects. Same keep-rule as
+            // functions: the module's own `Test::skip` stays for a later
+            // re-import, only the `GLOBAL::` alias goes.
+            self.registry_mut().proto_subs.retain(|key| {
+                proto_sub_snapshot.contains(key)
+                    || (key.contains("::") && !key.starts_with("GLOBAL::"))
+            });
+            self.registry_mut().proto_functions.retain(|key, _| {
+                if proto_fn_snapshot.contains(key) {
+                    return true;
+                }
+                let ks = key.resolve();
+                ks.contains("::") && !ks.starts_with("GLOBAL::")
             });
             self.newline_mode = newline_mode;
             self.strict_mode = strict_mode;

--- a/t/lib/ScopedProtoExport.rakumod
+++ b/t/lib/ScopedProtoExport.rakumod
@@ -1,0 +1,8 @@
+unit module ScopedProtoExport;
+
+# A `proto`/`multi` pair that deliberately collides with the core `head`
+# listop, so an importer can tell whether the import is still in scope.
+proto sub head(|) is export {*}
+multi sub head($what) { "module-head:$what" }
+
+sub scoped-only() is export { "in scope" }

--- a/t/use-in-do-block-is-scoped.t
+++ b/t/use-in-do-block-is-scoped.t
@@ -1,0 +1,36 @@
+# An import is lexical to the block that asked for it, and a `do { }` block is a
+# block: `my (&f) = do { use M; (&f) }` takes the routines it names as values
+# and leaves everything else M exports out of the enclosing scope. Two halves
+# were missing:
+#   * `do { }` never emitted PushImportScope/PopImportScope at all (only the
+#     statement-form bare block did), so every import leaked.
+#   * `pop_import_scope` rolled back `functions`/`classes` but not the two proto
+#     tables, so an imported `proto sub head(|)` stayed visible to `has_proto`
+#     and kept a later bare `head(3, @a)` on the user-routine argument path
+#     (VarRef-wrapped array) instead of the core listop's flattened one.
+# roast/S32-list/skip.t is the file this was found on: it imports `Test`
+# selectively through exactly this shape so the core `skip` stays reachable.
+use lib $?FILE.IO.parent.add('lib').Str;
+use Test;
+
+plan 7;
+
+my @array = <a b c d e f g h>;
+
+my (&taken) = do {
+    use ScopedProtoExport;
+    is scoped-only(), "in scope", "an imported sub is visible inside the do block";
+    is head("x"), "module-head:x", "an imported proto beats the core listop inside the block";
+    (&scoped-only)
+};
+
+is taken(), "in scope", "a routine taken out of the block as a value still works";
+is head(3, @array).join(","), "a,b,c", "the core listop is back after the do block";
+dies-ok { EVAL 'scoped-only()' }, "the imported sub is out of scope after the do block";
+
+# The statement-form bare block scopes the proto too.
+{
+    use ScopedProtoExport;
+    is head("y"), "module-head:y", "an imported proto is visible inside a bare block";
+}
+is head(3, @array).join(","), "a,b,c", "the core listop is back after a bare block";

--- a/todo/tickets/use-inside-a-block-leaks-to-the-enclosing-scope.md
+++ b/todo/tickets/use-inside-a-block-leaks-to-the-enclosing-scope.md
@@ -1,5 +1,20 @@
 # `use` inside a block leaks its imports to the enclosing scope
 
+**Partly fixed (2026-08-03)** —
+`news/2026-08/do-block-import-scope-and-imported-protos.md`. A `do { }` block now
+opens an import scope like a bare block does, and `pop_import_scope` rolls back
+the two proto tables (`proto_subs` / `proto_functions`) as well as
+`functions`/`classes`. That closed the `roast/S32-list/skip.t` case described
+below (55/55 under both providers); pin `t/use-in-do-block-is-scoped.t`.
+
+What is left is the `env` half described under "Why it is not a one-liner", plus
+the specific `Test` symptom in the minimal repro at the bottom: `&ok` stays
+reachable after `{ use Test; }` because mutsu's **native TAP provider** is gated
+on `loaded_modules`, which is deliberately never rolled back. That is not the
+import scope — it goes away with the native provider itself (step 3 of
+`todo/tickets/vendor-real-test-module.md`), so do not "fix" it by scoping
+`loaded_modules`.
+
 In raku an import is lexical to the block that asked for it:
 
 ```raku


### PR DESCRIPTION
An import is lexical to the block that asked for it. mutsu had a mechanism for that (`push_import_scope`/`pop_import_scope` around a bare block), but two halves were missing — and `roast/S32-list/skip.t` needs both. That file imports `Test` selectively, through exactly the shape the two bugs met in:

```raku
# By default, Test exports a "skip" sub, which interferes with the "skip"
# functionality we want to test here.  Hence the selective import here.
BEGIN my (&plan, &subtest, &is, &is-deeply, &throws-like) = do {
    use Test;
    (&plan, &subtest, &is, &is-deeply, &throws-like)
}
```

### 1. A `do { }` block never opened an import scope

`compile_stmt`'s `Stmt::Block` arm emitted `PushImportScope`/`PopImportScope` when the block contained a `use`; `compile_do_block_expr` did not. Under mutsu's native `Test` provider the leak was invisible on this file (the native `skip` handler disambiguates the list-skip shape); under `MUTSU_REAL_TEST=1` the file aborted six assertions in with `skip() was passed a non-integer number of tests`.

### 2. `pop_import_scope` did not roll back the proto tables

Closing the first half exposed the second. `import_module` writes the importing package's alias into `proto_functions` **and** into the `proto_subs` name set (`has_proto` reads the latter). Neither was snapshotted, so `Test`'s `proto sub skip(|) is export` stayed visible as `GLOBAL::skip` after the block.

That is not a wrong-routine bug — it is an *argument-shape* one. `normalize_call_args_for_target` keeps call arguments in their raw `VarRef`-wrapped form when a routine of that name is declared (so `is rw` can bind through). The stale proto kept that branch alive, so `builtin_skip` received `@array` as a `VarRef`, fell through its flattening match to the catch-all arm, and skipped 5 elements of a one-element list:

```
skip(0, @array)   # (a b c d e f g h,)  — one element, the array itself
skip(5, @array)   # ()
```

Both proto tables now use the same keep-rule the function table already used: entries added since the push are dropped, except a module's own package-qualified definitions (`Test::skip`), which persist so a sibling block's later `use` still has something to alias. `ImportScopeSnapshot` became a named struct in the process — every symbol table an import writes into has to be listed there, and a 6-tuple made that list easy to leave incomplete.

### Result

`roast/S32-list/skip.t` passes 55/55 under **both** providers. Local `make test` (2806 files) and `make roast` (1435 files) are green.

Pin: `t/use-in-do-block-is-scoped.t` with fixture `t/lib/ScopedProtoExport.rakumod`, which exports a `proto sub head(|)` that deliberately collides with the core `head` listop — the collision is what makes the leak observable without leaning on `Test` itself. Verified it fails 3/7 without the fix.

### Not fixed here

`{ use Test; } say &ok.defined` still answers `True`. That is not the import scope: the native TAP provider is gated on `loaded_modules`, which is deliberately never rolled back. It disappears with the native provider itself (step 3 of `todo/tickets/vendor-real-test-module.md`). Noted in the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)