### PR TITLE
fix: a `for` statement modifier is not a placeholder scope

### DIFF
--- a/news/2026-08/for-modifier-placeholder-scope.md
+++ b/news/2026-08/for-modifier-placeholder-scope.md
@@ -1,0 +1,62 @@
+# A `for` statement modifier is not a placeholder scope
+
+`Digest::MD5` and `Digest::RIPEMD` both build their message block with
+
+    $^b.push($_) for (@$msg, 0x80, 0x00 xx …).flat.rotor(4).map({ :256[@^a.reverse] });
+
+and mutsu read `$^b` as `True`. Reduced:
+
+    my $f = { say $^b for (1, 2) }; $f(42);
+    # raku:  42 42
+    # mutsu: True True
+
+## The AST could not tell the two `for` forms apart
+
+`collect_ph_stmt_shallow`'s `Stmt::For` arm deliberately did NOT descend into
+the loop body, and that is right for a `for` **block**: its body is its own
+placeholder scope, so `for @a { $^x }` gives the *loop* the parameter and the
+enclosing block must not also claim it. But a `for` **statement modifier** is not
+a block — its body is one statement evaluated in the enclosing scope — and both
+forms were spelled as `Stmt::For { param: None, params: [] }`, indistinguishable.
+
+`Stmt::For` now carries `is_statement_modifier: bool`, set only by the modifier
+production in `parser/stmt/modifier.rs`, matching the `is_statement_modifier`
+`Stmt::Given` already had. The three placeholder walkers in `ast.rs`
+(`collect_ph_stmt_shallow`, `collect_unattached_ph_stmt`, `check_bare_var_stmt`)
+descend into the body only for the modifier form. Codegen ignores the flag: the
+two forms compile identically.
+
+## The plain spelling of a placeholder
+
+Collecting `$^b` correctly then exposed the next line of the same block:
+
+    $^b.push($_) for …;
+    $b.write-uint64: $b.elems, $bits, LittleEndian;
+
+`$^b` declares the parameter under its *plain* name, so the later `$b` is the
+same variable. mutsu enforces the ordering rule ("a bare `$b` written *before*
+its `$^b` is `X::Undeclared`") with `bare_precedes_placeholder`, whose walker
+did not look inside a `Stmt::VarDecl`'s initializer or a `for` modifier's body —
+so `{ my $z = $^b; say $b }` and `{ say $^b for 1; say $b }` both reported the
+later `$b` as undeclared. Both arms were added, checked against rakudo:
+
+| block                             | rakudo     | reason                              |
+| --------------------------------- | ---------- | ----------------------------------- |
+| `{ my $z = $^b; say $b }`         | ok         | same statement scope                |
+| `{ say $^b for 1; say $b }`       | ok         | a modifier body is this scope       |
+| `{ for 1 { $^b }; say $b }`       | undeclared | the loop block owns the placeholder |
+| `{ if 1 { $^b }; say $b }`        | undeclared | the `if` block owns it              |
+| `{ say $b; say $^b }`             | undeclared | bare use precedes the placeholder   |
+
+Rows 1, 2 and 5 are pinned in `t/for-modifier-placeholder-scope.t`, which passes
+under rakudo as well as mutsu. Rows 3 and 4 stay **known false negatives**:
+mutsu accepts both. That gap predates this change and is a separate defect in
+`bare_precedes_placeholder` — the scan is per top-level statement and never
+descends into a nested block's body, so it cannot see that the inner `$^b`
+belongs to the inner block rather than to this one. Fixing it means giving the
+walker the same scope discipline the placeholder collectors have; it is not
+needed by the `Digest` distribution, so it is left recorded here rather than
+attempted alongside.
+
+`Digest::MD5` now runs to completion; its digest is still wrong, which is a
+further bug tracked in `todo/tickets/digest-dist-blockers.md`.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -785,6 +785,14 @@ pub(crate) enum Stmt {
         /// True when `-> {}` (empty pointy block) was used, meaning the block
         /// explicitly declares zero parameters. Passing any argument should throw.
         explicit_zero_params: bool,
+        /// True when this loop came from the `EXPR for LIST` **statement
+        /// modifier** form rather than the `for LIST { ... }` block form. A
+        /// modifier body is not a block: it is evaluated in the enclosing
+        /// scope, so a placeholder in it (`{ say $^b for 1, 2 }`) belongs to
+        /// the *enclosing* block, not to the loop. The block form is its own
+        /// placeholder scope (`for @a { $^x }` gives the loop the parameter).
+        #[serde(default)]
+        is_statement_modifier: bool,
     },
     Say(Vec<Expr>),
     Put(Vec<Expr>),
@@ -1410,7 +1418,21 @@ fn collect_unattached_ph_stmt(stmt: &Stmt, out: &mut Vec<String>) {
         Stmt::If { cond, .. } | Stmt::While { cond, .. } | Stmt::When { cond, .. } => {
             collect_unattached_ph_expr(cond, out)
         }
-        Stmt::For { iterable, .. } => collect_unattached_ph_expr(iterable, out),
+        Stmt::For {
+            iterable,
+            body,
+            is_statement_modifier,
+            ..
+        } => {
+            collect_unattached_ph_expr(iterable, out);
+            // A `for` statement modifier is not a block — its body runs in the
+            // enclosing scope, so a placeholder there is unattached here too.
+            if *is_statement_modifier {
+                for s in body {
+                    collect_unattached_ph_stmt(s, out);
+                }
+            }
+        }
         Stmt::Given { topic, .. } => collect_unattached_ph_expr(topic, out),
         Stmt::Label { stmt, .. } => collect_unattached_ph_stmt(stmt, out),
         // Everything else (blocks, sub/class decls, ...) is a boundary.
@@ -2028,12 +2050,27 @@ fn collect_ph_stmt_shallow(stmt: &Stmt, out: &mut Vec<String>) {
                 collect_ph_stmt_shallow(s, out);
             }
         }
-        Stmt::For { iterable, .. } => {
-            // A `for` body is its own placeholder scope: with no explicit loop
-            // signature its placeholders become the loop's parameters (see
+        Stmt::For {
+            iterable,
+            body,
+            is_statement_modifier,
+            ..
+        } => {
+            // A `for` BLOCK body is its own placeholder scope: with no explicit
+            // loop signature its placeholders become the loop's parameters (see
             // parser::stmt::control::for_loops), so they must not also be claimed
             // by the enclosing block/sub. Only the iterable is in this scope.
+            //
+            // A `for` STATEMENT MODIFIER has no block: `$^b.push($_) for @list`
+            // evaluates its body in the enclosing scope, so `$^b` is the
+            // *enclosing* block's parameter (`{ say $^b for 1, 2 }` called with
+            // 42 prints "42" twice). Descend in that case.
             collect_ph_expr_shallow(iterable, out);
+            if *is_statement_modifier {
+                for s in body {
+                    collect_ph_stmt_shallow(s, out);
+                }
+            }
         }
         Stmt::Loop { body, .. } | Stmt::React { body } => {
             for s in body {
@@ -2349,10 +2386,30 @@ fn check_bare_var_stmt(stmt: &Stmt, bare_name: &str, found: &mut bool) {
         Stmt::Expr(e) | Stmt::Return(e) | Stmt::Die(e) | Stmt::Fail(e) | Stmt::Take(e, _) => {
             check_bare_var_expr(e, bare_name, found);
         }
-        Stmt::Assign { expr, .. } => check_bare_var_expr(expr, bare_name, found),
+        Stmt::Assign { expr, .. } | Stmt::VarDecl { expr, .. } => {
+            check_bare_var_expr(expr, bare_name, found)
+        }
         Stmt::Say(es) | Stmt::Put(es) | Stmt::Print(es) | Stmt::Note(es) => {
             for e in es {
                 check_bare_var_expr(e, bare_name, found);
+            }
+        }
+        // A `for` statement MODIFIER is not a block: its body is part of this
+        // statement and runs in this scope, so `$^b` there declares this block's
+        // `$b` (`{ say $^b for 1; say $b }`). A `for` BLOCK owns its
+        // placeholders, so `{ for 1 { $^b }; say $b }` really is undeclared —
+        // only the iterable is in this scope there.
+        Stmt::For {
+            iterable,
+            body,
+            is_statement_modifier,
+            ..
+        } => {
+            check_bare_var_expr(iterable, bare_name, found);
+            if *is_statement_modifier {
+                for s in body {
+                    check_bare_var_stmt(s, bare_name, found);
+                }
             }
         }
         Stmt::Call { args, .. } => {

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -1231,6 +1231,7 @@ impl Compiler {
                 mode,
                 rw_block,
                 explicit_zero_params,
+                is_statement_modifier,
             } = stmt.as_ref()
         {
             let mut new_body = body.clone();
@@ -1262,6 +1263,7 @@ impl Compiler {
                 mode: *mode,
                 rw_block: *rw_block,
                 explicit_zero_params: *explicit_zero_params,
+                is_statement_modifier: *is_statement_modifier,
             }];
             return Some(gather_body);
         }

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -378,6 +378,9 @@ impl Compiler {
             mode: crate::ast::ForMode::Normal,
             rw_block: false,
             explicit_zero_params: false,
+            // Placeholders were already resolved on the source `lazy for` node;
+            // this synthesized loop wraps an ordinary block body.
+            is_statement_modifier: false,
         };
         // Build gather block wrapping the for loop, then mark it `.lazy` so the
         // body does not run until the resulting Seq is consumed (`lazy for`

--- a/src/compiler/helpers_phasers.rs
+++ b/src/compiler/helpers_phasers.rs
@@ -167,6 +167,7 @@ impl Compiler {
                 mode,
                 rw_block,
                 explicit_zero_params,
+                is_statement_modifier,
             } => Stmt::For {
                 iterable: iterable.clone(),
                 param: param.clone(),
@@ -184,6 +185,7 @@ impl Compiler {
                 mode: *mode,
                 rw_block: *rw_block,
                 explicit_zero_params: *explicit_zero_params,
+                is_statement_modifier: *is_statement_modifier,
             },
             Stmt::Loop {
                 init,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1855,6 +1855,9 @@ impl Compiler {
                 mode,
                 rw_block,
                 explicit_zero_params,
+                // Only the placeholder collectors in `ast.rs` care whether this
+                // loop came from the statement-modifier form; codegen is identical.
+                is_statement_modifier: _,
             } => {
                 // `for @a[*] { ... }` — a whole-array Whatever slice iterates the
                 // same elements as `for @a`, including aliasing for write-back

--- a/src/parser/primary/ident/supply.rs
+++ b/src/parser/primary/ident/supply.rs
@@ -175,6 +175,7 @@ fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {
             mode,
             rw_block,
             explicit_zero_params,
+            is_statement_modifier,
         } => Stmt::For {
             iterable,
             param,
@@ -186,6 +187,7 @@ fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {
             mode,
             rw_block,
             explicit_zero_params,
+            is_statement_modifier,
         },
         Stmt::Given {
             topic,

--- a/src/parser/stmt/control/for_loops.rs
+++ b/src/parser/stmt/control/for_loops.rs
@@ -313,6 +313,7 @@ fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stm
             mode,
             rw_block,
             explicit_zero_params,
+            is_statement_modifier: false,
         },
     ))
 }

--- a/src/parser/stmt/control/labeled_loop.rs
+++ b/src/parser/stmt/control/labeled_loop.rs
@@ -51,6 +51,7 @@ pub(crate) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
                 mode: crate::ast::ForMode::Normal,
                 rw_block,
                 explicit_zero_params,
+                is_statement_modifier: false,
             },
         ));
     }
@@ -135,6 +136,9 @@ pub(crate) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
                 mode: crate::ast::ForMode::Normal,
                 rw_block: false,
                 explicit_zero_params: false,
+                // A labeled `do {}` / bare `{}` lowered to a dummy loop: the
+                // body is a real block, so it owns its placeholders.
+                is_statement_modifier: false,
             },
         ));
     }
@@ -156,6 +160,9 @@ pub(crate) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
                 mode: crate::ast::ForMode::Normal,
                 rw_block: false,
                 explicit_zero_params: false,
+                // A labeled `do {}` / bare `{}` lowered to a dummy loop: the
+                // body is a real block, so it owns its placeholders.
+                is_statement_modifier: false,
             },
         ));
     }

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -554,6 +554,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 mode: crate::ast::ForMode::Normal,
                 rw_block: false,
                 explicit_zero_params: false,
+                is_statement_modifier: true,
             },
         )));
     }

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -250,6 +250,7 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             mode,
             rw_block,
             explicit_zero_params,
+            is_statement_modifier: _,
         } => {
             // Implicit-topic (`for SRC { ... $_ }`, slice 6) and explicit-signature
             // (`for @a -> $x`, slice 12) forms. Hyper/race/lazy modes, `<->` rw

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -189,6 +189,9 @@ fn lower_for(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         mode: crate::ast::ForMode::Normal,
         rw_block: false,
         explicit_zero_params: false,
+        // RakuAST spells the modifier form as `StatementModifierFor`, which this
+        // lowering does not cover; a `RakuAst::Statement::For` is the block form.
+        is_statement_modifier: false,
     })
 }
 

--- a/src/runtime/dispatch_proto_rewrite.rs
+++ b/src/runtime/dispatch_proto_rewrite.rs
@@ -81,6 +81,7 @@ impl Interpreter {
                 mode,
                 rw_block,
                 explicit_zero_params,
+                is_statement_modifier,
             } => Stmt::For {
                 iterable: Self::rewrite_proto_dispatch_expr(iterable),
                 body: Self::rewrite_proto_dispatch_stmts(body),
@@ -92,6 +93,7 @@ impl Interpreter {
                 mode: *mode,
                 rw_block: *rw_block,
                 explicit_zero_params: *explicit_zero_params,
+                is_statement_modifier: *is_statement_modifier,
             },
             Stmt::Loop {
                 init,

--- a/t/for-modifier-placeholder-scope.t
+++ b/t/for-modifier-placeholder-scope.t
@@ -1,0 +1,65 @@
+use Test;
+
+plan 10;
+
+# A `for` STATEMENT MODIFIER is not a block: its body is evaluated in the
+# enclosing scope, so a placeholder written there belongs to the *enclosing*
+# block, not to the loop. A `for` BLOCK is its own placeholder scope
+# (`for @a { $^x }` gives the loop the parameter), and the AST spells both as
+# `Stmt::For` — hence the `is_statement_modifier` flag.
+
+{
+    my @seen;
+    my $f = { @seen.push($^b) for (1, 2) };
+    $f(42);
+    is @seen, (42, 42), 'a placeholder in a `for` modifier body is the enclosing block parameter';
+}
+
+{
+    my $f = { $^b for (1, 2) };
+    is $f.arity, 1, '...so the block has arity 1';
+    is $f.count, 1, '...and count 1';
+}
+
+# The shape Digest::MD5 / Digest::RIPEMD build their message block with.
+{
+    my $build = {
+        $^b.push($_) for (10, 20, 30);
+        $b.push(40);
+        $b;
+    };
+    is $build(my @acc), (10, 20, 30, 40),
+        'the plain spelling `$b` refers back to the `$^b` used in the modifier body';
+}
+
+# The block form keeps giving the LOOP the parameter.
+{
+    my @doubled;
+    for (7, 8) { @doubled.push($^x * 2) }
+    is @doubled, (14, 16), 'a `for` block body still owns its own placeholders';
+}
+
+{
+    my $f = { my @r; for (1, 2) { @r.push($^y) }; @r };
+    is $f(9), (1, 2), '...even when nested in a placeholder block (bound to the loop value)';
+    is $f.arity, 0, '...and the enclosing block does not claim it';
+}
+
+# `while` / `until` modifiers behave the same way.
+{
+    my $i = 0;
+    my @seen;
+    my $f = { @seen.push($^b) while $i++ < 2 };
+    $f(42);
+    is @seen, (42, 42), 'a placeholder in a `while` modifier body is the enclosing parameter';
+}
+
+# A placeholder declares its plain spelling as a lexical of the block.
+{
+    my $f = { my $z = $^b; $z + $b };
+    is $f(21), 42, '`my $z = $^b` makes the later `$b` declared';
+}
+
+# ...and using the plain spelling BEFORE the placeholder is still an error.
+throws-like 'my $f = { say $b; say $^b }; $f(1)', X::Undeclared,
+    'a bare `$b` in a statement before its `$^b` is undeclared';

--- a/todo/tickets/bare-precedes-placeholder-nested-block.md
+++ b/todo/tickets/bare-precedes-placeholder-nested-block.md
@@ -1,0 +1,44 @@
+# `bare_precedes_placeholder` does not respect nested block scopes
+
+A placeholder declares its parameter under the *plain* name, so a bare `$b`
+written **before** the `$^b` that declares it is `X::Undeclared` in rakudo.
+mutsu implements that ordering rule with `ast::bare_precedes_placeholder`, which
+walks the block's statements in order, flips `ph_seen` on the first statement
+containing `Var("^b")`, and reports the first earlier statement that references
+a bare `Var("b")`.
+
+The walk has no notion of scope: it descends into whatever `check_bare_var_stmt`
+happens to handle, and a `$^b` found in a **nested block's** body counts as
+declaring *this* block's `$b`. rakudo says the opposite — the inner block owns
+that placeholder, so the outer `$b` is undeclared:
+
+    my $f = { for 1 { $^b }; say $b }; $f(42)   # rakudo: X::Undeclared;  mutsu: prints 1
+    my $f = { if 1  { $^b }; say $b }; $f(42)   # rakudo: X::Undeclared;  mutsu: prints 1
+
+(The `for` **statement modifier** form is the opposite case and is correct:
+`{ say $^b for 1; say $b }` is legal in both, because a modifier body is not a
+block. See `news/2026-08/for-modifier-placeholder-scope.md`, which added the
+`is_statement_modifier` flag the `Stmt::For` arm now consults.)
+
+There is a second, orthogonal gap in the same routine: the order is tracked per
+*statement*, not per sub-expression, so `{ $b + $^b }` is accepted even though
+the bare use precedes the placeholder within the one statement.
+
+## Why this is more than a one-line fix
+
+`check_bare_var_stmt` / `check_bare_var_expr` are a private ad-hoc walker,
+separate from the three placeholder collectors in `ast.rs`
+(`collect_ph_stmt_shallow`, `collect_unattached_ph_stmt`,
+`collect_ph_stmt`). The right fix is to give the ordering check the same scope
+discipline those collectors already encode — stop at every construct that opens
+a placeholder scope (bare/pointy block, `if`/`while`/`for` **block** bodies,
+closures, `do`/`gather`) while still descending through statement headers and
+statement-modifier bodies — rather than growing a fourth walker with its own
+idea of what a scope is. Doing that properly probably means expressing the
+ordering rule *in terms of* the existing collectors instead of beside them.
+
+Affected: `src/ast.rs` (`bare_precedes_placeholder`, `stmt_contains_var_named`,
+`stmt_references_bare`, `check_bare_var_stmt`, `check_bare_var_expr`).
+
+Both cases are **false negatives** — mutsu accepts code rakudo rejects — so
+nothing miscompiles today; the cost is a missing compile-time diagnosis.

--- a/todo/tickets/digest-dist-blockers.md
+++ b/todo/tickets/digest-dist-blockers.md
@@ -4,8 +4,11 @@ grondilu's `Digest` dist (`libdigest-raku`, Artistic-2.0) provides `Digest::MD5`
 `Digest::SHA1`, `Digest::SHA2`, `Digest::SHA3`, `Digest::RIPEMD` and `HMAC`, and
 is the dependency of `Digest::HMAC:ver<1.0.7>:auth<zef:jjmerelo>`. Seven general
 interpreter bugs found while running it were fixed (see
-`news/2026-08/digest-dist-seven-fixes.md`); `Digest::SHA1` and `Digest::SHA2`'s
-`sha224`/`sha256` now produce correct digests. Four blockers remain, each an
+`news/2026-08/digest-dist-seven-fixes.md`), then four more that its roast
+fallout exposed (`news/2026-08/digest-dist-followup-four-fixes.md`);
+`Digest::SHA1` and `Digest::SHA2`'s `sha224`/`sha256` now produce correct
+digests. Blocker 1 below is fixed
+(`news/2026-08/for-modifier-placeholder-scope.md`); three remain, each an
 independent general bug.
 
 Reproduce with the vendored-in-zef-store copy:
@@ -13,32 +16,13 @@ Reproduce with the vendored-in-zef-store copy:
     D=~/.zef/store/libdigest-raku/74E0CB00D9501F6422E8C95959D6C212224112F7
     timeout 300 ./target/debug/mutsu -I $D/lib $D/t/md5.t
 
-## 1. A placeholder is invisible inside a `for` statement modifier
+## 1. A placeholder is invisible inside a `for` statement modifier — FIXED
 
-`Digest::MD5` and `Digest::RIPEMD` both build their message block with
-
-    $^b.push($_) for (@$msg, 0x80, 0x00 xx …).flat.rotor(4).map({ :256[@^a.reverse] });
-
-Minimal repro:
-
-    my $f = { say $^b for (1, 2) }; $f(42);
-    # raku:  42 42
-    # mutsu: True True
-
-The placeholder is not collected as the enclosing block's parameter, so the block
-compiles as an `AnonSub` with no signature and `$^b` evaluates to `True`. Root
-cause: `collect_ph_stmt_shallow`'s `Stmt::For` arm deliberately does NOT descend
-into the loop body, because a `for` **block** body is its own placeholder scope
-(`for @a { $^x }` gives the loop the parameter). A `for` **statement modifier** is
-not a block — its body is evaluated in the enclosing scope — but the AST does not
-distinguish the two forms: both are `Stmt::For` with `param: None, params: []`.
-The block form's body happens to start with a `SetLine`, which the codebase
-already uses as a pointy-block heuristic elsewhere (`is_pointy` in
-`compiler/expr_closure.rs`), but the honest fix is an explicit
-`statement_modifier: bool` field on `Stmt::For` (and the same question applies to
-`while`/`until` modifiers). Affects: `src/ast.rs` (`Stmt::For`,
-`collect_ph_stmt_shallow`, `collect_unattached_ph_stmt`), every `Stmt::For`
-construction site in the parser.
+Fixed by the `is_statement_modifier` field on `Stmt::For`; see
+`news/2026-08/for-modifier-placeholder-scope.md`. `Digest::MD5` now runs to
+completion, though it still produces a wrong digest (a further bug, not yet
+reduced — `md5("abc")` gives `fe2be2927d9087ecb52bcb1fedc50c16` instead of
+`900150983cd24fb0d6963f7d28e17f72`).
 
 ## 2. A WhateverCode cannot bind to a `@`-sigil parameter
 


### PR DESCRIPTION
`Digest::MD5` and `Digest::RIPEMD` build their message block with
`$^b.push($_) for (…).flat.rotor(4).map({ … })`, and mutsu read `$^b` as `True`:

```raku
my $f = { say $^b for (1, 2) }; $f(42);
# raku:  42 42
# mutsu: True True
```

## The AST could not tell the two `for` forms apart

`collect_ph_stmt_shallow`'s `Stmt::For` arm deliberately did NOT descend into the
loop body, and that is right for a `for` **block**: its body is its own
placeholder scope, so `for @a { $^x }` gives the *loop* the parameter and the
enclosing block must not also claim it. But a `for` **statement modifier** is not
a block — its body is one statement evaluated in the enclosing scope — and both
forms were spelled `Stmt::For { param: None, params: [] }`, indistinguishable.

`Stmt::For` now carries `is_statement_modifier: bool` (matching the field
`Stmt::Given` already had), set only by the modifier production in
`parser/stmt/modifier.rs`. The placeholder walkers in `ast.rs` descend into the
body only for that form. Codegen ignores the flag — the two forms compile
identically.

## The plain spelling of a placeholder

Collecting `$^b` correctly then exposed the next line of the same block:

```raku
$^b.push($_) for …;
$b.write-uint64: $b.elems, $bits, LittleEndian;
```

`$^b` declares the parameter under its *plain* name, so the later `$b` is the
same variable. mutsu enforces the ordering rule ("a bare `$b` written *before*
its `$^b` is `X::Undeclared`") with `bare_precedes_placeholder`, whose walker did
not look inside a `Stmt::VarDecl` initializer or a `for` modifier body. Both arms
were added; the boundaries were checked against rakudo:

| block                             | rakudo     | reason                              |
| --------------------------------- | ---------- | ----------------------------------- |
| `{ my $z = $^b; say $b }`         | ok         | same statement scope                |
| `{ say $^b for 1; say $b }`       | ok         | a modifier body is this scope       |
| `{ for 1 { $^b }; say $b }`       | undeclared | the loop block owns the placeholder |
| `{ if 1 { $^b }; say $b }`        | undeclared | the `if` block owns it              |
| `{ say $b; say $^b }`             | undeclared | bare use precedes the placeholder   |

Rows 1, 2 and 5 are pinned in `t/for-modifier-placeholder-scope.t`, which passes
under rakudo as well as mutsu. Rows 3 and 4 stay known **false negatives** that
predate this change (mutsu accepts both); recorded in
`todo/tickets/bare-precedes-placeholder-nested-block.md`.

## Status

`Digest::MD5` now runs to completion; its digest is still wrong, which is a
further bug tracked in `todo/tickets/digest-dist-blockers.md` (blocker 1 there is
now marked fixed).

`make test` green (2827 files / 26844 tests, plus 662 cargo tests). The whitelisted
`S02-`/`S03-`/`S04-`/`S05-`/`S06-`/`integration/` roast files were run locally and
are green; `integration/deep-recursion-initing-native-array.t` overflows the stack
in a **debug** build on a clean tree too (it passes in CI's release build), so it
is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)