### PR TITLE
fix(vm): blocks/closures carry their own nested-sub compiled_fns table

### DIFF
--- a/news/2026-08/subdata-carries-its-own-nested-sub-table.md
+++ b/news/2026-08/subdata-carries-its-own-nested-sub-table.md
@@ -1,0 +1,37 @@
+# A block's nested subs resolve their compiled bytecode from any calling context
+
+ADR-0019's C6e-3c slice gave `CompiledFunction` and `MethodDef` their own
+`compiled_fns` carrier earlier this month, so a routine invoked from a
+foreign compilation unit's compiled code could still resolve its own nested
+`sub` declarations' bytecode instead of falling back to the AST
+interpreter. `SubData` — the runtime value for a bare block or closure, as
+opposed to a named routine — was explicitly scoped out of that work, and a
+2026-08-07 re-audit found it was a real gap: a `sub` declared inside a block
+passed to another module's compiled code (the shape `Test::Util`'s
+`group-of` uses) could not resolve its own compiled bytecode and silently
+kept interpreting instead.
+
+`CompiledCode` now carries the same `compiled_fns: Option<Arc<CompiledFns>>`
+field, populated from the closure's own nested-sub table at compile time
+(previously computed and discarded). `SubData` copies it at every
+closure-construction site, and the two dispatch fast paths that invoke a
+`Sub`'s compiled bytecode — `vm_call_on_value` and `vm_call_map_block` — now
+prefer it over the caller's ambient table.
+
+`vm_call_map_block` turned out to have a more general, currently-live
+version of the same bug: it substituted a hardcoded empty table for every
+`.map`/`.grep` block regardless of context, so a nested named `sub` inside
+any such block never resolved its own bytecode — always AST-interpreted,
+independent of any C6e-3c timeline. Both call sites are fixed.
+
+Validated with a temporary `MUTSU_FORCE_BODYLESS=1` instrument (forcing
+every plan-derived sub to register without an AST body, mimicking a fully
+completed `legacy_body` drop): the full `t/` suite (27,755 tests) and the 37
+whitelisted roast files exercising `Test::Util`'s `group-of` (3,788 tests)
+both pass. Pinned by `t/subdata-nested-sub-compiled-fns.t`.
+
+This closes Class 2 of
+`todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md` (ADR-0019
+C6e-3c); the legacy-body field itself is not dropped yet — a fresh
+full-suite forced-instrument sweep is still needed to confirm no further
+classes remain.

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -1269,14 +1269,21 @@ impl Compiler {
         }
         // Transfer any compiled functions from the closure to the parent while
         // preserving the declaration-plan references into the imported table.
-        // The caller reads them back via `compiled_functions_ref()` /
-        // `take_compiled_functions()` when it needs this routine's own
-        // nested-sub table (ADR-0019 C6e-3c), so the returned snapshot itself
-        // is not needed here.
-        let _ = self.import_compiled_functions(
+        // The imported (post-remap) snapshot is this closure's own nested-sub
+        // table — attach it to the closure body itself
+        // (`CompiledCode::compiled_fns`) so a `SubData` built from this code at
+        // runtime can resolve its nested subs' `RegisterSub` opcodes even when
+        // invoked through a foreign `CompiledFns` context (e.g. a captured
+        // block called from a different compilation unit's compiled code, the
+        // gap identified in
+        // `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`,
+        // ADR-0019 C6e-3c).
+        let own_compiled_fns = self.import_compiled_functions(
             &mut sub_compiler.code,
             std::mem::take(&mut sub_compiler.compiled_functions),
         );
+        sub_compiler.code.compiled_fns =
+            (!own_compiled_fns.is_empty()).then(|| std::sync::Arc::new(own_compiled_fns));
         sub_compiler.code.is_routine = is_routine;
         // Use the sub_compiler's source line if a SetLine was processed
         // within the body, otherwise fall back to the parent compiler's

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2351,6 +2351,17 @@ pub(crate) struct CompiledCode {
     pub(crate) lex_scopes: Vec<Arc<crate::compiler::lex_scope::LexScopeChain>>,
     /// Pre-compiled closure bodies embedded in this code chunk.
     pub(crate) closure_compiled_codes: Vec<Arc<CompiledCode>>,
+    /// Compiled functions this closure/block body directly declares as nested
+    /// `sub`s, keyed exactly as they were installed into the enclosing compile
+    /// pass's functions table (post name-collision remap). `None` when the
+    /// body declares no nested sub. Mirrors
+    /// [`CompiledFunction::compiled_fns`] for the same reason: a `SubData`
+    /// built from this code and invoked as a detached `Sub` VALUE from a
+    /// foreign `CompiledFns` context cannot resolve a nested `RegisterSub`'s
+    /// `compiled_routine_keys` from the caller's table alone (ADR-0019
+    /// C6e-3c; see
+    /// `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`).
+    pub(crate) compiled_fns: Option<Arc<CompiledFns>>,
     /// Own local slots that reach an atomic-op builtin (`⚛$x`, `$x ⚛= v`,
     /// `cas($x, …)`) as the target VARIABLE. These builtins are compiled to a
     /// `__mutsu_*_var(name_str, …)` call and resolve the target by NAME from env
@@ -2988,6 +2999,7 @@ impl CompiledCode {
             param_local_slots: Vec::new(),
             lex_scopes: Vec::new(),
             closure_compiled_codes: Vec::new(),
+            compiled_fns: None,
             atomic_env_sync_locals: Vec::new(),
             atomic_target_syms: rustc_hash::FxHashSet::default(),
             named_arg_specs: Vec::new(),

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -255,6 +255,7 @@ impl Interpreter {
                     empty_sig: false,
                     is_bare_block: false,
                     compiled_code: None,
+                    compiled_fns: None,
                     compiled_routine: None,
                     deprecated_message: None,
                     source_line: None,

--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -108,6 +108,7 @@ impl Interpreter {
             empty_sig: false,
             is_bare_block: true,
             compiled_code: None,
+            compiled_fns: None,
             compiled_routine: None,
             deprecated_message: None,
             source_line: None,

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -69,6 +69,7 @@ impl Interpreter {
                 empty_sig: false,
                 is_bare_block: false,
                 compiled_code: None,
+                compiled_fns: None,
                 compiled_routine: None,
                 deprecated_message: None,
                 source_line: None,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2781,6 +2781,7 @@ mod tests {
             empty_sig: false,
             is_bare_block: false,
             compiled_code: Some(Arc::new(compiled)),
+            compiled_fns: None,
             compiled_routine: None,
             deprecated_message: None,
             source_line: None,

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -1207,6 +1207,7 @@ impl Interpreter {
             empty_sig: false,
             is_bare_block: true,
             compiled_code: None,
+            compiled_fns: None,
             compiled_routine: None,
             deprecated_message: None,
             source_line: None,

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -555,6 +555,7 @@ impl Interpreter {
                 empty_sig: data.empty_sig,
                 is_bare_block: data.is_bare_block,
                 compiled_code: data.compiled_code.clone(),
+                compiled_fns: data.compiled_fns.clone(),
                 compiled_routine: data.compiled_routine.clone(),
                 deprecated_message: data.deprecated_message.clone(),
                 source_line: data.source_line,

--- a/src/runtime/run_main.rs
+++ b/src/runtime/run_main.rs
@@ -214,6 +214,7 @@ impl Interpreter {
             empty_sig: false,
             is_bare_block: false,
             compiled_code: None,
+            compiled_fns: None,
             compiled_routine: None,
             deprecated_message: None,
             source_line: None,

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -850,6 +850,17 @@ pub struct SubData {
     pub(crate) is_bare_block: bool,
     /// Pre-compiled bytecode for this closure (if compiled).
     pub(crate) compiled_code: Option<Arc<CompiledCode>>,
+    /// Compiled functions this closure/block body directly declares as nested
+    /// `sub`s, copied from `compiled_code.compiled_fns` at construction time.
+    /// A dispatch site invoking this Sub's `compiled_code` should prefer this
+    /// table over whatever `CompiledFns` the CALLER's frame happens to have in
+    /// scope, the same way a routine `Sub` prefers `compiled_routine`'s own
+    /// `compiled_fns` — otherwise a nested `sub` declared inside a captured
+    /// block invoked from a foreign compilation unit (e.g. an imported
+    /// module's own compiled code calling a `&block`-typed parameter) cannot
+    /// resolve its own `RegisterSub` bytecode (ADR-0019 C6e-3c; see
+    /// `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`).
+    pub(crate) compiled_fns: Option<Arc<crate::opcode::CompiledFns>>,
     /// The registry routine this code object *is*, when it was built from a
     /// declared routine rather than from a closure-creation op — `&foo`, a
     /// `.candidates` entry, a `nextsame` candidate, an operator fallback, a

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -224,6 +224,7 @@ fn sample_sub() -> Gc<SubData> {
         empty_sig: false,
         is_bare_block: false,
         compiled_code: None,
+        compiled_fns: None,
         compiled_routine: None,
         deprecated_message: None,
         source_line: None,

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -732,6 +732,7 @@ mod tests {
             empty_sig: false,
             is_bare_block: false,
             compiled_code: None,
+            compiled_fns: None,
             compiled_routine: None,
             deprecated_message: None,
             source_line: None,

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -343,6 +343,7 @@ impl Value {
             empty_sig: false,
             is_bare_block: false,
             compiled_code: None,
+            compiled_fns: None,
             compiled_routine: None,
             deprecated_message: None,
             source_line: None,

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -390,6 +390,12 @@ impl Interpreter {
         let empty_fns = CompiledFns::default();
         if let Some(cc) = &data.compiled_code {
             let cc = cc.clone();
+            // Prefer this closure's own nested-sub table over an empty one, the
+            // same way the `compiled_routine` branch below does (ADR-0019
+            // C6e-3c) — otherwise a nested `sub` declared inside this block
+            // cannot resolve its own `RegisterSub` bytecode when the block is
+            // invoked from a foreign `compiled_fns` context.
+            let fns = data.compiled_fns.as_deref().unwrap_or(&empty_fns);
             let data = data.clone();
             return self.call_compiled_closure_with_topic(
                 &data,
@@ -397,7 +403,7 @@ impl Interpreter {
                 args,
                 explicit_topic,
                 capture_rw_topic,
-                &empty_fns,
+                fns,
             );
         }
         // A code object built from a registry routine carries that routine's own
@@ -501,9 +507,20 @@ impl Interpreter {
             && let Some(ref cc) = data.compiled_code
         {
             let cc = cc.clone();
-            let data = data.clone();
             let empty_fns = CompiledFns::default();
-            let fns = compiled_fns.unwrap_or(&empty_fns);
+            // Prefer this closure's own nested-sub table over the caller's
+            // ambient one (ADR-0019 C6e-3c) — mirrors the `compiled_routine`
+            // branch below. A nested `sub` declared inside this block can
+            // otherwise fail to resolve its own `RegisterSub` bytecode when
+            // the block is invoked from a foreign `compiled_fns` context
+            // (e.g. a captured block called from a different compilation
+            // unit's compiled code).
+            let fns = data
+                .compiled_fns
+                .as_deref()
+                .or(compiled_fns)
+                .unwrap_or(&empty_fns);
+            let data = data.clone();
             return self.call_compiled_closure(&data, &cc, args, fns);
         }
 

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -219,6 +219,9 @@ impl Interpreter {
                 .and_then(|cc| cc.source_line)
                 .map(|l| l as u32)
                 .or_else(|| self.current_source_line());
+            let compiled_fns = compiled_code
+                .as_ref()
+                .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.lexical_closure_package()),
                 name: Symbol::intern(""),
@@ -239,6 +242,7 @@ impl Interpreter {
                 authoritative_captures,
                 upvalues,
                 compiled_code,
+                compiled_fns,
                 compiled_routine: None,
                 deprecated_message: None,
                 source_line: cc_source_line,
@@ -302,6 +306,9 @@ impl Interpreter {
                 .and_then(|cc| cc.source_line)
                 .map(|l| l as u32)
                 .or_else(|| self.current_source_line());
+            let compiled_fns = compiled_code
+                .as_ref()
+                .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.lexical_closure_package()),
                 // Anonymous closures pool a SubDecl with an empty name; a
@@ -325,6 +332,7 @@ impl Interpreter {
                 authoritative_captures,
                 upvalues,
                 compiled_code,
+                compiled_fns,
                 compiled_routine: None,
                 deprecated_message: None,
                 source_line: cc_source_line,

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -104,6 +104,9 @@ impl Interpreter {
                 .and_then(|cc| cc.source_line)
                 .map(|l| l as u32)
                 .or_else(|| self.current_source_line());
+            let compiled_fns = compiled_code
+                .as_ref()
+                .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.lexical_closure_package()),
                 name: Symbol::intern(""),
@@ -125,6 +128,7 @@ impl Interpreter {
                 authoritative_captures,
                 upvalues,
                 compiled_code,
+                compiled_fns,
                 compiled_routine: None,
                 deprecated_message: None,
                 source_line: cc_source_line,
@@ -155,6 +159,9 @@ impl Interpreter {
                 .and_then(|cc| cc.source_line)
                 .map(|l| l as u32)
                 .or_else(|| self.current_source_line());
+            let compiled_fns = compiled_code
+                .as_ref()
+                .and_then(|cc| cc.compiled_fns.clone());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.lexical_closure_package()),
                 name: Symbol::intern(""),
@@ -174,6 +181,7 @@ impl Interpreter {
                 authoritative_captures,
                 upvalues,
                 compiled_code,
+                compiled_fns,
                 compiled_routine: None,
                 deprecated_message: None,
                 source_line: cc_source_line,

--- a/t/lib/BlockCarrierOtf.rakumod
+++ b/t/lib/BlockCarrierOtf.rakumod
@@ -1,0 +1,13 @@
+unit module BlockCarrierOtf;
+
+# A module sub with its OWN nested sub, whose compiled `CompiledFns` table
+# is what a naive dispatch would substitute for a captured block's table
+# too (ADR-0019 C6e-3c, the SubData carrier gap).
+sub helper-in-module {
+    "from-module";
+}
+
+sub run-it(&blk) is export {
+    helper-in-module();
+    blk();
+}

--- a/t/subdata-nested-sub-compiled-fns.t
+++ b/t/subdata-nested-sub-compiled-fns.t
@@ -1,0 +1,46 @@
+use lib $*PROGRAM.parent.child("lib").Str;
+use Test;
+use BlockCarrierOtf;
+
+# A `sub` declared inside a bare block/closure compiles to bytecode whose
+# `RegisterSub` opcode's compiled-routine key must resolve against the
+# block's OWN compiled-functions table. Before this fix, `SubData` (unlike
+# `CompiledFunction`/`MethodDef`) carried no such table, so a nested sub's
+# `RegisterSub` opcode inherited whatever table the block's CALLER happened
+# to have — which is a different, unrelated table when the block is invoked
+# from a different compilation unit's own compiled code (e.g. a module sub
+# that itself has nested subs, calling a caller-supplied `&block` argument).
+# This still worked correctness-wise via the AST-body interpreter fallback;
+# this file pins the behavior now that block dispatch runs the compiled body
+# with the block's own functions table
+# (ADR-0019 C6e-3c, `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md`).
+
+plan 5;
+
+is run-it({
+    sub pos-match { "matched" }
+    pos-match();
+}), "matched", 'nested sub inside a block invoked cross-module resolves its own bytecode';
+
+is run-it({
+    sub add-one($x) { $x + 1 }
+    add-one(41);
+}), 42, 'nested sub with a param inside a cross-module block';
+
+my @r = (1, 2, 3).map({
+    sub double($x) { $x * 2 }
+    double($_);
+});
+is @r, (2, 4, 6), 'nested sub inside a native .map block';
+
+my @g = (1, 2, 3, 4).grep({
+    sub even($x) { $x % 2 == 0 }
+    even($_);
+});
+is @g, (2, 4), 'nested sub inside a native .grep block';
+
+# Repeated cross-module invocation (idempotent re-registration path).
+is run-it({
+    sub pos-match { "matched-again" }
+    pos-match();
+}), "matched-again", 'repeated cross-module block invocation with its own nested sub';

--- a/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
+++ b/todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md
@@ -388,7 +388,7 @@ it under the forced instrument, so it is unaudited, not confirmed-safe.
 
 **Class 2 — a plan-derived def declared inside a bare block/closure, invoked
 through a call path whose executing `compiled_fns` table isn't the def's own
-— NOT fixed, root cause identified.** Repro: `roast/S12-subset/subtypes.t`
+— FIXED (2026-08-07).** Repro: `roast/S12-subset/subtypes.t`
 (`sub pos-match { $wanted = $^got; True }` declared inside a block passed as
 `&tests` to `Test::Util`'s `group-of`, which itself calls `tests()` from
 *within its own compiled code* — `group-of` is `is export is test-assertion`,
@@ -437,11 +437,38 @@ in shape to the earlier fixes but touching different call sites (block/closure
 invocation, not routine/method invocation) — a fresh, scoped investigation,
 not a copy-paste of the earlier fix.
 
-**Conclusion: `CompiledSubDeclPlan::legacy_body` is NOT droppable yet.**
-Class 1 is fixed (2026-08-07). Class 2 is real and load-bearing today (not
-just under the forced instrument) — `pos-match` already runs interpreted on
-`main`. The next session resuming this thread should re-run the full-suite
-forced-instrument A/B (`vm_register_sub_ops.rs::exec_register_sub_op`, OR the
-literal body-selection predicate, not just the outer `plan_fully_compiled`
-check) after fixing Class 2, to check whether any further classes remain
-before the field can actually be deleted.
+**Class 2 fix (2026-08-07):** `CompiledCode` gained the same
+`compiled_fns: Option<Arc<CompiledFns>>` carrier `CompiledFunction`/`MethodDef`
+already had, populated at the end of `compile_closure_body_with_routine_flag`
+(`helpers_sub_body.rs`) from the closure's own `import_compiled_functions`
+return value — previously discarded with `let _ = ...`. `SubData` copies it
+from `compiled_code.compiled_fns` at all four closure-construction opcode
+sites (`exec_make_anon_sub_op`, `exec_make_anon_sub_params_op`,
+`exec_make_lambda_op`, `exec_make_block_closure_op`) and at the `&?BLOCK`
+self-ref rebuild in `resolution_call_sub.rs`. The two dispatch fast paths that
+invoke a `Sub`'s `compiled_code` now prefer it: `vm_call_on_value`
+(`data.compiled_fns.as_deref().or(compiled_fns)`, `vm_dispatch_helpers.rs`)
+and `vm_call_map_block`, which previously passed a hardcoded `&empty_fns`
+UNCONDITIONALLY for the `compiled_code` branch — a real, always-live bug
+(not just latent under a forced instrument): a nested named `sub` inside any
+`.map`/`.grep` block never resolved its own compiled bytecode and always fell
+back to the AST `legacy_body`, on `main`, today, independent of C6e-3c's
+timeline. Both fast paths are now fixed. Validated: full `t/` suite (27,755
+tests) plus the 37 whitelisted roast files using `Test::Util`'s `group-of`
+(3,788 tests) both green under a temporary `MUTSU_FORCE_BODYLESS=1` instrument
+that unconditionally empties every plan-derived body (reverted before commit);
+pinned by `t/subdata-nested-sub-compiled-fns.t` (cross-module block +
+`.map`/`.grep` block nested-sub cases), landed independently of the
+field-drop timeline since the `vm_call_map_block` half is a real
+current-default-config fix.
+
+**Conclusion: `CompiledSubDeclPlan::legacy_body` is NOT confirmed droppable
+yet, but both known classes are now fixed.** Class 1 and Class 2 are both
+fixed (2026-08-07). The next session resuming this thread should re-run the
+full-suite forced-instrument A/B (`vm_register_sub_ops.rs::exec_register_sub_op`,
+forcing the literal body-selection predicate, not just the outer
+`plan_fully_compiled` check) plus a full `make roast` under the same forced
+instrument, to check whether any further classes remain before the field can
+actually be deleted. This session validated `t/` plus a 37-file roast sample
+(the `group-of` set) under the forced instrument, not the full roast
+whitelist.


### PR DESCRIPTION
## Summary
- `CompiledFunction`/`MethodDef` already carry a `compiled_fns` table so a routine invoked from a foreign compilation unit's compiled code can resolve its own nested subs' bytecode. `SubData` (bare blocks/closures) was scoped out of that earlier ADR-0019 C6e-3c work — a nested `sub` declared inside a block passed to another module's compiled code (`Test::Util`'s `group-of` shape) never resolved its own bytecode and silently kept interpreting.
- `CompiledCode` now carries the same `compiled_fns` field, populated from the closure's own nested-sub table at compile time (previously computed and discarded). `SubData` copies it at every closure-construction site, and the two dispatch fast paths that invoke a `Sub`'s compiled bytecode (`vm_call_on_value`, `vm_call_map_block`) prefer it over the caller's ambient table.
- `vm_call_map_block` had a more general, **currently-live** version of the same bug: it substituted a hardcoded empty table for every `.map`/`.grep` block regardless of context, so a nested named `sub` inside such a block never resolved its own bytecode at all, independent of any C6e-3c timeline.
- Closes Class 2 of `todo/deep/c6e-legacy-body-drop-blocked-by-gate-rejected-shapes.md` (ADR-0019 C6e-3c). The `legacy_body` field drop itself remains blocked pending a fresh full-suite forced-instrument sweep to confirm no further classes remain.

## Test plan
- [x] New test `t/subdata-nested-sub-compiled-fns.t` (cross-module block + `.map`/`.grep` block nested-sub cases), pinned against `raku` output.
- [x] `make test` — PASS
- [x] `make roast` — PASS
- [x] Validated under a temporary `MUTSU_FORCE_BODYLESS=1` instrument (reverted before commit): full `t/` suite (27,755 tests) and the 37 whitelisted roast files using `Test::Util`'s `group-of` (3,788 tests), both green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>