### PR TITLE
refactor(runtime): sigilless scalar params run compiled; fix take-in-callee gather suspension

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,9 +115,13 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 18/53 slices merged (D0 landed). Next slice: C6e — C6d-1, C6d-3's Phase-C
-half, C6d-4, and C6d-5 have all landed, so C6d's only open sub-box is the ADR-0009-scoped
-C6d-2, which does not gate C6 (token defs never come from `CompiledSubDeclPlan`).**
+**Current progress: 18/53 slices merged (D0 landed). Current box: C6e, subdivided per the
+measure-then-split precedent — C6e-1 (redeclaration-identity hash + eager body facts, #5952)
+and C6e-2a (sigilless scalars run compiled) have landed; C6e-2b (sub-signature params),
+C6e-2c (`start` bodies), and C6e-3 (drop `legacy_body`) remain, tracked with measurements in
+`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`. C6d's only open sub-box
+is the ADR-0009-scoped C6d-2, which does not gate C6 (token defs never come from
+`CompiledSubDeclPlan`).**
 
 The count tallies top-level boxes only; sub-boxes (C6a–C6e, C6d-1..5, E1a/E1b) are that box's
 PRs, and a subdivided box is checked when its last sub-box merges. A box that turns out to need
@@ -271,7 +275,15 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
     with the plan's C4 redeclaration fingerprint, and fill `RoutineBodyFacts` eagerly at plan
     lowering — the C6b cache is lazy and still reads `def.body` on a miss, which a body-less def
     cannot serve. The proto `{*}` rewrite moved to C8: a proto def is built from `stmt_pool` by
-    `RegisterProtoSub`, not from the sub plan, so it does not gate this field.
+    `RegisterProtoSub`, not from the sub plan, so it does not gate this field. Subdivided
+    (measure-then-split): C6e-1 landed the identity hash + eager facts (#5952); C6e-2 kills the
+    gate-rejected interpreter shapes — C6e-2a (landed) runs sigilless scalars compiled
+    (`news/2026-08/sigilless-params-run-compiled.md`, which also surfaced and fixed the
+    take-in-callee lazy-gather suspension bug,
+    `news/2026-08/gather-take-in-callee-eager.md`), C6e-2b (sub-signature params) and
+    C6e-2c (`start` bodies) remain; C6e-3 then seeds fingerprints and drops `legacy_body`.
+    Measurements and per-shape notes:
+    `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.
 - [ ] **C7 — Remove the sub-registration AST adapter.** Delete dead sub-shaped walker branches and
   prove the routine registry never compiles a migrated declaration on demand.
 - [ ] **C8 — Proto declarations register from typed plans.** Migrate `RegisterProtoSub` and

--- a/news/2026-08/gather-take-in-callee-eager.md
+++ b/news/2026-08/gather-take-in-callee-eager.md
@@ -1,0 +1,29 @@
+# A take inside a called routine no longer corrupts lazy-gather suspension
+
+The lazy-gather pull driver (`force_lazy_list_vm_n_inner`) runs the gather
+body's compiled code with a take limit and suspends by unwinding a signal
+from `take_value` when the limit is reached, snapshotting the body's ip,
+stack, and locals as coroutine state. That design assumes the `take` fires in
+the body's own frame. When the body *calls* a routine and the take fires
+inside the callee (`gather trip(5)` where `trip` takes inside its `for`
+loop), the signal unwound the callee frames and left the saved ip pointing at
+the body's call op with its arguments already drained — resuming then
+underflowed the VM stack ("Interpreter stack underflow in CallFunc") for a
+compiled callee, or silently lost every element after the first for an
+interpreter-arm callee.
+
+`take_value` now compares the live call-frame depth against the depth the
+pull driver recorded at entry (`lazy_pull_entry_call_depth`, saved/restored
+per pull so nested pulls compare against their own entry). A take arriving
+from a nested call frame skips the suspension and keeps collecting eagerly:
+the pull over-produces but stays correct, and a take at the body's own depth
+still suspends lazily as before (pinned by `t/gather-take-in-callee.t`,
+including an infinite own-frame gather).
+
+Found by the ADR-0019 C6e-2a gate widening: `roast/integration/
+advent2012-day04.t`'s `triplets(\N)` used to reach the interpreter arm, whose
+wrong-but-quiet variant of this bug passed the test only because that gather
+takes exactly once. Routing it through the compiled entry exposed the crash —
+but the bug was reachable on `main` with a plain `$n` parameter all along.
+One adjacent pre-existing wrongness remains and is ticketed:
+`todo/tickets/do-for-over-lazy-gather-drops-first-value.md`.

--- a/news/2026-08/sigilless-params-run-compiled.md
+++ b/news/2026-08/sigilless-params-run-compiled.md
@@ -1,0 +1,38 @@
+# Sigilless scalar params run compiled (ADR-0019 C6e-2a)
+
+The OTF/plan-bytecode gate (`def_module_single_sig_body_ok_ignoring_state`) no
+longer excludes routines with sigilless scalar parameters (`sub f(\x)`), so
+they run through the shared compiled entry instead of the C6d-5 interpreter
+arm. Measured before changing anything (per the survey discipline): across the
+whole `t/` suite the interpreter arm received 168 calls — 63 sigilless, 101
+`start`-body, 1 sub-signature, 0 trait-based; across the roast whitelist,
+3,677 — ~990 sigilless, 2,659 `start`-body, 14 sub-signature. An A/B run with
+the gate experimentally widened showed exactly one failing shape out of all 19
+sigilless-sub test files and the full `t/` suite: the EVAL-boundary
+caller-alias writeback (`t/sigilless-params.t` test 3).
+
+Two general fixes in the compiled return path (`vm_call_named_inner.rs`) made
+the widening safe:
+
+- **The alias-chain flush.** A compiled body writes a sigilless param through
+  its local slot, and the caller-alias writes only reached the caller via the
+  Slice F slot drain — which repairs *compiled* caller slots and runs after
+  the caller-env merge, so an interpreter-frame caller (an EVAL body) read the
+  stale pre-call value. The return path now flushes the param's final slot
+  value through the `__mutsu_sigilless_alias::` chain (reusing
+  `propagate_sigilless_alias_chain`) before the merge, mirroring the
+  interpreter arm's `merge_sigilless_alias_writes`.
+- **The name-collision re-apply.** The caller-env merge skips callee-local
+  names, which silently dropped the writeback whenever the caller's variable
+  had the same bare name as the parameter (`sub rts(\x) {...}; my $x = 1;
+  rts($x)` — caller `$x` and param `x` share the env key `x`). The collected
+  (target, value) pairs are re-applied to the restored env unconditionally
+  after the merge, matching the interpreter arm's unconditional insert. This
+  shape had no pre-existing test; `t/sigilless-param-compiled-writeback.t`
+  now pins it alongside the EVAL, die-after-write, and sequential-call cases.
+
+This is the first of the C6e-2 sub-slices
+(`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`): the
+remaining gate-rejected shapes are non-capture sub-signature params (15 hits
+total) and `start`-containing bodies (the recursive-start param-capture
+problem), still routed to the interpreter arm.

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -247,6 +247,17 @@ impl Interpreter {
             if let Some(Some(limit)) = self.gather_take_limits.last()
                 && items.len() >= *limit
             {
+                // A take inside a routine call NESTED under the lazy-pull
+                // driver cannot suspend soundly (the driver snapshots only its
+                // own frame; the signal would unwind the callee and corrupt
+                // the saved ip/stack — see `lazy_pull_entry_call_depth`). Keep
+                // collecting eagerly instead; over-production is correct.
+                if self
+                    .lazy_pull_entry_call_depth
+                    .is_some_and(|entry| self.call_frames.len() > entry)
+                {
+                    return Ok(());
+                }
                 if self.lazy_take_boundary_defer {
                     // Inside a condition-driven loop: defer the suspension to
                     // the loop's iteration boundary (`gather_suspend_pending`)

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2268,6 +2268,19 @@ pub struct Interpreter {
     /// and roast pins its side-effect timing (S04-statements/gather.t
     /// "gather is lazy"). Saved/restored on loop-op entry/exit.
     pub(crate) lazy_take_boundary_defer: bool,
+    /// Call-frame depth (`call_frames.len()`) at entry to the innermost active
+    /// lazy-gather pull (`force_lazy_list_vm_n_inner`), `None` outside one.
+    /// The pull driver can only snapshot/resume ITS OWN frame (ip, stack,
+    /// locals of the gather body's compiled code), so a take-limit hit inside
+    /// a NESTED routine call cannot suspend soundly: the signal would unwind
+    /// the callee frames and leave the saved ip pointing at the caller's
+    /// call op with its arguments already drained (resume then skips the call
+    /// or underflows the stack — `gather trip(5)` with `take` inside `trip`'s
+    /// `for` loop). `take_value` compares the live depth against this and
+    /// keeps collecting eagerly instead of suspending when the take is
+    /// deeper: the pull over-produces but stays correct. Saved/restored
+    /// around each pull, so nested pulls compare against their own entry.
+    pub(crate) lazy_pull_entry_call_depth: Option<usize>,
     pub(crate) rw_map_topic_capture: Option<Value>,
 }
 

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2341,6 +2341,7 @@ impl Interpreter {
             gather_resume_body_ip: None,
             gather_suspend_pending: false,
             lazy_take_boundary_defer: false,
+            lazy_pull_entry_call_depth: None,
             rw_map_topic_capture: None,
         };
         interpreter.init_io_environment();

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -700,6 +700,7 @@ impl Interpreter {
             gather_resume_body_ip: None,
             gather_suspend_pending: false,
             lazy_take_boundary_defer: false,
+            lazy_pull_entry_call_depth: None,
             rw_map_topic_capture: None,
         };
         // Raku gives each start block fresh $/ and $! (they are lexically scoped).

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -2022,7 +2022,14 @@ impl Interpreter {
                 .traits
                 .iter()
                 .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"));
-            (is_capture || (!pd.sigilless && pd.sub_signature.is_none())) && traits_otf_safe
+            // ADR-0019 C6e-2: a sigilless *scalar* (`\x`) is compiled-safe now
+            // that the compiled return path flushes its final value through the
+            // `__mutsu_sigilless_alias::` chain before the caller-env merge
+            // (vm_call_named_inner), which covers the EVAL-boundary caller-alias
+            // writeback that used to require the interpreter arm
+            // (t/sigilless-params.t test 3). A non-capture sub-signature
+            // (destructuring) parameter stays excluded.
+            (is_capture || pd.sub_signature.is_none()) && traits_otf_safe
         }) && !Self::routine_body_facts(def).module_otf_needs_interpreter
     }
 
@@ -2094,9 +2101,11 @@ impl Interpreter {
         // made module-level lexical + private-sibling reads work under OTF;
         // the chmod-IntStr allomorph fix unblocked S32-io/chdir.t).
         // Signature/body gates (shared with the cross-thread shared-body path):
-        //   - a capture parameter (`|c`) binds read-only and is fine, but a
-        //     sigilless *scalar* (`\x`) / non-capture sub-signature stays excluded
-        //     (caller-alias writeback across an EVAL boundary — see the doc above);
+        //   - a capture parameter (`|c`) binds read-only and is fine, and a
+        //     sigilless *scalar* (`\x`) is compiled-safe since ADR-0019 C6e-2
+        //     (the compiled return path flushes the alias chain before the
+        //     caller-env merge, covering the EVAL-boundary writeback); only a
+        //     non-capture sub-signature (destructuring) stays excluded;
         //   - standard binding-time traits (`is copy`/`is rw`/`is raw`/`is
         //     readonly`/`is required`) are OTF-safe (compiled binding honors them,
         //     rw/raw writeback carries the #4091 caller slot); only NativeCall

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -458,6 +458,54 @@ impl Interpreter {
                 }
             }
         }
+        // ADR-0019 C6e-2: flush a sigilless scalar param's (`\x`) final slot
+        // value through its `__mutsu_sigilless_alias::` chain into the callee
+        // env, so the caller-env merge below carries the write to the caller —
+        // including an interpreter-frame caller (an EVAL body), which the
+        // Slice F slot drain cannot repair (it writes compiled caller slots
+        // only; the merge dropped the write because the alias-target env entry
+        // was still the stale pre-call value at merge time). The interpreter
+        // arm gets the same effect from its alias-aware writeback merge
+        // (t/sigilless-params.t test 3 pins the EVAL case). The (target, value)
+        // pairs are also collected and re-applied to `restored_env` after the
+        // merge below: the merge skips callee-local names, which silently drops
+        // the writeback when the caller's variable has the same bare name as
+        // the parameter (`sub rts(\x) {...}; my $x = 1; rts($x)`).
+        let mut sigilless_writebacks: Vec<(String, Value)> = Vec::new();
+        if crate::env::closure_meta_keys_possible() {
+            for pd in &cf.param_defs {
+                if !pd.sigilless || pd.slurpy || pd.name.is_empty() {
+                    continue;
+                }
+                if let Some(slot) = cf.code.locals.iter().position(|n| n == &pd.name) {
+                    let final_val = self.locals[slot].clone();
+                    // Collect every alias-chain hop before propagating, so the
+                    // post-merge re-apply sees the same targets.
+                    let mut seen = std::collections::HashSet::new();
+                    let mut alias = self
+                        .env()
+                        .get(&crate::runtime::sigilless_alias_key(&pd.name))
+                        .and_then(|v| match v.view() {
+                            ValueView::Str(s) => Some(s.to_string()),
+                            _ => None,
+                        });
+                    while let Some(target) = alias {
+                        if !seen.insert(target.clone()) {
+                            break;
+                        }
+                        sigilless_writebacks.push((target.clone(), final_val.clone()));
+                        alias = self
+                            .env()
+                            .get(&crate::runtime::sigilless_alias_key(&target))
+                            .and_then(|v| match v.view() {
+                                ValueView::Str(s) => Some(s.to_string()),
+                                _ => None,
+                            });
+                    }
+                    self.propagate_sigilless_alias_chain(&cf.code, &pd.name, &final_val);
+                }
+            }
+        }
 
         self.set_current_package(saved_package);
         self.pop_routine();
@@ -609,6 +657,19 @@ impl Interpreter {
                     .copied()
                     .collect();
                 self.update_end_phaser_envs(end_phaser_count_before, &current, &dying);
+            }
+            // ADR-0019 C6e-2: re-apply the sigilless-alias writebacks collected
+            // before the merge. The merge's callee-local exclusion drops an
+            // alias target whose bare name matches the parameter name
+            // (`sub rts(\x) {...}; my $x = 1; rts($x)` — caller `$x` and param
+            // `x` share the env key "x"), so the final value is inserted
+            // unconditionally, mirroring the interpreter arm's alias-aware
+            // writeback merge.
+            for (target, val) in &sigilless_writebacks {
+                if target == "_" || target == "@_" || target == "%_" {
+                    continue;
+                }
+                restored_env.insert(target.clone(), val.clone());
             }
             *self.env_mut() = restored_env;
         }

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -151,6 +151,12 @@ impl Interpreter {
             0
         };
         self.push_gather_take_limit(Some(needed));
+        // Record this pull's call-frame depth so `take_value` can detect a
+        // take arriving from a NESTED routine call, where suspension is
+        // unsound (see the `lazy_pull_entry_call_depth` field doc).
+        let saved_pull_depth = self
+            .lazy_pull_entry_call_depth
+            .replace(self.call_frames.len());
 
         // Run the compiled code
         let run_fns = fns.as_ref();
@@ -197,6 +203,7 @@ impl Interpreter {
             body_finished = true;
         }
 
+        self.lazy_pull_entry_call_depth = saved_pull_depth;
         // The body may finish (or error) with the deferred-suspension flag
         // still set (straight-line takes, last iteration); it must not leak
         // into an unrelated later loop.

--- a/t/gather-take-in-callee.t
+++ b/t/gather-take-in-callee.t
@@ -1,0 +1,52 @@
+use Test;
+
+# ADR-0019 C6e-2: a `take` that fires inside a routine CALLED from a gather
+# body (rather than in the body's own code) cannot suspend the lazy-pull
+# coroutine soundly — the driver snapshots only its own frame, so the old
+# suspension signal unwound the callee and corrupted the saved ip/stack
+# ("Interpreter stack underflow in CallFunc" for a compiled callee, silently
+# missing elements for an interpreter-arm one). `take_value` now keeps
+# collecting eagerly when the take arrives from a nested call frame
+# (`lazy_pull_entry_call_depth`), so these shapes produce every element.
+
+plan 6;
+
+sub trip($n) { for 1..2 -> \a { take a * $n } }
+sub trip-sigilless(\N) { for 1..3 -> \a { take a * N } }
+
+{
+    my @a = gather trip(5);
+    is-deeply @a, [5, 10], 'assignment materializes takes from a called sub';
+}
+{
+    my @got;
+    for gather trip(5) { @got.push($_) }
+    is-deeply @got, [5, 10], 'statement for iterates takes from a called sub';
+}
+{
+    my $s := gather trip(7);
+    is "$s[0] $s[1]", '7 14', 'indexed access pulls takes from a called sub';
+}
+{
+    my @a = gather trip-sigilless(10);
+    is-deeply @a, [10, 20, 30], 'sigilless-param callee takes materialize';
+}
+{
+    # The advent2012-day04.t problem-9 shape: nested gather, the inner one
+    # over a sub call, consumed by a statement-modifier for.
+    my @r = gather {
+        sub triplets(\N) {
+            for 1..3 -> \a {
+                take $(a, a + N);
+            }
+        }
+        take .list[1] for gather triplets(10);
+    };
+    is-deeply @r, [11, 12, 13], 'nested gather over a called sub';
+}
+{
+    # A take at the gather body's own depth still suspends lazily: the
+    # infinite gather below must terminate via the bounded slice.
+    my $inf := gather { my $i = 0; loop { take ++$i } };
+    is-deeply $inf[^3].list, (1, 2, 3), 'own-frame takes stay lazily suspendable';
+}

--- a/t/sigilless-param-compiled-writeback.t
+++ b/t/sigilless-param-compiled-writeback.t
@@ -1,0 +1,74 @@
+use Test;
+
+# ADR-0019 C6e-2: sigilless scalar params (`\x`) run through the compiled
+# routine entry (the OTF/plan-bytecode gate no longer excludes them). The
+# caller-alias writeback must survive every calling context: same-frame,
+# across an EVAL boundary (the compiled return path flushes the
+# `__mutsu_sigilless_alias::` chain before the caller-env merge), and when
+# the callee dies after the write (write-through, not return-merge-only).
+
+plan 10;
+
+sub set2(\x, \y) { x = 11; y = 22 }
+sub read-then-set(\x) { my $t = x; x = $t + 1 }
+sub swap(\x, \y) { my $z = y; y = x; x = $z }
+sub poke(\x) { x = 99; die "boom" }
+
+# Same-frame calls
+{
+    my $a = 1; my $b = 2;
+    set2($a, $b);
+    is "$a|$b", '11|22', 'direct: assignments through two sigilless aliases';
+}
+{
+    my $c = 5;
+    read-then-set($c);
+    is $c, 6, 'direct: read-then-assign through a sigilless alias';
+}
+{
+    my $d = 5; my $e = 3;
+    swap($d, $e);
+    is "$d|$e", '3|5', 'direct: swap through sigilless aliases';
+}
+{
+    my $f = 5;
+    try { poke($f) }
+    is $f, 99, 'direct: write-through survives a die after the assignment';
+}
+
+# EVAL-boundary calls: the callee's alias writeback must reach the EVAL
+# frame and propagate to the enclosing scope.
+{
+    my $a = 1; my $b = 2;
+    EVAL 'set2($a, $b)';
+    is "$a|$b", '11|22', 'EVAL: assignments through two sigilless aliases';
+}
+{
+    my $c = 5;
+    EVAL 'read-then-set($c)';
+    is $c, 6, 'EVAL: read-then-assign through a sigilless alias';
+}
+{
+    my $d = 5; my $e = 3;
+    EVAL 'swap($d, $e)';
+    is "$d|$e", '3|5', 'EVAL: swap through sigilless aliases';
+}
+{
+    my $f = 5;
+    try { EVAL 'poke($f)' }
+    is $f, 99, 'EVAL: write-through survives a die after the assignment';
+}
+
+# Repeated calls keep aliasing fresh arguments (no stale alias leak).
+{
+    my $x = 1; my $y = 10;
+    read-then-set($x);
+    read-then-set($y);
+    is "$x|$y", '2|11', 'sequential calls alias their own arguments';
+}
+
+# A sigilless param still binds non-lvalue arguments read-only-safely.
+{
+    sub ident(\v) { v }
+    is ident(42), 42, 'literal argument binds fine through a sigilless param';
+}

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -50,6 +50,37 @@ Dropping `CompiledSubDeclPlan::legacy_body` makes every plan-derived
 Suggested subdivision when resuming: C6e-2 = measure + kill the reader
 classes (1) and (3); C6e-3 = seed fingerprints and drop the field.
 
+## C6e-2 progress
+
+The residual-arm measurement ran 2026-08-05 (env-gated instrumentation on the
+else arm, full `t/` + roast whitelist): 168 hits across `t/` (63 sigilless /
+101 `start`-body / 1 sub-signature / 0 trait), 3,677 across roast (~990
+sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
+`start`-body volume is concentrated in a handful of recursive-start subs
+(`conc-fib`, `does-fail`, `fib`).
+
+- **C6e-2a (landed): sigilless scalars.** The gate accepts `\x` scalars;
+  the compiled return path flushes the final slot value through the
+  `__mutsu_sigilless_alias::` chain before the caller-env merge and
+  re-applies the (target, value) pairs unconditionally after it (the merge's
+  callee-local exclusion dropped the writeback when the caller variable's
+  bare name collided with the param name) —
+  `news/2026-08/sigilless-params-run-compiled.md`,
+  pinned by `t/sigilless-param-compiled-writeback.t`. The rerouting also
+  exposed (and fixed) a pre-existing general bug: a `take` inside a routine
+  CALLED from a lazily-pulled gather body corrupted the suspension coroutine
+  (`news/2026-08/gather-take-in-callee-eager.md`; residual do-for wrongness
+  in `todo/tickets/do-for-over-lazy-gather-drops-first-value.md`).
+- **C6e-2b (open): non-capture sub-signature params** (15 hits total:
+  `group-of` in S05, `typed`). Needs the compiled binder to reproduce
+  destructuring; measure with a widened-gate A/B before implementing.
+- **C6e-2c (open): `start`-containing bodies.** The gate excludes ALL
+  `start` bodies because a *recursive* sub whose start closure captures a
+  param breaks under OTF (the recursive call re-binds the param name in the
+  thread env the closure keeps reading — t/start-block-return-value.t
+  test 3). The fix is per-invocation isolation of captured params, not a
+  gate tweak; design against the closure-capture cell playbook.
+
 Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
 (the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`
 (the C6d-5 gate).

--- a/todo/tickets/do-for-over-lazy-gather-drops-first-value.md
+++ b/todo/tickets/do-for-over-lazy-gather-drops-first-value.md
@@ -1,0 +1,28 @@
+# `do for` over a lazy gather drops the first iteration's value
+
+Minimal repro:
+
+```raku
+sub trip($n) { for 1..2 -> \a { take a * $n } }
+my @a = do for gather trip(5) { $_ };
+say @a;   # mutsu: [10] — raku: [5 10]
+```
+
+The statement form (`for gather trip(5) { @got.push($_) }`) iterates both
+elements correctly, and plain materialization (`my @a = gather trip(5)`) is
+right too (both pinned by `t/gather-take-in-callee.t`); only the expression
+form `do for`'s value collection loses the FIRST iteration's block value.
+
+This is pre-existing, not a regression from the C6e-2 lazy-pull fix: before
+that fix this shape either crashed ("Interpreter stack underflow in
+CallFunc", compiled callee) or produced `[5]` (interpreter-arm callee, also
+wrong) — the take-in-callee suspension was unsound in every variant
+(`todo/deep/`… see `news/2026-08/gather-take-in-callee-eager.md`). The
+first pull now returns the correct element; the do-for collector appears to
+discard the value produced during the pull that materialized the list, then
+collect normally from the second element on.
+
+Where to look: the do-for (expression) collection path over a `LazyList`
+source — the statement/expression asymmetry means the bug is in how the
+expression form's accumulator interacts with the first lazy pull, not in the
+pull driver itself.


### PR DESCRIPTION
ADR-0019 C6e-2a: the OTF/plan-bytecode gate no longer excludes routines with
sigilless scalar parameters (`sub f(\x)`), so they run through the shared
compiled entry instead of the C6d-5 interpreter arm.

## Measurement first

Instrumented the interpreter arm (env-gated) and ran the full suites:

| reason | t/ | roast whitelist |
|---|---|---|
| `start`-body | 101 | 2,659 |
| sigilless scalar | 63 | ~990 |
| sub-signature | 1 | 14 |
| non-OTF trait | 0 | 0 |

An A/B run with the gate experimentally widened showed exactly one failing
shape across all 19 sigilless-sub test files and the full `t/` suite: the
EVAL-boundary caller-alias writeback (`t/sigilless-params.t` test 3).

## Fixes that make the widening safe

**Alias-chain flush (`vm_call_named_inner.rs`).** A compiled body writes a
sigilless param through its local slot; the caller-alias write only reached
the caller via the Slice F slot drain, which repairs *compiled* caller slots
and runs after the caller-env merge — an interpreter-frame caller (an EVAL
body) read the stale pre-call value. The return path now flushes the param's
final slot value through the `__mutsu_sigilless_alias::` chain (reusing
`propagate_sigilless_alias_chain`) before the merge.

**Name-collision re-apply.** The caller-env merge skips callee-local names,
which silently dropped the writeback whenever the caller's variable had the
same bare name as the parameter (`sub rts(\x) {...}; my $x = 1; rts($x)` —
both use the env key `x`). The collected (target, value) pairs are re-applied
to the restored env unconditionally after the merge, matching the interpreter
arm. New shape, pinned by `t/sigilless-param-compiled-writeback.t`.

**Take-in-callee lazy-gather suspension (pre-existing general bug, exposed by
the rerouting).** The lazy-pull driver suspends by unwinding a signal from
`take_value` and snapshotting the gather body's ip/stack/locals — sound only
when the take fires in the body's own frame. A take inside a *called* routine
unwound the callee and corrupted the saved state: "Interpreter stack underflow
in CallFunc" for a compiled callee (reachable on `main` with a plain `$n`
param), silently missing elements for an interpreter-arm one
(`roast/integration/advent2012-day04.t` passed only because its gather takes
exactly once). `take_value` now compares the live call-frame depth against the
pull's entry depth (`lazy_pull_entry_call_depth`) and keeps collecting eagerly
instead of suspending when the take is deeper. Own-frame takes still suspend
lazily. Pinned by `t/gather-take-in-callee.t`; a residual pre-existing do-for
wrongness is ticketed in
`todo/tickets/do-for-over-lazy-gather-drops-first-value.md`.

Remaining C6e-2 shapes (sub-signature params, `start` bodies) stay on the
interpreter arm and are tracked with the measurements in
`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.

Validated locally: full `t/` (debug) and full `make roast` (release) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)