### PR TITLE
docs(todo): record the 2026-08-04 real-Test slice and the next wall

### DIFF
--- a/todo/tickets/lexical-amp-binding-does-not-shadow-a-routine.md
+++ b/todo/tickets/lexical-amp-binding-does-not-shadow-a-routine.md
@@ -1,0 +1,63 @@
+# `my &f = ...` does not shadow an outer `sub f` for a by-name call
+
+A `my &f` binding is an ordinary lexical and shadows any outer routine of the
+same name. mutsu resolves a by-name call to the routine registry first, so the
+binding is ignored and the outer routine is called instead — usually with the
+wrong arity, so it surfaces as a confusing "Too few positionals passed".
+
+## Minimal repro
+
+```raku
+sub tester($a, $b) { say "outer $a $b" }
+tester(1, 2);
+
+{
+    my &tester = -> $x { say "lexical $x" };
+    tester(9);
+}
+tester(3, 4);
+```
+
+```
+raku                     mutsu
+outer 1 2                outer 1 2
+lexical 9                Too few positionals passed; expected 2 arguments but got 1
+outer 3 4                  in block <unit> at ...:4
+```
+
+Calling through the variable (`&tester($x)` / `$tester(9)` shapes) works; it is
+specifically the bare-name listop/parenthesised call that goes to the registry.
+
+## Why it matters
+
+This is what `roast/S04-statements/given.t` reaches after
+`news/2026-08/eval-sub-shadows-a-registered-routine.md`. Its
+`given/when with explicit conditions` subtest does
+
+```raku
+my &test-given = produce-tester $condition;   # produce-tester EVALs a fresh sub
+test-given topic, $desc, :$match;
+```
+
+while an earlier subtest's `my sub test-given(Mu \topic, Mu \condition, $message, :$match)`
+is still in the registry. The call resolves to that 3-positional routine and
+dies with "Too few positionals passed; expected 3 arguments but got 2", losing
+the whole 3-subtest group.
+
+## Why it is not a one-liner
+
+The call-resolution order is shared by every by-name call site, and mutsu
+deliberately prefers the registry in several places (imported routines, `our`
+routines, multi dispatch, the native-builtin guards of
+`news/2026-07/qualified-call-no-longer-aliases-a-builtin.md`). The rule to
+implement is Raku's: a *lexical* `&name` binding visible at the call site wins
+over a package/registry routine of that name, and only falls through when there
+is none. Deciding "visible at the call site" has to work at compile time where
+possible (the compiler knows the enclosing `my &name` declarations) rather than
+by probing `env` at run time, or the fast call paths regress.
+
+Related: `todo/deep/...`-style leak that makes this hit more often than it
+should — a `my sub` declared inside a block invoked as a *callable* stays
+visible after the block (`::('&tester').defined` is `True` in mutsu, `False` in
+raku), so the outer routine that loses the contest is often one that should not
+exist at that point at all.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -730,3 +730,38 @@ are the best-value place to start, since an abort costs a whole file:
 `roast/S12-methods/qualified.t` is worth a second look too: its Malformed
 assertion passes now and the file moved on to `Cannot dispatch to method me on
 Parent because it is not inherited or done by Bar` in its inheritance subtest.
+
+### Working the diagnostic-free aborts (2026-08-04)
+
+Two of the listed aborts were taken, and both were general interpreter bugs the
+strict module merely exposed. Neither was in `Test.rakumod` and neither was
+about assertions.
+
+| file | cause | fix |
+| --- | --- | --- |
+| `S02-types/capture.t` (now 46/46) | the atomic shared-array store seeded itself from an **undereferenced `ContainerRef`**, so it started EMPTY and dropped `Test.rakumod`'s whole `@vars` subtest stack the first time the file spawned a thread | `news/2026-08/shared-array-mutation-through-a-container-cell.md` |
+| `S04-statements/given.t` (still failing, one step further) | an EVAL'd `sub` collided with a routine only the **registry** knew about, so `produce-tester`'s per-subtest `sub test-given` raised "Redeclaration of routine" | `news/2026-08/eval-sub-shadows-a-registered-routine.md` |
+
+Three things worth carrying forward:
+
+- **`@`/`%` module lexicals are `ContainerRef` cells as seen from the module's
+  own subs.** Any code that reads an env binding's `ValueView` and expects a
+  bare `Array`/`Hash` is wrong there. The bug above matched neither arm and
+  silently took the `_ => default()` branch.
+- **A fix in this campaign routinely unmasks the next bug.** The `given.t` fix
+  made `roast/S04-statements/return.t` test 15 fail — it had been passing
+  because the EVAL died of the very redeclaration being removed, so the
+  snippet's `return` was never exercised. Local full `make roast` caught it; the
+  underlying lexotic-`return` bug is fixed in the same PR.
+- **`!routine_stack.is_empty()` is not "is a routine live".** A bare block, a
+  `for` body and an *anonymous* `sub` all push a `RoutineFrame` with
+  `is_block: true`. `Interpreter::enclosing_routine_exists()` is the predicate
+  that asks the real question — but it is only correct for an EVAL *unit*; the
+  other users of that compile path recompile closure bodies where the live frame
+  IS the routine.
+
+`given.t`'s next wall is its own ticket:
+`todo/tickets/lexical-amp-binding-does-not-shadow-a-routine.md` — `my &f = ...`
+does not shadow an outer `sub f` for a bare-name call, so
+`my &test-given = produce-tester $condition; test-given topic, ...` still
+reaches the earlier subtest's 3-positional `test-given`.


### PR DESCRIPTION
Ledger update for the real-`Test` vendoring campaign, plus a new ticket.

- `todo/tickets/vendor-real-test-module.md` — records the two diagnostic-free aborts taken on 2026-08-04 (`S02-types/capture.t` now 46/46; `S04-statements/given.t` one step further), and three carry-forward lessons: a module's `@`/`%` file-scope lexicals are `ContainerRef` cells as seen from its own subs; a fix in this campaign routinely unmasks the next bug (`return.t` test 15 had been passing for the wrong reason); `!routine_stack.is_empty()` is not "is a routine live".
- `todo/tickets/lexical-amp-binding-does-not-shadow-a-routine.md` — new: `my &f = ...` does not shadow an outer `sub f` for a bare-name call, which is `given.t`'s next wall. 8-line repro included.

Documentation only — the four heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)