### PR TITLE
refactor(runtime): role attribute-default registry tables run through DeclTraitArg

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -472,6 +472,29 @@ walkers wholesale is not possible before then.
     does (the actual "child chunk" perf win — today's `Ast` variant still recompiles the
     default expression's bytecode on every construction, same as before this slice), and
     D2c-3 (the three role registry tables).
+    **D2c-3 landed 2026-08-07**: the three `Expr`-valued role registry tables —
+    `role_attribute_default_exprs`, `role_class_level_attrs`, `class_attribute_default_exprs`
+    (`registry.rs`) — are now `DeclTraitArg`-valued, matching `ClassAttributeDef`. The write
+    side (`registration_role_body.rs`) simplified rather than grew: `role_attribute_default_exprs`
+    used to convert `decl.is_default` (already a `DeclTraitArg` since D2c-1) back to a raw
+    `Expr` via the `DeclTraitArg::as_expr()` escape valve just to store it — it now stores
+    `def_arg.clone()` directly, retiring that escape valve's only caller outside `Ast`-only
+    paths. `role_class_level_attrs` still wraps `decl.default` (a `CompiledAttrDecl` field,
+    still `Option<Expr>` — unaffected by D2b/D2c-2's scope) in `DeclTraitArg::Ast`, the same
+    pattern D2c-2 used at its own `ClassAttributeDef` construction sites.
+    `registration_class_compose.rs` (the role→class copy at composition) and all four eval
+    sites the migration touched (`runtime_var_meta.rs`'s `class_attribute_default_with_role_fallback`
+    and `apply_container_attribute_defaults`, `methods_call_dispatch.rs`'s role
+    type-object class-level-attribute read) now call `eval_decl_trait_arg` instead of
+    `eval_block_value(&[Stmt::Expr(...)])`. `methods_call_dispatch.rs`'s site is a fourth eval
+    site the D2c research pass's original enumeration missed — found only because grepping
+    the registry table names surfaces every reader regardless of eval mechanism, unlike a
+    field-by-field code search. Same verification as D2c-2 (full `t/`, `S12-attributes`/
+    `S14-roles` roast whitelist), all green. With D2c-1 through D2c-3 landed, no
+    `ClassAttributeDef`/role-registry attribute-default or `where`-constraint path in the
+    interpreter still evaluates through a raw `Expr` + `eval_block_value` call; the only
+    remaining piece of the parent D2c box is the actual bytecode precompilation (the
+    `Compiled` variant is still unused for `default`/`where_constraint`/the role tables).
   - [ ] **D2d — Publish generated accessors through the canonical table.** Give `MethodEntry` an
     accessor arm populated from `ClassDef::attributes` in `sync_user_method_entries`, so
     `has_public_accessor`/`resolve_user_method_or_accessor` (`class_introspection.rs`) and the

--- a/news/2026-08/d2c3-role-attr-default-registry-decl-trait-arg.md
+++ b/news/2026-08/d2c3-role-attr-default-registry-decl-trait-arg.md
@@ -1,0 +1,36 @@
+# ADR-0019 D2c-3: role attribute-default registry tables run through `DeclTraitArg`
+
+Follow-on to D2c-2 (`news/2026-08/d2c2-attribute-decl-trait-arg.md`): the three
+`Expr`-valued registry tables that carry a role attribute's deferred default across
+composition — `role_attribute_default_exprs`, `role_class_level_attrs`, and
+`class_attribute_default_exprs` (`src/runtime/registry.rs`) — are now `DeclTraitArg`-valued,
+matching `ClassAttributeDef.default`/`.where_constraint`.
+
+The write side actually got simpler. `registration_role_body.rs` used to convert
+`decl.is_default` — already a `DeclTraitArg` since D2c-1 — back into a raw `Expr` via the
+`DeclTraitArg::as_expr()` escape valve just to store it into `role_attribute_default_exprs`.
+It now stores the `DeclTraitArg` directly, retiring that escape valve's only caller outside
+an `Ast`-only path. `role_class_level_attrs` still wraps `CompiledAttrDecl.default` (still
+`Option<Expr>` — out of scope for D2b/D2c) in `DeclTraitArg::Ast`, the same pattern D2c-2
+used at `ClassAttributeDef`'s own construction sites.
+
+`registration_class_compose.rs` (the role→class copy that runs at composition) and all four
+eval sites the migration touched — `runtime_var_meta.rs`'s
+`class_attribute_default_with_role_fallback` and `apply_container_attribute_defaults`, and
+`methods_call_dispatch.rs`'s role type-object class-level-attribute read (`R.x` on a role's
+type object) — now call `Interpreter::eval_decl_trait_arg` instead of
+`eval_block_value(&[Stmt::Expr(...)])`. The `methods_call_dispatch.rs` site is a fourth eval
+site the original D2c research pass's enumeration missed: it was found by grepping the
+registry table names directly, which surfaces every reader regardless of which eval
+mechanism it happened to use, rather than repeating the original field-by-field code search.
+
+With D2c-1 through D2c-3 landed, no `ClassAttributeDef` or role-registry attribute-default /
+`where`-constraint path in the interpreter still evaluates through a raw `Expr` plus its own
+`eval_block_value` call. Verified the same way as D2c-2: the full `t/` suite (2935 files,
+27795 tests) and every roast-whitelisted `S12-attributes`/`S14-roles` file, all green.
+
+What's left under the parent D2c box is the actual bytecode precompilation — every
+`DeclTraitArg` these paths build is still `Literal`/`Ast`, never `Compiled`, so a non-literal
+default's expression still compiles fresh on every construction, same as before D2c-1
+through D2c-3. That, and D2d (accessor publication), are the remaining open boxes in ADR-0019
+Phase D2.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2700,7 +2700,7 @@ impl Interpreter {
                 };
                 if let Some(default) = class_level_default {
                     return match default {
-                        Some(expr) => self.eval_block_value(&[Stmt::Expr(expr)]),
+                        Some(arg) => self.eval_decl_trait_arg(&arg),
                         None => Ok(Value::NIL),
                     };
                 }

--- a/src/runtime/registration_class_compose.rs
+++ b/src/runtime/registration_class_compose.rs
@@ -189,16 +189,16 @@ impl Interpreter {
         // onto the consuming class as a class-level attribute, so the accessor
         // works on the class type object (`C.x`), matching raku. The default
         // expr is evaluated now (role param bindings, if any, are in scope).
-        let role_class_level: Vec<(String, Option<crate::ast::Expr>)> = self
+        let role_class_level: Vec<(String, Option<crate::opcode::DeclTraitArg>)> = self
             .registry()
             .role_class_level_attrs
             .iter()
             .filter(|((r, _), _)| r == base_role_name)
-            .map(|((_, attr), expr)| (attr.clone(), expr.clone()))
+            .map(|((_, attr), arg)| (attr.clone(), arg.clone()))
             .collect();
         for (attr, default) in role_class_level {
-            let value = if let Some(expr) = default {
-                self.eval_block_value(&[Stmt::Expr(expr)])?
+            let value = if let Some(arg) = default {
+                self.eval_decl_trait_arg(&arg)?
             } else {
                 Value::NIL
             };
@@ -207,18 +207,18 @@ impl Interpreter {
         // Carry each composed-role attribute's deferred `is default(...)`
         // expression onto the consuming class so it can be evaluated at
         // construction with this class's type-param bindings in scope.
-        let role_default_exprs: Vec<(String, crate::ast::Expr)> = self
+        let role_default_exprs: Vec<(String, crate::opcode::DeclTraitArg)> = self
             .registry()
             .role_attribute_default_exprs
             .iter()
             .filter(|((r, _), _)| r == base_role_name)
-            .map(|((_, attr), expr)| (attr.clone(), expr.clone()))
+            .map(|((_, attr), arg)| (attr.clone(), arg.clone()))
             .collect();
-        for (attr, expr) in role_default_exprs {
+        for (attr, arg) in role_default_exprs {
             self.registry_mut()
                 .class_attribute_default_exprs
                 .entry((cx.name.to_string(), attr))
-                .or_insert(expr);
+                .or_insert(arg);
         }
         // Carry each composed-role attribute's `is Type` container trait
         // (`has @.a is Array[TV]`, `has @.a is G::A`) onto the consuming

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -27,7 +27,9 @@ impl Interpreter {
         if decl.is_my || decl.is_our {
             self.registry_mut().role_class_level_attrs.insert(
                 (cx.name.to_string(), attr_name_str.clone()),
-                decl.default.clone(),
+                decl.default
+                    .clone()
+                    .map(|e| crate::opcode::DeclTraitArg::Ast(Box::new(e))),
             );
             return Ok(());
         }
@@ -66,7 +68,7 @@ impl Interpreter {
         if let Some(def_arg) = &decl.is_default {
             self.registry_mut().role_attribute_default_exprs.insert(
                 (cx.name.to_string(), attr_name_str.clone()),
-                def_arg.as_expr(),
+                def_arg.clone(),
             );
         }
         // Check if this attribute already exists from a composed role

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -163,16 +163,18 @@ pub(crate) struct Registry {
     /// value cannot be evaluated until the role is composed and its type params
     /// are bound: (role-base, attr) -> expr. Evaluated at instance construction
     /// (with role param bindings in scope) to tag `@`/`%` containers.
-    pub(crate) role_attribute_default_exprs: HashMap<(String, String), crate::ast::Expr>,
+    pub(crate) role_attribute_default_exprs: HashMap<(String, String), crate::opcode::DeclTraitArg>,
     /// Class-level (`my $.x` / `our $.x`) role attributes: (role-base, attr) ->
     /// optional default expr. These generate an accessor on the *type object*
     /// (not per-instance), so at composition they are copied into the consuming
     /// class's `class_level_attrs` rather than its per-instance attributes.
-    pub(crate) role_class_level_attrs: HashMap<(String, String), Option<crate::ast::Expr>>,
+    pub(crate) role_class_level_attrs:
+        HashMap<(String, String), Option<crate::opcode::DeclTraitArg>>,
     /// Per-attribute deferred `is default(...)` expression carried from a composed
     /// parametric role onto a consuming class: (class, attr) -> expr. Evaluated at
     /// construction with the class's role type-param bindings in scope.
-    pub(crate) class_attribute_default_exprs: HashMap<(String, String), crate::ast::Expr>,
+    pub(crate) class_attribute_default_exprs:
+        HashMap<(String, String), crate::opcode::DeclTraitArg>,
     /// Per-attribute declared type: (class, attr) -> type name.
     pub(crate) class_attribute_is_types: HashMap<(String, String), String>,
     /// Per-attribute `is Type` container trait declared on a *role* attribute:

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -344,12 +344,12 @@ impl Interpreter {
     ) -> Option<Value> {
         self.class_attribute_default(class_name, attr_name)
             .or_else(|| {
-                let expr = self
+                let arg = self
                     .registry()
                     .class_attribute_default_exprs
                     .get(&(class_name.to_string(), attr_name.to_string()))
                     .cloned()?;
-                self.eval_block_value(&[crate::ast::Stmt::Expr(expr)]).ok()
+                self.eval_decl_trait_arg(&arg).ok()
             })
     }
 
@@ -425,12 +425,12 @@ impl Interpreter {
             let def = self
                 .class_attribute_default(class_name, attr_name.as_str())
                 .or_else(|| {
-                    let expr = self
+                    let arg = self
                         .registry()
                         .class_attribute_default_exprs
                         .get(&(class_name.to_string(), attr_name.resolve()))
                         .cloned()?;
-                    self.eval_block_value(&[crate::ast::Stmt::Expr(expr)]).ok()
+                    self.eval_decl_trait_arg(&arg).ok()
                 });
             if let Some(def) = def
                 && let Some(val) = attributes.remove(attr_name)


### PR DESCRIPTION
## Summary

ADR-0019 D2c-3 (follow-on to D2c-2, #6032): retypes the three `Expr`-valued registry tables that carry a role attribute's deferred default across composition — `role_attribute_default_exprs`/`role_class_level_attrs`/`class_attribute_default_exprs` (`src/runtime/registry.rs`) — to `DeclTraitArg`, matching `ClassAttributeDef.default`/`.where_constraint`.

- `registration_role_body.rs`'s write side actually simplifies: `role_attribute_default_exprs` used to convert `decl.is_default` (already `DeclTraitArg` since D2c-1) back to a raw `Expr` via the `DeclTraitArg::as_expr()` escape valve just to store it — it now stores the `DeclTraitArg` directly, retiring that escape valve's only non-`Ast`-only caller.
- `registration_class_compose.rs` (the role→class copy at composition) and all four eval sites — `runtime_var_meta.rs`'s `class_attribute_default_with_role_fallback`/`apply_container_attribute_defaults`, and `methods_call_dispatch.rs`'s role type-object class-level-attribute read (`R.x`) — now call `eval_decl_trait_arg` instead of `eval_block_value(&[Stmt::Expr(...)])`.
- The `methods_call_dispatch.rs` site is a fourth eval site the original D2c research pass missed — found by grepping the registry table names directly rather than repeating the field-by-field search.

With D2c-1 through D2c-3 landed, no `ClassAttributeDef`/role-registry attribute-default or `where`-constraint path still evaluates through a raw `Expr` + `eval_block_value`. Remaining under the parent D2c box: the actual bytecode precompilation (every `DeclTraitArg` here is still `Literal`/`Ast`, never `Compiled`).

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
- [x] `prove -e target/debug/mutsu` over 191 attribute/default/build/bless/role-related `t/` files (1671 tests) — all green
- [x] Full `make test` (2935 files, 27795 tests) — PASS
- [x] `MUTSU_FUDGE=1 prove` over every roast-whitelisted `S12-attributes`/`S14-roles` file (33 files, 874 tests) — PASS
- [ ] CI `make roast` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)