### PR TITLE
docs(adr): record C6d-3/4/5 and D0 as landed; correct the C6d site inventory

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,12 +115,11 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 17/53 slices merged. Next slice: C6d-4 (`call_sub_value`'s
-`eval_block_value(&data.body)`), or C6d-3's Phase-C half — C6d-1 is complete (C6a, C6b and C6c
-landed; C6 and C6d are both subdivided below, C6d from a measurement of where its sites are
-actually reached).**
+**Current progress: 18/53 slices merged (D0 landed). Next slice: C6e — C6d-1, C6d-3's Phase-C
+half, C6d-4, and C6d-5 have all landed, so C6d's only open sub-box is the ADR-0009-scoped
+C6d-2, which does not gate C6 (token defs never come from `CompiledSubDeclPlan`).**
 
-The count tallies top-level boxes only; sub-boxes (C6a–C6e, C6d-1..4, E1a/E1b) are that box's
+The count tallies top-level boxes only; sub-boxes (C6a–C6e, C6d-1..5, E1a/E1b) are that box's
 PRs, and a subdivided box is checked when its last sub-box merges. A box that turns out to need
 subdivision follows C6's precedent: measure first, then split in place.
 
@@ -203,7 +202,10 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
     never reaches these sites, and the sites do not tree-walk — `run_block` recompiles the body
     per call, so what C6d removes is a repeated compile. The mismatch to solve is that
     `compile_block_raw` compiles a *block* whose arguments the caller already bound, while
-    `def.compiled` binds its own from `param_local_slots`. Subdivide:
+    `def.compiled` binds its own from `param_local_slots`. (The six-site count itself turned
+    out to be incomplete: C6d-5 found a seventh live site and an eighth negligible one — the
+    grep to trust is for *all* `&def.body` / `&data.body` execution forms, not the two the
+    survey instrumented.) Subdivide:
     - [x] **C6d-1 — the ordinary-routine tail** (`calls.rs:call_function_def`,
       `calls.rs:exec_call`): 192 hits over ~37 names. The shape is settled and is neither
       candidate above: these are *callers* reaching the interpreter entry `call_function_def`
@@ -233,13 +235,37 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
       sub-box does not gate C6**: token defs are never built from `CompiledSubDeclPlan`, so it
       gates only the later deletion of the `FunctionDef.body` field itself (with F7). It stays
       listed here so the field's last reader class is not forgotten.
-    - [ ] **C6d-3 — the two sites dead across the whole suite**
+    - [x] **C6d-3 — the two sites dead across the whole suite**
       (`dispatch_proto_call.rs:call_proto_dispatch`, `types/roles.rs:run_role_submethod`); the
-      latter's `def` is a `MethodDef`, so move it to Phase D.
-    - [ ] **C6d-4 — `call_sub_value`'s `eval_block_value(&data.body)`**, which takes a *code
-      object's* body rather than a def's: after C6c that is the one path left that still
-      executes a routine code object's AST, reached when a `.wrap` chain routes dispatch through
-      the interpreter carrier.
+      latter's `def` is a `MethodDef`, so it is reassigned to Phase D. The former's proto-sub
+      arm now delegates the candidate run to `call_routine_def`, keeping only the
+      remaining-candidate/multi/samewith frames and the `X::Multi::NoMatch` construction, and
+      is pinned for the first time by `t/proto-dispatch-interpreter-path.t`
+      (`news/2026-08/proto-star-fallback-runs-compiled-candidate.md`). The `is rw` relay
+      through a non-trivial proto body is a pre-existing gap, unchanged by the rewire —
+      `todo/tickets/rw-writeback-through-nontrivial-proto-body-is-lost.md`.
+    - [x] **C6d-4 — `call_sub_value`'s `eval_block_value(&data.body)`**, which takes a *code
+      object's* body rather than a def's: after C6c that was the one path left that still
+      executed a routine code object's AST, reached when a `.wrap` chain routes dispatch through
+      the interpreter carrier (230 of the site's 9,574 fresh-survey hits; the rest are
+      blocks/closures, which carry `compiled_code` and keep the carrier). Now runs
+      `SubData::compiled_routine` via `call_compiled_closure`, gated off for scalar-rw/raw
+      routines until rw binding is cell-based
+      (`todo/tickets/rw-writeback-through-wrap-chain-needs-shared-cells.md` — the
+      different-name wrap relay is broken on every path, `main` included). Fixed two general
+      bugs along the way: the C6c value-dispatch path's missing rw-param slot flush, and both
+      compiled_routine forks reclassifying a value call's binding failure as a compile-flavored
+      `X::TypeCheck::Argument` (raku and roast S03-sequence/misc.t demand runtime
+      `X::TypeCheck::Binding`) — `news/2026-08/routine-code-object-carrier-runs-bytecode.md`.
+    - [x] **C6d-5 — `call_function_fallback`'s def arm**, a seventh `&def.body` execution site
+      the original six-site survey missed (an eighth, `call_proxy_callback`, gets 2
+      anonymous-block hits and is out of C6d scope): 410 hits across `t/`, dominated by
+      multi-candidate names, `def.compiled` attached in essentially every hit. Folded to
+      `call_routine_def` behind the same gate the OTF dispatch uses
+      (`def_module_single_sig_body_ok_ignoring_state`); a gate-rejected def keeps the
+      interpreter arm, which is load-bearing semantics for those shapes (the sigilless-scalar
+      EVAL-boundary writeback of `t/sigilless-params.t` is why the gate exists) —
+      `news/2026-08/fallback-def-arm-runs-compiled-body.md`.
   - [ ] **C6e — redeclaration comparison and eager body facts, then drop the plan field.**
     Replace the two `body_debug_without_setline(&def.body)` comparisons (`registration_sub.rs`)
     with the plan's C4 redeclaration fingerprint, and fill `RoutineBodyFacts` eagerly at plan
@@ -266,10 +292,15 @@ the later slices independently landable. Second, the class walker also registers
 ADR-0009, so D6, D9, and D10 exclude the token/rule arms until that work lands — deleting the
 walkers wholesale is not possible before then.
 
-- [ ] **D0 — Split the class/role walkers into named phases with no behavior change.** Extract
+- [x] **D0 — Split the class/role walkers into named phases with no behavior change.** Extract
   `register_class_decl`'s sections (rollback snapshot, parent validation, role composition,
   punning, attribute pre-scan, body walk, custom-HOW install) and `register_role_decl`'s three
-  passes into functions with explicit inputs, so D1–D9 replace one function at a time.
+  passes into functions with explicit inputs, so D1–D9 replace one function at a time. Landed
+  as fifteen files, hosts reduced to orchestrators (229/334 lines), with arm-level `continue`
+  semantics made explicit via `ClassBodyFlow::{RunTail,SkipTail}` —
+  `news/2026-08/class-role-walkers-split-into-phases.md`. Phase D also inherits
+  `types/roles.rs:run_role_submethod` from C6d-3 (a `MethodDef` body-execution site, dead
+  across the suite).
 - [ ] **D1 — Encode class structural operations.** Put package open/reopen, parent edges, repr,
   visibility, lexical/package aliases, and source-order metadata in immutable plan operations.
 - [ ] **D2 — Encode attributes and generated accessors.** Compile defaults/constraints as child

--- a/news/2026-08/class-role-walkers-split-into-phases.md
+++ b/news/2026-08/class-role-walkers-split-into-phases.md
@@ -1,0 +1,36 @@
+# The class/role registration walkers are split into named phases
+
+ADR-0019 D0 (#5949) — a pure mechanical extraction with zero behavior
+change, so D1–D9 can replace one function at a time. `register_class_decl`
+was a single ~2,500-line function whose concerns shared ~8 mutable locals,
+and `register_role_decl` (~920 lines) had the same shape; the D1–D6 cut
+lines run through those function bodies, which is why this slice exists.
+
+Both are now orchestrators over named phase functions with explicit
+inputs. The class walker's phases live in `registration_class_validate.rs`
+(rollback snapshot `ClassRegSnapshot`, redeclaration/parent validation,
+shell publication), `registration_class_compose.rs` and
+`_compose_body.rs` (role composition behind a `RoleCompositionCx`,
+deferred role bodies, puns), and `registration_class_body*.rs` (the body
+walk behind a `ClassBodyCx` context struct: attributes, methods,
+`also does`, exit phasers/finalization/EXPORTHOW); the host file is 229
+lines. The role walker splits into `registration_role_decl.rs`
+(validation, state reset, body pre-scan + dispatch, finish),
+`registration_role_body.rs` (`has`/`does` arms), and
+`registration_role_method.rs`; host file 334 lines.
+
+Two extraction notes worth keeping. Arm-level `continue`s used to skip the
+per-statement registry-republication tail, so an extracted arm returning
+normally would have *run* the tail — an ordering change; extracted arms
+signal it with an explicit `ClassBodyFlow::{RunTail,SkipTail}` return, and
+all 21 `continue`s were audited. Error-path restores are inconsistent by
+design (some restore package/env, the duplicate-method error does not;
+body-walk errors never trigger the registry rollback) — preserved exactly.
+The only consolidation: the byte-identical `our method`/`my method`
+invocant munging became one `method_sub_form_params` helper; everything
+else is verbatim motion with comments moved alongside.
+
+Validated with the full local `make test` and `make roast`, targeted
+S12/S14 roast files, and error-path spot checks. Executed by a worktree
+subagent from a one-page brief; the diff was 15 files, +4,326/−3,667,
+every new file ≤ 502 lines.

--- a/news/2026-08/fallback-def-arm-runs-compiled-body.md
+++ b/news/2026-08/fallback-def-arm-runs-compiled-body.md
@@ -1,0 +1,32 @@
+# Compiled-eligible fallback calls run the routine's bytecode
+
+ADR-0019 C6d-5 (#5950) — a def-execution site the C6d survey missed: it
+counted six `&def.body` execution sites, but `call_function_fallback`'s def
+arm was a seventh (and `call_proxy_callback`'s `run_block(&data.body)` an
+eighth, which gets 2 anonymous-block hits across `t/` and stays out of C6d
+scope). The arm is the interpreter terminal reached when a name resolves
+but the VM's OTF dispatch declined it — a proto name, a multi-candidate
+name, or a gate-rejected single — and it compiled the routine's AST body
+on every call via `eval_block_value_with_pre_post`: 410 hits across `t/`
+in a fresh instrumented survey, dominated by multi dispatch and
+`trait_mod:<is>`, with `def.compiled` already attached in essentially
+every hit.
+
+The arm now runs `call_routine_def` when the def passes the same
+signature/body assessment the OTF dispatch uses
+(`def_module_single_sig_body_ok_ignoring_state`), keeping only the
+multi/samewith frames (for `callsame`/`nextsame`) and the is-raw/rw Proxy
+tail caller-side. A def the gate rejects keeps the interpreter arm
+unchanged — that arm is load-bearing semantics for those shapes, not a
+missed optimization: a sigilless-scalar param's caller-alias writeback
+across an EVAL boundary (`t/sigilless-params.t`'s `EVAL 'swap($a, $b)'`)
+only works through the interpreter's sigilless-alias merge, which is
+exactly why the OTF gate excluded that shape in the first place. The
+first, unconditional version of this fold broke that test, which is how
+the gate's purpose was rediscovered.
+
+`state` passes the gate deliberately: `call_routine_def` runs one stable
+body identity (the plan's compiled routine, or one memoized OTF compile),
+so cells are not severed the way the per-call recompile this replaces
+would sever them — verified against `raku` on a state-bearing multi
+dispatched through this arm.

--- a/news/2026-08/proto-star-fallback-runs-compiled-candidate.md
+++ b/news/2026-08/proto-star-fallback-runs-compiled-candidate.md
@@ -1,0 +1,33 @@
+# The proto {*} fallback runs the compiled candidate body
+
+ADR-0019 C6d-3, Phase-C half (#5947). The interpreter proto-dispatch entry
+`call_proto_dispatch` — the fallback `vm_call_proto_dispatch` takes for a
+candidate whose body trips the OTF gate (a class declaration or a `start`
+call in the body), for empty-sig-with-args, and for no-candidate errors,
+plus the direct `{*}` entry when the proto *body* itself runs through the
+interpreter carrier — held its own copy of the retired `call_function_def`
+shape: env save, parameter binding, a `run_block(&def.body)` body run (a
+fresh compile of the candidate's AST per call), and a hand-rolled rw/env
+writeback. The site was dead across the whole `t/` suite in the C6d survey,
+so it also had no pin.
+
+The proto-sub arm now delegates the candidate run to `call_routine_def`,
+keeping only what is proto-specific: the remaining-candidate collection and
+multi-dispatch frame (for `nextsame`/`callsame`), the samewith context, and
+the `X::Multi::NoMatch` error construction. The compiled entry enforces
+`empty_sig`, binds parameters including rw writeback, pushes the routine
+frame, and performs the caller-env writeback merge; an explicit `return`
+comes back already unwrapped by `finalize_return_with_spec`, so a surviving
+Err-with-return_value is a non-local return and now propagates instead of
+being swallowed into `Ok`.
+
+Pinned by `t/proto-dispatch-interpreter-path.t` (13 assertions, every
+expectation taken from `raku` first; a breakpoint confirmed the deferred
+candidates actually reach the rewired arm). The `is rw` writeback through a
+non-trivial proto body remains a pre-existing gap — verified unchanged by
+A/B on this rewire — tracked in
+`todo/tickets/rw-writeback-through-nontrivial-proto-body-is-lost.md`.
+
+The other C6d-3 site, `types/roles.rs:run_role_submethod`, is dead across
+the suite and its `def` is a `MethodDef`, so it is reassigned to Phase D's
+class/role work, as the checklist anticipated.

--- a/news/2026-08/routine-code-object-carrier-runs-bytecode.md
+++ b/news/2026-08/routine-code-object-carrier-runs-bytecode.md
@@ -1,0 +1,33 @@
+# A routine code object runs its compiled body in the interpreter carrier
+
+ADR-0019 C6d-4 (#5948). After C6c, `call_sub_value`'s
+`eval_block_value(&data.body)` was the one dispatch path left that still
+executed a routine code object's AST — reached when a `.wrap` chain routes
+the original sub's direct run (the `callsame`/`nextcallee` legs) through
+the interpreter carrier, and by the other carriers that call a routine
+value through that entry (230 of the site's 9,574 hits in a fresh `t/`
+survey; the rest are blocks and closures, which carry `compiled_code`, not
+`compiled_routine`, and keep the carrier). The fork mirrors
+`vm_call_on_value`'s C6c dispatch: run `SubData::compiled_routine`'s
+bytecode via `call_compiled_closure`.
+
+The fork is gated off for a routine with a scalar `is rw`/`is raw`
+parameter: mutsu's rw writeback is a value copy-back, not a shared
+container, and a wrap chain's rw relay currently survives only through the
+interpreter carrier's same-name blanket merge — the different-name relay is
+broken on every path, on `main` too, with a raku baseline recorded in
+`todo/tickets/rw-writeback-through-wrap-chain-needs-shared-cells.md`. The
+cell-based fix filed there also removes this gate.
+
+The slice also fixed a pre-existing rw bug on the C6c value-dispatch path
+(`my &b = &bump; b($c)` left `$c` unchanged; raku mutates it):
+`call_compiled_closure`'s exit read the rw param's value from env for the
+caller writeback, but a scalar rw param is bound to a slot-only local, so
+the body's write never reached env and the writeback copied the stale
+bind-time value. The rw-param slot flush that
+`call_compiled_function_named_inner` already performs is now ported there,
+storing through a shared cell when the binder installed one so aliases
+survive.
+
+Pinned by `t/wrap-original-runs-compiled-body.t` (10 assertions,
+raku-first).

--- a/todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md
+++ b/todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md
@@ -129,3 +129,28 @@ Mirroring how C6 was subdivided:
 - **C6d-3 — prove the two dead sites dead** (`call_proto_dispatch`,
   `run_role_submethod`), and move `run_role_submethod` to Phase D where its `MethodDef`
   belongs.
+
+## Update 3: C6d-1/3/4/5 landed; the six-site inventory was itself incomplete
+
+C6d-1 closed with `exec_call`'s fold (#5946). `call_proto_dispatch` was not left as a
+coverage argument: its proto-sub arm got the same `call_routine_def` fold plus its first
+pin, `t/proto-dispatch-interpreter-path.t` (#5947). The code-object path
+(`call_sub_value`) landed as C6d-4 (#5948), with an rw gate documented in
+`todo/tickets/rw-writeback-through-wrap-chain-needs-shared-cells.md`.
+
+The headline correction: **the six-site inventory missed two sites**, because the
+original grep matched `run_block(&def.body)` / `eval_block_value(&def.body)` but not the
+other execution forms. A fresh sweep for all `&def.body` / `&data.body` executors found:
+
+- `builtins_operators_fallback.rs:call_function_fallback`'s def arm
+  (`eval_block_value_with_pre_post(&def.body)`) — **410 hits** across `t/`, the largest
+  live ordinary-routine site of the whole campaign. Folded as C6d-5 (#5950), gated on
+  `def_module_single_sig_body_ok_ignoring_state`; the gate-rejected shapes (sigilless
+  scalar param + EVAL-boundary writeback, interpreter-coupled bodies) keep the
+  interpreter arm on purpose.
+- `methods_mut_proxy.rs:call_proxy_callback`'s `run_block(&data.body)` — 2 hits, both
+  anonymous blocks (`compiled_routine` never set), so it is block-family and out of C6d
+  scope.
+
+Remaining in this file's scope: C6d-2 (token/rule bodies, ADR-0009), and
+`run_role_submethod` (Phase D).


### PR DESCRIPTION
ADR-0019 progress batch for #5947 (C6d-3 Phase-C half), #5948 (C6d-4), #5950 (C6d-5), and #5949 (D0) — kept out of those code PRs so parallel slices did not conflict on the ADR file.

- Checks C6d-3, C6d-4, C6d-5 (new sub-box), and D0; progress 17 → 18 top-level boxes; next-slice pointer moves to C6e (C6d-2 stays open but does not gate C6).
- Records the survey correction: the six-site C6d inventory missed `call_function_fallback`'s def arm (410 hits — folded as C6d-5) and `call_proxy_callback` (2 anonymous-block hits, out of scope), because the original grep matched only two of the body-execution forms.
- Adds the four `news/2026-08/` entries and the survey doc's landed-state section.

Docs-only — the heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)