### PR TITLE
fix(parser): X::Syntax::Missing and X::UnitScope::* carry their `.what`

### DIFF
--- a/news/2026-08/syntax-missing-and-unitscope-carry-what.md
+++ b/news/2026-08/syntax-missing-and-unitscope-carry-what.md
@@ -1,0 +1,43 @@
+# `X::Syntax::Missing` and `X::UnitScope::*` carry their `.what`
+
+Naming the class is only half of a typed exception. `throws-like 'repeat { 1 }',
+X::Syntax::Missing, what => '"while" or "until"'` reads the *attribute*, and the
+`"X::Type: text"` parse-error message convention
+(`news/2026-08/parse-error-keeps-its-exception-class.md`) preserves only the
+class. So both of these matched the class and then died on
+`No such method 'what'`, aborting the rest of the file — the same shape the
+earlier typed-attribute pass fixed for five other classes
+(`news/2026-08/typed-exceptions-carry-their-attributes.md`).
+
+Three changes, in increasing order of generality:
+
+**`X::Syntax::Missing` derives `what` from its own message.** rakudo spells that
+message as literally `Missing {what}`, so the attribute is a strip of the
+prefix rather than a second copy — the message and the attribute cannot
+disagree, and a future raise site gets `.what` for free. Done once in
+`RuntimeError::exception_value_with_backtrace`, the bridge that turns the
+message convention into an exception object. The `repeat` site's wording moved
+to rakudo's (`Missing "while" or "until"` rather than `"while" or "until"
+required after repeat`), which is what makes the derivation yield the right
+value there; `Missing block` already had the shape.
+
+**`X::UnitScope::TooLate` / `X::UnitScope::Invalid` carry it explicitly.** Their
+messages do not spell `what` in a derivable place, so the four raise sites pass
+it through a new `PError::raw_with_what`. It stays a *soft* error — these sites
+are best-error candidates the statement dispatcher may still back out of, so
+making them fatal would change parsing.
+
+**A soft parse diagnosis now forwards its structured exception.** `parse_program`
+only copied `PError::exception` into the `RuntimeError` on the *fatal* branch;
+the soft branch rebuilt from the message alone and dropped it. That is why the
+attribute above did not arrive until this was fixed too.
+
+Two whitelisted roast files now run to completion under `MUTSU_REAL_TEST=1`
+instead of aborting mid-plan: `roast/S04-statements/repeat.t` (21 tests) and
+`roast/S06-other/main-semicolon.t` (10 tests).
+
+Pin: `t/syntax-missing-and-unitscope-carry-what.t`. It reads `.what` off the
+caught exception rather than going through `throws-like`'s named matchers —
+mutsu's own native `throws-like` does not check those, so a matcher-based pin
+would have passed without the fix. Without it the file stops at its second
+assertion; all 9 pass under `raku`.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -407,12 +407,23 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
                 // inside an "expected A or B or …" list and leave the exception
                 // classed `X::Syntax::Confused`.
                 if let Some(typed) = e.typed_convention_message() {
-                    Err(with_parse_hint(RuntimeError::with_location(
+                    let mut err = RuntimeError::with_location(
                         typed.to_string(),
                         RuntimeErrorCode::ParseExpected,
                         line_num,
                         col_num,
-                    )))
+                    );
+                    // A SOFT diagnosis may still carry a structured exception —
+                    // the message convention preserves only the class, and some
+                    // sites also need the attributes rakudo's exception has
+                    // (`X::UnitScope::Invalid.what`). The fatal branch above
+                    // already forwards it; without the same here, a
+                    // `throws-like …, X::…, what => …` matched the class and
+                    // then died on `No such method 'what'`.
+                    if let Some(ex) = e.exception {
+                        err.exception = Some(ex);
+                    }
+                    Err(with_parse_hint(err))
                 } else if let Some(context) = near_snippet(tail, 60) {
                     Err(with_parse_hint(RuntimeError::with_location(
                         format!(

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -59,6 +59,35 @@ impl PError {
         }
     }
 
+    /// [`Self::raw`], plus the `what` attribute rakudo's exception carries.
+    ///
+    /// The `"X::Type: text"` message convention preserves the *class* but
+    /// nothing else, so a `throws-like …, X::UnitScope::Invalid, what => "sub"`
+    /// matched the class and then died on `No such method 'what'`, aborting the
+    /// file (`roast/S06-other/main-semicolon.t`). Stays SOFT — these sites are
+    /// best-error candidates the statement dispatcher may still back out of, so
+    /// they must not become fatal.
+    pub fn raw_with_what(
+        message: String,
+        remaining_len: Option<usize>,
+        class_name: &str,
+        what: &str,
+    ) -> Self {
+        let text = crate::value::RuntimeError::split_typed_message_convention(&message)
+            .map(|(_, t)| t)
+            .unwrap_or(message.as_str());
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("message".to_string(), crate::value::Value::str_from(text));
+        attrs.insert("what".to_string(), crate::value::Value::str_from(what));
+        let exception =
+            crate::value::Value::make_instance(crate::symbol::Symbol::intern(class_name), attrs);
+        PError {
+            messages: vec![message],
+            remaining_len,
+            exception: Some(Box::new(exception)),
+        }
+    }
+
     /// Build a fatal (non-recoverable) parse error.
     /// Fatal errors are not swallowed by the statement dispatcher.
     pub fn fatal(message: String) -> Self {

--- a/src/parser/stmt/control/loop_repeat.rs
+++ b/src/parser/stmt/control/loop_repeat.rs
@@ -445,7 +445,10 @@ pub(crate) fn repeat_stmt(input: &str) -> PResult<'_, Stmt> {
             },
         ));
     }
+    // rakudo's own wording, `Missing "while" or "until"` — which is also what
+    // makes the exception's `.what` attribute derivable (see
+    // `RuntimeError::exception_value_with_backtrace`).
     Err(PError::fatal(
-        "X::Syntax::Missing: \"while\" or \"until\" required after repeat".to_string(),
+        "X::Syntax::Missing: Missing \"while\" or \"until\"".to_string(),
     ))
 }

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -223,10 +223,12 @@ pub(crate) fn stmt_list_with_mode(
             && let Ok((after_decl, mut main_sub)) = sub::top_level_main_semicolon_decl(r)
         {
             if saw_compunit_declarator {
-                return Err(PError::raw(
+                return Err(PError::raw_with_what(
                     "X::UnitScope::TooLate: A unit-scoped sub declaration is too late in the compilation unit"
                         .to_string(),
                     Some(r.len()),
+                    "X::UnitScope::TooLate",
+                    "sub",
                 ));
             }
             let (tail_rest, tail_stmts) = stmt_list_with_mode(after_decl, false, emit_setline)?;
@@ -241,12 +243,14 @@ pub(crate) fn stmt_list_with_mode(
             && let Ok((after_multi, _)) = ws1(after_multi)
             && sub::top_level_main_semicolon_decl(after_multi).is_ok()
         {
-            return Err(PError::raw(
+            return Err(PError::raw_with_what(
                 "X::UnitScope::Invalid: A unit-scoped sub definition is not allowed except on a MAIN sub; \
                  Please use the block form. If you did not mean to declare a unit-scoped sub, \
                  perhaps you accidentally placed a semicolon after routine's definition?"
                     .to_string(),
                 Some(r.len()),
+                "X::UnitScope::Invalid",
+                "sub",
             ));
         }
         // `unit class`/`unit role`/`unit grammar` (semicolon form): the rest of

--- a/src/parser/stmt/sub/sub_decl.rs
+++ b/src/parser/stmt/sub/sub_decl.rs
@@ -259,21 +259,25 @@ pub(crate) fn sub_decl_body(
             ));
         }
         if !has_explicit_signature {
-            return Err(PError::raw(
+            return Err(PError::raw_with_what(
                 "X::UnitScope::Invalid: A unit-scoped sub definition is not allowed except on a MAIN sub; \
                  Please use the block form. If you did not mean to declare a unit-scoped sub, \
                  perhaps you accidentally placed a semicolon after routine's definition?"
                     .to_string(),
                 Some(rest.len()),
+                "X::UnitScope::Invalid",
+                "sub",
             ));
         }
         if name == "MAIN" && !allow_main_semicolon_decl {
-            return Err(PError::raw(
+            return Err(PError::raw_with_what(
                 "X::UnitScope::Invalid: A unit-scoped sub definition is not allowed except on a MAIN sub; \
                  Please use the block form. If you did not mean to declare a unit-scoped sub, \
                  perhaps you accidentally placed a semicolon after routine's definition?"
                     .to_string(),
                 Some(rest.len()),
+                "X::UnitScope::Invalid",
+                "sub",
             ));
         }
         return Ok((

--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -216,6 +216,18 @@ impl RuntimeError {
             .unwrap_or((self.untyped_exception_class(), self.message.as_str()));
         let mut attrs = HashMap::new();
         attrs.insert("message".to_string(), Value::str_from(text));
+        // `X::Syntax::Missing`'s message IS `Missing {what}` in rakudo, so the
+        // attribute the roast tests match on (`what => 'block'`,
+        // `what => '"while" or "until"'`) can be derived from it rather than
+        // spelled twice — the same "derive it the way rakudo derives it so the
+        // two cannot disagree" rule the typed-attribute pass used. Without it a
+        // `throws-like …, X::Syntax::Missing, what => …` matched the class and
+        // then died on `No such method 'what'`, aborting the file.
+        if class_name == "X::Syntax::Missing"
+            && let Some(what) = text.strip_prefix("Missing ")
+        {
+            attrs.insert("what".to_string(), Value::str_from(what));
+        }
         if let Some(line) = self.line() {
             attrs.insert("line".to_string(), Value::int(line as i64));
         }

--- a/t/syntax-missing-and-unitscope-carry-what.t
+++ b/t/syntax-missing-and-unitscope-carry-what.t
@@ -1,0 +1,47 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# Naming the class is only half of a typed exception: `throws-like …,
+# X::Syntax::Missing, what => '"while" or "until"'` reads the ATTRIBUTE, and the
+# `"X::Type: text"` parse-error message convention preserves only the class. So
+# these matched the class and then died on `No such method 'what'`, aborting the
+# whole file.
+#
+# X::Syntax::Missing derives `what` from its own message, which rakudo spells as
+# `Missing {what}` -- so the two cannot disagree. X::UnitScope::* carries it
+# explicitly from the raise site, and a SOFT parse diagnosis now forwards its
+# structured exception the way a fatal one already did.
+#
+# The assertions read `.what` off the caught exception rather than going through
+# `throws-like`'s named matchers: mutsu's own native `throws-like` does not
+# check those, so a matcher-based pin would pass without the fix.
+
+plan 9;
+
+sub caught($code) {
+    my $e;
+    { EVAL $code; CATCH { default { $e = $_ } } }
+    $e
+}
+
+my $repeat = caught 'repeat { 1 }';
+isa-ok $repeat, X::Syntax::Missing, 'repeat without while/until is X::Syntax::Missing';
+is $repeat.what, '"while" or "until"', '...and carries .what';
+is $repeat.message, 'Missing "while" or "until"', '...with rakudo\'s own message';
+
+my $block = caught 'if 1; 2';
+isa-ok $block, X::Syntax::Missing, 'a missing block is X::Syntax::Missing';
+is $block.what, 'block', '...and carries what => "block"';
+
+my $late = caught "module AtBeginning \{\}\nsub MAIN;";
+isa-ok $late, X::UnitScope::TooLate, 'a too-late unit-scoped sub is X::UnitScope::TooLate';
+is $late.what, 'sub', '...and carries what => "sub"';
+
+my $sub-scope = caught '{ sub MAIN; }';
+is $sub-scope.what, 'sub', 'a unit-scoped sub in a subscope carries what => "sub"';
+
+# `repeat ... while` itself is untouched.
+my $n = 0;
+repeat { $n++ } while $n < 3;
+is $n, 3, 'repeat/while still runs';


### PR DESCRIPTION
## What

Naming the class is only half of a typed exception. `throws-like 'repeat { 1 }', X::Syntax::Missing, what => '"while" or "until"'` reads the **attribute**, and the `"X::Type: text"` parse-error message convention preserves only the class. So both classes matched and then died on `No such method 'what'`, aborting the rest of the file — the same shape [the earlier typed-attribute pass](../blob/main/news/2026-08/typed-exceptions-carry-their-attributes.md) fixed for five other classes.

Three changes, in increasing order of generality:

1. **`X::Syntax::Missing` derives `what` from its own message.** rakudo spells that message as literally `Missing {what}`, so the attribute is a strip of the prefix rather than a second copy — message and attribute cannot disagree, and a future raise site gets `.what` for free. Done once in `RuntimeError::exception_value_with_backtrace`, the bridge that turns the convention into an exception object. The `repeat` site's wording moved to rakudo's (`Missing "while" or "until"`), which is what makes the derivation yield the right value there; `Missing block` already had the shape.
2. **`X::UnitScope::TooLate` / `X::UnitScope::Invalid` carry it explicitly.** Their messages do not spell `what` in a derivable place, so the four raise sites use a new `PError::raw_with_what`. It stays a *soft* error — these sites are best-error candidates the statement dispatcher may still back out of, so making them fatal would change parsing.
3. **A soft parse diagnosis now forwards its structured exception.** `parse_program` only copied `PError::exception` into the `RuntimeError` on the *fatal* branch; the soft branch rebuilt from the message alone and dropped it. That is why (2) did not arrive until this was fixed too.

## Verification

- `roast/S04-statements/repeat.t` (21 tests) and `roast/S06-other/main-semicolon.t` (10 tests) now run to completion under `MUTSU_REAL_TEST=1` instead of aborting mid-plan.
- `t/syntax-missing-and-unitscope-carry-what.t` — new pin. It reads `.what` off the caught exception rather than through `throws-like`'s named matchers: **mutsu's own native `throws-like` does not check those**, so a matcher-based pin would have passed without the fix. Without it the file stops at its second assertion; all 9 pass under `raku`.
- `make test` PASS (2845 files), release `make roast` PASS (1435 files), bundled-library gate PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)