### PR TITLE
perf(dispatch): a user operator runs its compiled body

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -110,8 +110,9 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 17/51 slices merged. Next slice: C6d-1 (C6a, C6b and C6c landed; C6 and C6d
-are both subdivided below, C6d from a measurement of where its sites are actually reached).**
+**Current progress: 17/51 slices merged. Next slice: attach plan-compiled bytecode to multi
+candidates — the blocker that keeps C6d-1 open (C6a, C6b and C6c landed; C6 and C6d are both
+subdivided below, C6d from a measurement of where its sites are actually reached).**
 
 The migration is complete only when every required box below is checked and the completion gates
 at the end pass. The order within a phase is intentional. A later phase may start when its stated
@@ -197,9 +198,24 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
       `news/2026-08/multi-deferral-runs-the-compiled-candidate.md`, which also records why the
       general `compile_and_call_function_def` entry cannot be used here (it re-pushes the
       multi-dispatch frame the chain owns, and the chain then defers to the same candidate
-      forever). Remaining callers: `builtins_operators_fallback` (user operators),
-      `builtins_operators_infix` (reduce), `builtins_operators_coerce`, `accessors_state`,
-      `main_args` (`MAIN`).
+      forever). Every remaining caller then followed — `builtins_operators_fallback` (user
+      operators), `builtins_operators_infix` (reduce), `builtins_operators_coerce` (hyper),
+      `accessors_state`, `main_args` (`MAIN`) — through one shared
+      `call_routine_def` entry, measured at -13.7% instructions / -22% wall on a reduce over a
+      user multi operator (`news/2026-08/user-operators-run-their-compiled-body.md`, which also
+      records that the *debug* build's instruction count inverts that ranking and must not be
+      used to judge a dispatch-path change). Two things keep the box open:
+      - `call_function_def` still answers one gated shape,
+        `multi_candidate_state_forces_interpreter`: a `state`-bearing candidate of a
+        signature-alternates name (`multi f(A $x) | (B $x) { state $c }`) is one routine with
+        one `state` cell. The compiler already threads a shared `state_group` into every
+        alternate's compiled body, but `vm_register_sub_ops` attaches plan-compiled bytecode
+        only to non-multi candidates (`if *multi { continue; }`), so a multi candidate arrives
+        with `compiled: None` and an on-the-fly compile per alternate fragments the cell
+        (`t/multi-signature-alternates.t`). **Attaching each compiled routine key to its multi
+        candidate retires the gate, the entry, and this half of the box.**
+      - `calls.rs:exec_call` (48 hits) still holds an inlined copy of `call_function_def`'s
+        body, including its own `run_block(&def.body)`.
     - [ ] **C6d-2 — grammar token/rule bodies** (`dispatch.rs:eval_token_def`,
       `regex_token_resolve.rs`): 956 of the 1148 hits, but those `FunctionDef`s carry a regex
       body, so scope this against ADR-0009's execution model rather than the OTF gate.
@@ -378,6 +394,16 @@ bytecode over compiling `data.body` on the fly, so no dispatch path executes an 
 these code objects. The three near-identical `SubData` literals behind `make_sub`,
 `make_sub_with_id`, and `make_sub_owning` collapsed into one `new_code_object` core in the
 process.
+
+Every caller of the interpreter routine entry `call_function_def` now invokes the routine's
+bytecode through one shared `call_routine_def`: the multi-deferral chain first, then the user
+`prefix:`/`postfix:` operators, the reduce and hyper steps over a user `infix:`, `reduce` given
+the operator as a routine value, and the selected `MAIN` candidate. What that removes is a
+per-call *compile* of the routine's AST body, not a tree walk. `call_function_def` itself
+survives only for `multi_candidate_state_forces_interpreter`, and its remaining blocker is
+narrow and named: multi candidates never receive plan-compiled bytecode, so a
+signature-alternates candidate cannot reach dispatch with the shared `state_group`-scoped body
+the compiler already produced for it.
 
 `RegisterClass` and `RegisterRole` now likewise index typed class/role declaration-plan pools for
 both source-order declarations and hoisted forward-reference shells. The VM no longer discovers

--- a/news/2026-08/user-operators-run-their-compiled-body.md
+++ b/news/2026-08/user-operators-run-their-compiled-body.md
@@ -1,0 +1,79 @@
+# A user-defined operator runs its compiled body
+
+ADR-0019 C6d-1, second slice. The first one moved the multi-deferral caller off
+the interpreter entry `call_function_def`; this one moves every remaining
+caller. `call_function_def`'s body run is `run_block(&def.body)` ->
+`run_block_raw` -> `compile_block_raw`: **the routine's AST body was compiled
+afresh on every call.** These callers now run the routine's bytecode instead —
+the body the declaration plan attached, or one memoized on-the-fly compile per
+body.
+
+The callers, all of which had already resolved the exact candidate they wanted:
+
+| caller | what reaches it |
+| --- | --- |
+| `builtins_operators_fallback` | a user `prefix:<>` / `postfix:<>` operator |
+| `builtins_operators_infix` | a reduce step over a user `infix:<>` |
+| `builtins_operators_coerce` | a hyper step over a user `infix:<>` |
+| `accessors_state` (`call_user_routine_direct`) | `reduce` given the operator as a routine value; the flip-flop infix fallback |
+| `main_args` | the selected `MAIN` candidate |
+
+Measured on a `[mm] 1 .. 200` reduce over a two-candidate user
+`multi sub infix:<mm>`, release build, pinned to one core: **15.44G -> 13.33G
+instructions (-13.7%)** and 1.26s -> 0.98s wall (-22%).
+
+## Two measurement notes worth keeping
+
+**Measure the release build.** The same A/B on the *debug* build says the
+opposite — 13.50G -> 15.46G, a 14% *regression*. Debug does not inline the
+compiled entry's per-call bookkeeping while `compile_block_raw` stays
+comparatively cheap, so the debug numbers invert the real ranking. This is the
+wall-clock warning in CLAUDE.md applying to instruction counts too: the
+`MUTSU_VM_STATS` *counters* are optimization-independent, a dispatch-path
+instruction count is not.
+
+**Do not use `compile_and_call_function_def`.** That general routine entry
+pushes a samewith context and a fresh multi-dispatch frame before running the
+body. Here the caller has already resolved its candidate, so building a
+candidate list per call is pure overhead, and it A/B'd measurably worse than
+`call_compiled_function_named` — the entry just below that setup, which also
+matches `call_function_def`'s semantics exactly (it pushed neither stack). The
+multi-deferral slice avoided the same entry for a stronger, correctness reason
+(it re-pushed the frame the deferral chain owns).
+
+While there, `otf_compile_function_def`'s cache key stopped being a SipHash over
+the body fingerprint plus a freshly allocated package `String`. Both halves are
+already integers — the fingerprint is memoized on the def and the package is an
+interned `Symbol` — so they are mixed arithmetically, and the package string is
+resolved only on a cache miss.
+
+## What still reaches the interpreter entry, and why
+
+`call_function_def` survives for exactly one gated shape, so C6d-1 is not yet
+complete. `multi_candidate_state_forces_interpreter` covers a `state`-bearing
+candidate of a name declared with signature *alternates*:
+
+```
+multi sub postfix:<CNT> (AltA $x) | (AltB $x) { state $counter = 0; ++$counter }
+```
+
+Those alternates are ONE routine with ONE `state` cell, shared through a
+compile-time `state_group` that the compiler already threads into every
+alternate's compiled body. But `vm_register_sub_ops` attaches plan-compiled
+bytecode only to *non-multi* candidates (`if *multi { continue; }`), so a multi
+candidate reaches dispatch with `compiled: None` and gets compiled on the fly
+under its own signature — one cell per alternate, which
+`t/multi-signature-alternates.t` catches. Attaching each compiled routine key to
+its multi candidate retires both the gate and the interpreter entry; that is the
+next C6d-1 slice.
+
+## Pinned
+
+`t/user-operator-compiled-body.t` (26 assertions, every expectation taken from
+`raku` first): the prefix/postfix/infix forms, reduce, triangular reduce, hyper,
+cross- and zip-metaops, `reduce(&infix:<...>)`, a two-candidate multi operator
+resolving per step, `is rw` writeback, a `state` variable across reduces, a
+declared default, a return constraint, a `where`-constrained candidate, a `die`
+propagating out, `$?PACKAGE` inside a package-scoped operator, and
+`.candidates`. The gated alternates shape cannot be raku-verified — `raku` does
+not accept that syntax — so `t/multi-signature-alternates.t` keeps pinning it.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -59,7 +59,7 @@ impl Interpreter {
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
         if let Some(def) = self.resolve_function_with_alias(full_name, &args) {
-            return self.call_function_def(&def, &args);
+            return self.call_routine_def(&def, args);
         }
         if let Some(err) = self.take_pending_dispatch_error() {
             return Err(err);
@@ -73,7 +73,7 @@ impl Interpreter {
         if let Some(pos) = full_name.rfind("::") {
             let short_name = &full_name[pos + 2..];
             if let Some(def) = self.resolve_function_with_alias(short_name, &args) {
-                return self.call_function_def(&def, &args);
+                return self.call_routine_def(&def, args);
             }
             let env_short = format!("&{}", short_name);
             if let Some(callable) = self.env.get(&env_short).cloned() {

--- a/src/runtime/builtins_operators_coerce.rs
+++ b/src/runtime/builtins_operators_coerce.rs
@@ -250,7 +250,7 @@ impl Interpreter {
             let pair_result = if let Some(v) =
                 self.resolve_function_with_types(&infix_name, &[l.clone(), r.clone()])
             {
-                self.call_function_def(&v, &[l, r])?
+                self.call_routine_def(&v, vec![l, r])?
             } else if inner == "=~=" || inner == "\u{2245}" {
                 // `=~=` needs $*TOLERANCE (self), so the static reduction table
                 // cannot host it (its `op=` catch-all would also mis-strip it).

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -19,7 +19,7 @@ impl Interpreter {
             .and_then(|s| s.strip_suffix('>'))
         {
             if let Some(def) = self.resolve_function_with_alias(name, args) {
-                return self.call_function_def(&def, args);
+                return self.call_routine_def(&def, args.to_vec());
             }
             if let Some(err) = self.take_pending_dispatch_error() {
                 return Err(err);
@@ -132,7 +132,7 @@ impl Interpreter {
             .and_then(|s| s.strip_suffix('>'))
         {
             if let Some(def) = self.resolve_function_with_alias(name, args) {
-                return self.call_function_def(&def, args);
+                return self.call_routine_def(&def, args.to_vec());
             }
             if let Some(err) = self.take_pending_dispatch_error() {
                 return Err(err);

--- a/src/runtime/builtins_operators_infix.rs
+++ b/src/runtime/builtins_operators_infix.rs
@@ -399,7 +399,7 @@ impl Interpreter {
             let infix_name = format!("infix:<{}>", op);
             if let Some(def) = self.resolve_function_with_types(&infix_name, &pair_args) {
                 crate::trace::trace_log!("call", "call_infix_routine dispatch def: {}", infix_name);
-                acc = self.call_function_def(&def, &pair_args)?;
+                acc = self.call_routine_def(&def, pair_args)?;
                 continue;
             }
             if let Some(callable) = self.env.get(&format!("&{}", infix_name)).cloned()
@@ -464,7 +464,7 @@ impl Interpreter {
                         "call_infix_routine fallback dispatch def: {}",
                         expr_infix_name
                     );
-                    acc = self.call_function_def(&def, &expr_args)?;
+                    acc = self.call_routine_def(&def, expr_args)?;
                     continue;
                 }
                 if let Some(callable) = self.env.get(&format!("&{}", expr_infix_name)).cloned()

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -159,8 +159,22 @@ impl Interpreter {
         }
     }
 
-    /// Call a specific FunctionDef directly, bypassing the built-in function dispatch.
-    /// Used for user-defined operator overrides.
+    /// Run a resolved routine's AST body through a fresh per-call compile.
+    ///
+    /// **This is not the routine entry point.** Every caller that used to reach it
+    /// now calls `call_routine_def`, which runs the routine's bytecode
+    /// (ADR-0019 C6d-1). It survives for exactly one gated case:
+    /// `multi_candidate_state_forces_interpreter` — a `state`-bearing candidate of
+    /// a name declared with signature *alternates*
+    /// (`multi f(A $x) | (B $x) { state $c }`). Those alternates are ONE routine
+    /// with ONE `state` cell, shared via a compile-time `state_group`, but
+    /// `vm_register_sub_ops` attaches plan-compiled bytecode only to non-multi
+    /// candidates, so each alternate would otherwise be compiled on the fly under
+    /// its own signature and get its own cell (`t/multi-signature-alternates.t`).
+    ///
+    /// TODO: compile to bytecode. Attaching each compiled routine key to its multi
+    /// candidate lets the alternates share the plan's `state_group`-scoped body,
+    /// which retires both the gate and this function.
     pub(crate) fn call_function_def(
         &mut self,
         def: &FunctionDef,

--- a/src/runtime/main_args.rs
+++ b/src/runtime/main_args.rs
@@ -521,7 +521,7 @@ impl Interpreter {
             .insert("*USAGE".to_string(), Value::str(usage_text));
         self.mark_readonly("$*USAGE");
         self.mark_readonly("*USAGE");
-        match self.call_function_def(candidate, &args) {
+        match self.call_routine_def(candidate, args) {
             Ok(_) => Ok(()),
             Err(e) if e.return_value.is_some() => Ok(()),
             Err(e) if e.message.is_empty() => Ok(()),

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -128,17 +128,22 @@ impl Interpreter {
         &mut self,
         def: &crate::ast::FunctionDef,
     ) -> Arc<CompiledFunction> {
-        let pkg = def.package.resolve();
         let fingerprint = def.body_fingerprint();
-        let cache_key = {
-            let mut hasher = std::hash::DefaultHasher::new();
-            std::hash::Hash::hash(&fingerprint, &mut hasher);
-            std::hash::Hash::hash(&pkg, &mut hasher);
-            std::hash::Hasher::finish(&hasher)
-        };
+        // The key discriminates (body, defining package), and both halves are
+        // already integers: the fingerprint is memoized on the def, and the
+        // package is an interned `Symbol`, so its id identifies its string
+        // exactly. Mixing them is a couple of ALU ops.
+        //
+        // It used to SipHash the fingerprint plus a freshly allocated package
+        // `String`. That is per *call* for a caller with no plan-attached
+        // bytecode — a user `infix:` operator in a reduce recompiled nothing but
+        // still paid the hash on every step, which profiled as 2.6% of a
+        // `[mm] 1 .. 200` run (ADR-0019 C6d-1).
+        let cache_key = fingerprint ^ (def.package.id() as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
         if let Some(cached) = self.otf_compile_cache.get(&cache_key) {
             return cached.clone();
         }
+        let pkg = def.package.resolve();
         let cc = {
             let mut compiler = crate::compiler::Compiler::new();
             if !pkg.is_empty() && pkg != "GLOBAL" {
@@ -240,6 +245,46 @@ impl Interpreter {
         }
 
         result
+    }
+
+    /// Call an *already resolved* routine definition as bytecode, from a runtime
+    /// caller that owns no `CompiledFns` table of its own — a user-defined
+    /// operator, a reduce or hyper step over one, or `MAIN`.
+    ///
+    /// This is the replacement for the interpreter entry `call_function_def`,
+    /// whose body run was `run_block(&def.body)`: not a tree walk, but a fresh
+    /// compile of the routine's AST on *every* call (ADR-0019 C6d-1). It runs the
+    /// bytecode the declaration plan already attached to the routine, falling back
+    /// to one memoized on-the-fly compile when the plan attached none.
+    ///
+    /// Deliberately NOT `compile_and_call_function_def`, for a weaker version of
+    /// the reason the multi-deferral caller avoids it: that entry pushes a samewith
+    /// context and a fresh *multi-dispatch frame*, and building a candidate list per
+    /// call is pure overhead here, because the caller has already resolved the
+    /// candidate it wants. A/B'd on a reduce over a two-candidate user `infix:`, it
+    /// cost measurably more than `call_compiled_function_named` — the entry just
+    /// below that setup, which also matches the semantics of the interpreter entry
+    /// this replaces exactly (`call_function_def` pushed neither stack).
+    pub(crate) fn call_routine_def(
+        &mut self,
+        def: &crate::ast::FunctionDef,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        // `as_str`, not `resolve`: the latter allocates a `String` per call.
+        let pkg = def.package.as_str();
+        let name = def.name.as_str();
+        // The one shape whose `state` cell an on-the-fly compile would fragment: a
+        // state-bearing candidate of a signature-alternates name. See
+        // `Interpreter::call_function_def`, which exists for this case alone.
+        if self.multi_candidate_state_forces_interpreter(name, def) {
+            return loan_env!(self, call_function_def(def, &args));
+        }
+        let empty_fns = CompiledFns::default();
+        let cf = match &def.compiled {
+            Some(compiled) => Arc::clone(compiled),
+            None => self.otf_compile_function_def(def),
+        };
+        self.call_compiled_function_named(&cf, args, &empty_fns, pkg, name)
     }
 
     /// Check if a function name is handled by the interpreter's Rust code

--- a/t/user-operator-compiled-body.t
+++ b/t/user-operator-compiled-body.t
@@ -1,0 +1,90 @@
+use Test;
+
+# ADR-0019 C6d-1. A user-defined operator, a reduce/hyper step over one, and a
+# `MAIN` candidate used to be invoked through the interpreter entry
+# `call_function_def`, whose body run was `run_block(&def.body)` -- a fresh
+# compile of the routine's AST on every call. They now run the routine's
+# bytecode; `call_function_def` survives only for the gated case named below.
+#
+# Every expectation below was taken from `raku` first. The one shape that
+# deliberately stays on the interpreter entry -- a state-bearing candidate of a
+# signature-alternates name -- cannot be verified against `raku`, which does not
+# accept that syntax; `t/multi-signature-alternates.t` pins it instead.
+
+plan 26;
+
+sub prefix:<dbl>($x) { $x * 2 }
+sub postfix:<!>($n) { [*] 1..$n }
+sub infix:<myop>($a, $b) { $a + $b * 2 }
+
+is dbl 21, 42, 'user prefix operator';
+is 5!, 120, 'user postfix operator';
+
+# The reduce/hyper/cross/zip metaoperator forms over a user infix: each step
+# resolves the candidate itself and then invokes it directly.
+is ([myop] 1, 2, 3), 11, 'reduce over a user infix operator';
+is (1, 2, 3).reduce(&infix:<myop>), 11, 'reduce with the operator as a routine value';
+is (my @l = (1, 2, 3)) >>myop<< (my @r = (10, 20, 30)), (21, 42, 63), 'hyper over a user infix';
+is (@l Xmyop @r).elems, 9, 'cross-metaop over a user infix';
+is ((1, 2) Zmyop (10, 20)), (21, 42), 'zip-metaop over a user infix';
+is ([\myop] 1, 2, 3), (1, 5, 11), 'triangular reduce over a user infix';
+
+# A *multi* operator is the shape that actually reached the interpreter entry:
+# `resolve_function_with_types` picks the candidate, so the invocation had no
+# dispatch of its own left to do.
+multi sub infix:<mm>(Int $a, Int $b) { $a * 10 + $b }
+multi sub infix:<mm>(Str $a, Str $b) { "$a|$b" }
+
+is 1 mm 2, 12, 'multi user infix, Int candidate';
+is "a" mm "b", 'a|b', 'multi user infix, Str candidate';
+is ([mm] 1, 2, 3), 123, 'reduce picks the Int candidate at every step';
+is ([mm] "a", "b", "c"), 'a|b|c', 'reduce picks the Str candidate at every step';
+is ([mm] 1, 2, 3, 4), 1234, 'a four-element reduce stays on one candidate';
+
+# An `is rw` parameter must still write back through the invocation.
+sub postfix:<!!>($n is rw) { $n = $n + 1; $n }
+my $c = 4;
+is $c!!, 5, 'rw parameter of a user postfix operator returns the new value';
+is $c, 5, 'rw parameter of a user postfix operator wrote back';
+
+# A `state` variable must belong to the routine, not to one invocation: the
+# per-call recompile this slice removes was the mechanism that could hand each
+# call a fresh cell.
+sub infix:<ss>($a, $b) { state $n = 0; $n = $n + 1; "($a,$b,$n)" }
+is ([ss] 1, 2, 3), '((1,2,1),3,2)', 'state in a reduced operator counts up within one reduce';
+is ([ss] 4, 5), '(4,5,3)', 'state in a reduced operator persists across reduces';
+
+# Declared defaults, and the routine's own body constructs.
+sub infix:<dd>($a, $b = 100) { $a + $b }
+is ([dd] 1, 2), 3, "a reduce supplies the operator's second argument";
+is infix:<dd>(1), 101, "the operator's own default applies when the argument is absent";
+
+sub infix:<blk>($a, $b) { my @acc; @acc.push($_) for $a, $b; @acc.join('-') }
+is ([blk] 'x', 'y'), 'x-y', 'an operator body with its own block and loop';
+
+# A return constraint is part of the routine, so it must survive whichever entry
+# invokes it.
+sub infix:<rt>($a, $b --> Int) { $a + $b }
+is ([rt] 1, 2, 3), 6, 'a reduced operator honours its return constraint';
+
+# A `where`-constrained multi operator: the caller resolves the candidate, so
+# the narrowing must already have happened by the time the body runs.
+multi sub infix:<wc>($a where * > 0, $b) { "pos $a $b" }
+multi sub infix:<wc>($a, $b) { "other $a $b" }
+is 1 wc 2, 'pos 1 2', 'where-constrained candidate of a user operator';
+is -1 wc 2, 'other -1 2', 'the fallback candidate when the where fails';
+
+# An exception must propagate out of the invocation, not be swallowed by it.
+sub prefix:<boom>($x) { die "boom $x" }
+my $err;
+try { boom 3; CATCH { default { $err = .message } } }
+is $err, 'boom 3', 'a die inside a user prefix operator propagates';
+
+# The operator resolved from another package still runs in its defining package.
+module Ops {
+    our sub infix:<pk>($a, $b) is export { "{$?PACKAGE.^name}:{$a + $b}" }
+}
+is (Ops::infix:<pk>(1, 2)), 'Ops:3', 'a package-scoped operator keeps its defining package';
+
+# `.candidates` on a multi operator still yields callable code objects.
+is (&infix:<mm>.candidates.elems), 2, 'both candidates of a multi operator are visible';

--- a/todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md
+++ b/todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md
@@ -88,6 +88,31 @@ advanced — the chain then defers to the same candidate forever and the stack o
 It uses the entry below that setup, `call_compiled_function_named`. Landed; see
 `news/2026-08/multi-deferral-runs-the-compiled-candidate.md`.
 
+## Update 2: the remaining callers landed, and re-measuring shrank the site
+
+All five remaining callers now go through one `call_routine_def`
+(`news/2026-08/user-operators-run-their-compiled-body.md`). Re-running the probe on the
+whole `t/` suite *after* the deferral slice found only **13** hits left at
+`calls.rs:call_function_def`, not the ~42 the arithmetic above implies: 8 `MAIN`, 3
+`postfix:<!>`, 2 `infix:<op>`. The `Test::Util`-style helper names in the table above
+(`is_run`, `group-of`, `tap-ok`, `assert-eq`) do **not** reach this site; they belong to
+`exec_call`'s 48.
+
+`compile_and_call_function_def` turned out to be the wrong entry for these callers too,
+for a weaker reason than the deferral chain's: they have already resolved their
+candidate, so its per-call multi-dispatch frame is pure overhead. It A/B'd measurably
+worse than `call_compiled_function_named`.
+
+Two blockers keep C6d-1 open, both narrow:
+
+1. **Multi candidates never get plan-attached bytecode** — `vm_register_sub_ops` has
+   `if *multi { continue; }` where it would attach a compiled routine key to a candidate
+   `FunctionDef`. That is why `multi_candidate_state_forces_interpreter` has to exist and
+   why `call_function_def` survives. Own ticket:
+   `todo/tickets/attach-plan-bytecode-to-multi-candidates.md`.
+2. **`calls.rs:exec_call`** still carries an inlined copy of `call_function_def`'s whole
+   body, `run_block(&def.body)` included.
+
 ## Suggested subdivision
 
 Mirroring how C6 was subdivided:

--- a/todo/tickets/attach-plan-bytecode-to-multi-candidates.md
+++ b/todo/tickets/attach-plan-bytecode-to-multi-candidates.md
@@ -1,0 +1,78 @@
+# A multi candidate never receives its plan-compiled bytecode
+
+`vm_register_sub_ops.rs` walks a sub declaration plan's `compiled_routine_keys` and
+attaches each compiled routine to the registry `FunctionDef` it belongs to — except it
+bails out for multis:
+
+```rust
+if let Some(def) = self.registry_mut().functions.get_mut(&registry_key) {
+    let def = std::sync::Arc::make_mut(def);
+    if *multi {
+        continue;          // <-- every multi candidate arrives with compiled: None
+    }
+    ...
+    def.compiled = Some(std::sync::Arc::new(adapted));
+}
+```
+
+The compiler *does* compile every candidate, primary and signature-alternate alike
+(`compiler/stmt.rs`, `compile_sub_body_with_deprecation` once per signature), and pushes
+a key for each into `compiled_routine_keys`. The missing piece is matching a key back to
+the specific candidate it was compiled from: multi candidates live in the registry under
+`/n`-suffixed keys and one name owns several `FunctionDef`s, so the non-multi path's
+`rsplit_once('/')` key derivation does not identify a candidate.
+
+## Why it matters
+
+Two things wait on this.
+
+**It is the last blocker on ADR-0019 C6d-1.** With `compiled: None`, a multi candidate
+reaching dispatch has to be compiled on the fly, keyed by body fingerprint. For a
+`state`-bearing candidate of a name declared with signature *alternates* that is wrong:
+
+```
+multi sub postfix:<CNT> (AltA $x) | (AltB $x) { state $counter = 0; ++$counter }
+```
+
+Those alternates are ONE routine with ONE `state` cell. The compiler shares the cell by
+threading one `state_group` into every alternate's compiled body — exactly the bytecode
+that never gets attached — so the on-the-fly compile, which knows nothing of the group and
+keys on the per-alternate signature, hands each alternate its own cell
+(`t/multi-signature-alternates.t` fails). `multi_candidate_state_forces_interpreter`
+exists solely to route that shape back to the interpreter entry `call_function_def`, and
+that gate is the only reason `call_function_def` still exists. Attaching the bytecode
+retires the gate, the entry, and one of the six `&def.body` execution sites.
+
+**It removes a per-call compile from every multi.** A multi candidate invoked through
+`call_routine_def` / `compile_and_call_function_def` pays an `otf_compile_function_def`
+lookup instead of using bytecode it already has, and the first call of each candidate pays
+the compile itself.
+
+## Shape of the work
+
+The plan already knows the order: `compiled_routine_keys[0]` is the primary signature and
+the rest follow `signature_alternates` in declaration order. Registration walks the same
+list. So the fix is to carry the candidate identity alongside the key — either by having
+`register_sub_decl` return the registry key it installed the candidate under, or by
+recording, at compile time, the same signature discriminator the registry uses. Then
+`adapted.params` / `param_defs` / `return_type` are copied from *that* candidate rather
+than from a name lookup.
+
+Care needed:
+
+- Signature alternates share one body but differ in parameters, so the adapted
+  `CompiledFunction` must take each candidate's own `param_defs` (and re-run
+  `precompute_param_local_slots`), while keeping the shared `state_group` scope baked into
+  the code.
+- `t/multi-candidate-state-otf.t` pins the opposite requirement for ordinary multis:
+  `multi f(Int) { state $c }` and `multi f(Str) { state $c }` are two routines and must
+  *not* share a cell.
+- `opcode.rs:remap_sub_decl_compiled_routine_keys` remaps these keys on compunit import,
+  so whatever identity is added has to be remapped with them.
+
+## Verification
+
+`t/multi-signature-alternates.t` and `t/multi-candidate-state-otf.t` are the two poles.
+Once both pass with the gate deleted, remove
+`multi_candidate_state_forces_interpreter`, its `multi_alternate_signature_names` set, and
+`Interpreter::call_function_def`, and check ADR-0019's C6d-1 box.

--- a/todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md
+++ b/todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md
@@ -1,0 +1,82 @@
+# A `state` scalar written with `=` (not `++`) loses the write between calls
+
+`state $n = 0; $n = $n + 1;` does not accumulate. Every call sees the
+initializer value again, so a `state` counter written with plain assignment is
+silently stuck at its first value:
+
+```
+$ raku  -e 'sub f() { state $n = 0; $n = $n + 1; $n }; say f(); say f(); say f();'
+1
+2
+3
+$ mutsu -e 'sub f() { state $n = 0; $n = $n + 1; $n }; say f(); say f(); say f();'
+1
+1
+1
+```
+
+`$n += 1` behaves the same way. `++$n` and `$n++` are correct, and so is a
+`state` aggregate (`state @a; @a.push(1)`), which is why the existing coverage
+misses this: every `state` case in `t/` — `t/state-per-clone-named-subs.t`,
+`t/state-in-loop-body-accumulates.t`, `t/module-state-sub-shared-cell.t`,
+`t/anon-state-per-routine-call.t` — increments with `++`.
+
+Found while measuring ADR-0019 C6d-1, not caused by it: it reproduces on
+`main` and predates that work. The routine runs on the ordinary compiled path
+(`MUTSU_VM_STATS` reports 0 function fallbacks), so this is a compiled-path
+bug, not a fallback one. Notably the *interpreter* entry got it right: the
+same operator body invoked through `call_function_def` accumulated correctly
+(pinned now by `t/user-operator-compiled-body.t`'s `infix:<ss>` cases).
+
+## What distinguishes the working shapes
+
+The write reaches the state cell only when something *else* in the body reads
+the variable in a way that forces a cell-direct read afterwards. Assignment as
+an *expression* is also fine — only the statement form followed by a plain read
+loses it:
+
+| body | raku | mutsu |
+| --- | --- | --- |
+| `state $n = 0; $n = $n + 1; $n` | 1, 2 | 1, **1** |
+| `state $n = 0; $n += 1; $n` | 1, 2 | 1, **1** |
+| `state $n = 0; $n = $n + 1;` (implicit return of the assignment) | 1, 2 | 1, **1** |
+| `state $n = 0; $n = $n + 1; return $n` | 1, 2 | 1, **1** |
+| `state $n = 0; $n = $n + 1; my $r = $n; $r` | 1, 2 | 1, **1** |
+| `state $n = 0; $n = $n + 1; say "in:$n"; $n` | 1, 2 | 1, 2 |
+| `state $n = 0; my $x = ($n = $n + 1); $x` | 1, 2 | 1, 2 |
+| `state $n = 0; $n++; $n` | 1, 2 | 1, 2 |
+| `state $s = ""; $s ~= "x"; $s` | x, xx | x, **x** |
+
+So the assignment writes the routine's VM local slot, and only some reads
+flush the slot into the state cell — the interpolating read does, the trailing
+bare read does not. The `++` forms presumably mutate the cell in place. That
+matches the dual-store shape recorded in
+`memory/project-mustache-remaining-two-files.md` ("a slot is only filled by a
+cell-direct read").
+
+A bare block reached through a statement modifier is broken the same way even
+with the interpolating read, so the loop-body clone path shares the defect:
+
+```
+$ raku  -e '{ state $n = 0; $n = $n + 1; say $n; } for 1..3;'   # 1 2 3
+$ mutsu -e '{ state $n = 0; $n = $n + 1; say $n; } for 1..3;'   # 1 1 1
+```
+
+## Why this is not a quick fix
+
+The bug is in which side of the slot/cell dual store owns a `state` variable's
+value at each read and write, so the fix has to establish one rule for all
+four of: the assignment opcode's target, the plain read, the interpolating
+read, and routine exit. Picking the wrong one re-introduces the per-clone
+identity behavior that `t/state-per-clone-named-subs.t` and
+`t/concurrent-state-var.t` pin (a nested named sub must re-initialize its
+`state` per enclosing call, while a top-level sub must not), so it needs the
+same care as the ADR-0018 slot/env work rather than a local patch at the
+assignment site.
+
+## Where to look
+
+- `src/vm/vm_var_ops.rs`, `src/vm/vm_misc_scope.rs` — state-cell read/write ops.
+- `src/vm/vm_call_named_inner.rs`, `src/vm/vm_call_fast.rs` — the per-call
+  state-cell seeding and the routine-exit flush.
+- `src/vm/vm_closure_dispatch.rs` — the block-clone variant of the same.


### PR DESCRIPTION
ADR-0019 **C6d-1, second slice**. The first slice moved the multi-deferral caller off the interpreter routine entry `call_function_def`; this one moves every remaining caller.

`call_function_def`'s body run is `run_block(&def.body)` -> `run_block_raw` -> `compile_block_raw`, so **the routine's AST body was compiled afresh on every call** — and every one of these callers had already resolved the exact candidate it wanted:

| caller | what reaches it |
| --- | --- |
| `builtins_operators_fallback` | a user `prefix:<>` / `postfix:<>` operator |
| `builtins_operators_infix` | a reduce step over a user `infix:<>` |
| `builtins_operators_coerce` | a hyper step over a user `infix:<>` |
| `accessors_state` (`call_user_routine_direct`) | `reduce` given the operator as a routine value; the flip-flop infix fallback |
| `main_args` | the selected `MAIN` candidate |

They now share one entry, `call_routine_def`, which runs the plan-attached bytecode or one memoized on-the-fly compile.

## Measured

`[mm] 1 .. 200` reduce over a two-candidate user `multi sub infix:<mm>`, **release** build pinned to one core:

| | instructions | wall |
| --- | --- | --- |
| main | 15.43G | 1.38s |
| this PR | 13.35G | 1.07s |
| | **-13.5%** | **-22%** |

**Read this off the release build.** The identical A/B on the *debug* build reports the opposite (13.50G -> 15.46G, +14%): debug leaves the compiled entry's per-call bookkeeping uninlined while `compile_block_raw` stays comparatively cheap, inverting the ranking. CLAUDE.md's wall-clock warning applies to dispatch-path instruction counts too — only the `MUTSU_VM_STATS` counters are optimization-independent.

## Two entry-point findings

- **Not `compile_and_call_function_def`.** That general routine entry pushes a samewith context and a fresh multi-dispatch frame before the body. With the candidate already resolved, building a candidate list per call is pure overhead, and it A/B'd measurably worse than `call_compiled_function_named` — the entry just below that setup, which also matches `call_function_def`'s semantics exactly (it pushed neither stack). The deferral slice avoided the same entry for a stronger, correctness reason.
- `otf_compile_function_def`'s cache key stopped being a SipHash over the body fingerprint plus a freshly allocated package `String`. Both halves are already integers (memoized fingerprint, interned `Symbol` id), so they mix arithmetically; the package string is resolved only on a cache miss.

## Why C6d-1 stays unchecked

`call_function_def` survives for exactly one gated shape, `multi_candidate_state_forces_interpreter`:

```raku
multi sub postfix:<CNT> (AltA $x) | (AltB $x) { state $counter = 0; ++$counter }
```

Signature alternates are ONE routine with ONE `state` cell, shared through a compile-time `state_group` that the compiler already threads into every alternate's compiled body — but `vm_register_sub_ops` attaches plan-compiled bytecode only to *non*-multi candidates (`if *multi { continue; }`), so a multi candidate reaches dispatch with `compiled: None` and an on-the-fly compile per alternate fragments the cell. `t/multi-signature-alternates.t` caught this during development. Follow-up filed as `todo/tickets/attach-plan-bytecode-to-multi-candidates.md`; landing it retires the gate, the entry, and one of the six `&def.body` sites. `calls.rs:exec_call`'s inlined copy is the other open half.

Re-probing the whole `t/` suite also corrected the survey: only **13** hits remain at this site (8 `MAIN`, 3 `postfix:<!>`, 2 `infix:<op>`), not the ~42 the earlier arithmetic implied.

## Unrelated bug found while measuring

A `state` scalar written with `=` or `+=` rather than `++` **loses the write between calls** — `sub f() { state $n = 0; $n = $n + 1; $n }` returns 1, 1, 1 where raku returns 1, 2, 3. It reproduces on `main`, predates this work, and every existing `state` test in `t/` increments with `++`, which is why it was never caught. Recorded in `todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md` with the full shape table; not fixed here.

## Testing

- `t/user-operator-compiled-body.t`, 26 assertions, **every expectation taken from `raku` first**: prefix/postfix/infix forms, reduce, triangular reduce, hyper, cross- and zip-metaops, `reduce(&infix:<...>)`, a two-candidate multi resolving per step, `is rw` writeback, `state` across reduces, a declared default, a return constraint, a `where`-constrained candidate, a `die` propagating out, `$?PACKAGE` in a package-scoped operator, `.candidates`.
- `make test`: 2884 files / 27428 tests, all pass.
- The gated alternates shape cannot be raku-verified (`raku` rejects that syntax); `t/multi-signature-alternates.t` keeps pinning it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)