### PR TITLE
refactor(runtime): has_public_accessor probes the canonical method table (ADR-0019 D2d)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -411,6 +411,16 @@ walkers wholesale is not possible before then.
     `.^methods`/`.^can`/`.^attributes` synthesis sites become table probes riding the existing
     generation-bump invalidation instead of MRO×attribute-vector scans. Independently landable
     (does not depend on D2b/D2c — `ClassDef::attributes` is already populated by registration).
+    **Partly landed 2026-08-07**: `MethodEntry` gained an `accessor: Option<bool>` arm, populated
+    in `sync_user_method_entries` alongside the existing `user_candidates` loop (same generation
+    bump, no new invalidation hook needed — Phase B's scheme was built write-path-agnostic).
+    `has_public_accessor` now probes it (`Registry::accessor_is_public`) per MRO level instead of
+    scanning each class's `attributes` vector. `resolve_user_method_or_accessor` and the
+    `.^methods`/`.^can`/`.^attributes` synthesis sites (`methods_classhow_method_obj.rs`,
+    `methods_classhow_attribute.rs`) are unmigrated — they carry more interacting logic (role
+    attributes, method/accessor shadow ordering, full `Attribute` meta-object construction for
+    `.^attributes`) that a first slice deliberately left alone rather than risk in one pass. See
+    `news/2026-08/d2d-accessor-method-entry.md`.
 - [ ] **D3 — Encode class methods and submethods as compiled candidates.** Install ordinary, multi,
   proto, private, rw, wrap, BUILD, and TWEAK metadata without walking `Stmt::MethodDecl`. That
   walk exists in three places, not one — the class walker (~508 lines), the role walker

--- a/news/2026-08/d2d-accessor-method-entry.md
+++ b/news/2026-08/d2d-accessor-method-entry.md
@@ -1,0 +1,35 @@
+# ADR-0019 D2d (partial): `has_public_accessor` probes the canonical method table
+
+`has_public_accessor` decided whether `$obj.name` should resolve to an
+auto-generated `has $.name` accessor by walking the class's MRO and, at each
+level, linearly scanning that class's `ClassAttributeDef` vector for a
+matching name — a scan on the per-call method-dispatch path (it backs the VM's
+`try_fast_accessor_read` fast path and the interpreter's instance-method
+dispatch fallback, among other callers). Meanwhile `MethodEntry`, the
+canonical `(owner, method)` table Phase B built for user/native method
+candidates, had no way to represent "this class also has an accessor here" —
+so accessor presence and method presence lived in two unrelated data
+structures despite both answering the same kind of query.
+
+`MethodEntry` gains an `accessor: Option<bool>` field (`None` = this class
+does not declare an attribute of that name; `Some(is_public)` when it does).
+`Registry::sync_user_method_entries` — already the single place that
+publishes a class's `ClassDef::methods` into the table on every registration
+mutation — now does the same for `ClassDef::attributes` in the same pass,
+under the same generation bump. `has_public_accessor` is now a per-MRO-level
+table probe (`Registry::accessor_is_public`) instead of a vector scan.
+
+This is a first slice, not the whole of D2d. `resolve_user_method_or_accessor`
+(the method-vs-accessor-vs-role-method race used by the mutation/write path
+and the compiled-dispatch re-check) and the `.^methods`/`.^can`/`.^attributes`
+introspection synthesis sites (`methods_classhow_method_obj.rs`,
+`methods_classhow_attribute.rs`) still do their own independent MRO×attribute
+scans. They carry meaningfully more logic than a boolean presence check
+(role-attribute composition, method-vs-accessor shadow ordering per level,
+full `Attribute` meta-object construction for `.^attributes`), so migrating
+them was left for a follow-up slice rather than risked in the same PR as the
+`MethodEntry` shape change.
+
+Verified with `cargo test --lib` (672 tests), the local attribute/accessor/
+private-method `prove` surface (56 files, 417 tests), and the full `t/` suite
+via `make test` (PASS) — all passing unchanged.

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -253,21 +253,14 @@ impl Interpreter {
     /// The most-derived declaration of an attribute name decides its
     /// visibility (mirroring `collect_class_attributes`' override-by-name
     /// merge), so walk the MRO derived-first and stop at the first class
-    /// declaring the name instead of cloning the whole merged attribute list
-    /// per query — this sits on the per-call method-dispatch path.
+    /// declaring the name — a `MethodEntry` table probe per level (ADR-0019
+    /// D2d) instead of a linear scan of that class's attribute vector, since
+    /// this sits on the per-call method-dispatch path.
     pub(crate) fn has_public_accessor(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
         for cn in mro.iter() {
-            if let Some(class_def) = self.registry().classes.get(cn.as_str())
-                // Within one class a later same-name declaration overrides an
-                // earlier one (collect_class_attributes' remove-then-push).
-                && let Some(attr) = class_def
-                    .attributes
-                    .iter()
-                    .rev()
-                    .find(|a| a.name == method_name)
-            {
-                return attr.is_public;
+            if let Some(is_public) = self.registry().accessor_is_public(cn.as_str(), method_name) {
+                return is_public;
             }
         }
         false

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -51,6 +51,14 @@ pub(crate) struct MethodEntryKey {
 pub(crate) struct MethodEntry {
     pub(crate) builtin: Option<crate::builtins::builtin_type_methods::BuiltinMethodEntry>,
     pub(crate) user_candidates: Vec<MethodDef>,
+    /// Visibility of the auto-generated accessor for a `has $.x`/`has $!x`
+    /// attribute this class declares directly, keyed by attribute name under
+    /// the same `(owner, name)` row as a same-named method would occupy
+    /// (ADR-0019 D2d). `Some(is_public)`, not a nested `Option` around a
+    /// descriptor: callers only ever need the visibility bit, not the full
+    /// `ClassAttributeDef` (that stays in `ClassDef::attributes`, the source
+    /// this is synced from).
+    pub(crate) accessor: Option<bool>,
 }
 
 /// Program declaration registry. See module docs.
@@ -303,17 +311,16 @@ impl Registry {
         self.method_entries.retain(|key, entry| {
             if key.owner == owner {
                 entry.user_candidates.clear();
+                entry.accessor = None;
             }
-            entry.builtin.is_some() || !entry.user_candidates.is_empty()
+            entry.builtin.is_some() || !entry.user_candidates.is_empty() || entry.accessor.is_some()
         });
-        let Some(methods) = self
-            .classes
-            .get(class_name)
-            .map(|class| class.methods.clone())
-        else {
+        let Some(class_def) = self.classes.get(class_name) else {
             self.bump_method_generation();
             return;
         };
+        let methods = class_def.methods.clone();
+        let attributes = class_def.attributes.clone();
         for (name, candidates) in methods {
             self.method_entries
                 .entry(MethodEntryKey {
@@ -322,6 +329,20 @@ impl Registry {
                 })
                 .or_default()
                 .user_candidates = candidates;
+        }
+        // A later same-name declaration within the class overrides an earlier
+        // one (mirrors `collect_class_attributes`'/`has_public_accessor`'s
+        // former remove-then-push / rev().find() semantics): iterating in
+        // declaration order and letting each write clobber the last gives the
+        // same "most recent wins" result.
+        for attr in &attributes {
+            self.method_entries
+                .entry(MethodEntryKey {
+                    owner,
+                    name: Symbol::intern(&attr.name),
+                })
+                .or_default()
+                .accessor = Some(attr.is_public);
         }
         self.bump_method_generation();
     }
@@ -338,6 +359,20 @@ impl Registry {
             })
             .filter(|entry| !entry.user_candidates.is_empty())
             .map(|entry| entry.user_candidates.clone())
+    }
+
+    /// Visibility of the auto-generated accessor `method_name` declares
+    /// directly on `class_name`, if any (ADR-0019 D2d). `None` means this
+    /// class does not declare an attribute of that name at all — distinct
+    /// from `Some(false)` (a private attribute, which still occupies the
+    /// name and must not fall through to an ancestor's same-named accessor).
+    pub(crate) fn accessor_is_public(&self, class_name: &str, method_name: &str) -> Option<bool> {
+        self.method_entries
+            .get(&MethodEntryKey {
+                owner: Symbol::intern(class_name),
+                name: Symbol::intern(method_name),
+            })
+            .and_then(|entry| entry.accessor)
     }
 
     pub(crate) fn replace_method_entries_from(&mut self, source: &Self) {


### PR DESCRIPTION
## Summary
- `MethodEntry` gains an `accessor: Option<bool>` arm, populated by `sync_user_method_entries` from `ClassDef::attributes` alongside the existing `user_candidates` loop (same generation-bump boundary, no new invalidation hook needed).
- `has_public_accessor` is now a per-MRO-level `MethodEntry` table probe (`Registry::accessor_is_public`) instead of a linear scan of each class's attribute vector — this sits on the per-call method-dispatch path (backs the VM's `try_fast_accessor_read` fast path and the interpreter's instance-method dispatch fallback).
- First slice of ADR-0019 D2d: `resolve_user_method_or_accessor` and the `.^methods`/`.^can`/`.^attributes` introspection synthesis sites still do their own independent MRO×attribute scans — they carry more interacting logic (role attributes, method/accessor shadow ordering, full `Attribute` meta-object construction) and are deliberately left for a follow-up slice.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo test --lib` (672 passed)
- [x] `prove -e target/debug/mutsu` over the attribute/accessor/private-method local test surface (56 files, 417 tests)
- [x] `make test` (full `t/` suite): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)