### PR TITLE
fix(compiler,vm): give a compiled routine its own nested-sub table

### DIFF
--- a/news/2026-08/compiled-function-carries-its-own-nested-sub-table.md
+++ b/news/2026-08/compiled-function-carries-its-own-nested-sub-table.md
@@ -1,0 +1,54 @@
+# A compiled routine now carries its own nested-sub table
+
+ADR-0019 C6e-3c (dropping `CompiledSubDeclPlan::legacy_body`) was blocked on
+a defect class found while investigating it: a plan-derived sub can have its
+declaration-time bytecode fully compiled (`plan_fully_compiled == true`) and
+still fail to *dispatch* that bytecode, because the `CompiledFns` table
+threaded through the executing call is often unrelated to the routine being
+invoked. This happens whenever a routine is called as a detached `Sub`
+VALUE — a map/grep block, an operator fallback, a `.wrap` target, `MAIN`, a
+multi-deferral candidate, a reduce/hyper step, `sub EXPORT` dispatch — since
+none of those calling contexts naturally has the callee's own compile-time
+functions table in scope. The concrete symptom: a nested `sub` declared
+inside such a routine's body could never resolve its own compiled routine
+key at registration time, so it silently fell back to registering with an
+executable AST body instead of running compiled — the `is-eqv` multi
+dispatching to `_is-eqv`, which declares a nested `sub test-eqv`, was one
+real instance.
+
+`CompiledFunction` now carries `compiled_fns: Option<Arc<CompiledFns>>` —
+the nested-sub subtree it was compiled alongside, mirroring the
+`MethodDef.compiled_fns` fix from #5982 but generalized from methods to
+plain subs. It is populated at both places a `CompiledFunction` is built
+(the named-sub compile path in `compiler/helpers_sub_body.rs`, and the
+on-the-fly compile path in `vm::vm_call_dispatch::otf_compile_function_def`)
+by having `Compiler::import_compiled_functions` return the post-remap
+import set it used to discard, instead of a caller having to re-derive it.
+
+An audit of the ~17 call sites that previously substituted
+`CompiledFns::default()` for a routine they had in hand now prefers
+`cf.compiled_fns` first, falling back to an empty table only when the
+routine declares no nested sub. Several of them funnel through
+`compile_and_call_function_def` and `call_function_compiled_first`, so
+fixing those two functions transitively fixed `sub EXPORT` dispatch, the
+`prefix:<~>` operator-overload probe, and the numeric/set operator
+fallbacks as well. The remaining `CompiledFns::default()` sites are either
+the pre-existing, already-correct `MethodDef.compiled_fns` reads, or a raw
+closure's `compiled_code` (out of scope: `SubData` carries no equivalent
+field, and a closure is never plan-derived).
+
+Validated by re-running the same experiment an earlier (reverted) attempt
+at dropping `legacy_body` used: force every plan-derived def to register
+body-less regardless of whether its compiled routine key resolves. Before
+this fix that surfaced eight real regressions across `t/`
+(`t/escaped-our-sub-*.t`, `t/our-sub-block-lexical-capture.t`,
+`t/is-eqv.t`, `t/module-sub-otf-*.t`, `t/mustache-battery.t`,
+`t/digest-battery.t`, `t/export-sub-infix-operator-closure.t`,
+`t/indirect-declarator-names.t`). With this fix in place, only one file
+still fails under the same forced experiment — a `proto sub` nested inside
+an OTF-compiled module sub, isolated to `RegisterProtoSub`'s separate,
+still-`stmt_pool`-indexed registration mechanism (ADR-0019 slice C8,
+explicitly out of C6e-3c's scope). The full `t/` suite (27718 tests) and
+`make roast` (218774 tests) both pass unmodified with the carrier field
+landed. Details and the narrowed remaining blocker:
+`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -21,12 +21,18 @@ impl Compiler {
     /// plans in that unit pointing at the imported keys. Multi candidates omit
     /// their body fingerprint from the normal lookup key, so two nested units can
     /// legitimately produce the same key for different routines.
+    ///
+    /// Returns the imported entries under their final (post-remap) keys, so a
+    /// caller building the `CompiledFunction` that owns this child unit can
+    /// attach them as that routine's own [`CompiledFunction::compiled_fns`]
+    /// (ADR-0019 C6e-3c) without re-deriving which keys were renamed.
     fn import_compiled_functions(
         &mut self,
         code: &mut CompiledCode,
         compiled_functions: CompiledFns,
-    ) {
+    ) -> CompiledFns {
         let mut remap = rustc_hash::FxHashMap::default();
+        let mut imported = CompiledFns::default();
         for (key, function) in compiled_functions {
             let imported_key = if self.compiled_functions.contains_key(&key) {
                 let base = key.resolve();
@@ -44,11 +50,14 @@ impl Compiler {
             if imported_key != key {
                 remap.insert(key, imported_key);
             }
-            self.compiled_functions.insert(imported_key, function);
+            self.compiled_functions
+                .insert(imported_key, function.clone());
+            imported.insert(imported_key, function);
         }
         if !remap.is_empty() {
             code.remap_sub_decl_compiled_routine_keys(&remap);
         }
+        imported
     }
 
     /// Recursively allocate local variable slots for sub_signature parameters
@@ -483,7 +492,7 @@ impl Compiler {
         // call_compiled_closure catches CX::Return at the right boundary.
         sub_compiler.code.is_routine = true;
         sub_compiler.code.compute_needs_env_sync();
-        self.import_compiled_functions(
+        let own_compiled_fns = self.import_compiled_functions(
             &mut sub_compiler.code,
             std::mem::take(&mut sub_compiler.compiled_functions),
         );
@@ -511,6 +520,8 @@ impl Compiler {
             // The declaring package, matching the package component of this
             // function's `compiled_fns` key (built from `self.current_package`).
             package: self.current_package.clone(),
+            compiled_fns: (!own_compiled_fns.is_empty())
+                .then(|| std::sync::Arc::new(own_compiled_fns)),
         };
         cf.precompute_param_local_slots();
         cf.precompute_named_call_plan();
@@ -1258,7 +1269,11 @@ impl Compiler {
         }
         // Transfer any compiled functions from the closure to the parent while
         // preserving the declaration-plan references into the imported table.
-        self.import_compiled_functions(
+        // The caller reads them back via `compiled_functions_ref()` /
+        // `take_compiled_functions()` when it needs this routine's own
+        // nested-sub table (ADR-0019 C6e-3c), so the returned snapshot itself
+        // is not needed here.
+        let _ = self.import_compiled_functions(
             &mut sub_compiler.code,
             std::mem::take(&mut sub_compiler.compiled_functions),
         );

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -5520,6 +5520,25 @@ pub(crate) struct CompiledFunction {
     /// sites pass the *caller's* package, which is wrong for a by-name call into
     /// another package; this authoritative field fixes all of them at once.
     pub(crate) package: String,
+    /// Compiled functions this routine's body directly or transitively
+    /// declares as nested `sub`s, keyed exactly as they were installed into
+    /// the enclosing compile pass's functions table (post name-collision
+    /// remap). `None` when the body declares no nested sub.
+    ///
+    /// A dispatch site that invokes this routine as a detached `Sub` VALUE —
+    /// a map/grep block, an operator fallback, a `.wrap` target, `MAIN`, a
+    /// reduce/hyper step — is not necessarily still inside the `CompiledFns`
+    /// table this routine was originally compiled alongside, so it cannot
+    /// resolve a nested `RegisterSub`'s `compiled_routine_keys` from its own
+    /// calling context. Without this field such sites substituted
+    /// `CompiledFns::default()`, which made a nested sub's declaration plan
+    /// fail to resolve its own bytecode and fall back to registering with an
+    /// executable AST body — the blocker recorded in
+    /// `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`
+    /// (ADR-0019 C6e-3c). Every such site should prefer this table over an
+    /// empty one before falling back to whatever `CompiledFns` the caller
+    /// happens to have in scope.
+    pub(crate) compiled_fns: Option<std::sync::Arc<CompiledFns>>,
 }
 
 impl CompiledFunction {

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -748,17 +748,21 @@ impl Interpreter {
             // same candidate forever (stack overflow in
             // `t/multi-where-otf-dispatch.t`). It also must not push a samewith
             // context, matching the interpreter entry this replaces.
-            let empty_fns = crate::opcode::CompiledFns::default();
             let cf = match &next_def.compiled {
                 Some(compiled) => std::sync::Arc::clone(compiled),
                 None => self.otf_compile_function_def(&next_def),
             };
+            // Prefer the candidate's own nested-sub table over an empty one
+            // (ADR-0019 C6e-3c) — this deferral chain owns no `CompiledFns` of
+            // its own to offer.
+            let empty_fns = crate::opcode::CompiledFns::default();
+            let fns = cf.compiled_fns.as_deref().unwrap_or(&empty_fns);
             let next_pkg = next_def.package.resolve();
             let next_name = next_def.name.resolve();
             let result = self.call_compiled_function_named(
                 &cf,
                 call_args.clone(),
-                &empty_fns,
+                fns,
                 &next_pkg,
                 &next_name,
             );

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -382,13 +382,18 @@ impl Interpreter {
             if data.compiled_routine.is_some()
                 && let Some(cf) = data.compiled_routine.clone()
             {
+                // Prefer the routine's own nested-sub table over an empty one
+                // (ADR-0019 C6e-3c): e.g. `_is-eqv`'s multi dispatch calling
+                // `test-eqv`, a `sub` nested in its own body, needs this to
+                // resolve `test-eqv`'s compiled routine key.
                 let empty_fns = CompiledFns::default();
+                let fns = cf.compiled_fns.as_deref().unwrap_or(&empty_fns);
                 // Carrier parity: a binding failure here must surface raw
                 // (X::TypeCheck::Binding), not reclassified as a compile-time
                 // X::TypeCheck::Argument. One-shot; consumed at the callee's
                 // entry — see suppress_binding_error_enhance.
                 self.suppress_binding_error_enhance = true;
-                return self.call_compiled_closure(&data, &cf.code, call_args, &empty_fns);
+                return self.call_compiled_closure(&data, &cf.code, call_args, fns);
             }
             let saved_env = self.env.clone();
             let saved_readonly = self.enter_readonly_frame();

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -570,9 +570,13 @@ impl Interpreter {
                 // paths above, it executes in the CURRENT env — the semantics
                 // this fast path is defined by (a captured-env install would
                 // read the phaser-creation-time snapshot, not the live state).
+                // Its own nested-sub table (if any) travels with it rather
+                // than substituting an empty one (ADR-0019 C6e-3c).
                 (
                     std::sync::Arc::new(cf.code.clone()),
-                    std::sync::Arc::new(crate::opcode::CompiledFns::default()),
+                    cf.compiled_fns.clone().unwrap_or_else(|| {
+                        std::sync::Arc::new(crate::opcode::CompiledFns::default())
+                    }),
                 )
             } else {
                 let compiler = crate::compiler::Compiler::new();

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -65,7 +65,10 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         if let Some(cf) = self.find_compiled_function(compiled_fns, name, &args) {
             let pkg = self.current_package().to_string();
-            return self.call_compiled_function_named(cf, args, compiled_fns, &pkg, name);
+            // Prefer the routine's own nested-sub table over the caller's
+            // (ADR-0019 C6e-3c) — see `compile_and_call_function_def`.
+            let fns = cf.compiled_fns.as_deref().unwrap_or(compiled_fns);
+            return self.call_compiled_function_named(cf, args, fns, &pkg, name);
         }
         if let Some(native_result) =
             self.try_native_function(crate::symbol::Symbol::intern(name), &args)
@@ -178,7 +181,11 @@ impl Interpreter {
             return cached;
         }
         let pkg = def.package.resolve();
-        let cc = {
+        // `compiler` compiles ONLY `def`'s own body, so anything it accumulates
+        // in `compiled_functions` is exactly this routine's own nested-sub
+        // subtree — attach it below so a later detached-value call of this
+        // routine can resolve its nested `RegisterSub` keys (ADR-0019 C6e-3c).
+        let (cc, own_compiled_fns) = {
             let mut compiler = crate::compiler::Compiler::new();
             if !pkg.is_empty() && pkg != "GLOBAL" {
                 compiler.set_current_package(pkg.to_string());
@@ -186,7 +193,8 @@ impl Interpreter {
             // Resolve $?DISTRIBUTION from the function's defining package (or an
             // enclosing module's distribution for a nested package / role method).
             compiler.current_distribution = self.resolve_package_distribution(&pkg);
-            compiler.compile_routine_closure_body(&def.params, &def.param_defs, &def.body)
+            let cc = compiler.compile_routine_closure_body(&def.params, &def.param_defs, &def.body);
+            (cc, compiler.take_compiled_functions())
         };
         let deprecated_info = def.deprecated_message.as_ref().map(|msg| {
             let kind = if def.is_method { "Method" } else { "Sub" };
@@ -215,6 +223,8 @@ impl Interpreter {
             declared_locals: None,
             param_name_syms: Vec::new(),
             package: pkg.clone(),
+            compiled_fns: (!own_compiled_fns.is_empty())
+                .then(|| std::sync::Arc::new(own_compiled_fns)),
         };
         cf.precompute_param_local_slots();
         cf.precompute_named_call_plan();
@@ -285,7 +295,13 @@ impl Interpreter {
         self.push_samewith_context(&name, None);
         let pushed_dispatch = loan_env!(self, push_multi_dispatch_frame(&name, &args));
 
-        let result = self.call_compiled_function_named(&cf, args, compiled_fns, &pkg, &name);
+        // Prefer the routine's own nested-sub table over the caller's: a
+        // caller with no table of its own (e.g. `sub EXPORT` dispatch) must
+        // still resolve `cf`'s own nested `RegisterSub` keys (ADR-0019
+        // C6e-3c), and a plan-compiled/OTF-compiled `cf` always carries the
+        // table it was compiled alongside.
+        let fns = cf.compiled_fns.as_deref().unwrap_or(compiled_fns);
+        let result = self.call_compiled_function_named(&cf, args, fns, &pkg, &name);
 
         self.pop_samewith_context();
         if pushed_dispatch {
@@ -321,12 +337,15 @@ impl Interpreter {
         // `as_str`, not `resolve`: the latter allocates a `String` per call.
         let pkg = def.package.as_str();
         let name = def.name.as_str();
-        let empty_fns = CompiledFns::default();
         let cf = match &def.compiled {
             Some(compiled) => Arc::clone(compiled),
             None => self.otf_compile_function_def(def),
         };
-        self.call_compiled_function_named(&cf, args, &empty_fns, pkg, name)
+        // Prefer the routine's own nested-sub table (ADR-0019 C6e-3c) over an
+        // empty one: this caller owns no `CompiledFns` of its own to offer.
+        let empty_fns = CompiledFns::default();
+        let fns = cf.compiled_fns.as_deref().unwrap_or(&empty_fns);
+        self.call_compiled_function_named(&cf, args, fns, pkg, name)
     }
 
     /// Check if a function name is handled by the interpreter's Rust code

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -402,31 +402,40 @@ impl Interpreter {
         }
         // A code object built from a registry routine carries that routine's own
         // bytecode, so it runs compiled without re-compiling its AST body
-        // (ADR-0019 C6c). Mirrors `vm_call_on_value`.
+        // (ADR-0019 C6c). Mirrors `vm_call_on_value`. Prefer the routine's own
+        // nested-sub table over an empty one (ADR-0019 C6e-3c).
         if let Some(cf) = data.compiled_routine.clone() {
             let data = data.clone();
+            let fns = cf.compiled_fns.as_deref().unwrap_or(&empty_fns);
             return self.call_compiled_closure_with_topic(
                 &data,
                 &cf.code,
                 args,
                 explicit_topic,
                 capture_rw_topic,
-                &empty_fns,
+                fns,
             );
         }
         // Sub without compiled_code: compile on-the-fly (mirrors vm_call_on_value).
-        let cc = {
+        let (cc, own_compiled_fns) = {
             let mut compiler = crate::compiler::Compiler::new();
-            compiler.compile_routine_closure_body(&data.params, &data.param_defs, &data.body)
+            let cc =
+                compiler.compile_routine_closure_body(&data.params, &data.param_defs, &data.body);
+            (cc, compiler.take_compiled_functions())
         };
         let data = data.clone();
+        let fns = if own_compiled_fns.is_empty() {
+            &empty_fns
+        } else {
+            &own_compiled_fns
+        };
         self.call_compiled_closure_with_topic(
             &data,
             &cc,
             args,
             explicit_topic,
             capture_rw_topic,
-            &empty_fns,
+            fns,
         )
     }
 
@@ -507,7 +516,14 @@ impl Interpreter {
         {
             let data = data.clone();
             let empty_fns = CompiledFns::default();
-            let fns = compiled_fns.unwrap_or(&empty_fns);
+            // Prefer the routine's OWN nested-sub table over the caller's
+            // (a detached value call's caller context has no relation to
+            // this callee's nested `RegisterSub` keys — ADR-0019 C6e-3c).
+            let fns = cf
+                .compiled_fns
+                .as_deref()
+                .or(compiled_fns)
+                .unwrap_or(&empty_fns);
             // A value call is never compile-time-diagnosable: keep a binding
             // failure's runtime X::TypeCheck::Binding identity instead of
             // reclassifying it as X::TypeCheck::Argument (raku throws Binding
@@ -520,14 +536,23 @@ impl Interpreter {
         if let ValueView::Sub(data) = target.view()
             && !data.body.is_empty()
         {
-            let cc = {
+            let (cc, own_compiled_fns) = {
                 let mut compiler = crate::compiler::Compiler::new();
                 // Use routine closure body so `return` inside the sub works correctly
-                compiler.compile_routine_closure_body(&data.params, &data.param_defs, &data.body)
+                let cc = compiler.compile_routine_closure_body(
+                    &data.params,
+                    &data.param_defs,
+                    &data.body,
+                );
+                (cc, compiler.take_compiled_functions())
             };
             let data = data.clone();
             let empty_fns = CompiledFns::default();
-            let fns = compiled_fns.unwrap_or(&empty_fns);
+            let fns = if !own_compiled_fns.is_empty() {
+                &own_compiled_fns
+            } else {
+                compiled_fns.unwrap_or(&empty_fns)
+            };
             // A value call is never compile-time-diagnosable, same reasoning as
             // the `compiled_routine` branch above: a named sub (e.g. from EVAL)
             // dispatched through a value must keep a binding failure's runtime

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -264,6 +264,60 @@ sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
   correctly. Fixed to match; this was latent on `main` too (masked by
   `legacy_body`) and is a pure improvement independent of the field drop.
 
+- **`CompiledFunction::compiled_fns` carrier landed (2026-08-06), closing the
+  ~17-site audit.** `CompiledFunction` now carries its own
+  `compiled_fns: Option<Arc<CompiledFns>>` — the nested-sub subtree it was
+  compiled alongside, captured at both construction sites
+  (`helpers_sub_body.rs`'s named-sub compile, and
+  `vm_call_dispatch.rs::otf_compile_function_def`) via
+  `import_compiled_functions` now returning its post-remap import set
+  instead of discarding it. Every dispatch site that used to substitute
+  `CompiledFns::default()` for a `CompiledFunction`/`compiled_routine`
+  value it had in hand now prefers `cf.compiled_fns` first: the
+  `resolution_call_sub.rs:385` wrap-chain/value-call carrier named above
+  (the `is-eqv` case), `call_routine_def`, `compile_and_call_function_def`
+  (which also fixes its callers transitively —
+  `apply_module_export`/`sub EXPORT`, `vm_misc_coerce.rs`'s
+  `prefix:<~>` overload probe, `vm_arith_ops.rs`, `vm_set_arith_ops.rs`,
+  `vm_var_assign_post_incdec.rs`), `call_function_compiled_first`'s
+  `find_compiled_function` fast path, the multi-deferral chain in
+  `builtins_dispatch_next.rs`, and `resolution_eval.rs`'s
+  `Lock.protect`-block body-less-routine case. `find_compiled_function`
+  fast path, the multi-deferral chain in `builtins_dispatch_next.rs`, and
+  `resolution_eval.rs`'s `Lock.protect`-block body-less-routine case. The
+  remaining `CompiledFns::default()` sites are either (a) already-correct
+  pre-existing `MethodDef.compiled_fns` reads (the #5982 fix, a different
+  field on a different struct) or (b) a raw closure's `compiled_code`
+  (`SubData` carries no equivalent field — closures aren't in C6e-3c's
+  scope, since a plan-derived *def* never routes through `compiled_code`).
+  Full `t/` suite (27718 tests) and the eight previously-named regression
+  files pass with the carrier landed.
+- **Validation: forcing every plan-derived def to register body-less
+  (bypassing `primary_compiled.is_some()` entirely) now surfaces only ONE
+  file, not eight.** Re-ran the same experiment the earlier removal attempt
+  used (env-gated instrument in `vm_register_sub_ops.rs`, reverted before
+  commit) with the carrier fix in place: `t/module-sub-otf-interpreter-constructs.t`
+  tests 3-4 (`nested proto+multi dispatch`) are the only failures across the
+  full `t/` suite. Root-caused to a narrower case than C6e-3c: a `proto sub
+  inner($) {*}` nested inside an `our sub` that is (a) loaded from an
+  imported module and (b) forced body-less returns `Nil` instead of
+  dispatching — but the SAME proto+multi nesting at the top level (no
+  module import), and plain/multi-only nesting (no `proto`) inside an
+  imported module sub, both work correctly even forced. This isolates the
+  gap to `RegisterProtoSub` specifically, which — per ADR-0019 Decision §1
+  and the C8 slice description — still indexes `stmt_pool` rather than a
+  `CompiledSubDeclPlan`; it is explicitly out of C6e-3c's scope ("C8...
+  Independent of C6/C7; the slice exists because... unreachable while these
+  two opcodes still index the statement pool"). **C6e-3c's own blocker (the
+  ~17-site audit) is therefore resolved; the field drop is now blocked
+  only on this proto-in-OTF-module-sub gap, which is C8-adjacent and needs
+  its own root-cause investigation** (why forcing the OUTER `our sub`
+  body-less breaks a proto nested inside it, when the proto mechanism
+  itself is unchanged — likely something the outer sub's dropped AST body
+  was still incidentally providing to the `RegisterProtoSub` walker, e.g.
+  `stmt_pool` reachability or a `{*}`-rewrite precondition keyed off the
+  def still being tree-walk-eligible).
+
 Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
 (the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`
 (the C6d-5 gate).


### PR DESCRIPTION
## Summary

ADR-0019 C6e-3c (dropping `CompiledSubDeclPlan::legacy_body`) was blocked on
a defect class its investigation found (`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`):
a plan-derived sub's declaration-time bytecode can be fully compiled and
still fail to *dispatch* it, because the `CompiledFns` table threaded
through the call is often unrelated to the routine being invoked — a
detached `Sub` value call (map/grep block, operator fallback, `.wrap`
target, `MAIN`, a multi-deferral candidate, `sub EXPORT` dispatch...) has
no natural way to reach the callee's own compile-time functions table. The
concrete symptom: a nested `sub` declared inside such a routine could never
resolve its own compiled routine key, so it silently kept an executable
AST body (`is-eqv`'s multi dispatching to `_is-eqv`, which declares a
nested `sub test-eqv`, was one real instance).

- `CompiledFunction` now carries `compiled_fns: Option<Arc<CompiledFns>>`
  — the nested-sub subtree it was compiled alongside — mirroring the
  `MethodDef.compiled_fns` fix from #5982, generalized from methods to
  plain subs. Populated at both construction sites (the named-sub compile
  path, and the on-the-fly compile path) via `import_compiled_functions`
  now returning its post-remap import set instead of discarding it.
- Audited the ~17 call sites that substituted `CompiledFns::default()` for
  a routine they had in hand and wired them to prefer `cf.compiled_fns`
  first. Several funnel through `compile_and_call_function_def` and
  `call_function_compiled_first`, so fixing those two transitively fixed
  `sub EXPORT` dispatch, the `prefix:<~>` operator-overload probe, and the
  numeric/set operator fallbacks too.

## Validation

Re-ran the same experiment an earlier (reverted) `legacy_body`-removal
attempt used: force every plan-derived def to register body-less
regardless of whether its compiled routine key resolves. Before this fix
that surfaced eight real regressions across `t/`. With this fix, only ONE
file still fails under the same forced experiment — a `proto sub` nested
inside an OTF-compiled module sub, isolated to `RegisterProtoSub`'s
separate, still-`stmt_pool`-indexed registration (ADR-0019 slice C8,
explicitly out of C6e-3c's scope). That narrower remaining gap is recorded
in the todo doc for a follow-up session.

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
- [x] Full `t/` suite: 27718 tests, all passing
- [x] `make roast`: 218774 tests, all passing
- [x] Named regression files from the prior investigation
      (`t/is-eqv.t`, `t/escaped-our-sub-*.t`, `t/module-sub-otf-*.t`,
      `t/export-sub-infix-operator-closure.t`,
      `t/indirect-declarator-names.t`, `t/our-sub-block-lexical-capture.t`,
      `t/nested-sub-in-method-compiled.t`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)