### PR TITLE
refactor(adr0019): E2b -- close Str/Hash/Int native-row gap, generalize 7 more Any rows

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1921,6 +1921,37 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     `list_dynamic_is_not_recognized` tests. `cargo test --lib` (734 tests) and a
     targeted `prove` over all `t/*array*.t`/`t/*list*.t` (214 files/2272 tests) both
     green.
+    **Progress 2026-08-10** (fifth slice): closed the `Str`/`Hash`/`Int` gap named
+    above, plus generalized seven more universal pseudo-methods
+    (`self`/`clone`/`WHERE`/`WHICH`/`sink`/`item`/`serial`) to `Any`-level rows
+    alongside the existing `so`/`not`/`defined`/`DEFINITE` ones -- found by reading
+    every match arm in `dispatch_core_coerce.rs`/`dispatch_core_math.rs` rather than
+    inferring from the sweep breakdown alone, since each has a receiver-type-agnostic
+    `_ => ...` fallback and therefore covers every owner at once, not just the three
+    this slice targeted. The `Str`/`Hash`/`Int`-specific additions (23/12/26 rows)
+    came from reading `dispatch_core_unicode.rs` (the `uniprop`/`ord`/`uniname`/
+    `uninames`/`unival`/`univals`/`chrs`/`bytes` cluster) and `dispatch_core_numeric.rs`
+    (the `rand`/`elems`/`lsb`/`msb` cluster, tried for every receiver by name only --
+    not gated on a numeric `ValueView`, the same reason `Int` recognizes `flip`/`uc`
+    via `target.to_string_value()`). `Str.sprintf`'s recognition is receiver-content-
+    dependent (needs exactly one `%`-directive), so its inverse-probe test uses a
+    dedicated format-string sample instead of the generic `"abc"` one. A fresh
+    `t/`-wide sweep confirmed `native_call_unmodeled` dropped from 4413 (this
+    session's file set; 3001 files, close to the fourth slice's 4377 over a
+    slightly different set) to 2823 (cumulative -92.5% from the original ~37904);
+    `Str`/`Hash`/`Int` disappeared entirely from the top-40 breakdown. Remaining top
+    pairs are now `RakuAST::StatementList`/`RakuAST::Statement::Expression`
+    (`gist`/`statements`/`expression`, ~141/31/21), exception types (`X::AdHoc`,
+    `CX::Warn`, `X::TypeCheck::Assignment`), `Failure` (`defined`/`exception`/`sink`,
+    ~45/30/18 -- `sink` persisting despite the new `Any` row means `Failure`'s
+    coverage-check chain walk is not finding it for this specific site, worth a
+    dedicated look next slice), `Buf`/`Buf[uint8]`/`utf8` (`list`/`elems`/`decode`/
+    `values`/`raku`/`gist`, ~20-45 each), `Set`/`SetHash` (`keys`/`elems`/`gist`/
+    `raku`, ~15-36 each), and `Match x Stringy`/`Anyxgist`/`Anyxraku`/`ProfiledGxraku`/
+    `Nilxraku`/`Backtracexlist`/`VersionxStr`/`Junctionxgist`/`DatexStr`/`Seqxis-lazy`/
+    `Signaturexgist` (14-50 each). New `any_second_batch_universal_rows_are_backed_by_the_cascade`
+    and `fifth_slice_extra_rows_are_backed_by_the_cascade` tests. `cargo test --lib`
+    (736 tests) and `make test` (3001 files/28167 tests) both green.
 - [ ] **E3 — Add the generation-keyed resolved-call cache.** Key by receiver TypeId, method symbol,
   call shape, and method generation; cache the ordered candidate sequence, not a second resolver.
   **Design 2026-08-10** (same doc): lands after E4b. Key `(TypeId, Symbol, CallShape)` where

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -455,4 +455,89 @@ mod tests {
         assert_eq!(native_method_arities(&list, "dynamic"), 0);
         assert_eq!(native_method_row("List", "dynamic").0, NativeArityMask::N);
     }
+
+    /// ADR-0019 E2b: `Any` gained seven more universal pseudo-methods
+    /// (`self`/`clone`/`WHERE`/`WHICH`/`sink`/`item`/`serial`) alongside the
+    /// existing `so`/`not`/`defined`/`DEFINITE` rows -- each has a receiver-
+    /// type-agnostic `_ => ...` fallback arm in `dispatch_core_coerce.rs` /
+    /// `dispatch_core_math.rs` (confirmed by reading every arm, 2026-08-10),
+    /// so one row per name at `Any` is correct and complete once the coverage
+    /// check walks the MRO chain (`Interpreter::record_native_row_coverage`),
+    /// same reasoning as `so`/`not`/`defined`. Verified against three
+    /// structurally different receivers here, the same discipline as
+    /// `any_mu_universal_rows_are_backed_by_the_cascade_for_multiple_receiver_types`.
+    #[test]
+    fn any_second_batch_universal_rows_are_backed_by_the_cascade() {
+        let str_sample = builtin_sample_value("Str").unwrap();
+        let int_sample = builtin_sample_value("Int").unwrap();
+        let hash_sample = builtin_sample_value("Hash").unwrap();
+        for name in ["self", "clone", "WHERE", "WHICH", "sink", "item", "serial"] {
+            let (arity, _flags) = native_method_row("Any", name);
+            assert!(
+                arity.contains(NativeArityMask::A0),
+                "{name} row should claim A0"
+            );
+            for sample in [&str_sample, &int_sample, &hash_sample] {
+                assert!(
+                    native_method_arities(sample, name) & 1 != 0,
+                    "{name} should be recognized at arity 0 for {sample:?}"
+                );
+            }
+        }
+    }
+
+    /// ADR-0019 E2b: `Str`/`Hash`/`Int` extra rows (fifth slice, 2026-08-10),
+    /// hand-probed against `builtin_sample_value` samples -- see the table
+    /// comment in `native_method_row_table.rs` for how each name was found
+    /// (mostly the Unicode-method cluster in `dispatch_core_unicode.rs` for
+    /// `Str`, and the shared numeric-method cluster in
+    /// `dispatch_core_numeric.rs` for `Int`, both read directly rather than
+    /// inferred from the coverage sweep alone).
+    #[test]
+    fn fifth_slice_extra_rows_are_backed_by_the_cascade() {
+        let str_sample = builtin_sample_value("Str").unwrap();
+        let hash_sample = builtin_sample_value("Hash").unwrap();
+        let int_sample = builtin_sample_value("Int").unwrap();
+        // `sprintf` recognition depends on the receiver's own content (it
+        // needs exactly one `%`-directive), so the generic "abc" sample does
+        // not exercise it -- use a format-string-shaped sample just for it.
+        let sprintf_sample = Value::str_from("got %d");
+        for (owner, sample) in [
+            ("Str", &str_sample),
+            ("Hash", &hash_sample),
+            ("Int", &int_sample),
+        ] {
+            for &(row_owner, name, arity, flags) in super::super::native_method_row_table::RAW_ROWS
+            {
+                if row_owner != owner {
+                    continue;
+                }
+                let flags = NativeRowFlags(flags);
+                if flags.contains(NativeRowFlags::SPECIAL)
+                    || flags.contains(NativeRowFlags::MUTATES_RECEIVER)
+                {
+                    continue;
+                }
+                let probe_sample = if owner == "Str" && name == "sprintf" {
+                    &sprintf_sample
+                } else {
+                    sample
+                };
+                let observed = native_method_arities(probe_sample, name);
+                let mask = NativeArityMask(arity);
+                for (bit, m) in [
+                    (0u8, NativeArityMask::A0),
+                    (1u8, NativeArityMask::A1),
+                    (2u8, NativeArityMask::A2),
+                ] {
+                    if mask.contains(m) {
+                        assert!(
+                            observed & (1 << bit) != 0,
+                            "{owner}x{name} row claims arity {bit} but the cascade does not recognize it"
+                        );
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -570,4 +570,126 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Match", "gist", 1, 0),
     ("Match", "raku", 1, 0),
     ("Match", "fmt", 7, 0),
+    // ADR-0019 E2b (fifth slice, 2026-08-10): seven more `Any` universal
+    // pseudo-methods, alongside the existing `so`/`not`/`defined`/`DEFINITE`
+    // rows above -- `self`/`clone`/`WHERE`/`WHICH`/`sink`/`item`/`serial`
+    // each have a receiver-type-agnostic `_ => ...` fallback arm in
+    // `dispatch_core_coerce.rs` (`self`/`WHERE`/`WHICH`/`serial`/`clone`) or
+    // `dispatch_core_math.rs` (`sink`/`item`), found by reading every match
+    // arm in those two files rather than guessing from the sweep breakdown
+    // alone. Verified by
+    // `any_second_batch_universal_rows_are_backed_by_the_cascade` in
+    // `native_method_row.rs`.
+    ("Any", "self", 1, 0),
+    ("Any", "clone", 1, 0),
+    ("Any", "WHERE", 1, 0),
+    ("Any", "WHICH", 1, 0),
+    ("Any", "sink", 1, 0),
+    ("Any", "item", 1, 0),
+    ("Any", "serial", 1, 0),
+    // ADR-0019 E2b (fifth slice): `Str` extra rows, hand-probed against a
+    // real `Value::str_from("abc")` sample -- the Unicode-method cluster
+    // (`ord`/`uniname`/`uninames`/`unival`/`univals`/`chrs`/`bytes`) lives in
+    // `dispatch_core_unicode.rs` alongside the already-modeled `uniprops`;
+    // `uniprop` (singular; distinct from the plural `uniprops` row above) is
+    // in the same file. `AST` is `Str`-only (`methods_0arg/mod.rs`, parses
+    // the string as Raku source, ADR-0010). `indent` is 1-arg
+    // (`methods_narg/dispatch_1arg.rs`). `sprintf`'s recognition depends on
+    // the receiver's own content (needs exactly one `%`-directive), not just
+    // arg shape -- see the dedicated probe sample in
+    // `fifth_slice_extra_rows_are_backed_by_the_cascade`. The remaining
+    // names (`list`/`UInt`/`FatRat`/`tclc`/`Range`/`Complex`/`Version`/
+    // `Real`/`Date`/`DateTime`/`reverse`/`byte`/`perl`) are ordinary coercion
+    // arms that also happen to fire for a plain `Str` receiver. Verified by
+    // `fifth_slice_extra_rows_are_backed_by_the_cascade` in
+    // `native_method_row.rs`.
+    ("Str", "uniprop", 3, 0),
+    ("Str", "AST", 1, 0),
+    ("Str", "indent", 2, 0),
+    ("Str", "list", 1, 0),
+    ("Str", "UInt", 1, 0),
+    ("Str", "FatRat", 3, 0),
+    ("Str", "sprintf", 2, 0),
+    ("Str", "ord", 1, 0),
+    ("Str", "uniname", 1, 0),
+    ("Str", "uninames", 1, 0),
+    ("Str", "unival", 1, 0),
+    ("Str", "univals", 1, 0),
+    ("Str", "chrs", 1, 0),
+    ("Str", "bytes", 1, 0),
+    ("Str", "tclc", 1, 0),
+    ("Str", "Range", 1, 0),
+    ("Str", "Complex", 1, 0),
+    ("Str", "Version", 1, 0),
+    ("Str", "Real", 1, 0),
+    ("Str", "Date", 1, 0),
+    ("Str", "DateTime", 1, 0),
+    ("Str", "reverse", 1, 0),
+    ("Str", "byte", 1, 0),
+    ("Str", "perl", 1, 0),
+    // ADR-0019 E2b (fifth slice): `Hash` extra rows, hand-probed against a
+    // real `Value::hash(...)` sample. `pick`/`roll` (1-arg count form, plus
+    // a bare 0-arg single-pick) live in `dispatch_1arg.rs`/
+    // `dispatch_core_range.rs`. `EXISTS-KEY`/`AT-KEY`/`AT-POS`/
+    // `EXISTS-POS` are the postcircumfix-subscript protocol methods
+    // (`dispatch_1arg.rs`). `List`/`Array`/`invert`/`flat`/`dynamic`/`perl`
+    // are ordinary coercion/collection arms that also fire for a Hash
+    // receiver. Verified by
+    // `fifth_slice_extra_rows_are_backed_by_the_cascade` in
+    // `native_method_row.rs`.
+    ("Hash", "pick", 3, 0),
+    ("Hash", "EXISTS-KEY", 2, 0),
+    ("Hash", "AT-KEY", 2, 0),
+    ("Hash", "List", 1, 0),
+    ("Hash", "invert", 1, 0),
+    ("Hash", "flat", 7, 0),
+    ("Hash", "Array", 1, 0),
+    ("Hash", "AT-POS", 2, 0),
+    ("Hash", "EXISTS-POS", 2, 0),
+    ("Hash", "dynamic", 1, 0),
+    ("Hash", "roll", 3, 0),
+    ("Hash", "perl", 1, 0),
+    // ADR-0019 E2b (fifth slice): `Int` extra rows, hand-probed against a
+    // real `Value::int(2)` sample. `rand`/`elems`/`lsb`/`msb` live in the
+    // shared numeric-method cluster `dispatch_core_numeric.rs`, which is
+    // tried for every receiver by name only (not gated on a numeric
+    // `ValueView`) -- `elems`/`rand` end up recognized for a bare `Int` the
+    // same way `uc`/`lc`/`fc`/`tc` do for a bare `Str` (already modeled).
+    // `flip`/`uniprop`/`uc` reach an `Int` receiver the same way: their
+    // dispatch arms call `target.to_string_value()` unconditionally.
+    // `numerator`/`denominator`/`UInt`/`Real`/`Version`/`Complex`/`perl`/
+    // `reverse`/`kv`/`pairs`/`int8`/`wordcase`/`rindex`/`EXISTS-KEY`/
+    // `AT-KEY`/`EXISTS-POS`/`Array`/`Supply`/`fmt` are ordinary
+    // coercion/collection/subscript arms that also fire for a plain `Int`
+    // receiver (real Raku semantics for some of these are a separate
+    // question from whether mutsu's cascade recognizes the name -- E2b only
+    // models the latter). Verified by
+    // `fifth_slice_extra_rows_are_backed_by_the_cascade` in
+    // `native_method_row.rs`.
+    ("Int", "rand", 1, 0),
+    ("Int", "elems", 1, 0),
+    ("Int", "flip", 1, 0),
+    ("Int", "uniprop", 3, 0),
+    ("Int", "fmt", 7, 0),
+    ("Int", "EXISTS-POS", 2, 0),
+    ("Int", "Array", 1, 0),
+    ("Int", "lsb", 1, 0),
+    ("Int", "msb", 1, 0),
+    ("Int", "Supply", 1, 0),
+    ("Int", "pairs", 1, 0),
+    ("Int", "denominator", 1, 0),
+    ("Int", "numerator", 1, 0),
+    ("Int", "kv", 1, 0),
+    ("Int", "int8", 1, 0),
+    ("Int", "rindex", 2, 0),
+    ("Int", "EXISTS-KEY", 2, 0),
+    ("Int", "AT-KEY", 2, 0),
+    ("Int", "UInt", 1, 0),
+    ("Int", "wordcase", 1, 0),
+    ("Int", "uc", 1, 0),
+    ("Int", "Real", 1, 0),
+    ("Int", "Version", 1, 0),
+    ("Int", "Complex", 1, 0),
+    ("Int", "perl", 1, 0),
+    ("Int", "reverse", 1, 0),
 ];


### PR DESCRIPTION
## Summary
- Fifth ADR-0019 E2b slice: hand-probed native-method rows for the `Str`/`Hash`/`Int` gap the fourth slice's sweep identified (`uniprop`/`AST`/`indent`, `pick`/`item`/`EXISTS-KEY`/`AT-KEY`, `rand`/`elems`/`WHICH`/`clone`), sourced by reading `dispatch_core_unicode.rs` and `dispatch_core_numeric.rs` directly.
- Generalized seven more universal pseudo-methods (`self`/`clone`/`WHERE`/`WHICH`/`sink`/`item`/`serial`) to `Any`-level rows alongside the existing `so`/`not`/`defined`/`DEFINITE` ones, since each has a receiver-type-agnostic fallback arm and closes the gap for every owner at once via the coverage check's chain walk.
- A fresh `t/`-wide sweep confirms `native_call_unmodeled` dropped from 4413 to 2823 (cumulative -92.5% from the original ~37904); `Str`/`Hash`/`Int` no longer appear in the top-40 breakdown.
- Zero behavior change: this table is only read by a `MUTSU_VM_STATS`-gated shadow coverage check and `#[cfg(test)]` inverse-probe tests, never by real dispatch.

## Test plan
- [x] `cargo test --lib` (736 tests, +2 new)
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `make test` (3001 files / 28167 tests, PASS)
- [ ] CI `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)