### PR TITLE
fix(parser): chained ranges are non-associative, and `unless`+`else` is a compile error

### DIFF
--- a/news/2026-08/nonassoc-range-and-unless-else.md
+++ b/news/2026-08/nonassoc-range-and-unless-else.md
@@ -1,0 +1,58 @@
+# Two compile-time diagnoses roast asks for by class: chained ranges and `unless`+`else`
+
+Continuing the exception-class residue under the real `Test` module
+(`todo/tickets/vendor-real-test-module.md`): 29 of the 132 genuine failures lose
+their first assertion to `right exception type (X::…)`. Two of those are
+mechanisms rather than one-offs.
+
+## The range operators are non-associative
+
+`1..2..3` is `X::Syntax::NonAssociative` in rakudo, carrying both spellings in
+`.left` / `.right` — the operators bind at one level and refuse to chain.
+mutsu's `range_expr` builds exactly one range and returns, so the trailing
+`..3` was simply left unconsumed and the statement failed with the parser's
+generic "Confused", which named neither operator.
+
+`range_expr` now checks for a following range operator after each of its four
+forms and raises `non_associative_pair_error` — the constructor was already
+there, used by the comparison chain (`1 <=> 2 leg 3`), and carries `.left` /
+`.right` exactly as rakudo does. `..^` and `^..` report their own spelling.
+`1...5` (the sequence operator) is deliberately not one of these, and neither is
+a range inside a list or parentheses.
+
+Freed: `roast/S03-operators/range.t` and `roast/S03-operators/precedence.t`.
+
+## `unless` does not take `else`
+
+rakudo rejects `unless 1 {} else {}` at *compile* time with
+`X::Syntax::UnlessElse`, carrying the offending `keyword` — which
+`roast/S04-statements/unless.t` matches on for all three of `else`, `elsif` and
+`orwith`.
+
+mutsu lowered it to a **runtime** `Stmt::Die` whose message merely *spelled* the
+class name (`"X::Syntax::UnlessElse: unless does not allow 'else'"`), so it
+arrived as a plain `X::AdHoc` with no `keyword` — and, worse, the rest of the
+file still compiled and ran. It now goes through
+`RuntimeError::unless_else`, a twin of the existing `without_else` that the
+`without` branch has used all along, via `PError::from_typed`.
+
+Freed: `roast/S04-statements/unless.t`.
+
+## Attempted and reverted: `X::Syntax::DuplicatedPrefix`
+
+The third mechanism in this batch did not survive measurement, and the record is
+in `todo/tickets/duplicated-prefix-needs-metaop-aware-placement.md`. Raising the
+diagnosis at the top of `prefix_expr` gets `~~1` / `^^5` right and passes
+`make test`, but it breaks valid metaop code — `1 Z^^ 2` and `1 X^^ 2` are legal
+in rakudo, and `1 Z?? 2 !! 3` is `X::Syntax::CannotMeta`
+(`roast/S03-operators/ternary.t` test 28, which went red in `make roast`).
+rakudo scans `Z^^` as **one infix token**, so the `^^` is never in term position;
+mutsu's infix scanner consumes only `Z` and then hands `^^ 2` to `prefix_expr`.
+The metaop scanner has to claim the whole sequence first — which is a bug on its
+own, since `1 Z^^ 2` currently parses as `1 Z ^(^2)` and dies with
+`X::Range::InvalidArg`.
+
+Pin: `t/nonassoc-range-and-unless-else.t` — both diagnoses with their
+attributes, the `without` twin alongside, and five assertions that plain ranges,
+parenthesized ranges, the sequence operator and a plain `unless` are unaffected.
+It passes under `raku` as well.

--- a/src/parser/expr/precedence/chain_cmp.rs
+++ b/src/parser/expr/precedence/chain_cmp.rs
@@ -214,6 +214,33 @@ pub(in crate::parser::expr) fn parse_negated_meta_comparison_op(
     Some((op, len + 1))
 }
 
+/// The range operator spelling at the start of `r`, if any. Longest match
+/// first, and `...` (the sequence operator) is deliberately not one of these.
+fn peek_range_op(r: &str) -> Option<&'static str> {
+    for op in ["^..^", "^..", "..^"] {
+        if r.starts_with(op) && !(op == "^.." && r.starts_with("^...")) {
+            return Some(op);
+        }
+    }
+    if r.starts_with("..") && !r.starts_with("...") {
+        return Some("..");
+    }
+    None
+}
+
+/// The range operators are non-associative, so `1..2..3` is a compile error in
+/// rakudo (`X::Syntax::NonAssociative`, carrying both spellings) rather than
+/// something to parse. `range_expr` builds one range and returns, so the
+/// trailing `..3` used to be left unconsumed and the statement failed with the
+/// parser's generic "Confused" — a diagnosis that named neither operator.
+fn reject_chained_range(after_rhs: &str, left_op: &'static str) -> Result<(), PError> {
+    let (r, _) = ws(after_rhs)?;
+    match peek_range_op(r) {
+        Some(right_op) => Err(non_associative_pair_error(left_op, right_op)),
+        None => Ok(()),
+    }
+}
+
 /// Range: ..  ..^  ^..  ^..^
 pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
     let (rest, left) = structural_expr(input)?;
@@ -225,6 +252,7 @@ pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
         let (r, right) = structural_expr(r).map_err(|err| {
             enrich_expected_error(err, "expected range RHS after '^..^'", r.len())
         })?;
+        reject_chained_range(r, "^..^")?;
         return Ok((
             r,
             Expr::Binary {
@@ -240,6 +268,7 @@ pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
         let (r, _) = ws(stripped)?;
         let (r, right) = structural_expr(r)
             .map_err(|err| enrich_expected_error(err, "expected range RHS after '^..'", r.len()))?;
+        reject_chained_range(r, "^..")?;
         return Ok((
             r,
             Expr::Binary {
@@ -254,6 +283,7 @@ pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
         let (r, _) = ws(stripped)?;
         let (r, right) = structural_expr(r)
             .map_err(|err| enrich_expected_error(err, "expected range RHS after '..^'", r.len()))?;
+        reject_chained_range(r, "..^")?;
         return Ok((
             r,
             Expr::Binary {
@@ -269,6 +299,7 @@ pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
         let (r, _) = ws(r)?;
         let (r, right) = structural_expr(r)
             .map_err(|err| enrich_expected_error(err, "expected range RHS after '..'", r.len()))?;
+        reject_chained_range(r, "..")?;
         return Ok((
             r,
             Expr::Binary {

--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -442,26 +442,18 @@ pub(crate) fn unless_stmt(input: &str) -> PResult<'_, Stmt> {
     let (rest, cond) = condition_expr(rest)?;
     let (rest, _) = ws(rest)?;
     let (rest, body) = block(rest)?;
-    // unless cannot have else/elsif/orwith — check but consume the trailing clause
+    // `unless` cannot have else/elsif/orwith. rakudo rejects this at COMPILE
+    // time with `X::Syntax::UnlessElse`, carrying the offending `keyword`
+    // (roast S04-statements/unless.t matches on it). mutsu used to lower it to
+    // a runtime `Stmt::Die` whose message merely *spelled* the class, which
+    // arrived as a plain `X::AdHoc` — and let the rest of the file compile.
+    // The `without` twin already goes through `RuntimeError::without_else`.
     let (check, _) = ws(rest)?;
     for kw in &["else", "elsif", "orwith"] {
-        if let Some(r) = keyword(kw, check) {
-            // Consume the rest of the invalid clause to produce a hard error
-            let (r, _) = ws(r)?;
-            // Skip condition (if any) and block
-            let r = if kw != &"else" {
-                if let Ok((r, _)) = expression(r) { r } else { r }
-            } else {
-                r
-            };
-            let (r, _) = ws(r)?;
-            let r = if let Ok((r, _)) = block(r) { r } else { r };
-            return Ok((
-                r,
-                Stmt::Die(Expr::Literal(crate::value::Value::str(format!(
-                    "X::Syntax::UnlessElse: unless does not allow '{kw}'"
-                )))),
-            ));
+        if keyword(kw, check).is_some() {
+            return Err(PError::from_typed(crate::value::RuntimeError::unless_else(
+                kw,
+            )));
         }
     }
     Ok((

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -211,6 +211,17 @@ impl RuntimeError {
         Self::typed("X::Syntax::WithoutElse", attrs)
     }
 
+    /// X::Syntax::UnlessElse - `unless` followed by an `else`-family keyword.
+    /// The `without` twin of this is [`Self::without_else`]; roast matches the
+    /// `keyword` attribute on both (`S04-statements/unless.t`).
+    pub(crate) fn unless_else(keyword: &str) -> Self {
+        let msg = format!("\"unless\" does not take \"{keyword}\", please rewrite using \"if\"");
+        let mut attrs = HashMap::new();
+        attrs.insert("keyword".to_string(), Value::str(keyword.to_string()));
+        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        Self::typed("X::Syntax::UnlessElse", attrs)
+    }
+
     /// X::Comp::Trait::Scope - a trait applied under a scope that does not take it.
     ///
     /// `type`/`subtype` split the trait (`is` / `export`), `declaring` names what

--- a/t/nonassoc-range-and-unless-else.t
+++ b/t/nonassoc-range-and-unless-else.t
@@ -1,0 +1,33 @@
+# Two compile-time diagnoses roast asks for by class:
+#
+#   * the range operators are non-associative, so `1..2..3` is
+#     X::Syntax::NonAssociative carrying both spellings — mutsu parsed one
+#     range, left `..3` unconsumed, and reported the generic "Confused".
+#   * `unless` does not take an `else`-family keyword. mutsu lowered that to a
+#     *runtime* `Stmt::Die` whose message merely spelled the class name, so it
+#     arrived as a plain X::AdHoc and the rest of the file still compiled.
+use Test;
+
+plan 13;
+
+for <else elsif orwith> -> $kw {
+    throws-like "unless 1 \{\} $kw 1 \{\}", X::Syntax::UnlessElse,
+        keyword => $kw, "unless + $kw";
+}
+# The `without` twin was already right; keep them pinned together.
+throws-like 'without 1 {} else {}', X::Syntax::WithoutElse,
+    keyword => 'else', 'without + else';
+
+throws-like '1..2..3', X::Syntax::NonAssociative, left => '..', right => '..',
+    'chained ..';
+throws-like '1 .. 2 .. 3', X::Syntax::NonAssociative, 'chained .. with spaces';
+throws-like '1..^2..3', X::Syntax::NonAssociative, left => '..^', right => '..',
+    'chained ..^ then ..';
+throws-like '1^..2..3', X::Syntax::NonAssociative, 'chained ^.. then ..';
+
+# A single range, a parenthesized chain, and the sequence operator are all fine.
+is-deeply (1..3).List, (1, 2, 3), 'a plain range still parses';
+is-deeply (1..^3).List, (1, 2), 'a plain ..^ still parses';
+is-deeply ((1..2), (3..4)).map(*.elems).List, (2, 2), 'ranges in a list';
+is-deeply (1...5).List, (1, 2, 3, 4, 5), 'the sequence operator is not a range chain';
+is (unless 0 { 42 }), 42, 'a plain unless still works';

--- a/todo/tickets/duplicated-prefix-needs-metaop-aware-placement.md
+++ b/todo/tickets/duplicated-prefix-needs-metaop-aware-placement.md
@@ -1,0 +1,60 @@
+# `X::Syntax::DuplicatedPrefix` needs a metaop-aware place to live
+
+`^`, `~` and `?` are each both a valid *prefix* operator and the first half of
+an infix (`^^` / `~~` / `??`), so rakudo refuses a doubled one in term position
+by name — `X::Syntax::DuplicatedPrefix`, carrying the run in `prefixes`:
+
+```
+my $x = ~~1     X::Syntax::DuplicatedPrefix   prefixes=~~
+my $x = ^^^1    X::Syntax::DuplicatedPrefix   prefixes=^^^
+say ^^5         X::Syntax::DuplicatedPrefix   prefixes=^^
+```
+
+mutsu answers `X::Syntax::Confused` for the first two and, worse, *silently
+accepts* `^^5` as `^(^5)` — a different program. `roast/S03-operators/misc.t`
+tests 35/36 ask for the class with the `prefixes` attribute
+(`throws-like "1%^^1", X::Syntax::DuplicatedPrefix, prefixes => "^^"`).
+
+## What was tried, and why it was reverted (2026-08-03)
+
+Raising the diagnosis at the top of `prefix_expr`
+(`src/parser/expr/postfix/loop_.rs`) gets the term-position cases right and
+`make test` passes — but it **breaks valid metaop code**:
+
+```
+1 Z^^ 2     raku: ok        mutsu with the check: X::Syntax::DuplicatedPrefix
+1 X^^ 2     raku: ok        mutsu with the check: X::Syntax::DuplicatedPrefix
+1 Z?? 2 !! 3  raku: X::Syntax::CannotMeta   mutsu with the check: DuplicatedPrefix
+```
+
+(the last one is `roast/S03-operators/ternary.t` test 28, which regressed in
+`make roast`). The cause is that rakudo scans `Z^^` as **one infix token**,
+so the `^^` is never in term position at all, whereas mutsu's infix scanner
+consumes only `Z` and then calls `prefix_expr` on `^^ 2`.
+
+So the diagnosis cannot live in `prefix_expr` until the metaop scanner claims
+the whole `Z^^` / `X^^` / `R~~` sequence as an infix. **Fix that first** — it is
+a bug in its own right: `1 Z^^ 2` today parses as `1 Z ^(^2)` and dies with
+`X::Range::InvalidArg` instead of zipping two booleans.
+
+The pieces that were written and can be recovered from the revert:
+
+* `RuntimeError::duplicated_prefix(prefixes)` — the message is
+  `Expected a term, but found either infix ^^ or redundant prefix ^` plus a
+  second line suggesting the spaced spelling, and the exception carries
+  `prefixes`.
+* The run test itself, whose one wrinkle is `?`: `???` is the warn-flavoured
+  yada stub (a real term), so only a run of *exactly two* `?` is a duplicated
+  prefix, while `^^^` and `~~~` are duplicated at any length. `????` and `???1`
+  are `X::Syntax::Confused` in rakudo, which mutsu already gets by falling
+  through. Getting this wrong breaks `t/routine-yada.t` and every
+  `Test::Tap`-using file (the module body contains `???`).
+
+## Blocked file
+
+`roast/S03-operators/misc.t` — tests 35 and 36 are its only real failures under
+the real `Test` module (test 38 is a `# TODO`), so the class plus the `prefixes`
+attribute closes it. Note test 36 (`555 ~~!~~ 666`) needs the `!~~` spelling to
+reach term position as `~~`, and test 35 (`1%^^1`, no spaces) needs `%^^1` to
+stop being read as the placeholder variable `%^^1` — both separate from the
+metaop issue above.


### PR DESCRIPTION
Two more of the exception-class residue under the real `Test` module (29 of the 132 genuine failures lose their first assertion to `right exception type (X::…)`). Both are mechanisms rather than one-offs.

### The range operators are non-associative

`1..2..3` is `X::Syntax::NonAssociative` in rakudo, carrying both spellings in `.left` / `.right`. mutsu's `range_expr` builds exactly one range and returns, so the trailing `..3` was simply left unconsumed and the statement failed with the parser's generic "Confused" — which named neither operator.

`range_expr` now checks for a following range operator after each of its four forms and raises `non_associative_pair_error`, which already existed for the comparison chain (`1 <=> 2 leg 3`) and carries `.left` / `.right` exactly as rakudo does. `..^` and `^..` report their own spelling. `1...5` (the sequence operator), ranges in a list, and parenthesized ranges are deliberately unaffected.

Frees `roast/S03-operators/range.t` and `roast/S03-operators/precedence.t`.

### `unless` does not take `else`

rakudo rejects `unless 1 {} else {}` at **compile** time with `X::Syntax::UnlessElse`, carrying the offending `keyword` — which `roast/S04-statements/unless.t` matches on for `else`, `elsif` and `orwith`.

mutsu lowered it to a **runtime** `Stmt::Die` whose message merely *spelled* the class name, so it arrived as a plain `X::AdHoc` with no `keyword` — and, worse, the rest of the file still compiled and ran. It now goes through `RuntimeError::unless_else`, a twin of the existing `without_else` that the `without` branch has used all along.

Frees `roast/S04-statements/unless.t`.

### Attempted and reverted: `X::Syntax::DuplicatedPrefix`

The third mechanism in this batch did not survive measurement. Raising the diagnosis at the top of `prefix_expr` gets `~~1` / `^^5` right and passes `make test`, but it **breaks valid metaop code**:

```
1 Z^^ 2       raku: ok                      with the check: X::Syntax::DuplicatedPrefix
1 X^^ 2       raku: ok                      with the check: X::Syntax::DuplicatedPrefix
1 Z?? 2 !! 3  raku: X::Syntax::CannotMeta   with the check: X::Syntax::DuplicatedPrefix
```

The last one is `roast/S03-operators/ternary.t` test 28, which went red in `make roast`. rakudo scans `Z^^` as **one infix token**, so the `^^` is never in term position; mutsu's infix scanner consumes only `Z` and hands `^^ 2` to `prefix_expr`. The metaop scanner has to claim the whole sequence first — itself a bug, since `1 Z^^ 2` currently parses as `1 Z ^(^2)` and dies with `X::Range::InvalidArg`. Written up with the recoverable pieces (including the `???` yada-stub wrinkle that breaks `t/routine-yada.t` if you get it wrong) in `todo/tickets/duplicated-prefix-needs-metaop-aware-placement.md`.

### Verification

Local `make test` (2810 files) and `make roast` (1435 files) are green.

Pin: `t/nonassoc-range-and-unless-else.t` — both diagnoses with their attributes, the `without` twin alongside, and five assertions that plain ranges, parenthesized ranges, the sequence operator and a plain `unless` are unaffected. It passes under `raku` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)