### PR TITLE
perf(runtime): cache process-constant IO env singletons (slice 3)

### DIFF
--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -4,23 +4,31 @@ use crate::value::ValueView;
 use std::sync::OnceLock;
 
 impl Interpreter {
-    /// Top-level `init_io_environment`, for `Interpreter::new()`. Does the real
-    /// `current_dir()` syscall for `$*CWD` (see the `for_thread_clone` variant).
+    /// Rebuild the per-interpreter IO/dynamic-var environment. Called both from
+    /// `Interpreter::new()` and from every `clone_for_thread` spawn.
+    ///
+    /// `$*CWD` is deliberately rebuilt via a real `current_dir()` syscall on
+    /// EVERY call, including thread-clone spawns, even though `cloned.env`
+    /// already carries the parent's current `$*CWD` value verbatim (from the
+    /// struct-construction-time env clone in `clone_for_thread_excluding`) and
+    /// a skip-and-reuse optimization looks safe at first glance. It is NOT
+    /// safe: a `start` block that both READS and WRITES a dynamic var inside
+    /// itself (e.g. `start indir $dir, { $*CWD.basename; $*CWD = ...; }`) can
+    /// have that var boxed into a captured `ContainerRef` cell at
+    /// closure-creation time (`box_captured_lexicals`), snapshotting whatever
+    /// value is CURRENTLY in `env` at that point — and a later `indir`/dynamic
+    /// rebind that only does `self.env.insert(...)` does not reach a cell the
+    /// closure already captured. Before this rebuild ran unconditionally, that
+    /// snapshot was always a fresh `IO::Path` Instance (built moments earlier
+    /// by this very function); skipping the rebuild let the snapshot instead be
+    /// whatever non-Path value an outer `my $*CWD = ...` lexical override had
+    /// left in env, breaking `t/start-dynamic-var-indir.t`. Rebuilding
+    /// unconditionally keeps that pre-closure-creation snapshot correct. See
+    /// docs/per-task-clone-slimming.md slice 3 for the caching this function
+    /// does apply (the other dynamic vars, which no closure boxing issue
+    /// touches because their identity is process-constant, not reassigned by
+    /// ordinary programs).
     pub(super) fn init_io_environment(&mut self) {
-        self.init_io_environment_impl(false);
-    }
-
-    /// `init_io_environment` for a `clone_for_thread` spawn. `$*CWD`/`*CWD` are
-    /// already correct in `cloned.env` (copied verbatim from the parent's env at
-    /// struct-construction time, then diverging thread-locally per the exclusion
-    /// in `clone_for_thread_excluding`) — skip both the `current_dir()` syscall
-    /// and the overwrite, since it would just recompute the same syscall-derived
-    /// value the clone already carries from the parent.
-    pub(super) fn init_io_environment_for_thread_clone(&mut self) {
-        self.init_io_environment_impl(true);
-    }
-
-    fn init_io_environment_impl(&mut self, for_thread_clone: bool) {
         let stdout = self.create_handle(
             IoHandleTarget::Stdout,
             IoHandleMode::Write,
@@ -52,18 +60,16 @@ impl Interpreter {
         let spec = self.make_io_spec_instance();
         self.env.insert("$*SPEC".to_string(), spec.clone());
         self.env.insert("*SPEC".to_string(), spec);
-        if !for_thread_clone {
-            #[cfg(not(target_arch = "wasm32"))]
-            let cwd_str = env::current_dir()
-                .unwrap_or_else(|_| PathBuf::from("."))
-                .to_string_lossy()
-                .to_string();
-            #[cfg(target_arch = "wasm32")]
-            let cwd_str = "/".to_string();
-            let cwd_val = self.make_io_path_instance(&cwd_str);
-            self.env.insert("$*CWD".to_string(), cwd_val.clone());
-            self.env.insert("*CWD".to_string(), cwd_val);
-        }
+        #[cfg(not(target_arch = "wasm32"))]
+        let cwd_str = env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .to_string_lossy()
+            .to_string();
+        #[cfg(target_arch = "wasm32")]
+        let cwd_str = "/".to_string();
+        let cwd_val = self.make_io_path_instance(&cwd_str);
+        self.env.insert("$*CWD".to_string(), cwd_val.clone());
+        self.env.insert("*CWD".to_string(), cwd_val);
         let tmpdir_val = self.make_io_path_instance(Self::cached_tmpdir_string());
         self.env.insert("$*TMPDIR".to_string(), tmpdir_val.clone());
         self.env.insert("*TMPDIR".to_string(), tmpdir_val);

--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -1,9 +1,26 @@
 use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
+use std::sync::OnceLock;
 
 impl Interpreter {
+    /// Top-level `init_io_environment`, for `Interpreter::new()`. Does the real
+    /// `current_dir()` syscall for `$*CWD` (see the `for_thread_clone` variant).
     pub(super) fn init_io_environment(&mut self) {
+        self.init_io_environment_impl(false);
+    }
+
+    /// `init_io_environment` for a `clone_for_thread` spawn. `$*CWD`/`*CWD` are
+    /// already correct in `cloned.env` (copied verbatim from the parent's env at
+    /// struct-construction time, then diverging thread-locally per the exclusion
+    /// in `clone_for_thread_excluding`) — skip both the `current_dir()` syscall
+    /// and the overwrite, since it would just recompute the same syscall-derived
+    /// value the clone already carries from the parent.
+    pub(super) fn init_io_environment_for_thread_clone(&mut self) {
+        self.init_io_environment_impl(true);
+    }
+
+    fn init_io_environment_impl(&mut self, for_thread_clone: bool) {
         let stdout = self.create_handle(
             IoHandleTarget::Stdout,
             IoHandleMode::Write,
@@ -35,70 +52,161 @@ impl Interpreter {
         let spec = self.make_io_spec_instance();
         self.env.insert("$*SPEC".to_string(), spec.clone());
         self.env.insert("*SPEC".to_string(), spec);
-        #[cfg(not(target_arch = "wasm32"))]
-        let cwd_str = env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .to_string_lossy()
-            .to_string();
-        #[cfg(target_arch = "wasm32")]
-        let cwd_str = "/".to_string();
-        let cwd_val = self.make_io_path_instance(&cwd_str);
-        self.env.insert("$*CWD".to_string(), cwd_val.clone());
-        self.env.insert("*CWD".to_string(), cwd_val);
-        #[cfg(not(target_arch = "wasm32"))]
-        let tmpdir_str = env::temp_dir().to_string_lossy().to_string();
-        #[cfg(target_arch = "wasm32")]
-        let tmpdir_str = "/tmp".to_string();
-        let tmpdir_val = self.make_io_path_instance(&tmpdir_str);
+        if !for_thread_clone {
+            #[cfg(not(target_arch = "wasm32"))]
+            let cwd_str = env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .to_string_lossy()
+                .to_string();
+            #[cfg(target_arch = "wasm32")]
+            let cwd_str = "/".to_string();
+            let cwd_val = self.make_io_path_instance(&cwd_str);
+            self.env.insert("$*CWD".to_string(), cwd_val.clone());
+            self.env.insert("*CWD".to_string(), cwd_val);
+        }
+        let tmpdir_val = self.make_io_path_instance(Self::cached_tmpdir_string());
         self.env.insert("$*TMPDIR".to_string(), tmpdir_val.clone());
         self.env.insert("*TMPDIR".to_string(), tmpdir_val);
-        #[cfg(not(target_arch = "wasm32"))]
-        let home_val = if let Ok(home) = env::var("HOME") {
-            self.make_io_path_instance(&home)
-        } else {
-            Value::NIL
+        let home_val = match Self::cached_home_string() {
+            Some(home) => self.make_io_path_instance(home),
+            None => Value::NIL,
         };
-        #[cfg(target_arch = "wasm32")]
-        let home_val = Value::NIL;
         self.env.insert("$*HOME".to_string(), home_val.clone());
         self.env.insert("*HOME".to_string(), home_val);
         // $*EXECUTABLE - path to the interpreter binary
-        #[cfg(not(target_arch = "wasm32"))]
-        let exe_path = Self::resolved_current_executable_path()
-            .to_string_lossy()
-            .to_string();
-        #[cfg(target_arch = "wasm32")]
-        let exe_path = "mutsu".to_string();
-        let exe_io = self.make_io_path_instance(&exe_path);
+        let exe_path = Self::cached_executable_path_string();
+        let exe_io = self.make_io_path_instance(exe_path);
         self.env.insert("$*EXECUTABLE".to_string(), exe_io.clone());
         self.env.insert("*EXECUTABLE".to_string(), exe_io);
         self.env.insert(
             "$*EXECUTABLE-NAME".to_string(),
             Value::str(
-                std::path::Path::new(&exe_path)
+                std::path::Path::new(exe_path)
                     .file_name()
                     .map(|f| f.to_string_lossy().to_string())
-                    .unwrap_or_else(|| exe_path.clone()),
+                    .unwrap_or_else(|| exe_path.to_string()),
             ),
         );
         let exec_name = self.env.get("$*EXECUTABLE-NAME").cloned().unwrap();
         self.env.insert("*EXECUTABLE-NAME".to_string(), exec_name);
-        let distro = Self::make_distro_instance();
+        let distro = Self::cached_distro_instance();
         self.env.insert("*DISTRO".to_string(), distro.clone());
         self.env.insert("?DISTRO".to_string(), distro);
-        let perl = Self::make_perl_instance();
+        let perl = Self::cached_perl_instance();
         self.env.insert("*PERL".to_string(), perl.clone());
         self.env.insert("?PERL".to_string(), perl);
-        let raku = Self::make_perl_instance();
+        let raku = Self::cached_raku_instance();
         self.env.insert("*RAKU".to_string(), raku.clone());
         self.env.insert("?RAKU".to_string(), raku);
-        let vm = Self::make_vm_instance();
+        let vm = Self::cached_vm_instance();
         self.env.insert("$*VM".to_string(), vm.clone());
         self.env.insert("*VM".to_string(), vm.clone());
         self.env.insert("?VM".to_string(), vm);
-        let kernel = Self::make_kernel_instance();
+        let kernel = Self::cached_kernel_instance();
         self.env.insert("*KERNEL".to_string(), kernel.clone());
         self.env.insert("?KERNEL".to_string(), kernel);
+    }
+
+    /// Process-constant `Distro` instance (docs/per-task-clone-slimming.md
+    /// slice 3): built once via `make_distro_instance` (which shells out to
+    /// `sw_vers` on macOS and reads `/etc/os-release` on Linux) and shared by
+    /// `Value` clone (a cheap handle copy, see `Value`'s internal `Arc`/`Gc`
+    /// reprs) into every `Interpreter::new()` / thread-clone env thereafter.
+    fn cached_distro_instance() -> Value {
+        static CACHE: OnceLock<Value> = OnceLock::new();
+        CACHE.get_or_init(Self::make_distro_instance).clone()
+    }
+
+    /// Process-constant `$*PERL` instance. Cached separately from
+    /// [`Self::cached_raku_instance`] even though both build from the same
+    /// `make_perl_instance()` body: `$*PERL` and `$*RAKU` are historically
+    /// distinct objects (`$*PERL !=== $*RAKU`), so they get their own cache
+    /// slot rather than aliasing one shared instance.
+    fn cached_perl_instance() -> Value {
+        static CACHE: OnceLock<Value> = OnceLock::new();
+        CACHE.get_or_init(Self::make_perl_instance).clone()
+    }
+
+    /// Process-constant `$*RAKU` instance (see [`Self::cached_perl_instance`]).
+    /// `update_raku_version_from_parser` mutates this in place via
+    /// `Value::write_back_sharing` (commits into the same shared attrs cell,
+    /// does not rebind to a new object), so a `use v6.x` version bump on the
+    /// top-level interpreter is visible to every later thread clone's copy of
+    /// this cached singleton too — matching the pre-existing
+    /// `IMMUTABLE_BASE_DYNAMICS` assumption that `$*RAKU`/`$*PERL` hold one
+    /// process-wide value.
+    fn cached_raku_instance() -> Value {
+        static CACHE: OnceLock<Value> = OnceLock::new();
+        CACHE.get_or_init(Self::make_perl_instance).clone()
+    }
+
+    /// Process-constant `$*VM` instance.
+    fn cached_vm_instance() -> Value {
+        static CACHE: OnceLock<Value> = OnceLock::new();
+        CACHE.get_or_init(Self::make_vm_instance).clone()
+    }
+
+    /// Process-constant `$*KERNEL` instance.
+    fn cached_kernel_instance() -> Value {
+        static CACHE: OnceLock<Value> = OnceLock::new();
+        CACHE.get_or_init(Self::make_kernel_instance).clone()
+    }
+
+    /// Process-constant interpreter-executable path string, computed once via
+    /// `resolved_current_executable_path()` (a `current_exe()` syscall). The
+    /// `IO::Path` `Value` itself is still built fresh per call
+    /// (`make_io_path_instance` embeds the CURRENT `$*SPEC`/`$*CWD`), only the
+    /// expensive path string is cached.
+    fn cached_executable_path_string() -> &'static str {
+        static CACHE: OnceLock<String> = OnceLock::new();
+        CACHE.get_or_init(|| {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Self::resolved_current_executable_path()
+                    .to_string_lossy()
+                    .to_string()
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                "mutsu".to_string()
+            }
+        })
+    }
+
+    /// Process-constant temp-dir path string, computed once via
+    /// `env::temp_dir()`. See [`Self::cached_executable_path_string`] for why
+    /// only the string (not the `IO::Path` `Value`) is cached.
+    fn cached_tmpdir_string() -> &'static str {
+        static CACHE: OnceLock<String> = OnceLock::new();
+        CACHE.get_or_init(|| {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                env::temp_dir().to_string_lossy().to_string()
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                "/tmp".to_string()
+            }
+        })
+    }
+
+    /// Process-constant `$HOME` path string, computed once via `env::var`.
+    /// `None` when the process has no `HOME` (matches the prior per-call
+    /// behavior of falling back to `Value::NIL`).
+    fn cached_home_string() -> Option<&'static str> {
+        static CACHE: OnceLock<Option<String>> = OnceLock::new();
+        CACHE
+            .get_or_init(|| {
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    env::var("HOME").ok()
+                }
+                #[cfg(target_arch = "wasm32")]
+                {
+                    None
+                }
+            })
+            .as_deref()
     }
 
     pub(super) fn get_dynamic_handle(&self, name: &str) -> Option<Value> {

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -688,7 +688,7 @@ impl Interpreter {
         cloned.env.insert("!".to_string(), Value::NIL);
         cloned.env.insert("$/".to_string(), Value::NIL);
         cloned.env.insert("$!".to_string(), Value::NIL);
-        cloned.init_io_environment();
+        cloned.init_io_environment_for_thread_clone();
         cloned
     }
 

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -688,7 +688,7 @@ impl Interpreter {
         cloned.env.insert("!".to_string(), Value::NIL);
         cloned.env.insert("$/".to_string(), Value::NIL);
         cloned.env.insert("$!".to_string(), Value::NIL);
-        cloned.init_io_environment_for_thread_clone();
+        cloned.init_io_environment();
         cloned
     }
 


### PR DESCRIPTION
## Summary

Slice 3 of `docs/per-task-clone-slimming.md`. `init_io_environment` runs on
every `clone_for_thread` spawn and rebuilt process-constant values every
time: `make_distro_instance` (shells out to `sw_vers` on macOS / reads
`/etc/os-release` on Linux), `make_perl_instance` (×2: `$*PERL`, `$*RAKU`),
`make_vm_instance`, `make_kernel_instance`, the `$*EXECUTABLE` path
resolution (`current_exe()` syscall), `env::temp_dir()`, and
`env::var("HOME")`.

Cache the process-constant ones in `OnceLock` statics, built once and
`Value`-cloned (a cheap handle copy) into every `Interpreter::new()` /
thread clone thereafter:
- `DISTRO` / `VM` / `KERNEL`: pure static data, no risk.
- `PERL` / `RAKU`: cached separately (two `OnceLock`s) since `$*PERL !===
  $*RAKU` are historically distinct objects. `update_raku_version_from_parser`
  mutates them in place via `Value::write_back_sharing` (commits into the
  same shared attrs cell, never rebinds to a new object), so a `use v6.x`
  version bump on the top-level interpreter is visible through every later
  thread clone's copy of the cached singleton too — consistent with the
  pre-existing `IMMUTABLE_BASE_DYNAMICS` assumption that these dynvars hold
  one process-wide value.
- `$*EXECUTABLE`(+`-NAME`) / `$*TMPDIR` / `$*HOME`: only the expensive
  underlying path STRING is cached; the `IO::Path` `Value` itself is still
  built fresh per call via `make_io_path_instance`, since that embeds the
  current `$*SPEC`/`$*CWD`.

**`$*CWD` is NOT part of this optimization** (see the second commit): an
earlier version of this PR also skipped `$*CWD`'s `current_dir()` syscall on
thread clones (reusing the parent's already-cloned env value), reasoning
that `cloned.env` already carries the correct value. That reasoning was
wrong — verified with a local repro plus a throwaway `origin/main` worktree
comparison. Root cause: a `start` block that both READS and WRITES a
dynamic var inside itself (e.g. `start indir $dir, { $*CWD.basename; $*CWD
= ...; }`) can have that var boxed into a captured `ContainerRef` cell at
closure-creation time (`box_captured_lexicals`), snapshotting whatever value
is CURRENTLY in env at that point. A later `indir`/dynamic rebind that only
does `self.env.insert(...)` does not reach a cell the closure already
captured. Before this campaign, `init_io_environment` ran unconditionally
on every thread clone, so that pre-closure-creation snapshot was always a
freshly built `IO::Path` Instance; skipping it let the snapshot instead be
whatever non-Path value an outer `my $*CWD = ...` lexical override had left
in env — regressing `t/start-dynamic-var-indir.t`. Fixed by reverting to an
unconditional real `current_dir()` syscall for `$*CWD` (byte-identical to
pre-campaign behavior for that one dynvar); the other cached singletons are
unaffected and keep their win.

## Verification

- `cargo build && cargo clippy -- -D warnings && cargo fmt -- --check`: clean.
- `make test`: `Result: PASS` (Files=2888, Tests=27453).
- `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S02-magicals/*.t` (dynvar
  introspection, including `DISTRO.t`/`KERNEL.t`/`PERL.t`/`RAKU.t`/`VM.t` —
  the exact tests exercising the newly-cached singletons): all pass.
- `prove -e target/debug/mutsu t/supply-*.t t/hyper.t
  t/concurrency-threading.t t/thread-*.t`: all pass.
- `t/start-dynamic-var-indir.t` (the regression this PR's second commit
  fixes): 5/5 clean runs.
- `MUTSU_VM_STATS=1` on `tmp/bench-start-shape.p6`: `registry_cow_clones=0`,
  `clone_env=4000`, `env_deep_copies=8000`, `worker-pool: tasks=4000
  spawns=2 warm_reuses=3998` — unchanged.
- Release bench (`tmp/bench-start-shape.p6`, median of 5,
  `/usr/bin/time -f %e`): **~1.21s (slice-2 baseline) -> ~0.66s**
  (0.66/0.66/0.63/0.63/0.69), a further ~45% reduction — **already past the
  plan doc's exit criterion (< ~1.0s) with slices 0-3 combined**, against a
  1.66s pre-campaign baseline.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `make test` (local full suite)
- [x] Targeted S02-magicals, supply/hyper/thread, and the
      start-dynamic-var-indir regression test
- [x] Release bench A/B (median of 5)
- [ ] CI: full `make roast` (background watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)