### PR TITLE
docs(adr): ADR-0021 P4 — fix stale ValuePair doc comments, mark Accepted

### DIFF
--- a/docs/adr/0021-argument-namedness-is-a-call-site-property.md
+++ b/docs/adr/0021-argument-namedness-is-a-call-site-property.md
@@ -1,6 +1,6 @@
 # ADR-0021: Argument named-ness is a call-site property — Pair flavour unification
 
-- **Status**: Proposed
+- **Status**: Accepted (P1-P3a and P3 shipped; P4 cleanup and P5 measured perf follow-up remain — see Implementation status below)
 - **Date**: 2026-08-08
 - **Related**:
   [todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md](../../todo/deep/pair-namedness-is-a-value-property-not-a-call-site-property.md),

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,4 +46,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0018](0018-slot-addressed-lexical-capture-and-env-sync.md) | Slot-addressed lexical capture and env synchronization | Accepted |
 | [0019](0019-compiled-declarations-and-unified-method-dispatch.md) | Compile declarations and unify method dispatch entries | Proposed |
 | [0020](0020-shared-worker-pool.md) | Shared worker pool — elastic growth, blocking `await` | Accepted (all slices landed; per-task clone slimming tracked separately) |
-| [0021](0021-argument-namedness-is-a-call-site-property.md) | Argument named-ness is a call-site property — Pair flavour unification | Proposed |
+| [0021](0021-argument-namedness-is-a-call-site-property.md) | Argument named-ness is a call-site property — Pair flavour unification | Accepted (P1-P3a and P3 shipped; P4/P5 remain) |

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1342,8 +1342,17 @@ pub(in crate::value) enum ValueRepr {
         name: Symbol,
         is_regex: bool,
     },
+    /// The named-argument-flavour Pair (ADR-0021): a transient marker that
+    /// only a call-site (a bareword-keyed fat-arrow/colonpair written
+    /// directly in an argument list) may mint. No value-producing operation
+    /// — a literal outside an argument list, a constructor, `.pairs`,
+    /// iteration, coercion — may return one; see `ValuePair` below for that.
     Pair(String, Box<Value>),
-    /// Pair with a non-string key (preserves the original key type for `.key`)
+    /// The positional (data) flavour of Pair — the default for everything
+    /// that isn't call-site argument syntax, including a plain string key
+    /// (not just a non-string typed key, despite the name predating
+    /// ADR-0021's minting-default flip; preserves the original key type/
+    /// value for `.key`/`.value`).
     ValuePair(Box<Value>, Box<Value>),
     Enum {
         enum_type: Symbol,

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -101,12 +101,11 @@ impl HashData {
         Value::Str(Arc::new(str_key.to_string()))
     }
 
-    /// Build a `Pair` for a hash entry, using the original typed key for object
-    /// hashes. Plain string keys yield `Value::Pair`; non-string typed keys
-    /// (object hashes) yield `Value::ValuePair`. Behaviour-neutral for plain
-    /// hashes (returns `Value::Pair(str_key, value)` as before).
     /// Build a `Pair` for a hash entry `(str_key, value)`, honoring object-hash
-    /// typed keys. The value is decontainerized: a hash element is stored as a
+    /// typed keys. ADR-0021: hash iteration is a data source, not a call site,
+    /// so the result is always the positional flavour (`Value::ValuePair`) —
+    /// for a plain string key too, not just object-hash typed keys. The value
+    /// is decontainerized: a hash element is stored as a
     /// `ContainerRef` cell, but the pair must carry the inner value (matching a
     /// `%h<k>` read and `.values`) — otherwise iterating a hash as pairs leaks
     /// the cell and `+`/`.elems` on the pair value misbehave (the cell counts as


### PR DESCRIPTION
## Summary

Small cleanup slice of [ADR-0021](docs/adr/0021-argument-namedness-is-a-call-site-property.md) P4 (the rest of P4 — renaming/consolidating duplicated flavour-pair arms — is explicitly optional per the ADR, "decide by churn at the time", not a sweep).

- `HashData::typed_pair` had two stacked doc comments: a stale one claiming "plain string keys yield `Value::Pair`; non-string typed keys yield `Value::ValuePair`" (left over from before the 2026-08 hash-derived-pairs slice made it always mint `ValuePair`), and a correct one appended right after it. Dropped the stale one.
- Updated `ValueRepr::Pair`/`ValuePair`'s own doc comments in `src/value/mod.rs` to describe ADR-0021's model directly — `Pair` is the transient call-site-only named-argument marker; `ValuePair` is the actual Pair representation, positional by default including plain string keys — instead of the pre-ADR "non-string key" framing.
- Marked the ADR **Accepted**: P1/P2/P3a/P3 (the I1-I5 invariants and the minting-default flip) have all shipped and merged; only P4's optional rename/consolidation and P5's measured perf follow-up remain.

Comment-only changes to `src/`, no behavior change.

## Test plan

- `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` clean.
- Spot-checked the ADR-0021 pin tests still pass (`t/pair-value-consumers-accept-both-flavors.t`, `t/pair-positional-arg.t`, `t/method-pair-argument-is-positional.t`, `t/slip-array-of-pairs-is-positional.t`).
- Full `make test`/`make roast` delegated to CI per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)