### PR TITLE
fix(runtime): wire is export, custom traits, BUILD/TWEAK validation into augment_class (ADR-0019 D3-6)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -680,6 +680,22 @@ walkers wholesale is not possible before then.
   `class`-declared `handles *`, not just `augment`), so it is out of D3's walker-drift scope and is
   tracked separately as `todo/tickets/wildcard-handles-loses-to-builtin-cool-methods.md`. Custom
   traits, `is export`, and BUILD/TWEAK validation remain open `augment_class` gaps.
+  **D3-6 landed 2026-08-08**, closing the last three drift points by porting the class walker's
+  logic verbatim: BUILD/TWEAK's `:$!attr` parameters are now validated against a pre-scanned set of
+  the class's own attribute names (existing plus any this same augmentation declares), rejecting an
+  undeclared one with `X::Attribute::Undeclared` — confirmed against `raku`, which rejects this at
+  compile time. `is export` and custom-trait (`trait_mod:<is>`, including `is native`) handling are
+  now wired identically to the class walker. Measuring against `raku` while building this slice
+  surfaced two further bugs that turned out to be **pre-existing in the class walker itself**, not
+  augment-specific drift, so they are out of D3's scope and tracked separately: `is export` on a
+  plain (non-operator) method name does nothing on any walker (only the operator-categorical sub-form
+  path — `method infix:<as> is export` and friends — actually works;
+  `todo/tickets/method-is-export-non-operator-name-does-nothing.md`), and a user `trait_mod:<is>`
+  multi typed `(Method $m, ...)` never dispatches because the code-object value built for the
+  about-to-be-installed method is a plain `Sub`, not a `Method`, so the type-checked parameter never
+  matches (`todo/tickets/method-typed-trait-mod-is-dispatch-never-matches.md`). D3-6 makes
+  `augment_class` reach exact parity with the class walker, including that walker's own
+  pre-existing limits — it does not fix either underlying bug.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
   expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
   names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1,4 +1,6 @@
-use super::registration_class::{apply_resolved_handles, make_delegation_method};
+use super::registration_class::{
+    AttrValidationCtx, apply_resolved_handles, make_delegation_method,
+};
 use super::registration_class_body_method_forms::method_sub_form_params;
 use super::*;
 use crate::ast::HandleSpec;
@@ -163,6 +165,23 @@ impl Interpreter {
                 other => vec![other],
             })
             .collect();
+        // ADR-0019 D3-6: BUILD/TWEAK's `:$!attr` validation (below) needs the
+        // full set of attribute names visible on this class — those already
+        // registered plus any this augmentation itself declares — matching
+        // the class walker's pre-scanned `class_own_attrs` (confirmed against
+        // `raku`: `augment class Foo { method BUILD(:$!y) {} }` with no
+        // declared `$.y`/`$!y` anywhere reports X::Attribute::Undeclared).
+        let mut own_attrs: HashSet<String> = self
+            .registry()
+            .classes
+            .get(name)
+            .map(|cd| cd.attributes.iter().map(|a| a.name.clone()).collect())
+            .unwrap_or_default();
+        for stmt in &flattened_body {
+            if let Stmt::HasDecl { .. } = stmt {
+                own_attrs.insert(crate::opcode::CompiledAttrDecl::from_stmt(stmt, None).name);
+            }
+        }
         for stmt in flattened_body {
             match stmt {
                 Stmt::MethodDecl { .. } => {
@@ -174,6 +193,30 @@ impl Interpreter {
                     // evaluated from the raw AST here rather than through a
                     // precompiled `method_name_chunks` cursor.
                     let decl = crate::opcode::CompiledMethodDecl::from_stmt(stmt);
+                    // ADR-0019 D3-6: matching the class walker, an augmented
+                    // BUILD/TWEAK submethod's `:$!attr` parameters must refer
+                    // to declared attributes; reject undeclared ones with
+                    // X::Attribute::Undeclared.
+                    {
+                        let mn = decl.name.resolve();
+                        if mn == "BUILD" || mn == "TWEAK" {
+                            for pd in &decl.param_defs {
+                                if pd.name.starts_with('!') && pd.name != "!" {
+                                    let attr_name = &pd.name[1..];
+                                    if !own_attrs.contains(attr_name) {
+                                        let ctx = AttrValidationCtx {
+                                            attrs: &own_attrs,
+                                            pkg_name: name,
+                                            pkg_kind: "class",
+                                        };
+                                        let err = Self::undeclared_attr_error(&ctx, attr_name, "!");
+                                        self.set_current_package(saved_package);
+                                        return Err(err);
+                                    }
+                                }
+                            }
+                        }
+                    }
                     let resolved_method_name = if let Some(expr) = &decl.name_expr {
                         self.eval_block_value(&[Stmt::Expr(expr.clone())])?
                             .to_string_value()
@@ -373,6 +416,99 @@ impl Interpreter {
                         );
                         self.fn_resolve_gen += 1;
                         self.mark_my_scoped_package_item(qualified_name);
+                    }
+                    // ADR-0019 D3-6: `is export` on an augmented method,
+                    // matching the class walker (confirmed against `raku`:
+                    // `augment class Foo { method greet() is export {...} }`
+                    // then `import Foo` exposes a `greet` sub).
+                    if decl.is_export && !self.suppress_exports {
+                        let tags = if decl.export_tags.is_empty() {
+                            vec!["DEFAULT".to_string()]
+                        } else {
+                            decl.export_tags.clone()
+                        };
+                        if Self::is_operator_categorical_name(&resolved_method_name) {
+                            self.register_exported_operator_method_sub(
+                                name,
+                                &resolved_method_name,
+                                &effective_param_defs,
+                                tags,
+                            );
+                        } else {
+                            self.register_exported_var(
+                                name.to_string(),
+                                format!("&{}", resolved_method_name),
+                                tags,
+                            );
+                        }
+                    }
+                    // ADR-0019 D3-6: an `is native(...)` augmented method
+                    // routes through NativeCall, matching the class walker.
+                    if decl.custom_traits.iter().any(|(t, _)| t == "native") {
+                        self.register_native_call_method(
+                            name,
+                            &resolved_method_name,
+                            &decl.param_defs,
+                            decl.return_type.as_ref(),
+                            &crate::opcode::decl_traits_from_ast(&decl.custom_traits),
+                        )?;
+                    }
+                    // ADR-0019 D3-6: apply user-defined `trait_mod:<is>`
+                    // traits on an augmented method, matching the class
+                    // walker (confirmed against `raku`).
+                    if !decl.custom_traits.is_empty() {
+                        let has_trait_mod = self.has_proto("trait_mod:<is>")
+                            || self.has_multi_candidates("trait_mod:<is>");
+                        if has_trait_mod {
+                            for (trait_name, trait_arg) in &decl.custom_traits {
+                                let mut trait_env = self.env.clone();
+                                trait_env.insert(
+                                    "__mutsu_lookup_class".to_string(),
+                                    Value::str(name.to_string()),
+                                );
+                                trait_env.insert(
+                                    "__mutsu_lookup_method".to_string(),
+                                    Value::str(resolved_method_name.clone()),
+                                );
+                                trait_env.insert(
+                                    "__mutsu_lookup_candidate_idx".to_string(),
+                                    Value::int(0),
+                                );
+                                let sub_val = Value::make_sub(
+                                    Symbol::intern(name),
+                                    Symbol::intern(&resolved_method_name),
+                                    effective_params.clone(),
+                                    effective_param_defs.clone(),
+                                    decl.body.clone(),
+                                    decl.is_rw,
+                                    trait_env,
+                                );
+                                let trait_arg_val = if let Some(arg_expr) = trait_arg {
+                                    Some(self.eval_block_value(&[crate::ast::Stmt::Expr(
+                                        arg_expr.clone(),
+                                    )])?)
+                                } else {
+                                    None
+                                };
+                                let type_obj = self.resolve_type_object(trait_name);
+                                let mut args = vec![sub_val];
+                                if let Some(type_val) = type_obj {
+                                    args.push(type_val);
+                                    if let Some(arg_val) = trait_arg_val {
+                                        args.push(arg_val);
+                                    }
+                                    let _ = self.call_function("trait_mod:<is>", args);
+                                } else {
+                                    let named_val = if let Some(arg_val) = trait_arg_val {
+                                        Value::pair(trait_name.clone(), arg_val)
+                                    } else {
+                                        Value::pair(trait_name.clone(), Value::TRUE)
+                                    };
+                                    args.push(named_val);
+                                    let _ = self.call_function("trait_mod:<is>", args);
+                                }
+                            }
+                        }
                     }
                     // ADR-0019 D3-5 follow-up: `handles` on a method
                     // synthesizes forwarder methods, matching the

--- a/t/augment-method-build-attr-validation.t
+++ b/t/augment-method-build-attr-validation.t
@@ -1,0 +1,42 @@
+use Test;
+use MONKEY-TYPING;
+
+# ADR-0019 D3-6: an augment-declared BUILD/TWEAK submethod's `:$!attr`
+# parameters must refer to declared attributes, matching the class/role
+# walkers. Verified against raku (rejects the undeclared case with
+# X::Attribute::Undeclared).
+
+plan 3;
+
+# A BUILD referencing a declared attribute works.
+{
+    class Built1 { has $.x; }
+    augment class Built1 {
+        method BUILD(:$!x) { }
+    }
+    is Built1.new(x => 5).x, 5, 'BUILD referencing a declared attribute is accepted';
+}
+
+# A BUILD referencing an undeclared attribute is rejected.
+{
+    my $died = False;
+    try {
+        EVAL 'class Built2 { }; augment class Built2 { method BUILD(:$!y) { } }';
+        CATCH {
+            default { $died = True; }
+        }
+    }
+    ok $died, 'BUILD referencing an undeclared attribute is rejected';
+}
+
+# Same check for TWEAK.
+{
+    my $died = False;
+    try {
+        EVAL 'class Built3 { }; augment class Built3 { method TWEAK(:$!z) { } }';
+        CATCH {
+            default { $died = True; }
+        }
+    }
+    ok $died, 'TWEAK referencing an undeclared attribute is rejected';
+}

--- a/t/augment-method-export-operator.t
+++ b/t/augment-method-export-operator.t
@@ -1,0 +1,23 @@
+use Test;
+use MONKEY-TYPING;
+
+# ADR-0019 D3-6: `is export` on an augment-declared operator method now
+# registers an importable sub form, matching the class walker. Verified
+# against raku. (A plain, non-operator method name's `is export` is a
+# separate, pre-existing bug shared by every walker; see
+# todo/tickets/method-is-export-non-operator-name-does-nothing.md.)
+
+plan 1;
+
+class Exported1 {
+    has $.val;
+    method Str() { "Exported1(" ~ $!val ~ ")" }
+}
+augment class Exported1 {
+    method infix:<as-str>($other) is export { self.Str ~ '+' ~ $other.Str }
+}
+import Exported1;
+my $a = Exported1.new(val => 1);
+my $b = Exported1.new(val => 2);
+is ($a as-str $b), 'Exported1(1)+Exported1(2)',
+    'is export on an augment-declared operator method registers an importable sub';

--- a/todo/tickets/method-is-export-non-operator-name-does-nothing.md
+++ b/todo/tickets/method-is-export-non-operator-name-does-nothing.md
@@ -1,0 +1,57 @@
+# `method name() is export` (non-operator name) registers no importable sub
+
+## Root cause
+
+`class_body_method_decl` (and, as of ADR-0019 D3-6, `augment_class`'s method
+arm and the role walker) handle `is export` on a method in two different ways
+depending on the method's name:
+
+- An *operator-categorical* name (`prefix:<~>`, `infix:<as>`, ...) goes through
+  `register_exported_operator_method_sub`, which builds and registers a real
+  `FunctionDef` sub-form under `{class}::{op}` in `self.registry_mut().functions`.
+  `import_module`'s sub-export loop reads exports from that registry and this
+  path works correctly (confirmed against `raku`).
+- Any other (plain) method name instead calls `register_exported_var(class,
+  "&name", tags)`, which only records `class::&name` as an *exported name* in
+  `exported_vars` — it never creates a corresponding sub value. `import_module`'s
+  var-export loop then does `self.env.get("{sigil}{module}::{bare}")` looking
+  for an actual value at that key, finds nothing (no such env entry was ever
+  written), and silently imports nothing.
+
+## Minimal repro
+
+```raku
+class Foo {
+    method greet() is export { "hi" }
+}
+import Foo;
+say greet(Foo.new);
+```
+
+`raku` prints `hi`. mutsu (as of 2026-08-08, `main`) fails with `Unknown
+function: greet`. Reproduces identically whether the method is declared in the
+class body or synthesized via `augment class Foo { ... }` — this is not
+walker drift, both the class walker and `augment_class` share the same broken
+`register_exported_var` path.
+
+## Why this is a separate ticket from the operator-method case
+
+The operator-method form is real and tested (`t/` + roast coverage rely on
+`method infix:<as> is export` style declarations, e.g. for HTTP::UserAgent-style
+operator overloads). The plain-name form has no working implementation at all
+today, not a drift between walkers, so fixing it means making
+`register_exported_var`'s plain-method path do what
+`register_exported_operator_method_sub` does for operators: build a real
+`FunctionDef` (self as first positional, forwarding to the method) and install
+it under `{class}::{name}` so `import_module`'s sub-export loop (not the
+var-export loop) can find and copy it. That is a real feature addition, not a
+one-line fix.
+
+## Affected files
+
+- `src/runtime/registration_class_body_method.rs` (`is_export` handling)
+- `src/runtime/registration_role_method.rs` (same shape, if it handles
+  `is_export` at all — unconfirmed, not checked as part of this finding)
+- `src/runtime/registration_class_augment.rs` (added by ADR-0019 D3-6)
+- `src/runtime/runtime_module_exports.rs` (`register_exported_var`,
+  `import_module`'s var-export loop)

--- a/todo/tickets/method-typed-trait-mod-is-dispatch-never-matches.md
+++ b/todo/tickets/method-typed-trait-mod-is-dispatch-never-matches.md
@@ -1,0 +1,67 @@
+# A user `trait_mod:<is>` multi typed `(Method $m, ...)` never dispatches
+
+## Root cause
+
+`class_body_method_decl` (and, as of ADR-0019 D3-6, `augment_class`'s method
+arm) apply a user-defined custom trait (`method foo() is loud { ... }`) by
+building a code-object value for the about-to-be-installed method with
+`Value::make_sub(...)` and passing it as the first argument to
+`self.call_function("trait_mod:<is>", args)`. `Value::make_sub` always
+produces a plain `Value::Sub` — there is no `is_method` flag or equivalent on
+`SubData` that marks a code object as a `Method` rather than a `Sub`.
+
+Real Raku modules that hook `is <trait>` on methods declare the multi
+candidate typed against `Method`, e.g.:
+
+```raku
+multi sub trait_mod:<is>(Method $m, :$loud!) {
+    say "custom trait applied to {$m.name}";
+}
+```
+
+Since mutsu's `sub_val` reports as a `Sub`, not a `Method`, this candidate's
+`Method $m` parameter type-checks the argument and rejects it — no candidate
+matches, `call_function` returns an error, and the call site discards it with
+`let _ = self.call_function(...)`, so the trait application silently does
+nothing. Confirmed against `raku`: the same script prints
+`custom trait applied to greet`; mutsu prints nothing.
+
+An *untyped* candidate (`multi sub trait_mod:<is>($m, :$loud!)`) does not fix
+it either — that is not a workaround, because `raku` itself refuses to compile
+that form for a method-level trait (`Can't use unknown trait 'is' -> 'loud' in
+method declaration`), so an untyped candidate is not what real modules ship.
+
+## Why this is deep / broad
+
+Fixing this needs a real way to answer "is this code object a `Method`"
+consistent with the rest of the type system (`.WHAT`, `.isa(Method)`,
+signature type-checking) — not just a local hack at the `trait_mod:<is>` call
+site. `Value::Sub`/`SubData` has no such marker today, and adding one touches
+whatever currently decides a code object's reported type (`.^name`, `isa`
+checks, dispatch). The three call sites that build this `sub_val`
+(`registration_class_body_method.rs`, `registration_role_method.rs`,
+`registration_class_augment.rs` after ADR-0019 D3-6) are all equally affected
+— this is not walker drift, it is one shared, pre-existing bug.
+
+## Affected files
+
+- `src/runtime/registration_class_body_method.rs` (the `sub_val` construction
+  and the two `call_function("trait_mod:<is>", ...)` call sites)
+- `src/runtime/registration_role_method.rs` (same shape)
+- `src/runtime/registration_class_augment.rs` (same shape, added by D3-6)
+- `src/value/value_methods_b.rs` (`Value::make_sub`, `SubData` — the type
+  representation that would need the fix)
+
+## Minimal repro
+
+```raku
+multi sub trait_mod:<is>(Method $m, :$loud!) {
+    say "custom trait applied to {$m.name}";
+}
+class Foo {
+    method greet() is loud { "hi" }
+}
+```
+
+`raku` prints `custom trait applied to greet`; mutsu (as of 2026-08-08) prints
+nothing, on `main` and after ADR-0019 D3-6 alike.


### PR DESCRIPTION
## Summary

- `augment_class`'s `MethodDecl` arm was missing three mechanisms the class walker already had (confirmed as real, user-visible drift against `raku`): BUILD/TWEAK `:$!attr` validation, `is export`, and custom-trait (`trait_mod:<is>`, including `is native`) dispatch.
- Ports the class walker's existing logic verbatim into `augment_class`, closing ADR-0019 D3's last open `augment_class` drift points (D3-6).
- Measuring against `raku` while building this slice surfaced two further bugs that are **pre-existing in the class walker itself** (not augment-specific drift), so they're out of scope here and recorded separately: `todo/tickets/method-is-export-non-operator-name-does-nothing.md` and `todo/tickets/method-typed-trait-mod-is-dispatch-never-matches.md`.

## Test plan

- [x] New tests: `t/augment-method-build-attr-validation.t`, `t/augment-method-export-operator.t`
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean
- [x] Full `t/` suite: 27887/27887 tests pass
- [x] Roast: `roast/S12-attributes/augment-and-initialization.t`, `roast/S12-class/augment-supersede.t`, and the full `S12-methods`/`S12-attributes`/`S12-class`/`S12-construction`/`S14-roles` whitelist set (90 files) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)