### PR TITLE
perf(dispatch): a multi deferral runs the next candidate's compiled body

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -189,9 +189,17 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
     `compile_block_raw` compiles a *block* whose arguments the caller already bound, while
     `def.compiled` binds its own from `param_local_slots`. Subdivide:
     - [ ] **C6d-1 — the ordinary-routine tail** (`calls.rs:call_function_def`,
-      `calls.rs:exec_call`): 192 hits over ~37 names, dominated by `where`-constrained multi
-      candidates re-dispatching through `nextsame`. Decide the block-chunk-vs-routine-convention
-      shape here, where the argument-binding conflict lives.
+      `calls.rs:exec_call`): 192 hits over ~37 names. The shape is settled and is neither
+      candidate above: these are *callers* reaching the interpreter entry `call_function_def`
+      where a compiled entry already exists, so each one is rewired rather than re-compiled. The
+      multi-deferral caller (`builtins_dispatch_next`, 102 of the 144
+      `call_function_def` hits) landed first — see
+      `news/2026-08/multi-deferral-runs-the-compiled-candidate.md`, which also records why the
+      general `compile_and_call_function_def` entry cannot be used here (it re-pushes the
+      multi-dispatch frame the chain owns, and the chain then defers to the same candidate
+      forever). Remaining callers: `builtins_operators_fallback` (user operators),
+      `builtins_operators_infix` (reduce), `builtins_operators_coerce`, `accessors_state`,
+      `main_args` (`MAIN`).
     - [ ] **C6d-2 — grammar token/rule bodies** (`dispatch.rs:eval_token_def`,
       `regex_token_resolve.rs`): 956 of the 1148 hits, but those `FunctionDef`s carry a regex
       body, so scope this against ADR-0009's execution model rather than the OTF gate.

--- a/news/2026-08/multi-deferral-runs-the-compiled-candidate.md
+++ b/news/2026-08/multi-deferral-runs-the-compiled-candidate.md
@@ -1,0 +1,53 @@
+# A multi deferral runs the next candidate's compiled body
+
+ADR-0019 C6d-1, first slice. `nextsame`/`callsame`/`nextwith`/`callwith` advance a
+multi-dispatch chain by picking the next matching candidate and invoking it. That
+invocation went through the interpreter entry `call_function_def`, whose body run
+is `run_block(&def.body)` -> `run_block_raw` -> `compile_block_raw`: **the
+candidate's AST body was compiled afresh on every deferral.** The deferral now
+runs the bytecode the declaration plan already attached to that candidate
+(`FunctionDef::compiled`), falling back to one memoized on-the-fly compile per
+candidate when the plan attached none.
+
+Measured effect: `t/multi-where-otf-dispatch.t` went from 103 recompiles at
+`calls.rs`'s `run_block(&def.body)` to 0. Those 103 were the single largest
+contributor to that site across the whole `t/` suite (144 hits total — see
+`todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md` for the survey
+this slice came out of).
+
+## The entry point this must *not* use
+
+The obvious rewrite — call `compile_and_call_function_def`, the general VM routine
+entry that most callers use — **overflows the stack**. That entry does
+
+```
+self.push_samewith_context(&name, None);
+let pushed_dispatch = push_multi_dispatch_frame(&name, &args);
+```
+
+before running the body, and a deferral chain *owns* the multi-dispatch frame it
+just advanced. Pushing a fresh frame for the same name resets the candidate list,
+so the next `nextsame` inside the deferred candidate defers to the same candidate
+again, forever. `t/multi-where-otf-dispatch.t` aborted with
+`fatal runtime error: stack overflow` at its `proto sub seq($) {*}` chain.
+
+The correct entry is the one below that setup — `call_compiled_function_named` —
+which runs the routine body without touching the samewith or multi-dispatch
+stacks, exactly matching the interpreter entry it replaces (`call_function_def`
+pushes neither). It and `otf_compile_function_def` widened from `pub(super)` to
+`pub(crate)` so the re-dispatch code in `runtime/` can reach them.
+
+## Pinned
+
+`t/multi-redispatch-compiled-candidate.t` (18 assertions, verified against `raku`
+first). The load-bearing cases are the deep chains — a five-candidate `nextsame`
+chain and a 20-iteration repeated chain — because a frame-ownership regression
+recurses until the stack overflows rather than failing an assertion. It also
+covers `callsame` value threading, `nextwith`/`callwith` argument replacement, a
+candidate that is itself recursive while deferring, `is rw` writeback through the
+chain, named arguments and the deferred candidate's own defaults, a `state`
+variable in a deferred candidate, and method `callsame` to a parent class.
+
+Note while writing it: `nextsame` **tail-calls** — it returns the next
+candidate's value directly and discards the current frame — so
+`'derived ' ~ nextsame()` never concatenates. Value threading needs `callsame`.

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -736,7 +736,31 @@ impl Interpreter {
             if have_rw_source {
                 self.set_pending_call_arg_sources(Some(rw_sources));
             }
-            let result = self.call_function_def(&next_def, &call_args);
+            // Run the next candidate as bytecode — the body the declaration plan
+            // compiled, or one on-the-fly compile memoized per candidate — instead
+            // of recompiling `next_def.body` on every deferral (ADR-0019 C6d-1).
+            //
+            // Deliberately NOT `compile_and_call_function_def`: that entry pushes a
+            // fresh multi-dispatch frame for the name, and this deferral chain
+            // *owns* the frame it just advanced above. Re-pushing it restarts the
+            // chain at the first candidate, so the next `nextsame` defers to the
+            // same candidate forever (stack overflow in
+            // `t/multi-where-otf-dispatch.t`). It also must not push a samewith
+            // context, matching the interpreter entry this replaces.
+            let empty_fns = crate::opcode::CompiledFns::default();
+            let cf = match &next_def.compiled {
+                Some(compiled) => std::sync::Arc::clone(compiled),
+                None => self.otf_compile_function_def(&next_def),
+            };
+            let next_pkg = next_def.package.resolve();
+            let next_name = next_def.name.resolve();
+            let result = self.call_compiled_function_named(
+                &cf,
+                call_args.clone(),
+                &empty_fns,
+                &next_pkg,
+                &next_name,
+            );
             if have_rw_source {
                 self.set_pending_call_arg_sources(None);
             }

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -124,7 +124,7 @@ impl Interpreter {
     /// across calls. Shared by `compile_and_call_function_def` and the non-trivial
     /// proto-body runner (ledger §D, multi-dispatch VM-ization), so both go through
     /// the same compile/cache path.
-    pub(super) fn otf_compile_function_def(
+    pub(crate) fn otf_compile_function_def(
         &mut self,
         def: &crate::ast::FunctionDef,
     ) -> Arc<CompiledFunction> {

--- a/src/vm/vm_call_named.rs
+++ b/src/vm/vm_call_named.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl Interpreter {
-    pub(super) fn call_compiled_function_named(
+    pub(crate) fn call_compiled_function_named(
         &mut self,
         cf: &CompiledFunction,
         args: Vec<Value>,

--- a/t/multi-redispatch-compiled-candidate.t
+++ b/t/multi-redispatch-compiled-candidate.t
@@ -1,0 +1,124 @@
+use Test;
+
+# ADR-0019 C6d-1: the `nextsame`/`callsame`/`nextwith`/`callwith` multi deferral
+# runs the next candidate as bytecode (the body the declaration plan compiled)
+# instead of recompiling that candidate's AST body on every deferral.
+#
+# The chain must keep owning its own multi-dispatch frame while doing so: an
+# entry point that pushes a fresh frame for the name restarts the chain at the
+# first candidate, so each `nextsame` defers to the same candidate forever. The
+# deep chains below are what catch that -- they would recurse until the stack
+# overflows rather than fail an assertion.
+
+plan 18;
+
+# A long deferral chain: every candidate matches, so the chain has to walk all
+# the way to the end exactly once.
+{
+    my @order;
+    proto sub deep($) {*}
+    multi sub deep(Int $n where * > 0)   { @order.push: 'a'; nextsame }
+    multi sub deep(Int $n where * > 1)   { @order.push: 'b'; nextsame }
+    multi sub deep(Int $n where * > 2)   { @order.push: 'c'; nextsame }
+    multi sub deep(Int $n where * > 3)   { @order.push: 'd'; nextsame }
+    multi sub deep($n)                   { @order.push: 'z'; 'done' }
+    is deep(9), 'done', 'a five-deep nextsame chain returns the last candidate value';
+    is @order.elems, 5, 'each candidate in the chain ran exactly once';
+    is @order.join(''), 'abcdz', 'the chain walked every candidate in order';
+}
+
+# Repeated calls must not accumulate state in the chain's frame.
+{
+    my @order;
+    proto sub rep($) {*}
+    multi sub rep(Int $n where * > 0) { @order.push: 'w'; nextsame }
+    multi sub rep($n)                 { @order.push: 'g' }
+    rep(1) for ^20;
+    is @order.elems, 40, 'a repeated chain runs each candidate once per call';
+    is @order.join('').substr(0, 4), 'wgwg', 'the per-call order is stable';
+}
+
+# `callsame` returns the deferred value rather than tail-calling.
+{
+    proto sub cs-chain($) {*}
+    multi sub cs-chain(Int $n where * > 0) { 'saw:' ~ callsame() }
+    multi sub cs-chain(Int $n where * > 1) { 'mid:' ~ callsame() }
+    multi sub cs-chain($n)                 { 'base' }
+    is cs-chain(5), 'saw:mid:base', 'callsame threads the value back up the chain';
+}
+
+# `nextwith` / `callwith` re-dispatch with new arguments.
+{
+    proto sub nw($) {*}
+    multi sub nw(Int $n where * > 100) { nextwith(1) }
+    multi sub nw(Int $n)               { "int $n" }
+    is nw(500), 'int 1', 'nextwith re-dispatches with the replacement argument';
+
+    proto sub cw($) {*}
+    multi sub cw(Int $n where * > 100) { 'got ' ~ callwith(2) }
+    multi sub cw(Int $n)               { "int $n" }
+    is cw(500), 'got int 2', 'callwith re-dispatches and returns the value';
+}
+
+# A candidate that defers is itself recursive: the chain and the recursion must
+# not be confused for one another.
+{
+    my @trace;
+    proto sub rec($) {*}
+    multi sub rec(Int $n where * > 0) {
+        @trace.push: "w$n";
+        rec($n - 1) if $n > 1;
+        nextsame;
+    }
+    multi sub rec(Int $n) { @trace.push: "g$n"; $n }
+    rec(3);
+    is @trace.grep(* eq 'w3').elems, 1, 'the outer recursive candidate ran once';
+    is @trace.grep(/^g/).elems, 3, 'each recursion level reached the generic candidate';
+}
+
+# An `is rw` parameter still writes back through a deferral.
+{
+    proto sub bump($ is rw) {*}
+    multi sub bump(Int $n is rw where * >= 0) { $n = $n + 1; nextsame }
+    multi sub bump($n is rw)                  { $n = $n * 10 }
+    my $v = 4;
+    bump($v);
+    is $v, 50, 'the rw writeback survives the deferral chain';
+}
+
+# Named arguments and defaults bind in the deferred candidate.
+{
+    proto sub nmd($, :$tag) {*}
+    multi sub nmd(Int $n where * > 0, :$tag) { 'pos-' ~ callsame() }
+    multi sub nmd($n, :$tag = 'd')           { "n=$n tag=$tag" }
+    is nmd(3, tag => 'x'), 'pos-n=3 tag=x',
+        'a named argument reaches the deferred candidate';
+    is nmd(3), 'pos-n=3 tag=d', 'the deferred candidate applies its own default';
+}
+
+# A `state` variable in a deferred candidate belongs to that candidate.
+{
+    proto sub st($) {*}
+    multi sub st(Int $n where * > 0) { nextsame }
+    multi sub st($n)                 { state $seen = 0; ++$seen }
+    st(1); st(1);
+    is st(1), 3, 'a deferred candidate keeps its own state across deferrals';
+}
+
+# Deferral inside a method chain (submethod/method candidates), to make sure the
+# routine-side change did not disturb method re-dispatch.
+{
+    class Base { method m(Int $n) { "base $n" } }
+    class Derived is Base { method m(Int $n) { 'derived ' ~ callsame() } }
+    is Derived.new.m(2), 'derived base 2', 'method callsame still reaches the parent';
+}
+
+# `.candidates`-driven manual dispatch is unaffected by the chain change.
+{
+    proto sub cand($) {*}
+    multi sub cand(Int $n) { "int $n" }
+    multi sub cand(Str $s) { "str $s" }
+    is &cand.candidates.elems, 2, 'both candidates are still visible';
+    is cand(1), 'int 1', 'ordinary multi dispatch still selects by type';
+    is cand('a'), 'str a', 'ordinary multi dispatch still selects the Str candidate';
+}

--- a/todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md
+++ b/todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md
@@ -71,6 +71,23 @@ have. The two candidate shapes are: compile the body as a block once and memoize
 chunk on the def beside `compiled`, or lift these sites to call the routine convention
 and delete their own argument binding.
 
+## Update: C6d-1's shape turned out to be neither candidate
+
+Following the `call_function_def` callers showed the ordinary-routine tail is not a
+convention problem at all. `compile_and_call_function_def` — the VM's routine entry —
+already exists and most callers use it; the tail is the handful of callers that still
+reach the *interpreter* entry `call_function_def`:
+`builtins_dispatch_next` (multi deferral), `builtins_operators_fallback` (user
+operators), `builtins_operators_infix` (reduce), `builtins_operators_coerce`,
+`accessors_state`, `main_args` (`MAIN`). Each is rewired, not redesigned.
+
+The one non-obvious constraint, found by trying the naive rewire: the multi-deferral
+caller must **not** use `compile_and_call_function_def`, because that entry pushes a
+fresh multi-dispatch frame for the name and a deferral chain owns the frame it just
+advanced — the chain then defers to the same candidate forever and the stack overflows.
+It uses the entry below that setup, `call_compiled_function_named`. Landed; see
+`news/2026-08/multi-deferral-runs-the-compiled-candidate.md`.
+
 ## Suggested subdivision
 
 Mirroring how C6 was subdivided:


### PR DESCRIPTION
ADR-0019 **C6d-1**, first slice — from the survey that landed in #5910.

`nextsame`/`callsame`/`nextwith`/`callwith` advance a multi-dispatch chain by picking the next matching candidate and invoking it. That invocation went through the interpreter entry `call_function_def`, whose body run is `run_block(&def.body)` → `run_block_raw` → `compile_block_raw`: **the candidate's AST body was compiled afresh on every deferral.** It now runs the bytecode the declaration plan already attached to that candidate (`FunctionDef::compiled`), falling back to one memoized OTF compile per candidate when the plan attached none.

**Measured:** `t/multi-where-otf-dispatch.t` went from 103 recompiles at that site to 0 (breakpoint count at `calls.rs`'s `run_block(&def.body)`). Those 103 were the single largest contributor to that site across the whole `t/` suite — 144 hits total per the survey.

## The entry point this must *not* use

The obvious rewrite — `compile_and_call_function_def`, the general VM routine entry most callers use — **overflows the stack**. It does

```rust
self.push_samewith_context(&name, None);
let pushed_dispatch = push_multi_dispatch_frame(&name, &args);
```

before running the body, and a deferral chain *owns* the multi-dispatch frame it just advanced. Pushing a fresh frame for the same name resets the candidate list, so the next `nextsame` inside the deferred candidate defers to the same candidate again, forever — `t/multi-where-otf-dispatch.t` aborted with `fatal runtime error: stack overflow` at its `proto sub seq($) {*}` chain.

The correct entry is the one below that setup, `call_compiled_function_named`, which runs the routine body without touching the samewith or multi-dispatch stacks — exactly matching the interpreter entry it replaces (`call_function_def` pushes neither). It and `otf_compile_function_def` widen from `pub(super)` to `pub(crate)` so the re-dispatch code in `runtime/` can reach them.

## Tests

`t/multi-redispatch-compiled-candidate.t` — 18 assertions, verified against `raku` first. The load-bearing cases are the deep chains (a five-candidate `nextsame` chain and a 20-iteration repeated chain), because a frame-ownership regression recurses until the stack overflows rather than failing an assertion. Also covers `callsame` value threading, `nextwith`/`callwith` argument replacement, a candidate that is itself recursive while deferring, `is rw` writeback through the chain, named arguments plus the deferred candidate's own defaults, a `state` variable in a deferred candidate, and method `callsame` to a parent class.

The whole existing re-dispatch family passes (`nextsame-rw-redispatch`, `proto-method-rw-redispatch`, `proto-rw-redispatch-coherence`, `samewith`, `samewith-inside-lazy-gather`, `callsame-punned-role-and-hyper-infix-sub`, `lexical-callwith-shadow`, `grammar-parse-override-nextwith`, `method-redispatch-compiled`, `method-redispatch-fingerprint`, `wrap`, `wrap-recursive-redispatch`, `gate-b-rw-redispatch-slot-read`).

Local `make test` (2881 files / 27379 tests) and `make roast` (1435 files / 218774 tests) both PASS.

## ADR bookkeeping

C6d-1's shape is now settled and recorded: it is neither of the two candidates the survey proposed. `compile_and_call_function_def` already exists and most callers use it — the tail is just the handful of callers still reaching the interpreter entry, so each is *rewired* rather than redesigned. Remaining callers listed in the ADR: `builtins_operators_fallback` (user operators), `builtins_operators_infix` (reduce), `builtins_operators_coerce`, `accessors_state`, `main_args` (`MAIN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)