### PR TITLE
fix(vm): sub-decl-as-last-statement fallback prefers compiled routine

### DIFF
--- a/news/2026-08/sub-decl-last-statement-fallback-prefers-compiled.md
+++ b/news/2026-08/sub-decl-last-statement-fallback-prefers-compiled.md
@@ -1,0 +1,28 @@
+# The sub-decl-as-last-statement Sub-value fallback prefers the plan's compiled routine
+
+Continuing the ADR-0019 C6e-3c `legacy_body` audit: when a `sub` declared
+as the last statement of a block returns a Sub value (`my $f = do { sub
+foo() {...} }`), and the def cannot be found in the registry under the
+plan's static name (a computed-name `sub ::($name)` declaration, or a
+just-out-of-scope def), `vm_call_named_inner.rs` used to build the
+returned Sub straight from `plan.legacy_body` — always the AST, never
+compiled bytecode.
+
+It now tries the plan's own `compiled_routine_keys[0]` against the call's
+functions table first (the same lookup pattern `RegisterSub` uses to
+decide body-less registration) and only falls back to the AST body if that
+key does not resolve.
+
+Measurement found this branch already unreachable through any realistic
+Raku program: a full `t/` run (27700+ tests) hit it zero times even before
+the fix, and real Rakudo does not accept a runtime-computed sub name in
+the first place (`SORRY! Name ::($name) is not compile-time known...`).
+Validated with the project's env-gated-widen A/B methodology instead of a
+dedicated pin test: an env var forced the registry lookup to miss for
+every declaration in the suite, exercising the new fallback path
+exclusively, and all 27705 tests still passed.
+
+This was the last outstanding `legacy_body` reader tracked for C6e-3c's
+former keep-classes. The field itself has not been deleted yet — that
+needs a fresh grep audit of every remaining `.legacy_body` reference
+before removal is safe.

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -405,8 +405,9 @@ impl Interpreter {
             // returned code object dispatches compiled instead of re-compiling
             // the plan's AST body (ADR-0019 C6e-3, the C6c treatment). The
             // registry key uses the plan's static name; a computed-name
-            // declaration (`sub ::($name)`) or a just-out-of-scope def keeps
-            // the plan-shape fallback.
+            // declaration (`sub ::($name)`) or a just-out-of-scope def falls
+            // back to the plan's own compiled routine (below), and only to
+            // its AST body if that too is unresolved.
             let single_key = format!("{}::{}", self.current_package(), plan.name.resolve());
             let registered = self
                 .registry()
@@ -426,15 +427,38 @@ impl Interpreter {
                     def.compiled.clone(),
                 )
             } else {
-                Value::make_sub(
-                    Symbol::intern(&self.current_package()),
-                    plan.name,
-                    plan.params.clone(),
-                    plan.param_defs.clone(),
-                    plan.legacy_body.clone(),
-                    plan.is_rw,
-                    self.clone_env(),
-                )
+                // The plan's own compiled routine (same key this call's
+                // RegisterSub just tried to install under) still counts as
+                // "compiled" even when the registry lookup above missed —
+                // build the Sub from it instead of the AST body, mirroring
+                // the C6c/C6e-3a treatment applied everywhere else a Sub
+                // value is constructed from a plan (ADR-0019 C6e-3c).
+                let plan_fully_compiled =
+                    plan.compiled_routine_keys.len() == 1 + plan.signature_alternates.len();
+                let primary_compiled = plan_fully_compiled
+                    .then(|| compiled_fns.get(&plan.compiled_routine_keys[0]))
+                    .flatten();
+                match primary_compiled {
+                    Some(compiled) => Value::make_sub_for_routine(
+                        Symbol::intern(&self.current_package()),
+                        plan.name,
+                        plan.params.clone(),
+                        plan.param_defs.clone(),
+                        Vec::new(),
+                        plan.is_rw,
+                        self.clone_env(),
+                        Some(std::sync::Arc::new(compiled.clone())),
+                    ),
+                    None => Value::make_sub(
+                        Symbol::intern(&self.current_package()),
+                        plan.name,
+                        plan.params.clone(),
+                        plan.param_defs.clone(),
+                        plan.legacy_body.clone(),
+                        plan.is_rw,
+                        self.clone_env(),
+                    ),
+                }
             };
         }
 

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -190,14 +190,37 @@ sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
   default when eligible). Pinned by `t/encoded-param-compiled.t`
   (`t/nativecall-module-compat.t` already covered parse/marshal
   correctness).
-- **C6e-3c (open):** the field itself. `CompiledSubDeclPlan::legacy_body`
-  now has no known live keep-class reader for the *safe* def shape, but it
-  still carries the AST for the registration fallback:
-  `vm_call_named_inner.rs`'s sub-decl-as-last-statement case falls back to
-  `plan.legacy_body.clone()` when a plan-derived def isn't found in the
-  registry (a computed-name/out-of-scope case) — that structural reader
-  needs its own C6c-style treatment (build from the plan's compiled routine
-  instead) before the field can be deleted outright.
+- **Registration fallback given the C6c treatment (2026-08-06):**
+  `vm_call_named_inner.rs`'s sub-decl-as-last-statement case (a `sub` as the
+  final statement of a block returns a Sub value) fell back to
+  `plan.legacy_body.clone()` whenever the def wasn't found in the registry
+  under the plan's static name (a computed-name `sub ::($name)` declaration
+  or a just-out-of-scope def). Measurement: zero hits across the full `t/`
+  suite (27700+ tests) even before this fix — the branch was already
+  essentially unreachable through ordinary syntax (real Rakudo does not
+  even accept a runtime-computed sub name: `SORRY! Name ::($name) is not
+  compile-time known, and can not serve as a sub declaration`), and no
+  realistic repro reaching it could be constructed. Fixed it anyway,
+  defensively: it now tries the plan's own `compiled_routine_keys[0]`
+  against the executing call's `compiled_fns` table first (the same
+  `plan_compiled(0)` pattern `vm_register_sub_ops.rs`'s `RegisterSub`
+  handler uses) and only falls back to `plan.legacy_body.clone()` if that
+  key does not resolve either. Validated via the same env-gated-widen A/B
+  the project uses when a direct repro isn't practical: an env var forced
+  the registry lookup to `None` so every declaration in the full `t/` suite
+  exercised this branch, and all 27705 tests still passed; the instrument
+  was removed before commit. No dedicated `.t` pin — none could be written
+  for a branch with no known reachable trigger.
+- **C6e-3c (open):** the field itself. Both former keep-classes (NativeCall
+  marshalling traits, class-walker nested subs) and the registration
+  fallback reader above are now resolved/hardened, but `legacy_body` has
+  not been physically deleted from `CompiledSubDeclPlan` yet — that
+  requires re-auditing every remaining `.legacy_body` read (`grep -rn
+  legacy_body src/`) to confirm none is load-bearing, then removing the
+  field and updating the two struct-literal construction sites
+  (`vm_register_sub_ops.rs`, `vm_typedecl_ops.rs`) plus the compiler side
+  that populates it. Not attempted in this session — do the final grep
+  audit first before assuming the deletion is purely mechanical.
 
 Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
 (the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`


### PR DESCRIPTION
## Summary

- ADR-0019 C6e-3c's `legacy_body` audit: `vm_call_named_inner.rs`'s sub-decl-as-last-statement case (`sub` as the final statement of a block, returning a Sub value) fell back to building the Sub from `plan.legacy_body` (AST only) whenever the def wasn't found in the registry under the plan's static name (computed-name `sub ::($name)` or a just-out-of-scope case).
- It now tries the plan's own `compiled_routine_keys[0]` against the call's functions table first — the same `plan_compiled(0)` lookup `RegisterSub` uses — and only falls back to the AST body if that key doesn't resolve either.
- This branch is essentially unreachable through ordinary Raku syntax: a full `t/` run (27700+ tests) hit it zero times even before the fix, and real Rakudo doesn't accept a runtime-computed sub name in the first place (`SORRY! Name ::($name) is not compile-time known...`). Validated with the project's env-gated-widen A/B methodology instead of a dedicated pin test: an env var forced the registry lookup to miss for every declaration in the suite, exercising the new fallback path exclusively — all 27705 tests still passed.
- This was the last outstanding `legacy_body` reader tracked for C6e-3c's former keep-classes (class-walker nested subs, NativeCall marshalling traits — both resolved earlier this session in #5982 / #5984). The `legacy_body` field itself is not deleted yet — that needs a fresh grep audit before removal is safe (documented in `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`).

## Test plan

- [x] `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings` clean
- [x] `make test` — full TAP suite green (27705 tests)
- [x] Env-gated A/B: forced the registry-miss fallback branch on for every declaration in the full `t/` suite — 27705/27705 still passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)