### PR TITLE
fix(regex): a quantified capture that ran once is still a list

### DIFF
--- a/news/2026-08/quantified-capture-single-iteration.md
+++ b/news/2026-08/quantified-capture-single-iteration.md
@@ -1,0 +1,47 @@
+# A quantified capture that ran once is still a list
+
+`"a" ~~ /(a)+/` bound `$0` to a bare `Match` instead of a one-element list.
+Rakudo listifies every quantified capture regardless of how many iterations ran
+— `(a)+`, `(a)*`, `(a)**1` and `(a)**0..1` all give `$0` an `Array`. Only a bare
+`?` is exempt: it binds the `Match` itself.
+
+`fold_quantified_captures` had the divergence marked as a deliberate TODO:
+
+```rust
+if new_entries <= stride {
+    // Exactly one iteration — mutsu keeps the single capture un-folded.
+    // TODO: Raku makes `*`/`+` always a List even for one match …
+    return;
+}
+```
+
+The fold now runs for a single iteration too. `descend_folded` reads the token's
+own quantifier to decide, so the one case Raku does *not* listify —
+`RegexQuant::ZeroOrOne`, the bare `?` — keeps binding a `Match`, while the
+otherwise-identical `**0..1` listifies.
+
+## Why it mattered
+
+`Cro::Uri`'s grammar actions walk the numbered capture as a list:
+
+```raku
+method pchars($/) {
+    my $result = '';
+    $result ~= $_<broken> ?? encode-percents(~$_) !! ~$_ for @$0;
+    make $result;
+}
+```
+
+`token pchars { (<[A..Za..z0..9._~…]>+ | '%' <[A..Fa..f0..9]>**2 | …)+ }` matches
+a plain path segment in one iteration, so `@$0` was empty and every segment
+produced the empty string. `Cro::Uri.parse("http://host/index.shtml").path` came
+back as `/`, and `Cro::HTTP::Client` — which builds its request target from
+exactly that (`my $target = ($proxy-url ?? ~$url !! $url.path) || '/'`) — sent
+every request to `/`. A `route { delegate <*> => $inner }` therefore never
+reached the delegated handler.
+
+The unlistified capture was long-standing; it became visible when `make` in a
+grammar action started taking effect for this shape, at which point the action's
+`''` result replaced the fallback text.
+
+Pinned by `t/regex-quantified-capture-single-iteration.t`.

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -961,7 +961,12 @@ fn count_pattern_capture_groups(pat: &RegexPattern) -> usize {
 /// Fold quantified captures. After a quantifier loop, positional entries from
 /// `base_len` onward may contain repeated captures from multiple iterations.
 /// If `stride` > 0 (captures per iteration), fold them into quantified lists.
-pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize, stride: usize) {
+pub(super) fn fold_quantified_captures(
+    caps: &mut RegexCaptures,
+    base_len: usize,
+    stride: usize,
+    fold_single: bool,
+) {
     if stride == 0 {
         return;
     }
@@ -980,10 +985,15 @@ pub(super) fn fold_quantified_captures(caps: &mut RegexCaptures, base_len: usize
         }
         return;
     }
-    if new_entries <= stride {
-        // Exactly one iteration — mutsu keeps the single capture un-folded.
-        // TODO: Raku makes `*`/`+` always a List even for one match (`(z)*`
-        // matching once yields `List(1)`); folding here has wider blast radius.
+    if new_entries < stride {
+        // Fewer captures than one iteration's worth: malformed, leave as is.
+        return;
+    }
+    if new_entries == stride && !fold_single {
+        // A bare `?` is the one quantifier Raku does NOT listify: `(a)?` binds
+        // `$0` to a Match (or Nil), unlike `(a)**0..1`, which yields a
+        // one-element Array. Every other quantifier folds even a single
+        // iteration (`fold_single`).
         return;
     }
     let iterations = new_entries / stride;

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -417,7 +417,14 @@ impl Interpreter {
     ) -> bool {
         let mf = store.mark();
         if stride > 0 {
-            store.fold_quantified(base_len, stride);
+            // Raku listifies every quantified capture, even for a single
+            // iteration: `(a)+`, `(a)*`, `(a)**1` and `(a)**0..1` all bind `$0`
+            // to an Array. A bare `?` is the sole exception — it binds a Match.
+            let fold_single = !matches!(
+                ctx.pattern.tokens[idx].quant,
+                crate::runtime::regex_types::RegexQuant::ZeroOrOne
+            );
+            store.fold_quantified(base_len, stride, fold_single);
         }
         let stop = self.walk_tokens(ctx, idx + 1, at, store, matches);
         store.rewind(mf);

--- a/src/runtime/regex/regex_trail.rs
+++ b/src/runtime/regex/regex_trail.rs
@@ -313,7 +313,7 @@ impl CapStore {
     }
 
     /// Trailed `fold_quantified_captures`: save the unfolded tail, then fold.
-    pub(super) fn fold_quantified(&mut self, base_len: usize, stride: usize) {
+    pub(super) fn fold_quantified(&mut self, base_len: usize, stride: usize, fold_single: bool) {
         if stride == 0 {
             return;
         }
@@ -328,7 +328,12 @@ impl CapStore {
         };
         self.caps.positional.extend(rec.slots.iter().cloned());
         self.trail.push(Undo::PosTail(Box::new(rec)));
-        super::regex_helpers::fold_quantified_captures(&mut self.caps, base_len, stride);
+        super::regex_helpers::fold_quantified_captures(
+            &mut self.caps,
+            base_len,
+            stride,
+            fold_single,
+        );
     }
 }
 
@@ -428,7 +433,7 @@ mod tests {
         store.push_positional(PosSlot::span(1, 2));
         store.push_positional(PosSlot::span(2, 3));
         let mf = store.mark();
-        store.fold_quantified(1, 1);
+        store.fold_quantified(1, 1, true);
         assert_eq!(store.caps().positional.len(), 2); // folded into one slot
         assert!(store.caps().positional[1].quantified.is_some());
         store.rewind(mf);

--- a/t/regex-quantified-capture-single-iteration.t
+++ b/t/regex-quantified-capture-single-iteration.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 10;
+
+# Raku listifies EVERY quantified capture, even when the quantifier ran exactly
+# once: `(a)+`, `(a)*`, `(a)**1` and `(a)**0..1` all bind `$0` to a list. A bare
+# `?` is the sole exception — it binds the Match itself.
+#
+# `Cro::Uri`'s grammar actions walk `@$0` (`method pchars($/) { … for @$0 }`),
+# so an unlistified single iteration made every parsed URI's path come out as
+# `/`, and every Cro client request went to the wrong target.
+
+'a' ~~ /(a)+/;
+nok $0 ~~ Match, 'a single-iteration + capture is not a bare Match';
+is $0.elems, 1, '... it is a one-element list';
+is ~$0[0], 'a', '... holding the iteration match';
+
+'a' ~~ /(a)*/;
+nok $0 ~~ Match, 'a single-iteration * capture is a list';
+
+'a' ~~ /(a)**1/;
+nok $0 ~~ Match, 'a **1 capture is a list';
+
+'a' ~~ /(a)**0..1/;
+nok $0 ~~ Match, 'a **0..1 capture is a list';
+
+'a' ~~ /(a)?/;
+ok $0 ~~ Match, 'a bare ? capture stays a Match';
+is ~$0, 'a', '... which is the matched text';
+
+'ab' ~~ /(\w)+/;
+is $0.elems, 2, 'a multi-iteration capture still lists every iteration';
+
+'ab' ~~ /(a)(b)/;
+ok $0 ~~ Match, 'an unquantified capture stays a Match';


### PR DESCRIPTION
`"a" ~~ /(a)+/` bound `$0` to a bare `Match` instead of a one-element list. Rakudo listifies **every** quantified capture regardless of how many iterations ran — `(a)+`, `(a)*`, `(a)**1` and `(a)**0..1` all give `$0` an `Array`. Only a bare `?` is exempt: it binds the `Match` itself.

`fold_quantified_captures` had the divergence marked as a deliberate TODO:

```rust
if new_entries <= stride {
    // Exactly one iteration — mutsu keeps the single capture un-folded.
    // TODO: Raku makes `*`/`+` always a List even for one match …
    return;
}
```

The fold now runs for a single iteration too. `descend_folded` reads the token's own quantifier to decide, so `RegexQuant::ZeroOrOne` (the bare `?`) keeps binding a `Match` while the otherwise-identical `**0..1` listifies — matching Rakudo on both.

### Why it mattered

`Cro::Uri`'s grammar actions walk the numbered capture as a list:

```raku
method pchars($/) {
    my $result = '';
    $result ~= $_<broken> ?? encode-percents(~$_) !! ~$_ for @$0;
    make $result;
}
```

`token pchars { (<[A..Za..z0..9._~…]>+ | '%' <[A..Fa..f0..9]>**2 | …)+ }` matches a plain path segment in a single iteration, so `@$0` was empty and every segment produced `''`. `Cro::Uri.parse("http://host/index.shtml").path` came back as `/`, and `Cro::HTTP::Client` — whose request target is exactly that path (`my $target = ($proxy-url ?? ~$url !! $url.path) || '/'`) — sent every request to `/`. A `route { delegate <*> => $inner }` therefore never reached the delegated handler.

The unlistified capture is long-standing; it only became visible when `make` in a grammar action started taking effect for this shape (#5822), at which point the action's `''` replaced the fallback text.

### Verification

- New pin `t/regex-quantified-capture-single-iteration.t` passes identically under `raku`.
- `make test`: `Result: PASS` (2819 files, 26767 tests).
- `Cro::Uri.parse(…).path` is `/index.shtml` again, and a delegated route block now routes to the delegated handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)