### PR TITLE
docs: ADR-0022 LTM alternation ranking design + 16 Cro-cluster diagnosis tickets

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -118,7 +118,7 @@ noted.
 | No oracle | `S02-names/pseudo-6d.t` | aborts at 116/159 | SORRY (`::=` NYI) | `::("CALLER")::<$*bar>` CALLER pseudo-package deref unsupported. Even on v2026.06 rakudo SORRYs because `::=` binding is unimplemented |
 | No oracle | `S02-names/pseudo-6e.t` | aborts at 79/202 | SORRY (`$?` constant twigil NYI) | Same as above (the 6.e version). Still SORRY on v2026.06 |
 | No oracle | `S02-names-vars/names.t` | 144/156, notok 3 | SORRY (unfudged line) | test 142 "Null PMC access when printing a var typed as ::foo" edge. raku SORRYs on a fudge-dependent line (a bare `$`) |
-| No oracle | `S05-metasyntax/longest-alternative.t` | 57/62, notok 5 | SORRY (`::` LTM stopper NYI) | LTM (longest-token-match) tie-break edge. Still SORRY on v2026.06 because rakudo has not implemented `::` |
+| No oracle | `S05-metasyntax/longest-alternative.t` | 59/62, notok 3 (28/50/54) | SORRY (`::` LTM stopper NYI) | Remaining 3 all need declarative-prefix LTM ranking — design complete in ADR-0022 (`docs/adr/0022-regex-alternation-ltm-ranking.md`): 28 = `<.ws>` prefix stopper, 50 = non-constant interpolation (ADR Slice 5), 54 = `\|\|` first-branch-only. Line 461 (negative lookahead) is `#?rakudo todo` upstream. Still SORRY on v2026.06 because rakudo has not implemented `::` |
 | No oracle | `S10-packages/basic.t` | 59/83, notok 9 | 6/83 (mutsu ahead; same on v2026.06) | Error-detection edges for the semicolon form of package declarations |
 | No oracle | `S12-attributes/trusts.t` | 9/15, notok 4-9 | SORRY (forward reference `trusts B`) | Cross-class private access via `trusts` unsupported. Still SORRY on v2026.06. Failing set shifted 2026-07-15 (private-attr wrong-class throw): tests 4-9 read `$!an_A` which class B never declares (throws now, matching rakudo semantics — likely a typo for the lexical `$an_A` in the test), while the class-C "untrusted access dies" tests now pass |
 | No oracle | `S19-command-line-options/01-dash-uppercase-i.t` | 0/8 | 0/8 (`$*OS` unsupported; same on v2026.06) | `-I` + `@*INC` + `$*OS` introspection (is_run subprocess) |
@@ -157,15 +157,17 @@ completed fix history lives in `news/`.
   test 52: the `<$subrule>` block compiles a string containing a `{...}` code block as a regex
   → "Prohibited regex interpolation" (X::SecurityPolicy); real raku dies at the same point
   (no MONKEY-SEE-NO-EVAL). Later blocks additionally need `<*literal>` partial-match support.
-- **`S05-metasyntax/longest-alternative.t`** — the remaining failures all require a proper LTM
-  *fate / declarative-prefix* model (mutsu's `|` picks the longest *actual* match): a
-  non-constant interpolated alternative must NOT count toward LTM (a constant `$x` does — needs
-  compile-time-constant tracking through interpolation); inside `|`, a sequential `||` group
-  contributes only its FIRST branch; a `rule`'s implicit `<.ws>` is non-declarative and stops the
-  prefix; negative lookahead (`#?rakudo todo` upstream); `IETF::RFC_Grammar::URI` fails to parse
-  — combined character-class subrule syntax (`<+unreserved +sub_delims>`,
-  `<[\-+.] +uri_alpha +digit>*`) not fully supported; Gproto proto-token subrule capture
-  `$m<foo>` comes back empty.
+- **`S05-metasyntax/longest-alternative.t`** — down to 3 failures (28/50/54; the
+  IETF::RFC_Grammar and Gproto blocks pass now). All three require the declarative-prefix
+  LTM ranking model, fully designed in **ADR-0022**
+  (`docs/adr/0022-regex-alternation-ltm-ranking.md`, with a raku-validated acceptance
+  matrix): mutsu's `|` currently ranks by longest *actual* match with declaration-order
+  ties, rakudo ranks by longest *declarative prefix* with longest-literal (litlen) ties.
+  Test 28 = a `rule`'s implicit `<.ws>` stops the prefix; test 50 = a non-constant
+  interpolated alternative must not count toward LTM (ADR Slice 5); test 54 = a `||`
+  group contributes only its first branch (plus a zero-width bypass). Negative lookahead
+  (line 461) is `#?rakudo todo` upstream — mutsu matches rakudo. The same ranking gap is
+  the last failure in Cro::HTTP `t/http-router.rakutest` (test 61).
 - **`S06-advanced/caller.t`** — unpassable on the plan count alone: `plan 22` but only 19
   assertions exist (the trailing "WRITEME: label tests" were never written). The 4 failing
   assertions are **stale old-Rakudo expectations that mutsu correctly diverges from** — do NOT

--- a/docs/adr/0022-regex-alternation-ltm-ranking.md
+++ b/docs/adr/0022-regex-alternation-ltm-ranking.md
@@ -1,0 +1,436 @@
+# ADR-0022: `|` alternation ranks branches by declarative-prefix LTM, not by longest actual match
+
+- **Status**: Proposed (2026-08-09). Design complete; implementation not started.
+- **Context**: `todo/deep/regex-alternation-ltm-longest-literal-prefix.md`;
+  `Cro::HTTP` `t/http-router.rakutest` test 61 (the file's last remaining failure);
+  `roast/S05-metasyntax/longest-alternative.t` tests 28/50/54 (the file's only failures,
+  62-test file — the BLOCKERS.md "57/62" row is stale).
+  Builds directly on ADR-0009's `LTM_DECLARATIVE_MODE` machinery.
+- **Scope**: semantics of `|` branch *ranking* in the regex engine. Protoregex dispatch
+  already ranks by declarative prefix (ADR-0009, `dispatch.rs::eval_token_call_values_at`)
+  and is NOT changed here; interpolated-`@array` alternation already approximates LTM by
+  length-sorting and is not changed here.
+
+## 1. Problem
+
+mutsu's `RegexAtom::Alternation` ranks branches by **longest actual (full-branch) match,
+ties broken by declaration order**. Rakudo ranks by **longest declarative-prefix match,
+ties broken by longest-literal (litlen), then declaration order**. Three observable
+divergence classes:
+
+1. **Tie + litlen** (the Cro bug):
+   ```raku
+   "/category/tree" ~~ / "/category/" (\w+) | "/category/tree" /;
+   say $0.defined ?? "capture-branch" !! "literal-branch";
+   # raku: literal-branch    mutsu: capture-branch
+   ```
+   Both branches match 14 chars; rakudo breaks the tie toward the branch whose match
+   crossed more *leading literal* characters (14 vs 10).
+2. **Prefix, not full length** (roast test 28): a branch whose *declarative prefix* is
+   shorter must lose even when its *full* match is longer.
+   ```raku
+   my rule  ltm_ws1 {\w+ '-'+}    # implicit <.ws> ends the prefix after \w+ (len 3)
+   my token ltm_ws2 {\w+ '-'}     # fully declarative (len 4)
+   'abc---' ~~ /<ltm_ws1> | <ltm_ws2>/   # raku picks ltm_ws2 ('abc-'), mutsu ltm_ws1 ('abc---')
+   ```
+3. **`||` contributes only its first branch** (roast test 54):
+   ```raku
+   'food' ~~ / 'foo' | ['doof' || 'food'] /   # raku: 'foo'   mutsu: 'food'
+   ```
+
+Two adjacent engine gaps surfaced during this investigation and are folded in:
+
+4. **No backtracking into shorter ends of the chosen branch** (the `Alternation` arm of
+   `regex_match_atom_all_with_capture_in_pkg` collects ONE end per branch):
+   ```raku
+   "aaab" ~~ / [ a+ | q ] ab /   # raku: "aaab"   mutsu: no match
+   ```
+5. **Losing branches' plain `{ }` code blocks run** (candidate collection matches every
+   branch fully, side effects included):
+   ```raku
+   my @ran; "abc" ~~ / 'ab' { @ran.push('b1') } x | 'abc' { @ran.push('b2') } /;
+   # raku: @ran == ['b2']   mutsu: ['b1','b2']
+   ```
+   (#4 is fixed by this ADR's Slice 3. #5 is documented as a known gap with a sketched
+   follow-up — see §6.)
+
+## 2. Rakudo semantics, validated
+
+Sources: black-box probe matrix run against rakudo v2026.06 (§7 acceptance matrix), and a
+direct reading of `nqp/src/QRegex/NFA.nqp` (the NFA construction that *defines* LTM).
+Key mechanics of the reference implementation:
+
+- Each `|` branch gets a **declarative-prefix NFA**. At an alternation point the engine
+  runs the combined NFA once and obtains, per branch (fate): the **longest prefix match
+  length** and a **litlen** (see below). Branch attempt order = length desc, litlen desc,
+  fate/declaration order asc. The winning branch is then matched *procedurally*; on
+  failure (or later outer failure) the next-ranked branch is tried.
+- **litlen** ("longest literal"): literal atoms emit `EDGE_CODEPOINT_LL` edges only while
+  the build-time flag `$!LITEND == 0`; `regex_nfa` sets `LITEND := 1` for every node type
+  except `literal`, `concat`, `alt` (NFA.nqp line ~174). So litlen counts the leading run
+  of literal characters, where:
+  - concatenation of adjacent literals extends it;
+  - a nested `|` whose branches are all pure-literal extends it (per-branch, i.e. the
+    litlen of whichever nested literal matched); any non-literal branch ends it at the
+    recombination point (`method alt`, "stop litlen at recombination unless all alts are
+    pure literal");
+  - a **capture group `( … )` / `$<x>=[ … ]` ends litlen** (rxtype `subcapture` is not in
+    the exempt set) **but is transparent for prefix *length*** (`method subcapture`
+    descends);
+  - **quantifiers end litlen** but participate fully in prefix length (loops/unrolling in
+    `method quant`);
+  - a **subrule call inlines the callee's own NFA including the callee's own `_LL`
+    marks**, so literals leading the callee's body extend litlen (validated: `\w+ | <abb>`
+    → the literal-bodied token wins the length tie).
+- **Prefix construction rules** (what ends/extends the declarative prefix):
+
+  | construct | prefix effect | validated by |
+  |---|---|---|
+  | literal, char class, `.`, ranges | consume, extend | probes 1–6 |
+  | `( … )`, `$<x>=[ … ]`, `[ … ]` | transparent (descend); capture kills litlen | C, D, E, F |
+  | quantifiers `* + ? ** n..m` (+ `%` separators) | loop/unroll, extend; kill litlen | G, 10, roast `<?> \| 'a' ** 1..2 'b'` |
+  | `** {code}` | terminate | M |
+  | nested `\|` | all branches participate | 9, K2 |
+  | `X \|\| Y` | first branch **plus a zero-width ε-bypass** (NFA.nqp `method altseq`: builds child 0, then an ε from entry to exit) | 15, 16, roast 54 |
+  | subrule call (token/rule/named) | inline callee NFA, cycle-guarded per name (`%seen` in `mergesubrule`); recursion cut = that call ends the path | 11, 28-probe, roast LTM-in-tokens tests |
+  | `<.ws>` / `ws` (implicit sigspace or explicit, incl. method form) | **terminate** (NFA.nqp `subrule` special-cases `ws` → fate) | 18, roast 28 |
+  | `<?before X>` (positive) | inline X, then terminate | 14 (with B) |
+  | `<!before X>`, `<?after>`/`<!after>`, other negated zero-width | terminate (zero-width) | H (matches rakudo's own `#?rakudo todo` on roast line 461) |
+  | plain `{ … }` block | terminate | A, ADR-0009 |
+  | `<?{ … }>` / `<!{ … }>` | ε — transparent, keep measuring, never execute | B, ADR-0009 |
+  | anchors `^ $ ^^ $$ << >>` | ε (transparent) | NFA.nqp `method anchor` |
+  | backreference `$0` / `$<name>` | terminate | 22 |
+  | non-constant `$var` interpolation | terminate (constants participate — inlined as literals at compile time) | 20/20c, roast 50 |
+  | conjunction `&` | terminate (no NFA method → fate) | — |
+
+- After ranking, **only the attempted branch runs procedurally** (side effects, captures);
+  on its failure — including failure of what *follows* the alternation — the engine falls
+  back to the next-ranked branch (roast: "sequential alternation first branch failure
+  after LTM tries next best option"), and to *shorter ends within the same branch* first
+  (probe I2: `"aaab" ~~ / [ a+ | q ] ab /` → `aaab`).
+
+**Deliberate non-goals / accepted divergences from rakudo quirks:**
+
+- No NFA construction. We measure prefixes with the existing backtracking matcher under
+  `LTM_DECLARATIVE_MODE` (ADR-0009). Equivalent for ranking purposes: for declarative
+  constructs, "max over all procedural match ends" = NFA longest match. A real token-NFA
+  is a possible later perf project (§6), not correctness.
+- litlen inside a **quantified subrule** counts in rakudo (merged `_LL` edges survive
+  quantifier unrolling: `(\w+) | <tj> ** 2 x` picks the subrule branch) while a directly
+  quantified literal does not (`(\w+) | 'ab' ** 2` picks the first branch). mutsu
+  implements the simple rule — quantifiers always end the litlen chain, including around
+  subrules. No roast test pins the quirk.
+- `:m` (ignoremark) literals: rakudo has no `_M_LL` edge (XXX comments in NFA.nqp), so
+  they never extend litlen. mutsu may treat them like `:i` literals (which do, via
+  `_I_LL`); no test pins the difference.
+
+## 3. Current mutsu structure (what has to change)
+
+Alternation is consumed via three code paths; all rank by longest end:
+
+1. **Plural/backtracking path**: `regex_match_atom_all_with_capture_in_pkg`
+   (`src/runtime/regex/regex_match_atom.rs:90`). Per branch, ONE end via the singular
+   `regex_match_end_from_caps_in_pkg`, then
+   `indexed.sort_by(|a,b| a.1.cmp(&b.1).then(b.0.cmp(&a.0)))` — end asc, index desc,
+   returned lowest-priority-first (the engine's LIFO pops from the back). Consumers:
+   `regex_match_core.rs` walk (`walk_tokens` candidate loops at ~505/556/1028),
+   `regex_match_sep.rs`, `regex_match_capture.rs:135/574`.
+2. **Singular path**: the `Alternation` arm of `regex_match_atom_with_capture_in_pkg`
+   (`src/runtime/regex/regex_match_capture.rs:100`) — "longest end wins, first-declared
+   on tie". Consumer: quantifier iteration growth (`grow_one_iter`,
+   `regex_match_core.rs:831`), i.e. `[a|b]+` iterations.
+3. **No-capture probe**: the `Alternation` arm of `regex_match_atom_in_pkg`
+   (`src/runtime/regex/regex_match_atom_simple.rs:193`) — longest end.
+
+Existing machinery to build on (ADR-0009):
+
+- `LTM_DECLARATIVE_MODE` / `LTM_PREFIX_TERMINATED` thread-locals
+  (`regex_helpers.rs:24/28`), honored today only by the `CodeAssertion` arm
+  (`regex_match_capture.rs:253`: assertion → zero-width pass; plain block → set
+  TERMINATED) and by `walk_tokens`'s unwind check (`regex_match_core.rs:457`).
+- `declarative_prefix_match_len(&mut self, pattern: &str, text: &str) -> (Option<usize>, bool)`
+  (`regex_resolve.rs:139`) — string-based, start-anchored; used by protoregex dispatch.
+- Subrule parse/candidate memoization (`parsed_subrule_candidates`, PARSED_TOKEN_CANDIDATES).
+
+Important context for the implementer: the sort-visible tie today is *accidentally
+passing* roast's "LTM - literal wins tie against `\w*`" (test 21) in-file while the same
+construct fails as a one-liner — do not trust the current green; after this change it
+must pass for the right reason (litlen through subrule descent).
+
+## 4. Decision
+
+Rank `|` branches at match time by the triple
+
+```
+(prefix_len desc, litlen desc, declaration index asc)
+```
+
+where both `prefix_len` and `litlen` are measured against the actual input at the current
+position, using the existing matcher under an *extended* `LTM_DECLARATIVE_MODE` — no NFA.
+Then produce backtracking candidates per branch with the **plural** ends enumeration,
+ordered branch-major by rank.
+
+### 4.1 New measurement API (Slice 1)
+
+`src/runtime/regex/regex_ltm_rank.rs` (new file), `impl Interpreter`:
+
+```rust
+/// Longest declarative-prefix match of `pattern` at `pos`, plus whether the
+/// measurement was cut short by a non-declarative atom (=> cannot be used to
+/// filter the branch out). Runs the ordinary ends-enumeration matcher under
+/// LTM_DECLARATIVE_MODE; never executes user code (ADR-0009 discipline).
+pub(crate) fn ltm_prefix_len_at(
+    &mut self,
+    pattern: &RegexPattern,
+    chars: &[char],
+    pos: usize,
+    pkg: &str,
+) -> (Option<usize>, bool)
+```
+
+Implementation: save/replace the two thread-local flags exactly as
+`declarative_prefix_match_len` does (they must nest — a measurement can occur inside a
+real match inside another measurement), call
+`regex_match_ends_from_caps_in_pkg(pattern, chars, pos, pkg)`, take the **max** end,
+subtract `pos`. Keep the string-based `declarative_prefix_match_len` for the proto path
+(or reroute it through this later — not required).
+
+### 4.2 Extend LTM_DECLARATIVE_MODE semantics (Slice 1)
+
+Today only code atoms are neutralized; the prefix table in §2 needs the other stoppers.
+Add mode-guarded early behavior for these atoms — in **both** capture-bearing atom
+matchers (`regex_match_atom_all_with_capture_in_pkg` and
+`regex_match_atom_with_capture_in_pkg`) and the no-capture prober
+(`regex_match_atom_in_pkg`), via one shared helper so the three stay in sync:
+
+```rust
+/// In LTM declarative mode, how this atom participates in prefix measurement.
+enum LtmAtomMode { Normal, Terminate, TerminateAfter(&RegexPattern) /* positive lookahead */ }
+fn ltm_atom_mode(atom: &RegexAtom) -> LtmAtomMode
+```
+
+- `Terminate` (zero-width success + set `LTM_PREFIX_TERMINATED`, so `walk_tokens`
+  unwinds and the length measured so far stands): `WsRule`; `Named` naming `ws` in
+  any lookup form — reuse the normalization in `named_lookup_is_ws`
+  (`regex_parse_core.rs:401`, strips `.`/`&` prefixes; verified: sigspace inserts
+  `WsRule`, explicit `<.ws>`/`<ws>` arrive as `Named`);
+  `Backref` / `NamedBackref`; `VarInterp`; `ClosureInterpolation`; `Conjunction`;
+  `RegexQuant::RepeatCode` (token-level check, since the quant sits on the token, not
+  the atom); negated or behind `Lookaround`; `CodeAssertion { is_assertion: false }`
+  (already done).
+- `TerminateAfter(inner)`: positive ahead `Lookaround` — measure `inner`'s ends from
+  `pos` as consuming, then terminate.
+- `CodeAssertion { is_assertion: true }`: zero-width pass without executing (already done).
+- `SequentialAlternation` in mode: candidates = ends(first branch) ∪ {pos} (the ε-bypass),
+  and it does NOT set TERMINATED by itself (the ε keeps the measurement alive past the
+  group). This cannot cause a false *filter*: with the ε the group can never be the sole
+  reason a fully-declarative measurement returns None.
+
+Anchors, groups, capture groups, quantifiers, char classes, nested `|`: already correct
+via normal matching (transparent / consuming). Note `^`/`$` atoms match normally in
+measurement — measurement starts at the real current `pos` on the real subject, so
+anchors evaluate exactly as in the real match.
+
+The `LTM_PREFIX_TERMINATED` flag today means "stopped at a *code* atom" to its one
+caller; after this slice it means "stopped at any non-declarative atom". Keep the
+ADR-0009 contract: **a terminated measurement can order but never filter**
+(`(None, true)` ⇒ keep the branch, ranked at prefix length measured so far / 0).
+
+### 4.3 litlen chain (Slice 2)
+
+Same new file:
+
+```rust
+/// Length of the leading-literal match of `pattern` at `pos`: how many input
+/// chars are consumed by the longest path through the pattern's leading
+/// literal region (per §2: concat of literals; nested alternation branches that
+/// are themselves pure leading-literal, taking the matched branch's length;
+/// non-capturing groups descend; subrule calls descend into the callee's own
+/// leading literal region, cycle-guarded; capture groups, quantifiers, char
+/// classes, and every other construct end the region).
+fn ltm_litlen_at(&mut self, pattern: &RegexPattern, chars: &[char], pos: usize,
+                 pkg: &str, seen: &mut HashSet<String>, depth: usize) -> usize
+```
+
+This is a direct char-comparison walk (respect `ignore_case` on comparison; `ignore_mark`
+literals may either count or not — see §2 non-goals), NOT a matcher run. Token loop from
+the front: `RegexAtom::Literal(c)` with `RegexQuant::One`, no separator, no
+capture aliases on the token → compare with `chars[pos + acc]`, mismatch ⇒ **return 0
+for the whole chain? No** — mismatch means this literal path does not match here; return
+`acc`… — careful: rakudo's litlen is the literal length *along the run that achieved the
+prefix match*. If a leading literal fails to match the input, the branch's prefix match
+(4.1) either failed too (fully-literal head) or matched via another nested-alt path. Rule:
+on mismatch inside a nested alternation, that nested branch contributes nothing and the
+max over the other nested branches is used; on mismatch in the top-level chain, the chain
+value is what matched so far only if the overall prefix measurement also stopped there —
+in practice return `acc` at first mismatch; the ranking only ever consults litlen between
+branches whose `prefix_len` already tied, which bounds any imprecision to genuinely
+ambiguous quirk territory.
+`Group(p)` → descend (continue chain only if the group consumed its entire own chain —
+i.e. the group's contribution ended exactly at a group boundary with no non-literal left
+before its end; simplest faithful rule: descend into `p` recursively; if `p`'s chain walk
+reached `p`'s end without hitting a region-ender, continue the outer chain, else stop
+after adding the inner contribution).
+`Alternation(alts)` → recursively evaluate each branch's chain; if every branch is
+pure-literal-to-its-end, contribution = the longest branch value that actually matched
+the input here, and the chain continues; otherwise contribution = best matching branch
+value and the chain stops (mirrors `method alt`'s litendback rule).
+`Named(name)` → resolve via the existing memoized subrule machinery
+(`parsed_subrule_candidates`); descend into the callee pattern with `seen` guarding
+recursion (on cycle: stop chain) and `depth` capped (e.g. 16). Multiple candidates
+(proto): max over candidates.
+Everything else → stop.
+
+### 4.4 Apply ranking in the three consumers (Slice 3)
+
+**(a) `regex_match_atom_all_with_capture_in_pkg` Alternation arm** — the main change:
+
+```text
+for (i, alt) in alternatives:                      # keep pure-code-block deferral as-is
+    (plen, stopped) = ltm_prefix_len_at(alt, chars, pos, pkg)
+    if plen is None and !stopped: skip branch      # fully-declarative non-match (sound filter)
+    rank_key = (plen.unwrap_or(0), ltm_litlen_at(...), i)
+    ends = regex_match_ends_from_caps_in_pkg(alt, chars, pos, pkg)   # PLURAL (fixes gap #4)
+    …collect (rank_key, ends)
+sort branches by (plen desc, litlen desc, i asc)
+emit LIFO lowest-priority-first: for branch in reverse-rank order:
+    for (end, caps) in branch.ends (already highest-priority-first) → reversed
+    → push, so the top of the stack is the best branch's most-preferred end,
+      then its shorter ends, then the next branch — matching rakudo's
+      "backtrack within the chosen branch before falling to the next fate".
+```
+
+Fully-declarative fast path (perf): if a cheap recursive scan finds no stopper anywhere
+in the branch (`branch_is_fully_declarative(alt)` — a pure tree walk, no matching), then
+`prefix_len = max end of the full ends enumeration` — reuse `ends`, zero extra matcher
+work. Only stopper-bearing branches pay a second (prefix) run. The scan itself is
+O(pattern size) per call; if profiling shows it hot, memoize per `Arc<RegexPattern>`
+identity later — do not add a raw-pointer cache (ParseMemo lesson, PR #6132).
+
+Dedup: today's arm dedups implicitly by sort; keep candidates with equal `end` from
+*different* branches distinct only if their capture deltas differ — simplest correct
+behavior: keep the current no-dedup (all candidates flow; the engine already tolerates
+duplicates elsewhere, cf. the CaptureGroup arm's dedup comment) but preserve order.
+
+**(b) singular arm** (`regex_match_capture.rs:100`): compute the same per-branch rank,
+pick the best-ranked branch that matches, return its greedy end (replace the
+`next > best_next` longest-end rule).
+
+**(c) no-capture arm** (`regex_match_atom_simple.rs:193`): same selection; return the
+chosen branch's greedy end. (This changes observable *ends* for shapes like problem #2
+even in probe contexts — intended.)
+
+`SequentialAlternation` runtime arms stay untouched (already declaration-ordered).
+
+### 4.5 Re-entrancy and threads
+
+The measurement flags are thread-locals with save/restore; 4.1 must follow the same
+discipline. The measurement itself calls back into the full matcher (subrules, closures
+are NOT executed in mode — verify `ClosureInterpolation` terminates rather than
+evaluates). No new global state; no cross-thread anything.
+
+## 5. Implementation slices (each a PR; order matters)
+
+1. **Slice 1 — mode extension + `ltm_prefix_len_at`** (`regex_ltm_rank.rs`,
+   `ltm_atom_mode` guards in the three atom matchers). Pin: extend
+   `t/regex-ltm-declarative-prefix.t` with ws/backref/lookahead/`||`-ε cases measured via
+   a proto-dispatch shape (the only current consumer), or unit-test the new API with
+   `#[test]` in the new module. No behavior change to `|` yet. Must stay green on
+   `S05-grammar/protoregex.t` (whitelisted).
+2. **Slice 2 — `ltm_litlen_at`** with `#[test]` unit coverage (literal chain, nested alt,
+   subrule descent, cycle guard, `:i`).
+3. **Slice 3 — ranking swap in the three arms + plural ends** (the semantic change).
+   Pin: new `t/regex-ltm-alternation.t` from the §7 matrix (raku-verified expectations).
+   Acceptance: `roast/S05-metasyntax/longest-alternative.t` 28 and 54 flip to ok
+   (50 needs Slice 5; line-461 negative-lookahead stays `#?rakudo todo` — mutsu matches
+   rakudo's current behavior); `Cro::HTTP` `t/http-router.rakutest` → 83/83
+   (run via `bash tmp/cro-suite-run.sh http`, single-instance rule). Watch for flips in:
+   whitelisted `S05-*` files, grammar-heavy roast (`S05-grammar/*`, `integration/*`),
+   and the JSON/YAML batteries suites (`scripts/battery-testsuite.sh`) — CI covers all;
+   fix forward.
+4. **Slice 4 — BLOCKERS.md + ledger update**: refresh the `longest-alternative.t` row
+   (currently stale), note remaining 50/461.
+5. **Slice 5 (optional, separate) — non-constant interpolation marking**: thread
+   interpolated-span info out of `interpolate_bound_regex_scalars`
+   (`regex_interpolate.rs:288` — today it returns only the substituted pattern String)
+   so the regex parser can flag tokens born from a runtime variable as non-declarative
+   (a `from_runtime_interpolation` bool on `RegexToken`), which `ltm_atom_mode` then
+   treats as Terminate. `constant`-declared values keep participating. Fixes roast
+   test 50; enables whitelisting `longest-alternative.t` (with 461 fudged upstream).
+   If span-threading proves too invasive, an acceptable interim is a per-pattern side
+   list of interpolated char ranges consulted at parse time — decide at implementation.
+
+Perf: iterate with the **debug** binary + `MUTSU_VM_STATS` where useful; wall-clock only
+on release; document nothing from local runs — after merge, read the bench CI
+(`git show origin/bench-data:bench-history.tsv`), expecting the regex-heavy rows
+(yaml-parse, grammar benches) to be the sensitive ones. The fully-declarative fast path
+in 4.4(a) is the guard: a branch with no stoppers pays only the (new) tree scan.
+
+## 6. Known gaps this ADR does NOT close
+
+- **Side effects of losing branches** (problem #5): fixing it means not fully matching
+  branches that lose the ranking until the engine actually attempts them — i.e. lazy
+  candidate production in the walk loop, an engine-shape change. Sketch: have the
+  Alternation arm return rank-ordered *branch descriptors* and let `walk_tokens`
+  materialize a branch's ends on first pop. Do it as its own ADR/slice if a real test
+  demands it; note that Slice 3 does not make this worse (it already runs today).
+- **A real token-NFA** for O(1)-ish ranking over many-branch alternations (the Cro
+  router compiles ~80 routes into one alternation, ranked per request): perf follow-up,
+  only if bench CI shows the measurement pass hot.
+- Rakudo quirk parity listed in §2 non-goals (quantified-subrule litlen, `:m` litlen).
+
+## 7. Acceptance matrix (raku v2026.06-verified; becomes `t/regex-ltm-alternation.t`)
+
+Each line: expression → expected winner/result (raku-verified 2026-08-09).
+
+```raku
+# ties broken by litlen
+"ab" ~~ / (\w\w) | 'ab' /                       # literal branch ($0 undefined)
+"ab" ~~ / 'ab' | (\w\w) /                       # literal branch
+"/category/tree" ~~ / "/category/" (\w+) | "/category/tree" /   # literal branch
+"abc" ~~ / 'a' (\w\w) | 'abc' /                 # literal branch (capture kills litlen)
+"abc" ~~ / 'a' \w\w | ('abc') /                 # FIRST branch (capture kills b2's litlen)
+"aab" ~~ / 'a' \w \w (<?>) | 'aa' \w /          # second branch (litlen 2 > 1)
+# capture groups transparent for length
+"/xy" ~~ / "/" \w | ("/xy") /                   # capture branch, matched "/xy"
+# groups/nested alternation extend litlen
+"/category/tree" ~~ / "/category/" (\w+) | "/category/" [ 'tree' ] /   # group branch
+"/c/tree" ~~ / "/c/" (\w+) | "/c/" [ 'tree' | 'x' ] /                  # nested-alt branch
+# quantifiers: length yes, litlen no
+"abab" ~~ / (\w+) | 'ab' ** 2 /                 # first branch (litlen tie 0-0, order)
+"aab" ~~ / 'a' | 'a' ** 1..2 'b' /              # second branch, matched "aab" (length 3)
+# subrule descent (length + litlen)
+my token abb { 'abb' }; "abb" ~~ / (\w+) | <abb> /       # <abb> wins ($<abb> defined)
+# code atoms
+"abcd" ~~ / 'ab' { ; } \w\w | 'abc' /           # 'abc' (block terminates prefix)
+"abcd" ~~ / 'ab' <?{ True }> \w\w | 'abc' /     # first branch, matched "abcd" (ε)
+# lookahead
+"abcd" ~~ / 'ab' <?before c> (\w\w) | 'abc' /   # 'abc' (litlen 3 beats 2 at length tie 3)
+"abcde" ~~ / ab <![e]> cde | ab.. /             # "abcd" (negated lookahead terminates)
+# sequential alternation inside |
+"food" ~~ / 'foo' | ['doof' || 'food'] /        # 'foo'
+"food" ~~ / 'foo' | ['food' || 'doof'] /        # 'food'
+# ws stopper
+my rule r {\w+ '-'+}; my token t {\w+ '-'}; "abc---" ~~ /<r>|<t>/   # <t>, "abc-"
+# fall to next best when the winner's tail fails
+"food" ~~ / (f\w+) x | 'foo' /                  # 'foo'
+# within-branch backtracking preserved across the alternation
+"aaab" ~~ / [ a+ | q ] ab /                     # "aaab"
+# ranking never overrides leftmost-position scan
+"xab" ~~ / 'ab' | b /                           # "ab" (position 1 beats position 2)
+# :i
+"AB" ~~ m:i/ (\w\w) | 'ab' /                    # literal branch
+# ratchet interaction unchanged (roast S05 486-489 already pass)
+'ab' ~~ / [ab | a ]: b /                        # Nil
+```
+
+## 8. Alternatives rejected
+
+- **Static branch reordering at parse time** (sort branches by static literal prefix):
+  cannot express input-dependent prefix lengths (`\w+` vs literal depends on the
+  subject); wrong on every "longer quantified atom wins" case.
+- **Keep longest-end ranking + litlen tie-break only**: fixes the Cro case but not
+  problem #2/#3 (prefix ≠ full length); roast 28/54 stay red.
+- **Full NFA now**: highest fidelity + best perf, but a large new engine component;
+  the matcher-under-mode measurement reuses ~everything and is behavior-equivalent for
+  ranking. NFA remains available as a follow-up optimization (§6).

--- a/todo/deep/regex-alternation-ltm-longest-literal-prefix.md
+++ b/todo/deep/regex-alternation-ltm-longest-literal-prefix.md
@@ -1,5 +1,19 @@
 # Regex alternation `|` picks the first matching branch, not the LTM-longest declarative prefix
 
+> **Design complete (2026-08-09): see ADR-0022**
+> (`docs/adr/0022-regex-alternation-ltm-ranking.md`) for the full validated
+> semantics, implementation slices, and acceptance matrix. Corrections found
+> during that investigation:
+> - mutsu's `|` is NOT plain first-match: all three engine paths rank by
+>   **longest actual full-branch match, ties broken by declaration order**. The
+>   Cro repro below is a length *tie* (14 vs 14) lost on the tie-break — rakudo
+>   breaks ties by longest-literal (litlen) first.
+> - `roast/S05-metasyntax/longest-alternative.t` is at **59/62** (fails 28, 50,
+>   54), not the 57/62 recorded in BLOCKERS.md.
+> - The engine also lacks backtracking into shorter ends of the chosen branch
+>   (`"aaab" ~~ / [ a+ | q ] ab /` fails; raku matches "aaab") — folded into
+>   ADR-0022 Slice 3.
+
 ## Symptom
 
 `Cro::HTTP` `t/http-router.rakutest` test 61 ("Two optional segments handled

--- a/todo/tickets/bare-hash-term-stringified.md
+++ b/todo/tickets/bare-hash-term-stringified.md
@@ -1,0 +1,41 @@
+# Bareword `hash` is stringified instead of calling the `hash` listop
+
+## Affected tests
+- `t/http-session-persistent.rakutest`: after subtest 16 the test calls `$persistent.purge`, whose body is `%!fake-db = hash;`. mutsu dies with `Odd number of elements found where hash initializer expected: found 1 element(s); last element seen: hash`, aborting the file — this is why the run has NO TAP plan and rc=1 (raku's `prove` reports it as a bad plan on top of the 4 subtest failures).
+
+## Repro (verified)
+```raku
+my %h = a => 1, b => 2;
+%h = hash;      # raku: empty hash
+say %h.elems;
+```
+- raku: `0` (and `say hash.raku` → `{}`)
+- mutsu: `Odd number of elements found where hash initializer expected: ... last element seen: hash` — the bareword evaluated to the string `"hash"`.
+
+`hash()` with parens works in mutsu (`{}`, and `hash(a => 1)` → `{:a(1)}`). Bare `list` works in mutsu. Note raku itself REJECTS bare `set`/`bag` ("may not be called without arguments") but ACCEPTS bare `hash` and `list` — mirror that: only `hash` needs adding, do not add `set`/`bag`.
+
+Secondary observation (cosmetic, optional): mutsu attributes the error to "in sub purge at t/http-session-persistent.rakutest line 48", but `purge` is at line 63-65; line 48 is inside `load`. Wrong line attribution for method bodies in monitors.
+
+## Root cause
+The parser produces `Expr::BareWord("hash")` (`mutsu --dump-ast -e 'my %h = hash;'` shows `VarDecl { expr: BareWord("hash") ... }`). At runtime `OpCode::GetBareWord` (`src/vm/vm_exec_dispatch.rs:741` → `exec_get_bare_word_op` in `src/vm/vm_var_get_ops.rs`) only treats a bareword as an implicit zero-arg builtin call when `Interpreter::is_implicit_zero_arg_builtin(name)` says so (`src/vm/vm_var_get_ops.rs:267`), and that allowlist is just `dir` and `lines`:
+
+```rust
+// src/runtime/registration.rs:842
+pub(crate) fn is_implicit_zero_arg_builtin(name: &str) -> bool {
+    matches!(name, "dir" | "lines")
+}
+```
+
+`hash` is not in the list, so the bareword falls through to the string fallback. (`list` works via a different path, so only `hash` is missing.)
+
+## Fix direction
+Add `"hash"` to `is_implicit_zero_arg_builtin` (`src/runtime/registration.rs:842`). The same predicate is also consulted by `src/runtime/system_eval_names.rs:863`. Confirm the call it routes to lands on the existing `hash` builtin (the one `hash()` already reaches — `builtin` dispatch in `src/runtime/builtins*.rs`). Make sure user-declared subs named `hash` still shadow the builtin (the existing zero-arg-builtin path already has that ordering for `dir`/`lines`; keep it).
+
+Do NOT add `set`/`bag`/`Set` etc. — raku rejects those bare (verified), and `hash` is listed in `raku-doc/doc/Language/perl-func.rakudoc`'s builtin set, satisfying the "builtins must be in perl-func" rule.
+
+Risks: minimal; a bareword `hash` used as a string was never valid Raku. Grep `t/` for accidental reliance.
+
+## Verification
+- `target/debug/mutsu -e 'my %h = a => 1; %h = hash; say %h.elems'` prints `0`; `-e 'say hash.raku'` prints `{}`.
+- `t/http-session-persistent.rakutest` no longer aborts after subtest 16: TAP plan `1..16` is printed and prove reports a clean plan (subtests 8/9/13/16 still need the sibling tickets).
+- Add a `t/` pin, e.g. `t/hash-term.t` (bare `hash` in assignment, `say hash.raku`, and `hash(a=>1)`).

--- a/todo/tickets/dynamic-var-leaks-via-start-shared-vars.md
+++ b/todo/tickets/dynamic-var-leaks-via-start-shared-vars.md
@@ -1,0 +1,128 @@
+# Dynamic variables bound before a `start` leak process-wide via shared_vars seeding
+
+## Affected tests
+
+- `t/http-router-plugin.rakutest` (Cro::HTTP dist) — aborts after `ok 4` (subtest
+  "Access to configuration with single level route block"). stderr:
+  `Too many messages` from `add-message` (test line 12), raised inside the
+  `my $test-outer = route { add-message 'o1'; ... }` block at test line 62.
+  raku runs the file to completion (`1..7`, rc=0).
+
+## Repro
+
+`tmp/tapdiag-dynleak2.raku` (verified 2026-08-09, release binary vs raku):
+
+```raku
+sub s1() { my $*A := 1; start { 0 } }
+await s1();
+say (try $*A).raku;          # mutsu: 1     raku: Nil
+
+sub s2() { my $*B := 2; start { 0 }; Nil }
+s2();
+say (try $*B).raku;          # mutsu: 2     raku: Nil  (no await needed)
+
+sub s4() { my $*D = 4; start { 0 } }
+await s4();
+say (try $*D).raku;          # mutsu: 4     raku: Nil  (assignment, not binding)
+
+# NO leak when the start body references the dynamic (closure capture owns it):
+sub s3() { my $*C := 3; start { $*C } }   # both: read works, no leak after return
+# NO leak when start runs BEFORE the binding:
+sub s5() { start { 0 }; my $*E := 5; }    # both: Nil
+```
+
+The discriminator: the leak happens iff a `start` is spawned **while the dynamic
+is in the frame env** and the spawned block does **not** capture that dynamic as
+a free variable.
+
+## Root cause
+
+`start` spawns via `spawn_callable_promise` (src/runtime/builtins_system.rs:171)
+→ `clone_for_thread_for_block` → `clone_for_thread_excluding`
+(src/runtime/runtime_thread.rs:130). Its seeding loop (runtime_thread.rs:164-250)
+copies **every** parent env entry into the lineage-shared, bare-name-keyed
+`shared_vars` store. The skip list (runtime_thread.rs:179-194) excludes
+`_`, `@_`, `%_`, `/`, `!`, `$/`, `$!`, `self`, `__mutsu_*`, `&*`, `?*` — and
+exactly ONE dynamic variable, `$*CWD`/`*CWD`, with a comment already stating the
+general rule: "in Raku, dynamic variables like $*CWD are thread-local". Every
+*other* `*`-twigil key (`*A`, `*CRO-ROUTER-ROUTE-HANDLER`, ...) is seeded into
+the store.
+
+The frame then returns; nothing removes the seeded entry. Any later lookup of
+`$*A` anywhere in the lineage misses the env and falls back to the store:
+src/vm/vm_env_helpers.rs:687-691 (`get_env_with_main_alias_inner`: "Fall back to
+shared_vars for cross-thread visibility"). So a dead frame's dynamic is now
+visible process-wide — dynamics are supposed to resolve through the *live*
+caller chain only (`is_dynamic_var_name`, src/env.rs:105-116 documents this).
+
+Why the "block references the dynamic" case does NOT leak: `block_captured_scalars`
+(runtime_thread.rs:13-101) excludes the block's own captured scalars from
+seeding, and a referenced dynamic is a free var of the block, so it never enters
+the store.
+
+Cro chain: `RouteHandler!invoke-internal`
+(Cro/HTTP/Router.rakumod:208-215) does `my $*CRO-ROUTER-ROUTE-HANDLER := self;`
+and then `start { ... }` (the handler body). The subtest-4 requests run two
+handlers of `$test-inner` (whose `plugin-config` holds `["i1","i2"]`); each spawn
+seeds `*CRO-ROUTER-ROUTE-HANDLER` into the store. Back at the top level, the
+next `route { add-message 'o1' }` calls `router-plugin-get-innermost-configs`
+(Router.rakumod:1503-1513), whose `with $*CRO-ROUTER-ROUTE-HANDLER` now finds
+the leaked handler, returns its 2-element config list, and `add-message` dies
+"Too many messages". Verified directly: inserting
+`note (try $*CRO-ROUTER-ROUTE-HANDLER).raku` before test line 62 prints the full
+leaked RouteHandler instance (with `plugin-config ... => ["i1", "i2"]`) under
+mutsu; raku would print Nil.
+
+## Fix direction
+
+In the seeding loop of `clone_for_thread_excluding`
+(src/runtime/runtime_thread.rs:179-194), generalize the `$*CWD`/`*CWD`
+special-case to all dynamic variables:
+
+```rust
+|| key.with_str(crate::env::is_dynamic_var_name)   // `*x` / `$*x` env keys
+```
+
+(`is_dynamic_var_name` is `pub(crate)` in src/env.rs:116 and already matches
+both the bare `*x` and sigiled `$*x` key forms — check its exact contract.)
+
+The spawned thread keeps SEEING parent dynamics: the child env is a clone of the
+parent env (same function, below the seeding loop), so read access inside the
+worker is unaffected; only the name-lane sharing (and hence the post-return
+process-wide visibility) is removed. This matches Raku semantics: dynamics are
+per-thread; a `start` snapshots the dynamic context for reads, and rebinding
+inside a worker never propagates to the parent.
+
+Defense in depth (optional): also filter `is_dynamic_var_name` keys in
+`sync_shared_vars_to_env` (src/runtime/runtime_shared_vars.rs:538-543, next to
+the existing `self`/`?` filter) so stale store entries created by older binaries
+or other lanes can never be pulled back into a live env.
+
+Risks:
+
+- Code that (incorrectly, per Raku) relied on a worker's dynamic ASSIGNMENT
+  being visible to the parent after `await` would regress — that behavior is
+  non-Raku, but grep t/ for tests asserting it before landing.
+- A dynamic holding a shared container (Channel/Array in `$*FOO`) still shares
+  through the container itself; only the name binding stops being shared. That
+  is the correct Raku behavior.
+
+## Verification
+
+- `tmp/tapdiag-dynleak2.raku`: all five probes must print exactly what raku
+  prints (Nil / Nil / 3+Nil / Nil / Nil).
+- `t/http-router-plugin.rakutest` must get past subtest 4 without the
+  "Too many messages" abort.
+- **The file WILL then reveal a further failure** (measured by probe, 2026-08-09:
+  bypassing the leak inside a copied test made the file run 1..7 with exactly one
+  failure): subtest 5 "Access to configuration with include", inner test 2
+  "Local configuration in included route handler not affected by outer" gets
+  `o1,o2` where `i1,i2` is expected — i.e. the *included* handler's
+  `get-innermost-plugin-configs` returns the OUTER route block's config. The
+  `copy-adding`/`merge-plugin-config`/`self.bless: :$!plugin-config` shape was
+  probed standalone and works in mutsu (tmp/tapdiag-bless.raku), so this is a
+  separate, not-yet-root-caused bug (suspect: cross-thread shared-store
+  interference with the handler instance attributes at request time). Budget it
+  as its own diagnosis; do not fold into this fix.
+- Roast: S17 concurrency files and `t/` dynamic-variable tests (regression net:
+  the seeding loop is hot for all `start`-based code).

--- a/todo/tickets/enum-value-fails-uint-typecheck.md
+++ b/todo/tickets/enum-value-fails-uint-typecheck.md
@@ -1,0 +1,63 @@
+# Enum value fails UInt type check (`INTERNAL_ERROR ~~ UInt` is False), aborting attribute assignment
+
+## Affected tests
+
+- `t/http2-frame-serializer.rakutest`: the file **aborts at line 131** with
+
+  ```
+  Type check failed in assignment to $!error-code; expected UInt but got Int
+  ```
+
+  when constructing `Cro::HTTP2::Frame::RstStream.new(error-code => INTERNAL_ERROR)` (`Cro::HTTP2::Frame` declares `has UInt $.error-code`; `INTERNAL_ERROR` is a value of `enum ErrorCode`). Every test from line 131 onward never runs, so the file emits no TAP plan and exits rc=1. This is why the file shows "ok=8 notok=3, plan missing" — fixing this unlocks the rest of the file (RstStream, Settings, PushPromise, Ping, GoAway, WindowUpdate, Continuation, and the two `test-multi` split tests).
+
+## Repro
+
+```raku
+enum ErrorCode <NO_ERROR PROTOCOL_ERROR INTERNAL_ERROR>;
+class RstStream { has UInt $.error-code is required; }
+say INTERNAL_ERROR ~~ UInt;                       # mutsu: False   raku: True
+my UInt $u = INTERNAL_ERROR;                      # mutsu: dies    raku: ok
+say RstStream.new(error-code => INTERNAL_ERROR);  # mutsu: dies    raku: ok
+```
+
+mutsu: `Type check failed in assignment to $u; expected UInt but got Int` (note it already reports the value as Int — the enum's underlying type — yet still fails). Plain `Int` values pass (`RstStream.new(error-code => 2)` works).
+
+## Root cause
+
+`src/runtime/types/type_matching.rs:475-486` — the `constraint == "UInt"` early-return arm matches only:
+
+```rust
+ValueView::Int(i) => i >= 0,
+ValueView::BigInt(n) => ...,
+ValueView::Nil => true,
+ValueView::Package(name) => name == "UInt" || name == "Int",
+_ => false,
+```
+
+A `ValueView::Enum { .. }` value falls into `_ => false`. The generic enum-compatibility check at line 496-501 (`if let ValueView::Enum { enum_type, .. } = value.view() ...`) sits AFTER this early return, so it is never reached for UInt. In Raku an Int-based enum value IS an Int, and `UInt` is `subset UInt of Int where * >= 0`, so any non-negative enum value must match.
+
+(Recent PR #6135 "uint-failure-and-subset-nominalization" touched UInt/subset logic but did not cover the Enum representation.)
+
+## Fix direction
+
+Add an Enum arm to the UInt block in `type_matching.rs:475`:
+
+```rust
+ValueView::Enum { value, .. } => match value {
+    crate::value::EnumValue::Int(i) => *i >= 0,
+    _ => false,
+},
+```
+
+(`EnumValue` is `src/value/mod.rs:1232-1237`: `Int(i64) | Str(String) | Generic(Box<Value>)`; a `Generic` holding an Int could be handled too, but `Int` covers real-world enums.)
+
+While there, check the sibling nominal-subset shortcuts in the same file for the same blind spot (e.g. any other `constraint == "..."` early-return that matches on Int views but not Enum) — at minimum verify `INTERNAL_ERROR ~~ Int` (works today via a different path) and `~~ Numeric`/`~~ Real` against raku.
+
+Risk: low — this widens acceptance to match Rakudo; the only hazard is a multi-dispatch tie changing where a candidate distinguishes `UInt` from an enum type, which roast S12/S02 enum tests will catch on CI.
+
+## Verification
+
+- The 3-line repro above matches raku (`True`, no death, object constructed).
+- `t/http2-frame-serializer.rakutest` reaches `done-testing` and prints a plan (subtests 4/5 and 11 additionally need `http2-lexical-sub-lost-after-routine-return.md` and `http2-rw-param-buf-element-assign.md`; with all three fixed the file should be 20/20-ish — establish the exact count under raku first: `cd tmp/cro-work/C_RO_CRO_HTTP_...; raku $(cat ../inc-paths.txt) -I lib -I t t/http2-frame-serializer.rakutest`).
+- New pin `t/enum-uint-subset.t` with the repro.
+- `make test` + CI roast (S12 enums, S02 subset tests).

--- a/todo/tickets/hash-slurpy-param-not-masked-from-cross-thread-name-store.md
+++ b/todo/tickets/hash-slurpy-param-not-masked-from-cross-thread-name-store.md
@@ -1,0 +1,39 @@
+# `*%options` slurpy receives another thread's same-named binding — `%`-sigil parameters are never masked from the cross-thread name store
+
+## Affected tests
+- `t/http-session-persistent.rakutest` subtest 16 ("Using old session for route 2"): expected `'Visit2 2'`, got `''`.
+
+## Symptom chain (each link verified with probes)
+1. `Cro::HTTP::Session::Persistent.process-responses` calls `$res.set-cookie($!cookie-name, $_, |%cookie-opts)` with `%cookie-opts = max-age => ..., :http-only, path => '/'`. A shadow probe confirms `%cookie-opts` has all 3 entries at the call site on the worker thread.
+2. Inside `Cro::HTTP::Response.set-cookie($name, $value, *%options)`, a probe shows `%options` = **`{host, nodelay, port}`** — a *different* live `%options` binding from elsewhere in the Cro server/client machinery in the same process (listener options), not the flattened `%cookie-opts`.
+3. Cookie built from those bogus named args → the wire header is `Set-Cookie: _session=<id>` with NO `Path=/` (verified with curl against the live mutsu server).
+4. The client jar then computes the default path from the request URI: `CookieJar!default-path('/hits')` returns `'/hits'` (Cro's RFC6265-ish fallback), so the stored cookie has `path="/hits"` (verified by dumping `$client.cookie-jar.contents`).
+5. `path-match('/hits', '/login')` and `path-match('/hits', '/hits2')` fail → the session cookie is only re-sent on `/hits`. `/login`'s `login = True` lands in a session the client never references again; `/hits2`'s request carries no cookie → fresh `SessionData` (login False) → `Logged` subset auth fails → 401 with empty body → `''`.
+
+The `subset Logged of SessionData where *.login` check itself is fine in mutsu (verified standalone: `tmp/repro-subset-where-attr.raku` matches raku).
+
+## Repro
+Live-context repro: `tmp/repro-session-logged3.raku` (spins a real Cro server on port 31379, one client, prints jar contents after each request). Under mutsu the jar shows `path="/hits"` after the first response and `/login`//`/hits2` go out cookie-less; under raku the test file passes (16/16 — run the actual test with real raku to see expected).
+
+Isolated repros that PASS (bounding the bug — the collision needs a busy multi-threaded process):
+- `$res.set-cookie(..., |%cookie-opts)` single-threaded: full header (`tmp/repro-setcookie-opts.raku`).
+- Same call inside `supply whenever` from a monitor method, driven cross-thread, small process: full header (`tmp/repro-setcookie-in-whenever.raku`).
+- `|%hash` into a `*%options` sub/method in the same shape: correct (`tmp/repro-slip-hash-in-whenever.raku`).
+
+So the minimal repro is still open; the live probe evidence (step 2: `%options` containing `host,nodelay,port`) pins the mechanism regardless.
+
+## Root cause
+The cross-thread shared store is keyed by BARE NAME. Scalar parameter names are masked per-call via `mask_thread_redeclared_params` (`src/runtime/runtime_shared_vars.rs:250-270`) precisely so a nested spawn / shared-store sync cannot substitute another frame's same-named binding. But that function **skips every `@`/`%`/`&` name** (`runtime_shared_vars.rs:259`: `if name.starts_with(['@', '%', '&']) { continue; }`) — aggregates deliberately "keep the name lane" for the `__mutsu_atomic_*` CAS copies (comment at `runtime_thread.rs:208-215`). Consequence: a `*%options` slurpy (or any `%`-named parameter) bound in one thread is visible/clobberable through the store by any other thread's live `%options`, and `Response.set-cookie`'s `%options` resolves to the listener's `host/nodelay/port` options hash published under the same bare name. Same architectural family as the sibling ticket `session-sibling-thread-array-name-merge.md` (name-keyed store cannot represent concurrent same-named bindings), but a distinct fix site: parameter binding, not the push lane.
+
+## Fix direction
+- Extend the parameter mask to `%`- and `@`-sigil parameter names: in `mask_thread_redeclared_params` (`src/runtime/runtime_shared_vars.rs:259`), stop skipping `@`/`%` (keep skipping `&`), masking them in `thread_param_shadow_vars` for the duration of the call the same way scalars are. The reason aggregates were excluded — the CAS lanes are keyed off base-name entries — applies to *declared lexicals*, not to per-invocation parameter bindings; a parameter's shadow must never be force-declared or synced (exactly the argument in the function's own doc comment at lines 216-249).
+- Then audit the read side: `sync_shared_vars_to_env` (`runtime_shared_vars.rs:527`) and the `GetLocal` shared-preference path must respect `thread_param_shadow_vars` for `%`/`@` names too (they currently consult `thread_redeclared_vars` via `container_name_is_redeclared`, which requires the mask that line 259 refuses to set).
+- If the sibling ticket's lineage-scoping of the atomic lanes lands first, re-test — it may narrow but probably not eliminate this one (the clobber here is the base-name lane, not the atomic lane).
+
+Risks: masking `%`/`@` parameters could hide a genuinely-shared aggregate passed by name into a callback that a sibling thread mutates concurrently — but such sharing is supposed to flow through the container/cell identity, not the name lane. Watch `t/lock.t`, S17 roast files, and the Cro suite (`t/http-*` under `tmp/cro-t.sh`).
+
+## Verification
+- `tmp/repro-session-logged3.raku`: jar shows `path="/"`, all five requests carry the cookie, `/hits2` returns `Visit2 2`.
+- `curl -v` against the repro server shows `Set-Cookie: _session=...; Max-Age=1800; Path=/; HttpOnly`.
+- `t/http-session-persistent.rakutest` subtest 16 passes; with the other three tickets the file reaches 16/16 with a proper TAP plan (rc=0).
+- Note: the file currently ALSO aborts after subtest 16 in `purge` — that is the separate `hash`-term ticket (`session-bare-hash-term.md`); both are needed for a clean run.

--- a/todo/tickets/lexical-sub-lost-after-routine-return.md
+++ b/todo/tickets/lexical-sub-lost-after-routine-return.md
@@ -1,0 +1,81 @@
+# Lexical named sub is unregistered when its declaring routine returns, breaking tap callbacks that fire later ("Unknown function")
+
+## Affected tests
+
+- `t/http2-frame-parser.rakutest` subtests 6, 8, 10, 12 — the flunked second leg ("Empty DATA frame", "DATA frame without padding", "DATA frame with zero padding", "DATA frame with padding"): the FrameSerializer never emits any Data frame, so `$complete` times out and `flunk $desc` fires at line 85.
+- `t/http2-frame-serializer.rakutest` subtests 4, 5 ("Simple data frame is not parsed back!", "Simple data frame with padding is not parsed back!"): same mechanism — the serializer's `send-message($frame, True)` awaits a promise that is never kept.
+
+All four failing frame-parser subtests and both frame-serializer subtests are Data frames because only the Data path passes `$consumes-window = True` to `send-message` (FrameSerializer.rakumod line 128-133), which emits a `WindowConsume` on `$connection-state.remote-window-change` and `await`s its promise. The promise is kept by `check-window-size` — a **lexical sub declared inside `submethod TWEAK` of `Cro::HTTP2::ConnectionState`** (ConnectionState.rakumod lines 25-61), called from the tap callback TWEAK registers. By the time the tap fires, TWEAK has long returned and mutsu has unregistered `check-window-size`, so the callback dies with `Unknown function: check-window-size`, the promise stays Planned, and the serializer hangs on `await`.
+
+Confirmed in the real module via a shadowed ConnectionState with a `CATCH` probe in the tap:
+
+```
+SHADOW-CS: tap error: Unknown function: check-window-size
+complete: Planned
+```
+
+## Repro
+
+Minimal, pure Raku (`tmp/h2-wc-min2.raku` variant A):
+
+```raku
+class CA {
+    has Supplier $.s = Supplier.new;
+    method setup() {
+        sub helperA($x) { say "A: helper $x"; True }
+        $!s.Supply.tap: {
+            CATCH { default { say "A CAUGHT: ", .message } }
+            helperA($_);
+        };
+    }
+}
+my $a = CA.new;
+$a.setup;
+$a.s.emit(42);
+sleep 0.3;
+```
+
+- mutsu (target/release/mutsu): `A CAUGHT: Unknown function: helperA`
+- raku: `A: helper 42`
+
+Boundary matrix (all verified, `tmp/h2-wc-min*.raku`):
+
+| Scenario | mutsu |
+|---|---|
+| tap registered in method, emit while method frame still live | OK |
+| tap registered in method/sub/TWEAK, emit after return | **FAIL** |
+| closure stored in a var (assignment is the routine's last statement) and called after return | OK |
+| tap registered inside a bare block (not routine) | OK |
+| helper as `my &h = -> ... {}` instead of named sub | OK |
+
+Cro-level repro (`tmp/h2-windowconsume.raku`, run via `bash tmp/croflake.sh` with `MUTSU_BIN` set to an absolute path): emits a `WindowConsume` into a fresh `Cro::HTTP2::ConnectionState` and prints `promise status: Planned` under mutsu, `Kept` under raku.
+
+## Root cause
+
+A routine body that declares inner routines snapshots the routine registry and restores it on return:
+
+- `src/vm/vm_call_named.rs:27-48` (`call_compiled_function_named`) — and the same gate in `src/vm/vm_call_fast.rs:34/364` and `src/vm/vm_method_dispatch.rs:631/924` and `1533/1769`.
+- The restore is skipped only when `return_value_escapes_routine(v)` (`src/vm/vm_call_light_typed.rs:654`) — i.e. when the **return slot** carries a Sub/Routine/Seq/LazyList.
+
+This escape analysis misses every **side-channel escape**: a closure passed to `.tap` (our case), stored into an attribute, pushed onto an array, registered as a callback. After the restore, a later invocation of the escaped closure cannot resolve the inner sub because `find_compiled_function` (`src/vm/vm_call_resolve.rs:53-57`) requires `resolve_function_with_types` (the runtime registry) to succeed before it will use the compiled-fns table — the bytecode still exists in `compiled_fns` but is unreachable by name.
+
+This is why the variant-A matrix looks the way it does: the "closure stored in var" cases work only because the assignment expression happens to be the routine's last statement, so the closure is also the return value and `return_value_escapes_routine` fires.
+
+## Fix direction
+
+Do not try to enumerate side channels statically (that is the incomplete-analysis trap CLAUDE.md warns about). Use a runtime over-approximation that cannot go flaky:
+
+1. Add a monotonically increasing `closures_created: u64` counter on `Interpreter`, bumped in the closure-creation exec ops (`exec_make_block_closure` and siblings in `src/vm/vm_register_sub_ops.rs`; also the pointy/anon-sub creation ops if separate).
+2. In each snapshot/restore gate (`vm_call_named.rs`, `vm_call_fast.rs`, `vm_method_dispatch.rs` x2), record the counter before running the body; skip `restore_routine_registry` when the counter changed during the call, in addition to the existing `return_value_escapes_routine` check.
+
+Cost/risk: the snapshot path only runs when `cf.declares_inner_routines` is true (rare), so the over-approximation just means such a routine's inner subs occasionally outlive the call — a bounded registration leak, matching what the un-scoped method-dispatch path leaked unconditionally before the check existed (see the comment block at `vm_call_light_typed.rs:636-653`). A sharper variant (only skip when a created closure's compiled unit is nested inside this `cf`) can come later.
+
+Note: the restore must still run for the loop-body case (`vm_for_loop_dispatch.rs`) — that one is about lexical scoping between sibling loops and is unrelated.
+
+## Verification
+
+- `tmp/h2-wc-min.raku`, `tmp/h2-wc-min2.raku` print no `CAUGHT:` lines and match raku output.
+- `tmp/h2-windowconsume.raku` (via `croflake.sh`) prints `promise status: Kept`.
+- `t/http2-frame-parser.rakutest`: 26/26 (currently 22/26).
+- `t/http2-frame-serializer.rakutest`: subtests 4 and 5 pass (subtest 11 and the end-of-file abort are separate tickets: `http2-rw-param-buf-element-assign.md`, `http2-uint-enum-typecheck.md`).
+- Existing suites: `make test`; watch `t/wrap.t`, `t/supply-*.t` — the registry restore interacts with sub redefinition tests.

--- a/todo/tickets/map-grep-inline-block-swallows-succeed.md
+++ b/todo/tickets/map-grep-inline-block-swallows-succeed.md
@@ -1,0 +1,113 @@
+# `when`/`default` inside a map/grep block: inline fast path does not absorb the succeed signal
+
+## Affected tests
+
+- `t/http-request-serializer.rakutest` (Cro::HTTP dist) — aborts after `ok 15`,
+  before test 16 "multipart/form-data with list of pairs" (test line 270).
+  stderr: `Type check failed for return value; expected Supply but got Any
+  (Cro::HTTP::Body::MultiPartFormData::Part())`. raku runs the file to
+  completion (`1..17`, rc=0).
+
+## Repro
+
+One-liner (verified 2026-08-09, release binary):
+
+```
+$ mutsu -e 'my @a = (1,2).map({ when Int { "int" } }); say @a.join(",")'
+Runtime error:            # empty message; exit 1
+$ raku  -e 'my @a = (1,2).map({ when Int { "int" } }); say @a.join(",")'
+int,int
+```
+
+`grep` is equally affected: `(1,2).grep({ when Int { True } })` → same empty
+"Runtime error:". A direct closure call is NOT affected
+(`my $b = { when Int { "int" } }; say $b(5)` prints `int` in both).
+
+The exact Cro shape is `tmp/tapdiag-ser7.raku` (class SerB): a method with
+`--> Supply` whose body does `my @parts = @body.map: { when Pair {
+Part.new(...) } }` fails with the observed "Type check failed for return value;
+expected Supply but got Any (Part())" — the escaping succeed signal carries a
+`return_value`, and the method-return machinery misreads it as the routine's
+return value, which then fails the `--> Supply` return-type check. (SerA in the
+same file proves the nested `self.serialize: $m, FormData.new: parts => ...`
+colon-call chain itself is fine.)
+
+The real-world source is
+`Cro/HTTP/BodySerializers.rakumod:189-204`
+(`Cro::HTTP::BodySerializer::MultiPartFormData.serialize(@body)`), which maps
+pairs through exactly this `when Pair / when Part / default` block.
+
+## Root cause
+
+A matched `when` raises a succeed control signal carrying the body's value:
+`exec_when_op`, src/vm/vm_given_when_ops.rs:401-407 (`RuntimeError::
+succeed_signal()` with `return_value = Some(last)`); same for `exec_default_op`
+at :440-446. The signal is normally absorbed at the enclosing block boundary:
+
+- closure calls: src/vm/vm_closure_dispatch.rs:793-803 (`Err(e) if
+  e.is_succeed()` → treat `e.return_value` as the block's return value);
+- statement bodies: `SucceedBarrier` (src/vm/vm_control_ops.rs:333-357).
+
+But `.map`/`.grep` with a block do NOT invoke the block through that machinery.
+The fast path `eval_map_over_items` (src/runtime/resolution_map_grep.rs:416-523)
+runs the block's compiled code inline via `vm.run_reuse(&code, ...)` (line 459).
+Its error arms handle only `is_next` (:485) and `is_last` (:486); the succeed
+signal falls into the generic `Err(e)` arm (:487-502) and propagates out of the
+map as a RuntimeError whose message is empty — hence the bare "Runtime error:".
+
+gdb-verified chain: `exec_when_op` (vm_given_when_ops.rs:407 raise) ←
+`run_reuse` ← `eval_map_over_items::{closure#11}` (resolution_map_grep.rs:459)
+← `dispatch_map_method` — no succeed-absorbing frame in between.
+
+## Fix direction
+
+In `eval_map_over_items` (src/runtime/resolution_map_grep.rs:459-503), add an
+arm before the generic error arm, mirroring vm_closure_dispatch.rs:793-803:
+
+```rust
+Err(e) if e.is_succeed() => {
+    let val = e.return_value.unwrap_or(Value::NIL);
+    let val = vm.reify_finite_pipe_value(val)?;   // same post-processing as Ok arm
+    match val.view() {
+        ValueView::Slip(elems) => result.extend(elems.iter().cloned()),
+        _ => result.push(val),
+    }
+}
+```
+
+Also reset the when-matched flag the way `exec_succeed_barrier_op` does
+(`set_when_matched(saved)`, vm_control_ops.rs:343-352) so an enclosing `given`
+does not see a stale match flag; capture `saved_when_matched` before the
+per-item `run_reuse` and restore it in this arm.
+
+Audit the sibling inline runners for the same missing arm (all found by
+`grep -n "is_next" src/runtime/resolution_map_grep*.rs`):
+
+- src/runtime/resolution_map_grep.rs:721-722 (second inline loop, `'body_redo`)
+- src/runtime/resolution_map_grep.rs:822-823 (`first`-style probe: a succeed
+  from a matched `when` means "this item produced a value" — decide truthiness
+  from `e.return_value`)
+- src/runtime/resolution_map_grep_rw.rs:283-286 and :546-547
+
+For grep, the absorbed `e.return_value` is the predicate result (use its
+truthiness), matching raku (`(1,2).grep({ when Int { True } })` → `(1 2)`).
+
+Risk: low — the arm only fires where today the whole map dies with an empty
+error. Make sure NOT to absorb succeed in the `for`-loop lazy paths that already
+break on it deliberately (src/vm/vm_for_loop_lazy.rs:148 — statement context,
+value dropped; that is correct for `for`).
+
+## Verification
+
+- The one-liners above print `int,int` / `(1 2)`-equivalent under mutsu.
+- `tmp/tapdiag-ser7.raku`: both A and B print `parts: a,b` and `Supply`.
+- `t/http-request-serializer.rakutest`: test 16 no longer aborts the file.
+  **Behind this abort sits one more blocker** (measured 2026-08-09 by shadowing
+  the `when`-map out of BodySerializers.rakumod): tests 16/17's `like ...,
+  /<$expected-output>/` then dies "Prohibited regex interpolation" — see ticket
+  `tap-regex-interp-dangerous-heuristic-overbroad.md`. With BOTH fixed the file
+  passes 1..17 (verified with both bypass shims; the regex-content assertion of
+  tests 16/17 was stubbed in that probe, so re-run the real file after the regex
+  fix).
+- Add a `t/` pin, e.g. `t/map-when-succeed.t`, covering map+when, grep+when,
+  map+default, and the `--> Supply` method shape (SerB).

--- a/todo/tickets/method-call-named-arg-closure-literal-not-marked-escaping.md
+++ b/todo/tickets/method-call-named-arg-closure-literal-not-marked-escaping.md
@@ -1,0 +1,74 @@
+# Closure literal passed as a method-call NAMED argument is not marked escaping — captured scalar goes stale across threads
+
+## Affected tests
+- `t/http-session-inmemory.rakutest` subtest 13 ("Session expires appropriately"): expected `'Visit 1'`, got `'Visit 4'`
+- `t/http-session-persistent.rakutest` subtest 13 (same name): expected `'Visit 1'`, got `'Visit 4'`
+
+The tests build the session middleware with `…new(expiration => Duration.new(60*30), now => { $fake-now })` and then advance `$fake-now += Duration.new(...)` on the main thread. The `&!now` closure, invoked on the server's worker threads, keeps returning the ORIGINAL `$fake-now`, so sessions never expire. (Subtests 11/12 pass either way — only 13 actually detects expiry.)
+
+## Repro (verified)
+`tmp/repro-stale-w4.raku` — no Cro needed:
+
+```raku
+my $x = 1;
+class Store {
+    has &.now is required;
+    method read() { &!now() }
+}
+my $store = Store.new(now => { $x });
+my $cmd = Channel.new;
+my $out = Channel.new;
+my $w = start {
+    for ^2 { $cmd.receive; $out.send($store.read()) }
+}
+$cmd.send(1); say "first (expect 1): ", $out.receive;
+$x = 42;
+$cmd.send(1); say "second (expect 42): ", $out.receive;
+await $w;
+```
+
+- raku: `first 1` / `second 42`
+- mutsu (release): `first 1` / `second 1` (stale)
+
+Discriminating variants (all verified):
+- `tmp/repro-stale-w9.raku`: same via an ordinary method `$store.set(now => { $x })` — FAILS too (not `.new`-specific).
+- `tmp/repro-stale-w8.raku`: named-arg closure to a plain SUB (`stash(now => { $x })`) — PASSES (the sub-call path already handles it).
+- `tmp/repro-stale-w7.raku`: `my &getter = { $x }; Store.new(now => &getter)` — PASSES (assignment marks it escaping, `$x` gets a cell).
+- `tmp/repro-stale-w5.raku`: single-threaded W4 — PASSES (the by-name coherence lane hides the missing cell on one thread).
+- Fresh `start { $store.read() }` after the mutation sees 42 (`tmp/repro-stale-w6.raku`) — each spawn re-snapshots, which is why short-lived-thread tests never caught this. Long-lived server threads (Cro) see the spawn-time snapshot forever.
+
+## Root cause
+Escape analysis marks closure-literal call arguments escaping so their captured-and-mutated lexicals get shared `ContainerRef` cells (`box_captured_lexicals`, `src/vm/vm_register_ops.rs:753`; policy comment in `src/compiler/helpers_call_args.rs:111-126`).
+
+The FUNCTION-call compile path unwraps a fat-arrow named argument before testing for a closure literal — `src/compiler/expr_call.rs:1428-1436`:
+
+```rust
+let value_expr = match arg {
+    Expr::Binary { op: TokenKind::FatArrow, right, .. } => right.as_ref(),
+    other => other,
+};
+let escaping_args = is_start || Self::is_closure_literal_arg(value_expr);
+```
+
+The METHOD-call compile paths do NOT unwrap: `src/compiler/expr_method.rs:155-157` (and the second site at `expr_method.rs:560`) test `Self::is_closure_literal_arg(arg)` on the raw argument, so `now => { $x }` (an `Expr::Binary { op: FatArrow, .. }`, same AST for colonpair form `:now({ $x })`) is never a "closure literal", `escaping` stays false, no cell is created for `$x`, and the closure captures a by-value snapshot. Worker threads clone the env at spawn and never see later main-thread writes. (This is the residue of #5891, which fixed the sub-call path only.)
+
+## Fix direction
+In `src/compiler/expr_method.rs`, at both `is_closure_literal_arg` call sites (~line 156 and ~line 560), unwrap the fat-arrow named-argument value exactly as `expr_call.rs:1428-1436` does before testing, e.g.
+
+```rust
+let value_expr = match arg {
+    Expr::Binary { op: TokenKind::FatArrow, right, .. } => right.as_ref(),
+    other => other,
+};
+let arg_esc = esc && (Self::is_closure_literal_arg(value_expr) || matches!(...legacy names...));
+```
+
+`compile_method_arg_with_escape` already wraps the whole argument compile in `with_escape`, so no further plumbing is needed. Consider hoisting the unwrap into a shared helper next to `is_closure_literal_arg` (`src/compiler/helpers_call_args.rs:138`) so the two paths cannot drift again.
+
+Risks: broader escaping means more boxing; the #2746 perf guard is preserved because only the literal closure value is marked, not the whole argument list. Watch the bench CI ctor/yaml rows. The `Pair.new` two-positional special case at `expr_method.rs:137-181` is unrelated (positional, not FatArrow) — don't touch it.
+
+## Verification
+- `tmp/repro-stale-w4.raku` and `tmp/repro-stale-w9.raku` print `second (expect 42): 42`.
+- `t/http-session-inmemory.rakutest` subtest 13 passes (file 13/13 together with the sibling tickets).
+- `t/http-session-persistent.rakutest` subtest 13 passes.
+- W5/W6/W7/W8 controls unchanged. Add a `t/` pin, e.g. `t/closure-named-arg-method-escape.t`, from W4.

--- a/todo/tickets/parameter-introspection-methods-missing.md
+++ b/todo/tickets/parameter-introspection-methods-missing.md
@@ -1,0 +1,100 @@
+# Parameter introspection gaps: `usage-name`, `constraint_list`, `default` (when absent)
+
+## Affected tests
+
+- `t/http-router-named-urls.t` (Cro::HTTP dist) — after the `-> +a` parse fix
+  (ticket `tap-pointy-param-sigilless-plus-slurpy.md`), every `route {}` block in
+  the file dies during `definition-complete` → `!generate-urls` → `TWEAK` →
+  `Cro::HTTP::Router::LinkGenerator::signature-to-sub`:
+  1. `No such method 'constraint_list' for invocant of type 'Parameter'`
+     (LinkGenerator.rakumod:25, `extract-static-part`)
+  2. with that worked around: `No such method 'usage-name' for invocant of type
+     'Parameter'` (LinkGenerator.rakumod:66)
+  Measured 2026-08-09 with a `*@a`-substituted copy of the test plus a shadowed
+  LinkGenerator; the file is unmeasured beyond `usage-name`.
+
+## Repro
+
+Verified against release binary vs raku:
+
+```
+$ raku  -e 'sub f("x") {}; say &f.signature.params[0].constraint_list.raku'
+("x",)
+$ mutsu -e 'sub f("x") {}; say &f.signature.params[0].constraint_list.raku'
+No such method 'constraint_list' for invocant of type 'Parameter'
+
+$ raku  -e 'sub f($x, :$y) {}; say &f.signature.params[0].usage-name'
+x
+$ mutsu -e '...same...'
+No such method 'usage-name' for invocant of type 'Parameter'
+
+$ raku  -e 'sub f($x) {}; say &f.signature.params[0].default.raku'
+Code            # type object when the parameter has no default
+$ mutsu -e '...same...'
+No such method 'default' for invocant of type 'Parameter'
+```
+
+Working already: `.name`, `.named`, `.positional`, `.optional`, `.slurpy`,
+`.type`, `.constraints` (returns the `all(...)` junction), `.named_names`.
+
+Cro usage (lib/Cro/HTTP/Router/LinkGenerator.rakumod, `signature-to-sub`):
+`$p.constraint_list == 1 && $p.constraint_list[0] ~~ Str` (line 25-27),
+`$param.usage-name` (line 66), `@default.push: $_ with $param.default` (for
+optional params). Router.rakumod itself avoids `constraint_list` via an
+autothreading `extract($param.constraints)` helper, which mutsu handles.
+
+## Root cause
+
+mutsu builds Parameter objects as plain Instances whose methods are attribute
+lookups: `make_param_attrs` in src/value/signature.rs (~lines 300-464).
+
+- `constraints` is inserted as an `all(...)` junction (signature.rs:441-455) but
+  no `constraint_list` attr/method exists. In Rakudo `constraint_list` is the
+  underlying List of the same items.
+- `usage-name` is never inserted (it is the variable name minus sigil and
+  twigil: `@foo` → `foo`, `$!x` → `x`).
+- `default` is inserted only when the parameter HAS a default
+  (signature.rs:420-433); an absent attribute makes method dispatch fail with
+  "No such method" instead of returning an undefined value. Rakudo returns the
+  `Code` type object when there is no default.
+
+## Fix direction
+
+All in `make_param_attrs` (src/value/signature.rs), where `constraint_items`
+is already computed (:441-451):
+
+1. `attrs.insert("constraint_list", Value::array(constraint_items.clone()))`
+   — insert BEFORE the junction consumes the Vec; `.raku` should render as a
+   List (check how mutsu prints `Value::array` under `.raku` — raku prints
+   `("x",)`; if array prints `["x"]`, use the list/List constructor instead).
+2. `usage-name`: compute from the already-known name — strip leading sigil
+   (`$@%&`) and twigil (`!.*^:?`) — and insert as Str. There may be an existing
+   helper for this near `parameter_to_raku` (signature.rs:467).
+3. `default`: when `p.default_expr` is None, insert the `Code` type object
+   (`Value::Package(Symbol::intern("Code"))` or whatever mutsu uses for type
+   objects) so `with $param.default` is False-y but the method exists. Verify
+   `raku -e 'sub f($x) {}; say &f.signature.params[0].default.defined'` → False
+   and match it.
+
+Alternatively, if Parameter has a native-method dispatch table somewhere,
+adding methods there is fine too — but the attrs map is how the existing
+methods (`named`, `optional`, ...) are served, so extending it is the
+consistent move.
+
+Risk: low; additive. Watch `.raku`/`.gist` roast pins for Parameter
+(`S06-signature/introspection*.t` if whitelisted) since new attrs may leak into
+introspection output if `parameter_to_raku` iterates attrs (it reads specific
+keys, so it should be safe — confirm).
+
+## Verification
+
+- The three repro one-liners match raku.
+- `t/http-router-named-urls.t` (with the `+a` parser fix): `signature-to-sub`
+  completes and the file starts emitting TAP. **The file is unmeasured past
+  `usage-name`** — expect possibly more gaps (the same sub also uses
+  `$param.type`, `$param.positional`, `$param.named`, `$param.slurpy`,
+  `$param.optional`, all currently working standalone). Re-run and triage
+  whatever surfaces next.
+- Roast: `S06-signature/introspection.t` if runnable, plus a `t/` pin
+  `t/parameter-introspection.t` covering the three methods incl. literal
+  (`"x"`), where-clause, and no-constraint parameters.

--- a/todo/tickets/pointy-param-sigilless-plus-slurpy.md
+++ b/todo/tickets/pointy-param-sigilless-plus-slurpy.md
@@ -1,0 +1,90 @@
+# Pointy-block signatures reject the sigilless one-arg slurpy `+a`
+
+## Affected tests
+
+- `t/http-router-named-urls.t` (Cro::HTTP dist) — produces NO TAP at all.
+  Compilation dies:
+  `===SORRY!=== ... Confused. expected statement ... at t/http-router-named-urls.t:104`
+  pointing at `test-route-urls route {`. The actual offender is INSIDE that
+  block, line 110: `get :name<css>, -> 'css', +a { };` — the `+a` parameter.
+  raku compiles and runs the file.
+
+## Repro
+
+Verified 2026-08-09 (release binary):
+
+```
+$ mutsu -e 'my $b = -> $x, +a { say a.raku }; $b(1,2,3)'
+Runtime error: X::Syntax::Malformed: Malformed initializer
+$ mutsu -e 'my $b = -> +a { say a.raku }; $b(1,2,3)'
+Runtime error: X::Syntax::Malformed: Malformed initializer
+$ raku  -e 'my $b = -> $x, +a { say a.raku }; $b(1,2,3)'
+(2, 3)
+```
+
+The SUB path already works (different parser module):
+
+```
+$ mutsu -e 'sub f($x, +a) { say a.raku }; f(1,2,3)'
+[2, 3]
+```
+
+(Sigiled forms `+@a`, `+$a`, `*@a` parse fine in pointy blocks too — only the
+sigilless `+name` form fails.)
+
+## Root cause
+
+Pointy-block parameters are parsed by `parse_pointy_param`
+(src/parser/stmt/control/pointy_param.rs:3). Its slurpy-marker section
+(pointy_param.rs:112-137) handles `**`-double-slurpy and `*`/`+` followed by a
+sigil (`@ % $ &`) only. For `+a` no branch strips the `+`, so control falls to
+`var_name(rest)` (pointy_param.rs:388) which fails on `+`, the whole
+`->`-lambda parse fails, and the statement parser surfaces "Malformed
+initializer" (assignment context) or "Confused" (file context, reported at the
+statement's first line — which is why the file error points at line 104, not
+110).
+
+The sub-signature parser has the missing branch:
+src/parser/stmt/sub_param/param_inner.rs:158-194 ("Sigilless single-argument
+rule slurpy: +foo") — parses the ident, optional `is` traits and default, and
+returns a ParamDef with `slurpy = true; onearg = true; sigilless = true`.
+
+## Fix direction
+
+In `parse_pointy_param` (src/parser/stmt/control/pointy_param.rs), after the
+existing `+`-with-sigil branch (:129-137), add the sigilless variant mirroring
+param_inner.rs:158-194:
+
+- condition: `rest.starts_with('+') && rest.len() > 1 &&
+  (rest.as_bytes()[1].is_ascii_alphabetic() || rest.as_bytes()[1] == b'_')`
+- parse `ident`, then reuse the function's existing trait/default tail handling
+  (or return early like param_inner does), and return a ParamDef with
+  `slurpy: true, onearg: true, sigilless: true, block_param: true`.
+
+The lambda body compilation already supports sigilless params
+(`parse_block_body_with_sigilless` / `register_sigilless_params` in
+src/parser/primary/misc/lambda.rs:399-452 key off `ParamDef.sigilless`), so no
+change should be needed there — but verify the body can reference bare `a`.
+
+Note while testing: the sub path prints `[2, 3]` where raku prints `(2, 3)` —
+the `+a` binding produces an Array-flavored gist instead of a List. Cosmetic
+for this ticket, but worth a pin if cheap to align.
+
+Risk: `+` is also a prefix operator; the new branch must require the alphabetic
+first char (as above) so `-> +$a`/`-> +@a` stay in the sigiled branch and
+expression-position `+foo` (not a signature) is unaffected — the branch only
+runs inside pointy-param context, so blast radius is small.
+
+## Verification
+
+- The three repro one-liners behave like raku (binding: `a` = remaining args
+  under the one-arg rule).
+- `t/http-router-named-urls.t` gets past compilation. **The file then hits the
+  next blocker immediately** (measured 2026-08-09 by substituting `*@a` for
+  `+a` in a copy): `No such method 'usage-name' for invocant of type
+  'Parameter'` (and behind it `constraint_list`, `default`) inside
+  `Cro::HTTP::Router::LinkGenerator::signature-to-sub` — see ticket
+  `tap-parameter-introspection-methods-missing.md`. The file remains unmeasured
+  beyond `route`-block registration until that lands.
+- Add `t/pointy-onearg-slurpy.t`: `-> +a {}`, `-> $x, +a {}`, `-> 'lit', +a {}`
+  (the Cro shape), with one-arg-rule flattening checks against `raku -e`.

--- a/todo/tickets/promise-supply-coercion-drives-react-on-calling-thread.md
+++ b/todo/tickets/promise-supply-coercion-drives-react-on-calling-thread.md
@@ -1,0 +1,55 @@
+# `Promise(supply { ... })` blocks the calling thread — deadlocks Cro body promises terminated by connection close
+
+## Affected tests
+- `t/http-response-parser.rakutest` subtest 111 ("Response with body terminated by close of connection") — flunked via the harness's 10s "Response parser failed to emit a HTTP response" path
+- `t/http-response-parser.rakutest` subtest 120 ("Connection close with incomplete body throws") — same flunk (its `pass` and checks 1-3 appear as subtests 116-119; check 4 hangs)
+
+These are the only two cases in the file whose BODY completion depends on the source supply's `done` (UntilClosed body / ContentLength-too-short + close). All content-length/chunked cases complete from data alone and pass.
+
+## Repro (verified)
+Minimal, no Cro (`tmp/repro-promise-supply-coerce.raku`):
+
+```raku
+my $s = Supplier.new;
+note "before coercion";
+my $p = Promise(supply {
+    my $acc = '';
+    whenever $s.Supply -> $v { $acc ~= $v; LAST emit $acc; }
+});
+note "after coercion: {$p.^name} status={$p.status}";
+start { $s.emit('a'); $s.emit('b'); $s.done; }
+say "result: ", await $p;
+```
+
+- raku: prints `after coercion: Promise status=Planned`, then `result: ab`.
+- mutsu (release): prints `before coercion` and hangs forever — the coercion itself blocks, the `start` never runs, deadlock.
+
+Cro-shape repro with the deadlock as seen in the test (`tmp/repro-bodytext-blocks.raku`, uses vendored Cro::HTTP::ResponseParser):
+- raku: `S: emitting` → emit returns → done sent → body resolves.
+- mutsu: `S: emitting` → `T: tap got response` (tap callback runs synchronously INSIDE `$in.emit` on the emitting thread — `.schedule-on($*SCHEDULER)` does not decouple) → `$r.body-text` never returns → `$in.done()` never executes → 10s timeout. Circular wait: the body promise can only resolve on `done`, and `done` can only be sent by the thread blocked waiting for the body promise.
+
+Chain in Cro: `body-text` → `body-blob` = `Promise(supply { whenever self.body-byte-stream {...} })` (`tmp/cro-work/C_RO_CRO_CORE_*/lib/Cro/MessageWithBody.rakumod:36-44`).
+
+## Root cause
+`Supply.Promise` for an on-demand supply (`supply { ... }` block) is implemented synchronously: dispatch at `src/runtime/native_supply_dispatch.rs:431-456` calls `supply_promise_on_demand` (`src/runtime/supply_promise.rs:330`), which runs the supply body inline and then **drives the react subscriptions on the calling thread** via `drive_react_subscriptions` with `SupplyDrivePolicy::Promise { deadline: now + 30s, .. }` (`src/runtime/supply_promise.rs:527-538`, loop in `src/vm/vm_react_loop.rs`). The coercion therefore does not return a Planned promise; it blocks until the supply is done or 30s elapse.
+
+Aggravating factor (secondary): mutsu tap callbacks run synchronously on the emitting thread; `.schedule-on` merely stores a `scheduler` attribute without changing delivery (`src/runtime/native_supply_dispatch.rs:457-468`). That is what puts the blocking coercion ON the producer thread and closes the deadlock cycle. (Repro `tmp/repro-schedule-on.raku`; note raku may also reuse the same pool thread, but its `emit` returns before the tap body runs — mutsu's does not.)
+
+Related minor anomaly noticed while bisecting (worth a one-line check in the same campaign): a tap's `done` callback can fire twice (`tmp/repro-class-transformer.raku` prints `OUT DONE` twice under mutsu, once under raku).
+
+## Fix direction
+Make on-demand `Supply.Promise` asynchronous:
+- In `supply_promise_on_demand`, after `run_on_demand_body` has collected the subscriptions (this part can stay synchronous — it must run the body to register whenevers), do NOT drive the react loop on the calling thread. Instead hand the `react_subs` + policy to a background drive: either
+  (a) spawn a GC-registered helper thread (`spawn_gc_helper_thread`, used at `supply_promise.rs:433` already — remember the "Gc-touching threads must be registered" rule) that owns a thread-clone interpreter and runs `drive_react_subscriptions_nested`, keeping/breaking the promise; or
+  (b) for live Supplier-backed sources, reuse the existing promise registry path (`supplier_register_promise`, `supply_promise.rs:351`) so the emitting thread itself resolves the promise on emit/done/quit — this is the same mechanism the `supplier_id_from_attrs` fast path at `native_supply_dispatch.rs:433-434` already uses for live supplies, extended to on-demand bodies whose whenevers hang off live suppliers.
+- Keep the synchronous drive for the `await $supply` path if it is load-bearing there (await is ALLOWED to block its thread — but note in this codebase `await` on a Supply likely routes through `.Promise` too; if so, `await` should block on the returned promise, not on the coercion).
+- Preserve the existing synchronous resolutions for static/finite sources (`react_subs.is_empty()` branch, `supply_promise.rs:396-401` / `:510-519`) — they resolve immediately and cannot deadlock; changing them would churn many passing tests.
+
+Risks: high-traffic machinery; the ordering guarantees of the current inline drive (values emitted synchronously before return) may be relied on by roast S17 supply tests. Time-box a survey of `SupplyDrivePolicy::Promise` callers first. A wrong thread-clone for the background drive can resurrect the shared-store collisions of the sibling tickets — prefer option (b) where possible since it adds no new thread.
+
+## Verification
+- `tmp/repro-promise-supply-coerce.raku`: prints `after coercion: Promise status=Planned` then `result: ab`.
+- `tmp/repro-bodytext-blocks.raku`: prints `S: after emit` / `S: after done` and `T: body promise resolved: Kept`.
+- `tmp/repro-respparser-untilclosed.raku`: C1 body Kept with `"hello\n"`; C2 body Broken with `X::Cro::HTTP::RawBodyParser::ContentLength::TooShort`.
+- `t/http-response-parser.rakutest`: 164/164 (subtests 111 and 120 pass; 116-119 keep passing).
+- roast S17-supply / S17-promise whitelist files locally, full roast via CI.

--- a/todo/tickets/regex-interp-dangerous-heuristic-overbroad.md
+++ b/todo/tickets/regex-interp-dangerous-heuristic-overbroad.md
@@ -1,0 +1,95 @@
+# `<$var>` regex interpolation rejected by over-broad "dangerous code" heuristic
+
+## Affected tests
+
+- `t/http-request-serializer.rakutest` (Cro::HTTP dist) — tests 16 and 17
+  ("multipart/form-data ..."), the `:rx` branch of `is-request`:
+  `like $joined-output.decode('utf-8'), /<$expected-output>/, $desc;`
+  dies `Prohibited regex interpolation`. This is the SECOND blocker of the file,
+  reachable only after the map/`when` succeed bug is fixed (see
+  `tap-map-grep-inline-block-swallows-succeed.md`); with both fixed the file
+  passes 1..17.
+
+## Repro
+
+`tmp/tapdiag-rxinterp.raku` (verified 2026-08-09):
+
+```raku
+my $p = Q/'boundary="' $<b>=[<-["]>+] '"'/;
+my $s = 'Content-type: multipart/form-data; boundary="abc123"';
+say ?($s ~~ /<$p>/);
+```
+
+- raku: matches (True; `$<b>` = `abc123`)
+- mutsu: `Prohibited regex interpolation` (X::SecurityPolicy), exit 1
+
+## Root cause
+
+`<$var>` interpolation compiles the string as regex source
+(src/runtime/regex_parse_core.rs:2520-2589). Before compiling it calls
+`contains_dangerous_regex_code`
+(src/runtime/regex_parse_modifier.rs:725-772) and raises
+`make_security_policy_error` (regex_parse_modifier.rs:847-856) on a hit
+(raise sites: regex_parse_core.rs:2560-2566 and
+src/runtime/regex/regex_match_capture.rs:359).
+
+The heuristic rejects plainly legal regex source:
+
+- any `<$` / `<@` substring (line 728) — but nested interpolation is legal raku;
+- `$(` / `@(` (line 732);
+- ANY `{` or `}` (line 736) — also hits `**{2..3}`-style quantifiers and other
+  non-code uses;
+- the double-quote check (lines 744-756): split on `"`, flag a `$`/`@`/`%`/`&`
+  inside an odd chunk. The Cro pattern above contains `"` characters inside
+  single-quoted literals (`'boundary="'`), so the "inside quotes" parity is
+  meaningless, and the `$<b>=` named-capture alias lands in an odd chunk → flagged;
+- `<\w+(...)>` subrule-with-args, `:my `/`:our `, `:(`.
+
+Rakudo's actual rule: interpolated regex source is compiled and matched; only
+*code execution* inside an interpolated regex (`{ ... }` code blocks,
+`<{ ... }>`, `<?{ ... }>`/`<!{ ... }>`) is prohibited without
+`use MONKEY-SEE-NO-EVAL` (X::SecurityPolicy::Eval). Named captures, char
+classes, quoted literals with any characters, and nested `<$x>` are all fine.
+
+## Fix direction
+
+Narrow `contains_dangerous_regex_code` to constructs that would EXECUTE code
+when the interpolated string is compiled:
+
+1. Tokenize just enough to find, outside quoted literals (`'...'` / `"..."`)
+   and char classes (`<[...]>`, `<-[...]>`):
+   - a bare `{` opening a code block,
+   - `<{`, `<?{`, `<!{`,
+   - `<::(` dynamic lookup (keep),
+   - `:my ` / `:our ` (keep — these declare in the caller's scope).
+2. Drop the `<$`/`<@`, `$(`/`@(`, double-quote-chunk, and `<\w+(...)>` checks
+   entirely, or gate them the same way (they must not fire inside quoted
+   literals / char classes). `$<name>=` is a capture alias, never code.
+3. Optional completeness: implement `use MONKEY-SEE-NO-EVAL` to allow even the
+   code cases when the pragma is active, and name the exception
+   `X::SecurityPolicy::Eval` with Rakudo's message ("Interpolation of a
+   variable that contains code ..."), so `throws-like` tests keyed on the type
+   still pass.
+
+Keep `contains_longname_alias` (regex_parse_modifier.rs:779) as is — separate
+check, not implicated.
+
+Risks: the heuristic is also consulted for match-time interpolation
+(regex_match_capture.rs:359); apply the same narrowed check there. Some roast
+security tests may pin the current over-broad behavior — run
+`grep -rl "Prohibited regex interpolation\|X::SecurityPolicy" t/ roast-whitelist.txt`
+before/after and adjust only mutsu-local `t/` pins, never roast.
+
+## Verification
+
+- The repro above matches with `$<b>` = `abc123` under mutsu.
+- `t/http-request-serializer.rakutest` tests 16-17 pass with the real `like`
+  regexes (probe already showed the serialized bytes are correct: with the
+  regex check stubbed to a `.contains('multipart/form-data')` check the file
+  passed 1..17, so this fix is the last measured blocker of the file — though
+  the exact `$<b>` boundary back-reference matching in the full pattern is
+  exercised for the first time by the real run).
+- Existing regex interpolation tests: `t/` files matching `rx-interp*` /
+  security-policy pins, plus a new `t/regex-interp-capture-alias.t` covering
+  `$<name>=[...]`, `<-["]>`, quoted `"` literals, and a genuine `{ code }`
+  rejection.

--- a/todo/tickets/rw-param-buf-element-assign-autovivifies-array.md
+++ b/todo/tickets/rw-param-buf-element-assign-autovivifies-array.md
@@ -1,0 +1,55 @@
+# Element assignment through an `is rw` parameter holding a Buf replaces the whole Buf with a fresh Array
+
+## Affected tests
+
+- `t/http2-frame-serializer.rakutest` subtest 11 ("Simple priority frame is not parsed back!"): serializing the Priority frame works (subtest 10 passes), but parsing it back dies inside `Cro::HTTP2::FrameParser`'s `my multi sub payload(2, Buf $data is rw, ...)` (FrameParser.rakumod line 159-166) at line 162 `$data[0] +&= 0x7F;` with:
+
+  ```
+  Type check failed for an element of $data; expected Buf but got Int (0)
+  ```
+
+  The parser's whenever body dies, the test's parser tap never fires, `$complete` times out, `flunk "$desc is not parsed back!"` fires.
+
+  (The Header-scan `$data[5] +&= 0x7F` at FrameParser line 55 does NOT hit this because there `$data` is a plain `my` local, not a typed rw parameter.)
+
+## Repro
+
+```raku
+sub f($d is rw) { $d[0] = 3; }
+my $b = Buf.new(0x80, 1);
+f($b);
+say $b.raku;
+```
+
+- mutsu (release and debug): `[3]` — the caller's Buf is replaced by a plain Array containing only the assigned element.
+- raku: `Buf.new(3,1)`.
+
+Variants (all verified):
+
+| Signature | mutsu result for `$d[0] = 3` on `Buf.new(0x80,1)` |
+|---|---|
+| `sub f(Buf $d)` (no rw) | `Buf.new(3,1)` — correct |
+| `sub f($d is rw)` | `[3]` — Buf lost |
+| `sub f(Buf $d is rw)` | dies `Type check failed ... expected Buf but got Int` (the Cro shape) |
+| `sub f($d is rw) { $d[1] = 9 }` | `[Any, 9]` — autoviv into a fresh Array |
+| `sub f(Array $d is rw)` on `[9,1]` | `$[3, 1]` — correct |
+
+Compound ops (`+&=`) go through the same read-modify-write and fail identically.
+
+## Root cause
+
+Reads through the rw parameter work (`$d[0]` returns 128), so the read path derefs the rw binding to the Buf. The **write** path does not: index assignment compiles to `Expr::IndexAssign` → `OpCode::IndexAssignExprNamed` → `exec_index_assign_expr_named_op` (`src/vm/vm_var_assign_element.rs:409` → `src/vm/vm_var_assign_index_named.rs:249`). That path has a dedicated Buf/Blob element-assignment lane (`vm_var_assign_index_named.rs` ~line 848: "Buf/Blob element and slice assignment") — but it is only reached when the variable's current value is seen as a Buf. When the callee's `$d` is an `is rw` binding (rw proxy / VarRef, not the raw Buf), the target classification misses the Buf lane and falls into the array autoviv lane, which builds a **fresh Array** sized to the index (hence `[3]` / `[Any, 9]`), and the rw writeback then propagates that Array (or, with a `Buf` type constraint on the parameter, fails the writeback type check with "expected Buf but got Int" — note the element value, not the array, reaches the check).
+
+The exact branch to fix is where `exec_index_assign_expr_named_op_inner` resolves the assignment target: it must deref an rw/VarRef target to its underlying value *before* classifying Buf vs Array vs autoviv, and route Buf/Blob targets into the existing Buf element lane so the mutation happens in the shared Buf cell (same as the non-rw parameter path already does).
+
+## Fix direction
+
+- In `src/vm/vm_var_assign_index_named.rs` (`exec_index_assign_expr_named_op_inner`, line 249ff): before the autoviv/array classification, if the target var's value is a VarRef/rw proxy, resolve it and re-dispatch on the underlying value; ensure the Buf/Blob lane (~line 848) accepts that resolved target and writes through to the shared cell, followed by the normal rw writeback of the (still-Buf) value.
+- Audit the sibling ops for the same gap: `IndexElemAutoviv`, `PostIncrementIndex`/`PostDecrementIndex` (compound `+&=` uses read-modify-write through the same named-index ops), and the slice-assign variant.
+- Risk: rw writeback of container values is delicate (see `news/2026-08` rw-accessor cell work); add pins for both the typed (`Buf $d is rw`) and untyped (`$d is rw`) shapes, and for compound ops.
+
+## Verification
+
+- New pin test `t/rw-param-buf-element-assign.t`: the repro table above (plain assign, compound `+&=`, index beyond 0, typed and untyped rw params), asserting the caller's Buf after the call.
+- `t/http2-frame-serializer.rakutest` subtest 11 passes (file needs the UInt-enum ticket `http2-uint-enum-typecheck.md` to reach its plan, and the lexical-sub ticket for subtests 4/5).
+- `tmp/h2-priority-parse.raku` (croflake.sh) prints the parsed Priority frame instead of QUIT.

--- a/todo/tickets/sibling-thread-my-array-merges-through-root-atomic-lane.md
+++ b/todo/tickets/sibling-thread-my-array-merges-through-root-atomic-lane.md
@@ -1,0 +1,59 @@
+# Sibling threads' distinct `my @a` bindings merge through the root-scoped `__mutsu_atomic_arr::` name lane
+
+## Affected tests
+- `t/http-session-inmemory.rakutest` subtests 8, 9 ("No session confusion with concurrent clients (A)/(B)")
+- `t/http-session-persistent.rakutest` subtests 8, 9 (same names)
+
+Observed failure shape: `$res-a` = `'Visit 1,Visit 1,Visit 2,...,Visit 8'` (9 elements) and `$res-b` = same prefix + one more element (10 elements) instead of two independent `'Visit 1..5'` strings. `$res-b` being exactly `$res-a` plus one trailing element proves both `start` blocks pushed into ONE array. The visit numbers running 1,1,2..9 (a single server-side counter) is the same bug hitting the cookie jar's internals: `Cro::HTTP::Client::CookieJar!purge` builds `my @replacer` and `add-to-request` builds `my @cookie-list` (plain lexicals, run concurrently by both clients' request pipelines), so the two jars' cookie lists merge, both clients start sending the same session cookie, and the two sessions collapse into one.
+
+## Repro (verified)
+`tmp/repro-start-await-r4.raku` — no Cro needed:
+
+```raku
+sub fetch($n, $i) { start { sleep 0.05; "$n$i" } }
+my $pa = start {
+    my @a;
+    for 1..5 -> $i { push @a, await fetch('A', $i) }
+    @a.join(',')
+}
+my $pb = start {
+    my @a;
+    for 1..5 -> $i { push @a, await fetch('B', $i) }
+    @a.join(',')
+}
+say "A: ", await $pa;
+say "B: ", await $pb;
+```
+
+- raku: `A: A1,A2,A3,A4,A5` / `B: B1,B2,B3,B4,B5`
+- mutsu (release): `A: A1,B1,A2,B2,A3,B3,B4,A4,A5` / `B: A1,B1,A2,B2,A3,B3,B4,A4,A5,B5`
+
+Negative controls that PASS (pin these to bound the fix):
+- Same loop with no nested spawn inside the threads (`push @a, "$n$i"; sleep 0.05` — no `await fetch`): no merge (`tmp/repro-start-my-array.raku`).
+- Scalar accumulator `my $acc = ''; $acc ~= $v` instead of `my @a`/push: no merge (`tmp/repro-start-await-r3.raku`).
+
+## Root cause
+Chain of three mechanisms, all by design individually, colliding:
+
+1. `my @a` inside a worker thread masks the name in `thread_redeclared_vars` (`src/vm/vm_var_assign_set_local.rs:1928-1945`), keeping it frame-local.
+2. **Any nested spawn drops that mask.** `clone_for_thread_excluding` force-`declare`s each re-declared name into the lineage store and then `retain`s away the mask (`src/runtime/runtime_thread.rs:241-249` and `:301-305`). The nested spawn here is the inner `start` in `fetch` (in Cro: every `$client.get` spawns). After that spawn, `container_name_is_redeclared("@a")` (`src/runtime/runtime_shared_vars.rs:210`) is false in that thread.
+3. With the mask gone, `ArrayPush` on a worker thread routes the push through the name-keyed atomic lane: gate at `src/vm/vm_data_push_ops.rs:123-135` (`is_thread_clone() || array_name_is_shared(...)`) → `shared_array_extend` (`src/runtime/builtins_atomic_shared.rs:253`). The lane key `__mutsu_atomic_arr::@a` is an *internal* key, and internal keys resolve at the **root store**, not the declaring lineage: `SharedStore::get`/`scope_for` in `src/runtime/shared_store.rs:106-114`, and `atomic_array_entry_exists` explicitly reads `self.shared_vars.root_store()` (`src/runtime/builtins_atomic_shared.rs:297-309`).
+
+So thread A's `@a` and thread B's `@a` — two unrelated frame-local bindings that merely share a bare name — both funnel into ONE process-global `__mutsu_atomic_arr::@a` entry, and each thread's final `@a.join(',')` reads the merged array. The ADR-0010 lineage chaining protects the base-name entries (`declare` binds into the current lineage) but the `__mutsu_atomic_arr::` lane bypasses it by being root-scoped.
+
+## Fix direction
+Preferred surgical fix: **scope the `__mutsu_atomic_arr::` / `__mutsu_atomic_hash::` keys to the lineage that owns the base name** instead of the root store. Concretely:
+- In `src/runtime/shared_store.rs`, make `scope_for` for `__mutsu_atomic_arr::@a` / `__mutsu_atomic_hash::%h` resolve to `owner_of("@a")` (the lineage tier that owns the base name via the nested-spawn `declare`), falling back to root only when no lineage owns the base name. `is_internal_key` currently sends all `__mutsu_*` keys to root; the atomic-array/hash lanes need the base-name-owner rule, while genuinely process-global internals (`__mutsu_shared_state::`, atomic-name lanes used by `cas`) keep root scoping.
+- Audit the direct `root_store()` reads: `atomic_array_entry_exists` (`src/runtime/builtins_atomic_shared.rs:297`) and the other `__mutsu_atomic_arr` sites listed by `git grep __mutsu_atomic_arr src/` (runtime_shared_vars.rs:130/472/507/572, runtime_thread.rs:765/877, vm_var_assign_local_get.rs, vm_env_helpers.rs, vm_call_method_mut_ops.rs) — they must all use the same owner-lineage resolution or reads/writes will split brain.
+
+Alternative (bigger, the ADR-0001/Track-B answer): give each `my @a` binding a per-binding `ContainerRef` cell and stop keying concurrency by name entirely. That is the long-term architecture; don't start it for this ticket.
+
+Do NOT "fix" this by keeping the redeclared mask across nested spawns — the force-declare + unmask exists to let genuinely shared re-declared names propagate (see the long comment at runtime_thread.rs:268-305); reverting it regresses `$port`/`$tap` bugs documented there.
+
+Risks: the lane is shared infrastructure for `t/lock.t`-style genuinely-shared arrays (parent declares `@a`, threads push) — that case still works because the parent's lineage owns the base name and all children resolve to it. Run `t/lock.t`, `t/thread-shared-scalar-visibility.t`, roast S17 whitelist files locally.
+
+## Verification
+- `tmp/repro-start-await-r4.raku` and `tmp/repro-start-await-r1.raku` print disjoint A/B sequences.
+- `t/http-session-inmemory.rakutest` subtests 8-9 pass (13/13 together with the other session tickets).
+- `t/http-session-persistent.rakutest` subtests 8-9 pass.
+- Negative controls above still pass; `make test` + CI roast green.

--- a/todo/tickets/slurpy-overflattens-nested-array-literals.md
+++ b/todo/tickets/slurpy-overflattens-nested-array-literals.md
@@ -1,0 +1,56 @@
+# `*@` slurpy over-flattens nested `[...]` literals (inner Array elements are not treated as containerized)
+
+## Affected tests
+
+- `t/http2-request-serializer.rakutest` subtests 3 and 6 (both named "check 1"): the test sub is `sub test($request, $count, $desc, *@checks, ...)` called with `[[check1..check4], [check1..check4]]`. Under mutsu `@checks` becomes the 8 individual check callables instead of 2 groups of 4, so `@checks[$counter]` is a *single callable* per frame — frame 2 of "Header + Data" runs `*.flags == 5`-style checks against the wrong frame and fails. It also silently reduces coverage everywhere in this file: each frame runs only "check 1" instead of its full 4-check group (visible in the TAP: one `check 1` per frame, no `check 2..4`).
+- `t/http2-response-serializer.rakutest` uses the same `*@checks` shape; its checks are currently unreachable (see `http2-supply-done-return-escapes-method.md`) but will hit this bug the moment that ticket is fixed.
+
+## Repro
+
+```raku
+sub f(*@c) { say @c.elems; say @c[0].raku; say @c[1].raku }
+f [[1,2],[3,4]];
+```
+
+- mutsu: `4` / `1` / `2` (fully flattened)
+- raku: `2` / `$[1, 2]` / `$[3, 4]` (one level flattened; inner Arrays preserved as itemized elements)
+
+Related probe results (mutsu vs raku):
+
+| Call | mutsu `@c.elems` | raku |
+|---|---|---|
+| `f [[1,2],[3,4]]` | 4 | 2 |
+| `my @x = [1,2],[3,4]; f @x` | 4 | 2 |
+| `f [$[1,2],$[3,4]]` (explicit itemization) | 2 | 2 |
+| `f [1,2]` | 2 | 2 |
+| `my $a = [[1,2],[3,4]]; f $a` | 1 | 1 |
+
+Underlying divergence: `[[1,2],[3,4]][0].raku` prints `[1, 2]` under mutsu but `$[1, 2]` under raku — mutsu does not model the Scalar container that every Array *element* lives in.
+
+## Root cause
+
+`flatten_value_for_slurpy` (`src/vm/vm_value_helpers.rs:548-554`) recurses into any `ValueView::Array` whose `ArrayKind` is not itemized (`ItemList`/`ItemArray`, see `src/value/value_collections.rs:18-20`). The function's contract ("itemized containers are preserved") is right, but the *inputs* never carry the itemization: an inner `[...]` literal element is stored as `ArrayKind::Array` (bare), because mutsu only marks itemization on explicit `$[...]` or scalar assignment — it does not model the rule that **elements of an Array are held in Scalar containers** and therefore never flatten further.
+
+In Raku the slurpy flattening rule is: expand Iterables recursively, but stop at anything inside a Scalar container. Since every element of a real Array is containerized, expanding an Array must contribute its elements *as-is* (one level); only List-kind (uncontainerized) elements keep flattening.
+
+## Fix direction
+
+Narrow, semantics-first fix in `flatten_value_for_slurpy` (`src/vm/vm_value_helpers.rs:548`): when the value being expanded is a **real Array** (`kind.is_real_array()`, i.e. `Array`/`ItemArray`/`Shaped`/`Lazy` — the `[...]` constructor and `@`-vars), push its elements without recursing into element Arrays; keep full recursion only for `List`-kind values (`(1,(2,3))` must still flatten to 3). Concretely: expand one level for Array-kind, recurse per-element only when the element is a non-itemized `List`.
+
+Cross-check cases the fix must keep correct (all verified against raku):
+
+- `my @x = 1,2; f @x` → 2 (unchanged)
+- `f (1,(2,3))` → 3 (List recursion preserved)
+- `f [1,[2,3]]` → 2 (raku: `1, $[2,3]`)
+- `f $a` where `$a = [[..],[..]]` → 1 (itemized scalar: unchanged)
+
+Also audit the two other callers of the helper (`vm_value_helpers.rs:602`, `vm_exec_dispatch.rs:1905`) — they feed the same slurpy semantics and should inherit the fix.
+
+The deeper alternative — itemizing elements at `MakeArray` (`src/compiler/expr.rs:290`) so `[0].raku` prints `$[1, 2]` — is the "correct architecture" endpoint but has a much larger blast radius (every `.raku` output, `is-deeply` comparisons); do it only with roast coverage, as a separate change.
+
+## Verification
+
+- `raku`-vs-mutsu on the probe table above (all five rows).
+- `t/http2-request-serializer.rakutest`: subtests currently named "check 1" become the full 4-check groups; the file's TAP shows `check 1..check 4` per frame and 0 failures. Expect the file's total test count to GROW (each group's checks 2-4 start running) — update expectations accordingly, don't be surprised by a different plan count.
+- New pin `t/slurpy-nested-array.t` with the probe table.
+- `make test` — slurpy flattening is load-bearing everywhere; the roast run on CI is the real safety net (S06-signature tests).

--- a/todo/tickets/supplier-preserving-backlog-destroyed-by-done-immutable-lane.md
+++ b/todo/tickets/supplier-preserving-backlog-destroyed-by-done-immutable-lane.md
@@ -1,0 +1,64 @@
+# Supplier::Preserving backlog is destroyed by `done` (immutable-lane `supplier_reset`), so a tap registered afterwards sees nothing
+
+## Affected tests
+
+- `t/http2-response-parser.rakutest` subtest 5 ("Headers + Data") — deterministic: the check `*.body-blob.result == $random` hangs because `body-blob` never resolves; `$test-completed` times out.
+- `t/http2-request-parser.rakutest` subtests around 12/19/42/44 — **flaky, ordering-dependent**: the same mechanism hits whenever the Data frame + `body.done` are processed *before* the checking `start` block calls `.body-blob`. Fails as "Headers + Data"/"Headers + Continuation + Data" flunks or as a failing `check 4` (`*.body-blob.result eq $payload`). Under parallel load it fails; run serially it usually passes.
+- `t/http2-request-serializer.rakutest` subtest 12 ("POST with set-body round-trips correctly over HTTP/2") — occasional: round-trip body goes through the same body-byte-stream machinery.
+
+Mechanism in Cro: `Cro::HTTP2::GeneralParser` builds `my $body = Supplier::Preserving.new`, stores `$body.Supply` via `set-body-byte-stream`, then on a Data frame does `$stream.body.emit: .data` and `$stream.body.done` (GeneralParser.rakumod lines 74-82, 87-97). `Cro::MessageWithBody.body-blob` (Cro::Core) later taps that supply via `Promise(supply { whenever self.body-byte-stream { ... LAST emit $joined } })`. Shadow probes confirmed both sides use the same supplier object (`Supplier::Preserving|778`), emit(123 bytes)+done complete BEFORE the tap registers, and the tap then receives neither the backlog nor `done` — so the `Promise(...)` coercion's drive loop blocks (30s internal deadline; the test's 5s `Promise.in` wins).
+
+## Repro
+
+Pure Raku (`tmp/h2-preserving-accessor.raku`):
+
+```raku
+class Holder { has $.body }
+
+# Case E: emit/done through an instance accessor chain, tap afterwards
+my $s = Supplier::Preserving.new;
+my $h = Holder.new(body => $s);
+$h.body.emit(Buf.new(1,2,3));
+$h.body.done;
+my $got = False;
+$s.Supply.tap: -> $b { say "E got {$b.elems}"; $got = True },
+    done => { say "E done" };
+say "E result: ", $got;
+
+# Case F: same calls on the bare variable
+my $s2 = Supplier::Preserving.new;
+$s2.emit(Buf.new(4,5));
+$s2.done;
+$s2.Supply.tap: -> $b { say "F got {$b.elems}" }, done => { say "F done" };
+```
+
+- mutsu: `E result: False` (no replay, no done callback), while F works (`F got 2` / `F done`).
+- raku: `E got 3` / `E done` / `E result: True` / `F got 2` / `F done`.
+
+The full-chain hang is reproduced by `tmp/h2-resp-parse.raku` (via `bash tmp/croflake.sh`, absolute `MUTSU_BIN`): mutsu prints `in start, calling body-blob` and then hangs (`status: Planned`); raku completes with `match: True`.
+
+## Root cause
+
+mutsu has two "done" lanes for a Supplier instance:
+
+- **Immutable lane** — `native_supplier` `"done"` arm, `src/runtime/native_supplier_methods.rs:367-467`. It ends with `supplier_reset(supplier_id)` (line 465), and `supplier_reset` (`src/runtime/native_methods/state.rs:558-568`) clears `state.emitted`, `emitted_seq`, AND the `done` flag in the process-global `SupplierRuntimeState`.
+- **Mutable lane** — `native_supplier_mut` `"done"` arm (same file, ~line 867+), which updates the instance's own attrs (`done => True`) and resets conditionally.
+
+A method call chained off an accessor (`$h.body.done`, `$stream.body.done`) dispatches down the immutable lane; a call on a bare variable (`$s.done`) takes the mutable lane — hence case E vs case F. For a `Supplier::Preserving` with **no tap/sink registered at done time**, the immutable lane's reset destroys exactly the state that Preserving exists to keep: the buffered values (`state.emitted`, watermarked by `preserved_consumed`, state.rs:175-183) and the terminal event. A later tap registration replays via `supplier_take_preserved_backlog` (state.rs:450) and `supplier_take_preserved_terminal` (state.rs:475) — both find a virgin state, so the tap gets nothing and a drive loop waiting on the supplier (`supplier_sink_register`, state.rs:220 — which replays `state.emitted` + `state.done`) blocks forever.
+
+This is the remaining piece of the known "done's supplier_reset wipes the buffer" family (see `news/` for #6129, which fixed the sink-ordering variant); the no-consumer-at-done case is still broken.
+
+## Fix direction
+
+In the immutable-lane `"done"` arm (`native_supplier_methods.rs:465`): when `attributes.contains_key("preserving")`, do **not** `supplier_reset` — leave `state.emitted` and `state.done` intact so the existing `preserved_consumed` / `preserved_terminal_delivered` watermarks give exactly-once replay to the next tap (that machinery already exists and is exercised by the passing case F path). Check the mutable-lane arm (~line 988 `supplier_reset(sid)`) for the same guard so the two lanes stay in parity; ideally extract one shared done-finalization helper.
+
+Risk: `supplier_reset` exists so a plain (non-preserving) Supplier can be reused after done — keep that behavior for non-preserving suppliers. Regression surface is the react/whenever done ordering fixed in #6129 (`tcp.rakutest` hang) and the S17 supply tests; also `t/supply-*.t`.
+
+## Verification
+
+- `tmp/h2-preserving-accessor.raku`: case E prints `E got 3` / `E done` / `E result: True`.
+- `tmp/h2-resp-parse.raku` (croflake.sh): prints `blob elems: 123 match: True`, `status: Kept`.
+- `t/http2-response-parser.rakutest`: 5/5 (currently 4/5 + flunk).
+- `t/http2-request-parser.rakutest`: 54/54 stable under load — run it ~5x and once with 4 concurrent instances; the flaky body-blob check-4 failures should disappear.
+- `t/http2-request-serializer.rakutest` subtest 12 stable across repeats.
+- `make test` (t/lock.t, t/supply-batch-period.t are nearby supply-state pins).

--- a/todo/tickets/supply-done-in-method-supply-block-escapes-as-cx-return.md
+++ b/todo/tickets/supply-done-in-method-supply-block-escapes-as-cx-return.md
@@ -1,0 +1,47 @@
+# `done` in a `supply` block declared inside a method leaks CX::Return, killing the tap with a quit
+
+## Affected tests
+
+- `t/http2-response-serializer.rakutest` subtests 1, 2, 3 ("Header", "Header + Data", "Header + Data - Content-Length unspecified"): the ResponseSerializer transformer emits **no frames at all**, so `$test-completed` times out and all three `flunk`. The trigger is `Cro::HTTP2::ResponseSerializer.transformer`'s `react { whenever $resp.push-promises() { ... } }` (ResponseSerializer.rakumod line 50): for a non-2.0 response, `Cro::HTTP::Response.push-promises` (Cro::Core `lib/Cro/HTTP/Response.rakumod:129-133`) returns `supply { done }` **from a method**. Under mutsu the `done` unwinds as `CX::Return`, the react block dies, and the whole transformer supply quits before the Headers frame is emitted.
+
+## Repro
+
+`tmp/h2-react-done2.raku`, minimal variant:
+
+```raku
+class A {
+    method pp() { supply { done } }
+}
+react { whenever A.new.pp() -> $x { say "got $x" } }
+say 'ok';
+```
+
+- mutsu: `A react block: Died because of the exception: CX::Return` (exit 1)
+- raku: `ok`
+
+The same body in a **plain sub** works (`sub pp-sub() { supply { done } }` — passes), as does an inline `react { whenever (supply { done }) {} }`. Even a plain `.tap` on the method-returned supply delivers `quit => CX::Return` instead of `done` (`tmp/h2-react-done3.raku`).
+
+Cro-level repro: `tmp/h2-resp-ser1.raku` (via `bash tmp/croflake.sh`, absolute `MUTSU_BIN`) prints `QUIT: A react block: ... CX::Return`; raku prints `GOT FRAME: Cro::HTTP2::Frame::Headers`.
+
+## Root cause
+
+1. The parser desugars a bare `done` inside a `supply` block into `$emitter.done(); return Nil` — `src/parser/primary/ident/supply.rs:131-140` (`Stmt::ReactDone => SyntheticBlock([MethodCall done, Stmt::Return(Nil)])`). The `Return(Nil)` is what terminates the on-demand body (Rakudo semantics: statements after `done` do not run).
+2. That `Return` is an ordinary routine-return signal. When the on-demand lambda runs (at tap time), the return unwinds through the closure boundary logic in `src/vm/vm_closure_dispatch.rs:805-828`: for a non-routine closure, the return is **propagated to the lexically enclosing routine** whenever a target can be identified — `has_target = e.return_target_callable_id().is_some() || data.env.contains_key("__mutsu_callable_id")`. The code comment even names this exact case: "If no target exists (e.g., supply block done+return), catch it locally."
+3. A closure created inside a **method** captures `__mutsu_callable_id` in its env (set when running the routine, see `src/runtime/builtins_operators_fallback.rs:579-590`), so `has_target` is true, the Return is stamped with the method's callable id and re-raised. The method frame returned long ago, so nothing consumes it and it escapes to the tap as an error → the supply quits with `CX::Return`. A closure created in a plain sub / mainline has no `__mutsu_callable_id` in env, hits the "catch locally" branch, and works — which is exactly the observed sub-vs-method asymmetry.
+
+## Fix direction
+
+Two options; A is surgical, B is the clean one:
+
+- **Option A**: in `vm_closure_dispatch.rs` (the `!cc.is_routine` branch at ~line 809), treat an on-demand supply lambda as a local return boundary: if the executing closure's parameter is the supply emitter (name starts with `crate::parser::SUPPLY_EMITTER_PREFIX`, see `src/parser/mod.rs:17`; the param name is available on the compiled closure / SubData), catch the return locally instead of consulting `has_target`. The desugared `Return(Nil)` is the only `return` that can textually target the lambda itself, and a user-written `return` inside a supply block *should* target the enclosing routine only while that routine is still on the stack — Rakudo also treats escaping the frame as `X::ControlFlow::Return`, not a tap quit, so guarding this on the emitter-param prefix keeps user `return` semantics unchanged for the live-frame case.
+- **Option B**: stop reusing `Stmt::Return` in the desugar. Give `supply.rs:131` a dedicated statement (e.g. `Stmt::SupplyBodyDone`) compiled to a control error that `run_on_demand_body` (`src/runtime/supply_promise.rs:93`) and the tap/react drive paths consume as normal termination (they already consume `is_react_done()` errors — but note the desugar deliberately does NOT use the react-done signal, because a bare `done` in a *supply* block must not terminate an enclosing react loop; the new control must be distinct from both `Return` and `ReactDone`).
+
+Risk: the `done`-terminates-body semantics must be preserved (`supply { done; say "after" }` must not print "after" — pinned by comparing with raku), and react-block `done` (`Stmt::ReactDone` outside supply rewrite) must keep travelling to the react loop.
+
+## Verification
+
+- `tmp/h2-react-done2.raku`: all five variants print their `ok` lines, matching raku.
+- `tmp/h2-react-done3.raku`: `.tap` fires the `done` callback, not `quit`; react completes.
+- `raku -e`-vs-mutsu spot check: `my $s = supply { done; say "after done" }; $s.tap: {}, done => { say "DONE" }` → prints only `DONE`.
+- `t/http2-response-serializer.rakutest`: 5/5 (currently 2/5). Note subtests 1-3 each have per-frame `ok $check($frame)` checks that will start executing; the file also depends on the slurpy ticket (`http2-slurpy-overflatten.md`) for those inner checks to iterate correctly, but plan/pass counts for the file's 5 named tests do not.
+- `make test` + existing supply tests (`t/supply-*.t`, S17 whitelisted files are the regression surface for return/done semantics).


### PR DESCRIPTION
## Summary

Deliverables of the 2026-08-09 Fable design/diagnosis session (design now, implementation in follow-up sessions per the agreed two-phase plan):

### ADR-0022 — regex `|` alternation LTM ranking (`docs/adr/0022-regex-alternation-ltm-ranking.md`)
- Full design for ranking alternation branches by **(declarative-prefix match length desc, longest-literal litlen desc, declaration order asc)** — rakudo's actual LTM — replacing mutsu's current longest-actual-match + declaration-order-tie rule.
- Semantics validated two ways: a ~40-case probe matrix against rakudo v2026.06, and a direct reading of nqp's `src/QRegex/NFA.nqp` (LITEND/litlen mechanics, `subcapture` transparency, `ws`→fate, `||` first-branch + ε-bypass, `<?{}>` ε vs `{}` fate).
- Reuses ADR-0009's `LTM_DECLARATIVE_MODE` measurement machinery (no NFA build); 5 implementation slices with file/function-level pointers, perf guards, and a raku-verified acceptance matrix destined for `t/regex-ltm-alternation.t`.
- Root cause of Cro `http-router.rakutest` test 61 (the file's last failure) and roast `S05-metasyntax/longest-alternative.t` 28/50/54; folds in two adjacent gaps found during validation (no backtracking into shorter ends of the chosen branch; losing branches' code blocks execute).
- BLOCKERS.md row refreshed (file is 59/62, the recorded 57/62 was stale); the deep ticket now points at the ADR.

### 16 diagnosis tickets (`todo/tickets/`)
Cover every currently non-green Cro::HTTP file in the http2/session/TAP-incomplete clusters. Each ticket: verified mutsu-vs-raku repro, root cause with `src/` line references, fix direction, verification plan. All are general interpreter bugs:

- **http2 cluster**: lexical sub unregistered on routine return (escape analysis misses side-channel escapes); `done` in a method's supply block escapes as CX::Return; `Supplier::Preserving` backlog destroyed by immutable-lane `done`; rw-param Buf element assign autovivifies an Array; `*@` slurpy over-flattens nested `[...]`; enum value fails `UInt` typecheck.
- **session cluster**: sibling threads' `my @a` merge through the root-scoped `__mutsu_atomic_arr::` lane; method-call named-arg closure literal not marked escaping; `%`-sigil params never masked from the cross-thread name store; bare `hash` term stringified; `Promise(supply{...})` drives the react loop synchronously (deadlock).
- **TAP-incomplete cluster**: dynamic vars leak process-wide via `start` shared-vars seeding; map/grep inline fast path swallows the `when` succeed signal; over-broad `<$var>` regex-interpolation security heuristic; pointy-block `+a` sigilless slurpy unparsed; `Parameter.usage-name`/`constraint_list`/`default` missing.

Docs-only diff — the heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)