### PR TITLE
test(t): import real Test::Util in 8 files that called its helpers unimported

### DIFF
--- a/t/io-handle-lock.t
+++ b/t/io-handle-lock.t
@@ -1,4 +1,6 @@
 use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
 plan 8;
 
 # IO::Handle.lock / .unlock using fcntl advisory record locks.

--- a/t/io-path-secure-resolve-link.t
+++ b/t/io-path-secure-resolve-link.t
@@ -1,4 +1,6 @@
 use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
 
 plan 12;
 

--- a/t/nil-semantics.t
+++ b/t/nil-semantics.t
@@ -1,4 +1,6 @@
 use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
 
 # Subscripting Nil (positionally or associatively) yields Nil again, so
 # chained access keeps returning Nil rather than an out-of-range Failure.

--- a/t/package-block-lexical-capture.t
+++ b/t/package-block-lexical-capture.t
@@ -1,4 +1,6 @@
 use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
 
 # A named sub defined inside a `package`/`module` BLOCK closes over the block's
 # `my` lexicals. mutsu's registry subs have no per-sub closure env and resolve

--- a/t/pairup.t
+++ b/t/pairup.t
@@ -1,4 +1,6 @@
 use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
 
 plan 6;
 

--- a/t/supply-collate.t
+++ b/t/supply-collate.t
@@ -1,4 +1,6 @@
 use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
 
 plan 4;
 

--- a/t/supply-list.t
+++ b/t/supply-list.t
@@ -1,4 +1,6 @@
 use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
 
 plan 4;
 

--- a/t/type-object-numeric-coercion.t
+++ b/t/type-object-numeric-coercion.t
@@ -1,4 +1,6 @@
 use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
 
 plan 9;
 

--- a/todo/tickets/nil-method-warnings-are-not-a-resumable-cx-warn.md
+++ b/todo/tickets/nil-method-warnings-are-not-a-resumable-cx-warn.md
@@ -1,0 +1,70 @@
+# `Nil.Real`/`.Int`/`.Str`'s warning is not a catchable `CX::Warn` control exception
+
+Found while retiring the native `Test::Util` overrides
+(`todo/tickets/retire-native-test-util-overrides.md`). When
+`t/any-type-object-int-coercion.t` and `t/bound-nil-method-warn.t` are
+switched to import the real `Test::Util` (`use lib
+$*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib"); use
+Test::Util;`), their `Nil.Real` / `Nil.Int` / `Nil.Str` (and bound-`Nil`
+equivalents) warning assertions fail — but the *same* files pass 100% under
+real `raku` with the same import. mutsu's own `warns-like` (used when the
+file does NOT import `Test::Util`, so mutsu's `is_test_function_name`
+fallback provides it) continues to report these as passing, so the
+divergence is specifically in how the underlying warning is *raised*, not
+in whether a warning fires at all.
+
+## Repro
+
+```raku
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+plan 1;
+warns-like { Nil.Real }, *.contains('Nil' & 'numeric'), 'Nil.Real warns';
+```
+
+mutsu: `not ok 1` — both `code threw a warning` AND `warning message passes
+test` fail (the subtest never sees the warning at all).
+raku: `ok 1`.
+
+## Root cause hypothesis
+
+Real `Test::Util`'s `warns-like` (`roast/packages/Test-Helpers/lib/Test/Util.rakumod:315-325`)
+catches the warning via:
+
+```raku
+CONTROL { when CX::Warn { $did-warn = True; $message = .message; .resume } }
+```
+
+i.e. it relies on `warn()` raising a **resumable `CX::Warn` control
+exception** that a `CONTROL` block can intercept. mutsu's native `Nil.Real`
+/ `.Int` / `.Str` coercions apparently print/raise their "Use of Nil in
+numeric/string context" warning through a different internal mechanism that
+does not surface as a `CX::Warn` a `CONTROL` handler can see — the message
+appears on stderr (confirmed: `t/any-type-object-int-coercion.t` without
+`Test::Util` prints `Use of Nil in numeric context` directly, so mutsu DOES
+warn, just not through the catchable-control-exception path).
+
+Narrower than it first looks: `Mu.Numeric`'s uninitialized-value warning
+(`t/type-object-numeric-coercion.t`) already works correctly through real
+`Test::Util`'s `warns-like` — only the `Nil`-specific coercion warnings
+(`Nil.Real`/`.Int`/`.Str`, plain and bound-via-`:=`) are affected. So the
+gap is specifically wherever the interpreter special-cases `Nil` numeric/
+string coercion warnings, not the general Cool-autoboxing warning path.
+
+## Where to look
+
+Find the `Nil` coercion warning call sites (search for "Use of Nil in" in
+`src/`) and compare how they raise the warning against whatever raises
+`Mu.Numeric`'s uninitialized-value warning (which IS caught correctly by
+`CONTROL { when CX::Warn }`). The `Nil` sites likely bypass the shared
+warn-raising helper the `Mu`/`Any` path uses.
+
+## Scope
+
+Not fixed as part of `retire-native-test-util-overrides` — that ticket
+reverted the `use Test::Util` addition for these two files (keeping them on
+mutsu's native `warns-like` fallback, which already passes) rather than
+block the mechanical migration on this deeper interpreter gap. The other 7
+files migrated in that PR (`is_run`, `is-eqv`, `is-path` callers) are
+unaffected.

--- a/todo/tickets/retire-native-test-util-overrides.md
+++ b/todo/tickets/retire-native-test-util-overrides.md
@@ -6,30 +6,95 @@ wide `is_test_function_name` set, so a routine imported from roast's real
 whitelisted roast files that `use Test::Util` pass
 (`news/2026-08/retired-native-test-util-overrides.md`).
 
-What is left is the deletion. The native handlers now run only for a file that
-calls one of those helpers **without** loading its module. Several `t/*.t` files
-do exactly that today (e.g. `t/io-handle-lock.t`, `t/supply-list.t`), so
-deleting the natives means adding the missing `use Test::Util` to them first —
-worth doing on its own, since `raku` rejects those files as written.
+## Progress (2026-08-10)
 
-Method:
+The file-migration half is done: of the 21 `t/*.t` files the ticket's grep
+flagged, only 10 were real (un-migrated) callers — the other 11 hits were
+comment-only mentions of the function names. Added `use lib
+$*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib"); use Test::Util;`
+to 8 of those 10 (all still pass under both `mutsu` and `raku`):
+`t/package-block-lexical-capture.t`, `t/supply-list.t`, `t/supply-collate.t`,
+`t/type-object-numeric-coercion.t`, `t/io-path-secure-resolve-link.t`,
+`t/pairup.t`, `t/nil-semantics.t`, `t/io-handle-lock.t`.
 
-```bash
-# files that call a Test::Util helper but never load the module
-grep -rl 'is_run\|is-path\|is-eqv\|group-of\|doesn.t-hang\|doesn.t-warn\|warns-like\|make-temp-' t/ \
-  | while read -r f; do grep -q 'use Test::Util' "$f" || echo "$f"; done
+**2 files were reverted** after migration surfaced a genuine interpreter bug,
+not a mechanical gap: `t/any-type-object-int-coercion.t` and
+`t/bound-nil-method-warn.t` call `warns-like` on `Nil.Real`/`.Int`/`.Str`
+coercions, and under the *real* `Test::Util`'s `warns-like` (which catches
+the warning via `CONTROL { when CX::Warn { ... .resume } }`), the warning is
+never observed at all — even though mutsu's native `warns-like` fallback (and
+real `raku`, with the same import) both see it fine. Filed as
+`todo/tickets/nil-method-warnings-are-not-a-resumable-cx-warn.md`. These two
+files are intentionally left un-migrated (still using mutsu's native
+`warns-like`) until that bug is fixed.
+
+Verified with the ticket's own grep re-run after these edits: the ONLY
+remaining un-migrated real caller in `t/` is `warns-like` (via the two
+reverted files above); every other candidate name (`is_run`,
+`Test::Util::run`, `get_out`, `is-eqv`, `group-of`, `doesn't-hang`,
+`doesn't-warn`, `make-temp-file`, `make-temp-path`, `make-temp-dir`,
+`is-deeply-junction`, `is-path`, `throws-like-any`) now has zero un-migrated
+`t/` callers. Also checked all whitelisted `roast/*.t` files for the same
+names without `use Test::Util` — none found (the only hit was
+`roast/fudge`, a Perl helper script, not a test file).
+
+## What is left: the deletion
+
+`call_test_function`'s match (`src/runtime/test_functions/mod.rs:261-315`)
+and `Interpreter::is_test_function_name` (`mod.rs:194-243`) can drop every
+arm/name **except** `"warns-like"` (still needed — see above) and the core
+`TEST_MODULE_EXPORTS` names (never touch those; they are `use Test` itself,
+not `Test::Util`). Concretely, remove these match arms and their
+`is_test_function_name` entries:
+
+```
+"throws-like-any" | "is_run" | "Test::Util::run" | "get_out"
+| "doesn't-warn" | "is-eqv" | "group-of" | "doesn't-hang"
+| "make-temp-file" | "make-temp-path" | "make-temp-dir"
+| "is-deeply-junction" | "is-path"
 ```
 
-Add the `use lib` + `use Test::Util` those files need, confirm each still passes
-under both `mutsu` and `raku`, then remove the native handlers from
-`src/runtime/test_functions/` and the corresponding names from
-`Interpreter::is_test_function_name`. `t/test-fn-import-shadow.t` is the pin to
-extend.
+Then delete the now-dead implementations (verify each has no other caller
+before deleting — `grep -rn 'fn <name>'` and `grep -rn '\.{name}\('` first):
+
+- **`src/runtime/test_functions/subprocess.rs`** (444 lines) — likely
+  deletable **in its entirety**: `test_fn_is_run`, `test_fn_get_out`,
+  `test_fn_run`, and their shared helpers `run_test_code_subprocess`,
+  `is_run_subprocess`, `extract_run_output_with_source`,
+  `split_tap_output_streams` appear to exist only for these three retired
+  functions. Confirm no other module calls the helpers before deleting the
+  file, then remove `mod subprocess;` from `test_functions/mod.rs`.
+- **`src/runtime/test_functions/comparison.rs`** (580 lines) — remove
+  `test_fn_is_deeply_junction` (~line 264) and `test_fn_is_eqv` (~line 558).
+  This file also hosts core `Test` comparisons (`is-deeply`, `is-approx`,
+  ...) that must NOT be touched — only delete the two named functions.
+- **`src/runtime/test_functions/util.rs`** (274 lines) — remove
+  `test_fn_doesnt_hang` (~line 8), `test_fn_make_temp_file` (~line 144),
+  `test_fn_make_temp_dir` (~line 193), `test_fn_is_path` (~line 240). Check
+  what (if anything) remains in the file afterward; it may become empty
+  enough to delete along with its `mod util;` line.
+- **`src/runtime/test_functions/tap_subtest.rs`** (200 lines) — remove
+  `test_fn_group_of` (~line 164); the rest of the file is core `subtest`
+  machinery, keep it.
+- **`src/runtime/test_functions/throws_like.rs`** (742 lines) — remove
+  `test_fn_throws_like_any` (~line 529); the rest is core `throws-like` /
+  `fails-like`, keep it.
+- **`src/runtime/test_functions/eval_exception.rs`** (568 lines) — remove
+  `test_fn_doesnt_warn` (~line 451); the rest is core eval-exception
+  machinery (`eval-lives-ok`, `eval-dies-ok`), keep it.
+
+After deleting, extend `t/test-fn-import-shadow.t` per the original plan,
+`cargo build` to catch anything still referencing the removed functions
+(e.g. dead `use` imports flagged by clippy), then run the full `t/` +
+`make roast` before opening the PR — this touches shared dispatch machinery
+(`call_test_function`, `is_test_function_name`) used by every `t/`/roast file
+that loads `Test`, so the safety net matters here more than usual.
 
 ## Known residue, unrelated to the deletion
 
 A file that ends with test failures prints `Runtime error: Test failures` on
 stderr, which rakudo does not. mutsu's `run()` returns the failure as a
-`RuntimeError` and `main` renders it. The exit status is already right (1), so
-the fix is to set `exit_code` and return `Ok`, the way the bailed-out branch
-does. Nothing asserts on it yet, but the next `is_run` slice will meet it.
+`RuntimeError` and `main` renders it. The exit status is already right (1),
+so the fix is to set `exit_code` and return `Ok`, the way the bailed-out
+branch does. Nothing asserts on it yet, but the next `is_run` slice will meet
+it.


### PR DESCRIPTION
## Summary
Part of `todo/tickets/retire-native-test-util-overrides.md`'s file-migration step (the prerequisite before the native `Test::Util` handlers can be deleted).

- Of the 21 `t/*.t` files the ticket's grep flagged as calling a `Test::Util` helper without loading the module, only 10 were real (un-migrated) callers — the other 11 were comment-only mentions.
- Added the standard `use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib"); use Test::Util;` header to 8 of those 10 (`is_run`, `is-eqv`, `is-path` callers) — all still pass under both `mutsu` and `raku`.
- The other 2 (`t/any-type-object-int-coercion.t`, `t/bound-nil-method-warn.t`) were migrated then **reverted**: their `warns-like` calls on `Nil.Real`/`.Int`/`.Str` stopped seeing the warning at all once routed through real `Test::Util`'s `CONTROL`-based `CX::Warn` catch, even though mutsu's native `warns-like` and real `raku` (same import) both see it fine. That's a genuine interpreter gap, not a mechanical migration gap — filed as `todo/tickets/nil-method-warnings-are-not-a-resumable-cx-warn.md`.
- Updated the parent ticket with the precise remaining deletion scope (exact match arms / functions / files to remove) now that this migration confirms `warns-like` is the only holdout function still needing its native handler.

This PR does NOT touch the native `Test::Util` dispatch code (`src/runtime/test_functions/`) — that deletion turned out to be a much larger, higher-risk slice (2800+ lines across 6 files, shared dispatch machinery used by every `Test`-loading file) and is left as the ticket's next step.

## Test plan
- [x] All 8 migrated files verified against both `raku` and `target/debug/mutsu` — pass on both.
- [x] The 2 reverted files verified to still pass via mutsu's native `warns-like` fallback.
- [x] Confirmed (re-running the ticket's grep) that `warns-like` is now the only Test::Util name with a remaining un-migrated `t/` caller; also checked all whitelisted `roast/*.t` files — none found.
- [x] Full local suite: `prove -j4 -e './target/debug/mutsu' t/` — 3004 files / 28180 tests, all pass.
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean (pre-commit hooks passed).
- [ ] CI (`make test` + `make roast`) — will watch after opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)