### PR TITLE
refactor(adr0019): E2b -- fix Failure/Exception/CX::Warn MRO chain gaps, close exception-family rows

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1995,6 +1995,57 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     value`, 9-26 each). New `setbagmix_rows_are_backed_by_the_cascade` and
     `rakuast_statementlist_rows_are_backed_by_the_cascade` tests. `cargo test
     --lib` (738 tests) and `make test` (3002 files/28169 tests) both green.
+    **Progress 2026-08-10** (seventh slice): found and fixed a second
+    root-cause chain-walk gap, this time in `builtin_type_catalog.rs` rather
+    than the coverage-check function itself. `Failure`'s
+    `dispatch_owner_chain` was just `["Failure"]` -- no continuation to
+    `Any`/`Mu` at all -- because `Failure` is never declared as a real class
+    anywhere in mutsu (built purely via `Value::make_instance`), so it had no
+    catalog row and the registry has no model of its ancestry either. Every
+    built-in `X::*` exception type had the same problem one level up: each
+    registers `Exception` as its parent (`BUILTIN_PARENT_TYPES`), but
+    `Exception` itself was never registered as an actual class, so
+    `compute_class_mro`'s implicit-`Any` rule (which only fires for a class
+    present in the registry) never applied to it, and every `X::*` type's
+    registry MRO dead-ended at `Exception` (e.g. `X::AdHoc`'s registry MRO
+    was `["X::AdHoc", "Exception"]`). `CX::Warn` had it worse still: built via
+    `Value::make_instance` with no registered parent at all, so its chain was
+    the bare `["CX::Warn"]` and never even mentioned `Exception`. Fixed with
+    three new `builtin_type_catalog` rows -- `Failure` (`["Failure", "Nil",
+    "Cool", "Any", "Mu"]`, raku: `Failure ISA Nil`), `Exception` (`["Exception",
+    "Any", "Mu"]`, letting `class_chain_with_catalog_tail`'s splice logic
+    patch every `X::*` type at once), and `CX::Warn` (`["CX::Warn",
+    "Exception", "Any", "Mu"]`, needed directly since its own registry chain
+    never reaches `Exception`) -- all three verified against real `raku`
+    `.^mro` output. This alone made the `Any`-declared universal rows
+    (`so`/`not`/`defined`/`self`/`clone`/`WHERE`/`WHICH`/`sink`/`item`/
+    `serial`) finally resolve for every `Failure`/`X::*`/`CX::Warn` receiver,
+    which is why `Failure`'s `sink`/`so`/`defined` gap from the sixth slice's
+    notes closed without a `Failure`-specific row. Then hand-probed the
+    concrete per-type rows still needed on top (`message`/`resume`/
+    `backtrace`/`gist`/`raku`/`Str`/`Bool`/`throw`/`exception`/`handled`,
+    varying per type -- e.g. `CX::Warn` lacks `throw`/`raku`, `Failure` lacks
+    `message`/`backtrace` -- confirmed by direct probe rather than assumed
+    shared, since `CX::Warn`'s own `resume` arm in `methods_0arg/mod.rs` is
+    gated on its exact class name, not a generic exception check). A fresh
+    `t/`-wide sweep confirmed `native_call_unmodeled` dropped from 1818 (this
+    session's file set) to 1498 (cumulative **-96%** from the original
+    ~37904); none of `Failure`/`X::AdHoc`/`CX::Warn`/`X::TypeCheck::Assignment`
+    remain in the top-40 breakdown. Remaining top pairs are now a long,
+    diffuse tail with no single dominant owner (`Match x Stringy`, `Any x
+    gist/raku/hash`, `Backtrace`/`Backtrace::Frame`, `ProfiledG x raku`, `Nil
+    x raku/gist`, `Version`, `Junction x gist`, `Seq x is-lazy`, `Date`/
+    `DateTime`, `Supply x list`, `Signature x gist`, `Range x hyper/lazy/
+    int-bounds/Array`, `Rat x FatRat/nude`, `Map x raku/gist`, `Duration x
+    Numeric`, `Pair x Pair`, `Mu x defined`, `CallFrame x defined`,
+    `RakuAST::IntLiteral x value`, `Attribute x defined`, `IO::Path::Parts x
+    AT-KEY`, `Int x ^name`, 7-28 each). New `failure_chain_reaches_any_and_mu_via_nil`
+    (`receiver_class.rs`) and `exception_family_rows_are_backed_by_the_cascade`
+    (`native_method_row.rs`) tests. Since this slice changes real
+    `dispatch_owner_chain`/`class_chain` answers (not just the coverage-check
+    table), ran `make roast` locally, not just `make test`, per the "touched
+    name/type resolution" rule -- both green (`cargo test --lib` 740 tests,
+    `make test` unchanged file count, `make roast` 1435 files / 218774 tests).
 - [ ] **E3 — Add the generation-keyed resolved-call cache.** Key by receiver TypeId, method symbol,
   call shape, and method generation; cache the ordered candidate sequence, not a second resolver.
   **Design 2026-08-10** (same doc): lands after E4b. Key `(TypeId, Symbol, CallShape)` where

--- a/src/builtins/builtin_type_catalog.rs
+++ b/src/builtins/builtin_type_catalog.rs
@@ -243,6 +243,44 @@ static CATALOG: &[BuiltinTypeInfo] = &[
     row!("Junction", mro: ["Junction", "Mu"], roles: [], owner: ""),
     // ---- Nil: distinct from the `Any` that `value_type_name` folds it to today ----
     row!("Nil", mro: ["Nil", "Cool", "Any", "Mu"], roles: [], owner: ""),
+    // `Failure` is never declared as a real class anywhere in mutsu (prelude or
+    // Rust) -- it is built purely via `Value::make_instance(Symbol::intern("Failure"), ...)`
+    // wherever a native method needs one, so the class registry has no model of
+    // its ancestry and `class_mro("Failure")` answers just `["Failure"]` with no
+    // continuation to `Any`/`Mu` at all (found via ADR-0019 E2b: the
+    // `native_call_unmodeled` counter never reached zero for `Failure`'s
+    // `Any`-declared universal methods -- `so`/`defined`/`sink`/... -- no matter
+    // how many rows were added, because the chain walk never got past
+    // `Failure` itself). raku: `Failure ISA Nil` (`Failure.new.^mro` is
+    // `Failure, Nil, Cool, Any, Mu`), which this catalog row supplies via
+    // `class_chain`'s direct `builtin_type_info` lookup, bypassing the
+    // registry entirely for this type the same way `Nil` above already does.
+    row!("Failure", mro: ["Failure", "Nil", "Cool", "Any", "Mu"], roles: [], owner: ""),
+    // `Exception` is a name every built-in `X::*` exception type registers as
+    // its parent (`BUILTIN_PARENT_TYPES` in `registration_class_decl.rs`),
+    // but "Exception" itself is never registered as an actual class in the
+    // registry -- so `compute_class_mro`'s implicit-`Any` rule (which only
+    // fires for a class actually present in `self.classes`) never applies to
+    // it, and every `X::*` type's registry MRO dead-ends at `Exception` with
+    // no `Any`/`Mu` continuation (e.g. `X::AdHoc`'s registry MRO was
+    // `["X::AdHoc", "Exception"]`). This catalog row lets
+    // `class_chain_with_catalog_tail`'s splice logic supply the missing tail
+    // for every such type in one place, the same mechanism the `Failure` row
+    // above uses. raku: `Exception.^mro` is `Exception, Any, Mu`.
+    row!("Exception", mro: ["Exception", "Any", "Mu"], roles: [], owner: ""),
+    // `CX::Warn` (and the sibling `CX::*` control-exception types) is built
+    // purely via `Value::make_instance` with no registered parent at all
+    // (unlike `X::AdHoc`, which at least registers `is Exception` even
+    // though `Exception` itself was unregistered) -- its registry MRO was
+    // the bare `["CX::Warn"]`, so the `Exception` splice above never
+    // triggers for it (its registry chain never mentions `Exception`).
+    // raku: `CX::Warn.^mro` is `CX::Warn, Exception, Any, Mu`.
+    row!(
+        "CX::Warn",
+        mro: ["CX::Warn", "Exception", "Any", "Mu"],
+        roles: [],
+        owner: "",
+    ),
     // ---- Allomorphs (V4) ----
     row!(
         "Allomorph",

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -575,6 +575,87 @@ mod tests {
         );
     }
 
+    /// ADR-0019 E2b (seventh slice, 2026-08-10): `Failure`/`X::AdHoc`/
+    /// `CX::Warn`/`X::TypeCheck::Assignment` rows, hand-probed against real
+    /// values raised via the interpreter. This is on top of two
+    /// `builtin_type_catalog` fixes (see `Exception`/`CX::Warn` rows there):
+    /// `Failure`'s chain used to dead-end at `["Failure"]` (no catalog row at
+    /// all), and every `X::*` exception type's chain dead-ended at
+    /// `["..., Exception"]` (a catalog row for the synthetic, never-declared
+    /// `Exception` parent was missing) -- so the `Any`-declared universal
+    /// rows (`so`/`not`/`defined`/`self`/`clone`/`WHERE`/`WHICH`/`sink`/
+    /// `item`/`serial`) could never be found for any exception-family
+    /// receiver via the chain walk no matter how many rows were added,
+    /// mirroring the `Failure` root-cause fix from the sixth slice. `resume`
+    /// is deliberately NOT generalized to a shared `Exception` row despite
+    /// appearing for all four probed types here: `CX::Warn`'s `resume` arm
+    /// (`methods_0arg/mod.rs`) is gated on `class_name == "CX::Warn"`
+    /// specifically, not a generic exception check, so each type's
+    /// recognition is verified independently instead of assumed shared.
+    #[test]
+    fn exception_family_rows_are_backed_by_the_cascade() {
+        let mut interp = crate::runtime::Interpreter::new();
+        interp
+            .run(
+                r#"
+                my $f = Failure.new("oops");
+                my $adhoc = X::AdHoc.new(:message("boom"));
+                my $warn;
+                sub trigger-warn {
+                    CONTROL { when CX::Warn { $warn = $_; .resume } }
+                    warn "w";
+                }
+                trigger-warn();
+                my $tca;
+                try { my Int $x = "not an int"; CATCH { default { $tca = $_ } } }
+                "#,
+            )
+            .unwrap();
+        for (var, owner) in [
+            ("f", "Failure"),
+            ("adhoc", "X::AdHoc"),
+            ("warn", "CX::Warn"),
+            ("tca", "X::TypeCheck::Assignment"),
+        ] {
+            let sample = interp.env().get(var).cloned().unwrap();
+            let sample = sample.with_deref(|v| v.clone());
+            for &(row_owner, name, arity, flags) in super::super::native_method_row_table::RAW_ROWS
+            {
+                if row_owner != owner {
+                    continue;
+                }
+                let flags = NativeRowFlags(flags);
+                if flags.contains(NativeRowFlags::SPECIAL)
+                    || flags.contains(NativeRowFlags::MUTATES_RECEIVER)
+                {
+                    continue;
+                }
+                let observed = native_method_arities(&sample, name);
+                let mask = NativeArityMask(arity);
+                for (bit, m) in [
+                    (0u8, NativeArityMask::A0),
+                    (1u8, NativeArityMask::A1),
+                    (2u8, NativeArityMask::A2),
+                ] {
+                    if mask.contains(m) {
+                        assert!(
+                            observed & (1 << bit) != 0,
+                            "{owner}x{name} row claims arity {bit} but the cascade does not recognize it"
+                        );
+                    }
+                }
+            }
+            // Every probed exception-family receiver's chain must reach `Any`
+            // (via the `Exception`/`Failure` catalog splice), or the `Any`
+            // universal rows would silently stop applying again.
+            let chain = interp.dispatch_owner_chain(&sample);
+            assert!(
+                chain.iter().any(|t| t.as_str() == "Any"),
+                "{owner}'s dispatch_owner_chain should reach Any: {chain:?}"
+            );
+        }
+    }
+
     /// ADR-0019 E2b: `Any` gained seven more universal pseudo-methods
     /// (`self`/`clone`/`WHERE`/`WHICH`/`sink`/`item`/`serial`) alongside the
     /// existing `so`/`not`/`defined`/`DEFINITE` rows -- each has a receiver-

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -858,4 +858,44 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("RakuAST::StatementList", "Bool", 1, 0),
     ("RakuAST::StatementList", "flat", 7, 0),
     ("RakuAST::Statement::Expression", "expression", 1, 0),
+    // ADR-0019 E2b (seventh slice, 2026-08-10): `Failure`/`X::AdHoc`/
+    // `CX::Warn`/`X::TypeCheck::Assignment` rows, hand-probed against real
+    // values raised via the interpreter -- `so`/`not`/`defined`/`self`/
+    // `clone`/`WHERE`/`WHICH`/`sink`/`item`/`serial` are deliberately absent
+    // from all four: they are the `Any` universal rows above, now reachable
+    // via the chain walk after the `Exception`/`CX::Warn`/`Failure`
+    // `builtin_type_catalog` fixes. `resume`/`backtrace`/`message`/`throw`/
+    // `raku` vary per concrete type (confirmed by direct probe, not assumed
+    // shared -- e.g. `CX::Warn` lacks `throw`/`raku`; `Failure` lacks
+    // `message`/`backtrace`). Verified by
+    // `exception_family_rows_are_backed_by_the_cascade` in
+    // `native_method_row.rs`.
+    ("Failure", "resume", 1, 0),
+    ("Failure", "exception", 1, 0),
+    ("Failure", "handled", 1, 0),
+    ("Failure", "gist", 1, 0),
+    ("Failure", "raku", 1, 0),
+    ("Failure", "Str", 3, 0),
+    ("Failure", "Bool", 1, 0),
+    ("Failure", "throw", 1, 0),
+    ("X::AdHoc", "message", 1, 0),
+    ("X::AdHoc", "resume", 1, 0),
+    ("X::AdHoc", "backtrace", 1, 0),
+    ("X::AdHoc", "gist", 1, 0),
+    ("X::AdHoc", "Str", 3, 0),
+    ("X::AdHoc", "Bool", 1, 0),
+    ("X::AdHoc", "throw", 1, 0),
+    ("CX::Warn", "message", 1, 0),
+    ("CX::Warn", "resume", 1, 0),
+    ("CX::Warn", "backtrace", 1, 0),
+    ("CX::Warn", "gist", 1, 0),
+    ("CX::Warn", "Str", 3, 0),
+    ("CX::Warn", "Bool", 1, 0),
+    ("X::TypeCheck::Assignment", "message", 1, 0),
+    ("X::TypeCheck::Assignment", "resume", 1, 0),
+    ("X::TypeCheck::Assignment", "backtrace", 1, 0),
+    ("X::TypeCheck::Assignment", "gist", 1, 0),
+    ("X::TypeCheck::Assignment", "Str", 3, 0),
+    ("X::TypeCheck::Assignment", "Bool", 1, 0),
+    ("X::TypeCheck::Assignment", "throw", 1, 0),
 ];

--- a/src/runtime/receiver_class.rs
+++ b/src/runtime/receiver_class.rs
@@ -451,6 +451,22 @@ mod tests {
         assert_eq!(names, vec!["Int", "Cool", "Any", "Mu"]);
     }
 
+    /// ADR-0019 E2b: `Failure` is never declared as a real class (built
+    /// purely via `Value::make_instance`), so before the `builtin_type_catalog`
+    /// row was added its chain was just `["Failure"]` -- no continuation to
+    /// `Any`/`Mu` at all, meaning the `Any`-declared universal-method rows
+    /// (`so`/`defined`/`sink`/...) could never be found via the chain walk in
+    /// `record_native_row_coverage` no matter how many rows were added.
+    #[test]
+    fn failure_chain_reaches_any_and_mu_via_nil() {
+        let mut i = interp();
+        i.run("my $f = Failure.new(\"oops\");").unwrap();
+        let f = i.env().get("f").cloned().unwrap();
+        let chain = i.dispatch_owner_chain(&f);
+        let names: Vec<&str> = chain.iter().map(|t| t.as_str()).collect();
+        assert_eq!(names, vec!["Failure", "Nil", "Cool", "Any", "Mu"]);
+    }
+
     #[test]
     fn package_type_object_is_type_object_definedness_with_same_chain_as_instance() {
         let mut i = interp();


### PR DESCRIPTION
## Summary
- Seventh ADR-0019 E2b slice, and another root-cause chain-walk fix. `Failure`'s `dispatch_owner_chain` was just `["Failure"]` -- no continuation to `Any`/`Mu` -- since `Failure` is never declared as a real class anywhere in mutsu (built purely via `Value::make_instance`), so it had no `builtin_type_catalog` row and the registry has no model of its ancestry.
- Every built-in `X::*` exception type had the same problem one level up: each registers `Exception` as its parent, but `Exception` itself was never registered as an actual class, so `compute_class_mro`'s implicit-`Any` rule never applied to it and every `X::*` type's chain dead-ended at `Exception`. `CX::Warn` had it worse: built with no registered parent at all, so its chain was the bare `["CX::Warn"]`.
- Fixed with three new `builtin_type_catalog` rows (`Failure`, `Exception`, `CX::Warn`), all verified against real `raku` `.^mro` output. This alone makes the `Any`-declared universal rows (`so`/`not`/`defined`/`self`/`clone`/`WHERE`/`WHICH`/`sink`/`item`/`serial`) finally resolve for every `Failure`/`X::*`/`CX::Warn` receiver. Then hand-probed the concrete per-type rows still needed on top (`message`/`resume`/`backtrace`/`gist`/`raku`/`Str`/`Bool`/`throw`/`exception`/`handled`).
- Since this changes real `dispatch_owner_chain`/`class_chain` answers (not just the coverage-check shadow table), ran `make roast` locally in addition to `make test`, per the project's name/type-resolution-change rule -- both green.
- A fresh `t/`-wide sweep confirms `native_call_unmodeled` dropped from 1818 to 1498 (cumulative -96% from the original ~37904).

## Test plan
- [x] `cargo test --lib` (740 tests, +2 new)
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `make test` (3002 files / 28169 tests, PASS)
- [x] `make roast` (1435 files / 218774 tests, PASS) -- run locally since this touches real MRO/dispatch-chain answers
- [ ] CI `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)