### PR TITLE
refactor(runtime): default class-body statements to run precompiled chunks (ADR-0019 D6-3e)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1269,6 +1269,24 @@ walkers wholesale is not possible before then.
   excluded — byte-identical PASS/FAIL output to the unforced baseline). D6-3e
   (token/rule carve-out check) is expected to fold into a later default-flip
   slice rather than needing its own PR, per the design doc's own note.
+  **D6-3e landed 2026-08-09**: flipped the default — `run_class_body_chunk_or_raw`
+  now runs a statement's precompiled `body_plan` chunk unconditionally
+  whenever one is present, instead of only under the `MUTSU_DROP_LEGACY_CLASS_BODY=1`
+  instrument. The token/rule carve-out needed no extra code: those ops keep
+  `chunk: None` permanently (D6-3b/c), so they fall through to the unchanged
+  `run_block_raw(stmts)` branch exactly as before. `class_body_plan_forced()`
+  and its `OnceLock` are deleted along with the instrument env var. Since the
+  instrument had already been forced through the same verification sweep in
+  D6-3d, this slice is a pure default flip with no new behavior — re-verified
+  via the full `t/` suite (28,062 tests), the `S12-class`/`S12-construction`/
+  `S14-roles`/`S05-grammar` roast files (957 tests, same pre-existing
+  `open_closed.t` failure), and `scripts/battery-testsuite.sh` (158/164,
+  byte-identical to the D6-3d baseline). `run_class_body`'s own dispatch loop
+  still drives off the raw flattened `body: &[Stmt]` (needed to classify each
+  statement's kind and, for `Attr`/`Method`/`Does`, to feed their handlers'
+  raw-statement fallback paths) — dropping `CompiledClassDeclPlan::legacy_body`
+  itself (D6-4) needs those three handlers threaded onto `ClassBodyOp`'s
+  already-typed fields instead, which did not fit this slice.
 - [x] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
   **Design pass done 2026-08-08 (no code landed):**

--- a/news/2026-08/d6-3e-class-body-chunk-default-flip.md
+++ b/news/2026-08/d6-3e-class-body-chunk-default-flip.md
@@ -1,0 +1,27 @@
+# ADR-0019 D6-3e: class-body statement chunks run by default
+
+`run_class_body`'s small statement arms (`class_body_other_stmt`,
+`class_body_code_alias`, `run_class_body_leave_phasers`) now run each
+statement's precompiled `body_plan` chunk (ADR-0019 D6-3a-d) by default,
+instead of on-the-fly compiling the raw statement via `run_block_raw` on
+every class registration. Previously this path only ran under the
+`MUTSU_DROP_LEGACY_CLASS_BODY=1` instrument, added in D6-3d to validate the
+chunk mechanism before flipping it on. `token`/`rule` statements keep their
+existing `run_block_raw` execution unchanged — they never get a compiled
+chunk (the ADR-0009 carve-out), so `run_class_body_chunk_or_raw` falls
+through to the same branch as before for them.
+
+Since the instrument had already been forced through a full verification
+sweep in D6-3d, this is a pure default flip with no behavior change,
+re-confirmed by the same sweep: the full `t/` suite (28,062 tests), the
+`S12-class`/`S12-construction`/`S14-roles`/`S05-grammar` roast files (957
+tests, only the pre-existing non-whitelisted `S12-class/open_closed.t`
+failure), and `scripts/battery-testsuite.sh` (158/164 files pass, 2
+excluded, byte-identical to the D6-3d baseline).
+
+`CompiledClassDeclPlan::legacy_body` itself is not dropped yet (ADR-0019
+D6-4): `run_class_body`'s dispatch loop still needs the raw flattened
+`body: &[Stmt]` to classify each statement's kind, and the `Attr`/`Method`/
+`Does` arms still take a raw `&Stmt` for their own logic and fallback
+paths. Removing the field requires threading those three handlers onto
+`ClassBodyOp`'s already-typed fields instead.

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -252,11 +252,10 @@ pub(crate) struct ClassDeclModifiers<'a> {
     /// Precomputed, position-aligned, typed mirror of the body statement
     /// walk (ADR-0019 D6-3a-c), threaded down to `run_class_body` so its
     /// small statement arms can run a precompiled chunk instead of
-    /// on-the-fly compiling the raw statement (gated behind
-    /// `MUTSU_DROP_LEGACY_CLASS_BODY`, D6-3d). Empty for registration paths
-    /// with no compiled plan available (role-pun/mixin synthesis, `augment
-    /// class`) — those keep the on-the-fly `run_block_raw` path
-    /// unconditionally, same as an empty body.
+    /// on-the-fly compiling the raw statement (D6-3d/e). Empty for
+    /// registration paths with no compiled plan available (role-pun/mixin
+    /// synthesis, `augment class`) — those keep the on-the-fly
+    /// `run_block_raw` path unconditionally, same as an empty body.
     pub(crate) body_plan: &'a [crate::opcode::ClassBodyOp],
 }
 

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -84,19 +84,6 @@ fn class_body_op_chunk(
     }
 }
 
-/// `MUTSU_DROP_LEGACY_CLASS_BODY=1` forces the class-body walk's small
-/// statement arms (`class_body_other_stmt`, `class_body_code_alias`,
-/// `run_class_body_leave_phasers`) to run their precompiled `body_plan`
-/// chunk (ADR-0019 D6-3d) instead of on-the-fly compiling the raw statement
-/// via `run_block_raw` on every registration — an instrument for validation
-/// sweeps (the `MUTSU_DROP_LEGACY_BODY`/C6e-3a precedent), not yet the
-/// default. Cached in a `OnceLock` like `compiler/const_fold.rs`'s
-/// `folding_allowed`.
-pub(super) fn class_body_plan_forced() -> bool {
-    static FORCED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FORCED.get_or_init(|| std::env::var("MUTSU_DROP_LEGACY_CLASS_BODY").as_deref() == Ok("1"))
-}
-
 impl Interpreter {
     /// Recursively surface `has`-attribute declarations nested inside a sub/block
     /// within a class body (`class C { sub f { has $.x } }`). Descends into
@@ -299,18 +286,18 @@ impl Interpreter {
     }
 
     /// Run a class-body statement's side effects, using its precompiled
-    /// `body_plan` chunk (ADR-0019 D6-3d) instead of on-the-fly compiling
-    /// `stmts` via `run_block_raw` when `MUTSU_DROP_LEGACY_CLASS_BODY=1`
-    /// forces the instrument and a chunk is available. Default (unforced)
-    /// behavior is unchanged: always `run_block_raw(stmts)`.
+    /// `body_plan` chunk (ADR-0019 D6-3d) when available instead of
+    /// on-the-fly compiling `stmts` via `run_block_raw` on every
+    /// registration. Falls back to `run_block_raw(stmts)` for a statement
+    /// kind D6-3b/c never compiles a chunk for (`token`/`rule`, the
+    /// ADR-0009 carve-out) or a registration path with no compiled plan at
+    /// all (role-pun/mixin synthesis, `augment class`).
     pub(super) fn run_class_body_chunk_or_raw(
         &mut self,
         chunk: Option<&crate::opcode::CompiledDeclExpr>,
         stmts: &[Stmt],
     ) -> Result<(), RuntimeError> {
-        if let Some(chunk) = chunk
-            && class_body_plan_forced()
-        {
+        if let Some(chunk) = chunk {
             return self.run_compiled_block_raw(&chunk.code, &chunk.fns);
         }
         self.run_block_raw(stmts)


### PR DESCRIPTION
## Summary
- `run_class_body_chunk_or_raw` now runs a statement's precompiled `body_plan` chunk (ADR-0019 D6-3a-d) unconditionally whenever one is present, instead of only under the `MUTSU_DROP_LEGACY_CLASS_BODY=1` instrument added in D6-3d.
- `token`/`rule` statements are unaffected (they never get a chunk, per the ADR-0009 carve-out) and keep running via `run_block_raw`.
- Pure default flip, no behavior change — the instrument had already been forced through the same full verification sweep in D6-3d.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `make test` — 28,062 tests, all pass
- [x] `MUTSU_FUDGE=1 prove` on `roast/S12-class`, `roast/S12-construction`, `roast/S14-roles`, `roast/S05-grammar` (release binary) — 957 tests, only the pre-existing non-whitelisted `S12-class/open_closed.t` failure
- [x] `scripts/battery-testsuite.sh` — 158/164 files pass (2 excluded), byte-identical to the D6-3d baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)