### PR TITLE
fix(runtime): qualified self.Builtin::new(...) and Date subclass arithmetic

### DIFF
--- a/news/2026-08/date-subclass-qualified-new-and-arithmetic.md
+++ b/news/2026-08/date-subclass-qualified-new-and-arithmetic.md
@@ -1,0 +1,41 @@
+# `Date` subclass constructors and arithmetic now match Rakudo
+
+`todo/tickets/dist-test-suite-failures-batch.md` listed `Date::YearDay` in the
+un-triaged `test_fail` bucket. Its module is a `class Date::YearDay is Date`
+whose own `multi method new` builds the object as
+`self.Date::new($year - 1, 12, 31) + $day_of_year` — a qualified constructor
+call to the builtin ancestor's `new`, followed by Date arithmetic on the
+result. Two separate, general bugs broke this shape:
+
+1. **`self.Date::new(...)` (or any `self.Builtin::new(...)`) fell back to
+   unqualified dispatch.** From a type object mid-construction, that re-entered
+   the caller's OWN overriding `new` — for `Date::YearDay` this went
+   `candidate 1 called` → falls through to the default constructor → `Default
+   constructor for 'Date::YearDay' only takes named arguments`. From an
+   existing instance it just failed outright: `No such method 'Date::new'`.
+   `try_qualified_native_ancestor_method`'s whitelist only covered a handful
+   of native ancestor types (`IO::Handle`, `Thread`, `VM`, ...), never `Date`.
+   Fixed generally in `src/runtime/methods_qualified.rs`: both the type-object
+   path (`dispatch_qualified_non_instance_method`) and the instance path
+   (`dispatch_qualified_instance_method`) now special-case `actual_method ==
+   "new"` for a qualifier with no user-defined constructor — build the
+   ancestor via `dispatch_new`, then bless the result as the RECEIVER's own
+   type, matching Rakudo's `Date.new`, whose implementation is
+   `self.bless(...)` with `self` dynamically the subclass.
+2. **Date `+`/`-` arithmetic recognized only the literal class name `"Date"`
+   as an operand.** `is_temporal_operand`/`instance_days` in
+   `src/builtins/arith/temporal.rs` gated on `class_name == "Date"`, so even a
+   correctly-built `Date` subclass instance was never recognized as
+   date-like at all — `$date_subclass_instance + 5` silently fell through to
+   plain numeric coercion and returned an `Int`. Fixed by duck-typing on the
+   `days`/`year` attributes Date always carries (mirroring how
+   `instance_datetime_parts` already duck-types DateTime) instead of the
+   literal class name. The arithmetic result also now clones the *original*
+   operand's full attribute set and keeps its class name — mirroring
+   Rakudo's `Date::infix:<+>`, which is `self.clone(:days(...))` — instead of
+   always rebuilding a plain `Date` that discarded the subclass type and any
+   custom attributes.
+
+Pinned by `t/date-subclass-qualified-new-and-arith.t`. `Date::YearDay`'s own
+test suite (`t/01-test-new.t`, 8 subtests) now passes cleanly under mutsu,
+matching raku.

--- a/src/builtins/arith/add_sub.rs
+++ b/src/builtins/arith/add_sub.rs
@@ -7,7 +7,7 @@ use super::rat::{
 };
 use super::temporal::{
     instance_datetime_parts, instance_days, instance_duration_value, instance_instant_raw,
-    instance_instant_value, make_duration, value_sub,
+    instance_instant_value, make_duration, rebuild_date_like, value_sub,
 };
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value, ValueView, make_big_fat_rat, make_big_rat_arith};
@@ -44,18 +44,12 @@ pub(crate) fn arith_add(left: Value, right: Value) -> Result<Value, RuntimeError
     if let Some(days) = instance_days(&left)
         && let ValueView::Int(delta) = right.view()
     {
-        use crate::builtins::methods_0arg::temporal;
-        let new_days = days + delta;
-        let (y, m, d) = temporal::epoch_days_to_civil(new_days);
-        return Ok(temporal::make_date(y, m, d));
+        return Ok(rebuild_date_like(&left, days + delta));
     }
     if let Some(days) = instance_days(&right)
         && let ValueView::Int(delta) = left.view()
     {
-        use crate::builtins::methods_0arg::temporal;
-        let new_days = days + delta;
-        let (y, m, d) = temporal::epoch_days_to_civil(new_days);
-        return Ok(temporal::make_date(y, m, d));
+        return Ok(rebuild_date_like(&right, days + delta));
     }
     // Instant + Instant is illegal
     if instance_instant_value(&left).is_some() && instance_instant_value(&right).is_some() {
@@ -266,10 +260,7 @@ pub(crate) fn arith_sub(left: Value, right: Value) -> Value {
     if let Some(days) = instance_days(&left)
         && let ValueView::Int(delta) = right.view()
     {
-        use crate::builtins::methods_0arg::temporal;
-        let new_days = days - delta;
-        let (y, m, d) = temporal::epoch_days_to_civil(new_days);
-        return temporal::make_date(y, m, d);
+        return rebuild_date_like(&left, days - delta);
     }
     // Mixin-wrapped Range - Real: perform Range arithmetic and re-wrap
     if let Some(result) = mixin_range_arith_val(left.clone(), right.clone(), arith_sub) {

--- a/src/builtins/arith/temporal.rs
+++ b/src/builtins/arith/temporal.rs
@@ -4,24 +4,59 @@ use super::rat::to_big_rat_parts;
 use crate::symbol::Symbol;
 use crate::value::{Value, ValueView, make_big_rat_arith};
 
+/// A Date-shaped instance always carries `year`/`month`/`day`/`days` (see
+/// `make_date_with_formatter`); DateTime carries `year`/`month`/`day` too but
+/// never `days` (it stores `epoch` instead), so checking for `days` already
+/// distinguishes the two. Duck-typed on attributes rather than on the literal
+/// class name `"Date"` so a `class Foo is Date` subclass instance (e.g. from
+/// a `Date::YearDay`-style module that calls `self.Date::new(...)` from its
+/// own constructor) is recognized as a Date arithmetic operand too, matching
+/// Rakudo.
+fn is_date_like(value: &Value) -> bool {
+    matches!(value.view(), ValueView::Instance { attributes, .. }
+        if attributes.contains_key("days") && attributes.contains_key("year"))
+}
+
 /// Check if a value is a Date, Instant, or Duration instance (temporal operand for arithmetic).
 pub(crate) fn is_temporal_operand(value: &Value) -> bool {
-    matches!(value.view(), ValueView::Instance { class_name, .. }
-        if class_name == "Date" || class_name == "Instant" || class_name == "Duration")
+    is_date_like(value)
+        || matches!(value.view(), ValueView::Instance { class_name, .. }
+            if class_name == "Instant" || class_name == "Duration")
 }
 
 pub(crate) fn instance_days(value: &Value) -> Option<i64> {
     match value.view() {
-        ValueView::Instance {
-            class_name,
-            attributes,
-            ..
-        } if class_name == "Date" => match attributes.as_map().get("days").map(Value::view) {
-            Some(ValueView::Int(days)) => Some(days),
-            _ => None,
-        },
+        ValueView::Instance { attributes, .. } if is_date_like(value) => {
+            match attributes.as_map().get("days").map(Value::view) {
+                Some(ValueView::Int(days)) => Some(days),
+                _ => None,
+            }
+        }
         _ => None,
     }
+}
+
+/// Build a new Date-shaped instance for an arithmetic result: clones
+/// `original`'s full attribute set (preserving any custom subclass
+/// attributes, e.g. a `Date::YearDay`-style formatter) and overwrites
+/// `year`/`month`/`day`/`days` with the recomputed date, keeping `original`'s
+/// own class name. Mirrors Rakudo's `Date::infix:<+>`/`infix:<->`, which are
+/// `self.clone(:days(...))` — a clone, not a fresh plain `Date`.
+pub(crate) fn rebuild_date_like(original: &Value, new_days: i64) -> Value {
+    let class_name = match original.view() {
+        ValueView::Instance { class_name, .. } => class_name,
+        _ => Symbol::intern("Date"),
+    };
+    let (y, m, d) = crate::builtins::methods_0arg::temporal::epoch_days_to_civil(new_days);
+    let mut attrs = match original.view() {
+        ValueView::Instance { attributes, .. } => attributes.to_map(),
+        _ => crate::value::AttrMap::new(),
+    };
+    attrs.insert("year", Value::int(y));
+    attrs.insert("month", Value::int(m));
+    attrs.insert("day", Value::int(d));
+    attrs.insert("days", Value::int(new_days));
+    Value::make_instance(class_name, attrs)
 }
 
 pub(crate) fn instance_instant_value(value: &Value) -> Option<f64> {

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -2,6 +2,7 @@ use super::methods_signature_errors::{
     make_method_not_found_error, make_private_permission_error, make_private_unqualified_error,
 };
 use super::*;
+use crate::symbol::Symbol;
 
 impl Interpreter {
     /// Handle private method calls on non-Instance, non-Package values.
@@ -453,6 +454,40 @@ impl Interpreter {
             return Some(self.dispatch_classhow_method(actual_method, args));
         }
 
+        // A qualified constructor call to a builtin ancestor with no user
+        // `new` of its own, made on an EXISTING instance (`self.Date::new(...)`
+        // from inside a Date subclass's own method, as opposed to mid-`new`
+        // on the type object — see the identical case in
+        // `dispatch_qualified_non_instance_method` for why unqualified
+        // fallback is wrong here): build the ancestor via its own native
+        // constructor logic, then bless the result as the RECEIVER's type.
+        if actual_method == "new" && qualifier != inst_cn_str {
+            let built = self.dispatch_new(Value::package(Symbol::intern(qualifier)), args.clone());
+            match built {
+                Ok(built_val) => {
+                    if let ValueView::Instance {
+                        attributes: built_attrs,
+                        id,
+                        ..
+                    } = built_val.view()
+                    {
+                        let target_sym = Symbol::intern(&inst_cn_str);
+                        return Some(Ok(Value::instance_parts(
+                            target_sym,
+                            crate::gc::Gc::new(crate::value::InstanceAttrs::new(
+                                target_sym,
+                                built_attrs.to_map(),
+                                id,
+                                true,
+                            )),
+                            id,
+                        )));
+                    }
+                }
+                Err(e) => return Some(Err(e)),
+            }
+        }
+
         // Last resort: the qualifier is a NATIVE builtin ancestor (verified in the
         // MRO above) whose method is Rust-implemented rather than a user method —
         // e.g. `self.IO::Path::slurp` from a class that `is IO::Path`. Dispatch it
@@ -818,6 +853,42 @@ impl Interpreter {
                     Some(target.clone()),
                 );
                 return Some(res.map(|(result, _updated)| result));
+            }
+            // A qualified constructor call to a builtin ancestor with no user
+            // `new` of its own (e.g. `self.Date::new(...)` from inside a
+            // `class Foo is Date { multi method new(...) {...} }`): build the
+            // ancestor via its own native constructor logic, then bless the
+            // result as the ORIGINAL invocant's type. This mirrors Rakudo,
+            // where `Date.new`'s implementation does `self.bless(...)` and
+            // `self` is dynamically the subclass, so the result comes back as
+            // `Foo`, not `Date`. Falling back to unqualified dispatch (below)
+            // would instead re-enter the caller's own overriding `new` —
+            // exactly the `Mu::new` recursion hazard noted above, just for an
+            // ancestor other than `Mu`.
+            if actual_method == "new" && qualifier != pkg_name {
+                let built =
+                    self.dispatch_new(Value::package(Symbol::intern(qualifier)), args.clone());
+                match built {
+                    Ok(built_val) => {
+                        if let ValueView::Instance { attributes, id, .. } = built_val.view() {
+                            let target_sym = Symbol::intern(&pkg_name);
+                            return Some(Ok(Value::instance_parts(
+                                target_sym,
+                                crate::gc::Gc::new(crate::value::InstanceAttrs::new(
+                                    target_sym,
+                                    attributes.to_map(),
+                                    id,
+                                    true,
+                                )),
+                                id,
+                            )));
+                        }
+                        // Not an instance (e.g. the ancestor constructs some
+                        // other kind of value) — no rebless target, fall
+                        // through to the generic handling below.
+                    }
+                    Err(e) => return Some(Err(e)),
+                }
             }
             // No user method in the qualifier class (e.g. a builtin like
             // `Int::abs`): fall back to ordinary unqualified dispatch.

--- a/t/date-subclass-qualified-new-and-arith.t
+++ b/t/date-subclass-qualified-new-and-arith.t
@@ -1,0 +1,61 @@
+use Test;
+
+# `class Foo is Date { multi method new(...) { self.Date::new(...) + ... } }`
+# is the shape used by the `Date::YearDay` distribution (P5seek's sibling on
+# CPAN Butterfly Plan): a `Date` subclass with its own multi `new` that calls
+# the base type's constructor via a qualified call, then does Date arithmetic
+# on the result. Two separate bugs used to break this:
+#
+#  1. `self.Date::new(...)` from a type object (before an instance exists)
+#     fell back to unqualified `.new` dispatch, which re-entered the caller's
+#     OWN overriding `new` instead of Date's native constructor logic —
+#     "Default constructor for 'Foo' only takes named arguments". From an
+#     instance it just failed outright — "No such method 'Date::new'".
+#  2. Date `+`/`-` arithmetic recognized only the literal class name "Date"
+#     as a valid operand, so even a correctly-built subclass instance was not
+#     treated as date-like at all, and the result of `+`/`-` was always
+#     rebuilt as a plain `Date`, discarding the subclass type and any custom
+#     attributes (Rakudo's `Date::infix:<+>` is `self.clone(:days(...))`,
+#     which preserves both).
+
+plan 9;
+
+class YearDay is Date {
+    multi method new(:$year!, :$day-of-year!, |c) {
+        self.Date::new($year - 1, 12, 31) + $day-of-year
+    }
+    multi method new(:$year!, :$doy!, |c) {
+        self.Date::new($year - 1, 12, 31) + $doy
+    }
+}
+
+my $d = YearDay.new(:year(2121), :day-of-year(42));
+isa-ok $d, YearDay, 'qualified-new-then-+ result is the subclass, not Date';
+isa-ok $d, Date, 'and still isa Date';
+is $d, Date.new(2121, 2, 11), 'day-of-year 42 in 2121 lands on the correct date';
+
+my $d2 = YearDay.new(:year(2121), :doy(42));
+is $d2, $d, 'the :doy candidate agrees with the :day-of-year candidate';
+
+# self.Date::new(...) called directly on an existing instance (not just a
+# type object mid-construction).
+{
+    class Wrapper is Date {
+        method rebuild { self.Date::new(self.year, self.month, self.day) }
+    }
+    my $w = Wrapper.new(2020, 6, 15).rebuild;
+    isa-ok $w, Wrapper, 'self.Date::new on an instance also blesses as the subclass';
+    is $w.Str, '2020-06-15', 'and carries the right date';
+}
+
+# Date subclass arithmetic keeps the subclass type and custom attributes.
+{
+    class Tagged is Date {
+        has $.tag = 'default';
+    }
+    my $t = Tagged.new(2020, 1, 1, :tag<hello>);
+    my $t2 = $t + 5;
+    isa-ok $t2, Tagged, 'Date subclass + Int stays the subclass type';
+    is $t2.tag, 'hello', 'and preserves a custom attribute (like .clone would)';
+    is $t2.Str, '2020-01-06', 'with the correct resulting date';
+}

--- a/todo/tickets/dist-test-suite-failures-batch.md
+++ b/todo/tickets/dist-test-suite-failures-batch.md
@@ -77,6 +77,14 @@ then check the constraint).
 Fixed as a side effect of unrelated work; see
 `news/2026-08/p5seek-not-reproducible.md`.
 
+### ~~`Date::YearDay` — qualified constructor call + Date arithmetic~~ — FIXED
+
+`self.Date::new(...)` (a qualified constructor call to a builtin ancestor)
+fell back to unqualified dispatch and re-entered the caller's own `new`, and
+Date `+`/`-` arithmetic only recognized the literal class name `"Date"`, so a
+subclass instance was never treated as date-like. Both fixed generally; see
+`news/2026-08/date-subclass-qualified-new-and-arithmetic.md`.
+
 ### `RSV` — triaged, root-caused, needs a compiler design pass
 
 `lib/RSV.rakumod` declares `constant \EOV = blob8.new(255);` (and `\EOR`,
@@ -92,7 +100,7 @@ it needs a design pass rather than a quick patch:
 
 ## Un-triaged `test_die` / `test_fail`
 
-`Date::YearDay`, `PSpec`, `Array::Rounded` (fail);
+`PSpec`, `Array::Rounded` (fail);
 `Math::Interval`, `Native::Overflow`, `App::SudokuHelper`, `P5tie`,
 `Mathematica::Serializer::Encoder`, `Hash::Restricted`, `Crypt::RC4`,
 `Random::Choice` (die).


### PR DESCRIPTION
## Summary
- `todo/tickets/dist-test-suite-failures-batch.md` listed `Date::YearDay` as an un-triaged `test_fail`. Its module is `class Date::YearDay is Date` whose own `multi method new` does `self.Date::new($year - 1, 12, 31) + $day_of_year` — a qualified constructor call to the builtin ancestor, followed by Date arithmetic.
- **Bug 1**: `self.Builtin::new(...)` (qualified constructor call to a builtin ancestor with no user `new`) fell back to unqualified dispatch, re-entering the caller's own overriding `new` — wrong result or "No such method". Fixed in `src/runtime/methods_qualified.rs` (both the type-object and instance qualified-dispatch paths): build the ancestor via `dispatch_new`, then bless the result as the receiver's own type, matching Rakudo (`Date.new` is `self.bless(...)`, dynamically blessing the subclass).
- **Bug 2**: Date `+`/`-` arithmetic only recognized the literal class name `"Date"`, so a `Date` subclass instance was never treated as date-like at all and silently fell through to plain numeric coercion. Fixed in `src/builtins/arith/temporal.rs` + `add_sub.rs` by duck-typing on the `days`/`year` attributes (mirroring how DateTime already duck-types), and the result now clones the original operand's attributes/class name (matching `Date::infix:<+>`'s `self.clone(:days(...))`) instead of always rebuilding a plain `Date`.

## Test plan
- [x] New `t/date-subclass-qualified-new-and-arith.t` (9 subtests) — pins both bugs
- [x] `t/date-subclass-methods.t` (14 subtests) — no regression
- [x] `roast/S32-temporal/{Date,DateTime,DateTime-Instant-Duration,calendar}.t` — all pass
- [x] `make test` — 2925 files / 27735 tests, all pass
- [x] `Date::YearDay`'s own dist test suite (`t/01-test-new.t`, 8 subtests) now passes cleanly under mutsu, matching raku

🤖 Generated with [Claude Code](https://claude.com/claude-code)