### PR TITLE
fix: slurpy single-argument rule, WhateverCode over hyper calls, Seq in a sub-signature

### DIFF
--- a/news/2026-08/slurpy-single-argument-rule-and-friends.md
+++ b/news/2026-08/slurpy-single-argument-rule-and-friends.md
@@ -1,0 +1,70 @@
+# The slurpy single-argument rule, WhateverCode over hyper calls, and Seq in a sub-signature
+
+Continuing to reduce grondilu's `Digest::RIPEMD` against `raku` (see
+`todo/tickets/digest-dist-blockers.md` blocker 2, "a WhateverCode cannot bind to
+a `@`-sigil parameter") turned up four more general interpreter bugs. Each was
+reduced to a one-liner before being fixed; the module now runs to completion,
+though its digest is still wrong (recorded in the ticket).
+
+## 1. `map` / `grep` / `Array.new` ignored the single-argument rule
+
+`map(&code, +values)`, `grep(&matcher, +values)` and `Array.new(|c)` all slurp
+with a `+@`-shaped parameter, and `+@` applies Raku's **single-argument rule**:
+exactly one list argument is flattened into its elements, but two or more are
+each one element of their own. mutsu flattened every argument unconditionally,
+so
+
+```raku
+map -> [$a, $b] { "$a/$b" }, (1, 2), (3, 4)
+```
+
+ran the block four times over four Ints — dying at the destructure — instead of
+twice over two pairs. That is exactly the shape `Digest::RIPEMD` builds its two
+round tables with, and the original blocker's confusing symptom (a
+`WhateverCode` reaching an `@`-sigil parameter) was just the first element of the
+first tuple arriving where the whole tuple should have.
+
+`Array.new` needed the same rule but not the `**@` one: `Array.new((1,2))` is two
+elements, while `List.new((1,2))` — a `**@` slurpy — stays one, and
+`Array.new(@a, 3)` keeps `@a` whole. An itemized `$(...)`/`$[...]` argument is
+never unwrapped.
+
+Pinned by `t/slurpy-single-argument-rule.t`.
+
+## 2. A hyper method call did not curry a `Whatever`
+
+`*.comb` is a `WhateverCode`; `*.comb».uc` was not. `Expr::HyperMethodCall` was
+missing from the currying machinery — `contains_whatever`, `count_whatever`,
+`replace_whatever_numbered`, `replace_whatever_single`, `rename_var` and the
+topic/`xx` probes all knew `MethodCall` and `DynamicMethodCall` but not their
+hyper twins. So the parser never wrapped the expression and the `*` was evaluated
+eagerly, leaving a `List` where a closure belonged:
+
+```raku
+my $g = *.comb».uc;
+$g("abc");   # No such method 'CALL-ME' for invocant of type 'List'
+```
+
+`Digest::RIPEMD` builds each round's constants with
+`given *.comb».parse-base(16)`, which died on exactly this.
+
+Pinned by `t/whatevercode-hyper-method.t`.
+
+## 3. An `@` parameter in a sub-signature rejected `Seq` and `Range`
+
+A destructuring `-> [@a, $b] {...}` accepted only an `Array` at `@a`, so a `Seq`
+or `Range` element failed to bind — even though a plain `sub f(@a)` takes both.
+Rakudo listifies a non-`Positional` `Iterable` on the way in, which is why
+`@a.^name` is `List` for a `Seq` and stays `Range` for a `Range`; mutsu now does
+the same, so the bound value also survives being iterated twice. A `Hash`, `Str`
+or `Int` element is still a binding error.
+
+`Digest::RIPEMD`'s `-> [&f, $r, @K, $s] {...}` binds a `Seq` at `@K`.
+
+Pinned by `t/sub-signature-array-param-iterable.t`.
+
+## Known remaining divergence
+
+`Nil` still binds to an `@` sub-parameter in mutsu where Rakudo raises
+`X::TypeCheck::Binding::Parameter`. Left alone here because the optional-parameter
+path leans on it; noted rather than changed blind.

--- a/src/parser/expr/whatever.rs
+++ b/src/parser/expr/whatever.rs
@@ -110,7 +110,7 @@ fn contains_xx_with_bare_whatever(expr: &Expr) -> bool {
                 || contains_xx_with_bare_whatever(right)
         }
         Expr::Unary { expr, .. } => contains_xx_with_bare_whatever(expr),
-        Expr::MethodCall { target, args, .. } => {
+        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
             contains_xx_with_bare_whatever(target)
                 || args.iter().any(contains_xx_with_bare_whatever)
         }
@@ -236,7 +236,12 @@ pub(crate) fn contains_whatever(expr: &Expr) -> bool {
         {
             false
         }
-        Expr::MethodCall { target, .. } | Expr::DynamicMethodCall { target, .. } => {
+        // A hyper method call curries exactly like a plain one: `*.comb».uc` is
+        // a WhateverCode, not an eager `Whatever.comb».uc`.
+        Expr::MethodCall { target, .. }
+        | Expr::DynamicMethodCall { target, .. }
+        | Expr::HyperMethodCall { target, .. }
+        | Expr::HyperMethodCallDynamic { target, .. } => {
             contains_whatever(target) || is_wrapped_whatevercode(target)
         }
         Expr::CallOn { target, .. } => {
@@ -364,9 +369,10 @@ pub(crate) fn count_whatever(expr: &Expr) -> usize {
         } => count_whatever(left),
         Expr::Binary { left, right, .. } => count_whatever(left) + count_whatever(right),
         Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => count_whatever(expr),
-        Expr::MethodCall { target, .. } | Expr::DynamicMethodCall { target, .. } => {
-            count_whatever(target)
-        }
+        Expr::MethodCall { target, .. }
+        | Expr::DynamicMethodCall { target, .. }
+        | Expr::HyperMethodCall { target, .. }
+        | Expr::HyperMethodCallDynamic { target, .. } => count_whatever(target),
         Expr::CallOn { target, .. } => {
             // Only the *target* of an invocation curries. A Whatever passed as a
             // call *argument* (`$sub(*)`, `&infix:<+>(*, 42)`) is a Whatever value
@@ -411,7 +417,7 @@ pub(crate) fn expr_contains_topic(expr: &Expr) -> bool {
         Expr::Whatever => false,
         Expr::Binary { left, right, .. } => expr_contains_topic(left) || expr_contains_topic(right),
         Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => expr_contains_topic(expr),
-        Expr::MethodCall { target, args, .. } => {
+        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
             expr_contains_topic(target) || args.iter().any(expr_contains_topic)
         }
         Expr::CallOn { target, args } => {

--- a/src/parser/expr/whatever_replace.rs
+++ b/src/parser/expr/whatever_replace.rs
@@ -138,6 +138,31 @@ pub(crate) fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Exp
             args: args.clone(),
             modifier: *modifier,
         },
+        // A hyper method call curries on its target exactly like a plain one.
+        Expr::HyperMethodCall {
+            target,
+            name,
+            args,
+            modifier,
+            quoted,
+        } => Expr::HyperMethodCall {
+            target: Box::new(replace_whatever_numbered(target, counter)),
+            name: *name,
+            args: args.clone(),
+            modifier: *modifier,
+            quoted: *quoted,
+        },
+        Expr::HyperMethodCallDynamic {
+            target,
+            name_expr,
+            args,
+            modifier,
+        } => Expr::HyperMethodCallDynamic {
+            target: Box::new(replace_whatever_numbered(target, counter)),
+            name_expr: name_expr.clone(),
+            args: args.clone(),
+            modifier: *modifier,
+        },
         // Only the *target* of an invocation curries; a Whatever passed as a call
         // *argument* stays a Whatever value (see `count_whatever`/`contains_whatever`),
         // so the args are left untouched rather than replaced by numbered params.
@@ -208,6 +233,22 @@ fn rename_var(expr: &Expr, old_name: &str, new_name: &str) -> Expr {
             modifier,
             quoted,
         } => Expr::MethodCall {
+            target: Box::new(rename_var(target, old_name, new_name)),
+            name: *name,
+            args: args
+                .iter()
+                .map(|a| rename_var(a, old_name, new_name))
+                .collect(),
+            modifier: *modifier,
+            quoted: *quoted,
+        },
+        Expr::HyperMethodCall {
+            target,
+            name,
+            args,
+            modifier,
+            quoted,
+        } => Expr::HyperMethodCall {
             target: Box::new(rename_var(target, old_name, new_name)),
             name: *name,
             args: args
@@ -307,6 +348,31 @@ pub(crate) fn replace_whatever_single(expr: &Expr) -> Expr {
             args,
             modifier,
         } => Expr::DynamicMethodCall {
+            target: Box::new(replace_whatever_single(target)),
+            name_expr: name_expr.clone(),
+            args: args.clone(),
+            modifier: *modifier,
+        },
+        // A hyper method call curries on its target exactly like a plain one.
+        Expr::HyperMethodCall {
+            target,
+            name,
+            args,
+            modifier,
+            quoted,
+        } => Expr::HyperMethodCall {
+            target: Box::new(replace_whatever_single(target)),
+            name: *name,
+            args: args.clone(),
+            modifier: *modifier,
+            quoted: *quoted,
+        },
+        Expr::HyperMethodCallDynamic {
+            target,
+            name_expr,
+            args,
+            modifier,
+        } => Expr::HyperMethodCallDynamic {
             target: Box::new(replace_whatever_single(target)),
             name_expr: name_expr.clone(),
             args: args.clone(),

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -20,7 +20,18 @@ impl Interpreter {
             return self.call_method_with_values(args[1].clone(), "map", method_args);
         }
         let mut list_items = Vec::new();
+        // Rakudo's `map(&code, +values)` slurps under the single-argument rule:
+        // exactly one list argument is flattened into its elements, but two or
+        // more are each one element of their own. So
+        // `map -> [$a, $b] {...}, (1,2), (3,4)` runs the block twice over two
+        // pairs, not four times over four Ints — which is what makes
+        // `Digest::RIPEMD`'s `map -> [&a,$b,@c,$d] {...}, (...), (...)` bind.
+        let single_arg_rule = args.len() <= 2;
         for (idx, arg) in args.iter().skip(1).enumerate() {
+            if !single_arg_rule {
+                list_items.push(arg.clone());
+                continue;
+            }
             // Check if this argument came from a $ variable (itemized container).
             // Scalar variables don't have a sigil prefix in arg_sources, while
             // @array and %hash variables start with '@' and '%' respectively.
@@ -140,7 +151,14 @@ impl Interpreter {
             return self.call_method_with_values(args[1].clone(), "grep", method_args);
         }
         let mut list_items = Vec::new();
+        // `grep(&matcher, +values)` slurps under the same single-argument rule
+        // as `map` above: two or more list arguments are two or more elements.
+        let single_arg_rule = args.len() <= 2;
         for arg in args.iter().skip(1) {
+            if !single_arg_rule {
+                list_items.push(arg.clone());
+                continue;
+            }
             match arg.view() {
                 // Only flatten List-kind arrays (from @-sigiled variables).
                 // Array-kind (from [...] literals) are kept as individual items,

--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -222,6 +222,20 @@ impl Interpreter {
                 ValueView::Array(..) if base_class_name == "CArray" => {
                     items.extend(crate::runtime::utils::value_to_list(arg));
                 }
+                // `Array.new(|c)` slurps with `+@`, so the single-argument rule
+                // applies: `Array.new((1,2))`, `Array.new([1,2])` and
+                // `Array.new(@a)` are all two elements, while
+                // `Array.new(@a, 3)` keeps `@a` whole (the `**@`-style behaviour
+                // the arm above documents) and `List.new((1,2))` — a `**@`
+                // slurpy — stays one element. An itemized `$(...)`/`$[...]` is a
+                // single value and is never unwrapped by the rule.
+                ValueView::Array(_, kind)
+                    if matches!(base_class_name, "Array" | "array")
+                        && args.len() == 1
+                        && !kind.is_itemized() =>
+                {
+                    items.extend(crate::runtime::utils::value_to_list(arg));
+                }
                 _ => items.push(arg.clone()),
             }
         }

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -810,14 +810,25 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
             if sub_pd.name.starts_with('@')
                 && !matches!(
                     candidate.view(),
-                    ValueView::Array(..) | ValueView::Nil | ValueView::Slip(_)
+                    ValueView::Array(..) | ValueView::Nil | ValueView::Slip(_) | ValueView::Seq(_)
                 )
+                && !candidate.is_range()
             {
                 return Err(RuntimeError::typecheck_binding_parameter_value(
                     &sub_pd.name,
                     "Positional",
                     candidate,
                 ));
+            }
+            // A `@` parameter listifies an Iterable that is not already
+            // Positional, so a destructured `Seq` element binds as a `List` —
+            // `-> [@a, $b] {...}` given `[(1,2).Seq, 9]` sees `@a.^name` as
+            // `List` in Rakudo, and `@a` must stay usable after the Seq is
+            // consumed. A `Range` is Positional already and binds unchanged.
+            if sub_pd.name.starts_with('@')
+                && let ValueView::Seq(items) = candidate.view()
+            {
+                candidate = Value::array(items.as_ref().clone());
             }
             if sub_pd.name.starts_with('%')
                 && !matches!(candidate.view(), ValueView::Hash(..) | ValueView::Nil)

--- a/t/slurpy-single-argument-rule.t
+++ b/t/slurpy-single-argument-rule.t
@@ -1,0 +1,60 @@
+use Test;
+
+# `map(&code, +values)`, `grep(&matcher, +values)` and `Array.new(|c)` all slurp
+# with a `+@`-shaped parameter, which applies the *single-argument rule*: exactly
+# one list argument is flattened into its elements, two or more are each one
+# element of their own. mutsu flattened every argument, so
+# `map -> [$a, $b] {...}, (1,2), (3,4)` ran the block four times over four Ints
+# instead of twice over two pairs -- the shape `Digest::RIPEMD` builds its round
+# tables with.
+
+plan 20;
+
+# --- map ------------------------------------------------------------------
+
+is (map { .raku }, (1, 2), (3, 4)).join('|'), '(1, 2)|(3, 4)',
+    'two list arguments are two elements';
+is (map { .raku }, (1, 2)).join('|'), '1|2',
+    'one list argument is flattened';
+is (map { .raku }, 1, 2).join('|'), '1|2',
+    'two scalar arguments are still two elements';
+is (map { .raku }, (1, 2), 9).join('|'), '(1, 2)|9',
+    'a list and a scalar do not flatten the list';
+is (map { .raku }, (1, 2).Seq, (3, 4).Seq).join('|'), '(1, 2).Seq|(3, 4).Seq',
+    'Seq arguments are kept whole';
+is (map { .raku }, 1 .. 3, 5 .. 7).join('|'), '1..3|5..7',
+    'Range arguments are kept whole';
+is (map { .raku }, [1, 2], [3, 4]).join('|'), '[1, 2]|[3, 4]',
+    'Array arguments are kept whole';
+is (map { .elems }, (1, 2), ()).join('|'), '2|0',
+    'an empty list argument is still one element';
+
+{
+    my @a = 1, 2;
+    is (map { .raku }, @a, @a).join('|'), '[1, 2]|[1, 2]',
+        'two @-variables are two elements';
+    is (map { .raku }, @a).join('|'), '1|2',
+        'one @-variable is flattened';
+}
+
+is (map { .raku }, (1, 2) xx 2).join('|'), '(1, 2)|(1, 2)',
+    'a single Seq-of-lists argument flattens one level only';
+
+# --- destructuring, the shape this was found through -----------------------
+
+is (map -> [$a, $b] { "$a/$b" }, (1, 2), (3, 4)).join('|'), '1/2|3/4',
+    'a destructuring block binds each list argument as a whole';
+
+# --- grep -----------------------------------------------------------------
+
+is (grep { True }, (1, 2), (3, 4)).elems, 2, 'grep counts two list arguments as two';
+is (grep { True }, (1, 2)).elems, 2, 'grep flattens a single list argument';
+is (grep { $_ > 1 }, 1, 2, 3).join(','), '2,3', 'grep over scalars is unchanged';
+
+# --- Array.new ------------------------------------------------------------
+
+is Array.new((1, 2)).elems, 2, 'Array.new flattens a single list argument';
+is Array.new([1, 2]).elems, 2, '... and a single Array argument';
+is Array.new((1, 2), (3, 4)).elems, 2, '... but keeps two arguments as two elements';
+is Array.new($(1, 2)).elems, 1, '... and never unwraps an itemized argument';
+is List.new((1, 2)).elems, 1, 'List.new slurps with **@ and does not apply the rule';

--- a/t/sub-signature-array-param-iterable.t
+++ b/t/sub-signature-array-param-iterable.t
@@ -1,0 +1,37 @@
+use Test;
+
+# An `@` parameter inside a destructuring sub-signature accepted only an Array,
+# so a `Seq` or `Range` element failed to bind even though a plain `sub f(@a)`
+# takes both. Rakudo listifies a non-Positional Iterable on the way in, which is
+# why `@a.^name` is `List` for a Seq and stays `Range` for a Range.
+# `Digest::RIPEMD`'s `-> [&f, $r, @K, $s] {...}` binds a `Seq` at `@K`.
+
+plan 10;
+
+my &g = -> [@a, $b] { "{@a.^name}:{@a.elems}" };
+
+is g([(1, 2).Seq, 9]), 'List:2', 'a Seq element binds to an @ sub-parameter';
+is g([1 .. 3, 9]), 'Range:3', 'a Range element binds and keeps its type';
+is g([[7, 8], 9]), 'Array:2', 'an Array element still binds';
+is g([(4, 5), 9]), 'List:2', 'a List element still binds';
+
+dies-ok { g([%(a => 1), 9]) }, 'a Hash element is still a binding error';
+dies-ok { g(['ab', 9]) }, 'a Str element is still a binding error';
+dies-ok { g([5, 9]) }, 'an Int element is still a binding error';
+
+# The bound List survives being read twice — a raw Seq would be exhausted.
+{
+    my &h = -> [@a, $b] { @a.elems + @a.elems };
+    is h([(1, 2, 3).Seq, 9]), 6, 'the listified Seq can be iterated more than once';
+}
+
+# The same through a `map` destructuring block, the shape RIPEMD uses.
+is (map -> [&f, @k] { "{&f(2)}/{@k.join(',')}" },
+        (* + 1, (7, 8).Seq), (* + 10, (1, 2, 3).Seq)).join('|'),
+    '3/7,8|12/1,2,3', 'a Seq binds through a map destructuring block';
+
+# A plain (non-destructured) signature was already fine; pin it.
+{
+    sub p(@a) { @a.elems }
+    is p((1, 2).Seq), 2, 'a plain @ parameter still takes a Seq';
+}

--- a/t/whatevercode-hyper-method.t
+++ b/t/whatevercode-hyper-method.t
@@ -1,0 +1,37 @@
+use Test;
+
+# A hyper method call was invisible to the Whatever-currying machinery, so
+# `*.comb».uc` evaluated `Whatever.comb».uc` eagerly and produced a List instead
+# of a WhateverCode. `Digest::RIPEMD` builds its round tables with
+# `given *.comb».parse-base(16)`, which died with "No such method 'CALL-ME' for
+# invocant of type 'List'".
+
+plan 10;
+
+isa-ok (*.comb».uc), Callable, 'a hyper method call curries into a WhateverCode';
+is (*.comb».uc).WHAT.gist, '(WhateverCode)', '... reported as WhateverCode';
+
+{
+    my $g = *.comb».uc;
+    is $g("abc").join(','), 'A,B,C', 'the curried closure applies the hyper call';
+}
+
+{
+    my $h = *.comb>>.parse-base(16);
+    is $h("1A").join(','), '1,10', 'the ASCII spelling curries too';
+}
+
+is (*.comb».uc)("xy").join(','), 'X,Y', 'the closure is callable straight away';
+
+is <ab cd>.map(*.comb».uc).map(*.join('')).join(','), 'AB,CD',
+    'it composes as a map block';
+
+is (*.comb».parse-base(16))("0123ABCD").join(','), '0,1,2,3,10,11,12,13',
+    'the shape Digest::RIPEMD uses';
+
+is (do given *.comb».parse-base(16) { .("12AB") }).join(','), '1,2,10,11',
+    '... reached through `given` and `.()`';
+
+# Chained past the hyper call, and with an argument.
+is (*.comb».uc.join('-'))("abc"), 'A-B-C', 'a plain method call after the hyper call';
+is (*.words».chars)("aa bbb").join(','), '2,3', 'a hyper call with no arguments';

--- a/todo/tickets/digest-dist-blockers.md
+++ b/todo/tickets/digest-dist-blockers.md
@@ -27,16 +27,27 @@ addressing, `Xxx` per-element thunking, `polymod` precision, and `.roll` on a
 `Str` range — all fixed in `news/2026-08/digest-md5-four-fixes.md`. `t/md5.t`
 passes in full.
 
-## 2. A WhateverCode cannot bind to a `@`-sigil parameter
+## 2. `rmd160` returns a four-byte zero digest
 
-`Digest::RIPEMD`:
+The original symptom here — a `WhateverCode` reaching an `@`-sigil parameter —
+was a chain of four general bugs, all reduced and fixed in
+`news/2026-08/slurpy-single-argument-rule-and-friends.md`: `map`/`grep`/`Array.new`
+ignoring the slurpy single-argument rule (which fed the destructure the *first
+element* of a tuple instead of the tuple), `*.comb».parse-base(16)` not currying
+because a hyper method call was invisible to the Whatever machinery, and an `@`
+parameter in a sub-signature rejecting a `Seq`/`Range`.
 
-    X::TypeCheck::Binding::Parameter: Type check failed in binding to parameter '@';
-      expected Positional but got WhateverCode (WhateverCode.new)
+`rmd160` now runs to completion, and the test's *expected* `Blob` is correct too
+(the `polymod` precision fix). What remains is a wrong digest: every input yields
+`Blob[uint8]:0x<00 00 00 00>` — four bytes rather than twenty. The suspect is the
+outer pipeline
 
-from `rmd160`'s destructuring loop signature `-> [&f, $r, @K, $s] { … }` fed by a
-list whose elements include `*`-derived WhateverCodes. Not yet reduced to a
-minimal repro.
+    blob8.new: map |*.polymod(256 xx 3),
+      |reduce -> blob32 $h, @words { blob32.new: [Z+] map {$_[[^5].rotate(++$)]},
+                                      $h, |await map -> [&f, $r, @K, $s] { start {...} }, ... }
+
+i.e. the `start`/`await` fan-out, the `[Z+]` reduction over five-element rotations,
+or `map |*.polymod(256 xx 3)` slipping. Not yet reduced.
 
 ## 3. `sha512` / `sha384` return an empty digest
 


### PR DESCRIPTION
Three more general interpreter bugs found reducing grondilu's `Digest::RIPEMD`
against `raku`. Together they take `rmd160` from a binding failure to running
end to end. Write-up in
`news/2026-08/slurpy-single-argument-rule-and-friends.md`.

### 1. `map` / `grep` / `Array.new` ignored the slurpy single-argument rule

`map(&code, +values)`, `grep(&matcher, +values)` and `Array.new(|c)` all slurp
with a `+@`-shaped parameter, and `+@` applies the **single-argument rule**:
exactly one list argument is flattened into its elements, two or more are each
one element of their own. mutsu flattened every argument:

```raku
map -> [$a, $b] { "$a/$b" }, (1, 2), (3, 4)
# was: four bindings of four Ints, dying at the destructure
# now: ("1/2", "3/4")

map { .raku }, (1, 2), (3, 4)     # was ("1","2","3","4"), now ("(1, 2)", "(3, 4)")
Array.new((1, 2)).elems           # was 1, now 2
```

`Array.new` gets the rule; `List.new` — a `**@` slurpy — does not
(`List.new((1,2)).elems` stays 1), `Array.new(@a, 3)` keeps `@a` whole, and an
itemized `$(...)`/`$[...]` is never unwrapped. All checked against Rakudo.

This was the real cause of the ticket's confusing "a WhateverCode reached an
`@`-sigil parameter": `Digest::RIPEMD` passes two round-table tuples to `map`,
and the destructure was being fed the *first element* of the first tuple.

### 2. A hyper method call did not curry a `Whatever`

`*.comb` is a WhateverCode; `*.comb».uc` was not.
`Expr::HyperMethodCall` / `HyperMethodCallDynamic` were missing from the whole
currying machinery — `contains_whatever`, `count_whatever`,
`replace_whatever_numbered`, `replace_whatever_single`, `rename_var`, and the
topic / `xx` probes all knew `MethodCall` but not its hyper twin. So the parser
never wrapped the expression and the `*` was evaluated eagerly:

```raku
my $g = *.comb».uc;
$g("abc");   # No such method 'CALL-ME' for invocant of type 'List'
```

`Digest::RIPEMD` builds each round's constants with
`given *.comb».parse-base(16)`.

### 3. An `@` parameter in a sub-signature rejected `Seq` and `Range`

`-> [@a, $b] {...}` accepted only an `Array` at `@a`, so a `Seq` or `Range`
element failed to bind — even though a plain `sub f(@a)` takes both. Rakudo
listifies a non-`Positional` `Iterable` on the way in, which is why `@a.^name` is
`List` for a `Seq` and stays `Range` for a `Range`; mutsu now matches, so the
bound value also survives being iterated twice. `Hash`/`Str`/`Int` elements are
still binding errors.

`Digest::RIPEMD`'s `-> [&f, $r, @K, $s] {...}` binds a `Seq` at `@K`.

### Verification

- `make test` — PASS (2845 files, 27022 tests).
- Locally PASS: every whitelisted `roast/S06-signature/*.t` (35 files),
  `S06-currying/{misc,positional,slurpy}.t`, `S06-multi/{subsignature,unpackability}.t`,
  `S02-types/{whatever,hyperwhatever,array}.t`, `S02-names-vars/signature.t`,
  `S32-list/{map,grep}.t`, `S32-array/create.t`.
- Three new pins, each verified to pass under `raku` as well:
  `t/slurpy-single-argument-rule.t`, `t/whatevercode-hyper-method.t`,
  `t/sub-signature-array-param-iterable.t`.

### Not fixed here

`rmd160` now runs but still returns a four-byte zero digest; the suspect is its
`start`/`await` + `[Z+]` pipeline. `Nil` still binds to an `@` sub-parameter
where Rakudo raises. Both recorded in `todo/tickets/digest-dist-blockers.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)