### PR TITLE
refactor(runtime): hash the redeclaration identity; compute body facts at plan lowering

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2021,6 +2021,12 @@ pub(crate) struct CompiledRoutineMetadata {
     pub(crate) has_non_nil_return: bool,
     pub(crate) is_stub: bool,
     pub(crate) has_param_return_redeclaration: bool,
+    /// The OTF-gate body predicates, computed once at plan lowering (ADR-0019
+    /// C6e): registration seeds `FunctionDef::body_facts_cache` from this, so
+    /// a plan-derived def never has to re-walk its body on a lazy cache miss —
+    /// which a body-less def will not be able to serve once `legacy_body` is
+    /// dropped.
+    pub(crate) body_facts: crate::ast::RoutineBodyFacts,
 }
 
 fn implicit_legacy_param(name: &str) -> ParamDef {
@@ -5123,6 +5129,14 @@ impl CompiledCode {
                         .as_ref()
                         .is_some_and(|(_, ret)| ret.is_some())
             }),
+            body_facts: crate::ast::RoutineBodyFacts {
+                needs_interpreter: crate::runtime::Interpreter::function_body_needs_interpreter(
+                    body,
+                ),
+                module_otf_needs_interpreter:
+                    crate::runtime::Interpreter::module_otf_body_needs_interpreter(body),
+                declares_state: crate::runtime::Interpreter::function_body_declares_state(body),
+            },
         };
         debug_assert_eq!(name_chunk.is_some(), name_expr.is_some());
         let plan_traits = zip_decl_trait_args(custom_traits, trait_args);

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -122,14 +122,32 @@ fn is_outer_amp_name(code_var_key: &str) -> bool {
     })
 }
 
-/// Format a function body for comparison, stripping SetLine annotations.
-/// Used to allow identical sub redeclarations that differ only in source line.
-fn body_debug_without_setline(body: &[Stmt]) -> String {
-    let filtered: Vec<_> = body
-        .iter()
-        .filter(|s| !matches!(s, Stmt::SetLine(_)))
-        .collect();
-    format!("{:?}", filtered)
+/// Line-insensitive identity of a routine declaration for redeclaration
+/// comparison: params, param_defs, and the body with top-level `SetLine`
+/// markers stripped, streamed into a hasher instead of rendered (the
+/// Debug-string compare this replaces built four full `String`s per check).
+/// Identical redeclarations that differ only in source line still compare
+/// equal, exactly as before. This is the single place the comparison reads
+/// `def.body`; ADR-0019 C6e-3 redirects it to the plan-recorded fingerprint
+/// once plan-derived defs stop carrying a body.
+fn registration_identity(def: &FunctionDef) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::fmt::Write as _;
+    use std::hash::Hasher;
+    struct HashWrite<'a>(&'a mut DefaultHasher);
+    impl std::fmt::Write for HashWrite<'_> {
+        fn write_str(&mut self, s: &str) -> std::fmt::Result {
+            self.0.write(s.as_bytes());
+            Ok(())
+        }
+    }
+    let mut hasher = DefaultHasher::new();
+    let mut sink = HashWrite(&mut hasher);
+    let _ = write!(sink, "{:?}\x00{:?}\x00", def.params, def.param_defs);
+    for stmt in def.body.iter().filter(|s| !matches!(s, Stmt::SetLine(_))) {
+        let _ = write!(sink, "{stmt:?}\x00");
+    }
+    hasher.finish()
 }
 
 /// Increment a string by one character (Raku's string increment for enums).
@@ -998,7 +1016,18 @@ impl Interpreter {
             decl_order: crate::runtime::resolution::next_decl_order(),
             compiled: None,
             body_fp_cache: std::sync::OnceLock::new(),
-            body_facts_cache: std::sync::OnceLock::new(),
+            // Seed the OTF-gate body facts eagerly from the plan (ADR-0019
+            // C6e): the lazy cache re-walks `def.body` on a miss, which a
+            // body-less plan-derived def will not be able to serve once
+            // `legacy_body` is dropped. A metadata-less caller (the prelude /
+            // forward-declaration walkers) keeps the lazy fill.
+            body_facts_cache: {
+                let cell = std::sync::OnceLock::new();
+                if let Some(metadata) = metadata {
+                    let _ = cell.set(metadata.body_facts);
+                }
+                cell
+            },
         };
         if let Some(compiled) = compiled {
             new_def.compiled = Some(Self::adapt_compiled_to_def(compiled, &new_def));
@@ -1051,11 +1080,8 @@ impl Interpreter {
         if let Some(existing) = existing {
             let same = existing.package == new_def.package
                 && existing.name == new_def.name
-                && existing.params == new_def.params
                 && existing.return_type == new_def.return_type
-                && format!("{:?}", existing.param_defs) == format!("{:?}", new_def.param_defs)
-                && body_debug_without_setline(&existing.body)
-                    == body_debug_without_setline(&new_def.body);
+                && registration_identity(&existing) == registration_identity(&new_def);
             // The identical declaration already installed here may have been
             // installed *without* a compiled body (a forward-declaration or
             // prelude pass registers from a source declaration and carries no
@@ -1651,10 +1677,7 @@ impl Interpreter {
         if let Some(existing) = self.registry().functions.get(&single_key_sym) {
             let same = existing.package == def.package
                 && existing.name == def.name
-                && existing.params == def.params
-                && format!("{:?}", existing.param_defs) == format!("{:?}", def.param_defs)
-                && body_debug_without_setline(&existing.body)
-                    == body_debug_without_setline(&def.body);
+                && registration_identity(existing) == registration_identity(&def);
             if same {
                 return Ok(());
             }

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1923,7 +1923,7 @@ impl Interpreter {
 
     /// Check if a function body contains constructs that require
     /// the full interpreter path (class/role declarations, start blocks).
-    fn function_body_needs_interpreter(body: &[crate::ast::Stmt]) -> bool {
+    pub(crate) fn function_body_needs_interpreter(body: &[crate::ast::Stmt]) -> bool {
         use crate::ast::Stmt;
         for stmt in body {
             match stmt {
@@ -2113,7 +2113,7 @@ impl Interpreter {
     /// `def_is_otf_compilable_module_single`). Conservative: any unrecognized
     /// nesting that could hide a risky construct keeps the sub on the
     /// interpreter, so a missed case only costs a fallback, never correctness.
-    fn module_otf_body_needs_interpreter(body: &[crate::ast::Stmt]) -> bool {
+    pub(crate) fn module_otf_body_needs_interpreter(body: &[crate::ast::Stmt]) -> bool {
         body.iter().any(Self::module_otf_stmt_needs_interpreter)
     }
 

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -1,0 +1,55 @@
+# C6e's legacy_body drop is blocked by the gate-rejected interpreter shapes
+
+Scoping note for ADR-0019 C6e ("redeclaration comparison and eager body facts,
+then drop the plan field"). The first two thirds landed as C6e-1; the field
+drop cannot follow yet, and the reason is structural, not effort.
+
+## What C6e-1 covered
+
+- The two `body_debug_without_setline` Debug-string comparisons in
+  `registration_sub.rs` are now one `registration_identity` hash (params,
+  param_defs, top-level-`SetLine`-stripped body — line-insensitive exactly as
+  before). It is the single place the redeclaration comparison reads
+  `def.body`; C6e-3 redirects it to a plan-recorded fingerprint. Note the
+  existing plan fingerprint (`sub_registration_fingerprint`) hashes `SetLine`
+  markers, so it is NOT a drop-in replacement — either it grows the same
+  filter or the plan records this identity separately.
+- `RoutineBodyFacts` is now computed at plan lowering
+  (`CompiledRoutineMetadata::body_facts`) and seeded into
+  `FunctionDef::body_facts_cache` at registration, so a plan-derived def never
+  re-walks its body on a lazy miss. Metadata-less callers (prelude /
+  forward-declaration walkers) keep the lazy fill until Phase D.
+
+## Why the field cannot be dropped yet
+
+Dropping `CompiledSubDeclPlan::legacy_body` makes every plan-derived
+`FunctionDef.body` empty. Three reader classes still need a real body:
+
+1. **The C6d-5 gate-rejected shapes.** `call_function_fallback`'s interpreter
+   arm survives (deliberately) for defs that fail
+   `def_module_single_sig_body_ok_ignoring_state` — a sigilless-scalar param
+   whose caller-alias writeback crosses an EVAL boundary
+   (`t/sigilless-params.t`), and the `module_otf_needs_interpreter` body
+   constructs (nested `when` control flow that must not escape the routine —
+   `is-deeply-junction` — among others). That arm executes
+   `eval_block_value_with_pre_post(&def.body)`; with an empty body those defs
+   simply stop working. Killing this dependence means making the compiled
+   entry reproduce the sigilless-alias writeback
+   (`merge_sigilless_alias_writes`) and the interpreter-only control-flow
+   semantics — measure the residual arm hits first (instrument the else arm;
+   the C6d-5 survey counted 410 for the whole arm before the fold split it).
+2. **`body_fingerprint` identity.** `FunctionDef::body_fingerprint()` and the
+   multi-candidate registry keys hash the body; an empty body would collide
+   every routine. The plan must hand its fingerprint down and seed
+   `body_fp_cache` (mind the SetLine question above — the two fingerprints
+   have different line-sensitivity and different purposes).
+3. **`vm_call_named_inner.rs`'s sub-decl-as-last-statement case** builds a
+   `Sub` value from the plan's `legacy_body` directly; it needs the C6c
+   treatment (build from the plan's compiled routine instead).
+
+Suggested subdivision when resuming: C6e-2 = measure + kill the reader
+classes (1) and (3); C6e-3 = seed fingerprints and drop the field.
+
+Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
+(the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`
+(the C6d-5 gate).


### PR DESCRIPTION
ADR-0019 **C6e**, first slice (C6e-1) — two of the box's three parts.

**Redeclaration identity.** The two `body_debug_without_setline` Debug-string comparisons in `registration_sub.rs` are now one `registration_identity` hash streamed into a hasher (params, param_defs, top-level-`SetLine`-stripped body) — the same line-insensitive equality as before without building four full `String`s per redeclaration check, and the single place the comparison reads `def.body`, which C6e-3 will redirect to a plan-recorded fingerprint. (The existing plan fingerprint hashes `SetLine` markers, so it is *not* a drop-in replacement; the mismatch is recorded for C6e-3.)

**Eager body facts.** `RoutineBodyFacts` (the OTF-gate body predicates) are now computed once at plan lowering (`CompiledRoutineMetadata::body_facts`) and seeded into `FunctionDef::body_facts_cache` at registration, so a plan-derived def never re-walks its body on a lazy cache miss — which a body-less def will not be able to serve once `legacy_body` is dropped. Metadata-less callers (the prelude / forward-declaration walkers) keep the lazy fill until Phase D.

**The field drop is deferred.** Dropping `CompiledSubDeclPlan::legacy_body` is blocked on three reader classes — the C6d-5 gate-rejected interpreter shapes (sigilless-EVAL writeback, interpreter-only control flow), the body-hashed fingerprint identities, and `vm_call_named_inner`'s sub-decl-as-last-statement `Sub` construction — analyzed with a C6e-2/C6e-3 subdivision in `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.

Verified locally: `make test` (27493 tests) PASS, clippy/fmt clean. Full local roast runs in parallel; CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)