### PR TITLE
docs(todo): record module-resolution repro follow-up and new HTTP/2 data-frame ticket

### DIFF
--- a/todo/tickets/http2-data-frame-content-mismatch-in-request-response-serializer-tests.md
+++ b/todo/tickets/http2-data-frame-content-mismatch-in-request-response-serializer-tests.md
@@ -1,0 +1,122 @@
+# HTTP/2 Data frame content check ("check 4") fails consistently across `http2-request-parser`/`http2-request-serializer`/`http2-response-serializer` rakutest suites
+
+## TL;DR
+
+Three Cro::HTTP2 rakutest files each have exactly one recurring subtest
+failure shape: a test helper (`sub test($request, $count, $desc, *@checks,
+:$fail)` in `http2-request-serializer.rakutest`, similarly named/shaped
+helpers in the other two files) runs several numbered "check N" assertions
+per emitted HTTP/2 frame; the LAST check in each affected case — comparing
+the frame's `.data` (a `Buf`, the DATA-frame body payload) against the
+originally-emitted random `Buf` via `eq` — fails, while earlier checks in
+the same case (frame type, flags, stream-identifier) pass.
+
+As of 2026-08-10 (release build, `bash tmp/cro-suite-run.sh http`):
+
+- `http2-request-parser.rakutest`: 1 failure (subtest "check 4")
+- `http2-request-serializer.rakutest`: 3 failures (same "check 4" shape,
+  once per test-case with a body: "Header + Data", "Header + Data (no
+  content-length)", possibly a third variant — see the file)
+- `http2-response-serializer.rakutest`: 3 failures, identical shape
+
+## Evidence
+
+```
+DIST=<CRO_HTTP_CHECKOUT>
+$BIN $INC -I "$DIST/lib" -I "$DIST/t" t/http2-request-serializer.rakutest
+# ok 3 - check 3
+# not ok 4 - check 4
+# (repeated 3x across the file's test cases)
+```
+
+Relevant excerpt, `<CRO_HTTP_CHECKOUT>/t/http2-request-serializer.rakutest`:
+
+```raku
+sub test($request, $count, $desc, *@checks, :$fail) {
+    ...
+    $serializer.transformer($fake-in.Supply).tap:
+    -> $frame {
+        for @checks[$counter].kv -> $i, $check {
+            ok $check($frame), "check {$i + 1}";
+        }
+        ...
+    }, ...
+    ...
+}
+...
+test $req, 2, 'Header + Data',
+    [[(* ~~ Cro::HTTP2::Frame::Headers), (*.flags == 4),
+      (*.stream-identifier == 5), (*.headers eq $encoder.encode-headers(@headers))],
+     [(* ~~ Cro::HTTP2::Frame::Data), (*.flags == 1),
+      (*.stream-identifier == 5), (*.data eq $random)]];   # <-- check 4 of the 2nd frame: fails
+```
+
+The body flows: `$body = Supplier::Preserving.new; $body.emit: $random;
+$body.done; ... $req.set-body-byte-stream: $body.Supply;` → serialized by
+`Cro::HTTP2::RequestSerializer.transformer` (`<CRO_HTTP_CHECKOUT>/lib/Cro/HTTP2/RequestSerializer.rakumod:51-66`):
+
+```raku
+if $req.has-body {
+    with $req.header('Content-Length') {
+        my $counter = $_;
+        whenever $body-byte-stream {
+            $counter -= .elems;
+            emit Cro::HTTP2::Frame::Data.new(
+                flags => $counter == 0 ?? 1 !! 0,
+                stream-identifier => $req.http2-stream-id,
+                data => $_
+            );
+            ...
+        }
+    }
+    ...
+}
+```
+
+So the emitted `Frame::Data.data` should be byte-identical to `$random`
+(a single 123-byte chunk, well under any frame-size limit, emitted once).
+
+## What was tried and ruled out (do not re-attempt — both matched `raku`,
+neither reproduced the mutsu bug)
+
+1. A minimal `Buf eq` round-trip through `Supplier::Preserving` (no HTTP2
+   involved): `$body.emit($random); $body.done; $body.Supply.tap: -> $data
+   { say $data eq $random }` — printed `True` under both `raku` and mutsu.
+   See `tmp/buf-eq-repro.raku`.
+2. A minimal nested-`whenever`-with-implicit-topic repro mirroring the
+   RequestSerializer's exact shape (outer `whenever $in -> $body-byte-stream
+   { whenever $body-byte-stream { emit Frame.new(data => $_) } }`, no `Cro`
+   dependency) — printed `True`/correct elem counts under both `raku` and
+   mutsu. See `tmp/whenever-data-topic-repro.raku`.
+3. A third variant adding the exact `with $req.header('Content-Length') {
+   my $counter = $_; whenever $body-byte-stream { ... $_ ... } }` topic
+   shape (outer `with`'s `$_` captured to `my $counter` BEFORE a nested
+   `whenever` reuses `$_` for its own, different topic — the leading
+   candidate hypothesis, since this project's campaign has repeatedly found
+   `$_`/topic-leak-through-frame bugs, see MEMORY.md's "直近で入った一般バグ
+   修正" note, 4 such bugs in one session) — also printed correct output
+   under both `raku` and mutsu. See `tmp/whenever-data-topic-repro2.raku`.
+
+None of the three isolates the trigger, so the bug needs either the real
+`Cro::HTTP2::RequestSerializer`/`ResponseSerializer` class (with its full
+`Cro::Transform` role composition, `HTTP::HPACK::Encoder`, and the rest of
+`Cro::HTTP2::Frame`'s class hierarchy) or a closer structural match not yet
+found — most likely something in `Cro::Transform`'s own `.transformer()`
+composition/dispatch machinery, or `Cro::HTTP2::Frame::Data`'s own
+attribute/`is`-trait machinery, rather than the bare `whenever`/topic
+mechanics tested above. A real shadow-bisect of
+`Cro::HTTP2::RequestSerializer.rakumod` itself (or `rust-gdb` breakpoints
+tracing what `$_`/the `Data.new(data => ...)` argument actually holds at
+each `emit`) is the next step, not another from-scratch synthetic repro.
+
+## Discovery context
+
+Found during a Cro::HTTP suite re-measurement (2026-08-10, `bash
+tmp/cro-suite-run.sh http`, 26/35 files fully green). This is one of the
+remaining 9 non-green files.
+
+## Verification (once fixed)
+
+- `http2-request-serializer.rakutest`, `http2-response-serializer.rakutest`,
+  `http2-request-parser.rakutest` should each report `notok=0` in
+  `tmp/cro-suite-run.sh http`'s per-file summary.

--- a/todo/tickets/module-resolution-flaky-with-multiple-I-paths-and-global-precomp-cache.md
+++ b/todo/tickets/module-resolution-flaky-with-multiple-I-paths-and-global-precomp-cache.md
@@ -100,3 +100,71 @@ this module-loading path.
 
 - The commands in "Evidence" above should give `ok` deterministically, run
   after run, with no dependency on `~/.cache/mutsu/precomp`'s prior state.
+
+## 2026-08-10 follow-up: two independent attempts to reproduce, both inconclusive — read before spending more time here
+
+**Background-agent investigation (~85 runs, could not reproduce):** a
+dedicated investigation session ran the exact "Evidence" repro (and the
+heavier `Cro::HTTP::Client` chain, closer to the original
+`Cro::Policy::Timeout` symptom) roughly 85 times — sequential batches of
+5/10/20, 10-12x concurrent parallel launches, cold and warm
+`~/.cache/mutsu/precomp`, and a from-scratch `cargo build --release`
+rebuild (byte-identical via sccache, ruling out a stale binary) — and got
+`ok` every single time, zero failures. It traced both `resolve_module_path`
+(`src/runtime/run_modules.rs:7-108`, a pure deterministic filesystem walk,
+no shared cache) and `MODULE_SCAN_CACHE` (`src/parser/stmt/simple/module_exports.rs:21-26`,
+correctly keyed by resolved file path) and found nothing unsound. It flagged
+a plausible **prior** cause: `ParseMemo` (`src/parser/memo.rs`) used to key
+memo entries by raw `(ptr, len)` of the input `&str`, which could return a
+stale entry for unrelated input when a short-lived nested-parse buffer got
+freed and its address reused (see
+`todo/deep/pointy-block-custom-param-trait-parse-time-check-fails-for-large-modules.md`
+for the proven, identical-signature case: same input/`-I` set flipping pass
+↔ fail across rebuilds). That hole was closed in commit `490dc01a4` (PR
+#6132, merged 2026-08-09) by mixing a per-parse-call generation counter into
+every memo key — confirmed to be an ancestor of both this ticket's base
+commit and current `HEAD`, so it cannot be the (whole) explanation, but the
+failure mode class matches closely enough that a *residual* variant is worth
+suspecting if this recurs.
+
+**A separate same-session direct reproduction turned out to be a shell
+artifact, not a mutsu bug — a critical confound to rule out first.** Testing
+independently (not knowing about the agent's negative result yet), a
+combined `INC="-I path1 -I path2 -I path3 ..."` string (as built by
+`tmp/cro-suite-run.sh` into one shell variable, one `-I` per Cro
+dependency) reproduced "Could not find Cro::Message" **deterministically,
+5/5**, when expanded unquoted directly in an interactive **zsh** shell
+(`$BIN $INC -I ... -e '...'`). Wrapping the *exact same* command in
+`bash -c '...'` made it pass **5/5**. Root cause: zsh does not word-split an
+unquoted variable expansion by default (bash does), so `$INC` — a string
+containing several embedded `-I path` pairs — collapsed into ONE argv
+element that no `-I` flag parser recognizes as multiple paths; effectively
+none of `$INC`'s paths reached the search list, only whatever separate,
+individually-quoted `-I "$SINGLE_PATH"` flags followed it. This is the same
+zsh trap already documented in
+[[session-lexical-sub-escape-fix]]/CLAUDE.md conventions (`${=INC}` or
+`bash -c` wrapping fixes it). **This specific combined-`$INC` pattern is
+NOT what the original "Evidence" section above used** (that one passes each
+`-I $VAR` separately, one single-path variable per flag, which is immune to
+this particular trap) — so this finding does not retroactively explain the
+original report, but it DOES mean: before trusting any *future* "could not
+find module" observation in this codebase, first check whether the
+reproducing command used a single shell variable holding multiple `-I
+path` pairs expanded unquoted, and if so, re-verify via `bash -c` before
+concluding it is a real interpreter bug. Both of these session's Cro-suite
+"module resolution" observations (`http2-request-parser`,
+`http2-request-serializer`, `http2-response-serializer`,
+`http-response-parser`, `http-session-inmemory`, `http-session-persistent`
+all transiently showing "Could not find X in module repositories" earlier
+in this session) were this exact zsh artifact — re-verified via `bash -c`
+immediately afterward, all six now show real, different, reproducible
+`not ok` subtest failures instead (module loads fine) — recorded separately
+where relevant, not further evidence for this ticket.
+
+**Net effect: no confirmed live reproduction of the *original* per-`-I`-flag
+pattern exists as of this update.** The next session that picks this up
+should first attempt the original "Evidence" section's exact commands
+(separate `-I $VAR` flags, always via `bash -c` or a `.sh` script to rule
+out shell quoting entirely) several dozen times; if it still cannot
+reproduce, consider closing this ticket as unreproducible/stale rather than
+letting it block on a phantom.


### PR DESCRIPTION
## Summary
- `module-resolution-flaky` ticket: two independent 2026-08-10 attempts to reproduce found nothing conclusive (a background-agent investigation ran ~85 clean iterations; a separate reproduction turned out to be a zsh word-split shell artifact, not a mutsu bug). Documented as a confound to check first before trusting any future "could not find module" report.
- New ticket: three Cro::HTTP2 rakutest files each fail one recurring Data-frame content check. Three synthetic repro attempts ruled out (documented so a future session doesn't repeat them); needs a shadow-bisect of the real module instead.

Docs-only change — no interpreter behavior changes.

## Test plan
- N/A (docs-only)