### PR TITLE
perf(threads): cue(:every) becomes a timer entry + pool enqueue (ADR-0020 slice 2)

### DIFF
--- a/docs/adr/0020-shared-worker-pool.md
+++ b/docs/adr/0020-shared-worker-pool.md
@@ -195,5 +195,10 @@ Concretely:
 - [x] Slice 1: pool behind `spawn_user_thread`; `start` / one-shot `cue` pooled; probes re-run
       (release A/B, 2026-08-05: ripemd shape 1.94s → 1.73s (−11%), 500 × trivial `start {}`
       0.190s → 0.172s (−9%), nested-500 unchanged — matching §5's 10–15% expectation).
-- [ ] Slice 2: `cue(:every)` → timer entry + pool enqueue; retire `scheduler_run_every_loop`.
+- [x] Slice 2: `cue(:every)` → timer entry + pool enqueue; retire `scheduler_run_every_loop`
+      (2026-08-05: 50 idle `cue(:every(60))` went from 52 threads / 16.7 GB VmSize to
+      4 threads / 761 MB. Adds Rakudo's 1ms minimum-resolution clamp + warning, and a
+      bounded `.cancel` wait for the in-flight iteration — the pool's wider
+      dispatch-to-execution window otherwise let a dead cue's last `cas` resurrect a
+      successor cue's same-named lexical through the bare-name atomic lane).
 - [ ] Slice 3: supply emitters / socket pumps / hyper-race, case by case.

--- a/news/2026-08/worker-pool-slice2-every-timer.md
+++ b/news/2026-08/worker-pool-slice2-every-timer.md
@@ -1,0 +1,31 @@
+# `cue(:every)` cues are timer entries now, not threads (ADR-0020 slice 2)
+
+A repeating `$*SCHEDULER.cue(:every)` no longer owns a dedicated OS thread
+sleeping through a repeat loop for its whole lifetime. It is now an entry on
+the shared deadline-heap timer (`interval_timer.rs`): each tick enqueues one
+iteration onto the ADR-0020 worker pool, skipping the tick while the previous
+iteration still runs. `scheduler_run_every_loop` is retired. This closes the
+worst resource row in ADR-0020 §1.1: 50 idle `cue(:every(60))` used to cost 52
+threads and 16.7 GB of VmSize; they are now 4 threads and 761 MB (raku on the
+same host idles at 5 threads / 1.2 GB).
+
+Semantics preserved and one Rakudo behavior gained:
+
+- `:in`/`:at` initial delays, `:times` (exact count), `:stop`, `:catch`, and
+  the `:every(Inf)` run-once / `-Inf` special cases all behave as before
+  (`roast/S17-scheduler/every.t` stays green).
+- Sub-1ms (zero/negative/`-Inf`) intervals now clamp to Rakudo's 1ms minimum
+  timer resolution with the same warning ("Minimum timer resolution is 1ms;
+  using that instead of Nms"). mutsu previously busy-spun at ~49k iterations/s
+  where raku runs ~890/s.
+- `.cancel` now waits (bounded, 100ms cap, self-cancel-safe) for an in-flight
+  iteration to finish before returning. The pool's dispatch-to-execution
+  window is far wider than the retired loop's check-to-call gap, and a
+  callback completing after `.cancel` raced the *next* same-named cue's fresh
+  lexical through the bare-name atomic lane — a dead cue's final
+  `cas $a, {.succ}` resurrected its count into the successor's `$a`
+  (intermittent `roast/S17-scheduler/every.t` failures, "seen 21 runs"). The
+  underlying bare-name-lane residue is a pre-existing bug that also
+  reproduces on thread-per-cue builds (see
+  `todo/tickets/cue-loop-lexical-shared-lane-residue.md`); the bounded wait
+  restores the old race odds at their source for the cancel path.

--- a/src/runtime/native_methods/interval_timer.rs
+++ b/src/runtime/native_methods/interval_timer.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 
 /// Returns `Some(period)` to be rescheduled `period` after this deadline
 /// (fixed-rate, with catch-up skipping), or `None` to be dropped.
-type TimerAction = Box<dyn FnMut() -> Option<Duration> + Send>;
+pub(crate) type TimerAction = Box<dyn FnMut() -> Option<Duration> + Send>;
 
 struct TimerEntry {
     /// Deadline in `thread_compat::mono_now()` seconds.
@@ -160,7 +160,11 @@ pub(crate) fn wasm_fire_next_timer() -> bool {
     true
 }
 
-fn register_entry(delay: Duration, action: TimerAction) {
+/// Register a raw timer entry: `action` runs on the driver thread `delay`
+/// from now, then again every `Some(period)` it returns. Driver-thread rules
+/// apply (cheap actions only, never user VM code — enqueue to the worker pool
+/// instead).
+pub(crate) fn register_entry(delay: Duration, action: TimerAction) {
     let (heap, cvar) = timer_state();
     let mut guard = heap.lock().unwrap();
     guard.push(TimerEntry {

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -220,6 +220,34 @@ impl Interpreter {
                     && let Some(flag) = cancellation_state(id as u64)
                 {
                     flag.store(true, Ordering::Relaxed);
+                    // A timer-driven `:every` cue may have an iteration in
+                    // flight (dispatched before the flag was set). Wait for it
+                    // (bounded) so no callback side effect lands after
+                    // `.cancel` returns: an in-flight `cas $a` completing
+                    // after the caller re-declares a same-named lexical
+                    // resurrects the dead cue's count through the bare-name
+                    // atomic lane (roast S17-scheduler/every.t). Skip the wait
+                    // when the callback itself called `.cancel` (same thread —
+                    // waiting would deadlock until the timeout).
+                    if let Some(busy_state) = cancellation_busy(id as u64) {
+                        let self_cancel = busy_state
+                            .running_thread
+                            .lock()
+                            .ok()
+                            .is_some_and(|g| *g == Some(std::thread::current().id()));
+                        if !self_cancel {
+                            crate::gc::block_quiescent(|| {
+                                let deadline = std::time::Instant::now()
+                                    + std::time::Duration::from_millis(100);
+                                while busy_state.busy.load(Ordering::Acquire)
+                                    && std::time::Instant::now() < deadline
+                                {
+                                    std::thread::yield_now();
+                                }
+                            });
+                        }
+                        drop_cancellation_busy(id as u64);
+                    }
                 }
                 Ok(Value::NIL)
             }
@@ -300,6 +328,15 @@ impl Interpreter {
 
                 if is_current_thread {
                     self.scheduler_run_sync(params)?;
+                } else if params.every.is_some_and(|e| e != f64::INFINITY)
+                    && params.delay != f64::INFINITY
+                {
+                    // A finite (or -Inf, clamped) `:every` cue is a deadline-heap
+                    // timer entry that enqueues each iteration onto the worker
+                    // pool (ADR-0020 slice 2) — no dedicated sleep-loop thread.
+                    // `:every(Inf)` and an Inf `:in` delay keep the one-shot
+                    // path, which preserves their historical run-once handling.
+                    self.cue_every_timer(params, cancellation_id)?;
                 } else {
                     let mut thread_interp = self.clone_for_thread();
                     // Track the spawned task so `$*SCHEDULER.loads` reflects it
@@ -318,21 +355,11 @@ impl Interpreter {
                         params.delay = 0.0;
                     }
                     // One-shot cues run on the ADR-0020 worker pool (slice 1).
-                    // A `:every` cue keeps a dedicated thread for now — its
-                    // repeat loop occupies a worker for the cue's whole
-                    // lifetime, which is exactly the shape slice 2 moves onto
-                    // the deadline-heap timer.
-                    let pooled = params.every.is_none();
                     let run = move || {
-                        let body = move || {
+                        crate::runtime::worker_pool::submit(move || {
                             thread_interp.scheduler_run_async(params);
                             state_scheduler::scheduler_task_finished();
-                        };
-                        if pooled {
-                            crate::runtime::worker_pool::submit(body);
-                        } else {
-                            crate::runtime::builtins_system::spawn_user_thread(body);
-                        }
+                        });
                     };
                     if deferred {
                         interval_timer::register_once(
@@ -456,73 +483,151 @@ impl Interpreter {
         }
     }
 
-    /// Run the repeating loop for :every, used by both sync and async paths.
-    /// Returns Ok(()) for sync, errors propagated only in sync mode.
-    fn scheduler_run_every_loop(
+    /// Drive a finite `:every` cue from the shared deadline-heap timer
+    /// (ADR-0020 slice 2): each tick enqueues one callback run onto the worker
+    /// pool, skipping the tick while the previous run is still going. The cue
+    /// stops owning a thread — the retired implementation was a dedicated
+    /// worker sleeping through a repeat loop for the cue's whole lifetime.
+    fn cue_every_timer(
         &mut self,
-        p: &CueParams,
-        propagate_errors: bool,
+        params: CueParams,
+        cancellation_id: u64,
     ) -> Result<(), RuntimeError> {
-        let interval = p.every.unwrap_or(0.0);
-        let mut count = 0;
-        loop {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        let every = params.every.unwrap_or(0.0);
+        // Rakudo parity: the timer has a 1ms minimum resolution; sub-1ms (and
+        // zero/negative/-Inf) intervals are clamped with the same warning.
+        let interval = if every < 0.001 {
+            let shown_ms = if every.is_finite() {
+                every * 1000.0
+            } else {
+                0.0
+            };
+            self.raise_resumable_warning(
+                &format!("Minimum timer resolution is 1ms; using that instead of {shown_ms}ms"),
+                Value::NIL,
+            )?;
+            0.001
+        } else {
+            every
+        };
+        let delay = params.delay;
+        let cancel_flag = params.cancel_flag.clone();
+        // `:every` with both `:times` and `:stop` is rejected up front, so the
+        // dispatch count is exact even though a `:stop` probe consumes a tick.
+        // The retired loop ran once even for `:times(0)` (it checked the count
+        // AFTER the call) — `max(1)` preserves that.
+        let times = params.times.map(|t| t.max(1));
+        // Block-aware clone: the callback's own captured scalars go through
+        // per-binding closure cells, not the bare-name shared lane, matching
+        // the `start` spawn path.
+        let thread_interp = self.clone_for_thread_for_block(&params.callback);
+        // Track the cue so `$*SCHEDULER.loads` reflects it until it dies.
+        state_scheduler::scheduler_task_started();
+        let state = Arc::new(std::sync::Mutex::new((thread_interp, params)));
+        let busy = Arc::new(AtomicBool::new(false));
+        let running_thread = Arc::new(std::sync::Mutex::new(None));
+        // Register the in-flight state under the Cancellation id so `.cancel`
+        // can wait for a dispatched iteration to finish (see
+        // `native_cancellation`).
+        register_cancellation_busy(
+            cancellation_id,
+            Arc::new(CancellationBusy {
+                busy: busy.clone(),
+                running_thread: running_thread.clone(),
+            }),
+        );
+        let stopped = Arc::new(AtomicBool::new(false));
+        let mut dispatched: usize = 0;
+        interval_timer::register_entry(
+            interval_timer::clamp_delay_secs(delay),
+            Box::new(move || {
+                // Driver-thread rules: cheap checks and a pool enqueue only —
+                // `:stop` and the callback are user code and run in the task.
+                if stopped.load(Ordering::Relaxed)
+                    || cancel_flag
+                        .as_ref()
+                        .is_some_and(|flag| flag.load(Ordering::Relaxed))
+                    || times.is_some_and(|max| dispatched >= max)
+                {
+                    state_scheduler::scheduler_task_finished();
+                    return None;
+                }
+                // Skip the tick while the previous iteration still runs (the
+                // timer's fixed-rate reschedule then naturally falls back to
+                // "next period after now").
+                if !busy.swap(true, Ordering::AcqRel) {
+                    dispatched += 1;
+                    let state = state.clone();
+                    let busy = busy.clone();
+                    let stopped = stopped.clone();
+                    let running_thread = running_thread.clone();
+                    crate::runtime::worker_pool::submit(move || {
+                        if let Ok(mut g) = running_thread.lock() {
+                            *g = Some(std::thread::current().id());
+                        }
+                        if let Ok(mut guard) = state.lock() {
+                            let (interp, p) = &mut *guard;
+                            // Re-check cancellation at execution time: the
+                            // dispatch-to-execution window (pool queue + lock)
+                            // is far wider than the retired loop's
+                            // check-to-call gap, and `.cancel` only waits for
+                            // iterations it could see dispatched.
+                            let is_cancelled = || {
+                                p.cancel_flag
+                                    .as_ref()
+                                    .is_some_and(|flag| flag.load(Ordering::Relaxed))
+                            };
+                            if !is_cancelled() {
+                                if interp.scheduler_check_stop(&p.stop_cb) {
+                                    stopped.store(true, Ordering::Relaxed);
+                                } else if !is_cancelled() {
+                                    // Second check right before the call: the
+                                    // stop probe above does a full shared-var
+                                    // env sync, which is most of the window.
+                                    let _ =
+                                        interp.scheduler_call_with_catch(&p.callback, &p.catch_cb);
+                                }
+                            }
+                        }
+                        if let Ok(mut g) = running_thread.lock() {
+                            *g = None;
+                        }
+                        busy.store(false, Ordering::Release);
+                    });
+                }
+                Some(std::time::Duration::from_secs_f64(interval))
+            }),
+        );
+        Ok(())
+    }
+
+    /// Synchronous scheduler execution (CurrentThreadScheduler). `:every` is
+    /// rejected up front on a CurrentThreadScheduler, so there is no repeat
+    /// handling here.
+    fn scheduler_run_sync(&mut self, p: CueParams) -> Result<(), RuntimeError> {
+        if !Self::scheduler_sleep(p.delay) {
+            return Ok(());
+        }
+        let count = p.times.unwrap_or(1);
+        for _ in 0..count {
             if Self::scheduler_is_cancelled(&p.cancel_flag) {
                 break;
             }
-            if self.scheduler_check_stop(&p.stop_cb) {
-                break;
-            }
-            if propagate_errors {
-                self.scheduler_call_with_catch(&p.callback, &p.catch_cb)?;
-            } else {
-                let _ = self.scheduler_call_with_catch(&p.callback, &p.catch_cb);
-            }
-            count += 1;
-            if p.times.is_some_and(|max| count >= max) {
-                break;
-            }
-            if interval == f64::INFINITY {
-                break;
-            } else if interval > 0.0 && interval.is_finite() {
-                // Quiescent — see `scheduler_sleep`.
-                crate::gc::block_quiescent(|| {
-                    crate::runtime::thread_compat::sleep(std::time::Duration::from_secs_f64(
-                        interval,
-                    ))
-                });
-            }
+            self.scheduler_call_with_catch(&p.callback, &p.catch_cb)?;
         }
         Ok(())
     }
 
-    /// Synchronous scheduler execution (CurrentThreadScheduler)
-    fn scheduler_run_sync(&mut self, p: CueParams) -> Result<(), RuntimeError> {
-        if !Self::scheduler_sleep(p.delay) {
-            // Inf delay: for :every(Inf), run once then stop
-            if p.every.is_some() {
-                self.scheduler_call_with_catch(&p.callback, &p.catch_cb)?;
-            }
-            return Ok(());
-        }
-
-        if p.every.is_some() {
-            self.scheduler_run_every_loop(&p, true)?;
-        } else {
-            let count = p.times.unwrap_or(1);
-            for _ in 0..count {
-                if Self::scheduler_is_cancelled(&p.cancel_flag) {
-                    break;
-                }
-                self.scheduler_call_with_catch(&p.callback, &p.catch_cb)?;
-            }
-        }
-        Ok(())
-    }
-
-    /// Async scheduler execution (ThreadPoolScheduler) - runs in spawned thread
+    /// Async scheduler execution (ThreadPoolScheduler) — runs in a pooled
+    /// worker task. Finite `:every` never reaches this (it is timer-driven,
+    /// `cue_every_timer`); an `:every(Inf)` cue or an Inf `:in` delay lands
+    /// here and runs once, preserving the retired repeat loop's break-after-
+    /// one-run on an infinite interval.
     fn scheduler_run_async(&mut self, p: CueParams) {
         if !Self::scheduler_sleep(p.delay) {
-            // Inf delay: for :every(Inf), run once then stop
+            // Inf delay: for :every, run once then stop
             if p.every.is_some() {
                 let _ = self.scheduler_call_with_catch(&p.callback, &p.catch_cb);
             }
@@ -530,7 +635,11 @@ impl Interpreter {
         }
 
         if p.every.is_some() {
-            let _ = self.scheduler_run_every_loop(&p, false);
+            if !Self::scheduler_is_cancelled(&p.cancel_flag)
+                && !self.scheduler_check_stop(&p.stop_cb)
+            {
+                let _ = self.scheduler_call_with_catch(&p.callback, &p.catch_cb);
+            }
         } else {
             let count = p.times.unwrap_or(1);
             for _ in 0..count {

--- a/src/runtime/native_methods/state_lock.rs
+++ b/src/runtime/native_methods/state_lock.rs
@@ -54,6 +54,45 @@ pub(super) fn cancellation_state(id: u64) -> Option<Arc<AtomicBool>> {
         .and_then(|map| map.get(&id).cloned())
 }
 
+/// A timer-driven `:every` cue's in-flight state, registered under its
+/// Cancellation id: `busy` is true from tick dispatch to iteration completion,
+/// `running_thread` names the worker actually executing the callback. Lets
+/// `.cancel` wait (bounded) for the in-flight iteration so no callback side
+/// effect lands after `.cancel` returns — see `cue_every_timer` and
+/// `native_cancellation`.
+pub(super) struct CancellationBusy {
+    pub(super) busy: Arc<AtomicBool>,
+    pub(super) running_thread: Arc<std::sync::Mutex<Option<std::thread::ThreadId>>>,
+}
+
+type CancellationBusyMap = std::sync::Mutex<HashMap<u64, Arc<CancellationBusy>>>;
+
+fn cancellation_busy_map() -> &'static CancellationBusyMap {
+    static MAP: OnceLock<CancellationBusyMap> = OnceLock::new();
+    MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+pub(super) fn register_cancellation_busy(id: u64, state: Arc<CancellationBusy>) {
+    if id > 0
+        && let Ok(mut map) = cancellation_busy_map().lock()
+    {
+        map.insert(id, state);
+    }
+}
+
+pub(super) fn cancellation_busy(id: u64) -> Option<Arc<CancellationBusy>> {
+    cancellation_busy_map()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&id).cloned())
+}
+
+pub(super) fn drop_cancellation_busy(id: u64) {
+    if let Ok(mut map) = cancellation_busy_map().lock() {
+        map.remove(&id);
+    }
+}
+
 pub(crate) fn lock_runtime_by_id(id: u64) -> Option<Arc<LockRuntime>> {
     lock_state_map()
         .read()

--- a/todo/tickets/cue-loop-lexical-shared-lane-residue.md
+++ b/todo/tickets/cue-loop-lexical-shared-lane-residue.md
@@ -1,0 +1,63 @@
+# A loop-redeclared lexical mutated by a `cue` callback keeps its previous iteration's value
+
+## Minimal repro
+
+```raku
+for 1..6 -> $round {
+    my $a = 0;
+    my $c = $*SCHEDULER.cue({ cas $a, {.succ} }, :every(0.1));
+    sleep 1;
+    $c.cancel;
+    say "round $round: $a";   # expected ~10 every round
+}
+```
+
+mutsu prints `10, 20, 30, 41, 52, 62` — each round's `$a` starts from the
+previous round's final value instead of 0. raku prints ~10 every round. The
+same shape with `start` instead of `cue` is correct (`1, 1, 1` for
+`for 1..3 { my $a = 0; await start { cas $a, {.succ} }; say $a }`).
+
+**This is NOT an ADR-0020 regression**: it reproduces identically on the
+pre-pool thread-per-cue implementation (verified on main `2d6db20c4`, which
+prints `10, 20, ..., 60`).
+
+## Root cause (as far as traced, 2026-08-05)
+
+The `cas $a` in the cue callback does not go through the name-keyed shared
+lane (`shared_vars` stays `0` throughout, observed with debug tracing) — it
+goes through the bare-name atomic key machinery (`reset_atomic_var_key_decl` /
+`__mutsu_atomic…`), and for a *loop-body* lexical the redeclaration reset does
+not stick: the next iteration's `my $a = 0` runs `reset_atomic_var_key_decl`,
+but the callback thread's writes re-create/overwrite the bare-name entry, and
+the loop iteration's fresh `$a` resolves back to it. Block-scoped versions
+(`{ my $a = 0; ... }` sequences) are mostly unaffected because each block's
+decl + `thread_redeclared_vars` mask + `clone_for_thread`'s `declare` reseeds
+the lane; the loop-body slot path skips part of that (the loop lexical lives
+in a slot, `env.get("a")` at cue time shows the right `0`, yet the callback
+still resolves the stale atomic entry).
+
+Related mechanism notes: `clone_for_thread_excluding` (ADR-0010 seeding),
+`vm_var_assign_set_local.rs` (`thread_redeclared_vars` /
+`reset_atomic_var_key_decl`), and the `t/lock.t` fix (#4167) which moved
+shared-array pushes to the `__mutsu_atomic_arr::` store — the scalar `cas`
+lane has the same bare-name-cannot-represent-two-bindings limitation.
+
+## Why it is not fixed inline
+
+The fix is in the bare-name atomic lane's interaction with loop-redeclared
+lexicals, not in the scheduler: any callback-holding construct that outlives a
+loop iteration (a `cue`, a tap, a timer) can resurrect the entry. It needs the
+same per-binding-cell treatment `start` blocks got via
+`box_captured_lexicals`/`clone_for_thread_for_block` (which `cue` now uses,
+2026-08-05 — insufficient because the atomic lane is separate), or the atomic
+key needs a binding-generation component. That is ADR-0010/Track-B-adjacent
+design work.
+
+## Impact
+
+- `:every` cues (and plausibly taps/timers) whose callbacks `cas`/atomically
+  mutate a loop-body lexical accumulate across iterations.
+- The `.cancel` bounded wait added in ADR-0020 slice 2 hides the common roast
+  shape (block-sequenced cues, `LEAVE $c.cancel`), so
+  `roast/S17-scheduler/every.t` is stable — but the loop shape above remains
+  wrong deterministically.


### PR DESCRIPTION
Implements slice 2 of [ADR-0020](docs/adr/0020-shared-worker-pool.md): a repeating `$*SCHEDULER.cue(:every)` no longer owns a dedicated OS thread — it is a deadline-heap timer entry (`interval_timer::register_entry`, now `pub(crate)`) that enqueues each iteration onto the worker pool, skipping a tick while the previous iteration still runs. `scheduler_run_every_loop` is retired.

## Results

- **50 idle `cue(:every(60))`: 52 threads / 16.7 GB VmSize → 4 threads / 761 MB** (ADR §1.1's worst resource row; raku idles at 5 threads / 1.2 GB on this host).
- Sub-1ms (zero/negative/`-Inf`) intervals clamp to **Rakudo's 1ms minimum timer resolution** with the same warning; mutsu previously busy-spun at ~49k iterations/s where raku runs ~890/s.
- `:in`/`:at` delays, exact `:times`, `:stop`, `:catch`, `:every(Inf)` run-once, and `-Inf` all preserved.

## The race this surfaced (and the fix)

Intermittent `roast/S17-scheduler/every.t` failures ("seen 21 runs") traced to: a dead cue's **in-flight last iteration** (dispatched before `.cancel`) completing after the next block re-declares the same-named lexical — the callback's `cas $a` resurrects the old count through the bare-name atomic lane. The retired loop had the same race with a µs-wide check-to-call window; the pool's dispatch-to-execution window made it observable.

Fix: `Cancellation.cancel` now does a **bounded wait** (100ms cap, self-cancel-safe via ThreadId comparison) for the in-flight iteration, registered per cancellation id (`CancellationBusy` in `state_lock.rs`). After the fix: 15/15 release runs green, 5/5 under `MUTSU_GC=on`.

The *underlying* bare-name-lane residue is a **pre-existing bug** — it reproduces deterministically on main's thread-per-cue implementation too (loop-body `my $a = 0` + cue callback accumulates 10, 20, 30…). Recorded with a minimal repro and root-cause notes in `todo/tickets/cue-loop-lexical-shared-lane-residue.md`.

## Verified locally

`make test` passes (27,453 tests); `roast/S17-scheduler/{every,basic,times,in,at}.t` + `S17-promise/{basic,start,in,at}.t` + `S17-lowlevel/semaphore.t` all pass on release; every.t additionally 15× release + 5× `MUTSU_GC=on`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)