### PR TITLE
refactor(runtime): ClassAttributeDef default/where_constraint run through DeclTraitArg

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -444,6 +444,34 @@ walkers wholesale is not possible before then.
     scope) via a new `DeclTraitArg::as_expr()` escape valve, since no compiled plan exists
     for that path yet. Remaining: `default`/`where_constraint` type-swap plus the ~15 eval
     sites (D2c-2), and the three role registry tables (D2c-3).
+    **D2c-2 landed 2026-08-07**: `ClassAttributeDef.default`/`.where_constraint`
+    (`src/runtime/mod.rs`) are now `Option<DeclTraitArg>` instead of `Option<Expr>`, and
+    every one of the ~15 eval sites the research pass found (`attr_build_defaults.rs`,
+    `methods_object_default_ctor.rs`, `methods_object_dispatch_new.rs` ×2,
+    `methods_object_attr_constraints.rs` (`check_attribute_where_constraint`,
+    `construct_proxy_subclass`), `methods_dispatch_new.rs`'s `dispatch_bless`,
+    `types/roles.rs`'s mixin path, `types/role_mixin_class.rs::seed_mixin_role_attributes`,
+    `methods_classhow_attribute.rs`'s `.^attributes` introspection, and
+    `registration_class_augment.rs`'s CUnion raw-bytes constructor) now dispatches through
+    `Interpreter::eval_decl_trait_arg`/`.literal()` instead of its own ad hoc
+    `Expr::Literal` pattern match plus a bespoke `eval_block_value(&[Stmt::Expr(...)])`
+    call. `DeferredAttrDefault.default` (`attr_build_defaults.rs`) and
+    `eval_attr_default_expr` moved in lockstep since a deferred default is a straight
+    move of the same field. Deliberately scoped down from the ADR text's aspiration,
+    per the research pass's own risk note: this is a **pure mechanism unification, not
+    a behavior change or a chunk-precompilation** — every site still constructs its
+    `DeclTraitArg` as `Literal`/`Ast` (never `Compiled`), so `CompiledAttrDecl.default`/
+    `.where_constraint` stay `Option<Expr>` and the near-duplicated env-setup blocks
+    (shapes A/B/C in the research doc) were intentionally left un-collapsed rather than
+    risk silently dropping one shape's binding (`methods_object_default_ctor.rs`'s
+    shape-B gate on `has_class_scoped_subs` in particular still needs the raku-behavior
+    verification the research pass flagged before it can be safely merged into shape A).
+    Verified via the full `t/` suite plus every roast `S12-attributes`/`S14-roles`
+    whitelisted file, all green with no output changes. Remaining for a later slice:
+    precompiling `default`/`where_constraint` chunks the way `is_default_chunks` already
+    does (the actual "child chunk" perf win — today's `Ast` variant still recompiles the
+    default expression's bytecode on every construction, same as before this slice), and
+    D2c-3 (the three role registry tables).
   - [ ] **D2d — Publish generated accessors through the canonical table.** Give `MethodEntry` an
     accessor arm populated from `ClassDef::attributes` in `sync_user_method_entries`, so
     `has_public_accessor`/`resolve_user_method_or_accessor` (`class_introspection.rs`) and the

--- a/news/2026-08/d2c2-attribute-decl-trait-arg.md
+++ b/news/2026-08/d2c2-attribute-decl-trait-arg.md
@@ -1,0 +1,48 @@
+# ADR-0019 D2c-2: attribute defaults and `where` constraints run through `DeclTraitArg`
+
+`ClassAttributeDef.default` and `.where_constraint` (`src/runtime/mod.rs`) were the last
+two attribute-descriptor fields still typed as a raw `Expr`. This slice retypes both to
+`Option<crate::opcode::DeclTraitArg>` — the same three-variant (`Literal`/`Compiled`/`Ast`)
+enum ADR-0019 D2c-1 gave `is_default` — and migrates every reader to the shared
+`Interpreter::eval_decl_trait_arg`/`DeclTraitArg::literal()` mechanism instead of each
+site's own `Expr::Literal` pattern match plus a bespoke
+`eval_block_value(&[Stmt::Expr(expr.clone())])` call.
+
+A 2026-08-07 research pass (`todo/deep/adr0019-d2c-attribute-default-chunks.md`) had found
+the real footprint of "compile defaults/constraints as child chunks" substantially larger
+than the ADR text implied: not 3 near-duplicated env-setup blocks but at least 15 eval
+sites across 5 distinct env-setup shapes (a "full" setup binding `self`/`?CLASS`/every
+sibling attribute, a "full + extra" variant adding `__ANON_STATE__`/`constructing_class`
+and a conditional package switch, a "minimal" self-only setup, several sites with no setup
+at all, and the role-mixin `captured_env`-merge path). This slice covers every one of
+them — `attr_build_defaults.rs`, `methods_object_default_ctor.rs`,
+`methods_object_dispatch_new.rs` (both its pre-BUILD and per-class-attrs loops),
+`methods_object_attr_constraints.rs` (`check_attribute_where_constraint`,
+`construct_proxy_subclass`), `methods_dispatch_new.rs`'s native `bless` path,
+`types/roles.rs`'s mixin-on-value path, `types/role_mixin_class.rs`'s runtime `does`
+composer, `methods_classhow_attribute.rs`'s `.^attributes` introspection object, and
+`registration_class_augment.rs`'s CUnion raw-bytes constructor — plus the six
+`ClassAttributeDef` construction sites that feed them.
+
+The scope is deliberately narrower than the ADR paragraph's "compile as child chunks"
+framing: this is a mechanism *unification*, not yet a bytecode *precompilation*. Every
+`DeclTraitArg` these sites build is still `Literal` or `Ast` — `CompiledAttrDecl.default`/
+`.where_constraint` stay `Option<Expr>`, so a non-literal default's bytecode is still
+compiled fresh on every construction, exactly as before. The near-duplicated env-setup
+blocks were also intentionally left un-collapsed: the research pass flagged that the
+"full + extra" shape's package-switch gate (`has_class_scoped_subs`) and its two extra
+bindings looked like accidental drift from the "full" shape rather than a deliberate
+difference, and merging them without first confirming that against raku behavior risked
+silently dropping a binding one shape currently provides. Both are left for a later
+slice.
+
+Verified with the full `t/` suite (191 attribute/default/build/bless/role-related files,
+1671 tests) and every roast-whitelisted `S12-attributes`/`S14-roles` file (33 files, 874
+tests), all green with no output changes — this is a pure type/mechanism refactor.
+
+Remaining under D2c: precompiling `default`/`where_constraint` chunks the way
+`is_default_chunks` already does (the actual "child chunk" architecture and perf win),
+and D2c-3 (the three `Expr`-valued role registry tables —
+`role_attribute_default_exprs`/`role_class_level_attrs`/`class_attribute_default_exprs`
+— which remain untouched since they are fed from `CompiledAttrDecl.is_default`/`.default`,
+not `ClassAttributeDef`).

--- a/src/runtime/attr_build_defaults.rs
+++ b/src/runtime/attr_build_defaults.rs
@@ -28,7 +28,7 @@
 use std::collections::HashSet;
 
 use super::{Interpreter, RuntimeError};
-use crate::ast::{Expr, Stmt};
+use crate::opcode::DeclTraitArg;
 use crate::symbol::Symbol;
 use crate::value::{AttrMap, Value, ValueView};
 
@@ -37,7 +37,7 @@ pub(crate) struct DeferredAttrDefault {
     pub(crate) name: String,
     pub(crate) sigil: char,
     /// The `has $.x = <expr>` initializer, when the attribute has one.
-    pub(crate) default: Option<Expr>,
+    pub(crate) default: Option<DeclTraitArg>,
     /// An `is built(&code)` override, which takes precedence over `default`.
     pub(crate) build_override: Option<Value>,
     /// The value the slot was seeded with; the slot still holding it is half of
@@ -116,16 +116,15 @@ impl Interpreter {
             let val = if let Some(build_override) = &d.build_override {
                 let val = self.call_sub_value(build_override.clone(), Vec::new(), false)?;
                 Self::coerce_attr_value_by_sigil(val, d.sigil)
-            } else if let Some(expr) = &d.default {
+            } else if let Some(arg) = &d.default {
                 // A literal needs no evaluation context at all — the same fast
                 // path the pre-BUILD pass takes for parser-generated zeroes.
-                if let Expr::Literal(lit_val) = expr {
+                if let Some(lit_val) = arg.literal() {
                     Self::coerce_attr_value_by_sigil(lit_val.clone(), d.sigil)
                 } else {
                     let attrs = cell.to_map();
-                    let expr = expr.clone();
                     let val =
-                        self.eval_attr_default_expr(class_key, class_name, &expr, inv, &attrs)?;
+                        self.eval_attr_default_expr(class_key, class_name, arg, inv, &attrs)?;
                     Self::coerce_attr_value_by_sigil(val, d.sigil)
                 }
             } else {
@@ -289,7 +288,7 @@ impl Interpreter {
         &mut self,
         class_key: &str,
         class_name: Symbol,
-        expr: &Expr,
+        arg: &DeclTraitArg,
         self_val: &Value,
         attrs: &AttrMap,
     ) -> Result<Value, RuntimeError> {
@@ -313,7 +312,7 @@ impl Interpreter {
         // (e.g. `sub inner`) are found when evaluating the initializer.
         let saved_package = self.current_package();
         self.set_current_package(class_key.to_string());
-        let result = self.eval_block_value(&[Stmt::Expr(expr.clone())]);
+        let result = self.eval_decl_trait_arg(arg);
         self.set_current_package(saved_package);
         for (key, old_val) in saved_attr_env {
             if let Some(v) = old_val {

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -239,18 +239,20 @@ impl Interpreter {
             "required".to_string(),
             Self::required_meta_value(is_required),
         );
-        if let Some(default_expr) = default {
+        if let Some(default_arg) = default {
             meta.insert("__mutsu_has_build".to_string(), Value::TRUE);
-            if let crate::ast::Expr::Literal(v) = default_expr {
+            if let Some(v) = default_arg.literal() {
                 meta.insert("build".to_string(), v.clone());
             } else {
-                // Wrap the default expression in a Sub closure so .build returns Code
+                // Wrap the default expression in a Sub closure so .build returns Code.
+                // `.as_expr()` never panics here: no caller precompiles a `Compiled`
+                // chunk into `ClassAttributeDef.default` yet (ADR-0019 D2c-2).
                 let sub_data = crate::value::SubData {
                     package: Symbol::intern("GLOBAL"),
                     name: Symbol::intern("<attribute-build>"),
                     params: Vec::new(),
                     param_defs: Vec::new(),
-                    body: vec![crate::ast::Stmt::Expr(default_expr.clone())],
+                    body: vec![crate::ast::Stmt::Expr(default_arg.as_expr())],
                     is_rw: false,
                     is_raw: false,
                     env: self.env().clone(),

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -377,61 +377,62 @@ impl Interpreter {
             // BUILD left the attribute alone, so the slot is seeded with the
             // no-initializer value now (runtime/attr_build_defaults.rs).
             let is_deferred = plan.has_build && default.is_some();
-            let val = if !is_deferred && let Some(Expr::Literal(lit_val)) = default {
-                // Fast path: simple literal defaults (e.g. native type
-                // defaults like Int(0)) don't need interpretation.
-                lit_val.clone()
-            } else if !is_deferred && let Some(expr) = default {
-                self.eval_block_value(&[Stmt::Expr(expr.clone())])?
-            } else if *sigil == '@' || *sigil == '%' {
-                // An `is Type` container trait (`has %.h is TypeConverter`)
-                // builds an instance of that type, exactly like `dispatch_new`'s
-                // `seed_attr_value` — a plain empty container here would strip
-                // the type (DBIish's `has %.Converter is DBDish::TypeConverter`
-                // lost its STORE/convert-function surface through bless).
-                if let Some(type_name) = plan.attr_is_types.get(attr_name).cloned() {
-                    self.build_is_type_container(&type_name, *sigil)
-                } else if *sigil == '@' {
-                    // A `@`-sigil attribute with no default is an empty Array,
-                    // not Nil (matches `dispatch_new`). Leaving it Nil makes
-                    // `@!attr.elems` return 1 (Any.elems) and corrupts guards.
-                    let mut arr = Value::real_array(Vec::new());
-                    if let Some(tc) = plan.type_constraints.get(attr_name).cloned() {
-                        arr = self.tag_container_metadata(
-                            arr,
-                            super::ContainerTypeInfo {
-                                value_type: tc,
-                                key_type: None,
-                                declared_type: None,
-                            },
-                        );
+            let val =
+                if !is_deferred && let Some(lit_val) = default.as_ref().and_then(|a| a.literal()) {
+                    // Fast path: simple literal defaults (e.g. native type
+                    // defaults like Int(0)) don't need interpretation.
+                    lit_val.clone()
+                } else if !is_deferred && let Some(arg) = default {
+                    self.eval_decl_trait_arg(arg)?
+                } else if *sigil == '@' || *sigil == '%' {
+                    // An `is Type` container trait (`has %.h is TypeConverter`)
+                    // builds an instance of that type, exactly like `dispatch_new`'s
+                    // `seed_attr_value` — a plain empty container here would strip
+                    // the type (DBIish's `has %.Converter is DBDish::TypeConverter`
+                    // lost its STORE/convert-function surface through bless).
+                    if let Some(type_name) = plan.attr_is_types.get(attr_name).cloned() {
+                        self.build_is_type_container(&type_name, *sigil)
+                    } else if *sigil == '@' {
+                        // A `@`-sigil attribute with no default is an empty Array,
+                        // not Nil (matches `dispatch_new`). Leaving it Nil makes
+                        // `@!attr.elems` return 1 (Any.elems) and corrupts guards.
+                        let mut arr = Value::real_array(Vec::new());
+                        if let Some(tc) = plan.type_constraints.get(attr_name).cloned() {
+                            arr = self.tag_container_metadata(
+                                arr,
+                                super::ContainerTypeInfo {
+                                    value_type: tc,
+                                    key_type: None,
+                                    declared_type: None,
+                                },
+                            );
+                        }
+                        arr
+                    } else {
+                        // A `%`-sigil attribute with no default is an empty Hash.
+                        Value::hash(HashMap::new())
                     }
-                    arr
                 } else {
-                    // A `%`-sigil attribute with no default is an empty Hash.
-                    Value::hash(HashMap::new())
-                }
-            } else {
-                // Native types have zero/empty defaults instead of Nil.
-                // The plan's type_constraints carry the same MRO-wide map
-                // `get_attr_type_constraint` would walk per attribute.
-                // A non-native attribute with no default seeds its nominal
-                // type object (`has $!z` reads as Any, `has Int $!x` as Int),
-                // matching raku — not Nil.
-                match plan.type_constraints.get(attr_name).map(String::as_str) {
-                    Some(
-                        "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
-                        | "uint32" | "uint64" | "byte" | "atomicint",
-                    ) => Value::int(0),
-                    Some("num" | "num32" | "num64") => Value::num(0.0),
-                    Some("str") => Value::str("".to_string()),
-                    Some(tc) => {
-                        let nominal = self.nominal_type_object_name_for_constraint(tc);
-                        Value::package(crate::symbol::Symbol::intern(&nominal))
+                    // Native types have zero/empty defaults instead of Nil.
+                    // The plan's type_constraints carry the same MRO-wide map
+                    // `get_attr_type_constraint` would walk per attribute.
+                    // A non-native attribute with no default seeds its nominal
+                    // type object (`has $!z` reads as Any, `has Int $!x` as Int),
+                    // matching raku — not Nil.
+                    match plan.type_constraints.get(attr_name).map(String::as_str) {
+                        Some(
+                            "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8"
+                            | "uint16" | "uint32" | "uint64" | "byte" | "atomicint",
+                        ) => Value::int(0),
+                        Some("num" | "num32" | "num64") => Value::num(0.0),
+                        Some("str") => Value::str("".to_string()),
+                        Some(tc) => {
+                            let nominal = self.nominal_type_object_name_for_constraint(tc);
+                            Value::package(crate::symbol::Symbol::intern(&nominal))
+                        }
+                        None => Value::package(crate::symbol::Symbol::intern("Any")),
                     }
-                    None => Value::package(crate::symbol::Symbol::intern("Any")),
-                }
-            };
+                };
             if is_deferred {
                 deferred_defaults.push(super::attr_build_defaults::DeferredAttrDefault {
                     name: attr_name.clone(),

--- a/src/runtime/methods_object_attr_constraints.rs
+++ b/src/runtime/methods_object_attr_constraints.rs
@@ -3,8 +3,12 @@ use crate::symbol::Symbol;
 use crate::value::AttrMap;
 
 impl Interpreter {
-    fn check_attribute_where_constraint(&mut self, pred: &Expr, value: &Value) -> bool {
-        let pred_val = match self.eval_block_value(&[Stmt::Expr(pred.clone())]) {
+    fn check_attribute_where_constraint(
+        &mut self,
+        pred: &crate::opcode::DeclTraitArg,
+        value: &Value,
+    ) -> bool {
+        let pred_val = match self.eval_decl_trait_arg(pred) {
             Ok(v) => v,
             Err(_) => return false,
         };
@@ -348,8 +352,8 @@ impl Interpreter {
             let default_expr = &attr.default;
             let sigil = &attr.sigil;
             if !extra_attrs.contains_key(attr_name) {
-                let default_val = if let Some(expr) = default_expr {
-                    let result = self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())])?;
+                let default_val = if let Some(arg) = default_expr {
+                    let result = self.eval_decl_trait_arg(arg)?;
                     Self::coerce_attr_value_by_sigil(result, *sigil)
                 } else {
                     match sigil {

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -183,24 +183,26 @@ impl Interpreter {
             if attrs.contains_key(attr_sym) {
                 continue;
             }
-            match default_expr {
+            let default_literal = default_expr.as_ref().and_then(|arg| arg.literal());
+            match default_literal {
                 // Raku: assigning `Nil` resets a container to its declared
                 // type's default, so `has Str $.n = Nil` holds `Str` — exactly
                 // what the no-initializer form holds — not `Nil`.
-                Some(Expr::Literal(lit_val)) if lit_val.is_nil() => {
+                Some(lit_val) if lit_val.is_nil() => {
                     let seeded =
                         self.seed_attr_value(cn_resolved, attr_name, *sigil, type_constraints);
                     attrs.insert(attr_sym, seeded);
                 }
                 // Fast path: a literal default needs no evaluation or binding.
                 // The interpreter stores it without a type check, so we do too.
-                Some(Expr::Literal(lit_val)) => {
+                Some(lit_val) => {
                     attrs.insert(
                         attr_sym,
                         Self::coerce_attr_value_by_sigil(lit_val.clone(), *sigil),
                     );
                 }
-                Some(expr) => {
+                None if default_expr.is_some() => {
+                    let arg = default_expr.as_ref().unwrap();
                     // Bind `self` and the already-set attributes, switch to the
                     // class package for class-scoped sub lookups, evaluate, then
                     // restore everything — per the interpreter's per-default setup.
@@ -236,7 +238,7 @@ impl Interpreter {
                     // even though no method-class / package context is active here.
                     let saved_constructing = self.constructing_class.take();
                     self.constructing_class = Some(cn_resolved.to_string());
-                    let result = self.eval_block_value(&[crate::ast::Stmt::Expr(expr.clone())]);
+                    let result = self.eval_decl_trait_arg(arg);
                     self.constructing_class = saved_constructing;
                     self.set_current_package(saved_package);
                     for (key, old_val) in saved_attr_env {

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1820,8 +1820,9 @@ impl Interpreter {
                 // convert user-provided values to shaped arrays preserving shape.
                 for attr in &class_attrs_info {
                     let (attr_name, default) = (&attr.name, &attr.default);
+                    let default_ast = default.as_ref().map(|arg| arg.as_expr());
                     if attr.sigil == '@'
-                        && let Some(dims) = Self::extract_shape_from_default(default.as_ref())
+                        && let Some(dims) = Self::extract_shape_from_default(default_ast.as_ref())
                         && let Some(val) = attrs.get(attr_name)
                         && !matches!(val.view(), ValueView::Array(_, ArrayKind::Shaped))
                     {
@@ -1926,11 +1927,11 @@ impl Interpreter {
                     let val = if let Some(build_override) = build_override {
                         let val = self.call_sub_value(build_override, Vec::new(), false)?;
                         Self::coerce_attr_value_by_sigil(val, sigil)
-                    } else if let Some(expr) = default {
+                    } else if let Some(arg) = default {
                         // Fast path: simple literal defaults (e.g. from native types
                         // like `has uint32 $.a` which generate `default: Int(0)`)
                         // don't need env manipulation or self-binding.
-                        if let Expr::Literal(ref lit_val) = expr {
+                        if let Some(lit_val) = arg.literal() {
                             Self::coerce_attr_value_by_sigil(lit_val.clone(), sigil)
                         } else {
                             // Before BUILD the evaluation context is a snapshot
@@ -1939,7 +1940,7 @@ impl Interpreter {
                             let val = self.eval_attr_default_expr(
                                 class_key,
                                 *class_name,
-                                &expr,
+                                &arg,
                                 &temp_self,
                                 &attrs,
                             )?;
@@ -2143,14 +2144,15 @@ impl Interpreter {
                             continue;
                         }
                         // Evaluate the default expression for this class's attribute
-                        let val = if let Some(Expr::Literal(ref lit_val)) = default {
+                        let val = if let Some(lit_val) = default.as_ref().and_then(|a| a.literal())
+                        {
                             // Fast path: simple literal defaults
                             Self::coerce_attr_value_by_sigil(lit_val.clone(), sigil)
-                        } else if let Some(expr) = default {
+                        } else if let Some(arg) = default {
                             let temp_self = Value::make_instance(*class_name, attrs.clone());
                             let old_self = self.env.get("self").cloned();
                             self.env.insert("self".to_string(), temp_self);
-                            let result = self.eval_block_value(&[Stmt::Expr(expr)]);
+                            let result = self.eval_decl_trait_arg(&arg);
                             if let Some(old) = old_self {
                                 self.env.insert("self".to_string(), old);
                             } else {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -444,15 +444,23 @@ use self::unicode::{check_unicode_property, check_unicode_property_with_args};
 ///
 /// Field order matches the historical tuple layout:
 /// `(attr_name, is_public, default, is_rw, is_required, sigil, where_constraint)`.
+///
+/// `default`/`where_constraint` are `DeclTraitArg` rather than a raw `Expr`
+/// (ADR-0019 D2c-2): every reader now runs them through
+/// `Interpreter::eval_decl_trait_arg`/`.literal()` instead of its own
+/// `Expr::Literal` pattern match, unifying the eval mechanism across the
+/// ~15 sites that fill/check attribute defaults and `where` constraints.
+/// Still always `Literal`/`Ast` for now — no call site precompiles a
+/// `Compiled` chunk yet, so `.as_expr()` on either field remains panic-free.
 #[derive(Debug, Clone)]
 pub(crate) struct ClassAttributeDef {
     pub(crate) name: String,
     pub(crate) is_public: bool,
-    pub(crate) default: Option<Expr>,
+    pub(crate) default: Option<crate::opcode::DeclTraitArg>,
     pub(crate) is_rw: bool,
     pub(crate) is_required: Option<Option<String>>,
     pub(crate) sigil: char,
-    pub(crate) where_constraint: Option<Expr>,
+    pub(crate) where_constraint: Option<crate::opcode::DeclTraitArg>,
 }
 
 /// The set of read-only variable names (`readonly_vars`), and the type of a

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -285,11 +285,17 @@ impl Interpreter {
                         class_def.attributes.push(ClassAttributeDef {
                             name: attr_name_str.clone(),
                             is_public: decl.is_public,
-                            default: decl.default.clone(),
+                            default: decl
+                                .default
+                                .clone()
+                                .map(|e| crate::opcode::DeclTraitArg::Ast(Box::new(e))),
                             is_rw: decl.is_rw,
                             is_required: decl.is_required.clone(),
                             sigil: decl.sigil,
-                            where_constraint: decl.where_constraint.clone(),
+                            where_constraint: decl
+                                .where_constraint
+                                .clone()
+                                .map(|e| crate::opcode::DeclTraitArg::Ast(Box::new(e))),
                         });
                         if decl.is_alias {
                             class_def.alias_attributes.insert(attr_name_str.clone());
@@ -594,8 +600,8 @@ impl Interpreter {
                     _ => {
                         if let Some(v) = named_args.get(attr_name) {
                             v.clone()
-                        } else if let Some(expr) = default {
-                            self.eval_block_value(&[Stmt::Expr(expr.clone())])?
+                        } else if let Some(arg) = default {
+                            self.eval_decl_trait_arg(arg)?
                         } else {
                             Value::int(0)
                         }
@@ -604,11 +610,8 @@ impl Interpreter {
                 attrs.insert(attr_name.clone(), val);
             } else if let Some(v) = named_args.get(attr_name) {
                 attrs.insert(attr_name.clone(), v.clone());
-            } else if let Some(expr) = default {
-                attrs.insert(
-                    attr_name.clone(),
-                    self.eval_block_value(&[Stmt::Expr(expr.clone())])?,
-                );
+            } else if let Some(arg) = default {
+                attrs.insert(attr_name.clone(), self.eval_decl_trait_arg(arg)?);
             } else {
                 attrs.insert(attr_name.clone(), Value::int(0));
             }

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -39,7 +39,10 @@ impl Interpreter {
         class_def.attributes.push(ClassAttributeDef {
             name: attr_name.clone(),
             is_public: decl.is_public,
-            default: decl.default.clone(),
+            default: decl
+                .default
+                .clone()
+                .map(|e| crate::opcode::DeclTraitArg::Ast(Box::new(e))),
             is_rw: effective_is_rw,
             is_required: decl.is_required.clone(),
             sigil: decl.sigil,
@@ -216,11 +219,17 @@ impl Interpreter {
         cx.class_def.attributes.push(ClassAttributeDef {
             name: attr_name_str.clone(),
             is_public: decl.is_public,
-            default: decl.default.clone(),
+            default: decl
+                .default
+                .clone()
+                .map(|e| crate::opcode::DeclTraitArg::Ast(Box::new(e))),
             is_rw: effective_is_rw,
             is_required: decl.is_required.clone(),
             sigil: decl.sigil,
-            where_constraint: decl.where_constraint.clone(),
+            where_constraint: decl
+                .where_constraint
+                .clone()
+                .map(|e| crate::opcode::DeclTraitArg::Ast(Box::new(e))),
         });
         // Store `is default(...)` trait value for this attribute.
         // When is_default is set, the evaluated value is stored for

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -107,11 +107,17 @@ impl Interpreter {
         cx.role_def.attributes.push(ClassAttributeDef {
             name: attr_name_str.clone(),
             is_public: decl.is_public,
-            default: decl.default.clone(),
+            default: decl
+                .default
+                .clone()
+                .map(|e| crate::opcode::DeclTraitArg::Ast(Box::new(e))),
             is_rw: effective_is_rw,
             is_required: decl.is_required.clone(),
             sigil: decl.sigil,
-            where_constraint: decl.where_constraint.clone(),
+            where_constraint: decl
+                .where_constraint
+                .clone()
+                .map(|e| crate::opcode::DeclTraitArg::Ast(Box::new(e))),
         });
         let attr_var_name = if decl.is_public {
             format!(".{}", attr_name_str)

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -401,7 +401,7 @@ impl Interpreter {
                 ClassAttributeDef {
                     name: name.to_string(),
                     is_public: true,
-                    default,
+                    default: default.map(|e| crate::opcode::DeclTraitArg::Ast(Box::new(e))),
                     is_rw: false,
                     is_required: None,
                     sigil,

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -269,7 +269,7 @@ impl Interpreter {
                     continue;
                 }
                 let value = match default_expr {
-                    Some(expr) => self.eval_block_value(&[Stmt::Expr(expr.clone())])?,
+                    Some(arg) => self.eval_decl_trait_arg(arg)?,
                     None => match sigil {
                         '@' => Value::real_array(Vec::new()),
                         '%' => Value::hash_with_data(Value::hash_arc(HashMap::new())),

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -462,8 +462,8 @@ impl Interpreter {
                 let sigil = &attr.sigil;
                 let value = if let Some(arg) = role_args.get(idx) {
                     arg.clone()
-                } else if let Some(default_expr) = default_expr {
-                    self.eval_block_value(&[Stmt::Expr(default_expr.clone())])?
+                } else if let Some(default_arg) = default_expr {
+                    self.eval_decl_trait_arg(default_arg)?
                 } else {
                     // Default value based on sigil: @ -> [], % -> {}, $ -> Nil
                     match sigil {


### PR DESCRIPTION
## Summary

ADR-0019 D2c-2 (see `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`): retypes `ClassAttributeDef.default`/`.where_constraint` from `Option<Expr>` to `Option<DeclTraitArg>` and migrates every eval site found by the 2026-08-07 research pass (`todo/deep/adr0019-d2c-attribute-default-chunks.md`) to the shared `Interpreter::eval_decl_trait_arg`/`DeclTraitArg::literal()` mechanism instead of each site's own ad hoc `Expr::Literal` check plus `eval_block_value` call.

- 6 `ClassAttributeDef` construction sites updated to wrap `Expr` into `DeclTraitArg::Ast`.
- 15 eval sites migrated across `attr_build_defaults.rs`, `methods_object_default_ctor.rs`, `methods_object_dispatch_new.rs` (×2), `methods_object_attr_constraints.rs` (`check_attribute_where_constraint`, `construct_proxy_subclass`), `methods_dispatch_new.rs`'s native `bless`, `types/roles.rs`/`types/role_mixin_class.rs`'s role-mixin paths, `methods_classhow_attribute.rs`'s `.^attributes` introspection, and `registration_class_augment.rs`'s CUnion constructor.
- `DeferredAttrDefault.default` and `eval_attr_default_expr` moved in lockstep.

Deliberately scoped down from the ADR's "compile as child chunks" framing: this is a **mechanism unification, not a behavior change or bytecode precompilation**. Every site still builds `Literal`/`Ast` (never `Compiled`), so `CompiledAttrDecl.default`/`.where_constraint` stay `Option<Expr>`, and the near-duplicated env-setup blocks (full/full+extra/minimal shapes) were intentionally left uncollapsed — the research pass flagged that the "full+extra" shape's `has_class_scoped_subs` gate and extra bindings look like possible drift, not a deliberate difference, and merging without raku-behavior verification risked silently dropping a binding.

Remaining under D2c: precompiling `default`/`where_constraint` as child chunks (the real "child chunk" perf win, mirroring `is_default_chunks`), and D2c-3 (the three `Expr`-valued role registry tables).

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
- [x] `prove -e target/debug/mutsu` over 191 attribute/default/build/bless/role-related `t/` files (1671 tests) — all green
- [x] Full `make test` (2935 files, 27795 tests) — PASS
- [x] `MUTSU_FUDGE=1 prove` over every roast-whitelisted `S12-attributes`/`S14-roles` file (33 files, 874 tests) — PASS
- [ ] CI `make roast` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)