### PR TITLE
feat(compiler): compile remaining class-body op chunks (ADR-0019 D6-3c)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1190,6 +1190,25 @@ walkers wholesale is not possible before then.
   `S12-construction`/`S14-roles` roast files (only the pre-existing,
   non-whitelisted `S12-class/open_closed.t` failure, unrelated). D6-3c
   (compiling the remaining small arms) is next.
+  **D6-3c landed 2026-08-09**: `CodeAlias`/`ProtoMethod`/`LeavePhaser` now
+  compile their raw statement into a chunk the same way
+  (`Compiler::compile_class_body_plan`'s match widened to all five
+  raw-statement-carrying arms) — each still executes its raw statement
+  wholesale at registration (`class_body_code_alias`'s trailing
+  `run_block_raw`, `class_body_proto_method_decl`'s `FunctionDef.body`
+  clone, `run_class_body_leave_phasers`'s per-phaser `run_block_raw`), so a
+  single-statement chunk mirrors each exactly; no arm needed a richer typed
+  payload for this purely-additive slice (the "`ProtoMethod` may reuse
+  `CompiledProtoDeclPlan`'s shape" idea floated in the design doc turned
+  out unnecessary). `body_plan` is now a complete, compiled mirror of
+  `legacy_body` with zero consumers — matching the slice-plan's own
+  description of D6-3c's end state. Verified via the full `t/` suite
+  (28,023 tests, two new: `t/cro-client-nested-param-shadow.t` and
+  `t/react-whenever-broken-promise.t` landed on `main` from unrelated PRs
+  in between) and the `S12-class`/`S12-construction`/`S14-roles`/
+  `S05-grammar` (proto/protoregex) roast files (only the same pre-existing
+  `open_closed.t` failure). D6-3d (driver cutover, instrument-gated) is
+  next.
 - [ ] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
   **Design pass done 2026-08-08 (no code landed):**

--- a/news/2026-08/adr0019-d6-3c-remaining-body-plan-chunks.md
+++ b/news/2026-08/adr0019-d6-3c-remaining-body-plan-chunks.md
@@ -1,0 +1,29 @@
+# ADR-0019 D6-3c: compile the class-body `CodeAlias`/`ProtoMethod`/`LeavePhaser` chunks
+
+Following D6-3a's `body_plan` skeleton and D6-3b's `Other`/`ClassSub` chunk compile,
+this slice compiles the three remaining raw-statement arms — `CodeAlias`
+(`our &baz ::= &bar`), `ProtoMethod` (a class-body `proto method`), and
+`LeavePhaser` (`will leave { ... }`) — into their own standalone
+`CompiledDeclExpr` chunk, the same way `Other`/`ClassSub` already do.
+`Compiler::compile_class_body_plan`'s match widened from two arms to all five
+raw-statement-carrying arms; the mechanism (`Compiler::compile_decl_stmt_chunk`)
+is unchanged.
+
+Each arm still executes its raw statement wholesale at registration today
+(`class_body_code_alias`'s trailing `run_block_raw`,
+`class_body_proto_method_decl`'s `FunctionDef.body` clone,
+`run_class_body_leave_phasers`'s per-phaser `run_block_raw`), so a
+single-statement chunk mirrors each exactly — no arm needed a richer typed
+payload for this purely-additive slice. (The design document floated reusing
+`CompiledProtoDeclPlan`'s shape for `ProtoMethod`; that turned out unnecessary.)
+
+`body_plan` is now a complete, compiled mirror of `legacy_body` with zero
+consumers, matching the D6-3 slice plan's own description of this milestone.
+
+Verified via the full `t/` suite (28,023 tests) and the `S12-class`/
+`S12-construction`/`S14-roles`/`S05-grammar` (proto/protoregex) roast files
+(only the pre-existing, non-whitelisted `S12-class/open_closed.t` failure).
+
+Next: D6-3d, the driver cutover — `run_class_body` switches its statement
+source from `legacy_body` to `body_plan`, behind an env-var instrument for
+validation before flipping the default.

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -216,8 +216,8 @@ impl Compiler {
     }
 
     /// Lower a class body into its ordered, typed op mirror (ADR-0019
-    /// D6-3a), then compile the `Other`/`ClassSub` arms' raw statement into
-    /// its own standalone chunk (ADR-0019 D6-3b) —
+    /// D6-3a), then compile every remaining raw-statement arm's own
+    /// standalone chunk (ADR-0019 D6-3b/c) —
     /// `crate::opcode::class_body_plan` classifies statements purely from
     /// the AST; only this compiler-side pass can turn a raw statement into
     /// a `CompiledDeclExpr`, since that needs a child `Compiler`
@@ -225,16 +225,27 @@ impl Compiler {
     /// `ClassSub` shares `Other`'s chunk mechanism (a top-level `SubDecl`
     /// runs through the same `class_body_other_stmt` path at registration,
     /// `ClassSub` only adds the `class_subs` tail-probe fact on top).
-    /// `token`/`rule` statements are excluded per the phase preamble's
-    /// ADR-0009 carve-out — they keep `chunk: None` and stay on the
-    /// registration-time `run_block_raw` path (D6-3e verifies this
-    /// explicitly once the driver cuts over).
+    /// `CodeAlias`/`ProtoMethod`/`LeavePhaser` (D6-3c) compile the same way
+    /// — each still executes its raw statement wholesale at registration
+    /// (`class_body_code_alias`'s trailing `run_block_raw`,
+    /// `class_body_proto_method_decl`'s `FunctionDef.body` clone,
+    /// `run_class_body_leave_phasers`'s per-phaser `run_block_raw`), so a
+    /// single-statement chunk mirrors each exactly; no arm needs a richer
+    /// typed payload for D6-3c's purely-additive scope. `token`/`rule`
+    /// statements are excluded per the phase preamble's ADR-0009 carve-out
+    /// — they keep `chunk: None` and stay on the registration-time
+    /// `run_block_raw` path (D6-3e verifies this explicitly once the
+    /// driver cuts over). After this, `body_plan` is a complete, compiled
+    /// mirror of `legacy_body` with zero consumers.
     fn compile_class_body_plan(&self, body: &[Stmt]) -> Vec<crate::opcode::ClassBodyOp> {
         let mut ops = crate::opcode::class_body_plan(body);
         for op in &mut ops {
             let (chunk, raw) = match op {
                 crate::opcode::ClassBodyOp::Other { chunk, raw }
-                | crate::opcode::ClassBodyOp::ClassSub { chunk, raw, .. } => (chunk, raw),
+                | crate::opcode::ClassBodyOp::ClassSub { chunk, raw, .. }
+                | crate::opcode::ClassBodyOp::CodeAlias { chunk, raw }
+                | crate::opcode::ClassBodyOp::ProtoMethod { chunk, raw }
+                | crate::opcode::ClassBodyOp::LeavePhaser { chunk, raw } => (chunk, raw),
                 _ => continue,
             };
             if !matches!(raw, Stmt::TokenDecl { .. } | Stmt::RuleDecl { .. }) {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -308,14 +308,15 @@ mod declaration_plan_tests {
         assert_eq!(names, vec!["w", "x", "y"]);
     }
 
-    /// ADR-0019 D6-3a/D6-3b: `body_plan` mirrors `run_class_body`'s own
+    /// ADR-0019 D6-3a/b/c: `body_plan` mirrors `run_class_body`'s own
     /// flattened dispatch order one-op-per-statement (including the
     /// interstitial `Stmt::SetLine` markers the parser inserts, which
     /// classify as `Other` the same way `run_class_body`'s `_` arm treats
     /// them today), with a nested-sub `has` appended at the end (matching
     /// `own_attribute_names`'s own append order), classifies each statement
-    /// kind into the right op, and (D6-3b) compiles a standalone chunk for
-    /// every `Other`/`ClassSub` statement.
+    /// kind into the right op, and compiles a standalone chunk for every
+    /// arm that carries a raw statement (`Other`/`ClassSub` in D6-3b,
+    /// `CodeAlias`/`ProtoMethod`/`LeavePhaser` in D6-3c).
     #[test]
     fn class_declarations_precompute_body_plan() {
         let (stmts, _) = crate::parse_dispatch::parse_source(
@@ -327,7 +328,7 @@ mod declaration_plan_tests {
                 sub helper() { 1 }
                 our &alias ::= &m;
                 proto method p(|) {*}
-                my $will-be-static = 1;
+                my $will-be-static will leave { 1 } = 1;
                 sub f { has $.w }
             }
             "#,
@@ -395,7 +396,7 @@ mod declaration_plan_tests {
             .iter()
             .filter(|op| !matches!(op, ClassBodyOp::Other { .. }))
             .collect();
-        assert_eq!(typed.len(), 8, "typed ops: {typed:?}");
+        assert_eq!(typed.len(), 9, "typed ops: {typed:?}");
         assert!(matches!(
             typed[0],
             ClassBodyOp::Attr { name } if name.as_str() == "x"
@@ -410,22 +411,30 @@ mod declaration_plan_tests {
             typed[3],
             ClassBodyOp::ClassSub { name, chunk: Some(_), .. } if name.as_str() == "helper"
         ));
+        // `CodeAlias`/`ProtoMethod`/`LeavePhaser` compile the same way (D6-3c).
         assert!(matches!(
             typed[4],
-            ClassBodyOp::CodeAlias { chunk: None, .. }
+            ClassBodyOp::CodeAlias { chunk: Some(_), .. }
         ));
         assert!(matches!(
             typed[5],
-            ClassBodyOp::ProtoMethod { chunk: None, .. }
+            ClassBodyOp::ProtoMethod { chunk: Some(_), .. }
+        ));
+        // `my $will-be-static will leave { 1 } = 1` lowers to a
+        // `SyntheticBlock` of [the `VarDecl` (an `Other` op), the `will
+        // leave` trait's own `Phaser { kind: Leave, .. }` statement].
+        assert!(matches!(
+            typed[6],
+            ClassBodyOp::LeavePhaser { chunk: Some(_), .. }
         ));
         // `sub f { has $.w }` is itself a `SubDecl` (another `ClassSub`),
         // whose nested `has $.w` is the last op, appended at the tail.
         assert!(matches!(
-            typed[6],
+            typed[7],
             ClassBodyOp::ClassSub { name, chunk: Some(_), .. } if name.as_str() == "f"
         ));
         assert!(matches!(
-            typed[7],
+            typed[8],
             ClassBodyOp::Attr { name } if name.as_str() == "w"
         ));
     }


### PR DESCRIPTION
## Summary
- D6-3c of the D6/D9 `legacy_body` removal design (`todo/deep/adr0019-d6-d9-legacy-body-removal.md`): compiles the three remaining raw-statement `body_plan` arms — `CodeAlias`, `ProtoMethod`, `LeavePhaser` — into their own standalone chunk, the same mechanism D6-3b (#6113) used for `Other`/`ClassSub`.
- `Compiler::compile_class_body_plan`'s match widened from two arms to all five raw-statement-carrying arms; `token`/`rule` exclusion (via the `Other` arm) is unaffected.
- `body_plan` is now a complete, compiled mirror of `legacy_body` with zero consumers, matching the D6-3 slice plan's own description of this milestone. Still purely additive — nothing outside the compiler unit tests reads a chunk yet; the driver cutover is D6-3d.
- Extended `class_declarations_precompute_body_plan` to cover a `will leave { }` phaser (now `chunk: Some(_)`) alongside the existing `CodeAlias`/`ProtoMethod` assertions.

## Test plan
- [x] `cargo test --lib` (696 passed)
- [x] `make test` (28,023 tests, PASS)
- [x] `cargo clippy -- -D warnings` clean
- [x] `MUTSU_FUDGE=1 prove -e target/release/mutsu roast/S12-class/*.t roast/S12-construction/*.t roast/S14-roles/*.t roast/S05-*/proto*.t` (only the pre-existing, non-whitelisted `open_closed.t` failure, unrelated)
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)