### PR TITLE
refactor(compiler): install sub candidates from compiled plans

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -197,6 +197,10 @@ pub(crate) struct FunctionDef {
     /// `multi f(Str :$a)`). 0 only for defs built outside a registration path.
     #[serde(default)]
     pub(crate) decl_order: u64,
+    /// Bytecode body selected by the declaration plan that installed this
+    /// candidate. Temporary ADR-0019 adapter; skipped by the AST/precomp format.
+    #[serde(skip)]
+    pub(crate) compiled: Option<std::sync::Arc<crate::opcode::CompiledFunction>>,
 }
 
 /// A `fmt::Write` sink that streams formatted bytes straight into a `Hasher`,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2421,6 +2421,22 @@ mod tests {
     }
 
     #[test]
+    fn sub_declaration_installs_its_compiled_candidate() {
+        let mut interp = Interpreter::new();
+        let output = interp
+            .run("sub compiled-adapter() { 42 }; say compiled-adapter();")
+            .unwrap();
+        assert_eq!(output, "42\n");
+        let key = Symbol::intern("GLOBAL::compiled-adapter");
+        let registry = interp.registry();
+        let def = registry
+            .functions
+            .get(&key)
+            .expect("registered function candidate");
+        assert!(def.compiled.is_some());
+    }
+
+    #[test]
     fn variables_and_concat() {
         let mut interp = Interpreter::new();
         let output = interp

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -218,6 +218,7 @@ impl Interpreter {
             deprecated_message: None,
             source_file: self.current_source_file(),
             decl_order: crate::runtime::resolution::next_decl_order(),
+            compiled: None,
         };
         // Register as a typed multi candidate under the class package, mirroring
         // the `multi sub` registration keys so `import` copies it and operator
@@ -2288,6 +2289,7 @@ impl Interpreter {
                             deprecated_message: None,
                             source_file: self.current_source_file(),
                             decl_order: crate::runtime::resolution::next_decl_order(),
+                            compiled: None,
                         };
                         self.registry_mut().functions.insert(
                             Symbol::intern(&qualified_name),
@@ -2368,6 +2370,7 @@ impl Interpreter {
                             deprecated_message: None,
                             source_file: self.current_source_file(),
                             decl_order: crate::runtime::resolution::next_decl_order(),
+                            compiled: None,
                         };
                         // Register under the short name (lexical scope)
                         self.registry_mut().functions.insert(
@@ -2566,6 +2569,7 @@ impl Interpreter {
                         deprecated_message: None,
                         source_file: self.current_source_file(),
                         decl_order: crate::runtime::resolution::next_decl_order(),
+                        compiled: None,
                     };
                     self.registry_mut()
                         .proto_methods

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -798,6 +798,7 @@ impl Interpreter {
             deprecated_message,
             source_file: self.current_source_file(),
             decl_order: crate::runtime::resolution::next_decl_order(),
+            compiled: None,
         };
         let single_key = format!("{}::{}", self.current_package(), name);
         let multi_prefix = format!("{}::{}/", self.current_package(), name);
@@ -1225,6 +1226,7 @@ impl Interpreter {
             deprecated_message: None,
             source_file: self.current_source_file(),
             decl_order: crate::runtime::resolution::next_decl_order(),
+            compiled: None,
         };
         self.insert_token_def(name, def, multi);
     }
@@ -1294,6 +1296,7 @@ impl Interpreter {
                 deprecated_message: None,
                 source_file: self.current_source_file(),
                 decl_order: crate::runtime::resolution::next_decl_order(),
+                compiled: None,
             }),
         );
         Ok(())
@@ -1400,6 +1403,7 @@ impl Interpreter {
             deprecated_message: None,
             source_file: self.current_source_file(),
             decl_order: crate::runtime::resolution::next_decl_order(),
+            compiled: None,
         };
         let single_key = format!("GLOBAL::{}", name);
         let single_key_sym = Symbol::intern(&single_key);
@@ -1544,6 +1548,7 @@ impl Interpreter {
                 deprecated_message: None,
                 source_file: self.current_source_file(),
                 decl_order: crate::runtime::resolution::next_decl_order(),
+                compiled: None,
             }),
         );
         Ok(())

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -205,14 +205,17 @@ impl Interpreter {
         let name = def.name.resolve();
         let pkg = def.package.resolve();
 
-        let cf = self.otf_compile_function_def(def);
+        let (cf, compiled_from_plan) = match &def.compiled {
+            Some(compiled) => (Arc::clone(compiled), true),
+            None => (self.otf_compile_function_def(def), false),
+        };
 
         // Cache by name for fast lookup in exec_call_func_op — but never for a
         // multi name. The name-keyed cache is type-blind, so caching one multi
         // candidate under the bare name would make a later call with different
         // argument types wrongly reuse it. Multi candidates are still cached by
         // body fingerprint in `otf_compile_cache` above (safe, per-candidate).
-        if !self.has_multi_candidates_cached(&name) {
+        if !compiled_from_plan && !self.has_multi_candidates_cached(&name) {
             let name_sym = Symbol::intern(&name);
             // Keyed to the *callsite* package, not `def.package`: the cache
             // answers "what does this bare name mean here", and a module's

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4395,7 +4395,7 @@ impl Interpreter {
             }
             OpCode::RegisterDecl(idx) => {
                 self.sync_source_line(code, *ip);
-                self.exec_register_decl_op(code, *idx)?;
+                self.exec_register_decl_op(code, *idx, compiled_fns)?;
                 *ip += 1;
             }
             OpCode::RegisterToken(idx) => {

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -188,6 +188,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         idx: u32,
+        compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         if let Some(crate::opcode::CompiledSubDeclPlan {
             name,
@@ -197,7 +198,7 @@ impl Interpreter {
             return_type,
             associativity,
             signature_alternates,
-            compiled_routine_keys: _,
+            compiled_routine_keys,
             legacy_body: body,
             multi,
             is_rw,
@@ -237,6 +238,50 @@ impl Interpreter {
                     *site_fp,
                 )
             })?;
+            for key in compiled_routine_keys {
+                let Some(compiled) = compiled_fns.get(key) else {
+                    continue;
+                };
+                let registry_key = if *multi {
+                    *key
+                } else {
+                    let resolved = key.resolve();
+                    Symbol::intern(
+                        resolved
+                            .rsplit_once('/')
+                            .map_or(&resolved, |(base, _)| base),
+                    )
+                };
+                if let Some(def) = self.registry_mut().functions.get_mut(&registry_key) {
+                    let def = std::sync::Arc::make_mut(def);
+                    // C4 moves compiler-derived signature metadata into the plan.
+                    // Until then, only candidates whose binding shape needs no
+                    // registration-time normalization can safely use this adapter.
+                    if *multi
+                        || def.param_defs.iter().any(|param| {
+                            param.named
+                                || param.default.is_some()
+                                || param.where_constraint.is_some()
+                                || param.sub_signature.is_some()
+                                || param.outer_sub_signature.is_some()
+                        })
+                    {
+                        continue;
+                    }
+                    let mut adapted = compiled.clone();
+                    adapted.params.clone_from(&def.params);
+                    adapted.param_defs.clone_from(&def.param_defs);
+                    adapted.return_type.clone_from(&def.return_type);
+                    adapted.empty_sig = def.empty_sig;
+                    adapted.is_rw = def.is_rw;
+                    adapted.is_raw = def.is_raw;
+                    adapted.source_file.clone_from(&def.source_file);
+                    adapted.precompute_param_local_slots();
+                    adapted.precompute_named_call_plan();
+                    adapted.precompute_param_name_syms();
+                    def.compiled = Some(std::sync::Arc::new(adapted));
+                }
+            }
             // An idempotent re-registration of an already-installed identical sub
             // leaves the registry untouched, so none of the install bookkeeping
             // below (cache invalidation, `&`-param shadow tracking, export, native

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -8,10 +8,11 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         idx: u32,
+        compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         match code.decl_plans.get(idx as usize).copied() {
             Some(crate::opcode::CompiledDeclPlanRef::Sub(plan_idx)) => {
-                self.exec_register_sub_op(code, plan_idx)
+                self.exec_register_sub_op(code, plan_idx, compiled_fns)
             }
             Some(crate::opcode::CompiledDeclPlanRef::Class(plan_idx)) => {
                 self.note_type_body_written_lexicals(code);


### PR DESCRIPTION
## Problem

ADR-0019 sub plans carry stable compiled routine keys, but registration still installs AST-only `FunctionDef` candidates. Calls then rediscover a compiled body by name/signature or compile the AST on demand.

## Approach

- add a temporary, non-serialized compiled body adapter to `FunctionDef`
- pass the active `CompiledFns` table through `RegisterDecl(Sub)`
- attach plan-selected compiled bodies to the installed registry candidates
- make the common FunctionDef call helper prefer the attached body over OTF compilation
- preserve the existing AST adapter when a recompiled dynamic body has no matching entry in the active compunit table

## Test evidence

- `cargo test sub_declaration_installs_its_compiled_candidate` — PASS
- `cargo test --test mzef_shim` — 3 PASS after fixing the dynamic-body fallback
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test` reached the integration phase; its only failures were the three `mzef_shim` cases above, caused by the initial missing-key error and verified fixed with the targeted rerun. Per repository policy the full command was not rerun; CI is the full confirmation.

Implements ADR-0019 slice C3.