### PR TITLE
fix(ops): a Unicode infix alias resolves to the same routine by name

### DIFF
--- a/news/2026-08/unicode-infix-alias-resolves-by-name.md
+++ b/news/2026-08/unicode-infix-alias-resolves-by-name.md
@@ -1,0 +1,28 @@
+# A Unicode infix alias resolves to the same routine by name
+
+`say 4 ≅ 4` worked; `say &infix:<≅>(4, 4)` died with `Two terms in a row`. So
+did `⩵`, `⩶`, `≠`, `≤` and `≥`. The parser recognises each Unicode spelling
+inline and maps it straight to the operator's `ComparisonOp`, but nothing did
+that mapping when an operator was reached by *name*: the four sites that
+dispatch an `infix:<op>` call each carried the same one-off
+`if op == "−" { "-" }` normalisation and no more, so `≅` reached
+`build_infix_expr` as itself, became a `TokenKind::Ident("≅")` binary that no
+compiler arm claims, and blew up as a syntax error at runtime.
+
+`Interpreter::normalize_unicode_infix` now holds the whole alias table in one
+place — the ten spellings the parser accepts — and the four dispatch sites plus
+`infix_token` go through it. rakudo agrees on the identity: `&infix:<≅>.name` is
+`infix:<=~=>`.
+
+The native `cmp-ok` had the same hole from the other direction: its string
+operator table listed `=~=`/`≅` but not `≤`, `≠`, `⩵` or `⩶`, and answered
+`cmp-ok: unsupported string operator '≤'`. It goes through the same table now.
+
+Found under the real `Test` module: `cmp-ok`'s way of turning a string operator
+into a callable is `&CALLER::LEXICAL::("infix:<$op>")`, so
+`roast/S32-num/complex.t`'s `cmp-ok 42, '≅', 42+0i` aborted the file's
+`Real ≅ Complex` subtest — and with it the rest of the file — before its first
+assertion. `complex.t` now passes under `MUTSU_REAL_TEST=1`.
+
+Pin: `t/unicode-infix-alias-by-name.t` (all fourteen assertions verified against
+`raku`).

--- a/src/runtime/builtins_operators_coerce.rs
+++ b/src/runtime/builtins_operators_coerce.rs
@@ -131,8 +131,31 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn infix_token(op: &str) -> TokenKind {
+    /// The ASCII spelling of a Unicode infix alias. The parser accepts both
+    /// spellings of each of these, and rakudo resolves them to a single routine
+    /// — `&infix:<≅>.name` is `infix:<=~=>` — so a call that reaches an operator
+    /// by *name* has to agree. Without it `&infix:<≅>(1, 1)` and
+    /// `&CALLER::LEXICAL::("infix:<≅>")` (which is how `Test.rakumod`'s `cmp-ok`
+    /// turns its string operator into a callable) built an `Ident("≅")` binary
+    /// no compiler arm claimed, and died with "Two terms in a row".
+    pub(crate) fn normalize_unicode_infix(op: &str) -> &str {
         match op {
+            "\u{2A75}" => "==",
+            "\u{2A76}" => "===",
+            "\u{2260}" => "!=",
+            "\u{2264}" => "<=",
+            "\u{2265}" => ">=",
+            "\u{2245}" => "=~=",
+            "\u{2212}" => "-",
+            "\u{00D7}" => "*",
+            "\u{00F7}" => "/",
+            "\u{2218}" => "o",
+            other => other,
+        }
+    }
+
+    pub(super) fn infix_token(op: &str) -> TokenKind {
+        match Self::normalize_unicode_infix(op) {
             "+" => TokenKind::Plus,
             "-" => TokenKind::Minus,
             "*" | "×" => TokenKind::Star,

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -12,8 +12,7 @@ impl Interpreter {
             .strip_prefix("infix:<")
             .and_then(|s| s.strip_suffix('>'))
         {
-            let normalized = if op == "−" { "-" } else { op };
-            return self.call_infix_routine(normalized, args);
+            return self.call_infix_routine(Self::normalize_unicode_infix(op), args);
         }
         if let Some(op) = name
             .strip_prefix("prefix:<")

--- a/src/runtime/test_functions/comparison.rs
+++ b/src/runtime/test_functions/comparison.rs
@@ -67,7 +67,11 @@ impl Interpreter {
                 let result = Self::cmp_ok_junction_thread(&left, &right, &op);
                 result.truthy()
             }
-            ValueView::Str(op) => match op.as_str() {
+            // A Unicode infix alias names the same operator as its ASCII
+            // spelling (`≤` is `<=`), so accept either here — the real
+            // `Test.rakumod` resolves the string through the operator's routine
+            // and never sees the difference.
+            ValueView::Str(op) => match Self::normalize_unicode_infix(op.as_str()) {
                 "~~" => self.smart_match(&left, &right),
                 "!~~" => !self.smart_match(&left, &right),
                 "eq" => left.to_string_value() == right.to_string_value(),

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -89,8 +89,7 @@ impl Interpreter {
             .strip_prefix("infix:<")
             .and_then(|s| s.strip_suffix('>'))
         {
-            let normalized = if op == "\u{2212}" { "-" } else { op };
-            return self.call_infix_routine(normalized, &args);
+            return self.call_infix_routine(Self::normalize_unicode_infix(op), &args);
         }
         // File/FS builtin function (`slurp`/`open`/…): user subs were resolved above
         // (compiled_fns / OTF), so dispatch the builtin natively on the VM-owned

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1455,9 +1455,8 @@ impl Interpreter {
                     // `call_infix_routine` on the same `self`), with the same
                     // arg-sources + rw-proxy handling => byte-identical. §D state
                     // ownership: the operator handlers are native Rust on VM state.
-                    let normalized = if op == "\u{2212}" { "-" } else { op };
                     self.set_pending_call_arg_sources(arg_sources);
-                    let result = self.call_infix_routine(normalized, &args);
+                    let result = self.call_infix_routine(Self::normalize_unicode_infix(op), &args);
                     self.set_pending_call_arg_sources(None);
                     let result = result?;
                     loan_env!(self, maybe_fetch_rw_proxy(result, true))

--- a/t/unicode-infix-alias-by-name.t
+++ b/t/unicode-infix-alias-by-name.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 14;
+
+# A Unicode infix alias names the same routine as its ASCII spelling, so
+# reaching it by name -- `&infix:<X>`, or the runtime string form that
+# Test.rakumod's `cmp-ok` uses -- has to resolve to the same operator.
+ok  &infix:<⩵>(4, 4),      '&infix:<⩵> is ==';
+ok  &infix:<⩶>(4, 4),      '&infix:<⩶> is ===';
+nok &infix:<≠>(4, 4),      '&infix:<≠> is !=';
+ok  &infix:<≤>(4, 4),      '&infix:<≤> is <=';
+ok  &infix:<≥>(4, 4),      '&infix:<≥> is >=';
+ok  &infix:<≅>(4, 4),      '&infix:<≅> is =~=';
+is  &infix:<−>(9, 4), 5,   '&infix:<−> is -';
+is  &infix:<×>(9, 4), 36,  '&infix:<×> is *';
+is  &infix:<÷>(9, 3), 3,   '&infix:<÷> is /';
+
+# The same names built at runtime, which is the shape `cmp-ok` reaches them by.
+my $op = '≅';
+ok &CALLER::LEXICAL::("infix:<$op>")(4, 4), 'the runtime string form resolves too';
+$op = '≤';
+ok &CALLER::LEXICAL::("infix:<$op>")(4, 9), 'and so does another alias';
+
+cmp-ok 4, '≅', 4,  'cmp-ok takes the alias as a string operator';
+cmp-ok 4, '≤', 9,  'cmp-ok takes ≤ too';
+cmp-ok 4, '≠', 9,  'cmp-ok takes ≠ too';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -748,6 +748,14 @@ same mechanism after `Instant`/`Duration` — **when a file emits every assertio
 but numbers only some of them, look for a type relation that diverted one
 `Test.rakumod` candidate group to the native provider.**
 
+`S32-num/complex.t` is closed
+(`news/2026-08/unicode-infix-alias-resolves-by-name.md`): six Unicode infix
+aliases (`≅ ⩵ ⩶ ≠ ≤ ≥`) parsed inline but did not resolve when reached by
+*name*, and `cmp-ok` reaches its string operator by name
+(`&CALLER::LEXICAL::("infix:<$op>")`). **An operator that works inline is not
+evidence that `&infix:<op>` works** — the parser and the by-name dispatch are
+separate tables, and only the parser had the aliases.
+
 `roast/S12-methods/qualified.t` is worth a second look too: its Malformed
 assertion passes now and the file moved on to `Cannot dispatch to method me on
 Parent because it is not inherited or done by Bar` in its inheritance subtest.


### PR DESCRIPTION
`say 4 ≅ 4` worked; `say &infix:<≅>(4, 4)` died with `Two terms in a row`. So did `⩵`, `⩶`, `≠`, `≤` and `≥`. The parser recognises each Unicode spelling inline and maps it straight to the operator, but nothing did that mapping when an operator was reached by *name*: the four sites that dispatch an `infix:<op>` call each carried the same one-off `if op == "−" { "-" }` normalisation and no more, so `≅` reached `build_infix_expr` as itself, became a `TokenKind::Ident("≅")` binary that no compiler arm claims, and blew up as a syntax error at runtime.

`Interpreter::normalize_unicode_infix` now holds the whole alias table in one place — the ten spellings the parser accepts — and the four dispatch sites plus `infix_token` go through it. rakudo agrees on the identity: `&infix:<≅>.name` is `infix:<=~=>`.

The native `cmp-ok` had the same hole from the other direction: its string operator table listed `=~=`/`≅` but not `≤`, `≠`, `⩵` or `⩶`, and answered `cmp-ok: unsupported string operator '≤'`. It shares the table now.

Found under the real `Test` module: `cmp-ok` turns its string operator into a callable with `&CALLER::LEXICAL::("infix:<$op>")`, so `roast/S32-num/complex.t`'s `cmp-ok 42, '≅', 42+0i` aborted the file's `Real ≅ Complex` subtest — and with it the rest of the file — before its first assertion. `complex.t` now passes under `MUTSU_REAL_TEST=1`.

Pin: `t/unicode-infix-alias-by-name.t` (all fourteen assertions verified against `raku`).

Verified locally: `make roast` PASS (1435 files), `make test` PASS (2855 files), batteries gate PASSED, `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)