### PR TITLE
docs(todo): triage roast/S06-operator-overloading/sub.t's three blockers

### DIFF
--- a/todo/deep/block-local-operator-leaks-into-later-parses.md
+++ b/todo/deep/block-local-operator-leaks-into-later-parses.md
@@ -1,0 +1,52 @@
+# An operator declared in a callable block changes how later code parses
+
+```raku
+sub run(&c) { c() }
+run { sub infix:["@"] ($a, $b) { 42 } }
+say EVAL 'sub circumfix:["@", "@"] ($a) { $a }; @ 5 @';
+```
+
+rakudo prints `5`. mutsu dies with `Confused. Two terms in a row`, because the
+`infix:<@>` declared inside the block is still visible when the `EVAL` string is
+*parsed*, so `@ 5 @` reads as an infix application with a missing right operand
+instead of the circumfix the string just declared.
+
+## Mechanism
+
+Two known facts compose:
+
+1. mutsu's routine registry is keyed by package alone, so a routine declared in
+   a block that runs as a *callable* stays in `registry().functions` after the
+   block returns. (`news/2026-08/sibling-scope-routine-shadow.md` fixed the
+   redeclaration half of this; the entry itself still outlives its scope.)
+2. `Interpreter::collect_operator_sub_names` (`src/runtime/system_eval_string.rs`)
+   builds the EVAL parser's operator pre-seed by walking **the whole registry**.
+
+So a stale operator entry does not merely stay callable — it changes the grammar
+the next `EVAL` is parsed with. Ordinary nested blocks are fine: `{ sub
+infix:["@"] … }` at statement level does not leak, because that path clears the
+registry entry. Only the callable-block form does.
+
+## Two possible fixes
+
+- **Narrow.** Pre-seed only operators that are lexically visible at the EVAL
+  site. A routine declared inside a callable block leaves a registry entry but
+  no `&name` in any visible env tier (this is exactly the asymmetry
+  `news/2026-08/eval-sub-shadows-a-registered-routine.md` documents), so
+  intersecting the registry walk with `env.visible_keys_where(|k|
+  k.starts_with('&'))` would drop the stale ones. Needs checking that a
+  compunit-level `sub infix:<…>` really does leave an `&infix:<…>` binding, and
+  that operators imported by `use` (which the same function collects from a
+  third source) are unaffected.
+- **Root.** Give routine declarations real lexical scope, so a block-local
+  routine is removed from the registry when its scope ends. That is the same
+  change `todo/deep/` wants for the routine-visibility half — a routine declared
+  in a sub body is still callable after the sub returns, which rakudo rejects at
+  compile time.
+
+## Where it bites
+
+`roast/S06-operator-overloading/sub.t` aborts on it after 24 of 29 assertions:
+the file declares `sub infix:["@"]` inside a `lives-ok { … }` and then EVALs a
+string declaring `circumfix:["@", "@"]`. See the ledger entry in
+`todo/tickets/vendor-real-test-module.md` for the file's other two blockers.

--- a/todo/tickets/operator-extension-name-error-classes.md
+++ b/todo/tickets/operator-extension-name-error-classes.md
@@ -1,0 +1,32 @@
+# A malformed operator name reports "Missing block" instead of its own class
+
+Two `sub <category>:<…>` spellings rakudo diagnoses precisely, and mutsu answers
+with the generic parse failure it falls back to when the name does not parse:
+
+| source | rakudo | mutsu |
+| --- | --- | --- |
+| `sub infix:[/./] { 42 }` | `X::Syntax::Extension::TooComplex` — "Colon pair value '/./' too complex to use in name" | `Missing block` |
+| `sub meow:<bar> {}` | `X::Syntax::Extension::Category` — "Cannot add tokens of category 'meow'" | `Missing block` |
+
+Both are the same shape as the parse-diagnosis work already landed this month
+(`news/2026-08/parse-error-keeps-its-exception-class.md`,
+`news/2026-08/three-parse-failures-keep-their-malformed-class.md`): the parser
+needs to *recognise* the construct far enough to say what is wrong with it,
+rather than backtracking out of the sub-name rule and reporting the missing
+block that the failed name left behind.
+
+- **TooComplex** fires when the colon-pair value of an operator name is not a
+  literal string / identifier list — a regex, a computed expression, anything
+  the name cannot be spelled from. `sub infix:["@"]` and `sub infix:[sym]`
+  (a constant) are both legal and already work, so the check is on the *kind* of
+  the bracketed value, not on brackets.
+- **Category** fires when the category before the colon is not one of the known
+  operator categories (`infix`, `prefix`, `postfix`, `circumfix`,
+  `postcircumfix`, `term`, `trait_mod`, `statement_control`, …). Note
+  `sub meow:foo<bar> {42}` is *legal* — an extended sub name, not an operator —
+  and mutsu already handles it, so the check must only fire for the
+  `category:<sym>` / `category:[sym]` operator-declaration shape.
+
+Both are needed by `roast/S06-operator-overloading/sub.t` (its assertions 21 and
+28-29); the file has a third, deeper blocker recorded in
+`todo/deep/block-local-operator-leaks-into-later-parses.md`.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -774,6 +774,18 @@ native provider never takes such an argument as a Raku value, so any test file
 that hands a container to a `Test` routine is exercising the cell form for the
 first time.**
 
+`S06-operator-overloading/sub.t` was triaged and needs **three** independent
+fixes, so it stays open. It aborts after 24 of 29 assertions on
+`todo/deep/block-local-operator-leaks-into-later-parses.md` — a `sub infix:["@"]`
+declared inside a `lives-ok { … }` is still in the registry when a later `EVAL`
+string is *parsed*, so that string's `@ 5 @` reads as an infix with a missing
+operand. The two assertions it loses before that want specific parse-error
+classes (`X::Syntax::Extension::TooComplex`,
+`X::Syntax::Extension::Category`) where mutsu answers the generic "Missing
+block" —`todo/tickets/operator-extension-name-error-classes.md`. **A file that
+fails at three unrelated layers is worth triaging in full before starting on
+it**: fixing only the visible first failure buys nothing here.
+
 `roast/S12-methods/qualified.t` is worth a second look too: its Malformed
 assertion passes now and the file moved on to `Cannot dispatch to method me on
 Parent because it is not inherited or done by Bar` in its inheritance subtest.


### PR DESCRIPTION
`roast/S06-operator-overloading/sub.t` aborts after 24 of 29 assertions under the real `Test` module, and the cause is not the visible first failure. Triaged in full rather than started on, because it needs three independent fixes.

**`todo/deep/block-local-operator-leaks-into-later-parses.md`** — the abort. Three-line repro:

```raku
sub run(&c) { c() }
run { sub infix:["@"] ($a, $b) { 42 } }
say EVAL 'sub circumfix:["@", "@"] ($a) { $a }; @ 5 @';
```

rakudo prints `5`; mutsu dies with `Confused. Two terms in a row`. Two known facts compose: mutsu's routine registry is keyed by package alone, so a routine declared in a block that runs as a *callable* outlives it (the redeclaration half of this was fixed in `news/2026-08/sibling-scope-routine-shadow.md`); and `collect_operator_sub_names` builds the EVAL parser's operator pre-seed by walking that whole registry. So a stale operator entry does not merely stay callable — it changes the **grammar** the next `EVAL` is parsed with. Ordinary nested blocks do not leak; only the callable-block form does. Two candidate fixes are written up: intersect the pre-seed with lexically visible `&name`s (the asymmetry that makes that work is already documented), or give routine declarations real lexical scope.

**`todo/tickets/operator-extension-name-error-classes.md`** — the two assertions lost before the abort. `sub infix:[/./]` wants `X::Syntax::Extension::TooComplex` and `sub meow:<bar>` wants `X::Syntax::Extension::Category`; mutsu backtracks out of the sub-name rule and reports the `Missing block` the failed name left behind. Same shape as the parse-diagnosis work already landed this month. The ticket records which neighbouring spellings are legal and must keep working — `sub infix:["@"]`, `sub infix:[sym]` with a constant, and `sub meow:foo<bar>` (an extended sub name, not an operator) all work today.

Docs only; the four heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)