### PR TITLE
fix(runtime): a shared array mutation must dereference (and keep) its container cell

### DIFF
--- a/news/2026-08/shared-array-mutation-through-a-container-cell.md
+++ b/news/2026-08/shared-array-mutation-through-a-container-cell.md
@@ -1,0 +1,53 @@
+# A shared array push seeded its store from an undereferenced cell, and emptied the array
+
+Once a program spawns a thread, `shared_vars_active` stays on for the rest of
+the process and every plain lexical `@a.push` funnels through the name-keyed
+`__mutsu_atomic_arr::` store, so concurrent appends serialize instead of
+clobbering each other's stale snapshots.
+
+The first mutation seeds that store from the array's current contents:
+
+```rust
+let seed = match shared.get(arr_name).or_else(|| self.env.get(arr_name)).map(Value::view) {
+    Some(ValueView::Array(elems, _)) => elems.as_ref().clone(),
+    _ => crate::value::ArrayData::default(),   // <- empty
+};
+```
+
+The env binding is not always a bare `Array`. Every lexical a closure captures
+is boxed into a `ContainerRef` cell — which is the shape a *module* file-scope
+`my @a` has as seen from the module's own subs. `ValueView::ContainerRef(..)`
+matches neither arm, so the atomic entry was seeded **empty** and everything the
+array already held was dropped. The write-back then did
+`self.env.insert(arr_name, updated)`, replacing the cell with a bare `Array` and
+detaching every other holder of the same container.
+
+Both halves are fixed: the seed dereferences the binding, and the write-back
+goes *through* the cell when there is one, so the container keeps its identity.
+
+## How it showed up
+
+Under the real `Test.rakumod` the array in question is `@vars`, the subtest
+stack. A test file that spawns a thread part-way through a subtest lost the
+outer frame, so the enclosing `subtest`'s `_pop_vars` died:
+
+```
+Cannot pop from an empty Array
+  in sub _pop_vars at Test.rakumod line 900
+  in sub subtest at Test.rakumod line 438
+  in block <unit> at roast/S02-types/capture.t line 301
+```
+
+`roast/S02-types/capture.t` is exactly that shape — its
+`types whose .Capture behaves like Mu.Capture` subtest reaches
+`(start {sleep .5}).&has-nameds`, and every `subtest` after that point pushed
+into a store that had thrown the outer frame away. The file now runs its 46
+assertions clean under `MUTSU_REAL_TEST=1`.
+
+Reduced to 20 lines with no `Test` involved at all: a module with a file-scope
+`my @vars`, a sub that pushes to it and a sub that pops, called around a
+`start`/`await` — the push after the spawn silently did nothing.
+
+Pin: `t/shared-array-mutate-keeps-container-cell.t`, which covers the module
+shape, the in-process closure-captured shape, and the nesting depth, and fails
+3 of its 6 assertions without the fix.

--- a/src/runtime/builtins_atomic_shared.rs
+++ b/src/runtime/builtins_atomic_shared.rs
@@ -342,11 +342,19 @@ impl Interpreter {
                 shared.get(&atomic_key).map(Value::view),
                 Some(ValueView::Array(..))
             ) {
-                let seed = match shared
+                // The env binding may be a `ContainerRef` cell rather than a
+                // bare Array — every lexical a closure captures is boxed into
+                // one, which is exactly the shape a *module* file-scope `@a`
+                // has when its own subs reach it. Reading the cell's view
+                // without dereferencing it matched neither arm and seeded the
+                // atomic entry EMPTY, silently dropping everything already in
+                // the array (`Test.rakumod`'s `@vars` subtest stack lost its
+                // outer frame the first time a test file spawned a thread).
+                let local = shared
                     .get(arr_name)
                     .or_else(|| self.env.get(arr_name))
-                    .map(Value::view)
-                {
+                    .map(Value::deref_container);
+                let seed = match local.as_ref().map(Value::view) {
                     Some(ValueView::Array(elems, _)) => elems.as_ref().clone(),
                     _ => crate::value::ArrayData::default(),
                 };
@@ -384,8 +392,16 @@ impl Interpreter {
         } else {
             self.mark_shared_var_dirty(arr_name);
             // Update the local env so this thread observes its own push
-            // immediately even on direct env reads.
-            self.env.insert(arr_name.to_string(), updated.clone());
+            // immediately even on direct env reads. A `ContainerRef` binding is
+            // written *through*: the cell is the array's identity for every
+            // other holder (a closure's captured copy, a `:=` alias), so
+            // replacing the binding with a bare Array would detach them all and
+            // freeze them at the pre-mutation contents.
+            if let Some(ValueView::ContainerRef(cell)) = self.env.get(arr_name).map(Value::view) {
+                *cell.lock().unwrap_or_else(|e| e.into_inner()) = updated.clone();
+            } else {
+                self.env.insert(arr_name.to_string(), updated.clone());
+            }
         }
         (result, updated)
     }

--- a/t/shared-array-mutate-keeps-container-cell.t
+++ b/t/shared-array-mutate-keeps-container-cell.t
@@ -1,0 +1,93 @@
+use v6;
+use Test;
+
+# Once a program spawns a thread, `shared_vars_active` stays on for the rest of
+# the process and every plain lexical `@a.push` funnels through the name-keyed
+# `__mutsu_atomic_arr::` store. Seeding that store read the env binding's view
+# without dereferencing it -- and a lexical a closure captures (which is what a
+# module's file-scope `my @a` is, as seen from its own subs) is a `ContainerRef`
+# cell, not a bare Array. Neither arm matched, so the atomic entry was seeded
+# EMPTY and everything already in the array was dropped; the write-back then
+# replaced the cell with a bare Array, detaching every other holder.
+#
+# Under the real Test.rakumod that is `@vars`, the subtest stack: a file that
+# spawned a thread mid-subtest lost the outer frame and died with "Cannot pop
+# from an empty Array" (roast/S02-types/capture.t).
+
+plan 6;
+
+my $dir = $*TMPDIR.child("mutsu-shared-arr-{$*PID}");
+$dir.mkdir;
+END { try { .unlink for $dir.dir; $dir.rmdir } }
+
+$dir.child('SharedArr.rakumod').spurt(
+    'unit module SharedArr;
+my @vars;
+sub sh-push($v) { @vars.push: $v }
+sub sh-elems() is export { @vars.elems }
+sub nest($v, &body) is export {
+    sh-push($v);
+    my $r = body();
+    (@vars.pop, $r)
+}
+');
+
+my $lib = 'use lib "' ~ $dir.absolute ~ '";' ~ "\n";
+
+sub run-snippet($name, $source) {
+    my $file = $dir.child($name);
+    $file.spurt($source);
+    my $proc = run($*EXECUTABLE, $file.absolute, :out, :err);
+    my $out = $proc.out.slurp(:close);
+    $proc.err.slurp(:close);
+    $out.trim.subst("\n", " ", :g)
+}
+
+# The array already holds one element when the thread spawns, and the push that
+# follows must not lose it.
+is run-snippet('mid.raku', $lib ~ 'use SharedArr;
+nest 1, {
+    await start { 1 };
+    nest 2, { say sh-elems() };
+};
+'), '2', 'a push after a mid-flight spawn keeps what the array already held';
+
+# The pop after that spawn must return the element the matching push added, and
+# leave the outer one in place.
+is run-snippet('pop.raku', $lib ~ 'use SharedArr;
+my $outer = nest 1, {
+    await start { 1 };
+    nest 2, { 0 };
+};
+say $outer[0];
+say sh-elems();
+'), '1 0', 'the outer frame is still poppable and the array drains to empty';
+
+# The cell identity has to survive: a second module sub reading the same
+# file-scope `@vars` must see the push, not a frozen pre-spawn copy.
+is run-snippet('identity.raku', $lib ~ 'use SharedArr;
+await start { 1 };
+nest 1, { say sh-elems() };
+say sh-elems();
+'), '1 0', 'another sub reading the same lexical sees the mutation';
+
+# Deeper nesting across the spawn.
+is run-snippet('deep.raku', $lib ~ 'use SharedArr;
+nest 1, {
+    nest 2, {
+        await start { 1 };
+        nest 3, { say sh-elems() };
+    };
+    say sh-elems();
+};
+'), '3 1', 'nested frames across a spawn all survive';
+
+# The in-process shape of the same thing, without a module: a `@a` captured by a
+# closure is celled too.
+my @a;
+my &grow = { @a.push: $^v };
+grow(1);
+await start { 1 };
+grow(2);
+is @a.elems, 2, 'a closure-captured array keeps its contents across a spawn';
+is-deeply @a[0], 1, 'and the pre-spawn element is still the first one';


### PR DESCRIPTION
## What

Once a program spawns a thread, `shared_vars_active` stays on for the rest of the process and every plain lexical `@a.push` funnels through the name-keyed `__mutsu_atomic_arr::` store. Seeding that store read the env binding's view **without dereferencing it**:

```rust
let seed = match shared.get(arr_name).or_else(|| self.env.get(arr_name)).map(Value::view) {
    Some(ValueView::Array(elems, _)) => elems.as_ref().clone(),
    _ => ArrayData::default(),   // <- empty
};
```

Every lexical a closure captures is boxed into a `ContainerRef` cell — which is the shape a **module file-scope `my @a`** has as seen from the module's own subs. `ContainerRef` matches neither arm, so the atomic entry was seeded **empty** and everything the array already held was dropped. The write-back then did `env.insert(name, updated)`, replacing the cell with a bare `Array` and detaching every other holder.

Both halves are fixed: the seed dereferences the binding, and the write-back goes *through* the cell when there is one.

## How it showed up

Under the real `Test.rakumod` the array is `@vars`, the subtest stack. A test file that spawns a thread part-way through a subtest lost the outer frame:

```
Cannot pop from an empty Array
  in sub _pop_vars at Test.rakumod line 900
  in sub subtest at Test.rakumod line 438
  in block <unit> at roast/S02-types/capture.t line 301
```

`roast/S02-types/capture.t` is exactly that shape (`(start {sleep .5}).&has-nameds` mid-subtest); it now runs its 46 assertions clean under `MUTSU_REAL_TEST=1`.

Reduced to a 20-line repro with no `Test` involved: a module with a file-scope `my @vars`, a sub that pushes and a sub that pops, called around a `start`/`await` — the push after the spawn silently did nothing.

## Verification

- `t/shared-array-mutate-keeps-container-cell.t` — new pin; **3 of its 6 assertions fail without the fix**, all 6 pass under `raku`.
- `make test` PASS (2830 files), release `make roast` PASS (1435 files), bundled-library gate PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)