### PR TITLE
refactor(runtime): proto {*} fallback runs the compiled candidate body

### DIFF
--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -100,20 +100,6 @@ impl Interpreter {
             )));
             return Err(err);
         };
-        if def.empty_sig && !args.is_empty() {
-            return Err(Self::reject_args_for_empty_sig(&args));
-        }
-        let saved_env = self.env.clone();
-        let saved_readonly = self.enter_readonly_frame();
-        let rw_bindings = match self.bind_function_args_values(&def.param_defs, &def.params, &args)
-        {
-            Ok(bindings) => bindings,
-            Err(e) => {
-                self.env = saved_env;
-                self.exit_readonly_frame(saved_readonly);
-                return Err(e);
-            }
-        };
         // Set up multi dispatch stack so nextsame/nextwith can walk through
         // remaining candidates when called inside a proto-dispatched multi sub.
         // Get candidates in dispatch order (same sorting as resolve_function_with_types)
@@ -131,33 +117,19 @@ impl Interpreter {
             ));
         }
         self.samewith_context_stack.push((proto_name.clone(), None));
-        self.routine_stack.push(RoutineFrame {
-            package: def.package.resolve(),
-            lexical_package: None,
-            name: def.name.resolve(),
-            line: None,
-            file: None,
-            is_method: false,
-            is_block: false,
-            def_file: None,
-            invocation_id: crate::runtime::next_invocation_id(),
-        });
-        let result = self.run_block(&def.body);
-        self.routine_stack.pop();
+        // The compiled entry replaces the run_block(&def.body) body run that
+        // lived here (ADR-0019 C6d-3): it enforces empty_sig, binds parameters
+        // (including the rw writeback), pushes the routine frame, and performs
+        // the caller-env writeback merge. An explicit `return` comes back
+        // already unwrapped by finalize_return_with_spec, so a surviving
+        // Err-with-return_value is a non-local return targeting an outer
+        // callable and must propagate.
+        let result = self.call_routine_def(&def, args);
         self.samewith_context_stack.pop();
         if pushed_dispatch {
             self.multi_dispatch_stack.pop();
         }
-        let implicit_return = self.env.get("_").cloned().unwrap_or(Value::NIL);
-        let mut restored_env = saved_env.clone();
-        self.apply_rw_bindings_to_env(&rw_bindings, &mut restored_env);
-        self.restore_env_preserving_existing(&restored_env, &def.params);
-        self.exit_readonly_frame(saved_readonly);
-        match result {
-            Err(e) if e.return_value.is_some() => Ok(e.return_value.unwrap()),
-            Err(e) => Err(e),
-            Ok(()) => Ok(implicit_return),
-        }
+        result
     }
 
     /// Collect remaining multi candidates after the current one, in dispatch order.

--- a/t/proto-dispatch-interpreter-path.t
+++ b/t/proto-dispatch-interpreter-path.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# ADR-0019 C6d-3: the interpreter proto-`{*}` fallback (call_proto_dispatch)
+# runs the selected candidate through the shared compiled entry
+# call_routine_def instead of a per-call run_block compile. The VM defers to
+# that fallback exactly when the candidate's body trips the OTF gate (a class
+# declaration or a `start` call in the body), so these cases pin the rewired
+# path; the plain cases pin the VM path around it. Expected values were taken
+# from raku first.
+
+plan 13;
+
+# state-declaring candidate under a non-trivial proto: state must persist
+# across calls (one cell, not one per re-compile).
+proto sub counter(|) { {*} }
+multi sub counter(Int $x) { state $n = 0; $n++; "int:$x:$n" }
+multi sub counter(Str $s) { "str:$s" }
+is counter(1), "int:1:1", "state candidate first call";
+is counter(2), "int:2:2", "state cell persists across proto-dispatched calls";
+is counter("a"), "str:a", "sibling candidate unaffected";
+
+# class-declaring candidate: the OTF gate defers this to the interpreter
+# proto path, which now runs the plan-compiled body.
+proto sub cls(|) { {*} }
+multi sub cls(Int $x) { class Inner { method m($v) { "cls:$v" } }; Inner.m($x) }
+multi sub cls(Str $s) { "str:$s" }
+is cls(4), "cls:4", "class-declaring candidate runs through the fallback";
+is cls("z"), "str:z", "compilable sibling still dispatches";
+
+# start-in-body candidate (the other OTF-gate trigger).
+proto sub st(|) { {*} }
+multi sub st(Int $x) { my $p = start { $x * 2 }; await $p }
+is st(21), 42, "start-declaring candidate runs through the fallback";
+
+# explicit return from a deferred candidate must unwrap at the candidate
+# boundary, not escape the proto body.
+proto sub retc(|) { {*} }
+multi sub retc(Int $x) { class R3 { }; return "ret:$x"; }
+is retc(7), "ret:7", "explicit return from a deferred candidate";
+
+# rw param through a class-declaring candidate: the call's own value is
+# correct. The writeback to the caller's container through a non-trivial
+# proto body is a known pre-existing gap
+# (todo/tickets/rw-writeback-through-nontrivial-proto-body-is-lost.md).
+proto sub bump($x is rw) { {*} }
+multi sub bump($x is rw) { class B2 { }; $x = $x + 1; $x }
+my $v = 10;
+is bump($v), 11, "rw candidate computes through the fallback";
+# is $v, 11, "rw writeback chains through the proto"; # enable with the ticket
+
+# callsame walks proto-dispatched candidates in order.
+proto sub walk(|) {*}
+multi sub walk(Int $x) { "int(" ~ callsame() ~ ")" }
+multi sub walk(Any $x) { "any:$x" }
+is walk(5), "int(any:5)", "callsame inside a proto-dispatched candidate";
+
+# a proto body that post-processes the {*} result.
+proto sub post($x) { "[" ~ {*} ~ "]" }
+multi sub post(Int $x) { "i$x" }
+is post(3), "[i3]", "proto body post-processes the dispatch result";
+
+# a proto BODY that itself trips the OTF gate runs through the interpreter
+# carrier, whose `{*}` reaches call_proto_dispatch directly.
+proto sub pb(|) { class PB { method tag() { "pb" } }; PB.tag ~ ":" ~ {*} }
+multi sub pb(Int $x) { "i$x" }
+multi sub pb(Str $s) { "s$s" }
+is pb(5), "pb:i5", "interpreter-carried proto body dispatches {*}";
+is pb("q"), "pb:sq", "and again for the second candidate";
+
+# no-candidate error still reports X::Multi::NoMatch.
+proto sub nomatch(Int $x) { {*} }
+multi sub nomatch(Int $x where * > 100) { "big" }
+throws-like { nomatch(1) }, Exception,
+    message => /"Cannot resolve caller"/,
+    "no matching candidate raises the proto no-match error";
+
+done-testing;

--- a/todo/tickets/rw-writeback-through-nontrivial-proto-body-is-lost.md
+++ b/todo/tickets/rw-writeback-through-nontrivial-proto-body-is-lost.md
@@ -1,0 +1,36 @@
+# `is rw` writeback through a non-trivial proto body is lost
+
+`{*}` redispatch inside a proto whose body is more than the bare `{*}` does not
+chain a candidate's `is rw` parameter write back to the caller's container:
+
+```raku
+proto sub bump($x is rw) { {*} }
+multi sub bump($x is rw) { $x = $x + 1; $x }
+my $v = 10;
+say bump($v);   # 11 (mutsu agrees)
+say $v;         # raku: 11 — mutsu: 10
+```
+
+Raku semantics: the proto's rw parameter aliases the caller's container, the
+candidate's rw parameter aliases the proto's, so the candidate's write chains
+through to `$v`. In mutsu the proto-dispatch frame carries the proto's
+*entry-time argument values*, not the caller's containers, so the candidate's
+writeback lands nowhere the proto's own exit writeback reads.
+
+This is a known pre-existing gap — `vm_call_proto_dispatch`'s doc comment
+(`src/vm/vm_call_func_ops.rs`) records it, and it fails identically whether the
+candidate runs through the VM path or the interpreter fallback
+(`call_proto_dispatch`), before and after the ADR-0019 C6d-3 rewire (verified
+2026-08-05 by A/B on that rewire: 11/10 both sides). The partial machinery that
+exists (`proto_rw_redispatch_args`) rebuilds args from the proto's current
+parameter values and names the proto params as arg sources, but only for simple
+all-positional signatures, and the final hop (proto param -> caller container at
+proto exit) still only works when the *proto body itself* is trivial enough to
+take the VM's trivial-proto fork.
+
+`t/proto-dispatch-interpreter-path.t` pins the surrounding behavior and carries
+a commented-out assertion for the `$v == 11` half; enable it when fixing this.
+
+Fix direction: the proto-dispatch frame needs to carry the caller's arg sources
+(or containers) so the candidate's rw writeback targets them, or the proto's
+exit writeback needs to read the candidate's post-`{*}` parameter values.


### PR DESCRIPTION
ADR-0019 C6d-3, Phase-C half.

The interpreter proto-dispatch entry `call_proto_dispatch` — the fallback `vm_call_proto_dispatch` takes for a candidate whose body trips the OTF gate (a class declaration or a `start` call), for empty-sig-with-args, and for no-candidate errors, plus the direct `{*}` entry when the proto *body* itself runs through the interpreter carrier — held its own copy of the retired `call_function_def` shape: env save, parameter binding, a `run_block(&def.body)` body run (a fresh compile of the candidate's AST per call), and a hand-rolled rw/env writeback. The site was dead across the whole `t/` suite in the C6d survey, so it also had no pin.

The proto-sub arm now delegates the candidate run to `call_routine_def`, keeping only what is proto-specific: the remaining-candidate collection and multi-dispatch frame (for `nextsame`/`callsame`), the samewith context, and the `X::Multi::NoMatch` error construction. The compiled entry enforces `empty_sig`, binds parameters including rw writeback, pushes the routine frame, and performs the caller-env writeback merge; an explicit `return` comes back already unwrapped by `finalize_return_with_spec`, so a surviving Err-with-return_value is a non-local return and now propagates instead of being swallowed into `Ok`.

Pinned by `t/proto-dispatch-interpreter-path.t` (13 assertions, every expectation taken from `raku` first; verified with a breakpoint that the deferred candidates actually reach the rewired arm). The `is rw` writeback through a non-trivial proto body remains a pre-existing gap — verified unchanged by A/B on this rewire (11/10 both sides vs raku's 11/11) — now tracked in `todo/tickets/rw-writeback-through-nontrivial-proto-body-is-lost.md`.

Verified locally: `make test` (27480 tests) PASS, clippy/fmt clean. Full local `make roast` is running in parallel as a double-check; CI's roast is authoritative.

The ADR checkbox/progress update follows as a docs-only PR once this and #5946 (C6d-1 final) are both merged, to avoid a three-way conflict on the ADR file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)