### PR TITLE
refactor(runtime): attr_decls covers our/my attributes, drops has-decl raw-Stmt fallback (ADR-0019 D10 partial)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1539,6 +1539,42 @@ walkers wholesale is not possible before then.
   beyond a cleanup PR, an earlier slice landed incompletely. The doc also fixes the
   cross-box dependency order: D2b-2 → D6-1..3 (D3-8a-d and D4-1/2 parallel) → D4-3 → D7 →
   D8 → D9 → field drops → D5 gate → D10.
+  **Partial progress 2026-08-09** (grep survey after D6-4/D9-5 landed): the `from_stmt`
+  criterion had two live violations — `class_body_has_decl`/`role_body_has_decl`'s
+  our/my-attribute fallback, added in D6-4/D9-5 themselves to preserve behavior for an
+  attribute the compiler's `attr_decls` collector deliberately excluded. Both collectors
+  (`compile_class_attr_decls`/`compile_role_attr_decls`) already build a full
+  `CompiledAttrDecl` via the identical `from_stmt` logic at COMPILE time; the class-side
+  exclusion (`if !*is_our && !*is_my`) was dropped (the role side already had no such
+  exclusion, so `role_body_has_decl`'s fallback had in fact been dead code since D7-4/D2c-4
+  landed, just never noticed until this grep pass), closing the gap for good. Both functions
+  now take the attribute's `Symbol` name and `.expect()` a lookup hit instead of falling back
+  to `from_stmt` — sound because `attr_decls` and `body_plan`/`class_body_plan` walk the
+  identical (flattened, nested-sub-surfaced) statement sequence, so every `Attr` op has a
+  matching `attr_decls` entry by construction. `ClassBodyOp::Attr`/`RoleBodyOp::Attr` shrank
+  back to a bare `{ name: Symbol }` marker (dropping the `raw: Stmt`/`raw: Box<Stmt>` field
+  D6-4/D9-5 had just added for this fallback), and `CompiledClassDeclPlan`/`CompiledRoleDeclPlan`
+  no longer carry any `#[allow(dead_code)]` shims from the pre-cutover "purely additive"
+  phase. Verified via the full `t/` suite, all Rust unit tests, the `S12-class`/
+  `S12-construction`/`S14-roles`/`S05-grammar`/`S12-attributes` roast files (the
+  `S12-attributes/trusts.t` 6-subtest failure is pre-existing per `TODO_roast/BLOCKERS.md`,
+  unrelated), `scripts/battery-testsuite.sh`, and a hand comparison against `raku` covering a
+  class/role `our`/`my` attribute plus a nested-sub `has`.
+  **Box left open**: the grep criterion's stricter reading — *zero* `Stmt::`-matching
+  registration code outside token/rule/augment — is not met and is not attempted here. The
+  remaining `Stmt::` reads are `ClassBodyOp::Other`/`ClassSub`/`CodeAlias`/`ProtoMethod`/
+  `LeavePhaser`'s own `raw: Stmt` field (each already a *typed op*, chosen by `body_plan`
+  without any AST walk; `raw` supplies that one op's specific payload — e.g. `ProtoMethod`'s
+  param defs, `LeavePhaser`'s inner body) and `RoleBodyOp::Deferred`'s `raw` (the stub-marker
+  check). This is the same shape the ADR's own C6 precedent blessed for `FunctionDef.body`
+  (a body-less def still needs *some* raw form for its pure-interpreter fallback) — it is
+  payload extraction from an already-classified op, not AST-shape dispatch, so it is not
+  itself a walker. Closing D10 to the letter of the design note's criterion would mean
+  giving every one of those five/six arms a fully typed payload with zero `Stmt` reads —
+  out of proportion to a "cleanup PR" and not scoped here. Leaving D10 unchecked rather than
+  overclaiming; a future session should either accept the `Other`/`Deferred`-style raw
+  payload as the permanent D10 end state (parallel to C6's accept-and-move-on) or scope the
+  remaining typed-payload work explicitly.
 
 ### Phase E — one dispatch resolver and native handler table
 

--- a/news/2026-08/d10-attr-decls-cover-our-my-attributes.md
+++ b/news/2026-08/d10-attr-decls-cover-our-my-attributes.md
@@ -1,0 +1,41 @@
+# ADR-0019 D10 (partial): attr_decls now covers our/my attributes, drops the has-decl raw-Stmt fallback
+
+`class_body_has_decl` and `role_body_has_decl` no longer fall back to
+rebuilding a `CompiledAttrDecl` from a raw `Stmt::HasDecl` at registration
+time. The compiler's `compile_class_attr_decls` previously excluded a
+class-level `our`/`my` attribute from the `attr_decls` table it builds at
+plan-lowering time — the reason `class_body_has_decl` needed a raw-statement
+fallback in the first place (added in ADR-0019 D6-4, closes D6). Dropping
+that exclusion means every `has` declaration, `our`/`my` included, now has a
+compile-time descriptor, so the registration-time lookup always hits.
+
+The role side turned out to already have full coverage:
+`compile_role_attr_decls` never excluded `our`/`my` attributes to begin
+with, so `role_body_has_decl`'s equivalent fallback (added in D9, closes D9)
+had actually been dead code since the role attribute-descriptor collector
+landed — this PR is what surfaced it via a grep sweep for `from_stmt`
+callers.
+
+With both fallbacks gone, `ClassBodyOp::Attr`/`RoleBodyOp::Attr` no longer
+need to carry a raw statement at all — they shrink back to a bare
+`{ name: Symbol }` marker, the same shape as `Method`/`Does`/`Parent`. Two
+stale `#[allow(dead_code)]` annotations left over from `body_plan`'s
+"purely additive, no consumer yet" phase (before D6-4/D9 wired it up as the
+walk's sole driver) are also removed now that the fields are genuinely
+read.
+
+Verified via the full `t/` suite, all Rust unit tests, the
+`S12-class`/`S12-construction`/`S14-roles`/`S05-grammar`/`S12-attributes`
+roast files (the `S12-attributes/trusts.t` failure is pre-existing per
+`TODO_roast/BLOCKERS.md`, unrelated to this change),
+`scripts/battery-testsuite.sh`, and a hand comparison against `raku`
+covering a class and a role with `our`/`my` attributes plus a nested-sub
+`has`.
+
+This closes the two concrete `from_stmt` gaps ADR-0019's D10 box flagged,
+but not the box itself — the remaining `Stmt::` reads in the class/role
+body walk (`Other`/`ClassSub`/`CodeAlias`/`ProtoMethod`/`LeavePhaser`'s own
+`raw` field, `Deferred`'s stub-marker check) are typed-op payload
+extraction, not AST-shape dispatch, mirroring the ADR's own accepted C6
+`FunctionDef.body` precedent. See the ADR's D10 entry for the open
+question of whether that is the intended permanent end state.

--- a/src/compiler/decl_plan.rs
+++ b/src/compiler/decl_plan.rs
@@ -398,23 +398,25 @@ impl Compiler {
             .collect()
     }
 
-    /// Precompile a full `CompiledAttrDecl` for each attribute a class body
-    /// declares directly in its own body (ADR-0019 D2b remainder), keyed by
-    /// attribute name so `class_body_has_decl` can look one up without
-    /// depending on its registration-time walk visiting attributes in
-    /// exactly this order. Mirrors `class_own_attribute_names`'s eligibility
-    /// (`our`/`my` class-level attributes are excluded — see
-    /// `run_class_body`'s early `SkipTail` return before the per-instance
-    /// attribute is registered) and traversal (SyntheticBlock-flattened top
-    /// level plus `has` nested directly inside a body `sub`, recursively) —
-    /// same helper shape as `class_own_attribute_names`/
-    /// `collect_nested_has_decl_names`, which the earlier
-    /// `collect_attr_is_default_chunks` did NOT share, double-pushing a
-    /// nested-sub `has ... is default` (once from the `SubDecl` arm's direct
-    /// loop, once from its own recursive call re-matching the same
-    /// statement). This mirrors the registration-side non-recursive-repeat
-    /// exactly to avoid that trap, harmless as it was under
-    /// first-match-wins name-keyed lookup.
+    /// Precompile a full `CompiledAttrDecl` for each `has` declaration a
+    /// class body declares directly in its own body (ADR-0019 D2b
+    /// remainder/D10), keyed by attribute name so `class_body_has_decl` can
+    /// look one up without depending on its registration-time walk visiting
+    /// attributes in exactly this order. Includes a class-level `our`/`my`
+    /// attribute too (unlike `class_own_attribute_names`, which is
+    /// per-instance-attribute-only and correctly keeps excluding them) —
+    /// `class_body_has_decl` branches on `decl.is_our`/`decl.is_my` itself
+    /// once it has the descriptor, so there is no reason for this table not
+    /// to carry every `has` statement's descriptor. Traversal
+    /// (SyntheticBlock-flattened top level plus `has` nested directly
+    /// inside a body `sub`, recursively) is the same shape as
+    /// `class_own_attribute_names`/`collect_nested_has_decl_names`, which
+    /// the earlier `collect_attr_is_default_chunks` did NOT share,
+    /// double-pushing a nested-sub `has ... is default` (once from the
+    /// `SubDecl` arm's direct loop, once from its own recursive call
+    /// re-matching the same statement). This mirrors the registration-side
+    /// non-recursive-repeat exactly to avoid that trap, harmless as it was
+    /// under first-match-wins name-keyed lookup.
     fn compile_class_attr_decls(
         &self,
         body: &[Stmt],
@@ -426,12 +428,7 @@ impl Compiler {
                 other => vec![other],
             })
             .filter_map(|stmt| match stmt {
-                Stmt::HasDecl {
-                    name,
-                    is_our,
-                    is_my,
-                    ..
-                } if !*is_our && !*is_my => Some((*name, self.compile_class_attr_decl(stmt))),
+                Stmt::HasDecl { name, .. } => Some((*name, self.compile_class_attr_decl(stmt))),
                 _ => None,
             })
             .collect();
@@ -449,15 +446,7 @@ impl Compiler {
                 Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. } | Stmt::HasDecl { .. } => {}
                 Stmt::SubDecl { body, .. } => {
                     for inner in body {
-                        if let Stmt::HasDecl {
-                            name,
-                            is_our,
-                            is_my,
-                            ..
-                        } = inner
-                            && !*is_our
-                            && !*is_my
-                        {
+                        if let Stmt::HasDecl { name, .. } = inner {
                             out.push((*name, self.compile_class_attr_decl(inner)));
                         }
                     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2796,14 +2796,12 @@ pub(crate) struct CompiledClassDeclPlan {
 /// One class-body statement, typed (ADR-0019 D6-3a). See
 /// [`CompiledClassDeclPlan::body_plan`].
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub(crate) enum ClassBodyOp {
     /// A top-level (or nested-sub) `has` declaration. Its typed descriptor
-    /// normally lives in `attr_decls`, keyed by this same name; `raw` is
-    /// used only as a fallback when it is not there (a class-level
-    /// `our`/`my` attribute, which `attr_decls`'s compiler-side collector
-    /// deliberately excludes — see `class_body_has_decl`).
-    Attr { name: Symbol, raw: Stmt },
+    /// lives in `attr_decls`, keyed by this same name (ADR-0019 D10:
+    /// `attr_decls` covers a class-level `our`/`my` attribute too, so no
+    /// raw-statement fallback is needed here — see `class_body_has_decl`).
+    Attr { name: Symbol },
     /// A `method`/`submethod` declaration. Advances the existing
     /// `method_name_chunks`/`method_decls` position cursor.
     Method,
@@ -2894,10 +2892,7 @@ fn classify_class_body_stmt(stmt: &Stmt) -> ClassBodyOp {
             chunk: None,
             raw: stmt.clone(),
         },
-        Stmt::HasDecl { name, .. } => ClassBodyOp::Attr {
-            name: *name,
-            raw: stmt.clone(),
-        },
+        Stmt::HasDecl { name, .. } => ClassBodyOp::Attr { name: *name },
         Stmt::MethodDecl { .. } => ClassBodyOp::Method,
         Stmt::DoesDecl { name, .. } => ClassBodyOp::Does { name: *name },
         Stmt::VarDecl {
@@ -2964,20 +2959,12 @@ pub(crate) struct RoleParentOp {
 /// separate type built from this one's `Deferred` ops.
 #[derive(Debug, Clone)]
 pub(crate) enum RoleBodyOp {
-    /// A top-level `has` declaration. Its typed descriptor normally lives in
-    /// `attr_decls`, keyed by this same name; `raw` is used only as a
-    /// fallback when it is not there (a role-level `our`/`my` attribute,
-    /// which `attr_decls`'s compiler-side collector excludes — see
-    /// `role_body_has_decl`). Boxed for the same enum-size reason as
-    /// `Deferred`'s `raw`. `name` has no non-test reader (`walk_role_body`
-    /// reads the name back out of `raw` via `role_body_has_decl`'s own
-    /// `Stmt::HasDecl` match instead) — kept for parity with
-    /// `ClassBodyOp::Attr` and pinned by `role_declarations_precompute_body_plan`.
-    Attr {
-        #[allow(dead_code)]
-        name: Symbol,
-        raw: Box<Stmt>,
-    },
+    /// A top-level `has` declaration. Its typed descriptor lives in
+    /// `attr_decls`, keyed by this same name — `compile_role_attr_decls` has
+    /// always covered a role-level `our`/`my` attribute too, so no
+    /// raw-statement fallback is needed here (ADR-0019 D10; see
+    /// `role_body_has_decl`).
+    Attr { name: Symbol },
     /// A `method`/`submethod` declaration. Advances the existing
     /// `method_name_chunks`/`method_decls` position cursor.
     Method,
@@ -3013,10 +3000,7 @@ pub(crate) fn role_body_plan(body: &[Stmt]) -> Vec<RoleBodyOp> {
 
 fn classify_role_body_stmt(stmt: &Stmt) -> RoleBodyOp {
     match stmt {
-        Stmt::HasDecl { name, .. } => RoleBodyOp::Attr {
-            name: *name,
-            raw: Box::new(stmt.clone()),
-        },
+        Stmt::HasDecl { name, .. } => RoleBodyOp::Attr { name: *name },
         Stmt::MethodDecl { .. } => RoleBodyOp::Method,
         Stmt::DoesDecl { .. } => RoleBodyOp::Parent,
         _ => RoleBodyOp::Deferred {

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -152,9 +152,9 @@ impl Interpreter {
                     });
                     continue;
                 }
-                crate::opcode::ClassBodyOp::Attr { raw, .. } => {
+                crate::opcode::ClassBodyOp::Attr { name } => {
                     if matches!(
-                        self.class_body_has_decl(&mut cx, raw)?,
+                        self.class_body_has_decl(&mut cx, *name)?,
                         ClassBodyFlow::SkipTail
                     ) {
                         continue;

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -112,31 +112,19 @@ impl Interpreter {
     pub(super) fn class_body_has_decl(
         &mut self,
         cx: &mut ClassBodyCx<'_>,
-        stmt: &Stmt,
+        name: crate::symbol::Symbol,
     ) -> Result<ClassBodyFlow, RuntimeError> {
         // Look up this attribute's precompiled descriptor (ADR-0019 D2b
-        // remainder) by name before falling back — `Stmt::HasDecl::name` is
-        // cheap to read directly, and a name-keyed lookup does not depend on
-        // this walk visiting attributes in the same order
-        // `compile_class_attr_decls` built the plan's vec in. A miss (a
-        // class-level `our`/`my` attribute, which the compiler-side vec
-        // excludes, or a registration path with no compiled plan at all)
-        // falls back to building one from the raw statement, same as before
-        // this migration.
-        let decl = match stmt {
-            Stmt::HasDecl { name, .. } => cx
-                .attr_decls
-                .iter()
-                .find(|(n, _)| n == name)
-                .map(|(_, decl)| decl.clone()),
-            _ => None,
-        }
-        .unwrap_or_else(|| {
-            crate::opcode::CompiledAttrDecl::from_stmt(
-                stmt,
-                crate::opcode::AttrDeclChunks::default(),
-            )
-        });
+        // remainder/D10) by name — `compile_class_attr_decls` walks the same
+        // (flattened, nested-sub-surfaced) statement sequence as
+        // `class_body_plan`, unfiltered, so every `Attr` op this walk visits
+        // has a matching entry here by construction.
+        let decl = cx
+            .attr_decls
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, decl)| decl.clone())
+            .expect("class_body_has_decl: no attr_decls entry for this Attr op's name");
         let attr_name_str = decl.name.clone();
 
         // An initializer that can never satisfy the constraint is a

--- a/src/runtime/registration_role_body.rs
+++ b/src/runtime/registration_role_body.rs
@@ -15,25 +15,20 @@ impl Interpreter {
     pub(super) fn role_body_has_decl(
         &mut self,
         cx: &mut RoleDeclCx<'_>,
-        stmt: &Stmt,
+        name: crate::symbol::Symbol,
     ) -> Result<(), RuntimeError> {
         // Look up this attribute's precompiled descriptor (ADR-0019 D2b
-        // remainder) by name before falling back — see the identical
-        // rationale in `class_body_has_decl`.
-        let decl = match stmt {
-            Stmt::HasDecl { name, .. } => cx
-                .attr_decls
-                .iter()
-                .find(|(n, _)| n == name)
-                .map(|(_, decl)| decl.clone()),
-            _ => None,
-        }
-        .unwrap_or_else(|| {
-            crate::opcode::CompiledAttrDecl::from_stmt(
-                stmt,
-                crate::opcode::AttrDeclChunks::default(),
-            )
-        });
+        // remainder/D10) by name — see the identical rationale in
+        // `class_body_has_decl`. `compile_role_attr_decls` has always
+        // covered a class-level `our`/`my` role attribute too (unlike the
+        // class side before D10), so this lookup has never needed a
+        // raw-statement fallback.
+        let decl = cx
+            .attr_decls
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, decl)| decl.clone())
+            .expect("role_body_has_decl: no attr_decls entry for this Attr op's name");
         let attr_name_str = decl.name.clone();
         // A class-level (`my $.x` / `our $.x`) role attribute is NOT a
         // per-instance attribute: it becomes a class-level attribute on the

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -149,8 +149,8 @@ impl Interpreter {
         // the real registration happens when the role body runs below.
         for op in body_plan {
             match op {
-                crate::opcode::RoleBodyOp::Attr { raw, .. } => {
-                    self.role_body_has_decl(cx, raw)?;
+                crate::opcode::RoleBodyOp::Attr { name } => {
+                    self.role_body_has_decl(cx, *name)?;
                 }
                 crate::opcode::RoleBodyOp::Parent => {
                     self.role_body_does_decl(cx)?;


### PR DESCRIPTION
## Summary
- `class_body_has_decl`/`role_body_has_decl` no longer fall back to rebuilding a `CompiledAttrDecl` from a raw `Stmt::HasDecl` at registration time.
- `compile_class_attr_decls` previously excluded a class-level `our`/`my` attribute from `attr_decls`; dropping that exclusion means every `has` declaration gets a compile-time descriptor and the registration-time lookup always hits.
- The role side already had full coverage (`compile_role_attr_decls` never excluded `our`/`my`), so `role_body_has_decl`'s equivalent fallback had actually been dead code since D7-4/D2c-4 — this PR is what surfaced it via a grep sweep for `from_stmt` callers.
- `ClassBodyOp::Attr`/`RoleBodyOp::Attr` shrink back to a bare `{ name: Symbol }` marker (matching `Method`/`Does`/`Parent`) now that neither needs a raw statement — the `raw` field D6-4/D9 had added for this fallback is removed.
- Also drops two stale `#[allow(dead_code)]` annotations left over from `body_plan`'s pre-cutover "purely additive" phase.
- Closes the two concrete `from_stmt` gaps ADR-0019's D10 box flagged, **not the box itself** — see the ADR entry for what's left (typed-op payload extraction in `Other`/`ClassSub`/`CodeAlias`/`ProtoMethod`/`LeavePhaser`, an accepted pattern mirroring the ADR's own C6 precedent).

## Test plan
- [x] `cargo build`, `cargo test --lib` (701 tests)
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] `make test` — 28,087 tests, all pass
- [x] `MUTSU_FUDGE=1 prove` on `roast/S12-class`, `roast/S12-construction`, `roast/S14-roles`, `roast/S05-grammar`, `roast/S12-attributes` (release binary) — the only failure is the pre-existing, non-whitelisted `S12-class/open_closed.t` and the pre-existing `S12-attributes/trusts.t` (6 subtests, matches `TODO_roast/BLOCKERS.md` exactly)
- [x] `scripts/battery-testsuite.sh` — 158/164 files pass (2 excluded), byte-identical to baseline
- [x] Hand comparison against `raku` covering `our`/`my` attributes on both a class and a role, plus a nested-sub `has` — byte-identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)