### PR TITLE
fix(state): a per-clone reset must drop the cross-thread cell too

### DIFF
--- a/news/2026-08/state-reset-must-reach-the-cross-thread-cell.md
+++ b/news/2026-08/state-reset-must-reach-the-cross-thread-cell.md
@@ -1,0 +1,60 @@
+# A `state` reset must reach the cross-thread cell
+
+Raku clones a block every time its enclosing block runs, so a `state`
+declared inside a loop body restarts on every execution of the loop
+*statement*. mutsu implements that by dropping the variable from the state
+store at loop-statement entry (`reset_state_locals_in_range`), which makes the
+next `StateVarInit` re-run the initializer.
+
+That drop reached only half the storage. Once any thread has been spawned,
+`StateVarInit` stops resolving a `state` through the local `state_vars` map and
+resolves it through a shared `ContainerRef` cell in `shared_vars` instead — the
+cell that lets concurrent calls to one routine (`await (^3).map: { start f() }`)
+observe one live container. `remove_state_var` dropped the local entry and left
+the cell in place, so from the first `start` onward the reset was a silent
+no-op and a loop-body `state` kept counting up across every later execution of
+its statement:
+
+```raku
+class TC {
+    method m(*@in) { my @r; for @in { @r.push(++state $s) }; @r.join(',') }
+}
+say TC.m(1, 2, 3);                  # 1,2,3
+say await start { TC.m(1, 2, 3) };  # 1,2,3
+say TC.m(1, 2, 3);                  # was 4,5,6 — raku says 1,2,3
+```
+
+`remove_state_var` now drops the shared cell too, under the same normalized key
+`StateVarInit` installs it with.
+
+## Why it surfaced now
+
+The counter this broke in practice is Cro's, in `Cro.compose`:
+
+```raku
+for flat @components-in Z @components-in[1..*] -> $comp, $next {
+    ++state $split;
+    ...
+    return Cro.compose: |@components-in[^$split], Cro::ConnectionManager.new(...), ...;
+}
+```
+
+`$split` is the index the connection manager gets spliced in at. Once
+`Cro::Service.start` had spawned a thread, the next `compose` began with the
+previous call's `$split` rather than 0, so the recursive call spliced the
+manager in one position later each time and handed itself a component list one
+element longer. That recursion is unbounded: Cro's `t/http-middleware.rakutest`
+aborted the whole file with a stack overflow, with no TAP output at all,
+as soon as a second server was built in one process.
+
+With the reset repaired the file runs to completion again — 10 of its 11
+subtests pass, leaving only the early-response body blocker already tracked in
+`todo/tickets/cro-middleware-await-body-text-dies-coercing-any-into-promise.md`.
+
+The regression came in with the 2026-08-04 `state` work (`a state is one
+container shared by its clone's invocations`): clearing the ambient scope for a
+method body gave every invocation of a method one stable state key, which is
+correct, and in doing so removed the accidental per-caller key variation that
+had been papering over the missing cell drop.
+
+Pinned by four new cases in `t/state-var-per-block-clone.t`.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -291,8 +291,25 @@ impl Interpreter {
     /// each execution of the statement is a fresh clone of its body block
     /// (Raku clones a block each time its enclosing block runs), so `state`
     /// declarations inside the body re-initialize.
+    ///
+    /// The cross-thread cell (`get_or_init_shared_state_cell`) must go too.
+    /// Once any thread has been spawned, `StateVarInit` resolves the variable
+    /// through that cell and ignores the local store entirely, so dropping only
+    /// the local entry left the reset a silent no-op: a loop-body `state` kept
+    /// counting up across later executions of its enclosing statement — Cro's
+    /// `Cro.compose` recursed on a `state $split` that never restarted at 1 and
+    /// blew the stack once a `Cro::Service.start` had run.
     pub(crate) fn remove_state_var(&mut self, key: &str) {
         self.state_vars.remove(key);
+        self.shared_vars.remove(&Self::shared_state_cell_key(key));
+    }
+
+    /// The `shared_vars` key under which `key`'s cross-thread `state` cell lives.
+    pub(crate) fn shared_state_cell_key(scoped_key: &str) -> String {
+        format!(
+            "__mutsu_shared_state::{}",
+            crate::runtime::Interpreter::normalize_state_key(scoped_key)
+        )
     }
 
     pub(crate) fn set_state_var(&mut self, key: String, value: Value) {

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -89,10 +89,7 @@ impl Interpreter {
             // `scoped_key` alone differs between `start f()` and a direct `f()`).
             // Normalize away the `/<n>` candidate suffix and the trailing
             // `@<ip>` position so both paths share one cell.
-            let shared_key = format!(
-                "__mutsu_shared_state::{}",
-                crate::runtime::Interpreter::normalize_state_key(&scoped_key)
-            );
+            let shared_key = Self::shared_state_cell_key(&scoped_key);
             let cell = self.get_or_init_shared_state_cell(&shared_key, initial);
             // Keep the local store pointing at the cell too, so the exit-time
             // writeback and any non-cell reader observe the same Arc.

--- a/t/state-var-per-block-clone.t
+++ b/t/state-var-per-block-clone.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 26;
+plan 30;
 
 # Raku clones a block every time its ENCLOSING block runs, and a `state` cell —
 # named, or the implicit one behind a bare `$` — belongs to the CLONE. So a
@@ -129,4 +129,21 @@ plan 26;
         ($o.m, $o.m, $o.m).join(',');
     };
     is $c(), "1,2,3", '...and so does an anonymous one';
+}
+
+# --- the per-clone restart survives a thread having run ---------------------
+{
+    # Once any thread has been spawned, `StateVarInit` resolves a `state`
+    # through a shared cross-thread cell and stops consulting the local store,
+    # so dropping only the local entry left the loop-statement reset a silent
+    # no-op: the loop body kept counting up on every later execution of the
+    # statement. Cro's `Cro.compose` recursed on a `state $split` that never
+    # restarted at 1 and blew the stack once a `Cro::Service.start` had run.
+    class TC {
+        method m(*@in) { my @r; for @in { @r.push(++state $s) }; @r.join(',') }
+    }
+    is TC.m(1, 2, 3), "1,2,3", 'a loop-body state in a method starts at 1';
+    is TC.m(1, 2, 3), "1,2,3", '...and restarts on the next call';
+    is (await start { TC.m(1, 2, 3) }), "1,2,3", '...and on a worker thread';
+    is TC.m(1, 2, 3), "1,2,3", '...and still restarts back on the main thread';
 }


### PR DESCRIPTION
Raku clones a block every time its enclosing block runs, so a `state` declared inside a loop body restarts on every execution of the loop *statement*. mutsu implements that by dropping the variable from the state store at loop-statement entry (`reset_state_locals_in_range`).

That drop reached only half the storage. Once any thread has been spawned, `StateVarInit` stops resolving a `state` through the local `state_vars` map and resolves it through a shared `ContainerRef` cell in `shared_vars` instead — the cell that lets concurrent calls to one routine observe one live container. `remove_state_var` dropped the local entry and left the cell in place, so from the first `start` onward the reset was a silent no-op:

```raku
class TC {
    method m(*@in) { my @r; for @in { @r.push(++state $s) }; @r.join(',') }
}
say TC.m(1, 2, 3);                  # 1,2,3
say await start { TC.m(1, 2, 3) };  # 1,2,3
say TC.m(1, 2, 3);                  # was 4,5,6 — raku says 1,2,3
```

`remove_state_var` now drops the shared cell too, under the same normalized key `StateVarInit` installs it with.

## Why it mattered

The counter this broke in practice is Cro's, in `Cro.compose`, where `++state $split` is the index the connection manager gets spliced in at. Once `Cro::Service.start` had spawned a thread, the next `compose` began with the previous call's `$split`, spliced the manager one position later and handed itself a component list one element longer — unbounded recursion. Cro's `t/http-middleware.rakutest` aborted the whole file with a stack overflow and no TAP output at all as soon as a second server was built in one process. With the reset repaired the file runs to completion: 10 of its 11 subtests pass, leaving only the early-response body blocker already tracked in `todo/tickets/cro-middleware-await-body-text-dies-coercing-any-into-promise.md`.

Bisected to the 2026-08-04 `state` work (#5901, "a state is one container shared by its clone's invocations"): clearing the ambient scope for a method body gave every invocation of a method one stable state key, which is correct, and in doing so removed the accidental per-caller key variation that had been papering over the missing cell drop.

## Testing

- Four new cases in `t/state-var-per-block-clone.t` (they pass under `raku` too).
- `make test`: all 2880 files, 27356 tests pass.
- `roast/S04-declarations/state.t`, `roast/S02-types/array.t`, `roast/S32-list/rotor.t` — the files #5901 was fixing — still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)