### PR TITLE
feat(compiler,runtime): class/role declarations precompute attribute pre-scan facts (ADR-0019 D2a)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -116,10 +116,14 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 `main`; this is not a stacked-PR plan.
 
 **Current progress: 22/53 slices merged (C6, C7, C8, and D1 complete, 2026-08-07). Phase C is
-fully checked; the next open box is D2 (attributes and generated accessors). D1 found most class
-structural data already typed-plan-driven from Phase A3/A4; the two remaining body-scanning reads
-(stub detection, `Stmt::TrustsDecl`) are now precomputed at plan lowering as
-`CompiledClassDeclPlan::is_stub`/`trusts`; see `news/2026-08/d1-class-structural-plan-fields.md`.
+fully checked; the next open box is D2 (attributes and generated accessors), now subdivided
+D2a-D2d — D2a landed 2026-08-07. D1 found most class structural data already typed-plan-driven
+from Phase A3/A4; the two remaining body-scanning reads (stub detection, `Stmt::TrustsDecl`) are
+now precomputed at plan lowering as `CompiledClassDeclPlan::is_stub`/`trusts`; see
+`news/2026-08/d1-class-structural-plan-fields.md`. D2, unlike D1, found attribute data with no
+existing typed-plan coverage at all; D2a took the same "precompute a re-derived body scan" pattern
+for the two pure pre-scan facts (class own-attribute names, role own-attribute
+names/used-modules/declared-types) — see `news/2026-08/d2a-attribute-prescan-plan-fields.md`.
 C8 migrated `RegisterProtoSub`/`RegisterProtoToken` onto `RegisterDecl` and made a non-trivial
 proto body compile its `{*}`-rewritten dispatch once, at declaration time, instead of on every
 call; see `news/2026-08/c8-proto-declarations-compiled-plans.md`. C7 removed the last sub-shaped
@@ -373,7 +377,40 @@ walkers wholesale is not possible before then.
   are precomputed at plan lowering as `CompiledClassDeclPlan::is_stub`/`trusts`, threaded through
   `ClassDeclModifiers`. `news/2026-08/d1-class-structural-plan-fields.md`.
 - [ ] **D2 — Encode attributes and generated accessors.** Compile defaults/constraints as child
-  chunks and publish generated methods through the canonical table.
+  chunks and publish generated methods through the canonical table. Unlike D1, a pre-PR survey
+  found attributes have **no** existing typed-plan coverage: `CompiledClassDeclPlan`/
+  `CompiledRoleDeclPlan` carried zero attribute fields, registration walked `Stmt::HasDecl` at
+  four independent sites, generated accessors were resolved by a special-cased runtime lookup
+  (`class_introspection.rs`) rather than `MethodEntry` rows, and defaults were evaluated by raw
+  `eval_block_value` at six sites — `CompiledDeclExpr` was not involved anywhere. So, following
+  C6/D0's measure-then-split precedent, the box is subdivided:
+  - [x] **D2a — Precompute body pre-scan facts.** The two runtime pre-scans that re-derive pure
+    syntactic facts from the body on every registration — `run_class_body`'s directly-declared
+    attribute-name set (used for `$!attr` validation, combining flattened top-level `has` with
+    `has` nested inside a body `sub`) and `walk_role_body`'s combined attribute-name /
+    `use`d-module / body-declared-type scan — move to the compiler as
+    `CompiledClassDeclPlan::own_attribute_names` and
+    `CompiledRoleDeclPlan::{own_attribute_names,body_used_modules,body_declared_types}`, threaded
+    through `ClassDeclModifiers` and `register_role_decl` respectively. Registration still walks
+    `legacy_body` for the actual `has`-arm dispatch (typing full attribute descriptors is D2b) —
+    no behavior change, no new fallback. `news/2026-08/d2a-attribute-prescan-plan-fields.md`.
+  - [ ] **D2b — Type full attribute descriptors.** Replace the `ClassAttributeDef` 7-tuple with a
+    named struct and a compiler-lowered `CompiledAttrDecl` (mirroring `RuntimeHasDeclSpec`, which
+    already covers the mainline/EVAL `has`-outside-class case) covering the full `Stmt::HasDecl`
+    surface; make `class_body_has_decl`/`role_body_has_decl`/the augment arm consume it instead of
+    re-destructuring the AST, and subsume `RuntimeHasDeclSpec`.
+  - [ ] **D2c — Compile defaults/constraints as child chunks.** Replace attribute
+    `default`/`is_default`/`where_constraint` `Expr`s (including the `Expr`-valued role
+    registry tables `role_attribute_default_exprs`/`role_class_level_attrs`/
+    `class_attribute_default_exprs`) with `CompiledDeclExpr` run through `run_decl_expr`,
+    collapsing the three near-duplicated env-setup blocks in `attr_build_defaults.rs`,
+    `methods_object_default_ctor.rs`, and `methods_object_dispatch_new.rs`.
+  - [ ] **D2d — Publish generated accessors through the canonical table.** Give `MethodEntry` an
+    accessor arm populated from `ClassDef::attributes` in `sync_user_method_entries`, so
+    `has_public_accessor`/`resolve_user_method_or_accessor` (`class_introspection.rs`) and the
+    `.^methods`/`.^can`/`.^attributes` synthesis sites become table probes riding the existing
+    generation-bump invalidation instead of MRO×attribute-vector scans. Independently landable
+    (does not depend on D2b/D2c — `ClassDef::attributes` is already populated by registration).
 - [ ] **D3 — Encode class methods and submethods as compiled candidates.** Install ordinary, multi,
   proto, private, rw, wrap, BUILD, and TWEAK metadata without walking `Stmt::MethodDecl`. That
   walk exists in three places, not one — the class walker (~508 lines), the role walker

--- a/news/2026-08/d2a-attribute-prescan-plan-fields.md
+++ b/news/2026-08/d2a-attribute-prescan-plan-fields.md
@@ -1,0 +1,55 @@
+# ADR-0019 D2a: attribute pre-scan facts precomputed as plan data
+
+D2 asked to encode attributes and generated accessors as typed plan
+operations. A survey done before starting found the box is not D1-shaped:
+D1 discovered that most class structural data (parents, repr, visibility,
+lexical/package aliases) was already typed-plan-driven from Phase A3/A4, but
+attributes had **zero** existing plan coverage. `CompiledClassDeclPlan` and
+`CompiledRoleDeclPlan` carried no attribute fields at all; registration
+walked `Stmt::HasDecl` at four independent sites; generated accessors were
+resolved by a special-cased runtime lookup (`class_introspection.rs`) rather
+than `MethodEntry` rows; and attribute defaults were evaluated by raw
+`eval_block_value` at six call sites, with `CompiledDeclExpr` (the C5
+re-entrant-bytecode mechanism) not involved anywhere.
+
+Given that shape, D2 is subdivided the way C6 and D0 were once their real
+size became clear: measure, then split. D2a takes the one slice that *is*
+D1-shaped — two runtime pre-scans that re-derive pure syntactic facts from
+the body on every registration, contributing no new attribute semantics of
+their own:
+
+- `run_class_body`'s pre-scan built the set of attribute names valid for
+  `$!attr` access: flattened top-level `has` declarations (after expanding
+  `has ($a, $b)` list-form `SyntheticBlock`s) plus any `has` nested inside a
+  `sub` in the class body (`class C { sub f { has $.x } }`, which Rakudo
+  still registers on the class). This set now lives in
+  `CompiledClassDeclPlan::own_attribute_names`, computed once at plan
+  lowering by `class_own_attribute_names`/`collect_nested_has_decl_names`
+  (mirroring the runtime's own `collect_nested_class_has_decls`), threaded
+  through `ClassDeclModifiers`.
+- `walk_role_body`'s pre-scan combined three unrelated facts in one loop:
+  attribute names the role declares, module names it `use`s/`need`s/
+  `import`s (needed because a role's method-signature validation runs before
+  the body's own `use` has loaded), and types the body declares itself (`my
+  enum`, `my class`, ...). All three move to
+  `CompiledRoleDeclPlan::{own_attribute_names,body_used_modules,body_declared_types}`,
+  computed once by `role_body_prescan` and threaded as three new
+  `register_role_decl` parameters.
+
+Registration still walks `legacy_body` for the actual `has`-arm dispatch —
+typing full attribute descriptors (a `CompiledAttrDecl` covering the whole
+`Stmt::HasDecl` surface, subsuming the existing `RuntimeHasDeclSpec`) is
+D2b, not this slice. This PR changes no attribute semantics: no new
+fallback, and the two callers that build a `ClassDeclModifiers` without a
+compiled plan (role-pun registration, runtime mixin-class synthesis) both
+already pass an empty body, so they simply supply `own_attribute_names: &[]`
+— the same pattern D1 used for `is_stub`/`trusts`.
+
+Pinned by two new compiler unit tests
+(`class_declarations_precompute_own_attribute_names`,
+`role_declarations_precompute_body_prescan`) alongside the existing
+attribute/class/role test surface. Full `t/` (27,765 tests) passes
+unchanged; the roast attribute/class/role surface is unchanged (two
+pre-existing non-whitelisted failures, `S12-attributes/trusts.t` and
+`S12-class/open_closed.t`, reproduce identically on `main` and are unrelated
+to this change).

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -206,6 +206,60 @@ mod declaration_plan_tests {
         assert!(plan_stub.is_stub);
         assert!(plan_stub.trusts.is_empty());
     }
+
+    /// ADR-0019 D2a: a class declaration's own attribute names — including
+    /// ones nested inside a body `sub`, and excluding class-level `our`/`my`
+    /// attributes — are precomputed at plan lowering, so `run_class_body`
+    /// never re-walks the body to derive them.
+    #[test]
+    fn class_declarations_precompute_own_attribute_names() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            "class A { has $.x; has $!y; our $.z; sub f { has $.w } }",
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_a = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "A")
+            .expect("class A declaration plan");
+        let mut names: Vec<_> = plan_a
+            .own_attribute_names
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["w", "x", "y"]);
+    }
+
+    /// ADR-0019 D2a: a role declaration's own attribute names, `use`d module
+    /// names, and body-declared type names are precomputed at plan lowering,
+    /// so `walk_role_body`'s pre-scan pass never re-derives them.
+    #[test]
+    fn role_declarations_precompute_body_prescan() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            "role R { use JSON::Fast; has $.x; my class Inner { } }",
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_r = code
+            .role_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "R")
+            .expect("role R declaration plan");
+        assert_eq!(
+            plan_r
+                .own_attribute_names
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>(),
+            vec!["x"]
+        );
+        assert_eq!(plan_r.body_used_modules, vec!["JSON::Fast".to_string()]);
+        assert_eq!(plan_r.body_declared_types, vec!["Inner".to_string()]);
+    }
 }
 mod const_fold;
 mod decl_plan;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2175,6 +2175,93 @@ fn is_stub_routine_body(body: &[Stmt]) -> bool {
     )
 }
 
+/// Recursively surface `has`-attribute names nested inside a `sub` within a
+/// class body (`class C { sub f { has $.x } }`), mirroring
+/// `Interpreter::collect_nested_class_has_decls` (ADR-0019 D2a). Descends
+/// into `sub` bodies but not into a nested `class`/`role`, which owns its
+/// own attribute scope. `our`/`my` (class-level) attributes are excluded, as
+/// they are not part of per-instance `$!attr` validation.
+fn collect_nested_has_decl_names(stmts: &[Stmt], out: &mut Vec<Symbol>) {
+    for s in stmts {
+        match s {
+            Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } | Stmt::HasDecl { .. } => {}
+            Stmt::SubDecl { body, .. } => {
+                for inner in body {
+                    if let Stmt::HasDecl {
+                        name,
+                        is_our,
+                        is_my,
+                        ..
+                    } = inner
+                        && !*is_our
+                        && !*is_my
+                    {
+                        out.push(*name);
+                    }
+                }
+                collect_nested_has_decl_names(body, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// The set of attribute names a class declares directly in its own body
+/// (ADR-0019 D2a), matching `run_class_body`'s pre-scan: top-level `has`
+/// declarations (after flattening `has ($a, $b)` list-form
+/// `SyntheticBlock`s) plus any `has` nested inside a `sub` in the body.
+/// Precomputed once at plan lowering instead of re-walked on every
+/// registration.
+fn class_own_attribute_names(body: &[Stmt]) -> Vec<Symbol> {
+    let mut names: Vec<Symbol> = body
+        .iter()
+        .flat_map(|s| match s {
+            Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+            other => vec![other],
+        })
+        .filter_map(|stmt| match stmt {
+            Stmt::HasDecl {
+                name,
+                is_our,
+                is_my,
+                ..
+            } if !*is_our && !*is_my => Some(*name),
+            _ => None,
+        })
+        .collect();
+    collect_nested_has_decl_names(body, &mut names);
+    names
+}
+
+/// Pre-scan facts for a role body (ADR-0019 D2a), mirroring the combined
+/// loop in `Interpreter::walk_role_body`: attribute names the role declares,
+/// module names it `use`s/`need`s/`import`s, and types it declares in its
+/// own body. All three are pure syntactic facts, precomputed once at plan
+/// lowering instead of re-walked on every registration.
+fn role_body_prescan(body: &[Stmt]) -> (Vec<Symbol>, Vec<String>, Vec<String>) {
+    let mut own_attribute_names = Vec::new();
+    let mut used_modules = Vec::new();
+    let mut declared_types = Vec::new();
+    let flattened = body.iter().flat_map(|s| match s {
+        Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+        other => vec![other],
+    });
+    for stmt in flattened {
+        match stmt {
+            Stmt::HasDecl { name, .. } => own_attribute_names.push(*name),
+            Stmt::Use { module, .. } | Stmt::Need { module } | Stmt::Import { module, .. } => {
+                used_modules.push(module.clone());
+            }
+            Stmt::EnumDecl { name, .. }
+            | Stmt::SubsetDecl { name, .. }
+            | Stmt::ClassDecl { name, .. }
+            | Stmt::RoleDecl { name, .. } => declared_types.push(name.resolve()),
+            _ => {}
+        }
+    }
+    (own_attribute_names, used_modules, declared_types)
+}
+
 fn body_contains_non_nil_return(stmts: &[Stmt]) -> bool {
     stmts.iter().any(|stmt| match stmt {
         Stmt::Return(expr) => !matches!(expr, Expr::Literal(value) if value.is_nil()),
@@ -2225,6 +2312,11 @@ pub(crate) struct CompiledClassDeclPlan {
     /// precomputed at plan lowering (ADR-0019 D1) instead of scanning
     /// `legacy_body` for `Stmt::TrustsDecl` at registration time.
     pub(crate) trusts: Vec<Symbol>,
+    /// Attribute names this class declares directly in its own body
+    /// (ADR-0019 D2a), precomputed at plan lowering instead of
+    /// `run_class_body` re-scanning the (flattened, nested-sub-surfaced)
+    /// body on every registration.
+    pub(crate) own_attribute_names: Vec<Symbol>,
 }
 
 #[derive(Debug, Clone)]
@@ -2239,6 +2331,16 @@ pub(crate) struct CompiledRoleDeclPlan {
     pub(crate) is_rw: bool,
     pub(crate) language_version: String,
     pub(crate) custom_traits: Vec<(String, Option<DeclTraitArg>)>,
+    /// Attribute names this role declares in its own body (ADR-0019 D2a),
+    /// precomputed at plan lowering instead of `walk_role_body`'s pre-scan
+    /// pass re-deriving it on every registration.
+    pub(crate) own_attribute_names: Vec<Symbol>,
+    /// Module names the body `use`s/`need`s/`import`s (ADR-0019 D2a),
+    /// precomputed alongside `own_attribute_names`.
+    pub(crate) body_used_modules: Vec<String>,
+    /// Types the body declares itself (`my enum`, `my class`, ...)
+    /// (ADR-0019 D2a), precomputed alongside `own_attribute_names`.
+    pub(crate) body_declared_types: Vec<String>,
 }
 
 /// A package-level `proto sub`/`proto rule`/`proto token` declaration lowered
@@ -5440,6 +5542,7 @@ impl CompiledCode {
                 _ => None,
             })
             .collect();
+        let own_attribute_names = class_own_attribute_names(body);
         let plan_idx = self.class_decl_plans.len() as u32;
         self.class_decl_plans.push(CompiledClassDeclPlan {
             name: *name,
@@ -5457,6 +5560,7 @@ impl CompiledCode {
             decl_id: *decl_id,
             is_stub,
             trusts,
+            own_attribute_names,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Class(plan_idx));
@@ -5482,6 +5586,7 @@ impl CompiledCode {
         else {
             panic!("add_role_decl_plan expects RoleDecl");
         };
+        let (own_attribute_names, body_used_modules, body_declared_types) = role_body_prescan(body);
         let plan_idx = self.role_decl_plans.len() as u32;
         self.role_decl_plans.push(CompiledRoleDeclPlan {
             name: *name,
@@ -5493,6 +5598,9 @@ impl CompiledCode {
             is_rw: *is_rw,
             language_version: language_version.clone(),
             custom_traits: zip_decl_trait_args(custom_traits, trait_args),
+            own_attribute_names,
+            body_used_modules,
+            body_declared_types,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Role(plan_idx));

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -195,6 +195,11 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// `publish_class_shell` scanning the body for `Stmt::TrustsDecl` at
     /// registration time.
     pub(crate) trusts: &'a [Symbol],
+    /// Attribute names the class declares directly in its own body,
+    /// precomputed by the compiler at plan lowering (ADR-0019 D2a) instead
+    /// of `run_class_body` re-scanning the body for `Stmt::HasDecl` at
+    /// registration time.
+    pub(crate) own_attribute_names: &'a [Symbol],
 }
 
 pub(super) fn parse_role_type_args(input: &str) -> Vec<String> {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -752,6 +752,7 @@ impl Interpreter {
             language_version: &language_version,
             is_stub: false,
             trusts: &[],
+            own_attribute_names: &[],
         };
         self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
         self.store_language_revision_from_version(&pun_name, &language_version);

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -70,6 +70,7 @@ impl Interpreter {
     /// (flattened) body statement through the per-statement arms, then fire
     /// LEAVE phasers, persist class-body statics, and restore the enclosing
     /// package/lexical scope. Returns the final `ClassDef`.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn run_class_body(
         &mut self,
         name: &str,
@@ -78,6 +79,7 @@ impl Interpreter {
         is_hidden: bool,
         class_is_rw: bool,
         class_lang_rev: &str,
+        own_attribute_names: &[Symbol],
     ) -> Result<ClassDef, RuntimeError> {
         let saved_package = self.current_package();
         let saved_env = self.env.clone();
@@ -99,27 +101,17 @@ impl Interpreter {
         // registers the attribute (the nested sub itself is still processed
         // normally; its body's `has` is a compile-time declaration).
         Self::collect_nested_class_has_decls(body, &mut flattened_body);
-        // Pre-scan: collect attribute names declared directly in this class body.
-        // Combined with role-composed attributes already in class_def.attributes,
-        // this gives the full set of attributes valid for $!attr access.
+        // The set of attributes valid for $!attr access: names declared
+        // directly in this class body (precomputed by the compiler at plan
+        // lowering, ADR-0019 D2a — `own_attribute_names` already covers the
+        // flattened top level plus any `has` nested inside a body `sub`)
+        // combined with role-composed attributes already in class_def.attributes.
         let mut class_own_attrs: HashSet<String> = class_def
             .attributes
             .iter()
             .map(|(n, ..)| n.clone())
             .collect();
-        for stmt in &flattened_body {
-            if let Stmt::HasDecl {
-                name: attr_name,
-                is_our,
-                is_my,
-                ..
-            } = stmt
-                && !*is_our
-                && !*is_my
-            {
-                class_own_attrs.insert(attr_name.resolve());
-            }
-        }
+        class_own_attrs.extend(own_attribute_names.iter().map(|s| s.resolve()));
         let mut cx = ClassBodyCx {
             name,
             is_hidden,

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -125,6 +125,7 @@ impl Interpreter {
             language_version: class_language_version,
             is_stub: is_stub_body,
             trusts,
+            own_attribute_names,
         } = modifiers;
         let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
@@ -221,6 +222,7 @@ impl Interpreter {
             is_hidden,
             class_is_rw,
             &class_lang_rev,
+            own_attribute_names,
         )?;
         self.finalize_class_registration(name, parents, class_def, &snapshot)?;
         self.install_class_exporthow(name, parents)?;

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -261,6 +261,7 @@ impl Interpreter {
         )))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn register_role_decl(
         &mut self,
         name: &str,
@@ -269,6 +270,9 @@ impl Interpreter {
         body: &[Stmt],
         role_is_rw: bool,
         language_version: &str,
+        own_attribute_names: &[Symbol],
+        body_used_modules: &[String],
+        body_declared_types: &[String],
     ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
 
@@ -316,9 +320,9 @@ impl Interpreter {
             role_is_rw,
             is_parametric: !type_params.is_empty(),
             role_def,
-            role_own_attrs: HashSet::new(),
-            body_used_modules: HashSet::new(),
-            body_declared_types: HashSet::new(),
+            role_own_attrs: own_attribute_names.iter().map(|s| s.resolve()).collect(),
+            body_used_modules: body_used_modules.iter().cloned().collect(),
+            body_declared_types: body_declared_types.iter().cloned().collect(),
         };
         self.walk_role_body(body, &mut cx)?;
         self.finish_role_registration(

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -176,9 +176,10 @@ impl Interpreter {
         prev_parents
     }
 
-    /// Walk the (flattened) role body: pre-scan declared attributes, used
-    /// modules and body-declared types, then dispatch each statement through
-    /// the per-statement arms.
+    /// Walk the (flattened) role body, dispatching each statement through the
+    /// per-statement arms. Declared attributes, used modules, and
+    /// body-declared types are precomputed by the compiler (ADR-0019 D2a)
+    /// and already populate `cx` by the time this runs.
     pub(super) fn walk_role_body(
         &mut self,
         body: &[Stmt],
@@ -191,39 +192,21 @@ impl Interpreter {
                 other => vec![other],
             })
             .collect();
-        // Pre-scan: collect attribute names declared in this role body, and the
-        // names of modules `use`d / `need`ed inside the body. A `unit role X; use
-        // A::B::C; method m(A::B::C:D $p) {...}` imports the type at BEGIN time, but
-        // this registration validates method param types before the body's `use`
-        // has loaded the module, so a qualified imported type looks unresolvable.
-        // Remember the used-module names so the param check can accept a qualified
-        // type that a body import supplies (the real resolution happens at the call
-        // site regardless).
-        //
-        // Types declared inside the role body itself (`my enum`, `my subset`,
-        // `my class`, ...) are not yet in the registry while the role's method
-        // signatures are validated, so collect their names to accept them as
-        // parameter/attribute constraints. The real registration happens when the
-        // role body runs.
-        for stmt in &flattened_body {
-            match stmt {
-                Stmt::HasDecl {
-                    name: attr_name, ..
-                } => {
-                    cx.role_own_attrs.insert(attr_name.resolve());
-                }
-                Stmt::Use { module, .. } | Stmt::Need { module } | Stmt::Import { module, .. } => {
-                    cx.body_used_modules.insert(module.clone());
-                }
-                Stmt::EnumDecl { name, .. }
-                | Stmt::SubsetDecl { name, .. }
-                | Stmt::ClassDecl { name, .. }
-                | Stmt::RoleDecl { name, .. } => {
-                    cx.body_declared_types.insert(name.resolve());
-                }
-                _ => {}
-            }
-        }
+        // Attribute names, `use`d/`need`ed module names, and body-declared
+        // types are precomputed by the compiler at plan lowering (ADR-0019
+        // D2a) and already populate `cx.role_own_attrs`/`body_used_modules`/
+        // `body_declared_types` — see `register_role_decl`. A `unit role X;
+        // use A::B::C; method m(A::B::C:D $p) {...}` imports the type at
+        // BEGIN time, but this registration validates method param types
+        // before the body's `use` has loaded the module, so a qualified
+        // imported type looks unresolvable; the precomputed used-module
+        // names let the param check accept a qualified type that a body
+        // import supplies (the real resolution happens at the call site
+        // regardless). Types declared inside the role body itself (`my
+        // enum`, `my subset`, `my class`, ...) are not yet in the registry
+        // while the role's method signatures are validated, so the
+        // precomputed names are accepted as parameter/attribute constraints;
+        // the real registration happens when the role body runs below.
         for stmt in flattened_body {
             match stmt {
                 Stmt::HasDecl { .. } => {

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -64,6 +64,7 @@ impl Interpreter {
             language_version: &language_version,
             is_stub: false,
             trusts: &[],
+            own_attribute_names: &[],
         };
         self.register_class_decl(&name, &parents, modifiers, &[])?;
         self.compose_mixin_role_submethods(&name, &fresh);

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -137,6 +137,7 @@ impl Interpreter {
             decl_id,
             is_stub,
             trusts,
+            own_attribute_names,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {
@@ -248,6 +249,7 @@ impl Interpreter {
                         language_version,
                         is_stub: *is_stub,
                         trusts,
+                        own_attribute_names,
                     },
                     body,
                 )
@@ -595,6 +597,9 @@ impl Interpreter {
             is_rw,
             language_version,
             custom_traits,
+            own_attribute_names,
+            body_used_modules,
+            body_declared_types,
         }) = code.role_decl_plans.get(idx as usize)
         {
             let name_str = name.resolve();
@@ -621,6 +626,9 @@ impl Interpreter {
                     body,
                     *is_rw,
                     language_version,
+                    own_attribute_names,
+                    body_used_modules,
+                    body_declared_types,
                 )
             )?;
             // Link `is Parent` references on this role to the lexical class visible


### PR DESCRIPTION
## Summary
- ADR-0019 Phase D box D2 ("attributes and generated accessors") turned out to have no existing typed-plan coverage at all — unlike D1, where most class structural data was already typed-plan-driven from Phase A3/A4. D2 is therefore subdivided (D2a–D2d), following the C6/D0 measure-then-split precedent.
- D2a moves the two runtime pre-scans that re-derive pure syntactic facts from a class/role body on every registration into the compiler:
  - `CompiledClassDeclPlan::own_attribute_names` — the set of attribute names valid for `$!attr` access, precomputed at plan lowering instead of `run_class_body` re-walking the flattened body (including `has` nested inside a body `sub`) on every registration.
  - `CompiledRoleDeclPlan::{own_attribute_names,body_used_modules,body_declared_types}` — the combined attribute-name / used-module / body-declared-type pre-scan `walk_role_body` used to run inline, precomputed once instead.
- Registration still walks `legacy_body` for the actual `has`-arm dispatch — this is not a new fallback, and typing full attribute descriptors (`CompiledAttrDecl`) is D2b, a later slice.

## Test plan
- [x] `cargo test --lib` — includes two new compiler unit tests (`class_declarations_precompute_own_attribute_names`, `role_declarations_precompute_body_prescan`)
- [x] `cargo clippy -- -D warnings` / `cargo fmt`
- [x] `make test` — full `t/` suite (27,765 tests), clean pass
- [x] Targeted roast: `S12-attributes/*`, `S12-class/*`, `S14-roles/*`, `6.c/S12-class/mro-6c.t`, `6.c/S14-roles/*` — only two pre-existing non-whitelisted failures (`S12-attributes/trusts.t`, `S12-class/open_closed.t`), verified identical failure counts on `main` (unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)