### PR TITLE
fix(parser): a multi-dimensional subscript is a compound-assignment lvalue

### DIFF
--- a/news/2026-08/multidim-subscript-compound-assign.md
+++ b/news/2026-08/multidim-subscript-compound-assign.md
@@ -1,0 +1,31 @@
+# A multi-dimensional subscript is a compound-assignment lvalue
+
+`@a[$x;$y] += 1` died with `Cannot modify an immutable value`, while the plain
+`@a[$x;$y] = $v` form has always worked. The failure was decided at parse time,
+not at run time: `build_compound_assign_expr`
+(`src/parser/stmt/assign/compound_expr.rs`) has an arm for `Expr::Index` — the
+single-subscript lvalue — but none for `Expr::MultiDimIndex`, so every
+multi-dimensional LHS fell through to the generic "this is not an lvalue" case
+and compiled to an unconditional `__mutsu_assignment_ro` call. The AST dump made
+it obvious:
+
+    DoBlock { body: [ MultiDimIndex { .. }, Literal(5),
+                      Call { name: "__mutsu_assignment_ro" } ] }
+
+The new arm mirrors the single-subscript one: each dimension is bound to a temp
+so a side-effecting subscript (`@a[$i++; f()] += 1`) is evaluated exactly once
+and shared by the read-back and the write, then the result is a
+`MultiDimIndexAssign` whose value is the compound expression. Short-circuit
+operators (`//=`, `||=`, …) keep their existing handling.
+
+Found in `Digest::SHA3`, whose `KeccakF1600` is written almost entirely in this
+form (`for ^5 X ^5 -> ($x, $y) { @lanes[$x;$y] +^= @D[$x] }`) — see
+`todo/tickets/digest-dist-blockers.md`. An `@`-parameter is bound read-only but
+its *elements* are the caller's containers and stay writable, which is exactly
+what that code relies on; the RO error was reported against the element write,
+so it read like a parameter-mutability bug rather than a missing parser arm.
+
+Pinned by `t/multidim-compound-assign.t` (12 tests, all also passing under
+`raku`), covering numeric/bitwise/string operators, three dimensions, an
+`@`-parameter and a `multi` candidate, `%h{k1;k2}`, single evaluation of the
+subscripts, `//=` short-circuiting, and the value the expression yields.

--- a/src/parser/stmt/assign/compound_expr.rs
+++ b/src/parser/stmt/assign/compound_expr.rs
@@ -124,6 +124,49 @@ pub(crate) fn build_compound_assign_expr(
                 |lhs_expr| compound_assigned_value_expr(lhs_expr, op, rhs),
             ));
         }
+        // `@a[$x;$y] op= rhs` — the multi-dimensional twin of the `Expr::Index`
+        // arm above. Without it the LHS fell through to the `other` arm and
+        // compiled to an unconditional `__mutsu_assignment_ro`, so every
+        // `@lanes[$x;$y] +^= @D[$x]` died with "Cannot modify an immutable
+        // value" (Digest::SHA3's `KeccakF1600`) even though the plain
+        // `@a[$x;$y] = v` form has always worked.
+        Expr::MultiDimIndex { target, dimensions } => {
+            // Bind each dimension to a temp so a side-effecting subscript
+            // (`@a[$i++; f()] += 1`) is evaluated exactly once, shared by the
+            // read-back and the write — same reason as the single-index arm.
+            let mut body = Vec::with_capacity(dimensions.len() + 1);
+            let mut tmp_dims = Vec::with_capacity(dimensions.len());
+            for dim in dimensions {
+                let tmp = format!(
+                    "__mutsu_idx_{}",
+                    TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
+                );
+                body.push(Stmt::VarDecl {
+                    name: tmp.clone(),
+                    expr: dim,
+                    type_constraint: None,
+                    is_state: false,
+                    is_our: false,
+                    is_dynamic: false,
+                    is_export: false,
+                    export_tags: Vec::new(),
+                    custom_traits: Vec::new(),
+                    where_constraint: None,
+                });
+                tmp_dims.push(Expr::Var(tmp));
+            }
+            let read_back = Expr::MultiDimIndex {
+                target: target.clone(),
+                dimensions: tmp_dims.clone(),
+            };
+            let assigned_value = compound_assigned_value_expr(read_back, op, rhs);
+            body.push(Stmt::Expr(Expr::MultiDimIndexAssign {
+                target,
+                dimensions: tmp_dims,
+                value: Box::new(assigned_value),
+            }));
+            Expr::DoBlock { body, label: None }
+        }
         Expr::MethodCall {
             target,
             name,

--- a/t/multidim-compound-assign.t
+++ b/t/multidim-compound-assign.t
@@ -1,0 +1,78 @@
+use Test;
+
+plan 12;
+
+# `@a[$x;$y] op= rhs` — the multi-dimensional subscript as a compound-assignment
+# lvalue. The parser had no arm for it, so it fell through to the generic
+# "not an lvalue" case and compiled to an unconditional X::Assignment::RO:
+# every `@lanes[$x;$y] +^= @D[$x]` (Digest::SHA3's `KeccakF1600`) died with
+# "Cannot modify an immutable value", while the plain `@a[$x;$y] = v` form has
+# always worked.
+
+{
+    my @a = [1, 2], [3, 4];
+    @a[0;1] += 5;
+    is @a.raku, [[1, 7], [3, 4]].raku, 'numeric compound assign through @a[x;y]';
+
+    @a[1;0] +^= 5;
+    is @a.raku, [[1, 7], [6, 4]].raku, 'bitwise compound assign through @a[x;y]';
+
+    @a[1;1] ~= "!";
+    is @a[1;1], "4!", 'string compound assign through @a[x;y]';
+}
+
+# Three dimensions.
+{
+    my @c;
+    @c[0;0;0] = 1;
+    @c[0;0;0] += 41;
+    is @c[0;0;0], 42, 'compound assign through a three-dimensional subscript';
+}
+
+# An `@`-parameter is bound read-only, but its ELEMENTS are the caller's
+# containers and stay writable — this is what Digest::SHA3 relies on.
+{
+    sub bump(@lanes) { @lanes[1;1] +^= 5; @lanes }
+    my @b = [1, 2], [3, 4];
+    bump(@b);
+    is @b.raku, [[1, 2], [3, 1]].raku, 'compound assign through an @-parameter element';
+
+    multi mbump(@lanes) { @lanes[0;0] +^= 1; @lanes }
+    my @d = [1, 2], [3, 4];
+    mbump(@d);
+    is @d.raku, [[0, 2], [3, 4]].raku, '...and through a multi candidate';
+}
+
+# A hash of hashes uses the same subscript form.
+{
+    my %g = a => { b => 1 };
+    %g{"a";"b"} += 41;
+    is %g<a><b>, 42, 'compound assign through %h{k1;k2}';
+}
+
+# The subscript expressions must be evaluated exactly once, shared by the
+# read-back and the write.
+{
+    my $calls = 0;
+    sub idx($n) { $calls++; $n }
+    my @e = [1, 2], [3, 4];
+    @e[idx(0); idx(1)] += 10;
+    is @e[0;1], 12, 'the element is updated';
+    is $calls, 2, 'each subscript expression is evaluated exactly once';
+}
+
+# Short-circuit compound operators keep their short-circuit semantics.
+{
+    my @f = [1, Nil], [3, 4];
+    @f[0;1] //= 9;
+    is @f[0;1], 9, '//= fills an undefined element';
+    @f[0;1] //= 11;
+    is @f[0;1], 9, '//= leaves a defined element alone';
+}
+
+# The whole thing is still an expression yielding the assigned value.
+{
+    my @g = [1, 2], [3, 4];
+    my $r = (@g[0;0] += 6);
+    is $r, 7, 'the compound assignment evaluates to the new value';
+}


### PR DESCRIPTION
`@a[$x;$y] += 1` died with `Cannot modify an immutable value`, while the plain `@a[$x;$y] = $v` form has always worked.

The failure was decided at **parse** time, not at run time. `build_compound_assign_expr` (`src/parser/stmt/assign/compound_expr.rs`) has an arm for `Expr::Index` — the single-subscript lvalue — but none for `Expr::MultiDimIndex`, so every multi-dimensional LHS fell through to the generic "this is not an lvalue" case and compiled to an unconditional `__mutsu_assignment_ro` call. `--dump-ast` shows it directly:

```
DoBlock { body: [ MultiDimIndex { .. }, Literal(5),
                  Call { name: "__mutsu_assignment_ro" } ] }
```

The new arm mirrors the single-subscript one: each dimension is bound to a temp so a side-effecting subscript (`@a[$i++; f()] += 1`) is evaluated exactly once and shared by the read-back and the write, then the result is a `MultiDimIndexAssign` whose value is the compound expression. Short-circuit operators (`//=`, `||=`, …) keep their existing handling.

## Where it came from

`Digest::SHA3`'s `KeccakF1600` is written almost entirely in this form:

```raku
for ^5 X ^5 -> ($x, $y) { @lanes[$x;$y] +^= @D[$x] }
```

An `@`-parameter is bound read-only but its *elements* are the caller's containers and stay writable, which is what that code relies on — and since the RO error was reported against the element write, it read like a parameter-mutability bug rather than a missing parser arm. See `todo/tickets/digest-dist-blockers.md`.

## Testing

- `t/multidim-compound-assign.t` (new, 12 tests) — all also pass under `raku`. Covers numeric/bitwise/string operators, three dimensions, an `@`-parameter and a `multi` candidate, `%h{k1;k2}`, single evaluation of the subscript expressions, `//=` short-circuiting, and the value the expression yields.
- Full local `prove t/`: 2859 files, 27161 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)