### PR TITLE
fix(vm): quit a supply when its nested whenever's promise breaks

### DIFF
--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -161,7 +161,14 @@ impl Interpreter {
         // been run once, and its `emit` reaches the outer whenever's callback
         // only while that supply's StreamConsumer is still on the stack.
         let mut stream_base: Option<usize> = None;
-        if self.build_react_subscriptions(&subscriptions, &mut react_subs, &mut stream_base)? {
+        let finished =
+            self.build_react_subscriptions(&subscriptions, &mut react_subs, &mut stream_base)?;
+        // Any `whenever <Promise>` nested inside a `supply { }` body was
+        // rewritten into a stand-in supplier above; arm the promises now that
+        // their taps are registered (`react_subs` built), so the resolution
+        // handler can push the result/quit reason without racing registration.
+        self.arm_pending_promise_whenevers();
+        if finished {
             if let Some(base) = stream_base {
                 self.supply_stream_consumers.truncate(base);
             }
@@ -296,6 +303,19 @@ impl Interpreter {
                                 self,
                                 run_on_demand_body(on_demand_cb.clone(), Some(emitter_supplier_id),)
                             );
+                            // A `whenever <Promise>` registered by the body is not
+                            // itself a `Supply`, so the marker walk below (which
+                            // only recognizes a `Supply`-sourced registration via
+                            // `value_to_react_subscription` /
+                            // `register_nested_on_demand_source`) would silently
+                            // drop it — a broken/kept promise nested inside a
+                            // `supply { }` body then never reached this react loop
+                            // at all (Cro::TCP::Connector.establish's `supply {
+                            // whenever self.connect(...) { ... } }`). Rewrite it
+                            // into a supplier-backed stand-in `Supply` first, same
+                            // as the `.tap()` path already does, so the ordinary
+                            // `supplier_id` handling below drives it.
+                            let emitted = self.normalize_promise_whenever_markers(emitted);
                             // Peek `done` (don't pop yet): the streaming consumer
                             // must stay registered while we replay any finite inner
                             // `whenever` sources below, so that `emit`s from those

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -299,6 +299,9 @@ impl Interpreter {
         let first_new = react_subs.len();
         let mut stream_base = None;
         let finished = self.build_react_subscriptions(&pending, react_subs, &mut stream_base)?;
+        // Arm any `whenever <Promise>` markers this batch's nested `supply { }`
+        // bodies registered (see the matching call in `run_react_event_loop`).
+        self.arm_pending_promise_whenevers();
         let new_supplier_regs: Vec<(u64, usize)> = react_subs[first_new..]
             .iter()
             .enumerate()

--- a/src/vm/vm_react_supply_helpers.rs
+++ b/src/vm/vm_react_supply_helpers.rs
@@ -116,6 +116,12 @@ impl Interpreter {
             self,
             run_on_demand_body(on_demand_cb, Some(emitter_supplier_id))
         );
+        // Same rewrite as the top-level on-demand handling in
+        // `vm_react_loop.rs`'s `build_react_subscriptions`: a nested `whenever
+        // <Promise>` marker is not a `Supply`, so it must become a
+        // supplier-backed stand-in before the marker walk below (which
+        // recognizes only `Supply`-sourced registrations) can see it.
+        let emitted = self.normalize_promise_whenever_markers(emitted);
         let streamed_done = self
             .supply_stream_consumers
             .get(stream_idx)

--- a/t/react-whenever-promise-nested-supply.t
+++ b/t/react-whenever-promise-nested-supply.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 2;
+
+# A `whenever <Promise>` directly inside a top-level `react { }` correctly
+# dies the react block when the promise is broken (t/react-whenever-broken-
+# promise.t, fixed by #6112). The same bug existed one level deeper: a
+# `whenever <Promise>` nested INSIDE a `supply { }` block's body did not quit
+# that supply when the promise broke, so a `react` consuming the supply never
+# saw the death — the supply silently produced nothing and the react block
+# completed normally instead of dying.
+#
+# Found via the vendored Cro::Core test suite (tcp.rakutest):
+# `Cro::TCP::Connector.establish` is implemented as
+#   supply {
+#       my Promise $connection = self.connect(|%options);
+#       whenever $connection -> Cro::Transform $transform { ... }
+#   }
+# and `establish(...).establish dies before service is started` expects the
+# enclosing `react` to die when the connect Promise breaks.
+{
+    my $s = supply {
+        my Promise $connection = Promise.new;
+        $connection.break('connect failed');
+        whenever $connection -> $transform {
+            flunk 'the nested whenever body must not run for a broken promise';
+            emit 'never';
+        }
+    }
+    my $died;
+    try {
+        react {
+            whenever $s -> $msg {
+                flunk 'the outer whenever body must not run: the supply never emits';
+            }
+        }
+        CATCH {
+            default { $died = $_; }
+        }
+    }
+    ok $died.defined,
+        'a broken promise nested in a supply{} whenever dies the enclosing react block';
+    like $died.message, /'connect failed'/,
+        'the caught exception carries the broken promise\'s message';
+}


### PR DESCRIPTION
## Summary
- Follow-up to #6112: `react { whenever <Promise> { ... } }` at the top level correctly dies on a broken promise, but a `whenever <Promise>` **nested inside a `supply { }` block** did not quit that supply when the promise broke — the supply silently produced nothing, so an enclosing `react` never saw the death.
- Found via Cro::Core's `tcp.rakutest`: `Cro::TCP::Connector.establish` is `supply { whenever self.connect(...) -> $transform { ... } }`, and the test expects the enclosing `react` to die when the connect Promise breaks.
- Root cause: a nested `whenever <Promise>` marker is not itself a `Supply`, so the on-demand marker walk (which only recognizes `Supply`-sourced registrations) silently dropped it. Fix: rewrite it into a supplier-backed stand-in `Supply` via `normalize_promise_whenever_markers` before the walk, then arm the parked promise (`arm_pending_promise_whenevers`) once its taps are registered.

## Test plan
- [x] New regression test `t/react-whenever-promise-nested-supply.t`
- [x] `make test` — full suite passes (2978 files / 28031 tests; the only failure was an unrelated leftover local test file from a sibling in-flight fix, not part of this branch)
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean
- [x] Manually confirmed `Cro::Core`'s `tcp.rakutest` "Establishing connection dies before/once service is started/stopped" subtests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>