### PR TITLE
docs(adr): C6c is a calling-convention change, not a field copy

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -111,7 +111,7 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 `main`; this is not a stacked-PR plan.
 
 **Current progress: 17/51 slices merged. Next slice: C6c (C6a and C6b landed; C6 is subdivided
-below).**
+below). C6c and C6d each need a design pass before coding — see their notes.**
 
 The migration is complete only when every required box below is checked and the completion gates
 at the end pass. The order within a phase is intentional. A later phase may start when its stated
@@ -171,8 +171,14 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
     single reader `Interpreter::routine_body_facts`, and read the existing `is_stub` field on the
     redeclaration path. (`collect_routine_body_local_names` and rw-target extraction return AST
     data rather than facts; they move with C6c/C6d.)
-  - [ ] **C6c — `Value::make_sub` from a def.** Carry `def.compiled` into the resulting `SubData`
-    so a code object built from a registry routine is bytecode-backed.
+  - [ ] **C6c — `Value::make_sub` from a def.** Make a code object built from a registry routine
+    bytecode-backed. **Not a field copy:** `FunctionDef.compiled` is an `Arc<CompiledFunction>`
+    invoked by `compile_and_call_function_def` (routine convention: `param_local_slots`,
+    `named_call_plan`, `param_name_syms`), while `SubData.compiled_code` is an `Arc<CompiledCode>`
+    invoked by `call_compiled_closure` (closure convention: upvalues aligned to
+    `cc.upvalue_syms`, captured env). Handing the inner `code` over would run a routine body under
+    the closure calling convention. The slice is to let a Sub value carry *routine* identity and
+    dispatch through the routine path; design that first.
   - [ ] **C6d — interpreter execution sites.** Route `eval_block_value(&def.body)` /
     `run_block(&def.body)` through `def.compiled`. **Not a small slice:** these carriers are
     reached precisely *because* an OTF gate rejected the routine, so eliminating them means

--- a/todo/deep/routine-code-objects-run-under-the-closure-convention.md
+++ b/todo/deep/routine-code-objects-run-under-the-closure-convention.md
@@ -1,0 +1,55 @@
+# A code object made from a registry routine cannot carry the routine's compiled body
+
+Blocks ADR-0019 C6c, and therefore the removal of `CompiledSubDeclPlan::legacy_body`.
+
+## The two conventions
+
+mutsu compiles a routine body twice-shaped, not twice-over:
+
+- `FunctionDef.compiled: Option<Arc<CompiledFunction>>` — attached by the declaration
+  plan (ADR-0019 C3). Invoked by `compile_and_call_function_def`, which binds
+  arguments through the routine convention: `param_local_slots`, `named_call_plan`,
+  `param_name_syms`.
+- `SubData.compiled_code: Option<Arc<CompiledCode>>` — attached when a closure value
+  is created (`MakeLambda`). Invoked by `call_compiled_closure`, which binds through
+  the closure convention: upvalues aligned with `cc.upvalue_syms`, plus the captured
+  env.
+
+`CompiledFunction` *contains* a `CompiledCode`, so the types look adaptable. They are
+not interchangeable: handing `def.compiled.code` to `SubData.compiled_code` would run
+a routine body under the closure calling convention, with no upvalue array and with
+parameters bound by the wrong plan.
+
+## Why it matters
+
+About a dozen sites build a code object out of a registry routine —
+`&foo`, `.candidates`, `nextsame`'s next candidate, operator fallback, `.wrap`
+targets, `Method` objects. Every one of them calls `Value::make_sub(def.package,
+def.name, def.params.clone(), def.param_defs.clone(), def.body.clone(), …)` and so
+produces a Sub whose only executable form is the **AST body**. That is the single
+largest remaining group of `FunctionDef.body` readers (`FunctionDef.body` is down to
+47 readers after ADR-0019 C6a/C6b, and this group is most of what is left), and it is
+why `legacy_body` cannot yet be dropped from the sub declaration plan.
+
+## What the fix probably looks like
+
+Let a Sub value carry *routine identity* rather than a bare `CompiledCode`, and have
+the call path dispatch it through `compile_and_call_function_def` instead of
+`call_compiled_closure`. Sketch:
+
+- add a `SubData` variant/field naming the routine (`Arc<CompiledFunction>`, or the
+  registry key plus a generation) alongside the existing `compiled_code`;
+- teach the Sub call path to pick the routine convention when that field is set;
+- keep the closure path byte-identical for genuine closures.
+
+The subtlety is that these code objects are *also* closures in one respect: several
+sites pass `self.env.clone()` as the Sub's env, and callers rely on that env being
+visible inside the body. A routine-convention call does not consult a captured env
+the same way, so the migration has to establish, per site, whether the env is load
+bearing or incidental.
+
+## Not to be confused with C6d
+
+The `eval_block_value(&def.body)` / `run_block(&def.body)` carriers are a different
+problem: those are reached because an OTF gate *rejected* the routine, so eliminating
+them means widening OTF coverage, not fixing a calling convention.


### PR DESCRIPTION
Documentation only. While scoping ADR-0019 **C6c** I found that its checklist entry understated the work the same way C6d's did, so I am correcting it before it misleads the next pass — rather than discovering it again mid-implementation.

## The finding

C6c read "carry `def.compiled` into the resulting `SubData`", which sounds like a field copy. It isn't. mutsu has **two calling conventions** for a compiled body:

| | type | invoked by | binds via |
|---|---|---|---|
| `FunctionDef.compiled` | `Arc<CompiledFunction>` | `compile_and_call_function_def` | `param_local_slots`, `named_call_plan`, `param_name_syms` |
| `SubData.compiled_code` | `Arc<CompiledCode>` | `call_compiled_closure` | upvalues aligned with `cc.upvalue_syms`, captured env |

`CompiledFunction` *contains* a `CompiledCode`, so the types look adaptable. Handing the inner `code` over would run a routine body under the **closure** calling convention — no upvalue array, parameters bound by the wrong plan.

## Why this matters for C6

Roughly a dozen sites build a code object out of a registry routine (`&foo`, `.candidates`, `nextsame`'s next candidate, operator fallback, `.wrap` targets, `Method` objects). Every one calls `Value::make_sub(…, def.body.clone(), …)`, so the resulting Sub's only executable form is the **AST body**. That is the largest remaining group of `FunctionDef.body` readers — 47 after C6a/C6b, down from 58 — and it is precisely why `legacy_body` cannot yet be dropped from the sub declaration plan.

## Contents

- ADR-0019: C6c's entry now states the actual shape and says to design it before coding; the progress line flags that both C6c and C6d need a design pass first.
- New `todo/deep/routine-code-objects-run-under-the-closure-convention.md` with the full finding, a sketch of the likely fix (let a Sub carry routine identity and dispatch through the routine path), and the non-obvious constraint I hit: several of those sites pass a live `self.env.clone()` as the Sub's env, and whether that env is load-bearing or incidental has to be established per site before the convention can be switched.

Docs-only, so the four heavy CI jobs skip by design (`scripts/ci-docs-only.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)