### PR TITLE
refactor(runtime,compiler): CompiledAttrDecl replaces ad-hoc HasDecl destructuring (ADR-0019 D2b)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -398,7 +398,22 @@ walkers wholesale is not possible before then.
     named struct and a compiler-lowered `CompiledAttrDecl` (mirroring `RuntimeHasDeclSpec`, which
     already covers the mainline/EVAL `has`-outside-class case) covering the full `Stmt::HasDecl`
     surface; make `class_body_has_decl`/`role_body_has_decl`/the augment arm consume it instead of
-    re-destructuring the AST, and subsume `RuntimeHasDeclSpec`.
+    re-destructuring the AST, and subsume `RuntimeHasDeclSpec`. **Partly landed 2026-08-07**:
+    `CompiledAttrDecl` now exists (`src/opcode.rs`) as a typed mirror of `Stmt::HasDecl`'s full
+    18-field surface, built once by `CompiledAttrDecl::from_stmt`; `class_body_has_decl`,
+    `role_body_has_decl`, and the `augment class` `has` arm all consume it instead of each
+    independently re-destructuring `Stmt::HasDecl` with a different subset of `_`-ignored fields,
+    and `RuntimeHasDeclSpec` now wraps `{ decl: CompiledAttrDecl, error: Value }` instead of
+    duplicating ten of the same fields — subsuming it as asked. What remains: descriptor
+    construction is still runtime-side (`from_stmt` runs once per encountered `Stmt::HasDecl`
+    while `class_body_has_decl`/`role_body_has_decl` walk `legacy_body`/`flattened_body` at
+    registration time), not compiler-lowered into a `Vec<CompiledAttrDecl>` on
+    `CompiledClassDeclPlan`/`CompiledRoleDeclPlan` the way D2a's `own_attribute_names` is. That
+    step needs position-correlating the precomputed vec with the registration-time statement walk
+    (nested-sub-declared attributes and `SyntheticBlock` flattening make the traversal order
+    non-trivial to match) and is naturally forced by D6/D9 dropping `legacy_body` outright, since
+    nothing will be left to walk on demand at that point. See
+    `news/2026-08/d2b-compiled-attr-decl.md`.
   - [ ] **D2c — Compile defaults/constraints as child chunks.** Replace attribute
     `default`/`is_default`/`where_constraint` `Expr`s (including the `Expr`-valued role
     registry tables `role_attribute_default_exprs`/`role_class_level_attrs`/

--- a/news/2026-08/d2b-compiled-attr-decl.md
+++ b/news/2026-08/d2b-compiled-attr-decl.md
@@ -1,0 +1,35 @@
+# ADR-0019 D2b (partial): `CompiledAttrDecl` replaces ad-hoc `Stmt::HasDecl` destructuring
+
+Four sites in the interpreter each independently pattern-matched `Stmt::HasDecl`'s
+18 fields to build a `ClassAttributeDef`: the class-body walk
+(`class_body_has_decl`), the role-body walk (`role_body_has_decl`), the
+`augment class`/`augment role` `has` arm, and the compiler's mainline/EVAL
+`has`-outside-class case (which built a separate `RuntimeHasDeclSpec` type).
+Each destructure ignored a different subset of fields with `_`, so the four
+sites drifted out of sync with each other over time — the augment arm, for
+example, silently skips `is_default`/`is_type`/`deprecated_message`/
+`attribute_built`/class-level (`our`/`my`) attributes that the class-body walk
+supports.
+
+`CompiledAttrDecl` (`src/opcode.rs`) is now the one place that destructures
+`Stmt::HasDecl`, via `CompiledAttrDecl::from_stmt`. All four sites build one
+and read its named fields instead. `RuntimeHasDeclSpec` — previously a
+10-field duplicate of the AST shape plus a runtime-only `error: Value` — now
+wraps `{ decl: CompiledAttrDecl, error: Value }`, so it no longer maintains a
+separate field set at all.
+
+This does not yet move descriptor construction to compile time. The three
+registration-time consumers still call `from_stmt` once per `Stmt::HasDecl`
+encountered while walking `legacy_body`/`flattened_body`, the same walk they
+did before — only the *shape* consumed at each stop changed, not *when* it is
+built. Precomputing a `Vec<CompiledAttrDecl>` on `CompiledClassDeclPlan`/
+`CompiledRoleDeclPlan` at plan lowering (mirroring D2a's
+`own_attribute_names`) is deferred: it requires the precomputed vector's
+order to exactly match the registration-time walk's traversal (including
+nested-sub-declared attributes and `SyntheticBlock`-flattened list-form `has`
+declarations), which is not free to get right and is not required to unblock
+D2c/D2d. It becomes unavoidable once D6/D9 drop `legacy_body` outright, since
+at that point there is no AST left to call `from_stmt` on.
+
+Verified with `cargo test --lib` (672 tests) and the local attribute/class/
+role/augment `prove` surface (26 files, 225 tests), all passing unchanged.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2772,21 +2772,7 @@ impl Compiler {
             // CATCH/CONTROL are extracted by compile_try/compile_body_with_implicit_try
             Stmt::Catch(_) | Stmt::Control(_) => {}
             // HasDecl outside class context.
-            Stmt::HasDecl {
-                name,
-                sigil,
-                is_public,
-                is_our,
-                is_my,
-                is_rw,
-                is_readonly,
-                is_required,
-                is_built,
-                type_constraint,
-                type_smiley,
-                default,
-                ..
-            } => {
+            Stmt::HasDecl { is_our, is_my, .. } => {
                 // `our $.x` / `my $.x` in the mainline is not a fatal error in
                 // Raku; it merely warns that generating an accessor method here
                 // is useless (there is no package to attach it to). Only the
@@ -2802,15 +2788,13 @@ impl Compiler {
                     self.code.emit(OpCode::Pop);
                     return;
                 }
-                let twigil = if *is_public { "." } else { "!" };
-                let bare = name.resolve();
-                let bare = bare.trim_start_matches(['.', '!']);
-                let sigil_ch = if *sigil == '!' || *sigil == '.' {
-                    '$'
-                } else {
-                    *sigil
-                };
-                let full_name = format!("{}{}{}", sigil_ch, twigil, bare);
+                // `Stmt::HasDecl::name` is already the bare (twigil-free) name
+                // and `sigil` is always `$`/`@`/`%` (the parser never produces
+                // `.`/`!`), so `CompiledAttrDecl::from_stmt`'s fields match
+                // this arm's historical `bare`/`sigil_ch` derivation exactly.
+                let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt);
+                let twigil = if decl.is_public { "." } else { "!" };
+                let full_name = format!("{}{}{}", decl.sigil, twigil, decl.name);
                 let mut attrs = std::collections::HashMap::new();
                 let err = if let Some(pkg_kind) = self.current_package_kind {
                     // Inside a `module`/`package` body: a package cannot hold
@@ -2840,19 +2824,7 @@ impl Compiler {
                 // runtime op that, when a class is currently being defined
                 // (`class Foo { BEGIN EVAL q[has $.x] }`), registers the
                 // attribute onto that class; otherwise it throws the error above.
-                let spec = crate::opcode::RuntimeHasDeclSpec {
-                    attr_name: bare.to_string(),
-                    is_public: *is_public,
-                    sigil: sigil_ch,
-                    is_rw: *is_rw,
-                    is_readonly: *is_readonly,
-                    is_required: is_required.clone(),
-                    is_built: *is_built,
-                    type_constraint: type_constraint.clone(),
-                    type_smiley: type_smiley.clone(),
-                    default: default.clone(),
-                    error: err,
-                };
+                let spec = crate::opcode::RuntimeHasDeclSpec { decl, error: err };
                 self.code.emit(OpCode::RuntimeHasDecl(Box::new(spec)));
             }
             // DoesDecl/TrustsDecl outside class context are no-ops

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -277,6 +277,89 @@ pub(crate) struct ForLoopSpec {
     pub(crate) body_declares_routines: bool,
 }
 
+/// A typed mirror of `Stmt::HasDecl` (ADR-0019 D2b), built once by
+/// [`CompiledAttrDecl::from_stmt`] instead of being re-destructured with an
+/// 18-field pattern at each of the class-body, role-body, augment, and
+/// mainline/EVAL `has`-registration sites. `name` is the resolved (twigil-free)
+/// attribute name and `where_constraint`/`is_default` are unboxed, matching
+/// what every consumer actually reads; everything else mirrors the AST field
+/// for field.
+#[derive(Debug, Clone)]
+pub(crate) struct CompiledAttrDecl {
+    pub(crate) name: String,
+    pub(crate) is_public: bool,
+    pub(crate) default: Option<crate::ast::Expr>,
+    pub(crate) handles: Vec<crate::ast::HandleSpec>,
+    pub(crate) is_rw: bool,
+    pub(crate) is_readonly: bool,
+    pub(crate) type_constraint: Option<String>,
+    pub(crate) type_smiley: Option<String>,
+    pub(crate) is_required: Option<Option<String>>,
+    pub(crate) sigil: char,
+    pub(crate) where_constraint: Option<crate::ast::Expr>,
+    pub(crate) is_alias: bool,
+    pub(crate) is_our: bool,
+    pub(crate) is_my: bool,
+    pub(crate) is_default: Option<crate::ast::Expr>,
+    pub(crate) is_type: Option<String>,
+    pub(crate) deprecated_message: Option<String>,
+    pub(crate) is_built: Option<bool>,
+    pub(crate) unknown_traits: Vec<(String, String, Option<crate::ast::Expr>)>,
+}
+
+impl CompiledAttrDecl {
+    /// Build a typed descriptor from a `Stmt::HasDecl`. Panics on any other
+    /// statement kind — every call site already matched on `Stmt::HasDecl`
+    /// before reaching here.
+    pub(crate) fn from_stmt(stmt: &Stmt) -> CompiledAttrDecl {
+        let Stmt::HasDecl {
+            name,
+            is_public,
+            default,
+            handles,
+            is_rw,
+            is_readonly,
+            type_constraint,
+            type_smiley,
+            is_required,
+            sigil,
+            where_constraint,
+            is_alias,
+            is_our,
+            is_my,
+            is_default,
+            is_type,
+            deprecated_message,
+            is_built,
+            unknown_traits,
+        } = stmt
+        else {
+            unreachable!("CompiledAttrDecl::from_stmt called on a non-HasDecl statement");
+        };
+        CompiledAttrDecl {
+            name: name.resolve(),
+            is_public: *is_public,
+            default: default.clone(),
+            handles: handles.clone(),
+            is_rw: *is_rw,
+            is_readonly: *is_readonly,
+            type_constraint: type_constraint.clone(),
+            type_smiley: type_smiley.clone(),
+            is_required: is_required.clone(),
+            sigil: *sigil,
+            where_constraint: where_constraint.as_deref().cloned(),
+            is_alias: *is_alias,
+            is_our: *is_our,
+            is_my: *is_my,
+            is_default: is_default.clone(),
+            is_type: is_type.clone(),
+            deprecated_message: deprecated_message.clone(),
+            is_built: *is_built,
+            unknown_traits: unknown_traits.clone(),
+        }
+    }
+}
+
 /// Payload of `OpCode::RuntimeHasDecl`. A `has $.x` that reaches the VM (rather
 /// than being collected declaratively by `register_class_decl`) only arises from
 /// mainline / EVAL'd source — e.g. `class Foo { BEGIN EVAL q[has $.x] }`. At
@@ -286,16 +369,7 @@ pub(crate) struct ForLoopSpec {
 /// or `X::Attribute::Package`). Boxed to keep `size_of::<OpCode>()` small.
 #[derive(Debug, Clone)]
 pub(crate) struct RuntimeHasDeclSpec {
-    pub(crate) attr_name: String,
-    pub(crate) is_public: bool,
-    pub(crate) sigil: char,
-    pub(crate) is_rw: bool,
-    pub(crate) is_readonly: bool,
-    pub(crate) is_required: Option<Option<String>>,
-    pub(crate) is_built: Option<bool>,
-    pub(crate) type_constraint: Option<String>,
-    pub(crate) type_smiley: Option<String>,
-    pub(crate) default: Option<crate::ast::Expr>,
+    pub(crate) decl: CompiledAttrDecl,
     /// The `X::Attribute::*` error to throw when this `has` runs outside a
     /// class-definition context.
     pub(crate) error: Value,

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -270,51 +270,31 @@ impl Interpreter {
                         }
                     }
                 }
-                Stmt::HasDecl {
-                    name: attr_name,
-                    is_public,
-                    default,
-                    is_rw,
-                    is_readonly: _,
-                    type_constraint,
-                    type_smiley: _,
-                    is_required,
-                    sigil,
-                    handles,
-                    where_constraint,
-                    is_alias,
-                    is_our: _,
-                    is_my: _,
-                    is_default: _,
-                    is_type: _,
-                    deprecated_message: _,
-                    is_built: _,
-                    unknown_traits: _,
-                } => {
-                    let attr_name_str = attr_name.resolve();
-                    let attr_var_name = if *is_public {
+                Stmt::HasDecl { .. } => {
+                    let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt);
+                    let attr_name_str = decl.name.clone();
+                    let attr_var_name = if decl.is_public {
                         format!(".{}", attr_name_str)
                     } else {
                         format!("!{}", attr_name_str)
                     };
                     // Resolve handles before taking mutable borrow on class_def
-                    let resolved = self.resolve_handle_specs_to_names(handles, &attr_var_name);
+                    let resolved =
+                        self.resolve_handle_specs_to_names(&decl.handles, &attr_var_name);
                     if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
                         class_def.attributes.push(ClassAttributeDef {
                             name: attr_name_str.clone(),
-                            is_public: *is_public,
-                            default: default.clone(),
-                            is_rw: *is_rw,
-                            is_required: is_required.clone(),
-                            sigil: *sigil,
-                            where_constraint: where_constraint
-                                .as_ref()
-                                .map(|wc| wc.as_ref().clone()),
+                            is_public: decl.is_public,
+                            default: decl.default.clone(),
+                            is_rw: decl.is_rw,
+                            is_required: decl.is_required.clone(),
+                            sigil: decl.sigil,
+                            where_constraint: decl.where_constraint.clone(),
                         });
-                        if *is_alias {
+                        if decl.is_alias {
                             class_def.alias_attributes.insert(attr_name_str.clone());
                         }
-                        if let Some(tc) = type_constraint {
+                        if let Some(tc) = &decl.type_constraint {
                             class_def
                                 .attribute_types
                                 .insert(attr_name_str.clone(), tc.clone());

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -19,7 +19,8 @@ impl Interpreter {
         class_name: &str,
         spec: &crate::opcode::RuntimeHasDeclSpec,
     ) -> Result<(), RuntimeError> {
-        let attr_name = &spec.attr_name;
+        let decl = &spec.decl;
+        let attr_name = &decl.name;
         let Some(mut class_def) = self.registry().classes.get(class_name).cloned() else {
             return Ok(());
         };
@@ -29,33 +30,33 @@ impl Interpreter {
         }
         self.validate_static_attribute_default(
             attr_name,
-            spec.sigil,
-            spec.default.as_ref(),
-            spec.type_constraint.as_deref(),
-            spec.type_smiley.as_deref(),
+            decl.sigil,
+            decl.default.as_ref(),
+            decl.type_constraint.as_deref(),
+            decl.type_smiley.as_deref(),
         )?;
-        let effective_is_rw = !spec.is_readonly && spec.is_rw;
+        let effective_is_rw = !decl.is_readonly && decl.is_rw;
         class_def.attributes.push(ClassAttributeDef {
             name: attr_name.clone(),
-            is_public: spec.is_public,
-            default: spec.default.clone(),
+            is_public: decl.is_public,
+            default: decl.default.clone(),
             is_rw: effective_is_rw,
-            is_required: spec.is_required.clone(),
-            sigil: spec.sigil,
+            is_required: decl.is_required.clone(),
+            sigil: decl.sigil,
             where_constraint: None,
         });
-        if let Some(tc) = &spec.type_constraint {
+        if let Some(tc) = &decl.type_constraint {
             let resolved_tc = tc.replace("::?CLASS", class_name);
             class_def
                 .attribute_types
                 .insert(attr_name.clone(), resolved_tc);
         }
-        if let Some(ts) = &spec.type_smiley {
+        if let Some(ts) = &decl.type_smiley {
             class_def
                 .attribute_smileys
                 .insert(attr_name.clone(), ts.clone());
         }
-        if let Some(built) = spec.is_built {
+        if let Some(built) = decl.is_built {
             class_def.attribute_built.insert(attr_name.clone(), built);
         }
         self.registry_mut()
@@ -112,40 +113,17 @@ impl Interpreter {
         cx: &mut ClassBodyCx<'_>,
         stmt: &Stmt,
     ) -> Result<ClassBodyFlow, RuntimeError> {
-        let Stmt::HasDecl {
-            name: attr_name,
-            is_public,
-            default,
-            handles,
-            is_rw,
-            is_readonly,
-            type_constraint,
-            type_smiley,
-            is_required,
-            sigil,
-            where_constraint,
-            is_alias,
-            is_our,
-            is_my,
-            is_default,
-            is_type,
-            deprecated_message,
-            is_built,
-            unknown_traits,
-        } = stmt
-        else {
-            unreachable!("class_body_has_decl called on a non-HasDecl statement");
-        };
-        let attr_name_str = attr_name.resolve();
+        let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt);
+        let attr_name_str = decl.name.clone();
 
         // An initializer that can never satisfy the constraint is a
         // declaration-time error in rakudo, before anything is built.
         if let Err(err) = self.validate_static_attribute_default(
             &attr_name_str,
-            *sigil,
-            default.as_ref(),
-            type_constraint.as_deref(),
-            type_smiley.as_deref(),
+            decl.sigil,
+            decl.default.as_ref(),
+            decl.type_constraint.as_deref(),
+            decl.type_smiley.as_deref(),
         ) {
             self.set_current_package(cx.saved_package.clone());
             self.env = cx.saved_env.clone();
@@ -157,14 +135,14 @@ impl Interpreter {
         // to it with an Attribute introspection object; otherwise raise
         // X::Comp::Trait::Unknown. Kept in a separate method so its
         // locals don't inflate this already-large function's frame.
-        if !unknown_traits.is_empty() {
+        if !decl.unknown_traits.is_empty() {
             if let Err(err) = self.apply_attribute_traits(
-                unknown_traits,
+                &decl.unknown_traits,
                 &attr_name_str,
-                *sigil,
-                *is_public,
+                decl.sigil,
+                decl.is_public,
                 cx.name,
-                type_constraint.as_deref(),
+                decl.type_constraint.as_deref(),
             ) {
                 self.set_current_package(cx.saved_package.clone());
                 self.env = cx.saved_env.clone();
@@ -192,9 +170,9 @@ impl Interpreter {
         }
 
         // Handle class-level attributes (our $.x / my $.x)
-        if *is_our || *is_my {
+        if decl.is_our || decl.is_my {
             // Evaluate the default value if present
-            let initial_value = if let Some(expr) = default {
+            let initial_value = if let Some(expr) = &decl.default {
                 self.eval_block_value(&[Stmt::Expr(expr.clone())])?
             } else {
                 Value::NIL
@@ -220,29 +198,30 @@ impl Interpreter {
                 attr_name_str, cx.name,
             )));
         }
-        let effective_is_rw = !*is_readonly && (*is_rw || (cx.class_is_rw && *is_public));
+        let effective_is_rw =
+            !decl.is_readonly && (decl.is_rw || (cx.class_is_rw && decl.is_public));
         cx.class_def.attributes.push(ClassAttributeDef {
             name: attr_name_str.clone(),
-            is_public: *is_public,
-            default: default.clone(),
+            is_public: decl.is_public,
+            default: decl.default.clone(),
             is_rw: effective_is_rw,
-            is_required: is_required.clone(),
-            sigil: *sigil,
-            where_constraint: where_constraint.as_ref().map(|wc| wc.as_ref().clone()),
+            is_required: decl.is_required.clone(),
+            sigil: decl.sigil,
+            where_constraint: decl.where_constraint.clone(),
         });
         // Store `is default(...)` trait value for this attribute.
         // When is_default is set, the evaluated value is stored for
         // .VAR.default and Nil-restore behavior.
         // When only `default` is set (from `is default(X)` without `= value`),
         // also store it as the is_default trait value.
-        if let Some(is_default_expr) = is_default {
+        if let Some(is_default_expr) = &decl.is_default {
             if let Ok(val) = self.eval_block_value(&[Stmt::Expr(is_default_expr.clone())]) {
                 // Type-check the default value against the attribute's type
                 // constraint. For an object hash (`%.a{KeyType}`) the
                 // constraint is `ValueType{KeyType}`; the `is default`
                 // value is an *element* default, so check it against the
                 // value type only.
-                if let Some(tc) = type_constraint {
+                if let Some(tc) = &decl.type_constraint {
                     let tc = tc
                         .split_once('{')
                         .map(|(value_tc, _)| value_tc)
@@ -294,48 +273,48 @@ impl Interpreter {
                     .class_attribute_defaults
                     .insert((cx.name.to_string(), attr_name_str.clone()), val);
             }
-        } else if default.is_some() {
+        } else if decl.default.is_some() {
             // No explicit `is default(X)`, but there IS a `default` expr.
             // This means either `has $.a = expr` or `has $.a is default(expr)` without `= value`.
             // We can't distinguish here, so we DON'T set class_attribute_defaults
             // (it would be wrong for `has $.a = 42` — Nil should give (Any), not 42).
         }
-        if *is_alias {
+        if decl.is_alias {
             cx.class_def.alias_attributes.insert(attr_name_str.clone());
         }
-        if let Some(tc) = type_constraint {
+        if let Some(tc) = &decl.type_constraint {
             // Resolve ::?CLASS to the current class name
             let resolved_tc = tc.replace("::?CLASS", cx.name);
             cx.class_def
                 .attribute_types
                 .insert(attr_name_str.clone(), resolved_tc);
         }
-        if let Some(ts) = type_smiley {
+        if let Some(ts) = &decl.type_smiley {
             cx.class_def
                 .attribute_smileys
                 .insert(attr_name_str.clone(), ts.clone());
         }
-        if let Some(built) = is_built {
+        if let Some(built) = decl.is_built {
             cx.class_def
                 .attribute_built
-                .insert(attr_name_str.clone(), *built);
+                .insert(attr_name_str.clone(), built);
         }
-        if let Some(it) = is_type {
+        if let Some(it) = &decl.is_type {
             self.registry_mut()
                 .class_attribute_is_types
                 .insert((cx.name.to_string(), attr_name_str.clone()), it.clone());
         }
-        if let Some(dm) = deprecated_message {
+        if let Some(dm) = &decl.deprecated_message {
             self.registry_mut()
                 .class_attribute_deprecated
                 .insert((cx.name.to_string(), attr_name_str.clone()), dm.clone());
         }
-        let attr_var_name = if *is_public {
+        let attr_var_name = if decl.is_public {
             format!(".{}", attr_name_str)
         } else {
             format!("!{}", attr_name_str)
         };
-        self.apply_handle_specs(handles, &attr_var_name, &mut cx.class_def);
+        self.apply_handle_specs(&decl.handles, &attr_var_name, &mut cx.class_def);
         Ok(ClassBodyFlow::RunTail)
     }
 }

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -16,41 +16,18 @@ impl Interpreter {
         cx: &mut RoleDeclCx<'_>,
         stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
-        let Stmt::HasDecl {
-            name: attr_name,
-            is_public,
-            default,
-            handles,
-            is_rw,
-            is_readonly,
-            type_constraint,
-            type_smiley,
-            is_required,
-            sigil,
-            where_constraint,
-            is_alias: _,
-            is_our,
-            is_my,
-            is_default,
-            is_type,
-            deprecated_message: _,
-            is_built: _,
-            unknown_traits: _,
-        } = stmt
-        else {
-            unreachable!("role_body_has_decl called on a non-HasDecl statement");
-        };
-        let attr_name_str = attr_name.resolve();
+        let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt);
+        let attr_name_str = decl.name.clone();
         // A class-level (`my $.x` / `our $.x`) role attribute is NOT a
         // per-instance attribute: it becomes a class-level attribute on the
         // consuming class (accessor on the type object, `C.x`) — exactly
         // like `class C { my $.x }`. Record its default expr keyed by
         // (role, attr) and skip the per-instance attribute registration, so
         // no per-instance accessor shadows the class-level fallback.
-        if *is_my || *is_our {
+        if decl.is_my || decl.is_our {
             self.registry_mut().role_class_level_attrs.insert(
                 (cx.name.to_string(), attr_name_str.clone()),
-                default.clone(),
+                decl.default.clone(),
             );
             return Ok(());
         }
@@ -60,7 +37,7 @@ impl Interpreter {
         // Carry an `is Type` container trait (`has @.a is G::A`) so it
         // can be transferred to the consuming class at composition and
         // its element type enforced.
-        if let Some(it) = is_type {
+        if let Some(it) = &decl.is_type {
             self.registry_mut()
                 .role_attribute_is_types
                 .insert((cx.name.to_string(), attr_name_str.clone()), it.clone());
@@ -71,12 +48,12 @@ impl Interpreter {
         // no class of its own to hold `attribute_types`. `::?CLASS`
         // stays unresolved here — it names the *consuming* class, so
         // it is substituted at composition.
-        if let Some(tc) = type_constraint {
+        if let Some(tc) = &decl.type_constraint {
             self.registry_mut()
                 .role_attribute_types
                 .insert((cx.name.to_string(), attr_name_str.clone()), tc.clone());
         }
-        if let Some(ts) = type_smiley {
+        if let Some(ts) = &decl.type_smiley {
             self.registry_mut()
                 .role_attribute_smileys
                 .insert((cx.name.to_string(), attr_name_str.clone()), ts.clone());
@@ -86,7 +63,7 @@ impl Interpreter {
         // until composition. Stash the expression keyed by (role, attr);
         // it is copied to the consuming class and evaluated at instance
         // construction (with type params bound).
-        if let Some(def_expr) = is_default {
+        if let Some(def_expr) = &decl.is_default {
             self.registry_mut().role_attribute_default_exprs.insert(
                 (cx.name.to_string(), attr_name_str.clone()),
                 def_expr.clone(),
@@ -125,22 +102,23 @@ impl Interpreter {
         }
         // Apply role-level `is rw`: same logic as class_is_rw
         // `is readonly` on individual attributes overrides `is rw` on the role
-        let effective_is_rw = !*is_readonly && (*is_rw || (cx.role_is_rw && *is_public));
+        let effective_is_rw =
+            !decl.is_readonly && (decl.is_rw || (cx.role_is_rw && decl.is_public));
         cx.role_def.attributes.push(ClassAttributeDef {
             name: attr_name_str.clone(),
-            is_public: *is_public,
-            default: default.clone(),
+            is_public: decl.is_public,
+            default: decl.default.clone(),
             is_rw: effective_is_rw,
-            is_required: is_required.clone(),
-            sigil: *sigil,
-            where_constraint: where_constraint.as_ref().map(|wc| wc.as_ref().clone()),
+            is_required: decl.is_required.clone(),
+            sigil: decl.sigil,
+            where_constraint: decl.where_constraint.clone(),
         });
-        let attr_var_name = if *is_public {
+        let attr_var_name = if decl.is_public {
             format!(".{}", attr_name_str)
         } else {
             format!("!{}", attr_name_str)
         };
-        self.apply_handle_specs_to_role(handles, &attr_var_name, &mut cx.role_def);
+        self.apply_handle_specs_to_role(&decl.handles, &attr_var_name, &mut cx.role_def);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Four sites (class-body walk, role-body walk, `augment class`/`augment role` `has` arm, mainline/EVAL `has`-outside-class) each independently re-destructured `Stmt::HasDecl`'s 18 fields with a different `_`-ignored subset. `CompiledAttrDecl::from_stmt` (`src/opcode.rs`) is now the one place that destructures the AST; all four sites consume its typed fields instead.
- `RuntimeHasDeclSpec` now wraps `{ decl: CompiledAttrDecl, error: Value }` instead of duplicating ten of the same fields, subsuming it as ADR-0019 D2b asks.
- Descriptor construction is still runtime-side (`from_stmt` runs once per `Stmt::HasDecl` encountered while walking `legacy_body`/`flattened_body`), not yet compiler-lowered into a plan-pool field the way D2a's `own_attribute_names` is — see the ADR note and `news/2026-08/d2b-compiled-attr-decl.md` for why that step is deferred to a later slice.
- Zero behavior change: verified the compiler's mainline arm's historical `bare`/`sigil_ch` derivation is equivalent to `CompiledAttrDecl::from_stmt`'s fields for every real parse (the parser never emits a `.`/`!` sigil or twigil-prefixed name).

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings` (matches the pre-commit hook command; `--all-targets` has 5 pre-existing unrelated failures reproduced on `main` too)
- [x] `cargo fmt`
- [x] `cargo test --lib` (672 passed)
- [x] `prove -e target/debug/mutsu` over the attribute/class-attr/augment/role-attribute/has-decl local test surface (26 files, 225 tests)
- [x] `make test` (full `t/` suite): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)