### PR TITLE
refactor(compiler): preserve imported routine plan keys

### DIFF
--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -2,6 +2,40 @@ use super::*;
 use std::sync::atomic::Ordering;
 
 impl Compiler {
+    /// Import routines compiled by a child compilation unit and keep declaration
+    /// plans in that unit pointing at the imported keys. Multi candidates omit
+    /// their body fingerprint from the normal lookup key, so two nested units can
+    /// legitimately produce the same key for different routines.
+    fn import_compiled_functions(
+        &mut self,
+        code: &mut CompiledCode,
+        compiled_functions: CompiledFns,
+    ) {
+        let mut remap = rustc_hash::FxHashMap::default();
+        for (key, function) in compiled_functions {
+            let imported_key = if self.compiled_functions.contains_key(&key) {
+                let base = key.resolve();
+                let mut ordinal = 1usize;
+                loop {
+                    let candidate = Symbol::intern(&format!("{base}#import{ordinal}"));
+                    if !self.compiled_functions.contains_key(&candidate) {
+                        break candidate;
+                    }
+                    ordinal += 1;
+                }
+            } else {
+                key
+            };
+            if imported_key != key {
+                remap.insert(key, imported_key);
+            }
+            self.compiled_functions.insert(imported_key, function);
+        }
+        if !remap.is_empty() {
+            code.remap_sub_decl_compiled_routine_keys(&remap);
+        }
+    }
+
     /// Recursively allocate local variable slots for sub_signature parameters
     /// (array/hash unpacking in function signatures like `sub f([$a, *@b]) { ... }`).
     fn alloc_sub_signature_locals(compiler: &mut Compiler, sub_params: &[crate::ast::ParamDef]) {
@@ -418,6 +452,10 @@ impl Compiler {
         // call_compiled_closure catches CX::Return at the right boundary.
         sub_compiler.code.is_routine = true;
         sub_compiler.code.compute_needs_env_sync();
+        self.import_compiled_functions(
+            &mut sub_compiler.code,
+            std::mem::take(&mut sub_compiler.compiled_functions),
+        );
         let mut cf = CompiledFunction {
             code: sub_compiler.code,
             source_file: None,
@@ -1156,10 +1194,12 @@ impl Compiler {
                 }
             }
         }
-        // Transfer any compiled functions from the closure to the parent
-        for (k, v) in sub_compiler.compiled_functions {
-            self.compiled_functions.insert(k, v);
-        }
+        // Transfer any compiled functions from the closure to the parent while
+        // preserving the declaration-plan references into the imported table.
+        self.import_compiled_functions(
+            &mut sub_compiler.code,
+            std::mem::take(&mut sub_compiler.compiled_functions),
+        );
         sub_compiler.code.is_routine = is_routine;
         // Use the sub_compiler's source line if a SetLine was processed
         // within the body, otherwise fall back to the parent compiler's

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -65,6 +65,28 @@ mod declaration_plan_tests {
     }
 
     #[test]
+    fn nested_compilation_units_remap_colliding_routine_plan_keys() {
+        let source = r#"
+            sub outer-a() { multi sub inner(Int $x) { 1 }; &inner }
+            sub outer-b() { multi sub inner(Int $x) { 2 }; &inner }
+        "#;
+        let (stmts, _) = crate::parse_dispatch::parse_source(source).expect("source parses");
+        let (_code, compiled_fns) = Compiler::new().compile(&stmts);
+
+        let inner_plans: Vec<_> = compiled_fns
+            .values()
+            .flat_map(|function| function.code.sub_decl_plans.iter())
+            .filter(|plan| plan.name.as_str() == "inner" && !plan.compiled_routine_keys.is_empty())
+            .collect();
+        assert_eq!(inner_plans.len(), 2);
+        let first = inner_plans[0].compiled_routine_keys[0];
+        let second = inner_plans[1].compiled_routine_keys[0];
+        assert_ne!(first, second);
+        assert!(compiled_fns.contains_key(&first));
+        assert!(compiled_fns.contains_key(&second));
+    }
+
+    #[test]
     fn type_declarations_leave_the_generic_statement_pool() {
         let (stmts, _) = crate::parse_dispatch::parse_source(
             "role R { method r { 1 } }; class C does R { method c { 2 } }; C.new.c",

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2474,6 +2474,22 @@ impl ConstKey {
 }
 
 impl CompiledCode {
+    pub(crate) fn remap_sub_decl_compiled_routine_keys(
+        &mut self,
+        remap: &rustc_hash::FxHashMap<Symbol, Symbol>,
+    ) {
+        for plan in &mut self.sub_decl_plans {
+            for key in &mut plan.compiled_routine_keys {
+                if let Some(remapped) = remap.get(key) {
+                    *key = *remapped;
+                }
+            }
+        }
+        for nested in &mut self.closure_compiled_codes {
+            Arc::make_mut(nested).remap_sub_decl_compiled_routine_keys(remap);
+        }
+    }
+
     fn mark_name_access_slots(&self, start: usize, end: usize, slots: &mut [bool]) {
         let end = end.min(self.ops.len());
         for op in &self.ops[start.min(end)..end] {


### PR DESCRIPTION
## Problem

ADR-0019 C1 records compiled routine keys in sub declaration plans, but child compiler tables were either discarded for named routines or merged with overwrite semantics. Colliding nested multi routine keys could therefore lose plan-to-body identity.

## Approach

- import child compiled routines through one remapping helper
- rewrite declaration-plan keys recursively when an imported key collides
- retain named-routine child tables instead of dropping them
- pin two nested compilation units with colliding multi keys

## Test evidence

- `cargo test nested_compilation_units_remap_colliding_routine_plan_keys`
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test` — Files=2851, Tests=27076, Result: PASS

Implements ADR-0019 slice C2.