### PR TITLE
fix(parser): NFC-normalize string literals from the source

### DIFF
--- a/news/2026-08/source-literals-are-nfc.md
+++ b/news/2026-08/source-literals-are-nfc.md
@@ -1,0 +1,40 @@
+# String literals in the source are NFC-normalized
+
+Raku's `Str` is NFG, so a literal written in the program text is normalized when
+the program is compiled. mutsu already normalized the buffer around an *escape*
+(`\x[2126]`, `\x[0041,0300]` — `parser/primary/string/escapes.rs`) and, since
+`news/2026-08/decoded-strings-are-nfc.md`, `.decode` output. Raw non-ASCII text
+in the source went through untouched:
+
+```raku
+my $lit = 'Ω';                    # written as U+2126 OHM SIGN
+say $lit.encode('utf-8').elems;    # raku: 2      mutsu: 3
+say $lit eq "\x[03A9]";            # raku: True   mutsu: False
+```
+
+## Fix
+
+`literal_str` in `parser/primary/string/helpers.rs` builds a string-literal
+`Value` through the shared `builtins::nfc` (the same helper the decode path
+uses, with its `is_nfc_quick` gate, so ASCII literals are free). Every
+`Expr::Literal(Value::str(…))` construction in the quoting constructs —
+single/double quotes, `q`/`qq`, heredocs, word quoting, `qx`, and the
+interpolation part-builders — goes through it.
+
+Pinned by `t/source-literals-are-nfc.t`. Its literals are written with U+2126 on
+purpose; the file says so, since an editor "tidying" them would silently make
+the test vacuous.
+
+## Effect
+
+Found while measuring the Cro suites: `t/http-request-parser.rakutest` failed
+exactly one of 344 checks,
+
+```raku
+*.query-value('ΩΩ') eqv '2omega';
+```
+
+and the test file really does spell `ΩΩ` with U+2126, while the value comes from
+percent-decoding `%E2%84%A6%E2%84%A6` — normalized since the decode fix, so the
+two no longer matched. **Cro's `t/http-request-parser.rakutest` is now
+344/344.**

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -232,15 +232,15 @@ fn decode_utf16_bytes(bytes: &[u8], big_endian: bool) -> Result<String, RuntimeE
         .map_err(|()| RuntimeError::new("Malformed UTF-16 string: unpaired surrogate (line 1)"))
 }
 
-/// NFC-normalize a decoded string. Raku's `Str` is NFG, so any string built from
-/// bytes is normalized at creation: `Buf.new(0xE2,0x84,0xA6).decode('utf-8')`
+/// NFC-normalize a string. Raku's `Str` is NFG, so any string built from bytes
+/// -- or read out of program source -- is normalized at creation: `Buf.new(0xE2,0x84,0xA6).decode('utf-8')`
 /// composes U+2126 OHM SIGN to U+03A9 GREEK CAPITAL LETTER OMEGA, and the result
 /// `eq`s a literal `"Ω"`. mutsu normalizes string *literals* at parse time
 /// (`parser/primary/string/escapes.rs`) but did not normalize decode output, so
 /// the two compared unequal even though `.ords` — which normalizes on read —
 /// reported the same code points. Cro's percent-decoding of a query key hit
 /// exactly this: `%E2%84%A6%E2%84%A6` decoded to a key no lookup could find.
-fn nfc(s: String) -> String {
+pub(crate) fn nfc(s: String) -> String {
     use unicode_normalization::{IsNormalized, UnicodeNormalization, is_nfc_quick};
     // `is_nfc_quick` answers `Yes` without allocating for the overwhelmingly
     // common already-normalized case (all-ASCII text answers immediately).

--- a/src/parser/primary/string/helpers.rs
+++ b/src/parser/primary/string/helpers.rs
@@ -362,3 +362,21 @@ pub(crate) fn process_q_escapes(content: &str, delim: char) -> String {
     }
     result
 }
+
+/// Build a string-literal `Value` from source text, NFC-normalized.
+///
+/// Raku's `Str` is NFG, so a literal written in the source is normalized when
+/// the program is compiled: a file containing U+2126 OHM SIGN yields a string
+/// that `eq`s `"\x[03A9]"` and encodes to two UTF-8 bytes. mutsu already
+/// normalized the buffer around an *escape* (`\x[2126]`, `\x[0041,0300]`) and,
+/// since `news/2026-08/decoded-strings-are-nfc.md`, `.decode` output — but raw
+/// non-ASCII text in the source went through untouched.
+///
+/// Cro's own test suite writes `'ΩΩ'` with U+2126 and compares it against a
+/// percent-decoded query key, so `*.query-value('ΩΩ')` never matched.
+///
+/// The `is_nfc_quick` gate inside makes this free for ASCII, which every hot
+/// literal is.
+pub(crate) fn literal_str(s: impl Into<String>) -> Value {
+    Value::str(crate::builtins::nfc(s.into()))
+}

--- a/src/parser/primary/string/heredoc.rs
+++ b/src/parser/primary/string/heredoc.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::ast::Expr;
 use crate::parser::parse_result::{PError, PResult};
 use crate::symbol::Symbol;
-use crate::value::Value;
 use crate::value::ValueView;
 
 use super::helpers::literal_str;

--- a/src/parser/primary/string/heredoc.rs
+++ b/src/parser/primary/string/heredoc.rs
@@ -5,6 +5,7 @@ use crate::symbol::Symbol;
 use crate::value::Value;
 use crate::value::ValueView;
 
+use super::helpers::literal_str;
 /// Find the newline that ends the *logical* source line starting at `r`.
 ///
 /// A heredoc body begins after the line on which the heredoc was introduced, but a
@@ -148,10 +149,10 @@ pub(crate) fn parse_to_heredoc_with_flags<'a>(
         } else if flags.q_mode {
             // q:heredoc processes \\ → \ (same as single-quoted strings)
             let processed = process_q_escapes(&content, '\0');
-            Expr::Literal(Value::str(processed))
+            Expr::Literal(literal_str(processed))
         } else {
             // `Q:to/.../` is verbatim: no interpolation, no escape processing.
-            Expr::Literal(Value::str(content))
+            Expr::Literal(literal_str(content))
         };
 
         // Apply word splitting if :w
@@ -161,7 +162,7 @@ pub(crate) fn parse_to_heredoc_with_flags<'a>(
             {
                 let words: Vec<Expr> = s
                     .split_whitespace()
-                    .map(|w| Expr::Literal(Value::str(w.to_string())))
+                    .map(|w| Expr::Literal(literal_str(w.to_string())))
                     .collect();
                 Expr::ArrayLiteral(words)
             } else {

--- a/src/parser/primary/string/interp_content.rs
+++ b/src/parser/primary/string/interp_content.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::ast::Expr;
 use crate::parser::expr::expression;
 use crate::parser::parse_result::PError;
-use crate::value::{Value, ValueView};
+use crate::value::ValueView;
 
 use super::helpers::literal_str;
 /// Assemble interpolation parts into a final expression.

--- a/src/parser/primary/string/interp_content.rs
+++ b/src/parser/primary/string/interp_content.rs
@@ -4,14 +4,15 @@ use crate::parser::expr::expression;
 use crate::parser::parse_result::PError;
 use crate::value::{Value, ValueView};
 
+use super::helpers::literal_str;
 /// Assemble interpolation parts into a final expression.
 pub(crate) fn finalize_interpolation(parts: Vec<Expr>, current: String) -> Expr {
     if parts.is_empty() {
-        Expr::Literal(Value::str(current))
+        Expr::Literal(literal_str(current))
     } else {
         let mut parts = parts;
         if !current.is_empty() {
-            parts.push(Expr::Literal(Value::str(current)));
+            parts.push(Expr::Literal(literal_str(current)));
         }
         if parts.len() == 1
             && matches!(&parts[0], Expr::Literal(v) if matches!(v.view(), ValueView::Str(_)))
@@ -60,7 +61,7 @@ pub(crate) fn interpolate_string_content_with_modes(
             && let Some(expr) = parse_braced_closure_body(inner.trim())
         {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(&mut current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(&mut current))));
             }
             parts.push(expr);
             rest = after;
@@ -151,7 +152,7 @@ pub(crate) fn try_embedded_qw(rest: &str) -> Option<(&str, Expr)> {
         let base = if interpolate {
             interpolate_string_content(inner)
         } else {
-            Expr::Literal(Value::str(inner.to_string()))
+            Expr::Literal(literal_str(inner.to_string()))
         };
         let words = Expr::MethodCall {
             target: Box::new(base),
@@ -173,7 +174,7 @@ pub(crate) fn parse_single_quote_qq(content: &str) -> Expr {
     while !rest.is_empty() {
         if let Some((after, words)) = try_embedded_qw(rest) {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(&mut current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(&mut current))));
             }
             parts.push(words);
             rest = after;
@@ -199,7 +200,7 @@ pub(crate) fn parse_single_quote_qq(content: &str) -> Expr {
             };
             if let Ok((after, interpolated)) = parsed {
                 if !current.is_empty() {
-                    parts.push(Expr::Literal(Value::str(std::mem::take(&mut current))));
+                    parts.push(Expr::Literal(literal_str(std::mem::take(&mut current))));
                 }
                 parts.push(interpolated);
                 rest = after;

--- a/src/parser/primary/string/interp_helpers.rs
+++ b/src/parser/primary/string/interp_helpers.rs
@@ -2,6 +2,7 @@ use crate::ast::Expr;
 use crate::symbol::Symbol;
 use crate::value::Value;
 
+use super::helpers::literal_str;
 /// Try to parse a postcircumfix call on an interpolated variable: "$var()" or "$var(args)".
 /// In Raku, `"$callable(args)"` invokes the callable during interpolation. Only triggers
 /// when `(` immediately follows the variable (or its index/postcircumfix). The argument
@@ -273,7 +274,7 @@ pub(crate) fn parse_shell_words_index(content: &str) -> Expr {
         return Expr::Var(var_name.to_string());
     }
     // Otherwise treat as literal string key
-    Expr::Literal(Value::str(trimmed.to_string()))
+    Expr::Literal(literal_str(trimmed.to_string()))
 }
 
 /// Handle double-sigil interpolation patterns like `@$name[]`, `%$name{}`, `$$name[]`, etc.
@@ -336,7 +337,7 @@ where
                 let (expr, r) = parse_postcircumfix_index(remainder, inner_expr.clone());
                 if r.len() < remainder.len() {
                     if !current.is_empty() {
-                        parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                        parts.push(Expr::Literal(literal_str(std::mem::take(current))));
                     }
                     parts.push(expr);
                     return Some(r);
@@ -352,7 +353,7 @@ where
                 let (expr, r) = parse_postcircumfix_index(remainder, inner_expr.clone());
                 if r.len() < remainder.len() {
                     if !current.is_empty() {
-                        parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                        parts.push(Expr::Literal(literal_str(std::mem::take(current))));
                     }
                     parts.push(expr);
                     return Some(r);
@@ -392,7 +393,7 @@ where
         let (expr, r) = parse_postcircumfix_index(remainder, inner_expr.clone());
         if r.len() < remainder.len() {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
             parts.push(expr);
             return Some(r);
@@ -405,7 +406,7 @@ where
     }
 
     if !current.is_empty() {
-        parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+        parts.push(Expr::Literal(literal_str(std::mem::take(current))));
     }
     parts.push(inner_expr);
     Some(remainder)

--- a/src/parser/primary/string/interp_helpers.rs
+++ b/src/parser/primary/string/interp_helpers.rs
@@ -1,6 +1,5 @@
 use crate::ast::Expr;
 use crate::symbol::Symbol;
-use crate::value::Value;
 
 use super::helpers::literal_str;
 /// Try to parse a postcircumfix call on an interpolated variable: "$var()" or "$var(args)".

--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -5,6 +5,7 @@ use crate::parser::primary::var::parse_var_name_from_str;
 use crate::symbol::Symbol;
 use crate::value::Value;
 
+use super::helpers::literal_str;
 /// Split a subscript's content on commas that are at the top nesting level
 /// (outside `[]`/`{}`/`()`/`<>` and string quotes), so `"@a[1,2]"` /
 /// `"%h{$x, $y}"` interpolation builds a slice rather than parsing only the
@@ -110,12 +111,14 @@ pub(crate) fn try_interpolate_var<'a>(
             let content = &after_lt[..end];
             let words: Vec<&str> = content.split_whitespace().collect();
             let index = if words.len() <= 1 {
-                Expr::Literal(Value::str(words.first().copied().unwrap_or("").to_string()))
+                Expr::Literal(literal_str(
+                    words.first().copied().unwrap_or("").to_string(),
+                ))
             } else {
                 Expr::ArrayLiteral(
                     words
                         .into_iter()
-                        .map(|w| Expr::Literal(Value::str(w.to_string())))
+                        .map(|w| Expr::Literal(literal_str(w.to_string())))
                         .collect(),
                 )
             };
@@ -145,7 +148,7 @@ pub(crate) fn try_interpolate_var<'a>(
                 } else if let Ok((_, expr)) = crate::parser::expr::expression(s) {
                     expr
                 } else {
-                    Expr::Literal(Value::str(s.to_string()))
+                    Expr::Literal(literal_str(s.to_string()))
                 }
             };
             let parts = split_top_level_commas(content);
@@ -222,7 +225,7 @@ pub(crate) fn try_interpolate_var<'a>(
         // Special variable $/ (match variable)
         if next == '/' {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
             let var_expr = Expr::Var("/".to_string());
             let (expr, var_rest) = parse_postcircumfix_index(&rest[2..], var_expr);
@@ -236,11 +239,11 @@ pub(crate) fn try_interpolate_var<'a>(
             && let Some(end) = after_lt.find('>')
         {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
             let key = &after_lt[..end];
             let var_expr = Expr::Var("/".to_string());
-            let index = Expr::Literal(Value::str(key.to_string()));
+            let index = Expr::Literal(literal_str(key.to_string()));
             let expr = Expr::Index {
                 target: Box::new(var_expr),
                 index: Box::new(index),
@@ -254,7 +257,7 @@ pub(crate) fn try_interpolate_var<'a>(
         // Numeric capture variables: $0, $1, $2, ...
         if next.is_ascii_digit() {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
             let var_rest = &rest[1..];
             let end = var_rest
@@ -322,7 +325,7 @@ pub(crate) fn try_interpolate_var<'a>(
                 };
                 if let Some(expr) = parsed {
                     if !current.is_empty() {
-                        parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                        parts.push(Expr::Literal(literal_str(std::mem::take(current))));
                     }
                     parts.push(expr);
                     return Some(remainder);
@@ -332,11 +335,11 @@ pub(crate) fn try_interpolate_var<'a>(
         // ${...} is Perl 5 scalar dereference syntax — throw X::Obsolete
         if next == '{' {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
             parts.push(Expr::Call {
                 name: Symbol::intern("die"),
-                args: vec![Expr::Literal(Value::str(
+                args: vec![Expr::Literal(literal_str(
                     "X::Obsolete: Unsupported use of ${expr}. In Raku please use: $(expr)."
                         .to_string(),
                 ))],
@@ -357,7 +360,7 @@ pub(crate) fn try_interpolate_var<'a>(
             || next == '^'
         {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
             let var_rest = &rest[1..];
             let (var_rest, var_name) = parse_var_name_from_str(var_rest);
@@ -377,7 +380,7 @@ pub(crate) fn try_interpolate_var<'a>(
             if var_name == "?FILE"
                 && let Some(file) = crate::parser::stmt::simple::parser_source_file()
             {
-                parts.push(Expr::Literal(Value::str(file)));
+                parts.push(Expr::Literal(literal_str(file)));
                 return Some(var_rest);
             }
             let (expr, var_rest) = parse_postcircumfix_index(var_rest, Expr::Var(var_name));
@@ -394,7 +397,7 @@ pub(crate) fn try_interpolate_var<'a>(
                 let first = after_dot.as_bytes()[0];
                 if first.is_ascii_alphabetic() || first == b'_' {
                     if !current.is_empty() {
-                        parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                        parts.push(Expr::Literal(literal_str(std::mem::take(current))));
                     }
                     let end = after_dot
                         .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
@@ -436,11 +439,11 @@ pub(crate) fn try_interpolate_var<'a>(
         // @{...} is Perl 5 array dereference syntax — throw X::Obsolete
         if next == '{' {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
             parts.push(Expr::Call {
                 name: Symbol::intern("die"),
-                args: vec![Expr::Literal(Value::str(
+                args: vec![Expr::Literal(literal_str(
                     "X::Obsolete: Unsupported use of @{expr}. In Raku please use: @(expr)."
                         .to_string(),
                 ))],
@@ -473,7 +476,7 @@ pub(crate) fn try_interpolate_var<'a>(
                 return None;
             }
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
             parts.push(expr);
             return Some(remainder);
@@ -493,7 +496,7 @@ pub(crate) fn try_interpolate_var<'a>(
             // Zen-slice: %hash{} should stringify the whole hash
             if let Some(r) = tail.strip_prefix("{}") {
                 if !current.is_empty() {
-                    parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                    parts.push(Expr::Literal(literal_str(std::mem::take(current))));
                 }
                 parts.push(expr);
                 return Some(r);
@@ -501,7 +504,7 @@ pub(crate) fn try_interpolate_var<'a>(
             // Zen-slice: %hash<> should stringify the whole hash
             if let Some(after_zen) = tail.strip_prefix("<>") {
                 if !current.is_empty() {
-                    parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                    parts.push(Expr::Literal(literal_str(std::mem::take(current))));
                 }
                 parts.push(expr);
                 return Some(after_zen);
@@ -509,7 +512,7 @@ pub(crate) fn try_interpolate_var<'a>(
             // Zen-slice: %hash[] should stringify the whole hash
             if let Some(r) = tail.strip_prefix("[]") {
                 if !current.is_empty() {
-                    parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                    parts.push(Expr::Literal(literal_str(std::mem::take(current))));
                 }
                 parts.push(expr);
                 return Some(r);
@@ -526,7 +529,7 @@ pub(crate) fn try_interpolate_var<'a>(
                 return None;
             }
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(current))));
             }
             parts.push(expr);
             return Some(remainder);
@@ -582,7 +585,7 @@ pub(crate) fn try_interpolate_var<'a>(
                         args
                     };
                     if !current.is_empty() {
-                        parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+                        parts.push(Expr::Literal(literal_str(std::mem::take(current))));
                     }
                     parts.push(Expr::Call {
                         name: Symbol::intern(name),

--- a/src/parser/primary/string/q_string.rs
+++ b/src/parser/primary/string/q_string.rs
@@ -4,6 +4,7 @@ use crate::parser::parse_result::{PError, PResult};
 use crate::symbol::Symbol;
 use crate::value::{Value, ValueView};
 
+use super::helpers::literal_str;
 /// Parse Q quoting with arbitrary delimiters: Q!...!, Q{...}, Q/.../, etc.
 /// Q means no interpolation and no escape processing — content is taken verbatim.
 pub(crate) fn big_q_string(input: &str) -> PResult<'_, Expr> {
@@ -142,7 +143,7 @@ pub(crate) fn apply_post_processing<'a>(
                     .collect()
             } else {
                 s.split_whitespace()
-                    .map(|w| Expr::Literal(Value::str(w.to_string())))
+                    .map(|w| Expr::Literal(literal_str(w.to_string())))
                     .collect()
             };
             return Ok((after, make_word_result_expr(words)));
@@ -295,7 +296,7 @@ pub(crate) fn q_string(input: &str) -> PResult<'_, Expr> {
         && !flags.full_backslash()
     {
         let processed = process_q_escapes(content, delim_char);
-        let expr = Expr::Literal(Value::str(processed));
+        let expr = Expr::Literal(literal_str(processed));
         return apply_post_processing(rest, expr, &flags);
     }
 
@@ -372,7 +373,7 @@ pub(crate) fn make_q_content_expr(
                 s.push(c);
             }
         }
-        Expr::Literal(Value::str(s))
+        Expr::Literal(literal_str(s))
     }
 }
 

--- a/src/parser/primary/string/quoted.rs
+++ b/src/parser/primary/string/quoted.rs
@@ -3,7 +3,6 @@ use crate::ast::Expr;
 use crate::parser::expr::expression;
 use crate::parser::parse_result::{PError, PResult, parse_char};
 use crate::token_kind::{lookup_emoji_sequence, lookup_unicode_char_by_name};
-use crate::value::Value;
 
 use super::helpers::literal_str;
 pub(crate) fn single_quoted_string(input: &str) -> PResult<'_, Expr> {

--- a/src/parser/primary/string/quoted.rs
+++ b/src/parser/primary/string/quoted.rs
@@ -5,6 +5,7 @@ use crate::parser::parse_result::{PError, PResult, parse_char};
 use crate::token_kind::{lookup_emoji_sequence, lookup_unicode_char_by_name};
 use crate::value::Value;
 
+use super::helpers::literal_str;
 pub(crate) fn single_quoted_string(input: &str) -> PResult<'_, Expr> {
     let (input, _) = parse_char(input, '\'')?;
     let start = input;
@@ -83,7 +84,7 @@ pub(crate) fn smart_single_quoted_string(input: &str) -> PResult<'_, Expr> {
             let content = &start[..start.len() - rest.len()];
             return Ok((
                 &rest[ch.len_utf8()..],
-                Expr::Literal(Value::str(content.to_string())),
+                Expr::Literal(literal_str(content.to_string())),
             ));
         }
         rest = &rest[ch.len_utf8()..];
@@ -111,7 +112,7 @@ pub(crate) fn corner_bracket_string(input: &str) -> PResult<'_, Expr> {
     if depth == 0 {
         let content = &rest[..pos];
         let after = &rest[pos + '｣'.len_utf8()..];
-        Ok((after, Expr::Literal(Value::str(content.to_string()))))
+        Ok((after, Expr::Literal(literal_str(content.to_string()))))
     } else {
         Err(PError::expected("closing ｣"))
     }
@@ -231,7 +232,7 @@ pub(crate) fn double_quoted_string(input: &str) -> PResult<'_, Expr> {
         // Block interpolation: { expr }
         if rest.starts_with('{') {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(&mut current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(&mut current))));
             }
             // Find matching close brace (tracking nesting). Braces inside a
             // quoted string within the block must NOT count — e.g.
@@ -380,7 +381,7 @@ pub(crate) fn smart_double_quoted_string(input: &str) -> PResult<'_, Expr> {
         }
         if rest.starts_with('{') {
             if !current.is_empty() {
-                parts.push(Expr::Literal(Value::str(std::mem::take(&mut current))));
+                parts.push(Expr::Literal(literal_str(std::mem::take(&mut current))));
             }
             let mut depth = 0;
             let mut end = 0;

--- a/src/parser/primary/string/quotewords.rs
+++ b/src/parser/primary/string/quotewords.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::ast::Expr;
 use crate::parser::parse_result::PError;
-use crate::value::Value;
 
 use super::helpers::literal_str;
 pub(crate) fn parse_quotewords_items(

--- a/src/parser/primary/string/quotewords.rs
+++ b/src/parser/primary/string/quotewords.rs
@@ -3,6 +3,7 @@ use crate::ast::Expr;
 use crate::parser::parse_result::PError;
 use crate::value::Value;
 
+use super::helpers::literal_str;
 pub(crate) fn parse_quotewords_items(
     content: &str,
     flags: &crate::parser::primary::quote_adverbs::QuoteFlags,
@@ -143,7 +144,7 @@ pub(crate) fn parse_quotewords_unicode_quoted_atom(input: &str) -> Option<(&str,
 
 pub(crate) fn parse_quotewords_single_quote_atom(input: &str) -> Option<(&str, Expr)> {
     let (rest, content) = parse_quotewords_quote_span(input, &['‘', '’'])?;
-    Some((rest, Expr::Literal(Value::str(content.to_string()))))
+    Some((rest, Expr::Literal(literal_str(content.to_string()))))
 }
 
 pub(crate) fn parse_quotewords_quote_span<'a>(

--- a/src/parser/primary/string/qx.rs
+++ b/src/parser/primary/string/qx.rs
@@ -4,6 +4,7 @@ use crate::parser::parse_result::{PError, PResult};
 use crate::symbol::Symbol;
 use crate::value::Value;
 
+use super::helpers::literal_str;
 /// Parse qx{...}, qqx{...} forms.
 /// qx executes with single-quote (backslash) interpolation.
 /// qqx executes with full interpolation.
@@ -44,7 +45,7 @@ pub(crate) fn qx_string(input: &str) -> PResult<'_, Expr> {
     } else {
         // qx uses q-style backslash (only \\ → \)
         let s = content.replace("\\\\", "\\");
-        Expr::Literal(Value::str(s))
+        Expr::Literal(literal_str(s))
     };
 
     Ok((

--- a/src/parser/primary/string/qx.rs
+++ b/src/parser/primary/string/qx.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::ast::Expr;
 use crate::parser::parse_result::{PError, PResult};
 use crate::symbol::Symbol;
-use crate::value::Value;
 
 use super::helpers::literal_str;
 /// Parse qx{...}, qqx{...} forms.

--- a/t/source-literals-are-nfc.t
+++ b/t/source-literals-are-nfc.t
@@ -1,0 +1,26 @@
+use Test;
+
+plan 7;
+
+# Raku's Str is NFG, so a literal written in the source is normalized when the
+# program is compiled. mutsu already normalized the buffer around an *escape*
+# (`\x[2126]`, `\x[0041,0300]`) and, since
+# news/2026-08/decoded-strings-are-nfc.md, `.decode` output — but raw non-ASCII
+# text in the source went through untouched, so a file containing U+2126 OHM
+# SIGN produced a string that did not `eq` "\x[03A9]".
+#
+# The literals below are written with U+2126 on purpose; do not "tidy" them.
+
+is 'Ω'.encode('utf-8').elems, 2, 'a single-quoted literal is NFC-normalized';
+ok 'Ω' eq "\x[03A9]", 'and equals the composed form';
+is "Ω".encode('utf-8').elems, 2, 'an interpolating literal too';
+is q{Ω}.encode('utf-8').elems, 2, 'a q{} literal too';
+is qq{Ω}.encode('utf-8').elems, 2, 'a qq{} literal too';
+
+# Decomposed sequences written literally compose as well.
+is "e\c[COMBINING ACUTE ACCENT]".chars, 1, 'an escape-built decomposed pair still composes';
+
+# A hash key written with the un-normalized form finds the composed key.
+my %h;
+%h{"\x[03A9]"} = 'v';
+is %h{'Ω'}, 'v', 'an un-normalized literal key finds the composed entry';


### PR DESCRIPTION
## Problem

```raku
my $lit = 'Ω';                    # written as U+2126 OHM SIGN
say $lit.encode('utf-8').elems;    # raku: 2      mutsu: 3
say $lit eq "\x[03A9]";            # raku: True   mutsu: False
```

Raku's `Str` is NFG, so a literal written in the program text is normalized when the program is compiled. mutsu already normalized the buffer around an *escape* (`\x[2126]`, `\x[0041,0300]` — `parser/primary/string/escapes.rs`) and, since #6060, `.decode` output. Raw non-ASCII text in the source went through untouched.

## Fix

`literal_str` (in `parser/primary/string/helpers.rs`) builds a string-literal `Value` through the shared `builtins::nfc` — the same helper the decode path uses, with its `is_nfc_quick` gate, so ASCII literals are free. Every `Expr::Literal(Value::str(…))` construction in the quoting constructs goes through it: single/double quotes, `q`/`qq`, heredocs, word quoting, `qx`, and the interpolation part-builders.

## Effect

Found while measuring the Cro suites. `t/http-request-parser.rakutest` failed exactly one of its 344 checks:

```raku
*.query-value('ΩΩ') eqv '2omega';
```

The test file really does spell `ΩΩ` with U+2126, while the value comes from percent-decoding `%E2%84%A6%E2%84%A6` — normalized since the decode fix, so the two no longer matched. **That file is now 344/344** (verified on a release build).

## Tests

- New pin: `t/source-literals-are-nfc.t` — single-quoted, interpolating, `q{}`, `qq{}`, an escape-built decomposed pair, and an un-normalized literal used as a hash key against a composed entry. Verified against real `raku`. Its literals are written with U+2126 on purpose and the file says so, since "tidying" them would silently make the test vacuous.
- `make test` green (2962 files, 27949 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)