### PR TITLE
docs(todo): deep-dive four more hard tickets down to implementable plans

### DIFF
--- a/todo/tickets/named-capture-absent-from-current-match-leaks-stale-value.md
+++ b/todo/tickets/named-capture-absent-from-current-match-leaks-stale-value.md
@@ -59,3 +59,340 @@ still be reachable when building the new one).
 Not measured; likely S-M once the actual lookup site is found, but requires
 tracing the `$/`-installation path fresh (not touched by the ticket that
 found this).
+
+## Deep-dive investigation (2026-08-10)
+
+Root cause confirmed. The ticket's guess ("a `$/`-adjacent lookup falls back
+to a broader/older store") is right in spirit but the mechanism is the
+opposite direction: the stale value is not a *fallback*, it *shadows* the
+correct `$/`-based lookup. Everything below was verified on current `main`
+(52f217429) against system `raku`.
+
+### Confirmed storage model
+
+mutsu keeps **three parallel stores** for match state, all in the
+interpreter's single dynamic env (NOT per-frame; see the scoping note below):
+
+1. **`$/`** = env key `"/"`. Installed (as a Match instance, a List for
+   `:g`/`:ov`/`:ex`, or `Value::NIL` on failure) by every top-level match
+   path.
+2. **Positional captures** = env keys `"0"`, `"1"`, ... . `$0` parses as
+   plain `Expr::Var("0")` (verified via `--dump-ast`), i.e. an ordinary env
+   read with **no** `$/` fallback. That is why the install sites *Nil-out*
+   stale numeric keys rather than removing them.
+3. **Named captures** = env keys `"<name>"` (angle brackets included in the
+   key). `$<x>` parses as `Expr::CaptureVar("x")`
+   (`src/parser/primary/var/scalar.rs:211`), compiles via
+   `compile_expr_capture_var` (`src/compiler/expr_data.rs:89-103`) to
+   `OpCode::GetCaptureVar` with the string constant `"<x>"`.
+
+**Lookup site** — `exec_get_capture_var_op`,
+`src/vm/vm_misc_codevar.rs:15-45`:
+
+- First tries `self.env().get("<x>")` — if the key is present (any value),
+  that wins.
+- Only if the key is **absent** does it fall back to reading `$/` (local
+  slot `"/"` first, then env `"/"`) and doing an `AT-KEY` lookup on it,
+  defaulting to `Value::NIL`.
+
+The env-first order is deliberate and load-bearing: mid-match code blocks
+(`/ $<x>=[a] { say ~$<x> } b /`) see `<x>` via incremental deposits from
+`src/runtime/regex/regex_eval_repeat.rs:367` and `:652` before the final
+`$/` is installed, and grammar action methods rely on the local-slot-`"/"`
+fallback surviving nested regex ops (see the comment in
+`vm_misc_codevar.rs:20-26`, pinned by `t/capture-var-topic-slot.t`). So the
+per-name store cannot simply be deleted (fix shape (a) is out).
+
+**Deposit / `$/`-install sites** (top-level, i.e. the ones that persist
+after the match):
+
+- Plain `~~ /re/` (the ticket repro): `smart_match_inner` single-regex arm,
+  `src/runtime/seq_helpers/smart_match.rs:864-988` — resets stale numeric
+  keys at :889-900, deposits named keys at :976-983, installs `"/"` at
+  :984. **No stale `<name>` purge.**
+- `~~ &token` (named token RHS): same file, arm at :411-485 — deposits
+  numerics at :441-444, `"/"` at :455, named at :456-471. **No numeric
+  reset and no `<name>` purge.**
+- `apply_single_regex_captures`,
+  `src/runtime/seq_helpers/regex_captures.rs:36-130` (used by `:nth`, `:c`,
+  `:pos`, P5 single match, ...) — installs `"/"` at :100, resets numerics at
+  :102-111, deposits named at :123-129. **No `<name>` purge.**
+- `apply_multi_regex_captures`, same file :278-313 (`:g`/`:ov`/`:ex`) —
+  installs `"/"` list at :305, sets numerics from the first match at
+  :306-312. **No numeric reset and no `<name>` purge.**
+- `.match` method: `dispatch_match_method`,
+  `src/runtime/methods_match_dispatch.rs` — multi-match early install at
+  :190, single-match deposits at :215-229. **No resets at all.**
+- `s///` (VM): `exec_subst_op` (`src/vm/vm_subst_exec.rs:7`) and
+  `exec_non_destructive_subst_op` (`:290`) install `"/"` at ~20 sites in
+  that file (:57, :239, :341, ...); the native fast path is
+  `try_native_subst` / `native_subst_regex` in `src/vm/vm_native_subst.rs`
+  (:130, :179, :183). **No `<name>` purge anywhere.**
+- `Grammar.parse`: `dispatch_package_parse`,
+  `src/runtime/methods_grammar.rs:594-601` — deposits named at :596-599,
+  installs `"/"` at :601. **No `<name>` purge.**
+- **Failure path**: `clear_match_state`,
+  `src/runtime/seq_helpers/regex_captures.rs:7-18` — Nils `"/"` and all
+  numeric keys. **Does NOT touch `<name>` keys.**
+
+Sites that are already clean and must NOT be touched:
+
+- Grammar *action* machinery (`methods_grammar.rs:875-1012` and
+  `:1289-1483`) snapshots all current `<...>` keys, `remove_sym`s them,
+  deposits its own, and restores the snapshot afterwards — self-cleaning.
+- Mid-match incremental deposits (`regex_eval_repeat.rs:367/:652`) and the
+  fresh eval env built by `make_regex_eval_env`
+  (`src/runtime/regex/regex_resolve.rs:529-575`) — in-match machinery, out
+  of scope.
+- `eval_subst_replacement_cased` (`src/runtime/methods_string_subst_repl.rs:10`)
+  clones and restores the whole env around the replacement block (:41), so
+  its deposits do not persist — not a leak source.
+
+**So the bug is:** numeric keys are reset on every install, `<name>` keys
+never are, and a stale `<name>` env entry shadows the `AT-KEY`-on-`$/`
+fallback in `GetCaptureVar` forever after.
+
+### Verified behavior table (raku vs mutsu main, 2026-08-10)
+
+| Probe | raku | mutsu main |
+|---|---|---|
+| `"xb" ~~ /$<x>=<[cdx]> "b"/;` then `"bb" ~~ /"b" "b"/;` → `$<x>.WHAT` | `Nil` | **`(Match)` (stale)** |
+| same, `$/.hash` after 2nd match | empty `Map` | empty `{}` (already correct — proves `$<x>` does not read `$/`) |
+| `"ab" ~~ /a(b)/;` then `"cd" ~~ /cd/;` → `$0.raku` | `Nil` | `Nil` (numerics already reset — not affected) |
+| `$<x>` / `$0` before any match ever ran | `Nil` / `Nil` | `Nil` / `Nil` (correct) |
+| `"ab" ~~ /$<x>=[ab]/;` then **failed** `"zz" ~~ /q/;` → `$<x>.WHAT`, `$/.WHAT` | `Nil`, `Nil` | **`(Match)` (stale)**, `Nil` |
+| stale `$<x>`, then `"cd".match(/cd/)` | `Nil` | **`(Match)`** |
+| stale `$<x>`, then `$s ~~ s/c/X/` | `Nil` | **`(Match)`** |
+| stale `$<x>`, then `"cd" ~~ &t` (token RHS) | `Nil` | **`(Match)`** |
+| stale `$<x>`, then `G.parse("cd")` | `Nil` | **`(Match)`** |
+| stale `$<x>`, then `"cd" ~~ m:g/cd/` | `Failure` (list `$/`) | **`(Match)`** |
+
+**Failed-match rule (pinned by measurement):** rakudo (6.d, this machine)
+sets `$/` to `Nil` after a failed `~~` — it does **not** preserve the last
+successful match's `$/`. mutsu's `clear_match_state` already matches that
+for `"/"` and numerics; only the `<name>` keys leak.
+
+**Scoping note:** in raku, `$/` is a fresh per-routine lexical (`sub f {
+say $/.WHAT }` after a file-scope match prints `Nil`; a match inside a sub
+does not touch the caller's `$/`). In mutsu it is a single dynamic env slot
+visible everywhere (the same probe prints `(Match)`). That divergence is
+**out of scope** for this ticket — the fix below operates on the single
+env store, and the ticket's sub-call repro (`m1(); m2(); say $<x>.WHAT`)
+converges to `Nil` under it in both implementations.
+
+### Chosen fix — (b): purge stale `<name>` env keys at every top-level `$/` install
+
+Fix shape (a) (route `$<name>` exclusively through `$/`) is rejected: the
+env-first order in `GetCaptureVar` is required by mid-match code blocks and
+by the action-method nested-match scenario documented in
+`vm_misc_codevar.rs:20-26` / `t/capture-var-topic-slot.t`. Fix (b) mirrors
+the numeric-key reset that already exists at the install sites.
+
+**Critical detail — purge means `remove_sym`, NOT insert-Nil.**
+`exec_get_capture_var_op` short-circuits on a *present* key even if its
+value is Nil; a Nil entry would therefore shadow the local-slot-`"/"`
+fallback that action methods depend on (breaking
+`t/capture-var-topic-slot.t`). Numeric keys keep their existing Nil-insert
+treatment (`$0` is a plain `Var` read with no fallback to shadow).
+
+Step-by-step:
+
+1. **Add one helper** in
+   `src/runtime/seq_helpers/regex_captures.rs` (inside `impl Interpreter`),
+   declared `pub(crate)` so both `crate::runtime` and `crate::vm` call it:
+
+   ```rust
+   /// Reset capture env vars left over from a previous match: numeric keys
+   /// (`0`, `1`, ...) are set to Nil ($0 is a plain env `Var` read), and
+   /// named-capture keys (`<name>`) are REMOVED so `$<name>`
+   /// (OpCode::GetCaptureVar) falls through to the current `$/` AT-KEY
+   /// lookup instead of seeing a stale entry. Removal, not Nil-ing, is
+   /// load-bearing: a present-but-Nil entry would shadow the local-slot
+   /// `$/` fallback action methods rely on (t/capture-var-topic-slot.t).
+   pub(crate) fn reset_capture_env_vars(&mut self) {
+       let numeric_keys: Vec<Symbol> = self
+           .env
+           .keys()
+           .filter(|k| k.with_str(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())))
+           .copied()
+           .collect();
+       for key in numeric_keys {
+           self.env.insert_sym(key, Value::NIL);
+       }
+       let angle_keys: Vec<Symbol> = self
+           .env
+           .keys()
+           .filter(|k| k.with_str(|s| s.len() > 2 && s.starts_with('<') && s.ends_with('>')))
+           .copied()
+           .collect();
+       for key in angle_keys {
+           self.env.remove_sym(key);
+       }
+   }
+   ```
+
+   (`Symbol`, `with_str`, `insert_sym`, `remove_sym` are all already used in
+   this file / in `methods_grammar.rs:884`.)
+
+2. **Call it at each install site**, replacing the duplicated numeric-reset
+   blocks where they exist:
+   - `clear_match_state` (`regex_captures.rs:7-18`): body becomes
+     `self.env.insert("/".to_string(), Value::NIL); self.reset_capture_env_vars();`
+     (this also fixes the failed-match leak; `clear_multi_match_state`
+     inherits it).
+   - `apply_single_regex_captures`: replace the numeric-reset block at
+     `regex_captures.rs:102-111` with `self.reset_capture_env_vars();`
+     (position unchanged: after the `"/"` install at :100, before the
+     deposits at :113-129).
+   - `apply_multi_regex_captures` (`regex_captures.rs:278`): add
+     `self.reset_capture_env_vars();` immediately before the `"/"` install
+     at :305.
+   - `smart_match_inner` single-regex arm: replace the stale-numeric block
+     at `smart_match.rs:889-900` with `self.reset_capture_env_vars();`.
+   - `smart_match_inner` token-RHS arm: add `self.reset_capture_env_vars();`
+     right after `if let Some(mut captures) = self.regex_match_with_captures(...)`
+     opens at `smart_match.rs:439`, before the positional loop at :441.
+   - `dispatch_match_method` (`methods_match_dispatch.rs`): add the call
+     (a) before the multi-match `"/"` install at :190 and (b) right after
+     `if let Some(mut captures) = captures` opens at :202.
+   - `exec_subst_op` (`vm_subst_exec.rs:7`) and
+     `exec_non_destructive_subst_op` (`vm_subst_exec.rs:290`): add
+     `self.reset_capture_env_vars();` once near the top of each function
+     (after the pattern/replacement constants are read, before any
+     matching). One entry-point call covers all ~20 `"/"` install branches
+     in that file, including the failure branches, matching raku's
+     clear-on-failure rule.
+   - `try_native_subst` (`vm_native_subst.rs:29`): same — one call at
+     function entry (this path bypasses `exec_subst_op`).
+   - `dispatch_package_parse` (`methods_grammar.rs`): add the call
+     immediately before the named-deposit loop at :594-599.
+   - Note for vm files: use `self.reset_capture_env_vars()` as-is — the
+     helper is on `Interpreter`, shared by both module trees; inside the
+     helper use the direct `self.env` field exactly as the existing code in
+     `regex_captures.rs` does.
+
+3. **Do NOT touch**: the grammar action snapshot/restore machinery
+   (`methods_grammar.rs:875-1012`, `:1289-1483`), the mid-match deposit
+   sites (`regex_eval_repeat.rs:367/:652`), `make_regex_eval_env`
+   (`regex_resolve.rs:529`), `eval_subst_replacement_cased`
+   (env-restored, not a leak), and `exec_get_capture_var_op` itself (the
+   read path is correct once stale keys are gone).
+
+4. **Rebuild and re-run the probes** (all previously printed `(Match)` for
+   `$<x>`; all must now print `Nil`):
+
+   ```
+   timeout 30 target/debug/mutsu -e '"ab" ~~ / $<x>=[ab] /; "cd" ~~ /cd/; say $<x>.WHAT'
+   timeout 30 target/debug/mutsu -e '"ab" ~~ / $<x>=[ab] /; "zz" ~~ /q/; say $<x>.WHAT'
+   timeout 30 target/debug/mutsu -e '"ab" ~~ / $<x>=[ab] /; "cd".match(/cd/); say $<x>.WHAT'
+   timeout 30 target/debug/mutsu -e '"ab" ~~ / $<x>=[ab] /; my $s = "cd"; $s ~~ s/c/X/; say $<x>.WHAT'
+   timeout 30 target/debug/mutsu -e 'my token t { cd }; "ab" ~~ / $<x>=[ab] /; "cd" ~~ &t; say $<x>.WHAT'
+   timeout 30 target/debug/mutsu -e 'grammar G { token TOP { cd } }; "ab" ~~ / $<x>=[ab] /; G.parse("cd"); say $<x>.WHAT'
+   timeout 30 target/debug/mutsu -e '"ab" ~~ / $<x>=[ab] /; "cd" ~~ m:g/cd/; say $<x>.WHAT'
+   ```
+
+   If any still leaks, `grep -rn 'insert(format!("<' src/` — every deposit
+   site is enumerable by that pattern — and add the helper call before that
+   site's deposit loop.
+
+5. **Add the regression test** `t/regex-stale-named-capture-cleared.t`
+   (Write tool):
+
+   ```raku
+   use v6;
+   use Test;
+   plan 14;
+
+   # Before any match has ever run.
+   ok $<x> === Nil, 'named capture var is Nil before any match';
+   ok $0 === Nil, 'positional capture var is Nil before any match';
+
+   "xb" ~~ / $<x>=<[cdx]> "b" /;
+   is ~$<x>, 'x', 'named capture set by first match';
+
+   "bb" ~~ / "b" "b" /;
+   ok $<x> === Nil, 'name absent from current pattern reads Nil, not stale value';
+   is $/.hash.elems, 0, '$/.hash is empty after captureless match';
+
+   # A FAILED match clears $/ and named captures (measured rakudo 6.d rule).
+   "xb" ~~ / $<x>=<[cdx]> "b" /;
+   "zz" ~~ / "q" /;
+   ok $<x> === Nil, 'failed match leaves no stale named capture';
+   ok $/ === Nil, 'failed match sets $/ to Nil';
+
+   # Positional analog stays correct.
+   "ab" ~~ / a (b) /;
+   "cd" ~~ / cd /;
+   ok $0 === Nil, 'positional capture cleared by captureless match';
+
+   # Sibling match paths.
+   "xb" ~~ / $<x>=<[cdx]> "b" /;
+   "cd".match(/cd/);
+   ok $<x> === Nil, '.match clears stale named captures';
+
+   "xb" ~~ / $<x>=<[cdx]> "b" /;
+   my $s = "cd";
+   $s ~~ s/c/X/;
+   ok $<x> === Nil, 's/// clears stale named captures';
+
+   my token t { cd }
+   "xb" ~~ / $<x>=<[cdx]> "b" /;
+   "cd" ~~ &t;
+   ok $<x> === Nil, 'token smartmatch clears stale named captures';
+
+   grammar StaleG { token TOP { cd } }
+   "xb" ~~ / $<x>=<[cdx]> "b" /;
+   StaleG.parse("cd");
+   ok $<x> === Nil, 'Grammar.parse clears stale named captures';
+
+   # The ticket's sub-call repro.
+   sub sm1 { "xb" ~~ / $<x>=<[cdx]> "b" / }
+   sub sm2 { "bb" ~~ / "b" "b" / }
+   sm1();
+   sm2();
+   ok $<x> === Nil, 'stale named capture cleared across sub-call matches';
+
+   # :g list-$/ — raku gives a Failure here, mutsu gives Nil after the fix;
+   # !.defined is true for both, and the load-bearing part is "not the
+   # stale Match".
+   "xb" ~~ / $<x>=<[cdx]> "b" /;
+   "cd" ~~ m:g/cd/;
+   ok !$<x>.defined, 'stale named capture not visible after :g match';
+   ```
+
+   Verify with `timeout 30 target/debug/mutsu t/regex-stale-named-capture-cleared.t`
+   (14/14), and sanity-check the same program under `raku` (all pass there
+   today except that raku's per-routine `$/` makes the "before any match"
+   asserts trivially true).
+
+6. **Targeted regressions** before pushing (then let CI run the full
+   roast):
+   - `prove -e target/debug/mutsu t/capture-var-topic-slot.t` — pins the
+     remove-vs-Nil distinction; if this fails, the purge inserted Nil
+     instead of removing, or purged inside the action machinery.
+   - `prove -e target/debug/mutsu t/match-*.t t/regex-*.t t/subst-*.t t/gram*.t`
+     plus the ~56 `t/*.t` files matching `\$<` (grep list them).
+   - Whitelisted roast spot-checks (`MUTSU_FUDGE=1 prove -e
+     'target/release/mutsu' <file>`): `roast/S05-capture/named.t`,
+     `alias.t`, `caps.t`, `subrule.t`, `match-object.t` (+ the `6.d` copy),
+     `roast/S05-match/blocks.t`, `capturing-contexts.t`, `arrayhash.t`,
+     `basics.t`, `make.t`, `roast/S05-grammar/action-stubs.t`, `example.t`,
+     `methods.t` (6.c), `roast/S05-modifier/global.t`, `counted-match.t`,
+     `pos.t`, `continue.t`, `repetition.t`, and `roast/S05-metasyntax/regex.t`
+     if whitelisted. These are the heaviest consumers of `$<...>` /
+     `$/`-install ordering.
+   - `cargo fmt` + `cargo clippy -- -D warnings`, then `make test`.
+
+### Known residues (acceptable, do not chase in this fix)
+
+- `m:g` + absent name: raku returns a `Failure` (AT-KEY on a list `$/`);
+  fixed mutsu returns `Nil`. Closer than the stale Match; exact Failure
+  semantics belong to a Match/List AT-KEY ticket.
+- A code block inside the *second* match (`/"b" { say $<x> } "b"/`) still
+  sees the previous match's `<x>` mid-match, because the purge runs at
+  install/clear time (match end). raku shows `Nil` there (fresh `$/`
+  during the match). Same-family but needs the mid-match eval-env story.
+- `$/` is per-routine lexical in raku, a single dynamic env slot in mutsu
+  (`sub f { say $/.WHAT }` after a file-scope match: raku `Nil`, mutsu
+  `(Match)`). Pre-existing divergence, orthogonal to this fix; worth its
+  own `todo/deep/` file if it ever bites a roast test.

--- a/todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md
+++ b/todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md
@@ -45,3 +45,294 @@ the defining-scope capture for a regex literal (see `b07ee6627` and
 The first half is the closure-capture-lifetime family (the captured env must outlive the frame that
 built the regex, like a `Sub`'s closure), and the second half is capture-namespace plumbing through
 assertion invocation — two different mechanisms that happen to meet in the same construct.
+
+## Deep-dive investigation (2026-08-10)
+
+**Recommendation: split this into two tickets / two PRs.** The two halves have disjoint root causes,
+touch disjoint files, and neither depends on the other. Bug 1 (defining-scope capture) lives in the
+compiler trigger + `Value::RegexCaptured` machinery from `b07ee6627`; bug 2 (capture leak) lives in
+the regex tokenizer/interpolator. The plans below are structured accordingly. Both were re-verified
+on `main` (post-#6174) on 2026-08-10; all raku columns below were produced with the system `raku`
+the same day.
+
+### Bug 1 root cause — the closure capture only fires for *code-bearing* patterns, and is a stale by-value snapshot even then
+
+`b07ee6627` added `Value::RegexCaptured` (`src/value/mod.rs`, `RegexClosure { pattern, scope:
+Arc<HashMap<String, Value>> }`) loaded via `OpCode::LoadRegexClosure`. But the compiler trigger,
+`regex_literal_closure_captures()` at **`src/compiler/expr_helpers.rs:711`**, bails at **line 717**:
+
+```rust
+if !pattern.contains('{') && !pattern.contains(":my ") && !pattern.contains(":let ") {
+    return None;
+}
+```
+
+So `rx/ $word /` (no embedded code) compiles to a plain `LoadConst` — **nothing captures the
+defining scope at all**. To answer the design question directly: for plain interpolation the stored
+regex holds **(b) names resolved against the live env at match time**; for code-bearing patterns it
+holds **(a) a by-value snapshot**. Neither is Raku's semantics (closure over the defining scope's
+*bindings*).
+
+The match-time lookups that then return the wrong/absent value (a stored regex is re-parsed on every
+match, so "parse time" here *is* match time):
+
+- Bare `$name` / `${name}` interpolation: `interpolate_regex_scalars()` at
+  **`src/runtime/regex_parse_modifier.rs:355-360` and `:423-426`** — `self.env.get(name)` on the
+  match-site env; the defining frame is gone, lookup yields `Value::NIL`, and
+  `push_value_as_regex_pattern` (**`regex_parse_modifier.rs:641`**) substitutes `<!>`
+  (never-match) for Nil. Hence the silent match failure in the main repro.
+- `<$var>` assertion: tokenizer at **`src/runtime/regex_parse_core.rs:2521`** —
+  `self.env.get(var_name)`, and the `None` arm throws `X::Undeclared` ("Variable '$pat' is not
+  declared"), which is what the `<$pat>`-flavoured repro dies with.
+- The undeclared-vars pre-check at **`regex_parse_modifier.rs:618`** has the same env dependency.
+
+**The snapshot half is also wrong, proven by probe W5/W6 below**: `install_regex_closure_scope()`
+(**`src/runtime/seq_helpers/smart_match.rs:75-92`**) inserts the *snapshot values* into env for the
+match, shadowing the live (mutated) lexical. Raku evaluates regex-embedded code and interpolation at
+match time against the defining *binding*, so mutation after regex construction must be visible.
+mutsu today fails `my $x = 1; my $re = rx/ abc <?{ $x == 2 }> /; $x = 2; "abc" ~~ $re` (mutsu:
+False, raku: True) — even in the same scope. So bug 1's fix cannot be "widen the trigger" alone;
+the capture must hold **shared cells** (`ContainerRef`), exactly the mechanism closures use
+(`box_captured_lexicals`, `src/vm/vm_register_ops.rs:759`) and exactly what the CLAUDE.md "gain"
+section prescribes. Note `capture_regex_closure()` (**`src/vm/vm_register_ops.rs:29`**) already
+documents "a capture that is already a shared `ContainerRef` cell is kept AS the cell" — the cell
+transport works; what is missing is (i) the widened trigger and (ii) making the mutated captures
+*be* cells.
+
+### Bug 2 root cause — `<$var>` splices the inner pattern's capture groups into the outer capture numbering
+
+The tokenizer's `<$var>` arm at **`src/runtime/regex_parse_core.rs:2519-2596`** resolves the
+variable, extracts the inner regex's **pattern string**, re-parses it, and wraps it as
+`RegexAtom::Group(parsed)` (line 2593). A `Group` is transparent to capture accumulation: the inner
+pattern's `CaptureGroup` atoms (matched at **`src/runtime/regex/regex_match_capture.rs:220`**, which
+pushes a `PosSlot` into the caps the caller merges) and its `named_capture` tokens are numbered/named
+straight into the **outer** match. Raku gives a `<$var>` call its own discarded Match object — no
+positional *or named* leakage (probes W1/W2 below; mutsu leaks both).
+
+There are three leak sites, all in the "value holds a Regex" family:
+
+1. `<$var>` → `RegexAtom::Group` — `regex_parse_core.rs:2590-2596` (the main one).
+2. Bare `$var` / `${name}` interpolation of a Regex value — `push_value_as_regex_pattern`
+   (**`regex_parse_modifier.rs:642-643`**) splices the raw pattern *text* (parens included) into
+   the outer pattern before parsing, so the inner `(\d+)` literally becomes an outer capture group.
+3. `@var` / `<@var>` alternation with Regex elements — text splice at
+   **`regex_parse_modifier.rs:496-505` and `:536-545`**, atom path `array_var_alternation_atom`
+   (**`regex_parse_core.rs:245`**).
+
+### Variant table (raku vs mutsu, 2026-08-10, all reproduced)
+
+| # | Probe | raku | mutsu |
+|---|-------|------|-------|
+| B1 | `sub make { my $word = 'abc'; rx/ $word / }` matched after return | True | **False** |
+| V1 | same scope: `$pat='abc'; $re=rx/$pat/; $pat='zzz'` — match `abc` / `zzz` | False / True (match-time value) | False / True (accidental: live env) |
+| V2 | two calls of `mk($w)` returning `rx/$word/` — each keeps its own | True / True / False | **False / False** / False |
+| V3 | regex per loop iteration `for <one two> -> $w { push rx/$w/ }` | each keeps its iteration | **False / False** |
+| V4 | nested sub, regex stored in hash, matched later | True | **False** |
+| V5 | `<$pat>` form escaping the sub | True | **dies X::Undeclared** |
+| V6 | `<$pat>` + mutation: match-time value wins | False / True | (dies) |
+| W5 | `my $x=1; $re=rx/abc <?{ $x==2 }>/; $x=2` same-scope | True | **False** (stale snapshot) |
+| W6 | code-bearing, mutated before `return` | True | **False** (stale snapshot) |
+| W1 | `<$inner>` where inner has `$<d>=(\d+)`: outer `$/<d>` / `$0` | undef / undef | **｢123｣** / undef |
+| B2 | `<$inner>` where inner has `(\d+)`: outer `$0` | undef | **｢123｣** |
+| W2 | bare `$inner` (Regex value) interpolated: outer `$0` | undef | **｢123｣** |
+| W3 | `<alias=$inner>`: `$/<alias>` / its `[0]` / `$0` | ｢123｣ / ｢123｣ / undef | **undef** / — / undef (separate pre-existing gap) |
+| W4 | `<@pats>` with capturing Regex elements: outer `$0` | undef | **｢123｣** |
+| W7 | `~$m` after `/ 'n=' <$inner7> /` (consumption) | `n=123` | `n=123` (agrees) |
+
+Repro scripts kept the session: `tmp/rx-variants.raku`, `tmp/rx-variants2.raku`.
+
+### Fix plan — bug 1 (PR 1): regex literals capture their defining scope as shared cells
+
+Everything reuses the `b07ee6627` machinery; no new Value variant, no new opcode.
+
+1. **Widen the compiler trigger** — `src/compiler/expr_helpers.rs:717`: delete the code-bearing
+   gate (`if !pattern.contains('{') && … return None;`). Any pattern whose
+   `CompiledCode::regex_interpolated_var_names()` (src/opcode.rs:4880) yields at least one
+   resolvable name now loads through `LoadRegexClosure`. Keep the existing filters (`_`, `/`,
+   all-digit names). The name scanner already skips `$<name>`, `$0`, and twigils (`$*x`) because
+   the char after the sigil must be alphabetic/underscore — verify with a unit test, do not change
+   it.
+2. **Track which captured names are mutated in the defining frame** — in
+   `CompiledCode::finalize`'s free-var analysis (src/opcode.rs, the regex-constants scan around
+   line 5335: `for c in &self.constants { … regex_interpolated_var_names … }`): today a name that
+   IS one of `own`'s locals is simply skipped. Additionally collect those own names into a local
+   `regex_captured_own: HashSet<Symbol>`. After the nested-closure fold has finished growing
+   `self_mutated` (i.e. just before the assignments at src/opcode.rs:5516), store
+   `regex_captured_own ∩ self_mutated` into a **new field**
+   `pub(crate) needs_cell_regex: Vec<Symbol>` on `CompiledCode` (initialize alongside
+   `needs_cell_locals` at :4029/:5517). Do NOT fold into `needs_cell_locals` — that set feeds
+   `box_captured_lexicals`' closure paths and the named-sub decl-site boxing deliberately avoids
+   it (see the over-boxing warning at src/vm/vm_var_assign_set_local.rs:239-242).
+3. **Box at capture time** — in `capture_regex_closure()` (src/vm/vm_register_ops.rs:29): before
+   reading a capture whose sym is in `code.needs_cell_regex` and whose slot is a real local
+   (`slot != NOT_A_LOCAL`), box the slot into a shared cell by calling the existing
+   `box_decl_local_cell(code, slot as usize)` (src/vm/vm_var_assign_local_get.rs:316 — it already
+   applies the correct skips: scalars only, no re-boxing, skip reference-bearing values and
+   type/`where`-constrained scalars, and it mirrors the cell into env). Then read the slot as
+   today — the captured value IS the cell, later frame writes go through it, and the stored regex
+   sees them. Unmutated captures stay cheap by-value snapshots (correct: nothing can change them).
+   A typed/constrained mutated scalar silently stays a snapshot — same accepted limitation as
+   closures; leave a `// TODO` noting it.
+4. **Deref at the `<$var>` consumption site** — `src/runtime/regex_parse_core.rs:2521`: after the
+   env lookup add `.map(|v| v.into_deref())` (the bare-`$name` interpolation path already derefs at
+   regex_parse_modifier.rs:361/:427; the `<$var>` arm does not, and a cell would otherwise
+   stringify). Also add the `or_else(|| self.env.get(&format!("${var_name}")))` fallback the other
+   lookups have, for keying symmetry.
+5. **Audit the install sites** — `install_regex_closure_scope` is already wrapped around `~~`
+   (smart_match.rs:237) and `.match`/`.subst` (methods_dispatch_match.rs:225/:228). Grep for other
+   entry points a *stored* regex value can reach — at minimum the `s///`/`TR///` VM ops in
+   `src/vm/vm_string_regex_ops.rs` and `.split`/`.comb` with a regex argument — and wrap them with
+   `with_regex_closure_scope` (smart_match.rs:122) where the regex flows in as a runtime value.
+   (They were not needed for code-bearing patterns' tests, but plain interpolation makes far more
+   regexes carry scopes.)
+6. **Do not touch** `install_regex_closure_scope`'s shadowing order: with cells, the installed
+   binding and the live frame binding are the *same cell*, which is what makes W5/V1 come out
+   right; the existing "rebound bindings survive uninstall" logic (smart_match.rs:99-117) is
+   unaffected.
+
+Expected behavioral deltas beyond the repro: V2/V3/V4/V5/W5/W6 all flip to raku's column. One
+deliberate semantic change: a regex interpolating `$x` matched in a scope with a *different* live
+`$x` now uses the defining scope's binding (raku-correct; previously match-site env won). Perf
+note: every interpolating regex literal now allocates a small scope map at load and pays an env
+install/uninstall per match — watch the bench CI row, but numeric benches (fib etc.) contain no
+regexes and are unaffected.
+
+### Fix plan — bug 2 (PR 2): `<$var>`-family calls are capture-isolated
+
+Mechanism choice: **parse-time capture stripping**, not a new `RegexAtom` variant. The engine has
+many `match atom` sites (regex_match_atom.rs, regex_match_atom_simple.rs, regex_match_capture.rs,
+regex_casefold.rs, regex_helpers.rs, plus zero-width/count classifiers) and a new variant would have
+to be threaded through all of them; a recursive pattern transform needs one function and no engine
+changes. The cost is one accepted edge: an inner-pattern backreference to an inner capture
+(`rx/(\w)$0/` used via `<$var>`) stops working — rare, note it with a `// TODO` (fixing it properly
+needs match-time isolation, i.e. the atom-variant design).
+
+1. **Add `strip_captures_pattern(&RegexPattern) -> RegexPattern`** in
+   `src/runtime/regex/regex_helpers.rs`, modeled byte-for-byte on the `strip_marks_pattern` /
+   `strip_marks_token` / `strip_marks_atom` traversal at :503-:590 (it already recurses through
+   every composite atom: Group, CaptureGroup, Alternation, SequentialAlternation, Conjunction,
+   Lookaround, GoalMatch, and the token `separator`). The transform: `CaptureGroup(p)` →
+   `Group(strip(p))`; on every token clear `named_capture`, `secondary_named_capture`,
+   `hash_capture`, and `force_list_capture` (struct fields at src/runtime/regex_types.rs:333-356);
+   recurse everywhere else.
+2. **Apply at the `<$var>` arm** — `regex_parse_core.rs:2590-2596`: wrap the parse result:
+   `RegexAtom::Group(strip_captures_pattern(&parsed))`. This fixes B2 and W1 (named leak) at once.
+   W3 (`<alias=$inner>` should expose the whole match under `$<alias>` *with* inner subcaptures) is
+   a separate pre-existing gap — mutsu yields undef there today, and stripping does not change
+   that; leave it out of scope with a note.
+3. **Bare `$var` / `${name}` holding a Regex** — in `interpolate_regex_scalars`
+   (regex_parse_modifier.rs, the two `push_value_as_regex_pattern` calls at :363 and :429): when
+   `value.view()` is `Regex`/`RegexWithAdverbs`, emit the text `<$name>` instead of splicing the
+   pattern body. The tokenizer's `<$var>` arm (fixed in step 2) then handles it — same env, same
+   match invocation, so the lookup re-resolves identically, and the W7 consumption semantics are
+   preserved. Non-regex values keep the existing escaped-literal splice. Do NOT touch the
+   bound-params variant `interpolate_bound_regex_scalars` (regex_interpolate.rs:288) — its values
+   live in a binding overlay the tokenizer cannot see; audit it separately if a leak is ever
+   reproduced through it.
+4. **Array alternation** — `array_var_alternation_atom` (regex_parse_core.rs:245): apply
+   `strip_captures_pattern` to each element parsed from a Regex value. For the *text* alternation
+   paths (regex_parse_modifier.rs:496-505 and :536-545): when any element is a Regex value, emit
+   `<@name>` (the tokenizer path) instead of the textual alternation; string-only arrays keep the
+   current text path unchanged. This fixes W4.
+5. The Junction arm of `push_value_as_regex_pattern` (:644-657) has the same theoretical leak for
+   `any(rx/(a)/, …)`; out of scope — note with a TODO.
+6. **Known limitation to document in the PR**: a `RegexCaptured` inner value reached via `<$var>`
+   loses its *own* captured closure scope (only the pattern string is extracted at
+   regex_parse_core.rs:2546-2549). After bug 1 lands, an escaped-and-nested regex may still miss
+   its lexicals; fixing that needs the inner scope installed around the Group match (the
+   atom-variant design). Leave a `// TODO` at the extraction site.
+
+### Inline test file (add as `t/regex-stored-closure-scope.t` in PR 1, extend `plan` and add the bug-2 block in PR 2)
+
+```raku
+use v6;
+use Test;
+
+plan 17;
+
+# --- Bug 1: a stored regex keeps its defining scope ---------------------------
+
+sub make() { my $word = 'abc'; return rx/ $word /; }
+my $r = make();
+ok ("xx abc yy" ~~ $r).defined, 'escaped regex still resolves its lexical (main repro)';
+
+sub mk($w) { my $word = $w; return rx/ $word /; }
+my $ra = mk('aaa');
+my $rb = mk('bbb');
+ok ("aaa" ~~ $ra).defined, 'first call keeps its own value';
+ok ("bbb" ~~ $rb).defined, 'second call keeps its own value';
+nok ("bbb" ~~ $ra).defined, 'calls do not share a frame (snapshot-vs-shared-frame discriminator)';
+
+my @res;
+for <one two> -> $w { @res.push: rx/ $w /; }
+ok ("one" ~~ @res[0]).defined, 'loop iteration 0 keeps its value';
+ok ("two" ~~ @res[1]).defined, 'loop iteration 1 keeps its value';
+nok ("two" ~~ @res[0]).defined, 'iterations do not share';
+
+my %h;
+sub outer { my $x = 'qq'; sub inner { return rx/ $x /; }; %h<r> = inner(); }
+outer();
+ok ("a qq b" ~~ %h<r>).defined, 'nested sub, stored in a hash, matched later';
+
+sub mk5 { my $pat = 'ab'; return rx/ <$pat> /; }
+ok ("xaby" ~~ mk5()).defined, '<$var> assertion form survives the frame';
+
+# Match-time evaluation: mutation after construction is visible (raku-verified).
+{
+    my $pat = 'abc';
+    my $re = rx/ $pat /;
+    $pat = 'zzz';
+    nok ("abc" ~~ $re).defined, 'interpolation sees the mutated value, not a snapshot (1)';
+    ok  ("zzz" ~~ $re).defined, 'interpolation sees the mutated value, not a snapshot (2)';
+}
+
+# The code-bearing capture must be a live cell, not a stale snapshot (W5/W6).
+{
+    my $x = 1;
+    my $re = rx/ abc <?{ $x == 2 }> /;
+    $x = 2;
+    ok ("abc" ~~ $re).defined, 'embedded code sees a same-scope mutation after construction';
+}
+sub mk6 { my $w = 'no'; my $r2 = rx/ abc <?{ $w eq 'yes' }> /; $w = 'yes'; return $r2; }
+ok ("abc" ~~ mk6()).defined, 'embedded code sees a mutation made before the frame died';
+
+# --- Bug 2: <$var>-family calls are capture-isolated (raku-verified) ----------
+
+{
+    my $inner = rx/ $<d>=(\d+) /;
+    my $m = "n=123" ~~ / 'n=' <$inner> /;
+    is ~$m, 'n=123', '<$inner> still consumes its text';
+    nok $m[0].defined,   '<$var> does not leak positional captures into $/';
+    nok $m<d>.defined,   '<$var> does not leak named captures into $/';
+}
+{
+    my $inner2 = rx/ (\d+) /;
+    "n=123" ~~ / 'n=' $inner2 /;
+    nok $0.defined, 'bare $var regex interpolation does not leak captures either';
+}
+```
+
+(A `<@pats>`-leak assertion — `my @pats = rx/(\d+)/, rx/(x+)/; "n=123" ~~ / 'n=' <@pats> /;
+nok $0.defined` — belongs in the PR-2 file too; bump the plan accordingly.)
+
+### Regression hazards
+
+- **`t/regex-literal-is-a-closure.t`** — the 9-subtest pin for `b07ee6627`. Subtest 2 ("the
+  defining scope wins over the match-site lexical") is the one a careless install-order change
+  breaks; with cells it must still pass (the cell IS the defining binding). Subtests 4/5 pin that
+  embedded-code writes survive uninstall.
+- **`t/gate-b-regex-interp-env-sync.t`**, **`t/regex-array-var-lookahead.t`**,
+  **`t/match-subst-named-regex-arg.t`**, **`t/regex-alias-subrule-captures.t`** — interpolation /
+  env-sync / alias-capture behavior adjacent to both fixes.
+- Whitelisted roast spot-checks (run with `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu'`):
+  **`roast/S05-interpolation/regex-in-variable.t`** and **`roast/S05-interpolation/lexicals.t`**
+  (exactly this feature area — they pass today and must stay green),
+  **`roast/S05-capture/subrule.t`** (capture-through-assertion semantics, sensitive to the strip
+  transform), **`roast/S05-metasyntax/regex.t`** (broad `<...>` metasyntax coverage). Also worth a
+  look: `roast/S05-capture/caps.t`.
+- Bug 1 step 2 touches `CompiledCode::finalize`'s free-var analysis — the env-writeback /
+  ADR-0018 family is historically sensitive to it (see MEMORY "env-writeback campaign"); keep the
+  change purely additive (a new set, no changes to `free`/`captured_mutated` membership).
+- Bug 2 step 3 changes what text the outer pattern contains; anything that caches by pattern
+  string (`regex_token_resolve.rs` with-args cache) should be sanity-checked with a grammar-heavy
+  file, e.g. `roast/S05-grammar/parse_and_parsefile.t`.

--- a/todo/tickets/subtest-recompiles-block-from-ast-every-call.md
+++ b/todo/tickets/subtest-recompiles-block-from-ast-every-call.md
@@ -52,3 +52,170 @@ Wrapping the whole file's `subtest` block in a loop multiplies the recompile cos
 
 Primarily compile-time/CPU overhead inside test files (which call `subtest` heavily) and the
 bundled-battery test suites that use TAP-style nested subtests; not a correctness bug.
+
+## Deep-dive investigation (2026-08-10)
+
+### Traced mechanism (the crux the ticket missed)
+
+The block does **not** arrive as bare AST — it arrives as an already-compiled closure, and the
+carrier throws the bytecode away:
+
+1. `subtest "s" => { ... }` parses as a plain `Stmt::Call { name: subtest, args:
+   [PositionalPair(Binary{op: FatArrow, ...})] }` (verified with `--dump-ast`). The dedicated
+   `Stmt::Subtest` parser arm (`src/parser/stmt/simple/control_stmts.rs:373`, tried at
+   `src/parser/stmt/mod.rs:181`) is effectively dead for this shape: it calls `expression(rest)`
+   for the name, and `expression` greedily consumes the whole `"s" => { ... }` pair (FatArrow is
+   an ordinary infix), so the arm's own `rest.starts_with("=>")` check at
+   `control_stmts.rs:379` always fails and the parse falls through to the function-call form.
+   The comma form `subtest "s", { ... }` is a plain two-arg call as well.
+2. The main-pass compiler compiles the anon block into closure bytecode and emits
+   `OpCode::MakeAnonSub` (`src/compiler/expr_closure.rs:113`). At runtime,
+   `exec_make_anon_sub_op` (`src/vm/vm_register_ops.rs:194`) builds the `SubData` **with
+   `compiled_code: Some(cc)` and `compiled_fns`** (lines 248-249) via `resolve_closure_code`.
+3. The call dispatches through `try_native_test_function` (`src/vm/vm_call_dispatch.rs:93`,
+   `src/vm/vm_native_test.rs:35`) → `test_fn_subtest`
+   (`src/runtime/test_functions/tap_subtest.rs:91`), which runs the block via
+   `self.call_sub_value(block, vec![], true)` at `tap_subtest.rs:133`.
+4. `call_sub_value` (`src/runtime/resolution_call_sub.rs:119`) has a compiled fast path **only
+   for `compiled_routine`** (line 383). A closure `SubData` carries `compiled_code`, never
+   `compiled_routine` (see the comment at line 376), so it falls into the interpreter carrier:
+   env clone/merge, then `self.eval_block_value(&data.body)` at line 718 →
+   `eval_block_value_inner` → `compile_block_value_opts`
+   (`src/runtime/resolution_eval.rs:99`, fresh `Compiler::new()` at line 104) → `run_nested`.
+   The `compiled_code` sitting on the `SubData` is consulted only for metadata
+   (`authoritative_free_vars`, supply marks) — never executed.
+
+So the fix needs **no parser change and no new cache**: the compile result is already cached on
+the `SubData` (keyed by code identity, env per-call — exactly the invalidation-free design a
+cache would have to invent). The carrier just has to use it.
+
+### Measured impact (debug build, 2026-08-10, main @ 52f217429)
+
+- `tmp/subtest-bench.p6` — 200 `subtest "..." => { ... }` calls, 4 assertions each:
+  **0.391 s**. Identical per-iteration work in a plain named sub called 200 times
+  (`tmp/subtest-bench-baseline.p6`): **0.203 s**. ≈ 0.9 ms/call carrier+recompile overhead,
+  ~2x file wall-clock for a subtest-shaped file.
+- `rust-gdb -batch -ex 'break src/runtime/resolution_eval.rs:104' -ex 'ignore 1 100000' -ex run
+  -ex 'info breakpoints' --args ./target/debug/mutsu ./tmp/subtest-bench.p6` →
+  `compile_block_value_opts` hit **exactly 200 times** (one full re-compile per call).
+- `tmp/subtest-class-loop.p6` — the ticket's class-in-subtest repro looped 50x:
+  `MUTSU_VM_STATS=1` reports `method_body_runtime_compiles=50` (one per call). The identical
+  shape invoked as a plain compiled closure (`tmp/class-block-loop.p6`, `my &b = { ... class D
+  ... }; for ^50 { b() }`) reports **0** — proving the compiled dispatch path eliminates the
+  per-call method-body recompile too.
+- There is no dedicated counter for block re-compiles; `method_body_runtime_compiles`
+  (`src/vm/vm_stats.rs:317`) only fires when the block declares a class after a runtime
+  statement. Use the gdb hit count for the general case.
+
+### Option analysis
+
+**(a) Extend the `Stmt::Subtest` parser/compiler arm — REJECTED.**
+- To fire at all, the arm would have to stop `expression()` before `=>` (a precedence-limited
+  name parse) or destructure the parsed FatArrow `Binary` after the fact, plus grow matches for
+  the comma form, block-first form, and `:todo`-style adverbs.
+- More importantly, `OpCode::SubtestScope` (`src/compiler/stmt.rs:3849`,
+  `src/vm/vm_scope_ops.rs:5`) is the *less correct* runtime: it inlines the body into the
+  enclosing frame with none of the decl snapshot/rollback (`snapshot_subtest_decls` /
+  `restore_subtest_decls`, `tap_subtest.rs:17-89`), env save/merge, or `plan skip-all`
+  callable-kind handling that `test_fn_subtest` provides. Routing more shapes into it is a
+  correctness downgrade, not just a perf change.
+- Real-Test-module constraint: under `MUTSU_REAL_TEST=1`, `try_native_test_function` declines
+  (`src/vm/vm_native_test.rs:49`) and the vendored `Test.rakumod`'s `sub subtest(&subtests,
+  $desc)` handles the call — its `subtests()` invocation already dispatches the block value
+  through the normal compiled call path. A parser arm that hard-routes `subtest` statements to
+  `SubtestScope` would *bypass* the real module, fighting the project's rung-2 north star
+  (eventually flipping the real module on for good, `src/runtime/runtime_module.rs:13`). So (a)
+  could only ever help the native provider, and would have to be env-var-gated in the parser —
+  ugly and wrong-direction. If anything, the near-dead `Stmt::Subtest` arm should eventually be
+  retired in favor of the function-call form, not extended.
+
+**(b) Compiled-block cache keyed by source location — REJECTED as redundant.** The compiled
+block already exists on `SubData.compiled_code`, cached at closure creation, keyed by code
+identity, with the captured env carried separately per closure instance. A second
+location-keyed cache would duplicate that and add invalidation questions for nothing.
+
+**(c) Compiled-first dispatch of the block value — CHOSEN.** This is exactly the PR #5942
+lever (`reduce_call_step`, commit ecb5eba21, `src/runtime/builtins_reduce.rs:348`; extended to
+`produce` in #5944/d08310b34): when the callable carries bytecode, route through
+`vm_call_on_value` (`src/vm/vm_dispatch_helpers.rs:458`, already `pub(crate)` since #5942),
+whose Sub-with-`compiled_code` fast path (line 531) runs `call_compiled_closure`
+(`src/vm/vm_closure_dispatch.rs:108`) — the same well-tested path every ordinary `b()` call
+takes, including free-var entry snapshot + changed-var writeback to the caller env
+(`vm_closure_dispatch.rs` ~690-713). `vm_call_on_value` itself reroutes wrap-chained Subs back
+to `call_sub_value` (line 499), so no wrap regression.
+
+### Step-by-step implementation plan
+
+All changes in `src/runtime/test_functions/tap_subtest.rs`. Do not touch the parser, compiler,
+or VM.
+
+1. Add a private helper on `impl Interpreter` in `tap_subtest.rs`, modeled 1:1 on
+   `reduce_call_step` (`src/runtime/builtins_reduce.rs:348`):
+
+   ```rust
+   /// Run a subtest body callable. Compiled-first: a `Sub` carrying bytecode
+   /// dispatches through the VM closure path; the `call_sub_value` AST
+   /// carrier re-compiles `data.body` on every invocation (see the ticket
+   /// header). Subs without bytecode keep the interpreter carrier.
+   fn subtest_call_block(&mut self, block: &Value) -> Result<Value, RuntimeError> {
+       let has_bytecode = matches!(
+           block.view(),
+           ValueView::Sub(d) if d.compiled_code.is_some() || d.compiled_routine.is_some()
+       );
+       if has_bytecode {
+           self.vm_call_on_value(block.clone(), vec![], None)
+       } else {
+           self.call_sub_value(block.clone(), vec![], true)
+       }
+   }
+   ```
+
+2. Replace `self.call_sub_value(block, vec![], true)` at `tap_subtest.rs:133`
+   (`test_fn_subtest`) with `self.subtest_call_block(&block)`.
+3. Replace the identical call at `tap_subtest.rs:194` (`test_fn_group_of`) the same way.
+4. Change nothing else in `test_fn_subtest`: the `callable_is_sub` detection (lines 123-127,
+   runs before the call), the `Must give \`subtest\`` plan-skip-all error propagation (line
+   137, dispatch-route-independent), the decl snapshot/restore (lines 132/145/159), and the
+   post-call env merge loop (lines 148-158) all stay. After `vm_call_on_value` returns,
+   `self.env` is the caller env plus the compiled path's free-var writebacks, so the merge loop
+   sees the same mutated keys it does today.
+5. `cargo fmt && cargo clippy -- -D warnings`.
+
+### Verification / acceptance
+
+- **Counter (primary signal):** `MUTSU_VM_STATS=1 timeout 30 target/debug/mutsu
+  tmp/subtest-class-loop.p6` — `method_body_runtime_compiles` must drop **50 → 0** (the
+  plain-closure control `tmp/class-block-loop.p6` already shows 0).
+- **Recompile count:** the gdb breakpoint on `src/runtime/resolution_eval.rs:104` against
+  `tmp/subtest-bench.p6` must drop **200 → 0** hits.
+- **Wall-clock:** `tmp/subtest-bench.p6` should move from 0.391 s toward the 0.203 s baseline
+  (debug build; exact number will retain some begin/finish_subtest overhead).
+- **Behavior:** `prove -e target/debug/mutsu` on: `t/subtest-plan.t`,
+  `t/subtest-reports-why-its-body-died.t`, `t/group-of.t`, `t/test-default-descriptions.t`,
+  then the full set (`grep -rln subtest t/` → 47 files). Roast (with `MUTSU_FUDGE=1`):
+  `roast/S24-testing/11-plan-skip-all-subtests.t` (exercises `plan skip-all` + `return` inside
+  both Sub and Block callables — the riskiest semantics), `roast/S24-testing/12-subtest-todo.t`,
+  and the rest of the whitelisted `S24-testing/` files. Then `make test` and let CI run full
+  roast. No new `.t` needed — behavior must not change.
+
+### Pitfalls
+
+- **Topic propagation:** the interpreter carrier binds the caller's `$_` into a zero-arg bare
+  block (`resolution_call_sub.rs:536-543`); the compiled path installs the topic by its own
+  rules (`vm_closure_dispatch.rs` ~565-585). A subtest body reading the *outer* `$_` could
+  observe a difference — but the compiled path is the language-standard `b()` semantics, so if
+  a roast test disagrees it will fail deterministically; fix forward, don't gate.
+- **Blocks without bytecode** (Subs built by interpreter-side code) keep the carrier via the
+  helper's fallback — zero behavior change there.
+- **MUTSU_REAL_TEST path** never reaches `tap_subtest.rs` (declined at
+  `vm_native_test.rs:49`) — unaffected either way, but re-run one subtest-using t/ file with
+  `MUTSU_REAL_TEST=1` as a sanity check.
+- **Env-merge correctness:** if a subtest body's write to an outer lexical stops propagating,
+  the suspect is the interaction between `call_compiled_closure`'s writeback and the manual
+  merge loop at `tap_subtest.rs:148-158` (see the env-writeback campaign memory note for the
+  bug shape); the loop only merges keys already present in `saved_env`, so a writeback that
+  lands in a parent env tier rather than the overlay would be the thing to check.
+- **Sibling recompile-per-call carriers** (same lever, out of scope here, worth follow-up
+  tickets): `eval_exception.rs:477` (`lives-ok`/`dies-ok` code arg), `throws_like.rs:503`,
+  `comparison.rs:135` (`cmp-ok` operator arg), `fails_like.rs:274`, and `classify`/`categorize`
+  if still uncovered (produce/reduce were fixed in #5942/#5944).

--- a/todo/tickets/wildcard-handles-loses-to-builtin-cool-methods.md
+++ b/todo/tickets/wildcard-handles-loses-to-builtin-cool-methods.md
@@ -42,3 +42,343 @@ Root cause not yet investigated in depth — needs tracing how built-in method
 resolution short-circuits before the wildcard-handles fallback runs (likely
 in `class_dispatch.rs`/`methods_classhow_dispatch.rs`'s owner/candidate
 resolution, ahead of `methods_instance_ops.rs`'s fallback block).
+
+## Deep-dive investigation (2026-08-10)
+
+Root cause fully traced (gdb-confirmed), rakudo semantics established with an
+oracle probe matrix, and an implementation plan follows. The original guess
+(`class_dispatch.rs` / `methods_classhow_dispatch.rs` owner resolution) was
+wrong — user-method resolution is fine (own/inherited/role methods already win
+in mutsu). The culprit is the **native builtin fast path**
+(`native_method_0arg/_1arg/_2arg`), which answers Cool-only methods for *any*
+receiver by stringifying it, before dispatch ever reaches the slow-path
+wildcard/FALLBACK block.
+
+### The rakudo rule (oracle-verified table)
+
+All probes run against system `raku` on 2026-08-10. `F` below is
+`class F { method inner() handles * { 'hello' } }` (method-based) or
+`has $.t handles * = 'hello'` (attribute-based) — both behave identically.
+
+| Probe | rakudo result | Delegated? |
+|---|---|---|
+| `F.new.uc` | `HELLO` | **yes** |
+| own `method uc` on the class | `OWN-UC` | no — own method wins |
+| `uc` inherited from a user parent class | `PARENT-UC` | no — inherited wins |
+| `uc` from a composed role | `ROLE-UC` | no — role method wins |
+| `F.new.list` | `(F.new,)` (Any.list) | no |
+| `F.new.Str` | `F<...>` (Mu.Str) | no |
+| `F.new.gist` | `F.new` (Mu.gist) | no |
+| `.WHAT/.isa/.defined/.Bool/.raku/.elems/.say` | all Mu/Any behavior | no |
+| `F.new.split(",")` | `Cannot resolve caller split(F:D, Str:D)` | **no** — Any carries a proto, resolution *succeeds* |
+| `class G {}; G.new.uc` (no handles) | `No such method 'uc' for invocant of type 'G'` | n/a — proves plain classes do not inherit Cool |
+| `handles *` + `FALLBACK` on same class, `.uc` | `HELLO` (either declaration order) | wildcard **beats** FALLBACK |
+| `FALLBACK` only (no handles), `.uc` | `FB:uc` | FALLBACK also intercepts Cool-only builtins |
+| wildcard delegate lacks the method, class has FALLBACK | `FB:uc` | falls through to FALLBACK |
+| wildcard delegate lacks the method, no FALLBACK | `No such method 'uc' for invocant of type 'M2'` — names the **delegating** class | error |
+| `method x() handles <uc gist>` (explicit list) | `.uc` → `HELLO`, `.gist` → `hello` | explicit list installs a *real* method, so it beats even Any.gist |
+| `class CH is PH {}` where PH has `handles *` | `HELLO` | delegation is inherited via MRO |
+| `~$obj`, `$obj eq "x"`, `+$obj` | Mu.Str coercion / `Cannot resolve caller Numeric(Op:D:)` | operators never delegate |
+| `F.new.can("uc")` | `()` | wildcard installs no methods |
+
+**The ordering rule, crisply:** `handles *` (and `FALLBACK`) fire **exactly
+when normal method resolution over the receiver's real MRO (class → parents →
+roles → Any → Mu) throws X::Method::NotFound** — i.e. they live at the
+"resolution failed" layer, wildcard before FALLBACK. A plain class derives
+from Any, not Cool, so Cool-only methods (`.uc`, `.flip`, `.subst`, ...) are
+*not resolvable* on it and are therefore interceptable; Any/Mu methods
+(`.gist`, `.list`, `.elems`, ...) always resolve and are never intercepted.
+Methods with an Any/Mu **proto** but no matching candidate (`split`, `fmt`,
+`Int`, `Numeric`, `Real`) count as *resolved* — they error, they do NOT
+delegate. Operators use Mu coercion, not delegation.
+
+### Confirmed mutsu dispatch trace (gdb, debug build 2026-08-10)
+
+`say Forward4.new.uc` — the `.uc` call takes this exact path (breakpoint on
+the `"uc"` arm, `bt`):
+
+1. `OpCode::CallMethod` → `exec_call_method_op` (`src/vm/vm_call_method_ops.rs:479`)
+   → `exec_call_method_op_impl` — calls `try_native_method` at
+   `src/vm/vm_call_method_ops.rs:1744` **before** any interpreter fallback.
+   (The mut-op twin `exec_call_method_mut_op_impl`,
+   `src/vm/vm_call_method_mut_ops.rs:2127`, does the same for variable
+   receivers — both funnel into the same gate.)
+2. `try_native_method` (`src/vm/vm_native_dispatch.rs:21`) →
+   `try_native_method_raw` (`:38`). Its Instance-bypass arm (`:192-265`)
+   checks Supply/exception/Real-Numeric/`is_native_method` — **it has no
+   wildcard-handles / FALLBACK check** — so it falls through to the
+   arity-keyed dispatch at `:369-377`.
+3. `native_method_0arg` (`src/builtins/methods_0arg/mod.rs:304`) → the
+   `try_dispatch!` chain (`mod.rs:2200-2207`) →
+   `dispatch_core_numeric::dispatch`, whose arm at
+   `src/builtins/methods_0arg/dispatch_core_numeric.rs:362-364` is
+   `"uc" => Some(Some(Ok(Value::str(grapheme_uppercase(&target.to_string_value())))))`
+   — unconditional for **any** receiver, including Instance. Result:
+   `"FORWARD4()"`.uc → `FORWARD4()`. Sibling arms `lc`/`fc`/`tc` (`:365-373`)
+   and the `dispatch_core_str`/`_unicode` string arms behave the same;
+   n-arg builtins (`.subst`, `.contains`, ...) are answered the same way via
+   `native_method_1arg`/`_2arg`.
+4. The wildcard-delegation / FALLBACK block at
+   `src/runtime/methods_instance_ops.rs:1743-1805` is therefore **never
+   reached** for any method name the native fast path knows.
+
+The interpreter entry (`call_method_with_values`,
+`src/runtime/methods_call_dispatch.rs:51`) has the same hole: its native
+fast-path call at `:2792-2801` is guarded by `should_bypass_native_fastpath`
+(`src/runtime/methods_native_bypass.rs:116`), which likewise has no
+wildcard/FALLBACK clause. Both gates must be fixed — if only the VM gate is
+fixed, the slow path re-enters the native fast path and re-answers wrongly.
+
+**Second bug found while tracing:** method-based wildcard delegation is
+entirely broken, even for non-builtin names. `method inner() handles *`
+registers the marker string `"&inner"` in `ClassDef::wildcard_handles`
+(`src/runtime/registration_class_body_method.rs:333-371`), but the fallback
+block at `methods_instance_ops.rs:1785` only does
+`attr_var.trim_start_matches('!').trim_start_matches('.')` and then
+`attributes.as_map().get(attr_key)` — `"&inner"` is not an attribute key, so
+the delegate is never found and dispatch falls through to "No such method".
+(Reproduced: `class FwdM2 { method inner() handles * { D.new } };
+FwdM2.new.greet` → `No such method 'greet'`; raku → `hi-from-D`.
+Attribute-based `has $.t handles *` works for non-builtin names.) The
+explicit-list form is unaffected because it synthesizes a real forwarder
+method resolved by `forward_resolved_delegation`
+(`src/runtime/class_dispatch.rs:573-609`), which *does* understand the `&`
+marker — mirror its delegate resolution.
+
+Current mutsu behavior for Any/Mu methods on a wildcard instance
+(`.elems`/`.list`/`.defined`/`.gist`) already matches raku (answered by
+native/builtin handlers before the fallback block) — the fix must keep that.
+
+### Fix plan
+
+The fix = one method-name classification + one registry predicate + two
+fast-path gates + repairing the `&` marker in the fallback block. No changes
+to `dispatch_core_numeric.rs` arms themselves (Str/Int/etc. depend on them).
+
+**Step 1 — add `cool_only_builtin_method(name: &str) -> bool`.**
+Location: `src/runtime/methods_native_bypass.rs`, as an associated fn on
+`Interpreter` (`pub(crate) fn cool_only_builtin_method(method: &str) -> bool`,
+a single `matches!`). This is the set of builtin method names that rakudo
+resolves **only** through Cool — i.e. the wildcard/FALLBACK-interceptable
+set. Every entry below was verified against the oracle
+(`raku -e "class G {}; my \$r = G.new.<M>"` → `No such method`):
+
+```
+uc lc fc tc tclc wordcase chars codes chomp chop trim trim-leading
+trim-trailing flip comb words lines substr index rindex starts-with
+ends-with contains subst sprintf ord chr ords Num Rat succ pred abs sqrt
+sign round floor ceiling truncate base exp log log10 log2 sin cos tan
+asin acos atan atan2 sinh cosh tanh asinh acosh atanh sec cosec cotan
+sech cosech cotanh cis unpolar roots polymod IO lazy race hyper
+samecase samemark samespace trans indent uniname uninames unival univals
+uniprop uniprops uniparse parse-base parse-names NFC NFD NFKC NFKD
+encode Date DateTime UInt Version
+```
+
+Do NOT include (verified to resolve on a plain Any instance, so never
+intercepted): `split fmt Int Numeric Real Str Stringy gist raku perl say put
+print note defined Bool so not isa does can clone new WHAT WHICH WHERE HOW
+WHY VAR self item sink list List elems end flat map grep first join sort min
+max minmax sum reduce unique squish repeated pick roll reverse head tail skip
+batch rotor keys values kv pairs antipairs invert Array Hash hash Slip Seq
+Set Bag Mix iterator eager are Capture cache classify categorize combinations
+permutations pairup deepmap duckmap nodemap tree collate toggle produce
+chrs`.
+
+**Step 2 — add `class_has_wildcard_handles_or_fallback(&mut self, class_name:
+&str) -> bool`.** Location: `src/runtime/class_introspection.rs`, next to
+`collect_wildcard_handles` (`:468`):
+
+```rust
+pub(crate) fn class_has_wildcard_handles_or_fallback(&mut self, class_name: &str) -> bool {
+    let mro = self.class_mro(class_name);
+    let has_wildcard = mro.iter().any(|cn| {
+        self.registry()
+            .classes
+            .get(cn.as_str())
+            .is_some_and(|cd| !cd.wildcard_handles.is_empty())
+    });
+    has_wildcard || self.has_user_method(class_name, "FALLBACK")
+}
+```
+
+`class_mro` is Arc-cached (`src/runtime/registry.rs:621`), so this is a short
+iteration + hashmap gets. Include the FALLBACK half: the oracle shows a
+FALLBACK-only class also intercepts `.uc` (`FB:uc`), and the slow-path block
+already tries FALLBACK after wildcard delegation.
+
+**Step 3 — VM gate.** In `try_native_method_raw`
+(`src/vm/vm_native_dispatch.rs`), inside the Instance arm (the
+`else if matches!(target.view(), ValueView::Instance { .. })` block,
+`:192-265`), immediately after the `is_native_method` check (`:261-264`),
+add:
+
+```rust
+// A Cool-only builtin (`.uc`, `.flip`, `.subst`, ...) is NOT resolvable
+// on a plain Any-derived instance in raku, so a class that declares
+// `handles *` (or a FALLBACK) must intercept it. Bail to the
+// interpreter's fallback chain (wildcard -> FALLBACK -> error).
+// Name gate first: the set test is a static `matches!` and free; the
+// MRO walk runs only for Instance x Cool-only-name calls, which were
+// previously answered by the (wrong) stringify fallback anyway.
+if Self::cool_only_builtin_method(&method_name)
+    && self.class_has_wildcard_handles_or_fallback(&cn)
+{
+    return None;
+}
+```
+
+This one site covers all VM entries (plain CallMethod at
+`vm_call_method_ops.rs:1744`, the mut path at
+`vm_call_method_mut_ops.rs:258/563/842/2127`, autothread at
+`vm_call_autothread.rs:471`, `.+`/`.*` at `vm_call_helpers.rs:318`) and all
+arities (the gate sits before the arity-keyed dispatch at `:369-377`).
+
+**Step 4 — interpreter gate.** In `should_bypass_native_fastpath`
+(`src/runtime/methods_native_bypass.rs:116`), add a clause to the big `||`
+chain (near the existing `has_user_method` Instance arm at `:214-215`):
+
+```rust
+|| (Self::cool_only_builtin_method(method)
+    && matches!(target.view(), ValueView::Instance { class_name, .. }
+        if self.class_has_wildcard_handles_or_fallback(&class_name.resolve())))
+```
+
+Required because `call_method_with_values`
+(`src/runtime/methods_call_dispatch.rs:2792-2801`) re-runs the native fast
+path on the slow-path route; without this the bypass from Step 3 is undone.
+
+**Step 5 — fix the `&` (method-based) marker in the fallback block.**
+Rework `src/runtime/methods_instance_ops.rs:1753-1795` so each
+`wildcard_attrs` entry is parsed as `(source, optional ":regex:" pattern)`
+and the delegate is resolved by marker kind, mirroring
+`forward_resolved_delegation` (`src/runtime/class_dispatch.rs:590-598`):
+
+- `source` starts with `&` → delegate =
+  `self.call_method_with_values(target.clone(), &source[1..], Vec::new())`
+  (on `Err`, `continue`). `inner` is a real user method, resolved before
+  this block ever runs, so no recursion risk.
+- otherwise → attribute read exactly as today (keep the clone-out-in-its-own-
+  statement pattern; the deadlock comment at `:1762-1768` explains why).
+- regex entries keep their pattern check first, then resolve the delegate by
+  the same two-way rule (a method-based regex marker is
+  `"&inner:regex:<pat>"` per `registration_class_body_method.rs:360-364` —
+  the current code never strips the `&`).
+
+Keep the existing order inside the block: wildcard delegation → FALLBACK →
+built-in fallbacks → error (matches the oracle table, including
+"delegate lacks method + FALLBACK → FALLBACK fires" via the existing
+`Err(_) => continue`, and the final error naming the delegating class).
+
+**Step 6 — hot-path guarantee (the review concern).** No new per-class cached
+flag is needed. The guard is name-gated first: for every method name outside
+the Cool-only set (i.e. all ordinary method calls, all Any/Mu builtins, all
+user methods) the added cost is one static `matches!` that fails — effectively
+free. The MRO walk only runs for the rare shape "Instance receiver × Cool-only
+builtin name", which today lands in the allocating
+`to_string_value()`+case-conversion stringify arm anyway. Non-Instance
+receivers (Int/Str/Array hot loops) never reach either gate. Do NOT compute a
+compose-time cached flag instead: `augment class` can add `handles *` after
+subclasses composed, and the ticket's repro was originally found via augment —
+a stale flag would be a flakiness risk (CLAUDE.md "gain vs risk").
+If in doubt, compare `MUTSU_VM_STATS=1` counters on the debug build before/
+after (they are optimization-level-independent); wall-clock verdicts come from
+bench CI (`git show origin/bench-data:bench-history.tsv`), not local runs.
+
+### Test file (new, `t/handles-wildcard-builtin-methods.t`)
+
+```raku
+use v6;
+use Test;
+
+plan 17;
+
+# builtin interception (attribute-based)
+class FwdAttr { has $.t handles * = 'hello'; }
+is FwdAttr.new.uc, 'HELLO', 'attribute handles *: .uc delegates';
+is FwdAttr.new.subst('h', 'j'), 'jello', 'attribute handles *: n-arg .subst delegates';
+
+# builtin interception (method-based)
+class FwdMeth { method inner() handles * { 'hello' } }
+is FwdMeth.new.uc, 'HELLO', 'method handles *: .uc delegates';
+is FwdMeth.new.flip, 'olleh', 'method handles *: .flip delegates';
+
+# method-based wildcard with a non-builtin name (bug 2)
+class Delegate { method greet() { 'hi-from-D' } }
+class FwdMeth2 { method inner() handles * { Delegate.new } }
+is FwdMeth2.new.greet, 'hi-from-D', 'method handles *: custom method delegates';
+
+# variable receiver exercises the VM mut-op path
+my $o = FwdAttr.new;
+is $o.uc, 'HELLO', 'variable receiver delegates too';
+
+# real methods always win
+class OwnWins { method inner() handles * { 'hello' }; method uc() { 'OWN' } }
+is OwnWins.new.uc, 'OWN', 'own method beats handles *';
+class P { method uc() { 'PARENT' } }
+class InhWins is P { method inner() handles * { 'hello' } }
+is InhWins.new.uc, 'PARENT', 'inherited method beats handles *';
+role R { method uc() { 'ROLE' } }
+class RoleWins does R { method inner() handles * { 'hello' } }
+is RoleWins.new.uc, 'ROLE', 'role method beats handles *';
+
+# delegation is inherited
+class SubFwd is FwdMeth { }
+is SubFwd.new.uc, 'HELLO', 'handles * is inherited by subclasses';
+
+# explicit handles list also intercepts a builtin
+class Expl { has $.t = 'hello'; method x() handles <uc> { $!t } }
+is Expl.new.uc, 'HELLO', 'explicit handles <uc> delegates';
+
+# ordering vs FALLBACK
+class Both { method inner() handles * { 'hello' }; method FALLBACK($n, |c) { "FB:$n" } }
+is Both.new.uc, 'HELLO', 'handles * beats FALLBACK';
+class FbOnly { method FALLBACK($name, |c) { "FB:$name" } }
+is FbOnly.new.uc, 'FB:uc', 'FALLBACK alone intercepts .uc';
+class Bare { }
+class FwdFb { method inner() handles * { Bare.new }; method FALLBACK($n, |c) { "FB:$n" } }
+is FwdFb.new.uc, 'FB:uc', 'FALLBACK fires when the delegate cannot handle';
+
+# missing on delegate, no FALLBACK: dies naming the method
+class FwdMiss { method inner() handles * { Bare.new } }
+throws-like { FwdMiss.new.uc }, Exception, message => /uc/,
+    'missing on delegate dies with no-such-method for uc';
+
+# Any/Mu methods are NOT intercepted
+class FwdList { has $.t handles * = (1, 2, 3); }
+is FwdList.new.elems, 1, '.elems resolves on Any, not delegated';
+ok FwdList.new.gist.contains('FwdList'), '.gist stays Mu.gist, not delegated';
+```
+
+Every `is` expectation above was verified against system `raku`.
+
+### Regression hazards
+
+- **Whitelisted roast:** `roast/S12-attributes/delegation.t` (23 `handles`
+  uses; lines 190-203 pin `handles *` with own-method-wins) and
+  `roast/S12-methods/delegation.t` are both in `roast-whitelist.txt` — run
+  both with `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' <file>` before
+  pushing.
+- **Local tests touching `handles`:** `t/attr-handles-angle-word.t`,
+  `t/handles-paren-strings.t`, `t/augment-method-handles-forwarder.t`,
+  `t/version.t`, `t/regex-my-var-interpolation.t` (the latter two use
+  `handles *`). Run them all.
+- **Hot path:** the guard must stay name-gated-first (Step 6). Do not move
+  the MRO walk ahead of the `cool_only_builtin_method` test, and do not add
+  any check outside the Instance arms. Ordinary method calls and non-Instance
+  receivers must not pay anything; bench CI (`bench-history.tsv` on
+  `bench-data`) is the wall-clock authority if a perf question comes up.
+- **Do not gate the fallback block itself on the Cool-only set.** Any/Mu
+  methods reach it only in shapes that already behave correctly (verified:
+  `.elems`/`.list`/`.gist`/`.defined` on wildcard instances match raku
+  today); adding a second gate there risks breaking Package-receiver
+  FALLBACK dispatch.
+- **Known residues, out of scope:** (a) `Err(_) => continue` in the wildcard
+  block swallows genuine exceptions thrown by a delegate method that *does*
+  exist (rakudo propagates them — it checks `.can` first); (b) operators
+  (`~$obj`, `+$obj`, `eq`) correctly do not delegate in either
+  implementation — do not "fix" them to delegate; (c) the Cool-only set is a
+  manual mirror of rakudo — when in doubt about a name, the oracle is
+  `raku -e "class G {}; my \$r = G.new.<M>"` (interceptable iff it prints
+  `No such method`; an arity/`Cannot resolve caller` error means it resolved
+  and is NOT interceptable).


### PR DESCRIPTION
Second round of ticket deep-dives (follow-up to #6179). Four more `todo/tickets/` files that previously lacked a root cause or a settled design now carry a `## Deep-dive investigation (2026-08-10)` section with confirmed root cause (gdb/oracle evidence), a step-by-step fix plan with file:line anchors, an inline raku-verified test file, and a regression list.

- **named-capture-absent-from-current-match-leaks-stale-value** — the stale value comes from a third capture store: env keys `"<name>"` deposited per capture name and never purged by any match-install site, shadowing the already-correct `$/` lookup. Fix: one `reset_capture_env_vars()` helper (Nil numeric keys, *remove* angle keys) called at ~9 enumerated install sites. Bonus pin: rakudo sets `$/` to Nil on a failed match rather than preserving the last success.
- **stored-regex-loses-its-defining-scope-lexicals** — recommends splitting; the halves are independent. (1) The `LoadRegexClosure` capture from b07ee6627 only fires for code-bearing patterns, and is a by-value snapshot where raku closes over bindings; fix = drop the gate + box mutated captures into `ContainerRef` cells via the existing `box_decl_local_cell`. (2) `<$var>` wraps the inner pattern as a capture-transparent `Group`, so inner captures number into the outer `$/`; fix = a `strip_captures_pattern` transform modeled on `strip_marks_pattern`.
- **subtest-recompiles-block-from-ast-every-call** — both options the ticket posed are rejected: the anon block already compiles to bytecode attached to `SubData.compiled_code`; `call_sub_value` simply has no compiled fast path for it and re-compiles from AST every call (measured ~2x wall-clock on a 200-subtest bench; `method_body_runtime_compiles` 50→0 is the acceptance counter). Fix = compiled-first dispatch, the PR #5942 `reduce` pattern, at the two `tap_subtest.rs` call sites.
- **wildcard-handles-loses-to-builtin-cool-methods** — user-method resolution is fine; the native builtin fast path answers Cool-only methods (`.uc`, …) for any receiver by stringifying it before the wildcard/FALLBACK block can run. The rakudo rule is pinned: delegation fires exactly when MRO resolution would throw `X::Method::NotFound` (Cool-only names interceptable, Any/Mu names never). Second bug found en route: method-based `handles *` never resolves its `&`-marker. Plan includes a name-gated-first hot-path design with zero cost for ordinary calls.

Docs-only — heavy CI jobs skip by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)