### PR TITLE
fix(runtime): state scalars live in a shared cell; plain = accumulates across calls

### DIFF
--- a/news/2026-08/state-scalar-cell-storage.md
+++ b/news/2026-08/state-scalar-cell-storage.md
@@ -1,0 +1,39 @@
+# `state` scalars live in a shared cell; plain `=` accumulates across calls
+
+`sub f() { state $n = 0; $n = $n + 1; $n }` returned 1, 1, 1 — every call
+saw the initializer again. The scalar lived in the plain state store while
+the assignment wrote only the routine's local slot; the exit persist then
+read the stale env copy and stored it back, so the write never survived the
+call. Only shapes that happened to force a cell-direct read (`say "in:$n"`)
+or mutate in place (`++`) accumulated, which is why the existing `state`
+coverage — all `++`-based — missed it
+(`todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md`,
+found while measuring ADR-0019 C6d-1).
+
+Fix: `StateVarInit` now stores an untyped `state` scalar in a
+`ContainerRef` cell, exactly as `state @a` / `state %h` aggregates already
+were (Track B slice 3) and as scalars already were under an active thread
+context. Slot, env and the state store share one cell, so the assignment's
+write-through reaches every reader and the exit persist stores the same
+cell. The old "scalars are already shared via box-on-capture escape
+analysis" argument only covered scalars some closure captures. Per-clone
+semantics are preserved (the cell is keyed by the scoped state key, so a
+nested named sub still re-initializes per enclosing call).
+
+Two carve-outs, both documented as residuals in the ticket: a
+type-constrained scalar keeps the plain store (the same rule as
+`box_captured_lexicals` — mutations must flow through the assignment
+chokepoint for the constraint re-check, and a `state buf32 $w` holding a
+Buf must not present as a cell to element assignment — Digest's SHA2,
+pinned by t/digest-battery.t), and the block-as-loop-body form
+(`{ state $n = 0; ... } for 1..3`) still loses writes to a block-scope
+shadowing defect that predates this change. The statement-modifier block's
+spurious per-iteration `ResetStateLocals` IS fixed (the loop compile sites
+set `suppress_loop_block_state_reset` when the loop body is a sole source
+block), and the expression-position typed state declaration
+(`(state buf32 $w .= new)`) now registers its type constraint like the
+statement form.
+
+Pinned by `t/state-scalar-plain-assignment.t` (plain `=`, `+=`, `~=`,
+implicit/explicit return, plain read after write, `++`, per-clone nested
+named sub) — expected values verified against raku.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -115,6 +115,16 @@ impl Compiler {
                 let is_dynamic = *ast_is_dynamic || self.var_is_dynamic(name);
                 // my $x = expr in expression context -> declare, assign, return value
                 if *is_state {
+                    // Register the declared type constraint BEFORE the init,
+                    // exactly as the statement-position decl does: assignments
+                    // must re-check it, and `StateVarInit` reads it to keep a
+                    // constrained scalar out of the ContainerRef cell
+                    // (`(state buf32 $w .= new)[$j] = ...` — Digest's SHA2).
+                    if let Some(tc) = type_constraint {
+                        let name_idx = self.code.add_constant(Value::str(name.clone()));
+                        let tc_idx = self.code.add_constant(Value::str(tc.clone()));
+                        self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                    }
                     self.compile_expr(expr);
                     let slot = self.alloc_local(name);
                     let ip = self.code.ops.len();

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -233,6 +233,10 @@ impl Compiler {
     }
 
     fn compile_collected_loop_body(&mut self, body: &[Stmt]) {
+        // `do { ... } for @xs`: the sole block IS the loop body, cloned once
+        // per loop statement — its `state` persists across iterations (see
+        // `loop_body_is_sole_block`).
+        self.suppress_loop_block_state_reset = Self::loop_body_is_sole_block(body);
         self.compile_stmts_value(body);
     }
 

--- a/src/compiler/helpers_stmt_analysis.rs
+++ b/src/compiler/helpers_stmt_analysis.rs
@@ -25,6 +25,23 @@ impl Compiler {
             .then(|| self.code.emit(OpCode::ResetStateLocals { body_end: 0 }))
     }
 
+    /// Whether a loop body consists of exactly one source `{ ... }` block
+    /// (the statement-modifier form `{ ... } for @xs` parses that way, with
+    /// only `SetLine` markers beside it). That block IS the loop's body — the
+    /// loop statement clones it once and its iterations share the clone, so
+    /// its `state` must persist across iterations (raku: `{ state $n = 0;
+    /// $n = $n + 1; say $n } for 1..3` prints 1 2 3). The compile sites set
+    /// [`Compiler::suppress_loop_block_state_reset`] from this so the block's
+    /// per-execution `ResetStateLocals` is skipped; the loop-entry reset
+    /// already restarts the state when the loop STATEMENT re-executes.
+    pub(super) fn loop_body_is_sole_block(body: &[Stmt]) -> bool {
+        let mut semantic = body.iter().filter(|s| !matches!(s, Stmt::SetLine(_)));
+        matches!(
+            (semantic.next(), semantic.next()),
+            (Some(Stmt::Block(_)), None)
+        )
+    }
+
     /// [`Self::emit_nested_block_state_reset`] for an `if`/`unless` branch: a
     /// postfix statement MODIFIER introduces no block, so the statement it gates
     /// belongs to the enclosing block and its `state` must not restart

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -370,6 +370,13 @@ pub(crate) struct Compiler {
     /// not a genuine source `{ ... }`). The `Stmt::Block` arm consumes it to
     /// decide whether the resulting scope is a backtrace-visible callframe.
     synthetic_block_body: bool,
+    /// Set true immediately before compiling a loop body that is a sole source
+    /// `{ ... }` block (the `{ ... } for @xs` statement-modifier form). The
+    /// `Stmt::Block` arm consumes it to skip the block's per-execution
+    /// `ResetStateLocals`: that block is the loop's body, cloned once per loop
+    /// statement, so its `state` persists across iterations — see
+    /// `loop_body_is_sole_block`.
+    suppress_loop_block_state_reset: bool,
     /// Set by the `Stmt::Block` arm just before calling `compile_try` for a
     /// genuine bare block that carries a `CATCH`/`CONTROL`. `compile_try`
     /// consumes it so the emitted `TryCatch` is marked as a bare-block
@@ -504,6 +511,7 @@ impl Compiler {
             suppress_pair_capture: false,
             suppress_list_var_alias: false,
             synthetic_block_body: false,
+            suppress_loop_block_state_reset: false,
             next_try_is_bare_block: false,
             fold_ctx: std::sync::Arc::new(const_fold::FoldCtx::enabled()),
             fold_root: true,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -592,8 +592,12 @@ impl Compiler {
                 // `OpCode::ResetStateLocals`. A SYNTHETIC body is excluded: a
                 // loop body is the block the loop statement clones ONCE (its
                 // iterations share the state), and an `if` branch already got
-                // its reset at the branch site.
-                let state_reset = is_bare
+                // its reset at the branch site. A sole-block loop body
+                // (`{ ... } for @xs`) is likewise the loop's own body — the
+                // loop compile sites set `suppress_loop_block_state_reset` so
+                // its `state` persists across iterations.
+                let suppress_loop_reset = std::mem::take(&mut self.suppress_loop_block_state_reset);
+                let state_reset = (is_bare && !suppress_loop_reset)
                     .then(|| self.emit_nested_block_state_reset(stmts))
                     .flatten();
                 if Self::has_catch_or_control(stmts) {
@@ -1858,6 +1862,8 @@ impl Compiler {
                     self.synthetic_block_body = true;
                     self.compile_stmt(&Stmt::Block(loop_body.clone()));
                 } else {
+                    self.suppress_loop_block_state_reset =
+                        Self::loop_body_is_sole_block(&loop_body);
                     self.compile_body_with_implicit_try(&loop_body);
                 }
                 self.code.patch_loop_end(loop_idx);
@@ -2156,6 +2162,7 @@ impl Compiler {
                 // `callframe`/`caller` inside sees the enclosing routine one
                 // level further up (see `callframe_block_depth`).
                 self.callframe_block_depth += 1;
+                self.suppress_loop_block_state_reset = Self::loop_body_is_sole_block(&loop_body);
                 self.compile_body_with_implicit_try(&loop_body);
                 self.callframe_block_depth -= 1;
                 for n in &newly_registered {
@@ -2211,6 +2218,7 @@ impl Compiler {
                 }
                 self.code.patch_cstyle_cond_end(loop_idx);
                 // Compile body
+                self.suppress_loop_block_state_reset = Self::loop_body_is_sole_block(&loop_body);
                 self.compile_body_with_implicit_try(&loop_body);
                 self.code.patch_cstyle_step_start(loop_idx);
                 // Compile step (if any)
@@ -2675,6 +2683,7 @@ impl Compiler {
                     label: label.clone(),
                 });
                 // Compile body
+                self.suppress_loop_block_state_reset = Self::loop_body_is_sole_block(&loop_body);
                 self.compile_body_with_implicit_try(&loop_body);
                 self.code.patch_repeat_cond_end(loop_idx);
                 // Compile condition (or push True if none)

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -56,6 +56,18 @@ impl Interpreter {
         let scoped_key = self.scoped_state_key(base_key);
         let slot_idx = slot as usize;
         let name = &code.locals[slot_idx];
+        // A type-constrained state scalar keeps the plain store (same rule as
+        // `box_captured_lexicals`, vm_register_ops): every mutation must keep
+        // flowing through the assignment chokepoint so the constraint
+        // re-checks, and a `state buf32 $w` holding a Buf must not present as
+        // a cell to the element-assignment path (`$w[$j] = ...` — Digest's
+        // SHA2). `Mu` is universal, so it stays cell-eligible.
+        let type_constrained_scalar = !name.starts_with('@') && !name.starts_with('%') && {
+            let tc = self
+                .var_type_constraint(name)
+                .or_else(|| self.var_type_constraint(name.trim_start_matches('$')));
+            tc.is_some_and(|t| t != "Mu")
+        };
         // Track C: while a thread is running, a user `state` variable lives in a
         // shared `ContainerRef` cell (keyed in shared_vars) so concurrent calls
         // to the same routine across threads — `await (^3).map: { start f() }`
@@ -100,10 +112,13 @@ impl Interpreter {
             cell
         } else if let Some(stored) = self.get_state_var(&scoped_key) {
             let stored = stored.clone();
-            // Track B slice 3: upgrade a plain stored aggregate to a cell
-            // (a value written by a pre-cell `set_state_var` plain insert),
-            // so every reader from here on shares one container.
-            if (name.starts_with('@') || name.starts_with('%')) && !stored.is_container_ref() {
+            // Track B slice 3: upgrade a plain stored value to a cell (a value
+            // written by a pre-cell `set_state_var` plain insert), so every
+            // reader from here on shares one container. Scalars included: a
+            // `state $n` written with plain `=` used to write only the local
+            // slot while the exit persist read the stale env copy, so the
+            // counter never accumulated (t/state-scalar-plain-assignment.t).
+            if !stored.is_container_ref() && !type_constrained_scalar {
                 let cell = stored.into_container_ref();
                 self.set_state_var(scoped_key.clone(), cell.clone());
                 cell
@@ -131,13 +146,19 @@ impl Interpreter {
             // captures the CELL, so sibling closures from the same factory
             // share one live container exactly like raku (`mk()` twice used to
             // give 1,1,2 instead of 1,2,3: each closure env froze its own
-            // aggregate snapshot). Scalars keep the plain store: they are
-            // already shared via box-on-capture escape analysis, and celling
-            // them here would double-box.
-            let val = if name.starts_with('@') || name.starts_with('%') {
-                coerced.into_container_ref()
-            } else {
+            // aggregate snapshot). Scalars live in a cell too (2026-08-06):
+            // "box-on-capture will share them" only covers variables some
+            // closure captures — an uncaptured `state $n` written with plain
+            // `=` wrote only the local slot while the exit persist read the
+            // stale env copy, so the counter reset on every call
+            // (t/state-scalar-plain-assignment.t). The cell makes slot, env
+            // and the state store one storage location, the same soundness
+            // argument as the aggregate case. Type-constrained scalars keep
+            // the plain store — see `type_constrained_scalar` above.
+            let val = if type_constrained_scalar {
                 coerced
+            } else {
+                coerced.into_container_ref()
             };
             self.set_state_var(scoped_key.clone(), val.clone());
             val

--- a/t/state-scalar-plain-assignment.t
+++ b/t/state-scalar-plain-assignment.t
@@ -1,0 +1,57 @@
+use Test;
+
+# A `state` scalar written with plain `=` (not `++`) must accumulate across
+# calls. The scalar used to live in the plain state store while the write hit
+# only the local slot, so the exit persist read a stale copy and every call
+# saw the initializer again. `state` scalars now live in a ContainerRef cell
+# like aggregates do, making slot, env and the store one location
+# (todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md).
+# Expected values verified against raku.
+
+plan 8;
+
+{
+    sub f() { state $n = 0; $n = $n + 1; $n }
+    is (f(), f(), f()).join(','), '1,2,3', 'plain = accumulates across calls';
+}
+
+{
+    sub f() { state $n = 0; $n += 1; $n }
+    is (f(), f()).join(','), '1,2', '+= accumulates across calls';
+}
+
+{
+    sub f() { state $s = ""; $s ~= "x"; $s }
+    is (f(), f()).join(','), 'x,xx', '~= accumulates across calls';
+}
+
+{
+    sub f() { state $n = 0; $n = $n + 1; }
+    is (f(), f()).join(','), '1,2', 'implicit return of the assignment accumulates';
+}
+
+{
+    sub f() { state $n = 0; $n = $n + 1; return $n }
+    is (f(), f()).join(','), '1,2', 'explicit return sees the accumulated value';
+}
+
+{
+    sub f() { state $n = 0; $n = $n + 1; my $r = $n; $r }
+    is (f(), f()).join(','), '1,2', 'a plain read after the assignment sees the write';
+}
+
+{
+    sub f() { state $n = 0; $n++; $n }
+    is (f(), f()).join(','), '1,2', '++ still accumulates';
+}
+
+{
+    # Per-clone identity must survive the cell: a nested named sub
+    # re-initializes its state per enclosing call.
+    sub outer() {
+        sub inner() { state $n = 0; $n = $n + 1; $n }
+        (inner(), inner()).join(',')
+    }
+    is (outer(), outer()).join('|'), '1,2|1,2',
+        'nested named sub state still re-initializes per enclosing call';
+}

--- a/todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md
+++ b/todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md
@@ -1,82 +1,60 @@
-# A `state` scalar written with `=` (not `++`) loses the write between calls
+# `state` in a block used as a loop body loses every write (residual)
 
-`state $n = 0; $n = $n + 1;` does not accumulate. Every call sees the
-initializer value again, so a `state` counter written with plain assignment is
-silently stuck at its first value:
+UPDATE 2026-08-06: the original headline symptom — a `state` scalar written
+with plain `=` in a routine losing the write between calls — is FIXED:
+`state` scalars now live in a `ContainerRef` cell exactly like `state`
+aggregates already did (`StateVarInit`'s scalar branch; the "box-on-capture
+will share them" assumption only covered captured scalars). Slot, env and
+the state store share one cell, so the write-through reaches every reader
+and the exit persist stores the same cell. Pinned by
+`t/state-scalar-plain-assignment.t` (plain `=`, `+=`, `~=`, implicit/
+explicit return, plain read after write, `++`, and the per-clone nested
+named sub semantics).
 
-```
-$ raku  -e 'sub f() { state $n = 0; $n = $n + 1; $n }; say f(); say f(); say f();'
-1
-2
-3
-$ mutsu -e 'sub f() { state $n = 0; $n = $n + 1; $n }; say f(); say f(); say f();'
-1
-1
-1
-```
+## Residual: type-constrained state scalars
 
-`$n += 1` behaves the same way. `++$n` and `$n++` are correct, and so is a
-`state` aggregate (`state @a; @a.push(1)`), which is why the existing coverage
-misses this: every `state` case in `t/` — `t/state-per-clone-named-subs.t`,
-`t/state-in-loop-body-accumulates.t`, `t/module-state-sub-shared-cell.t`,
-`t/anon-state-per-routine-call.t` — increments with `++`.
+A TYPE-CONSTRAINED state scalar (`state Int $n = 0; $n = $n + 1`) still
+loses the write (1,1 — raku: 1,2): it keeps the plain store, mirroring
+`box_captured_lexicals`' rule that a constrained scalar must flow through
+the assignment chokepoint so the constraint re-checks (and a
+`state buf32 $w` holding a Buf must not present as a cell to the
+element-assignment path — Digest's SHA2 `(state buf32 $w .= new)[$j] = …`,
+pinned by t/digest-battery.t). Fixing typed scalars needs either
+constraint-checking write-through on the cell, or the exit-persist rule
+rework the original ticket described. (The expression-position typed state
+decl also failed to register its constraint at all — fixed: the
+`(state buf32 $w …)` expr branch now emits `SetVarType` like the statement
+form.)
 
-Found while measuring ADR-0019 C6d-1, not caused by it: it reproduces on
-`main` and predates that work. The routine runs on the ordinary compiled path
-(`MUTSU_VM_STATS` reports 0 function fallbacks), so this is a compiled-path
-bug, not a fallback one. Notably the *interpreter* entry got it right: the
-same operator body invoked through `call_function_def` accumulated correctly
-(pinned now by `t/user-operator-compiled-body.t`'s `infix:<ss>` cases).
-
-## What distinguishes the working shapes
-
-The write reaches the state cell only when something *else* in the body reads
-the variable in a way that forces a cell-direct read afterwards. Assignment as
-an *expression* is also fine — only the statement form followed by a plain read
-loses it:
-
-| body | raku | mutsu |
-| --- | --- | --- |
-| `state $n = 0; $n = $n + 1; $n` | 1, 2 | 1, **1** |
-| `state $n = 0; $n += 1; $n` | 1, 2 | 1, **1** |
-| `state $n = 0; $n = $n + 1;` (implicit return of the assignment) | 1, 2 | 1, **1** |
-| `state $n = 0; $n = $n + 1; return $n` | 1, 2 | 1, **1** |
-| `state $n = 0; $n = $n + 1; my $r = $n; $r` | 1, 2 | 1, **1** |
-| `state $n = 0; $n = $n + 1; say "in:$n"; $n` | 1, 2 | 1, 2 |
-| `state $n = 0; my $x = ($n = $n + 1); $x` | 1, 2 | 1, 2 |
-| `state $n = 0; $n++; $n` | 1, 2 | 1, 2 |
-| `state $s = ""; $s ~= "x"; $s` | x, xx | x, **x** |
-
-So the assignment writes the routine's VM local slot, and only some reads
-flush the slot into the state cell — the interpolating read does, the trailing
-bare read does not. The `++` forms presumably mutate the cell in place. That
-matches the dual-store shape recorded in
-`memory/project-mustache-remaining-two-files.md` ("a slot is only filled by a
-cell-direct read").
-
-A bare block reached through a statement modifier is broken the same way even
-with the interpolating read, so the loop-body clone path shares the defect:
+## Residual: the block-as-loop-body form
 
 ```
 $ raku  -e '{ state $n = 0; $n = $n + 1; say $n; } for 1..3;'   # 1 2 3
 $ mutsu -e '{ state $n = 0; $n = $n + 1; say $n; } for 1..3;'   # 1 1 1
+$ mutsu -e '{ state $n = 0; $n++;        say $n; } for 1..3;'   # 1 1 1 (also wrong)
 ```
 
-## Why this is not a quick fix
+Two distinct causes, one fixed:
 
-The bug is in which side of the slot/cell dual store owns a `state` variable's
-value at each read and write, so the fix has to establish one rule for all
-four of: the assignment opcode's target, the plain read, the interpolating
-read, and routine exit. Picking the wrong one re-introduces the per-clone
-identity behavior that `t/state-per-clone-named-subs.t` and
-`t/concurrent-state-var.t` pin (a nested named sub must re-initialize its
-`state` per enclosing call, while a top-level sub must not), so it needs the
-same care as the ADR-0018 slot/env work rather than a local patch at the
-assignment site.
+1. **(fixed)** the statement-modifier form parses as `For { body: [Block(...)] }`
+   and the `Stmt::Block` arm emitted a per-execution `ResetStateLocals` INSIDE
+   the loop body — the state store was wiped every iteration. The loop compile
+   sites now set `Compiler::suppress_loop_block_state_reset` when the loop body
+   is a sole source block (`loop_body_is_sole_block`), because that block IS
+   the loop's body: cloned once per loop statement, its iterations share the
+   clone (the loop-entry `reset_state_locals_in_range` still restarts the
+   state when the loop STATEMENT re-executes).
+2. **(open)** even without the reset, the write inside the block never reaches
+   the state cell: gdb shows the per-iteration `StateVarInit` finds the stored
+   cell still holding the initializer. Operator-independent (`=` and `++`
+   both), so the block's scope machinery (BlockLocalScope env overlay) is
+   shadowing the cell — the assignment writes a block-scoped plain copy
+   instead of through the cell, and the block-exit scope restore discards it.
+   The inline statement form (`for 1..3 { state $n = 0; ... }`, no Block
+   wrapper) is correct, which isolates the defect to the Block-in-loop-body
+   scope path.
 
-## Where to look
-
-- `src/vm/vm_var_ops.rs`, `src/vm/vm_misc_scope.rs` — state-cell read/write ops.
-- `src/vm/vm_call_named_inner.rs`, `src/vm/vm_call_fast.rs` — the per-call
-  state-cell seeding and the routine-exit flush.
-- `src/vm/vm_closure_dispatch.rs` — the block-clone variant of the same.
+Where to look: `exec_block_local_scope_op` (vm_exec_dispatch /
+vm_misc_scope) — how a block-scoped env overlay treats a name whose outer
+binding is a `ContainerRef` state cell; the write should go through the
+cell, not insert a shadowing plain value.


### PR DESCRIPTION
`sub f() { state $n = 0; $n = $n + 1; $n }` returned **1, 1, 1** (raku: 1, 2, 3): the scalar lived in the plain state store while the assignment wrote only the local slot, so the exit persist stored a stale copy and every call saw the initializer again. Only cell-direct-read shapes (`say "in:$n"`) or in-place mutation (`++`) accumulated — which is why the existing all-`++` state coverage missed it. Ticket: `todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md` (found while measuring ADR-0019 C6d-1).

## Fix

`StateVarInit` stores an untyped `state` scalar in a **`ContainerRef` cell**, exactly as `state @a` / `state %h` aggregates already were (Track B slice 3) and as scalars already were under an active thread context. Slot, env and the state store share one cell, so the assignment's write-through reaches every reader and the exit persist stores the same cell. Per-clone semantics are preserved (cell keyed by the scoped state key — a nested named sub still re-initializes per enclosing call, verified against raku).

## Carve-outs (ticket residuals)

- **Type-constrained scalars keep the plain store** — same rule as `box_captured_lexicals`: mutations must flow through the assignment chokepoint for the constraint re-check, and a `state buf32 $w` holding a Buf must not present as a cell to element assignment (Digest's SHA2 `(state buf32 $w .= new)[$j] = …`, pinned by t/digest-battery.t).
- **The block-as-loop-body form** (`{ state $n = 0; … } for 1..3`) still loses writes to a pre-existing block-scope shadowing defect (operator-independent, documented in the ticket).

## Also fixed on the way

- The statement-modifier loop body's spurious per-iteration `ResetStateLocals` (the loop compile sites set `suppress_loop_block_state_reset` when the loop body is a sole source block — that block IS the loop's body, cloned once per loop statement).
- The expression-position typed state decl (`(state buf32 $w .= new)`) now registers its type constraint via `SetVarType` like the statement form.

## Validation

Full `t/` PASS, full local `make roast` PASS, battery gate **GATE PASSED** (the state representation touches module code — File::Temp/Digest exercise it). Pinned by `t/state-scalar-plain-assignment.t` (8 cases, expected values verified against raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)