### PR TITLE
refactor(runtime): compiled-eligible fallback calls run the routine's bytecode

### DIFF
--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -451,6 +451,48 @@ impl Interpreter {
                 ));
             }
             self.samewith_context_stack.push((name.to_string(), None));
+            // ADR-0019 C6d-5: a compiled-eligible routine runs its plan-attached
+            // (or memoized OTF) bytecode through the shared compiled entry
+            // instead of the per-call `eval_block_value_with_pre_post` compile
+            // below. The gate is the same signature/body assessment the OTF
+            // dispatch uses (`def_module_single_sig_body_ok_ignoring_state`):
+            // a def it rejects — a sigilless-scalar param whose caller-alias
+            // writeback must cross an EVAL boundary, an interpreter-coupled
+            // body construct — keeps the interpreter arm, which is
+            // load-bearing semantics for those shapes, not a missed
+            // optimization (t/sigilless-params.t pins the EVAL case). `state`
+            // is fine here: `call_routine_def` runs one stable body identity
+            // (the plan's, or one memoized compile), so cells are not severed
+            // the way a per-call OTF recompile severs them. The compiled entry
+            // enforces empty_sig, merges where-constraint capture env, binds
+            // parameters (keeping this by-name call's enhanced binding error),
+            // performs the caller-env writeback merge, converts `fail`,
+            // propagates non-local returns targeting outer callables, and
+            // finalizes the return-type spec; only the multi/samewith frames
+            // (for callsame/nextsame) and the is-raw/rw Proxy tail stay here.
+            if Self::def_module_single_sig_body_ok_ignoring_state(&def) {
+                let fold_is_rw = !def.is_raw;
+                let result = self.call_routine_def(&def, args.to_vec());
+                self.samewith_context_stack.pop();
+                if pushed_dispatch {
+                    self.multi_dispatch_stack.pop();
+                }
+                return result.and_then(|v| {
+                    let v = if def.is_raw {
+                        // Mark Proxy as decontainerized so the VM's auto-FETCH
+                        // doesn't strip it (mirrors the interpreter arm's tail).
+                        if matches!(v.view(), ValueView::Proxy { .. }) {
+                            let (fetcher, storer, subclass, _) = v.into_proxy_parts().unwrap();
+                            Value::proxy_parts(fetcher, storer, subclass, true)
+                        } else {
+                            v
+                        }
+                    } else {
+                        v
+                    };
+                    self.maybe_fetch_rw_proxy(v, fold_is_rw)
+                });
+            }
             if def.empty_sig && !args.is_empty() {
                 self.samewith_context_stack.pop();
                 return Err(Self::reject_args_for_empty_sig(args));

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -2013,7 +2013,9 @@ impl Interpreter {
     /// which the per-call OTF path excludes (a per-thread recompile severs the
     /// shared `state` cell), but which the cross-thread shared captured body
     /// handles correctly.
-    fn def_module_single_sig_body_ok_ignoring_state(def: &crate::ast::FunctionDef) -> bool {
+    pub(crate) fn def_module_single_sig_body_ok_ignoring_state(
+        def: &crate::ast::FunctionDef,
+    ) -> bool {
         def.param_defs.iter().all(|pd| {
             let is_capture = pd.slurpy && pd.sigilless;
             let traits_otf_safe = pd


### PR DESCRIPTION
ADR-0019 **C6d-5** — a def-execution site the C6d survey missed (it counted six sites; this is the seventh; the eighth, `call_proxy_callback`, gets 2 anonymous-block hits across `t/` and stays out of C6d scope).

`call_function_fallback`'s def arm — the interpreter terminal reached when a name resolves but the VM's OTF dispatch declined it (a proto name, a multi-candidate name, or a gate-rejected single) — compiled the routine's AST body on **every call** via `eval_block_value_with_pre_post`: 410 hits across `t/` in a fresh instrumented survey, dominated by multi dispatch and `trait_mod:<is>`, with `def.compiled` already attached in essentially every hit.

The arm now runs `call_routine_def` when the def passes the same signature/body assessment the OTF dispatch uses (`def_module_single_sig_body_ok_ignoring_state`), keeping only the multi/samewith frames (for `callsame`/`nextsame`) and the is-raw/rw Proxy tail caller-side. A def the gate rejects keeps the interpreter arm **unchanged** — that arm is load-bearing semantics for those shapes, not a missed optimization: a sigilless-scalar param's caller-alias writeback across an EVAL boundary (`t/sigilless-params.t`, `EVAL 'swap($a, $b)'`) only works through the interpreter's sigilless-alias merge, which is exactly why the OTF gate excluded it (found the hard way: the first, unconditional version of this fold broke that test).

`state` passes the gate deliberately: `call_routine_def` runs one stable body identity (the plan's compiled routine, or one memoized OTF compile), so cells are not severed the way the per-call recompile this replaces would sever them — verified against `raku` on a state-bearing multi dispatched through this arm.

Verified locally: `make test` (27482 tests) PASS, clippy/fmt clean. Full local roast runs in parallel; CI is authoritative.

ADR checkbox/survey-doc updates land in the batched docs-only PR together with C6d-3/C6d-4/D0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)