### PR TITLE
fix(vm): the with-statement-modifier form now writes a container element topic back

### DIFF
--- a/news/2026-08/with-statement-modifier-element-writeback.md
+++ b/news/2026-08/with-statement-modifier-element-writeback.md
@@ -1,0 +1,59 @@
+# `.=Int with @a[i]` silently dropped the mutation
+
+`t/http-router.rakutest` in the vendored Cro suite hung forever on any route
+with a typed optional trailing parameter (`Int $page?`) whose value was
+actually present in the URL (`/orders/history/2`, but not the bare
+`/orders/history`). Isolated with `CRODBG=1`: the router's own debug trace
+showed the route matched and its `Capture` was built with the raw path
+segment `"2"` (a `Str`), not the `Int 2` the matcher's regex block is
+supposed to produce — `Cro::HTTP::Router`'s matcher does exactly
+`.=Int with @segs[2]` to convert a path segment before building the
+Capture. Binding a `Str` where the handler signature declares `Int $page?`
+then went nowhere; the request pipeline never delivered a response and the
+client's `$responses.receive` blocked forever.
+
+## Root cause
+
+Minimal, Cro-independent repro:
+
+```
+$ mutsu -e 'my @a = "1","2"; .=Int with @a[1]; say @a.raku'
+["1", "2"]     # raku: ["1", 2]
+```
+
+`with @a[i] { ... }` (the block form) already worked — `stmt.rs`'s
+statement-position `Given` compiler detects an `Expr::Index` topic and emits
+`OpCode::TagElementSource`, so the topic aliases the array element as an
+lvalue and any mutation of `$_` writes back through
+`write_back_element_source`.
+
+The *statement-modifier* form (`.=Int with @a[i]`) takes a different path:
+because `.=Int` parses as an expression statement, the parser wraps the whole
+thing in `Expr::DoStmt(Stmt::Given { is_statement_modifier: true, ... })` to
+preserve expression semantics (`src/parser/stmt/modifier.rs`). But the
+expression-form `Given` compiler (`compile_expr_do_stmt` in
+`src/compiler/expr_block.rs`) was a stripped-down copy of the statement-position
+one that never got the `Expr::Index`/`TagElementSource` branch — only a bare
+`Expr::Var`/`ArrayVar`/`HashVar` topic got tagged (`TagContainerRef`, for
+whole-container writeback via shared mutation). An array/hash *element* topic
+fell through to a plain `compile_expr(topic)`, pushing a value copy with no
+way back to the source. The VM side (`exec_do_given_expr_op`) matched: it
+never consulted `self.element_source` or called `write_back_element_source`
+at all.
+
+`do given @a[i] { ... }` (explicit block, still routed through the same
+`DoStmt(Given)` path) had the identical bug — the statement-modifier form is
+just the common way to trigger it.
+
+## Fix
+
+Mirror the statement-position compiler's `element_source` detection in
+`compile_expr_do_stmt`'s `Given` arm, and give `exec_do_given_expr_op` the
+same element-source save/writeback/one-shot-clear handling
+`exec_given_op` already has.
+
+Pin: `t/with-statement-modifier-element-writeback.t`. `http-router.rakutest`
+no longer hangs (it still has other, unrelated failures — see the ticket
+this fix does not close). A related gap in `for @a[i] { ... }` (which should
+alias the same way but doesn't) is out of scope and filed separately:
+`todo/tickets/for-single-element-topic-does-not-write-back.md`.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -61,17 +61,44 @@ impl Compiler {
                 );
             }
             Stmt::Given { topic, body, .. } => {
-                self.compile_expr(topic);
-                if let Some(source_name) = match topic {
-                    Expr::Var(name) => Some(name.clone()),
-                    Expr::ArrayVar(name) => Some(format!("@{}", name)),
-                    Expr::HashVar(name) => Some(format!("%{}", name)),
+                // An lvalue container *element* topic (`do given @a[i]`, which
+                // `.=Int with @a[i]` desugars to — see modifier.rs) aliases
+                // that element rw, same as the statement-position Given arm
+                // (stmt.rs). Without this, the topic was pushed as a plain
+                // value and `.=Int`'s mutation of `$_` never reached `@a[i]`.
+                let element_source = match topic {
+                    Expr::Index {
+                        target,
+                        index,
+                        is_positional,
+                    } => Self::container_var_name(target)
+                        .filter(|c| {
+                            let after_sigil = c.strip_prefix(['$', '@', '%']).unwrap_or(c);
+                            !after_sigil.starts_with(['!', '.'])
+                        })
+                        .map(|c| (c, index, *is_positional)),
                     _ => None,
-                } {
-                    let source_slot = self.local_map.get(source_name.as_str()).copied();
-                    let name_idx = self.code.add_constant(Value::str(source_name));
-                    self.code
-                        .emit(OpCode::TagContainerRef(name_idx, source_slot));
+                };
+                if let Some((container, index, is_positional)) = element_source {
+                    self.compile_expr(index);
+                    let container_idx = self.code.add_constant(Value::str(container));
+                    self.code.emit(OpCode::TagElementSource {
+                        container_idx,
+                        positional: is_positional,
+                    });
+                } else {
+                    self.compile_expr(topic);
+                    if let Some(source_name) = match topic {
+                        Expr::Var(name) => Some(name.clone()),
+                        Expr::ArrayVar(name) => Some(format!("@{}", name)),
+                        Expr::HashVar(name) => Some(format!("%{}", name)),
+                        _ => None,
+                    } {
+                        let source_slot = self.local_map.get(source_name.as_str()).copied();
+                        let name_idx = self.code.add_constant(Value::str(source_name));
+                        self.code
+                            .emit(OpCode::TagContainerRef(name_idx, source_slot));
+                    }
                 }
                 // A scalar placeholder in the body binds the topic, same as
                 // the statement-position Given arm (`do given 5 { $^a + 1 }`).

--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -229,6 +229,14 @@ impl Interpreter {
         let topic_local_slot = self.find_local_slot(code, "_");
         let saved_local_topic = topic_local_slot.map(|s| self.locals[s].clone());
         let saved_when = self.when_matched();
+        // An element-source topic (`do given @a[i]` — what `.=Int with @a[i]`
+        // desugars to, see modifier.rs) aliases an lvalue element: `$_`'s final
+        // value is written back to that element below, matching the
+        // statement-position `Given`'s handling (`exec_given_op`). This is a
+        // one-shot signal set by `TagElementSource` immediately before this op,
+        // so it is cleared (not restored) once consumed.
+        let element_source = self.element_source.take();
+        let element_orig = element_source.is_some().then(|| topic.clone());
         // Consume the topic's `TagContainerRef` signal (emitted right before this
         // op by `do given @c`). It must NOT survive into the body: a nested
         // `for @c[$slice] { }` — whose slice iterable emits no source tag of its
@@ -243,7 +251,7 @@ impl Interpreter {
         let saved_topic_source = self.topic_source_var.take();
         let saved_container_source = self.topic_container_source.take();
         if let Some((src, _)) = &saved_container_ref
-            && self.element_source.is_none()
+            && element_source.is_none()
         {
             self.topic_source_var = Some(src.clone());
             if src.starts_with('@') || src.starts_with('%') {
@@ -288,10 +296,14 @@ impl Interpreter {
                 }
                 self.topic_source_var = saved_topic_source;
                 self.topic_container_source = saved_container_source;
+                self.element_source = None;
                 return Err(e);
             }
         }
 
+        if let Some(src) = &element_source {
+            self.write_back_element_source(code, src, &None, element_orig.as_ref());
+        }
         loan_env!(self, set_when_matched(saved_when));
         if let Some(v) = saved_topic {
             self.env_mut().insert("_".to_string(), v);
@@ -303,6 +315,7 @@ impl Interpreter {
         }
         self.topic_source_var = saved_topic_source;
         self.topic_container_source = saved_container_source;
+        self.element_source = None;
         self.stack.push(last);
         *ip = end;
         Ok(())

--- a/t/with-statement-modifier-element-writeback.t
+++ b/t/with-statement-modifier-element-writeback.t
@@ -1,0 +1,51 @@
+use Test;
+plan 5;
+
+# `t/with-element-topic.t` pins the *block* form (`with EXPR { ... }`), which
+# already wrote a container-element topic back correctly. The statement-
+# *modifier* form (`STMT with EXPR`) took a different compile path when the
+# statement was itself an expression statement (e.g. `.=Int with @a[i]`): the
+# parser wraps it in `Expr::DoStmt(Stmt::Given)` to preserve expression
+# semantics (`modifier.rs`), and the expression-form Given compiler
+# (`compile_expr_do_stmt` in `expr_block.rs`) never had the element-source
+# detection the statement-position compiler (`stmt.rs`) has — so the topic
+# was pushed as a plain value copy and any mutation of `$_` (`.=Int`, `$_ = `)
+# never reached the array/hash element.
+#
+# This is not a synthetic corner case: `Cro::HTTP::Router`'s route matcher
+# does exactly `.=Int with @segs[2]` to convert a path segment to `Int` before
+# building the route's argument Capture, so the vendored Cro suite's
+# `http-router.rakutest` hung forever on any route with a typed optional
+# trailing parameter (`Int $page?`) whose value was actually present — the
+# unconverted `Str` failed to bind and the response was silently never
+# produced.
+
+{
+    my @a = "1", "2";
+    .=Int with @a[1];
+    is-deeply @a, ["1", 2], '.=Int with @a[i] (statement modifier) writes the Int back to the element';
+    is @a[1].WHAT.raku, 'Int', 'the element is now a real Int, not a Str';
+}
+
+{
+    my %h = a => "1";
+    .=Int with %h<a>;
+    is %h<a>, 1, '.=Int with %h<k> (statement modifier) writes the Int back to the element';
+}
+
+{
+    # A plain scalar variable topic already worked (`Expr::Var` gets
+    # `TagContainerRef` in both compile paths) — pin it alongside the element
+    # cases so a regression is caught in the same file.
+    my $x = "1";
+    .=Int with $x;
+    is $x, 1, '.=Int with $x (statement modifier, plain scalar) still writes back';
+}
+
+{
+    # `do given @a[i] { ... }` is the same DoStmt(Given) compile path with an
+    # explicit block instead of a bare expression statement body.
+    my @a = "1", "2";
+    do given @a[1] { .=Int };
+    is-deeply @a, ["1", 2], 'do given @a[i] { .=Int } writes the Int back to the element';
+}

--- a/todo/tickets/for-single-element-topic-does-not-write-back.md
+++ b/todo/tickets/for-single-element-topic-does-not-write-back.md
@@ -1,0 +1,33 @@
+# `for @a[i] { ... }` does not alias the element for writeback
+
+`for EXPR { ... }` over a single non-iterable element (`for @a[i] { .=Int }`)
+should topicalize `@a[i]` the same way `with @a[i] { ... }` does — as an
+lvalue alias, so `.=Int`/`$_ = ...` inside the body write back to the
+element. `raku` does this; mutsu does not:
+
+```
+$ raku -e 'my @a = "1","2"; for @a[1] { .=Int }; say @a.raku'
+["1", 2]
+$ mutsu -e 'my @a = "1","2"; for @a[1] { .=Int }; say @a.raku'
+["1", "2"]
+```
+
+Found as a side note while fixing the `with`-statement-modifier element
+writeback bug (`news/2026-08/with-statement-modifier-element-writeback.md`) —
+that fix only covers `with`/`given`'s `Expr::DoStmt(Stmt::Given)` compile
+path (`src/compiler/expr_block.rs`), not `for`'s loop compilation
+(`src/compiler/stmt.rs`'s `Stmt::For` handling / `src/vm/vm_control_ops.rs`),
+which is a different opcode family entirely.
+
+## Where to look
+
+- `src/compiler/stmt.rs`'s `Stmt::For` compilation: does it ever detect a
+  non-iterable single-element source (`@a[i]`, `%h<k>`) as its own case, or
+  does everything go through the general iterable path (which would coerce
+  `@a[i]`'s value into a one-element list and iterate that, losing the
+  container/index pair needed for writeback)? Compare against how `given`
+  detects `element_source` (`stmt.rs` around the `Stmt::Given` arm, `Expr::Index`
+  matching + `OpCode::TagElementSource`).
+- The VM's loop execution (`src/vm/vm_control_ops.rs` or wherever `for`
+  iterates) would need the same `write_back_element_source` treatment
+  (`src/vm/vm_loop_writeback.rs`) `given`/`with` now get consistently.


### PR DESCRIPTION
## Summary
- `.=Int with @a[i]` (the statement-modifier form of `with`) silently dropped the mutation, while the block form (`with @a[i] { .=Int }`) already worked correctly.
- Root cause: the statement-modifier form wraps the statement in `Expr::DoStmt(Stmt::Given)` (`src/parser/stmt/modifier.rs`), which compiles through a *different* function (`compile_expr_do_stmt` in `src/compiler/expr_block.rs`) than the statement-position `Given` (`src/compiler/stmt.rs`). The expression-form compiler never had the `Expr::Index` element-source detection the statement-position one has, so a container-element topic was pushed as a plain value copy — `$_`'s final value had nowhere to write back to. `exec_do_given_expr_op` (VM side) matched: it never consulted `self.element_source` or called `write_back_element_source` at all.
- Fix: mirror the statement-position compiler's element-source detection into the expression form, and give `exec_do_given_expr_op` the same save/writeback/one-shot-clear handling `exec_given_op` already has.
- This is a general-purpose language bug, not Cro-specific, but it's what hung the vendored Cro suite's `http-router.rakutest` forever: `Cro::HTTP::Router`'s route matcher does exactly `.=Int with @segs[2]` to convert a path segment before building the route's Capture, so any route with a typed optional trailing parameter (`Int $page?`) whose value was actually present bound an unconverted `Str` and the response was never produced. `http-router.rakutest` no longer hangs (64/83 passing now, up from stalling around test 57-59 with `rc=124`; the remaining 19 failures are unrelated pre-existing bugs).
- A related gap where `for @a[i] { .=Int }` should alias the element the same way but doesn't is out of scope for this PR — filed as `todo/tickets/for-single-element-topic-does-not-write-back.md`.

## Test plan
- [x] `target/debug/mutsu t/with-statement-modifier-element-writeback.t` — 5/5 pass, matches `raku` exactly
- [x] `target/debug/mutsu t/with-element-topic.t` — existing block-form test, still 12/12 pass (no regression)
- [x] `make test` — full local suite passes
- [x] Re-ran the full vendored Cro::HTTP and Cro::Core suites with a fresh release build — no regressions; only `http-router.rakutest` changed (rc=124 hang → rc=1, 64/83)
- [ ] CI: `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)