### PR TITLE
fix(compiler): hand compiled bytecode to nested our-sub hoist plans

### DIFF
--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -335,13 +335,30 @@ impl Compiler {
         let mut nested = Vec::new();
         collect(stmts, 0, &mut nested);
         for mut hoisted in nested {
-            if let Stmt::SubDecl { custom_traits, .. } = &mut hoisted {
-                custom_traits.retain(|(t, _)| {
-                    t.starts_with("__") || t == "default" || t.starts_with("DEPRECATED")
-                });
-            }
+            let name = match &mut hoisted {
+                Stmt::SubDecl {
+                    name,
+                    custom_traits,
+                    ..
+                } => {
+                    custom_traits.retain(|(t, _)| {
+                        t.starts_with("__") || t == "default" || t.starts_with("DEPRECATED")
+                    });
+                    *name
+                }
+                _ => unreachable!("collect() only pushes SubDecl statements"),
+            };
             let idx = self.add_sub_decl_plan(&hoisted);
             self.code.emit(OpCode::RegisterDecl(idx));
+            // Remember the hoisted plan so the source-order compile of the
+            // same declaration hands it the bytecode it compiles, exactly
+            // like `hoist_sub_decls` does (`Compiler::hoisted_sub_plans`) —
+            // without this, this plan's `compiled_routine_keys` stays empty
+            // forever (ADR-0019 C6e-3c: `CompiledSubDeclPlan` no longer has
+            // an AST body to fall back to when that happens).
+            if let Some(fp) = self.code.sub_decl_plan_fingerprint(idx) {
+                self.hoisted_sub_plans.push((name, fp, idx));
+            }
         }
     }
 

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -211,16 +211,58 @@ sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
   exercised this branch, and all 27705 tests still passed; the instrument
   was removed before commit. No dedicated `.t` pin — none could be written
   for a branch with no known reachable trigger.
-- **C6e-3c (open):** the field itself. Both former keep-classes (NativeCall
-  marshalling traits, class-walker nested subs) and the registration
-  fallback reader above are now resolved/hardened, but `legacy_body` has
-  not been physically deleted from `CompiledSubDeclPlan` yet — that
-  requires re-auditing every remaining `.legacy_body` read (`grep -rn
-  legacy_body src/`) to confirm none is load-bearing, then removing the
-  field and updating the two struct-literal construction sites
-  (`vm_register_sub_ops.rs`, `vm_typedecl_ops.rs`) plus the compiler side
-  that populates it. Not attempted in this session — do the final grep
-  audit first before assuming the deletion is purely mechanical.
+- **C6e-3c (open, blocked on a new prerequisite found 2026-08-06):** the
+  field itself. A fresh `grep -rn legacy_body src/` audit confirmed
+  `CompiledClassDeclPlan`/`CompiledRoleDeclPlan` each have their own
+  unrelated `legacy_body` (a different ADR-0019 stage; only
+  `CompiledSubDeclPlan::legacy_body` is this ticket's target), and that
+  `CompiledSubDeclPlan::legacy_body` itself has exactly three real readers:
+  the two `body` bindings inside `vm_register_sub_ops.rs::exec_register_sub_op`
+  (passed to `register_compiled_sub_decl`/`register_sub_alternate_decl` and to
+  the block-lexical escape hatch) and `vm_call_named_inner.rs`'s
+  sub-decl-as-last-statement fallback. All three already ran an empty body
+  whenever `plan_fully_compiled && primary_compiled.is_some()` — the
+  C6e-3b/C6e-3c-established "safe class". Removing the field (tried and
+  **reverted** this session, see below) makes that condition's `false` branch
+  fall to a literally-empty body instead of `legacy_body` — the compiler-side
+  check for when `compile_sub_body_with_deprecation` can return `None`
+  confirmed the field is not needed for that path (the only `None` site,
+  a heredoc-scope-error, emits an immediate `Die` right after the plan's own
+  `RegisterDecl`, so the mis-compiled def can never actually be called).
+  **But the `false` branch is reachable for a second, much broader reason
+  that the removal attempt surfaced by running `make test` and hitting eight
+  real regressions** (`t/escaped-our-sub-*.t`, `t/our-sub-block-lexical-capture.t`,
+  `t/is-eqv.t`, `t/module-sub-otf-*.t`, `t/mustache-battery.t`,
+  `t/digest-battery.t`, `t/export-sub-infix-operator-closure.t`,
+  `t/indirect-declarator-names.t`): a plan can have `compiled_routine_keys`
+  fully populated (`plan_fully_compiled == true`) and yet the key still fails
+  to resolve in the *executing call's* `compiled_fns` table
+  (`primary_compiled.is_none()`), because that table is a **different, stale
+  one** substituted at the call site. This is the SAME defect class the
+  class-walker nested-subs keep-class above was fixed for (`MethodDef` got
+  its own `compiled_fns: Option<Arc<CompiledFns>>` in #5982), but it turns
+  out `call_compiled_method`'s 7 sites were not the only offenders — `grep
+  -rln 'CompiledFns::default()' src/` finds ~17 files, and at least
+  `resolution_call_sub.rs:385` (a "code object built from a registry
+  routine" carrier — reached e.g. when `is-eqv`'s `multi` dispatch calls
+  `_is-eqv`, which declares a nested `sub test-eqv`) demonstrably substitutes
+  an empty table for a routine that DOES have real nested-sub bytecode
+  compiled, just not reachable through that call's default-fns shortcut.
+  Neither `FunctionDef` nor `CompiledFunction` nor `SubData` carries a
+  reference to "this routine's own sibling functions table" the way
+  `MethodDef` now does — that is the missing piece. **C6e-3c cannot proceed
+  until each of those ~17 `CompiledFns::default()` call sites is audited and
+  given the routine's real table (or proven never to matter, the way the
+  NativeCall trait and registration-fallback keep-classes were), mirroring
+  the `MethodDef.compiled_fns` fix but generalized beyond methods.** That is
+  itself a multi-PR campaign, not a one-session slice. One narrow, genuinely
+  safe fix WAS extracted from this investigation and landed independently:
+  `hoist_nested_our_subs` (`compiler/helpers_ast_utils.rs`) never pushed its
+  hoisted plans into `Compiler::hoisted_sub_plans`, so an `our sub` nested in
+  a block never got its `compiled_routine_keys` handed over at all
+  (`keys_len=0` forever) — unlike `hoist_sub_decls`, which already does this
+  correctly. Fixed to match; this was latent on `main` too (masked by
+  `legacy_body`) and is a pure improvement independent of the field drop.
 
 Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
 (the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`

--- a/todo/deep/compiled-fns-default-breaks-nested-subs-outside-methods.md
+++ b/todo/deep/compiled-fns-default-breaks-nested-subs-outside-methods.md
@@ -1,0 +1,128 @@
+# `CompiledFns::default()` call sites silently drop nested-sub bytecode outside methods
+
+Found 2026-08-06 while attempting ADR-0019 C6e-3c (dropping
+`CompiledSubDeclPlan::legacy_body`); see that ticket
+(`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`) for the
+full narrative. This file is the actionable, generalized follow-up.
+
+## The defect
+
+A compiled routine that declares a nested `sub` (or a block-lexical `our sub`)
+only runs that nested sub correctly when the *executing call's*
+`compiled_fns: &CompiledFns` table happens to contain the nested sub's
+compiled key. Several call sites do not thread the real table through and
+instead pass `CompiledFns::default()` (an empty map) — the routine's own body
+still resolves fine (it runs from its own `CompiledFunction`/`compiled_code`),
+but any `RegisterSub` op inside that body for a nested declaration then finds
+`compiled_fns.get(&key)` returns `None`. Before ADR-0019 C6e-3b/3c, this was
+silently papered over: the nested sub's registration fell back to its AST
+body (`legacy_body` on `CompiledSubDeclPlan`) and ran through the tree-walking
+interpreter, producing the right answer at the cost of not being compiled.
+With `legacy_body` gone (or even just with the C6e-3b default-empty-body
+policy pushed further), a def in this state has neither a working AST body
+nor a resolvable compiled routine — it is silently a no-op / returns Nil.
+
+This is the *same defect class* already fixed once for method bodies: PR
+#5982 (`project-adr0019-c6e3c-nested-sub-lifted` memory) found that all 7
+`call_compiled_method` call sites (`class_dispatch.rs`,
+`builtins_dispatch_next.rs`, four `vm/vm_call_method_compiled_*.rs` files)
+substituted a hardcoded `CompiledFns::default()` for the executing method's
+own functions table, and fixed it by giving `MethodDef` its own
+`compiled_fns: Option<Arc<CompiledFns>>`, populated in
+`compile_method_def_in_place_with_dist` from the per-method `Compiler`'s own
+`compiled_functions` (previously discarded — only `compiled_code` was kept),
+then threading `method_def.compiled_fns` through all 7 sites instead of the
+hardcoded empty table.
+
+## Why it is not just a methods problem
+
+`grep -rln 'CompiledFns::default()' src/` currently finds ~17 files:
+
+```
+src/runtime/methods_distribution.rs
+src/runtime/decl_types.rs
+src/runtime/resolution_eval.rs
+src/vm/vm_call_method_compiled_interpret.rs   (already fixed for methods)
+src/runtime/runtime_module_export_sub.rs      (checked: EXPORT-only, deliberate)
+src/vm/vm_hyper_method_ops.rs
+src/vm/vm_misc_coerce.rs
+src/vm/vm_dispatch_helpers.rs
+src/runtime/resolution_call_sub.rs            (confirmed reproducer, see below)
+src/compiler/mod.rs
+src/runtime/class_dispatch.rs                 (already fixed for methods)
+src/vm/vm_var_assign_post_incdec.rs
+src/vm/vm_call_dispatch.rs
+src/runtime/builtins_dispatch_next.rs         (already fixed for methods)
+src/vm/vm_call_method_compiled_mut.rs         (already fixed for methods)
+src/vm/vm_set_arith_ops.rs
+src/vm/vm_arith_ops.rs
+src/vm/vm_call_method_compiled_cache.rs       (already fixed for methods)
+```
+
+Not all of these matter (some are genuinely fine to use an empty table — e.g.
+`runtime_module_export_sub.rs`'s `apply_module_export` calls the special
+`EXPORT` sub, which by construction should not itself declare callable nested
+subs that outlive it). But at least one — `resolution_call_sub.rs:385`, in
+the "code object built from a registry routine" carrier branch of
+`call_sub_value` — is a confirmed live reproducer:
+
+```raku
+proto sub is-eqv2(|) {*}
+multi sub is-eqv2(Mu $got, Mu $expected, Str:D $desc) {
+    sub test-eqv (Mu $got, Mu $expected) { $got eqv $expected }
+    my $test = test-eqv $got, $expected;
+    say "test=$test desc=$desc";
+}
+is-eqv2(42, 42, 'ints');
+```
+
+This is (almost verbatim) `Test::Util`'s real `_is-eqv` helper
+(`roast/packages/Test-Helpers/lib/Test/Util.rakumod`), which is why
+`t/is-eqv.t` was one of the tests that broke during the C6e-3c attempt. A
+plain (non-`multi`) top-level `sub outer { sub inner {...}; inner() }` does
+NOT reproduce it — something about how a `multi` candidate resolved to a Sub
+*value* and invoked via `call_sub_value` lands on the
+`data.compiled_routine.is_some()` branch (`resolution_call_sub.rs:382-391`)
+that hardcodes `let empty_fns = CompiledFns::default();` instead of the
+routine's own sibling-functions table.
+
+## What's missing structurally
+
+Unlike `MethodDef`, neither `FunctionDef` (the registry entry for an ordinary
+named sub) nor `CompiledFunction` (the compiled-routine descriptor,
+`Arc<CompiledFunction>` — this is what `SubData::compiled_routine` and
+`data.compiled_routine` above hold) nor `SubData` itself carries a reference
+to "this routine's own compiled sibling-functions table". `CompiledFunction`
+only has `code: CompiledCode` (its own bytecode), not the map of nested-sub
+keys → `CompiledFunction`s that its `RegisterSub` ops need to resolve.
+
+## Suggested next steps
+
+1. Decide where the per-routine `compiled_fns` table should live: probably a
+   new field on `CompiledFunction` itself (`Arc<CompiledFns>` or similar,
+   populated once at compile time from the compiling unit's
+   `compiled_functions`, mirroring `MethodDef.compiled_fns`), since that is
+   the thing every one of these call sites already has in hand
+   (`data.compiled_routine` / `cf`).
+2. Audit each of the ~17 `CompiledFns::default()` sites individually: does
+   this call path ever execute a routine that could contain nested `sub`
+   declarations? Fix the ones that can (thread the real table); leave a
+   `// TODO:` or a comment justifying the ones that provably cannot (like
+   `runtime_module_export_sub.rs`'s `EXPORT`-only use), following this
+   project's "measure, don't assume" convention — env-gated A/B against the
+   full `t/` + roast whitelist per site, the same way #5982 and the
+   `hoist_nested_our_subs` fix (see the C6e-3c ticket) were validated.
+3. Only after that lands should ADR-0019 C6e-3c (dropping
+   `CompiledSubDeclPlan::legacy_body`) be re-attempted — re-run `make test`
+   after the field removal as the acceptance gate; the removal itself is
+   mechanical once every reader's real dependency is gone.
+
+## What NOT to do
+
+Do not re-attempt dropping `legacy_body` before this lands — the field is the
+only thing currently keeping every one of these mis-wired call sites correct
+by accident (falling back to interpreting the real AST body). Removing it
+first would silently turn "runs slowly, via the interpreter" into "runs
+nothing, silently returns Nil" for every affected call path, which is worse
+and much harder to notice than a `make test` failure caught immediately after
+the field-removal PR.


### PR DESCRIPTION
## Summary
- `hoist_nested_our_subs` (early-registers `our sub`s nested inside blocks so `&OUR::foo()` resolves before the declaring block runs) never pushed its hoisted plans into `Compiler::hoisted_sub_plans`, unlike the sibling `hoist_sub_decls`. The source-order compile of the same declaration therefore never handed its compiled bytecode over, leaving the hoisted plan's `compiled_routine_keys` empty forever — silently masked today by `CompiledSubDeclPlan::legacy_body` falling back to the tree-walking interpreter for these subs.
- Fixed to match `hoist_sub_decls`'s existing hand-over pattern.
- Documents two findings from an ADR-0019 C6e-3c attempt (dropping `legacy_body`) that surfaced and then reverted this session: `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md` now records why that field drop is blocked, and a new ticket `todo/deep/compiled-fns-default-breaks-nested-subs-outside-methods.md` describes the actual prerequisite (several `CompiledFns::default()` call sites outside method dispatch silently drop nested-sub bytecode, the same defect class already fixed once for methods in #5982, just not everywhere).

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `make test` (27718 tests, all passing)
- [x] Spot-checked `roast/S04-declarations/our.t`, `roast/S02-names/our.t`, `roast/S02-names-vars/variables-and-packages.t`, `roast/S14-roles/basic.t` — all pass (unrelated failures in non-whitelisted `pseudo-6c/6d/6e.t` pre-exist on `main`)