### PR TITLE
fix(runtime): END phasers run in reverse install order, not registration order

### DIFF
--- a/news/2026-08/end-phasers-run-in-install-order.md
+++ b/news/2026-08/end-phasers-run-in-install-order.md
@@ -36,11 +36,20 @@ still breaks ties within a class):
 | --- | --- |
 | a module's ENDs, in load order | earliest — a nested `use` installs the inner module's first |
 | the main compunit's top-level ENDs, in source order | after every module |
-| ENDs the main compunit registers while running (a block, a sub, an `EVAL`) | last, i.e. run first |
+| ENDs the main compunit registers while running (a block, a sub, an `EVAL`) — and any module it `use`s *from* an `EVAL` | last, i.e. run first |
 
-Which class a registration belongs to is decided by a new `module_load_depth`,
-bumped around `load_module` — a depth rather than a flag because a module may
-`use` another one.
+Which class a registration belongs to is decided by a new `module_load_order`
+stack, pushed around `load_module` — a stack rather than a flag because a module
+may `use` another one, and the nested load inherits its loader's class.
+
+A `use` reached from an **`EVAL`** is the one that is *not* `MODULE`: rakudo
+compiles the EVAL'd snippet at run time, so it installs that module's ENDs after
+everything the main compunit declared and they run *before* the script's — the
+opposite of a plain `use`. `File::Temp`'s own test suite turns on exactly this
+distinction: `03-tempfile.rakutest` writes `'use File::Temp; …'.EVAL` with a
+comment saying it does so to make the module's unlink-at-END run before the
+file's own END inspects the files. Classifying every `load_module` as `MODULE`
+inverted that and cost the file five assertions.
 
 `roast/S04-phasers/multiple.t`, `ascending-order.t`, `descending-order.t` and
 `interpolate.t` all pass under `MUTSU_REAL_TEST=1`. Pin:

--- a/news/2026-08/end-phasers-run-in-install-order.md
+++ b/news/2026-08/end-phasers-run-in-install-order.md
@@ -1,0 +1,54 @@
+# A module's END phaser runs *after* the script's, not before
+
+```raku
+# EndM.rakumod:  unit module EndM;  END { say "module END" }
+use EndM;
+END { say "script END" }
+```
+
+```
+raku : script END, module END
+mutsu: module END, script END
+```
+
+END phasers run in reverse *install* order, and rakudo installs one when the
+compunit that declares it is compiled — so a `use` on line 1 installs the
+module's ENDs before any of the script's own, and the LIFO order then puts the
+script's first.
+
+mutsu registers the main compunit's top-level ENDs **eagerly**, before the body
+runs, so that they still run when the body dies. That hoist is correct on its
+own (rakudo's install is compile-time too), but it put every main-compunit END
+*ahead* of every module's in the registration list, and the exit-time
+`.iter().rev()` then reversed the pair.
+
+Under the real `Test.rakumod` this is not cosmetic: the module's END *is* the
+plan check. Four `roast/S04-phasers` files assert from inside their own `END`,
+so the plan check ran first and reported `# You planned 2 tests, but ran 1` on a
+file that went on to emit both — with the missing `ok` printed immediately
+after the complaint.
+
+An `EndPhaser` now carries an `order` field recording where rakudo would have
+installed it, and the exit-time loop sorts by it (stably, so registration order
+still breaks ties within a class):
+
+| class | when |
+| --- | --- |
+| a module's ENDs, in load order | earliest — a nested `use` installs the inner module's first |
+| the main compunit's top-level ENDs, in source order | after every module |
+| ENDs the main compunit registers while running (a block, a sub, an `EVAL`) | last, i.e. run first |
+
+Which class a registration belongs to is decided by a new `module_load_depth`,
+bumped around `load_module` — a depth rather than a flag because a module may
+`use` another one.
+
+`roast/S04-phasers/multiple.t`, `ascending-order.t`, `descending-order.t` and
+`interpolate.t` all pass under `MUTSU_REAL_TEST=1`. Pin:
+`t/end-phaser-module-order.t`, which also pins the eager registration this had
+to preserve (the order still holds when the mainline dies).
+
+One case stays approximate: a main-compunit top-level `END` written *textually
+before* a `use`. rakudo installs those in source order, interleaved with the
+`use`; mutsu's hoist has already registered all of them by the time any module
+loads, so they sort as one block. `use` at the top of the file — every case in
+`t/` and roast — is exact.

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -51,11 +51,11 @@ impl Interpreter {
     /// the main compunit declares) or inside a block/sub/`EVAL` of the main
     /// compunit (installed as the compiler walked past it, after any `use`).
     pub(crate) fn push_end_phaser(&mut self, body: Vec<Stmt>) {
-        let base = if self.module_load_depth > 0 {
-            super::end_order::MODULE
-        } else {
-            super::end_order::RUNTIME
-        };
+        let base = self
+            .module_load_order
+            .last()
+            .copied()
+            .unwrap_or(super::end_order::RUNTIME);
         self.push_end_phaser_ordered(body, base);
     }
 

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -46,14 +46,38 @@ impl Interpreter {
         )
     }
 
+    /// Register an END phaser found while *running*: inside a module body (in
+    /// which case rakudo would have installed it at the `use`, before anything
+    /// the main compunit declares) or inside a block/sub/`EVAL` of the main
+    /// compunit (installed as the compiler walked past it, after any `use`).
     pub(crate) fn push_end_phaser(&mut self, body: Vec<Stmt>) {
+        let base = if self.module_load_depth > 0 {
+            super::end_order::MODULE
+        } else {
+            super::end_order::RUNTIME
+        };
+        self.push_end_phaser_ordered(body, base);
+    }
+
+    /// Register one of the main compunit's top-level END phasers. These are
+    /// registered eagerly, before the body runs, so that they still run when
+    /// the body dies — which is why they need an explicit install order rather
+    /// than the position they happen to land in.
+    pub(crate) fn push_end_phaser_main(&mut self, body: Vec<Stmt>) {
+        self.push_end_phaser_ordered(body, super::end_order::MAIN);
+    }
+
+    fn push_end_phaser_ordered(&mut self, body: Vec<Stmt>, order_base: u64) {
         let captured_env = self.env.clone();
         let package = self.current_package();
+        let order = order_base + self.end_phaser_seq;
+        self.end_phaser_seq += 1;
         self.end_phasers.push(super::EndPhaser {
             body,
             env: captured_env,
             package,
             dead_keys: crate::runtime::NameSet::default(),
+            order,
         });
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1115,10 +1115,11 @@ pub struct Interpreter {
     /// Monotonic tie-breaker for [`EndPhaser::order`], so phasers within one
     /// [`end_order`] class keep the order they were registered in.
     end_phaser_seq: u64,
-    /// How many module bodies are currently executing. An END registered while
-    /// this is non-zero belongs to a module, and rakudo would have installed it
-    /// at the `use` — i.e. before the main compunit's own.
-    module_load_depth: usize,
+    /// One entry per module body currently executing, holding the [`end_order`]
+    /// class the END phasers it registers belong to. Empty while the main
+    /// compunit runs. See `load_module` for why a `use` reached from an `EVAL`
+    /// is not `end_order::MODULE`.
+    module_load_order: Vec<u64>,
     /// Tracks END phaser site_ids to ensure each is registered only once.
     end_phaser_sites: HashSet<u64>,
     chroot_root: Option<PathBuf>,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -852,6 +852,34 @@ pub(crate) struct EndPhaser {
     /// captured key names a variable that is *still alive*, so the live value
     /// wins and a later mutation is visible, as it is in Raku.
     pub(crate) dead_keys: NameSet,
+    /// Install order, which is what decides the exit-time run order (END
+    /// phasers run in reverse of it). It is NOT the registration order: mutsu
+    /// registers the main compunit's top-level ENDs *eagerly*, before the body
+    /// runs, so a `use` on line 1 registers the module's END after them even
+    /// though rakudo installs it first. See [`end_order`].
+    pub(crate) order: u64,
+}
+
+/// Install-order bases for [`EndPhaser::order`]; lowest = installed earliest =
+/// run last.
+///
+/// rakudo installs an END phaser when the compunit that declares it is
+/// *compiled*, so `use M` on line 1 installs `M`'s ENDs before any of the
+/// script's own, and the LIFO run order then puts the script's first. mutsu
+/// loads modules at run time and hoists the main compunit's top-level ENDs to
+/// before the body (so they still run when the body dies), which reverses the
+/// two. Sorting by these bases at exit restores rakudo's order without giving
+/// up the hoist.
+pub(crate) mod end_order {
+    /// A module's ENDs, in load order — a nested `use` installs the inner
+    /// module's first, exactly as rakudo does.
+    pub(crate) const MODULE: u64 = 0;
+    /// The main compunit's top-level ENDs, in source order.
+    pub(crate) const MAIN: u64 = 1 << 40;
+    /// ENDs the main compunit registers while running (inside a block, a sub,
+    /// an `EVAL`). rakudo installs these as it compiles past them, i.e. after
+    /// everything a `use` at the top of the file brought in.
+    pub(crate) const RUNTIME: u64 = 2 << 40;
 }
 
 /// What a name in `pos_light_call_cache` resolves to.
@@ -1084,6 +1112,13 @@ pub struct Interpreter {
     pub(crate) pending_use_export_args: Option<Vec<Value>>,
     /// Registered END phasers, in registration order (they run in reverse).
     end_phasers: Vec<EndPhaser>,
+    /// Monotonic tie-breaker for [`EndPhaser::order`], so phasers within one
+    /// [`end_order`] class keep the order they were registered in.
+    end_phaser_seq: u64,
+    /// How many module bodies are currently executing. An END registered while
+    /// this is non-zero belongs to a module, and rakudo would have installed it
+    /// at the `use` — i.e. before the main compunit's own.
+    module_load_depth: usize,
     /// Tracks END phaser site_ids to ensure each is registered only once.
     end_phaser_sites: HashSet<u64>,
     chroot_root: Option<PathBuf>,

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -421,7 +421,7 @@ impl Interpreter {
                     body,
                 } = stmt
                 {
-                    self.push_end_phaser(body.clone());
+                    self.push_end_phaser_main(body.clone());
                     false
                 } else {
                     true
@@ -797,7 +797,14 @@ impl Interpreter {
             self.exit_status_locked = exit_already_requested;
             // Clear halted flag so END phasers can execute even after exit()
             self.halted = false;
-            let phasers = self.end_phasers.clone();
+            // Run in reverse *install* order, which is not the registration
+            // order: the main compunit's top-level ENDs are registered eagerly
+            // above, before any `use` has loaded a module. `EndPhaser::order`
+            // records where rakudo would have installed each one; the sort is
+            // stable, so phasers within one class keep their registration
+            // order. See `end_order`.
+            let mut phasers = self.end_phasers.clone();
+            phasers.sort_by_key(|p| p.order);
             // Save the env state before any END phasers run.  This lets us
             // distinguish between variables set by prior END phasers (which
             // should propagate) and stale captured values (which should not

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -592,17 +592,31 @@ impl Interpreter {
         )
     }
 
-    /// Load and run a module, tracking that a module body is executing.
+    /// Load and run a module, recording which [`super::end_order`] class the
+    /// ENDs its body registers belong to.
     ///
-    /// The depth is what tells `push_end_phaser` that an END belongs to a
-    /// module: rakudo installs those at the `use` (compile time), before any of
-    /// the loading compunit's own, and the exit-time LIFO order then puts the
-    /// script's ENDs first. It has to be a depth rather than a flag because a
-    /// module may `use` another one.
+    /// A plain `use` is compile-time in rakudo, so the module's ENDs are
+    /// installed before any of the loading compunit's own and the exit-time
+    /// LIFO order then puts the script's first — that is `MODULE`. A `use`
+    /// reached from an `EVAL` is *not* compile-time: rakudo installs it when
+    /// the EVAL runs, i.e. after everything the main compunit declared, so it
+    /// stays in the `RUNTIME` class and its ENDs run *before* the script's.
+    /// (`File::Temp`'s test suite depends on exactly this: it EVALs
+    /// `use File::Temp` so that the module's unlink-at-END runs before the
+    /// file's own END inspects the files.)
+    ///
+    /// It is a stack rather than a flag because a module may `use` another one;
+    /// a nested load inherits its loader's class, since a module reached from
+    /// an EVAL'd `use` is just as runtime-installed as the outer one.
     pub(super) fn load_module(&mut self, module: &str) -> Result<(), RuntimeError> {
-        self.module_load_depth += 1;
+        let order = match self.module_load_order.last() {
+            Some(&inherited) => inherited,
+            None if self.env.get("__mutsu_in_eval").is_some() => super::end_order::RUNTIME,
+            None => super::end_order::MODULE,
+        };
+        self.module_load_order.push(order);
         let result = self.load_module_inner(module);
-        self.module_load_depth -= 1;
+        self.module_load_order.pop();
         result
     }
 

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -592,7 +592,21 @@ impl Interpreter {
         )
     }
 
+    /// Load and run a module, tracking that a module body is executing.
+    ///
+    /// The depth is what tells `push_end_phaser` that an END belongs to a
+    /// module: rakudo installs those at the `use` (compile time), before any of
+    /// the loading compunit's own, and the exit-time LIFO order then puts the
+    /// script's ENDs first. It has to be a depth rather than a flag because a
+    /// module may `use` another one.
     pub(super) fn load_module(&mut self, module: &str) -> Result<(), RuntimeError> {
+        self.module_load_depth += 1;
+        let result = self.load_module_inner(module);
+        self.module_load_depth -= 1;
+        result
+    }
+
+    fn load_module_inner(&mut self, module: &str) -> Result<(), RuntimeError> {
         // Snapshot the `use` args (set by `exec_use_module_op`) before running
         // the module body: a transitive `use` inside the body would otherwise
         // overwrite the field. Handed to the module's `sub EXPORT`, if any.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2107,7 +2107,7 @@ impl Interpreter {
             pending_use_export_args: None,
             end_phasers: Vec::new(),
             end_phaser_seq: 0,
-            module_load_depth: 0,
+            module_load_order: Vec::new(),
             end_phaser_sites: HashSet::new(),
             chroot_root: None,
             loaded_modules: HashSet::new(),

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2106,6 +2106,8 @@ impl Interpreter {
             pending_dist_selectors: Vec::new(),
             pending_use_export_args: None,
             end_phasers: Vec::new(),
+            end_phaser_seq: 0,
+            module_load_depth: 0,
             end_phaser_sites: HashSet::new(),
             chroot_root: None,
             loaded_modules: HashSet::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -379,7 +379,7 @@ impl Interpreter {
             pending_use_export_args: None,
             end_phasers: Vec::new(),
             end_phaser_seq: 0,
-            module_load_depth: 0,
+            module_load_order: Vec::new(),
             end_phaser_sites: HashSet::new(),
             chroot_root: self.chroot_root.clone(),
             loaded_modules: self.loaded_modules.clone(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -378,6 +378,8 @@ impl Interpreter {
             pending_dist_selectors: Vec::new(),
             pending_use_export_args: None,
             end_phasers: Vec::new(),
+            end_phaser_seq: 0,
+            module_load_depth: 0,
             end_phaser_sites: HashSet::new(),
             chroot_root: self.chroot_root.clone(),
             loaded_modules: self.loaded_modules.clone(),

--- a/t/end-phaser-module-order.t
+++ b/t/end-phaser-module-order.t
@@ -12,7 +12,7 @@ use Test;
 # ran before the file's own `END { is ... }` and reported "You planned 2 tests,
 # but ran 1" on a file that went on to emit both.
 
-plan 5;
+plan 6;
 
 my $dir = $*TMPDIR.child("mutsu-end-order-{$*PID}");
 $dir.mkdir;
@@ -64,6 +64,15 @@ like run-snippet('nested.raku', $lib ~ 'use EndOrderNest;
 END { say "script" }
 '), / 'script N A' $ /,
     'a module used by a module installs its END first, so it runs last';
+
+# A `use` reached from an EVAL is *not* compile-time, so its module's END is
+# installed after everything the script declared and therefore runs first --
+# the opposite of the plain `use` above. File::Temp's own test suite depends on
+# this: it EVALs `use File::Temp` precisely so the module's unlink-at-END runs
+# before the file's END inspects the files.
+is run-snippet('evaled.raku', $lib ~ 'END { say "script" }
+"use EndOrderA".EVAL;
+'), 'A script', "a module used from an EVAL installs its END last, so it runs first";
 
 # Two ENDs in the same compunit are unaffected: still reverse source order.
 is run-snippet('same.raku', 'END { say "first" }

--- a/t/end-phaser-module-order.t
+++ b/t/end-phaser-module-order.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# END phasers run in reverse *install* order, and rakudo installs a module's
+# when the `use` is compiled -- before anything the loading compunit declares.
+# So a script's own END runs first and the module's last.
+#
+# mutsu registers the main compunit's top-level ENDs eagerly, before the body
+# runs (so they still run when the body dies), which put them *ahead* of every
+# module's in the registration list and reversed the pair. Under the real
+# Test.rakumod that is not cosmetic: the module's END is the plan check, so it
+# ran before the file's own `END { is ... }` and reported "You planned 2 tests,
+# but ran 1" on a file that went on to emit both.
+
+plan 5;
+
+my $dir = $*TMPDIR.child("mutsu-end-order-{$*PID}");
+$dir.mkdir;
+END { try { .unlink for $dir.dir; $dir.rmdir } }
+
+sub run-snippet($name, $source) {
+    my $file = $dir.child($name);
+    $file.spurt($source);
+    my $proc = run($*EXECUTABLE, $file.absolute, :out, :err);
+    my $out = $proc.out.slurp(:close);
+    $proc.err.slurp(:close);
+    $out.trim.subst("\n", " ", :g)
+}
+
+$dir.child('EndOrderA.rakumod').spurt(
+    'unit module EndOrderA;
+END { say "A" }
+');
+$dir.child('EndOrderB.rakumod').spurt(
+    'unit module EndOrderB;
+END { say "B" }
+');
+# No `use lib` here: rakudo rejects one inside a module ("cannot be
+# precompiled"). The loading script's `use lib` is what puts the directory on
+# the search path for this nested `use` too.
+$dir.child('EndOrderNest.rakumod').spurt(
+    'unit module EndOrderNest;
+use EndOrderA;
+END { say "N" }
+');
+
+my $lib = 'use lib "' ~ $dir.absolute ~ '";' ~ "\n";
+
+is run-snippet('one.raku', $lib ~ 'use EndOrderA;
+END { say "script" }
+'), 'script A', "the script's END runs before the module's";
+
+is run-snippet('two.raku', $lib ~ 'use EndOrderA;
+use EndOrderB;
+END { say "script" }
+'), 'script B A',
+    'later-loaded modules run before earlier-loaded ones';
+
+# A module used by a module installs its END first, so it runs last. Asserted
+# on the tail only: rakudo precompiles EndOrderNest in a separate phase that
+# loads EndOrderA and fires its END there too, so raku's own output for this
+# snippet carries a leading stray "A" that has nothing to do with the ordering.
+like run-snippet('nested.raku', $lib ~ 'use EndOrderNest;
+END { say "script" }
+'), / 'script N A' $ /,
+    'a module used by a module installs its END first, so it runs last';
+
+# Two ENDs in the same compunit are unaffected: still reverse source order.
+is run-snippet('same.raku', 'END { say "first" }
+END { say "second" }
+'), 'second first', 'two ENDs in one compunit still run in reverse';
+
+# The eager registration this ordering has to preserve: an END still runs when
+# the mainline dies before reaching the end of the file.
+is run-snippet('dies.raku', $lib ~ 'use EndOrderA;
+END { say "script" }
+die "boom";
+'), 'script A', 'the order survives a mainline that dies';


### PR DESCRIPTION
```raku
# EndM.rakumod:  unit module EndM;  END { say "module END" }
use EndM;
END { say "script END" }
```

```
raku : script END, module END
mutsu: module END, script END
```

END phasers run in reverse *install* order, and rakudo installs one when the
compunit that declares it is compiled — so a `use` on line 1 installs the
module's ENDs before any of the script's own, and the LIFO order then puts the
script's first.

mutsu registers the main compunit's top-level ENDs **eagerly**, before the body
runs, so that they still run when the body dies. That hoist is correct on its
own (rakudo's install is compile-time too), but it put every main-compunit END
*ahead* of every module's in the registration list, and the exit-time
`.iter().rev()` then reversed the pair.

Under the real `Test.rakumod` this is not cosmetic: the module's END *is* the
plan check. Four `roast/S04-phasers` files assert from inside their own `END`,
so the plan check ran first and reported `# You planned 2 tests, but ran 1` on
a file that went on to emit both — with the missing `ok` printed immediately
after the complaint. All four (`multiple.t`, `ascending-order.t`,
`descending-order.t`, `interpolate.t`) now pass under `MUTSU_REAL_TEST=1`.

An `EndPhaser` now carries an `order` field recording where rakudo would have
installed it, and the exit-time loop sorts by it (stably, so registration order
still breaks ties within a class):

| class | when |
| --- | --- |
| a module's ENDs, in load order | earliest — a nested `use` installs the inner module's first |
| the main compunit's top-level ENDs, in source order | after every module |
| ENDs the main compunit registers while running (a block, a sub, an `EVAL`) | last, i.e. run first |

Which class a registration belongs to is decided by a new `module_load_depth`,
bumped around `load_module` — a depth rather than a flag because a module may
`use` another one.

Pin: `t/end-phaser-module-order.t`, which also pins the eager registration this
had to preserve (the order still holds when the mainline dies).

One case stays approximate: a main-compunit top-level `END` written *textually
before* a `use`. rakudo installs those in source order, interleaved with the
`use`; mutsu's hoist has already registered all of them by the time any module
loads, so they sort as one block. `use` at the top of the file — every case in
`t/` and roast — is exact.

Local `make test` (2817 files) and `make roast` (1435 files) both PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)