### PR TITLE
perf: a BEGIN inside a module routine runs once, not once per execution

### DIFF
--- a/news/2026-08/begin-in-a-module-routine-runs-once.md
+++ b/news/2026-08/begin-in-a-module-routine-runs-once.md
@@ -1,0 +1,59 @@
+# A `BEGIN` inside a module routine runs once, not once per execution
+
+`BEGIN <expr>` promises exactly one evaluation. mutsu delivered that only for
+the mainline: `reorder_phasers` lifts a `BEGIN` rvalue out of the enclosing
+closure and hoists it to the top of the compilation unit, but that pass is run
+from `run_program` alone — a module's body goes straight to `run_block`. So
+every `BEGIN` inside a module's routines was compiled inline and re-evaluated
+on **every execution of the surrounding code**.
+
+The cost is not subtle when the BEGIN sits in a loop body. `Digest::SHA2`'s
+compression round reads its round constant from
+
+    (BEGIN map { frac $_ **(1/3), 32 }, @primes[^64])[$j]
+
+so mutsu rebuilt the whole 64-word table — 64 cube roots, each a `FatRat`
+`**(1/3)` — once per round, i.e. 4096 times per 64-byte block. A single
+`sha256("abc")` executed 65069 opcodes, 4096 of them the `1/3` division alone.
+
+## The fix
+
+A `BEGIN` that reaches the compiler is one the lifter left in place, so the
+compiler now emits `OpCode::BeginOnceExpr` for it: the body runs at most once
+and its value is memoized in the same `once` store that `once { … }` uses. The
+value is computed at first use rather than hoisted, which is *safer* than
+hoisting here — a hoisted BEGIN would run before the module-level `constant`
+declarations it reads (`@primes` above), which is exactly why lifting the
+module case was not the fix.
+
+The memo cell's key is the interesting part. `once` keys on the op's bytecode
+position plus the enclosing routine's clone id, but a BEGIN needs to survive
+something stronger: a block handed to a builtin that runs it through the AST
+carrier — `reduce`, `classify`, `categorize`, … — is **recompiled on every
+call** (`call_sub_value` → `eval_block_value` → `Compiler::compile`), so any id
+minted during compilation is fresh each time and the memo would never hit. That
+is precisely the SHA2 shape: the round function is a `reduce` callback. So the
+site id is hashed from source identity instead — declaring package, source
+line, and a fingerprint of the BEGIN body — which is stable across
+recompilations. Two textually identical BEGINs on one line are told apart by an
+occurrence counter, so they keep separate cells.
+
+## Result
+
+The `Digest` distribution's own test suite, on a release build:
+
+| file | before | after | raku |
+| --- | --- | --- | --- |
+| `t/md5.t` | 42.5s | 2.2s | 1.0s |
+| `t/sha.t` | 97.9s | 1.5s | 1.9s |
+| `t/rfc4231.t` | >200s (timeout) | 5.9s | 2.4s |
+| `t/ripemd.t` | >200s (timeout) | 512.9s | 46.0s |
+
+`sha256("abc")` drops from 65069 opcodes to 23248. Three of the four files now
+run comfortably faster than the batteries gate's per-file budget; `t/ripemd.t`
+completes but is still 11x raku, which is a separate (unrelated) gap.
+
+Pin: `t/begin-once-in-module-routine.t`, which checks all three properties
+against a module fixture — one array shared by repeated calls, one array shared
+by every iteration of a `reduce` callback, and two same-line BEGINs staying
+distinct. Every assertion passes under rakudo too.

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -300,21 +300,65 @@ impl Compiler {
         }
     }
 
-    /// Compile PhaserExpr (INIT/CHECK/END as rvalue).
+    /// Compile PhaserExpr (BEGIN/INIT/CHECK/END as rvalue).
     pub(super) fn compile_expr_phaser(&mut self, kind: &PhaserKind, body: &[Stmt]) {
-        if matches!(kind, crate::ast::PhaserKind::End) {
-            let end_stmt = Stmt::Phaser {
-                kind: crate::ast::PhaserKind::End,
-                body: body.to_vec(),
-            };
-            let idx = self.code.add_stmt(end_stmt);
-            let site_id =
-                super::STATE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as u64;
-            self.code.emit(OpCode::PhaserEnd { idx, site_id });
-            self.code.emit(OpCode::LoadNil);
-        } else {
-            self.compile_block_inline(body);
+        match kind {
+            crate::ast::PhaserKind::End => {
+                let end_stmt = Stmt::Phaser {
+                    kind: crate::ast::PhaserKind::End,
+                    body: body.to_vec(),
+                };
+                let idx = self.code.add_stmt(end_stmt);
+                let site_id =
+                    super::STATE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as u64;
+                self.code.emit(OpCode::PhaserEnd { idx, site_id });
+                self.code.emit(OpCode::LoadNil);
+            }
+            // A BEGIN reaching the compiler is one the phaser lifter left in
+            // place: the lifter hoists `BEGIN <expr>` to the unit's top level,
+            // but it only walks the mainline, so every BEGIN inside a module's
+            // routines arrives here. Compiled inline it would be re-evaluated on
+            // every execution — `Digest::SHA2`'s per-round constant table was
+            // rebuilt 64 times per compression block. Memoize it per site
+            // instead: BEGIN promises one evaluation, and computing it at first
+            // use (rather than hoisting it) keeps it after the declarations it
+            // reads, e.g. a module-level `constant`.
+            crate::ast::PhaserKind::Begin => {
+                let site_id = self.begin_site_id(body);
+                let idx = self.code.emit(OpCode::BeginOnceExpr {
+                    body_end: 0,
+                    site_id,
+                });
+                self.compile_block_inline(body);
+                self.code.patch_body_end(idx);
+            }
+            _ => self.compile_block_inline(body),
         }
+    }
+
+    /// The memo cell a `BEGIN <expr>` site claims at run time.
+    ///
+    /// It must be **stable across recompilations of the same source**: a block
+    /// handed to a builtin that runs it through the AST carrier
+    /// (`reduce`/`classify`/…) is recompiled on every call, so a counter handed
+    /// out at compile time would mint a fresh cell each time and the BEGIN would
+    /// run again. Hashing the source identity — declaring package, line, and the
+    /// body itself — gives the same id every recompile. Two textually identical
+    /// BEGINs on one line are told apart by an occurrence counter, so they keep
+    /// separate cells within a compilation.
+    fn begin_site_id(&mut self, body: &[Stmt]) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::hash::DefaultHasher::new();
+        self.current_package.hash(&mut hasher);
+        self.last_source_line.hash(&mut hasher);
+        crate::ast::function_body_fingerprint(&[], &[], body).hash(&mut hasher);
+        let base = hasher.finish();
+        let seq = self.begin_site_seq.entry(base).or_insert(0);
+        *seq += 1;
+        let mut hasher = std::hash::DefaultHasher::new();
+        base.hash(&mut hasher);
+        seq.hash(&mut hasher);
+        hasher.finish()
     }
 
     /// Compile `once { ... }` expression.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -361,6 +361,11 @@ pub(crate) struct Compiler {
     /// Line of the `Stmt::SetLine` marker last seen (the line attached to the ops
     /// emitted since; also the definition line of a block/sub compiled here).
     last_source_line: Option<i64>,
+    /// How many `BEGIN <expr>` sites with the same (package, line, body) identity
+    /// this compilation has already emitted. Disambiguates two textually
+    /// identical BEGINs on one line so they keep separate memo cells; see
+    /// `begin_site_id`.
+    begin_site_seq: std::collections::HashMap<u64, u32>,
     /// Pending writebacks for Index expressions passed to function calls.
     /// After the call returns, if the `is rw` parameter was written to,
     /// we need to write the temp variable value back to the original hash/array slot.
@@ -471,6 +476,7 @@ impl Compiler {
             enclosing_local_names: std::collections::HashSet::new(),
             prebound_placeholder_params: std::collections::HashSet::new(),
             last_source_line: None,
+            begin_site_seq: std::collections::HashMap::new(),
             pending_index_rw_writebacks: Vec::new(),
             current_distribution: None,
             escaping_position: false,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -934,6 +934,16 @@ pub(crate) enum OpCode {
     OnceExpr {
         body_end: u32,
     },
+    /// A `BEGIN <expr>` whose value the phaser lifter could not hoist out of its
+    /// enclosing routine (module bodies are not lifted at all — see
+    /// `compile_expr_phaser`). The body still runs at most once: the result is
+    /// memoized in the `once` store under a compile-time site id, so unlike
+    /// `OnceExpr` the memo is shared by every clone of the enclosing code object,
+    /// which is what BEGIN means (one value, baked in at compile time).
+    BeginOnceExpr {
+        body_end: u32,
+        site_id: u64,
+    },
     DoGivenExpr {
         body_end: u32,
     },
@@ -4849,6 +4859,7 @@ impl CompiledCode {
             OpCode::PackageScope { body_end, .. } => *body_end = target,
             OpCode::DoBlockExpr { body_end, .. } => *body_end = target,
             OpCode::OnceExpr { body_end, .. } => *body_end = target,
+            OpCode::BeginOnceExpr { body_end, .. } => *body_end = target,
             OpCode::DoGivenExpr { body_end, .. } => *body_end = target,
             OpCode::SubtestScope { body_end, .. } => *body_end = target,
             OpCode::ReactScope { body_end, .. } => *body_end = target,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4360,6 +4360,10 @@ impl Interpreter {
                 self.sync_source_line(code, *ip);
                 self.exec_once_expr_op(code, *body_end, ip, compiled_fns)?;
             }
+            OpCode::BeginOnceExpr { body_end, site_id } => {
+                self.sync_source_line(code, *ip);
+                self.exec_begin_once_expr_op(code, *body_end, *site_id, ip, compiled_fns)?;
+            }
             OpCode::DoGivenExpr { body_end } => {
                 self.sync_source_line(code, *ip);
                 self.exec_do_given_expr_op(code, *body_end, ip, compiled_fns)?;

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -231,6 +231,51 @@ impl Interpreter {
         result
     }
 
+    /// `BEGIN <expr>` that stayed inside a routine (see `compile_expr_phaser`).
+    /// Same memo mechanism as `once`, but keyed by the compile-time site id
+    /// alone: a BEGIN is one value shared by every clone of the enclosing code,
+    /// not one per clone.
+    pub(super) fn exec_begin_once_expr_op(
+        &mut self,
+        code: &CompiledCode,
+        body_end: u32,
+        site_id: u64,
+        ip: &mut usize,
+        compiled_fns: &CompiledFns,
+    ) -> Result<(), RuntimeError> {
+        let cache_key = format!("BEGIN#{site_id}");
+        let store = std::sync::Arc::clone(self.once_store());
+        match store.claim(&cache_key) {
+            crate::runtime::once_store::OnceClaim::Cached(value) => {
+                self.stack.push(value);
+                *ip = body_end as usize;
+                Ok(())
+            }
+            crate::runtime::once_store::OnceClaim::Claimed => {
+                let body_start = *ip + 1;
+                let end = body_end as usize;
+                let stack_base = self.stack.len();
+                match self.run_range(code, body_start, end, compiled_fns) {
+                    Ok(()) => {
+                        let value = if self.stack.len() > stack_base {
+                            self.stack.pop().unwrap_or(Value::NIL)
+                        } else {
+                            Value::NIL
+                        };
+                        store.fulfill(&cache_key, value.clone());
+                        self.stack.push(value);
+                        *ip = end;
+                        Ok(())
+                    }
+                    Err(e) => {
+                        store.abandon(&cache_key);
+                        Err(e)
+                    }
+                }
+            }
+        }
+    }
+
     pub(super) fn exec_once_expr_op(
         &mut self,
         code: &CompiledCode,

--- a/t/begin-once-in-module-routine.t
+++ b/t/begin-once-in-module-routine.t
@@ -1,0 +1,21 @@
+use v6;
+use lib 't/lib';
+use Test;
+use BeginOnceInRoutine;
+
+plan 5;
+
+# `BEGIN <expr>` promises ONE evaluation. The phaser lifter hoists a BEGIN out
+# of the mainline, but it never walks a module's routine bodies, so every BEGIN
+# inside a module was compiled inline and re-evaluated on every execution --
+# `Digest::SHA2` rebuilt its 64-word round-constant table once per round.
+
+is direct(), 1, 'a BEGIN inside a module routine yields its value';
+is direct(), 2, 'the second call pushes into the SAME array';
+is direct(), 3, 'and so does the third -- the BEGIN body ran once';
+
+# The `reduce` callback is recompiled on every iteration (the AST carrier), so
+# the memo cell must not be keyed by the compilation that emitted it.
+is via-reduce(), 4, 'a BEGIN inside a reduce callback is one array for all 4 iterations';
+
+is twice(), False, 'two identical BEGINs on one line are separate sites';

--- a/t/lib/BeginOnceInRoutine.rakumod
+++ b/t/lib/BeginOnceInRoutine.rakumod
@@ -1,0 +1,32 @@
+unit module BeginOnceInRoutine;
+
+# A module's routines are never walked by the phaser lifter (that pass only
+# reorders the mainline), so these BEGINs reach the compiler in place -- the
+# case `BeginOnceExpr` memoizes. Evaluated once, `BEGIN []` is ONE array that
+# every call pushes into; re-evaluated, each call would get a fresh empty one.
+
+sub direct() is export {
+    my $a = BEGIN [];
+    $a.push(1);
+    $a.elems
+}
+
+# `reduce` runs its callback through the AST carrier, which recompiles the
+# block on every iteration. The memo cell is keyed by source identity, not by
+# the compilation that emitted it, so the BEGIN still runs exactly once.
+sub via-reduce() is export {
+    my $seen;
+    reduce -> $acc, $j {
+        my $a = BEGIN [];
+        $a.push($j);
+        $seen = $a;
+        $acc + $j
+    }, 0, |^4;
+    $seen.elems
+}
+
+# Two textually identical BEGINs on one line are separate sites and keep
+# separate values.
+sub twice() is export {
+    (BEGIN []) =:= (BEGIN [])
+}


### PR DESCRIPTION
## The bug

`BEGIN <expr>` promises exactly one evaluation. mutsu delivered that only for
the mainline: `reorder_phasers` lifts a `BEGIN` rvalue out of its enclosing
closure and hoists it to the top of the unit, but that pass runs from
`run_program` alone — a module's body goes straight to `run_block`. Every
`BEGIN` inside a module's routines was compiled inline and re-evaluated on
**every execution of the surrounding code**.

`Digest::SHA2`'s compression round reads its round constant from

```raku
(BEGIN map { frac $_ **(1/3), 32 }, @primes[^64])[$j]
```

so mutsu rebuilt the whole 64-word table — 64 `FatRat` cube roots — once per
round, 4096 times per 64-byte block.

## The fix

A `BEGIN` that reaches the compiler is one the lifter left in place, so it now
compiles to `OpCode::BeginOnceExpr`: the body runs at most once and the value is
memoized in the same store `once { … }` uses. Computing it at first use rather
than hoisting is deliberate — a hoisted BEGIN would run *before* the
module-level `constant` declarations it reads (`@primes`), which is why lifting
the module case was not the fix.

The memo key is hashed from **source identity** (declaring package, source line,
body fingerprint) rather than minted during compilation. A block handed to a
builtin that runs it through the AST carrier — `reduce`, `classify`, … — is
recompiled on every call (`call_sub_value` → `eval_block_value` →
`Compiler::compile`), so a compile-time id would be fresh each time and the memo
would never hit. That is exactly the SHA2 shape: the round function is a
`reduce` callback. An occurrence counter keeps two textually identical
same-line BEGINs in separate cells.

## Result

The `Digest` distribution's own suite, release build:

| file | before | after | raku |
| --- | --- | --- | --- |
| `t/md5.t` | 42.5s | 2.2s | 1.0s |
| `t/sha.t` | 97.9s | 1.5s | 1.9s |
| `t/rfc4231.t` | >200s (timeout) | 5.9s | 2.4s |
| `t/ripemd.t` | >200s (timeout) | 512.9s | 46.0s |

`sha256("abc")` drops from 65069 opcodes to 23248.

## Tests

- New pin `t/begin-once-in-module-routine.t` (+ `t/lib/BeginOnceInRoutine.rakumod`):
  repeated calls share one array, a `reduce` callback's BEGIN shares one array
  across all iterations, and two same-line BEGINs stay distinct. **Every
  assertion passes under rakudo too.**
- `make test`: 2879 files, 27345 tests, PASS.
- `roast/S04-phasers/*.t` (17 files) and the whitelisted `S10-packages` /
  `S11-modules` files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)