### PR TITLE
fix(errors): give X::TypeCheck::Binding::Parameter a real Parameter object

### DIFF
--- a/news/2026-08/binding-failures-carry-a-parameter-object.md
+++ b/news/2026-08/binding-failures-carry-a-parameter-object.md
@@ -1,0 +1,51 @@
+# A binding failure now carries a real `Parameter` object
+
+`X::TypeCheck::Binding::Parameter.parameter` stored the parameter's *name* as a
+`Str`. That is enough to render the message, but raku exposes a `Parameter`
+there, and code that recovers from a binding failure introspects it rather than
+reading the text.
+
+`Cro::HTTP::Router` is exactly such code. When no route matches, it re-invokes
+each candidate whose signature rejected the capture and reads the resulting
+exception to choose a status:
+
+```raku
+CATCH {
+    when X::TypeCheck::Binding::Parameter {
+        my $param = .parameter;
+        if $param.named { $status = 400; last }
+        elsif $param ~~ Cro::HTTP::Router::Auth || $param.type ~~ Cro::HTTP::Auth {
+            $status = 401; last
+        }
+    }
+    default {}
+}
+```
+
+Under mutsu `.parameter` answered a `Str`, so `$param.named` died with `No such
+method 'named' for invocant of type 'Str'` inside the router's supply — which
+swallowed the response entirely. A request that should have been answered
+`401 Unauthorized` got **no response at all**: the socket simply produced nothing.
+
+`RuntimeError::with_parameter_object` now stamps the materialized `Parameter`
+onto the exception, and the two constraint/type binding-failure sites in
+`runtime/types/binding_signature.rs` (which already hold the `ParamDef`) use it.
+The `Parameter` is built by the same
+`crate::value::signature::make_parameter_value_from_param_def` that
+`Signature.params` uses, so it is born as whatever mixin type a custom trait on
+the declaration composed — which is how `$param ~~ Cro::HTTP::Router::Auth`
+(from Cro's `is auth` trait) can ever be true.
+
+## Result
+
+Cro's `t/http-middleware.rakutest` is **fully green, 24 of 24 subtests** — the
+first time that file has passed end to end. The last failure was the auth
+scenario: an `Admin`-constrained route reached by a merely logged-in session must
+produce 401, which an `after` middleware then rewrites into a redirect to `/401`.
+
+Pinned by `t/typecheck-binding-parameter-object.t`.
+
+Two named-parameter assertions were left out of that test on purpose: mutsu does
+not check a named parameter's type constraint at all, so no exception is raised
+to introspect. That gap is recorded in
+`todo/tickets/named-parameter-type-constraints-are-not-enforced.md`.

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1742,7 +1742,8 @@ impl Interpreter {
                                         got,
                                         crate::runtime::utils::gist_value(&value)
                                     )),
-                                ));
+                                )
+                                .with_parameter_object(pd));
                             }
                             return Err(RuntimeError::typecheck_binding_parameter(
                                 &display_name,
@@ -1752,7 +1753,8 @@ impl Interpreter {
                                     "{}: Type check failed for {}: expected {}, got {}",
                                     type_error_kind, display_name, resolved_constraint, got
                                 )),
-                            ));
+                            )
+                            .with_parameter_object(pd));
                         } else {
                             value = self
                                 .try_coerce_value_for_constraint(&resolved_constraint, value)

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -577,6 +577,28 @@ impl RuntimeError {
         Self::typed("X::TypeCheck::Binding::Parameter", attrs)
     }
 
+    /// Replace this binding error's `.parameter` with the real `Parameter`
+    /// object raku exposes there.
+    ///
+    /// The plain constructors above store the parameter *name*, which is enough
+    /// for the message but not for introspection: raku's
+    /// `X::TypeCheck::Binding::Parameter.parameter` is a `Parameter`, and code
+    /// that recovers from a binding failure asks it things — `Cro::HTTP::Router`
+    /// answers 400 vs 401 vs 404 from `$param.named` and `$param.type`, and
+    /// matches the parameter against the mixin type its `is auth` trait
+    /// composed, which only a materialized `Parameter` carries.
+    pub(crate) fn with_parameter_object(self, pd: &crate::ast::ParamDef) -> Self {
+        if let Some(ValueView::Instance { attributes, .. }) =
+            self.exception.as_deref().map(Value::view)
+        {
+            attributes.insert(
+                "parameter",
+                crate::value::signature::make_parameter_value_from_param_def(pd),
+            );
+        }
+        self
+    }
+
     /// Like `typecheck_binding_parameter`, but with raku's exact wording
     /// ("expected T but got U (repr)", not "expected T, got U") and `.got`
     /// carrying the actual offending value. Matches the hand-rolled format

--- a/t/typecheck-binding-parameter-object.t
+++ b/t/typecheck-binding-parameter-object.t
@@ -1,0 +1,33 @@
+use Test;
+
+# X::TypeCheck::Binding::Parameter.parameter is a Parameter object, not the
+# parameter's name. Code that recovers from a binding failure introspects it --
+# Cro::HTTP::Router decides 400 vs 401 vs 404 from `.named` and `.type`, and
+# matches the parameter itself against the mixin type an `is auth` trait
+# composed, none of which a bare Str can answer.
+
+plan 7;
+
+class Session { has $.admin }
+subset Admin of Session where *.admin;
+
+# Subset (constraint) failure.
+{
+    my &handler = -> Admin $user, $path { 'secret' };
+    try handler(Session.new(:!admin), 'private');
+    my $e = $!;
+    isa-ok $e, X::TypeCheck::Binding::Parameter, 'subset failure is a binding error';
+    isa-ok $e.parameter, Parameter, '.parameter is a Parameter object';
+    is $e.parameter.name, '$user', '.parameter.name is the sigiled name';
+    nok $e.parameter.named, '.parameter.named is False for a positional';
+}
+
+# Plain type failure.
+{
+    my &handler = -> Int $n { $n };
+    try handler('nope');
+    my $e = $!;
+    isa-ok $e, X::TypeCheck::Binding::Parameter, 'type failure is a binding error';
+    isa-ok $e.parameter, Parameter, '.parameter is a Parameter object';
+    is $e.parameter.name, '$n', '.parameter.name is the sigiled name';
+}

--- a/todo/tickets/named-parameter-type-constraints-are-not-enforced.md
+++ b/todo/tickets/named-parameter-type-constraints-are-not-enforced.md
@@ -1,0 +1,39 @@
+# A named parameter's type constraint is never checked
+
+A type constraint on a **named** parameter is accepted and then ignored, for both
+`sub` and block forms:
+
+```raku
+sub h(Int :$limit) { $limit }
+say h(limit => "nope").raku;      # raku: dies    mutsu: "nope"
+
+my &b = -> Int :$limit { $limit };
+say b(limit => "nope").raku;      # raku: dies    mutsu: "nope"
+```
+
+raku dies with `Type check failed in binding to parameter '$limit'; expected Int
+but got Str ("nope")`. Positional parameters *are* checked, so the gap is
+specific to the named-binding path.
+
+## Why it matters
+
+Beyond the missing error itself, an unchecked named parameter cannot produce the
+`X::TypeCheck::Binding::Parameter` that recovery code keys off. `Cro::HTTP::Router`
+answers **400 Bad Request** for a failed *named* unpack and **401** for a failed
+auth parameter by asking the raised exception's `.parameter.named`
+(`lib/Cro/HTTP/Router.rakumod`, the `@*BIND-FAILS` loop) — with no exception
+raised, the 400 branch is unreachable and such a request falls through to 404.
+The 401 half of that logic works as of
+`news/2026-08/binding-failures-carry-a-parameter-object.md`.
+
+## Where to look
+
+The positional path raises from `runtime/types/binding_signature.rs` (the
+`resolved_constraint` check that produces `Constraint type check failed …` /
+`Type check failed for …`). The named path binds arguments without reaching it.
+A fix should route named binding through the same constraint check *and* attach
+the `Parameter` object via `RuntimeError::with_parameter_object`, so
+`.parameter.named` is True there.
+
+A regression test is ready to extend: `t/typecheck-binding-parameter-object.t`
+had two named-parameter assertions removed for exactly this gap.


### PR DESCRIPTION
## Problem

`X::TypeCheck::Binding::Parameter.parameter` stored the parameter's **name** as a `Str`. Raku exposes a `Parameter` object there, and code that recovers from a binding failure introspects it rather than reading the message text.

`Cro::HTTP::Router` is exactly such code. When no route matches, it re-invokes each candidate whose signature rejected the capture and reads the resulting exception to choose a status:

```raku
CATCH {
    when X::TypeCheck::Binding::Parameter {
        my $param = .parameter;
        if $param.named { $status = 400; last }
        elsif $param ~~ Cro::HTTP::Router::Auth || $param.type ~~ Cro::HTTP::Auth {
            $status = 401; last
        }
    }
    default {}
}
```

Under mutsu this died with `No such method 'named' for invocant of type 'Str'` **inside the router's supply**, which swallowed the response entirely — a request that should have been answered `401 Unauthorized` produced *no response at all* on the socket.

## Fix

`RuntimeError::with_parameter_object` stamps the materialized `Parameter` onto the exception, and the two constraint/type binding-failure sites in `runtime/types/binding_signature.rs` (which already hold the `ParamDef`) use it. The object is built by the same `crate::value::signature::make_parameter_value_from_param_def` that `Signature.params` uses, so it is born as whatever mixin type a custom trait on the declaration composed — which is how `$param ~~ Cro::HTTP::Router::Auth` (from Cro's `is auth` trait) can ever be true.

## Result

Cro's `t/http-middleware.rakutest` is **fully green, 24 of 24 subtests** — the first time that file has passed end to end (it was 23/24 after #6044).

Pinned by `t/typecheck-binding-parameter-object.t` (7 assertions, identical under real `raku`). `make test` green.

Two named-parameter assertions were deliberately left out of that test: mutsu does not check a named parameter's type constraint at all, so there is no exception to introspect. Recorded in `todo/tickets/named-parameter-type-constraints-are-not-enforced.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)