### PR TITLE
docs: close the P5seek test-suite-failure ticket item (not reproducible)

### DIFF
--- a/news/2026-08/p5seek-not-reproducible.md
+++ b/news/2026-08/p5seek-not-reproducible.md
@@ -1,0 +1,16 @@
+# `P5seek`'s test suite failure no longer reproduces
+
+`todo/tickets/dist-test-suite-failures-batch.md` listed `P5seek` in the
+un-triaged `test_fail` bucket from the 2026-07-25 `--run-tests` sweep.
+
+Re-running its test suite against current `main` (`raku -I lib t/01-basic.t`
+under mutsu, from the cached sweep tarball at
+`~/.cache/mutsu-dist-sweep/P_5S_P5SEEK_*.tar.gz`) now passes all 11 subtests
+cleanly, matching `raku` exactly — both with and without `MUTSU_FUDGE=1` (the
+sweep script always sets it). The dist exercises `IO::Handle.seek` with a
+`SeekType` enum value looked up via `.^enum_value_list[$whence]`, `proto sub`
+export visibility, and `term:<...>` constant export — all now behave
+correctly.
+
+No code change; the underlying fix landed as a side effect of unrelated work
+between 2026-07-25 and 2026-08-06. Closing the ticket item.

--- a/todo/tickets/dist-test-suite-failures-batch.md
+++ b/todo/tickets/dist-test-suite-failures-batch.md
@@ -72,6 +72,11 @@ unsupported — `subset Sm of Int where * < 10; Sm(5)` returns 5 in raku,
 `Unknown function: Sm` in mutsu. Different mechanism (coerce to the base type,
 then check the constraint).
 
+### ~~`P5seek` — test suite failure~~ — not reproducible on current main
+
+Fixed as a side effect of unrelated work; see
+`news/2026-08/p5seek-not-reproducible.md`.
+
 ### `RSV` — triaged, root-caused, needs a compiler design pass
 
 `lib/RSV.rakumod` declares `constant \EOV = blob8.new(255);` (and `\EOR`,
@@ -87,7 +92,7 @@ it needs a design pass rather than a quick patch:
 
 ## Un-triaged `test_die` / `test_fail`
 
-`P5seek`, `Date::YearDay`, `PSpec`, `Array::Rounded` (fail);
+`Date::YearDay`, `PSpec`, `Array::Rounded` (fail);
 `Math::Interval`, `Native::Overflow`, `App::SudokuHelper`, `P5tie`,
 `Mathematica::Serializer::Encoder`, `Hash::Restricted`, `Crypt::RC4`,
 `Random::Choice` (die).


### PR DESCRIPTION
## Summary
- `P5seek` was listed in `todo/tickets/dist-test-suite-failures-batch.md`'s un-triaged `test_fail` bucket (2026-07-25 sweep).
- Re-running its own test suite (`t/01-basic.t`, 11 subtests) against current `main` under mutsu now passes cleanly, matching `raku` exactly, both with and without `MUTSU_FUDGE=1`.
- No code change — the underlying fix landed as a side effect of unrelated work between 2026-07-25 and 2026-08-06. Closing via a `news/` entry and trimming the ticket.

## Test plan
- [x] `raku -I lib t/01-basic.t` (baseline) — 11/11 pass
- [x] `target/debug/mutsu -I lib t/01-basic.t` (with and without `MUTSU_FUDGE=1`) — 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)