### PR TITLE
refactor(runtime): sub-signature params run compiled

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -116,9 +116,10 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 `main`; this is not a stacked-PR plan.
 
 **Current progress: 18/53 slices merged (D0 landed). Current box: C6e, subdivided per the
-measure-then-split precedent — C6e-1 (redeclaration-identity hash + eager body facts, #5952)
-and C6e-2a (sigilless scalars run compiled) have landed; C6e-2b (sub-signature params),
-C6e-2c (`start` bodies), and C6e-3 (drop `legacy_body`) remain, tracked with measurements in
+measure-then-split precedent — C6e-1 (redeclaration-identity hash + eager body facts, #5952),
+C6e-2a (sigilless scalars run compiled, #5953), and C6e-2b (sub-signature params run
+compiled) have landed; C6e-2c (`start` bodies) and C6e-3 (drop `legacy_body`) remain,
+tracked with measurements in
 `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`. C6d's only open sub-box
 is the ADR-0009-scoped C6d-2, which does not gate C6 (token defs never come from
 `CompiledSubDeclPlan`).**
@@ -277,11 +278,13 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
     cannot serve. The proto `{*}` rewrite moved to C8: a proto def is built from `stmt_pool` by
     `RegisterProtoSub`, not from the sub plan, so it does not gate this field. Subdivided
     (measure-then-split): C6e-1 landed the identity hash + eager facts (#5952); C6e-2 kills the
-    gate-rejected interpreter shapes — C6e-2a (landed) runs sigilless scalars compiled
+    gate-rejected interpreter shapes — C6e-2a (landed, #5953) runs sigilless scalars compiled
     (`news/2026-08/sigilless-params-run-compiled.md`, which also surfaced and fixed the
     take-in-callee lazy-gather suspension bug,
-    `news/2026-08/gather-take-in-callee-eager.md`), C6e-2b (sub-signature params) and
-    C6e-2c (`start` bodies) remain; C6e-3 then seeds fingerprints and drops `legacy_body`.
+    `news/2026-08/gather-take-in-callee-eager.md`), C6e-2b (landed) lifts the sub-signature
+    exclusion (`news/2026-08/subsig-params-run-compiled.md` — parameter shapes no longer gate
+    compilation at all), and C6e-2c (`start` bodies) remains; C6e-3 then seeds fingerprints
+    and drops `legacy_body`.
     Measurements and per-shape notes:
     `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.
 - [ ] **C7 — Remove the sub-registration AST adapter.** Delete dead sub-shaped walker branches and

--- a/news/2026-08/subsig-params-run-compiled.md
+++ b/news/2026-08/subsig-params-run-compiled.md
@@ -1,0 +1,28 @@
+# Sub-signature params run compiled (ADR-0019 C6e-2b)
+
+The OTF/plan-bytecode gate (`def_module_single_sig_body_ok_ignoring_state`)
+no longer excludes routines with sub-signature (destructuring) parameters —
+`sub group-of (Pair (Int:D :key($plan), ...))` and friends now run through
+the shared compiled entry instead of the C6d-5 interpreter arm. This was the
+smallest of the three gate-rejected shape classes measured for C6e-2 (15
+interpreter-arm hits across `t/` + the roast whitelist, vs ~1,050 sigilless
+and ~2,760 `start`-body).
+
+Measured before changing anything: with the exclusion experimentally lifted,
+the full `t/` suite (2,894 files) and all 37 roast files exercising
+`Test::Util`'s `group-of` (the dominant destructuring consumer) showed zero
+real regressions — the only diffs were a non-whitelisted file that fails
+identically on the baseline and one debug-binary timeout under `-j4` load
+that passes solo. The mechanism explains why: parameter binding runs through
+the shared `bind_function_args_values` on both arms, and destructured
+elements bind read-only (`MarkSigillessReadonly` for `(\i, \j)` shapes), so
+the historical exclusion reason — the sigilless caller-alias writeback fixed
+in C6e-2a — never applied to sub-signatures in the first place.
+
+With C6e-2a and C6e-2b landed, parameter *shapes* no longer gate compilation
+at all; the param predicate is down to the NativeCall marshalling traits
+(`is encoded(...)`). The remaining gate-rejected class is `start`-containing
+bodies (C6e-2c, the recursive-start param-capture problem) — tracked in
+`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`. Pinned
+by `t/subsig-param-compiled.t`, including the nested `group-of` Pair shape
+and an EVAL-boundary call.

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -2016,20 +2016,22 @@ impl Interpreter {
     pub(crate) fn def_module_single_sig_body_ok_ignoring_state(
         def: &crate::ast::FunctionDef,
     ) -> bool {
+        // Parameter shapes no longer gate compilation. ADR-0019 C6e-2a made a
+        // sigilless *scalar* (`\x`) compiled-safe (the compiled return path
+        // flushes its final value through the `__mutsu_sigilless_alias::`
+        // chain before the caller-env merge — vm_call_named_inner — which
+        // covers the EVAL-boundary caller-alias writeback that used to require
+        // the interpreter arm; t/sigilless-params.t test 3). C6e-2b lifted the
+        // sub-signature (destructuring) exclusion too: binding runs through
+        // the shared `bind_function_args_values` on both arms, and the
+        // destructured elements bind read-only, so the historical exclusion
+        // reason (caller-alias writeback) never applied to them
+        // (t/subsig-param-compiled.t). Only NativeCall marshalling traits
+        // (`is encoded(...)`) still keep a def on the interpreter.
         def.param_defs.iter().all(|pd| {
-            let is_capture = pd.slurpy && pd.sigilless;
-            let traits_otf_safe = pd
-                .traits
+            pd.traits
                 .iter()
-                .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"));
-            // ADR-0019 C6e-2: a sigilless *scalar* (`\x`) is compiled-safe now
-            // that the compiled return path flushes its final value through the
-            // `__mutsu_sigilless_alias::` chain before the caller-env merge
-            // (vm_call_named_inner), which covers the EVAL-boundary caller-alias
-            // writeback that used to require the interpreter arm
-            // (t/sigilless-params.t test 3). A non-capture sub-signature
-            // (destructuring) parameter stays excluded.
-            (is_capture || pd.sub_signature.is_none()) && traits_otf_safe
+                .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"))
         }) && !Self::routine_body_facts(def).module_otf_needs_interpreter
     }
 
@@ -2101,11 +2103,12 @@ impl Interpreter {
         // made module-level lexical + private-sibling reads work under OTF;
         // the chmod-IntStr allomorph fix unblocked S32-io/chdir.t).
         // Signature/body gates (shared with the cross-thread shared-body path):
-        //   - a capture parameter (`|c`) binds read-only and is fine, and a
-        //     sigilless *scalar* (`\x`) is compiled-safe since ADR-0019 C6e-2
-        //     (the compiled return path flushes the alias chain before the
-        //     caller-env merge, covering the EVAL-boundary writeback); only a
-        //     non-capture sub-signature (destructuring) stays excluded;
+        //   - parameter shapes no longer exclude: captures (`|c`) bind
+        //     read-only, sigilless scalars (`\x`) are compiled-safe since
+        //     ADR-0019 C6e-2a (the compiled return path flushes the alias
+        //     chain before the caller-env merge, covering the EVAL-boundary
+        //     writeback), and sub-signature destructuring since C6e-2b (shared
+        //     binder, read-only elements);
         //   - standard binding-time traits (`is copy`/`is rw`/`is raw`/`is
         //     readonly`/`is required`) are OTF-safe (compiled binding honors them,
         //     rw/raw writeback carries the #4091 caller slot); only NativeCall

--- a/t/subsig-param-compiled.t
+++ b/t/subsig-param-compiled.t
@@ -1,0 +1,30 @@
+use Test;
+
+# ADR-0019 C6e-2b: routines with sub-signature (destructuring) parameters run
+# through the compiled entry — the OTF/plan-bytecode gate no longer excludes
+# them. Binding runs through the shared binder on both arms and destructured
+# elements bind read-only, so behavior must match the interpreter arm exactly.
+
+plan 6;
+
+sub pairdest (Pair (Int:D :key($k), Str:D :value($v))) { "$k|$v" }
+sub listdest ([$a, $b, *@rest]) { "$a-$b-@rest[]" }
+sub nested (Pair (Int:D :key($plan), Pair :value((Str:D :key($desc), :value(&code))))) {
+    "$plan/$desc/" ~ code()
+}
+sub sigilless-dest ((\i, \j)) { i + j }
+
+is pairdest(3 => "x"), '3|x', 'named Pair destructure';
+is listdest([1, 2, 3, 4]), '1-2-3 4', 'positional list destructure with slurpy tail';
+is nested(2 => ("hi" => { 42 })), '2/hi/42',
+    'nested Pair-in-Pair destructure with a code-valued leaf (the group-of shape)';
+is sigilless-dest((5, 7)), 12, 'sigilless destructured elements';
+
+# EVAL-boundary call: the compiled routing must hold across a re-entrant
+# compile too.
+my $p = 4 => "y";
+is EVAL('pairdest($p)'), '4|y', 'destructuring callee reached through EVAL';
+
+# Repeated calls rebind fresh destructured elements.
+is listdest([9, 8]) ~ ';' ~ listdest([7, 6]), '9-8-;7-6-',
+    'sequential calls destructure their own arguments';

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -71,9 +71,15 @@ sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
   CALLED from a lazily-pulled gather body corrupted the suspension coroutine
   (`news/2026-08/gather-take-in-callee-eager.md`; residual do-for wrongness
   in `todo/tickets/do-for-over-lazy-gather-drops-first-value.md`).
-- **C6e-2b (open): non-capture sub-signature params** (15 hits total:
-  `group-of` in S05, `typed`). Needs the compiled binder to reproduce
-  destructuring; measure with a widened-gate A/B before implementing.
+- **C6e-2b (landed): non-capture sub-signature params** (15 hits total:
+  `group-of`, `typed`). The widened-gate A/B (full `t/` + all 37 group-of
+  roast files) showed zero real regressions: binding runs through the shared
+  `bind_function_args_values` on both arms and destructured elements bind
+  read-only, so the compiled binder already reproduced destructuring and the
+  slice reduced to removing the exclusion —
+  `news/2026-08/subsig-params-run-compiled.md`, pinned by
+  `t/subsig-param-compiled.t`. Parameter shapes no longer gate compilation;
+  the param predicate is down to NativeCall marshalling traits.
 - **C6e-2c (open): `start`-containing bodies.** The gate excludes ALL
   `start` bodies because a *recursive* sub whose start closure captures a
   param breaks under OTF (the recursive call re-binds the param name in the


### PR DESCRIPTION
ADR-0019 C6e-2b: the OTF/plan-bytecode gate
(`def_module_single_sig_body_ok_ignoring_state`) no longer excludes routines
with sub-signature (destructuring) parameters — `sub group-of (Pair (Int:D
:key($plan), ...))` and friends run through the shared compiled entry instead
of the C6d-5 interpreter arm. With C6e-2a (#5953) and this slice, parameter
*shapes* no longer gate compilation at all; the param predicate is down to
the NativeCall marshalling traits (`is encoded(...)`).

## Measurement first

This was the smallest of the three gate-rejected shape classes measured for
C6e-2 (15 interpreter-arm hits across `t/` + the roast whitelist, vs ~1,050
sigilless and ~2,760 `start`-body). With the exclusion experimentally lifted
behind an env var:

- direct shapes (named Pair destructure, positional list destructure with a
  slurpy tail, the nested `group-of` Pair-in-Pair shape with a code-valued
  leaf, sigilless `(\i, \j)` elements) — identical to baseline and to raku;
- the full `t/` suite (2,894 files) — PASS;
- all 37 roast files exercising `Test::Util`'s `group-of` — zero real
  regressions (one non-whitelisted file fails identically on baseline; one
  debug-binary timeout under `-j4` load passes solo).

The mechanism explains the clean A/B: parameter binding runs through the
shared `bind_function_args_values` on both arms, and destructured elements
bind read-only (`MarkSigillessReadonly` for sigilless shapes), so the
historical exclusion reason — the sigilless caller-alias writeback fixed in
C6e-2a — never applied to sub-signatures. The slice therefore reduces to
removing the exclusion, plus `t/subsig-param-compiled.t` pinning the shapes
above and an EVAL-boundary call.

Remaining gate-rejected class: `start`-containing bodies (C6e-2c), tracked in
`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.

Validated locally: full `t/` (debug) and full `make roast` (release) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)