### PR TITLE
refactor(vm): invalidate method caches by generation

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -171,5 +171,7 @@ restoration synchronize user candidates into the table. Dispatch still reads the
 with it in the next stage.
 
 Every built-in seed and user-candidate synchronization advances the registry's monotonic method
-generation. Dispatch caches do not consume it yet; wiring that generation into resolved-call cache
-keys is the prerequisite for switching their read side to `MethodEntry` safely.
+generation. Resolver and fast-dispatch entry points compare it with the interpreter's observed
+generation and invalidate the resolve, fast, multi, constructor, and private-method caches as one
+unit when it changes. This removes correctness dependence on registration sites remembering every
+individual cache before the read side switches to `MethodEntry`.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2018,6 +2018,8 @@ pub struct Interpreter {
     pub(crate) prepared_fn_defs: HashMap<Symbol, (u64, Arc<FunctionDef>)>,
     pub(crate) method_resolve_cache:
         rustc_hash::FxHashMap<(Symbol, Symbol), crate::vm::MethodResolveEntry>,
+    /// Registry method generation observed when the method caches were last valid.
+    pub(crate) method_cache_generation: u64,
     #[allow(clippy::type_complexity)]
     pub(crate) last_method_resolve: Option<(Symbol, Symbol, Symbol, Arc<MethodDef>)>,
     pub(crate) fast_method_cache:

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2310,6 +2310,7 @@ impl Interpreter {
             registered_fn_fingerprints: Default::default(),
             prepared_fn_defs: HashMap::new(),
             method_resolve_cache: rustc_hash::FxHashMap::default(),
+            method_cache_generation: 0,
             last_method_resolve: None,
             fast_method_cache: rustc_hash::FxHashMap::default(),
             native_ctor_plan_cache: rustc_hash::FxHashMap::default(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -609,6 +609,7 @@ impl Interpreter {
             registered_fn_fingerprints: Default::default(),
             prepared_fn_defs: HashMap::new(),
             method_resolve_cache: rustc_hash::FxHashMap::default(),
+            method_cache_generation: 0,
             last_method_resolve: None,
             fast_method_cache: rustc_hash::FxHashMap::default(),
             native_ctor_plan_cache: rustc_hash::FxHashMap::default(),

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 impl Interpreter {
+    pub(crate) fn refresh_method_caches_for_generation(&mut self) {
+        let generation = self.registry().method_generation;
+        if self.method_cache_generation == generation {
+            return;
+        }
+        self.method_cache_generation = generation;
+        self.method_resolve_cache.clear();
+        self.last_method_resolve = None;
+        self.fast_method_cache.clear();
+        self.native_ctor_plan_cache.clear();
+        self.multi_resolve_cache.clear();
+        self.multi_type_cacheable.clear();
+        self.dispatch_multi_candidate.clear();
+        self.clear_private_zeroarg_method_cache();
+    }
+
     /// Try compiled method fast path; fall back to interpreter.
     ///
     /// Wrapper that preserves the caller's env `self`: the inner dispatch can run
@@ -129,6 +145,7 @@ impl Interpreter {
         crate::symbol::Symbol,
         std::sync::Arc<crate::runtime::MethodDef>,
     )> {
+        self.refresh_method_caches_for_generation();
         // Non-multi resolution depends only on (class, method) — not on arg
         // types/values — so it can be memoized. This mirrors the cache hierarchy
         // already used by the interpret path (`vm_call_method_compiled_interpret`);

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -480,6 +480,7 @@ impl Interpreter {
             _ => None,
         };
         if let Some(class_sym) = class_sym_opt {
+            self.refresh_method_caches_for_generation();
             let cn = class_sym.as_str();
             let cache_key = (class_sym, method_sym);
 


### PR DESCRIPTION
## Problem

Method-table mutations now have a registry generation, but dispatch correctness still depended on each mutation site manually clearing every overlapping cache.

## Approach

- track the method generation observed by each Interpreter
- check it at resolved-method and fast-dispatch entry points
- invalidate resolve, inline-fast, multi, constructor, structural-candidate, and private-method caches together when it changes
- initialize thread clones with an unobserved generation
- update ADR-0019 status

## Tests

- registry generation/override unit test
- targeted augment, MOP add-method, multi-method, and role-conflict TAP tests
- cargo build
- cargo clippy -- -D warnings
- cargo fmt --all