### PR TITLE
fix(dispatch): samewith inside a lazy gather redispatches the right routine

### DIFF
--- a/news/2026-08/samewith-inside-lazy-gather.md
+++ b/news/2026-08/samewith-inside-lazy-gather.md
@@ -1,0 +1,55 @@
+# `samewith` inside a lazy `gather` redispatches the right routine
+
+`samewith` is *lexical* in Rakudo: it redispatches `&?ROUTINE`, the routine the
+call was written in. mutsu implemented it purely dynamically — a
+`samewith_context_stack` pushed on entering a multi candidate and popped on the
+way out — which is indistinguishable from the lexical rule right up until a
+closure created inside the routine runs after the routine has returned. A lazy
+`gather` body is exactly that closure, and it failed in two different ways
+depending on who forced it.
+
+**Forced from an outer scope, it died.** The frame it needed had been popped:
+
+    proto K($x, $len?) {*}
+    multi K($x)       { gather { take $x; take $x + 1 } }
+    multi K($x, $len) { gather for samewith($x) { take $_ * $len } }
+    say K(3, 10).list;   # samewith called outside of a dispatch context
+
+**Forced while some other routine was still on the stack, it silently
+redispatched THAT routine** — the worse failure, because nothing looked wrong
+until the arguments did not fit. `Digest::SHA3`'s `Keccak` is called from
+`sha3_256`, and its output stage is
+`gather for samewith $inputBytes, :$delimitedSuffix, :$rate, :$capacity {...}`;
+the `.list` that forces it runs inside `sha3_256`, so the top of the stack was
+`sha3_256` and mutsu called *that* with `Keccak`'s named arguments, reporting
+`Unexpected named argument 'delimitedSuffix' passed`.
+
+## The fix
+
+`exec_make_gather_op` records the innermost samewith context into the env
+snapshot it already takes for the gather body
+(`__mutsu_samewith_lexical_name`, plus `__mutsu_samewith_lexical_invocant` for a
+method), and every path that runs a gather body — `force_lazy_list_vm`,
+`force_lazy_list_vm_n`, `force_lazy_list` and `force_lazy_list_prefix_bridge` —
+re-pushes that context for the duration of the run.
+
+Re-pushing, rather than consulting the env at the `samewith` call site, is what
+keeps the rest of the semantics intact: a routine *called from* the body pushes
+its own frame on top, so its own `samewith` still means itself, and the frame
+disappears again when the force returns. The capture also lives in the gather's
+own env, so two gathers created in two different routines each redispatch their
+own routine.
+
+## What it unblocks
+
+This is the remaining half of `todo/tickets/digest-dist-blockers.md` §6.
+Together with the named-dispatch fix
+(`news/2026-08/multi-named-narrowness-declaration-order.md`), `Digest::SHA3`'s
+`sha3_256` now runs all the way through `Keccak` into `KeccakF1600`, where it
+stops on an unrelated `Cannot modify an immutable value` — recorded on the
+ticket.
+
+Pinned by `t/samewith-inside-lazy-gather.t` (8 tests, all of which also pass
+under `raku`), whose last case uses `t/lib/SamewithGatherModule.rakumod` to
+reproduce the `Digest::SHA3` shape exactly: a module-private `proto` redispatched
+from a gather that the exported entry point forces.

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -100,6 +100,9 @@ impl Interpreter {
     /// Re-dispatch to the same multi/method from the top with new arguments.
     pub(super) fn builtin_samewith(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         // Use the samewith context stack to find the enclosing multi sub/method.
+        // A lazy `gather` body re-pushes the context it captured at creation for
+        // the duration of its force (see `push_captured_samewith_context`), so
+        // this stack is correct there too.
         if let Some((name, invocant)) = self.samewith_context_stack.last().cloned() {
             if let Some(inv) = invocant {
                 // Method dispatch: re-call the method on the same invocant
@@ -112,6 +115,62 @@ impl Interpreter {
         Err(RuntimeError::new(
             "samewith called outside of a dispatch context",
         ))
+    }
+
+    /// Env key holding the routine name a lazy `gather` was created inside, so
+    /// `samewith` still resolves once the gather body is forced. By then the
+    /// declaring routine's dynamic `samewith_context_stack` frame is gone — and
+    /// worse, the frame on top belongs to whichever routine happened to force
+    /// the gather, so consulting the dynamic stack silently redispatched the
+    /// WRONG routine rather than failing.
+    ///
+    /// `samewith` is *lexical* in Rakudo — it re-dispatches `&?ROUTINE` — so
+    /// capturing it with the gather's env snapshot is the right shape, not a
+    /// workaround: the body keeps referring to the routine it was written in.
+    pub(crate) const SAMEWITH_LEXICAL_NAME_KEY: &str = "__mutsu_samewith_lexical_name";
+    /// Companion of [`Self::SAMEWITH_LEXICAL_NAME_KEY`] holding the invocant for
+    /// a method (absent for a plain sub).
+    pub(crate) const SAMEWITH_LEXICAL_INVOCANT_KEY: &str = "__mutsu_samewith_lexical_invocant";
+
+    /// Record the innermost dynamic samewith context into `env` so a closure
+    /// captured from it (today: a lazy `gather` body) can still redispatch.
+    pub(crate) fn capture_samewith_context_into(&self, env: &mut crate::env::Env) {
+        let Some((name, invocant)) = self.samewith_context_stack.last() else {
+            return;
+        };
+        env.insert(
+            Self::SAMEWITH_LEXICAL_NAME_KEY.to_string(),
+            Value::str(name.clone()),
+        );
+        if let Some(inv) = invocant {
+            env.insert(Self::SAMEWITH_LEXICAL_INVOCANT_KEY.to_string(), inv.clone());
+        }
+    }
+
+    /// Re-push the samewith context `env` captured (see
+    /// [`Self::capture_samewith_context_into`]) for the duration of a lazy
+    /// `gather` body's execution, so `samewith` written in that body resolves
+    /// to the routine the body was written in. Returns whether a frame was
+    /// pushed; the caller must then `pop_captured_samewith_context`.
+    ///
+    /// Pushing (rather than consulting the env at the `samewith` call) keeps
+    /// ordinary stack semantics: a routine *called from* the body pushes its
+    /// own frame on top and its `samewith` still means itself.
+    pub(crate) fn push_captured_samewith_context(&mut self, env: &crate::env::Env) -> bool {
+        let Some(name) = env.get(Self::SAMEWITH_LEXICAL_NAME_KEY) else {
+            return false;
+        };
+        let name = name.to_string_value();
+        let invocant = env.get(Self::SAMEWITH_LEXICAL_INVOCANT_KEY).cloned();
+        self.samewith_context_stack.push((name, invocant));
+        true
+    }
+
+    /// Undo a [`Self::push_captured_samewith_context`] that returned `true`.
+    pub(crate) fn pop_captured_samewith_context(&mut self, pushed: bool) {
+        if pushed {
+            self.samewith_context_stack.pop();
+        }
     }
 
     /// When a user method on a subclass of a builtin metamodel class

--- a/src/runtime/resolution_lazy.rs
+++ b/src/runtime/resolution_lazy.rs
@@ -66,7 +66,11 @@ impl Interpreter {
         // X::Redeclaration. The VM force path never hits this because it dispatches
         // the body's subs out of the body's own `compiled_fns`.
         self.push_block_scope_depth();
+        // The body's `samewith` names the routine the gather was WRITTEN in —
+        // see `push_captured_samewith_context`.
+        let pushed_samewith = self.push_captured_samewith_context(&list.env);
         let run_res = self.run_block(&list.body);
+        self.pop_captured_samewith_context(pushed_samewith);
         self.pop_block_scope_depth();
         let items = self.gather_items.pop().unwrap_or_default();
         self.gather_take_limits.pop();
@@ -104,7 +108,10 @@ impl Interpreter {
         self.gather_items.push(Vec::new());
         self.gather_take_limits.push(Some(needed_len));
         self.gather_suspend_pending = false;
+        // See `push_captured_samewith_context`.
+        let pushed_samewith = self.push_captured_samewith_context(&list.env);
         let run_res = self.run_block(&list.body);
+        self.pop_captured_samewith_context(pushed_samewith);
         // Clear the deferred-suspension flag on exit — see the matching clear
         // in force_lazy_list_vm_n_inner.
         self.gather_suspend_pending = false;

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -188,7 +188,12 @@ impl Interpreter {
         // The body runs under its OWN readonly context, not the consumer
         // frame's (see take_readonly_state).
         let saved_readonly = self.take_readonly_state();
+        // A `samewith` in the body means the routine the gather was WRITTEN in,
+        // not whichever routine is forcing it now — re-push the context the
+        // gather captured at creation.
+        let pushed_samewith = self.push_captured_samewith_context(&list.env);
         let r = self.force_lazy_list_vm_inner(list);
+        self.pop_captured_samewith_context(pushed_samewith);
         self.restore_readonly_state(saved_readonly);
         self.reconcile_caller_after_lazy_force(caller_code);
         // An array-context lazy list IS the array's element store: a Nil the
@@ -439,7 +444,10 @@ impl Interpreter {
         // The body runs under its OWN readonly context, not the consumer
         // frame's (see take_readonly_state).
         let saved_readonly = self.take_readonly_state();
+        // See `force_lazy_list_vm`: the body's `samewith` is lexical.
+        let pushed_samewith = self.push_captured_samewith_context(&list.env);
         let r = self.force_lazy_list_vm_n_inner(list, needed);
+        self.pop_captured_samewith_context(pushed_samewith);
         self.restore_readonly_state(saved_readonly);
         self.reconcile_caller_after_lazy_force(caller_code);
         // See force_lazy_list_vm: array-context elements store Any, not Nil.

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -81,6 +81,12 @@ impl Interpreter {
             self.box_captured_lexicals(code, &analysis_cc);
             let mut env = self.env().clone();
             env.insert("__mutsu_lazylist_from_gather".to_string(), Value::TRUE);
+            // A `samewith` in the body redispatches the routine the gather was
+            // WRITTEN in, but the body runs after that routine has returned and
+            // its dynamic dispatch frame has been popped. Capture the context
+            // with the env snapshot so it survives (Digest::SHA3's `Keccak`
+            // ends in `gather for samewith $inputBytes, ...`).
+            self.capture_samewith_context_into(&mut env);
             // A forward aggregate free var with no baked parent slot is the
             // self-reference in a binding initializer (`my @a := gather {
             // ... @a ... }`). Tag it before the LazyList is built; GetArrayVar

--- a/t/lib/SamewithGatherModule.rakumod
+++ b/t/lib/SamewithGatherModule.rakumod
@@ -1,0 +1,33 @@
+unit module SamewithGatherModule;
+
+# The shape `Digest::SHA3`'s `Keccak` uses: a `proto` whose wide candidate ends
+# in `gather for samewith <the narrow candidate's arguments> { ... }`, called
+# through an exported entry point. `Keccak` itself is NOT exported, so the
+# gather body's `samewith` has to resolve a name that is only visible inside
+# this module — while the body runs after `hashit` has returned.
+our proto hashit($) is export {*}
+multi hashit(Str $s) { samewith $s.encode }
+multi hashit(Blob $b) {
+    [~] Keccak $b, delimitedSuffix => 0x06, outputByteLen => 2,
+                   rate => 1088, capacity => 512
+}
+
+our proto Keccak(
+    Blob $inputBytes,
+    byte :$delimitedSuffix,
+    UInt :$outputByteLen is copy,
+    UInt :$rate where * %% 8,
+    UInt :$capacity where $rate + $capacity == 1600,
+) {*}
+
+multi Keccak($inputBytes, :$delimitedSuffix, :$rate, :$capacity) {
+    gather loop { take "b($delimitedSuffix,$rate,$capacity)" }
+}
+
+multi Keccak($inputBytes, :$delimitedSuffix, :$outputByteLen is copy, :$rate, :$capacity) {
+    gather for samewith $inputBytes, :$delimitedSuffix, :$rate, :$capacity {
+        take "w:$_";
+        $outputByteLen -= 1;
+        last if $outputByteLen <= 0;
+    }
+}

--- a/t/samewith-inside-lazy-gather.t
+++ b/t/samewith-inside-lazy-gather.t
@@ -1,0 +1,74 @@
+use lib $?FILE.IO.parent.add('lib').Str;
+use Test;
+use SamewithGatherModule;
+
+plan 8;
+
+# `samewith` is LEXICAL in Raku: it re-dispatches `&?ROUTINE`, the routine the
+# call was written in. A lazy `gather` body runs after that routine has already
+# returned, so a purely dynamic dispatch stack has nothing left to redispatch
+# to. Digest::SHA3's `Keccak` ends in exactly this shape:
+#
+#     gather for samewith $inputBytes, :$delimitedSuffix, :$rate, :$capacity {...}
+
+{
+    proto K($x, $len?) {*}
+    multi K($x)       { gather { take $x; take $x + 1 } }
+    multi K($x, $len) { gather for samewith($x) { take $_ * $len } }
+    is K(3, 10).list.join(","), "30,40",
+        'samewith in a gather-for list resolves after the routine returned';
+}
+
+# The delegate need not itself be lazy.
+{
+    proto L($x, $len?) {*}
+    multi L($x)       { (3, 4) }
+    multi L($x, $len) { gather for samewith($x) { take $_ * $len } }
+    is L(3, 10).list.join(","), "30,40",
+        'samewith in a gather resolving to an eager candidate';
+}
+
+# A `take`-ing gather that calls samewith directly (not through a `for`).
+{
+    proto M($x, $len?) {*}
+    multi M($x)       { $x * 2 }
+    multi M($x, $len) { gather { take samewith($x); take $len } }
+    is M(3, 10).list.join(","), "6,10", 'samewith directly inside a gather body';
+}
+
+# Methods keep their invocant.
+{
+    my class C {
+        proto method m($x, $len?) {*}
+        multi method m($x)       { gather { take $x; take $x + 1 } }
+        multi method m($x, $len) { gather for self.m($x) { take $_ * $len } }
+        multi method n($x)       { gather { take $x; take $x + 1 } }
+        multi method n($x, $len) { gather for samewith($x) { take $_ * $len } }
+    }
+    is C.new.m(3, 10).list.join(","), "30,40", 'explicit self.m control case';
+    is C.new.n(3, 10).list.join(","), "30,40", 'samewith in a gather inside a method';
+}
+
+# The capture is per-gather, not a global: a gather created in one routine and
+# forced after a DIFFERENT routine has run redispatches its own routine.
+{
+    proto P($x, $len?) {*}
+    multi P($x)       { gather { take $x; take $x + 1 } }
+    multi P($x, $len) { gather for samewith($x) { take $_ * $len } }
+
+    proto Q($x, $len?) {*}
+    multi Q($x)       { gather { take $x * 100 } }
+    multi Q($x, $len) { gather for samewith($x) { take $_ + $len } }
+
+    my $p = P(3, 10);
+    my $q = Q(3, 10);
+    is $q.list.join(","), "310", 'the second gather redispatches its own routine';
+    is $p.list.join(","), "30,40", 'and the first still redispatches its own';
+}
+
+# The Digest::SHA3 shape: the redispatched routine is module-private, and the
+# gather is forced from the consumer's scope. Before the fix the dynamic stack
+# named whichever routine was doing the forcing, so this redispatched the
+# EXPORTED entry point with the inner routine's named arguments.
+is SamewithGatherModule::hashit("abc"), "w:b(6,1088,512)w:b(6,1088,512)",
+    'samewith in a gather resolves a module-private proto';

--- a/todo/tickets/digest-dist-blockers.md
+++ b/todo/tickets/digest-dist-blockers.md
@@ -69,41 +69,48 @@ letting `encode_elems` do the width masking; see
 `news/2026-08/buf-wide-element-assign-saturation.md`. `sha384`, `sha512` and the
 rest of `t/sha.t`'s SHA-1/SHA-2 subtests now pass.
 
-## 6. `Digest::SHA3` — `samewith` inside a lazy `gather`
+## 6. `Digest::SHA3` — down to `KeccakF1600`'s immutable value
 
-The named-only multi-dispatch half of this blocker is FIXED — see
-`news/2026-08/multi-named-narrowness-declaration-order.md`. Named parameters now
-contribute exactly one boolean narrowness step ("declares a named at all"), and
-equally-narrow candidates are resolved by declaration order, so `Keccak`'s
-`:$outputByteLen`-less call reaches the sibling candidate it is delegating to
-instead of recursing into itself.
+Both originally-reported halves are FIXED:
 
-What remains is the lazy `gather`. `Digest::SHA3`'s `Keccak` is a `proto` with
-five named parameters and two `multi`s; the `:$outputByteLen` candidate finishes
-with
+- the named-only multi dispatch (`Keccak`'s two candidates differ only in an
+  extra `:$outputByteLen`) —
+  `news/2026-08/multi-named-narrowness-declaration-order.md`;
+- `samewith` inside the lazy `gather` that `Keccak`'s wide candidate ends with —
+  `news/2026-08/samewith-inside-lazy-gather.md`. Its "Unexpected named argument
+  'delimitedSuffix' passed" face was the same bug: the dynamic dispatch stack
+  named `sha3_256` (the routine doing the forcing) instead of `Keccak`, so the
+  redispatch went to the wrong routine rather than failing.
 
-    gather for samewith $inputBytes, :$delimitedSuffix, :$rate, :$capacity { ... }
+`sha3_256("abc")` now runs all the way into the permutation and stops on an
+unrelated bug:
 
-Calling it directly dies with `samewith called outside of a dispatch context` —
-the enclosing routine's dispatch frame is gone by the time the lazy `gather`
-body runs. Reduced:
+    Cannot modify an immutable value
+      in sub KeccakF1600 ... in sub Keccak ... in sub sha3_256
 
-    proto K($x, :$a, :$len) {*}
-    multi K($x, :$a)        { gather { take $x; take $x + $a } }
-    multi K($x, :$a, :$len) { gather for samewith($x, :$a) { take $_ * $len } }
-    say K(3, a => 1, len => 10).list;
-    # raku:  (30 40)
-    # mutsu: an empty line
+`KeccakF1600` has two candidates, `multi KeccakF1600(@lanes)` and
+`multi KeccakF1600(blob8 $state)`, and the caller writes
+`$state .= &KeccakF1600`. That is the next thing to reduce.
 
-(mutsu prints an empty line — the `say` runs but the list is empty, and the
-`samewith` failure never surfaces — so there is a second problem in how the
-failing `gather` is sunk.)
+Two smaller residues found while fixing the above, neither on the `Digest`
+critical path:
 
-Going through `sha3_256` instead of calling `Keccak` directly currently fails
-earlier and differently ("Unexpected named argument 'delimitedSuffix' passed",
-reported against `multi sha3_256(Blob $input) { [~] Keccak $input, … }`); that
-may be the reduce metaop `[~]` swallowing the named arguments into its list
-rather than passing them to `Keccak`, and needs its own reduction.
+- A gather created inside a module routine and forced from the *consumer's*
+  top-level scope cannot resolve a module-private name:
+  `Digest::SHA3::Keccak(...)` called directly from a script dies with
+  `Unknown function: Keccak` when its `samewith` fires. Going through the
+  exported `sha3_256` works, because the force then happens with the module's
+  scope in view. The samewith context capture records only the routine NAME;
+  making it carry the declaring package needs the package-qualified proto
+  dispatch below to work first.
+- `T::K8::Keccak(...)` — a package-qualified call to a module's `proto` from
+  outside the module — reports `No matching candidates for proto sub:
+  T::K8::Keccak` even though the identical unqualified call inside the module
+  resolves. Independent of `samewith`; reproduced with a two-candidate proto
+  and no `gather` at all.
+- `say` swallows an exception raised while `.gist` forces a lazy `Seq`, which is
+  what made the original `samewith` failure print an empty line instead of an
+  error: `todo/tickets/say-swallows-an-exception-from-gist.md`.
 
 ## 5. `read-ubits` / `write-bits` on a wide buffer
 

--- a/todo/tickets/say-swallows-an-exception-from-gist.md
+++ b/todo/tickets/say-swallows-an-exception-from-gist.md
@@ -1,0 +1,47 @@
+# `say` swallows an exception raised while computing `.gist`
+
+`render_gist_value` (`src/runtime/io_env.rs`) calls `.gist` on the value and, on
+*any* error, falls back to the native gist:
+
+```rust
+match self.call_method_with_values(value.clone(), "gist", vec![]) {
+    Ok(result) => Ok(result.to_string_value()),
+    Err(e) if e.return_value.is_some() => Err(RuntimeError::controlflow_return(true)),
+    Err(e) if /* X::ControlFlow::Return */ => Err(e),
+    Err(_) => Ok(crate::runtime::gist_value(value)),
+}
+```
+
+The fallback is meant for a *dispatch* failure (no `.gist` to call), but it also
+eats a genuine user exception thrown from inside `.gist` — including one thrown
+while `.gist` forces a lazy `Seq`. The existing `TODO` on that function already
+notes that `render_str_value` (`put`/`print`) swallows even the control signals.
+
+Minimal repro — a `die` in a `gather` created inside a routine:
+
+```raku
+sub f() { gather { take 1; die "boom-after-take" } }
+say f().list;        # raku: dies with "boom-after-take"
+say "after f";       # mutsu: prints an empty line, then "after f", exit 0
+```
+
+The same gather written at file scope propagates correctly, because `say` gets a
+plain `Seq` there rather than an unforced `LazyList` whose `.gist` does the
+forcing. `f().raku` also propagates — only the `.gist` route swallows.
+
+This was found while fixing `samewith` inside a lazy `gather`
+(`news/2026-08/samewith-inside-lazy-gather.md`); it is what made that bug print
+an empty line instead of reporting `samewith called outside of a dispatch
+context`, and it is what `todo/tickets/digest-dist-blockers.md` §6 called "a
+second problem in how the failing `gather` is sunk".
+
+## Why it is not a one-liner
+
+Narrowing the fallback means deciding which errors are "dispatch failed, use the
+native gist" and which are "the user's code threw". mutsu signals a missing
+method in more than one shape (a typed `X::Method::NotFound` instance, and plain
+`RuntimeError`s whose message starts with `X::Method::NotFound:` — see
+`methods_classhow_dispatch.rs` / `methods_grammar.rs`), so the predicate has to
+be written against the real set, not guessed. `say`/`note`/`put`/`print` are on
+essentially every code path, so the blast radius is the whole suite: the change
+wants its own PR and a full roast run, not a rider on an unrelated fix.


### PR DESCRIPTION
`samewith` is *lexical* in Rakudo — it redispatches `&?ROUTINE`, the routine the call was written in. mutsu resolved it purely dynamically, from a `samewith_context_stack` pushed on entering a multi candidate and popped on the way out. A lazy `gather` body runs *after* that routine has returned, so it failed in two different ways depending on who forced it.

**Forced from an outer scope, it died:**

```raku
proto K($x, $len?) {*}
multi K($x)       { gather { take $x; take $x + 1 } }
multi K($x, $len) { gather for samewith($x) { take $_ * $len } }
say K(3, 10).list;   # samewith called outside of a dispatch context
```

**Forced while another routine was still on the stack, it silently redispatched THAT routine** — the worse failure, because nothing looks wrong until the arguments do not fit. `Digest::SHA3`'s `Keccak` is called from `sha3_256` and its output stage is `gather for samewith $inputBytes, :$delimitedSuffix, :$rate, :$capacity {...}`; the `.list` that forces it runs *inside* `sha3_256`, so the top of the stack was `sha3_256` and mutsu called that with `Keccak`'s named arguments, reporting `Unexpected named argument 'delimitedSuffix' passed`. That message was previously filed on the ticket as a possibly-separate `[~]`-reduce bug; it is this one.

## The fix

`exec_make_gather_op` records the innermost samewith context into the env snapshot it already takes for the gather body (`__mutsu_samewith_lexical_name`, plus `__mutsu_samewith_lexical_invocant` for a method), and every path that runs a gather body — `force_lazy_list_vm`, `force_lazy_list_vm_n`, `force_lazy_list`, `force_lazy_list_prefix_bridge` — re-pushes that context for the duration of the run.

Re-pushing, rather than consulting the env at the `samewith` call site, is what keeps the rest of the semantics intact: a routine *called from* the body pushes its own frame on top, so its own `samewith` still means itself, and the frame disappears again when the force returns. The capture lives in each gather's own env, so two gathers created in two different routines each redispatch their own routine.

## What it unblocks

The remaining half of `todo/tickets/digest-dist-blockers.md` §6. `Digest::SHA3`'s `sha3_256` now runs all the way through `Keccak` into `KeccakF1600`, where it stops on an unrelated `Cannot modify an immutable value` — recorded on the ticket along with two smaller residues found on the way (a module-private name not resolving when the gather is forced from the consumer's top-level scope, and package-qualified proto dispatch failing from outside the module).

Also files `todo/tickets/say-swallows-an-exception-from-gist.md`: `render_gist_value` falls back to the native gist on *any* error, so `say` on a lazy `Seq` whose forcing throws prints an empty line and continues. That is what hid the original `samewith` failure. It needs its own PR — `say`/`note`/`put` are on every code path.

## Testing

- `t/samewith-inside-lazy-gather.t` (new, 8 tests) — all 8 also pass under `raku`. The last case uses `t/lib/SamewithGatherModule.rakumod` to reproduce the `Digest::SHA3` shape exactly: a module-private `proto` redispatched from a gather that the exported entry point forces.
- Full local `prove t/`: 2859 files, 27157 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)