### PR TITLE
fix(vm): module sub's shared-state call path uses its own nested-sub table

### DIFF
--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -2100,7 +2100,14 @@ impl Interpreter {
         name: &str,
     ) -> Result<Value, RuntimeError> {
         let saved_scope = self.state_scope_id.take();
-        let result = self.call_compiled_function_named(shared, args, compiled_fns, pkg, name);
+        // Prefer the routine's own nested-sub table over the caller's
+        // (ADR-0019 C6e-3c, mirrors `compile_and_call_function_def`): a
+        // module sub with a nested declaration (e.g. a `proto ... {*}`
+        // synthesizes a `state` var, routing it through this shared-body
+        // path even with no user-written `state`) must resolve its own
+        // `RegisterDecl` keys, not the caller's unrelated table.
+        let fns = shared.compiled_fns.as_deref().unwrap_or(compiled_fns);
+        let result = self.call_compiled_function_named(shared, args, fns, pkg, name);
         self.state_scope_id = saved_scope;
         result
     }

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -298,25 +298,47 @@ sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
   used (env-gated instrument in `vm_register_sub_ops.rs`, reverted before
   commit) with the carrier fix in place: `t/module-sub-otf-interpreter-constructs.t`
   tests 3-4 (`nested proto+multi dispatch`) are the only failures across the
-  full `t/` suite. Root-caused to a narrower case than C6e-3c: a `proto sub
-  inner($) {*}` nested inside an `our sub` that is (a) loaded from an
-  imported module and (b) forced body-less returns `Nil` instead of
-  dispatching — but the SAME proto+multi nesting at the top level (no
-  module import), and plain/multi-only nesting (no `proto`) inside an
-  imported module sub, both work correctly even forced. This isolates the
-  gap to `RegisterProtoSub` specifically, which — per ADR-0019 Decision §1
-  and the C8 slice description — still indexes `stmt_pool` rather than a
-  `CompiledSubDeclPlan`; it is explicitly out of C6e-3c's scope ("C8...
-  Independent of C6/C7; the slice exists because... unreachable while these
-  two opcodes still index the statement pool"). **C6e-3c's own blocker (the
-  ~17-site audit) is therefore resolved; the field drop is now blocked
-  only on this proto-in-OTF-module-sub gap, which is C8-adjacent and needs
-  its own root-cause investigation** (why forcing the OUTER `our sub`
-  body-less breaks a proto nested inside it, when the proto mechanism
-  itself is unchanged — likely something the outer sub's dropped AST body
-  was still incidentally providing to the `RegisterProtoSub` walker, e.g.
-  `stmt_pool` reachability or a `{*}`-rewrite precondition keyed off the
-  def still being tree-walk-eligible).
+  full `t/` suite. First root-caused (wrongly) to a narrower case scoped to
+  `RegisterProtoSub`/C8; **that guess was superseded the same session** —
+  see below for the actual mechanism and fix.
+- **RESOLVED (2026-08-06): the gap was a fourth `CompiledFns::default()`-shaped
+  site the ~17-site audit missed, not a `RegisterProtoSub`/C8 gap.** The
+  parser synthesizes a hidden `state $__ANON_STATE_0__` declaration ahead of
+  every bodyless `proto sub NAME(...) {*}` (backing its dispatch-identity
+  machinery), so `oc-proto`'s body — `proto sub inner($) {*}; multi sub
+  inner(Int $v) {...}; multi sub inner(Str $v) {...}; inner($x)` — genuinely
+  `declares_state`, and `def_module_single_sig_body_ok_ignoring_state`'s
+  caller routes the call through the "cross-thread shared captured body"
+  path (`imported_state_body_for_def` / `call_shared_state_body`,
+  `vm_call_func_ops.rs`) even though the routine has no *user-written*
+  `state`. That path predates the C6e-3c carrier fix and was never updated
+  to prefer the routine's own nested-sub table: `call_shared_state_body`
+  passed the *caller's* `compiled_fns` straight through to
+  `call_compiled_function_named` instead of `shared.compiled_fns`. For a
+  top-level (non-imported) `our sub` with the same proto+multi shape this is
+  harmless (the caller's own table already contains everything, since
+  nothing crossed a compilation-unit boundary); the module-import case is
+  where the caller's table and the routine's own table diverge, which is
+  why only the imported-module shape reproduced — the earlier "isolates the
+  gap to `RegisterProtoSub`" conclusion was a correlation (the `state` var
+  only exists because of the `proto`), not the actual mechanism, and does
+  not implicate `RegisterProtoSub`/`stmt_pool`/C8 at all. Confirmed via the
+  same env-gated `MUTSU_FORCE_BODYLESS` instrument (reverted before commit):
+  before the fix, forced execution returns `Nil` for both `oc-proto(5)` and
+  `oc-proto("x")`; after adding `let fns =
+  shared.compiled_fns.as_deref().unwrap_or(compiled_fns);` in
+  `call_shared_state_body`, both the minimal repro and the full
+  `t/module-sub-otf-interpreter-constructs.t` (40/40, forced) pass. **This
+  also means the bug is real and general TODAY on `main`, independent of
+  C6e-3c's timeline** — any imported module sub reaching the shared-state
+  path (real `state`, or a nested bodyless `proto {*}`'s synthetic one) that
+  also declares a nested sub whose own registration would otherwise resolve
+  body-less silently loses that optimization and keeps interpreting the
+  nested body instead (currently unobservable behaviorally, since the AST
+  fallback is still correct — just uncompiled). **C6e-3c's field-drop
+  blocker is now fully resolved**; the next step is auditing whether C6e-3c
+  can proceed straight to closing out (dropping `legacy_body` for real) or
+  needs one more full-suite A/B pass first.
 
 Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
 (the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`

--- a/todo/tickets/nontrivial-proto-body-otf-may-use-wrong-nested-sub-table.md
+++ b/todo/tickets/nontrivial-proto-body-otf-may-use-wrong-nested-sub-table.md
@@ -1,0 +1,41 @@
+# `vm_try_run_nontrivial_proto_body` may pass the wrong nested-sub table to a freshly OTF-compiled proto body
+
+While investigating the ADR-0019 C6e-3c blocker (see
+`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`), the fix
+landed for `call_shared_state_body` in `src/vm/vm_call_func_ops.rs` — it was
+passing the *caller's* `compiled_fns` table to
+`call_compiled_function_named` instead of the callee's own
+(`cf.compiled_fns`), which resolves nested `RegisterDecl` opcodes against the
+wrong table (ADR-0019 C6e-3c's "own nested-sub table" carrier,
+`CompiledFunction::compiled_fns`).
+
+`vm_try_run_nontrivial_proto_body` (same file, ~line 1671) has the identical
+shape and was NOT audited or fixed in this pass:
+
+```rust
+let cf = self.otf_compile_function_def(&proto_def);
+let pkg = proto_def.package.resolve();
+self.push_proto_dispatch_frame(name.to_string(), args.clone());
+let result = self.call_compiled_function_named(&cf, args, compiled_fns, &pkg, name);
+```
+
+This handles a *non-trivial* proto body (`proto foo($x) { say "x"; {*} }`,
+as opposed to a bodyless/`{*}`-only proto). `cf` comes from a fresh
+`otf_compile_function_def` call, so `cf.compiled_fns` should be populated by
+the standard `helpers_sub_body.rs` construction site if the proto body
+itself declares any nested subs/protos/multis. Passing `compiled_fns` (the
+caller's table) instead of `cf.compiled_fns.as_deref().unwrap_or(compiled_fns)`
+means such a nested declaration could hit the same "wrong empty table" bug
+`call_shared_state_body` had.
+
+Not confirmed with a repro — this is a scoping note from code inspection,
+not a verified bug. To check: does a proto with a non-trivial body AND a
+nested named sub declaration (e.g. `proto foo($x) { my sub helper() {...};
+say helper(); {*} }`) reach this function, and does forcing that nested
+sub's registration body-less (the same `MUTSU_FORCE_BODYLESS` env-gated
+instrument used for the C6e-3c investigation) break it the same way
+`oc-proto` did?
+
+If confirmed, the fix is the same one-line pattern:
+`let fns = cf.compiled_fns.as_deref().unwrap_or(compiled_fns);` before the
+`call_compiled_function_named` call.


### PR DESCRIPTION
## Summary
- `call_shared_state_body` (the cross-thread shared captured body used when an imported module sub's call routes through the `state`-declaring dispatch path — including the hidden `state` var the parser synthesizes for a bodyless `proto sub NAME(...) {*}`) passed the *caller's* `compiled_fns` table straight through to `call_compiled_function_named`, instead of preferring the routine's own (`shared.compiled_fns`, ADR-0019 C6e-3c's nested-sub-table carrier).
- This meant a nested `RegisterDecl` inside such a routine's body (e.g. `multi sub inner(...)` nested inside a proto+multi dispatcher) resolved its compiled-routine key against the wrong (empty) table when the routine was called from a different compilation unit than the one it was declared in.
- Root-causes and supersedes an earlier (incorrect) hypothesis recorded in `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md` that scoped this gap to `RegisterProtoSub`/C8; the doc is updated with the real mechanism.
- Verified with the project's env-gated `MUTSU_FORCE_BODYLESS` A/B instrument (added, exercised, then reverted before commit — not part of this diff): before the fix, a module-imported `our sub` containing a nested `proto sub {*}` + multi candidates returned `Nil` under a forced body-less registration; after the fix, it dispatches correctly, matching normal (unforced) behavior.
- Files a follow-up ticket (`todo/tickets/nontrivial-proto-body-otf-may-use-wrong-nested-sub-table.md`) for a same-shaped, unaudited call site in `vm_try_run_nontrivial_proto_body`.

## Test plan
- [x] `make test` — 27726 tests, all green
- [x] `t/module-sub-otf-interpreter-constructs.t` passes both normally and under the `MUTSU_FORCE_BODYLESS` A/B instrument (40/40 both ways)
- [x] `t/module-state-sub-shared-cell.t`, `t/state-aggregate-shared-cell.t`, and the other `t/module-sub-otf-*.t` files pass
- [x] Targeted roast: `S04-declarations/state.t`, `S06-advanced/dispatching.t`, `S06-advanced/lexical-subs.t`, `S06-multi/by-trait.t`, `S06-multi/lexical-multis.t`, `S06-multi/positional-vs-named.t`, `S05-grammar/protos.t`, `S17-supply/batch.t` — all pass
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)