### PR TITLE
fix(vm): a closure arg to a custom infix operator now writes back

### DIFF
--- a/news/2026-08/user-infix-closure-arg-writeback.md
+++ b/news/2026-08/user-infix-closure-arg-writeback.md
@@ -1,0 +1,30 @@
+# A closure argument to a custom infix operator now writes back to the caller
+
+A closure passed as an argument to a custom user-defined infix operator
+(`sub infix:<times>(Int $num, &closure) {...}`, called as
+`20 times { $value++ }`) did not write its mutation of an outer lexical back
+to the caller's scope once the statement finished — even though the mutation
+was visible while still inside the callee's dynamic extent. The same closure
+passed to an ordinary named sub call (`my_times(20, { $value++ })`) already
+worked correctly, so the value only went missing through the custom-infix
+call path.
+
+Root cause: `exec_infix_func_op` (the `OpCode::InfixFunc` VM handler,
+`src/vm/vm_flipflop_ops.rs`) drives the same underlying call machinery as an
+ordinary function call (`try_user_infix` / `compile_and_call_function_def` →
+`call_compiled_function_named`), which stages any `rw`-writeback source into
+`pending_rw_writeback_sources` on the way out. Every other call-opcode
+handler (`OpCode::CallFunc`, `OpCode::ExecCall`) drains that staged set into
+the caller's own local slot via `apply_pending_rw_writeback(code)` right
+after the call — `exec_infix_func_op` never did, so the caller kept reading
+its stale, never-refreshed local slot for `$value`.
+
+Fixed by adding the same `apply_pending_rw_writeback(code)` call to
+`exec_infix_func_op`, covering all three of its call-out branches (the
+lexical `&infix:<op>` shadow early return, `try_user_infix`, and the
+list-associative `compile_and_call_function_def` fallback).
+
+Found via the `PSpec` distribution's own test suite
+(`todo/tickets/dist-test-suite-failures-batch.md`): its `times` helper
+(`sub infix:<times>(Int $num, &closure) { for ^$num { closure() } }`) is
+exactly this shape. Pinned by `t/user-infix-closure-arg-writeback.t`.

--- a/src/vm/vm_flipflop_ops.rs
+++ b/src/vm/vm_flipflop_ops.rs
@@ -62,6 +62,7 @@ impl Interpreter {
                 && let Some(callable) = self.lexical_infix_override(code, &infix_name)
             {
                 let result = self.call_sub_value(callable, call_args, false)?;
+                self.apply_pending_rw_writeback(code);
                 self.stack.push(result);
                 return Ok(());
             }
@@ -120,6 +121,7 @@ impl Interpreter {
                 }
             }
         };
+        self.apply_pending_rw_writeback(code);
         self.stack.push(result);
         Ok(())
     }

--- a/t/user-infix-closure-arg-writeback.t
+++ b/t/user-infix-closure-arg-writeback.t
@@ -1,0 +1,46 @@
+use Test;
+
+# A closure passed as an argument to a custom user-defined word-form infix
+# operator (`sub infix:<times>(Int $num, &closure) {...}`, called as
+# `20 times { $value++ }`) must write its mutation of an outer lexical back
+# to the caller's scope once the statement finishes — exactly like passing
+# the same closure to an ordinary named sub call already does. The mutation
+# was visible while still inside the callee's dynamic extent, but reading the
+# outer variable AFTER the statement returned saw the stale, never-refreshed
+# value: `exec_infix_func_op` (the `OpCode::InfixFunc` handler) never drained
+# `pending_rw_writeback_sources` into the caller's local slot the way every
+# other call-opcode handler (`OpCode::CallFunc`, `OpCode::ExecCall`) does.
+# Found via the `PSpec` distribution's own test suite (its `times`/`xxx`
+# helpers are exactly this shape).
+
+plan 4;
+
+{
+    sub infix:<my-times>(Int $num, &closure) {
+        for ^$num { closure() }
+    }
+    my $value = 0;
+    20 my-times { $value++ }
+    is $value, 20, 'closure arg to a custom infix writes back to the outer lexical';
+}
+
+# The lexical-`&infix:<op>`-shadow early-return path.
+{
+    my $value = 0;
+    sub apply(&op, $num) { op($num) }
+    my &infix:<my-shadow> = -> $num, &closure { closure(); $num };
+    my $value2 = 0;
+    5 my-shadow { $value2++ };
+    is $value2, 1, 'closure arg through a lexical &infix:<op> override writes back too';
+}
+
+# Multiple sequential custom-infix calls with closures don't cross-clobber.
+{
+    sub infix:<my-times2>(Int $num, &closure) { for ^$num { closure() } }
+    my $a = 0;
+    my $b = 0;
+    3 my-times2 { $a++ }
+    5 my-times2 { $b++ }
+    is $a, 3, 'first custom-infix closure call writes back correctly';
+    is $b, 5, 'second custom-infix closure call writes back correctly, independent of the first';
+}

--- a/todo/deep/bare-block-as-infix-operand-not-recognized.md
+++ b/todo/deep/bare-block-as-infix-operand-not-recognized.md
@@ -1,0 +1,93 @@
+# A leading `{ ... }` before a custom infix operator is never parsed as its LHS operand
+
+## Root cause
+
+Raku's statement grammar has a well-known ambiguity: a `{` at the start of a
+statement can begin either a bare block (a standalone statement, its own
+lexical scope) or a term (a hash literal, or — the case here — the left
+operand of an expression that continues past the closing `}`). Rakudo
+resolves this by looking ahead past the matching `}`: if the next token
+cannot itself start a new statement (e.g. it's an infix operator token, known
+because the operator was already declared earlier in the file), the `{...}`
+is a term, not a complete statement, and parsing continues into the infix
+expression.
+
+mutsu's statement parser does not perform this lookahead for a *custom*
+(user-declared) infix operator. `{ ... }` at statement position is committed
+to as a complete bare-block statement unconditionally, so a following custom
+operator token starts a brand-new (and bogus) statement:
+
+```raku
+sub infix:<zork>(&closure, Int $num) is export {
+    say "called with num=$num";
+}
+{ say "hi"; } zork 25;
+```
+
+mutsu: `{ say "hi"; }` runs as a bare block (prints "hi"), then a NEW
+statement `zork 25;` is parsed — since `zork` isn't a declared *function*
+(only `infix:<zork>` is), this fails with `Undeclared routine: zork used`.
+raku: parses the whole thing as one `infix:<zork>` call and prints `called
+with num=25` (the block is never independently executed as a statement — it's
+consumed as the `&closure` argument).
+
+Confirmed this is not about bareword-vs-symbolic operator spelling — the same
+failure reproduces with a fresh symbolic operator too (`{ say "hi"; } ⚡ 25;`
+→ `Confused. expected statement`), so the bug is squarely "a leading `{...}`
+never looks ahead for ANY infix continuation," not something specific to word
+operators.
+
+## Affected files
+
+The exact statement/term disambiguation site was not pinned down in this
+investigation session (out of scope for the fix that motivated finding this —
+see below); it lives somewhere in the top-level statement dispatch under
+`src/parser/stmt/` (`mod.rs` and friends), specifically wherever a leading
+`TokenKind::LeftBrace` at statement position currently commits unconditionally
+to a bare-block-statement parse. `src/parser/stmt/control/labeled_loop.rs:118`
+and `src/parser/stmt/modifier.rs:207` both have comments acknowledging
+"bare block" as a distinct parse target, and are candidate starting points for
+tracing the decision point, but neither was confirmed as the actual site.
+
+## Why it is large
+
+- This is a genuine grammar-ambiguity resolution, not a narrow bug: the fix
+  needs lookahead past the block's matching `}` to the next token, checked
+  against the SAME "known declared infix operators" table the expression
+  parser already consults elsewhere (custom operators are typically
+  registered as they're declared, mid-file, which is itself a parser-state
+  dependency worth confirming holds here too).
+- The fix has to avoid regressing the (far more common) legitimate bare-block
+  statement case — `{ ... }` followed by literally anything else (a new
+  statement, EOF, a closing brace of an enclosing block) must keep parsing as
+  a bare block exactly as today.
+- It plausibly interacts with existing special-cased leading-block handling
+  (labelled bare blocks / `do` blocks per `labeled_loop.rs`, statement
+  modifiers per `modifier.rs`), so the change needs to thread through those
+  existing paths rather than add a parallel one.
+- Precedence also matters once the lookahead succeeds: the resulting
+  `Expr::InfixFunc`-style parse has to respect the declared operator's own
+  precedence/associativity relative to whatever follows on the same line.
+
+## Repro
+
+```raku
+sub infix:<zork>(&closure, Int $num) is export {
+    say "called with num=$num";
+}
+{ say "hi"; } zork 25;
+```
+
+Expected (raku): prints `called with num=25` only.
+Actual (mutsu): prints `hi`, then `===SORRY!=== ... Undeclared routine: zork
+used`.
+
+Found via the `PSpec` distribution's own test suite
+(`todo/tickets/dist-test-suite-failures-batch.md`): its `xxx` helper is
+`sub infix:<xxx>(&closure, Int $num) { $num times &closure }`, called as
+`{ $value--; } xxx 25;` — exactly this shape. `PSpec`'s sibling bug (a closure
+argument to a custom infix operator not writing its outer-lexical mutation
+back to the caller — the `times` helper, `20 times { $value++ }`) was a
+separate, already-fixed issue (`news/2026-08/user-infix-closure-arg-writeback.md`
+if present, or see the `t/user-infix-closure-arg-writeback.t` regression
+test); this ticket is only the remaining `{...} OP arg` parse gap.


### PR DESCRIPTION
## Summary
- Found while triaging the `PSpec` distribution's own test suite (`todo/tickets/dist-test-suite-failures-batch.md`): its `times` helper (`sub infix:<times>(Int $num, &closure) { for ^$num { closure() } }`) is a custom user-defined infix operator taking a closure argument.
- A closure passed this way (`20 times { $value++ }`) did not write its mutation of an outer lexical back to the caller once the statement finished, even though the mutation was visible inside the callee's dynamic extent. The identical shape via an ordinary named sub call (`my_times(20, { $value++ })`) already worked correctly.
- Root cause: `exec_infix_func_op` (`OpCode::InfixFunc`, `src/vm/vm_flipflop_ops.rs`) drives the same call machinery as an ordinary call (`call_compiled_function_named`), which stages any `rw`-writeback source into `pending_rw_writeback_sources`. Every other call-opcode handler (`CallFunc`, `ExecCall`) drains that set into the caller's local slot via `apply_pending_rw_writeback(code)` right after the call; `exec_infix_func_op` never did.
- Fix: add `apply_pending_rw_writeback(code)` to all three call-out branches of `exec_infix_func_op` (the lexical `&infix:<op>` shadow early return, `try_user_infix`, and the list-associative fallback).
- Also files `todo/deep/bare-block-as-infix-operand-not-recognized.md` for a separate, unrelated parser gap PSpec's sibling `xxx` helper exposed — a leading `{ ... }` before a custom infix operator is never recognized as its LHS operand (a genuine grammar-ambiguity lookahead feature, out of scope for this fix).

## Test plan
- [x] New `t/user-infix-closure-arg-writeback.t` (4 subtests) — pins the fix, including the lexical-shadow early-return branch
- [x] All `t/*infix*` tests — no regression
- [x] `make test` — 2926 files / 27739 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)