### PR TITLE
fix(parser): angle-bracket word lists no longer warn about leading-zero octal typos

### DIFF
--- a/news/2026-08/angle-word-leading-zero-no-octal-warning.md
+++ b/news/2026-08/angle-word-leading-zero-no-octal-warning.md
@@ -1,0 +1,22 @@
+# Angle-bracket word lists no longer warn about "leading 0" octal typos
+
+`<0 10 021 1320 02431>` and similar `<...>` quote-word lists were emitting a
+spurious `Potential difficulties: Leading 0 does not indicate octal in Raku`
+warning for any word that looked like a leading-zero integer (`021`, `02431`),
+even though the words are string-literal `q:w` content, not numeric-literal
+syntax — raku emits no such warning here.
+
+Root cause: `<...>` list parsing produces allomorphic values (`IntStr`,
+`RatStr`, ...) by feeding each word through the same `integer()` parser used
+for real numeric literals in expression position, and that parser
+unconditionally records the leading-zero warning as a side effect. `<021>`
+correctly becomes `IntStr` with `.Int == 21` (decimal, not octal) and
+`.Str eq '021'` in both raku and mutsu — only the warning was wrong.
+
+Fix: split `integer()` into a shared `integer_impl(input, warn: bool)`, keep
+`integer()` (used at expression-parsing call sites) warning as before, and add
+a new `integer_no_warn()` for the angle-word allomorph path
+(`src/parser/primary/container/allomorph.rs`). Found via the real-dist
+compatibility sweep (`String::Splice`'s test suite,
+`todo/tickets/dist-test-suite-failures-batch.md`). Pinned by
+`t/angle-word-leading-zero-no-warn.t`.

--- a/src/parser/primary/container/allomorph.rs
+++ b/src/parser/primary/container/allomorph.rs
@@ -94,7 +94,7 @@ fn angle_word_value_impl(word: &str, fraction_allomorphic: bool) -> Value {
         make_allomorphic_value(val, word)
     };
     if let Ok((rest, crate::ast::Expr::Literal(val))) =
-        crate::parser::primary::number::integer(num_word)
+        crate::parser::primary::number::integer_no_warn(num_word)
         && rest.is_empty()
     {
         return apply(val);

--- a/src/parser/primary/number.rs
+++ b/src/parser/primary/number.rs
@@ -304,6 +304,19 @@ pub(super) fn parse_int_radix(clean: &str, radix: u32) -> Expr {
 
 /// Parse an integer literal (including underscore separators).
 pub(super) fn integer(input: &str) -> PResult<'_, Expr> {
+    integer_impl(input, true)
+}
+
+/// Like `integer`, but never emits the "Leading 0 does not indicate octal"
+/// warning. Used when parsing a `<...>` quote-word: `<021>` becomes an
+/// allomorphic IntStr whose Int value ignores the leading zero (decimal 21),
+/// but the word is a string literal, not numeric-literal syntax, so the
+/// octal-typo warning must not fire.
+pub(super) fn integer_no_warn(input: &str) -> PResult<'_, Expr> {
+    integer_impl(input, false)
+}
+
+fn integer_impl(input: &str, warn: bool) -> PResult<'_, Expr> {
     check_multi_underscore(input)?;
     // Hex: 0x...
     if let Some(result) = parse_prefixed_radix(input, "0x", "0X", 16, |c| {
@@ -330,7 +343,7 @@ pub(super) fn integer(input: &str) -> PResult<'_, Expr> {
     {
         return Err(PError::expected("integer (not decimal)"));
     }
-    if input.starts_with('0') && clean.len() > 1 {
+    if warn && input.starts_with('0') && clean.len() > 1 {
         let literal = &input[..input.len() - rest.len()];
         let suggested_digits = clean.trim_start_matches('0');
         let suggested = format!(

--- a/t/angle-word-leading-zero-no-warn.t
+++ b/t/angle-word-leading-zero-no-warn.t
@@ -1,0 +1,16 @@
+use v6;
+use Test;
+
+plan 4;
+
+# `<021>` is a quote-word (q:w) that produces an allomorphic IntStr whose
+# numeric value ignores the leading zero (decimal 21, not octal). Since the
+# word is string-literal syntax, not numeric-literal syntax, the "Leading 0
+# does not indicate octal" compile-time warning must not fire for it.
+my @ans = <0 10 021 1320 02431>;
+is @ans.join(' '), '0 10 021 1320 02431', 'angle word list keeps original spelling';
+
+my $x = <021>;
+isa-ok $x, IntStr, '<021> is an IntStr allomorph';
+is $x.Str, '021', '<021>.Str keeps the leading zero';
+is $x.Int, 21, '<021>.Int parses as decimal 21, not octal';

--- a/todo/tickets/dist-test-suite-failures-batch.md
+++ b/todo/tickets/dist-test-suite-failures-batch.md
@@ -41,17 +41,9 @@ equally broken before the listop-shadow gate landed
 changed which error appears. Suspect the call path looks for an exported proto
 rather than assembling the exported multi candidates.
 
-### `String::Splice` — spurious octal worry for a bare word inside `<...>`
+### ~~`String::Splice` — spurious octal worry for a bare word inside `<...>`~~ — FIXED
 
-```raku
-my @ans = <0 10 021 1320 02431>;
-# mutsu: Potential difficulties: Leading 0 does not indicate octal in Raku; use 0o21 ... (found 021)
-# raku:  (no warning)
-```
-
-Inside a word-quote list these are **strings**, not numeric literals, so the
-leading-zero worry must not fire. Independent of the item above; cosmetic but
-noisy (four warnings on one line).
+Fixed: `news/2026-08/angle-word-leading-zero-no-octal-warning.md`.
 
 ### `Text::Sorensen` — `.value` on Any
 


### PR DESCRIPTION
## Summary
- `<0 10 021 1320 02431>` and similar `<...>` quote-word lists spuriously emitted the "Leading 0 does not indicate octal in Raku" warning for numeric-looking words, even though `<...>` content is `q:w` string-literal syntax, not a numeric literal — raku emits no warning here.
- Found via the real-dist compatibility sweep (`String::Splice`'s own test suite); tracked in `todo/tickets/dist-test-suite-failures-batch.md`.

## Root cause
The `<...>` allomorph parser (`angle_word_value_impl`) reuses the same `integer()` parser used for real numeric-literal expression parsing to detect `IntStr` words like `<021>`. That parser unconditionally records the leading-zero-octal warning as a side effect, regardless of call site.

## Fix
Split `integer()` into a shared `integer_impl(input, warn: bool)`. Expression-position numeric literals keep calling `integer()` (warns as before); the angle-word allomorph path now calls a new `integer_no_warn()`.

## Test plan
- [x] New `t/angle-word-leading-zero-no-warn.t`, verified identical output under `raku`
- [x] `make test` — all green (2924 files, 27726 tests)
- [x] `cargo clippy -- -D warnings` / `cargo fmt` clean (pre-commit hooks passed)