### PR TITLE
refactor(adr0019): E2b ninth slice -- close the Date/DateTime/Backtrace/Complex clusters

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2092,6 +2092,38 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     instant-related whitelisted files, 83 files) rather than the full suite,
     per the "touched name/type resolution" rule -- all green, full `make
     roast` left to CI.
+    **Progress 2026-08-10** (ninth slice): the `todo/deep/adr0019-e2-e4-resolver-core.md`
+    design's own risk note says E4b/E3 "may [not] land while `native_call_unmodeled`
+    ... is nonzero on the sweep corpus", so this slice closed three more
+    coherent clusters left after the eighth slice's partial coverage: the
+    full `Date`/`DateTime` accessor surface (`day`/`month`/`minute`/`second`/
+    `offset-in-minutes`/`offset-in-hours`/`timezone`/`days-in-year`/
+    `formatter`/`day-of-week`/`succ`/`perl`/`daycount`/`dd-mm-yyyy`/
+    `mm-dd-yyyy`/`yyyy-mm-dd`/`Date`/`Instant`, 21 rows total), plus
+    `Backtrace` (`flat`/`defined`/`concise`/`summary`/`Stringy`),
+    `Backtrace::Frame` (`is-setting`/`code`/`Str`), and `Complex`
+    (`re`/`im`/`reals`/`conj`/`reverse`/`Complex`), all hand-probed the same
+    way. A fresh `t/`-wide sweep confirmed `native_call_unmodeled` dropped
+    from 593 to 528 (cumulative **-98.6%** from the original ~37904). New
+    `ninth_slice_rows_are_backed_by_the_cascade` test. `cargo test --lib`
+    (743 tests) and `make test` (3004 files/28181 tests) both green; this
+    slice is pure row-table addition (no `dispatch_owner_chain`/registration
+    change), so no local roast run was required per the "touched name/type
+    resolution" rule.
+    **Assessment**: the remaining 528 is genuinely one-off -- individual
+    RakuAST node-accessor getters (one row per AST node class), NativeCall
+    `CArray[T]` element-type variants, and ad-hoc test-fixture class names
+    that appear as an "owner" only because that specific `t/` file declared
+    a class with that name (`Foo`, `TC`, `Wrapper`, `FooDate`, ...) -- not a
+    reusable cluster like `Any`/`Exception`/`Date` were. Continuing to chase
+    individual 1-2-hit entries here has sharply diminishing returns per the
+    effort already spent on three slices' worth of clustering. Before
+    E4b starts, re-run the sweep and either (a) accept a small nonzero
+    floor with each remaining hit justified inline (mirroring the
+    `flaky-tests.txt` precedent for accepted exceptions), or (b) spend one
+    more slice specifically on the RakuAST node-accessor family (the
+    largest remaining homogeneous cluster) if a session wants to push
+    further before flipping the switch.
 - [ ] **E3 — Add the generation-keyed resolved-call cache.** Key by receiver TypeId, method symbol,
   call shape, and method generation; cache the ordered candidate sequence, not a second resolver.
   **Design 2026-08-10** (same doc): lands after E4b. Key `(TypeId, Symbol, CallShape)` where

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -897,4 +897,69 @@ mod tests {
             );
         }
     }
+
+    /// ADR-0019 E2b (ninth slice, 2026-08-10): the full `Date`/`DateTime`
+    /// accessor cluster plus `Backtrace`/`Backtrace::Frame`/`Complex` extras
+    /// left after the eighth slice's partial coverage, hand-probed against
+    /// real values the same way.
+    #[test]
+    fn ninth_slice_rows_are_backed_by_the_cascade() {
+        use crate::builtins::builtin_type_methods::native_method_arities;
+        let mut interp = crate::runtime::Interpreter::new();
+        interp
+            .run(
+                r#"
+                my $date = Date.new(2024,3,15);
+                my $datetime = DateTime.new(2024,3,15,12,30,45);
+                try { 42.no-such-method() };
+                my $notfound = $!;
+                my $frame;
+                {
+                    my sub with-frame { fail }();
+                    CATCH { default {
+                        my $bt2 = .backtrace;
+                        $frame = $bt2.list[0];
+                    }}
+                }
+                my $bt = $notfound.backtrace;
+                my $complex = 3+4i;
+                "#,
+            )
+            .unwrap();
+        let get = |name: &str| interp.env().get(name).cloned().unwrap();
+        let samples: &[(&str, Value)] = &[
+            ("Date", get("date")),
+            ("DateTime", get("datetime")),
+            ("Backtrace", get("bt")),
+            ("Backtrace::Frame", get("frame")),
+            ("Complex", get("complex")),
+        ];
+        for (label, sample) in samples {
+            for &(row_owner, name, arity, flags) in RAW_ROWS {
+                if row_owner != *label {
+                    continue;
+                }
+                let flags = NativeRowFlags(flags);
+                if flags.contains(NativeRowFlags::SPECIAL)
+                    || flags.contains(NativeRowFlags::MUTATES_RECEIVER)
+                {
+                    continue;
+                }
+                let observed = native_method_arities(sample, name);
+                let mask = NativeArityMask(arity);
+                for (bit, m) in [
+                    (0u8, NativeArityMask::A0),
+                    (1u8, NativeArityMask::A1),
+                    (2u8, NativeArityMask::A2),
+                ] {
+                    if mask.contains(m) {
+                        assert!(
+                            observed & (1 << bit) != 0,
+                            "{label}x{name} row claims arity {bit} but the cascade does not recognize it"
+                        );
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -1007,4 +1007,47 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Match", "Stringy", 1, 0),
     ("Match", "join", 3, 0),
     ("Match", "AT-POS", 2, 0),
+    // ADR-0019 E2b (ninth slice, 2026-08-10): three more coherent clusters
+    // hand-probed the same way -- the full `Date`/`DateTime` accessor
+    // surface and `Backtrace`/`Backtrace::Frame`/`Complex` extras left after
+    // the eighth slice's partial coverage. The remaining sweep tail after
+    // this slice is genuinely one-off (RakuAST node accessors, NativeCall
+    // `CArray[T]` variants, ad-hoc test-fixture class names) with no
+    // reusable owner cluster left -- see the ADR progress note for why
+    // chasing it further has diminishing returns.
+    ("Date", "day", 1, 0),
+    ("Date", "month", 1, 0),
+    ("Date", "formatter", 1, 0),
+    ("Date", "day-of-week", 1, 0),
+    ("Date", "succ", 1, 0),
+    ("Date", "perl", 1, 0),
+    ("Date", "days-in-year", 1, 0),
+    ("Date", "daycount", 1, 0),
+    ("DateTime", "minute", 1, 0),
+    ("DateTime", "Date", 1, 0),
+    ("DateTime", "offset-in-minutes", 1, 0),
+    ("DateTime", "day", 1, 0),
+    ("DateTime", "month", 1, 0),
+    ("DateTime", "second", 1, 0),
+    ("DateTime", "timezone", 1, 0),
+    ("DateTime", "days-in-year", 1, 0),
+    ("DateTime", "dd-mm-yyyy", 1, 0),
+    ("DateTime", "mm-dd-yyyy", 1, 0),
+    ("DateTime", "yyyy-mm-dd", 1, 0),
+    ("DateTime", "offset-in-hours", 1, 0),
+    ("DateTime", "Instant", 1, 0),
+    ("Backtrace", "flat", 7, 0),
+    ("Backtrace", "defined", 1, 0),
+    ("Backtrace", "concise", 1, 0),
+    ("Backtrace", "summary", 1, 0),
+    ("Backtrace", "Stringy", 1, 0),
+    ("Backtrace::Frame", "is-setting", 1, 0),
+    ("Backtrace::Frame", "code", 1, 0),
+    ("Backtrace::Frame", "Str", 3, 0),
+    ("Complex", "re", 1, 0),
+    ("Complex", "im", 1, 0),
+    ("Complex", "reals", 1, 0),
+    ("Complex", "conj", 1, 0),
+    ("Complex", "reverse", 1, 0),
+    ("Complex", "Complex", 1, 0),
 ];


### PR DESCRIPTION
## Summary
- Add the full `Date`/`DateTime` accessor surface (`day`/`month`/`minute`/`second`/`offset-in-minutes`/`offset-in-hours`/`timezone`/`days-in-year`/`formatter`/`day-of-week`/`succ`/`perl`/`daycount`/`dd-mm-yyyy`/`mm-dd-yyyy`/`yyyy-mm-dd`/`Date`/`Instant`), plus `Backtrace` (`flat`/`defined`/`concise`/`summary`/`Stringy`), `Backtrace::Frame` (`is-setting`/`code`/`Str`), and `Complex` (`re`/`im`/`reals`/`conj`/`reverse`/`Complex`) rows, each hand-probed against a real interpreter value (same discipline as the eighth slice).
- `native_call_unmodeled` drops from 593 to 528 (cumulative **-98.6%** from the original ~37904).
- The remaining tail is genuinely one-off (individual RakuAST node accessors, NativeCall `CArray[T]` variants, ad-hoc test-fixture class names) with no reusable cluster left -- see the ADR progress note for the assessment and options before E4b starts (E4b's design doc explicitly gates on this counter being at/near zero).

## Test plan
- [x] `cargo test --lib` (743 tests, including new `ninth_slice_rows_are_backed_by_the_cascade`)
- [x] `cargo clippy --lib -- -D warnings`, `cargo fmt`
- [x] `make test` (3004 files / 28181 tests)
- [x] Spot-checked relevant roast files (Date, DateTime, DateTime-Instant-Duration, complex, exception catch) -- all green
- [ ] Full `make roast` via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)