### PR TITLE
feat(compiler): compile class-body Other/ClassSub statements into chunks (ADR-0019 D6-3b)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1168,6 +1168,28 @@ walkers wholesale is not possible before then.
   `body_plan.len()` against an independently re-derived flattened-statement
   count and the typed-op sequence for one of each kind. D6-3b (compiling
   `Other` chunks) is next.
+  **D6-3b landed 2026-08-09**: every `Other` op's raw statement is now
+  compiled into its own standalone `CompiledDeclExpr` chunk, via a
+  generalization of `compile_decl_expr_inner`'s child-`Compiler` setup
+  (`Compiler::new_decl_chunk_compiler`) into a new
+  `Compiler::compile_decl_stmt_chunk(&Stmt)` sibling that compiles a whole
+  statement instead of one wrapped `Expr` — the ADR's own suggested
+  generalization. `ClassSub` gets a chunk the same way (it runs through the
+  identical `class_body_other_stmt` path at registration, per the original
+  design sketch's "the SubDecl tail probe fact + Other chunk" comment) via
+  a new `Compiler::compile_class_body_plan` pass that fills in both arms'
+  `chunk` after `crate::opcode::class_body_plan`'s pure AST classification.
+  `token`/`rule` statements are explicitly excluded (checked by a new
+  `class_declarations_body_plan_excludes_token_rule_chunks` test) — they
+  keep `chunk: None`, per the phase preamble's ADR-0009 carve-out; D6-3e
+  will confirm the driver still routes them through `run_block_raw`
+  unchanged once D6-3d cuts over. `CodeAlias`/`ProtoMethod`/`LeavePhaser`
+  remain `chunk: None` (D6-3c). Still additive — nothing outside the
+  compiler unit tests reads a compiled `Other`/`ClassSub` chunk yet.
+  Verified via the full `t/` suite (28,019 tests) and the `S12-class`/
+  `S12-construction`/`S14-roles` roast files (only the pre-existing,
+  non-whitelisted `S12-class/open_closed.t` failure, unrelated). D6-3c
+  (compiling the remaining small arms) is next.
 - [ ] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
   **Design pass done 2026-08-08 (no code landed):**

--- a/news/2026-08/adr0019-d6-3b-other-chunk-compile.md
+++ b/news/2026-08/adr0019-d6-3b-other-chunk-compile.md
@@ -1,0 +1,30 @@
+# ADR-0019 D6-3b: compile the class-body `Other` (and `ClassSub`) chunks
+
+Following D6-3a's `body_plan` skeleton, this slice compiles the `Other` arm's raw
+statement into its own standalone `CompiledDeclExpr` chunk — the largest and
+highest-value reader per the D6/D9 reader inventory
+(`todo/deep/adr0019-d6-d9-legacy-body-removal.md`).
+
+`compile_decl_expr_inner`'s child-`Compiler` setup (a standalone unit with no local
+slots, so every variable resolves through the declaration's own environment) is
+factored out into `Compiler::new_decl_chunk_compiler`, shared by a new
+`Compiler::compile_decl_stmt_chunk(&Stmt)` sibling that compiles a whole statement
+instead of one `Expr` wrapped in `Stmt::Expr` — the generalization the design
+document called for. `ClassSub` gets a chunk through the same mechanism: a top-level
+`SubDecl` runs through the identical `class_body_other_stmt` path at registration
+(only adding the `class_subs` tail-probe fact on top), matching the original design
+sketch's own comment ("the SubDecl tail probe fact + Other chunk").
+
+`token`/`rule` declarations are explicitly excluded — they keep `chunk: None` and
+stay on the registration-time `run_block_raw` path, per the phase preamble's
+ADR-0009 carve-out. A new compiler unit test
+(`class_declarations_body_plan_excludes_token_rule_chunks`) pins this.
+
+Still purely additive: nothing outside the compiler's own unit tests reads a
+compiled `Other`/`ClassSub` chunk yet — the driver cutover is D6-3d. Verified via
+the full `t/` suite (28,019 tests) and the `S12-class`/`S12-construction`/
+`S14-roles` roast files (only the pre-existing, non-whitelisted
+`S12-class/open_closed.t` failure, unrelated to this change).
+
+Next: D6-3c (compiling the remaining small arms — `CodeAlias`/`ProtoMethod`/
+`LeavePhaser`).

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -20,11 +20,14 @@ impl Compiler {
         self.compile_decl_expr_inner(expr, false)
     }
 
-    fn compile_decl_expr_inner(
-        &self,
-        expr: &Expr,
-        mint_named_pair: bool,
-    ) -> crate::opcode::CompiledDeclExpr {
+    /// The shared setup [`Self::compile_decl_expr_inner`] and
+    /// [`Self::compile_decl_stmt_chunk`] both need: a standalone child
+    /// `Compiler` with no local slots, so every variable the chunk names
+    /// resolves through the environment the declaration registers in. The
+    /// package and distribution come from the declaration's own lexical
+    /// position rather than from whatever routine frame happens to be live
+    /// when registration runs.
+    fn new_decl_chunk_compiler(&self) -> Compiler {
         let mut chunk_compiler = Compiler::new();
         chunk_compiler.is_routine = self.is_routine;
         chunk_compiler.lexically_in_routine = self.lexically_in_routine;
@@ -36,6 +39,15 @@ impl Compiler {
         chunk_compiler.set_current_package(self.current_package.clone());
         chunk_compiler.current_distribution = self.current_distribution.clone();
         chunk_compiler.last_source_line = self.last_source_line;
+        chunk_compiler
+    }
+
+    fn compile_decl_expr_inner(
+        &self,
+        expr: &Expr,
+        mint_named_pair: bool,
+    ) -> crate::opcode::CompiledDeclExpr {
+        let mut chunk_compiler = self.new_decl_chunk_compiler();
         // ADR-0021 I2/I3: a bareword-keyed fat-arrow (or colonpair, same AST
         // shape) written directly as a declaration-time trait/role argument
         // (`is foo(:bar(1))`, `role B does A[:a(1)]`) mints the named
@@ -47,6 +59,23 @@ impl Compiler {
             chunk_compiler.mint_named_pair = true;
         }
         let body = [Stmt::Expr(expr.clone())];
+        let (code, fns) = chunk_compiler.compile(&body);
+        crate::opcode::CompiledDeclExpr {
+            code: std::sync::Arc::new(code),
+            fns: std::sync::Arc::new(fns),
+        }
+    }
+
+    /// Compile an arbitrary class-body statement into its own standalone
+    /// bytecode chunk (ADR-0019 D6-3b) — the statement-shaped
+    /// generalization of [`Self::compile_decl_expr`]: same standalone-unit
+    /// compile, but for a whole `&Stmt` rather than one wrapped `Expr`,
+    /// since `ClassBodyOp::Other`'s statement kinds (`use`/`need`, nested
+    /// `class`/`role`, BEGIN/CHECK, EVAL, `my`/`our` lexicals, ...) are not
+    /// expressions.
+    pub(crate) fn compile_decl_stmt_chunk(&self, stmt: &Stmt) -> crate::opcode::CompiledDeclExpr {
+        let chunk_compiler = self.new_decl_chunk_compiler();
+        let body = [stmt.clone()];
         let (code, fns) = chunk_compiler.compile(&body);
         crate::opcode::CompiledDeclExpr {
             code: std::sync::Arc::new(code),
@@ -173,6 +202,7 @@ impl Compiler {
         // true`); `is_hidden` gates the implicit `*%_` the same way too.
         let method_compiled_keys =
             self.compile_method_body_keys(body, package_name.as_deref(), *is_hidden, true);
+        let body_plan = self.compile_class_body_plan(body);
         self.code.add_class_decl_plan(
             stmt,
             name_chunk,
@@ -181,7 +211,37 @@ impl Compiler {
             method_name_chunks,
             parent_arg_chunks,
             method_compiled_keys,
+            body_plan,
         )
+    }
+
+    /// Lower a class body into its ordered, typed op mirror (ADR-0019
+    /// D6-3a), then compile the `Other`/`ClassSub` arms' raw statement into
+    /// its own standalone chunk (ADR-0019 D6-3b) —
+    /// `crate::opcode::class_body_plan` classifies statements purely from
+    /// the AST; only this compiler-side pass can turn a raw statement into
+    /// a `CompiledDeclExpr`, since that needs a child `Compiler`
+    /// (package/distribution context), not just pattern matching.
+    /// `ClassSub` shares `Other`'s chunk mechanism (a top-level `SubDecl`
+    /// runs through the same `class_body_other_stmt` path at registration,
+    /// `ClassSub` only adds the `class_subs` tail-probe fact on top).
+    /// `token`/`rule` statements are excluded per the phase preamble's
+    /// ADR-0009 carve-out — they keep `chunk: None` and stay on the
+    /// registration-time `run_block_raw` path (D6-3e verifies this
+    /// explicitly once the driver cuts over).
+    fn compile_class_body_plan(&self, body: &[Stmt]) -> Vec<crate::opcode::ClassBodyOp> {
+        let mut ops = crate::opcode::class_body_plan(body);
+        for op in &mut ops {
+            let (chunk, raw) = match op {
+                crate::opcode::ClassBodyOp::Other { chunk, raw }
+                | crate::opcode::ClassBodyOp::ClassSub { chunk, raw, .. } => (chunk, raw),
+                _ => continue,
+            };
+            if !matches!(raw, Stmt::TokenDecl { .. } | Stmt::RuleDecl { .. }) {
+                *chunk = Some(self.compile_decl_stmt_chunk(raw));
+            }
+        }
+        ops
     }
 
     /// Compile each top-level `method`/`submethod` declaration's body to

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -308,13 +308,14 @@ mod declaration_plan_tests {
         assert_eq!(names, vec!["w", "x", "y"]);
     }
 
-    /// ADR-0019 D6-3a: `body_plan` mirrors `run_class_body`'s own flattened
-    /// dispatch order one-op-per-statement (including the interstitial
-    /// `Stmt::SetLine` markers the parser inserts, which classify as
-    /// `Other` the same way `run_class_body`'s `_` arm treats them today),
-    /// with a nested-sub `has` appended at the end (matching
-    /// `own_attribute_names`'s own append order), and classifies each
-    /// statement kind into the right op.
+    /// ADR-0019 D6-3a/D6-3b: `body_plan` mirrors `run_class_body`'s own
+    /// flattened dispatch order one-op-per-statement (including the
+    /// interstitial `Stmt::SetLine` markers the parser inserts, which
+    /// classify as `Other` the same way `run_class_body`'s `_` arm treats
+    /// them today), with a nested-sub `has` appended at the end (matching
+    /// `own_attribute_names`'s own append order), classifies each statement
+    /// kind into the right op, and (D6-3b) compiles a standalone chunk for
+    /// every `Other`/`ClassSub` statement.
     #[test]
     fn class_declarations_precompute_body_plan() {
         let (stmts, _) = crate::parse_dispatch::parse_source(
@@ -377,11 +378,18 @@ mod declaration_plan_tests {
         collect_nested_has(body, &mut flattened);
         assert_eq!(plan_a.body_plan.len(), flattened.len());
 
-        // Filtering out `Other` ops (which absorb both `SetLine` markers and
-        // the `my`-lexical statement, matching `declared_static_names`'s own
-        // separate handling of body statics) leaves exactly the typed arms,
-        // in source order, with the nested-sub `has` appended at the tail.
+        // Every `Other` op (the `SetLine` markers and the `my`-lexical
+        // statement, matching `declared_static_names`'s own separate
+        // handling of body statics) got its own compiled chunk (D6-3b).
         use crate::opcode::ClassBodyOp;
+        for op in &plan_a.body_plan {
+            if let ClassBodyOp::Other { chunk, .. } = op {
+                assert!(chunk.is_some(), "Other op missing a compiled chunk: {op:?}");
+            }
+        }
+
+        // Filtering out `Other` ops leaves exactly the typed arms, in
+        // source order, with the nested-sub `has` appended at the tail.
         let typed: Vec<&ClassBodyOp> = plan_a
             .body_plan
             .iter()
@@ -397,9 +405,10 @@ mod declaration_plan_tests {
             typed[2],
             ClassBodyOp::Does { name } if name.as_str() == "Baz"
         ));
+        // `ClassSub` shares `Other`'s chunk mechanism (D6-3b).
         assert!(matches!(
             typed[3],
-            ClassBodyOp::ClassSub { name, chunk: None, .. } if name.as_str() == "helper"
+            ClassBodyOp::ClassSub { name, chunk: Some(_), .. } if name.as_str() == "helper"
         ));
         assert!(matches!(
             typed[4],
@@ -413,12 +422,47 @@ mod declaration_plan_tests {
         // whose nested `has $.w` is the last op, appended at the tail.
         assert!(matches!(
             typed[6],
-            ClassBodyOp::ClassSub { name, chunk: None, .. } if name.as_str() == "f"
+            ClassBodyOp::ClassSub { name, chunk: Some(_), .. } if name.as_str() == "f"
         ));
         assert!(matches!(
             typed[7],
             ClassBodyOp::Attr { name } if name.as_str() == "w"
         ));
+    }
+
+    /// ADR-0019 D6-3b: `token`/`rule` declarations are excluded from the
+    /// `Other`-chunk compile — the phase preamble's ADR-0009 carve-out —
+    /// and keep `chunk: None`, staying on the registration-time
+    /// `run_block_raw` path until their own dedicated slice.
+    #[test]
+    fn class_declarations_body_plan_excludes_token_rule_chunks() {
+        let (stmts, _) =
+            crate::parse_dispatch::parse_source("class A { token t { a }; rule r { a } }")
+                .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_a = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "A")
+            .expect("class A declaration plan");
+
+        use crate::opcode::ClassBodyOp;
+        let token_rule_ops: Vec<&ClassBodyOp> = plan_a
+            .body_plan
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    ClassBodyOp::Other { raw, .. }
+                        if matches!(raw, Stmt::TokenDecl { .. } | Stmt::RuleDecl { .. })
+                )
+            })
+            .collect();
+        assert_eq!(token_rule_ops.len(), 2, "ops: {token_rule_ops:?}");
+        for op in token_rule_ops {
+            assert!(matches!(op, ClassBodyOp::Other { chunk: None, .. }));
+        }
     }
 
     /// ADR-0019 D2a: a role declaration's own attribute names, `use`d module

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2843,7 +2843,7 @@ pub(crate) enum ClassBodyOp {
 /// match does, then append nested-sub `has` declarations (in
 /// `Interpreter::collect_nested_class_has_decls` order) as more `Attr` ops —
 /// `run_class_body` appends them to the same iteration, not a separate pass.
-fn class_body_plan(body: &[Stmt]) -> Vec<ClassBodyOp> {
+pub(crate) fn class_body_plan(body: &[Stmt]) -> Vec<ClassBodyOp> {
     let mut flattened: Vec<&Stmt> = body
         .iter()
         .flat_map(|s| match s {
@@ -6198,6 +6198,7 @@ impl CompiledCode {
         method_name_chunks: Vec<Option<CompiledDeclExpr>>,
         parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>,
         method_compiled_keys: Vec<Option<Symbol>>,
+        body_plan: Vec<ClassBodyOp>,
     ) -> u32 {
         let Stmt::ClassDecl {
             name,
@@ -6230,7 +6231,6 @@ impl CompiledCode {
             .collect();
         let own_attribute_names = class_own_attribute_names(body);
         let declared_static_names = class_declared_static_names(body);
-        let body_plan = class_body_plan(body);
         let mut method_decls = compile_method_decls(body);
         // ADR-0019 D3-8a: attach each method's precomputed main-pass
         // bytecode key, position-aligned by the same flattened walk


### PR DESCRIPTION
## Summary
- D6-3b of the D6/D9 `legacy_body` removal design (`todo/deep/adr0019-d6-d9-legacy-body-removal.md`): compiles the `body_plan` skeleton's `Other` arm (the largest and highest-value reader per the reader inventory) into its own standalone `CompiledDeclExpr` chunk.
- `compile_decl_expr_inner`'s child-`Compiler` setup is factored into `Compiler::new_decl_chunk_compiler`, shared by a new `Compiler::compile_decl_stmt_chunk(&Stmt)` sibling that compiles a whole statement (not just a wrapped `Expr`) — the generalization the design document asked for.
- `ClassSub` gets a chunk through the same mechanism (a top-level `SubDecl` runs through the identical `class_body_other_stmt` path at registration, only adding the `class_subs` tail-probe fact on top — matching the original design sketch's own "the SubDecl tail probe fact + Other chunk" comment).
- `token`/`rule` statements are explicitly excluded (`chunk: None`, pinned by a new test), per the phase preamble's ADR-0009 carve-out.
- Still purely additive — nothing outside the compiler's own unit tests reads a compiled chunk yet; the driver cutover is D6-3d.

## Test plan
- [x] `cargo test --lib` (696 passed)
- [x] `make test` (28,019 tests, PASS)
- [x] `cargo clippy -- -D warnings` clean
- [x] `MUTSU_FUDGE=1 prove -e target/release/mutsu roast/S12-class/*.t roast/S12-construction/*.t roast/S14-roles/*.t` (only the pre-existing, non-whitelisted `open_closed.t` failure, unrelated)
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)