### PR TITLE
docs(adr): detailed designs for all remaining ADR-0019 Phase D boxes

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -132,7 +132,16 @@ closed as already-bytecode-native (a lateral move, not a gain), its "deferred cl
 folds into D8 rather than needing its own slice, and its "parent expressions" piece is a real
 re-parse-per-registration bug but is gated on parser/AST work and constrained by a shared `&str`
 resolver API also used for genuinely dynamic type-name concretization — scoped as future
-D4-1/D4-2/D4-3. D1 found most class structural data already typed-plan-driven
+D4-1/D4-2/D4-3. A 2026-08-08 design sweep then produced detailed designs for **every remaining
+Phase D box** — the D2 remainder, D4, D5, D6, D7, D8, D9, and D10 — recorded as
+`todo/deep/adr0019-d2-remainder-attr-plan-lowering.md`, `adr0019-d4-parent-expr-chunks.md`,
+`adr0019-d5-plan-driven-how-ops.md`, `adr0019-d6-d9-legacy-body-removal.md` (includes the
+grep-complete `legacy_body` reader inventory and D10), and
+`adr0019-d7-d8-role-plan-encoding.md`, with condensed entries in each box below; the notable
+re-scope is D5, which shrank to ordering invariants plus a verification gate riding on D6 (the
+user-HOW protocol never reads a raw `Stmt`). The recommended cross-box order is D2b-2 →
+D6-1..3 (with D3-8a-d and D4-1/2 in parallel) → D4-3 → D7 → D8 → D9 → the two field drops →
+D5's gate → D10. D1 found most class structural data already typed-plan-driven
 from Phase A3/A4; the two remaining body-scanning reads (stub detection, `Stmt::TrustsDecl`) are
 now precomputed at plan lowering as `CompiledClassDeclPlan::is_stub`/`trusts`; see
 `news/2026-08/d1-class-structural-plan-fields.md`. D2, unlike D1, found attribute data with no
@@ -551,6 +560,18 @@ walkers wholesale is not possible before then.
     are already a single source of truth kept in lockstep by `sync_user_method_entries` — reading
     one over the other here is a lateral move, not a mechanism unification, so it does not meet the
     ADR's own "gain" bar (see CLAUDE.md's "What gain and risk actually mean"). D2d is done.
+  **D2 remainder design pass done 2026-08-08 (no code landed):**
+  `todo/deep/adr0019-d2-remainder-attr-plan-lowering.md`. The D2b position-correlation blocker
+  is now precisely characterized (the runtime walk *appends* nested-sub `has` decls while the
+  compiler collector *interleaves* them — genuinely different orders, plus a latent double-push
+  in the collector), so the plan lowering is **name-keyed** (`attr_decls: Vec<(Symbol,
+  CompiledAttrDecl)>`, the `is_default_chunks` precedent) with `from_stmt` kept as the guarded
+  fallback (slice D2b-2, also a D6/D9 prerequisite). For the D2c remainder, every default/where
+  eval site already funnels through `eval_decl_trait_arg`, so flipping to
+  `DeclTraitArg::Compiled` needs no eval-site changes — the work is construction-side plus
+  retiring the two `as_expr` consumers that would panic on `Compiled` in the same slice
+  (D2c-4); the A/B env-setup unification stays optional (D2c-5) behind raku verification of
+  shape B's `has_class_scoped_subs` gate.
 - [ ] **D3 — Encode class methods and submethods as compiled candidates.** Install ordinary, multi,
   proto, private, rw, wrap, BUILD, and TWEAK metadata without walking `Stmt::MethodDecl`. That
   walk exists in three places, not one — the class walker (~508 lines), the role walker
@@ -837,23 +858,97 @@ walkers wholesale is not possible before then.
   correctness bug, independent of ADR-0019's declaration-plan migration either way; filed as
   `todo/tickets/also-does-role-bracket-args-dropped-in-class-body.md` rather than fixed here, since
   a correct fix means porting a ~200-line carryover block, not a one-line parser change.
+  **D4 design pass done 2026-08-08 (no code landed):**
+  `todo/deep/adr0019-d4-parent-expr-chunks.md` details the D4-1/2/3 sub-boxes: D4-1 (parser
+  captures bracket args as parsed `Vec<Expr>` alongside the unchanged concatenated string —
+  parse failure keeps the string path, so nothing currently accepted is rejected; also found
+  three concat sites beyond the original four, including the role-side synthetic `DoesDecl`),
+  D4-2 (class-plan `parent_arg_chunks` via `compile_decl_trait_arg`; the role-body site's
+  carriage deliberately joins D7's `parent_ops` instead of a throwaway field), D4-3
+  (`resolve_role_candidate` gains `pre_args: Option<&[Value]>` — only the
+  `eval_role_arg_values` call swaps, everything downstream already operates on values; the
+  cutover is gated on a raku case table because the string path's heuristics sometimes produce
+  type objects where naive evaluation would not). The `Expr` path also fixes
+  `split_balanced_comma_list`'s quote-blindness (`R["a,b"]` mis-splits today) for free.
 - [ ] **D5 — Drive user HOW operations from plan ops.** Execute `new_type`, `add_method`, trait
   interception, and `compose` without entering `register_class_decl`'s AST walker.
+  **Design pass done 2026-08-08 (no code landed) — the box shrinks:**
+  `todo/deep/adr0019-d5-plan-driven-how-ops.md`. The survey found the user-HOW protocol
+  (`new_type`/`add_method`/`compose`) runs entirely *after* native registration and reads the
+  finished registry, never a raw `Stmt` — `add_method` re-enumerates registry `MethodDef`s,
+  `add_attribute` is never called by mutsu, trait-interception inputs are all plan-resident
+  (class traits on the plan, method traits/bodies on `CompiledMethodDecl`, attribute traits
+  closed by D2b-2). D5 is therefore not a migration: D5-1 codifies the ordering invariants
+  D6's cutover must keep (shell → registry-authoritative interleaved body writes → HOW
+  instantiate → new_type → add_method → trait dispatch → compose; HOW installs keyed on the
+  resolved storage name), and D5-2 is a verification gate (OO::Monitors battery + metamodel
+  roast) riding on D6's slices rather than a separate code PR.
 - [ ] **D6 — Remove `CompiledClassDeclPlan::legacy_body`.** Preserve augmentation, rollback,
   redeclaration errors, language revisions, nested types, and EVAL behavior. Excludes the
   token/rule arms (see the phase preamble). Start with the C6d-style instrumentation survey —
   C6's one box became nine PRs, and this field has the same shape.
+  **Survey + design pass done 2026-08-08 (no code landed):**
+  `todo/deep/adr0019-d6-d9-legacy-body-removal.md` holds the grep-complete reader inventory
+  (the only destructuring reads are the two register ops; no reader exists outside
+  registration; augment reads `stmt_pool`, unaffected) and the design: a typed ordered
+  `body_plan: Vec<ClassBodyOp>` lowered at compile time, whose `Other` arm carries a
+  per-statement `CompiledDeclExpr` chunk replacing `class_body_other_stmt`'s
+  per-registration `run_block_raw` OTF compile — the driver keeps its exact env-seeding /
+  BEGIN-swallowing / writeback / re-publish structure, only the statement source changes.
+  The token/rule exclusion is carried as an `Other.raw` rump (the C6 `FunctionDef.body`
+  precedent). Notable freebies found: the `TrustsDecl` walk arm is redundant with D1's plan
+  field (deletable now), and `persist_class_body_statics`' body re-scan becomes a
+  `declared_static_names` plan fact. Slices D6-1 (cheap facts + dead arm), D6-2 (= D2b-2),
+  D6-3 (`body_plan`, instrument-gated, expected to subdivide per arm like C6d), D6-4 (field
+  drop via the C6e-3c forced-instrument playbook).
 - [ ] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
+  **Design pass done 2026-08-08 (no code landed):**
+  `todo/deep/adr0019-d7-d8-role-plan-encoding.md`. The role plan gains the class side's
+  missing twins (`is_stub`, our-scope violation — the role plan has no D1-style fields at
+  all), name-keyed `attr_decls`, typed `parent_ops` (replacing the
+  `__mutsu_role_hides__`/`__mutsu_role_hidden__` string-marker encoding and carrying D4's
+  arg chunks for the role-body `does` site), and a `body_plan` op walk. Deliberately narrower
+  than the box text sounds: candidate selection, trial binding, specificity, conflict and
+  required-method detection, and pun materialization read the *registry*, not the AST, and
+  stay runtime — the declaration's own structure becomes plan data; the composition algebra
+  over it does not move. Slices D7-1..4 in the doc.
 - [ ] **D8 — Compile role declaration-time bodies and traits.** Run parameterized-role and composed
   ancestor bodies as bytecode child chunks with correct once-per-composition behavior. (Custom-trait
   arguments already landed with C5; the bodies remain.)
+  **Design pass done 2026-08-08 (no code landed), same doc as D7.** Unit of compilation is
+  **one chunk per deferred statement** (not per body): the five consumer sites' per-statement
+  package routing (type decls → role package, token/rule → composing class package), the
+  lexical-persistence scan (becomes a precomputed `declared_vars`), and the
+  `X::Role::Instantiation` wrapping all operate at statement granularity, so consumers keep
+  their exact env dance and swap only `run_block_raw(stmt)` for `run_decl_expr(chunk)`. The
+  frozen-plan concern (nested declarations' plans lowered once per role rather than per
+  composition) resolves to a verification item, not a blocker — registration is
+  per-execution and composition-dependent names resolve through the env; a failing case keeps
+  a raw fallback. Once-per-composition semantics are *preserved*, not changed (the current
+  role-global `pun:`/`mixin:` memos and the unguarded class path are recorded; any
+  raku-conformance divergence gets its own ticket). Includes the `run_role_submethod` rider
+  (the C6d-3 leftover goes bytecode after D3-8). Slices D8-1..4 in the doc.
 - [ ] **D9 — Remove `CompiledRoleDeclPlan::legacy_body`.** Preserve role puns, runtime mixins,
   conflicts, BUILD/TWEAK, custom HOWs, and EVAL. Same rule as D6: survey first, token/rule arms
   excluded.
+  **Survey + design pass done 2026-08-08 (no code landed), same doc as D6.** The role body's
+  structural difference from the class side: its non-declaration statements *escape
+  registration* into `RoleDef::deferred_body_stmts` and run per composition — so D9 is
+  sequenced after D8 by necessity, exactly as the D4 scoping pass concluded. Slices D9-1
+  (role `is_stub` + our-scope plan facts, = D7-1), D9-2 (= D2b-2 role half), D9-3 (= D7-3),
+  D9-4 (= D8 chunks), D9-5 (field drop, forced-instrument playbook).
 - [ ] **D10 — Delete class/role AST registration walkers.** Keep only VM plan execution plus
   metadata helpers that do not inspect executable AST declarations. The token/rule arms of the
   body walk stay until their ADR-0009-scoped slice lands; D10 deletes everything else.
+  **Design note 2026-08-08 (in the D6/D9 doc):** D10 needs no separate mechanism — after
+  D6-4/D9-5 the walkers *are* the plan-op executors; D10 is a cleanup PR deleting residual
+  raw-`Stmt` match arms and orphaned helpers, with grep-based completion criteria (no
+  `Stmt::`-matching registration code outside token/rule routing and the `stmt_pool`-fed
+  augment walker; no runtime `from_stmt` callers outside augment/EVAL fallbacks). If it grows
+  beyond a cleanup PR, an earlier slice landed incompletely. The doc also fixes the
+  cross-box dependency order: D2b-2 → D6-1..3 (D3-8a-d and D4-1/2 parallel) → D4-3 → D7 →
+  D8 → D9 → field drops → D5 gate → D10.
 
 ### Phase E — one dispatch resolver and native handler table
 

--- a/todo/deep/adr0019-d2-remainder-attr-plan-lowering.md
+++ b/todo/deep/adr0019-d2-remainder-attr-plan-lowering.md
@@ -1,0 +1,84 @@
+# ADR-0019 D2 remainder design: plan-lowered attribute descriptors and compiled default/where chunks
+
+Design pass (2026-08-08, no code landed) for the two open pieces of the D2 box: the D2b
+remainder (compiler-lowered `Vec<CompiledAttrDecl>` on the plans) and the D2c remainder
+(actually using `DeclTraitArg::Compiled` for `default`/`where_constraint`, which today still
+recompile per construction through the `Ast` variant). Builds on
+`todo/deep/adr0019-d2c-attribute-default-chunks.md` (the 2026-08-07 research pass) and a fresh
+2026-08-08 survey.
+
+## Position correlation: name-keyed is the answer, and now we know why positional fails
+
+The D2b deferral reason ("position-correlating the precomputed vec with the registration-time
+statement walk") is now precisely characterized:
+
+- The runtime class walk flattens one level of `SyntheticBlock`, then
+  `collect_nested_class_has_decls` **appends** nested-sub `has` decls to the **end**
+  (`registration_class_body.rs:66-82,121`).
+- The compiler-side collector `collect_attr_is_default_chunks` (`compiler/decl_plan.rs:139-186`)
+  instead **interleaves** nested-sub attrs at the enclosing `SubDecl`'s position — a genuinely
+  different order. (It also double-pushes a nested `has ... is default` — once from the
+  `SubDecl` arm's direct loop, once from its recursion — harmless under name-keyed first-match
+  lookup, but a latent trap any positional design would trip on.)
+- Role walks have no nested-sub surfacing at all (`registration_role_decl.rs:194-231`), so
+  positional would work there — but uniformity wins.
+
+Since an attribute name is unique per class/role, **name-keying** (the `is_default_chunks`
+precedent, `opcode.rs:2533-2538`, looked up in `registration_class_body_attr.rs:124-131`)
+sidesteps order entirely. Decision: the D2b remainder lowers
+`CompiledClassDeclPlan::attr_decls: Vec<(Symbol, CompiledAttrDecl)>` /
+`CompiledRoleDeclPlan::attr_decls` **keyed by attribute name**, built by a collector that fixes
+the double-push. `class_body_has_decl`/`role_body_has_decl` look up by the current
+`Stmt::HasDecl`'s name and fall back to `CompiledAttrDecl::from_stmt` when absent (augment,
+EVAL, runtime `has`, and any future mismatch) — the same guarded-degrade shape as every other
+plan cutover. `is_default_chunks` folds into the lowered struct (its `is_default` field) and
+the separate plan field retires.
+
+## Compiled default/where chunks: the eval sites are ready; the work is construction-side
+
+The 2026-08-08 survey confirmed all three env-setup shapes (A:
+`attr_build_defaults.rs:287-335`; B: `methods_object_default_ctor.rs:204-298`; C:
+`methods_object_dispatch_new.rs:2146-2163`) and both where-constraint sites
+(`methods_object_attr_constraints.rs:6-22,356` — which set up **no** env at all) already funnel
+through `eval_decl_trait_arg`, which handles `Compiled` transparently via `run_decl_expr`.
+Chunks compile slot-free (`compile_decl_expr`, `decl_plan.rs:19-37`), so they read
+`self`/`?CLASS`/`!attr`/`.attr` from whatever env the shapes populate — **no eval-site changes
+are needed to flip the variant**. The construction-side work:
+
+1. At plan lowering, compile each attribute's `default`/`where_constraint` expression into
+   `DeclTraitArg::Compiled` inside the lowered `CompiledAttrDecl` (keeping the
+   `compile_decl_trait_arg` literal short-circuit, so the 9 literal fast paths stay literal).
+2. **Retire the two `as_expr` consumers that would panic on `Compiled`**
+   (`DeclTraitArg::as_expr` is `unreachable!` on `Compiled`, `opcode.rs:2145-2153`):
+   - `extract_shape_from_default` (`methods_object_dispatch_new.rs:1823`) reads the default
+     `Expr` to derive a declared shape for `@`-sigil attrs — a **pure syntactic fact**;
+     precompute it at lowering into a `CompiledAttrDecl::declared_shape` field (D2a pattern).
+   - `.^attributes` introspection builds a build closure from the default `Expr`
+     (`methods_classhow_attribute.rs:248-255`) — rebuild the closure around
+     `eval_decl_trait_arg` on the stored `DeclTraitArg` instead of the raw `Expr`.
+   These two must land in the same slice as (1) or the panic-free invariant documented on
+   `ClassAttributeDef` (`runtime/mod.rs:448-454`) breaks.
+3. The three role registry tables are already `DeclTraitArg`-valued (D2c-3); once role
+   `attr_decls` carry `Compiled`, the tables receive `Compiled` for free (the earlier research
+   pass confirmed role type params bind at env level, so a single compile-time chunk is sound
+   for `is default(T)`-shaped role defaults).
+
+The A/B env-setup unification (shape B's `has_class_scoped_subs` package-switch gate and extra
+`__ANON_STATE__`/`constructing_class` bindings vs shape A's unconditional switch) remains a
+**separate optional slice** gated on raku-behavior verification, exactly as the research pass
+flagged — flipping the variant does not require it.
+
+## Slices
+
+- **D2b-2** — lower name-keyed `attr_decls` onto both plans (chunks still `Literal`/`Ast` at
+  this point, i.e. a pure construction-site move: registration stops calling `from_stmt` for
+  plan-backed walks); fold `is_default_chunks` in; fix the collector double-push. No behavior
+  change; full `t/` + roast S12-attributes/S14-roles.
+- **D2c-4** — compile `default`/`where_constraint` to `Compiled` inside the lowered structs +
+  the two `as_expr` consumer retirements (+ `declared_shape` precompute). Measurable gain: the
+  `Ast` variant's per-construction recompile disappears; verify with a
+  construction-in-a-loop microbench and the same test set.
+- **D2c-5 (optional)** — A/B env-setup unification after verifying shape B's gate against raku.
+
+D2b-2 is also a **D6/D9 prerequisite**: the has-arm is one of the readers keeping
+`legacy_body` alive (see `todo/deep/adr0019-d6-d9-legacy-body-removal.md`).

--- a/todo/deep/adr0019-d4-parent-expr-chunks.md
+++ b/todo/deep/adr0019-d4-parent-expr-chunks.md
@@ -1,0 +1,80 @@
+# ADR-0019 D4 design: parent/role bracket arguments as parsed expressions
+
+Design pass (2026-08-08, no code landed) detailing the D4-1/D4-2/D4-3 sub-boxes the 2026-08-08
+scoping pass named for the one live D4 piece: `is Parent[Args]`/`does Role[Args]`/`hides
+Parent[Args]` bracket content is captured as raw balanced-bracket source text, string-concatenated
+onto the parent name, and re-parsed + tree-walked **per argument, per registration** by
+`eval_role_arg_values`.
+
+## Current state (2026-08-08 survey)
+
+- `parse_optional_bracket_suffix` (`parser/stmt/class/class_decl.rs:60-79`) scans by `[`/`]`
+  depth only (no quote awareness) and returns the raw text including brackets. Concat sites:
+  `class_decl.rs:416-417` (`is`), `:459-460` (lowercase `is` fallback), `:474-477` (`does`,
+  into both `parents` and `does_parents`), `:486-489` (`hides`), plus three the original ADR
+  note missed: `class_decl.rs:237-238`/`:247` (augment), `role_decl.rs:311-313` (role `does`,
+  folded into a synthetic `Stmt::DoesDecl { name: Symbol }` in the body at `:422-429`), and
+  `package_decl.rs:215-216` (unit-class `is`).
+- AST carriers are plain strings: `Stmt::ClassDecl { parents, hidden_parents, does_parents:
+  Vec<String> }` (`ast.rs:1012-1034`); `Stmt::RoleDecl` has **no** parent field at all (parents
+  travel as body `DoesDecl`s). `CompiledClassDeclPlan` mirrors the strings
+  (`opcode.rs:2507-2512`); `CompiledRoleDeclPlan` has no parent fields.
+- `resolve_role_candidate` (`registration_role.rs:134-262`) splits the bracket text back out
+  (`split_balanced_comma_list`, `runtime/mod.rs:84-107` — tracks `(`/`[` depth but **not quotes
+  or braces**, so `R["a,b"]` mis-splits) and `eval_role_arg_values` (`registration_role.rs:
+  18-74`) re-parses each argument string with `parse_source` + `eval_block_value`, with four
+  text-based heuristics: the `::`-prefix rejection, `should_treat_role_arg_as_type_expr` (char
+  whitelist + `:`/`(`/`::` presence → treat as type name, with an enum-value probe and a
+  never-registry-checked `Value::package(text)` fallback), and the `{...}` → `({...})`
+  block-literal paren wrap.
+- Call sites: three declaration-origin (`registration_class_compose.rs:88`,
+  `registration_role_body.rs:212` and `:268`) and two genuinely dynamic that must keep the
+  string path forever (`registration_class_augment.rs:985` — pun-name round-trip, which already
+  demonstrates the lossiness by having to guard `resolved_args != type_args`;
+  `methods_qualified.rs:291` — `$obj.R[Int]::meth` concretization strings).
+
+## Design
+
+**D4-1 — parser: capture `Vec<Expr>` alongside the string (additive, no behavior change).**
+`parse_optional_bracket_suffix` additionally attempts to parse the bracket content as a
+comma-separated expression list with the real expression parser. On success, the parsed
+`Vec<Expr>` rides in new AST fields — `Stmt::ClassDecl::parent_args: Vec<(String,
+Vec<Expr>)>` keyed by the full concatenated parent string (covering `is`/`does`/`hides`
+uniformly), and an `args: Option<Vec<Expr>>` payload on `Stmt::DoesDecl` for the role-side
+synthetic parents. On parse failure the field is simply absent — the string path remains
+authoritative, so nothing the depth-scan accepted is ever rejected. The concatenated string is
+kept **unchanged** as the registry key and display name. This also sidesteps
+`split_balanced_comma_list`'s quote-blindness for every declaration that gets `Expr`s: the real
+parser splits `R["a,b"]` correctly (a latent bug class the string path cannot fix).
+
+**D4-2 — compiler: lower argument chunks onto the class plan.** For each `parent_args` entry,
+compile each `Expr` with `compile_decl_trait_arg` (literal short-circuit + `Compiled` chunks,
+the C5 mechanism) into `CompiledClassDeclPlan::parent_arg_chunks: Vec<(String,
+Vec<DeclTraitArg>)>`, keyed by the same full parent string. The role-body `DoesDecl` site has
+no plan carriage yet — its typed encoding belongs to D7's role-structure plan ops (see
+`todo/deep/adr0019-d7-d8-role-plan-encoding.md`), so D4-2 deliberately covers only the class
+header; the role-body cutover joins the D7 slices to avoid inventing a throwaway plan field.
+
+**D4-3 — registration cutover for the class-header site.** Least-invasive signature change per
+the survey: `resolve_role_candidate` gains `pre_args: Option<&[Value]>` (or a
+`_with_args` wrapper keeping the 1-arg form). Only the `eval_role_arg_values` call swaps:
+`Some(v) => v.to_vec()`; everything downstream (arity filter, trial `bind_function_args_values`,
+specificity sort, winner re-bind) already operates on `Vec<Value>`. `compose_class_parent_roles`
+evaluates the plan chunks via `eval_decl_trait_arg` and passes the values; the four existing
+string-path callers pass `None` unchanged. The text-based heuristics are naturally bypassed on
+the value path (a parsed `Expr` argument cannot be the `::T`-in-application error case — that
+shape fails the D4-1 parse and stays on the string path, where the check still fires).
+
+## Verification and risks
+
+The behavioral-parity risk the scoping pass flagged concentrates in `eval_role_arg_values`'s
+heuristics: the enum-value probe and the `Value::package(text)` type-name fallback mean the
+string path sometimes produces a *type object* where a naive `Expr` evaluation would produce a
+*value* (or an error). D4-3 must therefore make the chunk evaluation reproduce the observable
+outcomes, not the mechanism: build a case table against `raku` covering type names
+(`R[Int]`), nested parameterizations (`R[Array[Int]]`), enum values, literals
+(`R[42]`, `R["a,b"]`), blocks (`R[{ $_ * 2 }]`), `where` types, and named args (`R[:x(1)]`),
+run under both paths, and gate the cutover on table equality (plus `t/`, roast S14-roles, and
+the battery gate — parametric roles are load-bearing for Cro). Sequencing: D4-1 and D4-2 are
+independently landable with zero behavior change; D4-3 is the only risky slice and can soak
+behind the case table.

--- a/todo/deep/adr0019-d5-plan-driven-how-ops.md
+++ b/todo/deep/adr0019-d5-plan-driven-how-ops.md
@@ -1,0 +1,69 @@
+# ADR-0019 D5 design: user HOW operations are already plan-compatible — D5 is ordering invariants plus verification
+
+Design pass (2026-08-08, no code landed) for D5 ("Drive user HOW operations from plan ops.
+Execute `new_type`, `add_method`, trait interception, and `compose` without entering
+`register_class_decl`'s AST walker"). The survey's central finding **shrinks this box**: the
+user-HOW protocol does not interleave with the AST body walk at all, and no HOW call-out reads
+a raw `Stmt`. D5 is therefore not a migration of the HOW machinery — it is a set of ordering
+invariants D6 must preserve, plus a verification gate.
+
+## Survey facts (2026-08-08)
+
+- A custom declarator (`monitor Foo {...}` via `EXPORTHOW::DECLARE`) is an ordinary
+  `Stmt::ClassDecl` tagged with a `__mutsu_declare_how` marker in `custom_traits`
+  (`parser/stmt/class/class_decl.rs:160-176`); the plan carries the keyword as a
+  `DeclTraitArg::Literal` (`opcode.rs:2127`). The HOW *type* is resolved at execution time from
+  the env (`EXPORTHOW::DECLARE::<kw>`, `vm_typedecl_ops.rs:439-440`) — runtime-only by nature.
+- **The protocol runs entirely after native registration**: `register_class_decl` (shell →
+  body walk with direct registry writes → finalize → `install_class_exporthow`) returns, then
+  the VM op does: DECLARE HOW attach + `declare_drive_how_protocol`
+  (`vm_typedecl_ops.rs:432-451`) → class-level `trait_mod:<is>` dispatch from plan fields
+  (`:456-500`) → user `compose` drain (`:507-514`, queued via
+  `registry.pending_class_compose`).
+- `new_type` marshals only the class name (with `pending_declare_new_type` backing the user's
+  `callsame`, `metamodel.rs:388-399`); `add_method` **re-enumerates from the finished
+  registry**, not the AST (`metamodel.rs:401-452` — public, non-submethod, non-multi first
+  overloads, name-sorted, `Method` objects built by `make_method_object_with_owner` with
+  `__mutsu_lookup_*` markers so user `.wrap`s land in `method_wrap_chains`); `add_attribute`
+  is never called by mutsu (the user's `new_type` calls the native bridge itself); `compose`
+  needs only the type object and the stored HOW instance (`registry.class_how_values`,
+  `registry.rs:122`).
+- Trait interception inputs are plan-resident already: class traits are plan fields; method
+  traits/bodies live on `CompiledMethodDecl` (`custom_traits` at `opcode.rs:409`, `body` at
+  `:397` — the walker builds the code object from the decl, `registration_class_body_method.rs:
+  237-299`); attribute traits ride `CompiledAttrDecl` (the one remaining runtime `from_stmt`,
+  closed by D2b-2).
+
+## What D5 actually consists of
+
+**D5-1 — codify the ordering invariants as the contract D6's body-plan cutover must keep.**
+The load-bearing sequence: shell publish → body registration (direct registry writes,
+re-published per statement) → HOW instantiate (`install_custom_class_how` before trait
+dispatch, so traits reach the HOW) → `new_type` → `add_method` → class `trait_mod:<is>` →
+`compose` (which must observe trait side effects, e.g. `@!aspects`,
+`vm_typedecl_ops.rs:502-506`). Two structural rules for any plan-driven registration:
+(a) **the registry stays authoritative between steps** — user code (attribute traits
+`^add_method`ing onto the class mid-registration) mutates the registry, and the walker's
+merge-back (`registration_class_body_attr.rs:167-185`) + per-statement re-publish
+(`registration_class_body.rs:227-230`) exist precisely so direct writes and side effects
+interleave; a plan executor must not batch into a private `ClassDef` clobbered at the end.
+(b) **HOW installs key on the resolved storage name** (lexical mangling is per-execution,
+`vm_typedecl_ops.rs:186-202`), never the plan's static name. This slice is documentation plus,
+optionally, one mechanical move for coherence: the DECLARE-keyword attach
+(`vm_typedecl_ops.rs:432-451`) migrating next to its sibling `install_class_exporthow` in the
+D0 exit-phase file — behavior-neutral, low value, skip if it churns.
+
+**D5-2 — verification gate, run after each D6 body-plan slice.** The box's completion
+criterion: the HOW protocol behaves identically when the registry is populated from plan ops
+instead of the AST walk. Since `add_method` reads the finished registry, this is automatic *if*
+the registry ends up identical — so the gate is behavioral: OO::Monitors verbatim
+(`scripts/battery-testsuite.sh`, the EXPORTHOW::DECLARE campaign's own acceptance bar) plus the
+metamodel roast files, executed as part of D6's slice verification rather than as a separate
+code PR.
+
+## Consequence for the ADR
+
+D5 has no independent implementation campaign; recommend re-scoping the box text to "preserve
+and verify" (D5-1 + D5-2) and sequencing it as a rider on D6. If D6's instrumentation survey
+later finds a HOW call-out that *does* read AST (none found in this pass), it re-opens as a real
+migration slice.

--- a/todo/deep/adr0019-d6-d9-legacy-body-removal.md
+++ b/todo/deep/adr0019-d6-d9-legacy-body-removal.md
@@ -1,0 +1,131 @@
+# ADR-0019 D6/D9 design: replacing the two `legacy_body` fields with typed body plans (and D10's endgame)
+
+Design pass (2026-08-08, no code landed) for D6 ("Remove `CompiledClassDeclPlan::legacy_body`"),
+D9 ("Remove `CompiledRoleDeclPlan::legacy_body`"), and the D10 walker deletion they enable. The
+ADR mandated a C6d-style survey before touching either field; that survey is done and inventoried
+below. (`CompiledProtoDeclPlan::legacy_body` is explicitly a separate later box — out of scope.)
+
+## Reader inventory (grep-complete, 2026-08-08)
+
+The only destructuring reads of either field are the two register ops
+(`vm_typedecl_ops.rs:134` class, `:602` role); each passes the body as a bare positional
+`&[Stmt]` into its walker. No reader exists outside registration — no introspection, error
+message, Pod, or serialization path touches the fields. `Stmt::AugmentClass` reads `stmt_pool`,
+not a plan, so D6 does not change augment's body source (the ADR's "preserve augmentation"
+clause is about the shared arm helpers D3-2..6 already unified).
+
+**Class side** — `register_class_decl` reads the body at exactly one site,
+`run_class_body` (`registration_class_decl.rs:221`); everything else in the orchestrator is
+already plan-driven (D1's `is_stub`/`trusts`, snapshot/redeclaration are registry-only). The
+walk's arms, scored:
+
+| Arm / reader | Plan coverage today |
+|---|---|
+| `MethodDecl` | done (D3-1/D3-7 — raw stmt is only a trigger; body AST inside `CompiledMethodDecl` is D3-8, orthogonal) |
+| `TrustsDecl` | **redundant** — D1's plan `trusts` already feeds `publish_class_shell`; the walk arm double-inserts. Deletable now |
+| `HasDecl` | partial — `CompiledAttrDecl` built at runtime `from_stmt`; closed by D2b-2 (`todo/deep/adr0019-d2-remainder-attr-plan-lowering.md`) |
+| `DoesDecl` (`also does R`) | name trivially typeable; execution half is D8; bracket args are D4/D7 |
+| `Phaser{Leave}` | none — bodies collected, then `run_block_raw` at exit |
+| `VarDecl` code alias (`our &baz ::= &bar`) | none |
+| `ProtoDecl{is_method}` | none (class-body method protos bypass C8's sub proto plans; builds a `FunctionDef` with a raw AST body) |
+| `SubDecl` tail probe (fq class-sub names) | none (a name scan) |
+| `_` → `class_body_other_stmt` | none — the largest reader; see below |
+| `persist_class_body_statics` VarDecl re-scan | none — pure syntactic name set |
+
+The `_` arm (`registration_class_body.rs:328-407`) is where plain statements, `use`/`need`,
+nested `class`/`role`, `sub` decls, BEGIN/CHECK, EVAL, `my`/`our` lexicals, **and `token`/`rule`
+decls** land. Mechanism: `run_block_raw` on a single raw `Stmt` — a fresh throwaway `Compiler`
+per statement, **per registration** (`run.rs:726-770`), then re-entrant `run_nested`. The user
+code already runs as bytecode; what `legacy_body` buys is only the *deferred per-registration
+compile*. The surrounding semantics that must survive any replacement: `current_package`/`?CLASS`
+seeding, class pre-inserted in the registry, `defining_class` for BEGIN/EVAL `has`-injection,
+BEGIN/EVAL failure swallowing, class-scoped env writeback into the saved env, per-statement
+registry re-publish, and the free-var writeback drain (Slice F, `run.rs:749-768` →
+`apply_pending_rw_writeback` at `vm_typedecl_ops.rs:522`).
+
+**Role side** — three body reads in `register_role_decl`: `check_role_body_our_scoped_decls`
+(syntactic violation scan), `role_body_is_stub` (**the role plan has no D1-style `is_stub`
+field** — a straight gap), and `walk_role_body`, whose arms are HasDecl (D2b-2 closes),
+DoesDecl (D4/D7), MethodDecl (done), stub-call detection (same missing `is_stub`), and the
+catch-all that **clones every other statement into `RoleDef::deferred_body_stmts`** — the one
+place a plan body escapes registration into the registry, executed per composition at five
+`run_block_raw` consumer sites. Dropping the role field therefore **requires D8 first** (the
+deferred-body chunk mechanism, `todo/deep/adr0019-d7-d8-role-plan-encoding.md`), which is why
+D9 is sequenced after D8 in the ADR.
+
+## Design: a typed, ordered body plan with per-statement compiled chunks
+
+The endgame shape for both sides is the same: replace `legacy_body: Vec<Stmt>` with an ordered
+op list lowered at compile time —
+
+```
+CompiledClassDeclPlan::body_plan: Vec<ClassBodyOp>
+ClassBodyOp = Attr { name: Symbol }            // joins the name-keyed attr_decls row (D2b-2)
+            | Method                            // advances the existing method cursor (D3-1/D3-7)
+            | Does { name: Symbol, args: Vec<DeclTraitArg> }   // D4/D7 chunks
+            | CodeAlias { alias: Symbol, source: Symbol }
+            | ProtoMethod(CompiledProtoDeclPlan-shaped payload)
+            | LeavePhaser(CompiledDeclExpr)
+            | ClassSub { name: Symbol }         // the SubDecl tail probe fact + Other chunk
+            | Other { chunk: CompiledDeclExpr, raw: Option<Stmt> }
+```
+
+with `Other.chunk` a statement-shaped `CompiledDeclExpr` (the C5 struct compiles any `&[Stmt]`
+— nothing limits it to one expression) compiled once at plan lowering, replacing the
+per-registration `run_block_raw` OTF compile. The driver keeps its exact current structure —
+same per-op env seeding, BEGIN/EVAL swallowing, writeback, re-publish — only the *source* of
+each step changes from raw `Stmt` to typed op. The `TrustsDecl` arm is deleted (redundant);
+`persist_class_body_statics`' re-scan becomes a `declared_static_names: Vec<Symbol>` plan field
+(D2a pattern); the lowering mirrors `collect_nested_class_has_decls`' append-at-end order for
+nested-sub attrs so `Attr` ops fire in the runtime walk's order.
+
+**The token/rule exclusion is carried by `Other.raw`**: per the phase preamble, D6/D9 exclude
+token/rule arms until their ADR-0009-scoped slice. A lowered `Other` op whose statement is a
+`TokenDecl`/`RuleDecl` keeps the raw `Stmt` beside (or instead of) the chunk and the driver
+routes it through today's `run_block_raw` path; every other statement kind drops its raw copy.
+The field-drop slice then shrinks `legacy_body` to exactly the token/rule raws — either an
+`Option`al rump field or the `Other.raw` payload — so "drop `legacy_body`" and "token/rule
+stays" are not in tension, mirroring how C6 scoped `FunctionDef.body` to token defs.
+
+**BEGIN semantics note**: a `BEGIN` phaser inside a class body currently executes during the
+body walk at registration time (not at main-pass compile time), and the chunk design preserves
+exactly that — the chunk is *compiled* earlier but still *executed* at registration. No
+observable timing change; anything more raku-faithful (true compile-time BEGIN) is out of
+ADR-0019's scope.
+
+## Slices
+
+- **D6-1 — cheap syntactic plan fields + dead arm.** `declared_static_names` on the class plan
+  (consumed by `persist_class_body_statics`); delete the redundant `TrustsDecl` walk arm.
+  Role twins in **D9-1**: `is_stub` and the our-scope-violation verdict precomputed on the role
+  plan (retiring `role_body_is_stub` + `check_role_body_our_scoped_decls`'s AST scans).
+- **D6-2** = D2b-2 (attr plan lowering, shared with the D2 remainder).
+- **D6-3 — `body_plan` introduction, additive.** Lower the op list alongside `legacy_body`;
+  the driver consumes ops but the field remains for fallback parity, with an env-var instrument
+  (C6e-3a's `MUTSU_DROP_LEGACY_BODY` precedent) that forces op-only execution for validation
+  sweeps. This is the big slice; expect it to subdivide per arm the way C6d did
+  (other-stmt chunks first, then code-alias/proto/leave-phaser).
+- **D6-4 — drop the class field** (modulo the token/rule rump) after a forced-instrument run
+  of the full `t/` suite and the roast whitelist, per the C6e-3c playbook. D5's verification
+  gate (OO::Monitors battery + metamodel roast) rides on D6-3/D6-4.
+- **D9-2** = the role `HasDecl` cutover (D2b-2's role half) and **D9-3** the typed `DoesDecl`
+  (D7's role-structure ops). **D9-4** = D8's deferred-body chunks replacing
+  `deferred_body_stmts`. **D9-5** — drop the role field, same instrument playbook.
+
+## D10 — walker deletion
+
+D10 needs no separate mechanism design: once D6-4/D9-5 land, `run_class_body`/`walk_role_body`
+*are* the plan-op executors and the "walkers" left to delete are the residual raw-`Stmt` match
+arms and any helper whose only caller was an AST arm. Completion criteria: (1) no
+`Stmt::`-matching code remains in `registration_class_*`/`registration_role_*` except the
+token/rule routing and the `stmt_pool`-fed augment walker (both explicitly retained); (2) the
+metadata helpers that survive (`collect_nested_class_has_decls`' compile-time mirror, prescans)
+live compiler-side only; (3) grep proves no runtime `CompiledAttrDecl::from_stmt`/
+`CompiledMethodDecl::from_stmt` caller remains outside augment/EVAL fallbacks. D10 is a
+cleanup PR, not a campaign — if it grows beyond that, a slice was landed incompletely.
+
+## Dependency order across the remaining Phase D boxes
+
+D2b-2 → D6-1..3 (class body plan) — with D3-8a-d and D4-1/2 landable in parallel —
+then D4-3, then D7 (role structure ops) → D8 (deferred-body chunks) → D9 → D6-4/D9-5 field
+drops → D5 verification gate → D10 cleanup.

--- a/todo/deep/adr0019-d7-d8-role-plan-encoding.md
+++ b/todo/deep/adr0019-d7-d8-role-plan-encoding.md
@@ -1,0 +1,131 @@
+# ADR-0019 D7/D8 design: typed role structure and compiled deferred bodies
+
+Design pass (2026-08-08, no code landed) for D7 ("Encode role structure and composition —
+parameters, attributes, methods, parent roles, conflicts, hides, pun metadata — into immutable
+plan operations") and D8 ("Compile role declaration-time bodies and traits — run
+parameterized-role and composed ancestor bodies as bytecode child chunks with correct
+once-per-composition behavior"). D8 also closes D4's "deferred class bodies" piece (same data,
+same entry points — established by the D4 scoping pass) and unblocks D9.
+
+## Survey facts (2026-08-08)
+
+- `register_role_decl`'s passes and what is already plan-driven: `type_params`/
+  `type_param_defs`, `own_attribute_names`, `body_used_modules`, `body_declared_types` (D2a),
+  `method_name_chunks`/`method_decls` (D3-1/D3-7), `custom_traits` as `DeclTraitArg` chunks
+  dispatched by the VM op tail (`vm_typedecl_ops.rs:716-744`). Still AST-driven: the
+  our-scope/stub pre-scans, the `HasDecl` arm (runtime `from_stmt`), the `DoesDecl` arm
+  (string-keyed parent resolution, hides/hidden markers), and the catch-all that clones every
+  remaining statement into `RoleDef::deferred_body_stmts` (`registration_role_decl.rs:240-251`)
+  — for parametric and plain roles alike; **nothing from a role body executes at declaration**.
+- Per-arity candidates live in `registry.role_candidates: HashMap<String,
+  Vec<RoleCandidateDef>>` (replace-or-append by signature match,
+  `registration_role_decl.rs:299-319`); `resolve_role_candidate` selects by arity filter +
+  trial bind + specificity score. Conflicts: attribute conflicts detected during the role walk
+  and raised at composition; method conflicts at `class.rs:190-280`; required-method checks at
+  `registration.rs:280-395`. `hides` is a `__mutsu_role_hides__` pseudo-parent marker →
+  `registry.role_hides`; `is hidden` a marker → `RoleDef.is_hidden`.
+- Deferred bodies execute per composition via `run_block_raw` **one statement at a time** at
+  five consumer sites (class-header composition `run_composed_role_deferred_body`
+  (`registration_class_compose_body.rs:64-277`), `also does`, puns, runtime mixins, and the
+  shared `run_role_body_for_composition` (`registration_class_augment.rs:1258-1303`)), with:
+  per-statement package routing (nested type decls → the **role's** package, `token`/`rule` →
+  the **composing class's** package), type captures bound at env level (`bind_type_capture` —
+  markers removed after, names kept), a `VarDecl` re-scan to persist body lexicals as
+  composing-class statics, per-composition renaming of nested classes
+  (`rename_generic_composed_class`), and `X::Role::Instantiation` wrapping of a dying body.
+- Once-per-composition tracking is partial: `registry.composed_role_bodies` memoizes only
+  `pun:{role}` and `mixin:{role}` (role-global, not per target); the class-composition path has
+  **no guard** — re-registering the same class re-runs the role body each time.
+- `run_role_submethod` (`types/roles.rs:516-577`) — the C6d-3 leftover — still executes a
+  mixin BUILD/TWEAK `MethodDef` body via `eval_block_value`.
+- The chunk mechanism exists: `CompiledDeclExpr` compiles any `&[Stmt]` slot-free and runs
+  re-entrantly via `run_decl_expr` mid-registration (C5); only its current constructor is
+  expression-shaped.
+
+## D7 design — typed role structure
+
+`CompiledRoleDeclPlan` gains, mirroring the class side's D1/D2/D6 fields:
+
+- `is_stub: bool` and `our_scope_violation: Option<&'static str/kind>` — the two pre-scans
+  become plan facts (shared with D9-1).
+- `attr_decls: Vec<(Symbol, CompiledAttrDecl)>` name-keyed (D2b-2's role half).
+- `parent_ops: Vec<RoleParentOp>` — one per `does` (including the parser's synthetic
+  `DoesDecl`s, which today are the only carrier of role parents): `{ name: Symbol, hides:
+  bool, hidden: bool, args: Vec<DeclTraitArg> }`. This replaces the `__mutsu_role_hides__`/
+  `__mutsu_role_hidden__` string-marker encoding with typed flags and gives D4's bracket-arg
+  chunks their role-side carriage (the class-header half is D4-2's `parent_arg_chunks`).
+- `body_plan: Vec<RoleBodyOp>` — the ordered walk list (Attr/Method/Parent/Deferred), same
+  shape as D6's `ClassBodyOp`, so `walk_role_body` becomes an op executor.
+
+What deliberately stays runtime: candidate selection, trial binding, specificity scoring,
+conflict/required-method detection, and pun materialization — these read the *registry* (other
+roles, the composing class), not the AST, and are composition-time by nature. D7's claim is
+narrower than the box text sounds: the *declaration's own structure* becomes immutable plan
+data; the *composition algebra* over that data stays where it is. Pun metadata needs no new
+encoding — `ensure_role_punned_to_class` copies registry data only; once `deferred_body_stmts`
+is chunk-backed (D8), nothing the pun copies is AST.
+
+## D8 design — deferred bodies as per-statement chunks
+
+**Unit of compilation: one chunk per deferred statement, not one chunk per body.** The
+consumers' per-statement package routing, the statement-kind dispatch
+(`ClassDecl`/`RoleDecl` vs `TokenDecl`/`RuleDecl` vs plain), and the lexical-persistence scan
+all operate at statement granularity; a monolithic body chunk would have to reproduce package
+switching *inside* the chunk. So:
+
+```
+RoleDef::deferred_body: Vec<DeferredBodyOp>   // replaces deferred_body_stmts
+DeferredBodyOp = { chunk: CompiledDeclExpr,
+                   kind: TypeDecl | TokenRule | Plain,
+                   declared_vars: Vec<Symbol>,   // replaces the VarDecl re-scan
+                   raw: Option<Stmt> }           // token/rule rump, same rule as D6
+```
+
+lowered at plan compile time (the ops live on `CompiledRoleDeclPlan`; `finish_role_registration`
+moves them onto `RoleDef` for the registry, replacing the raw clone). The five consumer sites
+keep their exact env dance — type-capture binds, package save/switch/restore per op using
+`kind`, `X::Role::Instantiation` wrapping, static persistence from `declared_vars` — swapping
+only `run_block_raw(stmt)` for `run_decl_expr(chunk)`. What D8 removes is the per-composition,
+per-statement throwaway compile; what it must not change is any composition-visible behavior.
+
+**The frozen-plan question (the survey's caveat, resolved as a verification item, not a
+blocker).** Compiling deferred statements at role-declaration time freezes any nested
+declaration's *plan* per role, whereas today each composition re-lowers it from raw AST. But
+registration is per-*execution*, not per-compile: running the chunk executes its `RegisterDecl`
+ops afresh each composition, composition-dependent names (parent types, type captures) resolve
+at execution through the env exactly as the D2c research pass established for defaults, and the
+parametric rename pass operates on the registry after the run. So freezing the plan should be
+semantics-preserving — **V1**: verify with a parametric role whose body declares a nested class
+referencing `T` (`role R[::T] { class Inner { has T $.x } }`) composed at two different type
+arguments, against `raku`. If a case genuinely needs per-composition re-lowering, that op keeps
+a `raw` fallback (guarded-degrade, same pattern as everywhere else).
+
+**Once-per-composition semantics are preserved, not "fixed".** The ADR text's
+"correct once-per-composition behavior" is read as: keep today's observable behavior (unguarded
+class-path re-runs on re-registration; role-global `pun:`/`mixin:` memos) while making each run
+cheap. Whether the memo *should* be `(role, target)`-keyed is a raku-conformance question
+independent of the chunk migration — **V2**: build a small case table against `raku`
+(loop-redeclared class composing a side-effecting role body; same role mixed into two values;
+two classes composing one role) and file any divergence as its own ticket rather than folding a
+behavior change into D8.
+
+**D8 rider — `run_role_submethod` goes bytecode.** After D3-8, a role's BUILD/TWEAK
+`MethodDef` carries `compiled_code`; rewire the mixin path's `eval_block_value(&def.body)` to
+run it (keeping the captured-env merge and `!attr` seed/readback), retiring the last
+Phase-D-assigned interpreter body-execution site.
+
+## Slices
+
+- **D7-1** = D9-1 (role `is_stub` + our-scope plan facts). **D7-2** = D2b-2's role half.
+  **D7-3** — `parent_ops` (typed does/hides/hidden + D4 arg chunks) consumed by
+  `role_body_does_decl`; the marker-string encoding retires. **D7-4** — `body_plan` op walk
+  (additive, instrument-gated like D6-3).
+- **D8-1** — lower `DeferredBodyOp` chunks; `finish_role_registration` stores them; consumers
+  still read raw stmts (additive). **D8-2** — consumer cutover behind the V1/V2 case tables +
+  roast S14 + battery gate (Cro/OO::Monitors exercise parametric composition heavily).
+  **D8-3** — the `run_role_submethod` rider. **D8-4** — drop `deferred_body_stmts` (the raw
+  vec), leaving only token/rule raws per the D6/D9 rump rule.
+
+Sequencing with the rest of Phase D: D7-1/2 are independent; D7-3 wants D4-1 (parser `Expr`
+capture) first; D8 wants D3-8 (for D8-3) and feeds D9-4/D9-5. Full ordering in
+`todo/deep/adr0019-d6-d9-legacy-body-removal.md`.


### PR DESCRIPTION
## Summary

Design-only PR (no code): completes the design coverage of **ADR-0019 Phase D**. Every box that lacked a detailed design now has one, based on a four-way code survey (grep-complete `legacy_body` reader inventory, the user-HOW call-out protocol, the role walker + deferred bodies, attribute lowering + parent-expression call sites).

New `todo/deep/` docs:

- **`adr0019-d2-remainder-attr-plan-lowering.md`** — D2b completion via **name-keyed** `attr_decls` (the position blocker is now precisely characterized: runtime appends nested-sub `has` decls, the compiler collector interleaves them — plus a latent double-push); D2c-4 flips defaults/where to `DeclTraitArg::Compiled` (all eval sites already funnel through `eval_decl_trait_arg`; the work is construction-side + retiring the two `as_expr` consumers).
- **`adr0019-d4-parent-expr-chunks.md`** — D4-1/2/3: parser captures bracket args as parsed `Vec<Expr>` beside the unchanged string (parse failure keeps the string path); class-plan chunks; `resolve_role_candidate` gains `pre_args: Option<&[Value]>` with a raku case-table gate. Also fixes `R[\"a,b\"]` mis-splitting for free.
- **`adr0019-d5-plan-driven-how-ops.md`** — **D5 shrinks**: the HOW protocol (`new_type`/`add_method`/`compose`) runs entirely after native registration and never reads a raw `Stmt`; D5 becomes ordering invariants (registry-authoritative interleaving, storage-name keying) + an OO::Monitors verification gate riding on D6.
- **`adr0019-d6-d9-legacy-body-removal.md`** — the C6d-style survey the ADR mandated, plus the design: typed `body_plan: Vec<ClassBodyOp>` with per-statement `CompiledDeclExpr` chunks replacing the per-registration `run_block_raw` OTF compile; token/rule carried as a raw rump (C6 precedent); freebies (redundant `TrustsDecl` arm, `declared_static_names`); D10 cleanup criteria and the cross-box dependency order.
- **`adr0019-d7-d8-role-plan-encoding.md`** — D7: role-plan twins of D1/D2 facts, typed `parent_ops` replacing the `__mutsu_role_hides__` string markers (composition algebra deliberately stays runtime); D8: **one chunk per deferred statement** (consumers keep their env dance, swap only the executor), frozen-plan concern resolved to a verification item, `run_role_submethod` rider.

The ADR gains condensed design entries per box and a progress-summary paragraph with the recommended order: D2b-2 → D6-1..3 (D3-8a-d, D4-1/2 parallel) → D4-3 → D7 → D8 → D9 → field drops → D5 gate → D10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)