### PR TITLE
feat(runtime,compiler): class declarations precompute stub/trusts as plan data (ADR-0019 D1)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,11 +115,14 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 21/53 slices merged (C6, C7, and C8 complete, 2026-08-07). Phase C is now
-fully checked; the next open box is D1 (class structural operations, Phase D). C8 migrated
-`RegisterProtoSub`/`RegisterProtoToken` onto `RegisterDecl` and made a non-trivial proto body
-compile its `{*}`-rewritten dispatch once, at declaration time, instead of on every call; see
-`news/2026-08/c8-proto-declarations-compiled-plans.md`. C7 removed the last sub-shaped
+**Current progress: 22/53 slices merged (C6, C7, C8, and D1 complete, 2026-08-07). Phase C is
+fully checked; the next open box is D2 (attributes and generated accessors). D1 found most class
+structural data already typed-plan-driven from Phase A3/A4; the two remaining body-scanning reads
+(stub detection, `Stmt::TrustsDecl`) are now precomputed at plan lowering as
+`CompiledClassDeclPlan::is_stub`/`trusts`; see `news/2026-08/d1-class-structural-plan-fields.md`.
+C8 migrated `RegisterProtoSub`/`RegisterProtoToken` onto `RegisterDecl` and made a non-trivial
+proto body compile its `{*}`-rewritten dispatch once, at declaration time, instead of on every
+call; see `news/2026-08/c8-proto-declarations-compiled-plans.md`. C7 removed the last sub-shaped
 AST-registration adapter: `preregister_top_level_subs` now installs a forward-declared sub through
 `register_compiled_sub_decl` with an eagerly OTF-compiled routine instead of leaving `compiled`
 unset for the first call to fill in; see
@@ -362,8 +365,13 @@ walkers wholesale is not possible before then.
   `news/2026-08/class-role-walkers-split-into-phases.md`. Phase D also inherits
   `types/roles.rs:run_role_submethod` from C6d-3 (a `MethodDef` body-execution site, dead
   across the suite).
-- [ ] **D1 — Encode class structural operations.** Put package open/reopen, parent edges, repr,
-  visibility, lexical/package aliases, and source-order metadata in immutable plan operations.
+- [x] **D1 — Encode class structural operations.** Package open/reopen, parent edges, repr,
+  visibility, and lexical/package aliases were already typed-plan-driven from Phase A3/A4
+  (`exec_register_class_op` reads them straight off `CompiledClassDeclPlan`). The two remaining
+  body-scanning reads — yada-stub detection (duplicated across `check_class_role_redeclaration` and
+  the now-deleted `class_body_is_stub`) and the `Stmt::TrustsDecl` scan in `publish_class_shell` —
+  are precomputed at plan lowering as `CompiledClassDeclPlan::is_stub`/`trusts`, threaded through
+  `ClassDeclModifiers`. `news/2026-08/d1-class-structural-plan-fields.md`.
 - [ ] **D2 — Encode attributes and generated accessors.** Compile defaults/constraints as child
   chunks and publish generated methods through the canonical table.
 - [ ] **D3 — Encode class methods and submethods as compiled candidates.** Install ordinary, multi,

--- a/news/2026-08/d1-class-structural-plan-fields.md
+++ b/news/2026-08/d1-class-structural-plan-fields.md
@@ -1,0 +1,35 @@
+# ADR-0019 D1: class declarations precompute stub and trusts as plan data
+
+D1 asked to put package open/reopen, parent edges, repr, visibility,
+lexical/package aliases, and source-order metadata into `CompiledClassDeclPlan`
+operations. Most of that was already typed-plan-driven: `exec_register_class_op`
+already reads `parents`, `repr`, `is_hidden`/`is_lexical`, and `hidden_parents`/
+`does_parents` straight off the plan (from Phase A3/A4), and package
+qualification, lexical-site mangling, and EXPORTHOW dispatch already operate on
+those typed fields rather than walking `Stmt::ClassDecl`.
+
+The two remaining structural reads against `legacy_body` were both simple
+body scans, and both scanned the *same* body twice in different shapes:
+`check_class_role_redeclaration` and `class_body_is_stub` independently
+re-derived "is this a yada-stub class body" (`class Foo { ... }`), and
+`publish_class_shell` walked the body's top level for `Stmt::TrustsDecl` on
+every registration. Both move to the compiler: `CompiledClassDeclPlan` gains
+`is_stub: bool` (reusing the same `is_stub_routine_body` free function
+`CompiledRoutineMetadata` already uses for subs) and `trusts: Vec<Symbol>`
+(collected once at plan lowering), threaded through `ClassDeclModifiers` to
+`register_class_decl`. `class_body_is_stub` is deleted outright —
+`check_class_role_redeclaration` now takes the precomputed bool directly, and
+`publish_class_shell` takes `&[Symbol]` instead of the body.
+
+The two callers that build a `ClassDeclModifiers` without a compiled plan
+(role-pun registration in `registration_class_augment.rs` and the runtime
+mixin-class synthesis in `types/role_mixin_class.rs`) both already pass an
+empty body, so they simply supply `is_stub: false, trusts: &[]` — no body to
+scan either way.
+
+Pinned by a new compiler unit test
+(`class_declarations_precompute_stub_and_trusts`) plus the existing structural
+test surface (`t/class-*.t`, `t/lexical-class-identity.t`,
+`t/exporthow-class-aspects.t`, the native-repr tests, and the whitelisted
+`roast/S12-class/*.t`, `roast/6.c/S12-class/mro-6c.t`). Full `t/`
+(27,761 tests) and the roast whitelist pass unchanged.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -175,6 +175,37 @@ mod declaration_plan_tests {
             .expect("proto g declaration plan");
         assert!(plan.compiled_routine_key.is_none());
     }
+
+    /// ADR-0019 D1: a class declaration's stub-ness and `trusts` targets are
+    /// precomputed at plan lowering, so registration never re-walks the body
+    /// to judge them (`check_class_role_redeclaration`, `publish_class_shell`).
+    #[test]
+    fn class_declarations_precompute_stub_and_trusts() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            "class A { trusts B; has $.x }; class B { }; class Stub { ... }",
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_a = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "A")
+            .expect("class A declaration plan");
+        assert!(!plan_a.is_stub);
+        assert_eq!(
+            plan_a.trusts.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            vec!["B"]
+        );
+
+        let plan_stub = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "Stub")
+            .expect("class Stub declaration plan");
+        assert!(plan_stub.is_stub);
+        assert!(plan_stub.trusts.is_empty());
+    }
 }
 mod const_fold;
 mod decl_plan;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2217,6 +2217,14 @@ pub(crate) struct CompiledClassDeclPlan {
     pub(crate) language_version: String,
     pub(crate) custom_traits: Vec<(String, Option<DeclTraitArg>)>,
     pub(crate) decl_id: u64,
+    /// Whether the declared body is a yada stub (ADR-0019 D1). Precomputed at
+    /// plan lowering so registration never re-walks `legacy_body` to judge
+    /// this — mirrors `CompiledRoutineMetadata::is_stub` for subs.
+    pub(crate) is_stub: bool,
+    /// `trusts SomeClass` declarations at the top level of the body,
+    /// precomputed at plan lowering (ADR-0019 D1) instead of scanning
+    /// `legacy_body` for `Stmt::TrustsDecl` at registration time.
+    pub(crate) trusts: Vec<Symbol>,
 }
 
 #[derive(Debug, Clone)]
@@ -5424,6 +5432,14 @@ impl CompiledCode {
         };
         debug_assert_eq!(name_chunk.is_some(), name_expr.is_some());
         let plan_traits = zip_decl_trait_args(custom_traits, trait_args);
+        let is_stub = is_stub_routine_body(body);
+        let trusts = body
+            .iter()
+            .filter_map(|s| match s {
+                Stmt::TrustsDecl { name } => Some(*name),
+                _ => None,
+            })
+            .collect();
         let plan_idx = self.class_decl_plans.len() as u32;
         self.class_decl_plans.push(CompiledClassDeclPlan {
             name: *name,
@@ -5439,6 +5455,8 @@ impl CompiledCode {
             language_version: language_version.clone(),
             custom_traits: plan_traits,
             decl_id: *decl_id,
+            is_stub,
+            trusts,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Class(plan_idx));

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -186,6 +186,15 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// Language version of the class being declared (e.g. "6.c", "6.d", "6.e").
     /// Used to determine whether submethods from composed roles should be included.
     pub(crate) language_version: &'a str,
+    /// Whether the declared body is a yada stub (`...`, `!!!`, or `???`).
+    /// Precomputed by the compiler at plan lowering (ADR-0019 D1), so
+    /// registration never re-walks the body to judge this.
+    pub(crate) is_stub: bool,
+    /// `trusts SomeClass` declarations at the top level of the body,
+    /// precomputed by the compiler at plan lowering (ADR-0019 D1) instead of
+    /// `publish_class_shell` scanning the body for `Stmt::TrustsDecl` at
+    /// registration time.
+    pub(crate) trusts: &'a [Symbol],
 }
 
 pub(super) fn parse_role_type_args(input: &str) -> Vec<String> {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -750,6 +750,8 @@ impl Interpreter {
             hidden_parents: &[],
             does_parents: &parents,
             language_version: &language_version,
+            is_stub: false,
+            trusts: &[],
         };
         self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
         self.store_language_revision_from_version(&pun_name, &language_version);

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -123,6 +123,8 @@ impl Interpreter {
             hidden_parents,
             does_parents,
             language_version: class_language_version,
+            is_stub: is_stub_body,
+            trusts,
         } = modifiers;
         let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
@@ -149,9 +151,7 @@ impl Interpreter {
             .class_attribute_is_types
             .retain(|(cn, _), _| cn != name);
 
-        self.check_class_role_redeclaration(name, is_lexical, body)?;
-
-        let is_stub_body = Self::class_body_is_stub(body);
+        self.check_class_role_redeclaration(name, is_lexical, is_stub_body)?;
 
         // If this is a stub registration but the class already exists and is
         // NOT a stub (i.e., it was already filled in by a hoisted real
@@ -206,7 +206,7 @@ impl Interpreter {
         );
         if self.publish_class_shell(
             name,
-            body,
+            trusts,
             &class_def,
             hidden_parents,
             does_parents,

--- a/src/runtime/registration_class_validate.rs
+++ b/src/runtime/registration_class_validate.rs
@@ -75,38 +75,19 @@ impl Interpreter {
     /// Detect X::Redeclaration when a class redefines a role in the same scope.
     /// Only check user-declared roles (not pre-registered builtins like Iterator).
     /// Lexical classes (`my class`) are allowed to shadow outer role names.
+    /// `is_stub` is precomputed by the compiler at plan lowering (ADR-0019 D1,
+    /// `crate::opcode::is_stub_routine_body`) — a non-stub class body redefining
+    /// a role name is always a genuine redeclaration.
     pub(super) fn check_class_role_redeclaration(
         &self,
         name: &str,
         is_lexical: bool,
-        body: &[Stmt],
+        is_stub: bool,
     ) -> Result<(), RuntimeError> {
-        if !is_lexical && self.registry().user_declared_roles.contains(name) {
-            // Only report redeclaration for non-stub class bodies
-            let body_non_stub: Vec<_> = body
-                .iter()
-                .filter(|s| !matches!(s, Stmt::SetLine(_)))
-                .collect();
-            let class_is_stub = body_non_stub.len() == 1
-                && matches!(body_non_stub[0], Stmt::Expr(Expr::Call { name: fn_name, .. })
-                    if *fn_name == "__mutsu_stub_die" || *fn_name == "__mutsu_stub_warn");
-            if !class_is_stub {
-                return Err(RuntimeError::redeclaration("symbol", name));
-            }
+        if !is_lexical && !is_stub && self.registry().user_declared_roles.contains(name) {
+            return Err(RuntimeError::redeclaration("symbol", name));
         }
         Ok(())
-    }
-
-    /// Detect stub body: `class Foo { ... }` — body is a stub operator call
-    /// Filter SetLine annotations which don't affect the stub nature.
-    pub(super) fn class_body_is_stub(body: &[Stmt]) -> bool {
-        let body_no_setline: Vec<_> = body
-            .iter()
-            .filter(|s| !matches!(s, Stmt::SetLine(_)))
-            .collect();
-        body_no_setline.len() == 1
-            && matches!(body_no_setline[0], Stmt::Expr(Expr::Call { name: fn_name, .. })
-                if *fn_name == "__mutsu_stub_die" || *fn_name == "__mutsu_stub_warn")
     }
 
     /// Validate that all parent classes exist.
@@ -377,23 +358,18 @@ impl Interpreter {
     pub(super) fn publish_class_shell(
         &mut self,
         name: &str,
-        body: &[Stmt],
+        trusts: &[Symbol],
         class_def: &ClassDef,
         hidden_parents: &[String],
         does_parents: &[String],
         is_stub_body: bool,
     ) -> Result<bool, RuntimeError> {
-        for stmt in body {
-            if let Stmt::TrustsDecl {
-                name: trusted_class,
-            } = stmt
-            {
-                self.registry_mut()
-                    .class_trusts
-                    .entry(name.to_string())
-                    .or_default()
-                    .insert(trusted_class.resolve());
-            }
+        for trusted_class in trusts {
+            self.registry_mut()
+                .class_trusts
+                .entry(name.to_string())
+                .or_default()
+                .insert(trusted_class.resolve());
         }
         // Make the class visible while its body executes so introspection calls
         // like `A.^add_method(...)` inside the declaration can resolve `A`.

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -62,6 +62,8 @@ impl Interpreter {
             hidden_parents: &[],
             does_parents: &fresh,
             language_version: &language_version,
+            is_stub: false,
+            trusts: &[],
         };
         self.register_class_decl(&name, &parents, modifiers, &[])?;
         self.compose_mixin_role_submethods(&name, &fresh);

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -135,6 +135,8 @@ impl Interpreter {
             language_version,
             custom_traits,
             decl_id,
+            is_stub,
+            trusts,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {
@@ -244,6 +246,8 @@ impl Interpreter {
                         hidden_parents: &mapped_hidden_parents,
                         does_parents,
                         language_version,
+                        is_stub: *is_stub,
+                        trusts,
                     },
                     body,
                 )


### PR DESCRIPTION
## Summary
- D1 asked to put package open/reopen, parent edges, repr, visibility, lexical/package aliases, and source-order metadata into `CompiledClassDeclPlan` operations. Most of that was already typed-plan-driven from Phase A3/A4 — `exec_register_class_op` already reads `parents`/`repr`/`is_hidden`/`is_lexical`/`hidden_parents`/`does_parents` straight off the plan.
- The two remaining structural reads against the raw AST body were both simple scans re-derived on every registration: `check_class_role_redeclaration` and `class_body_is_stub` independently computed the same "is this a yada-stub body" judgment, and `publish_class_shell` walked the body's top level for `Stmt::TrustsDecl` every time.
- Both move to the compiler: `CompiledClassDeclPlan` gains `is_stub: bool` (reusing the same `is_stub_routine_body` free function `CompiledRoutineMetadata` already uses for subs) and `trusts: Vec<Symbol>`, computed once at plan lowering and threaded through `ClassDeclModifiers`. `class_body_is_stub` is deleted outright.
- The two callers that build a `ClassDeclModifiers` without a compiled plan (role-pun registration in `registration_class_augment.rs`, runtime mixin-class synthesis in `types/role_mixin_class.rs`) already pass an empty body, so they simply supply `is_stub: false, trusts: &[]`.
- ADR-0019 progress: 22/53 slices, next open box is D2.

## Test plan
- [x] `cargo test --lib` (670 passed, incl. a new compiler unit test `class_declarations_precompute_stub_and_trusts`)
- [x] `prove -j4 -e target/debug/mutsu t/` (27,761 tests, all pass)
- [x] Targeted class structural tests: `t/class-redeclaration.t`, `t/class-decl-hoist-shell.t`, `t/class-is-rw.t`, `t/lexical-class-identity.t`, `t/exporthow-class-aspects.t`, native-repr tests, and more (118 tests)
- [x] Whitelisted roast: all 23 `roast/S12-class/*.t` + `roast/6.c/S12-class/mro-6c.t` (296 tests)
- [x] Confirmed `roast/S12-attributes/trusts.t`'s 6 failing subtests are pre-existing (identical failure before this change — unrelated incomplete attribute-privacy enforcement, not a registration-mechanics issue)
- [x] `cargo fmt` / `cargo clippy -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)