### PR TITLE
refactor(runtime): admit user candidates to method table

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -160,5 +160,12 @@ The dispatch layer now has a canonical `BuiltinMethodEntry` keyed by owner type 
 Built-in introspection derives its name list from those entries. The
 runtime `Registry` owns those entries in a `(owner, method)` map, seeds them from static data at
 construction without invoking native handlers, and serves built-in introspection from that map.
-Replacing the transitional arity-specific dispatch functions with static native handler IDs, then
-admitting user candidates into the same entry type, remains open.
+Replacing the transitional arity-specific dispatch functions with static native handler IDs and
+routing dispatch reads through the shared entry remain open.
+
+`MethodEntry` now carries both an optional built-in descriptor and ordered user candidates, so a
+user override and its built-in fallback share one `(owner, method)` row. Class declaration,
+rollback, augmentation, role composition, MOP `add_method`, partial registration, and `EVAL`
+restoration synchronize user candidates into the table. Dispatch still reads the compatibility
+`ClassDef::methods` mirror until compiled-candidate replacement and generation invalidation move
+with it in the next stage.

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -765,6 +765,7 @@ impl Interpreter {
                 if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
                     class_def.methods.insert(method_name, vec![def]);
                 }
+                self.registry_mut().sync_user_method_entries(&class_name);
                 // Class shape changed (an added BUILD/TWEAK/new flips ctor
                 // eligibility) — drop cached construction plans.
                 self.native_ctor_plan_cache.clear();
@@ -821,6 +822,7 @@ impl Interpreter {
                         false
                     };
                 if inserted {
+                    self.registry_mut().sync_user_method_entries(&class_name);
                     self.native_ctor_plan_cache.clear();
                     return Ok(Value::NIL);
                 }

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -343,6 +343,7 @@ impl Interpreter {
             self.compose_role_into_augmented_class(name, role_name);
         }
 
+        self.registry_mut().sync_user_method_entries(name);
         self.set_current_package(saved_package);
         Ok(())
     }
@@ -437,6 +438,7 @@ impl Interpreter {
             .entry(name.to_string())
             .or_default()
             .extend(composed);
+        self.registry_mut().sync_user_method_entries(name);
         // Recompile so the fast path sees the newly composed methods.
         self.compile_class_methods(name);
     }

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -404,6 +404,8 @@ impl Interpreter {
         let mut def = self.registry_mut().classes.remove(old_name)?;
         def.mro = std::sync::Arc::from(Vec::<Symbol>::new());
         self.registry_mut().classes.insert(new_name.clone(), def);
+        self.registry_mut().sync_user_method_entries(old_name);
+        self.registry_mut().sync_user_method_entries(&new_name);
         if self.user_declared_classes.remove(old_name) {
             self.user_declared_classes.insert(new_name.clone());
         }
@@ -506,6 +508,8 @@ impl Interpreter {
             } else {
                 reg.class_role_param_bindings.remove(name);
             }
+            drop(reg);
+            this.registry_mut().sync_user_method_entries(name);
         };
 
         // Detect X::Redeclaration when a class redefines a role in the same scope.
@@ -1577,11 +1581,13 @@ impl Interpreter {
         self.registry_mut()
             .classes
             .insert(name.to_string(), class_def.clone());
+        self.registry_mut().sync_user_method_entries(name);
         if is_stub_body {
             self.registry_mut().class_stubs.insert(name.to_string());
             self.registry_mut()
                 .classes
                 .insert(name.to_string(), class_def);
+            self.registry_mut().sync_user_method_entries(name);
             let mut stack = Vec::new();
             let _ = self.compute_class_mro(name, &mut stack)?;
             return Ok(deferred_custom_traits);
@@ -2519,6 +2525,7 @@ impl Interpreter {
                     self.registry_mut()
                         .classes
                         .insert(name.to_string(), class_def.clone());
+                    self.registry_mut().sync_user_method_entries(name);
                     self.run_block_raw(std::slice::from_ref(stmt))?;
                     for outer_name in saved_env.keys() {
                         let class_scoped_name = format!("{}::{}", name, outer_name);
@@ -2597,6 +2604,7 @@ impl Interpreter {
                     self.registry_mut()
                         .classes
                         .insert(name.to_string(), class_def.clone());
+                    self.registry_mut().sync_user_method_entries(name);
                     // Mark this class as "being defined" so a `has`-attribute
                     // declaration executed by a *compile-time* phaser
                     // (`class Foo { BEGIN EVAL q[has $.x] }`) attaches to it
@@ -2658,6 +2666,7 @@ impl Interpreter {
             self.registry_mut()
                 .classes
                 .insert(name.to_string(), class_def.clone());
+            self.registry_mut().sync_user_method_entries(name);
         }
         // Fire class-body LEAVE phasers in LIFO order now that the body scope
         // is being left. They run while the class package/env are still active
@@ -2846,6 +2855,7 @@ impl Interpreter {
         self.registry_mut()
             .classes
             .insert(name.to_string(), class_def);
+        self.registry_mut().sync_user_method_entries(name);
         let mut stack = Vec::new();
         if let Err(err) = self.compute_class_mro(name, &mut stack) {
             restore_previous_state(self);

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -46,6 +46,12 @@ pub(crate) struct MethodEntryKey {
     pub(crate) name: Symbol,
 }
 
+#[derive(Clone, Default)]
+pub(crate) struct MethodEntry {
+    pub(crate) builtin: Option<crate::builtins::builtin_type_methods::BuiltinMethodEntry>,
+    pub(crate) user_candidates: Vec<MethodDef>,
+}
+
 /// Program declaration registry. See module docs.
 ///
 /// Fields are migrated here group-by-group (PLAN.md PR-A). Fields are
@@ -58,8 +64,7 @@ pub(crate) struct MethodEntryKey {
 pub(crate) struct Registry {
     /// Canonical type x method table. It initially owns the built-in entries;
     /// declaration registration will add user candidates to the same table.
-    pub(crate) method_entries:
-        HashMap<MethodEntryKey, crate::builtins::builtin_type_methods::BuiltinMethodEntry>,
+    pub(crate) method_entries: HashMap<MethodEntryKey, MethodEntry>,
     /// `enum Name (...)` declarations: enum name -> [(variant name, value)].
     pub(crate) enum_types: HashMap<String, Vec<(String, EnumValue)>>,
     /// `subset Name of Base where { ... }` declarations.
@@ -267,8 +272,9 @@ impl Registry {
                     owner: Symbol::intern(entry.owner),
                     name: Symbol::intern(entry.name),
                 };
-                let old = self.method_entries.insert(key, entry);
-                debug_assert!(old.is_none(), "duplicate built-in method entry");
+                let slot = self.method_entries.entry(key).or_default();
+                debug_assert!(slot.builtin.is_none(), "duplicate built-in method entry");
+                slot.builtin = Some(entry);
             }
         }
     }
@@ -282,10 +288,36 @@ impl Registry {
         let mut entries: Vec<_> = self
             .method_entries
             .iter()
-            .filter_map(|(key, entry)| (key.owner == owner).then_some(*entry))
+            .filter_map(|(key, entry)| (key.owner == owner).then_some(entry.builtin).flatten())
             .collect();
         entries.sort_unstable_by_key(|entry| entry.order);
         entries.into_iter().map(|entry| entry.name).collect()
+    }
+
+    pub(crate) fn sync_user_method_entries(&mut self, class_name: &str) {
+        let owner = Symbol::intern(class_name);
+        self.method_entries.retain(|key, entry| {
+            if key.owner == owner {
+                entry.user_candidates.clear();
+            }
+            entry.builtin.is_some() || !entry.user_candidates.is_empty()
+        });
+        let Some(methods) = self
+            .classes
+            .get(class_name)
+            .map(|class| class.methods.clone())
+        else {
+            return;
+        };
+        for (name, candidates) in methods {
+            self.method_entries
+                .entry(MethodEntryKey {
+                    owner,
+                    name: Symbol::intern(&name),
+                })
+                .or_default()
+                .user_candidates = candidates;
+        }
     }
 }
 
@@ -570,7 +602,7 @@ impl Registry {
     ) -> Option<Vec<MethodDef>> {
         self.classes
             .get(class_name)
-            .and_then(|c| c.methods.get(method_name))
+            .and_then(|class| class.methods.get(method_name))
             .cloned()
     }
 
@@ -719,10 +751,16 @@ mod tests {
             registry.builtin_method_names("Str"),
             crate::builtins::builtin_type_methods::introspected_type_method_names("Str")
         );
-        assert!(registry.method_entries.contains_key(&MethodEntryKey {
-            owner: Symbol::intern("Str"),
-            name: Symbol::intern("chars"),
-        }));
+        assert!(matches!(
+            registry.method_entries.get(&MethodEntryKey {
+                owner: Symbol::intern("Str"),
+                name: Symbol::intern("chars"),
+            }),
+            Some(MethodEntry {
+                builtin: Some(_),
+                ..
+            })
+        ));
     }
 
     #[test]
@@ -738,5 +776,44 @@ mod tests {
             registry.builtin_method_names("Method"),
             registry.builtin_method_names("Sub")
         );
+    }
+
+    #[test]
+    fn user_override_shares_the_builtin_method_entry() {
+        let mut registry = Registry::default();
+        registry.seed_builtin_method_entries();
+        let method = MethodDef {
+            lexical_package: "GLOBAL".to_string(),
+            params: Vec::new(),
+            param_defs: Vec::new(),
+            body: std::sync::Arc::new(Vec::new()),
+            is_rw: false,
+            is_private: false,
+            is_multi: false,
+            is_my: false,
+            role_origin: None,
+            original_role: None,
+            return_type: None,
+            compiled_code: None,
+            delegation: None,
+            is_default: false,
+            deprecated_message: None,
+            is_submethod: false,
+            captured_env: None,
+        };
+        let mut class = ClassDef::default();
+        class.methods.insert("chars".to_string(), vec![method]);
+        registry.classes.insert("Str".to_string(), class);
+        registry.sync_user_method_entries("Str");
+
+        let entry = registry
+            .method_entries
+            .get(&MethodEntryKey {
+                owner: Symbol::intern("Str"),
+                name: Symbol::intern("chars"),
+            })
+            .expect("Str.chars entry");
+        assert!(entry.builtin.is_some());
+        assert_eq!(entry.user_candidates.len(), 1);
     }
 }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2096,6 +2096,10 @@ impl Interpreter {
                     }
                     roles
                 };
+                let class_names: Vec<String> = registry.classes.keys().cloned().collect();
+                for class_name in class_names {
+                    registry.sync_user_method_entries(&class_name);
+                }
                 Arc::new(RwLock::new(registry))
             },
             registry_write_gen: std::sync::atomic::AtomicU64::new(0),

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -354,6 +354,7 @@ impl Interpreter {
                         class_def.methods.insert(resolved_method_name, vec![def]);
                     }
                 }
+                self.registry_mut().sync_user_method_entries(&class_name);
             } else {
                 remaining.push(stmt);
             }

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -425,6 +425,10 @@ impl Interpreter {
         self.registry_mut()
             .class_role_param_bindings
             .extend(current_class_role_param_bindings);
+        let class_names: Vec<String> = self.registry().classes.keys().cloned().collect();
+        for class_name in class_names {
+            self.registry_mut().sync_user_method_entries(&class_name);
+        }
         for key in current_type_keys.union(&snapshot_type_keys) {
             if let Some(value) = current_env.get(key).cloned() {
                 self.env.insert(key.clone(), value);


### PR DESCRIPTION
## Problem

ADR-0019s registry-owned type-by-method table contained only built-in descriptors. User candidates still existed solely in ClassDef.methods, so built-in overrides could not share a canonical entry.

## Approach

- make each MethodEntry hold both an optional built-in descriptor and ordered user candidates
- synchronize class candidates after declaration, rollback, intermediate class publication, augmentation, role composition, MOP add_method, partial registration, initialization, and EVAL restoration
- preserve ClassDef.methods as the dispatch-read compatibility mirror for this migration layer
- document that read-side cutover moves with compiled-candidate replacement and generation invalidation

## Tests

- registry unit tests, including built-in plus user override sharing one entry
- targeted TAP: add-method-qualified-and-invocant, augment-class, augment-does-role, can-methods-drift, coercion-str-method-dispatch, multi-method, multi-method-roles, role-conflict
- cargo build
- cargo clippy -- -D warnings
- cargo fmt --all