### PR TITLE
refactor(vm): unify declaration registration opcode

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -151,6 +151,11 @@ these declaration kinds by inspecting the generic statement pool. Their `legacy_
 remain until structural registration and declaration-time expressions become plan operations and
 compiled child chunks.
 
+The three declaration entry opcodes have been consolidated into `RegisterDecl`, whose compact
+operand selects a tagged `CompiledDeclPlanRef`. Sub/class/role plans retain their typed cold-data
+pools, while VM opcode dispatch and declaration-sensitive compiler analysis now share one bytecode
+entry.
+
 The dispatch layer now has a canonical `BuiltinMethodEntry` keyed by owner type and method name,
 including native arity bits. Built-in introspection derives its name list from those entries. The
 catalog is still populated through the transitional native probes and slow-path declarations;

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -341,7 +341,7 @@ impl Compiler {
                 });
             }
             let idx = self.code.add_sub_decl_plan(&hoisted);
-            self.code.emit(OpCode::RegisterSub(idx));
+            self.code.emit(OpCode::RegisterDecl(idx));
         }
     }
 
@@ -370,10 +370,10 @@ impl Compiler {
         Some(self.code.add_constant(Value::str(qualified)))
     }
 
-    /// Hoist sub declarations: emit RegisterSub for all SubDecl statements
+    /// Hoist sub declarations: emit RegisterDecl(Sub) for all SubDecl statements
     /// before executing the rest of the block, so that `&name` references
     /// are available before the sub declaration appears in source order.
-    /// Note: we only emit RegisterSub here, not compile_sub_body, because
+    /// Note: we only emit RegisterDecl here, not compile_sub_body, because
     /// the normal SubDecl handling will compile the body. Compiling here
     /// would cause the compiled_functions map (which is flat) to be overwritten
     /// by later hoists from other scopes.
@@ -425,7 +425,7 @@ impl Compiler {
                     });
                 }
                 let idx = self.code.add_sub_decl_plan(&hoisted);
-                self.code.emit(OpCode::RegisterSub(idx));
+                self.code.emit(OpCode::RegisterDecl(idx));
             }
         }
     }
@@ -623,7 +623,7 @@ impl Compiler {
                         custom_traits.push(("__hoisted".to_string(), None));
                     }
                     let idx = self.code.add_class_decl_plan(&shell);
-                    self.code.emit(OpCode::RegisterClass(idx));
+                    self.code.emit(OpCode::RegisterDecl(idx));
                 }
                 Stmt::RoleDecl { .. } => {
                     let mut shell = self.qualify_decl_name(stmt);
@@ -634,7 +634,7 @@ impl Compiler {
                         custom_traits.push(("__hoisted".to_string(), None));
                     }
                     let idx = self.code.add_role_decl_plan(&shell);
-                    self.code.emit(OpCode::RegisterRole(idx));
+                    self.code.emit(OpCode::RegisterDecl(idx));
                 }
                 _ => {}
             }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -47,12 +47,14 @@ mod declaration_plan_tests {
                 .all(|stmt| !matches!(stmt, crate::ast::Stmt::SubDecl { .. })),
             "compiled sub declarations must not remain executable generic statements"
         );
-        assert!(code.ops.iter().all(|op| match op {
-            crate::opcode::OpCode::RegisterSub(idx) => {
-                (*idx as usize) < code.sub_decl_plans.len()
-            }
-            _ => true,
-        }));
+        assert!(code.ops.iter().any(|op| matches!(
+            op,
+            crate::opcode::OpCode::RegisterDecl(idx)
+                if matches!(
+                    code.decl_plans.get(*idx as usize),
+                    Some(crate::opcode::CompiledDeclPlanRef::Sub(_))
+                )
+        )));
     }
 
     #[test]
@@ -69,15 +71,22 @@ mod declaration_plan_tests {
             stmt,
             crate::ast::Stmt::ClassDecl { .. } | crate::ast::Stmt::RoleDecl { .. }
         )));
-        assert!(code.ops.iter().all(|op| match op {
-            crate::opcode::OpCode::RegisterClass(idx) => {
-                (*idx as usize) < code.class_decl_plans.len()
-            }
-            crate::opcode::OpCode::RegisterRole(idx) => {
-                (*idx as usize) < code.role_decl_plans.len()
-            }
-            _ => true,
-        }));
+        assert!(code.ops.iter().any(|op| matches!(
+            op,
+            crate::opcode::OpCode::RegisterDecl(idx)
+                if matches!(
+                    code.decl_plans.get(*idx as usize),
+                    Some(crate::opcode::CompiledDeclPlanRef::Class(_))
+                )
+        )));
+        assert!(code.ops.iter().any(|op| matches!(
+            op,
+            crate::opcode::OpCode::RegisterDecl(idx)
+                if matches!(
+                    code.decl_plans.get(*idx as usize),
+                    Some(crate::opcode::CompiledDeclPlanRef::Role(_))
+                )
+        )));
     }
 }
 mod const_fold;

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3039,7 +3039,7 @@ impl Compiler {
                     return;
                 }
                 let idx = self.code.add_sub_decl_plan(stmt);
-                self.code.emit(OpCode::RegisterSub(idx));
+                self.code.emit(OpCode::RegisterDecl(idx));
                 if name_expr.is_some() {
                     // Runtime-resolved sub names cannot be keyed reliably in compiled_fns.
                     return;
@@ -3141,7 +3141,7 @@ impl Compiler {
                     custom_traits: vec![("__mutsu_method_decl".to_string(), None)],
                 };
                 let idx = self.code.add_sub_decl_plan(&lowered);
-                self.code.emit(OpCode::RegisterSub(idx));
+                self.code.emit(OpCode::RegisterDecl(idx));
                 if name_expr.is_none() {
                     let mut method_params: Vec<String> = vec![
                         "self".to_string(),
@@ -3450,7 +3450,7 @@ impl Compiler {
                 // (e.g. `class D` inside `unit module A::B` → `A::B::D`).
                 let stmt = self.qualify_decl_name(stmt);
                 let idx = self.code.add_class_decl_plan(&stmt);
-                self.code.emit(OpCode::RegisterClass(idx));
+                self.code.emit(OpCode::RegisterDecl(idx));
             }
             Stmt::AugmentClass { .. } => {
                 let idx = self.code.add_stmt(stmt.clone());
@@ -3462,7 +3462,7 @@ impl Compiler {
                 self.record_type_body_captures(body);
                 let stmt = self.qualify_decl_name(stmt);
                 let idx = self.code.add_role_decl_plan(&stmt);
-                self.code.emit(OpCode::RegisterRole(idx));
+                self.code.emit(OpCode::RegisterDecl(idx));
             }
             Stmt::SubsetDecl { .. } => {
                 let idx = self.code.add_stmt(stmt.clone());

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1507,14 +1507,12 @@ pub(crate) enum OpCode {
     /// When `false`, the op is at top level with no lexical routine and
     /// throws `X::ControlFlow::Return` directly.
     ReturnFromNonRoutine(bool),
-    RegisterSub(u32),
+    RegisterDecl(u32),
     RegisterToken(u32),
     RegisterProtoSub(u32),
     RegisterProtoToken(u32),
     RegisterEnum(u32),
-    RegisterClass(u32),
     AugmentClass(u32),
-    RegisterRole(u32),
     RegisterSubset(u32),
     SubtestScope {
         body_end: u32,
@@ -1900,6 +1898,13 @@ pub(crate) struct CompiledRoleDeclPlan {
     pub(crate) custom_traits: Vec<(String, Option<Expr>)>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompiledDeclPlanRef {
+    Sub(u32),
+    Class(u32),
+    Role(u32),
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledCode {
     pub(crate) ops: Vec<OpCode>,
@@ -1920,11 +1925,14 @@ pub(crate) struct CompiledCode {
     /// chunk stops growing, so it costs no memory in the executed code.
     const_index: rustc_hash::FxHashMap<ConstKey, u32>,
     pub(crate) stmt_pool: Vec<Stmt>,
-    /// Typed declaration plans consumed by `RegisterSub`. Unlike `stmt_pool`, every entry is
+    /// Typed declaration plans consumed through `RegisterDecl`. Unlike `stmt_pool`, every entry is
     /// known to be a sub declaration, so the VM does not inspect or execute a source statement.
     pub(crate) sub_decl_plans: Vec<CompiledSubDeclPlan>,
     pub(crate) class_decl_plans: Vec<CompiledClassDeclPlan>,
     pub(crate) role_decl_plans: Vec<CompiledRoleDeclPlan>,
+    /// The single declaration-registration operand pool. `RegisterDecl(i)` selects one tagged
+    /// typed plan here; declaration-specific metadata stays out of the hot opcode enum.
+    pub(crate) decl_plans: Vec<CompiledDeclPlanRef>,
     pub(crate) locals: Vec<String>,
     /// Pre-interned Symbol for each local name. Avoids Symbol::intern()
     /// on every env sync in hot paths.
@@ -2532,6 +2540,7 @@ impl CompiledCode {
             sub_decl_plans: Vec::new(),
             class_decl_plans: Vec::new(),
             role_decl_plans: Vec::new(),
+            decl_plans: Vec::new(),
             locals: Vec::new(),
             locals_sym: Vec::new(),
             locals_alias_sym: Vec::new(),
@@ -3117,9 +3126,7 @@ impl CompiledCode {
             let defines_lazy_body = self.ops.iter().any(|op| {
                 matches!(
                     op,
-                    OpCode::RegisterSub(_)
-                        | OpCode::RegisterClass(_)
-                        | OpCode::RegisterRole(_)
+                    OpCode::RegisterDecl(_)
                         // A deferred END body (`PhaserEnd`, run after the frame
                         // exits) and a compile-time BEGIN/CHECK body (`CheckPhaser`)
                         // reconstruct the installing frame's lexicals BY NAME from
@@ -4365,9 +4372,7 @@ impl CompiledCode {
                     | OpCode::HyperMethodCallDynamic { .. }
                     | OpCode::BlockScope { .. }
                     | OpCode::BlockLocalScope { .. }
-                    | OpCode::RegisterSub(_)
-                    | OpCode::RegisterClass(_)
-                    | OpCode::RegisterRole(_)
+                    | OpCode::RegisterDecl(_)
                     | OpCode::RegisterEnum(_)
                     | OpCode::RegisterPackage { .. }
                     | OpCode::RegisterPackageMy { .. }
@@ -4745,7 +4750,7 @@ impl CompiledCode {
                 *is_raw,
             )
         });
-        let idx = self.sub_decl_plans.len() as u32;
+        let plan_idx = self.sub_decl_plans.len() as u32;
         self.sub_decl_plans.push(CompiledSubDeclPlan {
             name: *name,
             name_expr: name_expr.clone(),
@@ -4765,6 +4770,8 @@ impl CompiledCode {
             custom_traits: custom_traits.clone(),
             fingerprint,
         });
+        let idx = self.decl_plans.len() as u32;
+        self.decl_plans.push(CompiledDeclPlanRef::Sub(plan_idx));
         idx
     }
 
@@ -4788,7 +4795,7 @@ impl CompiledCode {
         else {
             panic!("add_class_decl_plan expects ClassDecl");
         };
-        let idx = self.class_decl_plans.len() as u32;
+        let plan_idx = self.class_decl_plans.len() as u32;
         self.class_decl_plans.push(CompiledClassDeclPlan {
             name: *name,
             name_expr: name_expr.clone(),
@@ -4804,6 +4811,8 @@ impl CompiledCode {
             custom_traits: custom_traits.clone(),
             decl_id: *decl_id,
         });
+        let idx = self.decl_plans.len() as u32;
+        self.decl_plans.push(CompiledDeclPlanRef::Class(plan_idx));
         idx
     }
 
@@ -4822,7 +4831,7 @@ impl CompiledCode {
         else {
             panic!("add_role_decl_plan expects RoleDecl");
         };
-        let idx = self.role_decl_plans.len() as u32;
+        let plan_idx = self.role_decl_plans.len() as u32;
         self.role_decl_plans.push(CompiledRoleDeclPlan {
             name: *name,
             type_params: type_params.clone(),
@@ -4834,6 +4843,8 @@ impl CompiledCode {
             language_version: language_version.clone(),
             custom_traits: custom_traits.clone(),
         });
+        let idx = self.decl_plans.len() as u32;
+        self.decl_plans.push(CompiledDeclPlanRef::Role(plan_idx));
         idx
     }
 }
@@ -4956,7 +4967,7 @@ pub(crate) struct CompiledFunction {
     /// nested functions can capture them via closure.
     pub(crate) has_inner_subs: bool,
     /// True if the function body *directly* declares a lexical routine via a
-    /// top-level `RegisterSub` / `RegisterSubset` opcode (`my sub`, a bare
+    /// top-level `RegisterDecl(Sub)` / `RegisterSubset` opcode (`my sub`, a bare
     /// nested `sub`/`regex`/`token`/`rule`, or a `subset`). Such a routine is
     /// lexically scoped to this body and — unless it escapes by being returned —
     /// must be removed from the (program-global) routine registry when the call
@@ -5152,10 +5163,8 @@ impl CompiledFunction {
             || self.code.ops.iter().any(|op| {
                 matches!(
                     op,
-                    OpCode::RegisterSub(..)
+                    OpCode::RegisterDecl(..)
                         | OpCode::RegisterSubset(..)
-                        | OpCode::RegisterClass(..)
-                        | OpCode::RegisterRole(..)
                         // CallOnValue/CallOnCodeVar may invoke closures that do `return`
                         // targeting an outer routine, requiring the routine stack.
                         | OpCode::CallOnValue { .. }
@@ -5167,11 +5176,14 @@ impl CompiledFunction {
         // A routine declared directly in this body (not inside a nested
         // BlockScope, which restores the registry itself) is lexical to the
         // body and must be unregistered on return unless it escapes.
-        self.declares_inner_routines = self
-            .code
-            .ops
-            .iter()
-            .any(|op| matches!(op, OpCode::RegisterSub(..) | OpCode::RegisterSubset(..)));
+        self.declares_inner_routines = self.code.ops.iter().any(|op| match op {
+            OpCode::RegisterDecl(idx) => matches!(
+                self.code.decl_plans.get(*idx as usize),
+                Some(CompiledDeclPlanRef::Sub(_))
+            ),
+            OpCode::RegisterSubset(..) => true,
+            _ => false,
+        });
     }
 
     /// Compute the set of variable names declared locally in this function

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -391,11 +391,13 @@ impl Interpreter {
         };
         // Raku semantics: `sub foo(...) { ... }` as the last statement
         // of a block returns the Sub. If the return value is Nil/Any and
-        // the last opcode was RegisterSub, create the Sub value.
+        // the last opcode was RegisterDecl(Sub), create the Sub value.
         if result.is_ok()
             && (ret_val.is_nil()
                 || matches!(ret_val.view(), ValueView::Package(n) if n.resolve() == "Any"))
-            && let Some(crate::opcode::OpCode::RegisterSub(idx)) = cf.code.ops.last()
+            && let Some(crate::opcode::OpCode::RegisterDecl(idx)) = cf.code.ops.last()
+            && let Some(crate::opcode::CompiledDeclPlanRef::Sub(plan_idx)) =
+                cf.code.decl_plans.get(*idx as usize)
             && let Some(crate::opcode::CompiledSubDeclPlan {
                 name: sub_name,
                 params,
@@ -403,7 +405,7 @@ impl Interpreter {
                 legacy_body: body,
                 is_rw,
                 ..
-            }) = cf.code.sub_decl_plans.get(*idx as usize)
+            }) = cf.code.sub_decl_plans.get(*plan_idx as usize)
         {
             ret_val = Value::make_sub(
                 Symbol::intern(&self.current_package()),

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4344,9 +4344,9 @@ impl Interpreter {
                 self.exec_make_block_closure_op(code, *idx, *cc_idx)?;
                 *ip += 1;
             }
-            OpCode::RegisterSub(idx) => {
+            OpCode::RegisterDecl(idx) => {
                 self.sync_source_line(code, *ip);
-                self.exec_register_sub_op(code, *idx)?;
+                self.exec_register_decl_op(code, *idx)?;
                 *ip += 1;
             }
             OpCode::RegisterToken(idx) => {
@@ -4405,34 +4405,9 @@ impl Interpreter {
                 self.exec_register_enum_op(code, *idx)?;
                 *ip += 1;
             }
-            OpCode::RegisterClass(idx) => {
-                self.sync_source_line(code, *ip);
-                self.note_type_body_written_lexicals(code);
-                if let Err(e) = self.exec_register_class_op(code, *idx) {
-                    // A `__hoisted` shell pre-registration (see
-                    // `hoist_type_decl_shells`) is best-effort: on failure the
-                    // in-place declaration still registers the class and
-                    // reports any real error.
-                    if !Self::class_plan_is_hoisted(code, *idx) {
-                        return Err(e);
-                    }
-                }
-                *ip += 1;
-            }
             OpCode::AugmentClass(idx) => {
                 self.sync_source_line(code, *ip);
                 self.exec_augment_class_op(code, *idx)?;
-                *ip += 1;
-            }
-            OpCode::RegisterRole(idx) => {
-                self.sync_source_line(code, *ip);
-                self.note_type_body_written_lexicals(code);
-                if let Err(e) = self.exec_register_role_op(code, *idx) {
-                    // Best-effort shell pre-registration; see RegisterClass.
-                    if !Self::role_plan_is_hoisted(code, *idx) {
-                        return Err(e);
-                    }
-                }
                 *ip += 1;
             }
             OpCode::RegisterSubset(idx) => {

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -4,21 +4,47 @@ use crate::ast::Expr;
 use crate::symbol::Symbol;
 
 impl Interpreter {
-    /// Whether a typed class/role plan is a `__hoisted` declaration-only shell emitted by
-    /// `hoist_type_decl_shells`. The opcode operand no longer indexes `stmt_pool`, so shell
-    /// detection must read the same typed plan pool as registration itself.
-    pub(super) fn class_plan_is_hoisted(code: &CompiledCode, idx: u32) -> bool {
-        code.class_decl_plans[idx as usize]
-            .custom_traits
-            .iter()
-            .any(|(name, _)| name == "__hoisted")
-    }
-
-    pub(super) fn role_plan_is_hoisted(code: &CompiledCode, idx: u32) -> bool {
-        code.role_decl_plans[idx as usize]
-            .custom_traits
-            .iter()
-            .any(|(name, _)| name == "__hoisted")
+    pub(super) fn exec_register_decl_op(
+        &mut self,
+        code: &CompiledCode,
+        idx: u32,
+    ) -> Result<(), RuntimeError> {
+        match code.decl_plans.get(idx as usize).copied() {
+            Some(crate::opcode::CompiledDeclPlanRef::Sub(plan_idx)) => {
+                self.exec_register_sub_op(code, plan_idx)
+            }
+            Some(crate::opcode::CompiledDeclPlanRef::Class(plan_idx)) => {
+                self.note_type_body_written_lexicals(code);
+                match self.exec_register_class_op(code, plan_idx) {
+                    Ok(()) => Ok(()),
+                    Err(_)
+                        if code.class_decl_plans[plan_idx as usize]
+                            .custom_traits
+                            .iter()
+                            .any(|(name, _)| name == "__hoisted") =>
+                    {
+                        Ok(())
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+            Some(crate::opcode::CompiledDeclPlanRef::Role(plan_idx)) => {
+                self.note_type_body_written_lexicals(code);
+                match self.exec_register_role_op(code, plan_idx) {
+                    Ok(()) => Ok(()),
+                    Err(_)
+                        if code.role_decl_plans[plan_idx as usize]
+                            .custom_traits
+                            .iter()
+                            .any(|(name, _)| name == "__hoisted") =>
+                    {
+                        Ok(())
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+            None => Err(RuntimeError::new("RegisterDecl plan index out of bounds")),
+        }
     }
 
     pub(super) fn exec_register_enum_op(


### PR DESCRIPTION
Consolidates RegisterSub, RegisterClass, and RegisterRole into one compact RegisterDecl opcode selecting a tagged CompiledDeclPlanRef. VM dispatch, declaration-sensitive analysis, and trailing-sub handling now consume the common operand pool. Tests: declaration invariants 2/2; opcode size guard; targeted sub/class/role/MOP TAP 22/22; cargo clippy.