### PR TITLE
perf(runtime): registry copy-on-write for per-task clone (slice 1)

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1085,21 +1085,20 @@ pub struct Interpreter {
     /// Declaration registry (enums/subsets/... — migrated group-by-group, PLAN.md ②),
     /// shared with the VM behind `Arc<RwLock>`. See [`Registry`] and `src/runtime/registry.rs`.
     /// Lock discipline: never hold a guard across user-code re-entry (deadlock).
-    registry: Arc<RwLock<Registry>>,
+    ///
+    /// The inner `Arc<Registry>` makes a per-thread spawn an O(1) share instead
+    /// of a deep clone of ~40 maps: `clone_for_thread` clones the `Arc`, and the
+    /// first *write* on either side after the share pays the one deep clone via
+    /// `Arc::make_mut` (see `RegistryWriteGuard::deref_mut`). Each thread still
+    /// gets its own outer `Arc<RwLock<...>>`, so declarations never leak between
+    /// threads — only the initial snapshot is lazily shared.
+    registry: Arc<RwLock<Arc<Registry>>>,
     /// Monotonic counter bumped on every `registry_mut()` acquisition, i.e. every
-    /// time the declaration registry may have been mutated. Used to invalidate
-    /// [`Self::regex_registry_snapshot`] so a cached snapshot is only reused while
-    /// the registry is unchanged. `AtomicU64` (not `Cell`) so `Interpreter` stays
-    /// `Send`/`Sync` — `registry_mut()` takes `&self`.
+    /// time the declaration registry may have been mutated. Several resolution
+    /// caches consult it to detect "did anything write the registry since I last
+    /// checked". `AtomicU64` (not `Cell`) so `Interpreter` stays `Send`/`Sync` —
+    /// `registry_mut()` takes `&self`.
     registry_write_gen: std::sync::atomic::AtomicU64,
-    /// Cached deep-clone snapshot of the registry (paired with the
-    /// `registry_write_gen` it was taken at) shared into the short-lived
-    /// sub-interpreters built for regex/grammar evaluation. In a hot loop that
-    /// matches many regexes/grammar tokens without declaring anything new (e.g.
-    /// zef parsing thousands of dist identities via a `grammar ... :actions`),
-    /// this collapses a full-registry deep clone *per token match* into a single
-    /// clone reused by `Arc::clone`. See `copy_full_registry_into`.
-    regex_registry_snapshot: Mutex<Option<(u64, Arc<RwLock<Registry>>)>>,
     /// Active `{*}` proto dispatch frames: (proto_name, args, method_ctx).
     /// `method_ctx` is `Some` when the active proto is a `proto method` body, so
     /// `{*}` redispatches to a multi *method* candidate on the invocant rather

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -86,32 +86,16 @@ impl Interpreter {
     pub(crate) fn copy_full_registry_into(&self, target: &mut Interpreter) {
         // The sub-interpreter only READS the registry during regex/grammar
         // evaluation (dispatching methods, resolving tokens/actions); it never
-        // declares new classes into it. So rather than deep-cloning the entire
-        // registry (all classes/roles/methods) on every call — catastrophic in a
-        // hot loop matching thousands of grammar tokens, each triggering a full
-        // clone — reuse a single cached snapshot behind an `Arc<RwLock>`, rebuilt
-        // only when the registry actually changed (tracked by `registry_write_gen`).
-        //
-        // Isolation is preserved: the snapshot is a SEPARATE `Arc<RwLock>` from
-        // `self.registry`, so any (rare) write a sub-interpreter makes lands on the
-        // shared snapshot, never leaking back into the parent's registry. Each
-        // thread has its own `Interpreter` (and thus its own cache), so the shared
-        // snapshot lock is never contended across threads.
-        let cur_gen = self
-            .registry_write_gen
-            .load(std::sync::atomic::Ordering::Relaxed);
-        {
-            let cache = self.regex_registry_snapshot.lock().unwrap();
-            if let Some((cached_gen, snapshot)) = &*cache
-                && *cached_gen == cur_gen
-            {
-                target.registry = Arc::clone(snapshot);
-                return;
-            }
-        }
-        let snapshot = Arc::new(RwLock::new(self.registry().clone()));
-        *self.regex_registry_snapshot.lock().unwrap() = Some((cur_gen, Arc::clone(&snapshot)));
-        target.registry = snapshot;
+        // declares new classes into it. Since the registry is copy-on-write
+        // (`Arc<RwLock<Arc<Registry>>>`, slice 1 of
+        // docs/per-task-clone-slimming.md), sharing the inner `Arc<Registry>`
+        // here is already O(1) — no per-call deep clone, and no snapshot cache
+        // needed. `target` gets its OWN outer `Arc<RwLock<...>>`, so a (rare)
+        // write on either side pays its own `Arc::make_mut` clone and never
+        // leaks into the other — this also fixes a latent bug in the prior
+        // shared-snapshot cache, where one sub-interpreter's write could leak
+        // into the next sub-interpreter built from the same cached snapshot.
+        target.registry = Arc::new(RwLock::new(Arc::clone(&self.registry.read().unwrap())));
     }
 
     /// Evaluate a closure interpolation `<{ code }>` inside a regex.

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -30,6 +30,7 @@
 // `HashMap`/`HashSet` names are aliased so the ~40 field declarations below
 // stay textually unchanged.
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::sync::Arc;
 
 use crate::ast::FunctionDef;
 use crate::symbol::Symbol;
@@ -787,19 +788,70 @@ impl Registry {
 // instrumentation). The registry's guards are concrete type aliases over the
 // generic guards, identified by the `"registry"` lock name in panic messages.
 
-/// Read guard for the shared [`Registry`]; a [`ReentrantReadGuard`] keyed by the
-/// `"registry"` lock name. See [`crate::runtime::lock_reentry`].
+/// Read guard for the shared [`Registry`]. Wraps a [`ReentrantReadGuard`] over
+/// the copy-on-write `Arc<Registry>` (see the `registry` field doc on
+/// `Interpreter`) and derefs straight through to `Registry`, so the ~819
+/// existing call sites (`self.registry().foo`) are unaffected by the added
+/// `Arc` layer. See [`crate::runtime::lock_reentry`].
 ///
 /// [`ReentrantReadGuard`]: crate::runtime::lock_reentry::ReentrantReadGuard
-pub(crate) type RegistryReadGuard<'a> =
-    crate::runtime::lock_reentry::ReentrantReadGuard<'a, Registry>;
+pub(crate) struct RegistryReadGuard<'a> {
+    inner: crate::runtime::lock_reentry::ReentrantReadGuard<'a, Arc<Registry>>,
+}
 
-/// Write guard for the shared [`Registry`]; a [`ReentrantWriteGuard`] keyed by
-/// the `"registry"` lock name. See [`crate::runtime::lock_reentry`].
+impl<'a> RegistryReadGuard<'a> {
+    pub(crate) fn new(lock: &'a std::sync::RwLock<Arc<Registry>>, name: &'static str) -> Self {
+        Self {
+            inner: crate::runtime::lock_reentry::ReentrantReadGuard::new(lock, name),
+        }
+    }
+}
+
+impl std::ops::Deref for RegistryReadGuard<'_> {
+    type Target = Registry;
+    #[inline]
+    fn deref(&self) -> &Registry {
+        &self.inner
+    }
+}
+
+/// Write guard for the shared [`Registry`]. Wraps a [`ReentrantWriteGuard`] over
+/// the copy-on-write `Arc<Registry>`; the first mutable deref after a share
+/// pays the one deep clone via `Arc::make_mut` (recorded as
+/// `registry_cow_clones`), then behaves exactly like a plain `&mut Registry`.
+/// See [`crate::runtime::lock_reentry`].
 ///
 /// [`ReentrantWriteGuard`]: crate::runtime::lock_reentry::ReentrantWriteGuard
-pub(crate) type RegistryWriteGuard<'a> =
-    crate::runtime::lock_reentry::ReentrantWriteGuard<'a, Registry>;
+pub(crate) struct RegistryWriteGuard<'a> {
+    inner: crate::runtime::lock_reentry::ReentrantWriteGuard<'a, Arc<Registry>>,
+}
+
+impl<'a> RegistryWriteGuard<'a> {
+    pub(crate) fn new(lock: &'a std::sync::RwLock<Arc<Registry>>, name: &'static str) -> Self {
+        Self {
+            inner: crate::runtime::lock_reentry::ReentrantWriteGuard::new(lock, name),
+        }
+    }
+}
+
+impl std::ops::Deref for RegistryWriteGuard<'_> {
+    type Target = Registry;
+    #[inline]
+    fn deref(&self) -> &Registry {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for RegistryWriteGuard<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Registry {
+        let arc: &mut Arc<Registry> = &mut self.inner;
+        if Arc::strong_count(arc) > 1 {
+            crate::vm::vm_stats::record_registry_cow_clone();
+        }
+        Arc::make_mut(arc)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -339,9 +339,8 @@ impl Interpreter {
     /// as [`Self::registry`].
     #[inline]
     pub(crate) fn registry_mut(&self) -> crate::runtime::registry::RegistryWriteGuard<'_> {
-        // Any write access may mutate the registry, so invalidate the cached
-        // regex/grammar snapshot (see `regex_registry_snapshot`). Cheap relaxed
-        // bump; the snapshot cache compares this generation before reusing.
+        // Any write access may mutate the registry, so bump the generation
+        // several resolution caches consult (cheap relaxed increment).
         self.registry_write_gen
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         crate::runtime::registry::RegistryWriteGuard::new(&self.registry, "registry")

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2100,10 +2100,9 @@ impl Interpreter {
                 for class_name in class_names {
                     registry.sync_user_method_entries(&class_name);
                 }
-                Arc::new(RwLock::new(registry))
+                Arc::new(RwLock::new(Arc::new(registry)))
             },
             registry_write_gen: std::sync::atomic::AtomicU64::new(0),
-            regex_registry_snapshot: Mutex::new(None),
             proto_dispatch_stack: Vec::new(),
             proto_method_skip: None,
             pending_dispatch_error: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -402,14 +402,15 @@ impl Interpreter {
             gather_items: Vec::new(),
             gather_take_limits: Vec::new(),
             block_scope_depth: self.block_scope_depth,
-            // Deep-clone the registry into a fresh Arc so the child thread gets an
-            // independent snapshot (matches prior per-field clone semantics: the
-            // child sees parent declarations but its own new ones don't leak back).
-            registry: Arc::new(RwLock::new(self.registry.read().unwrap().clone())),
-            // Fresh per-thread: the snapshot cache must not be shared across
-            // threads (each thread's `Interpreter` owns its own registry).
+            // O(1) share of the inner `Arc<Registry>` — a fresh outer lock so the
+            // child thread gets an independent snapshot (matches prior per-field
+            // clone semantics: the child sees parent declarations but its own new
+            // ones don't leak back), while the deep clone itself is deferred until
+            // either side's first registry write (`Arc::make_mut` in
+            // `RegistryWriteGuard::deref_mut`). In spawn-heavy loops where neither
+            // side writes the registry, the deep clone (and its drop) never happens.
+            registry: Arc::new(RwLock::new(Arc::clone(&self.registry.read().unwrap()))),
             registry_write_gen: std::sync::atomic::AtomicU64::new(0),
-            regex_registry_snapshot: Mutex::new(None),
             proto_dispatch_stack: Vec::new(),
             proto_method_skip: None,
             pending_dispatch_error: None,

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -197,6 +197,22 @@ pub(crate) fn record_regex_match_materialization() {
     }
 }
 
+// Registry copy-on-write (docs/per-task-clone-slimming.md slice 1): counts
+// the deep clones `Arc::make_mut` actually performs in `RegistryWriteGuard`,
+// i.e. how often a registry write hit a still-shared `Arc<Registry>`. Should
+// stay near-zero on a spawn-heavy benchmark where neither side writes the
+// registry between spawns; a per-task count means some write path touches
+// `registry_mut()` every spawn (see the plan doc's "stop and ask" condition).
+static REGISTRY_COW_CLONES: AtomicU64 = AtomicU64::new(0);
+
+/// Record one `Arc::make_mut` deep clone of the copy-on-write registry.
+#[inline]
+pub(crate) fn record_registry_cow_clone() {
+    if enabled() {
+        REGISTRY_COW_CLONES.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 // ADR-0020 worker pool: `POOL_TASKS` counts every task submitted to the
 // elastic pool; `POOL_SPAWNS` the subset that grew the pool (no idle worker
 // at submit time). `tasks - spawns` is therefore the warm-reuse count the
@@ -539,6 +555,8 @@ pub(crate) fn dump() {
     eprintln!(
         "[mutsu vm-stats] regex-code-parse-cache: hits={code_parse_hits} misses={code_parse_misses}"
     );
+    let registry_cow_clones = REGISTRY_COW_CLONES.load(Ordering::Relaxed);
+    eprintln!("[mutsu vm-stats] registry-cow: clones={registry_cow_clones}");
     let pool_tasks = POOL_TASKS.load(Ordering::Relaxed);
     let pool_spawns = POOL_SPAWNS.load(Ordering::Relaxed);
     eprintln!(


### PR DESCRIPTION
## Summary

Slice 1 (the big one) of `docs/per-task-clone-slimming.md`, companion to
ADR-0020 SS1.3, which identified the per-task `Interpreter` clone as the
dominant per-`start` cost the shared worker pool deliberately did not
address.

- The declaration `Registry` field changes from `Arc<RwLock<Registry>>` to
  `Arc<RwLock<Arc<Registry>>>`. A thread spawn now shares the inner `Arc`
  (O(1)) instead of deep-cloning ~40 maps; the first *write* on either side
  after the share pays the one deep clone via `Arc::make_mut`. Semantics are
  identical to the prior eager deep clone: each `Interpreter` still gets its
  own outer lock and its own logical snapshot, the clone is merely lazy.
- `RegistryReadGuard`/`RegistryWriteGuard` become newtype structs wrapping the
  existing reentrant guards over `Arc<Registry>`, `Deref`/`DerefMut`-ing
  straight through to `Registry` so the ~1100 existing call sites
  (`self.registry().foo`, `self.registry_mut().foo = ...`) are unaffected.
  `RegistryWriteGuard::deref_mut` records a new `registry_cow_clones`
  vm-stats counter whenever `Arc::make_mut` actually clones (i.e. the Arc was
  still shared), so the campaign can watch for a regressed write path.
- `copy_full_registry_into` (the regex/grammar sub-interpreter snapshot path)
  drops its bespoke `regex_registry_snapshot` generation-cache field entirely
  and uses the same O(1) Arc share. This is also a correctness fix: the old
  cache shared one `Arc<RwLock<Registry>>` **outer lock** across every
  sub-interpreter built from it, so one sub-interpreter's (rare) registry
  write could leak into the next; the COW share gives each sub-interpreter
  its own outer lock, isolating them.

## Verification

- `cargo build && cargo clippy -- -D warnings && cargo fmt -- --check`: clean.
- `MUTSU_VM_STATS=1` on `tmp/bench-start-shape.p6` (debug build):
  `registry_cow_clones=0` (confirms no per-task registry write path — the
  slice's core correctness expectation), `clone_env=4000`,
  `env_deep_copies=8000`, `worker-pool: tasks=4000 spawns=2
  warm_reuses=3998` (pool reuse unaffected).
- `make test`: `Result: PASS` (Files=2888, Tests=27453).
- Targeted roast: `MUTSU_FUDGE=1 prove -e target/debug/mutsu
  roast/S17-promise/start.t roast/S17-supply/act.t
  roast/S05-grammar/action-stubs.t roast/S05-grammar/protoregex.t
  roast/S05-metasyntax/regex.t` — all pass (the plan doc named
  `S05-grammar/action-methods.t`, which doesn't exist in this vendored
  roast; `action-stubs.t` + `protoregex.t` are the files that actually
  exercise grammar actions / the `copy_full_registry_into` rewrite).
- Release bench (`tmp/bench-start-shape.p6`, median of 5,
  `/usr/bin/time -f %e`): **1.66s -> ~1.01s** (1.00/0.98/1.11/1.01/1.06),
  ~39% off the pre-campaign baseline — the largest single-slice win of the
  campaign, as the plan doc predicted.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `make test` (local full suite)
- [x] Targeted roast files (S17-promise/start, S17-supply/act,
      S05-grammar actions, S05-metasyntax/regex)
- [x] Release bench A/B (median of 5)
- [ ] CI: full `make roast` (background watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)