### PR TITLE
refactor(runtime): generation-track method entries

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -169,3 +169,7 @@ rollback, augmentation, role composition, MOP `add_method`, partial registration
 restoration synchronize user candidates into the table. Dispatch still reads the compatibility
 `ClassDef::methods` mirror until compiled-candidate replacement and generation invalidation move
 with it in the next stage.
+
+Every built-in seed and user-candidate synchronization advances the registry's monotonic method
+generation. Dispatch caches do not consume it yet; wiring that generation into resolved-call cache
+keys is the prerequisite for switching their read side to `MethodEntry` safely.

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -65,6 +65,8 @@ pub(crate) struct Registry {
     /// Canonical type x method table. It initially owns the built-in entries;
     /// declaration registration will add user candidates to the same table.
     pub(crate) method_entries: HashMap<MethodEntryKey, MethodEntry>,
+    /// Monotonic invalidation generation for the canonical method table.
+    pub(crate) method_generation: u64,
     /// `enum Name (...)` declarations: enum name -> [(variant name, value)].
     pub(crate) enum_types: HashMap<String, Vec<(String, EnumValue)>>,
     /// `subset Name of Base where { ... }` declarations.
@@ -277,6 +279,7 @@ impl Registry {
                 slot.builtin = Some(entry);
             }
         }
+        self.bump_method_generation();
     }
 
     pub(crate) fn builtin_method_names(&self, type_name: &str) -> Vec<&'static str> {
@@ -307,6 +310,7 @@ impl Registry {
             .get(class_name)
             .map(|class| class.methods.clone())
         else {
+            self.bump_method_generation();
             return;
         };
         for (name, candidates) in methods {
@@ -317,6 +321,14 @@ impl Registry {
                 })
                 .or_default()
                 .user_candidates = candidates;
+        }
+        self.bump_method_generation();
+    }
+
+    fn bump_method_generation(&mut self) {
+        self.method_generation = self.method_generation.wrapping_add(1);
+        if self.method_generation == 0 {
+            self.method_generation = 1;
         }
     }
 }
@@ -782,6 +794,7 @@ mod tests {
     fn user_override_shares_the_builtin_method_entry() {
         let mut registry = Registry::default();
         registry.seed_builtin_method_entries();
+        let seeded_generation = registry.method_generation;
         let method = MethodDef {
             lexical_package: "GLOBAL".to_string(),
             params: Vec::new(),
@@ -805,6 +818,7 @@ mod tests {
         class.methods.insert("chars".to_string(), vec![method]);
         registry.classes.insert("Str".to_string(), class);
         registry.sync_user_method_entries("Str");
+        assert!(registry.method_generation > seeded_generation);
 
         let entry = registry
             .method_entries
@@ -815,5 +829,19 @@ mod tests {
             .expect("Str.chars entry");
         assert!(entry.builtin.is_some());
         assert_eq!(entry.user_candidates.len(), 1);
+
+        let override_generation = registry.method_generation;
+        registry.classes.remove("Str");
+        registry.sync_user_method_entries("Str");
+        assert!(registry.method_generation > override_generation);
+        let entry = registry
+            .method_entries
+            .get(&MethodEntryKey {
+                owner: Symbol::intern("Str"),
+                name: Symbol::intern("chars"),
+            })
+            .expect("built-in entry survives user removal");
+        assert!(entry.builtin.is_some());
+        assert!(entry.user_candidates.is_empty());
     }
 }


### PR DESCRIPTION
## Problem

User and built-in methods now share canonical entries, but table mutations had no common invalidation token. Switching dispatch reads before establishing that rule left stale compiled candidates visible in EVAL and augment flows.

## Approach

- add a monotonic method generation to Registry
- advance it for built-in seeding and every user-candidate synchronization, including removal
- preserve zero as the uninitialized sentinel across wrapping
- document generation wiring as the prerequisite for dispatch read-side cutover

## Tests

- user override shares a built-in row and advances generation on add/remove
- targeted augment, MOP add-method, multi-method, and role-conflict TAP tests
- cargo build
- cargo clippy -- -D warnings
- cargo fmt --all