### PR TITLE
docs: close the Text::Sorensen test-suite-failure ticket item (not reproducible)

### DIFF
--- a/news/2026-08/text-sorensen-value-on-any-not-reproducible.md
+++ b/news/2026-08/text-sorensen-value-on-any-not-reproducible.md
@@ -1,0 +1,18 @@
+# `Text::Sorensen`'s `t/01-basic.t` failure no longer reproduces
+
+`todo/tickets/dist-test-suite-failures-batch.md` tracked a triaged failure in
+the `Text::Sorensen` dist's own test suite: `No such method 'value' for
+invocant of type 'Any'` at `t/01-basic.t:15`, reached after subtest 3 of 21
+(found by the 2026-07-25 `--run-tests` sweep).
+
+Re-running the dist's test suite against current `main`
+(`raku -I lib t/01-basic.t` under mutsu, from the cached sweep tarball at
+`~/.cache/mutsu-dist-sweep/T_EX_TEXT_SORENSEN_*.tar.gz`) now passes all 21
+subtests cleanly, matching `raku` exactly. The suspect code path — the
+`%hash.race.map({ ... .value ... })` multi candidate of `sorensen()`/`jaccard()`
+in `lib/Text/Sorensen.pm6`, which calls `.value`/`.key` on the topic during a
+`Bag`/`Bag` set intersection and symmetric-difference calculation — was
+reduced to a minimal standalone repro and also passes.
+
+No code change; the underlying fix landed as a side effect of unrelated work
+between 2026-07-25 and 2026-08-06. Closing the ticket item.

--- a/todo/tickets/dist-test-suite-failures-batch.md
+++ b/todo/tickets/dist-test-suite-failures-batch.md
@@ -53,11 +53,10 @@ Inside a word-quote list these are **strings**, not numeric literals, so the
 leading-zero worry must not fire. Independent of the item above; cosmetic but
 noisy (four warnings on one line).
 
-### `Text::Sorensen` — `.value` on Any
+### ~~`Text::Sorensen` — `.value` on Any~~ — not reproducible on current main
 
-Reaches subtest 4 of 21, then dies with
-`No such method 'value' for invocant of type 'Any'` at `t/01-basic.t:15`. Whatever
-the code expects to be a `Pair` there is `Any` in mutsu. Needs reduction.
+Fixed as a side effect of unrelated work; see
+`news/2026-08/text-sorensen-value-on-any-not-reproducible.md`.
 
 ### ~~`Locale::Dates` — `Unknown function: Dates`~~ — FIXED
 


### PR DESCRIPTION
## Summary
- `todo/tickets/dist-test-suite-failures-batch.md` tracked a `Text::Sorensen` dist test-suite failure (`.value` on `Any` in a `Bag` intersection inside `sorensen()`/`jaccard()`) found by the 2026-07-25 `--run-tests` sweep.
- Re-ran the dist's own suite (`raku -I lib t/01-basic.t` under mutsu, from the cached sweep tarball) and a reduced standalone repro against current `main`: both pass all subtests cleanly, matching `raku`.
- No code change — fixed as a side effect of unrelated work landed between 2026-07-25 and today. Closing the ticket item with a `news/` entry per the project's todo-tickets workflow.

## Test plan
- [x] docs-only change (`ci-docs-only.sh` classifies this as skip-eligible for the heavy CI jobs)