### PR TITLE
docs(todo): deep-dive four hard tickets down to implementable plans

### DIFF
--- a/todo/tickets/s17-supply-syntax-burns-600-cpu-seconds.md
+++ b/todo/tickets/s17-supply-syntax-burns-600-cpu-seconds.md
@@ -40,3 +40,262 @@ identical 57s / 610 CPU-s. The slowness predates that campaign.
 react drive loop's polling (`vm/vm_react_loop.rs`, `vm_react_subscriptions.rs`)
 and `Self::sleep_for_supply_delay` / the promise-wait paths, any of which
 spinning would explain a ~11:1 CPU-to-wall ratio.
+
+## Deep-dive investigation (2026-08-10)
+
+Profiled on a `--profile profiling` build (release-optimized + debuginfo),
+current `main` (52f217429). **The ticket's guesses were wrong**: the react
+drive loop (`vm_react_subscriptions.rs`) blocks correctly on its `ReactWaker`
+with a 250 ms cap, `sleep_for_supply_delay` is a real blocking sleep, the
+worker pool parks on a condvar, and the interval timer is already a single
+deadline-heap thread. None of them spins.
+
+### Measured numbers
+
+- Full file, profiling build: **76 s wall, 542 s user + 65 s sys = 607 CPU-s**
+  (`timeout 120 env MUTSU_FUDGE=1 target/profiling/mutsu roast/S17-supply/syntax.t`).
+- Per-subtest gaps (timestamped TAP output): test 63 "CLOSE phaser sees correct
+  outer scope" 6.9 s; test 69 12.1 s; test 70 12.2 s; test 71 30.4 s.
+- **Tests 69–71 run in under 0.6 s each when extracted and run in isolation.**
+  Their slowness in-file is entirely collateral damage from test 63.
+
+### The root cause: `Tap.close` never tears down the channel-backed act-loop worker
+
+Test 63 (`roast/S17-supply/syntax.t:457-476`) does
+`(supply { whenever Supply.interval(0.01) { }; CLOSE {...} }).tap.close`
+4000 times. Each `.tap` leaks a pool worker that runs forever:
+
+1. `Supply.interval` (`src/runtime/methods_instance_ops.rs:1508-1583`) creates
+   a `supply_event_channel()` pair, parks the `SupplyReceiver` in the
+   supply-channel map under a fresh `supply_id`, and registers the
+   `SupplySender` on the shared interval-timer heap
+   (`src/runtime/native_methods/interval_timer.rs:193-211`). The timer entry
+   dies **only when `tx.send` fails**, i.e. when the receiver is dropped.
+2. Tapping the enclosing `supply { }` block hits the "live channel-backed
+   whenever source" branch of the tap handler
+   (`src/runtime/native_supply_mut_methods.rs:527-602`): it
+   `take_supply_channel(chan_sid)`s the receiver and
+   `worker_pool::submit`s `run_supply_act_loop(driver, rx, body_cb, ...)`
+   (submit at line 593).
+3. `run_supply_act_loop` (`src/runtime/native_methods/encoding.rs:444-541`)
+   blocks in `rx.recv()` and dispatches the `whenever` body via
+   `call_sub_value` for every tick. It exits only on channel disconnect,
+   `Done`/`Quit` with no handler, or a `done`-family signal raised by the body.
+4. `Tap.close` (`native_tap` "close",
+   `src/runtime/native_methods/scheduler.rs:167-225`) closes supplier-registry
+   taps, cascades `upstream_taps`, and fires CLOSE phasers — but **the
+   channel-backed branch records nothing in `upstream_taps` and nothing in the
+   Tap handle that could reach the worker**. The receiver is owned by the
+   blocked worker; the sender is owned by the timer heap; neither ever drops.
+   `SupplyReceiver`/`SupplySender`
+   (`src/runtime/native_methods/supply_channel.rs`) have **no receiver-side
+   close** at all.
+
+So after `.close` the timer keeps sending a tick every 10 ms and the worker
+keeps waking and dispatching the (empty) `whenever` body through the full
+interpreter path — forever, until process exit. 4000 taps → ~4000 permanent
+workers × 100 dispatches/s ≈ 400 K interpreter dispatches/s across all cores.
+
+**Empirical confirmation** (repro below, taps all closed, then `sleep 10`):
+the process held **3379 live threads at 956 % CPU** during the sleep, and the
+run's CPU total grew from 77 CPU-s (no sleep) to 113 CPU-s (+36 CPU-s burned
+by "idle" leaked workers in ~10 s). The direct-tap path
+(`Supply.interval(0.01).tap({;}).close`, handler branch at
+`native_supply_mut_methods.rs:236-251`, which returns an **empty** Tap handle)
+leaks identically: 100 closed taps still burn ~0.5 core.
+
+### Profile top self-time (perf, `--no-children`)
+
+Whole file (123 K samples): `nanbox::gc_op` 20.5 %, `Gc::drop` 11.9 %,
+`nanbox::payload_op` 7.1 %, `LocalKey::with` 4.2 %, `value_eq` 3.1 %, `malloc`
+2.6 %, `call_sub_value` 2.2 % — i.e. Value refcount/env churn from the leaked
+workers' body dispatches, not a syscall spin. Leak-phase-only attach profile
+(after all taps closed) shows the same churn plus the timer thread's fan-out:
+`supply_channel::notify_all`, `mpmc Channel::send`, `SyncWaker::notify`,
+`futex_wake`, `native_queued_spin_lock_slowpath`. There is a **single** spin
+site (the leaked act-loop workers, ~90 % of the burn); the timer-thread send
+fan-out is secondary and disappears with the same fix.
+
+### Minimal repro (put in `tmp/`, run with `timeout 60 target/release/mutsu`)
+
+```raku
+my atomicint $total = 0;
+sub test-close($val) {
+    supply {
+        whenever Supply.interval(0.01) { }
+        CLOSE { $total ⚛+= $val; }
+    }
+}
+await do for ^4 { start for ^1000 { test-close($_).tap.close; } }
+say "taps closed, total=$total";
+sleep 10;   # CPU should be ~0 here; actually burns ~3.5 cores (3379 threads)
+```
+
+Watch `grep Threads /proc/<pid>/status` during the sleep: thousands of leaked
+workers.
+
+### Fix plan (step by step)
+
+The wait protocol to build: `Tap.close` sets a per-worker close flag; the act
+loop's blocking receive becomes a **bounded** wait (250 ms cap, the
+`REACT_IDLE_WAIT` idiom — a safety net, not a latency bound) that re-checks the
+flag; the sender also checks the flag so the interval-timer entry dies on its
+next tick. No condvar hand-off is needed because the wait is bounded — a missed
+wakeup costs at most 250 ms, never a hang.
+
+1. **`src/runtime/native_methods/supply_channel.rs`** — add a shared
+   `closed: Arc<AtomicBool>` to `SupplySender` and `SupplyReceiver`, created in
+   `supply_event_channel()` (clone into both halves; `SupplySender::clone`
+   shares it).
+   - `SupplySender::send`: if `self.closed.load(Ordering::Acquire)`, return
+     `Err(mpsc::SendError(event))` without sending. (The interval timer treats
+     a failed send as "receiver gone" and drops its heap entry —
+     `interval_timer.rs:202-208` — exactly the cascade wanted.)
+   - Add `SupplyReceiver::recv_timeout(&self, d: Duration) ->
+     Result<SupplyEvent, mpsc::RecvTimeoutError>` (delegate to
+     `self.rx.recv_timeout(d)`).
+   - Add `SupplyReceiver::close_flag(&self) -> Arc<AtomicBool>` (clone of the
+     shared flag) so the tap site can keep a handle after moving `rx` into the
+     worker.
+2. **Registry** (mirror the cancellation-map idiom in
+   `src/runtime/native_methods/state_lock.rs:41-55`): a
+   `OnceLock<Mutex<HashMap<u64, Arc<AtomicBool>>>>` with
+   `register_act_loop_close(flag: Arc<AtomicBool>) -> u64` (own `AtomicU64`
+   counter), `close_act_loop(id: u64)` (set flag `Ordering::Release`, remove
+   entry; no-op on missing id), and `unregister_act_loop_close(id: u64)`
+   (remove only — called by the worker on exit so the map cannot grow).
+   Put it in `state_lock.rs` or a small new `state` submodule; re-export via
+   `native_methods/mod.rs`.
+3. **`run_supply_act_loop`** (`src/runtime/native_methods/encoding.rs:444`) —
+   add a parameter `close_flag: Option<(u64, Arc<AtomicBool>)>`. Replace the
+   `rx.recv()` at line 460 with:
+   ```rust
+   let recv = loop {
+       if let Some((_, f)) = &close_flag
+           && f.load(Ordering::Acquire)
+       {
+           break Err(());          // treated like disconnect: exit silently
+       }
+       #[cfg(not(target_arch = "wasm32"))]
+       match rx.recv_timeout(Duration::from_millis(250)) {
+           Ok(ev) => break Ok(ev),
+           Err(mpsc::RecvTimeoutError::Timeout) => continue,
+           Err(mpsc::RecvTimeoutError::Disconnected) => break Err(()),
+       }
+       #[cfg(target_arch = "wasm32")]
+       break rx.recv().map_err(|_| ());   // wasm: keep the old blocking recv
+   };
+   ```
+   and match on `recv` where the old code matched `rx.recv()`. **Also re-check
+   the flag after a successful receive, before dispatching** — this is what
+   makes "no body dispatch starts after `close` returns" a hard guarantee (the
+   pin test below relies on it). On *every* exit path (all `break`s fall
+   through to the function end — add the call there), run
+   `unregister_act_loop_close(id)` when `close_flag` is `Some`.
+   Do **not** wrap the wait in `gc::block_quiescent`: the received event moves
+   a `Gc` Value, and the current code raw-blocks — keep the GC posture
+   unchanged.
+4. **Wire the two leaking call sites** in
+   `src/runtime/native_supply_mut_methods.rs`:
+   - Direct live-supply tap (lines 236-251): before `submit`, do
+     `let flag = rx.close_flag(); let fid = register_act_loop_close(flag.clone());`
+     pass `Some((fid, flag))` into `run_supply_act_loop`, and return the Tap
+     with `{"act_loop_close_ids" => Value::array(vec![Value::int(fid as i64)])}`
+     instead of the current empty `HashMap`.
+   - Channel-backed whenever source (lines 527-602, submit at 593): same
+     dance; collect the ids in a `let mut act_loop_close_ids: Vec<Value>`
+     declared next to `upstream_taps` (line 279) — one supply block can have
+     several such sources — and at the Tap-handle build (lines 1104-1111)
+     insert `"act_loop_close_ids"` into `tap_handle_attrs` when non-empty.
+5. **`native_tap` "close"** (`src/runtime/native_methods/scheduler.rs:173`):
+   after the `close_supplier_tap` call and before/alongside the
+   `close_upstream_taps` cascade, read `attributes.get("act_loop_close_ids")`,
+   and for each `ValueView::Int(id)` call `close_act_loop(id as u64)`. Nested
+   Tap handles inside `upstream_taps` recurse through `native_tap("close")`
+   (`close_upstream_taps`, scheduler.rs:136-165) and will close their own ids —
+   no extra recursion needed.
+6. Teardown then converges from both ends: the flagged sender makes the timer
+   entry die on its next tick even before the worker wakes, and the worker
+   exits within ≤250 ms, dropping `rx` (which also disconnects any other
+   sender clones).
+
+### Pin test (new file `t/supply-tap-close-interval.t`, Write tool)
+
+```raku
+use v6;
+plan 2;
+{
+    my atomicint $ticks = 0;
+    my $s = supply { whenever Supply.interval(0.01) { $ticks⚛++ } };
+    my $tap = $s.tap({ ; });
+    sleep 0.1;
+    $tap.close;
+    sleep 0.35;            # > one 250ms bounded-wait round + in-flight body
+    my $after = ⚛$ticks;
+    sleep 0.3;
+    is ⚛$ticks, $after, 'supply-block interval stops ticking after tap.close';
+}
+{
+    my atomicint $n = 0;
+    my $tap = Supply.interval(0.01).tap({ $n⚛++ });
+    sleep 0.1;
+    $tap.close;
+    sleep 0.35;
+    my $after = ⚛$n;
+    sleep 0.3;
+    is ⚛$n, $after, 'direct interval tap stops ticking after tap.close';
+}
+```
+
+This is deterministic (not load-flaky) *because of* the post-receive flag
+re-check in step 3: once `close` returns the flag is set, so no new body
+dispatch can start; the 0.35 s grace covers the bounded wait plus any body
+already in flight.
+
+### Verification plan
+
+1. `cargo build --release` (CI runs roast on release).
+2. `time MUTSU_FUDGE=1 prove -e target/release/mutsu roast/S17-supply/syntax.t`
+   — **targets: wall < 15 s AND total CPU (`cusr+csys`) < 60 s** (baseline:
+   57 s wall / 610 CPU-s; expected result is a few seconds wall with CPU ≈
+   wall, since tests 69-71 run in <1 s once test 63 stops leaking).
+3. Re-run the repro above: CPU during the trailing `sleep 10` must be ~0 and
+   the thread count must fall back to the pool floor (`min(cores,8)` + a few).
+4. No-regression sweep (each with `MUTSU_FUDGE=1 prove -e target/release/mutsu`):
+   `roast/S17-supply/interval.t`, `roast/S17-supply/on-demand.t`,
+   `roast/S17-supply/syntax-nonblocking-await.t`,
+   `roast/S17-procasync/basic.t`, `roast/S32-io/IO-Socket-Async.t` (the act
+   loop also drives socket/signal taps), plus `prove -e target/debug/mutsu
+   t/supply-batch-period.t t/supply-tap-close-interval.t` and a full
+   `make test`.
+5. Per CLAUDE.md flaky rules: S17 files may need a retry under parallel load,
+   but a *concrete subtest* failure (`Failed: N`) in any of the above after
+   this change is a real regression, not flakiness. Do not quarantine
+   syntax.t in `flaky-tests.txt` — this fix is the reason not to.
+
+### Pitfalls
+
+- **Close ≠ done.** Breaking out of the act loop via the flag must NOT run
+  `chain_done_cb` (the whenever's LAST phasers + done-group marker) — raku
+  does not fire LAST on `.close`. Exit the loop the way a disconnect does.
+  CLOSE phasers are already handled separately by `native_tap` via
+  `take_supplier_close_callbacks` (run-once semantics — don't add a second
+  firing path).
+- **Missed-wakeup risk is bounded, not eliminated** — that is the design: the
+  250 ms `recv_timeout` cap means a close that races the worker's wait is
+  honoured at most 250 ms late. Never replace it with an unbounded `recv()`
+  plus "the closer sends a wake event": the closer has no sender handle, and
+  inventing one that lives in the Tap would keep the channel alive.
+- **Do not set the closed flag from anywhere except `Tap.close`/`.cancel`.**
+  `SupplySender::send`'s new early-return must never trigger for channels
+  whose flag is untouched (all other users: Proc::Async, sockets, react
+  receivers) — their behavior is unchanged.
+- **wasm32**: `worker_pool::submit` delegates to the cooperative scheduler;
+  a `recv_timeout` poll loop there would spin the only thread. Keep the plain
+  `recv()` under `cfg(target_arch = "wasm32")` (see step 3's cfg fork).
+- **Registry hygiene**: the worker must `unregister_act_loop_close` on every
+  exit path or the map leaks an entry per tap; `close_act_loop` on an
+  already-removed id must stay a no-op (close racing worker exit).
+- The GC stance of the act loop's wait (raw block, no
+  `block_quiescent`/safepoint) is pre-existing — do not "fix" it in this
+  change.

--- a/todo/tickets/same-role-composed-twice-multi-dispatch-picks-one-candidate.md
+++ b/todo/tickets/same-role-composed-twice-multi-dispatch-picks-one-candidate.md
@@ -38,3 +38,275 @@ for the same `(class, method name)` don't both survive dispatch — out of scope
 declaration-plan-lowering slice. The one roast test that exercises this shape only calls with one
 argument type, so it doesn't currently catch the bug; a fix should add a two-argument-type
 regression test (`t/role-double-parametric-multi-dispatch.t`) alongside the real fix.
+
+## Deep-dive investigation (2026-08-10)
+
+### Confirmed root cause: multi dispatch is CORRECT — the shared per-class `T` binding is wrong
+
+Both suspects named above are exonerated. The bug is not in candidate storage, not in a
+composition dedup, and not in `multi_resolve_cache`/`dispatch_multi_candidate`. **Both
+substituted `MethodDef`s survive into dispatch with correctly substituted signatures, and the
+multi-dispatcher selects the correct candidate per argument type.** What is wrong is the value
+the selected candidate's *body* sees for the bareword type `T`: it is injected into the method
+env at call time from `Registry::class_role_param_bindings` — a flat
+`class -> (param name -> value)` map (`src/runtime/registry.rs:241`) — and the **second
+composition of the same role overwrites the first composition's `T` entry**, because the map is
+keyed only by the bare param name `"T"`, not by which parameterization the executing candidate
+came from.
+
+The exact overwrite site is `src/runtime/registration_class_compose.rs:219-223`
+(`compose_role_into_class`): each composition does
+`cx.out.class_role_param_bindings.insert(p.clone(), v.clone())` into a single flat
+`FxHashMap<String, Value>` shared by all compositions of the class
+(`RoleCompositionOutcome.class_role_param_bindings`, same file line 61). For
+`does R[Int] does R[Str]` the first composition inserts `T => Int`, the second inserts
+`T => Str` over it. The merged flat map is then stored per class at
+`src/runtime/registration_class_decl.rs:200-206`. At method-call time,
+`call_compiled_method` injects it into the body env at
+`src/vm/vm_method_dispatch.rs:335-344` ("Role param bindings":
+`self.class_role_param_bindings(owner_class)` then a name-keyed `env_mut().insert`), so BOTH
+candidates' bodies read `T == Str`.
+
+### Evidence
+
+1. **Candidates + substituted signatures survive.** Composition appends, never overwrites:
+   `registration_class_compose.rs:315-357` builds `composed` via
+   `substitute_type_params_in_method` (`src/runtime/registration_class.rs:298-367`, which
+   correctly rewrites each candidate's `type_constraint` `T -> Int` / `T -> Str`) and does
+   `cx.class_def.methods.entry(mname).or_default().extend(composed)`. Calling with a
+   non-matching arg proves both are consulted with correct types:
+   `A.new.foo(3.5)` dies with `none of these signatures matches: (A: Int $t, ...) (A: Str $t, ...)`.
+2. **Selection is per-argument-type correct.** Changing the body to not mention `T`
+   (`multi method foo(T $t) { "arg=" ~ $t.^name }`) prints `arg=Int` / `arg=Str` — the right
+   candidate runs for each call.
+3. **gdb proof that the injection site is the mechanism.** With a breakpoint on
+   `src/vm/vm_method_dispatch.rs:338` (the binding-injection loop inside
+   `call_compiled_method`), the repro hits it on both calls with `owner_class="A"`, and the two
+   calls carry **different `method_def` pointers** (`0x7fffe00870a0` for `foo(5)`,
+   `0x7fffe00928d0` for `foo("x")`) — i.e. dispatch selected two distinct candidates — yet both
+   print `T=Str`, because the injected map is the class-level `{T => Str}`. Backtrace:
+   `exec_call_method_op_impl -> try_compiled_method_or_interpret_* ->
+   dispatch_compiled_method (vm_call_method_compiled_cache.rs:348) -> call_compiled_method`.
+4. **Registration-time, not call-order caching.** Calling with the Str arg first changes
+   nothing (`T=Str` / `T=Str`); swapping the `does` order flips both outputs to `T=Int` —
+   exactly the flat-map last-write-wins signature. `multi_resolve_cache` keys include argument
+   types and returns the correct per-type candidate (point 3), so the caches need no change and
+   no invalidation.
+
+Related but SEPARATE cosmetic discrepancy noticed en route: `A.^methods(:local)` on current
+main lists only ONE `foo` (with the Int signature) while raku lists one proto-like entry with
+`.candidates.elems == 2`. That is introspection name-dedup, not this bug (the ticket header's
+".^methods shows both" observation is stale), and the fix below does not address it.
+
+### Variant behavior table (current main, debug build 2026-08-10)
+
+| Variant | mutsu | raku | Verdict |
+|---|---|---|---|
+| `does R[Int] does R[Str]`; `foo(5)`, `foo("x")` | `T=Str`, `T=Str` | `T=Int`, `T=Str` | the bug |
+| `does R[Str] does R[Int]` (swapped) | `T=Int`, `T=Int` | `T=Int`, `T=Str` | last `does` wins — registration-time overwrite |
+| Call `foo("x")` before `foo(5)` | `T=Str`, `T=Str` | `T=Str`, `T=Int` | call order irrelevant — NOT a first-call cache |
+| `foo(3.5)` (matches neither) | dies listing BOTH `(A: Int $t ...)` and `(A: Str $t ...)` | dies listing both | both candidates + substituted types survive dispatch |
+| Body `"arg=" ~ $t.^name` (no `T` read) | `arg=Int`, `arg=Str` | same | candidate SELECTION is correct |
+| plus class-body `multi method foo(Rat $t)` | `class-Rat` for `foo(3.5)`; `T=Str`/`T=Str` for Int/Str args | `class-Rat`; `T=Int`/`T=Str` | class multi coexists; role-candidate `T` still wrong |
+| `also does R[Int]; also does R[Str]` in class body | dies: `Cannot resolve caller foo(A:D: Int); ... (A: T $t, ...)` — UNsubstituted `T` | `T=Int`, `T=Str` | DIFFERENT pre-existing bug: `todo/tickets/also-does-role-bracket-args-dropped-in-class-body.md`. Do not test `also does` in this fix |
+| Single composition `does R[Int]` (two classes, one arg type each) | correct | correct | per-class map is fine when each class composes the role once |
+
+### Fix plan (step by step)
+
+The candidate already knows which parameterization it came from at composition time; the fix is
+to stamp the bindings **per `MethodDef`** and prefer them over the per-class map at injection
+time. Keep `class_role_param_bindings` itself — its other consumers (constructor/attr-default
+eval at `src/runtime/methods_object_dispatch_new.rs:1630-1646` and `:1869-1887`, role-pun
+construction `:557-584`, qualified concretization calls in `src/runtime/methods_qualified.rs`,
+EVAL snapshotting in `src/runtime/system_eval_string.rs`, `t`est-function nested interpreters)
+are per-class by nature (composing two parameterizations that both declare `has T $.x` is an
+attribute conflict in raku anyway).
+
+1. **Add the field** to `MethodDef` (`src/runtime/decl_types.rs:95-140`):
+
+   ```rust
+   /// Role type-parameter bindings for THIS composed candidate (`T => Int`),
+   /// stamped by `compose_role_into_class` when a parameterized role is
+   /// composed. Injected into the body env at dispatch in preference to the
+   /// per-class `class_role_param_bindings` map, which is last-write-wins
+   /// when the same role is composed twice with different args. `None` for
+   /// methods not composed from a parameterized role.
+   pub(crate) role_param_bindings: Option<std::sync::Arc<Vec<(String, Value)>>>,
+   ```
+
+   `Arc` keeps `MethodDef::clone` O(1). There are 15 struct-literal construction sites (no
+   `Default`), in: `src/runtime/system.rs`, `registration_class_body_method.rs`,
+   `dispatch_proto.rs`, `methods_classhow_dispatch.rs`, `decl_types.rs`,
+   `registration_role_method.rs`, `registry.rs`, `runtime_init.rs`, `registration_class.rs`,
+   `registration_class_augment.rs`. Add `role_param_bindings: None` to each EXCEPT
+   `substitute_type_params_in_method`'s rebuild (`registration_class.rs:347-366`), which must
+   carry it through: `role_param_bindings: method.role_param_bindings.clone()`. The compiler
+   enforces completeness — do not add `..Default::default()`.
+
+2. **Stamp at composition** in `compose_role_into_class`
+   (`src/runtime/registration_class_compose.rs:315-357`). Before the `let composed = ...`
+   block, build once per role application:
+
+   ```rust
+   let candidate_bindings: Option<std::sync::Arc<Vec<(String, Value)>>> =
+       if role_param_names.is_empty() {
+           None
+       } else {
+           Some(std::sync::Arc::new(
+               role_param_names
+                   .iter()
+                   .cloned()
+                   .zip(role_arg_values.iter().cloned())
+                   .collect(),
+           ))
+       };
+   ```
+
+   and in BOTH map closures (the `type_subs.is_empty()` branch and the substituting branch)
+   set `method.role_param_bindings = candidate_bindings.clone();` next to the existing
+   `role_origin` stamping. (Both branches: `type_subs` pairs names with `type_value_name`
+   strings and is empty iff `role_param_names` is empty, but stamping via
+   `candidate_bindings` keeps the two branches symmetric and covers value-typed role params.)
+
+3. **Prefer per-candidate bindings at injection**, `src/vm/vm_method_dispatch.rs:335-344`
+   (`call_compiled_method`), keeping the block exactly where it is (BEFORE the
+   `captured_env` merge at line 351 and before param binding, to preserve precedence):
+
+   ```rust
+   // Role param bindings — prefer the candidate's own composition bindings
+   // (same role composed twice with different args gives each candidate its
+   // own T); fall back to the per-class map for class-body methods.
+   if let Some(bindings) = method_def.role_param_bindings.as_deref() {
+       for (name, value) in bindings {
+           self.env_mut().insert(name.clone(), value.clone());
+       }
+   } else if let Some(role_bindings) = self.class_role_param_bindings(owner_class) {
+       ...existing two arms unchanged...
+   ```
+
+4. **Defensive gate updates** (today the class map is always non-empty whenever any candidate
+   carries bindings, but `registration_class_validate.rs:35-67` removes/restores the class map
+   on re-registration paths, so make the gates self-sufficient):
+   - `src/vm/vm_method_dispatch.rs:123-126`: `has_role_bindings` gains
+     `|| method_def.role_param_bindings.is_some()`.
+   - `src/vm/vm_call_method_compiled_cache.rs:428-434`: same addition to its
+     `has_role_bindings` (this gate routes binding-carrying methods away from the pinned fast
+     path; it must keep doing so).
+
+5. **Candidate matching** (`src/runtime/resolution_method.rs:14-75`,
+   `method_args_match_for_invocant`): it injects the class-level `role_bindings` parameter
+   into the env before matching. Since each candidate's `type_constraint` is already
+   substituted, this only matters for a `where` clause or sub-signature that reads `T`
+   directly. Inside the function, prefer `def.role_param_bindings` (the `def: &MethodDef`
+   parameter is already in scope) over the passed-in class-level map; no caller-signature
+   changes needed (callers: `resolution_method.rs:189/:613`,
+   `resolution_private_method.rs:40/137/151`, `resolution_sequence.rs:150`).
+
+6. **Do NOT touch**: `multi_resolve_cache` / `func_multi_resolve_cache` /
+   `dispatch_multi_candidate` (they key on argument types and already resolve correctly; the
+   fix changes only the env the resolved candidate's body runs with, which is not cached);
+   the constructor/attr-default consumers listed above; `roast/` anything.
+
+### Test plan
+
+Add `t/role-double-parametric-multi-dispatch.t` with exactly this content (verified 12/12 OK
+under `raku` on 2026-08-10; on current mutsu main tests 1, 3, 6, 9 fail with `T=Str`/`T=Int`
+inversions, everything else already passes):
+
+```raku
+use v6;
+use Test;
+
+plan 12;
+
+my role R[::T] { multi method foo(T $t) { "T=" ~ T.^name } }
+
+# Same parametric role composed twice with different type args:
+# each candidate's body must see ITS OWN T binding.
+my class A does R[Int] does R[Str] { }
+is A.new.foo(5),   "T=Int", "Int arg selects the R[Int] candidate and binds T=Int";
+is A.new.foo("x"), "T=Str", "Str arg selects the R[Str] candidate and binds T=Str";
+
+# Swapped composition order must not change the outcome.
+my class B does R[Str] does R[Int] { }
+is B.new.foo(5),   "T=Int", "swapped does order: Int arg still binds T=Int";
+is B.new.foo("x"), "T=Str", "swapped does order: Str arg still binds T=Str";
+
+# Call order must not matter either (no first-call cache poisoning).
+my class C does R[Int] does R[Str] { }
+is C.new.foo("x"), "T=Str", "Str-typed first call binds T=Str";
+is C.new.foo(5),   "T=Int", "Int-typed second call binds T=Int";
+
+# An argument matching neither candidate dies (both candidates must
+# survive into dispatch with correctly substituted signatures).
+dies-ok { A.new.foo(3.5) }, "Rat arg matches neither Int nor Str candidate";
+
+# A class-body multi of the same name coexists with the role candidates.
+my class D does R[Int] does R[Str] { multi method foo(Rat $t) { "class-Rat" } }
+is D.new.foo(3.5), "class-Rat", "class-body Rat candidate wins for Rat";
+is D.new.foo(5),   "T=Int",     "role Int candidate still selected alongside class multi";
+is D.new.foo("x"), "T=Str",     "role Str candidate still selected alongside class multi";
+
+# Single composition (the already-working shape) keeps working.
+my class E does R[Int] { }
+is E.new.foo(5), "T=Int", "single composition binds T=Int";
+dies-ok { E.new.foo("x") }, "single composition rejects a Str arg";
+```
+
+Verification sequence: `cargo build`, `prove -e target/debug/mutsu
+t/role-double-parametric-multi-dispatch.t`, then the targeted regression set below, then
+`cargo fmt` + `cargo clippy -- -D warnings` + `make test`, and let CI run the full roast.
+
+### Pitfalls / regression hazards
+
+- **Targeted regression tests** (run locally before pushing; all exercise
+  parameterized-role method composition / role-param env injection):
+  - `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/S14-roles/parameterized-type.t`
+    (whitelisted; contains the "correct multi selected from multiple parametric roles"
+    subtest — the one-arg-type shape this ticket generalizes)
+  - `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/S14-roles/parameterized-basic.t`,
+    `roast/S14-roles/parameter-subtyping.t`, `roast/S14-roles/generic-subtyping.t`,
+    `roast/S14-roles/composition.t` (all whitelisted)
+  - local: `prove -e target/debug/mutsu t/qualified-role-multi-concretization.t
+    t/role-samename-composition-and-nested-class.t t/parametric-role-typed-var.t
+    t/role-parameterisation-keeps-the-topic.t t/my-enum-and-type-params-in-role.t`
+- **Precedence inside `call_compiled_method`:** the binding injection must stay exactly where
+  the current block is — after `self`/`?CLASS` setup, BEFORE the `captured_env`
+  insert-if-absent merge (`vm_method_dispatch.rs:351-358`) and before parameter binding, so
+  params/self still shadow `T` and captured envs do not shadow the fresh binding.
+- **`substitute_type_params_in_method` rebuilds `MethodDef` field-by-field** — forgetting the
+  carry-through there silently reverts the fix for exactly the substituted candidates it is
+  meant for (the compiler catches a *missing* field, and copying `None` would also compile —
+  copy `method.role_param_bindings.clone()`).
+- **Runtime mixins** (`$obj does R[Int]`, `but`) build their bindings separately
+  (`methods_qualified.rs:664-690`, per-value) and likely have the same last-wins shape when
+  the same role is mixed twice; out of scope here (see
+  `todo/tickets/mixin-role-order-not-tracked.md`), but do not regress that path — it does not
+  read `MethodDef.role_param_bindings`, so the fix is orthogonal to it.
+- **`also does` stays broken by a different bug** (bracket args dropped, signature keeps
+  unsubstituted `T` — see the variant table). Keep it out of the new test file.
+
+### ADR-0019 interaction
+
+No conflict; the fix is aligned with the ADR's own plan and should land now, in the legacy
+code, as described above.
+
+- The buggy consumption site (`call_compiled_method`, `vm_method_dispatch.rs:335`) and the
+  stamping site (`compose_role_into_class`) are legacy machinery that ADR-0019 will eventually
+  rework, but no Phase E resolver code has landed for candidate execution (E8-E11 are
+  design-only as of 2026-08-09, `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`),
+  and Phase D's role-plan encoding (D7, landed) still materializes composed candidates as
+  `MethodDef`s — so `MethodDef.role_param_bindings` is a carrier that survives both phases.
+- The ADR explicitly anticipates this fix: `docs/adr/0019-...md:844-845` notes "role method
+  bodies may need **per-composition re-instantiation** depending on how a parametric role's
+  type captures reach compiled bytecode" (D3-8 scoping). Per-candidate bindings stamped at
+  composition IS that per-composition instantiation, done as data instead of recompilation.
+- Coordination hazard to note in the PR: the E4/E8 "ordered candidate sequence" resolver, when
+  it arrives, must inject `role_param_bindings` from the *selected* candidate (not from a
+  class-level map) in whatever replaces `call_compiled_method`'s env setup — the new field
+  makes that a one-line rule. Also `drop_flattened_role_duplicates`
+  (`resolution_method.rs:613-630`) de-dups candidates at resolution time because the composed
+  role is also an MRO entry; it compares candidates, and after this fix two same-name
+  candidates differ in `role_param_bindings` as well as `param_defs` — it must keep treating
+  the two substituted candidates as distinct (they already differ in `param_defs`, so current
+  behavior is safe; just do not "simplify" it to compare by role_origin+name).

--- a/todo/tickets/sinking-a-try-blocks-discarded-value-escapes-the-try.md
+++ b/todo/tickets/sinking-a-try-blocks-discarded-value-escapes-the-try.md
@@ -71,3 +71,276 @@ distinction between a real `try` and the implicit one). The reify-on-sink of a
 Related: `todo/deep/deferred-seq-materialization-destroys-the-original.md` is the
 other place in this campaign where the real module's strictness meets mutsu's
 eagerness, but it is a different mechanism (a `.defined` probe, not a sink).
+
+## Deep-dive investigation (2026-08-10)
+
+**Headline result: the motivating symptom is already fixed on current main.**
+`roast/integration/advent2009-day20.t` passes 21/21 both plain and under
+`MUTSU_REAL_TEST=1` (verified 2026-08-10, debug build). The fix was PR #6115
+(merged 2026-08-09, `e16d93a41`, branch `fix/try-lazy-seq-sink-in-scope`):
+commit `a2808479c` gave the `...` stub `fail()` semantics instead of `die()`
+(`src/runtime/builtins_control_flow.rs`, pinned by `t/stub-fail-semantics.t`,
+news: `news/2026-08/stub-fail-semantics.md`), and `604a8bbb6` made unhandled
+Failures throw in string-coerce context. The file is whitelisted
+(`roast-whitelist.txt:1342`). The ticket's "mutsu" column above is therefore
+stale for row 1 (mutsu no longer throws there). Rakudo's sink rule — the open
+question this ticket asked to pin down — is now derived empirically below.
+
+### Probe matrix (raku 2025.x vs mutsu current main, 2026-08-10)
+
+Probe scripts: `tmp/sink-probes.sh`, `tmp/sink-probes2.sh`, `tmp/sink-probes3.sh`
+(run as `sh tmp/sink-probes.sh raku` / `sh tmp/sink-probes.sh target/debug/mutsu`;
+each mutsu invocation wrapped in `timeout 30`). "throws" = uncaught, nonzero exit.
+Matches are marked =, divergences marked with the divergent side's output.
+
+Group A — try in statement position, tail statement varies (unit scope):
+
+| # | snippet | raku | mutsu |
+| --- | --- | --- | --- |
+| P1 | `try { fail "x" }; say "alive ", $!.defined` | `alive True` | = |
+| P2 | `sub f { fail "x" }; try { f() }; say ...` | `alive True` | = |
+| P3 | `my $v = try { fail "x" }; say $v.^name` | `alive Any` | = |
+| P4 | `try { (1..3).map({die "boom"}) }; say ...` | **throws** | `alive True` (caught) |
+| P5 | `sub f { (1..3).map({die "boom"}) }; try { f() }; say ...` | **throws** | `alive True` (caught) |
+| P6 | `sub f { (1..3).map({ say "forced $_"; $_ }) }; try { f() }; say "done"` | forced 1..3, done | = |
+| P7 | same with literal `.map` tail in try | forced 1..3, done | = |
+
+Group B — plain statements without try (baseline; all match):
+
+| # | snippet | raku | mutsu |
+| --- | --- | --- | --- |
+| P8 | `f(); say "done"` (side-effect Seq) | forced 1..3, done | = |
+| P9 | `f(); say "alive"` (die Seq) | throws | = |
+| P10 | `(1..3).map({ say "forced $_" }); say "done"` | forced, done | = |
+| P11 | `sub f { fail "x" }; f(); say "alive"` | throws | = |
+| Q13 | `my $s = (1..3).map({ fail "x" }); say $s.eager.raku` | throws | = |
+| Q15 | `sub f { (1..3).map({ fail "x" }) }; f(); say "alive"` | throws | = |
+
+Group C — try inside a sub, non-final statement (the ticket shape):
+
+| # | snippet | raku | mutsu |
+| --- | --- | --- | --- |
+| P12 | `sub f { (1..3).map({die "boom"}) }; sub ee { try { f() }; $! }; say ee().^name` | **throws** | `X::AdHoc` + alive (caught) |
+| P13 | same with literal `.map` tail | **throws** (`in sub ee`) | `X::AdHoc` + alive (caught) |
+| P14/P15 | side-effect variants of P12/P13 | forced 1..3, done | = |
+| P18 | `sub ee { try { f() } }; say ee().^name` (die Seq, try final, value used) | `Seq` + alive (never forced) | `Nil` + alive (forced+caught) |
+| Q5 | `sub ee { try { map -> $x,$y { ... }, 1..6; }; $! }` (yada literal) | **throws** (`in sub ee`) | `Failure` + alive |
+| Q6 | same via `sub f { map -> ... }` call | **throws** | `Failure` + alive |
+| Q11 | `try { EVAL $c }` in sub, `$c` = die-Seq code | **throws** | `X::AdHoc` + alive |
+| Q14 | `sub f { (1..3).map({ fail "x" }) }; try { f() }; say ...` (unit) | **throws** | `alive True` |
+
+Group D — the EVAL / eval-lives-ok cell (all key cells MATCH now):
+
+| # | snippet | raku | mutsu |
+| --- | --- | --- | --- |
+| P16/R4 | `sub ee($c) { try { EVAL ($c); }; $! }; ee(q[map -> $x, $y { ... }, 1..6])` | returns Failure, `.defined` False, alive | = |
+| R9 | `not defined ee(...)` (the eval-lives-ok check) | `True` | = |
+| R5 | R4 + `say "reached-tail"` before `$!` | "reached-tail" NOT printed — the yada `fail` fired during the post-try sink **early-returns the Failure from `ee`** | = (also no reached-tail) |
+| R8 | R5 with block `{ say "invoked"; ... }` | invoked, no reached-tail, r=Failure | invoked, **reached-tail printed**, r=X::StubCode |
+| P17/Q10 | `try { EVAL ... }; say "made it"` at **unit** scope (literal or runtime string) | **throws** | = (throws) |
+| Q2 | `my $r = EVAL $c; say $r.^name` (value used) | `Seq` (lazy, unforced) | = |
+| Q3 | ... `$r.eager` | throws Stub code executed | = |
+| Q12 | `sub f { map -> $x,$y { ... }, 1..6 }; try { f() }; say ...` at unit | **throws** | = (throws) |
+| Q4 | `try { map -> $x,$y { ... }, 1..6; }; say ...` at unit | **throws** | = (throws) |
+| R6 | Q5 + reached-tail marker | throws (no marker) | `r=Failure` + alive (no marker — early return) |
+| R7 | Q6 + markers | invoked, then **throws** | invoked, reached-tail, `r=X::StubCode`, alive |
+
+Group E — where the sink happens relative to the protection:
+
+| # | snippet | raku | mutsu |
+| --- | --- | --- | --- |
+| P22 | `try { (1..3).map({ die "boom" }); CATCH { default { say "caught-inside" } } }` | caught-inside, alive | = |
+| P23 | same with tail call `f()` | caught-inside, alive | = |
+| Q8 | P23 shape inside a sub | caught, alive | = |
+| Q9 | `try { (1..3).map({die "boom"}) }; CATCH { default { say "unit-caught" } };` at unit | **unit-caught** (the escape is caught by the *enclosing* block's CATCH) | alive, no unit-caught (inner try already caught it) |
+| P20/P21 | bare block tail/non-tail call sink | forced, done (+ useless-use warn P21) | = |
+
+Group F — the underlying laziness split (root cause of every divergent cell):
+
+| # | snippet | raku | mutsu |
+| --- | --- | --- | --- |
+| M2 | `sub f { (1..3).map({ say "invoked"; $_ }) }; my $x = f(); say "got"` | got first (lazy) | **invoked 1..3 first** (eager at call boundary) |
+| M4 | `my $x = (1..3).map({ say "invoked"; $_ }); say "got"` | lazy | eager |
+| M5 | `my $x = map -> $a,$b { say "invoked"; $a }, 1..6; say "got"` | lazy | eager |
+| Q2 | EVAL-returned Seq | lazy | lazy (=) — EVAL is the one boundary mutsu does NOT reify through |
+
+### The derived rule (the question this ticket left open)
+
+Rakudo's sink-context propagation, stated from the data: **a statement-position
+`try { ... }`'s value IS sunk — there is no "call results are exempt" rule** (the
+ticket's hypothesis 2 is refuted: P6/P14/P16b force and print in raku). Sink
+context propagates statically into immediately-invoked blocks onto their final
+statement, but a plain `try`'s own handler wrapper interposes and stops that
+propagation, so the tail value escapes the handler un-sunk and is sunk by the
+generic statement-level sink at the `try` statement itself — **outside the
+protection** (the ticket's hypothesis 1, "sink outside the try is a mutsu bug",
+is also refuted: raku behaves the same way — P4/P5/P12/P13/Q4-Q6/Q12 all throw
+uncaught in raku, and Q9 shows the escape is catchable by the *enclosing*
+block's CATCH). When the block carries an **explicit CATCH phaser**, there is no
+wrapper, sink propagates into the block, and force-time exceptions are raised
+inside the protected region (P22/P23/Q8). Orthogonally, `try` absorbs a trailing
+Failure *value* inside its protection (`$!` = `.exception`, result Nil —
+P1/P2/Q1). What makes the roast cell pass under raku is a third mechanism
+entirely: the yada `...` in the mapped block runs `fail`, and a `fail` fired
+while the Seq is being forced at the post-try statement sink unwinds as a
+control return to a live enclosing routine when the block's lexical chain (via
+EVAL's caller-context compilation) resolves to one — `eval_exception`
+early-returns an unhandled Failure (R5/R8: `reached-tail` never prints), whose
+`.defined` is False, so `eval-lives-ok` passes. Without the EVAL boundary
+(R6/R7) rakudo throws instead. Compile-time vs runtime split: the sink *marking*
+is static (non-final statements; final statements of sunk blocks unless a
+handler wrapper interposes); the *forcing* is runtime, performed by whichever
+frame owns the marked statement.
+
+### Mutsu's current state against that rule
+
+- **SinkPop placement is already rakudo-conformant.** `Stmt::Expr(Expr::Try)`
+  compiles the try (`src/compiler/stmt.rs:717-730`, `SinkPop` emitted at line
+  729) *after* `compile_try` → `compile_try_region`
+  (`src/compiler/helpers_control_flow.rs:564-566, 577-712`) has closed the
+  `TryCatch` region (opcode emitted at line 621, tail value kept on stack at
+  lines 646-655, `ThrowIfFailure` at line 670, region patched closed at lines
+  705-710). So the statement sink (`OpCode::SinkPop` handler at
+  `src/vm/vm_exec_dispatch.rs:2741`, LazyList forcing via `force_lazy_list_vm`
+  at lines 2834-2836, defined in `src/vm/vm_helpers_lazy.rs`) runs outside the
+  trap — exactly where raku runs it. **Do not move it inside.**
+- **The EVAL cell matches** (P16/R4/R5/R9, and the roast file passes) because
+  #6115's fail-semantics `...` + mutsu's fail-signal conversion at the sub
+  boundary reproduce raku's early-return-of-Failure observable.
+- **Every remaining divergent cell (P4, P5, P12, P13, P18, Q5, Q6, Q9, Q11,
+  Q14, R6, R7, R8) traces to eager Seq reification, not to try/sink placement**:
+  mutsu forces map Seqs at call/assignment boundaries (group F), so the
+  force-time error surfaces *inside* the try (where mutsu's trap catches it)
+  instead of at the caller's statement sink (where raku lets it escape). Mutsu
+  is uniformly *more forgiving* than raku in these cells — it cannot abort a
+  file raku would pass, only pass constructs raku would abort. These cells
+  belong to the eagerness campaign
+  (`todo/deep/deferred-seq-materialization-destroys-the-original.md`), not here.
+
+### Implementation plan (for the implementing agent)
+
+The semantics question is resolved and the motivating roast failure is fixed.
+What remains is to **pin the now-correct behavior** so neither the sink
+placement nor the `...`-fail mechanism regresses silently, and to hand the
+residual cells to the campaign that owns them. Concretely:
+
+1. Create branch `test/pin-try-statement-sink-semantics` off `main`.
+2. Add `t/try-sink-semantics.t` with exactly the content below. It was verified
+   2026-08-10 to pass 14/14 under BOTH `target/debug/mutsu` and `raku` (a true
+   parity pin; a working copy exists at `tmp/try-sink-semantics.t`):
+
+```raku
+use MONKEY-SEE-NO-EVAL;
+use Test;
+plan 14;
+
+# A. try absorbs a trailing Failure value inside its protection (raku: P1/P2/Q1)
+try { fail "x" };
+ok $!.defined, 'try absorbs a literal trailing fail, $! set';
+sub ff() { fail "x" }
+try { ff() };
+ok $!.defined, 'try absorbs a call-returned trailing Failure, $! set';
+sub q1() { fail "x" }
+my $r = try { q1() };
+ok !$r.defined, 'absorbed-Failure try returns an undefined value';
+is $!.^name, 'X::AdHoc', 'try sets $! to the exception behind the Failure';
+
+# B. statement-position try's value IS sunk (side effects run) (raku: P6/P7)
+my @forced;
+sub seq-se() { (1..3).map({ @forced.push($_); $_ }) }
+try { seq-se() };
+is @forced.elems, 3, 'statement-position try forces a call-returned Seq';
+@forced = ();
+try { (1..3).map({ @forced.push($_); $_ }) };
+is @forced.elems, 3, 'statement-position try forces a literal map Seq';
+
+# C. explicit CATCH sees the force-time die (raku: P22/P23/Q8)
+my $caught = False;
+try { (1..3).map({ die "boom" }); CATCH { default { $caught = True } } };
+ok $caught, 'explicit CATCH catches a force-time die of the tail map';
+$caught = False;
+sub die-seq() { (1..3).map({ die "boom" }) }
+try { die-seq(); CATCH { default { $caught = True } } };
+ok $caught, 'explicit CATCH catches a force-time die of a call-returned Seq';
+
+# D. the eval_exception / eval-lives-ok cell (raku: P16/R4/R9) — this is the
+#    exact Test.rakumod shape that costs advent2009-day20.t when broken.
+sub eval_exception($code) {
+    try { EVAL ($code); }
+    $!
+}
+my $e = eval_exception(q[map -> $x, $y { ... }, 1..6]);
+ok (not defined $e), 'eval_exception of a lazy stub map is not defined';
+ok $e ~~ Failure, 'eval_exception of a lazy stub map returns a Failure';
+
+# E. unit-scope escapes: sinking a lazy stub map at unit scope kills the
+#    program even under try (raku parity: Q4/Q10/Q12/P17) — subprocess checks
+my $p = run($*EXECUTABLE, '-e', 'use MONKEY-SEE-NO-EVAL; my $c = q[map -> $x, $y { ... }, 1..6]; try { EVAL $c; }; say "made it"', :out, :err);
+ok $p.exitcode != 0, 'unit-scope try{EVAL lazy stub map} still dies at the statement sink (raku parity)';
+unlike $p.out.slurp(:close), /'made it'/, '... and does not reach the next statement';
+$p = run($*EXECUTABLE, '-e', 'sub f { map -> $x, $y { ... }, 1..6 }; try { f() }; say "made it"', :out, :err);
+ok $p.exitcode != 0, 'unit-scope try{call returning lazy stub map} dies (raku parity)';
+unlike $p.out.slurp(:close), /'made it'/, '... and does not reach the next statement';
+```
+
+3. Verify locally (no src/ changes are needed or wanted):
+   - `cargo build`
+   - `timeout 60 target/debug/mutsu t/try-sink-semantics.t` → 14/14
+   - `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/integration/advent2009-day20.t` → PASS
+   - `MUTSU_REAL_TEST=1 MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/integration/advent2009-day20.t` → PASS
+   - `make test` (debug binary, per ADR-0014)
+4. Append a short "residual try-cell divergences (2026-08-10)" section to
+   `todo/deep/deferred-seq-materialization-destroys-the-original.md` listing the
+   divergent shapes from the matrix above (P4, P5, P12, P13, P18, Q5, Q6, Q9,
+   Q11, Q14, R6, R7, R8 — one-line snippets + raku-vs-mutsu outcome), stating
+   that they are eagerness artifacts and will align automatically once
+   sub-returned/assigned Seqs stay lazy, and warning that landing laziness makes
+   mutsu STRICTER in those cells (a full-roast CI sweep is mandatory then).
+5. `git mv` THIS ticket to `news/2026-08/try-statement-sink-semantics-pinned.md`
+   and rewrite it as an accomplishment (headline: fixed by #6115's `...`-fail
+   semantics; sink placement verified rakudo-conformant; parity pinned by
+   `t/try-sink-semantics.t`; residual cells handed to the deferred-seq deep
+   ticket). Per `todo/README.md`, `todo/` holds only open findings.
+6. PR per CLAUDE.md workflow: conventional title
+   `test(sink): pin try-statement sink semantics (raku parity matrix)`,
+   `gh pr merge --auto --merge`, verify mergeStateStatus, background CI watch.
+
+**Do NOT, under any circumstances:**
+- Move the `SinkPop` for a try statement inside the `TryCatch` region, or make
+  `TryCatch` trap SinkPop-time exceptions. That *sounds* like the ticket's
+  original ask, but the matrix proves raku sinks outside the protection; moving
+  it inside would break raku parity on Q4/Q10/Q12/P17 (unit-scope escapes, all
+  currently matching) and re-break the semantics #6115 fixed.
+- "Fix" the P4/P5/P12-type cells by special-casing `try` or by forcing the tail
+  value inside `compile_try_region`. They are eagerness artifacts; the fix is
+  Seq laziness (deep ticket), not try surgery.
+- Revert or weaken `...`'s fail semantics (`t/stub-fail-semantics.t` pins it).
+
+### Test plan
+
+- New: `t/try-sink-semantics.t` (above, 14 assertions, raku-verified).
+- Existing pins that must stay green (the sink behavior is load-bearing):
+  `t/stub-fail-semantics.t`, `t/statement-call-sinks-its-value.t`,
+  `t/sink-tail-failure.t`, `t/sink-method-context.t`, `t/sink-warning.t`,
+  `t/dot-eq-sink.t`, `t/failure-sink-handled.t`,
+  `t/imported-sub-shadows-builtin-in-sink-position.t`,
+  `t/throws-like-gather-sink.t`, `t/regex-sep-quantifier-ratchet.t` (adjacent).
+- Roast: `roast/integration/advent2009-day20.t` stays 21/21 in both plain and
+  `MUTSU_REAL_TEST=1` modes; it is whitelisted (`roast-whitelist.txt:1342`) and
+  per CLAUDE.md a whitelisted file must never regress — CI's full `make roast`
+  is the safety net for the rest of the suite.
+
+### Regression hazards
+
+- The pinning test's group E spawns subprocesses via `$*EXECUTABLE`; keep it
+  fast (it is — the child dies at the first sink) and never hardcode anything
+  environment-specific in the child code strings.
+- Any future change to `ThrowIfFailure` (`src/vm/vm_exec_dispatch.rs:2682`),
+  `SinkPop`/`SinkPopAssign` (`:2710`, `:2741`), `compile_try_region`
+  (`src/compiler/helpers_control_flow.rs:577`), or the fail-signal-to-Failure
+  conversion at sub boundaries touches this matrix; re-run
+  `t/try-sink-semantics.t` plus the t/ sink pins above first.
+- When the deferred-seq laziness campaign lands, cells P4/P5/P12/P13/P18/Q5/Q6/
+  Q9/Q11/Q14/R6/R7 will flip toward raku's stricter behavior — that campaign
+  must re-run this file (group A-D stays valid; only divergence notes in the
+  deep ticket become obsolete) and sweep the whole whitelist.

--- a/todo/tickets/when-only-block-nonmatch-value-wrong.md
+++ b/todo/tickets/when-only-block-nonmatch-value-wrong.md
@@ -90,3 +90,405 @@ pins — run them after any change).
   still pass.
 - Add a `t/` pin covering the non-match case for both `.map` and `.grep`
   with a `when`-only block.
+
+## Deep-dive investigation (2026-08-10)
+
+Step 1 of the fix direction is now DONE. Everything below was verified
+against Rakudo v2026.06 on this machine and against the current source
+tree (main, `52f217429`). The remaining work is purely mechanical; the
+implementation plan below names every insertion point.
+
+### Probe matrix (raku = Rakudo v2026.06 oracle; mutsu = current main)
+
+| # | Probe (`raku -e '...'`) | raku output | mutsu today |
+|---|---|---|---|
+| 1 | `say (1..5).map({ when 2 { "two" } }).raku` | `(Bool::False, "two", Bool::False, Bool::False, Bool::False).Seq` | `(1, "two", 3, 4, 5).Seq` |
+| 2 | `say (1..5).map({ when 2 { "two" } }).elems` | `5` | 5 |
+| 3 | `my @a = (1,"a",2).map({ when Int { "int" } }); say @a.raku` | `["int", 0, "int"]` | `["int", "a", "int"]` |
+| 4 | `say (1..5).grep({ when 2 { True } }).raku` | `(2,).Seq` | filters nothing |
+| 5 | `my @a = (1,"a",2,"b").grep({ when Int { True } }); say @a.join(",")` | `1,2` | `1,a,2,b` |
+| 6 | `say (1,2,3).first({ when 5 { True } }).raku` | `Nil` | `1` |
+| 7 | `my $b = { when 2 { "two" } }; say $b(3).raku; say $b(2).raku` | `Bool::False` / `"two"` | `Nil` / `"two"` |
+| 8 | `$b(3).WHAT` / `?($b(3))` / `so $b(3)` | `Bool` / `False` / `False` | — |
+| 9 | `my $b = { when "b" { "hit" } }; say $b("a").raku` | `Bool::False` | — |
+| 10 | `my $b = { when /x/ { "hit" } }; say $b("abc").raku` | `Bool::False` | — |
+| 11 | `my $b = { when * > 5 { "big" } }; say $b(3).raku` | `Bool::False` | — |
+| 12 | `my $b = { when 2\|3 { "j" } }; say $b(5).raku` | `Bool::False` | — |
+| 13 | `my $b = { when Str { "s" } }; say $b(3).raku` | `0` | — |
+| 14 | `my $b = { when Int:D { "d" } }; say $b("a").raku` | `0` | — |
+| 15 | `class Foo {}; my $b = { when Foo { "f" } }; say $b(3).raku` | `0` | — |
+| 16 | `constant T = Int; my $b = { when T { "t" } }; say $b("a").raku` | `0` | — |
+| 17 | `subset Even of Int where * %% 2; { when Even { "e" } }` on 3 | `0` | — |
+| 18 | `{ when Positional { "p" } }` on 3 | `0` | — |
+| 19 | `enum Color <R G B>; my $b = { when R { "r" } }; say $b(5).raku` | `Bool::False` | — |
+| 20 | `my $b = { default { "d" } }; say $b(3).raku` | `"d"` | — |
+| 21 | `{ when 2 { "two" }; default { "d" } }` on 3 / on 2 | `"d"` / `"two"` | — |
+| 22 | `{ when 2 { proceed }; when Int { "int" } }` on 2 / 9 / `"a"` | `"int"` / `"int"` / `0` | — |
+| 23 | `{ when Int { succeed "S" } }` on 2 / `"a"` | `"S"` / `0` | — |
+| 24 | `{ when 2 { "two" }; "after" }` on 3 / on 2 | `"after"` / `"two"` | same (verified) |
+| 25 | `{ my $x = 42; when 2 { "two" } }` on 3 / on 2 | `Bool::False` / `"two"` | — |
+| 26 | `for 1..4 { when 2 { say "two" } }; say "done"` | `two` then `done` | same |
+| 27 | `(1..4).map(-> $x { when 2 { "two" } }).raku` | `(0, 0, 0, 0).Seq` (!) | — |
+| 28 | `my @a = 1..4; @a.=map(<-> $x { when 2 { "two" } }); say @a.raku` | `[0, 0, 0, 0]` | — |
+| 29 | `my $b = { ; }; say $b(3).raku` | `Nil` | — |
+| 30 | `my $b = { when 2 { proceed } }; say $b(2).raku` | crash: `No such method 'raku' for ... VMNull` | — |
+| 31 | `$_ = False; my $a = do { when .so { "foo" } }; say $a.raku` | `Bool::False` | `Any` |
+| 32 | `say (given 3 { when 2 { "two" } }).raku` | `Bool::False` | `Nil` |
+| 33 | `say ("a" ~~ Int).raku` (plain smartmatch, for contrast) | `Bool::False` | — |
+
+Notes on the odd rows:
+
+- Row 27/28: a pointy block with an explicit parameter does NOT bind `$_`
+  to the parameter — `when 2` tests the *outer* `$_` (`Any`), so every
+  element yields the non-match value, `"two"` never fires, and even the
+  0-vs-False flavor flips (a Rakudo internal artifact on an undefined
+  topic). Pathological shape; do not chase the flavor here.
+- Row 30: a matched `when` whose body consists only of `proceed`, falling
+  off the end of the block, produces literal VMNull in Rakudo — i.e.
+  Rakudo itself has no defined value for that shape. Any defined falsy
+  value we produce there is acceptable.
+- Row 33 is the key to the flavor split: plain `"a" ~~ Int` returns
+  `Bool::False`, but the failed `when Int` yields Int `0` — because
+  Rakudo's optimizer compiles a type-object `when` matcher down to
+  `nqp::istype`, whose native-int 0 result boxes as `Int` and leaks out
+  as the statement value. It is an implementation artifact, but it is
+  observable, stable across type shapes (classes, roles, subsets,
+  `:D`/`:U` smileys, `constant` aliases — rows 13-18), and it is what the
+  ticket's own repro pins, so we reproduce it.
+
+### The confirmed rakudo rule (crisp)
+
+A non-matching `when` statement does not "produce nothing": it evaluates
+to the falsy result of its own condition test, and control simply falls
+through to the next statement. If the `when` (or a `when`/`default`
+chain) is the block's final statement and no branch matches, that falsy
+test result IS the block's value — canonically `Bool::False`, except
+that Rakudo yields Int `0` when the matcher is a type object (any class,
+role, subset, or smiley-suffixed type — the `nqp::istype` boxing
+artifact). The value is defined, is not `Nil`, is not `Empty` (`.elems`
+of the mapped Seq stays the full length, row 2), and is never the topic.
+A matched `when` instead `succeed`s out of the enclosing block with its
+body's value. `raku-doc/doc/Language/control.rakudoc` confirms this
+explicitly (lines 537-546): with `$_ = False`, `$a = do when .so
+{ "foo" }` leaves `$a == False` — "the block is not abandoned since the
+comparison is false, so `$a` will actually get a value."
+
+This dissolves the ticket's earlier "contradiction": the `0` seen in the
+map probe was the type-matcher flavor (`when Int` → istype → Int 0); the
+`False` seen in the direct-call probe was the value-matcher flavor
+(`when 2` → Bool::False). Same rule, two matcher kinds — there is no
+extra boolean coercion in map/grep.
+
+### mutsu today — where the wrong value comes from
+
+- `exec_when_op` (`src/vm/vm_given_when_ops.rs:324-412`): on non-match
+  it pops the cond value, pushes NOTHING, and falls to `*ip = end;
+  Ok(())` (line 410). On match it raises a succeed signal carrying the
+  body value (line 404-407); the four fast-path sites already absorb
+  that in their `is_succeed` arms (that was the sibling fix).
+- The four `Ok(())` fallback sites (`grep -n 'or_else(|| vm.env().get' src/runtime/resolution_map_grep*.rs`):
+  - A. `eval_map_over_items` — `src/runtime/resolution_map_grep.rs:462-466`
+  - B. `try_first_match_batched` — `src/runtime/resolution_map_grep.rs:725-729`
+  - C. `eval_map_over_items_rw` — `src/runtime/resolution_map_grep_rw.rs:271-275`
+  - D. `eval_grep_over_items_with_mutated` — `src/runtime/resolution_map_grep_rw.rs:536-540`
+  Each computes `vm.last_stack_value().cloned().or_else(|| vm.env().get("_").cloned()).unwrap_or(Value::NIL)`.
+  `last_stack_value()` (`src/vm/vm_core_helpers.rs:248`) is `Some` only
+  when the stack holds exactly one value. A non-matching tail `when`
+  leaves the stack empty (the block body is compiled by
+  `Compiler::compile` → `compile_unit`, whose tail-statement match at
+  `src/compiler/mod.rs:2595-2687` has no `Stmt::When` arm — it falls to
+  plain `compile_stmt`, and `OpCode::When` pushes nothing on non-match).
+  So the `.or_else` topic fallback fires and the ORIGINAL ITEM leaks out.
+- The topic fallback is genuinely load-bearing for other tail shapes
+  (blocks whose tail compiles as a sink statement and whose meaning is
+  "reflect the possibly-mutated `$_`", plus the rw `<->`/`.=map`
+  writeback machinery around it), so it cannot simply be replaced.
+  Note the rw WRITEBACK itself (`topic_key`/`rw_cell`/`topic_source_key`
+  env entries) is independent of this value fallback — the fix below
+  does not touch it.
+- The same wrong-value disease exists OUTSIDE map/grep (rows 7/31/32:
+  direct block call → `Nil`, `do { when ... }` → `Any`, bare
+  `given`+`when` → `Nil`; raku gives `False` in all three), but through
+  different fallback paths (closure-call result handling,
+  `compile_block_inline`'s trailing `LoadNil` at
+  `src/compiler/helpers_block_inline.rs:387`). Out of scope here — see
+  "Follow-up" below.
+
+### Mechanism decision
+
+**Compile-time tail gate + runtime value marker.** Two pieces, both tiny:
+
+1. A compile-time predicate answers "is this block a bare `when`/`default`
+   chain in tail position?" — computable at the four sites directly from
+   the AST they already hold (`normalized_body`), no new opcode, no
+   compiler flag, no change to compiled code. This gates the carve-out so
+   the topic fallback keeps firing for every other tail shape (the rw
+   safety constraint).
+2. A runtime marker field supplies the exact non-match VALUE. Only
+   `exec_when_op` knows the failed matcher's runtime value (`cond_val`),
+   which is what decides the Int-0-vs-False flavor exactly — including
+   `constant T = Int` aliases (row 16) that no AST inspection can
+   classify. On non-match it records
+   `Some(0 or False)`; the four sites consume it only when the gate says
+   the tail is a when chain and the stack is empty.
+
+Why not the alternatives:
+
+- *Pure compile-time value* (classify the tail `When`'s cond AST:
+  `BareWord("Int")` → 0, else False): cannot get rows 16-18 right
+  (`constant` type aliases, subsets resolved at runtime), and would
+  misclassify enum values (`when R`, row 19 — `BareWord` but NOT a type).
+- *The general fix* (make `exec_when_op` push the falsy value on the
+  stack on non-match, fixing given/do/direct-call too): architecturally
+  the right end state, but its blast radius is every statement-sequence
+  compile site: `compile_unit:2679-2686` already Pops after a non-last
+  `when` (currently a no-op because nothing was pushed — it would become
+  load-bearing), `compile_block_inline` does NOT pop non-last whens and
+  appends `LoadNil` after a tail when (helpers_block_inline.rs:387, which
+  would bury the pushed value), and loop bodies would accumulate one
+  value per non-matching iteration unless every loop op truncates the
+  stack. That is a separate, careful campaign — see Follow-up.
+
+### Implementation plan (step by step)
+
+All line numbers refer to main @ `52f217429`; re-locate with the quoted
+context if drifted.
+
+**Step 1 — new Interpreter field.**
+In `src/runtime/mod.rs`, directly after `when_matched: bool,` (line
+1142), add:
+
+```rust
+    /// The falsy value the most recent non-matching `when` evaluated to:
+    /// rakudo yields Int 0 for a type-object matcher (nqp::istype boxing)
+    /// and Bool::False otherwise. Consumed (and cleared) only by the
+    /// inline map/grep/first fast paths, gated on the block's tail
+    /// statement being a `when`/`default` chain — see
+    /// `resolution_map_grep::tail_is_when_chain`.
+    pub(crate) when_nonmatch_value: Option<Value>,
+```
+
+Add `when_nonmatch_value: None,` to both struct initializers: next to
+`when_matched: false,` at `src/runtime/runtime_init.rs:1871` and
+`src/runtime/runtime_thread.rs:459`. (Pattern precedent: the
+`pub(crate) state_scope_id` field, mod.rs:2143, set directly on `vm` by
+the same fast paths.)
+
+**Step 2 — record the value in `exec_when_op`.**
+`src/vm/vm_given_when_ops.rs`: the function ends (lines 381-411) as
+`if matches { ... } ; *ip = end; Ok(())`. Give the `if` an `else` so the
+marker is set ONLY on the non-match path (not on match+`proceed`):
+
+```rust
+        if matches {
+            /* ... existing body unchanged ... */
+        } else {
+            // A failed `when` evaluates to the falsy result of its test
+            // (control.rakudoc: "the block is not abandoned since the
+            // comparison is false"). Rakudo boxes a type-object matcher's
+            // nqp::istype result as Int 0; everything else is Bool::False.
+            // Nothing is pushed (stack discipline unchanged); the inline
+            // map/grep/first fast paths read this to distinguish "tail
+            // when matched nothing" from "no value produced".
+            self.when_nonmatch_value = Some(if cond_val.is_package_value() {
+                Value::int(0)
+            } else {
+                Value::FALSE
+            });
+        }
+        *ip = end;
+        Ok(())
+```
+
+`cond_val` is the local popped at the top of the function and is still
+live. `is_package_value()` (`src/value/view.rs:634`) is the tag probe for
+`ValueView::Package` type objects; `when Int:D` parses as
+`BareWord("Int:D")` and evaluates to a Package value too (the smartmatch
+`(_, ValueView::Package(type_name))` arm at
+`src/runtime/seq_helpers/smart_match.rs:1411` parses the smiley suffix
+off the package name, so the representation is settled). Enum values are
+not Package values, so row 19's False comes out right. Do NOT touch
+`exec_default_op` (a `default` has no non-match path).
+
+**Step 3 — tail predicate helper.**
+In `src/runtime/resolution_map_grep.rs`, after
+`normalize_tail_stmt_for_value` (line 162), add:
+
+```rust
+/// Whether the body's last non-`SetLine` statement is a `when`/`default`
+/// — i.e. the block is a bare when-chain in tail position. When such a
+/// block matches NO branch, it evaluates to the failed test's falsy
+/// value (`Interpreter::when_nonmatch_value`), NOT to the topic: the
+/// topic fallback exists only to reflect a possibly-mutated `$_` for rw
+/// semantics and must not fire for a when-tail block.
+pub(super) fn tail_is_when_chain(body: &[crate::ast::Stmt]) -> bool {
+    use crate::ast::Stmt;
+    body.iter()
+        .rev()
+        .find(|s| !matches!(s, Stmt::SetLine(_)))
+        .is_some_and(|s| matches!(s, Stmt::When { .. } | Stmt::Default(_)))
+}
+```
+
+**Step 4 — the four sites.** At each site, right after
+`let (code, compiled_fns) = compiler.compile(&normalized_body);`
+(map_grep.rs:356 and 662; map_grep_rw.rs:150 and 414), add:
+
+```rust
+let tail_is_when = tail_is_when_chain(&normalized_body);
+```
+
+(in the rw file: `super::resolution_map_grep::tail_is_when_chain(...)`,
+same qualification style as its `normalize_tail_stmt_for_value` call).
+
+Per iteration, clear the marker so a value recorded by an unrelated
+`when` (a nested `given` in a previous iteration, an enclosing chain)
+cannot leak in — insert `vm.when_nonmatch_value = None;` immediately
+before each `let saved_when_matched = vm.when_matched();` /
+`match vm.run_reuse(...)` (map_grep.rs:459, map_grep.rs:722,
+map_grep_rw.rs:268, map_grep_rw.rs:533; site B has no
+saved_when_matched-free spot issues — put it just above line 722).
+
+Then change each `Ok(())` value computation from
+
+```rust
+let val = vm
+    .last_stack_value()
+    .cloned()
+    .or_else(|| vm.env().get("_").cloned())
+    .unwrap_or(Value::NIL);
+```
+
+to
+
+```rust
+let val = vm
+    .last_stack_value()
+    .cloned()
+    .or_else(|| tail_is_when.then(|| vm.when_nonmatch_value.take().unwrap_or(Value::FALSE)))
+    .or_else(|| vm.env().get("_").cloned())
+    .unwrap_or(Value::NIL);
+```
+
+(sites B and D bind the variable as `pred` instead of `val`; edit
+identically at map_grep.rs:462-466, map_grep.rs:725-729,
+map_grep_rw.rs:271-275, map_grep_rw.rs:536-540). The
+`unwrap_or(Value::FALSE)` inside covers the only way to reach Ok(()) with
+an empty stack, a when tail, and no marker: a MATCHED tail `when` whose
+body `proceed`s off the end of the block — the shape where Rakudo itself
+returns VMNull garbage (row 30), so a defined `False` is the sane choice.
+The rw writeback closures / `topic_source_key` reads at these sites are
+NOT touched — they run independently of the value computation, so
+`<->`, `.=map`, and `$_`-mutation writeback are structurally unaffected.
+
+**Step 5 — tests** (see test plan below), then `cargo fmt`,
+`cargo clippy -- -D warnings`, `make test`, targeted roast files, PR per
+the normal workflow.
+
+### Test plan
+
+`t/when-only-block-nonmatch-value.t` (new; `.join` is used deliberately —
+it distinguishes the flavors, since `0.Str` is `"0"` and `False.Str` is
+`"False"`):
+
+```raku
+use Test;
+
+plan 11;
+
+# Rakudo rule: a block whose tail when-chain matches nothing evaluates to
+# the failed test's falsy value — Int 0 for a type-object matcher,
+# Bool::False otherwise. Never the topic, never Nil/Empty.
+
+is (1, "a", 2).map({ when Int { "int" } }).join(","), "int,0,int",
+    'map: non-matching item yields Int 0 for a type matcher';
+
+is (1..5).map({ when 2 { "two" } }).join(","), "False,two,False,False,False",
+    'map: non-matching item yields False for a value matcher';
+
+is (1, "a", 2, "b").grep({ when Int { True } }).join(","), "1,2",
+    'grep: when-only block filters items matching no branch';
+
+is (1..5).grep({ when 2 { True } }).join(","), "2",
+    'grep: value-matcher when-only block filters too';
+
+nok (1, 2, 3).first({ when 5 { True } }).defined,
+    'first: a when-only predicate matching nothing finds nothing';
+
+is (1, "a").map({ when Int { "int" }; default { "other" } }).join(","), "int,other",
+    'map: a default branch supplies the non-match value instead';
+
+is (2, 3).map({ my $x = 42; when 2 { "two" } }).join(","), "two,False",
+    'map: a statement before the tail when does not change the rule';
+
+is (2, 3).map({ when 2 { "two" }; "after" }).join(","), "two,after",
+    'map: a when followed by another statement falls through to it';
+
+{
+    my @out;
+    for 1..4 { when 2 { @out.push("two") } }
+    is @out.join(","), "two", 'for: when-only loop body still fires only on the match';
+}
+
+{
+    my @a = (1, 2, 3);
+    @a .= map({ when Int { $_ * 10 } });
+    is @a.join(","), "10,20,30", 'rw .=map with a matching when still writes back';
+}
+
+todo "direct block call goes through the closure-call fallback, not the map/grep fast path; needs the general exec_when_op fix (see follow-up)";
+is-deeply { when 2 { "two" } }(3), False,
+    'direct call: non-matching when-only block evaluates to False';
+
+done-testing;
+```
+
+Expected-output cross-checks (all verified against raku on 2026-08-10):
+rows 1-8 of the plan correspond to probe rows 3, 1, 5, 4, 6, 21, 25, 24.
+
+### Regression hazards — run these after the change
+
+`t/` (all touch when-in-block or the same fast paths):
+
+- `t/map-when-succeed.t` — the sibling succeed-signal fix's pin; its 5
+  tests all go through the same four Ok/succeed arms. Test 3
+  (`when Int { "int" }; default { "other" }`) and test 4 (rw `.=map`)
+  are the closest to this change.
+- `t/proceed-succeed.t`, `t/when-succeed-innermost-block.t`,
+  `t/when-block-value-not-sunk.t` (sink-warning analysis — compiler
+  untouched, but it pins when-block value semantics),
+  `t/given-when-tail-assign-value.t`, `t/given-when-tail-if-value.t`,
+  `t/when-value-through-block-local.t`.
+- rw/writeback pins: `t/eager-map-grep-captured-writeback-coherence.t`,
+  `t/for-multiparam-copy-rw.t`, `t/method-rw-param-writeback-coherence.t`,
+  plus the full `grep -rl "<->" t/` set.
+- `t/whatever-map-topic.t` (outer-topic binding in map blocks — probe
+  row 27's shape).
+
+Whitelisted roast (run with `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu'`):
+
+- `roast/S04-statements/when.t` (96 lines, whitelisted)
+- `roast/S04-statements/given.t` (whitelisted)
+
+then let CI's full `make roast` be the comprehensive net.
+
+Known cosmetic divergence accepted: probe row 27/28's pointy-with-param
+shape (`-> $x { when 2 ... }` testing the outer `Any` topic) yields
+False-flavored values in mutsu where Rakudo shows 0 — an undefined-topic
+Rakudo artifact on a pathological shape; both are falsy.
+
+### Follow-up (separate ticket when implementing)
+
+The same non-match value is still wrong OUTSIDE map/grep: a direct block
+call gives `Nil`, `do { when ... }` gives `Any`, and a bare
+`given`/`when` gives `Nil`, where raku gives `False`/`0` (probe rows 7,
+31, 32). The correct general fix is to make `exec_when_op` deliver the
+falsy value everywhere (e.g. push it on the stack on non-match), which
+requires a stack-hygiene sweep: `compile_unit:2679`'s after-when `Pop`
+becomes load-bearing, `compile_block_inline` needs the same non-last
+`Pop` plus suppression of its trailing `LoadNil`
+(helpers_block_inline.rs:387) after a when tail, and loop bodies must not
+accumulate one value per non-matching iteration. File it as
+`todo/tickets/when-nonmatch-value-outside-map-grep.md` (the probe rows
+above are its repro) when this ticket's fix lands; the
+`when_nonmatch_value` marker added here is a stepping stone it can reuse.


### PR DESCRIPTION
Four `todo/tickets/` files that previously lacked a root cause or a settled spec now carry a `## Deep-dive investigation (2026-08-10)` section with confirmed root cause, a step-by-step fix plan, an inline test file, and a regression list — detailed enough for a mid-tier agent to implement without further investigation.

- **s17-supply-syntax-burns-600-cpu-seconds** — profiled with perf: no poll loop spins; the burn is thousands of leaked supply act-loop worker threads. `Tap.close` cannot tear down the pooled `run_supply_act_loop` driving a channel-backed `Supply.interval` source (measured 3379 live threads at 956% CPU after all taps were closed). Fix plan: closable supply channel (`Arc<AtomicBool>`), a close registry wired into both Tap-handle sites, bounded `recv_timeout` in the act loop.
- **same-role-composed-twice-multi-dispatch-picks-one-candidate** — multi dispatch exonerated (gdb-verified: both substituted candidates survive and are selected correctly). The real bug is the flat per-class `class_role_param_bindings` map: each composition overwrites `T`, so method bodies read the last composition's value. Fix plan: per-candidate `role_param_bindings` on `MethodDef`, preferred over the class map at injection time. ADR-0019 interaction checked: no conflict.
- **when-only-block-nonmatch-value-wrong** — 33-probe oracle matrix settles the spec: a non-matching `when` evaluates to the falsy result of its own condition test (`False` for value matchers, `0` for type-object matchers), never Empty/Nil/topic. Mechanism chosen (tail-gate + runtime non-match marker) keeps the rw/`.=map` writeback fallback untouched.
- **sinking-a-try-blocks-discarded-value-escapes-the-try** — found stale: the motivating `advent2009-day20.t` failure was fixed by #6115, and a ~40-cell probe matrix shows mutsu's SinkPop-outside-try placement is rakudo-conformant. Plan: add the pin test, close the ticket to `news/`, hand residual divergences to the deferred-seq deep ticket.

Docs-only — heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)