### PR TITLE
feat(compiler): compile role body into a typed op walk (ADR-0019 D7-4)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,9 +115,9 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 34/53 slices merged (C6, C7, C8, D1, and D2d complete; D2a and D2c-1/2/3 also
-landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, D4-3, D7-3, and D3-8a landed
-2026-08-08; D3-8b, D3-8c, and D3-8d landed 2026-08-09). Phase C is fully checked; the open box is
+**Current progress: 35/53 slices merged (C6, C7, C8, D1, D2d, and D7 complete; D2a and D2c-1/2/3
+also landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, D4-3, D7-3, and D3-8a landed
+2026-08-08; D3-8b, D3-8c, D3-8d, and D7-4 landed 2026-08-09). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
@@ -1269,7 +1269,7 @@ walkers wholesale is not possible before then.
   excluded — byte-identical PASS/FAIL output to the unforced baseline). D6-3e
   (token/rule carve-out check) is expected to fold into a later default-flip
   slice rather than needing its own PR, per the design doc's own note.
-- [ ] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
+- [x] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
   **Design pass done 2026-08-08 (no code landed):**
   `todo/deep/adr0019-d7-d8-role-plan-encoding.md`. The role plan gains the class side's
@@ -1309,7 +1309,27 @@ walkers wholesale is not possible before then.
   today's double-evaluation of a side-effecting bracket argument into a single evaluation, a
   real behavior change out of this slice's scope. Verified via the full `t/` suite (27,992
   tests) and every whitelisted `S14-roles`/`S12-coercion` roast file, plus `t/mro-role-hides.t`
-  (hides/hidden-specific coverage), all green. D7-4 (`body_plan` op walk) remains open.
+  (hides/hidden-specific coverage), all green.
+  **D7-4 landed 2026-08-09**: `CompiledRoleDeclPlan` gained `body_plan: Vec<RoleBodyOp>`, a
+  new typed enum (`Attr`/`Method`/`Parent`/`Deferred`) computed at plan lowering by a new
+  `role_body_plan` free function mirroring `walk_role_body`'s own dispatch loop: a single-level
+  `SyntheticBlock` flatten (unlike the class side, a role body has no nested-sub `has`
+  collection — `walk_role_body`'s own comment confirms roles have none), classified the same way
+  the runtime match does. Deliberately narrower than `ClassBodyOp`: a role body has no
+  `ClassSub`/`CodeAlias`/`ProtoMethod`/`LeavePhaser` arms (those class-only statement kinds, plus
+  the `__mutsu_stub_die`/`__mutsu_stub_warn` stub marker and `SetLine` markers, all fall through
+  to `Deferred`), and `Deferred` carries no compiled chunk — deferred-statement chunk compilation
+  is D8's job (`RoleDef::deferred_body`'s own `DeferredBodyOp`, a separate type per the D7/D8
+  design doc). `Deferred`'s `raw: Stmt` field is boxed (`Box<Stmt>`): unlike `ClassBodyOp`, whose
+  every non-tiny variant also carries a same-size `Stmt` (keeping the largest/second-largest size
+  gap small), `RoleBodyOp`'s `Attr`/`Method`/`Parent` are all marker-sized, so an unboxed `Stmt`
+  tripped `clippy::large_enum_variant`. Purely additive — no non-test consumer reads the field yet
+  (`#[allow(dead_code)]` on the field/enum, the D6-3a precedent), pinned by a new compiler unit
+  test (`role_declarations_precompute_body_plan`) asserting `body_plan.len()` against an
+  independently re-derived flattened-statement count and the typed op sequence (including the
+  role-header `does` clause's synthetic `DoesDecl`, prepended to the body ahead of a body-level
+  `does`, both classifying as `Parent`). Verified via the full `t/` suite (28,037 tests). This
+  closes D7 — all of D7-1..4 have now landed.
 - [ ] **D8 — Compile role declaration-time bodies and traits.** Run parameterized-role and composed
   ancestor bodies as bytecode child chunks with correct once-per-composition behavior. (Custom-trait
   arguments already landed with C5; the bodies remain.)

--- a/news/2026-08/adr0019-d7-4-role-body-plan.md
+++ b/news/2026-08/adr0019-d7-4-role-body-plan.md
@@ -1,0 +1,30 @@
+# ADR-0019 D7-4: role body compiled into a typed op walk, closing D7
+
+`CompiledRoleDeclPlan` gained `body_plan: Vec<RoleBodyOp>`, a new typed enum
+(`Attr`/`Method`/`Parent`/`Deferred`) computed at plan lowering by a new
+`role_body_plan` free function that mirrors `walk_role_body`'s own dispatch
+loop: a single-level `SyntheticBlock` flatten (a role body has no nested-sub
+`has` collection, unlike the class side), classified the same way the runtime
+match does.
+
+This is the role-side twin of D6-3a's class `body_plan`, but deliberately
+narrower: a role body has no `ClassSub`/`CodeAlias`/`ProtoMethod`/
+`LeavePhaser` arms, and its `Deferred` catch-all (which also absorbs the
+`__mutsu_stub_die`/`__mutsu_stub_warn` stub marker call and `SetLine`
+markers) carries no compiled chunk — deferred-statement chunk compilation is
+D8's job, on a separate `RoleDef::deferred_body` type. `Deferred`'s raw
+statement is boxed (`Box<Stmt>`): unlike `ClassBodyOp`, whose every non-tiny
+variant also carries a same-size `Stmt`, `RoleBodyOp`'s `Attr`/`Method`/
+`Parent` variants are all marker-sized, so an unboxed `Stmt` tripped
+`clippy::large_enum_variant`.
+
+Purely additive — no non-test consumer reads the field yet — and pinned by a
+new compiler unit test (`role_declarations_precompute_body_plan`) asserting
+`body_plan.len()` against an independently re-derived flattened-statement
+count and the typed op sequence, including the role-header `does` clause's
+synthetic `DoesDecl` (prepended to the body ahead of any body-level `does`,
+both classifying as `Parent`). Verified via the full `t/` suite (28,037
+tests).
+
+With D7-1 (=D9-1), D7-2 (=D2b-2's role half), D7-3, and now D7-4 all landed,
+ADR-0019's D7 box ("Encode role structure and composition") is complete.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -662,6 +662,72 @@ mod declaration_plan_tests {
             .expect("role R declaration plan");
         assert_eq!(plan_r.our_scope_violation, None);
     }
+
+    /// ADR-0019 D7-4: a role's `body_plan` is an ordered, typed mirror of
+    /// its (single-level flattened) body, one op per statement
+    /// `walk_role_body`'s dispatch loop visits — the role-side twin of
+    /// D6-3a's class `body_plan`.
+    #[test]
+    fn role_declarations_precompute_body_plan() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            r#"
+            role R does Some {
+                has $.x;
+                method m { 42 }
+                does Baz;
+                say "hi";
+            }
+            "#,
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_r = code
+            .role_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "R")
+            .expect("role R declaration plan");
+
+        // Independently re-derive the flattened statement count (same
+        // single-level transform `role_body_plan` applies), so the length
+        // check does not hardcode a count sensitive to the parser's own
+        // `SetLine` insertion behavior.
+        let Stmt::RoleDecl { body, .. } = stmts
+            .iter()
+            .find(|s| matches!(s, Stmt::RoleDecl { name, .. } if name.as_str() == "R"))
+            .expect("role R declaration statement")
+        else {
+            unreachable!()
+        };
+        let flattened: Vec<&Stmt> = body
+            .iter()
+            .flat_map(|s| match s {
+                Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+                other => vec![other],
+            })
+            .collect();
+        assert_eq!(plan_r.body_plan.len(), flattened.len());
+
+        // Filtering out `Deferred` ops (the `SetLine` markers and the `say`
+        // statement) leaves exactly the typed arms, in source order. The
+        // role-header `does Some` clause is a synthetic `DoesDecl`
+        // prepended to the body, so it appears before the body-level
+        // `does Baz` clause even though both classify as `Parent`.
+        use crate::opcode::RoleBodyOp;
+        let typed: Vec<&RoleBodyOp> = plan_r
+            .body_plan
+            .iter()
+            .filter(|op| !matches!(op, RoleBodyOp::Deferred { .. }))
+            .collect();
+        assert_eq!(typed.len(), 4, "typed ops: {typed:?}");
+        assert!(matches!(typed[0], RoleBodyOp::Parent));
+        assert!(matches!(
+            typed[1],
+            RoleBodyOp::Attr { name } if name.as_str() == "x"
+        ));
+        assert!(matches!(typed[2], RoleBodyOp::Method));
+        assert!(matches!(typed[3], RoleBodyOp::Parent));
+    }
 }
 mod const_fold;
 mod decl_plan;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2943,6 +2943,65 @@ pub(crate) struct RoleParentOp {
     pub(crate) args: Option<Vec<DeclTraitArg>>,
 }
 
+/// One role-body statement, typed (ADR-0019 D7-4) — the role-side twin of
+/// [`ClassBodyOp`]. Purely additive: no consumer reads this yet
+/// (`walk_role_body` still walks raw `Stmt`s). Deliberately narrower than
+/// `ClassBodyOp`: a role body has no nested-sub `has` collection and no
+/// `ClassSub`/`CodeAlias`/`ProtoMethod`/`LeavePhaser` arms (those class-only
+/// statement kinds fall through to `Deferred` in a role body, exactly as
+/// `walk_role_body`'s own catch-all treats them), and carries no compiled
+/// chunk yet — deferred-statement chunk compilation is D8's job
+/// (`RoleDef::deferred_body`'s own `DeferredBodyOp`, a separate type).
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) enum RoleBodyOp {
+    /// A top-level `has` declaration. Its typed descriptor lives in
+    /// `attr_decls`, keyed by this same name.
+    Attr { name: Symbol },
+    /// A `method`/`submethod` declaration. Advances the existing
+    /// `method_name_chunks`/`method_decls` position cursor.
+    Method,
+    /// A `does`/`hides`/`is hidden` clause. Its typed descriptor lives in
+    /// `parent_ops`, read by position via `parent_op_idx`.
+    Parent,
+    /// Everything else: the `__mutsu_stub_die`/`__mutsu_stub_warn` stub
+    /// marker call (`is_stub` already covers this as a plan fact — see
+    /// `role_body_is_stub`), `SetLine` source-line markers, and every
+    /// statement `walk_role_body` pushes onto `RoleDef::deferred_body_stmts`
+    /// to run at composition time. Boxed: unlike `ClassBodyOp` (whose other
+    /// variants also carry a same-size `Stmt`, keeping the largest/
+    /// second-largest gap small), `Attr`/`Method`/`Parent` here are all
+    /// marker-sized, so an unboxed `Stmt` would trip
+    /// `clippy::large_enum_variant`.
+    Deferred { raw: Box<Stmt> },
+}
+
+/// Lower a role body into its ordered, typed op mirror (ADR-0019 D7-4),
+/// matching `walk_role_body`'s own dispatch loop exactly: a single-level
+/// `SyntheticBlock`-flatten (roles have no nested-sub `has` collection —
+/// `walk_role_body`'s own comment confirms it), classifying each statement
+/// the same way the runtime match does.
+pub(crate) fn role_body_plan(body: &[Stmt]) -> Vec<RoleBodyOp> {
+    body.iter()
+        .flat_map(|s| match s {
+            Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
+            other => vec![other],
+        })
+        .map(classify_role_body_stmt)
+        .collect()
+}
+
+fn classify_role_body_stmt(stmt: &Stmt) -> RoleBodyOp {
+    match stmt {
+        Stmt::HasDecl { name, .. } => RoleBodyOp::Attr { name: *name },
+        Stmt::MethodDecl { .. } => RoleBodyOp::Method,
+        Stmt::DoesDecl { .. } => RoleBodyOp::Parent,
+        _ => RoleBodyOp::Deferred {
+            raw: Box::new(stmt.clone()),
+        },
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledRoleDeclPlan {
     pub(crate) name: Symbol,
@@ -2997,6 +3056,12 @@ pub(crate) struct CompiledRoleDeclPlan {
     /// (ADR-0019 D7-3), one per `DoesDecl` statement in source order; see
     /// [`RoleParentOp`].
     pub(crate) parent_ops: Vec<RoleParentOp>,
+    /// Ordered, typed mirror of the (single-level flattened) role body
+    /// (ADR-0019 D7-4), one op per statement `walk_role_body`'s dispatch
+    /// loop visits. Purely additive — no non-test consumer reads this field
+    /// yet. See [`RoleBodyOp`].
+    #[allow(dead_code)]
+    pub(crate) body_plan: Vec<RoleBodyOp>,
 }
 
 /// A package-level `proto sub`/`proto rule`/`proto token` declaration lowered
@@ -6301,6 +6366,7 @@ impl CompiledCode {
         }
         let is_stub = role_body_is_stub(body);
         let our_scope_violation = role_body_our_scope_violation(body);
+        let body_plan = role_body_plan(body);
         let plan_idx = self.role_decl_plans.len() as u32;
         self.role_decl_plans.push(CompiledRoleDeclPlan {
             name: *name,
@@ -6321,6 +6387,7 @@ impl CompiledCode {
             is_stub,
             our_scope_violation,
             parent_ops,
+            body_plan,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Role(plan_idx));

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -637,6 +637,7 @@ impl Interpreter {
             is_stub,
             our_scope_violation,
             parent_ops,
+            body_plan: _,
         }) = code.role_decl_plans.get(idx as usize)
         {
             let name_str = name.resolve();


### PR DESCRIPTION
## Summary
- Adds `CompiledRoleDeclPlan::body_plan: Vec<RoleBodyOp>`, the role-side twin of D6-3a's class `body_plan`, computed by a new `role_body_plan` free function mirroring `walk_role_body`'s own dispatch loop (single-level `SyntheticBlock` flatten, `Attr`/`Method`/`Parent`/`Deferred` classification).
- Purely additive — no non-test consumer reads the field yet (deferred-statement chunk compilation is D8's job).
- Closes ADR-0019's **D7** box (role structure and composition): D7-1 (=D9-1), D7-2 (=D2b-2's role half), D7-3, and now D7-4 have all landed.

## Test plan
- [x] New compiler unit test `role_declarations_precompute_body_plan` (asserts `body_plan.len()` against an independently re-derived flattened-statement count, and the typed op sequence including the role-header `does` clause's synthetic `DoesDecl`)
- [x] `cargo clippy -- -D warnings` / `cargo fmt`
- [x] Full `t/` TAP suite (28,037 tests) green
- [x] `roast/S14-roles/*.t`, `roast/S12-coercion/*.t`, `roast/S12-class/*.t`, `roast/S12-construction/*.t` green (only the pre-existing, non-whitelisted `S12-class/open_closed.t` failure, unrelated)
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)