### PR TITLE
refactor(runtime): drop CompiledClassDeclPlan::legacy_body (ADR-0019 D6-4, closes D6)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,9 +115,10 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 36/53 slices merged (C6, C7, C8, D1, D2d, D7, and D8 complete; D2a and D2c-1/2/3
-also landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, D4-3, D7-3, and D3-8a landed
-2026-08-08; D3-8b, D3-8c, D3-8d, D7-4, D8-1, D8-2, D8-3, and D8-4 landed 2026-08-09). Phase C is fully checked; the open box is
+**Current progress: 38/53 slices merged (C6, C7, C8, D1, D2d, D6, D7, and D8 complete; D2a and
+D2c-1/2/3 also landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, D4-3, D7-3, and D3-8a
+landed 2026-08-08; D3-8b, D3-8c, D3-8d, D7-4, D8-1, D8-2, D8-3, D8-4, D6-3e, and D6-4 landed
+2026-08-09). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
 shape B's `has_class_scoped_subs` gate) remains open in D2. D3 (class methods/submethods as compiled candidates) is open;
@@ -1116,7 +1117,7 @@ walkers wholesale is not possible before then.
   instantiate → new_type → add_method → trait dispatch → compose; HOW installs keyed on the
   resolved storage name), and D5-2 is a verification gate (OO::Monitors battery + metamodel
   roast) riding on D6's slices rather than a separate code PR.
-- [ ] **D6 — Remove `CompiledClassDeclPlan::legacy_body`.** Preserve augmentation, rollback,
+- [x] **D6 — Remove `CompiledClassDeclPlan::legacy_body`.** Preserve augmentation, rollback,
   redeclaration errors, language revisions, nested types, and EVAL behavior. Excludes the
   token/rule arms (see the phase preamble). Start with the C6d-style instrumentation survey —
   C6's one box became nine PRs, and this field has the same shape.
@@ -1287,6 +1288,42 @@ walkers wholesale is not possible before then.
   raw-statement fallback paths) — dropping `CompiledClassDeclPlan::legacy_body`
   itself (D6-4) needs those three handlers threaded onto `ClassBodyOp`'s
   already-typed fields instead, which did not fit this slice.
+  **D6-4 landed 2026-08-09**: `run_class_body` now iterates `body_plan:
+  &[ClassBodyOp]` directly — the separate raw flattened `body: &[Stmt]`
+  parameter, its `SyntheticBlock`-flatten, and its
+  `collect_nested_class_has_decls` nested-`has` scan are all gone;
+  `body_plan` already carries every op in the same order (it is built by
+  the identical flatten-then-classify-then-nested-append transform,
+  `crate::opcode::class_body_plan`), so no runtime preprocessing is needed
+  any more. Two handlers changed shape to stop needing a raw `Stmt`:
+  `class_body_does_decl` now takes the `Does` op's own `name: Symbol`
+  instead of re-matching `Stmt::DoesDecl` for the same field, and
+  `ClassBodyOp::Attr` gained a `raw: Stmt` field (populated unconditionally
+  by `classify_class_body_stmt`, cheap the same way `ClassSub`/`CodeAlias`/
+  `ProtoMethod`/`LeavePhaser` already carry their own `raw`) so
+  `class_body_has_decl`'s existing our/my-attribute fallback — attribute
+  names in `attr_decls` deliberately exclude `is_our`/`is_my` attributes,
+  which therefore miss the primary name-keyed lookup and need the raw
+  `HasDecl` statement to build an ad hoc `CompiledAttrDecl` — still has a
+  raw statement to read without a separate lookaside list. `Method` and
+  `Does` needed no such change: `class_body_method_decl` already took no
+  statement, and `class_body_does_decl`'s only use of `stmt` was the same
+  `name` its op already carries. `CompiledClassDeclPlan::legacy_body` and
+  its one construction site are deleted, along with `register_class_decl`'s
+  now-unused `body: &[Stmt]` parameter and its three call sites' trailing
+  `body`/`&[]` argument (the VM opcode handler, role-pun/mixin synthesis,
+  and `augment class` — the latter two already passed `body_plan: &[]`
+  alongside it, so an empty plan alone now correctly drives zero
+  iterations). Verified via the full `t/` suite (28,062 tests) and unit
+  tests (701, including the fixed-up `class_declarations_precompute_body_plan`
+  callers), the `S12-class`/`S12-construction`/`S14-roles`/`S05-grammar`
+  roast files (957 tests, same pre-existing `open_closed.t` failure), and
+  `scripts/battery-testsuite.sh` (158/164, byte-identical) — plus a hand
+  comparison against `raku` exercising every `ClassBodyOp` variant in one
+  class (an attribute with an `our`/`my` sibling to force the fallback
+  path, `also does`, a class-scoped `sub`, a code alias, a `proto method`,
+  and a `will leave` phaser), byte-identical output. This closes ADR-0019's
+  D6 box.
 - [x] **D7 — Encode role structure and composition.** Put role parameters, attributes, methods,
   parent roles, conflicts, hides, and pun metadata into immutable plan operations.
   **Design pass done 2026-08-08 (no code landed):**

--- a/news/2026-08/d6-4-drop-class-body-legacy-body-closes-d6.md
+++ b/news/2026-08/d6-4-drop-class-body-legacy-body-closes-d6.md
@@ -1,0 +1,37 @@
+# ADR-0019 D6-4: dropped CompiledClassDeclPlan::legacy_body, closes D6
+
+`run_class_body` now iterates the compiler-precomputed `body_plan:
+&[ClassBodyOp]` directly instead of a raw, separately-stored
+`Vec<Stmt>`. Previously the registration-time walker zipped a
+`SyntheticBlock`-flattened, nested-`has`-decl-appended copy of the class
+body against `body_plan` on every registration, re-deriving at runtime
+exactly what the compiler had already computed once at plan-lowering time.
+`body_plan` is built by the identical flatten-then-classify-then-append
+transform, so it already carries every op in the same order — the
+runtime-side preprocessing was pure duplicated work.
+
+Two of the small per-statement handlers changed shape to stop needing a
+raw `Stmt` at all: `class_body_does_decl` now takes the `Does` op's own
+`name: Symbol` field directly instead of re-matching `Stmt::DoesDecl` for
+it, and `ClassBodyOp::Attr` gained its own `raw: Stmt` field (populated
+unconditionally, the same way `ClassSub`/`CodeAlias`/`ProtoMethod`/
+`LeavePhaser` already carry theirs) so `class_body_has_decl`'s existing
+fallback for a class-level `our`/`my` attribute — excluded from the
+compiler's name-keyed `attr_decls` table by design, so it needs the raw
+`HasDecl` statement to build an ad hoc descriptor — still has one to read,
+without a separate lookaside list to keep in sync.
+
+With every consumer moved onto `body_plan`, `CompiledClassDeclPlan::legacy_body`
+itself, its one construction site, and `register_class_decl`'s now-unused
+`body: &[Stmt]` parameter (plus its three call sites' trailing argument)
+are all deleted. This closes ADR-0019's D6 box.
+
+Verified via the full `t/` suite (28,062 tests), all 701 Rust unit tests,
+the `S12-class`/`S12-construction`/`S14-roles`/`S05-grammar` roast files
+(957 tests, only the pre-existing non-whitelisted `S12-class/open_closed.t`
+failure), `scripts/battery-testsuite.sh` (158/164, byte-identical to
+baseline), and a hand comparison against `raku` exercising every
+`ClassBodyOp` variant in one class declaration (an attribute with an
+`our`/`my` sibling to force the new fallback path, `also does`, a
+class-scoped `sub`, a code alias, a `proto method`, and a `will leave`
+phaser) — byte-identical output.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -399,7 +399,7 @@ mod declaration_plan_tests {
         assert_eq!(typed.len(), 9, "typed ops: {typed:?}");
         assert!(matches!(
             typed[0],
-            ClassBodyOp::Attr { name } if name.as_str() == "x"
+            ClassBodyOp::Attr { name, .. } if name.as_str() == "x"
         ));
         assert!(matches!(typed[1], ClassBodyOp::Method));
         assert!(matches!(
@@ -435,7 +435,7 @@ mod declaration_plan_tests {
         ));
         assert!(matches!(
             typed[8],
-            ClassBodyOp::Attr { name } if name.as_str() == "w"
+            ClassBodyOp::Attr { name, .. } if name.as_str() == "w"
         ));
     }
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2487,10 +2487,12 @@ fn is_stub_routine_body(body: &[Stmt]) -> bool {
 
 /// Recursively surface `has`-attribute names nested inside a `sub` within a
 /// class body (`class C { sub f { has $.x } }`), mirroring
-/// `Interpreter::collect_nested_class_has_decls` (ADR-0019 D2a). Descends
-/// into `sub` bodies but not into a nested `class`/`role`, which owns its
-/// own attribute scope. `our`/`my` (class-level) attributes are excluded, as
-/// they are not part of per-instance `$!attr` validation.
+/// `collect_nested_has_decl_stmts` below, which `class_body_plan` uses to
+/// give each such nested declaration its own trailing `Attr` op (ADR-0019
+/// D6-4). Descends into `sub` bodies but not into a nested `class`/`role`,
+/// which owns its own attribute scope. `our`/`my` (class-level) attributes
+/// are excluded here, as they are not part of per-instance `$!attr`
+/// validation.
 fn collect_nested_has_decl_names(stmts: &[Stmt], out: &mut Vec<Symbol>) {
     for s in stmts {
         match s {
@@ -2720,19 +2722,16 @@ pub(crate) struct CompiledClassDeclPlan {
     pub(crate) hidden_parents: Vec<String>,
     pub(crate) does_parents: Vec<String>,
     pub(crate) repr: Option<String>,
-    /// Compatibility payload for the class/role registry walker. Declaration-time expressions
-    /// move to compiled child chunks in the next ADR-0019 stage.
-    pub(crate) legacy_body: Vec<Stmt>,
     pub(crate) language_version: String,
     pub(crate) custom_traits: Vec<(String, Option<DeclTraitArg>)>,
     pub(crate) decl_id: u64,
     /// Whether the declared body is a yada stub (ADR-0019 D1). Precomputed at
-    /// plan lowering so registration never re-walks `legacy_body` to judge
+    /// plan lowering so registration never re-walks the raw body to judge
     /// this — mirrors `CompiledRoutineMetadata::is_stub` for subs.
     pub(crate) is_stub: bool,
     /// `trusts SomeClass` declarations at the top level of the body,
-    /// precomputed at plan lowering (ADR-0019 D1) instead of scanning
-    /// `legacy_body` for `Stmt::TrustsDecl` at registration time.
+    /// precomputed at plan lowering (ADR-0019 D1) instead of scanning the
+    /// raw body for `Stmt::TrustsDecl` at registration time.
     pub(crate) trusts: Vec<Symbol>,
     /// Attribute names this class declares directly in its own body
     /// (ADR-0019 D2a), precomputed at plan lowering instead of
@@ -2796,8 +2795,11 @@ pub(crate) struct CompiledClassDeclPlan {
 #[allow(dead_code)]
 pub(crate) enum ClassBodyOp {
     /// A top-level (or nested-sub) `has` declaration. Its typed descriptor
-    /// lives in `attr_decls`, keyed by this same name.
-    Attr { name: Symbol },
+    /// normally lives in `attr_decls`, keyed by this same name; `raw` is
+    /// used only as a fallback when it is not there (a class-level
+    /// `our`/`my` attribute, which `attr_decls`'s compiler-side collector
+    /// deliberately excludes — see `class_body_has_decl`).
+    Attr { name: Symbol, raw: Stmt },
     /// A `method`/`submethod` declaration. Advances the existing
     /// `method_name_chunks`/`method_decls` position cursor.
     Method,
@@ -2837,12 +2839,11 @@ pub(crate) enum ClassBodyOp {
     },
 }
 
-/// Lower a class body into its ordered, typed op mirror (ADR-0019 D6-3a),
-/// matching `run_class_body`'s own dispatch loop exactly: `SyntheticBlock`-
-/// flatten the top level, classify each statement the same way the runtime
-/// match does, then append nested-sub `has` declarations (in
-/// `Interpreter::collect_nested_class_has_decls` order) as more `Attr` ops —
-/// `run_class_body` appends them to the same iteration, not a separate pass.
+/// Lower a class body into its ordered, typed op mirror (ADR-0019 D6-3a):
+/// `SyntheticBlock`-flatten the top level, classify each statement, then
+/// append nested-sub `has` declarations as more `Attr` ops. Since D6-4,
+/// this is the sole source `run_class_body` walks — there is no separate
+/// runtime-side flatten/append pass to mirror any more.
 pub(crate) fn class_body_plan(body: &[Stmt]) -> Vec<ClassBodyOp> {
     let mut flattened: Vec<&Stmt> = body
         .iter()
@@ -2858,9 +2859,11 @@ pub(crate) fn class_body_plan(body: &[Stmt]) -> Vec<ClassBodyOp> {
         .collect()
 }
 
-/// `Interpreter::collect_nested_class_has_decls`'s compile-time mirror: `has`
-/// declarations inside a body `sub`, in the same order, as statement
-/// references rather than just names (unlike [`collect_nested_has_decl_names`]).
+/// `has` declarations inside a body `sub`, as statement references rather
+/// than just names (unlike [`collect_nested_has_decl_names`]) — unfiltered,
+/// so a class-level `our`/`my` nested `has` gets its own `Attr` op too (its
+/// `raw` field is `class_body_has_decl`'s only source for it, since
+/// `attr_decls` excludes it).
 fn collect_nested_has_decl_stmts<'a>(stmts: &'a [Stmt], out: &mut Vec<&'a Stmt>) {
     for s in stmts {
         match s {
@@ -2887,7 +2890,10 @@ fn classify_class_body_stmt(stmt: &Stmt) -> ClassBodyOp {
             chunk: None,
             raw: stmt.clone(),
         },
-        Stmt::HasDecl { name, .. } => ClassBodyOp::Attr { name: *name },
+        Stmt::HasDecl { name, .. } => ClassBodyOp::Attr {
+            name: *name,
+            raw: stmt.clone(),
+        },
         Stmt::MethodDecl { .. } => ClassBodyOp::Method,
         Stmt::DoesDecl { name, .. } => ClassBodyOp::Does { name: *name },
         Stmt::VarDecl {
@@ -6390,7 +6396,6 @@ impl CompiledCode {
             hidden_parents: hidden_parents.clone(),
             does_parents: does_parents.clone(),
             repr: repr.clone(),
-            legacy_body: body.clone(),
             language_version: language_version.clone(),
             custom_traits: plan_traits,
             decl_id: *decl_id,

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1008,7 +1008,7 @@ impl Interpreter {
             compiled_fns: &crate::opcode::CompiledFns::default(),
             body_plan: &[],
         };
-        self.register_class_decl(&pun_name, &parents, modifiers, &[])?;
+        self.register_class_decl(&pun_name, &parents, modifiers)?;
         self.store_language_revision_from_version(&pun_name, &language_version);
         Ok(Some(pun_name))
     }

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -69,53 +69,23 @@ pub(super) struct ClassBodyLeavePhaser {
     pub(super) chunk: Option<crate::opcode::CompiledDeclExpr>,
 }
 
-/// Extract a body-walk op's compiled chunk, if any — `None` for a statement
-/// kind D6-3b/c never compiles a chunk for (`token`/`rule`, per the phase
-/// preamble's ADR-0009 carve-out) or when `op` itself is `None` (a
-/// length-mismatch fallback, see `run_class_body`).
-fn class_body_op_chunk(
-    op: Option<&crate::opcode::ClassBodyOp>,
-) -> Option<&crate::opcode::CompiledDeclExpr> {
-    match op? {
-        crate::opcode::ClassBodyOp::Other { chunk, .. }
-        | crate::opcode::ClassBodyOp::ClassSub { chunk, .. }
-        | crate::opcode::ClassBodyOp::CodeAlias { chunk, .. } => chunk.as_ref(),
-        _ => None,
-    }
-}
-
 impl Interpreter {
-    /// Recursively surface `has`-attribute declarations nested inside a sub/block
-    /// within a class body (`class C { sub f { has $.x } }`). Descends into
-    /// `sub`/block bodies but NOT into a nested `class`/`role` (which owns its own
-    /// attribute scope). Collects only `HasDecl` statements.
-    fn collect_nested_class_has_decls<'a>(stmts: &'a [Stmt], out: &mut Vec<&'a Stmt>) {
-        for s in stmts {
-            match s {
-                // Own attribute scope / already collected at the top level.
-                Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } | Stmt::HasDecl { .. } => {}
-                Stmt::SubDecl { body, .. } => {
-                    for inner in body {
-                        if matches!(inner, Stmt::HasDecl { .. }) {
-                            out.push(inner);
-                        }
-                    }
-                    Self::collect_nested_class_has_decls(body, out);
-                }
-                _ => {}
-            }
-        }
-    }
-
     /// Execute the class body: make the class package current, walk every
-    /// (flattened) body statement through the per-statement arms, then fire
-    /// LEAVE phasers, persist class-body statics, and restore the enclosing
+    /// op in `body_plan` through the per-statement arms, then fire LEAVE
+    /// phasers, persist class-body statics, and restore the enclosing
     /// package/lexical scope. Returns the final `ClassDef`.
+    ///
+    /// `body_plan` (ADR-0019 D6-3a-d) is the sole driver of this walk as of
+    /// D6-4 — there is no separate raw `Vec<Stmt>` to zip it against any
+    /// more. It is already `SyntheticBlock`-flattened and carries nested-sub
+    /// `has` declarations as trailing `Attr` ops (`crate::opcode::class_body_plan`),
+    /// so it needs no further preprocessing here. A registration path with
+    /// no compiled plan (role-pun/mixin synthesis, `augment class`) passes
+    /// an empty `body_plan`, and the loop below simply does nothing.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn run_class_body(
         &mut self,
         name: &str,
-        body: &[Stmt],
         class_def: ClassDef,
         is_hidden: bool,
         class_is_rw: bool,
@@ -133,38 +103,6 @@ impl Interpreter {
         self.set_current_package(name.to_string());
         self.env
             .insert("?CLASS".to_string(), Value::package(Symbol::intern(name)));
-        // Flatten SyntheticBlock (from `has ($a, $b)` list form) so inner
-        // HasDecl statements are processed at the top level.
-        let mut flattened_body: Vec<&Stmt> = body
-            .iter()
-            .flat_map(|s| match s {
-                Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
-                other => vec![other],
-            })
-            .collect();
-        // An attribute can also be declared inside a nested sub/block within the
-        // class body (`class C { sub f { has $.x } }`) — Rakudo still registers it
-        // on the class. Surface those `has` declarations so the main loop below
-        // registers the attribute (the nested sub itself is still processed
-        // normally; its body's `has` is a compile-time declaration).
-        Self::collect_nested_class_has_decls(body, &mut flattened_body);
-        // `body_plan` (ADR-0019 D6-3a-d) is a position-aligned typed mirror of
-        // this same flattened statement sequence, computed by the compiler at
-        // plan lowering (`crate::opcode::class_body_plan` mirrors this
-        // function's own flatten+nested-has-append exactly — pinned by the
-        // `class_declarations_precompute_body_plan` compiler unit test). A
-        // registration path with no compiled plan (role-pun/mixin synthesis,
-        // `augment class`) always pairs an empty `body_plan` with an empty
-        // `body`, so lengths agree there too; guard against any other
-        // mismatch by falling back to `None` (the pre-D6-3d on-the-fly
-        // compile path) rather than risking a misaligned zip silently
-        // dropping trailing statements.
-        let body_plan_ops: Vec<Option<&crate::opcode::ClassBodyOp>> =
-            if body_plan.len() == flattened_body.len() {
-                body_plan.iter().map(Some).collect()
-            } else {
-                vec![None; flattened_body.len()]
-            };
         // The set of attributes valid for $!attr access: names declared
         // directly in this class body (precomputed by the compiler at plan
         // lowering, ADR-0019 D2a — `own_attribute_names` already covers the
@@ -202,66 +140,54 @@ impl Interpreter {
         // i.e. once all body statements have been processed. Collect them here
         // and run them (LIFO) after the loop instead of executing them inline.
         let mut class_leave_phasers: Vec<ClassBodyLeavePhaser> = Vec::new();
-        for (stmt, op) in flattened_body.into_iter().zip(body_plan_ops) {
-            match stmt {
-                Stmt::Phaser {
-                    kind: PhaserKind::Leave,
-                    body,
-                } => {
-                    let chunk = match op {
-                        Some(crate::opcode::ClassBodyOp::LeavePhaser { chunk, .. }) => {
-                            chunk.clone()
-                        }
-                        _ => None,
+        for op in body_plan {
+            match op {
+                crate::opcode::ClassBodyOp::LeavePhaser { chunk, raw } => {
+                    let Stmt::Phaser { body, .. } = raw else {
+                        unreachable!("LeavePhaser op's raw statement must be Stmt::Phaser");
                     };
                     class_leave_phasers.push(ClassBodyLeavePhaser {
                         body: body.clone(),
-                        chunk,
+                        chunk: chunk.clone(),
                     });
+                    continue;
                 }
-                Stmt::HasDecl { .. } => {
+                crate::opcode::ClassBodyOp::Attr { raw, .. } => {
                     if matches!(
-                        self.class_body_has_decl(&mut cx, stmt)?,
+                        self.class_body_has_decl(&mut cx, raw)?,
                         ClassBodyFlow::SkipTail
                     ) {
                         continue;
                     }
                 }
-                Stmt::MethodDecl { .. } => {
+                crate::opcode::ClassBodyOp::Method => {
                     self.class_body_method_decl(&mut cx)?;
                 }
-                Stmt::DoesDecl { .. } => {
+                crate::opcode::ClassBodyOp::Does { name: role_name } => {
                     if matches!(
-                        self.class_body_does_decl(&mut cx, stmt)?,
+                        self.class_body_does_decl(&mut cx, *role_name)?,
                         ClassBodyFlow::SkipTail
                     ) {
                         continue;
                     }
                 }
                 // our &baz ::= &bar  — alias a method under a new name
-                Stmt::VarDecl {
-                    name: var_name,
-                    expr: Expr::CodeVar(_),
-                    ..
-                } if var_name.starts_with('&') => {
-                    let chunk = class_body_op_chunk(op);
-                    self.class_body_code_alias(&mut cx, stmt, chunk)?;
+                crate::opcode::ClassBodyOp::CodeAlias { chunk, raw } => {
+                    self.class_body_code_alias(&mut cx, raw, chunk.as_ref())?;
                 }
-                Stmt::ProtoDecl {
-                    is_method: true, ..
-                } => {
-                    self.class_body_proto_method_decl(&mut cx, stmt)?;
+                crate::opcode::ClassBodyOp::ProtoMethod { raw, .. } => {
+                    self.class_body_proto_method_decl(&mut cx, raw)?;
                 }
-                _ => {
-                    let chunk = class_body_op_chunk(op);
-                    self.class_body_other_stmt(&mut cx, stmt, chunk)?;
+                crate::opcode::ClassBodyOp::ClassSub { chunk, raw, .. }
+                | crate::opcode::ClassBodyOp::Other { chunk, raw } => {
+                    self.class_body_other_stmt(&mut cx, raw, chunk.as_ref())?;
                 }
             }
             // Check if any new functions were registered under the class package
             // during body processing (e.g., class-scoped subs).
             // Only count functions that are actual subs (not methods, which are
             // registered via MethodDecl and stored in the class methods table).
-            if let Stmt::SubDecl { name: sub_name, .. } = stmt {
+            if let crate::opcode::ClassBodyOp::ClassSub { name: sub_name, .. } = op {
                 let fq = format!("{}::{}", cx.name, sub_name);
                 if self.registry().functions.contains_key(&Symbol::intern(&fq))
                     && !saved_functions_keys.contains(&fq)

--- a/src/runtime/registration_class_body_does.rs
+++ b/src/runtime/registration_class_body_does.rs
@@ -12,14 +12,8 @@ impl Interpreter {
     pub(super) fn class_body_does_decl(
         &mut self,
         cx: &mut ClassBodyCx<'_>,
-        stmt: &Stmt,
+        role_name: Symbol,
     ) -> Result<ClassBodyFlow, RuntimeError> {
-        let Stmt::DoesDecl {
-            name: role_name, ..
-        } = stmt
-        else {
-            unreachable!("class_body_does_decl called on a non-DoesDecl statement");
-        };
         let raw_role_name = role_name.resolve();
         // An imported role referenced by its short alias (`does
         // PackageRepo` where the role is registered as

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -110,7 +110,6 @@ impl Interpreter {
         name: &str,
         parents: &[String],
         modifiers: ClassDeclModifiers<'_>,
-        body: &[Stmt],
     ) -> Result<Vec<String>, RuntimeError> {
         self.clear_private_zeroarg_method_cache();
         // Mark this as a user-declared class so its collected attribute list is
@@ -224,7 +223,6 @@ impl Interpreter {
         }
         let class_def = self.run_class_body(
             name,
-            body,
             class_def,
             is_hidden,
             class_is_rw,

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -73,7 +73,7 @@ impl Interpreter {
             compiled_fns: &crate::opcode::CompiledFns::default(),
             body_plan: &[],
         };
-        self.register_class_decl(&name, &parents, modifiers, &[])?;
+        self.register_class_decl(&name, &parents, modifiers)?;
         self.compose_mixin_role_submethods(&name, &fresh);
         // A mixin type is synthesized, not written by the user: it must inherit
         // the base's accessor authority rather than claim its own. Marked

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -132,7 +132,6 @@ impl Interpreter {
             hidden_parents,
             does_parents,
             repr,
-            legacy_body: body,
             language_version,
             custom_traits,
             decl_id,
@@ -281,7 +280,6 @@ impl Interpreter {
                         compiled_fns,
                         body_plan,
                     },
-                    body,
                 )
             )?;
             // Check for assignment to native read-only params before


### PR DESCRIPTION
## Summary
- `run_class_body` now iterates the compiler-precomputed `body_plan: &[ClassBodyOp]` directly instead of a raw, separately-stored `Vec<Stmt>` that duplicated exactly what `body_plan` already carries (same flatten-then-classify-then-append transform).
- `class_body_does_decl` takes the `Does` op's own `name: Symbol` directly instead of re-matching the raw statement for it.
- `ClassBodyOp::Attr` gained its own `raw: Stmt` field (mirroring `ClassSub`/`CodeAlias`/`ProtoMethod`/`LeavePhaser`) so `class_body_has_decl`'s existing fallback for a class-level `our`/`my` attribute (excluded from the compiler's name-keyed `attr_decls` by design) still has a raw statement to read.
- `CompiledClassDeclPlan::legacy_body`, its construction site, and `register_class_decl`'s now-unused `body: &[Stmt]` parameter (plus its 3 call sites) are deleted.
- Closes ADR-0019's D6 box.

## Test plan
- [x] `cargo build`, `cargo test --lib` (701 tests)
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] `make test` — 28,062 tests, all pass
- [x] `MUTSU_FUDGE=1 prove` on `roast/S12-class`, `roast/S12-construction`, `roast/S14-roles`, `roast/S05-grammar` (release binary) — 957 tests, only the pre-existing non-whitelisted `S12-class/open_closed.t` failure
- [x] `scripts/battery-testsuite.sh` — 158/164 files pass (2 excluded), byte-identical to baseline
- [x] Hand comparison against `raku` exercising every `ClassBodyOp` variant in one class (attribute with an `our`/`my` sibling to force the fallback path, `also does`, class-scoped `sub`, code alias, `proto method`, `will leave` phaser) — byte-identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)