### PR TITLE
perf(vm): memoize the OTF gates' routine-body predicates (ADR-0019 C6b)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -110,7 +110,8 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 17/51 slices merged. Next slice: C6b (C6a landed; C6 is subdivided below).**
+**Current progress: 17/51 slices merged. Next slice: C6c (C6a and C6b landed; C6 is subdivided
+below).**
 
 The migration is complete only when every required box below is checked and the completion gates
 at the end pass. The order within a phase is intentional. A later phase may start when its stated
@@ -165,13 +166,17 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
   separable groups, each its own PR; the box is checked only when the plan field is gone:
   - [x] **C6a — identity hashes.** Replace per-read `function_body_fingerprint(&def.…)` with a
     memoized `FunctionDef::body_fingerprint()`, retiring the `func_def_fp_cache` side cache.
-  - [ ] **C6b — body analysis.** Precompute `is_stub` / `needs_interpreter` / `declares_state` /
-    `collect_routine_body_local_names` / rw-target extraction in the compiler, as C4 did for
-    signature metadata.
+  - [x] **C6b — OTF-gate body predicates.** Memoize `needs_interpreter` /
+    `module_otf_needs_interpreter` / `declares_state` as `RoutineBodyFacts` on the def, behind the
+    single reader `Interpreter::routine_body_facts`, and read the existing `is_stub` field on the
+    redeclaration path. (`collect_routine_body_local_names` and rw-target extraction return AST
+    data rather than facts; they move with C6c/C6d.)
   - [ ] **C6c — `Value::make_sub` from a def.** Carry `def.compiled` into the resulting `SubData`
     so a code object built from a registry routine is bytecode-backed.
   - [ ] **C6d — interpreter execution sites.** Route `eval_block_value(&def.body)` /
-    `run_block(&def.body)` through `def.compiled`.
+    `run_block(&def.body)` through `def.compiled`. **Not a small slice:** these carriers are
+    reached precisely *because* an OTF gate rejected the routine, so eliminating them means
+    widening OTF coverage to every routine, not rewiring a call. Scope it as its own program.
   - [ ] **C6e — redeclaration comparison and the proto rewrite**, then drop the plan field.
 - [ ] **C7 — Remove the sub-registration AST adapter.** Delete dead sub-shaped walker branches and
   prove the routine registry never compiles a migrated declaration on demand.

--- a/news/2026-08/otf-gate-body-predicates-are-memoized.md
+++ b/news/2026-08/otf-gate-body-predicates-are-memoized.md
@@ -1,0 +1,29 @@
+# The OTF gates stop re-walking the routine body
+
+ADR-0019 C6b, following [C6a](routine-identity-fingerprint-is-memoized-on-the-def.md).
+Same shape, different category of `FunctionDef.body` reader.
+
+Whether a routine can be compiled on the fly instead of tree-walked is decided by
+gates that ask three questions of its body: does it contain a construct the
+standalone-compiled form would not preserve (`function_body_needs_interpreter`),
+the stricter module/dynamic-single variant of that
+(`module_otf_body_needs_interpreter`), and does it declare a `state` variable
+(`function_body_declares_state`). Each is a pure predicate that walks the entire
+body AST, each was called straight off `def.body`, and the gates run on every
+slow-path call to the routine — so the same walks over the same immutable AST were
+repeated for the life of the program.
+
+They are now computed once into a `RoutineBodyFacts` memoized on the def
+(`FunctionDef::body_facts_cache`, a `OnceLock`, `#[serde(skip)]` like the
+fingerprint memo). The three are memoized together rather than separately: the
+module-single gate asks for two of them anyway, and one extra walk on first touch
+is nothing beside the compile the gates exist to authorize.
+
+`Interpreter::routine_body_facts` is now the *only* place that reads `def.body` for
+these facts, which is the point: when the compiler starts supplying them
+(the eventual end of C6), one function changes instead of seven call sites.
+
+Separately, the redeclaration path's `is_stub_routine_body(&existing.body)` now
+reads the `is_stub` field that C4 already derives at registration.
+
+`FunctionDef.body` readers: 50 -> 47.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -210,6 +210,28 @@ pub(crate) struct FunctionDef {
     /// simply recomputes it on first use.
     #[serde(skip)]
     pub(crate) body_fp_cache: std::sync::OnceLock<u64>,
+    /// Memoized [`RoutineBodyFacts`], filled by
+    /// `Interpreter::routine_body_facts`. Derived state, like `body_fp_cache`.
+    #[serde(skip)]
+    pub(crate) body_facts_cache: std::sync::OnceLock<RoutineBodyFacts>,
+}
+
+/// Properties of a routine body that the on-the-fly compilation gates ask about.
+///
+/// Each is a pure predicate over the body AST, and each used to be recomputed by
+/// walking that AST at every gate evaluation. They are memoized together on the
+/// def ([`FunctionDef::body_facts_cache`]): the module-single gate asks for two of
+/// the three anyway, and one walk more on first touch is negligible next to the
+/// compile the gates decide whether to perform.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RoutineBodyFacts {
+    /// The body contains a construct whose semantics the standalone-compiled
+    /// form would not preserve (a type declaration, a `start` block, ...).
+    pub(crate) needs_interpreter: bool,
+    /// The stricter variant of the above applied to module/dynamic single subs.
+    pub(crate) module_otf_needs_interpreter: bool,
+    /// The body declares a `state` variable somewhere.
+    pub(crate) declares_state: bool,
 }
 
 impl FunctionDef {

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -221,6 +221,7 @@ impl Interpreter {
             decl_order: crate::runtime::resolution::next_decl_order(),
             compiled: None,
             body_fp_cache: std::sync::OnceLock::new(),
+            body_facts_cache: std::sync::OnceLock::new(),
         };
         // Register as a typed multi candidate under the class package, mirroring
         // the `multi sub` registration keys so `import` copies it and operator
@@ -2297,6 +2298,7 @@ impl Interpreter {
                             decl_order: crate::runtime::resolution::next_decl_order(),
                             compiled: None,
                             body_fp_cache: std::sync::OnceLock::new(),
+                            body_facts_cache: std::sync::OnceLock::new(),
                         };
                         self.registry_mut().functions.insert(
                             Symbol::intern(&qualified_name),
@@ -2380,6 +2382,7 @@ impl Interpreter {
                             decl_order: crate::runtime::resolution::next_decl_order(),
                             compiled: None,
                             body_fp_cache: std::sync::OnceLock::new(),
+                            body_facts_cache: std::sync::OnceLock::new(),
                         };
                         // Register under the short name (lexical scope)
                         self.registry_mut().functions.insert(
@@ -2581,6 +2584,7 @@ impl Interpreter {
                         decl_order: crate::runtime::resolution::next_decl_order(),
                         compiled: None,
                         body_fp_cache: std::sync::OnceLock::new(),
+                        body_facts_cache: std::sync::OnceLock::new(),
                     };
                     self.registry_mut()
                         .proto_methods

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -889,6 +889,7 @@ impl Interpreter {
             decl_order: crate::runtime::resolution::next_decl_order(),
             compiled: None,
             body_fp_cache: std::sync::OnceLock::new(),
+            body_facts_cache: std::sync::OnceLock::new(),
         };
         let single_key = format!("{}::{}", self.current_package(), name);
         let multi_prefix = format!("{}::{}/", self.current_package(), name);
@@ -1318,6 +1319,7 @@ impl Interpreter {
             decl_order: crate::runtime::resolution::next_decl_order(),
             compiled: None,
             body_fp_cache: std::sync::OnceLock::new(),
+            body_facts_cache: std::sync::OnceLock::new(),
         };
         self.insert_token_def(name, def, multi);
     }
@@ -1390,6 +1392,7 @@ impl Interpreter {
                 decl_order: crate::runtime::resolution::next_decl_order(),
                 compiled: None,
                 body_fp_cache: std::sync::OnceLock::new(),
+                body_facts_cache: std::sync::OnceLock::new(),
             }),
         );
         Ok(())
@@ -1499,6 +1502,7 @@ impl Interpreter {
             decl_order: crate::runtime::resolution::next_decl_order(),
             compiled: None,
             body_fp_cache: std::sync::OnceLock::new(),
+            body_facts_cache: std::sync::OnceLock::new(),
         };
         let single_key = format!("GLOBAL::{}", name);
         let single_key_sym = Symbol::intern(&single_key);
@@ -1537,7 +1541,9 @@ impl Interpreter {
             .registry()
             .functions
             .get(&single_key_sym)
-            .is_some_and(|existing| Self::is_stub_routine_body(&existing.body));
+            // `is_stub` is derived once at registration (ADR-0019 C4), so the
+            // installed def already answers this without re-walking its body.
+            .is_some_and(|existing| existing.is_stub);
         if multi {
             if has_single && !has_proto && !supersede {
                 return Err(RuntimeError::redeclaration_routine(name));
@@ -1646,6 +1652,7 @@ impl Interpreter {
                 decl_order: crate::runtime::resolution::next_decl_order(),
                 compiled: None,
                 body_fp_cache: std::sync::OnceLock::new(),
+                body_facts_cache: std::sync::OnceLock::new(),
             }),
         );
         Ok(())

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1869,7 +1869,7 @@ impl Interpreter {
         // with a default value stays excluded here (the name-cache-pollution /
         // builtin-shadow hazard, PR #3546 — allowed at genuine multi sites via
         // `def_is_otf_compilable_multi_candidate`).
-        !Self::function_body_needs_interpreter(&def.body)
+        !Self::routine_body_facts(def).needs_interpreter
             && def.param_defs.iter().all(|pd| pd.default.is_none())
     }
 
@@ -1892,7 +1892,26 @@ impl Interpreter {
         // already picked this candidate by matching the callback's signature, so
         // the compiled binding only binds the callable (byte-identical). Defaults
         // are allowed because a multi site does not name-cache the candidate.
-        !Self::function_body_needs_interpreter(&def.body)
+        !Self::routine_body_facts(def).needs_interpreter
+    }
+
+    /// The OTF-compilation gates' body predicates for `def`, computed once and
+    /// memoized on the def itself (`FunctionDef::body_facts_cache`).
+    ///
+    /// Each predicate walks the whole body AST, and the gates are evaluated on
+    /// every slow-path call to the routine, so recomputing them per call was pure
+    /// repeat work over immutable data. This is also the single place that reads
+    /// `def.body` for these facts, so ADR-0019 C6 can later feed them from the
+    /// compiler by changing one function.
+    pub(super) fn routine_body_facts(
+        def: &crate::ast::FunctionDef,
+    ) -> crate::ast::RoutineBodyFacts {
+        *def.body_facts_cache
+            .get_or_init(|| crate::ast::RoutineBodyFacts {
+                needs_interpreter: Self::function_body_needs_interpreter(&def.body),
+                module_otf_needs_interpreter: Self::module_otf_body_needs_interpreter(&def.body),
+                declares_state: Self::function_body_declares_state(&def.body),
+            })
     }
 
     /// Check if a function body contains constructs that require
@@ -1995,7 +2014,7 @@ impl Interpreter {
                 .iter()
                 .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"));
             (is_capture || (!pd.sigilless && pd.sub_signature.is_none())) && traits_otf_safe
-        }) && !Self::module_otf_body_needs_interpreter(&def.body)
+        }) && !Self::routine_body_facts(def).module_otf_needs_interpreter
     }
 
     /// Return the shared captured body for a resolved module sub def IF routing it
@@ -2012,7 +2031,7 @@ impl Interpreter {
         def: &crate::ast::FunctionDef,
     ) -> Option<std::sync::Arc<CompiledFunction>> {
         if self.imported_compiled_fns.is_empty()
-            || !Self::function_body_declares_state(&def.body)
+            || !Self::routine_body_facts(def).declares_state
             || !Self::def_module_single_sig_body_ok_ignoring_state(def)
         {
             return None;
@@ -2077,7 +2096,7 @@ impl Interpreter {
         // module sub's shared `state` cell (the cross-thread shared captured body,
         // `imported_state_body_for_def`, is the path that admits `state`).
         Self::def_module_single_sig_body_ok_ignoring_state(def)
-            && !Self::function_body_declares_state(&def.body)
+            && !Self::routine_body_facts(def).declares_state
     }
 
     /// Recursively detect interpreter-coupled statements/expressions in a module
@@ -2195,7 +2214,7 @@ impl Interpreter {
         def: &crate::ast::FunctionDef,
     ) -> bool {
         !self.multi_alternate_signature_names.is_empty()
-            && Self::function_body_declares_state(&def.body)
+            && Self::routine_body_facts(def).declares_state
             && self
                 .multi_alternate_signature_names
                 .contains(&Symbol::intern(name))


### PR DESCRIPTION
ADR-0019 **C6b**, following [C6a](https://github.com/tokuhirom/mutsu/pull/5904). Same shape, different category of `FunctionDef.body` reader.

## What changed

Whether a routine can be compiled on the fly instead of tree-walked is decided by gates that ask three questions of its body:

- `function_body_needs_interpreter` — does it contain a construct the standalone-compiled form would not preserve (a type declaration, a `start` block, …)
- `module_otf_body_needs_interpreter` — the stricter module/dynamic-single variant
- `function_body_declares_state` — does it declare a `state` variable anywhere

Each is a pure predicate that walks the **entire body AST**, each was called straight off `def.body`, and the gates run on every slow-path call to the routine. So the same walks over the same immutable AST repeated for the life of the program.

They are now computed once into a `RoutineBodyFacts` memoized on the def (`FunctionDef::body_facts_cache`, a `OnceLock`, `#[serde(skip)]` like the C6a fingerprint memo).

Memoized *together* rather than as three separate locks, deliberately: the module-single gate asks for two of them anyway, and one extra walk on first touch is nothing beside the compile the gates exist to authorize. That trade is noted in the doc comment.

`Interpreter::routine_body_facts` is now the only place reading `def.body` for these facts — which is the real point. When the compiler eventually supplies them, one function changes instead of seven call sites.

Separately, the redeclaration path's `is_stub_routine_body(&existing.body)` now reads the `is_stub` field that C4 already derives at registration.

## Result

`FunctionDef.body` readers: **50 → 47** (58 at the start of C6).

## A note on the rest of C6

While scoping this I found that **C6d is not a slice** and I have said so in the ADR rather than leaving it as an innocuous-looking checkbox. The `eval_block_value(&def.body)` / `run_block(&def.body)` carriers are reached *precisely because* an OTF gate rejected the routine, so removing them means widening OTF coverage to every routine — a program, not a rewiring. C6c (`Value::make_sub` from a def carrying `def.compiled`) remains the next bounded step.

## Verification

- `make test` — PASS (2877 files, 27314 tests)
- `make roast` — PASS
- `scripts/battery-testsuite.sh` — `GATE PASSED`, 153/158

No benchmark number is claimed; per the repo's rule those come from the bench CI. The mechanical claim is the one this PR stands on: three full AST walks per slow-path call become three per def.

🤖 Generated with [Claude Code](https://claude.com/claude-code)