### PR TITLE
fix(parser): key parse memos by (generation, ptr, len) to close stale-pointer soundness hole

### DIFF
--- a/news/2026-08/parse-memo-generation-key.md
+++ b/news/2026-08/parse-memo-generation-key.md
@@ -1,0 +1,41 @@
+# ParseMemo keys now include a parse generation, closing a stale-pointer soundness hole
+
+The parser's three memo tables (`EXPR_MEMO`, `STMT_MEMO`, `PRIMARY_MEMO`) and the
+sibling `STMT_ANON_STATES_TLS` table keyed cached parse results by the raw
+`(ptr, len)` of the input `&str`. That key only identifies a slice while its
+owning buffer is alive — but nested parses do not respect that lifetime:
+`scan_module_source` reads a module file into a temporary `String`, parses it
+with `parse_program_partial` (populating the memo tables with entries keyed by
+pointers into that buffer), and the `String` is then dropped mid-way through the
+*enclosing* parse. When the allocator handed the freed address to a later
+same-sized allocation, a stale entry from the dead buffer could be returned for
+unrelated input — a silent false success or false failure with no error at all.
+Because the collision depends on the allocator's address layout for a given
+binary, the symptom was a per-build lottery: deterministic for one binary,
+absent for the next (see
+`todo/deep/pointy-block-custom-param-trait-parse-time-check-fails-for-large-modules.md`,
+where `http-router.rakutest` flipped between 64/83 and 0/83 across rebuilds
+with no source change).
+
+The fix mixes a thread-local, monotonically increasing **parse generation**
+into every memo key: `(generation, ptr, len)`. `parse_program` and
+`parse_program_partial` each enter a fresh generation on entry and restore the
+enclosing parse's generation on exit (RAII guard, so early error returns are
+covered). Within one generation every live buffer's `(ptr, len)` is unique;
+entries from other generations never match, so a nested parse's entries can
+never leak into the outer parse via address reuse. The generation is constant
+throughout a single parse, so memo hit rates are unchanged — the cost is one
+thread-local read per lookup and 8 bytes per key.
+
+Pinned by a unit test (`parser::memo::tests::generation_isolates_entries_at_the_same_address`)
+that stores entries for the same slice under two generations and verifies
+neither side can see the other's entry.
+
+Whether this was the root cause of the `http-router.rakutest` flip is not yet
+proven (the session's builds were all on the "lucky" side, so no failing binary
+was available to test against). Four release rebuilds with deliberately varied
+binary layout (dead-code padding in `main`) all held stable at the historical
+maximum of 64/83 after the fix. The deep ticket stays open with an updated
+decision protocol: if the flip ever recurs on a fixed binary, the memo theory
+is refuted and the "full CLI path divergence" investigation becomes the main
+line.

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -15,7 +15,7 @@ mod tests_meta;
 #[cfg(test)]
 mod tests_postfix;
 
-use super::memo::{MemoEntry, MemoStats, ParseMemo};
+use super::memo::{MemoEntry, MemoKey, MemoStats, ParseMemo};
 use super::parse_result::PResult;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -45,7 +45,7 @@ use whatever_wrap::{try_wrap_whatevercode_call_chain, wrap_composition_operands}
 pub(crate) use whatever_replace::{replace_whatever_numbered, replace_whatever_single};
 
 thread_local! {
-    static EXPR_MEMO_TLS: RefCell<HashMap<(usize, usize), MemoEntry<Expr>>> = RefCell::new(HashMap::new());
+    static EXPR_MEMO_TLS: RefCell<HashMap<MemoKey, MemoEntry<Expr>>> = RefCell::new(HashMap::new());
     static EXPR_MEMO_STATS_TLS: RefCell<MemoStats> = RefCell::new(MemoStats::default());
 }
 

--- a/src/parser/memo.rs
+++ b/src/parser/memo.rs
@@ -1,10 +1,11 @@
 //! Generic memoization for parser combinators.
 //!
-//! Each memo table stores parse results keyed by `(ptr, len)` of the input `&str`.
-//! Provides `get()`, `store()`, `reset()`, and `stats()` via thread-local storage.
+//! Each memo table stores parse results keyed by `(generation, ptr, len)` of the
+//! input `&str`. Provides `get()`, `store()`, `reset()`, and `stats()` via
+//! thread-local storage.
 
 use super::parse_result::{PError, PResult};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -20,11 +21,66 @@ pub(super) struct MemoStats {
     pub stores: usize,
 }
 
+/// Memo keys are `(generation, ptr, len)`. The raw `(ptr, len)` of a `&str`
+/// only identifies a slice while its owning buffer is alive: nested parses
+/// (module export scans, EVAL) parse short-lived `String` buffers that are
+/// dropped mid-way through the enclosing parse, and the allocator readily
+/// hands the freed address to an unrelated later allocation — so a bare
+/// pointer key can return a stale entry from a dead buffer for different
+/// input, silently corrupting the parse. Mixing in a per-parse generation
+/// makes that impossible: within one generation every live buffer's
+/// `(ptr, len)` is unique, and entries from other generations never match.
+pub(super) type MemoKey = (u64, usize, usize);
+
+thread_local! {
+    static CURRENT_GENERATION: Cell<u64> = const { Cell::new(0) };
+    static NEXT_GENERATION: Cell<u64> = const { Cell::new(1) };
+}
+
+/// RAII guard returned by `begin_parse_generation()`; restores the enclosing
+/// parse's generation on drop (the outer buffer is still alive, so its keys
+/// are valid again).
+pub(super) struct ParseGenerationGuard {
+    prev: u64,
+}
+
+impl Drop for ParseGenerationGuard {
+    fn drop(&mut self) {
+        CURRENT_GENERATION.with(|g| g.set(self.prev));
+    }
+}
+
+/// Enter a fresh parse generation for the duration of one `parse_program` /
+/// `parse_program_partial` call. Never reuses a generation number: a nested
+/// parse must not share the generation of any parse whose buffer has been
+/// freed.
+pub(super) fn begin_parse_generation() -> ParseGenerationGuard {
+    let prev = CURRENT_GENERATION.with(|g| g.get());
+    let fresh = NEXT_GENERATION.with(|n| {
+        let v = n.get();
+        n.set(v + 1);
+        v
+    });
+    CURRENT_GENERATION.with(|g| g.set(fresh));
+    ParseGenerationGuard { prev }
+}
+
+/// Build the memo key for `input` under the current parse generation. Shared
+/// with sibling pointer-keyed tables (`STMT_ANON_STATES_TLS`) so they stay
+/// sound the same way the memo tables do.
+pub(in crate::parser) fn memo_key(input: &str) -> MemoKey {
+    (
+        CURRENT_GENERATION.with(|g| g.get()),
+        input.as_ptr() as usize,
+        input.len(),
+    )
+}
+
 /// A thread-local memoization table for parser results.
 ///
 /// Create a static instance via `ParseMemo::new()` referencing thread-local storage,
 /// then call `get()`, `store()`, `reset()`, and `stats()`.
-type MemoMap<T> = RefCell<HashMap<(usize, usize), MemoEntry<T>>>;
+type MemoMap<T> = RefCell<HashMap<MemoKey, MemoEntry<T>>>;
 
 pub(super) struct ParseMemo<T: Clone + 'static> {
     memo: &'static std::thread::LocalKey<MemoMap<T>>,
@@ -39,8 +95,8 @@ impl<T: Clone + 'static> ParseMemo<T> {
         ParseMemo { memo, stats }
     }
 
-    fn key(input: &str) -> (usize, usize) {
-        (input.as_ptr() as usize, input.len())
+    fn key(input: &str) -> MemoKey {
+        memo_key(input)
     }
 
     /// Look up a cached parse result. Returns `None` on cache miss.
@@ -110,5 +166,46 @@ impl<T: Clone + 'static> ParseMemo<T> {
             let s = *s.borrow();
             (s.hits, s.misses, s.stores)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    thread_local! {
+        static TEST_MEMO_TLS: MemoMap<i32> = RefCell::new(HashMap::new());
+        static TEST_MEMO_STATS_TLS: RefCell<MemoStats> = RefCell::new(MemoStats::default());
+    }
+    static TEST_MEMO: ParseMemo<i32> = ParseMemo::new(&TEST_MEMO_TLS, &TEST_MEMO_STATS_TLS);
+
+    #[test]
+    fn generation_isolates_entries_at_the_same_address() {
+        if !crate::parser::parse_memo_enabled() {
+            return;
+        }
+        TEST_MEMO.reset();
+        let buffer = String::from("abcdef");
+        let input: &str = &buffer;
+        let outer = begin_parse_generation();
+
+        let result: PResult<'_, i32> = Ok((&input[3..], 1));
+        TEST_MEMO.store(input, &result);
+        assert!(matches!(TEST_MEMO.get(input), Some(Ok((_, 1)))));
+
+        {
+            // A nested parse of a buffer that happens to sit at the same
+            // (ptr, len) — modeled with the very same slice — must neither see
+            // the outer entry nor leak its own entry back out.
+            let _nested = begin_parse_generation();
+            assert!(TEST_MEMO.get(input).is_none());
+            let nested_result: PResult<'_, i32> = Ok((&input[1..], 2));
+            TEST_MEMO.store(input, &nested_result);
+            assert!(matches!(TEST_MEMO.get(input), Some(Ok((_, 2)))));
+        }
+
+        assert!(matches!(TEST_MEMO.get(input), Some(Ok((_, 1)))));
+        drop(outer);
+        TEST_MEMO.reset();
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -323,6 +323,10 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
         primary::reset_primary_memo();
         stmt::reset_statement_memo();
     }
+    // Give this parse its own memo generation so entries keyed to `input` can
+    // never be confused with entries a nested parse stored for a since-dropped
+    // buffer at the same address (see `memo::MemoKey`).
+    let _memo_generation = memo::begin_parse_generation();
     stmt::reset_user_subs();
     crate::trace::trace_log!("parse", "parser start memo={}", memo_enabled);
     primary::set_original_source(input);
@@ -570,6 +574,11 @@ pub(crate) fn parse_program_partial(input: &str) -> (Vec<Stmt>, Option<String>) 
         primary::reset_primary_memo();
         stmt::reset_statement_memo();
     }
+    // Fresh memo generation for this nested parse of a (usually short-lived)
+    // buffer; the guard restores the enclosing parse's generation on return so
+    // the entries this parse stored can never leak into the outer parse via
+    // allocator address reuse (see `memo::MemoKey`).
+    let _memo_generation = memo::begin_parse_generation();
     // This is a best-effort nested sub-parse (module export scan / EVAL / pseudo
     // package). It must not leak the scanned source's `use vX` pragma into the
     // caller: `reset_user_subs` resets the language version to the 6.d default and

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod regex;
 pub(in crate::parser) mod string;
 pub(crate) mod var;
 
-use super::memo::{MemoEntry, MemoStats, ParseMemo};
+use super::memo::{MemoEntry, MemoKey, MemoStats, ParseMemo};
 use super::parse_result::{PError, PResult, update_best_error};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -21,7 +21,7 @@ use crate::ast::Expr;
 use crate::value::Value;
 
 thread_local! {
-    static PRIMARY_MEMO_TLS: RefCell<HashMap<(usize, usize), MemoEntry<Expr>>> = RefCell::new(HashMap::new());
+    static PRIMARY_MEMO_TLS: RefCell<HashMap<MemoKey, MemoEntry<Expr>>> = RefCell::new(HashMap::new());
     static PRIMARY_MEMO_STATS_TLS: RefCell<MemoStats> = RefCell::new(MemoStats::default());
     /// Original source pointer and length, set at parse_program start for $?LINE computation.
     static ORIGINAL_SOURCE: RefCell<(usize, usize)> = const { RefCell::new((0, 0)) };

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod sub;
 pub(crate) mod sub_param;
 pub(crate) mod word_logical_split;
 
-use super::memo::{MemoEntry, MemoStats, ParseMemo};
+use super::memo::{MemoEntry, MemoKey, MemoStats, ParseMemo};
 use super::parse_result::{MISSING_BLOCK, PError, PResult, parse_char, update_best_error};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -62,7 +62,7 @@ pub(super) use pub_shims::{
 };
 
 thread_local! {
-    static STMT_MEMO_TLS: RefCell<HashMap<(usize, usize), MemoEntry<Stmt>>> = RefCell::new(HashMap::new());
+    static STMT_MEMO_TLS: RefCell<HashMap<MemoKey, MemoEntry<Stmt>>> = RefCell::new(HashMap::new());
     static STMT_MEMO_STATS_TLS: RefCell<MemoStats> = RefCell::new(MemoStats::default());
     /// The anonymous-state names (`__ANON_STATE_<id>__`) each memoized statement
     /// minted into its ENCLOSING block's scope, keyed exactly like `STMT_MEMO`.
@@ -73,14 +73,14 @@ thread_local! {
     /// hit). The names were recorded in that first scope, so without replaying
     /// them here the surviving block would emit no implicit `state` declaration
     /// for its bare `$` — see `simple::take_anon_state_decls`.
-    static STMT_ANON_STATES_TLS: RefCell<HashMap<(usize, usize), Vec<String>>> =
+    static STMT_ANON_STATES_TLS: RefCell<HashMap<MemoKey, Vec<String>>> =
         RefCell::new(HashMap::new());
 }
 
 static STMT_MEMO: ParseMemo<Stmt> = ParseMemo::new(&STMT_MEMO_TLS, &STMT_MEMO_STATS_TLS);
 
-fn stmt_memo_key(input: &str) -> (usize, usize) {
-    (input.as_ptr() as usize, input.len())
+fn stmt_memo_key(input: &str) -> MemoKey {
+    super::memo::memo_key(input)
 }
 
 pub(super) fn reset_statement_memo() {

--- a/todo/deep/pointy-block-custom-param-trait-parse-time-check-fails-for-large-modules.md
+++ b/todo/deep/pointy-block-custom-param-trait-parse-time-check-fails-for-large-modules.md
@@ -129,6 +129,30 @@ the suite should not be surprised by a different count than a prior session reco
 should not treat a lower count as a regression from their own changes without first
 confirming the *same* binary/build reproduces it more than once.
 
+## Status update (2026-08-09): the ParseMemo soundness hole is fixed; symptom attribution still open
+
+The pointer-identity keying described above is fixed: memo keys are now
+`(generation, ptr, len)` with a fresh thread-local generation per
+`parse_program` / `parse_program_partial` call (restored on exit), so a nested
+scan's entries can never be returned to the enclosing parse via allocator
+address reuse (`news/2026-08/parse-memo-generation-key.md`). The
+`STMT_ANON_STATES_TLS` table, which shared the same raw-pointer keying, was
+fixed the same way.
+
+Whether that collision was *this ticket's* root cause remains unproven: every
+build available this session (debug and release) was on the "lucky" side, so
+there was no failing binary to test `MUTSU_PARSE_MEMO=0` against. After the
+fix, four release rebuilds with deliberately varied binary layout (dead-code
+padding in `main`) all held at the historical maximum 64/83 for
+`http-router.rakutest`, and the minimal repro passes.
+
+**Decision protocol going forward:** if the 64/83 ⇔ 0/83 flip (or the "unknown
+trait 'is' -> 'query'" error) ever recurs on a post-fix binary, the memo theory
+is **refuted** — re-run with `MUTSU_PARSE_MEMO=0` to double-check, then pursue
+the "full CLI parse path divergence" investigation below (the side where ~15
+synthetic repro attempts failed). Until then, treat the memo collision as the
+most plausible explanation and this ticket as watch-only.
+
 ## Suggested next steps
 
 1. Instrument `main.rs`'s actual parse call (not a substitute unit test) with a


### PR DESCRIPTION
## Summary

The parser's three memo tables (`EXPR_MEMO`, `STMT_MEMO`, `PRIMARY_MEMO`) and the sibling `STMT_ANON_STATES_TLS` table keyed cached parse results by the raw `(ptr, len)` of the input `&str`. That key only identifies a slice while its owning buffer is alive — but nested parses don't respect that lifetime: `scan_module_source` parses a temporary module `String` via `parse_program_partial` (populating the memos with entries keyed by pointers into that buffer), and the `String` is dropped mid-way through the *enclosing* parse. When the allocator reused the freed address for a later same-sized allocation, a stale entry from the dead buffer was silently returned for unrelated input.

Because the collision depends on the allocator's address layout for a given binary, the symptom was a per-build lottery: `http-router.rakutest` flipped between 64/83 and 0/83 across rebuilds with no source change (see `todo/deep/pointy-block-custom-param-trait-parse-time-check-fails-for-large-modules.md`).

## Fix

Mix a thread-local, monotonically increasing **parse generation** into every memo key: `(generation, ptr, len)`. `parse_program` and `parse_program_partial` enter a fresh generation on entry and restore the enclosing parse's generation via an RAII guard (early error returns covered). Within one generation every live buffer's `(ptr, len)` is unique; entries from other generations never match — so a nested parse's entries can never leak into the outer parse via address reuse.

Perf: the generation is constant within a single parse, so memo hit rates are unchanged. Cost is one thread-local read per lookup and 8 bytes per key (will watch bench CI).

## Verification

- New unit test `parser::memo::tests::generation_isolates_entries_at_the_same_address` pins the isolation directly.
- `make test`: 28051 tests, all green.
- Cro `http-router.rakutest` held stable at the historical maximum 64/83 across **four release rebuilds with deliberately varied binary layout** (dead-code padding in `main`); the minimal pointy-trait repro passes.
- Whether this collision was the root cause of the http-router flip is not yet proven (all builds this session were on the "lucky" side, so no failing binary existed to test against). The deep ticket stays open with a decision protocol: if the flip recurs post-fix, the memo theory is refuted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)