### PR TITLE
refactor(compiler): lower type declarations into typed plans

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -145,6 +145,12 @@ the plan, and the VM no longer pattern-matches `Stmt::SubDecl`. The plan still c
 `legacy_body` for the existing routine-registry adapter. Replacing that field with the compiled
 routine reference is the next declaration slice.
 
+`RegisterClass` and `RegisterRole` now likewise index typed class/role declaration-plan pools for
+both source-order declarations and hoisted forward-reference shells. The VM no longer discovers
+these declaration kinds by inspecting the generic statement pool. Their `legacy_body` adapters
+remain until structural registration and declaration-time expressions become plan operations and
+compiled child chunks.
+
 The dispatch layer now has a canonical `BuiltinMethodEntry` keyed by owner type and method name,
 including native arity bits. Built-in introspection derives its name list from those entries. The
 catalog is still populated through the transitional native probes and slow-path declarations;

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -622,7 +622,7 @@ impl Compiler {
                         });
                         custom_traits.push(("__hoisted".to_string(), None));
                     }
-                    let idx = self.code.add_stmt(shell);
+                    let idx = self.code.add_class_decl_plan(&shell);
                     self.code.emit(OpCode::RegisterClass(idx));
                 }
                 Stmt::RoleDecl { .. } => {
@@ -633,7 +633,7 @@ impl Compiler {
                         });
                         custom_traits.push(("__hoisted".to_string(), None));
                     }
-                    let idx = self.code.add_stmt(shell);
+                    let idx = self.code.add_role_decl_plan(&shell);
                     self.code.emit(OpCode::RegisterRole(idx));
                 }
                 _ => {}

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -54,6 +54,31 @@ mod declaration_plan_tests {
             _ => true,
         }));
     }
+
+    #[test]
+    fn type_declarations_leave_the_generic_statement_pool() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            "role R { method r { 1 } }; class C does R { method c { 2 } }; C.new.c",
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        assert!(!code.class_decl_plans.is_empty());
+        assert!(!code.role_decl_plans.is_empty());
+        assert!(code.stmt_pool.iter().all(|stmt| !matches!(
+            stmt,
+            crate::ast::Stmt::ClassDecl { .. } | crate::ast::Stmt::RoleDecl { .. }
+        )));
+        assert!(code.ops.iter().all(|op| match op {
+            crate::opcode::OpCode::RegisterClass(idx) => {
+                (*idx as usize) < code.class_decl_plans.len()
+            }
+            crate::opcode::OpCode::RegisterRole(idx) => {
+                (*idx as usize) < code.role_decl_plans.len()
+            }
+            _ => true,
+        }));
+    }
 }
 mod const_fold;
 mod expr;

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3449,7 +3449,7 @@ impl Compiler {
                 // registers it under the correct nested package
                 // (e.g. `class D` inside `unit module A::B` → `A::B::D`).
                 let stmt = self.qualify_decl_name(stmt);
-                let idx = self.code.add_stmt(stmt);
+                let idx = self.code.add_class_decl_plan(&stmt);
                 self.code.emit(OpCode::RegisterClass(idx));
             }
             Stmt::AugmentClass { .. } => {
@@ -3461,7 +3461,7 @@ impl Compiler {
                 // Same as RegisterClass above: a role method has no creation op.
                 self.record_type_body_captures(body);
                 let stmt = self.qualify_decl_name(stmt);
-                let idx = self.code.add_stmt(stmt);
+                let idx = self.code.add_role_decl_plan(&stmt);
                 self.code.emit(OpCode::RegisterRole(idx));
             }
             Stmt::SubsetDecl { .. } => {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1868,6 +1868,39 @@ pub(crate) struct CompiledSubDeclPlan {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct CompiledClassDeclPlan {
+    pub(crate) name: Symbol,
+    pub(crate) name_expr: Option<Expr>,
+    pub(crate) parents: Vec<String>,
+    pub(crate) class_is_rw: bool,
+    pub(crate) is_hidden: bool,
+    pub(crate) is_lexical: bool,
+    pub(crate) hidden_parents: Vec<String>,
+    pub(crate) does_parents: Vec<String>,
+    pub(crate) repr: Option<String>,
+    /// Compatibility payload for the class/role registry walker. Declaration-time expressions
+    /// move to compiled child chunks in the next ADR-0019 stage.
+    pub(crate) legacy_body: Vec<Stmt>,
+    pub(crate) language_version: String,
+    pub(crate) custom_traits: Vec<(String, Option<Expr>)>,
+    pub(crate) decl_id: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CompiledRoleDeclPlan {
+    pub(crate) name: Symbol,
+    pub(crate) type_params: Vec<String>,
+    pub(crate) type_param_defs: Vec<ParamDef>,
+    pub(crate) is_export: bool,
+    pub(crate) export_tags: Vec<String>,
+    /// Compatibility payload for the role-composition registry walker.
+    pub(crate) legacy_body: Vec<Stmt>,
+    pub(crate) is_rw: bool,
+    pub(crate) language_version: String,
+    pub(crate) custom_traits: Vec<(String, Option<Expr>)>,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct CompiledCode {
     pub(crate) ops: Vec<OpCode>,
     /// Static ip -> source line table, parallel to `ops` (0 = unknown). Replaces
@@ -1890,6 +1923,8 @@ pub(crate) struct CompiledCode {
     /// Typed declaration plans consumed by `RegisterSub`. Unlike `stmt_pool`, every entry is
     /// known to be a sub declaration, so the VM does not inspect or execute a source statement.
     pub(crate) sub_decl_plans: Vec<CompiledSubDeclPlan>,
+    pub(crate) class_decl_plans: Vec<CompiledClassDeclPlan>,
+    pub(crate) role_decl_plans: Vec<CompiledRoleDeclPlan>,
     pub(crate) locals: Vec<String>,
     /// Pre-interned Symbol for each local name. Avoids Symbol::intern()
     /// on every env sync in hot paths.
@@ -2495,6 +2530,8 @@ impl CompiledCode {
             const_index: rustc_hash::FxHashMap::default(),
             stmt_pool: Vec::new(),
             sub_decl_plans: Vec::new(),
+            class_decl_plans: Vec::new(),
+            role_decl_plans: Vec::new(),
             locals: Vec::new(),
             locals_sym: Vec::new(),
             locals_alias_sym: Vec::new(),
@@ -4727,6 +4764,75 @@ impl CompiledCode {
             supersede: *supersede,
             custom_traits: custom_traits.clone(),
             fingerprint,
+        });
+        idx
+    }
+
+    pub(crate) fn add_class_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+        let Stmt::ClassDecl {
+            name,
+            name_expr,
+            parents,
+            class_is_rw,
+            is_hidden,
+            is_lexical,
+            hidden_parents,
+            does_parents,
+            repr,
+            body,
+            language_version,
+            custom_traits,
+            decl_id,
+            ..
+        } = stmt
+        else {
+            panic!("add_class_decl_plan expects ClassDecl");
+        };
+        let idx = self.class_decl_plans.len() as u32;
+        self.class_decl_plans.push(CompiledClassDeclPlan {
+            name: *name,
+            name_expr: name_expr.clone(),
+            parents: parents.clone(),
+            class_is_rw: *class_is_rw,
+            is_hidden: *is_hidden,
+            is_lexical: *is_lexical,
+            hidden_parents: hidden_parents.clone(),
+            does_parents: does_parents.clone(),
+            repr: repr.clone(),
+            legacy_body: body.clone(),
+            language_version: language_version.clone(),
+            custom_traits: custom_traits.clone(),
+            decl_id: *decl_id,
+        });
+        idx
+    }
+
+    pub(crate) fn add_role_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+        let Stmt::RoleDecl {
+            name,
+            type_params,
+            type_param_defs,
+            is_export,
+            export_tags,
+            body,
+            is_rw,
+            language_version,
+            custom_traits,
+        } = stmt
+        else {
+            panic!("add_role_decl_plan expects RoleDecl");
+        };
+        let idx = self.role_decl_plans.len() as u32;
+        self.role_decl_plans.push(CompiledRoleDeclPlan {
+            name: *name,
+            type_params: type_params.clone(),
+            type_param_defs: type_param_defs.clone(),
+            is_export: *is_export,
+            export_tags: export_tags.clone(),
+            legacy_body: body.clone(),
+            is_rw: *is_rw,
+            language_version: language_version.clone(),
+            custom_traits: custom_traits.clone(),
         });
         idx
     }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4413,7 +4413,7 @@ impl Interpreter {
                     // `hoist_type_decl_shells`) is best-effort: on failure the
                     // in-place declaration still registers the class and
                     // reports any real error.
-                    if !Self::stmt_is_hoisted_type_shell(&code.stmt_pool[*idx as usize]) {
+                    if !Self::class_plan_is_hoisted(code, *idx) {
                         return Err(e);
                     }
                 }
@@ -4429,7 +4429,7 @@ impl Interpreter {
                 self.note_type_body_written_lexicals(code);
                 if let Err(e) = self.exec_register_role_op(code, *idx) {
                     // Best-effort shell pre-registration; see RegisterClass.
-                    if !Self::stmt_is_hoisted_type_shell(&code.stmt_pool[*idx as usize]) {
+                    if !Self::role_plan_is_hoisted(code, *idx) {
                         return Err(e);
                     }
                 }

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -4,17 +4,21 @@ use crate::ast::Expr;
 use crate::symbol::Symbol;
 
 impl Interpreter {
-    /// Whether a stmt-pool entry is a `__hoisted` declaration-only shell
-    /// emitted by `hoist_type_decl_shells` (compiler). Shell registration
-    /// errors are swallowed at the dispatch site — the in-place declaration
-    /// reports any real error.
-    pub(super) fn stmt_is_hoisted_type_shell(stmt: &Stmt) -> bool {
-        match stmt {
-            Stmt::ClassDecl { custom_traits, .. } | Stmt::RoleDecl { custom_traits, .. } => {
-                custom_traits.iter().any(|(t, _)| t == "__hoisted")
-            }
-            _ => false,
-        }
+    /// Whether a typed class/role plan is a `__hoisted` declaration-only shell emitted by
+    /// `hoist_type_decl_shells`. The opcode operand no longer indexes `stmt_pool`, so shell
+    /// detection must read the same typed plan pool as registration itself.
+    pub(super) fn class_plan_is_hoisted(code: &CompiledCode, idx: u32) -> bool {
+        code.class_decl_plans[idx as usize]
+            .custom_traits
+            .iter()
+            .any(|(name, _)| name == "__hoisted")
+    }
+
+    pub(super) fn role_plan_is_hoisted(code: &CompiledCode, idx: u32) -> bool {
+        code.role_decl_plans[idx as usize]
+            .custom_traits
+            .iter()
+            .any(|(name, _)| name == "__hoisted")
     }
 
     pub(super) fn exec_register_enum_op(

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -84,8 +84,7 @@ impl Interpreter {
         self.func_multi_resolve_cache.clear();
         self.func_multi_type_cacheable.clear();
         self.dispatch_multi_candidate.clear();
-        let stmt = &code.stmt_pool[idx as usize];
-        if let Stmt::ClassDecl {
+        if let Some(crate::opcode::CompiledClassDeclPlan {
             name,
             name_expr,
             parents,
@@ -95,12 +94,11 @@ impl Interpreter {
             hidden_parents,
             does_parents,
             repr,
-            body,
+            legacy_body: body,
             language_version,
             custom_traits,
             decl_id,
-            ..
-        } = stmt
+        }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(expr) = name_expr {
                 self.vm_eval_block_value(&[Stmt::Expr(expr.clone())])?
@@ -511,18 +509,17 @@ impl Interpreter {
         code: &CompiledCode,
         idx: u32,
     ) -> Result<(), RuntimeError> {
-        let stmt = &code.stmt_pool[idx as usize];
-        if let Stmt::RoleDecl {
+        if let Some(crate::opcode::CompiledRoleDeclPlan {
             name,
             type_params,
             type_param_defs,
             is_export,
             export_tags,
-            body,
+            legacy_body: body,
             is_rw,
             language_version,
             custom_traits,
-        } = stmt
+        }) = code.role_decl_plans.get(idx as usize)
         {
             let name_str = name.resolve();
             let current_package = self.current_package().to_string();


### PR DESCRIPTION
Moves source-order and hoisted class/role registration from the generic statement pool into typed CompiledClassDeclPlan and CompiledRoleDeclPlan pools. The VM consumes plan operands directly, with legacy body adapters retained for the next plan-op migration. Tests: declaration-plan unit invariants 2/2; targeted class/role/MOP TAP 21/21; cargo clippy.