### PR TITLE
refactor(adr0019): E1c -- collapse MOP fallback owner arms into one classifier helper

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1799,8 +1799,36 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     until that ticket is picked up on its own, rather than bundling an unverified behavior change
     into this switch. MOP fallback consolidation (E1c) stays out of scope. Verified via `make
     test` (28,121 tests) and a full `make roast` (218,774 tests), both green.
-  - [ ] **E1c — MOP fallback consolidation.** Collapse the 13+8 per-MOP-entry owner-fallback
+  - [x] **E1c — MOP fallback consolidation.** Collapse the 13+8 per-MOP-entry owner-fallback
     arms into one classifier-backed `mop_receiver_owner` helper.
+    **Landed 2026-08-10**: `Interpreter::mop_receiver_owner` (`src/runtime/receiver_class.rs`) —
+    Package/Instance report their own name directly, everything else resolves through
+    `dispatch_owner_name` (the E1b classifier) instead of `value_type_name` — replaces the
+    22 duplicated `_ => value_type_name(&args[0]).to_string()` / `let name = match ... {
+    Package(..)=>.., Instance(..)=>.., _=>value_type_name(..) }` fallback sites across
+    `methods_classhow_dispatch.rs` (13), `methods_classhow_mro.rs` (3),
+    `methods_classhow_parents.rs` (3), `methods_classhow_builtin_methods.rs` (1),
+    `methods_classhow_lookup.rs` (1), and `methods_classhow_method_obj.rs` (1) — one more than
+    the design doc's 21-site estimate because `dispatch_classhow_roles`'s Mixin arm nests two
+    fallback arms in one match. Four call sites (`classhow_lookup`, `classhow_find_method`,
+    `dispatch_classhow_roles`, `filter_mro_unhidden`) needed `&self` -> `&mut self` promotion
+    since the classifier caches the registry MRO lookup (`class_mro`) mutably; every caller of
+    those four was already `&mut self`, so the promotion did not cascade further. Sites with an
+    extra non-Package/Instance arm the plain 3-arm pattern didn't cover (`RakuAst` in
+    `classhow_mro_names`/`dispatch_classhow_parents`/`method_table`/`collect_can_methods`,
+    `Enum` in `collect_can_methods`) kept that arm explicit ahead of the fallback rather than
+    folding it into the helper, since those arms carry different logic than a plain owner
+    lookup. Two sites deliberately broadened behavior in a direction the E1b rules already
+    established as correct: `"parameterize"`'s `base` and `dispatch_classhow_roles`'s Mixin
+    fallback previously had no `Instance` arm at all (falling to `value_type_name`'s "Any"
+    answer for a receiver that in practice is never an Instance); `mop_receiver_owner` now
+    resolves an Instance there too, consistent with the owner rules E1b already made
+    authoritative elsewhere — not exercised by any known test, called out here for review
+    honesty. Verified via `make test` (2994 files/28129 tests) and a full `make roast` (1435
+    files/218,748 tests), both green — the three `make roast` failures seen on the first run
+    (`spurt.t`, `socket-recv-vs-read.t`, `S17-supply/syntax.t`) were confirmed to be artifacts of
+    an interrupted prior local run (stale `temp-file-RT-126006-test` plus load-induced timing)
+    by re-running each file individually, not regressions from this change.
 - [ ] **E2 — Give every native entry an exact handler ID.** Generate static type×method handler rows
   for pure arity handlers and stateful/special handlers; pin type-object, subclass, Map/Seq,
   Failure, and Rat-style cases that broke the reverted attempt.

--- a/news/2026-08/adr0019-e1c-mop-fallback-consolidation.md
+++ b/news/2026-08/adr0019-e1c-mop-fallback-consolidation.md
@@ -1,0 +1,26 @@
+# ADR-0019 E1c: MOP fallback consolidation
+
+Phase E's receiver-owner box (E1) closes out: E1a introduced the `TypeId`/classifier in
+shadow mode, E1b made it authoritative at the dispatch-critical sites, and this slice (E1c)
+finishes the sweep by collapsing the remaining "who owns this MOP entry" duplication.
+
+Twenty-two call sites across six `runtime/methods_classhow_*.rs` modules each re-derived a
+receiver's owner name by hand with the same shape: a type object or instance reports its own
+name, and everything else falls back to `value_type_name`, the pre-ADR-0019 string-based
+classifier that flattens Enum receivers to `"Int"` and role mixins to their un-mixed base
+type. Every one of those fallback arms now calls one new helper,
+`Interpreter::mop_receiver_owner`, which delegates the fallback case to `dispatch_owner_name`
+(the classifier E1b already made authoritative for dispatch). Four functions needed a
+`&self` -> `&mut self` promotion to make the call, since the classifier caches a registry MRO
+lookup; every caller of those four already held `&mut self`, so the promotion did not
+propagate any further.
+
+Two sites (`.^parameterize`'s base-type lookup and `.^roles`'s Mixin-receiver fallback)
+previously had no `Instance` arm at all, silently falling to `value_type_name`'s "Any" answer
+for a receiver that is never expected to be an Instance in practice. `mop_receiver_owner`
+resolves an Instance there too now, consistent with the owner rules E1b already established —
+a deliberate, no-known-test-affects-it broadening rather than a behavior-preserving refactor at
+those two spots.
+
+Verified via `make test` (2994 files / 28,129 tests) and a full `make roast` (1435 files /
+218,748 tests), both green.

--- a/src/runtime/methods_classhow_builtin_methods.rs
+++ b/src/runtime/methods_classhow_builtin_methods.rs
@@ -7,11 +7,7 @@ impl Interpreter {
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
         let invocant = &args[0];
-        let class_name = match invocant.view() {
-            ValueView::Package(name) => name.resolve(),
-            ValueView::Instance { class_name, .. } => class_name.resolve(),
-            _ => value_type_name(invocant).to_string(),
-        };
+        let class_name = self.mop_receiver_owner(invocant);
 
         // Parse named arguments
         let mut local = false;

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -171,7 +171,7 @@ impl Interpreter {
                         .join(",");
                     format!("{}[{}]", base_name, args_str)
                 }
-                _ => value_type_name(&args[0]).to_string(),
+                _ => self.dispatch_owner_name(&args[0]).to_string(),
             })),
             "array_type" if !args.is_empty() => {
                 // The element type of a native array-ish container. Derived from
@@ -193,13 +193,7 @@ impl Interpreter {
                 Ok(Value::str(shorten_type_name(&full)))
             }
             "ver" if args.len() == 1 => {
-                let name = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    // A plain value (`42.^ver`): resolve through its type so
-                    // builtins answer below.
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let name = self.mop_receiver_owner(&args[0]);
                 if let Some(meta) = self.type_metadata.get(&name)
                     && let Some(value) = meta.get("ver").cloned()
                 {
@@ -252,11 +246,7 @@ impl Interpreter {
                 ))
             }
             "auth" if args.len() == 1 => {
-                let name = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let name = self.mop_receiver_owner(&args[0]);
                 // A bare `package` uses PackageHOW, which has no `.^auth`.
                 if matches!(
                     self.registry().package_kinds.get(&name),
@@ -279,11 +269,7 @@ impl Interpreter {
                 Ok(Value::str(String::new()))
             }
             "api" if args.len() == 1 => {
-                let name = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let name = self.mop_receiver_owner(&args[0]);
                 // A bare `package` uses PackageHOW, which has no `.^api`.
                 if matches!(
                     self.registry().package_kinds.get(&name),
@@ -390,11 +376,7 @@ impl Interpreter {
                 }
             }
             "archetypes" if !args.is_empty() => {
-                let invocant_name = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let invocant_name = self.mop_receiver_owner(&args[0]);
                 let base_name = invocant_name
                     .split_once('[')
                     .map(|(base, _)| base)
@@ -432,11 +414,7 @@ impl Interpreter {
                 ))
             }
             "nominalize" if !args.is_empty() => {
-                let invocant_name = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let invocant_name = self.mop_receiver_owner(&args[0]);
                 let nominal = self.nominalize_type_name(&invocant_name);
                 Ok(Value::package(Symbol::intern(&nominal)))
             }
@@ -556,10 +534,7 @@ impl Interpreter {
                 // `Base[Arg,...]` package name that `vm_var_index_ops.rs` produces
                 // for the `[ ]` syntax, so `Set.^parameterize(Str)` and `Set[Str]`
                 // yield an identical parameterized type object.
-                let base = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let base = self.mop_receiver_owner(&args[0]);
                 let param_args = args[1..]
                     .iter()
                     .filter(|a| !matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
@@ -578,11 +553,7 @@ impl Interpreter {
                 ))))
             }
             "coerce" if args.len() >= 2 => {
-                let target_constraint = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let target_constraint = self.mop_receiver_owner(&args[0]);
                 let original = args[1].clone();
                 let parse_coercion = |constraint: &str| -> Option<(String, Option<String>)> {
                     if !constraint.ends_with(')') || constraint.contains('[') {
@@ -971,11 +942,7 @@ impl Interpreter {
             }
             "methods" if !args.is_empty() => self.dispatch_classhow_methods(&args),
             "attributes" if !args.is_empty() => {
-                let owner_class = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let owner_class = self.mop_receiver_owner(&args[0]);
                 let local_only = args[1..].iter().any(
                     |a| matches!(a.view(), ValueView::Pair(k, v) if k == "local" && v.truthy()),
                 );
@@ -1044,11 +1011,7 @@ impl Interpreter {
                 Ok(Value::array(Vec::new()))
             }
             "concretization" if args.len() >= 2 => {
-                let class_name = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let class_name = self.mop_receiver_owner(&args[0]);
                 let role_name = match args[1].view() {
                     ValueView::Package(name) => name.resolve(),
                     ValueView::ParametricRole {
@@ -1201,11 +1164,7 @@ impl Interpreter {
                 {
                     return Ok(rev.clone());
                 }
-                let type_name = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let type_name = self.mop_receiver_owner(&args[0]);
                 if let Some(meta) = self.type_metadata.get(&type_name)
                     && let Some(rev) = meta.get("language-revision")
                 {
@@ -1222,19 +1181,13 @@ impl Interpreter {
             }
             "method_table" if !args.is_empty() => {
                 let type_name = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
                     ValueView::RakuAst(node) => node.class.printed_name().to_string(),
-                    _ => value_type_name(&args[0]).to_string(),
+                    _ => self.mop_receiver_owner(&args[0]),
                 };
                 Ok(Value::hash(self.class_method_table(&type_name)))
             }
             "submethod_table" if !args.is_empty() => {
-                let type_name = match args[0].view() {
-                    ValueView::Package(name) => name.resolve(),
-                    ValueView::Instance { class_name, .. } => class_name.resolve(),
-                    _ => value_type_name(&args[0]).to_string(),
-                };
+                let type_name = self.mop_receiver_owner(&args[0]);
                 let mut table = HashMap::new();
                 if let Some(class_def) = self.registry().classes.get(&type_name) {
                     for (name, defs) in &class_def.methods {

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::symbol::Symbol;
 
 impl Interpreter {
-    pub(super) fn classhow_lookup(&self, invocant: &Value, method_name: &str) -> Option<Value> {
+    pub(super) fn classhow_lookup(&mut self, invocant: &Value, method_name: &str) -> Option<Value> {
         let (class_name, class_name_str) = match invocant.view() {
             ValueView::Package(name) => (name, name.resolve()),
             // An instance of a user class carries its class name; `value_type_name` would
@@ -10,8 +10,8 @@ impl Interpreter {
             // nothing while `Class.^lookup('m')` did.
             ValueView::Instance { class_name, .. } => (class_name, class_name.resolve()),
             _ => {
-                // For concrete values, derive the type name
-                let type_name = crate::runtime::utils::value_type_name(invocant).to_string();
+                // For concrete values, derive the type name via the classifier.
+                let type_name = self.dispatch_owner_name(invocant).to_string();
                 (Symbol::intern(&type_name), type_name)
             }
         };
@@ -309,7 +309,7 @@ impl Interpreter {
     }
 
     pub(super) fn classhow_find_method(
-        &self,
+        &mut self,
         invocant: &Value,
         method_name: &str,
     ) -> Option<Value> {

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -289,11 +289,9 @@ impl Interpreter {
     /// defines the method. This implements `.can(method-name)`.
     pub(super) fn collect_can_methods(&mut self, target: &Value, method_name: &str) -> Vec<Value> {
         let class_name = match target.view() {
-            ValueView::Instance { class_name, .. } => class_name.resolve(),
-            ValueView::Package(name) => name.resolve(),
             ValueView::RakuAst(node) => node.class.printed_name().to_string(),
             ValueView::Enum { enum_type, .. } => enum_type.resolve(),
-            _ => utils::value_type_name(target).to_string(),
+            _ => self.mop_receiver_owner(target),
         };
         // RakuAST model classes are native type objects rather than ordinary
         // ClassDef entries. Keep `.^can` in lockstep with `.^methods(:local)`

--- a/src/runtime/methods_classhow_mro.rs
+++ b/src/runtime/methods_classhow_mro.rs
@@ -4,10 +4,8 @@ use crate::symbol::Symbol;
 impl Interpreter {
     pub(super) fn classhow_mro_names(&mut self, invocant: &Value) -> Vec<String> {
         let class_name = match invocant.view() {
-            ValueView::Package(name) => name.resolve(),
             ValueView::RakuAst(node) => node.class.printed_name().to_string(),
-            ValueView::Instance { class_name, .. } => class_name.resolve(),
-            _ => value_type_name(invocant).to_string(),
+            _ => self.mop_receiver_owner(invocant),
         };
         let mut mro = if let Some(mro) = crate::rakuast::type_object_mro(&class_name) {
             mro
@@ -67,11 +65,7 @@ impl Interpreter {
         invocant: &Value,
         _concretizations: bool,
     ) -> Vec<Value> {
-        let class_name = match invocant.view() {
-            ValueView::Package(name) => name.resolve(),
-            ValueView::Instance { class_name, .. } => class_name.resolve(),
-            _ => value_type_name(invocant).to_string(),
-        };
+        let class_name = self.mop_receiver_owner(invocant);
         let base_mro = self.classhow_mro_names(invocant);
         let mut result: Vec<Value> = Vec::new();
         let mut seen: HashSet<String> = HashSet::new();
@@ -150,12 +144,8 @@ impl Interpreter {
     }
 
     /// Filter MRO to remove hidden classes and their associated roles.
-    pub(super) fn filter_mro_unhidden(&self, invocant: &Value, mro: Vec<Value>) -> Vec<Value> {
-        let class_name = match invocant.view() {
-            ValueView::Package(name) => name.resolve(),
-            ValueView::Instance { class_name, .. } => class_name.resolve(),
-            _ => value_type_name(invocant).to_string(),
-        };
+    pub(super) fn filter_mro_unhidden(&mut self, invocant: &Value, mro: Vec<Value>) -> Vec<Value> {
+        let class_name = self.mop_receiver_owner(invocant);
         // Collect hidden parent names for this class
         let hidden_parents: rustc_hash::FxHashSet<String> = self
             .registry()

--- a/src/runtime/methods_classhow_parents.rs
+++ b/src/runtime/methods_classhow_parents.rs
@@ -15,10 +15,8 @@ impl Interpreter {
         let all = has_flag("all");
         let tree = has_flag("tree");
         let class_name = match args[0].view() {
-            ValueView::Package(name) => name.resolve(),
             ValueView::RakuAst(node) => node.class.printed_name().to_string(),
-            ValueView::Instance { class_name, .. } => class_name.resolve(),
-            _ => value_type_name(&args[0]).to_string(),
+            _ => self.mop_receiver_owner(&args[0]),
         };
         if tree {
             // `.^parents(:tree)` returns the parent tree. A single direct parent
@@ -147,7 +145,10 @@ impl Interpreter {
             .any(|r| r.split_once('[').map(|(b, _)| b).unwrap_or(r) == role)
     }
 
-    pub(crate) fn dispatch_classhow_roles(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(crate) fn dispatch_classhow_roles(
+        &mut self,
+        args: &[Value],
+    ) -> Result<Value, RuntimeError> {
         // Detect whether the invocant is an instance (Mixin or Instance) vs a
         // type object (Package). For punned role instances, the role itself
         // should be included in the result.
@@ -156,13 +157,11 @@ impl Interpreter {
             ValueView::Instance { .. } | ValueView::Mixin(_, _)
         );
         let class_name = match args[0].view() {
-            ValueView::Package(name) => name.resolve(),
-            ValueView::Instance { class_name, .. } => class_name.resolve(),
             ValueView::Mixin(inner, _) => match inner.as_ref().view() {
                 ValueView::Instance { class_name, .. } => class_name.resolve(),
-                _ => value_type_name(&args[0]).to_string(),
+                _ => self.dispatch_owner_name(&args[0]).to_string(),
             },
-            _ => value_type_name(&args[0]).to_string(),
+            _ => self.mop_receiver_owner(&args[0]),
         };
         let local = args[1..]
             .iter()

--- a/src/runtime/receiver_class.rs
+++ b/src/runtime/receiver_class.rs
@@ -318,6 +318,24 @@ impl Interpreter {
             .unwrap_or_else(|| well_known_types().any.as_str())
     }
 
+    /// ADR-0019 **E1c**: the owner name a `Metamodel` MOP entry (`.^ver`,
+    /// `.^auth`, `.^attributes`, `.^concretization`, ...) keys its lookup on. A
+    /// type object or instance reports its own declared name directly, exactly
+    /// like the sites this replaces; every other receiver (concrete builtins,
+    /// Enum values, role mixins) resolves through [`Self::dispatch_owner_name`]
+    /// instead of `value_type_name` — the two agree except for the E1a-ledger
+    /// cases (Enum, role mixin) where the classifier is the *correct* answer.
+    /// Collapses the 13+8 duplicated `_ => value_type_name(&args[0]).to_string()`
+    /// fallback arms surveyed across the MOP dispatch modules
+    /// (`todo/deep/adr0019-e1-typeid-receiver-owner.md`) into one call.
+    pub(crate) fn mop_receiver_owner(&mut self, value: &Value) -> String {
+        match value.view() {
+            ValueView::Package(name) => name.resolve(),
+            ValueView::Instance { class_name, .. } => class_name.resolve(),
+            _ => self.dispatch_owner_name(value).to_string(),
+        }
+    }
+
     /// Shadow-mode comparison for ADR-0019 E1a (`MUTSU_VM_STATS`-gated, a no-op
     /// otherwise): compute the classifier's owner for `target` and compare it against
     /// `old_owner` (the name the *existing* dispatch-path logic at `site` already


### PR DESCRIPTION
## Summary
- Closes ADR-0019 Phase E box **E1** (E1a shadow mode -> E1b dispatch cutover -> **E1c** MOP fallback consolidation).
- Adds `Interpreter::mop_receiver_owner` (`src/runtime/receiver_class.rs`): Package/Instance report their own name directly, everything else resolves through the E1b classifier (`dispatch_owner_name`) instead of the pre-ADR-0019 string-based `value_type_name`.
- Replaces 22 duplicated fallback arms across `methods_classhow_dispatch.rs` (13), `methods_classhow_mro.rs` (3), `methods_classhow_parents.rs` (3), `methods_classhow_builtin_methods.rs` (1), `methods_classhow_lookup.rs` (1), `methods_classhow_method_obj.rs` (1) -- one more than the design doc's 21-site estimate (`dispatch_classhow_roles`'s Mixin arm nests two fallback arms in one match).
- Four functions (`classhow_lookup`, `classhow_find_method`, `dispatch_classhow_roles`, `filter_mro_unhidden`) needed `&self` -> `&mut self` promotion since the classifier caches a registry MRO lookup; every caller of those four was already `&mut self`, so it didn't cascade further.
- Two sites (`.^parameterize`'s base lookup, `.^roles`'s Mixin fallback) previously had no `Instance` arm at all and fell to `value_type_name`'s `"Any"` answer; `mop_receiver_owner` now resolves an Instance there too -- a deliberate broadening consistent with the E1b owner rules, not exercised by any known test, called out for review honesty.

## Test plan
- [x] `make test` -- 2994 files / 28,129 tests, green
- [x] `make roast` -- 1435 files / 218,748 tests, green (three failures on the first run -- `spurt.t`, `socket-recv-vs-read.t`, `S17-supply/syntax.t` -- were confirmed artifacts of an interrupted prior local `make roast` run, not regressions, by re-running each file individually)
- [x] `cargo clippy -- -D warnings`, `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)