### PR TITLE
refactor(adr0019): E2b twelfth slice -- fix parametrized type-name MRO chains

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2183,6 +2183,54 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     `cargo test --lib` (745 tests) and `make test` (3007 files/28205 tests)
     both green; pure row-table addition (no dispatch/registration change),
     so no local roast run required per the established rule.
+    **Progress 2026-08-10** (twelfth slice): fixed a genuine MRO-computation
+    bug for parametrized type names (`Array[Int]`, `array[int32]`,
+    `CArray[uint8]`) rather than adding more rows. `catalog_chain_for_name`'s
+    and `class_mro`/`class_mro_readonly`'s fallback for an uncataloged name
+    used to be `[name, Any, Mu]` / a bare `[name]` -- never reaching the
+    base type's real ancestry (`array[int32].^mro` in real raku is
+    `array[int32], array, Cool, Any, Mu`; mutsu's chain skipped straight to
+    `Any`/`Mu` or dead-ended at the name alone). Fixed by stripping the
+    `[...]` argument and splicing the base type's own catalog chain when the
+    base is a catalog builtin (the existing `Blob[uint32]`-style handling
+    only covered a base that was itself a *registered* class). This also
+    required two new catalog rows (`array`, `CArray` -- the NativeCall
+    typed-array bases; only the boxed `Array` collection type had one) and
+    surfaced a SECOND, independent latent bug in
+    `class_chain_with_catalog_tail`: its `continues` branch (detecting when
+    the registry MRO already carries a catalog-consistent continuation)
+    matched the newly-fully-spliced chain and then unconditionally
+    `break`-ed without pushing the rest of it, silently truncating a chain
+    like `[array[int32], array, Cool, Any, Mu]` back down to
+    `[array[int32], array]`. Both fixes are general (not array-specific) --
+    the second one benefits every builtin ancestor whose registry MRO
+    happens to already continue consistently, not just parametrized names.
+    Two new receiver_class.rs tests
+    (`parametrized_type_object_chain_is_not_truncated`,
+    `typed_native_array_type_object_chain_is_not_truncated`) plus a catalog
+    pin (`native_array_bases_match_raku_exactly`). `cargo test --lib` (748
+    tests) and `make test` (3010 files/28218 tests) both green; this touches
+    core MRO computation used far beyond arrays (registry.rs/receiver_class.rs
+    are load-bearing for `.^mro`, method resolution, augment gates, ...), so
+    117 whitelisted roast files across `S09-typed-arrays`/`S12-class`/
+    `S14-roles`/generics/NativeCall were run locally per the "touched
+    name/type resolution" rule -- all green.
+    **Gate-renegotiation proposal (raised with the user, not yet decided):**
+    after 12 slices `native_call_unmodeled` is down **~99%** (~37904 to
+    ~400) with no dominant cluster left; remaining hits are dozens of 1-10-hit
+    one-offs (individual RakuAST-adjacent one-offs, NativeCall `CArray[T]`
+    per-owner methods, ad-hoc test-fixture class names) that so far have
+    turned out NOT to be real dispatch bugs on inspection (unlike the tenth
+    and twelfth slices' finds). The design doc's own risk note requires this
+    counter to be exactly zero before E4b/E3 can land ("neither...may land
+    while `native_call_unmodeled`...is nonzero on the sweep corpus"). Given
+    the diminishing returns on the remaining tail, a proposed alternative
+    surfaced during advice-seeking on this decision: make E4b's resolver
+    fall back to the existing cascade on any row miss AND keep incrementing
+    the counter, so an incomplete table degrades to today's behavior instead
+    of misdispatching -- turning "zero" from a hard precondition into a
+    monitoring goal. This is a change to Phase E's contract and needs an
+    explicit decision, not a silent exception list; not yet adopted.
 - [ ] **E3 — Add the generation-keyed resolved-call cache.** Key by receiver TypeId, method symbol,
   call shape, and method generation; cache the ordered candidate sequence, not a second resolver.
   **Design 2026-08-10** (same doc): lands after E4b. Key `(TypeId, Symbol, CallShape)` where

--- a/src/builtins/builtin_type_catalog.rs
+++ b/src/builtins/builtin_type_catalog.rs
@@ -89,6 +89,26 @@ static CATALOG: &[BuiltinTypeInfo] = &[
         roles: ["Positional", "Iterable"],
         owner: "Array",
     ),
+    // `array`/`CArray` are the NativeCall-facing typed-array bases (lower-case
+    // `array` for `array[int32]` etc., `CArray` for `nativecast`ed C arrays).
+    // Neither was previously in this catalog OR in `registry.rs`'s separate
+    // `builtin_mro_table`, so a value/type-object of a parametrized name like
+    // `Array[Int]`/`array[int32]`/`CArray[uint8]` fell all the way through
+    // both tables' fallbacks to `[name]` or `[name, Any, Mu]` -- never
+    // reaching this row's own ancestry, even though `Array[Int]` itself
+    // already had a row (ADR-0019 E2b twelfth slice: the fallback that
+    // strips a `Base[T]` name and splices `Base`'s catalog chain is what
+    // actually reaches it, in `receiver_class.rs`/`registry.rs`). raku:
+    // `array.^mro` is `array, Cool, Any, Mu`; `CArray.^mro` is (short-named,
+    // dropping the real `NativeCall::Types::` package prefix mutsu does not
+    // model) `CArray, Any, Mu`.
+    row!(
+        "array",
+        mro: ["array", "Cool", "Any", "Mu"],
+        roles: ["Positional"],
+        owner: "",
+    ),
+    row!("CArray", mro: ["CArray", "Any", "Mu"], roles: ["Positional"], owner: ""),
     row!(
         "List",
         mro: ["List", "Cool", "Any", "Mu"],
@@ -589,6 +609,22 @@ mod tests {
         );
         let row = builtin_type_info("Buf[uint8]").unwrap();
         assert_eq!(row.mro, &["Buf[uint8]", "Any", "Mu"]);
+    }
+
+    #[test]
+    fn native_array_bases_match_raku_exactly() {
+        // ADR-0019 E2b (twelfth slice, 2026-08-10): `array`/`CArray` are the
+        // NativeCall-facing typed-array bases; confirmed against
+        // `array.^mro`/`CArray.^mro` (short-named -- the real
+        // `NativeCall::Types::CArray` package prefix is not modeled here).
+        assert_eq!(
+            builtin_type_info("array").unwrap().mro,
+            &["array", "Cool", "Any", "Mu"]
+        );
+        assert_eq!(
+            builtin_type_info("CArray").unwrap().mro,
+            &["CArray", "Any", "Mu"]
+        );
     }
 
     #[test]

--- a/src/runtime/receiver_class.rs
+++ b/src/runtime/receiver_class.rs
@@ -174,6 +174,20 @@ impl Interpreter {
         {
             return info.mro.iter().map(|s| TypeId::intern(s)).collect();
         }
+        // A parametrized name (`Array[Int]`, `array[int32]`, `CArray[uint8]`)
+        // not itself in the catalog: strip the `[...]` argument and splice the
+        // BASE type's own catalog chain ahead of it (mirrors `registry.rs`'s
+        // `class_mro`/`class_mro_readonly` fix for the same pattern, ADR-0019
+        // E2b twelfth slice) -- without this, every typed-array VALUE's chain
+        // dead-ended at itself, never reaching `Array`/`List`/`Any`/`Mu`.
+        if let Some((base, _)) = name.split_once('[')
+            && name.ends_with(']')
+            && let Some(info) = builtin_type_info(base)
+        {
+            let mut chain = vec![TypeId::intern(name)];
+            chain.extend(info.mro.iter().map(|s| TypeId::intern(s)));
+            return chain;
+        }
         vec![
             TypeId::intern(name),
             well_known_types().any,
@@ -214,7 +228,15 @@ impl Interpreter {
                     .mro
                     .get(1)
                     .is_some_and(|next| reg_mro.get(i + 1).is_some_and(|s| s.as_str() == *next));
-                if !continues {
+                if continues {
+                    // `reg_mro` already carries the catalog's own continuation
+                    // (ADR-0019 E2b twelfth slice: `class_mro`'s parametrized-name
+                    // fallback for `Array[Int]`/`array[int32]`/`CArray[uint8]`
+                    // splices the full catalog tail itself) -- push the rest of
+                    // `reg_mro` verbatim instead of stopping here, or the chain
+                    // would silently drop everything past this builtin ancestor.
+                    chain.extend(reg_mro[i + 1..].iter().map(|s| TypeId::from_symbol(*s)));
+                } else {
                     for tail_name in &info.mro[1..] {
                         let tid = TypeId::intern(tail_name);
                         if !chain.contains(&tid) {
@@ -465,6 +487,49 @@ mod tests {
         let chain = i.dispatch_owner_chain(&f);
         let names: Vec<&str> = chain.iter().map(|t| t.as_str()).collect();
         assert_eq!(names, vec!["Failure", "Nil", "Cool", "Any", "Mu"]);
+    }
+
+    /// ADR-0019 E2b (twelfth slice, 2026-08-10): a bare parametrized TYPE
+    /// OBJECT (`Array[Int]`, `array[int32].WHAT`, ...) is a `Package` whose
+    /// name is the literal parametrized string -- never a user-declared
+    /// class, so `class_mro("Array[Int]")` used to treat it as parentless
+    /// (`compute_class_mro`'s fallback for an unregistered class with no
+    /// parents), yielding just `["Array[Int]"]` with no continuation at
+    /// all, unlike raku's real `Array[Int].^mro` (`Array[Int], Array, List,
+    /// Cool, Any, Mu`). Confirmed against raku (`Array[Int].gist` was
+    /// `native_call_unmodeled`-flagged before this fix, per the full `t/`
+    /// sweep), then fixed in two steps: (1) `class_mro`/`class_mro_readonly`
+    /// strip the `[...]` argument and splice the base's own catalog chain
+    /// when the base is a catalog builtin (not just a registered class,
+    /// which the existing `Blob[uint32]`-style handling already covered),
+    /// and (2) `class_chain_with_catalog_tail`'s `continues` branch, which
+    /// matched the now-already-spliced tail and `break`-ed WITHOUT pushing
+    /// the rest of `reg_mro` -- silently truncating the chain right back
+    /// down to `[Array[Int], Array]`. Fixed by extending `chain` with the
+    /// remaining `reg_mro` elements on the `continues` branch instead of
+    /// dropping them.
+    #[test]
+    fn parametrized_type_object_chain_is_not_truncated() {
+        let mut i = interp();
+        let package = Value::package(crate::symbol::Symbol::intern("Array[Int]"));
+        let chain = i.dispatch_owner_chain(&package);
+        let names: Vec<&str> = chain.iter().map(|t| t.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["Array[Int]", "Array", "List", "Cool", "Any", "Mu"]
+        );
+    }
+
+    /// ADR-0019 E2b (twelfth slice): the NativeCall-facing sibling of the
+    /// test above, using the newly-added `array` catalog row (previously
+    /// only `Array`, the boxed collection type, had one).
+    #[test]
+    fn typed_native_array_type_object_chain_is_not_truncated() {
+        let mut i = interp();
+        let package = Value::package(crate::symbol::Symbol::intern("array[int32]"));
+        let chain = i.dispatch_owner_chain(&package);
+        let names: Vec<&str> = chain.iter().map(|t| t.as_str()).collect();
+        assert_eq!(names, vec!["array[int32]", "array", "Cool", "Any", "Mu"]);
     }
 
     #[test]

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -631,11 +631,22 @@ impl Registry {
         if !self.classes.contains_key(class_name)
             && let Some((base, _)) = class_name.split_once('[')
             && class_name.ends_with(']')
-            && self.classes.contains_key(base)
         {
-            let mut mro = vec![Symbol::intern(class_name)];
-            mro.extend(self.class_mro(base).iter().copied());
-            return mro.into();
+            if self.classes.contains_key(base) {
+                let mut mro = vec![Symbol::intern(class_name)];
+                mro.extend(self.class_mro(base).iter().copied());
+                return mro.into();
+            }
+            // `base` is not a user-registered class but IS a catalog builtin
+            // (`Array[Int]`, `array[int32]`, `CArray[uint8]`, ...): splice the
+            // catalog's own chain directly rather than recursing through
+            // `class_mro`, whose `compute_class_mro` fallback would otherwise
+            // treat an un-registered `base` like "Array" as parentless.
+            if let Some(info) = crate::builtins::builtin_type_catalog::builtin_type_info(base) {
+                let mut mro = vec![Symbol::intern(class_name)];
+                mro.extend(info.mro.iter().map(|s| Symbol::intern(s)));
+                return mro.into();
+            }
         }
         let mut stack = Vec::new();
         match self.compute_class_mro(class_name, &mut stack) {
@@ -664,11 +675,17 @@ impl Registry {
             }
             if let Some((base, _)) = class_name.split_once('[')
                 && class_name.ends_with(']')
-                && self.classes.contains_key(base)
             {
-                let mut mro = vec![Symbol::intern(class_name)];
-                mro.extend(self.class_mro_readonly(base)?.iter().copied());
-                return Some(mro.into());
+                if self.classes.contains_key(base) {
+                    let mut mro = vec![Symbol::intern(class_name)];
+                    mro.extend(self.class_mro_readonly(base)?.iter().copied());
+                    return Some(mro.into());
+                }
+                if let Some(info) = crate::builtins::builtin_type_catalog::builtin_type_info(base) {
+                    let mut mro = vec![Symbol::intern(class_name)];
+                    mro.extend(info.mro.iter().map(|s| Symbol::intern(s)));
+                    return Some(mro.into());
+                }
             }
             // Not a registered class at all: the write side computes but has no
             // `ClassDef` to cache into, so the result is identical read-only.


### PR DESCRIPTION
## Summary
- `Array[Int]`, `array[int32]`, `CArray[uint8]`, and similar parametrized type names had a broken MRO fallback: an uncataloged name resolved to `[name, Any, Mu]` (or just `[name]` for a Package type object) instead of reaching the base type's real ancestry. raku's `array[int32].^mro` is `array[int32], array, Cool, Any, Mu`; mutsu's chain skipped straight past it.
- Fixed by stripping the `[...]` argument and splicing the base type's own catalog chain when the base is a catalog builtin (not just a registered class, which the existing `Blob[uint32]`-style handling already covered). This required two new catalog rows (`array`, `CArray` -- the NativeCall typed-array bases) and surfaced a **second, independent** bug in `class_chain_with_catalog_tail`: its "continues" branch matched the newly-fully-spliced chain and then broke without pushing the rest of it, silently truncating the chain right back down. Both fixes are general, not array-specific.
- After twelve slices, `native_call_unmodeled` is down **~99%** (~37904 to ~400) with no dominant cluster left in the remainder. This PR's commit also raises a gate-renegotiation proposal in the ADR (docs-only note, not yet decided) for whether E4b's resolver should fall back to the cascade on a row miss rather than require the counter to hit exactly zero first.

## Test plan
- [x] `cargo test --lib` (748 tests, all green)
- [x] `make test` (3010 files / 28218 tests, all green)
- [x] Two new `receiver_class.rs` tests plus a `builtin_type_catalog.rs` pin
- [x] This touches core MRO computation used far beyond arrays, so 117 whitelisted roast files across `S09-typed-arrays`/`S12-class`/`S14-roles`/generics/NativeCall were run locally -- all green
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)