### PR TITLE
fix(class): let `is List` subclasses take a positional new

### DIFF
--- a/news/2026-08/is-list-subclass-takes-positional-new.md
+++ b/news/2026-08/is-list-subclass-takes-positional-new.md
@@ -1,0 +1,36 @@
+# `class C is List { }` takes a positional `.new`
+
+`class C is Array { }` inherited `Array.new`'s positional constructor and
+answered positional methods from the instance's backing
+`__mutsu_array_storage`. `class C is List { }` did neither — it fell through to
+`Mu.new` and died:
+
+```raku
+class MyList is List { }
+MyList.new('a', 'b');   # Default constructor for 'MyList' only takes named arguments
+```
+
+Every gate that recognised the backing store tested the MRO for `Array` alone.
+They now go through `Interpreter::is_positional_base`, which accepts `Array` and
+`List`: construction seeds the storage from the positional arguments, and
+`.elems` / `.join` / `AT-POS` / iteration delegate to it.
+
+The two bases keep their different mutability. A fresh instance's storage kind is
+chosen by `positional_base_storage`: an `Array` subclass gets a real `Array`, a
+`List` subclass an immutable `List`, so `.push` on the latter still raises
+`X::Immutable` exactly as raku does.
+
+## Result
+
+`Cro::HTTP::MultiValue is List does Stringy` — the type Cro uses whenever a query
+string or a form body repeats a key — is constructible and stringifies
+correctly. In `t/http-request-parser.rakutest` the "Query strings with multiple
+values for the same key" and "Multiple entries with same name in
+application/x-www-form-urlencoded" cases now pass.
+
+The remaining multi-value assertion (`%hash<a>[*]`) is blocked on a separate
+gap — a whatever-slice reads nothing from *any* storage-backed instance,
+including an `is Array` one — recorded in
+`todo/tickets/whatever-slice-on-a-storage-backed-instance-gives-nil.md`.
+
+Pinned by `t/is-list-subclass.t`.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -368,6 +368,31 @@ impl Interpreter {
     /// its captured-outer lexicals from the live caller env (which every sibling
     /// callback in the same react block writes back to) instead of restoring a
     /// stale per-instance snapshot that would clobber a sibling's update.
+    /// True for the two builtin bases whose subclasses keep their elements in
+    /// the instance's `__mutsu_array_storage` and delegate positional methods
+    /// to it: `Array` and `List`.
+    ///
+    /// `class C is List { }` needs the same treatment as `class C is Array { }`
+    /// — `List.new` takes its elements positionally and the instance answers
+    /// `.elems`/`.join`/`.list`/`AT-POS` from them. Cro's
+    /// `Cro::HTTP::MultiValue is List does Stringy` is built exactly that way,
+    /// so without this a query string or form body with a repeated key could
+    /// not be represented at all.
+    pub(crate) fn is_positional_base(name: &str) -> bool {
+        name == "Array" || name == "List"
+    }
+
+    /// The backing store a fresh `is Array`/`is List` subclass instance gets.
+    /// A `List` subclass must be backed by an immutable `List`, not an `Array`,
+    /// so `.push` on one still raises `X::Immutable` as raku does.
+    pub(crate) fn positional_base_storage(&mut self, class_key: &str, items: Vec<Value>) -> Value {
+        if self.class_mro(class_key).iter().any(|n| n == "Array") {
+            Value::real_array(items)
+        } else {
+            Value::array(items)
+        }
+    }
+
     pub(crate) fn clear_closure_captured_state_for(&mut self, id: u64) {
         self.closure_captured_state
             .retain(|(entry_id, _), _| *entry_id != id);

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -484,14 +484,19 @@ impl Interpreter {
         // storage (which `Array` methods on the instance delegate to). Only
         // touch the storage when there are positional args, so a plain
         // named-args `bless` keeps the empty storage seeded by `dispatch_new`.
-        if self.class_mro(cn_resolved).iter().any(|n| n == "Array") {
+        if self
+            .class_mro(cn_resolved)
+            .iter()
+            .any(|n| *n == "Array" || *n == "List")
+        {
             let elems: Vec<Value> = args
                 .iter()
                 .filter(|a| !a.is_string_pair_value())
                 .cloned()
                 .collect();
             if !elems.is_empty() || !attributes.contains_key("__mutsu_array_storage") {
-                attributes.insert("__mutsu_array_storage", Value::real_array(elems));
+                let storage = self.positional_base_storage(cn_resolved, elems);
+                attributes.insert("__mutsu_array_storage", storage);
             }
         }
         // Embed `is default(...)` element defaults into `@`/`%` containers.

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1790,9 +1790,9 @@ impl Interpreter {
                     if self.class_does_baggy_or_setty(&cn) {
                         return self.construct_baggy_instance(&cn, &args);
                     }
-                    let accepts_positional = class_mro
-                        .iter()
-                        .any(|n| n == "Array" || n == "Int" || n == "Num" || n == "Hash");
+                    let accepts_positional = class_mro.iter().any(|n| {
+                        *n == "Array" || *n == "List" || n == "Int" || n == "Num" || n == "Hash"
+                    });
                     if !accepts_positional {
                         return Err(constructor_positional_error(&class_name.resolve()));
                     }
@@ -1848,14 +1848,13 @@ impl Interpreter {
                         .first()
                         .map_or(0, crate::runtime::to_int)
                 };
-                if class_mro.iter().any(|name| name == "Array")
+                if class_mro.iter().any(|n| *n == "Array" || *n == "List")
                     && !attrs.contains_key("__mutsu_array_storage")
                     && !positional_ctor_args.is_empty()
                 {
-                    attrs.insert(
-                        "__mutsu_array_storage".to_string(),
-                        Value::real_array(positional_ctor_args),
-                    );
+                    let storage =
+                        self.positional_base_storage(class_key, positional_ctor_args.clone());
+                    attrs.insert("__mutsu_array_storage".to_string(), storage);
                 }
                 if class_mro.iter().any(|name| name == "Int")
                     && !attrs.contains_key("__mutsu_int_value")
@@ -2209,14 +2208,15 @@ impl Interpreter {
                         attrs.insert(qualified_key, val);
                     }
                 }
-                // If the class inherits from Array, add backing array storage
-                if self.class_mro(class_key).iter().any(|n| n == "Array")
+                // If the class inherits from Array or List, add backing storage
+                if self
+                    .class_mro(class_key)
+                    .iter()
+                    .any(|n| *n == "Array" || *n == "List")
                     && !attrs.contains_key("__mutsu_array_storage")
                 {
-                    attrs.insert(
-                        "__mutsu_array_storage".to_string(),
-                        Value::real_array(Vec::new()),
-                    );
+                    let storage = self.positional_base_storage(class_key, Vec::new());
+                    attrs.insert("__mutsu_array_storage".to_string(), storage);
                 }
                 // Tag typed `@`/`%` attributes (`has Int @.nums`) with
                 // element-type metadata and type-check their elements (the

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -334,7 +334,10 @@ impl Interpreter {
             if !self.has_user_method(class, method)
                 && let ValueView::Instance { attributes, .. } = target.view()
                 && attributes.contains_key("__mutsu_array_storage")
-                && self.mro_readonly(class).iter().any(|n| n == "Array")
+                && self
+                    .mro_readonly(class)
+                    .iter()
+                    .any(|n| Self::is_positional_base(n))
             {
                 let storage = attributes
                     .as_map()

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2003,7 +2003,10 @@ impl Interpreter {
                     if is_array_method
                         && !self.has_user_method(&cn, &method)
                         && attributes.contains_key("__mutsu_array_storage")
-                        && self.mro_readonly(&cn).iter().any(|n| n == "Array")
+                        && self
+                            .mro_readonly(&cn)
+                            .iter()
+                            .any(|n| Self::is_positional_base(n))
                     {
                         let mut storage = attributes
                             .as_map()

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1482,7 +1482,10 @@ impl Interpreter {
                     let cn = class_name.resolve();
                     if !self.has_user_method(&cn, method)
                         && attributes.contains_key("__mutsu_array_storage")
-                        && self.mro_readonly(&cn).iter().any(|n| n == "Array")
+                        && self
+                            .mro_readonly(&cn)
+                            .iter()
+                            .any(|n| Self::is_positional_base(n))
                     {
                         let storage = attributes
                             .as_map()

--- a/t/is-list-subclass.t
+++ b/t/is-list-subclass.t
@@ -1,0 +1,34 @@
+use Test;
+
+# `class C is List { }` gets `List.new`'s positional constructor and answers
+# positional methods from the elements, exactly as `class C is Array { }` does.
+# Cro's `Cro::HTTP::MultiValue is List does Stringy` is built that way, so a
+# query string or form body with a repeated key could not be represented at all.
+
+plan 8;
+
+class MyList is List { }
+
+{
+    my $l = MyList.new('a', 'b', 'c');
+    is $l.^name, 'MyList', 'the instance keeps its own type';
+    is $l.elems, 3, '.elems counts the positional constructor arguments';
+    is $l.join('-'), 'a-b-c', '.join reaches the elements';
+    is $l[1], 'b', 'positional indexing reaches the elements';
+    is $l.map(*.uc).join(','), 'A,B,C', 'iteration reaches the elements';
+}
+
+# A List subclass is immutable, unlike an Array subclass.
+{
+    my $l = MyList.new(1, 2);
+    dies-ok { $l.push(3) }, 'a List subclass rejects .push';
+    is $l.elems, 2, 'and is unchanged by the attempt';
+}
+
+# `is Array` still gets a mutable backing store.
+{
+    class MyArray is Array { }
+    my $a = MyArray.new(1, 2);
+    $a.push(3);
+    is $a.elems, 3, 'an Array subclass still accepts .push';
+}

--- a/todo/tickets/whatever-slice-on-a-storage-backed-instance-gives-nil.md
+++ b/todo/tickets/whatever-slice-on-a-storage-backed-instance-gives-nil.md
@@ -1,0 +1,42 @@
+# `$obj[*]` on an `is Array` / `is List` subclass instance gives Nil
+
+A whatever-slice reads nothing from an instance whose elements live in the
+backing `__mutsu_array_storage`, even though every other subscript form works:
+
+```raku
+class MA is Array { }
+my $m = MA.new('a', 'b');
+say $m[0].raku;      # "a"      -- correct
+say $m[0,1].raku;    # ("a","b") -- correct
+say $m[*].raku;      # raku: ("a", "b")    mutsu: Nil
+```
+
+The same holds for `class MyList is List { }`. A *plain* container is fine —
+`my @a = 'a','b'; @a[*]` and `my $l = (1,2); $l[*]` both answer correctly — so
+the gap is specific to the instance-subscript path, which resolves an integer or
+list index against the storage but has no arm for `Whatever`. (The `:exists`
+adverb path in `vm/vm_var_ops.rs` *does* have a `ValueView::Whatever` arm that
+expands it via `.elems`; the plain read path needs the same.)
+
+## Why it matters
+
+It is the last failure of Cro's multi-value query/body family in
+`t/http-request-parser.rakutest`:
+
+```raku
+is-deeply %hash<a>[*], ('1', '3', '4'), 'Indexing multi-value is correct (1)';
+```
+
+where `%hash<a>` is a `Cro::HTTP::MultiValue` (`is List does Stringy`). Its
+construction and stringification work as of
+`news/2026-08/is-list-subclass-takes-positional-new.md`; only `[*]` does not.
+
+## Where to look
+
+The instance subscript path — `try_compiled_method_or_interpret(... "AT-POS")`
+and the `__mutsu_array_storage` delegation in `vm/vm_call_method_ops.rs` /
+`vm/vm_call_method_compiled_interpret.rs`. A `Whatever` index should expand to
+`0 ..^ .elems` before delegating, mirroring the `:exists` arm in
+`vm/vm_var_ops.rs`.
+
+Related: `todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md`.


### PR DESCRIPTION
## Problem

`class C is Array { }` inherited `Array.new`'s positional constructor and answered positional methods from the instance's backing `__mutsu_array_storage`. `class C is List { }` did neither — it fell through to `Mu.new` and died:

```raku
class MyList is List { }
MyList.new('a', 'b');   # Default constructor for 'MyList' only takes named arguments
```

Every gate that recognised the backing store tested the MRO for `Array` alone.

## Fix

Those gates now go through `Interpreter::is_positional_base`, which accepts `Array` and `List`: construction seeds the storage from the positional arguments, and `.elems` / `.join` / `AT-POS` / iteration delegate to it.

The two bases keep their different mutability. A fresh instance's storage kind is chosen by `positional_base_storage`: an `Array` subclass gets a real `Array`, a `List` subclass an immutable `List`, so `.push` on the latter still raises `X::Immutable` exactly as raku does.

## Result

`Cro::HTTP::MultiValue is List does Stringy` — the type Cro uses whenever a query string or a form body repeats a key — is constructible and stringifies correctly. In `t/http-request-parser.rakutest` the "Query strings with multiple values for the same key" and "Multiple entries with same name in application/x-www-form-urlencoded" cases now pass.

The remaining multi-value assertion (`%hash<a>[*]`) is blocked on a separate gap — a whatever-slice reads nothing from *any* storage-backed instance, including an `is Array` one — filed as `todo/tickets/whatever-slice-on-a-storage-backed-instance-gives-nil.md`.

Pinned by `t/is-list-subclass.t` (8 assertions, identical under real `raku`). `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)