### PR TITLE
fix: four bugs behind Digest::MD5's wrong digest

### DIFF
--- a/news/2026-08/digest-md5-four-fixes.md
+++ b/news/2026-08/digest-md5-four-fixes.md
@@ -1,0 +1,105 @@
+# Four general fixes make grondilu's `Digest::MD5` produce correct digests
+
+`Digest::MD5` from grondilu's `libdigest-raku` ran to completion after the
+`for`-modifier placeholder fix (`news/2026-08/for-modifier-placeholder-scope.md`)
+but produced a wrong digest — `md5("abc")` gave `fe2be2927d9087ecb52bcb1fedc50c16`
+instead of `900150983cd24fb0d6963f7d28e17f72`. Reducing the module's expression
+tree piece by piece against `raku` turned up four independent interpreter bugs,
+none of them specific to MD5. All four are fixed; `t/md5.t` in that distribution
+now passes in full, and `t/sha.t` is down to its documented `sha384`/`sha512`
+blocker.
+
+## 1. Byte-addressed `Buf` accessors ignored the element width
+
+`read-int*` / `read-uint*` / `read-num*` and their `write-*` counterparts were
+handed a *projection* of the buffer — one byte per element, taking each
+element's low byte — rather than its real storage. On every width-1 buffer
+(`Buf`, `Blob`, `utf8`, `buf8`) that projection is the storage, so the bug was
+invisible there; on a `buf16`/`buf32`/`buf64` it was destructive. A write read
+the wrong bytes, and committing the result back stored one element per byte, so
+`buf32.new(0x80636261, 0x11223344).write-uint64(2, 24, LittleEndian)` flattened
+the existing elements to `0x61, 0x44`.
+
+Rakudo addresses the buffer's actual storage, and the offset those methods take
+counts **elements**: the byte position is `offset * width`. So on a `buf32`
+offset 1 is element 1, and on a `buf16` a four-byte write at offset 1 spans
+elements 1 and 2. The growth rule is MoarVM's, which mixes the units — a write
+past the end resizes the buffer to `offset + size` *elements*, so
+`buf32.new(1,2).write-uint32(2, $v)` leaves six elements, not three. That reads
+like an `MVMArray` slip, but it is observable and `Digest::MD5` runs into it, so
+mutsu matches it rather than inventing a tidier rule.
+
+`value_buf.rs` grew `buf_raw_bytes` / `set_buf_raw_bytes` / `make_buf_from_raw_bytes`
+alongside the existing one-byte-per-element helpers, and the six write dispatch
+sites and five read arms were moved onto them, with the offset scaled by
+`buf_elem_width`. `apply_write_int` / `apply_write_num` take the width and share
+one `write_byte_offset` helper. The `nqp::writeuint` path keeps width 1: its
+`buf_bytes_mutate` carrier hands over one byte per element already, so its offset
+is a plain byte offset.
+
+Pinned by `t/buf-wide-read-write-int.t`.
+
+## 2. `Xxx` / `Zxx` thunked the whole left list instead of each element
+
+`xx` re-evaluates its left operand once per repetition. Under a cross or zip
+meta-op that re-evaluation is *per element* of the left list: `($i++, 100) Xxx 3`
+is `((0,1,2), (100,100,100))` — one `Seq` per left element — and leaves `$i` at
+3. mutsu wrapped the entire left side in one thunk and repeated that, producing
+the transposed `((0,100), (1,100), (2,100))`. `Zxx` had the same shape bug in a
+subtler form: it re-ran the whole-list thunk `count` times per position and
+picked element `i` out of each result, so `($v++, 5) Zxx (2,3)` printed the right
+values but ran the side effect five times instead of two.
+
+The compiler now rewrites a list-literal left operand into a list of
+argument-less thunks, one per element (`Compiler::per_element_thunks`), and the
+carriers repeat one element at a time: the new `__mutsu_cross_xx` (left element
+outer, count inner) and a rewritten `__mutsu_zip_xx`. A left side that is *not* a
+list literal — `$i++ Xxx 3`, `@a Xxx 3`, `(...).list Xxx 3` — is a single
+already-evaluated value in Rakudo too, and still falls through to the ordinary
+`MetaOp` path. `__mutsu_reverse_xx` keeps serving `Rxx`, whose left side really
+is one whole expression.
+
+This is what generated MD5's per-round message-index table,
+`16 X[R%] flat ($++, 5*$++ + 1, 3*$++ + 5, 7*$++) Xxx 16`.
+
+Pinned by `t/metaop-xx-per-element-thunk.t`.
+
+## 3. `polymod` had no arbitrary-precision path
+
+`polymod`'s exact path was capped at `i128`, so an invocant wider than that fell
+through to an `f64` loop that cannot represent the number at all: a finite
+divisor list produced zeros and an infinite one produced nothing.
+`parse-base('900150983cd24fb0d6963f7d28e17f72', 16).polymod(256 xx *)` — how the
+`Digest` test builds its expected `Blob` — returned an empty `Seq`, which is why
+every MD5 comparison read `expected: 'Blob:0x<>'`.
+
+Integer operands now decompose in `BigInt` arithmetic, ahead of the rational
+path, in both the finite and the infinite-divisor forms. Non-integer invocants
+keep the rational and float behaviour they had.
+
+Pinned by `t/polymod-bigint.t`.
+
+## 4. `.roll($n)` on a non-numeric `Range` always returned the start element
+
+The `GenericRange` sampler enumerated and picked from the range only when the
+start was numeric; anything else answered the start element. So
+`("a".."z").roll(8).join` was `aaaaaaaa` every time — which made the `Digest`
+test's "hash 100 random strings" subtest hash the same string a hundred times.
+`.pick` was unaffected.
+
+Any endpoint pair is now enumerated via `.succ` and sampled from, so a rolled
+element keeps its type (`(1.1..3.1).roll` still yields `Rat`s). An unbounded end
+(`1..*`, `'a'..Inf`) keeps answering the start element rather than trying to
+reify the range — previously the numeric branch would have attempted exactly
+that.
+
+Pinned by `t/range-roll-non-numeric.t`.
+
+## Not fixed here
+
+`read-ubits` / `write-bits` now address the buffer's raw storage rather than the
+low-byte projection, so a wide buffer at least survives a bit-write intact. They
+still diverge from MoarVM on wide buffers, where a bit offset appears to select
+whole elements (`buf32.new(0x11223344, 0x55667788).read-ubits(8, 8)` is
+`0x55667788` in Rakudo). Width-1 buffers — every practical use — are unaffected.
+Recorded in `todo/tickets/digest-dist-blockers.md`.

--- a/src/builtins/buf_write_int.rs
+++ b/src/builtins/buf_write_int.rs
@@ -6,7 +6,7 @@
 //   (similarly for write-int8, write-uint16, ..., write-int128)
 
 use crate::symbol::Symbol;
-use crate::value::value_buf::{buf_bytes_or_empty, set_buf_bytes};
+use crate::value::value_buf::{buf_elem_width, buf_raw_bytes_or_empty, set_buf_raw_bytes};
 use crate::value::{InstanceAttrs, RuntimeError, Value, ValueView};
 
 /// Returns Some((byte_size, is_signed)) if the method is a write-int/uint method.
@@ -55,28 +55,58 @@ fn to_u128_value(value: &Value) -> u128 {
     }
 }
 
-/// Apply a write-int/uint write to a byte vector (resizing if needed).
-pub(crate) fn apply_write_int(
+/// Where a `write-int*` / `write-num*` of `size` bytes at element `offset`
+/// lands in a buffer's raw storage, growing that storage if the write runs past
+/// its end.
+///
+/// The offset counts **elements**, not bytes: Rakudo's `$buf.write-uint32(1, …)`
+/// overwrites element 1 of a `buf32`, and spans elements 1 and 2 of a `buf16`.
+/// So the byte position is `offset * width`, and every width-1 buffer — `Buf`,
+/// `Blob`, `buf8`, the overwhelmingly common case — keeps exactly the plain byte
+/// offset it always had.
+///
+/// The growth rule reproduces MoarVM's, which mixes the units: a write past the
+/// end resizes the buffer to `offset + size` *elements*. That reads like a slip
+/// in `MVMArray`, but it is observable — `buf32.new(1,2).write-uint32(2, $v)`
+/// leaves six elements, not three — so mutsu matches it rather than inventing a
+/// tidier rule.
+pub(crate) fn write_byte_offset(
     bytes: &mut Vec<u8>,
     method: &str,
     offset: i64,
-    value: &Value,
-    endian_val: i64,
-) -> Result<(), RuntimeError> {
-    let (size, _signed) = write_int_info(method).expect("not a write-int method");
+    size: usize,
+    width: usize,
+) -> Result<usize, RuntimeError> {
     if offset < 0 {
         return Err(RuntimeError::new(format!(
             "Cannot write to a negative offset for {}: {}",
             method, offset
         )));
     }
-    let off = offset as usize;
-    let needed = off
-        .checked_add(size)
-        .ok_or_else(|| RuntimeError::new(format!("{} offset {} too large", method, offset)))?;
-    if bytes.len() < needed {
-        bytes.resize(needed, 0u8);
+    let width = width.max(1);
+    let too_large = || RuntimeError::new(format!("{} offset {} too large", method, offset));
+    let off = (offset as usize).checked_mul(width).ok_or_else(too_large)?;
+    let end = off.checked_add(size).ok_or_else(too_large)?;
+    if bytes.len() < end {
+        let elems = (offset as usize).checked_add(size).ok_or_else(too_large)?;
+        let grown = elems.checked_mul(width).ok_or_else(too_large)?;
+        bytes.resize(grown, 0u8);
     }
+    Ok(off)
+}
+
+/// Apply a write-int/uint write to a buffer's raw storage bytes (resizing if
+/// needed). `width` is the buffer's element width — see [`write_byte_offset`].
+pub(crate) fn apply_write_int(
+    bytes: &mut Vec<u8>,
+    method: &str,
+    offset: i64,
+    value: &Value,
+    endian_val: i64,
+    width: usize,
+) -> Result<(), RuntimeError> {
+    let (size, _signed) = write_int_info(method).expect("not a write-int method");
+    let off = write_byte_offset(bytes, method, offset, size, width)?;
 
     let raw = to_u128_value(value);
 
@@ -186,7 +216,7 @@ pub(crate) fn try_native_buf_write(
             if !crate::runtime::utils::is_buf_or_blob_class(&cn) {
                 return None;
             }
-            bytes = buf_bytes_or_empty(&attributes);
+            bytes = buf_raw_bytes_or_empty(&attributes);
             inst = Some(BufWriteCell {
                 attributes: attributes.clone(),
                 class_sym: class_name,
@@ -213,12 +243,13 @@ pub(crate) fn try_native_buf_write(
     } else {
         0
     };
+    let width = buf_elem_width(&cn);
     let res = if is_num {
         crate::builtins::buf_write_num::apply_write_num(
-            &mut bytes, method, offset_i64, &args[1], endian_val,
+            &mut bytes, method, offset_i64, &args[1], endian_val, width,
         )
     } else {
-        apply_write_int(&mut bytes, method, offset_i64, &args[1], endian_val)
+        apply_write_int(&mut bytes, method, offset_i64, &args[1], endian_val, width)
     };
     if let Err(e) = res {
         return Some(Err(e));
@@ -226,7 +257,7 @@ pub(crate) fn try_native_buf_write(
     match inst {
         Some(cell) => {
             let mut updated_map = cell.attributes.to_map();
-            set_buf_bytes(&mut updated_map, cell.class_sym, &bytes);
+            set_buf_raw_bytes(&mut updated_map, cell.class_sym, bytes);
             Some(Ok(Value::write_back_sharing(
                 &cell.attributes,
                 cell.class_sym,
@@ -236,7 +267,7 @@ pub(crate) fn try_native_buf_write(
         }
         None => {
             let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
-            Some(Ok(crate::builtins::buf_write_num::make_buf_value(
+            Some(Ok(crate::builtins::buf_write_num::make_buf_value_from_raw(
                 &normalized,
                 bytes,
             )))

--- a/src/builtins/buf_write_num.rs
+++ b/src/builtins/buf_write_num.rs
@@ -43,28 +43,20 @@ pub(crate) fn to_f64_value(value: &Value) -> f64 {
     }
 }
 
-/// Apply a write-num write to a byte slice (resizing if needed).
+/// Apply a write-num write to a buffer's raw storage bytes (resizing if
+/// needed). `width` is the buffer's element width — see
+/// [`crate::builtins::buf_write_int::write_byte_offset`].
 pub(crate) fn apply_write_num(
     bytes: &mut Vec<u8>,
     method: &str,
     offset: i64,
     value: &Value,
     endian_val: i64,
+    width: usize,
 ) -> Result<(), RuntimeError> {
     let size = write_num_size(method).expect("not a write-num method");
-    if offset < 0 {
-        return Err(RuntimeError::new(format!(
-            "Cannot write to a negative offset for {}: {}",
-            method, offset
-        )));
-    }
-    let off = offset as usize;
-    let needed = off
-        .checked_add(size)
-        .ok_or_else(|| RuntimeError::new(format!("write-num offset {} too large", offset)))?;
-    if bytes.len() < needed {
-        bytes.resize(needed, 0u8);
-    }
+    let off =
+        crate::builtins::buf_write_int::write_byte_offset(bytes, method, offset, size, width)?;
     let v = to_f64_value(value);
     if size == 4 {
         let v32 = v as f32;
@@ -85,8 +77,15 @@ pub(crate) fn apply_write_num(
     Ok(())
 }
 
-/// Build a fresh Buf instance value from a byte vector.
+/// Build a fresh Buf instance value from a byte vector, one element per byte.
 pub(crate) fn make_buf_value(class_name: &str, bytes: Vec<u8>) -> Value {
     use crate::symbol::Symbol;
     crate::value::value_buf::make_buf_from_bytes(Symbol::intern(class_name), &bytes)
+}
+
+/// Build a fresh Buf instance value over *raw storage bytes* — already laid out
+/// at `class_name`'s element width, as the `write-*` methods produce them.
+pub(crate) fn make_buf_value_from_raw(class_name: &str, bytes: Vec<u8>) -> Value {
+    use crate::symbol::Symbol;
+    crate::value::value_buf::make_buf_from_raw_bytes(Symbol::intern(class_name), bytes)
 }

--- a/src/builtins/methods_narg/buf.rs
+++ b/src/builtins/methods_narg/buf.rs
@@ -144,6 +144,51 @@ pub(crate) fn buf_get_bytes(target: &Value) -> Option<Vec<u8>> {
     None
 }
 
+/// A Buf/Blob instance's raw storage bytes together with its element width —
+/// what the byte-addressed `read-*` methods index into.
+///
+/// The offset those methods take counts **elements**: `$buf.read-uint32(1)` on
+/// a `buf32` reads element 1, i.e. byte `1 * 4`. For a width-1 buffer (`Buf`,
+/// `Blob`, `buf8`, …) the width is 1 and this is exactly [`buf_get_bytes`].
+pub(crate) fn buf_get_raw_bytes(target: &Value) -> Option<(Vec<u8>, usize)> {
+    if let ValueView::Instance {
+        class_name,
+        attributes,
+        ..
+    } = target.view()
+    {
+        let cn = class_name.resolve();
+        if crate::runtime::utils::is_buf_or_blob_class(&cn) {
+            let bytes = crate::value::value_buf::buf_raw_bytes(&attributes)?;
+            return Some((bytes, crate::value::value_buf::buf_elem_width(&cn)));
+        }
+    }
+    None
+}
+
+/// Where a byte-addressed read of `size` bytes at element `offset` starts in
+/// `bytes`, or the out-of-range error. See [`buf_get_raw_bytes`] for why the
+/// offset is scaled by the element width.
+pub(crate) fn read_byte_offset(
+    bytes: &[u8],
+    offset: i64,
+    size: usize,
+    width: usize,
+) -> Result<usize, RuntimeError> {
+    let width = width.max(1);
+    let start = (offset >= 0)
+        .then(|| (offset as usize).checked_mul(width))
+        .flatten();
+    match start {
+        Some(off) if off.checked_add(size).is_some_and(|end| end <= bytes.len()) => Ok(off),
+        _ => Err(RuntimeError::new(format!(
+            "read from out of range. Is: {}, should be in 0..{}",
+            offset,
+            bytes.len() / width
+        ))),
+    }
+}
+
 pub(crate) fn to_int_val(v: &Value) -> i64 {
     match v.view() {
         ValueView::Int(i) => i,

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -3,9 +3,9 @@ use super::base::{
     BaseDigits, f64_to_rat, parse_radix_checked, range_pick_n_fast, rat_base_repeating, rat_to_base,
 };
 use super::buf::{
-    buf_class_name, buf_get_bytes, buf_get_int_items, is_buf_like, make_buf_from_int_items,
-    out_of_range_error, range_bounds, read_f32_ne, read_f64_ne, read_int_method_info,
-    read_int_value, resolve_buf_index, to_int_val,
+    buf_class_name, buf_get_int_items, buf_get_raw_bytes, is_buf_like, make_buf_from_int_items,
+    out_of_range_error, range_bounds, read_byte_offset, read_f32_ne, read_f64_ne,
+    read_int_method_info, read_int_value, resolve_buf_index, to_int_val,
 };
 use super::flatten::{flatten_target, is_hammer_pair, parse_flat_depth};
 use super::fmt_contains::{
@@ -1826,11 +1826,20 @@ pub(crate) fn native_method_1arg(
                         if let Some(result) = crate::builtins::methods_0arg::dispatch_core_range::generic_range_pick_one_pub(start, end, excl_start, excl_end) {
                             return Some(result);
                         }
-                        // Non-integer numeric endpoints (Rat/Num/FatRat):
-                        // enumerate via `.succ` (value_to_list preserves the
-                        // endpoint type) so a picked element keeps its type —
-                        // `(1.1..3.1).roll(n)` yields Rats, not Nums.
-                        if start.is_numeric() {
+                        // Any other endpoint pair — non-integer numeric
+                        // (Rat/Num/FatRat) or non-numeric (`'a'..'z'`) — is
+                        // enumerated via `.succ` (value_to_list preserves the
+                        // endpoint type) and sampled from that, so a picked
+                        // element keeps its type: `(1.1..3.1).roll(n)` yields
+                        // Rats, not Nums, and `('a'..'z').roll(n)` yields
+                        // distinct letters rather than 'a' every time.
+                        //
+                        // An unbounded end (`1..*`, `'a'..Inf`) has no
+                        // enumeration to sample, so it keeps answering the start
+                        // element rather than trying to reify the range.
+                        let unbounded = matches!(end.view(), ValueView::Whatever)
+                            || matches!(end.view(), ValueView::Num(f) if f.is_infinite());
+                        if !unbounded {
                             let vals = crate::runtime::utils::value_to_list(range);
                             if !vals.is_empty() {
                                 let idx = (crate::builtins::rng::builtin_rand() * vals.len() as f64)
@@ -2018,21 +2027,13 @@ pub(crate) fn native_method_1arg(
                     method, type_name,
                 ))));
             }
-            let bytes = buf_get_bytes(target)?;
+            let (bytes, width) = buf_get_raw_bytes(target)?;
             let offset_i64 = to_int_val(arg);
             let size: usize = if method == "read-num32" { 4 } else { 8 };
-            if offset_i64 < 0
-                || (offset_i64 as usize)
-                    .checked_add(size)
-                    .is_none_or(|end| end > bytes.len())
-            {
-                return Some(Err(RuntimeError::new(format!(
-                    "read from out of range. Is: {}, should be in 0..{}",
-                    offset_i64,
-                    bytes.len()
-                ))));
-            }
-            let offset = offset_i64 as usize;
+            let offset = match read_byte_offset(&bytes, offset_i64, size, width) {
+                Ok(off) => off,
+                Err(e) => return Some(Err(e)),
+            };
             let result = if size == 4 {
                 read_f32_ne(&bytes[offset..offset + 4])
             } else {
@@ -2049,21 +2050,13 @@ pub(crate) fn native_method_1arg(
                     method, type_name,
                 ))));
             }
-            let bytes = buf_get_bytes(target)?;
+            let (bytes, width) = buf_get_raw_bytes(target)?;
             let offset_i64 = to_int_val(arg);
             let (size, signed) = read_int_method_info(method);
-            if offset_i64 < 0
-                || (offset_i64 as usize)
-                    .checked_add(size)
-                    .is_none_or(|end| end > bytes.len())
-            {
-                return Some(Err(RuntimeError::new(format!(
-                    "read from out of range. Is: {}, should be in 0..{}",
-                    offset_i64,
-                    bytes.len()
-                ))));
-            }
-            let offset = offset_i64 as usize;
+            let offset = match read_byte_offset(&bytes, offset_i64, size, width) {
+                Ok(off) => off,
+                Err(e) => return Some(Err(e)),
+            };
             // NativeEndian default
             let endian: i64 = if cfg!(target_endian = "little") { 1 } else { 2 };
             Some(Ok(read_int_value(

--- a/src/builtins/methods_narg/dispatch_2arg.rs
+++ b/src/builtins/methods_narg/dispatch_2arg.rs
@@ -1,10 +1,10 @@
 use super::allomorph::out_of_range_failure;
 use super::base::{BaseDigits, f64_to_rat, rat_to_base};
 use super::buf::{
-    bigint_to_value, buf_class_name, buf_get_bytes, buf_get_int_items, is_buf_like,
-    make_buf_from_int_items, out_of_range_error, read_f32_endian, read_f64_endian,
-    read_int_method_info, read_int_value, read_ubits_from_bytes, resolve_buf_index,
-    resolve_buf_len, to_int_val,
+    bigint_to_value, buf_class_name, buf_get_int_items, buf_get_raw_bytes, is_buf_like,
+    make_buf_from_int_items, out_of_range_error, read_byte_offset, read_f32_endian,
+    read_f64_endian, read_int_method_info, read_int_value, read_ubits_from_bytes,
+    resolve_buf_index, resolve_buf_len, to_int_val,
 };
 use super::flatten::{flatten_target, is_hammer_pair, parse_flat_depth};
 use super::fmt_contains::{fmt_joinable_target, fmt_single_or_pair};
@@ -268,7 +268,7 @@ pub(crate) fn native_method_2arg(
             }
         }
         "read-ubits" | "read-bits" => {
-            let bytes = buf_get_bytes(target)?;
+            let (bytes, _) = buf_get_raw_bytes(target)?;
             let from = runtime::to_int(arg1);
             let bits = runtime::to_int(arg2);
             if from < 0 || bits < 0 {
@@ -305,7 +305,7 @@ pub(crate) fn native_method_2arg(
                     method, type_name,
                 ))));
             }
-            let bytes = buf_get_bytes(target)?;
+            let (bytes, width) = buf_get_raw_bytes(target)?;
             let offset_i64 = to_int_val(arg1);
             let endian_val = match arg2.view() {
                 ValueView::Enum { value, .. } => value.as_i64(),
@@ -313,18 +313,10 @@ pub(crate) fn native_method_2arg(
                 _ => 0, // NativeEndian
             };
             let size: usize = if method == "read-num32" { 4 } else { 8 };
-            if offset_i64 < 0
-                || (offset_i64 as usize)
-                    .checked_add(size)
-                    .is_none_or(|end| end > bytes.len())
-            {
-                return Some(Err(RuntimeError::new(format!(
-                    "read from out of range. Is: {}, should be in 0..{}",
-                    offset_i64,
-                    bytes.len()
-                ))));
-            }
-            let offset = offset_i64 as usize;
+            let offset = match read_byte_offset(&bytes, offset_i64, size, width) {
+                Ok(off) => off,
+                Err(e) => return Some(Err(e)),
+            };
             let result = if size == 4 {
                 read_f32_endian(&bytes[offset..offset + 4], endian_val)
             } else {
@@ -341,7 +333,7 @@ pub(crate) fn native_method_2arg(
                     method, type_name,
                 ))));
             }
-            let bytes = buf_get_bytes(target)?;
+            let (bytes, width) = buf_get_raw_bytes(target)?;
             let offset_i64 = to_int_val(arg1);
             let endian_val = match arg2.view() {
                 ValueView::Enum { value, .. } => value.as_i64(),
@@ -349,18 +341,10 @@ pub(crate) fn native_method_2arg(
                 _ => 0, // NativeEndian
             };
             let (size, signed) = read_int_method_info(method);
-            if offset_i64 < 0
-                || (offset_i64 as usize)
-                    .checked_add(size)
-                    .is_none_or(|end| end > bytes.len())
-            {
-                return Some(Err(RuntimeError::new(format!(
-                    "read from out of range. Is: {}, should be in 0..{}",
-                    offset_i64,
-                    bytes.len()
-                ))));
-            }
-            let offset = offset_i64 as usize;
+            let offset = match read_byte_offset(&bytes, offset_i64, size, width) {
+                Ok(off) => off,
+                Err(e) => return Some(Err(e)),
+            };
             Some(Ok(read_int_value(
                 &bytes[offset..offset + size],
                 size,

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -356,6 +356,28 @@ impl Compiler {
         }
     }
 
+    /// A literal list rewritten as a list of argument-less thunks, one per
+    /// element — the operand shape a thunky base operator under `X`/`Z` needs,
+    /// so it can re-evaluate a single element without re-running its siblings.
+    ///
+    /// `None` when the operand is not a list literal, which is exactly when
+    /// Rakudo evaluates it once as an ordinary value.
+    fn per_element_thunks(left: &Expr) -> Option<Expr> {
+        let Expr::ArrayLiteral(elems) = left else {
+            return None;
+        };
+        Some(Expr::ArrayLiteral(
+            elems
+                .iter()
+                .map(|elem| Expr::AnonSub {
+                    body: vec![Stmt::Expr(elem.clone())],
+                    is_rw: false,
+                    is_block: true,
+                })
+                .collect(),
+        ))
+    }
+
     /// Compile MetaOp (Rop, Xop, Zop).
     pub(super) fn compile_expr_meta_op(&mut self, meta: &str, op: &str, left: &Expr, right: &Expr) {
         if meta == "X" && matches!(op, "and" | "&&" | "or" | "||" | "andthen" | "orelse") {
@@ -375,15 +397,26 @@ impl Compiler {
             self.compile_expr(&rewritten);
             return;
         }
-        if meta == "X" && op == "xx" && matches!(left, Expr::ArrayLiteral(_)) {
-            let thunked = Expr::AnonSub {
-                body: vec![Stmt::Expr(left.clone())],
-                is_rw: false,
-                is_block: true,
+        // `Xxx` / `Zxx` over a literal list: `xx` re-evaluates its left operand
+        // once per repetition, and under a cross/zip that re-evaluation is
+        // *per element* — `($i++, 100) Xxx 3` is `(0,1,2), (100,100,100)`, not
+        // three copies of the whole list. So each element gets its own thunk and
+        // the carrier repeats one element at a time. A left side that is not a
+        // list literal (`$i++ Xxx 3`, `@a Xxx 3`, `(...).list Xxx 3`) is a single
+        // already-evaluated value in Rakudo too, and falls through to the
+        // ordinary MetaOp path.
+        if matches!(meta, "X" | "Z")
+            && op == "xx"
+            && let Some(thunks) = Self::per_element_thunks(left)
+        {
+            let carrier = if meta == "X" {
+                "__mutsu_cross_xx"
+            } else {
+                "__mutsu_zip_xx"
             };
             let rewritten = Expr::Call {
-                name: Symbol::intern("__mutsu_reverse_xx"),
-                args: vec![right.clone(), thunked],
+                name: Symbol::intern(carrier),
+                args: vec![right.clone(), thunks],
             };
             self.compile_expr(&rewritten);
             return;
@@ -421,20 +454,6 @@ impl Compiler {
                     left.clone(),
                     thunked,
                 ],
-            };
-            self.compile_expr(&rewritten);
-            return;
-        }
-        // Zxx with list left side: thunk the left side
-        if meta == "Z" && op == "xx" && matches!(left, Expr::ArrayLiteral(_)) {
-            let thunked = Expr::AnonSub {
-                body: vec![Stmt::Expr(left.clone())],
-                is_rw: false,
-                is_block: true,
-            };
-            let rewritten = Expr::Call {
-                name: Symbol::intern("__mutsu_zip_xx"),
-                args: vec![right.clone(), thunked],
             };
             self.compile_expr(&rewritten);
             return;

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -390,6 +390,7 @@ impl Interpreter {
             "__mutsu_zip_shortcircuit" => self.builtin_zip_shortcircuit(&args),
             "__mutsu_zip_shortcircuit_topic" => self.builtin_zip_shortcircuit_topic(&args),
             "__mutsu_zip_xx" => self.builtin_zip_xx(&args),
+            "__mutsu_cross_xx" => self.builtin_cross_xx(&args),
             "__mutsu_zip_assign" => self.builtin_zip_assign(&args),
             "__mutsu_bind_index_value" => Ok(Value::pair(
                 "__mutsu_bind_index_value".to_string(),

--- a/src/runtime/builtins_feed.rs
+++ b/src/runtime/builtins_feed.rs
@@ -414,31 +414,58 @@ impl Interpreter {
         Ok(Value::array(out))
     }
 
-    /// Zip xx with thunked left side: `<a b c> Zxx (0,1,0)`
-    /// For each count in the right list, re-evaluates the thunk `count` times,
-    /// extracting element at position `i`. Preserves side-effect semantics.
+    /// `<a b c> Zxx (0,1,0)` — zip with a per-element thunked left side.
+    ///
+    /// The left list arrives as one argument-less thunk per element (see
+    /// `Compiler::per_element_thunks`). Element `i` is paired with count `i` and
+    /// re-evaluated that many times, so a side effect in element `i` fires
+    /// exactly as often as that element is repeated: `($v++, 5) Zxx (2,3)` is
+    /// `((0,1), (5,5,5))` and leaves `$v` at 2, not 5.
     pub(super) fn builtin_zip_xx(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         if args.len() != 2 {
             return Err(RuntimeError::new(
-                "__mutsu_zip_xx expects right_list and left_thunk",
+                "__mutsu_zip_xx expects right_list and left_thunks",
             ));
         }
-        let right_values = crate::runtime::value_to_list(&args[0]);
-        let thunk = args[1].clone();
+        let counts = crate::runtime::value_to_list(&args[0]);
+        let thunks = crate::runtime::value_to_list(&args[1]);
         let mut out = Vec::new();
-        for (i, count_val) in right_values.iter().enumerate() {
-            let count = crate::runtime::to_int(count_val).max(0) as usize;
-            let mut repeated = Vec::with_capacity(count);
-            for _ in 0..count {
-                let val = self.eval_call_on_value(thunk.clone(), Vec::new())?;
-                let items = crate::runtime::value_to_list(&val);
-                if i >= items.len() {
-                    return Ok(Value::seq(out));
-                }
-                repeated.push(items.into_iter().nth(i).unwrap_or(Value::NIL));
-            }
-            out.push(Value::seq(repeated));
+        for (thunk, count_val) in thunks.iter().zip(counts.iter()) {
+            out.push(self.repeat_xx_thunk(thunk, count_val)?);
         }
         Ok(Value::seq(out))
+    }
+
+    /// `<a b c> Xxx (2,3)` — cross with a per-element thunked left side.
+    ///
+    /// Left element outer, count inner, matching Rakudo's cross order: each
+    /// element's thunk is re-evaluated once per repetition of each count, so
+    /// `($t++, 5) Xxx (2,3)` is `((0,1), (2,3,4), (5,5), (5,5,5))`.
+    pub(super) fn builtin_cross_xx(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
+        if args.len() != 2 {
+            return Err(RuntimeError::new(
+                "__mutsu_cross_xx expects right_list and left_thunks",
+            ));
+        }
+        let counts = crate::runtime::value_to_list(&args[0]);
+        let thunks = crate::runtime::value_to_list(&args[1]);
+        let mut out = Vec::with_capacity(thunks.len() * counts.len());
+        for thunk in &thunks {
+            for count_val in &counts {
+                out.push(self.repeat_xx_thunk(thunk, count_val)?);
+            }
+        }
+        Ok(Value::seq(out))
+    }
+
+    /// One `element xx count` under a cross/zip meta-op: the element's thunk run
+    /// `count` times, its results collected into a `Seq`.
+    fn repeat_xx_thunk(&mut self, thunk: &Value, count: &Value) -> Result<Value, RuntimeError> {
+        let count = crate::runtime::to_int(count).max(0) as usize;
+        let mut repeated = Vec::with_capacity(count);
+        for _ in 0..count {
+            repeated.push(self.eval_call_on_value(thunk.clone(), Vec::new())?);
+        }
+        Ok(Value::seq(repeated))
     }
 }

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -11,7 +11,8 @@ use crate::symbol::Symbol;
 use crate::value::ValueView;
 use crate::value::signature::extract_sig_info;
 use crate::value::value_buf::{
-    buf_bytes_or_empty, buf_elems_or_empty, make_buf, set_buf_bytes, with_buf_bytes,
+    buf_elem_width, buf_elems_or_empty, buf_raw_bytes_or_empty, make_buf, set_buf_raw_bytes,
+    with_buf_bytes,
 };
 
 impl Interpreter {
@@ -802,7 +803,7 @@ impl Interpreter {
                     } => {
                         let cn = class_name.resolve();
                         if crate::runtime::utils::is_buf_or_blob_class(&cn) {
-                            let v = buf_bytes_or_empty(&attributes);
+                            let v = buf_raw_bytes_or_empty(&attributes);
                             (
                                 true,
                                 Some(cn),
@@ -843,14 +844,19 @@ impl Interpreter {
                 };
                 let mut bytes = base_bytes;
                 crate::builtins::buf_write_num::apply_write_num(
-                    &mut bytes, method, offset_i64, &args[1], endian_val,
+                    &mut bytes,
+                    method,
+                    offset_i64,
+                    &args[1],
+                    endian_val,
+                    buf_elem_width(&cn),
                 )?;
                 if is_inst {
                     let class_sym = class_sym_opt.unwrap();
                     let id = id_opt.unwrap();
                     let updated_cell = attrs_opt.unwrap();
                     let mut updated_map = updated_cell.to_map();
-                    set_buf_bytes(&mut updated_map, class_sym, &bytes);
+                    set_buf_raw_bytes(&mut updated_map, class_sym, bytes);
                     return Ok(Value::write_back_sharing(
                         &updated_cell,
                         class_sym,
@@ -859,7 +865,7 @@ impl Interpreter {
                     ));
                 }
                 let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
-                return Ok(crate::builtins::buf_write_num::make_buf_value(
+                return Ok(crate::builtins::buf_write_num::make_buf_value_from_raw(
                     &normalized,
                     bytes,
                 ));
@@ -887,7 +893,7 @@ impl Interpreter {
                     } => {
                         let cn = class_name.resolve();
                         if crate::runtime::utils::is_buf_or_blob_class(&cn) {
-                            let v = buf_bytes_or_empty(&attributes);
+                            let v = buf_raw_bytes_or_empty(&attributes);
                             (
                                 true,
                                 Some(cn),
@@ -928,14 +934,19 @@ impl Interpreter {
                 };
                 let mut bytes = base_bytes;
                 crate::builtins::buf_write_int::apply_write_int(
-                    &mut bytes, method, offset_i64, &args[1], endian_val,
+                    &mut bytes,
+                    method,
+                    offset_i64,
+                    &args[1],
+                    endian_val,
+                    buf_elem_width(&cn),
                 )?;
                 if is_inst {
                     let class_sym = class_sym_opt.unwrap();
                     let id = id_opt.unwrap();
                     let updated_cell = attrs_opt.unwrap();
                     let mut updated_map = updated_cell.to_map();
-                    set_buf_bytes(&mut updated_map, class_sym, &bytes);
+                    set_buf_raw_bytes(&mut updated_map, class_sym, bytes);
                     return Ok(Value::write_back_sharing(
                         &updated_cell,
                         class_sym,
@@ -944,7 +955,7 @@ impl Interpreter {
                     ));
                 }
                 let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
-                return Ok(crate::builtins::buf_write_num::make_buf_value(
+                return Ok(crate::builtins::buf_write_num::make_buf_value_from_raw(
                     &normalized,
                     bytes,
                 ));

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -230,6 +230,9 @@ impl Interpreter {
         // instead of accreting float noise. Any operand outside that domain (Num,
         // BigRat, negatives, a zero divisor, an infinite source, or an i128
         // overflow) falls through to the float loop below unchanged.
+        if let Some(exact) = polymod_exact_int(target, &divisors, has_infinite) {
+            return Ok(Value::seq(exact));
+        }
         if !has_infinite && let Some(exact) = polymod_exact(target, &divisors) {
             return Ok(Value::seq(exact));
         }
@@ -353,6 +356,59 @@ impl Interpreter {
             Ok(Value::array(processed))
         }
     }
+}
+
+/// A non-negative integer operand as a `BigInt`. `None` for anything else — a
+/// `Num`, a `Rat`, or a negative — which sends `polymod` on to the rational and
+/// float paths below.
+fn polymod_int(v: &Value) -> Option<num_bigint::BigInt> {
+    use num_bigint::{BigInt, Sign};
+    match v.view() {
+        ValueView::Int(n) if n >= 0 => Some(BigInt::from(n)),
+        ValueView::BigInt(n) if n.as_ref().sign() != Sign::Minus => Some(n.as_ref().clone()),
+        ValueView::Bool(b) => Some(BigInt::from(u8::from(b))),
+        _ => None,
+    }
+}
+
+/// Exact integer `polymod`, in arbitrary precision.
+///
+/// The rational path below is capped at `i128`, so an invocant wider than that
+/// — `parse-base($md5_hex, 16).polymod(256 xx *)`, a 128-bit digest — overflowed
+/// it and fell through to the `f64` loop, which cannot represent the number at
+/// all and produced zeros (or, for an infinite divisor list, nothing). Integer
+/// operands are the overwhelmingly common case, so they get their own `BigInt`
+/// loop ahead of the rational one.
+///
+/// `has_infinite` marks a divisor list that continues past the elements reified
+/// so far (`256 xx *`): the decomposition then stops as soon as the invocant is
+/// exhausted, and no final quotient is appended.
+fn polymod_exact_int(target: &Value, divisors: &[Value], has_infinite: bool) -> Option<Vec<Value>> {
+    use num_traits::{One, Zero};
+    let mut n = polymod_int(target)?;
+    let mut result = Vec::with_capacity(divisors.len() + 1);
+    for d in divisors {
+        let d = polymod_int(d)?;
+        if d.is_zero() {
+            // Zero divisor: leave the float path's own INFINITY handling in place.
+            return None;
+        }
+        if has_infinite {
+            if n.is_zero() {
+                return Some(result);
+            }
+            // Every further step would divide by one and never terminate.
+            if d.is_one() {
+                result.push(Value::from_bigint(n));
+                return Some(result);
+            }
+        }
+        let (q, r) = (&n / &d, &n % &d);
+        result.push(Value::from_bigint(r));
+        n = q;
+    }
+    result.push(Value::from_bigint(n));
+    Some(result)
 }
 
 /// A non-negative Int/Rat as an exact rational `(num, den)` with `den > 0`.

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2,7 +2,9 @@ use super::methods_signature_errors::make_x_immutable_error;
 use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
-use crate::value::value_buf::{buf_bytes_in, buf_bytes_or_empty, set_buf_bytes};
+use crate::value::value_buf::{
+    buf_elem_width, buf_raw_bytes_in, buf_raw_bytes_or_empty, set_buf_raw_bytes,
+};
 use num_bigint::BigInt;
 use num_traits::Signed;
 impl Interpreter {
@@ -290,7 +292,7 @@ impl Interpreter {
         } = target.view()
             && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
         {
-            let bytes = buf_bytes_or_empty(&attributes);
+            let bytes = buf_raw_bytes_or_empty(&attributes);
 
             if (method == "read-ubits" || method == "read-bits") && args.len() == 2 {
                 let Some(from) = Self::value_to_non_negative_i64(&args[0]) else {
@@ -327,7 +329,7 @@ impl Interpreter {
                 };
                 let written = crate::builtins::buf_bits::write_bits(&bytes, from, bits, &args[2])?;
                 let mut updated_attrs = attributes.to_map();
-                set_buf_bytes(&mut updated_attrs, class_name, &written);
+                set_buf_raw_bytes(&mut updated_attrs, class_name, written);
                 return Ok(Value::write_back_sharing(
                     &attributes,
                     class_name,
@@ -372,12 +374,17 @@ impl Interpreter {
                 ValueView::Num(f) => f as i64,
                 _ => 0,
             };
-            let mut bytes = buf_bytes_or_empty(&attributes);
+            let mut bytes = buf_raw_bytes_or_empty(&attributes);
             crate::builtins::buf_write_num::apply_write_num(
-                &mut bytes, method, offset_i64, value_val, endian_val,
+                &mut bytes,
+                method,
+                offset_i64,
+                value_val,
+                endian_val,
+                buf_elem_width(&cn),
             )?;
             let mut updated_attrs = attributes.to_map();
-            set_buf_bytes(&mut updated_attrs, class_name, &bytes);
+            set_buf_raw_bytes(&mut updated_attrs, class_name, bytes);
             let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
@@ -408,10 +415,15 @@ impl Interpreter {
                 };
                 let mut bytes: Vec<u8> = Vec::new();
                 crate::builtins::buf_write_num::apply_write_num(
-                    &mut bytes, method, offset_i64, &args[1], endian_val,
+                    &mut bytes,
+                    method,
+                    offset_i64,
+                    &args[1],
+                    endian_val,
+                    buf_elem_width(&cn),
                 )?;
                 let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
-                return Ok(crate::builtins::buf_write_num::make_buf_value(
+                return Ok(crate::builtins::buf_write_num::make_buf_value_from_raw(
                     &normalized,
                     bytes,
                 ));
@@ -453,12 +465,17 @@ impl Interpreter {
                 ValueView::Num(f) => f as i64,
                 _ => 0,
             };
-            let mut bytes = buf_bytes_or_empty(&attributes);
+            let mut bytes = buf_raw_bytes_or_empty(&attributes);
             crate::builtins::buf_write_int::apply_write_int(
-                &mut bytes, method, offset_i64, value_val, endian_val,
+                &mut bytes,
+                method,
+                offset_i64,
+                value_val,
+                endian_val,
+                buf_elem_width(&cn),
             )?;
             let mut updated_attrs = attributes.to_map();
-            set_buf_bytes(&mut updated_attrs, class_name, &bytes);
+            set_buf_raw_bytes(&mut updated_attrs, class_name, bytes);
             let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
@@ -489,10 +506,15 @@ impl Interpreter {
                 };
                 let mut bytes: Vec<u8> = Vec::new();
                 crate::builtins::buf_write_int::apply_write_int(
-                    &mut bytes, method, offset_i64, &args[1], endian_val,
+                    &mut bytes,
+                    method,
+                    offset_i64,
+                    &args[1],
+                    endian_val,
+                    buf_elem_width(&cn),
                 )?;
                 let normalized = crate::runtime::utils::normalize_buf_type_name(&cn);
-                return Ok(crate::builtins::buf_write_num::make_buf_value(
+                return Ok(crate::builtins::buf_write_num::make_buf_value_from_raw(
                     &normalized,
                     bytes,
                 ));
@@ -2008,9 +2030,9 @@ impl Interpreter {
                     return Err(RuntimeError::new("bit offset/length must be non-negative"));
                 }
                 let mut updated = attributes.to_map();
-                let bytes = buf_bytes_in(&updated).unwrap_or_default();
+                let bytes = buf_raw_bytes_in(&updated).unwrap_or_default();
                 let bytes = crate::builtins::buf_bits::write_bits(&bytes, from, bits, &args[2])?;
-                set_buf_bytes(&mut updated, class_name, &bytes);
+                set_buf_raw_bytes(&mut updated, class_name, bytes);
                 let updated_instance =
                     Value::write_back_sharing(&attributes, class_name, updated, target_id);
                 self.env

--- a/src/runtime/nqp_ops.rs
+++ b/src/runtime/nqp_ops.rs
@@ -383,8 +383,10 @@ impl Interpreter {
                 let (size, endian) = flag_size_endian(iarg(args, 3));
                 let method = write_method_for(size, op == "writeint");
                 let r = buf_bytes_mutate(op, &buf, |bytes| {
+                    // `buf_bytes_mutate` hands over one byte per element, so the
+                    // offset is already a plain byte offset — width 1.
                     crate::builtins::buf_write_int::apply_write_int(
-                        bytes, method, offset, &val, endian,
+                        bytes, method, offset, &val, endian, 1,
                     )
                 });
                 match r {

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -531,6 +531,65 @@ pub(crate) fn set_buf_bytes(map: &mut AttrMap, class_name: Symbol, bytes: &[u8])
     set_buf_elems(map, class_name, bytes_to_elems(bytes));
 }
 
+/// The buffer's storage exactly as the node holds it: `elems * width` bytes,
+/// little-endian within each element.
+///
+/// This is the byte string the *byte-addressed* methods — `read-int*` /
+/// `read-uint*` / `read-num*` / `write-*` / the bit accessors — index into.
+/// [`buf_bytes`] is the wrong source for them on a wide buffer, because it
+/// projects each element down to its low byte, losing three quarters of a
+/// `buf32`. Rakudo addresses the real storage: `$buf.read-uint32($offset)`
+/// starts `$offset * width` bytes in, so on a `buf32` offset 1 is element 1
+/// rather than element 0's second byte.
+///
+/// For every width-1 buffer (`Buf`, `Blob`, `utf8`, `buf8`, …) this is
+/// byte-for-byte what [`buf_bytes`] returns.
+pub(crate) fn buf_raw_bytes(attrs: &InstanceAttrs) -> Option<Vec<u8>> {
+    buf_raw_bytes_in(&attrs.as_map())
+}
+
+/// [`buf_raw_bytes`] against an attribute map already in hand.
+pub(crate) fn buf_raw_bytes_in(map: &AttrMap) -> Option<Vec<u8>> {
+    Some(node_in(map)?.bytes.clone())
+}
+
+/// [`buf_raw_bytes`] with an absent buffer read as empty.
+pub(crate) fn buf_raw_bytes_or_empty(attrs: &InstanceAttrs) -> Vec<u8> {
+    buf_raw_bytes(attrs).unwrap_or_default()
+}
+
+/// Store raw storage bytes — already at `class_name`'s element width — into a
+/// map being built or updated. The counterpart of [`buf_raw_bytes`]; use
+/// [`set_buf_bytes`] when the bytes are meant as one element each instead.
+///
+/// A trailing partial element is zero-padded out to a whole one, so a caller
+/// that grew the storage by a byte count that is not a multiple of the width
+/// still leaves a well-formed buffer behind.
+pub(crate) fn set_buf_raw_bytes(map: &mut AttrMap, class_name: Symbol, bytes: Vec<u8>) {
+    let (width, kind) = elem_type(&class_name.resolve());
+    map.insert(
+        ELEMS_ATTR,
+        storage_value(pad_to_width(bytes, width), width, kind),
+    );
+}
+
+/// A fresh `Buf`/`Blob`-shaped instance of `class_name` over raw storage bytes.
+pub(crate) fn make_buf_from_raw_bytes(class_name: Symbol, bytes: Vec<u8>) -> Value {
+    let mut map = AttrMap::new();
+    set_buf_raw_bytes(&mut map, class_name, bytes);
+    Value::make_instance(class_name, map)
+}
+
+/// Round a raw byte string up to a whole number of `width`-byte elements.
+fn pad_to_width(mut bytes: Vec<u8>, width: u8) -> Vec<u8> {
+    let w = width.max(1) as usize;
+    let rem = bytes.len() % w;
+    if rem != 0 {
+        bytes.resize(bytes.len() + (w - rem), 0u8);
+    }
+    bytes
+}
+
 /// A fresh `Buf`/`Blob`-shaped instance of `class_name` over raw bytes.
 pub(crate) fn make_buf_from_bytes(class_name: Symbol, bytes: &[u8]) -> Value {
     make_buf(class_name, bytes_to_elems(bytes))

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2682,7 +2682,7 @@ impl Interpreter {
         if cn == "Blob" || cn.starts_with("Blob[") || cn.starts_with("blob") {
             return None;
         }
-        let mut bytes = crate::value::value_buf::buf_bytes_or_empty(&attributes);
+        let mut bytes = crate::value::value_buf::buf_raw_bytes_or_empty(&attributes);
         // Compute the new bytes via the shared pure transform.
         let new_bytes: Vec<u8> = if is_write_bits {
             if args.len() != 3 {
@@ -2713,13 +2713,14 @@ impl Interpreter {
             } else {
                 0
             };
+            let width = crate::value::value_buf::buf_elem_width(&cn);
             let res = if is_write_num {
                 crate::builtins::buf_write_num::apply_write_num(
-                    &mut bytes, method, offset_i64, &args[1], endian_val,
+                    &mut bytes, method, offset_i64, &args[1], endian_val, width,
                 )
             } else {
                 crate::builtins::buf_write_int::apply_write_int(
-                    &mut bytes, method, offset_i64, &args[1], endian_val,
+                    &mut bytes, method, offset_i64, &args[1], endian_val, width,
                 )
             };
             if let Err(e) = res {
@@ -2731,7 +2732,7 @@ impl Interpreter {
         // (so aliases observing the same buf see the mutation), then refresh the
         // receiver binding to match the interpreter's `env.insert(target_var, ...)`.
         let mut updated_attrs = attributes.to_map();
-        crate::value::value_buf::set_buf_bytes(&mut updated_attrs, class_name, &new_bytes);
+        crate::value::value_buf::set_buf_raw_bytes(&mut updated_attrs, class_name, new_bytes);
         let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
         self.env_mut()
             .insert(target_name.to_string(), updated.clone());

--- a/t/buf-wide-read-write-int.t
+++ b/t/buf-wide-read-write-int.t
@@ -1,0 +1,126 @@
+use Test;
+
+# The byte-addressed Buf accessors (`read-int*`/`read-uint*`/`read-num*` and
+# their `write-*` counterparts) index a buffer's *real* storage, and their
+# offset counts elements, not bytes: on a `buf32` offset 1 is element 1, i.e.
+# byte 4. mutsu used to hand those methods a one-byte-per-element projection of
+# the buffer, so a write both read the wrong bytes and flattened every existing
+# element down to its low byte -- which is what made `Digest::MD5` produce a
+# wrong digest.
+
+plan 26;
+
+# --- writes land on the right element ------------------------------------
+
+{
+    my $b = buf32.new(0x80636261, 0x11223344, 0x55667788);
+    $b.write-uint32: 1, 0xAABBCCDD, LittleEndian;
+    is $b.list.join(','), (0x80636261, 0xAABBCCDD, 0x55667788).join(','),
+        'write-uint32 at offset 1 replaces element 1 of a buf32';
+    is $b.elems, 3, 'an in-range write does not resize the buffer';
+}
+
+{
+    my $b = buf32.new(0x80636261, 0x11223344, 0x55667788);
+    $b.write-uint8: 1, 0xEE;
+    is $b.list.join(','), (0x80636261, 0x112233EE, 0x55667788).join(','),
+        'write-uint8 at offset 1 touches only element 1 low byte';
+}
+
+{
+    my $b = buf16.new(0x1234, 0x5678, 0x9abc);
+    $b.write-uint32: 1, 0xAABBCCDD, LittleEndian;
+    is $b.list.join(','), (0x1234, 0xCCDD, 0xAABB).join(','),
+        'a 4-byte write spans two buf16 elements';
+}
+
+{
+    my $b = buf8.new(1, 2, 3, 4, 5, 6, 7, 8);
+    $b.write-uint32: 1, 0xAABBCCDD, LittleEndian;
+    is $b.list.join(','), (1, 0xDD, 0xCC, 0xBB, 0xAA, 6, 7, 8).join(','),
+        'a width-1 buffer keeps its plain byte offset';
+}
+
+{
+    my $b = buf32.new(0x80636261, 0x11223344, 0x55667788);
+    $b.write-uint32: 1, 0xAABBCCDD, BigEndian;
+    is $b.list.join(','), (0x80636261, 0xDDCCBBAA, 0x55667788).join(','),
+        'BigEndian writes the element the other way round';
+}
+
+# --- growth follows MoarVM: `offset + size` *elements* --------------------
+
+{
+    my $b = buf32.new(1, 2);
+    $b.write-uint32: 2, 0xAABBCCDD, LittleEndian;
+    is $b.elems, 6, 'a write past the end grows to offset + size elements';
+    is $b.list.join(','), (1, 2, 0xAABBCCDD, 0, 0, 0).join(','),
+        '... with the value at the requested element and the rest zeroed';
+}
+
+{
+    my $b = buf32.new(1, 2);
+    $b.write-uint64: 0, 0x1122334455667788, LittleEndian;
+    is $b.elems, 2, 'a write that fits does not grow the buffer';
+    is $b.list.join(','), (0x55667788, 0x11223344).join(','),
+        '... and spans two buf32 elements little-endian';
+}
+
+{
+    my $b = buf16.new(1, 2);
+    $b.write-uint64: 1, 0x1122334455667788, LittleEndian;
+    is $b.elems, 9, 'buf16 grows to offset + size elements too';
+    is $b.list.join(','), (1, 0x7788, 0x5566, 0x3344, 0x1122, 0, 0, 0, 0).join(','),
+        '... with the eight bytes laid across four elements';
+}
+
+# --- the type-object form builds the same buffer --------------------------
+
+{
+    my $b = buf32.write-uint32(1, 0xAABBCCDD, LittleEndian);
+    is $b.elems, 5, 'buf32.write-uint32 on the type object grows the same way';
+    is $b.list.join(','), (0, 0xAABBCCDD, 0, 0, 0).join(','),
+        '... and puts the value in element 1';
+}
+
+# --- write-num ------------------------------------------------------------
+
+{
+    my $b = buf32.new(0, 0, 0, 0);
+    $b.write-num32: 1, 1.5e0, LittleEndian;
+    is $b.list.join(','), (0, 0x3FC00000, 0, 0).join(','),
+        'write-num32 encodes into a single buf32 element';
+}
+
+# --- reads use the same addressing ---------------------------------------
+
+{
+    my $b = buf32.new(0x80636261, 0x11223344, 0x55667788);
+    is $b.read-uint32(0, LittleEndian), 0x80636261, 'read-uint32 at 0';
+    is $b.read-uint32(2, LittleEndian), 0x55667788, 'read-uint32 at the last element';
+    is $b.read-uint64(0, LittleEndian), 0x1122334480636261,
+        'read-uint64 spans two buf32 elements';
+    is $b.read-uint16(1, LittleEndian), 0x3344, 'read-uint16 reads element 1 low half';
+    is $b.read-uint8(1), 0x44, 'read-uint8 reads element 1 low byte';
+    is $b.read-int8(1), 0x44, 'read-int8 likewise';
+}
+
+{
+    my $b = buf16.new(0x1234, 0x5678, 0x9abc, 0xdef0);
+    is $b.read-uint32(1, LittleEndian), 0x9ABC5678, 'read-uint32 spans two buf16 elements';
+    is $b.read-uint8(3), 0xF0, 'read-uint8 reads the fourth element low byte';
+}
+
+{
+    my $b = buf8.new(1, 2, 3, 4, 5, 6, 7, 8);
+    is $b.read-uint32(1, LittleEndian), 0x05040302,
+        'a width-1 buffer still reads at a plain byte offset';
+}
+
+# --- out of range ---------------------------------------------------------
+
+{
+    my $b = buf32.new(1, 2, 3);
+    dies-ok { $b.read-uint32(3) }, 'reading past the last element dies';
+    lives-ok { $b.read-uint64(0) }, 'a read that fits within the storage lives';
+}

--- a/t/metaop-xx-per-element-thunk.t
+++ b/t/metaop-xx-per-element-thunk.t
@@ -1,0 +1,87 @@
+use Test;
+
+# `xx` re-evaluates its left operand once per repetition. Under a cross or zip
+# meta-op that re-evaluation is *per element* of the left list: `($i++, 100) Xxx
+# 3` is `((0,1,2), (100,100,100))`, one Seq per left element, not three copies
+# of the whole list. mutsu used to thunk the left side as a whole and repeat it,
+# which transposed the result and (for `Zxx`) over-ran the side effects.
+#
+# A left side that is not a list literal is a single already-evaluated value in
+# Rakudo too, so it must NOT be re-evaluated.
+
+plan 19;
+
+# --- Xxx: shape ----------------------------------------------------------
+
+is ((1, 2) Xxx 3).elems, 2, 'Xxx yields one Seq per left element';
+is ((1, 2) Xxx 3).map(*.join(',')).join('|'), '1,1,1|2,2,2',
+    'each left element is repeated on its own';
+is ((1, 2) Xxx (3, 4)).map(*.join(',')).join('|'),
+    '1,1,1|1,1,1,1|2,2,2|2,2,2,2',
+    'left element outer, count inner';
+
+# --- Xxx: per-element re-evaluation ---------------------------------------
+
+{
+    my $i = 0;
+    is (($i++, 100) Xxx 3).map(*.join(',')).join('|'), '0,1,2|100,100,100',
+        'only the element with the side effect is re-evaluated';
+    is $i, 3, '... exactly once per repetition';
+}
+
+{
+    my $t = 0;
+    is (($t++, 5) Xxx (2, 3)).map(*.join(',')).join('|'), '0,1|2,3,4|5,5|5,5,5',
+        'a thunked element re-runs for every count it is crossed with';
+    is $t, 5, '... 2 + 3 times in total';
+}
+
+{
+    my $s = 0;
+    is (($s++, $s++) Xxx 2).map(*.join(',')).join('|'), '0,1|2,3',
+        'two thunked elements run element-major';
+    is $s, 4, '... two evaluations each';
+}
+
+# --- a non-literal left side is evaluated once ----------------------------
+
+{
+    my $p = 0;
+    is (($p++ Xxx 3).map(*.join(',')).join('|')), '0,0,0',
+        'a scalar left operand is evaluated once and repeated';
+    is $p, 1, '... with a single side effect';
+}
+
+{
+    my $m = 0;
+    my @l = ($m++, 100);
+    is (@l Xxx 3).map(*.join(',')).join('|'), '0,0,0|100,100,100',
+        'an array variable left side is a plain value list';
+    is $m, 1, '... whose elements were already evaluated';
+}
+
+{
+    my $u = 0;
+    is (($u++, 5).list Xxx 2).map(*.join(',')).join('|'), '0,0|5,5',
+        'a method call on the left side is evaluated once';
+    is $u, 1, '... with a single side effect';
+}
+
+# --- a list element keeps its identity ------------------------------------
+
+{
+    my @a = 1, 2;
+    is ((@a, 5) Xxx 2).map({ .map({ .elems // 1 }).join(',') }).join('|'), '2,2|1,1',
+        'an array element is repeated whole, not flattened into the cross';
+}
+
+# --- Zxx pairs element i with count i -------------------------------------
+
+{
+    my $v = 0;
+    is (($v++, 5) Zxx (2, 3)).map(*.join(',')).join('|'), '0,1|5,5,5',
+        'Zxx repeats each element by its own count';
+    is $v, 2, '... running element 0 only as often as its own count';
+}
+
+is ((1, 2) Xxx 0).map(*.elems).join(','), '0,0', 'a zero count yields empty Seqs';

--- a/t/polymod-bigint.t
+++ b/t/polymod-bigint.t
@@ -1,0 +1,36 @@
+use Test;
+
+# `polymod`'s exact path was capped at i128, so an invocant wider than that fell
+# through to an f64 loop that cannot represent the number: a finite divisor list
+# produced zeros and an infinite one (`256 xx *`) produced nothing at all.
+# Integer operands now decompose in arbitrary precision.
+# Found via `Digest::MD5`'s test, which compares against
+# `Blob.new(parse-base($hex, 16).polymod(256 xx *).reverse)`.
+
+plan 11;
+
+my $md5 = parse-base('900150983cd24fb0d6963f7d28e17f72', 16);
+
+is $md5.polymod(256 xx *).join(','),
+    (114, 127, 225, 40, 125, 63, 150, 214, 176, 79, 210, 60, 152, 80, 1, 144).join(','),
+    'a 128-bit Int decomposes into its base-256 digits';
+is $md5.polymod(256 xx *).elems, 16, '... sixteen of them, with no trailing quotient';
+is Blob.new($md5.polymod(256 xx *).reverse).list.fmt('%02x', ''),
+    '900150983cd24fb0d6963f7d28e17f72',
+    '... and rebuilds the original hex digest';
+
+is $md5.polymod(256, 256, 256).join(','),
+    (114, 127, 225, 11409262320051119695188490943784).join(','),
+    'a finite divisor list keeps the remaining quotient, in full precision';
+
+# The infinite form stops as soon as the invocant is exhausted.
+is 1000.polymod(256 xx *).join(','), '232,3', 'a small Int needs only two digits';
+is 255.polymod(256 xx *).join(','), '255', 'a single digit stops after one step';
+is 0.polymod(256 xx *).elems, 0, 'zero decomposes into nothing';
+is (2**200).polymod(2 xx *).elems, 201, 'a 201-bit Int yields 201 binary digits';
+
+# Non-integer operands keep the rational/float behaviour they had.
+is 5.Rat.polymod(0.3, 0.2).join(','), '0.2,0,80', 'a Rat invocant still decomposes exactly';
+is 600.polymod(gather { take 5; take 6 }).join(','), '0,0,20',
+    'a finite lazy divisor source is still forced';
+is 1234.polymod(10, 10, 10).join(','), '4,3,2,1', 'the ordinary Int case is unchanged';

--- a/t/range-roll-non-numeric.t
+++ b/t/range-roll-non-numeric.t
@@ -1,0 +1,24 @@
+use Test;
+
+# `.roll($n)` on a Range with non-integer endpoints sampled the enumeration only
+# when the start was numeric; a Str range (`'a'..'z'`) fell through to "return
+# the start element", so `("a".."z").roll(8).join` was always 'aaaaaaaa'.
+# Found via `Digest::MD5`'s "hash 100 random strings" subtest, which hashed the
+# same string a hundred times.
+
+plan 8;
+
+my @letters = ('a' .. 'z').roll(200);
+is @letters.elems, 200, 'roll(n) on a Str range returns n elements';
+ok @letters.all ~~ /^ <[a..z]> $/, '... all drawn from the range';
+ok @letters.unique.elems > 10, '... and actually varied, not the start element';
+
+my @pair = ('a' .. 'e').roll(*)[^50];
+is @pair.elems, 50, 'roll(*) on a Str range is pullable';
+ok @pair.unique.elems > 1, '... and varied too';
+
+isa-ok ('a' .. 'z').roll, Str, 'the no-argument form still yields one element';
+
+# The numeric paths keep the types they had.
+ok (1 .. 26).roll(50).all ~~ Int, 'an Int range still rolls Ints';
+ok (1.1 .. 3.1).roll(20).all ~~ Rat, 'a Rat range still rolls Rats';

--- a/todo/tickets/digest-dist-blockers.md
+++ b/todo/tickets/digest-dist-blockers.md
@@ -5,9 +5,11 @@ grondilu's `Digest` dist (`libdigest-raku`, Artistic-2.0) provides `Digest::MD5`
 is the dependency of `Digest::HMAC:ver<1.0.7>:auth<zef:jjmerelo>`. Seven general
 interpreter bugs found while running it were fixed (see
 `news/2026-08/digest-dist-seven-fixes.md`), then four more that its roast
-fallout exposed (`news/2026-08/digest-dist-followup-four-fixes.md`);
-`Digest::SHA1` and `Digest::SHA2`'s `sha224`/`sha256` now produce correct
-digests. Blockers 1 (`news/2026-08/for-modifier-placeholder-scope.md`) and 4
+fallout exposed (`news/2026-08/digest-dist-followup-four-fixes.md`), then four
+more behind MD5's wrong digest (`news/2026-08/digest-md5-four-fixes.md`).
+`Digest::MD5`, `Digest::SHA1` and `Digest::SHA2`'s `sha224`/`sha256` now produce
+correct digests, and the dist's `t/md5.t` passes in full. Blockers 1
+(`news/2026-08/for-modifier-placeholder-scope.md`) and 4
 (`news/2026-08/named-params-do-not-narrow.md`) are fixed; two remain, each an
 independent general bug.
 
@@ -19,10 +21,11 @@ Reproduce with the vendored-in-zef-store copy:
 ## 1. A placeholder is invisible inside a `for` statement modifier — FIXED
 
 Fixed by the `is_statement_modifier` field on `Stmt::For`; see
-`news/2026-08/for-modifier-placeholder-scope.md`. `Digest::MD5` now runs to
-completion, though it still produces a wrong digest (a further bug, not yet
-reduced — `md5("abc")` gives `fe2be2927d9087ecb52bcb1fedc50c16` instead of
-`900150983cd24fb0d6963f7d28e17f72`).
+`news/2026-08/for-modifier-placeholder-scope.md`. The wrong digest that remained
+after it turned out to be four more independent bugs — wide-`Buf` `write-uint*`
+addressing, `Xxx` per-element thunking, `polymod` precision, and `.roll` on a
+`Str` range — all fixed in `news/2026-08/digest-md5-four-fixes.md`. `t/md5.t`
+passes in full.
 
 ## 2. A WhateverCode cannot bind to a `@`-sigil parameter
 
@@ -42,6 +45,21 @@ minimal repro.
 is in the block pipeline: `blob64`, `state buf64 $w`, the `$H[]` zen slice, the
 `(8*$data).polymod(256 xx 15).reverse` length encoding, or `map * mod 2**64` over
 a Blob. `sha384` is `sha512` with a different initial hash, so it falls with it.
+(The wide-`Buf` and `polymod` fixes of 2026-08-04 did not move this one; the rest
+of `t/sha.t` — SHA-1, `sha224`, `sha256` — passes.)
+
+## 5. `read-ubits` / `write-bits` on a wide buffer
+
+Not a `Digest` blocker, found while fixing the byte-addressed accessors. The bit
+accessors now index the buffer's raw storage, so a bit-write no longer destroys
+a `buf16`/`buf32`/`buf64`'s element width, but they still diverge from MoarVM,
+where a bit offset appears to select whole elements:
+
+    buf32.new(0x11223344, 0x55667788).read-ubits(8, 8)   # raku: 0x55667788
+    my $c = buf32.new(0, 0); $c.write-bits(8, 8, 0xAB)   # raku: (0, 0xAB)
+
+Width-1 buffers — every practical use — are unaffected, which is why this was
+left out of that fix.
 
 ## 4. `HMAC`'s named-parameter multis dispatch as ambiguous — FIXED
 


### PR DESCRIPTION
Reducing grondilu's `Digest::MD5` against `raku` piece by piece turned up four
independent interpreter bugs behind its wrong digest (`md5("abc")` gave
`fe2be2927d9087ecb52bcb1fedc50c16`). All four are general; none is specific to
MD5. Full write-up in `news/2026-08/digest-md5-four-fixes.md`.

### 1. Byte-addressed `Buf` accessors ignored the element width

`read-int*` / `read-uint*` / `read-num*` and their `write-*` counterparts were
handed a *projection* of the buffer — one byte per element, taking each
element's low byte — rather than its real storage. On every width-1 buffer that
projection **is** the storage, so the bug was invisible there; on a
`buf16`/`buf32`/`buf64` it was destructive:

```raku
my $b = buf32.new(0x80636261, 0x11223344);
$b.write-uint64: 2, 24, LittleEndian;
say $b;   # was Buf[uint32].new(97, 68, 24, 0, ...)
          # now Buf[uint32].new(2153996897, 287454020, 24, 0, ...)
```

Rakudo addresses the real storage, and the offset counts **elements**: the byte
position is `offset * width`. A write past the end grows the buffer to
`offset + size` *elements* — MoarVM's own unit-mixing rule, which reads like an
`MVMArray` slip but is observable, so mutsu matches it.

`value_buf.rs` grew raw-storage accessors alongside the one-byte-per-element
ones, and the six write dispatch sites and five read arms moved onto them.
`nqp::writeuint` keeps width 1 (its carrier already hands over one byte per
element).

### 2. `Xxx` / `Zxx` thunked the whole left list instead of each element

`xx` re-evaluates its left operand once per repetition, and under a cross/zip
that re-evaluation is *per element*:

```raku
my $i = 0; say (($i++, 100) Xxx 3).raku;
# was ((0, 100), (1, 100), (2, 100)).Seq
# now ((0, 1, 2).Seq, (100, 100, 100).Seq).Seq
```

A list-literal left operand is now compiled to one argument-less thunk per
element, driven by a new `__mutsu_cross_xx` (element outer, count inner) and a
rewritten `__mutsu_zip_xx` — which also stops over-running side effects
(`($v++, 5) Zxx (2,3)` ran the counter five times, now two). A non-literal left
side is a single already-evaluated value in Rakudo too and still takes the
ordinary `MetaOp` path.

This is what builds MD5's per-round message-index table,
`16 X[R%] flat ($++, 5*$++ + 1, 3*$++ + 5, 7*$++) Xxx 16`.

### 3. `polymod` had no arbitrary-precision path

Capped at `i128`, so a wider invocant fell through to an `f64` loop that cannot
represent it — zeros for a finite divisor list, an empty `Seq` for `256 xx *`.
That is how the `Digest` test builds its expected `Blob`, which is why every
comparison read `expected: 'Blob:0x<>'`. Integer operands now decompose in
`BigInt`, ahead of the rational path; non-integer invocants are unchanged.

### 4. `.roll($n)` on a non-numeric `Range` always returned the start element

`("a".."z").roll(8).join` was `aaaaaaaa` every time, so the `Digest` test's
"hash 100 random strings" subtest hashed one string a hundred times. `.pick` was
fine. Any bounded endpoint pair is now enumerated and sampled from, keeping the
element type; an unbounded end (`1..*`) still answers the start element rather
than trying to reify the range.

### Verification

- `make test` — PASS (2836 files, 26921 tests).
- The 15 most closely related whitelisted roast files all PASS locally
  (`S03-buf/{read,write}-{int,num}.t`, `read-write-bits.t`,
  `S03-metaops/{cross,zip,misc}.t`, `S03-operators/buf.t`,
  `S32-container/buf.t`, `S32-list/{cross,pick,roll}.t`, `S32-num/polymod.t`,
  `S13-overloading/metaoperators.t`).
- Four new pins: `t/buf-wide-read-write-int.t`,
  `t/metaop-xx-per-element-thunk.t`, `t/polymod-bigint.t`,
  `t/range-roll-non-numeric.t` — each verified to pass under `raku` as well.
- The `Digest` dist's `t/md5.t` now passes in full; `t/sha.t` is down to its
  documented `sha384`/`sha512` blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)