### PR TITLE
docs(adr): detailed designs for all ADR-0019 Phase E boxes

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -168,6 +168,21 @@ ADR-0009-scoped C6d-2, which does not gate C6 (token defs never come from
 `CompiledSubDeclPlan`) — it stays open only for the later `FunctionDef.body` field deletion
 (F7).**
 
+A 2026-08-10 design sweep produced detailed designs for **every Phase E box**, from a
+four-way code survey (owner-resolution sites, dispatch entry points, cache/registry state,
+multi/wrap/deferral machinery), recorded as
+`todo/deep/adr0019-e1-typeid-receiver-owner.md`,
+`todo/deep/adr0019-e2-e4-resolver-core.md`,
+`todo/deep/adr0019-e5-e7-entry-routing.md`, and
+`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`, with condensed entries in each box
+below. Notable outcomes: `TypeId` is a newtype over `Symbol` (dense ids rejected — the
+registry COW-forks per thread), E2 handler rows are recognition metadata whose completeness is
+counter-measured to zero *before* any read depends on them (the reverted attempt's fix), the
+E4 resolver caches an ordered candidate sequence that E9 turns into deferral cursors, and the
+survey corrected the entry-point inventory (see the Phase E preamble). The recommended
+cross-box order is E1a → E1b (→ E1c) → E2a → E4a → E2b → E4b → E3 → E5 → E6 → E7 → E8 →
+E9 → E10 → E11, with E10a movable earlier (anytime after E3).
+
 The count tallies top-level boxes only; sub-boxes (C6a–C6e, C6d-1..5, E1a/E1b) are that box's
 PRs, and a subdivided box is checked when its last sub-box merges. A box that turns out to need
 subdivision follows C6's precedent: measure first, then split in place.
@@ -1693,6 +1708,17 @@ the `ArrayPush` fast-path opcode that currently bypasses method dispatch entirel
 that inventory; each also rewrites a function larger than any slice merged so far
 (`exec_call_method_op` ~1.3k lines, `exec_call_method_mut_op` ~1.7k, the interpreter's
 `call_method_with_values` ~3.8k), so expect them to subdivide from a measurement, as C6 did.
+**Inventory corrections (2026-08-10 survey):** `call_method_with_values` lives in
+`runtime/methods_call_dispatch.rs`, not `runtime/methods.rs`; `call_method_mut_with_values`
+(`runtime/methods_mut_dispatch.rs`, ~2.6k lines) is a second slow path of comparable size and
+belongs to E6's inventory; `exec_call_method_dynamic_mut_op` reaches the interpreter with no
+native or compiled probe at all; and `exec_hyper_method_call_dynamic_op` lacks the
+user-override gate its static twin has — the last two are pre-existing behavior divergences to
+raku-verify and close during E6, not just refactor targets. The detailed designs for this
+phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
+`todo/deep/adr0019-e2-e4-resolver-core.md` (E2/E3/E4),
+`todo/deep/adr0019-e5-e7-entry-routing.md` (E5/E6/E7), and
+`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` (E8/E9/E10/E11).
 
 - [ ] **E1 — Introduce stable `TypeId` and receiver-owner resolution.** Resolve concrete values,
   type objects, user classes, builtin subclasses, role mixins, and representation aliases to an
@@ -1700,32 +1726,107 @@ that inventory; each also rewrites a function larger than any slice merged so fa
   lives at ~20 sites in 7 files today — including 14 per-MOP-entry fallbacks in
   `methods_classhow_dispatch.rs` and the alias logic baked into `value_type_name` itself — so
   this lands in two steps:
+  **Design 2026-08-10** (`todo/deep/adr0019-e1-typeid-receiver-owner.md`): `TypeId` is a
+  newtype over `Symbol` (dense ids rejected: the registry COW-forks per thread, and
+  `MethodEntryKey.owner` is already a Symbol); one static `BuiltinTypeInfo` catalog —
+  adjudicated against raku, not against the union of the current tables — replaces the four
+  divergent builtin MRO tables (`builtin_type_parents`, `Registry::builtin_mro_table`,
+  `builtin_type_mro_chain`, `builtin_type_distance`'s inline table); one classifier
+  `receiver_dispatch_class`/`dispatch_mro` produces the ordered chain plus definedness plus a
+  `ReceiverExec` hint (e.g. `ArrayStorageDelegate` for `is Array` subclasses). E1a's shadow
+  target is "reproduce the site's current decision" with an accepted-mismatch ledger for the
+  deliberate differences, which flip in E1b.
   - [ ] **E1a — shadow mode.** Compute the TypeId-based owner beside the string-based one and
     compare under a `MUTSU_VM_STATS`-gated counter; land with zero behavior change and drive the
     mismatch count to zero on `make test` plus targeted roast.
   - [ ] **E1b — switch.** Make the TypeId owner authoritative and delete the per-site string
     scans; the MOP fallback sites may follow as their own PR if the diff warrants it.
+  - [ ] **E1c — MOP fallback consolidation.** Collapse the 13+8 per-MOP-entry owner-fallback
+    arms into one classifier-backed `mop_receiver_owner` helper.
 - [ ] **E2 — Give every native entry an exact handler ID.** Generate static type×method handler rows
   for pure arity handlers and stateful/special handlers; pin type-object, subclass, Map/Seq,
   Failure, and Rat-style cases that broke the reverted attempt.
+  **Design 2026-08-10** (`todo/deep/adr0019-e2-e4-resolver-core.md`): rows are *recognition
+  metadata* (owner, name, arity mask, TYPE_OBJECT_OK/MUTATES/SPECIAL flags), not function
+  pointers — invocation stays in the arity cascades until F3. Coverage is measured to zero via
+  a `native_call_unmodeled` counter plus a cfg(test) inverse probe before any read depends on
+  rows (the ~700 cascade arms vs ~350 catalog slots gap is the reverted attempt's failure
+  mode). The admission-gate checks split per a classification table: method-identity facts
+  become row flags; receiver-state facts become resolver guards, deduplicating
+  `try_native_method_raw` and its twin `should_bypass_native_fastpath`.
+  - [ ] **E2a — row schema + instruments + pinned regression tests.** Zero behavior change.
+  - [ ] **E2b — drive `native_call_unmodeled` to zero** through the gate-classification table.
 - [ ] **E3 — Add the generation-keyed resolved-call cache.** Key by receiver TypeId, method symbol,
   call shape, and method generation; cache the ordered candidate sequence, not a second resolver.
+  **Design 2026-08-10** (same doc): lands after E4b. Key `(TypeId, Symbol, CallShape)` where
+  CallShape packs arity bucket + has-named (named calls get sequence caching for the first
+  time); joins `refresh_method_caches_for_generation`'s wholesale clear set; the two probe
+  sites that today bypass the generation refresh gain it. `fast_method_cache` survives as the
+  monomorphic IC in front until F5 — retiring it inside Phase E would be an unmeasured perf
+  cliff. Bench-CI parity evidence is part of this box's exit (G3's dispatch clause).
 - [ ] **E4 — Resolve native and user candidates in one MRO walk.** Preserve user shadowing,
   visibility, invocant definedness, arity/signature ordering, and native fallback in one result.
+  **Design 2026-08-10** (same doc): `resolve_sequence(chain, name, shape, definedness)` returns
+  a `ResolvedSequence` — the shape-independent ordered candidate universe (user candidates in
+  stored order per level, accessor arbitration, native rows at catalog levels, proto slot);
+  ranking/signature selection stays per-call via the existing ladder extracted to consume a
+  candidate slice. The six copy-pasted submethod no-inherit rules collapse into the one build
+  site. Sibling walkers migrate with their consumers (E7/E8/E9), not here.
+  - [ ] **E4a — sequence builder + shadow parity (user candidates only)**, counter-verified
+    against `resolve_method_with_owner_impl` outcomes.
+  - [ ] **E4b — authoritative switch at the cached-resolve boundaries**, native rows included,
+    `should_bypass_native_fastpath` deleted. Local `make roast` before PR.
 - [ ] **E5 — Route ordinary VM method calls through the resolver.** Cover zero/n-arg and named-call
   opcodes while retaining mutation/writeback semantics at the caller boundary.
+  **Design 2026-08-10** (`todo/deep/adr0019-e5-e7-entry-routing.md`): the cutover shape is
+  "resolver decides, existing arms execute" — each entry's dispatch-probe section becomes a
+  match on the resolver decision while receiver normalization, method-identity intercepts, and
+  writeback tails stay put. A measurement slice (per-entry per-outcome
+  `MUTSU_VM_STATS` counters + an interceptor-taxonomy table per entry) precedes and orders the
+  cutovers, C6d-style. JIT shims are asserted tail-identical, not rewritten. The interpreter
+  slow paths shrink by attrition (one probe section at a time), never by a one-PR rewrite.
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
+  **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow
+  path), the dynamic-mut and hyper-dynamic gate gaps (raku-verified, closed by routing through
+  the same decision), and `ArrayPush` — which keeps its container fast path behind a
+  generation-refreshed `array_dispatch_pristine` bit (no user/wrap rows under `Array`/`List`),
+  closing today's augmented-Array divergence with an O(1) check.
 - [ ] **E7 — Route metaobject, qualified, and re-entrant calls through the resolver.** Cover HOW,
   `.^lookup`/`.^can`, qualified/private dispatch, EVAL carriers, and method objects.
+  **Design 2026-08-10** (same doc): one consumer family per sub-PR (`run_instance_method`
+  carrier sites, qualified, private-as-sequence-query, `.^lookup`/`.^can`/`.^methods` reading
+  the call-path sequence, WALK, re-entrant carriers). The `.^can` dummy-`Value::NIL` probe is
+  replaced by an E2 row lookup — a correctness fix as well as a routing change.
 - [ ] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
+  **Design 2026-08-10** (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`):
+  candidates carry `level`/`stored_idx` so winner selection (existing ladder, per call) and
+  deferral order (sequence order + per-call signature filter) both derive from one sequence;
+  submethod visibility and `drop_flattened_role_duplicates` apply at build time.
+  `Registry::proto_methods` folds into `MethodEntry`. Unifying the method-vs-sub ranking
+  ladders is explicitly out of scope.
 - [ ] **E9 — Add resolver cursors for `samewith`/`nextsame`/`callsame`/`nextwith`.** Continue within
   the resolved sequence instead of re-entering name-based resolution.
+  **Design 2026-08-10** (same doc): one `DispatchCursor {seq, next, invocant, args}` replaces
+  the recomputed `MethodDispatchFrame.remaining` + fingerprint winner-removal; wrap chains
+  become cursor-prefix entries (deleting the `sub_id == 0` sentinel, `wrap_skip_once`, and the
+  by-name re-entries); the four synthesized native next-candidate fallbacks become ordinary
+  sequence tail entries; proto `{*}` re-ranks the cursor's sequence instead of re-entering by
+  name. **A mandatory raku verification campaign (E9-pre, 13 chain-order scenarios) lands as
+  `t/` pins before any cursor cutover** — this is the highest-semantic-risk box of the phase.
 - [ ] **E10 — Move wrap/unwrap mutation into canonical entries.** Bump the generation and remove
   wrap-specific cache-clearing paths.
+  **Design 2026-08-10** (same doc): `method_wrap_chains` moves into the registry; every
+  wrap/unwrap/restore path — including the two that currently invalidate nothing — bumps
+  `method_generation`; the global `has_any_wrap_chains()` prefilter (which disables the fast
+  cache program-wide once any wrap exists) is deleted after E3; the `.unwrap` method-wrap leak
+  is fixed en route.
 - [ ] **E11 — Retire arity-specific lookup entry points.** Keep native arity functions only as
   handler implementations selected by `MethodEntry`.
+  **Design 2026-08-10** (same doc): grep-based completion criterion — no caller of
+  `native_method_{0,1,2}arg` outside the resolver's native-invocation helper, `builtins/`
+  internal recursion, and `#[cfg(test)]`; added to the G2 architectural guard test.
 
 ### Phase F — derive introspection and remove compatibility state
 

--- a/todo/deep/adr0019-e1-typeid-receiver-owner.md
+++ b/todo/deep/adr0019-e1-typeid-receiver-owner.md
@@ -1,0 +1,253 @@
+# ADR-0019 E1 design: stable TypeId and receiver-owner resolution
+
+Design pass for Phase E box E1 (see the ADR's Phase E section). E1 is the foundation of the
+whole phase: the reverted handler-ID attempt (b252837e7, reverted f1485d136, 2026-08-04) failed
+not because handler IDs are wrong but because it consulted the registry with owners produced by
+`value_type_name()`, which is not a dispatch owner. Everything later in Phase E (E2 rows, E4
+resolver, E3 cache keys) keys on the owner E1 defines, so E1 must land first and land shadow-first.
+No code has landed for this box yet.
+
+## Problem statement
+
+The "who owns this method for this receiver" decision is scattered and inconsistent:
+
+1. **`value_type_name()`** (`src/runtime/utils/type_misc.rs:3`, returns `&'static str`) answers
+   `"Any"` for every user-class `Instance` (type_misc.rs:96), `"Package"` for every type object
+   (type_misc.rs:93), and bakes representation aliases into itself (`Hash` with
+   `declared_type == Some("Map")` → `"Map"` at :24; `LazyList` → `"Seq"`/`"Array"` by
+   `is_from_gather()` at :22; `Array(_, kind)` → `"Array"`/`"List"` by `kind.is_real_array()`
+   at :18).
+2. **Four near-duplicate naming paths** exist: `value_type_name`, `what_type_name`
+   (`src/value/types.rs:4` — resolves Instance/Package names, no Map alias, adds the
+   `+{Role}` mixin suffix), `Value::isa_check`'s inline third copy of the alias table
+   (`src/value/types_isa.rs:6`), and `dispatch_caret_name` (`.^name`,
+   `src/runtime/methods_introspect.rs:615`).
+3. **Four independent builtin MRO tables** that disagree with each other:
+   - `builtin_type_parents` (`src/builtins/builtin_type_methods.rs:845-862`): chains up to but
+     not including Any/Mu; has `Hash→[Hash,Map,Cool]`.
+   - `Registry::builtin_mro_table` (`src/runtime/registry.rs:573-615`): a disjoint set (Match,
+     Capture, IO::Spec::*, Distribution::*, CompUnit::*).
+   - `Interpreter::builtin_type_mro_chain` (`src/runtime/methods_call_helpers.rs:454-475`):
+     includes Any/Mu, but `Hash→[Hash,Cool,Any,Mu]` (no Map), plus Set/Bag/Mix/Regex/Sub/Junction
+     rows absent from the first table.
+   - `builtin_type_distance`'s inline table (`src/runtime/resolution_method.rs:473-503`): a
+     fourth spelling that also interleaves roles (`Int→[Int,Numeric,Real,Cool,Any,Mu]`,
+     `Sub→[Sub,Routine,Block,Code,Callable,Any,Mu]`), plus the Buf/Blob family table in
+     `dispatch_candidates.rs:672-700`.
+4. **~27 owner-decision sites** feed dispatch or the `(owner, method)` registry lookup, each
+   re-deriving the owner by hand. The dispatch-critical ones: `call_method_with_values`'s
+   augment gate (`methods_call_dispatch.rs:3646`), `dispatch_instance_and_fallback`'s
+   dispatch-class pick with its own hand-rolled `["Routine","Block","Code","Callable"]` walk
+   (`methods_instance_ops.rs:1675-1696`), the `.^add_fallback` MRO extension
+   (`methods_instance_ops.rs:2304`), qualified dispatch (`methods_qualified.rs:897`),
+   `type_matches_value` (`types/type_matching.rs:1463`), and the multi-cache arg keys
+   (`vm_call_method_compiled_cache.rs:52`). Plus the 13 literal
+   `_ => value_type_name(&args[0]).to_string()` fallback arms in `methods_classhow_dispatch.rs`
+   (lines 174, 201, 258, 285, 396, 438, 561, 584, 977, 1050, 1207, 1228, 1236) and the same
+   3-arm shape repeated 8 more times across `methods_classhow_mro.rs`,
+   `methods_classhow_parents.rs`, `methods_classhow_builtin_methods.rs`,
+   `methods_classhow_lookup.rs`, `methods_classhow_method_obj.rs`.
+5. **No integer type identity exists.** `grep -rn "TypeId" src` → 0 hits. `Symbol(u32)`
+   (`src/symbol.rs:14`, append-only global intern table, `&'static str` resolution) is the only
+   interned identity. `MethodEntryKey { owner: Symbol, name: Symbol }` (`registry.rs:44-48`)
+   already uses it, but `Registry.classes`/`roles`/etc. are `String`-keyed, and hot-path
+   comparisons like `sym == "Array"` go through a table lookup + byte compare
+   (`symbol.rs:29-39` — NOT O(1)).
+
+## Facts the design rests on (survey results, 2026-08-09)
+
+- The registry write side is already Symbol-keyed and canonical-in-shape:
+  `sync_user_method_entries` interns the passed `class_name` verbatim (`registry.rs:321`), and
+  builtin rows are keyed by `canonical_builtin_owner` (`builtin_type_methods.rs:766-788`), which
+  folds `Rat|FatRat→Rat`, `Sub|Method|Block|Routine|Code→Code`, buf/blob classes→`Blob`.
+- User-class MRO is already computed and cached as `Arc<[Symbol]>` (`ClassDef::mro`,
+  `decl_types.rs:31`; `Registry::class_mro` `registry.rs:621-651`, `class_mro_readonly`
+  :660-686). `compute_class_mro` (`registry.rs:439-570`) is string-based C3 with special cases
+  (role parents re-ordered, `Any`/`Cool` seeds, parametric parents).
+- Builtin subclasses (`class Foo is Array`) have **no** modeled Array method table; dispatch
+  reaches native Array methods by delegating to the `__mutsu_array_storage` backing attribute at
+  ~14 scattered sites, and `nextsame` needs the `native_array_storage_next_candidate` synthesized
+  fallback (`builtins_dispatch_next.rs:263-310`).
+- Mixins record roles as map keys `__mutsu_role__{Name}` inside a `HashMap`;
+  `dispatch_mixin_method_call` (`methods_mixin_dispatch.rs:7`) walks those keys **in HashMap
+  iteration order** — the multi-role precedence is not deterministically ordered today.
+- Role puns materialize a real `ClassDef` under the role's name with
+  `mro: [role, Any, Mu]` (`registration_class_augment.rs:1116-1131`), so puns resolve through
+  the normal user-class path once punned.
+- Enums: `value_type_name` says `"Int"` (`type_misc.rs` Enum arm), while `.^can` special-cases
+  `Enum → enum_type` (`methods_classhow_method_obj.rs:295`) — two different owners for the same
+  receiver depending on entry point.
+- Thread forking COW-clones the registry (`runtime_thread.rs:439-446`); any *dense* id space
+  owned by the registry would fork with it, while `Symbol` is process-global and append-only.
+
+## Design decisions
+
+**1. `TypeId` is a newtype over `Symbol`, not a dense index.**
+
+```rust
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct TypeId(Symbol);
+```
+
+The newtype's value is the *invariant*, not the representation: a `TypeId` may only be produced
+by the E1 classifier or the E1 catalog, so holding one proves the name went through owner
+canonicalization (aliases folded, Instance/Package resolved to the class symbol). Dense ids are
+rejected because (a) the registry is COW-forked per thread, so a registry-owned id space would
+diverge across forks while Symbols cannot; (b) `MethodEntryKey.owner` is already a Symbol, so no
+key migration is needed; (c) `Registry.classes` et al. are `String`-keyed and their migration is
+Phase-F cleanup, which dense ids would drag into E1. Hot-path string comparisons are eliminated
+by a lazily-initialized well-known-symbol struct (one-time interning):
+
+```rust
+pub(crate) struct WellKnownTypes { pub any: TypeId, pub mu: TypeId, pub cool: TypeId,
+    pub array: TypeId, pub list: TypeId, pub hash: TypeId, pub map: TypeId, /* ... */ }
+```
+
+so `chain.contains(&wk.array)` is a u32 compare, never `sym == "Array"`.
+
+**2. One static builtin type catalog replaces the four MRO tables.**
+
+A single `builtin_type_info()` static table (living beside the method catalog in
+`builtin_type_methods.rs`, since F3 will fuse them) with one row per builtin type:
+
+```rust
+pub(crate) struct BuiltinTypeInfo {
+    pub name: &'static str,
+    pub mro: &'static [&'static str],    // full linear chain incl. Any, Mu
+    pub roles: &'static [&'static str],  // Positional/Associative/Callable/Numeric/Real/Stringy...
+    pub dispatch_owner: &'static str,    // canonical_builtin_owner successor ("" = self)
+}
+```
+
+The linear `mro` serves dispatch walks; the `roles` list serves type-matching/distance (the
+current `builtin_type_distance` and `dispatch_candidates` tables interleave roles into the
+chain — the catalog keeps them separate because MRO order and role membership are different
+facts, and `.^mro` must not report roles). The four existing tables become readers of this one
+(or are deleted where E1b's cutover replaces their call sites). `canonical_builtin_owner` folds
+into `dispatch_owner`.
+
+Authority for the rows is **raku, not the union of the current tables**: V1 below adjudicates
+every divergence against `raku -e 'say T.^mro'` / `T.^roles` output, recorded in the test that
+pins the catalog. Divergences from *current mutsu behavior* discovered this way do NOT get
+silently fixed in E1a (zero-behavior-change rule); they are listed in the E1a PR as an
+accepted-mismatch ledger and flipped deliberately in E1b (or filed as tickets if they turn out
+to be visible bug fixes with their own blast radius).
+
+**3. One receiver classifier: `receiver_dispatch_class(&Value) -> ReceiverClass`.**
+
+```rust
+pub(crate) struct ReceiverClass {
+    pub type_id: TypeId,          // canonical dispatch owner of the receiver itself
+    pub definedness: Definedness, // Concrete | TypeObject  (for :D/:U invocant filtering, E4)
+    pub exec: ReceiverExec,       // Direct | ArrayStorageDelegate | MixinLayered | ...
+}
+pub(crate) enum Definedness { Concrete, TypeObject }
+```
+
+plus `dispatch_mro(&Value) -> SmallVec<[TypeId; 8]>` returning the full ordered owner chain:
+
+- `Instance { class_name }` → `class_name`'s registry MRO (already `Arc<[Symbol]>`), Concrete.
+- `Package(name)` → the same chain as an instance of `name`, TypeObject. (This is the fix for
+  "type objects appeared as Package": a type object's dispatch chain is its type's chain; only
+  definedness differs.)
+- Builtin concrete values → catalog chain (aliases resolved here and only here: `Map`-declared
+  Hash starts at `Map`, gather-LazyList at `Seq`, `ArrayKind` non-real arrays at `List`,
+  Set/Bag/Mix mutability variants, `BigRat`→`FatRat`, allomorph mixins→`IntStr` etc.).
+- `Mixin(inner, mixins)` → role TypeIds first, then the inner chain; `exec: MixinLayered`.
+  Role order within one mixin layer must be made deterministic (V2).
+- Enum values → `[enum_type, Int-chain...]` (V3).
+- User class `is Array` → the registry MRO already contains `Array`, and the catalog supplies
+  `Array`'s tail, so the chain is `[Foo, Array, List, Cool, Any, Mu]`; `exec:
+  ArrayStorageDelegate` tells the execution layer (E4/E5) that native list handlers run against
+  the `__mutsu_array_storage` attribute. E1 itself does not touch the 14 delegation sites; it
+  only makes the chain *say* what they currently hand-code.
+- `Scalar`/`ContainerRef`/`VarRef`/`LazyThunk` → recurse to the held value, as
+  `value_type_name` does today.
+
+**4. E1a shadow mode: compare the classifier against today's decisions at four choke points.**
+
+Zero behavior change. At each site, compute the new owner beside the old and bump
+`MUTSU_VM_STATS`-gated counters `owner_shadow_checks` / `owner_shadow_mismatches` (plus a
+per-site breakdown counter so a mismatch names its site). The four sites, chosen because they
+are the dispatch-path decisions E5-E7 will route through the resolver:
+
+1. `call_method_with_values`'s `value_type_name` augment gate
+   (`methods_call_dispatch.rs:3646`) — compare `chain[0]`'s name.
+2. `dispatch_instance_and_fallback`'s dispatch-class pick (`methods_instance_ops.rs:1675`) —
+   compare the picked class.
+3. `try_compiled_method_or_interpret_inner`'s Instance/Package owner
+   (`vm_call_method_compiled_interpret.rs`, the block feeding `resolve_method_cached`).
+4. `multi_arg_type_keys` (`vm_call_method_compiled_cache.rs:52`) — compare the per-arg key
+   symbol.
+
+The shadow target is **"the new classifier reproduces the site's current decision"**, not "the
+new classifier is right". Where the classifier is deliberately different (type objects,
+subclasses, aliases — the failure modes the box exists for), the mismatch is *expected*; the
+E1a exit criterion is therefore not a raw zero but: every mismatch bucket on a full `t/` +
+whitelisted-roast sweep is either zero or matched to a line in the accepted-mismatch ledger.
+An unexplained bucket blocks E1b.
+
+**5. E1b cutover: dispatch sites first, MOP fallbacks as their own PR.**
+
+E1b makes the classifier authoritative at the four sites above plus the remaining
+dispatch-path owner scans (`methods_instance_ops.rs:2264/2304/2494/2536`,
+`methods_qualified.rs:897`, `type_matching.rs:1463`, `methods_call_helpers.rs:292`), deleting
+the per-site string logic. The 13+8 MOP fallback arms collapse into one shared helper
+`mop_receiver_owner(&Value) -> String` (the existing 3-arm Package/Instance/fallback shape,
+now backed by the classifier) as **E1c**, a separate mostly-mechanical PR — the ADR already
+allows "the MOP fallback sites may follow as their own PR if the diff warrants it", and the
+survey says it will (21 sites across 6 files).
+
+**Out of scope for E1** (state this in the PR description to keep review honest): display
+naming (`.^name`, `what_type_name`'s `+{Role}` suffix, `user_facing_type_name` mangling) is a
+*presentation* concern and stays as-is; `isa_check`'s table unification is a candidate follow-up
+ticket once the catalog exists; fixing the mixin-order nondeterminism (V2) lands here only if
+V2 shows raku semantics require it, otherwise it is filed as a ticket.
+
+## Slice plan
+
+- **E1a — catalog + classifier + shadow counters.** The `TypeId` newtype, `WellKnownTypes`,
+  `BuiltinTypeInfo` static catalog with the raku-adjudicated rows and a unit test pinning them,
+  `receiver_dispatch_class`/`dispatch_mro`, the four shadow probes, the stats counters, and the
+  accepted-mismatch ledger in the PR description. Zero behavior change; validate with full `t/`,
+  the stats sweep, and `cargo test`.
+- **E1b — dispatch-site cutover.** Classifier becomes authoritative at the enumerated dispatch
+  sites; per-site string scans deleted; the four MRO tables' dispatch-path readers move to the
+  catalog (introspection readers like `classhow_mro_names`' Grammar special case may keep their
+  own logic until E7/F2 if their output is observably different — decide per reader from the
+  ledger). Because this changes how names and types resolve, run a local `make roast` before
+  the PR (per the working agreement), not just `make test`.
+- **E1c — MOP fallback consolidation.** `mop_receiver_owner` helper; mechanical replacement of
+  the 21 fallback arms; no semantic change beyond the E1b-established owner rules.
+
+## Verification items (resolve during E1a)
+
+- **V1 — adjudicate the four-table divergence against raku.** For every type named in any of
+  the four tables, capture `raku -e '<T>.^mro.say; <T>.^roles.say'` and record the catalog row
+  from that output. Known divergences to adjudicate explicitly: `Hash` (Map in the chain or
+  not), `Sub` (Callable placement), `Bool` (raku: `Bool is Int`), `Seq`, `Junction` (raku:
+  `Junction → Mu`, skipping Any), Buf/Blob parameterized names, `Nil` (`resolution_method.rs`
+  hand-codes `[Nil, Cool, Any, Mu]`).
+- **V2 — mixin role order.** `my $x = 0 but A but B` where both roles define `m`: check raku's
+  winner, then check whether mutsu's current HashMap-order walk is deterministic for the same
+  program across runs. If raku requires later-wins and mutsu is nondeterministic, that is a
+  pre-existing bug to file (and the classifier's chain ordering fixes it in E1b); the
+  classifier must at minimum be deterministic.
+- **V3 — enum receivers.** raku: `enum E <a b>; say a.^mro` — expect the enum type before Int.
+  Confirm which owner today's dispatch actually uses at each entry (`.^can` uses enum_type,
+  `value_type_name` says Int) and pick the chain accordingly.
+- **V4 — allomorphs.** `<1/3>`, `IntStr` etc.: confirm the catalog rows and that the mixin
+  shortcut in `value_type_name:116-130` is reproduced by the classifier.
+- **V5 — parameterized Buf/Blob names.** `is_buf_or_blob_class` accepts dynamic names
+  (`buf8`, `Buf[uint8]`); the classifier must resolve them to catalog rows without allocating
+  per call (intern once per distinct name is acceptable — Symbol interning already memoizes).
+
+## Risk notes
+
+The classifier itself is additive and shadow-verified, so E1a is low-risk by construction. The
+risk concentrates in E1b: an owner change at a dispatch site changes *which* method table is
+consulted first, and the blast radius is every method call. Mitigations: the E1a ledger must be
+complete before E1b starts (no "we'll see in CI"); E1b runs local `make roast`; and E1b's diff
+should be reviewable site-by-site — if it grows past ~10 sites, split it. Perf: the classifier
+must not allocate on the hot path (SmallVec chain, `Arc<[Symbol]>` reuse for instances); add the
+chain construction to an existing bench sanity check rather than a new counter gate.

--- a/todo/deep/adr0019-e2-e4-resolver-core.md
+++ b/todo/deep/adr0019-e2-e4-resolver-core.md
@@ -1,0 +1,257 @@
+# ADR-0019 E2/E3/E4 design: native handler rows, the one resolver, and the resolved-call cache
+
+Design pass for Phase E boxes E2 (exact handler IDs), E3 (generation-keyed resolved-call cache),
+and E4 (one MRO walk for native + user candidates). These three are one mechanism seen from
+three sides — the rows are what the resolver reads, the cache is where its result lives — so
+they are designed together and land interleaved (E2a → E4a → E2b → E4b → E3, see the slice
+plan). Depends on E1 (`TypeId`, `receiver_dispatch_class`, `dispatch_mro`); see
+`adr0019-e1-typeid-receiver-owner.md`. No code has landed for these boxes yet.
+
+## Postmortem: why the 2026-08-04 handler-ID attempt was reverted
+
+Commit b252837e7 added `handler: NativeMethodHandlerId::PureArity` to every
+`BuiltinMethodEntry`, cached `(Symbol, Symbol) → Option<NativeMethodHandlerId>` on the
+interpreter, and made `vm_native_dispatch` consult the registry row before invoking the
+arity-specific implementation. Reverted same day (f1485d136). Two structural causes:
+
+1. **Wrong owner.** The registry probe keyed on `value_type_name()` output: type objects
+   probed as `Package`, user Array subclasses as `Any`, `Map`-declared hashes needed the alias
+   special case — so the row lookup answered "no entry" (or the wrong entry) for receivers the
+   string-match cascades accept. This is E1's job; E2 must not start before E1b.
+2. **One-step flip with no shadow phase.** The row catalog (14 name slices, ~350 slots) is a
+   *strict subset* of what the match cascades accept (~700 quoted-name arms across
+   `methods_0arg/` and `methods_narg/` — e.g. `Failure`, temporal, `Version`, allomorph and
+   `Rat`-specific arms have no catalog row at all), and the flip made the incomplete rows
+   load-bearing immediately. Coverage has to be *measured to completeness* before any read-side
+   behavior depends on the rows.
+
+## Facts the design rests on (survey results, 2026-08-09)
+
+**The native layer:**
+
+- Three pure entries, dispatching by `match` on the resolved method-name `&str`:
+  `native_method_0arg(&Value, Symbol)` (`builtins/methods_0arg/mod.rs:304`),
+  `native_method_1arg` (`methods_narg/dispatch_1arg.rs:25`), `native_method_2arg`
+  (`dispatch_2arg.rs:17`). Return `Option<Result<Value>>`; `None` = not handled. **No 3+-arg
+  entry exists** — 3-arg natives are hand-rolled pre-dispatch escapes
+  (`vm_native_dispatch.rs:159,345,355,364`). No `_mut` variants exist; mutation is Tier-A VM
+  helpers (`try_native_array_mut` etc. in `vm_call_method_mut_ops.rs`) that write back into env
+  by name themselves.
+- The admission gate `try_native_method_raw` (`vm_native_dispatch.rs:38-492`) runs ~16 checks
+  before the arity switch, and `should_bypass_native_fastpath`
+  (`runtime/methods_native_bypass.rs:116`) is its independently-maintained interpreter twin.
+  Both consult `is_native_method` (`class_introspection.rs:63-221`) — itself a hand-coded
+  per-class name-list cascade plus the `ClassDef::native_methods` registry tail.
+- `BuiltinMethodEntry { owner, name, order }` (`builtin_type_methods.rs:718-726`) carries **no
+  arity, no mutability, no handler, no type-object admissibility**.
+
+**The resolution layer (what E4 unifies):**
+
+- The ranked resolver is `resolve_method_with_owner_impl` (`resolution_method.rs:116-382`):
+  MRO walk collecting `(owner, MethodDef)` matches, then a tie-break ladder (type distance →
+  narrowness tuple → explicit-named → most-derived owner → `is default` → ambiguous).
+- At least six sibling walkers re-implement parts of it: `resolve_all_methods_with_owner`
+  (:551, the nextsame list), `resolve_methods_per_mro_level` (:635, `.+`/`.*`),
+  `count_visible_method_candidates` (:518), `has_multiple_dispatch_candidates`
+  (`accessors_state.rs:538`), `multi_dispatch_type_cacheable`
+  (`vm_call_method_compiled_cache.rs:66`), the private-method resolver family
+  (`resolution_private_method.rs`), plus `resolve_user_method_or_accessor`
+  (`class_introspection.rs:280`) and WALK's own (`methods_walk.rs:583`).
+- The submethod no-inherit rule (`def.is_my && is_ancestor → skip`) is copy-pasted at six
+  sites (`resolution_method.rs:179,161,541,586,650`, `accessors_state.rs:568`,
+  `class_dispatch.rs:124`).
+- Native candidates are **not** part of any resolution result today: after user resolution
+  fails, control falls through hand-ordered probe sequences per entry point, and `nextsame`
+  reaching a native base needs four synthesized fallbacks
+  (`native_{grammar_parse,mu_base,array_storage,metamodel}_next_candidate` in
+  `builtins_dispatch_next.rs`).
+
+**The cache layer (what E3 replaces):**
+
+- `MethodEntry { builtin, user_candidates: Vec<MethodDef>, accessor }` keyed
+  `(owner: Symbol, name: Symbol)` with a monotonic `method_generation` bumped at exactly 4
+  sites inside `registry.rs` (:293, :321, :349, :415). One read-boundary refresh,
+  `refresh_method_caches_for_generation` (`vm_call_method_compiled_cache.rs:4-18`), clears 7
+  caches wholesale on generation change; it is called from only 2 places, and several probe
+  sites (`native_ctor_plan`, `has_multiple_dispatch_candidates`, private-method resolve,
+  accessor reads) bypass it and rely on the ~24 manual clear blocks (88 statements across 13
+  files).
+- No cache key encodes call shape. `fast_method_cache` is keyed `(class, method)` with arity
+  as a post-hit *guard*; named-arg calls simply decline the multi cache
+  (`multi_arg_type_keys` returns `None` for Pair/Instance/… at
+  `vm_call_method_compiled_cache.rs:37-51`). The whole fast cache is disabled globally
+  whenever any wrap chain exists (`has_any_wrap_chains`, `accessors_state.rs:842`).
+- `fn_resolve_gen` is a second, function-side generation scheme (bumped ~30 sites); wrap
+  mutation bumps only it, never `method_generation`.
+
+## Design decisions
+
+**1. E2 rows are *recognition metadata*, not function pointers — invocation stays in the
+arity cascades until F3.** The row schema:
+
+```rust
+pub(crate) struct NativeMethodRow {
+    pub owner: &'static str,          // canonical dispatch owner (E1 TypeId name)
+    pub name: &'static str,
+    pub order: u16,                   // existing .^methods catalog order
+    pub arity: NativeArityMask,       // bitmask: A0 | A1 | A2 | N (slow-path/special)
+    pub flags: NativeRowFlags,        // see below
+}
+bitflags NativeRowFlags {
+    TYPE_OBJECT_OK,     // callable on a type object (e.g. .Str on Str:U is "" + warn, .raku, .gist)
+    MUTATES_RECEIVER,   // implemented by a Tier-A mut helper / mut slow path, not the pure layer
+    SPECIAL,            // handled by a named interceptor, never by native_method_*arg
+}
+```
+
+`BuiltinMethodEntry` grows into (or is replaced by) this row; `MethodEntry.builtin` carries it
+unchanged. What the resolver ultimately needs from a row is the answer to "may this
+(owner, name, shape, definedness) be served natively, and by which tier" — that is recognition,
+not invocation. Converting ~700 match arms into per-method function pointers is exactly F3's
+retirement of the hand tables and is *not* required for any Phase E box; sequencing it here
+would repeat the reverted attempt's mistake at 20× the diff.
+
+**2. Row completeness is driven by counters to a measured zero, before any read depends on
+rows.** Two instruments:
+
+- Runtime shadow counter `native_call_unmodeled` (`MUTSU_VM_STATS`-gated): bumped whenever
+  `native_method_{0,1,2}arg` returns `Some(..)` for an `(owner, name)` that has no row (or a
+  row whose arity mask excludes the call's arity). Swept over full `t/` plus whitelisted roast;
+  every hit is a missing/wrong row to add.
+- Test-side inverse probe (cfg(test), the B1/B2 precedent allows probing in tests): for each
+  row with arity bit A0/A1/A2 and not SPECIAL/MUTATES, call the corresponding cascade with a
+  representative receiver of the owner type and assert recognition. This catches rows that
+  claim coverage the cascades do not provide (the reverted attempt's silent wrong-entry mode).
+
+The pinned regression cases the ADR names (each becomes a `t/` test in E2a, before anything
+flips): a type object receiving a catalog method (`Str.gist`, `Int.raku`), a user `is Array`
+subclass calling `push`/`elems` (storage delegation), `Map` receiving Hash-owned methods and
+its own, a gather `Seq` vs `Array` LazyList, `Failure` (must explode on unhandled use, not
+dispatch — `methods_call_dispatch.rs:629` — so Failure rows must be SPECIAL), `<1/3>` Rat and
+`FatRat` methods, allomorph (`IntStr`) dispatch.
+
+**3. The admission gate splits into method-identity facts (→ rows) and receiver-state facts
+(→ resolver guards).** Classification of `try_native_method_raw`'s checks:
+
+| Check (vm_native_dispatch.rs) | Class | Destination |
+|---|---|---|
+| deferred-Seq bail :81, lazy-pipe :116, lazy guard :135 | receiver state | resolver guard (pre-probe) |
+| NativeCall `.REPR`/`.WHERE` :94, `.Capture` :103 | method identity | SPECIAL rows |
+| Proxy receivers :141 | receiver state | resolver guard |
+| `squish`/`tail` always-interpreter :150 | method identity | row absent / SPECIAL |
+| 3-arg `contains`/`starts-with`/`substr-eq`/buf-write :159,345,355,364 | method identity | rows with arity N (slow-path) |
+| `mixin_role_has_method` :165 | receiver state | resolver (mixin layer precedes native in the chain) |
+| Instance/lazy-Match arms incl. `is_native_method` :171-262 | both | user candidates + `native_methods` registry rows |
+| Supply lists :192,266 | method identity | rows under Supply owner |
+| collection-`.gist`-with-Instance :294, `container_needs_raku_dispatch` :301 | receiver state | resolver guard |
+| post-switch fixups (:381-491 decode/Map-gist/clone-retag) | execution detail | stay with invocation |
+
+`should_bypass_native_fastpath` (`methods_native_bypass.rs`) is the same list re-implemented;
+E4b's cutover deletes it in favor of the one resolver-side guard set. This table is the E2b
+work list.
+
+**4. E4: one resolver producing one canonical result type.**
+
+```rust
+pub(crate) struct ResolvedSequence {
+    pub generation: u64,                       // registry method_generation at build time
+    pub candidates: Arc<[ResolvedCandidate]>,  // full ordered sequence, most-derived first
+    pub proto: Option<ProtoRef>,               // proto method interception (E8)
+}
+pub(crate) enum ResolvedCandidate {
+    User { owner: TypeId, def: Arc<MethodDef> },              // stored order within a level
+    Accessor { owner: TypeId, public: bool },                 // generated attribute accessor
+    Native { owner: TypeId, row: &'static NativeMethodRow },  // recognition; execution per tier
+}
+```
+
+`resolve_sequence(chain: &[TypeId], name: Symbol, shape: CallShape, definedness) ->
+Option<ResolvedSequence>` walks the E1 chain once. Per level: user candidates from
+`MethodEntry.user_candidates` in stored order (skipping `is_private`; skipping
+`is_my` candidates when level > 0 — the six copy-pasted submethod rules collapse into this one
+line); the accessor bit from `MethodEntry.accessor` with today's
+`resolve_user_method_or_accessor` arbitration; the native row if the level is a catalog owner.
+**Signature matching and ranking stay per-call**: the sequence is the shape-independent
+candidate universe; the existing ranker (`resolve_method_with_owner_impl`'s ladder, extracted
+to take a candidate slice instead of doing its own walk) selects the winner from it per call.
+This is what lets E9 later give `nextsame` a cursor and lets the native base be "just the next
+candidate" — deleting the four synthesized native fallbacks.
+
+E4 lands shadow-first like E1: **E4a** builds the sequence beside the current resolution at the
+two `resolve_method_cached` boundaries and compares the winner
+(`owner symbol + MethodDef body fingerprint`) under counters `resolver_shadow_checks` /
+`resolver_shadow_mismatches`, user candidates only. **E4b** adds native rows to the sequence,
+makes the sequence authoritative at those boundaries, and deletes
+`should_bypass_native_fastpath` in favor of the unified guard set. The sibling walkers
+(`resolve_all_methods_with_owner` etc.) are *not* rewritten in E4 — they migrate with their
+consumers (E8/E9 for the deferral list, E7 for WALK/lookup).
+
+**5. E3: cache the sequence, keep the wholesale-clear generation discipline.**
+
+```rust
+resolved_seq_cache: FxHashMap<(TypeId, Symbol, CallShape), Arc<ResolvedSequence>>
+// CallShape: packed { arity_bucket: 0|1|2|3+, has_named: bool }
+```
+
+- The cache joins `refresh_method_caches_for_generation`'s clear set; the per-entry
+  `generation` stamp is a debug assertion, not the invalidation mechanism (wholesale clear on
+  generation change is today's proven model and avoids stale-entry resurrection reasoning).
+- `CallShape.has_named` exists so named-arg calls get *sequence* caching (today they decline
+  the multi cache entirely); the named-aware winner selection still runs per call.
+- `fast_method_cache` is **not** deleted in E3: it survives as the monomorphic in-line layer in
+  front (its post-hit guards are load-bearing: arity/defaults/attr-alias/container-sharing,
+  `vm_call_method_compiled_interpret.rs:493-539`). F5 retires it once the sequence cache plus
+  E10's generation-covered wraps make it redundant — retiring it early would put an unmeasured
+  perf cliff inside Phase E.
+- The read boundary gains the two missing refresh calls (private-method resolve and
+  `has_multiple_dispatch_candidates` probe sites) so the generation actually covers every
+  method-shaped cache read; the manual clear blocks stay until F5 (they are then provably
+  redundant instead of speculatively deleted).
+
+**6. Perf gate.** The resolver adds work only on fast-cache misses (the IC stays in front), but
+E4b/E3 must show bench-CI parity (fib, bench-tak, and one dispatch-heavy bench) before their
+boxes close — G3's "cache-hit dispatch remains generation-checked O(1)" is checked here, not
+deferred to the end of the migration.
+
+## Slice plan
+
+- **E2a — row schema + instruments + pinned tests.** `NativeMethodRow`/flags, rows generated
+  from the existing 14 name slices (arity/flags initially conservative: arity mask from which
+  cascade file names the method, SPECIAL where §3's table says so), the `native_call_unmodeled`
+  counter, the cfg(test) inverse probe, and the regression tests from decision 2. Zero behavior
+  change.
+- **E4a — sequence builder + shadow parity (user candidates only).** Counter-verified against
+  `resolve_method_with_owner_impl` outcomes on full `t/` + roast S12/S14/S32 sweeps. Zero
+  behavior change.
+- **E2b — drive `native_call_unmodeled` to zero.** Add missing rows file-by-file through the
+  gate-classification table; each sub-PR is mechanical row addition plus its sweep evidence.
+- **E4b — authoritative switch at the cached-resolve boundaries + native rows in sequence +
+  delete `should_bypass_native_fastpath`.** Local `make roast` before PR (semantics-touching).
+- **E3 — the sequence cache + refresh-coverage completion.** Bench evidence in the PR.
+
+Expected to subdivide further from the E2b sweep the way C6 did; the boxes above are the
+ordered layers, not necessarily five single PRs.
+
+## Verification items
+
+- **V1**: enumerate every quoted-name arm in `methods_0arg/`/`methods_narg/` (scripted count,
+  committed as the E2b checklist) and reconcile against rows; the ADR's "~700 arms vs ~350
+  slots" gap must end at zero unmodeled hits, with SPECIAL/absent rows justified per arm.
+- **V2**: confirm `MethodEntry.user_candidates` order equals `ClassDef::methods` stored order
+  under role composition and `also does` (it is synced verbatim, `registry.rs:326-334`, but
+  `resolve_class_stub_requirements` mutates order at `registration.rs:347-369` — the sequence
+  must be built *after* those mutations, which sync timing already guarantees; add a test).
+- **V3**: definedness filtering — confirm where `:D`/`:U` invocant constraints are enforced
+  today (bind time) and keep them there; the sequence carries definedness only for E4's
+  candidate admission of type-object calls (TYPE_OBJECT_OK rows).
+- **V4**: thread-fork behavior — the new cache resets in `clone_for_thread_excluding` with the
+  other method caches (`runtime_thread.rs:704-714` block).
+
+## Risk notes
+
+The reverted attempt is the risk model: rows becoming load-bearing while incomplete. The
+counter-to-zero discipline (E2b) and shadow-first sequencing (E4a before E4b) are the
+mitigations; neither E4b nor E3 may land while `native_call_unmodeled` or
+`resolver_shadow_mismatches` is nonzero on the sweep corpus. Second risk: perf regression from
+double resolution during shadow phases — shadow probes are `MUTSU_VM_STATS`-gated so the
+default build pays one branch, not two resolutions.

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -1,0 +1,180 @@
+# ADR-0019 E5/E6/E7 design: routing every call entry through the resolver
+
+Design pass for Phase E boxes E5 (ordinary VM method calls), E6 (mutation-aware and container
+calls), and E7 (metaobject, qualified, and re-entrant calls). Depends on the E4 resolver and E2
+rows (`adr0019-e2-e4-resolver-core.md`). These boxes rewrite the largest functions in the
+codebase; the ADR already mandates that they "subdivide from a measurement, as C6 did" — this
+doc fixes the measurement protocol and the per-entry cutover shape so each sub-slice is
+mechanical. No code has landed for these boxes yet.
+
+## The corrected entry inventory
+
+The ADR preamble's inventory, verified and extended by the 2026-08-09 survey. Sizes are current
+line counts.
+
+**Opcode entries (6):**
+
+| Opcode | Handler | Site | Size |
+|---|---|---|---|
+| `CallMethod` | `exec_call_method_op_impl` | `vm_call_method_ops.rs:500-1806` | ~1.3k |
+| `CallMethodMut` | `exec_call_method_mut_op_impl` | `vm_call_method_mut_ops.rs:429-2169` | ~1.7k |
+| `CallMethodDynamic` | `exec_call_method_dynamic_op` | `vm_call_method_mut_ops.rs:30-276` | ~250 |
+| `CallMethodDynamicMut` | `exec_call_method_dynamic_mut_op` | `vm_call_method_mut_ops.rs:278-364` | ~90 |
+| `HyperMethodCall` | `exec_hyper_method_call_op` | `vm_hyper_method_ops.rs:446-960` | ~515 |
+| `HyperMethodCallDynamic` | `exec_hyper_method_call_dynamic_op` | `vm_hyper_method_ops.rs:1119-1339` | ~220 |
+
+**Non-opcode entries:** `vm_call_method_with_values` / `vm_call_method_mut_with_values`
+(forwarding shims, `vm_core_helpers.rs:87/233`), the `vm_run_instance_method` carrier
+(`vm_core_helpers.rs:98` → `class_dispatch.rs:52`, used by `CallDefined` and user
+`method sink` at `vm_exec_dispatch.rs:2460/2799`), the two JIT shims
+(`vm_jit_helpers.rs:314/367` — pure re-entry wrappers whose tails must stay byte-identical to
+the interpreter arms), and the three `vm_call_helpers` entries
+(`call_method_all_with_fallback` :303, `call_method_mut_with_temp_target` :327,
+`call_method_all_with_temp_target` :347).
+
+**Fast-path bypass:** `ArrayPush` → `exec_array_push_op` (`vm_data_push_ops.rs:45-302`).
+
+**Corrections/additions the ADR preamble should carry (folded into the ADR by this design PR):**
+
+1. The interpreter slow path `call_method_with_values` lives in
+   `runtime/methods_call_dispatch.rs:51-3827` (~3.8k lines), not `runtime/methods.rs`.
+2. `call_method_mut_with_values` (`runtime/methods_mut_dispatch.rs:11-2565`, ~2.6k lines) is a
+   **second slow path of comparable size** — E6's real target alongside
+   `exec_call_method_mut_op`; it always bottoms out in `call_method_with_values` (:2564).
+3. `exec_call_method_dynamic_mut_op` reaches the interpreter with **no native probe and no
+   compiled-method probe at all** (`vm_call_method_mut_ops.rs:353` goes straight to
+   `vm_call_method_mut_with_values`; only `try_native_buf_mut` at :342 precedes it).
+4. `exec_hyper_method_call_dynamic_op` lacks the `skip_native`/`has_user_method` gate and the
+   `nil_absorbs_method` arm that its static twin has (`vm_hyper_method_ops.rs:1231-1284` vs
+   :626-653/:787) — a user method overriding a builtin is honored per-element by
+   `HyperMethodCall` but potentially not by the dynamic form.
+
+Items 3 and 4 are pre-existing behavior divergences, not just refactor targets: raku-verify
+each (does the divergence produce observably wrong results today?) before the E6 cutover, and
+fix them *by* the cutover (both entries consulting the same resolver removes the divergence by
+construction) — with their own pinned tests, not silently.
+
+## Facts that shape the cutover
+
+- Every entry is a hand-ordered gauntlet: receiver normalization (ContainerRef/Scalar
+  unwrapping, lazy forcing), dozens of method-identity intercepts (`.return`, `.throw`,
+  `Pair.freeze`, `Lock.protect`, `Match.make`, proto interception, `xxKEY` fast paths, …),
+  native probes, then the compiled/interpret fallthrough. The probe *order* differs per entry
+  (e.g. `CallMethod` checks `try_fast_accessor_read` at :739 before junction threading at :778;
+  the mut op puts the `xxKEY` block at :1369-1827 after its own gates).
+- The mutation/writeback machinery is entirely at the caller boundary (opcode tails at
+  `vm_exec_dispatch.rs:3090-3094` and :3160-3238: `attr_env_snapshot`, `same_binding` rebind
+  test, `apply_pending_rw_writeback`, `drain_pending_local_updates_after_call`,
+  `mirror_attr_env_to_cell`) and inside Tier-A native mut helpers that write back into env by
+  name. **E5/E6 must not move any of this**; the boxes' own text says "retaining
+  mutation/writeback semantics at the caller boundary".
+- `exec_array_push_op` bypasses all dispatch stages. A user-class receiver escapes to the slow
+  path by the `is_simple_array` shape test (so user `push` works by accident), but an
+  `augment class Array { method push }` (or role mixed onto Array) is **not honored** for the
+  1-arg `@a.push($x)` while the n-arg form (CallMethodMut) honors it via `has_user_method` —
+  a real divergence today.
+
+## Design decisions
+
+**1. The cutover shape is "resolver decides, existing arms execute".** Each entry gains, at
+the point where its *dispatch probes* start (after receiver normalization, before the first
+probe), a single call:
+
+```rust
+let decision = self.resolve_dispatch(&receiver, method_sym, shape)?; // E4 sequence + guards
+```
+
+and its probe cascade becomes a `match` on the decision's first applicable candidate: user
+candidate → the existing compiled/interpret invocation path; native row → the existing
+`try_native_method` invocation (tier-selected); accessor → the existing accessor read;
+nothing → the existing not-found path. The special-case intercepts and the writeback tails do
+not move. This makes each cutover PR a *reordering-preserving* rewrite of one entry's probe
+section, reviewable against the taxonomy below, instead of a rewrite of a 1.7k-line function.
+
+**2. Interceptor taxonomy — every pre-resolver arm gets classified, per entry, before its
+cutover PR.** Classes:
+
+- **(a) receiver normalization** (ContainerRef/Scalar deref, lazy-IO force, Seq reify,
+  junction auto-thread): stays before the resolver, unchanged.
+- **(b) method-identity intercepts** (`.return`/`.throw`/`.emit`/`Pair.freeze`/
+  `Lock.protect`/`Match.make`/proto interception/`xxKEY` fast arms/Nil pre-dispatch): stay put
+  in E5/E6, each annotated with the E2 SPECIAL row that will eventually own it. Moving them is
+  F-phase cleanup; E5/E6 only require that none of them *resolves by name* behind the
+  resolver's back.
+- **(c) dispatch probes** (`skip_native` computation, `has_user_method` gates,
+  `try_native_method`, `try_fast_accessor_read`, `__mutsu_array_storage` delegation blocks,
+  compiled/interpret fallthrough): replaced by the decision match. The storage-delegation
+  blocks collapse into the `ReceiverExec::ArrayStorageDelegate` execution arm.
+- **(d) writeback tails**: untouched (JIT shims keep byte-identical tails).
+
+The classification lists (one table per entry, ~30-60 rows each) are produced during the
+measurement slice and committed with it — they are the review artifact that makes the big
+cutovers safe.
+
+**3. Measurement before subdivision (the C6d protocol, mandated here).** A
+`MUTSU_VM_STATS`-gated per-entry, per-outcome counter set
+(`dispatch_entry_{callmethod,callmethodmut,...}_{intercept,native,user,accessor,notfound}`)
+lands first, swept over full `t/` and whitelisted roast. The sweep decides: (i) sub-slice
+order within E5/E6 (highest-traffic outcome first); (ii) which intercepts are dead or
+near-dead (candidates for deletion rather than porting); (iii) the parity corpus for each
+cutover (files that exercise the entry's every outcome). Do not skip this on the theory that
+the survey above already measured — the survey counted code, not traffic.
+
+**4. Slicing of the three boxes.**
+
+- **E5 — ordinary calls**: measurement slice (counters + taxonomy tables for `CallMethod`,
+  `CallMethodDynamic`, hyper non-mut paths, `call_method_all_with_fallback`), then per-entry
+  cutovers: E5b `CallMethod`, E5c `CallMethodDynamic` + the two hyper entries' per-element
+  probe (their loop/writeback structure is untouched; only the inner
+  `try_native_method`/`call_method_mut_with_temp_target` probe pair consults the decision),
+  E5d JIT-shim parity check (no code change expected — assert the shims still just re-enter
+  the rewritten ops).
+- **E6 — mutation-aware calls**: E6a measurement + taxonomy for `CallMethodMut`,
+  `CallMethodDynamicMut`, `call_method_mut_with_values`, and the Tier-A helpers; E6b
+  `CallMethodMut` probe-section cutover; E6c the two dynamic gaps (inventory corrections 3/4)
+  fixed by routing through the same decision; E6d `ArrayPush`: keep the opcode and its
+  container fast path, but gate it with a generation-refreshed pristine bit —
+  `array_dispatch_pristine: bool` on the interpreter, recomputed on generation change as
+  "no user candidates and no wrap rows under owners `Array`/`List`" — falling back to the
+  `CallMethodMut` path when false. That closes the augment divergence with an O(1) hot-path
+  check and no per-push registry probe.
+- **E7 — metaobject/qualified/re-entrant calls**: the `run_instance_method` carrier's two VM
+  sites, qualified dispatch (`methods_qualified.rs`), private-method dispatch
+  (`resolution_private_method.rs` — becomes a sequence query with a private-visibility flag),
+  `.^lookup`/`.^can`/`.^methods` reading the same sequence the calls use (the `.^can` live
+  probe that calls `native_method_1arg` with a dummy `Value::NIL`,
+  `methods_classhow_method_obj.rs:386-388`, is replaced by an E2 row lookup — also a
+  correctness fix, since dummy-arg probing can false-negative), WALK, and the EVAL/`subtest`
+  re-entrant paths. E7 is expected to subdivide per consumer once E5/E6 stabilize the
+  decision API; scope each sub-PR to one consumer family.
+
+**5. The interpreter slow paths shrink by attrition, not rewrite.** `call_method_with_values`
+(~3.8k) and `call_method_mut_with_values` (~2.6k) are *reached less* as the VM entries consult
+the resolver first; their own probe sections (the native fast path at
+`methods_call_dispatch.rs:2770-3008`, the by-name dispatch groups at :3693-3715, the instance
+fallback tail) get the same decision-match treatment as sub-slices of E5/E6 once the VM-side
+cutovers are proven. Do not attempt a top-down rewrite of either function in one PR — that is
+the "rewrites a function larger than any slice merged so far" trap the ADR warns about; the
+decision-match conversion of one probe section at a time is the intended unit.
+
+## Verification items
+
+- **V1**: raku ground truth for inventory corrections 3/4 (dynamic-mut and hyper-dynamic
+  divergences): construct programs where a user/augment method is called through
+  `$obj."$name"(...)` mut forms and `».$name` — record raku behavior, pin tests.
+- **V2**: augmented-Array `ArrayPush` divergence: `augment class Array { method push(...) }` +
+  `@a.push($x)` vs `@a.push($x,$y)` — raku baseline, pinned test, fixed by E6d.
+- **V3**: JIT parity — run the jit-stress suite after each E5/E6 cutover slice (CI covers it,
+  but the local targeted check is the shim-tail byte-parity assertion).
+- **V4**: hyper writeback — the per-element temp-target protocol
+  (`call_method_mut_with_temp_target`'s env round-trip) must be preserved by E5c; the existing
+  `TODO: compile to bytecode` there is out of scope.
+
+## Risk notes
+
+These are the highest-traffic code paths in the interpreter; the protections are (i) the
+decision API is already shadow-proven by E4a/E4b before any entry consumes it, (ii) each
+cutover changes one entry and ships with its taxonomy table and sweep evidence, (iii) writeback
+tails and interceptors do not move, and (iv) local `make roast` before every cutover PR
+(semantics-adjacent). Perf: each cutover PR cites the bench-CI rows for its main-merge commit;
+a regression on fib/bench-tak blocks the next slice until explained.

--- a/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
+++ b/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
@@ -1,0 +1,210 @@
+# ADR-0019 E8/E9/E10/E11 design: multi ordering, deferral cursors, wrap generations, arity retirement
+
+Design pass for Phase E boxes E8 (multi/proto/submethod ordering in the candidate sequence),
+E9 (resolver cursors for `samewith`/`nextsame`/`callsame`/`nextwith`), E10 (wrap/unwrap into
+canonical entries + generation), and E11 (retire arity-specific lookup entry points). Depends
+on the E4 `ResolvedSequence` (`adr0019-e2-e4-resolver-core.md`) and the E5-E7 routing
+(`adr0019-e5-e7-entry-routing.md`). E9 is the highest-semantic-risk box of the whole phase and
+carries a mandatory raku verification campaign (D8-2/D3-8 precedent — 拙速厳禁). No code has
+landed for these boxes yet.
+
+## Facts the design rests on (survey results, 2026-08-09)
+
+**Multi/submethod/proto (E8):**
+
+- Method multis and sub multis rank with **two hand-synchronized ladders**: methods via
+  `method_candidate_type_distance` + the `narrowness` tuple + MRO-index + `is default`
+  (`resolution_method.rs:116-382`; the sync comment is at :248-253), subs via
+  `candidate_specificity_rank`/`candidate_type_distance` (`dispatch_candidates.rs`). Method
+  multis tie-break by **stored order** (`narrowed.first()`, :296-298); subs have an explicit
+  `decl_order` sort key (`dispatch_resolve.rs:79-90`).
+- The submethod no-inherit rule is copy-pasted at six sites plus WALK's inverted variant
+  (enumerated in the E2-E4 doc); BUILD/TWEAK have their own precomputed plan
+  (`ctor_phase_plan.rs:31-167`) whose pinning bypasses full dispatch only when
+  `native_call_specs.is_empty() && !has_any_wrap_chains()` (:231-234).
+- Proto methods live in a **third table**, `Registry::proto_methods:
+  HashMap<(String, String), FunctionDef>` (`registry.rs:267-271`), with their own MRO walk
+  (`dispatch_proto.rs:222-241`). A proto's `{*}` does not hand candidates to the callee — it
+  sets a one-shot `proto_method_skip` flag and **re-enters `call_method_with_values` by name**
+  (`dispatch_proto_call.rs:14-57`). The VM `{*}` arm falls back to the interpreter for the
+  method case (`vm_call_func_ops.rs:1704-1710`).
+- Role composition appends candidates per role in iteration order
+  (`registration_class_compose.rs:352-356`); `resolve_class_stub_requirements` then *mutates*
+  candidate order (class wins, role duplicates removed — `registration.rs:347-369`);
+  `drop_flattened_role_duplicates` (`resolution_method.rs:613-630`) de-dups again at
+  resolution time because the composed role is also an MRO entry.
+- `.^lookup(...).candidates` uses yet another ordering (reversed MRO, multi owners only,
+  `methods_classhow_lookup.rs:238-292`), and **wrap identity is keyed to that stored candidate
+  index** (`__mutsu_lookup_candidate_idx`, :279-281).
+
+**Deferral (E9):** three separate stacks, none a cursor —
+
+- `method_dispatch_stack: Vec<MethodDispatchFrame>` (`mod.rs:1797`, struct at
+  `decl_types.rs:165-176`): `remaining` is recomputed by `resolve_all_methods_with_owner` (a
+  second, unranked walk) with the winner removed by **AST body fingerprint** comparison; built
+  at three push sites (`class_dispatch.rs:218-240/277-283/358-364`,
+  `accessors_state.rs:748-836`, `methods_mixin_dispatch.rs:200-225`).
+- `wrap_dispatch_stack: Vec<WrapDispatchFrame>` (`mod.rs:1831`): `remaining` is a
+  `Vec<Value>` of wrapper code objects; a method wrap is marked `sub_id == 0` and falls
+  through to the method stack when exhausted (`builtins_dispatch_next.rs:365-427`); the
+  original-method leg re-enters **by name** (:391) guarded by `wrap_skip_once`.
+- `multi_dispatch_stack` (subs) plus `samewith_context_stack` — `samewith` re-enters
+  `call_method_with_values`/`call_function` **by name** (`builtins_dispatch_next.rs:101-118`).
+- When the user MRO is exhausted, four synthesized native fallbacks are force-pushed with
+  empty `remaining`: `native_{grammar_parse,mu_base,array_storage,metamodel}_next_candidate`
+  (`builtins_dispatch_next.rs:181-310`).
+- `dispatch_next_candidate` searches the stacks in fixed priority wrap → method → multi →
+  native-metamodel → `Mu.new` fallback (:358-903); `lastcall` truncates the topmost frame
+  (:62-75); `nextcallee` mirrors the search (:938-983).
+
+**Wrap (E10):** all state on `Interpreter`, not the registry — `wrap_chains` (by sub id),
+`method_wrap_chains` (by `(class, method, candidate_idx)`), five sibling maps
+(`mod.rs:1819-1850`). Invalidation is `fn_resolve_gen += 1` at four sites
+(`methods_sub.rs:883/927/951`, `methods_call_dispatch.rs:2240`) — **never**
+`method_generation` — and two wrap paths invalidate **nothing** (`.wrap` on a `^lookup`
+candidate, `methods_sub.rs:796-799`; `.wrap` on a `Method` object,
+`methods_instance_ops.rs:2202-2205`). Dispatch stays correct only via the global prefilter
+`has_any_wrap_chains()` (`accessors_state.rs:842-844`), which disables the fast method cache
+for the whole program as soon as one wrap exists. `.unwrap`/`restore` never remove
+`method_wrap_chains` entries (only class redeclaration purges them,
+`registration_class_validate.rs:377`).
+
+**Arity entries (E11):** `native_method_{0,1,2}arg` are called as *probes* (not just
+handlers) at: the `.^can` live probe with a dummy `Value::NIL` arg
+(`methods_classhow_method_obj.rs:386-388`), `accessors_stack.rs:189` (`.is_some()` existence
+test), `builtins_collection.rs:384`, the arity-switch ladders
+(`methods_call_dispatch.rs:2795-2800`, `vm_native_dispatch.rs:369-377`,
+`methods_instance_ops.rs:1454-1470`), and the mut slow path's direct calls
+(`methods_mut_dispatch.rs:1703-1921`). The `#[cfg(test)]`
+`native_responds_to`/`native_method_arities` probes are already runtime-retired (B1/B2).
+
+## Design decisions
+
+**1. E8: the sequence encodes structure; ranking stays per-call; the two ladders are NOT
+unified.** `ResolvedCandidate` gains the structural facts the ranker and the deferral order
+need:
+
+```rust
+User { owner: TypeId, def: Arc<MethodDef>, level: u16, stored_idx: u16 }
+```
+
+- `level`/`stored_idx` reproduce today's observable orders: winner selection = existing method
+  ladder over the sequence; deferral order = sequence order (MRO level, then stored index)
+  filtered by per-call signature match — which is exactly what
+  `resolve_all_methods_with_owner` computes today, so that walker is deleted once E9 consumes
+  the sequence.
+- Submethod visibility (`is_my && level > 0`) and `drop_flattened_role_duplicates` are applied
+  at sequence *build* time (one site each). The composed-order mutations
+  (`resolve_class_stub_requirements`) happen before sync, so the sequence inherits them — no
+  new mechanism.
+- The box text says "without changing tie-breaking or role conflicts": unifying the method and
+  sub ranking ladders is explicitly **out of scope** (file the asymmetry — method multis lack
+  `decl_order` — as a ticket with a raku repro if one exists; do not fix it silently inside
+  E8).
+- Proto methods: `Registry::proto_methods` folds into `MethodEntry` as a
+  `proto: Option<ProtoMethodDef>` column; the sequence's `proto` slot (already in the E4
+  schema) makes proto interception a resolver outcome instead of the standalone
+  `lookup_proto_method` MRO walk. The `{*}` re-entry rewrite itself is E9 (it needs cursors).
+
+**2. E9: one `DispatchCursor` replaces recomputation; wrappers become sequence prefix
+entries.**
+
+```rust
+pub(crate) struct DispatchCursor {
+    seq: Arc<ResolvedSequence>,   // includes Native candidates — the four synthesized
+    next: usize,                  //   fallbacks become ordinary sequence tail entries
+    invocant: Option<Value>,
+    args: Vec<Value>,             // the original binding, for nextsame/callsame
+    // rw bookkeeping carried over from MethodDispatchFrame.rw_params
+}
+```
+
+- At dispatch time the chosen entry pushes a cursor positioned after the winner. `callsame`/
+  `nextsame` advance from `next`, applying the per-call signature filter as they go (matching
+  today's "remaining = signature-matching candidates in MRO order" semantics); `callwith`/
+  `nextwith` do the same with replacement args; `lastcall` sets `next = seq.len()`;
+  `nextcallee` peeks. `samewith` re-runs the *ranker* over the same sequence with new args (not
+  a name re-entry), preserving its restart-from-the-top semantics.
+- Wrap chains materialize as cursor-prefix entries: resolving a wrapped candidate yields
+  `[Wrapper(outermost) … Wrapper(innermost), the candidate, …rest of sequence]`, so `callsame`
+  inside a wrapper is ordinary cursor advancement and the `sub_id == 0` sentinel, the
+  `wrap_skip_once` flag, and the by-name original-method re-entry all disappear. The mid-MRO
+  wrap interception (`builtins_dispatch_next.rs:445-499`) likewise falls out: the next
+  candidate's wrappers are already its prefix.
+- The winner-removal-by-fingerprint hack disappears because the cursor knows the winner's
+  index; the fingerprint comparison sites (`class_dispatch.rs:225-232`,
+  `accessors_state.rs:808-818`) are deleted with their frames.
+- The proto `{*}` becomes: run the ranker over `cursor.seq` excluding the proto itself —
+  deleting `proto_method_skip` and the arg-source save/restore dance
+  (`dispatch_proto_call.rs:45-55`).
+- Migration is frame-by-frame: E9a converts `MethodDispatchFrame` to the cursor (method calls
+  only, wrap prefix not yet), E9b folds `WrapDispatchFrame` in, E9c converts proto `{*}` and
+  `samewith`. The sub-side `multi_dispatch_stack` is out of scope here (it is Phase C/F
+  territory — sub multis already carry their candidate list; converting them to the same
+  cursor type is an optional follow-up once methods prove the shape).
+
+**3. E9 verification campaign (mandatory, before E9a lands).** A table of raku ground truths,
+each becoming a `t/` pin, covering at least: nextsame through (a) multi candidates in one
+class, (b) an inherited same-name method, (c) a role-composed method that also exists in the
+class (flattened-duplicate case), (d) `is Array` subclass reaching native push (today's
+`native_array_storage_next_candidate`), (e) Grammar `.parse` override calling nextsame; wrap
+interleavings: callsame inside a wrapper of (f) a plain method, (g) a multi candidate, (h) a
+method that also has an inherited version — including wrap applied mid-MRO; (i) `lastcall`
+inside a wrapper; (j) samewith with changed args from a multi candidate; (k) callwith
+arg-rebinding with `is rw` params; (l) `{*}` in a proto method with multi candidates across
+MRO levels; (m) BUILD calling callsame. Divergences found between raku and current mutsu are
+tickets first, design inputs second — do not encode a mutsu bug into the cursor semantics.
+
+**4. E10: wraps move under the registry generation; the global prefilter dies.**
+
+- `method_wrap_chains` moves into the registry keyed `(owner: Symbol, method: Symbol,
+  candidate_idx: u16)` (keeping the stored-index identity that `.^lookup` wraps already use;
+  candidate-index stability across composition is exactly as good as today — no better, no
+  worse). Every wrap/unwrap/restore path — including the two currently-invalidation-free ones —
+  goes through registry write entries that bump `method_generation` (the ADR's Phase B note
+  already promises "no new invalidation hook needed — Phase B's scheme was built
+  write-path-agnostic").
+- Sub-side `wrap_chains` stays interpreter-owned (sub dispatch is not registry-keyed) but its
+  mutation sites also bump `method_generation` so one generation covers all resolved-sequence
+  invalidation; `fn_resolve_gen` bumps stay until F5 retires that scheme.
+- After E3/E5 route reads through the generation-checked sequence cache,
+  `has_any_wrap_chains()` and its five prefilter call sites are deleted — un-gating the fast
+  cache for every program that uses `.wrap` anywhere (a measurable perf win to cite in the PR).
+- `.unwrap`/`restore` gain the missing `method_wrap_chains` removal (pre-existing leak: a
+  restored method wrap today survives as a stale chain entry, kept live only by prefilter
+  overhead); raku-verify `.unwrap` semantics on method wraps first.
+
+**5. E11: probes become row lookups; the arity functions become invocation-only.** After
+E5-E7, the remaining *lookup* uses of `native_method_{0,1,2}arg` are replaced by E2 row
+queries: the `.^can` dummy-NIL probe (also a correctness fix — dummy-arg probing
+false-negatives on arms that type-check the argument), the `accessors_stack.rs:189` existence
+test, `builtins_collection.rs:384`, and the three arity-switch ladders (which by then are the
+invocation tier behind the resolver's Native decision). Completion criterion (grep-based, D10
+style): **no caller of `native_method_{0,1,2}arg` outside (i) the single native-invocation
+helper the resolver's Native arm calls, (ii) internal recursion within `builtins/`, and (iii)
+`#[cfg(test)]`** — any new probe-shaped caller is a regression against this box.
+
+## Slice plan
+
+- **E8a** — sequence gains `level`/`stored_idx` + build-time submethod/duplicate rules; ranker
+  extracted to consume a candidate slice; shadow-compare winner AND deferral list against
+  `resolve_all_methods_with_owner` output under a counter (list equality by fingerprint).
+- **E8b** — proto methods into `MethodEntry`; `lookup_proto_method` deleted;
+  `try_proto_method_body` reads the sequence's proto slot.
+- **E9-pre** — the raku verification campaign (docs + `t/` pins only; any mutsu divergence
+  filed as tickets).
+- **E9a/E9b/E9c** — cursor cutovers per decision 2's migration order, each with the campaign's
+  relevant pins green and local `make roast`.
+- **E10a** — registry-owned method wraps + generation bumps on all wrap mutations (+ the
+  unwrap leak fix). **E10b** — delete `has_any_wrap_chains` prefilter once E3 is in (order
+  with E3, whichever lands second does the deletion); bench evidence.
+- **E11** — probe retirement + the grep criterion added to the architectural guard test (G2).
+
+## Risk notes
+
+E9 changes the observable order of user-visible dispatch chains — the one area where "CI
+catches it" is least true because chain-order bugs hide in rarely-exercised deferral paths.
+Hence the mandatory pre-campaign and per-slice `make roast`. E10's registry move touches the
+thread-fork COW path (`runtime_thread.rs`) — wraps created in a child must not leak to the
+parent (today's interpreter-owned maps get that isolation for free; the registry COW gives the
+same, but add a test). E11 is mechanical once E5-E7 land; do not start it earlier.


### PR DESCRIPTION
## Summary

Design-only PR: detailed, implementation-ready designs for **every ADR-0019 Phase E box** (E1-E11, the "one dispatch resolver and native handler table" campaign), following the Phase D design-sweep precedent (#6076/#6078). Four deep design docs under `todo/deep/`, condensed entries and inventory corrections in the ADR itself.

## What the survey found (inputs to the designs)

- **No `TypeId` exists**; owner decisions live at 27+ sites; the builtin MRO is modeled by **four divergent tables**; naming has four parallel paths. (E1 doc)
- The reverted handler-ID attempt (b252837e7 / f1485d136) failed on two structural causes: owners from `value_type_name()` and a one-step read-side flip over rows covering ~350 of ~700 cascade arms. (E2-E4 doc postmortem)
- Entry-point inventory corrections: `call_method_mut_with_values` is a second ~2.6k-line slow path; `exec_call_method_dynamic_mut_op` has **no native/compiled probe at all**; hyper-dynamic lacks the user-override gate its static twin has; `ArrayPush` ignores an augmented `Array` on 1-arg push while the n-arg form honors it. (E5-E7 doc)
- All three deferral stacks recompute "remaining" by name-based resolution + AST-fingerprint winner removal; wrap mutation bumps only `fn_resolve_gen` (two wrap paths invalidate nothing) and correctness rests on a global prefilter that disables the fast cache program-wide. (E8-E11 doc)

## Key design decisions

- `TypeId` = newtype over `Symbol`; one raku-adjudicated static type catalog; shadow-first cutover with an accepted-mismatch ledger.
- E2 rows are recognition metadata (not fn pointers — that is F3); completeness counter-measured to zero **before** any read depends on rows.
- E4 `ResolvedSequence` = shape-independent ordered candidate universe (user + accessor + native + proto); ranking stays per-call; E3 caches the sequence under the existing generation discipline.
- E5-E7: "resolver decides, existing arms execute"; measurement slice + per-entry interceptor taxonomy before each cutover; writeback tails and JIT shim tails untouched.
- E9: `DispatchCursor` with wrap chains as prefix entries; **mandatory raku verification campaign (E9-pre) before any cursor cutover**.
- E10: wraps move under `method_generation`; the `has_any_wrap_chains` prefilter is deleted after E3.

Recommended cross-box order: E1a → E1b (→ E1c) → E2a → E4a → E2b → E4b → E3 → E5 → E6 → E7 → E8 → E9 → E10 → E11.

Docs-only diff (`docs/` + `todo/`) — heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)