### PR TITLE
fix(cro): `delegate` in a route block reaches its target

### DIFF
--- a/news/2026-08/cro-delegate-route-block.md
+++ b/news/2026-08/cro-delegate-route-block.md
@@ -1,0 +1,60 @@
+# `delegate` in a Cro route block works
+
+`route { delegate <*> => $inner }` produced no response at all: the client's
+`await Cro::HTTP::Client.get(...)` resolved to `Any` and, with a plain
+`Cro::Transform` as the delegate target, the request never reached the
+transform's `transformer` either. This blocked the `before-matched` /
+`after-matched` subtests of the vendored Cro::HTTP `t/http-middleware.rakutest`,
+which wrap an application by delegating to it.
+
+Two independent interpreter bugs were behind it.
+
+## `Parameter.constraints` is an `all()` junction
+
+Cro's route compiler decides whether a compiled route needs a signature bind
+test by asking each parameter for its constraints and counting them:
+
+```raku
+sub extract-constraints(Parameter:D $param) {
+    my @constraints;
+    sub extract($v --> Nil) { @constraints.push($v) }
+    extract($param.constraints);
+    return @constraints;
+}
+```
+
+That works because Raku's `.constraints` is an `all()` junction: an
+unconstrained parameter yields the *empty* `all()`, calling `extract` on it
+autothreads zero times, and `@constraints` stays empty. mutsu returned
+`Bool::True` for an unconstrained parameter, so every parameter looked
+constrained. A wildcard `delegate`'s handler signature is `-> *@ { }`, and the
+spurious "has constraints" verdict made the generated route regex carry a
+`$han.signature.ACCEPTS($cap)` bind check that Rakudo does not emit.
+
+`.constraints` is now always a `Junction` — `all()` when the parameter has no
+value constraint, `all($literal)` for a literal parameter, `all($code)` for a
+`where` clause. The empty junction still smartmatches truely against anything,
+so its use as a matcher is unchanged. With this, mutsu's generated route matcher
+is byte-identical to Rakudo's for the same route block.
+
+## `supply` works as a statement prefix
+
+`Cro::HTTP::Router::RouteSet::DelegateHandler.invoke` opens its pipeline with
+
+```raku
+my $current = supply emit $req;
+```
+
+mutsu only understood `supply { ... }` and the `supply whenever ... { ... }`
+shorthand, so this was a parse failure ("Two terms in a row") raised when the
+method ran — on a supply worker, where it was swallowed and left the pipeline
+silently dead. The related `supply for ^3 { emit $_ }` parsed but ran its body
+outside any supply, so the `emit` escaped as an unhandled `CX::Emit`.
+
+`supply STATEMENT` now lowers exactly like `supply { STATEMENT }`, following the
+same statement-prefix path `gather` already used: the statement is parsed with
+`statement_pub`, its terminating `;` is given back to the caller, and a
+`do`-block statement is inlined rather than nested.
+
+Pinned by `t/parameter-constraints-junction.t` and
+`t/supply-statement-prefix.t`.

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1454,6 +1454,22 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         return Ok((r2, supply_method_call(block_body)));
     }
 
+    // `supply STATEMENT` — the statement-prefix form (S06), e.g.
+    // `my $s = supply emit $req;` or `supply for ^3 { emit $_ }`. The statement
+    // becomes the whole supply body, so `emit` inside it binds to this block's
+    // emitter instead of escaping as an unhandled CX::Emit.
+    if name == "supply"
+        && let Ok((r_after, stmt)) = crate::parser::stmt::statement_pub(r)
+    {
+        // As for `gather`, the statement parse eats the terminating `;` but the
+        // supply expression must stop before it.
+        let r_after = restore_do_stmt_terminator(r, r_after);
+        if let crate::ast::Stmt::Expr(Expr::DoBlock { body, label: None }) = &stmt {
+            return Ok((r_after, supply_method_call(body.clone())));
+        }
+        return Ok((r_after, supply_method_call(vec![stmt])));
+    }
+
     // set/bag/mix followed immediately by < (no whitespace) is a parse error
     if matches!(name.as_str(), "set" | "bag" | "mix")
         && rest.starts_with('<')

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -408,18 +408,22 @@ fn build_parameter_attrs(p: &SigParam) -> HashMap<String, Value> {
         attrs.insert("default".to_string(), default_sub);
     }
 
-    // .constraints: for literal values, store the literal directly;
-    // for where clauses, convert the constraint Expr to a Value;
-    // for unconstrained params, Bool(true) smartmatches against anything
-    if let Some(ref lit) = p.literal_value {
-        attrs.insert("constraints".to_string(), lit.clone());
+    // .constraints is always an `all()` junction of the parameter's value
+    // constraints (a literal value, or the code of a `where` clause). An
+    // unconstrained parameter yields the empty `all()`, which both smartmatches
+    // truely against anything and autothreads a call zero times — code such as
+    // Cro's route compiler relies on the latter to detect "no constraints".
+    let constraint_items: Vec<Value> = if let Some(ref lit) = p.literal_value {
+        vec![lit.clone()]
     } else if let Some(ref where_expr) = p.where_constraint {
-        let constraint_val = where_expr_to_value(where_expr);
-        attrs.insert("constraints".to_string(), constraint_val);
+        vec![where_expr_to_value(where_expr)]
     } else {
-        // Unconstrained param: .constraints smartmatches truely against anything
-        attrs.insert("constraints".to_string(), Value::Bool(true));
-    }
+        Vec::new()
+    };
+    attrs.insert(
+        "constraints".to_string(),
+        Value::junction(crate::value::JunctionKind::All, constraint_items),
+    );
 
     if let Some(sub) = &p.sub_signature {
         attrs.insert(

--- a/t/parameter-constraints-junction.t
+++ b/t/parameter-constraints-junction.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 9;
+
+# `Parameter.constraints` is an `all()` junction of the parameter's value
+# constraints. An unconstrained parameter yields the EMPTY `all()`, which is
+# what lets a caller detect "no constraints" by autothreading a sub over it —
+# the idiom Cro's route compiler uses to decide whether a signature bind test
+# is needed.
+
+sub collect($param) {
+    my @out;
+    sub extract($v --> Nil) { @out.push($v) }
+    extract($param.constraints);
+    @out
+}
+
+my $slurpy = (-> *@ { }).signature.params[0];
+isa-ok $slurpy.constraints, Junction, 'slurpy parameter .constraints is a Junction';
+is collect($slurpy).elems, 0, 'unconstrained slurpy autothreads zero times';
+
+my $plain = (-> $x { }).signature.params[0];
+is collect($plain).elems, 0, 'unconstrained scalar autothreads zero times';
+
+my $typed = (-> Int $y { }).signature.params[0];
+is collect($typed).elems, 0, 'a type constraint is not a value constraint';
+
+my $literal = (-> "lit" { }).signature.params[0];
+is collect($literal).elems, 1, 'a literal parameter has one constraint';
+is collect($literal)[0], 'lit', 'the literal is the constraint';
+
+my $whered = (-> $z where * > 5 { }).signature.params[0];
+is collect($whered).elems, 1, 'a where clause is one constraint';
+ok collect($whered)[0] ~~ Callable, 'the where constraint is callable';
+
+# The empty junction still smartmatches truely against anything, so code that
+# uses .constraints as a matcher keeps working.
+ok 42 ~~ $plain.constraints, 'empty all() accepts any value';

--- a/t/supply-statement-prefix.t
+++ b/t/supply-statement-prefix.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 5;
+
+# `supply` is a statement prefix (S06): `supply STATEMENT` is `supply { STATEMENT }`,
+# so an `emit` in that statement belongs to the new supply rather than escaping.
+# Cro's Cro::HTTP::Router::DelegateHandler.invoke opens its pipeline with
+# `my $current = supply emit $req;`.
+
+{
+    my $s = supply emit 42;
+    my @got;
+    $s.tap(-> $v { @got.push($v) });
+    is @got, [42], 'supply emit EXPR emits once per tap';
+}
+
+{
+    my $s = supply for 1..3 { emit $_ * 10 }
+    my @got;
+    $s.tap(-> $v { @got.push($v) });
+    is @got, [10, 20, 30], 'supply for LOOP emits each iteration';
+}
+
+{
+    # On-demand: the body runs again for every tap.
+    my $runs = 0;
+    my $s = supply emit ++$runs;
+    my @first;
+    $s.tap(-> $v { @first.push($v) });
+    my @second;
+    $s.tap(-> $v { @second.push($v) });
+    is @first, [1], 'first tap runs the body';
+    is @second, [2], 'second tap runs the body again';
+}
+
+{
+    # The statement-prefix form composes with a downstream transform.
+    my $src = supply emit 'REQ';
+    my $out = supply whenever $src -> $v { emit "wrapped($v)" };
+    my @got;
+    $out.tap(-> $v { @got.push($v) });
+    is @got, ['wrapped(REQ)'], 'a statement-prefix supply feeds a whenever chain';
+}


### PR DESCRIPTION
`route { delegate <*> => $inner }` produced no response at all — the client's `await Cro::HTTP::Client.get(...)` resolved to `Any`, and with a plain `Cro::Transform` as the target the request never reached its `transformer`. This blocked the `before-matched` / `after-matched` subtests of the vendored Cro::HTTP `t/http-middleware.rakutest`.

Two independent interpreter bugs were behind it.

### `Parameter.constraints` is an `all()` junction

Cro's route compiler counts a parameter's constraints by autothreading a sub over `.constraints`:

```raku
sub extract($v --> Nil) { @constraints.push($v) }
extract($param.constraints);
```

That relies on `.constraints` being an `all()` junction whose *empty* form autothreads zero times. mutsu returned `Bool::True` for an unconstrained parameter, so every parameter looked constrained, and a wildcard delegate's `-> *@ { }` handler signature made the generated route regex carry a `$han.signature.ACCEPTS($cap)` bind check that Rakudo does not emit.

`.constraints` is now always a `Junction`: `all()` when unconstrained, `all($literal)` for a literal parameter, `all($code)` for a `where` clause. The empty junction still smartmatches truely against anything, so its use as a matcher is unchanged. With this the generated route matcher is byte-identical to Rakudo's.

### `supply` works as a statement prefix

`DelegateHandler.invoke` opens its pipeline with `my $current = supply emit $req;`. mutsu understood only `supply { ... }` and `supply whenever ... { ... }`, so this was a parse failure raised when the method ran — on a supply worker, where it was swallowed and left the pipeline silently dead. `supply for ^3 { emit $_ }` parsed but ran its body outside any supply, so the `emit` escaped as an unhandled `CX::Emit`.

`supply STATEMENT` now lowers exactly like `supply { STATEMENT }`, via the same statement-prefix path `gather` already used.

### Verification

- `route { delegate <*> => $inner }` and `delegate <*> => SomeTransform` both round-trip 200 OK against a real `Cro::HTTP::Server` now (they returned `Any` / hung before).
- New pins `t/parameter-constraints-junction.t` and `t/supply-statement-prefix.t` pass identically under `raku`.
- `make test`: only `t/io-socket-async-{bin,listen}.t` failed, from port contention with the Cro servers running alongside; both pass on a clean rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)