### PR TITLE
feat(compiler): lower attribute descriptors into class/role declaration plans (ADR-0019 D2b-2)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -116,10 +116,10 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 `main`; this is not a stacked-PR plan.
 
 **Current progress: 28/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
-landed, 2026-08-07). Phase C is fully checked; the open box is D2 (attributes and generated
-accessors), subdivided D2a-D2d — D2a, D2c-1/2/3, and D2d are done; D2b (typed attribute
-descriptors) and the "compile `default`/`where_constraint` as actual bytecode chunks" remainder of
-D2c are the only pieces still open. D3 (class methods/submethods as compiled candidates) is open;
+landed, 2026-08-07; D2b-2 landed 2026-08-08). Phase C is fully checked; the open box is D2
+(attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3, and D2d are
+done; the "compile `default`/`where_constraint` as actual bytecode chunks" remainder of D2c
+(D2c-4/D2c-5) is the only piece still open. D3 (class methods/submethods as compiled candidates) is open;
 D3-1 through D3-7 landed (walker-drift unification plus the compile-time `CompiledMethodDecl`
 precompute), and a 2026-08-08 scoping pass found D3's literal goal — compiling method *bodies*
 through the single main-pass `Compiler` the way `SubDecl` does, instead of a throwaway
@@ -572,6 +572,27 @@ walkers wholesale is not possible before then.
   retiring the two `as_expr` consumers that would panic on `Compiled` in the same slice
   (D2c-4); the A/B env-setup unification stays optional (D2c-5) behind raku verification of
   shape B's `has_class_scoped_subs` gate.
+  **D2b-2 landed 2026-08-08**: `CompiledClassDeclPlan`/`CompiledRoleDeclPlan` both gained
+  `attr_decls: Vec<(Symbol, CompiledAttrDecl)>`, replacing the class-only `is_default_chunks`
+  field. The class-side collector (`compile_class_attr_decls`/`collect_nested_class_attr_decls`
+  in `compiler/decl_plan.rs`) mirrors `class_own_attribute_names`'s proven-correct traversal
+  (SyntheticBlock-flattened top level, `has` nested inside a body `sub` surfaced via a
+  non-recursing-into-itself second pass) instead of the old `collect_attr_is_default_chunks`
+  shape, which fixes the double-push the design pass found: the old code both pushed a
+  nested-sub `has ... is default` from the `SubDecl` arm's direct loop AND re-matched it on
+  the immediately following recursive call into the same statements. `class_body_has_decl`/
+  `role_body_has_decl` now look their current `Stmt::HasDecl` up in `cx.attr_decls` by name
+  first, falling back to `CompiledAttrDecl::from_stmt` only on a miss (a class-level
+  `our`/`my` attribute, which the collector excludes exactly like `own_attribute_names`
+  already does, or a registration path with no compiled plan — `augment class`, role-pun/mixin
+  synthesis). The role side gains attribute-descriptor plan lowering for the first time (roles
+  never had `is_default_chunks`); its `is default(...)` argument deliberately stays
+  `DeclTraitArg::Ast` (no new compile step — `role_body_has_decl` already only stashed the raw
+  expression for later composition-time evaluation), so this slice is a pure construction-side
+  move on both plans, not a behavior change. Verified via the full `t/` suite (27,942 tests) and
+  every whitelisted `S12-attributes`/`S14-roles` roast file (36 files), plus a manual raku-vs-mutsu
+  comparison covering a nested-sub `is default`, a role instance-attribute default, and a role
+  `my`-scoped class-level attribute — all four values matched exactly.
 - [ ] **D3 — Encode class methods and submethods as compiled candidates.** Install ordinary, multi,
   proto, private, rw, wrap, BUILD, and TWEAK metadata without walking `Stmt::MethodDecl`. That
   walk exists in three places, not one — the class walker (~508 lines), the role walker

--- a/news/2026-08/adr0019-d2b-2-attr-decl-plan-lowering.md
+++ b/news/2026-08/adr0019-d2b-2-attr-decl-plan-lowering.md
@@ -1,0 +1,45 @@
+# ADR-0019 D2b-2: attribute descriptors move to the declaration plan
+
+Class and role declaration plans now carry `attr_decls: Vec<(Symbol,
+CompiledAttrDecl)>`, a name-keyed vector of fully-typed attribute descriptors
+built once at compile time. This replaces `CompiledClassDeclPlan`'s
+class-only `is_default_chunks` field and closes the remaining half of D2b
+(D2b-2 in the ADR-0019 checklist): registration no longer calls
+`CompiledAttrDecl::from_stmt` on the raw `Stmt::HasDecl` for every plan-backed
+`has` declaration it encounters.
+
+The class-side collector needed a real fix, not just a mechanical port. The
+previous `is_default_chunks` collector recursed into a `SubDecl`'s body twice
+for the same nested `has` statement — once from an explicit loop over the
+`SubDecl`'s direct children, once again from a blanket recursive call into
+those same children — silently double-pushing an entry for any `has ...  is
+default(...)` declared inside a `sub` nested in a class body. It was harmless
+under the old scheme (a linear name-keyed scan just finds the first match),
+but would have been a real bug for anything order-sensitive. The new
+collector instead mirrors `class_own_attribute_names`'s already-proven
+traversal shape (used for the D2a own-attribute-name precompute): a
+non-recursing second pass that never re-visits a statement it already
+processed.
+
+`class_body_has_decl` and `role_body_has_decl` now look their current
+statement up in the plan's `attr_decls` by name, falling back to
+`CompiledAttrDecl::from_stmt` only on a miss — a class-level `our`/`my`
+attribute (deliberately excluded from the collector, matching
+`own_attribute_names`'s existing exclusion) or a registration path with no
+compiled plan at all (`augment class`, role-pun/mixin synthesis). Role
+declaration plans gain this attribute-descriptor lowering for the first
+time — roles never had an `is_default_chunks` equivalent — but a role's `is
+default(...)` argument deliberately stays `DeclTraitArg::Ast` rather than
+being compiled to a chunk, since `role_body_has_decl` only stashes the raw
+expression for later composition-time evaluation; that keeps this slice a
+pure construction-side move with no behavior change on either plan.
+
+Verified against the full `t/` suite (27,942 tests) and every whitelisted
+`S12-attributes`/`S14-roles` roast file (36 files), plus a manual raku-vs-mutsu
+comparison covering a nested-sub `is default`, a role instance-attribute
+default, and a role `my`-scoped class-level attribute — matching exactly.
+
+This also clears a prerequisite for D6/D9 (removing
+`CompiledClassDeclPlan`/`CompiledRoleDeclPlan`'s `legacy_body` field): the
+`has`-arm registration read was one of the last readers keeping that field
+alive.

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -116,73 +116,91 @@ impl Compiler {
         };
         let name_chunk = name_expr.as_ref().map(|e| self.compile_decl_expr(e));
         let trait_args = self.compile_decl_trait_args(custom_traits);
-        let is_default_chunks = self.compile_attr_is_default_chunks(body);
+        let attr_decls = self.compile_class_attr_decls(body);
         let method_name_chunks = self.compile_method_name_chunks(body);
-        self.code.add_class_decl_plan(
-            stmt,
-            name_chunk,
-            trait_args,
-            is_default_chunks,
-            method_name_chunks,
-        )
+        self.code
+            .add_class_decl_plan(stmt, name_chunk, trait_args, attr_decls, method_name_chunks)
     }
 
-    /// Precompile the `is default(...)` trait argument of each of a class
-    /// body's own attributes into a child chunk (ADR-0019 D2c), keyed by
+    /// Precompile a full `CompiledAttrDecl` for each attribute a class body
+    /// declares directly in its own body (ADR-0019 D2b remainder), keyed by
     /// attribute name so `class_body_has_decl` can look one up without
     /// depending on its registration-time walk visiting attributes in
-    /// exactly this order. Mirrors `class_body_has_decl`'s eligibility
-    /// (`our`/`my` class-level attributes never reach the `is_default` arm —
-    /// see `run_class_body`'s early `SkipTail` return) and
-    /// `collect_nested_class_has_decls`'s traversal (SyntheticBlock-flattened
-    /// top level plus `has` nested directly inside a body `sub`, recursively).
-    fn compile_attr_is_default_chunks(
+    /// exactly this order. Mirrors `class_own_attribute_names`'s eligibility
+    /// (`our`/`my` class-level attributes are excluded — see
+    /// `run_class_body`'s early `SkipTail` return before the per-instance
+    /// attribute is registered) and traversal (SyntheticBlock-flattened top
+    /// level plus `has` nested directly inside a body `sub`, recursively) —
+    /// same helper shape as `class_own_attribute_names`/
+    /// `collect_nested_has_decl_names`, which the earlier
+    /// `collect_attr_is_default_chunks` did NOT share, double-pushing a
+    /// nested-sub `has ... is default` (once from the `SubDecl` arm's direct
+    /// loop, once from its own recursive call re-matching the same
+    /// statement). This mirrors the registration-side non-recursive-repeat
+    /// exactly to avoid that trap, harmless as it was under
+    /// first-match-wins name-keyed lookup.
+    fn compile_class_attr_decls(
         &self,
         body: &[Stmt],
-    ) -> Vec<(Symbol, crate::opcode::DeclTraitArg)> {
-        let mut out = Vec::new();
-        self.collect_attr_is_default_chunks(body, &mut out);
-        out
-    }
-
-    fn collect_attr_is_default_chunks(
-        &self,
-        body: &[Stmt],
-        out: &mut Vec<(Symbol, crate::opcode::DeclTraitArg)>,
-    ) {
-        for stmt in body {
-            match stmt {
-                Stmt::SyntheticBlock(inner) => self.collect_attr_is_default_chunks(inner, out),
+    ) -> Vec<(Symbol, crate::opcode::CompiledAttrDecl)> {
+        let mut out: Vec<(Symbol, crate::opcode::CompiledAttrDecl)> = body
+            .iter()
+            .flat_map(|s| match s {
+                Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+                other => vec![other],
+            })
+            .filter_map(|stmt| match stmt {
                 Stmt::HasDecl {
                     name,
                     is_our,
                     is_my,
-                    is_default: Some(expr),
                     ..
-                } if !*is_our && !*is_my => {
-                    out.push((*name, self.compile_decl_trait_arg(expr)));
-                }
+                } if !*is_our && !*is_my => Some((*name, self.compile_class_attr_decl(stmt))),
+                _ => None,
+            })
+            .collect();
+        self.collect_nested_class_attr_decls(body, &mut out);
+        out
+    }
+
+    fn collect_nested_class_attr_decls(
+        &self,
+        stmts: &[Stmt],
+        out: &mut Vec<(Symbol, crate::opcode::CompiledAttrDecl)>,
+    ) {
+        for s in stmts {
+            match s {
                 Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } | Stmt::HasDecl { .. } => {}
-                Stmt::SubDecl { body: inner, .. } => {
-                    for s in inner {
+                Stmt::SubDecl { body, .. } => {
+                    for inner in body {
                         if let Stmt::HasDecl {
                             name,
                             is_our,
                             is_my,
-                            is_default: Some(expr),
                             ..
-                        } = s
+                        } = inner
                             && !*is_our
                             && !*is_my
                         {
-                            out.push((*name, self.compile_decl_trait_arg(expr)));
+                            out.push((*name, self.compile_class_attr_decl(inner)));
                         }
                     }
-                    self.collect_attr_is_default_chunks(inner, out);
+                    self.collect_nested_class_attr_decls(body, out);
                 }
                 _ => {}
             }
         }
+    }
+
+    /// Build one attribute's typed descriptor, precompiling its `is
+    /// default(...)` trait argument (ADR-0019 D2c) inline the same way
+    /// `class_body_has_decl` used to look one up separately.
+    fn compile_class_attr_decl(&self, stmt: &Stmt) -> crate::opcode::CompiledAttrDecl {
+        let Stmt::HasDecl { is_default, .. } = stmt else {
+            unreachable!("compile_class_attr_decl called on a non-HasDecl statement");
+        };
+        let chunk = is_default.as_ref().map(|e| self.compile_decl_trait_arg(e));
+        crate::opcode::CompiledAttrDecl::from_stmt(stmt, chunk.as_ref())
     }
 
     /// [`Self::add_sub_decl_plan`] for a role declaration. A role's name is
@@ -197,8 +215,36 @@ impl Compiler {
             panic!("add_role_decl_plan expects RoleDecl");
         };
         let trait_args = self.compile_decl_trait_args(custom_traits);
+        let attr_decls = Self::compile_role_attr_decls(body);
         let method_name_chunks = self.compile_method_name_chunks(body);
         self.code
-            .add_role_decl_plan(stmt, trait_args, method_name_chunks)
+            .add_role_decl_plan(stmt, trait_args, attr_decls, method_name_chunks)
+    }
+
+    /// Precompile a full `CompiledAttrDecl` for each attribute a role body
+    /// declares (ADR-0019 D2b remainder), keyed by attribute name — see
+    /// `compile_class_attr_decls`. Mirrors `role_body_prescan`'s single-level
+    /// `SyntheticBlock` flatten with no nested-sub surfacing (roles have none
+    /// — `walk_role_body`'s own comment confirms it) and includes class-level
+    /// (`our`/`my`) attributes, unlike the class side: `role_body_has_decl`
+    /// handles both kinds through the same arm. No `is default(...)` chunk is
+    /// precompiled here (stays `DeclTraitArg::Ast`, calling
+    /// `CompiledAttrDecl::from_stmt(stmt, None)` exactly as
+    /// `role_body_has_decl` already did) — a pure construction-side move,
+    /// not a new compile step.
+    fn compile_role_attr_decls(body: &[Stmt]) -> Vec<(Symbol, crate::opcode::CompiledAttrDecl)> {
+        body.iter()
+            .flat_map(|s| match s {
+                Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+                other => vec![other],
+            })
+            .filter_map(|stmt| match stmt {
+                Stmt::HasDecl { name, .. } => Some((
+                    *name,
+                    crate::opcode::CompiledAttrDecl::from_stmt(stmt, None),
+                )),
+                _ => None,
+            })
+            .collect()
     }
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -301,10 +301,9 @@ pub(crate) struct CompiledAttrDecl {
     pub(crate) is_our: bool,
     pub(crate) is_my: bool,
     /// The `is default(...)` trait argument (ADR-0019 D2c). `Ast` unless a
-    /// caller with compiler access at plan-lowering time (currently
-    /// `class_body_has_decl`, via `CompiledClassDeclPlan::is_default_chunks`)
-    /// supplied a precompiled `Literal`/`Compiled` replacement — see
-    /// [`Self::from_stmt`].
+    /// caller with compiler access at plan-lowering time (currently the
+    /// class-plan half of `CompiledClassDeclPlan::attr_decls`) supplied a
+    /// precompiled `Literal`/`Compiled` replacement — see [`Self::from_stmt`].
     pub(crate) is_default: Option<DeclTraitArg>,
     pub(crate) is_type: Option<String>,
     pub(crate) deprecated_message: Option<String>,
@@ -2530,12 +2529,17 @@ pub(crate) struct CompiledClassDeclPlan {
     /// `run_class_body` re-scanning the (flattened, nested-sub-surfaced)
     /// body on every registration.
     pub(crate) own_attribute_names: Vec<Symbol>,
-    /// Precompiled `is default(...)` trait argument for each own attribute
-    /// that declares one (ADR-0019 D2c), keyed by attribute name rather than
-    /// position — `class_body_has_decl` looks a chunk up by the `Stmt::HasDecl`
-    /// it is currently visiting instead of relying on the registration-time
-    /// walk visiting attributes in the same order this was built in.
-    pub(crate) is_default_chunks: Vec<(Symbol, DeclTraitArg)>,
+    /// Precompiled typed descriptor for each of the class's own attributes
+    /// (ADR-0019 D2b remainder), keyed by attribute name — `class_body_has_decl`
+    /// looks a descriptor up by the `Stmt::HasDecl` it is currently visiting
+    /// instead of calling `CompiledAttrDecl::from_stmt` on the raw statement
+    /// at registration time (falling back to `from_stmt` only on a lookup
+    /// miss, e.g. a class-level `our`/`my` attribute, which this vec excludes
+    /// the same way `own_attribute_names` does). The `is default(...)` trait
+    /// argument inside each descriptor is precompiled to a
+    /// `Literal`/`Compiled` chunk (ADR-0019 D2c); `default`/`where_constraint`
+    /// remain raw `Expr`s (`DeclTraitArg::Ast`) until D2c-4.
+    pub(crate) attr_decls: Vec<(Symbol, CompiledAttrDecl)>,
     /// Precompiled runtime-resolved-name chunk for each top-level `method`/
     /// `submethod` declaration in the body (ADR-0019 D3-1), one entry per
     /// method in the order `run_class_body`'s `SyntheticBlock`-flattened walk
@@ -2573,6 +2577,15 @@ pub(crate) struct CompiledRoleDeclPlan {
     /// Types the body declares itself (`my enum`, `my class`, ...)
     /// (ADR-0019 D2a), precomputed alongside `own_attribute_names`.
     pub(crate) body_declared_types: Vec<String>,
+    /// Precompiled typed descriptor for each attribute the role declares in
+    /// its own body (ADR-0019 D2b remainder), keyed by attribute name — see
+    /// `CompiledClassDeclPlan::attr_decls`. Unlike the class side, a role's
+    /// `is default(...)` is NOT precompiled to a chunk here (it stays
+    /// `DeclTraitArg::Ast`, matching `role_body_has_decl`'s existing
+    /// behavior of always calling `CompiledAttrDecl::from_stmt(stmt, None)`);
+    /// this vec is a pure construction-side move that stops registration
+    /// re-destructuring the raw `Stmt::HasDecl`, not a new compile step.
+    pub(crate) attr_decls: Vec<(Symbol, CompiledAttrDecl)>,
     /// Precompiled runtime-resolved-name chunk for each top-level `method`/
     /// `submethod` declaration in the body (ADR-0019 D3-1). See
     /// `CompiledClassDeclPlan::method_name_chunks`.
@@ -5752,7 +5765,7 @@ impl CompiledCode {
         stmt: &Stmt,
         name_chunk: Option<CompiledDeclExpr>,
         trait_args: Vec<Option<DeclTraitArg>>,
-        is_default_chunks: Vec<(Symbol, DeclTraitArg)>,
+        attr_decls: Vec<(Symbol, CompiledAttrDecl)>,
         method_name_chunks: Vec<Option<CompiledDeclExpr>>,
     ) -> u32 {
         let Stmt::ClassDecl {
@@ -5804,7 +5817,7 @@ impl CompiledCode {
             is_stub,
             trusts,
             own_attribute_names,
-            is_default_chunks,
+            attr_decls,
             method_name_chunks,
             method_decls,
         });
@@ -5817,6 +5830,7 @@ impl CompiledCode {
         &mut self,
         stmt: &Stmt,
         trait_args: Vec<Option<DeclTraitArg>>,
+        attr_decls: Vec<(Symbol, CompiledAttrDecl)>,
         method_name_chunks: Vec<Option<CompiledDeclExpr>>,
     ) -> u32 {
         let Stmt::RoleDecl {
@@ -5849,6 +5863,7 @@ impl CompiledCode {
             own_attribute_names,
             body_used_modules,
             body_declared_types,
+            attr_decls,
             method_name_chunks,
             method_decls,
         });

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -200,12 +200,12 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// of `run_class_body` re-scanning the body for `Stmt::HasDecl` at
     /// registration time.
     pub(crate) own_attribute_names: &'a [Symbol],
-    /// Precompiled `is default(...)` trait-argument chunks for this class
-    /// body's own attributes (ADR-0019 D2c), keyed by attribute name, threaded
-    /// down to `class_body_has_decl` via `ClassBodyCx`. Empty for
-    /// registration paths with no compiled plan available (role bodies,
-    /// `augment class`) — those keep evaluating the raw AST expression.
-    pub(crate) attr_is_default_chunks: &'a [(Symbol, crate::opcode::DeclTraitArg)],
+    /// Precompiled typed descriptor for each of the class's own attributes
+    /// (ADR-0019 D2b remainder), keyed by attribute name, threaded down to
+    /// `class_body_has_decl` via `ClassBodyCx`. Empty for registration paths
+    /// with no compiled plan available (role bodies, `augment class`) —
+    /// those keep building a descriptor from the raw AST statement.
+    pub(crate) attr_decls: &'a [(Symbol, crate::opcode::CompiledAttrDecl)],
     /// Precompiled runtime-resolved-name chunk for each top-level `method`/
     /// `submethod` declaration in the body (ADR-0019 D3-1), read by position
     /// in `class_body_method_decl` via `ClassBodyCx`. Empty for registration

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1023,7 +1023,7 @@ impl Interpreter {
             is_stub: false,
             trusts: &[],
             own_attribute_names: &[],
-            attr_is_default_chunks: &[],
+            attr_decls: &[],
             method_name_chunks: &[],
             method_decls: &[],
         };

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -23,10 +23,10 @@ pub(super) struct ClassBodyCx<'a> {
     /// role-composed attributes: the full set of attributes valid for
     /// `$!attr` access.
     pub(super) class_own_attrs: HashSet<String>,
-    /// Precompiled `is default(...)` chunks for this class body's own
-    /// attributes (ADR-0019 D2c), keyed by attribute name; see
+    /// Precompiled typed descriptor for each of this class body's own
+    /// attributes (ADR-0019 D2b remainder), keyed by attribute name; see
     /// `class_body_has_decl`.
-    pub(super) is_default_chunks: &'a [(Symbol, crate::opcode::DeclTraitArg)],
+    pub(super) attr_decls: &'a [(Symbol, crate::opcode::CompiledAttrDecl)],
     /// Precompiled runtime-resolved-name chunk for each top-level `method`/
     /// `submethod` declaration in the body (ADR-0019 D3-1), read by position
     /// via `method_name_chunk_idx`; see `class_body_method_decl`.
@@ -95,7 +95,7 @@ impl Interpreter {
         class_is_rw: bool,
         class_lang_rev: &str,
         own_attribute_names: &[Symbol],
-        is_default_chunks: &[(Symbol, crate::opcode::DeclTraitArg)],
+        attr_decls: &[(Symbol, crate::opcode::CompiledAttrDecl)],
         method_name_chunks: &[Option<crate::opcode::CompiledDeclExpr>],
         method_decls: &[crate::opcode::CompiledMethodDecl],
     ) -> Result<ClassDef, RuntimeError> {
@@ -139,7 +139,7 @@ impl Interpreter {
             saved_env,
             class_def,
             class_own_attrs,
-            is_default_chunks,
+            attr_decls,
             method_name_chunks,
             method_decls,
             method_name_chunk_idx: 0,

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -116,20 +116,24 @@ impl Interpreter {
         cx: &mut ClassBodyCx<'_>,
         stmt: &Stmt,
     ) -> Result<ClassBodyFlow, RuntimeError> {
-        // Look up this attribute's precompiled `is default(...)` chunk (ADR-0019
-        // D2c) by name before building `decl` — `Stmt::HasDecl::name` is cheap to
-        // read directly, and a name-keyed lookup does not depend on this walk
-        // visiting attributes in the same order `compile_attr_is_default_chunks`
-        // built the plan's chunk list in.
-        let is_default_chunk = match stmt {
+        // Look up this attribute's precompiled descriptor (ADR-0019 D2b
+        // remainder) by name before falling back — `Stmt::HasDecl::name` is
+        // cheap to read directly, and a name-keyed lookup does not depend on
+        // this walk visiting attributes in the same order
+        // `compile_class_attr_decls` built the plan's vec in. A miss (a
+        // class-level `our`/`my` attribute, which the compiler-side vec
+        // excludes, or a registration path with no compiled plan at all)
+        // falls back to building one from the raw statement, same as before
+        // this migration.
+        let decl = match stmt {
             Stmt::HasDecl { name, .. } => cx
-                .is_default_chunks
+                .attr_decls
                 .iter()
                 .find(|(n, _)| n == name)
-                .map(|(_, chunk)| chunk),
+                .map(|(_, decl)| decl.clone()),
             _ => None,
-        };
-        let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt, is_default_chunk);
+        }
+        .unwrap_or_else(|| crate::opcode::CompiledAttrDecl::from_stmt(stmt, None));
         let attr_name_str = decl.name.clone();
 
         // An initializer that can never satisfy the constraint is a

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -126,7 +126,7 @@ impl Interpreter {
             is_stub: is_stub_body,
             trusts,
             own_attribute_names,
-            attr_is_default_chunks,
+            attr_decls,
             method_name_chunks,
             method_decls,
         } = modifiers;
@@ -226,7 +226,7 @@ impl Interpreter {
             class_is_rw,
             &class_lang_rev,
             own_attribute_names,
-            attr_is_default_chunks,
+            attr_decls,
             method_name_chunks,
             method_decls,
         )?;

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -273,6 +273,7 @@ impl Interpreter {
         own_attribute_names: &[Symbol],
         body_used_modules: &[String],
         body_declared_types: &[String],
+        attr_decls: &[(Symbol, crate::opcode::CompiledAttrDecl)],
         method_name_chunks: &[Option<crate::opcode::CompiledDeclExpr>],
         method_decls: &[crate::opcode::CompiledMethodDecl],
     ) -> Result<(), RuntimeError> {
@@ -325,6 +326,7 @@ impl Interpreter {
             role_own_attrs: own_attribute_names.iter().map(|s| s.resolve()).collect(),
             body_used_modules: body_used_modules.iter().cloned().collect(),
             body_declared_types: body_declared_types.iter().cloned().collect(),
+            attr_decls,
             method_name_chunks,
             method_decls,
             method_name_chunk_idx: 0,

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -16,7 +16,18 @@ impl Interpreter {
         cx: &mut RoleDeclCx<'_>,
         stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
-        let decl = crate::opcode::CompiledAttrDecl::from_stmt(stmt, None);
+        // Look up this attribute's precompiled descriptor (ADR-0019 D2b
+        // remainder) by name before falling back — see the identical
+        // rationale in `class_body_has_decl`.
+        let decl = match stmt {
+            Stmt::HasDecl { name, .. } => cx
+                .attr_decls
+                .iter()
+                .find(|(n, _)| n == name)
+                .map(|(_, decl)| decl.clone()),
+            _ => None,
+        }
+        .unwrap_or_else(|| crate::opcode::CompiledAttrDecl::from_stmt(stmt, None));
         let attr_name_str = decl.name.clone();
         // A class-level (`my $.x` / `our $.x`) role attribute is NOT a
         // per-instance attribute: it becomes a class-level attribute on the

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -22,6 +22,10 @@ pub(super) struct RoleDeclCx<'a> {
     pub(super) body_used_modules: HashSet<String>,
     /// Types declared inside the role body itself (pre-scan pass).
     pub(super) body_declared_types: HashSet<String>,
+    /// Precompiled typed descriptor for each attribute this role declares
+    /// (ADR-0019 D2b remainder), keyed by attribute name; see
+    /// `role_body_has_decl`.
+    pub(super) attr_decls: &'a [(Symbol, crate::opcode::CompiledAttrDecl)],
     /// Precompiled runtime-resolved-name chunk for each top-level `method`/
     /// `submethod` declaration in the body (ADR-0019 D3-1), read by position
     /// via `method_name_chunk_idx`; see `role_body_method_decl`.

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -65,7 +65,7 @@ impl Interpreter {
             is_stub: false,
             trusts: &[],
             own_attribute_names: &[],
-            attr_is_default_chunks: &[],
+            attr_decls: &[],
             method_name_chunks: &[],
             method_decls: &[],
         };

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -138,7 +138,7 @@ impl Interpreter {
             is_stub,
             trusts,
             own_attribute_names,
-            is_default_chunks,
+            attr_decls,
             method_name_chunks,
             method_decls,
         }) = code.class_decl_plans.get(idx as usize)
@@ -253,7 +253,7 @@ impl Interpreter {
                         is_stub: *is_stub,
                         trusts,
                         own_attribute_names,
-                        attr_is_default_chunks: is_default_chunks,
+                        attr_decls,
                         method_name_chunks,
                         method_decls,
                     },
@@ -606,6 +606,7 @@ impl Interpreter {
             own_attribute_names,
             body_used_modules,
             body_declared_types,
+            attr_decls,
             method_name_chunks,
             method_decls,
         }) = code.role_decl_plans.get(idx as usize)
@@ -637,6 +638,7 @@ impl Interpreter {
                     own_attribute_names,
                     body_used_modules,
                     body_declared_types,
+                    attr_decls,
                     method_name_chunks,
                     method_decls,
                 )


### PR DESCRIPTION
## Summary

- `CompiledClassDeclPlan`/`CompiledRoleDeclPlan` gain a name-keyed `attr_decls: Vec<(Symbol, CompiledAttrDecl)>`, replacing the class-only `is_default_chunks` field. `class_body_has_decl`/`role_body_has_decl` now look their current `Stmt::HasDecl` up by name at registration time instead of calling `CompiledAttrDecl::from_stmt` on the raw statement, falling back to `from_stmt` only on a miss (class-level `our`/`my` attributes, `augment class`, role-pun/mixin synthesis).
- Fixes a double-push bug in the old `is_default_chunks` collector: it re-visited a nested-sub `has ... is default(...)` twice (once via an explicit loop over the `SubDecl`'s children, once via a blanket recursive call into those same children). The new collector mirrors `class_own_attribute_names`'s already-correct non-recursing traversal instead.
- Pure construction-side move, no behavior change: a role's `is default(...)` argument deliberately stays `DeclTraitArg::Ast` (roles never had chunk compilation for it before).
- This is ADR-0019 slice D2b-2, closing the last open piece of D2b, and is also a prerequisite for D6/D9 (removing `legacy_body`).

See `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` and `todo/deep/adr0019-d2-remainder-attr-plan-lowering.md` for the full design.

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt`
- [x] `make test` — full `t/` suite, 27,942 tests, all pass
- [x] `MUTSU_FUDGE=1` roast run (release binary) over every whitelisted `S12-attributes`/`S14-roles` file (36 files), all pass
- [x] Manual raku-vs-mutsu comparison: nested-sub `is default`, role instance-attribute default, role `my`-scoped class-level attribute — outputs match exactly