### PR TITLE
fix(runtime): propagate errors raised by a coercion method

### DIFF
--- a/news/2026-08/coercion-method-errors-no-longer-swallowed.md
+++ b/news/2026-08/coercion-method-errors-no-longer-swallowed.md
@@ -1,0 +1,49 @@
+# An error raised by a coercion method is no longer swallowed
+
+`Target($value)` falls back to Raku's coercion protocol when the target type
+declares no `COERCE`/`new`: it calls `$value.Target`. mutsu probed for that
+method with a plain "did the call succeed?" test:
+
+```rust
+if args.len() == 1
+    && let Ok(res) = self.call_method_with_values(args[0].clone(), name, vec![])
+{
+    return Ok(res);
+}
+// ... otherwise: "Impossible coercion from '<type>' into '<Target>'"
+```
+
+so an error raised *inside* a coercion method that does exist was discarded and
+replaced with a coercion complaint. Two things were wrong with the report:
+
+- the failure it named was not the failure that happened, and
+- the source type it named was `Any` for **every** class instance, because
+  `value_type_name` returns a `&'static str` and answers a flat `"Any"` for
+  `ValueView::Instance`.
+
+Debugging a Cro chunked response body therefore produced
+`Impossible coercion from 'Any' into 'Promise': no acceptable coercion method
+found` for what was really `No such method 'data' for invocant of type 'Buf'`
+raised inside `Supply.Promise` — a message that named neither the real error nor
+even the real source type, and sent the investigation down the wrong path
+entirely.
+
+## Fix
+
+- Distinguish "the invocant has no `.Target` method" from "the `.Target` method
+  it does have failed". The new `RuntimeError::is_method_not_found_for(name)`
+  checks that the missing method is the one we asked for — a plain
+  `is_method_not_found()` would still have swallowed the Cro case, whose real
+  error was itself an `X::Method::NotFound` for a *different* method (`data`).
+  Anything else propagates unchanged.
+- Report the value's real type in `X::Coerce::Impossible`. The new
+  `types::diagnostic_type_name` answers an instance's class name and a type
+  object's package name, falling back to `value_type_name` otherwise, so
+  `Promise(Plain.new)` now says `from 'Plain'` exactly as raku does (previously
+  `from 'Any'`).
+
+Pinned by `t/coercion-method-error-propagates.t`, whose four assertions match
+`raku` exactly: an `X::AdHoc` from the coercion method propagates, an
+`X::Method::NotFound` raised *inside* it propagates, a value with no coercion
+method still gets `X::Coerce::Impossible`, and that message names the source
+type.

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -832,12 +832,21 @@ impl Interpreter {
             // built-in targets with native-only constructors land in
             // (`class_has_method` sees user methods only), e.g.
             // Cro::MessageWithBody.body-blob's `Promise(supply { ... })`.
-            if args.len() == 1
-                && let Ok(res) = self.call_method_with_values(args[0].clone(), name, vec![])
-            {
-                return Ok(res);
+            if args.len() == 1 {
+                match self.call_method_with_values(args[0].clone(), name, vec![]) {
+                    Ok(res) => return Ok(res),
+                    // Only fall through to "impossible coercion" when the value
+                    // genuinely has no `.<Target>` method. An error *raised by*
+                    // that method is a real failure and must propagate:
+                    // swallowing it reported a nonsense "Impossible coercion
+                    // from 'Any'" and hid the true cause (a Cro response body
+                    // supply died with "No such method 'data'", and all the user
+                    // saw was a bogus coercion error).
+                    Err(err) if err.is_method_not_found_for(name) => {}
+                    Err(err) => return Err(err),
+                }
             }
-            let source_type = crate::runtime::value_type_name(&args[0]).to_string();
+            let source_type = crate::runtime::types::diagnostic_type_name(&args[0]);
             let msg = format!(
                 "Impossible coercion from '{}' into '{}': no acceptable coercion method found",
                 source_type, name
@@ -896,7 +905,7 @@ impl Interpreter {
                 if self.in_does_rhs {
                     return Ok(Value::pair(name.to_string(), Value::array(args.to_vec())));
                 }
-                let source_type = crate::runtime::value_type_name(&args[0]).to_string();
+                let source_type = crate::runtime::types::diagnostic_type_name(&args[0]);
                 let msg = format!(
                     "Impossible coercion from '{}' into '{}': no acceptable coercion method found",
                     source_type, name

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -31,10 +31,22 @@ pub(crate) fn is_coercion_constraint(constraint: &str) -> bool {
     bytes.last() == Some(&b')') && bytes.contains(&b'(') && !bytes.contains(&b'[')
 }
 
+/// The type name to report for `value` in a diagnostic. `value_type_name`
+/// returns a `&'static str`, so it answers a flat "Any" for every instance and
+/// type object; a message that names the user's actual class is far more
+/// useful ("Impossible coercion from 'Supply'", not "... from 'Any'").
+pub(crate) fn diagnostic_type_name(value: &Value) -> String {
+    match value.view() {
+        ValueView::Instance { class_name, .. } => class_name.resolve().to_string(),
+        ValueView::Package(name) => name.resolve().to_string(),
+        _ => crate::runtime::value_type_name(value).to_string(),
+    }
+}
+
 pub(crate) fn coerce_impossible_error(target: &str, got: &Value) -> RuntimeError {
     let msg = format!(
         "Impossible coercion from '{}' into '{}': no acceptable coercion method found",
-        crate::runtime::value_type_name(got),
+        diagnostic_type_name(got),
         target
     );
     let mut attrs = std::collections::HashMap::new();

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -13,7 +13,9 @@ mod type_matching_static;
 mod type_registry;
 
 // Re-export public items from submodules
-pub(crate) use coercion::{coerce_impossible_error, is_coercion_constraint, parse_coercion_type};
+pub(crate) use coercion::{
+    coerce_impossible_error, diagnostic_type_name, is_coercion_constraint, parse_coercion_type,
+};
 pub(in crate::runtime) use signature::{
     bind_named_rename_sub_signature, bind_sub_signature_from_value,
     collect_nested_named_alias_keys, encode_slurpy_rw_param, indexed_varref_from_value,

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -341,6 +341,28 @@ impl RuntimeError {
             || self.message.contains("No such private method '")
     }
 
+    /// Check if this error is "the invocant has no method `name`" — as opposed
+    /// to some *other* method being missing deeper inside the call. A caller
+    /// that probes for an optional method must distinguish the two: treating
+    /// any `X::Method::NotFound` as "the probe missed" swallows a genuine
+    /// failure raised by the method it did find.
+    pub(crate) fn is_method_not_found_for(&self, name: &str) -> bool {
+        if !self.is_method_not_found() {
+            return false;
+        }
+        if let Some(ref ex) = self.exception
+            && let ValueView::Instance { attributes, .. } = ex.view()
+            && let Some(m) = attributes.as_map().get("method")
+        {
+            return m.to_string_value() == name;
+        }
+        self.message
+            .contains(&format!("No such method '{name}' for"))
+            || self
+                .message
+                .contains(&format!("No such private method '{name}' for"))
+    }
+
     /// Check if this error represents a multi-dispatch no-match
     /// (`X::Multi::NoMatch`). Used by constructor/accessor dispatch to decide
     /// whether to fall back to a default candidate (e.g. `Mu.new`).

--- a/t/coercion-method-error-propagates.t
+++ b/t/coercion-method-error-propagates.t
@@ -1,0 +1,42 @@
+use Test;
+
+# `Target($value)` falls back to Raku's `$value.Target` coercion method when the
+# target type declares no COERCE/new. mutsu probed for that method with a plain
+# "did the call succeed?" test, so an error *raised inside* the method was
+# swallowed and reported as "Impossible coercion from 'Any' into 'Target'" --
+# a message that names neither the real failure nor even the real source type.
+#
+# Found via Cro: a chunked response body supply died with "No such method
+# 'data'" deep inside `Promise($supply)`, and all the user saw was the bogus
+# coercion error.
+
+plan 4;
+
+class Boom {
+    method Promise() { die "boom from the coercion method" }
+}
+
+throws-like { Promise(Boom.new) }, X::AdHoc,
+    message => /'boom from the coercion method'/,
+    'an error raised by the coercion method propagates unchanged';
+
+# A *different* method missing inside the coercion method is still that
+# method's failure, not "this value cannot coerce".
+class InnerMissing {
+    method Promise() { 42.no-such-method-here }
+}
+
+throws-like { Promise(InnerMissing.new) }, X::Method::NotFound,
+    'a method-not-found raised inside the coercion method propagates too';
+
+# A value that genuinely has no coercion method still reports the coercion
+# failure, naming its own type.
+class Plain { }
+
+throws-like { Promise(Plain.new) }, X::Coerce::Impossible,
+    'a value with no coercion method still reports X::Coerce::Impossible';
+
+my $msg = '';
+try { Promise(Plain.new) };
+$msg = $! ?? $!.message !! '';
+ok $msg.contains('Plain'), 'the coercion failure names the source type';

--- a/todo/deep/cro-client-cannot-read-a-chunked-response-body.md
+++ b/todo/deep/cro-client-cannot-read-a-chunked-response-body.md
@@ -1,0 +1,139 @@
+# Cro's HTTP client cannot read a chunked response body
+
+`Cro::HTTP::Client` under mutsu reads a `Content-Length`-framed response body
+fine but dies on a `Transfer-Encoding: chunked` one:
+
+```
+Died because of the exception:
+    No such method 'data' for invocant of type 'Buf'
+  in sub body-blob ...
+  in sub body-text ...
+```
+
+`.data` is `Cro::TCP::Message.data`, read in `Cro::HTTP::ResponseParser`'s
+`whenever $in -> Cro::TCP::Message $packet`. A raw `Buf` reaching that
+subscription means the body bytes the parser emits into its **own**
+`$raw-body-byte-stream` Supplier are being delivered back to the parser's
+upstream `whenever $in` — supply cross-talk, not a chunked-decoding bug as such.
+(The `Cro::TCP::Message` type constraint on the parameter is also not enforced,
+which is why it surfaces as a missing method rather than a binding failure.)
+
+The mutsu **server** side is fine: `curl` reads a chunked response from a mutsu
+Cro server correctly, body and all.
+
+## Why it matters
+
+It is the remaining failure in Cro's `t/http-middleware.rakutest` subtest 4
+(`Cro::HTTP::Middleware::RequestResponse`). That test's cache middleware answers
+the second request with
+
+```raku
+given Cro::HTTP::Response.new(:$request, :200status) {
+    .set-body-byte-stream: supply emit $!cached-blob;
+    .emit;
+}
+```
+
+which carries no `Content-Length`, so `Cro::HTTP::ResponseSerializer` frames it
+chunked — and the in-process client then cannot read it.
+
+## Reproduction (no Cro server needed)
+
+`tmp/` is scratch, so recreate these two files:
+
+```raku
+# tmp/chunked-srv.raku -- a raw socket server that answers one chunked response
+my $listen = IO::Socket::Async.listen('localhost', 31318);
+my $tap = $listen.tap(-> $conn {
+    my $body = "HTTP/1.1 200 OK\r\nTransfer-encoding: chunked\r\n\r\n1\r\n1\r\n0\r\n\r\n";
+    $conn.Supply(:bin).tap(-> $ { });
+    $conn.print($body);
+    Promise.in(0.3).then({ $conn.close });
+});
+say "listening";
+sleep 25;
+```
+
+```raku
+# tmp/chunked-cli.raku
+use Cro::HTTP::Client;
+my $resp = await Cro::HTTP::Client.get('http://localhost:31318/x');
+say "status = ", $resp.status;
+say "body   = ", (await $resp.body-text).raku;
+```
+
+Run the server under plain `raku` (it uses no Cro), then the client under each:
+real `raku` prints `body = "1"`; mutsu dies as above. `curl` against the same
+server is also fine, so the response itself is well-formed.
+
+## Where to look
+
+`Cro::HTTP::RawBodyParser::Chunked.parser` (in the Cro::HTTP dist's
+`lib/Cro/HTTP/RawBodyParser.rakumod`) is a `supply { }` whose `whenever
+$raw-blobs` body calls a `sub parse-chunks()` declared *after* it in the same
+block. `Cro::HTTP::ResponseParser` wires it up as
+
+```raku
+$raw-body-byte-stream = Supplier.new;
+$response.set-body-byte-stream(preserve(
+    $raw-body-parser.parser($response, $raw-body-byte-stream.Supply, $leftover)));
+$raw-body-byte-stream.emit($header-decoder.consume-exactly-bytes($count));
+```
+
+all from *inside* its own `whenever $in` body — a supply created and fed from
+within another supply's callback, with a `preserve` in between.
+
+The `ContentLength` parser has the same outer shape and works, so the difference
+is either the nested `sub` or the fact that `Chunked` needs more than one
+upstream packet.
+
+## Smaller divergence found while narrowing (may or may not be the same bug)
+
+This two-level shape already diverges without any Cro:
+
+```raku
+sub chunk-parser(Supply $raw) {
+    supply {
+        my $buffer = Buf.new;
+        whenever $raw -> $blob { $buffer.append($blob); drain(); }
+        sub drain() {
+            while $buffer.elems >= 2 { emit $buffer.subbuf(0, 2); $buffer .= subbuf(2) }
+        }
+    }
+}
+class Msg { has $.data; }
+sub transformer(Supply $in) {
+    supply {
+        my ($raw, $body-out);
+        whenever $in -> Msg $packet {
+            if !$raw.defined {
+                $raw = Supplier.new;
+                $body-out = chunk-parser($raw.Supply);
+                emit $body-out;
+            }
+            $raw.emit($packet.data);
+        }
+    }
+}
+my $wire = Supplier.new;
+my @bodies;
+transformer($wire.Supply).tap(-> $b { @bodies.push($b) });
+$wire.emit(Msg.new(data => Buf.new(0x61, 0x62)));
+$wire.emit(Msg.new(data => Buf.new(0x63, 0x64)));
+my @got;
+@bodies[0].tap(-> $v { @got.push($v.decode('ascii')) });
+$wire.emit(Msg.new(data => Buf.new(0x65, 0x66)));
+say @got.raku;      # raku: ["ef"]   mutsu: []
+```
+
+The single-level version (a `supply` whose `whenever` calls a `sub` declared
+after it) is clean in both, so the nesting is what breaks it: an inner supply
+created inside an outer supply's `whenever` body loses the values later pushed
+into its source.
+
+## Note
+
+Diagnosing this was much harder than it should have been because
+`Promise($supply)` swallowed the real error and reported
+`Impossible coercion from 'Any' into 'Promise'`. That is fixed separately
+(`news/2026-08/coercion-method-errors-no-longer-swallowed.md`).


### PR DESCRIPTION
## Problem

`Target($value)` falls back to Raku's coercion protocol — calling `$value.Target` — when the target type declares no `COERCE`/`new`. mutsu probed for that method with a plain "did the call succeed?" test:

```rust
if args.len() == 1
    && let Ok(res) = self.call_method_with_values(args[0].clone(), name, vec![])
{
    return Ok(res);
}
// ... otherwise: "Impossible coercion from '<type>' into '<Target>'"
```

so an error raised *inside* a coercion method that **does** exist was discarded and replaced with a coercion complaint. Two things were wrong with the report:

- the failure it named was not the failure that happened, and
- the source type it named was `Any` for **every** class instance, because `value_type_name` returns a `&'static str` and answers a flat `"Any"` for `ValueView::Instance`.

Debugging a Cro chunked response body therefore produced

```
Impossible coercion from 'Any' into 'Promise': no acceptable coercion method found
```

for what was really `No such method 'data' for invocant of type 'Buf'` raised inside `Supply.Promise` — a message naming neither the real error nor even the real source type.

## Fix

- **`RuntimeError::is_method_not_found_for(name)`** distinguishes "the invocant has no `.Target` method" from "the `.Target` method it does have failed". This distinction is load-bearing: a plain `is_method_not_found()` would still have swallowed the Cro case, whose real error was itself an `X::Method::NotFound` — for a *different* method (`data`). Anything else propagates unchanged.
- **`types::diagnostic_type_name`** answers an instance's class name and a type object's package name, falling back to `value_type_name` otherwise, so `X::Coerce::Impossible` names the real source type: `Promise(Plain.new)` now says `from 'Plain'`, exactly as raku does (previously `from 'Any'`).

## Test

`t/coercion-method-error-propagates.t` — four assertions, all matching `raku` exactly:

1. an `X::AdHoc` thrown by the coercion method propagates unchanged;
2. an `X::Method::NotFound` raised *inside* the coercion method propagates too;
3. a value with no coercion method still gets `X::Coerce::Impossible`;
4. that message names the source type.

`make test` passes locally (2938 files, 27806 tests).

## Also filed

`todo/deep/cro-client-cannot-read-a-chunked-response-body.md` — the underlying Cro failure this uncovered (mutsu's `Cro::HTTP::Client` dies on a `Transfer-Encoding: chunked` response body; the server side is fine, `curl` reads it), with a Cro-free reproduction and a smaller nested-supply divergence found while narrowing it. It is the last failure in Cro's `t/http-middleware.rakutest` subtest 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)