### PR TITLE
fix(runtime): role-composed attribute is default(...) restores after Nil

### DIFF
--- a/news/2026-08/role-attribute-is-default-nil-restore.md
+++ b/news/2026-08/role-attribute-is-default-nil-restore.md
@@ -1,0 +1,38 @@
+# A role-composed attribute's `is default(...)` now restores after Nil
+
+A directly-declared class attribute's `is default(...)` restores correctly
+when `Nil` is assigned to it, but a role-composed one did not:
+
+```raku
+role R { has $.w is default(21) is rw; }
+class Consumer does R { }
+my $obj = Consumer.new;
+say $obj.w;        # 21 — correct
+$obj.w = Nil;
+say $obj.w;         # was printing Nil; now correctly prints 21
+```
+
+The root cause was a second registry table. A directly-declared attribute's
+`is default(...)` is evaluated once at registration and cached as a `Value`
+in `Registry::class_attribute_defaults`. A role attribute's default may
+reference the role's type parameter (`is default(T)`), so it can't be
+evaluated until the role is composed into a class — it is instead copied
+onto the consuming class as a raw `Expr` in a separate table,
+`Registry::class_attribute_default_exprs`, evaluated on demand later.
+
+Every Nil-restore call site (the per-method-call `$!attr`/`$.attr` default
+seeding in `vm_method_dispatch.rs`, and the direct rw-accessor-assignment
+paths in `methods_mut_method_lvalue.rs`/`builtins_multidim_assign.rs`) only
+ever consulted the `Value` table, so a role-composed attribute's default was
+silently treated as absent. A new helper,
+`Interpreter::class_attribute_default_with_role_fallback`, falls back to
+evaluating the `Expr` table when the `Value` table misses (mirroring the
+fallback `apply_container_attribute_defaults` already used for `@`/`%`
+element defaults), and all seven call sites now go through it. The
+`any_attr_defaults` fast-gate in `vm_method_dispatch.rs` was widened to also
+check the `Expr` table, since a program with only role-attribute defaults
+(no directly-declared ones) previously skipped the whole mechanism.
+
+Found while writing a regression test for ADR-0019 D2c-1
+(`news/2026-08/d2c1-is-default-attribute-chunk.md`); unrelated to that
+change and fixed separately.

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -120,7 +120,7 @@ impl Interpreter {
             } else {
                 // Check class_attribute_default for instance attributes
                 let class_default = if let ValueView::Instance { class_name, .. } = target.view() {
-                    self.class_attribute_default(&class_name.resolve(), &method)
+                    self.class_attribute_default_with_role_fallback(&class_name.resolve(), &method)
                 } else {
                     None
                 };
@@ -324,7 +324,7 @@ impl Interpreter {
         // `is default(...)`, else the attribute's declared default, else Nil.
         let absent_default = self.container_default(&current).or_else(|| {
             if let ValueView::Instance { class_name, .. } = target.view() {
-                self.class_attribute_default(&class_name.resolve(), &method)
+                self.class_attribute_default_with_role_fallback(&class_name.resolve(), &method)
             } else {
                 None
             }

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -825,7 +825,8 @@ impl Interpreter {
                     // When Nil is assigned to an attribute with `is default(...)`,
                     // restore the default value instead of setting Nil.
                     if assigned_value.is_nil()
-                        && let Some(def) = self.class_attribute_default(qualifier, &attr_name)
+                        && let Some(def) =
+                            self.class_attribute_default_with_role_fallback(qualifier, &attr_name)
                     {
                         assigned_value = def;
                     }
@@ -899,7 +900,8 @@ impl Interpreter {
                     // When Nil is assigned to an attribute with `is default(...)`,
                     // restore the default value instead of setting Nil.
                     if assigned_value.is_nil()
-                        && let Some(def) = self.class_attribute_default(qualifier, actual_method)
+                        && let Some(def) = self
+                            .class_attribute_default_with_role_fallback(qualifier, actual_method)
                     {
                         assigned_value = def;
                     }
@@ -1107,7 +1109,7 @@ impl Interpreter {
                 // because Nil will be replaced by the default value.
                 let nil_has_default = value.is_nil()
                     && self
-                        .class_attribute_default(&class_name.resolve(), method)
+                        .class_attribute_default_with_role_fallback(&class_name.resolve(), method)
                         .is_some();
                 // Nil assigned to a typed attribute restores the type object default
                 let nil_restores_type = value.is_nil() && !nil_has_default;
@@ -1198,7 +1200,8 @@ impl Interpreter {
                 // When Nil is assigned to an attribute with `is default(...)`,
                 // restore the default value instead of setting Nil.
                 if assigned_value.is_nil()
-                    && let Some(def) = self.class_attribute_default(&class_name.resolve(), method)
+                    && let Some(def) = self
+                        .class_attribute_default_with_role_fallback(&class_name.resolve(), method)
                 {
                     assigned_value = def;
                 }
@@ -1392,7 +1395,8 @@ impl Interpreter {
             // When Nil is assigned to an attribute with `is default(...)`,
             // restore the default value instead of setting Nil.
             if assigned_value.is_nil()
-                && let Some(def) = self.class_attribute_default(&class_name.resolve(), &attr_name)
+                && let Some(def) = self
+                    .class_attribute_default_with_role_fallback(&class_name.resolve(), &attr_name)
             {
                 assigned_value = def;
             }

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -323,6 +323,36 @@ impl Interpreter {
             .cloned()
     }
 
+    /// [`Self::class_attribute_default`], falling back to evaluating a
+    /// role-composed attribute's deferred `is default(...)` expression.
+    ///
+    /// A *directly declared* class attribute's `is default(...)` is
+    /// evaluated once at registration and cached in `class_attribute_defaults`
+    /// (a `Value` table). A *role-composed* attribute's `is default(...)` may
+    /// reference the role's type parameters (`is default(T)`), so it cannot
+    /// be evaluated until composition — it is copied onto the consuming class
+    /// as a raw expression in `class_attribute_default_exprs` instead (see
+    /// `registration_class_compose.rs`). Reading only the `Value` table (as
+    /// `class_attribute_default` does) silently treats a role-composed
+    /// attribute as if it declared no default at all — this is the fallback
+    /// that `apply_container_attribute_defaults` already applies for
+    /// `@`/`%` element defaults; scalar restore-on-Nil callers need the same.
+    pub(crate) fn class_attribute_default_with_role_fallback(
+        &mut self,
+        class_name: &str,
+        attr_name: &str,
+    ) -> Option<Value> {
+        self.class_attribute_default(class_name, attr_name)
+            .or_else(|| {
+                let expr = self
+                    .registry()
+                    .class_attribute_default_exprs
+                    .get(&(class_name.to_string(), attr_name.to_string()))
+                    .cloned()?;
+                self.eval_block_value(&[crate::ast::Stmt::Expr(expr)]).ok()
+            })
+    }
+
     /// Get the `is DEPRECATED` message for a class attribute accessor.
     pub(crate) fn class_attribute_deprecated(
         &self,

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -511,7 +511,8 @@ impl Interpreter {
         // program declaring ANY attribute default: the common no-default case
         // otherwise paid 2 lookups (each allocating a (String, String) key)
         // per attribute on every method call.
-        let any_attr_defaults = !self.registry().class_attribute_defaults.is_empty();
+        let any_attr_defaults = !self.registry().class_attribute_defaults.is_empty()
+            || !self.registry().class_attribute_default_exprs.is_empty();
         if any_attr_defaults {
             for attr_name in attributes.keys() {
                 let attr_name = attr_name.as_str();
@@ -520,8 +521,13 @@ impl Interpreter {
                 }
                 // Check both the owner class and the receiver class for defaults
                 let default_val = self
-                    .class_attribute_default(owner_class, attr_name)
-                    .or_else(|| self.class_attribute_default(receiver_class_name, attr_name));
+                    .class_attribute_default_with_role_fallback(owner_class, attr_name)
+                    .or_else(|| {
+                        self.class_attribute_default_with_role_fallback(
+                            receiver_class_name,
+                            attr_name,
+                        )
+                    });
                 if let Some(def) = default_val {
                     // Register for $!attr and $.attr variable names
                     self.set_var_default(&format!("!{}", attr_name), def.clone());
@@ -1419,7 +1425,8 @@ impl Interpreter {
 
         // Register `is default(...)` values for attribute variables. Gated on
         // the program declaring ANY attribute default (see the slow path).
-        let any_attr_defaults = !self.registry().class_attribute_defaults.is_empty();
+        let any_attr_defaults = !self.registry().class_attribute_defaults.is_empty()
+            || !self.registry().class_attribute_default_exprs.is_empty();
         if any_attr_defaults && let Some(cell) = &attrs_cell {
             let attr_names: Vec<&'static str> = cell
                 .as_map()
@@ -1429,8 +1436,13 @@ impl Interpreter {
                 .collect();
             for attr_name in &attr_names {
                 let default_val = self
-                    .class_attribute_default(owner_class, attr_name)
-                    .or_else(|| self.class_attribute_default(receiver_class_name, attr_name));
+                    .class_attribute_default_with_role_fallback(owner_class, attr_name)
+                    .or_else(|| {
+                        self.class_attribute_default_with_role_fallback(
+                            receiver_class_name,
+                            attr_name,
+                        )
+                    });
                 if let Some(def) = default_val {
                     self.set_var_default(&format!("!{}", attr_name), def.clone());
                     self.set_var_default(&format!(".{}", attr_name), def.clone());

--- a/t/role-attribute-is-default-nil-restore.t
+++ b/t/role-attribute-is-default-nil-restore.t
@@ -1,0 +1,48 @@
+use Test;
+
+# A role-composed attribute's `is default(...)` must restore after a Nil
+# assignment, same as a directly-declared class attribute's. The default
+# expression for a role attribute is deferred (it may reference the role's
+# type parameter) and copied onto the consuming class as a raw expression at
+# composition time, in a separate registry table from a direct attribute's
+# already-evaluated default — the Nil-restore paths must consult both.
+
+{
+    role R { has $.w is default(21) is rw; }
+    class Consumer does R { }
+    my $obj = Consumer.new;
+    is $obj.w, 21, 'role-composed attribute default is used for a fresh instance';
+    $obj.w = Nil;
+    is $obj.w, 21, 'role-composed attribute default is restored after Nil assignment';
+    $obj.w = 5;
+    is $obj.w, 5, 'role-composed attribute accepts an explicit rw assignment';
+    $obj.w = Nil;
+    is $obj.w, 21, 'role-composed attribute default is restored again after a later Nil';
+}
+
+# Two independent instances of the same role-consuming class each restore
+# their own default correctly.
+{
+    role R2 { has $.v is default(99) is rw; }
+    class C2 does R2 { }
+    my $a = C2.new;
+    my $b = C2.new;
+    $a.v = 1;
+    $b.v = Nil;
+    is $a.v, 1, 'one instance keeps its explicit value';
+    is $b.v, 99, 'the other instance restores the role default';
+}
+
+# A directly-declared class attribute's default still restores correctly
+# alongside a role-composed one in the same program (regression guard for
+# the shared Nil-restore code path).
+{
+    class Direct {
+        has $.d is default(7) is rw;
+    }
+    my $obj = Direct.new;
+    $obj.d = Nil;
+    is $obj.d, 7, 'directly-declared class attribute default still restores after Nil';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary
- A directly-declared class attribute's `is default(...)` restores correctly when `Nil` is assigned, but a role-composed one did not — `role R { has $.w is default(21) is rw; } class Consumer does R {}` would print `21` then `Nil` instead of `21`/`21`.
- Root cause: a role attribute's default may reference the role's type parameter, so it defers evaluation to composition time and lands in a separate `Expr`-valued registry table (`class_attribute_default_exprs`) rather than the already-evaluated `Value` table (`class_attribute_defaults`) a direct attribute uses. Every Nil-restore call site only ever consulted the `Value` table.
- Added `Interpreter::class_attribute_default_with_role_fallback`, mirroring the fallback `apply_container_attribute_defaults` already used for `@`/`%` element defaults, and routed all seven Nil-restore call sites through it (`vm_method_dispatch.rs`'s per-method-call attribute-default seeding, plus the direct rw-accessor-assignment paths in `methods_mut_method_lvalue.rs`/`builtins_multidim_assign.rs`). Also widened the `any_attr_defaults` fast-gate to check the `Expr` table too, since a program with only role-attribute defaults (no directly-declared ones) previously skipped the mechanism entirely.
- Found while writing a regression test for an unrelated ADR-0019 change (`todo/tickets/role-attribute-is-default-nil-restore-after-composition.md`, filed in PR #6028 — will clean that ticket up once both PRs land).

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] `cargo test --lib` (672 passed)
- [x] `prove -j4 -e target/debug/mutsu t/` — 2934 files, all pass (new `t/role-attribute-is-default-nil-restore.t`)
- [x] Targeted roast: `S12-attributes/defaults.t`, `S12-attributes/class.t`, `S14-roles/attributes*.t`, `basic.t`, `composition.t`, `parameterized-basic.t`, `rw.t` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)