### PR TITLE
fix(parser): three parse failures keep their X::Syntax::Malformed class

### DIFF
--- a/news/2026-08/three-parse-failures-keep-their-malformed-class.md
+++ b/news/2026-08/three-parse-failures-keep-their-malformed-class.md
@@ -1,0 +1,53 @@
+# Three parse failures keep their `X::Syntax::Malformed` class
+
+The `right exception type (X::Syntax::Malformed)` cluster was the largest named
+group in the real-`Test` roast residue, three files deep. None of the three was
+a construct mutsu failed to reject — it rejected all three. Each rejection was a
+*soft* parse error, so the enclosing alternative backtracked and the failure came
+out as the parser's generic "Confused." with no class at all.
+
+| construct | raku says | reached mutsu as |
+| --- | --- | --- |
+| `my $x = ` | `Malformed initializer` | `X::Syntax::Confused` |
+| `.::` | `Malformed class-qualified postfix call` | `X::Syntax::Confused` |
+| `:7` / `:7\x[308]a` | `Malformed radix number` | `X::Syntax::Confused` |
+
+All three are now fatal errors carrying a real `X::Syntax::Malformed` with the
+`.what` the roast tests match on, built by a new shared
+`PError::malformed(what)` — there were already three hand-rolled copies of that
+five-line construction in the parser.
+
+`roast/S04-statements/terminator.t` and `roast/S02-literals/pairs.t` pass under
+`MUTSU_REAL_TEST=1`. `roast/S12-methods/qualified.t`'s assertion passes too; the
+file moves on to an unrelated `Cannot dispatch to method me on Parent` in its
+inheritance subtest.
+
+## The `.::` half was two different code paths
+
+`$x.::` already produced a Malformed — with mutsu's own wording ("Malformed
+qualified method name"), now raku's. But `.::` at statement start is the *topic*
+form and never reached that check, so it fell through every alternative. Both
+paths raise the same error now.
+
+## What the initializer fix had to learn: only when nothing was readable
+
+The first version converted *every* RHS failure after `=` into "Malformed
+initializer", and local `make roast` caught two regressions that `make test` did
+not: `my @a = 1, => 2` must be `X::Syntax::InfixInTermPosition`
+(`roast/S32-exceptions/misc2.t`) and
+`my $foo = { given $bar { when Real { 1 } ... } }` must be plain
+`X::Syntax::Confused` — both had produced the better diagnosis already and the
+blanket conversion masked it. `roast/S03-operators/ternary.t` lost
+`X::Syntax::ConditionalOperator::PrecedenceTooLoose` the same way.
+
+So the conversion applies only when the RHS parse failed *without consuming
+anything*, and never over an error that is already fatal or already carries a
+classified exception. An initializer that parsed part of itself keeps its own
+diagnosis, which is what rakudo reports too.
+
+This is the second time in two days that a new diagnostic was only safe once it
+was measured against the full roast suite rather than `make test` — see
+`news/2026-08/metaop-doubled-infix-base.md`.
+
+Pin: `t/malformed-syntax-classes.t`, which asserts both directions — the three
+classes, and the two failures that must *not* be flattened into them.

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -990,9 +990,7 @@ fn postfix_expr_loop_from(
                     rest = r2;
                     continue;
                 } else {
-                    return Err(PError::fatal(
-                        "X::Syntax::Malformed: Malformed qualified method name".to_string(),
-                    ));
+                    return Err(PError::malformed("class-qualified postfix call"));
                 }
             }
             // Parse method name

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -89,6 +89,33 @@ impl PError {
         }
     }
 
+    /// Build the fatal `X::Syntax::Malformed` rakudo throws when a construct is
+    /// recognised but its body cannot be read — `Malformed initializer`,
+    /// `Malformed class-qualified postfix call`, ... `what` is both the tail of
+    /// the message and the exception's `.what` attribute, which the roast tests
+    /// match on.
+    ///
+    /// These are always *fatal*: the construct's opener is the commit point, so
+    /// letting the alternative backtrack only loses the diagnosis to the
+    /// parser's generic "Confused."
+    pub fn malformed(what: &str) -> Self {
+        let message = format!("X::Syntax::Malformed: Malformed {}", what);
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert(
+            "message".to_string(),
+            crate::value::Value::str(message.clone()),
+        );
+        attrs.insert(
+            "what".to_string(),
+            crate::value::Value::str(what.to_string()),
+        );
+        let exception = crate::value::Value::make_instance(
+            crate::symbol::Symbol::intern("X::Syntax::Malformed"),
+            attrs,
+        );
+        PError::fatal_with_exception(message, Box::new(exception))
+    }
+
     /// Build the fatal `X::Comp::Group` rakudo throws when one construct draws
     /// *two* complaints: a specific diagnosis plus the fatal one it leads to.
     ///

--- a/src/parser/primary/misc/colonpair.rs
+++ b/src/parser/primary/misc/colonpair.rs
@@ -28,9 +28,14 @@ pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
     if digit_end > 0 && r[digit_end..].starts_with('<') {
         return Err(PError::expected("generic radix literal"));
     }
-    // :2 or :36 alone (digits with no <, (, or [ suffix) is a malformed radix literal.
-    // Only trigger this when the remaining part doesn't start with an identifier char
-    // (to avoid blocking :123name colonpairs).
+    // `:2` / `:36` with no `<`, `(` or `[` body and no identifier after it is a
+    // malformed radix literal — raku's "Malformed radix number". The identifier
+    // exclusion is what keeps `:123name` (a numeric-value colonpair) parsing;
+    // note a *combining mark* is not alphabetic, so `:7\x[308]a` lands here
+    // exactly as raku's does (`roast/S02-literals/pairs.t`).
+    //
+    // Fatal, not a soft decline: with nothing left that could parse this text,
+    // a soft error only loses the diagnosis to the parser's generic "Confused."
     if digit_end > 0 {
         let after = &r[digit_end..];
         let next_ch = after.chars().next();
@@ -41,7 +46,7 @@ pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
             && !after.starts_with('(')
             && !after.starts_with('[')
         {
-            return Err(PError::expected("generic radix literal"));
+            return Err(PError::malformed("radix number"));
         }
     }
     // :[ ... ]: itemized array literal — `:[]` is `$[]`, `:[1,2]` is `$[1,2]`

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -1090,6 +1090,16 @@ pub(in crate::parser::primary) fn topic_method_call(input: &str) -> PResult<'_, 
         return Err(PError::expected("topic method call"));
     }
     let r = &input[1..];
+    // `.::` with no name after it is the same error as the postfix form
+    // (`$x.::`) — raku's "Malformed class-qualified postfix call". The topic
+    // form never reached that check, so a bare `.::` fell through every
+    // alternative and came out as the generic "Confused."
+    // (`roast/S12-methods/qualified.t`).
+    if let Some(after_colons) = r.strip_prefix("::")
+        && !after_colons.starts_with(|c: char| c.is_alphanumeric() || c == '_')
+    {
+        return Err(PError::malformed("class-qualified postfix call"));
+    }
     // .=method — mutating topic method call: $_ = $_.method(args)
     if let Some(stripped) = r.strip_prefix('=') {
         let (r, _) = ws(stripped)?;

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -300,6 +300,30 @@ where
 }
 
 /// Handle simple assignment (`=`).
+/// A declaration whose `=` is followed by *nothing readable* is
+/// `X::Syntax::Malformed`, `what => 'initializer'` — raku's "Malformed
+/// initializer" for `my $x = `. The `=` is the commit point: past it there is no
+/// other reading of the text, so the error is *fatal* rather than a soft one
+/// that lets the whole declaration alternative backtrack. Left soft, it reached
+/// the parser's generic "Confused." and lost the class
+/// (`roast/S04-statements/terminator.t`).
+///
+/// "Nothing readable" is the load-bearing part, and only `rhs_input` can tell us
+/// so. An RHS that parsed *some* of itself before failing has already produced
+/// the better diagnosis, and rakudo reports that one instead — `my @a = 1, => 2`
+/// is `X::Syntax::InfixInTermPosition` and `my $foo = { given $bar { when Real
+/// { 1 } ... } }` is plain `X::Syntax::Confused`, both of which this masked
+/// when it converted every failure (`roast/S32-exceptions/misc2.t`,
+/// `roast/S03-operators/ternary.t`). A fatal or already-classified error is
+/// likewise left alone.
+fn malformed_initializer(err: PError, rhs_input: &str) -> PError {
+    let failed_immediately = err.remaining_len.is_none_or(|len| len >= rhs_input.len());
+    if err.exception.is_some() || err.is_fatal() || !failed_immediately {
+        return err;
+    }
+    PError::malformed("initializer")
+}
+
 fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
     let (rest, _) = ws(input)?;
     // class-scope routine aliasing form:
@@ -348,10 +372,12 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
     // The RHS is parsed at a precedence that stops before the loose
     // word-logicals (`and`/`or`/`andthen`/...): in Raku they are looser than the
     // declaration's `=`, so `my $x = 1 and 2` is `(my $x = 1) and 2`.
+    let rhs_input = rest;
     let (rest, expr) = if s.is_array || s.is_hash {
-        parse_assign_expr_or_comma_no_word_logical(rest)?
+        parse_assign_expr_or_comma_no_word_logical(rest)
+            .map_err(|e| malformed_initializer(e, rhs_input))?
     } else {
-        expression_no_word_logical(rest)?
+        expression_no_word_logical(rest).map_err(|e| malformed_initializer(e, rhs_input))?
     };
     // Capture a trailing word-logical tail, seeded by a re-read of the declared
     // variable. It is re-attached below as a scopeless `SyntheticBlock` second

--- a/t/malformed-syntax-classes.t
+++ b/t/malformed-syntax-classes.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+plan 11;
+
+# Three constructs rakudo diagnoses as X::Syntax::Malformed. mutsu had already
+# rejected all three, but each rejection was a *soft* parse error, so the
+# declaration/call alternative backtracked and the failure came out as the
+# parser's generic "Confused." with no class at all.
+
+# `my $x = ` — the `=` is the commit point, so an unreadable RHS is a malformed
+# initializer rather than a reason to reconsider the whole declaration.
+throws-like 'my $x = ', X::Syntax::Malformed, what => 'initializer';
+throws-like 'my @a = ', X::Syntax::Malformed, what => 'initializer';
+throws-like 'my $x = ;', X::Syntax::Malformed, what => 'initializer';
+
+# ...but only when *nothing* of the RHS could be read. An initializer that
+# parsed part of itself has already produced the better diagnosis, and that one
+# wins — flattening every failure to "Malformed initializer" masked these two.
+throws-like 'my @a = 1, => 2', X::Syntax::InfixInTermPosition, infix => '=>';
+throws-like 'my $foo = { given 1 { when Real { 1 } when Str { 2 } } };',
+    X::Syntax::Confused;
+
+# `.::` — a class-qualified postfix call with no name after the `::`. The
+# postfix form already said so; the *topic* form (`.::` at statement start)
+# never reached that check.
+throws-like '.::', X::Syntax::Malformed, what => 'class-qualified postfix call';
+throws-like 'my $x; $x.::', X::Syntax::Malformed,
+    what => 'class-qualified postfix call';
+
+# `:7` — digits after the colon with no `<`/`(`/`[` body and no identifier is a
+# malformed radix number. A combining mark is not alphabetic, so the synthetic
+# numeral `:7\x[308]a` lands here too rather than reading as a `:name(7)` pair.
+throws-like ':7', X::Syntax::Malformed, what => 'radix number';
+throws-like ":7\x[308]a", X::Syntax::Malformed, what => 'radix number';
+
+# The neighbouring forms these three must not swallow.
+is-deeply EVAL(':7a'), (a => 7), ':<digits><identifier> is still a numeric colonpair';
+is :16<ff>, 255, 'a radix literal with a body still parses';


### PR DESCRIPTION
The `right exception type (X::Syntax::Malformed)` cluster was the largest named
group in the real-`Test` roast residue. None of the three files was a construct
mutsu failed to reject — it rejected all three. Each rejection was a *soft*
parse error, so the enclosing alternative backtracked and the failure came out
as the parser's generic "Confused." with no class at all.

| construct | raku says | reached mutsu as |
| --- | --- | --- |
| `my $x = ` | `Malformed initializer` | `X::Syntax::Confused` |
| `.::` | `Malformed class-qualified postfix call` | `X::Syntax::Confused` |
| `:7` / `:7\x[308]a` | `Malformed radix number` | `X::Syntax::Confused` |

All three now raise a fatal error carrying a real `X::Syntax::Malformed` with
the `.what` the roast tests match on, built by a new shared
`PError::malformed(what)` — there were already three hand-rolled copies of that
five-line construction in the parser.

The `.::` half was two different code paths: `$x.::` already produced a
Malformed (with mutsu's own wording, now raku's), but `.::` at statement start
is the *topic* form and never reached that check.

### What the initializer fix had to learn

The first version converted *every* RHS failure after `=` into "Malformed
initializer", and local `make roast` caught three regressions that `make test`
did not:

- `my @a = 1, => 2` must be `X::Syntax::InfixInTermPosition`
- `my $foo = { given $bar { when Real { 1 } ... } }` must be plain `X::Syntax::Confused`
- a too-loose ternary adverb must be `X::Syntax::ConditionalOperator::PrecedenceTooLoose`

All three had produced the better diagnosis already and the blanket conversion
masked it. So the conversion applies only when the RHS parse failed *without
consuming anything*, and never over an error that is already fatal or already
carries a classified exception — which is what rakudo reports too.

`roast/S04-statements/terminator.t` and `roast/S02-literals/pairs.t` pass under
`MUTSU_REAL_TEST=1`; `roast/S12-methods/qualified.t`'s assertion passes and the
file moves on to an unrelated inheritance-dispatch failure.

Pin: `t/malformed-syntax-classes.t`, which asserts both directions — the three
classes, and the two failures that must *not* be flattened into them.

Local `make test` (2815 files) and `make roast` (1435 files) both PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)