### PR TITLE
feat(vm): lvalue routines register body-less via plan-recorded tails (C6e-3c)

### DIFF
--- a/news/2026-08/lvalue-tail-from-plan-metadata.md
+++ b/news/2026-08/lvalue-tail-from-plan-metadata.md
@@ -1,0 +1,28 @@
+# Lvalue routines register body-less; the assign tail comes from plan metadata
+
+The last C6e-3b keep-class with a landable story: a routine-level
+`is rw`/`is raw` routine (or one whose tail is an explicit `return-rw`)
+kept its AST body because the assignment machinery
+(`assign_named_sub_lvalue_with_values`) re-extracted the assign target of
+`f() = v` from the body's last expression (`rw_sub_target_expr`).
+
+The plan now records that tail at lowering
+(`CompiledRoutineMetadata::rw_tail_expr`, an `Arc<Expr>` present only for
+the lvalue shapes), registration seeds it into the new
+`FunctionDef::rw_tail_expr`, and the assign path prefers the seeded expr
+with the body walk as the metadata-less fallback. A body-less routine code
+object reaching the callable-value assign path delegates to the named path
+(its installed def carries the tail). With that, the registration
+predicate's `is_rw`/`is_raw`/`return-rw` conditions are gone — lvalue
+routines register with an empty body like every other safe-class def.
+
+The C6e-3c cut-line is now down to: a plan without resolvable bytecode for
+every declared signature (class-walker nested subs), and NativeCall
+marshalling traits (measured non-vendorable;
+`todo/deep/nativecall-cannot-be-vendored.md`).
+
+Found on the way (pre-existing, verified on v0.20.0): an lvalue sub whose
+tail is an array ELEMENT (`sub elem() is rw { @a[1] }`) is not assignable —
+`todo/tickets/lvalue-sub-element-tail-not-assignable.md`.
+
+Pinned by `t/lvalue-sub-plan-tail.t` (verified against raku).

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -214,6 +214,14 @@ pub(crate) struct FunctionDef {
     /// `Interpreter::routine_body_facts`. Derived state, like `body_fp_cache`.
     #[serde(skip)]
     pub(crate) body_facts_cache: std::sync::OnceLock<RoutineBodyFacts>,
+    /// The lvalue-assignment target of a routine-level `is rw`/`is raw`
+    /// routine (or an explicit tail `return-rw $var`), seeded from the plan's
+    /// `CompiledRoutineMetadata::rw_tail_expr` at registration. The assign
+    /// machinery (`assign_named_sub_lvalue_with_values`) prefers this over
+    /// re-extracting the tail from `body`, which a body-less plan-derived
+    /// def cannot serve (ADR-0019 C6e-3c lvalue keep-class).
+    #[serde(skip)]
+    pub(crate) rw_tail_expr: Option<std::sync::Arc<Expr>>,
 }
 
 /// Properties of a routine body that the on-the-fly compilation gates ask about.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2044,6 +2044,14 @@ pub(crate) struct CompiledRoutineMetadata {
     /// judgment must come from the declaration, not from the (possibly
     /// dropped) `legacy_body` payload (C6e-3).
     pub(crate) body_is_empty: bool,
+    /// The lvalue-assignment target of a routine-level `is rw`/`is raw`
+    /// routine (or one whose tail is an explicit `return-rw`): the last
+    /// expression statement of the declared body, which the assignment
+    /// machinery (`assign_named_sub_lvalue_with_values`) evaluates as the
+    /// target of `f() = v`. Recorded at plan lowering so the assign path no
+    /// longer needs the AST body — the lvalue keep-class of the C6e-3c
+    /// `legacy_body` drop. `None` for ordinary routines.
+    pub(crate) rw_tail_expr: Option<std::sync::Arc<Expr>>,
 }
 
 /// Registration metadata for one declared signature of a sub declaration,
@@ -2055,7 +2063,17 @@ fn compiled_routine_metadata(
     params: &[String],
     param_defs: &[ParamDef],
     body: &[Stmt],
+    is_rw: bool,
+    is_raw: bool,
 ) -> CompiledRoutineMetadata {
+    // The lvalue-assignment tail (see the field doc): recorded for an
+    // `is rw`/`is raw` routine, or for any routine whose last expression is
+    // an explicit `return-rw $var` (assignable without the routine trait).
+    let rw_tail_expr = crate::runtime::Interpreter::rw_sub_target_expr(body)
+        .filter(|tail| {
+            is_rw || is_raw || crate::runtime::Interpreter::is_explicit_return_rw_target(tail)
+        })
+        .map(std::sync::Arc::new);
     let (uses_positional, uses_named) = if params.is_empty() && param_defs.is_empty() {
         let body_shape = format!("{body:?}");
         (
@@ -2103,6 +2121,7 @@ fn compiled_routine_metadata(
         ),
         body_is_empty: body.is_empty(),
         effective_param_defs,
+        rw_tail_expr,
     }
 }
 
@@ -5176,11 +5195,11 @@ impl CompiledCode {
                 *is_raw,
             )
         });
-        let routine_metadata = compiled_routine_metadata(params, param_defs, body);
+        let routine_metadata = compiled_routine_metadata(params, param_defs, body, *is_rw, *is_raw);
         let alternate_metadata = signature_alternates
             .iter()
             .map(|(alt_params, alt_param_defs)| {
-                compiled_routine_metadata(alt_params, alt_param_defs, body)
+                compiled_routine_metadata(alt_params, alt_param_defs, body, *is_rw, *is_raw)
             })
             .collect();
         debug_assert_eq!(name_chunk.is_some(), name_expr.is_some());

--- a/src/runtime/builtins_lvalue.rs
+++ b/src/runtime/builtins_lvalue.rs
@@ -446,7 +446,15 @@ impl Interpreter {
         }
 
         if let Some(def) = self.resolve_function_with_alias(name, &call_args) {
-            if let Some(target_expr) = Self::rw_sub_target_expr(&def.body) {
+            // Prefer the plan-recorded lvalue tail (a body-less plan-derived
+            // def has no AST body to extract it from — ADR-0019 C6e-3c);
+            // fall back to the body walk for metadata-less defs.
+            let tail = def
+                .rw_tail_expr
+                .as_deref()
+                .cloned()
+                .or_else(|| Self::rw_sub_target_expr(&def.body));
+            if let Some(target_expr) = tail {
                 let allow_target_assign =
                     def.is_rw || Self::is_explicit_return_rw_target(&target_expr);
                 if allow_target_assign {
@@ -496,6 +504,18 @@ impl Interpreter {
             }
             ValueView::Sub(data) => {
                 let data = data.clone();
+                // A body-less routine code object (ADR-0019 C6e-3b registers
+                // safe-class defs with an empty AST body) carries no tail to
+                // extract; its installed def does (`rw_tail_expr`). Delegate
+                // to the named path, which reads the def.
+                if data.body.is_empty() && data.compiled_routine.is_some() && !data.name.is_empty()
+                {
+                    return self.assign_named_sub_lvalue_with_values(
+                        &data.name.resolve(),
+                        call_args,
+                        value,
+                    );
+                }
                 if let Some(target_expr) = Self::rw_sub_target_expr(&data.body) {
                     let allow_target_assign =
                         data.is_rw || Self::is_explicit_return_rw_target(&target_expr);

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -300,6 +300,7 @@ impl Interpreter {
             compiled: None,
             body_fp_cache: std::sync::OnceLock::new(),
             body_facts_cache: std::sync::OnceLock::new(),
+            rw_tail_expr: None,
         };
         self.registry_mut()
             .proto_methods

--- a/src/runtime/registration_class_body_method.rs
+++ b/src/runtime/registration_class_body_method.rs
@@ -366,6 +366,7 @@ impl Interpreter {
                 compiled: None,
                 body_fp_cache: std::sync::OnceLock::new(),
                 body_facts_cache: std::sync::OnceLock::new(),
+                rw_tail_expr: None,
             };
             self.registry_mut().functions.insert(
                 Symbol::intern(&qualified_name),
@@ -399,6 +400,7 @@ impl Interpreter {
                 compiled: None,
                 body_fp_cache: std::sync::OnceLock::new(),
                 body_facts_cache: std::sync::OnceLock::new(),
+                rw_tail_expr: None,
             };
             // Register under the short name (lexical scope)
             self.registry_mut().functions.insert(

--- a/src/runtime/registration_class_body_method_forms.rs
+++ b/src/runtime/registration_class_body_method_forms.rs
@@ -171,6 +171,7 @@ impl Interpreter {
             compiled: None,
             body_fp_cache: std::sync::OnceLock::new(),
             body_facts_cache: std::sync::OnceLock::new(),
+            rw_tail_expr: None,
         };
         // Register as a typed multi candidate under the class package, mirroring
         // the `multi sub` registration keys so `import` copies it and operator

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1019,6 +1019,10 @@ impl Interpreter {
                 }
                 cell
             },
+            // Seed the lvalue tail from the plan; a metadata-less caller keeps
+            // None and the assign path falls back to extracting it from the
+            // (real, non-plan) body.
+            rw_tail_expr: metadata.and_then(|m| m.rw_tail_expr.clone()),
         };
         // The seeded values must equal what the lazy fill would compute while
         // the body is still attached — a divergence here would silently change
@@ -1604,6 +1608,7 @@ impl Interpreter {
             compiled: None,
             body_fp_cache: std::sync::OnceLock::new(),
             body_facts_cache: std::sync::OnceLock::new(),
+            rw_tail_expr: None,
         };
         self.insert_token_def(name, def, multi);
     }
@@ -1677,6 +1682,7 @@ impl Interpreter {
                 compiled: None,
                 body_fp_cache: std::sync::OnceLock::new(),
                 body_facts_cache: std::sync::OnceLock::new(),
+                rw_tail_expr: None,
             }),
         );
         Ok(())
@@ -1790,6 +1796,7 @@ impl Interpreter {
             compiled: None,
             body_fp_cache: std::sync::OnceLock::new(),
             body_facts_cache: std::sync::OnceLock::new(),
+            rw_tail_expr: None,
         };
         let single_key = format!("GLOBAL::{}", name);
         let single_key_sym = Symbol::intern(&single_key);
@@ -1937,6 +1944,7 @@ impl Interpreter {
                 compiled: None,
                 body_fp_cache: std::sync::OnceLock::new(),
                 body_facts_cache: std::sync::OnceLock::new(),
+                rw_tail_expr: None,
             }),
         );
         Ok(())

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -255,19 +255,13 @@ impl Interpreter {
                 // carries keys its executing table does not hold, and a def
                 // with neither body nor bytecode cannot run.
                 && primary_compiled.is_some()
-                // Scalar `is rw`/`is raw` PARAMS no longer keep the body: the
-                // binder aliases them through shared `ContainerRef` cells
-                // (news/2026-08/rw-params-bind-shared-cells.md), so their
-                // compiled bodies relay rw writes on every path. Only the
-                // routine-level lvalue forms below still need the AST.
-                // An lvalue routine (`sub f() is rw/is raw { $var }`, or a
-                // tail `$x.return-rw`) keeps its body: the assignment
-                // machinery extracts the assign target from the AST
-                // (`rw_sub_target_expr` / `is_explicit_return_rw_target`).
-                && !*is_rw
-                && !*is_raw
-                && !Self::rw_sub_target_expr(body)
-                    .is_some_and(|e| Self::is_explicit_return_rw_target(&e))
+            // Scalar `is rw`/`is raw` PARAMS don't keep the body (the binder
+            // aliases them through shared `ContainerRef` cells,
+            // news/2026-08/rw-params-bind-shared-cells.md), and neither do
+            // routine-level lvalue forms anymore: the plan records the
+            // assign-target tail (`CompiledRoutineMetadata::rw_tail_expr`)
+            // and the assign machinery reads it off the installed def, so
+            // `rw_sub_target_expr` no longer needs the AST body.
             {
                 &empty_body
             } else {

--- a/t/lvalue-sub-plan-tail.t
+++ b/t/lvalue-sub-plan-tail.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# An lvalue routine's assign target now comes from plan metadata
+# (CompiledRoutineMetadata::rw_tail_expr), not from re-extracting the tail
+# of the AST body — such routines register body-less like every other
+# safe-class def (ADR-0019 C6e-3c lvalue keep-class). Expected values
+# verified against raku.
+
+plan 4;
+
+my $var = 1;
+sub f() is rw { $var }
+f() = 5;
+is $var, 5, "is rw routine assigns through its tail variable";
+
+my $w = 1;
+sub g() is rw { $w }
+my &c = &g;
+c() = 7;
+is $w, 7, "is rw routine called as a code object assigns too";
+
+my $m = 1;
+sub h() { $m.return-rw }
+h() = 9;
+is $m, 9, "an explicit .return-rw tail is assignable without the trait";
+
+sub plain() { 42 }
+my $err = False;
+try { plain() = 1; } // ($err = True);
+ok $!.defined || $err, "assigning a non-rw routine still dies";
+
+# NOTE: an ELEMENT tail (`sub elem() is rw { @a[1] }; elem() = 99`) is a
+# pre-existing gap (X::Assignment::RO on v0.20.0 too) — see
+# todo/tickets/lvalue-sub-element-tail-not-assignable.md.
+
+done-testing;

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -144,12 +144,18 @@ sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
   (`news/2026-08/sig-alternates-register-with-metadata.md`). The C6e-3a
   debug asserts cover the per-slot values wherever a body is still
   attached.
+- **Lvalue keep-class LIFTED (2026-08-06):** the plan records the
+  assign-target tail at lowering (`CompiledRoutineMetadata::rw_tail_expr`),
+  registration seeds `FunctionDef::rw_tail_expr`, and the assign machinery
+  prefers it over the body walk (body-less code objects delegate to the
+  named path) — so routine-level `is rw`/`is raw`/tail-`return-rw` routines
+  register body-less (`news/2026-08/lvalue-tail-from-plan-metadata.md`).
 - **C6e-3c (open):** the field itself. `CompiledSubDeclPlan::legacy_body`
   still carries the AST for the remaining keep-classes (unresolvable plan
-  bytecode, routine-level lvalue forms, NativeCall traits) and for the
-  registration fallback; dropping it outright still needs a story for
-  those classes. Registration-time body use for the safe class is
-  already zero.
+  bytecode — class-walker nested subs — and NativeCall marshalling traits,
+  measured non-vendorable) and for the registration fallback; dropping it
+  outright still needs a story for those two. Registration-time body use
+  for the safe class is already zero.
 
 Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
 (the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`

--- a/todo/tickets/lvalue-sub-element-tail-not-assignable.md
+++ b/todo/tickets/lvalue-sub-element-tail-not-assignable.md
@@ -1,0 +1,25 @@
+# An lvalue sub whose tail is an array element is not assignable
+
+```raku
+my @a = 1, 2, 3;
+sub elem() is rw { @a[1] }
+elem() = 99;
+say @a;   # raku: [1 99 3] — mutsu: X::Assignment::RO: sub 'elem' is not rw
+```
+
+Pre-existing (verified on the v0.20.0 release binary, 2026-08-06, while
+landing the plan-recorded lvalue tail — not a regression from that change).
+The assign machinery (`assign_named_sub_lvalue_with_values`) extracts the
+routine's tail expression and hands it to `assign_rw_target_expr`, which
+handles a plain `Expr::Var` tail but fails for an `Expr::Index` tail
+(`@a[1]`), falling through to the "sub is not rw" error. A scalar-variable
+tail (`sub f() is rw { $var }`) works.
+
+Fix direction: `assign_rw_target_expr` should assign an Index tail through
+the ordinary index-assignment path (the same lvalue evaluation `@a[1] = v`
+compiles to), evaluated in the caller's env like the Var case. Note the
+tail expr now also arrives via `CompiledRoutineMetadata::rw_tail_expr`
+(`news/2026-08/lvalue-tail-from-plan-metadata.md`), so the fix lives purely
+in the assign path, not in registration.
+
+Pin to enable: the commented case in `t/lvalue-sub-plan-tail.t`.


### PR DESCRIPTION
## Summary

The last C6e-3b keep-class with a landable story: a routine-level `is rw`/`is raw` routine (or one whose tail is an explicit `return-rw`) kept its AST body because the assignment machinery (`assign_named_sub_lvalue_with_values`) re-extracted the assign target of `f() = v` from the body's last expression (`rw_sub_target_expr`).

The plan now records that tail at lowering (`CompiledRoutineMetadata::rw_tail_expr`, an `Arc<Expr>` present only for the lvalue shapes), registration seeds the new `FunctionDef::rw_tail_expr`, and the assign path prefers the seeded expr with the body walk as the metadata-less fallback. A body-less routine code object reaching the callable-value assign path delegates to the named path (its installed def carries the tail). With that, the registration predicate's `is_rw`/`is_raw`/`return-rw` conditions are deleted — lvalue routines register with an empty body like every other safe-class def.

The C6e-3c cut-line (ledger updated) is now down to: unresolvable plan bytecode (class-walker nested subs) and NativeCall marshalling traits (measured non-vendorable).

Found on the way, pre-existing on v0.20.0: an lvalue sub whose tail is an array ELEMENT is not assignable — filed as `todo/tickets/lvalue-sub-element-tail-not-assignable.md`.

## Validation

- `t/lvalue-sub-plan-tail.t` — new pin (4 cases, verified against raku)
- lvalue/rw/proxy/assign t/ batch (165 files / 1,507 tests) green
- `make test` — 2904 files / 27,584 tests PASS
- local `make roast` (release) — 1435 files / 218,774 tests PASS
- `scripts/battery-testsuite.sh` — GATE PASSED (157/162, baseline unchanged)
- `cargo clippy -- -D warnings` / `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)