### PR TITLE
fix(runtime): synthesize handles forwarders in augment class (ADR-0019 D3-5)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -670,6 +670,16 @@ walkers wholesale is not possible before then.
   export`/`export_tags`, and BUILD/TWEAK `:$!attr` validation remain absent from `augment_class`
   (present at the class walker, `handles` also at the role walker) — each is a separate,
   independently-scoped gap, not reconciled by this slice.
+  **`handles` forwarder synthesis landed as a same-day follow-up (2026-08-08)**: `augment_class`'s
+  `MethodDecl` arm now synthesizes `Name`/`Rename` forwarder methods the same way the class/role
+  walkers do (`augment class Foo { method inner() handles 'uc' {...} }` previously left
+  `Foo.new.uc` dispatching to the built-in `Cool` coercion instead of forwarding to `inner`).
+  `Wildcard`/`Regex` specs are wired through the same `class_def.wildcard_handles` list the other
+  two walkers populate, but a wildcard handle losing to a same-named built-in `Cool`/`Any` method
+  turned out to be a pre-existing bug shared by *all three* walkers (reproduces with a plain
+  `class`-declared `handles *`, not just `augment`), so it is out of D3's walker-drift scope and is
+  tracked separately as `todo/tickets/wildcard-handles-loses-to-builtin-cool-methods.md`. Custom
+  traits, `is export`, and BUILD/TWEAK validation remain open `augment_class` gaps.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
   expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
   names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies

--- a/news/2026-08/augment-class-handles-forwarder.md
+++ b/news/2026-08/augment-class-handles-forwarder.md
@@ -1,0 +1,17 @@
+# augment class methods now synthesize `handles` forwarders
+
+`augment class Foo { method inner() handles 'uc' {...} }` previously did nothing with the
+`handles` clause: `Foo.new.uc` dispatched straight to the built-in `Cool.uc` coercion instead of
+forwarding to `inner`'s return value, because `augment_class`'s `MethodDecl` arm never synthesized
+the delegation methods the ordinary class and role body walkers already build for `handles`.
+
+Fixed by porting the same `Name`/`Rename` forwarder synthesis
+(`registration_class.rs::make_delegation_method`) the class walker already uses, keyed off the
+same `CompiledMethodDecl.handles` field the ADR-0019 D3 unification gave all three walkers.
+Verified line-for-line against `raku` with `t/augment-method-handles-forwarder.t`.
+
+`Wildcard`/`Regex` handle specs are wired the same way (pushed onto `class_def.wildcard_handles`),
+but testing surfaced that a wildcard handle loses to a same-named built-in `Cool`/`Any` method
+(e.g. `.uc`) on *any* class, not just an augmented one — a pre-existing, unrelated dispatch-order
+bug now tracked at `todo/tickets/wildcard-handles-loses-to-builtin-cool-methods.md` rather than
+folded into this fix.

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1,6 +1,7 @@
-use super::registration_class::apply_resolved_handles;
+use super::registration_class::{apply_resolved_handles, make_delegation_method};
 use super::registration_class_body_method_forms::method_sub_form_params;
 use super::*;
+use crate::ast::HandleSpec;
 use crate::symbol::Symbol;
 
 impl Interpreter {
@@ -372,6 +373,44 @@ impl Interpreter {
                         );
                         self.fn_resolve_gen += 1;
                         self.mark_my_scoped_package_item(qualified_name);
+                    }
+                    // ADR-0019 D3-5 follow-up: `handles` on a method
+                    // synthesizes forwarder methods, matching the
+                    // class/role walkers (confirmed against `raku`:
+                    // `augment class Foo { method inner() handles 'uc'
+                    // {...} }` makes `Foo.new.uc` dispatch through
+                    // `inner`).
+                    if !decl.handles.is_empty()
+                        && let Some(class_def) = self.registry_mut().classes.get_mut(name)
+                    {
+                        let source_attr_marker = format!("&{}", resolved_method_name);
+                        for spec in &decl.handles {
+                            match spec {
+                                HandleSpec::Name(target) => {
+                                    class_def
+                                        .methods
+                                        .entry(target.clone())
+                                        .or_default()
+                                        .push(make_delegation_method(&source_attr_marker, target));
+                                }
+                                HandleSpec::Rename { exposed, target } => {
+                                    class_def
+                                        .methods
+                                        .entry(exposed.clone())
+                                        .or_default()
+                                        .push(make_delegation_method(&source_attr_marker, target));
+                                }
+                                HandleSpec::Wildcard => {
+                                    class_def.wildcard_handles.push(source_attr_marker.clone());
+                                }
+                                HandleSpec::Regex(pattern) => {
+                                    class_def
+                                        .wildcard_handles
+                                        .push(format!("{}:regex:{}", source_attr_marker, pattern));
+                                }
+                                HandleSpec::Type(_) => {}
+                            }
+                        }
                     }
                 }
                 Stmt::HasDecl { .. } => {

--- a/t/augment-method-handles-forwarder.t
+++ b/t/augment-method-handles-forwarder.t
@@ -1,0 +1,32 @@
+use Test;
+use MONKEY-TYPING;
+
+# ADR-0019 D3-5 follow-up: `handles` on an augment-declared method now
+# synthesizes forwarder methods, matching the class/role walkers. Verified
+# against raku.
+
+plan 2;
+
+# Plain `handles 'name'`
+{
+    class Forward1 { }
+    augment class Forward1 {
+        method inner() handles 'uc' { 'hello' }
+    }
+    is Forward1.new.uc, 'HELLO', 'handles Name forwards to the target method';
+}
+
+# Renamed `handles (exposed => 'target')`
+{
+    class Forward2 { }
+    augment class Forward2 {
+        method inner() handles (up => 'uc') { 'hello' }
+    }
+    is Forward2.new.up, 'HELLO', 'handles Rename forwards under the exposed name';
+}
+
+# NOTE: `handles *` (Wildcard) is deliberately not covered here — it hits a
+# separate, pre-existing bug shared by the class/role walkers too (a
+# built-in Cool method like `.uc` wins over wildcard delegation instead of
+# the reverse), not an augment-specific drift. See
+# todo/tickets/wildcard-handles-loses-to-builtin-cool-methods.md.

--- a/todo/tickets/wildcard-handles-loses-to-builtin-cool-methods.md
+++ b/todo/tickets/wildcard-handles-loses-to-builtin-cool-methods.md
@@ -1,0 +1,44 @@
+# `handles *` (wildcard delegation) loses to built-in Cool/Any methods
+
+`handles *` on a method (or attribute) is supposed to let the class intercept
+*any* method call not otherwise defined and forward it to the delegate. In
+`raku`, this wins even over a built-in method the object would otherwise
+inherit from `Cool`/`Any` — e.g. `.uc`:
+
+```raku
+class Forward {
+    method inner() handles * { 'hello' }
+}
+say Forward.new.uc;   # raku: HELLO (forwarded to 'hello'.uc)
+```
+
+mutsu instead resolves `.uc` through the normal built-in dispatch path before
+ever reaching the wildcard-delegation fallback in
+`src/runtime/methods_instance_ops.rs` ("Wildcard delegation (`handles *`) and
+FALLBACK method dispatch" block, ~line 1712), so `Forward.new.uc` returns the
+upper-cased default stringification of the instance (`FORWARD()`) instead of
+forwarding to the delegate's `.uc`.
+
+A method name with no built-in collision (e.g. a custom method name) is
+unaffected — wildcard delegation only loses when the target method name also
+happens to be a real built-in method on `Cool`/`Any`.
+
+Reproduced identically for a plain `class`-declared wildcard handle (not just
+`augment class`), so this is not walker-specific drift (ADR-0019 D3) — it is
+a dispatch-ordering bug: the built-in method table is consulted before the
+wildcard-delegation fallback, when `raku`'s semantics require the reverse
+order for a class that declares `handles *`.
+
+Minimal repro: `/tmp/rk9.raku` in the investigating session — recreate with:
+
+```raku
+class Forward4 {
+    method inner() handles * { 'hello' }
+}
+say Forward4.new.uc;
+```
+
+Root cause not yet investigated in depth — needs tracing how built-in method
+resolution short-circuits before the wildcard-handles fallback runs (likely
+in `class_dispatch.rs`/`methods_classhow_dispatch.rs`'s owner/candidate
+resolution, ahead of `methods_instance_ops.rs`'s fallback block).


### PR DESCRIPTION
## Summary
- `augment_class`'s `MethodDecl` arm ignored a method's `handles` clause entirely: `augment class Foo { method inner() handles 'uc' {...} }` left `Foo.new.uc` dispatching to the built-in `Cool` coercion instead of forwarding to `inner`'s return value, unlike the class/role walkers which already synthesize these forwarders.
- Port the same `Name`/`Rename` forwarder synthesis (`registration_class::make_delegation_method`) using the `CompiledMethodDecl.handles` field the D3 unification already gave all three walkers.
- `Wildcard`/`Regex` specs are wired the same way (`class_def.wildcard_handles`), but testing found a wildcard handle losing to a same-named built-in `Cool`/`Any` method (e.g. `.uc`) is a separate, pre-existing bug reproducible on a plain `class`-declared `handles *` too — not augment-specific drift, so it's filed as `todo/tickets/wildcard-handles-loses-to-builtin-cool-methods.md` rather than folded into this fix.
- Follow-up to #6055 (ADR-0019 D3-5); updates the ADR checklist entry accordingly.

## Test plan
- [x] New `t/augment-method-handles-forwarder.t`, verified line-for-line against `raku`.
- [x] `make test` — full pass (27,874 tests).
- [x] `MUTSU_FUDGE=1` roast run of the 94 whitelisted `S12-methods`/`S12-attributes`/`S12-class`/`S12-construction`/`S14-roles` files against the release binary — all pass.
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)