### PR TITLE
perf(threads): pool supply emitters, socket pumps, hyper/race batches (ADR-0020 slice 3)

### DIFF
--- a/docs/adr/0020-shared-worker-pool.md
+++ b/docs/adr/0020-shared-worker-pool.md
@@ -1,6 +1,8 @@
 # ADR-0020: Shared worker pool — elastic growth, blocking `await`
 
-- Status: **Proposed**
+- Status: **Accepted** (all implementation slices landed 2026-08-05; the companion
+  per-task clone slimming is out of scope here — see
+  `todo/tickets/digest-ripemd-start-per-block-overhead.md`)
 - Date: 2026-08-05
 - Context: extracted from PLAN.md §5 via `todo/deep/shared-worker-pool-adr.md` (2026-08-02);
   groundwork measured 2026-07-17 on main `159a30cb0` and re-measured 2026-08-05 on main
@@ -201,4 +203,17 @@ Concretely:
       bounded `.cancel` wait for the in-flight iteration — the pool's wider
       dispatch-to-execution window otherwise let a dead cue's last `cas` resurrect a
       successor cue's same-named lexical through the bare-name atomic lane).
-- [ ] Slice 3: supply emitters / socket pumps / hyper-race, case by case.
+- [x] Slice 3: supply emitters / socket pumps / hyper-race, case by case
+      (2026-08-05). Pooled: the two `Supply.throttle` coordinators and their
+      joined workers, the per-value `Supply.start` runner, promise-waiter
+      dispatch (`dispatch_waiters`), the uncaught-handler one-shot, the
+      zip / zip-latest pumps, both `run_supply_act_loop` drivers, the bare-tap
+      socket accept driver, and the hyper/race batch workers. Joined fan-outs
+      go through the new `worker_pool::submit_joinable` (native: pool + result
+      channel, a panicking task surfaces as a disconnected channel = `Err` on
+      join; wasm32: delegates to the cooperative `JoinHandle`, whose `join`
+      runs the queued task — the cfg fork lives in `worker_pool.rs` only).
+      Supply-lifetime pumps borrow a worker until done — same thread cost as
+      before while alive, warm reuse across create/tear-down churn
+      (Cro-style per-connection pipelines). `Thread.start` stays a dedicated
+      thread per §3.6.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,4 +45,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0017](0017-cli-option-errors-follow-rakudo.md) | A command-line *option* error follows rakudo — message, stream, and a zero exit status | Accepted |
 | [0018](0018-slot-addressed-lexical-capture-and-env-sync.md) | Slot-addressed lexical capture and env synchronization | Accepted |
 | [0019](0019-compiled-declarations-and-unified-method-dispatch.md) | Compile declarations and unify method dispatch entries | Proposed |
-| [0020](0020-shared-worker-pool.md) | Shared worker pool — elastic growth, blocking `await` | Proposed |
+| [0020](0020-shared-worker-pool.md) | Shared worker pool — elastic growth, blocking `await` | Accepted (all slices landed; per-task clone slimming tracked separately) |

--- a/news/2026-08/worker-pool-slice3-supply-socket-hyper.md
+++ b/news/2026-08/worker-pool-slice3-supply-socket-hyper.md
@@ -1,0 +1,36 @@
+# Worker pool slice 3: supply emitters, socket pumps, hyper/race batches (ADR-0020)
+
+The third slice of the ADR-0020 shared-worker-pool campaign routes the
+remaining user-code spawn sites through the elastic pool. After this slice,
+`Thread.start` is the only `spawn_user_thread` call site left — deliberately,
+per ADR-0020 §3.6: a `Thread.start` thread has user-visible identity
+(`$*THREAD.id`) that must stay stable for its whole lifetime.
+
+What moved onto the pool, case by case:
+
+- **Short one-shots** — the per-value `Supply.start` block runner (fires per
+  emitted value, the hottest supply spawner), promise-waiter dispatch
+  (`SharedPromise::dispatch_waiters`, fired on every resolution with queued
+  `.then`/`.andthen` waiters; ordering is unchanged because all of a promise's
+  waiters run in registration order inside one pooled task), the
+  uncaught-handler callback, and both `Supply.throttle` coordinators.
+- **Joined fan-outs** — hyper/race batch workers and `Supply.throttle`'s
+  concurrency-limited workers. These needed a new `worker_pool::submit_joinable`
+  API: natively it pairs a pooled task with a result channel (a panicking task
+  drops the sender during unwind, so `join` reports `Err` exactly like a
+  dedicated thread's join); on wasm32 it delegates to the cooperative
+  scheduler's `JoinHandle`, whose `join` *runs* the queued task — a channel
+  wait would spin forever there, which is why the cfg fork lives inside
+  `worker_pool.rs` rather than at call sites. Inter-item synchronization
+  (Promises between hyper items) still works: the submit-side starvation check
+  gives every batch its own worker, the same concurrency as thread-per-batch.
+- **Supply-lifetime pumps** — the zip / zip-latest coordinators, both
+  `run_supply_act_loop` drivers (live `.act`/`.tap`, whenever socket sources),
+  and the bare-tap socket accept driver. A pump borrows a worker until its
+  supply is done, so the steady-state thread cost is unchanged; the win is
+  warm reuse across create/tear-down churn — exactly the Cro-style
+  per-connection pipeline shape, where each connection previously paid a
+  fresh 256 MiB-stack thread spawn.
+
+`MUTSU_POOL=off` still restores thread-per-task at every site (the joinable
+path falls back to a dedicated thread that feeds the same channel).

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -248,7 +248,8 @@ impl Interpreter {
                     {
                         let handler_interp = thread_interp.clone_for_thread();
                         let ex_val = error_val;
-                        spawn_user_thread(move || {
+                        // Pooled (ADR-0020 slice 3): short one-shot callback.
+                        crate::runtime::worker_pool::submit(move || {
                             let mut handler_interp = handler_interp;
                             let _ = handler_interp.call_value(handler, vec![ex_val]);
                         });

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -396,6 +396,8 @@ impl Interpreter {
         // default ~2-8 MiB thread stack overflows on deep VM nesting (e.g. an
         // async server whose react loop constructs objects whose BUILD re-enters
         // the VM -- HTTP::Server::Tiny). See `USER_THREAD_STACK_SIZE`.
+        // Deliberately NOT pooled (ADR-0020 §3.6): a `Thread.start` thread has
+        // user-visible identity (`$*THREAD.id`) stable for its whole lifetime.
         let handle = crate::runtime::builtins_system::spawn_user_thread(move || {
             // Set the mutsu thread ID for $*THREAD.id consistency
             super::set_current_mutsu_thread_id(mutsu_tid);

--- a/src/runtime/methods_supply_dispatch.rs
+++ b/src/runtime/methods_supply_dispatch.rs
@@ -198,8 +198,10 @@ impl Interpreter {
 
         // Buffers and emits `Value`s (Gc nodes): registered GC mutator; the
         // poll loop parks at a GC park point each round so a stop-the-world
-        // can proceed while it idles.
-        crate::runtime::builtins_system::spawn_user_thread(move || {
+        // can proceed while it idles. Pooled (ADR-0020 slice 3): the pump
+        // borrows a worker for the supply's lifetime and returns it on done —
+        // warm reuse when supplies are created/torn down repeatedly.
+        crate::runtime::worker_pool::submit(move || {
             let n = sources.len();
             let mut buffers: Vec<std::collections::VecDeque<Value>> =
                 vec![std::collections::VecDeque::new(); n];

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -503,7 +503,10 @@ impl Interpreter {
                 } else if !matches!(callback.view(), ValueView::Nil) {
                     let cb = callback.clone();
                     let mut driver = self.clone_for_thread();
-                    crate::runtime::builtins_system::spawn_user_thread(move || {
+                    // Pooled (ADR-0020 slice 3): per-listener accept driver —
+                    // warm reuse across short-lived listeners (Cro-style
+                    // per-connection churn).
+                    crate::runtime::worker_pool::submit(move || {
                         let Some(rx) = take_supply_channel(supply_id) else {
                             return;
                         };

--- a/src/runtime/native_supply_dispatch.rs
+++ b/src/runtime/native_supply_dispatch.rs
@@ -1075,7 +1075,8 @@ impl Interpreter {
 
                         // Holds and emits `Value`s (Gc nodes): registered GC
                         // mutator; parks each poll round for stop-the-world.
-                        crate::runtime::builtins_system::spawn_user_thread(move || {
+                        // Pooled (ADR-0020 slice 3): supply-lifetime pump.
+                        crate::runtime::worker_pool::submit(move || {
                             let n = sources.len();
                             let mut latest: Vec<Option<Value>> = vec![None; n];
                             let mut done: Vec<bool> = vec![false; n];

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -242,7 +242,8 @@ impl Interpreter {
                     let delay = delay_seconds;
                     let done = done_cb.clone();
                     let quit = quit_cb.clone();
-                    crate::runtime::builtins_system::spawn_user_thread(move || {
+                    // Pooled (ADR-0020 slice 3): supply-lifetime act driver.
+                    crate::runtime::worker_pool::submit(move || {
                         Self::run_supply_act_loop(&mut thread_interp, &rx, &cb, delay, done, quit);
                     });
                     let tap_instance = Value::make_instance(Symbol::intern("Tap"), HashMap::new());
@@ -585,7 +586,9 @@ impl Interpreter {
                                 };
                                 let mut driver = self.clone_for_thread();
                                 let body_cb = body_cb.clone();
-                                crate::runtime::builtins_system::spawn_user_thread(move || {
+                                // Pooled (ADR-0020 slice 3): whenever-source
+                                // reader, lives until the channel closes.
+                                crate::runtime::worker_pool::submit(move || {
                                     Self::run_supply_act_loop(
                                         &mut driver,
                                         &rx,

--- a/src/runtime/supply_transform.rs
+++ b/src/runtime/supply_transform.rs
@@ -77,8 +77,9 @@ impl Interpreter {
                 let mut thread_interp = self.clone_for_thread();
                 // Runs a full interpreter (VM safepoints park it during
                 // execution): registered GC mutator; the control wait and the
-                // worker joins are quiescent safe regions.
-                crate::runtime::builtins_system::spawn_user_thread(move || {
+                // worker joins are quiescent safe regions. Pooled (ADR-0020
+                // slice 3): one-shot coordinator, may block — the pool grows.
+                crate::runtime::worker_pool::submit(move || {
                     let current_limit = wait_for_control_limit(ctrl_id);
                     let effective_limit = if current_limit > 0 {
                         current_limit
@@ -104,43 +105,37 @@ impl Interpreter {
                         let next_idx = Arc::clone(&next_idx);
                         let emit_lock = Arc::clone(&emit_lock);
                         let emitted_count = Arc::clone(&emitted_count);
-                        handles.push(crate::runtime::builtins_system::spawn_user_thread(
-                            move || {
-                                loop {
-                                    let idx =
-                                        next_idx.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    if idx >= vals.len() {
-                                        break;
-                                    }
-                                    if let Ok(result) = winterp.call_sub_value(
-                                        blk.clone(),
-                                        vec![vals[idx].clone()],
-                                        false,
-                                    ) {
-                                        let promise = SharedPromise::new_kept(result);
-                                        let pval = Value::promise(promise);
-                                        let _guard = emit_lock.lock().unwrap();
-                                        supplier_emit(out_supplier_id, pval.clone());
-                                        let actions =
-                                            supplier_emit_callbacks(out_supplier_id, &pval);
-                                        for action in actions {
-                                            if let SupplierEmitAction::Call(tap, emitted, delay) =
-                                                action
-                                            {
-                                                Self::sleep_for_supply_delay(delay);
-                                                let _ = winterp.call_sub_value(
-                                                    tap,
-                                                    vec![emitted],
-                                                    true,
-                                                );
-                                            }
-                                        }
-                                        emitted_count
-                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    }
+                        handles.push(crate::runtime::worker_pool::submit_joinable(move || {
+                            loop {
+                                let idx =
+                                    next_idx.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                if idx >= vals.len() {
+                                    break;
                                 }
-                            },
-                        ));
+                                if let Ok(result) = winterp.call_sub_value(
+                                    blk.clone(),
+                                    vec![vals[idx].clone()],
+                                    false,
+                                ) {
+                                    let promise = SharedPromise::new_kept(result);
+                                    let pval = Value::promise(promise);
+                                    let _guard = emit_lock.lock().unwrap();
+                                    supplier_emit(out_supplier_id, pval.clone());
+                                    let actions = supplier_emit_callbacks(out_supplier_id, &pval);
+                                    for action in actions {
+                                        if let SupplierEmitAction::Call(tap, emitted, delay) =
+                                            action
+                                        {
+                                            Self::sleep_for_supply_delay(delay);
+                                            let _ =
+                                                winterp.call_sub_value(tap, vec![emitted], true);
+                                        }
+                                    }
+                                    emitted_count
+                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                }
+                            }
+                        }));
                     }
                     for handle in handles {
                         let _ = crate::gc::block_quiescent(|| handle.join());
@@ -205,8 +200,8 @@ impl Interpreter {
             let secs = seconds;
             let mut thread_interp = self.clone_for_thread();
             // Registered GC mutator (runs a full interpreter); the control
-            // wait is a quiescent safe region.
-            crate::runtime::builtins_system::spawn_user_thread(move || {
+            // wait is a quiescent safe region. Pooled (ADR-0020 slice 3).
+            crate::runtime::worker_pool::submit(move || {
                 let current_limit = wait_for_control_limit(ctrl_id);
                 let effective_limit = if current_limit > 0 {
                     current_limit as usize
@@ -369,9 +364,10 @@ impl Interpreter {
             }
         }
 
-        // Spawn a thread to run the block asynchronously
+        // Run the block asynchronously. Pooled (ADR-0020 slice 3): fires per
+        // emitted value — the hottest supply spawner, warm reuse pays here.
         let mut thread_interp = self.clone_for_thread();
-        crate::runtime::builtins_system::spawn_user_thread(move || {
+        crate::runtime::worker_pool::submit(move || {
             let result_val = thread_interp
                 .call_sub_value(callable, vec![value], true)
                 .unwrap_or(Value::NIL);

--- a/src/runtime/worker_pool.rs
+++ b/src/runtime/worker_pool.rs
@@ -163,3 +163,60 @@ pub(crate) fn submit(task: impl FnOnce() + Send + 'static) {
 pub(crate) fn submit(task: impl FnOnce() + Send + 'static) {
     crate::runtime::builtins_system::spawn_user_thread(task);
 }
+
+/// Handle on a pooled task whose completion (and result) the spawner waits
+/// for. Natively this is a channel the task sends its result on — a worker
+/// that panics drops the sender during unwind, so `join` reports the panic as
+/// `Err` exactly like a dedicated thread's `join` would. On wasm32 it wraps
+/// the cooperative scheduler's `JoinHandle`, whose `join` *runs* the queued
+/// task — a channel wait would spin forever there, which is why the cfg fork
+/// lives here and not at the call sites.
+pub(crate) struct TaskHandle<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    rx: std::sync::mpsc::Receiver<T>,
+    #[cfg(target_arch = "wasm32")]
+    inner: crate::runtime::thread_compat::JoinHandle<T>,
+}
+
+impl<T> TaskHandle<T> {
+    /// Wait for the task to finish and take its result. Callers wrap this in
+    /// `gc::block_quiescent` like any thread join — the wait itself touches no
+    /// `Gc` state.
+    pub(crate) fn join(self) -> std::thread::Result<T> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.rx
+                .recv()
+                .map_err(|e| Box::new(e) as Box<dyn std::any::Any + Send>)
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.inner.join()
+        }
+    }
+}
+
+/// Run `task` on a pooled worker and return a handle its spawner can `join`.
+/// For the joined fan-out sites (hyper/race batches, throttle workers) that
+/// need every task running *concurrently*: the submit-side starvation check
+/// spawns a fresh worker whenever none is idle, so N submitted tasks get N
+/// workers just like thread-per-task did.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn submit_joinable<T: Send + 'static>(
+    task: impl FnOnce() -> T + Send + 'static,
+) -> TaskHandle<T> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    submit(move || {
+        let _ = tx.send(task());
+    });
+    TaskHandle { rx }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn submit_joinable<T: Send + 'static>(
+    task: impl FnOnce() -> T + Send + 'static,
+) -> TaskHandle<T> {
+    TaskHandle {
+        inner: crate::runtime::builtins_system::spawn_user_thread(task),
+    }
+}

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -193,7 +193,10 @@ impl SharedPromise {
         if waiters.is_empty() {
             return;
         }
-        crate::runtime::builtins_system::spawn_user_thread(move || {
+        // Pooled (ADR-0020 slice 3): fires on every promise resolution that
+        // has queued waiters. Ordering is preserved — all of this promise's
+        // waiters run in registration order inside the single pooled task.
+        crate::runtime::worker_pool::submit(move || {
             for waiter in waiters {
                 waiter(
                     status.clone(),

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -54,70 +54,70 @@ impl Interpreter {
             String,
             String,
         );
-        let mut handles: Vec<crate::runtime::thread_compat::JoinHandle<ThreadResult>> =
+        let mut handles: Vec<crate::runtime::worker_pool::TaskHandle<ThreadResult>> =
             Vec::with_capacity(num_batches);
         for batch in batches {
             let thread_interp = self.clone_for_thread();
             let block_clone = block.clone();
             let is_map_flag = is_map;
-            // Large user-code stack: hyper/race batch threads run user VM code,
-            // which overflows the default thread stack on deep nesting.
-            handles.push(crate::runtime::builtins_system::spawn_user_thread(
-                move || {
-                    // CP-3 collapse: the cloned per-thread Interpreter *is* the Interpreter.
-                    let mut vm = thread_interp;
-                    let mut results = Vec::with_capacity(batch.len());
-                    let mut error: Option<RuntimeError> = None;
-                    for item in &batch {
-                        if error.is_some() {
-                            break;
-                        }
-                        // Route the per-item user-code call through the same
-                        // panic->X::AdHoc boundary that `start{}`/Promise workers use
-                        // (`guard_worker_panic`). Without it, a Rust panic raised by
-                        // user code in this batch thread only surfaces as a generic
-                        // "Thread panicked in hyper/race" at `join()` and leaks the raw
-                        // Rust panic message to stderr; the guard converts it into a
-                        // catchable X::AdHoc and suppresses the default backtrace dump,
-                        // making worker panic handling uniform across all spawn sites.
-                        let call_result = crate::vm::guard_worker_panic(|| {
-                            vm.vm_call_on_value(block_clone.clone(), vec![item.clone()], None)
-                        });
-                        match call_result {
-                            Ok(val) => {
-                                if is_map_flag {
-                                    // A callback returning a finite lazy `.map`/
-                                    // `.grep` pipe must reify here — the wrapped
-                                    // HyperSeq's downstream `.flat`/`for` use static
-                                    // readers that cannot force a nested pipe.
-                                    match vm.reify_finite_pipe_value(val) {
-                                        Ok(val) => {
-                                            if let ValueView::Slip(s) = val.view() {
-                                                results.extend(s.iter().cloned());
-                                            } else {
-                                                results.push(val);
-                                            }
+            // Pooled (ADR-0020 slice 3). Inter-batch synchronization (e.g.
+            // Promises between items) still works: the submit-side starvation
+            // check gives every batch its own worker, same concurrency as
+            // thread-per-batch. Workers keep the large user-code stack.
+            handles.push(crate::runtime::worker_pool::submit_joinable(move || {
+                // CP-3 collapse: the cloned per-thread Interpreter *is* the Interpreter.
+                let mut vm = thread_interp;
+                let mut results = Vec::with_capacity(batch.len());
+                let mut error: Option<RuntimeError> = None;
+                for item in &batch {
+                    if error.is_some() {
+                        break;
+                    }
+                    // Route the per-item user-code call through the same
+                    // panic->X::AdHoc boundary that `start{}`/Promise workers use
+                    // (`guard_worker_panic`). Without it, a Rust panic raised by
+                    // user code in this batch thread only surfaces as a generic
+                    // "Thread panicked in hyper/race" at `join()` and leaks the raw
+                    // Rust panic message to stderr; the guard converts it into a
+                    // catchable X::AdHoc and suppresses the default backtrace dump,
+                    // making worker panic handling uniform across all spawn sites.
+                    let call_result = crate::vm::guard_worker_panic(|| {
+                        vm.vm_call_on_value(block_clone.clone(), vec![item.clone()], None)
+                    });
+                    match call_result {
+                        Ok(val) => {
+                            if is_map_flag {
+                                // A callback returning a finite lazy `.map`/
+                                // `.grep` pipe must reify here — the wrapped
+                                // HyperSeq's downstream `.flat`/`for` use static
+                                // readers that cannot force a nested pipe.
+                                match vm.reify_finite_pipe_value(val) {
+                                    Ok(val) => {
+                                        if let ValueView::Slip(s) = val.view() {
+                                            results.extend(s.iter().cloned());
+                                        } else {
+                                            results.push(val);
                                         }
-                                        Err(e) => error = Some(e),
                                     }
-                                } else if val.truthy() {
-                                    results.push(item.clone());
+                                    Err(e) => error = Some(e),
                                 }
+                            } else if val.truthy() {
+                                results.push(item.clone());
                             }
-                            Err(e) => {
-                                error = Some(e);
-                            }
+                        }
+                        Err(e) => {
+                            error = Some(e);
                         }
                     }
-                    let output = vm.take_output();
-                    let stderr = vm.take_stderr_output();
-                    let final_result = match error {
-                        Some(e) => Err(e),
-                        None => Ok(results),
-                    };
-                    (vm, final_result, output, stderr)
-                },
-            ));
+                }
+                let output = vm.take_output();
+                let stderr = vm.take_stderr_output();
+                let final_result = match error {
+                    Some(e) => Err(e),
+                    None => Ok(results),
+                };
+                (vm, final_result, output, stderr)
+            }));
         }
         let mut all_results = Vec::with_capacity(items.len());
         let mut first_error: Option<RuntimeError> = None;


### PR DESCRIPTION
## Summary

The third and final implementation slice of the ADR-0020 shared-worker-pool campaign: route the remaining user-code spawn sites through the elastic pool. After this slice, `Thread.start` is the **only** `spawn_user_thread` call site left — deliberately, per ADR-0020 §3.6 (user-visible `$*THREAD.id` identity must stay stable for the thread's lifetime).

### Pooled, case by case

- **Short one-shots** — the per-value `Supply.start` runner (fires per emitted value, the hottest supply spawner), promise-waiter dispatch (`dispatch_waiters`, fired on every resolution with queued `.then`/`.andthen` waiters; registration order is preserved inside the single pooled task), the uncaught-handler callback, and both `Supply.throttle` coordinators.
- **Joined fan-outs** — hyper/race batch workers and `Supply.throttle`'s concurrency-limited workers, via the new `worker_pool::submit_joinable`:
  - native: pooled task + result channel — a panicking task drops the sender during unwind, so `join` reports `Err` exactly like a dedicated thread's join;
  - wasm32: delegates to the cooperative scheduler's `JoinHandle`, whose `join` *runs* the queued task — a channel wait would spin forever there, so the cfg fork lives in `worker_pool.rs` only.
  - Inter-item Promise synchronization still works: the submit-side starvation check gives every batch its own worker (same concurrency as thread-per-batch).
- **Supply-lifetime pumps** — zip / zip-latest coordinators, both `run_supply_act_loop` drivers, and the bare-tap socket accept driver. A pump borrows a worker until its supply is done — same steady-state thread cost, warm reuse across create/tear-down churn (the Cro-style per-connection pipeline shape).

`MUTSU_POOL=off` still restores thread-per-task at every site.

### ADR status

This completes the ADR-0020 implementation checklist (prelim #5921, slice 1 #5923, slice 2 #5925): the ADR moves **Proposed → Accepted**. The companion per-task clone slimming (the dominant ripemd lever, ADR §1.3) stays deliberately out of scope, tracked in `todo/tickets/digest-ripemd-start-per-block-overhead.md`.

## Test plan

- `make test` green locally (2888 files / 27453 tests).
- Targeted suites green: supply/hyper/promise/socket `t/` files (75 files / 388 tests) and 14 relevant roast files (throttle / zip / zip-latest / act / start / hyperrace / promise / procasync, stress included, 279 tests).
- `cargo clippy -- -D warnings` + `cargo fmt` clean.
- CI runs the full `make roast` as the comprehensive safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)