### PR TITLE
docs(todo): record the anonymous-state key-stability hazard

### DIFF
--- a/todo/tickets/anonymous-state-var-not-reset-per-routine-call.md
+++ b/todo/tickets/anonymous-state-var-not-reset-per-routine-call.md
@@ -178,12 +178,62 @@ both be satisfied by a global registry.
 
 **So the marking has to live on the `CompiledCode` that was compiled**, as the
 original Route B note said, and the runtime has to consult the *executing*
-chunk. That is the one open design question: `anon_state_key` is reached from 13
-call sites (`vm_exec_dispatch.rs`, `vm_var_assign_post_incdec.rs`,
-`vm_misc_coerce.rs`, `vm_var_assign_typed.rs`, `vm_misc_assign.rs`), none of
-which has `code` in hand today. Either thread `&CompiledCode` to them, or keep
-an Interpreter-side stack of the executing chunk's per-call set pushed and
-popped where chunks are entered.
+chunk.
+
+### Route B v2, prototyped and shelved (2026-08-04) — per-chunk is not enough either
+
+Built and shelved as PR #5885. The threading concern above turned out to be a
+non-issue: **all 13 `anon_state_key` call sites already have
+`code: &CompiledCode` in scope** (the earlier note read the helper signatures,
+not the callers), so moving the set onto `CompiledCode::per_call_anon_states`
+and passing `code` down is mechanical. That version got every row of the table
+right, kept `roast/S32-list/rotor.t` green, and made `rmd160("abc")` correct on
+the second call in a process. The full `prove t/` (2869 files) passed.
+
+It regressed **`roast/S32-list/classify.t` test 39**:
+
+```raku
+<a b c>.classify({ ~($ ~= $_); })
+# raku / main: :{ a => [a], ab => [b], abc => [c] }
+# Route B v2:  :{ a => [a], b  => [b], c   => [c] }   -- the `$` reset per item
+```
+
+The cause is a **key-stability hazard**, and it is the thing to solve first:
+
+- Several runtime paths re-compile a block body from its AST
+  (`eval_map_over_items` and its grep/rw siblings, `exec_make_gather_op`,
+  `call_sub_value`), which loses the lexical position, so the cursor has to be
+  restated at each of those sites. Without that, `map { ++$ }` — the whole
+  reason this ticket exists — never resets.
+- But once it is restated, ONE `$` occurrence can be executed by TWO chunks that
+  classified it differently. Its write then lands on
+  `__anon_state::<name>#<bucket>` while its read looks up the plain
+  `__anon_state::<name>` (or the reverse), and the counter looks like it reset.
+  Under gdb the classify callback's own chunk reports an EMPTY
+  `per_call_anon_states` and bucket 0, yet the value still fails to carry — the
+  write went through a different, marked chunk.
+
+So the classification has to be attached to the `$` occurrence in a way that
+**every chunk that executes it agrees on**. Neither a global registry (poisoned
+by analysis passes, above) nor a per-chunk set (this attempt) provides that
+alone. Two shapes worth considering next:
+
+1. Carry the classification on the closure VALUE (`SubData`) / the gather's
+   `LazyList`, so a re-compile inherits it from the block being run rather than
+   re-deriving it. That also removes the per-site restatement entirely.
+2. Make the *key* independent of the classification — always
+   `__anon_state::<name>#<bucket>`, with `bucket` = 0 for a non-per-call
+   occurrence — so a disagreement about classification can no longer split one
+   variable across two keys. This is a small change and worth trying first; it
+   turns the hazard into "at worst the wrong bucket", not "two different
+   variables".
+
+A third, independent point the prototype settled: the inline-body marking must
+be **opt-in** (`Stmt::For`'s block form arming a one-shot flag), because
+`Stmt::If`/`Stmt::While` carry no `is_statement_modifier` flag — adding one is
+~90 `Stmt::If` construction sites away — so `$++ if C` (which must keep
+counting; `rotor.t`'s hand-written `Iterator` depends on it) cannot be told from
+`if C { $++ }`.
 
 ## Why it matters
 


### PR DESCRIPTION
Follow-up to #5875 and #5884. Route B v2 was built (PR #5885, now closed) and is shelved on a specific, newly-identified obstacle. The ticket now records it so the next attempt starts from the real problem.

## What v2 settled

The threading concern the previous note raised was a **non-issue**: all 13 `anon_state_key` call sites already have `code: &CompiledCode` in scope — the earlier note read the helper signatures, not the callers. Moving the classification off the global registry (which #5884 showed gets poisoned by analysis passes) and onto `CompiledCode::per_call_anon_states` is mechanical.

That version got every row of the ticket's behaviour table right, kept `roast/S32-list/rotor.t` green (21 tests, 1s), made `rmd160("abc")` correct on the second call in a process, and passed the full `prove t/` (2869 files, 27232 tests).

## Why it still cannot land

It regressed `roast/S32-list/classify.t` test 39:

```raku
<a b c>.classify({ ~($ ~= $_); })
# raku / main: :{ a => [a], ab => [b], abc => [c] }
# Route B v2:  :{ a => [a], b  => [b], c   => [c] }   -- the `$` reset per item
```

A **key-stability hazard**, and it is inherent to per-chunk classification:

- Several runtime paths re-compile a block body from its AST (`eval_map_over_items` and its grep/rw siblings, `exec_make_gather_op`, `call_sub_value`), losing the lexical position — so the cursor must be restated at each. Without that, `map { ++$ }`, the whole reason this ticket exists, never resets.
- Once it is restated, **one `$` occurrence can be executed by two chunks that classified it differently**. Its write lands on `__anon_state::<name>#<bucket>` while its read looks up the plain `__anon_state::<name>` (or the reverse). Under gdb the classify callback's own chunk reports an empty set and bucket 0, yet the value still fails to carry — the write went through a different, marked chunk.

## What the note proposes next

1. Carry the classification on the **closure value** (`SubData`) / the gather's `LazyList`, so a re-compile inherits it from the block being run instead of re-deriving it — which also removes the per-site restatement entirely.
2. Or make the key **unconditionally** carry a bucket (0 when not per-call), so a classification disagreement can no longer split one variable across two keys. Small change, worth trying first: it turns the hazard into "at worst the wrong bucket" rather than "two different variables".

It also keeps the point v2 settled independently: the inline-body marking must be **opt-in** (armed only by `Stmt::For`'s block form), because `Stmt::If`/`Stmt::While` carry no `is_statement_modifier` flag — adding one is ~90 `Stmt::If` construction sites away — so `$++ if C` cannot be told from `if C { $++ }`.

Documentation only — no behaviour change. `todo/tickets/digest-dist-blockers.md` blocker 2 stays open; every other blocker in that ticket except the non-blocking §5 is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)