### PR TITLE
feat(runtime): precompile method decl name_expr into chunks (ADR-0019 D3-1)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -595,6 +595,21 @@ walkers wholesale is not possible before then.
   `add_sub_decl_plan`/`add_class_decl_plan` already do, since it is read-and-discarded immediately
   (never stored on `MethodDef`) and is the most literally-duplicated-verbatim logic across all
   three sites — a clean, low-risk demonstration slice that doesn't touch `MethodDef`'s shape.
+  **D3-1 landed 2026-08-07** for the two walkers with an existing declaration plan:
+  `CompiledClassDeclPlan`/`CompiledRoleDeclPlan` gained a `method_name_chunks:
+  Vec<Option<CompiledDeclExpr>>`, one entry per top-level `method`/`submethod` statement
+  precompiled by `Compiler::compile_method_name_chunks` (mirroring the exact `SyntheticBlock`
+  flattening `run_class_body`/`walk_role_body` already perform), and `class_body_method_decl`/
+  `role_body_method_decl` read the chunk at that statement's position via a cursor threaded through
+  `ClassBodyCx`/`RoleDeclCx` instead of recompiling `name_expr` from a cloned AST node on every
+  registration. Position, not name, is the key: unlike D2c-1's attribute `is_default` chunks (keyed
+  by the attribute's own unique name), a method's fallback `name: Symbol` is not reliable to key on
+  — an indirect declaration with a non-literal expression falls back to a shared placeholder, and
+  ordinary `multi` methods legitimately share a literal name. `augment_class`'s `MethodDecl` arm was
+  left unmigrated: `augment class` has no declaration plan at all yet (`Stmt::AugmentClass` still
+  indexes `stmt_pool` via the legacy `AugmentClass(u32)` opcode, outside the ADR-0019 plan system
+  entirely), so giving it a chunk means building that machinery from scratch — separate, larger
+  scope than this slice. `news/2026-08/d3-1-method-name-chunks.md`.
   D3-2/D3-3/D3-4 (one per walker, per the ADR's own expectation) should then unify onto a shared
   `CompiledMethodDecl::from_stmt` and fix the drift found above (the `augment_class` `is_lexical_only`
   gating gap and privacy-aware duplicate detection in particular) as part of the unification, the

--- a/news/2026-08/d3-1-method-name-chunks.md
+++ b/news/2026-08/d3-1-method-name-chunks.md
@@ -1,0 +1,41 @@
+# ADR-0019 D3-1: method declaration name chunks precompiled
+
+`class_body_method_decl`, `role_body_method_decl`, and `augment_class`'s
+`MethodDecl` arm each evaluated a `method ::($name) {...}` computed method
+name the same way: `self.eval_block_value(&[Stmt::Expr(expr.clone())])`,
+recompiling the expression's bytecode from a raw AST clone on every single
+registration. This mirrored the pattern `SubDecl`/`ClassDecl` used before
+ADR-0019 C5/D2c precompiled their own computed-name and trait-argument
+expressions into child chunks (`CompiledDeclExpr`) at plan-lowering time.
+
+The two walkers with an existing declaration plan — `CompiledClassDeclPlan`
+and `CompiledRoleDeclPlan` — now carry a `method_name_chunks:
+Vec<Option<CompiledDeclExpr>>`, one entry per top-level `method`/`submethod`
+statement in the body (after the same `SyntheticBlock` flattening
+`run_class_body`/`walk_role_body` already perform), precompiled once by
+`Compiler::compile_method_name_chunks`. Registration reads the chunk at that
+statement's position instead of recompiling `name_expr` from a clone.
+
+Position, not name, is the shared key: unlike an attribute's `is
+default(...)` chunk (ADR-0019 D2c-1, keyed by the attribute's own unique
+name), a method's fallback `name: Symbol` is not reliable to key on — an
+indirect declaration with a non-literal expression falls back to a shared
+placeholder, and ordinary `multi` methods legitimately share a literal name.
+Both sides (the compiler's collector and the two runtime walkers) flatten
+`SyntheticBlock` identically and visit `MethodDecl` statements in the same
+order with no other filtering, so a cursor threaded through `ClassBodyCx`/
+`RoleDeclCx` stays aligned by construction.
+
+`augment_class`'s `MethodDecl` arm keeps evaluating the raw AST expression:
+`augment class` is not part of the ADR-0019 declaration-plan system at all
+yet (`Stmt::AugmentClass` still indexes `stmt_pool` directly via a legacy
+`AugmentClass(u32)` opcode), so there is no compiled plan to attach a chunk
+to. Giving it one is separate, larger scope — building the augment
+declaration-plan machinery from scratch — left for a later slice.
+
+Extended `t/indirect-declarator-names.t` with a multi-method class and a
+role, each interleaving ordinary and `method ::(...)` declarations, to
+exercise the positional cursor with more than one indirect name per body
+(the prior coverage had exactly one method per declaration, which would not
+have caught a misaligned cursor). Verified byte-identical output against
+`raku` for the new cases.

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -45,6 +45,35 @@ impl Compiler {
         }
     }
 
+    /// Precompile the runtime-resolved-name chunk of each top-level `method`/
+    /// `submethod` declaration in a class or role body (ADR-0019 D3-1), one
+    /// entry per method encountered after `SyntheticBlock` flattening —
+    /// mirroring `run_class_body`/`walk_role_body`'s own flattening exactly,
+    /// so registration can read a chunk by position instead of recompiling
+    /// `name_expr` from raw AST on every registration. A method's fallback
+    /// `name: Symbol` is not a reliable key here (unlike an attribute's
+    /// unique name): an indirect declaration with a non-literal expression
+    /// falls back to a shared placeholder, and ordinary multi methods
+    /// legitimately share a literal name — position is the only key both
+    /// sides can agree on.
+    fn compile_method_name_chunks(
+        &self,
+        body: &[Stmt],
+    ) -> Vec<Option<crate::opcode::CompiledDeclExpr>> {
+        body.iter()
+            .flat_map(|s| match s {
+                Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+                other => vec![other],
+            })
+            .filter_map(|stmt| match stmt {
+                Stmt::MethodDecl { name_expr, .. } => {
+                    Some(name_expr.as_ref().map(|e| self.compile_decl_expr(e)))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Lower a declaration's custom-trait arguments, index-aligned with its
     /// `custom_traits` list.
     fn compile_decl_trait_args(
@@ -88,8 +117,14 @@ impl Compiler {
         let name_chunk = name_expr.as_ref().map(|e| self.compile_decl_expr(e));
         let trait_args = self.compile_decl_trait_args(custom_traits);
         let is_default_chunks = self.compile_attr_is_default_chunks(body);
-        self.code
-            .add_class_decl_plan(stmt, name_chunk, trait_args, is_default_chunks)
+        let method_name_chunks = self.compile_method_name_chunks(body);
+        self.code.add_class_decl_plan(
+            stmt,
+            name_chunk,
+            trait_args,
+            is_default_chunks,
+            method_name_chunks,
+        )
     }
 
     /// Precompile the `is default(...)` trait argument of each of a class
@@ -153,10 +188,17 @@ impl Compiler {
     /// [`Self::add_sub_decl_plan`] for a role declaration. A role's name is
     /// always compile-time known, so only its trait arguments are lowered.
     pub(crate) fn add_role_decl_plan(&mut self, stmt: &Stmt) -> u32 {
-        let Stmt::RoleDecl { custom_traits, .. } = stmt else {
+        let Stmt::RoleDecl {
+            custom_traits,
+            body,
+            ..
+        } = stmt
+        else {
             panic!("add_role_decl_plan expects RoleDecl");
         };
         let trait_args = self.compile_decl_trait_args(custom_traits);
-        self.code.add_role_decl_plan(stmt, trait_args)
+        let method_name_chunks = self.compile_method_name_chunks(body);
+        self.code
+            .add_role_decl_plan(stmt, trait_args, method_name_chunks)
     }
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2430,6 +2430,13 @@ pub(crate) struct CompiledClassDeclPlan {
     /// it is currently visiting instead of relying on the registration-time
     /// walk visiting attributes in the same order this was built in.
     pub(crate) is_default_chunks: Vec<(Symbol, DeclTraitArg)>,
+    /// Precompiled runtime-resolved-name chunk for each top-level `method`/
+    /// `submethod` declaration in the body (ADR-0019 D3-1), one entry per
+    /// method in the order `run_class_body`'s `SyntheticBlock`-flattened walk
+    /// encounters them (`None` for a method with no computed name). Read by
+    /// position, not by name: an indirect `method ::($name) {...}` name has
+    /// no guaranteed-unique fallback name to key on the way attributes do.
+    pub(crate) method_name_chunks: Vec<Option<CompiledDeclExpr>>,
 }
 
 #[derive(Debug, Clone)]
@@ -2454,6 +2461,10 @@ pub(crate) struct CompiledRoleDeclPlan {
     /// Types the body declares itself (`my enum`, `my class`, ...)
     /// (ADR-0019 D2a), precomputed alongside `own_attribute_names`.
     pub(crate) body_declared_types: Vec<String>,
+    /// Precompiled runtime-resolved-name chunk for each top-level `method`/
+    /// `submethod` declaration in the body (ADR-0019 D3-1). See
+    /// `CompiledClassDeclPlan::method_name_chunks`.
+    pub(crate) method_name_chunks: Vec<Option<CompiledDeclExpr>>,
 }
 
 /// A package-level `proto sub`/`proto rule`/`proto token` declaration lowered
@@ -5626,6 +5637,7 @@ impl CompiledCode {
         name_chunk: Option<CompiledDeclExpr>,
         trait_args: Vec<Option<DeclTraitArg>>,
         is_default_chunks: Vec<(Symbol, DeclTraitArg)>,
+        method_name_chunks: Vec<Option<CompiledDeclExpr>>,
     ) -> u32 {
         let Stmt::ClassDecl {
             name,
@@ -5676,6 +5688,7 @@ impl CompiledCode {
             trusts,
             own_attribute_names,
             is_default_chunks,
+            method_name_chunks,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Class(plan_idx));
@@ -5686,6 +5699,7 @@ impl CompiledCode {
         &mut self,
         stmt: &Stmt,
         trait_args: Vec<Option<DeclTraitArg>>,
+        method_name_chunks: Vec<Option<CompiledDeclExpr>>,
     ) -> u32 {
         let Stmt::RoleDecl {
             name,
@@ -5716,6 +5730,7 @@ impl CompiledCode {
             own_attribute_names,
             body_used_modules,
             body_declared_types,
+            method_name_chunks,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Role(plan_idx));

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -206,6 +206,12 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// registration paths with no compiled plan available (role bodies,
     /// `augment class`) — those keep evaluating the raw AST expression.
     pub(crate) attr_is_default_chunks: &'a [(Symbol, crate::opcode::DeclTraitArg)],
+    /// Precompiled runtime-resolved-name chunk for each top-level `method`/
+    /// `submethod` declaration in the body (ADR-0019 D3-1), read by position
+    /// in `class_body_method_decl` via `ClassBodyCx`. Empty for registration
+    /// paths with no compiled plan available (`augment class`, and the
+    /// role-pun/mixin synthesis paths that call this with an empty body).
+    pub(crate) method_name_chunks: &'a [Option<crate::opcode::CompiledDeclExpr>],
 }
 
 pub(super) fn parse_role_type_args(input: &str) -> Vec<String> {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -743,6 +743,7 @@ impl Interpreter {
             trusts: &[],
             own_attribute_names: &[],
             attr_is_default_chunks: &[],
+            method_name_chunks: &[],
         };
         self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
         self.store_language_revision_from_version(&pun_name, &language_version);

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -27,6 +27,13 @@ pub(super) struct ClassBodyCx<'a> {
     /// attributes (ADR-0019 D2c), keyed by attribute name; see
     /// `class_body_has_decl`.
     pub(super) is_default_chunks: &'a [(Symbol, crate::opcode::DeclTraitArg)],
+    /// Precompiled runtime-resolved-name chunk for each top-level `method`/
+    /// `submethod` declaration in the body (ADR-0019 D3-1), read by position
+    /// via `method_name_chunk_idx`; see `class_body_method_decl`.
+    pub(super) method_name_chunks: &'a [Option<crate::opcode::CompiledDeclExpr>],
+    /// Cursor into `method_name_chunks`, advanced by one on every method
+    /// statement `class_body_method_decl` processes.
+    pub(super) method_name_chunk_idx: usize,
 }
 
 impl ClassBodyCx<'_> {
@@ -85,6 +92,7 @@ impl Interpreter {
         class_lang_rev: &str,
         own_attribute_names: &[Symbol],
         is_default_chunks: &[(Symbol, crate::opcode::DeclTraitArg)],
+        method_name_chunks: &[Option<crate::opcode::CompiledDeclExpr>],
     ) -> Result<ClassDef, RuntimeError> {
         let saved_package = self.current_package();
         let saved_env = self.env.clone();
@@ -127,6 +135,8 @@ impl Interpreter {
             class_def,
             class_own_attrs,
             is_default_chunks,
+            method_name_chunks,
+            method_name_chunk_idx: 0,
         };
         let saved_functions_keys: HashSet<String> = self
             .registry()

--- a/src/runtime/registration_class_body_method.rs
+++ b/src/runtime/registration_class_body_method.rs
@@ -63,9 +63,20 @@ impl Interpreter {
                 }
             }
         }
-        let resolved_method_name = if let Some(expr) = name_expr {
-            self.eval_block_value(&[Stmt::Expr(expr.clone())])?
-                .to_string_value()
+        // ADR-0019 D3-1: the chunk at this cursor position was compiled from
+        // this exact statement's `name_expr` at plan-lowering time — the
+        // compiler and this walk both flatten `SyntheticBlock` the same way,
+        // so position, not name, is the shared key (see
+        // `Compiler::compile_method_name_chunks`).
+        let chunk_idx = cx.method_name_chunk_idx;
+        cx.method_name_chunk_idx += 1;
+        let resolved_method_name = if name_expr.is_some() {
+            let chunk = cx
+                .method_name_chunks
+                .get(chunk_idx)
+                .and_then(|c| c.as_ref())
+                .expect("method_name_chunks misaligned with class body walk");
+            self.run_decl_expr(chunk)?.to_string_value()
         } else {
             method_name.resolve()
         };

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -127,6 +127,7 @@ impl Interpreter {
             trusts,
             own_attribute_names,
             attr_is_default_chunks,
+            method_name_chunks,
         } = modifiers;
         let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
@@ -225,6 +226,7 @@ impl Interpreter {
             &class_lang_rev,
             own_attribute_names,
             attr_is_default_chunks,
+            method_name_chunks,
         )?;
         self.finalize_class_registration(name, parents, class_def, &snapshot)?;
         self.install_class_exporthow(name, parents)?;

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -273,6 +273,7 @@ impl Interpreter {
         own_attribute_names: &[Symbol],
         body_used_modules: &[String],
         body_declared_types: &[String],
+        method_name_chunks: &[Option<crate::opcode::CompiledDeclExpr>],
     ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
 
@@ -323,6 +324,8 @@ impl Interpreter {
             role_own_attrs: own_attribute_names.iter().map(|s| s.resolve()).collect(),
             body_used_modules: body_used_modules.iter().cloned().collect(),
             body_declared_types: body_declared_types.iter().cloned().collect(),
+            method_name_chunks,
+            method_name_chunk_idx: 0,
         };
         self.walk_role_body(body, &mut cx)?;
         self.finish_role_registration(

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -22,6 +22,13 @@ pub(super) struct RoleDeclCx<'a> {
     pub(super) body_used_modules: HashSet<String>,
     /// Types declared inside the role body itself (pre-scan pass).
     pub(super) body_declared_types: HashSet<String>,
+    /// Precompiled runtime-resolved-name chunk for each top-level `method`/
+    /// `submethod` declaration in the body (ADR-0019 D3-1), read by position
+    /// via `method_name_chunk_idx`; see `role_body_method_decl`.
+    pub(super) method_name_chunks: &'a [Option<crate::opcode::CompiledDeclExpr>],
+    /// Cursor into `method_name_chunks`, advanced by one on every method
+    /// statement `role_body_method_decl` processes.
+    pub(super) method_name_chunk_idx: usize,
 }
 
 impl RoleDeclCx<'_> {

--- a/src/runtime/registration_role_method.rs
+++ b/src/runtime/registration_role_method.rs
@@ -185,9 +185,18 @@ impl Interpreter {
                 "Unimplemented multi method from role",
             ));
         }
-        let resolved_method_name = if let Some(expr) = name_expr {
-            self.eval_block_value(&[Stmt::Expr(expr.clone())])?
-                .to_string_value()
+        // ADR-0019 D3-1: see `class_body_method_decl`'s identical comment —
+        // the compiler and this walk flatten `SyntheticBlock` identically, so
+        // the chunk at this cursor position matches this statement.
+        let chunk_idx = cx.method_name_chunk_idx;
+        cx.method_name_chunk_idx += 1;
+        let resolved_method_name = if name_expr.is_some() {
+            let chunk = cx
+                .method_name_chunks
+                .get(chunk_idx)
+                .and_then(|c| c.as_ref())
+                .expect("method_name_chunks misaligned with role body walk");
+            self.run_decl_expr(chunk)?.to_string_value()
         } else {
             method_name.resolve()
         };

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -66,6 +66,7 @@ impl Interpreter {
             trusts: &[],
             own_attribute_names: &[],
             attr_is_default_chunks: &[],
+            method_name_chunks: &[],
         };
         self.register_class_decl(&name, &parents, modifiers, &[])?;
         self.compose_mixin_role_submethods(&name, &fresh);

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -139,6 +139,7 @@ impl Interpreter {
             trusts,
             own_attribute_names,
             is_default_chunks,
+            method_name_chunks,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {
@@ -252,6 +253,7 @@ impl Interpreter {
                         trusts,
                         own_attribute_names,
                         attr_is_default_chunks: is_default_chunks,
+                        method_name_chunks,
                     },
                     body,
                 )
@@ -602,6 +604,7 @@ impl Interpreter {
             own_attribute_names,
             body_used_modules,
             body_declared_types,
+            method_name_chunks,
         }) = code.role_decl_plans.get(idx as usize)
         {
             let name_str = name.resolve();
@@ -631,6 +634,7 @@ impl Interpreter {
                     own_attribute_names,
                     body_used_modules,
                     body_declared_types,
+                    method_name_chunks,
                 )
             )?;
             // Link `is Parent` references on this role to the lexical class visible

--- a/t/indirect-declarator-names.t
+++ b/t/indirect-declarator-names.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 5;
+plan 7;
 
 my constant cname = 'LocalIndirectClass';
 class ::(cname) {
@@ -19,3 +19,28 @@ class M {
 is M."sp ace"(), 23, 'method ::(\"...\") allows method names with spaces';
 
 ok ::('&say') =:= &say, '::(\"&foo\") resolves code objects via indirect lookup';
+
+class MultiIndirect {
+    my constant mname1 = 'second';
+    my constant mname2 = 'fourth';
+    method first() { 1 }
+    method ::(mname1) { 2 }
+    method third() { 3 }
+    method ::(mname2) { 4 }
+}
+is-deeply
+    (MultiIndirect.first, MultiIndirect.second, MultiIndirect.third, MultiIndirect.fourth),
+    (1, 2, 3, 4),
+    'multiple ::(...) methods interleaved with ordinary methods resolve correctly';
+
+role RIndirect {
+    my constant rname = 'rsecond';
+    method rfirst() { 'a' }
+    method ::(rname) { 'b' }
+    method rthird() { 'c' }
+}
+class UsesRIndirect does RIndirect { }
+is-deeply
+    (UsesRIndirect.rfirst, UsesRIndirect.rsecond, UsesRIndirect.rthird),
+    ('a', 'b', 'c'),
+    'role ::(...) methods interleaved with ordinary methods resolve correctly';


### PR DESCRIPTION
## Summary

- ADR-0019 D3-1: precompile a `method ::($name) {...}` computed method name into a `CompiledDeclExpr` chunk at plan-lowering time, the same way `SubDecl`/`ClassDecl` already do for their own computed names (C5) and attribute `is default(...)` traits (D2c-1).
- `CompiledClassDeclPlan`/`CompiledRoleDeclPlan` gain `method_name_chunks: Vec<Option<CompiledDeclExpr>>`, one entry per top-level `method`/`submethod` statement (after the same `SyntheticBlock` flattening the runtime walkers already perform). `class_body_method_decl`/`role_body_method_decl` read the chunk at that statement's position via a cursor on `ClassBodyCx`/`RoleDeclCx`, instead of recompiling `name_expr` from a cloned AST node on every registration.
- Position, not name, is the shared key: unlike D2c-1's attribute chunks (keyed by the attribute's own unique name), a method's fallback `name: Symbol` is unreliable — an indirect declaration with a non-literal expression falls back to a shared placeholder, and `multi` methods legitimately share a literal name.
- `augment_class`'s `MethodDecl` arm is deliberately left unmigrated: `augment class` has no declaration plan yet (`Stmt::AugmentClass` still indexes `stmt_pool` via the legacy `AugmentClass(u32)` opcode) — giving it a chunk means building that plan machinery from scratch, out of scope for this slice.

See `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (D3 box) and `news/2026-08/d3-1-method-name-chunks.md` for details.

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` clean
- [x] Extended `t/indirect-declarator-names.t` with a multi-method class and a role, each interleaving ordinary and `method ::(...)` declarations, to exercise the cursor with more than one indirect name per body. Verified identical output against `raku`.
- [x] `make test` — 27810 tests, all green
- [x] All whitelisted `roast/S12-methods/*.t` and `roast/S14-roles/*.t` (48 files) individually green