### PR TITLE
fix(runtime,nativecall): a Buf survives nested-index assignment; a parametric Buf/Blob native-call param no longer marshals as NULL

### DIFF
--- a/news/2026-08/buf-nested-index-assign-and-parametric-native-param.md
+++ b/news/2026-08/buf-nested-index-assign-and-parametric-native-param.md
@@ -1,0 +1,47 @@
+# A Buf survives nested-index assignment, and a parametric Buf/Blob native-call param no longer marshals as NULL
+
+Two independent fixes from `todo/tickets/typed-buf-native-interop-holes.md`
+(items 3 and 4; items 1 and 2 of that ticket were re-verified and no longer
+reproduce).
+
+## `@a[0][1] = v` no longer clobbers a Buf into a plain Array
+
+```raku
+my @a;
+@a[0] = Buf[uint64].allocate(2);
+@a[0][1] = 42;
+say @a[0].^name;  # raku: Buf[uint64]   mutsu (before): Array
+```
+
+The 2-level nested-index-assign path (`src/vm/vm_var_assign_index_named.rs`)
+checks whether the slot it's about to write through already holds a
+container, autovivifying a fresh Array/Hash only if not. A Buf's element
+storage lives in a shared attribute cell on a `Value::Instance`, not as a raw
+Array/Hash payload, so the probe didn't recognize it and clobbered it — the
+same gap existed for a Buf reached through a hash key (`%h<k>[1] = v`) and
+through a `:=`-bound cell, both fixed by the same helper
+(`write_buf_element_if_buf_instance`), used both in the array-outer
+nested-assign arm and in `assign_into_nested_container` (which also serves
+the hash-outer arm and `ContainerRef` chains).
+
+## A `Buf[T]`/`Blob[T]` native-call parameter marshals as the buffer's address, not NULL
+
+```raku
+use NativeCall;
+sub strlen(Buf[uint8]) returns size_t is native { * }
+say strlen(Buf[uint8].new(72, 105, 0));  # raku: 2   mutsu (before): SEGV
+```
+
+`CType::from_type_name` (`src/runtime/nativecall.rs`) only recognizes the
+bare stems `Buf`/`Blob`/`buf8`/`blob8` — a parameterized spelling like
+`Buf[uint8]` reached it unstripped, matched nothing, and fell through to the
+"starts-uppercase ⇒ opaque `CStruct` pointer" heuristic in
+`vm_register_sub_ops.rs`. A plain Buf instance has no `address` attribute for
+that path to read, so NULL was passed to C — silently for a function that
+merely returns a length, and with a SEGV for one like `strlen` that actually
+dereferences the pointer. Fixed by stripping a `Buf[...]`/`Blob[...]`
+parameter to its stem before the `CType::from_type_name` lookup, same as the
+existing `CArray[T]` handling just above it.
+
+Regression tests: `t/buf-nested-index-assign-preserves-buf.t`,
+`t/nativecall-parametric-buf-param-marshals-address.t`.

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -689,7 +689,21 @@ impl Interpreter {
                 });
                 continue;
             }
-            let ct = match CType::from_type_name(tc) {
+            // A parameterized `Buf[T]`/`Blob[T]` marshals as `CType::Buf`
+            // regardless of its element type `T` -- it's passed as a raw
+            // address+length, per `CType::from_type_name`'s own doc comment
+            // ("the bracketed forms are handled by the caller stripping to
+            // the stem"). Without this, the bracketed name falls through to
+            // the CStruct-by-shape heuristic below (starts uppercase) and
+            // marshals as a `void*` looked up via `pointer_address` -- which
+            // a `Buf` instance has no `address` attribute for, so NULL is
+            // passed to C silently (e.g. `strlen(Buf[uint8] $s)` segfaults
+            // on the native side instead of reading the buffer).
+            let buf_stem = tc
+                .split_once('[')
+                .map(|(stem, _)| stem)
+                .filter(|stem| *stem == "Buf" || *stem == "Blob");
+            let ct = match CType::from_type_name(buf_stem.unwrap_or(tc)) {
                 Some(ct) => ct,
                 // A user-declared `is repr('CStruct')` class (an opaque native
                 // handle, e.g. `SSL_CTX`) is passed by pointer. Recognize it by

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2803,6 +2803,22 @@ impl Interpreter {
                     // Container identity (§3): write through a shared node.
                     let arr = crate::value::gc_data_mut(outer_arr);
                     Self::autoviv_resize(arr, inner_i + 1, native_fill.clone())?;
+                    // A Buf/Blob-shaped Instance in the slot (`@a[0]` holding a
+                    // `Buf[uint64]`) carries its element storage in a shared
+                    // attribute cell, not as a raw Array/Hash payload, so the
+                    // `needs_viv` probe below would not recognize it as an
+                    // existing container and clobber it with a fresh Array —
+                    // silently destroying the buffer (`@a[0][1] = v` turned
+                    // `@a[0]` from `Buf[uint64]` into a plain `Array`). Write
+                    // through its element storage directly instead, mirroring
+                    // the single-level `$buf[i] = v` arm above.
+                    if Self::write_buf_element_if_buf_instance(
+                        &arr[inner_i],
+                        &outer_key,
+                        val.clone(),
+                    )? {
+                        return Ok(true);
+                    }
                     // Autovivify the slot if it's not already a container. A
                     // `:=`-bound element is a shared `ContainerRef` cell holding a
                     // container — descend through it (below) instead of clobbering it.
@@ -2903,6 +2919,50 @@ impl Interpreter {
         Ok(())
     }
 
+    /// If `target` is a Buf/Blob-shaped Instance, write `val` at `pos` through
+    /// its shared element-storage attribute cell and return `true`. `false`
+    /// (no write attempted) for anything else, or for a non-numeric `pos`.
+    /// Used by both nested-index-assign arms (array-outer and the
+    /// `:=`-cell-descending helper below) so a Buf sitting behind a second
+    /// subscript (`@a[0][1] = v`, `%h<k>[1] = v`, or a bound cell to either)
+    /// is written into rather than silently no-op'd or clobbered by the
+    /// generic Array/Hash fallback, which doesn't recognize an Instance as an
+    /// existing container.
+    fn write_buf_element_if_buf_instance(
+        target: &Value,
+        pos: &str,
+        val: Value,
+    ) -> Result<bool, RuntimeError> {
+        let ValueView::Instance {
+            attributes,
+            class_name,
+            ..
+        } = target.view()
+        else {
+            return Ok(false);
+        };
+        if !crate::runtime::utils::is_native_elems_class(&class_name.resolve())
+            || !crate::value::value_buf::has_buf_elems(&attributes)
+        {
+            return Ok(false);
+        }
+        let Ok(pos) = pos.parse::<usize>() else {
+            return Ok(true);
+        };
+        let mut resize_err = None;
+        crate::value::value_buf::with_buf_elems_mut(&attributes, |buf_arr| {
+            if let Err(e) = Self::autoviv_resize(buf_arr, pos + 1, Value::int(0)) {
+                resize_err = Some(e);
+                return;
+            }
+            buf_arr[pos] = val;
+        });
+        match resize_err {
+            Some(e) => Err(e),
+            None => Ok(true),
+        }
+    }
+
     /// Assign `val` into `target[outer_key]`, descending through any chain of
     /// `:=`-bound container cells (`ContainerRef`). Used by the 2-level nested
     /// assign so that a write to a container-valued bound element
@@ -2917,6 +2977,12 @@ impl Interpreter {
             let cell = cell.clone();
             let mut guard = cell.lock().unwrap();
             Self::assign_into_nested_container(&mut guard, outer_key, val)?;
+        } else if Self::write_buf_element_if_buf_instance(target, outer_key, val.clone())? {
+            // A Buf/Blob's element storage lives in a shared attribute cell,
+            // not a raw Array/Hash payload -- write through it directly
+            // (mirrors the array-outer nested-assign arm) instead of falling
+            // through to `with_array_mut`/`with_hash_mut`, which return
+            // `None` for an Instance and silently no-op the write.
         } else if let Some(r) = target.with_array_mut(|arr, _| -> Result<(), RuntimeError> {
             if let Ok(i) = outer_key.parse::<usize>() {
                 // Autovivified gaps fill with the `Any` type object (matching

--- a/t/buf-nested-index-assign-preserves-buf.t
+++ b/t/buf-nested-index-assign-preserves-buf.t
@@ -1,0 +1,23 @@
+use Test;
+
+# `@a[0][1] = v` where `@a[0]` holds a Buf must write into the Buf's own
+# element storage, not autovivify a fresh Array over it. The nested-index
+# assign's "does this slot already hold a container?" probe only recognized
+# raw Array/Hash/ContainerRef payloads -- a Buf is a `Value::Instance` (its
+# element storage lives in a shared attribute cell), so it fell through and
+# got silently replaced with `[Any, 42]`.
+# (todo/tickets/typed-buf-native-interop-holes.md, item 3)
+
+plan 4;
+
+my @a;
+@a[0] = Buf[uint64].allocate(2);
+@a[0][1] = 42;
+is @a[0].^name, 'Buf[uint64]', 'the element is still a Buf after nested assignment';
+is-deeply @a[0].list, (0, 42), 'the write landed at the right index, not the whole element replaced';
+
+my %h;
+%h<k> = Buf.new(1, 2, 3);
+%h<k>[1] = 99;
+is %h<k>.^name, 'Buf', 'a Buf under a hash key survives nested assignment too';
+is-deeply %h<k>.list, (1, 99, 3), 'the hash-nested write landed at the right index';

--- a/t/nativecall-parametric-buf-param-marshals-address.t
+++ b/t/nativecall-parametric-buf-param-marshals-address.t
@@ -1,0 +1,22 @@
+use Test;
+use NativeCall;
+
+# A `Buf[uint8]`/`Blob[uint8]`-style parametric signature parameter must
+# marshal the same way as the bare `Buf`/`Blob` stem does: a `void*` to the
+# buffer's raw bytes. `CType::from_type_name` only recognizes the bare stems
+# ("Buf", "Blob", "buf8", "blob8"); a bracketed spelling that reached it
+# unstripped fell through to the "starts-uppercase => opaque CStruct pointer"
+# heuristic, which found no `address` attribute on a plain Buf instance and
+# passed NULL to C instead -- silently on a `--> size_t`-returning function,
+# or a SEGV on one like `strlen` that dereferences the pointer.
+# (todo/tickets/typed-buf-native-interop-holes.md, item 4)
+
+plan 2;
+
+sub strlen(Buf[uint8]) returns size_t is native { * }
+my $b = Buf[uint8].new(72, 105, 0); # "Hi\0"
+is strlen($b), 2, 'a Buf[uint8] parameter marshals as the buffer address, not NULL';
+
+sub strlen2(Blob[uint8]) returns size_t is native is symbol('strlen') { * }
+my $b2 = Blob[uint8].new(87, 111, 0); # "Wo\0"
+is strlen2($b2), 2, 'a Blob[uint8] parameter marshals as the buffer address, not NULL';

--- a/todo/tickets/typed-buf-native-interop-holes.md
+++ b/todo/tickets/typed-buf-native-interop-holes.md
@@ -2,41 +2,33 @@
 
 Side findings from the DBIish mysql parity campaign (2026-07-29, the session
 that fixed the `& 0xff` element-assign truncation and added the CArray
-element-write arm). All reproduce on a plain build; none block the DBIish
-suites, but each is a real divergence from Rakudo.
+element-write arm). None block the DBIish suites, but each was a real
+divergence from Rakudo when found.
 
-1. **`Buf[intptr]`-style alias fallback picks width 1.** `BufData` width is
-   derived once from the class-name string (`buf_elem_width`,
-   `src/value/value_buf.rs`): substring probe for "64"/"32"/"16", else 1.
-   Parameterization normally resolves `constant intptr = uint64` to the class
-   name `Buf[uint64]`, but if the alias ever fails to resolve, the name
-   `"Buf[intptr]"` silently probes to width 1 + signed — a differently-shaped
-   buffer with no error. The probe should fail loudly (or resolve through the
-   registry) instead of guessing.
+Items 2-4 were re-verified 2026-08-06 (S-effort sweep off `todo/TRIAGE.md`):
+item 2 no longer reproduces (fixed by other work since 2026-07-29 — see
+`t/buf-wide-read-write-int.t`, already whitelisted); items 3 and 4 did
+reproduce and are now fixed — see
+`news/2026-08/buf-nested-index-assign-and-parametric-native-param.md`.
 
-2. **Byte-level read/write methods use the one-byte-per-element view on wide
-   Bufs.** `.write-uint64`/`.read-*` (`src/builtins/buf_write_int.rs`) go
-   through `buf_bytes_or_empty`/`set_buf_bytes`; on a width-8 node
-   `node_bytes` returns only the LOW byte of each element and the writeback
-   stores one byte per element. `Buf[uint64].allocate(2).write-uint64(0, 8192)`
-   produces an 8-element buffer with one byte of the u64 per element. These
-   should address `node.bytes` directly.
+Only item 1 remains, and it does **not** currently reproduce either: the
+straightforward repro (`constant intptr = uint64; Buf[intptr].new(...)`)
+resolves the alias correctly today, matching raku (`Buf[uint64]`, width 8).
+Left open only because the underlying fragility is still real, not because
+anything concretely fails right now.
 
-3. **Nested index assignment clobbers a Buf element container.**
-   `@a[0][1] = v` where `@a[0]` is a `Buf[uint64]` replaces the Buf with a
-   plain Raku Array (`.^name` becomes `Array`) via the autoviv fallback in
-   `src/vm/vm_var_assign_index_named.rs` (the arm that overwrites any
-   container matching none of the Hash/Array/Set/Bag/Mix arms). The fallback
-   should refuse to clobber an Instance carrying Buf storage or an `address`
-   attribute.
+1. **`Buf[intptr]`-style alias fallback picks width 1 -- IF alias resolution
+   ever fails, not reproduced today.** `BufData` width is derived once from
+   the class-name string (`buf_elem_width`, `src/value/value_buf.rs`):
+   substring probe for "64"/"32"/"16", else 1. Parameterization normally
+   resolves `constant intptr = uint64` to the class name `Buf[uint64]` before
+   `buf_elem_width` ever sees it, but if some *other* alias path ever handed
+   the unresolved name through instead, `"Buf[intptr]"` would silently probe
+   to width 1 + signed -- a differently-shaped buffer with no error. The
+   probe should fail loudly (or resolve through the registry) instead of
+   guessing, but finding a concrete unresolved-alias repro is a prerequisite
+   for justifying the change (see "don't add error handling for scenarios
+   that can't happen", CLAUDE.md).
 
-4. **A `Buf[uint64]` / `Blob[uint8]` signature parameter marshals as NULL.**
-   `CType::from_type_name` (`src/runtime/nativecall.rs`) only maps the bare
-   stems (`Buf`, `Blob`, `buf8`, `blob8`); a parameterized spelling isn't
-   stripped to its stem in `vm_register_sub_ops.rs`, hits the
-   "starts-uppercase ⇒ CStruct" heuristic, becomes `CType::Pointer`, and
-   `value_c_address` finds no `address` attribute — so NULL is passed to C
-   with no diagnostic.
-
-Minimal repros are one-liners per item; see
-`news/2026-07/dbiish-upstream-suite-parity.md` for the campaign context.
+Minimal repros are one-liners; see `news/2026-07/dbiish-upstream-suite-parity.md`
+for the original campaign context.


### PR DESCRIPTION
## Summary
- `@a[0][1] = v` (or `%h<k>[1] = v`, or through a `:=`-bound cell) where the element is a Buf no longer clobbers it into a plain Array — the nested-index-assign container probe now recognizes a Buf's Instance-with-shared-attribute-cell storage and writes through it.
- A `Buf[T]`/`Blob[T]` native-call signature parameter now marshals as the buffer's address instead of NULL (previously it reached the "opaque CStruct pointer" heuristic unstripped and passed NULL to C — a SEGV for a function like `strlen` that dereferences the pointer).
- Both from `todo/tickets/typed-buf-native-interop-holes.md` (items 3 & 4). Items 1 and 2 of that ticket were re-verified and no longer reproduce (item 2 was already fixed elsewhere; item 1's alias-resolution-failure scenario doesn't currently construct).

## Test plan
- New regression tests: `t/buf-nested-index-assign-preserves-buf.t`, `t/nativecall-parametric-buf-param-marshals-address.t`
- `make test` — all 2913 files pass locally
- `prove -e target/debug/mutsu t/buf-*.t t/nativecall-*.t` — all 48 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)