### PR TITLE
fix: a start block read the wrong destructured @ parameter, and |$buf did not slip

### DIFF
--- a/news/2026-08/start-block-destructured-array-param.md
+++ b/news/2026-08/start-block-destructured-array-param.md
@@ -1,0 +1,66 @@
+# A `start` block read the wrong destructured `@` parameter, and `|$buf` did not slip
+
+Two more general bugs from grondilu's `Digest::RIPEMD`, which now computes the
+correct RIPEMD-160 digest for every RFC test vector.
+
+## 1. A destructured `@`/`%` parameter was frozen at the first spawn's value
+
+```raku
+await map -> [$a, @K] { start { "$a:{@K[0]}" } }, (1, (100,101)), (2, (200,201))
+# was  1:100, 2:100
+# now  1:100, 2:200
+```
+
+`@`/`%` lexicals captured by a spawned block are carried by the process-wide,
+bare-name-keyed `shared_vars` store rather than by the closure machinery
+(`docs/recursive-start-shared-vars.md` — `$` names were moved off that lane and
+given a per-binding home; aggregates were deliberately left on it, because the
+`__mutsu_atomic_*` CAS copies are keyed off those entries). That store is seeded
+once per name with `seed_if_absent`, so the first spawn's value is immortal, and
+the worker prefers it over its own env copy.
+
+A destructuring sub-signature is the one parameter path that writes `env` with no
+local slot behind it — every compiled binding path declines a `sub_signature`, so
+`bind_sub_signature_from_value` is the whole story — and what it binds is
+provably a *fresh per-invocation binding*, never the one shared object the lane
+exists to represent. Those names are now recorded as they are bound
+(`Interpreter::sub_signature_bound_aggregates`) and, at spawn time, kept off the
+lane and masked in the child, exactly as a captured `$` already was. Two
+conditions narrow it to that case: the name must be one a sub-signature bound,
+*and* the spawned block's free variable must resolve to no parent slot. A plain
+`-> @K` parameter therefore keeps the lane, as do unrelated outer aggregates that
+merely share a name.
+
+The general form of this — two ordinary bindings of one `@` name, one of them
+captured by a spawn — is not fixed here; it needs the per-binding home the doc
+defers. Recorded as `todo/tickets/shared-var-lane-freezes-a-reused-array-name.md`.
+
+Pinned by `t/start-block-destructured-array-param.t`.
+
+## 2. `|$buf` slipped the buffer, not its elements
+
+A `Buf`/`Blob` is `Positional`, so `|$buf` slips its elements — and at the
+buffer's own element width, so `|blob32.new(7, 8)` is `slip(7, 8)`.
+`exec_make_slip_op` had no arm for a buffer instance, so it fell through to
+`_ => vec![val]` and produced a one-item slip holding the whole buffer:
+
+```raku
+my $b = blob32.new(7, 8);
+say (1, |$b, 2);   # was (1, Blob[uint32].new(7,8), 2), now (1, 7, 8, 2)
+```
+
+`Digest::RIPEMD` renders its digest with `map |*.polymod(256 xx 3), |$reduced`,
+where `$reduced` is a `blob32` — so the `WhateverCode` was handed the whole Blob
+and digested a numified `0`, giving four zero bytes for every input. A type
+object (`|Buf`) carries no element storage and stays one item, as in Rakudo.
+
+Pinned by `t/slip-a-buf.t`.
+
+## What is left in `Digest::RIPEMD`
+
+`rmd160` now returns the correct digest for every RFC vector — but only for the
+*first* call in a process. Its output stage rotates the five hash words with
+`map { $_[[^5].rotate(++$)] }`, and mutsu never resets an anonymous `$` state
+variable when its enclosing routine is re-entered, so later calls rotate by the
+wrong amount. That is an independent bug with its own minimal repro, recorded as
+`todo/tickets/anonymous-state-var-not-reset-per-routine-call.md`.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1436,6 +1436,21 @@ pub struct Interpreter {
     /// in-flight window closes that hole; the store is republished normally once
     /// the initializer's value lands. Empty for single-threaded programs.
     pub(crate) thread_decl_in_flight: std::collections::HashSet<String>,
+    /// `@`/`%` names that a **destructuring sub-signature** has bound
+    /// (`-> [$a, @K] { ... }`), with their sigils.
+    ///
+    /// Such a name is a fresh per-invocation binding, never the one shared
+    /// object the name-keyed `shared_vars` lane exists to represent. Left on that
+    /// lane it is seeded once (`seed_if_absent`) and then frozen at the first
+    /// spawn's value, so two `start` blocks created by two iterations of the same
+    /// destructuring block both read the same `@K`. `clone_for_thread_for_block`
+    /// consults this set — intersected with the spawned block's free variables,
+    /// so an unrelated outer aggregate that merely shares a name is unaffected —
+    /// to keep those names off the lane and mask them in the child instead.
+    ///
+    /// Only populated while `shared_vars_active`; empty (zero-cost) for
+    /// single-threaded programs.
+    pub(crate) sub_signature_bound_aggregates: std::collections::HashSet<String>,
     /// Set while an *incidental* locals -> env mirror is running: the I/O
     /// pre-sync (`sync_env_from_locals_declared`, run before Say/Put/Print/Note
     /// so a `$*OUT` override or a `.gist` sees fresh values) and the regex

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2168,6 +2168,7 @@ impl Interpreter {
             state_vars: HashMap::new(),
             thread_redeclared_vars: std::collections::HashSet::new(),
             thread_decl_in_flight: std::collections::HashSet::new(),
+            sub_signature_bound_aggregates: std::collections::HashSet::new(),
             suppress_shared_publish: false,
             type_body_written_lexicals: std::collections::HashSet::new(),
             closure_captured_state: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -64,6 +64,30 @@ impl Interpreter {
                 }
                 out.insert(bare.to_string());
             }
+            // An `@`/`%` free variable that a **destructuring sub-signature**
+            // bound is a fresh per-invocation binding, not the one shared object
+            // the name lane represents. Left on the lane it is seeded once and
+            // frozen at the first spawn's value, so
+            // `map -> [$a, @K] { start { @K[0] } }, ...` had every worker read
+            // the first iteration's `@K`.
+            //
+            // Two conditions narrow this to exactly that case. The name must be
+            // one a sub-signature has bound, and the free variable must resolve
+            // to NO parent slot: the sub-signature binder is the only parameter
+            // path that writes `env` without a local slot (every compiled
+            // binding path declines a `sub_signature`), so a plain `-> @K`
+            // parameter — which republishes into the lane from its slot on each
+            // call, and works today — keeps the lane. Together they also leave
+            // an unrelated outer aggregate that merely shares the name, and its
+            // `__mutsu_atomic_*` CAS copies, exactly where
+            // `docs/recursive-start-shared-vars.md` requires.
+            for (i, sym) in cc.free_var_syms.iter().enumerate() {
+                let name = sym.resolve();
+                let slot_bound = cc.free_var_parent_slots.get(i).copied().flatten().is_some();
+                if !slot_bound && self.sub_signature_bound_aggregates.contains(name.as_str()) {
+                    out.insert(name.to_string());
+                }
+            }
         }
         out
     }
@@ -155,11 +179,15 @@ impl Interpreter {
                 // ... } }`). Seeding those names here ran a second, lossy
                 // mechanism in parallel with the working one and silently
                 // overwrote its correct answer (PLAN.md §6).
-                // `@`/`%` aggregates always keep this lane: their
-                // `__mutsu_atomic_*` CAS copies are keyed off these entries.
+                // `@`/`%` aggregates keep this lane by default: their
+                // `__mutsu_atomic_*` CAS copies are keyed off these entries. The
+                // one exception is an aggregate bound by a destructuring
+                // sub-signature, which `block_captured_scalars` puts in this set
+                // *with* its sigil — a fresh per-invocation binding the lane
+                // cannot represent (it would freeze at the first spawn's value).
                 if !captured_scalars.is_empty()
-                    && !key.starts_with('@')
-                    && !key.starts_with('%')
+                    && (!key.starts_with('@') && !key.starts_with('%')
+                        || captured_scalars.contains(key.as_str()))
                     && captured_scalars.contains(key.trim_start_matches('$'))
                 {
                     continue;
@@ -443,6 +471,8 @@ impl Interpreter {
             // The child starts no declaration of its own; its own `my`s populate
             // this as they run.
             thread_decl_in_flight: std::collections::HashSet::new(),
+            // The child re-binds its own destructured parameters if it runs any.
+            sub_signature_bound_aggregates: std::collections::HashSet::new(),
             suppress_shared_publish: false,
             // A worker can instantiate a type registered on the parent, so the
             // set of method-written lexicals travels with the clone.

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -650,6 +650,32 @@ pub(in crate::runtime) fn bind_named_rename_sub_signature(
     Ok(())
 }
 
+/// Bind one destructured sub-parameter into the environment.
+///
+/// A sub-signature parameter is a **fresh per-invocation binding**, exactly like
+/// a `my` declaration, so — while threads are live — it has to mask the
+/// name-keyed `shared_vars` lane the same way `my` does
+/// (`vm_var_assign_set_local.rs`). Without the mask, a `@`/`%` sub-parameter
+/// captured by a spawned block is read out of that lane, which is seeded once
+/// (`seed_if_absent`) and therefore frozen at the *first* spawn's value:
+///
+/// ```raku
+/// await map -> [$a, @K] { start { "$a:{@K[0]}" } }, (1, (100,101)), (2, (200,201))
+/// # was 1:100,2:100 — the second worker read the first iteration's @K
+/// ```
+///
+/// `$` sub-parameters were already correct: the closure machinery owns them per
+/// binding and keeps them off that lane entirely. `&` names are routines and
+/// keep the lane; so do twigil'd forms, which share a name by design.
+fn bind_sub_param_name(interpreter: &mut Interpreter, name: &str, value: Value) {
+    if interpreter.shared_vars_active && Interpreter::is_plain_lexical_name(name) {
+        interpreter
+            .sub_signature_bound_aggregates
+            .insert(name.to_string());
+    }
+    interpreter.env.insert(name.to_string(), value);
+}
+
 pub(in crate::runtime) fn bind_sub_signature_from_value(
     interpreter: &mut Interpreter,
     sub_params: &[ParamDef],
@@ -686,9 +712,7 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
                 let mut named = named_values_from_unpack_target(value);
                 named.retain(|k, _| !consumed_named_keys.contains(k));
                 if !sub_pd.name.is_empty() {
-                    interpreter
-                        .env
-                        .insert(sub_pd.name.clone(), Value::hash(named));
+                    bind_sub_param_name(interpreter, &sub_pd.name, Value::hash(named));
                 }
             } else if sub_pd.name.starts_with('@')
                 || sub_pd.name.starts_with('$')
@@ -700,9 +724,7 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
                 nested_positional_idx = positional.len();
                 let remaining_value = Value::array(remaining);
                 if !sub_pd.name.is_empty() {
-                    interpreter
-                        .env
-                        .insert(sub_pd.name.clone(), remaining_value.clone());
+                    bind_sub_param_name(interpreter, &sub_pd.name, remaining_value.clone());
                 }
                 // A slurpy param may itself destructure the list it collects,
                 // e.g. `*@ ($a, $b, $y, *@)`. Bind those inner params against the
@@ -756,9 +778,7 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
             // don't leak into recursive calls.
             if !sub_pd.name.is_empty() {
                 let default_val = Interpreter::missing_optional_param_value(sub_pd);
-                interpreter
-                    .env
-                    .insert(sub_pd.name.clone(), default_val.clone());
+                bind_sub_param_name(interpreter, &sub_pd.name, default_val.clone());
                 // An unsupplied `:outer(:$inner)` alias must still declare the
                 // inner names the body actually reads.
                 if sub_pd.named
@@ -766,9 +786,7 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
                 {
                     for apd in alias_params.iter().filter(|a| a.named && !a.slurpy) {
                         if !apd.name.is_empty() {
-                            interpreter
-                                .env
-                                .insert(apd.name.clone(), default_val.clone());
+                            bind_sub_param_name(interpreter, &apd.name, default_val.clone());
                         }
                     }
                 }
@@ -867,9 +885,7 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
         }
         let bind_alias_name = !(sub_pd.named && sub_pd.sub_signature.is_some());
         if !sub_pd.name.is_empty() && bind_alias_name {
-            interpreter
-                .env
-                .insert(sub_pd.name.clone(), candidate.clone());
+            bind_sub_param_name(interpreter, &sub_pd.name, candidate.clone());
         }
         if let Some(nested) = &sub_pd.sub_signature {
             // A named sub-param's parens are either a RENAME/alias target

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -119,6 +119,22 @@ impl Interpreter {
             | ValueView::RangeExclStart(..)
             | ValueView::RangeExclBoth(..)
             | ValueView::GenericRange { .. } => crate::runtime::utils::value_to_list(&val),
+            // A `Buf`/`Blob` is Positional, so `|$buf` slips its ELEMENTS, at the
+            // buffer's own width — `|blob32.new(7, 8)` is `slip(7, 8)`, not a
+            // one-item slip holding the buffer. `Digest::RIPEMD` ends with
+            // `map |*.polymod(256 xx 3), |$reduced_blob32`, which fed the
+            // WhateverCode the whole Blob and digested a numified 0.
+            // A type object (`|Buf`) carries no element storage and stays one
+            // item, as in Rakudo.
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
+                && crate::value::value_buf::has_buf_elems(&attributes) =>
+            {
+                crate::value::value_buf::buf_elems_or_empty(&attributes)
+            }
             _ => vec![val],
         };
         self.stack.push(Value::slip(items));

--- a/t/slip-a-buf.t
+++ b/t/slip-a-buf.t
@@ -1,0 +1,42 @@
+use Test;
+
+# A `Buf`/`Blob` is Positional, so `|$buf` slips its *elements*, at the buffer's
+# own element width. mutsu produced a one-item slip holding the buffer itself,
+# so `map |*.polymod(256 xx 3), |$blob32` — how `Digest::RIPEMD` renders its
+# final digest — handed the WhateverCode the whole Blob and digested a
+# numified 0.
+
+plan 12;
+
+{
+    my $b = blob32.new(7, 8);
+    is (|$b).elems, 2, 'slipping a blob32 yields its elements';
+    is (|$b).join(','), '7,8', '... at the buffer element width, not byte by byte';
+    is (1, |$b, 2).join(','), '1,7,8,2', '... and they flatten into an enclosing list';
+}
+
+{
+    my $b = Buf.new(7, 8, 9);
+    is (|$b).join(','), '7,8,9', 'slipping a Buf yields its bytes';
+    sub count(*@a) { @a.elems }
+    is count(|$b), 3, '... reaching a slurpy as three arguments';
+}
+
+is (|utf8.new(65, 66)).join(','), '65,66', 'slipping a utf8 buffer yields its codes';
+is (|blob8.new()).elems, 0, 'slipping an empty buffer yields nothing';
+
+# A type object has no element storage and stays a single item.
+is (|Buf).elems, 1, 'slipping the Buf type object keeps it whole';
+is (|Blob).elems, 1, '... and the Blob type object too';
+
+# The shape Digest::RIPEMD ends with.
+{
+    my $r = blob32.new(4144542350, 2056805856);
+    is (map |*.polymod(256 xx 3), |$r).join(','), '142,178,8,247,224,93,152,122',
+        'a slipped Blob feeds map one element at a time';
+    is (blob8.new: map |*.polymod(256 xx 3), |$r).list.fmt('%02x', ''),
+        '8eb208f7e05d987a', '... and renders the expected bytes';
+}
+
+# Slipping still works where it already did.
+is (|(7, 8)).join(','), '7,8', 'slipping a plain list is unchanged';

--- a/t/start-block-destructured-array-param.t
+++ b/t/start-block-destructured-array-param.t
@@ -1,0 +1,68 @@
+use Test;
+
+# An `@`/`%` parameter bound by a destructuring sub-signature is a fresh
+# per-invocation binding, but it was left on the name-keyed `shared_vars` lane
+# that `start` blocks read from. That lane is seeded once per name, so every
+# worker spawned by a later iteration read the FIRST iteration's value:
+#
+#   await map -> [$a, @K] { start { "$a:{@K[0]}" } }, (1, (100,101)), (2, (200,201))
+#   # was 1:100,2:100
+#
+# `$`-sigil sub-parameters were already correct (the closure machinery owns them
+# per binding), and so were plain `-> @K { ... }` parameters.
+
+plan 8;
+
+{
+    my @got = await map -> [$a, @K] { start { "$a:{@K[0]}" } },
+        (1, (100, 101)), (2, (200, 201));
+    is @got.join('|'), '1:100|2:200',
+        'each worker sees its own destructured @ parameter';
+}
+
+{
+    my @got = await map -> [@K] { start { @K.join(',') } },
+        ((10, 11),), ((20, 21),), ((30, 31),);
+    is @got.join('|'), '10,11|20,21|30,31', 'three workers, three bindings';
+}
+
+{
+    my @got = await map -> [%h] { start { %h<k> } },
+        (%(k => 'a'),), (%(k => 'b'),);
+    is @got.join('|'), 'a|b', 'a destructured % parameter too';
+}
+
+# A slow body makes the workers genuinely overlap.
+{
+    sub slow { my $s = 0; $s += $_ for ^20000; $s }
+    my @got = await map -> [$a, @K] { start { slow(); "$a:{@K[0]}" } },
+        (1, (100, 101)), (2, (200, 201));
+    is @got.join('|'), '1:100|2:200', 'still correct when the workers overlap';
+}
+
+# The shapes that already worked must keep working.
+{
+    # A distinct name: the `@`-keyed shared-var lane cannot hold two live
+    # bindings of ONE name, so reusing `@K` here would hit a separate,
+    # pre-existing bug (recorded in todo/tickets/).
+    my @got = await map -> @P { start { @P[0] } }, (100, 101), (200, 201);
+    is @got.join('|'), '100|200', 'a plain @ parameter is unaffected';
+}
+
+{
+    my @got = map -> [$a, @K] { "$a:{@K[0]}" }, (1, (100, 101)), (2, (200, 201));
+    is @got.join('|'), '1:100|2:200', 'the synchronous form is unaffected';
+}
+
+{
+    my @got = (map -> [$a, @K] { -> { "$a:{@K[0]}" } }, (1, (100, 101)), (2, (200, 201)))
+        .map({ .() });
+    is @got.join('|'), '1:100|2:200', 'a plain closure is unaffected';
+}
+
+# An ordinary outer array still reaches a worker as ONE shared object.
+{
+    my @shared = 1, 2, 3;
+    await start { @shared.push(4) };
+    is @shared.join(','), '1,2,3,4', 'an outer @ lexical is still shared with a worker';
+}

--- a/todo/tickets/anonymous-state-var-not-reset-per-routine-call.md
+++ b/todo/tickets/anonymous-state-var-not-reset-per-routine-call.md
@@ -1,0 +1,45 @@
+# An anonymous state variable (`$++` / `++$`) is not reset when its enclosing routine is re-entered
+
+A bare `$` in a block is an anonymous state variable belonging to that block's
+*clone*. Re-entering the enclosing routine produces a fresh clone, so the counter
+restarts. mutsu keys it only by its compile-time name, so it keeps counting
+across calls:
+
+```raku
+sub f() { (map { ++$ }, 1, 2, 3).join(',') }
+say f();   # raku: 1,2,3   mutsu: 1,2,3
+say f();   # raku: 1,2,3   mutsu: 4,5,6
+
+sub g() { my @r; for ^3 { @r.push(++$) }; @r.join(',') }
+say g();   # raku: 1,2,3   mutsu: 1,2,3
+say g();   # raku: 1,2,3   mutsu: 4,5,6
+
+sub h() { (map { $++ }, 1, 2, 3).join(',') }
+say h();   # raku: 0,1,2   mutsu: 0,1,2
+say h();   # raku: 0,1,2   mutsu: 3,4,5
+```
+
+A **named** `state` in the same position is already correct — `sub i() { (map {
+state $n = 0; ++$n }, 1, 2, 3).join(',') }` yields `1,2,3` twice in both — so the
+fix is to give the anonymous form the same per-clone keying the named one has.
+A block stored in a variable and called repeatedly (`my $blk = { ++$ }; $blk()`)
+must keep counting: that is one clone.
+
+## Where
+
+`Interpreter::anon_state_key` (`src/vm/vm_var_ops.rs`) builds the key as
+`__anon_state::__ANON_STATE_<n>` — the compile-time placeholder name and nothing
+else — and `anon_state_value` / `sync_anon_state_value` read and write it in the
+process-wide `state_vars` map. Named `state` instead goes through
+`CompiledCode::state_locals` plus `normalize_state_key`
+(`src/runtime/runtime_class_query.rs`), which is what gives it a per-invocation
+identity. The readers are `vm_exec_dispatch.rs` (the `__ANON_STATE__` fast path),
+`vm_misc_coerce.rs`, `vm_var_assign_post_incdec.rs` and `vm_var_assign_typed.rs`.
+
+## Why it matters
+
+Found as the last remaining wrong-digest cause in grondilu's `Digest::RIPEMD`
+(`todo/tickets/digest-dist-blockers.md`): its output stage rotates the five
+hash words with `map { $_[[^5].rotate(++$)] }`, so the second and later
+`rmd160(...)` calls in one process rotate by the wrong amount and return a
+correct-but-rotated digest. Each call is correct in a fresh process.

--- a/todo/tickets/digest-dist-blockers.md
+++ b/todo/tickets/digest-dist-blockers.md
@@ -27,27 +27,32 @@ addressing, `Xxx` per-element thunking, `polymod` precision, and `.roll` on a
 `Str` range — all fixed in `news/2026-08/digest-md5-four-fixes.md`. `t/md5.t`
 passes in full.
 
-## 2. `rmd160` returns a four-byte zero digest
+## 2. `rmd160` is correct once per process — MOSTLY FIXED
 
-The original symptom here — a `WhateverCode` reaching an `@`-sigil parameter —
-was a chain of four general bugs, all reduced and fixed in
-`news/2026-08/slurpy-single-argument-rule-and-friends.md`: `map`/`grep`/`Array.new`
-ignoring the slurpy single-argument rule (which fed the destructure the *first
-element* of a tuple instead of the tuple), `*.comb».parse-base(16)` not currying
-because a hyper method call was invisible to the Whatever machinery, and an `@`
-parameter in a sub-signature rejecting a `Seq`/`Range`.
+The original symptom — a `WhateverCode` reaching an `@`-sigil parameter — was a
+chain of six general bugs, all reduced and fixed:
 
-`rmd160` now runs to completion, and the test's *expected* `Blob` is correct too
-(the `polymod` precision fix). What remains is a wrong digest: every input yields
-`Blob[uint8]:0x<00 00 00 00>` — four bytes rather than twenty. The suspect is the
-outer pipeline
+- `news/2026-08/slurpy-single-argument-rule-and-friends.md`:
+  `map`/`grep`/`Array.new` ignoring the slurpy single-argument rule (which fed
+  the destructure the *first element* of a tuple instead of the tuple),
+  `*.comb».parse-base(16)` not currying because a hyper method call was invisible
+  to the Whatever machinery, and an `@` parameter in a sub-signature rejecting a
+  `Seq`/`Range`.
+- `news/2026-08/start-block-destructured-array-param.md`: a destructured `@`
+  parameter frozen at the first spawn's value on the shared-var name lane (so the
+  second `start` branch computed the wrong half of the round), and `|$blob32`
+  slipping the buffer instead of its elements (so the digest render numified the
+  whole Blob to 0 and emitted four zero bytes).
 
-    blob8.new: map |*.polymod(256 xx 3),
-      |reduce -> blob32 $h, @words { blob32.new: [Z+] map {$_[[^5].rotate(++$)]},
-                                      $h, |await map -> [&f, $r, @K, $s] { start {...} }, ... }
-
-i.e. the `start`/`await` fan-out, the `[Z+]` reduction over five-element rotations,
-or `map |*.polymod(256 xx 3)` slipping. Not yet reduced.
+`rmd160` now returns the correct digest for every RFC vector — but only for the
+**first** call in a process. Its output stage rotates the five hash words with
+`map { $_[[^5].rotate(++$)] }`, and mutsu never resets an anonymous `$` state
+variable when its enclosing routine is re-entered, so later calls in the same
+process rotate by the wrong amount and return a correct-but-rotated digest. That
+is an independent bug with its own minimal repro:
+`todo/tickets/anonymous-state-var-not-reset-per-routine-call.md`. Fixing it should
+take `t/ripemd.t` to a full pass (its `'a' x 1_000_000` vector is slow in a debug
+build — use a release binary).
 
 ## 3. `sha512` / `sha384` return an empty digest
 

--- a/todo/tickets/shared-var-lane-freezes-a-reused-array-name.md
+++ b/todo/tickets/shared-var-lane-freezes-a-reused-array-name.md
@@ -1,0 +1,48 @@
+# The `@`/`%` shared-var lane freezes a name once two bindings reuse it
+
+The name-keyed `shared_vars` store (`src/runtime/shared_store.rs`) is what keeps
+a parent and a `start` worker on ONE array object, and `@`/`%` names stay on it
+by design (`docs/recursive-start-shared-vars.md`). But it is keyed by the bare
+name and seeded once (`seed_if_absent`), so it cannot represent two
+*concurrently-live* bindings of one name. When a second, unrelated binding of the
+same `@` name later feeds a spawn, the worker reads the first one:
+
+```raku
+say (await map -> [$a, @K] { start { "$a:{@K[0]}" } }, (1, (100,101)), (2, (200,201))).join('|');
+say (await map -> @K       { start { @K[0] } },        (300, 301), (400, 401)).join('|');
+# raku:  1:100|2:200   then  300|400
+# mutsu: 1:100|2:200   then  100|100      <- the second line reads the FIRST line's @K
+```
+
+The second line is correct on its own (`300|400`) and correct with a different
+name (`@P`). It only breaks after some earlier binding has already seeded `@K`.
+The `$`-sigil case does not have this problem: those names were taken off the
+lane entirely and given a per-binding home (PLAN.md §6).
+
+The destructuring-sub-signature half of this was fixed in
+`news/2026-08/start-block-destructured-array-param.md` by keeping *those*
+bindings off the lane (they are provably per-invocation). What remains is the
+general case: two ordinary bindings of one `@` name, at least one of which is
+captured by a spawned block.
+
+## Why it is large
+
+The real fix is the one `docs/recursive-start-shared-vars.md` defers: give
+`@`/`%` captures a per-binding home like `$` has, instead of the bare-name lane.
+That is blocked on the `__mutsu_atomic_*` CAS copies, which are keyed off these
+very entries, and on `push_to_shared_var` / the element-assign write-throughs,
+which decide "is this name genuinely shared?" by *presence* in the store. Pinning
+`t/concurrency-threading.t` test 4 (`my $c = Channel.new; start { $c.send(42) }`)
+showed the same lane is load-bearing for non-`$` shapes that
+`box_captured_lexicals` declines to box.
+
+A narrower stopgap would be to make each *fresh binding* of an `@`/`%` name
+`declare` into the current lineage (shadowing the ancestor entry) rather than
+leaving the stale one visible — the mechanism `thread_redeclared_vars` already
+uses for `my`. That was tried for the sub-signature case and moved the error
+rather than removing it: the lane then holds the *latest* binding, so an earlier
+still-running worker reads the newer value.
+
+## Minimal repro
+
+The two-line program above. Reproduces deterministically; no timing involved.


### PR DESCRIPTION
Two more general bugs from grondilu's `Digest::RIPEMD`. With them, `rmd160`
computes the correct RIPEMD-160 digest for every RFC test vector. Write-up in
`news/2026-08/start-block-destructured-array-param.md`.

### 1. A destructured `@`/`%` parameter was frozen at the first spawn's value

```raku
await map -> [$a, @K] { start { "$a:{@K[0]}" } }, (1, (100,101)), (2, (200,201))
# was  1:100, 2:100
# now  1:100, 2:200
```

`@`/`%` lexicals captured by a spawned block are carried by the process-wide,
bare-name-keyed `shared_vars` store rather than by the closure machinery
(`docs/recursive-start-shared-vars.md`: `$` names were moved off that lane and
given a per-binding home; aggregates were deliberately left on it because the
`__mutsu_atomic_*` CAS copies key off those entries). The store is seeded once
per name with `seed_if_absent`, so the first spawn's value is immortal and the
worker prefers it over its own env copy.

A destructuring sub-signature is the one parameter path that writes `env` with no
local slot behind it — every compiled binding path declines a `sub_signature` —
and what it binds is provably a *fresh per-invocation binding*, never the one
shared object the lane exists to represent. Those names are now recorded as they
bind (`Interpreter::sub_signature_bound_aggregates`) and kept off the lane at
spawn, masked in the child exactly as a captured `$` already is.

Two conditions narrow it to that case: the name must be one a sub-signature
bound, **and** the spawned block's free variable must resolve to no parent slot.
So a plain `-> @K` parameter (which republishes from its slot on every call, and
works today) keeps the lane, as do unrelated outer aggregates that merely share a
name — including the `Channel`/`Lock` shapes `box_captured_lexicals` declines to
box.

### 2. `|$buf` slipped the buffer, not its elements

A `Buf`/`Blob` is `Positional`, so `|$buf` slips its elements at the buffer's own
element width. `exec_make_slip_op` had no arm for a buffer instance and fell
through to `_ => vec![val]`:

```raku
my $b = blob32.new(7, 8);
say (1, |$b, 2);   # was (1, Blob[uint32].new(7,8), 2), now (1, 7, 8, 2)
```

`Digest::RIPEMD` renders its digest with `map |*.polymod(256 xx 3), |$reduced`
over a `blob32`, so the `WhateverCode` got the whole Blob and digested a numified
`0` — four zero bytes for every input. A type object (`|Buf`) carries no element
storage and stays one item, as in Rakudo.

### Verification

- `make test` — PASS (2848 files, 27046 tests).
- Locally PASS: 25 whitelisted `roast/S17-{promise,supply}/*.t` (including
  `start.t`, `stress.t`, `lock-async-stress{,2}.t`, `nonblocking-await.t`),
  `S07-slip/slip.t`, `S32-container/buf.t`, `S03-buf/write-int.t`,
  `S03-operators/buf.t`.
- Two new pins, both verified to pass under `raku`:
  `t/start-block-destructured-array-param.t`, `t/slip-a-buf.t`.

### Recorded, not fixed

- `todo/tickets/anonymous-state-var-not-reset-per-routine-call.md` — mutsu never
  resets an anonymous `$` state variable when its enclosing routine is
  re-entered (`sub f() { (map { ++$ }, 1,2,3).join(',') }` gives `4,5,6` on the
  second call). This is the last thing between `rmd160` and a full `t/ripemd.t`:
  its output stage rotates the hash words with `map { $_[[^5].rotate(++$)] }`, so
  only the first call in a process is correct. A named `state` in the same
  position already resets correctly.
- `todo/tickets/shared-var-lane-freezes-a-reused-array-name.md` — the general
  form of bug 1 (two ordinary bindings of one `@` name, one captured by a spawn).
  Pre-existing; needs the per-binding home the design doc defers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)