### PR TITLE
fix(runtime): an EVAL'd sub shadows an outer routine, and its return needs a real routine

### DIFF
--- a/news/2026-08/eval-sub-shadows-a-registered-routine.md
+++ b/news/2026-08/eval-sub-shadows-a-registered-routine.md
@@ -1,0 +1,86 @@
+# An EVAL'd `sub` shadows an outer routine — including one only the registry knows about
+
+`EVAL` compiles a new compunit nested inside the caller's scope, so a `sub f`
+declared in it **shadows** an outer `f`; it can never be a redeclaration of one.
+Only a name declared inside the *same* EVAL still conflicts.
+
+mutsu already had that exemption, but it was wired to one of the two records a
+declaration leaves behind. `EVAL_OUTER_AMP_NAMES` snapshots the `&name` env
+bindings that existed when the EVAL began, and only the `env`-side redeclaration
+check consulted it. The checks against the routine **registry** (`has_single` /
+`has_multi`) had no exemption at all.
+
+The two records do not always agree about what exists. A `my sub` declared
+inside a block that runs as a *callable* leaves a registry entry reachable after
+the block without leaving an `&name` in any visible env tier:
+
+```raku
+sub run(&b) { b() }
+run { my sub tester($x) { say "outer $x" }; tester(1) }
+run {
+    my sub produce($n) { EVAL "sub tester(\$x) \{ say \"eval$n \$x\" }" }
+    for 1, 2 -> $n { my &t = produce $n; t(9) }
+}
+```
+
+```
+raku : outer 1 / eval1 9 / eval2 9
+mutsu: outer 1 / Redeclaration of routine 'tester'. Did you mean to declare a multi-sub?
+```
+
+`roast/S04-statements/given.t` is exactly this shape — it EVALs a fresh
+`sub test-given` per subtest while an earlier subtest's `my sub test-given` is
+still registered — and died on the very first one, taking a whole 3-subtest
+group with it.
+
+The fix adds the registry counterpart, `EVAL_OUTER_ROUTINE_KEYS`, taken at the
+same point and keyed by interned `Symbol` so the snapshot allocates no strings.
+A routine key present in it is shadowed rather than redeclared; a key registered
+*inside* the EVAL is not in it and still collides, so the exemption does not
+become a blanket "anything goes inside EVAL".
+
+## What the fix unmasked, and had to fix too
+
+`roast/S04-statements/return.t` test 15 was passing **for the wrong reason**:
+
+```raku
+is (try EVAL 'my $double = -> $x { return 2 * $x }; sub foo($x) { $double($x) }; foo 42').defined,
+   False, 'return is lexotic only; must not attempt dynamic return';
+```
+
+The file declares a `sub foo` earlier, so the EVAL used to die of the very
+redeclaration this change removes — which made `.defined` `False` without the
+snippet's `return` ever being exercised. With the EVAL succeeding, the real
+behaviour showed: mutsu returned `84`.
+
+`return` in a non-routine block does a *non-local* return when a routine
+lexically encloses it, and throws `X::ControlFlow::Return` when none does. The
+EVAL compile path decided that from `!self.routine_stack.is_empty()` — but a
+bare `{ ... }` block, a `for` body and a closure all push a `RoutineFrame` too
+(`is_block: true`). So an `EVAL` run from inside a mainline block compiled its
+snippet as "inside a routine", and a `return` in the snippet's own pointy block
+returned from whatever sub later called it. At file scope, where the stack is
+genuinely empty, the same snippet was already correct — which is why only the
+in-a-block form was wrong.
+
+Both flags the path sets (`is_routine`, `lexically_in_routine`) now ask
+`enclosing_routine_exists()`, which ignores block frames. A `return` inside an
+EVAL called from a *real* routine still returns from it, as rakudo does. As a
+side effect the throw became catchable by the surrounding `try` instead of
+escaping to the top level. Pin:
+`t/eval-return-target-needs-a-real-routine.t`.
+
+## Two smaller things from the same investigation
+
+* `Env::keys()` exposes only the innermost tier's overlay, while `Env::get()`
+  walks the parent chain and the base tier — so the existing `&name` snapshot
+  was already missing names the check could find. `Env::visible_keys_where` is
+  the chain-walking, key-only counterpart (`flatten()` answers the same question
+  but deep-copies every value, far too expensive per EVAL), and the snapshot now
+  uses it.
+* The underlying leak is still open: a `my sub` inside a block invoked as a
+  callable should not be visible after the block at all
+  (`::('&tester').defined` is `True` in mutsu, `False` in raku).
+
+Pin: `t/eval-sub-shadows-outer-routine.t` — 5 of its 6 assertions fail without
+the fix, and all 6 pass under `raku`.

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -768,6 +768,40 @@ impl Env {
         }
         for (k, v) in self.inner.iter() {
             out.insert(k.resolve(), v.clone());
+        }
+        out
+    }
+
+    /// Every name VISIBLE from this env whose resolved key satisfies `keep`,
+    /// walking the parent chain and the immutable base tier the way
+    /// [`Self::get`] does — unlike [`Self::keys`], which exposes only this
+    /// tier's overlay.
+    ///
+    /// Key-only, so it costs no `Value` clones: [`Self::flatten`] answers the
+    /// same question but deep-copies every value, which is far too expensive
+    /// for a per-`EVAL` snapshot.
+    pub fn visible_keys_where(&self, keep: impl Fn(&str) -> bool + Copy) -> HashSet<String> {
+        let mut out: HashSet<String> = match &self.parent {
+            Some(parent) => parent.visible_keys_where(keep),
+            None => global_base()
+                .map(|b| {
+                    b.keys()
+                        .map(|k| k.resolve())
+                        .filter(|k| keep(k))
+                        .collect::<HashSet<String>>()
+                })
+                .unwrap_or_default(),
+        };
+        if let Some(tomb) = &self.tombstones {
+            for k in tomb {
+                out.remove(&k.resolve());
+            }
+        }
+        for k in self.inner.keys() {
+            let name = k.resolve();
+            if keep(&name) {
+                out.insert(name);
+            }
         }
         out
     }

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -10,6 +10,23 @@ impl Interpreter {
         &self.routine_stack
     }
 
+    /// Whether an actual **routine** (sub/method) encloses the running code —
+    /// not merely some frame. A bare `{ ... }` block, a `for` body and a
+    /// closure all push a `RoutineFrame` with `is_block: true`, so
+    /// `!routine_stack.is_empty()` answers "is any frame live", which is a
+    /// different question.
+    ///
+    /// It matters for `return`: a `return` in a non-routine block does a
+    /// *non-local* return when a routine lexically encloses it, and throws
+    /// `X::ControlFlow::Return` when none does. Deciding that from
+    /// `is_empty()` made an `EVAL` run inside a mainline `{ ... }` block
+    /// compile its snippet as "inside a routine", so a `return` in the
+    /// snippet's own pointy block returned from whatever sub later called it
+    /// instead of throwing (`roast/S04-statements/return.t` test 15).
+    pub(crate) fn enclosing_routine_exists(&self) -> bool {
+        self.routine_stack.iter().any(|f| !f.is_block)
+    }
+
     /// Push a new routine frame. `line` and `file` record the call-site
     /// in the *caller* (the line/file where this function was called from);
     /// `def_file` is the file the routine's body lives in (None = main

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -26,6 +26,41 @@ thread_local! {
     /// a redeclaration — but a name declared *inside* the same EVAL
     /// (`EVAL 'my &x; sub x {}'`) is NOT in this set and still conflicts.
     static EVAL_OUTER_AMP_NAMES: RefCell<Vec<HashSet<String>>> = const { RefCell::new(Vec::new()) };
+
+    /// The registry counterpart of `EVAL_OUTER_AMP_NAMES`: the routine keys
+    /// (`Pkg::name`, and `Pkg::name/arity` for multis) already registered when
+    /// an `EVAL` began.
+    ///
+    /// The `&name` binding and the registry entry are two records of the same
+    /// declaration, and the redeclaration checks consult both — so exempting
+    /// only the first is not enough. They also do not always agree about what
+    /// exists: a `my sub` declared inside a block that runs as a *callable*
+    /// leaves a registry entry reachable after the block without leaving an
+    /// `&name` in any visible env tier, which is exactly the state
+    /// `roast/S04-statements/given.t` EVALs its `sub test-given` into.
+    ///
+    /// Keyed by interned `Symbol`, so taking the snapshot allocates no strings.
+    static EVAL_OUTER_ROUTINE_KEYS: RefCell<Vec<HashSet<Symbol>>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+/// Push the set of registry routine keys that exist as an `EVAL` begins.
+pub(crate) fn push_eval_outer_routine_keys(keys: impl Iterator<Item = Symbol>) {
+    let set: HashSet<Symbol> = keys.collect();
+    EVAL_OUTER_ROUTINE_KEYS.with(|stack| stack.borrow_mut().push(set));
+}
+
+/// Pop the routine-key snapshot when an EVAL finishes.
+pub(crate) fn pop_eval_outer_routine_keys() {
+    EVAL_OUTER_ROUTINE_KEYS.with(|stack| {
+        stack.borrow_mut().pop();
+    });
+}
+
+/// Whether a routine under `key` was registered before the innermost active EVAL.
+fn is_outer_routine_key(key: Symbol) -> bool {
+    EVAL_OUTER_ROUTINE_KEYS
+        .with(|stack| stack.borrow().last().is_some_and(|set| set.contains(&key)))
 }
 
 /// Push the set of `&name` keys currently in `env` as the outer-amp snapshot for
@@ -851,20 +886,39 @@ impl Interpreter {
             .functions
             .get(&single_key_sym)
             .is_some_and(|existing| Self::is_stub_routine_body(&existing.body));
+        // These REGISTRY checks need the EVAL shadow exemption too, and the
+        // `&name` snapshot cannot supply it: the two records of a declaration
+        // do not always agree about what exists. A `my sub` declared inside a
+        // block that runs as a *callable* leaves a registry entry reachable
+        // afterwards without leaving an `&name` in any visible env tier — so
+        // `shadows_outer_eval_name` was false while `has_single` was true, and
+        // an EVAL'd `sub` of that name raised "Redeclaration of routine"
+        // instead of shadowing it. `roast/S04-statements/given.t` is exactly
+        // that: it EVALs a fresh `sub test-given` per subtest while an earlier
+        // subtest's `my sub test-given` is still registered.
+        let shadows_outer_eval_single = is_in_eval && is_outer_routine_key(single_key_sym);
+        let shadows_outer_eval_multi = is_in_eval
+            && self
+                .registry()
+                .functions
+                .keys()
+                .filter(|k| k.resolve().starts_with(&multi_prefix))
+                .all(|k| is_outer_routine_key(*k));
         if multi {
             if has_single
                 && !has_proto
                 && !allow_redeclare
                 && !allow_lexical_shadow
+                && !shadows_outer_eval_single
                 && !has_user_custom_traits
             {
                 return Err(RuntimeError::redeclaration_routine(name));
             }
         } else if !allow_redeclare && !allow_lexical_shadow && !has_user_custom_traits {
-            if has_multi && !has_proto {
+            if has_multi && !has_proto && !shadows_outer_eval_multi {
                 return Err(RuntimeError::redeclaration_routine(name));
             }
-            if has_single && !existing_is_stub {
+            if has_single && !existing_is_stub && !shadows_outer_eval_single {
                 return Err(RuntimeError::redeclaration_routine(name));
             }
         }

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -105,8 +105,30 @@ impl Interpreter {
         if is_eval_unit {
             compiler.mark_as_eval_unit();
         }
-        compiler.is_routine = !self.routine_stack.is_empty();
-        compiler.lexically_in_routine = !self.routine_stack.is_empty();
+        // For an EVAL'd compilation unit's mainline the question is whether a
+        // *routine* lexically encloses the `EVAL` call — and a mainline
+        // `{ ... }` block, a `for` body and a closure all push a `RoutineFrame`
+        // too (`is_block: true`), so `!routine_stack.is_empty()` answers a
+        // different one. Counting a block frame made an `EVAL` run from inside
+        // such a block compile its snippet as "inside a routine", and a
+        // `return` in the snippet's own pointy block then did a *non-local*
+        // return — out of whatever sub later called that block — instead of
+        // throwing `X::ControlFlow::Return`
+        // (`roast/S04-statements/return.t` test 15). Both flags feed the same
+        // decision (`compile_closure_body_with_routine_flag` ORs them into a
+        // nested block's own), so both ask the same question.
+        //
+        // Only for an EVAL unit. The other callers hand this an ordinary
+        // closure/sub BODY to (re-)compile, and there the live frame is the
+        // routine being run — including an anonymous `sub`, which pushes a
+        // block frame — so narrowing it would turn their `return` into a throw.
+        let in_routine = if is_eval_unit {
+            self.enclosing_routine_exists()
+        } else {
+            !self.routine_stack.is_empty()
+        };
+        compiler.is_routine = in_routine;
+        compiler.lexically_in_routine = in_routine;
         // Let a nested closure in this body recognize the enclosing routine's
         // sigilless parameters (`\attr`) as lexical captures rather than
         // barewords. The fresh compiler otherwise has no signature context.

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -258,11 +258,26 @@ impl Interpreter {
         // Record the `&name` code-vars that already exist in the enclosing scope,
         // so a sub declared inside this EVAL may shadow them without being treated
         // as a redeclaration (see registration_sub.rs).
+        //
+        // `visible_keys_where`, not `keys()`: the redeclaration check this feeds
+        // resolves the name with `env.get`, which walks the parent chain and the
+        // base tier, while `keys()` exposes only the innermost tier's overlay.
+        // A name reachable through the chain was therefore *found* by the check
+        // but *absent* from the shadow snapshot, so an EVAL'd `sub f` collided
+        // with an outer `f` instead of shadowing it — which is what
+        // `roast/S04-statements/given.t` does, EVALing a fresh `sub test-given`
+        // per subtest while an earlier subtest's `my sub test-given` is still
+        // reachable.
         crate::runtime::registration_sub::push_eval_outer_amp_names(
             self.env
-                .keys()
-                .map(|k| k.resolve().to_string())
-                .filter(|k| k.starts_with('&')),
+                .visible_keys_where(|k| k.starts_with('&'))
+                .into_iter(),
+        );
+        // ...and the registry counterpart, which is what the redeclaration
+        // checks against `functions` consult. Interned `Symbol`s, so no strings
+        // are allocated to take it.
+        crate::runtime::registration_sub::push_eval_outer_routine_keys(
+            self.registry().functions.keys().copied(),
         );
         self.env.insert("__mutsu_in_eval".to_string(), Value::TRUE);
         // A `:key<>` colonpair (empty angle brackets) in the EVAL'd source's Pod
@@ -461,6 +476,7 @@ impl Interpreter {
             self.env.remove("_");
         }
         crate::runtime::registration_sub::pop_eval_outer_amp_names();
+        crate::runtime::registration_sub::pop_eval_outer_routine_keys();
         result
     }
 }

--- a/t/eval-return-target-needs-a-real-routine.t
+++ b/t/eval-return-target-needs-a-real-routine.t
@@ -1,0 +1,41 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# `return` in a non-routine block does a *non-local* return when a routine
+# lexically encloses it, and throws X::ControlFlow::Return when none does.
+# mutsu decided that for an EVAL'd snippet from `!routine_stack.is_empty()` --
+# but a bare `{ ... }` block, a `for` body and a closure all push a
+# `RoutineFrame` too (`is_block: true`). So an EVAL run from inside a mainline
+# block compiled its snippet as "inside a routine", and a `return` in the
+# snippet's own pointy block returned from whatever sub later called that block
+# instead of throwing.
+
+plan 6;
+
+# The shape roast/S04-statements/return.t test 15 asserts, run from inside a
+# block rather than at file scope.
+{
+    my $r = try EVAL 'my $d = -> $x { return 2 * $x }; sub f($x) { $d($x) }; f 42';
+    nok $r.defined, 'return is lexotic: an EVALd blocks return does not target its caller';
+    is $!.^name, 'X::ControlFlow::Return', 'and it is X::ControlFlow::Return';
+}
+
+# Same snippet at file scope, which already worked -- pinned so the fix cannot
+# be "make both wrong the same way".
+my $top = try EVAL 'my $d2 = -> $x { return 2 * $x }; sub f2($x) { $d2($x) }; f2 42';
+nok $top.defined, 'and the same holds at file scope';
+
+# A bare `return` in an EVAL from inside a block throws, and the throw is
+# catchable rather than escaping to the top level.
+{
+    my $bare = try EVAL 'return 1';
+    is $!.^name, 'X::ControlFlow::Return', 'a bare EVALd return from a block throws catchably';
+    nok $bare.defined, 'and yields no value';
+}
+
+# When a REAL routine encloses the EVAL, `return` in the snippet still returns
+# from it -- rakudo does this, so the fix must not turn every EVALd return into
+# a throw.
+sub enclosing { my $x = EVAL 'return 7'; return 8 }
+is enclosing(), 7, 'an EVALd return still returns from a genuinely enclosing routine';

--- a/t/eval-sub-shadows-outer-routine.t
+++ b/t/eval-sub-shadows-outer-routine.t
@@ -1,0 +1,55 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# `EVAL` compiles a new compunit nested inside the caller's scope, so a `sub f`
+# declared in it SHADOWS an outer `f` -- it can never be a redeclaration of one.
+# Only a name declared inside the same EVAL still conflicts.
+#
+# mutsu had the exemption, but only for the `&name` env binding. The
+# redeclaration checks also consult the routine REGISTRY, and the two records do
+# not always agree about what exists: a `my sub` declared inside a block that
+# runs as a *callable* leaves a registry entry reachable afterwards without
+# leaving an `&name` in any visible env tier. An EVAL'd `sub` of that name then
+# raised "Redeclaration of routine" -- which is what roast/S04-statements/given.t
+# hit, EVALing a fresh `sub test-given` per subtest while an earlier subtest's
+# `my sub test-given` was still registered.
+
+plan 6;
+
+sub run(&b) { b() }
+
+my @log;
+
+run {
+    my sub tester($x) { @log.push: "outer $x" }
+    tester(1);
+}
+
+lives-ok {
+    run {
+        my sub produce($n) {
+            EVAL "sub tester(\$x) \{ \@log.push: \"eval$n \$x\" }";
+        }
+        for 1, 2 -> $n {
+            my &t = produce $n;
+            t(9);
+        }
+    }
+}, 'an EVALd sub shadows a routine left registered by a callable block';
+
+is-deeply @log, ['outer 1', 'eval1 9', 'eval2 9'],
+    'and each EVAL produced its own routine';
+
+# The same shape with the outer routine at file scope.
+sub top-level($a, $b) { "$a$b" }
+is top-level(1, 2), '12', 'the file-scope routine works before the EVAL';
+my $evaled = EVAL 'sub top-level($x) { "e$x" }';
+is $evaled(7), 'e7', 'an EVALd sub may shadow a file-scope routine of the same name';
+is top-level(1, 2), '12', "and the outer routine is unaffected afterwards";
+
+# A name declared *inside* the same EVAL still conflicts -- the exemption must
+# not turn into a blanket "anything goes inside EVAL".
+throws-like { EVAL 'sub dup-in-eval() { 1 }; sub dup-in-eval() { 2 }' },
+    Exception,
+    'two declarations of one name inside a single EVAL still collide';


### PR DESCRIPTION
## What

`EVAL` compiles a new compunit nested inside the caller's scope, so a `sub f` declared in it **shadows** an outer `f` — it can never be a redeclaration of one. mutsu had that exemption, but wired to only one of the two records a declaration leaves behind: `EVAL_OUTER_AMP_NAMES` snapshots the `&name` env bindings, and only the env-side redeclaration check consulted it. The checks against the routine **registry** had no exemption at all.

The two records do not always agree about what exists. A `my sub` declared inside a block that runs as a *callable* leaves a registry entry reachable afterwards without leaving an `&name` in any visible env tier:

```raku
sub run(&b) { b() }
run { my sub tester($x) { say "outer $x" }; tester(1) }
run {
    my sub produce($n) { EVAL "sub tester(\$x) \{ say \"eval$n \$x\" }" }
    for 1, 2 -> $n { my &t = produce $n; t(9) }
}
```

```
raku : outer 1 / eval1 9 / eval2 9
mutsu: outer 1 / Redeclaration of routine 'tester'. Did you mean to declare a multi-sub?
```

`roast/S04-statements/given.t` is exactly this shape and died on the very first one.

The fix adds the registry counterpart `EVAL_OUTER_ROUTINE_KEYS`, taken at the same point and keyed by interned `Symbol` so the snapshot allocates no strings. A key registered *inside* the EVAL is not in it and still collides, so this is not a blanket "anything goes inside EVAL".

Also: `Env::keys()` exposes only the innermost tier's overlay while `Env::get()` walks the parent chain and the base tier, so the `&name` snapshot was already missing names the check could find. `Env::visible_keys_where` is the chain-walking, key-only counterpart (`flatten()` answers the same question but deep-copies every value).

## What it unmasked, and had to fix too

`roast/S04-statements/return.t` test 15 was passing **for the wrong reason**: the file declares a `sub foo` earlier, so its `try EVAL '... sub foo($x) {...}; foo 42'` used to die of this very redeclaration, making `.defined` `False` without the snippet's `return` ever running. With the EVAL succeeding, mutsu returned `84`.

`return` in a non-routine block does a *non-local* return when a routine lexically encloses it, and throws `X::ControlFlow::Return` when none does. The EVAL compile path decided that from `!routine_stack.is_empty()` — but a bare `{ ... }` block, a `for` body and a closure all push a `RoutineFrame` (`is_block: true`). So an `EVAL` from inside a mainline block compiled its snippet as "inside a routine", and a `return` in the snippet's own pointy block returned from whatever sub later called it. At file scope the same snippet was already correct.

Both flags now ask `enclosing_routine_exists()`, which ignores block frames — **for an EVAL unit only**. The other callers of that path recompile ordinary closure/sub bodies, where the live frame *is* the routine being run (an anonymous `sub` pushes a block frame), so narrowing it there turned their `return` into a throw; `make test` caught that and it is gated.

## Verification

- `t/eval-sub-shadows-outer-routine.t` — **5 of its 6 assertions fail without the fix**.
- `t/eval-return-target-needs-a-real-routine.t` — new pin for the return half.
- Both pass verbatim under `raku`.
- `make test` PASS (2832 files), release `make roast` PASS (1435 files), bundled-library gate PASSED.

`given.t` itself is not fixed by this — it moves on to a separate bug (`my &f = ...` does not shadow an outer `sub f` for a by-name call), which is its own slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)