### PR TITLE
feat(compiler,runtime): wire class-body walk to compiled body_plan chunks (ADR-0019 D6-3d)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1209,6 +1209,66 @@ walkers wholesale is not possible before then.
   `S05-grammar` (proto/protoregex) roast files (only the same pre-existing
   `open_closed.t` failure). D6-3d (driver cutover, instrument-gated) is
   next.
+  **D6-3d landed 2026-08-09**: `run_class_body` now consumes `body_plan` in
+  parallel with the flattened `legacy_body` statement list (zipped, same
+  order/length by construction — `class_body_plan` mirrors the runtime
+  walk's own flatten+nested-has-append exactly), and its three small-arm
+  helpers (`class_body_other_stmt`/`ClassSub`, `class_body_code_alias`,
+  `run_class_body_leave_phasers`) run a statement's precompiled chunk via a
+  new `Interpreter::run_compiled_block_raw` (the `run_block_raw` post-compile
+  half — `run_nested` plus the `free_var_writes` writeback drain — factored
+  out so both the on-the-fly and precompiled paths share it) instead of the
+  registration-time `run_block_raw` OTF compile, gated behind
+  `MUTSU_DROP_LEGACY_CLASS_BODY=1` (the `MUTSU_DROP_LEGACY_BODY`/C6e-3a
+  precedent) — unset by default, so this slice ships with zero behavior
+  change; the instrument exists to validate the chunk path before a future
+  slice flips the default. `ProtoMethod`'s chunk stays unused:
+  `class_body_proto_method_decl` never executed the raw statement (it only
+  clones `proto_body`/`param_defs` off the AST into a `FunctionDef`), so
+  there is nothing for its chunk to replace yet.
+
+  Wiring the instrument surfaced two real, previously-invisible bugs in the
+  "purely additive" D6-3a-c chunks (invisible because nothing consumed them
+  until now):
+  1. **`LeavePhaser`'s chunk compiled to a silent no-op.** D6-3c compiled
+     the chunk from the *wrapping* `Stmt::Phaser{kind: Leave, ..}`
+     statement, but `compiler/stmt.rs`'s `Stmt::Phaser { .. } => {}`
+     catch-all arm compiles an un-lowered `PhaserKind::Leave` to nothing
+     (LEAVE is normally driven by the enclosing `BlockScope` registering a
+     callback, not direct statement compilation) — while
+     `run_class_body_leave_phasers` actually runs the phaser's *inner*
+     `body`. Fixed by generalizing the single-statement chunk compile into
+     `Compiler::compile_decl_stmts_chunk_in_package(stmts: &[Stmt], ..)` and
+     calling it with the phaser's own inner body for the `LeavePhaser` op.
+     Pinned by `class_declarations_leave_phaser_chunk_compiles_inner_body`.
+  2. **Every D6-3b/c chunk qualified bare variable/sub names against the
+     wrong package.** `Compiler::qualify_variable_name`/`qualify_package_name`
+     bake package qualification in at COMPILE time from `self.current_package`
+     — but `compile_class_body_plan`'s child compiler inherited the *outer*
+     (enclosing) compiler's ambient package, not the class's own name, unlike
+     `compile_method_body`'s explicit
+     `method_compiler.set_current_package(package_name.to_string())`. A
+     top-level `no strict; class Foo { $foo = 42; }` therefore wrote a bare
+     unqualified global instead of `Foo::foo` under the forced instrument,
+     diverging from `run_block_raw`'s registration-time compile (which
+     qualifies against the interpreter's `current_package()`, already `Foo`
+     by the time the body walk runs) — caught by the pre-existing
+     `t/strict-use-and-eval.t`. Fixed by threading `package_name: Option<&str>`
+     (the same value `compile_method_body_keys` already receives — `None` for
+     a computed class name/hoisted shell, in which case every op keeps
+     `chunk: None` and falls back to `run_block_raw`, mirroring the
+     method-body precedent) into `compile_class_body_plan` and having
+     `compile_decl_stmts_chunk_in_package` override `current_package` on the
+     child compiler. Pinned by
+     `class_declarations_other_chunk_qualifies_against_declaring_class`.
+
+  Verified with `MUTSU_DROP_LEGACY_CLASS_BODY=1` forced: the full `t/` suite
+  (28,023 tests), the `S12-class`/`S12-construction`/`S14-roles`/`S05-grammar`
+  roast files (1,042 tests, same pre-existing `open_closed.t` failure as
+  unforced), and `scripts/battery-testsuite.sh` (158/164 files pass, 2
+  excluded — byte-identical PASS/FAIL output to the unforced baseline). D6-3e
+  (token/rule carve-out check) is expected to fold into a later default-flip
+  slice rather than needing its own PR, per the design doc's own note.
 - [ ] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
   **Design pass done 2026-08-08 (no code landed):**

--- a/news/2026-08/adr0019-d6-3d-body-plan-driver-cutover.md
+++ b/news/2026-08/adr0019-d6-3d-body-plan-driver-cutover.md
@@ -1,0 +1,63 @@
+# ADR-0019 D6-3d: wire `run_class_body` to the compiled `body_plan`, instrument-gated
+
+Following D6-3a-c's additive `body_plan` (a typed, position-aligned mirror of a
+class body's flattened statement list, with a compiled `CompiledDeclExpr` chunk
+for every non-token/rule arm), this slice cuts the driver over: `run_class_body`
+now zips `body_plan` against the existing flattened `legacy_body` walk (both are
+built by the identical flatten+nested-has-append transform, so their order and
+length agree by construction), and its three small-statement arms
+(`class_body_other_stmt`/`ClassSub`, `class_body_code_alias`,
+`run_class_body_leave_phasers`) can run a statement's precompiled chunk instead
+of the registration-time `run_block_raw` on-the-fly compile.
+
+A new `Interpreter::run_compiled_block_raw` carries `run_block_raw`'s
+post-compile half (`run_nested` plus the `free_var_writes` → pending-writeback
+drain) so both the on-the-fly and precompiled paths share the exact same
+execution/writeback semantics.
+
+The cutover is gated behind `MUTSU_DROP_LEGACY_CLASS_BODY=1` (the
+`MUTSU_DROP_LEGACY_BODY`/C6e-3a precedent from the sub side) and unset by
+default, so this slice ships with zero behavior change — the instrument exists
+to validate the chunk path exhaustively before a later slice flips the default.
+`ProtoMethod`'s chunk stays unused: `class_body_proto_method_decl` never
+actually executed the raw statement (it only clones `proto_body`/`param_defs`
+off the AST into a `FunctionDef`), so there is nothing for its chunk to
+replace yet.
+
+Wiring the instrument surfaced two real bugs in the previously-dead D6-3a-c
+chunks, invisible until something finally consumed them:
+
+1. **`LeavePhaser`'s chunk compiled to a silent no-op.** D6-3c compiled it
+   from the *wrapping* `Stmt::Phaser{kind: Leave, ..}` statement, but an
+   un-lowered `PhaserKind::Leave` compiles to nothing on its own (LEAVE is
+   normally driven by the enclosing `BlockScope` registering a callback, not
+   direct statement compilation) — while the runtime actually runs the
+   phaser's *inner* `body`. Fixed by generalizing the chunk compile into
+   `Compiler::compile_decl_stmts_chunk_in_package` (accepting `&[Stmt]`) and
+   feeding it the phaser's own inner body.
+2. **Every D6-3b/c chunk qualified bare variable/sub names against the wrong
+   package.** Bare-name package qualification is baked in at compile time
+   from the compiler's `current_package`, but the child compiler used for
+   each chunk inherited the *outer* (enclosing) compiler's ambient package
+   instead of the declaring class's own name. A top-level
+   `no strict; class Foo { $foo = 42; }` wrote an unqualified global instead
+   of `Foo::foo` under the forced instrument — caught by the pre-existing
+   `t/strict-use-and-eval.t`. Fixed by threading the same `package_name`
+   already computed for main-pass method-body compilation into
+   `compile_class_body_plan`, falling back to `chunk: None` (the
+   `run_block_raw` path) for a computed class name/hoisted shell, exactly
+   like the method-body precedent.
+
+Both fixes are pinned by new compiler unit tests
+(`class_declarations_leave_phaser_chunk_compiles_inner_body`,
+`class_declarations_other_chunk_qualifies_against_declaring_class`).
+
+Verified with `MUTSU_DROP_LEGACY_CLASS_BODY=1` forced: the full `t/` suite
+(28,023 tests), the `S12-class`/`S12-construction`/`S14-roles`/`S05-grammar`
+roast files (1,042 tests, same pre-existing `open_closed.t` failure as
+unforced), and `scripts/battery-testsuite.sh` (158/164 files pass, 2 excluded
+— byte-identical PASS/FAIL output to the unforced baseline).
+
+Next: a later slice flips the default once more validation has accumulated,
+then D6-4 drops `CompiledClassDeclPlan::legacy_body` (modulo the token/rule
+rump).

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -21,10 +21,10 @@ impl Compiler {
     }
 
     /// The shared setup [`Self::compile_decl_expr_inner`] and
-    /// [`Self::compile_decl_stmt_chunk`] both need: a standalone child
-    /// `Compiler` with no local slots, so every variable the chunk names
-    /// resolves through the environment the declaration registers in. The
-    /// package and distribution come from the declaration's own lexical
+    /// [`Self::compile_decl_stmts_chunk_in_package`] both need: a standalone
+    /// child `Compiler` with no local slots, so every variable the chunk
+    /// names resolves through the environment the declaration registers in.
+    /// The package and distribution come from the declaration's own lexical
     /// position rather than from whatever routine frame happens to be live
     /// when registration runs.
     fn new_decl_chunk_compiler(&self) -> Compiler {
@@ -66,17 +66,45 @@ impl Compiler {
         }
     }
 
-    /// Compile an arbitrary class-body statement into its own standalone
-    /// bytecode chunk (ADR-0019 D6-3b) — the statement-shaped
+    /// Compile a class-body statement (or, for `ClassBodyOp::LeavePhaser`, a
+    /// phaser's own inner statement list) into its own standalone bytecode
+    /// chunk (ADR-0019 D6-3b/c), qualifying bare variable/sub names against
+    /// `package` instead of this (outer) compiler's own ambient
+    /// `current_package` (ADR-0019 D6-3d) — the statement-shaped
     /// generalization of [`Self::compile_decl_expr`]: same standalone-unit
-    /// compile, but for a whole `&Stmt` rather than one wrapped `Expr`,
-    /// since `ClassBodyOp::Other`'s statement kinds (`use`/`need`, nested
+    /// compile, but for a `&[Stmt]` rather than one wrapped `Expr`, since
+    /// `ClassBodyOp::Other`'s statement kinds (`use`/`need`, nested
     /// `class`/`role`, BEGIN/CHECK, EVAL, `my`/`our` lexicals, ...) are not
     /// expressions.
-    pub(crate) fn compile_decl_stmt_chunk(&self, stmt: &Stmt) -> crate::opcode::CompiledDeclExpr {
-        let chunk_compiler = self.new_decl_chunk_compiler();
-        let body = [stmt.clone()];
-        let (code, fns) = chunk_compiler.compile(&body);
+    ///
+    /// A class-body statement is lexically INSIDE the class, so
+    /// `qualify_variable_name`/`qualify_package_name` must resolve as if
+    /// `current_package` were the class's own name — mirroring
+    /// `compile_method_body`'s
+    /// `method_compiler.set_current_package(package_name.to_string())` and
+    /// the registration-time throwaway compile it replaces
+    /// (`compile_method_def_in_place_with_dist`). Without this override, a
+    /// bare `$foo = 42` in a top-level `class Foo { $foo = 42 }` would
+    /// qualify against the OUTER (GLOBAL) package instead of `Foo::`,
+    /// diverging from `run_block_raw`'s registration-time compile (which
+    /// qualifies against the interpreter's `current_package()`, already
+    /// switched to `Foo` by the time the class body walk runs).
+    ///
+    /// `ClassBodyOp::LeavePhaser` calls this with a `will leave { ... }`
+    /// phaser's own *inner* body, NOT the wrapping `Stmt::Phaser` statement
+    /// — `compiler/stmt.rs`'s `Stmt::Phaser { .. } => {}` catch-all arm
+    /// compiles an un-lowered `PhaserKind::Leave` statement to a no-op
+    /// (LEAVE is normally driven by the enclosing `BlockScope` registering
+    /// a callback, not by direct statement compilation), which would make
+    /// the chunk silently empty.
+    fn compile_decl_stmts_chunk_in_package(
+        &self,
+        stmts: &[Stmt],
+        package: &str,
+    ) -> crate::opcode::CompiledDeclExpr {
+        let mut chunk_compiler = self.new_decl_chunk_compiler();
+        chunk_compiler.set_current_package(package.to_string());
+        let (code, fns) = chunk_compiler.compile(stmts);
         crate::opcode::CompiledDeclExpr {
             code: std::sync::Arc::new(code),
             fns: std::sync::Arc::new(fns),
@@ -202,7 +230,7 @@ impl Compiler {
         // true`); `is_hidden` gates the implicit `*%_` the same way too.
         let method_compiled_keys =
             self.compile_method_body_keys(body, package_name.as_deref(), *is_hidden, true);
-        let body_plan = self.compile_class_body_plan(body);
+        let body_plan = self.compile_class_body_plan(body, package_name.as_deref());
         self.code.add_class_decl_plan(
             stmt,
             name_chunk,
@@ -225,31 +253,61 @@ impl Compiler {
     /// `ClassSub` shares `Other`'s chunk mechanism (a top-level `SubDecl`
     /// runs through the same `class_body_other_stmt` path at registration,
     /// `ClassSub` only adds the `class_subs` tail-probe fact on top).
-    /// `CodeAlias`/`ProtoMethod`/`LeavePhaser` (D6-3c) compile the same way
-    /// — each still executes its raw statement wholesale at registration
+    /// `CodeAlias`/`ProtoMethod` (D6-3c) compile the same way — each still
+    /// executes its raw statement wholesale at registration
     /// (`class_body_code_alias`'s trailing `run_block_raw`,
-    /// `class_body_proto_method_decl`'s `FunctionDef.body` clone,
-    /// `run_class_body_leave_phasers`'s per-phaser `run_block_raw`), so a
-    /// single-statement chunk mirrors each exactly; no arm needs a richer
-    /// typed payload for D6-3c's purely-additive scope. `token`/`rule`
-    /// statements are excluded per the phase preamble's ADR-0009 carve-out
-    /// — they keep `chunk: None` and stay on the registration-time
-    /// `run_block_raw` path (D6-3e verifies this explicitly once the
-    /// driver cuts over). After this, `body_plan` is a complete, compiled
-    /// mirror of `legacy_body` with zero consumers.
-    fn compile_class_body_plan(&self, body: &[Stmt]) -> Vec<crate::opcode::ClassBodyOp> {
+    /// `class_body_proto_method_decl`'s `FunctionDef.body` clone), so a
+    /// single-statement chunk mirrors each exactly. `LeavePhaser` compiles
+    /// its *inner* `body` instead of the wrapping `Stmt::Phaser` — see
+    /// [`Self::compile_decl_stmts_chunk_in_package`]'s doc comment for why
+    /// the wrapper itself would compile to a no-op — mirroring
+    /// `run_class_body_leave_phasers`'s per-phaser `run_block_raw(body)`
+    /// exactly. `token`/`rule` statements are excluded per the phase
+    /// preamble's ADR-0009 carve-out — they keep `chunk: None` and stay on
+    /// the registration-time `run_block_raw` path (D6-3e verifies this
+    /// explicitly once the driver cuts over). After this, `body_plan` is a
+    /// complete, compiled mirror of `legacy_body` with zero consumers.
+    ///
+    /// `package_name` is `None` exactly when [`Self::compile_method_body_keys`]
+    /// also gets `None` (a computed class name / hoisted shell — no
+    /// compile-time-known package to qualify bare variable/sub names
+    /// against, see [`Self::compile_decl_stmts_chunk_in_package`]): every op
+    /// keeps `chunk: None` in that case too, falling back to the
+    /// registration-time `run_block_raw` path exactly like the method-body
+    /// precedent falls back to `compile_method_def_in_place_with_dist`.
+    fn compile_class_body_plan(
+        &self,
+        body: &[Stmt],
+        package_name: Option<&str>,
+    ) -> Vec<crate::opcode::ClassBodyOp> {
         let mut ops = crate::opcode::class_body_plan(body);
+        let Some(package_name) = package_name else {
+            return ops;
+        };
         for op in &mut ops {
+            if let crate::opcode::ClassBodyOp::LeavePhaser { chunk, raw } = op {
+                let Stmt::Phaser {
+                    body: phaser_body, ..
+                } = raw
+                else {
+                    unreachable!("LeavePhaser op's raw statement must be Stmt::Phaser");
+                };
+                *chunk = Some(self.compile_decl_stmts_chunk_in_package(phaser_body, package_name));
+                continue;
+            }
             let (chunk, raw) = match op {
                 crate::opcode::ClassBodyOp::Other { chunk, raw }
                 | crate::opcode::ClassBodyOp::ClassSub { chunk, raw, .. }
                 | crate::opcode::ClassBodyOp::CodeAlias { chunk, raw }
-                | crate::opcode::ClassBodyOp::ProtoMethod { chunk, raw }
-                | crate::opcode::ClassBodyOp::LeavePhaser { chunk, raw } => (chunk, raw),
+                | crate::opcode::ClassBodyOp::ProtoMethod { chunk, raw } => (chunk, raw),
                 _ => continue,
             };
             if !matches!(raw, Stmt::TokenDecl { .. } | Stmt::RuleDecl { .. }) {
-                *chunk = Some(self.compile_decl_stmt_chunk(raw));
+                *chunk =
+                    Some(self.compile_decl_stmts_chunk_in_package(
+                        std::slice::from_ref(raw),
+                        package_name,
+                    ));
             }
         }
         ops

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -474,6 +474,109 @@ mod declaration_plan_tests {
         }
     }
 
+    /// ADR-0019 D6-3d: `ClassBodyOp::LeavePhaser`'s chunk must compile the
+    /// phaser's own *inner* body, not the wrapping `Stmt::Phaser` statement
+    /// — `compiler/stmt.rs`'s `Stmt::Phaser { .. } => {}` catch-all arm
+    /// compiles a bare (un-lowered) `PhaserKind::Leave` statement to a
+    /// no-op, since LEAVE is normally driven by the enclosing `BlockScope`
+    /// registering a callback rather than by direct statement compilation.
+    /// Compiling the wrapper directly (the pre-fix behavior) would silently
+    /// produce a dead chunk with no observable side effect.
+    #[test]
+    fn class_declarations_leave_phaser_chunk_compiles_inner_body() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            "class A { my $will-be-static will leave { $tracker = 99 } = 1; }",
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_a = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "A")
+            .expect("class A declaration plan");
+
+        use crate::opcode::ClassBodyOp;
+        let phaser_chunk = plan_a
+            .body_plan
+            .iter()
+            .find_map(|op| match op {
+                ClassBodyOp::LeavePhaser { chunk: Some(c), .. } => Some(c),
+                _ => None,
+            })
+            .expect("a compiled LeavePhaser chunk");
+        // The wrapper-statement compile (the pre-fix behavior) emits no
+        // opcodes for `$tracker = 99` at all; compiling the inner body
+        // directly must emit real assignment bytecode.
+        assert!(
+            !phaser_chunk.code.ops.is_empty(),
+            "LeavePhaser chunk must not be empty (compiled the no-op wrapper instead of the inner body)"
+        );
+        assert!(
+            phaser_chunk
+                .code
+                .constants
+                .iter()
+                .any(|v| v.to_string_value() == "99"),
+            "LeavePhaser chunk should embed the inner body's `99` literal, ops: {:?}",
+            phaser_chunk.code.ops
+        );
+    }
+
+    /// ADR-0019 D6-3d: an `Other` op's chunk must qualify a bare package
+    /// variable against the *declaring class's own name*, not the outer
+    /// (enclosing) compiler's ambient package — `t/strict-use-and-eval.t`'s
+    /// `no strict; class Foo { $foo = 42; }` regressed under the
+    /// `MUTSU_DROP_LEGACY_CLASS_BODY=1` instrument until this was fixed:
+    /// `Compiler::qualify_variable_name` bakes package qualification in at
+    /// COMPILE time, and a body-plan chunk compiled with the wrong ambient
+    /// `current_package` silently wrote a bare (unqualified) global instead
+    /// of `Foo::foo`, diverging from `run_block_raw`'s registration-time
+    /// compile (which qualifies against the interpreter's
+    /// `current_package()`, already switched to `Foo` by then).
+    #[test]
+    fn class_declarations_other_chunk_qualifies_against_declaring_class() {
+        let (stmts, _) =
+            crate::parse_dispatch::parse_source("class Foo { $foo = 42; }").expect("parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_foo = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "Foo")
+            .expect("class Foo declaration plan");
+
+        // A `SetLine` marker statement (interstitial, parser-inserted) is
+        // also classified as `Other` and compiles to an empty chunk, so
+        // check every `Other` chunk rather than assuming the first is the
+        // `$foo = 42;` assignment.
+        use crate::opcode::ClassBodyOp;
+        let other_chunks: Vec<_> = plan_foo
+            .body_plan
+            .iter()
+            .filter_map(|op| match op {
+                ClassBodyOp::Other { chunk: Some(c), .. } => Some(c),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !other_chunks.is_empty(),
+            "expected at least one Other chunk"
+        );
+        assert!(
+            other_chunks.iter().any(|c| c
+                .code
+                .constants
+                .iter()
+                .any(|v| v.to_string_value() == "Foo::foo")),
+            "an Other chunk should qualify `$foo` as `Foo::foo`, chunks' constants: {:?}",
+            other_chunks
+                .iter()
+                .map(|c| &c.code.constants)
+                .collect::<Vec<_>>()
+        );
+    }
+
     /// ADR-0019 D2a: a role declaration's own attribute names, `use`d module
     /// names, and body-declared type names are precomputed at plan lowering,
     /// so `walk_role_body`'s pre-scan pass never re-derives them.

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -249,6 +249,15 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// harmless, since their `method_decls` is empty too, so the lookup is
     /// never reached.
     pub(crate) compiled_fns: &'a crate::opcode::CompiledFns,
+    /// Precomputed, position-aligned, typed mirror of the body statement
+    /// walk (ADR-0019 D6-3a-c), threaded down to `run_class_body` so its
+    /// small statement arms can run a precompiled chunk instead of
+    /// on-the-fly compiling the raw statement (gated behind
+    /// `MUTSU_DROP_LEGACY_CLASS_BODY`, D6-3d). Empty for registration paths
+    /// with no compiled plan available (role-pun/mixin synthesis, `augment
+    /// class`) — those keep the on-the-fly `run_block_raw` path
+    /// unconditionally, same as an empty body.
+    pub(crate) body_plan: &'a [crate::opcode::ClassBodyOp],
 }
 
 pub(super) fn parse_role_type_args(input: &str) -> Vec<String> {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1006,6 +1006,7 @@ impl Interpreter {
             declared_static_names: &[],
             parent_pre_args: &[],
             compiled_fns: &crate::opcode::CompiledFns::default(),
+            body_plan: &[],
         };
         self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
         self.store_language_revision_from_version(&pun_name, &language_version);

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -61,6 +61,42 @@ pub(super) enum ClassBodyFlow {
     SkipTail,
 }
 
+/// A collected class-body-scoped LEAVE phaser (`will leave { ... }`),
+/// carrying both its raw inner body (the pre-D6-3d execution source) and its
+/// precompiled chunk (ADR-0019 D6-3c/d) — see `run_class_body_leave_phasers`.
+pub(super) struct ClassBodyLeavePhaser {
+    pub(super) body: Vec<Stmt>,
+    pub(super) chunk: Option<crate::opcode::CompiledDeclExpr>,
+}
+
+/// Extract a body-walk op's compiled chunk, if any — `None` for a statement
+/// kind D6-3b/c never compiles a chunk for (`token`/`rule`, per the phase
+/// preamble's ADR-0009 carve-out) or when `op` itself is `None` (a
+/// length-mismatch fallback, see `run_class_body`).
+fn class_body_op_chunk(
+    op: Option<&crate::opcode::ClassBodyOp>,
+) -> Option<&crate::opcode::CompiledDeclExpr> {
+    match op? {
+        crate::opcode::ClassBodyOp::Other { chunk, .. }
+        | crate::opcode::ClassBodyOp::ClassSub { chunk, .. }
+        | crate::opcode::ClassBodyOp::CodeAlias { chunk, .. } => chunk.as_ref(),
+        _ => None,
+    }
+}
+
+/// `MUTSU_DROP_LEGACY_CLASS_BODY=1` forces the class-body walk's small
+/// statement arms (`class_body_other_stmt`, `class_body_code_alias`,
+/// `run_class_body_leave_phasers`) to run their precompiled `body_plan`
+/// chunk (ADR-0019 D6-3d) instead of on-the-fly compiling the raw statement
+/// via `run_block_raw` on every registration — an instrument for validation
+/// sweeps (the `MUTSU_DROP_LEGACY_BODY`/C6e-3a precedent), not yet the
+/// default. Cached in a `OnceLock` like `compiler/const_fold.rs`'s
+/// `folding_allowed`.
+pub(super) fn class_body_plan_forced() -> bool {
+    static FORCED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FORCED.get_or_init(|| std::env::var("MUTSU_DROP_LEGACY_CLASS_BODY").as_deref() == Ok("1"))
+}
+
 impl Interpreter {
     /// Recursively surface `has`-attribute declarations nested inside a sub/block
     /// within a class body (`class C { sub f { has $.x } }`). Descends into
@@ -103,6 +139,7 @@ impl Interpreter {
         method_decls: &[crate::opcode::CompiledMethodDecl],
         declared_static_names: &[Symbol],
         compiled_fns: &crate::opcode::CompiledFns,
+        body_plan: &[crate::opcode::ClassBodyOp],
     ) -> Result<ClassDef, RuntimeError> {
         let saved_package = self.current_package();
         let saved_env = self.env.clone();
@@ -124,6 +161,23 @@ impl Interpreter {
         // registers the attribute (the nested sub itself is still processed
         // normally; its body's `has` is a compile-time declaration).
         Self::collect_nested_class_has_decls(body, &mut flattened_body);
+        // `body_plan` (ADR-0019 D6-3a-d) is a position-aligned typed mirror of
+        // this same flattened statement sequence, computed by the compiler at
+        // plan lowering (`crate::opcode::class_body_plan` mirrors this
+        // function's own flatten+nested-has-append exactly — pinned by the
+        // `class_declarations_precompute_body_plan` compiler unit test). A
+        // registration path with no compiled plan (role-pun/mixin synthesis,
+        // `augment class`) always pairs an empty `body_plan` with an empty
+        // `body`, so lengths agree there too; guard against any other
+        // mismatch by falling back to `None` (the pre-D6-3d on-the-fly
+        // compile path) rather than risking a misaligned zip silently
+        // dropping trailing statements.
+        let body_plan_ops: Vec<Option<&crate::opcode::ClassBodyOp>> =
+            if body_plan.len() == flattened_body.len() {
+                body_plan.iter().map(Some).collect()
+            } else {
+                vec![None; flattened_body.len()]
+            };
         // The set of attributes valid for $!attr access: names declared
         // directly in this class body (precomputed by the compiler at plan
         // lowering, ADR-0019 D2a — `own_attribute_names` already covers the
@@ -160,14 +214,23 @@ impl Interpreter {
         // `my $x will leave { ... }`) must fire when the class body is left,
         // i.e. once all body statements have been processed. Collect them here
         // and run them (LIFO) after the loop instead of executing them inline.
-        let mut class_leave_phasers: Vec<Vec<Stmt>> = Vec::new();
-        for stmt in flattened_body {
+        let mut class_leave_phasers: Vec<ClassBodyLeavePhaser> = Vec::new();
+        for (stmt, op) in flattened_body.into_iter().zip(body_plan_ops) {
             match stmt {
                 Stmt::Phaser {
                     kind: PhaserKind::Leave,
                     body,
                 } => {
-                    class_leave_phasers.push(body.clone());
+                    let chunk = match op {
+                        Some(crate::opcode::ClassBodyOp::LeavePhaser { chunk, .. }) => {
+                            chunk.clone()
+                        }
+                        _ => None,
+                    };
+                    class_leave_phasers.push(ClassBodyLeavePhaser {
+                        body: body.clone(),
+                        chunk,
+                    });
                 }
                 Stmt::HasDecl { .. } => {
                     if matches!(
@@ -194,7 +257,8 @@ impl Interpreter {
                     expr: Expr::CodeVar(_),
                     ..
                 } if var_name.starts_with('&') => {
-                    self.class_body_code_alias(&mut cx, stmt)?;
+                    let chunk = class_body_op_chunk(op);
+                    self.class_body_code_alias(&mut cx, stmt, chunk)?;
                 }
                 Stmt::ProtoDecl {
                     is_method: true, ..
@@ -202,7 +266,8 @@ impl Interpreter {
                     self.class_body_proto_method_decl(&mut cx, stmt)?;
                 }
                 _ => {
-                    self.class_body_other_stmt(&mut cx, stmt)?;
+                    let chunk = class_body_op_chunk(op);
+                    self.class_body_other_stmt(&mut cx, stmt, chunk)?;
                 }
             }
             // Check if any new functions were registered under the class package
@@ -233,11 +298,30 @@ impl Interpreter {
         Ok(cx.class_def)
     }
 
+    /// Run a class-body statement's side effects, using its precompiled
+    /// `body_plan` chunk (ADR-0019 D6-3d) instead of on-the-fly compiling
+    /// `stmts` via `run_block_raw` when `MUTSU_DROP_LEGACY_CLASS_BODY=1`
+    /// forces the instrument and a chunk is available. Default (unforced)
+    /// behavior is unchanged: always `run_block_raw(stmts)`.
+    pub(super) fn run_class_body_chunk_or_raw(
+        &mut self,
+        chunk: Option<&crate::opcode::CompiledDeclExpr>,
+        stmts: &[Stmt],
+    ) -> Result<(), RuntimeError> {
+        if let Some(chunk) = chunk
+            && class_body_plan_forced()
+        {
+            return self.run_compiled_block_raw(&chunk.code, &chunk.fns);
+        }
+        self.run_block_raw(stmts)
+    }
+
     /// `our &baz ::= &bar` in a class body — alias a method under a new name.
     fn class_body_code_alias(
         &mut self,
         cx: &mut ClassBodyCx<'_>,
         stmt: &Stmt,
+        chunk: Option<&crate::opcode::CompiledDeclExpr>,
     ) -> Result<(), RuntimeError> {
         let Stmt::VarDecl {
             name: var_name,
@@ -256,7 +340,7 @@ impl Interpreter {
             .classes
             .insert(cx.name.to_string(), cx.class_def.clone());
         self.registry_mut().sync_user_method_entries(cx.name);
-        self.run_block_raw(std::slice::from_ref(stmt))?;
+        self.run_class_body_chunk_or_raw(chunk, std::slice::from_ref(stmt))?;
         for outer_name in cx.saved_env.keys() {
             let class_scoped_name = format!("{}::{}", cx.name, outer_name);
             if let Some(updated) = self.env.get(&class_scoped_name).cloned() {
@@ -327,6 +411,7 @@ impl Interpreter {
         &mut self,
         cx: &mut ClassBodyCx<'_>,
         stmt: &Stmt,
+        chunk: Option<&crate::opcode::CompiledDeclExpr>,
     ) -> Result<(), RuntimeError> {
         // An anonymous method (`method { $!x }`) parses as an
         // `AnonSubParams` expression statement (with an implicit
@@ -382,7 +467,7 @@ impl Interpreter {
         } else {
             None
         };
-        let result = self.run_block_raw(std::slice::from_ref(stmt));
+        let result = self.run_class_body_chunk_or_raw(chunk, std::slice::from_ref(stmt));
         if let Some(saved) = saved_defining {
             self.defining_class = saved;
         }

--- a/src/runtime/registration_class_body_exit.rs
+++ b/src/runtime/registration_class_body_exit.rs
@@ -4,7 +4,7 @@
 //! rollback on failure) and custom-HOW installation. Pure mechanical
 //! extraction from `registration_class_decl.rs` — no behavior change.
 
-use super::registration_class_body::ClassBodyCx;
+use super::registration_class_body::{ClassBodyCx, ClassBodyLeavePhaser};
 use super::registration_class_validate::ClassRegSnapshot;
 use super::*;
 
@@ -17,10 +17,10 @@ impl Interpreter {
     pub(super) fn run_class_body_leave_phasers(
         &mut self,
         cx: &ClassBodyCx<'_>,
-        class_leave_phasers: &[Vec<Stmt>],
+        class_leave_phasers: &[ClassBodyLeavePhaser],
     ) -> Result<(), RuntimeError> {
-        for body in class_leave_phasers.iter().rev() {
-            self.run_block_raw(body)?;
+        for phaser in class_leave_phasers.iter().rev() {
+            self.run_class_body_chunk_or_raw(phaser.chunk.as_ref(), &phaser.body)?;
             for outer_name in cx.saved_env.keys() {
                 let class_scoped_name = format!("{}::{}", cx.name, outer_name);
                 if let Some(updated) = self.env.get(&class_scoped_name).cloned() {

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -132,6 +132,7 @@ impl Interpreter {
             declared_static_names,
             parent_pre_args,
             compiled_fns,
+            body_plan,
         } = modifiers;
         let class_lang_rev = language_revision_letter(class_language_version);
         // Normalize parent names: strip leading `::` (indirect name lookup syntax).
@@ -234,6 +235,7 @@ impl Interpreter {
             method_decls,
             declared_static_names,
             compiled_fns,
+            body_plan,
         )?;
         self.finalize_class_registration(name, parents, class_def, &snapshot)?;
         self.install_class_exporthow(name, parents)?;

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -728,11 +728,25 @@ impl Interpreter {
             return Ok(());
         }
         let (code, compiled_fns) = self.compile_block_raw(stmts);
+        self.run_compiled_block_raw(&code, &compiled_fns)
+    }
+
+    /// [`Self::run_block_raw`]'s precompiled-chunk twin (ADR-0019 D6-3d):
+    /// same execution/writeback semantics, but takes an already-compiled
+    /// `CompiledCode`/`CompiledFns` pair (e.g. a `ClassBodyOp` arm's
+    /// `CompiledDeclExpr`) instead of compiling `stmts` on the fly on every
+    /// call. Split out so both paths share the free-var-writeback drain
+    /// instead of duplicating it.
+    pub(crate) fn run_compiled_block_raw(
+        &mut self,
+        code: &crate::opcode::CompiledCode,
+        compiled_fns: &crate::opcode::CompiledFns,
+    ) -> Result<(), RuntimeError> {
         // CP-3 collapse: run the compiled block re-entrantly in place (no
         // `mem::take(self)` + `VM::new` ping-pong), exactly like the VM-side
         // `vm_run_block_raw`. `run_nested` saves/resets/restores the per-execution
         // registers and flags env_dirty so the outer locals re-sync from env.
-        let result = self.run_nested(&code, &compiled_fns);
+        let result = self.run_nested(code, compiled_fns);
         // Slice F (env<->locals coherence): a deferred class/role body that
         // mutates an outer lexical (`class C { $tracker = 99 }`) writes it into
         // `env` by name; record those names so the caller (the class/role

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -71,6 +71,7 @@ impl Interpreter {
             declared_static_names: &[],
             parent_pre_args: &[],
             compiled_fns: &crate::opcode::CompiledFns::default(),
+            body_plan: &[],
         };
         self.register_class_decl(&name, &parents, modifiers, &[])?;
         self.compose_mixin_role_submethods(&name, &fresh);

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -144,7 +144,7 @@ impl Interpreter {
             method_decls,
             declared_static_names,
             parent_arg_chunks,
-            body_plan: _,
+            body_plan,
         }) = code.class_decl_plans.get(idx as usize)
         {
             let resolved_name = if let Some(chunk) = name_chunk {
@@ -279,6 +279,7 @@ impl Interpreter {
                         declared_static_names,
                         parent_pre_args: &parent_pre_args,
                         compiled_fns,
+                        body_plan,
                     },
                     body,
                 )


### PR DESCRIPTION
## Summary
- `run_class_body` now consumes `CompiledClassDeclPlan::body_plan` (ADR-0019 D6-3a-c) in parallel with the flattened `legacy_body` statement list, running each small-arm statement's precompiled chunk via a new `Interpreter::run_compiled_block_raw` instead of the registration-time `run_block_raw` on-the-fly compile.
- Gated behind `MUTSU_DROP_LEGACY_CLASS_BODY=1` (unset by default — zero behavior change in this slice), following the `MUTSU_DROP_LEGACY_BODY`/C6e-3a precedent from the sub side. The instrument validates the chunk path before a future slice flips the default and D6-4 drops `legacy_body`.
- Wiring the instrument surfaced two real, previously-invisible bugs in the "purely additive" D6-3a-c chunks:
  1. `LeavePhaser`'s chunk compiled the *wrapping* `Stmt::Phaser` statement, which is a silent no-op (LEAVE is normally driven by the enclosing `BlockScope`, not direct statement compilation) — fixed to compile the phaser's own inner body.
  2. Every D6-3b/c chunk qualified bare variable/sub names against the *outer* compiler's ambient package instead of the declaring class's own name (bare-name qualification is baked in at compile time) — fixed by threading the same `package_name` already computed for main-pass method-body compilation.
- Both fixes are pinned by new compiler unit tests.

## Test plan
- [x] `cargo test --lib` (698 tests)
- [x] `cargo clippy -- -D warnings`, `cargo fmt`
- [x] `prove -e target/debug/mutsu t/` — default (unset) and `MUTSU_DROP_LEGACY_CLASS_BODY=1` forced — both 28,023 tests pass
- [x] `MUTSU_FUDGE=1 prove -e target/release/mutsu` over the `S12-class`/`S12-construction`/`S14-roles`/`S05-grammar` roast whitelist — default and forced, both 1,042 tests pass (same pre-existing unrelated `open_closed.t` failure not in whitelist)
- [x] `scripts/battery-testsuite.sh` — default and forced, both `GATE PASSED`, byte-identical PASS/FAIL output (158/164 files pass, 2 excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)