### PR TITLE
fix(vm): a native array keeps truncating after a thread is spawned

### DIFF
--- a/news/2026-08/native-array-push-after-a-start.md
+++ b/news/2026-08/native-array-push-after-a-start.md
@@ -1,0 +1,38 @@
+# A native array kept truncating after a thread was spawned
+
+`my uint32 @W` truncates every stored value to 32 bits. It stopped doing so —
+process-wide, permanently — as soon as anything anywhere ran a `start`.
+
+The VM's array-push op has a separate branch for `shared_vars_active`, the flag
+that latches on at the first thread spawn so that concurrent `@a.push` calls
+serialize through the atomic shared store instead of clobbering each other. That
+branch pushed the value straight into the container, skipping the two steps the
+single-threaded path applies first: the declared **element type check** and the
+**native-width wrap**. A second `ContainerRef` branch further down skipped them
+for the same reason.
+
+The failure is silent and cross-module, which is what makes it worth writing
+down. In the bundled `Digest` distribution, `Digest::RIPEMD`'s `rmd160` runs the
+two halves of each compression round in `start` blocks. After calling it, an
+unrelated `Digest::SHA1::sha1` returned a **wrong digest** — `sha1("abc")` came
+out `360737f7…` instead of `a9993e36…` — because `sha1-block` builds its message
+schedule with
+
+```raku
+my uint32 @W = $M;
+@W.push: S(1, [+^] @W[$_ X- <3 8 14 16>]) for 16..79;
+```
+
+and the schedule words silently grew past 32 bits (`@W[19]` became
+`0x1_8589_8e01`). `sha1("")` still looked right — an empty message has no bytes
+to overflow with — so the corruption depended on the input, which is the worst
+shape a hashing bug can have.
+
+Both checks now live in helpers (`check_push_element_type`,
+`wrap_native_int_push_value`) that every push path calls, so the element type
+governs the push regardless of the target's shape or the process's threading
+history.
+
+Pin: `t/native-array-push-after-start.t` — `uint32` truncation before and after
+a `start`, `int8` signed wrapping, multi-value pushes, and the type check still
+rejecting a bad element. Every assertion passes under rakudo too.

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -67,6 +67,14 @@ impl Interpreter {
         if self.shared_vars_active {
             let val = self.stack.pop().unwrap_or(Value::NIL);
             let val = self.push_nil_to_elem_default(target_name, val);
+            // The declared element type governs this push exactly as it does the
+            // single-threaded one below. `shared_vars_active` latches on for the
+            // rest of the process at the first `start`, so without this a
+            // `my uint32 @W` stopped truncating to 32 bits once ANY thread had
+            // been spawned anywhere — and `Digest::SHA1`, whose message schedule
+            // relies on that truncation, then produced a silently wrong digest.
+            self.check_push_element_type(target_name, &val)?;
+            let val = self.wrap_native_int_push_value(target_name, val);
             let target = self.env().get(target_name).cloned().unwrap_or(Value::NIL);
             // Track B/Track C: a `state @a` under an active thread context is a
             // shared `ContainerRef` cell. Push INTO the cell under its lock
@@ -186,6 +194,18 @@ impl Interpreter {
             return Ok(());
         }
 
+        // The declared element type governs the push whatever SHAPE the target
+        // has. It is checked and applied here, above the target dispatch, because
+        // a plain lexical does not stay a plain `Array` for a program's whole
+        // life: once any `start` runs, `shared_vars_active` wraps lexicals in a
+        // `ContainerRef` cell, which took the `!is_simple_array` branch below and
+        // skipped both. `my uint32 @W` therefore stopped truncating to 32 bits
+        // after the first thread spawned anywhere in the process — and since
+        // `Digest::SHA1`'s message schedule relies on that truncation, a `sha1`
+        // call after any `start` silently produced a WRONG digest.
+        self.check_push_element_type(target_name, &val)?;
+        let val = self.wrap_native_int_push_value(target_name, val);
+
         // TODO: compile to bytecode — non-simple-target push, blocked-by:
         // first-class container identity Phase 2 (closure-captured ContainerRef
         // arrays). See ledger §1.
@@ -239,42 +259,6 @@ impl Interpreter {
             return Ok(());
         }
 
-        // Check type constraint on the array variable.
-        // For Slip values, check each element individually.
-        if let Some(type_name) = self
-            .var_type_constraint_fast(target_name)
-            .map(|s| s.to_string())
-        {
-            // Owned clone of the Slip backing (a view guard's borrow cannot
-            // outlive the match), so the item refs stay valid for the loop.
-            let slip_items: Option<std::sync::Arc<Vec<Value>>> = match val.view() {
-                ValueView::Slip(items) => Some(items.clone()),
-                _ => None,
-            };
-            let items_to_check: Vec<&Value> = match &slip_items {
-                Some(items) => items.iter().collect(),
-                None => vec![&val],
-            };
-            for item in items_to_check {
-                if !self.type_matches_value(&type_name, item) {
-                    // A rejected element push reports "for an element of @a"
-                    // (matching rakudo and the interpreter's other array-mutator
-                    // paths), not the scalar "in assignment to @a" wording.
-                    return Err(crate::runtime::utils::type_check_element_typed_error(
-                        target_name,
-                        &type_name,
-                        item,
-                    ));
-                }
-            }
-        }
-
-        // A push onto a native integer array stores through the native slot, so
-        // the value wraps to the element width exactly as an assignment does
-        // (`my uint32 @W; @W.push(6535351809)` stores 2240384513). Without this,
-        // `@W` held out-of-range values and Digest::SHA1's message schedule
-        // (whose rotate relies on uint32 truncation) computed the wrong digest.
-        let val = self.wrap_native_int_push_value(target_name, val);
         let mut val_slot = Some(val);
         // Container identity (§3): append through the shared backing node —
         // no COW, no local-slot zeroing dance — so every by-value holder of
@@ -314,6 +298,44 @@ impl Interpreter {
         // into its local slot just above, so the caller's slot is coherent — a
         // pull would be redundant. (The interpreter-fallback push branches above,
         // for shared/shaped/non-simple-array targets, keep their conservative mark.)
+        Ok(())
+    }
+
+    /// Type-check a pushed value (or every element of a pushed `Slip`) against
+    /// the declared element type of `target_name`. A no-op for an untyped array.
+    fn check_push_element_type(
+        &mut self,
+        target_name: &str,
+        val: &Value,
+    ) -> Result<(), RuntimeError> {
+        let Some(type_name) = self
+            .var_type_constraint_fast(target_name)
+            .map(|s| s.to_string())
+        else {
+            return Ok(());
+        };
+        // Owned clone of the Slip backing (a view guard's borrow cannot
+        // outlive the match), so the item refs stay valid for the loop.
+        let slip_items: Option<std::sync::Arc<Vec<Value>>> = match val.view() {
+            ValueView::Slip(items) => Some(items.clone()),
+            _ => None,
+        };
+        let items_to_check: Vec<&Value> = match &slip_items {
+            Some(items) => items.iter().collect(),
+            None => vec![val],
+        };
+        for item in items_to_check {
+            if !self.type_matches_value(&type_name, item) {
+                // A rejected element push reports "for an element of @a"
+                // (matching rakudo and the interpreter's other array-mutator
+                // paths), not the scalar "in assignment to @a" wording.
+                return Err(crate::runtime::utils::type_check_element_typed_error(
+                    target_name,
+                    &type_name,
+                    item,
+                ));
+            }
+        }
         Ok(())
     }
 

--- a/t/native-array-push-after-start.t
+++ b/t/native-array-push-after-start.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A native-typed array truncates every stored value to its element width, and
+# that must not depend on whether the process has ever spawned a thread. The
+# VM's push op has a separate `shared_vars_active` branch -- taken from the
+# first `start` onwards, for the rest of the process -- which skipped both the
+# element type check and the native-width wrap. `my uint32 @W` therefore
+# stopped truncating after any `start` anywhere, and `Digest::SHA1`, whose
+# message schedule relies on that truncation, silently produced a wrong digest.
+
+sub build-uint32() {
+    my uint32 @W = 1, 2;
+    @W.push: 0x1_8589_8e01;   # one bit above 32 bits
+    @W[2]
+}
+
+is build-uint32(), 0x8589_8e01, 'uint32 array push truncates to 32 bits';
+
+await start { 1 + 1 };
+
+is build-uint32(), 0x8589_8e01,
+    'and still truncates after a thread has been spawned';
+
+my int8 @b;
+@b.push: 200;
+is @b[0], -56, 'int8 array push wraps into the signed range after a start';
+
+my uint8 @u;
+@u.push: 300, 301;
+is @u.join(','), '44,45', 'every value of a multi-value push is wrapped';
+
+# The element TYPE check lives on the same path and must survive too.
+my Int @typed;
+throws-like { @typed.push: "not an int" }, X::TypeCheck,
+    'a typed array still rejects a bad push after a start';


### PR DESCRIPTION
## The bug

```raku
sub build { my uint32 @W = 1, 2; @W.push: 0x1_8589_8e01; @W[2] }
say build();            # 2240384513  — truncated to 32 bits, correct
await start { 1 + 1 };
say build();            # 6535351809  — no longer truncated
```

The VM's array-push op has a separate branch for `shared_vars_active`, the flag
that latches on at the first thread spawn so concurrent `@a.push` calls
serialize through the atomic shared store. That branch pushed the value straight
into the container, skipping the two steps the single-threaded path applies
first: the declared **element type check** and the **native-width wrap**. A
second `ContainerRef` branch below skipped them for the same reason. The flag
never goes back to false, so one `start` anywhere disabled native truncation for
the rest of the process.

## Why it matters — a silent wrong digest

In the `Digest` distribution, `Digest::RIPEMD`'s `rmd160` runs the two halves of
each compression round in `start` blocks. After calling it, an **unrelated**
`Digest::SHA1::sha1` returned a wrong answer:

```
sha1("abc")            # a9993e364706816aba3e25717850c26c9cd0d89d   (correct)
rmd160("abc");
sha1("abc")            # 360737f72f3088e31056811549cdca1cb69b64e7   (WRONG)
```

`sha1-block` builds its message schedule as `my uint32 @W = $M; @W.push: … for
16..79`, and the words silently grew past 32 bits (`@W[19]` became
`0x1_8589_8e01`). `sha1("")` still looked right — an empty message has no bytes
to overflow with — so the corruption depended on the input.

## The fix

The check and the wrap move into helpers (`check_push_element_type`,
`wrap_native_int_push_value`) that every push path calls, so the declared
element type governs the push regardless of the target's shape or the process's
threading history.

## Tests

- New pin `t/native-array-push-after-start.t`: `uint32` truncation before and
  after a `start`, `int8` signed wrapping, multi-value push, and the element
  type check still rejecting a bad push. **Every assertion passes under rakudo.**
- `make test`: 2884 files, 27407 tests, PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)