### PR TITLE
perf(runtime): spawn-seeding counters (clone-slimming slice 5 step A)

### DIFF
--- a/docs/per-task-clone-slimming.md
+++ b/docs/per-task-clone-slimming.md
@@ -344,6 +344,10 @@ and `spawn_seed_inserts` (entries actually inserted) to the seeding loop.
 Report on the bench: expected `keys` ≈ env_size × 4000, `inserts` ≈ env_size.
 Land the counters as their own tiny PR — they quantify the remaining headroom.
 
+> **Step A result (2026-08-05, PR #5933):** `keys_walked=120000` (30 env
+> entries × 4000 spawns), `inserts=23` — the walk is ~99.98% redundant
+> re-walk, exactly as predicted.
+
 **Step B (design sketch — REVIEW WITH THE USER / a capable model before
 implementing):** give `Env` a monotonically increasing `write_gen: u64`
 (bumped in `cow_mut`, `insert*`, `remove`); remember on the Interpreter the
@@ -356,6 +360,22 @@ becomes a *flaky* cross-thread bug, the worst outcome class in this codebase.
 That is why step B is gated on explicit review — do not implement it in the
 same PR as step A, and do not implement it at all without sign-off recorded in
 the PR description.
+
+> **Step B RETIRED by measurement (2026-08-05) — do not implement.** A
+> local-only measurement hack (skip the seed/`declare` calls while keeping the
+> walk, after the store is saturated) bounded the win at **zero**: debug
+> baseline 8.2s vs 8.16s hacked; release baseline 0.70–0.74s vs 0.71–0.73s
+> hacked (bench shape, 4000 tasks). After slice 0 made the per-key lookups
+> FxHashMap-cheap, 120k walked keys cost single-digit milliseconds total — the
+> walk is no longer a cost center, so the generation-skip machinery (an Env
+> write-gen, a store-removal counter, equality memos on
+> `captured_scalars`/`thread_redeclared_vars`/`thread_decl_in_flight`, a
+> memoized handle-id set) would add flake-risk surface for no measurable
+> return. The redundancy the step A counters show is real but free.
+> (Incidental finding from the measurement: over-approximating
+> `referenced_handle_ids` to "all handles in the table" made the bench 14×
+> slower — per-spawn handle cloning is very sensitive to the referenced-only
+> filter; keep it exact.)
 
 ### Slice 6 (correctness-led, separate discussion): inherit parent dynamic IO
 vars in thread clones

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -156,7 +156,13 @@ impl Interpreter {
         // could be).
         let mut referenced_handle_ids = std::collections::HashSet::new();
         {
+            // Slice 5 step A instrumentation: how many env entries this walk
+            // visits vs. how many actually land in the store. Accumulated
+            // locally and recorded once per spawn (one atomic add per counter).
+            let mut seed_keys_walked: u64 = 0;
+            let mut seed_inserts: u64 = 0;
             for (key, val) in &self.env {
+                seed_keys_walked += 1;
                 if let Some(id) = Self::handle_id_from_value(val) {
                     referenced_handle_ids.insert(id);
                 }
@@ -228,10 +234,12 @@ impl Interpreter {
                     && !self.thread_decl_in_flight.contains(&key)
                 {
                     shared.declare(&key, val.clone());
-                } else {
-                    shared.seed_if_absent(&key, || val.clone());
+                    seed_inserts += 1;
+                } else if shared.seed_if_absent(&key, || val.clone()) {
+                    seed_inserts += 1;
                 }
             }
+            crate::vm::vm_stats::record_spawn_seeding(seed_keys_walked, seed_inserts);
             // Track C: migrate the parent's existing `state` variables into shared
             // cells (keyed by their normalized cross-compilation key) so a routine
             // whose `state` was already mutated before the first thread spawned

--- a/src/runtime/shared_store.rs
+++ b/src/runtime/shared_store.rs
@@ -153,15 +153,18 @@ impl SharedStore {
     /// Seed a name only if neither this lineage nor an ancestor already has it.
     /// `clone_for_thread` migrates the parent env this way: an entry an earlier
     /// thread already updated must not be reset to the spawning env's copy.
-    pub(crate) fn seed_if_absent(&self, key: &str, value: impl FnOnce() -> Value) {
+    /// Returns whether an entry was actually inserted (the per-spawn seeding
+    /// counters distinguish walked-and-skipped from walked-and-inserted).
+    pub(crate) fn seed_if_absent(&self, key: &str, value: impl FnOnce() -> Value) -> bool {
         if self.contains_key(key) {
-            return;
+            return false;
         }
         self.scope_for(key)
             .own
             .write()
             .unwrap()
             .insert(key.to_string(), value());
+        true
     }
 
     /// Fetch `key` when it already holds a cell, else install `make()` in this

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -213,6 +213,26 @@ pub(crate) fn record_registry_cow_clone() {
     }
 }
 
+// Per-spawn lineage seeding (docs/per-task-clone-slimming.md slice 5 step A):
+// `SPAWN_SEED_KEYS` counts env entries walked by the `clone_for_thread`
+// seeding loop; `SPAWN_SEED_INSERTS` the subset that actually landed in the
+// shared store (`declare` or a `seed_if_absent` that inserted). On a
+// same-scope spawn loop, keys grows as env_size x spawns while inserts
+// saturates at ~env_size — the gap quantifies the redundant re-walk that the
+// (review-gated) step B generation skip would eliminate.
+static SPAWN_SEED_KEYS: AtomicU64 = AtomicU64::new(0);
+static SPAWN_SEED_INSERTS: AtomicU64 = AtomicU64::new(0);
+
+/// Record one spawn's lineage-seeding walk: `keys` env entries walked,
+/// `inserts` of them actually inserted into the shared store.
+#[inline]
+pub(crate) fn record_spawn_seeding(keys: u64, inserts: u64) {
+    if enabled() {
+        SPAWN_SEED_KEYS.fetch_add(keys, Ordering::Relaxed);
+        SPAWN_SEED_INSERTS.fetch_add(inserts, Ordering::Relaxed);
+    }
+}
+
 // ADR-0020 worker pool: `POOL_TASKS` counts every task submitted to the
 // elastic pool; `POOL_SPAWNS` the subset that grew the pool (no idle worker
 // at submit time). `tasks - spawns` is therefore the warm-reuse count the
@@ -557,6 +577,11 @@ pub(crate) fn dump() {
     );
     let registry_cow_clones = REGISTRY_COW_CLONES.load(Ordering::Relaxed);
     eprintln!("[mutsu vm-stats] registry-cow: clones={registry_cow_clones}");
+    let spawn_seed_keys = SPAWN_SEED_KEYS.load(Ordering::Relaxed);
+    let spawn_seed_inserts = SPAWN_SEED_INSERTS.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] spawn-seeding: keys_walked={spawn_seed_keys} inserts={spawn_seed_inserts}"
+    );
     let pool_tasks = POOL_TASKS.load(Ordering::Relaxed);
     let pool_spawns = POOL_SPAWNS.load(Ordering::Relaxed);
     eprintln!(


### PR DESCRIPTION
Slice 5 **step A** of docs/per-task-clone-slimming.md: instrumentation only, no behavior change. The second commit records the step-B verdict in the plan doc.

## What

- `clone_for_thread_excluding` now counts, per spawn, the env entries its ADR-0010 lineage-seeding walk visits (`spawn_seed_keys`) and the subset that actually lands in the shared store (`spawn_seed_inserts`).
- `SharedStore::seed_if_absent` returns `bool` (inserted or already-present) so the caller can count without a second lookup. No semantic change.
- Counters follow the `record_pool_task` pattern: accumulated in locals, one `record_spawn_seeding(keys, inserts)` call per spawn (two relaxed atomic adds), fully gated on the cached `MUTSU_VM_STATS` flag.

## Counters on the bench (debug build, `MUTSU_VM_STATS=1 ./target/debug/mutsu tmp/bench-start-shape.p6`)

```
[mutsu vm-stats] dual-store: clone_env=4000 (O(1) Arc bumps) env_deep_copies=8000 (O(env) make_mut) env_flushes=0 slots_flushed=0
[mutsu vm-stats] registry-cow: clones=0
[mutsu vm-stats] spawn-seeding: keys_walked=120000 inserts=23
[mutsu vm-stats] worker-pool: tasks=4000 spawns=2 warm_reuses=3998
```

`keys_walked=120000` = ~30 env entries x 4000 spawns; `inserts=23` = the store saturates after the first task. Worker-pool reuse intact.

## Step B verdict: RETIRED by measurement — do not implement

The step-B generation skip was gated on measure-first review (docs/per-task-clone-slimming.md §4 slice 5, §6). Measured with a local-only hack that skips the seed/`declare` calls once the store is saturated (walk and handle-id collection kept exact):

- debug: baseline 8.17/8.20s vs hacked 8.26/8.06s
- release: baseline 0.73/0.70/0.74s vs hacked 0.73/0.71/0.72s

Zero headroom: after slice 0 (FxHashMap), 120k walked keys cost single-digit milliseconds total. The skip machinery (Env write-gen, store-removal counter, equality memos on captured/redeclared/in-flight sets, memoized handle-id set) would be pure flake-risk surface for no measurable return. Recorded in the plan doc in this PR.

Incidental finding: over-approximating `referenced_handle_ids` to "all handles" made the bench 14x slower — the referenced-only handle filter is load-bearing; keep it exact.

## Wall-clock (release, median of 5, local A/B for development only)

`tmp/bench-start-shape.p6`: **0.71s** (0.68/0.70/0.71/0.71/0.71) — unchanged from the post-slice-4 state within noise, as expected for gated instrumentation. Campaign so far: 1.66s (baseline) → 0.71s; the plan's < ~1.0s bench exit criterion is met. Full `ripemd.t` re-measured at 461s (was ~513s) — the remaining gap is per-round interpreter cost, outside this campaign's clone-payload scope.

## Verification

- `cargo clippy -- -D warnings`, `cargo fmt` — clean
- `make test` — All tests successful (Files=2888, Tests=27453)

🤖 Generated with [Claude Code](https://claude.com/claude-code)