### PR TITLE
refactor(adr0019): E4a -- sequence builder + shadow parity (user candidates)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1858,8 +1858,40 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   ranking/signature selection stays per-call via the existing ladder extracted to consume a
   candidate slice. The six copy-pasted submethod no-inherit rules collapse into the one build
   site. Sibling walkers migrate with their consumers (E7/E8/E9), not here.
-  - [ ] **E4a — sequence builder + shadow parity (user candidates only)**, counter-verified
+  - [x] **E4a — sequence builder + shadow parity (user candidates only)**, counter-verified
     against `resolve_method_with_owner_impl` outcomes.
+    **Landed 2026-08-10**: `ResolvedSequence`/`ResolvedCandidate::User` plus
+    `Interpreter::resolve_sequence` (`src/runtime/resolution_sequence.rs`) walk an E1
+    `TypeId` chain and collect every visible user-declared candidate per level (private
+    skip; `is_my` skip when the level is an ancestor) into the flat, shape-independent
+    candidate universe decision 4 describes. `resolve_method_with_owner_impl`'s winner-
+    picking tie-break ladder (type distance, `is default`, narrowness, explicit-named,
+    most-derived-owner, `X::Multi::Ambiguous`) was extracted verbatim into
+    `Interpreter::pick_method_winner` (`resolution_method.rs`) — a pure code-motion
+    refactor, zero behavior change — so both the real resolver and the shadow builder
+    rank with the exact same rules. `Interpreter::shadow_check_resolver`
+    (`MUTSU_VM_STATS`-gated) builds the sequence at `resolve_method_cached`'s two
+    resolution boundaries (multi-cache-miss and fresh-resolve), filters candidates
+    through `method_args_match_for_invocant`, ranks with `pick_method_winner`, and
+    compares the winner (owner symbol + `MethodDef.body` `Arc` pointer identity)
+    against the real answer under new `resolver_shadow_checks`/`_mismatches` counters.
+    Two correctness-critical guards keep this a true zero-behavior-change probe:
+    `self.dispatch_ambiguous` is saved/restored around the shadow ranking (it can set
+    the flag, which the caller reads immediately after the real resolve); candidates
+    with a `where`-clause param are skipped entirely, since `where` is user code whose
+    dynamic-variable writes are a deliberately-preserved side effect
+    (`restore_env_preserving_dynamics`) that must not run twice. Verified via a
+    `MUTSU_VM_STATS=1` sweep over full `t/` (2996 files, 12396 shadow checks) plus the
+    whitelisted `roast/{S12,S14,S32}-*` corpus (382 files, 12767 checks): 3 mismatches
+    total (0.012%), all in `t/`, all the same explained bucket — a non-multi method
+    resolves by name alone in the real resolver even when its signature does not bind
+    the call (`method assign-rw($a is rw)` called with a literal; a role-typed param
+    called with the wrong type), which the shadow builder does not yet model since it
+    only ranks args-matching candidates. This is the E8-deferred early-stopping rule
+    documented in `resolution_sequence.rs`'s module doc, not a new finding — E1a set
+    the precedent of landing with an explained-mismatch ledger rather than blocking on
+    it. `make test` (2996 files/28149 tests) and the full whitelisted roast sweep both
+    green.
   - [ ] **E4b — authoritative switch at the cached-resolve boundaries**, native rows included,
     `should_bypass_native_fastpath` deleted. Local `make roast` before PR.
 - [ ] **E5 — Route ordinary VM method calls through the resolver.** Cover zero/n-arg and named-call

--- a/news/2026-08/adr0019-e4a-sequence-builder-shadow.md
+++ b/news/2026-08/adr0019-e4a-sequence-builder-shadow.md
@@ -1,0 +1,46 @@
+# ADR-0019 E4a: the sequence builder lands in shadow mode
+
+Phase E's dispatch resolver (ADR-0019) now has its first slice of box E4 — the
+one-MRO-walk candidate sequence that will eventually unify native and user
+method resolution. E4a builds only the user-candidate half, purely for
+shadow-mode verification: `Interpreter::resolve_sequence`
+(`src/runtime/resolution_sequence.rs`) walks E1's `TypeId` receiver chain and
+collects every visible user-declared method candidate per level into a flat
+`ResolvedSequence`, the shape-independent candidate universe the design doc
+calls for.
+
+To rank a shadow sequence with the exact same rules the real resolver uses,
+`resolve_method_with_owner_impl`'s tie-break ladder (type-hierarchy distance,
+`is default`, narrowness, explicit-named preference, most-derived-owner,
+`X::Multi::Ambiguous`) was extracted verbatim into a new
+`Interpreter::pick_method_winner` — a pure code-motion refactor with no
+behavior change, shared by both the production resolver and the new shadow
+path.
+
+`Interpreter::shadow_check_resolver`, gated behind `MUTSU_VM_STATS`, builds
+the sequence at `resolve_method_cached`'s two resolution boundaries, filters
+candidates through the existing `method_args_match_for_invocant`, ranks the
+survivors with `pick_method_winner`, and compares the winner against the real
+resolver's answer under new `resolver_shadow_checks`/`resolver_shadow_mismatches`
+counters. Two guards keep this a true zero-behavior-change probe:
+`dispatch_ambiguous` is saved and restored around the shadow ranking (it can
+be set by `pick_method_winner`, and the caller reads it immediately after the
+real resolve), and any candidate carrying a `where`-clause parameter is
+skipped entirely, since a `where` clause is user code whose dynamic-variable
+writes are a deliberately-preserved side effect that must not run twice.
+
+A sweep of `MUTSU_VM_STATS=1` over the full `t/` suite (2996 files, 12396
+shadow checks) plus the whitelisted `roast/{S12,S14,S32}-*` corpus (382
+files, 12767 checks) found 3 mismatches total (0.012%), all in `t/`, all one
+explained bucket: the real resolver returns a non-multi method's sole
+candidate by name alone even when its signature does not bind the call's
+arguments (an `is rw` parameter fed a literal, a role-typed parameter fed the
+wrong type) — Raku raises the mismatch as a bind-time error rather than
+falling through to a different candidate. The shadow builder, which only
+ranks args-matching candidates, has no notion of this yet; it is the same
+early-stopping rule box E8 is scoped to model, not a new finding — following
+the precedent E1a set of landing a shadow-verified box with an explained-
+mismatch ledger.
+
+`make test` (2996 files / 28149 tests) and the full whitelisted roast sweep
+were run and are green with this change.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -372,6 +372,7 @@ pub(crate) mod resolution_map_grep;
 mod resolution_map_grep_rw;
 mod resolution_method;
 mod resolution_private_method;
+mod resolution_sequence;
 mod run;
 mod run_dist;
 mod run_main;

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -214,6 +214,26 @@ impl Interpreter {
                 }
             }
         }
+        let _ = submethod_blocks; // used for control flow above
+        self.pick_method_winner(&mro, arg_values, invocant, all_matches)
+    }
+
+    /// Pick the winning candidate from an MRO walk's collected multi-method
+    /// matches: type-hierarchy distance, then `is default`/narrowness/
+    /// explicit-named/most-derived-owner tie-breaks, raising
+    /// `X::Multi::Ambiguous` (`self.dispatch_ambiguous`) when none of those
+    /// break the tie. Extracted from `resolve_method_with_owner_impl`
+    /// (ADR-0019 E4a) so a candidate list collected a different way — e.g.
+    /// `resolution_sequence::resolve_sequence`'s TypeId-chain walk — can be
+    /// ranked with the exact same rules instead of re-deriving them. `mro` is
+    /// consulted only for the most-derived-owner tie-break's position lookup.
+    pub(crate) fn pick_method_winner(
+        &mut self,
+        mro: &[Symbol],
+        arg_values: &[Value],
+        invocant: Option<&Value>,
+        mut all_matches: Vec<(Symbol, MethodDef)>,
+    ) -> Option<(Symbol, MethodDef)> {
         if all_matches.len() <= 1 {
             return all_matches.into_iter().next();
         }
@@ -377,7 +397,6 @@ impl Interpreter {
                 self.dispatch_ambiguous = true;
             }
         }
-        let _ = submethod_blocks; // used for control flow above
         Some(all_matches.remove(best_idx))
     }
 

--- a/src/runtime/resolution_sequence.rs
+++ b/src/runtime/resolution_sequence.rs
@@ -1,0 +1,227 @@
+//! ADR-0019 Phase E box E4a: the sequence builder (user candidates only, shadow mode).
+//!
+//! [`Interpreter::resolve_sequence`] walks an E1 [`TypeId`] MRO chain and collects
+//! every visible user-declared method candidate for a name into a flat
+//! [`ResolvedSequence`] — the "shape-independent candidate universe" of design
+//! decision 4 in `todo/deep/adr0019-e2-e4-resolver-core.md`. Nothing in the VM or
+//! the interpreter's real dispatch reads a sequence today: E4a only builds one
+//! beside the existing resolver, at the two `resolve_method_cached` boundaries, and
+//! compares the winner ([`Interpreter::pick_method_winner`], extracted from
+//! `resolve_method_with_owner_impl` unchanged) against the real resolution under
+//! `MUTSU_VM_STATS` counters (`resolver_shadow_checks`/`_mismatches`).
+//!
+//! **Known, accepted divergence** (not yet modeled — E8's job per the design doc):
+//! `resolve_method_with_owner_impl` treats a non-multi method's lookup as independent
+//! of whether the call's arguments actually bind it — Raku itself resolves a plain
+//! (non-multi) method purely by name; a signature mismatch (an `is rw` param fed a
+//! literal, a typed param fed the wrong type) is a bind-time error raised *after*
+//! resolution, not a lookup failure that falls through to a differently-shaped
+//! candidate. Two concrete instances of that rule, both load-bearing for
+//! `resolve_method_with_owner_impl`'s early-stopping MRO walk:
+//! - a single visible non-multi candidate is returned even when its own signature
+//!   does not match the call (`first_visible_non_multi` in the real resolver);
+//! - a non-multi override on a more-derived class hides same-named candidates on
+//!   every ancestor the same way, regardless of match, while a pure-submethod level
+//!   does not count as such an override.
+//!
+//! The E4a shadow winner only ranks candidates that already passed
+//! `method_args_match_for_invocant`, so it has no notion of either case: it answers
+//! `None` where the real resolver still returns the sole non-matching candidate.
+//! Confirmed empirically (2026-08-10 sweep, see the landed PR note) — every
+//! observed mismatch was exactly this shape (`real=Some(..) shadow=None` for a
+//! single-candidate class, e.g. `method assign-rw($a is rw)` called with a
+//! literal). Expected on the sweep and bucketed (like E1a's ledger) rather than
+//! blocking the box; unifying it is E8's job (candidates carry `level`/`stored_idx`
+//! so this exact rule becomes representable in the sequence itself).
+
+use super::*;
+use crate::type_id::TypeId;
+use std::sync::Arc;
+
+/// One candidate in a [`ResolvedSequence`]. E4a only ever constructs `User`; the
+/// accessor bit and native rows join in E4b (design decision 4).
+#[derive(Clone)]
+pub(crate) enum ResolvedCandidate {
+    /// A user-declared method, at its MRO level, in the class's stored
+    /// declaration order.
+    User { owner: TypeId, def: Arc<MethodDef> },
+}
+
+/// The shape-independent ordered candidate universe for one `(receiver chain,
+/// method name)` pair. See the module doc for what E4a does and does not yet
+/// model.
+#[derive(Clone)]
+pub(crate) struct ResolvedSequence {
+    /// The registry's `method_generation` at build time — a debug/comparison
+    /// aid for E3's future cache, not consulted by anything in E4a.
+    #[allow(dead_code)]
+    pub(crate) generation: u64,
+    pub(crate) candidates: Vec<ResolvedCandidate>,
+}
+
+impl Interpreter {
+    /// Build the ordered user-candidate sequence for `chain` (an E1 TypeId MRO,
+    /// most-derived first) and `name`: every non-private, non-submethod-shadowed
+    /// candidate at every level, in stored declaration order. Mirrors the
+    /// membership rules `resolve_method_with_owner_impl` applies per candidate
+    /// (`is_private` skip; `is_my` skip when the level is an ancestor) but not its
+    /// early-stopping MRO-walk control flow — see the module doc.
+    pub(crate) fn resolve_sequence(&mut self, chain: &[TypeId], name: Symbol) -> ResolvedSequence {
+        let generation = self.registry().method_generation;
+        let mut candidates = Vec::new();
+        for (level, owner) in chain.iter().enumerate() {
+            let is_ancestor = level > 0;
+            let Some(overloads) = self
+                .registry()
+                .user_method_overloads(owner.as_str(), name.as_str())
+            else {
+                continue;
+            };
+            for def in overloads {
+                if def.is_private || (def.is_my && is_ancestor) {
+                    continue;
+                }
+                candidates.push(ResolvedCandidate::User {
+                    owner: *owner,
+                    def: Arc::new(def),
+                });
+            }
+        }
+        ResolvedSequence {
+            generation,
+            candidates,
+        }
+    }
+
+    /// ADR-0019 E4a shadow probe (`MUTSU_VM_STATS`-gated, a no-op otherwise):
+    /// build the sequence for `invocant`/`name`, rank it with
+    /// [`Self::pick_method_winner`] against `arg_values`, and compare the winner to
+    /// `real` — the answer `resolve_method_cached`'s two resolution boundaries just
+    /// computed via the existing `resolve_method_with_owner_impl` path. Purely
+    /// observational: `real` continues to drive dispatch unchanged.
+    ///
+    /// Two care points, both required to keep this a true zero-behavior-change
+    /// probe:
+    /// - `self.dispatch_ambiguous` is saved and restored around the shadow
+    ///   ranking, since [`Self::pick_method_winner`] can set it — without the
+    ///   save/restore, a shadow-only ambiguity would silently overwrite the real
+    ///   resolution's (correct) flag, which `resolve_method_cached`'s caller reads
+    ///   immediately afterward.
+    /// - candidates whose signature carries a `where` clause are skipped
+    ///   entirely (no `method_args_match_for_invocant` call at all): a `where`
+    ///   clause is user code, and its dynamic-variable (`$*x`) writes are a real,
+    ///   deliberately-preserved side effect (see
+    ///   `Interpreter::restore_env_preserving_dynamics`) — running the same match
+    ///   twice would duplicate that side effect.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn shadow_check_resolver(
+        &mut self,
+        site: &'static str,
+        class_name: &str,
+        method: &str,
+        method_sym: Symbol,
+        arg_values: &[Value],
+        invocant: &Value,
+        real: Option<&(Symbol, MethodDef)>,
+    ) {
+        if !crate::vm::vm_stats::enabled() {
+            return;
+        }
+        let saved_ambiguous = self.dispatch_ambiguous;
+        let chain = self.dispatch_mro(invocant);
+        let seq = self.resolve_sequence(&chain, method_sym);
+        let has_where_candidate = seq.candidates.iter().any(|c| {
+            let ResolvedCandidate::User { def, .. } = c;
+            def.param_defs.iter().any(|p| p.where_constraint.is_some())
+        });
+        if has_where_candidate {
+            self.dispatch_ambiguous = saved_ambiguous;
+            return;
+        }
+        let role_bindings = self.registry().get_role_param_bindings(class_name);
+        let mro: Vec<Symbol> = chain.iter().map(|t| t.symbol()).collect();
+        let mut matched: Vec<(Symbol, MethodDef)> = Vec::new();
+        for c in &seq.candidates {
+            let ResolvedCandidate::User { owner, def } = c;
+            if self.method_args_match_for_invocant(
+                class_name,
+                def,
+                arg_values,
+                role_bindings.as_ref(),
+                Some(invocant),
+            ) {
+                matched.push((owner.symbol(), (**def).clone()));
+            }
+        }
+        let shadow = self.pick_method_winner(&mro, arg_values, Some(invocant), matched);
+        self.dispatch_ambiguous = saved_ambiguous;
+        let matched_ok = match (real, shadow.as_ref()) {
+            (None, None) => true,
+            (Some((ro, rd)), Some((so, sd))) => ro == so && Arc::ptr_eq(&rd.body, &sd.body),
+            _ => false,
+        };
+        crate::vm::vm_stats::record_resolver_shadow_check(site, matched_ok, || {
+            format!(
+                "class={class_name} method={method} real={:?} shadow={:?}",
+                real.map(|(o, _)| o.as_str()),
+                shadow.as_ref().map(|(o, _)| o.as_str()),
+            )
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn interp() -> Interpreter {
+        Interpreter::new()
+    }
+
+    #[test]
+    fn resolve_sequence_collects_candidates_in_mro_order() {
+        let mut i = interp();
+        i.run("class Base { method greet { 'base' } }\nclass Child is Base { method greet { 'child' } }")
+            .unwrap();
+        let chain = vec![TypeId::intern("Child"), TypeId::intern("Base")];
+        let seq = i.resolve_sequence(&chain, Symbol::intern("greet"));
+        let owners: Vec<&str> = seq
+            .candidates
+            .iter()
+            .map(|ResolvedCandidate::User { owner, .. }| owner.as_str())
+            .collect();
+        assert_eq!(owners, vec!["Child", "Base"]);
+    }
+
+    #[test]
+    fn resolve_sequence_skips_a_submethod_on_an_ancestor_level() {
+        let mut i = interp();
+        i.run("class Base { submethod only-base { } }\nclass Child is Base { }")
+            .unwrap();
+        let chain = vec![TypeId::intern("Child"), TypeId::intern("Base")];
+        let seq = i.resolve_sequence(&chain, Symbol::intern("only-base"));
+        assert!(
+            seq.candidates.is_empty(),
+            "a submethod on an ancestor level must not appear in a descendant's sequence"
+        );
+    }
+
+    #[test]
+    fn resolve_sequence_finds_a_submethod_at_its_own_level() {
+        let mut i = interp();
+        i.run("class Base { submethod only-base { } }\nclass Child is Base { }")
+            .unwrap();
+        let chain = vec![TypeId::intern("Base")];
+        let seq = i.resolve_sequence(&chain, Symbol::intern("only-base"));
+        assert_eq!(seq.candidates.len(), 1);
+    }
+
+    #[test]
+    fn resolve_sequence_is_empty_for_an_unknown_method() {
+        let mut i = interp();
+        i.run("class Base { }").unwrap();
+        let chain = vec![TypeId::intern("Base")];
+        let seq = i.resolve_sequence(&chain, Symbol::intern("nope"));
+        assert!(seq.candidates.is_empty());
+    }
+}

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -195,6 +195,17 @@ impl Interpreter {
                 self,
                 resolve_method_with_owner_invocant(cn, method, args, target)
             );
+            // ADR-0019 E4a shadow probe (zero behavior change): see
+            // `todo/deep/adr0019-e2-e4-resolver-core.md`.
+            self.shadow_check_resolver(
+                "resolve_method_cached:multi",
+                cn,
+                method,
+                method_sym,
+                args,
+                target,
+                resolved.as_ref(),
+            );
             let resolved_arc = resolved.map(|(o, d)| (o, std::sync::Arc::new(d)));
             if !self.dispatch_ambiguous {
                 self.multi_resolve_cache.insert(mkey, resolved_arc.clone());
@@ -202,11 +213,22 @@ impl Interpreter {
             return resolved_arc;
         }
         // 4. Resolve fresh; cache the result when it is non-multi.
-        let resolved_arc = loan_env!(
+        let resolved = loan_env!(
             self,
             resolve_method_with_owner_invocant(cn, method, args, target)
-        )
-        .map(|(o, d)| (o, std::sync::Arc::new(d)));
+        );
+        // ADR-0019 E4a shadow probe (zero behavior change): see
+        // `todo/deep/adr0019-e2-e4-resolver-core.md`.
+        self.shadow_check_resolver(
+            "resolve_method_cached:fresh",
+            cn,
+            method,
+            method_sym,
+            args,
+            target,
+            resolved.as_ref(),
+        );
+        let resolved_arc = resolved.map(|(o, d)| (o, std::sync::Arc::new(d)));
         if resolved_arc.as_ref().is_none_or(|(_, def)| !def.is_multi) {
             self.method_resolve_cache
                 .insert((class_sym, method_sym), resolved_arc.clone());

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -397,6 +397,46 @@ pub(crate) fn record_native_call_recognition(site: &str, owner: &str, name: &str
     }
 }
 
+// ADR-0019 Phase E box E4a: shadow comparison between
+// `resolution_sequence::resolve_sequence`'s user-candidate winner and the existing
+// `resolve_method_with_owner_impl` answer, at the two `resolve_method_cached`
+// resolution boundaries (multi-cache miss and fresh resolve).
+// `RESOLVER_SHADOW_CHECKS`/`_MISMATCHES` are the totals; `resolver_shadow_mismatch_by_site`
+// breaks mismatches down by `"<site> [class=... method=... real=... shadow=...]"` for
+// the E4a PR's accepted-mismatch ledger — the sequence builder does not yet model
+// `resolve_method_with_owner_impl`'s early-stopping rule that a non-multi method
+// resolves by name alone, independent of whether the call's arguments actually bind
+// it (see `runtime::resolution_sequence`'s module doc and
+// `todo/deep/adr0019-e2-e4-resolver-core.md`). Nothing reads these counters to make a
+// dispatch decision: shadow-only, zero behavior change.
+static RESOLVER_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static RESOLVER_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn resolver_shadow_mismatch_by_site() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_SITE: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_SITE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one E4a shadow comparison at `site`. `detail` is only evaluated on a
+/// mismatch, mirroring [`record_owner_shadow_check`].
+#[inline]
+pub(crate) fn record_resolver_shadow_check(
+    site: &str,
+    matched: bool,
+    detail: impl FnOnce() -> String,
+) {
+    if !enabled() {
+        return;
+    }
+    RESOLVER_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        RESOLVER_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = resolver_shadow_mismatch_by_site().lock() {
+            *map.entry(format!("{site} [{}]", detail())).or_insert(0) += 1;
+        }
+    }
+}
+
 /// Whether instrumentation is active. Resolved once from the environment so the
 /// hot path is a single cached boolean load when the feature is off.
 #[inline]
@@ -704,6 +744,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e2a native_call_unmodeled by (owner x name [site]) (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let resolver_shadow_checks = RESOLVER_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let resolver_shadow_mismatches = RESOLVER_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-e4a: resolver_shadow_checks={resolver_shadow_checks} resolver_shadow_mismatches={resolver_shadow_mismatches}"
+    );
+    if let Ok(map) = resolver_shadow_mismatch_by_site().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-e4a resolver-shadow mismatches by site (top {}): {}",
             top.len(),
             top.join(" ")
         );


### PR DESCRIPTION
## Summary
- ADR-0019 Phase E box **E4a**: build `ResolvedSequence`/`resolve_sequence`, walking the E1 `TypeId` receiver chain to collect user-declared method candidates per level into the shape-independent candidate universe the resolver design (`todo/deep/adr0019-e2-e4-resolver-core.md`) calls for.
- Extract `resolve_method_with_owner_impl`'s winner-picking tie-break ladder verbatim into `pick_method_winner` (pure code-motion refactor, zero behavior change) so the shadow sequence ranks with the exact same rules as the real resolver.
- Add `shadow_check_resolver` (`MUTSU_VM_STATS`-gated) comparing the shadow winner against the real resolver at `resolve_method_cached`'s two resolution boundaries under new `resolver_shadow_checks`/`resolver_shadow_mismatches` counters. Two guards keep it a true zero-behavior-change probe: `dispatch_ambiguous` is saved/restored around the shadow ranking, and candidates with a `where`-clause parameter are skipped (avoids duplicating a real side effect).

## Verification
- `MUTSU_VM_STATS=1` sweep over full `t/` (2996 files, 12396 shadow checks) + whitelisted `roast/{S12,S14,S32}-*` (382 files, 12767 checks): **3 mismatches total (0.012%)**, all one explained bucket -- a non-multi method resolves by name alone even when its signature doesn't bind the call (`method assign-rw($a is rw)` called with a literal; a role-typed param called with the wrong type). This is the E8-deferred early-stopping rule documented in `resolution_sequence.rs`'s module doc, not a new finding -- following the precedent E1a set of landing with an explained-mismatch ledger.
- `make test` (2996 files / 28149 tests): PASS
- 4 new Rust unit tests for `resolve_sequence` (MRO order, submethod non-inheritance, unknown method)
- `cargo clippy -- -D warnings` / `cargo fmt`: clean

## Test plan
- [x] `cargo build`
- [x] `cargo test --lib resolution_sequence`
- [x] `make test`
- [x] `MUTSU_VM_STATS=1` sweep over `t/` + roast S12/S14/S32
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)