### PR TITLE
fix(runtime): propagate a broken Promise from a whenever nested inside a supply body

### DIFF
--- a/src/runtime/react_died.rs
+++ b/src/runtime/react_died.rs
@@ -137,6 +137,43 @@ impl Interpreter {
                     ..ReactSubscription::new(callback)
                 });
             }
+            return None;
+        }
+        // A `whenever <Promise>` registered from *inside* a nested on-demand
+        // supply body (e.g. `Cro::Connector.establish`'s `supply { whenever
+        // self.connect(...) -> $t { whenever $t.transformer(...) {...} } }`)
+        // lands here rather than in the top-level `build_react_subscriptions`
+        // Promise arm. Without this, a broken promise with no QUIT handler was
+        // silently dropped instead of dying the react (this function returned
+        // `None`, and none of `register_nested_on_demand_source`'s other
+        // fallbacks recognize a bare Promise source either).
+        if let ValueView::Promise(shared) = source.view() {
+            let (tx, rx) = crate::runtime::native_methods::supply_channel::supply_event_channel();
+            let shared_clone = shared.clone();
+            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+                let (result, _, _) = shared_clone.wait();
+                if shared_clone.status() == "Broken" {
+                    let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Quit(result));
+                } else {
+                    let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Emit(result));
+                    let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Done);
+                }
+            });
+            let last_cbs = items
+                .get(2)
+                .and_then(Self::react_value_array_items)
+                .unwrap_or_default();
+            let quit_cbs = items
+                .get(3)
+                .and_then(Self::react_value_array_items)
+                .unwrap_or_default();
+            return Some(ReactSubscription {
+                receiver: Some(rx),
+                promise: Some(shared.clone()),
+                last_callbacks: last_cbs,
+                quit_callbacks: quit_cbs,
+                ..ReactSubscription::new(callback)
+            });
         }
         None
     }

--- a/t/supply-whenever-nested-broken-promise.t
+++ b/t/supply-whenever-nested-broken-promise.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 2;
+
+# `whenever <Promise> { ... }` NESTED inside a `supply { }` block's on-demand
+# body (rather than directly in a `react { }` block) used to silently drop a
+# broken promise instead of dying the outer react. The nested whenever's
+# subscription marker is registered while `run_on_demand_body` is driving the
+# body synchronously, and is turned into a `ReactSubscription` by
+# `value_to_react_subscription` / `register_nested_on_demand_source` — neither
+# of which had a `ValueView::Promise` arm (only `build_react_subscriptions`,
+# used for a *top-level* `whenever <Promise>`, did). So the marker matched
+# none of the fallback branches and was dropped on the floor.
+#
+# (Found via Cro::Connector.establish's `supply { whenever self.connect(...)
+# -> $t { whenever $t.transformer(...) {...} } }` shape: `tcp.rakutest`
+# expects connecting to a dead port to die the react instead of hanging.)
+
+my $s = supply {
+    my Promise $connection = Promise.new;
+    $connection.break('connect failed');
+    whenever $connection -> $transform {
+        flunk 'the nested whenever body must not run for a broken promise';
+        emit 'never';
+    }
+}
+my $died;
+try {
+    react {
+        whenever $s -> $msg {
+            flunk 'the outer whenever must not receive a value';
+        }
+    }
+    CATCH {
+        default { $died = $_; }
+    }
+}
+ok $died.defined, 'a broken promise nested inside a supply body dies the outer react';
+like $died.message, /'connect failed'/, 'the caught exception carries the broken promise\'s message';


### PR DESCRIPTION
## Summary
- `whenever <Promise> { ... }` registered from *inside* a `supply { }` block's on-demand body (rather than directly under `react { }`) went through `value_to_react_subscription` / `register_nested_on_demand_source`, neither of which had a `ValueView::Promise` arm — only `build_react_subscriptions` (used for a top-level `whenever <Promise>`, fixed in #6112) did.
- So a broken promise with no `QUIT` handler was silently dropped instead of dying the enclosing react — the subscription marker matched none of the fallback branches and was discarded.
- Adds the same channel+thread Promise handling to `value_to_react_subscription` so both call sites (top-level nested-registration replay and the `SupplyDrivePolicy::Promise` await path) pick it up.

Found via `Cro::Core`'s `tcp.rakutest`, through `Cro::Connector.establish`'s `supply { whenever self.connect(...) -> $t { whenever $t.transformer(...) {...} } }` shape — connecting to a dead port must die the react. Verified against the vendored (not-yet-bundled) Cro test suite locally: `tcp.rakutest` goes from 42/44 to **44/44**, `Cro::Core` is now 9/9 fully green. `Cro::HTTP` re-run shows no regression (still 20/34 fully green files, unrelated to this change).

## Test plan
- [x] New pinning test `t/supply-whenever-nested-broken-promise.t`
- [x] `prove -e target/debug/mutsu` on all `t/react*.t` and `t/supply*.t` (79 files, 371 tests) — all pass
- [x] `cargo fmt -- --check` / `RUSTUP_TOOLCHAIN=1.96.1 cargo clippy -- -D warnings` clean
- [x] CI will run `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)