### PR TITLE
fix(str): make substr/index/rindex/indices grapheme-based

### DIFF
--- a/news/2026-08/string-positions-are-grapheme-based.md
+++ b/news/2026-08/string-positions-are-grapheme-based.md
@@ -1,0 +1,55 @@
+# String positions are grapheme-based
+
+A Raku string is a sequence of **graphemes**, so every position and length a
+string method reports or accepts is a grapheme index. `.chars` already counted
+graphemes (`str.graphemes(true).count()`), but `substr`, `index`, `rindex` and
+`indices` counted **codepoints** — so the two scales silently disagreed on any
+string holding a multi-codepoint grapheme, and a position computed with one was
+wrong when fed to the other.
+
+```raku
+"AAA\r\n--bnd".index("--bnd")   # raku: 4          mutsu was: 5
+"\r\nHello".substr(1)           # raku: "Hello"    mutsu was: "\nHello"
+```
+
+The second is worse than an off-by-one: it returns a **torn grapheme**, half a
+CRLF.
+
+`\r\n` is one grapheme and is everywhere in wire protocols, so this was
+load-bearing rather than exotic. Cro's `multipart/form-data` parser walks a body
+with exactly that pair of calls —
+
+```raku
+$payload .= substr($start + $dd-boundary.chars);
+my $next-boundary = $payload.index($search);   # $search = "\r\n$dd-boundary"
+```
+
+— so it lost a character per boundary and rejected every multipart body with
+`Unexpected text after multpart/form-data boundary`.
+
+## Fix
+
+`crate::builtins::string_pos` holds the three conversions the string methods
+need — `grapheme_units`, `grapheme_offset` (byte offset from `str::find` →
+grapheme offset) and `grapheme_len` — and `substr`, `index`, `rindex` and
+`indices` now go through them, in both the interpreter dispatch and the native
+fast paths.
+
+ASCII text with no `\r\n` has exactly one grapheme per byte, so all three take a
+fast path that skips segmentation entirely. That covers the overwhelming
+majority of strings, which is why this is a correctness fix rather than a
+throughput one.
+
+## Result
+
+`Cro::HTTP::BodyParser::MultiPartFormData` parses. In
+`t/http-request-parser.rakutest` the passing assertion count goes from **293 to
+323**. The raw *failure* count goes 9 → 18 at the same time, and that is the
+point: the multipart body parse used to die, so all of its per-part assertions
+were skipped. They now run, and twelve of them fail on a separate issue — a
+part with no `Content-Type` header should default to `text/plain`, and mutsu
+gives it no content-type at all. That is a real, newly-visible bug rather than a
+regression.
+
+Pinned by `t/string-positions-are-graphemes.t` (18 assertions, byte-identical
+output under real `raku`) and three unit tests in `builtins::string_pos`.

--- a/src/builtins/functions/dispatch_2arg.rs
+++ b/src/builtins/functions/dispatch_2arg.rs
@@ -234,7 +234,9 @@ pub(crate) fn native_function_2arg(
             let s = arg1.to_string_value();
             let needle = arg2.to_string_value();
             Some(Ok(match s.find(&needle) {
-                Some(pos) => Value::int(s[..pos].chars().count() as i64),
+                Some(pos) => {
+                    Value::int(crate::builtins::string_pos::grapheme_offset(&s, pos) as i64)
+                }
                 None => Value::NIL,
             }))
         }
@@ -250,7 +252,9 @@ pub(crate) fn native_function_2arg(
             let s = arg1.to_string_value();
             let needle = arg2.to_string_value();
             Some(Ok(match s.rfind(&needle) {
-                Some(pos) => Value::int(s[..pos].chars().count() as i64),
+                Some(pos) => {
+                    Value::int(crate::builtins::string_pos::grapheme_offset(&s, pos) as i64)
+                }
                 None => Value::NIL,
             }))
         }

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -459,7 +459,7 @@ pub(crate) fn native_method_1arg(
             let needle = arg.to_string_value();
             match s.find(&needle) {
                 Some(pos) => {
-                    let char_pos = s[..pos].chars().count();
+                    let char_pos = crate::builtins::string_pos::grapheme_offset(&s, pos);
                     Some(Ok(Value::int(char_pos as i64)))
                 }
                 None => Some(Ok(Value::NIL)),
@@ -1018,7 +1018,7 @@ pub(crate) fn native_method_1arg(
             let needle = arg.to_string_value();
             match s.rfind(&needle) {
                 Some(pos) => {
-                    let char_pos = s[..pos].chars().count();
+                    let char_pos = crate::builtins::string_pos::grapheme_offset(&s, pos);
                     Some(Ok(Value::int(char_pos as i64)))
                 }
                 None => Some(Ok(Value::NIL)),

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod seq_coerce;
 pub(crate) mod sha1;
 pub(crate) mod split;
 pub(crate) mod str_increment;
+pub(crate) mod string_pos;
 pub(crate) mod substr;
 pub(crate) mod transliterate;
 pub(crate) mod unicode;

--- a/src/builtins/string_pos.rs
+++ b/src/builtins/string_pos.rs
@@ -1,0 +1,87 @@
+//! Grapheme-based string positions.
+//!
+//! A Raku string is a sequence of **graphemes**, so every position and length a
+//! string method reports or accepts is a grapheme index. `.chars` already
+//! counted graphemes (`str.graphemes(true).count()`), but `substr`, `index`,
+//! `rindex` and `indices` counted *codepoints*, so the two scales disagreed on
+//! any string holding a multi-codepoint grapheme.
+//!
+//! `\r\n` is exactly such a grapheme and is everywhere in wire protocols, which
+//! made the mismatch load-bearing rather than exotic:
+//!
+//! ```text
+//! "AAA\r\n--bnd".index("--bnd")   raku: 4   mutsu was: 5
+//! "\r\nHello".substr(1)           raku: "Hello"   mutsu was: "\nHello"
+//! ```
+//!
+//! Cro's `multipart/form-data` parser walks a body with exactly that pair of
+//! calls, so it lost a character per boundary and rejected every multipart body.
+//!
+//! Both helpers take a fast path for ASCII text with no `\r\n`, where one byte
+//! is one grapheme and no segmentation pass is needed.
+
+use unicode_segmentation::UnicodeSegmentation;
+
+/// True when `s` has one grapheme per byte, so byte offsets *are* grapheme
+/// offsets. ASCII guarantees one byte per codepoint; the only ASCII sequence
+/// that merges two codepoints into one grapheme is `\r\n`.
+#[inline]
+fn is_flat_ascii(s: &str) -> bool {
+    s.is_ascii() && !s.contains("\r\n")
+}
+
+/// Split `s` into its graphemes, the units a positional string method indexes.
+pub(crate) fn grapheme_units(s: &str) -> Vec<&str> {
+    if is_flat_ascii(s) {
+        return (0..s.len()).map(|i| &s[i..i + 1]).collect();
+    }
+    s.graphemes(true).collect()
+}
+
+/// Convert a **byte** offset (what `str::find` returns) into the grapheme
+/// offset Raku reports. `byte_pos` must lie on a grapheme boundary, which it
+/// does for the result of a substring search.
+pub(crate) fn grapheme_offset(s: &str, byte_pos: usize) -> usize {
+    if is_flat_ascii(s) {
+        return byte_pos;
+    }
+    s[..byte_pos].graphemes(true).count()
+}
+
+/// The number of graphemes in `s` — the length `index`/`substr` positions are
+/// measured against, and what `.chars` reports.
+pub(crate) fn grapheme_len(s: &str) -> usize {
+    if is_flat_ascii(s) {
+        return s.len();
+    }
+    s.graphemes(true).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crlf_is_one_grapheme_everywhere() {
+        let s = "AAA\r\n--bnd";
+        assert_eq!(grapheme_len(s), 9);
+        assert_eq!(grapheme_offset(s, s.find("--bnd").unwrap()), 4);
+        assert_eq!(grapheme_units(s)[3], "\r\n");
+    }
+
+    #[test]
+    fn flat_ascii_takes_the_fast_path() {
+        let s = "hello world";
+        assert_eq!(grapheme_len(s), 11);
+        assert_eq!(grapheme_offset(s, 6), 6);
+        assert_eq!(grapheme_units(s).len(), 11);
+    }
+
+    #[test]
+    fn combining_marks_count_as_one() {
+        // "e" + COMBINING ACUTE ACCENT is one grapheme, two codepoints.
+        let s = "a\u{65}\u{301}b";
+        assert_eq!(grapheme_len(s), 3);
+        assert_eq!(grapheme_offset(s, s.find('b').unwrap()), 2);
+    }
+}

--- a/src/builtins/substr.rs
+++ b/src/builtins/substr.rs
@@ -13,6 +13,7 @@
 //! — stays in the interpreter's `dispatch_substr`. This helper returns `None`
 //! for all of those so the caller defers, exactly as the four copies did.
 
+use crate::builtins::string_pos::grapheme_units;
 use crate::value::{RuntimeError, Value, ValueView};
 
 /// Pure `substr` slice for a non-negative integer `start` and optional
@@ -36,7 +37,7 @@ pub(crate) fn native_substr_slice(
         None => None,
     };
 
-    let chars: Vec<char> = text.chars().collect();
+    let chars = grapheme_units(text);
     if start > chars.len() {
         return None; // out-of-range: the interpreter returns a Failure
     }
@@ -44,9 +45,9 @@ pub(crate) fn native_substr_slice(
     let slice: String = match len {
         Some(l) => {
             let end = (start + l).min(chars.len());
-            chars[start..end].iter().collect()
+            chars[start..end].concat()
         }
-        None => chars[start..].iter().collect(),
+        None => chars[start..].concat(),
     };
     Some(Ok(Value::str(slice)))
 }

--- a/src/runtime/methods_string_index.rs
+++ b/src/runtime/methods_string_index.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::builtins::string_pos::{grapheme_len, grapheme_offset, grapheme_units};
 use crate::symbol::Symbol;
 
 impl Interpreter {
@@ -52,7 +53,7 @@ impl Interpreter {
             0
         };
         let text = target.to_string_value();
-        let len = text.chars().count() as i64;
+        let len = grapheme_len(&text) as i64;
         if start < 0 {
             return Ok(RuntimeError::out_of_range_failure(
                 "start",
@@ -63,7 +64,7 @@ impl Interpreter {
         if start > len {
             return Ok(Value::NIL);
         }
-        let hay: String = text.chars().skip(start as usize).collect();
+        let hay: String = grapheme_units(&text)[(start as usize).min(len as usize)..].concat();
         let mut best: Option<usize> = None;
         for needle in &needles {
             let pos = if ignore_case && ignore_mark {
@@ -73,7 +74,7 @@ impl Interpreter {
             } else if ignore_mark {
                 self.index_ignoremark(&hay, needle)
             } else {
-                hay.find(needle.as_str()).map(|p| hay[..p].chars().count())
+                hay.find(needle.as_str()).map(|p| grapheme_offset(&hay, p))
             };
             if let Some(char_pos) = pos {
                 best = Some(match best {
@@ -131,7 +132,7 @@ impl Interpreter {
             0
         };
         let text = target.to_string_value();
-        let len = text.chars().count() as i64;
+        let len = grapheme_len(&text) as i64;
         if start < 0 {
             return Ok(RuntimeError::out_of_range_failure(
                 "start",
@@ -139,17 +140,17 @@ impl Interpreter {
                 &format!("0..{}", len),
             ));
         }
-        let text_chars: Vec<char> = text.chars().collect();
+        let text_chars = grapheme_units(&text);
         let mut results: Vec<Value> = Vec::new();
         if needle.is_empty() {
             for i in (start as usize)..=text_chars.len() {
                 results.push(Value::int(i as i64));
             }
         } else {
-            let needle_len = needle.chars().count();
+            let needle_len = grapheme_len(&needle);
             let mut pos = start as usize;
             while pos <= text_chars.len() {
-                let hay: String = text_chars[pos..].iter().collect();
+                let hay: String = text_chars[pos..].concat();
                 let found = if ignore_case && ignore_mark {
                     self.index_ignorecase_ignoremark(&hay, &needle)
                 } else if ignore_case {
@@ -157,7 +158,7 @@ impl Interpreter {
                 } else if ignore_mark {
                     self.index_ignoremark(&hay, &needle)
                 } else {
-                    hay.find(needle.as_str()).map(|p| hay[..p].chars().count())
+                    hay.find(needle.as_str()).map(|p| grapheme_offset(&hay, p))
                 };
                 match found {
                     Some(char_pos) => {
@@ -209,7 +210,7 @@ impl Interpreter {
                 ]
             };
         let text = target.to_string_value();
-        let char_len = text.chars().count() as i64;
+        let char_len = grapheme_len(&text) as i64;
         // Optional position argument (maximum char index to consider)
         let max_pos = if let Some(pos_val) = positional.get(1) {
             // Check for negative values first (returns Failure, not exception)
@@ -274,8 +275,8 @@ impl Interpreter {
         for needle in &needles {
             // Search the entire string with rfind
             let pos = {
-                let chars: Vec<char> = text.chars().collect();
-                let n_chars: Vec<char> = needle.chars().collect();
+                let chars = grapheme_units(&text);
+                let n_chars = grapheme_units(needle);
                 if n_chars.is_empty() {
                     match max_pos {
                         Some(p) => Some(p),
@@ -317,7 +318,7 @@ impl Interpreter {
         let needle_lower = needle.to_lowercase();
         hay_lower
             .find(&needle_lower)
-            .map(|byte_pos| hay_lower[..byte_pos].chars().count())
+            .map(|byte_pos| grapheme_offset(&hay_lower, byte_pos))
     }
 
     pub(super) fn index_ignoremark(&self, hay: &str, needle: &str) -> Option<usize> {
@@ -325,7 +326,7 @@ impl Interpreter {
         let needle_stripped = self.strip_marks(needle);
         hay_stripped
             .find(&needle_stripped)
-            .map(|byte_pos| hay_stripped[..byte_pos].chars().count())
+            .map(|byte_pos| grapheme_offset(&hay_stripped, byte_pos))
     }
 
     pub(super) fn index_ignorecase_ignoremark(&self, hay: &str, needle: &str) -> Option<usize> {
@@ -333,7 +334,7 @@ impl Interpreter {
         let needle_stripped = self.strip_marks(needle).to_lowercase();
         hay_stripped
             .find(&needle_stripped)
-            .map(|byte_pos| hay_stripped[..byte_pos].chars().count())
+            .map(|byte_pos| grapheme_offset(&hay_stripped, byte_pos))
     }
 
     pub(super) fn strip_marks(&self, s: &str) -> String {

--- a/src/runtime/methods_string_substr.rs
+++ b/src/runtime/methods_string_substr.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::builtins::string_pos::grapheme_units;
 use crate::symbol::Symbol;
 
 impl Interpreter {
@@ -74,7 +75,7 @@ impl Interpreter {
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let s = target.to_string_value();
-        let chars: Vec<char> = s.chars().collect();
+        let chars = grapheme_units(&s);
         let total_len = chars.len();
 
         // Check if first arg is a Range — handle substr($str, 6..8) form
@@ -84,7 +85,7 @@ impl Interpreter {
         {
             let rs = range_start.min(total_len);
             let re = range_end.min(total_len);
-            return Ok(Value::str(chars[rs..re].iter().collect()));
+            return Ok(Value::str(chars[rs..re].concat()));
         }
 
         // First arg: start position
@@ -147,7 +148,7 @@ impl Interpreter {
             total_len // no length: take rest
         };
 
-        Ok(Value::str(chars[start..end].iter().collect()))
+        Ok(Value::str(chars[start..end].concat()))
     }
 
     /// substr-rw in non-lvalue context: just return the substring (same as substr).
@@ -173,8 +174,7 @@ impl Interpreter {
             .cloned()
             .unwrap_or(Value::str(String::new()));
         let s = target.to_string_value();
-        let chars: Vec<char> = s.chars().collect();
-        let str_len = chars.len();
+        let str_len = grapheme_units(&s).len();
 
         // Resolve range
         let (start, end) = self.resolve_substr_rw_range(args, str_len)?;

--- a/t/string-positions-are-graphemes.t
+++ b/t/string-positions-are-graphemes.t
@@ -1,0 +1,50 @@
+use Test;
+
+# A Raku string is a sequence of graphemes, so every position and length a
+# string method reports or accepts is a grapheme index. `.chars` already counted
+# graphemes; `substr`, `index`, `rindex` and `indices` counted codepoints, so
+# the two scales disagreed on any string holding a multi-codepoint grapheme.
+# `\r\n` is one such grapheme and is everywhere in wire protocols -- Cro's
+# multipart/form-data parser walks a body with exactly `index` + `substr` and
+# lost a character per boundary.
+
+plan 18;
+
+# --- CRLF is one grapheme.
+{
+    my $s = "AAA\r\n--bnd\r\nBBB";
+    is $s.chars, 13, '.chars counts CRLF as one';
+    is $s.index('--bnd'), 4, 'index reports a grapheme offset past a CRLF';
+    is $s.index("\r\n"), 3, 'index finds a CRLF needle';
+    is $s.index("\r\n", 4), 9, 'index honours a grapheme start offset';
+    is $s.rindex("\r\n"), 9, 'rindex reports a grapheme offset';
+    is $s.rindex('B'), 12, 'rindex past two CRLFs';
+    is-deeply $s.indices("\r\n"), (3, 9), 'indices are grapheme offsets';
+    is $s.substr(4, 5), '--bnd', 'substr slices by grapheme';
+    is $s.substr(3), "\r\n--bnd\r\nBBB", 'substr with no length starts on a grapheme';
+    is $s.substr(4), "--bnd\r\nBBB", 'substr past a CRLF does not tear it';
+}
+
+# A start offset that lands just after a CRLF must not split it.
+{
+    my $t = "\r\nHello";
+    is $t.chars, 6, 'leading CRLF counts once';
+    is $t.substr(1), 'Hello', 'substr(1) steps over the whole CRLF';
+}
+
+# --- A combining mark is one grapheme too.
+{
+    my $t = "a\c[LATIN SMALL LETTER E]\c[COMBINING ACUTE ACCENT]bc";
+    is $t.chars, 4, 'a base plus a combining mark is one grapheme';
+    is $t.index('b'), 2, 'index counts the combined grapheme once';
+    is $t.rindex('c'), 3, 'rindex counts the combined grapheme once';
+    is $t.substr(1, 1), "\c[LATIN SMALL LETTER E]\c[COMBINING ACUTE ACCENT]",
+        'substr yields the whole grapheme';
+}
+
+# --- Plain ASCII is unchanged (the fast path).
+{
+    my $u = 'hello world';
+    is $u.index('o'), 4, 'ASCII index is unchanged';
+    is $u.substr(6, 5), 'world', 'ASCII substr is unchanged';
+}

--- a/todo/tickets/multipart-part-has-no-default-content-type.md
+++ b/todo/tickets/multipart-part-has-no-default-content-type.md
@@ -1,0 +1,34 @@
+# A multipart/form-data part with no `Content-Type` gets no content-type at all
+
+`Cro::HTTP::Body::MultiPartFormData::Part.content-type` should default to
+`text/plain` when the part carries no `Content-Type` header. Under mutsu it is
+undefined, so all three assertions fail in `t/http-request-parser.rakutest`:
+
+```
+not ok - First part has a content-type that is a Cro::MediaType
+not ok - First part has default text type
+not ok - First part has default plain subtype
+```
+
+while the sibling assertions about the same part (`name`, `body-blob`,
+`body-text`) pass. The `is-deeply @parts[0].body, '355…'` assertion fails too,
+which is likely the same cause: `Part.body` dispatches on the content-type to
+choose a body parser, so an undefined content-type cannot select the text one.
+
+## Why it is newly visible
+
+The multipart parser used to die outright on a grapheme/codepoint index mismatch
+(`news/2026-08/string-positions-are-grapheme-based.md`), so every per-part
+assertion was skipped. They run now; twelve of them fail on this one issue, and
+it is the largest remaining cluster in that file.
+
+## Where to look
+
+`Cro::HTTP::Body::MultiPartFormData::Part` in the Cro::HTTP dist's
+`lib/Cro/HTTP/Body.rakumod`, and how `Cro::HTTP::BodyParsers`'
+`MultiPartFormData.parse` builds each `Part`. The default is expressed in Cro
+itself, so this is very likely a mutsu-side gap in whatever expresses it —
+an attribute default, a `content-type` method with a `//` fallback, or role
+composition — rather than something to implement natively. Start by reading the
+real definition and reproducing it standalone, the way `tmp/multipart.raku`
+reproduces the parser.


### PR DESCRIPTION
## Problem

A Raku string is a sequence of **graphemes**, so every position and length a string method reports or accepts is a grapheme index. `.chars` already counted graphemes (`str.graphemes(true).count()`), but `substr`, `index`, `rindex` and `indices` counted **codepoints** — so the two scales silently disagreed on any string holding a multi-codepoint grapheme, and a position computed with one was wrong when fed to the other.

```raku
"AAA\r\n--bnd".index("--bnd")   # raku: 4          mutsu was: 5
"\r\nHello".substr(1)           # raku: "Hello"    mutsu was: "\nHello"
```

The second is worse than an off-by-one: it returns a **torn grapheme**, half a CRLF.

`\r\n` is one grapheme and is everywhere in wire protocols, so this was load-bearing rather than exotic. Cro's `multipart/form-data` parser walks a body with exactly that pair of calls —

```raku
$payload .= substr($start + $dd-boundary.chars);
my $next-boundary = $payload.index($search);   # $search = "\r\n$dd-boundary"
```

— so it lost a character per boundary and rejected every multipart body with `Unexpected text after multpart/form-data boundary`.

## Fix

`crate::builtins::string_pos` holds the three conversions the string methods need — `grapheme_units`, `grapheme_offset` (byte offset from `str::find` → grapheme offset) and `grapheme_len` — and `substr`, `index`, `rindex` and `indices` now go through them, in both the interpreter dispatch and the native fast paths.

ASCII text with no `\r\n` has exactly one grapheme per byte, so all three take a fast path that skips segmentation entirely. That covers the overwhelming majority of strings, which is why this is a correctness fix rather than a throughput one.

## Result

`Cro::HTTP::BodyParser::MultiPartFormData` parses. In `t/http-request-parser.rakutest` the passing assertion count goes from **293 to 323**.

The raw *failure* count goes 9 → 18 at the same time, and that is worth stating plainly: the multipart body parse used to die, so all of its per-part assertions were skipped. They now run, and twelve of them fail on a separate issue — a part with no `Content-Type` header should default to `text/plain`, and mutsu gives it none. That is a real, newly-visible bug rather than a regression, filed as `todo/tickets/multipart-part-has-no-default-content-type.md`.

Pinned by `t/string-positions-are-graphemes.t` (18 assertions, byte-identical output under real `raku`) and three unit tests in `builtins::string_pos`. `make test` green; roast `S32-str/` (59 files, 30k assertions) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)