### PR TITLE
fix(parser): a block's `}` at end of line terminates the statement

### DIFF
--- a/news/2026-08/block-brace-at-end-of-line-ends-the-statement.md
+++ b/news/2026-08/block-brace-at-end-of-line-ends-the-statement.md
@@ -1,0 +1,69 @@
+# A block's closing brace at end of line now terminates the statement
+
+In Raku a `}` that closes a block and sits at the end of a line is a statement
+separator. Whatever starts the next line begins a new statement — even when it
+is spelled like an infix operator:
+
+```raku
+g { 1 }
+before { 2 }      # two calls, NOT g({ 1 } before { 2 })
+```
+
+mutsu's parser had no such rule, so the expression parser cheerfully consumed
+the `before` on the next line as `infix:<before>` and folded the two statements
+into one comparison.
+
+This is the shape `Cro::HTTP::Router` uses for the middleware stanza of a
+`route { }` block:
+
+```raku
+my $app = route {
+    before-matched { $before-m-p.keep }
+    before { $before-p.keep }
+    after { $after-p.keep }
+    after-matched { $after-m-p.keep }
+}
+```
+
+`before-matched`'s block was joined to the next line's `before` block by
+`infix:<before>`, so the call received a single `Bool` argument and died with
+"No matching candidates for proto sub: before-matched". `after-matched` on its
+own was fine — only `before` and `after` are also infix operators, which is why
+the failure looked so arbitrary.
+
+## Mechanism
+
+Rakudo implements this with a `$*ENDSTMT` dynamic variable that its `ws` rule
+consults. mutsu's parser has no single whitespace chokepoint the infix layers
+share, so `parser::stmt_ending_brace` takes the mirror-image approach: the
+block-term parser records **where the next token after such a brace starts**
+(as a `(pointer, length)` pair identifying the exact input position, so a mark
+cannot alias a position in another buffer), and the operator recognisers ask
+`infix_barred_by_stmt_ending_brace` before consuming an operator there.
+
+The mark is set only when a newline (optionally after a trailing `# comment`)
+separates the brace from the next token, so a brace in the middle of a line
+still takes an infix: `say ({ 1 } before { 2 })` is unchanged. It is set only
+for a block parsed as an expression *term*, not for the body of an `if` / `for`
+/ `sub` declaration, so `}` followed by `else` on the next line is unaffected.
+
+## Result
+
+Cro's `t/http-middleware.rakutest` no longer aborts after its 11th subtest: it
+runs all 24, with 22 passing. (Two remain: subtest 4's
+`Cro::HTTP::Middleware::RequestResponse` and subtest 22's "After middleware is
+applied", both separate issues.)
+
+Pinned by `t/block-brace-ends-statement.t`, which checks the positive case, the
+same-line case that must still parse as an infix, and the two cases where a
+newline or a mid-line brace must not terminate anything. All five assertions
+match `raku`'s behaviour exactly.
+
+## Known adjacent gap
+
+A paren-less call to a sub whose name is an infix word (`sub before(&c) {…};
+before { 2 }`) still parses as a bare `before()` plus a stray block, because
+`is_infix_word_op` refuses to treat any of those names as a listop regardless of
+whether a sub of that name is declared. Cro's own code is unaffected (its
+`before` calls sit inside a `route { }` block where the imported sub wins), so
+this is recorded rather than fixed here.

--- a/src/parser/expr/precedence/chain_cmp.rs
+++ b/src/parser/expr/precedence/chain_cmp.rs
@@ -111,6 +111,12 @@ pub(crate) fn wrap_smartmatch_rhs(right: Expr) -> Expr {
 
 /// Extract a comparison operator from the start of the input, returning the op and its length.
 pub(in crate::parser::expr) fn parse_comparison_op(r: &str) -> Option<(ComparisonOp, usize)> {
+    // A block's `}` at end of the previous line terminated the statement, so
+    // whatever sits here begins a new one -- `before`/`after`/`eq`/... at this
+    // position is a term, not an infix (see `parser::stmt_ending_brace`).
+    if crate::parser::stmt_ending_brace::infix_barred_by_stmt_ending_brace(r) {
+        return None;
+    }
     // Unicode comparison operators
     if r.starts_with('\u{2A75}') {
         // ⩵ (U+2A75) — numeric equality (alias for ==)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,6 +6,7 @@ mod parse_result;
 mod primary;
 mod sink_warn;
 mod stmt;
+pub(crate) mod stmt_ending_brace;
 mod whenever_scope;
 use std::sync::OnceLock;
 

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -323,6 +323,10 @@ pub(crate) fn block_or_hash_expr(input: &str) -> PResult<'_, Expr> {
             return Err(PError::expected("'}'"));
         }
         let r = &r[1..];
+        // In Raku a block's `}` at end of line terminates the statement, so an
+        // infix word on the next line (`g { 1 }` NL `before { 2 }`) starts a
+        // new statement instead of taking this block as its left operand.
+        crate::parser::stmt_ending_brace::mark_stmt_ending_brace(r);
         crate::parser::stmt::simple::prepend_anon_state_decls(&mut stmts);
         Ok((r, make_anon_sub(stmts)))
     })();

--- a/src/parser/stmt_ending_brace.rs
+++ b/src/parser/stmt_ending_brace.rs
@@ -1,0 +1,70 @@
+//! Raku's "a block's closing brace at end of line terminates the statement" rule.
+//!
+//! `}` that closes a *block* and is followed by a newline is a statement
+//! separator, so whatever starts the next line begins a new statement — even
+//! when it is spelled like an infix operator:
+//!
+//! ```raku
+//! g { 1 }
+//! before { 2 }     # two calls, NOT `g({ 1 } before { 2 })`
+//! ```
+//!
+//! Rakudo implements this with a `$*ENDSTMT` dynamic variable that its `ws`
+//! rule consults. mutsu's parser has no single whitespace chokepoint the infix
+//! layers share, so instead the block-term parser records **where the next
+//! token after such a brace starts**, and each infix layer asks
+//! [`infix_barred_by_stmt_ending_brace`] before consuming an operator there.
+//!
+//! The mark is a `(pointer, length)` pair of the next token's input slice.
+//! Comparing both makes it an exact position identity: a stale mark left over
+//! from an earlier parse cannot alias a position in a different buffer.
+
+use std::cell::Cell;
+
+thread_local! {
+    /// `(ptr, len)` of the first token after a statement-ending `}`, or
+    /// `(null, 0)` when there is none pending.
+    static MARK: Cell<(*const u8, usize)> = const { Cell::new((std::ptr::null(), 0)) };
+}
+
+/// Record that a block's `}` just ended, with `after_brace` being the input
+/// immediately following it. Sets the mark only when a newline separates the
+/// brace from the next token — a `}` in the middle of a line does not end the
+/// statement (`say ({ 1 } before { 2 })` really is an infix `before`).
+pub(crate) fn mark_stmt_ending_brace(after_brace: &str) {
+    let mut rest = after_brace;
+    let mut saw_newline = false;
+    loop {
+        let trimmed = rest.trim_start_matches([' ', '\t', '\r']);
+        if let Some(nl) = trimmed.strip_prefix('\n') {
+            saw_newline = true;
+            rest = nl;
+            continue;
+        }
+        // A trailing `# comment` still leaves the brace at end of line.
+        if trimmed.starts_with('#') {
+            match trimmed.find('\n') {
+                Some(idx) => {
+                    saw_newline = true;
+                    rest = &trimmed[idx + 1..];
+                    continue;
+                }
+                // A comment running to end of input: nothing follows, so there
+                // is no infix to bar.
+                None => return,
+            }
+        }
+        rest = trimmed;
+        break;
+    }
+    if saw_newline && !rest.is_empty() {
+        MARK.with(|m| m.set((rest.as_ptr(), rest.len())));
+    }
+}
+
+/// True when `r` (an input already positioned past the whitespace following an
+/// expression) sits exactly at a token that a statement-ending `}` separated
+/// from that expression. An infix operator spelled there is not an infix.
+pub(crate) fn infix_barred_by_stmt_ending_brace(r: &str) -> bool {
+    MARK.with(|m| m.get() == (r.as_ptr(), r.len()))
+}

--- a/t/block-brace-ends-statement.t
+++ b/t/block-brace-ends-statement.t
@@ -1,0 +1,43 @@
+use Test;
+
+# In Raku a `}` that closes a block and sits at the end of a line terminates
+# the statement. So a word that would otherwise be an infix operator -- `before`,
+# `after`, `eq`, ... -- begins a NEW statement when it starts the next line:
+#
+#     g { 1 }
+#     before { 2 }      # two calls, not `g({ 1 } before { 2 })`
+#
+# Without this rule, `Cro::HTTP::Router`'s idiomatic
+# `before-matched { ... }` / `before { ... }` stanza inside a `route { }` block
+# parsed as one `before-matched(Bool)` call and died with
+# "No matching candidates for proto sub: before-matched".
+
+plan 5;
+
+my $got;
+sub g($x) { $got = $x }
+sub before($x) { $x }
+sub after($x) { $x }
+
+$got = Nil;
+g { 1 }
+before(5);
+ok $got ~~ Callable, 'a block argument survives a following `before` line';
+
+$got = Nil;
+g { 1 }
+after(5);
+ok $got ~~ Callable, 'a block argument survives a following `after` line';
+
+# The rule is about end of *line*: on one line the infix really is an infix.
+ok ({ 1 } before { 2 }).WHAT === Bool, 'same-line `before` is still the infix';
+
+# It is the brace that terminates, not the newline: a non-block operand still
+# continues across a line break.
+my $sum = 1
+    + 2;
+is $sum, 3, 'a newline before an infix still continues a non-block expression';
+
+# A `}` followed by something other than a newline does not terminate.
+my @a = 1, 2, 3;
+ok (@a.map({ $_ }).join(',') eq '1,2,3'), 'a brace mid-line does not terminate';

--- a/todo/tickets/infix-word-name-is-never-a-listop-call.md
+++ b/todo/tickets/infix-word-name-is-never-a-listop-call.md
@@ -1,0 +1,42 @@
+# A sub named after an infix word can never be called as a listop
+
+`is_infix_word_op` (`src/parser/primary/ident/predicates.rs`) lists every name
+that is also an infix operator — `Z X R x xx eq ne lt gt le ge cmp coll unicmp
+leg and or not div mod gcd lcm but does min max ff fff before after andthen
+orelse notandthen` — and the identifier parser refuses to treat any of them as a
+listop call. That is right for an undeclared name, but it holds even when a sub
+of that name is in scope, so a paren-less call to it is mis-parsed:
+
+```raku
+sub before(&cb) { say "called" }
+before { 2 };            # mutsu: calls before() with no args, leaves { 2 }
+                         #        dangling -> "Too few positionals passed"
+                         # raku:  calls before({ 2 })
+```
+
+With parentheses (`before(5)`) it works, so the gap is specific to the listop
+(paren-less) form.
+
+`Cro::HTTP::Router` exports subs named exactly `before` and `after` and its
+tests call them paren-less inside a `route { }` block. That happens to work
+today, so this is not currently blocking anything — but the same shape in any
+other module would fail.
+
+## Where to fix
+
+The identifier parser should consult the declared-sub table before applying
+`is_infix_word_op`: a name that is a *declared routine in scope* and appears in
+term position (i.e. not directly after a complete operand) is a listop call, not
+an infix. Note the two halves are already distinguished elsewhere — the same
+predicate is consulted from term position and from operator position, and only
+the operator-position use should be unconditional.
+
+Care is needed for the genuinely ambiguous case `@a min @b` where a user has
+also declared `sub min`, and for `x`/`xx`, whose infix form is extremely common.
+
+## Related
+
+Found while fixing the "block brace at end of line ends the statement" rule
+(`news/2026-08/block-brace-at-end-of-line-ends-the-statement.md`); the two
+interact, since the terminator rule is what makes the next line's `before` a
+term position at all.


### PR DESCRIPTION
## Problem

In Raku a `}` that closes a block and sits at the end of a line is a statement separator, so whatever starts the next line begins a new statement — even when it is spelled like an infix operator:

```raku
g { 1 }
before { 2 }      # two calls, NOT g({ 1 } before { 2 })
```

mutsu's expression parser had no such rule and consumed the next line's `before` as `infix:<before>`, folding the two statements into one comparison.

That is exactly the shape `Cro::HTTP::Router`'s middleware stanza uses inside a `route { }` block:

```raku
my $app = route {
    before-matched { $before-m-p.keep }
    before { $before-p.keep }
    after { $after-p.keep }
    after-matched { $after-m-p.keep }
}
```

so `before-matched`'s block was joined to the next line's block by `infix:<before>` and the call received one `Bool`, dying with `No matching candidates for proto sub: before-matched`. Only `before` and `after` are *also* infix operators, which is why `after-matched` on its own looked fine and the failure seemed arbitrary.

## Mechanism

Rakudo implements this with a `$*ENDSTMT` dynamic variable that its `ws` rule consults. mutsu's parser has no single whitespace chokepoint the infix layers share, so `parser::stmt_ending_brace` mirrors it from the other side:

- the block-term parser records **where the next token after such a brace starts**, as a `(pointer, length)` pair identifying the exact input position (comparing both makes a stale mark unable to alias a position in another buffer);
- the operator recogniser asks `infix_barred_by_stmt_ending_brace` before consuming an operator there.

Deliberately narrow in two ways:

- the mark is set only when a newline (optionally after a trailing `# comment`) separates the brace from the next token, so `say ({ 1 } before { 2 })` still parses as an infix;
- it is set only for a block parsed as an expression **term**, not for the body of an `if` / `for` / `sub` declaration, so `}` followed by `else` on the next line is unaffected.

## Result

Cro's `t/http-middleware.rakutest` no longer aborts after its 11th subtest — it runs all 24, with 22 passing. The two remaining failures (subtest 4's `Cro::HTTP::Middleware::RequestResponse`, subtest 22's "After middleware is applied") are separate issues.

## Test

`t/block-brace-ends-statement.t` — five assertions covering the positive case, the same-line case that must still be an infix, and the two cases where a newline or a mid-line brace must not terminate anything. All five produce identical output under `raku` and mutsu; the first two fail without this change.

`make test` passes locally (2936 files, 27797 tests).

## Also recorded

`todo/tickets/infix-word-name-is-never-a-listop-call.md` — an adjacent gap this surfaced: `is_infix_word_op` refuses to treat `before`/`after`/`min`/`x`/… as a listop even when a sub of that name is declared, so `sub before(&c) {…}; before { 2 }` still mis-parses. Cro's own code is unaffected, so it is filed rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)