### PR TITLE
fix(encoding): make the streaming decoder honour its own encoding

### DIFF
--- a/news/2026-08/streaming-decoder-honours-its-encoding.md
+++ b/news/2026-08/streaming-decoder-honours-its-encoding.md
@@ -1,0 +1,38 @@
+# The streaming `Encoding::Decoder` honours the encoding it was built with
+
+`Encoding::Registry.find('iso-8859-1').decoder()` decoded its buffer as UTF-8.
+Every byte above 0x7F therefore came back as U+FFFD:
+
+```raku
+my $d = Encoding::Registry.find('iso-8859-1').decoder();
+$d.add-bytes(Buf.new(0xE1, 0xE2, 0xB5));
+say $d.consume-all-chars();   # raku: "áâµ"    mutsu: "\x[FFFD]\x[FFFD]"
+```
+
+`Buf.decode('latin-1')` was always right — the gap was only in the *streaming*
+decoder, whose `decode_bytes` special-cased `utf8-c8` and otherwise ran
+`String::from_utf8_lossy` regardless of the `encoding` attribute it had stored.
+`consume-all-chars`, `consume-available-chars` and `consume-line-chars` all went
+through it.
+
+## Fix
+
+`builtins` exposes `decode_bytes_with_encoding_label`, which resolves a label
+through the same alias table `.decode` uses (`latin-1` / `latin1` /
+`iso-8859-1` are one encoding) and decodes with the existing per-encoding
+decoder. `decode_bytes` now consults it first and only falls back to the lossy
+UTF-8 read on a decode error, which is what a streaming decoder needs for an
+incomplete trailing sequence.
+
+`decode_available` gained a companion gate, `is_single_byte_encoding_label`: for
+a single-byte encoding the whole buffer is always complete, so it is handed back
+in one piece instead of running UTF-8's "back off to the last valid sequence"
+walk (which would have discarded every high byte as an incomplete sequence).
+
+Pinned by `t/streaming-decoder-encoding.t`.
+
+## Effect
+
+Cro builds its HTTP header decoder exactly this way, so any header value outside
+ASCII was mangled. `t/http-request-parser.rakutest`'s "Field value can be any
+printable char including latin-1 range" now passes.

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -144,6 +144,32 @@ pub(crate) fn num_to_rat_with_epsilon(f: f64, epsilon: f64) -> Value {
     crate::value::make_rat(numer, q1)
 }
 
+/// Decode `bytes` with the named encoding, resolving the label through the same
+/// alias table `.decode` uses (`latin-1`/`latin1`/`iso-8859-1` are one encoding).
+/// `None` when the label is not a known encoding, so the caller can fall back.
+///
+/// The streaming `Encoding::Decoder` needs this: it used to decode every buffer
+/// as UTF-8 regardless of the encoding it was built with, so
+/// `Encoding::Registry.find('iso-8859-1').decoder()` — which is exactly how
+/// Cro's HTTP header decoder is built — turned every high byte into U+FFFD.
+pub(crate) fn decode_bytes_with_encoding_label(
+    bytes: &[u8],
+    label: &str,
+) -> Option<Result<String, RuntimeError>> {
+    let normalized = normalize_builtin_encoding_label(label)?;
+    Some(decode_bytes_with_builtin_encoding(bytes, &normalized))
+}
+
+/// True when the label names a single-byte encoding, i.e. one where every byte
+/// is a complete character. A streaming decoder can hand back its whole buffer
+/// for these instead of holding an incomplete-sequence tail as it must for UTF-8.
+pub(crate) fn is_single_byte_encoding_label(label: &str) -> bool {
+    matches!(
+        normalize_builtin_encoding_label(label).as_deref(),
+        Some("ascii" | "iso-8859-1" | "windows-1251" | "windows-1252")
+    )
+}
+
 fn normalize_builtin_encoding_label(name: &str) -> Option<String> {
     let lowered = name.to_lowercase();
     let normalized = match lowered.as_str() {

--- a/src/runtime/native_methods/encoding.rs
+++ b/src/runtime/native_methods/encoding.rs
@@ -53,6 +53,17 @@ fn value_to_byte(v: &Value) -> Option<u8> {
 fn decode_bytes(bytes: &[u8], translate_nl: bool, encoding: &str) -> String {
     let s = if encoding == "utf8-c8" {
         crate::runtime::utf8_c8::decode_utf8_c8(bytes)
+    } else if !encoding.is_empty()
+        && let Some(Ok(decoded)) =
+            crate::builtins::decode_bytes_with_encoding_label(bytes, encoding)
+    {
+        // The decoder's own encoding wins. Falling through to UTF-8 turned every
+        // latin-1 high byte into U+FFFD, which is how Cro's HTTP header decoder
+        // (`Encoding::Registry.find('iso-8859-1').decoder()`) mangled header
+        // values. A decode *error* (e.g. a partial UTF-8 sequence at the end of
+        // the buffer) still falls back to the lossy read below, since a
+        // streaming decoder must never hard-fail on an incomplete tail.
+        decoded
     } else {
         String::from_utf8_lossy(bytes).into_owned()
     };
@@ -69,6 +80,14 @@ fn decode_available(bytes: &[u8], encoding: &str) -> (String, Vec<u8>) {
     if encoding == "utf8-c8" {
         // utf8-c8 can always decode all bytes (invalid ones become synthetics)
         let s = crate::runtime::utf8_c8::decode_utf8_c8(bytes);
+        return (s, Vec::new());
+    }
+    // A single-byte encoding never has an incomplete trailing sequence, so the
+    // whole buffer is available; only UTF-8 needs the "back off to the last
+    // complete sequence" walk below.
+    if crate::builtins::is_single_byte_encoding_label(encoding)
+        && let Some(Ok(s)) = crate::builtins::decode_bytes_with_encoding_label(bytes, encoding)
+    {
         return (s, Vec::new());
     }
     let mut end = bytes.len();

--- a/t/streaming-decoder-encoding.t
+++ b/t/streaming-decoder-encoding.t
@@ -1,0 +1,58 @@
+use Test;
+
+plan 8;
+
+# The streaming `Encoding::Decoder` used to decode every buffer as UTF-8 no
+# matter which encoding it was built with, so a latin-1 decoder turned every
+# high byte into U+FFFD. Cro builds its HTTP header decoder exactly that way
+# (`Encoding::Registry.find('iso-8859-1').decoder()`), which mangled any header
+# value outside ASCII.
+
+my $high = Buf.new(0xE1, 0xE2, 0xB5);   # latin-1 for a-acute, a-circumflex, micro
+
+{
+    my $d = Encoding::Registry.find('iso-8859-1').decoder();
+    $d.add-bytes($high);
+    is $d.consume-all-chars(), "\c[LATIN SMALL LETTER A WITH ACUTE]\c[LATIN SMALL LETTER A WITH CIRCUMFLEX]\c[MICRO SIGN]",
+        'consume-all-chars honours a latin-1 decoder';
+}
+
+{
+    my $d = Encoding::Registry.find('latin-1').decoder();
+    $d.add-bytes($high);
+    is $d.consume-available-chars().chars, 3,
+        'consume-available-chars hands back every byte of a single-byte encoding';
+}
+
+{
+    my $d = Encoding::Registry.find('iso-8859-1').decoder();
+    $d.set-line-separators(["\r\n", "\n"]);
+    $d.add-bytes(Buf.new(0xE1, 0x0D, 0x0A, 0xE2, 0x0D, 0x0A));
+    is $d.consume-line-chars(:chomp), "\c[LATIN SMALL LETTER A WITH ACUTE]",
+        'consume-line-chars decodes a latin-1 line';
+    is $d.consume-line-chars(:chomp), "\c[LATIN SMALL LETTER A WITH CIRCUMFLEX]",
+        'and the next one';
+    nok $d.consume-line-chars(:chomp).defined, 'then an undefined Str';
+}
+
+# UTF-8 stays intact, including the incomplete-tail handling
+# `consume-available-chars` needs for a multi-byte encoding.
+{
+    my $d = Encoding::Registry.find('utf-8').decoder();
+    $d.add-bytes("h\c[LATIN SMALL LETTER E WITH ACUTE]llo".encode('utf-8'));
+    is $d.consume-all-chars(), "h\c[LATIN SMALL LETTER E WITH ACUTE]llo",
+        'a utf-8 decoder still decodes utf-8';
+}
+
+{
+    my $bytes = "\c[LATIN SMALL LETTER E WITH ACUTE]x".encode('utf-8');
+    my $d = Encoding::Registry.find('utf-8').decoder();
+    $d.add-bytes($bytes.subbuf(0, 1));           # first half of the 2-byte sequence
+    is $d.consume-available-chars(), '',
+        'an incomplete utf-8 sequence is held back';
+    # (`consume-available-chars` alone is not pinned here: raku holds the final
+    # grapheme back in case a combining mark follows, mutsu does not.)
+    $d.add-bytes($bytes.subbuf(1));
+    is $d.consume-all-chars(), "\c[LATIN SMALL LETTER E WITH ACUTE]x",
+        'and completes once the rest arrives';
+}


### PR DESCRIPTION
## Problem

```raku
my $d = Encoding::Registry.find('iso-8859-1').decoder();
$d.add-bytes(Buf.new(0xE1, 0xE2, 0xB5));
say $d.consume-all-chars();   # raku: "áâµ"    mutsu: "\x[FFFD]\x[FFFD]"
```

`Buf.decode('latin-1')` was always right — the gap was only in the *streaming* decoder, whose `decode_bytes` special-cased `utf8-c8` and otherwise ran `String::from_utf8_lossy` regardless of the `encoding` attribute it had stored. `consume-all-chars`, `consume-available-chars` and `consume-line-chars` all went through it.

## Fix

- `builtins::decode_bytes_with_encoding_label` — resolves a label through the same alias table `.decode` uses (`latin-1` / `latin1` / `iso-8859-1` are one encoding) and decodes with the existing per-encoding decoder. `decode_bytes` consults it first and falls back to the lossy UTF-8 read only on a decode *error*, which is what a streaming decoder needs for an incomplete trailing sequence.
- `builtins::is_single_byte_encoding_label` — for a single-byte encoding the whole buffer is always complete, so `decode_available` hands it back in one piece instead of running UTF-8's "back off to the last valid sequence" walk, which would have discarded every high byte as an incomplete sequence.

## Effect

Cro builds its HTTP header decoder exactly this way, so any header value outside ASCII was mangled. `t/http-request-parser.rakutest`'s "Field value can be any printable char including latin-1 range" now passes; the file is down to a single remaining failure.

## Tests

- New pin: `t/streaming-decoder-encoding.t` — latin-1 through all three consume methods, plus UTF-8 regression cover including the incomplete-sequence hold-back. Verified against real `raku`. (One case is deliberately not pinned: raku's `consume-available-chars` holds the final grapheme back in case a combining mark follows; mutsu does not, and that is a separate gap.)
- `make test` green (2948 files, 27883 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)