### PR TITLE
feat(adr0019): E1b -- make the TypeId receiver classifier authoritative

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1736,11 +1736,69 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   `ReceiverExec` hint (e.g. `ArrayStorageDelegate` for `is Array` subclasses). E1a's shadow
   target is "reproduce the site's current decision" with an accepted-mismatch ledger for the
   deliberate differences, which flip in E1b.
-  - [ ] **E1a — shadow mode.** Compute the TypeId-based owner beside the string-based one and
+  - [x] **E1a — shadow mode.** Compute the TypeId-based owner beside the string-based one and
     compare under a `MUTSU_VM_STATS`-gated counter; land with zero behavior change and drive the
     mismatch count to zero on `make test` plus targeted roast.
-  - [ ] **E1b — switch.** Make the TypeId owner authoritative and delete the per-site string
+    **Landed 2026-08-10** (`#6156`): `TypeId` (`src/type_id.rs`, a newtype over `Symbol`) plus
+    `WellKnownTypes` for O(1) comparisons; `BuiltinTypeInfo`, one static catalog
+    (`src/builtins/builtin_type_catalog.rs`) replacing, for the new classifier only, the four
+    divergent builtin MRO tables — every row adjudicated against `raku -e 'say T.^mro; say
+    T.^roles'` (Rakudo 2026.06), pinned by a `#[test]`; `Interpreter::receiver_dispatch_class`/
+    `dispatch_mro` (`src/runtime/receiver_class.rs`), one classifier resolving
+    Instance/Package/ParametricRole (registry MRO + catalog tail splice for builtin subclasses),
+    concrete builtins, Enum (enum type ahead of Int), and role Mixins (allomorph shortcut +
+    role-first chain) to one ordered `TypeId` chain; four shadow probes
+    (`Interpreter::shadow_check_owner`) at the dispatch-critical owner sites, comparing the
+    classifier's answer against each site's existing string-based decision under new
+    `owner_shadow_checks`/`owner_shadow_mismatches` `MUTSU_VM_STATS` counters. Zero behavior
+    change — the probes only compute-compare-count. Verified via a `MUTSU_VM_STATS=1` sweep over
+    all `t/*.t` plus roast S02/S06/S12/S14 (~26k shadow checks, ~611 mismatches, ~2.3%), every
+    mismatch bucketed into exactly three explained causes (no unexplained bucket): Enum receivers
+    (`value_type_name` says `"Int"`, raku's `.^mro` puts the enum type first — the classifier is
+    right, E1b fixes the legacy sites), role Mixin/ParametricRole generic-collapse
+    (`value_type_name` reports `"Any"`/`"Package"`/the pre-mixin type while ignoring the role
+    layer — exactly E1's target failure mode), and a `multi_arg_type_keys` Package-collision case
+    filed as its own ticket (`todo/tickets/multi-arg-type-keys-package-collision.md` — unconfirmed
+    as a live bug after two repro attempts, kept as a small standalone follow-up). Two tickets
+    filed from findings along the way: `todo/tickets/mixin-role-order-not-tracked.md` (mutsu's
+    `MixinOverrides` carries no role-application-order, so `(0 but A) but Z` resolves collisions
+    alphabetically instead of "later wins" like raku — the E1a classifier deliberately mirrors the
+    same wrong-but-deterministic order rather than diverging further, since fixing it needs an
+    order field on every mixin construction site, out of scope for a shadow-only box) and
+    `multi-arg-type-keys-package-collision.md` above. `make test` (2990 files/28109 tests) green,
+    unchanged. **This landed-note and its news entry are retroactive** — filed alongside E1b
+    (below) after the fact; E1a's own PR did not update either.
+  - [x] **E1b — switch.** Make the TypeId owner authoritative and delete the per-site string
     scans; the MOP fallback sites may follow as their own PR if the diff warrants it.
+    **Landed 2026-08-10**: the classifier becomes authoritative at the three E1a shadow sites
+    that were safe to cut over unconditionally — `call_method_with_values`'s augment gate,
+    `dispatch_instance_and_fallback`'s value-type dispatch pick, and the `are_actual_type_name`/
+    `are_value_matches_type`/`.^add_fallback` fallback-arm trio — via two new helpers,
+    `Interpreter::dispatch_owner_chain`/`dispatch_owner_name` (`src/runtime/receiver_class.rs`).
+    These are a `dispatch_mro` variant that skips a role Mixin's role-`TypeId` prefix, returning
+    the *inner* value's own chain instead: every call site consulting this chain runs strictly
+    *after* a dedicated, role-registry-aware path already tried role methods for the same
+    receiver, so re-deriving a role owner here would at best repeat that lookup and at worst
+    regress — confirmed by a direct repro (`augment class Array { method my-foo {...} }; (@a but
+    R).my-foo` resolved fine under the old `value_type_name`-unwrap-to-inner behavior; using the
+    raw role-first chain instead made it unresolvable). `methods_qualified.rs`'s qualified-dispatch
+    membership check and `type_matching.rs`'s `type_matches_value` both moved to walking the full
+    `dispatch_owner_chain`/`dispatch_mro` chain (not just its first element) — required, not just
+    thorough, since an Enum's chain is `[EnumType, Int, Cool, Any, Mu]` and a plain `Int`
+    constraint must still match an enum value through the `Int` link further down. The two
+    remaining divergent MRO tables this box's scope covered (`type_inherits`/
+    `builtin_type_mro_chain` in `methods_call_helpers.rs`) were deleted outright, their two call
+    sites (`methods_qualified.rs`, `vm_call_helpers.rs`'s `.+`/`.*` all-candidates count) now
+    reading the classifier's chain. `try_compiled_method_or_interpret_inner`'s `class_sym` site
+    needed no behavior change — it was already provably classifier-equivalent by construction
+    (confirmed zero mismatches in E1a's sweep) — so its now-redundant shadow probe was removed
+    without adding a chain-walk allocation to that hot fast-dispatch path. Deliberately NOT cut
+    over: `multi_arg_type_keys` (`vm_call_method_compiled_cache.rs`) — unlike the other three
+    original E1a sites, its cutover is not a shadow-mode-safe refactor but IS the fix for
+    `todo/tickets/multi-arg-type-keys-package-collision.md`, so it stays on `shadow_check_owner`
+    until that ticket is picked up on its own, rather than bundling an unverified behavior change
+    into this switch. MOP fallback consolidation (E1c) stays out of scope. Verified via `make
+    test` (28,121 tests) and a full `make roast` (218,774 tests), both green.
   - [ ] **E1c — MOP fallback consolidation.** Collapse the 13+8 per-MOP-entry owner-fallback
     arms into one classifier-backed `mop_receiver_owner` helper.
 - [ ] **E2 — Give every native entry an exact handler ID.** Generate static type×method handler rows

--- a/news/2026-08/adr0019-e1a-typeid-shadow-classifier.md
+++ b/news/2026-08/adr0019-e1a-typeid-shadow-classifier.md
@@ -1,0 +1,32 @@
+# ADR-0019 E1a: a stable TypeId and shadow-mode receiver classifier
+
+Dispatch's "who owns this method for this receiver" decision was scattered across ~27 sites and
+backed by four disagreeing builtin-MRO tables and four near-duplicate type-naming functions. E1a
+lays the foundation for unifying it: a `TypeId` newtype over `Symbol` (`src/type_id.rs`), a
+`WellKnownTypes` struct for O(1) comparisons against common types, a single static
+`BuiltinTypeInfo` catalog (`src/builtins/builtin_type_catalog.rs`) adjudicated row-by-row against
+real `raku -e 'say T.^mro; say T.^roles'` output rather than the union of the existing tables, and
+one classifier — `Interpreter::receiver_dispatch_class`/`dispatch_mro`
+(`src/runtime/receiver_class.rs`) — that resolves any receiver (Instance, Package, ParametricRole,
+concrete builtin, Enum, role Mixin) to one ordered `TypeId` chain.
+
+This slice is purely additive: four shadow probes compute the classifier's answer beside each
+dispatch-critical site's existing string-based decision and compare-and-count under new
+`MUTSU_VM_STATS` counters (`owner_shadow_checks`/`owner_shadow_mismatches`). No dispatch outcome
+changed.
+
+A `MUTSU_VM_STATS=1` sweep over the full `t/*.t` suite plus roast S02/S06/S12/S14 (~26,000 shadow
+checks) found ~611 mismatches (2.3%), every one accounted for in exactly three buckets: Enum
+receivers (the classifier correctly puts the enum type ahead of `Int` in the MRO chain, where the
+legacy string path collapsed it to plain `"Int"`), role Mixin/ParametricRole receivers (the legacy
+path reported the generic `"Any"`/`"Package"` or the pre-mixin type, ignoring the role layer
+entirely — exactly the failure mode E1 exists to fix), and one `multi_arg_type_keys`
+Package-collision case that couldn't be reproduced as a live bug in two attempts and was filed as
+its own ticket rather than guessed at.
+
+Two follow-up tickets came out of the investigation: `mixin-role-order-not-tracked.md` (mutsu
+resolves `(0 but A) but Z`'s method collisions alphabetically since `MixinOverrides` carries no
+application-order information, where raku has the later-applied role win — the classifier
+deliberately mirrors the same wrong-but-deterministic behavior rather than diverging further, since
+a real fix needs an order field threaded through every mixin construction site) and
+`multi-arg-type-keys-package-collision.md` (the unconfirmed cache-key collision above).

--- a/news/2026-08/adr0019-e1b-typeid-authoritative.md
+++ b/news/2026-08/adr0019-e1b-typeid-authoritative.md
@@ -1,0 +1,47 @@
+# ADR-0019 E1b: the TypeId classifier becomes authoritative
+
+Building on E1a's shadow-mode classifier, the `TypeId`-based receiver-owner decision now actually
+drives dispatch at the three sites E1a's sweep showed were safe to cut over unconditionally:
+`call_method_with_values`'s augment gate, `dispatch_instance_and_fallback`'s value-type dispatch
+pick, and the small fallback-arm trio in `are_actual_type_name`/`are_value_matches_type`/
+`.^add_fallback`. Two new helpers do the work: `Interpreter::dispatch_owner_chain`/
+`dispatch_owner_name` (`src/runtime/receiver_class.rs`), a `dispatch_mro` variant with one
+deliberate difference — for a role Mixin receiver it skips the role-`TypeId` chain prefix and
+returns the inner value's own chain instead.
+
+That skip isn't optional. Every call site consulting this chain runs strictly after a dedicated,
+role-registry-aware path has already tried role methods for the same receiver
+(`dispatch_mixin_method_call` before the augment gate; `dispatch_qualified_mixin_method` before
+qualified dispatch). Re-deriving a role owner at this point would at best repeat that lookup and
+at worst regress: a direct repro confirmed it before landing — `augment class Array { method
+my-foo {...} }; (@a but R).my-foo` resolved fine under the old `value_type_name`-based owner
+(which unwraps a Mixin to its inner value the same way this skip does); switching to the raw
+role-first chain made it unresolvable, since the role `R` has no `augment`-recorded method by that
+name.
+
+Two related sites were widened from a single owner name to walking the *whole* chain:
+`methods_qualified.rs`'s qualified-dispatch membership check and `type_matching.rs`'s
+`type_matches_value`. This is required, not just more thorough — an Enum value's chain is
+`[EnumType, Int, Cool, Any, Mu]`, and a plain `Int` type constraint must still match an enum value
+through the `Int` link further down the chain; checking only the chain's head would have broken
+enum values against `Int`-typed parameters.
+
+Two of the four remaining divergent builtin-MRO tables from the E1 design doc's original inventory
+— `type_inherits`/`builtin_type_mro_chain` in `methods_call_helpers.rs` — were deleted outright,
+with their two call sites now reading the classifier's own chain. A third site
+(`try_compiled_method_or_interpret_inner`'s `class_sym`) needed no code change at all: it was
+already provably classifier-equivalent by construction, confirmed by zero mismatches across E1a's
+entire sweep, so its now-redundant shadow probe was simply removed rather than adding a
+chain-walk allocation to that hot fast-dispatch path for no behavioral benefit.
+
+One site was deliberately left on the shadow probe: `multi_arg_type_keys`
+(`vm_call_method_compiled_cache.rs`). Unlike the other three original E1a sites, making it
+authoritative there isn't a shadow-mode-safe refactor — it's the actual fix for
+`todo/tickets/multi-arg-type-keys-package-collision.md`, an unconfirmed but plausible cache-key
+collision. Bundling an unverified behavior change into this switch would have made the ticket's
+own investigation (confirm or refute the collision) inseparable from this slice's zero-risk
+cutover, so it stays deferred to be picked up on its own.
+
+MOP fallback consolidation (E1c — collapsing the 13+8 per-MOP-entry owner-fallback arms into one
+classifier-backed helper) remains out of scope. Verified via `make test` (28,121 tests) and a full
+`make roast` (218,774 tests), both green with no regressions.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3643,10 +3643,13 @@ impl Interpreter {
             target.view(),
             ValueView::Instance { .. } | ValueView::Package(_)
         ) {
-            let type_name = crate::runtime::utils::value_type_name(&target);
-            // ADR-0019 E1a shadow probe (zero behavior change): see
-            // `todo/deep/adr0019-e1-typeid-receiver-owner.md`.
-            self.shadow_check_owner("call_method_with_values.augment_gate", &target, type_name);
+            // ADR-0019 E1b: authoritative TypeId classifier owner (was
+            // `value_type_name`) — see `Interpreter::dispatch_owner_name` and
+            // `todo/deep/adr0019-e1-typeid-receiver-owner.md`. This fixes the
+            // Enum ("Int" -> the real enum type) and ParametricRole/Instance-in-
+            // Mixin ("Package"/"Any" -> the real name) collapses the old
+            // `value_type_name`-based owner had.
+            let type_name = self.dispatch_owner_name(&target);
             if self.has_user_method(type_name, method) {
                 return self.dispatch_instance_and_fallback(target, method, args);
             }

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -440,37 +440,11 @@ impl Interpreter {
         Ok(crate::value::value_buf::make_buf(class_name, byte_vals))
     }
 
-    /// Check if a builtin type inherits from a given ancestor type.
-    /// Covers the standard Raku type hierarchy for builtin types.
-    pub(super) fn type_inherits(type_name: &str, ancestor: &str) -> bool {
-        Self::builtin_type_mro_chain(type_name).contains(&ancestor)
-    }
-
-    /// The built-in type's MRO chain (self + ancestors), used by `type_inherits`
-    /// and by `.+`/`.*` all-candidates dispatch to count how many MRO levels
-    /// define a method. Roles (e.g. `Positional`) are intentionally omitted: they
-    /// carry no entry in `builtin_type_method_names`, so they never contribute a
-    /// candidate, and omitting them keeps this chain small.
-    pub(crate) fn builtin_type_mro_chain(type_name: &str) -> &'static [&'static str] {
-        match type_name {
-            "Int" => &["Int", "Cool", "Any", "Mu"],
-            "Num" => &["Num", "Cool", "Any", "Mu"],
-            "Rat" | "FatRat" => &["Rat", "Cool", "Any", "Mu"],
-            "Str" => &["Str", "Cool", "Any", "Mu"],
-            "Bool" => &["Bool", "Int", "Cool", "Any", "Mu"],
-            "Array" => &["Array", "List", "Cool", "Any", "Mu"],
-            "List" => &["List", "Cool", "Any", "Mu"],
-            "Hash" => &["Hash", "Cool", "Any", "Mu"],
-            "Range" => &["Range", "Cool", "Any", "Mu"],
-            "Pair" => &["Pair", "Cool", "Any", "Mu"],
-            "Set" => &["Set", "Any", "Mu"],
-            "Bag" => &["Bag", "Any", "Mu"],
-            "Mix" => &["Mix", "Any", "Mu"],
-            "Complex" => &["Complex", "Cool", "Any", "Mu"],
-            "Regex" => &["Regex", "Method", "Routine", "Block", "Code", "Any", "Mu"],
-            "Sub" => &["Sub", "Routine", "Block", "Code", "Any", "Mu"],
-            "Junction" => &["Junction", "Mu"],
-            _ => &["Any", "Mu"],
-        }
-    }
+    // `type_inherits`/`builtin_type_mro_chain` (one of the four divergent
+    // builtin-MRO tables the ADR-0019 E1 design doc calls out) were retired in
+    // E1b: their two call sites (`methods_qualified.rs`'s qualified-dispatch
+    // ancestor check, `vm_call_helpers.rs`'s `.+`/`.*` all-candidates count)
+    // now consult the TypeId classifier's catalog-backed chain instead — see
+    // `Interpreter::dispatch_owner_chain`/`dispatch_mro` and
+    // `todo/deep/adr0019-e1-typeid-receiver-owner.md`.
 }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1672,14 +1672,10 @@ impl Interpreter {
             target.view(),
             ValueView::Instance { .. } | ValueView::Package(_)
         ) {
-            let class_name = crate::runtime::utils::value_type_name(&target);
-            // ADR-0019 E1a shadow probe (zero behavior change): see
+            // ADR-0019 E1b: authoritative TypeId classifier owner (was
+            // `value_type_name`) — see `Interpreter::dispatch_owner_name` and
             // `todo/deep/adr0019-e1-typeid-receiver-owner.md`.
-            self.shadow_check_owner(
-                "dispatch_instance_and_fallback.value_type_dispatch",
-                &target,
-                class_name,
-            );
+            let class_name = self.dispatch_owner_name(&target);
             let dispatch_class = if self.has_user_method(class_name, method) {
                 Some(class_name)
             } else if matches!(target.view(), ValueView::Array(_, kind) if !kind.is_itemized())
@@ -2265,10 +2261,13 @@ impl Interpreter {
                         );
                     }
                 }
+                // ADR-0019 E1b: authoritative TypeId classifier owner (was
+                // `value_type_name`) in the fallback arm — see
+                // `Interpreter::dispatch_owner_name`.
                 let type_name = match target.view() {
                     ValueView::Instance { class_name, .. } => class_name.resolve(),
                     ValueView::Package(name) => name.resolve(),
-                    _ => crate::runtime::utils::value_type_name(&target).to_string(),
+                    _ => self.dispatch_owner_name(&target).to_string(),
                 };
                 // RakuAST construction via a non-`new` constructor (Phase 4),
                 // e.g. `RakuAST::Name.from-identifier("x")` (`.new` is handled
@@ -2305,10 +2304,13 @@ impl Interpreter {
         if self.method_fallbacks.is_empty() {
             return None;
         }
+        // ADR-0019 E1b: authoritative TypeId classifier owner (was
+        // `value_type_name`) in the fallback arm — see
+        // `Interpreter::dispatch_owner_name`.
         let type_name = match target.view() {
             ValueView::Instance { class_name, .. } => class_name.resolve(),
             ValueView::Package(name) => name.resolve(),
-            _ => crate::runtime::utils::value_type_name(target).to_string(),
+            _ => self.dispatch_owner_name(target).to_string(),
         };
         // Consult the class itself first, then its ancestors (MRO).
         let mut classes = vec![type_name.clone()];
@@ -2444,7 +2446,7 @@ impl Interpreter {
                 let expected_type = self.are_expected_type_name(expected);
                 for (idx, value) in values.iter().enumerate() {
                     if !self.are_value_matches_type(value, &expected_type) {
-                        let actual = Self::are_actual_type_name(value);
+                        let actual = self.are_actual_type_name(value);
                         let message = if values.len() == 1 {
                             format!("Expected '{}' but got '{}'", expected_type, actual)
                         } else {
@@ -2498,7 +2500,9 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.resolve())
                 .collect(),
-            _ => vec![crate::runtime::utils::value_type_name(value).to_string()],
+            // ADR-0019 E1b: authoritative TypeId classifier owner (was
+            // `value_type_name`) — see `Interpreter::dispatch_owner_name`.
+            _ => vec![self.dispatch_owner_name(value).to_string()],
         }
     }
 
@@ -2536,11 +2540,13 @@ impl Interpreter {
         self.type_matches_value(expected_type, value)
     }
 
-    fn are_actual_type_name(value: &Value) -> String {
+    fn are_actual_type_name(&mut self, value: &Value) -> String {
         match value.view() {
             ValueView::Package(name) => name.resolve(),
             ValueView::Instance { class_name, .. } => class_name.resolve(),
-            _ => crate::runtime::utils::value_type_name(value).to_string(),
+            // ADR-0019 E1b: authoritative TypeId classifier owner (was
+            // `value_type_name`) — see `Interpreter::dispatch_owner_name`.
+            _ => self.dispatch_owner_name(value).to_string(),
         }
     }
 

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -894,8 +894,23 @@ impl Interpreter {
             // `Int::abs`): fall back to ordinary unqualified dispatch.
             return Some(self.call_method_with_values(target.clone(), actual_method, args));
         }
-        let type_name = super::utils::value_type_name(target);
-        let type_matches = qualifier == type_name || Self::type_inherits(type_name, qualifier);
+        // ADR-0019 E1b: authoritative TypeId classifier chain (was
+        // `value_type_name` + the `type_inherits`/`builtin_type_mro_chain`
+        // divergent MRO table) — see `Interpreter::dispatch_owner_chain` and
+        // `todo/deep/adr0019-e1-typeid-receiver-owner.md`. `dispatch_qualified_mixin_method`
+        // already tried a role-qualified call on a Mixin receiver before this
+        // function runs, so `dispatch_owner_chain`'s role-skip is required here
+        // too: an unmatched role name must not satisfy this membership check by
+        // literal equality with the chain's first element (confirmed by repro:
+        // `(@a but R).R::elems` must still raise `X::Method::InvalidQualifier`
+        // when `R` does not define `elems`, not silently re-dispatch through the
+        // Mixin's unqualified fallback).
+        let chain = self.dispatch_owner_chain(target);
+        let type_name = chain
+            .first()
+            .map(|t| t.as_str())
+            .unwrap_or_else(|| crate::type_id::well_known_types().any.as_str());
+        let type_matches = qualifier == type_name || chain.iter().any(|t| t.as_str() == qualifier);
         if type_matches {
             return Some(self.call_method_with_values(target.clone(), actual_method, args));
         }

--- a/src/runtime/receiver_class.rs
+++ b/src/runtime/receiver_class.rs
@@ -1,4 +1,4 @@
-//! ADR-0019 Phase E box E1a: the shadow-mode receiver classifier.
+//! ADR-0019 Phase E box E1: the receiver classifier.
 //!
 //! `receiver_dispatch_class`/`dispatch_mro` compute the "who owns this method for this
 //! receiver" decision from a single place, using [`crate::type_id::TypeId`] and the
@@ -7,10 +7,20 @@
 //! `todo/deep/adr0019-e1-typeid-receiver-owner.md` for the full design and the
 //! verification items (V1-V5) referenced in the comments below.
 //!
-//! **E1a is shadow-only.** Nothing here drives dispatch yet — [`Interpreter::shadow_check_owner`]
-//! is the only way this module is reached from the interpreter, and it only records a
-//! `MUTSU_VM_STATS` comparison against the *existing* owner decision. Making the
-//! classifier authoritative is E1b.
+//! **E1a** (landed) wired the classifier in shadow mode only, comparing its answer
+//! against each site's existing string-based decision under `MUTSU_VM_STATS` counters
+//! without changing behavior.
+//!
+//! **E1b** (this slice) makes the classifier authoritative at the dispatch/fallback
+//! sites enumerated in the design doc's E1b bullet, via [`Interpreter::dispatch_owner_chain`]
+//! / [`Interpreter::dispatch_owner_name`] (a `dispatch_mro` variant that skips a role
+//! `Mixin`'s role-TypeId prefix — see its doc comment for why). The lone exception is
+//! `multi_arg_type_keys` (`vm_call_method_compiled_cache.rs`), whose cutover is
+//! deliberately deferred to `todo/tickets/multi-arg-type-keys-package-collision.md`:
+//! unlike the other three original E1a sites, making it authoritative there is not a
+//! shadow-mode-safe refactor but IS the fix for that ticket's Package-collision bug, so
+//! it stays on `shadow_check_owner` until that ticket is picked up on its own. MOP
+//! fallback consolidation (E1c) is still out of scope here.
 
 use super::*;
 use crate::builtins::builtin_type_catalog::builtin_type_info;
@@ -263,11 +273,59 @@ impl Interpreter {
         chain
     }
 
+    /// ADR-0019 **E1b**: the dispatch-owner chain for a **non-Instance,
+    /// non-Package** receiver, authoritative at the fallback/qualified-dispatch
+    /// sites enumerated in `todo/deep/adr0019-e1-typeid-receiver-owner.md`'s E1b
+    /// slice. This is [`Self::dispatch_mro`] with one deliberate difference: for a
+    /// role `Mixin` it skips the role-`TypeId` prefix `dispatch_mro` puts first,
+    /// returning the *inner* value's own chain instead.
+    ///
+    /// Why the skip is required, not optional: every call site that consults this
+    /// chain runs strictly *after* a dedicated, role-registry-aware path has
+    /// already tried role methods for the same receiver
+    /// (`dispatch_mixin_method_call` before `call_method_with_values`'s augment
+    /// gate; `dispatch_qualified_mixin_method` before
+    /// `dispatch_qualified_non_instance_method`). Re-deriving a role owner here
+    /// would at best repeat that lookup, and at worst regress: using the role
+    /// name as the SOLE owner for a role mixed onto a builtin value (`@a but R`)
+    /// stops any lookup keyed on that single name from ever reaching the inner
+    /// value's real builtin ancestry. Confirmed by direct repro before this cutover
+    /// landed: `augment class Array { method my-foo {...} }; (@a but R).my-foo`
+    /// resolved fine under the old `value_type_name`-based owner (which unwraps a
+    /// Mixin to its inner value, same as this skip); switching the owner to
+    /// `dispatch_mro`'s raw role-first chain's first element made it
+    /// unresolvable, since `"R"` has no `augment`-recorded method of that name.
+    /// Allomorphs (`<1/3>`, `IntStr` et al.) are exempted from the skip: their
+    /// classifier chain already starts with the allomorph type itself, not a
+    /// role, so `dispatch_mro`'s answer is already correct.
+    pub(crate) fn dispatch_owner_chain(&mut self, value: &Value) -> Vec<TypeId> {
+        if let ValueView::Mixin(inner, mixins) = value.view()
+            && !mixins.contains_key("Str")
+        {
+            return self.dispatch_mro(inner.as_ref());
+        }
+        self.dispatch_mro(value)
+    }
+
+    /// The single canonical owner name for [`Self::dispatch_owner_chain`] — the
+    /// classifier's authoritative answer for a non-Instance, non-Package receiver,
+    /// replacing `value_type_name` at the E1b-cutover sites (fallback/augment
+    /// gates that key a lookup on ONE name, not a full MRO walk).
+    pub(crate) fn dispatch_owner_name(&mut self, value: &Value) -> &'static str {
+        self.dispatch_owner_chain(value)
+            .first()
+            .map(|t| t.as_str())
+            .unwrap_or_else(|| well_known_types().any.as_str())
+    }
+
     /// Shadow-mode comparison for ADR-0019 E1a (`MUTSU_VM_STATS`-gated, a no-op
     /// otherwise): compute the classifier's owner for `target` and compare it against
     /// `old_owner` (the name the *existing* dispatch-path logic at `site` already
     /// picked). Purely observational — `old_owner` continues to drive dispatch
-    /// unchanged. See `todo/deep/adr0019-e1-typeid-receiver-owner.md`.
+    /// unchanged. Retained in E1b only at `multi_arg_type_keys`
+    /// (`vm_call_method_compiled_cache.rs`), whose cutover is deliberately deferred
+    /// to its own ticket — see `todo/tickets/multi-arg-type-keys-package-collision.md`.
+    /// See `todo/deep/adr0019-e1-typeid-receiver-owner.md`.
     pub(crate) fn shadow_check_owner(
         &mut self,
         site: &'static str,

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -1460,7 +1460,22 @@ impl Interpreter {
             // rejected when the constraint is Any.
             return Self::type_matches(constraint, &resolved);
         }
-        let value_type = crate::runtime::value_type_name(value);
-        Self::type_matches(constraint, value_type)
+        // ADR-0019 E1b: authoritative TypeId classifier chain (was a single
+        // `value_type_name` string) — see `Interpreter::dispatch_owner_chain`
+        // and `todo/deep/adr0019-e1-typeid-receiver-owner.md`. Walking the
+        // whole chain (not just its first element) is required, not merely
+        // more thorough: an Enum value's chain is `[EnumType, Int, Cool, Any,
+        // Mu]` (V3 -- `value_type_name` collapsed it to the single name
+        // "Int"), and a plain `Int` constraint must still match an enum value
+        // through the `Int` link further down the chain, which a single-name
+        // swap to `EnumType` alone would have broken. Role membership (a
+        // Mixin's applied roles) was already checked above by name via
+        // `mixins.keys()`, so this uses the un-skipped `dispatch_mro` --
+        // finding a role name here again by literal `type_matches` equality
+        // is harmless (it can only re-confirm a match the constraint author
+        // wrote as the bare role name).
+        self.dispatch_mro(value)
+            .iter()
+            .any(|t| Self::type_matches(constraint, t.as_str()))
     }
 }

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -287,13 +287,19 @@ impl Interpreter {
         ) {
             return 1;
         }
-        // Use the *introspective* type name (List vs Array distinguished by
-        // ArrayKind), so `<a b>` (List) walks the List MRO, not Array's.
-        let type_name = crate::runtime::value_type_name(target);
-        let count = Self::builtin_type_mro_chain(type_name)
+        // ADR-0019 E1b: authoritative TypeId classifier chain (was
+        // `value_type_name` + the `builtin_type_mro_chain` divergent MRO
+        // table) — see `Interpreter::dispatch_mro` and
+        // `todo/deep/adr0019-e1-typeid-receiver-owner.md`. `target` is
+        // guaranteed non-Instance/non-Mixin by the early return above, so the
+        // role-skip `dispatch_owner_chain` variant is unnecessary here — the
+        // classifier's own chain (which still distinguishes List vs Array by
+        // `ArrayKind`, same as the old `value_type_name`) is exactly right.
+        let chain = self.dispatch_mro(target);
+        let count = chain
             .iter()
-            .filter(|cn| {
-                crate::builtins::builtin_type_methods::builtin_type_method_names(cn)
+            .filter(|t| {
+                crate::builtins::builtin_type_methods::builtin_type_method_names(t.as_str())
                     .contains(&method)
             })
             .count();

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -484,13 +484,19 @@ impl Interpreter {
             _ => None,
         };
         if let Some(class_sym) = class_sym_opt {
-            // ADR-0019 E1a shadow probe (zero behavior change): see
-            // `todo/deep/adr0019-e1-typeid-receiver-owner.md`.
-            self.shadow_check_owner(
-                "try_compiled_method_or_interpret_inner.class_sym",
-                &target,
-                class_sym.as_str(),
-            );
+            // ADR-0019 E1b: this site is already TypeId-classifier-authoritative
+            // by construction, with no code change needed. `class_sym` here is
+            // the receiver's own Instance/Package Symbol, which is *always*
+            // `Interpreter::dispatch_mro`'s first chain element for an
+            // Instance/Package receiver (`dispatch_mro`'s Instance/Package arms
+            // both start the chain at the class's own registry-MRO head) — the
+            // E1a shadow sweep confirmed zero mismatches here across all of
+            // `t/*.t` plus S02/S06/S12/S14 roast. Routing this hot fast-dispatch
+            // path through `receiver_dispatch_class`/`dispatch_mro` anyway would
+            // add a `Vec<TypeId>` allocation and a `class_mro` lookup for a
+            // provably-identical answer — a pure perf regression for zero
+            // behavior change — so the shadow probe (now redundant) is removed
+            // and the direct `class_sym.as_str()` read is kept.
             self.refresh_method_caches_for_generation();
             let cn = class_sym.as_str();
             let cache_key = (class_sym, method_sym);


### PR DESCRIPTION
## Summary

ADR-0019 Phase E box **E1b** (`todo/deep/adr0019-e1-typeid-receiver-owner.md`), building on E1a's shadow-mode classifier (#6156).

- The TypeId classifier now drives dispatch at the three sites E1a's mismatch sweep showed were safe to cut over unconditionally: `call_method_with_values`'s augment gate, `dispatch_instance_and_fallback`'s value-type dispatch pick, and the `are_actual_type_name`/`are_value_matches_type`/`.^add_fallback` fallback-arm trio.
- Two new helpers, `Interpreter::dispatch_owner_chain`/`dispatch_owner_name` (`src/runtime/receiver_class.rs`) — a `dispatch_mro` variant that skips a role Mixin's role-`TypeId` prefix, returning the inner value's own chain instead. This is required, not optional: every consuming call site already tried role methods via a dedicated role-aware path first, so re-deriving a role owner here would at best repeat that lookup and at worst regress — confirmed by a direct repro (`augment class Array { method my-foo {...} }; (@a but R).my-foo` broke under the raw role-first chain, worked under the skip, matching old behavior).
- `methods_qualified.rs`'s qualified-dispatch membership check and `type_matching.rs`'s `type_matches_value` now walk the *whole* chain instead of just its head — required for Enum receivers, whose chain is `[EnumType, Int, Cool, Any, Mu]`; a plain `Int` constraint must still match through the `Int` link further down.
- Two of the four divergent builtin-MRO tables (`type_inherits`/`builtin_type_mro_chain`) are deleted outright, their call sites reading the classifier's chain instead.
- `try_compiled_method_or_interpret_inner`'s `class_sym` site needed no code change — already provably classifier-equivalent by construction (zero mismatches in E1a's sweep) — so its now-redundant shadow probe was removed without adding a chain-walk allocation to that hot fast-dispatch path.
- `multi_arg_type_keys` stays on the E1a shadow probe on purpose: its cutover is the actual fix for `todo/tickets/multi-arg-type-keys-package-collision.md`, not a zero-risk refactor, so it's deferred to that ticket rather than bundled here.
- Also backfills the ADR/news documentation for E1a, which its own PR (#6156) merged without either.

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` — clean
- [x] `make test` — 28,121 tests, all green
- [x] Full `make roast` (release build) — 218,774 tests, all green, no regressions
- [x] Spot-checked `roast/S02-types/quanthash.t` (not whitelisted) shows only its 3 already-documented, pre-existing `TODO_roast/BLOCKERS.md` failures (Track B/GC element-cell work, unrelated to dispatch) — confirmed not a regression from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)