### PR TITLE
fix(scope): gate user infix ops out of compiled module code via module_call_depth

### DIFF
--- a/news/2026-08/module-call-depth-user-infix-scope.md
+++ b/news/2026-08/module-call-depth-user-infix-scope.md
@@ -1,0 +1,40 @@
+# fix: user `sub infix:<op>` no longer leaks into compiled module code
+
+In Raku, operator declarations are lexically scoped per compilation unit.
+A `sub infix:<+>` declared in the test script must not intercept arithmetic
+inside `Test.rakumod` (or any other compiled module), because the module was
+compiled in its own lexical scope where the user's operator does not exist.
+
+mutsu stored user-declared infix operators in a global `HashSet` on the
+interpreter, giving them interpreter-wide (dynamic) scope instead of
+lexical-per-compilation-unit scope.  When `advent2013-day10.t` declared
+`sub infix:<+>`, `sub infix:</>`, and `sub infix:<&>` inside a block,
+those declarations immediately hijacked all subsequent `+`, `/`, `&`
+dispatches — including the counter arithmetic inside `Test.rakumod`'s
+`is()` function.  As a result test numbers 28–44 appeared blank (the
+counter returned `Nil` instead of an integer).
+
+## Fix
+
+Added `module_call_depth: u32` to `Interpreter`.  Every compiled-function
+call path increments the counter on entry and decrements it on exit when
+the called function belongs to an external module
+(`CompiledFunction::source_file` is `Some`).  `user_infix_override` now
+gates on `module_call_depth == 0`: while the interpreter is inside any
+module frame, user-declared infix operators are invisible, restoring
+lexical-per-compilation-unit semantics.
+
+The counter is incremented/decremented in all four compiled-function
+dispatch paths: `call_compiled_function_fast`,
+`call_compiled_function_named`, `call_compiled_function_positional_light`,
+and `call_compiled_function_light_spec`.
+
+Also fixed `RoutineRegistrySnapshot` to include `user_declared_infix_ops`,
+so that `BlockScope` blocks restore the operator set on exit — preventing
+a block-local `sub infix:<op>` from leaking into subsequent code outside
+the block.
+
+## Affected test
+
+`roast/integration/advent2013-day10.t` — all 44 tests now pass (was 27/44
+or fewer depending on earlier operator declarations).

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -199,6 +199,7 @@ impl Interpreter {
             registry.proto_subs.clone(),
             registry.proto_tokens.clone(),
             registry.our_scoped_functions.keys().copied().collect(),
+            self.user_declared_infix_ops.clone(),
         )
     }
 
@@ -211,8 +212,21 @@ impl Interpreter {
     }
 
     fn restore_routine_registry_impl(&mut self, snapshot: RoutineRegistrySnapshot, is_eval: bool) {
-        let (mut functions, proto_functions, token_defs, proto_subs, proto_tokens, our_scoped_keys) =
-            snapshot;
+        let (
+            mut functions,
+            proto_functions,
+            token_defs,
+            proto_subs,
+            proto_tokens,
+            our_scoped_keys,
+            user_infix_ops,
+        ) = snapshot;
+        // Restore the user-declared infix operator set.  In Raku, operators are
+        // lexically scoped per compilation unit; not restoring this caused a
+        // block-local `sub infix:<+>` to keep intercepting imported-module
+        // arithmetic (e.g. Test.rakumod's `$num_of_tests_run + 1`) after the
+        // block exited, resetting the test counter to Nil.
+        self.user_declared_infix_ops = user_infix_ops;
         self.reinstate_module_functions(&mut functions);
         // Collect our-scoped functions that were newly added during this block
         // (not present in the snapshot) that need to persist after scope restoration.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1008,6 +1008,13 @@ pub struct Interpreter {
     /// no-override hot path (e.g. tight `Int + Int` loops) free of registry
     /// lookups.
     pub(crate) user_declared_infix_ops: HashSet<String>,
+    /// Counts how many stack frames deep we are inside a module/external
+    /// compiled function (one whose `CompiledFunction::source_file` is
+    /// `Some`). User-declared `sub infix:<op>` from the test script must NOT
+    /// override operators used inside compiled module code (e.g. Test.rakumod's
+    /// counter arithmetic), mirroring Raku's lexical-per-compilation-unit
+    /// operator scoping. `user_infix_override` gates on this being zero.
+    pub(crate) module_call_depth: u32,
     lib_paths: Vec<String>,
     /// Bundled-battery module search paths (`modules/<Dist>/lib` shipped
     /// alongside the binary). Searched *after* every `lib_paths` entry so the
@@ -2439,6 +2446,7 @@ pub(crate) type RoutineRegistrySnapshot = (
     rustc_hash::FxHashSet<String>,
     rustc_hash::FxHashSet<String>,
     rustc_hash::FxHashSet<Symbol>,
+    std::collections::HashSet<String>, // user_declared_infix_ops snapshot
 );
 
 /// What a lexical import scope (`{ use Foo; ... }`) restores when it pops: the

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1028,7 +1028,7 @@ pub struct Interpreter {
     /// Interpreter behind transitional `Arc<RwLock>` scaffolding. Snapshot-cloned
     /// per thread (see [`io_handles`] module docs and `clone_for_thread`).
     io_handles: Arc<RwLock<io_handles::IoHandleTable>>,
-    program_path: Option<String>,
+    pub(crate) program_path: Option<String>,
     /// Name of the package currently in scope (e.g. `GLOBAL`, `Foo::Bar`),
     /// used to build fully-qualified names during function/method dispatch and
     /// declaration. Held behind transitional `Arc<RwLock>` scaffolding so the VM

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1834,6 +1834,7 @@ impl Interpreter {
             operator_assoc: HashMap::new(),
             imported_operator_names: HashSet::new(),
             user_declared_infix_ops: HashSet::new(),
+            module_call_depth: 0,
             lib_paths: Vec::new(),
             bundled_lib_paths: Self::resolve_bundled_lib_paths(),
             io_handles: Arc::new(RwLock::new(io_handles::IoHandleTable {

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -397,6 +397,7 @@ impl Interpreter {
             operator_assoc: self.operator_assoc.clone(),
             imported_operator_names: self.imported_operator_names.clone(),
             user_declared_infix_ops: self.user_declared_infix_ops.clone(),
+            module_call_depth: 0,
             lib_paths: self.lib_paths.clone(),
             bundled_lib_paths: self.bundled_lib_paths.clone(),
             io_handles: Arc::new(RwLock::new(io_handles::IoHandleTable {

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -41,9 +41,16 @@ impl Interpreter {
     /// Whether a user-declared `sub infix:<op>` is in scope for `canon`
     /// (e.g. `"infix:<+>"`). The set is empty in the overwhelming common
     /// case, keeping tight numeric loops free of any registry lookup.
+    ///
+    /// Returns false when inside a module function (`module_call_depth > 0`):
+    /// user infix ops from the test file are lexically scoped to their
+    /// compilation unit and must not override operators inside imported
+    /// modules (e.g. Test.rakumod's `$num_of_tests_run + 1`).
     #[inline]
     fn user_infix_override(&self, canon: &str) -> bool {
-        !self.user_declared_infix_ops.is_empty() && self.user_declared_infix_ops.contains(canon)
+        self.module_call_depth == 0
+            && !self.user_declared_infix_ops.is_empty()
+            && self.user_declared_infix_ops.contains(canon)
     }
 
     /// METAOP_ASSIGN identity substitution (`$x OP= $y` with an undefined `$x`).

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -20,6 +20,12 @@ impl Interpreter {
         // so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         self.record_cf_deprecation(cf);
+        // Gate user-infix overrides out of module code (source_file = Some):
+        // operators are lexically scoped per compilation unit.
+        let is_module_call = cf.source_file.is_some();
+        if is_module_call {
+            self.module_call_depth += 1;
+        }
         // A routine declared directly in this body is lexical; snapshot the
         // registry so it is removed on return unless it escaped (see
         // `call_compiled_function_named` / `return_value_escapes_routine`).
@@ -350,6 +356,9 @@ impl Interpreter {
                 Ok(v) if Self::return_value_escapes_routine(v) => {}
                 _ => self.restore_routine_registry(snapshot),
             }
+        }
+        if is_module_call {
+            self.module_call_depth -= 1;
         }
         final_result
     }

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -20,9 +20,10 @@ impl Interpreter {
         // so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         self.record_cf_deprecation(cf);
-        // Gate user-infix overrides out of module code (source_file = Some):
-        // operators are lexically scoped per compilation unit.
-        let is_module_call = cf.source_file.is_some();
+        // Gate user-infix overrides out of module code: only count a call as
+        // "module code" when the function's source file differs from the main
+        // script (same logic as call_compiled_function_named).
+        let is_module_call = Self::is_module_call(cf, self.program_path.as_deref());
         if is_module_call {
             self.module_call_depth += 1;
         }

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -12,6 +12,12 @@ impl Interpreter {
         // so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         self.record_cf_deprecation(cf);
+        // Gate user-infix overrides out of module code (source_file = Some):
+        // operators are lexically scoped per compilation unit.
+        let is_module_call = cf.source_file.is_some();
+        if is_module_call {
+            self.module_call_depth += 1;
+        }
         let param_slots = cf.param_local_slots.as_ref().unwrap();
         let positional_count = param_slots.len();
         let actual_count = args.len();
@@ -26,6 +32,9 @@ impl Interpreter {
                 "Too few positionals passed; expected {} arguments but got {}",
                 positional_count, actual_count
             );
+            if is_module_call {
+                self.module_call_depth -= 1;
+            }
             return Err(RuntimeError::typed(
                 "X::TypeCheck::Argument",
                 Self::type_check_argument_attrs(func_name, &cf.param_defs, args, msg),
@@ -159,6 +168,9 @@ impl Interpreter {
                     self.loop_local_vars = saved_loop_local_vars;
                     self.loop_local_saved_env = saved_loop_local_saved_env;
                     self.block_declared_vars = saved_block_declared_vars;
+                    if is_module_call {
+                        self.module_call_depth -= 1;
+                    }
                     {
                         let param_name = &cf.param_defs[param_idx].name;
                         let got = runtime::value_type_name(&val);
@@ -426,6 +438,9 @@ impl Interpreter {
             });
         }
 
+        if is_module_call {
+            self.module_call_depth -= 1;
+        }
         match result {
             Ok(()) if fail_bypass => Ok(ret_val),
             Ok(()) => {

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -12,9 +12,10 @@ impl Interpreter {
         // so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         self.record_cf_deprecation(cf);
-        // Gate user-infix overrides out of module code (source_file = Some):
-        // operators are lexically scoped per compilation unit.
-        let is_module_call = cf.source_file.is_some();
+        // Gate user-infix overrides out of module code: only count a call as
+        // "module code" when the function's source file differs from the main
+        // script (same logic as call_compiled_function_named).
+        let is_module_call = Self::is_module_call(cf, self.program_path.as_deref());
         if is_module_call {
             self.module_call_depth += 1;
         }

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -38,6 +38,7 @@ impl Interpreter {
         // chunk without one takes the full named dispatch instead.
         let Some(plan) = cf.named_call_plan.as_deref() else {
             let pkg = self.current_package().to_string();
+            // call_compiled_function_named handles module_call_depth itself.
             return self.call_compiled_function_named(
                 cf,
                 args.to_vec(),
@@ -46,6 +47,12 @@ impl Interpreter {
                 func_name,
             );
         };
+        // Gate user-infix overrides out of module code (source_file = Some):
+        // operators are lexically scoped per compilation unit.
+        let is_module_call = cf.source_file.is_some();
+        if is_module_call {
+            self.module_call_depth += 1;
+        }
         // Save caller locals and create callee locals
         let saved_locals = std::mem::take(&mut self.locals);
         // Isolate the caller's loop-body-local declaration scope (mirrors
@@ -349,6 +356,9 @@ impl Interpreter {
             self.loop_local_vars = saved_loop_local_vars;
             self.loop_local_saved_env = saved_loop_local_saved_env;
             self.block_declared_vars = saved_block_declared_vars;
+            if is_module_call {
+                self.module_call_depth -= 1;
+            }
             return Err(e);
         }
 
@@ -599,6 +609,9 @@ impl Interpreter {
             }
         }
 
+        if is_module_call {
+            self.module_call_depth -= 1;
+        }
         match result {
             Ok(()) if fail_bypass => Ok(ret_val),
             Ok(()) => {

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -47,9 +47,10 @@ impl Interpreter {
                 func_name,
             );
         };
-        // Gate user-infix overrides out of module code (source_file = Some):
-        // operators are lexically scoped per compilation unit.
-        let is_module_call = cf.source_file.is_some();
+        // Gate user-infix overrides out of module code: only count a call as
+        // "module code" when the function's source file differs from the main
+        // script (same logic as call_compiled_function_named).
+        let is_module_call = Self::is_module_call(cf, self.program_path.as_deref());
         if is_module_call {
             self.module_call_depth += 1;
         }

--- a/src/vm/vm_call_named.rs
+++ b/src/vm/vm_call_named.rs
@@ -9,9 +9,13 @@ impl Interpreter {
         fn_package: &str,
         fn_name: &str,
     ) -> Result<Value, RuntimeError> {
-        // Gate user-infix overrides out of module code (source_file = Some):
-        // operators are lexically scoped per compilation unit.
-        let is_module_call = cf.source_file.is_some();
+        // Gate user-infix overrides out of module code: only count a call as
+        // "module code" when the function's source file differs from the main
+        // script.  User-defined `multi sub` in the test file are OTF-compiled
+        // and carry `source_file = Some(script_path)`, so they must NOT be
+        // treated as module code — user infix ops must remain available inside
+        // them (lexically scoped per compilation unit).
+        let is_module_call = Self::is_module_call(cf, self.program_path.as_deref());
         if is_module_call {
             self.module_call_depth += 1;
         }

--- a/src/vm/vm_call_named.rs
+++ b/src/vm/vm_call_named.rs
@@ -9,26 +9,36 @@ impl Interpreter {
         fn_package: &str,
         fn_name: &str,
     ) -> Result<Value, RuntimeError> {
+        // Gate user-infix overrides out of module code (source_file = Some):
+        // operators are lexically scoped per compilation unit.
+        let is_module_call = cf.source_file.is_some();
+        if is_module_call {
+            self.module_call_depth += 1;
+        }
         // A routine declared directly in this body is lexical to the call.
         // Snapshot the routine registry around the (multi-exit) body so the
         // lexical routine is removed on return — UNLESS it escapes by being
         // returned (then its registry entry must survive so it stays callable
         // by name). The snapshot is cheap relative to the rare case it guards.
-        if !cf.declares_inner_routines {
-            return self.call_compiled_function_named_inner(
+        let result = if !cf.declares_inner_routines {
+            self.call_compiled_function_named_inner(cf, args, compiled_fns, fn_package, fn_name)
+        } else {
+            let snapshot = self.snapshot_routine_registry();
+            let r = self.call_compiled_function_named_inner(
                 cf,
                 args,
                 compiled_fns,
                 fn_package,
                 fn_name,
             );
-        }
-        let snapshot = self.snapshot_routine_registry();
-        let result =
-            self.call_compiled_function_named_inner(cf, args, compiled_fns, fn_package, fn_name);
-        match &result {
-            Ok(v) if Self::return_value_escapes_routine(v) => {}
-            _ => self.restore_routine_registry(snapshot),
+            match &r {
+                Ok(v) if Self::return_value_escapes_routine(v) => {}
+                _ => self.restore_routine_registry(snapshot),
+            }
+            r
+        };
+        if is_module_call {
+            self.module_call_depth -= 1;
         }
         result
     }

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -1,6 +1,28 @@
 use super::*;
 
 impl Interpreter {
+    /// Whether calling `cf` should be treated as a cross-module call for the
+    /// purpose of gating user-declared infix operators.
+    ///
+    /// A function is a "module call" when it was compiled from a *different*
+    /// compilation unit than the main script:
+    ///
+    /// - AOT-compiled functions (`source_file = None`) are always from the
+    ///   user's own script — never a module call.
+    /// - OTF-compiled functions from the main script (`source_file ==
+    ///   program_path`) are also user code — not a module call.
+    /// - OTF-compiled functions from a *different* file (e.g. Test.rakumod)
+    ///   are module code — counted as a module call so user infix ops defined
+    ///   in the test script do not override arithmetic inside the module.
+    #[inline]
+    pub(super) fn is_module_call(cf: &CompiledFunction, program_path: Option<&str>) -> bool {
+        match (&cf.source_file, program_path) {
+            (None, _) => false,
+            (Some(cf_file), Some(prog)) => cf_file.as_str() != prog,
+            (Some(_), None) => true,
+        }
+    }
+
     /// Enforce a `ContainerRef` cell's registered `of`-type constraint before a
     /// write-through (`$ref = v` on a `:=`-bound typed slot — a typed rw
     /// attribute accessor bind, or a `my T $` anonymous typed scalar). Mirrors


### PR DESCRIPTION
## Summary

- User-declared `sub infix:<op>` operators were stored in a global `HashSet` on the interpreter, giving them interpreter-wide (dynamic) scope instead of Raku's lexical-per-compilation-unit scope
- When `advent2013-day10.t` declared `sub infix:<+>`, `/`, `&` inside a block, those hijacked arithmetic inside `Test.rakumod`'s `is()` function (the test counter returned Nil → blank test numbers 28–44)
- Add `module_call_depth: u32` to `Interpreter`; increment on entry into any compiled function with `source_file = Some(...)` (external module), decrement on exit; `user_infix_override` returns `false` when > 0
- Also include `user_declared_infix_ops` in `RoutineRegistrySnapshot` so `BlockScope` blocks restore the operator set on exit

## Test plan

- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/integration/advent2013-day10.t` → 44/44 ✓ (was failing tests 28–44)
- [x] `make test` passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)