### PR TITLE
fix(compiler): a routine declared in one body does not redeclare a sibling's

### DIFF
--- a/news/2026-08/sibling-scope-routine-shadow.md
+++ b/news/2026-08/sibling-scope-routine-shadow.md
@@ -1,0 +1,47 @@
+# A routine declared in one body does not redeclare a sibling body's
+
+```raku
+sub run(&body) { body() }
+run { sub f($x) { ... }; f(1) }
+run { multi f($x) { ... }; f(2) }   # Redeclaration of routine 'f'
+```
+
+Two blocks, two scopes, two unrelated routines — but mutsu's routine registry is
+keyed by *package* alone, so the second declaration saw the first still
+registered and raised `X::Redeclaration`. The exemption for this
+(`allow_lexical_shadow`) existed already, gated on `block_scope_depth > 0`,
+which an inlined bare block sets and a body executed as a routine or closure
+never does. The same failure therefore hit two sibling `sub` bodies as well.
+
+The compiler already knows the answer statically: it compiles a routine or
+closure body with its own `Compiler`, and its hoist pass marks the copies it
+registers early as `__lexical_hoist`. What was missing is that the *in-sequence*
+registration of the very same declaration carried no such mark. It does now —
+`Compiler::mark_lexical_body` sets the flag when a body compiler starts, and the
+`SubDecl` arm marks the declaration it registers.
+
+Two things had to be kept true while widening it:
+
+- **A conflict inside one body is still `X::Redeclaration`.** `mark_lexical_body`
+  records which names that body declares in a conflicting way (not every
+  declaration `multi`) and refuses to mark those. Deciding this from the body's
+  statements rather than from compile order matters: each declaration is
+  compiled twice (hoist pass, then in sequence), so an "is this the first one I
+  have seen?" test marks the hoist copy and leaves the real one bare.
+- **A `multi` that shadows a single takes the name over.** Registration already
+  cleared a shadowed same-named entry for a plain `sub`; the `multi` case did
+  not, so the sibling scope's `sub f` stayed registered and went on answering
+  `f(2)` from inside the block whose own `multi f` had just been declared.
+
+Found under the real `Test` module: `roast/S12-subset/subtypes.t` builds each
+`group-of` as a subtest block, and two of them declare `test-pos` — one `sub`,
+one `multi`. The file aborted at the second, losing 60 of its 92 assertions. It
+passes under `MUTSU_REAL_TEST=1` now, and still passes under the native
+provider.
+
+Pin: `t/sibling-scope-routine-shadow.t` (all eight assertions verified against
+`raku`).
+
+This does not make routine declarations lexically scoped — a routine declared in
+a body is still visible after that body returns, which `raku` rejects at compile
+time. That is the larger change; this one fixes the redeclaration rule alone.

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -392,6 +392,31 @@ impl Compiler {
         }
     }
 
+    /// Mark this compiler as compiling a routine/closure BODY, and record which
+    /// routine names that body redeclares within itself. See
+    /// [`Compiler::lexical_dup_routines`].
+    pub(super) fn mark_lexical_body(&mut self, body: &[Stmt]) {
+        self.in_lexical_scope = true;
+        let mut all_multi: HashMap<String, bool> = HashMap::new();
+        for stmt in body {
+            if let Stmt::SubDecl { name, multi, .. } = stmt {
+                let name = name.resolve();
+                match all_multi.get(&name) {
+                    None => {
+                        all_multi.insert(name, *multi);
+                    }
+                    Some(prev_all_multi) => {
+                        // Several `multi`s of one name are one routine, not a
+                        // redeclaration; anything else in the mix conflicts.
+                        if !(*prev_all_multi && *multi) {
+                            self.lexical_dup_routines.insert(name);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     pub(super) fn hoist_sub_decls(&mut self, stmts: &[Stmt], lexical_hoist: bool) {
         self.seed_user_listop_shadows(stmts);
         for stmt in stmts {

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -261,6 +261,7 @@ impl Compiler {
         // exactly the parameter slots (before the body can shadow them). §1.5.
         sub_compiler.record_param_local_slots(params, param_defs);
         // Hoist sub declarations within the sub body
+        sub_compiler.mark_lexical_body(body);
         sub_compiler.hoist_sub_decls(body, true);
         // Seed the body chunk's ip -> line table with the sub's definition line so
         // its prologue ops (before the body's first statement marker) already
@@ -873,6 +874,7 @@ impl Compiler {
         // exactly the parameter slots (before the body can shadow them). §1.5.
         sub_compiler.record_param_local_slots(params, param_defs);
         // Hoist sub declarations within the closure body
+        sub_compiler.mark_lexical_body(body);
         sub_compiler.hoist_sub_decls(body, true);
         // If body contains CATCH/CONTROL, wrap in implicit try. compile_try
         // leaves the body's final-expression value on the stack, which is the

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::ast::{AssignOp, CallArg, Expr, PhaserKind, Stmt, make_anon_sub};
@@ -179,6 +179,20 @@ pub(crate) struct Compiler {
     /// `OUTER::` from its mainline lands on nothing, which also means its true
     /// mainline is one frame in — so `UNIT::` must stop there, not at the wrapper.
     unit_root_scope: usize,
+    /// True when this compiler is compiling a routine or closure BODY rather
+    /// than a compilation unit's mainline. A `sub`/`multi` declared there is
+    /// lexical to that body, so it may shadow a same-named routine belonging to
+    /// a different scope — mutsu's routine registry is keyed by package alone,
+    /// and without this marker a `sub f` in one sub body made a `multi f` in a
+    /// *sibling* body an X::Redeclaration.
+    in_lexical_scope: bool,
+    /// Routine names this body declares more than once in a way that conflicts
+    /// (not every declaration is `multi`). Those must NOT be marked lexical:
+    /// the conflict is inside this one scope, so it is a genuine
+    /// X::Redeclaration and the runtime check has to keep seeing it. Computed
+    /// once from the body's own statements, so it does not depend on how many
+    /// times a declaration is compiled (the hoist pass compiles each twice).
+    lexical_dup_routines: HashSet<String>,
     /// Track type constraints for local variables (for compile-time literal checks).
     local_types: HashMap<String, String>,
     compiled_functions: CompiledFns,
@@ -421,6 +435,8 @@ impl Compiler {
             local_scopes: vec![HashMap::new()],
             enclosing_scopes: Vec::new(),
             unit_root_scope: 0,
+            in_lexical_scope: false,
+            lexical_dup_routines: HashSet::new(),
             local_types: HashMap::new(),
             compiled_functions: CompiledFns::default(),
             current_package: "GLOBAL".to_string(),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3041,7 +3041,23 @@ impl Compiler {
                     self.code.emit(OpCode::Die);
                     return;
                 }
-                let idx = self.code.add_sub_decl_plan(stmt);
+                // The hoist pass marks its copy of a body-local declaration
+                // `__lexical_hoist`; the in-sequence registration is the same
+                // declaration and has to say so too, or registering it a second
+                // time reports the *sibling* scope's routine of that name as a
+                // redeclaration.
+                let body_local =
+                    self.in_lexical_scope && !self.lexical_dup_routines.contains(&name.resolve());
+                let idx =
+                    if body_local && !custom_traits.iter().any(|(t, _)| t == "__lexical_hoist") {
+                        let mut marked = stmt.clone();
+                        if let Stmt::SubDecl { custom_traits, .. } = &mut marked {
+                            custom_traits.push(("__lexical_hoist".to_string(), None));
+                        }
+                        self.code.add_sub_decl_plan(&marked)
+                    } else {
+                        self.code.add_sub_decl_plan(stmt)
+                    };
                 self.code.emit(OpCode::RegisterDecl(idx));
                 if name_expr.is_some() {
                     // Runtime-resolved sub names cannot be keyed reliably in compiled_fns.

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -933,6 +933,18 @@ impl Interpreter {
             // Invalidate name-keyed resolution caches.
             self.fn_resolve_gen += 1;
         }
+        // A `multi` that lexically shadows a same-named *single* takes the name
+        // over completely, exactly as the `!multi` case above does — otherwise
+        // the shadowed single stays registered and keeps answering the call,
+        // which is how a sibling block's `sub f` went on being called from a
+        // block whose own `multi f` had just been declared. Sibling candidates
+        // of this multi's own group are keyed with a `/` suffix and are left
+        // alone.
+        if multi && allow_lexical_shadow && !is_our_scoped && has_single && !has_proto {
+            let lexical_single = Symbol::intern(&format!("{}::{}", self.current_package(), name));
+            self.registry_mut().functions.remove(&lexical_single);
+            self.fn_resolve_gen += 1;
+        }
         if let Some(assoc) = associativity {
             self.operator_assoc.insert(name.to_string(), assoc.clone());
             self.operator_assoc.insert(

--- a/t/sibling-scope-routine-shadow.t
+++ b/t/sibling-scope-routine-shadow.t
@@ -1,0 +1,57 @@
+use Test;
+
+plan 8;
+
+# A `sub` declared in a routine or block body is lexical to that body, so a
+# same-named routine in a *sibling* body is a fresh declaration, not a
+# redeclaration -- even when the two disagree about `multi`.
+my @seen;
+sub run(&body) { body() }
+
+run {
+    sub f($x) { @seen.push("single-$x") }
+    f(1);
+}
+run {
+    multi f($x)      { @seen.push("multi-$x") }
+    multi f(Str $s)  { @seen.push("multi-str-$s") }
+    f(2);
+    f('x');
+}
+is-deeply @seen, ['single-1', 'multi-2', 'multi-str-x'],
+    'sibling blocks each get their own routine';
+
+@seen = ();
+sub a { sub g($x) { @seen.push("a-$x") }; g(1) }
+sub b { multi g($x) { @seen.push("b-$x") }; g(2) }
+a();
+b();
+is-deeply @seen, ['a-1', 'b-2'], 'sibling sub bodies do the same';
+
+# Nested one level deeper, which is the shape roast/S12-subset/subtypes.t uses
+# (a subtest inside a subtest).
+@seen = ();
+run {
+    run { sub h($x) { @seen.push("h1-$x") }; h(1) }
+    run { multi h($x) { @seen.push("h2-$x") }; h(2) }
+}
+is-deeply @seen, ['h1-1', 'h2-2'], 'nested sibling blocks too';
+
+# The multi takes the name over inside its own scope rather than letting the
+# sibling's single keep answering.
+@seen = ();
+run { sub k($x) { @seen.push("single") }; k(1) }
+run { multi k(Int $) { @seen.push("multi-int") }; k(1) }
+is-deeply @seen, ['single', 'multi-int'], 'the multi wins in its own scope';
+
+# A genuine redeclaration inside ONE scope is still an error, at every depth.
+throws-like 'sub f1() {say 1}; multi f1() {say 2}', X::Redeclaration,
+    'compunit-level redeclaration still throws';
+throws-like 'sub o1 { sub f2() {say 1}; multi f2() {say 2} }; o1()',
+    X::Redeclaration, 'redeclaration inside one sub body still throws';
+throws-like 'sub r1(&c){c()}; r1 { sub f3() {say 1}; multi f3() {say 2} }',
+    X::Redeclaration, 'redeclaration inside one block still throws';
+
+# Several `multi`s of one name in one body are one routine, not a conflict.
+lives-ok { EVAL 'sub r2(&c){c()}; r2 { multi f4(Int $){}; multi f4(Str $){} }' },
+    'sibling multis in one body are fine';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -756,6 +756,15 @@ aliases (`≅ ⩵ ⩶ ≠ ≤ ≥`) parsed inline but did not resolve when reach
 evidence that `&infix:<op>` works** — the parser and the by-name dispatch are
 separate tables, and only the parser had the aliases.
 
+`S12-subset/subtypes.t` is closed
+(`news/2026-08/sibling-scope-routine-shadow.md`): a `sub f` in one subtest block
+made a `multi f` in the *next* one an `X::Redeclaration`, because mutsu keys the
+routine registry by package and the lexical-shadow exemption was gated on a
+scope depth that only an *inlined* bare block sets. **A declaration compiled in
+a routine/closure body is registered twice** (hoist pass, then in sequence), so
+any "have I seen this name before?" test in the compiler counts the hoist copy
+first.
+
 `roast/S12-methods/qualified.t` is worth a second look too: its Malformed
 assertion passes now and the file moved on to `Cannot dispatch to method me on
 Parent because it is not inherited or done by Bar` in its inheritance subtest.


### PR DESCRIPTION
```raku
sub run(&body) { body() }
run { sub f($x) { ... }; f(1) }
run { multi f($x) { ... }; f(2) }   # Redeclaration of routine 'f'
```

Two blocks, two scopes, two unrelated routines — but mutsu's routine registry is keyed by *package* alone, so the second declaration saw the first still registered. The exemption for this (`allow_lexical_shadow`) existed already, gated on `block_scope_depth > 0`, which an inlined bare block sets and a body executed as a routine or closure never does. Two sibling `sub` bodies hit it too.

The compiler knows the answer statically: it compiles such a body with its own `Compiler`, and its hoist pass already marks the copies it registers early as `__lexical_hoist`. What was missing is that the *in-sequence* registration of the very same declaration carried no such mark. `Compiler::mark_lexical_body` now sets the flag when a body compiler starts, and the `SubDecl` arm marks the declaration it registers.

Two things had to stay true while widening it:

- **A conflict inside one body is still `X::Redeclaration`.** `mark_lexical_body` records which names that body declares in a conflicting way (not every declaration `multi`) and refuses to mark those. Deciding this from the body's statements rather than compile order matters: each declaration is compiled twice (hoist pass, then in sequence), so an "is this the first one I have seen?" test marks the hoist copy and leaves the real one bare.
- **A `multi` that shadows a single takes the name over.** Registration already cleared a shadowed same-named entry for a plain `sub`; the `multi` case did not, so the sibling scope's `sub f` stayed registered and went on answering `f(2)` from inside the block whose own `multi f` had just been declared.

Found under the real `Test` module: `roast/S12-subset/subtypes.t` builds each `group-of` as a subtest block, and two of them declare `test-pos` — one `sub`, one `multi`. The file aborted at the second, losing 60 of its 92 assertions. It passes under `MUTSU_REAL_TEST=1` now, and still passes under the native provider.

Pin: `t/sibling-scope-routine-shadow.t` (all eight assertions verified against `raku`).

This does not make routine declarations lexically scoped — a routine declared in a body is still visible after that body returns, which `raku` rejects at compile time. That is the larger change; this fixes the redeclaration rule alone.

Verified locally: `make roast` PASS (1435 files), `make test` PASS (2856 files), batteries gate PASSED, `cargo clippy -- -D warnings` clean. (`roast/S04-exception-handlers/catch.t` timed out once mid-work; measured at 13–24 s on pristine `main` versus 10–21 s with this change, so that is pre-existing load sensitivity, not a regression here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)