### PR TITLE
refactor(runtime): drop CompiledRoleDeclPlan::legacy_body (ADR-0019 D9, closes D9)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -115,9 +115,9 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress: 38/53 slices merged (C6, C7, C8, D1, D2d, D6, D7, and D8 complete; D2a and
+**Current progress: 39/53 slices merged (C6, C7, C8, D1, D2d, D6, D7, D8, and D9 complete; D2a and
 D2c-1/2/3 also landed, 2026-08-07; D2b-2, D2c-4, D6-1, D7-1/D9-1, D4-1, D4-2, D4-3, D7-3, and D3-8a
-landed 2026-08-08; D3-8b, D3-8c, D3-8d, D7-4, D8-1, D8-2, D8-3, D8-4, D6-3e, and D6-4 landed
+landed 2026-08-08; D3-8b, D3-8c, D3-8d, D7-4, D8-1, D8-2, D8-3, D8-4, D6-3e, D6-4, and D9-5 landed
 2026-08-09). Phase C is fully checked; the open box is
 D2 (attributes and generated accessors), subdivided D2a-D2d — D2a, D2b-2, D2c-1/2/3/4, and D2d are
 done; only the optional D2c-5 (A/B env-setup unification, gated on raku-behavior verification of
@@ -1489,7 +1489,7 @@ walkers wholesale is not possible before then.
   the field. Verified via the full `t/` suite (28,037 tests) and every whitelisted
   `S06-signature`/`S12-*`/`S14-*` roast file (release binary). This closes ADR-0019's D8
   box now that D8-1..4 have all landed.
-- [ ] **D9 — Remove `CompiledRoleDeclPlan::legacy_body`.** Preserve role puns, runtime mixins,
+- [x] **D9 — Remove `CompiledRoleDeclPlan::legacy_body`.** Preserve role puns, runtime mixins,
   conflicts, BUILD/TWEAK, custom HOWs, and EVAL. Same rule as D6: survey first, token/rule arms
   excluded.
   **Survey + design pass done 2026-08-08 (no code landed), same doc as D6.** The role body's
@@ -1500,6 +1500,34 @@ walkers wholesale is not possible before then.
   D9-4 (= D8 chunks), D9-5 (field drop, forced-instrument playbook). **D9-1 landed
   2026-08-08 — see D7-1 above (same slice). D9-3 landed 2026-08-08 — see D7-3 above (same
   slice): `parent_ops` covers the role side's typed `DoesDecl` encoding D9-3 asked for.**
+  **D9-5 landed 2026-08-09**: unlike the class side, the role side needed no separate
+  default-flip slice — `body_plan: Vec<RoleBodyOp>` (D7-4) had sat purely additive with zero
+  non-test consumers, so this box went straight from "additive" to "sole driver, field
+  dropped" in one PR, mirroring D6-4's shape (`walk_role_body` now iterates `body_plan`
+  directly, no raw `Vec<Stmt>` to zip it against) but smaller: roles have only one
+  `register_role_decl` call site (no pun/mixin/augment-style synthetic caller passing a
+  hand-built body the way classes have three), and no nested-sub `has` collection to drop.
+  `RoleBodyOp::Attr` gained a `raw: Box<Stmt>` field (boxed, matching `Deferred`'s existing
+  boxing rationale — an unboxed `Stmt` on `Attr` alone would trip
+  `clippy::large_enum_variant` against the marker-sized `Method`/`Parent` variants) so
+  `role_body_has_decl`'s existing our/my-attribute fallback (identical rationale to the class
+  side) still has a raw statement to read. `RoleBodyOp::Deferred`'s existing `raw` already
+  covered the walk's other two raw-statement uses (the `__mutsu_stub_die`/`__mutsu_stub_warn`
+  stub-marker check and the no-op `SetLine`/everything-else fallthrough), needing no change.
+  `CompiledRoleDeclPlan::legacy_body`, its one construction site, and
+  `register_role_decl`'s `body: &[Stmt]` parameter (replaced by `body_plan: &[RoleBodyOp]`,
+  threaded through from the VM opcode handler) are deleted. Verified via the full `t/` suite
+  (28,087 tests), all 701 Rust unit tests, the `S12-class`/`S12-construction`/`S14-roles`/
+  `S05-grammar` roast files (957 tests, same pre-existing `open_closed.t` failure),
+  `scripts/battery-testsuite.sh` (158/164, byte-identical), and a hand comparison against
+  `raku` exercising every `RoleBodyOp` variant in one role composed onto a class (an
+  attribute with a `my`-scoped sibling to force the fallback path, a nested `does`, a method,
+  and a nested `my class`) — byte-identical output. Verification also surfaced a real,
+  pre-existing, unrelated divergence — an `our`-scoped role attribute (`our $.x` inside a
+  role body) is accepted by mutsu instead of raising raku's
+  `X::Declaration::OurScopeInRole` — filed as
+  `todo/tickets/role-our-scoped-attribute-not-rejected.md` rather than fixed here (out of
+  scope for a structural field-removal slice). This closes ADR-0019's D9 box.
 - [ ] **D10 — Delete class/role AST registration walkers.** Keep only VM plan execution plus
   metadata helpers that do not inspect executable AST declarations. The token/rule arms of the
   body walk stay until their ADR-0009-scoped slice lands; D10 deletes everything else.

--- a/news/2026-08/d9-drop-role-legacy-body-closes-d9.md
+++ b/news/2026-08/d9-drop-role-legacy-body-closes-d9.md
@@ -1,0 +1,39 @@
+# ADR-0019 D9: dropped CompiledRoleDeclPlan::legacy_body, closes D9
+
+`walk_role_body` now iterates the compiler-precomputed `body_plan:
+&[RoleBodyOp]` directly instead of a raw, separately-stored `Vec<Stmt>`,
+the role-side twin of D6-4's class-body change. `RoleBodyOp` (added in
+ADR-0019 D7-4) had sat purely additive with zero non-test consumers, so
+this box went straight from "additive typed mirror" to "sole driver, raw
+field dropped" in a single PR — the role side needed no separate
+default-flip slice the way the class side did.
+
+`RoleBodyOp::Attr` gained a `raw: Box<Stmt>` field (boxed, matching
+`Deferred`'s existing boxing rationale for the same enum-size reason) so
+`role_body_has_decl`'s existing fallback for a role-level `my`-scoped
+attribute — excluded from the compiler's name-keyed `attr_decls` table,
+same as the class side — still has a raw statement to read.
+`RoleBodyOp::Deferred`'s existing `raw` already covered the walk's other
+two raw-statement uses (the `__mutsu_stub_die`/`__mutsu_stub_warn` stub
+marker check, and the no-op fallthrough for `SetLine` and every other
+deferred-to-composition statement), so no change was needed there.
+
+With every consumer moved onto `body_plan`,
+`CompiledRoleDeclPlan::legacy_body`, its one construction site, and
+`register_role_decl`'s now-unused `body: &[Stmt]` parameter (replaced by
+`body_plan: &[RoleBodyOp]`) are all deleted. This closes ADR-0019's D9 box.
+
+Verified via the full `t/` suite (28,087 tests), all 701 Rust unit tests,
+the `S12-class`/`S12-construction`/`S14-roles`/`S05-grammar` roast files
+(957 tests, only the pre-existing non-whitelisted `S12-class/open_closed.t`
+failure), `scripts/battery-testsuite.sh` (158/164, byte-identical to
+baseline), and a hand comparison against `raku` exercising every
+`RoleBodyOp` variant in one role composed onto a class (an attribute with
+a `my`-scoped sibling to force the fallback path, a nested `does`, a
+method, and a nested `my class`) — byte-identical output.
+
+Verification also surfaced a real, pre-existing, unrelated divergence: an
+`our`-scoped role attribute (`our $.x` inside a role body) is accepted by
+mutsu instead of raising raku's `X::Declaration::OurScopeInRole`. Filed as
+`todo/tickets/role-our-scoped-attribute-not-rejected.md` rather than fixed
+here, since it is out of scope for a structural field-removal slice.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -723,7 +723,7 @@ mod declaration_plan_tests {
         assert!(matches!(typed[0], RoleBodyOp::Parent));
         assert!(matches!(
             typed[1],
-            RoleBodyOp::Attr { name } if name.as_str() == "x"
+            RoleBodyOp::Attr { name, .. } if name.as_str() == "x"
         ));
         assert!(matches!(typed[2], RoleBodyOp::Method));
         assert!(matches!(typed[3], RoleBodyOp::Parent));

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2782,16 +2782,14 @@ pub(crate) struct CompiledClassDeclPlan {
     /// `resolve_role_candidate` re-parsing the concatenated parent string.
     pub(crate) parent_arg_chunks: Vec<(String, Vec<DeclTraitArg>)>,
     /// Ordered, typed mirror of the flattened class body (ADR-0019 D6-3a),
-    /// one op per statement `run_class_body`'s dispatch loop visits (the
-    /// same `SyntheticBlock`-flattened top level, with nested-sub `has`
-    /// declarations appended at the end — see [`class_body_plan`]). Purely
-    /// additive: no non-test consumer reads this field yet (D6-3d wires
-    /// `run_class_body` to it). The already-typed arms (`Attr`/`Method`/
+    /// one op per statement — the sole driver of `run_class_body`'s dispatch
+    /// loop since D6-4 (the same `SyntheticBlock`-flattened top level, with
+    /// nested-sub `has` declarations appended at the end — see
+    /// [`class_body_plan`]). The already-typed arms (`Attr`/`Method`/
     /// `Does`/`ClassSub`) carry only a name/marker, since their real
     /// payload already lives in `attr_decls`/`method_decls`/
     /// `parent_arg_chunks`; the remaining arms carry their raw statement
-    /// with `chunk: None` until D6-3b/c precompile them.
-    #[allow(dead_code)]
+    /// alongside their precompiled `chunk`.
     pub(crate) body_plan: Vec<ClassBodyOp>,
 }
 
@@ -2956,20 +2954,30 @@ pub(crate) struct RoleParentOp {
 }
 
 /// One role-body statement, typed (ADR-0019 D7-4) — the role-side twin of
-/// [`ClassBodyOp`]. Purely additive: no consumer reads this yet
-/// (`walk_role_body` still walks raw `Stmt`s). Deliberately narrower than
-/// `ClassBodyOp`: a role body has no nested-sub `has` collection and no
-/// `ClassSub`/`CodeAlias`/`ProtoMethod`/`LeavePhaser` arms (those class-only
-/// statement kinds fall through to `Deferred` in a role body, exactly as
-/// `walk_role_body`'s own catch-all treats them), and carries no compiled
-/// chunk yet — deferred-statement chunk compilation is D8's job
-/// (`RoleDef::deferred_body`'s own `DeferredBodyOp`, a separate type).
+/// [`ClassBodyOp`], and since D9 the sole driver of `walk_role_body`.
+/// Deliberately narrower than `ClassBodyOp`: a role body has no nested-sub
+/// `has` collection and no `ClassSub`/`CodeAlias`/`ProtoMethod`/`LeavePhaser`
+/// arms (those class-only statement kinds fall through to `Deferred` in a
+/// role body, exactly as `walk_role_body`'s own catch-all treats them), and
+/// carries no compiled chunk itself — deferred-statement chunk compilation
+/// is `RoleDef::deferred_body`'s own `DeferredBodyOp` (ADR-0019 D8), a
+/// separate type built from this one's `Deferred` ops.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub(crate) enum RoleBodyOp {
-    /// A top-level `has` declaration. Its typed descriptor lives in
-    /// `attr_decls`, keyed by this same name.
-    Attr { name: Symbol },
+    /// A top-level `has` declaration. Its typed descriptor normally lives in
+    /// `attr_decls`, keyed by this same name; `raw` is used only as a
+    /// fallback when it is not there (a role-level `our`/`my` attribute,
+    /// which `attr_decls`'s compiler-side collector excludes — see
+    /// `role_body_has_decl`). Boxed for the same enum-size reason as
+    /// `Deferred`'s `raw`. `name` has no non-test reader (`walk_role_body`
+    /// reads the name back out of `raw` via `role_body_has_decl`'s own
+    /// `Stmt::HasDecl` match instead) — kept for parity with
+    /// `ClassBodyOp::Attr` and pinned by `role_declarations_precompute_body_plan`.
+    Attr {
+        #[allow(dead_code)]
+        name: Symbol,
+        raw: Box<Stmt>,
+    },
     /// A `method`/`submethod` declaration. Advances the existing
     /// `method_name_chunks`/`method_decls` position cursor.
     Method,
@@ -3005,7 +3013,10 @@ pub(crate) fn role_body_plan(body: &[Stmt]) -> Vec<RoleBodyOp> {
 
 fn classify_role_body_stmt(stmt: &Stmt) -> RoleBodyOp {
     match stmt {
-        Stmt::HasDecl { name, .. } => RoleBodyOp::Attr { name: *name },
+        Stmt::HasDecl { name, .. } => RoleBodyOp::Attr {
+            name: *name,
+            raw: Box::new(stmt.clone()),
+        },
         Stmt::MethodDecl { .. } => RoleBodyOp::Method,
         Stmt::DoesDecl { .. } => RoleBodyOp::Parent,
         _ => RoleBodyOp::Deferred {
@@ -3089,8 +3100,6 @@ pub(crate) struct CompiledRoleDeclPlan {
     pub(crate) type_param_defs: Vec<ParamDef>,
     pub(crate) is_export: bool,
     pub(crate) export_tags: Vec<String>,
-    /// Compatibility payload for the role-composition registry walker.
-    pub(crate) legacy_body: Vec<Stmt>,
     pub(crate) is_rw: bool,
     pub(crate) language_version: String,
     pub(crate) custom_traits: Vec<(String, Option<DeclTraitArg>)>,
@@ -3137,10 +3146,8 @@ pub(crate) struct CompiledRoleDeclPlan {
     /// [`RoleParentOp`].
     pub(crate) parent_ops: Vec<RoleParentOp>,
     /// Ordered, typed mirror of the (single-level flattened) role body
-    /// (ADR-0019 D7-4), one op per statement `walk_role_body`'s dispatch
-    /// loop visits. Purely additive — no non-test consumer reads this field
-    /// yet. See [`RoleBodyOp`].
-    #[allow(dead_code)]
+    /// (ADR-0019 D7-4), one op per statement — the sole driver of
+    /// `walk_role_body`'s dispatch loop since D9. See [`RoleBodyOp`].
     pub(crate) body_plan: Vec<RoleBodyOp>,
     /// Precompiled per-statement chunk for each deferred (non-attribute,
     /// non-method, non-`does`) statement in the role body (ADR-0019 D8-1),
@@ -6462,7 +6469,6 @@ impl CompiledCode {
             type_param_defs: type_param_defs.clone(),
             is_export: *is_export,
             export_tags: export_tags.clone(),
-            legacy_body: body.clone(),
             is_rw: *is_rw,
             language_version: language_version.clone(),
             custom_traits: zip_decl_trait_args(custom_traits, trait_args),

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -311,7 +311,7 @@ impl Interpreter {
         name: &str,
         type_params: &[String],
         type_param_defs: &[ParamDef],
-        body: &[Stmt],
+        body_plan: &[crate::opcode::RoleBodyOp],
         role_is_rw: bool,
         language_version: &str,
         own_attribute_names: &[Symbol],
@@ -392,7 +392,7 @@ impl Interpreter {
             parent_op_idx: 0,
             compiled_fns,
         };
-        self.walk_role_body(body, &mut cx)?;
+        self.walk_role_body(body_plan, &mut cx)?;
         self.finish_role_registration(
             name,
             type_params,

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -118,22 +118,20 @@ impl Interpreter {
         prev_parents
     }
 
-    /// Walk the (flattened) role body, dispatching each statement through the
-    /// per-statement arms. Declared attributes, used modules, and
-    /// body-declared types are precomputed by the compiler (ADR-0019 D2a)
-    /// and already populate `cx` by the time this runs.
+    /// Walk the role body, dispatching each op through the per-statement
+    /// arms. Declared attributes, used modules, and body-declared types are
+    /// precomputed by the compiler (ADR-0019 D2a) and already populate `cx`
+    /// by the time this runs.
+    ///
+    /// `body_plan` (ADR-0019 D7-4/D9) is the sole driver of this walk — it
+    /// is already single-level `SyntheticBlock`-flattened and classified by
+    /// the compiler (`crate::opcode::role_body_plan`), so there is no
+    /// runtime-side flatten to redo.
     pub(super) fn walk_role_body(
         &mut self,
-        body: &[Stmt],
+        body_plan: &[crate::opcode::RoleBodyOp],
         cx: &mut RoleDeclCx<'_>,
     ) -> Result<(), RuntimeError> {
-        let flattened_body: Vec<&Stmt> = body
-            .iter()
-            .flat_map(|s| match s {
-                Stmt::SyntheticBlock(inner) => inner.iter().collect::<Vec<_>>(),
-                other => vec![other],
-            })
-            .collect();
         // Attribute names, `use`d/`need`ed module names, and body-declared
         // types are precomputed by the compiler at plan lowering (ADR-0019
         // D2a) and already populate `cx.role_own_attrs`/`body_used_modules`/
@@ -149,33 +147,32 @@ impl Interpreter {
         // while the role's method signatures are validated, so the
         // precomputed names are accepted as parameter/attribute constraints;
         // the real registration happens when the role body runs below.
-        for stmt in flattened_body {
-            match stmt {
-                Stmt::HasDecl { .. } => {
-                    self.role_body_has_decl(cx, stmt)?;
+        for op in body_plan {
+            match op {
+                crate::opcode::RoleBodyOp::Attr { raw, .. } => {
+                    self.role_body_has_decl(cx, raw)?;
                 }
-                Stmt::DoesDecl { .. } => {
+                crate::opcode::RoleBodyOp::Parent => {
                     self.role_body_does_decl(cx)?;
                 }
-                Stmt::MethodDecl { .. } => {
+                crate::opcode::RoleBodyOp::Method => {
                     self.role_body_method_decl(cx)?;
                 }
-                Stmt::Expr(Expr::Call { name, .. })
-                    if name == "__mutsu_stub_die" || name == "__mutsu_stub_warn" =>
-                {
-                    cx.role_def.is_stub_role = true;
-                }
-                Stmt::SetLine(_) => {
-                    // Skip source line annotations
-                }
-                _ => {
-                    // Every other statement (non-method/non-attribute/non-`does`) is
-                    // deferred to composition time, so role methods can be called
-                    // from within the role block body (e.g. `role R { method foo {};
+                crate::opcode::RoleBodyOp::Deferred { raw } => {
+                    if let Stmt::Expr(Expr::Call { name, .. }) = raw.as_ref()
+                        && (name == "__mutsu_stub_die" || name == "__mutsu_stub_warn")
+                    {
+                        cx.role_def.is_stub_role = true;
+                    }
+                    // Every other statement (non-method/non-attribute/non-`does`,
+                    // including `SetLine` source-line markers) is deferred to
+                    // composition time, so role methods can be called from
+                    // within the role block body (e.g. `role R { method foo {};
                     // R.foo }`) and, for a parameterized role, so it can be
                     // re-evaluated with concrete type bindings. The compiler's
-                    // `deferred_body_ops` (ADR-0019 D8-1/D8-2) already covers running
-                    // it at every composition site — nothing to record here.
+                    // `deferred_body_ops` (ADR-0019 D8-1/D8-2) already covers
+                    // running it at every composition site — nothing to record
+                    // here.
                 }
             }
         }

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -622,7 +622,6 @@ impl Interpreter {
             type_param_defs,
             is_export,
             export_tags,
-            legacy_body: body,
             is_rw,
             language_version,
             custom_traits,
@@ -635,7 +634,7 @@ impl Interpreter {
             is_stub,
             our_scope_violation,
             parent_ops,
-            body_plan: _,
+            body_plan,
             deferred_body_ops,
         }) = code.role_decl_plans.get(idx as usize)
         {
@@ -660,7 +659,7 @@ impl Interpreter {
                     &qualified_name,
                     type_params,
                     type_param_defs,
-                    body,
+                    body_plan,
                     *is_rw,
                     language_version,
                     own_attribute_names,

--- a/todo/tickets/role-our-scoped-attribute-not-rejected.md
+++ b/todo/tickets/role-our-scoped-attribute-not-rejected.md
@@ -1,0 +1,56 @@
+# `our $.attr` inside a role body is not rejected (X::Declaration::OurScopeInRole)
+
+Discovered incidentally while verifying ADR-0019 D9 (dropping
+`CompiledRoleDeclPlan::legacy_body`) — unrelated to that change, a
+pre-existing divergence.
+
+Real Raku rejects an `our`-scoped declaration inside a role body at compile
+time:
+
+```
+role R {
+    our $.shared = "our-attr";
+}
+```
+
+```
+===SORRY!=== Error while compiling ...
+Cannot declare our-scoped variable inside of a role
+(the scope inside of a role is generic, so there is no unambiguous
+package to install the symbol in)
+at ...:2
+------>     our $.shared<HERE> = "our-attr";
+```
+
+mutsu accepts it and treats it as a role-level (class-level-on-composition)
+attribute instead of raising `X::Declaration::OurScopeInRole`, e.g.:
+
+```
+role R {
+    our $.shared = "our-attr";
+}
+class A does R {}
+say A.shared;   # mutsu prints "our-attr"; raku never gets here
+```
+
+`register_role_decl`/`walk_role_body` already has an `our_scope_violation`
+mechanism (ADR-0019 D7-1/D9-1, `CompiledRoleDeclPlan::our_scope_violation`,
+`role_body_our_scope_violation`) that correctly rejects `our sub`, `our
+class`, etc. inside a role — see `check_role_body_our_scoped_decls`/
+`role_body_our_scope_violation` in `src/opcode.rs` and
+`src/runtime/registration_role_decl.rs`. It just does not currently flag an
+`our`-scoped `has` (attribute) declaration the same way. `class_body_has_decl`
+/`role_body_has_decl` (`src/runtime/registration_role_body.rs`) both treat
+`decl.is_our || decl.is_my` as a valid class-level-attribute form without
+checking `is_our` against the role-specific restriction.
+
+Fix likely belongs in whatever builds `our_scope_violation` at plan-lowering
+time (`role_body_our_scope_violation` in `src/opcode.rs`) — it should also
+scan for `Stmt::HasDecl { is_our: true, .. }` at the top level of the role
+body, the same way it presumably already scans for `our sub`/`our class`.
+Needs a `raku`-verified case table before implementing (per this repo's
+"measure before naming the fix" convention) — in particular, confirm
+whether `my $.attr` (accepted by both raku and mutsu today) is the only
+non-rejected class-level-attribute form inside a role, and whether the
+rejection message/exception type is exactly `X::Declaration::OurScopeInRole`
+for the attribute case too.


### PR DESCRIPTION
## Summary
- `walk_role_body` now iterates the compiler-precomputed `body_plan: &[RoleBodyOp]` directly instead of a raw, separately-stored `Vec<Stmt>` — the role-side twin of D6-4's class-body change.
- `RoleBodyOp::Attr` gained a `raw: Box<Stmt>` field (boxed, matching `Deferred`'s existing boxing rationale to avoid `clippy::large_enum_variant`) so `role_body_has_decl`'s existing fallback for a role-level `my`-scoped attribute still has a raw statement to read.
- `RoleBodyOp::Deferred`'s existing `raw` already covered the walk's other two raw-statement uses (stub-marker detection, `SetLine`/everything-else no-op).
- `CompiledRoleDeclPlan::legacy_body`, its one construction site, and `register_role_decl`'s now-unused `body: &[Stmt]` parameter are deleted.
- Closes ADR-0019's D9 box.
- Also files `todo/tickets/role-our-scoped-attribute-not-rejected.md` — a pre-existing, unrelated divergence found during verification (mutsu accepts `our $.x` inside a role body instead of raising raku's `X::Declaration::OurScopeInRole`). Not fixed here — out of scope for this structural slice.

## Test plan
- [x] `cargo build`, `cargo test --lib` (701 tests)
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] `make test` — 28,087 tests, all pass
- [x] `MUTSU_FUDGE=1 prove` on `roast/S12-class`, `roast/S12-construction`, `roast/S14-roles`, `roast/S05-grammar` (release binary) — 957 tests, only the pre-existing non-whitelisted `S12-class/open_closed.t` failure
- [x] `scripts/battery-testsuite.sh` — 158/164 files pass (2 excluded), byte-identical to baseline
- [x] Hand comparison against `raku` exercising every `RoleBodyOp` variant in one role composed onto a class (attribute with a `my`-scoped sibling to force the fallback path, nested `does`, method, nested `my class`) — byte-identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)