### PR TITLE
feat(compiler): precompute class-body static names, drop redundant TrustsDecl arm (ADR-0019 D6-1)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,8 +115,8 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 28/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
-landed, 2026-08-07; D2b-2 and D2c-4 landed 2026-08-08). Phase C is fully checked; the open box is
+**Current progress: 29/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
+landed, 2026-08-07; D2b-2, D2c-4, and D6-1 landed 2026-08-08). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
@@ -963,6 +963,20 @@ walkers wholesale is not possible before then.
   `declared_static_names` plan fact. Slices D6-1 (cheap facts + dead arm), D6-2 (= D2b-2),
   D6-3 (`body_plan`, instrument-gated, expected to subdivide per arm like C6d), D6-4 (field
   drop via the C6e-3c forced-instrument playbook).
+  **D6-1 landed 2026-08-08**: `CompiledClassDeclPlan` gained
+  `declared_static_names: Vec<Symbol>`, computed at plan lowering by a new
+  `class_declared_static_names` free function mirroring
+  `persist_class_body_statics`'s inline `declared_statics` scan (a top-level,
+  unflattened `Stmt::VarDecl` that is neither `our` nor `dynamic`).
+  `persist_class_body_statics` now takes this precomputed slice instead of
+  re-deriving it from the raw body on every registration. The redundant
+  `Stmt::TrustsDecl` walk arm in `run_class_body` is deleted — `publish_class_shell`
+  already inserts the same `class_trusts` entry from D1's `trusts` plan field
+  before the body walk starts, and the compiler already compiles a bare
+  `TrustsDecl` statement to a no-op (`compiler/stmt.rs`), so the statement
+  now safely falls through to the catch-all `class_body_other_stmt` arm with
+  no behavior change. D9-1 (the role-side twin: `is_stub` + our-scope-violation
+  plan facts) is not part of this slice.
 - [ ] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
   **Design pass done 2026-08-08 (no code landed):**

--- a/news/2026-08/adr0019-d6-1-declared-static-names-and-trusts-dedup.md
+++ b/news/2026-08/adr0019-d6-1-declared-static-names-and-trusts-dedup.md
@@ -1,0 +1,26 @@
+# ADR-0019 D6-1: class-body static names precomputed, redundant `TrustsDecl` walk arm deleted
+
+The first slice of D6 ("Remove `CompiledClassDeclPlan::legacy_body`") lands two independent,
+cheap facts identified by the 2026-08-08 D6/D9 design pass
+(`todo/deep/adr0019-d6-d9-legacy-body-removal.md`):
+
+- **`CompiledClassDeclPlan::declared_static_names: Vec<Symbol>`** — the names a class body
+  `my`/`state`-declares at its own top level, precomputed at plan lowering by a new
+  `class_declared_static_names` free function that mirrors `persist_class_body_statics`'s
+  inline scan (a top-level, unflattened `Stmt::VarDecl` that is neither `our` nor `dynamic`).
+  `persist_class_body_statics` now takes this precomputed slice instead of re-walking the raw
+  body on every class registration to decide which lexicals count as class-body statics.
+- **The redundant `Stmt::TrustsDecl` walk arm in `run_class_body` is deleted.**
+  `publish_class_shell` already inserts the same `class_trusts` entry from D1's `trusts` plan
+  field *before* the body walk starts, so the walk arm was a pure double-insert into the same
+  `HashSet`. The compiler already compiles a bare `TrustsDecl` statement to a no-op
+  (`compiler/stmt.rs`), so the statement now safely falls through to the catch-all
+  `class_body_other_stmt` arm with no observable behavior change.
+
+Both changes are pure mechanical hoists — no new fallback, no behavior change — verified with a
+new compiler unit test (`class_declarations_precompute_declared_static_names`) plus the existing
+`t/trusts-undeclared.t`, `t/private-trusts.t`, `t/class-body-static-in-sub.t`,
+`t/class-body-my-lexical-scope.t`, and related class-body-static tests, and a full `make test`
+run.
+
+D9-1, the role-side twin (role `is_stub` + our-scope-violation plan facts), is a separate slice.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -207,6 +207,33 @@ mod declaration_plan_tests {
         assert!(plan_stub.trusts.is_empty());
     }
 
+    /// ADR-0019 D6-1: names a class body `my`/`state`-declares at its own
+    /// top level are precomputed at plan lowering, so
+    /// `persist_class_body_statics` never re-walks the raw body to derive
+    /// them. `our`/`dynamic` declarations and non-`VarDecl` statements are
+    /// excluded.
+    #[test]
+    fn class_declarations_precompute_declared_static_names() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            "class A { my $x = 1; state $y = 2; our $z = 3; has $.w }",
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_a = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "A")
+            .expect("class A declaration plan");
+        let mut names: Vec<_> = plan_a
+            .declared_static_names
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["x", "y"]);
+    }
+
     /// ADR-0019 D2a: a class declaration's own attribute names — including
     /// ones nested inside a body `sub`, and excluding class-level `our`/`my`
     /// attributes — are precomputed at plan lowering, so `run_class_body`

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2521,6 +2521,25 @@ fn class_own_attribute_names(body: &[Stmt]) -> Vec<Symbol> {
     names
 }
 
+/// Names a class body `my`/`state`-declares at its own top level (ADR-0019
+/// D6-1), mirroring `persist_class_body_statics`'s `declared_statics` scan:
+/// a top-level (unflattened) `Stmt::VarDecl` that is neither `our` nor
+/// `dynamic`. Precomputed once at plan lowering instead of re-walked on
+/// every registration.
+fn class_declared_static_names(body: &[Stmt]) -> Vec<Symbol> {
+    body.iter()
+        .filter_map(|stmt| match stmt {
+            Stmt::VarDecl {
+                name,
+                is_our: false,
+                is_dynamic: false,
+                ..
+            } => Some(Symbol::intern(name)),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Pre-scan facts for a role body (ADR-0019 D2a), mirroring the combined
 /// loop in `Interpreter::walk_role_body`: attribute names the role declares,
 /// module names it `use`s/`need`s/`import`s, and types it declares in its
@@ -2650,6 +2669,11 @@ pub(crate) struct CompiledClassDeclPlan {
     /// reads a clone by position instead of calling `CompiledMethodDecl::from_stmt`
     /// on the raw statement every time the class declaration executes.
     pub(crate) method_decls: Vec<CompiledMethodDecl>,
+    /// Names the class body `my`/`state`-declares at its own top level
+    /// (ADR-0019 D6-1), precomputed at plan lowering instead of
+    /// `persist_class_body_statics` re-walking the raw body on every
+    /// registration to decide which lexicals are body statics.
+    pub(crate) declared_static_names: Vec<Symbol>,
 }
 
 #[derive(Debug, Clone)]
@@ -5895,6 +5919,7 @@ impl CompiledCode {
             })
             .collect();
         let own_attribute_names = class_own_attribute_names(body);
+        let declared_static_names = class_declared_static_names(body);
         let method_decls = compile_method_decls(body);
         let plan_idx = self.class_decl_plans.len() as u32;
         self.class_decl_plans.push(CompiledClassDeclPlan {
@@ -5917,6 +5942,7 @@ impl CompiledCode {
             attr_decls,
             method_name_chunks,
             method_decls,
+            declared_static_names,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Class(plan_idx));

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -219,6 +219,12 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// available (the role-pun/mixin synthesis paths that call this with an
     /// empty body).
     pub(crate) method_decls: &'a [crate::opcode::CompiledMethodDecl],
+    /// Names the class body `my`/`state`-declares at its own top level
+    /// (ADR-0019 D6-1), precomputed by the compiler at plan lowering instead
+    /// of `persist_class_body_statics` re-walking the raw body at
+    /// registration time. Empty for registration paths with no compiled plan
+    /// available (role-pun/mixin synthesis, `augment class`).
+    pub(crate) declared_static_names: &'a [Symbol],
 }
 
 pub(super) fn parse_role_type_args(input: &str) -> Vec<String> {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1030,6 +1030,7 @@ impl Interpreter {
             attr_decls: &[],
             method_name_chunks: &[],
             method_decls: &[],
+            declared_static_names: &[],
         };
         self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
         self.store_language_revision_from_version(&pun_name, &language_version);

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -98,6 +98,7 @@ impl Interpreter {
         attr_decls: &[(Symbol, crate::opcode::CompiledAttrDecl)],
         method_name_chunks: &[Option<crate::opcode::CompiledDeclExpr>],
         method_decls: &[crate::opcode::CompiledMethodDecl],
+        declared_static_names: &[Symbol],
     ) -> Result<ClassDef, RuntimeError> {
         let saved_package = self.current_package();
         let saved_env = self.env.clone();
@@ -182,15 +183,6 @@ impl Interpreter {
                         continue;
                     }
                 }
-                Stmt::TrustsDecl {
-                    name: trusted_class,
-                } => {
-                    self.registry_mut()
-                        .class_trusts
-                        .entry(cx.name.to_string())
-                        .or_default()
-                        .insert(trusted_class.resolve());
-                }
                 // our &baz ::= &bar  — alias a method under a new name
                 Stmt::VarDecl {
                     name: var_name,
@@ -230,7 +222,7 @@ impl Interpreter {
             self.registry_mut().sync_user_method_entries(cx.name);
         }
         self.run_class_body_leave_phasers(&cx, &class_leave_phasers)?;
-        self.persist_class_body_statics(&cx, body);
+        self.persist_class_body_statics(&cx, declared_static_names);
         self.restore_nested_type_short_names(&cx);
         self.set_current_package(cx.saved_package.clone());
         Ok(cx.class_def)

--- a/src/runtime/registration_class_body_exit.rs
+++ b/src/runtime/registration_class_body_exit.rs
@@ -43,30 +43,29 @@ impl Interpreter {
     /// the package-block store in `exec_package_scope_op`. `current_package`
     /// is still `name` here, which is exactly when a method of this class
     /// reads these names, so the store is correctly scoped.
-    pub(super) fn persist_class_body_statics(&mut self, cx: &ClassBodyCx<'_>, body: &[Stmt]) {
-        // Names this class body actually `my`/`state`-declared at top level. A
-        // class-body static is normally recognized by being NEW in `env` (absent
-        // from `saved_env`). But a same-named lexical leaked into the persistent
-        // mainline env by an EARLIER module's class body (the success path leaves
-        // body statics in `env`) makes `saved_env` already carry the name, so this
-        // class's own `my $x` would be wrongly skipped and never registered as a
-        // static — its methods then fall back to the leaked bare-name global (e.g.
-        // `HTTP::Message`/`HTTP::Request` both `my $CRLF`). A name explicitly
-        // declared here IS a static regardless of any pre-existing outer/leaked
-        // binding, so recognize it directly from the body.
+    pub(super) fn persist_class_body_statics(
+        &mut self,
+        cx: &ClassBodyCx<'_>,
+        declared_static_names: &[crate::symbol::Symbol],
+    ) {
+        // Names this class body actually `my`/`state`-declared at top level
+        // (ADR-0019 D6-1: precomputed by the compiler at plan lowering
+        // instead of re-walked here). A class-body static is normally
+        // recognized by being NEW in `env` (absent from `saved_env`). But a
+        // same-named lexical leaked into the persistent mainline env by an
+        // EARLIER module's class body (the success path leaves body statics
+        // in `env`) makes `saved_env` already carry the name, so this
+        // class's own `my $x` would be wrongly skipped and never registered
+        // as a static — its methods then fall back to the leaked bare-name
+        // global (e.g. `HTTP::Message`/`HTTP::Request` both `my $CRLF`). A
+        // name explicitly declared here IS a static regardless of any
+        // pre-existing outer/leaked binding, so recognize it directly from
+        // the precomputed declaration list.
         let name = cx.name;
         let saved_env = &cx.saved_env;
-        let declared_statics: std::collections::HashSet<&str> = body
+        let declared_statics: std::collections::HashSet<String> = declared_static_names
             .iter()
-            .filter_map(|stmt| match stmt {
-                Stmt::VarDecl {
-                    name,
-                    is_our: false,
-                    is_dynamic: false,
-                    ..
-                } => Some(name.as_str()),
-                _ => None,
-            })
+            .map(|sym| sym.resolve())
             .collect();
         let body_lexicals: Vec<(String, Value)> = self
             .env

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -129,6 +129,7 @@ impl Interpreter {
             attr_decls,
             method_name_chunks,
             method_decls,
+            declared_static_names,
         } = modifiers;
         let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
@@ -229,6 +230,7 @@ impl Interpreter {
             attr_decls,
             method_name_chunks,
             method_decls,
+            declared_static_names,
         )?;
         self.finalize_class_registration(name, parents, class_def, &snapshot)?;
         self.install_class_exporthow(name, parents)?;

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -68,6 +68,7 @@ impl Interpreter {
             attr_decls: &[],
             method_name_chunks: &[],
             method_decls: &[],
+            declared_static_names: &[],
         };
         self.register_class_decl(&name, &parents, modifiers, &[])?;
         self.compose_mixin_role_submethods(&name, &fresh);

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -141,6 +141,7 @@ impl Interpreter {
             attr_decls,
             method_name_chunks,
             method_decls,
+            declared_static_names,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {
@@ -256,6 +257,7 @@ impl Interpreter {
                         attr_decls,
                         method_name_chunks,
                         method_decls,
+                        declared_static_names,
                     },
                     body,
                 )


### PR DESCRIPTION
## Summary
- First slice of ADR-0019 D6 ("Remove `CompiledClassDeclPlan::legacy_body`"), per the 2026-08-08 design pass (`todo/deep/adr0019-d6-d9-legacy-body-removal.md`).
- Add `CompiledClassDeclPlan::declared_static_names: Vec<Symbol>`, precomputed at plan lowering (mirroring `persist_class_body_statics`'s inline scan), so `persist_class_body_statics` no longer re-walks the raw class body on every registration.
- Delete the redundant `Stmt::TrustsDecl` walk arm in `run_class_body`: `publish_class_shell` already inserts the same `class_trusts` entry from D1's `trusts` plan field before the body walk starts, and the compiler already compiles a bare `TrustsDecl` statement to a no-op, so the statement now safely falls through to the catch-all arm with no behavior change.

## Test plan
- [x] New compiler unit test `class_declarations_precompute_declared_static_names`
- [x] `prove -e target/debug/mutsu` on `t/trusts-undeclared.t`, `t/private-trusts.t`, `t/method-private-errors.t`, `t/qualified-private-method-nested-owner.t`, `t/class-body-static-in-sub.t`, `t/class-body-my-lexical-scope.t`, `t/class-body-captured-var-writeback-coherence.t`, `t/class-body-type-scope.t`, `t/cross-module-short-name-types.t`, `t/constant-scalar-my-bare-name-collision.t`, `t/nested-package-not-a-class-static.t`
- [x] Full `make test` (27959 tests, PASS)
- [x] `cargo clippy -- -D warnings`, `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)