### PR TITLE
feat(compiler): precompute role stub-ness and our-scope violations (ADR-0019 D7-1/D9-1)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,8 +115,8 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 29/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
-landed, 2026-08-07; D2b-2, D2c-4, and D6-1 landed 2026-08-08). Phase C is fully checked; the open box is
+**Current progress: 30/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
+landed, 2026-08-07; D2b-2, D2c-4, D6-1, and D7-1/D9-1 landed 2026-08-08). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
@@ -989,6 +989,15 @@ walkers wholesale is not possible before then.
   required-method detection, and pun materialization read the *registry*, not the AST, and
   stay runtime — the declaration's own structure becomes plan data; the composition algebra
   over it does not move. Slices D7-1..4 in the doc.
+  **D7-1 (= D9-1) landed 2026-08-08**: `CompiledRoleDeclPlan` gained `is_stub: bool` and
+  `our_scope_violation: Option<&'static str>`, computed at plan lowering by new
+  `role_body_is_stub`/`role_body_our_scope_violation` free functions mirroring
+  `Interpreter::role_body_is_stub`/`check_role_body_our_scoped_decls`'s scans verbatim
+  (including the role side's looser `.any()` stub check, unlike the class side's
+  single-statement `is_stub_routine_body` — an existing divergence, not changed here).
+  `register_role_decl` now takes both precomputed facts as parameters instead of re-walking
+  the raw body on every registration; the two now-dead `Interpreter` methods are deleted (no
+  other callers). D7-2..4 remain open.
 - [ ] **D8 — Compile role declaration-time bodies and traits.** Run parameterized-role and composed
   ancestor bodies as bytecode child chunks with correct once-per-composition behavior. (Custom-trait
   arguments already landed with C5; the bodies remain.)
@@ -1013,7 +1022,8 @@ walkers wholesale is not possible before then.
   registration* into `RoleDef::deferred_body_stmts` and run per composition — so D9 is
   sequenced after D8 by necessity, exactly as the D4 scoping pass concluded. Slices D9-1
   (role `is_stub` + our-scope plan facts, = D7-1), D9-2 (= D2b-2 role half), D9-3 (= D7-3),
-  D9-4 (= D8 chunks), D9-5 (field drop, forced-instrument playbook).
+  D9-4 (= D8 chunks), D9-5 (field drop, forced-instrument playbook). **D9-1 landed
+  2026-08-08 — see D7-1 above (same slice).**
 - [ ] **D10 — Delete class/role AST registration walkers.** Keep only VM plan execution plus
   metadata helpers that do not inspect executable AST declarations. The token/rule arms of the
   body walk stay until their ADR-0009-scoped slice lands; D10 deletes everything else.

--- a/news/2026-08/adr0019-d7-1-role-stub-ourscope-plan-facts.md
+++ b/news/2026-08/adr0019-d7-1-role-stub-ourscope-plan-facts.md
@@ -1,0 +1,33 @@
+# ADR-0019 D7-1/D9-1: role stub-ness and our-scope violations precomputed at plan lowering
+
+`CompiledRoleDeclPlan` gains two facts the role plan never had a D1-style equivalent for:
+
+- **`is_stub: bool`** — whether the role body is a yada-stub declaration (`...`, `!!!`, or
+  `???`), computed by a new `role_body_is_stub` free function that mirrors
+  `Interpreter::role_body_is_stub` exactly, including its looser `.any()` check (any top-level
+  statement being a stub call marks the whole role a stub) — unlike the class side's
+  `is_stub_routine_body`, which requires the stub to be the body's *only* statement. This is an
+  existing, pre-existing divergence between the class and role stub checks; this slice
+  preserves it rather than unifying it, per the "precompute, don't change behavior" rule.
+- **`our_scope_violation: Option<&'static str>`** — the first our-scoped declaration kind
+  (`"class"`, `"subset"`, `"enum"`, `"role"`, `"constant"`, `"variable"`, `"sub"`, or
+  `"method"`) found in the role body, if any, computed by a new
+  `role_body_our_scope_violation` function mirroring
+  `Interpreter::check_role_body_our_scoped_decls`'s scan verbatim.
+
+Both are computed once at plan lowering (`add_role_decl_plan`) instead of `register_role_decl`
+re-walking the raw body on every registration. `register_role_decl` now takes both facts as
+parameters: `our_scope_violation: Option<&str>` drives the `X::Declaration::OurScopeInRole`
+raise directly (the error-construction code moved from the old scan into the registration
+function unchanged), and `is_stub_body: bool` replaces the old inline `Self::role_body_is_stub(body)`
+call. The two now-dead `Interpreter` methods (`check_role_body_our_scoped_decls`,
+`role_body_is_stub`) are deleted — `register_role_decl` was their only caller.
+
+This is D7-1 and D9-1 at once: the ADR names them as the same slice (the role plan's `is_stub`/
+our-scope facts are shared infrastructure for both "encode role structure" (D7) and "remove
+`CompiledRoleDeclPlan::legacy_body`" (D9)). D7-2..4 and D9-2..5 remain open.
+
+Verified with two new compiler unit tests
+(`role_declarations_precompute_stub_and_our_scope_violation`, alongside the existing
+`role_declarations_precompute_body_prescan`), the existing role/stub/our-scope `t/` tests, the
+full whitelisted `roast/S14-roles/*` suite (24 files, 448 tests), and a full `make test` run.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -287,6 +287,64 @@ mod declaration_plan_tests {
         assert_eq!(plan_r.body_used_modules, vec!["JSON::Fast".to_string()]);
         assert_eq!(plan_r.body_declared_types, vec!["Inner".to_string()]);
     }
+
+    /// ADR-0019 D7-1/D9-1: a role declaration's stub-ness and its first
+    /// our-scope violation (if any) are precomputed at plan lowering, so
+    /// `register_role_decl` never re-walks the raw body to derive them.
+    #[test]
+    fn role_declarations_precompute_stub_and_our_scope_violation() {
+        let (stmts, _) =
+            crate::parse_dispatch::parse_source("role Stub { ... }; role Plain { has $.x }")
+                .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_stub = code
+            .role_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "Stub")
+            .expect("role Stub declaration plan");
+        assert!(plan_stub.is_stub);
+        assert_eq!(plan_stub.our_scope_violation, None);
+
+        let plan_plain = code
+            .role_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "Plain")
+            .expect("role Plain declaration plan");
+        assert!(!plan_plain.is_stub);
+        assert_eq!(plan_plain.our_scope_violation, None);
+
+        let (stmts, _) =
+            crate::parse_dispatch::parse_source("role R { our $x = 1 }").expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+        let plan_r = code
+            .role_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "R")
+            .expect("role R declaration plan");
+        assert_eq!(plan_r.our_scope_violation, Some("variable"));
+
+        let (stmts, _) =
+            crate::parse_dispatch::parse_source("role R { class C {} }").expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+        let plan_r = code
+            .role_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "R")
+            .expect("role R declaration plan");
+        assert_eq!(plan_r.our_scope_violation, Some("class"));
+
+        // A `my class` inside a role is lexically scoped and allowed.
+        let (stmts, _) =
+            crate::parse_dispatch::parse_source("role R { my class C {} }").expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+        let plan_r = code
+            .role_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "R")
+            .expect("role R declaration plan");
+        assert_eq!(plan_r.our_scope_violation, None);
+    }
 }
 mod const_fold;
 mod decl_plan;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2569,6 +2569,78 @@ fn role_body_prescan(body: &[Stmt]) -> (Vec<Symbol>, Vec<String>, Vec<String>) {
     (own_attribute_names, used_modules, declared_types)
 }
 
+/// Whether the role body is a stub declaration (ADR-0019 D7-1/D9-1),
+/// mirroring `Interpreter::role_body_is_stub`: any top-level statement is a
+/// yada-stub call (`...`/`!!!`/`???`). Unlike the class side's
+/// `is_stub_routine_body`, this does not require the stub to be the body's
+/// only statement — precomputed at plan lowering instead of re-walked on
+/// every registration.
+fn role_body_is_stub(body: &[Stmt]) -> bool {
+    body.iter().any(|s| {
+        matches!(s, Stmt::Expr(Expr::Call { name, .. })
+            if name == "__mutsu_stub_die" || name == "__mutsu_stub_warn")
+    })
+}
+
+/// The first our-scoped declaration kind found in a role body (ADR-0019
+/// D7-1/D9-1), mirroring `Interpreter::check_role_body_our_scoped_decls`'s
+/// scan: an implicitly our-scoped `class`/`subset`/`enum`/`role`, or an
+/// explicit `our sub`/`our variable`/`our method`/`constant`, is forbidden
+/// inside a role body. `None` when the body has no violation. Precomputed
+/// at plan lowering instead of re-walked on every registration;
+/// `register_role_decl` raises `X::Declaration::OurScopeInRole` from this
+/// fact instead of constructing it inline.
+fn role_body_our_scope_violation(body: &[Stmt]) -> Option<&'static str> {
+    let flattened = body.iter().flat_map(|s| match s {
+        Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+        other => vec![other],
+    });
+    for stmt in flattened {
+        let declaration = match stmt {
+            // A `my class`/`my subset`/`my enum`/`my role` inside a role is
+            // lexically scoped and private to the role body, which is
+            // allowed; only an implicitly our-scoped declaration is
+            // forbidden.
+            Stmt::ClassDecl {
+                is_lexical: false, ..
+            } => Some("class"),
+            Stmt::ClassDecl { .. } => None,
+            Stmt::SubsetDecl { is_my: true, .. } => None,
+            Stmt::SubsetDecl { .. } => Some("subset"),
+            Stmt::EnumDecl { is_my: true, .. } => None,
+            Stmt::EnumDecl { .. } => Some("enum"),
+            Stmt::RoleDecl { custom_traits, .. }
+                if custom_traits.iter().any(|(t, _)| t == "__my_scoped") =>
+            {
+                None
+            }
+            Stmt::RoleDecl { .. } => Some("role"),
+            Stmt::VarDecl {
+                is_our: true,
+                custom_traits,
+                ..
+            } => {
+                if custom_traits.iter().any(|(t, _)| t == "__constant") {
+                    Some("constant")
+                } else {
+                    Some("variable")
+                }
+            }
+            Stmt::SubDecl { custom_traits, .. }
+                if custom_traits.iter().any(|(t, _)| t == "__our_scoped") =>
+            {
+                Some("sub")
+            }
+            Stmt::MethodDecl { is_our: true, .. } => Some("method"),
+            _ => None,
+        };
+        if declaration.is_some() {
+            return declaration;
+        }
+    }
+    None
+}
+
 /// Precompute a typed `CompiledMethodDecl` for each top-level `method`/
 /// `submethod` declaration in a class/role body (ADR-0019 D3-7), in the same
 /// `SyntheticBlock`-flattened order `compile_method_name_chunks` already
@@ -2715,6 +2787,17 @@ pub(crate) struct CompiledRoleDeclPlan {
     /// declaration in the body (ADR-0019 D3-7). See
     /// `CompiledClassDeclPlan::method_decls`.
     pub(crate) method_decls: Vec<CompiledMethodDecl>,
+    /// Whether the role body is a stub declaration (ADR-0019 D7-1/D9-1),
+    /// precomputed at plan lowering instead of `register_role_decl`
+    /// re-walking the body every registration.
+    pub(crate) is_stub: bool,
+    /// The first our-scoped declaration kind (`"class"`, `"variable"`, ...)
+    /// found in the role body, if any (ADR-0019 D7-1/D9-1); `None` when the
+    /// body has no violation. Precomputed at plan lowering instead of
+    /// `check_role_body_our_scoped_decls` re-walking the body every
+    /// registration; `register_role_decl` raises
+    /// `X::Declaration::OurScopeInRole` from this fact.
+    pub(crate) our_scope_violation: Option<&'static str>,
 }
 
 /// A package-level `proto sub`/`proto rule`/`proto token` declaration lowered
@@ -5972,6 +6055,8 @@ impl CompiledCode {
         };
         let (own_attribute_names, body_used_modules, body_declared_types) = role_body_prescan(body);
         let method_decls = compile_method_decls(body);
+        let is_stub = role_body_is_stub(body);
+        let our_scope_violation = role_body_our_scope_violation(body);
         let plan_idx = self.role_decl_plans.len() as u32;
         self.role_decl_plans.push(CompiledRoleDeclPlan {
             name: *name,
@@ -5989,6 +6074,8 @@ impl CompiledCode {
             attr_decls,
             method_name_chunks,
             method_decls,
+            is_stub,
+            our_scope_violation,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Role(plan_idx));

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -276,17 +276,29 @@ impl Interpreter {
         attr_decls: &[(Symbol, crate::opcode::CompiledAttrDecl)],
         method_name_chunks: &[Option<crate::opcode::CompiledDeclExpr>],
         method_decls: &[crate::opcode::CompiledMethodDecl],
+        is_stub_body: bool,
+        our_scope_violation: Option<&str>,
     ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
 
-        Self::check_role_body_our_scoped_decls(body)?;
+        if let Some(decl) = our_scope_violation {
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("declaration".to_string(), Value::str(decl.to_string()));
+            attrs.insert(
+                "message".to_string(),
+                Value::str(format!(
+                    "Cannot declare our-scoped {} inside of a role",
+                    decl
+                )),
+            );
+            return Err(RuntimeError::typed("X::Declaration::OurScopeInRole", attrs));
+        }
         self.check_role_type_param_validity(type_param_defs)?;
 
         // If this is a stub declaration (body is `...`, `!!!`, or `???`)
         // and a real (non-stub) role already exists under this name, treat
         // the stub as a forward declaration / no-op — don't register a new
         // stub candidate that would shadow the real one.
-        let is_stub_body = Self::role_body_is_stub(body);
         if is_stub_body
             && type_params.is_empty()
             && self

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -50,79 +50,6 @@ impl RoleDeclCx<'_> {
 }
 
 impl Interpreter {
-    /// Check for our-scoped declarations inside the role body.
-    /// In Raku, class/subset/enum/constant/role are implicitly our-scoped,
-    /// and explicit `our sub/method/variable` are also forbidden inside roles.
-    pub(super) fn check_role_body_our_scoped_decls(body: &[Stmt]) -> Result<(), RuntimeError> {
-        let check_body: Vec<&Stmt> = body
-            .iter()
-            .flat_map(|s| match s {
-                Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
-                other => vec![other],
-            })
-            .collect();
-        for stmt in &check_body {
-            let declaration = match stmt {
-                // A `my class` inside a role is a lexically-scoped class private to the
-                // role and is allowed; only an implicitly our-scoped `class` is forbidden.
-                Stmt::ClassDecl {
-                    is_lexical: false, ..
-                } => Some("class"),
-                Stmt::ClassDecl { .. } => None,
-                // A `my subset` inside a role is lexically scoped and private to the
-                // role body, which is allowed (like `my class`/`my role`); only an
-                // implicitly our-scoped `subset` is forbidden.
-                Stmt::SubsetDecl { is_my: true, .. } => None,
-                Stmt::SubsetDecl { .. } => Some("subset"),
-                // A `my enum` is lexically scoped and private to the role body,
-                // which is allowed (like `my class`/`my subset`/`my role`); only
-                // an implicitly our-scoped `enum` is forbidden.
-                Stmt::EnumDecl { is_my: true, .. } => None,
-                Stmt::EnumDecl { .. } => Some("enum"),
-                // A `my role` is lexically scoped and private to the role body, which
-                // is allowed (like `my class`); only an implicitly our-scoped `role` is
-                // forbidden.
-                Stmt::RoleDecl { custom_traits, .. }
-                    if custom_traits.iter().any(|(t, _)| t == "__my_scoped") =>
-                {
-                    None
-                }
-                Stmt::RoleDecl { .. } => Some("role"),
-                Stmt::VarDecl {
-                    is_our: true,
-                    custom_traits,
-                    ..
-                } => {
-                    if custom_traits.iter().any(|(t, _)| t == "__constant") {
-                        Some("constant")
-                    } else {
-                        Some("variable")
-                    }
-                }
-                Stmt::SubDecl { custom_traits, .. }
-                    if custom_traits.iter().any(|(t, _)| t == "__our_scoped") =>
-                {
-                    Some("sub")
-                }
-                Stmt::MethodDecl { is_our: true, .. } => Some("method"),
-                _ => None,
-            };
-            if let Some(decl) = declaration {
-                let mut attrs = std::collections::HashMap::new();
-                attrs.insert("declaration".to_string(), Value::str(decl.to_string()));
-                attrs.insert(
-                    "message".to_string(),
-                    Value::str(format!(
-                        "Cannot declare our-scoped {} inside of a role",
-                        decl
-                    )),
-                );
-                return Err(RuntimeError::typed("X::Declaration::OurScopeInRole", attrs));
-            }
-        }
-        Ok(())
-    }
-
     /// Validate the role's own type-parameter list: a bare-type parameter
     /// (`role R[SomeType]`) must name a resolvable type.
     pub(super) fn check_role_type_param_validity(
@@ -148,15 +75,6 @@ impl Interpreter {
             }
         }
         Ok(())
-    }
-
-    /// Whether the role body is a stub declaration (body is `...`, `!!!`, or
-    /// `???`).
-    pub(super) fn role_body_is_stub(body: &[Stmt]) -> bool {
-        body.iter().any(|s| {
-            matches!(s, Stmt::Expr(Expr::Call { name, .. })
-                if name == "__mutsu_stub_die" || name == "__mutsu_stub_warn")
-        })
     }
 
     /// Clean up stale registry entries for this role name before

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -611,6 +611,8 @@ impl Interpreter {
             attr_decls,
             method_name_chunks,
             method_decls,
+            is_stub,
+            our_scope_violation,
         }) = code.role_decl_plans.get(idx as usize)
         {
             let name_str = name.resolve();
@@ -643,6 +645,8 @@ impl Interpreter {
                     attr_decls,
                     method_name_chunks,
                     method_decls,
+                    *is_stub,
+                    *our_scope_violation,
                 )
             )?;
             // Link `is Parent` references on this role to the lexical class visible


### PR DESCRIPTION
## Summary
- `CompiledRoleDeclPlan` gains `is_stub: bool` and `our_scope_violation: Option<&'static str>`, precomputed at plan lowering by new `role_body_is_stub`/`role_body_our_scope_violation` free functions that mirror `Interpreter::role_body_is_stub`/`check_role_body_our_scoped_decls` verbatim (including the role side's looser `.any()` stub check vs. the class side's single-statement `is_stub_routine_body` — a pre-existing divergence, preserved not fixed here).
- `register_role_decl` now takes both facts as parameters instead of re-walking the raw body on every registration; the two now-dead `Interpreter` methods are deleted (no other callers).
- This is D7-1 and D9-1 at once — the ADR names them as the same slice, shared infrastructure for both "encode role structure" (D7) and "remove `CompiledRoleDeclPlan::legacy_body`" (D9). See `todo/deep/adr0019-d7-d8-role-plan-encoding.md`.

## Test plan
- [x] New compiler unit test `role_declarations_precompute_stub_and_our_scope_violation`
- [x] `prove -e target/debug/mutsu` on role/stub/our-scope-adjacent `t/` tests
- [x] Full whitelisted `roast/S14-roles/*` suite (24 files, 448 tests) on release build
- [x] Full `make test` (27962 tests, PASS)
- [x] `cargo clippy -- -D warnings`, `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)