### PR TITLE
fix(compiler): a `state` declaration buried in an expression still resets

### DIFF
--- a/news/2026-08/state-decl-nested-in-an-expression.md
+++ b/news/2026-08/state-decl-nested-in-an-expression.md
@@ -1,0 +1,28 @@
+# A `state` declaration buried in an expression is still a declaration
+
+Raku clones a block every time its enclosing block runs, so a `state` inside an
+`if` branch or a bare block restarts on every execution of the construct that
+contains it. mutsu emits an `OpCode::ResetStateLocals` at the head of such an
+inline block, but only when the block's statements declare `state` — and the
+test for that, `expr_has_state_decl`, recognized a declaration only when it
+*was* the whole expression.
+
+It usually is not. `++state $n` parses as a prefix operator wrapped around the
+declaration, so:
+
+```raku
+sub f() { my @r; if 1 { @r.push(++state $n) }; @r.join(',') }
+say (f(), f(), f()).join('|');   # was 1|2|3 — raku says 1|1|1
+```
+
+The walk now descends through operator, call, subscript and interpolation
+shapes, and stops at anything that introduces a block of its own (`Block`,
+`Lambda`, `AnonSub`, ...) — a `state` in there belongs to *that* clone and is
+reset at its own entry, so descending would only emit a redundant reset.
+
+The same predicate decides whether a `state` initializer's evaluation can be
+skipped once the variable is initialized, so widening it also fixes a nested
+declaration in an initializer (`state $a = (state $b = 0) + 1`) that has to run
+its own `StateVarInit` on every call.
+
+Pinned by `t/state-decl-nested-in-expression.t`, which passes under `raku` too.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -158,17 +158,72 @@ impl Compiler {
         )
     }
 
-    /// Returns true if the expression contains a state variable declaration
-    /// (recursively). Used to decide whether `StateVarInitGuard` can safely
-    /// skip evaluation of a state variable's RHS initializer.
+    /// Returns true if the expression contains a state variable declaration at
+    /// its OWN block level. Used to decide whether `StateVarInitGuard` can
+    /// safely skip evaluation of a state variable's RHS initializer, and
+    /// whether an inline nested block needs a `ResetStateLocals`.
+    ///
+    /// The walk descends through operator/call/subscript shapes but stops at
+    /// anything that introduces a block of its own (`Block`, `Lambda`,
+    /// `AnonSub`, `Gather`, ...): a `state` in there belongs to *that* clone
+    /// and is reset at its entry, so descending would only make this block emit
+    /// a redundant reset.
+    ///
+    /// Descending at all matters because a `state` declaration is usually not
+    /// the whole expression: `++state $n` parses as a `Unary` around the decl,
+    /// so a shallow test missed it and an `if` branch holding one never emitted
+    /// its reset — `sub f { if 1 { ++state $n } }` counted 1, 2, 3 across calls
+    /// where raku restarts at 1 each time.
     pub(super) fn expr_has_state_decl(expr: &Expr) -> bool {
+        let any = |es: &[Expr]| es.iter().any(Self::expr_has_state_decl);
         match expr {
-            Expr::DoStmt(stmt) => {
-                if let Stmt::VarDecl { is_state: true, .. } = stmt.as_ref() {
-                    return true;
-                }
-                false
+            Expr::DoStmt(stmt) => match stmt.as_ref() {
+                Stmt::VarDecl { is_state: true, .. } => true,
+                Stmt::VarDecl { expr, .. } | Stmt::Expr(expr) => Self::expr_has_state_decl(expr),
+                _ => false,
+            },
+            Expr::Grouped(e)
+            | Expr::Unary { expr: e, .. }
+            | Expr::PostfixOp { expr: e, .. }
+            | Expr::AssignExpr { expr: e, .. }
+            | Expr::Itemize(e)
+            | Expr::DeitemizeForBind(e)
+            | Expr::Eager(e)
+            | Expr::PositionalPair(e)
+            | Expr::ZenSlice(e) => Self::expr_has_state_decl(e),
+            Expr::Binary { left, right, .. } => {
+                Self::expr_has_state_decl(left) || Self::expr_has_state_decl(right)
             }
+            Expr::Ternary {
+                cond,
+                then_expr,
+                else_expr,
+            } => {
+                Self::expr_has_state_decl(cond)
+                    || Self::expr_has_state_decl(then_expr)
+                    || Self::expr_has_state_decl(else_expr)
+            }
+            Expr::Index { target, index, .. } => {
+                Self::expr_has_state_decl(target) || Self::expr_has_state_decl(index)
+            }
+            Expr::IndexAssign {
+                target,
+                index,
+                value,
+                ..
+            } => {
+                Self::expr_has_state_decl(target)
+                    || Self::expr_has_state_decl(index)
+                    || Self::expr_has_state_decl(value)
+            }
+            Expr::MethodCall { target, args, .. } | Expr::CallOn { target, args } => {
+                Self::expr_has_state_decl(target) || any(args)
+            }
+            Expr::Call { args, .. } | Expr::UserRoutineCall { args, .. } => any(args),
+            Expr::ArrayLiteral(es)
+            | Expr::BracketArray(es, _)
+            | Expr::CaptureLiteral(es)
+            | Expr::StringInterpolation(es) => any(es),
             _ => false,
         }
     }

--- a/t/state-decl-nested-in-expression.t
+++ b/t/state-decl-nested-in-expression.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 12;
+
+# A `state` declaration is usually not the whole expression it sits in:
+# `++state $n` parses as a prefix operator wrapped around the declaration, and
+# `@r.push(state $n // 0)` buries it in a call argument. The compiler decides
+# whether an inline nested block (an `if` branch, a bare block) needs a
+# `ResetStateLocals` by asking whether its statements declare `state` at their
+# own level — and that test only recognized a declaration that WAS the whole
+# expression. So `if 1 { ++state $n }` emitted no reset and its `state` kept
+# counting across calls, where raku restarts it with the branch's clone.
+
+sub incr()  { my @r; if 1 { @r.push(++state $n) }; @r.join(',') }
+is (incr(), incr(), incr()).join('|'), "1|1|1", 'prefix ++ around a state decl';
+
+sub post()  { my @r; if 1 { (state $n)++; @r.push($n) }; @r.join(',') }
+is (post(), post(), post()).join('|'), "1|1|1", '...and a postfix ++';
+
+sub bin()   { my @r; if 1 { @r.push((state $n = 0) + 1); $n++ }; @r.join(',') }
+is (bin(), bin(), bin()).join('|'), "1|1|1", '...an operand of an infix';
+
+sub arg()   { my @r; if 1 { @r.push(++(state $n)) }; @r.join(',') }
+is (arg(), arg(), arg()).join('|'), "1|1|1", '...inside a call argument';
+
+sub tern($c) { my @r; if 1 { @r.push($c ?? ++state $n !! 0) }; @r.join(',') }
+is (tern(1), tern(1)).join('|'), "1|1", '...a ternary branch';
+
+sub arr()   { my @r; if 1 { @r.push([++state $n].join('')) }; @r.join(',') }
+is (arr(), arr()).join('|'), "1|1", '...an array literal element';
+
+sub meth()  { my @r; if 1 { @r.push((++state $n).Str) }; @r.join(',') }
+is (meth(), meth()).join('|'), "1|1", '...a method-call invocant';
+
+sub interp() { my @r; if 1 { @r.push("{++state $n}") }; @r.join(',') }
+is (interp(), interp()).join('|'), "1|1", '...an interpolated string';
+
+sub bare()  { my @r; { @r.push(++state $n) }; @r.join(',') }
+is (bare(), bare()).join('|'), "1|1", 'a bare block resets it too';
+
+# The same walk decides whether a `state` initializer's evaluation can be
+# skipped once initialized: a nested `state` in the RHS must still run its own
+# StateVarInit on every call.
+sub nested() { state $a = (state $b = 0) + 1; $b++; "$a/$b" }
+is (nested(), nested(), nested()).join('|'), "1/1|1/2|1/3",
+    'a nested state decl in an initializer keeps its own init';
+
+# What must NOT restart: a `state` at the routine's own level, however it is
+# wrapped, belongs to the routine's clone.
+sub plain() { ++state $n }
+is (plain(), plain(), plain()).join(','), "1,2,3",
+    'a wrapped state at routine level keeps counting';
+
+sub modif() { my @r; @r.push(++state $n) if 1; @r.join(',') }
+is (modif(), modif(), modif()).join('|'), "1|2|3",
+    'a postfix if introduces no block, so it must not reset';


### PR DESCRIPTION
Raku clones a block every time its enclosing block runs, so a `state` inside an `if` branch or a bare block restarts on every execution of the construct that contains it. mutsu emits an `OpCode::ResetStateLocals` at the head of such an inline block, but only when the block's statements declare `state` — and the test for that, `expr_has_state_decl`, recognized a declaration only when it *was* the whole expression.

It usually is not. `++state $n` parses as a prefix operator wrapped around the declaration:

```raku
sub f() { my @r; if 1 { @r.push(++state $n) }; @r.join(',') }
say (f(), f(), f()).join('|');   # was 1|2|3 — raku says 1|1|1
```

The walk now descends through operator, call, subscript and interpolation shapes, and stops at anything that introduces a block of its own (`Block`, `Lambda`, `AnonSub`, ...) — a `state` in there belongs to *that* clone and is reset at its own entry, so descending would only emit a redundant reset.

The same predicate decides whether a `state` initializer's evaluation can be skipped once the variable is initialized, so widening it also fixes a nested declaration in an initializer (`state $a = (state $b = 0) + 1`), which has to run its own `StateVarInit` on every call.

## Testing

- New `t/state-decl-nested-in-expression.t` (12 cases; passes under `raku` too), covering prefix/postfix `++`, an infix operand, a call argument, a ternary branch, an array-literal element, a method invocant and string interpolation — plus the two shapes that must NOT reset (a `state` at the routine's own level, and one gated by a postfix `if`, which introduces no block).
- `make test`: 2933 files, 27781 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)