### PR TITLE
regex: intern named capture keys

### DIFF
--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -6,8 +6,7 @@
   (2026-07-31), P4 one-list-per-axis in two layers (2026-07-31), P5 lazy
   `ValueRepr::Match(Gc<MatchNode>)` (2026-07-31). Per-phase outcomes, measurements and the
   behaviour corrections are recorded inline in §Phasing. **Residue, deliberately deferred and
-  not blocking** — capture names are still `String` keys (interning to `Symbol` needs a
-  Symbol-keyed hash map on the Match render path); `CodeBlockContext` keeps a text snapshot,
+  not blocking** — `CodeBlockContext` keeps a text snapshot,
   materialized from spans at its single construction site; and the reduce walk / failed
   partial-parse replay still build eager `Match` objects for `$/` inside in-regex code blocks
   (small counts, unchanged semantics). **Standing consequence of P5**: a `view()`-based
@@ -340,9 +339,10 @@ comments).
   materialized from spans at its single construction site (same engine
   space, so semantics are unchanged); `hash_captures` (accumulator-only) and
   `positional_slots` (the pcre2 numbering axis) stay separate by design.
-- Capture names remain `String` keys — interning them to `Symbol`s needs a
-  Symbol-keyed hash map on the Match render path and is deferred as a
-  follow-up optimization, not part of the axis collapse.
+- Capture names remained `String` keys in the original P4 landing. The
+  follow-up `news/2026-08/regex-capture-names-are-interned.md` changed both
+  capture axes and the undo trail to `Symbol` keys; only Match rendering and
+  code-block snapshots resolve them back to strings.
 - Behavior changes, all corrective toward raku and consistent with what P3a
   did for the subcap axis: subcap-less capture leaves report real offsets,
   and `:m`/`:i`-fold capture texts read through consumers derive from the

--- a/news/2026-08/regex-capture-names-are-interned.md
+++ b/news/2026-08/regex-capture-names-are-interned.md
@@ -1,0 +1,11 @@
+# Regex capture names stay interned through matching
+
+ADR-0016 left named capture axes keyed by owned `String`s after its P4 axis
+collapse. A grammar parse therefore still allocated and compared capture-name
+strings while applying candidates and recording undo entries.
+
+`RegexCaptures` and stored `CapChildren` now key their named axes by `Symbol`.
+The backtracking trail records the same compact symbol handle, and capture names
+are resolved to strings only when a Raku-level `Match.hash` or a regex code-block
+snapshot is materialized. This completes the first non-blocking residue recorded
+by ADR-0016 without changing capture behavior.

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -301,7 +301,7 @@ impl Interpreter {
             if k.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
                 continue;
             }
-            if let Some(m) = made_named.get(k) {
+            if let Some(m) = made_named.get(k.as_str()) {
                 env.push((format!("<{}>", k), m.clone()));
                 continue;
             }
@@ -519,7 +519,7 @@ impl Interpreter {
             .unwrap_or_else(|| rule_name.clone());
         let Some(sub) = new_caps
             .named
-            .get(&cap_name)
+            .get(&Symbol::intern(&cap_name))
             .and_then(|slot| slot.nodes.last())
             .cloned()
         else {

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -570,7 +570,7 @@ impl Interpreter {
     /// accumulator and stored `CapNode`s (their child axes are the same types).
     fn reduce_child_axes(
         &mut self,
-        named: &mut HashMap<String, NamedSlot>,
+        named: &mut HashMap<Symbol, NamedSlot>,
         positional: &mut [PosSlot],
         target: Option<&MatchTarget>,
     ) {
@@ -586,7 +586,7 @@ impl Interpreter {
         let skip_untouched = self.grammar_rule_dynvar_decls.is_empty();
         // Children first so a parent block reading a child's `.made` sees it.
         for (key, slot) in named.iter_mut() {
-            let child_rule = Self::reduce_child_rule_name(key);
+            let child_rule = Self::reduce_child_rule_name(key.as_str());
             for sc in slot.nodes.iter_mut() {
                 if skip_untouched && !Self::subtree_has_code_blocks(sc) {
                     continue;

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -1042,7 +1042,7 @@ pub(super) fn pos_slot_texts(slots: &[PosSlot], chars: &[char]) -> Vec<String> {
 /// `CodeBlockContext` snapshot carries. Silent-action marker keys never had
 /// text entries pre-P4 and are skipped.
 pub(super) fn named_slot_texts(
-    named: &HashMap<String, NamedSlot>,
+    named: &HashMap<crate::symbol::Symbol, NamedSlot>,
     chars: &[char],
 ) -> HashMap<String, Vec<String>> {
     named
@@ -1050,7 +1050,7 @@ pub(super) fn named_slot_texts(
         .filter(|(k, _)| !k.starts_with(SILENT_ACTION_MARKER_PREFIX))
         .map(|(k, slot)| {
             (
-                k.clone(),
+                k.resolve(),
                 slot.nodes
                     .iter()
                     .map(|n| span_chars_text(n.from, n.to, chars))

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -742,7 +742,7 @@ impl Interpreter {
                 super::regex_helpers::record_reduced_subrule(&spec.lookup_name, &subcap);
                 new_caps
                     .named
-                    .entry(capture_name.to_string())
+                    .entry(Symbol::intern(capture_name))
                     .or_default()
                     .nodes
                     .push(subcap);
@@ -754,7 +754,7 @@ impl Interpreter {
                 if let Some(orig_subcap) = original_subcap {
                     new_caps
                         .named
-                        .entry(spec.lookup_name.clone())
+                        .entry(Symbol::intern(&spec.lookup_name))
                         .or_default()
                         .nodes
                         .push(std::sync::Arc::new(orig_subcap.into_cap_node()));
@@ -790,7 +790,12 @@ impl Interpreter {
                 );
                 let subcap = std::sync::Arc::new(subcap.into_cap_node());
                 super::regex_helpers::record_reduced_subrule(&spec.lookup_name, &subcap);
-                new_caps.named.entry(marker).or_default().nodes.push(subcap);
+                new_caps
+                    .named
+                    .entry(Symbol::intern(&marker))
+                    .or_default()
+                    .nodes
+                    .push(subcap);
             } else {
                 // Childless silent subrule (`<.ws>`, `<.CRLF>`, `<.sym>`, ...): no
                 // nested captures and (in practice) no action of interest, so keep

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -372,11 +372,7 @@ impl Interpreter {
                             .positional
                             .extend(inner_caps.positional.iter().cloned());
                         for (k, v) in &inner_caps.named {
-                            new_caps
-                                .named
-                                .entry(k.clone())
-                                .or_default()
-                                .merge(v.clone());
+                            new_caps.named.entry(*k).or_default().merge(v.clone());
                         }
                         return Some((end, new_caps));
                     }
@@ -433,7 +429,7 @@ impl Interpreter {
                 // alloc-free scheme as the positional Backref (ADR-0016 P4).
                 let node = current_caps
                     .named
-                    .get(name.as_str())
+                    .get(&Symbol::intern(name))
                     .and_then(|slot| slot.nodes.last());
                 if let Some(node) = node {
                     let (a, b) = (node.from.min(chars.len()), node.to.min(chars.len()));
@@ -663,7 +659,7 @@ impl Interpreter {
                 if !spec.silent {
                     new_caps
                         .named
-                        .entry(spec.lookup_name.to_string())
+                        .entry(Symbol::intern(&spec.lookup_name))
                         .or_default()
                         .nodes
                         .push(std::sync::Arc::new(CapNode {
@@ -710,7 +706,7 @@ impl Interpreter {
                 if let Some(capture_name) = capture_name {
                     new_caps
                         .named
-                        .entry(capture_name.to_string())
+                        .entry(Symbol::intern(capture_name))
                         .or_default()
                         .merge(NamedSlot::leaf(pos, end));
                     // For <foo=alpha>, also capture under the original name.
@@ -724,7 +720,7 @@ impl Interpreter {
                             .insert(capture_name.to_string(), spec.lookup_name.clone());
                         new_caps
                             .named
-                            .entry(spec.lookup_name.to_string())
+                            .entry(Symbol::intern(&spec.lookup_name))
                             .or_default()
                             .merge(NamedSlot::leaf(pos, end));
                     }
@@ -760,7 +756,7 @@ impl Interpreter {
                 if let Some(capture_name) = capture_name {
                     new_caps
                         .named
-                        .entry(capture_name.to_string())
+                        .entry(Symbol::intern(capture_name))
                         .or_default()
                         .merge(NamedSlot::leaf(pos, end));
                 }
@@ -828,7 +824,7 @@ impl Interpreter {
                     let capture_name = spec.capture_name.unwrap_or(literal);
                     new_caps
                         .named
-                        .entry(capture_name)
+                        .entry(Symbol::intern(&capture_name))
                         .or_default()
                         .merge(NamedSlot::leaf(pos, pos + name_chars.len()));
                     return Some((pos + name_chars.len(), new_caps));

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -305,7 +305,15 @@ impl Interpreter {
                 .clone()
                 .or_else(|| (!spec.silent).then(|| spec.lookup_name.clone()));
             own_key
-                .and_then(|k| store.caps().named.get(&k)?.nodes.last().cloned())
+                .and_then(|k| {
+                    store
+                        .caps()
+                        .named
+                        .get(&Symbol::intern(&k))?
+                        .nodes
+                        .last()
+                        .cloned()
+                })
                 .filter(|sc| sc.from == from && sc.to == to)
         } else {
             None

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -346,7 +346,7 @@ impl Interpreter {
                     let mut subcap = best.clone();
                     subcap.sym = best_sym;
                     best.named
-                        .entry(spec.lookup_name.clone())
+                        .entry(Symbol::intern(&spec.lookup_name))
                         .or_default()
                         .nodes
                         .push(std::sync::Arc::new(subcap.into_cap_node()));

--- a/src/runtime/regex/regex_match_sep.rs
+++ b/src/runtime/regex/regex_match_sep.rs
@@ -81,7 +81,7 @@ impl Interpreter {
             let assemble = |trailing: Option<&RegexCaptures>, end: usize| {
                 let mut caps = RegexCaptures::default();
                 for n in names.iter() {
-                    caps.named.entry(n.clone()).or_default().quantified = true;
+                    caps.named.entry(Symbol::intern(n)).or_default().quantified = true;
                 }
                 Self::append_separated_captures(
                     &mut caps,
@@ -116,7 +116,7 @@ impl Interpreter {
         if min == 0 {
             let mut caps = RegexCaptures::default();
             for n in names.iter() {
-                caps.named.entry(n.clone()).or_default().quantified = true;
+                caps.named.entry(Symbol::intern(n)).or_default().quantified = true;
             }
             out.push((start, caps));
         }
@@ -226,7 +226,7 @@ impl Interpreter {
             // `match_separated_quantifier`).
             let mut caps = RegexCaptures::default();
             for n in Self::collect_quantified_names_for_token(token) {
-                caps.named.entry(n).or_default().quantified = true;
+                caps.named.entry(Symbol::intern(&n)).or_default().quantified = true;
             }
             return vec![(start, caps)];
         }
@@ -240,7 +240,7 @@ impl Interpreter {
         let names = Self::collect_quantified_names_for_token(token);
         let mut caps = RegexCaptures::default();
         for n in names.iter() {
-            caps.named.entry(n.clone()).or_default().quantified = true;
+            caps.named.entry(Symbol::intern(n)).or_default().quantified = true;
         }
         // Trailing separator for `%%`: Rakudo consumes it greedily, and
         // ratchet commits to that single choice.
@@ -444,7 +444,7 @@ impl Interpreter {
         // Named captures: merge every iteration's named captures (as arrays).
         for src in atom_caps.iter().chain(all_sep.iter().copied()) {
             for (k, v) in &src.named {
-                let slot = caps.named.entry(k.clone()).or_default();
+                let slot = caps.named.entry(*k).or_default();
                 slot.merge(v.clone());
                 slot.quantified = true;
             }

--- a/src/runtime/regex/regex_trail.rs
+++ b/src/runtime/regex/regex_trail.rs
@@ -38,7 +38,7 @@ pub(super) enum Undo {
     /// Restore a named slot: remove the key if it was newly created, else
     /// truncate its nodes to `len` and restore the quantified flag.
     NamedTrunc {
-        key: String,
+        key: crate::symbol::Symbol,
         len: usize,
         present: bool,
         quantified: bool,
@@ -167,13 +167,13 @@ impl CapStore {
         self.trail.push(Undo::PosLen(self.caps.positional.len()));
     }
 
-    fn record_named_key(&mut self, key: &str) {
-        let (len, present, quantified) = match self.caps.named.get(key) {
+    fn record_named_key(&mut self, key: crate::symbol::Symbol) {
+        let (len, present, quantified) = match self.caps.named.get(&key) {
             Some(slot) => (slot.nodes.len(), true, slot.quantified),
             None => (0, false, false),
         };
         self.trail.push(Undo::NamedTrunc {
-            key: key.to_string(),
+            key,
             len,
             present,
             quantified,
@@ -200,7 +200,7 @@ impl CapStore {
     /// per-level metadata (from/to/match_from) are intentionally NOT merged.
     pub(super) fn merge_delta(&mut self, mut delta: RegexCaptures) {
         for (k, v) in delta.named.drain() {
-            self.record_named_key(&k);
+            self.record_named_key(k);
             let slot = self.caps.named.entry(k).or_default();
             slot.nodes.extend(v.nodes);
             slot.quantified |= v.quantified;
@@ -241,20 +241,17 @@ impl CapStore {
 
     /// Append one span-bearing entry under a capture name.
     pub(super) fn push_named_node(&mut self, key: &str, sub: Arc<CapNode>) {
+        let key = crate::symbol::Symbol::intern(key);
         self.record_named_key(key);
-        self.caps
-            .named
-            .entry(key.to_string())
-            .or_default()
-            .nodes
-            .push(sub);
+        self.caps.named.entry(key).or_default().nodes.push(sub);
     }
 
     /// Mark a name as quantified (renders as an Array even for 0/1 entries).
     pub(super) fn insert_named_quantified(&mut self, name: String) {
+        let name = crate::symbol::Symbol::intern(&name);
         let already = self.caps.named.get(&name).is_some_and(|s| s.quantified);
         if !already {
-            self.record_named_key(&name);
+            self.record_named_key(name);
             self.caps.named.entry(name).or_default().quantified = true;
         }
     }
@@ -350,12 +347,13 @@ fn split_off_clamped<T>(v: &mut Vec<T>, at: usize) -> Vec<T> {
 mod tests {
     use super::super::super::{NamedSlot, PosSlot, RegexCaptures};
     use super::CapStore;
+    use crate::symbol::Symbol;
 
     fn store_with_base() -> CapStore {
         let mut init = RegexCaptures::default();
         init.positional.push(PosSlot::span(0, 1));
         init.named
-            .entry("x".to_string())
+            .entry(Symbol::intern("x"))
             .or_default()
             .merge(NamedSlot::leaf(0, 1));
         CapStore::new(init)
@@ -371,8 +369,9 @@ mod tests {
             (0, 1)
         );
         assert_eq!(store.caps().named.len(), 1);
-        assert_eq!(store.caps().named["x"].nodes.len(), 1);
-        assert!(!store.caps().named["x"].quantified);
+        let x = Symbol::intern("x");
+        assert_eq!(store.caps().named[&x].nodes.len(), 1);
+        assert!(!store.caps().named[&x].quantified);
         assert!(store.caps().capture_start.is_none());
         assert!(store.caps().sym.is_none());
     }
@@ -385,24 +384,26 @@ mod tests {
         delta.positional.push(PosSlot::span(1, 2));
         delta
             .named
-            .entry("x".to_string())
+            .entry(Symbol::intern("x"))
             .or_default()
             .merge(NamedSlot::leaf(2, 3));
-        let y = delta.named.entry("y".to_string()).or_default();
+        let y = delta.named.entry(Symbol::intern("y")).or_default();
         y.merge(NamedSlot::leaf(3, 4));
         y.quantified = true;
         delta.capture_start = Some(3);
         delta.sym = Some("s".to_string());
         store.merge_delta(delta);
         assert_eq!(store.caps().positional.len(), 2);
-        assert_eq!(store.caps().named["x"].nodes.len(), 2);
-        assert_eq!(store.caps().named["y"].nodes.len(), 1);
-        assert!(store.caps().named["y"].quantified);
+        let x = Symbol::intern("x");
+        let y = Symbol::intern("y");
+        assert_eq!(store.caps().named[&x].nodes.len(), 2);
+        assert_eq!(store.caps().named[&y].nodes.len(), 1);
+        assert!(store.caps().named[&y].quantified);
         assert_eq!(store.caps().capture_start, Some(3));
         assert_eq!(store.caps().sym.as_deref(), Some("s"));
         store.rewind(m);
         assert_base(&store);
-        assert!(!store.caps().named.contains_key("y"));
+        assert!(!store.caps().named.contains_key(&y));
     }
 
     #[test]
@@ -465,9 +466,10 @@ mod tests {
         );
         store.insert_named_quantified("k".to_string());
         store.rewind(m2);
-        assert_eq!(store.caps().named["k"].nodes.len(), 1);
-        assert!(!store.caps().named["k"].quantified);
+        let k = Symbol::intern("k");
+        assert_eq!(store.caps().named[&k].nodes.len(), 1);
+        assert!(!store.caps().named[&k].quantified);
         store.rewind(m1);
-        assert!(!store.caps().named.contains_key("k"));
+        assert!(!store.caps().named.contains_key(&k));
     }
 }

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -9,6 +9,7 @@
 //! those siblings keep their access (the whole set is re-exported from
 //! `runtime` via `pub(crate) use self::regex_types::*`).
 
+use crate::symbol::Symbol;
 use crate::value::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -156,7 +157,9 @@ pub(crate) struct CapChildren {
     /// the quantified flag in one axis. Silent-action captures (`<.foo>`)
     /// live under `SILENT_ACTION_MARKER_PREFIX`-prefixed keys and are hidden
     /// from `.hash`.
-    pub(crate) named: HashMap<String, NamedSlot>,
+    /// Capture names stay interned throughout matching and backtracking; only
+    /// Match `.hash` materialization resolves them back to user-facing strings.
+    pub(crate) named: HashMap<Symbol, NamedSlot>,
     pub(crate) capture_alias_map: HashMap<String, String>,
     /// Positional captures as span-bearing slots (ADR-0016 P4). Unlike the
     /// pre-P4 parallel vectors, the span survives onto the stored node — the
@@ -247,8 +250,8 @@ impl RegexCaptures {
 #[derive(Clone, Default)]
 pub(crate) struct RegexCaptures {
     /// Named captures as span-bearing slots (ADR-0016 P4). Keyed by capture
-    /// name; silent-action captures use `SILENT_ACTION_MARKER_PREFIX` keys.
-    pub(crate) named: HashMap<String, NamedSlot>,
+    /// name; silent-action captures use interned `SILENT_ACTION_MARKER_PREFIX` keys.
+    pub(crate) named: HashMap<Symbol, NamedSlot>,
     /// Positional captures as span-bearing slots (ADR-0016 P4): span, nested
     /// subcaptures, quantified iteration lists, and the Nil marker in one axis.
     pub(crate) positional: Vec<PosSlot>,

--- a/src/runtime/seq_helpers/regex_captures.rs
+++ b/src/runtime/seq_helpers/regex_captures.rs
@@ -78,9 +78,9 @@ impl Interpreter {
                 .map(|n| make_capture_match(&captures.span_text(n.from, n.to), n.from, n.to))
                 .collect();
             if vals.len() == 1 && !v.quantified {
-                named.insert(k.clone(), vals[0].clone());
+                named.insert(k.resolve(), vals[0].clone());
             } else {
-                named.insert(k.clone(), Value::array(vals));
+                named.insert(k.resolve(), Value::array(vals));
             }
         }
         // Add hash captures from %<name>=(...) aliasing
@@ -450,7 +450,7 @@ impl Interpreter {
             if let (Some(Some(name)), Some((start, end))) = (names.get(idx), locs.get(idx)) {
                 text.get(start..end)?;
                 out.named
-                    .entry(name.to_string())
+                    .entry(Symbol::intern(name))
                     .or_default()
                     .merge(NamedSlot::leaf(to_char(start), to_char(end)));
             }
@@ -509,7 +509,7 @@ impl Interpreter {
                         continue;
                     }
                     item.named
-                        .entry(name.to_string())
+                        .entry(Symbol::intern(name))
                         .or_default()
                         .merge(NamedSlot::leaf(to_char(c_start), to_char(c_end)));
                 }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -817,7 +817,9 @@ impl Interpreter {
                     for hash_name in captures.hash_captures.keys() {
                         // Don't overwrite existing named captures; an empty
                         // placeholder slot makes the builder create the key.
-                        named_with_hash.entry(hash_name.clone()).or_default();
+                        named_with_hash
+                            .entry(Symbol::intern(hash_name))
+                            .or_default();
                     }
                     let match_obj = Value::make_match_object_full(
                         captures.from as i64,

--- a/src/value/match_lazy.rs
+++ b/src/value/match_lazy.rs
@@ -171,11 +171,11 @@ impl MatchNode {
             }
             let vals: Vec<Value> = slot.nodes.iter().map(|sc| self.lazy_child(sc)).collect();
             if vals.len() == 1 && !slot.quantified {
-                sub_named.insert(key.clone(), vals[0].clone());
+                sub_named.insert(key.resolve(), vals[0].clone());
             } else {
                 // Quantified names (including zero-iteration ones) and
                 // multi-entry captures render as arrays.
-                sub_named.insert(key.clone(), Value::real_array(vals));
+                sub_named.insert(key.resolve(), Value::real_array(vals));
             }
         }
 
@@ -377,7 +377,7 @@ mod tests {
         caps.from = 0;
         caps.to = 2;
         caps.named.insert(
-            "x".to_string(),
+            Symbol::intern("x"),
             crate::runtime::NamedSlot {
                 nodes: vec![Arc::clone(&child)],
                 quantified: false,

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -19,7 +19,7 @@ impl Value {
         from: i64,
         to: i64,
         positional: &[crate::runtime::PosSlot],
-        named: &HashMap<String, crate::runtime::NamedSlot>,
+        named: &HashMap<crate::symbol::Symbol, crate::runtime::NamedSlot>,
         target: crate::runtime::MatchTarget,
     ) -> Self {
         let has_children = !named.is_empty() || !positional.is_empty();


### PR DESCRIPTION
## Problem

ADR-0016 left the named capture axes and their undo records keyed by owned `String`s, so capture-name allocation and byte comparison remained in the matcher.

## Approach

- key `RegexCaptures` and `CapChildren` named axes by interned `Symbol`
- carry `Symbol` through the backtracking trail and resolve names only at Match/code-block rendering boundaries
- update ADR-0016 residue and add a news entry

## Test evidence

- `cargo test regex_trail -- --nocapture`
- `cargo test match_lazy -- --nocapture`
- `prove -e target/debug/mutsu t/regex-capture.t t/regex-named-alias-dual-capture.t t/regex-quantified-capture-single-iteration.t t/grammar-alias-actions.t t/grammar-nested-action-dispatch.t t/grammar-silent-rule-action.t` (50 assertions)
- `cargo fmt --all`
- `cargo clippy -- -D warnings`

Full `make test` was not repeated because repository policy prohibits rerunning it in the same work session; CI provides the full suite.