### PR TITLE
fix(stub): use fail() semantics for ... so stub calls return Failure

### DIFF
--- a/news/2026-08/stub-fail-semantics.md
+++ b/news/2026-08/stub-fail-semantics.md
@@ -1,0 +1,30 @@
+# `...` stub code uses `fail` semantics (returns Failure to caller)
+
+Raku's `...` (stub code / `WhateverCode` placeholder) uses `fail()` internally,
+not `die()`. This means calling a stub routine returns a `Failure` to its caller
+rather than immediately throwing an exception.
+
+Previously mutsu used `die` semantics for `...`, which caused `eval-lives-ok`
+in `roast/integration/advent2009-day20.t` (tests 12–13) to fail. The relevant
+code path is:
+
+```raku
+sub eval_exception($code) {
+    try { EVAL ($code) }  # EVAL returns lazy Seq; try exits OK
+    $!                    # $! is Any (no exception caught)
+}
+```
+
+When `EVAL q[map -> $x, $y { ... }, 1..6]` returns a lazy `Seq`, that Seq is
+sunk by `SinkPop` **outside** the `try` scope. With the old `die` semantics, the
+exception from the stub call escaped the sub boundary as a thrown exception,
+crashing the caller. With `fail` semantics, the `is_fail` signal at the sub
+boundary is converted to a `Failure` value, so the caller receives
+`Failure(X::StubCode)` — which is `not defined` — and `eval-lives-ok` passes.
+
+Existing `try { ... }` behaviour is unchanged: `try` catches `fail` signals the
+same way it catches `die`, so `$! ~~ X::StubCode` after `try { ... }` still
+holds. Stub class methods now correctly return `Failure` to their callers instead
+of throwing.
+
+Pinned by `t/stub-fail-semantics.t`.

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -544,7 +544,11 @@ impl Interpreter {
             message.push_str(&arg.to_string_value());
         }
         let ex = Self::make_stub_exception(message);
-        Err(self.runtime_error_from_die_value(&ex, "Stub code executed", false))
+        // Raku's `...` uses `fail` semantics: the stub returns a Failure to
+        // its direct caller rather than throwing immediately.  At the top
+        // level (or when sunk outside a sub boundary) the Failure propagates
+        // as an exception, matching rakudo's behaviour.
+        Err(self.runtime_error_from_die_value(&ex, "Stub code executed", true))
     }
 
     /// Compile-target for constructs the parser recognizes as an undeclared

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -241,6 +241,11 @@ impl Interpreter {
     /// `concat_values` / `to_str_context` handle those, including built-in
     /// `.gist`/`.Str`). Shared by infix `~` and the string-comparison ops.
     pub(super) fn coerce_stringy_operand(&mut self, v: Value) -> Result<Value, RuntimeError> {
+        // Unhandled Failure throws in string context (infix `~`, `eq`/…),
+        // matching Rakudo: `(sub { ... }).() ~ ""` dies with X::StubCode.
+        if let Some(err) = self.failure_to_runtime_error_if_unhandled(&v) {
+            return Err(err);
+        }
         // A Nil operand in a string context (infix `~`, `eq`/`lt`/… string
         // comparisons) warns and resumes with the empty string, matching
         // Rakudo — once per Nil operand (so `Nil ~ Nil` warns twice).

--- a/t/stub-fail-semantics.t
+++ b/t/stub-fail-semantics.t
@@ -1,0 +1,35 @@
+use MONKEY-SEE-NO-EVAL;
+use Test;
+plan 6;
+
+# Raku's `...` stub uses fail() semantics (not die()):
+# - Calling a stub routine returns Failure to the caller
+# - try { ... } still catches it (Failure on stack is caught by try)
+# - Failure in sink context (e.g. sunk lazy Seq) propagates as is_fail,
+#   which at a sub boundary converts to Failure for the caller
+
+# 1-2: stub sub returns Failure to caller
+sub stub-sub() { ... }
+my $r = stub-sub();
+ok !defined($r), 'stub sub return is not defined';
+ok $r ~~ Failure, 'stub sub returns a Failure';
+
+# 3: try { ... } still catches the stub (fail propagates to try like die)
+try { ... }
+ok $! ~~ X::StubCode, 'try catches stub, $! is X::StubCode';
+
+# 4-5: eval_exception pattern (real Test.rakumod usage)
+# EVAL q[map -> $x,$y { ... }, 1..6] returns a lazy Seq;
+# when that Seq is sunk outside try{}, the stub fires as fail(),
+# which propagates through the sub boundary as Failure.
+sub eval_exception_test($code) {
+    try { EVAL ($code) }
+    $!
+}
+my $ee = eval_exception_test(q[map -> $x, $y { ... }, 1..6]);
+ok !defined($ee), 'eval_exception returns not-defined for lazy stub map';
+ok $ee ~~ Failure, 'eval_exception returns Failure for lazy stub map';
+
+# 6: stub class method returns Failure
+class Foo { method bar() { ... } }
+ok !defined(Foo.new.bar), 'stub class method returns not-defined Failure';


### PR DESCRIPTION
## Summary

- Raku's `...` (stub code) uses `fail()` not `die()` internally: calling a stub routine returns a `Failure` to its caller rather than immediately throwing
- This fixes `eval-lives-ok 'map -> $x, $y { ... }, 1..6'` in `roast/integration/advent2009-day20.t` (tests 12–13)
- Pin: `t/stub-fail-semantics.t`

## Root cause

When `try { EVAL q[map -> $x, $y { ... }, 1..6] }` is evaluated as a statement (sink context) inside `eval_exception`, the `EVAL` is the last expression in the try block (value context). It returns a lazy `Seq`. The try block exits normally with the Seq on the stack. `SinkPop` then forces the Seq **outside** the try protection range.

With old `die` semantics for `...`: the exception propagated through the sub boundary as a thrown exception, crashing the test caller.

With `fail` semantics (this fix): the `is_fail` signal at the sub call boundary converts to `Failure(X::StubCode)`, which is `not defined` — so `eval-lives-ok` passes.

## Unchanged behaviour

- `try { ... }` still catches stubs: `fail` signals route to the catch handler same as `die`
- Stub class methods now correctly return `Failure` to callers instead of throwing

## Test plan

- [ ] `MUTSU_REAL_TEST=1 prove -e 'target/debug/mutsu' roast/integration/advent2009-day20.t` passes all 21 tests
- [ ] `prove -e 'target/debug/mutsu' t/stub-fail-semantics.t` passes 6/6
- [ ] `make test` passes (2977 files, 28027 subtests, all green)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)