### PR TITLE
fix(vm,runtime): an is Array subclass supports is trait, nextwith, and fractional subscripts

### DIFF
--- a/news/2026-08/array-subclass-nextwith-and-num-subscript.md
+++ b/news/2026-08/array-subclass-nextwith-and-num-subscript.md
@@ -1,0 +1,43 @@
+# An `is Array` subclass now supports the `is` trait, `nextwith`, and fractional subscripts
+
+Investigating `Array::Rounded` (`todo/tickets/dist-test-suite-failures-batch.md`) surfaced four
+separate, general bugs in how a user class that `is Array` interacts with the rest of the
+interpreter — all confirmed against real `raku` and fixed:
+
+1. **`Foo.new(1,2,3)` with no user-defined `new`** went through the generic default-constructor
+   path (`dispatch_new`'s positional-arg handling in `methods_object_dispatch_new.rs`), which
+   stashed the elements under a stray `__array_items` attribute key that none of the Array
+   delegation methods (`elems`, `AT-POS`, `push`, list-context flattening, ...) actually read —
+   they all read `__mutsu_array_storage`, the same key the `nextwith(|@values)`-from-`new` path
+   already used. `Foo.new(1,2,3).elems` silently came back `0`. Fixed by using the same key and the
+   same `Value::real_array` constructor; the now-dead `__array_items` read in
+   `runtime/utils/list.rs` was removed.
+2. **`my @a is Foo = ...`** (the `is` trait on an `@`-sigil variable) had no implementation at all
+   for a user class target — `exec_apply_var_trait_op` (`vm_var_trait_ops.rs`) only handled the
+   `%`-sigil "tied hash" case. Added a mirroring `@`-sigil branch: when the trait names a registered
+   class/role whose MRO includes `Array`, composes `Positional`, or defines `AT-POS`, construct an
+   instance of it and gather any initializer already assigned to the variable as positional args.
+3. **`nextwith`/`nextsame` from inside a single (non-multi, non-wrapped) compiled method** — which
+   pushes no `method_dispatch_stack` frame — fell straight through to the "MRO exhausted, return
+   Nil" fallback in `dispatch_next_candidate` (`builtins_dispatch_next.rs`) instead of reaching the
+   native `Array` base behavior. `Array::Rounded`'s `method AT-POS($i) { nextwith $i.round }` (called
+   directly, e.g. `$obj.AT-POS(1.5)`) silently returned `Nil`. Added
+   `native_array_storage_next_candidate`, mirroring the existing `native_mu_base_next_candidate`
+   fallback, which resolves the invocant from the samewith context / `self` env binding (there is no
+   dispatch frame to read it from) and delegates to the native method on the backing storage.
+4. **A fractional/`Rat` subscript (`@obj[1.5]`) on an `Instance`** fell through every match arm in
+   `vm_var_index_ops.rs` straight to `Nil` — only an `Int` index dispatched to `AT-POS`/`AT-KEY`.
+   Confirmed against raku that subscript syntax always truncates a fractional index to `Int` before
+   `AT-POS` ever sees it (`$obj[1.5]` calls `AT-POS(1)`, not `AT-POS(1.5)` — only a *direct*
+   `.AT-POS(1.5)` call sees the fractional value). Added a truncating arm mirroring the plain-`Array`
+   truncation behavior, instead of forwarding the untruncated value (which would have diverged from
+   raku semantics for the general case).
+
+Regression-pinned in `t/array-subclass-new-default-ctor.t`, verified line-for-line against `raku`.
+
+**Not fixed, and still blocking `Array::Rounded`'s own test suite** (16/35 still fail): the dist's
+actual rounding mechanism is a set of exported `multi sub postcircumfix:<[ ]>` candidates (an
+operator overload, not the `AT-POS` method), which mutsu never dispatches for `@obj[...]` syntax —
+see `todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md`. A separate gap (`my @a is
+Rounded = ...` where `Rounded` is a constant imported from another module) is also still open,
+documented in the same ticket.

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -252,6 +252,63 @@ impl Interpreter {
         }
     }
 
+    /// When a user `is Array` subclass overrides a Positional protocol method
+    /// (`AT-POS`/`ASSIGN-POS`/`BIND-POS`/`DELETE-POS`/`elems`/`push`/...) and
+    /// calls `nextsame`/`nextwith` (or `callsame`/`callwith`), the NATIVE array
+    /// behavior on the instance's backing `__mutsu_array_storage` is the final
+    /// base candidate — `Array` is not a user-registered class with real
+    /// `MethodDef`s, so the regular MRO chain never reaches it (mirrors
+    /// `native_mu_base_next_candidate`). Without this, e.g. `Array::Rounded`'s
+    /// `method AT-POS($index) { nextwith $index.round }` silently returned Nil.
+    fn native_array_storage_next_candidate(
+        &mut self,
+        override_args: Option<&[Value]>,
+    ) -> Option<Result<Value, RuntimeError>> {
+        let method_name = self.samewith_context_stack.last().map(|(n, _)| n.clone())?;
+        // A single (non-multi, non-wrapped) compiled method pushes no
+        // `method_dispatch_stack` frame, so the invocant/args must come from
+        // the samewith context and `self` rather than a dispatch frame (mirrors
+        // `native_mu_base_next_candidate`'s `self.env.get("self")` fallback).
+        let invocant = self
+            .method_dispatch_stack
+            .last()
+            .map(|f| f.invocant.clone())
+            .or_else(|| {
+                self.samewith_context_stack
+                    .last()
+                    .and_then(|(_, i)| i.clone())
+            })
+            .or_else(|| self.env.get("self").cloned())?;
+        let args: Vec<Value> = match override_args {
+            Some(a) => a.to_vec(),
+            None => self
+                .method_dispatch_stack
+                .last()
+                .map(|f| f.args.clone())
+                .unwrap_or_default(),
+        };
+        let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = invocant.view()
+        else {
+            return None;
+        };
+        if !attributes.contains_key("__mutsu_array_storage")
+            || !self
+                .mro_readonly(&class_name.resolve())
+                .iter()
+                .any(|n| n == "Array")
+        {
+            return None;
+        }
+        let method_sym = Symbol::intern(&method_name);
+        attributes.with_attr_mut("__mutsu_array_storage", |storage| {
+            self.try_native_method(storage, method_sym, &args)
+        })?
+    }
+
     /// When a user-overridden grammar `parse`/`subparse`/`parsefile` calls
     /// `nextsame`/`nextwith` (or `callsame`/`callwith`) and the user MRO is
     /// exhausted, the NATIVE grammar parse is the final base candidate. It is not
@@ -443,15 +500,20 @@ impl Interpreter {
             let (receiver_class, invocant, mut call_args, owner_class, mut method_def, rw_params) = {
                 let frame = &mut self.method_dispatch_stack[frame_idx];
                 let Some((owner_class, method_def)) = frame.remaining.first().cloned() else {
-                    // User MRO exhausted: a grammar `parse`/`subparse` override or a
-                    // metamodel-HOW dispatch falls through to the native
-                    // implementation as the last candidate before giving up.
+                    // User MRO exhausted: a grammar `parse`/`subparse` override, an
+                    // `is Array` subclass's Positional override, or a metamodel-HOW
+                    // dispatch falls through to the native implementation as the
+                    // last candidate before giving up.
                     let result = if let Some(res) =
                         self.native_grammar_parse_next_candidate(override_args.as_deref())
                     {
                         res?
                     } else if let Some(res) =
                         self.native_mu_base_next_candidate(override_args.as_deref())
+                    {
+                        res?
+                    } else if let Some(res) =
+                        self.native_array_storage_next_candidate(override_args.as_deref())
                     {
                         res?
                     } else {
@@ -840,6 +902,22 @@ impl Interpreter {
                 }
                 return Ok(result);
             }
+        }
+        // A single (non-multi, non-wrapped) compiled method pushes no
+        // `method_dispatch_stack` frame at all, so an `is Array` subclass's
+        // Positional override (`method AT-POS($i) { nextwith $i.round }`)
+        // reaches here directly rather than the exhausted-MRO branch above.
+        // The native array behavior on the backing `__mutsu_array_storage` is
+        // still the correct base candidate.
+        if let Some(res) = self.native_array_storage_next_candidate(override_args.as_deref()) {
+            let result = res?;
+            if tail_call {
+                return Err(RuntimeError {
+                    return_value: Some(result),
+                    ..RuntimeError::new("")
+                });
+            }
+            return Ok(result);
         }
         // If we're inside a method but there's simply no next candidate in the MRO,
         // return Nil (this is the Raku behavior for callsame/callwith at the end of

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1852,12 +1852,12 @@ impl Interpreter {
                         .map_or(0, crate::runtime::to_int)
                 };
                 if class_mro.iter().any(|name| name == "Array")
-                    && !attrs.contains_key("__array_items")
+                    && !attrs.contains_key("__mutsu_array_storage")
                     && !positional_ctor_args.is_empty()
                 {
                     attrs.insert(
-                        "__array_items".to_string(),
-                        Value::array(positional_ctor_args),
+                        "__mutsu_array_storage".to_string(),
+                        Value::real_array(positional_ctor_args),
                     );
                 }
                 if class_mro.iter().any(|name| name == "Int")

--- a/src/runtime/ops_compare.rs
+++ b/src/runtime/ops_compare.rs
@@ -81,7 +81,7 @@ impl Interpreter {
                 .collect(),
             ValueView::Slip(items) => items.to_vec(),
             // Positional-ish instances (WalkList candidates, Backtrace frames,
-            // captured __array_items) share the utils implementation.
+            // Array-subclass backing storage) share the utils implementation.
             ValueView::Instance { .. } => crate::runtime::utils::value_to_list(val),
             // Nil is a single scalar item in list context (e.g. `for Nil { }`
             // does one iteration); it is not an empty list.

--- a/src/runtime/utils/list.rs
+++ b/src/runtime/utils/list.rs
@@ -519,11 +519,6 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
             if let Some(elems) = crate::value::value_buf::buf_elems(&attributes) {
                 return elems;
             }
-            if let Some(ValueView::Array(items, ..)) =
-                attributes.as_map().get("__array_items").map(Value::view)
-            {
-                return items.to_vec();
-            }
             // An `is Array` subclass instance is Positional: in list context it
             // flattens to its backing storage elements (`for @$vec { ... }`).
             if let Some(storage) = attributes.as_map().get("__mutsu_array_storage") {

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -18,7 +18,7 @@ impl Interpreter {
     /// settle path: print-and-resume when no CONTROL handler is active, run a
     /// resume-safe handler inline, and otherwise fall back to the same
     /// unwinding signal as before.
-    pub(super) fn try_native_method(
+    pub(crate) fn try_native_method(
         &mut self,
         target: &Value,
         method_sym: crate::symbol::Symbol,

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1295,6 +1295,34 @@ impl Interpreter {
                     result
                 }
             }
+            // A non-integer numeric subscript (`@a[1.5]`) on an instance: Raku
+            // truncates a fractional Positional subscript to Int at the
+            // subscript site regardless of receiver (confirmed against raku:
+            // `$obj.AT-POS(1.5)` sees 1.5, but `$obj[1.5]` calls AT-POS with
+            // 1 already truncated) — mirror the plain-`Array` truncating arms
+            // above instead of forwarding the fractional value.
+            (
+                ValueView::Instance { .. },
+                ValueView::Num(_) | ValueView::Rat(..) | ValueView::FatRat(..),
+            ) => {
+                let i = crate::runtime::to_int(&index);
+                let fallback = target.clone();
+                let result = self
+                    .try_compiled_method_or_interpret(target.clone(), "AT-POS", vec![Value::int(i)])
+                    .or_else(|_| {
+                        self.try_compiled_method_or_interpret(
+                            fallback,
+                            "AT-KEY",
+                            vec![Value::int(i)],
+                        )
+                    })
+                    .unwrap_or(Value::NIL);
+                if result.is_nil() {
+                    self.typed_container_default(&target)
+                } else {
+                    result
+                }
+            }
             // Whatever slice on a tied Associative instance (`%h is Foo; %h{*}`):
             // enumerate the class's own keys (via its `keys` method) and read each
             // through AT-KEY, mirroring the plain-Hash `(Hash, Whatever)` arm above.

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -432,6 +432,44 @@ impl Interpreter {
             }
         }
 
+        // `my @a is CustomClass` where CustomClass subclasses `Array` (e.g.
+        // `class Array::Rounded is Array {...}`) or composes `Positional`:
+        // back the variable with a blessed instance, so indexing overrides
+        // (AT-POS/ASSIGN-POS/DELETE-POS/...) and other methods dispatch to
+        // the class's own methods, mirroring the `%`-sigil tied-hash block
+        // below. Raku ties an `@` variable to ANY class named by `is` — the
+        // `@` sigil supplies the positional semantics.
+        if name.starts_with('@')
+            && (self.registry().classes.contains_key(&trait_name)
+                || self.registry().roles.contains_key(&trait_name))
+            && (self.class_mro(&trait_name).iter().any(|n| n == "Array")
+                || self.class_does_role(&trait_name, "Positional")
+                || self.has_user_method_including_role(&trait_name, "AT-POS"))
+        {
+            if has_arg {
+                self.stack.pop();
+            }
+            let name_str = name.to_string();
+            // Gather any initializer values (`my @a is Foo = <a b c d e>`
+            // assigns the initializer before this trait op runs) as a flat
+            // positional list, matching `Foo.new(|@values)`.
+            let init_source = self
+                .read_local_slot_or_name(code, slot, &name_str)
+                .or_else(|| self.get_env_with_main_alias(&name_str));
+            let init_values: Vec<Value> = match init_source.as_ref().map(Value::view) {
+                Some(ValueView::Array(a, _)) if !a.is_empty() => a.iter().cloned().collect(),
+                Some(ValueView::Seq(s) | ValueView::Slip(s)) if !s.is_empty() => {
+                    s.iter().cloned().collect()
+                }
+                _ => Vec::new(),
+            };
+            let type_obj = Value::package(crate::symbol::Symbol::intern(&trait_name));
+            let instance = self.try_compiled_method_or_interpret(type_obj, "new", init_values)?;
+            self.write_local_slot_or_name(code, eff_slot, &name_str, instance.clone());
+            self.set_env_with_main_alias(&name_str, instance);
+            return Ok(());
+        }
+
         // `my %h is CustomClass` where CustomClass composes `Associative` (e.g.
         // `does Hash::Agnostic`): back the variable with a blessed instance, so
         // subscripting (AT-KEY/ASSIGN-KEY/DELETE-KEY), iteration and coercion

--- a/t/array-subclass-new-default-ctor.t
+++ b/t/array-subclass-new-default-ctor.t
@@ -1,0 +1,36 @@
+use Test;
+plan 7;
+
+# `Foo.new(1,2,3)` for a class `is Array` with NO user-defined `new` goes
+# through the generic default-constructor path (dispatch_new's positional-arg
+# handling), which used to stash the elements under a stray attribute key
+# (`__array_items`) that none of the Array-delegation methods (elems,
+# AT-POS, push, ...) actually read -- they all read `__mutsu_array_storage`
+# (the same key the `nextwith(|@values)` bless-time path uses). So
+# `Foo.new(1,2,3).elems` silently came back 0.
+class Foo is Array {
+    method AT-POS($index) { nextwith $index.round }
+}
+
+my $f = Foo.new(1, 2, 3);
+is $f.^name, 'Foo', 'no-args-defined new still tags the subclass';
+is $f.elems, 3, 'positional args populate the backing storage';
+is $f[0], 1, 'AT-POS reads the backing storage';
+is $f[1], 2, 'AT-POS reads the backing storage (2)';
+
+# A custom Positional override calling nextwith reaches the native array
+# base, even though the class has no OTHER user candidate in the MRO for
+# AT-POS -- a single (non-multi, non-wrapped) compiled method pushes no
+# `method_dispatch_stack` frame, so this used to fall through the
+# exhausted-MRO check straight to Nil. Called directly (not via subscript
+# syntax, which truncates the index to Int before AT-POS ever sees it --
+# confirmed against raku: `$f[1.5]` calls AT-POS with 1, not 1.5).
+is $f.AT-POS(1.5), 3, 'nextwith from a Positional override reaches the native Array base';
+
+# Subscript syntax on an instance truncates a fractional index to Int before
+# dispatching to AT-POS, exactly like a plain Array -- it used to fall
+# through every match arm straight to Nil for a non-Int index.
+is $f[1.5], 2, 'a fractional subscript on an instance truncates like a plain Array';
+
+my @g is Foo = <a b c>;
+is @g.^name, 'Foo', 'the "is" trait on an @-sigil variable blesses as the user Array subclass';

--- a/todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md
+++ b/todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md
@@ -1,0 +1,102 @@
+# A user-exported `postcircumfix:&lt;[ ]&gt;` multi candidate is never dispatched for `@obj[...]` subscript syntax
+
+Found while investigating `Array::Rounded` (`todo/tickets/dist-test-suite-failures-batch.md`'s
+Un-triaged list). The dist's actual rounding mechanism is NOT the `AT-POS` method override it also
+declares (that one only matters for a *direct* `.AT-POS(...)` call, or the Positional protocol paths
+that route through it — `:exists`/`:delete`/`:p`/`:k`/`:v` adverbs). The real mechanism is a set of
+**exported `multi sub postcircumfix:&lt;[ ]&gt;` candidates** that intercept the subscript *operator*
+itself for a non-`Int` index on the class:
+
+```raku
+my constant &old-same = &postcircumfix:<[ ]>;
+proto sub postcircumfix:<[ ]>($, |) is export {*}
+multi sub postcircumfix:<[ ]>(Array::Rounded:D \SELF, Int:D $index) {
+    old-same SELF, $index
+}
+multi sub postcircumfix:<[ ]>(Array::Rounded:D \SELF, Any:D \index) {
+    old-same SELF, index.round
+}
+# ... more candidates for Iterable/Callable/Whatever/List index shapes ...
+```
+
+Confirmed against real `raku` (`raku -e 'say 1.5.round'` → `2`; a minimal two-file repro with `use
+Mod2; class Baz is Array {}; multi sub postcircumfix:<[ ]>(Baz:D \s, Any:D \i) {...}` was NOT built
+here, but the mechanism is a standard, spec'd Raku operator-overload feature — see
+`raku-doc/doc/Language/operators.rakudoc` "Adding new operators" / `is export`). This is a genuine,
+general capability gap, not specific to this dist: **any module that defines a custom
+`postcircumfix:&lt;[ ]&gt;` (or `postcircumfix:&lt;{ }&gt;`, `postfix:&lt;++&gt;`, etc.) multi
+candidate scoped to a user class is never consulted when mutsu compiles `@obj[...]`/`%obj{...}`
+subscript syntax** — that syntax always lowers straight to the native `Index`/`IndexAssign` opcode
+family (`src/vm/vm_var_index_ops.rs`, `src/vm/vm_var_assign_index_named.rs`), which for an
+`Instance` target only ever calls the built-in `AT-POS`/`AT-KEY`/etc. protocol methods (added
+2026-08-06/07, see `news/2026-08/array-subclass-nextwith-and-num-subscript.md`), never checking the
+op-name multi-sub table (`postcircumfix:&lt;[ ]&gt;` et al.) the way a *written-out* call to
+`&postcircumfix:<[ ]>(...)` or a custom infix (`$a xxx $b`, fixed generally in
+`news/2026-08/user-infix-closure-arg-writeback.md` for a related but distinct gap — writeback, not
+dispatch-site — earlier this same day) would.
+
+## Why this is deep, not a quick patch
+
+- The compiler currently treats `@expr[...]` as **syntax**, lowering it directly to an `Index`
+  opcode at compile time — it does not go through the generic `Undeclared routine` /
+  multi-candidate-resolution machinery that a plain function call does. Making it consult a
+  user-declared `postcircumfix:&lt;[ ]&gt;` multi means either:
+  1. Compiling `@expr[...]` to a call-shaped op that checks "does any user multi candidate for
+     `postcircumfix:&lt;[ ]&gt;` match this (target, index) pair, by MRO/type, before falling back to
+     the native `Index` opcode" — a real dispatch-site change touching every subscript compile site
+     (positional, associative, multi-dim, autovivifying, lvalue-assignment forms all have their own
+     opcodes/handlers per `vm_var_index_ops.rs`, `vm_var_assign_index_named.rs`,
+     `builtins_multidim_assign.rs`).
+  2. Or, cheaper but narrower: at the `Instance` arms already added for `AT-POS`/`AT-KEY` dispatch,
+     ALSO probe for a user `postcircumfix:&lt;[ ]&gt;` multi registered against the instance's class
+     before falling to `AT-POS`, and route through it if found. This still needs the multi-candidate
+     matcher (parameter type checks including `Int:D` vs `Any:D` specificity ordering) invoked from a
+     VM op rather than the normal call-site compiled dispatch — a new, narrower entry point into
+     `resolve_all_methods_with_owner`-style candidate resolution, but for *subs*, not methods.
+  - Either way this is a **dispatch-site redesign for every subscript op**, not a one-line delegation
+    fix like the three `Array::Rounded`-adjacent bugs fixed alongside this ticket.
+- Getting candidate *specificity* right matters for correctness: `Int:D $index` must beat `Any:D
+  \index` for an actual `Int` index (raku picks the narrower candidate), so a naive "any matching
+  multi wins" implementation would silently break the plain-`Int` fast path this dist ALSO relies on
+  (`multi sub postcircumfix:<[ ]>(Array::Rounded:D \SELF, Int:D $index) { old-same SELF, $index }`).
+
+## What's confirmed fixed alongside this (do not re-investigate)
+
+Three genuine, general, already-fixed bugs surfaced along the way (verified against real `raku`,
+regression-pinned in `t/array-subclass-new-default-ctor.t`):
+
+1. `Foo.new(1,2,3)` for an `is Array` subclass with no user `new` stashed the elements under a stray
+   `__array_items` attribute key that no delegation method actually read (they all read
+   `__mutsu_array_storage`) — `src/runtime/methods_object_dispatch_new.rs`.
+2. `my @a is Foo = ...` (the `is` TRAIT on an `@`-sigil variable) had no implementation at all for a
+   user class target — added a new `@`-sigil branch in `exec_apply_var_trait_op`
+   (`src/vm/vm_var_trait_ops.rs`), mirroring the existing `%`-sigil tied-hash mechanism.
+3. `nextwith`/`nextsame` from inside a single (non-multi, non-wrapped) compiled method — which pushes
+   no `method_dispatch_stack` frame — fell straight to the "MRO exhausted, return Nil" fallback
+   instead of reaching the native `Array` base behavior on `__mutsu_array_storage`
+   (`src/runtime/builtins_dispatch_next.rs`, new `native_array_storage_next_candidate`).
+4. A fractional/`Rat` subscript (`@obj[1.5]`) on an `Instance` fell through every match arm straight
+   to `Nil` instead of truncating to `Int` and dispatching to `AT-POS`/`AT-KEY` like a plain `Array`
+   does (`src/vm/vm_var_index_ops.rs`) — confirmed against raku that subscript syntax ALWAYS truncates
+   before `AT-POS` sees the index (a *direct* `.AT-POS(1.5)` call is the only way to see the
+   fractional value — this is what `Array::Rounded`'s `AT-POS` override actually depends on, it's the
+   `postcircumfix:&lt;[ ]&gt;` multis, not `AT-POS`, that see the raw subscript expression).
+
+## What's still broken
+
+**Also a separate, un-investigated gap**: `my @a is Rounded = ...` where `Rounded` is a `my constant
+... is export` aliasing the real class, imported from ANOTHER module (`use Array::Rounded`), does not
+resolve — `@a.^name` stays `Array` (fix #2 above only checked the trait name literally against
+`registry().classes`/`registry().roles`, which only matches when the `is` trait names the class
+directly, e.g. `is Array::Rounded` or a same-file `my constant`). A direct bareword reference to the
+same constant elsewhere (`Rounded.new(...)`) resolves correctly via the normal `GetBareWord`
+opcode's resolution chain (`src/vm/vm_var_get_ops.rs`) — `exec_apply_var_trait_op` needs the same
+resolution for `trait_name`, not just a registry key match. Not fixed here; `exec_apply_var_trait_op`
+(`src/vm/vm_var_trait_ops.rs`) has no access to `compiled_fns`/`code`-driven bareword resolution the
+way `exec_get_bare_word_op` does, so plumbing this through needs its own small design pass. This is
+`Array::Rounded`-idiomatic (many "provides a nicer-named constant for a verbosely-named class" Raku
+modules follow this pattern), so likely affects other dists too.
+
+Do not close `Array::Rounded`'s row in `dist-test-suite-failures-batch.md` until BOTH this ticket
+(postcircumfix dispatch) and the constant-alias `is` trait gap above are resolved — the dist's own
+test suite still fails 16/35 with both outstanding.

--- a/todo/tickets/dist-test-suite-failures-batch.md
+++ b/todo/tickets/dist-test-suite-failures-batch.md
@@ -101,6 +101,17 @@ subclass instance was never treated as date-like. Both fixed generally; see
   genuine grammar-ambiguity lookahead feature needing a design pass:
   [todo/deep/bare-block-as-infix-operand-not-recognized.md](../deep/bare-block-as-infix-operand-not-recognized.md).
 
+### `Array::Rounded` — triaged, 4 general bugs fixed, 2 remain (needs a design pass)
+
+Four separate, general bugs in how an `is Array` subclass interacts with construction, `nextwith`,
+and fractional subscripts were found and fixed:
+`news/2026-08/array-subclass-nextwith-and-num-subscript.md`. The dist's own test suite still fails
+16/35 — its actual rounding mechanism is exported `multi sub postcircumfix:<[ ]>` candidates (an
+operator overload on the subscript syntax, not the `AT-POS` method it also declares), which mutsu
+never dispatches for `@obj[...]`; a `my @a is Rounded = ...` cross-module constant-alias `is` trait
+gap also remains. Both documented, not fixed:
+[todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md](../deep/user-postcircumfix-index-not-dispatched-for-instances.md).
+
 ### `RSV` — triaged, root-caused, needs a compiler design pass
 
 `lib/RSV.rakumod` declares `constant \EOV = blob8.new(255);` (and `\EOR`,
@@ -116,7 +127,6 @@ it needs a design pass rather than a quick patch:
 
 ## Un-triaged `test_die` / `test_fail`
 
-`Array::Rounded` (fail);
 `Math::Interval`, `Native::Overflow`, `App::SudokuHelper`, `P5tie`,
 `Mathematica::Serializer::Encoder`, `Hash::Restricted`, `Crypt::RC4`,
 `Random::Choice` (die).


### PR DESCRIPTION
## Summary
Investigating `Array::Rounded` (`todo/tickets/dist-test-suite-failures-batch.md`) surfaced four separate, general bugs in how a user class that `is Array` interacts with the rest of the interpreter — all confirmed against real `raku`:

- `Foo.new(1,2,3)` with no user-defined `new` stashed positional args under a stray `__array_items` attribute key that no delegation method (`elems`, `AT-POS`, `push`, list-context flattening) actually read — they all read `__mutsu_array_storage`, the same key `nextwith(|@values)`-from-`new` already used.
- `my @a is Foo = ...` had no implementation at all for a user class target — `exec_apply_var_trait_op` only handled the `%`-sigil tied-hash case. Added a mirroring `@`-sigil branch.
- `nextwith`/`nextsame` from inside a single (non-multi, non-wrapped) compiled method — which pushes no `method_dispatch_stack` frame — fell straight to the "MRO exhausted, return Nil" fallback instead of reaching the native `Array` base behavior on the backing storage.
- A fractional/`Rat` subscript (`@obj[1.5]`) on an `Instance` fell through every match arm straight to `Nil`; added a truncating arm mirroring plain-`Array` semantics (confirmed raku truncates the subscript to `Int` before `AT-POS` ever sees it — only a *direct* `.AT-POS(1.5)` call sees the fractional value).

`Array::Rounded`'s own test suite still fails 16/35: its actual rounding mechanism is exported `multi sub postcircumfix:<[ ]>` candidates (an operator overload mutsu never dispatches for `@obj[...]` syntax), not the `AT-POS` method override fixed here. Documented as a new deep ticket (`todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md`) along with a cross-module constant-alias `is` trait gap that also blocks it.

## Test plan
- [x] New regression test `t/array-subclass-new-default-ctor.t`, verified line-for-line against real `raku`.
- [x] Existing `t/array-subclass-vector.t` (the pre-existing `is Array` subclass test) still passes — no regression.
- [x] `make test` — 27745 tests, all passing.
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean (pre-commit hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)