### PR TITLE
feat(vm): rw-param routines register body-less (C6e-3c prep)

### DIFF
--- a/news/2026-08/rw-param-routines-register-body-less.md
+++ b/news/2026-08/rw-param-routines-register-body-less.md
@@ -1,0 +1,22 @@
+# Routines with scalar rw params register body-less (C6e-3c prep)
+
+The C6e-3b safe-class empty-body registration excluded routines with a
+scalar `is rw`/`is raw` parameter: their calls were gated onto the
+interpreter carrier (which executes the AST body), so registering them
+body-less would have broken every such call. With shared-cell rw binding
+(`news/2026-08/rw-params-bind-shared-cells.md`) those routines run their
+compiled bodies on every path, so the keep-class is lifted:
+`vm_register_sub_ops.rs`'s registration predicate no longer checks
+`has_rw_scalar_param`, and a plan-derived rw-param routine registers with
+an empty body like any other safe-class def.
+
+The remaining C6e-3c keep-classes are down to: a plan without resolvable
+bytecode for every declared signature (class-walker nested subs),
+routine-level `is rw`/`is raw`/tail-`return-rw` lvalue routines (the
+assignment machinery extracts the target from the AST), and NativeCall
+marshalling traits — tracked in
+`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.
+
+Validated with the full local chain (t/ suite, `make roast`, battery
+gate); the rw behavior itself is pinned by `t/rw-shared-cell.t` and
+`t/proto-dispatch-interpreter-path.t`.

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -231,17 +231,6 @@ impl Interpreter {
             // nested sub registered from a class-walker method body, whose
             // keys do not resolve in this call site's fns table).
             let plan_fully_compiled = compiled_routine_keys.len() == 1 + signature_alternates.len();
-            // A routine with a scalar `is rw`/`is raw` param stays on the
-            // interpreter carrier (resolution_call_sub keeps it off the
-            // compiled fork until rw binding is cell-based — see
-            // todo/tickets/rw-writeback-through-wrap-chain-needs-shared-cells.md),
-            // so it must keep its AST body.
-            let has_rw_scalar_param = param_defs.iter().any(|pd| {
-                pd.traits.iter().any(|t| t == "rw" || t == "raw")
-                    && !pd.name.starts_with('@')
-                    && !pd.name.starts_with('%')
-                    && !pd.name.starts_with('&')
-            });
             // The plan compiled one routine body per declared signature: the
             // primary first, then each `signature_alternates` entry in
             // declaration order. Registration installs the candidates in that
@@ -265,7 +254,11 @@ impl Interpreter {
                 // carries keys its executing table does not hold, and a def
                 // with neither body nor bytecode cannot run.
                 && primary_compiled.is_some()
-                && !has_rw_scalar_param
+                // Scalar `is rw`/`is raw` PARAMS no longer keep the body: the
+                // binder aliases them through shared `ContainerRef` cells
+                // (news/2026-08/rw-params-bind-shared-cells.md), so their
+                // compiled bodies relay rw writes on every path. Only the
+                // routine-level lvalue forms below still need the AST.
                 // An lvalue routine (`sub f() is rw/is raw { $var }`, or a
                 // tail `$x.return-rw`) keeps its body: the assignment
                 // machinery extracts the assign target from the AST

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -126,19 +126,21 @@ sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
   raw` params (the interpreter-carrier rw relay — RESOLVED, see below),
   routine-level `is rw`/`is raw` and tail `return-rw` (the lvalue machinery
   extracts the assign target from the AST), and NativeCall traits.
-- **Scalar rw/raw keep-class unblocked (2026-08-06):** scalar `is rw`/`is
+- **Scalar rw/raw keep-class LIFTED (2026-08-06):** scalar `is rw`/`is
   raw` params now bind shared `ContainerRef` cells chained to the caller's
-  container (`news/2026-08/rw-params-bind-shared-cells.md`), and the C6d-4
+  container (`news/2026-08/rw-params-bind-shared-cells.md`), the C6d-4
   gate in `resolution_call_sub.rs` is deleted — rw routines run their
-  compiled bodies through `call_sub_value`. The registration predicate's
-  rw keep-class can now be lifted (flip it to the empty-body default and
-  A/B the usual suite) as its own slice.
+  compiled bodies through `call_sub_value` — and the registration
+  predicate no longer checks `has_rw_scalar_param`
+  (`news/2026-08/rw-param-routines-register-body-less.md`): rw-param
+  routines register body-less like any safe-class def.
 - **C6e-3c (open):** the field itself. `CompiledSubDeclPlan::legacy_body`
-  still carries the AST for the keep-classes above and for the registration
-  fallback; dropping it outright still needs the rw keep-class flip (above),
-  per-slot metadata for signature alternates (they register metadata-less
-  today), and a NativeCall story. Registration-time body use for the safe
-  class is already zero.
+  still carries the AST for the remaining keep-classes (unresolvable plan
+  bytecode, routine-level lvalue forms, NativeCall traits) and for the
+  registration fallback; dropping it outright still needs per-slot
+  metadata for signature alternates (they register metadata-less today)
+  and a NativeCall story. Registration-time body use for the safe class
+  is already zero.
 
 Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
 (the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`


### PR DESCRIPTION
## Summary

The C6e-3b safe-class empty-body registration excluded routines with a scalar `is rw`/`is raw` parameter: their calls were gated onto the interpreter carrier, which executes the AST body. Shared-cell rw binding (#5960) moved those calls onto the compiled path everywhere, so this PR lifts the keep-class — `vm_register_sub_ops.rs`'s registration predicate no longer checks `has_rw_scalar_param`, and a plan-derived rw-param routine registers with an empty body like any other safe-class def.

Remaining C6e-3c keep-classes (ledger updated in `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`): a plan without resolvable bytecode for every declared signature (class-walker nested subs), routine-level lvalue forms (`is rw`/`is raw`/tail `return-rw`), and NativeCall marshalling traits.

## Validation

- rw/wrap/proto/binder t/ batch (274 files) green
- `make test` — 2900 files / 27,553 tests PASS
- local `make roast` (release) — 1435 files / 218,774 tests PASS
- `scripts/battery-testsuite.sh` — GATE PASSED (157/162, baseline unchanged)
- `cargo clippy -- -D warnings` / `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)