### PR TITLE
fix(runtime): start blocks inherit the spawning scope's dynamic IO vars (clone-slimming slice 6)

### DIFF
--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -4,8 +4,10 @@ use crate::value::ValueView;
 use std::sync::OnceLock;
 
 impl Interpreter {
-    /// Rebuild the per-interpreter IO/dynamic-var environment. Called both from
-    /// `Interpreter::new()` and from every `clone_for_thread` spawn.
+    /// Rebuild the per-interpreter IO/dynamic-var environment. Called from
+    /// `Interpreter::new()`; every `clone_for_thread` spawn uses the
+    /// [`Self::init_io_environment_for_thread_clone`] variant, which inherits
+    /// already-present dynamic IO handle vars instead of clobbering them.
     ///
     /// `$*CWD` is deliberately rebuilt via a real `current_dir()` syscall on
     /// EVERY call, including thread-clone spawns, even though `cloned.env`
@@ -29,34 +31,74 @@ impl Interpreter {
     /// touches because their identity is process-constant, not reassigned by
     /// ordinary programs).
     pub(super) fn init_io_environment(&mut self) {
-        let stdout = self.create_handle(
-            IoHandleTarget::Stdout,
-            IoHandleMode::Write,
-            Some("STDOUT".to_string()),
-        );
-        self.env.insert("$*OUT".to_string(), stdout.clone());
-        self.env.insert("*OUT".to_string(), stdout);
-        let stderr = self.create_handle(
-            IoHandleTarget::Stderr,
-            IoHandleMode::Write,
-            Some("STDERR".to_string()),
-        );
-        self.env.insert("$*ERR".to_string(), stderr.clone());
-        self.env.insert("*ERR".to_string(), stderr);
-        let stdin = self.create_handle(
-            IoHandleTarget::Stdin,
-            IoHandleMode::Read,
-            Some("STDIN".to_string()),
-        );
-        self.env.insert("$*IN".to_string(), stdin.clone());
-        self.env.insert("*IN".to_string(), stdin);
-        let argfiles = self.create_handle(
-            IoHandleTarget::ArgFiles,
-            IoHandleMode::Read,
-            Some("$*ARGFILES".to_string()),
-        );
-        self.env.insert("$*ARGFILES".to_string(), argfiles.clone());
-        self.env.insert("*ARGFILES".to_string(), argfiles);
+        self.init_io_environment_impl(false)
+    }
+
+    /// [`Self::init_io_environment`] for a `clone_for_thread` spawn
+    /// (docs/per-task-clone-slimming.md slice 6): dynamic IO handle vars
+    /// (`$*OUT`/`$*ERR`/`$*IN`/`$*ARGFILES`) the cloned env already carries are
+    /// INHERITED instead of clobbered with fresh default handles — in Raku a
+    /// `start` block sees the spawning scope's `my $*OUT = ...` redirection
+    /// (pin: `t/start-inherits-dynamic-out.t`). The non-handle dynamic vars
+    /// below the handle block are still rebuilt exactly as before (see the
+    /// `$*CWD` comment above for why that rebuild must stay unconditional).
+    pub(super) fn init_io_environment_for_thread_clone(&mut self) {
+        self.init_io_environment_impl(true)
+    }
+
+    /// Whether the cloned env carries a usable inherited entry for the dynamic
+    /// IO var `name` (or its bare `alias`): a user object (the output-capture
+    /// redirection idiom), or a default handle whose id survived the referenced-
+    /// handle clone in `clone_for_thread_excluding`. A handle id that did NOT
+    /// survive (e.g. the parent closed it) reports unusable so the caller
+    /// rebuilds the default, preserving the pre-slice-6 behavior for that edge.
+    fn inherited_io_entry_usable(&self, name: &str, alias: &str) -> bool {
+        let Some(v) = self.env.get(name).or_else(|| self.env.get(alias)) else {
+            return false;
+        };
+        match Self::handle_id_from_value(v) {
+            Some(id) => self.io_handles().map.contains_key(&id),
+            None => !v.is_nil(),
+        }
+    }
+
+    fn init_io_environment_impl(&mut self, for_thread_clone: bool) {
+        if !(for_thread_clone && self.inherited_io_entry_usable("$*OUT", "*OUT")) {
+            let stdout = self.create_handle(
+                IoHandleTarget::Stdout,
+                IoHandleMode::Write,
+                Some("STDOUT".to_string()),
+            );
+            self.env.insert("$*OUT".to_string(), stdout.clone());
+            self.env.insert("*OUT".to_string(), stdout);
+        }
+        if !(for_thread_clone && self.inherited_io_entry_usable("$*ERR", "*ERR")) {
+            let stderr = self.create_handle(
+                IoHandleTarget::Stderr,
+                IoHandleMode::Write,
+                Some("STDERR".to_string()),
+            );
+            self.env.insert("$*ERR".to_string(), stderr.clone());
+            self.env.insert("*ERR".to_string(), stderr);
+        }
+        if !(for_thread_clone && self.inherited_io_entry_usable("$*IN", "*IN")) {
+            let stdin = self.create_handle(
+                IoHandleTarget::Stdin,
+                IoHandleMode::Read,
+                Some("STDIN".to_string()),
+            );
+            self.env.insert("$*IN".to_string(), stdin.clone());
+            self.env.insert("*IN".to_string(), stdin);
+        }
+        if !(for_thread_clone && self.inherited_io_entry_usable("$*ARGFILES", "*ARGFILES")) {
+            let argfiles = self.create_handle(
+                IoHandleTarget::ArgFiles,
+                IoHandleMode::Read,
+                Some("$*ARGFILES".to_string()),
+            );
+            self.env.insert("$*ARGFILES".to_string(), argfiles.clone());
+            self.env.insert("*ARGFILES".to_string(), argfiles);
+        }
         let spec = self.make_io_spec_instance();
         self.env.insert("$*SPEC".to_string(), spec.clone());
         self.env.insert("*SPEC".to_string(), spec);

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -698,7 +698,7 @@ impl Interpreter {
         cloned.env.insert("!".to_string(), Value::NIL);
         cloned.env.insert("$/".to_string(), Value::NIL);
         cloned.env.insert("$!".to_string(), Value::NIL);
-        cloned.init_io_environment();
+        cloned.init_io_environment_for_thread_clone();
         cloned
     }
 

--- a/t/start-inherits-dynamic-out.t
+++ b/t/start-inherits-dynamic-out.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# docs/per-task-clone-slimming.md slice 6: a `start` block must inherit the
+# spawning scope's dynamic IO vars ($*OUT/$*ERR), like rakudo, instead of
+# having init_io_environment clobber the thread clone's env entries with
+# fresh default handles. Oracle: raku prints captured=[X] for each shape.
+
+plan 4;
+
+my $out = "";
+{
+    my $*OUT = class { method print(*@a) { $out ~= @a.join }; method flush {} }.new;
+    await start { print "X" };
+}
+is $out, "X", 'start inherits the redirected $*OUT (print)';
+
+my $err = "";
+{
+    my $*ERR = class { method print(*@a) { $err ~= @a.join }; method flush {} }.new;
+    await start { $*ERR.print("E") };
+}
+is $err, "E", 'start inherits the redirected $*ERR (explicit .print)';
+
+my $out2 = "";
+{
+    my $*OUT = class { method print(*@a) { $out2 ~= @a.join }; method flush {} }.new;
+    await start { say 42 };
+}
+is $out2, "42\n", 'start inherits the redirected $*OUT (say routes through it)';
+
+my $out3 = "";
+{
+    my $*OUT = class { method print(*@a) { $out3 ~= @a.join }; method flush {} }.new;
+    my $p = Promise.start({ print "P" });
+    await $p;
+}
+is $out3, "P", 'Promise.start inherits the redirected $*OUT';


### PR DESCRIPTION
Slice 6 of docs/per-task-clone-slimming.md — the correctness-led slice.

## The bug (Raku-compat divergence)

```raku
my $out = ""; { my $*OUT = class { method print(*@a) { $out ~= @a.join };
method flush {} }.new; await start { print "X" } }; say "captured=[$out]"
# raku:  captured=[X]      (start inherits the redirected $*OUT)
# mutsu: X + captured=[]   (init_io_environment clobbered the child's $*OUT)
```

The thread clone carried the parent's env entries over correctly, but `init_io_environment` then unconditionally overwrote `$*OUT`/`$*ERR`/`$*IN`/`$*ARGFILES` with fresh default handles.

## The fix

Thread clones call a new `init_io_environment_for_thread_clone`, which keeps an already-present entry when it is *usable*: a user object (the output-capture idiom), or a default handle whose id survived the referenced-handle clone. A missing or dead entry (parent closed the handle) still gets a fresh default — the pre-slice-6 behavior for that edge. `Interpreter::new` is unchanged; the non-handle dynamic vars (`$*CWD` etc.) are still rebuilt unconditionally per the existing load-bearing comment.

Oracle-checked against raku for 4 shapes (`print`, explicit `$*ERR.print`, `say` routing, `Promise.start`): all match now. Pin: `t/start-inherits-dynamic-out.t`.

## Perf side effect: bench 0.71s → 0.19s

Four `create_handle` calls + eight env inserts per task disappear from the spawn path.

- `tmp/bench-start-shape.p6` (4000 tasks), release, 5 runs: **0.18/0.19/0.19/0.21/0.17** (was 0.68–0.74 post-slice-4). Past the campaign's < ~1.0s exit criterion and below raku's 0.33s on the same machine.
- Counters intact: `worker-pool: tasks=4000 spawns=3 warm_reuses=3997`, `registry-cow: clones=0`, `env_deep_copies=8000`.
- `rmd160("a" x 100_000)`: 31.1s → 26.3s. (`ripemd.t`'s remaining gap is per-round interpreter cost, outside this campaign.)

## Verification

- `make test` — All tests successful (Files=2889, Tests=27457)
- Guard tests from the plan: `t/thread-*.t t/subtest*.t t/start-*.t t/concurrency-threading.t t/lock.t t/supply-batch-period.t` (22 files) and `roast/S17-promise/start.t roast/S17-promise/nonblocking-await.t roast/S17-supply/act.t roast/S02-magicals/env.t` — all pass; no TAP output-ordering breakage.
- `cargo clippy -- -D warnings`, `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)