### PR TITLE
fix: a buf64 element assignment saturated at i64::MAX

### DIFF
--- a/news/2026-08/buf-wide-element-assign-saturation.md
+++ b/news/2026-08/buf-wide-element-assign-saturation.md
@@ -1,0 +1,32 @@
+# A `buf64` element assignment saturated at `i64::MAX`
+
+`Digest::SHA2`'s `sha512`/`sha384` returned the wrong digest. The constants, the
+padding and every round primitive checked out against raku; a per-round trace of
+the 80-round compression showed the message schedule going wrong at `t = 25`,
+with `$w[25]` reading back as `7FFFFFFFFFFFFFFF` — `i64::MAX`, a saturation
+marker, not a plausible SHA word.
+
+The buffer write paths all mask an element to the node's own width on the way
+in, and `elem_to_u64` deliberately routes a `BigInt` through `to_u64` first
+precisely so that a `uint64` element above `i64::MAX` keeps its bits. But the
+`$b[i] = v` and `$b[i, j] = v, w` VM paths converted the value *before* handing
+it over:
+
+    arr[pos] = Value::int(crate::runtime::to_int(&v));
+
+`to_int` saturates a `BigInt` at `i64::MAX`, so by the time `encode_elems` ran
+there was nothing left to mask — every `buf64` element at or above 2**63 became
+`0x7FFF_FFFF_FFFF_FFFF`. The comment on those lines already said the masking was
+`encode_elems`'s job; the pre-conversion was simply redundant *and* lossy. A
+buffer could therefore disagree with itself depending on how it was filled:
+`blob64.new(0xFFFF_FFFF_FFFF_FFFF)` was right, `$b[0] = 0xFFFF_FFFF_FFFF_FFFF`
+was not, and `.splice` and `write-uint64` sat on the correct side too.
+
+The fix stores the value unconverted and lets `encode_elems`/`elem_to_u64` do
+the coercion and the width masking, which is what every other write path already
+does. Narrow buffers are unaffected — a byte still wraps mod 256 — because the
+masking never moved.
+
+`Digest::SHA2` now produces the correct `sha384` and `sha512` digests for the
+NIST vectors, so the `Digest` dist's `t/sha.t` passes its SHA-1 and SHA-2
+subtests in full. Pinned by `t/buf-uint64-element-assign.t`.

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -833,11 +833,13 @@ impl Interpreter {
                             return;
                         }
                         for (i, &pos) in indices.iter().enumerate() {
-                            let v = vals.get(i).cloned().unwrap_or(Value::NIL);
-                            // No `& 0xff` here: encode_elems masks to the
+                            // Stored unconverted: encode_elems masks to the
                             // node's own element width (a Buf[uint64] element
-                            // must keep all 8 bytes).
-                            arr[pos] = Value::int(crate::runtime::to_int(&v));
+                            // must keep all 8 bytes), and its `elem_to_u64`
+                            // does the coercion. Pre-converting with `to_int`
+                            // would saturate a `uint64` element above
+                            // `i64::MAX` at `0x7FFF_FFFF_FFFF_FFFF`.
+                            arr[pos] = vals.get(i).cloned().unwrap_or(Value::NIL);
                         }
                     });
                     if let Some(e) = resize_err {
@@ -856,9 +858,11 @@ impl Interpreter {
                     self.stack.push(Value::array(assigned));
                     return Ok(());
                 } else if let Some(pos) = Self::index_to_usize(&idx) {
-                    // Full-width element value; encode_elems masks to the
-                    // node's element width (Buf[uint64] keeps all 8 bytes).
-                    let elem = Value::int(crate::runtime::to_int(&val));
+                    // Full-width element value, stored unconverted: encode_elems
+                    // masks to the node's element width (Buf[uint64] keeps all
+                    // 8 bytes) and coerces via `elem_to_u64`. Pre-converting
+                    // with `to_int` would saturate an element above `i64::MAX`.
+                    let elem = val.clone();
                     let mut resize_err = None;
                     crate::value::value_buf::with_buf_elems_mut(&attributes, |arr| {
                         if let Err(e) = Self::autoviv_resize(arr, pos + 1, Value::int(0)) {

--- a/t/buf-uint64-element-assign.t
+++ b/t/buf-uint64-element-assign.t
@@ -1,0 +1,61 @@
+use Test;
+
+# Element and slice assignment on a wide buffer used to run the value through
+# `to_int` before storing it, and `to_int` saturates a BigInt at `i64::MAX`. A
+# `buf64` element at or above 2**63 therefore came back as
+# 0x7FFF_FFFF_FFFF_FFFF instead of the value written. `Buf.new` and `.splice`
+# were unaffected — they encode straight from the Value — so a buffer could
+# disagree with itself depending on how it was filled.
+#
+# Found via grondilu's Digest dist: `Digest::SHA2`'s sha512 keeps its message
+# schedule in a `state buf64 $w` and assigns `$w[$t] = ...`, so every schedule
+# word >= 2**63 was clamped and the digest was wrong from round 25 on.
+
+plan 8;
+
+{
+    my buf64 $b .= new(1, 2, 3);
+    $b[1] = 0xFFFFFFFFFFFFFFFF;
+    is $b[1], 0xFFFFFFFFFFFFFFFF, 'buf64 element assignment keeps a full-width uint64';
+    is-deeply $b.list, (1, 0xFFFFFFFFFFFFFFFF, 3), 'the other elements are untouched';
+}
+
+{
+    my buf64 $b .= new(0);
+    $b[0] = 0x8000000000000000;
+    is $b[0], 0x8000000000000000, 'buf64 element assignment keeps a value at exactly 2**63';
+}
+
+{
+    my buf64 $b .= new(1, 2, 3);
+    $b[0, 2] = 0x8000000000000000, 0xFFFFFFFFFFFFFFFF;
+    is-deeply $b.list, (0x8000000000000000, 2, 0xFFFFFFFFFFFFFFFF),
+        'buf64 slice assignment keeps full-width uint64 elements';
+}
+
+{
+    # The element still wraps at its own width, as every other write path does
+    # — the fix removes a premature saturation, not the masking.
+    my buf32 $b .= new(0, 0);
+    $b[0] = 0xFFFFFFFF;
+    $b[1] = 0x1_FFFF_FFFF;
+    is-deeply $b.list, (0xFFFFFFFF, 0xFFFFFFFF), 'buf32 elements keep their full width and mask';
+}
+
+{
+    # A `buf64` filled by `.new` and one filled by element assignment must agree.
+    my buf64 $a .= new(0xDEADBEEFCAFEBABE, 0xFFFFFFFFFFFFFFFF);
+    my buf64 $b .= new(0, 0);
+    $b[0] = 0xDEADBEEFCAFEBABE;
+    $b[1] = 0xFFFFFFFFFFFFFFFF;
+    is-deeply $b, $a, 'element assignment agrees with Buf.new';
+    is $b.gist, $a.gist, 'and so does the gist';
+}
+
+{
+    # Narrow buffers are unchanged.
+    my $b = Buf.new(0, 0);
+    $b[0] = 300;
+    $b[1] = -1;
+    is-deeply $b.list, (44, 255), 'byte buffer element assignment still masks to 0..255';
+}

--- a/todo/tickets/digest-dist-blockers.md
+++ b/todo/tickets/digest-dist-blockers.md
@@ -7,11 +7,13 @@ interpreter bugs found while running it were fixed (see
 `news/2026-08/digest-dist-seven-fixes.md`), then four more that its roast
 fallout exposed (`news/2026-08/digest-dist-followup-four-fixes.md`), then four
 more behind MD5's wrong digest (`news/2026-08/digest-md5-four-fixes.md`).
-`Digest::MD5`, `Digest::SHA1` and `Digest::SHA2`'s `sha224`/`sha256` now produce
-correct digests, and the dist's `t/md5.t` passes in full. Blockers 1
-(`news/2026-08/for-modifier-placeholder-scope.md`) and 4
-(`news/2026-08/named-params-do-not-narrow.md`) are fixed; two remain, each an
-independent general bug.
+`Digest::MD5`, `Digest::SHA1` and all four `Digest::SHA2` digests now come out
+correct, and the dist's `t/md5.t` passes in full. Blockers 1
+(`news/2026-08/for-modifier-placeholder-scope.md`), 3
+(`news/2026-08/buf-wide-element-assign-saturation.md`) and 4
+(`news/2026-08/named-params-do-not-narrow.md`) are fixed. What remains is
+blocker 2's anonymous-`$`-state residue, the `Digest::SHA3` cluster (6), and the
+non-blocking wide-buffer bit accessors (5).
 
 Reproduce with the vendored-in-zef-store copy:
 
@@ -54,15 +56,54 @@ is an independent bug with its own minimal repro:
 take `t/ripemd.t` to a full pass (its `'a' x 1_000_000` vector is slow in a debug
 build — use a release binary).
 
-## 3. `sha512` / `sha384` return an empty digest
+## 3. `sha512` / `sha384` return a wrong digest — FIXED
 
-`sha512("abc")` returns eight zero bytes. The `√` FatRat operator and the
-`blob64` initial-hash constants are correct (verified against raku), so the fault
-is in the block pipeline: `blob64`, `state buf64 $w`, the `$H[]` zen slice, the
-`(8*$data).polymod(256 xx 15).reverse` length encoding, or `map * mod 2**64` over
-a Blob. `sha384` is `sha512` with a different initial hash, so it falls with it.
-(The wide-`Buf` and `polymod` fixes of 2026-08-04 did not move this one; the rest
-of `t/sha.t` — SHA-1, `sha224`, `sha256` — passes.)
+The symptom in the original report ("eight zero bytes") had already moved on by
+the time this was picked up: `sha512("abc")` returned a full 64 bytes, just the
+wrong ones. A per-round trace of the 80-round compression put the divergence at
+`t = 25`, where the message schedule word read back as `7FFFFFFFFFFFFFFF` — an
+`i64::MAX` saturation marker. `$w[$t] = ...` on a `state buf64 $w` ran the value
+through `to_int` before storing it, which saturates a `BigInt`, so every schedule
+word at or above 2**63 was clamped. Fixed by storing the element unconverted and
+letting `encode_elems` do the width masking; see
+`news/2026-08/buf-wide-element-assign-saturation.md`. `sha384`, `sha512` and the
+rest of `t/sha.t`'s SHA-1/SHA-2 subtests now pass.
+
+## 6. `Digest::SHA3` — `samewith` inside a lazy `gather`, and named-only multi dispatch
+
+With SHA-2 fixed, `t/sha.t`'s remaining failure is its SHA-3 subtest, which runs
+zero tests. `Digest::SHA3`'s `Keccak` is a `proto` with five named parameters and
+two `multi`s; the `:$outputByteLen` candidate finishes with
+
+    gather for samewith $inputBytes, :$delimitedSuffix, :$rate, :$capacity { ... }
+
+Calling it directly returns a `Seq` whose reification dies with `samewith called
+outside of a dispatch context` — the enclosing routine's dispatch frame is gone
+by the time the lazy `gather` body runs. Reduced:
+
+    proto f($x, :$n) {*}
+    multi f($x, :$n)  { "base($x)" }
+    multi f($x, :$n!) { gather for samewith($x) { take "$_ x$n" } }
+    say f(3, n => 2).list;   # mutsu: no output at all, exit 0
+
+(mutsu prints nothing — the `say` itself produces no line — so there is a second
+problem in how the failing `gather` is sunk.)
+
+A separate, probably-related dispatch bug shows up with the same signature shape
+when the extra named argument is *omitted*: an all-named candidate set picks the
+wider candidate instead of the exact one.
+
+    proto K($in, :$suffix, :$len, :$rate) {*}
+    multi K($in, :$suffix, :$rate)        { "two: $suffix $rate" }
+    multi K($in, :$suffix, :$len, :$rate) { "three: $suffix $len $rate" }
+    say K(1, suffix => 6, rate => 1152);
+    # raku:  two: 6 1152
+    # mutsu: three: 6  1152   (plus an uninitialized-value warning for $len)
+
+Note this does *not* reproduce once the parameters carry the `byte`/`UInt` types
+and `where` clauses the real `Keccak` proto uses — that variant dispatches
+correctly — so the narrowness comparison is sensitive to something beyond the
+name set. Both are general bugs, neither is a `Digest::SHA2` blocker.
 
 ## 5. `read-ubits` / `write-bits` on a wide buffer
 


### PR DESCRIPTION
## What

`\$b[i] = v` and `\$b[i, j] = v, w` on a storage-backed buffer converted the value with `to_int` before storing it:

```rust
arr[pos] = Value::int(crate::runtime::to_int(&v));
```

`to_int` saturates a `BigInt` at `i64::MAX`, so every `buf64` element at or above 2**63 was clamped to `0x7FFF_FFFF_FFFF_FFFF` before `encode_elems` — whose `elem_to_u64` goes through `to_u64` *precisely* to avoid that — ever saw it. The pre-conversion was redundant as well as lossy: the comment on those very lines already delegated the width masking to `encode_elems`.

A buffer could therefore disagree with itself depending on how it was filled — `blob64.new(...)`, `.splice` and `write-uint64` were all correct, element assignment was not:

```raku
my buf64 $b .= new(1, 2, 3);
$b[1] = 0xFFFFFFFFFFFFFFFF;
say $b[1].base(16);
# raku:  FFFFFFFFFFFFFFFF
# mutsu: 7FFFFFFFFFFFFFFF
```

## Fix

Store the value unconverted and let `encode_elems`/`elem_to_u64` do the coercion and the width masking, as every other write path already does. Narrow buffers are unchanged — a byte still wraps mod 256.

## How it was found

grondilu's `Digest` dist (`todo/tickets/digest-dist-blockers.md` blocker 3). `Digest::SHA2`'s `sha512` keeps its message schedule in a `state buf64 \$w` and assigns `\$w[\$t] = ...`, so every schedule word >= 2**63 was clamped. The constants, the padding and every round primitive matched raku exactly; a per-round trace put the divergence at `t = 25`, with `\$w[25]` reading back as `7FFFFFFFFFFFFFFF` — an `i64::MAX` marker rather than a plausible SHA word.

`sha384`/`sha512` now match the NIST vectors, and the dist's `t/sha.t` passes its SHA-1 and SHA-2 subtests in full. The remaining SHA-3 subtest is an unrelated cluster (`samewith` inside a lazy `gather`), recorded as blocker 6 in the ticket.

## Tests

- `t/buf-uint64-element-assign.t` (new, 8 tests) — validated to pass identically under `raku`.
- `make test`: 2850 files / 27063 tests, all pass.
- `roast/S32-container/buf.t` + `roast/S09-subscript/slice.t`: 77 tests, pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)