### PR TITLE
fix(pragma): closures capture fatal_mode at creation time

### DIFF
--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -290,6 +290,7 @@ impl Interpreter {
                     owned_captures: Vec::new(),
                     authoritative_captures: Vec::new(),
                     upvalues: Vec::new(),
+                    captured_fatal_mode: false,
                 };
                 meta.insert(
                     "build".to_string(),

--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -117,6 +117,7 @@ impl Interpreter {
             owned_captures: Vec::new(),
             authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
+            captured_fatal_mode: false,
         }))
     }
 

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -78,6 +78,7 @@ impl Interpreter {
                 owned_captures: Vec::new(),
                 authoritative_captures: Vec::new(),
                 upvalues: Vec::new(),
+                captured_fatal_mode: false,
             };
             // Store the routine name so call_sub_value can dispatch
             sub_data.env.insert(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2848,6 +2848,7 @@ mod tests {
             owned_captures: Vec::new(),
             authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
+            captured_fatal_mode: false,
         });
 
         let mut interp = Interpreter::new();

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -1221,6 +1221,7 @@ impl Interpreter {
             owned_captures: Vec::new(),
             authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
+            captured_fatal_mode: false,
         }));
         let args = vec![
             tick,

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -566,6 +566,7 @@ impl Interpreter {
                 owned_captures: data.owned_captures.clone(),
                 authoritative_captures: data.authoritative_captures.clone(),
                 upvalues: data.upvalues.clone(),
+                captured_fatal_mode: data.captured_fatal_mode,
             });
             new_env.insert(
                 "&?BLOCK".to_string(),

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -463,6 +463,15 @@ impl Interpreter {
                             // it here — the result array's static readers (`.flat`,
                             // `for`) can't run the VM to force a nested pipe.
                             let val = vm.reify_finite_pipe_value(val)?;
+                            // Under `use fatal`, a Failure produced by the map
+                            // callback must throw immediately rather than be
+                            // collected silently — e.g. `"a".map: *.Int` inside a
+                            // `use fatal` scope should surface X::Str::Numeric.
+                            if vm.fatal_mode
+                                && let Some(err) = vm.failure_to_runtime_error_if_unhandled(&val)
+                            {
+                                return Err(err);
+                            }
                             match val.view() {
                                 ValueView::Slip(elems) => result.extend(elems.iter().cloned()),
                                 _ => result.push(val),

--- a/src/runtime/run_main.rs
+++ b/src/runtime/run_main.rs
@@ -223,6 +223,7 @@ impl Interpreter {
             owned_captures: Vec::new(),
             authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
+            captured_fatal_mode: false,
         }))
     }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -930,6 +930,11 @@ pub struct SubData {
     /// Installed as `Interpreter::upvalues` on closure entry. Empty for closures
     /// with no upvalue-eligible free variables.
     pub(crate) upvalues: Vec<Option<Value>>,
+    /// `fatal_mode` value captured at closure-creation time. When a closure is
+    /// created inside a `use fatal` scope, this is `true`; the pragma propagates
+    /// into the closure so that Failures produced inside it (even via sub-closures
+    /// evaluated lazily after the creating scope has exited) still throw.
+    pub(crate) captured_fatal_mode: bool,
 }
 
 fn gcd(mut a: i64, mut b: i64) -> i64 {

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -233,6 +233,7 @@ fn sample_sub() -> Gc<SubData> {
         owned_captures: vec![],
         authoritative_captures: vec![],
         upvalues: vec![],
+        captured_fatal_mode: false,
     })
 }
 

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -741,6 +741,7 @@ mod tests {
             owned_captures: Vec::new(),
             authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
+            captured_fatal_mode: false,
         }
     }
 

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -352,6 +352,7 @@ impl Value {
             owned_captures: Vec::new(),
             authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
+            captured_fatal_mode: false,
         }
     }
 

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -113,8 +113,30 @@ impl Interpreter {
         compiled_fns: &CompiledFns,
     ) -> Result<Value, RuntimeError> {
         let saved_pragmas = self.save_pragma_state();
+        // Initialise fatal_mode (and other pragmas) from the closure's captured
+        // state so that `use fatal` propagates into lazily-evaluated sub-closures
+        // (e.g. a WhateverCode created inside a `use fatal` block still throws
+        // when evaluated after the block has returned).
+        self.fatal_mode = data.captured_fatal_mode;
         let result =
             self.call_compiled_closure_with_topic(data, cc, args, None, false, compiled_fns);
+        // Under `use fatal` (active at this point, before the scope-restore below),
+        // a returned Failure must throw rather than propagate silently. This makes
+        // a WhateverCode like `*.Int` throw when it produces a Failure — matching
+        // Raku semantics where the pragma is captured at closure-creation time and
+        // applies to every invocation of the closure, even after the creating scope
+        // has exited.
+        let result = if self.fatal_mode {
+            result.and_then(|val| {
+                if let Some(err) = self.failure_to_runtime_error_if_unhandled(&val) {
+                    Err(err)
+                } else {
+                    Ok(val)
+                }
+            })
+        } else {
+            result
+        };
         self.restore_pragma_state(saved_pragmas);
         result
     }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -248,6 +248,7 @@ impl Interpreter {
                 deprecated_message: None,
                 source_line: cc_source_line,
                 source_file: self.current_source_file(),
+                captured_fatal_mode: self.fatal_mode,
             }));
             self.stack.push(val);
             Ok(())
@@ -332,6 +333,7 @@ impl Interpreter {
                 owned_captures,
                 authoritative_captures,
                 upvalues,
+                captured_fatal_mode: self.fatal_mode,
                 compiled_code,
                 compiled_fns,
                 compiled_routine: None,

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -134,6 +134,7 @@ impl Interpreter {
                 deprecated_message: None,
                 source_line: cc_source_line,
                 source_file: self.current_source_file(),
+                captured_fatal_mode: self.fatal_mode,
             }));
             self.stack.push(val);
             Ok(())
@@ -188,6 +189,7 @@ impl Interpreter {
                 deprecated_message: None,
                 source_line: cc_source_line,
                 source_file: self.current_source_file(),
+                captured_fatal_mode: self.fatal_mode,
             }));
             self.stack.push(val);
             Ok(())


### PR DESCRIPTION
## Summary

- Adds `captured_fatal_mode: bool` to `SubData` so closures created inside a `use fatal` scope carry the pragma into their body, regardless of when they are invoked.
- `call_compiled_closure` now seeds `self.fatal_mode` from `data.captured_fatal_mode` (in addition to the save/restore from #6125), so Failures produced inside propagate as exceptions.
- The eager `.map` fast path in `resolution_map_grep.rs` checks `vm.fatal_mode` after each element and turns a Failure into an immediate error (WhateverCode there runs via `run_reuse`, not `call_compiled_closure`).

Fixes `throws-like { use fatal; "a".map: *.Int }, X::Str::Numeric` passing correctly under both native and real `Test.rakumod` (`MUTSU_REAL_TEST=1`).

Supersedes the partial fix in #6125 (which only saved/restored but didn't propagate the pragma into sub-closures).

## Test plan

- [ ] `prove -e 'target/debug/mutsu' t/use-fatal-pragma-scope.t t/whatever-code-fixes.t` — 20/20 pass
- [ ] `env MUTSU_REAL_TEST=1 prove -e 'target/debug/mutsu' t/whatever-code-fixes.t` — 12/12 pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)