### PR TITLE
fix(pragma): also save/restore pragma state across closure value calls

### DIFF
--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -112,7 +112,11 @@ impl Interpreter {
         args: Vec<Value>,
         compiled_fns: &CompiledFns,
     ) -> Result<Value, RuntimeError> {
-        self.call_compiled_closure_with_topic(data, cc, args, None, false, compiled_fns)
+        let saved_pragmas = self.save_pragma_state();
+        let result =
+            self.call_compiled_closure_with_topic(data, cc, args, None, false, compiled_fns);
+        self.restore_pragma_state(saved_pragmas);
+        result
     }
 
     /// Like [`Self::call_compiled_closure`] but with an optional explicit topic

--- a/t/use-fatal-pragma-scope.t
+++ b/t/use-fatal-pragma-scope.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 8;
+plan 10;
 
 # use fatal inside a sub body must not leak to the caller after the sub returns.
 # All fail() calls are inside subs (never mainline) because fail in mainline always throws.
@@ -93,3 +93,14 @@ sub caller_repeat() {
 }
 my $r8 = caller_repeat();
 ok !$r8.defined, "Repeated sub_with_fatal calls do not accumulate fatal state";
+
+# Test 9: bare closure { use fatal; ... } called at mainline does not leak to caller
+my $closure_at_mainline = { use fatal; 1 };
+$closure_at_mainline();
+my $f9 = "bar"[5];
+ok !$f9.defined, "closure with use fatal called at mainline does not leak";
+
+# Test 10: do {} block with use fatal at mainline does not leak
+my $x10 = do { use fatal; 1 };
+my $f10 = "bar"[5];
+ok !$f10.defined, "do block with use fatal at mainline does not leak";


### PR DESCRIPTION
## Summary

PR #6123 added pragma save/restore to named-function call paths but missed the closure value case.

- `\$c()` where `\$c` is a Code variable dispatches via `CallOnValue` → `call_compiled_closure`, which lacked save/restore
- A closure like `my \$c = { use fatal; 1 }; \$c()` would leak `fatal_mode = true` into the caller
- Added pragma save/restore around `call_compiled_closure_with_topic` in `call_compiled_closure`
- Extended `t/use-fatal-pragma-scope.t`: plan 8→10, added tests for mainline closure (test 9) and mainline `do {}` block (test 10)

## Test plan
- [ ] `t/use-fatal-pragma-scope.t` passes (10/10 including new tests 9 and 10)
- [ ] No regressions in `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)