### PR TITLE
fix: Digest::SHA3 produces the right digest — four general fixes

### DIFF
--- a/news/2026-08/digest-sha3-runs.md
+++ b/news/2026-08/digest-sha3-runs.md
@@ -1,0 +1,60 @@
+# `Digest::SHA3` produces the right digest — four more general fixes
+
+`sha3_256("abc")` now returns `3a985da7…31532`, matching rakudo. Getting there
+took four independent interpreter bugs on top of the two already landed for this
+distribution (`news/2026-08/multi-named-narrowness-declaration-order.md` and
+`news/2026-08/samewith-inside-lazy-gather.md`). Each one is general; none is
+specific to `Digest`. The remaining `todo/tickets/digest-dist-blockers.md` §6
+entry is closed by this.
+
+## A `given` statement modifier is not a placeholder scope
+
+    sub ROL64 { ($^a +> (64 - $_) +| $a +< $_) % (1 +< 64) given $^n % 64 }
+
+came out with the single parameter `$^n`: `collect_ph_stmt_shallow`'s
+`Stmt::Given` arm collected placeholders from the topic only, which is right for
+a `given {}` BLOCK (its body is its own scope, and a placeholder there is the
+block's parameter bound to the topic) but wrong for the statement-modifier form,
+which introduces no block at all. `Stmt::For` already made exactly this
+distinction via `is_statement_modifier`; `Stmt::Given` now does too, and the
+compiler's matching "bind the body placeholder to the topic" step is skipped for
+the modifier form. `ROL64` was silently rotating by the wrong amount.
+
+## A multi-dimensional subscript is a list-assignment target
+
+    ($current, @lanes[$x;$y]) = @lanes[$x;$y], ROL64 $current, …
+
+failed the compiler's list-assignment target gate (which admitted `Expr::Index`
+but not `Expr::MultiDimIndex`) and fell through to the runtime's "cannot assign
+through non-callable value". It is a single-item target, like a single-index
+`@a[i]` one, and compiles to a `MultiDimIndexAssign` reading its item from the
+same decontainerized RHS snapshot the other targets use — so a swap
+(`(@s[0;0], @s[1;1]) = @s[1;1], @s[0;0]`) works.
+
+## A sized buffer is `Buf[uint8]`, not `buf8`
+
+`multi KeccakF1600(blob8 $state)` lost every dispatch to its sibling
+`multi KeccakF1600(@lanes)`, so the permutation never ran and the digest came
+out as the padded input. Two things hid the buffer from the type-distance table:
+`.^name` renders a sized buffer parameterized (`Buf[uint8]`) while the source
+spells it `buf8`, and `value_type_name` answers the generic `"Any"` for every
+instance — so the Buf/Blob family table, keyed on the short spelling of
+`value_type_name`'s answer, never matched one. Both spellings are recognized
+now, the lookup falls back to the instance's class name, and a `bufN` correctly
+ranks its same-width `blobN` as an ancestor (`buf8 ~~ blob8` is True, but
+`blob8` was not in the `buf8` chain at all).
+
+## A Range subscript is a slice on a Buf
+
+    $new-state[$_ ..^ $_ + 8] = store64 @lanes[$i;$j];
+
+reported "Index out of range". The Buf element-assign path handled a comma list
+(`$b[0,1,2] = …`) and a single index, but a Range reached the scalar arm and
+failed `index_to_usize`. A finite Range is now expanded to the index list the
+slice arm already consumes; element-width masking is unchanged (`buf8[0..1] =
+300, -1` still stores `44, 255`).
+
+Pinned by `t/given-modifier-placeholder-scope.t`,
+`t/sized-buffer-dispatch-narrowness.t` and
+`t/buf-range-slice-and-multidim-list-assign.t` — 29 tests, all also passing
+under `raku`.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2102,12 +2102,28 @@ fn collect_ph_stmt_shallow(stmt: &Stmt, out: &mut Vec<String>) {
                 collect_ph_stmt_shallow(s, out);
             }
         }
-        Stmt::Given { topic, .. } => {
+        Stmt::Given {
+            topic,
+            body,
+            is_statement_modifier,
+        } => {
             // The topic is evaluated in THIS block's scope, but the given/with
-            // body is its OWN `{}` block scope: a placeholder inside it is the
-            // given-block's parameter, bound to the topic (`with 2 { $^a }` is
-            // 2, not the enclosing block's argument) — mirrors the If arm.
+            // BLOCK body is its OWN `{}` block scope: a placeholder inside it is
+            // the given-block's parameter, bound to the topic (`with 2 { $^a }`
+            // is 2, not the enclosing block's argument) — mirrors the If arm.
+            //
+            // A `given` STATEMENT MODIFIER has no block, so its body runs in the
+            // enclosing scope and its placeholders are the enclosing routine's
+            // parameters — exactly the For arm's modifier rule. Digest::SHA3's
+            // `sub ROL64 { ($^a +> (64 - $_) +| $a +< $_) % (1 +< 64) given $^n%64 }`
+            // otherwise came out with the single parameter `$^n`, so `$^a` read
+            // the topic instead of the first argument.
             collect_ph_expr_shallow(topic, out);
+            if *is_statement_modifier {
+                for s in body {
+                    collect_ph_stmt_shallow(s, out);
+                }
+            }
         }
         Stmt::When { cond, body } => {
             collect_ph_expr_shallow(cond, out);

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -290,6 +290,7 @@ impl Compiler {
                         | Expr::HashVar(_)
                         | Expr::Whatever
                         | Expr::Index { .. }
+                        | Expr::MultiDimIndex { .. }
                 ) || matches!(t, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. }))
             })
         {
@@ -470,6 +471,31 @@ impl Compiler {
                         });
                         self.code.emit(OpCode::Pop);
                         offset += width;
+                    }
+                    // `($current, @lanes[$x;$y]) = @lanes[$x;$y], $rotated`
+                    // (Digest::SHA3's `KeccakF1600`): a multi-dimensional
+                    // subscript is a single-item target, like a single-index
+                    // `@a[i]` one. Without this arm the whole list assignment
+                    // failed the target gate above and fell through to the
+                    // runtime's "cannot assign through non-callable value".
+                    Expr::MultiDimIndex { target, dimensions } => {
+                        let src_name = if seen_slurpy {
+                            tmp_name.clone()
+                        } else {
+                            snap_name.clone()
+                        };
+                        let rhs_item = Expr::Index {
+                            target: Box::new(Expr::Var(src_name)),
+                            index: Box::new(Expr::Literal(Value::int(offset as i64))),
+                            is_positional: true,
+                        };
+                        self.compile_expr(&Expr::MultiDimIndexAssign {
+                            target: target.clone(),
+                            dimensions: dimensions.clone(),
+                            value: Box::new(rhs_item),
+                        });
+                        self.code.emit(OpCode::Pop);
+                        offset += 1;
                     }
                     _ => {
                         // Whatever (`*`) discard slot consumes one item.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2514,13 +2514,22 @@ impl Compiler {
                     }
                     _ => None,
                 };
-                // A scalar placeholder in the body is the given/with block's
+                // A scalar placeholder in the body is the given/with BLOCK's
                 // parameter, bound to the topic (`with 2 { $^a == 3 ?? … }`
                 // sees 2). The topic value is on the stack here; keep a copy
                 // for the binding, mirroring the If arm's cond placeholder.
-                if let Some(ph) = crate::ast::collect_placeholders_shallow(body)
-                    .into_iter()
-                    .find(|n| n.starts_with('^'))
+                //
+                // A `given` STATEMENT MODIFIER introduces no block, so a
+                // placeholder in its body belongs to the enclosing routine and
+                // is already bound as one of its parameters (see the matching
+                // `is_statement_modifier` arm in `collect_ph_stmt_shallow`).
+                // Rebinding it to the topic here made
+                // `sub ROL64 { ($^a … $_ …) given $^n%64 }` read the topic for
+                // `$^a` instead of the first argument.
+                if !*is_statement_modifier
+                    && let Some(ph) = crate::ast::collect_placeholders_shallow(body)
+                        .into_iter()
+                        .find(|n| n.starts_with('^'))
                 {
                     self.code.emit(OpCode::Dup);
                     self.emit_set_named_var(&ph);

--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -552,6 +552,23 @@ impl Interpreter {
 
     /// Return how many MRO levels separate `constraint` from the actual type
     /// of `value`.  0 means exact match; larger means less specific.
+    /// The short spelling of a sized Buf/Blob type name. `.^name` renders these
+    /// parameterized (`Buf[uint8]`); Raku source spells them `buf8`/`blob8`.
+    /// Anything else is returned unchanged.
+    fn canonical_buf_type_name(name: &str) -> &str {
+        match name {
+            "Buf[uint8]" => "buf8",
+            "Buf[uint16]" => "buf16",
+            "Buf[uint32]" => "buf32",
+            "Buf[uint64]" => "buf64",
+            "Blob[uint8]" => "blob8",
+            "Blob[uint16]" => "blob16",
+            "Blob[uint32]" => "blob32",
+            "Blob[uint64]" => "blob64",
+            other => other,
+        }
+    }
+
     fn type_hierarchy_distance(&self, constraint: &str, value: &Value) -> usize {
         let value_type = super::value_type_name(value);
         // Strip :D/:U smiley
@@ -627,25 +644,75 @@ impl Interpreter {
             }
         }
         // Buf/Blob family. `Buf` extends `Blob`; the `utfN` encodings and the
-        // sized `blobN`/`bufN` types do the `Blob`/`Buf` roles. The value's own
-        // type is distance 0 and was handled above, so these lists start at the
-        // first ancestor and the index is offset by one. Without them a
-        // `Blob:D` candidate scored the 500 "unknown type" distance for a
-        // `"x".encode` argument and lost the tie-break to whichever candidate
-        // happened to be declared first.
-        let buf_ancestors: &[&str] = match value_type {
+        // sized `blobN`/`bufN` types do the `Blob`/`Buf` roles, and a `bufN`
+        // also does its same-width `blobN` (`buf8 ~~ blob8` is True). The
+        // value's own type is distance 0, so these lists start at the first
+        // ancestor and the index is offset by one. Without them a `Blob:D`
+        // candidate scored the 500 "unknown type" distance for a `"x".encode`
+        // argument and lost the tie-break to whichever candidate happened to be
+        // declared first.
+        //
+        // Both spellings have to be recognized: `.^name` renders a sized buffer
+        // parameterized (`Buf[uint8]`) while the source spells it `buf8`, so
+        // matching only the short form made EVERY sized buffer fall through to
+        // the 500 fallback — `multi f(blob8 $s)` then lost to `multi f(@a)` for
+        // a `buf8` argument (Digest::SHA3's `KeccakF1600`, which never ran its
+        // permutation as a result).
+        // A sized buffer is an `Instance` whose class is `Buf[uint8]`, and
+        // `value_type_name` answers the generic "Any" for every instance — so
+        // the family table below never matched one. Use the instance's class
+        // name (the MRO/role checks above have already failed for it: `Buf` is
+        // not a registered user class).
+        let instance_class = match value.view() {
+            ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
+            _ => None,
+        };
+        let vt = Self::canonical_buf_type_name(instance_class.as_deref().unwrap_or(value_type));
+        let cbase = Self::canonical_buf_type_name(base);
+        let buf_ancestors: &[&str] = match vt {
             "Buf" => &["Blob", "Positional", "Stringy", "Any", "Mu"],
-            "buf8" | "buf16" | "buf32" | "buf64" => {
-                &["Buf", "Blob", "Positional", "Stringy", "Any", "Mu"]
-            }
+            "Blob" => &["Positional", "Stringy", "Any", "Mu"],
+            "buf8" => &["Buf", "blob8", "Blob", "Positional", "Stringy", "Any", "Mu"],
+            "buf16" => &[
+                "Buf",
+                "blob16",
+                "Blob",
+                "Positional",
+                "Stringy",
+                "Any",
+                "Mu",
+            ],
+            "buf32" => &[
+                "Buf",
+                "blob32",
+                "Blob",
+                "Positional",
+                "Stringy",
+                "Any",
+                "Mu",
+            ],
+            "buf64" => &[
+                "Buf",
+                "blob64",
+                "Blob",
+                "Positional",
+                "Stringy",
+                "Any",
+                "Mu",
+            ],
             "utf8" | "utf16" | "utf32" | "blob8" | "blob16" | "blob32" | "blob64" => {
                 &["Blob", "Positional", "Stringy", "Any", "Mu"]
             }
             _ => &[],
         };
         if !buf_ancestors.is_empty() {
+            // `buf8` vs `Buf[uint8]` are the same type spelled two ways; the
+            // literal-equality check above only catches the matching spelling.
+            if cbase == vt {
+                return 0;
+            }
             for (i, &ancestor) in buf_ancestors.iter().enumerate() {
-                if ancestor == base {
+                if ancestor == cbase {
                     return i + 1;
                 }
             }

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -816,6 +816,23 @@ impl Interpreter {
                     return Err(RuntimeError::assignment_ro(Some("Blob")));
                 }
                 let attributes = attributes.clone();
+                // A finite Range subscript is a slice, exactly like a comma
+                // list: expand it to the index list the slice arm consumes.
+                // Without this `$buf[$i ..^ $i + 8] = @bytes` (Digest::SHA3's
+                // `store64` write-back) reached the scalar arm, failed
+                // `index_to_usize`, and reported "Index out of range" — while
+                // the equivalent `$buf[@idx]` worked.
+                let idx = match idx.view() {
+                    ValueView::Range(_, b)
+                    | ValueView::RangeExcl(_, b)
+                    | ValueView::RangeExclStart(_, b)
+                    | ValueView::RangeExclBoth(_, b)
+                        if b != i64::MAX =>
+                    {
+                        Value::array(crate::runtime::utils::value_to_list(&idx))
+                    }
+                    _ => idx.clone(),
+                };
                 if let ValueView::Array(keys, ..) = idx.view() {
                     let vals = self.assignment_rhs_values(&val)?;
                     let indices = keys

--- a/t/buf-range-slice-and-multidim-list-assign.t
+++ b/t/buf-range-slice-and-multidim-list-assign.t
@@ -1,0 +1,66 @@
+use Test;
+
+plan 11;
+
+# --- A Range subscript is a slice on a Buf, like a comma list ---------------
+# The Buf element-assign path handled a comma list (`$b[0,1,2] = …`) and a
+# single index but not a Range, so `$b[$i ..^ $i + 8] = @bytes` fell through to
+# the scalar arm and reported "Index out of range". Digest::SHA3's `store64`
+# write-back is exactly that form.
+{
+    my buf8 $n .= new: 0 xx 16;
+    $n[0 ..^ 8] = 1, 2, 3, 4, 5, 6, 7, 8;
+    is $n.list.join(","), "1,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0",
+        'an exclusive Range slice assigns through a Buf';
+
+    my $i = 8;
+    $n[$i ..^ $i + 8] = 9 xx 8;
+    is $n.list.join(","), "1,2,3,4,5,6,7,8,9,9,9,9,9,9,9,9",
+        '...at a computed offset';
+
+    my buf8 $m .= new: 0 xx 8;
+    $m[0 .. 2] = 1, 2, 3;
+    is $m.list.join(","), "1,2,3,0,0,0,0,0", 'an inclusive Range slice too';
+
+    my buf8 $p .= new: 0 xx 8;
+    $p[0, 1, 2] = 7, 7, 7;
+    is $p.list.join(","), "7,7,7,0,0,0,0,0", 'control: the comma-list slice';
+
+    # The element width still masks the stored value.
+    my buf8 $w .= new: 0 xx 4;
+    $w[0 .. 1] = 300, -1;
+    is $w.list.join(","), "44,255,0,0", 'stored elements are masked to the width';
+
+    # Wider buffers keep their element width.
+    my buf16 $b16 .= new: 0 xx 4;
+    $b16[0 .. 1] = 300, 70000;
+    is $b16.list.join(","), "300,4464,0,0", 'a buf16 range slice keeps 16-bit elements';
+}
+
+# --- A multi-dimensional subscript is a list-assignment target --------------
+# `($a, @m[$x;$y]) = ...` failed the compiler's list-assignment target gate and
+# fell through to the runtime's "cannot assign through non-callable value".
+# Digest::SHA3's rho/pi step is written this way.
+{
+    my @a = [1, 2], [3, 4];
+    my $c = 9;
+    ($c, @a[0;1]) = @a[0;1], $c;
+    is $c, 2, 'the scalar target receives its item';
+    is @a.raku, [[1, 9], [3, 4]].raku, 'the multi-dim target receives its item';
+
+    my @e = [1, 2], [3, 4];
+    (@e[0;0], @e[1;1]) = 7, 8;
+    is @e.raku, [[7, 2], [3, 8]].raku, 'two multi-dim targets in one assignment';
+
+    # The RHS is snapshotted before any target is written, so a swap works.
+    my @s = [1, 2], [3, 4];
+    (@s[0;0], @s[1;1]) = @s[1;1], @s[0;0];
+    is @s.raku, [[4, 2], [3, 1]].raku, 'a swap through two multi-dim targets';
+
+    # Mixed with a slurpy tail.
+    my @f = [0, 0], [0, 0];
+    my @rest;
+    (@f[0;0], @rest) = 1, 2, 3;
+    is "{@f[0;0]} {@rest.join(',')}", "1 2,3",
+        'a multi-dim target followed by a slurpy array';
+}

--- a/t/given-modifier-placeholder-scope.t
+++ b/t/given-modifier-placeholder-scope.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 7;
+
+# A `given` STATEMENT MODIFIER introduces no block, so a placeholder in the
+# statement it modifies belongs to the ENCLOSING routine and is one of its
+# parameters. mutsu treated the modified statement like a `given {}` block body:
+# its placeholders were not collected into the routine's signature, and were
+# instead bound to the topic. Digest::SHA3's rotate helper is exactly this
+# shape and came out as a one-parameter routine:
+#
+#     sub ROL64 { ($^a +> (64 - $_) +| $a +< $_) % (1 +< 64) given $^n % 64 }
+
+{
+    sub r1 { "a=$^a n=$^n" }
+    is r1(10, 20), "a=10 n=20", 'control: two placeholders, no modifier';
+
+    sub r2 { "a=$^a n=$^n topic=$_" given $^n % 64 }
+    is r2(10, 20), "a=10 n=20 topic=20",
+        'a `given` modifier does not steal the body placeholders';
+
+    sub r3 { "a=$^a topic=$_" given $^n }
+    is r3(10, 20), "a=10 topic=20",
+        '...and the topic is the modifier expression, not the first argument';
+
+    sub r4 { my $t = $^n % 64; "a=$^a n=$^n t=$t" }
+    is r4(10, 20), "a=10 n=20 t=20",
+        'control: the same computation without the modifier';
+}
+
+# The real thing: a 64-bit rotate.
+{
+    sub ROL64 { ($^a +> (64 - $_) +| $a +< $_) % (1 +< 64) given $^n % 64 }
+    is ROL64(1, 1), 2, 'ROL64 rotates by one';
+    is ROL64(0x0102030405060708, 8), 144964032628459521, 'ROL64 rotates by eight';
+}
+
+# A `given` BLOCK is unchanged: its body IS its own scope, and a placeholder
+# there is the block's parameter, bound to the topic.
+{
+    my $out = do given 42 { $^a };
+    is $out, 42, 'a placeholder in a given BLOCK still binds the topic';
+}

--- a/t/sized-buffer-dispatch-narrowness.t
+++ b/t/sized-buffer-dispatch-narrowness.t
@@ -1,0 +1,71 @@
+use Test;
+
+plan 11;
+
+# A sized buffer (`buf8`, `blob8`, …) is an instance whose `.^name` is the
+# PARAMETERIZED spelling `Buf[uint8]`, while Raku source spells it `buf8`.
+# The multi-dispatch type-distance table matched only the short spelling and
+# only through `value_type_name` (which answers the generic "Any" for every
+# instance), so every sized buffer scored the "unrelated type" distance: a
+# `Buf`/`Blob`/`buf8`/`blob8` candidate lost to a bare `@`-parameter one.
+# Digest::SHA3's `multi KeccakF1600(blob8 $state)` was shadowed by its
+# `multi KeccakF1600(@lanes)` sibling, so the permutation never ran.
+
+my buf8  $b8   .= new: 1, 2, 3, 4;
+my blob8 $bl8  .= new: 1, 2, 3, 4;
+my       $buf   = Buf.new(1, 2);
+
+{
+    multi A(@l)       { "array" }
+    multi A(blob8 $x) { "blob8" }
+    is A($b8), "blob8", 'blob8 beats a bare @-parameter for a buf8';
+
+    multi B(@l)      { "array" }
+    multi B(Blob $x) { "Blob" }
+    is B($b8), "Blob", 'Blob beats a bare @-parameter for a buf8';
+
+    multi C(@l)     { "array" }
+    multi C(Buf $x) { "Buf" }
+    is C($b8), "Buf", 'Buf beats a bare @-parameter for a buf8';
+
+    multi D(@l)      { "array" }
+    multi D(buf8 $x) { "buf8" }
+    is D($b8), "buf8", 'buf8 beats a bare @-parameter for a buf8';
+
+    multi E(@l)     { "array" }
+    multi E(Buf $x) { "Buf" }
+    is E($buf), "Buf", 'the unsized Buf case still works';
+
+    multi F(@l)      { "array" }
+    multi F(Blob $x) { "Blob" }
+    is F($bl8), "Blob", '...and a blob8 argument';
+}
+
+# Declaration order must not decide any of these — the typed candidate wins
+# whichever way round it is declared.
+{
+    multi G(blob8 $x) { "blob8" }
+    multi G(@l)       { "array" }
+    is G($b8), "blob8", 'reversing the declarations does not change the winner';
+}
+
+# Narrower still wins over wider inside the family.
+{
+    multi H(Blob $x) { "Blob" }
+    multi H(buf8 $x) { "buf8" }
+    is H($b8), "buf8", 'buf8 is narrower than Blob for a buf8';
+
+    multi I(Blob $x) { "Blob" }
+    multi I(Buf $x)  { "Buf" }
+    is I($b8), "Buf", 'Buf is narrower than Blob for a buf8';
+}
+
+# An unrelated type still loses to the @-parameter.
+{
+    multi J(@l)     { "array" }
+    multi J(Int $x) { "Int" }
+    is J($b8), "array", 'an unrelated constraint does not match at all';
+}
+
+# The typecheck these distances have to agree with.
+ok $b8 ~~ blob8, 'a buf8 does the blob8 role';

--- a/todo/tickets/digest-dist-blockers.md
+++ b/todo/tickets/digest-dist-blockers.md
@@ -7,13 +7,15 @@ interpreter bugs found while running it were fixed (see
 `news/2026-08/digest-dist-seven-fixes.md`), then four more that its roast
 fallout exposed (`news/2026-08/digest-dist-followup-four-fixes.md`), then four
 more behind MD5's wrong digest (`news/2026-08/digest-md5-four-fixes.md`).
-`Digest::MD5`, `Digest::SHA1` and all four `Digest::SHA2` digests now come out
-correct, and the dist's `t/md5.t` passes in full. Blockers 1
-(`news/2026-08/for-modifier-placeholder-scope.md`), 3
-(`news/2026-08/buf-wide-element-assign-saturation.md`) and 4
-(`news/2026-08/named-params-do-not-narrow.md`) are fixed. What remains is
-blocker 2's anonymous-`$`-state residue, the `Digest::SHA3` cluster (6), and the
-non-blocking wide-buffer bit accessors (5).
+`Digest::MD5`, `Digest::SHA1`, all four `Digest::SHA2` digests and
+`Digest::SHA3` now come out correct, and the dist's `t/md5.t` passes in full.
+Blockers 1 (`news/2026-08/for-modifier-placeholder-scope.md`), 3
+(`news/2026-08/buf-wide-element-assign-saturation.md`), 4
+(`news/2026-08/named-params-do-not-narrow.md`) and 6
+(`news/2026-08/multi-named-narrowness-declaration-order.md`,
+`news/2026-08/samewith-inside-lazy-gather.md`,
+`news/2026-08/digest-sha3-runs.md`) are fixed. What remains is blocker 2's
+anonymous-`$`-state residue and the non-blocking wide-buffer bit accessors (5).
 
 Reproduce with the vendored-in-zef-store copy:
 
@@ -69,9 +71,9 @@ letting `encode_elems` do the width masking; see
 `news/2026-08/buf-wide-element-assign-saturation.md`. `sha384`, `sha512` and the
 rest of `t/sha.t`'s SHA-1/SHA-2 subtests now pass.
 
-## 6. `Digest::SHA3` — down to `KeccakF1600`'s immutable value
+## 6. `Digest::SHA3` — FIXED
 
-Both originally-reported halves are FIXED:
+`sha3_256("abc")` returns `3a985da7…31532`, matching rakudo. Six general fixes:
 
 - the named-only multi dispatch (`Keccak`'s two candidates differ only in an
   extra `:$outputByteLen`) —
@@ -80,20 +82,26 @@ Both originally-reported halves are FIXED:
   `news/2026-08/samewith-inside-lazy-gather.md`. Its "Unexpected named argument
   'delimitedSuffix' passed" face was the same bug: the dynamic dispatch stack
   named `sha3_256` (the routine doing the forcing) instead of `Keccak`, so the
-  redispatch went to the wrong routine rather than failing.
+  redispatch went to the wrong routine rather than failing;
+- `@a[$x;$y] += 1` compiling to an unconditional `X::Assignment::RO` —
+  `news/2026-08/multidim-subscript-compound-assign.md`;
+- a `given` statement modifier stealing the modified statement's placeholders, a
+  multi-dimensional subscript not being a list-assignment target, a sized buffer
+  (`Buf[uint8]`) being invisible to the multi-dispatch type-distance table, and a
+  Range subscript not being a slice on a `Buf` — `news/2026-08/digest-sha3-runs.md`.
 
-`sha3_256("abc")` now runs all the way into the permutation and stops on an
-unrelated bug:
-
-    Cannot modify an immutable value
-      in sub KeccakF1600 ... in sub Keccak ... in sub sha3_256
-
-`KeccakF1600` has two candidates, `multi KeccakF1600(@lanes)` and
-`multi KeccakF1600(blob8 $state)`, and the caller writes
-`$state .= &KeccakF1600`. That is the next thing to reduce.
-
-Two smaller residues found while fixing the above, neither on the `Digest`
+Three smaller residues found while fixing the above, none on the `Digest`
 critical path:
+
+- A `with` statement modifier still hides its statement's placeholders:
+  `sub w1 { "a=$^a topic=$_" with $^n }; w1(3, 4)` is `a=3 topic=4` in rakudo but
+  `a=True topic=3` in mutsu. `with` desugars to
+  `Given { is_statement_modifier, body: [DoStmt(If { cond: $_.defined, … })] }`,
+  and the synthetic `If` is opaque to both the placeholder collector and the
+  compiler's placeholder binding (which binds `$^a` to the condition value,
+  hence `True`). The `given` form is fixed; making the synthetic `If`
+  transparent needs a marker on it, since a genuine nested `if` block inside the
+  modified statement must stay a scope.
 
 - A gather created inside a module routine and forced from the *consumer's*
   top-level scope cannot resolve a module-private name:


### PR DESCRIPTION
`sha3_256("abc")` now returns `3a985da7…31532`, matching rakudo. Four independent interpreter bugs, on top of the two already landed for this distribution (#5868, #5870) and the multi-dim compound assign (#5872). Each is general; none is specific to `Digest`. Closes `todo/tickets/digest-dist-blockers.md` §6.

## 1. A `given` statement modifier is not a placeholder scope

```raku
sub ROL64 { ($^a +> (64 - $_) +| $a +< $_) % (1 +< 64) given $^n % 64 }
```

came out with the single parameter `$^n`, so `$^a` read the topic and the rotate was silently wrong. `collect_ph_stmt_shallow`'s `Stmt::Given` arm collected from the topic only — right for a `given {}` BLOCK (its body is its own scope, and a placeholder there is the block's parameter bound to the topic), wrong for the statement-modifier form, which introduces no block at all. `Stmt::For` already made exactly this distinction via `is_statement_modifier`; `Stmt::Given` now does too, and the compiler's matching "bind the body placeholder to the topic" step is skipped for the modifier form.

## 2. A multi-dimensional subscript is a list-assignment target

```raku
($current, @lanes[$x;$y]) = @lanes[$x;$y], ROL64 $current, …
```

failed the compiler's list-assignment target gate (which admitted `Expr::Index` but not `Expr::MultiDimIndex`) and fell through to the runtime's "cannot assign through non-callable value". It is a single-item target like a single-index one, and reads its item from the same decontainerized RHS snapshot the other targets use — so a swap `(@s[0;0], @s[1;1]) = @s[1;1], @s[0;0]` works.

## 3. A sized buffer is `Buf[uint8]`, not `buf8`

`multi KeccakF1600(blob8 $state)` lost every dispatch to its sibling `multi KeccakF1600(@lanes)`, so the permutation never ran and the digest came out as the padded input. Two things hid the buffer from the type-distance table: `.^name` renders a sized buffer parameterized (`Buf[uint8]`) while source spells it `buf8`, and `value_type_name` answers the generic `"Any"` for *every* instance — so the Buf/Blob family table, keyed on the short spelling of `value_type_name`'s answer, never matched one. Both spellings are recognized now, the lookup falls back to the instance's class name, and a `bufN` correctly ranks its same-width `blobN` as an ancestor (`buf8 ~~ blob8` is True, but `blob8` was not in the `buf8` chain at all).

## 4. A Range subscript is a slice on a Buf

```raku
$new-state[$_ ..^ $_ + 8] = store64 @lanes[$i;$j];
```

reported "Index out of range". The Buf element-assign path handled a comma list (`$b[0,1,2] = …`) and a single index, but a Range reached the scalar arm and failed `index_to_usize`. A finite Range is now expanded to the index list the slice arm already consumes; element-width masking is unchanged (`buf8[0..1] = 300, -1` still stores `44, 255`).

## Testing

- `t/given-modifier-placeholder-scope.t` (7), `t/sized-buffer-dispatch-narrowness.t` (11), `t/buf-range-slice-and-multidim-list-assign.t` (11) — 29 new tests, all also passing under `raku`.
- Full local `prove t/`: 2865 files, 27212 tests, all pass.

One residue is recorded on the ticket: a `with` statement modifier still hides its statement's placeholders, because `with` desugars through a synthetic `If` that is opaque to both the collector and the compiler's binding. Making that transparent needs a marker on the node, since a genuine nested `if` block must stay a scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)