### PR TITLE
perf: O(1) Buf/Blob element read in the index op

### DIFF
--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -273,6 +273,26 @@ pub(crate) fn with_buf_elems<R>(attrs: &InstanceAttrs, f: impl FnOnce(&[Value]) 
     Some(f(&elems))
 }
 
+/// One element decoded in place — the O(1) subscript read (`$blob[$i]`).
+/// `None` when the instance carries no element storage or `idx` is out of
+/// range; the caller picks the out-of-range policy (Buf/Blob `AT-POS`
+/// yields 0). Exists so a hot `@words[$i]` loop does not pay
+/// [`decode_elems`]'s whole-buffer `Vec<Value>` per access.
+pub(crate) fn buf_elem_at(attrs: &InstanceAttrs, idx: usize) -> Option<Value> {
+    let map = attrs.as_map();
+    let node = node_in(&map)?;
+    let w = node.width as usize;
+    let start = idx.checked_mul(w)?;
+    let chunk = node.bytes.get(start..start.checked_add(w)?)?;
+    let mut raw = [0u8; 8];
+    raw[..w].copy_from_slice(chunk);
+    Some(decode_elem_bits(
+        u64::from_le_bytes(raw),
+        node.width,
+        node.kind,
+    ))
+}
+
 /// Whether this instance carries element storage at all. Distinguishes a real
 /// (possibly empty) buffer from a `Blob`/`Buf` **type object**, which has none.
 pub(crate) fn has_buf_elems(attrs: &InstanceAttrs) -> bool {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1250,6 +1250,33 @@ impl Interpreter {
                     None => Value::NIL,
                 }
             }
+            // `Buf`/`Blob` (and Raku-side `CArray`) element read: decode the one
+            // element in place instead of routing through AT-POS method dispatch
+            // — which re-resolves the parametrized MRO (`Blob[uint32]`) per
+            // access — and `decode_elems`, which decodes the WHOLE buffer into a
+            // fresh `Vec<Value>` per access (O(N) per read, O(N^2) for a loop).
+            // Same result as the dispatch_1arg AT-POS arm: in-range -> element,
+            // out-of-range (or storage-less) -> 0; a negative index falls out of
+            // AT-POS as Nil, which the generic arm below turns into the typed
+            // container default — reproduced here. Same name-is-authoritative
+            // trust as the `CArray[T]` native-handle arm above.
+            (
+                ValueView::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                },
+                ValueView::Int(i),
+            ) if crate::runtime::utils::is_native_elems_class(class_name.as_str())
+                && crate::value::value_buf::has_buf_elems(&attributes) =>
+            {
+                if i < 0 {
+                    self.typed_container_default(&target)
+                } else {
+                    crate::value::value_buf::buf_elem_at(&attributes, i as usize)
+                        .unwrap_or(Value::int(0))
+                }
+            }
             (ValueView::Instance { .. }, ValueView::Int(i)) => {
                 let fallback = target.clone();
                 let result = self

--- a/t/blob-index-fast-path.t
+++ b/t/blob-index-fast-path.t
@@ -1,0 +1,34 @@
+# Pins the in-place Buf/Blob element read in exec_index_op_with_positional
+# (the fast path that bypasses AT-POS method dispatch and whole-buffer
+# decode): the observable subscript behavior must stay exactly what the
+# dispatch_1arg AT-POS arm produced.
+use Test;
+
+plan 12;
+
+my $b = blob32.new(1, 2, 3);
+is $b[0], 1, 'blob32 first element';
+is $b[2], 3, 'blob32 last element';
+is $b[5], 0, 'blob32 out-of-range reads as 0';
+my $neg = -1;
+ok $b[$neg] === Nil, 'blob32 negative index reads as Nil';
+
+my $c = buf8.new(9, 8, 255);
+is $c[1], 8, 'buf8 element';
+is $c[2], 255, 'buf8 unsigned byte is not sign-extended';
+is $c[10], 0, 'buf8 out-of-range reads as 0';
+
+my $u = utf8.new(65, 66);
+is $u[1], 66, 'utf8 (Blob[uint8] alias) element';
+
+is blob64.new(18446744073709551615)[0], 18446744073709551615,
+    'blob64 element above i64::MAX decodes as the full unsigned value';
+
+my $s = Blob[int8].new(-1, -128);
+is $s[0], -1, 'signed element is sign-extended from its width';
+is $s[1], -128, 'signed minimum survives the round-trip';
+
+# Reads must see writes that went through the shared storage node.
+my $w = buf8.new(1, 2, 3);
+$w[1] = 42;
+is $w[1], 42, 'read observes an element written through ASSIGN-POS';


### PR DESCRIPTION
## Summary

Working the `todo/tickets/digest-ripemd-start-per-block-overhead.md` levers: `$blob[$i]` routed through AT-POS method dispatch, paying per access:

- an **uncached parametrized MRO resolve** of `Blob[uint32]` in `try_user_io_handle_method` (registry guard + `Symbol::intern` + Vec/Arc build, result never cached),
- the generic dispatch chain's allocations (args `Vec`, self save/restore, ~12 `method == "new"` gates),
- and — the big one — `decode_elems` in the `dispatch_1arg` AT-POS arm decoding the **whole buffer** into a fresh `Vec<Value>` per element read: O(N) per access, **O(N²) for a loop over the buffer**.

## Fix

A dedicated `(Instance, Int)` arm in `exec_index_op_with_positional` for native-elems classes (Buf/Blob and Raku-side CArray), decoding the one element in place via the new `value_buf::buf_elem_at` (bounds-checked single-chunk decode, no allocation). Same name-is-authoritative trust as the adjacent `CArray[T]` native-handle arm.

## Behavior

Unchanged, pinned by the new `t/blob-index-fast-path.t` (12 subtests): in-range → element (incl. `uint64 > i64::MAX` → BigInt, sign-extension for signed widths), out-of-range → 0, negative → Nil/typed default, and reads observe ASSIGN-POS writes through the shared storage node. Verified byte-identical against the pre-change binary.

## Measured (release)

- 1M-iteration `blob32` element-read loop: **12.0s → 0.79s (~15x)**.
- Buf/Blob roast files (`S03-buf/*`, `S03-operators/buf.t`, `S32-container/buf.t`): all PASS.
- `make test`: full PASS (2890 files).
- The rmd160 gate itself is flat (~29.6s at 100k input) — its dominant cost is the per-round closure-call setup, the next lever on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)