### PR TITLE
fix(pragma): save/restore lexical pragma state at function call boundaries

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1934,7 +1934,7 @@ pub struct Interpreter {
     /// When true, module precompilation cache is enabled.
     precomp_enabled: bool,
     /// When true, `augment class` is allowed (set by `use MONKEY-TYPING` or `use MONKEY`).
-    monkey_typing: bool,
+    pub(crate) monkey_typing: bool,
     /// Defaults selected by the import list of the latest
     /// `use JSON::Fast <...>` / `use JSON::Tiny` (see `runtime/json.rs`).
     pub(crate) json_import_defaults: crate::runtime::json::JsonImportDefaults,

--- a/src/vm/vm_call_fast.rs
+++ b/src/vm/vm_call_fast.rs
@@ -133,6 +133,10 @@ impl Interpreter {
         // (`P::show()` from GLOBAL) would run the body under GLOBAL and silently
         // lose package-var reads/writes.
         let saved_package = self.enter_routine_package(cf);
+        // Lexical pragmas (`use fatal`, `use strict`, `use MONKEY-TYPING`,
+        // `use newline`) are scoped to the compilation unit where they appear.
+        // Save and restore around the body so callee's `use fatal` never leaks.
+        let saved_pragmas = self.save_pragma_state();
         let let_mark = self.let_saves_len();
         // Frame-less path: roll back the line the body's ops advanced to manually.
         let saved_line = self.cur_source_line;
@@ -338,6 +342,8 @@ impl Interpreter {
         }
 
         self.leave_routine_package(saved_package);
+        // Restore the caller's pragma state (fatal/strict/newline/monkey-typing).
+        self.restore_pragma_state(saved_pragmas);
 
         let final_result = match result {
             Ok(()) if fail_bypass => Ok(ret_val),

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -237,6 +237,11 @@ impl Interpreter {
         // package). Restored after the env merge below.
         let saved_package = self.enter_routine_package(cf);
 
+        // Lexical pragmas (`use fatal`, `use strict`, `use MONKEY-TYPING`,
+        // `use newline`) are scoped to the compilation unit where they appear.
+        // Save and restore around the body so callee's `use fatal` never leaks.
+        let saved_pragmas = self.save_pragma_state();
+
         // A routine (sub/method) body is its own topicalizer for a bare
         // `when`/`default`: a matching `when` sets the global `when_matched`
         // flag (and returns via the succeed signal, caught by the
@@ -312,6 +317,8 @@ impl Interpreter {
         if cf.code.is_routine {
             self.set_when_matched(saved_when_matched);
         }
+        // Restore the caller's pragma state (fatal/strict/newline/monkey-typing).
+        self.restore_pragma_state(saved_pragmas);
 
         // Natural fall-through completion (no explicit return / fail / error
         // break arm): restore any `temp` bindings the body introduced so a

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -448,6 +448,11 @@ impl Interpreter {
         // required-param early returns above). Restored after the env merge below.
         let saved_package = self.enter_routine_package(cf);
 
+        // Lexical pragmas (`use fatal`, `use strict`, `use MONKEY-TYPING`,
+        // `use newline`) are scoped to the compilation unit where they appear.
+        // Save and restore around the body so callee's `use fatal` never leaks.
+        let saved_pragmas = self.save_pragma_state();
+
         // A routine body is its own topicalizer for a bare `when`/`default`: a
         // matching `when` sets the global `when_matched` flag, which must not
         // leak to an enclosing `given`/`with` body (see vm_call_light.rs for the
@@ -510,6 +515,8 @@ impl Interpreter {
         if cf.code.is_routine {
             self.set_when_matched(saved_when_matched);
         }
+        // Restore the caller's pragma state (fatal/strict/newline/monkey-typing).
+        self.restore_pragma_state(saved_pragmas);
 
         // Natural fall-through completion (no explicit return / fail / error
         // break arm): restore any `temp` bindings the body introduced so a

--- a/src/vm/vm_call_named.rs
+++ b/src/vm/vm_call_named.rs
@@ -19,6 +19,11 @@ impl Interpreter {
         if is_module_call {
             self.module_call_depth += 1;
         }
+        // Lexical pragmas (`use fatal`, `use strict`, `use MONKEY-TYPING`,
+        // `use newline`) are scoped to the compilation unit where they appear.
+        // Save the caller's pragma state and restore it on every exit path so
+        // `use fatal` inside the callee does not bleed into the caller.
+        let saved_pragmas = self.save_pragma_state();
         // A routine declared directly in this body is lexical to the call.
         // Snapshot the routine registry around the (multi-exit) body so the
         // lexical routine is removed on return — UNLESS it escapes by being
@@ -41,6 +46,7 @@ impl Interpreter {
             }
             r
         };
+        self.restore_pragma_state(saved_pragmas);
         if is_module_call {
             self.module_call_depth -= 1;
         }

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -23,6 +23,36 @@ impl Interpreter {
         }
     }
 
+    /// Snapshot the lexical pragma state (`use fatal`, `use strict`,
+    /// `use newline`, `use MONKEY-TYPING`) before entering a function body.
+    /// Must be paired with `restore_pragma_state` on every exit path to prevent
+    /// the callee's pragmas from leaking into the caller's scope.
+    ///
+    /// In real Raku, pragmas are compile-time and lexically scoped per
+    /// compilation unit.  mutsu approximates this at runtime: save on entry,
+    /// restore on exit, so `use fatal` inside a sub never outlives that sub.
+    #[inline]
+    pub(super) fn save_pragma_state(&self) -> (bool, bool, crate::runtime::NewlineMode, bool) {
+        (
+            self.fatal_mode,
+            self.strict_mode,
+            self.newline_mode,
+            self.monkey_typing,
+        )
+    }
+
+    /// Restore pragma state saved by `save_pragma_state`.
+    #[inline]
+    pub(super) fn restore_pragma_state(
+        &mut self,
+        state: (bool, bool, crate::runtime::NewlineMode, bool),
+    ) {
+        self.fatal_mode = state.0;
+        self.strict_mode = state.1;
+        self.newline_mode = state.2;
+        self.monkey_typing = state.3;
+    }
+
     /// Enforce a `ContainerRef` cell's registered `of`-type constraint before a
     /// write-through (`$ref = v` on a `:=`-bound typed slot — a typed rw
     /// attribute accessor bind, or a `my T $` anonymous typed scalar). Mirrors

--- a/t/use-fatal-pragma-scope.t
+++ b/t/use-fatal-pragma-scope.t
@@ -1,0 +1,95 @@
+use Test;
+
+plan 8;
+
+# use fatal inside a sub body must not leak to the caller after the sub returns.
+# All fail() calls are inside subs (never mainline) because fail in mainline always throws.
+
+sub sub_with_fatal() {
+    use fatal;
+    my $x = 1;  # no failure here, just activates the pragma
+}
+
+# Test 1: use fatal inside callee sub does not leak into caller sub
+sub caller_no_fatal_1() {
+    sub_with_fatal();
+    my $f = fail "should not throw";
+    return $f;
+}
+my $r1 = caller_no_fatal_1();
+ok !$r1.defined, "use fatal in callee sub does not leak to caller (fail stays soft)";
+
+# Test 2: closure with use fatal also does not leak to the enclosing sub
+sub closure_with_fatal() {
+    my $c = { use fatal; 1 };
+    $c();
+}
+sub caller_after_closure() {
+    closure_with_fatal();
+    my $f = fail "should not throw 2";
+    return $f;
+}
+my $r2 = caller_after_closure();
+ok !$r2.defined, "use fatal in closure does not leak to caller sub";
+
+# Test 3: use fatal DOES make fail() throw inside that sub's own body
+sub sub_that_fails() {
+    use fatal;
+    fail "inner failure";
+}
+dies-ok { sub_that_fails() }, "use fatal inside sub causes fail() to throw inside sub";
+
+# Test 4: when CALLER has use fatal and callee returns a Failure, caller's
+# assignment of that Failure throws (fatal is active in the caller scope)
+sub inner_that_fails_silently() {
+    my $x = fail "inner";
+    return $x;
+}
+sub caller_with_fatal() {
+    use fatal;
+    inner_that_fails_silently();  # Failure propagates, caller fatal mode catches it
+}
+dies-ok { caller_with_fatal() }, "Failure returned from callee throws in fatal caller";
+
+# Test 5: outer fatal scope is still active after a non-fatal nested sub returns
+sub nested_non_fatal() { my $x = fail "non-fatal"; return $x; }
+sub outer_fatal_check() {
+    use fatal;
+    my $inner_result = nested_non_fatal();  # callee runs fine, returns Failure
+    my $after = 42;
+    return $after;
+}
+my $threw5 = False;
+try { outer_fatal_check(); CATCH { default { $threw5 = True; } } }
+ok $threw5, "outer fatal scope catches Failure assigned from callee's return value";
+
+# Test 6: use strict inside a sub must not leak to the caller
+sub sub_with_strict() {
+    use strict;
+    my $x = 1;
+}
+sub caller_after_strict() {
+    sub_with_strict();
+    return 42;
+}
+is caller_after_strict(), 42, "use strict inside sub does not crash caller";
+
+# Test 7: use MONKEY-TYPING inside a sub must not leak
+sub sub_with_monkey() {
+    use MONKEY-TYPING;
+    my $x = 1;
+}
+sub caller_after_monkey() {
+    sub_with_monkey();
+    return 99;
+}
+is caller_after_monkey(), 99, "use MONKEY-TYPING inside sub does not crash caller";
+
+# Test 8: Repeated calls to sub_with_fatal do not accumulate fatal state
+sub caller_repeat() {
+    sub_with_fatal(); sub_with_fatal(); sub_with_fatal();
+    my $f = fail "still not throwing";
+    return $f;
+}
+my $r8 = caller_repeat();
+ok !$r8.defined, "Repeated sub_with_fatal calls do not accumulate fatal state";


### PR DESCRIPTION
## Summary

- `use fatal`, `use strict`, `use MONKEY-TYPING`, and `use newline` are lexically scoped pragmas in Raku, but mutsu sets them at runtime via `UseModule` opcodes without saving/restoring at call boundaries
- This caused callee pragma state to bleed into the caller after return (e.g. `use fatal` inside a sub leaked to its caller, making silent `Failure` assignments throw unexpectedly)
- Add `save_pragma_state`/`restore_pragma_state` helpers and wire them into all five compiled call paths: `call_compiled_function_named`, `call_compiled_function_positional_light`, `call_compiled_function_light_spec`, `call_compiled_function_fast`
- Add `t/use-fatal-pragma-scope.t` with 8 tests covering the leak scenarios

## Test plan

- [ ] `t/use-fatal-pragma-scope.t` passes (8/8 tests)
- [ ] `make test` passes with no regressions
- [ ] CI passes (test + roast + gc-stress + jit-stress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)