### PR TITLE
docs(todo): record why the obvious anonymous-state fix does not work

### DIFF
--- a/todo/tickets/anonymous-state-var-not-reset-per-routine-call.md
+++ b/todo/tickets/anonymous-state-var-not-reset-per-routine-call.md
@@ -36,6 +36,48 @@ process-wide `state_vars` map. Named `state` instead goes through
 identity. The readers are `vm_exec_dispatch.rs` (the `__ANON_STATE__` fast path),
 `vm_misc_coerce.rs`, `vm_var_assign_post_incdec.rs` and `vm_var_assign_typed.rs`.
 
+## The scope rule, and what it has to preserve
+
+The counter belongs to the **innermost enclosing block's clone**. A named sub's
+body is cloned once (at registration), so a bare `$` directly in a sub body
+*persists* across calls; a `map`/`for` block inside it is cloned per call, so a
+`$` there *resets*. Both directions are load-bearing:
+
+| shape | raku | must |
+|---|---|---|
+| `sub f { my $x = ++$; $x }` x3 | `1,2,3` | persist (`roast/S02-types/whatever.t:486`) |
+| `sub k() { $c = ++$ for ^3; $c }` x2 | `3,6` | persist (statement modifier, no block) |
+| `my $blk = { ++$ }` x3 | `1,2,3` | persist (one clone) |
+| `method m { $++ }` x3 | `0,1,2` | persist (`roast/S32-list/rotor.t:68`) |
+| `[ $++ xx 3 ] xx 3` | `0..8` | persist (`roast/S04-statements/gather.t:242`) |
+| `while $++ < 3` | - | persist across iterations |
+| `sub f() { map { ++$ }, 1,2,3 }` x2 | `1,2,3` twice | **reset** |
+| `sub g() { for ^3 { ... ++$ } }` x2 | `1,2,3` twice | **reset** |
+
+## A tried-and-rejected fix (2026-08-04)
+
+Routing `anon_state_key` through `Interpreter::scoped_state_key` — the clone-id
+scoping a named `state` uses — plus resolving these names *only* from the state
+store (their `env` entry is global via `GetGlobal`/`SetGlobal`, so it outlives
+the clone and was being found first) fixes every reset row above and keeps the
+one-clone, method, `xx`-thunk, `while` and grid rows. **But it breaks the two
+named-sub persistence rows:** `sub f { my $x = ++$; $x }` yields `1,1,2` and the
+statement-modifier `for` yields `3,3`. The `1,1,2` shape says `state_scope_id`
+alternates between two values across successive calls of one named sub when read
+*mid-body* — a named `state` in the same position is unaffected because it only
+consults the id at the call boundaries (`load_state_locals` /
+`sync_state_locals`), never inside the body.
+
+So `state_scope_id` is not a reliable mid-body lever. The remaining route is the
+structural one: give the anonymous form a real local slot and a `state_locals`
+entry at its innermost enclosing block, so it uses exactly the named-`state`
+machinery. That needs, at minimum: an `is_non_lexical_name` exclusion in
+`src/opcode.rs` (otherwise the name becomes a closure-capture candidate and a
+captured snapshot races the store), an initializer that yields `Any` rather than
+`Nil` (`roast/S03-operators/context.t:87`), and a decision about
+`src/vm/vm_call_eligibility.rs`, whose fast/light call paths are gated on
+`state_locals.is_empty()` — every sub containing a bare `$` would lose them.
+
 ## Why it matters
 
 Found as the last remaining wrong-digest cause in grondilu's `Digest::RIPEMD`


### PR DESCRIPTION
Follow-up to #5852, which left
`todo/tickets/anonymous-state-var-not-reset-per-routine-call.md` as the last
thing between `Digest::RIPEMD`'s `rmd160` and a full `t/ripemd.t` pass.

I attempted the obvious fix and it does not hold. Rather than leave that finding
in a session log, this records it in the ticket:

- **What was tried:** route `anon_state_key` through
  `Interpreter::scoped_state_key` (the clone-id scoping a named `state` already
  uses), and resolve bare-`$` names *only* from the state store — their `env`
  entry is global (`GetGlobal`/`SetGlobal`), so it outlives the block clone that
  owns the counter and was being found first.
- **What it fixed:** every shape that must reset (`sub f() { map { ++$ }, 1,2,3 }`
  and the `for`-block form), while keeping the one-clone, method, `xx`-thunk,
  `while` and `[ $++ xx 3 ] xx 3` shapes.
- **Why it was reverted:** it breaks the two shapes that must *persist*.
  `sub f { my $x = ++$; $x }` yields `1,1,2` instead of `1,2,3`, and a
  statement-modifier `for` stops accumulating. The `1,1,2` pattern says
  `state_scope_id` alternates between two values across successive calls of one
  named sub when read **mid-body**; a named `state` in the same position is
  unaffected because it consults the id only at the call boundaries
  (`load_state_locals` / `sync_state_locals`), never inside the body.

The ticket now also carries the full table of shapes the fix has to preserve in
each direction (with the roast files that pin them), and names the remaining
route — give the anonymous form a real local slot and a `state_locals` entry at
its innermost enclosing block — together with its three known prerequisites: an
`is_non_lexical_name` exclusion in `src/opcode.rs`, an `Any` (not `Nil`)
initializer, and a decision about `src/vm/vm_call_eligibility.rs`, whose
fast/light call paths are gated on `state_locals.is_empty()`.

Documentation only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)