### PR TITLE
docs(adr): detailed design for ADR-0019 D3-8 (method-body main-pass compilation)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -123,7 +123,10 @@ D2c are the only pieces still open. D3 (class methods/submethods as compiled can
 D3-1 through D3-7 landed (walker-drift unification plus the compile-time `CompiledMethodDecl`
 precompute), and a 2026-08-08 scoping pass found D3's literal goal — compiling method *bodies*
 through the single main-pass `Compiler` the way `SubDecl` does, instead of a throwaway
-per-registration `Compiler::new()` — still fully open and scoped as a future D3-8. D4 (class
+per-registration `Compiler::new()` — still fully open and scoped as a future D3-8, whose detailed
+design (parity-first bare compile, per-decl `compiled_routine_key` on `CompiledMethodDecl`,
+guarded registration install, D3-8a-d slice plan) landed 2026-08-08 as
+`todo/deep/adr0019-d3-8-method-body-main-pass-compilation.md`. D4 (class
 declaration-time expressions) was also scoped 2026-08-08, no code landed: its "aliases" piece is
 closed as already-bytecode-native (a lateral move, not a gain), its "deferred class bodies" piece
 folds into D8 rather than needing its own slice, and its "parent expressions" piece is a real
@@ -746,6 +749,24 @@ walkers wholesale is not possible before then.
   all, since nothing in the walk reads it anymore. `augment_class` (no compiled plan) and the
   role-pun/mixin synthesis paths keep passing an empty `method_decls` slice, matching
   `method_name_chunks`'s existing D3-1 precedent.
+  **D3-8 design pass done 2026-08-08 (no code landed):** the full design is
+  `todo/deep/adr0019-d3-8-method-body-main-pass-compilation.md`. Key findings that shaped it: the
+  method-body compile is composition- and class-name-independent (`T` is an env variable injected
+  at method entry, `::?CLASS`/`::?ROLE` bind dynamically, the `::?CLASS` param substitution only
+  rewrites bind-time `param_defs` strings), so one main-pass compile per declaration is sound; the
+  scoping pass's "multi methods have no signature-keyed pool slot" complication dissolves by
+  carrying a per-declaration `compiled_routine_key: Option<Symbol>` on `CompiledMethodDecl`
+  (positionally delivered by the existing D3-1/D3-7 cursor) instead of a keyed pool; role methods
+  are today recompiled once per composing class only because the `role_candidates` snapshot is
+  cloned before `compile_role_methods` runs, and installing at `role_body_method_decl` time
+  collapses that to one compile with no composition changes; and the parity-first rule (replicate
+  the throwaway `Compiler::new()` seeding exactly, no lexical-scope inheritance yet) keeps the
+  cutover byte-verifiable. Slices: D3-8a (additive compiler side + `MUTSU_VM_STATS`
+  `method_body_runtime_compiles` counter), D3-8b/c (class/role walker cutover with a
+  params-equality guard that degrades to the runtime fallback), D3-8d (instrument-and-sweep
+  proving the fallback only fires for `augment`/`.^add_method`/computed-name shapes).
+  `compile_method_def_in_place_with_dist` remains as the narrowed fallback, mirroring
+  `otf_compile_function_def`'s role for subs.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
   expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
   names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies

--- a/todo/deep/adr0019-d3-8-method-body-main-pass-compilation.md
+++ b/todo/deep/adr0019-d3-8-method-body-main-pass-compilation.md
@@ -1,0 +1,249 @@
+# ADR-0019 D3-8 design: compile method bodies in the main-pass compiler
+
+Design pass for the D3-8 box scoped by the D3-7 session (see the ADR's Phase D section): method
+**bodies** are the last routine-body class still compiled at runtime by a throwaway
+`Compiler::new()`, unlike `sub` bodies, which Phase C (C1-C8) moved to main-pass compilation with
+pool-keyed `CompiledFunction`s. This document records the investigation results, the design
+decisions, and a slice plan. No code has landed for this box yet.
+
+## Problem statement
+
+Every method/submethod body is compiled by
+`Interpreter::compile_method_def_in_place_with_dist` (`src/runtime/accessors_resolve.rs:17-60`):
+a fresh `Compiler::new()` per method, seeded with only four things — the method package
+(`original_role`/`role_origin`/class), `current_distribution`, `lexically_in_method = true`, and
+the synthetic param prefix `["self", "__ANON_STATE__", "?CLASS", "?ROLE"]` — memoized solely by
+`def.compiled_code.is_some()`. Costs, confirmed by survey:
+
+1. **Registration-time compilation, repeated per registration.** A class declared inside a loop
+   or a repeatedly-called sub recompiles every method body on every registration (the
+   `compiled_code.is_some()` guard only helps within one `MethodDef`'s lifetime, and registration
+   builds fresh `MethodDef`s).
+2. **Role methods are compiled once per composing class, by accident.** Composition reads the
+   `role_candidates` snapshot (`registration_role_decl.rs:286-297`), which is cloned *before*
+   `compile_role_methods` runs (`vm_typedecl_ops.rs:672`), so composed defs arrive with
+   `compiled_code: None` and each composing class recompiles byte-identical bodies. (The compile
+   inputs are composition-invariant: package comes from the role, `T` resolves via env at call
+   time, `::?CLASS`/`::?ROLE` bind at method entry — see "Facts" below.)
+3. **One dispatch path recompiles per call.** `class_dispatch.rs:497-507` compiles into a local
+   `compiled_holder` clone and throws the result away after the call.
+4. **The main-pass compiler already compiles every method body once and discards the bytecode.**
+   `record_type_body_captures` (`src/compiler/helpers_sub_body.rs:752-786`) runs a full
+   `compile_closure_body` per top-level method statement purely to harvest
+   `free_var_writes` for `type_body_written_lexicals`, then drops the compiled code.
+5. **The throwaway compiler has zero lexical context** — no `inherit_enclosing_scopes`, no
+   `inherit_fold_ctx`, no `inherit_outer_code_var_names` — unlike `compile_sub_body`
+   (`helpers_sub_body.rs:205-259`). This is why a class declared inside a sub cannot see the
+   sub's lexicals (`sub outer($n) { class C { method m { $n * 2 } } }` — mutsu returns 0, raku
+   42). D3-8 does not fix that bug (it also needs runtime capture semantics), but the main-pass
+   mechanism is the prerequisite for ever fixing it.
+
+The goal mirrors Phase C: compile each method body **once, at main-pass compile time**, key it
+into the program's `CompiledFns` table, carry the key on the declaration plan, and have
+registration install `MethodDef.compiled_code` by table lookup — with
+`compile_method_def_in_place_with_dist` demoted to the fallback role `otf_compile_function_def`
+plays for subs (existing fallback narrowed, not a new one).
+
+## Facts the design rests on (survey results, 2026-08-08)
+
+**The Phase C mechanism to mirror** (`sub` side):
+
+- `Stmt::SubDecl` compilation order: plan + `RegisterDecl` emitted first (`stmt.rs:3180-3192`),
+  then the body compiled via `compile_sub_body_with_deprecation` (`stmt.rs:3235-3266`), then keys
+  attached to the plan via `set_sub_decl_compiled_routine_keys` (`stmt.rs:3283-3284`,
+  `opcode.rs:5742-5748`).
+- Keys index `CompiledFns = FxHashMap<Symbol, CompiledFunction>` (`opcode.rs:5874`), a side table
+  threaded through VM execution; `exec_register_sub_op` resolves
+  `compiled_fns.get(&compiled_routine_keys[slot])` with a length invariant that degrades to
+  "no bytecode" (runtime fallback) rather than a shifted mapping
+  (`vm_register_sub_ops.rs:249-254`).
+- Nested compilation units merge child `compiled_functions` into the parent with collision
+  renaming (`#import{N}`) plus `remap_sub_decl_compiled_routine_keys` rewriting every plan key,
+  recursively through `closure_compiled_codes` (`helpers_sub_body.rs:29-61`,
+  `opcode.rs:3249-3270`); the post-remap snapshot also becomes the routine's own
+  `CompiledFunction::compiled_fns` so detached values still resolve nested keys (C6e-3c).
+- A package-level `method` outside a class is *already* main-pass compiled through this exact
+  machinery: lowered to a synthetic `SubDecl` and compiled with the same four synthetic params
+  prepended (`stmt.rs:3286-3344`) — the direct precedent that method bodies compile fine through
+  `compile_sub_body`-shaped code.
+
+**What the runtime method compile actually depends on** (all of it available or replicable at
+main-pass time for the static-name case):
+
+- Package: `original_role`/`role_origin`/class storage name (`accessors_resolve.rs:30-35`). For a
+  class walker method this is the qualified class name; for a role walker method the qualified
+  role name. Statically known unless the declaration name is computed (`class ::($n)`), which is
+  exactly the case D3-1's `method_name_chunks` fallback already models.
+- `current_distribution` (`accessors_resolve.rs:36`): the runtime resolves it per class/role via
+  `resolve_package_distribution`; at main-pass time the enclosing compiler's
+  `current_distribution` is the declaring compunit's distribution — same value for a
+  declaration being compiled in its own compunit (verification item V3).
+- Effective params: `MethodDef.params`/`param_defs` are the *registration-derived* effective
+  set — `effective_method_param_defs` (`registration.rs:60-69`, appends `%_` unless
+  `is hidden`/explicit `*%`), auto-`@_` insertion driven by `auto_signature_uses(&body)`
+  (`registration_class_body_method.rs:83-118`), and `::?CLASS` type-constraint substitution
+  (`registration_class_body_method.rs:76-82`). All are pure functions of (AST, `is hidden`,
+  resolved class name). `is hidden` is a literal trait name on the declaration, statically
+  visible in the plan. The `::?CLASS` substitution rewrites `param_defs` *type-constraint
+  strings* only — bind-time data, not body-compile input (verification item V1 confirms type
+  constraint strings don't alter emitted bytecode).
+- `lexically_in_method = true` and the four synthetic params (`accessors_resolve.rs:41-48`).
+- Post-passes `compute_may_capture_outer_vars()` + `compute_needs_env_sync()`
+  (`accessors_resolve.rs:51-52`).
+- Nested subs land in the throwaway compiler's `compiled_functions`, carried as
+  `MethodDef::compiled_fns` (`accessors_resolve.rs:57-59`).
+
+**What the body compile does NOT depend on** (so one compile is sound):
+
+- The composing class: role param `T` is an ordinary env variable injected at method entry from
+  a class-keyed registry map (`vm_method_dispatch.rs:336-344`,
+  `registration_class_compose.rs:178-182`); type-constraint strings resolve `T` through the
+  env-alias fallback in `type_matches_value` (`types/type_matching.rs:846-852`). Composition
+  substitutes `param_defs` type strings (`registration_class.rs:275-300`) but clones `body` and
+  `compiled_code` untouched (`registration_class.rs:313,321`). Bodies are never AST-rewritten
+  per composition.
+- `::?CLASS`/`::?ROLE`: bound dynamically at method entry (`vm_method_dispatch.rs:279-291`),
+  reserved at compile time only as param *names*.
+- Param defaults and `where` clauses: evaluated at bind time from `param_defs` AST
+  (`types/binding_signature.rs:1143-1145`, `:60-61`), not compiled into the body.
+
+**Sites that must keep the runtime fallback** (legitimately dynamic, no plan or no static name):
+
+- `augment class` (no declaration plan at all — `Stmt::AugmentClass` still indexes `stmt_pool`;
+  its walker passes `method_decls: &[]` — `registration_class_augment.rs:1028`).
+- `.^add_method`/`.^add_multi_method` (hardcode `compiled_code: None`,
+  `methods_classhow_dispatch.rs:807`; served by `populate_uncompiled_method`,
+  `vm_call_method_compiled_cache.rs:222-248`).
+- Computed declaration names (`class ::($name) { ... }`) — no static package for the key.
+- Runtime mixins (`$x but R`) read the role's already-compiled `RoleDef.methods` directly
+  (`methods_mixin_dispatch.rs:143`), and role puns copy compiled defs — both become no-ops for
+  the bulk pass rather than fallback consumers.
+
+## Design decisions
+
+**1. Per-declaration key on `CompiledMethodDecl`, not a parallel keyed pool.**
+`CompiledMethodDecl` (D3-2/D3-7, `opcode.rs:392-412`) gains
+`compiled_routine_key: Option<Symbol>`. D3-7 already delivers these structs positionally to both
+walkers through the `method_name_chunk_idx` cursor, so the key needs no separate correlation
+mechanism and no signature-keyed pool slots — the "multi methods have no signature-keyed pool
+slot" complication from the scoping pass dissolves: each multi candidate is its own
+`CompiledMethodDecl` carrying its own key, and the registry dispatch table stays
+`Vec<MethodDef>` with per-candidate `compiled_code` exactly as today. `None` = "no main-pass
+bytecode, use the runtime fallback" (computed name, dynamic shape, or future guard bail).
+
+**2. The main-pass compile replicates the throwaway compiler bit-for-bit; parity first, lexical
+inheritance later.** The new compile path (a `compile_method_body` sibling of
+`compile_sub_body`) creates a bare sub-Compiler seeded exactly like
+`compile_method_def_in_place_with_dist`: `set_current_package(qualified declaration name)`,
+`current_distribution` from the enclosing compiler, `lexically_in_method = true`, synthetic
+params + compile-time effective params, `compile_routine_closure_body`, then
+`compute_may_capture_outer_vars`/`compute_needs_env_sync`. Deliberately NO
+`inherit_enclosing_scopes`/`inherit_fold_ctx`/`inherit_outer_code_var_names` in the first
+cutover: seeding them would change name resolution inside bodies (outer names would compile to
+slot references that don't exist in the method's runtime frame) — that is the future
+lexical-capture project, not this box. Parity makes the cutover mechanically verifiable: same
+inputs, same bytecode as the runtime compile produces today.
+
+**3. Effective params are computed at compile time by the same shared functions registration
+uses.** `effective_method_param_defs`, `has_explicit_named_slurpy`,
+`implicit_method_named_slurpy_param` (`registration.rs:23-69`) and `auto_signature_uses` move to
+(or are re-exported from) a location both the compiler and registration can call — one
+implementation, drift-proof by construction, the D2b/`CompiledAttrDecl` pattern. The compiler
+computes them from the plan's static facts (`is hidden` from the literal trait list); the
+`::?CLASS` substitution is registration-only (it needs the resolved class name) and by V1 does
+not affect the compiled body.
+
+**4. Registration installs by key with an equality guard, falling back on mismatch.**
+`class_body_method_decl`/`role_body_method_decl`, after building the `MethodDef` exactly as
+today, do: if `decl.compiled_routine_key` resolves in the ambient `CompiledFns` **and**
+`cf.params == [synthetic prefix] + def.params`, install
+`def.compiled_code = Some(Arc::new(cf.code.clone()))` and `def.compiled_fns = cf.compiled_fns`;
+otherwise leave `None` and let the existing bulk pass compile at runtime (unchanged fallback).
+The params-equality guard catches every case where registration-time effective params diverge
+from the compiler's assumption (however it might arise) and degrades to today's behavior instead
+of running mismatched bytecode — the same "degrade, never shift" philosophy as
+`vm_register_sub_ops.rs:249-254`.
+
+**5. Key shape and collision handling follow C2.** Keys are interned as
+`"{package}::{name}!m/{arity}#{fingerprint:x}"` (a `!m` marker keeps them disjoint from sub
+keys; fingerprint = `function_body_fingerprint` over the effective params/param_defs/body, which
+also disambiguates same-named multi candidates). Insertion into `Compiler::compiled_functions`
+reuses the existing collision rename; `remap_sub_decl_compiled_routine_keys`
+(`opcode.rs:3249-3270`) is extended to also rewrite
+`class_decl_plans[*].method_decls[*].compiled_routine_key` and the role-plan equivalent, so
+nested-compunit import keeps identity exactly as C2 does for subs.
+
+**6. The role N-compiles-to-1 dedup falls out for free.** Under this design the install happens
+inside `role_body_method_decl` — i.e. during `register_role_decl`, *before* the
+`role_candidates` snapshot is cloned (`registration_role_decl.rs:286-297`). The snapshot then
+carries `compiled_code`, composition's clones preserve it (`registration_class.rs:321`), and the
+per-composing-class recompile disappears without touching composition code.
+
+**7. `record_type_body_captures` stays untouched initially.** Its analysis compile inherits the
+enclosing scopes and package, so its free-var classification differs from the bare parity
+compile — reusing one for the other would silently change `type_body_written_lexicals`.
+Accepting two main-pass compiles per method body (one analysis, one kept) is the price of a
+verifiable cutover; merging them is a follow-up optimization once the parity compile is proven.
+
+**8. Measurable completion gate (ADR-0001 style).** Add a `MUTSU_VM_STATS` counter
+`method_body_runtime_compiles`, incremented in `compile_method_def_in_place_with_dist` when it
+actually compiles. The box's exit criterion: the counter is **zero** across a representative
+`t/` + roast S12/S14 sweep except for the enumerated dynamic shapes (`augment`, `.^add_method`,
+computed names), and the `class_dispatch.rs` per-call recompile path no longer fires for
+plan-declared methods.
+
+## Slice plan
+
+- **D3-8a — compiler side, additive, nothing reads it.** Shared effective-param functions;
+  `compile_method_body` (bare parity compile); per-decl key recorded on `CompiledMethodDecl`
+  during `add_class_decl_plan`/`add_role_decl_plan` for statically-named declarations;
+  remap-walk extension; the stats counter. No behavior change — validate with full `t/` +
+  targeted roast, plus a debug assertion (or test) that the parity compile of a sample corpus
+  byte-matches the runtime compile's output.
+- **D3-8b — class walker cutover.** `class_body_method_decl` installs by key with the guard of
+  decision 4. The bulk `compile_class_methods` pass stays (it now mostly no-ops via the
+  `compiled_code.is_some()` short-circuit and still serves fallback shapes). Verify with the
+  counter on `t/` and roast S12.
+- **D3-8c — role walker cutover.** Same for `role_body_method_decl`; verify the composition
+  dedup (counter drops for a `for ^N { class C does R {...} }`-shaped stress) and roast S14 +
+  the bundled-battery gate (`scripts/battery-testsuite.sh`), since parametric-role method
+  dispatch is load-bearing for Cro/the batteries.
+- **D3-8d — fallback narrowing survey.** Instrument-and-sweep (C6d precedent): confirm every
+  remaining `method_body_runtime_compiles` hit is an enumerated dynamic shape; record any
+  stragglers as their own tickets (candidates: proto method bodies registered as `FunctionDef`
+  via `registration_class_body.rs:292`, BUILD/TWEAK plan pinning, `nextsame` MRO walk — all
+  expected to be served automatically once defs carry bytecode, but the sweep proves it).
+
+Follow-ups explicitly out of this box, to be filed/kept as separate findings:
+
+- Merging `record_type_body_captures` with the parity compile (single main-pass compile per
+  method body).
+- Lexical capture for methods of a class declared inside a sub (needs runtime capture
+  semantics — the parity compile deliberately preserves today's dynamic-env behavior).
+- Persisting the `class_dispatch.rs:497-507` local-clone compile for the residual fallback
+  shapes (per-call recompile for `.^add_multi_method` candidates reached through that path).
+- `augment class` plans (D3-1's noted gap: `Stmt::AugmentClass` is outside the plan system).
+
+## Verification items (resolve during D3-8a, before the cutover slices)
+
+- **V1**: confirm `param_defs` type-constraint strings do not influence
+  `compile_routine_closure_body`'s emitted bytecode (they should be bind-time-only; if any
+  native-type slot specialization reads them, the guard in decision 4 must extend to
+  `param_defs` equality and the `::?CLASS`-substitution case falls back).
+- **V2**: confirm `cx.is_hidden` is derived only from the literal trait list (no computed
+  path), so the compile-time `%_` decision is sound.
+- **V3**: confirm `resolve_package_distribution(class)` equals the declaring compunit's
+  `current_distribution` for bundled batteries/modules (the two derivations differ today:
+  `compile_class_methods` resolves per class, `compile_role_methods` per role —
+  `accessors_resolve.rs:116,125`); if they can diverge, thread a plan-level distribution
+  instead.
+- **V4**: byte-parity spot check of the new compile against the runtime compile across a corpus
+  (e.g. every method body in `t/` fixtures) — cheap to script, catches any missed seeding.
+
+## Risk notes
+
+The change is architecture-correct-by-construction on the read side (registration behavior is
+unchanged whenever the key is absent or the guard fails), so the risk concentrates in silent
+bytecode divergence between the parity compile and the runtime compile — addressed by V1-V4 and
+the parity-first rule (decision 2). Per the working agreement on semantics-touching changes, run
+a local `make roast` before each cutover PR (D3-8b/c), not just `make test`.


### PR DESCRIPTION
## Summary

Design-only PR (no code): the detailed design pass for **ADR-0019 D3-8** — compiling method/submethod bodies through the single main-pass `Compiler` the way `SubDecl` bodies are (Phase C), instead of the throwaway per-registration `Compiler::new()` in `compile_method_def_in_place_with_dist`.

- New: `todo/deep/adr0019-d3-8-method-body-main-pass-compilation.md` — problem statement, survey facts (file:line), 8 design decisions, D3-8a–d slice plan, verification items V1–V4, risk notes.
- ADR-0019: condensed design-pass entry in the D3 section + progress-summary pointer.

## Key design points

- **Per-declaration `compiled_routine_key: Option<Symbol>` on `CompiledMethodDecl`** (delivered positionally by the existing D3-1/D3-7 cursor) — dissolves the "multi methods have no signature-keyed pool slot" complication from the scoping pass.
- **Body compilation is composition- and class-name-independent** (survey-confirmed): role type captures are env variables injected at method entry; `::?CLASS`/`::?ROLE` bind dynamically; the `::?CLASS` param substitution only rewrites bind-time `param_defs` strings. One compile per declaration is sound.
- **Parity-first**: the main-pass compile replicates the throwaway compiler's seeding exactly (no lexical-scope inheritance yet), making the cutover byte-verifiable.
- **Guarded install**: registration installs by key only when `cf.params` match the effective params; any mismatch degrades to today's runtime compile (existing fallback narrowed, not a new one).
- **Free role dedup**: installing at `role_body_method_decl` time (before the `role_candidates` snapshot clone) collapses today's accidental once-per-composing-class recompile to one compile.
- **Completion gate**: `MUTSU_VM_STATS` counter `method_body_runtime_compiles` must be zero outside the enumerated dynamic shapes (`augment`, `.^add_method`, computed names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)