### PR TITLE
fix(types): a built-in role brings its own roles with it

### DIFF
--- a/news/2026-08/builtin-role-composes-its-own-roles.md
+++ b/news/2026-08/builtin-role-composes-its-own-roles.md
@@ -1,0 +1,25 @@
+# A built-in role brings its own roles with it
+
+`class Fixed2 does Real { ... }` made `Fixed2 ~~ Real` true and
+`Fixed2 ~~ Numeric` false. The transitive role walk in
+`src/runtime/types/type_matching.rs` follows `registry().role_parents`, which
+only records what *user* code declared, so `Real does Numeric` — a fact about a
+built-in role — was nowhere in the picture. The same hole hid
+`Mixy ~~ Baggy`, `Setty ~~ QuantHash` and `Baggy ~~ QuantHash`.
+
+`Registry::builtin_role_parents` now names those four compositions, and
+`Registry::role_parents_of` merges them with the declared ones so the walk sites
+see one list. The type-object branch needed a little more: its registry walk is
+gated on the constraint resolving to a *user-declared* role, and `Numeric` never
+does, so a small dedicated pass over the built-in parents runs before that gate.
+
+Found under the real `Test` module, and the symptom is the one this campaign has
+now seen three times: `Test.rakumod` declares `multi sub is-approx(Numeric $got,
+Numeric $expected, ...)`, so an `is-approx` over two `Fixed2` values matched
+*none* of the module's candidates and fell through to mutsu's native provider,
+which keeps a separate counter. `roast/S32-num/real-bridge.t` emitted all 201
+assertions but numbered only 195 of them, and the module's `END` plan check
+failed the file. It now passes under `MUTSU_REAL_TEST=1`.
+
+Pin: `t/builtin-role-composes-its-own-roles.t` (all twelve assertions verified
+against `raku`).

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -724,6 +724,36 @@ impl Registry {
     /// parametric suffix is stripped (`R[Int]` -> `R`). Push order is load-bearing
     /// — the caller consumes this LIFO via `.pop()` and relies on first-match-wins,
     /// so this method MUST NOT dedup or sort (dedup happens during the walk).
+    /// The roles a *built-in* role itself composes. `role_parents` only records
+    /// what user code declared, so without this a `class F does Real` knew
+    /// nothing of `Real does Numeric` and `F ~~ Numeric` answered False —
+    /// which sent every `is-approx(Numeric, Numeric, ...)` in `Test.rakumod`
+    /// past its own candidates and into the native provider's separate counter
+    /// (`roast/S32-num/real-bridge.t`).
+    pub(crate) fn builtin_role_parents(role_name: &str) -> &'static [&'static str] {
+        match role_name {
+            "Real" => &["Numeric"],
+            "Setty" | "Baggy" => &["QuantHash", "Associative"],
+            "Mixy" => &["Baggy"],
+            _ => &[],
+        }
+    }
+
+    /// Every role the named role composes, declared or built-in.
+    pub(crate) fn role_parents_of(&self, role_name: &str) -> Vec<String> {
+        let mut parents: Vec<String> = self
+            .role_parents
+            .get(role_name)
+            .cloned()
+            .unwrap_or_default();
+        for builtin in Self::builtin_role_parents(role_name) {
+            if !parents.iter().any(|p| p == builtin) {
+                parents.push((*builtin).to_string());
+            }
+        }
+        parents
+    }
+
     pub(crate) fn composed_roles_seed(&self, mro: &[Symbol]) -> Vec<String> {
         let mut seed = Vec::new();
         for cn in mro {

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -1142,6 +1142,26 @@ impl Interpreter {
             {
                 return true;
             }
+            // A composed *built-in* role brings its own parents (`Real does
+            // Numeric`), and neither the parent nor the constraint naming it is
+            // a user-declared role, so the registry walk below — gated on
+            // `resolved_constraint` — never reaches them.
+            {
+                let mut stack: Vec<String> = mro.iter().map(|s| s.resolve()).collect();
+                stack.extend(self.registry().composed_roles_seed(&mro));
+                let mut seen = HashSet::new();
+                while let Some(role_name) = stack.pop() {
+                    if !seen.insert(role_name.clone()) {
+                        continue;
+                    }
+                    for rp in Registry::builtin_role_parents(&role_name) {
+                        if Self::type_matches(effective_constraint, rp) {
+                            return true;
+                        }
+                        stack.push((*rp).to_string());
+                    }
+                }
+            }
             // Check transitive role composition through class_composed_roles and role_parents
             if resolved_constraint.is_some() {
                 // Seed from the registry (composed roles over the MRO); the divergent
@@ -1181,6 +1201,13 @@ impl Interpreter {
                                 role_stack.push(rp_base.to_string());
                             }
                         }
+                    }
+                    // A built-in role's own parents are not in the registry, and
+                    // `resolve_role_key` cannot find them either, so push them
+                    // unconditionally — `Real does Numeric` is as true for a
+                    // user class as a declared composition would be.
+                    for rp in Registry::builtin_role_parents(&role_name) {
+                        role_stack.push((*rp).to_string());
                     }
                 }
             }
@@ -1248,10 +1275,8 @@ impl Interpreter {
                             }
                         }
                     }
-                    if let Some(rparents) = self.registry().role_parents.get(&parent) {
-                        for rp in rparents {
-                            stack.push(rp.clone());
-                        }
+                    for rp in self.registry().role_parents_of(&parent) {
+                        stack.push(rp);
                     }
                 }
             }
@@ -1326,11 +1351,9 @@ impl Interpreter {
                     if Self::type_matches(constraint, &role_name) {
                         return true;
                     }
-                    if let Some(rparents) = self.registry().role_parents.get(&role_name) {
-                        for rp in rparents {
-                            let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
-                            role_stack.push(rp_base.to_string());
-                        }
+                    for rp in self.registry().role_parents_of(&role_name) {
+                        let rp_base = rp.split_once('[').map(|(b, _)| b).unwrap_or(rp.as_str());
+                        role_stack.push(rp_base.to_string());
                     }
                 }
             }

--- a/t/builtin-role-composes-its-own-roles.t
+++ b/t/builtin-role-composes-its-own-roles.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 12;
+
+# A built-in role composes roles of its own. `Real does Numeric`, so a class
+# that only says `does Real` is a Numeric too.
+class Fixed does Real {
+    has Int $.hundredths;
+    method Bridge() { $!hundredths.Bridge / 100.Bridge }
+}
+
+my $one = Fixed.new(hundredths => 100);
+
+ok $one ~~ Real, 'the instance does the role it named';
+ok $one ~~ Numeric, 'and the role that role composes';
+ok Fixed ~~ Real, 'the type object does the role it named';
+ok Fixed ~~ Numeric, 'and the role that role composes';
+nok $one ~~ Cool, 'Real does not drag Cool in';
+
+ok Real ~~ Numeric, 'the built-in role itself does its parent';
+ok Setty ~~ QuantHash, 'Setty does QuantHash';
+ok Baggy ~~ QuantHash, 'Baggy does QuantHash';
+ok Mixy ~~ Baggy, 'Mixy does Baggy';
+ok Mixy ~~ QuantHash, 'and transitively QuantHash';
+
+# The relation is what a `Numeric` parameter constraint is checked against, and
+# getting it wrong silently diverted Test.rakumod's `is-approx(Numeric, Numeric)`
+# candidates (roast/S32-num/real-bridge.t).
+sub takes-numeric(Numeric $n) { 'matched' }
+is takes-numeric($one), 'matched', 'a Numeric parameter accepts it';
+
+sub takes-real(Real $r) { 'matched' }
+is takes-real($one), 'matched', 'and so does a Real parameter';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -740,6 +740,14 @@ native provider's separate counter. **A "plan mismatch plus a blank
 description" is worth checking against the argument's own type before looking at
 `Test` at all.**
 
+`S32-num/real-bridge.t` is closed
+(`news/2026-08/builtin-role-composes-its-own-roles.md`): a `class Fixed2 does
+Real` was not `Numeric`, because `role_parents` only records *user*
+compositions and `Real does Numeric` is a built-in one. Third instance of the
+same mechanism after `Instant`/`Duration` — **when a file emits every assertion
+but numbers only some of them, look for a type relation that diverted one
+`Test.rakumod` candidate group to the native provider.**
+
 `roast/S12-methods/qualified.t` is worth a second look too: its Malformed
 assertion passes now and the file moved on to `Cannot dispatch to method me on
 Parent because it is not inherited or done by Bar` in its inheritance subtest.


### PR DESCRIPTION
`class Fixed2 does Real { ... }` made `Fixed2 ~~ Real` true and `Fixed2 ~~ Numeric` false. The transitive role walk in `src/runtime/types/type_matching.rs` follows `registry().role_parents`, which only records what *user* code declared, so `Real does Numeric` — a fact about a built-in role — was nowhere in the picture. The same hole hid `Mixy ~~ Baggy`, `Setty ~~ QuantHash` and `Baggy ~~ QuantHash`.

`Registry::builtin_role_parents` now names those four compositions, and `Registry::role_parents_of` merges them with the declared ones so the walk sites see one list. The type-object branch needed a little more: its registry walk is gated on the constraint resolving to a *user-declared* role, and `Numeric` never does, so a small dedicated pass over the built-in parents runs before that gate.

Found under the real `Test` module, and the symptom is the one this campaign has now seen three times (after `Instant`/`Duration`): `Test.rakumod` declares `multi sub is-approx(Numeric $got, Numeric $expected, ...)`, so an `is-approx` over two `Fixed2` values matched *none* of the module's candidates and fell through to mutsu's native provider, which keeps a separate counter. `roast/S32-num/real-bridge.t` emitted all 201 assertions but numbered only 195 of them, and the module's `END` plan check failed the file. It now passes under `MUTSU_REAL_TEST=1`.

Pin: `t/builtin-role-composes-its-own-roles.t` (all twelve assertions verified against `raku`).

Verified locally: `make roast` PASS (1435 files), `make test` PASS (2853 files), batteries gate PASSED, `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)