### PR TITLE
fix: named parameters do not narrow a multi candidate

### DIFF
--- a/news/2026-08/named-params-do-not-narrow.md
+++ b/news/2026-08/named-params-do-not-narrow.md
@@ -1,0 +1,76 @@
+# Named parameters do not narrow a multi candidate
+
+`Digest::HMAC`'s dependency declares three candidates that differ only in which
+of two *named* parameters carries a type:
+
+```raku
+multi hmac(Str :$key,      :$msg, :&hash, :$block-size) { samewith key => $key.encode, … }
+multi hmac(    :$key, Str :$msg, :&hash, :$block-size) { samewith :$key, msg => $msg.encode, … }
+multi hmac(Blob :$key is copy, Blob :$msg, :&hash, :$block-size) { … }
+```
+
+Called with both `:$key` and `:$msg` as `Str`, mutsu answered
+`Ambiguous call to 'hmac()'`. Rakudo runs candidate 1, whose `samewith` reaches
+candidate 2, whose `samewith` reaches candidate 3.
+
+## Narrowness is a property of the positional parameters
+
+Raku computes candidate narrowness from the **positional** parameters. A named
+parameter's type decides whether a candidate is *applicable*; it never makes one
+candidate narrower than another. Two candidates that differ only in their named
+types therefore land in the same narrowness group, and rakudo resolves that by
+**declaration order** rather than reporting ambiguity. Verified directly:
+
+```raku
+proto p(:$a) {*}
+multi p(Any :$a) { "Any" }
+multi p(Int :$a) { "Int" }
+say p(a => 1);       # rakudo: Any  -- Int does NOT outrank Any
+```
+
+Reversing the two declarations makes the same call answer `Int`. The positional
+analogue is genuinely ambiguous in rakudo, and stays ambiguous here:
+
+```raku
+multi g(Str $a,     $b) { }
+multi g(    $a, Str $b) { }
+g("x", "y")          # X::Multi::Ambiguous, in rakudo and in mutsu
+```
+
+And a positional still narrows even when a named "disagrees":
+`multi r(Any $x, Int :$a)` / `multi r(Int $x, Any :$a)` resolves `r(1, a => 1)`
+to the `Int $x` candidate in both implementations.
+
+## The change
+
+Three places in `dispatch_candidates.rs` stopped consulting named parameters:
+
+* `candidate_specificity_rank_for_args` computes its type-narrowness components
+  (`typed_param_count`, `subset_type_count`, `literal_value_count`,
+  `where_count`, `subsig_count`, `trait_count`) over positionals only. How
+  *many* nameds a candidate declares stays a tie-break — a signature that
+  accepts more of the call's nameds is still the better fit — only their types
+  are excluded.
+* `candidate_type_distance` skips named parameters, so a named type cannot move
+  the secondary sort key either.
+* The ambiguity report is suppressed when any tied candidate has a
+  type-constrained named parameter (`candidate_has_typed_named_param`). That
+  mirrors rakudo's own mechanism: such a candidate needs a trial bind, and the
+  first one that binds wins, so the tie never reaches the ambiguity check.
+
+`hmac(key => "Jefe", msg => "what do ya want for nothing?", hash => &sha1,
+block-size => 64)` now produces the RFC 2202 vector
+`effcdf6ae5eb2fa2d27416d5f184df9c259a7c79`. Pinned by
+`t/multi-named-narrowness.t`, which passes under rakudo as well as mutsu.
+
+## Known residue
+
+When candidates tie, mutsu takes the first in the *sorted candidate list*, and
+`sort_candidates_by_specificity` breaks an equal-rank tie on the registry key
+string rather than on declaration order — the registry is a hash map, so
+declaration order is not otherwise preserved. That is right often enough for the
+cases above, but `multi h(:$a)` declared before `multi h(Str :$a)` still picks
+the typed one where rakudo picks the untyped. `FunctionDef` already has a
+`decl_order` field (stamped only for proto-token candidates today); extending it
+to every multi is the fix, and is recorded in
+`todo/tickets/multi-tie-break-declaration-order.md`.

--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -153,6 +153,7 @@ impl Interpreter {
         let mut best_shape_sorted = best_shape.clone();
         best_shape_sorted.sort();
         if tied.len() > 1
+            && !tied.iter().any(Self::candidate_has_typed_named_param)
             && tied
                 .iter()
                 .all(|def| !self.candidate_uses_order_sensitive_dispatch(def))
@@ -177,6 +178,32 @@ impl Interpreter {
         Some(matches.remove(0))
     }
 
+    /// Whether any *named* parameter of `def` carries a type constraint.
+    ///
+    /// Narrowness in Raku is computed from the POSITIONAL parameters only —
+    /// named parameters decide whether a candidate is *applicable*, never how
+    /// narrow it is. So two candidates that differ only in the types of their
+    /// named parameters land in the same narrowness group, and rakudo does not
+    /// call that ambiguous: a candidate with type-constrained nameds needs a
+    /// trial bind, and the FIRST one that binds wins.
+    ///
+    /// ```text
+    /// multi f(Str :$a,     :$b) { "A" }
+    /// multi f(    :$a, Str :$b) { "B" }
+    /// f(a => "x", b => "y")   # "A" -- declaration order, not ambiguous
+    /// ```
+    ///
+    /// (Both are applicable; A is simply declared first. Reversing the two
+    /// declarations makes the call return "B".) The positional analogue
+    /// `multi g(Str $a, $b)` / `multi g($a, Str $b)` really is ambiguous, in
+    /// rakudo and here alike, which is why this only suppresses the report when
+    /// a named type constraint is what tied the candidates.
+    fn candidate_has_typed_named_param(def: &Arc<FunctionDef>) -> bool {
+        Self::dispatch_visible_params(def)
+            .into_iter()
+            .any(|p| p.named && p.type_constraint.is_some())
+    }
+
     pub(super) fn candidate_specificity_rank(
         &self,
         def: &FunctionDef,
@@ -194,7 +221,16 @@ impl Interpreter {
         def: &FunctionDef,
         args: &[Value],
     ) -> (usize, usize, usize, usize, usize, usize, usize) {
-        let params = Self::dispatch_visible_params(def);
+        let all_params = Self::dispatch_visible_params(def);
+        // Type narrowness is computed from the POSITIONAL parameters only.
+        // A named parameter's type decides whether the candidate is
+        // *applicable*, never how narrow it is — `multi p(Any :$a)` and
+        // `multi p(Int :$a)` are equally narrow in rakudo, so `p(a => 1)`
+        // picks whichever is declared first (verified against rakudo; the
+        // positional pair `multi r(Any $x, Int :$a)` / `multi r(Int $x, Any
+        // :$a)` still resolves to the `Int $x` one). See
+        // `candidate_has_typed_named_param` for the matching ambiguity rule.
+        let params: Vec<&ParamDef> = all_params.iter().copied().filter(|p| !p.named).collect();
         let param_args = self.dispatch_param_arguments(&params, args);
         let effective: Vec<Option<&str>> = params
             .iter()
@@ -236,7 +272,10 @@ impl Interpreter {
             })
             .count();
         let subsig_count = params.iter().filter(|p| p.sub_signature.is_some()).count();
-        let named_count = params.iter().filter(|p| p.named).count();
+        // How MANY nameds a candidate declares is still a tie-break (a
+        // signature that accepts more of the call's nameds is the better fit);
+        // only their *types* are excluded above.
+        let named_count = all_params.iter().filter(|p| p.named).count();
         let trait_count = params
             .iter()
             .filter(|p| {
@@ -355,27 +394,11 @@ impl Interpreter {
         let mut pos_idx = 0usize;
         for pd in params.iter() {
             if let Some(constraint) = &pd.type_constraint {
-                // For named params, find the matching Pair arg
+                // A named parameter's type does not contribute to narrowness
+                // (see `candidate_specificity_rank_for_args`), so it must not
+                // move the distance either — otherwise `multi p(Int :$a)` would
+                // still outrank `multi p(Any :$a)` on the secondary key.
                 if pd.named {
-                    let bare_name = pd.name.trim_start_matches(|c: char| "$@%&".contains(c));
-                    let named_val = args.iter().find_map(|a| {
-                        if let ValueView::Pair(key, val) = a.view() {
-                            if key == bare_name {
-                                Some(val.clone())
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
-                    });
-                    if let Some(val) = named_val {
-                        let effective = self.effective_dispatch_constraint(constraint, Some(&val));
-                        let base = Self::constraint_base_name(effective);
-                        total += self.type_hierarchy_distance_with_var_type(base, &val, None);
-                    } else {
-                        total += 1000;
-                    }
                     continue;
                 }
                 if pos_idx < args.len() {

--- a/t/multi-named-narrowness.t
+++ b/t/multi-named-narrowness.t
@@ -1,0 +1,76 @@
+use Test;
+
+plan 11;
+
+# Narrowness in multi dispatch is computed from the POSITIONAL parameters only.
+# A named parameter's type decides whether a candidate is *applicable*, never
+# how narrow it is — so candidates that differ only in their named types land in
+# the same narrowness group, and rakudo resolves that by declaration order
+# rather than calling it ambiguous.
+
+{
+    proto f(:$a, :$b) {*}
+    multi f(Str :$a,     :$b) { "A" }
+    multi f(    :$a, Str :$b) { "B" }
+    multi f(Int :$a, Int :$b) { "C" }
+
+    is f(a => "x", b => "y"), "A", 'two equally-applicable named candidates: the first declared wins';
+    is f(a => 1,   b => 2),   "C", 'only one candidate applicable: it wins';
+    is f(a => "x", b => 3),   "A", 'the Str :$a candidate is the only applicable one';
+    is f(a => 3,   b => "y"), "B", 'the Str :$b candidate is the only applicable one';
+}
+
+# Declaration order really is what decides — reversing it reverses the answer.
+{
+    proto p(:$a) {*}
+    multi p(Any :$a) { "Any" }
+    multi p(Int :$a) { "Int" }
+    is p(a => 1), "Any", 'Int :$a does NOT outrank Any :$a';
+}
+{
+    proto q(:$a) {*}
+    multi q(Int :$a) { "Int" }
+    multi q(Any :$a) { "Any" }
+    is q(a => 1), "Int", '...and reversing the declarations reverses the winner';
+}
+
+# A positional still narrows normally, even when a named would "disagree".
+{
+    proto r($x, :$a) {*}
+    multi r(Any $x, Int :$a) { "Any/Int" }
+    multi r(Int $x, Any :$a) { "Int/Any" }
+    is r(1, a => 1), "Int/Any", 'positional narrowness decides; the named type is ignored';
+}
+
+# The positional analogue of the first case IS ambiguous, here as in rakudo.
+{
+    proto g($a, $b) {*}
+    multi g(Str $a,     $b) { "A" }
+    multi g(    $a, Str $b) { "B" }
+    throws-like { g("x", "y") }, X::Multi::Ambiguous,
+        'two equally-narrow POSITIONAL candidates are still ambiguous';
+}
+
+# Applicability by named type still works — an argument that no candidate's
+# named type accepts is a dispatch failure, not a silent first-candidate win.
+{
+    proto s(:$a) {*}
+    multi s(Int :$a) { "Int" }
+    multi s(Str :$a) { "Str" }
+    is s(a => 1),   "Int", 'named types still select by applicability (Int)';
+    is s(a => "x"), "Str", 'named types still select by applicability (Str)';
+}
+
+# The shape that motivated this: HMAC's `samewith` chain, where candidates 1 and
+# 2 each constrain one named and leave the other untyped.
+{
+    # Each `samewith` retypes one named so the next candidate takes over, exactly
+    # as HMAC's `key => $key.encode` / `msg => $msg.encode` do.
+    proto hm(:$key, :$msg) {*}
+    multi hm(Str :$key,     :$msg) { "k:" ~ samewith key => $key.chars, :$msg }
+    multi hm(    :$key, Str :$msg) { "m:" ~ samewith :$key, msg => $msg.chars }
+    multi hm(Int :$key, Int :$msg) { "done" }
+
+    is hm(key => "ab", msg => "cde"), "k:m:done",
+        'candidate 1 runs, samewith reaches candidate 2, then candidate 3';
+}

--- a/todo/deep/promise-spawn-segv-under-load.md
+++ b/todo/deep/promise-spawn-segv-under-load.md
@@ -1,0 +1,77 @@
+# SEGV in `spawn_callable_promise` under many concurrent `Promise.start`
+
+`roast/S17-lowlevel/semaphore.t` (whitelisted, 2 tests, 4000 `Promise.start`
+closures per subtest) SEGVs with 0 tests run at roughly **6-8% under CPU
+contention**, in the jit-stress configuration. It is the S17 failure the prose
+"known flaky" list in CLAUDE.md has always described in the abstract; this file
+records the measurement and the actual crash site.
+
+## Measured, and NOT a recent regression
+
+Twelve concurrent copies on a 12-core box, release build,
+`MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2 MUTSU_FUDGE=1` (the exact `jit-stress` job
+configuration), 48 runs per tree:
+
+| tree                                        | SEGV / runs |
+| ------------------------------------------- | ----------- |
+| `17e4d38b5` (before the Digest PR #5822)     | 3 / 48      |
+| `d0233c8ce` (after #5822 and #5834)          | 4 / 48      |
+
+Statistically the same, so neither the `PostIncrementIndex` slot change in #5822
+(which `@r[$i]++` in the second subtest exercises) nor the placeholder-scope
+change in #5834 introduced it. Serially, and even at `-j12` through `prove`, it
+does not reproduce at all: 24 consecutive clean runs. It needs *many independent
+processes* competing for cores. `scripts/flake-repro.sh` is the intended tool;
+the ad-hoc driver used here was 12 background copies per round, 4 rounds.
+
+## The crash site
+
+`MUTSU_CRASH_DIR` catches it (`tmp/crash/<pid>.txt`):
+
+    signal: 11 (SIGSEGV)
+    si_code: 1                      # SEGV_MAPERR - address not mapped
+    fault-addr: 0x000075762bfff9c8
+    thread: mutsu
+    ...
+      3: ___pthread_detach at ./nptl/pthread_detach.c:36:6
+      4: core::ptr::drop_in_place<std::thread::join_handle::JoinHandle<()>>
+      5: mutsu::runtime::builtins_system::…::spawn_callable_promise
+      6: mutsu::runtime::methods_promise_class::…::dispatch_promise_start
+      7: mutsu::runtime::methods_dispatch_match::…::dispatch_method_by_name_1
+      8: mutsu::runtime::methods_call_dispatch::…::call_method_with_values
+      9: mutsu::runtime::methods_mut_dispatch::…::call_method_mut_with_values
+     10: mutsu::vm::vm_call_method_compiled_mut::…::try_compiled_method_mut_or_interpret_sym
+     11: mutsu::vm::vm_call_method_mut_ops::…::exec_call_method_mut_op_impl
+     13: mutsu::vm::vm_jit_helpers::call_method_mut
+
+The faulting address sits just below a page boundary (`…fff9c8`) with
+`SEGV_MAPERR`, which is the signature of a **guard-page hit**, i.e. a stack
+overflow — not a corrupt `JoinHandle`. `pthread_detach` is simply the innermost
+frame when the already-deep VM stack runs out: dropping the `JoinHandle` that
+`spawn_callable_promise` returns detaches the thread, and that call is made from
+inside a nested VM dispatch chain (`vm_jit_helpers::call_method_mut` →
+`exec_call_method_mut_op` → … → `dispatch_promise_start`), on the VM's own
+spawned thread rather than on the main thread.
+
+## Why this is a deep item, not a ticket
+
+Two things have to be settled together:
+
+1. **How much stack a VM thread gets, and who decides.** The main VM thread is
+   spawned with an explicit stack size; the threads `Promise.start` creates
+   inherit whatever the runtime default is. If 4000 outstanding promises can
+   push a dispatch chain over the limit, the fix is not "raise the number" —
+   it is deciding where the VM's recursion budget is declared and enforcing it
+   uniformly for every thread the interpreter spawns (see also
+   `roast/integration/deep-recursion-initing-native-array.t`, which overflows in
+   a *debug* build for the same underlying reason).
+2. **Whether `spawn_callable_promise` should hold a `JoinHandle` at all.** The
+   crash is in the *drop* of a handle the promise machinery does not join. A
+   design in which the spawned thread's completion is observed through the
+   `Promise` (and the handle is detached at a shallow stack depth, or never
+   created) removes this frame from the deep path entirely.
+
+Until then the test stays whitelisted and un-quarantined: quarantining a SEGV
+would hide a real memory-safety-adjacent defect, and a single CI occurrence
+passes on re-run. Do **not** add it to `flaky-tests.txt` without revisiting this
+decision.

--- a/todo/tickets/digest-dist-blockers.md
+++ b/todo/tickets/digest-dist-blockers.md
@@ -7,8 +7,8 @@ interpreter bugs found while running it were fixed (see
 `news/2026-08/digest-dist-seven-fixes.md`), then four more that its roast
 fallout exposed (`news/2026-08/digest-dist-followup-four-fixes.md`);
 `Digest::SHA1` and `Digest::SHA2`'s `sha224`/`sha256` now produce correct
-digests. Blocker 1 below is fixed
-(`news/2026-08/for-modifier-placeholder-scope.md`); three remain, each an
+digests. Blockers 1 (`news/2026-08/for-modifier-placeholder-scope.md`) and 4
+(`news/2026-08/named-params-do-not-narrow.md`) are fixed; two remain, each an
 independent general bug.
 
 Reproduce with the vendored-in-zef-store copy:
@@ -43,7 +43,14 @@ is in the block pipeline: `blob64`, `state buf64 $w`, the `$H[]` zen slice, the
 `(8*$data).polymod(256 xx 15).reverse` length encoding, or `map * mod 2**64` over
 a Blob. `sha384` is `sha512` with a different initial hash, so it falls with it.
 
-## 4. `HMAC`'s named-parameter multis dispatch as ambiguous
+## 4. `HMAC`'s named-parameter multis dispatch as ambiguous — FIXED
+
+Fixed by excluding named parameters from narrowness; see
+`news/2026-08/named-params-do-not-narrow.md`. `hmac(key => "Jefe", …)` now
+produces the RFC 2202 vector. The residual declaration-order tie-break is
+`todo/tickets/multi-tie-break-declaration-order.md`.
+
+<details><summary>original report</summary>
 
     hmac key => "Jefe", msg => "…", hash => &sha1, block-size => 64
     # mutsu: Ambiguous call to 'hmac()'
@@ -59,6 +66,8 @@ With both `:$key` and `:$msg` passed as `Str`, candidates 1 and 2 each constrain
 one named parameter and leave the other untyped. Rakudo resolves this (it runs
 candidate 1, then `samewith` reaches candidate 2, then 3); mutsu calls it
 ambiguous. The narrowness comparison for *named* parameters is the thing to fix.
+
+</details>
 
 ## Also relevant: `Digest::HMAC` itself
 

--- a/todo/tickets/multi-tie-break-declaration-order.md
+++ b/todo/tickets/multi-tie-break-declaration-order.md
@@ -1,0 +1,53 @@
+# A tied multi candidate should be broken by declaration order
+
+When several multi candidates are equally narrow, Raku picks the one declared
+first. mutsu picks the first of the *sorted candidate list*, and
+`sort_candidates_by_specificity` (`src/runtime/dispatch_resolve.rs`) breaks an
+equal-rank tie on the **registry key string**:
+
+```rust
+candidates.sort_by(|a, b| {
+    let a_rank = self.candidate_specificity_rank(&a.1);
+    let b_rank = self.candidate_specificity_rank(&b.1);
+    b_rank.cmp(&a_rank).then(a.0.cmp(&b.0))   // <- key string, not declaration order
+});
+```
+
+The candidates themselves are collected by iterating `registry().functions`, a
+hash map, so nothing upstream preserves declaration order either.
+
+Now that named parameters no longer contribute to narrowness
+(`news/2026-08/named-params-do-not-narrow.md`), ties are more common and the gap
+is visible:
+
+    proto h(:$a) {*}
+    multi h(    :$a) { "untyped" }
+    multi h(Str :$a) { "typed" }
+    say h(a => "x");        # rakudo: untyped    mutsu: typed
+
+    proto h3(:$a) {*}
+    multi h3(    :$a) { "untyped" }
+    multi h3(Any :$a) { "any" }
+    say h3(a => "x");       # rakudo: untyped    mutsu: any
+
+Both candidates are applicable and equally narrow, so declaration order should
+decide; mutsu instead lands on whichever key sorts later. (The `Any :$a` vs
+`Int :$a` pair *does* come out right today, so this is not uniformly wrong —
+which is exactly why it needs a real ordering key rather than more tuning.)
+
+## The fix
+
+`FunctionDef` already carries `decl_order: u64` (`src/ast.rs`), a monotonic
+registration stamp — but it is only set for `token`/`rule` proto candidates, by
+`insert_token_def`, and is 0 for everything else. Stamp it for every routine
+registration and use it as the final tie-break in
+`sort_candidates_by_specificity` (and in `choose_best_matching_candidate`'s
+`ranked.sort_by`, whose stability then carries it through).
+
+The work is small but touches every registration path (`registration_sub.rs`,
+the class/role method paths, `EXPORTHOW`/`EVAL` re-registration), and the stamp
+has to survive precompilation — `decl_order` is `#[serde(default)]`, so a
+precompiled unit that predates the change deserializes every candidate as 0 and
+silently loses the ordering. Getting that right, and deciding whether the stamp
+is global or per-`(package, name)`, is what makes this a ticket rather than a
+one-line patch.


### PR DESCRIPTION
`Digest::HMAC`'s dependency declares three candidates that differ only in which
of two *named* parameters carries a type:

```raku
multi hmac(Str :$key,      :$msg, :&hash, :$block-size) { samewith key => $key.encode, … }
multi hmac(    :$key, Str :$msg, :&hash, :$block-size) { samewith :$key, msg => $msg.encode, … }
multi hmac(Blob :$key is copy, Blob :$msg, :&hash, :$block-size) { … }
```

Called with both `:$key` and `:$msg` as `Str`, mutsu answered
`Ambiguous call to 'hmac()'`. Rakudo runs candidate 1, whose `samewith` reaches
candidate 2, whose `samewith` reaches candidate 3.

## Narrowness is a property of the positional parameters

Raku computes candidate narrowness from the **positional** parameters. A named
parameter's type decides whether a candidate is *applicable*; it never makes one
candidate narrower than another. Candidates that differ only in their named types
therefore land in the same narrowness group, and rakudo resolves that by
**declaration order** rather than reporting ambiguity. Verified directly against
rakudo:

```raku
proto p(:$a) {*}
multi p(Any :$a) { "Any" }
multi p(Int :$a) { "Int" }
say p(a => 1);       # rakudo: Any  -- Int does NOT outrank Any
```

Reversing the two declarations makes the same call answer `Int`. The positional
analogue is genuinely ambiguous in rakudo, and stays ambiguous here:

```raku
multi g(Str $a,     $b) { }
multi g(    $a, Str $b) { }
g("x", "y")          # X::Multi::Ambiguous, in rakudo and in mutsu
```

And a positional still narrows even when a named "disagrees":
`multi r(Any $x, Int :$a)` / `multi r(Int $x, Any :$a)` resolves `r(1, a => 1)`
to the `Int $x` candidate in both.

## The change

Three places in `dispatch_candidates.rs` stopped consulting named parameters:

- **`candidate_specificity_rank_for_args`** computes its type-narrowness
  components (`typed_param_count`, `subset_type_count`, `literal_value_count`,
  `where_count`, `subsig_count`, `trait_count`) over positionals only. How
  *many* nameds a candidate declares stays a tie-break — a signature that
  accepts more of the call's nameds is still the better fit — only their types
  are excluded.
- **`candidate_type_distance`** skips named parameters, so a named type cannot
  move the secondary sort key either.
- **The ambiguity report** is suppressed when any tied candidate has a
  type-constrained named parameter (`candidate_has_typed_named_param`). That
  mirrors rakudo's own mechanism: such a candidate needs a trial bind, and the
  first one that binds wins, so the tie never reaches the ambiguity check.

## Result

```
$ mutsu -I …/libdigest-raku/lib -e 'use HMAC; use Digest::SHA1;
    say hmac(key => "Jefe", msg => "what do ya want for nothing?",
             hash => &sha1, block-size => 64).list.fmt("%02x","")'
effcdf6ae5eb2fa2d27416d5f184df9c259a7c79     # the RFC 2202 vector
```

Pinned by `t/multi-named-narrowness.t` (11 tests), which passes under rakudo as
well as mutsu. `make test` green (2833 files / 26883 tests). The whitelisted
`S06-`/`S12-`/`S14-`/`S32-` roast files were run locally and are green apart from
the three `S32-str/*-encode-decode.t` files, which need `make roast`'s cwd to
find their `t/spec/…` sample data.

## Known residue (not fixed here)

When candidates tie, mutsu takes the first of the *sorted* candidate list, and
`sort_candidates_by_specificity` breaks an equal-rank tie on the registry key
string — the registry is a hash map, so declaration order is not preserved. That
is right often enough for the cases above, but `multi h(:$a)` declared before
`multi h(Str :$a)` still picks the typed one where rakudo picks the untyped.
`FunctionDef::decl_order` already exists but is stamped only for proto-token
candidates; extending it is recorded in
`todo/tickets/multi-tie-break-declaration-order.md`.

This PR also records `todo/deep/promise-spawn-segv-under-load.md`: the
`S17-lowlevel/semaphore.t` SEGV that failed jit-stress on #5834 is a
stack-overflow guard-page hit in `spawn_callable_promise`, measured at 3/48
before the Digest PRs and 4/48 after — pre-existing, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)