### PR TITLE
feat(runtime): encode role parent/hides/hidden ops as a typed plan (ADR-0019 D7-3)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -116,7 +116,7 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 `main`; this is not a stacked-PR plan.
 
 **Current progress: 31/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
-landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, and D4-3 landed 2026-08-08). Phase C is fully checked; the open box is
+landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, D4-3, and D7-3 landed 2026-08-08). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
@@ -1042,8 +1042,26 @@ walkers wholesale is not possible before then.
   `register_role_decl` now takes both precomputed facts as parameters instead of re-walking
   the raw body on every registration; the two now-dead `Interpreter` methods are deleted (no
   other callers). D7-2 (= D2b-2's role half, name-keyed `attr_decls`) was already delivered by
-  D2b-2 landing on both `CompiledClassDeclPlan` and `CompiledRoleDeclPlan` at once. D7-3..4
-  remain open.
+  D2b-2 landing on both `CompiledClassDeclPlan` and `CompiledRoleDeclPlan` at once.
+  **D7-3 landed 2026-08-08**: `CompiledRoleDeclPlan` gained `parent_ops: Vec<RoleParentOp>`
+  (`{ name, hides, hidden, args: Option<Vec<DeclTraitArg>> }`), one op per `DoesDecl` statement
+  in the (`SyntheticBlock`-flattened) role body, computed by a new
+  `Compiler::compile_role_parent_ops` mirroring `compile_role_attr_decls`'s flatten so the two
+  sides' traversal order agrees. `role_body_does_decl` now reads its op by position via a
+  cursor (the same style D3-1's `method_name_chunk_idx` uses) instead of string-matching the
+  `__mutsu_role_hidden__`/`__mutsu_role_hides__<name>` marker names the parser still encodes on
+  the raw `Stmt::DoesDecl` — the marker classification moved from the runtime hot path to the
+  one-time compiler precompute. The `args` chunk (D4-1's parsed bracket expressions, compiled
+  the same way D4-2 compiled the class-header site) also feeds `resolve_role_candidate_with_args`
+  for the role-body `does` site's own parametric-candidate resolution (the piece D4-2 deliberately
+  left for D7), reusing the exact `should_treat_role_arg_as_type_expr` coercion-type bail-out
+  D4-3's own regression fix established. Deliberately left as the old string path: the earlier
+  `concretized_parent` lookup in the same function (a second, independent `resolve_role_candidate`
+  call already re-evaluating the same bracket text) — wiring `pre_args` there too would collapse
+  today's double-evaluation of a side-effecting bracket argument into a single evaluation, a
+  real behavior change out of this slice's scope. Verified via the full `t/` suite (27,992
+  tests) and every whitelisted `S14-roles`/`S12-coercion` roast file, plus `t/mro-role-hides.t`
+  (hides/hidden-specific coverage), all green. D7-4 (`body_plan` op walk) remains open.
 - [ ] **D8 — Compile role declaration-time bodies and traits.** Run parameterized-role and composed
   ancestor bodies as bytecode child chunks with correct once-per-composition behavior. (Custom-trait
   arguments already landed with C5; the bodies remain.)

--- a/news/2026-08/adr0019-d7-3-role-parent-ops.md
+++ b/news/2026-08/adr0019-d7-3-role-parent-ops.md
@@ -1,0 +1,29 @@
+# ADR-0019 D7-3: typed role parent ops replace the hides/hidden string markers
+
+`CompiledRoleDeclPlan` gained `parent_ops: Vec<RoleParentOp>`, a typed record of every
+`does`/`hides`/`is hidden` clause in a role's own body. Each op mirrors one `DoesDecl` statement
+in the (`SyntheticBlock`-flattened) body, computed once at compile time by a new
+`Compiler::compile_role_parent_ops` — the same flatten `compile_role_attr_decls` already uses, so
+the compiler's op list and the runtime's body walk stay aligned by position.
+
+Previously `role_body_does_decl` classified each `DoesDecl` statement by string-matching its name
+against `__mutsu_role_hidden__` and stripping a `__mutsu_role_hides__` prefix, on every role
+registration. That classification now happens once, at compile time; the runtime reads a typed
+`RoleParentOp { name, hides, hidden, args }` by position instead, via a cursor in the same style
+D3-1's `method_name_chunk_idx` established.
+
+`args` also carries ADR-0019 D4-1's parsed bracket-argument expressions, compiled to
+`DeclTraitArg` chunks the way D4-2 compiled the class-header site. The role-body `does` site's own
+parametric-candidate resolution (`resolve_role_candidate_with_args`) now evaluates these
+precompiled chunks instead of re-parsing the concatenated parent string — the piece D4-2
+deliberately left open for D7 — reusing D4-3's `should_treat_role_arg_as_type_expr` bail-out for
+coercion-type arguments (`does R[Str:D(Numeric)]`) that parse as an `Expr` but must not be
+evaluated as one.
+
+Left untouched on purpose: the same function's earlier `concretized_parent` lookup, a second
+independent `resolve_role_candidate` call over the same bracket text. Wiring precompiled args
+into that call too would collapse today's double-evaluation of a side-effecting bracket argument
+into a single evaluation — a real behavior change, out of this slice's narrow scope.
+
+Verified via the full `t/` suite (27,992 tests), every whitelisted `S14-roles`/`S12-coercion`
+roast file, and `t/mro-role-hides.t` (hides/hidden-specific coverage), all green.

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -264,8 +264,62 @@ impl Compiler {
         let trait_args = self.compile_decl_trait_args(custom_traits);
         let attr_decls = self.compile_role_attr_decls(body);
         let method_name_chunks = self.compile_method_name_chunks(body);
+        let parent_ops = self.compile_role_parent_ops(body);
         self.code
-            .add_role_decl_plan(stmt, trait_args, attr_decls, method_name_chunks)
+            .add_role_decl_plan(stmt, trait_args, attr_decls, method_name_chunks, parent_ops)
+    }
+
+    /// Precompile each `does`/`hides`/`is hidden` clause of a role's own body
+    /// into a typed [`crate::opcode::RoleParentOp`] (ADR-0019 D7-3), one per
+    /// `DoesDecl` statement in source order after the same `SyntheticBlock`
+    /// flatten `compile_role_attr_decls` uses — `walk_role_body` flattens
+    /// identically, so the runtime cursor and this vec stay aligned. The
+    /// parser folds `does`/`is Parent`/`hides` clauses from the role header
+    /// (and the `is hidden` trait) into synthetic `DoesDecl` statements
+    /// prepended to the body; a `hides Parent` clause contributes two
+    /// statements (the plain parent, then the `__mutsu_role_hides__` marker),
+    /// which this precompute turns into two typed ops rather than collapsing
+    /// them, preserving the walk's exact statement-by-statement shape.
+    fn compile_role_parent_ops(&self, body: &[Stmt]) -> Vec<crate::opcode::RoleParentOp> {
+        body.iter()
+            .flat_map(|s| match s {
+                Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+                other => vec![other],
+            })
+            .filter_map(|stmt| match stmt {
+                Stmt::DoesDecl { name, args } => {
+                    let name_str = name.resolve();
+                    if name_str == "__mutsu_role_hidden__" {
+                        return Some(crate::opcode::RoleParentOp {
+                            name: Symbol::intern(""),
+                            hides: false,
+                            hidden: true,
+                            args: None,
+                        });
+                    }
+                    if let Some(hidden_name) = name_str.strip_prefix("__mutsu_role_hides__") {
+                        return Some(crate::opcode::RoleParentOp {
+                            name: Symbol::intern(hidden_name),
+                            hides: true,
+                            hidden: false,
+                            args: None,
+                        });
+                    }
+                    Some(crate::opcode::RoleParentOp {
+                        name: *name,
+                        hides: false,
+                        hidden: false,
+                        args: args.as_ref().map(|exprs| {
+                            exprs
+                                .iter()
+                                .map(|e| self.compile_decl_trait_arg(e))
+                                .collect()
+                        }),
+                    })
+                }
+                _ => None,
+            })
+            .collect()
     }
 
     /// Precompile a full `CompiledAttrDecl` for each attribute a role body

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2756,6 +2756,33 @@ pub(crate) struct CompiledClassDeclPlan {
     pub(crate) parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>,
 }
 
+/// One `does`/`hides`/`is hidden` clause from a role's own body, as a typed
+/// plan op (ADR-0019 D7-3) read by position during the role-body walk
+/// instead of the runtime string-matching the `__mutsu_role_hides__`/
+/// `__mutsu_role_hidden__` marker names the parser encodes as synthetic
+/// `Stmt::DoesDecl` statements. One op per `DoesDecl` statement the
+/// (`SyntheticBlock`-flattened) body contains, in source order — mirroring
+/// `walk_role_body`'s own flatten exactly so the two sides' cursors agree.
+#[derive(Debug, Clone)]
+pub(crate) struct RoleParentOp {
+    /// The parent/hidden-class name (unused when `hidden` is set — the
+    /// `is hidden` marker names nothing).
+    pub(crate) name: Symbol,
+    /// This op is the `__mutsu_role_hides__` marker: `name` is the class
+    /// this role hides (already stripped of the marker prefix).
+    pub(crate) hides: bool,
+    /// This op is the `__mutsu_role_hidden__` marker (`is hidden` on the
+    /// role itself).
+    pub(crate) hidden: bool,
+    /// Precompiled bracket-argument chunks for a real `does Role[Args]`
+    /// parent (ADR-0019 D4-1's `Stmt::DoesDecl::args`, compiled the same way
+    /// as `parent_arg_chunks`). `None` when the bracket content did not
+    /// parse as a clean expression list, or there is no bracket — the
+    /// consumer falls back to the string path exactly as the class-header
+    /// site (D4-3) does.
+    pub(crate) args: Option<Vec<DeclTraitArg>>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledRoleDeclPlan {
     pub(crate) name: Symbol,
@@ -2806,6 +2833,10 @@ pub(crate) struct CompiledRoleDeclPlan {
     /// registration; `register_role_decl` raises
     /// `X::Declaration::OurScopeInRole` from this fact.
     pub(crate) our_scope_violation: Option<&'static str>,
+    /// Typed `does`/`hides`/`is hidden` ops for this role's own body
+    /// (ADR-0019 D7-3), one per `DoesDecl` statement in source order; see
+    /// [`RoleParentOp`].
+    pub(crate) parent_ops: Vec<RoleParentOp>,
 }
 
 /// A package-level `proto sub`/`proto rule`/`proto token` declaration lowered
@@ -6048,6 +6079,7 @@ impl CompiledCode {
         trait_args: Vec<Option<DeclTraitArg>>,
         attr_decls: Vec<(Symbol, CompiledAttrDecl)>,
         method_name_chunks: Vec<Option<CompiledDeclExpr>>,
+        parent_ops: Vec<RoleParentOp>,
     ) -> u32 {
         let Stmt::RoleDecl {
             name,
@@ -6086,6 +6118,7 @@ impl CompiledCode {
             method_decls,
             is_stub,
             our_scope_violation,
+            parent_ops,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Role(plan_idx));

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -297,6 +297,7 @@ impl Interpreter {
         method_decls: &[crate::opcode::CompiledMethodDecl],
         is_stub_body: bool,
         our_scope_violation: Option<&str>,
+        parent_ops: &[crate::opcode::RoleParentOp],
     ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
 
@@ -361,6 +362,8 @@ impl Interpreter {
             method_name_chunks,
             method_decls,
             method_name_chunk_idx: 0,
+            parent_ops,
+            parent_op_idx: 0,
         };
         self.walk_role_body(body, &mut cx)?;
         self.finish_role_registration(

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -3,7 +3,8 @@
 //! extraction from `registration_role.rs` — no behavior change.
 
 use super::registration_class::{
-    parse_role_type_args, substitute_type_params_in_method, type_value_name,
+    parse_role_type_args, should_treat_role_arg_as_type_expr, substitute_type_params_in_method,
+    type_value_name,
 };
 use super::registration_role_decl::RoleDeclCx;
 use super::*;
@@ -141,32 +142,38 @@ impl Interpreter {
 
     /// The `does` arm of the role-body walk: record parent roles/classes and
     /// compose a parent role's attributes and methods into this role.
+    ///
+    /// ADR-0019 D7-3: `op` is precompiled by the compiler at plan lowering
+    /// (`CompiledRoleDeclPlan::parent_ops`) and read here by position via the
+    /// same cursor style `role_body_method_decl` uses, instead of the
+    /// runtime string-matching the `__mutsu_role_hides__`/
+    /// `__mutsu_role_hidden__` marker names on the raw statement.
     pub(super) fn role_body_does_decl(
         &mut self,
         cx: &mut RoleDeclCx<'_>,
-        stmt: &Stmt,
     ) -> Result<(), RuntimeError> {
-        let Stmt::DoesDecl {
-            name: role_name, ..
-        } = stmt
-        else {
-            unreachable!("role_body_does_decl called on a non-DoesDecl statement");
-        };
+        let op_idx = cx.parent_op_idx;
+        cx.parent_op_idx += 1;
+        let op = cx
+            .parent_ops
+            .get(op_idx)
+            .cloned()
+            .expect("parent_ops misaligned with role body walk");
         let name = cx.name;
-        if *role_name == "__mutsu_role_hidden__" {
+        if op.hidden {
             cx.role_def.is_hidden = true;
             return Ok(());
         }
-        let role_name_str = role_name.resolve();
-        if let Some(hidden_name) = role_name_str.strip_prefix("__mutsu_role_hides__") {
+        if op.hides {
             // Track hidden class relationship for this role
             self.registry_mut()
                 .role_hides
                 .entry(name.to_string())
                 .or_default()
-                .push(hidden_name.to_string());
+                .push(op.name.resolve());
             return Ok(());
         }
+        let role_name_str = op.name.resolve();
         // A sibling role referenced by its short name (`role Derived
         // does Base` inside `unit module M`, where Base is registered
         // as `M::Base`) must resolve to its qualified name — the same
@@ -275,9 +282,40 @@ impl Interpreter {
         // role_type_params branch below and defer real composition to
         // class-application time.
         let forwards_type_param = role_name_str.contains("::");
+        // Evaluate this parent's precompiled bracket-argument chunks
+        // (ADR-0019 D7-3), if any, instead of leaving candidate resolution
+        // to re-parse the concatenated parent string — same bail-out as the
+        // class-header site (D4-3): a coercion-type argument
+        // (`does R[Str:D(Numeric)]`) parses cleanly as an `Expr` but must
+        // NOT be evaluated as one (`should_treat_role_arg_as_type_expr`
+        // turns it into a `Package` marker instead), so skip the chunk path
+        // for the whole application when any raw argument would trigger it.
+        let has_type_expr_arg = role_name_str
+            .find('[')
+            .map(|start| {
+                let args_str = &role_name_str[start + 1..role_name_str.len() - 1];
+                parse_role_type_args(args_str)
+                    .iter()
+                    .any(|a| should_treat_role_arg_as_type_expr(a))
+            })
+            .unwrap_or(false);
+        let pre_args = if has_type_expr_arg {
+            None
+        } else {
+            match &op.args {
+                Some(chunks) => {
+                    let mut values = Vec::with_capacity(chunks.len());
+                    for chunk in chunks {
+                        values.push(self.eval_decl_trait_arg(chunk)?);
+                    }
+                    Some(values)
+                }
+                None => None,
+            }
+        };
         let type_subs: Vec<(String, String)> = if !forwards_type_param
             && let Some((_, resolved_param_names, resolved_values)) =
-                self.resolve_role_candidate(&role_name_str)?
+                self.resolve_role_candidate_with_args(&role_name_str, pre_args.as_deref())?
         {
             // Store the resolved param bindings so they are
             // available when the child role is punned to a class

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -37,6 +37,13 @@ pub(super) struct RoleDeclCx<'a> {
     /// Cursor into `method_name_chunks`/`method_decls`, advanced by one on
     /// every method statement `role_body_method_decl` processes.
     pub(super) method_name_chunk_idx: usize,
+    /// Typed `does`/`hides`/`is hidden` ops for this role's own body
+    /// (ADR-0019 D7-3), read by position via `parent_op_idx`; see
+    /// `role_body_does_decl`.
+    pub(super) parent_ops: &'a [crate::opcode::RoleParentOp],
+    /// Cursor into `parent_ops`, advanced by one on every `DoesDecl`
+    /// statement `role_body_does_decl` processes.
+    pub(super) parent_op_idx: usize,
 }
 
 impl RoleDeclCx<'_> {
@@ -146,7 +153,7 @@ impl Interpreter {
                     self.role_body_has_decl(cx, stmt)?;
                 }
                 Stmt::DoesDecl { .. } => {
-                    self.role_body_does_decl(cx, stmt)?;
+                    self.role_body_does_decl(cx)?;
                 }
                 Stmt::MethodDecl { .. } => {
                     self.role_body_method_decl(cx)?;

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -631,6 +631,7 @@ impl Interpreter {
             method_decls,
             is_stub,
             our_scope_violation,
+            parent_ops,
         }) = code.role_decl_plans.get(idx as usize)
         {
             let name_str = name.resolve();
@@ -665,6 +666,7 @@ impl Interpreter {
                     method_decls,
                     *is_stub,
                     *our_scope_violation,
+                    parent_ops,
                 )
             )?;
             // Link `is Parent` references on this role to the lexical class visible


### PR DESCRIPTION
## Summary
- `CompiledRoleDeclPlan` gains `parent_ops: Vec<RoleParentOp>`, precomputed at compile time from a role body's `DoesDecl` statements (mirroring `compile_role_attr_decls`'s `SyntheticBlock` flatten so the compiler's op list and the runtime's body walk stay position-aligned).
- `role_body_does_decl` reads its op by position via a cursor (same style as D3-1's `method_name_chunk_idx`) instead of runtime string-matching the `__mutsu_role_hidden__`/`__mutsu_role_hides__<name>` marker names on every role registration.
- The typed op also carries D4-1's parsed bracket-argument expressions, compiled to `DeclTraitArg` chunks the way D4-2 compiled the class-header site — the role-body `does` site's own parametric-candidate resolution now evaluates these precompiled chunks via `resolve_role_candidate_with_args` instead of re-parsing the concatenated parent string (the piece D4-2 deliberately left for D7), reusing D4-3's `should_treat_role_arg_as_type_expr` coercion-type bail-out.
- Deliberately left untouched: the same function's earlier `concretized_parent` lookup (a second, independent `resolve_role_candidate` call over the same bracket text) — wiring precompiled args there too would collapse today's double-evaluation of a side-effecting bracket argument into a single evaluation, a real behavior change out of this slice's scope.
- ADR-0019 progress checklist and `news/2026-08/` updated (D7-3 landed; D7-4 `body_plan` op walk remains open).

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings` (pre-commit config; clean)
- [x] `cargo fmt`
- [x] `make test` — 27,992 tests, all green
- [x] Every whitelisted `S14-roles`/`S12-coercion` roast file — all PASS
- [x] `t/mro-role-hides.t` (hides/hidden-specific coverage) — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)