### PR TITLE
fix(runtime): reconcile augment_class method-decl drift (ADR-0019 D3-5)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -653,6 +653,23 @@ walkers wholesale is not possible before then.
   all three walkers sharing one typed constructor, D3-5 can compare and reconcile the still-open
   fields directly instead of re-deriving each walker's field set from its own AST match arm the way
   the original 2026-08-07 scoping pass had to.
+  **D3-5 landed 2026-08-08**: fixed the two `augment_class` drift points confirmed as real,
+  user-visible gaps against `raku` (`t/augment-method-lexical-scoping.t`). `MethodDef.is_my` now
+  stores `decl.is_submethod` like the class/role walkers, and `is_lexical_only`/`is_our_only`
+  gating excludes `my method`/`our method` from the method table — before this fix,
+  `augment class Foo { my method secret {...} }` put `secret` in `Foo`'s method table
+  (`Foo.can('secret')` wrongly returned it), and `our method` was both directly callable as a
+  method and absent as a package sub, the reverse of `raku`'s behavior. Fixing the gating exposed
+  that `augment_class` never registered the `our`/`my` function forms the class walker registers
+  (`Package::name(invocant)` / lexical `name(invocant)`), so this slice ports that registration
+  too — confirmed against `raku` that both forms are expected to resolve. Duplicate-method
+  detection is now privacy-aware (`is_private` compared, matching the class/role walkers): a
+  public `method foo` and a private `method !foo` of the same name coexist instead of
+  `augment_class` wrongly rejecting the second declaration as already-declared. Still open:
+  `handles` forwarder synthesis, custom-trait/`is native`-style trait dispatch, `is
+  export`/`export_tags`, and BUILD/TWEAK `:$!attr` validation remain absent from `augment_class`
+  (present at the class walker, `handles` also at the role walker) — each is a separate,
+  independently-scoped gap, not reconciled by this slice.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
   expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
   names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies

--- a/news/2026-08/d3-5-augment-method-drift-fixed.md
+++ b/news/2026-08/d3-5-augment-method-drift-fixed.md
@@ -1,0 +1,27 @@
+# ADR-0019 D3-5: augment class method drift fixed
+
+`augment class`'s `MethodDecl` arm (`registration_class_augment.rs`) diverged from the class and
+role body walkers in ways that were user-visible, confirmed against `raku`:
+
+- `augment class Foo { my method secret {...} }` put `secret` into `Foo`'s method table, so
+  `Foo.can('secret')` wrongly reported it. `raku` keeps a `my method` out of the method table
+  entirely — it is only callable lexically from a sibling declaration in the same block.
+- `augment class Foo { our method pkg {...} }` made `pkg` directly callable as `Foo.new.pkg`, and
+  did not register it as the package-qualified sub `Foo::pkg(invocant)` that `raku` expects.
+- A public `method foo` and a private `method !foo` declared across a `class`/`augment class` pair
+  wrongly collided ("already has a method 'foo'") — `raku` treats a method's privacy as part of
+  its identity, so a public and a private method of the same name coexist in separate namespaces.
+
+The fix mirrors the class walker: `MethodDef.is_my` now stores `is_submethod` (not the raw parser
+`is_my` flag), `is_lexical_only`/`is_our_only` gating excludes `my method`/`our method` from the
+method table, the `our`/`my` function forms are registered the same way the class walker registers
+them, and duplicate-method detection compares `is_private` before rejecting a redeclaration. All
+three regressions are pinned by the new `t/augment-method-lexical-scoping.t`, verified line-for-line
+against `raku`.
+
+This closes ADR-0019 D3-5, one of the reconciliation slices the D3 scoping pass and D3-2/D3-3/D3-4
+set up by giving all three method-declaration walkers (class, role, augment) a shared
+`CompiledMethodDecl` constructor: with drift expressed as unused struct fields instead of absent
+destructure bindings, it became directly comparable and fixable at each walker's call site.
+Remaining `augment_class` gaps (`handles` forwarders, custom traits, `is export`, BUILD/TWEAK
+`:$!attr` validation) are documented in the ADR as still open, independently-scoped follow-ups.

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1,4 +1,5 @@
 use super::registration_class::apply_resolved_handles;
+use super::registration_class_body_method_forms::method_sub_form_params;
 use super::*;
 use crate::symbol::Symbol;
 
@@ -222,18 +223,19 @@ impl Interpreter {
                         .collect();
                     let def = MethodDef {
                         lexical_package: self.current_package(),
-                        params: effective_params,
-                        param_defs: effective_param_defs,
+                        params: effective_params.clone(),
+                        param_defs: effective_param_defs.clone(),
                         body: std::sync::Arc::new(decl.body.clone()),
                         is_rw: decl.is_rw,
                         is_private: decl.is_private,
                         is_multi: decl.multi,
-                        // Unlike the class/role walkers (which store
-                        // `is_submethod` here for inheritance filtering),
-                        // this stores the raw `is_my` flag — a pre-existing
-                        // drift documented in the ADR-0019 D3 scoping pass,
-                        // not fixed by this slice.
-                        is_my: decl.is_my,
+                        // ADR-0019 D3-5: mirror the class/role walkers, which
+                        // store `is_submethod` here (inheritance filtering),
+                        // not the raw parser `is_my` flag — `my method` is
+                        // gated out of the method table entirely below, so by
+                        // construction the stored `MethodDef` only needs
+                        // `is_my` to mean "is this a submethod".
+                        is_my: decl.is_submethod,
                         role_origin: None,
                         original_role: None,
                         return_type: decl.return_type.clone(),
@@ -245,29 +247,131 @@ impl Interpreter {
                         is_submethod: decl.is_submethod,
                         captured_env: None,
                     };
-                    if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
+                    // ADR-0019 D3-5: `my method`/`our method` are not part of
+                    // the class method table — only callable as functions,
+                    // registered below — matching the class walker's
+                    // `is_lexical_only`/`is_our_only` gating (confirmed
+                    // against `raku`: `augment class Foo { my method secret
+                    // {...} }` leaves `Foo.can('secret')` empty). Submethods
+                    // still go in the table even though they also carry
+                    // `is_my=true` from the parser.
+                    let is_lexical_only = decl.is_my && !decl.is_submethod;
+                    let is_our_only = decl.is_our && !decl.our_variable_form;
+                    if !is_lexical_only
+                        && !is_our_only
+                        && let Some(class_def) = self.registry_mut().classes.get_mut(name)
+                    {
                         if decl.multi {
                             class_def
                                 .methods
-                                .entry(resolved_method_name)
+                                .entry(resolved_method_name.clone())
                                 .or_default()
                                 .push(def);
                         } else {
-                            // Check for duplicate non-multi method definition.
-                            // Only error if the existing method was defined in
-                            // this class (not composed from a role).
+                            // Check for duplicate non-multi method
+                            // definition. Only error if the existing
+                            // method was defined in this class (not
+                            // composed from a role) AND shares the same
+                            // privacy — a private `method !foo` and a
+                            // public `method foo` live in separate
+                            // namespaces and do not collide (confirmed
+                            // against `raku`), matching the class
+                            // walker's privacy-aware check (ADR-0019
+                            // D3-5).
+                            let new_is_private = def.is_private;
                             if let Some(existing) = class_def.methods.get(&resolved_method_name) {
-                                let all_from_role =
-                                    existing.iter().all(|m| m.role_origin.is_some());
-                                if !all_from_role {
+                                let conflicts = existing.iter().any(|m| {
+                                    m.role_origin.is_none() && m.is_private == new_is_private
+                                });
+                                if conflicts {
                                     return Err(RuntimeError::new(format!(
                                         "Package '{}' already has a method '{}' (did you mean to declare a multi method?)",
                                         name, resolved_method_name
                                     )));
                                 }
                             }
-                            class_def.methods.insert(resolved_method_name, vec![def]);
+                            let entry = class_def
+                                .methods
+                                .entry(resolved_method_name.clone())
+                                .or_default();
+                            entry.retain(|m| m.is_private != new_is_private);
+                            entry.push(def);
                         }
+                    }
+                    // ADR-0019 D3-5: `our method` also registers as a
+                    // package-scoped sub, and `my method` as a
+                    // lexically-scoped function — matching the class
+                    // walker (confirmed against `raku`: both
+                    // `Foo::pkg(invocant)` and an in-body call to a `my
+                    // method` resolve).
+                    if decl.is_our {
+                        let qualified_name = format!("{}::{}", name, resolved_method_name);
+                        let (our_params, our_param_defs) =
+                            method_sub_form_params(&effective_params, &effective_param_defs);
+                        let func_def = crate::ast::FunctionDef {
+                            package: Symbol::intern(name),
+                            name: Symbol::intern(&resolved_method_name),
+                            params: our_params,
+                            param_defs: our_param_defs,
+                            body: decl.body.clone(),
+                            is_test_assertion: false,
+                            is_rw: decl.is_rw,
+                            is_raw: false,
+                            is_method: true,
+                            empty_sig: false,
+                            is_stub: Self::is_stub_routine_body(&decl.body),
+                            return_type: None,
+                            is_default: decl.is_default_candidate,
+                            deprecated_message: None,
+                            source_file: self.current_source_file(),
+                            decl_order: crate::runtime::resolution::next_decl_order(),
+                            compiled: None,
+                            body_fp_cache: std::sync::OnceLock::new(),
+                            body_facts_cache: std::sync::OnceLock::new(),
+                            rw_tail_expr: None,
+                        };
+                        self.registry_mut().functions.insert(
+                            Symbol::intern(&qualified_name),
+                            std::sync::Arc::new(func_def),
+                        );
+                        self.fn_resolve_gen += 1;
+                    }
+                    if decl.is_my {
+                        let (my_params, my_param_defs) =
+                            method_sub_form_params(&effective_params, &effective_param_defs);
+                        let func_def = crate::ast::FunctionDef {
+                            package: Symbol::intern(name),
+                            name: Symbol::intern(&resolved_method_name),
+                            params: my_params,
+                            param_defs: my_param_defs,
+                            body: decl.body.clone(),
+                            is_test_assertion: false,
+                            is_rw: decl.is_rw,
+                            is_raw: false,
+                            is_method: true,
+                            empty_sig: false,
+                            is_stub: Self::is_stub_routine_body(&decl.body),
+                            return_type: None,
+                            is_default: decl.is_default_candidate,
+                            deprecated_message: None,
+                            source_file: self.current_source_file(),
+                            decl_order: crate::runtime::resolution::next_decl_order(),
+                            compiled: None,
+                            body_fp_cache: std::sync::OnceLock::new(),
+                            body_facts_cache: std::sync::OnceLock::new(),
+                            rw_tail_expr: None,
+                        };
+                        self.registry_mut().functions.insert(
+                            Symbol::intern(&resolved_method_name),
+                            std::sync::Arc::new(func_def.clone()),
+                        );
+                        let qualified_name = format!("{}::{}", name, resolved_method_name);
+                        self.registry_mut().functions.insert(
+                            Symbol::intern(&qualified_name),
+                            std::sync::Arc::new(func_def),
+                        );
+                        self.fn_resolve_gen += 1;
+                        self.mark_my_scoped_package_item(qualified_name);
                     }
                 }
                 Stmt::HasDecl { .. } => {

--- a/t/augment-method-lexical-scoping.t
+++ b/t/augment-method-lexical-scoping.t
@@ -1,0 +1,71 @@
+use Test;
+use MONKEY-TYPING;
+
+# ADR-0019 D3-5: `augment class` now mirrors the class/role walkers' handling
+# of `my method` / `our method` (not part of the method table; registered as
+# functions instead) and privacy-aware duplicate-method detection (a private
+# and a public method of the same name coexist). Verified against raku.
+
+plan 8;
+
+# `my method` inside augment: not in the method table, but callable
+# lexically from a sibling method declared in the same augment block.
+{
+    class LexMethod { }
+    augment class LexMethod {
+        my method secret { 'secret' }
+        method pub { secret(self) }
+    }
+    is LexMethod.new.can('secret').elems, 0, 'my method is not in the method table';
+    is LexMethod.new.pub, 'secret', 'my method is callable lexically from a sibling method';
+}
+
+# `our method` inside augment: not in the method table, but callable as a
+# package-qualified sub.
+{
+    class PkgMethod { }
+    augment class PkgMethod {
+        our method pkg { 'pkg' }
+    }
+    is PkgMethod.new.can('pkg').elems, 0, 'our method is not in the method table';
+    is PkgMethod::pkg(PkgMethod.new), 'pkg', 'our method is callable as Package::name(invocant)';
+    dies-ok { PkgMethod.new.pkg }, 'our method is not callable as a method';
+}
+
+# Privacy-aware duplicate detection: a public and a private method of the
+# same name coexist (separate namespaces), matching the class/role walkers.
+{
+    class PrivPub {
+        method pub { 'pub' }
+    }
+    augment class PrivPub {
+        method !pub { 'priv-pub' }
+    }
+    is PrivPub.new.pub, 'pub', 'public method unaffected by a same-named private augment method';
+}
+
+# Same-privacy redeclaration across class + augment is still rejected.
+{
+    class SamePriv {
+        method !priv { 'one' }
+    }
+    dies-ok {
+        EVAL q[
+            use MONKEY-TYPING;
+            augment class SamePriv {
+                method !priv { 'two' }
+            }
+        ];
+    }, 'redeclaring the same private method via augment still errors';
+}
+
+# Multi methods declared via augment still coexist with the original.
+{
+    class MultiAugment {
+        multi method greet(Int $x) { "int:$x" }
+    }
+    augment class MultiAugment {
+        multi method greet(Str $x) { "str:$x" }
+    }
+    is MultiAugment.new.greet("hi"), 'str:hi', 'multi method added via augment still dispatches';
+}


### PR DESCRIPTION
## Summary
- `augment_class`'s `MethodDecl` arm diverged from the class/role walkers in three user-visible ways, confirmed against `raku`:
  - `my method` inside `augment class` leaked into the method table (`Foo.can('secret')` wrongly returned it).
  - `our method` was directly callable as a method instead of only via the package-qualified sub `Foo::pkg(invocant)`.
  - Duplicate-method detection was not privacy-aware, so a public `method foo` and a private `method !foo` declared across a `class`/`augment class` pair wrongly collided.
- Mirror the class walker's fix: `MethodDef.is_my` now stores `is_submethod`, `is_lexical_only`/`is_our_only` gating excludes `my`/`our` methods from the table, the `our`/`my` function forms are registered, and duplicate detection compares `is_private`.
- Closes ADR-0019 D3-5 (see the updated ADR and `news/2026-08/d3-5-augment-method-drift-fixed.md` for detail). Remaining `augment_class` gaps (`handles` forwarders, custom traits, `is export`, BUILD/TWEAK `:$!attr` validation) are documented as still-open, independently-scoped follow-ups.

## Test plan
- [x] New `t/augment-method-lexical-scoping.t`, verified line-for-line against `raku`.
- [x] `make test` — full pass (27,872 tests).
- [x] `MUTSU_FUDGE=1` roast run of the 94 whitelisted `S12-methods`/`S12-attributes`/`S12-class`/`S12-construction`/`S14-roles` files against the release binary — all pass.
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)