### PR TITLE
perf(runtime): single-pass env iteration in clone_for_thread_excluding (slice 2)

### DIFF
--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -146,8 +146,20 @@ impl Interpreter {
         // its OWN store, which is why two hyper workers that each declare
         // `my $uri` no longer collide on one bare-name entry.
         let shared = Arc::clone(&self.shared_vars);
+        // Merged with the lineage-seeding walk below (was a separate `for value
+        // in self.env.values()` pass): both need one full traversal of the
+        // parent env per spawn, so collecting handle ids here — BEFORE any of
+        // the seeding loop's `continue`s — does both jobs in one pass. Every
+        // value must still be checked for a handle id even when the seeding
+        // side skips it (e.g. `$*CWD`/`self`/`__mutsu_*` are never handles, but
+        // an excluded captured scalar or an already-visible name legitimately
+        // could be).
+        let mut referenced_handle_ids = std::collections::HashSet::new();
         {
             for (key, val) in &self.env {
+                if let Some(id) = Self::handle_id_from_value(val) {
+                    referenced_handle_ids.insert(id);
+                }
                 // Skip internal variables and topic variables.
                 // Also skip $*CWD/*CWD — in Raku, dynamic variables like $*CWD
                 // are thread-local; mutations inside `start` blocks must not
@@ -264,12 +276,6 @@ impl Interpreter {
             captured_scalars.contains(n.trim_start_matches('$'))
                 || self.thread_decl_in_flight.contains(n)
         });
-        let mut referenced_handle_ids = std::collections::HashSet::new();
-        for value in self.env.values() {
-            if let Some(id) = Self::handle_id_from_value(value) {
-                referenced_handle_ids.insert(id);
-            }
-        }
         let mut cloned_handles = HashMap::new();
         let handles_guard = self.io_handles();
         for (id, handle) in &handles_guard.map {


### PR DESCRIPTION
## Summary

Slice 2 of `docs/per-task-clone-slimming.md`. `clone_for_thread_excluding`
walked the parent env twice per spawn: once for ADR-0010 lineage seeding
(`for (key, val) in &self.env` with several `continue`s), once for the
IO-handle-id scan (`for value in self.env.values()`). Merged into one
traversal: the handle-id check now runs unconditionally as the first
statement in the seeding loop's body, before any `continue`, so every value
is still checked for a handle id even when the seeding side skips it (e.g.
an excluded captured scalar, or a name already visible in the lineage
store). Behavior is unchanged — this is purely a traversal merge.

## Verification

- `cargo build && cargo clippy -- -D warnings && cargo fmt -- --check`: clean.
- `make test`: `Result: PASS` (Files=2888, Tests=27453).
- Targeted: `prove -e target/debug/mutsu t/supply-*.t t/hyper.t
  t/concurrency-threading.t` — all pass.
- `MUTSU_VM_STATS=1` on `tmp/bench-start-shape.p6`: `clone_env=4000`,
  `env_deep_copies=8000`, `worker-pool: tasks=4000 spawns=2
  warm_reuses=3998` — unchanged (this slice only removes a redundant
  traversal, no seeding/count behavior change).
- Release bench (`tmp/bench-start-shape.p6`, median of 5,
  `/usr/bin/time -f %e`), measured against a rebase onto `main` (which
  already includes slice 0's FxHashMap change, merged as #5928):
  before ~1.22s (1.18/1.22/1.24/1.24/1.23, slice-0-only baseline from
  #5928's own measurement), after ~1.21s (1.17/1.17/1.21/1.26/1.27) — at
  noise level, as the plan doc anticipated ("expect a small single-digit %
  win; skip the slice if it measures at noise level AND the code reads
  worse — record the measurement either way"). Landing anyway: removing a
  full O(env) traversal per spawn is a straightforward simplification with
  a clear invariant comment, not a readability regression, so it's worth
  keeping even though the parent-env in this benchmark is small enough that
  the second pass wasn't the bottleneck.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `make test` (local full suite)
- [x] Targeted supply/hyper/concurrency tests
- [x] Release bench A/B (median of 5)
- [ ] CI: full `make roast` (background watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)