### PR TITLE
fix(threading): a spawn inside an initializer must not unmask the declaration

### DIFF
--- a/news/2026-08/decl-in-flight-spawn-must-not-unmask.md
+++ b/news/2026-08/decl-in-flight-spawn-must-not-unmask.md
@@ -1,0 +1,65 @@
+# A spawn inside an initializer no longer reverts the variable being declared
+
+A `my` whose *initializer* starts a worker thread could end up holding the value
+of the binding it was about to shadow. In a loop that meant every iteration's
+variable silently reverted to the previous iteration's:
+
+```raku
+for ^3 -> $round {
+    my $tap = IO::Socket::Async.listen('localhost', $port).tap(-> $c { $c.close });
+    my $c = await IO::Socket::Async.connect('localhost', $port);   # the trigger
+    $c.close;
+    note "round $round tap=", $tap.WHICH;   # 46 / 46 / 77
+    $tap.close;
+}
+```
+
+Round 1 printed round 0's `Tap`, so `$tap.close` closed the *previous* round's
+listener and left the current one bound forever. That is the whole "a stopped
+server keeps answering" family: `Cro::Service.stop` closes its pipeline through
+exactly this shape, so a restarted `Cro::HTTP::Server` kept serving from the
+listener it was supposed to have released.
+
+## Root cause
+
+The cross-thread shared store is keyed by bare name, so it cannot represent two
+concurrently-live bindings of one name. `thread_redeclared_vars` masks a name a
+frame has re-declared, keeping the fresh binding out of that lane; the mask is
+dropped again at the next `clone_for_thread`, which first force-`declare`s the
+name's *current* value into the lineage. That handshake rests on a premise —
+"the current value is the binding the mask was protecting" — and the premise is
+false while a declaration is still **in flight**.
+
+`my $tap = ...listen(...).tap(...)` runs `SetVarDynamic` (declare, mask set),
+then evaluates the initializer, then stores. The `.tap` spawns a worker *during*
+the initializer, so `clone_for_thread` ran between the declaration and its
+store: neither the slot nor `env` held the new binding yet, both still carried
+the outer one. The spawn published that outer value into the lineage and then
+unmasked the name, and the `await`'s `sync_shared_vars_to_env` dutifully pulled
+it back over the slot the initializer had by then filled in.
+
+`rust-gdb -batch` showed the sequence directly, with one breakpoint per
+mechanism (`DECL "tap"` → `CLONE_FOR_THREAD retain` → `SYNC_SHARED_PUSH "tap"` →
+`CALLERWB_APPLY "tap"`), and round 2 — where no spawn falls in that window —
+skipping the last two.
+
+## Fix
+
+`thread_decl_in_flight` records the window between a declaration and the store
+that ends it (`SetVarDynamic` inserts, `exec_set_local_op` removes). Within it,
+`clone_for_thread` keeps the mask and seeds the name only if absent instead of
+force-declaring a value that is about to be stale. The window closes at the
+store, so the very next spawn republishes the binding normally and a genuinely
+shared variable keeps working; the set is empty for single-threaded programs.
+
+Pinned by `t/io-socket-async-relisten-loop.t` (green on raku too), which
+allocates its port from a port-0 listen rather than hardcoding one. All 99
+whitelisted S17 concurrency roast files stay green.
+
+## Effect on the vendored Cro::HTTP suite
+
+`t/http-middleware.rakutest` no longer hangs at the end of its first subtest —
+it now runs the second subtest's assertions as well. Serving from a *third*
+server bound to the same port still returns empty bodies, so the multi-server
+files are not green yet; that remaining facet stays tracked in
+`todo/tickets/async-listener-not-freed-when-relistening-in-a-loop.md`.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1365,6 +1365,21 @@ pub struct Interpreter {
     /// parent's *current* bindings). Only populated while
     /// `shared_vars_active`; empty (zero-cost) for single-threaded programs.
     pub(crate) thread_redeclared_vars: std::collections::HashSet<String>,
+    /// Subset of [`Self::thread_redeclared_vars`] whose declaration is still
+    /// *in flight*: the `my` has run but its initializer has not stored a value
+    /// yet, so neither the slot nor `env` holds the new binding — both still
+    /// carry the shadowed OUTER value.
+    ///
+    /// `clone_for_thread` normally drops a re-declaration mask because it
+    /// force-seeds the name's *current* value into the child lineage first. That
+    /// premise fails for a name in this set: a spawn that happens **inside the
+    /// initializer** (`my $tap = Supply.tap(...)`, whose `.tap` starts a worker)
+    /// would seed the outer binding's value and then unmask the name, so the
+    /// next `sync_shared_vars_to_env` pulls that stale value back over the
+    /// binding the initializer is about to create. Keeping the mask for the
+    /// in-flight window closes that hole; the store is republished normally once
+    /// the initializer's value lands. Empty for single-threaded programs.
+    pub(crate) thread_decl_in_flight: std::collections::HashSet<String>,
     /// Union of every executed `CompiledCode::type_body_written_lexicals`:
     /// lexicals written by a registered class/role method body. These keep the
     /// name-keyed `shared_vars` lane even when a spawned block also captures

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2157,6 +2157,7 @@ impl Interpreter {
             escaped_our_sub_names: std::collections::HashSet::new(),
             state_vars: HashMap::new(),
             thread_redeclared_vars: std::collections::HashSet::new(),
+            thread_decl_in_flight: std::collections::HashSet::new(),
             type_body_written_lexicals: std::collections::HashSet::new(),
             closure_captured_state: HashMap::new(),
             once_values: Arc::new(crate::runtime::once_store::OnceStore::default()),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -169,7 +169,14 @@ impl Interpreter {
                 // EXCEPT names this thread re-declared: their entry (if any)
                 // belongs to the shadowed outer binding, so bind the current one
                 // into this lineage, shadowing the ancestor's.
-                if self.thread_redeclared_vars.contains(&key) {
+                // A declaration still in flight has no "current" value to bind:
+                // `val` is the binding this `my` is about to shadow, so publishing
+                // it would overwrite the lane with a value that is about to be
+                // stale. Seed it only to give the child *something* under the name
+                // (it captured the outer binding), and keep the mask below.
+                if self.thread_redeclared_vars.contains(&key)
+                    && !self.thread_decl_in_flight.contains(&key)
+                {
                     shared.declare(&key, val.clone());
                 } else {
                     shared.seed_if_absent(&key, || val.clone());
@@ -206,8 +213,19 @@ impl Interpreter {
         // the next `await`'s `sync_shared_vars_to_env` pull the stale Nil back
         // over the live binding (`$port` in roast S17-promise/
         // nonblocking-await.t's socket server went Nil → connect to port 0).
-        self.thread_redeclared_vars
-            .retain(|n| captured_scalars.contains(n.trim_start_matches('$')));
+        //
+        // A name whose declaration is still IN FLIGHT is excluded for the same
+        // reason from the other direction: the seed above took the value of the
+        // binding this `my` is about to SHADOW, because the initializer that
+        // produced this very spawn has not stored anything yet. Unmasking would
+        // let the next `sync_shared_vars_to_env` pull that outer value back over
+        // the new binding — `my $tap = IO::Socket::Async.listen(...).tap({...})`
+        // in a loop reverted to the previous iteration's `Tap`, which is what
+        // made a restarted `Cro::HTTP::Server` keep answering from the old one.
+        self.thread_redeclared_vars.retain(|n| {
+            captured_scalars.contains(n.trim_start_matches('$'))
+                || self.thread_decl_in_flight.contains(n)
+        });
         let mut referenced_handle_ids = std::collections::HashSet::new();
         for value in self.env.values() {
             if let Some(id) = Self::handle_id_from_value(value) {
@@ -417,6 +435,9 @@ impl Interpreter {
             // stay env-local, and a stale same-named ancestor entry must not be
             // pulled over the captured copy at a sync point.
             thread_redeclared_vars: captured_scalars.clone(),
+            // The child starts no declaration of its own; its own `my`s populate
+            // this as they run.
+            thread_decl_in_flight: std::collections::HashSet::new(),
             // A worker can instantiate a type registered on the parent, so the
             // set of method-written lexicals travels with the clone.
             type_body_written_lexicals: self.type_body_written_lexicals.clone(),

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -248,6 +248,14 @@ impl Interpreter {
         // local AND persist the cell so a call after the block reads the live value.
         let box_decl_our = self.vardecl_context && !code.needs_cell_escaping_our_sub.is_empty();
         let r = self.exec_set_local_op_inner(code, idx);
+        // The store that ends a declaration's in-flight window: from here the
+        // slot holds the new binding, so a spawn may unmask the name again (see
+        // `thread_decl_in_flight`). Only ever non-empty in threaded programs.
+        if !self.thread_decl_in_flight.is_empty()
+            && let Some(name) = code.locals.get(idx as usize)
+        {
+            self.thread_decl_in_flight.remove(name);
+        }
         // Phase 3 Stage 2: write-through scalar attribute writes to the cell.
         if r.is_ok() {
             self.sync_our_package_var_from_local(code, idx as usize);
@@ -1928,6 +1936,12 @@ impl Interpreter {
                 .any(|(_, key)| key.contains(&format!("::{}@", name)));
             if !is_state {
                 self.thread_redeclared_vars.insert(name.to_string());
+                // The initializer has not run yet, so neither this frame's slot
+                // nor `env` holds the new binding. Mark the window so a spawn
+                // performed BY the initializer cannot unmask the name and let the
+                // shadowed outer value be pulled back over it
+                // (`thread_decl_in_flight`). Cleared by the store that ends it.
+                self.thread_decl_in_flight.insert(name.to_string());
             }
         }
         // A fresh declaration without an explicit type must not inherit stale

--- a/t/io-socket-async-relisten-loop.t
+++ b/t/io-socket-async-relisten-loop.t
@@ -1,0 +1,46 @@
+use Test;
+
+plan 5;
+
+# A `my $tap` declared in a loop body whose INITIALIZER spawns a worker
+# (`.tap` on a listening socket) used to revert to the previous iteration's
+# Tap as soon as a connection was accepted: the spawn happened while the
+# declaration was still in flight, so the cross-thread store was seeded with
+# the binding this `my` was about to shadow and the re-declaration mask was
+# dropped, letting the next sync pull that stale value back over the slot.
+#
+# Consequence: `$tap.close` closed the PREVIOUS round's listener and left the
+# current one bound forever — the "a stopped server keeps answering" family.
+
+# Never hardcode a port: ask the OS for one and reuse the number.
+my $probe = IO::Socket::Async.listen('localhost', 0);
+my $probe-tap = $probe.tap(-> $conn { $conn.close });
+my $port = $probe-tap.socket-port.result;
+$probe-tap.close;
+
+ok $port > 0, 'got an ephemeral port to re-listen on';
+
+my @seen;
+my $rounds-completed = 0;
+
+for ^3 -> $round {
+    my $tap = IO::Socket::Async.listen('localhost', $port).tap(-> $conn { $conn.close });
+    my $client = await IO::Socket::Async.connect('localhost', $port);
+    $client.close;
+    @seen.push($tap.WHICH.Str);
+    $tap.close;
+    $rounds-completed++;
+}
+
+is $rounds-completed, 3, 'all three re-listen rounds completed';
+is @seen.elems, 3, 'observed one Tap per round';
+is @seen.unique.elems, 3, 'each round observed its OWN Tap, not an earlier one';
+
+# The listener really was released each round: a fourth listen on the same
+# port still succeeds.
+my $again = IO::Socket::Async.listen('localhost', $port);
+my $again-tap = $again.tap(-> $conn { $conn.close });
+my $last = await IO::Socket::Async.connect('localhost', $port);
+$last.close;
+$again-tap.close;
+pass 'the port is still bindable after the loop';

--- a/todo/tickets/async-listener-not-freed-when-relistening-in-a-loop.md
+++ b/todo/tickets/async-listener-not-freed-when-relistening-in-a-loop.md
@@ -1,96 +1,67 @@
-# A `my $tap` in a loop body reverts to the previous iteration's Tap once a connection is accepted
+# A third server bound to the same port returns empty bodies
 
-```raku
-my $port = 31427;
-for ^3 -> $round {
-    my $tap = IO::Socket::Async.listen('localhost', $port).tap(-> $c { $c.close; });
-    my $c = await IO::Socket::Async.connect('localhost', $port);   # <- the trigger
-    $c.close;
-    note "round $round tap=", $tap.WHICH;
-    $tap.close;
-}
+## Fixed part (do not re-derive)
+
+The loop-body `my $tap` that reverted to the previous iteration's `Tap` once a
+connection was accepted is **fixed** — see
+`news/2026-08/decl-in-flight-spawn-must-not-unmask.md`. Root cause: the `.tap`
+in the *initializer* spawned a worker while the declaration was still in flight,
+so `clone_for_thread` seeded the shadowed outer value into the shared lane and
+dropped the re-declaration mask; the next `await`'s `sync_shared_vars_to_env`
+pulled it back over the slot. `thread_decl_in_flight` now keeps the mask for
+that window. Pinned by `t/io-socket-async-relisten-loop.t`.
+
+The earlier `IO::Socket::Async.listen` finding is also fixed:
+`TcpListener::bind(&str)` walked *every* address the host resolved to and took
+the first that succeeded, so a re-listen whose previous listener was still bound
+to `[::1]` quietly bound `127.0.0.1` instead — two listeners for one
+`localhost:port` (two LISTEN rows in `ss -tan`), and a client reached whichever
+its own resolution picked. `listen` now resolves once and binds that single
+address.
+
+## What still fails
+
+Re-binding one port across *more than two* rounds still breaks, and it is no
+longer a stale-`$tap` problem: each round now observes its own `Tap` and the
+port is still bindable afterwards (that is exactly what the pin test asserts).
+What fails is the **serving**, from round 2 on.
+
+`tmp/mw6.p6` (six sequential `Cro::HTTP::Server`s on one port, each `.start`ed,
+requested and `.stop`ped) prints:
+
+```
+round 2: OK
+round 2: OK
+round 2:          <- empty body from here on
+round 2:
+round 2:
+round 2:
 ```
 
-```
-round 0 tap=Tap|46
-round 1 tap=Tap|46      <- round 0's Tap object, not the one just created
-round 2 tap=Tap|77
-```
+Two things are wrong and they may or may not be the same bug:
 
-Without the `connect` (`tmp/cap10.p6`) every round gets its own Tap
-(`46 / 88 / 130`), including with an unrelated `await start { 1 }` in the body.
-It is accepting a **connection** that does it.
+1. **The body is empty from the third round on.** The first two servers answer
+   `OK`; every later one returns an empty body.
+2. **`$i` reads `2` in every iteration.** `say "round $i: $body"` prints `round
+   2` even in the first iteration — the `for ^6 -> $i` parameter, not a `my`.
+   This is NOT reproducible in isolation: `for ^4 -> $i { my $r = await start {
+   $i * 10 }; say "round $i: $r" }` is correct on mutsu and raku
+   (`tmp/loopvar.p6`), as is the socket-listen form. So it needs the Cro stack
+   to show up, and it is worth isolating before chasing (2) as its own bug —
+   it may be a symptom of (1) rather than a second defect.
 
-`gdb` on `native_tap` shows the same `attributes` pointer for round 0 and round 1
-(`attributes=0x7fffe00adb50` both times), and `register_async_listener` /
-`set_listener_closed` disagree: round 1 registers listener **2** and then closes
-listener **1**. So round 1's listener is never closed and stays bound forever.
+`t/http-middleware.rakutest` shows the same shape: its first subtest now passes
+4/4 (it used to hang there), the second subtest's four assertions all fail with
+an empty body, and the file then hangs — so a `timeout` is still needed when
+running it.
 
-## Why it matters
+The other multi-server files in the vendored Cro::HTTP suite —
+`http-auth-basic*`, `http-session-*`, `router-auth`, `http-log-file` — are the
+same family and are expected to move together with this.
 
-This is the whole "a stopped Cro server keeps serving" family, and it is what
-still blocks the vendored Cro::HTTP multi-server tests after
-`news/2026-08/supply-tap-close-cascades-upstream.md` made `Cro::Service.stop`
-close its pipeline properly:
+## Where to look next
 
-- `tmp/mw6.p6` (six sequential `Cro::HTTP::Server`s on one port) serves two
-  rounds and then returns empty bodies;
-- `t/http-middleware.rakutest` passes its first subtest 4/4 and then hangs;
-- `http-auth-basic`, `http-session-*` and `router-auth` are the same shape.
-
-It is almost certainly the "secondary anomaly" recorded with
-`news/2026-08/threaded-array-mutation-escapes-to-the-caller.md`: a
-`for 1..3 -> $i { say "round $i"; …Cro request…; say "round $i status" }` printed
-`round 2 status` in *every* iteration. Same shape — a loop-body scalar reverting
-to another iteration's value once a request has run. `tmp/mw6.p6` reproduces that
-one directly (it prints `round 2:` six times).
-
-## Where to look
-
-The accepted connection runs the tap callback on a spawned worker
-(`spawn_gc_helper_thread` / `spawn_user_thread` in
-`src/runtime/native_methods/socket_async.rs`), which arms the cross-thread shared
-lane. The caller's `my $tap` is a plain scalar, so the suspect is the stale
-snapshot path — `sync_shared_vars_to_env` / `pending_caller_var_writeback`
-pulling the previous iteration's value back over the live binding, the same
-mechanism `thread_redeclared_vars` masks for re-declared names
-(`src/runtime/runtime_shared_vars.rs`). Note the loop body's `my $tap` *is* a
-re-declaration each iteration, so either the mask is not being set here (the
-compiler skips `SetVarDynamic` for a `my` it considers already declared in the
-scope — see `is_default_init` / `already_declared` in `src/compiler/stmt.rs`) or
-it is being cleared by the spawn before the next round.
-
-Two facts are already established with `rust-gdb -batch`, so don't re-derive
-them:
-
-- **The mask *is* being set.** Breaking on the `thread_redeclared_vars.insert`
-  in `exec_set_var_dynamic_op` prints `c`, `tap`, `c`: round 0's `my $tap` runs
-  before any thread has armed the lane (so it is correctly not masked — there is
-  nothing to shadow yet) and round 1's `my $tap` *is* masked. So the write side
-  (`set_shared_var_sym`) and the bulk read side (`sync_shared_vars_to_env`) are
-  both already gated for this name.
-- **The stale value therefore arrives some other way.** `$tap.close` takes its
-  invocant off the stack from a `GetLocal`, and `exec_get_local_op` prefers
-  `self.locals[idx]` for a non-Nil scalar — so the suspect is a writeback into
-  the *slot* (or into `env` on a path that bypasses the slot) which skips the
-  mask. `sync_shared_vars_for_names` (`src/runtime/runtime_shared_vars.rs`) is
-  one such path: unlike `sync_shared_vars_to_env` it does **not** consult
-  `thread_redeclared_vars` at all. `pending_caller_var_writeback` /
-  `apply_pending_rw_writeback`, which drain a synced name straight into the
-  caller's slot, are the other two candidates. Check those three first.
-
-## Related, already fixed here
-
-`IO::Socket::Async.listen` used to `TcpListener::bind(&str)`, which walks *every*
-address the host resolves to and takes the first that succeeds. `localhost`
-resolves to both `[::1]` and `127.0.0.1`, so a re-listen whose previous listener
-was still bound to the first address quietly bound the *other* one: two listeners
-for one `localhost:port` coexisted (visible as two LISTEN rows in `ss -tan`), a
-client reached whichever its own resolution picked, and only a third round hit
-EADDRINUSE. `listen` now resolves once and binds that single address, so a
-genuinely-busy port is a real error the existing retry loop waits out — which is
-what made the stale-`$tap` bug above visible at round 2 instead of round 3.
-
-Pin when the `$tap` bug is fixed: a `t/io-socket-async-relisten-loop.t` running
-the loop above. Never hardcode a port — allocate one from a port-0 listen and
-reuse that number (per the `t/io-socket-recv-limit.t` lesson).
+The listener side is now sound, so start from the *connection* side: what the
+third `Cro::HTTP::Server` on a port does differently from the first two.
+`tmp/mw6.p6` is the smallest reproducer; `bash tmp/crorun.sh tmp/mw6.p6` runs it
+against the staged dists in `tmp/cro-work/` (it needs the release binary).


### PR DESCRIPTION
## Problem

A `my` whose **initializer** starts a worker thread could end up holding the value of the binding it was about to shadow. In a loop, every iteration's variable silently reverted to the previous iteration's:

```raku
for ^3 -> $round {
    my $tap = IO::Socket::Async.listen('localhost', $port).tap(-> $c { $c.close });
    my $c = await IO::Socket::Async.connect('localhost', $port);   # the trigger
    $c.close;
    note "round $round tap=", $tap.WHICH;   # 46 / 46 / 77
    $tap.close;
}
```

Round 1 printed round 0's `Tap`, so `$tap.close` closed the *previous* round's listener and left the current one bound forever. That is the whole "a stopped server keeps answering" family — `Cro::Service.stop` closes its pipeline through exactly this shape.

## Root cause

The cross-thread shared store is keyed by bare name, so it cannot represent two concurrently-live bindings of one name. `thread_redeclared_vars` masks a name a frame has re-declared; the mask is dropped again at the next `clone_for_thread`, which first force-`declare`s the name's *current* value into the lineage. That handshake rests on a premise — "the current value is the binding the mask was protecting" — which is false while a declaration is still **in flight**.

`my $tap = ...listen(...).tap(...)` runs `SetVarDynamic` (declare, mask set), evaluates the initializer, then stores. The `.tap` spawns a worker *during* the initializer, so `clone_for_thread` ran between the declaration and its store: neither the slot nor `env` held the new binding yet. The spawn published the outer value into the lineage and unmasked the name, and the `await`'s `sync_shared_vars_to_env` pulled it back over the slot the initializer had by then filled in.

`rust-gdb -batch` showed the sequence directly, one breakpoint per mechanism:

```
DECL "tap"  ->  CLONE_FOR_THREAD retain  ->  SYNC_SHARED_PUSH "tap"  ->  CALLERWB_APPLY "tap"
```

Round 2, where no spawn falls in that window, skips the last two.

## Fix

`thread_decl_in_flight` records the window between a declaration and the store that ends it (`SetVarDynamic` inserts, `exec_set_local_op` removes). Within it, `clone_for_thread` keeps the mask and seeds the name only if absent instead of force-declaring a value that is about to be stale. The window closes at the store, so the next spawn republishes the binding normally and a genuinely shared variable keeps working. The set is empty for single-threaded programs.

## Verification

- Pin: `t/io-socket-async-relisten-loop.t` — green on raku too; allocates its port from a port-0 listen rather than hardcoding one.
- Full local TAP suite: 2809 files / 26673 tests, all pass.
- All 99 whitelisted `S17-*` concurrency roast files pass on the release build.

## Effect on the vendored Cro::HTTP suite

`t/http-middleware.rakutest` no longer hangs at the end of its first subtest — it now runs the second subtest's assertions too. Serving from a *third* server bound to the same port still returns empty bodies, so the multi-server files are not green yet; that remaining facet stays tracked in `todo/tickets/async-listener-not-freed-when-relistening-in-a-loop.md`, which this PR rewrites to separate the fixed part from what is left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)