### PR TITLE
fix(runtime): EVAL'd named-sub value calls use runtime arity messages; named regex captures don't leak Nil for a zero-width optional atom

### DIFF
--- a/news/2026-08/eval-named-sub-value-call-arity-message.md
+++ b/news/2026-08/eval-named-sub-value-call-arity-message.md
@@ -1,0 +1,47 @@
+# A dynamically-called EVAL'd named sub reports a runtime arity error, not a compile-time one
+
+Found via `Template::Mojo` 0.2.2 (`t/00-basic.rakutest` test 16,
+`todo/tickets/template-mojo-residual-failures.md`), whose generated template
+`sub` is built as source text, `EVAL`'d, stored in a lexical, and invoked
+through that lexical:
+
+```raku
+sub build() {
+    EVAL 'sub t { $^a + $^b }';
+}
+my &f = build();
+f(23);
+```
+
+raku: `Too few positionals passed; expected 2 arguments but got 1` — a plain
+runtime message, since a value call through `&f` is never
+compile-time-diagnosable. mutsu instead reported `Calling t(Int) will never
+work with declared signature ()` — the phrasing reserved for a
+statically-resolved bare call — with an empty `()` signature to boot, since
+placeholder-derived params never populate `param_defs`.
+
+Two independent bugs, both in the path a named sub with only implicit
+`^`-twigil placeholder params (`$^a`, `$^b`) takes when it has no cached
+compiled bytecode (the `EVAL`'d case) and is called through a value rather
+than a static name:
+
+1. `src/vm/vm_dispatch_helpers.rs`'s "compile on-the-fly" branch of
+   `vm_call_on_value` never set `suppress_binding_error_enhance`, unlike its
+   sibling `compiled_routine` branch just above it — even though the same
+   "a value call is never compile-time-diagnosable" reasoning applies. Fixed
+   by setting the flag there too.
+2. The legacy placeholder binder this call falls into
+   (`bind_function_args_values` in `src/runtime/types/binding_signature.rs`)
+   had its own message bug once the wrapper was gone: its too-few message
+   read "Missing required implicit placeholder parameter $^b" instead of
+   raku's `Too few positionals passed; expected N arguments but got M`. Fixed
+   to match.
+
+raku also rejects too-many positionals for this shape (mutsu still silently
+absorbs them into `@_`), but that half was deliberately left as-is — see
+`todo/tickets/template-mojo-residual-failures.md` for why a general fix was
+tried and reverted (it regressed `t/placeholder.t`'s `mixed-placeholder`
+test, which relies on exactly this leniency for a placeholder sub whose body
+also references bare `@_`/`%_`).
+
+Regression test: `t/eval-named-sub-placeholder-arity.t`.

--- a/news/2026-08/regex-token-named-optional-atom-empty-match-not-nil.md
+++ b/news/2026-08/regex-token-named-optional-atom-empty-match-not-nil.md
@@ -1,0 +1,47 @@
+# A `?`-quantified named token now yields an empty Match, not Nil, when it takes zero reps
+
+Found via `Template::Mojo` 0.2.2 (`t/03-capture.rakutest`,
+`todo/tickets/template-mojo-residual-failures.md`), whose `perlline` grammar
+token is `^^ \h* '%' $<get-result>=['=']? $<expr>=[...] [\n | $]`. When the
+optional `=` did not appear, mutsu's `$<get-result>` was `Nil`; raku's is a
+defined, empty `Match`:
+
+```raku
+if "b" ~~ / $<x>=[<[cd]>]? "b" / {
+    say $<x>.WHAT;   # raku: (Match)   mutsu (before): Nil
+}
+```
+
+Whether an unmatched optional named capture is `Nil` or an empty `Match`
+turns out to depend on *where* the `?` sits, verified case-by-case against
+`raku`:
+
+- `$<x>=[...]?` / `$<x>=<[...]>?` — the `?` quantifies the same token the
+  name is attached to. The token "runs" as a unit even on its zero branch, so
+  `$<x>` is a defined, zero-width `Match`.
+- `(x)?` / `$<x>=(...)?` — the `?` quantifies a `CaptureGroup` atom. Raku
+  still yields `Nil` here even when the capturing group itself carries the
+  name — the capturing-group case is special-cased differently from every
+  other atom kind.
+
+mutsu's regex engine (`src/runtime/regex/regex_match_core.rs`,
+`RegexQuant::ZeroOrOne`) has three "zero repetitions won" branches (ratchet,
+frugal, and the default greedy fallback), and none of them applied the
+token's own `$<name>=` alias — only the loop over actually-matched candidates
+did. Fixed by calling the existing `store_apply_named_capture` helper with a
+zero-width span (`pos, pos`) in all three zero branches, gated on the atom
+not being a `CaptureGroup` (which keeps the `(x)?`/`$<x>=(...)?` case `Nil`,
+matching raku). `store_apply_named_capture` was already a no-op for tokens
+with no `named_capture`, so this is safe to call unconditionally for
+non-`CaptureGroup` atoms.
+
+Chasing this down the `Template::Mojo` test surfaced a second, unrelated
+pre-existing bug: `$<name>` for a capture *absent from the current match's
+own pattern* was falling back to a stale value from an earlier match in the
+same scope instead of `Nil`. That is now tracked separately —
+`todo/tickets/named-capture-absent-from-current-match-leaks-stale-value.md` —
+since it's a different lookup path (this fix is about names *present* in the
+pattern that matched zero times, not names absent from the pattern
+entirely).
+
+Regression test: `t/regex-optional-named-capture-nil-vs-match.t`.

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -543,6 +543,16 @@ impl Interpreter {
                 // `collect_nested_list_quantified_names`).
                 let mut zo_list_names = HashSet::new();
                 Self::collect_nested_list_quantified_names(&token.atom, &mut zo_list_names);
+                // A name assigned directly to *this* token (`$<x>=[...]?`,
+                // `$<x>=<[cd]>?`) always "runs" as a unit even when the `?`
+                // takes its zero branch, so it renders as an empty (zero-width)
+                // Match — unlike a name on a *capturing-group* atom
+                // (`$<x>=(...)?`), where Raku still yields Nil for zero reps
+                // (verified against `raku`: the CaptureGroup case differs from
+                // every other atom kind). `store_apply_named_capture` is a
+                // no-op when `token.named_capture` is unset, so this is safe
+                // to call unconditionally for non-CaptureGroup atoms.
+                let named_zero_capture = !matches!(token.atom, RegexAtom::CaptureGroup(_));
                 let mut candidates = self.regex_match_atom_all_with_capture_in_pkg(
                     &token.atom,
                     ctx.chars,
@@ -556,6 +566,9 @@ impl Interpreter {
                         // Atom didn't match — commit to "zero" (no match).
                         let m = store.mark();
                         store.reserve_nil(zo_stride);
+                        if named_zero_capture {
+                            Self::store_apply_named_capture(store, token, pos, pos, pos_base);
+                        }
                         for n in &zo_list_names {
                             store.insert_named_quantified(n.clone());
                         }
@@ -569,6 +582,9 @@ impl Interpreter {
                     // Frugal: prefer zero matches — try zero first.
                     let m = store.mark();
                     store.reserve_nil(zo_stride);
+                    if named_zero_capture {
+                        Self::store_apply_named_capture(store, token, pos, pos, pos_base);
+                    }
                     for n in &zo_list_names {
                         store.insert_named_quantified(n.clone());
                     }
@@ -593,6 +609,9 @@ impl Interpreter {
                     // Greedy: the zero candidate is tried last.
                     let m = store.mark();
                     store.reserve_nil(zo_stride);
+                    if named_zero_capture {
+                        Self::store_apply_named_capture(store, token, pos, pos, pos_base);
+                    }
                     for n in &zo_list_names {
                         store.insert_named_quantified(n.clone());
                     }

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -367,6 +367,30 @@ impl Interpreter {
                 .collect();
             let mut consumed_named: rustc_hash::FxHashSet<String> =
                 rustc_hash::FxHashSet::default();
+            // Used only for the "too few positionals" message below (Raku's
+            // wording, not this legacy binder's own). A "too many" check is
+            // deliberately NOT added here: a `^`-twigil placeholder sub whose
+            // body also references bare `@_`/`%_` legitimately accepts more
+            // positionals than its placeholders alone (leftovers flow into
+            // `@_`, see the unconditional insert below) -- e.g.
+            // `sub f { [@_[0], @^arr.elems] }` -- and nothing in `params`
+            // distinguishes that shape from one that should reject extras
+            // (todo/tickets/template-mojo-residual-failures.md discusses the
+            // one-sided fix that was tried and reverted here: it required
+            // reserving a synthetic `params` entry, which leaks into the
+            // ~80 other call sites that read a Sub's raw `params`, e.g.
+            // multi-dispatch candidate arity matching in
+            // `methods_signature_candidates.rs`).
+            let required_positional_count = params
+                .iter()
+                .filter(|p| {
+                    let named_key = p
+                        .strip_prefix(':')
+                        .or_else(|| p.strip_prefix("@:"))
+                        .or_else(|| p.strip_prefix("%:"));
+                    named_key.is_none()
+                })
+                .count();
             let mut positional_idx = 0usize;
             for param in params.iter() {
                 // Named placeholder: $:f, @:f, %:f -- match by Pair key
@@ -416,8 +440,9 @@ impl Interpreter {
                     || param.starts_with("&^")
                 {
                     return Err(RuntimeError::new(format!(
-                        "Missing required implicit placeholder parameter ${}",
-                        param
+                        "Too few positionals passed; expected {} arguments but got {}",
+                        required_positional_count,
+                        positional_args.len()
                     )));
                 }
             }

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -528,6 +528,12 @@ impl Interpreter {
             let data = data.clone();
             let empty_fns = CompiledFns::default();
             let fns = compiled_fns.unwrap_or(&empty_fns);
+            // A value call is never compile-time-diagnosable, same reasoning as
+            // the `compiled_routine` branch above: a named sub (e.g. from EVAL)
+            // dispatched through a value must keep a binding failure's runtime
+            // identity instead of the "will never work with declared signature"
+            // wrap, which is meant for statically-resolved bare calls.
+            self.suppress_binding_error_enhance = true;
             return self.call_compiled_closure(&data, &cc, args, fns);
         }
 

--- a/t/eval-named-sub-placeholder-arity.t
+++ b/t/eval-named-sub-placeholder-arity.t
@@ -1,0 +1,40 @@
+use Test;
+
+# A named sub built via EVAL (`sub t { $^a + $^b }`), stored in a lexical and
+# called as a value, is a runtime call -- not compile-time-diagnosable -- so
+# an arity mismatch must surface raku's plain runtime message, not the
+# "Calling ... will never work with declared signature ..." wrapper (which is
+# for statically-resolved bare calls). Found via Template::Mojo, whose
+# generated template sub is exactly this shape.
+# (todo/tickets/template-mojo-residual-failures.md)
+#
+# Only the too-few case is covered here. Raku also rejects too-many
+# positionals for this shape, but mutsu deliberately does not enforce that:
+# a `^`-twigil placeholder sub whose body also references bare `@_`/`%_`
+# legitimately accepts extra positionals in Raku (they flow into `@_`), and
+# nothing in mutsu's raw `params` list distinguishes that shape from one that
+# should reject extras -- see the comment above `required_positional_count`
+# in `src/runtime/types/binding_signature.rs` for why a targeted fix was
+# tried and reverted.
+
+use MONKEY-SEE-NO-EVAL;
+
+plan 2;
+
+sub build() {
+    EVAL 'sub t { $^a + $^b }';
+}
+
+sub call-with(*@args) {
+    my &f = build();
+    my $err = '';
+    {
+        f(|@args);
+        CATCH { default { $err = .Str } }
+    }
+    $err;
+}
+
+my $too-few = call-with(23);
+ok $too-few ~~ /'Too few positionals passed'/, 'too few positionals: message shape';
+ok $too-few ~~ /'expected 2'/ && $too-few ~~ /'got 1'/, 'too few positionals: counts';

--- a/t/regex-optional-named-capture-nil-vs-match.t
+++ b/t/regex-optional-named-capture-nil-vs-match.t
@@ -1,0 +1,60 @@
+use Test;
+
+# An unmatched named capture's Nil-ness depends on WHERE the `?` sits, not
+# just on whether the name matched zero times (verified against `raku`):
+#
+# - `$<x>=[...]?` / `$<x>=<[...]>?` -- the `?` quantifies the SAME token the
+#   name is attached to, so the token "runs" as a unit even on its zero
+#   branch: `$<x>` is a defined, empty (zero-width) Match.
+# - `(x)?` / `$<x>=(...)?` -- the `?` quantifies a CaptureGroup atom, and
+#   Raku still yields Nil for a capturing group that matched zero times, even
+#   when the group itself carries the name.
+#
+# Each scenario uses its own capture name (rather than reusing `$<x>` across
+# blocks) because a named capture absent from the current match falls back to
+# a stale value from an earlier match in this file -- a real, separate bug
+# (todo/tickets/named-capture-absent-from-current-match-leaks-stale-value.md)
+# that this test intentionally does not exercise.
+
+plan 8;
+
+if "b" ~~ / $<ncg>=[<[cd]>]? "b" / {
+    ok $<ncg>.defined, 'name on a non-capturing group: defined (empty Match)';
+    is ~$<ncg>, '', 'name on a non-capturing group: stringifies to empty string';
+} else {
+    flunk 'name on a non-capturing group: match';
+    flunk 'name on a non-capturing group: stringify';
+}
+
+if "b" ~~ / $<bare>=<[cd]>? "b" / {
+    ok $<bare>.defined, 'name on a bare quantified atom: defined (empty Match)';
+    is ~$<bare>, '', 'name on a bare quantified atom: stringifies to empty string';
+} else {
+    flunk 'name on a bare atom: match';
+    flunk 'name on a bare atom: stringify';
+}
+
+if "b" ~~ / $<cg>=(<[cd]>)? "b" / {
+    nok $<cg>.defined, 'name on a capturing group: Nil (group did not run)';
+} else {
+    flunk 'name on a capturing group: match';
+}
+
+if "b" ~~ /(<[ab]> $<outer>=<[cd]>)? "b"/ {
+    nok $<outer>.defined, 'name inside an unmatched outer group: Nil';
+} else {
+    flunk 'name inside an unmatched outer group: match';
+}
+
+# A matched (non-zero) named capture is unaffected by any of the above.
+if "bc" ~~ / "b" $<ncg2>=[<[cd]>]? / {
+    is ~$<ncg2>, 'c', 'a matched non-capturing-group name still captures its text';
+} else {
+    flunk 'matched non-capturing group name';
+}
+
+if "cb" ~~ / $<bare2>=<[cd]>? "b" / {
+    is ~$<bare2>, 'c', 'a matched bare-atom name still captures its text';
+} else {
+    flunk 'matched bare atom name';
+}

--- a/todo/tickets/named-capture-absent-from-current-match-leaks-stale-value.md
+++ b/todo/tickets/named-capture-absent-from-current-match-leaks-stale-value.md
@@ -1,0 +1,61 @@
+# `$<name>` for a capture absent from the current match leaks the previous match's value
+
+Found while writing a regression test for
+`news/2026-08/regex-token-named-optional-atom-empty-match-not-nil.md`
+(the `?`-on-the-named-token fix).
+
+`$<name>` (equivalently `$/<name>` / `$<name>` after `~~`) should be `Nil` when
+the *current* successful match's pattern has no capture called `name` at all
+-- not merely when the name matched zero times. mutsu instead returns the
+value from an *earlier* match in the same dynamic scope:
+
+```raku
+if "xb" ~~ / $<x>=<[cdx]> "b" / {
+    say "block1 x=", ~$<x>;      # x           -- both agree
+}
+if "bb" ~~ / "b" "b" / {         # this pattern has no $<x> at all
+    say "block2 x=", $<x>.WHAT;  # raku: Nil : mutsu: (Match), the stale "x" from block1
+}
+```
+
+raku: `block1 x=x` / `block2 x=Nil`.
+mutsu: `block1 x=x` / `block2 x=(Match)` (leaking block1's captured Match).
+
+Reproduces the same way through a plain top-level `sub` call, so it is not
+specific to bare-block topicalization:
+
+```raku
+sub m1 { "xb" ~~ / $<x>=<[cdx]> "b" / }
+sub m2 { "bb" ~~ / "b" "b" / }
+m1();
+m2();
+say $<x>.WHAT;   # raku: Nil, mutsu: (Match)
+```
+
+## Why this matters
+
+Any code that branches on `$<name>.defined` after a *second* match whose
+pattern doesn't declare `name` will silently see a stale Match object instead
+of Nil. This is a narrower, unrelated bug from the "which `?` placement gives
+Nil vs an empty Match" question that
+`news/2026-08/regex-token-named-optional-atom-empty-match-not-nil.md` fixed --
+that fix is specifically about names *present* in the current pattern that
+matched zero times; this ticket is about names *absent* from the current
+pattern's token list entirely.
+
+## Where to look
+
+The named-capture read path for `$<name>` / `$/<name>` (`Match` indexing by
+Str key) almost certainly resolves through some `$/`-adjacent lookup that,
+when the current match's `named` map has no entry for the key, falls back to
+a broader/older store instead of returning `Nil` outright. Candidates:
+`src/runtime/regex/regex_match_public.rs`, the `Match` hash-subscript method
+implementation, and wherever the interpreter installs `$/` after a successful
+top-level `~~`/`.match` (look for where the *previous* `$/`'s named map could
+still be reachable when building the new one).
+
+## Effort
+
+Not measured; likely S-M once the actual lookup site is found, but requires
+tracing the `$/`-installation path fresh (not touched by the ticket that
+found this).

--- a/todo/tickets/rule-sigspace-does-not-consume-trailing-whitespace.md
+++ b/todo/tickets/rule-sigspace-does-not-consume-trailing-whitespace.md
@@ -1,0 +1,78 @@
+# `rule` (`:sigspace`) does not consume whitespace trailing the last atom
+
+Found while chasing the remaining `Template::Mojo` `03-capture.rakutest`
+failure (`todo/tickets/template-mojo-residual-failures.md` issue 2 turned out
+to have two layers; the Nil-vs-empty-Match layer is fixed, this is the rest).
+
+In Raku, `rule`/`:sigspace` inserts an implicit `<.ws>` between adjacent atoms
+-- including between the *last* literal atom and whatever whitespace follows
+it in the pattern source, right up to the closing `}`. mutsu's regex parser
+inserts the between-atom `WsRule` tokens (`src/runtime/regex_parse_core.rs`,
+the `c.is_whitespace()` branch around line 731) but the trailing whitespace
+after the final atom is apparently never reached — matching consistently
+stops immediately after the last literal, never consuming what follows.
+
+Minimal repro (`subparse` used to inspect `.to` without needing an anchor):
+
+```raku
+grammar G {
+    rule r { 'a' 'b' }
+}
+my $s = "a b   c";
+my $m = G.subparse($s, rule => 'r');
+say "to=" ~ $m.to;
+say "rest=[" ~ $s.substr($m.to) ~ "]";
+```
+
+raku: `to=6` / `rest=[c]` (all three trailing spaces consumed by the
+post-'b' `<.ws>`, which is `\s+` after a word character).
+mutsu: `to=3` / `rest=[   c]` (stops right after `'b'`, no trailing `<.ws>`
+at all).
+
+The same gap reproduces with a name-and-quote-delimited case closer to the
+original find:
+
+```raku
+grammar G {
+    rule perlcapture-begin {
+        '<%' 'my' $<name>=<var> '=' 'begin' '%>'
+    }
+    token var { <sigil> [ \w+ ] }
+    token sigil { '&' | '$' }
+}
+my $s = "<% my &block = begin %>\nHello";
+my $m = G.subparse($s, rule => 'perlcapture-begin');
+say "to=" ~ $m.to;          # raku: 24 (consumes the trailing \n)  mutsu: 23
+```
+
+## Impact
+
+`Template::Mojo`'s `perlcapture-begin`/`perlcapture-end` rules are declared
+with `rule` specifically to get this behavior (skip the literal newline right
+after `<% ... begin %>` / `<% end %>`), so without it mutsu emits spurious
+`$_M ~= '\n'` literals into the generated template sub, producing extra blank
+lines in rendered output. Reproduced end-to-end via
+`~/.zef/store/Template-Mojo-0.2.2/*/t/03-capture.rakutest`
+(`mzef install Template::Mojo` first, or unpack the dist tarball).
+
+This is a general `rule`/`:sigspace` gap, not Template::Mojo-specific — any
+grammar relying on trailing sigspace after a rule's last atom will hit it.
+
+## Where to look
+
+`src/runtime/regex_parse_core.rs`'s per-character tokenizer loop (the
+`c.is_whitespace()` branch, currently only inserts a `WsRule` token when
+`chars.peek()` finds more pattern text after the whitespace run — or possibly
+the token/rule BODY TEXT itself is trimmed of trailing whitespace before
+reaching this parser at all, in the caller that extracts `{ ... }` body
+source for `token`/`rule`/`regex` declarations). Check both: (1) whether the
+extracted body string for a `rule { ... }` still contains its trailing
+whitespace before `}` when handed to the regex parser, and (2) whether the
+tokenizer, when it does see trailing whitespace with no more atoms following,
+still emits a `WsRule` (it should — a `RegexToken` doesn't need "something
+after" to be meaningful, it just needs to be walked in `walk_tokens`).
+
+## Effort
+
+Not measured; the tokenizer-vs-body-trimming split needs an hour or two of
+tracing before the actual fix site is clear, so likely S-M once diagnosed.

--- a/todo/tickets/template-mojo-residual-failures.md
+++ b/todo/tickets/template-mojo-residual-failures.md
@@ -1,4 +1,4 @@
-# Template::Mojo: three residual failures after the quoted-angle regex fix
+# Template::Mojo: residual failure after the arity-message and Nil-capture fixes
 
 Split out of `todo/tickets/grammar-named-capture-resolved-as-method.md` on
 2026-07-26. That ticket's root cause — a quoted `<`/`>` inside a regex assertion
@@ -7,7 +7,7 @@ taking `Template::Mojo` 0.2.2 from every test file dying immediately to:
 
 | file | mutsu | raku |
 | --- | --- | --- |
-| `t/00-basic.rakutest` | 15/17 | 17/17 |
+| `t/00-basic.rakutest` | 16/17 (was 15/17) | 17/17 |
 | `t/01-template.rakutest` | 3/3 | 3/3 |
 | `t/02-complex.rakutest` | 1/1 | 1/1 |
 | `t/03-capture.rakutest` | 0/1 | 1/1 |
@@ -16,24 +16,45 @@ taking `Template::Mojo` 0.2.2 from every test file dying immediately to:
 Reproduce by unpacking the dist and running `mutsu -I lib t/<file>` (the tarball
 URL is in the git history of the original ticket).
 
-## 1. `00-basic` tests 16 & 17 — arity error message from EVAL'd code
+## 1. `00-basic` test 16 — FIXED 2026-08-06; test 17 stays open (by decision)
 
-```raku
-Template::Mojo.new('<%= $^a + $^b %>').render(23);
-# the test asserts the caught error matches /expected\s2/ and /got\s1/
-```
+Was: a named sub built via EVAL (`sub t { $^a + $^b }`), called through a
+lexical value (`&f(23)`), reported the compile-time-flavored "Calling
+t(Int) will never work with declared signature ()" instead of raku's plain
+runtime "Too few positionals passed; expected 2 arguments but got 1". Two
+independent bugs, both in the legacy placeholder binder that this call shape
+falls into (`bind_function_args_values` in
+`src/runtime/types/binding_signature.rs`, reached via the "compile on-the-fly"
+value-call branch in `src/vm/vm_dispatch_helpers.rs`):
 
-The template compiles to a `sub` **built as source text and EVAL'd**, whose body
-uses `$^a`/`$^b`. Called with the wrong number of arguments, raku's message is
-`Too few positionals passed; expected 2 arguments but got 1`.
+1. That value-call branch never set `suppress_binding_error_enhance`, unlike
+   its sibling branches, so `enhance_binding_error` wrapped the raw runtime
+   error in the "will never work" compile-time phrasing (and with an empty
+   `()` signature, since placeholder params never populate `param_defs`).
+2. The legacy binder's too-few message didn't match raku's wording
+   ("Missing required implicit placeholder parameter $^b" instead of "Too few
+   positionals passed; expected N arguments but got M").
 
-Note that mutsu already produces exactly that message for a plain placeholder
-block (`my $f = { $^a + $^b }; $f(23)` — byte-identical to raku), so the gap is
-specific to the EVAL'd `sub NAME { ... $^a ... }` shape the module builds, or to
-how the error surfaces through `.render`. Start by reducing
-`EVAL 'sub t { $^a + $^b }'` and calling it with one argument.
+Both fixed; regression test `t/eval-named-sub-placeholder-arity.t`.
 
-## 2. `03-capture` — `Use of Nil in string context` in the action
+**Test 17 ("too many arguments") stays failing, by decision, not oversight.**
+raku also rejects extra positionals for this exact shape, but the general fix
+was tried and reverted: mutsu's legacy binder has no reliable signal to tell
+"a `^`-twigil placeholder sub with an exact arity" apart from "one whose body
+also references bare `@_`/`%_`, which legitimately accepts extra positionals
+in Raku" (`t/placeholder.t`'s `mixed-placeholder` sub is exactly the second
+shape, and regressed under the first attempt). The only place that
+distinction is knowable is at parse time (does the body reference `@_`/`%_`),
+and the only way found to carry it to the runtime binder was a synthetic
+`params` entry — which leaks into the ~80 other call sites across the
+codebase that read a Sub's raw `params` list verbatim (multi-dispatch
+candidate arity matching in `methods_signature_candidates.rs` was the one
+caught by inspection; auditing all ~80 was out of scope for this ticket). See
+the comment above `required_positional_count` in `binding_signature.rs` for
+the full reasoning. A real fix needs a dedicated field threaded from the AST
+through to the runtime `Sub` value, not a `params` list hack.
+
+## 2. `03-capture` — two layers, one fixed, one still open
 
 ```
 Use of Nil in string context
@@ -41,14 +62,35 @@ Use of Nil in string context
 ```
 
 `method perlline($/) { make expr($/) ~ "\n" }` — the helper `expr` reads
-`$<get-result>` / `$<expr>` off the match. One of them is `Nil` where raku has a
-value, for the `% my $x = ...` capture-block template this file exercises. Since
-the surrounding grammar now parses, this is a capture-population difference on
-the `perlline` token (`^^ \h* '%' $<get-result>=['=']? $<expr>=[ <-[\n]>* ] [\n | $]`)
-— most likely the optional `$<get-result>=['=']?` capture when it does not match.
+`$<get-result>` / `$<expr>` off the match, from the `perlline` token
+(`^^ \h* '%' $<get-result>=['=']? $<expr>=[ <-[\n]>* ] [\n | $]`).
 
-## Why they are separate
+**Layer 1 (FIXED 2026-08-06):** `$<get-result>=['=']?` unmatched was
+rendering as `Nil` instead of Raku's empty (zero-width) `Match` — the
+Nil-vs-empty-Match choice depends on whether the `?` quantifies the SAME
+token the name is attached to (empty Match) or a `CaptureGroup` atom (still
+Nil, matches Raku). Fixed in `src/runtime/regex/regex_match_core.rs`
+(`RegexQuant::ZeroOrOne`'s three zero-match branches); see
+`news/2026-08/regex-token-named-optional-atom-empty-match-not-nil.md` and
+regression test `t/regex-optional-named-capture-nil-vs-match.t`. This also
+surfaced a second, unrelated pre-existing bug
+(`todo/tickets/named-capture-absent-from-current-match-leaks-stale-value.md`)
+that the new test deliberately routes around (distinct capture names per
+scenario).
 
-Both are independent of the angle-bracket parse bug and of each other, and
-neither is a grammar-scanner issue. The first is placeholder/arity plumbing
-through EVAL; the second is capture population for an optional capture.
+**Layer 2 (still open):** with the Nil warnings gone, the file still fails —
+not from a wrong value, but from extra blank lines in the rendered output.
+Root-caused to `todo/tickets/rule-sigspace-does-not-consume-trailing-whitespace.md`:
+`Template::Mojo`'s `perlcapture-begin`/`perlcapture-end` rules rely on
+`rule`'s `:sigspace` consuming the newline right after `<% ... begin %>` /
+`<% end %>`, and mutsu's regex engine never emits that trailing `<.ws>` after
+a rule's last atom. That is a general grammar-engine gap, not specific to
+this dist, and is the actual blocker for `03-capture.rakutest`.
+
+## Why they were separate
+
+All three findings are independent: the first is placeholder/arity plumbing
+through EVAL (fixed), the second is capture population for an optional
+capture whose `?` sits on the named token itself (fixed), and the third is a
+`rule`/`:sigspace` boundary gap (open, tracked in its own ticket since it's a
+general engine issue, not Template::Mojo-specific).


### PR DESCRIPTION
## Summary
- A named sub built via `EVAL` and called through a lexical value (`&f(23)`) now reports raku's plain runtime arity message ("Too few positionals passed; expected N arguments but got M") instead of the compile-time-flavored "Calling t(Int) will never work with declared signature ()" wrapper with a bogus empty signature.
- `$<name>=[...]?` (a `?` quantifying the same token the name is attached to) now yields an empty, zero-width `Match` when it matches zero times, matching raku — previously it was `Nil`. `$<name>=(...)?` (name on a `CaptureGroup` atom) correctly stays `Nil`, matching raku's own special-casing there.
- Both found via `Template::Mojo` 0.2.2's test suite (`todo/tickets/template-mojo-residual-failures.md`), which goes from 15/17 to 16/17 on `00-basic.rakutest`.

## Follow-up tickets filed (out of scope here)
- `todo/tickets/named-capture-absent-from-current-match-leaks-stale-value.md` — `$<name>` for a capture absent from the *current* match's pattern falls back to a stale value from an earlier match instead of `Nil`.
- `todo/tickets/rule-sigspace-does-not-consume-trailing-whitespace.md` — `rule`/`:sigspace` never emits a trailing `<.ws>` after a rule's last atom, which is the real remaining blocker for `03-capture.rakutest`.
- The "too many positionals" half of the arity fix was attempted and reverted (see the comment above `required_positional_count` in `binding_signature.rs` and the ticket) — it required a synthetic `params` list entry that leaks into ~80 other call sites reading a Sub's raw `params`, and regressed `t/placeholder.t`'s `mixed-placeholder` test.

## Test plan
- New regression tests: `t/eval-named-sub-placeholder-arity.t`, `t/regex-optional-named-capture-nil-vs-match.t`
- `make test` — all 2909 files pass locally
- Verified against `Template::Mojo` 0.2.2's `00-basic.rakutest` (15/17 → 16/17) and `03-capture.rakutest` (Nil warnings gone; remaining failure is the separately-filed `:sigspace` gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)