### PR TITLE
docs(todo): root-cause Cro's chunked body failure as a nested-sub emit leak

### DIFF
--- a/todo/deep/cro-client-cannot-read-a-chunked-response-body.md
+++ b/todo/deep/cro-client-cannot-read-a-chunked-response-body.md
@@ -10,13 +10,20 @@ Died because of the exception:
   in sub body-text ...
 ```
 
-`.data` is `Cro::TCP::Message.data`, read in `Cro::HTTP::ResponseParser`'s
-`whenever $in -> Cro::TCP::Message $packet`. A raw `Buf` reaching that
-subscription means the body bytes the parser emits into its **own**
-`$raw-body-byte-stream` Supplier are being delivered back to the parser's
-upstream `whenever $in` — supply cross-talk, not a chunked-decoding bug as such.
-(The `Cro::TCP::Message` type constraint on the parameter is also not enforced,
-which is why it surfaces as a missing method rather than a binding failure.)
+**Root-caused**: see
+`todo/deep/nested-sub-emit-leaks-into-the-outer-supply.md`. A bare `emit` inside
+a `sub` declared in a `supply { }` body is not rewritten to `$emitter.emit(...)`
+and resolves dynamically to `active_supply_emitters.last()`, which is the
+*outer* supply when the inner supply's `whenever` fires inside the outer body.
+`Cro::HTTP::RawBodyParser::Chunked` emits from exactly such a nested
+`sub parse-chunks()`, and `Cro::HTTP::ResponseParser` creates and feeds it from
+inside its own `whenever $in` body — so the decoded `Buf` is emitted out of the
+ResponseParser's supply instead of the body supply. `.data` is
+`Cro::TCP::Message.data`, read by the ResponseParser itself. The
+`ContentLength` parser emits inline rather than from a nested sub, which is why
+`Content-Length` bodies work and chunked ones do not. (The `Cro::TCP::Message`
+type constraint on the parameter is also not enforced, which is why it surfaces
+as a missing method rather than a binding failure.)
 
 The mutsu **server** side is fine: `curl` reads a chunked response from a mutsu
 Cro server correctly, body and all.
@@ -83,53 +90,14 @@ $raw-body-byte-stream.emit($header-decoder.consume-exactly-bytes($count));
 all from *inside* its own `whenever $in` body — a supply created and fed from
 within another supply's callback, with a `preserve` in between.
 
-The `ContentLength` parser has the same outer shape and works, so the difference
-is either the nested `sub` or the fact that `Chunked` needs more than one
-upstream packet.
+The `ContentLength` parser has the same outer shape and works; the difference is
+the nested `sub` (see the root-cause ticket above).
 
-## Smaller divergence found while narrowing (may or may not be the same bug)
+## Narrowing
 
-This two-level shape already diverges without any Cro:
-
-```raku
-sub chunk-parser(Supply $raw) {
-    supply {
-        my $buffer = Buf.new;
-        whenever $raw -> $blob { $buffer.append($blob); drain(); }
-        sub drain() {
-            while $buffer.elems >= 2 { emit $buffer.subbuf(0, 2); $buffer .= subbuf(2) }
-        }
-    }
-}
-class Msg { has $.data; }
-sub transformer(Supply $in) {
-    supply {
-        my ($raw, $body-out);
-        whenever $in -> Msg $packet {
-            if !$raw.defined {
-                $raw = Supplier.new;
-                $body-out = chunk-parser($raw.Supply);
-                emit $body-out;
-            }
-            $raw.emit($packet.data);
-        }
-    }
-}
-my $wire = Supplier.new;
-my @bodies;
-transformer($wire.Supply).tap(-> $b { @bodies.push($b) });
-$wire.emit(Msg.new(data => Buf.new(0x61, 0x62)));
-$wire.emit(Msg.new(data => Buf.new(0x63, 0x64)));
-my @got;
-@bodies[0].tap(-> $v { @got.push($v.decode('ascii')) });
-$wire.emit(Msg.new(data => Buf.new(0x65, 0x66)));
-say @got.raku;      # raku: ["ef"]   mutsu: []
-```
-
-The single-level version (a `supply` whose `whenever` calls a `sub` declared
-after it) is clean in both, so the nesting is what breaks it: an inner supply
-created inside an outer supply's `whenever` body loses the values later pushed
-into its source.
+The step-by-step narrowing from this failure down to the nested-`sub` emit leak
+— including the four-variant table that isolates the trigger — lives in
+`todo/deep/nested-sub-emit-leaks-into-the-outer-supply.md`.
 
 ## Note
 

--- a/todo/deep/nested-sub-emit-leaks-into-the-outer-supply.md
+++ b/todo/deep/nested-sub-emit-leaks-into-the-outer-supply.md
@@ -1,0 +1,162 @@
+# A bare `emit` inside a supply block's nested `sub` leaks into the outer supply
+
+The parser rewrites an `emit` written **directly** in a `supply { }` body to
+`$emitter.emit(...)`. An `emit` written inside a `sub` *declared in* that body is
+not rewritten, so at run time it falls through to `Interpreter::call_function`'s
+`emit` arm (`src/runtime/builtins.rs:886`), which resolves the target
+dynamically:
+
+```rust
+if let Some(emitter) = self.active_supply_emitters.last().cloned() {
+    return self.call_method_with_values(emitter, "emit", vec![value]).map(|_| Value::NIL);
+}
+```
+
+That is the right idea — Raku catches `emit` with the innermost *dynamically*
+enclosing supply — but when an inner supply's `whenever` body runs **while an
+outer supply's body is still on the stack**, `active_supply_emitters.last()` is
+the *outer* emitter, and the inner supply's value is emitted downstream of the
+wrong supply.
+
+## Reproduction
+
+```raku
+sub v2(Supply $raw) {
+    supply {
+        whenever $raw -> $v { twice($v) }
+        sub twice($x) { emit $x * 2 }      # <-- not rewritten to $emitter.emit
+    }
+}
+
+my $wire = Supplier.new;
+my $raw;
+my @bodies;
+my $outer = supply {
+    whenever $wire -> $v {
+        if !$raw.defined {
+            $raw = Supplier.new;
+            emit v2($raw.Supply);          # hand the inner supply downstream
+        }
+        $raw.emit($v);                     # runs the inner whenever *inside* this body
+    }
+};
+$outer.tap(-> $b { @bodies.push($b) });
+$wire.emit(1);
+@bodies[0].tap(-> $x { }) if @bodies;
+$wire.emit(2);
+
+say @bodies.elems;                  # raku: 1     mutsu: 2
+say @bodies.map(*.WHICH).raku;      # mutsu: (ObjAt "Supply|43", ValueObjAt "Int|4")
+```
+
+The second element of `@bodies` is the **Int 4** — `twice(2)`'s value, which
+belongs to the inner supply, arriving at the *outer* supply's tap. The outer
+lexicals are fine (`$raw` is still defined on the second call, verified by
+recording it into an array), so this is purely mis-routed emission.
+
+The trigger is exactly the nested `sub`. Four variants of the inner parser,
+identical except for how the value is emitted:
+
+| inner parser | mutsu |
+| --- | --- |
+| `whenever $raw -> $v { emit $v * 2 }` | correct |
+| `my @buf; whenever $raw -> $v { @buf.push($v); emit @buf.shift * 2 }` | correct |
+| `whenever $raw -> $v { twice($v) }` + `sub twice($x) { emit $x * 2 }` after | **leaks** |
+| same, with the `sub` declared before the `whenever` | **leaks** |
+
+An inner supply that is *not* created inside the outer supply's `whenever` body
+is fine — the outer emitter has to be dynamically active at the moment the inner
+`whenever` fires.
+
+## Why it matters: Cro cannot read a chunked response body
+
+`Cro::HTTP::RawBodyParser::Chunked.parser` is precisely this shape:
+
+```raku
+supply {
+    my $state = AwaitingLength;
+    my $buffer = Buf.new;
+    whenever $raw_blobs -> $blob { $buffer.append($blob); parse-chunks(); }
+    sub parse-chunks() { ... emit $buffer.subbuf(0, $length-awaited); ... }
+}
+```
+
+and `Cro::HTTP::ResponseParser` creates and feeds it from **inside its own**
+`whenever $in` body:
+
+```raku
+$raw-body-byte-stream = Supplier.new;
+$response.set-body-byte-stream(preserve(
+    $raw-body-parser.parser($response, $raw-body-byte-stream.Supply, $leftover)));
+$raw-body-byte-stream.emit($header-decoder.consume-exactly-bytes($count));
+```
+
+So `parse-chunks`'s decoded `Buf` is emitted out of the **ResponseParser's**
+supply instead of the body supply, and the client dies with
+
+```
+No such method 'data' for invocant of type 'Buf'
+```
+
+(`.data` is `Cro::TCP::Message.data`, read by the ResponseParser itself). The
+`ContentLength` parser emits inline rather than from a nested sub, which is why
+`Content-Length` bodies work and chunked ones do not.
+
+`curl` reads a chunked response from a mutsu Cro **server** correctly, so only
+the client is affected.
+
+### Cro-free client reproduction
+
+```raku
+# tmp/chunked-srv.raku -- run under plain raku; uses no Cro
+my $listen = IO::Socket::Async.listen('localhost', 31318);
+my $tap = $listen.tap(-> $conn {
+    my $body = "HTTP/1.1 200 OK\r\nTransfer-encoding: chunked\r\n\r\n1\r\n1\r\n0\r\n\r\n";
+    $conn.Supply(:bin).tap(-> $ { });
+    $conn.print($body);
+    Promise.in(0.3).then({ $conn.close });
+});
+say "listening";
+sleep 25;
+```
+
+```raku
+# tmp/chunked-cli.raku
+use Cro::HTTP::Client;
+my $resp = await Cro::HTTP::Client.get('http://localhost:31318/x');
+say "body = ", (await $resp.body-text).raku;   # raku: "1"   mutsu: dies
+```
+
+It is the remaining failure in Cro's `t/http-middleware.rakutest` subtest 4: the
+cache middleware answers the second request with a body that carries no
+`Content-Length`, so `Cro::HTTP::ResponseSerializer` frames it chunked, and the
+in-process client then cannot read it.
+
+## Where the fix belongs
+
+`Interpreter::call_supply_tap` (`src/runtime/supply_promise.rs`) already exists
+for exactly this purpose: it finds the `__mutsu_supply_emitter_<id>` lexical in
+the *callback's own* env and pushes it onto `active_supply_emitters` for the
+duration of the call, so a bare `emit` in a sub the callback calls resolves to
+the right supply. The bug is that this does not hold for the failing shape —
+either the whenever body no longer captures that lexical once the block also
+declares a `sub` (the free-variable/`owned_lexicals` analysis changes), or the
+body reaches dispatch through a path that does not push (note that
+`Interpreter::call_react_callback` in `src/vm/vm_react_loop.rs` runs whenever
+bodies via `vm_call_map_block` and does **not** push an emitter). A `gdb` break
+on `supply_promise.rs`'s `let res = self.call_sub_value(tap, ...)` shows a mix of
+`pushed = true` and `pushed = false` dispatches on the reproduction above;
+identifying which one is the inner whenever body is the next concrete step.
+
+The durable fix is to make the emitter dynamically scoped to *whichever* supply
+a callback belongs to, at every dispatch site — not just the `call_supply_tap`
+one — so that a nested supply's callbacks never inherit the enclosing supply's
+emitter.
+
+## Related
+
+- `todo/deep/compiled-fns-default-breaks-nested-subs-outside-methods.md` — nested
+  named subs and their captured environment.
+- The misleading `Impossible coercion from 'Any' into 'Promise'` that hid this
+  for a whole investigation is fixed in
+  `news/2026-08/coercion-method-errors-no-longer-swallowed.md`.


### PR DESCRIPTION
Follow-up to #6037, which filed `todo/deep/cro-client-cannot-read-a-chunked-response-body.md` as an open question. It is now root-caused.

## The bug

The parser rewrites an `emit` written **directly** in a `supply { }` body to `$emitter.emit(...)`. An `emit` written inside a `sub` *declared in* that body is not rewritten, so it falls through to the dynamic fallback in `Interpreter::call_function`:

```rust
if let Some(emitter) = self.active_supply_emitters.last().cloned() { … }
```

That is the right idea — Raku catches `emit` with the innermost *dynamically* enclosing supply — but when an inner supply's `whenever` body runs **while an outer supply's body is still on the stack**, `.last()` is the *outer* emitter, and the inner supply's value is emitted downstream of the wrong supply.

Nine-line reproduction in the ticket; the tell is that the outer supply's tap receives an `Int` that belongs to the inner supply. The outer lexicals are provably fine, so it is purely mis-routed emission.

The trigger is exactly the nested `sub`:

| inner parser | mutsu |
| --- | --- |
| `whenever $raw -> $v { emit $v * 2 }` | correct |
| `my @buf; whenever $raw -> $v { @buf.push($v); emit @buf.shift * 2 }` | correct |
| `whenever $raw -> $v { twice($v) }` + `sub twice($x) { emit $x * 2 }` after | **leaks** |
| same, with the `sub` declared before the `whenever` | **leaks** |

## Why it explains the Cro failure

`Cro::HTTP::RawBodyParser::Chunked` emits from a nested `sub parse-chunks()`, and `Cro::HTTP::ResponseParser` creates and feeds it from inside its own `whenever $in` body — so the decoded `Buf` leaves the ResponseParser's supply instead of the body supply, and the client dies with `No such method 'data' for invocant of type 'Buf'` (`.data` is `Cro::TCP::Message.data`, read by the ResponseParser itself). `Cro::HTTP::RawBodyParser::ContentLength` emits inline, which is why `Content-Length` bodies work and chunked ones do not.

This is the remaining failure in Cro's `t/http-middleware.rakutest` subtest 4.

## Contents

- **new** `todo/deep/nested-sub-emit-leaks-into-the-outer-supply.md` — the root cause, the reproduction, the variant table, and where the fix belongs (`call_supply_tap` already implements the intended dynamic scoping; it needs to hold at *every* callback dispatch site, notably `call_react_callback`, which does not push an emitter).
- `todo/deep/cro-client-cannot-read-a-chunked-response-body.md` — rewritten to point at it instead of speculating about supply cross-talk.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)