### PR TITLE
fix(vm): state in a statement-modifier block body accumulates across iterations

### DIFF
--- a/news/2026-08/state-block-loop-body-accumulates.md
+++ b/news/2026-08/state-block-loop-body-accumulates.md
@@ -1,0 +1,29 @@
+# `state` in a statement-modifier block body accumulates across iterations
+
+```raku
+{ state $n = 0; $n = $n + 1; say $n; } for 1..3;   # raku: 1 2 3 — mutsu printed 1 1 1
+```
+
+Two defects stacked. First, the block-exit cleanup (`exec_block_scope_op` /
+`exec_block_local_scope_op`) treated the `state` declaration as a block-local
+`my`: it Nil'd the slot and dropped the env entry on exit, and the enclosing
+loop's `sync_state_locals_in_range` then persisted that Nil THROUGH the
+shared state cell (#5959's cell storage), so every iteration's
+`StateVarInit` found Nil and the counter restarted. State slots (any slot
+with a `StateVarInit` in the block's range) are now excluded from the exit
+resets — a `state` variable's storage outlives the block by definition.
+
+Second, fixing that exposed an over-broad #5959 suppression: the
+sole-source-block ResetStateLocals skip applied to ANY loop body that is a
+single block, which conflates the statement-modifier form (`{...} for @xs` —
+the block IS the loop body, cloned once, state persists) with a nested bare
+block in a prefix body (`for ^3 { { state ... } }` — re-cloned per
+iteration, state restarts, raku prints 1 1 1). The suppression is now gated
+on `Stmt::For`'s `is_statement_modifier`, so both shapes match raku. The
+non-`for` loop variants lack the flag and keep the old behavior for the
+nested corner — recorded as a residual in
+`todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md`
+alongside the type-constrained-scalar residual.
+
+Pinned by `t/state-block-loop-body.t` (4 cases, verified against raku);
+`t/state-var-per-block-clone.t` test 5 pins the nested re-clone.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1882,9 +1882,7 @@ impl Compiler {
                 mode,
                 rw_block,
                 explicit_zero_params,
-                // Only the placeholder collectors in `ast.rs` care whether this
-                // loop came from the statement-modifier form; codegen is identical.
-                is_statement_modifier: _,
+                is_statement_modifier,
             } => {
                 // `for @a[*] { ... }` — a whole-array Whatever slice iterates the
                 // same elements as `for @a`, including aliasing for write-back
@@ -2162,7 +2160,14 @@ impl Compiler {
                 // `callframe`/`caller` inside sees the enclosing routine one
                 // level further up (see `callframe_block_depth`).
                 self.callframe_block_depth += 1;
-                self.suppress_loop_block_state_reset = Self::loop_body_is_sole_block(&loop_body);
+                // Only the statement-MODIFIER form's sole block is the loop's
+                // own body (cloned once per statement, state persists). A sole
+                // block inside a prefix `for` body (`for ^3 { { state ... } }`)
+                // is a NESTED bare block that re-clones per iteration, so its
+                // per-execution ResetStateLocals must stay (raku prints 1 1 1
+                // there — t/state-var-per-block-clone.t test 5).
+                self.suppress_loop_block_state_reset =
+                    *is_statement_modifier && Self::loop_body_is_sole_block(&loop_body);
                 self.compile_body_with_implicit_try(&loop_body);
                 self.callframe_block_depth -= 1;
                 for n in &newly_registered {

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -212,6 +212,21 @@ impl Interpreter {
                 _ => None,
             })
             .collect();
+        // A `state` declaration inside this branch is NOT a block-local `my`:
+        // its storage (the state store's shared cell) outlives the block, and
+        // the frame-exit `sync_state_locals` persists the slot/env value back
+        // through that cell. Treating it as a fresh block-local wiped it — the
+        // exit cleanup below removed the env entry and Nil'd the slot, so the
+        // sync wrote Nil THROUGH the shared cell and every iteration of
+        // `{ state $n = 0; $n = $n + 1 } for 1..3` restarted from Nil (1 1 1
+        // instead of 1 2 3). Exclude state slots from both cleanups.
+        let state_slots: rustc_hash::FxHashSet<usize> = code.ops[body_start..body_end]
+            .iter()
+            .filter_map(|op| match op {
+                OpCode::StateVarInit(slot, _) => Some(*slot as usize),
+                _ => None,
+            })
+            .collect();
         // Snapshot the env keys present before the branch runs so that on exit
         // we can tell a *fresh* block-local `my` (no outer binding of that name)
         // apart from one that merely *shadows* an existing outer binding (which
@@ -272,6 +287,15 @@ impl Interpreter {
             // `our`/dynamic/package-qualified names have their own scoping and
             // must persist; only plain lexicals were recorded as block-local.
             if env_had_before.contains(sym) {
+                continue;
+            }
+            // A `state` variable's env/slot mirror the shared state cell; see
+            // the `state_slots` comment above.
+            if !state_slots.is_empty()
+                && state_slots
+                    .iter()
+                    .any(|&idx| code.local_sym(idx) == Some(*sym))
+            {
                 continue;
             }
             self.env_mut().remove_sym(*sym);

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -252,6 +252,21 @@ impl Interpreter {
                 _ => None,
             })
             .collect();
+        // A `state` declaration inside this block is NOT a block-local `my`:
+        // its storage (the state store's shared cell) outlives the block, and
+        // an enclosing loop's `sync_state_locals_in_range` persists the
+        // slot/env value back through that cell after the block exits.
+        // Treating it as a fresh block-local Nil'd the slot on exit, so the
+        // sync wrote Nil THROUGH the shared cell and every iteration of
+        // `{ state $n = 0; $n = $n + 1 } for 1..3` restarted from Nil
+        // (1 1 1 instead of 1 2 3). Exclude state slots from the exit resets.
+        let state_slots: rustc_hash::FxHashSet<usize> = code.ops[pre_start..end]
+            .iter()
+            .filter_map(|op| match op {
+                OpCode::StateVarInit(slot, _) => Some(*slot as usize),
+                _ => None,
+            })
+            .collect();
         let routine_snapshot = self.snapshot_routine_registry();
         let saved_env = self.env().clone();
         // Under shadow slots (default) the block exit uses a targeted Nil-reset of
@@ -511,7 +526,7 @@ impl Interpreter {
                     || code
                         .local_sym(idx)
                         .is_some_and(|s| block_declared.contains(&s));
-                if non_propagating {
+                if non_propagating && !state_slots.contains(&idx) {
                     self.locals[idx] = saved.get(idx).cloned().unwrap_or(Value::NIL);
                 }
             }
@@ -535,7 +550,7 @@ impl Interpreter {
                     .local_sym(idx)
                     .is_some_and(|s| block_declared.contains(&s));
                 let non_propagating = name == "_" || name.starts_with('*') || is_block_declared;
-                if non_propagating {
+                if non_propagating && !state_slots.contains(&idx) {
                     if is_block_declared {
                         if owned_slots.contains(&idx) {
                             self.locals[idx] = Value::NIL;

--- a/t/state-block-loop-body.t
+++ b/t/state-block-loop-body.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# A block used as a loop body via the statement-modifier form is cloned once
+# per loop statement, so its `state` persists across iterations; a bare block
+# NESTED in a prefix loop body re-clones per iteration, so its `state`
+# restarts. The modifier form used to lose every write (1 1 1) because the
+# block-exit cleanup treated the state slot as a block-local `my` and the
+# loop's state sync then wrote Nil through the shared cell. Expected values
+# verified against raku.
+
+plan 4;
+
+my @a;
+{ state $n = 0; $n = $n + 1; @a.push($n); } for 1..3;
+is @a.join(','), '1,2,3', 'statement-modifier block body: plain = accumulates';
+
+my @b;
+{ state $n = 0; $n++; @b.push($n); } for 1..3;
+is @b.join(','), '1,2,3', 'statement-modifier block body: ++ accumulates';
+
+my @c;
+for 1..3 { { state $n = 0; $n++; @c.push($n); } }
+is @c.join(','), '1,1,1', 'a nested bare block re-clones per iteration';
+
+my @d;
+{ my $m = 10; state $n = 0; $n++; @d.push($n + $m); } for 1..2;
+is @d.join(','), '11,12', 'state accumulates while a sibling my stays block-local';
+
+done-testing;

--- a/todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md
+++ b/todo/tickets/state-scalar-plain-assignment-is-lost-across-calls.md
@@ -1,15 +1,19 @@
-# `state` in a block used as a loop body loses every write (residual)
+# Type-constrained state scalars lose plain-`=` writes (residual)
 
-UPDATE 2026-08-06: the original headline symptom — a `state` scalar written
-with plain `=` in a routine losing the write between calls — is FIXED:
-`state` scalars now live in a `ContainerRef` cell exactly like `state`
-aggregates already did (`StateVarInit`'s scalar branch; the "box-on-capture
-will share them" assumption only covered captured scalars). Slot, env and
-the state store share one cell, so the write-through reaches every reader
-and the exit persist stores the same cell. Pinned by
-`t/state-scalar-plain-assignment.t` (plain `=`, `+=`, `~=`, implicit/
-explicit return, plain read after write, `++`, and the per-clone nested
-named sub semantics).
+UPDATE 2026-08-06 (2): the block-as-loop-body residual is FIXED — the
+block-exit cleanup no longer treats a `state` slot as a block-local `my`
+(its storage outlives the block; the loop's `sync_state_locals_in_range`
+was writing Nil through the shared cell), and the #5959 sole-block
+ResetStateLocals suppression is now gated on `Stmt::For`'s
+`is_statement_modifier` so a nested bare block in a prefix `for` body
+still re-clones per iteration (raku: 1 1 1). Pinned by
+`t/state-block-loop-body.t`; details in
+`news/2026-08/state-block-loop-body-accumulates.md`.
+
+UPDATE 2026-08-06 (1): the original headline symptom — a `state` scalar
+written with plain `=` in a routine losing the write between calls — was
+fixed by StateVarInit's shared-cell storage (#5959), pinned by
+`t/state-scalar-plain-assignment.t`.
 
 ## Residual: type-constrained state scalars
 
@@ -21,40 +25,14 @@ the assignment chokepoint so the constraint re-checks (and a
 element-assignment path — Digest's SHA2 `(state buf32 $w .= new)[$j] = …`,
 pinned by t/digest-battery.t). Fixing typed scalars needs either
 constraint-checking write-through on the cell, or the exit-persist rule
-rework the original ticket described. (The expression-position typed state
-decl also failed to register its constraint at all — fixed: the
-`(state buf32 $w …)` expr branch now emits `SetVarType` like the statement
-form.)
+rework the original ticket described.
 
-## Residual: the block-as-loop-body form
+## Residual: nested-block state in non-`for` loops
 
-```
-$ raku  -e '{ state $n = 0; $n = $n + 1; say $n; } for 1..3;'   # 1 2 3
-$ mutsu -e '{ state $n = 0; $n = $n + 1; say $n; } for 1..3;'   # 1 1 1
-$ mutsu -e '{ state $n = 0; $n++;        say $n; } for 1..3;'   # 1 1 1 (also wrong)
-```
-
-Two distinct causes, one fixed:
-
-1. **(fixed)** the statement-modifier form parses as `For { body: [Block(...)] }`
-   and the `Stmt::Block` arm emitted a per-execution `ResetStateLocals` INSIDE
-   the loop body — the state store was wiped every iteration. The loop compile
-   sites now set `Compiler::suppress_loop_block_state_reset` when the loop body
-   is a sole source block (`loop_body_is_sole_block`), because that block IS
-   the loop's body: cloned once per loop statement, its iterations share the
-   clone (the loop-entry `reset_state_locals_in_range` still restarts the
-   state when the loop STATEMENT re-executes).
-2. **(open)** even without the reset, the write inside the block never reaches
-   the state cell: gdb shows the per-iteration `StateVarInit` finds the stored
-   cell still holding the initializer. Operator-independent (`=` and `++`
-   both), so the block's scope machinery (BlockLocalScope env overlay) is
-   shadowing the cell — the assignment writes a block-scoped plain copy
-   instead of through the cell, and the block-exit scope restore discards it.
-   The inline statement form (`for 1..3 { state $n = 0; ... }`, no Block
-   wrapper) is correct, which isolates the defect to the Block-in-loop-body
-   scope path.
-
-Where to look: `exec_block_local_scope_op` (vm_exec_dispatch /
-vm_misc_scope) — how a block-scoped env overlay treats a name whose outer
-binding is a `ContainerRef` state cell; the write should go through the
-cell, not insert a shadowing plain value.
+`Stmt::While` (and the C-style/repeat arms) carry no
+`is_statement_modifier` flag (44 construction sites), so their
+sole-block suppression from #5959 still applies to a NESTED bare block:
+`while $c { { state $n = 0; ... } }` persists state across iterations
+where raku restarts it. The `for` twin is fixed (flag exists on
+`Stmt::For`); fixing these needs the flag added to the other loop
+statement variants or a parser-side marker on the body block.


### PR DESCRIPTION
## Summary

```raku
{ state $n = 0; $n = $n + 1; say $n; } for 1..3;   # raku: 1 2 3 — mutsu printed 1 1 1
```

Two stacked defects (the open residual in the state-scalar ticket):

1. **Block-exit cleanup corrupted the state cell.** `exec_block_scope_op` / `exec_block_local_scope_op` treated the `state` declaration as a block-local `my` — Nil'd the slot and dropped the env entry on exit — and the enclosing loop's `sync_state_locals_in_range` then persisted that Nil **through** the shared state cell (#5959's cell storage), so every iteration's `StateVarInit` found Nil. State slots (any slot with a `StateVarInit` in the block's range) are now excluded from the exit resets: a `state` variable's storage outlives the block by definition.

2. **The #5959 sole-block suppression was over-broad.** It applied to ANY single-block loop body, conflating the statement-modifier form (`{...} for @xs` — the block IS the loop body, state persists) with a nested bare block in a prefix body (`for ^3 { { state ... } }` — re-clones per iteration, raku prints 1 1 1; pinned by `t/state-var-per-block-clone.t` test 5, which caught this). The suppression is now gated on `Stmt::For`'s `is_statement_modifier`.

Residuals recorded in the ticket: type-constrained state scalars (unchanged), and the nested-block corner for non-`for` loops (`Stmt::While` etc. carry no modifier flag — 44 construction sites, its own slice).

## Validation

- `t/state-block-loop-body.t` — new pin (4 cases, verified against raku)
- state/scope/loop t/ batch (207 files / 1,637 tests) green
- `make test` — 2903 files / 27,569 tests PASS
- local `make roast` (release) — 1435 files / 218,774 tests PASS
- `scripts/battery-testsuite.sh` — GATE PASSED (157/162, baseline unchanged)
- `cargo clippy -- -D warnings` / `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)