### PR TITLE
docs(todo): record the measured @vars collision that blocks a roast file

### DIFF
--- a/todo/tickets/module-file-scope-array-and-hash-still-share-the-caller.md
+++ b/todo/tickets/module-file-scope-array-and-hash-still-share-the-caller.md
@@ -50,6 +50,42 @@ file-scope `my @a`/`my %h` **and** a consumer that declares the same name.
 `todo/tickets/vendor-real-test-module.md`; the other eight of its file-scope
 lexicals are scalars and are fixed.
 
+## A measured instance: `roast/integration/99problems-41-to-50.t` (2026-08-05)
+
+That predicted collision is real and it costs a whole roast file. Under
+`MUTSU_REAL_TEST=1` the file aborts after 1 of its 9 assertions with
+`unknown variable: A`, raised from the test's own grammar action:
+
+```raku
+method truth-table($expr, $actions) {
+    my @vars = @( $/.ast<vars> );          # <-- same name as Test.rakumod's
+    sub the-truth(@vals) {
+        our %*VAR = @vars Z=> @vals;       # built from the WRONG @vars
+        ...
+    }
+}
+```
+
+`%*VAR` therefore comes out empty and the `term:sym<var>` closure's
+`%*VAR{$id} // die "unknown variable: $id"` fires. Renaming the *test's*
+`@vars` to `@varz` makes the file pass, which is the confirmation — the file is
+otherwise unmodified and `raku` passes it as written.
+
+Bisecting `Test.rakumod` converges on `sub _push_vars` (`@vars.push: item [...]`),
+i.e. the declaration alone is not enough; it takes a routine that mutates the
+array by name. Two notes on doing that bisect, since the obvious method does not
+work:
+
+- **Do not truncate `Test.rakumod` at a line number.** File scope calls
+  `_init_vars()` at line 41 and that routine is declared at line 867, so every
+  prefix cut either fails to parse or dies on `Unknown function: _init_vars`
+  long before it changes behaviour.
+- Split the file into brace-balanced top-level chunks (248 of them) and always
+  keep chunks 0-47 plus the `_init_vars` chunk (220). Then a keep-range or
+  drop-range bisect converges in about six runs.
+
+So the file is blocked on this ticket, not on anything in `Test`.
+
 Pin when fixed: extend `t/module-file-scope-lexical.t` (and
 `t/lib/UnitFileLexical.rakumod`) with the array/hash cases that were written and
 then removed when the slice was scoped to scalars.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -836,17 +836,30 @@ the program; a sequence generator merges its capture over the live env, so the
 self-referential `my @primes = …, -> $p { … } … *` kept seeing the hoisted empty
 array on every deferred pull.
 
+`integration/99problems-41-to-50.t` was taken next and is **blocked, not
+fixable here**: its grammar action declares `my @vars`, which is the same name
+as `Test.rakumod`'s file-scope `my @vars`, and the two share one env key. That
+is exactly the case
+`todo/tickets/module-file-scope-array-and-hash-still-share-the-caller.md`
+predicted would be the one that matters; the measured instance is recorded
+there. Renaming the *test's* `@vars` makes the file pass, so nothing else is
+wrong with it.
+
 Two things this batch adds to the campaign's method:
 
 - **A file that only fails "because a module is loaded" may not be about
-  anything the module *does*.** `cmp-ok` is never called here. Look for
-  compile-time global flags, not just executed code.
+  anything the module *does*.** `cmp-ok` is never called in `advent2012-day14.t`
+  and `_push_vars` is never called in `99problems-41-to-50.t`; in both cases it
+  was enough that the routine exists. Look for compile-time global flags and
+  name collisions, not just executed code.
 - **Bisect the module by brace-balanced top-level chunks, not by line count.**
   Truncating `Test.rakumod` at a line number breaks parsing (or drops
   `_init_vars`, which file scope calls at line 41) long before it changes
   behaviour; every prefix cut gave a useless answer. Splitting into 248
-  chunks and always keeping chunks 0-47 plus the `_init_vars` chunk made the
-  bisect converge in six runs.
+  chunks and always keeping chunks 0-47 plus the `_init_vars` chunk made both
+  bisects converge in about six runs. Two directions are worth having: keep
+  `0-47, 220, a..b` when the file needs no `Test` routines, and drop `a..b` from
+  the full set when it does.
 
 ### Six files closed on 2026-08-04, and none of the causes was in `Test`
 


### PR DESCRIPTION
Documentation only.

`roast/integration/99problems-41-to-50.t` aborts after 1 of its 9 assertions
under `MUTSU_REAL_TEST=1` with `unknown variable: A`, raised from the test's own
grammar action. The cause is that the action declares `my @vars` — the same name
as `Test.rakumod`'s file-scope `my @vars` — and a module's file-scope `@`/`%`
lexical still shares one env key with the loading scope. Renaming the *test's*
`@vars` to `@varz` makes the file pass, so nothing else is wrong with it.

That is exactly the case `module-file-scope-array-and-hash-still-share-the-caller.md`
already predicted ("`Test.rakumod`'s `@vars` is the one that matters"), so the
measured instance is recorded in that ticket rather than filed as a new one. The
bisect converges on `sub _push_vars` (`@vars.push: item [...]`): the declaration
alone is not enough, it takes a routine that mutates the array by name.

Also records the bisect method, since the obvious one does not work:
`Test.rakumod` cannot be truncated at a line number — file scope calls
`_init_vars()` at line 41 and that routine is declared at line 867, so every
prefix cut fails to parse or dies on `Unknown function: _init_vars` long before
it changes behaviour. Splitting the file into brace-balanced top-level chunks and
always keeping chunks 0-47 plus the `_init_vars` chunk converges in about six
runs, and it is what found the cause of #5914 too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)