### PR TITLE
feat(runtime): run role BUILD/TWEAK submethods from precompiled bytecode (ADR-0019 D8-3)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -117,7 +117,7 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 
 **Current progress: 35/53 slices merged (C6, C7, C8, D1, D2d, and D7 complete; D2a and D2c-1/2/3
 also landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, D4-3, D7-3, and D3-8a landed
-2026-08-08; D3-8b, D3-8c, D3-8d, D7-4, D8-1, and D8-2 landed 2026-08-09). Phase C is fully checked; the open box is
+2026-08-08; D3-8b, D3-8c, D3-8d, D7-4, D8-1, D8-2, and D8-3 landed 2026-08-09). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
@@ -1398,6 +1398,31 @@ walkers wholesale is not possible before then.
   gate (`scripts/battery-testsuite.sh`, 158/164, `OO::Monitors` green).
   `news/2026-08/d8-2-role-deferred-body-consumer-cutover.md`. D8-3 (the
   `run_role_submethod` rider) and D8-4 (dropping `deferred_body_stmts`) remain.
+  **D8-3 landed 2026-08-09**: `run_role_submethod` (the BUILD/TWEAK submethod runner
+  `call_role_build_submethods` uses after `$value does Role` / `$value but Role` composes
+  a role onto a non-`Instance` value — an `Int`/`Str`/etc., not a class construction,
+  which stays on its own already-compiled path) now runs the submethod's precompiled
+  `MethodDef::compiled_code` via `run_compiled_block_raw` instead of re-parsing/
+  re-compiling `def.body` through the AST-walking `eval_block_value` carrier on every
+  composition, falling back to `eval_block_value` only when a method has no compiled
+  chunk (e.g. installed via a meta-programming hook). No behavior change: `$!attr`
+  reads/writes inside the body were already resolved through env keys
+  (`self`/`"!attr_name"`, seeded/read back by `run_role_submethod` itself, not through
+  an instance attribute cell — `self` here is a `Mixin` over a non-`Instance`, so the
+  compiled `GetLocal`/`SetLocal` ops' `self_instance_attrs` cell lookup no-ops both ways
+  and execution falls through to the ordinary local-slot read/write, which `run_nested`
+  bridges to/from `env` at entry/exit exactly as `eval_block_value` did) — verified via
+  a raku-checked repro (scalar-attribute BUILD/TWEAK, BUILD-before-TWEAK ordering,
+  captured-outer-lexical writeback, the non-mutating `but` form) pinned by
+  `t/role-submethod-runtime-does-compiled.t`, the full `t/` suite (28,037 tests), and
+  every whitelisted `S06-signature`/`S12-*`/`S14-*` roast file (release binary).
+  Verification also surfaced two pre-existing, unrelated bugs in this same composition
+  path — confirmed identical before and after this slice's change, so not regressions —
+  filed as `todo/tickets/role-submethod-array-hash-attr-key-mismatch.md` (an `@!attr`/
+  `%!attr` write inside such a submethod silently no-ops: only the scalar-shaped env key
+  is seeded/read back) and `todo/tickets/role-submethod-runtime-does-parameterized-value.md`
+  (a parameterized role's own type/value parameter is invisible inside its BUILD/TWEAK
+  when composed this way). D8-4 (dropping `deferred_body_stmts`) remains, closing D8.
 - [ ] **D9 — Remove `CompiledRoleDeclPlan::legacy_body`.** Preserve role puns, runtime mixins,
   conflicts, BUILD/TWEAK, custom HOWs, and EVAL. Same rule as D6: survey first, token/rule arms
   excluded.

--- a/news/2026-08/d8-3-role-submethod-compiled-body.md
+++ b/news/2026-08/d8-3-role-submethod-compiled-body.md
@@ -1,0 +1,31 @@
+# ADR-0019 D8-3: role BUILD/TWEAK submethods run precompiled bytecode when mixed onto a plain value
+
+When `$value does Role` or `$value but Role` composes a role onto a plain, non-`Instance` value —
+an `Int`, `Str`, or any other scalar, as opposed to `class C does Role` construction, which already
+had its own compiled path — the role's `BUILD`/`TWEAK` submethods ran through
+`run_role_submethod` (`src/runtime/types/roles.rs`). That function re-parsed and re-compiled the
+submethod's raw AST body via the `eval_block_value` carrier on every single composition, instead of
+reusing the bytecode chunk the role's method registration already compiled once
+(`MethodDef::compiled_code`).
+
+`run_role_submethod` now runs that precompiled chunk directly via `run_compiled_block_raw`, falling
+back to `eval_block_value` only for the rare method that has no compiled chunk (e.g. one installed
+through a meta-programming hook). This closes the `run_role_submethod` rider mentioned in ADR-0019's
+D8 slice — the compile-once-per-role-declaration principle D8-1/D8-2 already established for a
+role's other deferred body statements now covers its BUILD/TWEAK submethods too.
+
+Behavior is unchanged: `$!attr` reads/writes inside such a submethod body were already resolved
+through plain env keys (`run_role_submethod` seeds/reads back `env["!attr_name"]` itself, since
+`self` here is a `Mixin` wrapping a non-`Instance` value with no attribute cell to route through) —
+the compiled `GetLocal`/`SetLocal` ops' cell-lookup machinery simply no-ops for this shape of `self`
+in both directions, and execution falls through to the ordinary VM local slot, which `run_nested`
+bridges to/from `env` at frame entry/exit exactly as the old AST-walking path did. Verified with a
+raku-checked repro (scalar-attribute `BUILD`/`TWEAK`, ordering, captured-outer-lexical writeback, the
+non-mutating `but` form), pinned by `t/role-submethod-runtime-does-compiled.t`, the full `t/` suite,
+and every whitelisted `S06-signature`/`S12-*`/`S14-*` roast file.
+
+Verification also turned up two pre-existing bugs in this same composition path, confirmed identical
+before and after this change (so not regressions, and out of scope for this slice): an `@!attr`/
+`%!attr` write inside such a submethod silently drops (`todo/tickets/role-submethod-array-hash-attr-key-mismatch.md`),
+and a parameterized role's own type/value parameter is invisible inside its `BUILD`/`TWEAK` when
+composed this way (`todo/tickets/role-submethod-runtime-does-parameterized-value.md`).

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -547,9 +547,25 @@ impl Interpreter {
         // Set self for the body
         let saved_self = self.env.get("self").cloned();
         self.env.insert("self".to_string(), target.clone());
-        // Execute body directly in current scope so closure
-        // variable mutations propagate to the outer scope.
-        let _result = self.eval_block_value(&def.body)?;
+        // Execute the body directly in current scope so closure variable
+        // mutations propagate to the outer scope. `$!attr` reads/writes
+        // inside the compiled body resolve to `GetLocal`/`SetLocal` ops on a
+        // slot named `"!attr"` (ADR-0019 D8-3): `self_instance_attrs` finds
+        // no cell for a Mixin over a non-Instance `self` (the scenario here
+        // — `does`/`but` on a plain value) and its cell-mirror is a silent
+        // no-op both ways, so the locals<->env bridge that `run_nested`
+        // performs at entry/exit is what actually threads the seeded
+        // `env["!attr"]` values through. Run D8-1's precompiled chunk when
+        // available instead of re-parsing/re-compiling `def.body` on every
+        // composition; a method not yet compiled (e.g. installed via a
+        // meta-programming hook) falls back to the raw-AST carrier.
+        if let Some(cc) = &def.compiled_code {
+            let empty_fns = crate::opcode::CompiledFns::default();
+            let fns_ref = def.compiled_fns.as_deref().unwrap_or(&empty_fns);
+            self.run_compiled_block_raw(cc, fns_ref)?;
+        } else {
+            self.eval_block_value(&def.body)?;
+        }
         // Read back modified attribute values from env into the mixin map
         let updated_target = if let ValueView::Mixin(inner, existing_mixins) = target.view() {
             let mut mixins = (**existing_mixins).clone();

--- a/t/role-submethod-runtime-does-compiled.t
+++ b/t/role-submethod-runtime-does-compiled.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 6;
+
+# `$value does Role` / `$value but Role`, applied to a plain (non-Instance)
+# value like an Int or Str, runs the role's BUILD/TWEAK submethods through
+# `run_role_submethod` (src/runtime/types/roles.rs), which now executes the
+# submethod's precompiled bytecode chunk instead of re-walking the raw AST on
+# every composition (ADR-0019 D8-3). Every expectation below was checked
+# against Rakudo v2026.06.
+
+role BuildsScalar { has $.x; submethod BUILD { $!x = 10 } }
+my $v = 5;
+$v does BuildsScalar;
+is $v.x, 10, 'BUILD assigns a scalar attribute on a does-mixed plain value';
+
+role TweaksScalar { has $.y = 1; submethod TWEAK { $!y = $!y + 100 } }
+my $s = "hi";
+my $s2 = $s but TweaksScalar;
+is $s2.y, 101, 'TWEAK sees the initialized value on a but-mixed plain value';
+is $s, 'hi', 'the non-mutating `but` form leaves the original value untouched';
+
+my @order;
+role RecordsOrder {
+    submethod BUILD { @order.push('B') }
+    submethod TWEAK { @order.push('T') }
+}
+my $u = 1;
+$u does RecordsOrder;
+is-deeply @order.List, <B T>, 'BUILD runs before TWEAK, each exactly once';
+
+my $outer = 0;
+role WritesOuter { submethod BUILD { $outer = 42 } }
+my $z = 1;
+$z does WritesOuter;
+is $outer, 42, 'a captured outer lexical write inside BUILD propagates out';
+
+role BeatsDefault { has $.x = 5; submethod BUILD { $!x = 9 } }
+my $b = 1;
+$b does BeatsDefault;
+is $b.x, 9, 'BUILD wins over an attribute initializer on a does-mixed value';

--- a/todo/tickets/role-submethod-array-hash-attr-key-mismatch.md
+++ b/todo/tickets/role-submethod-array-hash-attr-key-mismatch.md
@@ -1,0 +1,62 @@
+# Role BUILD/TWEAK submethod on a `does`/`but`-mixed plain value drops array/hash attribute writes
+
+`run_role_submethod` (`src/runtime/types/roles.rs`, the helper `call_role_build_submethods` uses
+after `$value does Role` / `$value but Role` composes a role onto a non-`Instance` value such as an
+`Int` or `Str`) seeds the submethod's attribute env vars using only the scalar twigil form:
+
+```rust
+let key = format!("__mutsu_attr__{}", attr_name);
+if let Some(val) = mixins.get(&key) {
+    self.env.insert(format!("!{}", attr_name), val.clone());
+}
+```
+
+and reads them back the same way (`format!("!{}", attr_name)`). For a scalar attribute (`has $.x`)
+this key (`"!x"`) matches what the compiled/interpreted body resolves `$!x` to. But for an array or
+hash attribute (`has @.a` / `has %.h`), the body's `@!a` / `%!h` reads and writes resolve through the
+sigil-prefixed env key (`"@!a"` / `"%!h"`), which is never seeded — so any `@!a.push(...)` or
+`%!h<k> = v` inside a role's `BUILD`/`TWEAK` submethod silently no-ops when the role is composed onto
+a plain, non-`Instance` value via `does`/`but`.
+
+## Repro
+
+```raku
+role RH {
+    has %.h;
+    submethod BUILD { %!h<a> = 1 }
+}
+my $v = 0;
+$v does RH;
+say $v.h.raku;   # raku: "{:a(1)}", mutsu: "{}".Seq (empty)
+
+role RA {
+    has @.a;
+    submethod BUILD { @!a.push(1); @!a.push(2) }
+}
+my $w = "x";
+$w does RA;
+say $w.a.raku;   # raku: "[1, 2]", mutsu: "[]"
+```
+
+Verified against Rakudo v2026.06 (raku binary on this machine): both attributes populate correctly.
+Confirmed present on `main` at commit `18b6f7745` (pre-dates ADR-0019 D8-3's compiled-body cutover of
+`run_role_submethod`; not a regression from that change — reproduces identically before and after).
+
+## Fix sketch
+
+`run_role_submethod`'s seed/readback loop needs to seed (and read back) the array/hash-shaped keys
+too — likely `format!("@!{}", attr_name)` / `format!("%!{}", attr_name)` alongside the scalar
+`"!{attr_name}"` form, picked by the attribute's declared sigil (`RoleDef`'s attribute list already
+carries the sigil — see how `apply_role_mixin`'s default-value construction switches on `attr.sigil`
+a few dozen lines above `run_role_submethod` in the same file). The mixin map itself already stores
+the value under the plain `__mutsu_attr__{name}` key regardless of sigil, so only the env seed/readback
+key needs to vary by sigil, mirroring how ordinary instance-attribute env keys are chosen elsewhere
+(`ATTR_ALIAS_META_PREFIX` / `attr_twigil_local` helpers in `src/vm/vm_method_dispatch.rs`).
+
+## Why not fixed inline with D8-3
+
+D8-3 (ADR-0019, "run_role_submethod rider") is scoped to swapping the body's execution mechanism
+(tree-walk `eval_block_value` -> `run_compiled_block_raw` over the precompiled chunk) without changing
+behavior. This bug is a pre-existing attribute-key mismatch orthogonal to that swap — confirmed
+identical on `main` before the swap — so fixing it belongs in its own PR with its own repro-driven
+`t/` test, not bundled into the bytecode-cutover slice.

--- a/todo/tickets/role-submethod-runtime-does-parameterized-value.md
+++ b/todo/tickets/role-submethod-runtime-does-parameterized-value.md
@@ -1,0 +1,43 @@
+# Parameterized role's BUILD submethod can't see its own type/value parameter when composed via runtime `does`/`but`
+
+`run_role_submethod` (`src/runtime/types/roles.rs`, invoked by `call_role_build_submethods` after
+`$value does Role[Arg]` / `$value but Role[Arg]` composes a role onto a non-`Instance` value) merges
+only `role.captured_env` into the submethod's env before running the body. A parameterized role's type
+parameter (`role RP[$v] { ... }`) is not part of `captured_env` — it is bound elsewhere via
+`class_role_param_bindings` (looked up by owner-class name in the ordinary compiled-method dispatch,
+`src/vm/vm_method_dispatch.rs` around the "Role param bindings" section) — so a `BUILD`/`TWEAK`
+submethod reading the role's own parameter through this composition path sees `(Any)`/the parameter's
+default instead of the argument actually supplied.
+
+## Repro
+
+```raku
+role RP[$v] { has $.p; submethod BUILD { $!p = $v } }
+my $q = 1;
+$q does RP[42];
+say $q.p;   # raku: 42, mutsu: (Any)
+```
+
+Verified against Rakudo v2026.06. Confirmed present on `main` at commit `18b6f7745`, identical before
+and after ADR-0019 D8-3 (the `run_role_submethod` compiled-body cutover) — not a regression from that
+change; a pre-existing gap in how this specific composition path threads role parameters into the
+submethod's scope.
+
+## Fix sketch
+
+`run_role_submethod` needs to resolve and seed the role's type/value parameter bindings the same way
+`call_compiled_method`'s "Role param bindings" step does (`self.class_role_param_bindings(owner_class)`
+/ `...(receiver_class_name)`), or thread the parameterized role's resolved bindings through
+`RoleDef`/the mixin map at composition time (`compose_role_on_value`, a few dozen lines above this
+function) so `run_role_submethod` can seed them into env alongside the captured closure environment.
+Needs a case survey first: does `class_role_param_bindings` even have an entry keyed by anything
+reachable from a plain (non-class) mixin target, or does that lookup only work for class-based
+composition? If not, this may need a role-id-keyed binding table analogous to the mixin map's own
+`__mutsu_role_id__{role_name}` marker (see `role_def_for_mixin_role` in the same file) rather than
+reusing `class_role_param_bindings` as-is.
+
+## Why not fixed inline with D8-3
+
+Out of scope for the D8-3 slice (swap `run_role_submethod`'s body execution from tree-walk to the
+precompiled bytecode chunk, no behavior change) — this is a distinct missing-context bug that predates
+and is orthogonal to that swap, confirmed identical on `main` before it.


### PR DESCRIPTION
## Summary

- `run_role_submethod` (the BUILD/TWEAK runner used after `$value does Role` / `$value but Role` composes a role onto a plain, non-`Instance` value) now runs the submethod's precompiled `MethodDef::compiled_code` via `run_compiled_block_raw`, instead of re-parsing/re-compiling `def.body` through the AST-walking `eval_block_value` carrier on every composition.
- Falls back to `eval_block_value` when a method has no compiled chunk (e.g. installed via a meta-programming hook).
- Closes the "`run_role_submethod` rider" that ADR-0019's D8 slice called out as remaining after D8-1/D8-2 (see `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`).
- No behavior change: `$!attr` reads/writes inside such a submethod already resolved through plain env keys (`self` here is a `Mixin` over a non-`Instance` value with no attribute cell, so the compiled ops' cell-lookup machinery no-ops both ways and falls through to the ordinary VM local slot, which `run_nested` bridges to/from `env` exactly as the old path did).
- Verification surfaced two pre-existing, unrelated bugs in this same composition path (confirmed identical before/after this change — not regressions): `todo/tickets/role-submethod-array-hash-attr-key-mismatch.md` and `todo/tickets/role-submethod-runtime-does-parameterized-value.md`.

## Test plan

- [x] New `t/role-submethod-runtime-does-compiled.t`, checked against `raku` directly.
- [x] `make test` — full `t/` suite green (28,037 tests).
- [x] All whitelisted `S06-signature`/`S12-*`/`S14-*` roast files green (release binary, `MUTSU_FUDGE=1`).
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)