### PR TITLE
perf(runtime): dispatch reduce steps compiled-first

### DIFF
--- a/src/runtime/builtins_reduce.rs
+++ b/src/runtime/builtins_reduce.rs
@@ -270,7 +270,7 @@ impl Interpreter {
                     right_edge = start;
                     // `last` inside the reduce block stops and keeps the current
                     // accumulator; `next` skips this step, also keeping the accumulator.
-                    match self.call_sub_value(callable.clone(), call_args, true) {
+                    match self.reduce_call_step(&callable, call_args) {
                         Ok(v) => {
                             acc = if is_thunky {
                                 match Self::dethunk(self, v) {
@@ -297,10 +297,9 @@ impl Interpreter {
             OpAssoc::Chain => {
                 let mut result = true;
                 for i in 0..items.len() - 1 {
-                    let v = self.call_sub_value(
-                        callable.clone(),
+                    let v = self.reduce_call_step(
+                        &callable,
                         vec![items[i].clone(), items[i + 1].clone()],
-                        true,
                     )?;
                     if !v.truthy() {
                         result = false;
@@ -319,7 +318,7 @@ impl Interpreter {
                     idx += step;
                     // `last` inside the reduce block stops and keeps the current
                     // accumulator; `next` skips this step, also keeping the accumulator.
-                    match self.call_sub_value(callable.clone(), call_args, true) {
+                    match self.reduce_call_step(&callable, call_args) {
                         Ok(v) => {
                             acc = if is_thunky {
                                 match Self::dethunk(self, v) {
@@ -347,6 +346,27 @@ impl Interpreter {
 
         self.hash_autovivify = saved_autovivify;
         result
+    }
+
+    /// Call one reduce step. Compiled-first: a `Sub` carrying bytecode
+    /// dispatches through the VM closure path; the `call_sub_value` AST
+    /// carrier re-compiles `data.body` on every step (Digest::RIPEMD's
+    /// 80-round reduce lambda paid a full recompile — including its
+    /// `BEGIN`-array's five anon subs — per round, per task).
+    fn reduce_call_step(
+        &mut self,
+        callable: &Value,
+        call_args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        let has_bytecode = matches!(
+            callable.view(),
+            ValueView::Sub(d) if d.compiled_code.is_some() || d.compiled_routine.is_some()
+        );
+        if has_bytecode {
+            self.vm_call_on_value(callable.clone(), call_args, None)
+        } else {
+            self.call_sub_value(callable.clone(), call_args, true)
+        }
     }
 
     fn is_thunky_reduce_op(callable: &Value) -> bool {

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -440,7 +440,7 @@ impl Interpreter {
     /// - a WeakSub -> upgrade to Sub and recurse
     ///
     /// Falls back to interpreter for Mixin (CALL-ME from roles) and Instance (CALL-ME).
-    pub(super) fn vm_call_on_value(
+    pub(crate) fn vm_call_on_value(
         &mut self,
         target: Value,
         args: Vec<Value>,


### PR DESCRIPTION
`reduce_items` called every step through `call_sub_value`, whose body execution is the `eval_block_value` AST carrier — it **re-compiles `data.body` on every invocation**. `Digest::RIPEMD`'s 80-round reduce lambda paid a full recompile (including its `BEGIN`-array's five anon subs) per round, per task: gdb showed `compile_routine_closure_body` firing hundreds of times in a 2k-input run, and perf put ~10% of the whole rmd160 run in the compiler plus its malloc traffic (ripemd ticket, next-lever investigation after the closure-setup slice #5941).

A `Sub` carrying bytecode (`compiled_code` or `compiled_routine`) now dispatches through the VM closure path (`vm_call_on_value`, made `pub(crate)`); Subs without bytecode keep the interpreter carrier. `last`/`next` loop control propagates identically through both paths (both surface as control-flagged `RuntimeError`s handled at the reduce loop).

This is also a step of slow-path retirement per CLAUDE.md: one fewer route through the tree-walk-era AST carrier.

## Measurements (release, local)

- rmd160("a" x 100_000) gate: **~28s → 12.0s**
- Full upstream libdigest `t/ripemd.t`: **295s → 119s** (9/9 pass) — inside the batteries gate's 120s per-file budget for the first time
- `make test` passes (2889 files); `roast/S03-metaops/reduce.t` 580/580

🤖 Generated with [Claude Code](https://claude.com/claude-code)