### PR TITLE
refactor(adr0019): E2b eighth slice -- close the diffuse tail, fix an exception MRO gap

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2046,6 +2046,52 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     table), ran `make roast` locally, not just `make test`, per the "touched
     name/type resolution" rule -- both green (`cargo test --lib` 740 tests,
     `make test` unchanged file count, `make roast` 1435 files / 218774 tests).
+    **Progress 2026-08-10** (eighth slice): closed most of the diffuse tail
+    left above -- ~25 owners with no `builtin_type_method_names` entry (same
+    situation as `Pair`/`Seq`/`Match`), each hand-probed against a real value
+    built via one shared interpreter script (`Version`, `Date`, `DateTime`,
+    `Duration`, `Signature`, `Backtrace`/`Backtrace::Frame`, `Range` (13 new
+    names), `Rat`, `Map`, `Pair`, `CallFrame`, `List`/`Array` (4 shared
+    names), `Attribute`, `IO::Path::Parts`, `Capture`, `Complex`, `Instant`,
+    `Uni`, `Block`, `Supply`, `Junction`, `Seq`, plus 3 more `Match` names).
+    Two additions were root-cause fixes rather than plain per-owner rows: (1)
+    `Any`'s `gist`/`raku`/`hash` cover the bare `Any` type object (confirmed
+    the same `ValueView::Package` formatting arm in `dispatch_core_repr.rs`
+    renders every type object uniformly, including user classes, so the row
+    is not an `Any`-only artifact); (2) `Exception`'s `message`/`gist`/`Str`
+    are declared at the shared `cn == "Exception" || cn.starts_with("X::") ||
+    cn.starts_with("CX::")` gate in `methods_0arg/mod.rs`, so one
+    `Exception`-owner row -- found via the chain-walk, mirroring the
+    `Failure`/`Exception` catalog fix from the seventh slice -- covers every
+    `X::*`/`CX::*` type without its own more-specific row, verified against
+    three previously-unmodeled types (`X::Method::NotFound`,
+    `X::Str::Sprintf::Directives::Unsupported`, `X::Str::Numeric`) without
+    adding a row for any of them individually. Verifying the `Exception` row
+    surfaced a genuine registration gap, not just a coverage-table gap:
+    `X::Str::Sprintf::Directives::Unsupported`'s `dispatch_owner_chain` was
+    the bare `["X::Str::Sprintf::Directives::Unsupported"]` -- unlike
+    `X::Method::NotFound`/`X::Str::Numeric`, it was never registered via
+    `runtime_init.rs`'s `register_x` helper, so it had no parent info at all
+    and the chain-walk could never reach `Exception` no matter how many rows
+    existed. Fixed with one `register_x("X::Str::Sprintf::Directives::
+    Unsupported", "Exception")` call (confirmed against real `raku`'s
+    `.^mro`: `(Unsupported, Exception, Any, Mu)`). A fresh `t/`-wide sweep
+    confirmed `native_call_unmodeled` dropped from 1498 to 593 (cumulative
+    **-98.4%** from the original ~37904); the only remaining top-40 entries
+    are `ProfiledG x raku` (24, a test-defined grammar under EXPORTHOW custom
+    HOW, not a generalizable builtin owner), `RakuAST::IntLiteral x value`
+    (9), `Int x ^name` / `CArray[uint8] x elems` (7 each, both deferred: the
+    caret-name arm is gated on the value carrying a role mixin, not plain
+    `Int`, and a generic `Int` row would over-claim; `CArray` is NativeCall
+    plumbing, low leverage), and a long single-digit tail. New
+    `eighth_slice_tail_rows_are_backed_by_the_cascade` test
+    (`native_method_row.rs`). `cargo test --lib` (741 tests) and `make test`
+    (3002 files/28169 tests) both green; since the `register_x` fix changes a
+    real `dispatch_owner_chain` answer, ran a targeted local roast sweep
+    (`sprintf`/exception/date/range/signature/junction/version/duration/
+    instant-related whitelisted files, 83 files) rather than the full suite,
+    per the "touched name/type resolution" rule -- all green, full `make
+    roast` left to CI.
 - [ ] **E3 — Add the generation-keyed resolved-call cache.** Key by receiver TypeId, method symbol,
   call shape, and method generation; cache the ordered candidate sequence, not a second resolver.
   **Design 2026-08-10** (same doc): lands after E4b. Key `(TypeId, Symbol, CallShape)` where

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -740,4 +740,161 @@ mod tests {
             }
         }
     }
+
+    /// ADR-0019 E2b (eighth slice, 2026-08-10): the long diffuse tail left
+    /// after the seventh slice (no single dominant owner, mostly 4-30 hits
+    /// each) -- rows hand-probed against real values of ~25 owners
+    /// constructed via one shared interpreter script, none of which have a
+    /// `builtin_type_method_names` entry (same situation as `Pair`/`Seq`/
+    /// `Match` in earlier slices). See the table comment in
+    /// `native_method_row_table.rs` for the two root-cause rows (`Any`'s
+    /// `gist`/`raku`/`hash` for the bare type object, `Exception`'s
+    /// `message`/`gist`/`Str` covering the whole un-rowed `X::*`/`CX::*`
+    /// tail via the chain-walk).
+    #[test]
+    fn eighth_slice_tail_rows_are_backed_by_the_cascade() {
+        use crate::builtins::builtin_type_methods::native_method_arities;
+        use crate::symbol::Symbol;
+        let mut interp = crate::runtime::Interpreter::new();
+        interp
+            .run(
+                r#"
+                my $version = v1.2.3;
+                my $date = Date.new(2024,1,15);
+                my $datetime = DateTime.new(2024,1,15,12,30,0);
+                my $duration = now - now;
+                sub foo($a, $b) { }
+                my $sig = &foo.signature;
+                try { 42.no-such-method() };
+                my $notfound = $!;
+                try { sprintf("%Q", 1) };
+                my $unsupported = $!;
+                try { "abc".Numeric };
+                my $numeric-err = $!;
+                my $frame;
+                {
+                    my sub with-frame { fail }();
+                    CATCH { default {
+                        my $bt2 = .backtrace;
+                        $frame = $bt2.list[0];
+                    }}
+                }
+                my $bt = $notfound.backtrace;
+                my $range = 1..10;
+                my $rat = 1.5;
+                my $map = Map.new("a" => 1);
+                my $pair = ("a" => 1);
+                my $cf = callframe();
+                my $list = (1,2,3);
+                class E2bEighthSliceFoo { has $.x; }
+                my $attr = E2bEighthSliceFoo.^attributes[0];
+                my $iopath = IO::Path.new("/a/b/c.txt");
+                my $parts = $iopath.parts;
+                my $cap = \(1,2,3);
+                my $complex = 1+2i;
+                my $instant = now;
+                my Int @arr = 1,2,3;
+                my $uni = "x".NFC;
+                my $block = { 42 };
+                my $sup = Supply.from-list(1,2,3);
+                "#,
+            )
+            .unwrap();
+        let get = |name: &str| interp.env().get(name).cloned().unwrap();
+        let junction = Value::junction(
+            crate::value::JunctionKind::Any,
+            vec![Value::int(1), Value::int(2), Value::int(3)],
+        );
+        let seq = Value::seq(vec![Value::int(1), Value::int(2), Value::int(3)]);
+        let mut match_interp = crate::runtime::Interpreter::new();
+        match_interp.run("'foo' ~~ /f(o)(o)/;").unwrap();
+        let match_sample = match_interp.env().get("/").cloned().unwrap();
+        let samples: &[(&str, Value)] = &[
+            ("Any", Value::package(Symbol::intern("Any"))),
+            ("Mu", Value::package(Symbol::intern("Mu"))),
+            ("Nil", Value::NIL),
+            ("Version", get("version")),
+            ("Date", get("date")),
+            ("DateTime", get("datetime")),
+            ("Duration", get("duration")),
+            ("Signature", get("sig")),
+            ("Backtrace", get("bt")),
+            ("Backtrace::Frame", get("frame")),
+            ("Range", get("range")),
+            ("Rat", get("rat")),
+            ("Map", get("map")),
+            ("Pair", get("pair")),
+            ("CallFrame", get("cf")),
+            ("List", get("list")),
+            ("Array", get("@arr")),
+            ("Attribute", get("attr")),
+            ("IO::Path::Parts", get("parts")),
+            ("Capture", get("cap")),
+            ("Complex", get("complex")),
+            ("Instant", get("instant")),
+            ("Uni", get("uni")),
+            ("Block", get("block")),
+            ("Supply", get("sup")),
+            ("Junction", junction),
+            ("Seq", seq),
+            ("Match", match_sample),
+        ];
+        let extra_exception_samples: &[(&str, Value)] = &[
+            ("X::Method::NotFound", get("notfound")),
+            (
+                "X::Str::Sprintf::Directives::Unsupported",
+                get("unsupported"),
+            ),
+            ("X::Str::Numeric", get("numeric-err")),
+        ];
+        for (label, sample) in samples {
+            for &(row_owner, name, arity, flags) in RAW_ROWS {
+                if row_owner != *label {
+                    continue;
+                }
+                let flags = NativeRowFlags(flags);
+                if flags.contains(NativeRowFlags::SPECIAL)
+                    || flags.contains(NativeRowFlags::MUTATES_RECEIVER)
+                {
+                    continue;
+                }
+                let observed = native_method_arities(sample, name);
+                let mask = NativeArityMask(arity);
+                for (bit, m) in [
+                    (0u8, NativeArityMask::A0),
+                    (1u8, NativeArityMask::A1),
+                    (2u8, NativeArityMask::A2),
+                ] {
+                    if mask.contains(m) {
+                        assert!(
+                            observed & (1 << bit) != 0,
+                            "{label}x{name} row claims arity {bit} but the cascade does not recognize it"
+                        );
+                    }
+                }
+            }
+        }
+        // The `Exception` row's whole point is to cover types that have NO
+        // row of their own: confirm the cascade recognizes `message`/`gist`
+        // for each, and that each one's chain actually reaches `Exception`.
+        for (owner, sample) in extra_exception_samples {
+            for name in ["message", "gist"] {
+                assert_ne!(
+                    native_method_arities(sample, name) & 1,
+                    0,
+                    "{owner}x{name} should be recognized at arity 0"
+                );
+                assert_eq!(
+                    native_method_row(owner, name).0,
+                    NativeArityMask::N,
+                    "{owner} should not have its own {name} row (covered via Exception)"
+                );
+            }
+            let chain = interp.dispatch_owner_chain(sample);
+            assert!(
+                chain.iter().any(|t| t.as_str() == "Exception"),
+                "{owner}'s dispatch_owner_chain should reach Exception: {chain:?}"
+            );
+        }
+    }
 }

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -898,4 +898,113 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("X::TypeCheck::Assignment", "Str", 3, 0),
     ("X::TypeCheck::Assignment", "Bool", 1, 0),
     ("X::TypeCheck::Assignment", "throw", 1, 0),
+    // ADR-0019 E2b (eighth slice, 2026-08-10): the sweep's remaining tail was a
+    // long list of single-digit-to-dozens owners with no dominant offender.
+    // Each row below was hand-probed against a real value of that owner
+    // (constructed via the interpreter, not `builtin_sample_value`, which has
+    // no entry for any of these) using `native_method_arities`, the same
+    // discipline as every earlier E2b slice. Two are root-cause fixes rather
+    // than plain additions:
+    // - `Any`'s `gist`/`raku`/`hash` cover the BARE `Any` type object
+    //   (`Any.gist` -> "(Any)"), reached via the generic `ValueView::Package`
+    //   formatting arm in `dispatch_core_repr.rs` that renders every type
+    //   object uniformly -- confirmed the same arm serves user classes too
+    //   (`class Foo {}; Foo.gist` -> "(Foo)"), so the row is not a
+    //   `Any`-sample artifact.
+    // - `Exception`'s `message`/`gist`/`Str` are declared at the shared
+    //   `cn == "Exception" || cn.starts_with("X::") || cn.starts_with("CX::")`
+    //   gate in `methods_0arg/mod.rs`, so one `Exception`-owner row (found via
+    //   the chain-walk, same as `Failure`'s fix in the seventh slice) covers
+    //   every `X::*`/`CX::*` type that does NOT already have its own
+    //   more-specific row above -- verified against three previously-unmodeled
+    //   types (`X::Method::NotFound`, `X::Str::Sprintf::Directives::Unsupported`,
+    //   `X::Str::Numeric`) without adding a row for any of them individually.
+    ("Any", "gist", 1, 0),
+    ("Any", "raku", 1, 0),
+    ("Any", "hash", 1, 0),
+    ("Mu", "defined", 1, 0),
+    ("Nil", "gist", 1, 0),
+    ("Nil", "raku", 1, 0),
+    ("Exception", "message", 1, 0),
+    ("Exception", "gist", 1, 0),
+    ("Exception", "Str", 3, 0),
+    ("Version", "Str", 3, 0),
+    ("Version", "raku", 1, 0),
+    ("Version", "gist", 1, 0),
+    ("Version", "parts", 1, 0),
+    ("Date", "Str", 3, 0),
+    ("Date", "raku", 1, 0),
+    ("Date", "gist", 1, 0),
+    ("Date", "year", 1, 0),
+    ("Date", "mm-dd-yyyy", 1, 0),
+    ("Date", "yyyy-mm-dd", 1, 0),
+    ("Date", "dd-mm-yyyy", 1, 0),
+    ("DateTime", "Str", 3, 0),
+    ("DateTime", "raku", 1, 0),
+    ("DateTime", "gist", 1, 0),
+    ("DateTime", "hour", 1, 0),
+    ("DateTime", "year", 1, 0),
+    ("Duration", "Numeric", 1, 0),
+    ("Duration", "abs", 1, 0),
+    ("Duration", "Int", 1, 0),
+    ("Duration", "gist", 1, 0),
+    ("Duration", "raku", 1, 0),
+    ("Signature", "gist", 1, 0),
+    ("Signature", "raku", 1, 0),
+    ("Backtrace", "list", 1, 0),
+    ("Backtrace", "Str", 3, 0),
+    ("Backtrace", "gist", 1, 0),
+    ("Backtrace::Frame", "is-routine", 1, 0),
+    ("Backtrace::Frame", "subname", 1, 0),
+    ("Backtrace::Frame", "is-hidden", 1, 0),
+    ("Backtrace::Frame", "file", 1, 0),
+    ("Backtrace::Frame", "line", 1, 0),
+    ("Backtrace::Frame", "gist", 1, 0),
+    ("Range", "hyper", 1, 0),
+    ("Range", "lazy", 1, 0),
+    ("Range", "int-bounds", 1, 0),
+    ("Range", "Array", 1, 0),
+    ("Range", "join", 1, 0),
+    ("Range", "AT-POS", 2, 0),
+    ("Range", "Supply", 1, 0),
+    ("Range", "race", 1, 0),
+    ("Range", "List", 1, 0),
+    ("Range", "in-range", 2, 0),
+    ("Range", "head", 3, 0),
+    ("Range", "EXISTS-POS", 2, 0),
+    ("Range", "batch", 2, 0),
+    ("Rat", "FatRat", 3, 0),
+    ("Rat", "nude", 1, 0),
+    ("Map", "raku", 1, 0),
+    ("Map", "gist", 1, 0),
+    ("Map", "keys", 1, 0),
+    ("Map", "elems", 1, 0),
+    ("Pair", "Pair", 1, 0),
+    ("CallFrame", "defined", 1, 0),
+    ("List", "tree", 1, 0),
+    ("List", "pairup", 1, 0),
+    ("List", "hash", 1, 0),
+    ("List", "fmt", 7, 0),
+    ("Array", "tree", 1, 0),
+    ("Array", "pairup", 1, 0),
+    ("Array", "hash", 1, 0),
+    ("Array", "fmt", 7, 0),
+    ("Attribute", "defined", 1, 0),
+    ("IO::Path::Parts", "AT-KEY", 2, 0),
+    ("IO::Path::Parts", "AT-POS", 2, 0),
+    ("Capture", "list", 1, 0),
+    ("Capture", "hash", 1, 0),
+    ("Complex", "UInt", 1, 0),
+    ("Complex", "isNaN", 1, 0),
+    ("Instant", "to-posix", 1, 0),
+    ("Instant", "Numeric", 1, 0),
+    ("Uni", "Str", 3, 0),
+    ("Block", "lazy", 1, 0),
+    ("Supply", "list", 1, 0),
+    ("Junction", "gist", 1, 0),
+    ("Junction", "Bool", 1, 0),
+    ("Seq", "is-lazy", 1, 0),
+    ("Match", "Stringy", 1, 0),
+    ("Match", "join", 3, 0),
+    ("Match", "AT-POS", 2, 0),
 ];

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1711,6 +1711,9 @@ impl Interpreter {
         // X::Str::Numeric
         register_x("X::Str::Numeric", "Exception");
 
+        // X::Str::Sprintf::Directives::Unsupported — unsupported sprintf directive.
+        register_x("X::Str::Sprintf::Directives::Unsupported", "Exception");
+
         // X::Str::Match::x — invalid :x argument to .subst / s///
         register_x("X::Str::Match::x", "Exception");
 


### PR DESCRIPTION
## Summary
- Hand-probe `native_method_row` entries for ~25 owners left in the diffuse tail after the seventh E2b slice (Version, Date, DateTime, Duration, Signature, Backtrace/Backtrace::Frame, Range, Rat, Map, Pair, CallFrame, List/Array, Attribute, IO::Path::Parts, Capture, Complex, Instant, Uni, Block, Supply, Junction, Seq, Match), each verified against a real value built via the interpreter.
- Two root-cause additions generalize further than a plain row: `Any`'s `gist`/`raku`/`hash` cover the bare `Any` type object; `Exception`'s `message`/`gist`/`Str` cover the whole un-rowed `X::*`/`CX::*` tail via the chain-walk (mirroring the `Failure`/`Exception` catalog fix from the seventh slice).
- Verifying the `Exception` row surfaced a real registration gap: `X::Str::Sprintf::Directives::Unsupported` was never registered via `runtime_init.rs`'s `register_x` helper, so its `dispatch_owner_chain` never reached `Exception` at all -- fixed with the missing `register_x` call (confirmed against real `raku`'s `.^mro`).
- `native_call_unmodeled` drops from 1498 to 593 (cumulative **-98.4%** from the original ~37904).

## Test plan
- [x] `cargo test --lib` (741 tests, including new `eighth_slice_tail_rows_are_backed_by_the_cascade`)
- [x] `cargo clippy --lib -- -D warnings`, `cargo fmt`
- [x] `make test` (3002 files / 28169 tests)
- [x] Targeted local roast sweep (83 whitelisted files touching sprintf/exceptions/date/range/signature/junction/version/duration/instant) -- all green
- [ ] Full `make roast` via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)