### PR TITLE
fix(encoding): NFC-normalize decoded strings

### DIFF
--- a/news/2026-08/decoded-strings-are-nfc.md
+++ b/news/2026-08/decoded-strings-are-nfc.md
@@ -1,0 +1,41 @@
+# A decoded string is NFC-normalized, like every other Raku string
+
+Raku's `Str` is NFG, so a string built from bytes is normalized at creation.
+mutsu normalized string *literals* at parse time
+(`parser/primary/string/escapes.rs`) but never normalized `.decode` output, so a
+decoded string compared unequal to an identical literal:
+
+```raku
+my $s = Buf.new(0xE2, 0x84, 0xA6).decode('utf-8');   # U+2126 OHM SIGN
+say $s.ords;                     # (937)     -- looks composed
+say $s.encode('utf-8').elems;    # raku: 2   mutsu: 3
+say $s eq "\x[03A9]";            # raku: True  mutsu: False
+```
+
+`.ords` normalizes on read, which is what made the bug so hard to see: every
+diagnostic printed the same code points while `eq`, `cmp`, `.encode` and hash
+lookup all disagreed.
+
+## Fix
+
+`decode_bytes_with_builtin_encoding` NFC-normalizes its result, via a quick
+check (`is_nfc_quick`) that returns the string untouched — and allocation-free —
+for the overwhelmingly common already-normalized case. `utf8-c8` is exempt:
+keeping invalid bytes as synthetic code points is the whole point of that
+encoding, and its round-trip must be exact.
+
+Pinned by `t/decoded-strings-are-nfc.t`.
+
+## Effect
+
+Found while closing out Cro's `t/http-request-parser.rakutest`. Cro
+percent-decodes a query string by turning `%XX` escapes into bytes and decoding
+them, so `?%E2%84%A6%E2%84%A6=2omega` produced a key that *printed* as `ΩΩ` but
+that no lookup with a literal `ΩΩ` could find:
+
+```raku
+*.query-hash eqv { 'a/b' => '2 3', love => '♥', ΩΩ => '2omega' },   # was False
+*.query-value('ΩΩ') eqv '2omega';                                    # was Any
+```
+
+That was the file's last remaining failure; it is now fully green under mutsu.

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -206,10 +206,37 @@ fn decode_utf16_bytes(bytes: &[u8], big_endian: bool) -> Result<String, RuntimeE
         .map_err(|()| RuntimeError::new("Malformed UTF-16 string: unpaired surrogate (line 1)"))
 }
 
+/// NFC-normalize a decoded string. Raku's `Str` is NFG, so any string built from
+/// bytes is normalized at creation: `Buf.new(0xE2,0x84,0xA6).decode('utf-8')`
+/// composes U+2126 OHM SIGN to U+03A9 GREEK CAPITAL LETTER OMEGA, and the result
+/// `eq`s a literal `"Ω"`. mutsu normalizes string *literals* at parse time
+/// (`parser/primary/string/escapes.rs`) but did not normalize decode output, so
+/// the two compared unequal even though `.ords` — which normalizes on read —
+/// reported the same code points. Cro's percent-decoding of a query key hit
+/// exactly this: `%E2%84%A6%E2%84%A6` decoded to a key no lookup could find.
+fn nfc(s: String) -> String {
+    use unicode_normalization::{IsNormalized, UnicodeNormalization, is_nfc_quick};
+    // `is_nfc_quick` answers `Yes` without allocating for the overwhelmingly
+    // common already-normalized case (all-ASCII text answers immediately).
+    match is_nfc_quick(s.chars()) {
+        IsNormalized::Yes => s,
+        _ => s.nfc().collect(),
+    }
+}
+
 fn decode_bytes_with_builtin_encoding(
     bytes: &[u8],
     encoding_name: &str,
 ) -> Result<String, RuntimeError> {
+    // utf8-c8 deliberately keeps invalid bytes as synthetic code points, so it
+    // must not be normalized — that is the whole point of the encoding.
+    if encoding_name == "utf8-c8" {
+        return Ok(crate::runtime::utf8_c8::decode_utf8_c8(bytes));
+    }
+    decode_bytes_unnormalized(bytes, encoding_name).map(nfc)
+}
+
+fn decode_bytes_unnormalized(bytes: &[u8], encoding_name: &str) -> Result<String, RuntimeError> {
     match encoding_name {
         "utf8-c8" => Ok(crate::runtime::utf8_c8::decode_utf8_c8(bytes)),
         "ascii" => {

--- a/t/decoded-strings-are-nfc.t
+++ b/t/decoded-strings-are-nfc.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 8;
+
+# Raku's Str is NFG, so a string built from bytes is normalized at creation.
+# mutsu normalized string *literals* at parse time but not `.decode` output, so
+# a decoded string compared unequal to an identical literal even though `.ords`
+# — which normalizes on read — reported the same code points.
+
+{
+    # U+2126 OHM SIGN composes to U+03A9 GREEK CAPITAL LETTER OMEGA.
+    my $s = Buf.new(0xE2, 0x84, 0xA6).decode('utf-8');
+    is $s, "\x[03A9]", 'a decoded OHM SIGN equals a literal OMEGA';
+    is $s.encode('utf-8').elems, 2, 'and is stored composed';
+}
+
+{
+    # "e" + COMBINING ACUTE composes to U+00E9.
+    my $s = Buf.new(0x65, 0xCC, 0x81).decode('utf-8');
+    is $s, "\x[00E9]", 'a decoded decomposed e-acute equals the composed literal';
+    is $s.chars, 1, 'and is one character';
+}
+
+{
+    # latin-1 has no combining marks, so decoding is unaffected.
+    my $s = Buf.new(0xE1, 0xE2).decode('latin-1');
+    is $s.chars, 2, 'a latin-1 decode is unchanged';
+    is $s, "\x[00E1]\x[00E2]", 'and holds the right characters';
+}
+
+{
+    # utf8-c8 must NOT be normalized: keeping invalid bytes as synthetics is the
+    # whole point of the encoding, and a round-trip has to be exact.
+    my $b = Buf.new(0xC3, 0x28);
+    is $b.decode('utf8-c8').encode('utf8-c8').list, (0xC3, 0x28),
+        'utf8-c8 still round-trips invalid bytes';
+}
+
+{
+    # A decoded string is usable as a hash key against a literal (this is what
+    # broke Cro's percent-decoded query keys).
+    my %h;
+    %h{Buf.new(0xE2, 0x84, 0xA6).decode('utf-8')} = 'v';
+    is %h{"\x[03A9]"}, 'v', 'a decoded string works as a hash key';
+}


### PR DESCRIPTION
## Problem

Raku's `Str` is NFG, so a string built from bytes is normalized at creation. mutsu normalized string *literals* at parse time (`parser/primary/string/escapes.rs`) but never normalized `.decode` output:

```raku
my $s = Buf.new(0xE2, 0x84, 0xA6).decode('utf-8');   # U+2126 OHM SIGN
say $s.ords;                     # (937)     -- looks composed
say $s.encode('utf-8').elems;    # raku: 2   mutsu: 3
say $s eq "\x[03A9]";            # raku: True  mutsu: False
```

`.ords` normalizes on read, which is what hid the bug: every diagnostic printed the same code points while `eq`, `cmp`, `.encode` and hash lookup all disagreed.

## Fix

`decode_bytes_with_builtin_encoding` NFC-normalizes its result, behind an `is_nfc_quick` gate so already-normalized text (all ASCII, in practice) is returned untouched and unallocated.

`utf8-c8` is exempt: keeping invalid bytes as synthetic code points is the whole point of that encoding, and its round-trip must stay exact (pinned in the test).

## Effect

Found while closing out Cro's `t/http-request-parser.rakutest`. Cro percent-decodes a query string by turning `%XX` escapes into bytes and decoding them, so `?%E2%84%A6%E2%84%A6=2omega` produced a key that *printed* as `ΩΩ` but that no lookup with a literal `ΩΩ` could find:

```raku
*.query-hash eqv { 'a/b' => '2 3', love => '♥', ΩΩ => '2omega' },   # was False
*.query-value('ΩΩ') eqv '2omega';                                    # was Any
```

That was the file's last remaining failure — with #6056, #6057 and #6059 it is now fully green under mutsu.

## Tests

- New pin: `t/decoded-strings-are-nfc.t` (OHM SIGN, decomposed e-acute, latin-1 unaffected, utf8-c8 round-trip preserved, decoded string as a hash key). Verified against real `raku`.
- `make test` green (2948 files, 27881 tests).
- Extra local sweep given the blast radius: whitelisted `S05-*`, `S15-*` and `S32-*` roast (435 files, 143k tests) — green. (Three `S32-str/*-encode-decode.t` need `scripts/run-roast-test.sh` for their sample-file paths; run that way they pass.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)