### PR TITLE
feat(compiler): support prefix ++/-- on an rw-accessor lvalue

### DIFF
--- a/news/2026-08/prefix-incdec-on-an-rw-accessor.md
+++ b/news/2026-08/prefix-incdec-on-an-rw-accessor.md
@@ -1,0 +1,35 @@
+# `++$obj.attr` works
+
+```raku
+class S { has $.count is rw = 0 }
+my $s = S.new;
+say ++$s.count;    # raku: 1
+                   # mutsu: Cannot resolve caller prefix:<++>(...);
+                   #        the parameter requires mutable arguments
+```
+
+`$s.count++` and `$s.count += 1` both worked: the postfix increment/decrement
+compiler already had a `MethodCall` arm that reads the accessor into a temp,
+increments the temp, and writes it back through
+`__mutsu_assign_method_lvalue`. The **prefix** forms had no such arm at all —
+`++`/`--` handled `Var`, `BareWord`, a declarator in expression position,
+`temp $x`, `.=`-assignment and `Index` targets, and everything else fell
+through to `__mutsu_incdec_nomatch`.
+
+## Fix
+
+`compile_prefix_incdec_method_lvalue` mirrors the postfix helper but leaves the
+*new* value on the stack, and the two `else` fallbacks in `compiler/expr_unary.rs`
+now try it before reporting the no-match error.
+
+An accessor on an *element* (`++@a[1].count`) is still unsupported; the postfix
+form does not support it either, so the two stay at parity. Noted in the test.
+
+Pinned by `t/prefix-incdec-on-an-rw-accessor.t`.
+
+## Effect
+
+Cro's session middleware writes `content 'text/plain', 'Visit ' ~ ++$session.count`,
+so every session route died and answered with an empty body.
+`t/http-session-inmemory.rakutest`'s first test passes now (it was failing with
+`got: ''`).

--- a/src/compiler/expr_postfix.rs
+++ b/src/compiler/expr_postfix.rs
@@ -2,6 +2,63 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Compiler {
+    /// Compile prefix `++`/`--` on an rw-accessor lvalue (`++$obj.count`).
+    ///
+    /// The postfix forms already route a method-call target through the
+    /// `__mutsu_assign_method_lvalue` writeback; the prefix forms had no
+    /// `MethodCall` arm at all and fell through to `__mutsu_incdec_nomatch`,
+    /// so `++$obj.count` died with "Cannot resolve caller prefix:<++>(...); the
+    /// parameter requires mutable arguments" while `$obj.count++` and
+    /// `$obj.count += 1` both worked. Cro's session middleware writes
+    /// `content 'text/plain', 'Visit ' ~ ++$session.count`, so every session
+    /// route answered with an empty body.
+    ///
+    /// Returns `false` when `expr` is not a method call on a named variable, so
+    /// the caller keeps its existing fallback.
+    pub(super) fn compile_prefix_incdec_method_lvalue(&mut self, expr: &Expr, inc: bool) -> bool {
+        let Expr::MethodCall {
+            target, name, args, ..
+        } = expr
+        else {
+            return false;
+        };
+        let Some(target_var) = (match target.as_ref() {
+            Expr::Var(n) => Some(n.clone()),
+            Expr::ArrayVar(n) => Some(format!("@{}", n)),
+            Expr::HashVar(n) => Some(format!("%{}", n)),
+            _ => None,
+        }) else {
+            return false;
+        };
+        let tmp_value_name = format!("__mutsu_tmp_method_preinc_{}", self.code.constants.len());
+        let tmp_value_idx = self.code.add_constant(Value::str(tmp_value_name.clone()));
+        // Read the accessor, increment the temp in place (prefix leaves the NEW
+        // value on the stack), then write the temp back through the accessor and
+        // yield the new value.
+        self.compile_expr(expr);
+        self.code.emit(OpCode::SetGlobal(tmp_value_idx));
+        if inc {
+            self.code.emit(OpCode::PreIncrement(tmp_value_idx, None));
+        } else {
+            self.code.emit(OpCode::PreDecrement(tmp_value_idx, None));
+        }
+        self.code.emit(OpCode::Pop);
+        let assign_expr = Expr::Call {
+            name: Symbol::intern("__mutsu_assign_method_lvalue"),
+            args: vec![
+                Expr::Var(target_var.clone()),
+                Expr::Literal(Value::str(name.resolve())),
+                Expr::ArrayLiteral(args.clone()),
+                Expr::Var(tmp_value_name.clone()),
+                Expr::Literal(Value::str(target_var)),
+            ],
+        };
+        self.compile_expr(&assign_expr);
+        self.code.emit(OpCode::Pop);
+        self.compile_expr(&Expr::Var(tmp_value_name));
+        true
+    }
+
     /// Compile postfix ++ on variable/index/method target.
     pub(super) fn compile_expr_postfix_inc(&mut self, expr: &Expr) {
         if let Some(var) = Self::temp_call_var(expr) {

--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -100,7 +100,7 @@ impl Compiler {
                         // Nested index (e.g. ++$foo[0][0])
                         self.compile_nested_prefix_incdec(expr, true);
                     }
-                } else {
+                } else if !self.compile_prefix_incdec_method_lvalue(expr, true) {
                     self.compile_expr(&Expr::Call {
                         name: Symbol::intern("__mutsu_incdec_nomatch"),
                         args: vec![Expr::Literal(Value::str_from("prefix:<++>"))],
@@ -160,7 +160,7 @@ impl Compiler {
                         // Nested index (e.g. --$foo[0][0])
                         self.compile_nested_prefix_incdec(expr, false);
                     }
-                } else {
+                } else if !self.compile_prefix_incdec_method_lvalue(expr, false) {
                     self.compile_expr(&Expr::Call {
                         name: Symbol::intern("__mutsu_incdec_nomatch"),
                         args: vec![Expr::Literal(Value::str_from("prefix:<-->"))],

--- a/t/prefix-incdec-on-an-rw-accessor.t
+++ b/t/prefix-incdec-on-an-rw-accessor.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 7;
+
+# `$obj.attr++` and `$obj.attr += 1` both routed a method-call lvalue through
+# the `__mutsu_assign_method_lvalue` writeback, but the PREFIX forms had no
+# `MethodCall` arm at all and fell through to `__mutsu_incdec_nomatch`:
+# `++$obj.attr` died with "Cannot resolve caller prefix:<++>(...); the parameter
+# requires mutable arguments".
+
+class S { has $.count is rw = 0 }
+
+{
+    my $s = S.new;
+    is ++$s.count, 1, 'prefix ++ yields the new value';
+    is $s.count, 1, 'and the write reached the attribute';
+    is "Visit " ~ ++$s.count, 'Visit 2', 'and it composes in an expression';
+    is --$s.count, 1, 'prefix -- yields the new value';
+    is $s.count, 1, 'and the write reached the attribute';
+}
+
+# The postfix forms keep their (different) value semantics.
+{
+    my $s = S.new;
+    is $s.count++, 0, 'postfix ++ still yields the old value';
+    is $s.count, 1, 'and still increments';
+}
+
+# NOTE: an accessor on an *element* (`++@a[1].count`) is out of scope — the
+# postfix form does not support it either, so the two stay at parity.


### PR DESCRIPTION
## Problem

```raku
class S { has $.count is rw = 0 }
my $s = S.new;
say ++$s.count;    # raku: 1
                   # mutsu: Cannot resolve caller prefix:<++>(...); the parameter requires mutable arguments
```

`$s.count++` and `$s.count += 1` both worked. The postfix increment/decrement compiler already had a `MethodCall` arm that reads the accessor into a temp, increments the temp, and writes it back through `__mutsu_assign_method_lvalue`. The **prefix** forms had no such arm at all — `++`/`--` handled `Var`, `BareWord`, a declarator in expression position, `temp $x`, `.=`-assignment and `Index` targets, and everything else fell through to `__mutsu_incdec_nomatch`.

## Fix

`compile_prefix_incdec_method_lvalue` mirrors the postfix helper but leaves the *new* value on the stack (prefix semantics), and both prefix fallbacks in `compiler/expr_unary.rs` try it before reporting the no-match error.

An accessor on an *element* (`++@a[1].count`) is still unsupported — the postfix form does not support it either, so the two stay at parity. Noted in the test.

## Effect

Cro's session middleware writes `content 'text/plain', 'Visit ' ~ ++$session.count`, so every session route died and answered with an empty body. `t/http-session-inmemory.rakutest`'s first test passes now (it was failing with `got: ''`).

## Tests

- New pin: `t/prefix-incdec-on-an-rw-accessor.t` — prefix `++`/`--` value and effect, composition in an expression, and the postfix forms keeping their different value semantics. Verified against real `raku`.
- `make test` green (2957 files, 27921 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)