### PR TITLE
feat(vm): ADR-0021 P2 — slip/capture named-ness follows the source container

### DIFF
--- a/docs/adr/0021-argument-namedness-is-a-call-site-property.md
+++ b/docs/adr/0021-argument-namedness-is-a-call-site-property.md
@@ -366,7 +366,7 @@ Each phase is independently shippable and lands with its own tests; CI's
 ## Implementation status
 
 - [x] P1 method-call boundary parity
-- [ ] P2 slip/capture/forwarding rules
+- [x] P2 slip/capture/forwarding rules
 - [ ] P3a QuantHash consumer prep
 - [ ] P3 minting-default inversion
 - [ ] P4 representation cleanup

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -2,10 +2,42 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
+    /// Convert a named-flavour Pair into the positional flavour; a no-op for
+    /// everything else (ADR-0021 I1/I4). The same normalization
+    /// `OpCode::ContainerizePair` performs at a compiled call boundary,
+    /// needed here too because a Slip's elements bypass the compiler
+    /// entirely — `exec_make_slip_op` applies this to every element sourced
+    /// from a genuinely positional container (Array/Seq/LazyList/Capture's
+    /// positional lane).
+    pub(super) fn containerize_pair_item(item: Value) -> Value {
+        match item.view() {
+            ValueView::Pair(k, v) => Value::value_pair(Value::str(k.clone()), v.clone()),
+            _ => item,
+        }
+    }
+
+    /// Convert a positional-flavour Pair (`Str` key only — a named argument
+    /// always has a string name) into the named flavour; a no-op for
+    /// everything else. The reverse of `containerize_pair_item`, applied at
+    /// the two places ADR-0021 I4 mints a named argument from a slip: a bare
+    /// `|$pair` and each `|%h` entry.
+    pub(super) fn namify_pair_item(item: Value) -> Value {
+        match item.view() {
+            ValueView::ValuePair(key, val) => match key.view() {
+                ValueView::Str(name) => Value::pair(name.to_string(), val.clone()),
+                _ => item,
+            },
+            _ => item,
+        }
+    }
+
     pub(super) fn append_slip_item(args: &mut Vec<Value>, item: &Value) {
         match item.view() {
             ValueView::Capture { positional, named } => {
-                args.extend(positional.iter().cloned());
+                // I5: containerize on append rather than trusting the stored
+                // flavour — the positional lane must stay positional even if
+                // an element was minted with the named flavour upstream.
+                args.extend(positional.iter().cloned().map(Self::containerize_pair_item));
                 for (k, v) in named.iter() {
                     args.push(Value::pair(k.clone(), v.clone()));
                 }
@@ -15,17 +47,6 @@ impl Interpreter {
             // a bare Hash into pairs before wrapping in a Slip. A Hash that is already
             // inside a Slip (e.g. from a Capture's positional list) should stay as-is.
             ValueView::Hash(_) => args.push(item.clone()),
-            // A `(:key(val))` positional-pair slipped via `|(...)` flattens back
-            // to a *named* argument in Raku (e.g. `.subst(|(:g), ...)` passes `:g`
-            // as the named `:g` adverb). Mirror `append_slip_value`'s ValuePair
-            // arm so the slipped pair is recognized as a named argument.
-            ValueView::ValuePair(key, val) => {
-                if let ValueView::Str(name) = key.view() {
-                    args.push(Value::pair(name.to_string(), val.clone()));
-                } else {
-                    args.push(item.clone());
-                }
-            }
             ValueView::Range(..)
             | ValueView::RangeExcl(..)
             | ValueView::RangeExclStart(..)
@@ -33,6 +54,10 @@ impl Interpreter {
             | ValueView::GenericRange { .. } => {
                 args.extend(crate::runtime::utils::value_to_list(item));
             }
+            // Every other item's flavour was already finalized by
+            // `exec_make_slip_op` when this Slip was built (positional
+            // sources containerized, a bare Pair/Hash source promoted to
+            // named) — trust it rather than reclassifying by value shape.
             _ => args.push(item.clone()),
         }
     }

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -87,11 +87,39 @@ impl Interpreter {
             return Ok(());
         }
         let items = match val.view() {
-            ValueView::Array(items, ..) => (*items).to_vec(),
+            // ADR-0021 I4: `|@l` / `|$list` produce POSITIONAL arguments even
+            // when an element happens to be a Pair (e.g. a literal `x => 1`
+            // sitting in an array, which mints the named flavour today absent
+            // an argument-position boundary to erase it). Containerize each
+            // element here, at the one place that knows these came from a
+            // positional container, rather than trying to recover that
+            // context later in `append_slip_item`.
+            ValueView::Array(items, ..) => items
+                .iter()
+                .cloned()
+                .map(Self::containerize_pair_item)
+                .collect(),
+            // A nested Slip's items were already finalized by the
+            // `exec_make_slip_op` call that built it (positional-source
+            // elements containerized, a bare-Pair/Hash source promoted to
+            // named) — re-processing here would re-flip an already-correct
+            // named item back to positional. Pass through unchanged.
             ValueView::Slip(items) => (*items).to_vec(),
-            ValueView::Seq(items) => (*items).to_vec(),
+            ValueView::Seq(items) => items
+                .iter()
+                .cloned()
+                .map(Self::containerize_pair_item)
+                .collect(),
             ValueView::Capture { positional, named } => {
-                let mut items = positional.clone();
+                // I5: a Capture's lanes are already classified by the call
+                // site that built it; replay them verbatim by lane rather
+                // than reclassifying by value flavour (positional stays
+                // positional, named stays named).
+                let mut items: Vec<Value> = positional
+                    .iter()
+                    .cloned()
+                    .map(Self::containerize_pair_item)
+                    .collect();
                 for (k, v) in named.iter() {
                     items.push(Value::pair(k.clone(), v.clone()));
                 }
@@ -99,16 +127,22 @@ impl Interpreter {
             }
             // typed_pair decodes an object hash's `.WHICH` store keys back to
             // the original key objects (plain hashes get `Pair(str_key, v)`).
+            // I4: `|%h` is always named, so promote every entry here rather
+            // than leaving it to `append_slip_item` to guess.
             ValueView::Hash(map) => map
                 .iter()
-                .map(|(k, v)| map.typed_pair(k, v.clone()))
+                .map(|(k, v)| Self::namify_pair_item(map.typed_pair(k, v.clone())))
                 .collect(),
             ValueView::LazyList(ll) => {
-                if ll.scan_spec.is_some() {
+                let items = if ll.scan_spec.is_some() {
                     ll.force_scan_to(200_000)
                 } else {
                     ll.cache.lock().unwrap().clone().unwrap_or_default()
-                }
+                };
+                items
+                    .into_iter()
+                    .map(Self::containerize_pair_item)
+                    .collect()
             }
             ValueView::LazyIoLines { .. } => match self.force_if_lazy_io_lines(val) {
                 Ok(forced) => crate::runtime::utils::value_to_list(&forced),
@@ -135,7 +169,12 @@ impl Interpreter {
             {
                 crate::value::value_buf::buf_elems_or_empty(&attributes)
             }
-            _ => vec![val],
+            // Slipping a bare value (`|$pair`, `|Pair.new(...)`) always
+            // produces a NAMED argument regardless of the Pair's own stored
+            // flavour (I4) — this is the one case where the value itself,
+            // not a container it lives in, decides named-ness by being
+            // slipped directly.
+            _ => vec![Self::namify_pair_item(val)],
         };
         self.stack.push(Value::slip(items));
         Ok(())

--- a/t/slip-array-of-pairs-is-positional.t
+++ b/t/slip-array-of-pairs-is-positional.t
@@ -1,0 +1,58 @@
+use Test;
+plan 8;
+
+# ADR-0021 P2 (I4): named-ness of a slipped argument depends on what kind
+# of container is being slipped, not on the flavour an individual Pair
+# element happens to carry. `|@l` / `|$list` always produce POSITIONAL
+# arguments (containerizing any Pair elements); `|$pair` and `|%h` always
+# produce NAMED arguments.
+
+multi g(Pair $p) { 'positional:' ~ $p.key ~ '=' ~ $p.value }
+multi g(:$x!) { 'named:x=' ~ $x }
+
+my @l = (x => 1,);
+is g(|@l), 'positional:x=1', 'slipping an array of pairs is positional';
+
+my $p = x => 1;
+is g(|$p), 'named:x=1', 'slipping a bare Pair variable is named';
+
+sub take_named(:$x!, :$y!) { "named x=$x y=$y" }
+my %h = x => 1, y => 2;
+is take_named(|%h), 'named x=1 y=2', 'slipping a Hash is named';
+
+# Forwarding a positional Pair through `|c` must stay positional.
+sub inner(Pair $p) { 'inner positional:' ~ $p.key ~ '=' ~ $p.value }
+sub inner_via_capture($outer_p) {
+    sub relay(|c) { inner(|c) }
+    relay($outer_p);
+}
+is inner_via_capture($p), 'inner positional:x=1',
+    'outer($p) -> inner(|c) forwarding stays positional';
+
+# callsame with a Pair positional must dispatch to the Pair candidate.
+class B {
+    multi method m(Pair $p) { 'B positional:' ~ $p.key ~ '=' ~ $p.value }
+    multi method m(:$x!) { 'B named:x=' ~ $x }
+}
+class D is B {
+    multi method m(Pair $p) { 'D->' ~ callsame }
+    multi method m(:$x!) { 'D->' ~ callsame }
+}
+is D.new.m($p), 'D->B positional:x=1', 'callsame with a Pair positional reaches the Pair candidate';
+
+# The `.subst(|(:g), ...)` / `.subst(|($k => v), ...)` adverb-promotion
+# shape stays named -- a *bare* Pair slip, not an array-of-pairs slip.
+my $str = "1234567";
+$str.subst(|(nth => 1..3), /../, 'XX');
+is +$/, 3, 'subst adverb promotion via bare pair slip still finds 3 matches';
+
+# Array of pairs used as a positional slurpy still binds elements as Pairs.
+sub slurpy(*@rest) { @rest.map({.WHAT.gist}).join(',') }
+is slurpy(|@l), '(Pair)', 'slurpy positional binding still sees Pair-typed elements';
+
+# A bareword fat-arrow written inside a generic list literal (not directly
+# as a call argument) is NOT a call-site named arg -- slipping that list
+# containerizes every element, including ones with a literal bareword key.
+multi h(Pair $p1, Pair $p2) { 'both positional:' ~ $p1.key ~ '=' ~ $p1.value ~ ',' ~ $p2.key ~ '=' ~ $p2.value }
+is h(|(@l[0], x => 9)), 'both positional:x=1,x=9',
+    'a literal bareword pair inside a slipped list literal is positional, not named';


### PR DESCRIPTION
## Summary

Implements Phase 2 of [ADR-0021](docs/adr/0021-argument-namedness-is-a-call-site-property.md) (argument named-ness is a call-site property): the I4/I5 invariants for slips, captures, and forwarding.

- `exec_make_slip_op` (`vm_coerce_concat_ops.rs`) now finalizes each element's named-ness *at construction time*, per source branch — the one place that actually knows what kind of container is being slipped:
  - Array / Seq / LazyList / a Capture's positional lane → containerize each element (positional), even if it happens to carry the named Pair flavour (e.g. a literal `x => 1` sitting in an array).
  - Hash entries and a bare slipped value (`|$pair`) → promote to named.
  - A nested `Slip`'s items are passed through unchanged — they were already finalized by their own construction, and re-processing them would flip an already-correct named item back to positional.
- `append_slip_item` (`vm_call_helpers.rs`) no longer reclassifies by value shape. That guesswork previously conflated "slip an array of pairs" with "slip a bare pair" — exactly the ambiguity `|%h.pairs` (hash-derived, positional per the earlier "hash-derived pairs are positional" slice) vs `|%h` (named) exposed. It now trusts the flavour `exec_make_slip_op` already finalized, except for its own `Capture` arm, which still containerizes its positional lane defensively on append (I5) rather than trusting the stored flavour.

Before this, `g(|@l)` where `@l` held a literal Pair misbound as named (should be positional, per raku). This also confirms forwarding (`outer($p) -> inner(|c)`) and `callsame` dispatch onto a Pair candidate — both already worked correctly as a side effect of P1's method-call boundary erasure, now pinned directly at the slip layer.

## Test plan

- New pin `t/slip-array-of-pairs-is-positional.t`: slip/capture/forwarding rows of the ADR's divergence table (`|@l` positional, `|$pair` named, `|%h` named, `|c` forwarding stays positional, `callsame` reaches the Pair candidate, `.subst(|($k => v), ...)` adverb promotion, slurpy binding, and a list literal `(pair-elem, x => 9)` slipped via `|(...)` — a *literal bareword* fat-arrow inside a generic list literal, not a call argument list, is still positional). Every case verified against `raku` first.
- Existing pins stay green: the full P1 pin set plus `t/pair-positional-arg.t`, `t/multi-dispatch-positional-pair.t`, `t/hash-pair-is-positional-argument.t`, `t/hash-first-positional.t`, `t/nested-pair-subsignature.t`, `t/pair-subsignature-dispatch.t`, `t/colon-const-fatarrow-key.t`, `t/setbagmix-gist-pair-elements.t`, `t/for-pairs-value-quanthash-writeback.t`.
- `roast/S05-substitution/subst.t` (the file with the `.subst(|($suffix => 1..3), ...)` adverb-promotion pin) stays green.
- A broad local roast sample on a release build (multi-dispatch, subset, slurpy/slip families, `S17-promise/start.t`) all pass — the last one specifically because P1's own regression there (fixed on the same branch history) taught us to check thread-heavy roast files locally before relying solely on CI for this ADR.
- `make test`: 2973 files, 28010 tests, all green.
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean.
- Full roast is delegated to CI per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)