### PR TITLE
refactor(runtime): resolve_user_method_or_accessor probes the canonical method table (ADR-0019 D2d)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -505,12 +505,21 @@ walkers wholesale is not possible before then.
     in `sync_user_method_entries` alongside the existing `user_candidates` loop (same generation
     bump, no new invalidation hook needed — Phase B's scheme was built write-path-agnostic).
     `has_public_accessor` now probes it (`Registry::accessor_is_public`) per MRO level instead of
-    scanning each class's `attributes` vector. `resolve_user_method_or_accessor` and the
-    `.^methods`/`.^can`/`.^attributes` synthesis sites (`methods_classhow_method_obj.rs`,
-    `methods_classhow_attribute.rs`) are unmigrated — they carry more interacting logic (role
-    attributes, method/accessor shadow ordering, full `Attribute` meta-object construction for
-    `.^attributes`) that a first slice deliberately left alone rather than risk in one pass. See
-    `news/2026-08/d2d-accessor-method-entry.md`.
+    scanning each class's `attributes` vector. See `news/2026-08/d2d-accessor-method-entry.md`.
+    **Second slice landed 2026-08-07**: `resolve_user_method_or_accessor`'s per-MRO-level
+    `class_def.methods.get(...)` scan (with its own inline `is_private`/`is_my`/`role_origin`
+    filtering, duplicating `sync_user_method_entries`' write-side logic) and
+    `class_def.attributes.iter().any(...)` scan are now table probes too:
+    `Registry::user_method_local_role_presence` (new — returns the two booleans directly instead
+    of cloning `Vec<MethodDef>` the way `user_method_overloads` does, since this sits on the
+    method/accessor dispatch race) and the already-existing `accessor_is_public`. Only the
+    `registry.classes.get(cn)` branch moved; the `registry.roles.get(cn)` branch (a punned role
+    used directly as a parent class) is untouched — general roles are not guaranteed to have a
+    synced `method_entries` row the way a class always does, so migrating it needs its own
+    verification pass. `native_methods.contains(...)` also stays as-is (a separate `HashSet`, out
+    of D2d's scope). Remaining in D2d: the `.^methods`/`.^can`/`.^attributes` synthesis sites
+    (`methods_classhow_method_obj.rs`, `methods_classhow_attribute.rs`) — full `Attribute`
+    meta-object construction, not a simple presence probe.
 - [ ] **D3 — Encode class methods and submethods as compiled candidates.** Install ordinary, multi,
   proto, private, rw, wrap, BUILD, and TWEAK metadata without walking `Stmt::MethodDecl`. That
   walk exists in three places, not one — the class walker (~508 lines), the role walker

--- a/news/2026-08/d2d-resolve-user-method-or-accessor-table-probe.md
+++ b/news/2026-08/d2d-resolve-user-method-or-accessor-table-probe.md
@@ -1,0 +1,37 @@
+# ADR-0019 D2d: resolve_user_method_or_accessor becomes a MethodEntry table probe
+
+`resolve_user_method_or_accessor` decides, per MRO level, whether an explicit
+user method or an auto-generated attribute accessor answers a given method
+name — the core of Raku's "explicit method beats accessor beats role method"
+priority rule used across method dispatch. It previously read
+`ClassDef::methods`/`ClassDef::attributes` directly: a `HashMap` lookup
+followed by an inline linear filter over the returned `Vec<MethodDef>`
+(reimplementing `is_private`/`is_my`/`role_origin` filtering already done once
+by `sync_user_method_entries` when it populates the canonical `MethodEntry`
+table), plus a linear scan of the attribute vector for the public-accessor
+check.
+
+Both scans are now table probes against `Registry::method_entries`, the same
+canonical `(owner, name)` table `has_public_accessor` was migrated onto in the
+first D2d slice. A new `Registry::user_method_local_role_presence` returns the
+`(has_local_method, has_role_method)` pair directly without cloning the
+candidate list — `resolve_user_method_or_accessor` sits on the per-call method
+dispatch path, so avoiding the `Vec<MethodDef>` clone that the existing
+`user_method_overloads` helper does matters here. The public-accessor check
+reuses `accessor_is_public` as-is.
+
+Only the `registry.classes.get(cn)` branch of the function moved. The sibling
+branch — a punned role used directly as a parent class — still reads
+`RoleDef` fields directly, since general roles are not guaranteed to have a
+synced `method_entries` row the way a class always does (only punned-role
+instantiation syncs one today), and `native_methods.contains(...)` (a
+separate `HashSet`) is untouched as out of scope for this table.
+
+Verified with the full `t/` suite and every `S12-attributes`/`S14-roles`
+roast-whitelisted file (36 files, 938 tests), all green with no output
+changes — this is a pure mechanism unification, not a behavior change.
+
+Remaining in D2d: the `.^methods`/`.^can`/`.^attributes` synthesis sites
+(`methods_classhow_method_obj.rs`, `methods_classhow_attribute.rs`), which
+carry meaningfully more logic (full `Attribute` meta-object construction) than
+a boolean presence probe.

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -288,23 +288,12 @@ impl Interpreter {
             let (has_local_method, has_role_method, has_attr, has_native) = {
                 let registry = self.registry();
                 if let Some(class_def) = registry.classes.get(cn.as_str()) {
-                    let (mut local, mut role) = (false, false);
-                    if let Some(defs) = class_def.methods.get(method_name) {
-                        for d in defs {
-                            if d.is_private || (d.is_my && is_ancestor) {
-                                continue;
-                            }
-                            if d.role_origin.is_none() {
-                                local = true;
-                            } else {
-                                role = true;
-                            }
-                        }
-                    }
-                    let attr = class_def
-                        .attributes
-                        .iter()
-                        .any(|a| a.is_public && a.name == method_name);
+                    let (local, role) = registry.user_method_local_role_presence(
+                        cn.as_str(),
+                        method_name,
+                        is_ancestor,
+                    );
+                    let attr = registry.accessor_is_public(cn.as_str(), method_name) == Some(true);
                     // A built-in class (e.g. Proc) may register a public attribute
                     // for `.raku`/introspection while a native method of the same
                     // name is the real getter (its computed fallbacks differ from

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -377,6 +377,39 @@ impl Registry {
             .and_then(|entry| entry.accessor)
     }
 
+    /// Per-level (`has_local_method`, `has_role_method`) presence used by
+    /// `resolve_user_method_or_accessor` (ADR-0019 D2d): whether `class_name`
+    /// directly declares a visible (non-private, not `is my`-shadowed-from-an-
+    /// ancestor) candidate for `method_name`, split by whether it originated
+    /// in a composed role. A table probe against `method_entries` instead of
+    /// `class_def.methods.get(...)` plus a `Vec<MethodDef>` clone — same data,
+    /// no allocation, since only the two booleans are needed here.
+    pub(crate) fn user_method_local_role_presence(
+        &self,
+        class_name: &str,
+        method_name: &str,
+        is_ancestor: bool,
+    ) -> (bool, bool) {
+        let Some(entry) = self.method_entries.get(&MethodEntryKey {
+            owner: Symbol::intern(class_name),
+            name: Symbol::intern(method_name),
+        }) else {
+            return (false, false);
+        };
+        let (mut local, mut role) = (false, false);
+        for d in &entry.user_candidates {
+            if d.is_private || (d.is_my && is_ancestor) {
+                continue;
+            }
+            if d.role_origin.is_none() {
+                local = true;
+            } else {
+                role = true;
+            }
+        }
+        (local, role)
+    }
+
     pub(crate) fn replace_method_entries_from(&mut self, source: &Self) {
         self.method_entries = source.method_entries.clone();
         self.bump_method_generation();


### PR DESCRIPTION
## Summary
- Second D2d slice: `resolve_user_method_or_accessor`'s per-MRO-level `ClassDef::methods`/`ClassDef::attributes` scans now probe the canonical `Registry::method_entries` table instead, matching the first D2d slice's migration of `has_public_accessor`.
- New `Registry::user_method_local_role_presence` returns `(has_local_method, has_role_method)` directly without cloning the candidate `Vec<MethodDef>` (this sits on the per-call method dispatch path). The public-accessor check reuses the existing `accessor_is_public`.
- Only the `registry.classes.get(cn)` branch moved; the punned-role-as-parent branch and `native_methods` stay untouched (out of scope — see the ADR update for why).
- Pure mechanism unification, no behavior change.

## Test plan
- [x] `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings`
- [x] `make test` — full pass (2936 files, 27797 tests)
- [x] `MUTSU_FUDGE=1 MUTSU_BIN=target/release/mutsu prove -e 'scripts/run-roast-test.sh' roast/{S12-attributes,S14-roles,6.c/S14-roles}/*.t` — 36 files, 938 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)