### PR TITLE
feat(compiler): compile declaration-time expressions into child chunks (ADR-0019 C5)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -110,7 +110,7 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 16/51 slices merged. Next slice: C5.**
+**Current progress: 17/51 slices merged. Next slice: C6.**
 
 The migration is complete only when every required box below is checked and the completion gates
 at the end pass. The order within a phase is intentional. A later phase may start when its stated
@@ -157,7 +157,7 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
 - [x] **C4 — Precompute AST-derived routine metadata in the compiler.** Move auto-signature use,
   empty-signature, return-shape validation, stub/proto identity, and redeclaration fingerprint data
   required by registration into `CompiledSubDeclPlan`/`CompiledFunction`.
-- [ ] **C5 — Move sub custom-trait and computed-name evaluation to child chunks.** Execute those
+- [x] **C5 — Move sub custom-trait and computed-name evaluation to child chunks.** Execute those
   expressions through re-entrant bytecode, including EVAL and NativeCall declaration cases.
 - [ ] **C6 — Remove `CompiledSubDeclPlan::legacy_body`.** Make ordinary, multi, `our`, hoisted,
   exported, operator, and top-level-method declarations register without an executable AST body.
@@ -173,7 +173,9 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
 - [ ] **D3 — Encode class methods and submethods as compiled candidates.** Install ordinary, multi,
   proto, private, rw, wrap, BUILD, and TWEAK metadata without walking `Stmt::MethodDecl`.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
-  expressions, aliases, and deferred class bodies through re-entrant bytecode chunks.
+  expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
+  names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies
+  remain.)
 - [ ] **D5 — Drive user HOW operations from plan ops.** Execute `new_type`, `add_method`, trait
   interception, and `compose` without entering `register_class_decl`'s AST walker.
 - [ ] **D6 — Remove `CompiledClassDeclPlan::legacy_body`.** Preserve augmentation, rollback,
@@ -181,7 +183,8 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
 - [ ] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
 - [ ] **D8 — Compile role declaration-time bodies and traits.** Run parameterized-role and composed
-  ancestor bodies as bytecode child chunks with correct once-per-composition behavior.
+  ancestor bodies as bytecode child chunks with correct once-per-composition behavior. (Custom-trait
+  arguments already landed with C5; the bodies remain.)
 - [ ] **D9 — Remove `CompiledRoleDeclPlan::legacy_body`.** Preserve role puns, runtime mixins,
   conflicts, BUILD/TWEAK, custom HOWs, and EVAL.
 - [ ] **D10 — Delete class/role AST registration walkers.** Keep only VM plan execution plus
@@ -298,14 +301,24 @@ reference. Registration now attaches the plan-selected compiled bodies to its te
 rediscovering them by name and signature. Registration metadata for implicit `@_`/`%_`, empty
 signatures, return-shape validation, stub identity, and redeclaration identity is now derived once
 while lowering `CompiledSubDeclPlan`; normalized named/default signatures can therefore retain
-their compiled bodies without a registration-time AST scan. The next slice compiles sub custom
-traits and computed names as declaration child chunks before removing `legacy_body`.
+their compiled bodies without a registration-time AST scan.
+
+A declaration's own expressions — a computed name (`sub ::($name)`) and each custom trait's
+argument (`is native(LIB)`, `is symbol('sym')`) — are no longer `Expr`s handed to the runtime and
+compiled on demand at every registration. The compiler lowers each one to a `CompiledDeclExpr`
+child chunk stored in the plan, and registration runs it through the VM's re-entrant bytecode
+entry (`run_decl_expr`). A constant argument is recorded as a `DeclTraitArg::Literal` and needs no
+chunk at all. The remaining `DeclTraitArg::Ast` variant is not a new fallback: it carries the
+declaration kinds whose registration still walks a source declaration — the prelude's
+forward-declaration pass and the class/role *method* walkers — and disappears with phase D. The
+next slice removes `CompiledSubDeclPlan::legacy_body`.
 
 `RegisterClass` and `RegisterRole` now likewise index typed class/role declaration-plan pools for
 both source-order declarations and hoisted forward-reference shells. The VM no longer discovers
-these declaration kinds by inspecting the generic statement pool. Their `legacy_body` adapters
-remain until structural registration and declaration-time expressions become plan operations and
-compiled child chunks.
+these declaration kinds by inspecting the generic statement pool, and their computed names and
+custom-trait arguments run as compiled child chunks alongside the sub ones. Their `legacy_body`
+adapters remain until structural registration and the remaining declaration-time expressions
+(parents, aliases, deferred bodies) become plan operations and compiled child chunks.
 
 The three declaration entry opcodes have been consolidated into `RegisterDecl`, whose compact
 operand selects a tagged `CompiledDeclPlanRef`. Sub/class/role plans retain their typed cold-data

--- a/news/2026-08/declaration-time-expressions-are-compiled-chunks.md
+++ b/news/2026-08/declaration-time-expressions-are-compiled-chunks.md
@@ -1,0 +1,39 @@
+# Declaration-time expressions are compiled child chunks
+
+ADR-0019 slice C5. A declaration carries expressions of its own, separate from the
+routine body: the computed name of `sub ::($name) {...}` / `class ::(NAME) {...}`, and
+the argument of every custom trait — `is native(LIB)`, `is symbol('sym')`,
+`is labelled(PREFIX ~ '-x')`. Until now the compiler stored those as `Expr`s inside the
+declaration plan and the runtime built bytecode for them *at every registration*, by
+wrapping the expression in a one-statement block and calling
+`Interpreter::compile_block_value`. A NativeCall binding declares `is native(LIB)` on
+every one of its entry points, so a module like `DBDish::mysql::Native` re-ran the
+compiler roughly forty times on load for expressions that never change.
+
+The compiler now lowers each of those expressions once, into a `CompiledDeclExpr` — a
+`CompiledCode` plus its own compiled-function table — stored in the declaration plan.
+Registration runs it through the VM's ordinary re-entrant bytecode entry
+(`Interpreter::run_decl_expr`), which is the `vm_eval_block_value` fast path with the
+on-demand compile removed: the same `run_nested` call and the same scope bookkeeping
+(block-scope depth, `let`/`temp` restore, pending `DESTROY`). A trait argument that is
+already a constant is recorded as a `DeclTraitArg::Literal` and needs no chunk at all,
+which is the common case for `is symbol('...')` and for internal markers such as
+`__mutsu_declare_how` (whose keyword the `EXPORTHOW::DECLARE` protocol reads straight
+off the literal instead of pattern-matching an `Expr::Literal`).
+
+The chunk is compiled the way the runtime helper it replaces compiled it — a standalone
+unit with no local slots, so every variable the expression names resolves through the
+environment the declaration registers in. What changes is that the package and
+distribution context now come from the declaration's own lexical position rather than
+from whichever routine frame happened to be live when registration ran.
+
+The change covers sub, class, and role declarations. `DeclTraitArg` retains an `Ast`
+variant for the two registration paths that still walk a source declaration — the
+prelude's forward-declaration pass and the class/role *method* walkers — so this is the
+existing fallback narrowed to those callers, not a new one; both disappear with ADR-0019
+phase D.
+
+Pinned by `t/decl-trait-arg-expression.t` (literal, computed, and call-valued trait
+arguments on a sub, a class, and a role) on top of the existing
+`t/indirect-declarator-names.t` and `roast/S02-names/indirect.t` coverage of computed
+declaration names.

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -1,0 +1,101 @@
+//! Lowering a source declaration into its typed declaration plan (ADR-0019).
+//!
+//! A declaration carries expressions of its own, separate from any routine body:
+//! the computed name of `sub ::($name) {...}` and the argument of each custom
+//! trait (`is native(LIB)`). They are compiled here, once, into child chunks the
+//! VM runs through its normal re-entrant bytecode entry at registration time.
+use super::*;
+
+impl Compiler {
+    /// Lower a declaration-time expression to its own bytecode chunk (ADR-0019 C5).
+    ///
+    /// This replaces compiling the expression at every registration through
+    /// `Interpreter::compile_block_value`, and it is deliberately compiled the
+    /// same way that helper compiled it: a standalone unit with no local slots,
+    /// so every variable it names resolves through the environment the
+    /// declaration registers in. The package and distribution come from the
+    /// declaration's own lexical position rather than from whatever routine
+    /// frame happens to be live when registration runs.
+    pub(crate) fn compile_decl_expr(&self, expr: &Expr) -> crate::opcode::CompiledDeclExpr {
+        let mut chunk_compiler = Compiler::new();
+        chunk_compiler.is_routine = self.is_routine;
+        chunk_compiler.lexically_in_routine = self.lexically_in_routine;
+        chunk_compiler.enclosing_package = Some(
+            self.enclosing_package
+                .clone()
+                .unwrap_or_else(|| self.current_package.clone()),
+        );
+        chunk_compiler.set_current_package(self.current_package.clone());
+        chunk_compiler.current_distribution = self.current_distribution.clone();
+        chunk_compiler.last_source_line = self.last_source_line;
+        let body = [Stmt::Expr(expr.clone())];
+        let (code, fns) = chunk_compiler.compile(&body);
+        crate::opcode::CompiledDeclExpr {
+            code: std::sync::Arc::new(code),
+            fns: std::sync::Arc::new(fns),
+        }
+    }
+
+    /// Lower one custom trait's argument. A constant needs no chunk: it is
+    /// already the value registration will use.
+    fn compile_decl_trait_arg(&self, expr: &Expr) -> crate::opcode::DeclTraitArg {
+        match expr {
+            Expr::Literal(value) => crate::opcode::DeclTraitArg::Literal(value.clone()),
+            _ => crate::opcode::DeclTraitArg::Compiled(self.compile_decl_expr(expr)),
+        }
+    }
+
+    /// Lower a declaration's custom-trait arguments, index-aligned with its
+    /// `custom_traits` list.
+    fn compile_decl_trait_args(
+        &self,
+        custom_traits: &[(String, Option<Expr>)],
+    ) -> Vec<Option<crate::opcode::DeclTraitArg>> {
+        custom_traits
+            .iter()
+            .map(|(_, arg)| arg.as_ref().map(|e| self.compile_decl_trait_arg(e)))
+            .collect()
+    }
+
+    /// Lower a `SubDecl` into the declaration-plan pool, compiling its
+    /// declaration-time expressions (computed name, custom-trait arguments) into
+    /// child chunks first.
+    pub(crate) fn add_sub_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+        let Stmt::SubDecl {
+            name_expr,
+            custom_traits,
+            ..
+        } = stmt
+        else {
+            panic!("add_sub_decl_plan expects SubDecl");
+        };
+        let name_chunk = name_expr.as_ref().map(|e| self.compile_decl_expr(e));
+        let trait_args = self.compile_decl_trait_args(custom_traits);
+        self.code.add_sub_decl_plan(stmt, name_chunk, trait_args)
+    }
+
+    /// [`Self::add_sub_decl_plan`] for a class declaration.
+    pub(crate) fn add_class_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+        let Stmt::ClassDecl {
+            name_expr,
+            custom_traits,
+            ..
+        } = stmt
+        else {
+            panic!("add_class_decl_plan expects ClassDecl");
+        };
+        let name_chunk = name_expr.as_ref().map(|e| self.compile_decl_expr(e));
+        let trait_args = self.compile_decl_trait_args(custom_traits);
+        self.code.add_class_decl_plan(stmt, name_chunk, trait_args)
+    }
+
+    /// [`Self::add_sub_decl_plan`] for a role declaration. A role's name is
+    /// always compile-time known, so only its trait arguments are lowered.
+    pub(crate) fn add_role_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+        let Stmt::RoleDecl { custom_traits, .. } = stmt else {
+            panic!("add_role_decl_plan expects RoleDecl");
+        };
+        let trait_args = self.compile_decl_trait_args(custom_traits);
+        self.code.add_role_decl_plan(stmt, trait_args)
+    }
+}

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -340,7 +340,7 @@ impl Compiler {
                     t.starts_with("__") || t == "default" || t.starts_with("DEPRECATED")
                 });
             }
-            let idx = self.code.add_sub_decl_plan(&hoisted);
+            let idx = self.add_sub_decl_plan(&hoisted);
             self.code.emit(OpCode::RegisterDecl(idx));
         }
     }
@@ -449,7 +449,7 @@ impl Compiler {
                         t.starts_with("__") || t == "default" || t.starts_with("DEPRECATED")
                     });
                 }
-                let idx = self.code.add_sub_decl_plan(&hoisted);
+                let idx = self.add_sub_decl_plan(&hoisted);
                 self.code.emit(OpCode::RegisterDecl(idx));
             }
         }
@@ -647,7 +647,7 @@ impl Compiler {
                         });
                         custom_traits.push(("__hoisted".to_string(), None));
                     }
-                    let idx = self.code.add_class_decl_plan(&shell);
+                    let idx = self.add_class_decl_plan(&shell);
                     self.code.emit(OpCode::RegisterDecl(idx));
                 }
                 Stmt::RoleDecl { .. } => {
@@ -658,7 +658,7 @@ impl Compiler {
                         });
                         custom_traits.push(("__hoisted".to_string(), None));
                     }
-                    let idx = self.code.add_role_decl_plan(&shell);
+                    let idx = self.add_role_decl_plan(&shell);
                     self.code.emit(OpCode::RegisterDecl(idx));
                 }
                 _ => {}

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -119,6 +119,7 @@ mod declaration_plan_tests {
     }
 }
 mod const_fold;
+mod decl_plan;
 mod expr;
 mod expr_binary;
 mod expr_block;

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3063,9 +3063,9 @@ impl Compiler {
                         if let Stmt::SubDecl { custom_traits, .. } = &mut marked {
                             custom_traits.push(("__lexical_hoist".to_string(), None));
                         }
-                        self.code.add_sub_decl_plan(&marked)
+                        self.add_sub_decl_plan(&marked)
                     } else {
-                        self.code.add_sub_decl_plan(stmt)
+                        self.add_sub_decl_plan(stmt)
                     };
                 self.code.emit(OpCode::RegisterDecl(idx));
                 if name_expr.is_some() {
@@ -3175,7 +3175,7 @@ impl Compiler {
                     supersede: false,
                     custom_traits: vec![("__mutsu_method_decl".to_string(), None)],
                 };
-                let idx = self.code.add_sub_decl_plan(&lowered);
+                let idx = self.add_sub_decl_plan(&lowered);
                 self.code.emit(OpCode::RegisterDecl(idx));
                 if name_expr.is_none() {
                     let mut method_params: Vec<String> = vec![
@@ -3489,7 +3489,7 @@ impl Compiler {
                 // registers it under the correct nested package
                 // (e.g. `class D` inside `unit module A::B` → `A::B::D`).
                 let stmt = self.qualify_decl_name(stmt);
-                let idx = self.code.add_class_decl_plan(&stmt);
+                let idx = self.add_class_decl_plan(&stmt);
                 self.code.emit(OpCode::RegisterDecl(idx));
             }
             Stmt::AugmentClass { .. } => {
@@ -3501,7 +3501,7 @@ impl Compiler {
                 // Same as RegisterClass above: a role method has no creation op.
                 self.record_type_body_captures(body);
                 let stmt = self.qualify_decl_name(stmt);
-                let idx = self.code.add_role_decl_plan(&stmt);
+                let idx = self.add_role_decl_plan(&stmt);
                 self.code.emit(OpCode::RegisterDecl(idx));
             }
             Stmt::SubsetDecl { .. } => {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1854,10 +1854,93 @@ pub(crate) struct EnvConsumerSlots {
     pub(crate) whenever: Vec<bool>,
 }
 
+/// A declaration-time expression lowered to its own bytecode chunk (ADR-0019 C5).
+///
+/// A computed routine name (`sub ::($name) {...}`) and a custom trait's argument
+/// (`is native(LIB)`, `is symbol('foo')`, `is nonesuch($x)`) are ordinary
+/// expressions that have to run when the declaration registers. They used to be
+/// handed to the runtime as an `Expr` and compiled on demand at every
+/// registration; the compiler now lowers them once, and registration runs the
+/// chunk through the VM's normal re-entrant bytecode entry.
+#[derive(Debug, Clone)]
+pub(crate) struct CompiledDeclExpr {
+    pub(crate) code: Arc<CompiledCode>,
+    pub(crate) fns: Arc<CompiledFns>,
+}
+
+/// The argument of a declaration trait.
+///
+/// `Literal` and `Compiled` are the ADR-0019 plan path: a constant argument
+/// (`is symbol('foo')`) is already a value and needs no chunk at all, everything
+/// else runs as bytecode. `Ast` remains for the declaration kinds whose
+/// registration still walks a source declaration (the prelude's
+/// forward-declaration pass and the class/role method walkers, migrated in
+/// phase D); it is the existing fallback narrowed to those callers, not a new one.
+#[derive(Debug, Clone)]
+pub(crate) enum DeclTraitArg {
+    Literal(Value),
+    Compiled(CompiledDeclExpr),
+    Ast(Box<Expr>),
+}
+
+impl DeclTraitArg {
+    /// The argument's value when it is a compile-time constant. Declaration
+    /// machinery that only needs a literal (the `EXPORTHOW::DECLARE` keyword)
+    /// reads it without running anything.
+    pub(crate) fn literal(&self) -> Option<&Value> {
+        match self {
+            DeclTraitArg::Literal(value) => Some(value),
+            DeclTraitArg::Ast(expr) => match &**expr {
+                Expr::Literal(value) => Some(value),
+                _ => None,
+            },
+            DeclTraitArg::Compiled(_) => None,
+        }
+    }
+}
+
+/// A declaration's custom traits as registration consumes them: the trait name
+/// plus its optional argument.
+pub(crate) type DeclTraits = [(String, Option<DeclTraitArg>)];
+
+/// Adapt AST-shaped custom traits for a registration path that has not been
+/// migrated to declaration plans yet.
+pub(crate) fn decl_traits_from_ast(
+    traits: &[(String, Option<Expr>)],
+) -> Vec<(String, Option<DeclTraitArg>)> {
+    traits
+        .iter()
+        .map(|(name, arg)| {
+            (
+                name.clone(),
+                arg.clone().map(|e| DeclTraitArg::Ast(Box::new(e))),
+            )
+        })
+        .collect()
+}
+
+/// Pair a declaration's trait names with the arguments the compiler lowered for
+/// them. `lowered` is index-aligned with `custom_traits`; a lowering site may
+/// append an argument-less marker trait (`__lexical_hoist`) after building the
+/// list, so a shorter list pads with `None` rather than misaligning.
+fn zip_decl_trait_args(
+    custom_traits: &[(String, Option<Expr>)],
+    lowered: Vec<Option<DeclTraitArg>>,
+) -> Vec<(String, Option<DeclTraitArg>)> {
+    debug_assert!(lowered.len() <= custom_traits.len());
+    custom_traits
+        .iter()
+        .map(|(name, _)| name.clone())
+        .zip(lowered.into_iter().chain(std::iter::repeat_with(|| None)))
+        .collect()
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledSubDeclPlan {
     pub(crate) name: Symbol,
-    pub(crate) name_expr: Option<Expr>,
+    /// The compiled chunk producing a runtime-resolved routine name, for
+    /// `sub ::($name) {...}`. `None` for the ordinary literal-name declaration.
+    pub(crate) name_chunk: Option<CompiledDeclExpr>,
     pub(crate) params: Vec<String>,
     pub(crate) param_defs: Vec<ParamDef>,
     pub(crate) return_type: Option<String>,
@@ -1879,7 +1962,7 @@ pub(crate) struct CompiledSubDeclPlan {
     pub(crate) export_tags: Vec<String>,
     pub(crate) is_test_assertion: bool,
     pub(crate) supersede: bool,
-    pub(crate) custom_traits: Vec<(String, Option<Expr>)>,
+    pub(crate) custom_traits: Vec<(String, Option<DeclTraitArg>)>,
     pub(crate) fingerprint: Option<u64>,
     /// Registration metadata derived once while lowering the declaration.
     /// Keeping it beside the plan prevents the registry adapter from walking
@@ -1958,7 +2041,9 @@ fn body_contains_non_nil_return(stmts: &[Stmt]) -> bool {
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledClassDeclPlan {
     pub(crate) name: Symbol,
-    pub(crate) name_expr: Option<Expr>,
+    /// The compiled chunk producing a runtime-resolved type name
+    /// (`class ::($name) {...}`). `None` for the ordinary literal-name form.
+    pub(crate) name_chunk: Option<CompiledDeclExpr>,
     pub(crate) parents: Vec<String>,
     pub(crate) class_is_rw: bool,
     pub(crate) is_hidden: bool,
@@ -1970,7 +2055,7 @@ pub(crate) struct CompiledClassDeclPlan {
     /// move to compiled child chunks in the next ADR-0019 stage.
     pub(crate) legacy_body: Vec<Stmt>,
     pub(crate) language_version: String,
-    pub(crate) custom_traits: Vec<(String, Option<Expr>)>,
+    pub(crate) custom_traits: Vec<(String, Option<DeclTraitArg>)>,
     pub(crate) decl_id: u64,
 }
 
@@ -1985,7 +2070,7 @@ pub(crate) struct CompiledRoleDeclPlan {
     pub(crate) legacy_body: Vec<Stmt>,
     pub(crate) is_rw: bool,
     pub(crate) language_version: String,
-    pub(crate) custom_traits: Vec<(String, Option<Expr>)>,
+    pub(crate) custom_traits: Vec<(String, Option<DeclTraitArg>)>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4849,7 +4934,16 @@ impl CompiledCode {
         idx
     }
 
-    pub(crate) fn add_sub_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+    /// Record a sub declaration plan. `name_chunk` and `trait_arg_chunks` are the
+    /// compiled declaration-time expressions the compiler lowered for this site
+    /// (ADR-0019 C5); `trait_arg_chunks` is index-aligned with the declaration's
+    /// `custom_traits`.
+    pub(crate) fn add_sub_decl_plan(
+        &mut self,
+        stmt: &Stmt,
+        name_chunk: Option<CompiledDeclExpr>,
+        trait_args: Vec<Option<DeclTraitArg>>,
+    ) -> u32 {
         let Stmt::SubDecl {
             name,
             name_expr,
@@ -4914,10 +5008,12 @@ impl CompiledCode {
                         .is_some_and(|(_, ret)| ret.is_some())
             }),
         };
+        debug_assert_eq!(name_chunk.is_some(), name_expr.is_some());
+        let plan_traits = zip_decl_trait_args(custom_traits, trait_args);
         let plan_idx = self.sub_decl_plans.len() as u32;
         self.sub_decl_plans.push(CompiledSubDeclPlan {
             name: *name,
-            name_expr: name_expr.clone(),
+            name_chunk,
             params: params.clone(),
             param_defs: param_defs.clone(),
             return_type: return_type.clone(),
@@ -4932,7 +5028,7 @@ impl CompiledCode {
             export_tags: export_tags.clone(),
             is_test_assertion: *is_test_assertion,
             supersede: *supersede,
-            custom_traits: custom_traits.clone(),
+            custom_traits: plan_traits,
             fingerprint,
             routine_metadata,
         });
@@ -4949,7 +5045,12 @@ impl CompiledCode {
         self.sub_decl_plans[*plan_idx as usize].compiled_routine_keys = keys;
     }
 
-    pub(crate) fn add_class_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+    pub(crate) fn add_class_decl_plan(
+        &mut self,
+        stmt: &Stmt,
+        name_chunk: Option<CompiledDeclExpr>,
+        trait_args: Vec<Option<DeclTraitArg>>,
+    ) -> u32 {
         let Stmt::ClassDecl {
             name,
             name_expr,
@@ -4969,10 +5070,12 @@ impl CompiledCode {
         else {
             panic!("add_class_decl_plan expects ClassDecl");
         };
+        debug_assert_eq!(name_chunk.is_some(), name_expr.is_some());
+        let plan_traits = zip_decl_trait_args(custom_traits, trait_args);
         let plan_idx = self.class_decl_plans.len() as u32;
         self.class_decl_plans.push(CompiledClassDeclPlan {
             name: *name,
-            name_expr: name_expr.clone(),
+            name_chunk,
             parents: parents.clone(),
             class_is_rw: *class_is_rw,
             is_hidden: *is_hidden,
@@ -4982,7 +5085,7 @@ impl CompiledCode {
             repr: repr.clone(),
             legacy_body: body.clone(),
             language_version: language_version.clone(),
-            custom_traits: custom_traits.clone(),
+            custom_traits: plan_traits,
             decl_id: *decl_id,
         });
         let idx = self.decl_plans.len() as u32;
@@ -4990,7 +5093,11 @@ impl CompiledCode {
         idx
     }
 
-    pub(crate) fn add_role_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+    pub(crate) fn add_role_decl_plan(
+        &mut self,
+        stmt: &Stmt,
+        trait_args: Vec<Option<DeclTraitArg>>,
+    ) -> u32 {
         let Stmt::RoleDecl {
             name,
             type_params,
@@ -5015,7 +5122,7 @@ impl CompiledCode {
             legacy_body: body.clone(),
             is_rw: *is_rw,
             language_version: language_version.clone(),
-            custom_traits: custom_traits.clone(),
+            custom_traits: zip_decl_trait_args(custom_traits, trait_args),
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Role(plan_idx));

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -2110,12 +2110,15 @@ impl Interpreter {
                     // how a whole C API is usually bound (`DBDish::mysql::Native`
                     // declares every one of its ~40 entry points this way).
                     if method_custom_traits.iter().any(|(t, _)| t == "native") {
+                        // Class/role method declarations still register from the
+                        // source declaration (ADR-0019 phase D), so their trait
+                        // arguments arrive as expressions.
                         self.register_native_call_method(
                             name,
                             &resolved_method_name,
                             param_defs,
                             return_type.as_ref(),
-                            method_custom_traits,
+                            &crate::opcode::decl_traits_from_ast(method_custom_traits),
                         )?;
                     }
                     // Apply custom trait_mod:<is> for each non-builtin trait on methods

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -483,7 +483,7 @@ impl Interpreter {
         is_raw: bool,
         is_test_assertion: bool,
         supersede: bool,
-        custom_traits: &[(String, Option<crate::ast::Expr>)],
+        custom_traits: &crate::opcode::DeclTraits,
     ) -> Result<SubRegisterOutcome, RuntimeError> {
         self.register_sub_decl_fp(
             name,
@@ -555,7 +555,7 @@ impl Interpreter {
         is_raw: bool,
         is_test_assertion: bool,
         supersede: bool,
-        custom_traits: &[(String, Option<crate::ast::Expr>)],
+        custom_traits: &crate::opcode::DeclTraits,
         site_fingerprint: Option<u64>,
     ) -> Result<SubRegisterOutcome, RuntimeError> {
         self.register_sub_decl_with_metadata(
@@ -590,7 +590,7 @@ impl Interpreter {
         is_raw: bool,
         is_test_assertion: bool,
         supersede: bool,
-        custom_traits: &[(String, Option<crate::ast::Expr>)],
+        custom_traits: &crate::opcode::DeclTraits,
         site_fingerprint: Option<u64>,
         metadata: &crate::opcode::CompiledRoutineMetadata,
     ) -> Result<SubRegisterOutcome, RuntimeError> {
@@ -626,7 +626,7 @@ impl Interpreter {
         is_raw: bool,
         is_test_assertion: bool,
         supersede: bool,
-        custom_traits: &[(String, Option<crate::ast::Expr>)],
+        custom_traits: &crate::opcode::DeclTraits,
         site_fingerprint: Option<u64>,
         metadata: Option<&crate::opcode::CompiledRoutineMetadata>,
     ) -> Result<SubRegisterOutcome, RuntimeError> {
@@ -1217,10 +1217,9 @@ impl Interpreter {
                     self.env.clone(),
                 );
                 // Evaluate the trait argument expression if present
-                let trait_arg_val = if let Some(arg_expr) = trait_arg {
-                    Some(self.eval_block_value(&[crate::ast::Stmt::Expr(arg_expr.clone())])?)
-                } else {
-                    None
+                let trait_arg_val = match trait_arg {
+                    Some(arg) => Some(self.eval_decl_trait_arg(arg)?),
+                    None => None,
                 };
                 // Try positional dispatch first: if the trait name is a known type/role,
                 // pass the type object as a positional argument.

--- a/src/vm/vm_core_helpers.rs
+++ b/src/vm/vm_core_helpers.rs
@@ -133,6 +133,40 @@ impl Interpreter {
         self.loan_env_for(|i| i.eval_block_value(body))
     }
 
+    /// Run a declaration-time expression chunk (ADR-0019 C5).
+    ///
+    /// The chunk was lowered by the compiler, so this is the `vm_eval_block_value`
+    /// fast path with the on-demand compile removed: the same re-entrant bytecode
+    /// entry and the same scope bookkeeping, minus rebuilding the bytecode at
+    /// every registration.
+    pub(crate) fn run_decl_expr(
+        &mut self,
+        chunk: &crate::opcode::CompiledDeclExpr,
+    ) -> Result<Value, RuntimeError> {
+        let let_mark = self.let_saves_len();
+        self.push_block_scope_depth();
+        let result = self.run_nested(&chunk.code, &chunk.fns);
+        self.pop_block_scope_depth();
+        self.restore_let_saves(let_mark);
+        self.run_pending_instance_destroys()?;
+        result.map(|v| v.unwrap_or(Value::NIL))
+    }
+
+    /// Evaluate a declaration trait's argument, whichever form it carries.
+    pub(crate) fn eval_decl_trait_arg(
+        &mut self,
+        arg: &crate::opcode::DeclTraitArg,
+    ) -> Result<Value, RuntimeError> {
+        match arg {
+            crate::opcode::DeclTraitArg::Literal(value) => Ok(value.clone()),
+            crate::opcode::DeclTraitArg::Compiled(chunk) => self.run_decl_expr(chunk),
+            crate::opcode::DeclTraitArg::Ast(expr) => {
+                let body = [Stmt::Expr((**expr).clone())];
+                self.vm_eval_block_value(&body)
+            }
+        }
+    }
+
     #[inline]
     pub(crate) fn vm_use_module_with_tags(
         &mut self,

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -192,7 +192,7 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         if let Some(crate::opcode::CompiledSubDeclPlan {
             name,
-            name_expr,
+            name_chunk,
             params,
             param_defs,
             return_type,
@@ -212,9 +212,8 @@ impl Interpreter {
             routine_metadata,
         }) = code.sub_decl_plans.get(idx as usize)
         {
-            let resolved_name = if let Some(expr) = name_expr {
-                self.vm_eval_block_value(&[Stmt::Expr(expr.clone())])?
-                    .to_string_value()
+            let resolved_name = if let Some(chunk) = name_chunk {
+                self.run_decl_expr(chunk)?.to_string_value()
             } else {
                 name.resolve()
             };
@@ -432,7 +431,7 @@ impl Interpreter {
                     .iter()
                     .any(|(t, _)| t == crate::runtime::PRELUDE_SUB_TRAIT)
                 && !*multi
-                && name_expr.is_none()
+                && name_chunk.is_none()
                 && !resolved_name.contains("::")
                 && !resolved_name.contains(':')
             {
@@ -475,7 +474,7 @@ impl Interpreter {
         name: &str,
         param_defs: &[crate::ast::ParamDef],
         return_type: Option<&String>,
-        custom_traits: &[(String, Option<crate::ast::Expr>)],
+        custom_traits: &crate::opcode::DeclTraits,
     ) -> Result<(), RuntimeError> {
         self.register_native_call_routine(name, None, param_defs, return_type, custom_traits)
     }
@@ -498,7 +497,7 @@ impl Interpreter {
         name: &str,
         param_defs: &[crate::ast::ParamDef],
         return_type: Option<&String>,
-        custom_traits: &[(String, Option<crate::ast::Expr>)],
+        custom_traits: &crate::opcode::DeclTraits,
     ) -> Result<(), RuntimeError> {
         self.register_native_call_routine(
             name,
@@ -520,7 +519,7 @@ impl Interpreter {
         invocant_class: Option<&str>,
         param_defs: &[crate::ast::ParamDef],
         return_type: Option<&String>,
-        custom_traits: &[(String, Option<crate::ast::Expr>)],
+        custom_traits: &crate::opcode::DeclTraits,
     ) -> Result<(), RuntimeError> {
         use crate::runtime::nativecall::{CType, NativeCallSpec, ParamSpec};
 
@@ -536,8 +535,8 @@ impl Interpreter {
             for (t, arg) in custom_traits {
                 if t == trait_name {
                     return Ok(match arg {
-                        Some(expr) => {
-                            let val = self.vm_eval_block_value(&[Stmt::Expr(expr.clone())])?;
+                        Some(arg) => {
+                            let val = self.eval_decl_trait_arg(arg)?;
                             let resolved = if matches!(val.view(), ValueView::Sub(..)) {
                                 self.vm_call_sub_value(val, Vec::new(), false)?
                             } else {

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -1,6 +1,5 @@
 //! Type-declaration registration ops: enum / class / augment / role / subset.
 use super::*;
-use crate::ast::Expr;
 use crate::symbol::Symbol;
 
 impl Interpreter {
@@ -117,7 +116,7 @@ impl Interpreter {
         self.dispatch_multi_candidate.clear();
         if let Some(crate::opcode::CompiledClassDeclPlan {
             name,
-            name_expr,
+            name_chunk,
             parents,
             class_is_rw,
             is_hidden,
@@ -131,9 +130,8 @@ impl Interpreter {
             decl_id,
         }) = code.class_decl_plans.get(idx as usize)
         {
-            let resolved_name = if let Some(expr) = name_expr {
-                self.vm_eval_block_value(&[Stmt::Expr(expr.clone())])?
-                    .to_string_value()
+            let resolved_name = if let Some(chunk) = name_chunk {
+                self.run_decl_expr(chunk)?.to_string_value()
             } else {
                 name.resolve()
             };
@@ -377,9 +375,11 @@ impl Interpreter {
             // (`new_type`, `add_method` per declared method), and queue the
             // user `compose` to run after the custom `is` traits (same
             // protocol as the EXPORTHOW `class` metaclass mapping below).
-            if let Some((_, Some(Expr::Literal(kw)))) = custom_traits
+            if let Some(kw) = custom_traits
                 .iter()
                 .find(|(t, _)| t == "__mutsu_declare_how")
+                .and_then(|(_, arg)| arg.as_ref())
+                .and_then(crate::opcode::DeclTraitArg::literal)
             {
                 let keyword = kw.to_string_value();
                 let how_type =
@@ -410,10 +410,9 @@ impl Interpreter {
                     if trait_name.starts_with("__") {
                         continue;
                     }
-                    let trait_value = if let Some(arg_expr) = trait_arg {
-                        self.vm_eval_block_value(&[Stmt::Expr(arg_expr.clone())])?
-                    } else {
-                        Value::TRUE
+                    let trait_value = match trait_arg {
+                        Some(arg) => self.eval_decl_trait_arg(arg)?,
+                        None => Value::TRUE,
                     };
                     let named_arg = Value::pair(trait_name.clone(), trait_value);
                     self.vm_call_function("trait_mod:<is>", vec![type_obj.clone(), named_arg])?;
@@ -663,10 +662,9 @@ impl Interpreter {
                     if trait_name.starts_with("__") {
                         continue;
                     }
-                    let trait_value = if let Some(arg_expr) = trait_arg {
-                        self.vm_eval_block_value(&[Stmt::Expr(arg_expr.clone())])?
-                    } else {
-                        Value::TRUE
+                    let trait_value = match trait_arg {
+                        Some(arg) => self.eval_decl_trait_arg(arg)?,
+                        None => Value::TRUE,
                     };
                     let named_arg = Value::pair(trait_name.clone(), trait_value);
                     self.vm_call_function("trait_mod:<is>", vec![type_obj.clone(), named_arg])?;

--- a/t/decl-trait-arg-expression.t
+++ b/t/decl-trait-arg-expression.t
@@ -1,0 +1,31 @@
+use Test;
+
+# ADR-0019 C5: a declaration's custom-trait argument is lowered by the compiler
+# into a declaration-time chunk (or kept as a constant when it is one) and run
+# through the VM's re-entrant bytecode entry at registration. Pin that every
+# argument shape still reaches `trait_mod:<is>` with the value it evaluates to.
+
+plan 8;
+
+my @log;
+multi sub trait_mod:<is>(Routine $r, :$labelled!) { @log.push("sub:{$r.name}:{$labelled}") }
+multi sub trait_mod:<is>(Mu:U $t, :$labelled!)    { @log.push("type:{$t.^name}:{$labelled}") }
+
+constant PREFIX = 'p';
+
+sub literal-arg() is labelled('lit') { 1 }
+sub computed-arg() is labelled(PREFIX ~ '-computed') { 2 }
+sub call-arg() is labelled(join('-', PREFIX, 'called')) { 3 }
+
+class TaggedClass is labelled(PREFIX ~ '-class') { }
+role TaggedRole is labelled(PREFIX ~ '-role') { }
+
+is literal-arg(), 1, 'sub with a literal trait argument stays callable';
+is computed-arg(), 2, 'sub with a computed trait argument stays callable';
+is call-arg(), 3, 'sub with a call-valued trait argument stays callable';
+
+ok @log.grep('sub:literal-arg:lit'), 'literal trait argument reaches trait_mod';
+ok @log.grep('sub:computed-arg:p-computed'), 'computed trait argument is evaluated';
+ok @log.grep('sub:call-arg:p-called'), 'a call in a trait argument is evaluated';
+ok @log.grep('type:TaggedClass:p-class'), 'a class trait argument is evaluated';
+ok @log.grep('type:TaggedRole:p-role'), 'a role trait argument is evaluated';


### PR DESCRIPTION
ADR-0019 slice **C5** — *Move sub custom-trait and computed-name evaluation to child chunks*, extended to class and role declarations while the machinery was being built.

## Problem

A declaration carries expressions of its own, separate from any routine body:

- the computed name of `sub ::($name) {...}` / `class ::(NAME) {...}`
- the argument of every custom trait — `is native(LIB)`, `is symbol('sym')`, `is labelled(PREFIX ~ '-x')`

Those were stored as `Expr`s inside the declaration plan, and the runtime rebuilt bytecode for them **at every registration** by wrapping the expression in a one-statement block and calling `Interpreter::compile_block_value`. A NativeCall binding declares `is native(LIB)` on every one of its entry points, so a module like `DBDish::mysql::Native` re-entered the compiler roughly forty times on load for expressions that never change.

## Change

The compiler lowers each declaration-time expression once into a `CompiledDeclExpr` (a `CompiledCode` plus its own compiled-function table) stored in the declaration plan. Registration runs it through the VM's ordinary re-entrant bytecode entry, `Interpreter::run_decl_expr` — which is the `vm_eval_block_value` fast path with the on-demand compile removed: same `run_nested` call, same scope bookkeeping (block-scope depth, `let`/`temp` restore, pending `DESTROY`).

A trait argument that is already a constant becomes a `DeclTraitArg::Literal` and needs no chunk at all. That also lets the `EXPORTHOW::DECLARE` protocol read its keyword straight off the value instead of pattern-matching an `Expr::Literal` in the plan.

The chunk is compiled the way the runtime helper it replaces compiled it — a standalone unit with no local slots, so every variable the expression names resolves through the environment the declaration registers in. What changes is that the package and distribution context now come from the declaration's own lexical position rather than from whichever routine frame happened to be live when registration ran.

`DeclTraitArg::Ast` remains for the two registration paths that still walk a source declaration (the prelude's forward-declaration pass and the class/role *method* walkers). It is the existing fallback narrowed to those callers, not a new one; both disappear with ADR-0019 phase D.

## Scope beyond C5

Class and role computed names and trait arguments went along for the ride, since they are the same two evaluation sites in `vm_typedecl_ops`. That is the expression part of D4 and D8; those boxes stay unchecked because their structural halves (parents, aliases, deferred bodies; role bodies) remain.

## Verification

Because this changes how declaration names resolve, all three suites were run locally:

- `make test` — PASS (2875 files, 27291 tests)
- `make roast` — PASS
- `scripts/battery-testsuite.sh` — `GATE PASSED`, 153/158

New pin: `t/decl-trait-arg-expression.t` (literal, computed, and call-valued trait arguments on a sub, a class, and a role — output matches `raku`), on top of the existing `t/indirect-declarator-names.t` and `roast/S02-names/indirect.t` coverage of computed declaration names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)