### PR TITLE
fix(vm): dying promises in top-level react/whenever

### DIFF
--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -446,8 +446,12 @@ impl Interpreter {
                         // race a cycle scan (the wait itself is STW-aware).
                         crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                             let (result, _, _) = shared_clone.wait();
-                            let _ = tx.send(SupplyEvent::Emit(result));
-                            let _ = tx.send(SupplyEvent::Done);
+                            if shared_clone.status() == "Broken" {
+                                let _ = tx.send(SupplyEvent::Quit(result));
+                            } else {
+                                let _ = tx.send(SupplyEvent::Emit(result));
+                                let _ = tx.send(SupplyEvent::Done);
+                            }
                         });
                         react_subs.push(ReactSubscription {
                             receiver: Some(rx),

--- a/t/react-whenever-broken-promise.t
+++ b/t/react-whenever-broken-promise.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 3;
+
+# `react { whenever <Promise> { ... } }` used to treat every settled Promise
+# as kept: the helper thread that waits on the promise sent Emit+Done
+# unconditionally, so a *broken* promise's exception value was bound to the
+# whenever's topic and the body ran as if the promise had succeeded, instead
+# of dying. (Found via Cro::Core's tcp.rakutest: connecting to a TCP port
+# with nothing listening breaks the connect Promise, and the react block was
+# expected to die rather than treat the exception as a connection.)
+
+{
+    my $p = Promise.new;
+    $p.break('boom');
+    my $died;
+    try {
+        react {
+            whenever $p {
+                flunk 'the whenever body must not run for a broken promise';
+                done;
+            }
+        }
+        CATCH {
+            default { $died = $_; }
+        }
+    }
+    ok $died.defined, 'a broken promise source dies the react block instead of running the body';
+    like $died.message, /boom/, 'the caught exception carries the broken promise\'s message';
+}
+
+{
+    # A kept promise must still run the whenever body as before.
+    my $p = Promise.new;
+    $p.keep(42);
+    my $got;
+    react {
+        whenever $p -> $v {
+            $got = $v;
+            done;
+        }
+    }
+    is $got, 42, 'a kept promise source still runs the whenever body with its value';
+}


### PR DESCRIPTION
## Summary
- `react { whenever <Promise> { ... } }` treated every settled Promise as kept: the helper thread that waits on it sent `Emit`+`Done` unconditionally, so a *broken* promise's exception value was bound to the whenever's topic and the body ran as if it had succeeded, instead of the react block dying.
- Found via Cro::Core's `tcp.rakutest`: connecting to a TCP port with nothing listening breaks the connect `Promise`, and the test expects `react { whenever Cro::TCP::Connector.establish(...) {} }` to die.
- Fix: check `shared.status()` after `wait()` and send `SupplyEvent::Quit` instead of `Emit`+`Done` when broken — matching the pattern already used by `supply_promise.rs` and `builtins_system_async.rs` for other Promise-consuming paths.

## Test plan
- [x] New regression test `t/react-whenever-broken-promise.t` (broken promise dies the react block; kept promise still runs the whenever body)
- [x] `make test` — all 2975 files / 28022 tests pass
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean
- [x] Manually confirmed `Cro::Core`'s `tcp.rakutest` improves (was 40/42, the two remaining failures were exactly this bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>