### PR TITLE
fix(supply): `done` in a tap callback is a control signal, not a failure

### DIFF
--- a/news/2026-08/done-in-a-tap-callback-is-a-control-signal.md
+++ b/news/2026-08/done-in-a-tap-callback-is-a-control-signal.md
@@ -1,0 +1,43 @@
+# `done` in a tap callback is a control signal, not a supply failure
+
+`Supplier.emit` dispatches to each registered tap callback and treats any error
+coming back as a supply failure: it routes the exception to the supplier's
+`quit` handlers, or re-raises it as one if there are none. Two control signals
+were already carved out of that — `return` (which belongs to the callback's
+enclosing routine) and `next` (which skips the rest of the body for this value)
+— but `done` and `last` were not.
+
+So a `done` inside a `whenever` body took the failure path. That path reads
+`err.exception` and rebuilds a plain `RuntimeError` from it, which **drops the
+control flag**: what started as a `Control::ReactDone` signal came out the other
+side as an ordinary thrown `X::ControlFlow` with `illegal => "done"`,
+`enclosing => "supply or react"`. Nothing downstream recognised it as a
+completion any more.
+
+The loudest symptom was on a channel reader thread. A `whenever` on a socket
+supply is driven by its own thread (`run_supply_act_loop`); when a body running
+there emitted into a `Supplier` whose own tap called `done`, the de-flagged
+exception surfaced at the top of that thread as
+
+```
+Unhandled exception in code scheduled on thread
+done without supply or react
+```
+
+and the loop answered it with `std::process::exit(1)`. That killed the whole
+process mid-file: the vendored Cro suite's `http-middleware.rakutest` aborted
+after subtest 4 in 2 runs out of 3, hiding subtests 5-11 entirely. It now
+completes all 11 every time.
+
+Both `"emit"` arms (`native_supplier_mut` and `native_supplier`) now propagate
+`done`/`last` unchanged, next to the existing `return` carve-out, and
+`run_supply_act_loop` absorbs such a signal as end-of-stream rather than as a
+fatal error — the same `is_react_done() || is_last()` treatment every other
+supply drive loop already gives it.
+
+One half of the semantics is still missing: completing the supply this way does
+not yet tear down the `whenever`'s subscription on its source, so the body keeps
+running (to no effect) for later emits. That is tracked in
+`todo/tickets/done-in-a-whenever-body-does-not-stop-later-emits.md`.
+
+Pinned by `t/supply-done-in-tap-callback-is-not-a-failure.t`.

--- a/src/runtime/native_methods/encoding.rs
+++ b/src/runtime/native_methods/encoding.rs
@@ -490,8 +490,19 @@ impl Interpreter {
             if interp.halted {
                 std::process::exit(interp.exit_code as i32);
             }
-            // If the callback threw an unhandled exception, terminate
+            // If the callback threw an unhandled exception, terminate — but a
+            // `done`/`last` is a control signal the supply machinery owns, not a
+            // failure. It reaches here whenever the body (or the tap's `done =>`
+            // chain, which carries the enclosing supply's LAST phasers and its
+            // done-group marker) completes the supply from this reader thread.
+            // Treating it as an unhandled exception killed the whole process
+            // mid-file. Every other supply drive loop absorbs it the same way —
+            // see the `is_react_done() || is_last()` arms in
+            // `native_supply_mut_methods` and `vm_react_subscriptions`.
             if let Err(err) = result {
+                if err.is_react_done() || err.is_last() {
+                    break;
+                }
                 eprintln!(
                     "Unhandled exception in code scheduled on thread\n{}",
                     err.message

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -112,6 +112,18 @@ impl Interpreter {
                                     if err.is_return() || err.return_value.is_some() {
                                         return Err(err);
                                     }
+                                    // `done`/`last` inside a whenever body ends
+                                    // the enclosing supply. Propagate the control
+                                    // signal unchanged so the supply machinery
+                                    // consumes it; falling through to the
+                                    // quit/failure path below strips the control
+                                    // flag and re-raises it as a thrown
+                                    // `X::ControlFlow`, which then surfaced on a
+                                    // channel reader thread as "done without
+                                    // supply or react" and killed the process.
+                                    if err.is_react_done() || err.is_last() {
+                                        return Err(err);
+                                    }
                                     // `next` inside a whenever body skips the rest
                                     // of the body for THIS value (Rakudo maps it to
                                     // a control exception the supply machinery
@@ -605,6 +617,18 @@ impl Interpreter {
                                     // the signal unchanged so that routine's call frame
                                     // consumes it — it is not a supply failure.
                                     if err.is_return() || err.return_value.is_some() {
+                                        return Err(err);
+                                    }
+                                    // `done`/`last` inside a whenever body ends
+                                    // the enclosing supply. Propagate the control
+                                    // signal unchanged so the supply machinery
+                                    // consumes it; falling through to the
+                                    // quit/failure path below strips the control
+                                    // flag and re-raises it as a thrown
+                                    // `X::ControlFlow`, which then surfaced on a
+                                    // channel reader thread as "done without
+                                    // supply or react" and killed the process.
+                                    if err.is_react_done() || err.is_last() {
                                         return Err(err);
                                     }
                                     // `next` inside a whenever body skips the rest

--- a/t/supply-done-in-tap-callback-is-not-a-failure.t
+++ b/t/supply-done-in-tap-callback-is-not-a-failure.t
@@ -1,0 +1,66 @@
+use Test;
+plan 4;
+
+# `done` inside a `whenever` body ends the enclosing supply. It is a control
+# signal the supply machinery owns, NOT a failure — so `Supplier.emit` must
+# propagate it unchanged rather than route it to the supplier's quit handlers,
+# which strips the control flag and re-raises it as a thrown `X::ControlFlow`.
+#
+# When it did, a `done` that crossed a channel reader thread (the thread that
+# drives a `whenever` on a socket supply) surfaced there as an unhandled
+# "done without supply or react" and killed the whole process. That aborted the
+# vendored Cro suite's `http-middleware.rakutest` mid-file in 2 runs out of 3.
+
+# `done` in a whenever body completes the supply, and does not quit it.
+{
+    my $source = Supplier.new;
+    my $quit-reason;
+    my $done = False;
+    my $s = supply {
+        whenever $source -> $v {
+            done if $v eq 'stop';
+        }
+    }
+    $s.tap(-> $ { }, done => { $done = True }, quit => -> $r { $quit-reason = $r });
+    $source.emit('one');
+    $source.emit('stop');
+    ok $done, 'done in a whenever body completes the supply';
+    nok $quit-reason.defined, 'done did not reach the quit handler';
+}
+
+# The same when the emit originates on a channel reader thread: a `whenever` on
+# a socket supply is driven from its own thread, and a `done` raised in a
+# downstream whenever body must still complete that downstream supply (and must
+# not surface on the reader thread as an unhandled exception).
+{
+    my $listen-tap = IO::Socket::Async.listen('127.0.0.1', 0).tap(-> $conn {
+        $conn.print("bye");
+        $conn.close;
+    });
+    my $port = $listen-tap.socket-port.result;
+    my $conn = await IO::Socket::Async.connect('127.0.0.1', $port);
+
+    my $relay = Supplier.new;
+    my $upstream = supply {
+        whenever $conn.Supply -> $data {
+            $relay.emit($data);
+        }
+    }
+    my $up-tap = $upstream.tap(-> $ { });
+
+    my $done = Promise.new;
+    my $downstream = supply {
+        whenever $relay -> $data {
+            done;
+        }
+    }
+    my $down-tap = $downstream.tap(-> $ { }, done => { $done.keep(True) });
+
+    await Promise.anyof($done, Promise.in(10));
+    ok $done.status ~~ Kept, 'done survives an emit that originated on a reader thread';
+    pass 'the process is still alive';
+
+    $down-tap.close;
+    $up-tap.close;
+    $listen-tap.close;
+}

--- a/todo/tickets/done-in-a-whenever-body-does-not-stop-later-emits.md
+++ b/todo/tickets/done-in-a-whenever-body-does-not-stop-later-emits.md
@@ -1,0 +1,43 @@
+# `done` in a `whenever` body does not stop the source delivering later values
+
+`done` inside a `whenever` body ends the enclosing supply, and rakudo tears the
+supply's subscriptions down with it — the source stops reaching the body. mutsu
+completes the supply (the downstream `done` handler fires) but leaves the
+`whenever`'s tap on the source registered, so the body keeps running for every
+later emit:
+
+```raku
+my $source = Supplier.new;
+my @got;
+my $s = supply {
+    whenever $source -> $v {
+        @got.push($v);
+        done if $v eq 'stop';
+    }
+}
+$s.tap(-> $ { });
+$source.emit('one');
+$source.emit('stop');
+$source.emit('ignored');
+say @got;      # raku: [one stop]      mutsu: [one stop ignored]
+```
+
+The emitted values go nowhere (the supply is already complete, so nothing is
+delivered downstream), which is why this has stayed invisible — but any side
+effect in the body still runs, once per later emit.
+
+## Where it is
+
+`Supplier.emit` now propagates the `done` control signal out of the tap-callback
+dispatch unchanged (`src/runtime/native_supplier_methods.rs`, both the mutable
+and immutable `"emit"` arms — see
+`news/2026-08/done-in-a-tap-callback-is-a-control-signal.md`). What is missing
+is the other half: whoever consumes that signal on behalf of the enclosing
+supply block should also close that block's upstream subscriptions, the way
+`close_all_supplier_taps` does for an explicit `Supplier.done` and the way the
+on-demand `tap` path's `__SupplyOnDemandComplete` marker does for a body-level
+`done`. The subscriptions to close are exactly the ones recorded in
+`upstream_taps` in `native_supply_mut_methods`' `"tap"` arm.
+
+Pinned-adjacent test: `t/supply-done-in-tap-callback-is-not-a-failure.t` covers
+the control-signal half; this ticket is the teardown half.


### PR DESCRIPTION
## Problem

`Supplier.emit` dispatches to each registered tap callback and treats any error
coming back as a supply failure: it routes the exception to the supplier's
`quit` handlers, or re-raises it as one if there are none. Two control signals
were already carved out of that — `return` (which belongs to the callback's
enclosing routine) and `next` (which skips the rest of the body for this value)
— but **`done` and `last` were not**.

So a `done` inside a `whenever` body took the failure path. That path reads
`err.exception` and rebuilds a plain `RuntimeError` from it, which **drops the
control flag**: what started as a `Control::ReactDone` signal came out the other
side as an ordinary thrown `X::ControlFlow` with `illegal => "done"`,
`enclosing => "supply or react"`, and nothing downstream recognised it as a
completion any more.

The loudest symptom was on a channel reader thread. A `whenever` on a socket
supply is driven by its own thread (`run_supply_act_loop`); when a body running
there emitted into a `Supplier` whose own tap called `done`, the de-flagged
exception surfaced at the top of that thread as

```
Unhandled exception in code scheduled on thread
done without supply or react
```

and the loop answered it with `std::process::exit(1)`.

## Result

That killed the whole process mid-file. The vendored Cro suite's
`http-middleware.rakutest` aborted after subtest 4 in **2 runs out of 3**,
hiding subtests 5-11 entirely. It now completes all 11 every time (4/4 runs
checked); the subtest tally is unchanged at 2 failing, but they are now
*measurable*.

## Fix

- Both `"emit"` arms (`native_supplier_mut` and `native_supplier`) propagate
  `done`/`last` unchanged, right next to the existing `return` carve-out.
- `run_supply_act_loop` absorbs such a signal as end-of-stream rather than as a
  fatal error — the same `is_react_done() || is_last()` treatment every other
  supply drive loop already gives it (`native_supply_mut_methods`,
  `vm_react_subscriptions`).

## Known remaining half

Completing the supply this way does not yet tear down the `whenever`'s
subscription on its source, so the body keeps running (to no effect) for later
emits: `@got` gets `[one stop ignored]` where raku gets `[one stop]`. That is
pre-existing, unchanged by this PR, and filed as
`todo/tickets/done-in-a-whenever-body-does-not-stop-later-emits.md` with the
concrete pointer (`upstream_taps` in the on-demand `"tap"` arm).

## Verification

- `t/supply-done-in-tap-callback-is-not-a-failure.t` — four checks, all matching
  `raku`; check 3 fails on `main`.
- `make test` passes (2861 files, 27171 tests).
- Whitelisted `S17-supply/*`, `S17-channel/*`, `S17-promise/*`, `S32-io/*` clean
  on a release build (the one `spurt.t` failure was the documented stale
  `temp-file-RT-126006-test` artifact; clean after removing it, as `make roast`
  does automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)