### PR TITLE
fix(vm): NativeCall encoded param trait runs compiled (ADR-0019 C6e-3c)

### DIFF
--- a/news/2026-08/nativecall-encoded-trait-runs-compiled.md
+++ b/news/2026-08/nativecall-encoded-trait-runs-compiled.md
@@ -1,0 +1,32 @@
+# NativeCall's `is encoded(...)` param trait no longer excludes a def from compiled dispatch
+
+ADR-0019 C6e-3c listed the NativeCall marshalling trait (`is encoded(...)`)
+as the last parameter-shape/trait exclusion in
+`def_module_single_sig_body_ok_ignoring_state` — the shared gate that
+decides whether a routine runs its plan-attached/OTF-compiled bytecode or
+falls back to the interpreter tree-walk.
+
+Measurement (full `t/` + roast under the existing C6e-2 instrumentation)
+found zero live readers of the trait for dispatch: actual string encoding
+for a native call happens explicitly via `.encode(...)` in the prelude
+(`nativecall_manage.rs`), not through this parameter trait, and the shared
+compiled binder (`bind_function_args_values`) only branches on
+`rw`/`raw`/`copy`/`invocant`. A genuine `is native(...)` sub never reaches
+this gate at all — `native_call_specs` is checked by name before body
+dispatch runs.
+
+Widened the gate's trait allowlist to include `encoded`. Sigilless scalars,
+sub-signature destructuring, `start`-containing bodies (C6e-2a/2b/2c), and
+now NativeCall marshalling traits (C6e-3c) all run compiled — no parameter
+shape or trait excludes a def from the compiled dispatch path anymore.
+
+Pinned by `t/encoded-param-compiled.t` (module-single OTF dispatch,
+repeated calls, recursion, multi-candidate dispatch, and an EVAL-boundary
+call); `t/nativecall-module-compat.t` already covered parse/marshal
+correctness for the trait itself.
+
+This does not by itself unblock dropping `CompiledSubDeclPlan::legacy_body`
+— a separate structural reader remains
+(`vm_call_named_inner.rs`'s computed-name/out-of-scope Sub-value fallback,
+tracked in
+`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`).

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -456,9 +456,10 @@ impl Interpreter {
             // instead of the per-call `eval_block_value_with_pre_post` compile
             // below. The gate is the same signature assessment the OTF
             // dispatch uses (`def_module_single_sig_body_ok_ignoring_state`):
-            // since C6e-2c only NativeCall marshalling traits keep a def on
-            // the interpreter arm (sigilless scalars, sub-signatures and
-            // `start` bodies all run compiled — C6e-2a/2b/2c). `state`
+            // since C6e-3c no parameter shape or trait keeps a def on the
+            // interpreter arm anymore (sigilless scalars, sub-signatures,
+            // `start` bodies, and NativeCall marshalling traits all run
+            // compiled — C6e-2a/2b/2c/3c). `state`
             // is fine here: `call_routine_def` runs one stable body identity
             // (the plan's, or one memoized compile), so cells are not severed
             // the way a per-call OTF recompile severs them. The compiled entry

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -2004,8 +2004,14 @@ impl Interpreter {
     /// `is rw`/`is raw`/`is copy`/`is readonly`/`is required` params are NOW
     /// allowed (§2 multi-dispatch VM-ization): the compiled binding already
     /// honored them for builtin shadows, and the rw/raw caller writeback carries
-    /// a compile-time caller slot (#4091). Only `is encoded(...)` (NativeCall)
-    /// stays excluded.
+    /// a compile-time caller slot (#4091). `is encoded(...)` (NativeCall
+    /// marshalling) is allowed too (ADR-0019 C6e-3c): it is inert on both
+    /// dispatch arms — nothing reads the trait for marshalling, since actual
+    /// string encoding for a native call happens explicitly via `.encode(...)`
+    /// in the prelude (`nativecall_manage.rs`), and the shared compiled binder
+    /// (`bind_function_args_values`) only branches on `rw`/`raw`/`copy`/
+    /// `invocant`. A genuine `is native(...)` sub never reaches this gate at
+    /// all — `native_call_specs` is checked by name before body dispatch.
     ///
     /// Defaults ARE allowed (name-cache-safe: no same-named builtin to mis-bind,
     /// and a single candidate always resolves to this def). Bodies and
@@ -2038,13 +2044,16 @@ impl Interpreter {
         // destructured elements bind read-only, so the historical exclusion
         // reason (caller-alias writeback) never applied to them
         // (t/subsig-param-compiled.t). C6e-2c lifted the last *body* exclusion
-        // (`start`-containing bodies — see the gate doc above), so the body no
-        // longer gates compilation at all. Only NativeCall marshalling traits
-        // (`is encoded(...)`) still keep a def on the interpreter.
+        // (`start`-containing bodies — see the gate doc above). C6e-3c lifted
+        // the last param-trait exclusion (`is encoded(...)`, see the gate doc
+        // above), so no parameter shape or trait gates compilation anymore.
         def.param_defs.iter().all(|pd| {
-            pd.traits
-                .iter()
-                .all(|t| matches!(t.as_str(), "copy" | "rw" | "raw" | "readonly" | "required"))
+            pd.traits.iter().all(|t| {
+                matches!(
+                    t.as_str(),
+                    "copy" | "rw" | "raw" | "readonly" | "required" | "encoded"
+                )
+            })
         })
     }
 
@@ -2124,8 +2133,9 @@ impl Interpreter {
         //     binder, read-only elements);
         //   - standard binding-time traits (`is copy`/`is rw`/`is raw`/`is
         //     readonly`/`is required`) are OTF-safe (compiled binding honors them,
-        //     rw/raw writeback carries the #4091 caller slot); only NativeCall
-        //     marshalling (`is encoded('utf8')`) stays excluded.
+        //     rw/raw writeback carries the #4091 caller slot); NativeCall
+        //     marshalling (`is encoded('utf8')`) is OTF-safe too since C6e-3c
+        //     (the trait is inert on both dispatch arms).
         // Plus the `state` exclusion: a per-call OTF recompile would sever a
         // module sub's shared `state` cell (the cross-thread shared captured body,
         // `imported_state_body_for_def`, is the path that admits `state`).

--- a/t/encoded-param-compiled.t
+++ b/t/encoded-param-compiled.t
@@ -1,0 +1,28 @@
+use Test;
+
+# ADR-0019 C6e-3c: routines with an `is encoded(...)` (NativeCall string
+# marshalling) parameter trait run through the compiled entry — the last
+# param-trait exclusion in the OTF/plan-bytecode gate
+# (`def_module_single_sig_body_ok_ignoring_state`) is lifted. The trait is
+# inert for dispatch (actual encoding happens via an explicit `.encode(...)`
+# call, not this binder), so behavior must match the interpreter arm exactly.
+
+plan 6;
+
+sub shout(Str $s is encoded('utf8')) { $s.uc }
+is shout('hi'), 'HI', 'basic call through the module-single OTF path';
+is shout('hi') ~ shout('yo'), 'HIYO', 'repeated calls reuse the compiled body';
+
+sub countdown(Int $n is encoded('utf8')) {
+    $n <= 0 ?? 'done' !! countdown($n - 1)
+}
+is countdown(3), 'done', 'recursive sub with an encoded param compiles and runs';
+
+multi sub greet(Str $s is encoded('utf8')) { "str:$s" }
+multi sub greet(Int $n) { "int:$n" }
+is greet('a'), 'str:a', 'multi candidate with an encoded param';
+is greet(5), 'int:5', 'sibling multi candidate without the trait still dispatches';
+
+# EVAL-boundary call: the compiled routing must hold across a re-entrant
+# compile too.
+is EVAL(q[shout('eval')]), 'EVAL', 'encoded-param callee reached through EVAL';

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -170,11 +170,34 @@ sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
   scope) a separate pre-existing bug: such a nested sub leaks into the
   enclosing global scope —
   `todo/tickets/nested-sub-in-method-leaks-to-global-scope.md`.
+- **NativeCall marshalling trait keep-class LIFTED (2026-08-06):** the
+  `is encoded(...)` param-trait exclusion in
+  `def_module_single_sig_body_ok_ignoring_state` (the OTF/module-single gate
+  and the C6d-5 interpreter-fallback arm share this one predicate) was
+  measured to have zero live readers — actual string encoding for a native
+  call happens explicitly via `.encode(...)` in the prelude
+  (`nativecall_manage.rs`), not through this trait, and the shared compiled
+  binder (`bind_function_args_values`) only branches on
+  `rw`/`raw`/`copy`/`invocant`. A genuine `is native(...)` sub never reaches
+  this gate at all — `native_call_specs` is checked by name before body
+  dispatch. Widened the gate's `matches!` to accept `encoded` alongside the
+  existing binding-time traits. Note: this predicate does NOT gate
+  *registration* (whether a def's body is emptied) — that decision
+  (`vm_register_sub_ops.rs`) already only checks whether the plan's compiled
+  routine key resolves, independent of param traits — so this fix is purely
+  about execution *routing* (letting such defs run their already-compiled
+  bytecode instead of tree-walking a body that C6e-3b already empties by
+  default when eligible). Pinned by `t/encoded-param-compiled.t`
+  (`t/nativecall-module-compat.t` already covered parse/marshal
+  correctness).
 - **C6e-3c (open):** the field itself. `CompiledSubDeclPlan::legacy_body`
-  still carries the AST for the one remaining keep-class — NativeCall
-  marshalling traits, measured non-vendorable — and for the registration
-  fallback; dropping it outright still needs a story for that case.
-  Registration-time body use for the safe class is already zero.
+  now has no known live keep-class reader for the *safe* def shape, but it
+  still carries the AST for the registration fallback:
+  `vm_call_named_inner.rs`'s sub-decl-as-last-statement case falls back to
+  `plan.legacy_body.clone()` when a plan-derived def isn't found in the
+  registry (a computed-name/out-of-scope case) — that structural reader
+  needs its own C6c-style treatment (build from the plan's compiled routine
+  instead) before the field can be deleted outright.
 
 Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
 (the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`


### PR DESCRIPTION
## Summary

- ADR-0019 C6e-3c's remaining keep-class for `def_module_single_sig_body_ok_ignoring_state` was `is encoded(...)` (NativeCall marshalling) — a def with that param trait fell back to the interpreter tree-walk instead of running compiled bytecode.
- Measured (grep of every reader): the trait is inert for dispatch. String encoding for a native call happens explicitly via `.encode(...)` in the prelude, not through this trait; the shared compiled binder only branches on `rw`/`raw`/`copy`/`invocant`; and a genuine `is native(...)` sub is resolved by name before body dispatch, never reaching this gate at all.
- Widened the gate's trait allowlist to include `encoded`, matching the C6e-2a/2b/2c precedent (measure-then-widen).
- This does not unblock dropping `CompiledSubDeclPlan::legacy_body` outright — a separate structural reader remains (`vm_call_named_inner.rs`'s computed-name/out-of-scope Sub-value fallback), tracked in `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.

## Test plan

- [x] `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings` clean
- [x] New pin: `t/encoded-param-compiled.t` (module-single OTF dispatch, repeated calls, recursion, multi-candidate dispatch, EVAL-boundary call)
- [x] `t/nativecall-*.t` (33 files) green
- [x] `make test` — full TAP suite green (27700 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)