### PR TITLE
feat(compiler,vm): proto declarations register from typed plans (ADR-0019 C8)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,9 +115,12 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 20/53 slices merged (C6 and C7 complete, 2026-08-07). Current box: C8 —
-migrate proto declarations off `stmt_pool`. C7 removed the last sub-shaped AST-registration
-adapter: `preregister_top_level_subs` now installs a forward-declared sub through
+**Current progress: 21/53 slices merged (C6, C7, and C8 complete, 2026-08-07). Phase C is now
+fully checked; the next open box is D1 (class structural operations, Phase D). C8 migrated
+`RegisterProtoSub`/`RegisterProtoToken` onto `RegisterDecl` and made a non-trivial proto body
+compile its `{*}`-rewritten dispatch once, at declaration time, instead of on every call; see
+`news/2026-08/c8-proto-declarations-compiled-plans.md`. C7 removed the last sub-shaped
+AST-registration adapter: `preregister_top_level_subs` now installs a forward-declared sub through
 `register_compiled_sub_decl` with an eagerly OTF-compiled routine instead of leaving `compiled`
 unset for the first call to fill in; see
 `news/2026-08/c7-forward-declaration-preregistration-compiles-eagerly.md`. C6's last sub-box,
@@ -324,12 +327,20 @@ dependency is complete, but cleanup slices stay last so each intermediate `main`
   `register_compiled_sub_decl` with an eagerly OTF-compiled routine, which let three functions with
   no other caller — `register_sub_decl`, `register_sub_decl_fp`, `register_sub_decl_as_global` — be
   deleted outright. `news/2026-08/c7-forward-declaration-preregistration-compiles-eagerly.md`.
-- [ ] **C8 — Proto declarations register from typed plans.** Migrate `RegisterProtoSub` and
-  `RegisterProtoToken` off `stmt_pool`, and compile the `{*}` dispatch instead of rewriting the
-  proto's AST body per call (`rewrite_proto_dispatch_stmts` plus the `proto_def.body = rewritten`
-  reassignment in `vm_call_func_ops.rs`). Independent of C6/C7; the slice exists because
-  Decision §1's "only general declaration-registration opcode" end state is unreachable while
-  these two opcodes still index the statement pool.
+- [x] **C8 — Proto declarations register from typed plans.** Migrated `RegisterProtoSub` and
+  `RegisterProtoToken` off `stmt_pool` onto `RegisterDecl` with two new `CompiledDeclPlanRef`
+  variants: `Proto(u32)` indexing a `CompiledProtoDeclPlan` pool, and `ProtoToken(Symbol)` carrying
+  its name inline (a `proto token`/`proto rule` LTM marker has no signature, body, or trait to
+  lower). A non-trivial proto body's `{*}` is rewritten to `__PROTO_DISPATCH__()` and compiled once
+  at declaration time (through the same `compile_sub_body` ordinary subs use); the VM's
+  `vm_try_run_nontrivial_proto_body` now runs that bytecode directly instead of rewriting and
+  OTF-compiling the AST on every call, keeping the old rewrite-and-OTF-compile path only as a
+  defensive fallback for a hand-built `FunctionDef` that never went through plan registration.
+  `CompiledProtoDeclPlan` still carries `legacy_body: Vec<Stmt>` — following
+  `CompiledRoleDeclPlan`'s own precedent — because the pure-interpreter operator-fallback path
+  (`call_proto_function`) and the triviality check
+  (`vm_resolve_trivial_proto_candidate`) still need the raw body; dropping it is a later box.
+  `news/2026-08/c8-proto-declarations-compiled-plans.md`.
 
 ### Phase D — class and role plans become bytecode-native
 

--- a/news/2026-08/c8-proto-declarations-compiled-plans.md
+++ b/news/2026-08/c8-proto-declarations-compiled-plans.md
@@ -1,0 +1,39 @@
+# ADR-0019 C8: proto declarations register from typed plans
+
+C8 asked to migrate `RegisterProtoSub` and `RegisterProtoToken` off the
+generic `stmt_pool`, and to compile the `{*}` dispatch instead of rewriting
+the proto's AST body on every call. Both opcodes were removed outright: a
+`proto sub`/`proto method` now lowers to a typed `CompiledProtoDeclPlan`
+(mirroring `CompiledSubDeclPlan`/`CompiledRoleDeclPlan`) and a `proto
+token`/`proto rule` LTM marker lowers to a `CompiledDeclPlanRef::ProtoToken`
+carrying just its name inline — both register through the same `RegisterDecl`
+opcode sub/class/role declarations already use, so proto declarations now
+also benefit from the conservative env-sync gate and `has_inner_subs`
+detection that key off `RegisterDecl`, closing a latent gap where a proto
+nested inside a routine body was invisible to both.
+
+The compile-time half: a non-trivial proto body (anything beyond an empty
+body or a bare `{*}`) has its `{*}` placeholder rewritten to a
+`__PROTO_DISPATCH__()` call once, at declaration compile time, then compiled
+through the same `compile_sub_body` ordinary subs use. The VM's
+`vm_try_run_nontrivial_proto_body` now runs that pre-compiled bytecode
+directly when the resolved proto carries it, instead of re-rewriting and
+OTF-compiling the AST on every call — the OTF-compile-and-cache path stays
+only as a defensive fallback for a hand-built `FunctionDef` that never went
+through plan registration.
+
+Following `CompiledRoleDeclPlan`'s own precedent (which still carries
+`legacy_body`), `CompiledProtoDeclPlan` keeps a `legacy_body: Vec<Stmt>` field
+for now: a registered proto's `FunctionDef` still needs its raw body for the
+pure-interpreter fallback reached from the user-operator dispatch path
+(`call_proto_function`, `builtins_operators_fallback.rs`) and for judging
+triviality (`vm_resolve_trivial_proto_candidate`). Dropping it is a later
+box, matching how C6's own `legacy_body` removal was split out from C1-C5.
+
+Pinned by two new compiler unit tests
+(`nontrivial_proto_declarations_compile_their_dispatch_body`,
+`trivial_proto_declarations_compile_no_dispatch_body`) plus the full existing
+proto/multi test surface (`t/proto-*.t`, `t/our-proto-*.t`,
+`t/multi-signature-alternates.t`, and the whitelisted
+`roast/S05-grammar/proto*.t` / `roast/S06-multi/*.t` / `roast/S12-methods/multi.t`
+files). Full `t/` (27,761 tests) and the roast whitelist pass unchanged.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -121,6 +121,60 @@ mod declaration_plan_tests {
                 )
         )));
     }
+
+    /// ADR-0019 C8: a non-trivial proto body compiles its `{*}`-rewritten
+    /// dispatch once, at declaration time, instead of leaving the VM to
+    /// rewrite and OTF-compile the AST on every call.
+    #[test]
+    fn nontrivial_proto_declarations_compile_their_dispatch_body() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            "proto sub f($x) { say 'before'; {*} }; multi sub f(Int $x) { $x }; f(1)",
+        )
+        .expect("source parses");
+        let (code, compiled_fns) = Compiler::new().compile(&stmts);
+
+        assert!(!code.proto_decl_plans.is_empty());
+        let plan = code
+            .proto_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "f")
+            .expect("proto f declaration plan");
+        let key = plan
+            .compiled_routine_key
+            .expect("non-trivial proto body must compile a routine");
+        assert!(compiled_fns.contains_key(&key));
+        assert!(
+            code.stmt_pool
+                .iter()
+                .all(|stmt| !matches!(stmt, crate::ast::Stmt::ProtoDecl { .. })),
+            "compiled proto declarations must not remain executable generic statements"
+        );
+        assert!(code.ops.iter().any(|op| matches!(
+            op,
+            crate::opcode::OpCode::RegisterDecl(idx)
+                if matches!(
+                    code.decl_plans.get(*idx as usize),
+                    Some(crate::opcode::CompiledDeclPlanRef::Proto(_))
+                )
+        )));
+    }
+
+    /// A trivial proto (`{*}` only) dispatches implicitly and has no
+    /// candidate body of its own to compile.
+    #[test]
+    fn trivial_proto_declarations_compile_no_dispatch_body() {
+        let (stmts, _) =
+            crate::parse_dispatch::parse_source("proto sub g($x) {*}; multi sub g(Int $x) { $x }")
+                .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan = code
+            .proto_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "g")
+            .expect("proto g declaration plan");
+        assert!(plan.compiled_routine_key.is_none());
+    }
 }
 mod const_fold;
 mod decl_plan;

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3325,16 +3325,45 @@ impl Compiler {
                 params,
                 param_defs,
                 body,
+                is_method,
                 ..
             } => {
-                let _ = (params.len(), param_defs.len(), body.len());
                 self.note_operator_decl(&name.resolve());
-                let idx = self.code.add_stmt(stmt.clone());
-                self.code.emit(OpCode::RegisterProtoSub(idx));
+                let idx = self.code.add_proto_decl_plan(stmt);
+                // A trivial proto body (empty, or a bare `{*}`) dispatches
+                // implicitly and has no candidate body of its own to compile
+                // (mirrors `vm_resolve_trivial_proto_candidate`'s gate). A
+                // `proto method`/`proto submethod` never installs at the
+                // package level (Phase D territory) and compiles no body here
+                // either — see `CompiledProtoDeclPlan::is_method`.
+                let significant: Vec<&Stmt> = body
+                    .iter()
+                    .filter(|s| !matches!(s, Stmt::SetLine(_)))
+                    .collect();
+                let trivial = significant.is_empty()
+                    || (significant.len() == 1
+                        && matches!(significant[0], Stmt::Expr(Expr::Whatever)));
+                if !*is_method && !trivial {
+                    let rewritten = crate::runtime::Interpreter::rewrite_proto_dispatch_stmts(body);
+                    let compiled_routine_key = self.compile_sub_body(
+                        &name.resolve(),
+                        params,
+                        param_defs,
+                        None,
+                        &rewritten,
+                        false,
+                        None,
+                        false,
+                        false,
+                    );
+                    self.code
+                        .set_proto_decl_compiled_routine_key(idx, compiled_routine_key);
+                }
+                self.code.emit(OpCode::RegisterDecl(idx));
             }
-            Stmt::ProtoToken { .. } => {
-                let idx = self.code.add_stmt(stmt.clone());
-                self.code.emit(OpCode::RegisterProtoToken(idx));
+            Stmt::ProtoToken { name } => {
+                let idx = self.code.add_proto_token_decl_plan(*name);
+                self.code.emit(OpCode::RegisterDecl(idx));
             }
             Stmt::Use { module, arg, .. } if module == "lib" && arg.is_some() => {
                 if let Some(expr) = arg {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1586,8 +1586,6 @@ pub(crate) enum OpCode {
     ReturnFromNonRoutine(bool),
     RegisterDecl(u32),
     RegisterToken(u32),
-    RegisterProtoSub(u32),
-    RegisterProtoToken(u32),
     RegisterEnum(u32),
     AugmentClass(u32),
     RegisterSubset(u32),
@@ -2235,11 +2233,47 @@ pub(crate) struct CompiledRoleDeclPlan {
     pub(crate) custom_traits: Vec<(String, Option<DeclTraitArg>)>,
 }
 
+/// A package-level `proto sub`/`proto rule`/`proto token` declaration lowered
+/// at compile time (ADR-0019 C8). The `{*}` placeholder in a non-trivial body
+/// is rewritten to a `__PROTO_DISPATCH__()` call and compiled once, here,
+/// instead of being rewritten and OTF-compiled on every call.
+#[derive(Debug, Clone)]
+pub(crate) struct CompiledProtoDeclPlan {
+    pub(crate) name: Symbol,
+    pub(crate) params: Vec<String>,
+    pub(crate) param_defs: Vec<ParamDef>,
+    pub(crate) is_export: bool,
+    pub(crate) custom_traits: Vec<String>,
+    /// True for `proto method`/`proto submethod`: such a proto never
+    /// registers at the package level (its `{*}` dispatches over the type's
+    /// method table, Phase D territory), so `compiled_routine_key` is always
+    /// `None` for it.
+    pub(crate) is_method: bool,
+    pub(crate) is_our: bool,
+    /// Compatibility payload, mirroring `CompiledRoleDeclPlan::legacy_body`:
+    /// a registered `FunctionDef` still needs the raw (un-rewritten) body for
+    /// the pure-interpreter fallback (`call_proto_function`, reached from the
+    /// user-operator dispatch fallback) and for judging triviality
+    /// (`vm_resolve_trivial_proto_candidate`). Dropping it is a later box,
+    /// not this one.
+    pub(crate) legacy_body: Vec<Stmt>,
+    /// Stable key of the bytecode compiled for the `{*}`-rewritten body.
+    /// `None` for a trivial proto (an empty body, or a body that is just a
+    /// bare `{*}`), which dispatches implicitly and has no candidate body of
+    /// its own to compile, and for a method proto (`is_method`).
+    pub(crate) compiled_routine_key: Option<Symbol>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompiledDeclPlanRef {
     Sub(u32),
     Class(u32),
     Role(u32),
+    Proto(u32),
+    /// A `proto token`/`proto rule` LTM marker (`Stmt::ProtoToken`), which
+    /// carries only a name — no signature, body, or traits — so the name is
+    /// stored inline rather than indexing a pool of its own.
+    ProtoToken(Symbol),
 }
 
 #[derive(Debug, Clone)]
@@ -2267,6 +2301,7 @@ pub(crate) struct CompiledCode {
     pub(crate) sub_decl_plans: Vec<CompiledSubDeclPlan>,
     pub(crate) class_decl_plans: Vec<CompiledClassDeclPlan>,
     pub(crate) role_decl_plans: Vec<CompiledRoleDeclPlan>,
+    pub(crate) proto_decl_plans: Vec<CompiledProtoDeclPlan>,
     /// The single declaration-registration operand pool. `RegisterDecl(i)` selects one tagged
     /// typed plan here; declaration-specific metadata stays out of the hot opcode enum.
     pub(crate) decl_plans: Vec<CompiledDeclPlanRef>,
@@ -2872,6 +2907,13 @@ impl CompiledCode {
                 }
             }
         }
+        for plan in &mut self.proto_decl_plans {
+            if let Some(key) = &mut plan.compiled_routine_key
+                && let Some(remapped) = remap.get(key)
+            {
+                *key = *remapped;
+            }
+        }
         for nested in &mut self.closure_compiled_codes {
             Arc::make_mut(nested).remap_sub_decl_compiled_routine_keys(remap);
         }
@@ -2980,6 +3022,7 @@ impl CompiledCode {
             sub_decl_plans: Vec::new(),
             class_decl_plans: Vec::new(),
             role_decl_plans: Vec::new(),
+            proto_decl_plans: Vec::new(),
             decl_plans: Vec::new(),
             locals: Vec::new(),
             locals_sym: Vec::new(),
@@ -5277,6 +5320,63 @@ impl CompiledCode {
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Sub(plan_idx));
         idx
+    }
+
+    /// Record a `proto sub`/`proto method` declaration plan (ADR-0019 C8).
+    /// `compiled_routine_key` starts `None`; the caller compiles the
+    /// `{*}`-rewritten body separately (mirroring `add_sub_decl_plan` +
+    /// `set_sub_decl_compiled_routine_keys`) and attaches it with
+    /// [`Self::set_proto_decl_compiled_routine_key`].
+    pub(crate) fn add_proto_decl_plan(&mut self, stmt: &Stmt) -> u32 {
+        let Stmt::ProtoDecl {
+            name,
+            params,
+            param_defs,
+            body,
+            is_export,
+            custom_traits,
+            is_method,
+            is_our,
+        } = stmt
+        else {
+            panic!("add_proto_decl_plan expects ProtoDecl");
+        };
+        let plan_idx = self.proto_decl_plans.len() as u32;
+        self.proto_decl_plans.push(CompiledProtoDeclPlan {
+            name: *name,
+            params: params.clone(),
+            param_defs: param_defs.clone(),
+            is_export: *is_export,
+            custom_traits: custom_traits.clone(),
+            is_method: *is_method,
+            is_our: *is_our,
+            legacy_body: body.clone(),
+            compiled_routine_key: None,
+        });
+        let idx = self.decl_plans.len() as u32;
+        self.decl_plans.push(CompiledDeclPlanRef::Proto(plan_idx));
+        idx
+    }
+
+    /// Record a `proto token`/`proto rule` LTM marker (ADR-0019 C8). Unlike
+    /// `add_proto_decl_plan`, there is no signature, body, or trait to lower —
+    /// `Stmt::ProtoToken` carries only a name.
+    pub(crate) fn add_proto_token_decl_plan(&mut self, name: Symbol) -> u32 {
+        let idx = self.decl_plans.len() as u32;
+        self.decl_plans.push(CompiledDeclPlanRef::ProtoToken(name));
+        idx
+    }
+
+    pub(crate) fn set_proto_decl_compiled_routine_key(
+        &mut self,
+        decl_idx: u32,
+        key: Option<Symbol>,
+    ) {
+        let Some(CompiledDeclPlanRef::Proto(plan_idx)) = self.decl_plans.get(decl_idx as usize)
+        else {
+            panic!("declaration plan is not a proto");
+        };
+        self.proto_decl_plans[*plan_idx as usize].compiled_routine_key = key;
     }
 
     /// The declaration-site fingerprint recorded for a sub plan, absent when the

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1540,6 +1540,7 @@ impl Interpreter {
         self.insert_token_def(name, def, multi);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn register_proto_decl(
         &mut self,
         name: &str,
@@ -1547,6 +1548,7 @@ impl Interpreter {
         param_defs: &[ParamDef],
         body: &[Stmt],
         is_our: bool,
+        compiled: Option<&crate::opcode::CompiledFunction>,
     ) -> Result<(), RuntimeError> {
         let key = format!("{}::{}", self.current_package(), name);
         // `our proto sub f(|) {*}` makes the whole multi a package symbol. Its
@@ -1606,7 +1608,7 @@ impl Interpreter {
                 deprecated_message: None,
                 source_file: self.current_source_file(),
                 decl_order: crate::runtime::resolution::next_decl_order(),
-                compiled: None,
+                compiled: compiled.cloned().map(std::sync::Arc::new),
                 body_fp_cache: std::sync::OnceLock::new(),
                 body_facts_cache: std::sync::OnceLock::new(),
                 rw_tail_expr: None,
@@ -1622,6 +1624,7 @@ impl Interpreter {
         params: &[String],
         param_defs: &[ParamDef],
         body: &[Stmt],
+        compiled: Option<&crate::opcode::CompiledFunction>,
     ) -> Result<(), RuntimeError> {
         let key = format!("GLOBAL::{}", name);
         if self
@@ -1668,7 +1671,7 @@ impl Interpreter {
                 deprecated_message: None,
                 source_file: self.current_source_file(),
                 decl_order: crate::runtime::resolution::next_decl_order(),
-                compiled: None,
+                compiled: compiled.cloned().map(std::sync::Arc::new),
                 body_fp_cache: std::sync::OnceLock::new(),
                 body_facts_cache: std::sync::OnceLock::new(),
                 rw_tail_expr: None,

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1638,35 +1638,47 @@ impl Interpreter {
         if !proto.param_defs.is_empty() && !self.method_args_match(&args, &proto.param_defs) {
             return None;
         }
-        // Rewrite `{*}` -> `__PROTO_DISPATCH__()` and require the resulting body +
-        // the proto's own signature to be OTF-compilable. `state` in the proto body
-        // (the caching-proto pattern `proto cached($a) { state %cache; ... {*} }`) is
-        // NOT excluded for a single-signature proto: `otf_compile_function_def`
-        // caches the compiled proto body by fingerprint+package, so its `state` key
-        // (which embeds the compiled opcode position) is stable across calls, and the
-        // proto's `/n`-suffixed package keeps it distinct from any candidate's own
-        // `state`. The persisted state cell therefore survives call-to-call exactly
-        // as the interpreter's does. A proto declared with signature *alternates*
-        // shares one `state` cell across them; registration hands every alternate
-        // the plan's `state_group`-scoped bytecode, so that sharing survives here
-        // too (`t/multi-signature-alternates.t`).
-        let rewritten = crate::runtime::Interpreter::rewrite_proto_dispatch_stmts(&proto.body);
-        let mut proto_def = proto.clone();
-        proto_def.body = rewritten;
-        // The clone carried the ORIGINAL body's memoized identity; the rewrite
-        // gave this def a different body, so drop it.
-        proto_def.invalidate_body_fingerprint();
-        if !Self::def_is_otf_compilable(&proto_def) {
-            return None;
-        }
-        // Compile the proto body and run it like a routine. `{*}` redispatch reads
-        // the args from `proto_dispatch_stack` (the ORIGINAL proto args, matching
-        // the interpreter's `call_proto_function`), so push that before the body
-        // runs and pop after. No multi-dispatch frame is pushed for the proto body
-        // itself — it is the dispatcher, not a candidate; the candidate's own
-        // `nextsame` frame is set up by the proto-dispatch handler when `{*}` runs.
-        let cf = self.otf_compile_function_def(&proto_def);
-        let pkg = proto_def.package.resolve();
+        // ADR-0019 C8: a plan-derived proto already carries the bytecode for
+        // its `{*}`-rewritten body, compiled once at declaration time — run
+        // it directly instead of rewriting and OTF-compiling the AST on
+        // every call. `state` in the proto body (the caching-proto pattern
+        // `proto cached($a) { state %cache; ... {*} }`) is safe here: the
+        // compiled routine is one fixed bytecode object shared by every call
+        // (not re-derived per call), so its `state` cell's identity — keyed
+        // by compiled opcode position — is as stable as any ordinary
+        // routine's. A proto declared with signature *alternates* shares one
+        // `state` cell across them the same way an ordinary multi does
+        // (`t/multi-signature-alternates.t`).
+        let (cf, pkg) = if let Some(compiled) = proto.compiled.clone() {
+            (compiled, proto.package.resolve())
+        } else {
+            // Fallback for a proto with no plan-compiled body — defensive; every
+            // non-trivial package proto sub is plan-derived once C8 is complete,
+            // but this keeps the OTF-compile path available for any def built
+            // outside declaration-plan registration (e.g. a hand-built
+            // `FunctionDef`). Rewrite `{*}` -> `__PROTO_DISPATCH__()` and
+            // require the resulting body + the proto's own signature to be
+            // OTF-compilable.
+            let rewritten = crate::runtime::Interpreter::rewrite_proto_dispatch_stmts(&proto.body);
+            let mut proto_def = proto.clone();
+            proto_def.body = rewritten;
+            // The clone carried the ORIGINAL body's memoized identity; the rewrite
+            // gave this def a different body, so drop it.
+            proto_def.invalidate_body_fingerprint();
+            if !Self::def_is_otf_compilable(&proto_def) {
+                return None;
+            }
+            let cf = self.otf_compile_function_def(&proto_def);
+            let pkg = proto_def.package.resolve();
+            (cf, pkg)
+        };
+        // `{*}` redispatch reads the args from `proto_dispatch_stack` (the
+        // ORIGINAL proto args, matching the interpreter's
+        // `call_proto_function`), so push that before the body runs and pop
+        // after. No multi-dispatch frame is pushed for the proto body itself
+        // — it is the dispatcher, not a candidate; the candidate's own
+        // `nextsame` frame is set up by the proto-dispatch handler when `{*}`
+        // runs.
         self.push_proto_dispatch_frame(name.to_string(), args.clone());
         // Prefer the proto body's own nested-sub table over the caller's
         // (ADR-0019 C6e-3c, mirrors `call_shared_state_body`): a proto body

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4453,16 +4453,6 @@ impl Interpreter {
                 self.exec_register_token_op(code, *idx)?;
                 *ip += 1;
             }
-            OpCode::RegisterProtoSub(idx) => {
-                self.sync_source_line(code, *ip);
-                self.exec_register_proto_sub_op(code, *idx)?;
-                *ip += 1;
-            }
-            OpCode::RegisterProtoToken(idx) => {
-                self.sync_source_line(code, *ip);
-                self.exec_register_proto_token_op(code, *idx)?;
-                *ip += 1;
-            }
             OpCode::UseModule {
                 name_idx,
                 tags_idx,

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -899,98 +899,84 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         idx: u32,
+        compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
-        let stmt = &code.stmt_pool[idx as usize];
-        if let Stmt::ProtoDecl {
+        let crate::opcode::CompiledProtoDeclPlan {
             name,
             params,
             param_defs,
-            body,
             is_export,
             custom_traits,
             is_method,
             is_our,
-            ..
-        } = stmt
-        {
-            let name_str = name.resolve();
-            // A `proto method`/`proto submethod` (`is_method`) is a *method*-level
-            // proto: its `{*}` dispatches over the type's multi-method candidates
-            // via the class method table, not the package-level proto-sub table.
-            // Registering it as a package proto sub is not only unnecessary but
-            // breaks role composition: the role body's `RegisterProtoSub` runs once
-            // when the role is declared and again when a class does the role, so the
-            // second registration hits the already-present `GLOBAL::<name>` proto and
-            // wrongly raises `X::Redeclaration` (lizmat's `Enumify` proto+multi
-            // pattern, SBOM::CycloneDX). Skip the package-level registration for
-            // method protos; the method-table path already handles them.
-            if !*is_method {
-                self.register_proto_decl(&name_str, params, param_defs, body, *is_our)?;
+            legacy_body: body,
+            compiled_routine_key,
+        } = &code.proto_decl_plans[idx as usize];
+        let name_str = name.resolve();
+        // The plan-compiled bytecode for the `{*}`-rewritten body (ADR-0019
+        // C8), `None` for a trivial proto or a method proto — see
+        // `CompiledProtoDeclPlan::compiled_routine_key`.
+        let compiled = compiled_routine_key.and_then(|key| compiled_fns.get(&key));
+        // A `proto method`/`proto submethod` (`is_method`) is a *method*-level
+        // proto: its `{*}` dispatches over the type's multi-method candidates
+        // via the class method table, not the package-level proto-sub table.
+        // Registering it as a package proto sub is not only unnecessary but
+        // breaks role composition: the role body's `RegisterDecl` runs once
+        // when the role is declared and again when a class does the role, so the
+        // second registration hits the already-present `GLOBAL::<name>` proto and
+        // wrongly raises `X::Redeclaration` (lizmat's `Enumify` proto+multi
+        // pattern, SBOM::CycloneDX). Skip the package-level registration for
+        // method protos; the method-table path already handles them.
+        if !*is_method {
+            self.register_proto_decl(&name_str, params, param_defs, body, *is_our, compiled)?;
+        }
+        if *is_export {
+            self.register_proto_decl_as_global(&name_str, params, param_defs, body, compiled)?;
+            // Record the export so consumers/MAIN-dispatch see the whole multi
+            // family. A `proto … is export` exports its candidates too (raku),
+            // e.g. zef's `proto MAIN(|) is export` over `multi sub MAIN(…)`.
+            if !self.suppress_exports {
+                let pkg = self.current_package().to_string();
+                self.register_exported_sub(pkg, name_str.clone(), Vec::new());
             }
-            if *is_export {
-                self.register_proto_decl_as_global(&name_str, params, param_defs, body)?;
-                // Record the export so consumers/MAIN-dispatch see the whole multi
-                // family. A `proto … is export` exports its candidates too (raku),
-                // e.g. zef's `proto MAIN(|) is export` over `multi sub MAIN(…)`.
-                if !self.suppress_exports {
-                    let pkg = self.current_package().to_string();
-                    self.register_exported_sub(pkg, name_str.clone(), Vec::new());
+        }
+        // Apply custom trait_mod:<is> for each non-builtin trait (only if defined)
+        if !custom_traits.is_empty() {
+            let has_trait_mod =
+                self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>");
+            for trait_name in custom_traits.iter().filter(|t| {
+                !t.starts_with("__")
+                    && *t != "default"
+                    && !t.starts_with("DEPRECATED")
+                    && *t != "deep"
+            }) {
+                if !has_trait_mod {
+                    return Err(RuntimeError::new(format!(
+                        "Can't use unknown trait 'is' -> '{}' in sub declaration.",
+                        trait_name
+                    )));
+                }
+                let sub_val = Value::make_sub(
+                    Symbol::intern(&self.current_package()),
+                    Symbol::intern(&name_str),
+                    params.clone(),
+                    param_defs.clone(),
+                    body.clone(),
+                    false,
+                    self.clone_env(),
+                );
+                let named_arg = Value::pair(trait_name.clone(), Value::TRUE);
+                let result = loan_env!(
+                    self,
+                    call_function("trait_mod:<is>", vec![sub_val, named_arg])
+                )?;
+                // If the trait_mod returned a modified sub (e.g. with CALL-ME mixed in),
+                // store it in the env so function dispatch can find it.
+                if matches!(result.view(), ValueView::Mixin(..)) {
+                    self.env_mut().insert(format!("&{}", name), result);
                 }
             }
-            // Apply custom trait_mod:<is> for each non-builtin trait (only if defined)
-            if !custom_traits.is_empty() {
-                let has_trait_mod =
-                    self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>");
-                for trait_name in custom_traits.iter().filter(|t| {
-                    !t.starts_with("__")
-                        && *t != "default"
-                        && !t.starts_with("DEPRECATED")
-                        && *t != "deep"
-                }) {
-                    if !has_trait_mod {
-                        return Err(RuntimeError::new(format!(
-                            "Can't use unknown trait 'is' -> '{}' in sub declaration.",
-                            trait_name
-                        )));
-                    }
-                    let sub_val = Value::make_sub(
-                        Symbol::intern(&self.current_package()),
-                        Symbol::intern(&name_str),
-                        params.clone(),
-                        param_defs.clone(),
-                        body.clone(),
-                        false,
-                        self.clone_env(),
-                    );
-                    let named_arg = Value::pair(trait_name.clone(), Value::TRUE);
-                    let result = loan_env!(
-                        self,
-                        call_function("trait_mod:<is>", vec![sub_val, named_arg])
-                    )?;
-                    // If the trait_mod returned a modified sub (e.g. with CALL-ME mixed in),
-                    // store it in the env so function dispatch can find it.
-                    if matches!(result.view(), ValueView::Mixin(..)) {
-                        self.env_mut().insert(format!("&{}", name), result);
-                    }
-                }
-            }
-            Ok(())
-        } else {
-            Err(RuntimeError::new("RegisterProtoSub expects ProtoDecl"))
         }
-    }
-
-    pub(super) fn exec_register_proto_token_op(
-        &mut self,
-        code: &CompiledCode,
-        idx: u32,
-    ) -> Result<(), RuntimeError> {
-        let stmt = &code.stmt_pool[idx as usize];
-        if let Stmt::ProtoToken { name } = stmt {
-            self.register_proto_token_decl(&name.resolve());
-            Ok(())
-        } else {
-            Err(RuntimeError::new("RegisterProtoToken expects ProtoToken"))
-        }
+        Ok(())
     }
 }

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -43,6 +43,13 @@ impl Interpreter {
                     Err(error) => Err(error),
                 }
             }
+            Some(crate::opcode::CompiledDeclPlanRef::Proto(plan_idx)) => {
+                self.exec_register_proto_sub_op(code, plan_idx, compiled_fns)
+            }
+            Some(crate::opcode::CompiledDeclPlanRef::ProtoToken(name)) => {
+                self.register_proto_token_decl(&name.resolve());
+                Ok(())
+            }
             None => Err(RuntimeError::new("RegisterDecl plan index out of bounds")),
         }
     }


### PR DESCRIPTION
## Summary
- `RegisterProtoSub`/`RegisterProtoToken` were the last two declaration-registration opcodes indexing the generic `stmt_pool` instead of `RegisterDecl`. Both are removed: a `proto sub`/`proto method` now lowers to a typed `CompiledProtoDeclPlan` (mirroring `CompiledSubDeclPlan`/`CompiledRoleDeclPlan`), and a `proto token`/`proto rule` LTM marker lowers to `CompiledDeclPlanRef::ProtoToken` carrying its name inline. Both register through `RegisterDecl`.
- A non-trivial proto body's `{*}` is rewritten to `__PROTO_DISPATCH__()` and compiled **once, at declaration time** (same `compile_sub_body` ordinary subs use), instead of being rewritten and OTF-compiled on every call. `vm_try_run_nontrivial_proto_body` now runs the pre-compiled bytecode directly when available; the old rewrite+OTF-compile path stays only as a defensive fallback for a hand-built `FunctionDef` that never went through plan registration.
- `CompiledProtoDeclPlan` keeps a `legacy_body` field for now, mirroring `CompiledRoleDeclPlan`'s own current state — the pure-interpreter operator-fallback path (`call_proto_function`) and the triviality check (`vm_resolve_trivial_proto_candidate`) still need the raw body. Dropping it is a later box, same as how C6's `legacy_body` removal was split out from C1-C5.
- Phase C of ADR-0019 is now fully checked (C1-C8); next open box is D1.

## Test plan
- [x] `cargo test --lib` (669 passed, incl. 2 new compiler unit tests pinning proto plan compilation)
- [x] `prove -j4 -e target/debug/mutsu t/` (27,761 tests, all pass)
- [x] Full `t/proto*.t`, `t/our-proto*.t`, `t/multi-signature-alternates.t`, `t/nontrivial-proto-body-nested-sub-compiled.t` (131 tests)
- [x] Whitelisted roast: `S05-grammar/protoregex.t`, `S05-grammar/protos.t`, `S05-metasyntax/proto-token-ltm.t`, all of `S06-multi/*.t`, `S12-methods/multi.t`, `S12-subset/multi-dispatch.t`, `S11-modules/import-multi.t` — under both debug and release builds
- [x] `cargo fmt` / `cargo clippy -- -D warnings`
- [x] Manual smoke: proto+state caching, proto nested inside a sub reading an outer lexical, `our proto ... is export` across a module import, grammar `proto token` LTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)