### PR TITLE
refactor(runtime): turn ClassAttributeDef into a named struct (ADR-0019 D2b prep)

### DIFF
--- a/news/2026-08/d2b-prep-class-attribute-def-struct.md
+++ b/news/2026-08/d2b-prep-class-attribute-def-struct.md
@@ -1,0 +1,32 @@
+# ADR-0019 D2b prep: `ClassAttributeDef` becomes a named struct
+
+D2b ("type full attribute descriptors") needs to attach a `CompiledDeclExpr` child
+chunk to an attribute's default/constraint expressions later in the D2 sequence
+(D2c), which cannot be done cleanly against a bare 7-tuple. This slice is the
+mechanical prerequisite: `ClassAttributeDef` (`src/runtime/mod.rs`) changes from
+
+```rust
+pub(crate) type ClassAttributeDef = (
+    String, bool, Option<Expr>, bool, Option<Option<String>>, char, Option<Expr>,
+);
+```
+
+to a named struct with the same field order —
+`name, is_public, default, is_rw, is_required, sigil, where_constraint` — and every
+construction/destructuring site across the codebase (31 files under
+`src/runtime/`) is updated to match. Zero behavior change: this is a pure
+rename/reshape, not a logic change.
+
+While converting the positional pattern in `is_native_default_constructible`
+(`src/runtime/methods_object.rs`), a pre-existing mismatch surfaced: the old
+tuple pattern bound the tuple's 5th field (`is_required`) to a local variable
+named `type_constraint`, and the surrounding code used it as though it held
+an actual type-constraint string (those live in the registry's
+`attribute_types` side table, not on `ClassAttributeDef` at all). This is
+carried over unchanged — fixing it is out of scope for a "zero behavior
+change" mechanical PR — and is recorded as
+`todo/tickets/native-ctor-gate-reads-is-required-as-type-constraint.md` for a
+follow-up session.
+
+Verified with `cargo test --lib` (670 tests) and the local class/role/attribute
+`prove` surface (88 files, 732 tests), all passing unchanged.

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -261,13 +261,13 @@ impl Interpreter {
             if let Some(class_def) = self.registry().classes.get(cn.as_str())
                 // Within one class a later same-name declaration overrides an
                 // earlier one (collect_class_attributes' remove-then-push).
-                && let Some((_, is_public, ..)) = class_def
+                && let Some(attr) = class_def
                     .attributes
                     .iter()
                     .rev()
-                    .find(|(n, ..)| n == method_name)
+                    .find(|a| a.name == method_name)
             {
-                return *is_public;
+                return attr.is_public;
             }
         }
         false
@@ -311,7 +311,7 @@ impl Interpreter {
                     let attr = class_def
                         .attributes
                         .iter()
-                        .any(|(n, is_public, ..)| *is_public && n == method_name);
+                        .any(|a| a.is_public && a.name == method_name);
                     // A built-in class (e.g. Proc) may register a public attribute
                     // for `.raku`/introspection while a native method of the same
                     // name is the real getter (its computed fallbacks differ from
@@ -329,7 +329,7 @@ impl Interpreter {
                     let attr = role_def
                         .attributes
                         .iter()
-                        .any(|(n, is_public, ..)| *is_public && n == method_name);
+                        .any(|a| a.is_public && a.name == method_name);
                     (local, false, attr, false)
                 } else {
                     (false, false, false, false)
@@ -366,9 +366,7 @@ impl Interpreter {
         let attrs = self.collect_class_attributes(class_name);
         let is_rw = attrs
             .iter()
-            .any(|(attr_name, is_public, _default, is_rw, ..)| {
-                *is_public && *is_rw && attr_name == method_name
-            });
+            .any(|attr| attr.is_public && attr.is_rw && attr.name == method_name);
         if !is_rw {
             return None;
         }
@@ -387,9 +385,9 @@ impl Interpreter {
             if let Some(&built) = class_def.attribute_built.get(attr_name) {
                 return built;
             }
-            for (name, is_public, ..) in &class_def.attributes {
-                if name == attr_name {
-                    return *is_public;
+            for attr in &class_def.attributes {
+                if attr.name == attr_name {
+                    return attr.is_public;
                 }
             }
         }
@@ -406,9 +404,9 @@ impl Interpreter {
                 if let Some(&built) = parent_def.attribute_built.get(attr_name) {
                     return built;
                 }
-                for (name, is_public, ..) in &parent_def.attributes {
-                    if name == attr_name {
-                        return *is_public;
+                for attr in &parent_def.attributes {
+                    if attr.name == attr_name {
+                        return attr.is_public;
                     }
                 }
             }
@@ -521,7 +519,7 @@ impl Interpreter {
             self.registry()
                 .classes
                 .get(cn.as_str())
-                .is_some_and(|cd| cd.attributes.iter().any(|(n, ..)| n == bare))
+                .is_some_and(|cd| cd.attributes.iter().any(|a| a.name == bare))
         })
     }
 
@@ -531,7 +529,7 @@ impl Interpreter {
         for cn in mro.iter().rev() {
             if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 for attr in &class_def.attributes {
-                    if let Some(pos) = attrs.iter().position(|(n, ..)| n == &attr.0) {
+                    if let Some(pos) = attrs.iter().position(|a| a.name == attr.name) {
                         attrs.remove(pos);
                     }
                     attrs.push(attr.clone());
@@ -558,7 +556,7 @@ impl Interpreter {
         for cn in mro.iter() {
             if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 for attr in &class_def.attributes {
-                    *attr_counts.entry(attr.0.clone()).or_insert(0) += 1;
+                    *attr_counts.entry(attr.name.clone()).or_insert(0) += 1;
                 }
             }
         }
@@ -566,7 +564,7 @@ impl Interpreter {
         for cn in mro.iter() {
             if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 for attr in &class_def.attributes {
-                    if attr_counts.get(&attr.0).copied().unwrap_or(0) > 1 {
+                    if attr_counts.get(&attr.name).copied().unwrap_or(0) > 1 {
                         result.push((cn.resolve(), attr.clone()));
                     }
                 }
@@ -594,7 +592,7 @@ impl Interpreter {
                     visited.push(parent_role_name.clone());
                     if let Some(parent_role) = self.registry().roles.get(&parent_role_name) {
                         for attr in &parent_role.attributes {
-                            if !attrs.iter().any(|a| a.0 == attr.0) {
+                            if !attrs.iter().any(|a| a.name == attr.name) {
                                 attrs.push(attr.clone());
                             }
                         }

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -350,12 +350,12 @@ impl crate::runtime::Interpreter {
         let attrs = self.collect_class_attributes(&registered);
         let fields: Vec<(String, String)> = attrs
             .iter()
-            .map(|(name, ..)| {
+            .map(|attr| {
                 let ty = self
-                    .get_attr_type_constraint(&registered, name)
+                    .get_attr_type_constraint(&registered, &attr.name)
                     .unwrap_or_default();
                 (
-                    name.clone(),
+                    attr.name.clone(),
                     self.resolve_field_type_alias(&ty, &registered),
                 )
             })

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2714,7 +2714,7 @@ impl Interpreter {
                         .is_some_and(|role| {
                             role.attributes
                                 .iter()
-                                .any(|(name, public, ..)| *public && name == method)
+                                .any(|a| a.is_public && a.name == method)
                         });
                 // Punning registers a class under the same name, so the retry
                 // falls through to ordinary class dispatch rather than
@@ -2739,7 +2739,7 @@ impl Interpreter {
                     && role
                         .attributes
                         .iter()
-                        .any(|(name, public, ..)| *public && name == method);
+                        .any(|a| a.is_public && a.name == method);
                 if (role.methods.contains_key(method) || has_public_accessor)
                     && role.methods.contains_key("new")
                     && let Some(punned) = self.ensure_parametric_role_pun_class(&base, type_args)?

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -61,7 +61,7 @@ impl Interpreter {
                 }
                 if let Some(cd) = self.registry().classes.get(cn) {
                     for attr in &cd.attributes {
-                        if seen_names.insert(attr.0.clone()) {
+                        if seen_names.insert(attr.name.clone()) {
                             result.push(self.make_attribute_object(attr, cn));
                         }
                     }
@@ -156,7 +156,12 @@ impl Interpreter {
     }
 
     fn make_attribute_object(&self, attr: &super::ClassAttributeDef, owner: &str) -> Value {
-        let (ref attr_name, is_public, ref default, is_rw, ref is_required, sigil, _) = *attr;
+        let attr_name = &attr.name;
+        let is_public = attr.is_public;
+        let default = &attr.default;
+        let is_rw = attr.is_rw;
+        let is_required = &attr.is_required;
+        let sigil = attr.sigil;
         // A custom trait_mod:<is> was applied to this attribute at class
         // registration: serve the SAME meta-object it mutated (role mixins,
         // values like JSON::Name's `$.json-name`), topped up below with the

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -950,15 +950,15 @@ impl Interpreter {
                     let sigil = attr_name_raw.chars().next().unwrap_or('$');
                     // Add the attribute to the class definition
                     if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
-                        class_def.attributes.push((
-                            bare_name.clone(),
-                            has_accessor, // is_public
-                            None,         // default_expr
-                            is_rw,        // is_rw
-                            None,         // is_required
-                            sigil,        // sigil
-                            None,         // where_constraint
-                        ));
+                        class_def.attributes.push(ClassAttributeDef {
+                            name: bare_name.clone(),
+                            is_public: has_accessor,
+                            default: None,
+                            is_rw,
+                            is_required: None,
+                            sigil,
+                            where_constraint: None,
+                        });
                         if let Some(tc) = type_constraint {
                             class_def.attribute_types.insert(bare_name, tc);
                         }

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -124,10 +124,11 @@ impl Interpreter {
         }
         // Check auto-generated accessor methods for public attributes (has $.x, has $.x is rw).
         // These are not stored in class_def.methods but are generated on-the-fly.
-        // ClassAttributeDef: (attr_name, is_public, default, is_rw, is_required, sigil, where)
+        // ClassAttributeDef fields: name, is_public, default, is_rw, is_required, sigil, where_constraint
         if let Some(class_def) = self.registry().classes.get(&class_name_str) {
-            for (attr_name, is_public, _, is_rw, _, _, _) in &class_def.attributes {
-                if *is_public && attr_name == method_name {
+            for attr in &class_def.attributes {
+                let (attr_name, is_public, is_rw) = (&attr.name, attr.is_public, attr.is_rw);
+                if is_public && attr_name == method_name {
                     let mut env = crate::env::Env::new();
                     env.insert(
                         "__mutsu_callable_type".to_string(),
@@ -139,7 +140,7 @@ impl Interpreter {
                         vec!["self".to_string()],
                         vec![Self::make_invocant_param(&class_name_str)],
                         vec![],
-                        *is_rw,
+                        is_rw,
                         env,
                     ));
                 }

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -11,9 +11,9 @@ impl Interpreter {
     ) {
         if let Some(class_def) = self.registry().classes.get(class_name) {
             // First add accessor methods for public attributes (in order)
-            for (attr_name, is_public, ..) in &class_def.attributes {
-                if *is_public && !class_def.methods.contains_key(attr_name) {
-                    result.push(self.make_native_method_object(attr_name));
+            for attr in &class_def.attributes {
+                if attr.is_public && !class_def.methods.contains_key(&attr.name) {
+                    result.push(self.make_native_method_object(&attr.name));
                 }
             }
             // Then add explicit methods
@@ -68,9 +68,12 @@ impl Interpreter {
         let Some(class_def) = registry.classes.get(class_name) else {
             return table;
         };
-        for (attr_name, is_public, ..) in &class_def.attributes {
-            if *is_public && !class_def.methods.contains_key(attr_name) {
-                table.insert(attr_name.clone(), self.make_native_method_object(attr_name));
+        for attr in &class_def.attributes {
+            if attr.is_public && !class_def.methods.contains_key(&attr.name) {
+                table.insert(
+                    attr.name.clone(),
+                    self.make_native_method_object(&attr.name),
+                );
             }
         }
         for (method_name, overloads) in &class_def.methods {
@@ -110,9 +113,9 @@ impl Interpreter {
     ) {
         if let Some(role_def) = self.registry().roles.get(role_name) {
             // Add accessor methods for public attributes
-            for (attr_name, is_public, ..) in &role_def.attributes {
-                if *is_public && !role_def.methods.contains_key(attr_name) {
-                    result.push(self.make_native_method_object(attr_name));
+            for attr in &role_def.attributes {
+                if attr.is_public && !role_def.methods.contains_key(&attr.name) {
+                    result.push(self.make_native_method_object(&attr.name));
                 }
             }
             // Add explicit methods
@@ -360,8 +363,8 @@ impl Interpreter {
         // Check for auto-generated attribute accessors (has $.x creates an accessor method).
         if results.is_empty() {
             let class_attrs = self.collect_class_attributes(&class_name);
-            for (attr_name, is_public, _, is_rw, ..) in &class_attrs {
-                if *is_public && attr_name == method_name {
+            for attr in &class_attrs {
+                if attr.is_public && attr.name == method_name {
                     results.push(Value::routine_parts(
                         Symbol::intern(&class_name),
                         Symbol::intern(method_name),
@@ -369,7 +372,7 @@ impl Interpreter {
                     ));
                     // Tag the routine with rw status if needed — currently Routine
                     // doesn't carry rw info, but we at least return a truthy result.
-                    let _ = is_rw; // suppress unused warning
+                    let _ = attr.is_rw; // suppress unused warning
                     break;
                 }
             }

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -355,9 +355,10 @@ impl Interpreter {
         let mut attributes = AttrMap::new();
         let mut deferred_defaults: Vec<super::attr_build_defaults::DeferredAttrDefault> =
             Vec::new();
-        for ((attr_name, _is_public, default, _is_rw, _, sigil, _), &attr_sym) in
-            plan.class_attrs.iter().zip(plan.attr_syms.iter())
-        {
+        for (attr, &attr_sym) in plan.class_attrs.iter().zip(plan.attr_syms.iter()) {
+            let attr_name = &attr.name;
+            let default = &attr.default;
+            let sigil = &attr.sigil;
             // A `@`/`%` attribute with no declared default that a bless named
             // argument provides would get an empty container here only for the
             // override loop below to immediately replace it — skip the throwaway
@@ -450,7 +451,7 @@ impl Interpreter {
                 match plan
                     .class_attrs
                     .iter()
-                    .position(|(n, ..)| n.as_str() == &**key)
+                    .position(|a| a.name.as_str() == &**key)
                 {
                     Some(i) => {
                         // Sigil-coerce like `dispatch_new` does: a `%`-attribute
@@ -458,7 +459,7 @@ impl Interpreter {
                         // `@`-attribute provided as a List becomes an Array
                         // (META6's `multi method new(*%items) { self.bless(|%items) }`
                         // passes `provides => ("Test::META" => "lib/...",)`).
-                        let sigil = plan.class_attrs[i].5;
+                        let sigil = plan.class_attrs[i].sigil;
                         attributes.insert(
                             plan.attr_syms[i],
                             Self::coerce_attr_value_by_sigil(value.clone(), sigil),
@@ -748,9 +749,8 @@ impl Interpreter {
     fn create_default_attr_slots(&mut self, class_name: &str) -> AttrMap {
         let mut attributes = AttrMap::new();
         if self.registry().classes.contains_key(class_name) {
-            for (attr_name, _is_public, _default, _is_rw, _, _, _) in
-                self.collect_class_attributes(class_name)
-            {
+            for attr in self.collect_class_attributes(class_name) {
+                let attr_name = attr.name;
                 let type_constraint = self.get_attr_type_constraint(class_name, &attr_name);
                 let val = match type_constraint.as_deref() {
                     Some(

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1316,8 +1316,8 @@ impl Interpreter {
                         return Ok(val.clone());
                     }
                 } else {
-                    for (attr_name, is_public, _, _, _, sigil, _) in &class_attrs {
-                        if *is_public && attr_name == method {
+                    for attr in &class_attrs {
+                        if attr.is_public && attr.name == method {
                             // Check for deprecated attribute accessor
                             if let Some(msg) = self.class_attribute_deprecated(&cn, method) {
                                 self.check_deprecation_for_method(method, &cn, &msg);
@@ -1329,7 +1329,7 @@ impl Interpreter {
                                 .unwrap_or(Value::NIL);
                             // For typed @/% attributes, register type metadata on the
                             // returned value so push/insert type enforcement works.
-                            if (*sigil == '@' || *sigil == '%')
+                            if (attr.sigil == '@' || attr.sigil == '%')
                                 && !val.is_nil()
                                 && self.container_type_metadata(&val).is_none()
                                 && let Some(tc) =
@@ -2519,7 +2519,8 @@ impl Interpreter {
     ) -> Vec<String> {
         let class_attrs = self.collect_class_attributes(class_name);
         let mut parts = Vec::new();
-        for (attr_name, is_public, _default, _is_rw, _is_required, sigil, _where) in &class_attrs {
+        for attr in &class_attrs {
+            let (attr_name, is_public, sigil) = (&attr.name, attr.is_public, attr.sigil);
             if !is_public {
                 continue;
             }
@@ -2534,7 +2535,7 @@ impl Interpreter {
                 // A `$`-sigil attribute is a Scalar container, so an aggregate
                 // it holds renders itemized: `Foo.new(x => $[1, 2])`. `@`/`%`
                 // attributes are the aggregate itself and stay bare.
-                let rendered = if *sigil == '$' {
+                let rendered = if sigil == '$' {
                     crate::builtins::methods_0arg::raku_repr::itemize_scalar_repr(val, rendered)
                 } else {
                     rendered
@@ -2578,7 +2579,7 @@ impl Interpreter {
         let class_attrs_info = self.collect_class_attributes(&class_name.resolve());
         let sigil_map: HashMap<String, char> = class_attrs_info
             .iter()
-            .map(|(name, _, _, _, _, sigil, _)| (name.clone(), *sigil))
+            .map(|attr| (attr.name.clone(), attr.sigil))
             .collect();
         let cn = class_name.resolve();
         for arg in args {

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -90,7 +90,7 @@ impl Interpreter {
                             self.registry().roles.get(role_name).is_some_and(|role| {
                                 role.attributes
                                     .iter()
-                                    .any(|(name, is_pub, ..)| name == method && *is_pub)
+                                    .any(|a| a.name == method && a.is_public)
                             })
                         });
                 if is_public {

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -82,7 +82,7 @@ impl Interpreter {
         let mro = self.class_mro(class_name);
         for cn in mro.iter() {
             if let Some(cd) = self.registry().classes.get(cn.as_str())
-                && cd.attributes.iter().any(|a| a.0 == attr)
+                && cd.attributes.iter().any(|a| a.name == attr)
             {
                 return Some(cn.resolve());
             }

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2429,9 +2429,7 @@ impl Interpreter {
                 } else {
                     class_attrs
                         .iter()
-                        .any(|(attr_name, is_public, _, is_rw, ..)| {
-                            *is_public && attr_name == method && *is_rw
-                        })
+                        .any(|a| a.is_public && a.name == method && a.is_rw)
                 };
                 if is_public_rw_accessor {
                     // User-defined rw method takes priority over simple accessor
@@ -2467,9 +2465,7 @@ impl Interpreter {
                     let is_public_accessor = if class_attrs.is_empty() {
                         false
                     } else {
-                        class_attrs
-                            .iter()
-                            .any(|(attr_name, is_public, ..)| *is_public && attr_name == method)
+                        class_attrs.iter().any(|a| a.is_public && a.name == method)
                     };
                     if is_public_accessor {
                         let current = attributes

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -42,11 +42,9 @@ impl Interpreter {
         {
             let base = role_name.split('[').next().unwrap_or(role_name);
             for candidate in [role_name, base] {
-                for (attr_name, is_public, _default, is_rw, _is_required, sigil, ..) in
-                    self.collect_role_attributes_for_class(candidate)
-                {
-                    if attr_name == method && is_public {
-                        if is_rw || sigil == '@' || sigil == '%' {
+                for attr in self.collect_role_attributes_for_class(candidate) {
+                    if attr.name == method && attr.is_public {
+                        if attr.is_rw || attr.sigil == '@' || attr.sigil == '%' {
                             return true;
                         }
                         found_attr = true;
@@ -869,10 +867,9 @@ impl Interpreter {
                 // No explicit method found — try auto-accessor for public `is rw` attributes
                 let class_attrs = self.collect_class_attributes(qualifier);
                 let mut found_rw = false;
-                for (attr_name, is_public, _default, is_rw, _is_required, sigil, ..) in &class_attrs
-                {
-                    if attr_name == actual_method && *is_public {
-                        if !is_rw && *sigil != '@' && *sigil != '%' {
+                for attr in &class_attrs {
+                    if attr.name == actual_method && attr.is_public {
+                        if !attr.is_rw && attr.sigil != '@' && attr.sigil != '%' {
                             return Err(RuntimeError::new(format!(
                                 "X::Assignment::RO: method '{}' is not rw",
                                 actual_method
@@ -996,9 +993,9 @@ impl Interpreter {
             // Check if the role attribute is public and rw before allowing assignment
             let cn = class_name.resolve();
             let role_attrs = self.collect_role_attributes_for_class(&cn);
-            for (attr_name, is_public, _default, is_rw, _, sigil, _) in &role_attrs {
-                if attr_name == method && *is_public {
-                    if !is_rw && *sigil != '@' && *sigil != '%' {
+            for attr in &role_attrs {
+                if attr.name == method && attr.is_public {
+                    if !attr.is_rw && attr.sigil != '@' && attr.sigil != '%' {
                         return Err(RuntimeError::new(format!(
                             "X::Assignment::RO: method '{}' is not rw",
                             method
@@ -1087,18 +1084,18 @@ impl Interpreter {
             let class_attrs = self.collect_class_attributes(&class_name.resolve());
             let mut found_public_rw = false;
             let mut attr_sigil = '$';
-            for (attr_name, is_public, _default, is_rw, _is_required, sigil, ..) in &class_attrs {
-                if attr_name == method && *is_public {
+            for attr in &class_attrs {
+                if attr.name == method && attr.is_public {
                     // @ and % attributes are containers whose elements are always writable
                     // through indexing, even without `is rw`.
-                    if !is_rw && *sigil != '@' && *sigil != '%' {
+                    if !attr.is_rw && attr.sigil != '@' && attr.sigil != '%' {
                         return Err(RuntimeError::new(format!(
                             "X::Assignment::RO: method '{}' is not rw",
                             method
                         )));
                     }
                     found_public_rw = true;
-                    attr_sigil = *sigil;
+                    attr_sigil = attr.sigil;
                     break;
                 }
             }

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -47,7 +47,7 @@ impl Interpreter {
             for cls in self.mro_readonly(cn_resolved) {
                 if let Some(cd) = self.registry().classes.get(&cls) {
                     for attr in &cd.attributes {
-                        if !seen.insert(attr.0.clone()) {
+                        if !seen.insert(attr.name.clone()) {
                             return false;
                         }
                     }
@@ -111,7 +111,18 @@ impl Interpreter {
                     p == "Any" || p == "Mu" || p == "Cool" || registry.classes.contains_key(p)
                 })
                 && class_def.attributes.iter().all(
-                    |(name, _, _, _is_required, type_constraint, sigil, _where_constraint)| {
+                    |attr| {
+                        let name = &attr.name;
+                        let sigil = &attr.sigil;
+                        // NOTE: this binds the tuple's former 5th positional
+                        // field (`is_required`), NOT an actual type
+                        // constraint (those live in `attribute_types`
+                        // separately) — a pre-existing mismatch between this
+                        // variable's name and what it holds, carried over
+                        // unchanged from the old positional tuple pattern
+                        // (ADR-0019 D2 struct conversion is a pure rename;
+                        // fixing this is out of scope here).
+                        let type_constraint = &attr.is_required;
                         // A constructible sigil/type shape:
                         // - `$`: a type constraint is allowed only when it is a
                         //   plain `type_matches_value`-checkable class/role/subset
@@ -380,7 +391,7 @@ impl Interpreter {
         let attr_syms = std::sync::Arc::new(
             class_attrs
                 .iter()
-                .map(|(n, ..)| crate::symbol::Symbol::intern(n))
+                .map(|a| crate::symbol::Symbol::intern(&a.name))
                 .collect::<Vec<_>>(),
         );
         // MRO-resolved `is Type` container traits for every declared attribute
@@ -388,9 +399,9 @@ impl Interpreter {
         let attr_is_types = std::sync::Arc::new(
             class_attrs
                 .iter()
-                .filter_map(|(n, ..)| {
-                    self.attribute_is_type_in_mro(cn_resolved, n)
-                        .map(|t| (n.clone(), t))
+                .filter_map(|a| {
+                    self.attribute_is_type_in_mro(cn_resolved, &a.name)
+                        .map(|t| (a.name.clone(), t))
                 })
                 .collect::<HashMap<String, String>>(),
         );
@@ -471,7 +482,7 @@ impl Interpreter {
             let registry = self.registry();
             if let Some(cd) = registry.classes.get(cls) {
                 for a in cd.attributes.iter() {
-                    owned.insert(a.0.clone());
+                    owned.insert(a.name.clone());
                 }
             }
         }

--- a/src/runtime/methods_object_attr_constraints.rs
+++ b/src/runtime/methods_object_attr_constraints.rs
@@ -128,9 +128,10 @@ impl Interpreter {
         attrs: &AttrMap,
     ) -> Result<(), RuntimeError> {
         let type_constraints = self.collect_attribute_type_constraints(class_name);
-        for (attr_name, _is_public, _default, _is_rw, _is_required, sigil, where_constraint) in
-            class_attrs_info
-        {
+        for attr in class_attrs_info {
+            let attr_name = &attr.name;
+            let sigil = &attr.sigil;
+            let where_constraint = &attr.where_constraint;
             if let Some(constraint) = type_constraints.get(attr_name)
                 && (constraint.starts_with(char::is_uppercase) || constraint.starts_with("::"))
                 && let Some(value) = attrs.get(attr_name)
@@ -255,9 +256,9 @@ impl Interpreter {
                         .entry(attr_name.clone())
                         .or_insert_with(|| smiley.clone());
                 }
-                for (attr_name, _, _, _, is_required, _, _) in &class_def.attributes {
-                    if is_required.is_some() {
-                        required_attrs.insert(attr_name.clone());
+                for attr in &class_def.attributes {
+                    if attr.is_required.is_some() {
+                        required_attrs.insert(attr.name.clone());
                     }
                 }
             }
@@ -342,9 +343,10 @@ impl Interpreter {
 
         // Initialize subclass attributes with defaults
         let class_attrs_info = self.collect_class_attributes(class_name);
-        for (attr_name, _is_public, default_expr, _is_rw, _is_required, sigil, _) in
-            &class_attrs_info
-        {
+        for attr in &class_attrs_info {
+            let attr_name = &attr.name;
+            let default_expr = &attr.default;
+            let sigil = &attr.sigil;
             if !extra_attrs.contains_key(attr_name) {
                 let default_val = if let Some(expr) = default_expr {
                     let result = self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())])?;

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -25,9 +25,12 @@ impl Interpreter {
         let type_constraints = &*plan.type_constraints;
 
         let attr_idx_of =
-            |name: &str| -> Option<usize> { class_attrs.iter().position(|(n, ..)| n == name) };
-        let sigil_of =
-            |name: &str| -> char { attr_idx_of(name).map(|i| class_attrs[i].5).unwrap_or('$') };
+            |name: &str| -> Option<usize> { class_attrs.iter().position(|a| a.name == name) };
+        let sigil_of = |name: &str| -> char {
+            attr_idx_of(name)
+                .map(|i| class_attrs[i].sigil)
+                .unwrap_or('$')
+        };
 
         // A custom BUILD replaces the default named-argument → attribute binding
         // for the attributes of the MRO layer that declares it: a provided
@@ -116,8 +119,9 @@ impl Interpreter {
         // `is_rw`, which must NOT gate construction (an unprovided `is rw`
         // attribute just gets its normal default, so it stays native).
         if !has_build {
-            for (attr_name, _, _, _is_rw, is_required, _, _) in class_attrs.iter() {
-                if let Some(reason) = is_required
+            for attr in class_attrs.iter() {
+                let attr_name = &attr.name;
+                if let Some(reason) = &attr.is_required
                     && !attrs.contains_key(attr_name)
                 {
                     let attr_full_name = format!("$!{}", attr_name);
@@ -141,8 +145,8 @@ impl Interpreter {
         // the interpreter's construction — fall through whether or not it was
         // provided (a shaped attribute must stay shaped even when assigned).
         // Only the empty-default `@`/`%` case (handled below) is native.
-        for (_attr_name, _, default_expr, _, _, sigil, _) in class_attrs.iter() {
-            if matches!(sigil, '@' | '%') && default_expr.is_some() {
+        for attr in class_attrs.iter() {
+            if matches!(attr.sigil, '@' | '%') && attr.default.is_some() {
                 return None;
             }
         }
@@ -152,11 +156,10 @@ impl Interpreter {
         // interpreter's constructor, so hand any such class over to it rather
         // than filling the defaults eagerly here.
         if has_build
-            && class_attrs.iter().zip(plan.attr_syms.iter()).any(
-                |((_, _, default_expr, _, _, _, _), &sym)| {
-                    default_expr.is_some() && !attrs.contains_key(sym)
-                },
-            )
+            && class_attrs
+                .iter()
+                .zip(plan.attr_syms.iter())
+                .any(|(attr, &sym)| attr.default.is_some() && !attrs.contains_key(sym))
         {
             return None;
         }
@@ -173,9 +176,10 @@ impl Interpreter {
         // that fast path made a 20k-iteration native-attr loop time out.
         let mut eval_error: Option<RuntimeError> = None;
         let mut typed_default_mismatch = false;
-        for ((attr_name, _is_public, default_expr, _, _, sigil, _), &attr_sym) in
-            class_attrs.iter().zip(plan.attr_syms.iter())
-        {
+        for (attr, &attr_sym) in class_attrs.iter().zip(plan.attr_syms.iter()) {
+            let attr_name = &attr.name;
+            let default_expr = &attr.default;
+            let sigil = &attr.sigil;
             if attrs.contains_key(attr_sym) {
                 continue;
             }
@@ -323,10 +327,9 @@ impl Interpreter {
         // `coerce_value_for_constraint` is the exact path the interpreter uses, so
         // the result is identical; the gate already excluded user-class targets,
         // so only built-in coercion logic runs here.
-        for ((attr_name, _, _, _, _, sigil, _), &attr_sym) in
-            class_attrs.iter().zip(plan.attr_syms.iter())
-        {
-            if *sigil != '$' {
+        for (attr, &attr_sym) in class_attrs.iter().zip(plan.attr_syms.iter()) {
+            let attr_name = &attr.name;
+            if attr.sigil != '$' {
                 continue;
             }
             if let Some(tc) = type_constraints.get(attr_name)
@@ -349,10 +352,9 @@ impl Interpreter {
         // container flattens it (just like `my @a = |@x` yields an `Array`, not a
         // `Slip`), so materialize it into a plain mutable `Array` here. Without
         // this the attribute keeps a `Slip` whose `.^name` is `Slip`.
-        for ((attr_name, _, _, _, _, sigil, _), &attr_sym) in
-            class_attrs.iter().zip(plan.attr_syms.iter())
-        {
-            if *sigil != '@' {
+        for (attr, &attr_sym) in class_attrs.iter().zip(plan.attr_syms.iter()) {
+            let attr_name = &attr.name;
+            if attr.sigil != '@' {
                 continue;
             }
             if let Some(ValueView::Slip(items) | ValueView::Seq(items)) =
@@ -365,9 +367,9 @@ impl Interpreter {
                 attrs.insert(attr_sym, flattened);
             }
         }
-        for ((attr_name, _, _, _, _, sigil, _), &attr_sym) in
-            class_attrs.iter().zip(plan.attr_syms.iter())
-        {
+        for (attr, &attr_sym) in class_attrs.iter().zip(plan.attr_syms.iter()) {
+            let attr_name = &attr.name;
+            let sigil = attr.sigil;
             if !matches!(sigil, '@' | '%') {
                 continue;
             }
@@ -375,7 +377,7 @@ impl Interpreter {
                 continue;
             };
             if let Some(val) = attrs.get(attr_name).cloned() {
-                match self.finalize_typed_container_attr(attr_name, *sigil, &elem_type, val) {
+                match self.finalize_typed_container_attr(attr_name, sigil, &elem_type, val) {
                     // Hashes embed the element type in `HashData`, so store the
                     // tagged value back into the attrs that move into the instance.
                     Ok(tagged) => {
@@ -401,7 +403,7 @@ impl Interpreter {
         // provided/defaulted value that fails its `where` is rejected here, and a
         // later BUILD/TWEAK that would "fix" it never runs. `class_attrs` is the
         // same `ClassAttributeDef` slice the interpreter uses.
-        let has_where = class_attrs.iter().any(|(.., where_c)| where_c.is_some());
+        let has_where = class_attrs.iter().any(|a| a.where_constraint.is_some());
         if has_where
             && let Err(e) =
                 self.enforce_attribute_where_constraints(cn_resolved, class_attrs, &attrs)
@@ -454,8 +456,9 @@ impl Interpreter {
             // exactly where the full constructor does its post-BUILD required
             // check. A still-unset attribute (`None` or `Nil`) raises
             // `X::Attribute::Required` with the same message and reason.
-            for (attr_name, _, _, _, is_required, _, _) in class_attrs.iter() {
-                if let Some(reason) = is_required {
+            for attr in class_attrs.iter() {
+                let attr_name = &attr.name;
+                if let Some(reason) = &attr.is_required {
                     // The pre-BUILD seed for an unset untyped attribute is
                     // the Any type object (not Nil), so treat it as unset too.
                     let is_set = !matches!(

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1654,15 +1654,13 @@ impl Interpreter {
                         _ => None,
                     })
                     .collect();
-                for (attr_name, _is_public, _default, _is_rw, is_required, _sigil, _) in
-                    &class_attrs_info
-                {
-                    if let Some(reason) = is_required {
+                for attr in &class_attrs_info {
+                    if let Some(reason) = &attr.is_required {
                         let has_build = self.class_has_method(class_key, "BUILD");
                         // If class has BUILD, BUILD handles attribute setting,
                         // so we skip required check here (BUILD may set defaults)
-                        if !has_build && !provided_attr_names.contains(attr_name.as_str()) {
-                            let attr_full_name = format!("$!{}", attr_name);
+                        if !has_build && !provided_attr_names.contains(attr.name.as_str()) {
+                            let attr_full_name = format!("$!{}", attr.name);
                             return Err(RuntimeError::attribute_required(
                                 &attr_full_name,
                                 reason.as_deref(),
@@ -1673,7 +1671,7 @@ impl Interpreter {
                 // Build a sigil map for later coercion
                 let sigil_map: HashMap<String, char> = class_attrs_info
                     .iter()
-                    .map(|(name, _, _, _, _, sigil, _)| (name.clone(), *sigil))
+                    .map(|attr| (attr.name.clone(), attr.sigil))
                     .collect();
                 // Attribute type constraints (MRO-wide), used to coerce a provided
                 // value for a coercion-typed attribute (`has Int() $.x`).
@@ -1805,10 +1803,9 @@ impl Interpreter {
                 // `Array`, not a `Slip`), so materialize it into a plain mutable
                 // `Array` here. Without this the attribute keeps a `Slip` whose
                 // `.^name` is `Slip` and whose re-iteration differs from raku's `Array`.
-                for (attr_name, _is_public, _default, _is_rw, _is_required, sigil, _) in
-                    &class_attrs_info
-                {
-                    if *sigil == '@'
+                for attr in &class_attrs_info {
+                    let attr_name = &attr.name;
+                    if attr.sigil == '@'
                         && let Some(ValueView::Slip(items) | ValueView::Seq(items)) =
                             attrs.get(attr_name).map(Value::view)
                     {
@@ -1821,10 +1818,9 @@ impl Interpreter {
                 }
                 // For @-sigiled attributes with shaped array declarations,
                 // convert user-provided values to shaped arrays preserving shape.
-                for (attr_name, _is_public, default, _is_rw, _is_required, sigil, _) in
-                    &class_attrs_info
-                {
-                    if *sigil == '@'
+                for attr in &class_attrs_info {
+                    let (attr_name, default) = (&attr.name, &attr.default);
+                    if attr.sigil == '@'
                         && let Some(dims) = Self::extract_shape_from_default(default.as_ref())
                         && let Some(val) = attrs.get(attr_name)
                         && !matches!(val.view(), ValueView::Array(_, ArrayKind::Shaped))
@@ -1890,9 +1886,13 @@ impl Interpreter {
                             .insert(format!("{}::{}", class_key, name), value.clone());
                     }
                 }
-                for (attr_name, _is_public, default, _is_rw, _is_required, sigil, _) in
-                    class_attrs_info.clone()
-                {
+                for attr in class_attrs_info.clone() {
+                    let ClassAttributeDef {
+                        name: attr_name,
+                        default,
+                        sigil,
+                        ..
+                    } = attr;
                     if attrs.contains_key(&attr_name) {
                         continue;
                     }
@@ -1982,7 +1982,7 @@ impl Interpreter {
                     } else {
                         pruned_info = class_attrs_info
                             .iter()
-                            .filter(|a| !deferred_names.contains(a.0.as_str()))
+                            .filter(|a| !deferred_names.contains(a.name.as_str()))
                             .cloned()
                             .collect();
                         let mut pruned = attrs.clone();
@@ -2042,10 +2042,9 @@ impl Interpreter {
                 // Check required attributes after all BUILDs have run
                 if has_build_phase {
                     let attrs = inv_cell.to_map();
-                    for (attr_name, _is_public, _default, _is_rw, is_required, _sigil, _) in
-                        &class_attrs_info
-                    {
-                        if let Some(reason) = is_required {
+                    for attr in &class_attrs_info {
+                        let attr_name = &attr.name;
+                        if let Some(reason) = &attr.is_required {
                             let attr_val = attrs.get(attr_name.as_str());
                             // The pre-BUILD seed for an unset untyped
                             // attribute is the Any type object, not Nil.
@@ -2115,11 +2114,13 @@ impl Interpreter {
                             _ => None,
                         })
                         .collect();
-                    for (
-                        declaring_class,
-                        (attr_name, _is_public, default, _is_rw, _is_required, sigil, _),
-                    ) in per_class_attrs
-                    {
+                    for (declaring_class, attr) in per_class_attrs {
+                        let ClassAttributeDef {
+                            name: attr_name,
+                            default,
+                            sigil,
+                            ..
+                        } = attr;
                         let qualified_key = format!("{}\0{}", declaring_class, attr_name);
                         if attrs.contains_key(&qualified_key) {
                             continue;
@@ -2222,7 +2223,8 @@ impl Interpreter {
                 // own metadata and are skipped. Done here against the final
                 // `attrs` so the Arc-pointer-keyed metadata survives into the
                 // instance (a clone shares the same backing Arc).
-                for (attr_name, _, _, _, _, sigil, _) in &class_attrs_info {
+                for attr in &class_attrs_info {
+                    let (attr_name, sigil) = (&attr.name, attr.sigil);
                     if !matches!(sigil, '@' | '%') {
                         continue;
                     }
@@ -2245,7 +2247,7 @@ impl Interpreter {
                     }
                     if let Some(val) = attrs.get(attr_name).cloned() {
                         let tagged =
-                            self.finalize_typed_container_attr(attr_name, *sigil, &elem_type, val)?;
+                            self.finalize_typed_container_attr(attr_name, sigil, &elem_type, val)?;
                         attrs.insert(attr_name.clone(), tagged);
                     }
                 }

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -210,8 +210,8 @@ impl Interpreter {
         // Read: look up the attribute in the qualifier class's attribute definitions
         if args.is_empty() {
             let class_attrs = self.collect_class_attributes(qualifier);
-            for (attr_name, is_public, ..) in &class_attrs {
-                if *is_public && attr_name == actual_method {
+            for attr in &class_attrs {
+                if attr.is_public && attr.name == actual_method {
                     return Some(Ok(attributes
                         .as_map()
                         .get(actual_method)

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -440,15 +440,20 @@ pub(crate) use methods_raku_dispatch::container_needs_raku_dispatch;
 
 use self::unicode::{check_unicode_property, check_unicode_property_with_args};
 
-pub(crate) type ClassAttributeDef = (
-    String,
-    bool,
-    Option<Expr>,
-    bool,
-    Option<Option<String>>,
-    char,
-    Option<Expr>,
-);
+/// One class/role attribute declaration.
+///
+/// Field order matches the historical tuple layout:
+/// `(attr_name, is_public, default, is_rw, is_required, sigil, where_constraint)`.
+#[derive(Debug, Clone)]
+pub(crate) struct ClassAttributeDef {
+    pub(crate) name: String,
+    pub(crate) is_public: bool,
+    pub(crate) default: Option<Expr>,
+    pub(crate) is_rw: bool,
+    pub(crate) is_required: Option<Option<String>>,
+    pub(crate) sigil: char,
+    pub(crate) where_constraint: Option<Expr>,
+}
 
 /// The set of read-only variable names (`readonly_vars`), and the type of a
 /// snapshot taken by `save_readonly_vars`.

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -244,7 +244,7 @@ impl Interpreter {
         }
         self.collect_class_attributes(class_name)
             .iter()
-            .any(|(attr_name, is_public, ..)| *is_public && attr_name == method_name)
+            .any(|a| a.is_public && a.name == method_name)
     }
 
     pub(super) fn resolve_class_stub_requirements(

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -300,15 +300,17 @@ impl Interpreter {
                     // Resolve handles before taking mutable borrow on class_def
                     let resolved = self.resolve_handle_specs_to_names(handles, &attr_var_name);
                     if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
-                        class_def.attributes.push((
-                            attr_name_str.clone(),
-                            *is_public,
-                            default.clone(),
-                            *is_rw,
-                            is_required.clone(),
-                            *sigil,
-                            where_constraint.as_ref().map(|wc| wc.as_ref().clone()),
-                        ));
+                        class_def.attributes.push(ClassAttributeDef {
+                            name: attr_name_str.clone(),
+                            is_public: *is_public,
+                            default: default.clone(),
+                            is_rw: *is_rw,
+                            is_required: is_required.clone(),
+                            sigil: *sigil,
+                            where_constraint: where_constraint
+                                .as_ref()
+                                .map(|wc| wc.as_ref().clone()),
+                        });
                         if *is_alias {
                             class_def.alias_attributes.insert(attr_name_str.clone());
                         }
@@ -396,7 +398,7 @@ impl Interpreter {
                             .extend(mdefs.clone());
                     }
                     for attr in &parent_role.attributes {
-                        if !all_attributes.iter().any(|a| a.0 == attr.0) {
+                        if !all_attributes.iter().any(|a| a.name == attr.name) {
                             all_attributes.push(attr.clone());
                         }
                     }
@@ -426,7 +428,7 @@ impl Interpreter {
                 }
             }
             for attr in all_attributes {
-                if !class_def.attributes.iter().any(|a| a.0 == attr.0) {
+                if !class_def.attributes.iter().any(|a| a.name == attr.name) {
                     class_def.attributes.push(attr);
                 }
             }
@@ -554,7 +556,8 @@ impl Interpreter {
         let mut max_bytes = 0u32;
         let mut raw_value: u64 = 0;
 
-        for (attr_name, _is_public, _default, _is_rw, _, _, _) in &class_attrs {
+        for attr in &class_attrs {
+            let attr_name = &attr.name;
             if let Some(val) = named_args.get(attr_name) {
                 let int_val = match val.view() {
                     ValueView::Int(i) => i as u64,
@@ -579,7 +582,9 @@ impl Interpreter {
         // Build attributes from shared bytes
         let bytes = raw_value.to_le_bytes();
         let mut attrs = HashMap::new();
-        for (attr_name, _is_public, default, _is_rw, _, _, _) in &class_attrs {
+        for attr in &class_attrs {
+            let attr_name = &attr.name;
+            let default = &attr.default;
             if let Some(type_constraint) = self.get_attr_type_constraint(class_name, attr_name) {
                 let byte_width = Self::native_type_byte_width(&type_constraint);
                 let val = match byte_width {
@@ -808,8 +813,7 @@ impl Interpreter {
                     if let Some(parent_role) = self.registry().roles.get(&parent_role_name).cloned()
                     {
                         for attr in &parent_role.attributes {
-                            // ClassAttributeDef is a tuple; field 0 is the attribute name
-                            if !all_attributes.iter().any(|a| a.0 == attr.0) {
+                            if !all_attributes.iter().any(|a| a.name == attr.name) {
                                 all_attributes.push(attr.clone());
                             }
                         }

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -109,7 +109,7 @@ impl Interpreter {
         let mut class_own_attrs: HashSet<String> = class_def
             .attributes
             .iter()
-            .map(|(n, ..)| n.clone())
+            .map(|a| a.name.clone())
             .collect();
         class_own_attrs.extend(own_attribute_names.iter().map(|s| s.resolve()));
         let mut cx = ClassBodyCx {

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -24,7 +24,7 @@ impl Interpreter {
             return Ok(());
         };
         // Already declared (e.g. a duplicate EVAL): no-op rather than abort.
-        if class_def.attributes.iter().any(|(n, ..)| n == attr_name) {
+        if class_def.attributes.iter().any(|a| &a.name == attr_name) {
             return Ok(());
         }
         self.validate_static_attribute_default(
@@ -35,15 +35,15 @@ impl Interpreter {
             spec.type_smiley.as_deref(),
         )?;
         let effective_is_rw = !spec.is_readonly && spec.is_rw;
-        class_def.attributes.push((
-            attr_name.clone(),
-            spec.is_public,
-            spec.default.clone(),
-            effective_is_rw,
-            spec.is_required.clone(),
-            spec.sigil,
-            None,
-        ));
+        class_def.attributes.push(ClassAttributeDef {
+            name: attr_name.clone(),
+            is_public: spec.is_public,
+            default: spec.default.clone(),
+            is_rw: effective_is_rw,
+            is_required: spec.is_required.clone(),
+            sigil: spec.sigil,
+            where_constraint: None,
+        });
         if let Some(tc) = &spec.type_constraint {
             let resolved_tc = tc.replace("::?CLASS", class_name);
             class_def
@@ -211,7 +211,7 @@ impl Interpreter {
             .class_def
             .attributes
             .iter()
-            .any(|(n, ..)| n == &attr_name_str)
+            .any(|a| a.name == attr_name_str)
         {
             self.set_current_package(cx.saved_package.clone());
             self.env = cx.saved_env.clone();
@@ -221,15 +221,15 @@ impl Interpreter {
             )));
         }
         let effective_is_rw = !*is_readonly && (*is_rw || (cx.class_is_rw && *is_public));
-        cx.class_def.attributes.push((
-            attr_name_str.clone(),
-            *is_public,
-            default.clone(),
-            effective_is_rw,
-            is_required.clone(),
-            *sigil,
-            where_constraint.as_ref().map(|wc| wc.as_ref().clone()),
-        ));
+        cx.class_def.attributes.push(ClassAttributeDef {
+            name: attr_name_str.clone(),
+            is_public: *is_public,
+            default: default.clone(),
+            is_rw: effective_is_rw,
+            is_required: is_required.clone(),
+            sigil: *sigil,
+            where_constraint: where_constraint.as_ref().map(|wc| wc.as_ref().clone()),
+        });
         // Store `is default(...)` trait value for this attribute.
         // When is_default is set, the evaluated value is stored for
         // .VAR.default and Nil-restore behavior.

--- a/src/runtime/registration_class_body_does.rs
+++ b/src/runtime/registration_class_body_does.rs
@@ -68,7 +68,7 @@ impl Interpreter {
             .unwrap_or_else(|| "c".to_string());
         let compose_submethods_does = cx.class_lang_rev == "c" && role_lang_rev_does == "c";
         for attr in &role.attributes {
-            if !cx.class_def.attributes.iter().any(|(n, ..)| n == &attr.0) {
+            if !cx.class_def.attributes.iter().any(|a| a.name == attr.name) {
                 cx.class_def.attributes.push(attr.clone());
             }
         }

--- a/src/runtime/registration_class_compose.rs
+++ b/src/runtime/registration_class_compose.rs
@@ -181,7 +181,7 @@ impl Interpreter {
                 .insert(p.clone(), v.clone());
         }
         for attr in &role.attributes {
-            if !cx.class_def.attributes.iter().any(|(n, ..)| n == &attr.0) {
+            if !cx.class_def.attributes.iter().any(|a| a.name == attr.name) {
                 cx.class_def.attributes.push(attr.clone());
             }
         }

--- a/src/runtime/registration_class_compose_body.rs
+++ b/src/runtime/registration_class_compose_body.rs
@@ -339,7 +339,7 @@ impl Interpreter {
                         Vec::new()
                     };
                     for attr in &parent_role.attributes {
-                        if !cx.class_def.attributes.iter().any(|(n, ..)| n == &attr.0) {
+                        if !cx.class_def.attributes.iter().any(|a| a.name == attr.name) {
                             cx.class_def.attributes.push(attr.clone());
                         }
                     }

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -97,7 +97,7 @@ impl Interpreter {
             .role_def
             .attributes
             .iter()
-            .find(|(n, ..)| n == &attr_name_str)
+            .find(|a| a.name == attr_name_str)
         {
             // The attribute already exists from a parent role composition.
             // Record the conflict; the existing one came from a composed role.
@@ -110,7 +110,7 @@ impl Interpreter {
                         parents.iter().find(|p| {
                             let base = p.split_once('[').map(|(b, _)| b).unwrap_or(p.as_str());
                             self.registry().roles.get(base).is_some_and(|r| {
-                                r.attributes.iter().any(|(n, ..)| n == &attr_name_str)
+                                r.attributes.iter().any(|a| a.name == attr_name_str)
                             })
                         })
                     })
@@ -126,15 +126,15 @@ impl Interpreter {
         // Apply role-level `is rw`: same logic as class_is_rw
         // `is readonly` on individual attributes overrides `is rw` on the role
         let effective_is_rw = !*is_readonly && (*is_rw || (cx.role_is_rw && *is_public));
-        cx.role_def.attributes.push((
-            attr_name_str.clone(),
-            *is_public,
-            default.clone(),
-            effective_is_rw,
-            is_required.clone(),
-            *sigil,
-            where_constraint.as_ref().map(|wc| wc.as_ref().clone()),
-        ));
+        cx.role_def.attributes.push(ClassAttributeDef {
+            name: attr_name_str.clone(),
+            is_public: *is_public,
+            default: default.clone(),
+            is_rw: effective_is_rw,
+            is_required: is_required.clone(),
+            sigil: *sigil,
+            where_constraint: where_constraint.as_ref().map(|wc| wc.as_ref().clone()),
+        });
         let attr_var_name = if *is_public {
             format!(".{}", attr_name_str)
         } else {
@@ -317,15 +317,15 @@ impl Interpreter {
             Vec::new()
         };
         for attr in &role.attributes {
-            if cx.role_def.attributes.iter().any(|(n, ..)| n == &attr.0) {
+            if cx.role_def.attributes.iter().any(|a| a.name == attr.name) {
                 // Already present. Only a real conflict if both
                 // sides declared it directly (vs. inherited from
                 // a shared ancestor in a diamond). Skip otherwise.
-                let parent_owns = role.own_attribute_names.contains(&attr.0);
-                let current_owns = cx.role_def.own_attribute_names.contains(&attr.0);
+                let parent_owns = role.own_attribute_names.contains(&attr.name);
+                let current_owns = cx.role_def.own_attribute_names.contains(&attr.name);
                 if parent_owns && current_owns {
                     cx.role_def.attribute_conflicts.push((
-                        attr.0.clone(),
+                        attr.name.clone(),
                         name.to_string(),
                         base_role_name.to_string(),
                     ));

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -260,7 +260,7 @@ impl Interpreter {
         let has_expr_default = role_def
             .attributes
             .iter()
-            .any(|(_, _, default, ..)| default.is_some());
+            .any(|attr| attr.default.is_some());
         if has_expr_default {
             role_def.captured_env = Some(self.env.flatten());
         }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -398,7 +398,15 @@ impl Interpreter {
             // type-object / value default: `in`/`out`/`err` => IO::Pipe,
             // os-error => Str, signal => Any, exitcode/pid => Nil, command => [].
             let proc_attr = |name: &str, sigil: char, default: Option<Expr>| -> ClassAttributeDef {
-                (name.to_string(), true, default, false, None, sigil, None)
+                ClassAttributeDef {
+                    name: name.to_string(),
+                    is_public: true,
+                    default,
+                    is_rw: false,
+                    is_required: None,
+                    sigil,
+                    where_constraint: None,
+                }
             };
             let nil_default = || Some(Expr::Literal(Value::NIL));
             let mut attribute_types = HashMap::new();

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -260,7 +260,10 @@ impl Interpreter {
                 }
                 saved
             });
-            for (attr_name, _is_public, default_expr, _, _, sigil, _) in &role.attributes {
+            for attr in &role.attributes {
+                let attr_name = &attr.name;
+                let default_expr = &attr.default;
+                let sigil = &attr.sigil;
                 if attributes.contains_key(attr_name.as_str()) {
                     continue;
                 }

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -437,11 +437,8 @@ impl Interpreter {
                 .get(role_name)
                 .is_some_and(|params| !params.is_empty());
             if !role_args.is_empty() && !has_type_params {
-                let public_attr_count = role
-                    .attributes
-                    .iter()
-                    .filter(|(_, is_public, ..)| *is_public)
-                    .count();
+                let public_attr_count =
+                    role.attributes.iter().filter(|attr| attr.is_public).count();
                 if public_attr_count != 1 {
                     return Err(RuntimeError::role_initialization(role_name));
                 }
@@ -459,9 +456,10 @@ impl Interpreter {
             } else {
                 None
             };
-            for (idx, (attr_name, _is_public, default_expr, _, _, sigil, _)) in
-                role.attributes.iter().enumerate()
-            {
+            for (idx, attr) in role.attributes.iter().enumerate() {
+                let attr_name = &attr.name;
+                let default_expr = &attr.default;
+                let sigil = &attr.sigil;
                 let value = if let Some(arg) = role_args.get(idx) {
                     arg.clone()
                 } else if let Some(default_expr) = default_expr {
@@ -536,7 +534,7 @@ impl Interpreter {
         let attr_names: Vec<String> = role
             .attributes
             .iter()
-            .map(|(name, ..)| name.clone())
+            .map(|attr| attr.name.clone())
             .collect();
         if let ValueView::Mixin(_, mixins) = target.view() {
             for attr_name in &attr_names {

--- a/todo/tickets/native-ctor-gate-reads-is-required-as-type-constraint.md
+++ b/todo/tickets/native-ctor-gate-reads-is-required-as-type-constraint.md
@@ -1,0 +1,73 @@
+# Native default-constructor gate reads `is_required` where it means to read a type constraint
+
+`Interpreter::is_native_default_constructible` in `src/runtime/methods_object.rs` decides,
+per attribute, whether a class's default `.new` can take the fully-native fast path instead
+of falling through to the interpreter-driven constructor. Its per-attribute closure binds:
+
+```rust
+let type_constraint = &attr.is_required;
+```
+
+`attr` is a `ClassAttributeDef` (`src/runtime/mod.rs`). `is_required` is
+`Option<Option<String>>` — `None` = not required, `Some(None)` = required, `Some(reason)` =
+required with a reason string. The variable is then used a few lines below as if it held the
+attribute's *type constraint* (a `Option<String>` naming a type like `Int` or `Str`), which is
+a completely different piece of data that actually lives in the registry's
+`attribute_types: HashMap<(String, String), String>` side table, keyed by `(class, attr)` —
+not on `ClassAttributeDef` at all.
+
+## History
+
+This is not a new bug. It was carried over unchanged from the original 7-tuple shape of
+`ClassAttributeDef` (`(name, is_public, default, is_rw, is_required, sigil, where_constraint)`):
+the closure destructured the tuple positionally as
+`|(name, _, _, _is_required, type_constraint, sigil, _where_constraint)|`, binding the tuple's
+5th positional field (`is_required`) to a variable literally named `type_constraint`. ADR-0019
+D2b's mechanical tuple→struct conversion (`refactor(runtime): turn ClassAttributeDef into a
+named struct`) preserved this exactly rather than fixing it, per that PR's "zero behavior
+change" scope — it left the struct-field equivalent `&attr.is_required` with the same
+misleading local name and an inline `NOTE:` comment pointing here.
+
+## Effect
+
+Needs investigation to characterize precisely, but the shape of the bug: the "does this
+attribute have a type constraint that the native ctor can check" gate is actually testing
+"is this attribute `is required`", which means:
+
+- An attribute with a real type constraint but no `is required` trait skips whatever
+  `is_simple_native_ctor_constraint`-style validation the type-constraint branch was meant to
+  apply (since `type_constraint` will be `None` there, as `is_required` defaults to `None`).
+- An attribute that IS `is required` (regardless of type) gets routed through whatever
+  branch the code takes when `type_constraint` looks like `Some(_)`/`Some(None)` — i.e. is
+  required-ness is spuriously read as "has *some* type constraint value", including the
+  `Some(None)` (required-without-reason) case looking exactly like a `Some(_)` type
+  constraint that happens to be empty.
+
+Net effect: `is_native_default_constructible`'s per-attribute gate may incorrectly admit or
+reject a class for the native fast constructor path based on `is required`-ness instead of
+actual type constraints, for classes with typed attributes and/or required attributes. Whether
+this is currently masked by other checks in the same function (the type-check the fast path
+itself performs once it thinks it's "native-constructible"), or produces a wrong result some
+observer can see (e.g. a required-but-untyped attribute wrongly treated as needing a type
+check, or a genuinely-typed non-required attribute skipping validation it should get) needs a
+minimal repro to pin down.
+
+## Where to look
+
+- `src/runtime/methods_object.rs`, `is_native_default_constructible`, the
+  `class_def.attributes.iter().all(|attr| { ... })` closure (~line 113 onward at the time of
+  writing) — read the branches that consume `type_constraint` right after the `NOTE:` comment,
+  and compare against what `registry.attribute_types.get(&(cls.clone(), attr.name.clone()))`
+  would actually report.
+- The native fast-constructor path itself (nearby in the same file / `methods_object_default_ctor.rs`)
+  to see whether it separately re-validates types, which would explain why this hasn't been
+  caught by roast yet (i.e. the gate is over/under-permissive but a second correct check downstream
+  papers over it — or doesn't).
+
+## Suggested minimal repro starting point
+
+A class with one attribute that has both a real type constraint and no `is required`, plus a
+sibling class with an `is required` untyped attribute, exercised through `.new` in a way that
+would observably differ between the native and interpreter constructor paths (e.g. a bad-typed
+value assigned via `BUILD`-adjacent means, or timing/side-effect visible only on the interpreter
+path). Compare `raku` and `mutsu` behavior once a concrete divergence is found.


### PR DESCRIPTION
## Summary
- Prerequisite for ADR-0019 D2b ("type full attribute descriptors"): a later slice needs to attach a `CompiledDeclExpr` child chunk to an attribute's default/constraint expressions (D2c), which is impractical against a bare positional tuple.
- Converts `ClassAttributeDef` (`src/runtime/mod.rs`) from a 7-element tuple type alias into a named struct with the same field order (`name, is_public, default, is_rw, is_required, sigil, where_constraint`), and updates every construction/destructuring site across the codebase (31 files under `src/runtime/`). Pure mechanical rename — zero behavior change.
- While converting `is_native_default_constructible` (`src/runtime/methods_object.rs`), a pre-existing mismatch surfaced: the old tuple pattern bound the tuple's `is_required` field to a variable named `type_constraint` and used it as though it held an actual type-constraint string. Preserved exactly (out of scope for a zero-behavior-change PR) and filed as `todo/tickets/native-ctor-gate-reads-is-required-as-type-constraint.md` for a follow-up.

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check`
- [x] `cargo test --lib` — 670 passed
- [x] `make test` — full `t/` suite (27,765 tests), clean pass
- [x] Targeted roast: `S12-attributes/*`, `S12-class/*`, `S14-roles/*`, `6.c/S12-class/mro-6c.t`, `6.c/S14-roles/*` — only the same two pre-existing non-whitelisted failures as before this change (`S12-attributes/trusts.t`, `S12-class/open_closed.t`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)