### PR TITLE
refactor(runtime): read compiled methods from entry table

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -175,3 +175,9 @@ generation. Resolver and fast-dispatch entry points compare it with the interpre
 generation and invalidate the resolve, fast, multi, constructor, and private-method caches as one
 unit when it changes. This removes correctness dependence on registration sites remembering every
 individual cache before the read side switches to `MethodEntry`.
+
+User-method presence checks and overload lookup now read compiled and delegation candidates from
+`MethodEntry.user_candidates`. `compile_class_methods` republishes its compiled candidates through
+the table. The remaining compatibility read is explicit: an uncompiled candidate (notably one
+installed by EVAL/MOP for on-demand compilation) is still read from `ClassDef::methods` until that
+on-demand compiler writes its result back through the canonical entry.

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -111,6 +111,7 @@ impl Interpreter {
         if let Some(class_def) = self.registry_mut().classes.get_mut(class_name) {
             Self::compile_methods_for_map(&mut class_def.methods, class_name, dist);
         }
+        self.registry_mut().sync_user_method_entries(class_name);
     }
 
     /// Compile method bodies for a given role.

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -325,6 +325,31 @@ impl Registry {
         self.bump_method_generation();
     }
 
+    pub(crate) fn user_method_overloads(
+        &self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<Vec<MethodDef>> {
+        let candidates = self
+            .method_entries
+            .get(&MethodEntryKey {
+                owner: Symbol::intern(class_name),
+                name: Symbol::intern(method_name),
+            })
+            .filter(|entry| !entry.user_candidates.is_empty())
+            .map(|entry| entry.user_candidates.clone());
+        if candidates.as_ref().is_some_and(|defs| {
+            defs.iter()
+                .all(|def| def.compiled_code.is_some() || def.delegation.is_some())
+        }) {
+            return candidates;
+        }
+        self.classes
+            .get(class_name)
+            .and_then(|class| class.methods.get(method_name))
+            .cloned()
+    }
+
     fn bump_method_generation(&mut self) {
         self.method_generation = self.method_generation.wrapping_add(1);
         if self.method_generation == 0 {
@@ -576,10 +601,14 @@ impl Registry {
     pub(crate) fn class_has_method(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
         for cn in mro.iter() {
-            if let Some(class_def) = self.classes.get(cn.as_str())
-                && (class_def.methods.contains_key(method_name)
-                    || class_def.native_methods.contains(method_name))
-            {
+            let has_user = self
+                .user_method_overloads(cn.as_str(), method_name)
+                .is_some();
+            let has_native = self
+                .classes
+                .get(cn.as_str())
+                .is_some_and(|class| class.native_methods.contains(method_name));
+            if has_user || has_native {
                 return true;
             }
         }
@@ -595,8 +624,9 @@ impl Registry {
     pub(crate) fn class_has_user_method(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
         for cn in mro.iter() {
-            if let Some(class_def) = self.classes.get(cn.as_str())
-                && class_def.methods.contains_key(method_name)
+            if self
+                .user_method_overloads(cn.as_str(), method_name)
+                .is_some()
             {
                 return true;
             }
@@ -612,10 +642,7 @@ impl Registry {
         class_name: &str,
         method_name: &str,
     ) -> Option<Vec<MethodDef>> {
-        self.classes
-            .get(class_name)
-            .and_then(|class| class.methods.get(method_name))
-            .cloned()
+        self.user_method_overloads(class_name, method_name)
     }
 
     /// Bound role type parameters for `class_name` (e.g. the `::T` -> value map


### PR DESCRIPTION
## Problem

User candidates were admitted to the canonical method table, but dispatch presence and overload lookup still read ClassDef.methods exclusively.

## Approach

- publish compile_class_methods results back through the method table
- route user-method presence and overload lookup through MethodEntry.user_candidates
- retain an explicit compatibility read for uncompiled EVAL/MOP candidates until on-demand compilation writes those candidates canonically
- preserve generation-based cache invalidation from the preceding layer
- update ADR-0019 status

## Tests

- registry unit tests
- targeted TAP covering augment/EVAL, role composition, MOP add-method, built-in override, multi dispatch, and conflicts (71 tests)
- cargo build
- cargo clippy -- -D warnings
- cargo fmt --all