### PR TITLE
perf(threads): elastic worker pool for start and one-shot cue (ADR-0020 slice 1)

### DIFF
--- a/docs/adr/0020-shared-worker-pool.md
+++ b/docs/adr/0020-shared-worker-pool.md
@@ -192,6 +192,8 @@ Concretely:
 ## 6. Implementation status
 
 - [x] Preliminary slice: reclassify the 5 no-user-code sites to `spawn_gc_helper_thread`.
-- [ ] Slice 1: pool behind `spawn_user_thread`; `start` / one-shot `cue` pooled; probes re-run.
+- [x] Slice 1: pool behind `spawn_user_thread`; `start` / one-shot `cue` pooled; probes re-run
+      (release A/B, 2026-08-05: ripemd shape 1.94s → 1.73s (−11%), 500 × trivial `start {}`
+      0.190s → 0.172s (−9%), nested-500 unchanged — matching §5's 10–15% expectation).
 - [ ] Slice 2: `cue(:every)` → timer entry + pool enqueue; retire `scheduler_run_every_loop`.
 - [ ] Slice 3: supply emitters / socket pumps / hyper-race, case by case.

--- a/news/2026-08/worker-pool-slice1-start-cue.md
+++ b/news/2026-08/worker-pool-slice1-start-cue.md
@@ -1,0 +1,36 @@
+# Elastic worker pool: `start` and one-shot `cue` now reuse warm threads (ADR-0020 slice 1)
+
+mutsu's hottest task spawners — `start` / `Promise.start`
+(`spawn_callable_promise`) and one-shot `$*SCHEDULER.cue` — now run on a
+process-wide elastic worker pool (`src/runtime/worker_pool.rs`) instead of
+spawning a fresh 256 MiB-stack OS thread per task. This implements slice 1 of
+[ADR-0020](../../docs/adr/0020-shared-worker-pool.md).
+
+The pool follows the ADR's decisions exactly:
+
+- **Elastic growth, blocking `await` stays.** `submit` grows the pool whenever
+  there are more queued tasks than parked workers — a busy worker may be
+  *blocked* on an `await` the queued task resolves, so waiting for one would
+  deadlock. Nested `start`+`await` at depth N still materializes ~N threads
+  (same as before, by design).
+- **STW-aware idle wait.** The task-queue park runs inside
+  `gc::block_quiescent`, so idle workers count as quiescent and never starve a
+  stop-the-world (the queue pop provably touches no `Gc` state).
+- **Task-boundary hygiene.** `drop_thread_local_gc_state()` runs between tasks
+  so one task's pending DESTROY queue / failure registry never leaks into the
+  next; a panicking task is caught and the worker survives with correct
+  accounting.
+- **Sizing.** Starts at 0 workers; a soft floor of `min(cores, 8)` workers
+  stays alive; beyond the floor an idle worker exits after a 1s grace period.
+  `:every` cues keep their dedicated thread for now — that shape is exactly
+  what slice 2 moves onto the deadline-heap timer.
+- **Escape hatch.** `MUTSU_POOL=off` restores thread-per-task for A/B runs and
+  flake triage. `MUTSU_VM_STATS=1` reports `worker-pool: tasks/spawns/warm_reuses`.
+
+Measured on the ADR's probes (release, median of 3, same host): the ripemd
+shape (2000 × `await map { start { $k*2 } }, 1, 2`) improved 1.94s → 1.73s
+(−11%) and 500 × trivial `start {}` 0.190s → 0.172s (−9%), matching the ADR §5
+expectation of 10–15% — the pool removes thread-machinery and GC-registration
+churn, while the dominant per-task `clone_for_thread` cost remains the
+companion lever tracked in
+`todo/tickets/digest-ripemd-start-per-block-overhead.md`.

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -192,7 +192,10 @@ impl Interpreter {
         };
         let block = stripped.unwrap_or(block);
 
-        spawn_user_thread(move || {
+        // Pooled (ADR-0020 slice 1): `start` is the hottest spawner, and its
+        // body may block (`await`) — the elastic pool reuses a warm worker or
+        // grows instead of deadlocking.
+        crate::runtime::worker_pool::submit(move || {
             // CP-3 collapse: the thread's cloned Interpreter *is* the VM — run the
             // block on it directly instead of wrapping it in a sub-VM.
             let mut thread_interp = thread_interp;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -408,6 +408,8 @@ pub(crate) mod value_iterator;
 /// Cooperative scheduler standing in for OS threads in the browser.
 #[cfg(target_arch = "wasm32")]
 pub(crate) mod wasm_sched;
+/// Elastic worker pool for short-lived user tasks (ADR-0020).
+pub(crate) mod worker_pool;
 pub(crate) use self::match_target::MatchTarget;
 pub(crate) use self::methods_subscript_protocol::refuse_map_removal;
 pub(crate) use self::output_sink::OutputSink;

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -317,14 +317,22 @@ impl Interpreter {
                     if deferred {
                         params.delay = 0.0;
                     }
-                    // Large user-code stack: the scheduled callback runs user VM
-                    // code, which overflows the default thread stack on deep
-                    // nesting. See `USER_THREAD_STACK_SIZE`.
+                    // One-shot cues run on the ADR-0020 worker pool (slice 1).
+                    // A `:every` cue keeps a dedicated thread for now — its
+                    // repeat loop occupies a worker for the cue's whole
+                    // lifetime, which is exactly the shape slice 2 moves onto
+                    // the deadline-heap timer.
+                    let pooled = params.every.is_none();
                     let run = move || {
-                        crate::runtime::builtins_system::spawn_user_thread(move || {
+                        let body = move || {
                             thread_interp.scheduler_run_async(params);
                             state_scheduler::scheduler_task_finished();
-                        });
+                        };
+                        if pooled {
+                            crate::runtime::worker_pool::submit(body);
+                        } else {
+                            crate::runtime::builtins_system::spawn_user_thread(body);
+                        }
                     };
                     if deferred {
                         interval_timer::register_once(

--- a/src/runtime/worker_pool.rs
+++ b/src/runtime/worker_pool.rs
@@ -1,0 +1,165 @@
+//! Process-wide elastic worker pool for short-lived user tasks (ADR-0020).
+//!
+//! `submit` runs a task on a warm pooled worker when one is idle, and grows the
+//! pool otherwise. Growth is the ADR-0020 §3.2 starvation check that keeps
+//! blocking `await` deadlock-free: a busy worker may be *blocked* on a wait
+//! whose resolution needs another worker, so a queued task never waits for a
+//! busy worker to come back — if no worker is idle, a new one is spawned.
+//! Workers keep the 256 MiB user-code stack reservation
+//! (`USER_THREAD_STACK_SIZE`); a soft floor of `min(cores, 8)` workers stays
+//! alive, and workers beyond the floor exit after an idle grace period.
+//!
+//! On wasm32 there is no pool: `submit` delegates to `spawn_user_thread`,
+//! whose cooperative scheduler is already a pool of one.
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use std::collections::VecDeque;
+    use std::sync::{Condvar, Mutex, OnceLock};
+    use std::time::{Duration, Instant};
+
+    pub(super) type Task = Box<dyn FnOnce() + Send + 'static>;
+
+    pub(super) struct PoolState {
+        pub(super) queue: VecDeque<Task>,
+        /// Workers parked in `wait_for_task` (not running or blocked in a task).
+        pub(super) idle: usize,
+        /// Total live workers (idle + running a task, possibly blocked).
+        pub(super) live: usize,
+    }
+
+    /// Idle grace period for workers above the keep-alive floor.
+    const IDLE_GRACE: Duration = Duration::from_secs(1);
+
+    pub(super) fn pool() -> &'static (Mutex<PoolState>, Condvar) {
+        static POOL: OnceLock<(Mutex<PoolState>, Condvar)> = OnceLock::new();
+        POOL.get_or_init(|| {
+            (
+                Mutex::new(PoolState {
+                    queue: VecDeque::new(),
+                    idle: 0,
+                    live: 0,
+                }),
+                Condvar::new(),
+            )
+        })
+    }
+
+    /// Soft floor of kept-alive workers. 256 MiB *reserved* stack each makes
+    /// this an address-space budget (ADR-0020 §3.2): `min(cores, 8)`.
+    fn keep_alive_floor() -> usize {
+        static FLOOR: OnceLock<usize> = OnceLock::new();
+        *FLOOR.get_or_init(|| {
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(4)
+                .min(8)
+        })
+    }
+
+    /// Escape hatch: `MUTSU_POOL=off` restores thread-per-task for A/B
+    /// comparison and flake triage.
+    pub(super) fn pool_enabled() -> bool {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            !matches!(
+                std::env::var("MUTSU_POOL").as_deref(),
+                Ok("off") | Ok("0") | Ok("no")
+            )
+        })
+    }
+
+    pub(super) fn spawn_pool_worker() {
+        // `spawn_user_thread` carries the whole worker-lifetime GC protocol:
+        // `enter_mutator_worker`/`preregister_worker_quiescent` on the parent,
+        // `worker_started` + `WorkerGuard` (drain -> unregister -> exit) in the
+        // worker. The pool adds only the per-task boundary inside `worker_loop`.
+        crate::runtime::builtins_system::spawn_user_thread(worker_loop);
+    }
+
+    fn worker_loop() {
+        while let Some(task) = wait_for_task() {
+            // A panicking task must not take the worker's `live` accounting
+            // with it: catch, forget, move on — same process-level outcome as
+            // a panicking dedicated thread (the panic is already turned into a
+            // broken Promise by `guard_worker_panic` where that matters).
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(task));
+            // Task boundary (ADR-0020 §3.4): task N's pending DESTROY queue
+            // and failure registry must not leak into task N+1 while the
+            // thread stays GC-registered.
+            crate::value::drop_thread_local_gc_state();
+        }
+    }
+
+    /// Park until a task is available. Returns `None` when the worker should
+    /// exit (idle past the grace period while above the keep-alive floor).
+    fn wait_for_task() -> Option<Task> {
+        // The park provably touches no `Gc` state (a queue pop moves a `Box`),
+        // so the whole wait counts quiescent: an idle pool never starves a
+        // stop-the-world (ADR-0020 §3.3).
+        crate::gc::block_quiescent(|| {
+            let (lock, cvar) = pool();
+            let mut st = lock.lock().unwrap();
+            if let Some(task) = st.queue.pop_front() {
+                return Some(task);
+            }
+            st.idle += 1;
+            let deadline = Instant::now() + IDLE_GRACE;
+            loop {
+                if let Some(task) = st.queue.pop_front() {
+                    st.idle -= 1;
+                    return Some(task);
+                }
+                if st.live <= keep_alive_floor() {
+                    // At/below the floor: park until woken, no deadline.
+                    st = cvar.wait(st).unwrap();
+                    continue;
+                }
+                let now = Instant::now();
+                if now >= deadline {
+                    st.idle -= 1;
+                    st.live -= 1;
+                    return None;
+                }
+                let (g, _) = cvar.wait_timeout(st, deadline - now).unwrap();
+                st = g;
+            }
+        })
+    }
+}
+
+/// Run `task` on a pooled worker thread. The task may run arbitrary user VM
+/// code (workers reserve the deep-recursion stack) and may block indefinitely
+/// (`await`, channel receive) — the pool grows instead of deadlocking. There
+/// is no join handle: completion is observed through whatever the task itself
+/// resolves (a promise, a channel, a counter).
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn submit(task: impl FnOnce() + Send + 'static) {
+    if !native::pool_enabled() {
+        crate::runtime::builtins_system::spawn_user_thread(task);
+        return;
+    }
+    crate::vm::vm_stats::record_pool_task();
+    let (lock, cvar) = native::pool();
+    let mut st = lock.lock().unwrap();
+    st.queue.push_back(Box::new(task));
+    // Starvation check (ADR-0020 §3.2): grow whenever there are more queued
+    // tasks than parked workers. Busy workers may be blocked on an `await`
+    // this very task resolves, so waiting for one is not an option.
+    let grow = st.queue.len() > st.idle;
+    if grow {
+        st.live += 1;
+        crate::vm::vm_stats::record_pool_spawn();
+    }
+    cvar.notify_one();
+    drop(st);
+    if grow {
+        native::spawn_pool_worker();
+    }
+}
+
+/// wasm32: the cooperative scheduler is already a pool of one — queue the task.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn submit(task: impl FnOnce() + Send + 'static) {
+    crate::runtime::builtins_system::spawn_user_thread(task);
+}

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -197,6 +197,30 @@ pub(crate) fn record_regex_match_materialization() {
     }
 }
 
+// ADR-0020 worker pool: `POOL_TASKS` counts every task submitted to the
+// elastic pool; `POOL_SPAWNS` the subset that grew the pool (no idle worker
+// at submit time). `tasks - spawns` is therefore the warm-reuse count the
+// pool exists to maximize — on a short-task churn shape (ripemd) spawns
+// should flatline at ~pool-floor while tasks keeps counting.
+static POOL_TASKS: AtomicU64 = AtomicU64::new(0);
+static POOL_SPAWNS: AtomicU64 = AtomicU64::new(0);
+
+/// Record one task submitted to the ADR-0020 worker pool.
+#[inline]
+pub(crate) fn record_pool_task() {
+    if enabled() {
+        POOL_TASKS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record one pool growth (a task found no idle worker and spawned one).
+#[inline]
+pub(crate) fn record_pool_spawn() {
+    if enabled() {
+        POOL_SPAWNS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 // JIT (ADR-0004 layer 4) counters: how many chunks compiled to native code,
 // how many body executions entered native code, and how many chunks bailed
 // out (contain a not-yet-supported opcode; see `jit_bailout_by_opcode` for
@@ -514,6 +538,12 @@ pub(crate) fn dump() {
     let code_parse_misses = REGEX_CODE_PARSE_MISSES.load(Ordering::Relaxed);
     eprintln!(
         "[mutsu vm-stats] regex-code-parse-cache: hits={code_parse_hits} misses={code_parse_misses}"
+    );
+    let pool_tasks = POOL_TASKS.load(Ordering::Relaxed);
+    let pool_spawns = POOL_SPAWNS.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] worker-pool: tasks={pool_tasks} spawns={pool_spawns} warm_reuses={}",
+        pool_tasks.saturating_sub(pool_spawns)
     );
     let jit_compiles = JIT_COMPILES.load(Ordering::Relaxed);
     let jit_entries = JIT_ENTRIES.load(Ordering::Relaxed);


### PR DESCRIPTION
Implements slice 1 of [ADR-0020](docs/adr/0020-shared-worker-pool.md): a process-wide elastic worker pool (`src/runtime/worker_pool.rs`) behind the hottest spawners.

## What changed

- **New `worker_pool::submit`**: enqueue a task; an idle warm worker picks it up, otherwise the pool grows. The growth rule is the ADR §3.2 starvation check — grow whenever queued tasks exceed parked workers — because a busy worker may be *blocked* on an `await` the queued task resolves; waiting for one would deadlock.
- **STW-aware idle wait (§3.3)**: the queue park runs inside `gc::block_quiescent` (the pop only moves a `Box`), so idle workers count as quiescent and never starve a stop-the-world.
- **Task boundary (§3.4)**: `drop_thread_local_gc_state()` between tasks; a panicking task is caught so worker accounting stays correct.
- **Sizing (§3.2)**: starts at 0; soft keep-alive floor `min(cores, 8)`; above the floor an idle worker exits after 1s grace. Workers keep the 256 MiB user-code stack reservation.
- **Routed through the pool**: `spawn_callable_promise` (`start` / `Promise.start`) and one-shot `cue`. `:every` cues keep a dedicated thread — that shape is what slice 2 moves onto the deadline-heap timer.
- **wasm32**: `submit` delegates to `spawn_user_thread` (the cooperative scheduler is already a pool of one). Verified with `cargo check --target wasm32-unknown-unknown --no-default-features --features wasm`.
- **Observability**: `MUTSU_VM_STATS=1` reports `worker-pool: tasks/spawns/warm_reuses`; `MUTSU_POOL=off` restores thread-per-task for A/B and flake triage.

## Measurements (release, median of 3, ADR probes)

| probe | pool off | pool on | delta |
|---|---|---|---|
| ripemd shape (2000 × `await map { start { $k*2 } }, 1, 2`) | 1.94s | 1.73s | −11% |
| 500 × trivial `start {}` | 0.190s | 0.172s | −9% |
| nested `start`+`await` depth 500 | 0.92s | 0.89s | unchanged (by design) |

Matches ADR §5's honest expectation (10–15%; the dominant per-task `clone_for_thread` cost is the companion lever tracked in `todo/tickets/digest-ripemd-start-per-block-overhead.md`).

## Verified locally

`make test` passes; smoke test under `MUTSU_GC=on MUTSU_GC_VERIFY=1` clean; roast `S17-promise/{basic,start,allof,anyof,nonblocking-await,in,at}.t`, `S17-lowlevel/{semaphore,lock}.t`, `S17-scheduler/{basic,times}.t` all pass. Warm reuse confirmed via vm-stats (sequential 500 starts: ~1 spawn, 499 warm reuses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)