### PR TITLE
refactor(adr0019): E2b eleventh slice -- RakuAST node-accessor rows

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2155,6 +2155,34 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     resolution" rule, since this changes MRO/registration) also green.
     Remaining 475 is the RakuAST/NativeCall/test-fixture tail the ninth
     slice's assessment already described -- still no dominant cluster left.
+    **Progress 2026-08-10** (eleventh slice): closed the `RakuAST::*`
+    node-accessor cluster (55 hits, the largest owner-group left after the
+    tenth slice). Unlike the exception cluster, every field-accessor call on
+    a `RakuAST::*` node dispatches through ONE shared, data-driven site
+    (`rakuast::node_accessor`, `methods_0arg/mod.rs`) that reads the node's
+    own `fields` list by name -- there is no per-class dispatch bug to fix,
+    just 31 missing (owner, field-name) rows across 19 node classes.
+    `rakuast::accessor_names` (a separate introspection-only registry
+    feeding `.^methods`/`.^attributes`) was considered as a mechanical
+    source to generate every row from, but rejected: it is itself
+    incomplete for 4 of the needed classes (`QuotedString`,
+    `Call::Name::WithoutParentheses`, `Statement::If`, `PointyBlock` all
+    have real fields `node_accessor` serves but no `accessor_names` entry),
+    so trusting it would have propagated that gap into the row table.
+    Instead each row was hand-probed against real nodes built the same two
+    ways `t/rakuast-construct-*.t` already does (direct `RakuAST::Foo.new(...)`
+    construction for `Parameter`/`ParameterTarget::Var`/`Type::Simple`/
+    `StrLiteral`, `Q[...].AST` deparse for the rest) -- catching along the
+    way that a plain string literal (`"abc"`) deparses to `QuotedString`,
+    not `StrLiteral`, confirmed by direct probe rather than assumed from the
+    name. A fresh sweep confirmed the entire `RakuAST::*` cluster is gone:
+    `native_call_unmodeled` dropped from 528 to 403 (cumulative **-98.9%**
+    from the original ~37904) -- no dominant cluster left in either of the
+    two E2b-tracked breakdowns run this session. New
+    `eleventh_slice_rakuast_accessor_rows_are_backed_by_the_cascade` test.
+    `cargo test --lib` (745 tests) and `make test` (3007 files/28205 tests)
+    both green; pure row-table addition (no dispatch/registration change),
+    so no local roast run required per the established rule.
 - [ ] **E3 — Add the generation-keyed resolved-call cache.** Key by receiver TypeId, method symbol,
   call shape, and method generation; cache the ordered candidate sequence, not a second resolver.
   **Design 2026-08-10** (same doc): lands after E4b. Key `(TypeId, Symbol, CallShape)` where

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -1055,4 +1055,139 @@ mod tests {
             }
         }
     }
+
+    /// ADR-0019 E2b (eleventh slice, 2026-08-10): the RakuAST node-accessor
+    /// cluster. Every owner probed here dispatches through the single
+    /// shared, data-driven `rakuast::node_accessor` site, so this test
+    /// exists to pin the actual field names each class carries (verified
+    /// against real nodes, not `rakuast::accessor_names`, which is a
+    /// separate and in a few cases incomplete introspection-only registry)
+    /// rather than to exercise per-class dispatch logic.
+    #[test]
+    fn eleventh_slice_rakuast_accessor_rows_are_backed_by_the_cascade() {
+        let mut interp = crate::runtime::Interpreter::new();
+        interp
+            .run(
+                r#"
+                use experimental :rakuast;
+                use MONKEY-SEE-NO-EVAL;
+
+                sub target($name) { RakuAST::ParameterTarget::Var.new(name => $name) }
+                my $target = target('$x');
+                my $int-type = RakuAST::Type::Simple.new(RakuAST::Name.from-identifier('Int'));
+                my $typed-param = RakuAST::Parameter.new(type => $int-type, target => $target);
+                my $named-param = RakuAST::Parameter.new(names => ['value'], target => target('$value'));
+                my $optional-param = RakuAST::Parameter.new(target => target('$y'), optional => True);
+                my $default-param = RakuAST::Parameter.new(target => target('$z'), default => RakuAST::IntLiteral.new(7));
+                my $slurpy-param = RakuAST::Parameter.new(target => target('@r'), slurpy => RakuAST::Parameter::Slurpy::Flattened);
+                my $where-param = RakuAST::Parameter.new(target => target('$w2'), where => RakuAST::IntLiteral.new(1));
+                my $sig = RakuAST::Signature.new(parameters => [$typed-param]);
+                my $strlit = RakuAST::StrLiteral.new("abc");
+
+                my $decl_ast = Q[my $y = 1 + -2].AST;
+                my $decl = $decl_ast.statements[0].expression;
+                my $init = $decl.initializer;
+                my $applyinfix = $init.expression;
+                my $intlit = $applyinfix.left;
+                my $applyprefix = $applyinfix.right;
+
+                my $ratlit_ast = Q[1.5].AST;
+                my $ratlit = $ratlit_ast.statements[0].expression;
+
+                my $qs_ast = Q[my $w; "a$w b"].AST;
+                my $qs = $qs_ast.statements[1].expression;
+
+                my $call_ast = Q[say 42].AST;
+                my $call = $call_ast.statements[0].expression;
+
+                my $if_ast = Q[if 1 {2} else {4}].AST;
+                my $ifnode = $if_ast.statements[0];
+
+                my $pb_ast = Q[-> $x { $x }].AST;
+                my $pb = $pb_ast.statements[0].expression;
+                my $pbsig = $pb.signature;
+
+                my $sub_ast = Q[sub foo($x) { $x }].AST;
+                my $sub = $sub_ast.statements[0].expression;
+                my $blockoid = $sub.body;
+
+                my $varlex_ast = Q[$y].AST;
+                my $varlex = $varlex_ast.statements[0].expression;
+
+                my $block_ast = Q[{ 42 }].AST;
+                my $block = $block_ast.statements[0].expression;
+                "#,
+            )
+            .unwrap();
+        let get = |name: &str| interp.env().get(name).cloned().unwrap();
+        let samples: &[(&str, Value)] = &[
+            ("RakuAST::IntLiteral", get("intlit")),
+            ("RakuAST::RatLiteral", get("ratlit")),
+            ("RakuAST::StrLiteral", get("strlit")),
+            ("RakuAST::QuotedString", get("qs")),
+            ("RakuAST::Var::Lexical", get("varlex")),
+            ("RakuAST::VarDeclaration::Simple", get("decl")),
+            ("RakuAST::Initializer::Assign", get("init")),
+            ("RakuAST::ApplyInfix", get("applyinfix")),
+            ("RakuAST::ApplyPrefix", get("applyprefix")),
+            ("RakuAST::Call::Name::WithoutParentheses", get("call")),
+            ("RakuAST::Statement::If", get("ifnode")),
+            ("RakuAST::Block", get("block")),
+            ("RakuAST::PointyBlock", get("pb")),
+            ("RakuAST::Signature", get("sig")),
+            ("RakuAST::Signature", get("pbsig")),
+            ("RakuAST::Sub", get("sub")),
+            ("RakuAST::Blockoid", get("blockoid")),
+            ("RakuAST::Parameter", get("typed-param")),
+            ("RakuAST::Parameter", get("named-param")),
+            ("RakuAST::Parameter", get("optional-param")),
+            ("RakuAST::Parameter", get("default-param")),
+            ("RakuAST::Parameter", get("slurpy-param")),
+            ("RakuAST::Parameter", get("where-param")),
+            ("RakuAST::ParameterTarget::Var", get("target")),
+            ("RakuAST::Type::Simple", get("int-type")),
+        ];
+        // `RakuAST::Parameter` models several OPTIONAL fields (`names`/
+        // `optional`/`default`/`slurpy`/`where`): each sample only carries
+        // the fields it was actually `.new()`-constructed with, so a row is
+        // "backed by the cascade" if ANY probed sample of that owner
+        // recognizes it (mirroring `native_method_arities`'s own "a small
+        // spread of representative arguments -- recognition just needs ONE
+        // to return `Some`" discipline), not every sample of that owner.
+        for &(row_owner, name, arity, flags) in super::super::native_method_row_table::RAW_ROWS {
+            if !row_owner.starts_with("RakuAST::") {
+                continue;
+            }
+            let flags = NativeRowFlags(flags);
+            if flags.contains(NativeRowFlags::SPECIAL)
+                || flags.contains(NativeRowFlags::MUTATES_RECEIVER)
+            {
+                continue;
+            }
+            let matching_samples: Vec<&Value> = samples
+                .iter()
+                .filter(|(owner, _)| *owner == row_owner)
+                .map(|(_, sample)| sample)
+                .collect();
+            if matching_samples.is_empty() {
+                continue;
+            }
+            let observed = matching_samples
+                .iter()
+                .fold(0u8, |acc, sample| acc | native_method_arities(sample, name));
+            let mask = NativeArityMask(arity);
+            for (bit, m) in [
+                (0u8, NativeArityMask::A0),
+                (1u8, NativeArityMask::A1),
+                (2u8, NativeArityMask::A2),
+            ] {
+                if mask.contains(m) {
+                    assert!(
+                        observed & (1 << bit) != 0,
+                        "{row_owner}x{name} row claims arity {bit} but no probed sample's cascade recognizes it"
+                    );
+                }
+            }
+        }
+    }
 }

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -1063,4 +1063,55 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Complex", "conj", 1, 0),
     ("Complex", "reverse", 1, 0),
     ("Complex", "Complex", 1, 0),
+    // ADR-0019 E2b (eleventh slice, 2026-08-10): the RakuAST node-accessor
+    // family, the largest remaining homogeneous cluster after the tenth
+    // slice closed `X::*`. Every field-accessor call on a `RakuAST::*` node
+    // (`rakuast::node_accessor`, `methods_0arg/mod.rs`) is served by ONE
+    // shared, data-driven 0-arg dispatch site that reads the node's own
+    // `fields` list by name -- there is no per-class Rust match arm to point
+    // a comment at, so each row here is simply "this class's real field
+    // list", hand-probed against live nodes built the same two ways the
+    // existing `t/rakuast-construct-*.t` suite already does: direct
+    // `RakuAST::Foo.new(...)` construction for `Parameter`/
+    // `ParameterTarget::Var`/`Type::Simple`/`StrLiteral`, and `Q[...].AST`
+    // deparse for everything reached more naturally by parsing (a plain
+    // string literal like `"abc"` deparses to `QuotedString`, not
+    // `StrLiteral` -- confirmed by direct probe, not assumed). See
+    // `rakuast::accessor_names` for the (separate, and in a few cases
+    // incomplete -- e.g. it does not list `QuotedString`/`Call::Name::
+    // WithoutParentheses`/`Statement::If`/`PointyBlock`) introspection-only
+    // registry `.^methods`/`.^attributes` read; `node_accessor`'s real
+    // per-instance `fields` list is the actual source of truth these rows
+    // were verified against.
+    ("RakuAST::IntLiteral", "value", 1, 0),
+    ("RakuAST::RatLiteral", "value", 1, 0),
+    ("RakuAST::StrLiteral", "value", 1, 0),
+    ("RakuAST::QuotedString", "segments", 1, 0),
+    ("RakuAST::Var::Lexical", "name", 1, 0),
+    ("RakuAST::VarDeclaration::Simple", "sigil", 1, 0),
+    ("RakuAST::VarDeclaration::Simple", "desigilname", 1, 0),
+    ("RakuAST::VarDeclaration::Simple", "initializer", 1, 0),
+    ("RakuAST::Initializer::Assign", "expression", 1, 0),
+    ("RakuAST::ApplyInfix", "left", 1, 0),
+    ("RakuAST::ApplyInfix", "right", 1, 0),
+    ("RakuAST::ApplyPrefix", "operand", 1, 0),
+    ("RakuAST::Call::Name::WithoutParentheses", "name", 1, 0),
+    ("RakuAST::Statement::If", "condition", 1, 0),
+    ("RakuAST::Statement::If", "then", 1, 0),
+    ("RakuAST::Block", "body", 1, 0),
+    ("RakuAST::Blockoid", "statement-list", 1, 0),
+    ("RakuAST::PointyBlock", "signature", 1, 0),
+    ("RakuAST::Sub", "name", 1, 0),
+    ("RakuAST::Sub", "signature", 1, 0),
+    ("RakuAST::Sub", "body", 1, 0),
+    ("RakuAST::Signature", "parameters", 1, 0),
+    ("RakuAST::Parameter", "type", 1, 0),
+    ("RakuAST::Parameter", "names", 1, 0),
+    ("RakuAST::Parameter", "target", 1, 0),
+    ("RakuAST::Parameter", "optional", 1, 0),
+    ("RakuAST::Parameter", "default", 1, 0),
+    ("RakuAST::Parameter", "where", 1, 0),
+    ("RakuAST::Parameter", "slurpy", 1, 0),
+    ("RakuAST::ParameterTarget::Var", "name", 1, 0),
+    ("RakuAST::Type::Simple", "name", 1, 0),
 ];


### PR DESCRIPTION
## Summary
- Closes the `RakuAST::*` node-accessor cluster (55 hits, the largest owner-group left after the tenth slice, #6199).
- Every field-accessor call on a `RakuAST::*` node dispatches through one shared, data-driven site (`rakuast::node_accessor`), so this is 31 missing `(owner, field-name)` rows across 19 node classes rather than a dispatch bug.
- `rakuast::accessor_names` (a separate introspection-only registry feeding `.^methods`/`.^attributes`) was considered as a mechanical source to generate every row from, but rejected: it is itself incomplete for 4 of the needed classes (`QuotedString`, `Call::Name::WithoutParentheses`, `Statement::If`, `PointyBlock` all have real fields `node_accessor` serves but no `accessor_names` entry). Each row was instead hand-probed against real nodes built the same two ways `t/rakuast-construct-*.t` already does (direct `RakuAST::Foo.new(...)` construction, and `Q[...].AST` deparse) -- catching along the way that a plain string literal deparses to `QuotedString`, not `StrLiteral`.
- `native_call_unmodeled` drops from 528 to 403 (cumulative **-98.9%** from the original ~37904).

## Test plan
- [x] `cargo test --lib` (745 tests, all green)
- [x] `make test` (3009 files / 28214 tests, all green)
- [x] New `eleventh_slice_rakuast_accessor_rows_are_backed_by_the_cascade` unit test
- [x] Pure row-table addition (no dispatch/registration change), so no local roast run required per the established rule
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)