### PR TITLE
refactor(compiler): bind sub plans to compiled routines

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -142,8 +142,10 @@ each instruction.
 Stage 1 is in progress. `RegisterSub` now indexes a typed `CompiledSubDeclPlan` pool rather than
 `CompiledCode::stmt_pool`; all normal, hoisted, nested-`our`, and top-level-method lowering sites use
 the plan, and the VM no longer pattern-matches `Stmt::SubDecl`. The plan still carries
-`legacy_body` for the existing routine-registry adapter. Replacing that field with the compiled
-routine reference is the next declaration slice.
+`legacy_body` for the existing routine-registry adapter. Source-order sub plans now also carry the
+stable keys of their primary and alternate compiled routines. The next adapter slice preserves
+that association across module import and installs `FunctionDef` candidates through those
+references before removing `legacy_body`.
 
 `RegisterClass` and `RegisterRole` now likewise index typed class/role declaration-plan pools for
 both source-order declarations and hoisted forward-reference shells. The VM no longer discovers

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -103,7 +103,7 @@ impl Compiler {
         state_group: Option<&str>,
         is_rw: bool,
         is_raw: bool,
-    ) {
+    ) -> Option<crate::symbol::Symbol> {
         self.compile_sub_body_with_deprecation(
             name,
             params,
@@ -115,7 +115,7 @@ impl Compiler {
             is_rw,
             is_raw,
             None,
-        );
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -131,7 +131,7 @@ impl Compiler {
         is_rw: bool,
         is_raw: bool,
         deprecated_info: Option<(String, String, String, String)>,
-    ) {
+    ) -> Option<crate::symbol::Symbol> {
         // Before compiling the sub body, check for heredoc interpolations
         // that reference variables not visible at the outer scope (where the
         // heredoc terminator physically appears in Raku).
@@ -139,7 +139,7 @@ impl Compiler {
             let idx = self.code.add_constant(err);
             self.code.emit(OpCode::LoadConst(idx));
             self.code.emit(OpCode::Die);
-            return;
+            return None;
         }
         let sink_last_expr = return_type
             .map(|s| Self::is_definite_return_spec(s))
@@ -523,8 +523,9 @@ impl Compiler {
             });
             self.code.escaping_our_sub_captures.push(esc);
         }
-        self.compiled_functions
-            .insert(crate::symbol::Symbol::intern(&key), cf);
+        let key = crate::symbol::Symbol::intern(&key);
+        self.compiled_functions.insert(key, cf);
+        Some(key)
     }
 
     fn compile_routine_body_stmts(

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -38,9 +38,16 @@ mod declaration_plan_tests {
     fn sub_declarations_leave_the_generic_statement_pool() {
         let (stmts, _) = crate::parse_dispatch::parse_source("sub f($x) { $x + 1 }; f(2)")
             .expect("source parses");
-        let (code, _) = Compiler::new().compile(&stmts);
+        let (code, compiled_fns) = Compiler::new().compile(&stmts);
 
         assert!(!code.sub_decl_plans.is_empty());
+        let plan = code
+            .sub_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "f" && !plan.compiled_routine_keys.is_empty())
+            .expect("source-order f declaration plan");
+        assert_eq!(plan.compiled_routine_keys.len(), 1);
+        assert!(compiled_fns.contains_key(&plan.compiled_routine_keys[0]));
         assert!(
             code.stmt_pool
                 .iter()

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3083,7 +3083,8 @@ impl Compiler {
                 // captures are boxed + persisted (escaping_our_sub_captures).
                 let prev_our = self.compiling_our_sub;
                 self.compiling_our_sub = custom_traits.iter().any(|(t, _)| t == "__our_scoped");
-                self.compile_sub_body_with_deprecation(
+                let mut compiled_routine_keys = Vec::new();
+                if let Some(key) = self.compile_sub_body_with_deprecation(
                     &name_str,
                     params,
                     param_defs,
@@ -3094,10 +3095,12 @@ impl Compiler {
                     *is_rw,
                     *is_raw,
                     deprecated_info.clone(),
-                );
+                ) {
+                    compiled_routine_keys.push(key);
+                }
                 self.compiling_our_sub = prev_our;
                 for (alt_params, alt_param_defs) in signature_alternates {
-                    self.compile_sub_body_with_deprecation(
+                    if let Some(key) = self.compile_sub_body_with_deprecation(
                         &name_str,
                         alt_params,
                         alt_param_defs,
@@ -3108,8 +3111,12 @@ impl Compiler {
                         *is_rw,
                         *is_raw,
                         deprecated_info.clone(),
-                    );
+                    ) {
+                        compiled_routine_keys.push(key);
+                    }
                 }
+                self.code
+                    .set_sub_decl_compiled_routine_keys(idx, compiled_routine_keys);
             }
             Stmt::MethodDecl {
                 name,
@@ -3153,17 +3160,22 @@ impl Compiler {
                         "?ROLE".to_string(),
                     ];
                     method_params.extend(params.iter().cloned());
-                    self.compile_sub_body(
-                        &name.resolve(),
-                        &method_params,
-                        param_defs,
-                        return_type.as_ref(),
-                        body,
-                        *multi,
-                        None,
-                        *is_rw,
-                        false,
-                    );
+                    let compiled_routine_keys = self
+                        .compile_sub_body(
+                            &name.resolve(),
+                            &method_params,
+                            param_defs,
+                            return_type.as_ref(),
+                            body,
+                            *multi,
+                            None,
+                            *is_rw,
+                            false,
+                        )
+                        .into_iter()
+                        .collect();
+                    self.code
+                        .set_sub_decl_compiled_routine_keys(idx, compiled_routine_keys);
                 }
             }
             Stmt::TokenDecl { .. } | Stmt::RuleDecl { .. } => {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1857,6 +1857,11 @@ pub(crate) struct CompiledSubDeclPlan {
     pub(crate) return_type: Option<String>,
     pub(crate) associativity: Option<String>,
     pub(crate) signature_alternates: Vec<(Vec<String>, Vec<ParamDef>)>,
+    /// Stable keys of the bytecode routines compiled for the primary signature
+    /// and its alternates. The compiler keeps this association explicit; the
+    /// next adapter slice preserves it while importing modules and installs
+    /// through these keys directly.
+    pub(crate) compiled_routine_keys: Vec<Symbol>,
     /// Compatibility payload for the routine registry. Method bodies already execute from
     /// `CompiledFunction`; this AST is removed when the registry adapter is retired in ADR-0019
     /// stage 1.
@@ -4793,6 +4798,7 @@ impl CompiledCode {
             return_type: return_type.clone(),
             associativity: associativity.clone(),
             signature_alternates: signature_alternates.clone(),
+            compiled_routine_keys: Vec::new(),
             legacy_body: body.clone(),
             multi: *multi,
             is_rw: *is_rw,
@@ -4807,6 +4813,14 @@ impl CompiledCode {
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Sub(plan_idx));
         idx
+    }
+
+    pub(crate) fn set_sub_decl_compiled_routine_keys(&mut self, decl_idx: u32, keys: Vec<Symbol>) {
+        let Some(CompiledDeclPlanRef::Sub(plan_idx)) = self.decl_plans.get(decl_idx as usize)
+        else {
+            panic!("declaration plan is not a sub");
+        };
+        self.sub_decl_plans[*plan_idx as usize].compiled_routine_keys = keys;
     }
 
     pub(crate) fn add_class_decl_plan(&mut self, stmt: &Stmt) -> u32 {

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -197,6 +197,7 @@ impl Interpreter {
             return_type,
             associativity,
             signature_alternates,
+            compiled_routine_keys: _,
             legacy_body: body,
             multi,
             is_rw,


### PR DESCRIPTION
## Problem

ADR-0019 sub declaration plans still have no explicit association with the bytecode routines compiled from their primary and alternate signatures. The next adapter step would otherwise need to rediscover those routines by reconstructing name/signature keys.

## Approach

- Return the stable compiled-function key from sub-body compilation.
- Store primary and alternate keys on the source-order `CompiledSubDeclPlan`.
- Keep hoisted shell plans keyless until their source-order declaration is compiled.
- Pin the plan-to-compiled-function association in compiler tests and update ADR-0019 status.

## Test evidence

- `cargo test declaration_plan_tests --lib`
- 9 targeted sub/multi/EVAL TAP files: 97 tests passed
- `cargo test --test mzef_shim`: 3 passed
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `make test` was run once; its only failure was the initial over-strict module-import validation caught by `mzef_shim`. That validation was removed and the failing `mzef_shim` target then passed.