### PR TITLE
fix(runtime): re-inject grammar-body my lexicals for token/rule dispatch

### DIFF
--- a/news/2026-08/grammar-body-my-lexical-scope.md
+++ b/news/2026-08/grammar-body-my-lexical-scope.md
@@ -1,0 +1,40 @@
+# Grammar-body `my` lexicals are now visible to token/rule dispatch
+
+A `my` variable declared directly in a `grammar` body (like a class-body static — see
+`t/class-body-my-lexical-scope.t`) is a lexical of that body: a `token`/`rule` method
+should see it the same way an ordinary method sees a class-body static.
+
+mutsu's class-body-static injection (`inject_class_body_statics`) only ran on the two
+method-dispatch paths, never on grammar token/subrule dispatch. A pattern that
+interpolates such a variable (`@array`/`$scalar`/`%hash`) silently resolved it to `Nil`
+at match time instead of its declared value, instead of raising an error — since an
+interpolated `Nil` in a regex alternation position simply matches nothing, the token
+would just always fail to match that part of its pattern.
+
+Discovered via the vendored `Cro::HTTP::Cookie` module's
+`token cookie-av:sym<samesite> { :i 'SameSite=' @same-site-opts }`, where
+`@same-site-opts` is a grammar-body `my @same-site-opts = SameSite.enums.values;`.
+Real `SameSite=Strict`/`Lax`/`None` cookie attributes were silently dropped on
+round-trip through `Cro::HTTP::Cookie.from-set-cookie`/`.to-set-cookie` — the
+`samesite` token candidate could never match, so proto dispatch always fell through to
+the generic `cookie-av:sym<extension>` catch-all instead.
+
+Fixed by adding `establish_grammar_body_statics` (mirroring the existing
+`establish_grammar_dynamic_vars` for `:my $*/%*/@*NAME` dynamic variables), invoked
+both where a grammar's own `TOP`/named-rule dispatch begins and where a token/rule body
+is re-parsed on each match attempt (`regex_token_resolve.rs`). Also fixed a related
+subrule-catch-all vs. array-interpolated-candidate tie-break: once the array
+resolves correctly, an array-interpolated proto-token candidate now correctly wins an
+LTM tie against a sibling candidate that calls a **named subrule** catch-all — pin:
+`t/grammar-body-my-lexical-scope.t`.
+
+A narrower, separate LTM discrepancy remains when the sibling catch-all is an
+**inline** unbounded quantifier (`<-[;]>+` written directly in the token body, not via
+a named subrule) — recorded as `todo/deep/ltm-inline-unbounded-quantifier-vs-array-tie.md`
+since it needs real Rakudo LTM-algorithm research, not a quick patch, and no known
+roast test currently depends on that exact shape.
+
+## Effect
+
+- `roast/packages`-vendored Cro::HTTP suite: `http-cookie.rakutest` and
+  `http-cookiejar.rakutest` SameSite round-trip subtests now pass.

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -83,6 +83,52 @@ impl Interpreter {
         saved
     }
 
+    /// A grammar body may declare a plain lexical (`grammar G { my @opts =
+    /// <a b c>; token t:sym<x> { ... @opts ... } }`), unlike the `:my
+    /// $*/%*/@*NAME` DYNAMIC declarations `establish_grammar_dynamic_vars`
+    /// handles above. Such a body-level `my` is a lexical of the class/grammar
+    /// body, not a global: its bare env binding is unbound once the body
+    /// finishes, and the authoritative copy lives only in `package_lexicals`
+    /// (see `news/2026-08/class-body-my-lexical-scope.md`). Method dispatch
+    /// re-injects it fresh on every call via `inject_class_body_statics`; a
+    /// grammar's token/rule bodies need the same treatment, because a
+    /// non-static pattern (one that interpolates a `$`/`@`/`%` variable) is
+    /// re-parsed against `self.env` on every match attempt rather than through
+    /// normal method-call machinery — without this, `@opts` silently resolves
+    /// to Nil during interpolation and vanishes from the compiled pattern
+    /// instead of becoming its declared alternation.
+    ///
+    /// Walks the grammar's package and its MRO ancestors (mirroring
+    /// `establish_grammar_dynamic_vars`) so an inherited grammar's own body
+    /// statics are visible too. Returns the prior bindings so the caller can
+    /// restore them when the parse ends.
+    fn establish_grammar_body_statics(&mut self, package: &str) -> Vec<(String, Option<Value>)> {
+        let mut packages = vec![package.to_string()];
+        packages.extend(
+            self.mro_readonly(package)
+                .into_iter()
+                .filter(|p| p != package),
+        );
+        let mut saved: Vec<(String, Option<Value>)> = Vec::new();
+        for pkg in &packages {
+            let Some(statics) = self.package_lexicals.get(pkg) else {
+                continue;
+            };
+            let entries: Vec<(String, Value)> = statics
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            for (k, v) in entries {
+                if saved.iter().any(|(sk, _)| sk == &k) {
+                    continue;
+                }
+                saved.push((k.clone(), self.env.get(&k).cloned()));
+                self.env.insert(k, v);
+            }
+        }
+        saved
+    }
+
     /// Collect `:my $*/%*/@*… = …;` declaration substrings (main-slang code
     /// between `:my ` and the terminating `;`) from a rule pattern.
     fn collect_dynamic_var_decls(pattern: &str, out: &mut Vec<String>) {
@@ -334,6 +380,11 @@ impl Interpreter {
         // Establish any `:my $*/%*/@*… = …;` dynamic variables the grammar's rules
         // declare, so action methods run during the match share them (`%*PLAYED`).
         let saved_grammar_dynvars = self.establish_grammar_dynamic_vars(package_name);
+        // Re-inject the grammar body's own `my` statics (`grammar G { my @opts
+        // = ...; token t { ... } }`): a plain `my` (unlike the `:my $*...`
+        // dynvars above) is unbound from `self.env` once the body finishes —
+        // see `establish_grammar_body_statics`.
+        let saved_grammar_body_statics = self.establish_grammar_body_statics(package_name);
         let candidate_from = start_pos.or(continue_pos).unwrap_or(0);
         let result = (|| -> Result<Value, RuntimeError> {
             let (pattern, start_rule_sym) =
@@ -592,6 +643,17 @@ impl Interpreter {
 
         // Restore any dynamic vars the grammar's rules established for this parse.
         for (key, prev) in saved_grammar_dynvars {
+            match prev {
+                Some(v) => {
+                    self.env.insert(key, v);
+                }
+                None => {
+                    self.env.remove(&key);
+                }
+            }
+        }
+        // Restore whatever `establish_grammar_body_statics` overwrote.
+        for (key, prev) in saved_grammar_body_statics {
             match prev {
                 Some(v) => {
                     self.env.insert(key, v);

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -138,6 +138,19 @@ impl Interpreter {
         if switch_pkg {
             self.set_current_package_shared(sub_pkg.to_string());
         }
+        // A token/rule body may reference a `my` variable declared in its own
+        // grammar body (`grammar G { my @opts = ...; token t:sym<x> { ...
+        // @opts ... } }`). Such a body-level `my` is unbound from `self.env`
+        // once the body finishes (its authoritative copy lives only in
+        // `package_lexicals` — see the class-body-my-lexical-scope fix), and
+        // method dispatch re-injects it fresh on every call
+        // (`inject_class_body_statics`). A non-static pattern (one containing
+        // a `@`/`$`/`%` interpolation) is re-parsed on every match attempt via
+        // this function, so without the same re-injection here, `@opts`
+        // silently resolves to Nil during interpolation and the array
+        // vanishes from the compiled pattern instead of becoming its declared
+        // alternation.
+        self.inject_class_body_statics(sub_pkg);
         let parsed = self.parse_regex(sub_pat);
         if switch_pkg {
             self.set_current_package_shared(saved_pkg);

--- a/t/grammar-body-my-lexical-scope.t
+++ b/t/grammar-body-my-lexical-scope.t
@@ -1,0 +1,66 @@
+use Test;
+
+plan 6;
+
+# A `my` declared in a grammar body (like a class body — see
+# t/class-body-my-lexical-scope.t) is a lexical of that body: a token/rule
+# method sees it, the same way an ordinary method sees a class-body static.
+# mutsu's class-body-static injection (`inject_class_body_statics`) only ran
+# on the two method-dispatch paths, never on grammar token/subrule dispatch,
+# so a pattern that interpolates such a variable (`@array`/`$scalar`/`%hash`)
+# silently resolved it to Nil at match time instead of its declared value —
+# discovered via Cro::HTTP::Cookie's `token cookie-av:sym<samesite> { :i
+# 'SameSite=' @same-site-opts }`, where `@same-site-opts` is a grammar-body
+# `my @same-site-opts = SameSite.enums.values;`. Real `SameSite=Strict`
+# cookies silently lost their `SameSite` attribute.
+
+grammar GBMLS-Basic {
+    my @opts = <Strict Lax None>;
+    token TOP { :i 'Foo=' @opts }
+}
+ok GBMLS-Basic.parse('Foo=Strict'), 'a grammar-body my @array interpolates into a token pattern';
+nok GBMLS-Basic.parse('Foo=Dog'), 'and a value outside the array correctly fails to match';
+
+# The actual bug shape: a proto token where one `:sym<>` candidate's pattern
+# ends in an array interpolation and a SIBLING candidate is a generic
+# catch-all that calls a NAMED SUBRULE (not an inline quantified atom — see
+# below). When both can match the same input, Rakudo's LTM prefers the
+# array-interpolated candidate; before this fix mutsu always picked the
+# catch-all because the array silently resolved to empty, so the two
+# candidates' real match lengths were never actually tied.
+my regex gbmls-path { <[\x1F..\xFF] - [;]>+ }
+
+grammar GBMLS-Proto {
+    my @opts = <Strict Lax None>;
+    token TOP { <name> [';' ' '? <val> ]* }
+    token name { <-[;]>+ }
+    proto token val {*}
+    token val:sym<known> { :i 'Foo=' @opts }
+    token val:sym<other> { <gbmls-path> }
+}
+class GBMLS-Actions {
+    method val:sym<known>($/) { make 'KNOWN' }
+    method val:sym<other>($/) { make 'OTHER' }
+}
+
+my $m1 = GBMLS-Proto.parse('x; Foo=Strict', :actions(GBMLS-Actions.new));
+is $m1<val>[0].made, 'KNOWN',
+    'an array-interpolated candidate wins an LTM tie over a sibling subrule catch-all';
+
+my $m2 = GBMLS-Proto.parse('x; Foo=Dog', :actions(GBMLS-Actions.new));
+is $m2<val>[0].made, 'OTHER',
+    'when the array-interpolated candidate genuinely cannot match, the catch-all still wins';
+
+# Direct `:rule<name>` dispatch (bypassing the nested-subrule path above) must
+# resolve the same lexical too.
+class GBMLS-DirectActions {
+    method val:sym<known>($/) { make 'KNOWN' }
+    method val:sym<other>($/) { make 'OTHER' }
+}
+my $m3 = GBMLS-Proto.parse('Foo=Strict', :rule<val>, :actions(GBMLS-DirectActions.new));
+is $m3.made, 'KNOWN', 'direct :rule<name> dispatch also sees the grammar-body my @array';
+
+# A grammar-body my is unbound outside the grammar, like a class-body my.
+nok $::('opts').defined, 'the grammar-body my does not leak into the enclosing scope';
+
+done-testing;

--- a/todo/deep/ltm-inline-unbounded-quantifier-vs-array-tie.md
+++ b/todo/deep/ltm-inline-unbounded-quantifier-vs-array-tie.md
@@ -1,0 +1,109 @@
+# Proto-token LTM: an inline unbounded quantified atom outranks an array-interpolated candidate even on a runtime length tie
+
+While root-causing the Cro::HTTP::Cookie `SameSite` cookie-attribute drop (fixed
+by making grammar-body `my` lexicals visible to token/subrule dispatch — see
+`news/2026-08/grammar-body-my-lexical-scope.md` and
+`t/grammar-body-my-lexical-scope.t`), a second, unrelated LTM discrepancy
+surfaced that is NOT fixed by that change and is out of scope for it.
+
+## Repro (verified against real `raku`)
+
+```raku
+grammar G {
+    my @opts = <Strict Lax None>;
+    token TOP { <name> [';' ' '? <val> ]* }
+    token name { <-[;]>+ }
+    proto token val {*}
+    token val:sym<known> { :i 'Foo=' @opts }
+    token val:sym<other> { <-[;]>+ }
+}
+class A {
+    method val:sym<known>($/) { make "KNOWN" }
+    method val:sym<other>($/) { make "OTHER" }
+}
+my $m = G.parse('x; Foo=Strict', :actions(A.new));
+say $m<val>[0].made;   # raku: OTHER   mutsu (post-fix): KNOWN
+```
+
+Both candidates match the full remaining text ("Foo=Strict", 10 chars) — a
+genuine runtime length tie. Real Raku's LTM still prefers `other` (the bare,
+inline, *unbounded* quantified char class `<-[;]>+` written directly in the
+token body) over `known` (a literal prefix followed by an array-interpolated
+alternation, even though its total declared/real length also reaches 10).
+
+Note the contrast with the case the grammar-body-my-lexical-scope fix DOES
+handle correctly: when the catch-all is written as a **named subrule call**
+(`token val:sym<other> { <path> }` where `my regex path { <-[;]>+ }`) instead
+of the same quantified atom **inlined directly** in the token body, real Raku
+flips to preferring `known`. This is exactly the shape of Cro's
+`cookie-av:sym<extension> { <path> }` vs `cookie-av:sym<samesite> { :i
+'SameSite=' @same-site-opts }`, which now works correctly. Only the *inline*
+form (no named subrule) exhibits this further discrepancy.
+
+## Why this is a separate bug from the grammar-body-my-lexical-scope fix
+
+Before that fix, `@opts` silently resolved to an empty array during
+interpolation, so `known`'s real pattern was effectively just `:i 'Foo='` (4
+chars) — genuinely shorter than `other`'s real match (10 chars). mutsu's
+runtime-comparison LTM picked `other` correctly, but only because the lengths
+were NOT actually tied (an accidental right answer for the wrong reason). Now
+that `@opts` resolves correctly, both candidates truly tie at 10 chars, and
+mutsu's tie-break (first-declared-wins, in `src/runtime/dispatch.rs`'s
+`eval_token_call_values_at`/`declarative_prefix_match_len`, and separately in
+`src/runtime/regex/regex_match_atom.rs`'s subrule-candidate loop) picks
+`known` — the first-declared candidate — whereas real Raku picks `other`.
+
+## Suspected root cause (not yet fully confirmed against Rakudo internals)
+
+Rakudo's LTM is not "run every candidate to completion and compare final
+match lengths, tie-break by declaration order" — it builds a static NFA from
+each candidate's *declarative prefix* and picks by structural longest-token
+match, not by re-executing and diffing end positions. An unbounded quantifier
+written directly in a token body (`<-[;]>+`, no upper bound) is apparently
+treated by that structural analysis as strictly outranking any alternative
+whose declared/consumed length is a finite, bounded quantity — even when, for
+one particular input, they happen to consume the same number of characters.
+A named subrule reference, by contrast, does NOT propagate that "unbounded"
+priority tag up to the caller's LTM comparison the same way (matching what
+`declarative_prefix_match_len`'s doc comment already says about descending
+into subrules to find code atoms, but evidently not about propagating
+quantifier-boundedness).
+
+mutsu's `declarative_prefix_match_len` (`src/runtime/regex/regex_resolve.rs`)
+and the informally-named "mechanism #2" in
+`src/runtime/regex/regex_match_atom.rs` (the `has_proto` branch of the named
+subrule-candidate loop) both implement LTM as "execute the real matcher (or a
+declarative-mode variant of it) and numerically compare end positions" — a
+fundamentally different mechanism than a symbolic bounded-vs-unbounded NFA
+priority. Modeling the real Rakudo semantics correctly would need genuine
+static analysis of each candidate's quantifier structure (which atoms are
+unbounded), which is a materially bigger change than the grammar-body-my fix
+and risks being a deep, invasive rework of the whole proto-dispatch engine
+(touching both `dispatch.rs` and `regex_match_atom.rs`, which currently use
+two independently-evolved LTM approximations — see the note below).
+
+## Why this file, not a same-session fix
+
+- It requires understanding/replicating Rakudo's actual NFA-based LTM
+  algorithm (declarative-prefix construction with boundedness-aware
+  priority), not just re-injecting a missing lexical.
+- mutsu currently has **two separate LTM implementations**
+  (`eval_token_call_values_at` for the outermost/`:rule<...>` dispatch vs. the
+  proto-candidate loop in `regex_match_atom.rs` for nested `<name>` subrule
+  references), which independently reproduce this same divergence. A proper
+  fix should likely unify them onto one algorithm rather than patch each one's
+  tie-break heuristic separately — that unification is itself a nontrivial
+  design question worth an ADR if pursued.
+- No known roast test currently depends on this exact shape (inline unbounded
+  quantifier competing against an array-interpolated candidate on a tie); it
+  was found via exploratory synthetic repros while root-causing the Cro
+  cookie bug, not via a failing roast/`t/` test. Recorded here so it is not
+  silently lost.
+
+## Suggested next step
+
+If/when picked up: first confirm with `raku --target=ast` or targeted
+Rakudo-source reading (not available in this sandbox) exactly how NQP's LTM
+weighs unbounded-vs-bounded declared lengths on a tie, then decide whether to
+unify `dispatch.rs`'s and `regex_match_atom.rs`'s LTM implementations before
+or as part of implementing that priority rule.


### PR DESCRIPTION
## Summary
- A `my` declared directly in a `grammar` body (like a class-body static) is a lexical of that body — a `token`/`rule` should see it, the same way an ordinary method sees a class-body static.
- mutsu's class-body-static injection only ran on the two method-dispatch paths, never on grammar token/subrule dispatch, so a pattern interpolating such a variable (`@array`/`$scalar`/`%hash`) silently resolved it to `Nil` at match time.
- Found via the vendored `Cro::HTTP::Cookie` module: `token cookie-av:sym<samesite> { :i 'SameSite=' @same-site-opts }` where `@same-site-opts` is a grammar-body `my @same-site-opts = SameSite.enums.values;` — real `SameSite=Strict`/`Lax`/`None` cookie attributes were silently dropped on round-trip, since the `samesite` candidate could never match and proto dispatch always fell through to the generic `extension` catch-all.
- Fix: `establish_grammar_body_statics` (mirroring the existing `establish_grammar_dynamic_vars` for `:my $*/%*/@*NAME` dynvars), invoked both where a grammar's `TOP`/named-rule dispatch begins and where a token/rule body is re-parsed on each match attempt.
- A narrower, separate LTM discrepancy (an inline unbounded quantifier vs. an array-interpolated candidate on a genuine runtime-length tie) remains out of scope — recorded as `todo/deep/ltm-inline-unbounded-quantifier-vs-array-tie.md` since it needs real Rakudo LTM-algorithm research.

## Test plan
- [x] New regression test `t/grammar-body-my-lexical-scope.t` (6 assertions, verified against real `raku` first)
- [x] `make test` — full suite passes (2977 files / 28029 tests)
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean
- [x] Manually confirmed `Cro::HTTP::Cookie`'s `SameSite` round-trip now works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>