### PR TITLE
feat(compiler): ADR-0021 P1 — method-call boundary parity for Pair named-ness

### DIFF
--- a/docs/adr/0021-argument-namedness-is-a-call-site-property.md
+++ b/docs/adr/0021-argument-namedness-is-a-call-site-property.md
@@ -365,7 +365,7 @@ Each phase is independently shippable and lands with its own tests; CI's
 
 ## Implementation status
 
-- [ ] P1 method-call boundary parity
+- [x] P1 method-call boundary parity
 - [ ] P2 slip/capture/forwarding rules
 - [ ] P3a QuantHash consumer prep
 - [ ] P3 minting-default inversion

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -797,6 +797,13 @@ impl Compiler {
             let arg_sources_idx = self.add_arg_sources_constant(args);
             for arg in args {
                 self.compile_expr(arg);
+                // ADR-0021: `&code(args)` is a sub call, same call-site
+                // named-ness rule as a regular function call. Erase any
+                // named flavour the argument value happens to carry unless
+                // it was written as a named arg at this call site.
+                if !Self::is_named_arg_expr(arg) {
+                    self.code.emit(OpCode::ContainerizePair);
+                }
             }
             let name_idx = self.code.add_constant(Value::str(name.clone()));
             self.code.emit(OpCode::CallOnCodeVar {
@@ -809,6 +816,9 @@ impl Compiler {
             let arg_sources_idx = self.add_arg_sources_constant(args);
             for arg in args {
                 self.compile_expr(arg);
+                if !Self::is_named_arg_expr(arg) {
+                    self.code.emit(OpCode::ContainerizePair);
+                }
             }
             self.code.emit(OpCode::CallOnValue {
                 arity: args.len() as u32,

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -162,6 +162,20 @@ impl Compiler {
                 && i == 1
                 && let Expr::Var(n) = arg
             {
+                // ADR-0021's `ContainerizePair` (just emitted above by
+                // `compile_method_arg_with_escape`, since a bare `$v` is not
+                // a syntactically-named arg) is semantically inert here —
+                // `Pair.new`'s value parameter is bound raw, not classified
+                // by named-ness — but its presence between the variable read
+                // and this `WrapVarRef` breaks the GetGlobal-immediately-
+                // followed-by-WrapVarRef adjacency that named-sub capture
+                // analysis (`helpers_sub_body.rs`) requires to box `$v`'s
+                // outer container. Pop it back off so the compiled sequence
+                // matches what it was before boundary erasure existed.
+                if matches!(self.code.ops.last(), Some(OpCode::ContainerizePair)) {
+                    self.code.ops.pop();
+                    self.code.op_lines.pop();
+                }
                 let src_idx = self.code.add_constant(Value::str(n.clone()));
                 self.code.emit(OpCode::WrapVarRef(src_idx));
             }

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -176,6 +176,18 @@ impl Compiler {
                 }
             })
         });
+        // ADR-0021 (argument named-ness is a call-site property): named-ness
+        // is decided by call-site syntax, not by what flavour of Pair the
+        // argument expression happens to evaluate to. The function-call path
+        // (`compile_call_arg_with_escape`, below) already normalizes every
+        // non-syntactically-named argument at the call boundary; the method
+        // path lacked this, so a Pair-valued variable/array-element/return
+        // value leaked its named flavour straight into method dispatch
+        // (`Pair.new($k,$v)` misbinding as a named arg, etc). Mirror the
+        // function path here so both call kinds erase the flavour identically.
+        if !Self::is_named_arg_expr(arg) {
+            self.code.emit(OpCode::ContainerizePair);
+        }
     }
 
     /// Check if an expression produces an array value that needs decontainerization
@@ -197,7 +209,7 @@ impl Compiler {
     /// Compile a function-call positional argument.
     /// Variable-like args are wrapped with source-name metadata so sigilless
     /// parameters (`\x`) can bind as writable aliases.
-    fn is_named_arg_expr(expr: &Expr) -> bool {
+    pub(super) fn is_named_arg_expr(expr: &Expr) -> bool {
         match expr {
             Expr::Binary { op, .. } if *op == crate::token_kind::TokenKind::FatArrow => true,
             Expr::Literal(lit) if matches!(lit.view(), crate::value::ValueView::Pair(..)) => true,

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -545,23 +545,10 @@ impl Compiler {
         // (e.g. a user `trait_mod:<is>` pushing to an outer `@names`) is boxed too.
         let mut nf_writes = cf.code.free_var_writes.clone();
         nf_writes.extend(cf.code.free_var_container_writes.iter().copied());
-        for (i, op) in cf.code.ops.iter().enumerate() {
-            let OpCode::GetGlobal(name_idx) = op else {
-                continue;
-            };
-            // Between the variable read and its WrapVarRef tag, the argument
-            // compile may have inserted no-op-on-plain-values normalization
-            // ops (ADR-0021 `ContainerizePair`; slurpy-flatten `Decont`) that
-            // don't touch identity — skip over them to find the WrapVarRef
-            // this GetGlobal feeds, rather than requiring true adjacency.
-            let wrap_pos = cf.code.ops[i + 1..]
-                .iter()
-                .position(|op| !matches!(op, OpCode::Decont | OpCode::ContainerizePair))
-                .map(|offset| i + 1 + offset);
-            let Some(wrap_pos) = wrap_pos else {
-                continue;
-            };
-            let OpCode::WrapVarRef(wrapped_idx) = &cf.code.ops[wrap_pos] else {
+        for pair in cf.code.ops.windows(2) {
+            let (OpCode::GetGlobal(name_idx), OpCode::WrapVarRef(wrapped_idx)) =
+                (&pair[0], &pair[1])
+            else {
                 continue;
             };
             if name_idx != wrapped_idx {

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -545,10 +545,23 @@ impl Compiler {
         // (e.g. a user `trait_mod:<is>` pushing to an outer `@names`) is boxed too.
         let mut nf_writes = cf.code.free_var_writes.clone();
         nf_writes.extend(cf.code.free_var_container_writes.iter().copied());
-        for pair in cf.code.ops.windows(2) {
-            let (OpCode::GetGlobal(name_idx), OpCode::WrapVarRef(wrapped_idx)) =
-                (&pair[0], &pair[1])
-            else {
+        for (i, op) in cf.code.ops.iter().enumerate() {
+            let OpCode::GetGlobal(name_idx) = op else {
+                continue;
+            };
+            // Between the variable read and its WrapVarRef tag, the argument
+            // compile may have inserted no-op-on-plain-values normalization
+            // ops (ADR-0021 `ContainerizePair`; slurpy-flatten `Decont`) that
+            // don't touch identity — skip over them to find the WrapVarRef
+            // this GetGlobal feeds, rather than requiring true adjacency.
+            let wrap_pos = cf.code.ops[i + 1..]
+                .iter()
+                .position(|op| !matches!(op, OpCode::Decont | OpCode::ContainerizePair))
+                .map(|offset| i + 1 + offset);
+            let Some(wrap_pos) = wrap_pos else {
+                continue;
+            };
+            let OpCode::WrapVarRef(wrapped_idx) = &cf.code.ops[wrap_pos] else {
                 continue;
             };
             if name_idx != wrapped_idx {

--- a/t/method-pair-argument-is-positional.t
+++ b/t/method-pair-argument-is-positional.t
@@ -1,0 +1,46 @@
+use Test;
+plan 10;
+
+# ADR-0021: argument named-ness is a call-site property, not a value
+# property. This pins the METHOD-call column of the divergence table --
+# previously only the function-call column erased a Pair's named flavour
+# at the call boundary (ContainerizePair), leaving every non-syntactic
+# Pair argument to a method call misbind as named.
+
+class D {
+    multi method m(Pair $p) { 'positional:' ~ $p.key ~ '=' ~ $p.value }
+    multi method m(:$a!) { 'named:a=' ~ $a }
+}
+my $d = D.new;
+
+is $d.m(Pair.new('a', 1)), 'positional:a=1', 'Pair.new(...) as method arg is positional';
+
+my $p = a => 1;
+is $d.m($p), 'positional:a=1', 'variable holding a Pair is positional as a method arg';
+
+my @l = (a => 1,);
+is $d.m(@l[0]), 'positional:a=1', 'array element Pair is positional as a method arg';
+
+sub mk() { return a => 1 }
+is $d.m(mk()), 'positional:a=1', 'sub return value Pair is positional as a method arg';
+
+is $d.m(a => 1), 'named:a=1', 'literal fat-arrow pair at the call site is still named';
+is $d.m(:a(1)), 'named:a=1', 'literal colonpair at the call site is still named';
+
+# Default constructor: a positional Pair argument must be rejected, not
+# silently bound as a named constructor argument.
+class Plain { has $.x; has $.y; }
+my $pp = a => 1;
+dies-ok { Plain.new($pp) }, 'default constructor rejects a positional Pair argument';
+
+# Pair.new's own two-positional form must not misclassify its own args.
+my $built = Pair.new('k', 'v');
+is $built.key, 'k', 'Pair.new key argument unaffected by boundary erasure';
+is $built.value, 'v', 'Pair.new value argument unaffected by boundary erasure';
+
+# A parenthesised pair is positional too (method call, not just sub call).
+class E {
+    multi method n(Pair $p) { 'positional' }
+    multi method n(:$a!) { 'named' }
+}
+is E.new.n((a => 1)), 'positional', 'parenthesised pair as method arg is positional';


### PR DESCRIPTION
## Summary

Implements Phase 1 of [ADR-0021](docs/adr/0021-argument-namedness-is-a-call-site-property.md) (argument named-ness is a call-site property).

- Emit `ContainerizePair` for non-syntactically-named method-call arguments (`compile_method_arg_with_escape`), mirroring the normalization the function-call path (`compile_call_arg_with_escape`) already applied.
- Apply the same normalization to `&code(args)` / callable-value invocation (`CallOn`).
- Fix a latent bug this exposed: the named-sub cell-capture scan in `helpers_sub_body.rs` looked for a bare `GetGlobal` immediately followed by `WrapVarRef` to detect which captured-outer variables need box-at-declaration treatment. Inserting `ContainerizePair` (or the pre-existing `Decont`) between the two ops broke that strict-adjacency check, silently losing container aliasing for `Pair.new('key', $outer)`-shaped captures inside named subs. The scan now skips over those no-op-on-plain-values normalization ops instead of requiring true adjacency.

Before this change, a `Pair`-valued variable, array element, sub return value, or `Pair.new(...)` result passed as a **method** argument leaked its named flavour straight into dispatch — misbinding as a named argument where raku treats it as positional. This was the root cause of `Cro::HTTP::Client` dying on `headers => [Authorization => '...']` (`X::Multi::NoMatch` on `append-header`).

## Test plan

- New pin `t/method-pair-argument-is-positional.t`: the method-call column of the ADR's raku-vs-mutsu divergence table (`Pair.new(...)`, a Pair-valued variable, an array element, a sub return value, a parenthesised pair — all positional; a literal fat-arrow/colonpair — still named; `Plain.new($pair)` default-ctor dying on a positional Pair arg).
- Existing pins stay green: `t/pair-positional-arg.t`, `t/multi-dispatch-positional-pair.t`, `t/hash-pair-is-positional-argument.t`, `t/hash-first-positional.t`, `t/nested-pair-subsignature.t`, `t/pair-subsignature-dispatch.t`, `t/colon-const-fatarrow-key.t`, `t/setbagmix-gist-pair-elements.t`, `t/for-pairs-value-quanthash-writeback.t`, `t/captured-outer-pair-container-alias.t`, `t/closure-arg-shares-its-captured-container.t`, `t/wrap-closure-capture.t`, `t/wrap-closure-container-capture.t`, `t/wrap-invocant-arg-source.t`.
- Manually verified against `raku` for every row of the divergence table plus a minimal Cro-shaped repro (`append-header` multi dispatched from an array of Pairs).
- `make test`: 2971 files, 27994 tests, all green.
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean.
- Full roast is delegated to CI per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)