### PR TITLE
docs(todo): correct a dead-end suggestion in the anonymous-state ticket

### DIFF
--- a/todo/tickets/anonymous-state-var-not-reset-per-routine-call.md
+++ b/todo/tickets/anonymous-state-var-not-reset-per-routine-call.md
@@ -221,12 +221,22 @@ alone. Two shapes worth considering next:
 1. Carry the classification on the closure VALUE (`SubData`) / the gather's
    `LazyList`, so a re-compile inherits it from the block being run rather than
    re-deriving it. That also removes the per-site restatement entirely.
-2. Make the *key* independent of the classification — always
-   `__anon_state::<name>#<bucket>`, with `bucket` = 0 for a non-per-call
-   occurrence — so a disagreement about classification can no longer split one
-   variable across two keys. This is a small change and worth trying first; it
-   turns the hazard into "at worst the wrong bucket", not "two different
-   variables".
+2. Decide the classification ONCE per source occurrence and put it somewhere
+   every compilation of that occurrence can see — the obvious carrier being the
+   name itself, since the runtime key is derived from it. Rewriting
+   `__ANON_STATE_<id>__` to a per-call spelling in the AST, once, at routine
+   registration, makes every re-compile of that body agree for free and removes
+   the per-site restatement. The cost is an AST walk: the set to rewrite is
+   `all_anon_state_names(body) − shallow_anon_state_names(body)`, and only the
+   shallow half exists today (`collect_ph_stmt_shallow`'s block-boundary
+   descent, which is reusable). Each `__ANON_STATE_<id>__` is unique per source
+   occurrence, so the two sets cannot overlap.
+
+   (An earlier version of this note suggested instead making the key
+   *unconditionally* carry a bucket — `#0` when not per-call — as a cheap
+   mitigation. **That does not work**: the two chunks would then produce
+   `…#<invocation>` and `…#0`, which is still two different keys for one
+   variable. Nothing short of making the chunks agree fixes the split.)
 
 A third, independent point the prototype settled: the inline-body marking must
 be **opt-in** (`Stmt::For`'s block form arming a one-shot flag), because


### PR DESCRIPTION
Correction to #5888.

That note offered "make the key unconditionally carry a bucket (`#0` when not per-call)" as a cheap thing to try first. On re-reading, **it does not work**: the two disagreeing chunks would then produce `…#<invocation>` and `…#0` — still two different keys for one variable. The split is not caused by one side lacking a suffix; it is caused by the chunks disagreeing about the classification at all. Leaving that suggestion in place would send the next attempt down a dead end.

Replaced with the shape that does address it: decide the classification **once per source occurrence** and carry it on the **name**, by rewriting `__ANON_STATE_<id>__` to a per-call spelling in the AST at routine registration. Every re-compile of that body then agrees for free, and the per-site cursor restatement that caused the hazard disappears entirely.

The note records the cost honestly — an AST walk computing `all_anon_state_names(body) − shallow_anon_state_names(body)`, of which only the shallow half exists today (`collect_ph_stmt_shallow`'s block-boundary descent, reusable) — and why the two sets cannot overlap (the parser mints one id per source occurrence).

Documentation only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)