### PR TITLE
fix(supply): a supply block's vouched captures survive foreign dispatch

### DIFF
--- a/news/2026-08/supply-block-captured-lexical.md
+++ b/news/2026-08/supply-block-captured-lexical.md
@@ -1,0 +1,56 @@
+# A supply block's captured lexicals survive dispatch from a foreign frame
+
+Two live instances of one `supply { … }` parse site shared their captures:
+
+```raku
+sub xform($tag, Supply $in --> Supply) {
+    supply whenever $in -> $v { emit $tag ~ '(' ~ $v ~ ')' }
+}
+my $src = Supplier.new;
+my $s = xform('a', $src.Supply);
+$s = xform('b', $s);
+$s.tap(-> $v { say $v });
+$src.emit('x');            # Rakudo: b(a(x)) — mutsu printed a(a(x))
+```
+
+The outer instance's `whenever` callback read the *inner* instance's `$tag`.
+
+## Why
+
+A `whenever` callback is dispatched much later, from whichever frame is
+emitting. `resolution_call_sub`'s merge gives the *calling* frame priority for
+any captured name that is not in the closure's authoritative set — deliberately,
+so a `Proxy` FETCH body and friends see live values. `exec_whenever_scope_op`
+counters that for supply blocks by handing each callback an `owned_lexicals`
+list, but that list held only the body's `my` declarations (and, since the
+previous fix, its emitter). `$tag` is a free variable of the block, captured from
+a `xform` frame that has already returned, so it fell through to caller priority
+— and with one parse site instantiated twice, the "caller" is the sibling
+instance, whose binding has the very same name.
+
+The compiler already computes exactly the right set: `authoritative_free_vars`,
+the captures the *creating frame* vouches it never writes after the capture op.
+The problem was that `exec_whenever_scope_op` sees the chunk `eval_block_value`
+re-compiled from the lambda's AST, and that chunk has no enclosing frame to
+vouch for anything, so its `authoritative_free_vars` was always empty.
+
+## Fix
+
+The vouched set now travels with the supply-body mark, the same way
+`supply_emitter_sym` does: `resolution_call_sub` copies the compiled lambda's
+`authoritative_free_vars` into `pending_supply_authoritative_free_vars`, and
+`resolution_eval` merges them into the re-compiled chunk.
+`exec_whenever_scope_op` adds them to `owned_lexicals`.
+
+Using the vouched set rather than all free variables is what keeps the two
+opposite cases working, both pinned in the new test:
+
+- a capture the *caller* reassigns after building the block must be read live
+  (`my $gate = 0; my $sup = supply { … emit $gate … }; $gate = 9`), and
+- a capture the *body* writes must reach the declaring frame
+  (`whenever $s.on-close({ $closed = True })`).
+
+Owning either by name would be a by-value snapshot that silently goes stale;
+the compiler's vouch excludes both.
+
+Pinned by `t/supply-block-captured-lexical.t`.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1191,6 +1191,12 @@ pub struct Interpreter {
     /// The emitter parameter name that goes with `pending_supply_block_body`, so
     /// the re-compiled chunk also carries `CompiledCode::supply_emitter_sym`.
     pending_supply_emitter_sym: Option<Symbol>,
+    /// The compiler-vouched never-written captures of the supply lambda whose
+    /// body `eval_block_value` is about to re-compile. Only the *original*
+    /// compile saw the creating frame, so the carrier chunk cannot derive
+    /// `authoritative_free_vars` itself — it has no enclosing frame to vouch.
+    /// Travels with `pending_supply_block_body`.
+    pending_supply_authoritative_free_vars: Vec<Symbol>,
     /// Names the block `eval_block_value_inner` most recently FINISHED running
     /// declared with its own `my` (excluding those it also uses as free
     /// variables). Written just before that function returns, so after a call

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -654,9 +654,18 @@ impl Interpreter {
             if self.pending_supply_emitter_sym.is_some() {
                 self.pending_supply_block_body = true;
             }
+            // Only the original compile saw the creating frame, so the vouched
+            // capture set has to be handed over rather than recomputed.
+            self.pending_supply_authoritative_free_vars = data
+                .compiled_code
+                .as_ref()
+                .filter(|cc| cc.is_supply_block_body)
+                .map(|cc| cc.authoritative_free_vars.clone())
+                .unwrap_or_default();
             let body_result = self.eval_block_value(&data.body);
             self.pending_supply_block_body = false;
             self.pending_supply_emitter_sym = None;
+            self.pending_supply_authoritative_free_vars = Vec::new();
             // The `my` names the body just declared, published by
             // `eval_block_value_inner`. Taken immediately, before anything below
             // can run another block and overwrite it. This is how a body with no

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -176,6 +176,8 @@ impl Interpreter {
         // inherit the mark — see `pending_supply_block_body`.
         let is_supply_block_body = std::mem::take(&mut self.pending_supply_block_body);
         let supply_emitter_sym = std::mem::take(&mut self.pending_supply_emitter_sym);
+        let supply_authoritative_free_vars =
+            std::mem::take(&mut self.pending_supply_authoritative_free_vars);
         let let_mark = self.let_saves_len();
         let mut saved_functions = self.registry().functions.clone();
         let saved_proto_subs = self.registry().proto_subs.clone();
@@ -211,6 +213,11 @@ impl Interpreter {
         let (mut code, compiled_fns) = self.compile_block_value_opts(body, is_eval_unit);
         code.is_supply_block_body = is_supply_block_body;
         code.supply_emitter_sym = supply_emitter_sym;
+        for sym in supply_authoritative_free_vars {
+            if !code.authoritative_free_vars.contains(&sym) {
+                code.authoritative_free_vars.push(sym);
+            }
+        }
         // Multi-frame coherence (env_dirty-deletion path): box any captured-outer
         // scalar this carrier body writes into a shared cell across env + saved
         // frames, so the by-name write survives the owner frame's env restore.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2127,6 +2127,7 @@ impl Interpreter {
             pending_eval_placeholder_params: Vec::new(),
             pending_supply_block_body: false,
             pending_supply_emitter_sym: None,
+            pending_supply_authoritative_free_vars: Vec::new(),
             last_block_my_declared: Vec::new(),
             predictive_seq_iters: HashMap::new(),
             protect_block_cache: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -395,6 +395,7 @@ impl Interpreter {
             pending_eval_placeholder_params: Vec::new(),
             pending_supply_block_body: false,
             pending_supply_emitter_sym: None,
+            pending_supply_authoritative_free_vars: Vec::new(),
             last_block_my_declared: Vec::new(),
             predictive_seq_iters: self.predictive_seq_iters.clone(),
             protect_block_cache: HashMap::new(),

--- a/src/vm/vm_scope_ops.rs
+++ b/src/vm/vm_scope_ops.rs
@@ -164,6 +164,30 @@ impl Interpreter {
                 {
                     owned.push(sym);
                 }
+                // The body's never-written free variables are owned too. A supply
+                // block body is a scope its caller never re-enters, and its
+                // `whenever` callbacks are dispatched much later from an arbitrary
+                // frame — so a lexical it captured must not be re-resolved against
+                // whoever happens to dispatch it. Two live instances of one parse
+                // site make this concrete: with
+                // `Cro::HTTP::Router::RouteSet.transformer`'s
+                // `supply { whenever $requests { … } }` instantiated for both the
+                // outer route set and a delegated inner one, the inner body's
+                // callback saw the OUTER `$requests`.
+                //
+                // Only `authoritative_free_vars` qualify — the captures the
+                // *creating frame* vouched for as never written after the capture.
+                // A capture the supply body writes is shared state whose updates
+                // must reach the declaring frame (`whenever $s.on-close({ $closed
+                // = True })`), and one the declaring frame reassigns after the
+                // block was built must still be read live (`my $gate = 0; my $sup
+                // = supply { … emit $gate … }; $gate = 9`) — freezing either here
+                // would be a by-value snapshot that silently goes stale.
+                for sym in &code.authoritative_free_vars {
+                    if !owned.contains(sym) {
+                        owned.push(*sym);
+                    }
+                }
                 owned
             } else {
                 Vec::new()

--- a/t/supply-block-captured-lexical.t
+++ b/t/supply-block-captured-lexical.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 3;
+
+# A `supply { … }` block's `whenever` callbacks run long after the routine that
+# built the block returned, dispatched from whatever frame happens to be
+# emitting. The lexicals the block captured must still resolve to what it
+# captured — even when the dispatching frame has a binding of the same name,
+# which is guaranteed the moment one parse site has two live instances.
+
+{
+    sub xform($tag, Supply $in --> Supply) {
+        supply whenever $in -> $v { emit $tag ~ '(' ~ $v ~ ')' }
+    }
+    my $src = Supplier.new;
+    my $s = xform('a', $src.Supply);
+    $s = xform('b', $s);
+    my @got;
+    $s.tap(-> $v { @got.push($v) });
+    $src.emit('x');
+    $src.emit('y');
+    is @got, ['b(a(x))', 'b(a(y))'], 'each instance keeps its own captured lexical';
+}
+
+{
+    # A capture the enclosing frame reassigns AFTER building the block must
+    # still be read live — it is not frozen by the ownership above.
+    my $gate = 0;
+    my $sup = supply { whenever Supply.from-list(1) { emit $gate } };
+    $gate = 9;
+    my @got;
+    $sup.tap({ @got.push($_) });
+    is @got, [9], 'a capture the caller reassigns later is read at tap time';
+}
+
+{
+    # A capture the supply body itself writes must reach the declaring frame.
+    my $seen = 0;
+    my $src = Supplier.new;
+    my $sup = supply { whenever $src.Supply -> $v { $seen = $v; emit $v } };
+    $sup.tap(-> $v { });
+    $src.emit(7);
+    is $seen, 7, 'a capture the body writes is visible to the declaring frame';
+}

--- a/todo/tickets/dead-my-declaration-breaks-a-composed-cro-transform.md
+++ b/todo/tickets/dead-my-declaration-breaks-a-composed-cro-transform.md
@@ -21,56 +21,45 @@ bugs behind it have been fixed:
 - A supply block's generated emitter is now owned by the `whenever` closures it
   creates, so two live instances of one parse site no longer feed each other
   (`news/2026-08/supply-block-reinstantiated.md`, pinned by
-  `t/supply-block-reinstantiated.t`). This removed the infinite
-  `[lc] target=...` loop.
+  `t/supply-block-reinstantiated.t`).
+- A supply block's compiler-vouched captures are owned too, so the inner route
+  set's callback stops reading the outer's `$requests`
+  (`news/2026-08/supply-block-captured-lexical.md`, pinned by
+  `t/supply-block-captured-lexical.t`).
 
-## The remaining bug
+## The remaining bug: `RouteHandler.invoke` never emits its response
 
-`Cro::HTTP::Router::RouteSet.transformer` is
+Routing is now entirely correct. `tmp/bm3.p6` (`route { before-matched
+LowerCase; delegate <*> => $application }`) reaches the delegated route set's
+own handler, matching raku step for step — and then stops:
+
+```
+[DBG-T] whenever fired, self=RouteSet|1169 requests=Supply|2499   <- inner, correct
+[DBG] routing-outcome for /index.shtml = (0, \("index.shtml"))
+[DBG] handler 0 = Cro::HTTP::Router::RouteSet::RouteHandler args=\("index.shtml")
+                                       <- raku prints `handler emitted Cro::HTTP::Response` here
+```
+
+So the next thing to dig into is `RouteHandler.invoke`
+(`lib/Cro/HTTP/Router.rakumod`, around line 205-264), specifically the
+`@!before-matched`-taken branch:
 
 ```raku
-method transformer(Supply:D $requests) {
-    supply {
-        whenever $requests -> $request { ... @!handlers ... }
-    }
+my $current = supply emit $request;
+$current = self!append-middleware($current, @!before-matched, %connection-state);
+my $response = supply whenever $current -> $req {
+    whenever self!invoke-internal($req, $args) { emit $_; }
 }
+return self!append-middleware($response, @!after-matched, %connection-state);
 ```
 
-A `delegate` puts **two live instances** of this one parse site in the pipeline:
-the outer route set (which owns the `DelegateHandler`) and the delegated inner
-route set. Instrumenting the body shows the second dispatch running with the
-*inner* invocant but the *outer* `$requests`:
-
-```
-[DBG-T] body entered,   self=RouteSet|1169 requests=Supply|2499   <- inner, correct
-  [lc] got /index.SHTML
-[DBG-T] whenever fired, self=RouteSet|1169 requests=Supply|2103   <- outer's $requests
-```
-
-`self` is right because `resolution_call_sub.rs` force-installs a closure's
-captured `self` (it is lexical in Raku). `$requests` is wrong because it is an
-ordinary free variable of the supply block — a parameter of the enclosing
-`transformer` frame, which has already returned — and the `merge_all`
-caller-priority merge in `resolution_call_sub.rs` lets the *calling* frame's
-same-named binding win for anything that is not in `authoritative_free_vars` /
-`authoritative_captures`.
-
-`exec_whenever_scope_op` (`src/vm/vm_scope_ops.rs`) already builds an
-`owned_lexicals` list for exactly this reason, but it covers only the supply
-body's `my` declarations plus (now) its emitter. A supply block body is a scope
-its caller never re-enters and whose `whenever` callbacks are dispatched later
-from arbitrary frames and threads, so **its free variables should be owned too**
-— that is the shape of the fix to try first:
-
-```rust
-owned.extend(code.free_var_syms.iter().copied());
-```
-
-Captures that genuinely must stay live are `ContainerRef` cells, and those are
-force-installed ahead of the authoritative check (`resolution_call_sub.rs:411`),
-so owning free vars by name should not freeze a shared cell. This needs a real
-`make test` + roast run: it widens the authoritative set for every supply block
-in the codebase.
+The `whenever` nested inside a `whenever` body — registered while the drive loop
+is already running, so it goes onto `pending_react_subscriptions` rather than a
+registration frame (`runtime/subtest.rs`, `run_whenever_with_value`) — is the
+prime suspect, together with `!invoke-internal`'s `start { … }` block. Note the
+handler that *does* work (`include`, and `delegate` with no middleware) takes
+the `else` branch, `return self!invoke-internal($request, $args)`, which has no
+nested `whenever` at all — that asymmetry is the lead.
 
 ## Reproducers
 


### PR DESCRIPTION
Two live instances of one `supply { … }` parse site shared their captures — the outer instance's `whenever` callback read the *inner* instance's lexical:

```raku
sub xform($tag, Supply $in --> Supply) {
    supply whenever $in -> $v { emit $tag ~ '(' ~ $v ~ ')' }
}
my $src = Supplier.new;
my $s = xform('a', $src.Supply);
$s = xform('b', $s);
$s.tap(-> $v { say $v });
$src.emit('x');            # Rakudo: b(a(x)) — mutsu printed a(a(x))
```

### Why

A `whenever` callback is dispatched much later, from whichever frame is emitting. `resolution_call_sub`'s merge gives that frame priority for any captured name outside the closure's authoritative set — deliberately, so a `Proxy` FETCH body and friends see live values. `exec_whenever_scope_op` counters that for supply blocks by handing each callback an `owned_lexicals` list, but that list held only the body's `my` declarations and (since #5830) its emitter. `$tag` is a free variable captured from an `xform` frame that has already returned, so it fell through to caller priority — and with one parse site instantiated twice, the "caller" is the sibling instance, whose binding has the very same name.

The compiler already computes exactly the right set: `authoritative_free_vars`, the captures the *creating frame* vouches it never writes after the capture op. It was unreachable here because `exec_whenever_scope_op` sees the chunk `eval_block_value` re-compiles from the lambda's AST, and that chunk has no enclosing frame to vouch for anything.

### Fix

The vouched set now travels with the supply-body mark, the same way `supply_emitter_sym` does: `resolution_call_sub` copies the compiled lambda's `authoritative_free_vars` into `pending_supply_authoritative_free_vars`, and `resolution_eval` merges them into the re-compiled chunk. `exec_whenever_scope_op` adds them to `owned_lexicals`.

Using the *vouched* set rather than all free variables is load-bearing, and both opposite cases are pinned in the new test — I measured each of them failing with the broader rule:

- a capture the **caller** reassigns after building the block must be read live (`my $gate = 0; my $sup = supply { … emit $gate … }; $gate = 9`) — owning all free vars broke `t/supply-cold-whenever-nonreact-drive.t`;
- a capture the **body** writes must reach the declaring frame (`whenever $s.on-close({ $closed = True })`) — owning all free vars broke `t/supply-multi-whenever-done.t`.

Owning either by name would be a by-value snapshot that silently goes stale; the compiler's vouch excludes both.

### Effect on Cro

`route { before-matched LowerCase; delegate <*> => $application }` now routes entirely correctly — the delegated route set's callback reads its own `$requests` and reaches its own `RouteHandler`, matching raku step for step. It still does not produce a response; the ticket is updated with the trace and the next lead (`RouteHandler.invoke`'s nested `whenever`).

### Verification

- New pin `t/supply-block-captured-lexical.t` passes identically under `raku`; test 1 fails as `a(a(x))` without this change.
- `make test`: `Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)