### PR TITLE
fix(parser): a `*.method` value keeps its braces a hash composer

### DIFF
--- a/news/2026-08/whatever-code-value-keeps-a-hash-composer.md
+++ b/news/2026-08/whatever-code-value-keeps-a-hash-composer.md
@@ -1,0 +1,24 @@
+# A `*.method` value keeps its braces a hash composer
+
+`{ :status(*.so) }` composed a `Block`, not a `Hash`. The brace-disambiguation
+scan in `src/parser/primary/misc/lambda.rs` treats an invocant-less method call
+as a topic reference — `{ a => .key }` really is a block — and it decided
+"invocant-less" by looking at the byte before the dot. A `*` was not in the list
+of things a term can end with, so the `.so` of `*.so` read as `$_.so` and forced
+the block branch. Any `*.method` inside braces was affected: `{ s => *.abs }`,
+`{ :err(/Sub/), :status(*.so) }`, and so on.
+
+The star is genuinely ambiguous from that position, because infix
+multiplication is spelled the same way: `{ a => 2 * .elems }` *is* a block, and
+its `.elems` *is* on the topic. So the fix does not simply add `*` to the
+term-enders — it walks back past the star (and past a `**` HyperWhatever) and
+asks what precedes it. A term there means the star is an infix and the call is a
+topic call; anything else — `(`, `,`, `=>`, the start of the body — means the
+star is a Whatever and is itself the invocant.
+
+Found under the real `Test` module. `roast/S24-testing/11-plan-skip-all-subtests.t`
+passes `{:err(/Sub/), :status(*.so)}` to `Test::Util`'s `is_run`, and with the
+hash arriving as a `Block` the multi-dispatch picked the no-test-name candidate,
+so the assertion lost its description and, because that candidate's `ok` fell
+through to mutsu's native provider, the file's own counter stopped at 2 of 4.
+The file now matches `raku` byte for byte. Pin: `t/hash-literal-whatever-value.t`.

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -523,6 +523,26 @@ fn is_implicit_topic_call(bytes: &[u8], at: usize) -> bool {
         // `$!.message` is a term even though it ends in punctuation; a bare `!`
         // is prefix negation (`{ a => !.defined }` is a block).
         b'!' => !matches!(p.checked_sub(2).map(|q| bytes[q]), Some(b'$')),
+        // `*.abs` / `**.abs` curries the Whatever, which *is* the invocant, so
+        // `{ :s(*.abs) }` stays a hash. Infix multiplication is spelled the same
+        // way from here (`{ a => 2 * .elems }` is a block), so decide on what
+        // precedes the star: a term there makes it an infix and the call a
+        // topic call.
+        b'*' => {
+            let mut q = p - 1;
+            while q > 0 && bytes[q - 1] == b'*' {
+                q -= 1;
+            }
+            while q > 0 && bytes[q - 1].is_ascii_whitespace() {
+                q -= 1;
+            }
+            match q.checked_sub(1).map(|s| bytes[s]) {
+                None => false,
+                Some(b')' | b']' | b'}' | b'\'' | b'"') => true,
+                Some(b'>') => !matches!(q.checked_sub(2).map(|s| bytes[s]), Some(b'=')),
+                Some(c) => c.is_ascii_alphanumeric() || c == b'_',
+            }
+        }
         // A `/` right before the dot closes a term far more often than it
         // divides by one: it ends `$/`, a quoting construct (`q:to/EOF/.trim`,
         // `q/x/.uc`) or a regex literal (`/rx/.gist`). Infix division, on the

--- a/t/hash-literal-whatever-value.t
+++ b/t/hash-literal-whatever-value.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 10;
+
+# `{ :name(*.method) }` is a hash: the Whatever is the method call's invocant,
+# so `.method` is not an implicit-topic call and does not force a block.
+is {:s(*.abs)}.WHAT.^name, 'Hash', 'colon pair with a WhateverCode value is a hash';
+is {s => *.abs}.WHAT.^name, 'Hash', 'fatarrow with a WhateverCode value is a hash';
+is {:err(/Sub/), :status(*.so)}.WHAT.^name, 'Hash',
+    'a WhateverCode alongside another pair still composes a hash';
+
+my $h = {:status(*.so), :out('x')};
+ok $h<status> ~~ Callable, 'the WhateverCode survives as the value';
+ok $h<status>.(1), 'and it is callable';
+is $h<out>, 'x', 'the sibling pair is intact';
+
+# Infix multiplication is spelled the same way from the dot, and there the call
+# really is on the topic, so these stay blocks.
+is {a => 2 * .elems}.WHAT.^name, 'Block', 'infix `*` before a topic call is a block';
+my $n = 2;
+is {a => $n * .elems}.WHAT.^name, 'Block', 'a variable operand does not change that';
+
+# Unrelated invocants keep working.
+is {:s(1.abs)}.WHAT.^name, 'Hash', 'a literal invocant is a hash';
+is {a => .key}.WHAT.^name, 'Block', 'a bare implicit-topic call is still a block';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -731,6 +731,15 @@ since an abort costs a whole file:
 `S29-context/die.t`, `S32-io/io-path.t`, `S32-num/{complex,real-bridge}.t`,
 `S32-temporal/DateTime.t`.
 
+`S24-testing/11-plan-skip-all-subtests.t` is closed
+(`news/2026-08/whatever-code-value-keeps-a-hash-composer.md`): `{:err(/Sub/),
+:status(*.so)}` composed a *Block*, because the brace disambiguator read the
+`.so` of `*.so` as an implicit-topic call. `Test::Util`'s `is_run` then matched
+its no-test-name candidate, which lost the description and answered through the
+native provider's separate counter. **A "plan mismatch plus a blank
+description" is worth checking against the argument's own type before looking at
+`Test` at all.**
+
 `roast/S12-methods/qualified.t` is worth a second look too: its Malformed
 assertion passes now and the file moved on to `Cannot dispatch to method me on
 Parent because it is not inherited or done by Bar` in its inheritance subtest.


### PR DESCRIPTION
`{ :status(*.so) }` composed a `Block`, not a `Hash`. The brace-disambiguation scan in `src/parser/primary/misc/lambda.rs` treats an invocant-less method call as a topic reference — `{ a => .key }` really is a block — and it decided "invocant-less" by looking at the byte before the dot. A `*` was not in the list of things a term can end with, so the `.so` of `*.so` read as `$_.so` and forced the block branch. Any `*.method` inside braces was affected.

The star is genuinely ambiguous from that position, because infix multiplication is spelled the same way: `{ a => 2 * .elems }` *is* a block and its `.elems` *is* on the topic. So the fix does not simply add `*` to the term-enders — it walks back past the star (and past a `**` HyperWhatever) and asks what precedes it. A term there means the star is an infix and the call is a topic call; anything else (`(`, `,`, `=>`, the start of the body) means the star is a Whatever and is itself the invocant.

Found under the real `Test` module. `roast/S24-testing/11-plan-skip-all-subtests.t` passes `{:err(/Sub/), :status(*.so)}` to `Test::Util`'s `is_run`; with the hash arriving as a `Block` the multi-dispatch picked the no-test-name candidate, so the assertion lost its description and, because that candidate's `ok` fell through to mutsu's native provider, the file's own counter stopped at 2 of 4. The file now matches `raku` byte for byte.

Pin: `t/hash-literal-whatever-value.t` (all ten assertions verified against `raku`).

Verified locally: `make roast` PASS (1435 files), `make test` PASS (2853 files), batteries gate PASSED, `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)