### PR TITLE
fix(supply): a supply block's `whenever` closures own their own emitter

### DIFF
--- a/news/2026-08/supply-block-reinstantiated.md
+++ b/news/2026-08/supply-block-reinstantiated.md
@@ -1,0 +1,53 @@
+# Two live instances of one `supply` block stop feeding each other
+
+Building a supply chain by calling the same routine repeatedly fed the pipeline
+its own output forever:
+
+```raku
+sub xform(Supply $in --> Supply) {
+    supply whenever $in -> $v { emit "w($v)" }
+}
+my $s = supply emit 'REQ';
+$s = xform($s);
+$s = xform($s);
+$s.tap(-> $v { say $v });        # w(w(REQ)) in Rakudo; an infinite loop in mutsu
+```
+
+Two *different* routines chained fine — the trigger was one routine used twice.
+
+## Why
+
+`supply { … }` lowers to `Supply.on-demand(-> $__mutsu_supply_emitter_N { … })`,
+and `emit x` inside the block is rewritten to `$__mutsu_supply_emitter_N.emit(x)`.
+That name is generated per **parse site**, which keeps sibling supply blocks
+apart, but every runtime **instance** of one parse site shares it. Tapping the
+outer instance runs the inner instance's body nested inside it, so the inner
+binding of the shared name was live when the outer body's `whenever` callback
+finally ran — and the outer `emit` went into the inner supply, whose value came
+straight back to the outer body.
+
+`exec_whenever_scope_op` already guards against exactly this class of shadowing:
+it hands each `whenever` callback a list of `owned_lexicals` (the closure's
+`authoritative_captures`), names that a same-named lexical in whatever frame
+dispatches the callback must never shadow. But that list was built from the
+supply body's `my` declarations, and the emitter is the body's *parameter*, so it
+was never in it. It has no compiled local slot either — a supply body's `locals`
+is empty — so it could not be recovered from the code object's local table.
+
+## Fix
+
+`CompiledCode` now carries `supply_emitter_sym`, the interned emitter parameter
+name, set wherever `is_supply_block_body` is set: in the compiler
+(`expr_closure.rs`, from the lambda's parameter) and on the interpreter's
+re-entrant carrier path, where it rides along with `pending_supply_block_body`
+from `resolution_call_sub` into `resolution_eval` — falling back to the
+`SubData`'s parameter list for a body compiled on the fly with no
+`CompiledCode`. `exec_whenever_scope_op` adds it to `owned_lexicals`.
+
+This is what a Cro middleware pipeline builds — `Cro::HTTP::Router`'s
+`!append-middleware` wraps its pipeline once per component, and
+`Cro::HTTP::Middleware::Request.transformer` wraps again — so a `before-matched`
+middleware in a route block used to spin forever instead of handling one
+request.
+
+Pinned by `t/supply-block-reinstantiated.t`.

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -344,6 +344,9 @@ impl Compiler {
         // { … })`, so the generated emitter parameter identifies the supply body.
         // See `CompiledCode::is_supply_block_body`.
         compiled.is_supply_block_body = param.starts_with(crate::parser::SUPPLY_EMITTER_PREFIX);
+        compiled.supply_emitter_sym = compiled
+            .is_supply_block_body
+            .then(|| crate::symbol::Symbol::intern(param));
         let esc = self.escaping_position;
         let cc_idx = self.add_closure_code_baked(compiled, esc);
         let idx = self.code.add_stmt(Stmt::SubDecl {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2319,6 +2319,15 @@ pub(crate) struct CompiledCode {
     /// declarations genuinely ARE that frame's lexicals and stay shared. Set
     /// during `compute_needs_env_sync`.
     pub(crate) is_supply_block_body: bool,
+    /// The generated emitter parameter of a `supply { … }` body
+    /// (`__mutsu_supply_emitter_N`), interned. `Some` exactly when
+    /// `is_supply_block_body`.
+    ///
+    /// The name is unique per *parse site* but shared by every runtime *instance*
+    /// of that site, so the `whenever` closures a body creates must own it — see
+    /// `exec_whenever_scope_op`. It has no compiled local slot (a `supply` body's
+    /// `locals` is empty), so it cannot be recovered from `locals_sym`.
+    pub(crate) supply_emitter_sym: Option<Symbol>,
     /// Ordered list of this closure's read-only plain-lexical free variables that
     /// have been promoted to index-based upvalues. Index `i` in this list is the
     /// operand of the `GetUpvalue(i)` ops that `compute_upvalues` rewrites in
@@ -2570,6 +2579,7 @@ impl CompiledCode {
             env_consumer_slots: EnvConsumerSlots::default(),
             dup_named_locals: Vec::new(),
             is_supply_block_body: false,
+            supply_emitter_sym: None,
             my_declared_sym: rustc_hash::FxHashSet::default(),
             my_declared_enum_sym: rustc_hash::FxHashSet::default(),
             free_var_syms: Vec::new(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1152,6 +1152,9 @@ pub struct Interpreter {
     /// the AST, and that copy would otherwise lose the mark. Consumed (taken) on
     /// entry, so a nested block compiled from inside the body does not inherit it.
     pending_supply_block_body: bool,
+    /// The emitter parameter name that goes with `pending_supply_block_body`, so
+    /// the re-compiled chunk also carries `CompiledCode::supply_emitter_sym`.
+    pending_supply_emitter_sym: Option<Symbol>,
     /// Names the block `eval_block_value_inner` most recently FINISHED running
     /// declared with its own `my` (excluding those it also uses as free
     /// variables). Written just before that function returns, so after a call

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -637,8 +637,26 @@ impl Interpreter {
                 .compiled_code
                 .as_ref()
                 .is_some_and(|cc| cc.is_supply_block_body);
+            // The emitter's name rides along so the recompiled chunk can tell the
+            // `whenever` closures it builds to own it (`exec_whenever_scope_op`).
+            // A `SubData` compiled on the fly has no `compiled_code`, so fall back
+            // to the parameter list, which is where the name came from anyway.
+            self.pending_supply_emitter_sym = data
+                .compiled_code
+                .as_ref()
+                .and_then(|cc| cc.supply_emitter_sym)
+                .or_else(|| {
+                    data.params
+                        .iter()
+                        .find(|p| p.starts_with(crate::parser::SUPPLY_EMITTER_PREFIX))
+                        .map(|p| Symbol::intern(p))
+                });
+            if self.pending_supply_emitter_sym.is_some() {
+                self.pending_supply_block_body = true;
+            }
             let body_result = self.eval_block_value(&data.body);
             self.pending_supply_block_body = false;
+            self.pending_supply_emitter_sym = None;
             // The `my` names the body just declared, published by
             // `eval_block_value_inner`. Taken immediately, before anything below
             // can run another block and overwrite it. This is how a body with no

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -175,6 +175,7 @@ impl Interpreter {
         // Taken (not read) so a block compiled from *inside* this body does not
         // inherit the mark — see `pending_supply_block_body`.
         let is_supply_block_body = std::mem::take(&mut self.pending_supply_block_body);
+        let supply_emitter_sym = std::mem::take(&mut self.pending_supply_emitter_sym);
         let let_mark = self.let_saves_len();
         let mut saved_functions = self.registry().functions.clone();
         let saved_proto_subs = self.registry().proto_subs.clone();
@@ -209,6 +210,7 @@ impl Interpreter {
             .collect();
         let (mut code, compiled_fns) = self.compile_block_value_opts(body, is_eval_unit);
         code.is_supply_block_body = is_supply_block_body;
+        code.supply_emitter_sym = supply_emitter_sym;
         // Multi-frame coherence (env_dirty-deletion path): box any captured-outer
         // scalar this carrier body writes into a shared cell across env + saved
         // frames, so the by-name write survives the owner frame's env restore.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2120,6 +2120,7 @@ impl Interpreter {
             pending_eval_sigilless: Vec::new(),
             pending_eval_placeholder_params: Vec::new(),
             pending_supply_block_body: false,
+            pending_supply_emitter_sym: None,
             last_block_my_declared: Vec::new(),
             predictive_seq_iters: HashMap::new(),
             protect_block_cache: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -392,6 +392,7 @@ impl Interpreter {
             pending_eval_sigilless: Vec::new(),
             pending_eval_placeholder_params: Vec::new(),
             pending_supply_block_body: false,
+            pending_supply_emitter_sym: None,
             last_block_my_declared: Vec::new(),
             predictive_seq_iters: self.predictive_seq_iters.clone(),
             protect_block_cache: HashMap::new(),

--- a/src/vm/vm_scope_ops.rs
+++ b/src/vm/vm_scope_ops.rs
@@ -143,11 +143,28 @@ impl Interpreter {
             // sibling `whenever`s are supposed to share (t/react-whenever-
             // shared-lexical.t). See `CompiledCode::is_supply_block_body`.
             let owned_lexicals: Vec<crate::symbol::Symbol> = if code.is_supply_block_body {
-                code.my_declared_sym
+                let mut owned: Vec<crate::symbol::Symbol> = code
+                    .my_declared_sym
                     .iter()
                     .filter(|sym| !code.free_var_syms.contains(sym))
                     .copied()
-                    .collect()
+                    .collect();
+                // The block's own emitter is its PARAMETER, not a `my`, so the
+                // filter above never sees it — yet it is the one name that MUST
+                // resolve to this instance. The generated name is unique per
+                // parse site but shared by every runtime instance of that site,
+                // so a supply chain built by calling the same routine twice
+                // (`$s = xform($s); $s = xform($s)`, exactly what Cro's
+                // middleware pipeline does) has two live instances of one block:
+                // tapping the outer one runs the inner one's body, whose binding
+                // then answered the OUTER body's `emit`, feeding the outer supply
+                // its own output forever.
+                if let Some(sym) = code.supply_emitter_sym
+                    && !owned.contains(&sym)
+                {
+                    owned.push(sym);
+                }
+                owned
             } else {
                 Vec::new()
             };

--- a/t/supply-block-reinstantiated.t
+++ b/t/supply-block-reinstantiated.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 3;
+
+# A `supply { … }` block's emitter has a name generated per PARSE SITE, but a
+# routine that returns such a block can be called more than once, so one parse
+# site can have several live instances. Tapping the outer instance runs the
+# inner one's body nested inside it; the `whenever` closures each instance
+# creates must keep answering their OWN emitter. When they did not, the outer
+# body's `emit` went back into the inner supply and fed itself forever — which
+# is exactly what a Cro middleware pipeline (`$s = wrap($s)` repeated) builds.
+
+sub xform(Supply $in --> Supply) {
+    supply whenever $in -> $v { emit "w($v)" }
+}
+
+{
+    my $s = supply emit 'REQ';
+    $s = xform($s);
+    $s = xform($s);
+    my @got;
+    $s.tap(-> $v { @got.push($v) });
+    is @got, ['w(w(REQ))'], 'two instances of one supply block chain, not loop';
+}
+
+{
+    # Three deep, to make sure the fix is not "the second one happens to work".
+    my $s = supply emit 1;
+    $s = xform($s) for ^3;
+    my @got;
+    $s.tap(-> $v { @got.push($v) });
+    is @got, ['w(w(w(1)))'], 'three instances of one supply block chain';
+}
+
+{
+    # Several values through a two-instance chain: each must be wrapped exactly
+    # twice and arrive in order.
+    my $s = supply for 1..3 { emit $_ }
+    $s = xform($s);
+    $s = xform($s);
+    my @got;
+    $s.tap(-> $v { @got.push($v) });
+    is @got, ['w(w(1))', 'w(w(2))', 'w(w(3))'], 'every value crosses the chain once';
+}

--- a/todo/tickets/dead-my-declaration-breaks-a-composed-cro-transform.md
+++ b/todo/tickets/dead-my-declaration-breaks-a-composed-cro-transform.md
@@ -1,87 +1,93 @@
-# `supply whenever f(...)` loses its subscription when `f` has a local
+# A supply block's free variables leak to the caller when its `whenever` fires
 
-`Cro::HTTP::Middleware::Response`-based middleware never reaches the client. The
-middleware runs, appends its header, emits; the role's outer `transformer` supply
-receives it and emits it too; a raw socket read proves the server writes a
-complete, correct response to the wire — and yet
-`await Cro::HTTP::Client.get(...)` in the same process resolves to `Nil`. The
-same middleware written directly as a `Cro::Transform` (what
-`t/http-middleware.rakutest`'s first subtest does) works.
+`Cro::HTTP::Middleware::*`-based middleware still does not reach the client.
+With `before-matched LowerCase` installed in a route block, the middleware runs
+once, lowercases the target, emits — and the request then re-enters the route
+matcher with the *wrong* route set state, so the client's
+`await Cro::HTTP::Client.get(...)` resolves to `Nil`.
 
-This is why that file passes its first subtest 4/4 and then hangs.
+## What has already been fixed (do not re-investigate)
 
-## Minimal trigger
+The original form of this ticket blamed `supply whenever f(...)` losing its
+subscription when `f` had a local. That framing is **obsolete** — three separate
+bugs behind it have been fixed:
 
-`Cro::HTTP::Middleware::Response.transformer` reaches its `process` through a
-helper (`wrap-response-logging`, `lib/Cro/HTTP/Middleware.rakumod:29`):
+- `Parameter.constraints` now returns an `all()` junction, so Cro's route
+  compiler stops adding a bogus signature bind check (see
+  `news/2026-08/cro-delegate-route-block.md`).
+- `supply STATEMENT` parses, so `DelegateHandler.invoke`'s
+  `my $current = supply emit $req;` no longer dies on a supply worker (same
+  news entry). This alone made `route { delegate <*> => $inner }` work.
+- A supply block's generated emitter is now owned by the `whenever` closures it
+  creates, so two live instances of one parse site no longer feed each other
+  (`news/2026-08/supply-block-reinstantiated.md`, pinned by
+  `t/supply-block-reinstantiated.t`). This removed the infinite
+  `[lc] target=...` loop.
 
-```raku
-supply whenever wrap-response-logging(self, $pipeline, { self.process($_) }) -> $response { ... }
-```
+## The remaining bug
 
-Reproduced with a *local* copy of the role, so no vendored file is involved. Only
-the helper's body varies (`tmp/mwvar.sh` builds each variant from `tmp/mw16.p6`;
-run them with `bash tmp/crorun.sh`):
-
-| # | body of `sub my-wrap-logging(Any $middleware, Supply $pipeline, &process --> Supply)` | result |
-| - | --- | --- |
-| L | `process($pipeline)` | works |
-| K | `my $x; process($pipeline)` | **broken** |
-| M | `my $x = process($pipeline); $x` | **broken** |
-| I | `if False { my $x; } else { process($pipeline) }` | **broken** |
-| H | `if False { my $zzqqx77 = 1; } else { process($pipeline) }` | **broken** |
-| G | `if False { process($pipeline); } else { process($pipeline) }` | works |
-| F | `if False { $middleware.WHAT; } else { process($pipeline) }` | works |
-| A | `if False { } else { process($pipeline) }` | works |
-
-**K vs L is the whole bug: one `my $x;` in the callee.** It needs no
-initializer, the name is irrelevant (H uses a name nothing else could collide
-with), and it need not even execute (I) — so the damage is not a runtime write
-but something about the callee having a local at all. F/G show an ordinary
-statement or a call in the same position is harmless.
-
-## The subscription, not the value
-
-Binding the call's result before the `whenever` **fixes it** (`tmp/mwv-K2.p6`):
+`Cro::HTTP::Router::RouteSet.transformer` is
 
 ```raku
-my $s = my-wrap-logging(self, $pipeline, { self.process($_) });
-supply whenever $s -> $response { ... }      # works
+method transformer(Supply:D $requests) {
+    supply {
+        whenever $requests -> $request { ... @!handlers ... }
+    }
+}
 ```
 
-So the callee returns the right Supply; what breaks is `supply whenever` applied
-directly to the *call expression* when that callee has locals. That is the thing
-to fix — and the `my $s` form is the workaround to confirm any candidate fix
-against.
+A `delegate` puts **two live instances** of this one parse site in the pipeline:
+the outer route set (which owns the `DelegateHandler`) and the delegated inner
+route set. Instrumenting the body shows the second dispatch running with the
+*inner* invocant but the *outer* `$requests`:
 
-## What does NOT reproduce it
+```
+[DBG-T] body entered,   self=RouteSet|1169 requests=Supply|2499   <- inner, correct
+  [lc] got /index.SHTML
+[DBG-T] whenever fired, self=RouteSet|1169 requests=Supply|2103   <- outer's $requests
+```
 
-All green on mutsu and raku, so the Cro `Cro::HTTP::Server` pipeline is still a
-required ingredient — do not keep shrinking, grow these toward the server:
+`self` is right because `resolution_call_sub.rs` force-installs a closure's
+captured `self` (it is lexical in Raku). `$requests` is wrong because it is an
+ordinary free variable of the supply block — a parameter of the enclosing
+`transformer` frame, which has already returned — and the `merge_all`
+caller-priority merge in `resolution_call_sub.rs` lets the *calling* frame's
+same-named binding win for anything that is not in `authoritative_free_vars` /
+`authoritative_captures`.
 
-- `tmp/whenever-call.p6` — exactly the `supply whenever wrap(...)` shape with a
-  `my $unused;` in `wrap`, tapped directly. Passes.
-- `tmp/deadmy2.p6` — the full role / `does Cro::Transform` shape, tapped directly.
-- `tmp/deadmy4.p6` — the same role composed via `Cro.compose(Inc, Doubler)` over
-  a `Cro::Message`, then tapped. So plain `Cro.compose` is not enough either.
+`exec_whenever_scope_op` (`src/vm/vm_scope_ops.rs`) already builds an
+`owned_lexicals` list for exactly this reason, but it covers only the supply
+body's `my` declarations plus (now) its emitter. A supply block body is a scope
+its caller never re-enters and whose `whenever` callbacks are dispatched later
+from arbitrary frames and threads, so **its free variables should be owned too**
+— that is the shape of the fix to try first:
 
-The failing reproducer is `tmp/mwv-K.p6`; `tmp/mwv-noafter.p6` is the control
-(same file, middleware not installed — passes, so the helper alone is harmless).
-`tmp/mwraw2.p6` is the raw-socket read that proves the server side is correct.
+```rust
+owned.extend(code.free_var_syms.iter().copied());
+```
 
-## Where to look
+Captures that genuinely must stay live are `ContainerRef` cells, and those are
+force-installed ahead of the authoritative check (`resolution_call_sub.rs:411`),
+so owning free vars by name should not freeze a shared cell. This needs a real
+`make test` + roast run: it widens the authoritative set for every supply block
+in the codebase.
 
-Between `deadmy4.p6` (passes) and `mwv-K.p6` (fails) what is left is the
-`Cro::HTTP::Server` pipeline: the connection manager, the sink end, the
-`before`/`after` insertion around the application, and the fact that the
-middleware runs on the worker thread handling the socket. Add those to
-`deadmy4.p6` one at a time. Once it reproduces standalone, the question is how
-the `whenever` operand's Supply is captured when the operand is a call whose
-frame has locals — compare the K and L variants' bytecode for the `supply
-whenever` operand (`--dump-bytecode`).
+## Reproducers
+
+- `tmp/bm1.p6` — `route { before-matched LowerCase; after-matched STS; delegate
+  <*> => $application }`. Fails on mutsu, passes on `raku`.
+- `tmp/bm3.p6` — the same with only `before-matched`; the trace above comes from
+  this one.
+- `tmp/dg1.p6`, `tmp/dg2.p6` (`DGVAR=A..D`) — the plain `delegate` variants,
+  which all pass now.
+- Run them with `bash tmp/crorund.sh <file>` (debug binary) / `tmp/crorun.sh`
+  (release) / `tmp/crorunraku.sh` (raku). `CRODBG=1` turns on the `[DBG…]` notes
+  that the staged copy of `Cro/HTTP/Router.rakumod` carries — those edits live
+  only in `tmp/cro-work/` and must not be vendored.
 
 ## Blast radius
 
-`http-middleware`, `http-session-inmemory`, `http-session-persistent`,
-`router-auth`, `http-auth-basic*` and `http-log-file` in the vendored Cro::HTTP
-suite all use `Cro::HTTP::Middleware::*` roles and should move together with this.
+`http-middleware` (subtest 2 onward), `http-session-inmemory`,
+`http-session-persistent`, `router-auth`, `http-auth-basic*` and
+`http-log-file` in the vendored Cro::HTTP suite all use
+`Cro::HTTP::Middleware::*` and should move together with this.


### PR DESCRIPTION
Chaining a supply through the **same routine twice** looped forever:

```raku
sub xform(Supply $in --> Supply) {
    supply whenever $in -> $v { emit "w($v)" }
}
my $s = supply emit 'REQ';
$s = xform($s);
$s = xform($s);
$s.tap(-> $v { say $v });   # `w(w(REQ))` in Rakudo; unbounded `w(w(w(…)))` here
```

Two *different* routines chained fine — the trigger was one routine used twice.

### Why

`supply { … }` lowers to `Supply.on-demand(-> $__mutsu_supply_emitter_N { … })`, and `emit x` inside the block becomes `$__mutsu_supply_emitter_N.emit(x)`. That name is generated per **parse site**, which keeps sibling supply blocks apart, but every runtime **instance** of one parse site shares it. Tapping the outer instance runs the inner instance's body nested inside it, so the inner binding of the shared name was live when the outer body's `whenever` callback finally ran — the outer `emit` went into the inner supply, and its value came straight back to the outer body.

`exec_whenever_scope_op` already guards this class of shadowing: it hands each `whenever` callback a list of `owned_lexicals` (the closure's `authoritative_captures`) that a same-named lexical in the dispatching frame must never shadow. But that list came from the supply body's `my` declarations, and the emitter is the body's *parameter*. It has no compiled local slot either — a supply body's `locals` is empty — so it could not be recovered from the code object's local table.

### Fix

`CompiledCode` now carries `supply_emitter_sym`, the interned emitter parameter name, set wherever `is_supply_block_body` is set: in the compiler (`expr_closure.rs`, from the lambda's parameter) and on the interpreter's re-entrant carrier path, riding along with `pending_supply_block_body` from `resolution_call_sub` into `resolution_eval` — with a fallback to the `SubData`'s parameter list for a body compiled on the fly with no `CompiledCode`. `exec_whenever_scope_op` adds it to `owned_lexicals`.

### Why it matters

This is exactly what a Cro middleware pipeline builds: `Cro::HTTP::Router`'s `!append-middleware` wraps its pipeline once per component and `Cro::HTTP::Middleware::Request.transformer` wraps again. A `before-matched` middleware in a route block used to spin forever instead of handling one request; it now runs once. (That route block still does not complete — the remaining cause is tracked in `todo/tickets/dead-my-declaration-breaks-a-composed-cro-transform.md`, which this PR updates with the trace.)

### Verification

- New pin `t/supply-block-reinstantiated.t` passes identically under `raku`.
- `make test`: `Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)