### PR TITLE
refactor(adr0019): E2b -- fold canonical_builtin_owner into coverage check, close Buf/Set/Bag/Mix/RakuAST gaps

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1952,6 +1952,49 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     `Signaturexgist` (14-50 each). New `any_second_batch_universal_rows_are_backed_by_the_cascade`
     and `fifth_slice_extra_rows_are_backed_by_the_cascade` tests. `cargo test --lib`
     (736 tests) and `make test` (3001 files/28167 tests) both green.
+    **Progress 2026-08-10** (sixth slice): found and fixed a root-cause gap in
+    `record_native_row_coverage` itself (`receiver_class.rs`), not just missing
+    rows -- the `Buf`/`Blob`/`utf8`/`FatRat` families are folded to a single
+    dispatch owner (`Blob`, `Rat`) whose native table actually serves them
+    (`canonical_builtin_owner`, `builtin_type_methods.rs`), but raku's own
+    `.^mro` for these types does NOT include the folded owner (confirmed
+    against real `raku`: `Buf.new.^mro` is `Buf, Any, Mu`, not `Buf, Blob, Any,
+    Mu`), so `dispatch_owner_chain`'s walk correctly omits it too and could
+    never find the folded owner's rows no matter how many were added. The
+    coverage check now also tries each chain owner through
+    `canonical_builtin_owner` as a fallback lookup, closing the whole
+    `Buf`/`Buf[uint8]`/`utf8`/`Blob[uint8]` family and `RatxFatRat`-shaped gaps
+    at once (this fold fix alone dropped the counter from 2825 to 2508). Also
+    closed the `Blob` row gaps the fold then exposed
+    (`decode` was under-counted as A0-only -- its A1 arm needs a real encoding
+    name like `"utf-8"`, not the generic empty-string dummy
+    `native_method_arities` tries; `values`/`List`/the `read-*` native-endian
+    accessor family were simply never probed, `Blob` not being one of the
+    original 11 owners). Then closed two more owner families with no
+    `builtin_type_method_names` entry (same situation as `Pair`/`Seq`/`Match`):
+    `Set`/`SetHash`/`Bag`/`BagHash`/`Mix`/`MixHash` (hand-probed against real
+    `set(...)`/`SetHash.new(...)`/etc values -- `grab` on an immutable
+    `Set`/`Bag`/`Mix` IS pure-cascade-recognized, since it always errors
+    "immutable" but `Some` still counts; the mutable `SetHash`/`BagHash`/
+    `MixHash` variant's `grab` is slow-path-only, so those three deliberately
+    have no `grab` row), and `RakuAST::StatementList`/
+    `RakuAST::Statement::Expression` (hand-probed against a real `Str.AST`
+    parse tree). A fresh `t/`-wide sweep confirmed `native_call_unmodeled`
+    dropped from 2825 (this session's file set after the fifth slice's PR
+    merged) to 1900 (cumulative -95% from the original ~37904); none of
+    `Buf`/`Blob`/`utf8`/`FatRat`/`Set`/`SetHash`/`Bag`/`BagHash`/`Mix`/
+    `MixHash`/`RakuAST::StatementList` remain in the top-40 breakdown.
+    Remaining top pairs are now exception types (`X::AdHoc`/`CX::Warn`/
+    `X::TypeCheck::Assignment`, `message`/`resume`/`backtrace`/`defined`,
+    14-89 each) and `Failure` (`defined`/`exception`/`sink`/`so`/`handled`,
+    9-45 each -- `sink` still not resolving via the `Any` row from the fifth
+    slice despite this slice's fold-lookup fix, worth a dedicated look), plus
+    a long tail (`Backtrace`/`Backtrace::Frame`, `Version`, `Date`/`DateTime`,
+    `Signature`, `Range x hyper/lazy/int-bounds`, `Map x raku`, `Duration x
+    Numeric`, `Mu x defined`, `CallFrame x defined`, `RakuAST::IntLiteral x
+    value`, 9-26 each). New `setbagmix_rows_are_backed_by_the_cascade` and
+    `rakuast_statementlist_rows_are_backed_by_the_cascade` tests. `cargo test
+    --lib` (738 tests) and `make test` (3002 files/28169 tests) both green.
 - [ ] **E3 — Add the generation-keyed resolved-call cache.** Key by receiver TypeId, method symbol,
   call shape, and method generation; cache the ordered candidate sequence, not a second resolver.
   **Design 2026-08-10** (same doc): lands after E4b. Key `(TypeId, Symbol, CallShape)` where

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -456,6 +456,125 @@ mod tests {
         assert_eq!(native_method_row("List", "dynamic").0, NativeArityMask::N);
     }
 
+    /// ADR-0019 E2b (sixth slice): `Set`/`SetHash`/`Bag`/`BagHash`/`Mix`/
+    /// `MixHash` rows, hand-probed against real values constructed via the
+    /// interpreter (`set(...)`/`SetHash.new(...)`/etc.) -- none of the six
+    /// owners has a `builtin_type_method_names` entry, same situation as
+    /// `Pair`/`Seq`/`Match`. `grab` (weighted removal) is deliberately absent
+    /// from `Set`/`SetHash`: those have no weights, and the probe confirmed
+    /// the cascade does not recognize it there while it does for the other
+    /// four.
+    #[test]
+    fn setbagmix_rows_are_backed_by_the_cascade() {
+        let mut interp = crate::runtime::Interpreter::new();
+        interp
+            .run("my $set = set(1,2,3); my $sethash = SetHash.new(1,2,3); my $bag = bag(1,1,2); my $baghash = BagHash.new(1,1,2); my $mix = mix(1,1,2); my $mixhash = MixHash.new(1,1,2);")
+            .unwrap();
+        for (var, owner) in [
+            ("set", "Set"),
+            ("sethash", "SetHash"),
+            ("bag", "Bag"),
+            ("baghash", "BagHash"),
+            ("mix", "Mix"),
+            ("mixhash", "MixHash"),
+        ] {
+            let sample = interp.env().get(var).cloned().unwrap();
+            for &(row_owner, name, arity, flags) in super::super::native_method_row_table::RAW_ROWS
+            {
+                if row_owner != owner {
+                    continue;
+                }
+                let flags = NativeRowFlags(flags);
+                if flags.contains(NativeRowFlags::SPECIAL)
+                    || flags.contains(NativeRowFlags::MUTATES_RECEIVER)
+                {
+                    continue;
+                }
+                let observed = native_method_arities(&sample, name);
+                let mask = NativeArityMask(arity);
+                for (bit, m) in [
+                    (0u8, NativeArityMask::A0),
+                    (1u8, NativeArityMask::A1),
+                    (2u8, NativeArityMask::A2),
+                ] {
+                    if mask.contains(m) {
+                        assert!(
+                            observed & (1 << bit) != 0,
+                            "{owner}x{name} row claims arity {bit} but the cascade does not recognize it"
+                        );
+                    }
+                }
+            }
+        }
+        // Immutable `Set.grab` IS recognized by the pure cascade (it always
+        // errors "immutable", but `Some` still counts) -- the mutable
+        // `SetHash` variant is not, same as `BagHash`/`MixHash` above.
+        assert!(
+            native_method_row("Set", "grab")
+                .0
+                .contains(NativeArityMask::A0)
+        );
+        assert_eq!(native_method_row("SetHash", "grab").0, NativeArityMask::N);
+        assert_ne!(
+            native_method_arities(&interp.env().get("set").cloned().unwrap(), "grab"),
+            0
+        );
+        assert_eq!(
+            native_method_arities(&interp.env().get("sethash").cloned().unwrap(), "grab"),
+            0
+        );
+    }
+
+    /// ADR-0019 E2b (sixth slice): `RakuAST::StatementList`/
+    /// `RakuAST::Statement::Expression` rows, hand-probed against a real
+    /// `Str.AST` parse tree (`'my $x = 1 + 2;'.AST`) -- neither owner has a
+    /// `builtin_type_method_names` entry. `RakuAST::Statement::Expression`'s
+    /// `expression` field accessor comes from the generic
+    /// `rakuast::node_accessor` dispatch (`methods_0arg/mod.rs`), reached the
+    /// same way for every RakuAST node class, not a `StatementList`-specific
+    /// mechanism.
+    #[test]
+    fn rakuast_statementlist_rows_are_backed_by_the_cascade() {
+        let mut interp = crate::runtime::Interpreter::new();
+        interp.run("my $ast = 'my $x = 1 + 2;'.AST;").unwrap();
+        let ast = interp.env().get("ast").cloned().unwrap();
+        for &(row_owner, name, arity, flags) in super::super::native_method_row_table::RAW_ROWS {
+            if row_owner != "RakuAST::StatementList" {
+                continue;
+            }
+            let flags = NativeRowFlags(flags);
+            if flags.contains(NativeRowFlags::SPECIAL)
+                || flags.contains(NativeRowFlags::MUTATES_RECEIVER)
+            {
+                continue;
+            }
+            let observed = native_method_arities(&ast, name);
+            let mask = NativeArityMask(arity);
+            for (bit, m) in [
+                (0u8, NativeArityMask::A0),
+                (1u8, NativeArityMask::A1),
+                (2u8, NativeArityMask::A2),
+            ] {
+                if mask.contains(m) {
+                    assert!(
+                        observed & (1 << bit) != 0,
+                        "RakuAST::StatementList x {name} row claims arity {bit} but the cascade does not recognize it"
+                    );
+                }
+            }
+        }
+        interp
+            .run("my @stmts = $ast.statements; my $inner = @stmts[0];")
+            .unwrap();
+        let inner = interp.env().get("inner").cloned().unwrap();
+        assert_ne!(native_method_arities(&inner, "expression"), 0);
+        assert!(
+            native_method_row("RakuAST::Statement::Expression", "expression")
+                .0
+                .contains(NativeArityMask::A0)
+        );
+    }
+
     /// ADR-0019 E2b: `Any` gained seven more universal pseudo-methods
     /// (`self`/`clone`/`WHERE`/`WHICH`/`sink`/`item`/`serial`) alongside the
     /// existing `so`/`not`/`defined`/`DEFINITE` rows -- each has a receiver-

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -371,7 +371,13 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Blob", "reallocate", 8, 4),
     ("Blob", "subbuf", 6, 0),
     ("Blob", "subbuf-rw", 4, 0),
-    ("Blob", "decode", 1, 0),
+    // `decode` is recognized at both A0 (default encoding) and A1 (explicit
+    // encoding name, `dispatch_1arg.rs`) -- the A1 arm needs a real encoding
+    // name (`"utf-8"`), not the generic empty-string dummy
+    // `native_method_arities` tries, so it was originally under-counted as
+    // A0-only. Confirmed with a direct `native_method_1arg` probe,
+    // 2026-08-10.
+    ("Blob", "decode", 3, 0),
     ("Blob", "elems", 1, 0),
     ("Blob", "bytes", 1, 0),
     ("Blob", "of", 1, 0),
@@ -383,6 +389,21 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Blob", "Str", 3, 0),
     ("Blob", "gist", 1, 0),
     ("Blob", "raku", 1, 0),
+    // ADR-0019 E2b (sixth slice, 2026-08-10): `Blob`/`Buf`-family extra rows
+    // found once the `record_native_row_coverage` `canonical_builtin_owner`
+    // fold (`receiver_class.rs`) started routing `Buf`/`utf8`/`Buf[uint8]`
+    // receivers to this table's `Blob` rows -- `values`/`List`/the
+    // `read-*`/`write-*` native-endian accessor family
+    // (`dispatch_1arg.rs`) were never probed by the original 11-owner E2a
+    // generation pass (`Blob` was not one of the 11). `read-*` is A1
+    // (offset) or A2 (offset, endianness), never A0.
+    ("Blob", "values", 1, 0),
+    ("Blob", "List", 1, 0),
+    ("Blob", "read-uint8", 6, 0),
+    ("Blob", "read-int8", 6, 0),
+    ("Blob", "read-uint16", 6, 0),
+    ("Blob", "read-int16", 6, 0),
+    ("Blob", "read-uint32", 6, 0),
     // ADR-0019 E2b: universal Any/Mu methods, added by hand (not probed via
     // `builtin_sample_value`, which has no representative sample for an
     // abstract owner) after `dispatch_owner_coverage`'s 2026-08-10 sweep
@@ -692,4 +713,149 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Int", "Complex", 1, 0),
     ("Int", "perl", 1, 0),
     ("Int", "reverse", 1, 0),
+    // ADR-0019 E2b (sixth slice, 2026-08-10): `Set`/`SetHash`/`Bag`/
+    // `BagHash`/`Mix`/`MixHash` rows, hand-probed against real values built
+    // via `set(...)`/`SetHash.new(...)`/etc through the interpreter --
+    // none of the six owners has a `builtin_type_method_names` entry, same
+    // situation as `Pair`/`Seq`/`Match`. `grab` (weighted removal) is
+    // deliberately absent from `Set`/`SetHash`: those carry no weights, and
+    // the cascade genuinely does not recognize it there (confirmed by
+    // `setbagmix_rows_are_backed_by_the_cascade` in `native_method_row.rs`,
+    // which also probes the `Set`/`SetHash` omission directly).
+    ("Set", "keys", 1, 0),
+    ("Set", "values", 1, 0),
+    ("Set", "kv", 1, 0),
+    ("Set", "pairs", 1, 0),
+    ("Set", "elems", 1, 0),
+    ("Set", "gist", 1, 0),
+    ("Set", "raku", 1, 0),
+    ("Set", "Str", 3, 0),
+    ("Set", "Bool", 1, 0),
+    ("Set", "list", 1, 0),
+    ("Set", "List", 1, 0),
+    ("Set", "Array", 1, 0),
+    ("Set", "total", 1, 0),
+    // Immutable `Set`'s `grab` IS recognized by the pure cascade
+    // (`dispatch_core_range.rs`'s `ValueView::Set(_, false)` arm) -- it
+    // always errors ("Cannot call .grab on an immutable Set"), but `Some`
+    // still counts as recognized. The mutable `SetHash` variant
+    // (`Set(_, true)`) falls through to the slow path instead (same as
+    // `BagHash`/`MixHash` above), so `SetHash` deliberately has no `grab`
+    // row here (defaults to `N`/`SPECIAL`).
+    ("Set", "grab", 3, 0),
+    ("Set", "pick", 3, 0),
+    ("Set", "roll", 3, 0),
+    ("Set", "WHICH", 1, 0),
+    ("SetHash", "keys", 1, 0),
+    ("SetHash", "values", 1, 0),
+    ("SetHash", "kv", 1, 0),
+    ("SetHash", "pairs", 1, 0),
+    ("SetHash", "elems", 1, 0),
+    ("SetHash", "gist", 1, 0),
+    ("SetHash", "raku", 1, 0),
+    ("SetHash", "Str", 3, 0),
+    ("SetHash", "Bool", 1, 0),
+    ("SetHash", "list", 1, 0),
+    ("SetHash", "List", 1, 0),
+    ("SetHash", "Array", 1, 0),
+    ("SetHash", "total", 1, 0),
+    ("SetHash", "pick", 3, 0),
+    ("SetHash", "roll", 3, 0),
+    ("SetHash", "WHICH", 1, 0),
+    ("Bag", "keys", 1, 0),
+    ("Bag", "values", 1, 0),
+    ("Bag", "kv", 1, 0),
+    ("Bag", "pairs", 1, 0),
+    ("Bag", "elems", 1, 0),
+    ("Bag", "gist", 1, 0),
+    ("Bag", "raku", 1, 0),
+    ("Bag", "Str", 3, 0),
+    ("Bag", "Bool", 1, 0),
+    ("Bag", "list", 1, 0),
+    ("Bag", "List", 1, 0),
+    ("Bag", "Array", 1, 0),
+    ("Bag", "total", 1, 0),
+    ("Bag", "grab", 3, 0),
+    ("Bag", "pick", 3, 0),
+    ("Bag", "roll", 3, 0),
+    ("Bag", "WHICH", 1, 0),
+    ("BagHash", "keys", 1, 0),
+    ("BagHash", "values", 1, 0),
+    ("BagHash", "kv", 1, 0),
+    ("BagHash", "pairs", 1, 0),
+    ("BagHash", "elems", 1, 0),
+    ("BagHash", "gist", 1, 0),
+    ("BagHash", "raku", 1, 0),
+    ("BagHash", "Str", 3, 0),
+    ("BagHash", "Bool", 1, 0),
+    ("BagHash", "list", 1, 0),
+    ("BagHash", "List", 1, 0),
+    ("BagHash", "Array", 1, 0),
+    ("BagHash", "total", 1, 0),
+    // `grab` on the *mutable* `BagHash`/`MixHash` variant is served by the
+    // `&mut self` slow path (`methods_mut_dispatch.rs`), not the pure
+    // arity cascade -- unlike the immutable `Bag`/`Mix`, whose `grab` the
+    // cascade DOES recognize (always erroring "immutable", still `Some`).
+    // Confirmed by probe: `native_method_arities` returns 0 for a `BagHash`
+    // sample. SPECIAL, not omitted, to keep the choice explicit.
+    ("BagHash", "grab", 8, 4),
+    ("BagHash", "pick", 3, 0),
+    ("BagHash", "roll", 3, 0),
+    ("BagHash", "WHICH", 1, 0),
+    ("Mix", "keys", 1, 0),
+    ("Mix", "values", 1, 0),
+    ("Mix", "kv", 1, 0),
+    ("Mix", "pairs", 1, 0),
+    ("Mix", "elems", 1, 0),
+    ("Mix", "gist", 1, 0),
+    ("Mix", "raku", 1, 0),
+    ("Mix", "Str", 3, 0),
+    ("Mix", "Bool", 1, 0),
+    ("Mix", "list", 1, 0),
+    ("Mix", "List", 1, 0),
+    ("Mix", "Array", 1, 0),
+    ("Mix", "total", 1, 0),
+    ("Mix", "grab", 3, 0),
+    ("Mix", "pick", 3, 0),
+    ("Mix", "roll", 3, 0),
+    ("Mix", "WHICH", 1, 0),
+    ("MixHash", "keys", 1, 0),
+    ("MixHash", "values", 1, 0),
+    ("MixHash", "kv", 1, 0),
+    ("MixHash", "pairs", 1, 0),
+    ("MixHash", "elems", 1, 0),
+    ("MixHash", "gist", 1, 0),
+    ("MixHash", "raku", 1, 0),
+    ("MixHash", "Str", 3, 0),
+    ("MixHash", "Bool", 1, 0),
+    ("MixHash", "list", 1, 0),
+    ("MixHash", "List", 1, 0),
+    ("MixHash", "Array", 1, 0),
+    ("MixHash", "total", 1, 0),
+    // Same as `BagHash`'s `grab` above: the mutable `MixHash` variant's
+    // `grab` is slow-path-only, not pure-cascade-recognized.
+    ("MixHash", "grab", 8, 4),
+    ("MixHash", "pick", 3, 0),
+    ("MixHash", "roll", 3, 0),
+    ("MixHash", "WHICH", 1, 0),
+    // ADR-0019 E2b (sixth slice): `RakuAST::StatementList` rows, hand-probed
+    // against a real `Str.AST` parse tree (`'my $x = 1 + 2;'.AST`) -- no
+    // `builtin_type_method_names` entry either. `RakuAST::Statement::Expression`'s
+    // `expression` field accessor reaches the generic `rakuast::node_accessor`
+    // dispatch (`methods_0arg/mod.rs`), the same mechanism every RakuAST node
+    // class uses for its own fields, not something `StatementList`-specific.
+    // Verified by `rakuast_statementlist_rows_are_backed_by_the_cascade` in
+    // `native_method_row.rs`.
+    ("RakuAST::StatementList", "gist", 1, 0),
+    ("RakuAST::StatementList", "statements", 1, 0),
+    ("RakuAST::StatementList", "add-statement", 2, 0),
+    ("RakuAST::StatementList", "raku", 1, 0),
+    ("RakuAST::StatementList", "Str", 3, 0),
+    ("RakuAST::StatementList", "WHICH", 1, 0),
+    ("RakuAST::StatementList", "list", 1, 0),
+    ("RakuAST::StatementList", "List", 1, 0),
+    ("RakuAST::StatementList", "elems", 1, 0),
+    ("RakuAST::StatementList", "Bool", 1, 0),
+    ("RakuAST::StatementList", "flat", 7, 0),
+    ("RakuAST::Statement::Expression", "expression", 1, 0),
 ];

--- a/src/runtime/receiver_class.rs
+++ b/src/runtime/receiver_class.rs
@@ -382,6 +382,21 @@ impl Interpreter {
     /// flat point lookup at the concrete owner alone over-counted every
     /// inherited-and-recognized method as unmodeled even though a row for it
     /// already existed further up the chain.
+    ///
+    /// Each chain element is also tried through
+    /// [`canonical_builtin_owner`](crate::builtins::builtin_type_methods::canonical_builtin_owner),
+    /// which folds a handful of builtin families to the single owner whose
+    /// native table actually serves them (`Sub`/`Method`/`Block`/`Routine`/
+    /// `Code` -> `Code`; the whole `Buf`/`Blob`/`utf8`/... family -> `Blob`;
+    /// `FatRat` -> `Rat`). raku's own `.^mro` for these types does NOT
+    /// include the folded owner (`Buf.new.^mro` is `Buf, Any, Mu`, not
+    /// `Buf, Blob, Any, Mu`) -- confirmed against real `raku`, 2026-08-10 --
+    /// so [`Self::dispatch_owner_chain`] correctly omits it too, and a plain
+    /// chain walk can never find the folded owner's rows. The row catalog
+    /// itself is generated keyed by this same folded owner (via
+    /// [`super::builtin_type_methods::builtin_method_entries`]), so without
+    /// this second lookup every Buf/Blob/FatRat-family method reads as
+    /// permanently unmodeled no matter how many rows are added.
     pub(crate) fn record_native_row_coverage(
         &mut self,
         site: &str,
@@ -395,9 +410,19 @@ impl Interpreter {
         let chain = self.dispatch_owner_chain(target);
         let mask = crate::builtins::native_method_row::NativeArityMask::for_arity(arity);
         let covered = chain.iter().any(|owner| {
-            crate::builtins::native_method_row::native_method_row(owner.as_str(), name)
+            let owner = owner.as_str();
+            if crate::builtins::native_method_row::native_method_row(owner, name)
                 .0
                 .contains(mask)
+            {
+                return true;
+            }
+            let folded = crate::builtins::builtin_type_methods::canonical_builtin_owner(owner);
+            !folded.is_empty()
+                && folded != owner
+                && crate::builtins::native_method_row::native_method_row(folded, name)
+                    .0
+                    .contains(mask)
         });
         let owner = chain
             .first()


### PR DESCRIPTION
## Summary
- Sixth ADR-0019 E2b slice, and a root-cause fix rather than just more rows: the `Buf`/`Blob`/`utf8`/`FatRat` families fold to a single dispatch owner (`Blob`, `Rat`) whose native table actually serves them (`canonical_builtin_owner`), but raku's own `.^mro` for these types does NOT include the folded owner (confirmed against real `raku`: `Buf.new.^mro` is `Buf, Any, Mu`, not `Buf, Blob, Any, Mu`) -- so the coverage check's chain walk could never find the folded owner's rows no matter how many were added. `record_native_row_coverage` now also tries each chain owner through `canonical_builtin_owner` as a fallback lookup.
- Closed the `Blob` row gaps the fold then exposed (`decode`'s A1 arm, `values`/`List`/the `read-*` native-endian accessor family).
- Hand-probed two more owner families with no `builtin_type_method_names` entry: `Set`/`SetHash`/`Bag`/`BagHash`/`Mix`/`MixHash` and `RakuAST::StatementList`/`RakuAST::Statement::Expression`.
- A fresh `t/`-wide sweep confirms `native_call_unmodeled` dropped from 2825 to 1900 (cumulative -95% from the original ~37904).
- Zero production behavior change: the coverage check is gated behind `MUTSU_VM_STATS`, and the table is only read by it plus `#[cfg(test)]` inverse-probe tests.

## Test plan
- [x] `cargo test --lib` (738 tests, +2 new)
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `make test` (3002 files / 28169 tests, PASS)
- [ ] CI `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)