### PR TITLE
fix(pair): a pair read out of a Hash is a positional argument

### DIFF
--- a/news/2026-08/hash-derived-pairs-are-positional-arguments.md
+++ b/news/2026-08/hash-derived-pairs-are-positional-arguments.md
@@ -1,0 +1,51 @@
+# A pair read out of a Hash is a positional argument
+
+In Raku, whether an argument is named is a property of the **call site**, not of
+the value: only a literal `k => v` / `:k(...)` written in the argument list is a
+named argument. A `Pair` that arrives through a variable — including one read
+out of a Hash — is an ordinary positional argument.
+
+mutsu encodes named-ness in the value instead (`ValueRepr::Pair` with a `Str`
+key means "named argument", `ValueRepr::ValuePair` means "positional"), so every
+hash-derived pair was misread as a named argument:
+
+```raku
+class C {
+    multi method take(Pair $p) { "Pair" }
+    multi method take(Str $s)  { "Str"  }
+}
+my %h = a => 1;
+C.new.take(%h.pairs[0]);    # Cannot resolve caller take(C:D: :a(Int))
+```
+
+`%h.pairs`, `%h.List`, `%h.antipairs`, `%h.invert` and iterating `%h` now all
+build the positional flavour, so each of those binds the `Pair` candidate as
+`raku` does.
+
+Two consequences fell out of it:
+
+- **`-> (:$k)` is a destructure, not a named parameter.** The lambda parser
+  flattened a lone named sub-signature parameter to the top level, which only
+  appeared to work while the pair being destructured was itself a named
+  argument. It now becomes a `__subsig__` destructuring parameter, like every
+  other parenthesised signature. (`-> :$k` remains the named parameter.)
+- **A `ValuePair` destructures exactly like a `Pair`.**
+  `named_values_from_unpack_target` handled only the latter; the two differ only
+  in what the call site meant, which has nothing to do with `Pair.Capture`.
+
+`t/coercion-type-regressions.t` was pinning `-> (:Str(Any) :$suffix)`, which
+`raku` rejects outright ("Missing block"); it now uses the shape the
+authoritative roast test (`S12-coercion/coercion-types.t`, rakudo #1800) writes,
+`-> % ( Str(Any) :$suffix )`.
+
+This is one slice of a wider problem — `Pair.new`, a fat-arrow assigned to a
+variable, and a fat-arrow inside an array literal still mint the named flavour.
+The remainder is tracked in
+`todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md`.
+
+With this and `%h.List` yielding pairs, `Cro::HTTP::Client` accepts
+`headers => %h`, so a request carrying custom headers completes: the vendored
+Cro suite's `http-middleware.rakutest` subtest 3 ("Conditional response
+middleware") now passes in full, as does subtest 7.
+
+Pinned by `t/hash-pair-is-positional-argument.t`.

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -99,9 +99,7 @@ fn positional_antipairs(values: &[Value]) -> Vec<Value> {
 }
 
 fn make_inverted_pair(key: Value, value: Value) -> Value {
-    if let ValueView::Str(s) = key.view() {
-        return Value::pair((**s).clone(), value);
-    }
+    // Positional flavour regardless of key type — see `quanthash_typed_pair`.
     Value::value_pair(key, value)
 }
 
@@ -638,7 +636,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     } else {
                         items
                             .iter()
-                            .map(|(k, v)| Value::pair(k.clone(), v.deref_container()))
+                            .map(|(k, v)| {
+                                Value::value_pair(Value::str(k.clone()), v.deref_container())
+                            })
                             .collect()
                     };
                     Some(Ok(Value::seq(pairs)))
@@ -741,12 +741,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         .map(|(k, v)| {
                             let orig_key = crate::runtime::utils::hash_typed_key(target, k);
                             // Decontainerize element cells (see t/bind-hash-value-pairs.t).
-                            let dv = v.deref_container();
-                            if let ValueView::Str(s) = dv.view() {
-                                Value::pair(s.to_string(), orig_key)
-                            } else {
-                                Value::value_pair(dv, orig_key)
-                            }
+                            Value::value_pair(v.deref_container(), orig_key)
                         })
                         .collect();
                     Some(Ok(Value::seq(pairs)))

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -141,7 +141,13 @@ fn arrow_lambda_inner(input: &str) -> PResult<'_, Expr> {
         if is_rw_block {
             inject_rw_trait(&mut sub_params);
         }
-        let param_defs = if sub_params.len() > 1 {
+        // A lone *named* sub-param is also a destructure, not a named parameter:
+        // `-> (:$suffix)` binds the `suffix` key out of the single argument it is
+        // handed (`%h.map(-> (:$k) {...})`), whereas `-> :$suffix` declares a
+        // named parameter the caller must pass. Flattening the former into the
+        // latter only appeared to work while every hash-derived pair was itself
+        // treated as a named argument.
+        let param_defs = if sub_params.len() > 1 || sub_params.first().is_some_and(|p| p.named) {
             let mut p = crate::parser::stmt::sub_param::make_param("__subsig__".to_string());
             p.sub_signature = Some(sub_params);
             vec![p]

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -301,6 +301,17 @@ pub(in crate::runtime) fn named_values_from_unpack_target(
             out.insert("value".to_string(), val.clone());
             out
         }
+        // A `ValuePair` destructures exactly like a `Pair` — the two differ only
+        // in whether the *call site* meant the pair as a named argument, which is
+        // nothing to do with `Pair.Capture`. A hash entry (`%h.map(-> (:$k) {...})`)
+        // arrives as a ValuePair, so without this arm it bound nothing.
+        ValueView::ValuePair(key, val) => {
+            let mut out = std::collections::HashMap::new();
+            out.insert(key.to_string_value(), (*val).clone());
+            out.insert("key".to_string(), (*key).clone());
+            out.insert("value".to_string(), (*val).clone());
+            out
+        }
         // A list of Pairs (e.g. `(a => 1, b => 2)`) destructured by named
         // params `(:$a, :$b)` binds each pair's key to its value.
         ValueView::Array(data, _) => pairs_in_list_to_named(data.items()),

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -114,7 +114,10 @@ impl HashData {
     pub fn typed_pair(&self, str_key: &str, value: Value) -> Value {
         let value = value.deref_container();
         match self.typed_key(str_key).into_repr() {
-            ValueRepr::Str(s) => Value::Pair((*s).clone(), Box::new(value)),
+            ValueRepr::Str(s) => Value::ValuePair(
+                Box::new(Value::from_repr(ValueRepr::Str(s))),
+                Box::new(value),
+            ),
             other => Value::ValuePair(Box::new(Value::from_repr(other)), Box::new(value)),
         }
     }

--- a/t/coercion-type-regressions.t
+++ b/t/coercion-type-regressions.t
@@ -6,9 +6,12 @@ throws-like { Int(Str).^coerce(3.141592653589793) },
     X::Coerce::Impossible,
     '.^coerce rejects unacceptable source value';
 
-my %pairs = :suffix("s");
+# The shape roast/S12-coercion/coercion-types.t exercises (rakudo #1800): a `%`
+# parameter whose sub-signature binds a coercive named. The bare `-> (:Str(Any)
+# :$suffix)` this test used to write is not valid Raku at all — `raku` rejects it
+# with "Missing block" — so it was pinning a mutsu-only parse.
 my %unit-multipliers = :s(1);
-my $mapped = %pairs.map(-> (:Str(Any) :$suffix) { %unit-multipliers{$suffix} });
+my $mapped = ({ suffix => 's' },).map(-> % ( Str(Any) :$suffix ) { %unit-multipliers{$suffix} });
 is $mapped[0], 1, 'map callback with named coercive parameter binds pair payload';
 
 my class SubCo {...}

--- a/t/hash-pair-is-positional-argument.t
+++ b/t/hash-pair-is-positional-argument.t
@@ -1,0 +1,34 @@
+use Test;
+plan 6;
+
+# In Raku, whether an argument is named is a property of the CALL SITE, not of
+# the value: only a literal `k => v` / `:k(...)` written in the argument list is
+# a named argument. A Pair that arrives through a variable — including one read
+# out of a Hash — is an ordinary positional argument.
+#
+# mutsu encodes named-ness in the value (`Pair` = named, `ValuePair` =
+# positional), so every hash-derived pair used to be misread as a named
+# argument. That is what made `Cro::HTTP::Client` reject `headers => %h`: its
+# `set-headers` matches `when Pair` and then calls `$request.append-header($_)`,
+# whose typed multi candidates saw a named argument and no candidate matched.
+
+class Sink {
+    multi method take(Pair $p) { "Pair:" ~ $p.key ~ '=' ~ $p.value }
+    multi method take(Str $s) { "Str:$s" }
+    multi method take(Str $n, Str $v) { "Str,Str" }
+}
+my $sink = Sink.new;
+my %h = a => 1;
+
+is $sink.take(%h.pairs[0]), 'Pair:a=1', 'a pair from %h.pairs binds the Pair candidate';
+is $sink.take(%h.List[0]), 'Pair:a=1', 'a pair from %h.List binds the Pair candidate';
+is %h.map({ $sink.take($_) }).join, 'Pair:a=1', 'a pair from iterating %h binds the Pair candidate';
+is $sink.take(%h.antipairs[0]), 'Pair:1=a', 'a pair from %h.antipairs binds the Pair candidate';
+is $sink.take(%h.invert[0]), 'Pair:1=a', 'a pair from %h.invert binds the Pair candidate';
+
+# `-> (:$k)` destructures its single argument; it is not a named parameter.
+# (`-> :$k` is the named parameter.) Flattening the former into the latter only
+# looked right while every hash-derived pair was itself a named argument — the
+# argument here is a Hash, whose Capture exposes its keys as named parts.
+is ({ a => 1 },).map(-> (:$a) { $a }).join, '1',
+    'a lone named sub-signature param destructures the argument';

--- a/todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md
+++ b/todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md
@@ -29,12 +29,26 @@ $c.m(Pair.new('a', 1));           # Cannot resolve caller m(C:D: :a(Int))
 my $p = a => 1;      $c.m($p);    # Cannot resolve caller m(C:D: :a(Int))
 my $q = :a(1);       $c.m($q);    # Cannot resolve caller m(C:D: :a(Int))
 my @l = [a => 1];    $c.m(@l[0]); # Cannot resolve caller m(C:D: :a(Int))
-my %h = a => 1;      $c.m(%h.pairs[0]); # Cannot resolve caller m(C:D: :a(Int))
 
 my $r = (a => 1);    $c.m($r);    # works — parenthesised, so PositionalPair
 ```
 
 `raku` prints `Pair` for every one of these. `tmp/hdr15.p6` is the matrix above.
+
+## What is already fixed
+
+The **hash-derived** half is done: entries read out of a Hash (`%h.pairs`,
+`%h.List`, `%h.antipairs`, `%h.invert`, iterating `%h`) are now built as
+positional pairs, so `$c.m(%h.pairs[0])` binds the `Pair` candidate — see
+`news/2026-08/hash-derived-pairs-are-positional-arguments.md` and
+`t/hash-pair-is-positional-argument.t`. What remains is every *other* way a Pair
+is minted: `Pair.new`, a fat-arrow or colonpair assigned to a variable, and a
+fat-arrow inside an array/list literal (`MakePair`).
+
+One deliberate exclusion from that slice: `quanthash_typed_pair` (Set/Bag/Mix
+entries) was left on the named flavour. Switching it made the vendored Cro
+suite's `http-middleware.rakutest` abort mid-file, so it needs its own
+investigation rather than being swept along.
 
 ## Why it matters
 
@@ -51,12 +65,11 @@ method !set-headers($request, @headers) {
 ```
 
 `when Pair` matches, then `append-header($_)` dispatches with `$_` read as a
-named argument and no candidate matches. So **every** `Cro::HTTP::Client`
-request that passes `headers => [...]` dies, which is what fails the vendored
-Cro suite's `http-middleware.rakutest` subtest 3 (its second half sends
-`Authorization: Bearer Polarer`) and blocks `router-auth`,
-`http-auth-basic*`, `http-session-*`. Minimal repro:
-`tmp/hdr2.p6` (mutsu: `X::Multi::NoMatch` on `append-header`; raku: 200).
+named argument and no candidate matches. `headers => %h` reaches `set-headers`
+through `%h.List` and so works now; `headers => [Authorization => '...']`
+reaches it through an array literal, whose elements `MakePair` still mints as
+named, and still dies. Minimal repro: `tmp/hdr2.p6` (the `list of pairs` line;
+mutsu: `X::Multi::NoMatch` on `append-header`, raku: 200).
 
 ## Why this is a deep ticket
 


### PR DESCRIPTION
## Problem

In Raku, whether an argument is named is a property of the **call site**, not of
the value: only a literal `k => v` / `:k(...)` written in the argument list is a
named argument. A `Pair` that arrives through a variable — including one read
out of a Hash — is an ordinary positional argument.

mutsu encodes named-ness in the value instead (`ValueRepr::Pair` with a `Str`
key = named, `ValueRepr::ValuePair` = positional), so every hash-derived pair
was misread as a named argument:

```raku
class C {
    multi method take(Pair $p) { "Pair" }
    multi method take(Str $s)  { "Str"  }
}
my %h = a => 1;
C.new.take(%h.pairs[0]);    # Cannot resolve caller take(C:D: :a(Int))
```

## Fix

`%h.pairs`, `%h.List`, `%h.antipairs`, `%h.invert` and iterating `%h` now build
the positional flavour, so each binds the `Pair` candidate as `raku` does.

Two consequences fell out of it:

- **`-> (:$k)` is a destructure, not a named parameter.** The lambda parser
  flattened a lone named sub-signature parameter to the top level, which only
  appeared to work while the pair being destructured was itself named. It now
  becomes a `__subsig__` parameter like every other parenthesised signature.
  (`-> :$k` remains the named parameter.)
- **A `ValuePair` destructures exactly like a `Pair`.**
  `named_values_from_unpack_target` handled only the latter; the two differ only
  in what the call site meant, which has nothing to do with `Pair.Capture`.

`t/coercion-type-regressions.t` was pinning `-> (:Str(Any) :$suffix)`, which
`raku` rejects outright ("Missing block"). It now uses the shape the
authoritative roast test (`S12-coercion/coercion-types.t`, rakudo #1800) writes,
`-> % ( Str(Any) :$suffix )` — and that roast file passes.

## Result

Together with `%h.List` yielding pairs (#5866), `Cro::HTTP::Client` accepts
`headers => %h`, so a request carrying custom headers completes. In the vendored
Cro suite's `http-middleware.rakutest`, subtests **3** ("Conditional response
middleware") and **7** now pass in full — 4 failing subtests on `main` down to 2.

## Scope

This is one slice. `Pair.new`, a fat-arrow assigned to a variable, and a
fat-arrow inside an array literal still mint the named flavour; that remainder
is tracked in
`todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md`,
which this PR updates. One deliberate exclusion is recorded there too: switching
Set/Bag/Mix entries (`quanthash_typed_pair`) made that Cro suite abort mid-file,
so it needs its own investigation rather than being swept along here.

## Verification

- `t/hash-pair-is-positional-argument.t` — six checks, all matching `raku`.
- `make test` passes (2857 files, 27132 tests).
- Whitelisted `S02-*`, `S03-*`, `S06-*`, `S12-*`, `S32-hash/*`, `S29-context/*`
  roast subset clean (485 files), plus `S04-*`/`S05-*`/`S09-*`/`S11-*`/`S14-*`/
  `S16-*`/`S17-supply/*` clean on a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)