### PR TITLE
feat(runtime): precompile CompiledMethodDecl at compile time (ADR-0019 D3-7)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -119,8 +119,12 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 landed, 2026-08-07). Phase C is fully checked; the open box is D2 (attributes and generated
 accessors), subdivided D2a-D2d — D2a, D2c-1/2/3, and D2d are done; D2b (typed attribute
 descriptors) and the "compile `default`/`where_constraint` as actual bytecode chunks" remainder of
-D2c are the only pieces still open, followed by D3 (class methods/submethods as compiled
-candidates). D1 found most class structural data already typed-plan-driven
+D2c are the only pieces still open. D3 (class methods/submethods as compiled candidates) is open;
+D3-1 through D3-7 landed (walker-drift unification plus the compile-time `CompiledMethodDecl`
+precompute), and a 2026-08-08 scoping pass found D3's literal goal — compiling method *bodies*
+through the single main-pass `Compiler` the way `SubDecl` does, instead of a throwaway
+per-registration `Compiler::new()` — still fully open and scoped as a future D3-8. D1 found most
+class structural data already typed-plan-driven
 from Phase A3/A4; the two remaining body-scanning reads (stub detection, `Stmt::TrustsDecl`) are
 now precomputed at plan lowering as `CompiledClassDeclPlan::is_stub`/`trusts`; see
 `news/2026-08/d1-class-structural-plan-fields.md`. D2, unlike D1, found attribute data with no
@@ -696,6 +700,47 @@ walkers wholesale is not possible before then.
   matches (`todo/tickets/method-typed-trait-mod-is-dispatch-never-matches.md`). D3-6 makes
   `augment_class` reach exact parity with the class walker, including that walker's own
   pre-existing limits — it does not fix either underlying bug.
+  **D3-7 scoping pass (2026-08-08):** with drift closed, the next natural step is the D2b-style
+  precompute — moving `CompiledMethodDecl::from_stmt`'s 19-field destructure from "once per
+  registration" (called at runtime by `class_body_method_decl`/`role_body_method_decl`, which
+  re-runs for a class/role declared inside a loop or a repeatedly-called sub) to "once, at compile
+  time", the way `own_attribute_names`/`is_default_chunks`/`method_name_chunks` already do for
+  their own fields. Unlike D2b's own attribute case, this has **no position-correlation blocker**:
+  D3-1 already solved exactly that problem for method statements (the `method_name_chunks` cursor,
+  built by flattening `SyntheticBlock` the same way the registration walk does), so the identical
+  cursor mechanism carries a full `CompiledMethodDecl` instead of just a name chunk.
+  A wider scoping investigation (an `Explore` agent survey of `compile_class_methods`/
+  `compile_role_methods`, `accessors_resolve.rs`) found a **separate, larger** gap behind the D3
+  box's literal text ("install ... compiled candidates ... without walking `Stmt::MethodDecl`"):
+  method *bodies* are not compiled by the single main-pass `Compiler` at all (unlike `SubDecl`,
+  which gets a pool-keyed `CompiledFunction` via `compiled_routine_keys` — ADR-0019 C1/C3). Instead
+  a method body is compiled by a throwaway `Compiler::new()` spun up by
+  `compile_method_def_in_place_with_dist` (`accessors_resolve.rs`), triggered once per class/role
+  from at least 9 distinct sites (`RegisterClass`/`RegisterRole` VM ops, role mixin composition,
+  three `augment class` sites, the method-dispatch-cache miss path, `nextsame` dispatch, BUILD/TWEAK
+  constructor-phase planning, `class_dispatch.rs`) and memoized via `compiled_code.is_some()`.
+  `Stmt::ClassDecl`/`RoleDecl` bodies are never walked by `compile_stmt` (unlike `module`/`package`,
+  which recurse and set `current_package`) — the only main-pass compile that already touches every
+  method body is `record_type_body_captures`'s escape analysis, whose result is discarded and whose
+  package context is the *enclosing* package, not the class's own name. Migrating this fully would
+  mirror C1-C4 for methods and needs its own multi-slice plan: `effective_param_defs`'s
+  `::?CLASS`-substitution and auto-`@_`-detection currently run at registration time reading the
+  real class name (not always known at the main-pass point a class body is reached — a computed
+  class name `class ::($name) {...}` is D3-1's own reason `method_name_chunks` exists); multi-method
+  candidates have no signature-keyed pool slot the way multi subs do (`class_body_method_decl`
+  pushes a plain `Vec<MethodDef>`); and role method bodies may need per-composition
+  re-instantiation depending on how a parametric role's type captures reach compiled bytecode. This
+  is left as a scoped-but-unstarted future slice (tentatively D3-8) rather than attempted in one PR.
+  **D3-7 landed 2026-08-08**: `CompiledClassDeclPlan`/`CompiledRoleDeclPlan` gained
+  `method_decls: Vec<CompiledMethodDecl>`, built once by a new `compile_method_decls` free function
+  (mirroring `compile_method_name_chunks`'s exact flatten-and-filter walk, needing no compiler state
+  since `CompiledMethodDecl::from_stmt` is pure AST-to-struct). `class_body_method_decl`/
+  `role_body_method_decl` now read a clone by position (reusing the existing
+  `method_name_chunk_idx` cursor for both vecs) instead of calling `CompiledMethodDecl::from_stmt`
+  on the raw statement at every registration; both functions no longer take a `stmt` parameter at
+  all, since nothing in the walk reads it anymore. `augment_class` (no compiled plan) and the
+  role-pun/mixin synthesis paths keep passing an empty `method_decls` slice, matching
+  `method_name_chunks`'s existing D3-1 precedent.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
   expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
   names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies

--- a/news/2026-08/d3-7-method-decl-compile-time-precompute.md
+++ b/news/2026-08/d3-7-method-decl-compile-time-precompute.md
@@ -1,0 +1,64 @@
+# ADR-0019 D3-7: precompute CompiledMethodDecl at compile time
+
+With D3-1 through D3-6 having unified and de-drifted how the class, role, and
+`augment class` walkers each build a `CompiledMethodDecl` from a
+`Stmt::MethodDecl`, the natural next step — mirroring D2b's own precedent for
+attribute descriptors — was moving that construction from runtime to compile
+time.
+
+`CompiledClassDeclPlan` and `CompiledRoleDeclPlan` now carry
+`method_decls: Vec<CompiledMethodDecl>`, built once by a new
+`compile_method_decls` free function that flattens `SyntheticBlock` the exact
+same way `compile_method_name_chunks` (D3-1) already does. Since
+`CompiledMethodDecl::from_stmt` is pure AST-to-struct conversion (no compiler
+state needed), the two vecs share one position cursor:
+`class_body_method_decl`/`role_body_method_decl` now read a clone of the
+precomputed descriptor by position instead of calling
+`CompiledMethodDecl::from_stmt` on the raw statement at every registration.
+Both functions dropped their now-unused `stmt` parameter entirely, since
+nothing in either walk reads the raw AST node anymore.
+
+This avoids re-cloning a method's body, param defs, custom traits, and
+handles specs on every registration of a class/role declared inside a loop
+or a repeatedly-called sub — previously that clone happened fresh each time
+`class_body_method_decl` ran, even though the source AST never changes.
+`augment_class` (which has no compiled declaration plan at all — `augment
+class` still indexes `stmt_pool`) and the role-pun/mixin synthesis paths keep
+passing an empty `method_decls` slice, matching `method_name_chunks`'s
+existing D3-1 precedent.
+
+## Scoping pass: D3's literal goal is a separate, larger gap
+
+A wider investigation into what D3 ("encode class methods and submethods as
+compiled candidates ... without walking `Stmt::MethodDecl`") actually still
+requires found a gap much larger than the `CompiledMethodDecl` precompute:
+method *bodies* are not compiled by the single main-pass `Compiler` at all,
+unlike `SubDecl`, which gets a pool-keyed `CompiledFunction` via
+`compiled_routine_keys` (ADR-0019 C1/C3). Instead, a method body is compiled
+by a throwaway `Compiler::new()` inside `compile_method_def_in_place_with_dist`
+(`accessors_resolve.rs`), triggered from at least nine distinct call sites
+(`RegisterClass`/`RegisterRole` VM ops, role mixin composition, three
+`augment class` sites, the method-dispatch-cache miss path, `nextsame`
+dispatch, BUILD/TWEAK constructor-phase planning, and `class_dispatch.rs`),
+memoized only via a `compiled_code.is_some()` guard. `Stmt::ClassDecl`/
+`RoleDecl` bodies are never walked by `compile_stmt` the way a `module`/
+`package` block is (which recurses and sets `current_package`) — the only
+main-pass compile that already touches every method body is
+`record_type_body_captures`'s escape analysis, and it throws its result away
+and runs under the *enclosing* package rather than the class's own name.
+
+Migrating this fully would mirror Phase C's whole C1-C4 arc, but for methods,
+and needs its own multi-slice plan: `effective_param_defs`'s
+`::?CLASS`-substitution and auto-`@_`-detection currently run at registration
+time reading the real (resolved) class name, which is not always known at the
+point the main pass reaches a class body (a computed class name like `class
+::($name) {...}` is exactly why D3-1's `method_name_chunks` exists in the
+first place); multi-method candidates have no signature-keyed pool slot the
+way multi subs do; and a parametric role's method bodies may need
+per-composition re-instantiation depending on how type captures reach
+compiled bytecode. This is recorded in the ADR as a scoped-but-unstarted
+future slice (tentatively D3-8) rather than attempted in one PR.
+
+Verified against the full `t/` suite (27,913 tests) and all 101 whitelisted
+roast files under `S12-methods`, `S12-attributes`, `S12-class`,
+`S12-construction`, `S14-roles`, and `S06-multi`.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2454,6 +2454,27 @@ fn role_body_prescan(body: &[Stmt]) -> (Vec<Symbol>, Vec<String>, Vec<String>) {
     (own_attribute_names, used_modules, declared_types)
 }
 
+/// Precompute a typed `CompiledMethodDecl` for each top-level `method`/
+/// `submethod` declaration in a class/role body (ADR-0019 D3-7), in the same
+/// `SyntheticBlock`-flattened order `compile_method_name_chunks` already
+/// walks — so the two vecs share one position cursor at registration time.
+/// This moves `CompiledMethodDecl::from_stmt`'s destructure from "once per
+/// registration" (`class_body_method_decl`/`role_body_method_decl`, which can
+/// re-run for a class declared inside a loop or a repeatedly-called sub) to
+/// "once, at compile time".
+fn compile_method_decls(body: &[Stmt]) -> Vec<CompiledMethodDecl> {
+    body.iter()
+        .flat_map(|s| match s {
+            Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+            other => vec![other],
+        })
+        .filter_map(|stmt| match stmt {
+            Stmt::MethodDecl { .. } => Some(CompiledMethodDecl::from_stmt(stmt)),
+            _ => None,
+        })
+        .collect()
+}
+
 fn body_contains_non_nil_return(stmts: &[Stmt]) -> bool {
     stmts.iter().any(|stmt| match stmt {
         Stmt::Return(expr) => !matches!(expr, Expr::Literal(value) if value.is_nil()),
@@ -2522,6 +2543,12 @@ pub(crate) struct CompiledClassDeclPlan {
     /// position, not by name: an indirect `method ::($name) {...}` name has
     /// no guaranteed-unique fallback name to key on the way attributes do.
     pub(crate) method_name_chunks: Vec<Option<CompiledDeclExpr>>,
+    /// Precompiled typed mirror of each top-level `method`/`submethod`
+    /// declaration in the body (ADR-0019 D3-7), position-aligned with
+    /// `method_name_chunks` (built by the same flattened walk). Registration
+    /// reads a clone by position instead of calling `CompiledMethodDecl::from_stmt`
+    /// on the raw statement every time the class declaration executes.
+    pub(crate) method_decls: Vec<CompiledMethodDecl>,
 }
 
 #[derive(Debug, Clone)]
@@ -2550,6 +2577,10 @@ pub(crate) struct CompiledRoleDeclPlan {
     /// `submethod` declaration in the body (ADR-0019 D3-1). See
     /// `CompiledClassDeclPlan::method_name_chunks`.
     pub(crate) method_name_chunks: Vec<Option<CompiledDeclExpr>>,
+    /// Precompiled typed mirror of each top-level `method`/`submethod`
+    /// declaration in the body (ADR-0019 D3-7). See
+    /// `CompiledClassDeclPlan::method_decls`.
+    pub(crate) method_decls: Vec<CompiledMethodDecl>,
 }
 
 /// A package-level `proto sub`/`proto rule`/`proto token` declaration lowered
@@ -5754,6 +5785,7 @@ impl CompiledCode {
             })
             .collect();
         let own_attribute_names = class_own_attribute_names(body);
+        let method_decls = compile_method_decls(body);
         let plan_idx = self.class_decl_plans.len() as u32;
         self.class_decl_plans.push(CompiledClassDeclPlan {
             name: *name,
@@ -5774,6 +5806,7 @@ impl CompiledCode {
             own_attribute_names,
             is_default_chunks,
             method_name_chunks,
+            method_decls,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Class(plan_idx));
@@ -5801,6 +5834,7 @@ impl CompiledCode {
             panic!("add_role_decl_plan expects RoleDecl");
         };
         let (own_attribute_names, body_used_modules, body_declared_types) = role_body_prescan(body);
+        let method_decls = compile_method_decls(body);
         let plan_idx = self.role_decl_plans.len() as u32;
         self.role_decl_plans.push(CompiledRoleDeclPlan {
             name: *name,
@@ -5816,6 +5850,7 @@ impl CompiledCode {
             body_used_modules,
             body_declared_types,
             method_name_chunks,
+            method_decls,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Role(plan_idx));

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -212,6 +212,13 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// paths with no compiled plan available (`augment class`, and the
     /// role-pun/mixin synthesis paths that call this with an empty body).
     pub(crate) method_name_chunks: &'a [Option<crate::opcode::CompiledDeclExpr>],
+    /// Precompiled typed mirror of each top-level `method`/`submethod`
+    /// declaration in the body (ADR-0019 D3-7), position-aligned with
+    /// `method_name_chunks`, threaded down to `class_body_method_decl` via
+    /// `ClassBodyCx`. Empty for registration paths with no compiled plan
+    /// available (the role-pun/mixin synthesis paths that call this with an
+    /// empty body).
+    pub(crate) method_decls: &'a [crate::opcode::CompiledMethodDecl],
 }
 
 pub(super) fn parse_role_type_args(input: &str) -> Vec<String> {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1025,6 +1025,7 @@ impl Interpreter {
             own_attribute_names: &[],
             attr_is_default_chunks: &[],
             method_name_chunks: &[],
+            method_decls: &[],
         };
         self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
         self.store_language_revision_from_version(&pun_name, &language_version);

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -31,8 +31,12 @@ pub(super) struct ClassBodyCx<'a> {
     /// `submethod` declaration in the body (ADR-0019 D3-1), read by position
     /// via `method_name_chunk_idx`; see `class_body_method_decl`.
     pub(super) method_name_chunks: &'a [Option<crate::opcode::CompiledDeclExpr>],
-    /// Cursor into `method_name_chunks`, advanced by one on every method
-    /// statement `class_body_method_decl` processes.
+    /// Precompiled typed mirror of each top-level `method`/`submethod`
+    /// declaration in the body (ADR-0019 D3-7), read by position via
+    /// `method_name_chunk_idx`; see `class_body_method_decl`.
+    pub(super) method_decls: &'a [crate::opcode::CompiledMethodDecl],
+    /// Cursor into `method_name_chunks`/`method_decls`, advanced by one on
+    /// every method statement `class_body_method_decl` processes.
     pub(super) method_name_chunk_idx: usize,
 }
 
@@ -93,6 +97,7 @@ impl Interpreter {
         own_attribute_names: &[Symbol],
         is_default_chunks: &[(Symbol, crate::opcode::DeclTraitArg)],
         method_name_chunks: &[Option<crate::opcode::CompiledDeclExpr>],
+        method_decls: &[crate::opcode::CompiledMethodDecl],
     ) -> Result<ClassDef, RuntimeError> {
         let saved_package = self.current_package();
         let saved_env = self.env.clone();
@@ -136,6 +141,7 @@ impl Interpreter {
             class_own_attrs,
             is_default_chunks,
             method_name_chunks,
+            method_decls,
             method_name_chunk_idx: 0,
         };
         let saved_functions_keys: HashSet<String> = self
@@ -166,7 +172,7 @@ impl Interpreter {
                     }
                 }
                 Stmt::MethodDecl { .. } => {
-                    self.class_body_method_decl(&mut cx, stmt)?;
+                    self.class_body_method_decl(&mut cx)?;
                 }
                 Stmt::DoesDecl { .. } => {
                     if matches!(

--- a/src/runtime/registration_class_body_method.rs
+++ b/src/runtime/registration_class_body_method.rs
@@ -7,7 +7,6 @@ use super::registration_class_body::ClassBodyCx;
 use super::registration_class_body_method_forms::method_sub_form_params;
 use super::*;
 use crate::ast::{HandleSpec, ParamDef};
-use crate::opcode::CompiledMethodDecl;
 use crate::symbol::Symbol;
 
 impl Interpreter {
@@ -17,13 +16,19 @@ impl Interpreter {
     pub(super) fn class_body_method_decl(
         &mut self,
         cx: &mut ClassBodyCx<'_>,
-        stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
-        // ADR-0019 D3-2: a typed mirror of the `Stmt::MethodDecl` fields
-        // (see `CompiledMethodDecl`), shared with the eventual role-body and
-        // augment `method` arms instead of each independently re-destructuring
-        // the 19-field AST variant.
-        let decl = CompiledMethodDecl::from_stmt(stmt);
+        // ADR-0019 D3-7: `decl` is precompiled by the compiler at plan
+        // lowering (`CompiledClassDeclPlan::method_decls`) and read here by
+        // position via the same cursor `method_name_chunks` already uses
+        // (D3-1) — `class_body_method_decl` no longer calls
+        // `CompiledMethodDecl::from_stmt` on the raw statement itself.
+        let chunk_idx = cx.method_name_chunk_idx;
+        cx.method_name_chunk_idx += 1;
+        let decl = cx
+            .method_decls
+            .get(chunk_idx)
+            .cloned()
+            .expect("method_decls misaligned with class body walk");
         self.validate_private_access_in_stmts(cx.name, &decl.body)?;
         Self::validate_attr_declared_in_class(&cx.attr_ctx(), &decl.body)?;
         // In BUILD/TWEAK submethods, :$!attr parameters must refer
@@ -50,8 +55,6 @@ impl Interpreter {
         // compiler and this walk both flatten `SyntheticBlock` the same way,
         // so position, not name, is the shared key (see
         // `Compiler::compile_method_name_chunks`).
-        let chunk_idx = cx.method_name_chunk_idx;
-        cx.method_name_chunk_idx += 1;
         let resolved_method_name = if decl.name_expr.is_some() {
             let chunk = cx
                 .method_name_chunks

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -128,6 +128,7 @@ impl Interpreter {
             own_attribute_names,
             attr_is_default_chunks,
             method_name_chunks,
+            method_decls,
         } = modifiers;
         let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
@@ -227,6 +228,7 @@ impl Interpreter {
             own_attribute_names,
             attr_is_default_chunks,
             method_name_chunks,
+            method_decls,
         )?;
         self.finalize_class_registration(name, parents, class_def, &snapshot)?;
         self.install_class_exporthow(name, parents)?;

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -274,6 +274,7 @@ impl Interpreter {
         body_used_modules: &[String],
         body_declared_types: &[String],
         method_name_chunks: &[Option<crate::opcode::CompiledDeclExpr>],
+        method_decls: &[crate::opcode::CompiledMethodDecl],
     ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
 
@@ -325,6 +326,7 @@ impl Interpreter {
             body_used_modules: body_used_modules.iter().cloned().collect(),
             body_declared_types: body_declared_types.iter().cloned().collect(),
             method_name_chunks,
+            method_decls,
             method_name_chunk_idx: 0,
         };
         self.walk_role_body(body, &mut cx)?;

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -26,8 +26,12 @@ pub(super) struct RoleDeclCx<'a> {
     /// `submethod` declaration in the body (ADR-0019 D3-1), read by position
     /// via `method_name_chunk_idx`; see `role_body_method_decl`.
     pub(super) method_name_chunks: &'a [Option<crate::opcode::CompiledDeclExpr>],
-    /// Cursor into `method_name_chunks`, advanced by one on every method
-    /// statement `role_body_method_decl` processes.
+    /// Precompiled typed mirror of each top-level `method`/`submethod`
+    /// declaration in the body (ADR-0019 D3-7), read by position via
+    /// `method_name_chunk_idx`; see `role_body_method_decl`.
+    pub(super) method_decls: &'a [crate::opcode::CompiledMethodDecl],
+    /// Cursor into `method_name_chunks`/`method_decls`, advanced by one on
+    /// every method statement `role_body_method_decl` processes.
     pub(super) method_name_chunk_idx: usize,
 }
 
@@ -223,7 +227,7 @@ impl Interpreter {
                     self.role_body_does_decl(cx, stmt)?;
                 }
                 Stmt::MethodDecl { .. } => {
-                    self.role_body_method_decl(cx, stmt)?;
+                    self.role_body_method_decl(cx)?;
                 }
                 Stmt::Expr(Expr::Call { name, .. })
                     if name == "__mutsu_stub_die" || name == "__mutsu_stub_warn" =>

--- a/src/runtime/registration_role_method.rs
+++ b/src/runtime/registration_role_method.rs
@@ -6,7 +6,6 @@ use super::registration_class::make_delegation_method;
 use super::registration_role_decl::RoleDeclCx;
 use super::*;
 use crate::ast::HandleSpec;
-use crate::opcode::CompiledMethodDecl;
 
 impl Interpreter {
     /// The `method` arm of the role-body walk: validate the declaration and
@@ -14,15 +13,23 @@ impl Interpreter {
     pub(super) fn role_body_method_decl(
         &mut self,
         cx: &mut RoleDeclCx<'_>,
-        stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
-        // ADR-0019 D3-3: shared typed mirror of `Stmt::MethodDecl` (see
-        // `CompiledMethodDecl`, D3-2). This walk does not read
+        // ADR-0019 D3-7: `decl` is precompiled by the compiler at plan
+        // lowering (`CompiledRoleDeclPlan::method_decls`) and read here by
+        // position via the same cursor `method_name_chunks` already uses
+        // (D3-1/D3-3) instead of calling `CompiledMethodDecl::from_stmt` on
+        // the raw statement. This walk does not read
         // `is_our`/`our_variable_form`/`custom_traits`/`is_export`/
         // `export_tags` — a role method is never `our`-registered as a
         // package sub and custom traits/exports on a role method are not
         // handled here, matching the walk's original ignored bindings.
-        let decl = CompiledMethodDecl::from_stmt(stmt);
+        let chunk_idx = cx.method_name_chunk_idx;
+        cx.method_name_chunk_idx += 1;
+        let decl = cx
+            .method_decls
+            .get(chunk_idx)
+            .cloned()
+            .expect("method_decls misaligned with role body walk");
         let name = cx.name;
         // Validate that $!attr references in the method body are declared
         // in this role (same check as for class methods).
@@ -174,8 +181,6 @@ impl Interpreter {
         // ADR-0019 D3-1: see `class_body_method_decl`'s identical comment —
         // the compiler and this walk flatten `SyntheticBlock` identically, so
         // the chunk at this cursor position matches this statement.
-        let chunk_idx = cx.method_name_chunk_idx;
-        cx.method_name_chunk_idx += 1;
         let resolved_method_name = if decl.name_expr.is_some() {
             let chunk = cx
                 .method_name_chunks

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -67,6 +67,7 @@ impl Interpreter {
             own_attribute_names: &[],
             attr_is_default_chunks: &[],
             method_name_chunks: &[],
+            method_decls: &[],
         };
         self.register_class_decl(&name, &parents, modifiers, &[])?;
         self.compose_mixin_role_submethods(&name, &fresh);

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -140,6 +140,7 @@ impl Interpreter {
             own_attribute_names,
             is_default_chunks,
             method_name_chunks,
+            method_decls,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {
@@ -254,6 +255,7 @@ impl Interpreter {
                         own_attribute_names,
                         attr_is_default_chunks: is_default_chunks,
                         method_name_chunks,
+                        method_decls,
                     },
                     body,
                 )
@@ -605,6 +607,7 @@ impl Interpreter {
             body_used_modules,
             body_declared_types,
             method_name_chunks,
+            method_decls,
         }) = code.role_decl_plans.get(idx as usize)
         {
             let name_str = name.resolve();
@@ -635,6 +638,7 @@ impl Interpreter {
                     body_used_modules,
                     body_declared_types,
                     method_name_chunks,
+                    method_decls,
                 )
             )?;
             // Link `is Parent` references on this role to the lexical class visible


### PR DESCRIPTION
## Summary
- ADR-0019 D3-7: `CompiledClassDeclPlan`/`CompiledRoleDeclPlan` now carry `method_decls: Vec<CompiledMethodDecl>`, precomputed once by the compiler (`compile_method_decls`, mirroring D3-1's `compile_method_name_chunks` flatten walk) instead of `CompiledMethodDecl::from_stmt` being called on the raw `Stmt::MethodDecl` at every registration.
- `class_body_method_decl`/`role_body_method_decl` read the precomputed descriptor by position, reusing the existing `method_name_chunk_idx` cursor; both functions drop their now-unused `stmt` parameter.
- Records a scoping pass in the ADR: D3's literal goal (method *bodies* compiled through the single main-pass `Compiler`, the way `SubDecl` already is via C1/C3) is a separate, larger gap — scoped as a future D3-8 slice, not attempted here.

## Test plan
- [x] `make test` — 27,913 tests, all green
- [x] All 101 whitelisted roast files under `S12-methods`, `S12-attributes`, `S12-class`, `S12-construction`, `S14-roles`, `S06-multi` — all pass against `target/release/mutsu`
- [x] `cargo clippy -- -D warnings` clean, `cargo fmt` clean
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)