### PR TITLE
perf(runtime): instance_type_metadata copy-on-write for per-task clone (slice 4)

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1572,10 +1572,13 @@ pub struct Interpreter {
     /// `current_package` / `io_handles`) so the VM and Interpreter can reach it
     /// as peers and CP-3 can fold it by handle transfer rather than ownership
     /// reasoning. Like those handles it is a *per-thread snapshot*, not
-    /// live-shared: `clone_for_thread` deep-copies the map into a fresh `Arc`,
-    /// so the lock never contends across threads. Collapses to a plain VM field
-    /// once the Interpreter execution path is removed (PLAN.md ④/⑤).
-    instance_type_metadata: Arc<RwLock<HashMap<u64, ContainerTypeInfo>>>,
+    /// live-shared: `clone_for_thread` shares the inner `Arc` (O(1); see the
+    /// `registry` field's copy-on-write doc, docs/per-task-clone-slimming.md
+    /// slice 4) into a fresh outer `Arc<RwLock<...>>`, so the lock never
+    /// contends across threads and the first write on either side after a
+    /// share pays the one deep clone via `Arc::make_mut`. Collapses to a plain
+    /// VM field once the Interpreter execution path is removed (PLAN.md ④/⑤).
+    instance_type_metadata: Arc<RwLock<Arc<HashMap<u64, ContainerTypeInfo>>>>,
     /// `let`/`temp` save stack: (name, saved value, is_temp, compiler-baked slot).
     /// The baked slot (§1.4/§1.5) lets the scope-exit restore write `locals[slot]`
     /// directly instead of resolving the name to the OUTER slot via
@@ -2285,7 +2288,7 @@ type SubsetPredicateCompiled = Arc<(crate::opcode::CompiledCode, crate::opcode::
 /// reads). It touches no `env`, so neither caller needs an env loan.
 pub(crate) fn container_type_metadata_with(
     value: &Value,
-    instance_meta: &Arc<RwLock<HashMap<u64, ContainerTypeInfo>>>,
+    instance_meta: &Arc<RwLock<Arc<HashMap<u64, ContainerTypeInfo>>>>,
 ) -> Option<ContainerTypeInfo> {
     // Embedded-metadata readers for Set/Bag/Mix (mirrors `hashdata_type_info`).
     macro_rules! embedded_type_info {

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -190,10 +190,8 @@ impl Interpreter {
                 );
             }
             ValueView::Instance { id, .. } => {
-                self.instance_type_metadata
-                    .write()
-                    .unwrap()
-                    .insert(id, info);
+                let mut guard = self.instance_type_metadata.write().unwrap();
+                Arc::make_mut(&mut guard).insert(id, info);
             }
             ValueView::Mixin(inner, _) => self.register_container_type_metadata(inner, info),
             _ => {}

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2185,7 +2185,7 @@ impl Interpreter {
             sigilless_alias_seen: false,
             var_defaults: HashMap::new(),
             var_hash_key_constraints: HashMap::new(),
-            instance_type_metadata: Arc::new(RwLock::new(HashMap::new())),
+            instance_type_metadata: Arc::new(RwLock::new(Arc::new(HashMap::new()))),
             let_saves: Vec::new(),
             grammar_rule_dynvar_decls: HashMap::new(),
             supply_emit_buffer: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -521,12 +521,16 @@ impl Interpreter {
             sigilless_alias_seen: self.sigilless_alias_seen,
             var_defaults: self.var_defaults.clone(),
             var_hash_key_constraints: self.var_hash_key_constraints.clone(),
-            // Per-thread snapshot (not a shared-handle clone): deep-copy the map
-            // into a fresh `Arc` so the child thread's instance type metadata is
-            // independent of the parent's, mirroring `io_handles`/`current_package`.
-            instance_type_metadata: Arc::new(RwLock::new(
-                self.instance_type_metadata.read().unwrap().clone(),
-            )),
+            // Per-thread snapshot (not a shared-handle clone), but an O(1) share
+            // of the inner `Arc` (docs/per-task-clone-slimming.md slice 4): a
+            // fresh outer `Arc<RwLock<...>>` keeps the child thread's instance
+            // type metadata independent of the parent's (mirroring
+            // `io_handles`/`current_package`), while the deep clone itself is
+            // deferred until either side's first write (`Arc::make_mut` in
+            // `register_container_type_metadata`).
+            instance_type_metadata: Arc::new(RwLock::new(Arc::clone(
+                &self.instance_type_metadata.read().unwrap(),
+            ))),
             let_saves: Vec::new(),
             grammar_rule_dynvar_decls: HashMap::new(),
             supply_emit_buffer: Vec::new(),


### PR DESCRIPTION
## Summary

Slice 4 of `docs/per-task-clone-slimming.md`: the same disease as slice 1
(Registry COW, #5929), a much smaller organ. `clone_for_thread_excluding`
deep-cloned the `instance_type_metadata` map
(`Arc<RwLock<HashMap<u64, ContainerTypeInfo>>>`) into a fresh `Arc` on
every spawn. Applies the identical `Arc<RwLock<Arc<...>>>` +
make_mut-on-write pattern: a thread spawn now shares the inner `Arc` (O(1))
instead of deep-cloning the map; the one write call site
(`register_container_type_metadata`'s `Instance` arm, in
`runtime_container.rs`) pays the deep clone via `Arc::make_mut` only when
the `Arc` is actually still shared.

Only one write site exists, so no new guard type is needed — the
`Arc::make_mut` call is inlined there directly, mirroring the
`RegistryWriteGuard::deref_mut` pattern from slice 1. The single read site
(`container_type_metadata_with`, shared by
`Interpreter::container_type_metadata` and the VM's peer-handle native
read) needed only a parameter-type update; its `.get(&id)` call still
compiles unchanged since `Arc<HashMap<...>>` derefs to `HashMap<...>`.

## Verification

- `cargo build && cargo clippy -- -D warnings && cargo fmt -- --check`: clean.
- `make test`: `Result: PASS` (Files=2888, Tests=27453).
- Targeted: `prove -e target/debug/mutsu t/thread-*.t
  t/concurrency-threading.t t/typed-array-*.t` (typed-array tests exercise
  the instance type-metadata path) — all pass.
- `MUTSU_VM_STATS=1` on `tmp/bench-start-shape.p6`: unchanged —
  `clone_env=4000`, `env_deep_copies=8000`, `worker-pool: tasks=4000
  spawns=2 warm_reuses=3998`.
- Release bench (`tmp/bench-start-shape.p6`, median of 5,
  `/usr/bin/time -f %e`), measured against this branch's own pre-slice-4
  baseline (cut from `main` with slices 0-2 merged; slice 3, #5931, was
  still open at branch-cut time so is not included in this A/B):
  ~1.21s -> ~0.94s (0.95/0.92/0.94/0.94/0.96), a further ~22% reduction.
  Per the plan doc: "If the win is at noise level, still land it — it
  removes a per-task allocation family and its drop for free" — this one
  measures as a real, if smaller, win.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `make test` (local full suite)
- [x] Targeted thread/typed-array tests
- [x] Release bench A/B (median of 5)
- [ ] CI: full `make roast` (background watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)