### PR TITLE
feat(compiler): typed class-body op skeleton for CompiledClassDeclPlan (ADR-0019 D6-3a)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1148,6 +1148,26 @@ walkers wholesale is not possible before then.
   now safely falls through to the catch-all `class_body_other_stmt` arm with
   no behavior change. D9-1 (the role-side twin: `is_stub` + our-scope-violation
   plan facts) is not part of this slice.
+  **D6-3a landed 2026-08-09**: `CompiledClassDeclPlan` gained
+  `body_plan: Vec<ClassBodyOp>`, a new typed enum (`Attr`/`Method`/`Does`/
+  `ClassSub`/`CodeAlias`/`ProtoMethod`/`LeavePhaser`/`Other`) computed at plan
+  lowering by a new `class_body_plan` free function that mirrors
+  `run_class_body`'s own dispatch loop exactly: the same `SyntheticBlock`-
+  flattened top level, classified the same way the runtime `match` does, with
+  nested-sub `has` declarations appended at the end (same order as
+  `own_attribute_names`). The already-typed arms (`Attr`/`Does`/`ClassSub`
+  carry a name, `Method` is a bare marker) advance the existing
+  `attr_decls`/`method_decls`/`parent_arg_chunks` cursors rather than
+  duplicating their payload; `CodeAlias`/`ProtoMethod`/`LeavePhaser`/`Other`
+  carry `chunk: None` plus the raw statement, to be precompiled by D6-3b/c.
+  Purely additive — no non-test consumer reads the field yet (`#[allow(dead_code)]`
+  on the field/enum, following the `current_pos`/`is_rw` precedent, since
+  `cargo clippy -- -D warnings` lints the non-test target where a
+  `#[cfg(test)]`-only reader does not silence the lint). Pinned by a new
+  compiler unit test (`class_declarations_precompute_body_plan`) asserting
+  `body_plan.len()` against an independently re-derived flattened-statement
+  count and the typed-op sequence for one of each kind. D6-3b (compiling
+  `Other` chunks) is next.
 - [ ] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
   **Design pass done 2026-08-08 (no code landed):**

--- a/news/2026-08/adr0019-d6-3a-class-body-plan-skeleton.md
+++ b/news/2026-08/adr0019-d6-3a-class-body-plan-skeleton.md
@@ -1,0 +1,33 @@
+# ADR-0019 D6-3a: typed `body_plan` skeleton for class declarations
+
+`CompiledClassDeclPlan` gained `body_plan: Vec<ClassBodyOp>`, the first slice of D6-3
+("`body_plan` introduction, additive") from the D6/D9 `legacy_body` removal design
+(`todo/deep/adr0019-d6-d9-legacy-body-removal.md`).
+
+`ClassBodyOp` is a new typed enum — `Attr`, `Method`, `Does`, `ClassSub`, `CodeAlias`,
+`ProtoMethod`, `LeavePhaser`, `Other` — computed at plan lowering by a new
+`class_body_plan` free function that mirrors `run_class_body`'s own dispatch loop
+exactly: the same `SyntheticBlock`-flattened top level, classified the same way the
+runtime `match` does, with nested-sub `has` declarations appended at the end (the same
+order `own_attribute_names` already uses). The already-typed arms carry only a
+name/marker — `Attr`/`Does`/`ClassSub` a `Symbol`, `Method` nothing at all — since
+their real payload already lives in `attr_decls`/`method_decls`/`parent_arg_chunks`;
+the remaining arms (`CodeAlias`/`ProtoMethod`/`LeavePhaser`/`Other`) carry `chunk:
+None` plus the raw statement, to be precompiled by D6-3b/c.
+
+This slice is purely additive: no non-test code reads `body_plan` yet (D6-3d wires
+`run_class_body` to it, behind an env-var instrument per the C6e-3a precedent). Since
+`cargo clippy -- -D warnings` lints the non-test target, a `#[cfg(test)]`-only reader
+does not silence the dead-code lint on its own — the field and enum carry
+`#[allow(dead_code)]`, matching the existing `current_pos`/`is_rw` precedent in the
+same file, alongside a compiler unit test
+(`class_declarations_precompute_body_plan`) that reads the field and pins the
+invariant the design calls for: `body_plan.len()` equals the flattened statement
+count (independently re-derived in the test itself, since the parser's interstitial
+`SetLine` markers make a hand-counted literal brittle), and the typed-op sequence
+matches source order for one example of every kind.
+
+Verified via the full `t/` suite (28,019 tests) and the `S12-class` roast files.
+
+Next: D6-3b (compiling the `Other` arm's chunks, the largest and highest-value
+reader per the reader inventory).

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -33,6 +33,7 @@ pub(crate) fn shadow_slots_active() -> bool {
 #[cfg(test)]
 mod declaration_plan_tests {
     use super::Compiler;
+    use crate::ast::Stmt;
 
     #[test]
     fn sub_declarations_leave_the_generic_statement_pool() {
@@ -305,6 +306,119 @@ mod declaration_plan_tests {
             .collect();
         names.sort_unstable();
         assert_eq!(names, vec!["w", "x", "y"]);
+    }
+
+    /// ADR-0019 D6-3a: `body_plan` mirrors `run_class_body`'s own flattened
+    /// dispatch order one-op-per-statement (including the interstitial
+    /// `Stmt::SetLine` markers the parser inserts, which classify as
+    /// `Other` the same way `run_class_body`'s `_` arm treats them today),
+    /// with a nested-sub `has` appended at the end (matching
+    /// `own_attribute_names`'s own append order), and classifies each
+    /// statement kind into the right op.
+    #[test]
+    fn class_declarations_precompute_body_plan() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            r#"
+            class A {
+                has $.x;
+                method m() { 42 }
+                also does Baz;
+                sub helper() { 1 }
+                our &alias ::= &m;
+                proto method p(|) {*}
+                my $will-be-static = 1;
+                sub f { has $.w }
+            }
+            "#,
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_a = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "A")
+            .expect("class A declaration plan");
+
+        // Independently re-derive the flattened statement count (same
+        // transform `class_body_plan` applies) straight from the AST, so
+        // the length check does not hardcode a count sensitive to the
+        // parser's own `SetLine` insertion behavior.
+        let Stmt::ClassDecl { body, .. } = stmts
+            .iter()
+            .find(|s| matches!(s, Stmt::ClassDecl { name, .. } if name.as_str() == "A"))
+            .expect("class A declaration statement")
+        else {
+            unreachable!()
+        };
+        let mut flattened: Vec<&Stmt> = body
+            .iter()
+            .flat_map(|s| match s {
+                Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+                other => vec![other],
+            })
+            .collect();
+        fn collect_nested_has<'a>(stmts: &'a [Stmt], out: &mut Vec<&'a Stmt>) {
+            for s in stmts {
+                match s {
+                    Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } | Stmt::HasDecl { .. } => {}
+                    Stmt::SubDecl { body, .. } => {
+                        for inner in body {
+                            if matches!(inner, Stmt::HasDecl { .. }) {
+                                out.push(inner);
+                            }
+                        }
+                        collect_nested_has(body, out);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        collect_nested_has(body, &mut flattened);
+        assert_eq!(plan_a.body_plan.len(), flattened.len());
+
+        // Filtering out `Other` ops (which absorb both `SetLine` markers and
+        // the `my`-lexical statement, matching `declared_static_names`'s own
+        // separate handling of body statics) leaves exactly the typed arms,
+        // in source order, with the nested-sub `has` appended at the tail.
+        use crate::opcode::ClassBodyOp;
+        let typed: Vec<&ClassBodyOp> = plan_a
+            .body_plan
+            .iter()
+            .filter(|op| !matches!(op, ClassBodyOp::Other { .. }))
+            .collect();
+        assert_eq!(typed.len(), 8, "typed ops: {typed:?}");
+        assert!(matches!(
+            typed[0],
+            ClassBodyOp::Attr { name } if name.as_str() == "x"
+        ));
+        assert!(matches!(typed[1], ClassBodyOp::Method));
+        assert!(matches!(
+            typed[2],
+            ClassBodyOp::Does { name } if name.as_str() == "Baz"
+        ));
+        assert!(matches!(
+            typed[3],
+            ClassBodyOp::ClassSub { name, chunk: None, .. } if name.as_str() == "helper"
+        ));
+        assert!(matches!(
+            typed[4],
+            ClassBodyOp::CodeAlias { chunk: None, .. }
+        ));
+        assert!(matches!(
+            typed[5],
+            ClassBodyOp::ProtoMethod { chunk: None, .. }
+        ));
+        // `sub f { has $.w }` is itself a `SubDecl` (another `ClassSub`),
+        // whose nested `has $.w` is the last op, appended at the tail.
+        assert!(matches!(
+            typed[6],
+            ClassBodyOp::ClassSub { name, chunk: None, .. } if name.as_str() == "f"
+        ));
+        assert!(matches!(
+            typed[7],
+            ClassBodyOp::Attr { name } if name.as_str() == "w"
+        ));
     }
 
     /// ADR-0019 D2a: a role declaration's own attribute names, `use`d module

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2776,6 +2776,144 @@ pub(crate) struct CompiledClassDeclPlan {
     /// Evaluated at composition time (ADR-0019 D4-3) instead of
     /// `resolve_role_candidate` re-parsing the concatenated parent string.
     pub(crate) parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>,
+    /// Ordered, typed mirror of the flattened class body (ADR-0019 D6-3a),
+    /// one op per statement `run_class_body`'s dispatch loop visits (the
+    /// same `SyntheticBlock`-flattened top level, with nested-sub `has`
+    /// declarations appended at the end — see [`class_body_plan`]). Purely
+    /// additive: no non-test consumer reads this field yet (D6-3d wires
+    /// `run_class_body` to it). The already-typed arms (`Attr`/`Method`/
+    /// `Does`/`ClassSub`) carry only a name/marker, since their real
+    /// payload already lives in `attr_decls`/`method_decls`/
+    /// `parent_arg_chunks`; the remaining arms carry their raw statement
+    /// with `chunk: None` until D6-3b/c precompile them.
+    #[allow(dead_code)]
+    pub(crate) body_plan: Vec<ClassBodyOp>,
+}
+
+/// One class-body statement, typed (ADR-0019 D6-3a). See
+/// [`CompiledClassDeclPlan::body_plan`].
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) enum ClassBodyOp {
+    /// A top-level (or nested-sub) `has` declaration. Its typed descriptor
+    /// lives in `attr_decls`, keyed by this same name.
+    Attr { name: Symbol },
+    /// A `method`/`submethod` declaration. Advances the existing
+    /// `method_name_chunks`/`method_decls` position cursor.
+    Method,
+    /// A body-level `also does Role` clause.
+    Does { name: Symbol },
+    /// A `sub` declaration. Runs like `Other` (via `chunk`), plus carries
+    /// the fact that a successful registration also needs the
+    /// `class_subs` tail-probe `run_class_body` performs after executing it.
+    ClassSub {
+        name: Symbol,
+        chunk: Option<CompiledDeclExpr>,
+        raw: Stmt,
+    },
+    /// `our &baz ::= &bar` — alias a method under a new name.
+    CodeAlias {
+        chunk: Option<CompiledDeclExpr>,
+        raw: Stmt,
+    },
+    /// A `proto method`/`proto submethod` declaration.
+    ProtoMethod {
+        chunk: Option<CompiledDeclExpr>,
+        raw: Stmt,
+    },
+    /// A `will leave { ... }`-style class-body-scoped LEAVE phaser.
+    LeavePhaser {
+        chunk: Option<CompiledDeclExpr>,
+        raw: Stmt,
+    },
+    /// Everything else (`use`/`need`, nested `class`/`role`, BEGIN/CHECK,
+    /// EVAL, `my`/`our` lexicals, `token`/`rule` declarations, ...).
+    /// `token`/`rule` statements are excluded from D6/D9's compiled-chunk
+    /// cutover (the phase preamble's ADR-0009 carve-out) and keep `chunk:
+    /// None` permanently — every other kind gets one in D6-3b.
+    Other {
+        chunk: Option<CompiledDeclExpr>,
+        raw: Stmt,
+    },
+}
+
+/// Lower a class body into its ordered, typed op mirror (ADR-0019 D6-3a),
+/// matching `run_class_body`'s own dispatch loop exactly: `SyntheticBlock`-
+/// flatten the top level, classify each statement the same way the runtime
+/// match does, then append nested-sub `has` declarations (in
+/// `Interpreter::collect_nested_class_has_decls` order) as more `Attr` ops —
+/// `run_class_body` appends them to the same iteration, not a separate pass.
+fn class_body_plan(body: &[Stmt]) -> Vec<ClassBodyOp> {
+    let mut flattened: Vec<&Stmt> = body
+        .iter()
+        .flat_map(|s| match s {
+            Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+            other => vec![other],
+        })
+        .collect();
+    collect_nested_has_decl_stmts(body, &mut flattened);
+    flattened
+        .iter()
+        .map(|stmt| classify_class_body_stmt(stmt))
+        .collect()
+}
+
+/// `Interpreter::collect_nested_class_has_decls`'s compile-time mirror: `has`
+/// declarations inside a body `sub`, in the same order, as statement
+/// references rather than just names (unlike [`collect_nested_has_decl_names`]).
+fn collect_nested_has_decl_stmts<'a>(stmts: &'a [Stmt], out: &mut Vec<&'a Stmt>) {
+    for s in stmts {
+        match s {
+            Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } | Stmt::HasDecl { .. } => {}
+            Stmt::SubDecl { body, .. } => {
+                for inner in body {
+                    if matches!(inner, Stmt::HasDecl { .. }) {
+                        out.push(inner);
+                    }
+                }
+                collect_nested_has_decl_stmts(body, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn classify_class_body_stmt(stmt: &Stmt) -> ClassBodyOp {
+    match stmt {
+        Stmt::Phaser {
+            kind: crate::ast::PhaserKind::Leave,
+            ..
+        } => ClassBodyOp::LeavePhaser {
+            chunk: None,
+            raw: stmt.clone(),
+        },
+        Stmt::HasDecl { name, .. } => ClassBodyOp::Attr { name: *name },
+        Stmt::MethodDecl { .. } => ClassBodyOp::Method,
+        Stmt::DoesDecl { name, .. } => ClassBodyOp::Does { name: *name },
+        Stmt::VarDecl {
+            expr: Expr::CodeVar(_),
+            name: var_name,
+            ..
+        } if var_name.starts_with('&') => ClassBodyOp::CodeAlias {
+            chunk: None,
+            raw: stmt.clone(),
+        },
+        Stmt::ProtoDecl {
+            is_method: true, ..
+        } => ClassBodyOp::ProtoMethod {
+            chunk: None,
+            raw: stmt.clone(),
+        },
+        Stmt::SubDecl { name, .. } => ClassBodyOp::ClassSub {
+            name: *name,
+            chunk: None,
+            raw: stmt.clone(),
+        },
+        _ => ClassBodyOp::Other {
+            chunk: None,
+            raw: stmt.clone(),
+        },
+    }
 }
 
 /// One `does`/`hides`/`is hidden` clause from a role's own body, as a typed
@@ -6092,6 +6230,7 @@ impl CompiledCode {
             .collect();
         let own_attribute_names = class_own_attribute_names(body);
         let declared_static_names = class_declared_static_names(body);
+        let body_plan = class_body_plan(body);
         let mut method_decls = compile_method_decls(body);
         // ADR-0019 D3-8a: attach each method's precomputed main-pass
         // bytecode key, position-aligned by the same flattened walk
@@ -6123,6 +6262,7 @@ impl CompiledCode {
             method_decls,
             declared_static_names,
             parent_arg_chunks,
+            body_plan,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Class(plan_idx));

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -144,6 +144,7 @@ impl Interpreter {
             method_decls,
             declared_static_names,
             parent_arg_chunks,
+            body_plan: _,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {


### PR DESCRIPTION
## Summary
- `CompiledClassDeclPlan` gains `body_plan: Vec<ClassBodyOp>`, a typed op mirror of the flattened class body — the first slice (D6-3a) of D6-3 in the `legacy_body` removal design (`todo/deep/adr0019-d6-d9-legacy-body-removal.md`).
- A new `class_body_plan` free function classifies each statement the same way `run_class_body`'s own dispatch loop does (`SyntheticBlock`-flattened top level, nested-sub `has` declarations appended at the end). Already-typed arms (`Attr`/`Method`/`Does`/`ClassSub`) carry only a name/marker since their real payload lives in `attr_decls`/`method_decls`/`parent_arg_chunks`; the rest (`CodeAlias`/`ProtoMethod`/`LeavePhaser`/`Other`) carry `chunk: None` plus the raw statement, to be precompiled in D6-3b/c.
- Purely additive — no non-test code reads the field yet. `#[allow(dead_code)]` on the field/enum matches the existing `current_pos`/`is_rw` precedent in `opcode.rs`, since `cargo clippy -- -D warnings` lints the non-test target and a `#[cfg(test)]`-only reader doesn't silence it.
- New compiler unit test `class_declarations_precompute_body_plan` pins the design's invariant: `body_plan.len()` equals an independently re-derived flattened-statement count, and the typed-op sequence matches source order for one example of every kind.

## Test plan
- [x] `cargo test --lib` (695 passed)
- [x] `make test` (28,019 tests, PASS)
- [x] `cargo clippy -- -D warnings` clean
- [x] `MUTSU_FUDGE=1 prove -e target/release/mutsu roast/S12-class/*.t` (only the pre-existing, non-whitelisted `open_closed.t` failure, unrelated to this change)
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)