### PR TITLE
docs(todo): the last two blockers in Cro's http-middleware suite

### DIFF
--- a/todo/tickets/cro-conditional-middleware-subtest-intermittent-promise-coercion.md
+++ b/todo/tickets/cro-conditional-middleware-subtest-intermittent-promise-coercion.md
@@ -1,0 +1,45 @@
+# Cro's Conditional-middleware subtest intermittently dies coercing Any into Promise
+
+The vendored Cro suite's `http-middleware.rakutest` subtest 3 ("Conditional
+response middleware using Cro::HTTP::Middleware::Conditional") passes on most
+runs but sometimes dies partway with
+
+```
+    # subtest died: Impossible coercion from 'Any' into 'Promise': no acceptable
+    coercion method found
+```
+
+(the diagnostic comes from `news/2026-08/subtest-reports-why-its-body-died.md`).
+When it dies it has already logged its earlier assertions; the failure is not in
+a particular assertion but in the subtest body between them.
+
+`Any` where a `Promise` is required is the shape of an `await` on something that
+never got its promise — most likely a response (or a `body-text`) that arrived
+as `Nil` because a pipeline stage completed early. The three fixes landed the
+same day that touched exactly that area are worth re-reading first:
+
+- `news/2026-08/channel-backed-whenever-source-is-not-finite.md` (a supply over
+  a socket used to complete at tap time)
+- `news/2026-08/done-in-a-tap-callback-is-a-control-signal.md` (a `done` that
+  lost its control flag)
+- `todo/tickets/done-in-a-whenever-body-does-not-stop-later-emits.md` (the
+  half of `done` semantics still missing: the source keeps delivering)
+
+The last of those is the most suspicious: a `whenever` body that keeps running
+after its supply completed can still take side effects, and the Conditional
+middleware's request and response halves share a `Supplier` whose `done` is
+driven by a LAST phaser.
+
+## How to see it
+
+```
+D=$(echo tmp/cro-work/C_RO_CRO_HTTP_*)
+for i in 1 2 3 4 5; do
+  timeout 300 target/debug/mutsu $(cat tmp/cro-work/inc-paths.txt) \
+      -I "$D/lib" -I "$D/t" "$D/t/http-middleware.rakutest" 2>&1 |
+    grep -E '^(ok|not ok) 3 '
+done
+```
+
+Roughly one run in several reports `not ok 3`; the rest report `ok 3` with all
+six of its assertions.

--- a/todo/tickets/route-handler-counter-loses-its-captured-atomicint.md
+++ b/todo/tickets/route-handler-counter-loses-its-captured-atomicint.md
@@ -1,0 +1,61 @@
+# A Cro route handler's captured `atomicint` counter does not count
+
+A `route` block that keeps per-application state in an `atomicint` and bumps it
+from a handler gets the wrong number out:
+
+```raku
+my $application = route {
+    my atomicint $i = 0;
+    get -> 'counter' {
+        my $n = ++⚛$i;
+        note "  [handler] run #$n";
+        content 'text/plain', $n.Str;
+    }
+}
+```
+
+Two requests to `/counter` print `run #0` **both times** and answer `0` both
+times; `raku` prints `run #1` / `run #2` and answers `1` / `2`
+(`tmp/counter1.p6`).
+
+## It is a Heisenbug: one statement earlier and it works
+
+Putting *any* statement before the increment fixes it. `tmp/counter2.p6` is the
+same server with a `note` first:
+
+```raku
+get -> 'counter' {
+    note "  [handler] before: name=", $i.^name, " read=", (try ⚛$i).raku;
+    my $n = ++⚛$i;
+    …
+}
+```
+
+and it counts correctly — `read=0` → `n=1` → `read=1`, then `read=1` → `n=2`.
+So the captured container is reachable and the atomic ops work; something about
+the increment being the **first statement of the handler body** loses it.
+
+That is the same first-statement/sink-position shape as the `ExecCall` builtin
+shadow fixed in `news/2026-08/imported-sub-shadows-a-builtin-in-sink-position.md`,
+which is worth checking first — but note this reproduces *with* that fix in.
+
+## Synthetic repros are all green
+
+Do not chase a smaller repro by guessing; these were tried and pass on mutsu:
+
+- `tmp/atomic1.p6` — `++⚛`/`⚛`/post-increment at file scope, in a sub, and in a
+  closure.
+- `tmp/atomic2.p6` — an `atomicint` declared inside a block passed to a sub,
+  captured by a handler closure registered from that block and called later
+  (the Cro `route`/`get` shape), plus the plain-`Int` control.
+- `tmp/atomic3.p6` — the same with the increment as the **first** statement of
+  the handler versus with a statement before it.
+
+Grow `tmp/counter1.p6` down instead.
+
+## Blast radius
+
+The vendored Cro suite's `http-middleware.rakutest` subtest 4
+("Request/response middleware using Cro::HTTP::Middleware::RequestResponse"),
+whose `/counter` route is exactly this shape: `is await($resp.body-text), '1'`
+gets `'3'`. That is the only failing subtest left in that file.


### PR DESCRIPTION
Documentation-only. With #5864, #5871, #5876 and #5882 in,
`http-middleware.rakutest` runs **all 11 subtests every time** — it used to
abort mid-file in 2 runs out of 3 — and is down to one deterministic failure
plus one intermittent one (from four failing subtests at the start of the day).
Both are written up so the next session starts from evidence rather than
re-deriving it.

**`route-handler-counter-loses-its-captured-atomicint.md`** — a `route` block's
`my atomicint $i` bumped from a handler answers `0` on every request instead of
counting (`raku` counts 1, 2). It is a Heisenbug: putting *any* statement before
the increment makes it work (`tmp/counter1.p6` vs `tmp/counter2.p6`). That is
the same first-statement shape as the `ExecCall` builtin shadow fixed in #5882,
which is the first thing to check — but it reproduces with that fix in. Three
synthetic repros (`tmp/atomic1.p6`, `tmp/atomic2.p6`, `tmp/atomic3.p6`) are
green and listed, so nobody re-derives them.

**`cro-conditional-middleware-subtest-intermittent-promise-coercion.md`** —
subtest 3 dies in roughly 2 runs out of 5 with `Impossible coercion from 'Any'
into 'Promise'` (measured: 5 runs gave 2/2/1/1/1 failing subtests). `Any` where
a `Promise` is wanted is what an `await` on a response that arrived as `Nil`
looks like. Points at the three supply fixes landed today and especially at
`todo/tickets/done-in-a-whenever-body-does-not-stop-later-emits.md` — the half
of `done` semantics still missing, where a completed supply's source keeps
delivering to the body.

Both reasons were surfaced by the `# subtest died: …` diagnostic from #5879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)