### PR TITLE
perf(runtime): dispatch produce steps compiled-first too

### DIFF
--- a/news/2026-08/reduce-compiled-first-dispatch.md
+++ b/news/2026-08/reduce-compiled-first-dispatch.md
@@ -1,0 +1,34 @@
+# reduce/produce steps dispatch compiled-first — t/ripemd.t 295s -> 119s
+
+`reduce_items` (and `eval_produce_over_items`) called every step through
+`call_sub_value`, whose body execution is the `eval_block_value` AST
+carrier — it re-compiles `data.body` on every invocation. For
+`Digest::RIPEMD` this meant the 80-round reduce lambda (including its
+`BEGIN`-array's five anon subs) was fully recompiled per step, per task:
+gdb showed `compile_routine_closure_body` firing hundreds of times in a
+2k-input run, and perf attributed ~10% of the whole rmd160 run to the
+compiler plus its malloc traffic.
+
+A `Sub` carrying bytecode (`compiled_code` or `compiled_routine`) now
+dispatches through the VM closure path (`vm_call_on_value`, made
+`pub(crate)`); Subs without bytecode keep the interpreter carrier.
+`last`/`next` loop control propagates identically through both paths.
+This retires one more route through the tree-walk-era AST carrier
+(reduce in #5942, produce in the follow-up PR).
+
+The companion slice #5941 slimmed the closure-call setup itself:
+`&?BLOCK`/block_stack reuse the caller's `Gc<SubData>` (refcount bump)
+instead of a full per-call `SubData` clone, the well-known env inserts
+(`self`, `&?BLOCK`, `__mutsu_callable_id`, `!`, `_`) are symbol-keyed,
+and `sanitize_call_args_owned` passes the caller's owned args `Vec`
+through untouched when no callsite-line marker is present (applied to
+the six dispatch paths that own their args). Closure-call microbench:
+4.30s -> 3.7s.
+
+Measured effect (release, local): `rmd160("a" x 100_000)` 28s -> 12.0s;
+the full upstream libdigest `t/ripemd.t` 295s -> 119s (9/9 pass) —
+inside the batteries gate's 120s per-file budget for the first time,
+though it stays un-whitelisted until another lever provides margin for
+slower CI runners (the gate is a hard `timeout 120`). Remaining levers
+are recorded in `todo/tickets/digest-ripemd-start-per-block-overhead.md`
+status update 4.

--- a/src/runtime/builtins_reduce.rs
+++ b/src/runtime/builtins_reduce.rs
@@ -93,7 +93,7 @@ impl Interpreter {
                     let start = right_edge - step;
                     let mut call_args = items[start..right_edge].to_vec();
                     call_args.push(acc.clone());
-                    match self.call_sub_value(callable.clone(), call_args, true) {
+                    match self.reduce_call_step(&callable, call_args) {
                         Ok(new_acc) => {
                             out.push(acc);
                             acc = new_acc;
@@ -114,7 +114,7 @@ impl Interpreter {
                 while idx + step <= items.len() {
                     let mut call_args = vec![acc.clone()];
                     call_args.extend(items[idx..idx + step].iter().cloned());
-                    match self.call_sub_value(callable.clone(), call_args, true) {
+                    match self.reduce_call_step(&callable, call_args) {
                         Ok(new_acc) => {
                             out.push(acc);
                             acc = new_acc;
@@ -348,7 +348,7 @@ impl Interpreter {
         result
     }
 
-    /// Call one reduce step. Compiled-first: a `Sub` carrying bytecode
+    /// Call one reduce/produce step. Compiled-first: a `Sub` carrying bytecode
     /// dispatches through the VM closure path; the `call_sub_value` AST
     /// carrier re-compiles `data.body` on every step (Digest::RIPEMD's
     /// 80-round reduce lambda paid a full recompile — including its


### PR DESCRIPTION
Same lever as #5942 for `eval_produce_over_items`: both assoc branches route each step through `reduce_call_step`, so a `Sub` carrying bytecode runs on the VM closure path instead of the `eval_block_value` AST carrier (which recompiles `data.body` per invocation). `last`/`next` handling is unchanged — both paths surface control-flagged `RuntimeError`s at the produce loop.

Also adds the `news/2026-08/` entry recording the reduce/produce compiled-first + closure-setup slimming work (#5941/#5942/this).

Verified: `make test` (2890 files), `roast/S03-metaops/reduce.t` 580/580, `t/produce-last.t`, and `produce`/`[\+]`/`[\*]` output matches raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)