### PR TITLE
fix(runtime): blocks with an explicit signature keep the outer $_ in map/grep

### DIFF
--- a/news/2026-08/explicit-param-block-topic-outer-in-iteration.md
+++ b/news/2026-08/explicit-param-block-topic-outer-in-iteration.md
@@ -1,0 +1,33 @@
+# grep/map no longer overwrite `$_` for blocks with an explicit signature — http-cookiejar 30/30
+
+A pointy block with an explicit signature (`-> $c { ... }`) does not declare
+`$_`; a `$_` in its body is a lexical reference to the enclosing scope's
+topic. mutsu's inline map/grep/first fast paths instead re-bound `$_` to the
+iteration element on every call, so `for <a b> { <a b c>.grep(-> $c { $c eq
+$_ }) }` compared each element with itself (always true) instead of with the
+`for` topic.
+
+The fix generalizes `whatever_code_keeps_outer_topic` into
+`block_keeps_outer_topic` (`src/runtime/resolution_map_grep.rs`): any block
+whose params are non-empty and do not include the implicit `_` keeps the
+enclosing topic — pointy blocks, placeholder blocks (`{ $^x ~ $_ }`),
+arity-2 blocks, and `$_`-referencing WhateverCode alike. Only a bare block
+(or a plain `*.foo` WhateverCode, whose placeholder IS `_`) topicalizes the
+element. The map fast path's arity>1 branch was also routed through
+`bind_loop_topic` so it obeys the same rule. Every expectation was verified
+against rakudo first (`for "o" { <a b>.map(-> $c { $c ~ $_ }) }` is
+`("ao", "bo")`, etc.); pinned in `t/block-topic-explicit-params.t`.
+
+This was the root cause of most of `http-cookiejar.rakutest`'s failures:
+`Cro::HTTP::Client::CookieJar.add-from-response`'s uniqueness check
+(`@!cookies.grep(-> $cs { checker($_, $cs) })`, where `$_` is the
+`for $resp.cookies` topic) never matched, so every re-add duplicated cookies
+("Use of Nil in string context" warnings from CookieJar line 106). With the
+fix the file goes 22/30 → **30/30 fully green**.
+
+Remaining related edge (not fixed here): rakudo resolves a stored block's
+non-declared `$_` as a definition-site lexical capture (`my $b = -> $c { $_
+}; given "outer" { $b("elem") }` is `Any` in rakudo — the definition-site
+topic), while mutsu resolves it dynamically at call time (`"outer"`). The
+iteration paths no longer hit this, and no known test depends on it; worth a
+ticket if it ever surfaces.

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -25,18 +25,21 @@ pub(crate) fn frame_authoritative_set(
 /// Does this callable's `$_` stay at the caller's topic instead of being
 /// topicalized to the element a map/grep/first loop is visiting?
 ///
-/// A WhateverCode whose body references `$_` (`*.new($_)`, `* eq $_`) compiles
-/// its `*` placeholder to a synthetic `__wc_N` param so the element binds
-/// there, NOT to `$_`; the body's `$_` must stay the caller's topic (S02 "no
-/// scoping issues when using topic variables": `do { $_ = 42; (Int).map(*.new($_)) }`
-/// -> `Int.new(42)`). A plain `*.abs` (no `$_` in the body) keeps `_` AS its
-/// placeholder param, so it must still receive the element — hence the
-/// `_`-is-not-a-param guard.
-pub(crate) fn whatever_code_keeps_outer_topic(data: &SubData) -> bool {
-    matches!(
-        data.env.get("__mutsu_callable_type").map(Value::view),
-        Some(ValueView::Str(kind)) if kind.as_str() == "WhateverCode"
-    ) && !data.params.iter().any(|p| p == "_")
+/// Any block with an explicit signature binds the element to its parameters,
+/// NOT to `$_`; its `$_` is a lexical reference to the enclosing topic. This
+/// covers pointy blocks (`-> $c { $c eq $_ }` — the CookieJar uniqueness-check
+/// shape), placeholder blocks (`{ $^x ~ $_ }`), and a WhateverCode whose body
+/// references `$_` (`*.new($_)` compiles its `*` to a synthetic `__wc_N`
+/// param; S02 "no scoping issues when using topic variables":
+/// `do { $_ = 42; (Int).map(*.new($_)) }` -> `Int.new(42)`). All verified
+/// against rakudo: `for "o" { <a b>.map(-> $c { $c ~ $_ }) }` is
+/// `("ao", "bo")`.
+///
+/// Only a block whose parameter IS the implicit `_` topicalizes the element —
+/// a bare `{ $_ }` block, or a plain `*.abs` WhateverCode (no `$_` in the
+/// body), which keeps `_` as its placeholder param.
+pub(crate) fn block_keeps_outer_topic(data: &SubData) -> bool {
+    !data.params.is_empty() && !data.params.iter().any(|p| p == "_")
 }
 
 /// A carrier Sub delegates its behaviour through env markers instead of its
@@ -58,7 +61,7 @@ pub(crate) fn sub_is_call_carrier(data: &SubData) -> bool {
 /// For a `$_`-referencing WhateverCode the topic is held at `outer_topic` for
 /// every iteration (re-set, so a prior iteration's tail value cannot leak into
 /// the next one's `$_`); otherwise the element is the topic.
-/// See [`whatever_code_keeps_outer_topic`].
+/// See [`block_keeps_outer_topic`].
 pub(crate) fn bind_loop_topic(
     env: &mut Env,
     item: &Value,
@@ -395,7 +398,7 @@ impl Interpreter {
                 }
             }
 
-            let is_whatever_code = whatever_code_keeps_outer_topic(&data);
+            let is_whatever_code = block_keeps_outer_topic(&data);
             let outer_topic = self.env.get("_").cloned();
 
             // CP-3 collapse: run the map loop with fresh execution registers
@@ -445,10 +448,12 @@ impl Interpreter {
                                     vm.env_mut().insert(p.clone(), list_items[i + idx].clone());
                                 }
                             }
-                            vm.env_mut()
-                                .insert(underscore.clone(), list_items[i].clone());
-                            vm.env_mut()
-                                .insert(dollar_topic.clone(), list_items[i].clone());
+                            bind_loop_topic(
+                                vm.env_mut(),
+                                &list_items[i],
+                                is_whatever_code,
+                                &outer_topic,
+                            );
                         }
                     }
                     match vm.run_reuse(&code, &compiled_fns) {
@@ -676,7 +681,7 @@ impl Interpreter {
             self.env.insert_sym(*k, v.clone());
         }
 
-        let keeps_outer_topic = whatever_code_keeps_outer_topic(&data);
+        let keeps_outer_topic = block_keeps_outer_topic(&data);
         let outer_topic = self.env.get("_").cloned();
 
         let mut found: Option<(usize, Value)> = None;

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -439,8 +439,7 @@ impl Interpreter {
                 self.env.insert_sym(*k, v.clone());
             }
 
-            let keeps_outer_topic =
-                super::resolution_map_grep::whatever_code_keeps_outer_topic(&data);
+            let keeps_outer_topic = super::resolution_map_grep::block_keeps_outer_topic(&data);
             let outer_topic = self.env.get("_").cloned();
 
             // CP-3 collapse: run the grep loop with fresh execution registers

--- a/t/block-topic-explicit-params.t
+++ b/t/block-topic-explicit-params.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+plan 8;
+
+# A block with an explicit signature binds the iteration element to its
+# parameters, NOT to $_ — its $_ stays the enclosing topic (all expectations
+# verified against rakudo).
+
+for <a b> {
+    my @hits = <a b c>.grep(-> $c { $c eq $_ });
+    is-deeply @hits, [$_], "grep pointy-block \$_ is the outer topic ($_)";
+}
+
+for "o" {
+    is-deeply <a b>.map(-> $c { $c ~ $_ }).List, ("ao", "bo"),
+        'map pointy-block $_ is the outer topic';
+    is-deeply <a b>.map({ $^x ~ $_ }).List, ("ao", "bo"),
+        'map placeholder-block $_ is the outer topic';
+    is-deeply <a b>.map(-> $c, $d { $c ~ $d ~ $_ }).List, ("abo",),
+        'arity-2 pointy-block $_ is the outer topic';
+    is-deeply <a b>.map({ $_ }).List, ("a", "b"),
+        'bare block still topicalizes the element';
+}
+
+# WhateverCode: a plain *.foo takes the element; one referencing $_ keeps the
+# outer topic (S02 "no scoping issues when using topic variables").
+is-deeply (1, 2, 3).grep(* > 1).List, (2, 3), 'plain WhateverCode takes the element';
+is-deeply (do { $_ = 42; (Int,).map(*.new($_)).List }), (42,),
+    'WhateverCode referencing $_ keeps the outer topic';


### PR DESCRIPTION
## Summary

A pointy block with an explicit signature (`-> $c { ... }`) does not declare `$_`; a `$_` in its body is a lexical reference to the enclosing scope's topic. mutsu's inline map/grep/first fast paths instead re-bound `$_` to the iteration element on every call:

```
$ raku -e 'for <a b> { say <a b c>.grep(-> $c { $c eq $_ }).raku }'
("a",)
("b",)
$ mutsu (before)
["a", "b", "c"]   # $c eq $_ compared the element with itself
["a", "b", "c"]
```

## Fix

`whatever_code_keeps_outer_topic` → `block_keeps_outer_topic` (`resolution_map_grep.rs`): any block whose params are non-empty and do not include the implicit `_` keeps the enclosing topic — pointy blocks, placeholder blocks (`{ $^x ~ $_ }`), arity-2 blocks, and `$_`-referencing WhateverCode alike. Only a bare block (or a plain `*.foo` WhateverCode, whose placeholder IS `_`) topicalizes the element. The map fast path's arity>1 branch now also goes through `bind_loop_topic`. Every expectation was verified against rakudo first.

## Impact

Root cause of most of `http-cookiejar.rakutest`'s failures: `Cro::HTTP::Client::CookieJar.add-from-response`'s uniqueness check (`@!cookies.grep(-> $cs { checker($_, $cs) })` where `$_` is the `for $resp.cookies` topic) never matched, duplicating cookies on every re-add. **The file goes 22/30 → 30/30 fully green.**

A related edge stays open (documented in the news entry): rakudo resolves a *stored* block's non-declared `$_` as a definition-site capture; mutsu resolves it dynamically at call time. The iteration paths no longer hit this.

## Verification

- New pin `t/block-topic-explicit-params.t` (8 tests, all verified against `raku`)
- `make test`: 28070 all green
- `http-cookiejar.rakutest`: 30/30

🤖 Generated with [Claude Code](https://claude.com/claude-code)