### PR TITLE
fix(supply): closing a tap closes the whole chain, not just its own block

### DIFF
--- a/news/2026-08/supply-tap-close-cascades-upstream.md
+++ b/news/2026-08/supply-tap-close-cascades-upstream.md
@@ -1,0 +1,68 @@
+# Closing a tap now closes the whole supply chain
+
+In raku, closing a tap closes the supply block that produced it, which closes the
+`whenever` subscriptions inside it, which closes *their* sources — all the way
+down to the original `Supplier` or listener. mutsu closed only the block the tap
+was taken on:
+
+```raku
+my $src = Supplier.new;
+my $upstream = supply {
+    whenever $src.Supply -> $v { emit $v * 10 }
+    CLOSE { say "UPSTREAM closed" }
+};
+my $mid = supply {
+    whenever $upstream -> $v { emit $v + 1 }
+    CLOSE { say "MID closed" }
+};
+my $tap = $mid.tap(-> $v { say "GOT $v" });
+$src.emit(1);      # GOT 11
+$tap.close;        # raku: UPSTREAM closed, MID closed
+                   # mutsu: MID closed
+$src.emit(2);      # raku: nothing
+                   # mutsu: GOT 21   <- delivered to a CLOSED tap
+```
+
+So the upstream block kept running: its `CLOSE` phasers never fired, and values
+still reached the closed tap callback.
+
+## Fix
+
+The on-demand `tap` path now records every subscription it creates upstream on
+the Tap handle it returns (`upstream_taps`): a `[supplier_id, tap_id]` pair for
+each `whenever` source and for the outer callback registered on the block's own
+emitter, plus the nested Tap handle when the source is itself a chained
+on-demand supply. `Tap.close` walks that list — `close_supplier_tap` for pairs,
+recursion for nested handles — before firing its own `CLOSE` callbacks, so a
+chain's `CLOSE` phasers run source-first exactly as raku's do. (The nested-handle
+half closes a long-standing `TODO: thread the inner Tap into the outer Tap
+handle` in `native_supply_mut_methods.rs`.)
+
+Pin: `t/supply-tap-close-cascades-upstream.t` (5 tests, green under `raku` too).
+
+## Effect on Cro
+
+`Cro::Service.stop` is exactly this shape — `$!service-tap.close` on a pipeline
+whose bottom is a TCP listener — so a "stopped" Cro server kept serving and a
+second server on the same port never saw a request:
+
+```raku
+my $app1 = route { get -> { content 'text/plain', "APP-ONE"; } };
+my $app2 = route { get -> { content 'text/plain', "APP-TWO"; } };
+# ...start, request, stop the first; then start the second on the same port
+# before: R1: APP-ONE / R2: APP-ONE
+# now:    R1: APP-ONE / R2: APP-TWO
+```
+
+`t/http-middleware.rakutest`'s first subtest goes from 2/4 to 4/4 as a result.
+
+**Known consequence:** the same file now *hangs* on its later subtests instead of
+completing with wrong answers. That is a second, pre-existing bug this fix
+exposes — re-`listen`ing on one port in a loop leaks listeners and eventually
+fails to bind, because `'localhost'` resolves to both `127.0.0.1` and `[::1]` and
+different rounds bind different ones. It reproduces identically on `main` with no
+supplies involved at all, and is filed as
+`todo/tickets/async-listener-not-freed-when-relistening-in-a-loop.md` with an
+`ss`-level diagnosis. Until it is fixed, a stale listener answering for a stopped
+server is traded for no listener answering — a deterministic failure instead of a
+silently wrong one.

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -145,9 +145,45 @@ impl Interpreter {
                 ) {
                     close_supplier_tap(supplier_id as u64, tap_id as u64);
                 }
+                // Cascade upstream. In raku, closing a tap closes the supply
+                // block that produced it, which closes the `whenever`
+                // subscriptions inside it, which closes *their* sources — all
+                // the way down to the original Supplier or listener. Without
+                // this the block kept running: its CLOSE phasers never fired and
+                // values still reached the (closed) tap callback, so
+                // `Cro::Service.stop` left the old listener serving and a second
+                // server on the same port never got a request.
+                if let Some(ValueView::Array(entries, ..)) =
+                    attributes.get("upstream_taps").map(Value::view)
+                {
+                    for entry in entries.iter().cloned().collect::<Vec<_>>() {
+                        match entry.view() {
+                            ValueView::Array(pair, ..) if pair.len() == 2 => {
+                                if let (ValueView::Int(sid), ValueView::Int(tid)) =
+                                    (pair[0].view(), pair[1].view())
+                                {
+                                    close_supplier_tap(sid as u64, tid as u64);
+                                }
+                            }
+                            // A chained on-demand source's own Tap handle:
+                            // recurse so its `whenever`s close in turn.
+                            ValueView::Instance {
+                                class_name,
+                                attributes: inner,
+                                ..
+                            } if class_name == "Tap" => {
+                                let inner = inner.as_map().clone();
+                                self.native_tap(&inner, "close")?;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
                 // Fire any CLOSE-phaser callbacks registered on this tap's
                 // supply emitter (run once — taking empties the list, so a
-                // later normal termination won't run them again).
+                // later normal termination won't run them again). After the
+                // cascade, so a chain's CLOSE phasers run source-first, as raku
+                // does.
                 if let Some(ValueView::Int(cid)) =
                     attributes.get("close_supplier_id").map(Value::view)
                 {

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -262,6 +262,14 @@ impl Interpreter {
                 );
                 let mut on_demand_quit: Option<Value> = None;
                 let mut done_group_marker: Option<Value> = None;
+                // Every subscription this tap creates upstream, so closing the
+                // returned Tap tears the whole chain down (raku: closing a tap
+                // closes the supply block, which closes its `whenever`
+                // subscriptions, cascading to the original source). Entries are
+                // either a `[supplier_id, tap_id]` pair or a nested Tap handle
+                // from a chained on-demand source; `native_tap`'s "close" walks
+                // them recursively.
+                let mut upstream_taps: Vec<Value> = Vec::new();
                 let values = if let Some(on_demand_cb) = attrs.get("on_demand_callback").cloned() {
                     // Give the emitter a supplier_id so that when a `whenever`
                     // body calls `$emitter.emit(val)`, the value can be dispatched
@@ -380,6 +388,12 @@ impl Interpreter {
                             {
                                 let supplier_id = sid as u64;
                                 register_supplier_tap(supplier_id, body_cb.clone(), 0.0);
+                                if let Some(tid) = last_supplier_tap_id(supplier_id) {
+                                    upstream_taps.push(Value::array(vec![
+                                        Value::int(supplier_id as i64),
+                                        Value::int(tid as i64),
+                                    ]));
+                                }
                                 // Raku serializes all `whenever` handlers of one
                                 // supply block ("only in one whenever block at a
                                 // time"). Tag this source trigger with the block's
@@ -402,6 +416,12 @@ impl Interpreter {
                                         delay_seconds,
                                     );
                                     outer_tap_registered = true;
+                                    if let Some(tid) = last_supplier_tap_id(emitter_supplier_id) {
+                                        upstream_taps.push(Value::array(vec![
+                                            Value::int(emitter_supplier_id as i64),
+                                            Value::int(tid as i64),
+                                        ]));
+                                    }
                                 }
                                 // Supplier::Preserving source: replay the backlog
                                 // buffered before this whenever subscribed (after
@@ -504,6 +524,12 @@ impl Interpreter {
                                         delay_seconds,
                                     );
                                     outer_tap_registered = true;
+                                    if let Some(tid) = last_supplier_tap_id(emitter_supplier_id) {
+                                        upstream_taps.push(Value::array(vec![
+                                            Value::int(emitter_supplier_id as i64),
+                                            Value::int(tid as i64),
+                                        ]));
+                                    }
                                 }
                                 if let Some(ref qf) = quit_cb {
                                     register_supplier_quit_callback(
@@ -557,6 +583,12 @@ impl Interpreter {
                                         delay_seconds,
                                     );
                                     outer_tap_registered = true;
+                                    if let Some(tid) = last_supplier_tap_id(emitter_supplier_id) {
+                                        upstream_taps.push(Value::array(vec![
+                                            Value::int(emitter_supplier_id as i64),
+                                            Value::int(tid as i64),
+                                        ]));
+                                    }
                                 }
                                 let last_cbs = Self::value_array_items(&arr[2]).unwrap_or_default();
                                 let quit_cbs = Self::value_array_items(&arr[3]).unwrap_or_default();
@@ -585,28 +617,40 @@ impl Interpreter {
                                 if let Some(q) = quit_cbs.first() {
                                     tap_args.push(Value::pair("quit".to_string(), q.clone()));
                                 }
-                                // TODO: thread the inner Tap into the outer Tap
-                                // handle so closing the outer tap tears down a
-                                // still-live inner pipeline.
-                                if let Err(err) = self.call_method_with_values(
+                                // The inner Tap is threaded into the outer Tap
+                                // handle (`upstream_taps`) so closing the outer
+                                // tap tears down a still-live inner pipeline.
+                                match self.call_method_with_values(
                                     inner_supply.clone(),
                                     "tap",
                                     tap_args,
                                 ) {
-                                    let reason = err
-                                        .exception
-                                        .as_deref()
-                                        .cloned()
-                                        .unwrap_or_else(|| Value::str(err.message.clone()));
-                                    if let Some(ref qf) = quit_cb {
-                                        self.call_supply_quit_handler(qf.clone(), reason)?;
-                                    } else {
-                                        return Err(Self::runtime_error_from_supply_reason(reason));
+                                    Ok(inner_tap) => {
+                                        if matches!(inner_tap.view(), ValueView::Instance { .. }) {
+                                            upstream_taps.push(inner_tap);
+                                        }
                                     }
-                                    return Ok((
-                                        Value::make_instance(Symbol::intern("Tap"), HashMap::new()),
-                                        attrs,
-                                    ));
+                                    Err(err) => {
+                                        let reason = err
+                                            .exception
+                                            .as_deref()
+                                            .cloned()
+                                            .unwrap_or_else(|| Value::str(err.message.clone()));
+                                        if let Some(ref qf) = quit_cb {
+                                            self.call_supply_quit_handler(qf.clone(), reason)?;
+                                        } else {
+                                            return Err(Self::runtime_error_from_supply_reason(
+                                                reason,
+                                            ));
+                                        }
+                                        return Ok((
+                                            Value::make_instance(
+                                                Symbol::intern("Tap"),
+                                                HashMap::new(),
+                                            ),
+                                            attrs,
+                                        ));
+                                    }
                                 }
                             } else {
                                 // Cold (supplier-less, non-on-demand) whenever
@@ -1005,6 +1049,10 @@ impl Interpreter {
                 if let Some(cid) = close_supplier_id {
                     tap_handle_attrs
                         .insert("close_supplier_id".to_string(), Value::int(cid as i64));
+                }
+                if !upstream_taps.is_empty() {
+                    tap_handle_attrs
+                        .insert("upstream_taps".to_string(), Value::array(upstream_taps));
                 }
                 let tap_instance = Value::make_instance(Symbol::intern("Tap"), tap_handle_attrs);
                 Ok((tap_instance, attrs))

--- a/t/supply-tap-close-cascades-upstream.t
+++ b/t/supply-tap-close-cascades-upstream.t
@@ -1,0 +1,55 @@
+use v6;
+use Test;
+
+# Closing a tap closes the supply block that produced it, which closes the
+# `whenever` subscriptions inside it, which closes *their* sources — all the way
+# down to the original Supplier. mutsu closed only the block the tap was taken
+# on: the upstream `whenever` stayed subscribed, so its CLOSE phaser never fired
+# and values kept reaching the (closed) tap callback.
+#
+# `Cro::Service.stop` is exactly this shape (`$!service-tap.close` on a pipeline
+# whose bottom is a TCP listener), so a stopped server kept serving and a second
+# server on the same port never saw a request.
+
+plan 5;
+
+my $src = Supplier.new;
+my @closed;
+my @got;
+
+my $upstream = supply {
+    whenever $src.Supply -> $v { emit $v * 10 }
+    CLOSE { @closed.push('upstream') }
+};
+my $mid = supply {
+    whenever $upstream -> $v { emit $v + 1 }
+    CLOSE { @closed.push('mid') }
+};
+
+my $tap = $mid.tap(-> $v { @got.push($v) });
+$src.emit(1);
+is @got.join(","), "11", "a value flows through both blocks";
+
+$tap.close;
+is @closed.join(","), "upstream,mid",
+    "closing the tap closes the whole chain, source-first";
+
+$src.emit(2);
+is @got.join(","), "11", "no value reaches the closed tap afterwards";
+
+# A single-level supply block still closes exactly once.
+my $src2 = Supplier.new;
+my @closed2;
+my $one = supply {
+    whenever $src2.Supply -> $v { emit $v }
+    CLOSE { @closed2.push('one') }
+};
+my @got2;
+my $tap2 = $one.tap(-> $v { @got2.push($v) });
+$src2.emit('a');
+$tap2.close;
+$src2.emit('b');
+is @closed2.join(","), "one", "a one-level block's CLOSE fires exactly once";
+is @got2.join(","), "a", "and it stops receiving";
+
+done-testing;

--- a/todo/tickets/async-listener-not-freed-when-relistening-in-a-loop.md
+++ b/todo/tickets/async-listener-not-freed-when-relistening-in-a-loop.md
@@ -1,0 +1,80 @@
+# Re-`listen`ing on one port in a loop leaks listeners and then fails to bind
+
+```raku
+my $port = 31422;
+for ^4 -> $round {
+    my $tap = IO::Socket::Async.listen('localhost', $port).tap(
+        -> $conn { $conn.close; },
+        quit => -> $e { note "round $round quit: $e" });
+    my $c = await IO::Socket::Async.connect('localhost', $port);
+    $c.close;
+    $tap.close;
+    note "round $round done";
+}
+```
+
+```
+round 0 done
+round 1 done
+round 2 done
+round 3 quit: Failed to bind: Address already in use (os error 98)
+round 3 done
+```
+
+raku runs all four rounds. The failure is **deterministic** (same round every run)
+and predates the tap-close cascade fix — verified by A/B against `main`
+(`news/2026-08/supply-tap-close-cascades-upstream.md`).
+
+## Evidence
+
+`ss -tan` taken while the loop runs shows **two** LISTEN sockets on the port at
+once, on different addresses:
+
+```
+LISTEN  127.0.0.1:31423   0.0.0.0:*
+LISTEN  [::1]:31423       [::]:*
+TIME-WAIT [::1]:50528 -> [::1]:31423
+...
+```
+
+`'localhost'` resolves to both `127.0.0.1` and `[::1]`, and
+`std::net::TcpListener::bind` picks one; different rounds can pick different
+ones, so two rounds' listeners coexist happily and a third collides with
+whichever address it draws. That also explains the *wrong-answer* symptom that
+shows up before the bind error: the client's `connect` resolves to the address of
+a **previous** round's still-live listener, so it is served by the stale round
+(`round 2 got: 'R1'`).
+
+Only the loop shape fails. A single `listen` / `tap.close` pair frees the port
+correctly (`ss` shows no LISTEN afterwards), and `set_listener_closed`
+(`src/runtime/native_methods/state.rs`) does wait for the accept thread's
+`stopped` acknowledgement before returning, so the close handshake itself works.
+
+## Likely fixes to evaluate
+
+1. **Resolve the host once and bind every address it yields** (or bind a single,
+   deterministic one), so `localhost` does not silently mean "either stack" —
+   raku/libuv binds what it resolved and reports a real conflict.
+2. **Set `SO_REUSEADDR` before `bind`** (raku does; std's `TcpListener::bind`
+   does not). Needs `socket2`, or `libc::setsockopt` behind the existing optional
+   `libc` feature — note `libc` is not available in the wasm build, so this needs
+   a cfg split.
+
+Both are worth doing; (1) is the actual cause of the cross-round answers.
+
+## Why it matters
+
+It is the remaining blocker for the vendored Cro::HTTP multi-server tests. With
+the tap-close cascade fixed, `Cro::Service.stop` really does stop the server —
+so `t/http-middleware.rakutest`'s first subtest now passes 4/4 (was 2/4), but the
+file then **hangs** on the later servers instead of answering from the stale
+listener. `t/http-auth-basic`, `http-session-*` and `router-auth` are all the
+same shape. Repro against the real dist: `tmp/mw6.p6` (six sequential
+`Cro::HTTP::Server`s on one port) answers for two rounds and then returns empty
+bodies.
+
+Pin when fixed: a `t/io-socket-async-relisten-loop.t` running the loop above
+(remember: never hardcode a port — listen on 0 and read the tap's `.socket-port`,
+per the `t/io-socket-recv-limit.t` lesson; this repro needs a fixed port only
+because it re-binds the same one deliberately, so allocate it once from a port-0
+listen and reuse that number).


### PR DESCRIPTION
## Problem

In raku, closing a tap closes the supply block that produced it, which closes the `whenever` subscriptions inside it, which closes *their* sources — all the way down to the original `Supplier` or listener. mutsu closed only the block the tap was taken on.

```raku
my $src = Supplier.new;
my $upstream = supply {
    whenever $src.Supply -> $v { emit $v * 10 }
    CLOSE { say "UPSTREAM closed" }
};
my $mid = supply {
    whenever $upstream -> $v { emit $v + 1 }
    CLOSE { say "MID closed" }
};
my $tap = $mid.tap(-> $v { say "GOT $v" });
$src.emit(1);      # GOT 11
$tap.close;        # raku: UPSTREAM closed, MID closed
                   # mutsu: MID closed
$src.emit(2);      # raku: nothing
                   # mutsu: GOT 21   <- delivered to a CLOSED tap
```

## Fix

The on-demand `tap` path records every subscription it creates upstream on the Tap handle it returns (`upstream_taps`):

- a `[supplier_id, tap_id]` pair for each `whenever` source, and for the outer callback registered on the block's own emitter;
- the nested Tap handle when the source is itself a chained on-demand supply — the case a long-standing `TODO: thread the inner Tap into the outer Tap handle` in `native_supply_mut_methods.rs` asked for.

`Tap.close` walks that list (`close_supplier_tap` for pairs, recursion for nested handles) **before** firing its own `CLOSE` callbacks, so a chain's `CLOSE` phasers run source-first exactly as raku's do.

## Effect on Cro

`Cro::Service.stop` is exactly this shape — `$!service-tap.close` on a pipeline whose bottom is a TCP listener — so a "stopped" Cro server kept serving and a second server on the same port never saw a request:

```
# before: R1: APP-ONE / R2: APP-ONE
# now:    R1: APP-ONE / R2: APP-TWO
```

`t/http-middleware.rakutest`'s first subtest goes from 2/4 to 4/4.

**Known consequence, stated plainly:** the same file now *hangs* on its later subtests instead of completing with wrong answers. That is a second, **pre-existing** bug this fix exposes — re-`listen`ing on one port in a loop leaks listeners and eventually fails to bind, because `'localhost'` resolves to both `127.0.0.1` and `[::1]` and different rounds bind different ones. It reproduces identically on `main` with no supplies involved at all (A/B'd), and is filed with an `ss`-level diagnosis as `todo/tickets/async-listener-not-freed-when-relistening-in-a-loop.md`. Until that lands, a stale listener answering for a stopped server is traded for no listener answering — a deterministic failure instead of a silently wrong one. No whitelisted test is affected either way.

## Testing

- New pin `t/supply-tap-close-cascades-upstream.t` (5 tests) — green under `raku` too.
- `make test`: PASS (2805 files, 26634 tests).
- All 99 whitelisted `roast/S17-*` files: PASS on a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)