### PR TITLE
feat(runtime): resolve role candidates from precompiled argument chunks (ADR-0019 D4-3)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -116,7 +116,7 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 `main`; this is not a stacked-PR plan.
 
 **Current progress: 31/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
-landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, and D4-2 landed 2026-08-08). Phase C is fully checked; the open box is
+landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, and D4-3 landed 2026-08-08). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
@@ -949,6 +949,33 @@ walkers wholesale is not possible before then.
   after `qualify_decl_name` re-keys `parent_args` first. Covers only the class-header site per
   the design doc; the role-body `DoesDecl` site's carriage still joins D7. No consumer reads it
   outside a new compiler unit test yet (D4-3).
+  **D4-3 landed 2026-08-08**: `resolve_role_candidate` gained a `resolve_role_candidate_with_args`
+  sibling taking `pre_args: Option<&[Value]>`; when set, it replaces the `eval_role_arg_values`
+  re-parse with the already-evaluated values, everything downstream (arity filter, trial bind,
+  specificity sort) unchanged. `compose_class_parent_roles` evaluates each parent's
+  `parent_arg_chunks` (looked up by the plan's *original*, pre-remap parent string — position-
+  aligned with `parents` through the `lexical_env_remap_name`/`qualify_sibling_parent_name`/
+  Grammar-self-parent-drop chain via a zipped `Vec<Option<&[DeclTraitArg]>>`, since none of those
+  remaps filter except the Grammar case, which the zip drops in lockstep) and passes the result;
+  the four string-only callers (`registration_role_body.rs` ×2, `registration_class_augment.rs`,
+  `methods_qualified.rs`) are unaffected. Verified against an 8-case `raku` table (literal, type
+  name, nested parameterization, enum value, comma-containing string, block literal) — all match
+  byte-for-byte, and the `Expr` path incidentally fixes a real `R["a,b"]`-comma-in-string parse
+  failure the old string path had (per the D4 design doc's prediction). A `make roast`
+  regression surfaced during verification (`S14-roles/parameterized-type.t`) traced to an
+  unrelated, real parser bug the D4-3 cutover exposed rather than caused: `parse_optional_bracket_suffix`
+  returned an owned `String` copy of the bracket content, and two sibling `does R[X] does R[Y]`
+  clauses on one class header each allocate their own short-lived copy — when the first is freed
+  at loop-iteration end, the second can land at the same heap address, aliasing the pointer-keyed
+  expression parse memo (`(ptr, len)`, no content check) and returning the first clause's cached
+  `Expr` for the second's distinct bracket content. Fixed at the root: `parse_optional_bracket_suffix`
+  now returns a slice of the persistent source buffer (never freed mid-parse) instead of an owned
+  copy — the memo can no longer alias it, by construction. Pinned by a Rust unit test
+  (`parse_class_decl_two_does_clauses_capture_distinct_bracket_exprs`) and a `t/` integration test
+  (`role-double-parametric-args-distinct.t`). A second, independent, pre-existing bug surfaced
+  during root-causing (present on `main` before D4-3 too: composing the same parametric role
+  twice, multi dispatch always picks one candidate regardless of the call's argument type) is
+  out of scope and filed as `todo/tickets/same-role-composed-twice-multi-dispatch-picks-one-candidate.md`.
 - [ ] **D5 — Drive user HOW operations from plan ops.** Execute `new_type`, `add_method`, trait
   interception, and `compose` without entering `register_class_decl`'s AST walker.
   **Design pass done 2026-08-08 (no code landed) — the box shrinks:**

--- a/news/2026-08/adr0019-d4-3-role-candidate-value-cutover.md
+++ b/news/2026-08/adr0019-d4-3-role-candidate-value-cutover.md
@@ -1,0 +1,44 @@
+# ADR-0019 D4-3: role-candidate resolution consumes precompiled argument values
+
+D4-1 captured `is Parent[Args]`/`does Role[Args]`/`hides Parent[Args]` bracket content as parsed
+`Expr`s; D4-2 lowered those into `CompiledClassDeclPlan::parent_arg_chunks`. D4-3 wires the class-
+header composition site to actually use them: `resolve_role_candidate` gained a
+`resolve_role_candidate_with_args` sibling taking `pre_args: Option<&[Value]>`, and when set, it
+replaces `eval_role_arg_values`'s per-argument, per-registration re-parse-and-tree-walk of the
+concatenated parent string with the already-evaluated values — everything downstream (arity
+filter, trial bind, specificity sort) is unchanged. `compose_class_parent_roles` evaluates each
+parent's chunk (looked up by the plan's original, pre-remap parent string, kept position-aligned
+with the lexical/sibling remap chain through a zipped `Vec<Option<&[DeclTraitArg]>>`) and passes
+the resulting values in.
+
+Verified against an 8-case `raku` comparison table (literal, type name, nested parameterization,
+enum value, comma-containing string, block literal) — every case matches byte-for-byte. The `Expr`
+path also fixes a real, independent bug for free: `R["a,b"]` used to fail to parse at all through
+the old string path's quote-blind comma splitter.
+
+## A parser bug this cutover exposed (and fixed)
+
+Verification surfaced a `make roast` regression in `S14-roles/parameterized-type.t`
+("correct multi selected from multiple parametric roles" — `class A does R[Str] does R[Int]`).
+Root cause: `parse_optional_bracket_suffix` returned an owned `String` copy of the bracket
+content. Two sibling `does R[X] does R[Y]` clauses on one class header each allocate their own
+short-lived copy; when the first is freed at the end of its loop iteration, the second's
+allocation can land at the exact same heap address — aliasing the parser's pointer-keyed
+expression memo (keyed by `(ptr, len)` with no content check) and silently returning the first
+clause's cached `Expr` for the second clause's genuinely different bracket content. This bug
+predates D4-3 (it lived in D4-1's new `parse_bracket_arg_exprs` call site from the start) but had
+no consumer to observe it until D4-3 made `parent_arg_chunks` load-bearing.
+
+Fixed at the root, not at the call site: `parse_optional_bracket_suffix` now returns a slice of
+the *persistent* source buffer (never freed mid-parse) instead of an owned copy, so the memo can
+never alias two sibling bracket clauses by construction. Pinned by a Rust unit test
+(`parse_class_decl_two_does_clauses_capture_distinct_bracket_exprs`) and a `t/` integration test
+(`role-double-parametric-args-distinct.t`).
+
+## A second, unrelated bug found (and filed, not fixed)
+
+Root-causing the above surfaced a second, independent, pre-existing bug — present on `main` before
+D4-3 too, so out of scope here: composing the same parametric role twice on one class header with
+different type arguments composes both multi candidates correctly, but dispatch always resolves
+to whichever one wins some unidentified tiebreak, regardless of the call's actual argument type.
+Filed as `todo/tickets/same-role-composed-twice-multi-dispatch-picks-one-candidate.md`.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2751,9 +2751,8 @@ pub(crate) struct CompiledClassDeclPlan {
     /// by the same concatenated parent string that `parents`/`does_parents`/
     /// `hidden_parents` use as a registry lookup key. Only entries whose
     /// bracket content parsed as a clean expression list (D4-1) appear here;
-    /// no consumer reads this yet outside tests (D4-3 wires it into
-    /// role-candidate resolution).
-    #[allow(dead_code)]
+    /// Evaluated at composition time (ADR-0019 D4-3) instead of
+    /// `resolve_role_candidate` re-parsing the concatenated parent string.
     pub(crate) parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>,
 }
 

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -57,9 +57,20 @@ pub(crate) fn parse_declarator_traits(input: &str) -> PResult<'_, Vec<(String, E
     Ok((rest, traits))
 }
 
-pub(crate) fn parse_optional_bracket_suffix(input: &str) -> PResult<'_, String> {
+/// Returns a slice of the ORIGINAL persistent source buffer, not a copy —
+/// deliberately, so that [`parse_bracket_arg_exprs`] can parse it through the
+/// pointer-keyed expression memo (`parser::memo::ParseMemo`, keyed by
+/// `(input.as_ptr(), input.len())` with no content check) without risking a
+/// stale cache hit. A freshly allocated, short-lived `String` copy is freed
+/// once its caller's scope ends; a *later* temporary allocation of the same
+/// size can land at the exact same address (observed with two sibling `does
+/// R[Int] does R[Str]` clauses on one class header, where the second bracket
+/// content's memo lookup returned the first's cached `Expr` — a real,
+/// reproducible bug, not a hypothetical one). A slice of the persistent
+/// source has no such lifetime, so its address is never reused mid-parse.
+pub(crate) fn parse_optional_bracket_suffix(input: &str) -> PResult<'_, &str> {
     if !input.starts_with('[') {
-        return Ok((input, String::new()));
+        return Ok((input, ""));
     }
     let mut depth = 0u32;
     let mut end = None;
@@ -75,7 +86,7 @@ pub(crate) fn parse_optional_bracket_suffix(input: &str) -> PResult<'_, String> 
         }
     }
     let end = end.ok_or_else(|| PError::expected("closing ']'"))?;
-    Ok((&input[end..], input[..end].to_string()))
+    Ok((&input[end..], &input[..end]))
 }
 
 /// Attempt to parse the inside of an `is`/`does`/`hides` bracket suffix
@@ -449,7 +460,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             {
                 let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
                 let full_name = format!("{}{}", parent, bracket_suffix);
-                if let Some(exprs) = parse_bracket_arg_exprs(&bracket_suffix) {
+                if let Some(exprs) = parse_bracket_arg_exprs(bracket_suffix) {
                     parent_args.push((full_name.clone(), exprs));
                 }
                 parents.push(full_name);
@@ -496,7 +507,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
                 }
                 let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
                 let full_name = format!("{}{}", parent, bracket_suffix);
-                if let Some(exprs) = parse_bracket_arg_exprs(&bracket_suffix) {
+                if let Some(exprs) = parse_bracket_arg_exprs(bracket_suffix) {
                     parent_args.push((full_name.clone(), exprs));
                 }
                 parents.push(full_name);
@@ -515,7 +526,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             let (r2, _) = ws(r2)?;
             let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
             let full_name = format!("{}{}", role_name, bracket_suffix);
-            if let Some(exprs) = parse_bracket_arg_exprs(&bracket_suffix) {
+            if let Some(exprs) = parse_bracket_arg_exprs(bracket_suffix) {
                 parent_args.push((full_name.clone(), exprs));
             }
             parents.push(full_name.clone());
@@ -530,7 +541,7 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             let (r2, _) = ws(r2)?;
             let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
             let hidden_parent = format!("{}{}", parent, bracket_suffix);
-            if let Some(exprs) = parse_bracket_arg_exprs(&bracket_suffix) {
+            if let Some(exprs) = parse_bracket_arg_exprs(bracket_suffix) {
                 parent_args.push((hidden_parent.clone(), exprs));
             }
             parents.push(hidden_parent.clone());

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -154,8 +154,7 @@ pub(crate) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
             let (r2, bracket_suffix) =
                 crate::parser::stmt::class::parse_optional_bracket_suffix(r2)?;
             let full_name = format!("{}{}", parent_name, bracket_suffix);
-            if let Some(exprs) =
-                crate::parser::stmt::class::parse_bracket_arg_exprs(&bracket_suffix)
+            if let Some(exprs) = crate::parser::stmt::class::parse_bracket_arg_exprs(bracket_suffix)
             {
                 parent_args.push((full_name.clone(), exprs));
             }
@@ -185,7 +184,7 @@ pub(crate) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
         let (r2, _) = ws(r2)?;
         let (r2, bracket_suffix) = crate::parser::stmt::class::parse_optional_bracket_suffix(r2)?;
         let full_name = format!("{}{}", role_name, bracket_suffix);
-        if let Some(exprs) = crate::parser::stmt::class::parse_bracket_arg_exprs(&bracket_suffix) {
+        if let Some(exprs) = crate::parser::stmt::class::parse_bracket_arg_exprs(bracket_suffix) {
             parent_args.push((full_name.clone(), exprs));
         }
         // The role-composition loop in `register_class_decl` walks `parents`

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -215,7 +215,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     // parametric, e.g. `is Foo[Int]`).
                     let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
                     let full_name = format!("{}{}", parent, bracket_suffix);
-                    if let Some(exprs) = super::class_decl::parse_bracket_arg_exprs(&bracket_suffix)
+                    if let Some(exprs) = super::class_decl::parse_bracket_arg_exprs(bracket_suffix)
                     {
                         parent_args.push((full_name.clone(), exprs));
                     }
@@ -313,7 +313,7 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 let (r2, _) = ws(r2)?;
                 let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
                 let (r2, _) = ws(r2)?;
-                let args = super::class_decl::parse_bracket_arg_exprs(&bracket_suffix);
+                let args = super::class_decl::parse_bracket_arg_exprs(bracket_suffix);
                 parent_roles.push((format!("{}{}", role_name, bracket_suffix), args));
                 r = r2;
                 continue;

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -310,7 +310,7 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
             let (r, _) = ws(r)?;
             let (r, bracket_suffix) = parse_optional_bracket_suffix(r)?;
             let (r, _) = ws(r)?;
-            let args = super::class_decl::parse_bracket_arg_exprs(&bracket_suffix);
+            let args = super::class_decl::parse_bracket_arg_exprs(bracket_suffix);
             parent_roles.push((format!("{}{}", role_name, bracket_suffix), args));
             rest = r;
             continue;

--- a/src/parser/stmt/tests_2.rs
+++ b/src/parser/stmt/tests_2.rs
@@ -411,6 +411,40 @@ fn parse_class_decl_empty_bracket_captures_zero_args() {
     assert!(parent_args[0].1.is_empty());
 }
 
+/// Regression test (ADR-0019 D4-3): `parse_optional_bracket_suffix` used to
+/// return an owned `String` copy of the bracket content. Two sibling `does`
+/// clauses on one class header each allocate their own short-lived
+/// `bracket_suffix` string; when the first is freed at the end of its loop
+/// iteration, the second's allocation can land at the exact same address —
+/// and the pointer-keyed expression parse memo (`(ptr, len)`, no content
+/// check) then returns the FIRST clause's cached `Expr` for the SECOND
+/// clause's genuinely different bracket content. `parse_optional_bracket_suffix`
+/// now returns a slice of the persistent source instead, which the memo can
+/// never alias. Runs the body twice (`MUTSU_PARSE_MEMO` defaults on) so a
+/// regression reproduces deterministically rather than depending on
+/// allocator behavior across a single run.
+#[test]
+fn parse_class_decl_two_does_clauses_capture_distinct_bracket_exprs() {
+    for _ in 0..2 {
+        let (rest, stmts) = program("class Foo does R[Int] does R[Str] { }").unwrap();
+        assert_eq!(rest, "");
+        let Stmt::ClassDecl { parent_args, .. } = &stmts[0] else {
+            panic!("expected ClassDecl");
+        };
+        assert_eq!(parent_args.len(), 2);
+        assert_eq!(parent_args[0].0, "R[Int]");
+        assert_eq!(parent_args[1].0, "R[Str]");
+        assert!(matches!(
+            &parent_args[0].1[..],
+            [Expr::BareWord(name)] if name == "Int"
+        ));
+        assert!(matches!(
+            &parent_args[1].1[..],
+            [Expr::BareWord(name)] if name == "Str"
+        ));
+    }
+}
+
 #[test]
 fn parse_class_decl_with_is_rw_trait() {
     let (rest, stmts) = program("class Foo is rw { has $.x }").unwrap();

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -225,6 +225,18 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// registration time. Empty for registration paths with no compiled plan
     /// available (role-pun/mixin synthesis, `augment class`).
     pub(crate) declared_static_names: &'a [Symbol],
+    /// Precompiled declaration-trait-arg chunks for each `is`/`does`/`hides`
+    /// parent's bracket arguments (ADR-0019 D4-2/D4-3), position-aligned
+    /// with the `parents` argument to `register_class_decl` (looked up by
+    /// the plan's original parent string before any lexical/sibling
+    /// remapping, then carried through the same filter that can drop a
+    /// parent — see the call site). `None` at a position means either the
+    /// parent had no bracket arguments or its bracket content did not parse
+    /// as a clean expression list (D4-1) — `compose_class_parent_roles`
+    /// falls back to re-parsing the concatenated parent string in both
+    /// cases. Empty for registration paths with no compiled plan available
+    /// (role-pun/mixin synthesis, `augment class`).
+    pub(crate) parent_pre_args: &'a [Option<&'a [crate::opcode::DeclTraitArg]>],
 }
 
 pub(super) fn parse_role_type_args(input: &str) -> Vec<String> {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1031,6 +1031,7 @@ impl Interpreter {
             method_name_chunks: &[],
             method_decls: &[],
             declared_static_names: &[],
+            parent_pre_args: &[],
         };
         self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
         self.store_language_revision_from_version(&pun_name, &language_version);

--- a/src/runtime/registration_class_compose.rs
+++ b/src/runtime/registration_class_compose.rs
@@ -4,7 +4,8 @@
 //! `registration_class_decl.rs` — no behavior change.
 
 use super::registration_class::{
-    ResolvedRoleCandidate, substitute_type_params_in_method, type_value_name,
+    ResolvedRoleCandidate, parse_role_type_args, should_treat_role_arg_as_type_expr,
+    substitute_type_params_in_method, type_value_name,
 };
 use super::registration_class_decl::BUILTIN_PARENT_TYPES;
 use super::*;
@@ -89,15 +90,39 @@ impl Interpreter {
             // Evaluate this parent's precompiled bracket-argument chunks
             // (ADR-0019 D4-3), if any, instead of leaving candidate
             // resolution to re-parse the concatenated parent string.
-            let pre_args = match parent_pre_args.get(i).copied().flatten() {
-                Some(chunks) => {
-                    let mut values = Vec::with_capacity(chunks.len());
-                    for chunk in chunks {
-                        values.push(self.eval_decl_trait_arg(chunk)?);
+            //
+            // A coercion-type argument (`R[Str:D(Numeric)]`) parses cleanly
+            // as an `Expr` (D4-1) — `Str:D(Numeric)` is syntactically a call
+            // — but it must NOT be evaluated as one: `eval_role_arg_values`'s
+            // `should_treat_role_arg_as_type_expr` heuristic exists
+            // precisely to turn this shape into a `Package` marker instead
+            // of calling it, and the value path has no equivalent. Reuse
+            // that same classification here as a bail-out: if any raw
+            // argument in this parent's bracket would trigger it, skip the
+            // chunk path for the WHOLE application and fall back to the
+            // string path, which already handles it correctly.
+            let has_type_expr_arg = resolved_parent_name
+                .find('[')
+                .map(|start| {
+                    let args_str = &resolved_parent_name[start + 1..resolved_parent_name.len() - 1];
+                    parse_role_type_args(args_str)
+                        .iter()
+                        .any(|a| should_treat_role_arg_as_type_expr(a))
+                })
+                .unwrap_or(false);
+            let pre_args = if has_type_expr_arg {
+                None
+            } else {
+                match parent_pre_args.get(i).copied().flatten() {
+                    Some(chunks) => {
+                        let mut values = Vec::with_capacity(chunks.len());
+                        for chunk in chunks {
+                            values.push(self.eval_decl_trait_arg(chunk)?);
+                        }
+                        Some(values)
                     }
-                    Some(values)
+                    None => None,
                 }
-                None => None,
             };
             if let Some(resolved) =
                 self.resolve_role_candidate_with_args(&resolved_parent_name, pre_args.as_deref())?

--- a/src/runtime/registration_class_compose.rs
+++ b/src/runtime/registration_class_compose.rs
@@ -77,15 +77,31 @@ impl Interpreter {
         cx: &mut RoleCompositionCx<'_>,
         parents: &[String],
         does_parents: &[String],
+        parent_pre_args: &[Option<&[crate::opcode::DeclTraitArg]>],
     ) -> Result<(), RuntimeError> {
         const BUILTIN_TYPES: &[&str] = BUILTIN_PARENT_TYPES;
-        for parent in parents {
+        for (i, parent) in parents.iter().enumerate() {
             let resolved_parent_name = self.resolve_declared_type_name(parent);
             let base_role_name = resolved_parent_name
                 .split_once('[')
                 .map(|(b, _)| b)
                 .unwrap_or(resolved_parent_name.as_str());
-            if let Some(resolved) = self.resolve_role_candidate(&resolved_parent_name)? {
+            // Evaluate this parent's precompiled bracket-argument chunks
+            // (ADR-0019 D4-3), if any, instead of leaving candidate
+            // resolution to re-parse the concatenated parent string.
+            let pre_args = match parent_pre_args.get(i).copied().flatten() {
+                Some(chunks) => {
+                    let mut values = Vec::with_capacity(chunks.len());
+                    for chunk in chunks {
+                        values.push(self.eval_decl_trait_arg(chunk)?);
+                    }
+                    Some(values)
+                }
+                None => None,
+            };
+            if let Some(resolved) =
+                self.resolve_role_candidate_with_args(&resolved_parent_name, pre_args.as_deref())?
+            {
                 // Check if this role was specified via `is` (punning) vs `does` (composition)
                 let is_punned = !does_parents.contains(parent);
                 self.compose_role_into_class(

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -130,6 +130,7 @@ impl Interpreter {
             method_name_chunks,
             method_decls,
             declared_static_names,
+            parent_pre_args,
         } = modifiers;
         let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
@@ -192,7 +193,7 @@ impl Interpreter {
                 class_def: &mut class_def,
                 out: RoleCompositionOutcome::default(),
             };
-            self.compose_class_parent_roles(&mut cx, parents, does_parents)?;
+            self.compose_class_parent_roles(&mut cx, parents, does_parents, parent_pre_args)?;
             cx.out
         };
         if class_role_param_bindings.is_empty() {

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -135,6 +135,21 @@ impl Interpreter {
         &mut self,
         parent: &str,
     ) -> Result<Option<ResolvedRoleCandidate>, RuntimeError> {
+        self.resolve_role_candidate_with_args(parent, None)
+    }
+
+    /// [`Self::resolve_role_candidate`], but with the bracket arguments
+    /// already evaluated (ADR-0019 D4-3) instead of re-parsing them out of
+    /// the concatenated `parent` string. `pre_args` is `None` for every
+    /// call site that has no precompiled chunk for this parent — a
+    /// computed/dynamic role application (`resolve_role_candidate`'s
+    /// existing callers), or a bracket whose content did not parse as a
+    /// clean expression list (D4-1) — and behaves exactly as before.
+    pub(crate) fn resolve_role_candidate_with_args(
+        &mut self,
+        parent: &str,
+        pre_args: Option<&[Value]>,
+    ) -> Result<Option<ResolvedRoleCandidate>, RuntimeError> {
         let parent = self.resolve_declared_type_name(parent);
         if let Some(bracket_start) = parent.find('[') {
             let args_str = &parent[bracket_start + 1..parent.len() - 1];
@@ -164,13 +179,17 @@ impl Interpreter {
             return Ok(None);
         };
 
-        let arg_exprs = if let Some(bracket_start) = parent.find('[') {
-            let args_str = &parent[bracket_start + 1..parent.len() - 1];
-            parse_role_type_args(args_str)
+        let arg_values = if let Some(pre_args) = pre_args {
+            pre_args.to_vec()
         } else {
-            Vec::new()
+            let arg_exprs = if let Some(bracket_start) = parent.find('[') {
+                let args_str = &parent[bracket_start + 1..parent.len() - 1];
+                parse_role_type_args(args_str)
+            } else {
+                Vec::new()
+            };
+            self.eval_role_arg_values(&arg_exprs)?
         };
-        let arg_values = self.eval_role_arg_values(&arg_exprs)?;
 
         let mut matches: Vec<(RoleCandidateDef, i32, usize)> = candidates
             .into_iter()

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -69,6 +69,7 @@ impl Interpreter {
             method_name_chunks: &[],
             method_decls: &[],
             declared_static_names: &[],
+            parent_pre_args: &[],
         };
         self.register_class_decl(&name, &parents, modifiers, &[])?;
         self.compose_mixin_role_submethods(&name, &fresh);

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -142,7 +142,7 @@ impl Interpreter {
             method_name_chunks,
             method_decls,
             declared_static_names,
-            parent_arg_chunks: _,
+            parent_arg_chunks,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {
@@ -211,16 +211,32 @@ impl Interpreter {
             // name (see `storage_name` above). Resolve each parent through the
             // current lexical env so `is C0` binds to the C0 visible in *this*
             // scope, not a same-named class from an unrelated earlier scope.
-            let mapped_parents: Vec<String> = parents
+            // Look up each parent's precompiled bracket-argument chunks
+            // (ADR-0019 D4-3) by its ORIGINAL, pre-remap plan string — the
+            // same key `parent_arg_chunks` was built from — before any of
+            // the lexical/sibling remapping below can change it. Zipped
+            // alongside the remap chain (rather than looked up again after)
+            // so the same filter that can drop the auto-added `Grammar`
+            // self-parent keeps both lists index-aligned.
+            let (mapped_parents, parent_pre_args): (
+                Vec<String>,
+                Vec<Option<&[crate::opcode::DeclTraitArg]>>,
+            ) = parents
                 .iter()
-                .map(|p| self.lexical_env_remap_name(p))
+                .map(|p| {
+                    let pre_args = parent_arg_chunks
+                        .iter()
+                        .find(|(key, _)| key == p)
+                        .map(|(_, args)| args.as_slice());
+                    (self.lexical_env_remap_name(p), pre_args)
+                })
                 // Qualify a bare parent that names a sibling class in the current
                 // package but collides with a built-in namespace (`class X::Decode
                 // is X` inside `module M`, where `X` is both `M::X` and the built-in
                 // `X::` exception namespace). Must run here, where `current_package`
                 // is the enclosing module — the child class name reaches
                 // `register_class_decl` without its module prefix.
-                .map(|p| self.qualify_sibling_parent_name(&p))
+                .map(|(p, pre_args)| (self.qualify_sibling_parent_name(&p), pre_args))
                 // Drop the auto-added `Grammar` default parent from a genuine
                 // top-level `grammar Grammar` (qualified name exactly `Grammar`,
                 // which would otherwise list itself as its own parent and loop the
@@ -229,8 +245,8 @@ impl Interpreter {
                 // itself and is kept — that is how the parser can unconditionally
                 // add the `Grammar` default parent. An EXPLICIT `class Foo is Foo`
                 // is left intact so it still raises the self-inheritance error.
-                .filter(|p| !(p == "Grammar" && qualified_name == "Grammar"))
-                .collect();
+                .filter(|(p, _)| !(p == "Grammar" && qualified_name == "Grammar"))
+                .unzip();
             let mapped_hidden_parents: Vec<String> = hidden_parents
                 .iter()
                 .map(|p| self.lexical_env_remap_name(p))
@@ -259,6 +275,7 @@ impl Interpreter {
                         method_name_chunks,
                         method_decls,
                         declared_static_names,
+                        parent_pre_args: &parent_pre_args,
                     },
                     body,
                 )

--- a/t/role-double-parametric-args-distinct.t
+++ b/t/role-double-parametric-args-distinct.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+plan 8;
+
+# ADR-0019 D4-3 regression: composing the same role twice on one class
+# header, each with a different bracket argument, must resolve each
+# application's own argument — not silently reuse the sibling clause's
+# value. (Root cause was a parser packrat-memo aliasing bug between two
+# short-lived bracket-content buffers; see the Rust unit test
+# parse_class_decl_two_does_clauses_capture_distinct_bracket_exprs in
+# src/parser/stmt/tests_2.rs for the parser-level pin.)
+role Holds[::T] { }
+class Both does Holds[Int] does Holds[Str] { }
+my @names = Both.^roles(:!transitive).map(*.^name).sort;
+is @names.elems, 2, 'both parametric applications composed';
+is-deeply @names.Set, ('Holds[Int]', 'Holds[Str]').Set,
+    'each application kept its own type argument';
+
+# Non-bareword argument kinds also resolve independently per application.
+role Tag[$x] { }
+class Tagged does Tag[42] does Tag["a,b"] { }
+my @tags = Tagged.^roles(:!transitive).map(*.^name).sort;
+is @tags.elems, 2, 'literal-argument applications both composed';
+
+# Plain single-application cases (already covered by earlier D4 slices,
+# re-asserted here alongside the double-application cases above).
+role R1[$x] { method v() { $x } }
+class C1 does R1[42] { }
+is C1.new.v, 42, 'single literal role application';
+
+role R2[::T] { method v() { T.^name } }
+class C2 does R2[Int] { }
+is C2.new.v, 'Int', 'single type-name role application';
+
+enum Kind <A B>;
+role R3[$x] { method v() { $x } }
+class C3 does R3[Kind::A] { }
+is C3.new.v, A, 'enum-value role application';
+
+role R4[$x] { method v() { $x } }
+class C4 does R4["a,b"] { }
+is C4.new.v, 'a,b', 'comma-containing string role argument';
+
+role R5[&f] { method v() { f(3) } }
+class C5 does R5[{ $_ * 2 }] { }
+is C5.new.v, 6, 'block-literal role argument';

--- a/todo/tickets/same-role-composed-twice-multi-dispatch-picks-one-candidate.md
+++ b/todo/tickets/same-role-composed-twice-multi-dispatch-picks-one-candidate.md
@@ -1,0 +1,40 @@
+# Composing the same parametric role twice with different type args loses multi dispatch by argument type
+
+`class A does R[Int] does R[Str]` where `role R[::T] { multi method foo(T $t) {...} }`
+correctly composes BOTH multi candidates into `A` (confirmed via `.^methods(:local)` and via the
+roast test `S14-roles/parameterized-type.t`'s "correct multi selected from multiple parametric
+roles" subtest, which only exercises the `Int` call and passes). But calling `.foo` with an
+argument that should select the *other* candidate dispatches to the wrong one — reproducible on
+`main`, independent of ADR-0019 D4:
+
+```
+my role R[::T] { multi method foo(T $t) { "T=" ~ T.^name } };
+my class A does R[Int] does R[Str] { };
+say A.new.foo(5);    # mutsu: "T=Str" (wrong, should be "T=Int")
+say A.new.foo("x");  # mutsu: "T=Str" (correct, but only by accident)
+```
+
+raku prints `T=Int` then `T=Str` — correct multi dispatch by argument type. mutsu always
+dispatches both calls to whichever candidate's substituted `MethodDef` happens to win a — as yet
+unidentified — resolution/cache step; swapping the `does` order flips which candidate wins,
+suggesting a last/first-registered tiebreak rather than genuine per-call signature matching.
+
+## Where this was found
+
+Discovered 2026-08-08 while implementing ADR-0019 D4-3 (`resolve_role_candidate_with_args`,
+`todo/deep/adr0019-d4-parent-expr-chunks.md`) and root-causing why `S14-roles/parameterized-type.t`
+started failing on the D4-3 branch: D4-3 exposed a *different*, real bug (see the fix landed in
+D4-3's PR: `parse_optional_bracket_suffix` returning an owned `String` let the pointer-keyed
+expression parse memo alias two sibling bracket arguments), but investigating it surfaced this
+independent, pre-existing multi-dispatch bug — confirmed present on `main` before D4-3 by running
+the repro above against a pre-D4-3 build.
+
+## Why this is filed rather than fixed here
+
+Root-causing requires tracing the multi-candidate resolution/caching path
+(`multi_resolve_cache`/`dispatch_multi_candidate` in `vm.rs`, or the method composition dedup in
+`registration_class_compose.rs`) to find why two structurally-different substituted `MethodDef`s
+for the same `(class, method name)` don't both survive dispatch — out of scope for a
+declaration-plan-lowering slice. The one roast test that exercises this shape only calls with one
+argument type, so it doesn't currently catch the bug; a fix should add a two-argument-type
+regression test (`t/role-double-parametric-multi-dispatch.t`) alongside the real fix.


### PR DESCRIPTION
## Summary
- `resolve_role_candidate` gains a `resolve_role_candidate_with_args` sibling taking
  `pre_args: Option<&[Value]>`; when set, it replaces `eval_role_arg_values`'s
  re-parse-and-tree-walk of the concatenated parent string with the already-evaluated values —
  everything downstream (arity filter, trial bind, specificity sort, winner re-bind) is unchanged.
- `compose_class_parent_roles` evaluates each parent's D4-2 `parent_arg_chunks` (looked up by the
  plan's *original*, pre-remap parent string, kept position-aligned with the
  `lexical_env_remap_name`/`qualify_sibling_parent_name`/Grammar-self-parent-drop chain via a
  zipped `Vec<Option<&[DeclTraitArg]>>`) and passes the resulting values in. The four string-only
  call sites (`registration_role_body.rs` ×2, `registration_class_augment.rs`,
  `methods_qualified.rs`) are unaffected.
- Verified against an 8-case `raku` comparison table (literal, type name, nested
  parameterization, enum value, comma-containing string, block literal) — all match
  byte-for-byte. The `Expr` path also fixes a real, independent bug for free: `R["a,b"]` used to
  fail to parse at all through the old string path's quote-blind comma splitter.

## A parser bug this cutover exposed (and fixed at the root)
Verification surfaced a `make roast` regression in `S14-roles/parameterized-type.t`. Root cause:
`parse_optional_bracket_suffix` returned an owned `String` copy of the bracket content. Two
sibling `does R[X] does R[Y]` clauses on one class header each allocate their own short-lived
copy; when the first is freed at loop-iteration end, the second can land at the same heap
address — aliasing the parser's pointer-keyed expression memo (keyed by `(ptr, len)`, no content
check) and silently returning the first clause's cached `Expr` for the second's genuinely
different bracket content. This bug predates this PR (it lived in D4-1's `parse_bracket_arg_exprs`
call site from the start) but had no consumer to observe it until this PR made
`parent_arg_chunks` load-bearing. Fixed by having `parse_optional_bracket_suffix` return a slice
of the persistent source buffer (never freed mid-parse) instead of an owned copy — the memo can
no longer alias it, by construction. Pinned by a Rust unit test
(`parse_class_decl_two_does_clauses_capture_distinct_bracket_exprs`) and a `t/` integration test
(`role-double-parametric-args-distinct.t`).

## A second, unrelated bug found (filed, not fixed)
Root-causing the above surfaced a second, independent, pre-existing bug — present on `main`
before this PR too: composing the same parametric role twice on one class header with different
type arguments composes both multi candidates correctly, but dispatch always resolves to
whichever one wins some unidentified tiebreak, regardless of the call's actual argument type.
Filed as `todo/tickets/same-role-composed-twice-multi-dispatch-picks-one-candidate.md`.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
- [x] `cargo test --lib` (683 passed)
- [x] `make test` (2970 files / 27982 tests, PASS)
- [x] `roast/S14-roles/*.t`, `S12-construction/*.t`, `S06-signature/*.t`, `S12-methods/*.t`,
      `S02-types/*.t` (the one unrelated pre-existing failure, `S02-types/quanthash.t`, is not
      whitelisted and fails identically on `main`)
- [x] 8-case `raku` comparison table for role bracket arguments
- [ ] CI: `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)