### PR TITLE
fix(vm): keep the caller's topic across a declaration-time value block

### DIFF
--- a/news/2026-08/decl-time-value-block-keeps-the-topic.md
+++ b/news/2026-08/decl-time-value-block-keeps-the-topic.md
@@ -1,0 +1,45 @@
+# Constructing an object no longer overwrites the caller's `$_`
+
+```raku
+class S { has Bool $.b }
+$_ = 3.7e0;
+S.new;
+say $_.^name;    # raku: Num    mutsu: Bool
+```
+
+The topic came back as the *type object of the last unset typed attribute*: a
+class with `has Int $.i; has Rat $.r` left `$_` holding `Rat`, and an untyped
+attribute or one with a default left it alone.
+
+## Root cause
+
+Seeding an unset typed attribute evaluates its declared type through
+`eval_decl_trait_arg` → `vm_eval_block_value`, which compiles the expression as a
+block **for its value** — so its last expression is a `SetTopic`. That helper
+runs at declaration time, inside whatever frame happens to be constructing, so
+the topic write escaped straight into the caller.
+
+## Fix
+
+`vm_eval_block_value` saves and restores `$_` around the nested run (both the
+compiled fast path and the interpreter fallback). The value it produces is
+unchanged.
+
+Pinned by `t/decl-time-value-block-keeps-the-topic.t`.
+
+## Effect
+
+Cro's cookie jar hit it in a loop body:
+
+```raku
+for $resp.cookies {
+    $state = CookieState.new(creation-time => DateTime.now, …);
+    self!get-cookie-lifetime($_, $state);      # $_ is now Bool
+}
+```
+
+`CookieState` has four `Bool` attributes, none of them passed, so `$_` stopped
+being the `Cro::HTTP::Cookie` and the private call failed its signature — which
+mutsu reports, misleadingly, as `No such private method 'get-cookie-lifetime'`.
+
+`t/http-session-inmemory.rakutest` goes from 2 tests to **13 run, 6 passing**.

--- a/src/vm/vm_core_helpers.rs
+++ b/src/vm/vm_core_helpers.rs
@@ -120,6 +120,23 @@ impl Interpreter {
         // (block-scope depth + let/temp restore + DESTROY pass). All current
         // callers pass a single `Stmt::Expr` (registration-time default / enum /
         // role-arg evaluation). Any other shape falls back to the interpreter.
+        // The block is compiled for its VALUE, which makes its last expression a
+        // `SetTopic` — but this helper runs at *declaration* time, inside whatever
+        // frame happens to be constructing, so that topic write escaped to the
+        // caller. `class S { has Bool $.b }; $_ = 'x'; S.new` left `$_` holding
+        // `Bool`, because seeding the unset typed attribute evaluates its type
+        // constraint through here. Cro hit it in a loop body — `for $resp.cookies
+        // { $state = CookieState.new(...); self!get-cookie-lifetime($_, $state) }`
+        // passed a `Bool` where a `Cro::HTTP::Cookie` was expected.
+        let saved_topic = self.env().get("_").cloned();
+        let restore_topic = |zelf: &mut Self| match &saved_topic {
+            Some(v) => {
+                zelf.env_mut().insert("_".to_string(), v.clone());
+            }
+            None => {
+                zelf.env_mut().remove("_");
+            }
+        };
         if body.iter().all(|s| matches!(s, Stmt::Expr(_))) {
             let (code, compiled_fns) = self.compile_block_value(body);
             let let_mark = self.let_saves_len();
@@ -127,10 +144,13 @@ impl Interpreter {
             let result = self.run_nested(&code, &compiled_fns);
             self.pop_block_scope_depth();
             self.restore_let_saves(let_mark);
+            restore_topic(self);
             self.loan_env_for(|i| i.run_pending_instance_destroys())?;
             return result.map(|v| v.unwrap_or(Value::NIL));
         }
-        self.loan_env_for(|i| i.eval_block_value(body))
+        let result = self.loan_env_for(|i| i.eval_block_value(body));
+        restore_topic(self);
+        result
     }
 
     /// Run a declaration-time expression chunk (ADR-0019 C5).

--- a/t/decl-time-value-block-keeps-the-topic.t
+++ b/t/decl-time-value-block-keeps-the-topic.t
@@ -1,0 +1,49 @@
+use Test;
+
+plan 5;
+
+# A declaration-time expression (an attribute's type constraint, an attribute
+# default, an enum value, a role argument) is evaluated by compiling it as a
+# block *for its value*, which makes its last expression a `SetTopic`. That runs
+# inside whatever frame is constructing, so the topic write escaped to the
+# caller.
+
+{
+    class S { has Bool $.b }
+    $_ = 3.7e0;
+    S.new;
+    is $_.^name, 'Num', 'constructing with an unset typed attribute keeps the topic';
+}
+
+{
+    class T { has Int $.i is rw; has Rat $.r is rw }
+    $_ = 3.7e0;
+    T.new(i => 1);
+    is $_.^name, 'Num', 'several typed attributes, one of them supplied';
+}
+
+{
+    class U { has Int $.i is rw = 5 }
+    $_ = 3.7e0;
+    U.new;
+    is $_.^name, 'Num', 'an attribute default keeps the topic too';
+}
+
+# The shape Cro hit: the topic is a loop variable and the constructed object's
+# attributes are typed, so the next statement saw the attribute's type object
+# instead of the loop item.
+{
+    class State { has Str $.name is rw; has Bool $.flag is rw }
+    my @seen;
+    for <a b> {
+        my $st = State.new(name => 'x');
+        @seen.push: $_;
+    }
+    is-deeply @seen, ['a', 'b'], 'a loop topic survives constructing a typed object';
+}
+
+# The value the declaration-time evaluation produces is still correct.
+{
+    class V { has Int $.i is rw }
+    nok V.new.i.defined, 'the unset typed attribute is still its own type object';
+}


### PR DESCRIPTION
## Problem

```raku
class S { has Bool $.b }
$_ = 3.7e0;
S.new;
say $_.^name;    # raku: Num    mutsu: Bool
```

The topic came back as the *type object of the last unset typed attribute*: a class with `has Int $.i; has Rat $.r` left `$_` holding `Rat`, while an untyped attribute or one with a default left it alone.

## Root cause

Seeding an unset typed attribute evaluates its declared type through `eval_decl_trait_arg` → `vm_eval_block_value`, which compiles the expression as a block **for its value** — so its last expression is a `SetTopic`. That helper runs at declaration time, inside whatever frame happens to be constructing, so the topic write escaped straight into the caller.

## Fix

`vm_eval_block_value` saves and restores `$_` around the nested run (both the compiled fast path and the interpreter fallback). The value it produces is unchanged (pinned).

## Effect

Cro's cookie jar hit it in a loop body:

```raku
for $resp.cookies {
    $state = CookieState.new(creation-time => DateTime.now, …);
    self!get-cookie-lifetime($_, $state);      # $_ is now Bool
}
```

`CookieState` has four `Bool` attributes, none of them passed, so `$_` stopped being the `Cro::HTTP::Cookie` and the private call failed its signature — which mutsu reports, misleadingly, as `No such private method 'get-cookie-lifetime'`.

`t/http-session-inmemory.rakutest` goes from 2 tests to **13 run, 6 passing**.

## Tests

- New pin: `t/decl-time-value-block-keeps-the-topic.t` — unset typed attribute, several typed attributes with one supplied, an attribute default, the loop-topic shape Cro hit, and the produced value still being right. Verified against real `raku`.
- `make test` green (2959 files, 27932 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)