### PR TITLE
refactor(vm): dispatch native methods by handler id

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -160,8 +160,10 @@ The dispatch layer now has a canonical `BuiltinMethodEntry` keyed by owner type 
 Built-in introspection derives its name list from those entries. The
 runtime `Registry` owns those entries in a `(owner, method)` map, seeds them from static data at
 construction without invoking native handlers, and serves built-in introspection from that map.
-Replacing the transitional arity-specific dispatch functions with static native handler IDs and
-routing dispatch reads through the shared entry remain open.
+Each built-in entry now carries a static `NativeMethodHandlerId`, and the VM pure-native dispatch
+entry admits modeled built-in calls through the registry row before invoking the arity-specific
+implementation behind that ID. Remaining compatibility call paths still invoke the arity helpers
+directly and must be routed through the shared entry.
 
 `MethodEntry` now carries both an optional built-in descriptor and ordered user candidates, so a
 user override and its built-in fallback share one `(owner, method)` row. Class declaration,

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -718,11 +718,19 @@ pub(crate) const METHOD_UNIVERSE: &[&str] = &[
 /// One canonical built-in type×method entry. User candidates will use the same shape once
 /// ADR-0019's registry migration lands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NativeMethodHandlerId {
+    PureArity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct BuiltinMethodEntry {
     pub(crate) owner: &'static str,
     pub(crate) name: &'static str,
     /// Stable catalog order used by `.^methods`.
     pub(crate) order: u16,
+    /// Static dispatch target. Arity-specific functions are implementation
+    /// details behind this ID, not independent method lookup sources.
+    pub(crate) handler: NativeMethodHandlerId,
 }
 
 /// Built-in owners whose method entries are installed into the runtime registry.
@@ -759,6 +767,7 @@ pub(crate) fn builtin_method_entries(type_name: &str) -> Vec<BuiltinMethodEntry>
             owner: canonical_builtin_owner(type_name),
             name,
             order: order as u16,
+            handler: NativeMethodHandlerId::PureArity,
         })
         .collect()
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2069,6 +2069,12 @@ pub struct Interpreter {
     pub(crate) last_method_resolve: Option<(Symbol, Symbol, Symbol, Arc<MethodDef>)>,
     pub(crate) fast_method_cache:
         rustc_hash::FxHashMap<(Symbol, Symbol), crate::vm::FastMethodCacheEntry>,
+    /// Static built-in type×method handler IDs. Built-in rows are immutable, so
+    /// this avoids taking the registry lock after the first native call shape.
+    pub(crate) native_method_handler_cache: rustc_hash::FxHashMap<
+        (Symbol, Symbol),
+        Option<crate::builtins::builtin_type_methods::NativeMethodHandlerId>,
+    >,
     /// Memoized `class -> NativeCtorPlan` for the native default constructor.
     /// Cleared wherever `fast_method_cache` is cleared, plus the MOP class-shape
     /// mutators (`Attribute.set_build`, `^add_attribute`, `^add_method`,

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -297,6 +297,24 @@ impl Registry {
         entries.into_iter().map(|entry| entry.name).collect()
     }
 
+    pub(crate) fn builtin_method_handler(
+        &self,
+        type_name: &str,
+        method_name: Symbol,
+    ) -> Option<crate::builtins::builtin_type_methods::NativeMethodHandlerId> {
+        let owner = crate::builtins::builtin_type_methods::canonical_builtin_owner(type_name);
+        if owner.is_empty() {
+            return None;
+        }
+        self.method_entries
+            .get(&MethodEntryKey {
+                owner: Symbol::intern(owner),
+                name: method_name,
+            })
+            .and_then(|entry| entry.builtin)
+            .map(|entry| entry.handler)
+    }
+
     pub(crate) fn sync_user_method_entries(&mut self, class_name: &str) {
         let owner = Symbol::intern(class_name);
         self.method_entries.retain(|key, entry| {
@@ -794,6 +812,14 @@ mod tests {
                 ..
             })
         ));
+        assert_eq!(
+            registry.builtin_method_handler("Str", Symbol::intern("chars")),
+            Some(crate::builtins::builtin_type_methods::NativeMethodHandlerId::PureArity)
+        );
+        assert_eq!(
+            registry.builtin_method_handler("Str", Symbol::intern("definitely-absent")),
+            None
+        );
     }
 
     #[test]

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2317,6 +2317,7 @@ impl Interpreter {
             method_cache_generation: 0,
             last_method_resolve: None,
             fast_method_cache: rustc_hash::FxHashMap::default(),
+            native_method_handler_cache: rustc_hash::FxHashMap::default(),
             native_ctor_plan_cache: rustc_hash::FxHashMap::default(),
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -616,6 +616,7 @@ impl Interpreter {
             method_cache_generation: 0,
             last_method_resolve: None,
             fast_method_cache: rustc_hash::FxHashMap::default(),
+            native_method_handler_cache: rustc_hash::FxHashMap::default(),
             native_ctor_plan_cache: rustc_hash::FxHashMap::default(),
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -366,14 +366,25 @@ impl Interpreter {
         {
             return Some(result);
         }
-        let mut result = if args.len() == 2 {
-            crate::builtins::native_method_2arg(target, method_sym, &args[0], &args[1])
-        } else if args.len() == 1 {
-            crate::builtins::native_method_1arg(target, method_sym, &args[0])
-        } else if args.is_empty() {
-            crate::builtins::native_method_0arg(target, method_sym)
+        let type_name = crate::runtime::utils::value_type_name(target);
+        let type_sym = crate::symbol::Symbol::intern(type_name);
+        let cache_key = (type_sym, method_sym);
+        let handler = if let Some(handler) = self.native_method_handler_cache.get(&cache_key) {
+            *handler
         } else {
-            return None;
+            let handler = self
+                .registry()
+                .builtin_method_handler(type_name, method_sym);
+            self.native_method_handler_cache.insert(cache_key, handler);
+            handler
+        }?;
+        let mut result = match handler {
+            crate::builtins::builtin_type_methods::NativeMethodHandlerId::PureArity => match args {
+                [a, b] => crate::builtins::native_method_2arg(target, method_sym, a, b),
+                [a] => crate::builtins::native_method_1arg(target, method_sym, a),
+                [] => crate::builtins::native_method_0arg(target, method_sym),
+                _ => return None,
+            },
         };
 
         // For gather-based LazyList, .List and .values preserve laziness


### PR DESCRIPTION
## Problem

Pure native VM dispatch still used the arity-specific functions as independent method lookup entry points instead of selecting a handler from the canonical type×method registry row.

## Approach

- add a static `NativeMethodHandlerId` to every built-in method entry
- resolve modeled built-in calls through the registry type×method row
- keep the 0/1/2-argument functions as implementation details behind the selected handler ID
- cache type×method handler resolution in an `FxHashMap`, avoiding registry locks after the first call shape
- keep initialization data-only; no handler probing is added

## Tests

- `cargo test builtin_method_catalog_is_registry_owned_and_ordered`
- targeted TAP: 11 files / 132 tests
- `cargo clippy -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

Stacked on #5838 as requested.