### PR TITLE
refactor(runtime): statement-position calls run the compiled routine body

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,10 +115,10 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 17/53 slices merged. Next slice: fold `calls.rs:exec_call`'s inlined copy of
-the retired `call_function_def` into the compiled entry — the last thing keeping C6d-1 open
-(C6a, C6b and C6c landed; C6 and C6d are both subdivided below, C6d from a measurement of where
-its sites are actually reached).**
+**Current progress: 17/53 slices merged. Next slice: C6d-4 (`call_sub_value`'s
+`eval_block_value(&data.body)`), or C6d-3's Phase-C half — C6d-1 is complete (C6a, C6b and C6c
+landed; C6 and C6d are both subdivided below, C6d from a measurement of where its sites are
+actually reached).**
 
 The count tallies top-level boxes only; sub-boxes (C6a–C6e, C6d-1..4, E1a/E1b) are that box's
 PRs, and a subdivided box is checked when its last sub-box merges. A box that turns out to need
@@ -204,7 +204,7 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
     per call, so what C6d removes is a repeated compile. The mismatch to solve is that
     `compile_block_raw` compiles a *block* whose arguments the caller already bound, while
     `def.compiled` binds its own from `param_local_slots`. Subdivide:
-    - [ ] **C6d-1 — the ordinary-routine tail** (`calls.rs:call_function_def`,
+    - [x] **C6d-1 — the ordinary-routine tail** (`calls.rs:call_function_def`,
       `calls.rs:exec_call`): 192 hits over ~37 names. The shape is settled and is neither
       candidate above: these are *callers* reaching the interpreter entry `call_function_def`
       where a compiled entry already exists, so each one is rewired rather than re-compiled. The
@@ -222,9 +222,11 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
       used to judge a dispatch-path change). `Interpreter::call_function_def` is now gone: its
       last gated shape, `multi_candidate_state_forces_interpreter`, was retired by installing
       multi candidates from their plan-compiled routines (see the implementation status below).
-      One thing keeps the box open:
-      - `calls.rs:exec_call` (48 hits) still holds an inlined copy of the retired
-        `call_function_def`'s body, including its own `run_block(&def.body)`.
+      The final piece — `calls.rs:exec_call`'s inlined copy of the retired
+      `call_function_def`'s body (48 hits), including its own `run_block(&def.body)` — now
+      delegates to `call_routine_def`, so statement-position calls run the routine's
+      plan-attached bytecode through the same entry and writeback merge as expression-position
+      calls (`news/2026-08/statement-calls-run-the-compiled-body.md`).
     - [ ] **C6d-2 — grammar token/rule bodies** (`dispatch.rs:eval_token_def`,
       `regex_token_resolve.rs`): 956 of the 1148 hits, but those `FunctionDef`s carry a regex
       body, so scope this against ADR-0009's execution model rather than the OTF gate. **This
@@ -472,7 +474,9 @@ Every caller of the interpreter routine entry `call_function_def` now invokes th
 bytecode through one shared `call_routine_def`: the multi-deferral chain first, then the user
 `prefix:`/`postfix:` operators, the reduce and hyper steps over a user `infix:`, `reduce` given
 the operator as a routine value, and the selected `MAIN` candidate. What that removes is a
-per-call *compile* of the routine's AST body, not a tree walk. `call_function_def` itself has been deleted.
+per-call *compile* of the routine's AST body, not a tree walk. `call_function_def` itself has been
+deleted, and the inlined copy of its body that `exec_call` (the statement-position call entry)
+carried is gone with it: that site now delegates to `call_routine_def` too, which closed C6d-1.
 
 Its last gated shape was `multi_candidate_state_forces_interpreter`, which existed because a
 multi candidate never received plan-compiled bytecode. Registration no longer discovers the

--- a/news/2026-08/statement-calls-run-the-compiled-body.md
+++ b/news/2026-08/statement-calls-run-the-compiled-body.md
@@ -1,0 +1,29 @@
+# Statement-position calls run the compiled routine body
+
+ADR-0019 C6d-1, final slice. `exec_call` — the statement-position call entry reached via
+`ExecCall`/`ExecCallPairs` — carried a full inlined copy of the retired interpreter routine
+entry `call_function_def`: its own env save, caller-env push, parameter binding, package
+switch, routine/block-stack frames, a `run_block(&def.body)` body run, and a hand-rolled
+blanket writeback merge on return. That body run recompiled the routine's AST on every call
+(48 hits across the `t/` suite in the C6d survey), and the merge was the legacy
+blanket-reconcile rather than the precise merge every expression-position call uses.
+
+The whole block now delegates to `call_routine_def`, the shared compiled entry the other
+C6d-1 callers adopted (multi deferral, user operators, reduce/hyper steps, `MAIN`). A
+statement call therefore runs the routine's plan-attached bytecode — falling back to one
+memoized on-the-fly compile when the plan attached none — and returns through the same
+writeback merge, deprecation recording (`cf.deprecated_info`), `empty_sig` rejection,
+callsite-line injection, and return-spec finalization as an expression call. The
+statement-position pre-dispatch stays where it was: native test-function delegation,
+`make`/`made`, the wrap chain, the JSON-module gate, and the proto no-match error.
+
+Two helpers died with the copy: `alias_params_into_current_package` (it existed to mirror
+bound parameters under package-qualified names for bodies compiled *without* parameter
+locals via `compile_block_raw`; a plan/OTF-compiled routine body bakes its parameters into
+local slots, so nothing qualifies them) and the zero-line `check_deprecation_for_def`
+wrapper (the compiled entry records deprecation from `cf.deprecated_info`, which both the
+plan compiler and the OTF compiler fill from the same `def.deprecated_message`).
+
+This closes C6d-1. The remaining C6d boxes are C6d-2 (grammar token/rule bodies, scoped
+against ADR-0009), C6d-3 (two suite-dead sites), and C6d-4 (`call_sub_value`'s code-object
+AST path).

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -2,11 +2,6 @@ use super::*;
 use crate::ast::FunctionDef;
 
 impl Interpreter {
-    /// Check if a function has the `is DEPRECATED` trait and record a deprecation event.
-    pub(crate) fn check_deprecation_for_def(&self, def: &FunctionDef) {
-        self.check_deprecation_for_def_with_line(def, None);
-    }
-
     /// Check if a function has the `is DEPRECATED` trait and record a deprecation event,
     /// using an explicit callsite line if provided.
     pub(crate) fn check_deprecation_for_def_with_line(
@@ -111,54 +106,6 @@ impl Interpreter {
         }
     }
 
-    /// When the routine's package is not GLOBAL, the compiler qualifies bare
-    /// variable references in its body as `$Package::name` (`compile_block_raw`
-    /// seeds the body compiler with the runtime package, and a body compiled on
-    /// its own has no parameter locals to shadow them). Mirror each bound
-    /// parameter under that qualified name so the body's reads find it.
-    ///
-    /// Must run *after* `bind_function_args_values`, and from every path that
-    /// invokes a routine body through `run_block` — `exec_call` lacked it, so an
-    /// `@`/`%` parameter of a routine in a non-GLOBAL package read as empty
-    /// there (`Test::Assuming`'s `is-primed-call` saw `@expect` as `[]`).
-    pub(crate) fn alias_params_into_current_package(&mut self, param_defs: &[ParamDef]) {
-        let cur_pkg = self.current_package().to_string();
-        if cur_pkg == "GLOBAL" {
-            return;
-        }
-        let qualified_aliases: Vec<(String, Value)> = param_defs
-            .iter()
-            .filter_map(|pd| {
-                let bare = pd
-                    .name
-                    .strip_prefix('$')
-                    .or_else(|| pd.name.strip_prefix('@'))
-                    .or_else(|| pd.name.strip_prefix('%'))
-                    .or_else(|| pd.name.strip_prefix('&'));
-                if let Some(bare) = bare {
-                    self.env.get(&pd.name).cloned().map(|v| {
-                        let sigil = &pd.name[..pd.name.len() - bare.len()];
-                        (format!("{}{}::{}", sigil, cur_pkg, bare), v)
-                    })
-                } else if !pd.name.is_empty()
-                    && !pd.name.starts_with('_')
-                    && !pd.name.starts_with('!')
-                    && !pd.name.contains("::")
-                {
-                    self.env
-                        .get(&pd.name)
-                        .cloned()
-                        .map(|v| (format!("{}::{}", cur_pkg, pd.name), v))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        for (key, val) in qualified_aliases {
-            self.env.insert(key, val);
-        }
-    }
-
     /// Execute a statement-position call. Returns the call's value so a
     /// tail-position statement call (`ExecCallPairs { keep_value: true }`) can
     /// use it as the body result; plain statement sites ignore it.
@@ -239,110 +186,15 @@ impl Interpreter {
                     {
                         return result;
                     }
-                    self.check_deprecation_for_def(&def);
-                    if def.empty_sig && !args.is_empty() {
-                        return Err(Self::reject_args_for_empty_sig(&args));
-                    }
-                    let saved_env = self.env.clone();
-                    let saved_readonly = self.enter_readonly_frame();
-                    if let Some(line) = self.test_pending_callsite_line {
-                        self.cur_source_line = line;
-                    }
-                    self.push_caller_env();
-                    let saved_package = self.current_package().to_string();
-                    let def_package = def.package.resolve();
-                    if !def_package.is_empty() && def_package != "GLOBAL" {
-                        self.set_current_package(def_package);
-                    }
-                    let return_spec = self.routine_return_spec_by_name(&def.name.resolve());
-                    let rw_bindings =
-                        match self.bind_function_args_values(&def.param_defs, &def.params, &args) {
-                            Ok(bindings) => bindings,
-                            Err(e) => {
-                                self.set_current_package(saved_package);
-                                self.pop_caller_env();
-                                self.env = saved_env;
-                                self.exit_readonly_frame(saved_readonly);
-                                return Err(Self::enhance_binding_error(
-                                    e,
-                                    &def.name.resolve(),
-                                    &def.param_defs,
-                                    &args,
-                                ));
-                            }
-                        };
-                    self.alias_params_into_current_package(&def.param_defs);
-                    let sub_val = Value::make_sub_for_routine(
-                        def.package,
-                        def.name,
-                        def.params.clone(),
-                        def.param_defs.clone(),
-                        def.body.clone(),
-                        def.is_rw,
-                        self.env.clone(),
-                        def.compiled.clone(),
-                    );
-                    self.block_stack.push(sub_val);
-                    let pushed_assertion = self.push_test_assertion_context(def.is_test_assertion);
-                    self.routine_stack.push(RoutineFrame {
-                        package: def.package.resolve(),
-                        lexical_package: None,
-                        name: def.name.resolve(),
-                        line: None,
-                        file: None,
-                        is_method: false,
-                        is_block: false,
-                        def_file: def.source_file.clone(),
-                        invocation_id: crate::runtime::next_invocation_id(),
-                    });
-                    self.prepare_definite_return_slot(return_spec.as_deref());
-                    let result = self.run_block(&def.body);
-                    self.routine_stack.pop();
-                    self.block_stack.pop();
-                    self.pop_test_assertion_context(pushed_assertion);
-                    self.set_current_package(saved_package);
-                    let implicit_return = self.env.get("_").cloned().unwrap_or(Value::NIL);
-                    let mut restored_env = saved_env;
-                    self.pop_caller_env_with_writeback(&mut restored_env);
-                    let excluded_names = Self::routine_writeback_excluded_names(&def);
-                    for (k, v) in self.env.iter() {
-                        let k_str = k.resolve();
-                        let scalar_writeback = restored_env.contains_key_sym(*k)
-                            && !excluded_names.contains(&k_str)
-                            && !matches!(
-                                v.view(),
-                                ValueView::Array(..)
-                                    | ValueView::Hash(..)
-                                    | ValueView::Sub(..)
-                                    | ValueView::WeakSub(..)
-                                    | ValueView::Routine { .. }
-                            );
-                        if k != "_"
-                            && k != "@_"
-                            && k != "%_"
-                            // Per-frame non-local-return target marker (see above).
-                            && k != "__mutsu_callable_id"
-                            && ((restored_env.contains_key_sym(*k)
-                                && matches!(v.view(), ValueView::Array(..) | ValueView::Hash(..)))
-                                || scalar_writeback
-                                || k.starts_with("__mutsu_var_meta::"))
-                        {
-                            restored_env.insert_sym(*k, v.clone());
-                        }
-                    }
-                    self.apply_rw_bindings_to_env(&rw_bindings, &mut restored_env);
-                    self.merge_sigilless_alias_writes(&mut restored_env, &self.env);
-                    let effective_return_spec = return_spec
-                        .as_deref()
-                        .map(|spec| self.resolved_type_capture_name(spec));
-                    self.env = restored_env;
-                    self.exit_readonly_frame(saved_readonly);
-                    let call_result = match result {
-                        Ok(()) => Ok(implicit_return),
-                        Err(e) => Err(e),
-                    };
-                    return self
-                        .finalize_return_with_spec(call_result, effective_return_spec.as_deref());
+                    // The compiled entry replaces the retired
+                    // `call_function_def`'s inlined copy that lived here
+                    // (ADR-0019 C6d-1): it records deprecation from
+                    // `cf.deprecated_info`, enforces `empty_sig`, injects the
+                    // pending callsite line, binds parameters, and performs
+                    // the caller-env writeback merge — all of which this site
+                    // reimplemented by hand around a `run_block(&def.body)`
+                    // that recompiled the body per call.
+                    return self.call_routine_def(&def, args);
                 } else if let Some(err) = self.take_pending_dispatch_error() {
                     return Err(err);
                 } else if self.has_proto(name) {


### PR DESCRIPTION
ADR-0019 C6d-1, final slice — closes C6d-1.

`exec_call` — the statement-position call entry (`ExecCall`/`ExecCallPairs`) — carried a full inlined copy of the retired interpreter routine entry `call_function_def`: its own env save, caller-env push, parameter binding, package switch, routine/block frames, a `run_block(&def.body)` body run (a fresh compile of the routine's AST per call; 48 hits across `t/` in the C6d survey), and a hand-rolled blanket writeback merge on return.

The block now delegates to `call_routine_def`, the shared compiled entry the other C6d-1 callers adopted (#5919 and the user-operator slice). A statement call therefore runs the routine's plan-attached bytecode (one memoized OTF compile when the plan attached none) and returns through the same writeback merge, deprecation recording (`cf.deprecated_info`), `empty_sig` rejection, callsite-line injection, and return-spec finalization as an expression call. The statement-position pre-dispatch is unchanged: native test-function delegation, `make`/`made`, the wrap chain, the JSON-module gate, and the proto no-match error.

Two helpers died with the copy:
- `alias_params_into_current_package` — only needed for bodies compiled *without* parameter locals via `compile_block_raw`; a plan/OTF-compiled routine bakes its parameters into local slots. Its motivating case (`Test::Assuming`'s `is-primed-call` reading `@expect` as `[]`) is covered by `roast/S06-currying/positional.t` + `assuming-and-mmd.t`, both verified locally.
- the zero-line `check_deprecation_for_def` wrapper — the compiled entry records deprecation from `cf.deprecated_info`, filled by both compilers from the same `def.deprecated_message`.

Verified locally: `make test` (27469 tests) and full `make roast` (218774 tests) both PASS; clippy/fmt clean. (Local roast was run before opening this PR because the writeback-merge semantics change is exactly the shape that passes `make test` but only roast catches.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)