### PR TITLE
fix(vm): keep multi-param `for` loop variables out of the cross-thread name lane

### DIFF
--- a/news/2026-08/for-multi-param-shared-lane.md
+++ b/news/2026-08/for-multi-param-shared-lane.md
@@ -1,0 +1,50 @@
+# A multi-parameter `for` loop no longer publishes its per-iteration binding cross-thread
+
+A `for @xs.kv -> $i, $comp { ... }` loop was rewriting the `$i` of a completely
+unrelated frame — in another file, in another routine — once any thread had
+been spawned in the process.
+
+`build_for_bind_stmts` binds a multi-parameter loop's variables with a plain
+`Stmt::Assign` rather than a `my`-style declaration. That assignment reaches
+`set_shared_var_sym`, which (while the cross-thread store is active) publishes
+the value under the variable's **bare name** into the process's lineage store.
+Every subsequent `await` then runs `sync_shared_vars_to_env`, which pulls the
+dirty bare-name entry back into the awaiting frame's `env` *and* — via
+`pending_caller_var_writeback` — into that frame's local slot. A
+single-parameter loop was never affected: it binds natively through the
+`ForLoop` opcode and never touches the name lane.
+
+The result, with no threading anywhere in the user's own code:
+
+```raku
+sub compose(@components) {
+    my $last;
+    for @components.kv -> $i, $comp { $last = $i + $comp }
+}
+await start { 1 };
+for 1..5 -> $i {
+    compose([10, 20, 30, 40, 50]);
+    await start { 1 };
+    say "loop i=$i";     # raku: 1 2 3 4 5;  mutsu: 1 4 4 4 4
+}
+```
+
+A multi-param loop variable is a fresh per-iteration binding, which is exactly
+the shape the bare-name store cannot represent — the same reason
+`exec_set_var_dynamic_op` masks a `my` re-declaration out of the lane.
+`exec_for_loop_body` now installs that mask for the loop's parameter names on
+entry and drops it on every exit path, including the two type-check errors and
+the two error propagations that bypass the normal restore. A `start` block that
+genuinely captures such a variable is unaffected: it gets a per-binding
+`ContainerRef` cell from `box_captured_lexicals`, the mechanism the name lane is
+redundant with.
+
+Found while chasing Cro's `t/http-session-inmemory.rakutest`, where
+`Cro.rakumod`'s pipeline compose (`for @components-in.kv -> $i, $comp`) was
+overwriting the `$i` of the test's own `for 1..5 -> $i` request loop, so all
+five requests reported "Visit 4". The remaining failures on that file no longer
+involve the store at all — they arrive through the `env` axis, and
+`todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md` records
+the re-measurement.
+
+Pinned by `t/for-multi-param-shared-lane.t`.

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -59,6 +59,17 @@ impl Interpreter {
         }
     }
 
+    /// Drop the cross-thread bare-name-lane masks a multi-param `for` loop
+    /// installed on entry. Only the names the loop itself added are dropped —
+    /// an enclosing `my` of the same name keeps its own mask. Called on every
+    /// exit path, including the error returns, so a mask can never outlive the
+    /// binding it describes.
+    fn unmask_for_multi_params(&mut self, names: &[String]) {
+        for name in names {
+            self.thread_redeclared_vars.remove(name);
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn exec_for_loop_body(
         &mut self,
@@ -283,6 +294,26 @@ impl Interpreter {
                 self.vm_set_var_type_constraint(name, None);
             }
         }
+        // A multi-param loop variable is a FRESH per-iteration binding, so it must
+        // not join the cross-thread bare-name lane — the same rule a `my`
+        // re-declaration gets in `exec_set_var_dynamic_op`. `build_for_bind_stmts`
+        // binds these via a plain `Stmt::Assign`, which reaches
+        // `set_shared_var_sym` and publishes every iteration's value under the
+        // BARE NAME, where any *unrelated* frame using the same name then reads
+        // it back at the next `await` (`sync_shared_vars_to_env`). That is how
+        // Cro's `for @components-in.kv -> $i, $comp` pipeline compose rewrote the
+        // `$i` of a `for 1..5 -> $i` loop in the user's own test file
+        // (`todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md`).
+        // A `start` block that genuinely captures such a variable is unaffected:
+        // it gets a per-binding `ContainerRef` cell from `box_captured_lexicals`,
+        // which is the mechanism the lane is redundant with.
+        let masked_multi_params: Vec<String> = spec
+            .multi_param_names
+            .iter()
+            .filter(|name| !name.starts_with('&') && name.as_str() != "_")
+            .filter(|name| self.thread_redeclared_vars.insert((*name).clone()))
+            .cloned()
+            .collect();
         // Save the single named loop param (`for ... -> $x`) too, so a loop in a
         // called sub that reuses the same variable name does not clobber an outer
         // loop's binding of that name (the env keys these by bare name). Skip
@@ -359,6 +390,7 @@ impl Interpreter {
                     && !self.type_matches_value(tc, &item)
                 {
                     let display = Self::for_param_display_name(name);
+                    self.unmask_for_multi_params(&masked_multi_params);
                     return Err(RuntimeError::typecheck_binding_parameter_with_repr(
                         &display, tc, &item,
                     ));
@@ -377,6 +409,7 @@ impl Interpreter {
                             .get(i)
                             .map(|n| Self::for_param_display_name(n))
                             .unwrap_or_default();
+                        self.unmask_for_multi_params(&masked_multi_params);
                         return Err(RuntimeError::typecheck_binding_parameter_with_repr(
                             &display, tc, v,
                         ));
@@ -793,6 +826,7 @@ impl Interpreter {
                         self.quanthash_bind_params = saved_quanthash_bind.clone();
                         self.restore_loop_topic(saved_topic, saved_topic_local);
                         self.pop_loop_local_scope(code);
+                        self.unmask_for_multi_params(&masked_multi_params);
                         return Err(e);
                     }
                     Err(e) => {
@@ -808,6 +842,7 @@ impl Interpreter {
                         }
                         self.restore_loop_topic(saved_topic.clone(), saved_topic_local.clone());
                         self.pop_loop_local_scope(code);
+                        self.unmask_for_multi_params(&masked_multi_params);
                         return Err(e);
                     }
                 }
@@ -875,6 +910,7 @@ impl Interpreter {
                 self.env_mut().remove(&sigilless_key);
             }
         }
+        self.unmask_for_multi_params(&masked_multi_params);
         // Restore the enclosing type constraint each multi-param name shadowed.
         for (name, tc) in saved_multi_param_types {
             if tc.is_some() {

--- a/t/for-multi-param-shared-lane.t
+++ b/t/for-multi-param-shared-lane.t
@@ -1,0 +1,75 @@
+use Test;
+
+plan 4;
+
+# A multi-parameter `for` loop binds a FRESH per-iteration lexical. It must not
+# publish that binding into the cross-thread bare-name store, where an unrelated
+# frame that happens to use the same variable name would read it back at the
+# next `await` (`sync_shared_vars_to_env`).
+
+sub compose(@components) {
+    my $last;
+    for @components.kv -> $i, $comp {
+        $last = $i + $comp;
+    }
+    $last
+}
+
+# Activate the cross-thread store.
+await start { 1 };
+
+{
+    my @seen;
+    for 1..5 -> $i {
+        compose([10, 20, 30, 40, 50]);
+        await start { 1 };
+        @seen.push($i);
+    }
+    is @seen.join(','), '1,2,3,4,5',
+        'an unrelated multi-param `for $i` does not rewrite this loop\'s $i';
+}
+
+# The same collision through a `while` loop's own re-declared name is already
+# masked; check the multi-param loop does not resurrect it via a hash source.
+sub walk(%h) {
+    my $n = 0;
+    for %h.kv -> $k, $v {
+        $n = $v;
+    }
+    $n
+}
+
+{
+    my @seen;
+    for <a b c> -> $k {
+        walk({ x => 1, y => 2 });
+        await start { 1 };
+        @seen.push($k);
+    }
+    is @seen.join(','), 'a,b,c',
+        'a multi-param `for $k, $v` does not rewrite an unrelated $k';
+}
+
+# Guard against over-masking: a `start` block that genuinely captures a
+# multi-param loop variable must still observe it (capture-by-cell, not the
+# name lane).
+{
+    my @got = await do for (10, 20).kv -> $i, $v {
+        start { $i * 100 + $v }
+    };
+    is @got.join(','), '10,120',
+        'a `start` capturing multi-param loop variables still sees them';
+}
+
+# ... and a nested multi-param loop of the same names still nests correctly.
+{
+    my @trace;
+    for (1, 2).kv -> $i, $v {
+        for (7, 8).kv -> $i, $v {
+            @trace.push("in:$i/$v");
+        }
+        @trace.push("out:$i/$v");
+    }
+    is @trace.join(' '), 'in:0/7 in:1/8 out:0/1 in:0/7 in:1/8 out:1/2',
+        'nested multi-param loops reusing the same names keep their bindings';
+}

--- a/todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md
+++ b/todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md
@@ -35,6 +35,47 @@ not ok 3 - Session cookie being sent makes state work (request 4)
 Every iteration reports `request 4`, and only the iteration where the body
 really is `Visit 4` passes.
 
+## Update 2026-08-08: the concrete Cro instance was a multi-param `for` loop
+
+The instrumentation below was re-run on current `main` and identified the
+writer exactly: **`Cro.rakumod`'s `for @components-in.kv -> $i, $comp`** (the
+pipeline compose), not the HPACK `while` loop originally guessed. A
+multi-parameter `for` binds its parameters with a plain `Stmt::Assign`
+(`build_for_bind_stmts`), which reaches `set_shared_var_sym` and publishes each
+per-iteration value under the bare name — while a *single*-param loop binds
+natively and is exempt. Minimal repro (no Cro, no modules):
+
+```raku
+sub compose(@components) {
+    my $last;
+    for @components.kv -> $i, $comp { $last = $i + $comp }
+}
+await start { 1 };
+for 1..5 -> $i {
+    compose([10, 20, 30, 40, 50]);
+    await start { 1 };
+    say "loop i=$i";     # raku: 1..5;  mutsu (before the fix): 1,4,4,4,4
+}
+```
+
+Fixed by masking a multi-param loop's names out of the bare-name lane for the
+loop's duration (the rule `exec_set_var_dynamic_op` already applies to a `my`
+re-declaration) — `src/vm/vm_for_loop_body.rs`, pinned by
+`t/for-multi-param-shared-lane.t`. `t/http-session-inmemory.rakutest`'s
+tests 3-7 still fail after it, but with a *different* wrong value (`-1`, the
+HPACK Huffman `while --$i >= 0` residue) reaching the frame through the **`env`
+axis, not the store** — no `SharedStore` write or pull for `i` happens any more.
+So the remaining leak on this file is a plain env-key collision, and this
+ticket's store-keying redesign is no longer what blocks it.
+
+Related, still open and single-threaded (no store involved):
+`todo/tickets/for-multi-param-array-hash-shadow-clobbers-outer-container.md` —
+a multi-param loop variable with no local slot in its frame writes a *global*
+of the same name (`sub f() { for <a b>.kv -> $j, $u {} }` clobbers an outer
+`my $j`). Same root cause (the bind is an assignment, not a declaration); the
+real fix is making it a per-iteration declaration, which is entangled with the
+§1.4 shadow-slot campaign.
+
 ## Mechanism, measured
 
 `Env::insert`/`insert_sym` were instrumented behind an env var to print a

--- a/todo/tickets/for-multi-param-array-hash-shadow-clobbers-outer-container.md
+++ b/todo/tickets/for-multi-param-array-hash-shadow-clobbers-outer-container.md
@@ -1,5 +1,21 @@
 # A multi-parameter `for` loop with an `@`/`%`-sigil parameter mutates the enclosing container it shadows
 
+**Update 2026-08-08:** the scalar case is *not* fully fixed either — the earlier
+fix only covered a shadowed name that already had a local slot in the same
+frame. When the frame has no slot for the name, the bind falls through to a
+**global by-name write** and clobbers an outer lexical of that name:
+
+```raku
+sub f() { for <a b c>.kv -> $j, $u { } }
+my $j = 42;
+f();
+say $j;    # raku: 42;  mutsu: 2
+```
+
+Same root cause as the `@`/`%` case below, and the same real fix (make the bind
+a per-iteration declaration). The cross-thread-lane symptom of this family was
+split off and fixed separately in `t/for-multi-param-shared-lane.t`.
+
 ```raku
 my @arr = (100, 200);
 for 1, [10,20], 2, [30,40] -> $a, @arr { }


### PR DESCRIPTION
A `for @xs.kv -> $i, $comp { ... }` loop was rewriting the `$i` of a completely unrelated frame — another routine, another file — once any thread had been spawned in the process.

## Root cause

`build_for_bind_stmts` binds a multi-parameter loop's variables with a plain `Stmt::Assign` rather than a `my`-style declaration. That assignment reaches `set_shared_var_sym`, which (while the cross-thread store is active) publishes the value under the variable's **bare name** into the lineage store. Every subsequent `await` runs `sync_shared_vars_to_env`, which pulls the dirty bare-name entry back into the awaiting frame's `env` *and* — via `pending_caller_var_writeback` — into that frame's local slot. A single-parameter loop was never affected: it binds natively through the `ForLoop` opcode and never touches the name lane.

Minimal repro (no modules, no user-visible threading in the loop):

```raku
sub compose(@components) {
    my $last;
    for @components.kv -> $i, $comp { $last = $i + $comp }
}
await start { 1 };
for 1..5 -> $i {
    compose([10, 20, 30, 40, 50]);
    await start { 1 };
    say "loop i=$i";     # raku: 1 2 3 4 5;  mutsu before: 1 4 4 4 4
}
```

## Fix

A multi-param loop variable is a fresh per-iteration binding — exactly the shape the bare-name store cannot represent, and the same reason `exec_set_var_dynamic_op` masks a `my` re-declaration out of the lane. `exec_for_loop_body` now installs that mask for the loop's parameter names on entry and drops it on every exit path, including the two type-check errors and the two error propagations that bypass the normal restore.

A `start` block that genuinely captures such a variable is unaffected: it gets a per-binding `ContainerRef` cell from `box_captured_lexicals`, the mechanism the name lane is redundant with. Test 3 of the new file pins that.

## Where it was found

Cro's `t/http-session-inmemory.rakutest`: `Cro.rakumod`'s pipeline compose (`for @components-in.kv -> $i, $comp`) was overwriting the `$i` of the test's own `for 1..5 -> $i` request loop, so all five requests reported "Visit 4". After this change no `SharedStore` write or pull for `i` happens at all on that file; the remaining failures there arrive through the `env` axis instead, and `todo/deep/shared-store-bare-name-collision-across-unrelated-frames.md` records the re-measurement.

## Tests

- New pin: `t/for-multi-param-shared-lane.t` (4 subtests; 1 and 2 fail on `main`, all 4 match `raku`).
- `make test`: PASS — 2963 files, 27953 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)