### PR TITLE
fix(vm): stop an rw parameter hijacking a same-named attribute

### DIFF
--- a/news/2026-08/rw-param-does-not-hijack-a-same-named-attribute.md
+++ b/news/2026-08/rw-param-does-not-hijack-a-same-named-attribute.md
@@ -1,0 +1,51 @@
+# An `is rw` parameter no longer hijacks a same-named attribute
+
+An `is rw` / `is raw` scalar parameter binds through a shared `ContainerRef`
+cell. The method-exit attribute reconcile (`reconcile_attrs`) scans each
+attribute's bare name for such a cell, to recover a `:=` attribute binding
+(`$!x := $outer`) whose authoritative value lives in env/locals rather than in
+the instance cell. It found the *parameter* and adopted it as the attribute's
+new value — permanently replacing the attribute:
+
+```raku
+class P { has $.total }
+class A {
+    has P $.pol = P.new(total => 7);
+    method run() { my P $q; self!fill($q) }
+    method !fill(P $pol is rw) { }     # <-- same name as the attribute
+}
+my $a = A.new;
+$a.run;
+say $a.pol.total;    # raku: 7   mutsu: "No such method 'total' for invocant of type 'Package'"
+```
+
+There were two ways in:
+
+* the frame's **own parameter** sharing the attribute's bare name;
+* a **caller's variable** of that name, reachable because a callee's env is the
+  flattened caller env — the very hazard the `frame_has_container_ref` gate
+  above the scan documents ("a caller-frame ContainerRef … is NOT a binding made
+  by this method") but could not catch, since the flattened copy lands in the
+  overlay it inspects.
+
+## Fix
+
+The bare candidate is the only dangerous one — no lexical can be called `!x` or
+`@.x` — so it is now honoured only for a name **this frame itself owns as a
+slot** (which is how a sigilless `has $x` is seeded) and that is not one of the
+method's parameters. The twigil candidates keep their env fallback unchanged.
+
+Pinned by `t/rw-param-does-not-hijack-same-named-attribute.t`, which also covers
+the two behaviours that must survive: a genuine `:=` attribute binding still
+tracks its target, and an rw parameter still writes back to its caller.
+
+## Where it was found
+
+`Cro::HTTP::Client` declares `has Cro::Policy::Timeout $.timeout-policy` and a
+private `method !assemble-request(… Cro::Policy::Timeout $timeout-policy is rw …)`.
+Its first request left the attribute holding the parameter's cell, so the second
+died with `Type check failed in assignment to $timeout-policy; expected
+Cro::Policy::Timeout but got Any`.
+
+That client-side failure is **not fully resolved** by this fix — see
+`todo/tickets/cro-client-timeout-policy-attribute-still-corrupted.md`.

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -739,7 +739,7 @@ impl Interpreter {
             // against the live cell + local/env writes before the env is torn
             // down. The cell-direct reads + per-op mirrors make the cell the
             // single source; the legacy attribute writeback is gone.
-            reconciled_attrs = self.reconcile_attrs(&base, cc);
+            reconciled_attrs = self.reconcile_attrs(&base, cc, &method_def.params);
 
             let method_var_bindings = self.take_var_bindings();
             let mut restored_bindings = saved_var_bindings;
@@ -763,7 +763,7 @@ impl Interpreter {
 
             // Phase 3 Stage 2: reconcile all attributes against the live cell +
             // local/env writes before the env is merged away.
-            reconciled_attrs = self.reconcile_attrs(&base, cc);
+            reconciled_attrs = self.reconcile_attrs(&base, cc, &method_def.params);
             // Callee-frame key predicate for the merge (formerly a per-call
             // materialized HashSet<String>): the method's params and locals,
             // the frame fixtures, the attribute twigil forms and sigilless
@@ -957,7 +957,12 @@ impl Interpreter {
     /// consumer that needs the post-method map (proxy_fetch) re-snapshots the
     /// live cell on demand instead — so the common exit pays no `to_map()`
     /// (full attr-map clone) at all.
-    fn reconcile_attrs(&self, base: &Value, code: &CompiledCode) -> Option<AttrMap> {
+    fn reconcile_attrs(
+        &self,
+        base: &Value,
+        code: &CompiledCode,
+        params: &[String],
+    ) -> Option<AttrMap> {
         let ValueView::Instance {
             attributes: cell, ..
         } = base.view()
@@ -997,18 +1002,42 @@ impl Interpreter {
                     continue;
                 }
                 let bare = ks.rsplit('\0').next().unwrap_or(ks);
-                // Sigilless (`has $x` → bare `x`) and twigil (`$!x`/`@.x`/…) keys
-                // may hold the `:=` ContainerRef alias.
+                // The BARE candidate is the dangerous one: unlike `!x`/`@.x`, it
+                // is a name an ordinary lexical or parameter can also have, and
+                // an `is rw`/`is raw` scalar parameter binds through a shared
+                // `ContainerRef` cell — exactly the shape this scan reads as a
+                // `:=` attribute binding. Two ways it went wrong, both of which
+                // *replaced the attribute* for the rest of the object's life:
+                //
+                //   * the frame's own parameter (`method !f(P $pol is rw)` in a
+                //     class with `has P $.pol`);
+                //   * a CALLER's variable of that name, reachable because the
+                //     callee env is the flattened caller env — the very hazard
+                //     the `frame_has_container_ref` gate above documents but
+                //     cannot catch, since the flattened copy is in the overlay.
+                //
+                // Cro::HTTP::Client hits both: `!assemble-request(…
+                // Cro::Policy::Timeout $timeout-policy is rw)` against its own
+                // `has $.timeout-policy`. The first request left the attribute
+                // holding the parameter's cell and the second died with "Type
+                // check failed in assignment to $timeout-policy".
+                //
+                // So the bare form is honoured only for a name this frame itself
+                // owns as a slot (how a sigilless `has $x` is seeded) and that is
+                // not a parameter. The twigil forms keep the env fallback: no
+                // lexical can be called `!x`.
+                let bare_owned =
+                    code.locals.iter().any(|n| n == bare) && !params.iter().any(|p| p == bare);
                 let candidates = [
-                    bare.to_string(),
-                    format!("!{}", bare),
-                    format!(".{}", bare),
-                    format!("@!{}", bare),
-                    format!("@.{}", bare),
-                    format!("%!{}", bare),
-                    format!("%.{}", bare),
+                    bare_owned.then(|| bare.to_string()),
+                    Some(format!("!{}", bare)),
+                    Some(format!(".{}", bare)),
+                    Some(format!("@!{}", bare)),
+                    Some(format!("@.{}", bare)),
+                    Some(format!("%!{}", bare)),
+                    Some(format!("%.{}", bare)),
                 ];
-                for key in candidates {
+                for key in candidates.into_iter().flatten() {
                     if let Some(v) = self.attr_env_or_local(code, &key)
                         && v.is_container_ref()
                     {
@@ -1608,7 +1637,7 @@ impl Interpreter {
         });
         // Phase 3 Stage 2: reconcile all attributes against the live cell +
         // local/env writes before the env is torn down.
-        let reconciled = self.reconcile_attrs(&base, cc);
+        let reconciled = self.reconcile_attrs(&base, cc, &method_def.params);
 
         let method_var_bindings = self.take_var_bindings();
         let mut restored_bindings = saved_var_bindings;

--- a/t/rw-param-does-not-hijack-same-named-attribute.t
+++ b/t/rw-param-does-not-hijack-same-named-attribute.t
@@ -1,0 +1,64 @@
+use Test;
+
+plan 5;
+
+# An `is rw`/`is raw` scalar parameter binds through a shared `ContainerRef`
+# cell. The method-exit attribute reconcile scans each attribute's bare name for
+# such a cell to recover a `:=` attribute binding (`$!x := $outer`) — and used to
+# find the *parameter* (or a caller variable of the same name, reachable because
+# a callee's env is the flattened caller env) and adopt it as the attribute's new
+# value, permanently replacing the attribute.
+
+class P { has $.total }
+
+# 1-2: the frame's own parameter shares the attribute's name.
+{
+    class A {
+        has P $.pol = P.new(total => 7);
+        method run() { my P $q; self!fill($q); }
+        method !fill(P $pol is rw) { }
+    }
+    my $a = A.new;
+    $a.run;
+    is $a.pol.total, 7, 'a same-named rw parameter does not replace the attribute';
+    $a.run;
+    is $a.pol.total, 7, 'and still not on a second call';
+}
+
+# 3: a caller variable shares the attribute's name.
+{
+    class B {
+        has P $.pol;
+        method run() {
+            my P $pol;
+            self!fill($pol);
+            return $!pol.defined;
+        }
+        method !fill(P $z is rw) { }
+    }
+    nok B.new.run, "a caller's same-named variable does not replace the attribute";
+}
+
+# 4: a genuine `:=` attribute binding still wins (what the scan is for).
+{
+    class D {
+        has $.bound;
+        method bind-to($x is rw) { $!bound := $x; }
+        method peek() { $!bound }
+    }
+    my $outer = 1;
+    my $d = D.new;
+    $d.bind-to($outer);
+    $outer = 42;
+    is $d.peek, 42, 'a real := attribute binding still tracks its target';
+}
+
+# 5: an rw parameter still writes back to its caller.
+{
+    class E {
+        has $.pol;
+        method run() { my $pol = 1; self!bump($pol); $pol }
+        method !bump($pol is rw) { $pol = 99 }
+    }
+    is E.new.run, 99, 'the rw parameter still writes back to the caller';
+}

--- a/todo/tickets/cro-client-timeout-policy-attribute-still-corrupted.md
+++ b/todo/tickets/cro-client-timeout-policy-attribute-still-corrupted.md
@@ -1,0 +1,85 @@
+# `Cro::HTTP::Client`'s `$!timeout-policy` still turns into `Any` after one request
+
+Every `Cro::HTTP::Client` test that makes two requests from the same client dies
+on the second one:
+
+```
+Type check failed in assignment to $timeout-policy; expected Cro::Policy::Timeout but got Any
+  in sub !assemble-request at .../Cro/HTTP/Client.rakumod line 1064
+  in sub request at .../Cro/HTTP/Client.rakumod line 616
+  in sub get at .../Cro/HTTP/Client.rakumod line 450
+```
+
+This blocks `t/http-session-inmemory.rakutest`, `t/http-session-persistent.rakutest`,
+and is the likely cause of the `rc=124` timeouts in `t/http-auth-basic*.rakutest`
+and the tail of `t/http-router.rakutest`.
+
+## What is known
+
+The relevant declarations (`lib/Cro/HTTP/Client.rakumod`):
+
+```raku
+has Cro::Policy::Timeout $.timeout-policy;                       # line 379
+my Cro::Policy::Timeout $timeout-policy;                         # line 615, in `method request`
+self!assemble-request($method, …, %options, $timeout-policy);    # line 616
+method !assemble-request(…, Cro::Policy::Timeout $timeout-policy is rw, …) { … }   # line 984
+    ($timeout-policy = self ?? $!timeout-policy // $default-timeout !! $default-timeout)
+        without $timeout-policy;                                 # line 1064
+```
+
+Instrumenting line 1064 (copy the file into a shadow tree that `-I` puts first)
+shows, on one client instance:
+
+* **first request** — `$!timeout-policy.^name` = `Cro::Policy::Timeout`,
+  `.defined` = `False`; the right-hand side evaluates to
+  `Cro::HTTP::Client::Policy::Timeout`. Correct.
+* **second request** — `$!timeout-policy.^name` = **`Any`**, `.defined` =
+  **`True`**. The attribute has been replaced between the two calls.
+
+Because it is now *defined*, `without $timeout-policy` … actually still holds
+(the local is undefined), the assignment runs, and the failure surfaces as a type
+check on the rw parameter's writeback into the caller's
+`my Cro::Policy::Timeout $timeout-policy`.
+
+## Not the same bug as #6061
+
+`news/2026-08/rw-param-does-not-hijack-a-same-named-attribute.md` fixed the
+`reconcile_attrs` bare-name scan adopting a same-named `is rw` parameter (or a
+caller variable) as a `:=` attribute binding. That is the same *shape* — the
+parameter and the attribute are both called `timeout-policy` — and it fixed the
+reduced repro:
+
+```raku
+class P { has $.total }
+class A {
+    has P $.pol = P.new(total => 7);
+    method run() { my P $q; self!fill($q) }
+    method !fill(P $pol is rw) { }
+}
+A.new.run;   # attribute used to be replaced by the parameter's cell
+```
+
+but the Cro symptom survives it unchanged, so a second path corrupts the
+attribute. Candidates not yet checked:
+
+* `method request` / `method get` are `multi method`s, so dispatch may go
+  through the interpreter slow path (`runtime/resolution_call_sub.rs`, which has
+  its own `changed_caller_locals` handling) rather than
+  `vm/vm_method_dispatch.rs`'s `call_compiled_method{,_fast}` where the fixed
+  scan lives. The backtrace frames read `in sub !assemble-request` / `in sub
+  request`, which is consistent with that.
+* `Cro::Policy::Timeout` is a **parameterized role** (`role
+  Cro::Policy::Timeout[%phase-defaults]`) used bare as a type constraint. The
+  attribute's declared-type machinery may not resolve it the same way on the
+  second pass.
+
+## How to reproduce
+
+```
+bash tmp/cro-t.sh t/http-session-inmemory.rakutest
+```
+
+(helper scripts and the vendored Cro checkout live under `tmp/`, which is
+gitignored; re-fetch with the Cro campaign's `inc-paths.txt` recipe if the
+checkout is gone). The `%*ENV<CRODBG>`-gated notes already in the vendored
+`Client.rakumod` do not cover line 1064 — add one there in a shadow copy.


### PR DESCRIPTION
## Problem

```raku
class P { has $.total }
class A {
    has P $.pol = P.new(total => 7);
    method run() { my P $q; self!fill($q) }
    method !fill(P $pol is rw) { }     # <-- same name as the attribute
}
my $a = A.new;
$a.run;
say $a.pol.total;    # raku: 7   mutsu: "No such method 'total' for invocant of type 'Package'"
```

An `is rw` / `is raw` scalar parameter binds through a shared `ContainerRef` cell. The method-exit attribute reconcile (`reconcile_attrs`) scans each attribute's bare name for such a cell, to recover a `:=` attribute binding (`$!x := $outer`) whose authoritative value lives in env/locals rather than in the instance cell. It found the *parameter* and adopted it as the attribute's new value — permanently replacing the attribute.

Two ways in:

- the frame's **own parameter** sharing the attribute's bare name;
- a **caller's variable** of that name, reachable because a callee's env is the flattened caller env — the very hazard the `frame_has_container_ref` gate above the scan documents ("a caller-frame ContainerRef … is NOT a binding made by this method") but could not catch, since the flattened copy lands in the overlay it inspects.

## Fix

The bare candidate is the only dangerous one — no lexical can be called `!x` or `@.x` — so it is honoured only for a name **this frame itself owns as a slot** (how a sigilless `has $x` is seeded) and that is not one of the method's parameters. The twigil candidates keep their env fallback unchanged.

## Tests

- New pin: `t/rw-param-does-not-hijack-same-named-attribute.t` — the parameter case, the caller-variable case, and the two behaviours that must survive (a genuine `:=` attribute binding still tracks its target; an rw parameter still writes back to its caller). Verified against real `raku`.
- `make test` green (2950 files, 27894 tests).

## Where it was found — and what is left

`Cro::HTTP::Client` declares `has Cro::Policy::Timeout $.timeout-policy` and `method !assemble-request(… Cro::Policy::Timeout $timeout-policy is rw …)`. Its first request left the attribute holding the parameter's cell, so the second died with `Type check failed in assignment to $timeout-policy; expected Cro::Policy::Timeout but got Any`.

That Cro symptom **survives this fix**, so a second path corrupts the attribute (likely the interpreter slow-path dispatch, since `request`/`get` are `multi method`s). Recorded with everything measured so far in `todo/tickets/cro-client-timeout-policy-attribute-still-corrupted.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)