### PR TITLE
feat(runtime): install main-pass-compiled method bodies by key (ADR-0019 D3-8b)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,15 +115,16 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 31/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
+**Current progress: 32/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
 landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, D4-3, D7-3, and D3-8a landed
-2026-08-08). Phase C is fully checked; the open box is
+2026-08-08; D3-8b landed 2026-08-09). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
 D3-1 through D3-7 landed (walker-drift unification plus the compile-time `CompiledMethodDecl`
-precompute), D3-8a also landed (the additive compiler-side half of the method-body main-pass
-compile — see below), and a 2026-08-08 scoping pass found D3's literal goal — compiling method *bodies*
+precompute), D3-8a and D3-8b also landed (the additive compiler-side half and the class-walker
+install-by-key cutover of the method-body main-pass compile — see below), and a 2026-08-08 scoping
+pass found D3's literal goal — compiling method *bodies*
 through the single main-pass `Compiler` the way `SubDecl` does, instead of a throwaway
 per-registration `Compiler::new()` — still fully open and scoped as a future D3-8, whose detailed
 design (parity-first bare compile, per-decl `compiled_routine_key` on `CompiledMethodDecl`,
@@ -890,6 +891,50 @@ walkers wholesale is not possible before then.
   an actual `Interpreter::run` — and asserts the two `CompiledCode`s are `Debug`-identical (after
   normalizing the process-global closure-ordinal/Symbol-intern-id noise both compiles pick up from
   unrelated background compilation). All pass.
+  **D3-8b landed 2026-08-09**: the class-walker install-by-key cutover (design decision 4).
+  `class_body_method_decl` (`runtime/registration_class_body_method.rs`) now looks up
+  `decl.compiled_routine_key` in the ambient `CompiledFns` pool and, when it resolves AND the
+  resolved `CompiledFunction`'s `params`/`param_defs` match what this registration walk just
+  computed for the same declaration, installs `MethodDef::compiled_code`/`compiled_fns` directly
+  from it instead of leaving them `None` for the bulk `compile_class_methods` pass to fill in later
+  via the registration-time throwaway compile. The comparison snapshots `effective_param_defs`
+  *before* the `::?CLASS` substitution (which `compile_method_body` never performs — design
+  decision 3) so the two sides line up; `ParamDef` has no `PartialEq` (it embeds `Expr`, which
+  doesn't either, and deriving it project-wide is a separate, much larger change), so the guard
+  compares `Debug`-formatted strings instead — exact, not a heuristic, since both sides are derived
+  from the same cloned `decl.param_defs`/`decl.body` within one process, unlike the D3-8a test's
+  two-separate-compiles comparison which has to normalize cross-run Symbol/closure-ordinal drift.
+  The ambient `CompiledFns` table reaches `class_body_method_decl` through a new plumbing path:
+  `exec_register_class_op` gained a `compiled_fns: &CompiledFns` parameter (mirroring
+  `exec_register_sub_op`, threaded from `exec_register_decl_op`, which already had it),
+  `ClassDeclModifiers`/`ClassBodyCx` gained a `compiled_fns` field, and the two non-VM-op call
+  sites of `register_class_decl` (role-pun synthesis in `registration_class_augment.rs`, mixin-type
+  synthesis in `types/role_mixin_class.rs`) pass `&CompiledFns::default()` — harmless, since both
+  call with an empty body, so `method_decls` is empty and the lookup is never reached. Verified
+  with a `MUTSU_VM_STATS=1` stress repro (`class C { method m($x) { $x + 1 } }` redeclared and
+  instantiated 50 times in a loop): `method_body_runtime_compiles` dropped from 50 (baseline, one
+  throwaway compile per loop iteration) to 0. `make test` and a full `make roast` both green, no
+  regressions. **One real regression was caught by the full `make roast` run and fixed in the same
+  slice**: `roast/S12-introspection/walk.t`'s `$?PACKAGE.^name` returned a mangled name (e.g.
+  `"GLOBAL::&::C2"` instead of `"C2"`) for a class declared inside a closure body (`subtest "..."
+  => { my class C2 { ... } }`). Root cause: D3-8a's `qualified_class_decl_name` (the compile-time
+  predictor of a class's registration-time qualified name, used both to key the compiled body and
+  to seed `$?PACKAGE`'s baked-in `LoadConst`) did not account for the compiler's synthetic
+  STATE-SCOPE pseudo-package (`current_package` containing `"::&"`, used purely for `state`
+  variable key uniqueness inside a sub/closure body) — a case `qualify_package_name`/
+  `qualify_variable_name` already special-cased elsewhere in the same file. Inside a state scope,
+  `current_package` does NOT track the runtime's real `current_package()` the way ordinary
+  package-scope bracketing does, so the "compile-time mirrors registration-time" assumption breaks
+  silently — undetectable by the params-equality guard, since a wrong package name is baked
+  directly into the body's bytecode, not carried as a parameter. The params-equality guard alone
+  cannot catch a wrong *package* prediction; fixed by extending the bail-out itself: both
+  `add_class_decl_plan` and `add_role_decl_plan` (`compiler/decl_plan.rs`) now skip main-pass
+  method-body compilation entirely (`compiled_routine_key` stays `None`, same as the
+  computed-name/hoisted-shell cases) whenever the declaration is nested inside such a state scope,
+  falling back to the unaffected registration-time throwaway compile. Fixed on the role side too
+  (`qualified_role_decl_name`) even though not yet observable (D3-8c doesn't install from it yet),
+  to avoid reintroducing the identical bug there. `role_body_method_decl` (D3-8c) is untouched — a separate future PR, since
+  parametric-role method dispatch needs its own roast S14 + battery-gate verification.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
   expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
   names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies

--- a/news/2026-08/adr0019-d3-8b-class-method-install-by-key.md
+++ b/news/2026-08/adr0019-d3-8b-class-method-install-by-key.md
@@ -1,0 +1,43 @@
+# ADR-0019 D3-8b: install main-pass-compiled method bodies by key
+
+`class_body_method_decl` now installs a class method's bytecode straight from the main-pass
+compile ADR-0019 D3-8a produces, instead of leaving `MethodDef::compiled_code`/`compiled_fns`
+`None` for the registration-time throwaway compile (`compile_method_def_in_place_with_dist`) to
+fill in on first call. When `CompiledMethodDecl::compiled_routine_key` resolves in the ambient
+`CompiledFns` pool *and* the resolved `CompiledFunction`'s `params`/`param_defs` match exactly
+what this registration walk just computed for the same declaration, the compiled bytecode installs
+directly; any mismatch (or a missing key, e.g. a computed method/class name) falls back unchanged
+to today's behavior.
+
+The ambient `CompiledFns` table reaches the class walker through a small plumbing extension:
+`exec_register_class_op` gained a `compiled_fns: &CompiledFns` parameter (mirroring
+`exec_register_sub_op`, which already had one), threaded through `ClassDeclModifiers`/
+`ClassBodyCx` down to `class_body_method_decl`. The two non-VM-op callers of `register_class_decl`
+(role-pun synthesis, mixin-type synthesis) pass an empty table — harmless, since both register
+with an empty body.
+
+A `MUTSU_VM_STATS=1` stress repro (`class C { method m($x) { $x + 1 } }` redeclared and
+instantiated 50 times in a loop) confirmed the effect directly: `method_body_runtime_compiles`
+dropped from 50 to 0.
+
+The full `make roast` run for this slice caught one real regression before it could land:
+`roast/S12-introspection/walk.t`'s `$?PACKAGE.^name` returned a mangled name for a class declared
+inside a closure body (a `subtest "..." => { my class C2 { ... } }` shape, a common test-file
+pattern). The root cause was in D3-8a's compile-time package-name predictor
+(`qualified_class_decl_name`): it didn't account for the compiler's synthetic STATE-SCOPE
+pseudo-package (a `current_package` value containing `"::&"`, used purely for `state`-variable key
+uniqueness inside a sub/closure body) — a case the same file's `qualify_package_name`/
+`qualify_variable_name` already special-cased, just not the newer D3-8a helper. Inside a state
+scope, `current_package` doesn't track the runtime's real `current_package()` the way ordinary
+package-scope bracketing does, so the "compile-time mirrors registration-time" assumption silently
+breaks — and since a wrong package name gets baked directly into the body's bytecode (not carried
+as a parameter), the params-equality install guard can't catch it. Fixed by extending the bail-out
+itself: a declaration nested inside a state scope now skips main-pass method-body compilation
+entirely (`compiled_routine_key` stays `None`), falling back to the unaffected registration-time
+compile — the same treatment already given to computed names and hoisted shells. The role-side
+twin (`qualified_role_decl_name`) got the identical fix even though it isn't observable yet (D3-8c,
+the role-walker cutover, hasn't landed), to avoid rediscovering the same bug later.
+
+`role_body_method_decl` is untouched — D3-8c, a separate future slice needing its own roast S14 +
+battery-gate verification, since parametric-role method dispatch is load-bearing for the bundled
+Cro/OO::Monitors batteries.

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -152,7 +152,23 @@ impl Compiler {
         // where only the source-order site compiles the body. Skip the
         // (otherwise-redundant) compile there.
         let is_hoisted_shell = custom_traits.iter().any(|(t, _)| t == "__hoisted");
-        let package_name = if name_expr.is_none() && !is_hoisted_shell {
+        // `self.current_package` containing `::&` means this class is
+        // declared inside a sub/method/closure body currently compiling
+        // under a synthetic STATE-SCOPE pseudo-package (`qualify_variable_name`
+        // /`qualify_package_name` already special-case this exact marker) —
+        // e.g. `subtest "..." => { my class C { ... } }`. That pseudo-package
+        // is compile-time-only bookkeeping for `state` variable key
+        // uniqueness; it does NOT track the runtime's actual
+        // `current_package()` the way ordinary package-scope bracketing
+        // does, so `qualified_class_decl_name`'s "compile-time mirrors
+        // registration-time" assumption (its own doc comment) does not hold
+        // here. Bail out — same as the computed-name case — rather than bake
+        // a wrong package name into `$?PACKAGE`/`?CLASS`-substituted
+        // constants the D3-8a compile produces (caught via
+        // roast/S12-introspection/walk.t's `$?PACKAGE.^name` inside a
+        // `subtest` block).
+        let in_state_scope = self.current_package.contains("::&");
+        let package_name = if name_expr.is_none() && !is_hoisted_shell && !in_state_scope {
             Some(self.qualified_class_decl_name(&name.resolve()))
         } else {
             None
@@ -380,7 +396,16 @@ impl Compiler {
         // whole original body, unlike the class shell) compile for a
         // `__hoisted` forward-reference shell, mirroring `add_class_decl_plan`.
         let is_hoisted_shell = custom_traits.iter().any(|(t, _)| t == "__hoisted");
-        let method_compiled_keys = if is_hoisted_shell {
+        // See `add_class_decl_plan`'s identical `in_state_scope` comment: a
+        // role declared inside a sub/closure body (e.g. `subtest "..." => {
+        // my role R { ... } }`) compiles under a synthetic STATE-SCOPE
+        // pseudo-package that does not track the runtime's real
+        // `current_package()`, so the compile-time package-name prediction
+        // is unreliable here too. Not observably reachable yet (D3-8b only
+        // installs from the class side), but fixed now so D3-8c does not
+        // reintroduce the same bug.
+        let in_state_scope = self.current_package.contains("::&");
+        let method_compiled_keys = if is_hoisted_shell || in_state_scope {
             self.compile_method_body_keys(body, None, false, false)
         } else {
             let package_name = self.qualified_role_decl_name(&name.resolve());

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -237,6 +237,18 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// cases. Empty for registration paths with no compiled plan available
     /// (role-pun/mixin synthesis, `augment class`).
     pub(crate) parent_pre_args: &'a [Option<&'a [crate::opcode::DeclTraitArg]>],
+    /// The ambient program-wide compiled-function pool (ADR-0019 D3-8b),
+    /// threaded down to `class_body_method_decl` via `ClassBodyCx` so it can
+    /// look up each `method_decls[i].compiled_routine_key` and install the
+    /// main-pass-compiled bytecode (ADR-0019 D3-8a,
+    /// `Compiler::compile_method_body`) directly, instead of leaving
+    /// `MethodDef::compiled_code` `None` for the registration-time
+    /// throwaway-compile fallback (`compile_method_def_in_place_with_dist`)
+    /// to fill in later. Call sites with no compiled plan available
+    /// (role-pun/mixin synthesis, `augment class`) pass an empty table —
+    /// harmless, since their `method_decls` is empty too, so the lookup is
+    /// never reached.
+    pub(crate) compiled_fns: &'a crate::opcode::CompiledFns,
 }
 
 pub(super) fn parse_role_type_args(input: &str) -> Vec<String> {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1005,6 +1005,7 @@ impl Interpreter {
             method_decls: &[],
             declared_static_names: &[],
             parent_pre_args: &[],
+            compiled_fns: &crate::opcode::CompiledFns::default(),
         };
         self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
         self.store_language_revision_from_version(&pun_name, &language_version);

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -38,6 +38,9 @@ pub(super) struct ClassBodyCx<'a> {
     /// Cursor into `method_name_chunks`/`method_decls`, advanced by one on
     /// every method statement `class_body_method_decl` processes.
     pub(super) method_name_chunk_idx: usize,
+    /// The ambient program-wide compiled-function pool (ADR-0019 D3-8b); see
+    /// `ClassDeclModifiers::compiled_fns`.
+    pub(super) compiled_fns: &'a crate::opcode::CompiledFns,
 }
 
 impl ClassBodyCx<'_> {
@@ -99,6 +102,7 @@ impl Interpreter {
         method_name_chunks: &[Option<crate::opcode::CompiledDeclExpr>],
         method_decls: &[crate::opcode::CompiledMethodDecl],
         declared_static_names: &[Symbol],
+        compiled_fns: &crate::opcode::CompiledFns,
     ) -> Result<ClassDef, RuntimeError> {
         let saved_package = self.current_package();
         let saved_env = self.env.clone();
@@ -144,6 +148,7 @@ impl Interpreter {
             method_name_chunks,
             method_decls,
             method_name_chunk_idx: 0,
+            compiled_fns,
         };
         let saved_functions_keys: HashSet<String> = self
             .registry()

--- a/src/runtime/registration_class_body_method.rs
+++ b/src/runtime/registration_class_body_method.rs
@@ -69,6 +69,17 @@ impl Interpreter {
             &decl.param_defs,
             cx.is_hidden,
         );
+        // ADR-0019 D3-8b: the main-pass compiled bytecode this method body
+        // may already have (`decl.compiled_routine_key`,
+        // `Compiler::compile_method_body`, ADR-0019 D3-8a) was compiled from
+        // `effective_param_defs` at THIS point in the pipeline — before the
+        // ::?CLASS substitution below, which `compile_method_body`
+        // deliberately never performs (design decision 3: a type-constraint
+        // STRING is bind-time-only data, never baked into bytecode).
+        // Snapshot it here so the install-by-key guard further down compares
+        // against exactly what the compiler computed, not this function's
+        // substituted copy.
+        let mut raw_param_defs_for_key_check = effective_param_defs.clone();
         // Resolve the ::?CLASS pseudo-type in parameter type
         // constraints to the enclosing class (raku fixes ::?CLASS
         // at compile time to the declaring class), mirroring the
@@ -88,10 +99,53 @@ impl Interpreter {
             &decl.body,
             &mut effective_param_defs,
         );
+        // Mirror the same auto-slurpy insertion onto the pre-substitution
+        // snapshot: it depends only on names/slurpy-ness (never on
+        // `type_constraint` content), so it commutes with the substitution
+        // above and this stays byte-identical to what `compile_method_body`
+        // computed.
+        crate::method_signature_shared::apply_auto_positional_slurpy(
+            decl.param_defs.is_empty(),
+            &decl.body,
+            &mut raw_param_defs_for_key_check,
+        );
         let effective_params: Vec<String> = effective_param_defs
             .iter()
             .map(|p| p.name.clone())
             .collect();
+        // ADR-0019 D3-8b (design decision 4): install the main-pass compiled
+        // bytecode by key when it resolves in the ambient compiled-function
+        // pool AND its params/param_defs match what THIS registration walk
+        // just computed. `ParamDef` has no `PartialEq` (it embeds `Expr`,
+        // which does not derive it either — adding that is a much larger,
+        // separate change), so structural equality is checked via `Debug`
+        // formatting, matching the comparison already used to pin
+        // main-pass/registration-time byte parity in the D3-8a test suite
+        // (`compiler/helpers_method_body.rs`). This is exact, not a
+        // heuristic: both sides are derived from the SAME cloned
+        // `decl.param_defs`/`decl.body` in this single process, so there is
+        // no cross-run Symbol-id or closure-ordinal divergence to normalize
+        // away (unlike that test, which compares two separate compiles).
+        // A mismatch (or missing key) leaves `compiled_code`/`compiled_fns`
+        // `None`, falling back unchanged to the registration-time throwaway
+        // compile (`compile_method_def_in_place_with_dist` via the bulk
+        // `compile_class_methods` pass).
+        let matched_compiled_fn = decl
+            .compiled_routine_key
+            .and_then(|key| cx.compiled_fns.get(&key))
+            .filter(|cf| {
+                let expected_full_params: Vec<String> =
+                    ["self", "__ANON_STATE__", "?CLASS", "?ROLE"]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .chain(effective_params.iter().cloned())
+                        .collect();
+                cf.params == expected_full_params
+                    && format!("{:?}", cf.param_defs) == format!("{raw_param_defs_for_key_check:?}")
+            });
+        let installed_compiled_code =
+            matched_compiled_fn.map(|cf| std::sync::Arc::new(cf.code.clone()));
+        let installed_compiled_fns = matched_compiled_fn.and_then(|cf| cf.compiled_fns.clone());
         let def = MethodDef {
             lexical_package: cx.saved_package.clone(),
             params: effective_params.clone(),
@@ -108,8 +162,8 @@ impl Interpreter {
             role_origin: None,
             original_role: None,
             return_type: decl.return_type.clone(),
-            compiled_code: None,
-            compiled_fns: None,
+            compiled_code: installed_compiled_code,
+            compiled_fns: installed_compiled_fns,
             delegation: None,
             is_default: decl.is_default_candidate,
             deprecated_message: decl.deprecated_message.clone(),

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -131,6 +131,7 @@ impl Interpreter {
             method_decls,
             declared_static_names,
             parent_pre_args,
+            compiled_fns,
         } = modifiers;
         let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
@@ -232,6 +233,7 @@ impl Interpreter {
             method_name_chunks,
             method_decls,
             declared_static_names,
+            compiled_fns,
         )?;
         self.finalize_class_registration(name, parents, class_def, &snapshot)?;
         self.install_class_exporthow(name, parents)?;

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -70,6 +70,7 @@ impl Interpreter {
             method_decls: &[],
             declared_static_names: &[],
             parent_pre_args: &[],
+            compiled_fns: &crate::opcode::CompiledFns::default(),
         };
         self.register_class_decl(&name, &parents, modifiers, &[])?;
         self.compose_mixin_role_submethods(&name, &fresh);

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -15,7 +15,7 @@ impl Interpreter {
             }
             Some(crate::opcode::CompiledDeclPlanRef::Class(plan_idx)) => {
                 self.note_type_body_written_lexicals(code);
-                match self.exec_register_class_op(code, plan_idx) {
+                match self.exec_register_class_op(code, plan_idx, compiled_fns) {
                     Ok(()) => Ok(()),
                     Err(_)
                         if code.class_decl_plans[plan_idx as usize]
@@ -105,6 +105,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         idx: u32,
+        compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         // Registering a class can shadow a same-named earlier class (`my class A`
         // in a fresh lexical scope) with different method bodies/candidates, so the
@@ -276,6 +277,7 @@ impl Interpreter {
                         method_decls,
                         declared_static_names,
                         parent_pre_args: &parent_pre_args,
+                        compiled_fns,
                     },
                     body,
                 )


### PR DESCRIPTION
## Summary
- `class_body_method_decl` now installs a class method's bytecode straight from the ADR-0019 D3-8a main-pass compile, instead of leaving `MethodDef::compiled_code`/`compiled_fns` `None` for the registration-time throwaway compile (`compile_method_def_in_place_with_dist`) to fill in on first call. Install happens only when `CompiledMethodDecl::compiled_routine_key` resolves in the ambient `CompiledFns` pool **and** the resolved `CompiledFunction`'s `params`/`param_defs` match exactly what registration just computed for the same declaration — any mismatch (or missing key, e.g. a computed name) falls back unchanged to today's behavior.
- The ambient `CompiledFns` table reaches the class walker via a small plumbing extension: `exec_register_class_op` gained a `compiled_fns: &CompiledFns` parameter (mirroring `exec_register_sub_op`), threaded through `ClassDeclModifiers`/`ClassBodyCx`. The two non-VM-op callers of `register_class_decl` (role-pun synthesis, mixin-type synthesis) pass an empty table — harmless, since both register with an empty body.
- Verified the effect directly with a `MUTSU_VM_STATS=1` stress repro (`class C { method m($x) { $x + 1 } }` redeclared/instantiated 50 times in a loop): `method_body_runtime_compiles` dropped from 50 to 0.
- **A real regression caught by the full `make roast` run and fixed in this slice**: a class declared inside a closure body (`subtest "..." => { my class C2 {...} }`, a common test-file pattern) got a mangled `$?PACKAGE.^name` (e.g. `"GLOBAL::&::C2"` instead of `"C2"`). Root cause: D3-8a's compile-time package-name predictor (`qualified_class_decl_name`) didn't account for the compiler's synthetic STATE-SCOPE pseudo-package (a `current_package` containing `"::&"`, used purely for `state`-variable key uniqueness inside a sub/closure body) — a case `qualify_package_name`/`qualify_variable_name` already special-case elsewhere in the same file. Inside a state scope, `current_package` doesn't track the runtime's real `current_package()`, so a wrong package name gets baked directly into the bytecode (not carried as a parameter), which the params-equality install guard can't catch. Fixed by extending the bail-out itself: a declaration nested in such a scope now skips main-pass method-body compilation entirely, same treatment as a computed name. Applied to the role-side predictor too (not yet observable — D3-8c hasn't landed — but avoids rediscovering the same bug there).
- `role_body_method_decl` (D3-8c) is untouched — a separate future PR needing its own roast S14 + battery-gate verification, since parametric-role method dispatch is load-bearing for the bundled Cro/OO::Monitors batteries.
- ADR-0019 progress checklist and `news/2026-08/` updated.

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` (pre-commit config) / `cargo fmt` — clean
- [x] `make test` — 28,019 tests, all green (post-rebase run)
- [x] Full `make roast` (release build) — all green after the state-scope fix (initially caught the walk.t regression above, which is now fixed)
- [x] `MUTSU_VM_STATS=1` stress repro confirming `method_body_runtime_compiles` drops to 0 for repeated class declaration/instantiation
- Note: an initial local `make roast` run showed `roast/S17-supply/syntax.t` timing out. Confirmed this is unrelated to this change and purely local-machine load (this dev container was running under load average 73 on 12 cores from many concurrent sessions/agents at the time) — the identical timeout reproduces on unmodified `main` under the same load, and does not reproduce on a re-run of this branch once load settled. Not in `flaky-tests.txt`; flagging here in case CI (a clean runner) shows anything, though it's expected to be clean there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)