### PR TITLE
fix(hash): `%h.List` yields the Hash's pairs

### DIFF
--- a/news/2026-08/hash-list-coercion-yields-pairs.md
+++ b/news/2026-08/hash-list-coercion-yields-pairs.md
@@ -1,0 +1,28 @@
+# `%h.List` yields the Hash's pairs
+
+`.List` on a Hash returned a one-element list holding the whole Hash
+(`({:a(1)},)`) instead of the Hash's pairs (`(:a(1),)`). The `"List"` arm of the
+native coercion table had no `Hash` case, so a Hash fell through to the scalar
+catch-all that wraps its target as a single element — even though the sibling
+`.list` and `.Array` arms had had a `Hash` case all along, so
+`%h.List` and `%h.list` disagreed.
+
+`Set`, `Bag` and `Mix` were wrapped by the same catch-all and are fixed with it:
+`.List` on those now yields their `key => weight` pairs, matching `.list`.
+
+This is one of the two independent reasons `Cro::HTTP::Client` rejected every
+request that passed `headers => %h`. The client does
+
+```raku
+when 'headers' {
+    self!set-headers($request, $value.List) if $value ~~ Iterable;
+}
+```
+
+and `set-headers` then requires each element to be a `Pair` or a
+`Cro::HTTP::Header`, so it saw a Hash and threw
+`X::Cro::HTTP::Client::IncorrectHeaderType`. (The other reason — a `Pair` read
+out of a variable being passed as a *named* argument — is recorded in
+`todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md`.)
+
+Pinned by `t/hash-list-coercion.t`.

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -417,6 +417,20 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 Some(Ok(target.clone()))
             }
             ValueView::LazyList(_) => None, // fall through to runtime to force
+            // `.List` on a Hash is its pairs, exactly like `.list`/`.Array`
+            // (`%h.List` is `(:a(1),)`, not `({:a(1)},)`). Without this arm the
+            // Hash fell through to the scalar catch-all and became a one-element
+            // list holding the whole Hash — which is how `Cro::HTTP::Client`'s
+            // `self!set-headers($request, $value.List)` saw a Hash where a Pair
+            // was required and rejected every `headers => %h`.
+            ValueView::Hash(map) => Some(Ok(Value::array(
+                map.iter()
+                    .map(|(k, v)| map.typed_pair(k, v.clone()))
+                    .collect::<Vec<_>>(),
+            ))),
+            ValueView::Set(..) | ValueView::Bag(..) | ValueView::Mix(..) => Some(Ok(Value::array(
+                crate::runtime::utils::value_to_list(target),
+            ))),
             _ => Some(Ok(Value::array(vec![target.clone()]))),
         },
         // `.Seq` on an explicitly `.lazy`-marked list likewise keeps it lazy

--- a/t/hash-list-coercion.t
+++ b/t/hash-list-coercion.t
@@ -1,0 +1,20 @@
+use Test;
+plan 8;
+
+# `.List` on a Hash is its pairs, exactly like `.list` and `.Array`. It used to
+# fall through to the scalar catch-all and produce a one-element list holding
+# the whole Hash — which is how `Cro::HTTP::Client`'s
+# `self!set-headers($request, $value.List)` saw a Hash where a Pair was
+# required and rejected every `headers => %h`.
+
+my %h = a => 1, b => 2;
+is %h.List.elems, 2, 'Hash.List has one element per pair';
+is %h.List.sort(*.key).map(*.key).join(','), 'a,b', 'Hash.List yields the keys';
+ok %h.List.all ~~ Pair, 'every Hash.List element is a Pair';
+is %h.List.sort(*.key).raku, %h.list.sort(*.key).raku, 'Hash.List agrees with Hash.list';
+
+is set(1, 2).List.elems, 2, 'Set.List has one element per member';
+ok set(1, 2).List.all ~~ Pair, 'every Set.List element is a Pair';
+is bag(1, 1, 2).List.sort(*.key).map(*.value).join(','), '2,1', 'Bag.List carries the weights';
+
+is (a => 1).List.raku, '(:a(1),)', 'Pair.List is still a one-element list';

--- a/todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md
+++ b/todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md
@@ -1,0 +1,93 @@
+# A `Pair` held in a variable is passed as a *named* argument
+
+In Raku, whether an argument is named is a property of the **call site**, not of
+the value. Only a literal `key => value` / `:key(...)` / `:$x` written directly
+in the argument list is a named argument; a `Pair` that arrives through a
+variable, an array element, `%h.pairs`, or `Pair.new` is an ordinary positional
+argument (you need `|$p` to make it named).
+
+mutsu encodes named-ness in the **value** instead: `ValueRepr::Pair(String, _)`
+means "named argument" and `ValueRepr::ValuePair(Value, Value)` means
+"positional argument" (see the comment in
+`src/runtime/types/args_matching.rs:99`, and `Value::is_string_pair_value`,
+which 32 call sites consult to split an argument list into positionals and
+nameds). The parser marks the few syntactic forms it knows are positional
+(`Expr::PositionalPair`, for a non-bareword key or a space-parenthesized
+`f (a => 1)`) and everything else defaults to the named flavour.
+
+So *any* `Pair` with a `Str` key that reaches a call through a variable is
+misread as a named argument:
+
+```raku
+class C {
+    multi method m(Pair $p) { say "Pair" }
+    multi method m(Str $s)  { say "Str"  }
+}
+my $c = C.new;
+
+$c.m(Pair.new('a', 1));           # Cannot resolve caller m(C:D: :a(Int))
+my $p = a => 1;      $c.m($p);    # Cannot resolve caller m(C:D: :a(Int))
+my $q = :a(1);       $c.m($q);    # Cannot resolve caller m(C:D: :a(Int))
+my @l = [a => 1];    $c.m(@l[0]); # Cannot resolve caller m(C:D: :a(Int))
+my %h = a => 1;      $c.m(%h.pairs[0]); # Cannot resolve caller m(C:D: :a(Int))
+
+my $r = (a => 1);    $c.m($r);    # works — parenthesised, so PositionalPair
+```
+
+`raku` prints `Pair` for every one of these. `tmp/hdr15.p6` is the matrix above.
+
+## Why it matters
+
+This is not an exotic corner. Any library that iterates pairs and hands them to
+a typed multi hits it. The case that surfaced it is `Cro::HTTP::Client`:
+
+```raku
+method !set-headers($request, @headers) {
+    for @headers {
+        when Pair | Cro::HTTP::Header { $request.append-header($_) }
+        default { die X::Cro::HTTP::Client::IncorrectHeaderType.new(what => $_) }
+    }
+}
+```
+
+`when Pair` matches, then `append-header($_)` dispatches with `$_` read as a
+named argument and no candidate matches. So **every** `Cro::HTTP::Client`
+request that passes `headers => [...]` dies, which is what fails the vendored
+Cro suite's `http-middleware.rakutest` subtest 3 (its second half sends
+`Authorization: Bearer Polarer`) and blocks `router-auth`,
+`http-auth-basic*`, `http-session-*`. Minimal repro:
+`tmp/hdr2.p6` (mutsu: `X::Multi::NoMatch` on `append-header`; raku: 200).
+
+## Why this is a deep ticket
+
+The fix is to move named-ness from the value to the call site, and both
+directions are wide:
+
+1. **Mark named args at the call site.** `Expr::Call` carries `args: Vec<Expr>`
+   with no named/positional distinction at all — the distinction only exists in
+   `ast::CallArg`, which this node does not use. Either teach the call nodes to
+   carry a named mask (and thread it through every `CallFunc`/`CallMethod`
+   opcode, minding the 48-byte `OpCode` budget), or emit a normalization opcode
+   after each non-syntactically-named argument. The latter costs an extra
+   instruction on the hottest path in the VM (`f($x)`), so it needs a static
+   "can this expression even yield a Pair" filter to be affordable.
+
+2. **Invert the value default.** Make `MakePair` (from `TokenKind::FatArrow`,
+   `src/compiler/expr_helpers.rs:199`) emit the *positional* flavour everywhere
+   except directly in an argument list, and make every Pair-producing builtin
+   (`Pair.new`, `.pairs`, `.kv`, `.antipair`, hash iteration, ...) produce the
+   positional flavour too. Zero runtime cost, but it changes what ~all Pair
+   construction sites produce and interacts with all 32 `is_string_pair_value`
+   consumers.
+
+Either way the blast radius is the whole dispatch/binding layer, so it wants an
+ADR and a full roast run rather than a local patch. Note that direction 2 is
+closer to the Raku model only by accident: the real model is that the *value*
+has no named-ness at all, so direction 1 is the honest one and direction 2 is a
+cheaper approximation of it.
+
+## Related
+
+`%h.List` returning a one-element list holding the Hash (instead of the Hash's
+pairs) was a second, independent reason `headers => %h` failed; that one is
+fixed — see `news/2026-08/hash-list-coercion-yields-pairs.md`.


### PR DESCRIPTION
## Problem

```raku
my %h = a => 1;
say %h.List;   # mutsu: ({a => 1},)   raku: (a => 1,)
say %h.list;   # both:  (a => 1,)
```

The `"List"` arm of the native coercion table had no `Hash` case, so a Hash fell
through to the scalar catch-all that wraps its target as a single element — even
though the sibling `.list` and `.Array` arms have had a `Hash` case all along,
so `%h.List` and `%h.list` disagreed with each other.

`Set`, `Bag` and `Mix` were wrapped by the same catch-all and are fixed with it:
`.List` on those now yields their `key => weight` pairs, matching `.list` and
`raku`.

## Why it showed up

This is one of the two independent reasons `Cro::HTTP::Client` rejects every
request that passes `headers => %h`:

```raku
when 'headers' {
    self!set-headers($request, $value.List) if $value ~~ Iterable;
}
```

`set-headers` requires each element to be a `Pair` or a `Cro::HTTP::Header`, so
it saw a Hash and threw `X::Cro::HTTP::Client::IncorrectHeaderType`.

The **other** reason is filed as a deep ticket rather than fixed here:
`todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md`. A
`Pair` read out of a variable (`Pair.new('a', 1)`, `my $p = a => 1`, `%h.pairs[0]`,
`@list[0]`) is passed as a **named** argument, because mutsu encodes named-ness
in the value (`Pair` = named, `ValuePair` = positional) rather than at the call
site as Raku does. That breaks `headers => [...]` too, and unpicking it touches
the whole dispatch/binding layer (32 `is_string_pair_value` consumers, and
`Expr::Call` carries no named/positional distinction at all), so it wants an ADR.

## Verification

Pinned by `t/hash-list-coercion.t` — all eight checks match `raku`, and checks
1-7 fail on `main`. `make test` passes (2854 files, 27102 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)