### PR TITLE
refactor(compiler,runtime): attribute is default(...) compiles to a child chunk (ADR-0019 D2c-1)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -419,7 +419,31 @@ walkers wholesale is not possible before then.
     registry tables `role_attribute_default_exprs`/`role_class_level_attrs`/
     `class_attribute_default_exprs`) with `CompiledDeclExpr` run through `run_decl_expr`,
     collapsing the three near-duplicated env-setup blocks in `attr_build_defaults.rs`,
-    `methods_object_default_ctor.rs`, and `methods_object_dispatch_new.rs`.
+    `methods_object_default_ctor.rs`, and `methods_object_dispatch_new.rs`. A 2026-08-07
+    research pass (`todo/deep/adr0019-d2c-attribute-default-chunks.md`) found the real
+    footprint substantially larger than this paragraph implies — ≥15 eval sites across 5
+    env-setup shapes, not 3 — and recommended a D2c-1/2/3 split.
+    **D2c-1 partly landed 2026-08-07 (`is_default` only)**: `CompiledAttrDecl::is_default`
+    is now a `DeclTraitArg` (`Literal`/`Compiled`/`Ast`, reusing the existing enum rather
+    than inventing a parallel one) instead of a raw `Expr`. `Compiler::add_class_decl_plan`
+    precompiles each own attribute's `is default(...)` argument into a name-keyed
+    `Vec<(Symbol, DeclTraitArg)>` (`CompiledClassDeclPlan::is_default_chunks`), threaded
+    through `ClassDeclModifiers`/`run_class_body`/`ClassBodyCx` to `class_body_has_decl`,
+    which looks its attribute's chunk up **by name** rather than by registration-walk
+    position — sidestepping the position-alignment risk the research pass flagged, at the
+    cost of a linear per-attribute scan (fine at typical attribute counts). `default` and
+    `where_constraint` are NOT migrated (still `Option<Expr>`, still feed
+    `ClassAttributeDef`, itself unchanged) — `is_default` was chosen first because it is the
+    only one of the three that is read-and-discarded at registration time rather than
+    stored for later (construction-time) evaluation, so it did not require also migrating
+    `ClassAttributeDef` and the ~15 downstream eval sites in the same PR. Only 2 of the 4
+    `CompiledAttrDecl::from_stmt` call sites read `is_default` at all
+    (`class_body_has_decl`, `role_body_has_decl`); the other two (the mainline/EVAL
+    `has`-outside-class error path, `augment class`) never did. `role_body_has_decl` keeps
+    stashing a raw `Expr` into the `role_attribute_default_exprs` registry table (D2c-3
+    scope) via a new `DeclTraitArg::as_expr()` escape valve, since no compiled plan exists
+    for that path yet. Remaining: `default`/`where_constraint` type-swap plus the ~15 eval
+    sites (D2c-2), and the three role registry tables (D2c-3).
   - [ ] **D2d — Publish generated accessors through the canonical table.** Give `MethodEntry` an
     accessor arm populated from `ClassDef::attributes` in `sync_user_method_entries`, so
     `has_public_accessor`/`resolve_user_method_or_accessor` (`class_introspection.rs`) and the

--- a/news/2026-08/d2c1-is-default-attribute-chunk.md
+++ b/news/2026-08/d2c1-is-default-attribute-chunk.md
@@ -1,0 +1,45 @@
+# ADR-0019 D2c-1: attribute `is default(...)` compiles to a child chunk
+
+A scoping pass over D2c ("compile defaults/constraints as child chunks",
+`todo/deep/adr0019-d2c-attribute-default-chunks.md`) found the box
+substantially bigger than the ADR text implies: at least 15 eval sites
+across 5 env-setup shapes, plus an architectural gap D2b didn't close
+(`CompiledAttrDecl::from_stmt` has no `Compiler` in scope at 3 of its 4 call
+sites). This lands the first, narrowly-scoped slice of the recommended
+D2c-1/2/3 split: the `is default(...)` trait argument on a directly-declared
+class attribute.
+
+`CompiledAttrDecl::is_default` is now a `DeclTraitArg` (the existing
+`Literal`/`Compiled`/`Ast` enum used elsewhere for declaration trait
+arguments) instead of a raw `Expr`. `Compiler::add_class_decl_plan`
+precompiles every own attribute's `is default(...)` argument into a
+name-keyed `Vec<(Symbol, DeclTraitArg)>`
+(`CompiledClassDeclPlan::is_default_chunks`), threaded through
+`ClassDeclModifiers` → `run_class_body` → `ClassBodyCx` to
+`class_body_has_decl`, which looks its current attribute's chunk up **by
+name** rather than by registration-walk position. Keying by name instead of
+position was a deliberate simplification over the position-zip approach
+the scoping pass suggested: it sidesteps entirely the risk of the
+registration-time traversal order silently drifting from the compile-time
+one (SyntheticBlock flattening, nested-sub-declared attributes), at the cost
+of a linear per-attribute scan — fine at ordinary attribute counts.
+
+`is_default` was picked over `default`/`where_constraint` for this first
+slice because it is read-and-discarded once at registration time
+(`class_body_has_decl` evaluates it immediately) rather than stored on
+`ClassAttributeDef` for later construction-time evaluation. Migrating
+`default`/`where_constraint` requires `ClassAttributeDef` itself to change
+in lockstep — that stays D2c-2. Only 2 of the 4 `CompiledAttrDecl::from_stmt`
+call sites ever read `.is_default` at all (`class_body_has_decl`,
+`role_body_has_decl`); the mainline/EVAL `has`-outside-class error path and
+`augment class` never did, so they needed no behavior change beyond passing
+`None` for the new precompiled-chunk parameter. `role_body_has_decl` still
+stashes a raw `Expr` into the `role_attribute_default_exprs` registry table
+(D2c-3's territory — role attribute defaults defer to composition time) via
+a new `DeclTraitArg::as_expr()` escape valve, since no compiled plan exists
+for that path yet.
+
+While writing the regression test for this slice, a pre-existing, unrelated
+bug surfaced: a role-composed attribute's `is default(...)` does not restore
+correctly after `= Nil` (`todo/tickets/role-attribute-is-default-nil-restore-after-composition.md`).
+Reproduces identically before this change; left for separate investigation.

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -79,6 +79,7 @@ impl Compiler {
         let Stmt::ClassDecl {
             name_expr,
             custom_traits,
+            body,
             ..
         } = stmt
         else {
@@ -86,7 +87,67 @@ impl Compiler {
         };
         let name_chunk = name_expr.as_ref().map(|e| self.compile_decl_expr(e));
         let trait_args = self.compile_decl_trait_args(custom_traits);
-        self.code.add_class_decl_plan(stmt, name_chunk, trait_args)
+        let is_default_chunks = self.compile_attr_is_default_chunks(body);
+        self.code
+            .add_class_decl_plan(stmt, name_chunk, trait_args, is_default_chunks)
+    }
+
+    /// Precompile the `is default(...)` trait argument of each of a class
+    /// body's own attributes into a child chunk (ADR-0019 D2c), keyed by
+    /// attribute name so `class_body_has_decl` can look one up without
+    /// depending on its registration-time walk visiting attributes in
+    /// exactly this order. Mirrors `class_body_has_decl`'s eligibility
+    /// (`our`/`my` class-level attributes never reach the `is_default` arm —
+    /// see `run_class_body`'s early `SkipTail` return) and
+    /// `collect_nested_class_has_decls`'s traversal (SyntheticBlock-flattened
+    /// top level plus `has` nested directly inside a body `sub`, recursively).
+    fn compile_attr_is_default_chunks(
+        &self,
+        body: &[Stmt],
+    ) -> Vec<(Symbol, crate::opcode::DeclTraitArg)> {
+        let mut out = Vec::new();
+        self.collect_attr_is_default_chunks(body, &mut out);
+        out
+    }
+
+    fn collect_attr_is_default_chunks(
+        &self,
+        body: &[Stmt],
+        out: &mut Vec<(Symbol, crate::opcode::DeclTraitArg)>,
+    ) {
+        for stmt in body {
+            match stmt {
+                Stmt::SyntheticBlock(inner) => self.collect_attr_is_default_chunks(inner, out),
+                Stmt::HasDecl {
+                    name,
+                    is_our,
+                    is_my,
+                    is_default: Some(expr),
+                    ..
+                } if !*is_our && !*is_my => {
+                    out.push((*name, self.compile_decl_trait_arg(expr)));
+                }
+                Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } | Stmt::HasDecl { .. } => {}
+                Stmt::SubDecl { body: inner, .. } => {
+                    for s in inner {
+                        if let Stmt::HasDecl {
+                            name,
+                            is_our,
+                            is_my,
+                            is_default: Some(expr),
+                            ..
+                        } = s
+                            && !*is_our
+                            && !*is_my
+                        {
+                            out.push((*name, self.compile_decl_trait_arg(expr)));
+                        }
+                    }
+                    self.collect_attr_is_default_chunks(inner, out);
+                }
+                _ => {}
+            }
+        }
     }
 
     /// [`Self::add_sub_decl_plan`] for a role declaration. A role's name is

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2792,7 +2792,7 @@ impl Compiler {
                 // and `sigil` is always `$`/`@`/`%` (the parser never produces
                 // `.`/`!`), so `CompiledAttrDecl::from_stmt`'s fields match
                 // this arm's historical `bare`/`sigil_ch` derivation exactly.
-                let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt);
+                let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt, None);
                 let twigil = if decl.is_public { "." } else { "!" };
                 let full_name = format!("{}{}{}", decl.sigil, twigil, decl.name);
                 let mut attrs = std::collections::HashMap::new();

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -300,7 +300,12 @@ pub(crate) struct CompiledAttrDecl {
     pub(crate) is_alias: bool,
     pub(crate) is_our: bool,
     pub(crate) is_my: bool,
-    pub(crate) is_default: Option<crate::ast::Expr>,
+    /// The `is default(...)` trait argument (ADR-0019 D2c). `Ast` unless a
+    /// caller with compiler access at plan-lowering time (currently
+    /// `class_body_has_decl`, via `CompiledClassDeclPlan::is_default_chunks`)
+    /// supplied a precompiled `Literal`/`Compiled` replacement — see
+    /// [`Self::from_stmt`].
+    pub(crate) is_default: Option<DeclTraitArg>,
     pub(crate) is_type: Option<String>,
     pub(crate) deprecated_message: Option<String>,
     pub(crate) is_built: Option<bool>,
@@ -311,7 +316,18 @@ impl CompiledAttrDecl {
     /// Build a typed descriptor from a `Stmt::HasDecl`. Panics on any other
     /// statement kind — every call site already matched on `Stmt::HasDecl`
     /// before reaching here.
-    pub(crate) fn from_stmt(stmt: &Stmt) -> CompiledAttrDecl {
+    ///
+    /// `is_default_chunk` is a precompiled replacement for the `is
+    /// default(...)` trait argument, looked up by the caller (by attribute
+    /// name) from a `CompiledClassDeclPlan`/`CompiledRoleDeclPlan` built at
+    /// compile time. Pass `None` when no such plan is available (registration
+    /// paths that still walk a raw AST body, e.g. role bodies and `augment
+    /// class`) — the raw expression is kept as `DeclTraitArg::Ast`, the same
+    /// fallback used elsewhere for not-yet-migrated declaration kinds.
+    pub(crate) fn from_stmt(
+        stmt: &Stmt,
+        is_default_chunk: Option<&DeclTraitArg>,
+    ) -> CompiledAttrDecl {
         let Stmt::HasDecl {
             name,
             is_public,
@@ -351,7 +367,9 @@ impl CompiledAttrDecl {
             is_alias: *is_alias,
             is_our: *is_our,
             is_my: *is_my,
-            is_default: is_default.clone(),
+            is_default: is_default_chunk
+                .cloned()
+                .or_else(|| is_default.clone().map(|e| DeclTraitArg::Ast(Box::new(e)))),
             is_type: is_type.clone(),
             deprecated_message: deprecated_message.clone(),
             is_built: *is_built,
@@ -2033,6 +2051,21 @@ impl DeclTraitArg {
             DeclTraitArg::Compiled(_) => None,
         }
     }
+
+    /// Reconstruct an `Expr` from the argument. An escape valve for the few
+    /// remaining consumers that store an `Expr` rather than evaluating it
+    /// immediately (the role attribute-default registry tables, ADR-0019
+    /// D2c-3) — never called on a `Compiled` chunk, since nothing on those
+    /// still-AST-walking paths produces one.
+    pub(crate) fn as_expr(&self) -> Expr {
+        match self {
+            DeclTraitArg::Literal(value) => Expr::Literal(value.clone()),
+            DeclTraitArg::Ast(expr) => (**expr).clone(),
+            DeclTraitArg::Compiled(_) => {
+                unreachable!("DeclTraitArg::as_expr called on a Compiled chunk")
+            }
+        }
+    }
 }
 
 /// A declaration's custom traits as registration consumes them: the trait name
@@ -2391,6 +2424,12 @@ pub(crate) struct CompiledClassDeclPlan {
     /// `run_class_body` re-scanning the (flattened, nested-sub-surfaced)
     /// body on every registration.
     pub(crate) own_attribute_names: Vec<Symbol>,
+    /// Precompiled `is default(...)` trait argument for each own attribute
+    /// that declares one (ADR-0019 D2c), keyed by attribute name rather than
+    /// position — `class_body_has_decl` looks a chunk up by the `Stmt::HasDecl`
+    /// it is currently visiting instead of relying on the registration-time
+    /// walk visiting attributes in the same order this was built in.
+    pub(crate) is_default_chunks: Vec<(Symbol, DeclTraitArg)>,
 }
 
 #[derive(Debug, Clone)]
@@ -5586,6 +5625,7 @@ impl CompiledCode {
         stmt: &Stmt,
         name_chunk: Option<CompiledDeclExpr>,
         trait_args: Vec<Option<DeclTraitArg>>,
+        is_default_chunks: Vec<(Symbol, DeclTraitArg)>,
     ) -> u32 {
         let Stmt::ClassDecl {
             name,
@@ -5635,6 +5675,7 @@ impl CompiledCode {
             is_stub,
             trusts,
             own_attribute_names,
+            is_default_chunks,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Class(plan_idx));

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -200,6 +200,12 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// of `run_class_body` re-scanning the body for `Stmt::HasDecl` at
     /// registration time.
     pub(crate) own_attribute_names: &'a [Symbol],
+    /// Precompiled `is default(...)` trait-argument chunks for this class
+    /// body's own attributes (ADR-0019 D2c), keyed by attribute name, threaded
+    /// down to `class_body_has_decl` via `ClassBodyCx`. Empty for
+    /// registration paths with no compiled plan available (role bodies,
+    /// `augment class`) — those keep evaluating the raw AST expression.
+    pub(crate) attr_is_default_chunks: &'a [(Symbol, crate::opcode::DeclTraitArg)],
 }
 
 pub(super) fn parse_role_type_args(input: &str) -> Vec<String> {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -271,7 +271,7 @@ impl Interpreter {
                     }
                 }
                 Stmt::HasDecl { .. } => {
-                    let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt);
+                    let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt, None);
                     let attr_name_str = decl.name.clone();
                     let attr_var_name = if decl.is_public {
                         format!(".{}", attr_name_str)
@@ -738,6 +738,7 @@ impl Interpreter {
             is_stub: false,
             trusts: &[],
             own_attribute_names: &[],
+            attr_is_default_chunks: &[],
         };
         self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
         self.store_language_revision_from_version(&pun_name, &language_version);

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -23,6 +23,10 @@ pub(super) struct ClassBodyCx<'a> {
     /// role-composed attributes: the full set of attributes valid for
     /// `$!attr` access.
     pub(super) class_own_attrs: HashSet<String>,
+    /// Precompiled `is default(...)` chunks for this class body's own
+    /// attributes (ADR-0019 D2c), keyed by attribute name; see
+    /// `class_body_has_decl`.
+    pub(super) is_default_chunks: &'a [(Symbol, crate::opcode::DeclTraitArg)],
 }
 
 impl ClassBodyCx<'_> {
@@ -80,6 +84,7 @@ impl Interpreter {
         class_is_rw: bool,
         class_lang_rev: &str,
         own_attribute_names: &[Symbol],
+        is_default_chunks: &[(Symbol, crate::opcode::DeclTraitArg)],
     ) -> Result<ClassDef, RuntimeError> {
         let saved_package = self.current_package();
         let saved_env = self.env.clone();
@@ -121,6 +126,7 @@ impl Interpreter {
             saved_env,
             class_def,
             class_own_attrs,
+            is_default_chunks,
         };
         let saved_functions_keys: HashSet<String> = self
             .registry()

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -113,7 +113,20 @@ impl Interpreter {
         cx: &mut ClassBodyCx<'_>,
         stmt: &Stmt,
     ) -> Result<ClassBodyFlow, RuntimeError> {
-        let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt);
+        // Look up this attribute's precompiled `is default(...)` chunk (ADR-0019
+        // D2c) by name before building `decl` — `Stmt::HasDecl::name` is cheap to
+        // read directly, and a name-keyed lookup does not depend on this walk
+        // visiting attributes in the same order `compile_attr_is_default_chunks`
+        // built the plan's chunk list in.
+        let is_default_chunk = match stmt {
+            Stmt::HasDecl { name, .. } => cx
+                .is_default_chunks
+                .iter()
+                .find(|(n, _)| n == name)
+                .map(|(_, chunk)| chunk),
+            _ => None,
+        };
+        let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt, is_default_chunk);
         let attr_name_str = decl.name.clone();
 
         // An initializer that can never satisfy the constraint is a
@@ -214,8 +227,8 @@ impl Interpreter {
         // .VAR.default and Nil-restore behavior.
         // When only `default` is set (from `is default(X)` without `= value`),
         // also store it as the is_default trait value.
-        if let Some(is_default_expr) = &decl.is_default {
-            if let Ok(val) = self.eval_block_value(&[Stmt::Expr(is_default_expr.clone())]) {
+        if let Some(is_default_arg) = &decl.is_default {
+            if let Ok(val) = self.eval_decl_trait_arg(is_default_arg) {
                 // Type-check the default value against the attribute's type
                 // constraint. For an object hash (`%.a{KeyType}`) the
                 // constraint is `ValueType{KeyType}`; the `is default`

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -126,6 +126,7 @@ impl Interpreter {
             is_stub: is_stub_body,
             trusts,
             own_attribute_names,
+            attr_is_default_chunks,
         } = modifiers;
         let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
@@ -223,6 +224,7 @@ impl Interpreter {
             class_is_rw,
             &class_lang_rev,
             own_attribute_names,
+            attr_is_default_chunks,
         )?;
         self.finalize_class_registration(name, parents, class_def, &snapshot)?;
         self.install_class_exporthow(name, parents)?;

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -16,7 +16,7 @@ impl Interpreter {
         cx: &mut RoleDeclCx<'_>,
         stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
-        let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt);
+        let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt, None);
         let attr_name_str = decl.name.clone();
         // A class-level (`my $.x` / `our $.x`) role attribute is NOT a
         // per-instance attribute: it becomes a class-level attribute on the
@@ -63,10 +63,10 @@ impl Interpreter {
         // until composition. Stash the expression keyed by (role, attr);
         // it is copied to the consuming class and evaluated at instance
         // construction (with type params bound).
-        if let Some(def_expr) = &decl.is_default {
+        if let Some(def_arg) = &decl.is_default {
             self.registry_mut().role_attribute_default_exprs.insert(
                 (cx.name.to_string(), attr_name_str.clone()),
-                def_expr.clone(),
+                def_arg.as_expr(),
             );
         }
         // Check if this attribute already exists from a composed role

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -65,6 +65,7 @@ impl Interpreter {
             is_stub: false,
             trusts: &[],
             own_attribute_names: &[],
+            attr_is_default_chunks: &[],
         };
         self.register_class_decl(&name, &parents, modifiers, &[])?;
         self.compose_mixin_role_submethods(&name, &fresh);

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -138,6 +138,7 @@ impl Interpreter {
             is_stub,
             trusts,
             own_attribute_names,
+            is_default_chunks,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {
@@ -250,6 +251,7 @@ impl Interpreter {
                         is_stub: *is_stub,
                         trusts,
                         own_attribute_names,
+                        attr_is_default_chunks: is_default_chunks,
                     },
                     body,
                 )

--- a/t/attribute-is-default-plan-chunk.t
+++ b/t/attribute-is-default-plan-chunk.t
@@ -1,0 +1,73 @@
+use Test;
+
+# `is default(...)` on a class attribute is now precompiled into a child
+# chunk at plan-lowering time (ADR-0019 D2c) instead of being re-compiled by
+# `eval_block_value` every time the class body registers. Exercise the
+# non-literal-expression path (forces the `Compiled` chunk, not the `Literal`
+# fast path) and repeated registration of the same declaration site with
+# different closed-over state, to make sure the precompiled chunk resolves
+# free variables dynamically per registration rather than baking in a stale
+# value.
+
+# Non-literal is-default expression on a class attribute.
+{
+    my $base = 10;
+    class WithComputedDefault {
+        has $.x is default($base + 5) is rw;
+    }
+    my $obj = WithComputedDefault.new;
+    is $obj.x, 15, 'is default(...) with a non-literal expr evaluates correctly';
+    $obj.x = Nil;
+    is $obj.x, 15, 'assigning Nil restores the computed default';
+}
+
+# The same declaration site re-registered across loop iterations must see
+# each iteration's own closed-over value, not a value baked in once.
+{
+    my @firsts;
+    my @restored;
+    for 1..3 -> $n {
+        my class Repeated {
+            has $.y is default($n * 100) is rw;
+        }
+        my $obj = Repeated.new;
+        @firsts.push($obj.y);
+        $obj.y = Nil;
+        @restored.push($obj.y);
+    }
+    is-deeply @firsts, [100, 200, 300],
+        'is default(...) picks up each registration\'s own loop-variable binding';
+    is-deeply @restored, [100, 200, 300],
+        'Nil-restore after repeated registration uses the matching binding too';
+}
+
+# `is default(...)` alongside an explicit `=` initializer: the initializer
+# wins on construction, the is-default value wins after Nil is assigned.
+{
+    my $d = 7;
+    class WithBoth {
+        has $.z is default($d * 2) is rw = 1;
+    }
+    my $obj = WithBoth.new;
+    is $obj.z, 1, 'explicit initializer wins over is default(...) on construction';
+    $obj.z = Nil;
+    is $obj.z, 14, 'is default(...) wins after Nil is assigned';
+}
+
+# A role attribute's `is default(...)` still evaluates correctly (not
+# migrated to a precompiled chunk in this slice — role attribute defaults are
+# deferred to composition time via the Expr-valued registry table, ADR-0019
+# D2c-3), so this is a regression guard that the class-side change didn't
+# disturb it. (Nil-restore of a role-composed attribute's `is default(...)`
+# is a separate, pre-existing bug — reproduces identically before this
+# change — and is out of scope here.)
+{
+    role R {
+        has $.w is default(21) is rw;
+    }
+    class Consumer does R { }
+    my $obj = Consumer.new;
+    is $obj.w, 21, 'role attribute is default(...) still evaluates at composition/construction';
+}
+
+done-testing;

--- a/todo/deep/adr0019-d2c-attribute-default-chunks.md
+++ b/todo/deep/adr0019-d2c-attribute-default-chunks.md
@@ -105,12 +105,38 @@ no changes. This unblocks migrating `role_attribute_default_exprs`/
 
 ## Recommended split for whoever picks this up
 
-- **D2c-1**: extend `add_class_decl_plan`/`add_role_decl_plan` to compile
+- **D2c-1** (`is_default` slice landed 2026-08-07, `default`/`where_constraint`
+  still open): extend `add_class_decl_plan`/`add_role_decl_plan` to compile
   per-attribute `default`/`where_constraint`/`is_default` chunks alongside
   `own_attribute_names`, thread through the plans, change `CompiledAttrDecl`'s
   three fields to a `Literal(Value) | Compiled(CompiledDeclExpr)` shape
   (name it after `DeclTraitArg`'s pattern, or reuse `DeclTraitArg` itself —
   worth deciding during implementation), update its 4 call sites.
+  **What actually landed**: only `is_default`, reusing `DeclTraitArg` as-is
+  (its existing `Ast` variant absorbed the "not yet migrated" callers for
+  free — no new fallback needed). `Compiler::add_class_decl_plan` now builds
+  `CompiledClassDeclPlan::is_default_chunks: Vec<(Symbol, DeclTraitArg)>`,
+  **keyed by attribute name** rather than position — this sidesteps the
+  position-alignment risk called out above entirely (`class_body_has_decl`
+  looks up its current `Stmt::HasDecl`'s name in the vec instead of relying
+  on registration-time traversal order matching compile-time traversal
+  order). The reason it stopped at `is_default` rather than all three
+  fields: `default`/`where_constraint` are *stored* into
+  `ClassAttributeDef` for later (construction-time) evaluation, so switching
+  their type requires `ClassAttributeDef` to change in the same PR — that's
+  D2c-2's work, described below unchanged. `is_default` is different: it is
+  read-and-discarded once at registration time (`class_body_has_decl`
+  evaluates it immediately via the new `eval_decl_trait_arg`, matching what
+  `eval_block_value(&[Stmt::Expr(...)])` did before, just without the
+  on-demand compile now that the common non-literal case is precompiled).
+  Only 2 of the 4 `from_stmt` call sites ever read `.is_default`
+  (`class_body_has_decl`, `role_body_has_decl`); the mainline/EVAL
+  `has`-outside-class error path and `augment class` never did, so they
+  needed no behavior change beyond passing `None` for the new
+  `is_default_chunk` parameter. `role_body_has_decl` still stashes a raw
+  `Expr` into `role_attribute_default_exprs` (D2c-3 territory) via a new
+  `DeclTraitArg::as_expr()` escape valve. See
+  `news/2026-08/d2c1-is-default-attribute-chunk.md`.
 - **D2c-2**: change `ClassAttributeDef.default`/`where_constraint`
   (`src/runtime/mod.rs`) to match — it's copied straight from
   `CompiledAttrDecl` at registration, so this is a cheap follow-on once

--- a/todo/tickets/role-attribute-is-default-nil-restore-after-composition.md
+++ b/todo/tickets/role-attribute-is-default-nil-restore-after-composition.md
@@ -1,0 +1,52 @@
+# A role-composed attribute's `is default(...)` does not restore after `= Nil`
+
+Found 2026-08-07 while writing a regression test for ADR-0019 D2c (attribute
+`is default(...)` chunk compilation). Unrelated to that change — reproduces
+identically on `main` before it.
+
+## Repro
+
+```raku
+role R { has $.w is default(21) is rw; }
+class Consumer does R { }
+my $obj = Consumer.new;
+say $obj.w;        # 21 — correct
+$obj.w = Nil;
+say $obj.w;         # mutsu: "" (Nil) — raku: 21
+```
+
+`raku` prints `21` both times. mutsu prints `21` then an empty string (`Nil`)
+after the reassignment — the default is used for the initial value but not
+for Nil-restore.
+
+## Likely area
+
+A role's `is default(...)` expression is stored in
+`Registry::role_attribute_default_exprs` (keyed by `(role, attr)`,
+`src/runtime/registration_role_body.rs`) and copied onto the consuming class
+into `Registry::class_attribute_default_exprs` (keyed by `(class, attr)`) at
+composition time (`src/runtime/registration_class_compose.rs:207-222`). A
+*directly declared* class attribute's `is default(...)` instead lives on
+`ClassAttributeDef` itself and is evaluated inline by `class_body_has_decl`
+(`src/runtime/registration_class_body_attr.rs`) into
+`Registry::class_attribute_defaults: HashMap<(String, String), Value>` (an
+already-evaluated *value* table, distinct from the *expression* table above
+despite the similar name). The Nil-restore path
+(`src/runtime/runtime_var_meta.rs:400`) reads `class_attribute_default_exprs`
+directly rather than routing through whatever resolves
+`class_attribute_defaults` for the direct-declaration case — worth checking
+whether the restore path only consults one of the two tables, or evaluates
+the expr fresh but with a package/env mismatch (a role's `is default` body
+was compiled/stored before the class-composition rename pass runs, so
+`self`/`::?CLASS` inside it may not resolve against the consuming class).
+Not investigated further — needs a `raku --target=ast` / `MUTSU_TRACE`
+comparison to pin down which of the two tables the restore path actually
+reads and why it comes up empty for the role-composed case specifically.
+
+## Why deferred
+
+Out of scope for the PR that found it (ADR-0019 D2c-1, which only touches
+directly-declared class attributes' `is default`, not role-composed ones —
+that's D2c-3, migrating `role_attribute_default_exprs`/
+`class_attribute_default_exprs` off raw `Expr`s). Fixing this bug is
+independent of that migration; it's a plain restore-path logic gap.


### PR DESCRIPTION
## Summary
- ADR-0019 D2c ("compile defaults/constraints as child chunks") turned out substantially bigger than the ADR text implied — a 2026-08-07 scoping pass (`todo/deep/adr0019-d2c-attribute-default-chunks.md`, PR #6026) found ≥15 eval sites across 5 env-setup shapes, plus a gap D2b left unclosed (`CompiledAttrDecl::from_stmt` has no `Compiler` in scope at 3 of its 4 call sites).
- This lands the first slice of the recommended D2c-1/2/3 split: `CompiledAttrDecl::is_default` becomes a `DeclTraitArg` (reusing the existing `Literal`/`Compiled`/`Ast` enum), precompiled per-attribute at plan-lowering time (`Compiler::add_class_decl_plan`) into a **name-keyed** `CompiledClassDeclPlan::is_default_chunks`, threaded through `ClassDeclModifiers` → `run_class_body` → `ClassBodyCx` to `class_body_has_decl`. Keying by attribute name rather than registration-walk position sidesteps the traversal-order-matching risk the scoping pass flagged.
- `default`/`where_constraint` stay `Option<Expr>` for now (that's D2c-2) — they're stored on `ClassAttributeDef` for later construction-time evaluation, unlike `is_default`, which is read-and-discarded once at registration time and so didn't require migrating `ClassAttributeDef` in the same PR.
- Only 2 of the 4 `CompiledAttrDecl::from_stmt` call sites ever read `.is_default` (`class_body_has_decl`, `role_body_has_decl`); the mainline/EVAL `has`-outside-class error path and `augment class` never did. `role_body_has_decl` keeps stashing a raw `Expr` into the `role_attribute_default_exprs` registry table (D2c-3 scope) via a new `DeclTraitArg::as_expr()` escape valve.
- Filed a pre-existing, unrelated bug found while writing the regression test: a role-composed attribute's `is default(...)` doesn't restore correctly after `= Nil` (`todo/tickets/role-attribute-is-default-nil-restore-after-composition.md`) — reproduces identically on `main`, left for separate investigation.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] `cargo test --lib` (672 passed)
- [x] `prove -j4 -e target/debug/mutsu t/` — 2933 files, all pass (includes new `t/attribute-is-default-plan-chunk.t`)
- [x] `MUTSU_FUDGE=1 MUTSU_BIN=target/release/mutsu prove -e scripts/run-roast-test.sh roast/S12-attributes/*.t roast/6.c/S14-roles/*.t roast/S14-roles/*.t` — all pass except `roast/S12-attributes/trusts.t`, confirmed pre-existing (identical 6/15 failure on `main`, not whitelisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)