### PR TITLE
feat(compiler): lower parent/role bracket args to declaration-trait-arg chunks (ADR-0019 D4-2)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -116,7 +116,7 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 `main`; this is not a stacked-PR plan.
 
 **Current progress: 31/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
-landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, and D4-1 landed 2026-08-08). Phase C is fully checked; the open box is
+landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, and D4-2 landed 2026-08-08). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
@@ -943,6 +943,12 @@ walkers wholesale is not possible before then.
   pass) re-keys `parent_args` through the same `qualify_parent` closure it already applies to
   `parents`/`does_parents`/`hidden_parents`, so a lookup by the (now qualified) parent string
   still hits. No consumer reads either field yet (D4-2/D4-3/D7-3).
+  **D4-2 landed 2026-08-08**: `CompiledClassDeclPlan` gained `parent_arg_chunks: Vec<(String,
+  Vec<DeclTraitArg>)>`, lowered from `parent_args` with the existing `compile_decl_trait_arg`
+  helper (literal short-circuit + `Compiled` chunks, the C5 mechanism) and keyed the same way
+  after `qualify_decl_name` re-keys `parent_args` first. Covers only the class-header site per
+  the design doc; the role-body `DoesDecl` site's carriage still joins D7. No consumer reads it
+  outside a new compiler unit test yet (D4-3).
 - [ ] **D5 — Drive user HOW operations from plan ops.** Execute `new_type`, `add_method`, trait
   interception, and `compose` without entering `register_class_decl`'s AST walker.
   **Design pass done 2026-08-08 (no code landed) — the box shrinks:**

--- a/news/2026-08/adr0019-d4-2-parent-arg-chunks.md
+++ b/news/2026-08/adr0019-d4-2-parent-arg-chunks.md
@@ -1,0 +1,24 @@
+# ADR-0019 D4-2: parent/role bracket arguments lowered to declaration-trait-arg chunks
+
+D4-1 taught the parser to also capture `is Parent[Args]`/`does Role[Args]`/`hides Parent[Args]`
+bracket content as a real, parsed `Vec<Expr>` (`Stmt::ClassDecl::parent_args`), riding alongside
+the unchanged concatenated-string parent name. D4-2 lowers those expressions at compile time
+instead of leaving them as raw AST for a future registration-time walk.
+
+`CompiledClassDeclPlan` gains `parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>`, keyed by the
+same full concatenated parent string `parents`/`does_parents`/`hidden_parents` already use as a
+registry lookup key. Each argument is compiled with the existing `compile_decl_trait_arg` helper
+(the C5 mechanism also used for custom-trait arguments): a literal argument (`R[42]`) stays a
+`DeclTraitArg::Literal` with no chunk at all, and everything else becomes a `DeclTraitArg::Compiled`
+re-entrant bytecode chunk. `compiler/stmt.rs`'s `qualify_decl_name` package-qualification pass
+already re-keys `parent_args` before `add_class_decl_plan` runs, so `parent_arg_chunks`'s keys are
+consistent with the (possibly package-qualified) parent strings for free.
+
+The role-body `does` site (`Stmt::DoesDecl::args`) has no plan carriage yet by design — its typed
+encoding belongs to D7's role-structure plan ops, so D4-2 covers only the class header, per the
+design doc's scoping.
+
+No consumer reads `parent_arg_chunks` outside a new compiler unit test yet — that is D4-3
+(registration cutover: `resolve_role_candidate` gains a `pre_args: Option<&[Value]>` fast path
+that evaluates these chunks instead of re-parsing the concatenated string through
+`eval_role_arg_values`).

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -109,6 +109,7 @@ impl Compiler {
             name_expr,
             custom_traits,
             body,
+            parent_args,
             ..
         } = stmt
         else {
@@ -118,8 +119,36 @@ impl Compiler {
         let trait_args = self.compile_decl_trait_args(custom_traits);
         let attr_decls = self.compile_class_attr_decls(body);
         let method_name_chunks = self.compile_method_name_chunks(body);
-        self.code
-            .add_class_decl_plan(stmt, name_chunk, trait_args, attr_decls, method_name_chunks)
+        let parent_arg_chunks = self.compile_parent_arg_chunks(parent_args);
+        self.code.add_class_decl_plan(
+            stmt,
+            name_chunk,
+            trait_args,
+            attr_decls,
+            method_name_chunks,
+            parent_arg_chunks,
+        )
+    }
+
+    /// Lower each parent/role bracket argument list to declaration-trait-arg
+    /// chunks (ADR-0019 D4-2), keyed by the same concatenated parent string
+    /// `parents`/`does_parents`/`hidden_parents` already use as a registry
+    /// lookup key. No consumer reads this yet (D4-3).
+    fn compile_parent_arg_chunks(
+        &self,
+        parent_args: &[(String, Vec<Expr>)],
+    ) -> Vec<(String, Vec<crate::opcode::DeclTraitArg>)> {
+        parent_args
+            .iter()
+            .map(|(key, args)| {
+                (
+                    key.clone(),
+                    args.iter()
+                        .map(|e| self.compile_decl_trait_arg(e))
+                        .collect(),
+                )
+            })
+            .collect()
     }
 
     /// Precompile a full `CompiledAttrDecl` for each attribute a class body

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -234,6 +234,53 @@ mod declaration_plan_tests {
         assert_eq!(names, vec!["x", "y"]);
     }
 
+    /// ADR-0019 D4-2: a bracketed `is`/`does` parent whose bracket content
+    /// parsed as a clean expression list (D4-1) is precompiled into a
+    /// declaration-trait-arg chunk per argument, keyed by the same
+    /// concatenated parent string `parents`/`does_parents` use. A literal
+    /// argument stays a `Literal` with no chunk; a non-literal argument
+    /// (here, a variable reference) compiles to a `Compiled` chunk.
+    #[test]
+    fn class_declarations_precompute_parent_arg_chunks() {
+        let (stmts, _) =
+            crate::parse_dispatch::parse_source("class A is Bar[Int, $x] does Baz[42] { }")
+                .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_a = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "A")
+            .expect("class A declaration plan");
+        let mut keys: Vec<_> = plan_a
+            .parent_arg_chunks
+            .iter()
+            .map(|(key, _)| key.as_str())
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec!["Bar[Int, $x]", "Baz[42]"]);
+
+        let (_, bar_args) = plan_a
+            .parent_arg_chunks
+            .iter()
+            .find(|(key, _)| key == "Bar[Int, $x]")
+            .expect("Bar[Int, $x] chunk entry");
+        assert_eq!(bar_args.len(), 2);
+        assert!(matches!(
+            bar_args[1],
+            crate::opcode::DeclTraitArg::Compiled(_)
+        ));
+
+        let (_, baz_args) = plan_a
+            .parent_arg_chunks
+            .iter()
+            .find(|(key, _)| key == "Baz[42]")
+            .expect("Baz[42] chunk entry");
+        assert_eq!(baz_args.len(), 1);
+        let literal = baz_args[0].literal().expect("Baz[42] arg is a literal");
+        assert!(matches!(literal.view(), crate::value::ValueView::Int(42)));
+    }
+
     /// ADR-0019 D2a: a class declaration's own attribute names — including
     /// ones nested inside a body `sub`, and excluding class-level `our`/`my`
     /// attributes — are precomputed at plan lowering, so `run_class_body`

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2746,6 +2746,15 @@ pub(crate) struct CompiledClassDeclPlan {
     /// `persist_class_body_statics` re-walking the raw body on every
     /// registration to decide which lexicals are body statics.
     pub(crate) declared_static_names: Vec<Symbol>,
+    /// Precompiled argument chunks for each bracketed `is Parent[Args]`/
+    /// `does Role[Args]`/`hides Parent[Args]` parent (ADR-0019 D4-2), keyed
+    /// by the same concatenated parent string that `parents`/`does_parents`/
+    /// `hidden_parents` use as a registry lookup key. Only entries whose
+    /// bracket content parsed as a clean expression list (D4-1) appear here;
+    /// no consumer reads this yet outside tests (D4-3 wires it into
+    /// role-candidate resolution).
+    #[allow(dead_code)]
+    pub(crate) parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>,
 }
 
 #[derive(Debug, Clone)]
@@ -5971,6 +5980,7 @@ impl CompiledCode {
         trait_args: Vec<Option<DeclTraitArg>>,
         attr_decls: Vec<(Symbol, CompiledAttrDecl)>,
         method_name_chunks: Vec<Option<CompiledDeclExpr>>,
+        parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>,
     ) -> u32 {
         let Stmt::ClassDecl {
             name,
@@ -6026,6 +6036,7 @@ impl CompiledCode {
             method_name_chunks,
             method_decls,
             declared_static_names,
+            parent_arg_chunks,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Class(plan_idx));

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -142,6 +142,7 @@ impl Interpreter {
             method_name_chunks,
             method_decls,
             declared_static_names,
+            parent_arg_chunks: _,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {


### PR DESCRIPTION
## Summary
- `CompiledClassDeclPlan` gains `parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>`, lowered
  from D4-1's `Stmt::ClassDecl::parent_args` via the existing `compile_decl_trait_arg` helper
  (literal short-circuit + `Compiled` bytecode chunks — the same C5 mechanism used for custom
  trait arguments), keyed by the same concatenated parent string `parents`/`does_parents`/
  `hidden_parents` already use as a registry lookup key.
- `compiler/stmt.rs`'s `qualify_decl_name` package-qualification pass already re-keys
  `parent_args` before `add_class_decl_plan` runs, so `parent_arg_chunks`'s keys stay consistent
  with the (possibly package-qualified) parent strings for free.
- Covers only the class-header site per the design doc (`todo/deep/adr0019-d4-parent-expr-chunks.md`);
  the role-body `DoesDecl` site's carriage joins D7's role-structure plan ops instead of a
  throwaway field.
- Purely additive: no consumer reads the field outside a new compiler unit test yet — that is
  D4-3 (registration cutover: `resolve_role_candidate` gains a `pre_args: Option<&[Value]>` fast
  path).

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
- [x] new unit test `class_declarations_precompute_parent_arg_chunks`
- [x] `cargo test --lib` (682 passed)
- [x] `make test` (2968 files / 27972 tests, PASS)
- [x] `roast/S14-roles/parameterized-*.t` + `parameter-subtyping.t` (113 tests, PASS)
- [ ] CI: `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)