### PR TITLE
fix(sequence): a generator's capture must not shadow a live lexical

### DIFF
--- a/news/2026-08/sequence-closure-env-does-not-shadow-a-live-lexical.md
+++ b/news/2026-08/sequence-closure-env-does-not-shadow-a-live-lexical.md
@@ -1,0 +1,72 @@
+# A sequence generator's captured env no longer shadows a live lexical
+
+`roast/integration/advent2012-day14.t` aborted after 3 of its 6 assertions under
+the real `Test` module with `X::Cannot::Empty` raised inside its own
+`is-prime-beta`, and passed under the native provider. The cause was neither in
+`Test.rakumod` nor in the test file: `use Test` merely *loaded* a module that
+contains `&CALLER::LEXICAL::("infix:<$op>")`, and that is enough to change how
+every closure in the process captures its environment.
+
+## What connects the two
+
+`REFLECTIVE_NAME_ACCESS_SEEN` (`src/opcode.rs`) is a process-global, monotonic
+flag: once any compiled chunk anywhere contains `EVAL`, a `CALLER::`/`OUTER::`
+read, a pseudo-stash lookup or a symbolic deref, `capture_closure_env` stops
+capturing a closure's *free variables* and captures the **whole environment by
+value** instead — it has to, because reflective code can ask for any name.
+`Test.rakumod`'s `cmp-ok` is such a chunk, so importing `Test` degrades every
+unrelated closure in the test file to a whole-env snapshot.
+
+That snapshot is harmless for names the closure actually closes over: those are
+boxed into shared `ContainerRef` cells, so later mutation is tracked. It is not
+harmless for the bulk names dragged along with them, because a sequence
+generator's env is **merged over** the live environment before its body runs
+(`sequence_closure_step`, and the seed pre-check in `eval_sequence`) rather than
+replacing it. Every captured name therefore shadows the caller's current
+binding.
+
+A self-referential sequence is exactly where that goes wrong:
+
+```raku
+my @primes = 2, 3, 5, -> $p { ($p+2, $p+4 ... &is-prime-beta)[*-1] } ... *;
+sub is-prime-beta($n) { $n %% none @primes ...^ * > sqrt $n }
+```
+
+The generator is created while `@primes` is still the hoisted empty array. Eager
+generation re-enters it, reads the empty `@primes`, and raises — which is
+expected and already handled: `deferred_after_generator_error` hands back a lazy
+closure sequence precisely so the generator re-runs once `@primes` is bound. But
+on that later pull the stale snapshot was re-imposed on the live env, so
+`is-prime-beta` still saw an empty `@primes` and raised again, this time with
+nowhere to defer to. `@primes` is not a free variable of the generator (the
+generator only mentions `&is-prime-beta`), so it was never a genuine capture —
+only bulk.
+
+## The fix
+
+Both merge sites now go through `install_sequence_closure_env`. A captured entry
+is installed unconditionally when it is a genuine capture — a free variable of
+the closure, an `owned_captures` loop binding, or an `authoritative_captures`
+vouch — or when it is not a *plain user lexical*
+(`crate::env::is_plain_user_lexical`: the system names, dynamics, specials and
+shadow-meta a closure body can reach through dedicated opcodes the free-var scan
+cannot see). A plain user lexical the closure does not close over is installed
+only when the live env has no binding of its own, so an escaped closure keeps
+today's behaviour while a live binding is left alone.
+
+This is the same classification the non-reflective capture path already uses to
+decide what to drop; the merge simply had no equivalent guard.
+
+`roast/integration/advent2012-day14.t` now passes 6/6 under the real `Test`
+module. Pin: `t/sequence-self-reference-under-reflective-capture.t`, which flips
+the reflective flag with an uncalled `CALLER::` routine so the shape reproduces
+without loading a module.
+
+## Worth carrying forward
+
+**A bug that appears only when a module is loaded is not necessarily about that
+module.** Bisecting `Test.rakumod` down to a single routine — by top-level
+brace-balanced chunks, since truncating the file at a line number breaks parsing
+long before it changes behaviour — showed the trigger was `cmp-ok`, and `cmp-ok`
+is never called. Merely *compiling* it set a process-global flag. Any measurement
+that assumes the module's routines have to run to matter will miss this class.

--- a/src/runtime/sequence.rs
+++ b/src/runtime/sequence.rs
@@ -33,6 +33,51 @@ impl Interpreter {
         err
     }
 
+    /// Merge a sequence generator/predicate closure's captured env over the LIVE
+    /// env before running its body.
+    ///
+    /// The merge (rather than a replace) is what lets the body see the enclosing
+    /// scope, but it means every captured name *shadows* the caller's current
+    /// binding. That is right for names the closure genuinely closes over and
+    /// wrong for the bulk names a *reflective* program's whole-env snapshot drags
+    /// along ([`Interpreter::capture_closure_env`] falls back to `clone_env()`
+    /// once any chunk in the process uses `EVAL`/`CALLER::`/symbolic deref — and
+    /// merely `use`-ing a module that contains one, such as the real
+    /// `Test.rakumod`'s `cmp-ok`, is enough).
+    ///
+    /// The bulk names are stale by construction here: a self-referential sequence
+    /// (`my @primes = 2, 3, 5, -> $p { … &is-prime-beta … } … *`) creates its
+    /// generator while `@primes` is still the hoisted empty array, so re-imposing
+    /// the snapshot on every later pull hides the assigned list from any routine
+    /// the body calls. Install a *plain user lexical* that the closure does not
+    /// close over only when the live env has no binding of its own — exactly the
+    /// classification [`crate::env::is_plain_user_lexical`] exists for.
+    fn install_sequence_closure_env(
+        &mut self,
+        data: &crate::value::SubData,
+        env: &crate::env::Env,
+    ) {
+        let genuine: Option<std::collections::HashSet<Symbol>> =
+            data.compiled_code.as_ref().map(|cc| {
+                cc.free_var_syms
+                    .iter()
+                    .chain(data.owned_captures.iter())
+                    .chain(data.authoritative_captures.iter())
+                    .copied()
+                    .collect()
+            });
+        for (k, v) in env.iter() {
+            if let Some(genuine) = &genuine
+                && !genuine.contains(k)
+                && k.with_str(crate::env::is_plain_user_lexical)
+                && self.env.contains_key_sym(*k)
+            {
+                continue;
+            }
+            self.env.insert_sym(*k, v.clone());
+        }
+    }
+
     fn collect_sequence_args_fixed(
         result: &[Value],
         arity: usize,
@@ -219,10 +264,8 @@ impl Interpreter {
                         .unwrap_or_default();
                     // Use the mutable closure env so side-effects persist across
                     // iterations (e.g. `my $i = 0; { ++$i } ... *`).
-                    if let Some(env) = closure_env.as_ref() {
-                        for (k, v) in env.iter() {
-                            self.env.insert_sym(*k, v.clone());
-                        }
+                    if let Some(env) = closure_env.clone() {
+                        self.install_sequence_closure_env(&data, &env);
                     }
 
                     // Bind parameters
@@ -853,9 +896,8 @@ impl Interpreter {
 
                 for (i, _) in seeds.iter().enumerate() {
                     let saved = self.env.clone();
-                    for (k, v) in &data.env {
-                        self.env.insert_sym(*k, v.clone());
-                    }
+                    let captured = data.env.clone();
+                    self.install_sequence_closure_env(&data, &captured);
 
                     // Collect the appropriate number of previous values up to position i+1
                     let args: Vec<Value> = if i + 1 < arity {

--- a/t/sequence-self-reference-under-reflective-capture.t
+++ b/t/sequence-self-reference-under-reflective-capture.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A self-referential sequence — the generator calls a routine that reads the
+# very array the sequence is bound to — must keep working when the program
+# contains reflective name access (`CALLER::` / `EVAL` / symbolic deref).
+#
+# Such a program makes every closure capture its whole environment by value, and
+# the generator is created while `@primes` is still the hoisted empty array. If
+# that snapshot is re-imposed on the live environment at each pull, the routine
+# the generator calls sees the empty array instead of the assigned sequence.
+
+plan 4;
+
+# Never called: its only job is to make reflective name access possible, which
+# is process-global.
+sub uses-caller() { CALLER::<$x> }
+
+my @primes = 2, 3, 5, -> $p { ($p + 2, $p + 4 ... &is-prime)[*-1] } ... *;
+sub is-prime($n) { $n %% none @primes ...^ * > sqrt $n }
+
+is-deeply @primes[0 .. 5].List, (2, 3, 5, 7, 11, 13),
+    'self-referential sequence extends past its eager seeds';
+is-deeply (2 .. 20).grep(&is-prime).List, (2, 3, 5, 7, 11, 13, 17, 19).List,
+    'the routine reading the sequence sees the assigned list';
+
+# An ordinary generator delegating to a named routine is unaffected.
+my @powers = 1, 2, -> $p { dbl($p) } ... *;
+sub dbl($p) { $p * 2 }
+is-deeply @powers[0 .. 4].List, (1, 2, 4, 8, 16),
+    'generator delegating to a named routine still works';
+
+# A genuine capture must still shadow a same-named caller lexical.
+my $step = 10;
+my @stepped = do {
+    my $step = 3;
+    (1, { $^a + $step } ... * > 10);
+};
+is-deeply @stepped.List, (1, 4, 7, 10, 13),
+    'the generator keeps its own captured $step, not the outer one';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -824,6 +824,30 @@ Three things worth carrying forward:
   other users of that compile path recompile closure bodies where the live frame
   IS the routine.
 
+### `integration/advent2012-day14.t` (2026-08-05): the trigger was a routine that never ran
+
+Closed 6/6 —
+`news/2026-08/sequence-closure-env-does-not-shadow-a-live-lexical.md`. The file
+aborted with `X::Cannot::Empty` inside its own `is-prime-beta`, and the cause was
+that `Test.rakumod` *contains* `&CALLER::LEXICAL::(…)` in `cmp-ok`. Compiling
+that routine sets the process-global `REFLECTIVE_NAME_ACCESS_SEEN`, which makes
+`capture_closure_env` snapshot the **whole env by value** for every closure in
+the program; a sequence generator merges its capture over the live env, so the
+self-referential `my @primes = …, -> $p { … } … *` kept seeing the hoisted empty
+array on every deferred pull.
+
+Two things this batch adds to the campaign's method:
+
+- **A file that only fails "because a module is loaded" may not be about
+  anything the module *does*.** `cmp-ok` is never called here. Look for
+  compile-time global flags, not just executed code.
+- **Bisect the module by brace-balanced top-level chunks, not by line count.**
+  Truncating `Test.rakumod` at a line number breaks parsing (or drops
+  `_init_vars`, which file scope calls at line 41) long before it changes
+  behaviour; every prefix cut gave a useless answer. Splitting into 248
+  chunks and always keeping chunks 0-47 plus the `_init_vars` chunk made the
+  bisect converge in six runs.
+
 ### Six files closed on 2026-08-04, and none of the causes was in `Test`
 
 | file | assertions | cause | fix |


### PR DESCRIPTION
`roast/integration/advent2012-day14.t` aborted after 3 of its 6 assertions under
the real `Test` module (`MUTSU_REAL_TEST=1`) with `X::Cannot::Empty` raised inside
its own `is-prime-beta`, and passed under the native provider. The cause was in
neither `Test.rakumod` nor the test file.

## Why loading a module changed an unrelated closure

`REFLECTIVE_NAME_ACCESS_SEEN` is a process-global, monotonic flag: once any
compiled chunk anywhere contains `EVAL`, a `CALLER::`/`OUTER::` read, a
pseudo-stash lookup or a symbolic deref, `capture_closure_env` captures a
closure's **whole environment by value** instead of just its free variables — it
has to, because reflective code can ask for any name. `Test.rakumod`'s `cmp-ok`
contains `&CALLER::LEXICAL::("infix:<$op>")`, so *compiling* it (it is never
called here) degrades every unrelated closure in the test file.

A sequence generator's captured env is **merged over** the live env before its
body runs rather than replacing it, so every captured name shadows the caller's
current binding. For a self-referential sequence that is fatal:

```raku
my @primes = 2, 3, 5, -> $p { ($p+2, $p+4 ... &is-prime-beta)[*-1] } ... *;
sub is-prime-beta($n) { $n %% none @primes ...^ * > sqrt $n }
```

The generator is created while `@primes` is still the hoisted empty array. Eager
generation re-enters it and raises — which is already handled, since
`deferred_after_generator_error` hands back a lazy sequence so the generator
re-runs once `@primes` is bound. But the stale snapshot was re-imposed on that
later pull, so `is-prime-beta` still saw an empty `@primes`. `@primes` is not a
free variable of the generator (it only mentions `&is-prime-beta`), so it was
never a genuine capture.

## The fix

Both merge sites go through a new `install_sequence_closure_env`. A captured
entry is installed unconditionally when it is a genuine capture (a free variable,
an `owned_captures` loop binding, or an `authoritative_captures` vouch) or when
it is not a *plain user lexical* (`crate::env::is_plain_user_lexical` — the
system names, dynamics, specials and shadow-meta a body reaches through
dedicated opcodes the free-var scan cannot see). A plain user lexical the closure
does not close over is installed only when the live env has no binding of its
own, so an escaped closure keeps today's behaviour. This is the same
classification the non-reflective capture path already uses; the merge had no
equivalent guard.

## Verification

- `roast/integration/advent2012-day14.t`: 3/6 abort → **6/6** under `MUTSU_REAL_TEST=1`.
- Pin `t/sequence-self-reference-under-reflective-capture.t` (flips the reflective
  flag with an uncalled `CALLER::` routine, so it reproduces without a module);
  verified to fail without the fix (`X::Cannot::Empty`, 0 of 4 planned tests run)
  and to match `raku`'s output with it.
- Local `make test` (2879 files) PASS, `make roast` (1435 files) PASS, batteries
  gate 153/158 PASS, `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)