### PR TITLE
docs: close the per-task clone-slimming campaign

### DIFF
--- a/docs/per-task-clone-slimming.md
+++ b/docs/per-task-clone-slimming.md
@@ -1,6 +1,15 @@
 # Per-task `clone_for_thread` slimming — implementation plan
 
-- Status: **design ready, implementation open** (2026-08-05)
+- Status: **CAMPAIGN COMPLETE** (2026-08-05) — slices 0/1/2/3/4 merged
+  (#5928/#5929/#5930/#5931/#5932), slice 5 step A merged (#5933) with step B
+  retired by measurement (see the slice 5 section), slice 6 merged (#5934).
+  Final spawn-shape bench: **0.19s** median-of-5 release (baseline 1.66s,
+  raku 0.33s on the same machine) — the < ~1.0s exit criterion is exceeded.
+  `t/ripemd.t` improved ~513s → 295.3s but stays over the 120s budget; the
+  remaining gap is per-round interpreter cost with a measured single cause
+  (Tier A JIT bails on the bitwise opcodes), handed off to
+  `todo/tickets/jit-bitwise-tier-a-coverage.md`. Do not reopen spawn-side
+  work from this plan. News: `news/2026-08/per-task-clone-slimming-campaign.md`.
 - Owner ticket: `todo/tickets/digest-ripemd-start-per-block-overhead.md`
 - Context: [ADR-0020](adr/0020-shared-worker-pool.md) §1.3 identified the per-task
   `Interpreter` clone as the dominant per-`start` cost that the worker pool
@@ -400,6 +409,19 @@ treat it as its own investigation: write `t/start-inherits-dynamic-out.t` from
 the oracle above first, then make it pass without breaking
 `t/thread-*.t` / `t/subtest*.t` / `roast/S17-promise/start.t`. If output
 ordering breaks, stop and record findings in the ticket.
+
+> **DONE (2026-08-05, #5934).** `init_io_environment_for_thread_clone` keeps a
+> usable inherited entry (a user object, or a handle id that survived the
+> referenced-handle clone) and rebuilds only missing/dead ones; the
+> `Interpreter::new` path and the non-handle dynamic vars are unchanged. All
+> four oracle shapes now match raku; pin `t/start-inherits-dynamic-out.t`. No
+> TAP output-ordering breakage (thread/subtest/start/lock guards + S17 roast
+> all green). The feared ordering entanglement did not materialize because a
+> cloned Stdout-target handle routes through the child's own `OutputSink`
+> exactly like a fresh default handle. Unexpectedly this was also the largest
+> perf win of the campaign: dropping the four `create_handle` calls + eight
+> env inserts per task took the bench from 0.71s to **0.19s** (local release,
+> median of 5).
 
 ## 5. Per-PR protocol
 

--- a/news/2026-08/per-task-clone-slimming-campaign.md
+++ b/news/2026-08/per-task-clone-slimming-campaign.md
@@ -1,0 +1,47 @@
+# Per-task clone slimming: spawn overhead now below raku (campaign complete)
+
+The `docs/per-task-clone-slimming.md` campaign — the companion lever to the
+ADR-0020 worker pool — landed all its slices on 2026-08-05:
+
+- **Slice 0** (#5928): `SharedStore` lineage maps on `FxHashMap` instead of
+  SipHash.
+- **Slice 1** (#5929): Registry copy-on-write — `Arc<RwLock<Arc<Registry>>>`
+  with `Arc::make_mut` on first write, replacing the eager ~40-map deep clone
+  per spawn (and retiring the regex-eval generation-cached snapshot).
+- **Slice 2** (#5930): single-pass env iteration in
+  `clone_for_thread_excluding` (lineage seeding + IO-handle scan merged).
+- **Slice 3** (#5931): process-constant IO env singletons (`$*DISTRO`,
+  `$*PERL`/`$*RAKU`, `$*VM`, `$*KERNEL`, executable/tmpdir/home strings)
+  cached in `OnceLock`s.
+- **Slice 4** (#5932): `instance_type_metadata` copy-on-write, same pattern
+  as slice 1.
+- **Slice 5 step A** (#5933): `spawn_seed_keys`/`spawn_seed_inserts` counters.
+  They showed the seeding walk is ~99.98% redundant re-walk on a same-scope
+  spawn loop (120000 keys walked, 23 inserted) — and a measurement hack then
+  bounded the win of skipping it at **zero** (release 0.70–0.74s vs
+  0.71–0.73s), so the review-gated **step B generation skip was retired
+  unimplemented**: after slice 0 the walk costs single-digit milliseconds
+  total, and the skip machinery would have been pure flake-risk surface.
+- **Slice 6** (#5934): `start` blocks now inherit the spawning scope's
+  dynamic IO vars — a Raku-compat fix (a redirected `my $*OUT = ...` capture
+  object is visible inside `start`, pin `t/start-inherits-dynamic-out.t`)
+  that also removed four `create_handle` calls and eight env inserts per
+  task, the single largest perf win of the campaign.
+
+Numbers (local A/B, release build, median of 5 — this spawn-shape bench is
+not in the bench-CI suite):
+
+- Bench `for ^2000 { await map -> $k { start { $k * 2 } }, 1, 2 }` (4000
+  tasks): **1.66s → 0.19s**, past the plan's < ~1.0s exit criterion and below
+  raku's 0.33s on the same machine. Pool reuse intact
+  (`tasks=4000 warm_reuses=3997`), `registry_cow_clones=0`.
+- `Digest::RIPEMD` (`t/ripemd.t`, the owner ticket's target): ~513s →
+  **295.3s** (9/9 pass), still over the 120s batteries-gate budget. The
+  remaining gap has a measured single cause — the 80-round compression loop
+  never enters the JIT (`jit: compiles=0`, every chunk bails on
+  `BitShiftLeft`) — handed off to
+  `todo/tickets/jit-bitwise-tier-a-coverage.md`.
+
+Incidental finding recorded in the plan doc: over-approximating the per-spawn
+`referenced_handle_ids` set to "all handles" makes the bench 14× slower — the
+referenced-only filter on handle cloning is load-bearing.


### PR DESCRIPTION
Docs-only campaign close, now that #5934 (slice 6) merged.

- `docs/per-task-clone-slimming.md`: status header → CAMPAIGN COMPLETE with the final numbers and the hand-off pointer; slice 6 section gets its DONE note (fix shape, guard results, and why the feared TAP ordering entanglement did not materialize).
- `news/2026-08/per-task-clone-slimming-campaign.md`: one entry for the whole campaign (slices 0–6, PR numbers, step B retirement, the 14× handle-filter incidental finding). Local A/B numbers are labeled as such — the spawn-shape bench is not in the bench-CI suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)