### PR TITLE
feat(test): a subtest says why its body died

### DIFF
--- a/news/2026-08/subtest-reports-why-its-body-died.md
+++ b/news/2026-08/subtest-reports-why-its-body-died.md
@@ -1,0 +1,39 @@
+# A subtest says why its body died
+
+A `subtest` whose body throws is reported as a failing test, but the reason was
+dropped on the floor. All the reader saw was
+
+```
+# Subtest: Interaction of middleware written as Cro::Transform with HTTP router
+    1..0
+not ok 6 - Interaction of middleware written as Cro::Transform with HTTP router
+```
+
+`finish_subtest` took the body's `Result` only to decide the ok/not-ok verdict
+and never rendered the error, so a dying subtest was one of the least
+diagnosable failures in the suite: no message, no line, no exception type — and
+nothing to distinguish "the body threw on its first statement" from "the body
+ran and planned zero tests".
+
+The reason now goes to `$*ERR`, indented to the subtest's level, next to the
+`# You failed N tests of M` line that already lives there:
+
+```
+    # subtest died: Expected IO::Handle
+```
+
+stdout — where the TAP stream lives — is untouched, so no plan or test count
+changes. When the error carries a typed exception its `.message` is rendered
+(via `exception_message_text`, so a class that computes its message gets its own
+text); otherwise the raw error message is used.
+
+This immediately paid for itself: the vendored Cro suite's
+`http-middleware.rakutest` subtest 6 had been a silent `1..0`, and the one new
+line named the culprit — a bareword `get` inside a multi-statement `route` block
+reaching mutsu's builtin `get` (read a line from a handle) instead of
+`Cro::HTTP::Router`'s exported one. That bug is now written up with its
+debugger trace in
+`todo/tickets/imported-sub-loses-to-a-builtin-inside-a-subtest.md`.
+
+Pinned by `t/subtest-reports-why-its-body-died.t` (both checks also pass under
+`raku`, which reports the same reason on stderr).

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -210,6 +210,21 @@ impl Interpreter {
         self.output_sink_mut().output = ctx.parent_output;
         self.halted = ctx.parent_halted;
         self.tap.end_subtest();
+        // A subtest whose body dies is reported as a failure, but the reason was
+        // dropped on the floor: all the reader saw was `1..0` and a bare
+        // `not ok`. Say what killed it, on stderr so TAP counting is untouched.
+        if let Err(ref err) = run_result {
+            let reason = match err.exception.as_deref() {
+                Some(exc) => self
+                    .exception_message_text(exc)
+                    .unwrap_or_else(|| err.message.clone()),
+                None => err.message.clone(),
+            };
+            let reason = reason.trim();
+            if !reason.is_empty() {
+                self.emit_stderr(&format!("{}# subtest died: {}\n", subtest_indent, reason));
+            }
+        }
         // Rakudo's subtest closes with its own count on `$failure_output`
         // (stderr), indented to its level, just as the top-level run does.
         if subtest_failed > 0 && !subtest_was_todo {

--- a/t/subtest-reports-why-its-body-died.t
+++ b/t/subtest-reports-why-its-body-died.t
@@ -1,0 +1,46 @@
+use Test;
+plan 2;
+
+# A subtest whose body dies is reported as a failure, but the reason used to be
+# dropped on the floor: all the reader saw was `1..0` and a bare `not ok`. That
+# made a dying subtest one of the hardest failures in the suite to diagnose —
+# the vendored Cro suite's `http-middleware.rakutest` subtest 6 sat at a silent
+# `1..0` until the interpreter was taught to say "Expected IO::Handle".
+#
+# The reason now goes to stderr (`$*ERR`), so TAP counting on stdout is
+# untouched.
+
+my $mutsu = $*EXECUTABLE.absolute;
+
+sub run-snippet(Str $code) {
+    my $file = $*TMPDIR.add("subtest-diag-{$*PID}-{(^10000).pick}.raku");
+    $file.spurt($code);
+    LEAVE { try $file.unlink }
+    my $proc = run $mutsu, $file.absolute, :out, :err;
+    my $out = $proc.out.slurp(:close);
+    my $err = $proc.err.slurp(:close);
+    return %( :$out, :$err );
+}
+
+my %dying = run-snippet(q:to/CODE/);
+    use Test;
+    plan 1;
+    subtest {
+        die "the body exploded";
+    }, 'dies';
+    CODE
+
+ok %dying<err>.contains('the body exploded'),
+    'a dying subtest reports what killed it on stderr';
+
+my %living = run-snippet(q:to/CODE/);
+    use Test;
+    plan 1;
+    subtest {
+        plan 1;
+        ok 1, 'inner';
+    }, 'lives';
+    CODE
+
+nok %living<err>.contains('subtest died'),
+    'a subtest whose body completes reports no death';

--- a/todo/tickets/imported-sub-loses-to-a-builtin-inside-a-subtest.md
+++ b/todo/tickets/imported-sub-loses-to-a-builtin-inside-a-subtest.md
@@ -1,0 +1,78 @@
+# A bareword call inside a `subtest` reaches the builtin instead of the imported sub
+
+A `route` block with **more than one statement**, evaluated inside a `subtest`,
+calls mutsu's builtin `get` (read a line from a handle) instead of
+`Cro::HTTP::Router`'s exported `get`, and dies with `Expected IO::Handle`:
+
+```raku
+use Cro::HTTP::Router;
+use Test;
+
+subtest {
+    my $a = route {
+        get -> { content 'text/html', "x" }
+        get -> 'y' { content 'text/html', "y" }
+    };
+    ok $a.defined, 'built';
+}, 'probe';
+```
+
+`raku` builds the route. mutsu dies. All three of these work:
+
+- the same `route` block at file scope, in a bare block, in a sub, or in a
+  `Callable` invoked by hand (`tmp/st6i.p6`);
+- a `route` block inside a subtest with a **single** statement
+  (`route { get -> { … } }`);
+- a `route` block inside a subtest whose first statement is not `get`
+  (`route { include $inner; get -> { … } }` builds fine — `tmp/st6k.p6`).
+
+So the trigger is "two or more statements, inside a subtest", not `include` and
+not any particular route verb.
+
+## What the debugger shows
+
+`rust-gdb` breaking on `src/runtime/handle_io.rs:119` (the `Expected IO::Handle`
+site) gives the chain:
+
+```
+builtin_get                       (runtime/builtins_io_stream.rs:106)
+call_function name="get"          (runtime/builtins.rs:1150)
+exec_call_values name="get"       (runtime/call_helpers.rs:43)
+exec_exec_call_op                 (vm/vm_call_exec_ops.rs:131)
+… call_compiled_function_named fn_package="Cro::HTTP::Router" fn_name="route"
+```
+
+So the call compiled to the **`ExecCall`** opcode (the fallback for a name the
+compiler could not resolve statically), and at run time
+`find_compiled_function(compiled_fns, "get", args)` returned `None`, which drops
+`exec_exec_call_op` into `exec_call_values` → `call_function` → the builtin. The
+`compiled_fns` pointer is the same one the enclosing frames use, so the registry
+is shared; what fails is `resolve_function_with_types("get", args)` inside
+`find_compiled_function_inner` (`vm/vm_call_resolve.rs:53` — its `?` on the
+fingerprint is the early return), i.e. the imported `&get` is not visible in the
+env at that moment.
+
+The subtest body is run through `call_sub_value` → `eval_block_value` →
+`run_compiled_block` → `run_nested` (`runtime/test_functions/tap_subtest.rs:133`),
+so the block is compiled at run time rather than with the file — which is the
+likely reason the multi-statement form emits `ExecCall` where the single-statement
+form does not.
+
+## Not reproducible without Cro (yet)
+
+Two synthetic attempts are **green** on mutsu, so do not chase a smaller repro by
+guessing:
+
+- `tmp/imp1.p6` + `tmp/implib/ImpTest.rakumod` — an exported `runner(&body)` and
+  an exported `marker()` called by bareword from a one- and a two-statement block
+  inside a subtest.
+- `tmp/imp2.p6` + `tmp/implib/ImpTest2.rakumod` — the same with the exported sub
+  named `get`, so it collides with the builtin.
+
+Grow `tmp/st6n.p6` (the minimal Cro repro above) down instead.
+
+## Blast radius
+
+`http-middleware.rakutest` subtest 6 ("Interaction of middleware written as
+Cro::Transform with HTTP router"), which reports a silent `1..0`. Extracted from
+the subtest into a bare block, all 11 of its assertions pass (`tmp/st6.p6`).


### PR DESCRIPTION
## Problem

A `subtest` whose body throws is reported as a failing test, but the reason was
dropped on the floor. All the reader saw was:

```
# Subtest: Interaction of middleware written as Cro::Transform with HTTP router
    1..0
not ok 6 - Interaction of middleware written as Cro::Transform with HTTP router
```

`finish_subtest` took the body's `Result` only to decide the ok/not-ok verdict
and never rendered the error — no message, no line, no exception type, and
nothing to distinguish "the body threw on its first statement" from "the body
ran and planned zero tests".

## Fix

The reason now goes to `$*ERR`, indented to the subtest's level, next to the
`# You failed N tests of M` line that already lives there:

```
    # subtest died: Expected IO::Handle
```

stdout — where the TAP stream lives — is untouched, so no plan or test count
changes. A typed exception renders its `.message` through
`exception_message_text` (so a class that computes its message gets its own
text); otherwise the raw error message is used.

## Why it matters

It immediately paid for itself. The vendored Cro suite's
`http-middleware.rakutest` subtest 6 had been a silent `1..0`, and the one new
line named the culprit: a bareword `get` inside a multi-statement `route` block
reaches mutsu's builtin `get` (read a line from a handle) instead of
`Cro::HTTP::Router`'s exported one. That bug is filed separately, with its
`rust-gdb` trace and the three shapes that *do* work, in
`todo/tickets/imported-sub-loses-to-a-builtin-inside-a-subtest.md`.

## Verification

- `t/subtest-reports-why-its-body-died.t` — both checks pass under mutsu **and**
  under `raku`, which reports the same reason on stderr.
- `make test` passes (2866 files, 27216 tests).
- Whitelisted `S24-*` (the Test-module tests), `S04-*` and `S17-supply/*` roast
  subset clean on a release build — the stderr line does not disturb TAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)