### PR TITLE
fix(runtime): role-composed and augment-declared methods keep is DEPRECATED

### DIFF
--- a/news/2026-08/role-augment-method-deprecated-message-dropped.md
+++ b/news/2026-08/role-augment-method-deprecated-message-dropped.md
@@ -1,0 +1,37 @@
+# Role-composed and augment-declared methods keep their `is DEPRECATED` message
+
+Found while scoping ADR-0019 D3 (which method declarations get walked
+independently in three places: the class body, role body, and `augment
+class` — each building a `MethodDef` from `Stmt::MethodDecl` by hand). The
+scoping pass flagged that `registration_role_method.rs`'s
+`role_body_method_decl` and `registration_class_augment.rs`'s
+`augment_class` both destructured `Stmt::MethodDecl::deprecated_message` and
+discarded it, hard-coding `MethodDef.deprecated_message: None` instead —
+unlike the class-body walker (`registration_class_body_method.rs`), which
+threads it through correctly.
+
+Confirmed against `raku` as a real behavior gap, not just an internal
+inconsistency:
+
+```raku
+role R { method foo() is DEPRECATED('use bar instead') { } }
+class C does R { }
+C.new.foo;
+```
+
+`raku` prints the usual `Saw 1 occurrence of deprecated code.` report;
+mutsu silently ran the method with no report at all. Same gap for
+`augment class C { method foo() is DEPRECATED(...) { } }`.
+
+Both sites now thread `deprecated_message` through to the constructed
+`MethodDef`, matching the class-body walker. Verified with the full `t/`
+suite, the whitelisted `roast/S02-types/isDEPRECATED.t`, and every
+`S12-methods`/`S14-roles` whitelisted file (52 files, 938 tests), all green.
+A new `t/role-augment-method-deprecated-message.t` pins both cases via
+`Deprecation.report`.
+
+Note: the reported attribution (`Method foo (from C)` vs. rakudo's `(from
+R)` for the role case) is a separate, pre-existing, purely cosmetic
+discrepancy in how the deprecation report names the declaring
+package — unrelated to this fix, which is about the message surviving at
+all.

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -175,6 +175,7 @@ impl Interpreter {
                     is_submethod,
                     return_type,
                     is_default_candidate,
+                    deprecated_message,
                     ..
                 } => {
                     let resolved_method_name = if let Some(expr) = name_expr {
@@ -241,7 +242,7 @@ impl Interpreter {
                         compiled_fns: None,
                         delegation: None,
                         is_default: *is_default_candidate,
-                        deprecated_message: None,
+                        deprecated_message: deprecated_message.clone(),
                         is_submethod: *is_submethod,
                         captured_env: None,
                     };

--- a/src/runtime/registration_role_method.rs
+++ b/src/runtime/registration_role_method.rs
@@ -30,7 +30,7 @@ impl Interpreter {
             our_variable_form: _,
             return_type,
             is_default_candidate,
-            deprecated_message: _,
+            deprecated_message,
             handles: method_handles,
             custom_traits: _,
             is_export: _,
@@ -218,7 +218,7 @@ impl Interpreter {
             compiled_fns: None,
             delegation: None,
             is_default: *is_default_candidate,
-            deprecated_message: None,
+            deprecated_message: deprecated_message.clone(),
             is_submethod: *is_submethod,
             captured_env: None,
         };

--- a/t/role-augment-method-deprecated-message.t
+++ b/t/role-augment-method-deprecated-message.t
@@ -1,0 +1,28 @@
+use Test;
+
+# A method's `is DEPRECATED(...)` message must survive both role composition
+# and `augment class` — registration_role_method.rs and
+# registration_class_augment.rs each independently build a MethodDef from
+# Stmt::MethodDecl and previously hard-coded deprecated_message to None
+# instead of threading the parsed message through.
+
+plan 2;
+
+{
+    role R { method foo() is DEPRECATED('use bar instead') { 42 } }
+    class C does R { }
+    C.new.foo;
+    ok Deprecation.report ~~ m/'use bar instead'/,
+        'role-composed method keeps its is DEPRECATED message';
+}
+
+{
+    use MONKEY-TYPING;
+    class D { }
+    augment class D { method quux() is DEPRECATED('use baz instead') { 42 } }
+    D.new.quux;
+    ok Deprecation.report ~~ m/'use baz instead'/,
+        'augment class method keeps its is DEPRECATED message';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary
- Found while scoping ADR-0019 D3 (the method-declaration walk exists independently in the class body, role body, and `augment class` walkers, and has drifted between them). `registration_role_method.rs`'s `role_body_method_decl` and `registration_class_augment.rs`'s `augment_class` both destructured `Stmt::MethodDecl::deprecated_message` and discarded it, hard-coding `MethodDef.deprecated_message: None` — unlike the class-body walker, which threads it through.
- Confirmed as a real gap against `raku`: a role-composed or `augment class`-declared method's `is DEPRECATED(...)` message was silently dropped by mutsu (no deprecation report at all), while `raku` correctly reports it.
- Both sites now thread `deprecated_message` through to the constructed `MethodDef`, matching the class-body walker.

## Test plan
- [x] `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings`
- [x] `make test` — full pass (2939 files, 27808 tests)
- [x] `MUTSU_FUDGE=1 MUTSU_BIN=target/release/mutsu prove -e 'scripts/run-roast-test.sh' roast/{S02-types/isDEPRECATED.t,S12-methods,S14-roles}/*.t` — 52 files, 938 tests, all green
- [x] New `t/role-augment-method-deprecated-message.t` (verified against both mutsu and `raku`), pinning the role and augment cases via `Deprecation.report`

🤖 Generated with [Claude Code](https://claude.com/claude-code)