### PR TITLE
docs(adr): measure where C6d's interpreter body sites are actually reached

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -110,8 +110,8 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 17/51 slices merged. Next slice: C6d (C6a, C6b and C6c landed; C6 is
-subdivided below). C6d needs a design pass before coding — see its note.**
+**Current progress: 17/51 slices merged. Next slice: C6d-1 (C6a, C6b and C6c landed; C6 and C6d
+are both subdivided below, C6d from a measurement of where its sites are actually reached).**
 
 The migration is complete only when every required box below is checked and the completion gates
 at the end pass. The order within a phase is intentional. A later phase may start when its stated
@@ -180,13 +180,28 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
     `news/2026-08/routine-code-objects-are-bytecode-backed.md`, which corrects the earlier
     scoping note.
   - [ ] **C6d — interpreter execution sites.** Route `eval_block_value(&def.body)` /
-    `run_block(&def.body)` through `def.compiled`. **Not a small slice:** these carriers are
-    reached precisely *because* an OTF gate rejected the routine, so eliminating them means
-    widening OTF coverage to every routine, not rewiring a call. Scope it as its own program.
-    Its sibling site is `call_sub_value`'s `eval_block_value(&data.body)`, which takes a *code
-    object's* body rather than a def's: after C6c that is the one path left that still executes a
-    routine code object's AST, reached when a `.wrap` chain routes dispatch through the
-    interpreter carrier. It needs the same widening, so it belongs here rather than in C6c.
+    `run_block(&def.body)` through `def.compiled`. Surveyed by instrumenting all six sites and
+    running the whole `t/` suite once (1148 hits — see
+    `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`), which corrects the
+    earlier "widen OTF coverage to every routine" framing: a routine whose body declares a class
+    never reaches these sites, and the sites do not tree-walk — `run_block` recompiles the body
+    per call, so what C6d removes is a repeated compile. The mismatch to solve is that
+    `compile_block_raw` compiles a *block* whose arguments the caller already bound, while
+    `def.compiled` binds its own from `param_local_slots`. Subdivide:
+    - [ ] **C6d-1 — the ordinary-routine tail** (`calls.rs:call_function_def`,
+      `calls.rs:exec_call`): 192 hits over ~37 names, dominated by `where`-constrained multi
+      candidates re-dispatching through `nextsame`. Decide the block-chunk-vs-routine-convention
+      shape here, where the argument-binding conflict lives.
+    - [ ] **C6d-2 — grammar token/rule bodies** (`dispatch.rs:eval_token_def`,
+      `regex_token_resolve.rs`): 956 of the 1148 hits, but those `FunctionDef`s carry a regex
+      body, so scope this against ADR-0009's execution model rather than the OTF gate.
+    - [ ] **C6d-3 — the two sites dead across the whole suite**
+      (`dispatch_proto_call.rs:call_proto_dispatch`, `types/roles.rs:run_role_submethod`); the
+      latter's `def` is a `MethodDef`, so move it to Phase D.
+    - [ ] **C6d-4 — `call_sub_value`'s `eval_block_value(&data.body)`**, which takes a *code
+      object's* body rather than a def's: after C6c that is the one path left that still
+      executes a routine code object's AST, reached when a `.wrap` chain routes dispatch through
+      the interpreter carrier.
   - [ ] **C6e — redeclaration comparison and the proto rewrite**, then drop the plan field.
 - [ ] **C7 — Remove the sub-registration AST adapter.** Delete dead sub-shaped walker branches and
   prove the routine registry never compiles a migrated declaration on demand.

--- a/todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md
+++ b/todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md
@@ -1,0 +1,87 @@
+# C6d is not "widen OTF coverage to every routine": 83% of its sites are token bodies
+
+Scoping measurement for ADR-0019 C6d, which the checklist described as "these carriers
+are reached precisely *because* an OTF gate rejected the routine, so eliminating them
+means widening OTF coverage to every routine". The measurement says otherwise, so the
+next pass should not start from that premise.
+
+## Method
+
+There are six `&def.body` execution sites. Each was instrumented with one env-gated
+`eprintln!` printing the site and the routine name, and the whole `t/` suite (2881
+files) was run once with the probe on:
+
+```
+MUTSU_C6D_SURVEY=1 prove -j4 -e target/debug/mutsu -r t/
+```
+
+1148 hits. (`t/vendored-real-test-module.t` fails under the probe because it compares
+stderr; that is the probe's artifact, not a regression.)
+
+## Result
+
+| site | hits | what it is |
+| --- | --- | --- |
+| `dispatch.rs:eval_token_def` | 632 | grammar `token`/`rule` body |
+| `regex_token_resolve.rs:resolve_token_patterns_with_args_in_pkg` | 324 | grammar `token`/`rule` body |
+| `calls.rs:call_function_def` | 144 | ordinary routine |
+| `calls.rs:exec_call` | 48 | ordinary routine |
+| `dispatch_proto_call.rs:call_proto_dispatch` | 0 | proto dispatch |
+| `types/roles.rs:run_role_submethod` | 0 | role submethod |
+
+Three things follow.
+
+**1. 956 of 1148 hits (83%) are grammar token/rule bodies.** Those `FunctionDef`s hold a
+*regex* body, not a routine body the compiler would compile as a routine, and their
+execution model is ADR-0009's, not the OTF gate's. Top names are the grammar rules
+themselves — `TOP` (483), `expr` (199), `block` (29), `block-string` (21). Whatever C6d
+does about them is a regex-execution question and should be scoped against ADR-0009.
+
+**2. The ordinary-routine tail is small and specific.** 192 hits over ~37 distinct
+names, and it is dominated by *multi dispatch through `where` constraints with
+`nextsame`*: all 102 `seq` hits come from `t/multi-where-otf-dispatch.t`'s
+`proto sub seq($) {*}` + three `where`-constrained candidates that `nextsame` through
+each other. The rest of the tail is the same family (`cs`, `cw`, `ns-multi`,
+`cw-multi`, `cs-multi`, `nw-multi` — the callsame/callwith/nextsame/nextwith tests),
+user operators (`postfix:<!>`, `infix:<op>`), and `Test::Util`-style helper subs
+(`is_run`, `group-of`, `tap-ok`, `is-deeply-junction`, `assert-eq`). None of that
+matches the four constructs the OTF-gate doc comment lists (`ClassDecl`/`RoleDecl`,
+`start`, cross-thread `state`, sigilless-scalar param + `EVAL`) — a routine whose body
+declares a class does *not* reach these sites (`MUTSU_VM_STATS` reports 0 function
+fallbacks for `sub f($x) { class C { has $.a }; C.new(a=>$x).a }`).
+
+**3. Two of the six sites are dead in the whole suite, and one of them is not C6d's.**
+`run_role_submethod`'s `def` is a `MethodDef`, not a `FunctionDef`, so it belongs to
+Phase D's class/role work. `call_proto_dispatch` needs only a coverage argument.
+
+## The convention question C6d actually has
+
+These sites do **not** tree-walk. `run_block` → `run_block_raw` →
+`compile_block_raw(stmts)` + `run_nested`, so the body is **compiled to bytecode at
+every call**. The cost C6d removes is therefore a per-call recompile, not
+interpretation — a smaller correctness risk and a clearer win than the checklist
+implies.
+
+But `compile_block_raw` compiles the body as a *block*: the caller has already bound
+the arguments (`bind_function_args_values` just above the call in
+`call_function_def`). `def.compiled` is routine bytecode that binds its own parameters
+from `param_local_slots`. So handing `def.compiled` to these sites double-binds, which
+is a real convention mismatch — a *different* one from the one C6c turned out not to
+have. The two candidate shapes are: compile the body as a block once and memoize that
+chunk on the def beside `compiled`, or lift these sites to call the routine convention
+and delete their own argument binding.
+
+## Suggested subdivision
+
+Mirroring how C6 was subdivided:
+
+- **C6d-1 — the ordinary-routine tail** (`calls.rs:call_function_def`,
+  `calls.rs:exec_call`): 192 hits, ~37 names, dominated by `where`-multi + re-dispatch.
+  Pick the block-chunk-vs-routine-convention shape here first, since this is where the
+  argument-binding conflict lives.
+- **C6d-2 — grammar token/rule bodies** (`dispatch.rs:eval_token_def`,
+  `regex_token_resolve.rs`): 83% of the hits, but a regex-execution-model question;
+  scope against ADR-0009 rather than the OTF gate.
+- **C6d-3 — prove the two dead sites dead** (`call_proto_dispatch`,
+  `run_role_submethod`), and move `run_role_submethod` to Phase D where its `MethodDef`
+  belongs.


### PR DESCRIPTION
Scoping pass for ADR-0019 **C6d**. Docs-only.

C6d's checklist entry said its carriers "are reached precisely *because* an OTF gate rejected the routine, so eliminating them means widening OTF coverage to every routine, not rewiring a call. Scope it as its own program." Scoping C6c taught me that reasoning from the code's shape without measuring produces a wrong scope, so I measured this one before starting.

## Method

All six `&def.body` execution sites got one env-gated `eprintln!` printing site + routine name, and the whole `t/` suite (2881 files) ran once with the probe on. 1148 hits. Instrumentation removed again; the diff here is docs-only.

## Result

| site | hits | what it is |
| --- | --- | --- |
| `dispatch.rs:eval_token_def` | 632 | grammar `token`/`rule` body |
| `regex_token_resolve.rs:resolve_token_patterns_with_args_in_pkg` | 324 | grammar `token`/`rule` body |
| `calls.rs:call_function_def` | 144 | ordinary routine |
| `calls.rs:exec_call` | 48 | ordinary routine |
| `dispatch_proto_call.rs:call_proto_dispatch` | 0 | proto dispatch |
| `types/roles.rs:run_role_submethod` | 0 | role submethod |

- **83% are grammar token/rule bodies.** Those `FunctionDef`s hold a *regex*, not a routine body the compiler would compile as a routine; their execution model is ADR-0009's, not the OTF gate's.
- **The ordinary-routine tail is small and specific**: 192 hits over ~37 names, dominated by `where`-constrained multi candidates re-dispatching through `nextsame` (all 102 `seq` hits are `t/multi-where-otf-dispatch.t`), plus the callsame/callwith tests, user operators, and `Test::Util`-style helpers. None of it is the four constructs the OTF-gate doc comment lists — a routine whose body declares a class reports **0** function fallbacks under `MUTSU_VM_STATS`.
- **Two sites are dead across the whole suite**, and `run_role_submethod`'s `def` is a `MethodDef`, so it belongs to Phase D rather than C6d.

## The convention question C6d actually has

These sites do not tree-walk: `run_block` → `run_block_raw` → `compile_block_raw` + `run_nested` **recompiles the body at every call**, so what C6d removes is a repeated compile, not interpretation. But `compile_block_raw` compiles the body as a *block* whose arguments the caller already bound (`bind_function_args_values` sits just above the call), while `def.compiled` binds its own from `param_local_slots` — so handing `def.compiled` over double-binds. That is a real mismatch, and a *different* one from the one C6c turned out not to have.

## Changes

- ADR-0019: C6d rewritten against the measurement and subdivided into C6d-1 (ordinary-routine tail — decide the block-chunk-vs-routine-convention shape here), C6d-2 (token bodies — scope against ADR-0009), C6d-3 (the two dead sites), C6d-4 (the code-object body C6c left behind). Next slice is now C6d-1.
- `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`: the method, the full table, the per-name breakdown, and the two candidate fix shapes.

CI note: this is a documentation-only diff, so `test` / `wasm-e2e` / `gc-stress` / `jit-stress` are skipped by design (`scripts/ci-docs-only.sh --classify` returns `true` for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)