### PR TITLE
feat(runtime): install main-pass-compiled role method bodies by key (ADR-0019 D3-8c)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,15 +115,16 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 32/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
+**Current progress: 33/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
 landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, D4-3, D7-3, and D3-8a landed
-2026-08-08; D3-8b landed 2026-08-09). Phase C is fully checked; the open box is
+2026-08-08; D3-8b and D3-8c landed 2026-08-09). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
 D3-1 through D3-7 landed (walker-drift unification plus the compile-time `CompiledMethodDecl`
-precompute), D3-8a and D3-8b also landed (the additive compiler-side half and the class-walker
-install-by-key cutover of the method-body main-pass compile — see below), and a 2026-08-08 scoping
+precompute), D3-8a, D3-8b, and D3-8c also landed (the additive compiler-side half plus the
+class-walker and role-walker install-by-key cutovers of the method-body main-pass compile — see
+below; D3-8d, the fallback-narrowing survey, remains open), and a 2026-08-08 scoping
 pass found D3's literal goal — compiling method *bodies*
 through the single main-pass `Compiler` the way `SubDecl` does, instead of a throwaway
 per-registration `Compiler::new()` — still fully open and scoped as a future D3-8, whose detailed
@@ -933,8 +934,25 @@ walkers wholesale is not possible before then.
   computed-name/hoisted-shell cases) whenever the declaration is nested inside such a state scope,
   falling back to the unaffected registration-time throwaway compile. Fixed on the role side too
   (`qualified_role_decl_name`) even though not yet observable (D3-8c doesn't install from it yet),
-  to avoid reintroducing the identical bug there. `role_body_method_decl` (D3-8c) is untouched — a separate future PR, since
-  parametric-role method dispatch needs its own roast S14 + battery-gate verification.
+  to avoid reintroducing the identical bug there.
+  **D3-8c landed 2026-08-09**: the role-walker install-by-key cutover, the same design-decision-4
+  guard as D3-8b applied to `role_body_method_decl`
+  (`runtime/registration_role_method.rs`). Simpler than the class side: `role_body_method_decl`
+  never performs a `::?CLASS`-style param-type substitution, so `effective_param_defs` computed
+  here IS exactly what `compile_method_body` computed at plan-lowering time (`is_hidden: false`,
+  no auto-`@_` detection, per `add_role_decl_plan`'s existing comment) — no separate
+  pre-substitution snapshot is needed, unlike D3-8b. The ambient `CompiledFns` pool reaches
+  `role_body_method_decl` the same way: `exec_register_role_op` gained a
+  `compiled_fns: &CompiledFns` parameter (threaded from `exec_register_decl_op`, which already had
+  it), `register_role_decl`/`RoleDeclCx` gained a `compiled_fns` field. `register_role_decl` has
+  only the one call site (the VM op), so no `CompiledFns::default()` plumbing was needed anywhere
+  else. Because the install happens inside `register_role_decl` itself — before the
+  `role_candidates` snapshot used by composition is cloned — the per-composing-class recompile
+  disappears for free (design decision 6), verified with a `MUTSU_VM_STATS=1` repro (a role with
+  two methods composed into 3 classes directly plus 5 more inside a loop):
+  `method_body_runtime_compiles` dropped from 18 (baseline) to 0. The D3-8a byte-parity unit tests
+  (including the two role-specific fixtures) and the full `t/` suite (2974 files, 28019 tests) both
+  stayed green, and all 121 whitelisted `roast/S12-*`/`S14-*` files passed on a release build.
 - [ ] **D4 — Compile class declaration-time expressions.** Cover computed names, traits, parent
   expressions, aliases, and deferred class bodies through re-entrant bytecode chunks. (Computed
   names and custom-trait arguments already landed with C5; parents, aliases, and deferred bodies

--- a/news/2026-08/adr0019-d3-8c-role-method-install-by-key.md
+++ b/news/2026-08/adr0019-d3-8c-role-method-install-by-key.md
@@ -1,0 +1,34 @@
+# ADR-0019 D3-8c: install main-pass-compiled role method bodies by key
+
+`role_body_method_decl` now installs a role method's bytecode straight from the main-pass compile
+ADR-0019 D3-8a produces, the same install-by-key guard D3-8b already applied to the class walker
+(`class_body_method_decl`): when `CompiledMethodDecl::compiled_routine_key` resolves in the
+ambient `CompiledFns` pool *and* the resolved `CompiledFunction`'s `params`/`param_defs` match
+exactly what this registration walk just computed for the same declaration, the compiled bytecode
+installs directly instead of leaving `MethodDef::compiled_code`/`compiled_fns` `None` for the
+registration-time throwaway compile (`compile_method_def_in_place_with_dist`) to fill in later.
+
+The role side is simpler than the class side: `role_body_method_decl` never performs a
+`::?CLASS`-style parameter-type substitution, so the `effective_param_defs` this walk computes IS
+exactly what `compile_method_body` computed at plan-lowering time (`is_hidden: false`, no
+auto-positional-`@_` detection — `add_role_decl_plan` already documented this divergence from the
+class side). No separate pre-substitution snapshot is needed, unlike D3-8b's
+`raw_param_defs_for_key_check`.
+
+The ambient `CompiledFns` table reaches the role walker the same way D3-8b wired the class walker:
+`exec_register_role_op` gained a `compiled_fns: &CompiledFns` parameter (threaded from
+`exec_register_decl_op`, which already had it), and `register_role_decl`/`RoleDeclCx` gained a
+`compiled_fns` field. `register_role_decl` has only the one call site (the VM op), so no
+`CompiledFns::default()` plumbing was needed elsewhere.
+
+Because the install happens inside `register_role_decl` itself — before the `role_candidates`
+snapshot composition reads is cloned — the per-composing-class recompile disappears for free (the
+design doc's decision 6): a `MUTSU_VM_STATS=1` repro (a role with two methods composed into 3
+classes directly, plus 5 more inside a loop) confirmed `method_body_runtime_compiles` dropped from
+18 to 0. The D3-8a byte-parity unit tests (including its two role-specific fixtures), the full
+`t/` suite (2974 files, 28019 tests), and all 121 whitelisted `roast/S12-*`/`S14-*` files stayed
+green on a release build.
+
+D3-8d (the fallback-narrowing survey confirming every remaining
+`method_body_runtime_compiles` hit is one of the enumerated dynamic shapes — `augment class`,
+`.^add_method`, computed names) remains open.

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -323,6 +323,7 @@ impl Interpreter {
         is_stub_body: bool,
         our_scope_violation: Option<&str>,
         parent_ops: &[crate::opcode::RoleParentOp],
+        compiled_fns: &crate::opcode::CompiledFns,
     ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
 
@@ -389,6 +390,7 @@ impl Interpreter {
             method_name_chunk_idx: 0,
             parent_ops,
             parent_op_idx: 0,
+            compiled_fns,
         };
         self.walk_role_body(body, &mut cx)?;
         self.finish_role_registration(

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -44,6 +44,9 @@ pub(super) struct RoleDeclCx<'a> {
     /// Cursor into `parent_ops`, advanced by one on every `DoesDecl`
     /// statement `role_body_does_decl` processes.
     pub(super) parent_op_idx: usize,
+    /// The ambient program-wide compiled-function pool (ADR-0019 D3-8c); see
+    /// `role_body_method_decl`.
+    pub(super) compiled_fns: &'a crate::opcode::CompiledFns,
 }
 
 impl RoleDeclCx<'_> {

--- a/src/runtime/registration_role_method.rs
+++ b/src/runtime/registration_role_method.rs
@@ -203,6 +203,34 @@ impl Interpreter {
             .iter()
             .map(|p| p.name.clone())
             .collect();
+        // ADR-0019 D3-8c: install by key with the same equality guard as
+        // the class walker (D3-8b, decision 4). `add_role_decl_plan`
+        // compiled this body with `is_hidden: false` and no auto `@_`
+        // detection (matching this walk exactly, no ::?CLASS-style
+        // substitution here), so `effective_param_defs` above IS what
+        // `compile_method_body` computed — no separate pre-substitution
+        // snapshot needed, unlike the class side. A mismatch (or missing
+        // key) leaves `compiled_code`/`compiled_fns` `None`, falling back
+        // unchanged to the registration-time throwaway compile. Installing
+        // here (inside `register_role_decl`, before the `role_candidates`
+        // snapshot is cloned) is what makes the per-composing-class
+        // recompile disappear for free (design decision 6).
+        let matched_compiled_fn = decl
+            .compiled_routine_key
+            .and_then(|key| cx.compiled_fns.get(&key))
+            .filter(|cf| {
+                let expected_full_params: Vec<String> =
+                    ["self", "__ANON_STATE__", "?CLASS", "?ROLE"]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .chain(effective_params.iter().cloned())
+                        .collect();
+                cf.params == expected_full_params
+                    && format!("{:?}", cf.param_defs) == format!("{effective_param_defs:?}")
+            });
+        let installed_compiled_code =
+            matched_compiled_fn.map(|cf| std::sync::Arc::new(cf.code.clone()));
+        let installed_compiled_fns = matched_compiled_fn.and_then(|cf| cf.compiled_fns.clone());
         let def = MethodDef {
             lexical_package: self.current_package(),
             params: effective_params,
@@ -215,8 +243,8 @@ impl Interpreter {
             role_origin: None,
             original_role: None,
             return_type: decl.return_type.clone(),
-            compiled_code: None,
-            compiled_fns: None,
+            compiled_code: installed_compiled_code,
+            compiled_fns: installed_compiled_fns,
             delegation: None,
             is_default: decl.is_default_candidate,
             deprecated_message: decl.deprecated_message.clone(),

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -30,7 +30,7 @@ impl Interpreter {
             }
             Some(crate::opcode::CompiledDeclPlanRef::Role(plan_idx)) => {
                 self.note_type_body_written_lexicals(code);
-                match self.exec_register_role_op(code, plan_idx) {
+                match self.exec_register_role_op(code, plan_idx, compiled_fns) {
                     Ok(()) => Ok(()),
                     Err(_)
                         if code.role_decl_plans[plan_idx as usize]
@@ -614,6 +614,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         idx: u32,
+        compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         if let Some(crate::opcode::CompiledRoleDeclPlan {
             name,
@@ -669,6 +670,7 @@ impl Interpreter {
                     *is_stub,
                     *our_scope_violation,
                     parent_ops,
+                    compiled_fns,
                 )
             )?;
             // Link `is Parent` references on this role to the lexical class visible


### PR DESCRIPTION
## Summary
- `role_body_method_decl` now installs `MethodDef::compiled_code`/`compiled_fns` directly from the main-pass compile (ADR-0019 D3-8a) when `compiled_routine_key` resolves in the ambient `CompiledFns` pool and its `params`/`param_defs` match this registration walk's computation — mirroring D3-8b's class-walker cutover.
- Threads `compiled_fns: &CompiledFns` through `exec_register_role_op` → `register_role_decl` → `RoleDeclCx`.
- Because the install happens inside `register_role_decl` before the `role_candidates` snapshot composition clones, the per-composing-class recompile disappears for free (design decision 6 of the D3-8 design doc).
- Updates the ADR-0019 execution-plan checklist (33/53 slices) and adds a `news/2026-08/` entry.

## Test plan
- [x] `cargo test --lib d3_8a_byte_parity` — 11/11 pass (including the two role-specific fixtures)
- [x] `prove -e target/debug/mutsu t/` — 2974 files, 28019 tests, all pass
- [x] `MUTSU_FUDGE=1 prove -e target/release/mutsu` over all 121 whitelisted `roast/S12-*`/`S14-*` files — all pass
- [x] `MUTSU_VM_STATS=1` repro (role with 2 methods composed into 8 classes, 5 inside a loop): `method_body_runtime_compiles` 18 → 0
- [x] `cargo clippy -- -D warnings`, `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)