### PR TITLE
refactor(adr0019): E2b tenth slice -- register the missing X::* exception types

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2124,6 +2124,37 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     more slice specifically on the RakuAST node-accessor family (the
     largest remaining homogeneous cluster) if a session wants to push
     further before flipping the switch.
+    **Progress 2026-08-10** (tenth slice): took option (a)'s spirit but as a
+    root-cause fix rather than a row addition -- the ninth slice's own
+    breakdown showed a 61-hit `X::*` cluster (biggest owner-group left) that
+    the eighth slice's `Exception` row should already have covered but did
+    not. The cause was not a missing row: `raku -e 'X::ControlFlow.^mro'`
+    confirmed `X::ControlFlow, Exception, Any, Mu`, but mutsu's own
+    `X::ControlFlow.^mro».^name` reported just `X::ControlFlow, Any, Mu` --
+    `Exception` was missing entirely. Twenty-one `X::*` types built all over
+    the interpreter (directly via `Value::make_instance`, or via the
+    `"X::Type: text"` message convention `split_typed_message_convention`
+    parses into a typed instance) were never `register_x`'d in
+    `runtime_init.rs`, so their registry MRO dead-ended at themselves with no
+    `Exception` continuation -- meaning `$exc ~~ Exception` and
+    `$exc.isa(Exception)` were silently `False` for any of them, not just a
+    counter artifact. Every name was confirmed against a live `raku -e`
+    probe before registering (one, `X::Role::Composition::Conflict`, is a
+    mutsu-only name from the message convention with no real rakudo
+    counterpart; `X::React::Died` is a role in rakudo but an Instance in
+    mutsu already) both still get `Exception` ancestry for mutsu's own
+    `CATCH`/`.isa` semantics to be internally consistent. Also added the
+    `Exception`-owner rows for `line`/`file`/`backtrace`/`throw`/`resume` --
+    declared in the same `cn.starts_with("X::")`-gated match blocks as
+    `message`/`gist`/`Str` but not yet in the row table. A fresh sweep
+    confirmed the entire `X::*` cluster (61 hits) is gone: `native_call_unmodeled`
+    dropped from 528 to 475. New `tenth_slice_exception_registration_rows_are_backed_by_the_cascade`
+    test. `cargo test --lib` (745 tests) and `make test` (3007 files/28205
+    tests) both green; local roast run on the 45 whitelisted files
+    referencing any touched `X::*` name (per the "touched name/type
+    resolution" rule, since this changes MRO/registration) also green.
+    Remaining 475 is the RakuAST/NativeCall/test-fixture tail the ninth
+    slice's assessment already described -- still no dominant cluster left.
 - [ ] **E3 — Add the generation-keyed resolved-call cache.** Key by receiver TypeId, method symbol,
   call shape, and method generation; cache the ordered candidate sequence, not a second resolver.
   **Design 2026-08-10** (same doc): lands after E4b. Key `(TypeId, Symbol, CallShape)` where

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -962,4 +962,97 @@ mod tests {
             }
         }
     }
+
+    /// ADR-0019 E2b (tenth slice, 2026-08-10): closes the `X::*` cluster --
+    /// not by adding per-type rows, but by fixing the root cause the eighth
+    /// slice's `Exception` row already assumed: dozens of `X::*` types were
+    /// never `register_x`'d (see `runtime_init.rs`), so their registry MRO
+    /// dead-ended at themselves with no `Exception` continuation, and the
+    /// `Exception`-owner rows never applied to them via the chain walk. Also
+    /// covers `line`/`file`/`backtrace`/`throw`/`resume`, the remaining
+    /// `Exception`-gated methods the eighth slice's `message`/`gist`/`Str`
+    /// rows did not yet include.
+    #[test]
+    fn tenth_slice_exception_registration_rows_are_backed_by_the_cascade() {
+        let mut interp = crate::runtime::Interpreter::new();
+        interp
+            .run(
+                r#"
+                my $cf = X::ControlFlow.new(:message("boom"));
+                my $unsat = X::CompUnit::UnsatisfiedDependency.new(:message("nope"));
+                my $seqc = X::Seq::Consumed.new(:message("consumed"));
+                my $dbz = X::Numeric::DivideByZero.new(:message("div0"));
+                my $plain;
+                try { die "X::Role::Composition::Conflict: multiple candidates" };
+                $plain = $!;
+                "#,
+            )
+            .unwrap();
+        let get = |name: &str| interp.env().get(name).cloned().unwrap();
+        let samples: &[(&str, Value)] = &[
+            ("X::ControlFlow", get("cf")),
+            ("X::CompUnit::UnsatisfiedDependency", get("unsat")),
+            ("X::Seq::Consumed", get("seqc")),
+            ("X::Numeric::DivideByZero", get("dbz")),
+            ("X::Role::Composition::Conflict", get("plain")),
+        ];
+        for (owner, sample) in samples {
+            let chain = interp.dispatch_owner_chain(sample);
+            assert!(
+                chain.iter().any(|t| t.as_str() == "Exception"),
+                "{owner}'s dispatch_owner_chain should reach Exception now it is register_x'd: {chain:?}"
+            );
+            for name in [
+                "message",
+                "gist",
+                "Str",
+                "line",
+                "file",
+                "backtrace",
+                "throw",
+                "resume",
+            ] {
+                assert_ne!(
+                    native_method_arities(sample, name) & 1,
+                    0,
+                    "{owner}x{name} should be recognized at arity 0"
+                );
+                assert_eq!(
+                    native_method_row(owner, name).0,
+                    NativeArityMask::N,
+                    "{owner} should not need its own {name} row (covered via Exception)"
+                );
+            }
+        }
+        // The new Exception-owner rows themselves must be backed by the
+        // cascade too, probed against the bare `Exception` type's own row
+        // declaration (mirrors the eighth slice's `message`/`gist`/`Str`
+        // check for the same owner).
+        for &(row_owner, name, arity, flags) in super::super::native_method_row_table::RAW_ROWS {
+            if row_owner != "Exception" {
+                continue;
+            }
+            let flags = NativeRowFlags(flags);
+            if flags.contains(NativeRowFlags::SPECIAL)
+                || flags.contains(NativeRowFlags::MUTATES_RECEIVER)
+            {
+                continue;
+            }
+            let (_, sample) = &samples[0];
+            let observed = native_method_arities(sample, name);
+            let mask = NativeArityMask(arity);
+            for (bit, m) in [
+                (0u8, NativeArityMask::A0),
+                (1u8, NativeArityMask::A1),
+                (2u8, NativeArityMask::A2),
+            ] {
+                if mask.contains(m) {
+                    assert!(
+                        observed & (1 << bit) != 0,
+                        "Exceptionx{name} row claims arity {bit} but the cascade does not recognize it"
+                    );
+                }
+            }
+        }
+    }
 }

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -928,6 +928,19 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Exception", "message", 1, 0),
     ("Exception", "gist", 1, 0),
     ("Exception", "Str", 3, 0),
+    // ADR-0019 E2b (tenth slice): `line`/`file`/`backtrace` and `throw`/
+    // `resume` are declared in the SAME `cn == "Exception" ||
+    // cn.starts_with("X::") || cn.starts_with("CX::")`-gated match blocks in
+    // `methods_0arg/mod.rs` as `message`/`gist`/`Str` above (the `throw`/
+    // `resume` gates additionally admit `Failure` and `CX::Warn` by name, but
+    // those already have their own rows), so one `Exception`-owner row each
+    // covers every `X::*`/`CX::*` subtype the chain walk now reaches (see the
+    // `register_x` additions in `runtime_init.rs` this same slice).
+    ("Exception", "line", 1, 0),
+    ("Exception", "file", 1, 0),
+    ("Exception", "backtrace", 1, 0),
+    ("Exception", "throw", 1, 0),
+    ("Exception", "resume", 1, 0),
     ("Version", "Str", 3, 0),
     ("Version", "raku", 1, 0),
     ("Version", "gist", 1, 0),

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1802,6 +1802,50 @@ impl Interpreter {
         register_x("X::Channel::SendOnClosed", "Exception");
         register_x("X::Channel::ReceiveOnClosed", "Exception");
 
+        // ADR-0019 E2b (tenth slice, 2026-08-10): these X::* types are
+        // constructed all over the interpreter (either directly via
+        // `Value::make_instance`, or via the `"X::Type: text"` message
+        // convention that `split_typed_message_convention` turns into a typed
+        // instance) but were never `register_x`'d, so their registry MRO
+        // dead-ended at themselves with no `Exception`/`Any`/`Mu` continuation
+        // at all -- found via `dispatch_owner_chain` on live samples
+        // (`X::ControlFlow.^mro` reported `X::ControlFlow, Any, Mu`, skipping
+        // `Exception` entirely). This is not just a coverage-counter artifact:
+        // it means `$exc ~~ Exception` and `$exc.isa(Exception)` were False
+        // for any of these until caught by a CATCH's own class-name-prefix
+        // matching, and `.defined`/`.so` fell through to a different
+        // dispatch path than every other exception. Every name below was
+        // confirmed against `raku -e '... .^mro».^name ...'` to have
+        // `Exception` as its sole direct parent, EXCEPT `X::Role::Composition::Conflict`
+        // (a mutsu-only name from the message convention above, not a real
+        // rakudo type) and `X::React::Died` (a role in rakudo, not a class,
+        // but mutsu already models it as an Instance the same way as every
+        // other X::* here) -- both still belong under Exception for mutsu's
+        // own CATCH/`.isa` semantics to be internally consistent.
+        register_x("X::Attribute::Required", "Exception");
+        register_x("X::Comp::FailGoal", "Exception");
+        register_x("X::CompUnit::UnsatisfiedDependency", "Exception");
+        register_x("X::ControlFlow", "Exception");
+        register_x("X::Declaration::OurScopeInRole", "Exception");
+        register_x("X::Dynamic::NotFound", "Exception");
+        register_x("X::IO::Unlink", "Exception");
+        register_x("X::IllegalDimensionInShape", "Exception");
+        register_x("X::Inheritance::UnknownParent", "Exception");
+        register_x("X::Mixin::NotComposable", "Exception");
+        register_x("X::NoZeroArgMeaning", "Exception");
+        register_x("X::Numeric::CannotConvert", "Exception");
+        register_x("X::Numeric::DivideByZero", "Exception");
+        register_x("X::Numeric::Uninitialized", "Exception");
+        register_x("X::React::Died", "Exception");
+        register_x("X::Role::Composition::Conflict", "Exception");
+        register_x("X::Role::Instantiation", "Exception");
+        register_x("X::Seq::Consumed", "Exception");
+        register_x("X::Str::Sprintf::Directives::Count", "Exception");
+        register_x("X::Syntax::BlockGobbled", "Exception");
+        register_x("X::Syntax::CannotMeta", "Exception");
+        register_x("X::Syntax::Extension::Category", "Exception");
+        register_x("X::Syntax::Extension::TooComplex", "Exception");
+
         // X::Comp::AdHoc does both X::Comp and X::AdHoc in rakudo (it is the
         // compile-time wrapper around an ad-hoc die), so `$e ~~ X::AdHoc` must
         // also be True. register_x only threads a single parent, so splice


### PR DESCRIPTION
## Summary
- Twenty-one `X::*` exception types (`X::ControlFlow`, `X::CompUnit::UnsatisfiedDependency`, `X::Numeric::DivideByZero`, `X::Seq::Consumed`, ...) were constructed all over the interpreter but never `register_x`'d in `runtime_init.rs`, so their registry MRO dead-ended at themselves with no `Exception`/`Any`/`Mu` continuation.
- Confirmed against `raku -e '...^mro...'` (real: `X::ControlFlow, Exception, Any, Mu`) vs mutsu's own `X::ControlFlow, Any, Mu` -- this is a real correctness bug (`.isa(Exception)`/`~~ Exception` were silently `False`), not just a coverage-counter artifact.
- Also adds the `Exception`-owner rows for `line`/`file`/`backtrace`/`throw`/`resume`, declared in the same `starts_with("X::")` gate as `message`/`gist`/`Str` but missing from the row table.
- `native_call_unmodeled` drops from 528 to 475; the entire `X::*` cluster (61 hits, the largest owner-group left per the ninth slice's breakdown) is now fully closed.

## Test plan
- [x] `cargo test --lib` (745 tests, all green)
- [x] `make test` (3007 files / 28205 tests, all green)
- [x] Local roast run on the 45 whitelisted files referencing any touched `X::*` name (per the "touched name/type resolution" rule) -- all green
- [x] New `tenth_slice_exception_registration_rows_are_backed_by_the_cascade` unit test
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)