### PR TITLE
fix(types): `Instant` and `Duration` are `Cool` types that do `Real`

### DIFF
--- a/news/2026-08/instant-and-duration-do-real.md
+++ b/news/2026-08/instant-and-duration-do-real.md
@@ -1,0 +1,52 @@
+# `Instant` and `Duration` are `Cool` types that `does Real`
+
+rakudo's `Instant.^mro` is `((Instant) (Cool) (Any) (Mu))`, and both `Instant`
+and `Duration` `does Real` — so `now ~~ Numeric`, `now ~~ Real` and `now ~~ Cool`
+are all `True`, and `Real.abs` applies to both.
+
+mutsu had `Duration` under `Real` alone, and neither type under `Numeric` or
+`Cool`. That is not academic. `Test.rakumod` declares its `is-approx` candidates
+as `is-approx(Numeric $got, Numeric $expected, …)`, so
+
+```raku
+is-approx $*INIT-INSTANT, $manual-init-time, :abs-tol(5), "..."
+```
+
+matched **none** of them and fell through to mutsu's native `Test` provider,
+which keeps its own counter. The test count reset mid-file, and the module's
+`END` plan check then failed on a file that had emitted every assertion:
+
+```
+ok 1 - $*INIT-INSTANT is defined
+ok 2 -    ... and is-a type Instant
+ok 1 -    ... of approximately correct value      <- native provider's counter
+# You planned 3 tests, but ran 2
+```
+
+Both types now match `Numeric` / `Real` / `Cool`.
+
+## `.abs`, which the type relation immediately needed
+
+Adding the relation alone made `instants-and-durations.t` *worse* (38 assertions
+down to 3): the right `is-approx` candidate was finally selected, and it died on
+`No such method 'abs' for invocant of type 'Instant'`, because `.abs` came from
+`Real` and mutsu's `Real` methods never reached these types.
+
+`Real.abs` is `self < 0 ?? -self !! self` on the value itself, so it **keeps the
+type** — `Instant.abs` is an `Instant`, `Duration.abs` a `Duration`. Both store
+their seconds as a Real `value` attribute (the same shape the existing `.Rat` /
+`.Int` arms coerce), so the implementation recurses into that and rebuilds the
+instance.
+
+`roast/S28-named-variables/init-instant.t` (3) and
+`roast/S02-types/instants-and-durations.t` (36) now pass under
+`MUTSU_REAL_TEST=1`. `roast/S32-num/real-bridge.t` moves from 195 to 195-of-201
+with a different remaining gap.
+
+Pin: `t/instant-duration-do-real.t` — without the change it fails 5 of the 6
+assertions it reaches and then dies on `.abs`; all 12 pass under `raku`.
+
+**Measure the whole file, not the first failure, when widening a type
+relation.** The count going 38 → 3 was the signal that the relation had unmasked
+a missing method rather than fixed anything; a "first `not ok`" check would have
+shown nothing, because the file aborted before asserting.

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -213,6 +213,27 @@ pub(super) fn dispatch(
                 ValueView::BigRat(n, d) => Value::bigrat(n.magnitude().clone().into(), d.clone()),
                 ValueView::Complex(r, i) => Value::num((r * r + i * i).sqrt()),
                 ValueView::Bool(b) => Value::int(if b { 1 } else { 0 }),
+                // `Instant`/`Duration` `does Real`, so `Real.abs` applies — and
+                // it keeps the type (`Instant.abs` is an `Instant`,
+                // `Duration.abs` a `Duration`), because rakudo's `Real.abs`
+                // is `self < 0 ?? -self !! self` on the value itself. They store
+                // their seconds as a Real `value` attribute, the same shape the
+                // `.Rat`/`.Int` arms coerce.
+                ValueView::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } if matches!(class_name.resolve().as_str(), "Duration" | "Instant") => {
+                    let inner = attributes.as_map().get("value")?.clone();
+                    let abs_inner = match dispatch(&inner, "abs") {
+                        Some(Some(Ok(v))) => v,
+                        Some(Some(Err(e))) => return Some(Some(Err(e))),
+                        _ => return Some(None),
+                    };
+                    let mut attrs = attributes.as_map().clone();
+                    attrs.insert("value".to_string(), abs_inner);
+                    Value::make_instance(class_name, attrs)
+                }
                 _ => return Some(None),
             };
             Some(Some(Ok(result)))

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -125,11 +125,26 @@ impl Interpreter {
         if constraint == "Str" && value_type == "str" {
             return true;
         }
-        // Numeric hierarchy: Int is a Numeric, Num is a Numeric
+        // Numeric hierarchy: Int is a Numeric, Num is a Numeric.
+        // `Instant`/`Duration` belong here too -- rakudo's are `Cool` types that
+        // `does Real` (`Instant.^mro` is `((Instant) (Cool) (Any) (Mu))`), so
+        // `now ~~ Numeric` is True. Leaving them out meant an `is-approx $a, $b`
+        // over two Instants matched none of `Test.rakumod`'s
+        // `is-approx(Numeric, Numeric, ...)` candidates and fell through to
+        // mutsu's native provider, which keeps its own counter -- the test count
+        // reset mid-file (roast/S28-named-variables/init-instant.t).
         if constraint == "Numeric"
             && matches!(
                 value_type,
-                "Int" | "Num" | "Rat" | "FatRat" | "Complex" | "Bool" | "UInt"
+                "Int"
+                    | "Num"
+                    | "Rat"
+                    | "FatRat"
+                    | "Complex"
+                    | "Bool"
+                    | "UInt"
+                    | "Instant"
+                    | "Duration"
             )
         {
             return true;
@@ -137,7 +152,7 @@ impl Interpreter {
         if constraint == "Real"
             && matches!(
                 value_type,
-                "Int" | "Num" | "Rat" | "FatRat" | "Bool" | "UInt" | "Duration"
+                "Int" | "Num" | "Rat" | "FatRat" | "Bool" | "UInt" | "Instant" | "Duration"
             )
         {
             return true;
@@ -188,6 +203,8 @@ impl Interpreter {
                     | "Map"
                     | "Range"
                     | "Seq"
+                    | "Instant"
+                    | "Duration"
             )
         {
             return true;

--- a/t/instant-duration-do-real.t
+++ b/t/instant-duration-do-real.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# rakudo's `Instant` and `Duration` are `Cool` types that `does Real`
+# (`Instant.^mro` is `((Instant) (Cool) (Any) (Mu))`), so `now ~~ Numeric` is
+# True and `Real.abs` applies to both -- keeping the type, because it is
+# `self < 0 ?? -self !! self` on the value itself.
+#
+# mutsu had `Duration` under `Real` only, and neither under `Numeric` or `Cool`.
+# That is not academic: `is-approx $a, $b, :abs-tol(5)` over two Instants matched
+# NONE of the real `Test.rakumod`'s `is-approx(Numeric, Numeric, ...)`
+# candidates and fell through to mutsu's native provider, which keeps its own
+# counter -- so the test count reset mid-file and the plan check failed on a file
+# that had emitted every assertion (roast/S28-named-variables/init-instant.t).
+
+plan 12;
+
+my $i = now;
+my $d = now - now;
+
+ok $i ~~ Numeric, 'an Instant is Numeric';
+ok $i ~~ Real,    'an Instant is Real';
+ok $i ~~ Cool,    'an Instant is Cool';
+ok $d ~~ Numeric, 'a Duration is Numeric';
+ok $d ~~ Real,    'a Duration is Real';
+ok $d ~~ Cool,    'a Duration is Cool';
+
+isa-ok $i.abs, Instant,  '.abs on an Instant keeps the type';
+isa-ok $d.abs, Duration, '.abs on a Duration keeps the type';
+
+my $neg = Duration.new(-42);
+is $neg.abs.Int, 42, '.abs on a negative Duration is its magnitude';
+isa-ok $neg.abs, Duration, '...and still a Duration';
+
+# A Numeric-constrained routine accepts them -- the shape that made the real
+# Test module fall through to the native provider.
+sub takes-numeric(Numeric $x, Numeric $y) { 'matched' }
+is takes-numeric($i, $i), 'matched', 'a Numeric-constrained sub accepts Instants';
+is takes-numeric($d, $d), 'matched', '...and Durations';


### PR DESCRIPTION
## What

rakudo's `Instant.^mro` is `((Instant) (Cool) (Any) (Mu))` and both `Instant` and `Duration` `does Real`, so `now ~~ Numeric`, `~~ Real` and `~~ Cool` are all `True` and `Real.abs` applies. mutsu had `Duration` under `Real` alone, and neither type under `Numeric` or `Cool`.

That is not academic. `Test.rakumod` declares its candidates as `is-approx(Numeric $got, Numeric $expected, …)`, so

```raku
is-approx $*INIT-INSTANT, $manual-init-time, :abs-tol(5), "..."
```

matched **none** of them and fell through to mutsu's native `Test` provider, which keeps its own counter:

```
ok 1 - $*INIT-INSTANT is defined
ok 2 -    ... and is-a type Instant
ok 1 -    ... of approximately correct value      <- native provider's counter
# You planned 3 tests, but ran 2
```

## `.abs`, which the relation immediately needed

Adding the type relation alone made `instants-and-durations.t` **worse** — 38 assertions down to 3 — because the right `is-approx` candidate was finally selected and died on `No such method 'abs' for invocant of type 'Instant'`.

`Real.abs` is `self < 0 ?? -self !! self` on the value itself, so it **keeps the type** (`Instant.abs` is an `Instant`). Both store their seconds as a Real `value` attribute — the same shape the existing `.Rat`/`.Int` arms coerce — so the implementation recurses into that and rebuilds the instance.

## Verification

- `roast/S28-named-variables/init-instant.t` (3) and `roast/S02-types/instants-and-durations.t` (36) now pass under `MUTSU_REAL_TEST=1`. `roast/S32-num/real-bridge.t` keeps its 195 and has a different remaining gap.
- `t/instant-duration-do-real.t` — new pin; without the change it fails **5 of the 6** assertions it reaches and then dies on `.abs`; all 12 pass under `raku`.
- `make test` PASS (2849 files), release `make roast` PASS (1435 files), bundled-library gate PASSED.

Worth recording: **measure the whole file, not the first failure, when widening a type relation.** The count going 38 → 3 was the signal that the relation had unmasked a missing method; a "first `not ok`" check would have shown nothing, because the file aborted before asserting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)