### PR TITLE
refactor(runtime): typed CompiledMethodDecl for role-body method walk (ADR-0019 D3-3)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -629,6 +629,15 @@ walkers wholesale is not possible before then.
   `augment_class` `is_lexical_only` gap and privacy-aware duplicate detection in particular); that
   requires the other two walkers to also build from `CompiledMethodDecl::from_stmt` so the drift
   becomes visible and fixable at one shared construction site, matching D2b's own precedent.
+  **D3-3 landed 2026-08-07** (role walker): `role_body_method_decl` now also builds one `decl =
+  CompiledMethodDecl::from_stmt(stmt)` and reads every field off it, the same conversion D3-2 did
+  for the class walker. Same verification (`t/` suite, same 90-file roast set). This walk never read
+  `is_our`/`our_variable_form`/`custom_traits`/`is_export`/`export_tags` before (a role method is
+  never `our`-registered as a package sub, and custom traits/exports on a role method go unhandled
+  here) — that omission is unchanged, now expressed as unread `CompiledMethodDecl` fields rather
+  than `_`-ignored destructure bindings. `augment_class`'s `MethodDecl` arm (D3-4) is the last of the
+  three; only once it also builds from `CompiledMethodDecl::from_stmt` does the drift between all
+  three become fixable at one shared site.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
   expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
   names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies

--- a/news/2026-08/d3-3-compiled-method-decl-role-walker.md
+++ b/news/2026-08/d3-3-compiled-method-decl-role-walker.md
@@ -1,0 +1,25 @@
+# ADR-0019 D3-3: `CompiledMethodDecl` for the role walker
+
+Continuing D3-2 (the class-body `method` arm's conversion to the shared
+`CompiledMethodDecl` typed mirror), `role_body_method_decl` now also builds
+one `decl = CompiledMethodDecl::from_stmt(stmt)` at its top and reads every
+field off it instead of the original 19-binding `Stmt::MethodDecl`
+destructure — the same pure mechanical conversion, no behavior change.
+
+This walk never read `is_our`, `our_variable_form`, `custom_traits`,
+`is_export`, or `export_tags` (a role method is never `our`-registered as a
+package sub, and custom traits/exports on a role method go unhandled at this
+site) — that gap is unchanged by this slice, now expressed as unread
+`CompiledMethodDecl` fields rather than `_`-ignored destructure bindings.
+
+Verified the same way as D3-2: the full `t/` suite (27810 tests) plus every
+whitelisted `S12-methods`, `S14-roles`, `S12-attributes`, `S12-class`, and
+`S12-construction` roast file (90 files), all green.
+
+`augment_class`'s `MethodDecl` arm (D3-4) is the last of the three walkers.
+Only once it also builds from `CompiledMethodDecl::from_stmt` does the drift
+ADR-0019's D3 scoping pass found between all three — most notably
+`augment_class` missing the class/role walkers' `is_lexical_only`/
+`is_our_only` gating and privacy-aware duplicate detection — become fixable
+at one shared construction site, the way D2b's `CompiledAttrDecl` unification
+fixed its own four-way drift by construction.

--- a/src/runtime/registration_role_method.rs
+++ b/src/runtime/registration_role_method.rs
@@ -6,6 +6,7 @@ use super::registration_class::make_delegation_method;
 use super::registration_role_decl::RoleDeclCx;
 use super::*;
 use crate::ast::HandleSpec;
+use crate::opcode::CompiledMethodDecl;
 
 impl Interpreter {
     /// The `method` arm of the role-body walk: validate the declaration and
@@ -15,34 +16,17 @@ impl Interpreter {
         cx: &mut RoleDeclCx<'_>,
         stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
-        let Stmt::MethodDecl {
-            name: method_name,
-            name_expr,
-            params: _,
-            param_defs,
-            body: method_body,
-            multi,
-            is_rw,
-            is_private,
-            is_our: _,
-            is_my,
-            is_submethod,
-            our_variable_form: _,
-            return_type,
-            is_default_candidate,
-            deprecated_message,
-            handles: method_handles,
-            custom_traits: _,
-            is_export: _,
-            export_tags: _,
-        } = stmt
-        else {
-            unreachable!("role_body_method_decl called on a non-MethodDecl statement");
-        };
+        // ADR-0019 D3-3: shared typed mirror of `Stmt::MethodDecl` (see
+        // `CompiledMethodDecl`, D3-2). This walk does not read
+        // `is_our`/`our_variable_form`/`custom_traits`/`is_export`/
+        // `export_tags` — a role method is never `our`-registered as a
+        // package sub and custom traits/exports on a role method are not
+        // handled here, matching the walk's original ignored bindings.
+        let decl = CompiledMethodDecl::from_stmt(stmt);
         let name = cx.name;
         // Validate that $!attr references in the method body are declared
         // in this role (same check as for class methods).
-        Self::validate_attr_declared_in_class(&cx.attr_ctx(), method_body)?;
+        Self::validate_attr_declared_in_class(&cx.attr_ctx(), &decl.body)?;
         // Validate that type constraints in method parameters are resolvable.
         // Undeclared types like A::C should throw X::Parameter::InvalidType.
         // A role nested in an enclosing package (e.g. `unit class A`)
@@ -80,7 +64,7 @@ impl Interpreter {
                 }
             }
         }
-        for pd in param_defs {
+        for pd in &decl.param_defs {
             if let Some(tc) = pd.type_constraint.as_deref() {
                 // Skip type captures (::T), invocant markers, and role type params
                 if tc.starts_with("::")
@@ -158,7 +142,8 @@ impl Interpreter {
         // must be implemented by the composing class.
         // Non-stub multi methods with ::?CLASS are fine.
         let body_is_stub = {
-            let filtered: Vec<_> = method_body
+            let filtered: Vec<_> = decl
+                .body
                 .iter()
                 .filter(|s| !matches!(s, Stmt::SetLine(_)))
                 .collect();
@@ -170,13 +155,14 @@ impl Interpreter {
                             || name == "__mutsu_stub_warn"
                 )
         };
-        if *multi
+        if decl.multi
             && body_is_stub
-            && (param_defs.iter().any(|pd| {
+            && (decl.param_defs.iter().any(|pd| {
                 pd.type_constraint
                     .as_deref()
                     .is_some_and(|tc| tc.contains("?CLASS"))
-            }) || return_type
+            }) || decl
+                .return_type
                 .as_deref()
                 .is_some_and(|rt| rt.contains("?CLASS")))
         {
@@ -190,7 +176,7 @@ impl Interpreter {
         // the chunk at this cursor position matches this statement.
         let chunk_idx = cx.method_name_chunk_idx;
         cx.method_name_chunk_idx += 1;
-        let resolved_method_name = if name_expr.is_some() {
+        let resolved_method_name = if decl.name_expr.is_some() {
             let chunk = cx
                 .method_name_chunks
                 .get(chunk_idx)
@@ -198,7 +184,7 @@ impl Interpreter {
                 .expect("method_name_chunks misaligned with role body walk");
             self.run_decl_expr(chunk)?.to_string_value()
         } else {
-            method_name.resolve()
+            decl.name.resolve()
         };
         // A method always carries an implicit `*%_` slurpy so callers
         // can pass (or forward) named arguments the signature does not
@@ -206,7 +192,7 @@ impl Interpreter {
         // at registration; role methods must too, so a role-composed
         // method absorbs stray named args the same way a class-declared
         // one does.
-        let effective_param_defs = Self::effective_method_param_defs(param_defs, false);
+        let effective_param_defs = Self::effective_method_param_defs(&decl.param_defs, false);
         let effective_params: Vec<String> = effective_param_defs
             .iter()
             .map(|p| p.name.clone())
@@ -215,28 +201,28 @@ impl Interpreter {
             lexical_package: self.current_package(),
             params: effective_params,
             param_defs: effective_param_defs,
-            body: std::sync::Arc::new(method_body.clone()),
-            is_rw: *is_rw,
-            is_private: *is_private,
-            is_multi: *multi,
-            is_my: *is_submethod,
+            body: std::sync::Arc::new(decl.body.clone()),
+            is_rw: decl.is_rw,
+            is_private: decl.is_private,
+            is_multi: decl.multi,
+            is_my: decl.is_submethod,
             role_origin: None,
             original_role: None,
-            return_type: return_type.clone(),
+            return_type: decl.return_type.clone(),
             compiled_code: None,
             compiled_fns: None,
             delegation: None,
-            is_default: *is_default_candidate,
-            deprecated_message: deprecated_message.clone(),
-            is_submethod: *is_submethod,
+            is_default: decl.is_default_candidate,
+            deprecated_message: decl.deprecated_message.clone(),
+            is_submethod: decl.is_submethod,
             captured_env: None,
         };
         // `my method` in roles are role-private, skip method table.
         // Submethods (is_submethod) DO get composed even though
         // is_my is true.
-        let is_role_private = *is_my && !*is_submethod;
+        let is_role_private = decl.is_my && !decl.is_submethod;
         if !is_role_private {
-            if *multi {
+            if decl.multi {
                 cx.role_def
                     .methods
                     .entry(resolved_method_name.clone())
@@ -259,9 +245,9 @@ impl Interpreter {
             }
         }
         // `handles` on a role method: synthesize forwarder methods.
-        if !is_role_private && !method_handles.is_empty() {
+        if !is_role_private && !decl.handles.is_empty() {
             let source_attr_marker = format!("&{}", resolved_method_name);
-            for spec in method_handles {
+            for spec in &decl.handles {
                 match spec {
                     HandleSpec::Name(target) => {
                         cx.role_def


### PR DESCRIPTION
## Summary

- ADR-0019 D3-3: continuing D3-2, `role_body_method_decl` now also builds one `decl = CompiledMethodDecl::from_stmt(stmt)` and reads every field off it instead of the original 19-binding `Stmt::MethodDecl` destructure — the same pure mechanical conversion, no behavior change.
- This walk never read `is_our`/`our_variable_form`/`custom_traits`/`is_export`/`export_tags` (a role method is never `our`-registered as a package sub, and custom traits/exports on a role method go unhandled here) — that gap is unchanged, now expressed as unread `CompiledMethodDecl` fields rather than `_`-ignored destructure bindings.
- `augment_class`'s `MethodDecl` arm (D3-4) is the last of the three walkers. Only once it also builds from `CompiledMethodDecl::from_stmt` does the drift ADR-0019's D3 scoping pass found between all three (most notably `augment_class` missing the `is_lexical_only`/`is_our_only` gating and privacy-aware duplicate detection) become fixable at one shared construction site.

See `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (D3 box) and `news/2026-08/d3-3-compiled-method-decl-role-walker.md`.

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` clean
- [x] `make test` — 27810 tests, all green
- [x] All whitelisted `roast/S12-methods`, `S14-roles`, `S12-attributes`, `S12-class`, `S12-construction` files (90 total) individually green