### PR TITLE
fix(operator): scope block-local infix-op overrides to their declaring source file

### DIFF
--- a/news/2026-08/user-infix-source-file-scoping.md
+++ b/news/2026-08/user-infix-source-file-scoping.md
@@ -1,0 +1,41 @@
+# Scope block-local infix-op overrides to their declaring source file
+
+Previously, a user-defined `infix:<op>` sub declared anywhere in a test script
+(e.g. overriding `+` for a custom `NotANumber` type) was active globally —
+including inside module code called from that script.  This corrupted
+Test.rakumod's internal arithmetic: `proclaim` incremented its run-counter with
+`$num_of_tests_run = $num_of_tests_run + 1`, and the test script's custom `+`
+was intercepted instead of the native one, making the counter always return the
+custom type rather than an integer.
+
+The root cause was `user_declared_infix_ops`, a flat `HashSet<String>` whose
+presence check fired regardless of which compilation unit was executing.
+`user_infix_override()` also read `?FILE` from the interpreter env, which is
+*inherited* through call frames: when Test.rakumod's `proclaim` ran (called from
+a test script), `?FILE` still reflected the test script's path, not
+Test.rakumod's.
+
+## Fix
+
+Converted `user_declared_infix_ops` from `HashSet<String>` to
+`FxHashMap<String, Option<String>>` where the value is:
+
+- `None` → exported / universally visible (visible in all executing files)
+- `Some(path)` → active only when the currently-executing compiled function body
+  comes from that source file
+
+Added `executing_cf_source_file: Option<String>` to the Interpreter, updated
+on every compiled-function entry/exit across all call paths (fast, light,
+light-typed, named-inner, closure dispatch) and during module loading.
+`user_infix_override()` now checks this field instead of `?FILE`.
+
+Exported operators (via `import_module` or `sub EXPORT`) are forced to `None`
+(universal) by using `insert(None)` rather than `or_insert(None)`, which would
+have left the file-scoped `Some(path)` entry set at declaration time intact.
+
+## Effect
+
+- `roast/integration/advent2013-day10.t` under `MUTSU_REAL_TEST=1`: 44/44
+  (was 12/44 — test counter was corrupted)
+- `roast/S06-operator-overloading/` suite: 223/223 (unchanged, including
+  `imported-subs.t` 20/20 with module-exported `multi infix:<+>`)

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -199,6 +199,7 @@ impl Interpreter {
             registry.proto_subs.clone(),
             registry.proto_tokens.clone(),
             registry.our_scoped_functions.keys().copied().collect(),
+            self.user_declared_infix_ops.clone(),
         )
     }
 
@@ -211,8 +212,16 @@ impl Interpreter {
     }
 
     fn restore_routine_registry_impl(&mut self, snapshot: RoutineRegistrySnapshot, is_eval: bool) {
-        let (mut functions, proto_functions, token_defs, proto_subs, proto_tokens, our_scoped_keys) =
-            snapshot;
+        let (
+            mut functions,
+            proto_functions,
+            token_defs,
+            proto_subs,
+            proto_tokens,
+            our_scoped_keys,
+            saved_user_infix_ops,
+        ) = snapshot;
+        self.user_declared_infix_ops = saved_user_infix_ops;
         self.reinstate_module_functions(&mut functions);
         // Collect our-scoped functions that were newly added during this block
         // (not present in the snapshot) that need to persist after scope restoration.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1000,14 +1000,23 @@ pub struct Interpreter {
     /// preseed the parser when EVAL is called so that imported operators
     /// remain visible, but non-exported operators from loaded modules do not.
     pub(crate) imported_operator_names: HashSet<String>,
-    /// Short-form infix operator sub names (`infix:<+>`, ...) that have ever
-    /// been user-declared, regardless of package/associativity. Consulted as a
+    /// Short-form infix operator sub names (`infix:<+>`, ...) mapped to the
+    /// source file of their declaration (`None` = main script or imported
+    /// export, `Some(path)` = declared inside that module). Consulted as a
     /// cheap guard by the VM's native-arithmetic fast paths (`exec_add_op` and
-    /// friends) so they only pay for a full multi-dispatch resolution lookup
-    /// when a user override could plausibly exist, keeping the common
-    /// no-override hot path (e.g. tight `Int + Int` loops) free of registry
-    /// lookups.
-    pub(crate) user_declared_infix_ops: HashSet<String>,
+    /// friends). `user_infix_override` compares the stored source file against
+    /// `current_source_file()` so that a block-local `sub infix:<+>` in the
+    /// test script does NOT leak into separately-compiled module code (e.g.
+    /// Test.rakumod's `proclaim` which uses `$n + 1` for the test counter).
+    pub(crate) user_declared_infix_ops: rustc_hash::FxHashMap<String, Option<String>>,
+    /// Source file of the currently-executing compiled function body. Updated on
+    /// every compiled-function entry/exit so `user_infix_override` can check
+    /// "is the operator declaration from THIS compilation unit?" rather than
+    /// reading `?FILE` from env (which is inherited through call frames and
+    /// always reads the main script path even when executing module code).
+    /// `None` = before any compiled function is entered (top-level script code).
+    /// Initialized to the main script's path in `run.rs` alongside `?FILE`.
+    pub(crate) executing_cf_source_file: Option<String>,
     lib_paths: Vec<String>,
     /// Bundled-battery module search paths (`modules/<Dist>/lib` shipped
     /// alongside the binary). Searched *after* every `lib_paths` entry so the
@@ -2417,6 +2426,7 @@ pub(crate) type RoutineRegistrySnapshot = (
     rustc_hash::FxHashSet<String>,
     rustc_hash::FxHashSet<String>,
     rustc_hash::FxHashSet<Symbol>,
+    rustc_hash::FxHashMap<String, Option<String>>, // user_declared_infix_ops snapshot
 );
 
 /// What a lexical import scope (`{ use Foo; ... }`) restores when it pops: the

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -664,7 +664,12 @@ impl Interpreter {
         compiled: Option<&crate::opcode::CompiledFunction>,
     ) -> Result<SubRegisterOutcome, RuntimeError> {
         if name.starts_with("infix:<") {
-            self.user_declared_infix_ops.insert(name.to_string());
+            // Record the declaring compilation unit so `user_infix_override` can
+            // filter out block-local overrides when executing in a different unit
+            // (e.g. Test.rakumod's proclaim must not see a test-script-block-local
+            // `sub infix:<+>`).
+            self.user_declared_infix_ops
+                .insert(name.to_string(), self.current_source_file());
             crate::vm::vm_jit::note_user_infix_decl();
         }
         // A plain (non-multi) `sub name` supersedes any earlier empty-signature

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -382,6 +382,10 @@ impl Interpreter {
             .unwrap_or_else(|| "<unknown>".to_string());
         self.env
             .insert("?FILE".to_string(), Value::str(file_name.clone()));
+        // Track the main script's path as the initial "executing compiled-function
+        // source file" so `user_infix_override` can distinguish top-level
+        // main-script declarations from module code at call time.
+        self.executing_cf_source_file = Some(file_name.clone());
         self.cur_source_line = 1;
         crate::parser::set_parser_lib_paths(self.parser_scan_lib_paths());
         crate::parser::set_parser_program_path(self.program_path.clone());

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -771,10 +771,13 @@ impl Interpreter {
             // routine registration records the module as each sub's
             // `source_file` (module backtrace frames, error-reporting.t 15).
             let saved_qfile = self.env.get("?FILE").cloned();
-            self.env.insert(
-                "?FILE".to_string(),
-                Value::str(source_path.to_string_lossy().to_string()),
-            );
+            let module_path = source_path.to_string_lossy().to_string();
+            self.env
+                .insert("?FILE".to_string(), Value::str(module_path.clone()));
+            // Mirror into executing_cf_source_file so block-local infix-operator
+            // declarations inside the module body record the MODULE's path, not
+            // the caller's. Restored alongside ?FILE below.
+            let saved_exec_src = self.executing_cf_source_file.replace(module_path);
             // See `package_type_aliases`: the module body runs in the CALLER's env,
             // so the short-name type aliases its own `use` statements install are
             // only as long-lived as the frame that triggered the load. Snapshot the
@@ -835,6 +838,7 @@ impl Interpreter {
                     self.env.remove("?FILE");
                 }
             }
+            self.executing_cf_source_file = saved_exec_src;
             if pushed_unit {
                 self.unit_module_loading_stack.pop();
             }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1833,7 +1833,8 @@ impl Interpreter {
             native_call_specs: HashMap::new(),
             operator_assoc: HashMap::new(),
             imported_operator_names: HashSet::new(),
-            user_declared_infix_ops: HashSet::new(),
+            user_declared_infix_ops: rustc_hash::FxHashMap::default(),
+            executing_cf_source_file: None,
             lib_paths: Vec::new(),
             bundled_lib_paths: Self::resolve_bundled_lib_paths(),
             io_handles: Arc::new(RwLock::new(io_handles::IoHandleTable {

--- a/src/runtime/runtime_module_export_sub.rs
+++ b/src/runtime/runtime_module_export_sub.rs
@@ -96,7 +96,11 @@ impl Interpreter {
                 self.imported_operator_names.insert(op.to_string());
             }
             if op.starts_with("infix:<") {
-                self.user_declared_infix_ops.insert(op.to_string());
+                // Exported operators: use None (universal) so they are active in
+                // ANY executing source file.  Must use `insert` not `or_insert`
+                // because `registration_sub.rs` already inserted `Some(path)` at
+                // declaration time; `or_insert` would leave that file-scoped entry.
+                self.user_declared_infix_ops.insert(op.to_string(), None);
                 crate::vm::vm_jit::note_user_infix_decl();
             }
         }

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -356,7 +356,13 @@ impl Interpreter {
                 self.imported_operator_names.insert(name.clone());
             }
             if name.starts_with("infix:<") {
-                self.user_declared_infix_ops.insert(name.clone());
+                // Exported operators are installed into the importer's namespace.
+                // Use `None` (universal visibility) so they are active in ANY
+                // executing source file.  We must use `insert` (not `or_insert`)
+                // because the operator was already registered with
+                // `Some(module_path)` by `registration_sub.rs` at declaration
+                // time; `or_insert` would leave that file-scoped entry in place.
+                self.user_declared_infix_ops.insert(name.clone(), None);
                 crate::vm::vm_jit::note_user_infix_decl();
             }
             let source_single = format!("{module}::{name}");

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -378,6 +378,7 @@ impl Interpreter {
             operator_assoc: self.operator_assoc.clone(),
             imported_operator_names: self.imported_operator_names.clone(),
             user_declared_infix_ops: self.user_declared_infix_ops.clone(),
+            executing_cf_source_file: self.executing_cf_source_file.clone(),
             lib_paths: self.lib_paths.clone(),
             bundled_lib_paths: self.bundled_lib_paths.clone(),
             io_handles: Arc::new(RwLock::new(io_handles::IoHandleTable {

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -39,11 +39,24 @@ pub(super) fn seed_meta_assign_identity(
 
 impl Interpreter {
     /// Whether a user-declared `sub infix:<op>` is in scope for `canon`
-    /// (e.g. `"infix:<+>"`). The set is empty in the overwhelming common
+    /// (e.g. `"infix:<+>"`). The map is empty in the overwhelming common
     /// case, keeping tight numeric loops free of any registry lookup.
+    ///
+    /// The check is source-file aware: a block-local `sub infix:<+>` declared
+    /// in the test script does NOT apply when executing inside a
+    /// separately-compiled module (e.g. Test.rakumod's `proclaim`, which uses
+    /// `$n + 1` for the test counter). `executing_cf_source_file` tracks
+    /// the source file of the CURRENTLY EXECUTING compiled-function body
+    /// (updated on every compiled-function entry/exit), not the env-inherited
+    /// `?FILE` (which stays as the main script's path throughout all calls).
+    /// `None` value = exported/universal (visible from any compilation unit).
     #[inline]
-    fn user_infix_override(&self, canon: &str) -> bool {
-        !self.user_declared_infix_ops.is_empty() && self.user_declared_infix_ops.contains(canon)
+    pub(super) fn user_infix_override(&self, canon: &str) -> bool {
+        match self.user_declared_infix_ops.get(canon) {
+            None => false,
+            Some(None) => true, // exported / visible everywhere
+            Some(decl_file) => *decl_file == self.executing_cf_source_file,
+        }
     }
 
     /// METAOP_ASSIGN identity substitution (`$x OP= $y` with an undefined `$x`).
@@ -157,10 +170,7 @@ impl Interpreter {
     /// (`f(a, b)`) are compiled directly, not through `MakeArray`, so they are
     /// unaffected — matching raku, where `infix:<,>` overloads value lists only.
     pub(super) fn try_comma_overload(&mut self, n: u32) -> Result<bool, RuntimeError> {
-        if n < 2
-            || self.user_declared_infix_ops.is_empty()
-            || !self.user_declared_infix_ops.contains("infix:<,>")
-        {
+        if n < 2 || !self.user_infix_override("infix:<,>") {
             return Ok(false);
         }
         let n = n as usize;

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -129,6 +129,16 @@ impl Interpreter {
         let let_mark = self.let_saves_len();
         // Frame-less path: roll back the line the body's ops advanced to manually.
         let saved_line = self.cur_source_line;
+        // Track executing CF source file so user_infix_override can distinguish
+        // "am I in the declaring compilation unit?" from module code (e.g.
+        // Test.rakumod's proclaim using `$n + 1`). Only update when the CF has
+        // a known source; anonymous/inherited CFs keep the caller's value.
+        let saved_exec_src = if let Some(f) = cf.source_file.as_ref() {
+            let old = self.executing_cf_source_file.replace(f.clone());
+            Some(old)
+        } else {
+            None
+        };
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -331,6 +341,9 @@ impl Interpreter {
         }
 
         self.leave_routine_package(saved_package);
+        if let Some(prev) = saved_exec_src {
+            self.executing_cf_source_file = prev;
+        }
 
         let final_result = match result {
             Ok(()) if fail_bypass => Ok(ret_val),

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -223,6 +223,13 @@ impl Interpreter {
         // arity/type-check early returns above, which run under the caller's
         // package). Restored after the env merge below.
         let saved_package = self.enter_routine_package(cf);
+        // Track executing CF source file (see vm_call_fast.rs for rationale).
+        let saved_exec_src = if let Some(f) = cf.source_file.as_ref() {
+            let old = self.executing_cf_source_file.replace(f.clone());
+            Some(old)
+        } else {
+            None
+        };
 
         // A routine (sub/method) body is its own topicalizer for a bare
         // `when`/`default`: a matching `when` sets the global `when_matched`
@@ -396,6 +403,9 @@ impl Interpreter {
             }
         }
         self.leave_routine_package(saved_package);
+        if let Some(prev) = saved_exec_src {
+            self.executing_cf_source_file = prev;
+        }
 
         // Return type check (if specified). Allows type objects, Nil, and Failure through.
         if result.is_ok()

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -436,6 +436,13 @@ impl Interpreter {
         // Run the body under the routine's declaring package (set after the
         // required-param early returns above). Restored after the env merge below.
         let saved_package = self.enter_routine_package(cf);
+        // Track executing CF source file (see vm_call_fast.rs for rationale).
+        let saved_exec_src = if let Some(f) = cf.source_file.as_ref() {
+            let old = self.executing_cf_source_file.replace(f.clone());
+            Some(old)
+        } else {
+            None
+        };
 
         // A routine body is its own topicalizer for a bare `when`/`default`: a
         // matching `when` sets the global `when_matched` flag, which must not
@@ -581,6 +588,9 @@ impl Interpreter {
             }
         }
         self.leave_routine_package(saved_package);
+        if let Some(prev) = saved_exec_src {
+            self.executing_cf_source_file = prev;
+        }
 
         // Slice F (env<->locals coherence): record the captured-outer variables
         // this body writes so the call-site op writes them straight through to the

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -281,6 +281,13 @@ impl Interpreter {
         if cf.code.is_routine {
             self.set_when_matched(false);
         }
+        // Track executing CF source file (see vm_call_fast.rs for rationale).
+        let saved_exec_src = if let Some(f) = cf.source_file.as_ref() {
+            let old = self.executing_cf_source_file.replace(f.clone());
+            Some(old)
+        } else {
+            None
+        };
         // Body-internal env_dirty (from nested calls) concerns the callee env,
         // which the return merge reconciles; reset so the post-merge value
         // reflects only what was actually written back to the caller.
@@ -557,6 +564,9 @@ impl Interpreter {
             }
         }
 
+        if let Some(prev) = saved_exec_src {
+            self.executing_cf_source_file = prev;
+        }
         self.set_current_package(saved_package);
         self.pop_routine();
         self.pop_test_assertion_context(pushed_assertion);

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -675,6 +675,13 @@ impl Interpreter {
                 None
             }
         };
+        // Track executing CF source file (see vm_call_fast.rs for rationale).
+        let saved_exec_src = if let Some(f) = data.source_file.as_ref() {
+            let old = self.executing_cf_source_file.replace(f.clone());
+            Some(old)
+        } else {
+            None
+        };
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -807,6 +814,9 @@ impl Interpreter {
 
         if let Some(p) = saved_pkg {
             self.set_current_package(p);
+        }
+        if let Some(prev) = saved_exec_src {
+            self.executing_cf_source_file = prev;
         }
 
         // Natural fall-through completion (no explicit return / break arm): a

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -21,7 +21,7 @@ impl Interpreter {
         // slow path). `user_declared_infix_ops` keeps this a cheap no-op HashSet
         // lookup on the (overwhelmingly common) no-override path.
         let op_eq_name = op.user_infix_name();
-        if self.user_declared_infix_ops.contains(op_eq_name)
+        if self.user_infix_override(op_eq_name)
             && let Some(def) =
                 self.resolve_function_with_types(op_eq_name, &[left.clone(), right.clone()])
         {


### PR DESCRIPTION
## Summary

- User-defined `infix:<op>` subs declared inside a block (e.g. a test script overriding `+`) were incorrectly active inside called module code, corrupting e.g. Test.rakumod's internal arithmetic counter
- Converts `user_declared_infix_ops` from `HashSet<String>` to `FxHashMap<String, Option<String>>` where `None` = exported/universal, `Some(path)` = active only when the executing compiled function comes from that source file
- Adds `executing_cf_source_file: Option<String>` to the Interpreter, updated on every compiled-function entry/exit across all call paths and during module loading
- Exported operators use `insert(None)` (not `or_insert`) to properly upgrade file-scoped declarations to universal visibility

## Effect

- `roast/integration/advent2013-day10.t` under `MUTSU_REAL_TEST=1`: 44/44 (was 12/44)
- `roast/S06-operator-overloading/` suite: 223/223 (unchanged, including `imported-subs.t` 20/20)
- `make test`: PASS

## Test plan

- [x] `MUTSU_REAL_TEST=1 MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/integration/advent2013-day10.t` → 44/44
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S06-operator-overloading/` → 223/223
- [x] `make test` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)