### PR TITLE
fix(vm): keep the attribute reconcile off the frame's own my-lexicals

### DIFF
--- a/news/2026-08/rw-param-does-not-hijack-a-same-named-attribute.md
+++ b/news/2026-08/rw-param-does-not-hijack-a-same-named-attribute.md
@@ -26,18 +26,22 @@ There were two ways in:
   flattened caller env — the very hazard the `frame_has_container_ref` gate
   above the scan documents ("a caller-frame ContainerRef … is NOT a binding made
   by this method") but could not catch, since the flattened copy lands in the
-  overlay it inspects.
+  overlay it inspects;
+* the frame's own **`my` lexical** of that name, boxed into a cell by being
+  passed to an rw parameter (`method go() { my P $pol; self!fill($pol) }`).
 
 ## Fix
 
 The bare candidate is the only dangerous one — no lexical can be called `!x` or
 `@.x` — so it is now honoured only for a name **this frame itself owns as a
-slot** (which is how a sigilless `has $x` is seeded) and that is not one of the
-method's parameters. The twigil candidates keep their env fallback unchanged.
+slot** (which is how a sigilless `has $x` is seeded) that the frame declared
+neither as a parameter nor as a `my`. The twigil candidates keep their env
+fallback unchanged.
 
-Pinned by `t/rw-param-does-not-hijack-same-named-attribute.t`, which also covers
-the two behaviours that must survive: a genuine `:=` attribute binding still
-tracks its target, and an rw parameter still writes back to its caller.
+Pinned by `t/rw-param-does-not-hijack-same-named-attribute.t`, which covers all
+three entry points plus the two behaviours that must survive: a genuine `:=`
+attribute binding still tracks its target, and an rw parameter still writes back
+to its caller.
 
 ## Where it was found
 
@@ -47,5 +51,8 @@ Its first request left the attribute holding the parameter's cell, so the second
 died with `Type check failed in assignment to $timeout-policy; expected
 Cro::Policy::Timeout but got Any`.
 
-That client-side failure is **not fully resolved** by this fix — see
-`todo/tickets/cro-client-timeout-policy-attribute-still-corrupted.md`.
+The type-check failure is gone. The client still does not complete a request —
+`t/http-session-inmemory.rakutest` now runs both its tests instead of dying on
+the first, but each comes back with an empty body and a new error, `P6opaque: no
+such attribute '$!timeout-policy' on type Cro::HTTP::Client`. That next layer is
+tracked in `todo/tickets/cro-client-timeout-policy-attribute-still-corrupted.md`.

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1022,12 +1022,21 @@ impl Interpreter {
                 // holding the parameter's cell and the second died with "Type
                 // check failed in assignment to $timeout-policy".
                 //
+                // A third: the frame's own `my` lexical of that name, boxed into
+                // a cell by passing it to an rw parameter — `method go() { my T
+                // $pol; self!f($pol) }` in a class with `has T $.pol`, which is
+                // how `Cro::HTTP::Client.request`'s `my Cro::Policy::Timeout
+                // $timeout-policy` reached the attribute.
+                //
                 // So the bare form is honoured only for a name this frame itself
-                // owns as a slot (how a sigilless `has $x` is seeded) and that is
-                // not a parameter. The twigil forms keep the env fallback: no
-                // lexical can be called `!x`.
-                let bare_owned =
-                    code.locals.iter().any(|n| n == bare) && !params.iter().any(|p| p == bare);
+                // owns as a slot (how a sigilless `has $x` is seeded) that the
+                // frame did NOT declare as a parameter or a `my`. The twigil
+                // forms keep the env fallback: no lexical can be called `!x`.
+                let bare_owned = code.locals.iter().any(|n| n == bare)
+                    && !params.iter().any(|p| p == bare)
+                    && !code
+                        .my_declared_sym
+                        .contains(&crate::symbol::Symbol::intern(bare));
                 let candidates = [
                     bare_owned.then(|| bare.to_string()),
                     Some(format!("!{}", bare)),

--- a/t/rw-param-does-not-hijack-same-named-attribute.t
+++ b/t/rw-param-does-not-hijack-same-named-attribute.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 5;
+plan 7;
 
 # An `is rw`/`is raw` scalar parameter binds through a shared `ContainerRef`
 # cell. The method-exit attribute reconcile scans each attribute's bare name for
@@ -39,7 +39,26 @@ class P { has $.total }
     nok B.new.run, "a caller's same-named variable does not replace the attribute";
 }
 
-# 4: a genuine `:=` attribute binding still wins (what the scan is for).
+# 4-5: the frame's own `my` lexical shares the attribute's name and is boxed
+# into a cell by being passed to an rw parameter. This is the shape
+# `Cro::HTTP::Client.request`'s `my Cro::Policy::Timeout $timeout-policy` has
+# against its own `has $.timeout-policy`; reading the attribute in the callee is
+# what made the adopted cell observable.
+{
+    class F {
+        has P $.pol;
+        method go() { my P $pol; self!fill($pol); 'ok' }
+        method !fill(P $pol is rw) {
+            my $d = P.new(total => 1);
+            ($pol = $!pol // $d) without $pol;
+        }
+    }
+    my $f = F.new;
+    is (try $f.go) // $!.message, 'ok', "a frame's own my-lexical does not replace the attribute";
+    is (try $f.go) // $!.message, 'ok', 'and the second call on the same instance still works';
+}
+
+# 6: a genuine `:=` attribute binding still wins (what the scan is for).
 {
     class D {
         has $.bound;
@@ -53,7 +72,7 @@ class P { has $.total }
     is $d.peek, 42, 'a real := attribute binding still tracks its target';
 }
 
-# 5: an rw parameter still writes back to its caller.
+# 7: an rw parameter still writes back to its caller.
 {
     class E {
         has $.pol;

--- a/todo/tickets/cro-client-timeout-policy-attribute-still-corrupted.md
+++ b/todo/tickets/cro-client-timeout-policy-attribute-still-corrupted.md
@@ -1,11 +1,11 @@
-# `Cro::HTTP::Client`'s `$!timeout-policy` still turns into `Any` after one request
+# `Cro::HTTP::Client` cannot complete a request: `$!timeout-policy` is unreadable
 
-Every `Cro::HTTP::Client` test that makes two requests from the same client dies
-on the second one:
+Every `Cro::HTTP::Client` request comes back with an empty body and this error:
 
 ```
-Type check failed in assignment to $timeout-policy; expected Cro::Policy::Timeout but got Any
-  in sub !assemble-request at .../Cro/HTTP/Client.rakumod line 1064
+P6opaque: no such attribute '$!timeout-policy' on type Cro::HTTP::Client in a
+MetamodelX::MonitorHOW when trying to get a value
+  in sub !assemble-request at .../Cro/HTTP/Client/CookieJar.rakumod line 1064
   in sub request at .../Cro/HTTP/Client.rakumod line 616
   in sub get at .../Cro/HTTP/Client.rakumod line 450
 ```
@@ -14,9 +14,9 @@ This blocks `t/http-session-inmemory.rakutest`, `t/http-session-persistent.rakut
 and is the likely cause of the `rc=124` timeouts in `t/http-auth-basic*.rakutest`
 and the tail of `t/http-router.rakutest`.
 
-## What is known
+## Where it is
 
-The relevant declarations (`lib/Cro/HTTP/Client.rakumod`):
+`lib/Cro/HTTP/Client.rakumod`:
 
 ```raku
 has Cro::Policy::Timeout $.timeout-policy;                       # line 379
@@ -27,51 +27,46 @@ method !assemble-request(…, Cro::Policy::Timeout $timeout-policy is rw, …) {
         without $timeout-policy;                                 # line 1064
 ```
 
-Instrumenting line 1064 (copy the file into a shadow tree that `-I` puts first)
-shows, on one client instance:
+## Leads
 
-* **first request** — `$!timeout-policy.^name` = `Cro::Policy::Timeout`,
-  `.defined` = `False`; the right-hand side evaluates to
-  `Cro::HTTP::Client::Policy::Timeout`. Correct.
-* **second request** — `$!timeout-policy.^name` = **`Any`**, `.defined` =
-  **`True`**. The attribute has been replaced between the two calls.
+* **The reported file is wrong.** The frame says
+  `!assemble-request at …/Cro/HTTP/Client/CookieJar.rakumod line 1064`, but
+  `!assemble-request` is in `Client.rakumod`, and `CookieJar.rakumod` is far
+  shorter than 1064 lines. So the backtrace's file and line come from different
+  frames — compare `todo/tickets/callframe-line-and-file-come-from-different-frames.md`.
+  Fixing that first would make this much easier to chase.
+* **`MetamodelX::MonitorHOW`** in the message means the invocant's HOW is
+  OO::Monitors' (`Cro::HTTP::Client::CookieJar` is a `monitor`). Either `self`
+  is the wrong object at that point, or an attribute read on a monitor-HOW
+  instance does not find the class's own attributes.
+* `self ?? $!timeout-policy // $default-timeout !! $default-timeout` must not
+  evaluate `$!timeout-policy` at all when `self` is a type object (`??`/`!!` is
+  looser than `//`, so the true branch is `$!timeout-policy // $default`). Worth
+  checking that mutsu short-circuits it — `Cro::HTTP::Client.get($url)` is a
+  legitimate class-level call.
 
-Because it is now *defined*, `without $timeout-policy` … actually still holds
-(the local is undefined), the assignment runs, and the failure surfaces as a type
-check on the rw parameter's writeback into the caller's
-`my Cro::Policy::Timeout $timeout-policy`.
+## History
 
-## Not the same bug as #6061
-
-`news/2026-08/rw-param-does-not-hijack-a-same-named-attribute.md` fixed the
-`reconcile_attrs` bare-name scan adopting a same-named `is rw` parameter (or a
-caller variable) as a `:=` attribute binding. That is the same *shape* — the
-parameter and the attribute are both called `timeout-policy` — and it fixed the
-reduced repro:
+The earlier symptom — `Type check failed in assignment to $timeout-policy;
+expected Cro::Policy::Timeout but got Any` on the *second* request from one
+client — was the `reconcile_attrs` bare-name scan adopting the same-named `is
+rw` parameter, the caller's variable, or the caller's `my` lexical as a `:=`
+attribute binding and thereby replacing the attribute. Fixed in
+`news/2026-08/rw-param-does-not-hijack-a-same-named-attribute.md`; the reduced
+repro now matches raku:
 
 ```raku
 class P { has $.total }
-class A {
-    has P $.pol = P.new(total => 7);
-    method run() { my P $q; self!fill($q) }
-    method !fill(P $pol is rw) { }
+class C {
+    has P $.pol;
+    method go() { my P $pol; self!f($pol); 'ok' }
+    method !f(P $pol is rw) { my $d = P.new; ($pol = $!pol // $d) without $pol }
 }
-A.new.run;   # attribute used to be replaced by the parameter's cell
+my $o = C.new; say $o.go; say $o.go;
 ```
 
-but the Cro symptom survives it unchanged, so a second path corrupts the
-attribute. Candidates not yet checked:
-
-* `method request` / `method get` are `multi method`s, so dispatch may go
-  through the interpreter slow path (`runtime/resolution_call_sub.rs`, which has
-  its own `changed_caller_locals` handling) rather than
-  `vm/vm_method_dispatch.rs`'s `call_compiled_method{,_fast}` where the fixed
-  scan lives. The backtrace frames read `in sub !assemble-request` / `in sub
-  request`, which is consistent with that.
-* `Cro::Policy::Timeout` is a **parameterized role** (`role
-  Cro::Policy::Timeout[%phase-defaults]`) used bare as a type constraint. The
-  attribute's declared-type machinery may not resolve it the same way on the
-  second pass.
+After that fix the test file gets *further* — it now runs both of its tests
+instead of dying on the first — but neither passes.
 
 ## How to reproduce
 
@@ -81,5 +76,6 @@ bash tmp/cro-t.sh t/http-session-inmemory.rakutest
 
 (helper scripts and the vendored Cro checkout live under `tmp/`, which is
 gitignored; re-fetch with the Cro campaign's `inc-paths.txt` recipe if the
-checkout is gone). The `%*ENV<CRODBG>`-gated notes already in the vendored
-`Client.rakumod` do not cover line 1064 — add one there in a shadow copy.
+checkout is gone). Copy `Client.rakumod` into a shadow tree that `-I` puts first
+to instrument line 1064 — the `%*ENV<CRODBG>`-gated notes already in the
+vendored file do not cover it.


### PR DESCRIPTION
Follow-up to #6063, same scan, third entry point.

## Problem

```raku
class T { has $.total }
class C {
    has T $.pol;
    method go() { my T $pol; self!f($pol); 'ok' }
    method !f(T $pol is rw) { my $d = T.new; ($pol = $!pol // $d) without $pol }
}
my $o = C.new;
say $o.go;   # ok
say $o.go;   # "Type check failed in assignment to $pol; expected T but got Any"
```

Passing `go`'s own `my T $pol` to an `is rw` parameter boxes it into a shared `ContainerRef` cell. `go`'s exit reconcile then scanned the attribute's bare name `pol`, found that cell in its own slot, and adopted it as a `:=` binding of `$.pol` — replacing the attribute. #6063 excluded the frame's *parameters* and caller-frame names from the bare candidate; a `my` in the frame itself was still eligible.

This is exactly the shape `Cro::HTTP::Client.request`'s `my Cro::Policy::Timeout $timeout-policy` has against its own `has $.timeout-policy`.

## Fix

Exclude `code.my_declared_sym` from the bare candidate too. A sigilless `has $x` is *seeded* into the frame from the attribute cell rather than `my`-declared, so the case the scan exists for is untouched (pinned).

## Tests

- `t/rw-param-does-not-hijack-same-named-attribute.t` extended to 7 tests: all three entry points, plus the two behaviours that must survive (a genuine `:=` attribute binding still tracks its target; an rw parameter still writes back to its caller). Verified against real `raku`.
- `make test` green (2956 files, 27911 tests).

## Cro status

`t/http-session-inmemory.rakutest` no longer dies on the first test with `Type check failed in assignment to $timeout-policy` — it now runs both of its tests. Neither passes yet: each request comes back with an empty body and a new error, `P6opaque: no such attribute '$!timeout-policy' on type Cro::HTTP::Client in a MetamodelX::MonitorHOW`. Measured before/after to confirm this is forward progress, not a regression. The next layer, with leads (the backtrace's file and line come from different frames, which is its own open ticket), is in `todo/tickets/cro-client-timeout-policy-attribute-still-corrupted.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)