### PR TITLE
feat(parser): capture is/does/hides bracket args as parsed Expr lists (ADR-0019 D4-1)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,8 +115,8 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 30/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
-landed, 2026-08-07; D2b-2, D2c-4, D6-1, and D7-1/D9-1 landed 2026-08-08). Phase C is fully checked; the open box is
+**Current progress: 31/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
+landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, and D4-1 landed 2026-08-08). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
@@ -932,6 +932,17 @@ walkers wholesale is not possible before then.
   cutover is gated on a raku case table because the string path's heuristics sometimes produce
   type objects where naive evaluation would not). The `Expr` path also fixes
   `split_balanced_comma_list`'s quote-blindness (`R["a,b"]` mis-splits today) for free.
+  **D4-1 landed 2026-08-08**: `Stmt::ClassDecl` gained `parent_args: Vec<(String, Vec<Expr>)>`
+  and `Stmt::DoesDecl` gained `args: Option<Vec<Expr>>`, populated by a new
+  `parse_bracket_arg_exprs` helper at every bracket-suffix call site that builds a genuine
+  `is`/`does`/`hides` parent string (class body, `unit class`, `unit role`, grammar `is`/`does`)
+  — nine sites in total once `grammar_module.rs`'s two and `package_decl.rs`'s unit-role `does`
+  were included alongside the seven the design doc enumerated. `augment`'s bracket sites and
+  `also does`/body-level `does R;` stay string-only (no bracket parsing happens there today).
+  `compiler/stmt.rs`'s `qualify_decl_name` (the `unit class`/`unit module` package-qualification
+  pass) re-keys `parent_args` through the same `qualify_parent` closure it already applies to
+  `parents`/`does_parents`/`hidden_parents`, so a lookup by the (now qualified) parent string
+  still hits. No consumer reads either field yet (D4-2/D4-3/D7-3).
 - [ ] **D5 — Drive user HOW operations from plan ops.** Execute `new_type`, `add_method`, trait
   interception, and `compose` without entering `register_class_decl`'s AST walker.
   **Design pass done 2026-08-08 (no code landed) — the box shrinks:**
@@ -997,7 +1008,9 @@ walkers wholesale is not possible before then.
   single-statement `is_stub_routine_body` — an existing divergence, not changed here).
   `register_role_decl` now takes both precomputed facts as parameters instead of re-walking
   the raw body on every registration; the two now-dead `Interpreter` methods are deleted (no
-  other callers). D7-2..4 remain open.
+  other callers). D7-2 (= D2b-2's role half, name-keyed `attr_decls`) was already delivered by
+  D2b-2 landing on both `CompiledClassDeclPlan` and `CompiledRoleDeclPlan` at once. D7-3..4
+  remain open.
 - [ ] **D8 — Compile role declaration-time bodies and traits.** Run parameterized-role and composed
   ancestor bodies as bytecode child chunks with correct once-per-composition behavior. (Custom-trait
   arguments already landed with C5; the bodies remain.)

--- a/news/2026-08/adr0019-d4-1-parent-bracket-arg-exprs.md
+++ b/news/2026-08/adr0019-d4-1-parent-bracket-arg-exprs.md
@@ -1,0 +1,36 @@
+# ADR-0019 D4-1: bracketed `is`/`does`/`hides` parents also captured as parsed expressions
+
+`is Parent[Args]`/`does Role[Args]`/`hides Parent[Args]` bracket content has always been captured
+as raw balanced-bracket source text, concatenated onto the parent name into `parents`/
+`does_parents`/`hidden_parents`. That concatenated string is re-parsed and tree-walked per
+argument, per registration, by `eval_role_arg_values` — the target of a future cutover
+(D4-3/D7-3).
+
+This slice is purely additive groundwork: the parser also parses the bracket content as a real,
+comma-separated expression list with the expression parser, riding alongside the unchanged
+string in two new AST fields:
+
+- `Stmt::ClassDecl::parent_args: Vec<(String, Vec<Expr>)>`, keyed by the same full concatenated
+  parent string that already appears in `parents`/`does_parents`/`hidden_parents`.
+- `Stmt::DoesDecl::args: Option<Vec<Expr>>`, for the role-body synthetic `does` parents (a
+  `Stmt::RoleDecl` body has no parent field of its own — parents travel as body `DoesDecl`s).
+
+An entry is present only when the bracket content parses cleanly as a complete expression list
+(`parse_bracket_arg_exprs`, a new free function in `class_decl.rs`); on any parse failure the
+string remains the sole source of truth, so nothing the existing balanced-bracket scan accepted
+is ever rejected. Nine call sites needed the new capture: the class-body `is`/`does`/`hides`
+loop, `unit class`'s `is` clause, `unit role`'s `does` clause, and grammar's `is`/`does` clauses
+(two more than the seven the original design doc enumerated — `grammar`'s own `is`/`does` loop
+desugars to a `ClassDecl` just like a plain class). `augment class`'s bracket sites and the
+body-level `does R;`/`also does R;` forms stay string-only, since neither ever parses bracket
+content today.
+
+One correctness wrinkle: `compiler/stmt.rs`'s `qualify_decl_name` (the `unit class`/`unit
+module` package-qualification pass, which rewrites bare parent names to `Pkg::Name`) had to
+re-key `parent_args` through the same `qualify_parent` closure it already applies to `parents`/
+`does_parents`/`hidden_parents` — otherwise a future lookup by the (now-qualified) parent string
+would silently miss.
+
+No consumer reads either new field yet — that is D4-2 (compiler: lower the exprs into compiled
+chunks on the class plan) and D4-3/D7-3 (registration cutover), tracked separately. Verified
+with four new parser unit tests and a full `make test` run (27962 tests, PASS).

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1031,6 +1031,17 @@ pub(crate) enum Stmt {
         /// 0 means "no stable site" (runtime-synthesized or deserialized node).
         #[serde(skip)]
         decl_id: u64,
+        /// Parsed argument expressions for a bracketed `is`/`does`/`hides`
+        /// parent (`is Parent[Args]`), keyed by the full concatenated parent
+        /// string that also appears in `parents`/`does_parents`/
+        /// `hidden_parents` (ADR-0019 D4-1). An entry is present only when
+        /// the bracket content parsed cleanly as a comma-separated
+        /// expression list; the concatenated string in the other fields
+        /// remains the sole authoritative source for the parent name/
+        /// registry key either way — this is a purely additive capture with
+        /// no consumer yet (D4-2/D4-3).
+        #[serde(default)]
+        parent_args: Vec<(String, Vec<Expr>)>,
     },
     HasDecl {
         name: Symbol,
@@ -1126,6 +1137,14 @@ pub(crate) enum Stmt {
     },
     DoesDecl {
         name: Symbol,
+        /// Parsed argument expressions for a bracketed role application
+        /// (`does Role[Args]`), if the bracket content parsed cleanly as a
+        /// comma-separated expression list (ADR-0019 D4-1). `name` (which
+        /// carries the full `Role[Args]` string) remains the sole
+        /// authoritative source for the role name/registry key either way —
+        /// purely additive, no consumer yet (D4-2/D4-3/D7-3).
+        #[serde(default)]
+        args: Option<Vec<Expr>>,
     },
     TrustsDecl {
         name: Symbol,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -93,11 +93,19 @@ impl Compiler {
                 custom_traits,
                 is_unit,
                 decl_id,
+                parent_args,
                 ..
             } => {
                 let new_parents: Vec<String> = parents.iter().map(&qualify_parent).collect();
                 let new_does: Vec<String> = does_parents.iter().map(&qualify_parent).collect();
                 let new_hidden: Vec<String> = hidden_parents.iter().map(&qualify_parent).collect();
+                // Re-key alongside `parents`/`does_parents`/`hidden_parents`
+                // above so `parent_args` lookups by the (now qualified)
+                // parent string still hit (ADR-0019 D4-1).
+                let new_parent_args: Vec<(String, Vec<Expr>)> = parent_args
+                    .iter()
+                    .map(|(k, v)| (qualify_parent(k), v.clone()))
+                    .collect();
                 Stmt::ClassDecl {
                     name: qualified_sym,
                     name_expr: name_expr.clone(),
@@ -113,6 +121,7 @@ impl Compiler {
                     custom_traits: custom_traits.clone(),
                     is_unit: *is_unit,
                     decl_id: *decl_id,
+                    parent_args: new_parent_args,
                 }
             }
             Stmt::RoleDecl {

--- a/src/parser/primary/misc/anon_decl.rs
+++ b/src/parser/primary/misc/anon_decl.rs
@@ -112,6 +112,7 @@ pub(crate) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
             0,
             Stmt::DoesDecl {
                 name: Symbol::intern(role_name),
+                args: None,
             },
         );
     }
@@ -132,6 +133,7 @@ pub(crate) fn anon_class_expr(input: &str) -> PResult<'_, Expr> {
             custom_traits: Vec::new(),
             is_unit: false,
             decl_id: crate::ast::next_class_decl_id(),
+            parent_args: Vec::new(),
         })),
     ))
 }

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -25,8 +25,8 @@ pub(crate) use token_body::{
 
 // Shared declarator helpers used across submodules.
 pub(crate) use class_decl::{
-    meta_setter_stmt, parse_declarator_traits, parse_optional_bracket_suffix,
-    reject_trailing_postfix,
+    meta_setter_stmt, parse_bracket_arg_exprs, parse_declarator_traits,
+    parse_optional_bracket_suffix, reject_trailing_postfix,
 };
 pub(crate) use package_decl::{
     check_pseudo_package_in_decl, export_name_clash_error, extract_exported_subs,

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -78,6 +78,38 @@ pub(crate) fn parse_optional_bracket_suffix(input: &str) -> PResult<'_, String> 
     Ok((&input[end..], input[..end].to_string()))
 }
 
+/// Attempt to parse the inside of an `is`/`does`/`hides` bracket suffix
+/// (`[Int, "a,b", { $_ * 2 }]`, as returned by [`parse_optional_bracket_suffix`])
+/// as a real, comma-separated expression list (ADR-0019 D4-1). Returns
+/// `None` when there is no bracket suffix at all, or when the content fails
+/// to parse cleanly as a complete expression list (leftover input after the
+/// last expression) — the raw concatenated string built by every caller
+/// remains the sole authoritative source for the parent name/registry key
+/// either way; this capture is purely additive with no consumer yet.
+pub(crate) fn parse_bracket_arg_exprs(bracket_suffix: &str) -> Option<Vec<Expr>> {
+    let inner = bracket_suffix.strip_prefix('[')?.strip_suffix(']')?;
+    let inner = inner.trim();
+    if inner.is_empty() {
+        return Some(Vec::new());
+    }
+    let mut exprs = Vec::new();
+    let mut rest = inner;
+    loop {
+        let (r, e) = expression(rest).ok()?;
+        exprs.push(e);
+        let (r, _) = ws(r).ok()?;
+        if r.is_empty() {
+            return Some(exprs);
+        }
+        let r = r.strip_prefix(',')?;
+        let (r, _) = ws(r).ok()?;
+        if r.is_empty() {
+            return Some(exprs);
+        }
+        rest = r;
+    }
+}
+
 /// Extract the tag names from an `is export(...)` argument list, e.g.
 /// `":ALL, :FOO"` -> `["ALL", "FOO"]`. Each colonpair `:NAME` contributes its
 /// name; bare words are also accepted (`export(FOO)`).
@@ -316,6 +348,7 @@ pub(crate) fn anon_class_decl(input: &str) -> PResult<'_, Stmt> {
         custom_traits: Vec::new(),
         is_unit: false,
         decl_id: crate::ast::next_class_decl_id(),
+        parent_args: Vec::new(),
     };
     // Emit the class registration followed by unregistering the name from the scope
     let unregister = Stmt::Expr(Expr::Call {
@@ -351,6 +384,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
     let mut hidden_parents = Vec::new();
     let mut parents = Vec::new();
     let mut does_parents = Vec::new();
+    let mut parent_args: Vec<(String, Vec<Expr>)> = Vec::new();
     let mut is_repr: Option<String> = None;
     let mut custom_traits: Vec<(String, Option<Expr>)> = Vec::new();
     let mut is_export = false;
@@ -414,7 +448,11 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
                 || parent.starts_with("::")
             {
                 let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
-                parents.push(format!("{}{}", parent, bracket_suffix));
+                let full_name = format!("{}{}", parent, bracket_suffix);
+                if let Some(exprs) = parse_bracket_arg_exprs(&bracket_suffix) {
+                    parent_args.push((full_name.clone(), exprs));
+                }
+                parents.push(full_name);
                 r = r2;
                 let (r2, _) = ws(r)?;
                 r = r2;
@@ -457,7 +495,11 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
                     continue;
                 }
                 let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
-                parents.push(format!("{}{}", parent, bracket_suffix));
+                let full_name = format!("{}{}", parent, bracket_suffix);
+                if let Some(exprs) = parse_bracket_arg_exprs(&bracket_suffix) {
+                    parent_args.push((full_name.clone(), exprs));
+                }
+                parents.push(full_name);
                 r = r2;
                 let (r2, _) = ws(r)?;
                 r = r2;
@@ -473,6 +515,9 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             let (r2, _) = ws(r2)?;
             let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
             let full_name = format!("{}{}", role_name, bracket_suffix);
+            if let Some(exprs) = parse_bracket_arg_exprs(&bracket_suffix) {
+                parent_args.push((full_name.clone(), exprs));
+            }
             parents.push(full_name.clone());
             does_parents.push(full_name);
             let (r2, _) = ws(r2)?;
@@ -485,6 +530,9 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             let (r2, _) = ws(r2)?;
             let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
             let hidden_parent = format!("{}{}", parent, bracket_suffix);
+            if let Some(exprs) = parse_bracket_arg_exprs(&bracket_suffix) {
+                parent_args.push((hidden_parent.clone(), exprs));
+            }
             parents.push(hidden_parent.clone());
             hidden_parents.push(hidden_parent);
             let (r2, _) = ws(r2)?;
@@ -562,6 +610,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
         custom_traits,
         is_unit: false,
         decl_id: crate::ast::next_class_decl_id(),
+        parent_args,
     };
     let mut stmts = Vec::new();
     for (trait_name, trait_value) in traits {
@@ -605,6 +654,7 @@ pub(crate) fn also_trait_stmt(input: &str) -> PResult<'_, Stmt> {
             r,
             Stmt::DoesDecl {
                 name: Symbol::intern(&name),
+                args: None,
             },
         ));
     }

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -19,6 +19,7 @@ pub(crate) fn does_decl(input: &str) -> PResult<'_, Stmt> {
         rest,
         Stmt::DoesDecl {
             name: Symbol::intern(&name),
+            args: None,
         },
     ))
 }
@@ -139,6 +140,7 @@ pub(crate) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
     let (rest, _) = ws(rest)?;
     let mut r = rest;
     let mut parents = Vec::new();
+    let mut parent_args: Vec<(String, Vec<Expr>)> = Vec::new();
     while let Some(r2) = keyword("is", r) {
         let (r2, _) = ws1(r2)?;
         let (r2, parent_name) = qualified_ident(r2)?;
@@ -151,7 +153,13 @@ pub(crate) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
         {
             let (r2, bracket_suffix) =
                 crate::parser::stmt::class::parse_optional_bracket_suffix(r2)?;
-            parents.push(format!("{}{}", parent_name, bracket_suffix));
+            let full_name = format!("{}{}", parent_name, bracket_suffix);
+            if let Some(exprs) =
+                crate::parser::stmt::class::parse_bracket_arg_exprs(&bracket_suffix)
+            {
+                parent_args.push((full_name.clone(), exprs));
+            }
+            parents.push(full_name);
             let (r2, _) = ws(r2)?;
             r = r2;
         } else {
@@ -177,6 +185,9 @@ pub(crate) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
         let (r2, _) = ws(r2)?;
         let (r2, bracket_suffix) = crate::parser::stmt::class::parse_optional_bracket_suffix(r2)?;
         let full_name = format!("{}{}", role_name, bracket_suffix);
+        if let Some(exprs) = crate::parser::stmt::class::parse_bracket_arg_exprs(&bracket_suffix) {
+            parent_args.push((full_name.clone(), exprs));
+        }
         // The role-composition loop in `register_class_decl` walks `parents`
         // and uses `does_parents` only to tell composition from punning, so a
         // `does` role must appear in both — otherwise the grammar composes
@@ -210,6 +221,7 @@ pub(crate) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
             custom_traits: Vec::new(),
             is_unit: false,
             decl_id: crate::ast::next_class_decl_id(),
+            parent_args,
         },
     ))
 }

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -187,6 +187,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         let mut class_is_rw = false;
         let mut is_hidden = false;
         let mut hidden_parents = Vec::new();
+        let mut parent_args: Vec<(String, Vec<crate::ast::Expr>)> = Vec::new();
         let mut r = r;
         loop {
             if let Some(r2) = keyword("is", r) {
@@ -213,7 +214,12 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     // Uppercase / indirect name is a superclass (possibly
                     // parametric, e.g. `is Foo[Int]`).
                     let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
-                    parents.push(format!("{}{}", parent, bracket_suffix));
+                    let full_name = format!("{}{}", parent, bracket_suffix);
+                    if let Some(exprs) = super::class_decl::parse_bracket_arg_exprs(&bracket_suffix)
+                    {
+                        parent_args.push((full_name.clone(), exprs));
+                    }
+                    parents.push(full_name);
                     let (r2, _) = ws(r2)?;
                     r = r2;
                     continue;
@@ -267,6 +273,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     custom_traits: Vec::new(),
                     is_unit: true,
                     decl_id: crate::ast::next_class_decl_id(),
+                    parent_args,
                 },
             ),
         ));
@@ -294,7 +301,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
             r = r2;
         }
         // Optional parent/trait clauses in any order (mirrors block-form roles).
-        let mut parent_roles: Vec<String> = Vec::new();
+        let mut parent_roles: Vec<(String, Option<Vec<crate::ast::Expr>>)> = Vec::new();
         let mut is_export = false;
         let mut export_tags: Vec<String> = Vec::new();
         let mut role_is_rw = false;
@@ -306,7 +313,8 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 let (r2, _) = ws(r2)?;
                 let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
                 let (r2, _) = ws(r2)?;
-                parent_roles.push(format!("{}{}", role_name, bracket_suffix));
+                let args = super::class_decl::parse_bracket_arg_exprs(&bracket_suffix);
+                parent_roles.push((format!("{}{}", role_name, bracket_suffix), args));
                 r = r2;
                 continue;
             }
@@ -334,7 +342,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     let has_parens = r2.starts_with('(');
                     let r2 = skip_balanced_parens(r2);
                     if !has_parens && trait_name.starts_with(|c: char| c.is_ascii_uppercase()) {
-                        parent_roles.push(trait_name);
+                        parent_roles.push((trait_name, None));
                     } else {
                         custom_traits.push((trait_name, None));
                     }
@@ -347,11 +355,12 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         }
         let (r, _) = opt_char(r, ';');
         let mut body: Vec<Stmt> = Vec::new();
-        for role_name in parent_roles.into_iter().rev() {
+        for (role_name, args) in parent_roles.into_iter().rev() {
             body.insert(
                 0,
                 Stmt::DoesDecl {
                     name: Symbol::intern(&role_name),
+                    args,
                 },
             );
         }
@@ -447,6 +456,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     custom_traits: Vec::new(),
                     is_unit: true,
                     decl_id: crate::ast::next_class_decl_id(),
+                    parent_args: Vec::new(),
                 },
             ),
         ));

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -289,7 +289,7 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
         type_param_defs = tpd;
         rest = rest2;
     }
-    let mut parent_roles: Vec<String> = Vec::new();
+    let mut parent_roles: Vec<(String, Option<Vec<Expr>>)> = Vec::new();
     let mut is_hidden_role = false;
     let mut role_is_rw = false;
     let mut is_export = false;
@@ -310,7 +310,8 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
             let (r, _) = ws(r)?;
             let (r, bracket_suffix) = parse_optional_bracket_suffix(r)?;
             let (r, _) = ws(r)?;
-            parent_roles.push(format!("{}{}", role_name, bracket_suffix));
+            let args = super::class_decl::parse_bracket_arg_exprs(&bracket_suffix);
+            parent_roles.push((format!("{}{}", role_name, bracket_suffix), args));
             rest = r;
             continue;
         }
@@ -373,7 +374,7 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
                     // No parens — treat as parent role. If it's actually
                     // a custom trait, the runtime will handle it via
                     // trait_mod:<is> when the role name is not found.
-                    parent_roles.push(trait_name);
+                    parent_roles.push((trait_name, None));
                     let (r, _) = ws(r)?;
                     rest = r;
                 }
@@ -385,9 +386,9 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
             let (r, hidden_name) = qualified_ident(r)?;
             let (r, _) = ws(r)?;
             // Track as a parent relationship
-            parent_roles.push(hidden_name.clone());
+            parent_roles.push((hidden_name.clone(), None));
             // Also mark the hidden relationship with a special marker
-            parent_roles.push(format!("__mutsu_role_hides__{}", hidden_name));
+            parent_roles.push((format!("__mutsu_role_hides__{}", hidden_name), None));
             rest = r;
             continue;
         }
@@ -416,14 +417,16 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
             0,
             Stmt::DoesDecl {
                 name: Symbol::intern("__mutsu_role_hidden__"),
+                args: None,
             },
         );
     }
-    for role_name in parent_roles.into_iter().rev() {
+    for (role_name, args) in parent_roles.into_iter().rev() {
         body.insert(
             0,
             Stmt::DoesDecl {
                 name: Symbol::intern(&role_name),
+                args,
             },
         );
     }

--- a/src/parser/stmt/tests_2.rs
+++ b/src/parser/stmt/tests_2.rs
@@ -354,6 +354,63 @@ fn parse_class_decl() {
     assert!(matches!(&stmts[0], Stmt::ClassDecl { name, .. } if name == "Foo"));
 }
 
+/// ADR-0019 D4-1: a bracketed `is`/`does`/`hides` parent's content is
+/// additionally captured as parsed `Expr`s alongside the raw concatenated
+/// string, keyed by that same string.
+#[test]
+fn parse_class_decl_captures_parent_bracket_exprs() {
+    let (rest, stmts) = program("class Foo is Bar[Int, \"a,b\"] { }").unwrap();
+    assert_eq!(rest, "");
+    assert_eq!(stmts.len(), 1);
+    let Stmt::ClassDecl {
+        parents,
+        parent_args,
+        ..
+    } = &stmts[0]
+    else {
+        panic!("expected ClassDecl");
+    };
+    assert_eq!(parents, &vec!["Bar[Int, \"a,b\"]".to_string()]);
+    assert_eq!(parent_args.len(), 1);
+    let (key, exprs) = &parent_args[0];
+    assert_eq!(key, "Bar[Int, \"a,b\"]");
+    assert_eq!(exprs.len(), 2);
+}
+
+/// A bracket suffix whose content does not parse as a clean expression list
+/// (here, two expressions with no separating comma) leaves `parent_args`
+/// without an entry for that parent — the raw string in `parents` remains
+/// the sole source of truth in that case, and no other bracket-suffix
+/// caller is affected by the failed parse.
+#[test]
+fn parse_class_decl_bracket_parse_failure_leaves_parent_args_empty() {
+    let (rest, stmts) = program("class Foo is Bar[1 2] { }").unwrap();
+    assert_eq!(rest, "");
+    let Stmt::ClassDecl {
+        parents,
+        parent_args,
+        ..
+    } = &stmts[0]
+    else {
+        panic!("expected ClassDecl");
+    };
+    assert_eq!(parents, &vec!["Bar[1 2]".to_string()]);
+    assert!(parent_args.is_empty());
+}
+
+/// An empty bracket (`does R[]`) parses cleanly as a zero-length arg list.
+#[test]
+fn parse_class_decl_empty_bracket_captures_zero_args() {
+    let (rest, stmts) = program("class Foo does R[] { }").unwrap();
+    assert_eq!(rest, "");
+    let Stmt::ClassDecl { parent_args, .. } = &stmts[0] else {
+        panic!("expected ClassDecl");
+    };
+    assert_eq!(parent_args.len(), 1);
+    assert_eq!(parent_args[0].0, "R[]");
+    assert!(parent_args[0].1.is_empty());
+}
+
 #[test]
 fn parse_class_decl_with_is_rw_trait() {
     let (rest, stmts) = program("class Foo is rw { has $.x }").unwrap();

--- a/src/parser/stmt/tests_3.rs
+++ b/src/parser/stmt/tests_3.rs
@@ -214,6 +214,22 @@ fn parse_role_decl_with_generics_and_does_clause() {
     assert!(matches!(&stmts[0], Stmt::RoleDecl { name, .. } if name == "R2"));
 }
 
+/// ADR-0019 D4-1: a role body's synthetic `does Role[Args]` `DoesDecl`
+/// captures the bracket content as parsed `Expr`s in its `args` field.
+#[test]
+fn parse_role_decl_does_clause_captures_bracket_exprs() {
+    let (rest, stmts) = program("role R2 does R1[Int] { }").unwrap();
+    assert_eq!(rest, "");
+    let Stmt::RoleDecl { body, .. } = &stmts[0] else {
+        panic!("expected RoleDecl");
+    };
+    let Stmt::DoesDecl { name, args } = &body[0] else {
+        panic!("expected DoesDecl as the first body statement");
+    };
+    assert_eq!(name.as_str(), "R1[Int]");
+    assert_eq!(args.as_ref().map(Vec::len), Some(1));
+}
+
 #[test]
 fn parse_grammar_decl_with_does_clause() {
     let (rest, stmts) = program("grammar G does R { rule TOP { ^ <x> } }").unwrap();

--- a/src/runtime/registration_class_body_does.rs
+++ b/src/runtime/registration_class_body_does.rs
@@ -14,7 +14,10 @@ impl Interpreter {
         cx: &mut ClassBodyCx<'_>,
         stmt: &Stmt,
     ) -> Result<ClassBodyFlow, RuntimeError> {
-        let Stmt::DoesDecl { name: role_name } = stmt else {
+        let Stmt::DoesDecl {
+            name: role_name, ..
+        } = stmt
+        else {
             unreachable!("class_body_does_decl called on a non-DoesDecl statement");
         };
         let raw_role_name = role_name.resolve();

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -146,7 +146,10 @@ impl Interpreter {
         cx: &mut RoleDeclCx<'_>,
         stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
-        let Stmt::DoesDecl { name: role_name } = stmt else {
+        let Stmt::DoesDecl {
+            name: role_name, ..
+        } = stmt
+        else {
             unreachable!("role_body_does_decl called on a non-DoesDecl statement");
         };
         let name = cx.name;


### PR DESCRIPTION
## Summary
- `Stmt::ClassDecl` gains `parent_args: Vec<(String, Vec<Expr>)>` and `Stmt::DoesDecl` gains `args: Option<Vec<Expr>>`, populated by a new `parse_bracket_arg_exprs` helper alongside the existing raw concatenated bracket-suffix string at every `is`/`does`/`hides` call site that builds a genuine parent string (class body, `unit class`, `unit role`, grammar `is`/`does` — nine sites, two more than the design doc's original seven since grammar's own `is`/`does` loop desugars to `ClassDecl` too).
- An entry is present only when the bracket content parses cleanly as a comma-separated expression list; on any parse failure the raw string remains the sole source of truth, so nothing previously accepted is rejected. `augment class`'s bracket sites and the body-level `does R;`/`also does R;` forms stay string-only (they never parse bracket content today).
- `compiler/stmt.rs`'s `qualify_decl_name` re-keys `parent_args` through the same `qualify_parent` closure it already applies to `parents`/`does_parents`/`hidden_parents`, so a lookup by the (now package-qualified) parent string still hits.
- Purely additive: no consumer reads either new field yet — that's D4-2 (compile the exprs into chunks on the class plan) and D4-3/D7-3 (registration cutover), tracked in `todo/deep/adr0019-d4-parent-expr-chunks.md`.

## Test plan
- [x] 4 new parser unit tests (`parse_class_decl_captures_parent_bracket_exprs`, `parse_class_decl_bracket_parse_failure_leaves_parent_args_empty`, `parse_class_decl_empty_bracket_captures_zero_args`, `parse_role_decl_does_clause_captures_bracket_exprs`)
- [x] Full `cargo test --lib` (681 tests, PASS)
- [x] Full `make test` (27962 tests, PASS)
- [x] `cargo clippy -- -D warnings`, `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)