### PR TITLE
fix(threading): the I/O pre-sync must not republish the printing frame's locals

### DIFF
--- a/news/2026-08/io-presync-must-not-publish-to-the-shared-lane.md
+++ b/news/2026-08/io-presync-must-not-publish-to-the-shared-lane.md
@@ -1,0 +1,77 @@
+# A `say` no longer republishes the printing frame's locals to the cross-thread lane
+
+Restarting an HTTP server on one port worked twice and then answered 404:
+
+```
+round 0: status=200 body='OK'
+round 1: status=200 body='OK'
+round 2: ERR X::Cro::HTTP::Error::Client: Server responded with 404 Not Found (GET http://localhost:31419//)
+round 3: ERR X::Cro::HTTP::Error::Client: Server responded with 404 Not Found (GET http://localhost:31419///)
+```
+
+Note the target: the caller's own `my $url` had grown a `/` — once per request.
+Each round asked for `"$url/"`, and each round `$url` was one slash longer than
+the round before.
+
+## Root cause
+
+The cross-thread shared store is keyed by **bare name**. Three functions mirror a
+frame's local slots into `env` in bulk so that a name-based reader can see them:
+
+- `sync_env_from_locals` — frame teardown (`run_inner`),
+- `sync_env_from_locals_declared` — run before every Say/Put/Print/Note, so a
+  `$*OUT` override or a `.gist` sees fresh values,
+- `sync_regex_interpolation_env_from_locals` — the same for regex interpolation.
+
+They all go through `set_env_with_main_alias`, which does double duty: it writes
+`env` *and* publishes to the shared store, marking the name dirty. For the two
+incidental mirrors that is wrong twice over. The mirror walks whichever frame
+happens to be printing, so it republishes that frame's `$url` — a callee's
+parameter, say — into the lane that belongs to the caller's `my $url`; and the
+dirty mark it leaves makes the caller's next `sync_shared_vars_to_env` pull the
+lane's current content back over its own live slot. `rust-gdb` showed the chain
+end to end: `SYNCPUSH "url"` at the `await`, then `CALLERWB "url"` writing it
+into the caller's slot, then the corrupted value in the next round's request.
+
+## Fix
+
+`suppress_shared_publish` is set while those two incidental mirrors run;
+`set_shared_var_sym` then writes `env` only, leaving the lane and its dirty set
+untouched. Genuine cross-thread writes are unaffected — they publish from the
+assignment sites, which mirror per write (`flush_local_to_env`).
+
+Frame teardown (`sync_env_from_locals`) deliberately keeps publishing. There the
+frame's own bindings, parameters included, are exactly what a worker spawned from
+that routine must see by name: roast `S17-channel/stress.t`'s
+`sub bogosort_concurrent(@list)` reaches `@list` from inside a `start` block
+through this lane, and suppressing it made that sub read the *previous* sub's
+same-named parameter instead (`1 2 3 4 5`, the earlier `sleep_sort`'s answer,
+where `e l p r` was expected). That regression is what pinned down which of the
+three mirrors may publish.
+
+## Verification
+
+- Unit pins in `src/runtime/runtime_shared_vars_tests.rs`: a suppressed write
+  reaches `env` but neither updates nor dirties the lane; an ordinary write does
+  both.
+- Full local TAP suite (2810 files / 26678 tests) and all 99 whitelisted `S17-*`
+  concurrency roast files pass, as does a 487-file `S04`/`S05`/`S16`/`S32` slice.
+- Six sequential `Cro::HTTP::Server`s on one port (`tmp/mw6.p6`, `tmp/mw9.p6`)
+  now serve every round; before, rounds three onward returned 404 or an empty
+  body.
+
+A self-contained Raku reproducer could not be constructed: the chain needs a
+worker lineage to publish a same-named local at teardown *and* the main frame to
+have marked that name dirty from a print, and every synthetic arrangement tried
+was defeated by one of the existing masks (`block_captured_scalars` masks a
+`start` block's captured scalars; a plain sub call heals `env` with the caller's
+own value on its next print). Hence the unit pins on the mechanism itself.
+
+## Still open
+
+`t/http-middleware.rakutest` passes its first subtest 4/4 and then hangs, and the
+other multi-server files in the vendored Cro::HTTP suite are unchanged — see
+`todo/tickets/async-listener-not-freed-when-relistening-in-a-loop.md`. A separate
+bare-name collision also survives: a multi-parameter `for @x.kv -> $i, $c` binds
+by `Stmt::Assign` rather than declaring, so `Cro.compose`'s `$i` still leaks into
+a caller's `$i` (`todo/tickets/for-multi-param-shadow-clobbers-outer-lexical.md`).

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1381,6 +1381,24 @@ pub struct Interpreter {
     /// in-flight window closes that hole; the store is republished normally once
     /// the initializer's value lands. Empty for single-threaded programs.
     pub(crate) thread_decl_in_flight: std::collections::HashSet<String>,
+    /// Set while an *incidental* locals -> env mirror is running: the I/O
+    /// pre-sync (`sync_env_from_locals_declared`, run before Say/Put/Print/Note
+    /// so a `$*OUT` override or a `.gist` sees fresh values) and the regex
+    /// interpolation pre-sync. Both exist purely so a name-based reader in THIS
+    /// interpreter can observe the frame's live slots through `env`.
+    ///
+    /// `set_env_with_main_alias` does double duty: it writes `env` AND publishes
+    /// to the cross-thread shared store. Publishing from these two is wrong,
+    /// because the store is keyed by BARE NAME while the mirror walks *whichever
+    /// frame happens to be printing*: a callee's parameter `$url` overwrote the
+    /// lane belonging to the caller's own `my $url`, and the caller's next
+    /// `sync_shared_vars_to_env` pulled it back — `Cro::HTTP::Client.get("$url/")`
+    /// grew a `/` on the caller's URL on every request, so the third server on a
+    /// port answered 404.
+    ///
+    /// Frame *teardown* (`sync_env_from_locals`) is deliberately NOT suppressed;
+    /// see the comment there.
+    pub(crate) suppress_shared_publish: bool,
     /// Union of every executed `CompiledCode::type_body_written_lexicals`:
     /// lexicals written by a registered class/role method body. These keep the
     /// name-keyed `shared_vars` lane even when a spawned block also captures

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2158,6 +2158,7 @@ impl Interpreter {
             state_vars: HashMap::new(),
             thread_redeclared_vars: std::collections::HashSet::new(),
             thread_decl_in_flight: std::collections::HashSet::new(),
+            suppress_shared_publish: false,
             type_body_written_lexicals: std::collections::HashSet::new(),
             closure_captured_state: HashMap::new(),
             once_values: Arc::new(crate::runtime::once_store::OnceStore::default()),

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -358,7 +358,13 @@ impl Interpreter {
         // name is a fresh binding shadowing the captured outer lexical, so its
         // writes stay env-local; the next `clone_for_thread` binds the current
         // value into this lineage (`declare`) and clears the mask.
-        if self.shared_vars_active && !self.thread_redeclared_vars.contains(key) {
+        // A blanket locals -> env mirror is a coherence pass over THIS frame's
+        // slots, not an assignment: the bare-name lane must not be republished
+        // from it (see `suppress_shared_publish`).
+        if self.shared_vars_active
+            && !self.suppress_shared_publish
+            && !self.thread_redeclared_vars.contains(key)
+        {
             // Ensure @-variables always store Array(true) (real Arrays) in the
             // cross-thread shared store, which backs the atomic-array CAS
             // mechanism and expects non-flattening Array semantics. This must
@@ -653,3 +659,7 @@ impl Interpreter {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "runtime_shared_vars_tests.rs"]
+mod tests;

--- a/src/runtime/runtime_shared_vars_tests.rs
+++ b/src/runtime/runtime_shared_vars_tests.rs
@@ -1,0 +1,63 @@
+use super::*;
+use crate::value::Value;
+/// The incidental locals -> env mirrors (the I/O pre-sync before
+/// Say/Put/Print/Note, and the regex interpolation pre-sync) must reach
+/// `env` WITHOUT touching the cross-thread lane. The lane is keyed by bare
+/// name, so republishing whichever frame happens to be printing both
+/// overwrites another live binding's entry and — via `mark_shared_var_dirty`
+/// — makes the next `sync_shared_vars_to_env` pull that entry back over the
+/// printing frame's own slot.
+#[test]
+fn suppressed_publish_writes_env_but_not_the_shared_lane() {
+    let mut interp = Interpreter::new();
+    interp.shared_vars_active = true;
+    interp
+        .shared_vars
+        .declare("url", Value::str("lane".to_string()));
+
+    interp.suppress_shared_publish = true;
+    interp.set_shared_var_sym("url", None, Value::str("frame-local".to_string()));
+
+    assert_eq!(
+        interp.env.get("url").and_then(|v| match v.view() {
+            ValueView::Str(s) => Some(s.to_string()),
+            _ => None,
+        }),
+        Some("frame-local".to_string()),
+        "the mirror must still make the value visible by name in env"
+    );
+    assert_eq!(
+        interp.shared_vars.get("url").and_then(|v| match v.view() {
+            ValueView::Str(s) => Some(s.to_string()),
+            _ => None,
+        }),
+        Some("lane".to_string()),
+        "the cross-thread lane must be left alone"
+    );
+    assert!(
+        !interp.is_shared_var_dirty("url"),
+        "a suppressed mirror must not mark the name dirty, or the next \
+         sync pulls the lane back over the live binding"
+    );
+}
+
+/// The same call with the flag clear is a genuine assignment and publishes.
+#[test]
+fn unsuppressed_write_publishes_to_the_shared_lane() {
+    let mut interp = Interpreter::new();
+    interp.shared_vars_active = true;
+    interp
+        .shared_vars
+        .declare("url", Value::str("lane".to_string()));
+
+    interp.set_shared_var_sym("url", None, Value::str("assigned".to_string()));
+
+    assert_eq!(
+        interp.shared_vars.get("url").and_then(|v| match v.view() {
+            ValueView::Str(s) => Some(s.to_string()),
+            _ => None,
+        }),
+        Some("assigned".to_string())
+    );
+    assert!(interp.is_shared_var_dirty("url"));
+}

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -438,6 +438,7 @@ impl Interpreter {
             // The child starts no declaration of its own; its own `my`s populate
             // this as they run.
             thread_decl_in_flight: std::collections::HashSet::new(),
+            suppress_shared_publish: false,
             // A worker can instantiate a type registered on the parent, so the
             // set of method-written lexicals travels with the clone.
             type_body_written_lexicals: self.type_body_written_lexicals.clone(),

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1171,6 +1171,13 @@ impl Interpreter {
         fully
     }
 
+    /// Unlike the two mirrors below, this one DOES keep publishing to the
+    /// cross-thread store. It runs at frame teardown (`run_inner`), where the
+    /// frame's own bindings — parameters included — are exactly what a worker
+    /// spawned from this routine must see under their names: roast
+    /// `S17-channel/stress.t`'s `sub bogosort_concurrent(@list)` reaches its
+    /// `@list` from inside a `start` block through this lane, and without the
+    /// publish it read the *previous* sub's same-named parameter instead.
     pub(super) fn sync_env_from_locals(&mut self, code: &CompiledCode) {
         for (i, name) in code.locals.iter().enumerate() {
             // §1.4 shadow slots: a name occupying several slots (an inner-block
@@ -1214,6 +1221,8 @@ impl Interpreter {
     /// either already present in env (declared, captured, `our`, dynamic) or
     /// forced there by the reflective-access flag — never slot-only.
     pub(super) fn sync_env_from_locals_declared(&mut self, code: &CompiledCode) {
+        let saved_suppress = self.suppress_shared_publish;
+        self.suppress_shared_publish = true;
         for (i, name) in code.locals.iter().enumerate() {
             if code.dup_named_locals.get(i).copied().unwrap_or(false) {
                 continue;
@@ -1223,9 +1232,12 @@ impl Interpreter {
             }
             self.set_env_with_main_alias(name, self.locals[i].clone());
         }
+        self.suppress_shared_publish = saved_suppress;
     }
 
     pub(super) fn sync_regex_interpolation_env_from_locals(&mut self, code: &CompiledCode) {
+        let saved_suppress = self.suppress_shared_publish;
+        self.suppress_shared_publish = true;
         for (i, name) in code.locals.iter().enumerate() {
             if name == "_"
                 || name == "/"
@@ -1260,6 +1272,7 @@ impl Interpreter {
             }
             self.set_env_with_main_alias(name, self.locals[i].clone());
         }
+        self.suppress_shared_publish = saved_suppress;
     }
 
     /// Check if a local name looks like a bare function parameter (no sigil).

--- a/todo/tickets/for-multi-param-shadow-clobbers-outer-lexical.md
+++ b/todo/tickets/for-multi-param-shadow-clobbers-outer-lexical.md
@@ -30,6 +30,32 @@ correct saved value) yet the post-loop read still saw the loop value, so the
 post-loop `GetLocal` resolves a *different* slot. Working out which slot each
 side owns is the actual work here.
 
+## It also leaks across frames through the cross-thread lane
+
+Because the binding is a `Stmt::Assign`, it compiles to a by-name store, which
+publishes into the bare-name cross-thread lane exactly like an ordinary
+assignment — a real `my` would have been masked by `thread_redeclared_vars`. So
+the loop parameter of a multi-param `for` in one routine overwrites a *different*
+routine's live same-named lexical:
+
+```
+for ^3 -> $i { ...anything that awaits a Cro request... ; say "round $i" }
+```
+
+printed `round 2` in every iteration, because `Cro.compose`'s
+`for @components-in.kv -> $i, $comp` (`Cro.rakumod:560`, six components) had
+published its own `$i` under the bare name `i`, and the caller's `await` pulled
+it back. Confirmed with `rust-gdb` breaking on the shared-store write: the
+backtrace is `set_env_with_main_alias("i") <- exec_for_loop_body <-
+call_compiled_method("Cro", "compose")`. Renaming the caller's loop variable
+makes it go away, which is how it was isolated.
+
+This is the strongest argument for fixing the binding form itself (making the
+multi-param bind a real per-iteration declaration) rather than patching the
+save/restore: one change would settle the value clobber, this lane leak, and the
+type-constraint save/restore added in
+`news/2026-08/for-multi-param-stale-type-constraint.md`.
+
 ## Why it matters
 
 Same family as the shared-lane container escape


### PR DESCRIPTION
## Problem

Restarting an HTTP server on one port worked twice and then answered 404:

```
round 0: status=200 body='OK'
round 1: status=200 body='OK'
round 2: ERR X::Cro::HTTP::Error::Client: Server responded with 404 Not Found (GET http://localhost:31419//)
round 3: ERR X::Cro::HTTP::Error::Client: Server responded with 404 Not Found (GET http://localhost:31419///)
```

Look at the target: the caller's own `my $url` had grown a `/` — once per request.

## Root cause

The cross-thread shared store is keyed by **bare name**. Three functions mirror a frame's local slots into `env` in bulk so a name-based reader can see them:

| mirror | when | purpose |
| --- | --- | --- |
| `sync_env_from_locals` | frame teardown (`run_inner`) | callers observe a routine's side effects |
| `sync_env_from_locals_declared` | before every Say/Put/Print/Note | a `$*OUT` override / `.gist` sees fresh values |
| `sync_regex_interpolation_env_from_locals` | before regex interpolation | same, for interpolated regexes |

All three go through `set_env_with_main_alias`, which does double duty: it writes `env` **and** publishes to the shared store, marking the name dirty. For the two *incidental* mirrors that is wrong twice over — the mirror walks whichever frame happens to be printing, so it republishes that frame's `$url` (a callee's parameter) into the lane belonging to the caller's `my $url`, and the dirty mark makes the caller's next `sync_shared_vars_to_env` pull the lane's content back over its own live slot.

`rust-gdb -batch` showed the chain end to end — `SYNCPUSH "url"` at the `await`, then `CALLERWB "url"` writing it into the caller's slot, then the corrupted value in the next round's request.

## Fix

`suppress_shared_publish` is set while those two incidental mirrors run; `set_shared_var_sym` then writes `env` only, leaving the lane and its dirty set untouched. Genuine cross-thread writes are unaffected — they publish from the assignment sites, which mirror per write (`flush_local_to_env`).

**Frame teardown deliberately keeps publishing.** There the frame's own bindings, parameters included, are exactly what a worker spawned from that routine must see by name: suppressing it too made roast `S17-channel/stress.t`'s `sub bogosort_concurrent(@list)` read the *previous* sub's same-named parameter from inside its `start` block (got `1 2 3 4 5`, the earlier `sleep_sort`'s answer, expecting `e l p r`). That regression is what pinned down which of the three mirrors may publish.

## Verification

- Unit pins in `src/runtime/runtime_shared_vars_tests.rs`: a suppressed write reaches `env` but neither updates nor dirties the lane; an ordinary write does both.
- Full local TAP suite: 2810 files / 26678 tests, all pass.
- All 99 whitelisted `S17-*` concurrency roast files pass, plus a 487-file `S04`/`S05`/`S16`/`S32` slice (74432 tests).
- Six sequential `Cro::HTTP::Server`s on one port now serve every round; before, rounds three onward returned 404 or an empty body.

A self-contained Raku reproducer could not be constructed — the chain needs a worker lineage to publish a same-named local at teardown *and* the main frame to have marked that name dirty from a print, and every synthetic arrangement tried was defeated by one of the existing masks. The news entry records what was tried; hence the unit pins on the mechanism itself.

## Still open

Recorded, not fixed here: `t/http-middleware.rakutest` still hangs after its first subtest, and a multi-parameter `for @x.kv -> $i, $c` binds by `Stmt::Assign` rather than declaring, so `Cro.compose`'s `$i` still leaks into a caller's `$i` — this PR adds that finding (with its gdb backtrace) to `todo/tickets/for-multi-param-shadow-clobbers-outer-lexical.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)