### PR TITLE
docs(todo): root-cause the lost pipelined Cro request

### DIFF
--- a/todo/tickets/second-emit-from-a-whenever-body-is-lost-after-a-nested-supply-cycle.md
+++ b/todo/tickets/second-emit-from-a-whenever-body-is-lost-after-a-nested-supply-cycle.md
@@ -1,8 +1,28 @@
-# A `whenever` body's `emit` is lost on its second invocation, after a nested supply completed
+# A supply-block lexical written from a nested sub reverts between `whenever` invocations
 
 `Cro::HTTP::RequestParser` parses two pipelined requests but only ever delivers
-the first. The second request is parsed completely — request line, headers, body
-bytes — and then `emit $request` neither reaches the tap nor returns.
+the first. Root-caused: the parser's `$request` lexical, reassigned by its nested
+`sub fresh-message`, is **back to the previous object** on the next `whenever`
+invocation, so the second request's headers are appended to the first request's
+object.
+
+## The failure chain
+
+1. `fresh-message` runs and *does* assign a new request — a note inside the sub
+   prints `new request Cro::HTTP::Request|906`.
+2. The next `whenever $in` invocation sees `$request` as `Cro::HTTP::Request|767`
+   again — the object from the *first* request.
+3. Packet 2's headers are appended to it, so it ends up with
+   `("Content-Type=text/plain", "Content-Length=22", "Content-Type=text/plain",
+   "Content-Length=19")`.
+4. Two `Content-Type` headers make `$request.content-type` parse
+   `'text/plain,text/plain'`, which dies with `X::Cro::MediaType::Invalid`.
+5. That exception escapes `emit $request`, so the second request never reaches
+   the tap and the test times out.
+
+`Cro::MediaType.parse('text/plain,text/plain')` fails identically under real
+`raku`, so step 4 is correct behaviour reached from a wrong state — the bug is
+entirely steps 1-2.
 
 ## Reproduction
 
@@ -36,60 +56,46 @@ say "got {@got.elems}: ", @got.raku;
 
 `raku` prints `got 2`, mutsu `got 1`.
 
-## What the trace shows
-
 The vendored `Cro/HTTP/RequestParser.rakumod` carries `%*ENV<CRODBG>`-gated
-`[DBG-P]` notes for exactly this (run with `CRODBG=1`). For the **second**
-packet every step runs:
-
-```
-[DBG-P] packet in, bytes=88 expecting=RequestLine
-[DBG-P] req-line="POST /bar HTTP/1.1"
-[DBG-P] header-line="Content-Type: text/plain"
-[DBG-P] header-line="Content-Length: 19"
-[DBG-P] header-line=""
-[DBG-P] blank line; has-cl=True has-te=False req=Cro::HTTP::Request|767
-[DBG-P] body-stream set, about to feed
-[DBG-P] count=20
-[DBG-P] fed body bytes
-```
-
-and then stops. The very next statement is `emit $request`, and the note placed
-immediately after it never fires — so `emit` itself throws or does not return.
-For the first packet the identical sequence works.
-
-Two further observations from the same trace:
-
-- `req=Cro::HTTP::Request|767` is the **same `.WHICH` for both requests**, even
-  though `fresh-message` ran in between (`[DBG-P] leftover kept, elems=0` proves
-  the `fresh-message; next;` branch was taken) and assigns
-  `$request = Cro::HTTP::Request.new`. Either the assignment does not survive to
-  the next `whenever` invocation or two distinct instances share a `.WHICH`.
-- Between the two `emit $request` calls, the body byte stream is fed, which runs
-  `Cro::HTTP::RawBodyParser::ContentLength`'s `whenever` to completion including
-  its `done`. A nested supply completing mid-body is the obvious suspect for
-  closing something the outer supply still needs.
+`[DBG-P]` notes covering every step above — run the repro with `CRODBG=1` and the
+whole chain is visible without re-instrumenting.
 
 ## Not a regression
 
-Measured on `75b0ad4ca` (before the supply emitter-stamp campaign of
-#6044/#6047/#6048): identical `got 1`. It predates that work.
-
-## Why it matters
-
-It is 3 of the 7 remaining failures in Cro's `t/http-request-parser.rakutest`
-("Two separate packages are parsed", and the two split-packet variants), and it
-means a mutsu Cro server cannot serve pipelined requests on one connection.
+Measured on `75b0ad4ca`, before the supply emitter-stamp campaign of
+#6044/#6047/#6048: identical `got 1`. It predates that work. It also survives
+#6048 (supply-block lexicals as shared `ContainerRef` cells), which fixed the
+*read* side of the same family — sibling `whenever`s and `LAST` phasers now share
+the block's lexical — so this is a distinct write-visibility hole.
 
 ## Reduced repros that do NOT reproduce it
 
-Worth knowing so the next attempt does not re-derive them:
+Five shapes were tried and all behave correctly, so the next attempt should not
+re-derive them (they are in `tmp/subwrite*.raku`):
 
-- a nested `my sub` writing a supply-block lexical, read back on a later
-  `whenever` invocation — correct;
+- a nested `my sub` writing a supply-block scalar, read back on a later
+  `whenever` invocation;
 - the same where the sub is called both from the supply body and from the
-  `whenever` body, allocating a fresh object each time — correct (each
-  invocation sees the new object).
+  `whenever` body, allocating a fresh object each time;
+- the sub called inside a `loop` in the `whenever` body, followed by `next`;
+- the `whenever` body emitting the very object the sub then replaces;
+- the same with a nested supply created, fed and completed in between.
 
-So the trigger needs the nested body-parser supply in the middle, not just the
-nested sub.
+The synthetic route is exhausted; per the project's own guidance the next step is
+a **shadow bisect of the real file** — copy `Cro/HTTP/RequestParser.rakumod` into
+a shadow tree that `-I` puts first, and delete statements from the `whenever`
+body until the revert stops.
+
+## Secondary defect found on the way
+
+The escaping exception is reported as `X::AdHoc: X::Cro::MediaType::Invalid()` —
+a typed exception flattened into `X::AdHoc` with the *type object's gist* as its
+message. Caught directly (`try Cro::MediaType.parse('text/plain,text/plain')`)
+the same exception keeps its class and message under mutsu, so the mangling is in
+the supply/quit propagation path, not in `die`.
+
+## Why it matters
+
+3 of the 7 remaining failures in Cro's `t/http-request-parser.rakutest` ("Two
+separate packages are parsed" and its two split-packet variants), and it means a
+mutsu Cro server cannot serve pipelined requests on one connection.


### PR DESCRIPTION
Follow-up to #6053, which pinned the failing statement. This replaces the guesswork after it with the actual chain.

`Cro::HTTP::RequestParser`'s `$request`, reassigned by its nested `sub fresh-message`, is **back to the previous object** on the next `whenever` invocation — a note *inside the sub* prints `new request Cro::HTTP::Request|906`, and the next invocation sees `|767` again. So packet 2's headers are appended to packet 1's request, which ends up with two `Content-Type` headers; `content-type` then parses `'text/plain,text/plain'` and dies with `X::Cro::MediaType::Invalid`, and that exception escapes `emit $request`.

`Cro::MediaType.parse('text/plain,text/plain')` fails identically under real `raku`, so the later steps are correct behaviour reached from a wrong state — the bug is entirely the reverted assignment.

The ticket also records:

- **How this differs from #6048**, which fixed the *read* side of the same family (sibling `whenever`s and `LAST` phasers now share the block's lexical). This is a distinct write-visibility hole and survives that fix.
- **Five reduced repros that do NOT reproduce it**, so the next attempt doesn't re-derive them — the synthetic route is exhausted and the next step is a shadow bisect of the real file.
- **A secondary defect found on the way**: a typed exception escaping through the supply/quit path is flattened into `X::AdHoc` with the *type object's gist* as its message (`X::AdHoc: X::Cro::MediaType::Invalid()`), though the same exception caught directly keeps its class and message.

Still not a regression — measured identical on `75b0ad4ca`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)