### PR TITLE
feat(compiler,runtime): ADR-0021 P3 — minting-default inversion (I2)

### DIFF
--- a/docs/adr/0021-argument-namedness-is-a-call-site-property.md
+++ b/docs/adr/0021-argument-namedness-is-a-call-site-property.md
@@ -368,6 +368,6 @@ Each phase is independently shippable and lands with its own tests; CI's
 - [x] P1 method-call boundary parity
 - [x] P2 slip/capture/forwarding rules
 - [x] P3a QuantHash consumer prep
-- [ ] P3 minting-default inversion
+- [x] P3 minting-default inversion
 - [ ] P4 representation cleanup
 - [ ] P5 measured perf follow-up

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -224,11 +224,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             ValueView::Bool(b) => Some(Ok(Value::int(if b { 1 } else { 0 }))),
             _ => None,
         },
+        // ADR-0021 I2: data-minted pairs default positional.
         "antipair" => match target.view() {
-            ValueView::Pair(k, v) => Some(Ok(match v.view() {
-                ValueView::Str(s) => Value::pair(s.to_string(), Value::str(k.clone())),
-                _ => Value::value_pair(v.clone(), Value::str(k.clone())),
-            })),
+            ValueView::Pair(k, v) => Some(Ok(Value::value_pair(v.clone(), Value::str(k.clone())))),
             ValueView::ValuePair(k, v) => Some(Ok(Value::value_pair(v.clone(), k.clone()))),
             _ => None,
         },

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -802,7 +802,14 @@ fn dispatch_capture(
                 .enumerate()
                 .map(|(idx, v)| Value::value_pair(Value::int(idx as i64), v.clone()))
                 .collect();
-            pairs.extend(named.iter().map(|(k, v)| Value::pair(k.clone(), v.clone())));
+            // ADR-0021 I2/P3: `.pairs`' output is data, not a call site — the
+            // named lane's entries default positional like the positional
+            // lane above, even though they came from a named argument.
+            pairs.extend(
+                named
+                    .iter()
+                    .map(|(k, v)| Value::value_pair(Value::str(k.clone()), v.clone())),
+            );
             Some(Ok(Value::seq(pairs)))
         }
         "antipairs" => {
@@ -1762,8 +1769,9 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             )
         };
         let pairs = || -> Vec<Value> {
+            // ADR-0021 I2: data-minted pairs default positional.
             keys.iter()
-                .map(|k| Value::pair((*k).to_string(), part(k)))
+                .map(|k| Value::value_pair(Value::str((*k).to_string()), part(k)))
                 .collect()
         };
         match method {
@@ -1895,17 +1903,18 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 return Some(Ok(Value::array(vals)));
             }
             "pairs" => {
+                // ADR-0021 I2: data-minted pairs default positional.
                 let mut pairs = Vec::new();
                 if let Some(ValueView::Array(list, _)) = list_v.as_ref().map(Value::view) {
                     for (i, v) in list.iter().enumerate() {
-                        pairs.push(Value::pair(i.to_string(), v.clone()));
+                        pairs.push(Value::value_pair(Value::str(i.to_string()), v.clone()));
                     }
                 }
                 if let Some(ValueView::Hash(named)) = named_v.as_ref().map(Value::view) {
                     let mut sorted: Vec<(&String, &Value)> = named.iter().collect();
                     sorted.sort_by_key(|(k, _)| (*k).clone());
                     for (k, v) in sorted {
-                        pairs.push(Value::pair(k.clone(), v.clone()));
+                        pairs.push(Value::value_pair(Value::str(k.clone()), v.clone()));
                     }
                 }
                 return Some(Ok(Value::array(pairs)));

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -17,6 +17,14 @@ impl Compiler {
     /// declaration's own lexical position rather than from whatever routine
     /// frame happens to be live when registration runs.
     pub(crate) fn compile_decl_expr(&self, expr: &Expr) -> crate::opcode::CompiledDeclExpr {
+        self.compile_decl_expr_inner(expr, false)
+    }
+
+    fn compile_decl_expr_inner(
+        &self,
+        expr: &Expr,
+        mint_named_pair: bool,
+    ) -> crate::opcode::CompiledDeclExpr {
         let mut chunk_compiler = Compiler::new();
         chunk_compiler.is_routine = self.is_routine;
         chunk_compiler.lexically_in_routine = self.lexically_in_routine;
@@ -28,6 +36,16 @@ impl Compiler {
         chunk_compiler.set_current_package(self.current_package.clone());
         chunk_compiler.current_distribution = self.current_distribution.clone();
         chunk_compiler.last_source_line = self.last_source_line;
+        // ADR-0021 I2/I3: a bareword-keyed fat-arrow (or colonpair, same AST
+        // shape) written directly as a declaration-time trait/role argument
+        // (`is foo(:bar(1))`, `role B does A[:a(1)]`) mints the named
+        // flavour — this chunk is conceptually an argument list, even
+        // though it's compiled as a standalone top-level statement.
+        if mint_named_pair
+            && matches!(expr, Expr::Binary { op, .. } if *op == crate::token_kind::TokenKind::FatArrow)
+        {
+            chunk_compiler.mint_named_pair = true;
+        }
         let body = [Stmt::Expr(expr.clone())];
         let (code, fns) = chunk_compiler.compile(&body);
         crate::opcode::CompiledDeclExpr {
@@ -41,7 +59,7 @@ impl Compiler {
     fn compile_decl_trait_arg(&self, expr: &Expr) -> crate::opcode::DeclTraitArg {
         match expr {
             Expr::Literal(value) => crate::opcode::DeclTraitArg::Literal(value.clone()),
-            _ => crate::opcode::DeclTraitArg::Compiled(self.compile_decl_expr(expr)),
+            _ => crate::opcode::DeclTraitArg::Compiled(self.compile_decl_expr_inner(expr, true)),
         }
     }
 

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -308,8 +308,18 @@ impl Compiler {
                             c.compile_expr(right);
                             let name_idx = c.code.add_constant(Value::str(name.clone()));
                             c.code.emit(OpCode::WrapVarRef(name_idx));
-                            c.code.emit(OpCode::MakePair);
+                            c.code.emit(OpCode::MakeNamedArg);
                             continue;
+                        }
+                        // A named element whose value isn't a bare variable
+                        // (`\(apples => (red => 2))`) still needs the named
+                        // (`MakeNamedArg`) flavour so `exec_make_capture_op`
+                        // routes it into the Capture's named lane rather than
+                        // the positional one (ADR-0021 I5: it classifies by
+                        // the marker, same as every other consumer).
+                        if matches!(item, Expr::Binary { op, .. } if *op == crate::token_kind::TokenKind::FatArrow)
+                        {
+                            c.mint_named_pair = true;
                         }
                         c.compile_expr(item);
                         // A plain scalar variable positional (`\($a)`) captures the

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -117,6 +117,11 @@ impl Compiler {
         op: &TokenKind,
         right: &Expr,
     ) {
+        // ADR-0021 I2/I3: read-and-clear immediately, before any nested
+        // compile (including of `left`/`right` below) can see it — see the
+        // field doc on `mint_named_pair`.
+        let mint_named_pair = self.mint_named_pair;
+        self.mint_named_pair = false;
         // Constant folding (ADR-0006 §2.1): a literal-only pure expression
         // (`60 * 60 * 24`) is evaluated here and collapses to one LoadConst.
         if let Some(folded) = self.try_const_fold_binary(left, op, right) {
@@ -631,7 +636,11 @@ impl Compiler {
             self.compile_expr(right);
             let name_idx = self.code.add_constant(Value::str(name.clone()));
             self.code.emit(OpCode::WrapVarRef(name_idx));
-            self.code.emit(OpCode::MakePair);
+            self.code.emit(if mint_named_pair {
+                OpCode::MakeNamedArg
+            } else {
+                OpCode::MakePair
+            });
             return;
         }
         if let Some(opcode) = Self::binary_opcode(op) {
@@ -679,6 +688,11 @@ impl Compiler {
                 } else {
                     self.code.emit(opcode);
                 }
+            } else if matches!(opcode, OpCode::MakePair) && mint_named_pair {
+                // ADR-0021 I2/I3: this fat-arrow is a bareword-keyed argument
+                // written directly in an argument list (or a colonpair,
+                // which parses to the same shape) — keep the named marker.
+                self.code.emit(OpCode::MakeNamedArg);
             } else {
                 self.code.emit(opcode);
             }

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -796,11 +796,16 @@ impl Compiler {
         if let Expr::CodeVar(name) = target {
             let arg_sources_idx = self.add_arg_sources_constant(args);
             for arg in args {
-                self.compile_expr(arg);
                 // ADR-0021: `&code(args)` is a sub call, same call-site
-                // named-ness rule as a regular function call. Erase any
-                // named flavour the argument value happens to carry unless
-                // it was written as a named arg at this call site.
+                // named-ness rule as a regular function call. A
+                // bareword-keyed fat-arrow/colonpair mints the named
+                // flavour; everything else erases any named flavour the
+                // argument value happens to carry.
+                if matches!(arg, Expr::Binary { op, .. } if *op == crate::token_kind::TokenKind::FatArrow)
+                {
+                    self.mint_named_pair = true;
+                }
+                self.compile_expr(arg);
                 if !Self::is_named_arg_expr(arg) {
                     self.code.emit(OpCode::ContainerizePair);
                 }
@@ -815,6 +820,10 @@ impl Compiler {
             self.compile_expr(target);
             let arg_sources_idx = self.add_arg_sources_constant(args);
             for arg in args {
+                if matches!(arg, Expr::Binary { op, .. } if *op == crate::token_kind::TokenKind::FatArrow)
+                {
+                    self.mint_named_pair = true;
+                }
                 self.compile_expr(arg);
                 if !Self::is_named_arg_expr(arg) {
                     self.code.emit(OpCode::ContainerizePair);

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -764,6 +764,18 @@ impl Compiler {
         }
         self.compile_expr(left);
         for r in right {
+            // ADR-0021 I2/I3: a trailing colonpair adverb (`1 / 3 :round`,
+            // appended into `right` by `attach_trailing_adverbs`) is a
+            // genuine named argument to the user-defined `infix:<op>` sub —
+            // mint the named flavour, not the data default. Same
+            // bareword-fat-arrow/colonpair shape `is_named_arg_expr`
+            // recognizes elsewhere; a real operand that happens to be this
+            // exact shape (rare) was equally adverb-classified before this
+            // ADR, since this dispatch has always read only value flavour.
+            if matches!(r, Expr::Binary { op, .. } if *op == crate::token_kind::TokenKind::FatArrow)
+            {
+                self.mint_named_pair = true;
+            }
             self.compile_expr(r);
         }
         let name_idx = self.code.add_constant(Value::str(name.to_string()));

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -170,6 +170,13 @@ impl Compiler {
                 // that check could never actually distinguish the two shapes
                 // and instead misfired on every real `$x = ...`/`$x += ...`
                 // argument. See todo/tickets/compound-assign-as-call-argument-yields-pair.md.
+                // ADR-0021 I2/I3: a bareword-keyed fat-arrow (or colonpair,
+                // same AST shape) written directly as this argument mints
+                // the named-argument flavour, not the data default.
+                if matches!(arg, Expr::Binary { op, .. } if *op == crate::token_kind::TokenKind::FatArrow)
+                {
+                    s.mint_named_pair = true;
+                }
                 s.compile_expr(arg);
                 if Self::needs_decont(arg) {
                     s.code.emit(OpCode::Decont);
@@ -259,6 +266,12 @@ impl Compiler {
         // NON-escaping (the #2746 guard: `map {...}` / `lives-ok {...}` must not
         // box even when the whole call sits in an escaping position like
         // `my @r = map {...}`). `start` overrides this with `escaping = true`.
+        // ADR-0021 I2/I3: a bareword-keyed fat-arrow (or colonpair, same AST
+        // shape) written directly as this argument mints the named-argument
+        // flavour, not the data default.
+        if matches!(arg, Expr::Binary { op, .. } if *op == crate::token_kind::TokenKind::FatArrow) {
+            self.mint_named_pair = true;
+        }
         self.with_escape(escaping, |c| {
             c.with_suppress_pair_capture(true, |c| c.compile_expr(arg))
         });

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -756,12 +756,12 @@ impl Compiler {
                 } => {
                     self.compile_expr(&Expr::Literal(Value::str(name.clone())));
                     self.compile_expr(expr);
-                    self.code.emit(OpCode::MakePair);
+                    self.code.emit(OpCode::MakeNamedArg);
                 }
                 CallArg::Named { name, value: None } => {
                     self.compile_expr(&Expr::Literal(Value::str(name.clone())));
                     self.compile_expr(&Expr::Literal(Value::TRUE));
-                    self.code.emit(OpCode::MakePair);
+                    self.code.emit(OpCode::MakeNamedArg);
                 }
                 // `|EXPR` interpolates into the argument list: MakeSlip builds
                 // the Slip and the slip side table spreads exactly these

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -575,6 +575,18 @@ pub(crate) struct Compiler {
     /// semantics corrupt the *previous* iteration's bound cell instead of
     /// storing a fresh one (see the `lock.t` array-corruption investigation).
     bind_target_direct: bool,
+    /// ADR-0021 I2/I3: when true, the *immediate* upcoming `Expr::Binary{
+    /// FatArrow}` compile (`compile_expr_binary`) mints the named-argument
+    /// flavour (`OpCode::MakeNamedArg`) instead of the data-default
+    /// (`OpCode::MakePair`). Set only around compiling a call/method
+    /// argument that IS, at its top level, a bareword-keyed fat-arrow or
+    /// colonpair (`is_named_arg_expr`'s `Binary` arm — the same shape
+    /// `ContainerizePair` boundary erasure is skipped for, since the
+    /// call-site syntax already marks it named). `compile_expr_binary` reads
+    /// and clears this once at entry, before recursing into the key/value
+    /// sub-expressions, so a Pair nested in the value (`f(a => (b => 1))`)
+    /// does not inherit it — only the outermost, genuinely-named pair does.
+    mint_named_pair: bool,
     /// Variables declared as `constant` (no Scalar container).
     constant_vars: std::collections::HashSet<String>,
     /// Scalar variables `:=`-bound to a non-itemized value (no Scalar
@@ -761,6 +773,7 @@ impl Compiler {
             scalar_bind_autovivify: false,
             bind_terminal: false,
             bind_target_direct: false,
+            mint_named_pair: false,
             constant_vars: std::collections::HashSet::new(),
             noncontainer_bound_vars: std::collections::HashSet::new(),
             constant_vars_in_scope: std::collections::HashSet::new(),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2570,12 +2570,12 @@ impl Compiler {
                         } => {
                             self.compile_expr(&Expr::Literal(Value::str(name.clone())));
                             self.compile_expr(expr);
-                            self.code.emit(OpCode::MakePair);
+                            self.code.emit(OpCode::MakeNamedArg);
                         }
                         CallArg::Named { name, value: None } => {
                             self.compile_expr(&Expr::Literal(Value::str(name.clone())));
                             self.compile_expr(&Expr::Literal(Value::TRUE));
-                            self.code.emit(OpCode::MakePair);
+                            self.code.emit(OpCode::MakeNamedArg);
                         }
                         // `|EXPR` interpolates into the argument list: MakeSlip
                         // builds the Slip, which spreads when bound.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -866,7 +866,19 @@ pub(crate) enum OpCode {
     SetDoesContext(bool),
 
     // -- Pair --
+    /// Build a data-minted Pair (ADR-0021 I2): always the positional
+    /// (`ValuePair`) flavour. Used by every fat-arrow `a => b` compile
+    /// EXCEPT argument-position named-arg synthesis, which uses
+    /// `MakeNamedArg` instead.
     MakePair,
+    /// Build a named-argument-flavour Pair (ADR-0021 I2/I3): emitted only
+    /// by compiled argument-position synthesis (a literal `key => value` /
+    /// `:key(value)` written directly in an argument list, or a Capture
+    /// literal's named-lane element `\(:$a)`) that intends the in-band
+    /// named marker to reach the callee's binder. Same payload and runtime
+    /// shape as `MakePair` (pop value, pop key, push a Pair) — only the
+    /// resulting flavour differs.
+    MakeNamedArg,
     /// Convert Pair(k,v) → ValuePair(Str(k),v) so it's treated as positional arg
     ContainerizePair,
 

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -550,10 +550,24 @@ impl Interpreter {
             }
             "__mutsu_set_newline" => {
                 let pair = args.first().cloned().unwrap_or(Value::NIL);
-                let ValueView::Pair(name, value) = pair.view() else {
-                    return Err(RuntimeError::new(
-                        "use newline expects a colonpair argument",
-                    ));
+                // ADR-0021: `:lf` here is data compiled via the positional
+                // default (`ValuePair`), not a call-site named argument —
+                // accept either flavour, matching the value's own String key.
+                let (name, value) = match pair.view() {
+                    ValueView::Pair(name, value) => (name.clone(), value.clone()),
+                    ValueView::ValuePair(key, value) => match key.view() {
+                        ValueView::Str(s) => (s.to_string(), value.clone()),
+                        _ => {
+                            return Err(RuntimeError::new(
+                                "use newline expects a colonpair argument",
+                            ));
+                        }
+                    },
+                    _ => {
+                        return Err(RuntimeError::new(
+                            "use newline expects a colonpair argument",
+                        ));
+                    }
                 };
                 if !value.truthy() {
                     return Err(RuntimeError::new("use newline expects a true mode adverb"));

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -158,7 +158,8 @@ impl Interpreter {
                 // Hashes are decomposed into their pairs
                 ValueView::Hash(map) => {
                     for (k, v) in map.iter() {
-                        let pair = Value::pair(k.clone(), v.clone());
+                        // ADR-0021 I2: data-minted pairs default positional.
+                        let pair = Value::value_pair(Value::str(k.clone()), v.clone());
                         insert_value(&pair, &mut elems, &mut original_keys);
                     }
                 }
@@ -215,7 +216,8 @@ impl Interpreter {
                 // Hashes are flattened into their pairs (each pair is a single element)
                 ValueView::Hash(map) => {
                     for (k, v) in map.iter() {
-                        let pair = Value::pair(k.clone(), v.clone());
+                        // ADR-0021 I2: data-minted pairs default positional.
+                        let pair = Value::value_pair(Value::str(k.clone()), v.clone());
                         add_item(&mut counts, &mut original_keys, &pair);
                     }
                 }
@@ -271,7 +273,8 @@ impl Interpreter {
                 // Hashes are flattened into their pairs; each pair becomes a key
                 ValueView::Hash(map) => {
                     for (k, v) in map.iter() {
-                        let pair = Value::pair(k.clone(), v.clone());
+                        // ADR-0021 I2: data-minted pairs default positional.
+                        let pair = Value::value_pair(Value::str(k.clone()), v.clone());
                         insert_value(&pair, &mut weights, &mut original_keys);
                     }
                 }
@@ -351,7 +354,9 @@ impl Interpreter {
             .map(|v| v.to_string_value())
             .unwrap_or_default();
         let val = args.get(1).cloned().unwrap_or(Value::NIL);
-        Ok(Value::pair(key, val))
+        // ADR-0021 I2: `pair(...)` is a data constructor, not argument-list
+        // syntax — the result is a plain (positional-flavour) Pair.
+        Ok(Value::value_pair(Value::str(key), val))
     }
 
     pub(super) fn builtin_keys(&self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -61,9 +61,10 @@ impl Interpreter {
                     ValueView::Array(items, ..) => list_items.extend(items.iter().cloned()),
                     ValueView::Seq(items) => list_items.extend(items.iter().cloned()),
                     ValueView::Hash(map) => {
-                        // Hashes in list context flatten to key-value Pairs
+                        // Hashes in list context flatten to key-value Pairs.
+                        // ADR-0021 I2: data-minted pairs default positional.
                         for (k, v) in map.iter() {
-                            list_items.push(Value::pair(k.clone(), v.clone()));
+                            list_items.push(Value::value_pair(Value::str(k.clone()), v.clone()));
                         }
                     }
                     _ if arg.is_range() => {

--- a/src/runtime/methods_collection_ops/sort.rs
+++ b/src/runtime/methods_collection_ops/sort.rs
@@ -674,11 +674,7 @@ pub(crate) fn sort_value_generic(
 }
 
 /// Build a `key => weight` pair for a Set/Bag/Mix element, preserving the
-/// original key type (`ValuePair`) when it is not a plain string key.
-fn setty_typed_pair(typed_key: Value, str_key: &str, weight: Value) -> Value {
-    if matches!(typed_key.view(), ValueView::Str(sv) if sv.as_ref() == str_key) {
-        Value::pair(str_key.to_string(), weight)
-    } else {
-        Value::value_pair(typed_key, weight)
-    }
+/// original key type. ADR-0021 I2: data-minted pairs default positional.
+fn setty_typed_pair(typed_key: Value, _str_key: &str, weight: Value) -> Value {
+    Value::value_pair(typed_key, weight)
 }

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -496,10 +496,8 @@ impl Interpreter {
             let key = ks[idx].clone();
             let weight = remaining.remove(&key).unwrap_or(0.0);
             let weight_val = crate::value::mix_weight_to_value(weight);
-            grabbed.push(match mix.typed_key(&key).view() {
-                ValueView::Str(sk) => Value::pair(sk.to_string(), weight_val),
-                _ => Value::value_pair(mix.typed_key(&key), weight_val),
-            });
+            // ADR-0021 I2: data-minted pairs default positional.
+            grabbed.push(Value::value_pair(mix.typed_key(&key), weight_val));
         }
         // TODO: compile to bytecode - should mutate the original variable
         Some(Ok(Value::seq(grabbed)))
@@ -596,10 +594,11 @@ impl Interpreter {
             let idx = (builtin_rand() * ks.len() as f64) as usize % ks.len();
             let key = ks[idx].clone();
             let val = remaining.remove(&key).unwrap_or_default();
-            grabbed.push(match bag_data.typed_key(&key).view() {
-                ValueView::Str(sk) => Value::pair(sk.to_string(), Value::from_bigint(val)),
-                _ => Value::value_pair(bag_data.typed_key(&key), Value::from_bigint(val)),
-            });
+            // ADR-0021 I2: data-minted pairs default positional.
+            grabbed.push(Value::value_pair(
+                bag_data.typed_key(&key),
+                Value::from_bigint(val),
+            ));
         }
         Ok(Value::seq(grabbed))
     }

--- a/src/runtime/methods_enum_dispatch.rs
+++ b/src/runtime/methods_enum_dispatch.rs
@@ -50,7 +50,8 @@ impl Interpreter {
             }
             "pair" => {
                 let val = value.to_value();
-                Some(Ok(Value::pair(key.resolve(), val)))
+                // ADR-0021 I2: data-minted pairs default positional.
+                Some(Ok(Value::value_pair(Value::str(key.resolve()), val)))
             }
             "ACCEPTS" => {
                 if args.is_empty() {
@@ -113,9 +114,10 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         match method {
             "pairs" => {
+                // ADR-0021 I2: data-minted pairs default positional.
                 let pairs: Vec<Value> = variants
                     .iter()
-                    .map(|(k, v)| Value::pair(k.clone(), v.to_value()))
+                    .map(|(k, v)| Value::value_pair(Value::str(k.clone()), v.to_value()))
                     .collect();
                 Ok(Value::array(pairs))
             }

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -226,16 +226,35 @@ impl Interpreter {
                 } else if key == "c" || key == "continue" {
                     continue_pos = value.as_int().and_then(|n| usize::try_from(n).ok());
                 } else if key == "args" {
-                    // :args(\(42)) passes a Capture; :args(42,) passes an Array
+                    // :args(\(42)) passes a Capture; :args(42,) / :args(:arg(42),)
+                    // passes an Array. `rule_args` is a flat mixed vec that
+                    // `bind_function_args_values` (below) classifies by Pair
+                    // flavour, same as an ordinary call's argument vec — so
+                    // flatten the Capture's two lanes back into that shape,
+                    // and (ADR-0021) promote any Pair-shaped Array element to
+                    // the named flavour: a `:args(...)` element is a rule
+                    // argument regardless of the flavour a list literal
+                    // mints by default (verified against raku: `:args(
+                    // :arg(42),)` binds `rule(:$arg)`'s named param).
                     match value.view() {
-                        ValueView::Capture {
-                            positional,
-                            named: _,
-                        } => {
+                        ValueView::Capture { positional, named } => {
                             rule_args = positional.clone();
+                            rule_args.extend(
+                                named.iter().map(|(k, v)| Value::pair(k.clone(), v.clone())),
+                            );
                         }
                         ValueView::Array(arr, _) => {
-                            rule_args = arr.as_ref().clone().into_items();
+                            rule_args = arr
+                                .iter()
+                                .cloned()
+                                .map(|item| match item.view() {
+                                    ValueView::ValuePair(k, v) => match k.view() {
+                                        ValueView::Str(s) => Value::pair(s.to_string(), v.clone()),
+                                        _ => item,
+                                    },
+                                    _ => item,
+                                })
+                                .collect();
                         }
                         _ => {
                             rule_args = vec![value.clone()];

--- a/src/runtime/methods_object_native_ctors_buf_num.rs
+++ b/src/runtime/methods_object_native_ctors_buf_num.rs
@@ -294,11 +294,9 @@ impl Interpreter {
                 "new",
             ));
         };
-        if matches!(key.view(), ValueView::Str(_)) {
-            Ok(Value::pair(key.to_string_value(), value))
-        } else {
-            Ok(Value::value_pair(key, value))
-        }
+        // ADR-0021 I2: `Pair.new(...)` is a data constructor, not
+        // argument-list syntax — the result is always positional-flavour.
+        Ok(Value::value_pair(key, value))
     }
 
     /// Build an `IterationBuffer` from `.new(...)` as pure data: flatten each

--- a/src/runtime/methods_quanthash_ctor.rs
+++ b/src/runtime/methods_quanthash_ctor.rs
@@ -86,8 +86,12 @@ impl Interpreter {
         }
         for item in &items {
             let check_val = if unwrap_pair {
+                // ADR-0021: a Pair sitting in the list literal being passed
+                // to `.new` mints the positional flavour by default — unwrap
+                // it identically to the named flavour.
                 match item.view() {
                     ValueView::Pair(_, v) => v.clone(),
+                    ValueView::ValuePair(_, v) => v.clone(),
                     _ => item.clone(),
                 }
             } else {

--- a/src/runtime/methods_temporal.rs
+++ b/src/runtime/methods_temporal.rs
@@ -1,6 +1,22 @@
 use crate::builtins::methods_0arg::temporal;
 use crate::value::{RuntimeError, Value, ValueView};
 
+/// Read a `:2hours`/`:30minutes`-style adverb argument regardless of Pair
+/// flavour (ADR-0021): these adverbs are commonly collected into a list
+/// literal (`.later((:2hours, :30minutes))`), which is a positional
+/// (`ValuePair`) context, not a call site — the named flavour is not
+/// guaranteed. A `Str`-keyed positional Pair is treated identically.
+fn temporal_adverb_pair(v: &Value) -> Option<(String, Value)> {
+    match v.view() {
+        ValueView::Pair(key, value) => Some((key.clone(), value.clone())),
+        ValueView::ValuePair(key, value) => match key.view() {
+            ValueView::Str(s) => Some((s.to_string(), value.clone())),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 fn has_date_attrs(attributes: &crate::gc::Gc<crate::value::InstanceAttrs>) -> bool {
     attributes.contains_key("year")
         && attributes.contains_key("month")
@@ -290,14 +306,14 @@ fn date_later_earlier(
     };
 
     for arg in args {
-        if let ValueView::Pair(key, value) = arg.view() {
-            apply_pair(key, value)?;
+        if let Some((key, value)) = temporal_adverb_pair(arg) {
+            apply_pair(&key, &value)?;
             continue;
         }
         if let Some(items) = arg.as_list_items() {
             for item in items.iter() {
-                if let ValueView::Pair(key, value) = item.view() {
-                    apply_pair(key, value)?;
+                if let Some((key, value)) = temporal_adverb_pair(item) {
+                    apply_pair(&key, &value)?;
                 }
             }
         }
@@ -426,14 +442,14 @@ fn datetime_later_earlier(
     };
 
     for arg in args {
-        if let ValueView::Pair(key, value) = arg.view() {
-            apply_pair(key, value)?;
+        if let Some((key, value)) = temporal_adverb_pair(arg) {
+            apply_pair(&key, &value)?;
             continue;
         }
         if let Some(items) = arg.as_list_items() {
             for item in items.iter() {
-                if let ValueView::Pair(key, value) = item.view() {
-                    apply_pair(key, value)?;
+                if let Some((key, value)) = temporal_adverb_pair(item) {
+                    apply_pair(&key, &value)?;
                 }
             }
         }

--- a/src/runtime/ops_reduction.rs
+++ b/src/runtime/ops_reduction.rs
@@ -670,10 +670,8 @@ impl Interpreter {
             "!=:=" => Ok(Value::truth(!super::values_identical(left, right))),
             "===" => Ok(Value::truth(super::values_identical(left, right))),
             "!===" => Ok(Value::truth(!super::values_identical(left, right))),
-            "=>" => match left.view() {
-                ValueView::Str(_) => Ok(Value::pair(left.to_string_value(), right.clone())),
-                _ => Ok(Value::value_pair(left.clone(), right.clone())),
-            },
+            // ADR-0021 I2: data-minted pairs default positional.
+            "=>" => Ok(Value::value_pair(left.clone(), right.clone())),
             "&" => {
                 let mut vals = match left.view() {
                     ValueView::Junction {

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -63,7 +63,7 @@ impl Interpreter {
             match crate::parse_dispatch::parse_source(eval_expr)
                 .and_then(|(stmts, _)| self.eval_block_value(&stmts))
             {
-                Ok(value) => values.push(value),
+                Ok(value) => values.push(Self::namify_reparsed_colonpair_role_arg(expr, value)),
                 Err(_) if looks_like_type_arg_expr(expr) => {
                     values.push(Value::package(Symbol::intern(expr.trim())));
                 }
@@ -71,6 +71,31 @@ impl Interpreter {
             }
         }
         Ok(values)
+    }
+
+    /// A role type/parameter argument (`R[:a(1)]`) is re-parsed and evaluated
+    /// as a standalone source string, outside any argument-list AST node —
+    /// so the compiler's call-site named-ness detection (ADR-0021 I3, keyed
+    /// off `is_named_arg_expr`) never sees it, and a genuine colonpair
+    /// argument compiles through the data-minting default (positional)
+    /// instead of the named flavour `role_candidate_arity_ok` expects for a
+    /// `:$name`-shaped role parameter. `R[:a(1)]` IS argument-list syntax
+    /// conceptually (this is exactly the "internal runtime argument
+    /// synthesis" case the ADR carves out as correct to mint named on
+    /// purpose) — restore the named flavour when the source was a genuine
+    /// bareword colonpair (`:name(...)`/`:name`/`:!name`, not `::Type`).
+    fn namify_reparsed_colonpair_role_arg(source: &str, value: Value) -> Value {
+        let trimmed = source.trim_start();
+        if !trimmed.starts_with(':') || trimmed.starts_with("::") {
+            return value;
+        }
+        match value.view() {
+            ValueView::ValuePair(key, val) => match key.view() {
+                ValueView::Str(s) => Value::pair(s.to_string(), val.clone()),
+                _ => value,
+            },
+            _ => value,
+        }
     }
 
     fn role_constraint_specificity(&self, constraint: Option<&str>) -> i32 {

--- a/src/runtime/seq_helpers/signature_helpers.rs
+++ b/src/runtime/seq_helpers/signature_helpers.rs
@@ -121,14 +121,24 @@ impl Interpreter {
                 named.insert("denominator".to_string(), Value::int(d));
                 Some((Vec::new(), named))
             }
+            // ADR-0021: a Pair element contributes a named arg regardless of
+            // flavour here — this is signature *smart-matching* against a
+            // List of values (`(1, 2, :42c) ~~ :($a, $b, :$c)`), not a
+            // compiled call site, so the positional (`ValuePair`) default a
+            // list literal now mints must be recognized identically to the
+            // named flavour.
             _ if value.as_list_items().is_some() => {
                 let mut positional = Vec::new();
                 let mut named = HashMap::new();
                 for item in value.as_list_items().unwrap().iter() {
-                    if let ValueView::Pair(k, v) = item.view() {
-                        named.insert(k.clone(), v.clone());
-                    } else {
-                        positional.push(item.clone());
+                    match item.view() {
+                        ValueView::Pair(k, v) => {
+                            named.insert(k.clone(), v.clone());
+                        }
+                        ValueView::ValuePair(k, v) => {
+                            named.insert(k.to_string_value(), v.clone());
+                        }
+                        _ => positional.push(item.clone()),
                     }
                 }
                 Some((positional, named))
@@ -136,6 +146,11 @@ impl Interpreter {
             ValueView::Pair(k, v) => {
                 let mut named = HashMap::new();
                 named.insert(k.clone(), v.clone());
+                Some((Vec::new(), named))
+            }
+            ValueView::ValuePair(k, v) => {
+                let mut named = HashMap::new();
+                named.insert(k.to_string_value(), v.clone());
                 Some((Vec::new(), named))
             }
             ValueView::Instance { attributes, .. } => {

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -135,6 +135,102 @@ impl Interpreter {
         out
     }
 
+    /// `IO::Path/Str ~~ :e/:d/:f/:l/:r/:w/:x/:rw/:rwx/:s/:z` file-test result
+    /// (and negated forms `:!e`, ...), shared by the `Pair`- and
+    /// `ValuePair`-flavour match arms in `smart_match` below.
+    fn io_path_file_test_result(key: &str, val: &Value, path_str: Option<String>) -> bool {
+        let negated = val.as_bool() == Some(false);
+        let Some(p) = path_str else {
+            return negated;
+        };
+        let path = std::path::Path::new(&p);
+        let result = match key {
+            "e" => path.exists(),
+            "d" => path.is_dir(),
+            "f" => path.is_file(),
+            "l" => std::fs::symlink_metadata(&p)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false),
+            "r" => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::metadata(&p)
+                        .map(|m| m.permissions().mode() & 0o444 != 0)
+                        .unwrap_or(false)
+                }
+                #[cfg(not(unix))]
+                {
+                    path.exists()
+                }
+            }
+            "w" => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::metadata(&p)
+                        .map(|m| m.permissions().mode() & 0o222 != 0)
+                        .unwrap_or(false)
+                }
+                #[cfg(not(unix))]
+                {
+                    path.exists()
+                }
+            }
+            "x" => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::metadata(&p)
+                        .map(|m| m.permissions().mode() & 0o111 != 0)
+                        .unwrap_or(false)
+                }
+                #[cfg(not(unix))]
+                {
+                    false
+                }
+            }
+            "rw" => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::metadata(&p)
+                        .map(|m| {
+                            let mode = m.permissions().mode();
+                            mode & 0o444 != 0 && mode & 0o222 != 0
+                        })
+                        .unwrap_or(false)
+                }
+                #[cfg(not(unix))]
+                {
+                    std::fs::metadata(&p)
+                        .map(|m| !m.permissions().readonly())
+                        .unwrap_or(false)
+                }
+            }
+            "rwx" => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::metadata(&p)
+                        .map(|m| {
+                            let mode = m.permissions().mode();
+                            mode & 0o444 != 0 && mode & 0o222 != 0 && mode & 0o111 != 0
+                        })
+                        .unwrap_or(false)
+                }
+                #[cfg(not(unix))]
+                {
+                    false
+                }
+            }
+            "s" => std::fs::metadata(&p).map(|m| m.len() > 0).unwrap_or(false),
+            "z" => std::fs::metadata(&p).map(|m| m.len() == 0).unwrap_or(false),
+            _ => false,
+        };
+        if negated { !result } else { result }
+    }
+
     pub(crate) fn smart_match(&mut self, left: &Value, right: &Value) -> bool {
         // A regex literal that closed over its defining scope (`RegexCaptured`)
         // needs that scope live while its embedded code runs.
@@ -920,7 +1016,10 @@ impl Interpreter {
                 }
             },
             // IO::Path/Str ~~ Pair(:e), :d, :f, :r, :w, :x file tests
-            // Also handles negated forms: :!e, :!d, :!f, :!r, :!w, :!x, :!s, :!z
+            // Also handles negated forms: :!e, :!d, :!f, :!r, :!w, :!x, :!s, :!z.
+            // ADR-0021: a bare colonpair on the RHS of `~~` (`$file ~~ :e`) is
+            // not an argument list, so it mints the positional flavour by
+            // default — accept `ValuePair` identically to `Pair`.
             (
                 ValueView::Instance {
                     class_name,
@@ -935,98 +1034,26 @@ impl Interpreter {
                     "e" | "d" | "f" | "l" | "r" | "w" | "x" | "rw" | "rwx" | "s" | "z"
                 ) =>
             {
-                let negated = val.as_bool() == Some(false);
                 let path_str = attributes.as_map().get("path").map(|v| v.to_string_value());
-                if let Some(p) = path_str {
-                    let path = std::path::Path::new(&p);
-                    let result = match key.as_str() {
-                        "e" => path.exists(),
-                        "d" => path.is_dir(),
-                        "f" => path.is_file(),
-                        "l" => std::fs::symlink_metadata(&p)
-                            .map(|m| m.file_type().is_symlink())
-                            .unwrap_or(false),
-                        "r" => {
-                            #[cfg(unix)]
-                            {
-                                use std::os::unix::fs::PermissionsExt;
-                                std::fs::metadata(&p)
-                                    .map(|m| m.permissions().mode() & 0o444 != 0)
-                                    .unwrap_or(false)
-                            }
-                            #[cfg(not(unix))]
-                            {
-                                path.exists()
-                            }
-                        }
-                        "w" => {
-                            #[cfg(unix)]
-                            {
-                                use std::os::unix::fs::PermissionsExt;
-                                std::fs::metadata(&p)
-                                    .map(|m| m.permissions().mode() & 0o222 != 0)
-                                    .unwrap_or(false)
-                            }
-                            #[cfg(not(unix))]
-                            {
-                                path.exists()
-                            }
-                        }
-                        "x" => {
-                            #[cfg(unix)]
-                            {
-                                use std::os::unix::fs::PermissionsExt;
-                                std::fs::metadata(&p)
-                                    .map(|m| m.permissions().mode() & 0o111 != 0)
-                                    .unwrap_or(false)
-                            }
-                            #[cfg(not(unix))]
-                            {
-                                false
-                            }
-                        }
-                        "rw" => {
-                            #[cfg(unix)]
-                            {
-                                use std::os::unix::fs::PermissionsExt;
-                                std::fs::metadata(&p)
-                                    .map(|m| {
-                                        let mode = m.permissions().mode();
-                                        mode & 0o444 != 0 && mode & 0o222 != 0
-                                    })
-                                    .unwrap_or(false)
-                            }
-                            #[cfg(not(unix))]
-                            {
-                                std::fs::metadata(&p)
-                                    .map(|m| !m.permissions().readonly())
-                                    .unwrap_or(false)
-                            }
-                        }
-                        "rwx" => {
-                            #[cfg(unix)]
-                            {
-                                use std::os::unix::fs::PermissionsExt;
-                                std::fs::metadata(&p)
-                                    .map(|m| {
-                                        let mode = m.permissions().mode();
-                                        mode & 0o444 != 0 && mode & 0o222 != 0 && mode & 0o111 != 0
-                                    })
-                                    .unwrap_or(false)
-                            }
-                            #[cfg(not(unix))]
-                            {
-                                false
-                            }
-                        }
-                        "s" => std::fs::metadata(&p).map(|m| m.len() > 0).unwrap_or(false),
-                        "z" => std::fs::metadata(&p).map(|m| m.len() == 0).unwrap_or(false),
-                        _ => false,
-                    };
-                    if negated { !result } else { result }
-                } else {
-                    negated
-                }
+                Self::io_path_file_test_result(key.as_str(), val, path_str)
+            }
+            (
+                ValueView::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                },
+                ValueView::ValuePair(key, val),
+            ) if Self::is_io_path_lexical_class(class_name.as_str())
+                && val.as_bool().is_some()
+                && matches!(key.view(), ValueView::Str(s) if matches!(
+                    s.as_str(),
+                    "e" | "d" | "f" | "l" | "r" | "w" | "x" | "rw" | "rwx" | "s" | "z"
+                )) =>
+            {
+                let key = key.to_string_value();
+                let path_str = attributes.as_map().get("path").map(|v| v.to_string_value());
+                Self::io_path_file_test_result(&key, val, path_str)
             }
             // Hash ~~ Pair: check that key exists in hash and value smartmatches
             // Hash ~~ Pair: look up the pair's key and smartmatch the hash value

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -551,22 +551,27 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
         // yields three `* => True` pairs, so `@a.elems == 3`). This mirrors
         // `value_to_list`. (Note: an array *literal* `[set(...)]` does NOT
         // flatten — that path is handled separately in `exec_make_array_op`.)
+        // ADR-0021 I2: data-minted pairs default positional.
         ValueView::Set(items, _) => Value::real_array(
             items
                 .iter()
-                .map(|s| Value::pair(s.clone(), Value::TRUE))
+                .map(|s| Value::value_pair(Value::str(s.clone()), Value::TRUE))
                 .collect(),
         ),
         ValueView::Bag(items, _) => Value::real_array(
             items
                 .iter()
-                .map(|(k, v)| Value::pair(k.clone(), Value::from_bigint(v.clone())))
+                .map(|(k, v)| {
+                    Value::value_pair(Value::str(k.clone()), Value::from_bigint(v.clone()))
+                })
                 .collect(),
         ),
         ValueView::Mix(items, _) => Value::real_array(
             items
                 .iter()
-                .map(|(k, v)| Value::pair(k.clone(), crate::value::mix_weight_to_value(*v)))
+                .map(|(k, v)| {
+                    Value::value_pair(Value::str(k.clone()), crate::value::mix_weight_to_value(*v))
+                })
                 .collect(),
         ),
         // A WalkList assigned to an `@` variable flattens to its candidate

--- a/src/runtime/utils/quanthash_keys.rs
+++ b/src/runtime/utils/quanthash_keys.rs
@@ -43,12 +43,10 @@ pub(crate) fn record_quanthash_original(
 }
 
 /// Build the `elem => weight` Pair for a QuantHash entry from the decoded
-/// element object (Str elements keep the string-keyed Pair form).
+/// element object. ADR-0021 I2: data-minted pairs default positional,
+/// regardless of the element's own type.
 pub(crate) fn quanthash_typed_pair(elem: Value, v: Value) -> Value {
-    match elem.view() {
-        ValueView::Str(s) => Value::pair(s.to_string(), v),
-        _ => Value::value_pair(elem, v),
-    }
+    Value::value_pair(elem, v)
 }
 
 /// Merge a source QuantHash's recorded original keys into an accumulator

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -76,13 +76,11 @@ impl Interpreter {
         if itemized {
             return vec![Value::hash_with_data_itemized(gc.clone(), true)];
         }
+        // ADR-0021 I2: data-minted pairs default positional.
         gc.keys()
             .map(|k| {
                 let vref = Value::hash_entry_ref_eager(gc.clone(), vec![k.clone()]);
-                match gc.typed_key(k).view() {
-                    ValueView::Str(s) => Value::pair((**s).clone(), vref),
-                    _ => Value::value_pair(gc.typed_key(k), vref),
-                }
+                Value::value_pair(gc.typed_key(k), vref)
             })
             .collect()
     }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2204,6 +2204,10 @@ impl Interpreter {
                 self.exec_make_pair_op(code);
                 *ip += 1;
             }
+            OpCode::MakeNamedArg => {
+                self.exec_make_named_arg_op(code);
+                *ip += 1;
+            }
             OpCode::ContainerizePair => {
                 let val = self.stack.pop().unwrap();
                 let containerized = match val.view() {

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -230,6 +230,16 @@ impl Interpreter {
             || matches!(v.view(), ValueView::Scalar(_))
     }
 
+    /// A Pair's (key, value) regardless of flavour, as a `(Value, Value)`
+    /// key/value pair ready to feed back into `Value::value_pair`.
+    fn as_pair_key_value(v: &Value) -> Option<(Value, Value)> {
+        match v.view() {
+            ValueView::Pair(k, val) => Some((Value::str(k.clone()), val.clone())),
+            ValueView::ValuePair(k, val) => Some((k.clone(), val.clone())),
+            _ => None,
+        }
+    }
+
     /// Apply a hyper binary op to a pair of values, recursing into nested
     /// Iterables so that e.g. `(1, {a=>2}, 4) <<~>> <a b c>` distributes the
     /// op into the hash element, yielding `("1a", {a=>"2b"}, "4c")`.
@@ -310,19 +320,23 @@ impl Interpreter {
         // applies when the *other* side is a plain scalar (not itself a Pair
         // or an Iterable) — those cases fall through to the generic
         // element-wise/base-case handling below.
-        if let ValueView::Pair(k, v) = left.view()
+        // ADR-0021 I2: data-minted pairs default positional. A Pair leaf is
+        // just as likely to be the positional flavour here (e.g. `(a => 1)
+        // »+» 1`, an expression-level pair, not a call argument), so match
+        // both.
+        if let Some((k, v)) = Self::as_pair_key_value(left)
             && !right.is_string_pair_value()
             && !Self::is_listy(right)
         {
-            let new_v = self.hyper_op_pair(op, v, right, dwim_left, dwim_right)?;
-            return Ok(Value::pair(k.clone(), new_v));
+            let new_v = self.hyper_op_pair(op, &v, right, dwim_left, dwim_right)?;
+            return Ok(Value::value_pair(k, new_v));
         }
-        if let ValueView::Pair(k, v) = right.view()
+        if let Some((k, v)) = Self::as_pair_key_value(right)
             && !left.is_string_pair_value()
             && !Self::is_listy(left)
         {
-            let new_v = self.hyper_op_pair(op, left, v, dwim_left, dwim_right)?;
-            return Ok(Value::pair(k.clone(), new_v));
+            let new_v = self.hyper_op_pair(op, left, &v, dwim_left, dwim_right)?;
+            return Ok(Value::value_pair(k, new_v));
         }
         // At least one side is a (non-hash) Iterable: distribute element-wise,
         // recursing so nested Iterables/Hashes are handled at every depth.

--- a/src/vm/vm_jit_support.rs
+++ b/src/vm/vm_jit_support.rs
@@ -110,6 +110,7 @@ pub(super) fn step_supported(op: &OpCode) -> bool {
             | OpCode::MakeRealArrayNoFlatten(_)
             | OpCode::MakeHash(_)
             | OpCode::MakePair
+            | OpCode::MakeNamedArg
             | OpCode::CoerceToList
             | OpCode::Itemize
             | OpCode::DeitemizeZen

--- a/src/vm/vm_meta_ops.rs
+++ b/src/vm/vm_meta_ops.rs
@@ -123,9 +123,10 @@ impl Interpreter {
                         results.push(Value::array(vec![left_iter.nth(i), right_iter.nth(i)]));
                     }
                 } else if op == "=>" {
+                    // ADR-0021 I2: data-minted pairs default positional.
                     for i in 0..len {
                         let key = left_iter.nth(i).to_string_value();
-                        results.push(Value::pair(key, right_iter.nth(i)));
+                        results.push(Value::value_pair(Value::str(key), right_iter.nth(i)));
                     }
                 } else {
                     // Check for 3-way zip reduction case ([Z+] a, b, c)

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -480,14 +480,48 @@ impl Interpreter {
         Ok(())
     }
 
+    /// `OpCode::MakePair`: build a data-minted Pair (ADR-0021 I2), always the
+    /// positional flavour — this is every fat-arrow compile except
+    /// argument-position named-arg synthesis (`OpCode::MakeNamedArg`, below).
     pub(super) fn exec_make_pair_op(&mut self, code: &crate::opcode::CompiledCode) {
+        let (left, right) = self.pop_pair_operands_capturing(code);
+        self.stack.push(Value::value_pair(left, right));
+    }
+
+    /// `OpCode::MakeNamedArg`: build a named-argument-flavour Pair (ADR-0021
+    /// I2/I3). Emitted only where the call-site syntax genuinely intends a
+    /// named argument (a literal `key => value` / `:key(value)` written
+    /// directly in an argument list, or a Capture literal's named-lane
+    /// element `\(:$a)`) — preserving the in-band named marker those sites
+    /// need to reach the callee's binder / `ExecCallPairs`.
+    pub(super) fn exec_make_named_arg_op(&mut self, code: &crate::opcode::CompiledCode) {
+        let (left, right) = self.pop_pair_operands_capturing(code);
+        // Preserve the original key type for `.key` to return the correct type.
+        // Use ValuePair for non-string keys, Pair (the named flavour) for
+        // string keys — the shape every named-arg key actually has.
+        match left.view() {
+            ValueView::Str(_) => {
+                let key = left.to_string_value();
+                self.stack.push(Value::pair(key, right));
+            }
+            _ => {
+                self.stack.push(Value::value_pair(left, right));
+            }
+        }
+    }
+
+    /// Shared operand pop for `MakePair`/`MakeNamedArg`: `key => $var` tags
+    /// the RHS scalar variable with `WrapVarRef`, so capture its container.
+    /// The Pair's value becomes a `ContainerRef` shared with `$var`, giving
+    /// Raku's write-through semantics: `$pair.value = X` updates `$var`, and
+    /// `$pair.value<k> = v` writes through to `$var`'s backing Array/Hash.
+    /// (See S02:1704 / roast S02-types/pair.t.)
+    fn pop_pair_operands_capturing(
+        &mut self,
+        code: &crate::opcode::CompiledCode,
+    ) -> (Value, Value) {
         let mut right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        // `key => $var`: the RHS scalar variable was tagged with `WrapVarRef`, so
-        // capture its container. The Pair's value becomes a `ContainerRef` shared
-        // with `$var`, giving Raku's write-through semantics: `$pair.value = X`
-        // updates `$var`, and `$pair.value<k> = v` writes through to `$var`'s
-        // backing Array/Hash. (See S02:1704 / roast S02-types/pair.t.)
         if let ValueView::VarRef {
             name: source_name,
             value: inner,
@@ -498,16 +532,6 @@ impl Interpreter {
             let inner = inner.clone();
             right = self.capture_var_cell(code, &source_name, inner);
         }
-        // Preserve the original key type for `.key` to return the correct type.
-        // Use ValuePair for non-string keys, Pair for string keys.
-        match left.view() {
-            ValueView::Str(_) => {
-                let key = left.to_string_value();
-                self.stack.push(Value::pair(key, right));
-            }
-            _ => {
-                self.stack.push(Value::value_pair(left, right));
-            }
-        }
+        (left, right)
     }
 }

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -82,6 +82,101 @@ fn is_numericish_matcher(v: &Value) -> bool {
     }
 }
 
+/// `IO::Path ~~ :e/:d/:f/:l/:r/:w/:x/:rw/:rwx/:s/:z` file-test result (and
+/// negated forms `:!e`, ...), shared by the `Pair`- and `ValuePair`-flavour
+/// match arms in `pure_smart_match` below.
+fn io_path_file_test_result(key: &str, negated: bool, path_str: Option<String>) -> bool {
+    let Some(p) = path_str else {
+        return negated;
+    };
+    let path = std::path::Path::new(&p);
+    let result = match key {
+        "e" => path.exists(),
+        "d" => path.is_dir(),
+        "f" => path.is_file(),
+        "r" => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::metadata(&p)
+                    .map(|m| m.permissions().mode() & 0o444 != 0)
+                    .unwrap_or(false)
+            }
+            #[cfg(not(unix))]
+            {
+                path.exists()
+            }
+        }
+        "w" => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::metadata(&p)
+                    .map(|m| m.permissions().mode() & 0o222 != 0)
+                    .unwrap_or(false)
+            }
+            #[cfg(not(unix))]
+            {
+                path.exists()
+            }
+        }
+        "x" => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::metadata(&p)
+                    .map(|m| m.permissions().mode() & 0o111 != 0)
+                    .unwrap_or(false)
+            }
+            #[cfg(not(unix))]
+            {
+                false
+            }
+        }
+        "rw" => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::metadata(&p)
+                    .map(|m| {
+                        let mode = m.permissions().mode();
+                        mode & 0o444 != 0 && mode & 0o222 != 0
+                    })
+                    .unwrap_or(false)
+            }
+            #[cfg(not(unix))]
+            {
+                std::fs::metadata(&p)
+                    .map(|m| !m.permissions().readonly())
+                    .unwrap_or(false)
+            }
+        }
+        "rwx" => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::metadata(&p)
+                    .map(|m| {
+                        let mode = m.permissions().mode();
+                        mode & 0o444 != 0 && mode & 0o222 != 0 && mode & 0o111 != 0
+                    })
+                    .unwrap_or(false)
+            }
+            #[cfg(not(unix))]
+            {
+                false
+            }
+        }
+        "l" => std::fs::symlink_metadata(&p)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false),
+        "s" => std::fs::metadata(&p).map(|m| m.len() > 0).unwrap_or(false),
+        "z" => std::fs::metadata(&p).map(|m| m.len() == 0).unwrap_or(false),
+        _ => false,
+    };
+    if negated { !result } else { result }
+}
+
 pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
     // An allomorph / numeric mixin (`<5.0>` RatStr) on the LHS compares by its
     // numeric base when the matcher is numeric: `<5.0> ~~ 5` and `<5.0> ~~ <5>`
@@ -399,7 +494,9 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
         })),
 
         // Scalar ~~ Hash: check key existence
-        // (but not for types that have more specific matches above)
+        // (but not for types that have more specific matches above — a Pair
+        // LHS, either flavour, defers to the interpreter's dedicated
+        // Hash ~~ Pair key/value-match semantics, ADR-0021)
         (_, ValueView::Hash(map))
             if !matches!(
                 left.view(),
@@ -408,6 +505,7 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
                     | ValueView::Hash(_)
                     | ValueView::Array(..)
                     | ValueView::Pair(..)
+                    | ValueView::ValuePair(..)
             ) && !needs_interpreter_lhs(left) =>
         {
             let key = left.to_string_value();
@@ -482,6 +580,9 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
         // IO::Path ~~ Pair(:e), :d, :f, :r, :w, :x, :rw, :rwx, :s, :z file tests
         // Also handles negated forms: :!e, :!d, :!f, :!r, :!w, :!x, :!rw, :!rwx, :!s, :!z
         // Note: Str ~~ :d is NOT supported (per Raku spec, only IO::Path has these methods)
+        // ADR-0021: a bare colonpair on the RHS of `~~` (`$file ~~ :e`) is not
+        // an argument list, so it mints the positional flavour by default —
+        // accept `ValuePair` identically to `Pair`.
         (
             ValueView::Instance {
                 class_name,
@@ -498,96 +599,26 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
         {
             let negated = matches!(val.view(), ValueView::Bool(false));
             let path_str = attributes.as_map().get("path").map(|v| v.to_string_value());
-            if let Some(p) = path_str {
-                let path = std::path::Path::new(&p);
-                let result = match key.as_str() {
-                    "e" => path.exists(),
-                    "d" => path.is_dir(),
-                    "f" => path.is_file(),
-                    "r" => {
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::PermissionsExt;
-                            std::fs::metadata(&p)
-                                .map(|m| m.permissions().mode() & 0o444 != 0)
-                                .unwrap_or(false)
-                        }
-                        #[cfg(not(unix))]
-                        {
-                            path.exists()
-                        }
-                    }
-                    "w" => {
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::PermissionsExt;
-                            std::fs::metadata(&p)
-                                .map(|m| m.permissions().mode() & 0o222 != 0)
-                                .unwrap_or(false)
-                        }
-                        #[cfg(not(unix))]
-                        {
-                            path.exists()
-                        }
-                    }
-                    "x" => {
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::PermissionsExt;
-                            std::fs::metadata(&p)
-                                .map(|m| m.permissions().mode() & 0o111 != 0)
-                                .unwrap_or(false)
-                        }
-                        #[cfg(not(unix))]
-                        {
-                            false
-                        }
-                    }
-                    "rw" => {
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::PermissionsExt;
-                            std::fs::metadata(&p)
-                                .map(|m| {
-                                    let mode = m.permissions().mode();
-                                    mode & 0o444 != 0 && mode & 0o222 != 0
-                                })
-                                .unwrap_or(false)
-                        }
-                        #[cfg(not(unix))]
-                        {
-                            std::fs::metadata(&p)
-                                .map(|m| !m.permissions().readonly())
-                                .unwrap_or(false)
-                        }
-                    }
-                    "rwx" => {
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::PermissionsExt;
-                            std::fs::metadata(&p)
-                                .map(|m| {
-                                    let mode = m.permissions().mode();
-                                    mode & 0o444 != 0 && mode & 0o222 != 0 && mode & 0o111 != 0
-                                })
-                                .unwrap_or(false)
-                        }
-                        #[cfg(not(unix))]
-                        {
-                            false
-                        }
-                    }
-                    "l" => std::fs::symlink_metadata(&p)
-                        .map(|m| m.file_type().is_symlink())
-                        .unwrap_or(false),
-                    "s" => std::fs::metadata(&p).map(|m| m.len() > 0).unwrap_or(false),
-                    "z" => std::fs::metadata(&p).map(|m| m.len() == 0).unwrap_or(false),
-                    _ => false,
-                };
-                Some(if negated { !result } else { result })
-            } else {
-                Some(negated)
-            }
+            Some(io_path_file_test_result(key.as_str(), negated, path_str))
+        }
+        (
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            },
+            ValueView::ValuePair(key, val),
+        ) if is_io_path_family(&class_name)
+            && matches!(val.view(), ValueView::Bool(_))
+            && matches!(key.view(), ValueView::Str(s) if matches!(
+                s.as_str(),
+                "e" | "d" | "f" | "l" | "r" | "w" | "x" | "rw" | "rwx" | "s" | "z"
+            )) =>
+        {
+            let negated = matches!(val.view(), ValueView::Bool(false));
+            let key = key.to_string_value();
+            let path_str = attributes.as_map().get("path").map(|v| v.to_string_value());
+            Some(io_path_file_test_result(&key, negated, path_str))
         }
 
         // Str/Int/Cool ~~ IO::Path: convert LHS to IO::Path and compare cleanup.absolute

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -307,9 +307,12 @@ impl Interpreter {
         value: Value,
     ) -> Result<Value, RuntimeError> {
         match value.view() {
-            // Associative types are preserved as-is
+            // Associative types are preserved as-is. A Pair is Associative
+            // regardless of flavour (ADR-0021: named-ness is a call-site
+            // marker, not a semantic difference here).
             ValueView::Hash(_)
             | ValueView::Pair(..)
+            | ValueView::ValuePair(..)
             | ValueView::Set(..)
             | ValueView::Bag(..)
             | ValueView::Mix(..) => Ok(value),

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -711,6 +711,54 @@ impl Interpreter {
                 }
             }
         }
+        // A Pair value (either flavour) answers `<key>` element access
+        // (`(a => 1)<a>` reads its own `.value`, any other key reads Nil).
+        // Unlike the `.value` *accessor*, which writes through a `key =>
+        // $var` capture's shared container, Raku's Associative subscript
+        // protocol on a Pair has no writable element slot at all — even a
+        // captured value's `<key> = ...` dies (verified against raku: only
+        // `.value = ...` writes through). Assigning through any key
+        // (existing or absent) dies, and binding into one is rejected
+        // outright, regardless of whether the binding itself is `constant`.
+        // `my $p = a => 1; $p<a> = 9` dies with "Cannot modify an immutable
+        // Int (1)" in raku for a completely ordinary (non-constant) `my $p`.
+        if let Some(target_val) = self.env().get(&var_name)
+            && let Some((pair_key, pair_value)) = match target_val.view() {
+                ValueView::Pair(k, v) => Some((k.clone(), v.clone())),
+                ValueView::ValuePair(k, v) => Some((k.to_string_value(), v.clone())),
+                _ => None,
+            }
+        {
+            if bind_mode {
+                return Err(RuntimeError::typed(
+                    "X::Bind",
+                    [(
+                        "message".to_string(),
+                        Value::str("Cannot bind to Pair".to_string()),
+                    )]
+                    .into_iter()
+                    .collect(),
+                ));
+            }
+            let elem_value = if pair_key == idx.to_string_value() {
+                pair_value.deref_container()
+            } else {
+                Value::NIL
+            };
+            let message = if matches!(elem_value.view(), ValueView::Nil) {
+                "Cannot modify an immutable Nil value".to_string()
+            } else {
+                format!(
+                    "Cannot modify an immutable {} ({})",
+                    crate::runtime::utils::value_type_name(&elem_value),
+                    elem_value.to_string_value()
+                )
+            };
+            let mut attrs = HashMap::new();
+            attrs.insert("message".to_string(), Value::str(message));
+            attrs.insert("value".to_string(), elem_value);
+            return Err(RuntimeError::typed("X::Assignment::RO", attrs));
+        }
         // Mix/Set/Bag: prevent auto-vivification of undefined typed variables.
         // When `my Mix $m; $m<key> = val`, the variable is undefined (Nil or
         // type object) but has an immutable type constraint.

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -136,9 +136,20 @@ impl Interpreter {
                 ValueView::Hash(map) => Some(map.clone()),
                 // A Pair answers `<key>:exists` for its own key: treat it as a
                 // single-entry map (`(a => 5)<a>:exists` is True, `<b>` False).
+                // ADR-0021: a Pair held in a variable or built outside a call
+                // argument list mints the positional flavour by default, so
+                // accept `ValuePair` identically.
                 ValueView::Pair(key, value) => {
                     let mut m = std::collections::HashMap::new();
                     m.insert((*key).clone(), (*value).clone());
+                    match Value::hash(m).view() {
+                        ValueView::Hash(map) => Some(map.clone()),
+                        _ => None,
+                    }
+                }
+                ValueView::ValuePair(key, value) => {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert(key.to_string_value(), (*value).clone());
                     match Value::hash(m).view() {
                         ValueView::Hash(map) => Some(map.clone()),
                         _ => None,

--- a/t/pair-value-consumers-accept-both-flavors.t
+++ b/t/pair-value-consumers-accept-both-flavors.t
@@ -1,0 +1,60 @@
+use Test;
+plan 9;
+
+# ADR-0021 P3 (I2): data-minted pairs default positional. A number of
+# consumers read a Pair-shaped value from data (not a call boundary) --
+# e.g. a variable, a list literal, or a bracketed role argument -- and must
+# accept the positional flavour identically to the (now rarer) named one.
+
+# QuantHash .pairs feeding a typed positional parameter (the ADR's original
+# motivating bug: Cro::HTTP::Client misbinding headers built this way).
+my $bag = bag <a b b c c c>;
+my @seen;
+sub show(Pair $p) { @seen.push("{$p.key}={$p.value}") }
+$bag.pairs.map(&show);
+is @seen.sort.join(','), 'a=1,b=2,c=3', '$bag.pairs.map(&show) binds each Pair positionally';
+
+# IO::Path file-test smartmatch with a bare colonpair (not a call argument).
+{
+    my $f = $*TMPDIR.add("adr0021-pair-consumer-filetest");
+    spurt $f, "x";
+    ok $f.IO ~~ :e, 'IO::Path ~~ :e (bare colonpair) still matches';
+    unlink $f;
+}
+
+# `<key>:exists` on a Pair held in a variable.
+my $p = a => 5;
+ok $p<a>:exists, 'variable-held Pair<key>:exists is True for its own key';
+nok $p<b>:exists, 'variable-held Pair<key>:exists is False for another key';
+
+# Hyper op on an expression-level Pair (not a call argument).
+is (a => 1) »+» 1, (a => 2), 'hyperop broadcasts into a positional-flavour Pair leaf';
+
+# DateTime.later with a list of adverb-shaped Pairs (not call arguments).
+{
+    my $now = DateTime.now;
+    is-deeply $now.later((:2hours, :30minutes)), $now.later(:2hours).later(:30minutes),
+        'DateTime.later(list-of-pairs) matches chained named-arg calls';
+}
+
+# Role bracket-argument colonpair (re-parsed standalone, not compiled in
+# argument position) still binds a role's named type parameter.
+{
+    role R[:$a = 1, :$b = $a * 2] {
+        method foo { "$a-$b" }
+    }
+    role S does R[:a(5)] { };
+    is S.new.foo, '5-10', 'role bracket colonpair argument binds the named role parameter';
+}
+
+# Grammar `.parse(..., :args(...))` with an Array of adverb-shaped Pairs.
+{
+    grammar H { rule r(:$arg) { { $arg == 42 } } }
+    ok H.parse('', :rule<r>, :args(:arg(42),)), ':args(Array-of-pairs) binds the rule\'s named param';
+}
+
+# `constant %M` from a single Pair, and subscript-assignment immutability.
+{
+    my constant %M = (a => 1);
+    is %M.WHAT.gist, '(Pair)', 'constant % from a single Pair stays a Pair (not coerced to Map)';
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of [ADR-0021](docs/adr/0021-argument-namedness-is-a-call-site-property.md) — the highest-risk phase per the ADR's own history (an earlier attempt aborted mid-file against the Cro suite). P3a (already merged) was the prerequisite prep for this.

**Minting-default flip (I2):** every enumerated data-minting site (`quanthash_typed_pair` + its 3 clones, `hash_live_pairs`, enum `.pair`/`.pairs`, `Capture.pairs`' named lane, `Match.pairs`, `Z=>`, `[=>]` reduction, `pair()`, `Pair.new`, `.antipair`, the map/grep and set/bag/mix hash-flattens, `coerce_containers.rs`'s Set/Bag/Mix list-context flatten) now mints `Value::value_pair` (positional) instead of `Value::pair` (named).

**Opcode split (I3):** `MakePair` becomes positional-minting (the new data default); a new `MakeNamedArg` opcode — same payload, same shared VarRef-capture helper — is emitted only by genuine argument-position synthesis: a bareword-keyed fat-arrow/colonpair written directly in a call/`CallOn` argument list, a Capture literal's named-lane element, a trailing operator adverb (`1 / 3 :round`), and declaration-time trait/role arguments (`is foo(:bar(1))`, `role B does A[:a(1)]` — compiled as a standalone re-entrant chunk, so a `mint_named_pair` flag threads through `compile_decl_expr` to restore it there). A `mint_named_pair` compiler flag (read-and-cleared at the top of `compile_expr_binary`, mirroring the existing `bind_target_direct` pattern) carries the signal from each call site to the one `Expr::Binary{FatArrow}` compile that needs it, without leaking into a Pair nested in the argument's own value.

**Consumer widening:** an audit of every `ValueView::Pair`-only match site (a consumer that assumed "named is the default" is now exactly as likely to see positional) found ~10 more sites needing a `ValuePair` sibling: the hyperop Pair-leaf broadcast, the IO::Path file-test smartmatch in both the interpreter and VM-native dispatcher (`$file ~~ :e`), the generic Hash-smartmatch exclusion list, `<key>:exists` on a Pair, `Set[T].new`'s unwrap_pair check, and `DateTime.later`/`.earlier`/`.clone`'s adverb-list reader. Also fixed two sites that re-parse a colonpair as a standalone source string outside any call-site AST (so compile-time named-ness detection can't reach them): role-parameterization's `eval_role_arg_values` and `Grammar.parse(..., :args(...))`'s adverb Array reader.

**Bonus fix surfaced along the way:** `%hashvar<key> = val` never checked whether the target was a Pair whose value is immutable — masked before because `constant %M = (a => 1)` was incorrectly coerced to a Map (a mutsu-only workaround this PR's correct fix stops shadowing). Verified against raku: this dies even for an ordinary non-constant `my $p = a => 1; $p<a> = 9`, and even `.value = 9` accessor write-through does NOT extend to `<key> =` subscript assignment.

## Test plan

- New pin `t/pair-value-consumers-accept-both-flavors.t` covering the consumer-widening fixes; every assertion verified against `raku` first.
- `$bag.pairs.map(&show)` binds — the ADR's original motivating bug (`Cro::HTTP::Client` misbinding `headers => [Authorization => '...']`).
- Full local `make roast` (1435 files): clean **PASS**, only the three pre-existing TODO-passed entries (`smiley.t`, `wacky.t`, `CollationTest_NON_IGNORABLE-2.t`), unrelated to this change.
- `make test`: 2974 files, 28019 tests, all green.
- `cargo test opcode_size_guard`: still holds the 48-byte `OpCode` budget with the new `MakeNamedArg` variant.
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)