### PR TITLE
fix(runtime): stop a method/sub parameter's shadow from clobbering a caller's same-named lexical

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1481,6 +1481,28 @@ pub struct Interpreter {
     /// in-flight window closes that hole; the store is republished normally once
     /// the initializer's value lands. Empty for single-threaded programs.
     pub(crate) thread_decl_in_flight: std::collections::HashSet<String>,
+    /// Bare scalar names currently masked in [`Self::thread_redeclared_vars`]
+    /// because of a **parameter binding** (`mask_thread_redeclared_params`),
+    /// not a `my` declaration. `clone_for_thread_excluding` must treat the two
+    /// differently: a `my` re-declaration's mask means "this spawn should see
+    /// MY new value as authoritative for the rest of the block", so it force-
+    /// `declare`s the value into the shared lineage. A parameter's shadow is
+    /// scoped to exactly this call and must never overwrite an unrelated
+    /// caller's live entry for the same bare name — it should always take the
+    /// `seed_if_absent` (no-op-if-already-visible) branch instead, even for a
+    /// nested spawn *inside this call's own body*.
+    ///
+    /// `thread_decl_in_flight` looked like the same "always seed_if_absent"
+    /// signal, but it is unsuitable here: `exec_set_local_op` clears an entry
+    /// from it as soon as ANY `SetLocal` targets a same-named slot — which the
+    /// call body's own bytecode does routinely (e.g. a coercion or a
+    /// re-assignment of the parameter), silently un-suppressing the force-
+    /// `declare` behavior partway through the call before any nested spawn.
+    /// A dedicated set, touched only by
+    /// [`mask_thread_redeclared_params`](Self::mask_thread_redeclared_params) /
+    /// [`unmask_thread_redeclared_params`](Self::unmask_thread_redeclared_params),
+    /// has no such interference. Empty for single-threaded programs.
+    pub(crate) thread_param_shadow_vars: std::collections::HashSet<String>,
     /// `@`/`%` names bound as **parameters through the env-level (runtime)
     /// binding path** — a destructuring sub-signature (`-> [$a, @K] { ... }`)
     /// or a runtime-invoked callback's plain parameter (`reduce -> $h, @words

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2178,6 +2178,7 @@ impl Interpreter {
             state_vars: HashMap::new(),
             thread_redeclared_vars: std::collections::HashSet::new(),
             thread_decl_in_flight: std::collections::HashSet::new(),
+            thread_param_shadow_vars: std::collections::HashSet::new(),
             param_bound_aggregates: std::collections::HashMap::new(),
             suppress_shared_publish: false,
             type_body_written_lexicals: std::collections::HashSet::new(),

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -1,6 +1,18 @@
 use super::*;
 use crate::value::ValueView;
 
+/// The bare scalar names [`Interpreter::mask_thread_redeclared_params`] newly
+/// added to `thread_redeclared_vars` / `thread_param_shadow_vars` for one
+/// call, so [`Interpreter::unmask_thread_redeclared_params`] can remove
+/// exactly those entries — from each set independently — on return, without
+/// disturbing a still-active ancestor frame's own mask. See the doc comment
+/// on `mask_thread_redeclared_params` for why the two sets are tracked apart.
+#[derive(Default)]
+pub(crate) struct ThreadParamMask {
+    redeclared: Vec<String>,
+    shadowed: Vec<String>,
+}
+
 impl Interpreter {
     /// Track C: assign a single hash element (`%h{$k} = $v`) through the shared
     /// cell so concurrent `start { %h{...} = ... }` blocks all land instead of
@@ -199,6 +211,76 @@ impl Interpreter {
         self.shared_vars_active
             && key.starts_with(['@', '%'])
             && self.thread_redeclared_vars.contains(key)
+    }
+
+    /// Mask each scalar parameter name in `names` as a fresh per-invocation
+    /// binding while the cross-thread shared store is active — the call-site
+    /// analogue of the `my` declaration mask `exec_set_var_dynamic_op` applies
+    /// (see its comment). A plain `thread_redeclared_vars` mask alone is not
+    /// enough for a *parameter*: unlike a `my` in the current block, the
+    /// parameter's shadow is scoped to exactly this call, but
+    /// `clone_for_thread_excluding` cannot tell the difference and would
+    /// force-`declare` the parameter's (shadowed) value into the shared store
+    /// on any nested spawn during the call body, clobbering an unrelated
+    /// caller's live entry for the same bare name (e.g. `Cro::HTTP::Client`'s
+    /// `request`/`!get-pipeline` methods each have their own `$url` parameter;
+    /// a `Promise.in(...)` spawned inside `!get-pipeline`'s body force-published
+    /// its `Cro::Uri $url` over the awaiting `start { ... }` block's own
+    /// `my $url`). Recording the name in
+    /// [`thread_param_shadow_vars`](Self::thread_param_shadow_vars) routes such
+    /// a nested spawn through `clone_for_thread_excluding`'s `seed_if_absent`
+    /// branch instead — a no-op when the name is already visible, which is
+    /// exactly the outer binding's case.
+    ///
+    /// `thread_redeclared_vars` and `thread_param_shadow_vars` are tracked
+    /// **independently**: a name can already be in `thread_redeclared_vars`
+    /// for an unrelated, possibly-stale reason (an ancestor frame's `my`
+    /// declaration whose mask nothing has cleared yet — the mask is not scoped
+    /// per declaration site). If this call deferred to that pre-existing mask
+    /// and skipped adding its own `thread_param_shadow_vars` entry, the stale
+    /// mask's "genuine `my`, safe to force-declare" semantics would apply to
+    /// THIS call's parameter too, re-opening the same clobbering hole. So this
+    /// call always ensures ITS OWN membership in `thread_param_shadow_vars`
+    /// while it runs, regardless of whether `thread_redeclared_vars` already
+    /// held the name, and tracks separately (per name) whether IT was the one
+    /// that added each entry — so
+    /// [`unmask_thread_redeclared_params`](Self::unmask_thread_redeclared_params)
+    /// removes exactly what this call added, from each set independently,
+    /// without disturbing a still-active ancestor's own mask.
+    pub(crate) fn mask_thread_redeclared_params<'a>(
+        &mut self,
+        names: impl Iterator<Item = &'a str>,
+    ) -> ThreadParamMask {
+        let mut mask = ThreadParamMask::default();
+        if !self.shared_vars_active {
+            return mask;
+        }
+        for name in names {
+            if name.is_empty() || name == "_" || name == "self" || name.starts_with(['@', '%', '&'])
+            {
+                continue;
+            }
+            let bare = name.trim_start_matches('$').to_string();
+            if self.thread_redeclared_vars.insert(bare.clone()) {
+                mask.redeclared.push(bare.clone());
+            }
+            if self.thread_param_shadow_vars.insert(bare.clone()) {
+                mask.shadowed.push(bare);
+            }
+        }
+        mask
+    }
+
+    /// Undo exactly the masking [`mask_thread_redeclared_params`] applied for
+    /// this call, restoring bare-name shared-store visibility for the
+    /// parameter's name once the call returns.
+    pub(crate) fn unmask_thread_redeclared_params(&mut self, mask: &ThreadParamMask) {
+        for name in &mask.redeclared {
+            self.thread_redeclared_vars.remove(name);
+        }
+        for name in &mask.shadowed {
+            self.thread_param_shadow_vars.remove(name);
+        }
     }
 
     /// Snapshot the set of keys currently present in `shared_vars`. Used by the

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -230,8 +230,17 @@ impl Interpreter {
                 // it would overwrite the lane with a value that is about to be
                 // stale. Seed it only to give the child *something* under the name
                 // (it captured the outer binding), and keep the mask below.
+                //
+                // A name masked because of a *parameter* binding
+                // (`thread_param_shadow_vars`, see `mask_thread_redeclared_params`)
+                // never takes the force-`declare` branch, even outside any
+                // in-flight window: the parameter's shadow is scoped to exactly
+                // the call that bound it, not "the rest of this block", so a
+                // nested spawn inside that call must not overwrite an unrelated
+                // caller's live entry for the same bare name.
                 if self.thread_redeclared_vars.contains(&key)
                     && !self.thread_decl_in_flight.contains(&key)
+                    && !self.thread_param_shadow_vars.contains(&key)
                 {
                     shared.declare(&key, val.clone());
                     seed_inserts += 1;
@@ -280,9 +289,19 @@ impl Interpreter {
         // the new binding — `my $tap = IO::Socket::Async.listen(...).tap({...})`
         // in a loop reverted to the previous iteration's `Tap`, which is what
         // made a restarted `Cro::HTTP::Server` keep answering from the old one.
+        //
+        // A parameter-binding mask (`thread_param_shadow_vars`) survives this
+        // pass unconditionally for the same reason as an in-flight `my`: the
+        // shadow is scoped to the still-executing call, not to "since the last
+        // spawn", so dropping it here (because the call didn't happen to be the
+        // very first spawn) would let the next `sync_shared_vars_to_env` pull
+        // the caller's unrelated value back over the parameter for the
+        // remainder of the call. Explicit `unmask_thread_redeclared_params` at
+        // the call's return is the only thing that ever clears it.
         self.thread_redeclared_vars.retain(|n| {
             captured_scalars.contains(n.trim_start_matches('$'))
                 || self.thread_decl_in_flight.contains(n)
+                || self.thread_param_shadow_vars.contains(n)
         });
         let mut cloned_handles = HashMap::new();
         let handles_guard = self.io_handles();
@@ -496,6 +515,9 @@ impl Interpreter {
             // The child starts no declaration of its own; its own `my`s populate
             // this as they run.
             thread_decl_in_flight: std::collections::HashSet::new(),
+            // The child starts no call of its own; its own parameter bindings
+            // populate this as they run.
+            thread_param_shadow_vars: std::collections::HashSet::new(),
             // The child re-binds its own env-bound parameters if it runs any.
             param_bound_aggregates: std::collections::HashMap::new(),
             suppress_shared_publish: false,

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -209,23 +209,15 @@ impl Interpreter {
         // `$desc` holding `inner`'s argument (`t/thread-callee-param-does-not-
         // clobber-caller.t`). Scalars only, for the same reason as the `my`
         // case: `@`/`%` names back the atomic element stores and `&` names are
-        // routines.
-        if self.shared_vars_active {
-            for pd in &cf.param_defs {
-                let name = pd.name.as_str();
-                if name.is_empty()
-                    || name == "_"
-                    || name == "self"
-                    || name.starts_with('@')
-                    || name.starts_with('%')
-                    || name.starts_with('&')
-                {
-                    continue;
-                }
-                self.thread_redeclared_vars
-                    .insert(name.trim_start_matches('$').to_string());
-            }
-        }
+        // routines. See `mask_thread_redeclared_params` for why a nested spawn
+        // *inside this call's own body* also needs the `thread_param_shadow_vars`
+        // companion mark (a bare `thread_redeclared_vars` mask alone still lets
+        // `clone_for_thread_excluding` force-publish the parameter's shadowed
+        // value over an unrelated caller's live entry of the same bare name);
+        // unmasked again at every return path below (search
+        // `unmask_thread_redeclared_params`).
+        let masked_params =
+            self.mask_thread_redeclared_params(cf.param_defs.iter().map(|pd| pd.name.as_str()));
         self.prepare_definite_return_slot(return_spec.as_deref());
 
         // Raku: $! is scoped per routine — fresh Nil on entry.
@@ -470,6 +462,11 @@ impl Interpreter {
         }
 
         self.stack.truncate(saved_stack_depth);
+
+        // Restore bare-name shared-store visibility for this call's own
+        // parameter names now that the call is over (see
+        // `mask_thread_redeclared_params`).
+        self.unmask_thread_redeclared_params(&masked_params);
 
         // Sync state variables back to persistent storage.
         // Read from env first (methods like push update env directly),

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -565,6 +565,23 @@ impl Interpreter {
                 return Err(e);
             }
         };
+        // A method parameter is a fresh per-invocation binding, exactly like a
+        // sub parameter (see the matching mark in
+        // `call_compiled_function_named_inner`): while the cross-thread shared
+        // store is active, its writes must stay thread-local instead of leaking
+        // to an unrelated caller's same-named lexical through the name-keyed
+        // store. Without this, a method whose own parameter happens to share a
+        // name with a lexical live in the awaiting frame (e.g.
+        // `Cro::HTTP::Client.request(Str $method, $url, ...)` called from a
+        // `start { ... await ... }` block that has its own `my $url`) clobbers
+        // the caller's variable once `await` syncs shared vars back — the
+        // callee's `$url` parameter is mistaken for a write to the caller's
+        // `$url`. See `mask_thread_redeclared_params` for why a bare
+        // `thread_redeclared_vars` mask alone is not sufficient and the
+        // `thread_param_shadow_vars` companion is also needed. Unmasked again
+        // at return (search `unmask_thread_redeclared_params`).
+        let masked_params =
+            self.mask_thread_redeclared_params(bind_param_defs.iter().map(|pd| pd.name.as_str()));
 
         // Initialize locals from env
         self.locals = vec![Value::NIL; cc.locals.len()];
@@ -873,6 +890,11 @@ impl Interpreter {
             let frame = self.pop_call_frame();
             *self.env_mut() = frame.saved_env;
         }
+
+        // Restore bare-name shared-store visibility for this call's own
+        // parameter names now that the call is over (see
+        // `mask_thread_redeclared_params`).
+        self.unmask_thread_redeclared_params(&masked_params);
 
         let final_result = match result {
             Ok(()) => Ok(explicit_return.unwrap_or(ret_val)),

--- a/t/cro-client-nested-param-shadow.t
+++ b/t/cro-client-nested-param-shadow.t
@@ -1,0 +1,86 @@
+use Test;
+use lib $*PROGRAM.parent(1).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+# Regression test for a cross-thread shared-variable clobber: a method's own
+# TYPED parameter (e.g. Cro::HTTP::Client's private
+# `!get-pipeline(Cro::Uri $url, ...)`) shares a bare name with an unrelated
+# lexical live in an awaiting `start { ... }` block (`my $url` in the test
+# script). Once the cross-thread shared-variable store is active, a nested
+# spawn happening *inside* the shadowing call (e.g. a `Promise.in(...)`
+# started deep in Cro's connection-establishment code) force-published the
+# callee's shadowed `$url` value into the store under the same bare name,
+# and the caller's next `await` pulled the wrong value back over its own
+# `$url` -- corrupting it permanently after the first HTTP request.
+#
+# Root cause and fix: src/runtime/runtime_shared_vars.rs
+# (`mask_thread_redeclared_params` / `ThreadParamMask` /
+# `unmask_thread_redeclared_params`), consulted from
+# src/runtime/runtime_thread.rs (`clone_for_thread_excluding`) and applied at
+# every method/sub call boundary in src/vm/vm_method_dispatch.rs
+# (`call_compiled_method`) and src/vm/vm_call_named_inner.rs
+# (`call_compiled_function_named_inner`).
+#
+# A from-scratch pure-Raku minimal repro was not found after extensive
+# investigation (the trigger needs the exact combination of: a nested spawn
+# happening while a same-named parameter is live, a shared-store dirty-mark
+# on the *caller's* lexical, and an env-based -- not local-slot-based --
+# read of it back in the caller; see the investigation notes referenced from
+# the PR this test shipped with). Pinning against the real vendored
+# Cro::HTTP::Client instead, per CLAUDE.md's testing conventions, is the
+# fallback when a minimal repro proves elusive.
+#
+# Requires the vendored Cro::HTTP dist tree under tmp/cro-work/ (built by a
+# local scratch script; not part of the committed tree). Automatically
+# skipped when absent -- including in CI, where this scratch directory is
+# never populated.
+
+my $inc-file = 'tmp/cro-work/inc-paths.txt'.IO;
+
+unless $inc-file.e {
+    plan :skip-all<Cro::HTTP vendored dist not present under tmp/cro-work/ (local-only regression test; see tmp/cro-suite-run.sh)>;
+}
+
+plan 1;
+
+my @compiler-args = $inc-file.slurp.words;
+
+my $code = q:to/RAKU/;
+use Cro::HTTP::Router;
+use Cro::HTTP::Server;
+use Cro::HTTP::Client;
+
+constant TEST_PORT = 31427;
+my $url = "http://localhost:{TEST_PORT}";
+
+my $app = route {
+    get -> 'route' {
+        content 'text/plain', 'GET response';
+    }
+}
+
+my $service = Cro::HTTP::Server.new(:host('localhost'), :port(TEST_PORT), application => $app);
+$service.start;
+
+my $p = start {
+    my $r1 = (await Cro::HTTP::Client.get("$url/route")).status;
+    my $before2 = $url;
+    my ($r2, $err);
+    try {
+        $r2 = (await Cro::HTTP::Client.get("$url/route")).status;
+        CATCH { default { $err = .message; } }
+    }
+    say "RESULT r1=$r1 before2=$before2 r2={$r2 // 'undef'} err={$err // ''}";
+    CATCH { default { say "RESULT caught: {.message}"; } }
+}
+# Await the block itself instead of a fixed `sleep` -- this must pass under
+# both the fast release binary (`make roast`) and the much slower debug
+# binary (`make test`, ADR-0014) without a fragile hardcoded timing budget.
+await $p;
+$service.stop;
+RAKU
+
+is_run $code,
+    { out => /'RESULT r1=200 before2=http://localhost:31427 r2=200'/, status => 0 },
+    :@compiler-args,
+    'a second Cro::HTTP::Client request inside the same start{} block does not corrupt an outer $url lexical';


### PR DESCRIPTION
## Summary

- A method/sub parameter that happens to share a bare name with a lexical live in an awaiting `start { ... }` block could clobber that caller's variable once the cross-thread shared-variable store got involved. Concrete case: `Cro::HTTP::Client`'s private `!get-pipeline(Cro::Uri $url, ...)` shadows the caller's own `my $url`; a nested spawn inside the shadowing call (e.g. a `Promise.in(...)` started deep in Cro's connection-establishment code) force-published the callee's shadowed value into the shared store under the bare name `url`, and the caller's next `await` pulled the wrong value back over its own `$url` — corrupting it permanently after the first HTTP request (every subsequent request's path became `/route/route/...`, 404).
- Root cause: `clone_for_thread_excluding` treated every name in `thread_redeclared_vars` as a genuine `my`-declaration shadow (whose value should be force-`declare`d into the shared lineage on any nested spawn — correct for a `my` that shadows for the rest of an enclosing block). A parameter's shadow is different: it's scoped to exactly the one call that bound it, and must never overwrite an unrelated caller's live entry for the same bare name.
- Fix: new `mask_thread_redeclared_params` / `unmask_thread_redeclared_params` (`src/runtime/runtime_shared_vars.rs`) mark a call's own scalar parameter names in a new, **independently-tracked** `thread_param_shadow_vars` set, which `clone_for_thread_excluding` (`src/runtime/runtime_thread.rs`) consults to always take the safe `seed_if_absent` branch for such a name instead of force-declaring. Applied at both call-boundary sites: `call_compiled_method` (`src/vm/vm_method_dispatch.rs`) and `call_compiled_function_named_inner` (`src/vm/vm_call_named_inner.rs`, which already had a narrower, single-set version of this protection for plain subs — this change generalizes and hardens it).

## Test plan

- [x] `t/cro-client-nested-param-shadow.t` added — pinned against the real vendored Cro::HTTP::Client (skipped automatically when the local `tmp/cro-work/` scratch dist isn't present, e.g. in CI). An extensive search for a from-scratch pure-Raku minimal repro did not turn one up; the trigger needs a specific combination of a nested spawn while shadowed, a shared-store dirty mark on the caller's lexical, and an env-based (not local-slot-based) read of it back in the caller.
- [x] `cargo fmt -- --check` / `cargo clippy -- -D warnings` clean
- [x] `make test` passes (2976 files, 28023 tests)
- [x] Manually re-confirmed the original failing Cro repro now succeeds (both requests return 200, `$url` stays uncorrupted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)