### PR TITLE
docs: record module-parse-warning-duplication investigation notes

### DIFF
--- a/todo/tickets/module-parse-warning-reported-twice.md
+++ b/todo/tickets/module-parse-warning-reported-twice.md
@@ -63,3 +63,56 @@ is only ever scanned and never loaded at run time. The warnings need an origin
 (source path + line) recorded when they are raised, and de-duplication on that
 origin — which also fixes the misattributed location. That means touching
 `add_parse_warning`'s signature and every one of its ~10 call sites.
+
+## Investigation notes (2026-08-06)
+
+Traced the exact call chain with `rust-gdb` breakpoints on `write_warn_to_stderr`
+for the repro above:
+
+- **First print**: `Interpreter::run` (`src/runtime/run.rs:397`) — the mainline
+  parse of `pcwarn.raku` itself. Parsing its `use PrecompWarn;` statement
+  triggers `scan_module_source` -> `parse_program_partial` on the module (for
+  the export scan), which pushes the warning into the *global* `PARSE_WARNINGS`
+  thread-local but never drains it. When the outer `parse_program` finishes and
+  `Interpreter::run` calls `take_parse_warnings()`, it picks up this leftover
+  entry along with (none, in this repro) its own.
+- **Second print**: `Interpreter::parse_module_source`
+  (`src/runtime/run_modules.rs:448`) — executing the `use` opcode actually loads
+  the module, re-parsing the identical source fresh and generating the same
+  warning text again, drained and printed here too.
+
+**The location misattribution has a different root cause than "no origin
+tracked at push time".** `write_warn_to_stderr` (`src/runtime/runtime_output.rs`)
+appends its "in ... at FILE line N" suffix via `self.build_backtrace_string()`
+— the *interpreter's current execution position* at print time, not anything
+derived from the parser's warning bookkeeping. Both prints fire while the VM is
+still mid-executing the `use PrecompWarn;` statement in `pcwarn.raku`, so both
+show `pcwarn.raku line 1` regardless of which parse actually produced the
+warning. Fixing this needs the print sites to use the warning's own recorded
+origin instead of the backtrace when one is available — a separate change from
+whatever fixes the duplication.
+
+**Attempted approach and why it was not landed:** `parser_source_file()`
+(`src/parser/stmt/simple/lib_paths.rs`) already tracks the file currently being
+parsed and is readable with zero call-site changes (`add_parse_warning` can
+snapshot it internally) — so *file*-level dedup (skip a `(file, message)` pair
+already surfaced) is cheap and closes the observed bug without the full
+per-line plumbing. The blocker is the **reset boundary**: `parse_program`
+(`src/parser/mod.rs:314`) clears `PARSE_WARNINGS` at the start of *every*
+top-level parse, including each nested module/EVAL parse — so a
+session-persistent "already surfaced" set must NOT be cleared there, or the
+module's second (run-time) parse would just refill it and reprint (defeating
+the fix). But it is unclear whether the set should ever reset at all within one
+process: mutsu tests commonly spin up multiple `Interpreter`s or run several
+`.t`/EVAL'd programs in one process (`is_run`, nested EVAL, the REPL), and each
+such *separate program run* likely should see its own warnings independently,
+the way separate `raku` process invocations would. Getting this boundary wrong
+either re-introduces the duplicate (reset too often) or silently suppresses a
+legitimate warning in a later, unrelated script sharing the process (reset too
+rarely) — and no existing test pins which behavior is correct, so a wrong
+choice would not necessarily be caught by `make test`/`make roast`. Whoever
+picks this up should either find/add such a test first, or scope the "surfaced"
+set to something narrower than the whole process (e.g. per top-level
+`Interpreter::run` invocation, threaded through explicitly rather than a bare
+thread-local) so nested module/EVAL parses share it but sibling top-level runs
+don't.


### PR DESCRIPTION
## Summary
- Investigated `todo/tickets/module-parse-warning-reported-twice.md` (a module's parse warning prints twice, misattributed to the importer's line).
- Traced the exact duplicate-print call chain with `rust-gdb` breakpoints: first print is `Interpreter::run`'s mainline drain picking up the export scan's leftover `PARSE_WARNINGS` entry; second is `parse_module_source`'s own fresh re-parse.
- Found the location misattribution has a *separate* root cause from what the ticket assumed: `write_warn_to_stderr` stamps the interpreter's current execution position (`build_backtrace_string()`), not anything derived from the parser's warning bookkeeping — so fixing that is independent of fixing the duplication.
- Attempted a file-level session-dedup fix (`parser_source_file()` is already readable inside `add_parse_warning` with zero call-site changes) but did not land it: the reset boundary for a session-persistent "already surfaced" set is unclear, since mutsu commonly runs multiple `Interpreter`s / programs in one process (`is_run`, nested `EVAL`, the REPL), and no existing test pins whether a later, unrelated program sharing the process should still see the same warning independently. A wrong reset boundary would either not fix the bug or silently suppress a legitimate warning elsewhere, and neither would necessarily be caught by `make test`/`make roast`.
- Recorded the full trace in the ticket so the next attempt doesn't have to redo the investigation, and outlined what's needed to close it safely (either a test that pins the reset boundary, or scoping the "surfaced" set to something narrower than the whole process).

This is a docs-only change (ticket notes); no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)