### PR TITLE
feat(compiler): sub ::($name) {...} compiles to bytecode

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -297,7 +297,19 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
     (`news/2026-08/safe-class-empty-body-default.md`); C6e-3c drops the field
     itself once the load-bearing classes — no resolvable plan bytecode, rw/raw
     scalars' interpreter carrier, lvalue routines, NativeCall — are unblocked.
-    Measurements and per-shape notes:
+    A 2026-08-07 re-audit (forcing the literal end state — body always empty,
+    not just the `plan_fully_compiled` half of the predicate — across the full
+    `t/` suite and full `make roast`) found the field is still NOT droppable:
+    runtime-resolved sub/method names (`sub ::($n) {...}`) were never
+    OTF-compiled at all (fixed the same day — the compiled-routine lookup key
+    is an internal symbol independent of the eventual runtime name, so it
+    compiles safely), and a plan-derived def declared inside a bare
+    block/closure invoked through a foreign compiled_fns context (e.g. a
+    module's own exported sub calling a captured block argument) loses its
+    compiled routine the same way `MethodDef`/`CompiledFunction` did before
+    their own carrier fixes — but `SubData` (blocks/closures) was explicitly
+    scoped out of that carrier work and still has no equivalent. Measurements
+    and per-shape notes, including this re-audit:
     `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.
 - [ ] **C7 — Remove the sub-registration AST adapter.** Delete dead sub-shaped walker branches and
   prove the routine registry never compiles a migrated declaration on demand.

--- a/news/2026-08/indirect-decl-name-subs-compile.md
+++ b/news/2026-08/indirect-decl-name-subs-compile.md
@@ -1,0 +1,52 @@
+# `sub ::($name) {...}` now compiles to bytecode, and a second `legacy_body` keep-class is found
+
+ADR-0019 C6e-3c's remaining step is deleting `CompiledSubDeclPlan::legacy_body`
+— the field that lets a plan-derived sub declaration fall back to its
+interpreted AST body when its compiled bytecode isn't usable. A prior session
+measured this as fully unblocked via an env-gated instrument that forced the
+`plan_fully_compiled` half of the registration predicate. Re-running the
+equivalent of an actual field deletion — forcing the *whole* body-selection
+predicate, so `body` is unconditionally empty regardless of
+`plan_fully_compiled`/`primary_compiled` — across the full `t/` suite and full
+`make roast` found the field is still load-bearing, for two reasons.
+
+## Runtime-resolved names were never compiled at all
+
+`sub ::($name) (...) {...}` (an indirect/computed declarator name) hit an
+explicit early return in the compiler: `if name_expr.is_some() { return; }`,
+with the comment "Runtime-resolved sub names cannot be keyed reliably in
+compiled_fns." That premise doesn't hold — the compiled-routine lookup key
+(`{package}::{name}/{arity}#{fingerprint}`) is a purely internal symbol used
+to find the `CompiledFunction` in the plan's own `compiled_fns` table; it has
+no relationship to `resolved_name`, the runtime-computed name the routine
+actually registers under at `RegisterDecl` time. `name` in the key is just the
+parser's placeholder text (the bareword/literal written inside `::(...)`, or
+`__INDIRECT_DECL_NAME__` for a non-literal expression) — good enough for
+uniqueness, irrelevant to correctness. Removing the early return lets the
+body compile like any other sub; `t/indirect-declarator-names.t` test 2 (`sub
+::(name) declares a callable sub`), which failed under the forced instrument
+before this change, now passes, with zero regressions across the full `t/`
+suite in both normal and forced modes.
+
+## A plan-derived def inside a block loses its compiled routine across a foreign call
+
+`roast/S12-subset/subtypes.t` failed under the same forced instrument: `sub
+pos-match {...}`, declared inside a block passed as `&tests` to
+`Test::Util`'s `group-of`, has `primary_compiled.is_none()` at registration —
+*even without forcing* — meaning it already runs interpreted on `main` today.
+`group-of` calls `tests()` from within its own compiled code (a different
+compilation unit than the test file), and the nested `pos-match` — though
+itself a plan-derived def, not a closure — executes its `RegisterSub` opcode
+as part of the *block's* bytecode, inheriting whatever `compiled_fns` table
+the block's own call path was given. Prior C6e-3c work gave `CompiledFunction`
+and `MethodDef` their own `compiled_fns` carrier so a routine's nested subs
+resolve correctly across a module boundary (the #5982 fix and its
+generalizations), but `SubData` (blocks/closures) was explicitly scoped out
+of that work. This repro shows the scoping was too narrow: a def nested
+inside a *block*, not just inside a *routine*, needs the same treatment. Not
+yet fixed — root cause identified but the carrier work for
+block/closure invocation is a fresh, separate slice.
+
+`CompiledSubDeclPlan::legacy_body` stays in place until that second class is
+resolved. Findings and the next step are recorded in
+`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3163,11 +3163,13 @@ impl Compiler {
                         self.add_sub_decl_plan(stmt)
                     };
                 self.code.emit(OpCode::RegisterDecl(idx));
-                if name_expr.is_some() {
-                    // Runtime-resolved sub names cannot be keyed reliably in compiled_fns.
-                    return;
-                }
-                // Also compile the body to bytecode for VM-native dispatch
+                // Also compile the body to bytecode for VM-native dispatch. This
+                // runs even for a runtime-resolved name (`sub ::($n) {...}`): the
+                // compiled_fns key below is an internal lookup symbol keyed off
+                // the parsed placeholder text plus package/arity/fingerprint, not
+                // the eventual runtime name, so it stays reliable — the *routine*
+                // registers under `resolved_name` at RegisterDecl time regardless
+                // of what key its bytecode was filed under (ADR-0019 C6e-3c).
                 let state_group = if *multi && !signature_alternates.is_empty() {
                     Some(format!(
                         "{}::{}",

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -343,3 +343,105 @@ sigilless / 2,659 `start`-body / 14 sub-signature / 0 trait). The
 Related: `todo/deep/c6d-interpreter-body-sites-are-mostly-token-bodies.md`
 (the site inventory), `news/2026-08/fallback-def-arm-runs-compiled-body.md`
 (the C6d-5 gate).
+
+## C6e-3c re-audit (2026-08-07): the field-drop A/B found two more real keep-classes
+
+The "field-drop blocker is now fully resolved" conclusion above was measured
+with an env-gated instrument that only forced the *outer* `plan_fully_compiled`
+check (`compiled_routine_keys.len() == 1 + signature_alternates.len()`), not
+the *whole* body-selection predicate. Re-running the same experiment but
+forcing the literal end state of deleting the field — i.e. `body` is
+unconditionally empty regardless of `plan_fully_compiled`/`primary_compiled`
+(`vm_register_sub_ops.rs::exec_register_sub_op`) — surfaces two more failures
+across the full `t/` suite (27,755 tests) and full `make roast`
+(218,774 tests, whitelist only). This is the correct experiment for "what
+happens if `legacy_body` is deleted", since after deletion there is no
+fallback left to select between; both classes below currently have
+`primary_compiled.is_none()` at registration time, so the real gate — not the
+narrower one from the prior audit — is what's keeping them alive.
+
+**Class 1 — runtime-resolved sub/method names (`sub ::($n) {...}`) — FIXED
+this session.** `src/compiler/stmt.rs`'s `Stmt::SubDecl` arm had an explicit
+early return: `if name_expr.is_some() { return; }` (comment: "Runtime-resolved
+sub names cannot be keyed reliably in compiled_fns"), skipping bytecode
+compilation entirely for a computed-name declaration, so
+`compiled_routine_keys` stayed empty and `plan_fully_compiled` was `false` by
+construction — not a registration-time table mismatch, but the compiler
+simply never producing bytecode for this shape. Investigation showed the
+premise was wrong: the compiled-routine lookup key
+(`format!("{pkg}::{name}/{arity}#{fingerprint}")`) is a purely internal
+symbol, unrelated to the runtime-resolved name the routine eventually
+registers under (`resolved_name`, computed separately via `name_chunk` at
+`RegisterDecl` time) — so it "keys reliably" just fine even when `name` is
+only the parser's placeholder text (the bareword/literal written inside
+`::(...)`, e.g. `"sname"` for `sub ::(sname) {...}`, or the literal
+`__INDIRECT_DECL_NAME__` for a non-literal/non-bareword expression). Deleting
+the early return and letting the body compile like any other sub fixed
+`t/indirect-declarator-names.t` test 2 (`sub ::(name) declares a callable
+sub`) under the forced instrument, with zero regressions across the full `t/`
+suite in both normal and forced modes. Only the `Stmt::SubDecl` arm was
+touched; the `Stmt::MethodDecl` arm (~line 3291, a different, likely
+rarely-hit code path lowering a package-level `method` decl into the same
+plan shape) has an analogous `if name_expr.is_none() { ... compile ... }`
+gate that was NOT touched — nothing in `t/` or the roast whitelist exercised
+it under the forced instrument, so it is unaudited, not confirmed-safe.
+
+**Class 2 — a plan-derived def declared inside a bare block/closure, invoked
+through a call path whose executing `compiled_fns` table isn't the def's own
+— NOT fixed, root cause identified.** Repro: `roast/S12-subset/subtypes.t`
+(`sub pos-match { $wanted = $^got; True }` declared inside a block passed as
+`&tests` to `Test::Util`'s `group-of`, which itself calls `tests()` from
+*within its own compiled code* — `group-of` is `is export is test-assertion`,
+compiled as part of the `Test::Util` module's own compilation unit). Even
+WITHOUT forcing, instrumented logging showed `primary_compiled.is_none()` at
+this def's `RegisterSub` execution (`plan_fully_compiled=true,
+compiled_routine_keys.len()=1`, but the key does not resolve in the
+`compiled_fns` table passed to this opcode) — meaning `pos-match` is *already*
+running via the interpreted `legacy_body` fallback today, on `main`, without
+any instrument. The field-drop A/B just makes that latent gap load-bearing.
+
+Hypothesis (not yet confirmed by instrumentation, since this needs tracing
+through the block/closure call path rather than the registration op): a bare
+block `{ ... }` (as opposed to a named routine/method) is compiled inline —
+`compile_sub_body_with_deprecation`'s freshly-inserted `CompiledFunction` for
+a *nested* `sub` like `pos-match` lands in the *enclosing* compiler's
+`compiled_functions` table (ultimately the top-level test file's pooled
+`compiled_fns`), not in any table the block's own `SubData` carries. The
+prior C6e-3c campaign gave `CompiledFunction` and `MethodDef` their own
+`compiled_fns: Option<Arc<CompiledFns>>` carrier (the #5982 fix, later
+generalized to ~17 more `call_compiled_method`-shaped sites, then to
+`call_shared_state_body`) specifically so a *routine's* nested subs resolve
+correctly when called through a foreign compiled_fns context (e.g. an
+imported module). `SubData` (raw closures/blocks, as opposed to
+`CompiledFunction`) was explicitly scoped OUT of that carrier work — see the
+"C6e-3c progress" section above: "a raw closure's `compiled_code` (`SubData`
+carries no equivalent field — closures aren't in C6e-3c's scope, since a
+plan-derived *def* never routes through `compiled_code`)". This repro shows
+that scoping decision was too narrow: even though `pos-match` itself IS a
+plan-derived def (not a closure), its `RegisterSub` opcode executes as part
+of the *block's* bytecode, so it inherits whatever `compiled_fns` table the
+block's own execution context was given — and when the block is invoked
+through `group-of` (cross-compilation-unit call), that table is apparently
+not the one `pos-match`'s `CompiledFunction` was actually inserted into.
+
+Fixing this needs tracing the call path that invokes a `&tests`-style
+captured block value from within a *different* module's compiled code (likely
+`call_sub_value` / whatever closure-invocation path `group-of`'s `tests()` bare
+call resolves to) and checking what `compiled_fns` argument reaches the
+block's own bytecode execution loop — the same "which table gets threaded
+through" question C6e-3c already solved three times for `CompiledFunction`
+call sites (`MethodDef.compiled_fns`, the ~17-site carrier audit,
+`call_shared_state_body`), but for `SubData`/block execution instead. This is
+a `SubData`-needs-its-own-compiled_fns-carrier feature, structurally similar
+in shape to the earlier fixes but touching different call sites (block/closure
+invocation, not routine/method invocation) — a fresh, scoped investigation,
+not a copy-paste of the earlier fix.
+
+**Conclusion: `CompiledSubDeclPlan::legacy_body` is NOT droppable yet.**
+Class 1 is fixed (2026-08-07). Class 2 is real and load-bearing today (not
+just under the forced instrument) — `pos-match` already runs interpreted on
+`main`. The next session resuming this thread should re-run the full-suite
+forced-instrument A/B (`vm_register_sub_ops.rs::exec_register_sub_op`, OR the
+literal body-selection predicate, not just the outer `plan_fully_compiled`
+check) after fixing Class 2, to check whether any further classes remain
+before the field can actually be deleted.


### PR DESCRIPTION
## Summary
- ADR-0019 C6e-3c (dropping `CompiledSubDeclPlan::legacy_body`): a computed/indirect sub declarator name (`sub ::($name) (...) {...}`) previously skipped bytecode compilation entirely on the premise that a runtime-resolved name "cannot be keyed reliably in compiled_fns." That premise is wrong — the internal compiled-routine lookup key has no relationship to the eventual runtime name — so this removes the early return and lets it compile normally.
- Re-running the field-drop A/B (forcing the whole body-selection predicate, not just `plan_fully_compiled`, across full `t/` + full `make roast`) found this was one of two remaining `legacy_body` keep-classes. The second (a plan-derived def declared inside a block/closure loses its compiled routine when the block is invoked through a foreign `compiled_fns` context — `SubData` has no carrier the way `CompiledFunction`/`MethodDef` now do) is **not fixed** in this PR; it's documented in `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md` for the next slice. The field itself stays in place.
- Docs: `docs/adr/0019-...md` C6e-3c bullet updated with the re-audit finding; `news/2026-08/indirect-decl-name-subs-compile.md` records the accomplishment + the open blocker.

## Test plan
- [x] `t/indirect-declarator-names.t` (existing local test, test 2 was the repro under the forced instrument)
- [x] `roast/S02-names/indirect.t` (whitelisted, covers `sub ::(name)` correctness)
- [x] Full local `t/` suite (27,755 tests) — PASS, both normal and forced-bodyless-instrument modes
- [x] Full local `make roast` (218,774 tests, whitelist) under the forced instrument — only the two documented keep-classes failed, both pre-existing on `main`; Class 1 (this fix) now passes, Class 2 documented
- [x] `cargo fmt` / `cargo clippy -- -D warnings`
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)