### PR TITLE
refactor(runtime): typed CompiledMethodDecl for augment method walk (ADR-0019 D3-4)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -638,6 +638,21 @@ walkers wholesale is not possible before then.
   than `_`-ignored destructure bindings. `augment_class`'s `MethodDecl` arm (D3-4) is the last of the
   three; only once it also builds from `CompiledMethodDecl::from_stmt` does the drift between all
   three become fixable at one shared site.
+  **D3-4 landed 2026-08-08** (augment walker, the last of the three): `augment_class`'s `MethodDecl`
+  arm also builds a `decl` and reads every field off it. `name_expr` is still evaluated from the raw
+  AST here (`self.eval_block_value(&[Stmt::Expr(expr.clone())])`), unlike the class/role walkers'
+  D3-1 chunk-cursor lookup — `augment class` has no compiled declaration plan at all
+  (`Stmt::AugmentClass` still indexes `stmt_pool`), so there is no `method_name_chunks` to read from.
+  This slice preserves, rather than fixes, every drift point the D3 scoping pass found:
+  `MethodDef.is_my` is still set from the raw `is_my` flag here (the class/role walkers use
+  `is_submethod`), duplicate-method detection is still not privacy-aware
+  (`all_from_role` only, no `is_private` comparison), and `is_lexical_only`/`is_our_only` gating,
+  `handles` forwarders, custom-trait/`is_export` handling, and BUILD/TWEAK `:$!attr` validation
+  remain absent from this walker — now visible as unused `CompiledMethodDecl` fields at this call
+  site rather than as absent destructure bindings, which is what makes the drift fixable at all: with
+  all three walkers sharing one typed constructor, D3-5 can compare and reconcile the still-open
+  fields directly instead of re-deriving each walker's field set from its own AST match arm the way
+  the original 2026-08-07 scoping pass had to.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
   expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
   names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies

--- a/news/2026-08/d3-4-compiled-method-decl-augment-walker.md
+++ b/news/2026-08/d3-4-compiled-method-decl-augment-walker.md
@@ -1,0 +1,40 @@
+# ADR-0019 D3-4: `CompiledMethodDecl` for the augment walker
+
+Completing the D3-2/D3-3 conversion, `augment_class`'s `MethodDecl` arm now
+also builds one `decl = CompiledMethodDecl::from_stmt(stmt)` and reads every
+field off it instead of the original partial `Stmt::MethodDecl { .. }`
+destructure — the last of the three `method`/`submethod`-registration
+walkers ADR-0019's D3 scoping pass identified.
+
+`name_expr` is still evaluated from the raw AST here
+(`self.eval_block_value(&[Stmt::Expr(expr.clone())])`), unlike the class and
+role walkers' D3-1 chunk-cursor lookup: `augment class` has no compiled
+declaration plan at all (`Stmt::AugmentClass` still indexes `stmt_pool` via
+the legacy `AugmentClass(u32)` opcode), so there is no `method_name_chunks`
+vector to read from. Giving it one is separate, larger scope.
+
+This slice deliberately preserves, rather than fixes, every drift point the
+D3 scoping pass found in `augment_class`: `MethodDef.is_my` is still set
+from the raw `is_my` flag (the class/role walkers use `is_submethod`
+instead, since `my`/`our method` are filtered out of `class_def.methods`
+before insertion at those two sites but not here); duplicate-method
+detection is still not privacy-aware (`all_from_role` only, no `is_private`
+comparison); and `is_lexical_only`/`is_our_only` gating, `handles`
+forwarders, custom-trait/`is_export` handling, and BUILD/TWEAK `:$!attr`
+validation remain entirely absent from this walker.
+
+The point of landing this conversion without also fixing the drift: with
+all three walkers now sharing one `CompiledMethodDecl::from_stmt`
+construction site, the remaining differences are visible as unused struct
+fields at this call site rather than as absent bindings in an independently
+hand-written destructure pattern — which is what makes a future D3-5 able to
+compare and reconcile them directly, the way D2b's `CompiledAttrDecl`
+unification fixed its own four-way `Stmt::HasDecl` drift by construction.
+
+Verified the same way as D3-2/D3-3: the full `t/` suite (27810 tests) plus
+95 whitelisted roast files covering `S12-methods`, `S14-roles`,
+`S12-attributes`, `S12-class`, `S12-construction`, and every file this
+repository's own grep found referencing `augment class`/`augment role`
+(`S10-packages/use-with-class.t`, `S32-exceptions/misc2.t`,
+`integration/rule-in-class-Str.t`, `integration/advent2009-day22.t`,
+`S12-enums/thorough.t`), all green.

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -163,32 +163,26 @@ impl Interpreter {
             .collect();
         for stmt in flattened_body {
             match stmt {
-                Stmt::MethodDecl {
-                    name: method_name,
-                    name_expr,
-                    param_defs,
-                    body: method_body,
-                    multi,
-                    is_rw,
-                    is_private,
-                    is_my,
-                    is_submethod,
-                    return_type,
-                    is_default_candidate,
-                    deprecated_message,
-                    ..
-                } => {
-                    let resolved_method_name = if let Some(expr) = name_expr {
+                Stmt::MethodDecl { .. } => {
+                    // ADR-0019 D3-4: shared typed mirror of `Stmt::MethodDecl`
+                    // (see `CompiledMethodDecl`, D3-2/D3-3). Unlike the class
+                    // and role walkers, `augment_class` has no compiled
+                    // declaration plan (`Stmt::AugmentClass` still indexes
+                    // `stmt_pool`), so a computed `name_expr` is still
+                    // evaluated from the raw AST here rather than through a
+                    // precompiled `method_name_chunks` cursor.
+                    let decl = crate::opcode::CompiledMethodDecl::from_stmt(stmt);
+                    let resolved_method_name = if let Some(expr) = &decl.name_expr {
                         self.eval_block_value(&[Stmt::Expr(expr.clone())])?
                             .to_string_value()
                     } else {
-                        method_name.resolve()
+                        decl.name.resolve()
                     };
                     let mut effective_param_defs =
-                        Self::effective_method_param_defs(param_defs, false);
+                        Self::effective_method_param_defs(&decl.param_defs, false);
                     // Auto-detect @_ usage in methods without explicit signatures
-                    if param_defs.is_empty() {
-                        let (use_positional, _) = Self::auto_signature_uses(method_body);
+                    if decl.param_defs.is_empty() {
+                        let (use_positional, _) = Self::auto_signature_uses(&decl.body);
                         if use_positional && !effective_param_defs.iter().any(|pd| pd.name == "@_")
                         {
                             let insert_pos = effective_param_defs
@@ -230,24 +224,29 @@ impl Interpreter {
                         lexical_package: self.current_package(),
                         params: effective_params,
                         param_defs: effective_param_defs,
-                        body: std::sync::Arc::new(method_body.clone()),
-                        is_rw: *is_rw,
-                        is_private: *is_private,
-                        is_multi: *multi,
-                        is_my: *is_my,
+                        body: std::sync::Arc::new(decl.body.clone()),
+                        is_rw: decl.is_rw,
+                        is_private: decl.is_private,
+                        is_multi: decl.multi,
+                        // Unlike the class/role walkers (which store
+                        // `is_submethod` here for inheritance filtering),
+                        // this stores the raw `is_my` flag — a pre-existing
+                        // drift documented in the ADR-0019 D3 scoping pass,
+                        // not fixed by this slice.
+                        is_my: decl.is_my,
                         role_origin: None,
                         original_role: None,
-                        return_type: return_type.clone(),
+                        return_type: decl.return_type.clone(),
                         compiled_code: None,
                         compiled_fns: None,
                         delegation: None,
-                        is_default: *is_default_candidate,
-                        deprecated_message: deprecated_message.clone(),
-                        is_submethod: *is_submethod,
+                        is_default: decl.is_default_candidate,
+                        deprecated_message: decl.deprecated_message.clone(),
+                        is_submethod: decl.is_submethod,
                         captured_env: None,
                     };
                     if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
-                        if *multi {
+                        if decl.multi {
                             class_def
                                 .methods
                                 .entry(resolved_method_name)


### PR DESCRIPTION
## Summary

- ADR-0019 D3-4 (last of the three method-registration walkers): `augment_class`'s `MethodDecl` arm now also builds one `decl = CompiledMethodDecl::from_stmt(stmt)` and reads every field off it, completing the D3-2 (class walker)/D3-3 (role walker) conversion.
- `name_expr` is still evaluated from raw AST here (`self.eval_block_value(...)`), unlike the class/role walkers' D3-1 chunk-cursor lookup — `augment class` has no compiled declaration plan at all (`Stmt::AugmentClass` still indexes `stmt_pool`), so there is no `method_name_chunks` to read from.
- This slice deliberately preserves, not fixes, every drift point the D3 scoping pass found in `augment_class`: `MethodDef.is_my` still comes from the raw `is_my` flag (class/role walkers use `is_submethod`), duplicate-method detection is still not privacy-aware, and `is_lexical_only`/`is_our_only` gating, `handles` forwarders, custom-trait/`is_export` handling, and BUILD/TWEAK `:$!attr` validation remain absent from this walker.
- The point of landing this conversion without fixing the drift: with all three walkers now sharing one `CompiledMethodDecl::from_stmt` construction site, the remaining differences are visible as unused struct fields at one call site instead of absent bindings in three independently hand-written destructures — which is what makes a future D3-5 able to reconcile them directly, the way D2b's `CompiledAttrDecl` fixed its own four-way drift by construction.

Note: this branched from `main` before PR #6045 (D3-3) merged, so it may need a rebase against the ADR doc's D3 section once #6045 lands (append-only text in the same location).

See `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (D3 box) and `news/2026-08/d3-4-compiled-method-decl-augment-walker.md`.

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` clean
- [x] `make test` — 27810 tests, all green
- [x] 95 whitelisted roast files (S12-methods, S14-roles, S12-attributes, S12-class, S12-construction, plus every file referencing `augment class`/`augment role`: S10-packages/use-with-class.t, S32-exceptions/misc2.t, integration/rule-in-class-Str.t, integration/advent2009-day22.t, S12-enums/thorough.t) individually green