### PR TITLE
feat(compiler,runtime): precompile role deferred-body statements into typed ops (ADR-0019 D8-1)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1346,6 +1346,25 @@ walkers wholesale is not possible before then.
   role-global `pun:`/`mixin:` memos and the unguarded class path are recorded; any
   raku-conformance divergence gets its own ticket). Includes the `run_role_submethod` rider
   (the C6d-3 leftover goes bytecode after D3-8). Slices D8-1..4 in the doc.
+  **D8-1 landed 2026-08-09**: `CompiledRoleDeclPlan` gained `deferred_body_ops:
+  Vec<DeferredBodyOp>` (`{ kind: TypeDecl | TokenRule | Plain, chunk: Option<CompiledDeclExpr>,
+  declared_vars: Vec<Symbol>, raw: Stmt }`), one op per `RoleBodyOp::Deferred` entry in D7-4's
+  `body_plan` — reusing D7-4's already-classified raw statements as input instead of re-deriving
+  them from `legacy_body`. `kind` mirrors `run_composed_role_deferred_body`'s own
+  `is_type_decl`/`is_regex_decl` classification; `declared_vars` replaces its `VarDecl` re-scan
+  (a non-`our`/non-`dynamic` `VarDecl`'s own name, empty otherwise). `chunk` compiles against the
+  role's own qualified package for `TypeDecl`/`Plain` — a reasonable but not yet
+  raku-cross-verified default per the design doc's "frozen plan" item, since a `Plain`
+  statement's true package at composition time is whatever was ambient at the call site, not
+  necessarily the role's own; `TokenRule` (the composing class's package, unknown until
+  composition — the same ADR-0009 carve-out D6/D9 apply to class-body token/rule statements)
+  keeps `chunk: None`. `register_role_decl` copies the ops onto a new `RoleDef::deferred_body`
+  field (`#[allow(dead_code)]`); `deferred_body_stmts` remains the sole execution path — nothing
+  reads `deferred_body` back yet. Pinned by a new compiler unit test
+  (`role_declarations_precompute_deferred_body`) asserting the op count against `body_plan`'s
+  own `Deferred` count and the `TypeDecl`/`TokenRule`/`declared_vars` classification for a
+  `my $y = 1`/`token t { a }` pair. Verified via the full `t/` suite (28,037 tests). D8-2
+  (consumer cutover behind the design doc's V1/V2 raku case tables) is next.
 - [ ] **D9 — Remove `CompiledRoleDeclPlan::legacy_body`.** Preserve role puns, runtime mixins,
   conflicts, BUILD/TWEAK, custom HOWs, and EVAL. Same rule as D6: survey first, token/rule arms
   excluded.

--- a/news/2026-08/adr0019-d8-1-role-deferred-body-ops.md
+++ b/news/2026-08/adr0019-d8-1-role-deferred-body-ops.md
@@ -1,0 +1,29 @@
+# ADR-0019 D8-1: role deferred-body statements precompiled into typed ops
+
+`CompiledRoleDeclPlan` gained `deferred_body_ops: Vec<DeferredBodyOp>`, one op
+per `RoleBodyOp::Deferred` entry in D7-4's `body_plan` — reusing D7-4's
+already-classified raw statements as input instead of re-deriving them from
+`legacy_body`. Each `DeferredBodyOp` carries:
+
+- `kind: TypeDecl | TokenRule | Plain`, mirroring
+  `run_composed_role_deferred_body`'s own `is_type_decl`/`is_regex_decl`
+  classification (a nested `class`/`role` registers under the role's own
+  package at composition time; a `token`/`rule`/`regex` registers under the
+  composing class's package, which isn't known until composition).
+- `declared_vars: Vec<Symbol>`, replacing the runtime's own `VarDecl`
+  re-scan for lexical-persistence bookkeeping — a non-`our`/non-`dynamic`
+  `VarDecl`'s own name, empty for every other statement kind.
+- `chunk: Option<CompiledDeclExpr>`, compiled against the role's own
+  qualified package for `TypeDecl`/`Plain` statements. `TokenRule`
+  statements keep `chunk: None` — the same ADR-0009 carve-out D6/D9 apply to
+  class-body token/rule statements — and stay on the `run_block_raw` path.
+
+`register_role_decl` copies the ops onto a new `RoleDef::deferred_body`
+field. This slice is purely additive: `deferred_body_stmts` remains the sole
+execution path, and nothing reads `deferred_body` back yet — the consumer
+cutover (behind the design doc's raku-verified case tables for the "frozen
+plan" question) is D8-2.
+
+Pinned by a new compiler unit test
+(`role_declarations_precompute_deferred_body`), verified via the full `t/`
+suite (28,037 tests).

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -526,11 +526,20 @@ impl Compiler {
         // pseudo-package, but `qualified_role_decl_name` now resolves the
         // correct runtime package in that case via `enclosing_package`, so no
         // special-casing is needed at this call site either.
-        let method_compiled_keys = if is_hoisted_shell {
-            self.compile_method_body_keys(body, None, false, false)
+        let package_name = if is_hoisted_shell {
+            None
         } else {
-            let package_name = self.qualified_role_decl_name(&name.resolve());
-            self.compile_method_body_keys(body, Some(&package_name), false, false)
+            Some(self.qualified_role_decl_name(&name.resolve()))
+        };
+        let method_compiled_keys =
+            self.compile_method_body_keys(body, package_name.as_deref(), false, false);
+        // ADR-0019 D8-1: a hoisted shell's deferred-body compile would be
+        // fully redundant too (same reasoning as `method_compiled_keys`
+        // above), so it stays empty; only the source-order declaration's
+        // plan compiles chunks.
+        let deferred_body_ops = match &package_name {
+            Some(package_name) => self.compile_role_deferred_body(body, package_name),
+            None => Vec::new(),
         };
         self.code.add_role_decl_plan(
             stmt,
@@ -539,7 +548,48 @@ impl Compiler {
             method_name_chunks,
             parent_ops,
             method_compiled_keys,
+            deferred_body_ops,
         )
+    }
+
+    /// Precompile each deferred role-body statement into a
+    /// [`crate::opcode::DeferredBodyOp`] (ADR-0019 D8-1) — reuses D7-4's
+    /// `RoleBodyOp::Deferred` raw statements as its input, one op per
+    /// `Deferred` entry `crate::opcode::role_body_plan` produces, in the
+    /// same order. `package_name` is the role's own qualified name; see
+    /// `DeferredBodyOp::chunk`'s doc comment for why this is a reasonable
+    /// default rather than a verified-correct package for every deferred
+    /// statement kind.
+    fn compile_role_deferred_body(
+        &self,
+        body: &[Stmt],
+        package_name: &str,
+    ) -> Vec<crate::opcode::DeferredBodyOp> {
+        crate::opcode::role_body_plan(body)
+            .into_iter()
+            .filter_map(|op| match op {
+                crate::opcode::RoleBodyOp::Deferred { raw } => Some(raw),
+                _ => None,
+            })
+            .map(|raw| {
+                let kind = crate::opcode::classify_deferred_body_op_kind(&raw);
+                let chunk = if kind == crate::opcode::DeferredBodyOpKind::TokenRule {
+                    None
+                } else {
+                    Some(self.compile_decl_stmts_chunk_in_package(
+                        std::slice::from_ref(raw.as_ref()),
+                        package_name,
+                    ))
+                };
+                let declared_vars = crate::opcode::deferred_body_op_declared_vars(&raw);
+                crate::opcode::DeferredBodyOp {
+                    kind,
+                    chunk,
+                    declared_vars,
+                    raw: *raw,
+                }
+            })
+            .collect()
     }
 
     /// Precompile each `does`/`hides`/`is hidden` clause of a role's own body

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -728,6 +728,78 @@ mod declaration_plan_tests {
         assert!(matches!(typed[2], RoleBodyOp::Method));
         assert!(matches!(typed[3], RoleBodyOp::Parent));
     }
+
+    /// ADR-0019 D8-1: each deferred (non-attribute, non-method, non-`does`)
+    /// role-body statement gets its own precompiled `DeferredBodyOp`, one
+    /// per `RoleBodyOp::Deferred` entry in `body_plan` — a `token`/`rule`
+    /// statement is classified `TokenRule` and kept `chunk: None` (the
+    /// composing class's package isn't known until composition), a
+    /// non-`our`/non-`dynamic` `VarDecl` records its own name in
+    /// `declared_vars`, and every other statement compiles a chunk.
+    #[test]
+    fn role_declarations_precompute_deferred_body() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            r#"
+            role R {
+                has $.x;
+                method m { 42 }
+                my $y = 1;
+                token t { a }
+                say "hi";
+            }
+            "#,
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        let plan_r = code
+            .role_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "R")
+            .expect("role R declaration plan");
+
+        use crate::opcode::RoleBodyOp;
+        let deferred_count = plan_r
+            .body_plan
+            .iter()
+            .filter(|op| matches!(op, RoleBodyOp::Deferred { .. }))
+            .count();
+        assert_eq!(plan_r.deferred_body_ops.len(), deferred_count);
+
+        use crate::opcode::DeferredBodyOpKind;
+        let var_op = plan_r
+            .deferred_body_ops
+            .iter()
+            .find(|op| matches!(&op.raw, Stmt::VarDecl { name, .. } if name == "y"))
+            .expect("the `my $y = 1` deferred op");
+        assert_eq!(var_op.kind, DeferredBodyOpKind::Plain);
+        assert!(var_op.chunk.is_some());
+        assert_eq!(
+            var_op
+                .declared_vars
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>(),
+            vec!["y"]
+        );
+
+        let token_op = plan_r
+            .deferred_body_ops
+            .iter()
+            .find(|op| matches!(&op.raw, Stmt::TokenDecl { .. }))
+            .expect("the `token t { a }` deferred op");
+        assert_eq!(token_op.kind, DeferredBodyOpKind::TokenRule);
+        assert!(token_op.chunk.is_none());
+        assert!(token_op.declared_vars.is_empty());
+
+        // Every other deferred op (the `SetLine` markers and the `say`
+        // statement) is `Plain` and compiled a chunk.
+        for op in &plan_r.deferred_body_ops {
+            if op.kind != DeferredBodyOpKind::TokenRule {
+                assert!(op.chunk.is_some(), "missing chunk for {op:?}");
+            }
+        }
+    }
 }
 mod const_fold;
 mod decl_plan;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3002,6 +3002,72 @@ fn classify_role_body_stmt(stmt: &Stmt) -> RoleBodyOp {
     }
 }
 
+/// How a deferred role-body statement's package resolves at composition
+/// time (ADR-0019 D8-1), mirroring `run_composed_role_deferred_body`'s
+/// `is_type_decl`/`is_regex_decl` classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum DeferredBodyOpKind {
+    /// A nested `class`/`role` declaration — registers under the role's
+    /// OWN package at composition time.
+    TypeDecl,
+    /// A `token`/`rule`/`regex` declaration — registers under the
+    /// COMPOSING class's package, which is not known until composition;
+    /// excluded from the compiled-chunk cutover, the same ADR-0009
+    /// carve-out D6/D9 apply to class-body token/rule statements.
+    TokenRule,
+    /// Everything else — runs with whatever package was ambient when
+    /// composition started.
+    Plain,
+}
+
+/// One deferred role-body statement, precompiled (ADR-0019 D8-1) — the
+/// per-statement unit a future slice moves onto `RoleDef::deferred_body`,
+/// eventually replacing `deferred_body_stmts` (D8-4). Purely additive for
+/// now: no consumer reads a `chunk` yet, registration still runs
+/// `deferred_body_stmts` unchanged. Reuses [`RoleBodyOp::Deferred`]'s raw
+/// statements as input — see [`deferred_body_ops`].
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) struct DeferredBodyOp {
+    pub(crate) kind: DeferredBodyOpKind,
+    /// `None` for `TokenRule` (excluded from the compiled-chunk cutover —
+    /// see [`DeferredBodyOpKind::TokenRule`]); compiled against the role's
+    /// own package for `TypeDecl`/`Plain`. That package guess is a
+    /// reasonable default (a nested type declares under the role's own
+    /// package; most `Plain` statements are lexical `my`/`state`
+    /// declarations needing no package qualification at all) but not
+    /// verified against every case — see the D7/D8 design doc's "frozen
+    /// plan" verification item, deferred to the consumer-cutover slice.
+    pub(crate) chunk: Option<CompiledDeclExpr>,
+    /// The name this statement declares as a plain (non-`our`,
+    /// non-`dynamic`) lexical `VarDecl`, replacing
+    /// `run_composed_role_deferred_body`'s own re-scan of every deferred
+    /// statement for this same fact. Empty for every other statement kind.
+    pub(crate) declared_vars: Vec<Symbol>,
+    pub(crate) raw: Stmt,
+}
+
+pub(crate) fn classify_deferred_body_op_kind(stmt: &Stmt) -> DeferredBodyOpKind {
+    match stmt {
+        Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } => DeferredBodyOpKind::TypeDecl,
+        Stmt::TokenDecl { .. } | Stmt::RuleDecl { .. } => DeferredBodyOpKind::TokenRule,
+        _ => DeferredBodyOpKind::Plain,
+    }
+}
+
+pub(crate) fn deferred_body_op_declared_vars(stmt: &Stmt) -> Vec<Symbol> {
+    match stmt {
+        Stmt::VarDecl {
+            name,
+            is_our: false,
+            is_dynamic: false,
+            ..
+        } => vec![Symbol::intern(name)],
+        _ => Vec::new(),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledRoleDeclPlan {
     pub(crate) name: Symbol,
@@ -3062,6 +3128,15 @@ pub(crate) struct CompiledRoleDeclPlan {
     /// yet. See [`RoleBodyOp`].
     #[allow(dead_code)]
     pub(crate) body_plan: Vec<RoleBodyOp>,
+    /// Precompiled per-statement chunk for each deferred (non-attribute,
+    /// non-method, non-`does`) statement in the role body (ADR-0019 D8-1),
+    /// derived from `body_plan`'s `Deferred` ops. `register_role_decl`
+    /// copies this onto `RoleDef::deferred_body`; `deferred_body_stmts`
+    /// remains the authoritative execution path until D8-2's consumer
+    /// cutover — this field is written but not yet read back. See
+    /// [`DeferredBodyOp`].
+    #[allow(dead_code)]
+    pub(crate) deferred_body_ops: Vec<DeferredBodyOp>,
 }
 
 /// A package-level `proto sub`/`proto rule`/`proto token` declaration lowered
@@ -6334,6 +6409,7 @@ impl CompiledCode {
         idx
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn add_role_decl_plan(
         &mut self,
         stmt: &Stmt,
@@ -6342,6 +6418,7 @@ impl CompiledCode {
         method_name_chunks: Vec<Option<CompiledDeclExpr>>,
         parent_ops: Vec<RoleParentOp>,
         method_compiled_keys: Vec<Option<Symbol>>,
+        deferred_body_ops: Vec<DeferredBodyOp>,
     ) -> u32 {
         let Stmt::RoleDecl {
             name,
@@ -6388,6 +6465,7 @@ impl CompiledCode {
             our_scope_violation,
             parent_ops,
             body_plan,
+            deferred_body_ops,
         });
         let idx = self.decl_plans.len() as u32;
         self.decl_plans.push(CompiledDeclPlanRef::Role(plan_idx));

--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -65,6 +65,12 @@ pub(crate) struct RoleDef {
     /// These are non-method/non-attribute statements that may reference type parameters
     /// and must be re-executed for each class composition with concrete type bindings.
     pub(crate) deferred_body_stmts: Vec<Stmt>,
+    /// Precompiled per-statement mirror of `deferred_body_stmts` (ADR-0019
+    /// D8-1), copied from `CompiledRoleDeclPlan::deferred_body_ops` at
+    /// registration. Purely additive: `deferred_body_stmts` remains the
+    /// authoritative execution path until D8-2's consumer cutover.
+    #[allow(dead_code)]
+    pub(crate) deferred_body: Vec<crate::opcode::DeferredBodyOp>,
     /// Unknown lowercase trait names deferred for custom `trait_mod:<is>` dispatch.
     pub(crate) deferred_custom_traits: Vec<String>,
 }

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -53,6 +53,7 @@ pub(super) fn builtin_role_def() -> RoleDef {
         attribute_conflicts: Vec::new(),
         own_attribute_names: HashSet::new(),
         deferred_body_stmts: Vec::new(),
+        deferred_body: Vec::new(),
         deferred_custom_traits: Vec::new(),
     }
 }

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -323,6 +323,7 @@ impl Interpreter {
         is_stub_body: bool,
         our_scope_violation: Option<&str>,
         parent_ops: &[crate::opcode::RoleParentOp],
+        deferred_body_ops: &[crate::opcode::DeferredBodyOp],
         compiled_fns: &crate::opcode::CompiledFns,
     ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
@@ -373,6 +374,7 @@ impl Interpreter {
             attribute_conflicts: Vec::new(),
             own_attribute_names: HashSet::new(),
             deferred_body_stmts: Vec::new(),
+            deferred_body: deferred_body_ops.to_vec(),
             deferred_custom_traits: Vec::new(),
         };
         let mut cx = RoleDeclCx {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1930,6 +1930,7 @@ impl Interpreter {
                             attribute_conflicts: Vec::new(),
                             own_attribute_names: std::collections::HashSet::new(),
                             deferred_body_stmts: Vec::new(),
+                            deferred_body: Vec::new(),
                             deferred_custom_traits: Vec::new(),
                         },
                     );
@@ -1947,6 +1948,7 @@ impl Interpreter {
                             attribute_conflicts: Vec::new(),
                             own_attribute_names: std::collections::HashSet::new(),
                             deferred_body_stmts: Vec::new(),
+                            deferred_body: Vec::new(),
                             deferred_custom_traits: Vec::new(),
                         },
                     );
@@ -1964,6 +1966,7 @@ impl Interpreter {
                             attribute_conflicts: Vec::new(),
                             own_attribute_names: std::collections::HashSet::new(),
                             deferred_body_stmts: Vec::new(),
+                            deferred_body: Vec::new(),
                             deferred_custom_traits: Vec::new(),
                         },
                     );
@@ -1981,6 +1984,7 @@ impl Interpreter {
                             attribute_conflicts: Vec::new(),
                             own_attribute_names: std::collections::HashSet::new(),
                             deferred_body_stmts: Vec::new(),
+                            deferred_body: Vec::new(),
                             deferred_custom_traits: Vec::new(),
                         },
                     );
@@ -1998,6 +2002,7 @@ impl Interpreter {
                             attribute_conflicts: Vec::new(),
                             own_attribute_names: std::collections::HashSet::new(),
                             deferred_body_stmts: Vec::new(),
+                            deferred_body: Vec::new(),
                             deferred_custom_traits: Vec::new(),
                         },
                     );
@@ -2048,6 +2053,7 @@ impl Interpreter {
                                 attribute_conflicts: Vec::new(),
                                 own_attribute_names: std::collections::HashSet::new(),
                                 deferred_body_stmts: Vec::new(),
+                                deferred_body: Vec::new(),
                                 deferred_custom_traits: Vec::new(),
                             },
                         );
@@ -2101,6 +2107,7 @@ impl Interpreter {
                                 attribute_conflicts: Vec::new(),
                                 own_attribute_names: std::collections::HashSet::new(),
                                 deferred_body_stmts: Vec::new(),
+                                deferred_body: Vec::new(),
                                 deferred_custom_traits: Vec::new(),
                             },
                         );

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -638,6 +638,7 @@ impl Interpreter {
             our_scope_violation,
             parent_ops,
             body_plan: _,
+            deferred_body_ops,
         }) = code.role_decl_plans.get(idx as usize)
         {
             let name_str = name.resolve();
@@ -673,6 +674,7 @@ impl Interpreter {
                     *is_stub,
                     *our_scope_violation,
                     parent_ops,
+                    deferred_body_ops,
                     compiled_fns,
                 )
             )?;


### PR DESCRIPTION
## Summary
- `CompiledRoleDeclPlan` gains `deferred_body_ops: Vec<DeferredBodyOp>`, one op per D7-4's `RoleBodyOp::Deferred` entry — reuses D7-4's already-classified raw statements as input.
- Each op carries `kind` (`TypeDecl`/`TokenRule`/`Plain`, mirroring `run_composed_role_deferred_body`'s package-routing logic), `declared_vars` (replacing the runtime's own `VarDecl` re-scan), and a precompiled `chunk` (`None` for `TokenRule`, which keeps the ADR-0009 carve-out and stays on `run_block_raw`).
- `register_role_decl` copies the ops onto a new `RoleDef::deferred_body` field. Purely additive: `deferred_body_stmts` remains the sole execution path — nothing reads `deferred_body` back yet. Consumer cutover (behind the design doc's raku-verified V1/V2 case tables) is D8-2.

## Test plan
- [x] New compiler unit test `role_declarations_precompute_deferred_body`
- [x] `cargo clippy -- -D warnings` / `cargo fmt`
- [x] Full `t/` TAP suite (28,037 tests) green
- [x] `roast/S14-roles/*.t`, `roast/S12-coercion/*.t`, `roast/S12-construction/*.t` green
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)