### PR TITLE
docs(todo): price the backtrace-frame fix before proposing a cheap one

### DIFF
--- a/todo/tickets/repeat-call-loses-backtrace-frame.md
+++ b/todo/tickets/repeat-call-loses-backtrace-frame.md
@@ -36,3 +36,47 @@ which means paying for the push/pop on the path that exists precisely to avoid
 per-call overhead — so it wants a cheap form (push a frame only when the callee
 can fail? record the callee name in a side slot the backtrace builder reads?)
 rather than a straight copy of the slow path.
+
+## Why "push it only on the error path" does not work (measured 2026-08-04)
+
+The obvious cheap fix — notice `Err(e)` coming back from the body loop in
+`call_compiled_function_fast` and add the frame there — cannot work. The
+backtrace is built at the **raise** site, deep inside the body, from the live
+routine stack; by the time the `Err` reaches this function the string is already
+formed. The repro shows both halves of that: call 2 loses `in sub f` *and*
+reports `in block <unit>` at line 1 (the `sub` declaration) instead of line 3
+(the call site), because the whole trace came from a stack that never had the
+frame.
+
+So the frame has to be pushed *before* the body runs, and the cost is real:
+
+```rust
+pub(crate) struct RoutineFrame {
+    pub package: String,
+    pub lexical_package: Option<String>,
+    pub name: String,
+    pub line: Option<u32>,
+    pub file: Option<String>,
+    ...
+}
+```
+
+Three `String`s and two `Option<String>` — several allocations per call, on the
+path whose entire purpose is to avoid exactly that. This is why the fast path
+skips it, and why a straight copy of the slow path is the wrong answer.
+
+### The shape worth pricing first
+
+Make the frame cheap to push rather than pushing it conditionally: `package` /
+`name` / `file` are all interned-able, so `Symbol` (Copy) would make the push a
+plain `Vec` push with no allocation, and the fast path could then just do it
+unconditionally like every other path. That also lines up with the symbol-intern
+direction already open in the method-call perf work.
+
+Size: **13 `RoutineFrame { … }` construction sites**, but ~81 `routine_stack`
+references overall, so the reader side (backtrace rendering, `callframe`
+introspection, `anon_state_key`) is where the work is.
+
+**Measure it on the bench CI, not locally**: this is a per-call cost on the
+hottest call path, and local wall-clock on this machine is unreliable whenever a
+sibling checkout is building (load average 15–20 on 12 cores is normal here).


### PR DESCRIPTION
`todo/tickets/repeat-call-loses-backtrace-frame.md` suggested pushing the routine frame only when the callee can fail. Measured: **that cannot work.**

The backtrace is built at the **raise** site, deep inside the body, from the live routine stack — so by the time the `Err` reaches `call_compiled_function_fast` the string is already formed. The repro shows both halves of that: call 2 loses `in sub f` *and* reports the `<unit>` frame at line 1 (the `sub` declaration) instead of line 3 (the call site), because the whole trace came from a stack that never had the frame.

So the frame has to be pushed *before* the body runs, and the cost is real: `RoutineFrame` carries three `String`s plus two `Option<String>` — several allocations per call, on the path whose entire purpose is avoiding exactly that.

The ticket now records the shape worth pricing instead — intern `package`/`name`/`file` to `Symbol` (Copy) so the push allocates nothing and the fast path can do it unconditionally like every other path — along with its size (13 `RoutineFrame { … }` construction sites but ~81 `routine_stack` references, so the reader side is where the work is) and the instruction to measure it on the bench CI rather than locally.

Docs-only, so the four heavy CI jobs skip by design.