### PR TITLE
fix(parser): raise X::Comp::Group where rakudo collects two complaints

### DIFF
--- a/news/2026-08/comp-group-for-two-complaints.md
+++ b/news/2026-08/comp-group-for-two-complaints.md
@@ -1,0 +1,72 @@
+# `X::Comp::Group`: what rakudo throws when one construct draws two complaints
+
+Classifying the roast residue under the real `Test` module by its *first* failing
+assertion (`todo/tickets/vendor-real-test-module.md`) left one cluster clearly
+on top: 7 files whose first loss is `right exception type (X::Comp::Group)`.
+This closes 5 of them.
+
+## The rule
+
+rakudo's compiler does not stop at the first complaint. It accumulates *worries*
+(warnings), *sorrows* (recoverable errors) and at most one *panic* (the fatal
+one), and what it finally throws depends on what it collected:
+
+| collected | thrown |
+| --- | --- |
+| a panic alone | that panic |
+| exactly one sorrow, no worries | that sorrow |
+| anything else | `X::Comp::Group` |
+
+So `throws-like 'say', X::Comp::Group` is not roast being odd — a bare `say`
+draws a *worry* ("Unsupported use of bare say…") and then a panic on the missing
+argument list, which is two things. And in the same file
+(`roast/S04-declarations/my-6e.t`), `my Int $a of Str` is a plain
+`X::Syntax::Variable::ConflictingTypes` while `my Int $a of Str is default("z")
+of Rat` is a group — because the second sorrows twice.
+
+mutsu raises one typed exception per parse failure, so there is no accumulator to
+consult. Instead, each site that reproduces a rakudo diagnosis *with a companion
+complaint* now says so, through a new `PError::comp_group` built on the existing
+`Value::make_comp_group`.
+
+## The four diagnoses
+
+| construct | what mutsu did | what it does now |
+| --- | --- | --- |
+| `say` / `print` / `put` with no argument | `X::Comp` carrying the advice | `X::Comp::Group`: the advice as a worry, `Argument to "say" seems to be malformed` as the panic |
+| `1__0` | `X::Syntax::Confused` with a 40-alternative "expected …" dump | `X::Comp::Group`: `Only isolated underscores are allowed inside numbers` as the sorrow, `Confused` as the panic |
+| `for 1.. { }`, `for 1... { }`, `for 1, {a=>1}` | `X::Syntax::Missing` | `X::Comp::Group`: `Expression needs parens to avoid gobbling block` |
+| `my Int $a of Str is default("z") of Rat` | `X::Syntax::Variable::ConflictingTypes` (the first conflict only) | `X::Comp::Group` of both conflicts |
+
+Three of the four are error-*quality* fixes as much as classification ones. The
+`1__0` message in particular was the parser's generic "Confused" listing every
+alternative it could have accepted — over 400 characters that told the reader
+nothing — where rakudo names the actual rule in eight words.
+
+Each change is deliberately narrow, because the neighbouring shapes are
+*differently* typed in rakudo and were already right:
+
+* `10_` stays `X::Syntax::Confused` and `_10` stays undeclared-symbol; only a run
+  of two or more underscores **between digits** is the group. `1_0` is still a
+  legal separator.
+* `for 1..2` stays `X::Syntax::Missing` — that block is genuinely absent, not
+  eaten. The gobbled-block test grew to cover `Expr::Hash` (an empty or
+  key-value-looking brace) and an infix's right operand (`1 .. {}`), which is
+  where the loop's block ends up when a range endpoint swallows it.
+* one redundant `of` still throws `X::Syntax::Variable::ConflictingTypes` on its
+  own. Getting the double form right meant making the `of` / `is`-trait parse a
+  loop that collects conflicts instead of throwing on the first one — rakudo's
+  accumulate-then-decide model in miniature, scoped to one declaration.
+
+## Result
+
+`roast/S16-io/bare-say.t`, `roast/S02-literals/underscores.t`,
+`roast/S04-statements/for.t`, `roast/S04-declarations/my-6e.t` and
+`roast/6.c/S04-declarations/my-6c.t` all pass under the real `Test` module.
+Pin: `t/comp-group-two-complaints.t`, which also asserts the shapes that must
+*not* become groups.
+
+The two files left in the cluster need an unterminated-regex diagnosis
+(`roast/S05-metasyntax/regex.t`) and paired-delimiter validation
+(`roast/S02-literals/quoting-unicode.t`); the first is written up in
+`todo/tickets/unterminated-regex-has-no-diagnosis.md`.

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -89,6 +89,50 @@ impl PError {
         }
     }
 
+    /// Build the fatal `X::Comp::Group` rakudo throws when one construct draws
+    /// *two* complaints: a specific diagnosis plus the fatal one it leads to.
+    ///
+    /// rakudo's compiler accumulates worries, sorrows and at most one panic, and
+    /// only collapses to a single exception when it collected exactly one thing
+    /// (a lone panic, or a lone sorrow with no worries). Anything else is an
+    /// `X::Comp::Group` — which is why `throws-like 'say', X::Comp::Group` is the
+    /// right expectation for a bare `say`: the "Unsupported use of bare say"
+    /// advice is a worry and the parse then panics on the missing argument.
+    ///
+    /// Use this only where rakudo genuinely collects two complaints. A site
+    /// reproducing a lone rakudo panic (or a lone sorrow) must keep throwing
+    /// that exception directly: `my Int $a of Str` is
+    /// `X::Syntax::Variable::ConflictingTypes`, and only the double-`of` form,
+    /// which sorrows twice, is a group.
+    pub fn comp_group(
+        complaint: crate::value::Value,
+        is_worry: bool,
+        panic_message: &str,
+        message: String,
+    ) -> Self {
+        let panic = crate::value::Value::make_exception(
+            "X::Comp::AdHoc",
+            &[
+                (
+                    "message",
+                    crate::value::Value::str(panic_message.to_string()),
+                ),
+                (
+                    "payload",
+                    crate::value::Value::str(panic_message.to_string()),
+                ),
+            ],
+        );
+        let (sorrows, worries) = if is_worry {
+            (Vec::new(), vec![complaint])
+        } else {
+            (vec![complaint], Vec::new())
+        };
+        let group =
+            crate::value::Value::make_comp_group(message.clone(), Some(panic), sorrows, worries);
+        Self::fatal_with_exception(message, Box::new(group))
+    }
+
     /// Build the fatal `X::Obsolete` parse error for a Perl 5 construct.
     ///
     /// `old` names the construct and `replacement` the Raku spelling; rakudo

--- a/src/parser/primary/number.rs
+++ b/src/parser/primary/number.rs
@@ -53,6 +53,61 @@ fn make_confused_error(reason: &str) -> PError {
     PError::fatal_with_exception(message, Box::new(exception))
 }
 
+/// `1__0`: a run of two or more underscores *between digits*. A single
+/// underscore between digits is a legal separator, so `scan_decimal_digits`
+/// simply stops before an invalid one and lets the statement parse fail with a
+/// generic "Confused" — which told the reader nothing. rakudo diagnoses this
+/// precisely ("Only isolated underscores are allowed inside numbers") as a
+/// *sorrow* and then panics on the leftover, so what it throws is an
+/// `X::Comp::Group` (roast/S02-literals/underscores.t).
+///
+/// Deliberately narrow: the run must be digit-delimited on both sides. A
+/// trailing `10_` or a leading `_10` is a different (and differently-typed)
+/// error in rakudo — `X::Syntax::Confused` and `X::Undeclared::Symbols` — and
+/// both are already right, so this must not claim them.
+fn check_multi_underscore(input: &str) -> Result<(), PError> {
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    let mut saw_digit = false;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c.is_ascii_digit() {
+            saw_digit = true;
+            i += 1;
+            continue;
+        }
+        if c != b'_' {
+            break;
+        }
+        let run_start = i;
+        while i < bytes.len() && bytes[i] == b'_' {
+            i += 1;
+        }
+        let run_len = i - run_start;
+        let followed_by_digit = bytes.get(i).is_some_and(u8::is_ascii_digit);
+        if run_len >= 2 && saw_digit && followed_by_digit {
+            const COMPLAINT: &str = "Only isolated underscores are allowed inside numbers";
+            let sorrow = Value::make_exception(
+                "X::Comp::AdHoc",
+                &[
+                    ("message", Value::str(COMPLAINT.to_string())),
+                    ("payload", Value::str(COMPLAINT.to_string())),
+                ],
+            );
+            return Err(PError::comp_group(
+                sorrow,
+                false,
+                "Confused",
+                COMPLAINT.to_string(),
+            ));
+        }
+        if !followed_by_digit {
+            break;
+        }
+    }
+    Ok(())
+}
+
 fn hex_alpha_value(c: char) -> Option<u32> {
     match c {
         'a'..='f' => Some(10 + (c as u32 - 'a' as u32)),
@@ -249,6 +304,7 @@ pub(super) fn parse_int_radix(clean: &str, radix: u32) -> Expr {
 
 /// Parse an integer literal (including underscore separators).
 pub(super) fn integer(input: &str) -> PResult<'_, Expr> {
+    check_multi_underscore(input)?;
     // Hex: 0x...
     if let Some(result) = parse_prefixed_radix(input, "0x", "0X", 16, |c| {
         decimal_digit_value(c).or_else(|| hex_alpha_value(c))
@@ -336,6 +392,7 @@ pub(super) fn integer(input: &str) -> PResult<'_, Expr> {
 /// Parse a decimal number literal.
 /// In Raku, decimal literals without exponent are Rat, with exponent are Num.
 pub(super) fn decimal(input: &str) -> PResult<'_, Expr> {
+    check_multi_underscore(input)?;
     let (rest, int_clean) = scan_decimal_digits(input).ok_or_else(|| PError::expected("digits"))?;
     let (rest, _) = parse_char(rest, '.')?;
     // The first character after the dot must be a digit, not an underscore.

--- a/src/parser/stmt/control/for_loops.rs
+++ b/src/parser/stmt/control/for_loops.rs
@@ -25,10 +25,18 @@ pub(crate) fn foreach_stmt(input: &str) -> PResult<'_, Stmt> {
 /// block gobbled by a comma list / list-op, e.g. the trailing `{ say 3 }` in
 /// `for 1, 2, 3, { say 3 }`. A brace block parses as `AnonSub`/`AnonSubParams`/
 /// `Block`; in a comma list it lands as the final element of an `ArrayLiteral`.
+///
+/// An *empty* or key-value-looking brace also parses as `Expr::Hash`, and an
+/// infix's right operand is another place the block gets eaten: `for 1.. { }`
+/// leaves `1 .. {}` with the loop's block as the range endpoint. rakudo answers
+/// all of these the same way — the "Expression needs parens to avoid gobbling
+/// block" sorrow — so they belong here, not in the plain `X::Syntax::Missing`
+/// branch (`for 1..2`, which really is just missing its block).
 fn expr_ends_with_block(expr: &Expr) -> bool {
     match expr {
-        Expr::AnonSub { .. } | Expr::AnonSubParams { .. } | Expr::Block(_) => true,
+        Expr::AnonSub { .. } | Expr::AnonSubParams { .. } | Expr::Block(_) | Expr::Hash(_) => true,
         Expr::ArrayLiteral(items) => items.last().is_some_and(expr_ends_with_block),
+        Expr::Binary { right, .. } => expr_ends_with_block(right),
         _ => false,
     }
 }

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -635,45 +635,48 @@ fn parse_variable_traits<'a>(
         rest = r2;
     }
 
-    // Postfix container typing: my @a of Int; my %h of Int;
-    if let Some(after_of) = keyword("of", rest) {
-        let (r, _) = ws1(after_of)?;
-        let (r, tc) = parse_type_constraint_expr(r).ok_or_else(|| PError::expected("type"))?;
-        let (r, _) = ws(r)?;
-        // A postfix `of Type` that follows an explicit prefix type
-        // (`my Int $a of Str`) declares the type twice, which is
-        // X::Syntax::Variable::ConflictingTypes.
-        if let Some(outer) = type_constraint.as_ref() {
-            let mut attrs = std::collections::HashMap::new();
-            attrs.insert(
-                "outer".to_string(),
-                crate::value::Value::package(crate::symbol::Symbol::intern(outer)),
-            );
-            attrs.insert(
-                "inner".to_string(),
-                crate::value::Value::package(crate::symbol::Symbol::intern(&tc)),
-            );
-            let msg = format!(
-                "{} not allowed here; variable list already declared with type {}",
-                tc, outer
-            );
-            attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
-            let ex = crate::value::Value::make_instance(
-                crate::symbol::Symbol::intern("X::Syntax::Variable::ConflictingTypes"),
-                attrs,
-            );
-            return Err(PError::fatal_with_exception(
-                format!("X::Syntax::Variable::ConflictingTypes: {}", msg),
-                Box::new(ex),
-            ));
+    // Postfix container typing (`my @a of Int`) and `is` traits, which may
+    // alternate: `my Int $a of Str is default("z") of Rat` declares the type
+    // three times over. Each redundant `of` is a *sorrow* in rakudo, and the
+    // parse keeps going — which is why the double-`of` form is an
+    // `X::Comp::Group` while the single one is a plain
+    // `X::Syntax::Variable::ConflictingTypes` (roast S04-declarations/my-6e.t).
+    // Collect them here and decide at the end rather than throwing on the first.
+    let mut type_conflicts: Vec<(crate::value::Value, String)> = Vec::new();
+    loop {
+        let mut progressed = false;
+        if let Some(after_of) = keyword("of", rest) {
+            let (r, _) = ws1(after_of)?;
+            let (r, tc) = parse_type_constraint_expr(r).ok_or_else(|| PError::expected("type"))?;
+            let (r, _) = ws(r)?;
+            if let Some(outer) = type_constraint.as_ref() {
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert(
+                    "outer".to_string(),
+                    crate::value::Value::package(crate::symbol::Symbol::intern(outer)),
+                );
+                attrs.insert(
+                    "inner".to_string(),
+                    crate::value::Value::package(crate::symbol::Symbol::intern(&tc)),
+                );
+                let msg = format!(
+                    "{} not allowed here; variable list already declared with type {}",
+                    tc, outer
+                );
+                attrs.insert("message".to_string(), crate::value::Value::str(msg.clone()));
+                type_conflicts.push((
+                    crate::value::Value::make_instance(
+                        crate::symbol::Symbol::intern("X::Syntax::Variable::ConflictingTypes"),
+                        attrs,
+                    ),
+                    msg,
+                ));
+            }
+            *type_constraint = Some(tc);
+            rest = r;
+            progressed = true;
         }
-        *type_constraint = Some(tc);
-        rest = r;
-    }
-    // Parse `is` traits that come after `of`
-    {
-        let mut r = rest;
-        while let Some(after_is) = keyword("is", r) {
+        while let Some(after_is) = keyword("is", rest) {
             let (r2, _) = ws1(after_is)?;
             let (r2, trait_name) = ident(r2)?;
             let is_builtin = is_supported_variable_trait(&trait_name);
@@ -688,15 +691,37 @@ fn parse_variable_traits<'a>(
                 if include_in_traits {
                     custom_traits.push((trait_name.clone(), Some(trait_arg)));
                 }
-                r = r3;
+                rest = r3;
             } else {
                 if include_in_traits {
                     custom_traits.push((trait_name.clone(), None));
                 }
-                r = r2;
+                rest = r2;
             }
+            progressed = true;
         }
-        rest = r;
+        if !progressed {
+            break;
+        }
+    }
+    if let Some((first, first_msg)) = type_conflicts.first() {
+        if type_conflicts.len() == 1 {
+            return Err(PError::fatal_with_exception(
+                format!("X::Syntax::Variable::ConflictingTypes: {}", first_msg),
+                Box::new(first.clone()),
+            ));
+        }
+        let rendered = type_conflicts
+            .iter()
+            .map(|(_, m)| m.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let sorrows = type_conflicts.iter().map(|(v, _)| v.clone()).collect();
+        let group = crate::value::Value::make_comp_group(rendered, None, sorrows, Vec::new());
+        return Err(PError::fatal_with_exception(
+            format!("X::Comp::Group: {}", first_msg),
+            Box::new(group),
+        ));
     }
     if is_hash {
         *type_constraint = match (type_constraint.take(), hash_key_constraint.take()) {

--- a/src/parser/stmt/simple/io_stmts.rs
+++ b/src/parser/stmt/simple/io_stmts.rs
@@ -4,13 +4,30 @@ use super::*;
 fn check_bare_io_func<'a>(name: &str, rest: &'a str) -> PResult<'a, ()> {
     let trimmed = rest.trim_start();
     if trimmed.is_empty() || trimmed.starts_with(';') || trimmed.starts_with('}') {
-        return Err(PError::fatal(format!(
-            "X::Comp: Unsupported use of bare \"{}\". \
-             In Raku please use: .{} if you meant to call it as a method on $_, \
+        // rakudo collects TWO complaints here: a *worry* explaining the bare
+        // form, and then a panic because the argument list is missing. Two
+        // collected complaints is exactly the condition for `X::Comp::Group`,
+        // which is what roast/S16-io/bare-say.t asks for — a lone `X::Comp`
+        // would be right only if rakudo had stopped at the worry.
+        let advice = format!(
+            "Unsupported use of bare \"{name}\". \
+             In Raku please use: .{name} if you meant to call it as a method on $_, \
              or use an explicit invocant or argument, \
-             or use &{} to refer to the function as a noun.",
-            name, name, name
-        )));
+             or use &{name} to refer to the function as a noun."
+        );
+        let worry = Value::make_exception(
+            "X::Comp::AdHoc",
+            &[
+                ("message", Value::str(advice.clone())),
+                ("payload", Value::str(advice.clone())),
+            ],
+        );
+        return Err(PError::comp_group(
+            worry,
+            true,
+            &format!("Argument to \"{name}\" seems to be malformed"),
+            advice,
+        ));
     }
     Ok((rest, ()))
 }

--- a/t/comp-group-two-complaints.t
+++ b/t/comp-group-two-complaints.t
@@ -1,0 +1,46 @@
+# rakudo's compiler accumulates worries, sorrows and at most one panic, and only
+# collapses to a single exception when it collected exactly one thing. Anything
+# else is an `X::Comp::Group`. mutsu raises one typed exception per parse
+# failure, so each site that reproduces a rakudo diagnosis with a companion
+# complaint has to say so — these are the four roast asks about
+# (S16-io/bare-say.t, S02-literals/underscores.t, S04-statements/for.t,
+# S04-declarations/my-6e.t).
+use Test;
+
+plan 15;
+
+# A bare `say`/`print`/`put`: a worry explaining the bare form, then a panic on
+# the missing argument list.
+for <say print put> -> $name {
+    throws-like $name, X::Comp::Group, "bare $name is a compiler error";
+}
+
+# Two or more underscores between digits. A lone `_` separator stays legal, and
+# the neighbouring shapes keep their own (different) exception classes.
+throws-like { EVAL '1__0' }, X::Comp::Group, 'multiple embedded underscores';
+is 1_0, 10, 'a single embedded underscore is still a separator';
+throws-like { EVAL '10_' }, X::Syntax::Confused, 'a trailing underscore is Confused, not a group';
+
+# A block eaten by the iterable expression. `for 1..2` really is just missing
+# its block and must stay X::Syntax::Missing.
+throws-like 'for 1.. { }', X::Comp::Group, 'range endpoint gobbled the block';
+throws-like 'for 1... { }', X::Comp::Group, 'sequence endpoint gobbled the block';
+throws-like 'for 1, {a=>1}', X::Comp::Group, 'trailing hash-looking block gobbled';
+throws-like 'for 1, 2, { say 3 }', X::Comp::Group, 'trailing block gobbled by the comma list';
+throws-like 'for 1..2', X::Syntax::Missing, 'a genuinely missing block is not a group';
+
+# One redundant `of` is a lone sorrow; two are a group.
+throws-like ｢my Int $a of Str｣, X::Syntax::Variable::ConflictingTypes,
+    'one conflicting type is thrown on its own';
+throws-like ｢my Int $a of Str is default("z") of Rat｣, X::Comp::Group,
+    'two conflicting types are grouped';
+
+# The group keeps its parts, so a caller can read them back.
+{
+    my $group = ((try EVAL 'say') // $!);
+    # rakudo line-wraps the rendered worry, so match on substance, not layout.
+    ok $group.worries».message.head.contains('Unsupported use of bare "say"'),
+        'the bare-say advice is the group worry';
+    is $group.panic.message, 'Argument to "say" seems to be malformed',
+        'the missing argument list is the group panic';
+}

--- a/todo/tickets/unterminated-regex-has-no-diagnosis.md
+++ b/todo/tickets/unterminated-regex-has-no-diagnosis.md
@@ -1,0 +1,53 @@
+# An unterminated regex literal has no diagnosis, so it lands on whatever parse happened to fail next
+
+rakudo answers *every* unterminated regex the same way — an `X::Comp::Group`
+whose sorrow is `Regex not terminated.` and whose panic names the delimiter it
+could not find:
+
+```
+'x' ~~ m/foo             X::Comp::Group  Regex not terminated. / Couldn't find terminator /
+'x' ~~ /foo              X::Comp::Group  Regex not terminated. / Unable to parse regex; couldn't find final '/'
+my $r = rx/abc           X::Comp::Group  Regex not terminated. / Couldn't find terminator /
+'x' ~~ m/foo (#) bar /   X::Comp::Group  Regex not terminated. (twice) / Unable to parse expression in metachar:sym<( )>
+```
+
+mutsu gives three *different* wrong answers for the first three, because
+`scan_to_delim` (`src/parser/primary/regex/scan.rs`) returns `None` and the
+regex-literal parse simply backtracks; whatever alternative parse fails last
+supplies the exception:
+
+```
+'x' ~~ m/foo             X::Undeclared::Symbols
+'x' ~~ /foo              X::Syntax::Confused
+my $r = rx/abc           X::Str::Numeric
+```
+
+The fourth is the one roast asks about directly:
+`roast/S05-metasyntax/regex.t` test 29 (`throws-like q['x' ~~ m/foo (#) bar /],
+X::Comp::Group, 'commented capture end = parse error'`). mutsu's regex scanner
+*does* honour `#`-to-end-of-line comments, so it correctly consumes `) bar /`
+and finds no terminator — it just has nothing to say about it.
+
+## Why it is not a one-liner
+
+`scan_to_delim` returning `None` is load-bearing for backtracking: a bare `/` is
+division far more often than it is a regex, so the scanner cannot be made to
+throw. The commit point differs per opener:
+
+* `m/…`, `rx/…`, `s/…/…/` — the keyword commits, so a failed scan there is
+  unambiguously an unterminated regex and can throw.
+* a bare `/…/` in term position — mutsu has already decided it is a regex by the
+  time it scans, so it is probably safe too, but that decision is spread over
+  the term-position dispatch and needs checking before committing.
+
+So the work is: add the `Regex not terminated.` sorrow + a
+`X::Comp::FailGoal` panic (via `PError::comp_group`, added in
+`news/2026-08/comp-group-for-two-complaints.md`), and thread it out of the
+committed openers only, one at a time, with the bare-`/` case measured last.
+
+## The other file in the same cluster
+
+`roast/S02-literals/quoting-unicode.t` also wants an `X::Comp::Group` (line 93,
+`m\c[SNOWMAN].\c[COMET]`), but it is *not* blocked on this alone: it loses seven
+assertions, six of them "Can't mix curly quote with ASCII quote" — arbitrary
+paired-delimiter validation, a separate piece of work.


### PR DESCRIPTION
Classifying the roast residue under the real `Test` module by its *first* failing assertion (`todo/tickets/vendor-real-test-module.md`) left one cluster clearly on top: 7 files whose first loss is `right exception type (X::Comp::Group)`. This closes 5 of them.

### The rule

rakudo's compiler does not stop at the first complaint. It accumulates *worries*, *sorrows* and at most one *panic*, and what it throws depends on what it collected:

| collected | thrown |
| --- | --- |
| a panic alone | that panic |
| exactly one sorrow, no worries | that sorrow |
| anything else | `X::Comp::Group` |

So `throws-like 'say', X::Comp::Group` is not roast being odd — a bare `say` draws a *worry* ("Unsupported use of bare say…") and then panics on the missing argument list. And in the same file, `my Int $a of Str` is a plain `X::Syntax::Variable::ConflictingTypes` while `my Int $a of Str is default("z") of Rat` is a group, because the second sorrows twice.

mutsu raises one typed exception per parse failure, so there is no accumulator to consult. Each site that reproduces a rakudo diagnosis *with a companion complaint* now says so, through a new `PError::comp_group` built on the existing `Value::make_comp_group`.

### The four diagnoses

| construct | before | after |
| --- | --- | --- |
| `say` / `print` / `put` with no argument | `X::Comp` carrying the advice | `X::Comp::Group`: advice as worry, `Argument to "say" seems to be malformed` as panic |
| `1__0` | `X::Syntax::Confused` with a 400-character "expected …" dump | `X::Comp::Group`: `Only isolated underscores are allowed inside numbers` |
| `for 1.. { }`, `for 1... { }`, `for 1, {a=>1}` | `X::Syntax::Missing` | `X::Comp::Group`: `Expression needs parens to avoid gobbling block` |
| `my Int $a of Str is default("z") of Rat` | `X::Syntax::Variable::ConflictingTypes` (first conflict only) | `X::Comp::Group` of both |

Three of the four are error-*quality* fixes as much as classification ones.

Each is narrow on purpose, because the neighbouring shapes are differently typed in rakudo and were already right:

- `10_` stays `X::Syntax::Confused`, `_10` stays undeclared-symbol; only a run of **two or more** underscores **between digits** groups. `1_0` is still a separator.
- `for 1..2` stays `X::Syntax::Missing` — that block is genuinely absent, not eaten. The gobbled-block test grew to cover `Expr::Hash` and an infix's right operand, which is where the loop's block lands when a range endpoint swallows it.
- one redundant `of` still throws on its own. Getting the double form right meant making the `of` / `is`-trait parse a loop that collects conflicts instead of throwing on the first — rakudo's accumulate-then-decide model in miniature, scoped to one declaration.

### Result

`S16-io/bare-say.t`, `S02-literals/underscores.t`, `S04-statements/for.t`, `S04-declarations/my-6e.t` and `6.c/S04-declarations/my-6c.t` all pass under the real `Test` module. Local `make test` (2807 files) and `make roast` (1435 files) are green.

Pin: `t/comp-group-two-complaints.t` — 15 assertions, including the shapes that must **not** become groups. It passes under `raku` as well.

### Not in this PR

The two files left in the cluster need an unterminated-regex diagnosis (`S05-metasyntax/regex.t`) and paired-delimiter validation (`S02-literals/quoting-unicode.t`). The first is written up in `todo/tickets/unterminated-regex-has-no-diagnosis.md` — mutsu currently gives three *different* wrong exception classes for three unterminated regexes, and the fix cannot simply make the scanner throw, because a bare `/` is division far more often than it is a regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)