### PR TITLE
perf(runtime): SharedStore lineage maps use FxHashMap (slice 0)

### DIFF
--- a/src/runtime/builtins_atomic.rs
+++ b/src/runtime/builtins_atomic.rs
@@ -177,7 +177,7 @@ impl Interpreter {
 
     pub(super) fn atomic_current_value(
         &self,
-        shared: &std::collections::HashMap<String, Value>,
+        shared: &rustc_hash::FxHashMap<String, Value>,
         name: &str,
         value_key: &str,
     ) -> Value {

--- a/src/runtime/shared_store.rs
+++ b/src/runtime/shared_store.rs
@@ -15,8 +15,12 @@
 //! - **declare** — always this lineage's `own`, shadowing any ancestor entry.
 
 use crate::value::Value;
-use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+
+// Lineage-store maps are String-keyed and hit on every spawn's seeding loop;
+// use FxHash instead of SipHash (variable names are program identifiers, not
+// attacker-controlled data, so HashDoS hardening buys nothing here).
+use rustc_hash::FxHashMap as HashMap;
 
 /// One lineage's slice of the cross-thread store, plus a link to the lineage
 /// that spawned it.
@@ -43,7 +47,7 @@ impl SharedStore {
     /// A root store — the main thread's lineage.
     pub(crate) fn root() -> Arc<Self> {
         Arc::new(Self {
-            own: RwLock::new(HashMap::new()),
+            own: RwLock::new(HashMap::default()),
             parent: None,
             root: None,
         })
@@ -54,7 +58,7 @@ impl SharedStore {
     /// visible and writable through the chain.
     pub(crate) fn child_of(parent: &Arc<Self>) -> Arc<Self> {
         Arc::new(Self {
-            own: RwLock::new(HashMap::new()),
+            own: RwLock::new(HashMap::default()),
             parent: Some(Arc::clone(parent)),
             root: Some(parent.root_ref()),
         })


### PR DESCRIPTION
## Summary

Slice 0 of `docs/per-task-clone-slimming.md` (companion to ADR-0020). The
per-lineage cross-thread lexical store (`src/runtime/shared_store.rs`,
ADR-0010) keyed its maps by `String` in `std::collections::HashMap`
(SipHash). Every `start {}` / pooled task spawn walks the parent env once
per key to seed the lineage store, and SipHash showed at 5.7% flat in the
ripemd-shape `perf` profile (see the plan doc §1). Switch to
`rustc_hash::FxHashMap`, matching `src/runtime/registry.rs`'s existing
justification: these keys are program-identifier variable names, not
attacker-controlled input, so HashDoS hardening buys nothing here.

One named-type call site (`builtins_atomic.rs::atomic_current_value`) took
the concrete `std::collections::HashMap` type as a parameter; updated to
`rustc_hash::FxHashMap`. All other `own_map()` callers go through type
inference and needed no change.

## Verification

- `cargo build && cargo clippy -- -D warnings && cargo fmt -- --check`: clean.
- `make test`: `Result: PASS` (Files=2888, Tests=27453).
- `MUTSU_VM_STATS=1` on `tmp/bench-start-shape.p6` (debug build) — counters
  unchanged from the plan doc's slice-0 baseline (confirms this slice is
  purely a hash-function swap, no traversal/count change):
  `clone_env=4000`, `env_deep_copies=8000`,
  `worker-pool: tasks=4000 spawns=2 warm_reuses=3998`.
- Release bench (`tmp/bench-start-shape.p6`, median of 5,
  `/usr/bin/time -f %e`): **1.66s -> ~1.22s** (1.18/1.22/1.24/1.24/1.23),
  roughly a 26% reduction. Larger than the plan doc's "a few percent"
  estimate, plausibly because the lineage-store seeding loop runs once per
  env key per spawn (4000 spawns x env size), more SipHash calls than a
  flat 5.7% profile share alone would suggest.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `make test` (local full suite)
- [x] Release bench A/B (median of 5)
- [ ] CI: full `make roast` (background watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)