### PR TITLE
perf(threads): reclassify 5 no-user-VM-code spawn sites to gc-helper threads

### DIFF
--- a/docs/adr/0020-shared-worker-pool.md
+++ b/docs/adr/0020-shared-worker-pool.md
@@ -191,7 +191,7 @@ Concretely:
 
 ## 6. Implementation status
 
-- [ ] Preliminary slice: reclassify the 5 no-user-code sites to `spawn_gc_helper_thread`.
+- [x] Preliminary slice: reclassify the 5 no-user-code sites to `spawn_gc_helper_thread`.
 - [ ] Slice 1: pool behind `spawn_user_thread`; `start` / one-shot `cue` pooled; probes re-run.
 - [ ] Slice 2: `cue(:every)` → timer entry + pool enqueue; retire `scheduler_run_every_loop`.
 - [ ] Slice 3: supply emitters / socket pumps / hyper-race, case by case.

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -322,8 +322,9 @@ impl Interpreter {
                         let stdin_arc = stdin_arc.clone();
                         // Receives `Value`s (Gc nodes) from the supply channel:
                         // must be a registered GC mutator, with the blocking
-                        // recv as a quiescent safe region.
-                        crate::runtime::builtins_system::spawn_user_thread(move || {
+                        // recv as a quiescent safe region. Runs no user VM
+                        // code, so the default stack suffices.
+                        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                             if let Some(rx) = take_supply_channel(source_supply_id) {
                                 while let Ok(event) = crate::gc::block_quiescent(|| rx.recv()) {
                                     match event {
@@ -391,15 +392,18 @@ impl Interpreter {
 
                 // Builds Proc `Value`s (Gc nodes) and resolves the promise:
                 // registered GC mutator; its child-wait / joins are quiescent.
-                crate::runtime::builtins_system::spawn_user_thread(move || {
+                // Runs no user VM code (`keep` dispatches waiters to a fresh
+                // user thread), so the default stack suffices.
+                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                     // Spawn stdout reader thread — streams raw chunks through channel
                     let stdout_handle = child_stdout.map(|stdout| {
                         let tx = stdout_channel;
                         let bin_mode = stdout_bin;
                         let sid = stdout_supply_id;
                         // Emits Buf `Value`s (Gc nodes): registered mutator,
-                        // pipe reads quiescent.
-                        crate::runtime::builtins_system::spawn_user_thread(move || {
+                        // pipe reads quiescent. No user VM code — default
+                        // stack.
+                        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                             use std::io::Read;
                             let mut stdout = stdout;
                             let mut collected = String::new();
@@ -454,8 +458,9 @@ impl Interpreter {
                         let tx = stderr_channel;
                         let bin_mode = stderr_bin;
                         let sid = stderr_supply_id;
-                        // Same as the stdout reader: registered + quiescent reads.
-                        crate::runtime::builtins_system::spawn_user_thread(move || {
+                        // Same as the stdout reader: registered + quiescent
+                        // reads, no user VM code — default stack.
+                        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                             use std::io::Read;
                             let mut stderr = stderr;
                             let mut collected = String::new();

--- a/src/runtime/signal_watcher.rs
+++ b/src/runtime/signal_watcher.rs
@@ -39,12 +39,13 @@ mod unix_impl {
                 libc::fcntl(fds[1], libc::F_SETFL, flags | libc::O_NONBLOCK);
             }
             // Start the reader thread. Registered as a GC mutator
-            // (`spawn_user_thread`): `dispatch_signal` clones registered
-            // `Value`s (potential Gc nodes); the blocking pipe read is a
+            // (`spawn_gc_helper_thread`): `dispatch_signal` clones registered
+            // `Value`s (potential Gc nodes) but never runs user VM code, so
+            // the default stack suffices; the blocking pipe read is a
             // quiescent safe region so the daemon never stalls a
             // stop-the-world.
             let read_fd = fds[0];
-            crate::runtime::builtins_system::spawn_user_thread(move || {
+            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                 signal_reader_thread(read_fd)
             });
             (fds[0], fds[1])


### PR DESCRIPTION
ADR-0020 preliminary slice (§3.5 / §6): the five `spawn_user_thread` call sites that never run user VM code are reclassified to `spawn_gc_helper_thread` — still registered GC mutators, but with the default thread stack instead of the 256 MiB user-thread reservation.

Sites changed:
- `native_proc_async.rs` — stdin supply feeder, proc waiter (resolves the promise; `keep` dispatches waiters to a fresh user thread, so no user code runs here), stdout pipe reader, stderr pipe reader
- `signal_watcher.rs` — signal reader daemon

Each spawn stops reserving 256 MiB of address space. No behavior change otherwise; comments updated to record why the default stack suffices.

Verified locally: `t/proc-async.t`, `t/native-proc-async-ctor.t`, `t/composite-promise-replays-proc-taps.t`, `t/run-capture.t`, `t/is-run.t`, `t/proc-start-cwd-env.t`, `t/whenever-next-signal.t`, and roast `S17-procasync/{basic,print,stress,kill,bind-handles,encoding}.t` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)