### PR TITLE
feat(vendor-test): route MUTSU_REAL_TEST=1 through vendored Test.rakumod

### DIFF
--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -238,7 +238,14 @@ impl Interpreter {
         // a plan nobody ran against, and `finish()` reported "You planned 14
         // test, but ran 0" on a file whose assertions had all passed.
         let user_declared = self.user_test_decl_beats_native(name, args);
+        // Under MUTSU_REAL_TEST=1 the real Test.rakumod owns the TAP state and
+        // all test assertions go through it.  The native handlers bypass that
+        // (they write to stdout directly and don't increment the real module's
+        // counters), so skip them here too — user declarations still win via
+        // `user_test_decl_beats_native` above; the native provider is only the
+        // fallback for files that call Test helpers without loading the module.
         if !user_declared
+            && !Self::real_test_module_enabled()
             && (self.loaded_modules.contains("Test")
                 || self.loaded_modules.iter().any(|m| m.starts_with("Test::")))
             && let Some(result) = self.call_test_function(name, args)?

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -141,7 +141,15 @@ impl Interpreter {
         // todo/tickets/retire-native-test-util-overrides.md, which now tracks
         // the seven roast files the widened guard exposes.
         let user_declared = self.user_test_decl_beats_native(name, &args);
-        if !user_declared && let Some(result) = self.call_test_function(name, &args)? {
+        // Under MUTSU_REAL_TEST=1 the real Test.rakumod owns the TAP state.
+        // The native handlers bypass that (they write to stdout directly and
+        // don't increment the real module's counters), so skip them — the real
+        // Raku sub (loaded from Test.rakumod / Test::Util source) must handle
+        // it.
+        if !user_declared
+            && !Self::real_test_module_enabled()
+            && let Some(result) = self.call_test_function(name, &args)?
+        {
             return Ok(result);
         }
         match name {

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -882,10 +882,13 @@ impl Interpreter {
     }
 
     pub(crate) fn user_function_matches_call(&mut self, name: &str, args: &[Value]) -> bool {
-        if !self.has_function(name) && !self.has_multi_function(name) {
+        let has_fn = self.has_function(name);
+        let has_multi = self.has_multi_function(name);
+        if !has_fn && !has_multi {
             return false;
         }
-        let Some(def) = self.resolve_function_with_types(name, args) else {
+        let def = self.resolve_function_with_types(name, args);
+        let Some(def) = def else {
             return false;
         };
         self.args_match_param_types(args, &def.param_defs)

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -54,27 +54,39 @@ impl Interpreter {
         }
         if let Some(path) = &self.program_path {
             let top_module = module.split("::").next().unwrap_or(module);
+            // The roast test suite's Test-Helpers package lives under
+            // `roast/packages/Test-Helpers/lib/` (NOT `Test/lib/`).  Build
+            // both the bare top_module name AND the `{top_module}-Helpers`
+            // variant so that `use Test::Util` resolves to
+            // `roast/packages/Test-Helpers/lib/Test/Util.rakumod`.
+            let top_module_variants: Vec<String> = {
+                let mut v = vec![top_module.to_string()];
+                v.push(format!("{}-Helpers", top_module));
+                v
+            };
             for ancestor in Path::new(path).ancestors() {
                 if ancestor.as_os_str().is_empty() {
                     continue;
                 }
-                for ext in &extensions {
-                    let filename = format!("{}{}", base_name, ext);
-                    candidates.push(
-                        ancestor
-                            .join("packages")
-                            .join(top_module)
-                            .join("lib")
-                            .join(&filename),
-                    );
-                    candidates.push(
-                        ancestor
-                            .join("roast")
-                            .join("packages")
-                            .join(top_module)
-                            .join("lib")
-                            .join(&filename),
-                    );
+                for top in &top_module_variants {
+                    for ext in &extensions {
+                        let filename = format!("{}{}", base_name, ext);
+                        candidates.push(
+                            ancestor
+                                .join("packages")
+                                .join(top)
+                                .join("lib")
+                                .join(&filename),
+                        );
+                        candidates.push(
+                            ancestor
+                                .join("roast")
+                                .join("packages")
+                                .join(top)
+                                .join("lib")
+                                .join(&filename),
+                        );
+                    }
                 }
             }
         }

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -14,9 +14,16 @@ impl Interpreter {
     /// is driven — the sweep tooling uses it, and it replaces the throwaway
     /// `unit module Test2;` rename the exercise ran under before.
     pub(crate) fn real_test_module_enabled() -> bool {
-        std::env::var("MUTSU_REAL_TEST")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
+        // Captured once at startup so that `%*ENV<MUTSU_REAL_TEST> = '1'` set
+        // mid-run in a parent process (as `t/vendored-real-test-module.t` does)
+        // does NOT retroactively silence the native TAP provider already in
+        // charge of that process.
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            std::env::var("MUTSU_REAL_TEST")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false)
+        })
     }
 
     /// Save current function/class/proto keys for lexical import scoping.

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -3,6 +3,25 @@ use crate::symbol::Symbol;
 use std::sync::Arc;
 
 impl Interpreter {
+    /// Extract the NOMINAL type from a type constraint string.
+    ///
+    /// Raku coercion types like `Bool(Mu)` mean "accept Mu (the nominal type) and
+    /// coerce it to Bool". For autothreading purposes, only the nominal type matters:
+    /// a `Bool(Mu)` parameter accepts Mu (which includes Junction), so no threading.
+    ///
+    /// Examples:
+    ///   `"Bool(Mu)"` → `"Mu"` (nominal = Mu, accepts Junction)
+    ///   `"Str(Any)"` → `"Any"` (nominal = Any, does thread)
+    ///   `"Bool"`     → `"Bool"` (no coercion)
+    fn nominal_type(type_constraint: &str) -> &str {
+        // `CoerceTo(NominalType)` — extract the inner type
+        if let Some(inner_start) = type_constraint.find('(')
+            && type_constraint.ends_with(')')
+        {
+            return &type_constraint[inner_start + 1..type_constraint.len() - 1];
+        }
+        type_constraint
+    }
     /// Check if any function call arguments are Junctions that need auto-threading.
     /// Returns Some(result) if auto-threading was performed, None if no auto-threading needed.
     pub(super) fn maybe_autothread_func_call(
@@ -127,10 +146,11 @@ impl Interpreter {
                         .find(|pd| pd.named && !pd.slurpy && !pd.double_slurpy && pd.name == *key)
                     {
                         if let Some(tc) = &pd.type_constraint {
-                            if matches!(tc.as_str(), "Mu" | "Junction") {
+                            let nominal = Self::nominal_type(tc.as_str());
+                            if matches!(nominal, "Mu" | "Junction") {
                                 return false;
                             }
-                            let resolved_base = self.resolve_subset_base_type(tc);
+                            let resolved_base = self.resolve_subset_base_type(nominal);
                             return !matches!(resolved_base.as_str(), "Mu" | "Junction");
                         }
                         return true; // No type constraint = default Any
@@ -158,16 +178,19 @@ impl Interpreter {
                     if pd.slurpy || pd.onearg || pd.double_slurpy {
                         return false;
                     }
-                    // Don't auto-thread if param accepts Mu or Junction
+                    // Don't auto-thread if param accepts Mu or Junction.
+                    // For coercion types like `Bool(Mu)`, the nominal type is the
+                    // inner type (Mu here) — autothreading is based on the nominal.
                     if let Some(tc) = &pd.type_constraint {
-                        if matches!(tc.as_str(), "Mu" | "Junction") {
+                        let nominal = Self::nominal_type(tc.as_str());
+                        if matches!(nominal, "Mu" | "Junction") {
                             return false;
                         }
                         // Don't auto-thread if the type constraint is a subset
                         // whose ultimate base type is Mu or Junction — the
                         // junction should be passed as-is to the subset's
                         // where-clause check.
-                        let resolved_base = self.resolve_subset_base_type(tc);
+                        let resolved_base = self.resolve_subset_base_type(nominal);
                         if matches!(resolved_base.as_str(), "Mu" | "Junction") {
                             return false;
                         }
@@ -521,7 +544,49 @@ impl Interpreter {
     ) -> Option<Vec<crate::ast::ParamDef>> {
         // Replace junction args with non-junction placeholder values for type resolution
         let resolved_args: Vec<Value> = args.iter().map(Self::unwrap_junction_deep).collect();
-        loan_env!(self, resolve_function_with_types(name, &resolved_args))
-            .map(|def| def.param_defs.clone())
+        if let Some(def) =
+            loan_env!(self, resolve_function_with_types(name, &resolved_args)).map(|d| d.clone())
+        {
+            return Some(def.param_defs.clone());
+        }
+        // Native operators (infix:<eq>, prefix:<!>, etc.) are not in the function
+        // registry but never accept Mu or Junction — synthesize Any-typed param defs
+        // so Junction args autothread through them (e.g. `&CALLER::LEXICAL::("infix:<eq>")`
+        // called from Test.rakumod's `cmp-ok` with a Junction expected value).
+        if (name.starts_with("infix:<")
+            || name.starts_with("prefix:<")
+            || name.starts_with("postfix:<"))
+            && name.ends_with('>')
+        {
+            let n = if name.starts_with("prefix:<") || name.starts_with("postfix:<") {
+                1usize
+            } else {
+                2usize
+            };
+            let pd = crate::ast::ParamDef {
+                name: String::new(),
+                default: None,
+                multi_invocant: false,
+                required: false,
+                named: false,
+                slurpy: false,
+                double_slurpy: false,
+                onearg: false,
+                sigilless: false,
+                type_constraint: None, // None = Any → autothread
+                literal_value: None,
+                sub_signature: None,
+                where_constraint: None,
+                traits: Vec::new(),
+                optional_marker: false,
+                outer_sub_signature: None,
+                code_signature: None,
+                is_invocant: false,
+                shape_constraints: None,
+                block_param: false,
+            };
+            return Some(vec![pd; n]);
+        }
+        None
     }
 }

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -353,8 +353,15 @@ impl Interpreter {
     /// (implemented in runtime/test_functions.rs), internal `__mutsu_*` functions,
     /// and pseudo-package qualified names that need special resolution.
     pub(super) fn is_interpreter_handled_function(&self, name: &str) -> bool {
-        // Test functions are implemented as Rust methods, not via AST
-        if self.test_mode_active() && crate::runtime::Interpreter::is_test_function_name(name) {
+        // Test functions are implemented as Rust methods, not via AST.
+        // Under MUTSU_REAL_TEST=1 the real Test.rakumod / Test::Util functions are
+        // proper user-defined Raku subs and must be resolved through the normal
+        // compiled-function path first; the native handlers are only the fallback
+        // when no user declaration exists (try_native_test_function checks this).
+        if self.test_mode_active()
+            && !crate::runtime::Interpreter::real_test_module_enabled()
+            && crate::runtime::Interpreter::is_test_function_name(name)
+        {
             return true;
         }
         // Internal functions are dispatched by the interpreter's call_function match

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -1,6 +1,16 @@
 use super::*;
 
 impl Interpreter {
+    /// Extract nominal type from a coercion-type string (e.g. `"Bool(Mu)"` → `"Mu"`).
+    fn nominal_type_for_closure(tc: &str) -> &str {
+        if let Some(inner_start) = tc.find('(')
+            && tc.ends_with(')')
+        {
+            return &tc[inner_start + 1..tc.len() - 1];
+        }
+        tc
+    }
+
     /// Find the first positional argument that is a Junction and whose corresponding
     /// parameter type constraint does not accept Junction (i.e., needs auto-threading).
     /// Returns the index of that argument, or None if no auto-threading is needed.
@@ -39,13 +49,16 @@ impl Interpreter {
             if let ValueView::Junction { .. } = arg.view() {
                 // Check if the corresponding param accepts Junction
                 if let Some(pd) = positional_params.get(positional_idx) {
-                    let constraint = pd.type_constraint.as_deref().unwrap_or(
+                    let constraint_raw = pd.type_constraint.as_deref().unwrap_or(
                         if is_pointy_block || pd.name.starts_with('@') || pd.name.starts_with('%') {
                             "Mu" // pointy blocks and array/hash sigils: implicit Mu
                         } else {
                             "Any" // scalar params ($x stored as "x"): implicit Any
                         },
                     );
+                    // For coercion types like `Bool(Mu)`, the nominal type is the
+                    // inner type (Mu) — autothreading is based on the nominal type.
+                    let constraint = Self::nominal_type_for_closure(constraint_raw);
                     // Mu and Junction accept junctions directly
                     if constraint == "Mu" || constraint == "Junction" {
                         // No auto-threading needed
@@ -301,6 +314,20 @@ impl Interpreter {
                 // A method's own invocant is bound from its args further below,
                 // after this merge, so it still wins over the captured value.
                 self.env_mut().insert_sym(*k, v.clone());
+            } else if !cc.is_routine && k.with_str(|s| s == "_") {
+                // `$_` (the topic) is LEXICAL in a block: a block lexically captures
+                // `$_` from its creation scope and must see that value when called
+                // from another routine. The don't-overwrite default hides it because
+                // the caller (a `sub`) resets `$_` to Any (line below), which ends
+                // up in the parent env that `entry_or_insert_sym` finds and stops at.
+                //
+                //     given 42 { my &b = { say $_ }; call-block(&b) }
+                //
+                // Without this, `$_` inside the block is Any (the callee routine's
+                // fresh topic) instead of 42. Routines reset `$_` explicitly (at the
+                // `is_routine && !param` guard in call_compiled_function_named_inner),
+                // so this overwrite is safe for non-routine blocks only.
+                self.env_mut().insert_sym(*k, v.clone());
             } else {
                 self.env_mut().entry_or_insert_sym(*k, v.clone());
             }
@@ -518,10 +545,19 @@ impl Interpreter {
                     .insert_sym(crate::symbol::Symbol::intern("_"), first.clone());
             }
         } else if data.params.is_empty() && args.is_empty() && data.name.is_empty() {
-            let caller_topic = self.call_frames.last().unwrap().saved_env.get("_").cloned();
-            if let Some(topic) = caller_topic {
-                self.env_mut()
-                    .insert_sym(crate::symbol::Symbol::intern("_"), topic);
+            // A block lexically captures $_ from its creation scope (the env-merge
+            // loop above installs it via insert_sym for non-routine blocks). Only
+            // inherit the caller's saved topic when the block did NOT capture $_ at
+            // all (e.g., created before any $_ was established in the env chain).
+            // Without this guard the caller's $_ (often Any from a routine reset)
+            // would silently overwrite a correctly-captured topic such as an
+            // IO::Path from a `for @tests { subtest { is-path $_, ... } }` loop.
+            if !data.env.contains_key("_") {
+                let caller_topic = self.call_frames.last().unwrap().saved_env.get("_").cloned();
+                if let Some(topic) = caller_topic {
+                    self.env_mut()
+                        .insert_sym(crate::symbol::Symbol::intern("_"), topic);
+                }
             }
         }
 

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -621,6 +621,52 @@ impl Interpreter {
         {
             let pkg = package.resolve();
             let name_str = name.resolve();
+            // Junction autothreading for operator routines called as values (e.g.
+            // `&CALLER::LEXICAL::("infix:<eq>")` used by Test.rakumod's `cmp-ok`).
+            // Operators never accept Mu/Junction, so any positional Junction arg must
+            // be threaded. The compiled-call path does this via `maybe_autothread_func_call`
+            // (which has access to the executing CompiledCode); the Routine-value path
+            // bypasses that and goes straight to the native implementation, losing the
+            // threading. Do the threading here before dispatch.
+            if (name_str.starts_with("infix:<")
+                || name_str.starts_with("prefix:<")
+                || name_str.starts_with("postfix:<"))
+                && name_str.ends_with('>')
+                && !matches!(
+                    name_str.as_str(),
+                    "infix:<,>"
+                        | "infix:<=>"
+                        | "infix:<=>>"
+                        | "infix:<and>"
+                        | "infix:<or>"
+                        | "infix:<not>"
+                )
+            {
+                // Find the leftmost positional Junction arg
+                if let Some((junction_idx, junction_val)) =
+                    args.iter().enumerate().find_map(|(i, v)| {
+                        if matches!(v.view(), ValueView::Junction { .. }) {
+                            Some((i, v.clone()))
+                        } else {
+                            None
+                        }
+                    })
+                    && let ValueView::Junction { kind, values } = junction_val.view()
+                {
+                    let values = values.clone();
+                    let mut results = Vec::with_capacity(values.len());
+                    for eigenvalue in values.iter() {
+                        let mut threaded_args = args.clone();
+                        threaded_args[junction_idx] = eigenvalue.clone();
+                        results.push(self.vm_call_on_value(
+                            target.clone(),
+                            threaded_args,
+                            compiled_fns,
+                        )?);
+                    }
+                    return Ok(Value::junction(kind, results));
+                }
+            }
             // A token/rule method value called with a cursor (`$meth($c)`,
             // e.g. from a custom grammar HOW's `find_method` wrapper) runs
             // the token at the cursor position and returns a Match.

--- a/src/vm/vm_native_test.rs
+++ b/src/vm/vm_native_test.rs
@@ -40,6 +40,15 @@ impl Interpreter {
         if !crate::runtime::Interpreter::is_test_function_name(name) || !self.test_module_loaded() {
             return None;
         }
+        // Under MUTSU_REAL_TEST=1 the real Test.rakumod owns the TAP state.
+        // The native handlers bypass that (they write to stdout directly and
+        // don't increment the real module's counters), so skip them — the real
+        // Raku sub (loaded from Test.rakumod / Test::Util source) must handle
+        // it.  If no user declaration exists, the interpreter throws "No such
+        // function" which is the correct behaviour for a missing import.
+        if crate::runtime::Interpreter::real_test_module_enabled() {
+            return None;
+        }
         // Some Test names collide with core builtins (notably `run`, which is the
         // `Proc` spawner far more often than `Test::Util::run`). The interpreter
         // resolves the builtin first (its `call_function` match runs before the


### PR DESCRIPTION
## Summary

- Guard all four native test-dispatch paths with `!real_test_module_enabled()` so native TAP handlers are silenced under `MUTSU_REAL_TEST=1`
- Fix `$_` topic capture in subtest blocks: a caller-topic overwrite erased the captured `IO::Path` — now guarded by `!data.env.contains_key("_")`
- Add Junction autothreading for `Routine` values returned by `&CALLER::LEXICAL::("infix:<eq>")` in `vm_call_on_value`
- Extract nominal type from coercion-type constraints (`Bool(Mu)` → `Mu`) to prevent double-autothreading through `proclaim`'s `Bool(Mu) $cond` parameter
- Expose `Test-Helpers` package to `run_modules.rs` so `use Test::Util` resolves correctly

All 43 subtests in `roast/S32-io/io-path.t` pass with `MUTSU_REAL_TEST=1`.

## Test plan

- [x] `timeout 60 env MUTSU_FUDGE=1 MUTSU_REAL_TEST=1 target/debug/mutsu roast/S32-io/io-path.t` → 43/43 pass
- [x] `make test` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)