### PR TITLE
fix(vm): a native array's slice assignment reads through its container cell

### DIFF
--- a/news/2026-08/native-array-slice-assign-reads-through-its-cell.md
+++ b/news/2026-08/native-array-slice-assign-reads-through-its-cell.md
@@ -1,0 +1,43 @@
+# A native array's slice assignment reads through its container cell
+
+```raku
+sub takes-scalar(Mu $x) { ?$x }
+my @a := array[num].new;
+@a[0] = 1e0;
+takes-scalar(@a);
+@a[^3] = 5e0, 6e0, 7e0;   # Type check failed for an element of @a;
+                          # expected num but got List
+```
+
+Passing an array to a *scalar* parameter boxes the caller's binding into a
+`ContainerRef` cell so a write inside the callee can reach it. From then on
+`self.env().get("@a")` answers the cell, not the array — and everything
+user-visible derefs through it transparently, so `@a.WHAT`, `@a.of`, `@a.raku`
+and even single-element assignment all kept working and the array still looked
+native from Raku.
+
+What did not deref was the test that decides whether a Range subscript is a
+slice. `exec_index_assign_expr_named_op_inner` gates its "expand a numeric Range
+into an explicit index list" step on
+`matches!(index_target.view(), Some(ValueView::Array(..)))`, which the cell does
+not match. With the expansion skipped, `^3` fell through to the ordinary
+single-key path and was stringified into the key `"0 1 2"`, so the whole
+right-hand list was type-checked against the scalar element type.
+
+The fix is one `Value::deref_container` before the match, applied to both the
+view test and the container-metadata lookup beside it.
+
+This is the third time a raw `ValueView` read of an env binding has been wrong
+in this spot's neighbourhood (see
+`news/2026-08/shared-array-mutation-through-a-container-cell.md`): **a binding
+that a call could have boxed must be dereferenced before its variant is
+inspected**, because the boxed form silently takes the `_ =>` branch instead of
+failing loudly.
+
+Found under the real `Test` module — `nok @arr, "…"` passes the array to `ok`'s
+`Mu $cond` — which is why `roast/S09-typed-arrays/native-num.t` ran 31 of its
+518 assertions there while passing under the native provider, whose `nok` never
+takes the array as a Raku argument. It is 518/518 now.
+
+Pin: `t/native-array-slice-assign-after-scalar-arg.t` (all eight assertions
+verified against `raku`).

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -508,16 +508,23 @@ impl Interpreter {
         let vtc_native = loan_env!(self, var_type_constraint(&var_name))
             .as_deref()
             .is_some_and(crate::runtime::native_types::is_native_array_element_type);
-        let ct_native = index_target
-            .as_ref()
-            .cloned()
+        // Read through a container cell: passing `@b` to a *scalar* parameter
+        // boxes the caller's binding into a `ContainerRef` for writeback, and
+        // from then on `self.env().get("@b")` is the cell rather than the array.
+        // Everything user-visible derefs transparently (`@b.of` still answers
+        // `num`), so the array kept looking native from Raku while this raw
+        // `ValueView::Array` test stopped matching — and a `@b[^3] = …` Range
+        // subscript silently stringified into the single key "0 1 2".
+        let index_target_deref = index_target.as_ref().map(Value::deref_container);
+        let ct_native = index_target_deref
+            .clone()
             .and_then(|v| self.container_type_metadata(&v))
             .is_some_and(|info| {
                 crate::runtime::native_types::is_native_array_element_type(&info.value_type)
             });
         let array_var_is_native = !var_name.starts_with('%')
             && matches!(
-                index_target.as_ref().map(Value::view),
+                index_target_deref.as_ref().map(Value::view),
                 Some(ValueView::Array(..))
             )
             && (vtc_native || ct_native);

--- a/t/native-array-slice-assign-after-scalar-arg.t
+++ b/t/native-array-slice-assign-after-scalar-arg.t
@@ -1,0 +1,46 @@
+use Test;
+
+plan 8;
+
+# Passing an array to a *scalar* parameter boxes the caller's binding into a
+# container cell for writeback. Everything user-visible reads through that cell,
+# so the array must keep behaving as the native typed array it is -- in
+# particular a Range subscript on the left of `=` must still be a slice.
+sub takes-scalar(Mu $x) { ?$x }
+
+my @a := array[num].new;
+@a[0] = 1e0;
+takes-scalar(@a);
+@a[^3] = 5e0, 6e0, 7e0;
+is-deeply @a.List, (5e0, 6e0, 7e0), 'Range slice assign survives a scalar-param call';
+is @a.of.^name, 'num', 'the array is still native';
+
+my @b := array[int].new;
+@b[0] = 1;
+takes-scalar(@b);
+@b[1..2] = 8, 9;
+is-deeply @b.List, (1, 8, 9), 'an inclusive Range slice too';
+
+my @c := array[str].new;
+@c[0] = 'a';
+takes-scalar(@c);
+@c[^2] = 'x', 'y';
+is-deeply @c.List, ('x', 'y'), 'and on a native str array';
+
+# A comma-list subscript was never affected; keep it pinned alongside.
+my @d := array[num].new;
+takes-scalar(@d);
+@d[0,1] = 3e0, 4e0;
+is-deeply @d.List, (3e0, 4e0), 'a comma-list slice assign still works';
+
+# Single-element assignment and reads are unaffected.
+my @e := array[num].new;
+takes-scalar(@e);
+@e[2] = 2e0;
+is @e.elems, 3, 'single-element assign still grows the array';
+is-deeply @e[^3].List, (0e0, 0e0, 2e0), 'slice READ was always fine';
+
+# Without the intervening call the slice assign has always worked.
+my @f := array[num].new;
+@f[^3] = 1e0, 2e0, 3e0;
+is-deeply @f.List, (1e0, 2e0, 3e0), 'and with no call at all';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -765,6 +765,15 @@ a routine/closure body is registered twice** (hoist pass, then in sequence), so
 any "have I seen this name before?" test in the compiler counts the hoist copy
 first.
 
+`S09-typed-arrays/native-num.t` is closed
+(`news/2026-08/native-array-slice-assign-reads-through-its-cell.md`): `nok @arr`
+passes the array to `ok`'s `Mu $cond`, which boxes the caller's binding into a
+`ContainerRef`, and the slice-assign path's raw `ValueView::Array` test then
+stopped matching — so `@arr[^3] = …` stringified its Range into one key. **The
+native provider never takes such an argument as a Raku value, so any test file
+that hands a container to a `Test` routine is exercising the cell form for the
+first time.**
+
 `roast/S12-methods/qualified.t` is worth a second look too: its Malformed
 assertion passes now and the file moved on to `Cannot dispatch to method me on
 Parent because it is not inherited or done by Bar` in its inheritance subtest.


### PR DESCRIPTION
```raku
sub takes-scalar(Mu $x) { ?$x }
my @a := array[num].new;
@a[0] = 1e0;
takes-scalar(@a);
@a[^3] = 5e0, 6e0, 7e0;   # Type check failed for an element of @a;
                          # expected num but got List
```

Passing an array to a *scalar* parameter boxes the caller's binding into a `ContainerRef` cell so a write inside the callee can reach it. From then on `self.env().get("@a")` answers the cell, not the array — and everything user-visible derefs through it transparently, so `@a.WHAT`, `@a.of`, `@a.raku` and even single-element assignment all kept working, and the array still looked native from Raku.

What did not deref was the test that decides whether a Range subscript is a slice. `exec_index_assign_expr_named_op_inner` gates its "expand a numeric Range into an explicit index list" step on `matches!(index_target.view(), Some(ValueView::Array(..)))`, which the cell does not match. With the expansion skipped, `^3` fell through to the ordinary single-key path and was stringified into the key `"0 1 2"`, so the whole right-hand list was type-checked against the scalar element type.

The fix is one `Value::deref_container` before the match, applied to both the view test and the container-metadata lookup beside it.

This is the third time a raw `ValueView` read of an env binding has been wrong in this neighbourhood (see `news/2026-08/shared-array-mutation-through-a-container-cell.md`): **a binding that a call could have boxed must be dereferenced before its variant is inspected**, because the boxed form silently takes the `_ =>` branch instead of failing loudly.

Found under the real `Test` module — `nok @arr, "…"` passes the array to `ok`'s `Mu $cond` — which is why `roast/S09-typed-arrays/native-num.t` ran 31 of its 518 assertions there while passing under the native provider, whose `nok` never takes the array as a Raku argument. It is 518/518 now, and still passes under the native provider.

Pin: `t/native-array-slice-assign-after-scalar-arg.t` (all eight assertions verified against `raku`).

Verified locally: `make roast` PASS (1435 files), `make test` PASS (2869 files), batteries gate PASSED, `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)