### PR TITLE
feat(regex): add LTM declarative-prefix measurement primitive (ADR-0022 Slice 1)

### DIFF
--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -4,6 +4,7 @@ mod regex_eval_class;
 mod regex_eval_repeat;
 pub(crate) mod regex_helpers;
 mod regex_interpolate;
+mod regex_ltm_rank;
 mod regex_match_atom;
 mod regex_match_atom_simple;
 mod regex_match_capture;

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -163,6 +163,24 @@ impl Drop for EnclosingRegexVarsGuard {
     }
 }
 
+/// Normalize a `<name>` / `<.name>` / `<&name>` subrule lookup name and check
+/// whether it names the `ws` rule (implicit sigspace or an explicit `<.ws>` /
+/// `<ws>` / method-form lookup). Shared between the regex parser's own
+/// `<.ws>`-detection (`regex_parse_core.rs`'s `token_is_ws_like`, which needs
+/// this to classify a token as ws-like at parse time) and the LTM
+/// declarative-prefix mode's atom classifier (ADR-0022 §4.2: `ws` terminates
+/// the prefix, same as an explicit code block).
+pub(crate) fn named_lookup_is_ws(name: &str) -> bool {
+    let mut raw = name.trim();
+    if let Some(stripped) = raw.strip_prefix('.') {
+        raw = stripped.trim();
+    }
+    if let Some(stripped) = raw.strip_prefix('&') {
+        raw = stripped.trim();
+    }
+    raw == "ws"
+}
+
 /// Is this env key a dynamic variable (`$*x` is stored as `*x`; `@*a` / `%*h`
 /// keep their sigil)? Such a name declared by an in-regex `:my` belongs to the
 /// per-rule dynvar machinery, not to the regex-lexical snapshot/restore.

--- a/src/runtime/regex/regex_ltm_rank.rs
+++ b/src/runtime/regex/regex_ltm_rank.rs
@@ -1,0 +1,376 @@
+//! ADR-0022 Slice 1: declarative-prefix LTM measurement infrastructure.
+//!
+//! This module adds the *measurement* primitive (`ltm_prefix_len_at`) and the
+//! shared atom classifier (`ltm_atom_mode`) that the three atom matchers
+//! consult under `LTM_DECLARATIVE_MODE`. It intentionally does NOT change how
+//! `|` alternation ranks its branches — that is ADR-0022 Slice 3. Nothing in
+//! this file is wired into the alternation-ranking consumer arms yet; the new
+//! API is exercised only by this module's own unit tests, plus indirectly by
+//! whatever already calls into `LTM_DECLARATIVE_MODE` (protoregex dispatch's
+//! `declarative_prefix_match_len`, `regex_resolve.rs`), whose *measurements*
+//! now see through more atom kinds than before (ADR-0009 previously handled
+//! only code atoms).
+
+use super::super::*;
+use super::regex_helpers::{LTM_DECLARATIVE_MODE, LTM_PREFIX_TERMINATED, named_lookup_is_ws};
+use std::cell::Cell;
+
+/// How an atom participates in LTM declarative-prefix measurement
+/// (ADR-0022 §4.2's prefix-construction table). `CodeAssertion` and
+/// `SequentialAlternation` are deliberately NOT covered here: `CodeAssertion`
+/// already has its own inline mode handling (ADR-0009), and
+/// `SequentialAlternation` needs a full ε-bypass measurement (candidates =
+/// ends(first branch) ∪ {pos}), not a single yes/no verdict — see
+/// `Interpreter::ltm_seqalt_candidates` / `ltm_seqalt_best`.
+pub(super) enum LtmAtomMode<'a> {
+    /// Measure exactly as a real match would (consuming/transparent).
+    Normal,
+    /// Zero-width success; the caller must set `LTM_PREFIX_TERMINATED` so the
+    /// walk unwinds and the length measured so far stands.
+    Terminate,
+    /// Measure the inner pattern's ends from the current position as if
+    /// consuming (positive lookahead: `<?before X>` inlines `X` then stops),
+    /// then terminate.
+    TerminateAfter(&'a RegexPattern),
+}
+
+/// Classify `atom` for LTM declarative-prefix measurement. Only meaningful
+/// while `LTM_DECLARATIVE_MODE` is set; callers must check that themselves
+/// (this function does not consult the thread-local) so the check happens
+/// once per atom match, not once per classification.
+pub(super) fn ltm_atom_mode(atom: &RegexAtom) -> LtmAtomMode<'_> {
+    match atom {
+        // <.ws> / <ws> / implicit sigspace: Rakudo's NFA special-cases `ws` ->
+        // fate (terminate), same as a subrule that names it in any lookup form.
+        RegexAtom::WsRule => LtmAtomMode::Terminate,
+        RegexAtom::Named(name) if named_lookup_is_ws(name) => LtmAtomMode::Terminate,
+        // Backreferences depend on a capture made so far in THIS match, not on
+        // the pattern's declarative structure — Rakudo's NFA has no method for
+        // them, so they terminate.
+        RegexAtom::Backref(_) | RegexAtom::NamedBackref(_) => LtmAtomMode::Terminate,
+        // A bare `$var` interpolating an in-regex lexical is not a compile-time
+        // literal; terminate (constants are inlined as literals before this
+        // atom kind is ever produced, so they never reach here — see §2).
+        RegexAtom::VarInterp(_) => LtmAtomMode::Terminate,
+        // `<{ code }>` — the interpolated pattern is not known without running
+        // code, so it cannot participate in a declarative prefix.
+        RegexAtom::ClosureInterpolation { .. } => LtmAtomMode::Terminate,
+        // `&` / `&&` conjunction: no NFA method in Rakudo -> fate (terminate).
+        RegexAtom::Conjunction(_) => LtmAtomMode::Terminate,
+        RegexAtom::Lookaround {
+            pattern,
+            negated,
+            is_behind,
+        } => {
+            if *negated || *is_behind {
+                // `<!before X>`, `<?after>`/`<!after>`, and any other negated
+                // zero-width lookaround: terminate (matches Rakudo's own
+                // `#?rakudo todo` on this quirk).
+                LtmAtomMode::Terminate
+            } else {
+                // `<?before X>`: inline X's measurement, then terminate.
+                LtmAtomMode::TerminateAfter(pattern)
+            }
+        }
+        _ => LtmAtomMode::Normal,
+    }
+}
+
+impl Interpreter {
+    /// ADR-0022 §4.1: the longest declarative-prefix match of `pattern` at
+    /// `pos`, plus whether the measurement was cut short by a
+    /// non-declarative atom (`true` => the `None`/short length proves
+    /// nothing about whether the real match would go further, so a caller
+    /// may use the length to ORDER branches but must never use it to FILTER
+    /// one out — same contract as `declarative_prefix_match_len`).
+    ///
+    /// Saves/restores `LTM_DECLARATIVE_MODE` / `LTM_PREFIX_TERMINATED`
+    /// exactly like `declarative_prefix_match_len` (`regex_resolve.rs`) —
+    /// they must nest, since a measurement can occur inside a real match
+    /// inside another measurement (a subrule's own pattern may be measured
+    /// while an outer measurement is still live). Never executes user code
+    /// (ADR-0009 discipline): every code-bearing / non-declarative atom kind
+    /// is neutralized by `ltm_atom_mode` or the `CodeAssertion` arm's
+    /// existing mode check.
+    ///
+    /// Not yet called from non-test code: this is ADR-0022 Slice 1
+    /// (measurement infrastructure only). Slice 3 wires it into the three
+    /// alternation-ranking consumer arms, at which point this attribute goes
+    /// away. TODO(ADR-0022 Slice 3): remove `#[allow(dead_code)]` once wired.
+    #[allow(dead_code)]
+    pub(crate) fn ltm_prefix_len_at(
+        &mut self,
+        pattern: &RegexPattern,
+        chars: &[char],
+        pos: usize,
+        pkg: &str,
+    ) -> (Option<usize>, bool) {
+        let saved_mode = LTM_DECLARATIVE_MODE.with(|f| f.replace(true));
+        let saved_terminated = LTM_PREFIX_TERMINATED.with(|f| f.replace(false));
+        let ends = self.regex_match_ends_from_caps_in_pkg(pattern, chars, pos, pkg);
+        let stopped_at_non_declarative = LTM_PREFIX_TERMINATED.with(Cell::get);
+        LTM_DECLARATIVE_MODE.with(|f| f.set(saved_mode));
+        LTM_PREFIX_TERMINATED.with(|f| f.set(saved_terminated));
+        let max_end = ends.into_iter().map(|(end, _)| end).max();
+        (max_end.map(|end| end - pos), stopped_at_non_declarative)
+    }
+
+    /// ADR-0022 §4.2's `SequentialAlternation` special case for the PLURAL
+    /// (all-candidates) atom matcher: in LTM mode, only the FIRST branch of
+    /// `X || Y ...` participates in the declarative prefix, plus a
+    /// zero-width epsilon bypass at `pos` (Rakudo `NFA.nqp::method altseq`
+    /// builds child 0, then an epsilon edge straight from entry to exit).
+    /// Deliberately does NOT set `LTM_PREFIX_TERMINATED` itself — the
+    /// epsilon keeps the measurement alive past the group, so `X || Y` can
+    /// never be the SOLE reason a fully-declarative measurement returns
+    /// `None` (a caller filtering on `(None, false)` must not drop a branch
+    /// just because its `||` group's first branch failed to match).
+    ///
+    /// Returned lowest-priority-first (the plural atom-matcher convention:
+    /// the engine iterates the result in reverse): the epsilon first, then
+    /// the first branch's own ends from lowest to highest.
+    pub(super) fn ltm_seqalt_candidates(
+        &mut self,
+        alternatives: &[RegexPattern],
+        chars: &[char],
+        pos: usize,
+        pkg: &str,
+    ) -> Vec<(usize, RegexCaptures)> {
+        let mut out = vec![(pos, RegexCaptures::default())];
+        if let Some(first) = alternatives.first() {
+            let mut ends = self.regex_match_ends_from_caps_in_pkg(first, chars, pos, pkg);
+            ends.reverse(); // highest-first -> lowest-first
+            for (end, mut inner_caps) in ends {
+                let mut new_caps = RegexCaptures::default();
+                for (k, v) in inner_caps.named.drain() {
+                    new_caps.named.entry(k).or_default().merge(v);
+                }
+                new_caps.positional.append(&mut inner_caps.positional);
+                new_caps.code_blocks.append(&mut inner_caps.code_blocks);
+                out.push((end, new_caps));
+            }
+        }
+        out
+    }
+
+    /// [`Self::ltm_seqalt_candidates`] collapsed to the single longest
+    /// candidate, for atom matchers that return one candidate rather than a
+    /// backtracking set (the singular capture-bearing matcher and the
+    /// no-capture prober).
+    pub(super) fn ltm_seqalt_best(
+        &mut self,
+        alternatives: &[RegexPattern],
+        chars: &[char],
+        pos: usize,
+        pkg: &str,
+    ) -> (usize, RegexCaptures) {
+        let mut best: (usize, RegexCaptures) = (pos, RegexCaptures::default());
+        if let Some(first) = alternatives.first() {
+            for (end, mut inner_caps) in
+                self.regex_match_ends_from_caps_in_pkg(first, chars, pos, pkg)
+            {
+                if end > best.0 {
+                    let mut new_caps = RegexCaptures::default();
+                    for (k, v) in inner_caps.named.drain() {
+                        new_caps.named.entry(k).or_default().merge(v);
+                    }
+                    new_caps.positional.append(&mut inner_caps.positional);
+                    new_caps.code_blocks.append(&mut inner_caps.code_blocks);
+                    best = (end, new_caps);
+                }
+            }
+        }
+        best
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::regex_parse::RegexParseMode;
+
+    /// Measure `pattern` (raw regex source, no delimiters) against `text` at
+    /// position 0 in the empty package, returning `ltm_prefix_len_at`'s result.
+    fn measure(pattern: &str, text: &str) -> (Option<usize>, bool) {
+        let mut interp = Interpreter::new();
+        let parsed = interp
+            .parse_regex_with_mode(pattern, RegexParseMode::Match)
+            .expect("pattern should parse");
+        let chars: Vec<char> = text.chars().collect();
+        interp.ltm_prefix_len_at(&parsed, &chars, 0, "")
+    }
+
+    #[test]
+    fn plain_literal_measures_full_length_not_terminated() {
+        let (len, stopped) = measure("abc", "abcabc");
+        assert_eq!(len, Some(3));
+        assert!(!stopped);
+    }
+
+    #[test]
+    fn ws_rule_terminates_prefix() {
+        // `\w+ '-'` with an implicit <.ws> injected by sigspace would need
+        // `:s`/`rule`; here we spell the ws rule explicitly to keep the test
+        // independent of sigspace wiring: prefix should stop AT the ws call,
+        // not continue past it.
+        let (len, stopped) = measure(r"a <.ws> b", "a   b");
+        assert!(stopped, "ws should terminate the declarative prefix");
+        // Terminated at the position right after 'a' (before <.ws> consumes
+        // anything) — the ws call itself is zero-width in mode.
+        assert_eq!(len, Some(1));
+    }
+
+    #[test]
+    fn named_ws_lookup_terminates_like_wsrule() {
+        let (len_dot, stopped_dot) = measure(r"a <.ws> b", "a   b");
+        let (len_plain, stopped_plain) = measure(r"a <ws> b", "a   b");
+        assert!(stopped_dot);
+        assert!(stopped_plain);
+        assert_eq!(len_dot, len_plain);
+    }
+
+    #[test]
+    fn backref_terminates_prefix() {
+        let (len, stopped) = measure(r"(a) $0", "aa");
+        assert!(stopped, "a backreference should terminate the prefix");
+        // Prefix includes the capture group's own consumption (1 char).
+        assert_eq!(len, Some(1));
+    }
+
+    #[test]
+    fn named_backref_terminates_prefix() {
+        let (len, stopped) = measure(r"$<x>=(a) $<x>", "aa");
+        assert!(stopped);
+        assert_eq!(len, Some(1));
+    }
+
+    #[test]
+    fn positive_lookahead_extends_prefix_then_terminates() {
+        // `'ab' <?before c> \w\w` on "abcd": prefix is 'ab' (2) + the
+        // lookahead's own inner match 'c' (1, measured as consuming) = 3,
+        // then terminates (the trailing \w\w does not extend it further).
+        let (len, stopped) = measure(r"ab <?before c> \w\w", "abcd");
+        assert!(stopped);
+        assert_eq!(len, Some(3));
+    }
+
+    #[test]
+    fn negative_lookahead_terminates_without_extending() {
+        let (len, stopped) = measure(r"ab <!before x> \w\w", "abcd");
+        assert!(stopped);
+        // Terminates right after 'ab' (2) — the negated lookahead does not
+        // extend the prefix at all, unlike the positive case.
+        assert_eq!(len, Some(2));
+    }
+
+    #[test]
+    fn lookbehind_terminates_without_extending() {
+        let (len, stopped) = measure(r"ab <?after ab> \w\w", "abcd");
+        assert!(stopped);
+        assert_eq!(len, Some(2));
+    }
+
+    #[test]
+    fn conjunction_terminates_prefix() {
+        // The conjunction group itself terminates as soon as it is reached
+        // (zero-width, per §2's "no NFA method -> fate"), so the measured
+        // prefix is exactly the declarative content BEFORE it — the leading
+        // 'a' (1 char). Wrapped in a non-capturing group (`[...]`) rather
+        // than `(...)` to keep the position slot bookkeeping out of the way.
+        let (len, stopped) = measure(r"a [a & a] \w", "aab");
+        assert!(stopped);
+        assert_eq!(len, Some(1));
+    }
+
+    #[test]
+    fn var_interp_terminates_prefix() {
+        let (len, stopped) = measure(r":my $x = 'a'; a $x \w", "aab");
+        assert!(stopped);
+        // 'a' (1) then the VarDecl + VarInterp: the interpolation atom itself
+        // terminates before consuming, so the prefix stops at 1.
+        assert_eq!(len, Some(1));
+    }
+
+    #[test]
+    fn closure_interpolation_terminates_prefix() {
+        let (len, stopped) = measure(r"a <{ 'b' }> \w", "abc");
+        assert!(stopped);
+        assert_eq!(len, Some(1));
+    }
+
+    #[test]
+    fn plain_code_block_still_terminates_per_adr_0009() {
+        // Pre-existing ADR-0009 behavior, unchanged by this slice.
+        let (len, stopped) = measure(r"a { ; } \w\w", "abcd");
+        assert!(stopped);
+        assert_eq!(len, Some(1));
+    }
+
+    #[test]
+    fn code_assertion_true_stays_zero_width_and_transparent() {
+        // Pre-existing ADR-0009 behavior, unchanged by this slice: <?{ ... }>
+        // does NOT terminate, and keeps measuring past it.
+        let (len, stopped) = measure(r"a <?{ 1 }> \w\w", "aaa");
+        assert!(!stopped);
+        assert_eq!(len, Some(3));
+    }
+
+    #[test]
+    fn sequential_alternation_epsilon_bypass_when_first_branch_fails() {
+        // `['doof' || 'food']` on "food": the first branch ('doof') does not
+        // match at all, but the epsilon bypass means the group still measures
+        // as zero-width instead of poisoning the whole prefix to None.
+        let (len, stopped) = measure(r"['doof' || 'food']", "food");
+        // Not stopped: SequentialAlternation's ε-bypass does not set
+        // TERMINATED itself, and nothing else in this pattern does either.
+        assert!(!stopped);
+        assert_eq!(len, Some(0));
+    }
+
+    #[test]
+    fn sequential_alternation_measures_first_branch_when_it_matches() {
+        let (len, stopped) = measure(r"['food' || 'doof']", "food");
+        assert!(!stopped);
+        assert_eq!(len, Some(4));
+    }
+
+    #[test]
+    fn sequential_alternation_never_the_sole_reason_for_none() {
+        // A pattern that is ENTIRELY `X || Y` must still measure as Some(0)
+        // (the epsilon), never None, even when no branch matches at all.
+        let (len, stopped) = measure(r"['zzz' || 'yyy']", "food");
+        assert!(!stopped);
+        assert_eq!(len, Some(0));
+    }
+
+    #[test]
+    fn repeat_code_terminates_without_evaluating() {
+        // `** {code}`: must terminate WITHOUT evaluating the code block (it
+        // could have side effects / rely on runtime-only state). Measured
+        // length stops right before the quantified atom's contribution.
+        let (len, stopped) = measure(r"a 'b' ** {1}", "abbb");
+        assert!(stopped);
+        assert_eq!(len, Some(1));
+    }
+
+    #[test]
+    fn nested_subrule_sees_terminator_through_recursion() {
+        // The declarative prefix must descend into a subrule and see a
+        // terminator nested inside it (mirrors `declarative_prefix_match_len`'s
+        // existing subrule-descent behavior for code atoms). Uses the real
+        // grammar/token declaration path (`Interpreter::run`) rather than
+        // poking registry internals directly, so the test tracks whatever
+        // storage `token`/`rule` declarations actually use.
+        let mut interp = Interpreter::new();
+        interp
+            .run("grammar G { token item { a <.ws> b } }")
+            .expect("grammar declaration should run");
+        let outer = interp
+            .parse_regex_with_mode("<item>", RegexParseMode::Match)
+            .expect("outer pattern should parse");
+        let chars: Vec<char> = "a   b".chars().collect();
+        let (len, stopped) = interp.ltm_prefix_len_at(&outer, &chars, 0, "G");
+        assert!(stopped);
+        assert_eq!(len, Some(1));
+    }
+}

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -2,7 +2,10 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
 use super::super::*;
-use super::regex_helpers::{NamedRegexLookupSpec, merge_regex_captures};
+use super::regex_helpers::{
+    LTM_DECLARATIVE_MODE, LTM_PREFIX_TERMINATED, NamedRegexLookupSpec, merge_regex_captures,
+};
+use super::regex_ltm_rank::{LtmAtomMode, ltm_atom_mode};
 
 thread_local! {
     /// Memoization cache for left-recursive named regex calls.
@@ -87,6 +90,38 @@ impl Interpreter {
         // subrule argument evaluation) — it must never be cloned into results.
         let _vars_seed = Self::arm_inline_vars_seed(atom, current_caps);
 
+        // ADR-0022 §4.2: in LTM declarative-prefix measurement mode, a
+        // non-declarative atom either terminates the prefix at its own
+        // position (zero-width) or — for a positive lookahead — inlines its
+        // inner pattern's consumption first, then terminates. `SequentialAlternation`
+        // is intentionally not covered by `ltm_atom_mode` (it needs its own
+        // ε-bypass measurement below) and `CodeAssertion` keeps its existing
+        // inline handling (ADR-0009), so both fall through to `LtmAtomMode::Normal`
+        // here and are unaffected by this guard.
+        if LTM_DECLARATIVE_MODE.with(std::cell::Cell::get) {
+            match ltm_atom_mode(atom) {
+                LtmAtomMode::Terminate => {
+                    LTM_PREFIX_TERMINATED.with(|f| f.set(true));
+                    return vec![(pos, RegexCaptures::default())];
+                }
+                LtmAtomMode::TerminateAfter(inner) => {
+                    // Measure the inner pattern BEFORE setting TERMINATED: the
+                    // inner walk checks the flag at its own entry, so setting
+                    // it first would short-circuit the inner measurement to
+                    // zero-width instead of letting it consume.
+                    let best_end = self
+                        .regex_match_ends_from_caps_in_pkg(inner, chars, pos, pkg)
+                        .into_iter()
+                        .map(|(end, _)| end)
+                        .max()
+                        .unwrap_or(pos);
+                    LTM_PREFIX_TERMINATED.with(|f| f.set(true));
+                    return vec![(best_end, RegexCaptures::default())];
+                }
+                LtmAtomMode::Normal => {}
+            }
+        }
+
         if let RegexAtom::Alternation(alternatives) = atom {
             // | (LTM): try all alternatives, longest match wins.
             //
@@ -135,6 +170,12 @@ impl Interpreter {
                 .collect();
         }
         if let RegexAtom::SequentialAlternation(alternatives) = atom {
+            if LTM_DECLARATIVE_MODE.with(std::cell::Cell::get) {
+                // ADR-0022 §4.2: only the first branch of `X || Y ...`
+                // participates in the declarative prefix, plus a zero-width
+                // epsilon bypass — see `ltm_seqalt_candidates`.
+                return self.ltm_seqalt_candidates(alternatives, chars, pos, pkg);
+            }
             // || (sequential alternation): alt0 has higher priority than alt1, etc.
             // All alternatives are included to allow outer-context backtracking,
             // but in priority order: alt0's matches have highest priority.

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -1,8 +1,10 @@
 use super::super::unicode::check_unicode_property;
 use super::super::*;
 use super::regex_helpers::{
-    CaseFoldIter, class_has_only_exact_chars, grapheme_end, is_word_char, matches_named_builtin,
+    CaseFoldIter, LTM_DECLARATIVE_MODE, LTM_PREFIX_TERMINATED, class_has_only_exact_chars,
+    grapheme_end, is_word_char, matches_named_builtin,
 };
+use super::regex_ltm_rank::{LtmAtomMode, ltm_atom_mode};
 
 impl Interpreter {
     #[allow(dead_code)]
@@ -167,6 +169,36 @@ impl Interpreter {
         pkg: &str,
         ignore_case: bool,
     ) -> Option<usize> {
+        // ADR-0022 §4.2: see the identical guard in
+        // `regex_match_atom_all_with_capture_in_pkg` (`regex_match_atom.rs`) —
+        // this no-capture prober must stay in sync with the two
+        // capture-bearing matchers via the shared `ltm_atom_mode` classifier.
+        // `SequentialAlternation` is handled specially below (its own arm);
+        // `CodeAssertion` already returns `Some(pos)` unconditionally here
+        // (zero-width, never executed — this function never runs code), which
+        // is a safe (if imprecise for a plain block) default under mode.
+        if LTM_DECLARATIVE_MODE.with(std::cell::Cell::get) {
+            match ltm_atom_mode(atom) {
+                LtmAtomMode::Terminate => {
+                    LTM_PREFIX_TERMINATED.with(|f| f.set(true));
+                    return Some(pos);
+                }
+                LtmAtomMode::TerminateAfter(inner) => {
+                    // Measure the inner pattern BEFORE setting TERMINATED —
+                    // see the identical ordering note in
+                    // `regex_match_atom_all_with_capture_in_pkg`.
+                    let best_end = self
+                        .regex_match_ends_from_caps_in_pkg(inner, chars, pos, pkg)
+                        .into_iter()
+                        .map(|(end, _)| end)
+                        .max()
+                        .unwrap_or(pos);
+                    LTM_PREFIX_TERMINATED.with(|f| f.set(true));
+                    return Some(best_end);
+                }
+                LtmAtomMode::Normal => {}
+            }
+        }
         // Group, CaptureGroup, Alternation, ZeroWidth, CodeAssertion can match zero-width
         match atom {
             RegexAtom::Group(pattern) => {
@@ -202,6 +234,12 @@ impl Interpreter {
                 return best;
             }
             RegexAtom::SequentialAlternation(alternatives) => {
+                if LTM_DECLARATIVE_MODE.with(std::cell::Cell::get) {
+                    // ADR-0022 §4.2: the no-capture counterpart of the plural
+                    // matcher's ε-bypass — see `ltm_seqalt_best`.
+                    let (end, _) = self.ltm_seqalt_best(alternatives, chars, pos, pkg);
+                    return Some(end);
+                }
                 for alt in alternatives {
                     if let Some(end) = self.regex_match_end_from_in_pkg(alt, chars, pos, pkg) {
                         return Some(end);

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -1,6 +1,10 @@
 use super::super::unicode::check_unicode_property;
 use super::super::*;
-use super::regex_helpers::{is_word_char, matches_named_builtin, merge_regex_captures};
+use super::regex_helpers::{
+    LTM_DECLARATIVE_MODE, LTM_PREFIX_TERMINATED, is_word_char, matches_named_builtin,
+    merge_regex_captures,
+};
+use super::regex_ltm_rank::{LtmAtomMode, ltm_atom_mode};
 
 impl Interpreter {
     /// Is this atom an inline sub-pattern — part of the *same* regex, just matched
@@ -47,6 +51,36 @@ impl Interpreter {
         ignore_case: bool,
     ) -> Option<(usize, RegexCaptures)> {
         let _vars_seed = Self::arm_inline_vars_seed(atom, current_caps);
+
+        // ADR-0022 §4.2: see the identical guard in
+        // `regex_match_atom_all_with_capture_in_pkg` (`regex_match_atom.rs`) —
+        // the two matchers must stay in sync via the shared `ltm_atom_mode`
+        // classifier. `SequentialAlternation` and `CodeAssertion` are not
+        // covered by `ltm_atom_mode` (see its doc comment) and fall through
+        // to their existing arms below, unaffected by this guard.
+        if LTM_DECLARATIVE_MODE.with(std::cell::Cell::get) {
+            match ltm_atom_mode(atom) {
+                LtmAtomMode::Terminate => {
+                    LTM_PREFIX_TERMINATED.with(|f| f.set(true));
+                    return Some((pos, RegexCaptures::default()));
+                }
+                LtmAtomMode::TerminateAfter(inner) => {
+                    // Measure the inner pattern BEFORE setting TERMINATED —
+                    // see the identical ordering note in
+                    // `regex_match_atom_all_with_capture_in_pkg`.
+                    let best_end = self
+                        .regex_match_ends_from_caps_in_pkg(inner, chars, pos, pkg)
+                        .into_iter()
+                        .map(|(end, _)| end)
+                        .max()
+                        .unwrap_or(pos);
+                    LTM_PREFIX_TERMINATED.with(|f| f.set(true));
+                    return Some((best_end, RegexCaptures::default()));
+                }
+                LtmAtomMode::Normal => {}
+            }
+        }
+
         // Handle zero-width and group atoms before the length check
         match atom {
             RegexAtom::Group(pattern) => {
@@ -144,6 +178,12 @@ impl Interpreter {
                     .next_back();
             }
             RegexAtom::SequentialAlternation(alternatives) => {
+                if LTM_DECLARATIVE_MODE.with(std::cell::Cell::get) {
+                    // ADR-0022 §4.2: the single-candidate counterpart of the
+                    // plural matcher's ε-bypass — see `ltm_seqalt_best`.
+                    let best = self.ltm_seqalt_best(alternatives, chars, pos, pkg);
+                    return Some(best);
+                }
                 for alt in alternatives {
                     if let Some((next, mut inner_caps)) =
                         self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -651,6 +651,19 @@ impl Interpreter {
                 self.walk_quant_chain(ctx, idx, pos, 1, None, true, store, matches)
             }
             RegexQuant::Repeat(..) | RegexQuant::RepeatCode(_) => {
+                // ADR-0022 §4.2: `** {code}` terminates the declarative prefix
+                // WITHOUT evaluating the code (the count may depend on
+                // runtime-only state, and measurement must never execute user
+                // code — ADR-0009). This lives here rather than in
+                // `ltm_atom_mode` because the quantifier sits on the TOKEN,
+                // not the atom. Mirrors the top-of-function termination check.
+                if let RegexQuant::RepeatCode(_) = token.quant
+                    && super::regex_helpers::LTM_DECLARATIVE_MODE.with(std::cell::Cell::get)
+                {
+                    super::regex_helpers::LTM_PREFIX_TERMINATED.with(|f| f.set(true));
+                    matches.push((pos, store.snapshot()));
+                    return true;
+                }
                 let (min, max) = match &token.quant {
                     RegexQuant::Repeat(min, max) => {
                         // Block-less empty range: /x ** 2..1/ should throw

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -398,17 +398,6 @@ impl Interpreter {
         pattern: &str,
         mode: RegexParseMode,
     ) -> Option<RegexPattern> {
-        fn named_lookup_is_ws(name: &str) -> bool {
-            let mut raw = name.trim();
-            if let Some(stripped) = raw.strip_prefix('.') {
-                raw = stripped.trim();
-            }
-            if let Some(stripped) = raw.strip_prefix('&') {
-                raw = stripped.trim();
-            }
-            raw == "ws"
-        }
-
         fn token_is_ws_like(token: &RegexToken) -> bool {
             match &token.atom {
                 RegexAtom::CharClass(class) => {
@@ -419,7 +408,7 @@ impl Interpreter {
                             .first()
                             .is_some_and(|item| matches!(item, ClassItem::Space))
                 }
-                RegexAtom::Named(name) => named_lookup_is_ws(name),
+                RegexAtom::Named(name) => super::regex::regex_helpers::named_lookup_is_ws(name),
                 RegexAtom::WsRule => true,
                 _ => false,
             }

--- a/t/regex-ltm-declarative-prefix.t
+++ b/t/regex-ltm-declarative-prefix.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 9;
+plan 11;
 
 # LTM candidate selection measures how far each candidate *declaratively* matches.
 # A code atom (`{ … }`, `<?{ … }>`, `<!{ … }>`) terminates the declarative prefix,
@@ -65,3 +65,47 @@ grammar Proto {
     token TOP { <t> }
 }
 is ~Proto.parse('abcd'), 'abcd', 'longest declarative prefix still wins LTM';
+
+# ADR-0022 Slice 1: the declarative-prefix measurement now sees through more
+# atom kinds than a bare code block (ADR-0009's original scope) — a
+# backreference, and the `ws` rule, both TERMINATE the measurement instead of
+# running through it as an ordinary (consuming) atom. Two proto candidates
+# below are each real, independently-viable matches; which one measures
+# longer flips once the terminator is honored, so the WINNING candidate
+# (and hence whether the surrounding `.parse`, which requires full
+# consumption, succeeds at all) changes. Both expectations are verified
+# against `raku` directly (2026-08-10) — `raku` also reports these as
+# non-matches, for the same reason: its NFA has no method for `$0` or `ws`,
+# so they end the branch's fate length right where they are reached.
+#
+# The proto must be the grammar's OWN start rule (`TOP`), not referenced via
+# `<name>` from a separate `TOP` — a `<name>` subrule reference inside
+# another pattern's body resolves through the regex engine's own named-atom
+# proto loop (`regex_match_atom.rs`), which ranks by longest ACTUAL match and
+# is untouched by this ADR (that is Slice 3 territory too). Only
+# `Grammar.parse`'s start-rule candidate selection
+# (`dispatch.rs::eval_token_call_values_at`) already ranks by declarative
+# prefix (ADR-0009) and is what this slice's extended atom-mode table changes
+# the measurement for.
+grammar BackrefProto {
+    # Old (pre-Slice-1) measurement ran the backref for real during
+    # candidate ranking, measuring the full 3-char "aaZ"; the correct
+    # (post-Slice-1) measurement terminates right after the capture group,
+    # at 1 char — shorter than sym<pair>'s fully-declarative 2 chars below.
+    proto token TOP {*}
+    token TOP:sym<backref> { (\w) $0 'Z' }
+    token TOP:sym<pair>    { \w \w }
+}
+nok BackrefProto.parse('aaZ').defined,
+    'backref terminates the LTM prefix, so the shorter fully-declarative candidate now ranks first and the parse (needing full consumption) fails';
+
+grammar WsProto {
+    # Old measurement ran <.ws> for real (consuming the space), measuring
+    # the full 4-char "ab Z"; the correct measurement terminates right after
+    # `\w+`, at 2 chars — shorter than sym<lit>'s fully-declarative 3 chars.
+    proto token TOP {*}
+    token TOP:sym<ws>  { \w+ <.ws> 'Z' }
+    token TOP:sym<lit> { 'ab' ' ' }
+}
+nok WsProto.parse('ab Z').defined,
+    'the ws rule terminates the LTM prefix, so the shorter fully-declarative candidate now ranks first and the parse (needing full consumption) fails';


### PR DESCRIPTION
## Summary

Implements **Slice 1 only** of ADR-0022 (`docs/adr/0022-regex-alternation-ltm-ranking.md`): the measurement infrastructure for ranking `|` alternation branches by declarative-prefix LTM like rakudo, instead of by longest-actual-match like mutsu currently does. This slice adds the measurement primitive and its atom-mode plumbing; **it does not change `|` alternation's observable ranking behavior** (that is Slice 3, a follow-up PR).

- New `src/runtime/regex/regex_ltm_rank.rs`:
  - `Interpreter::ltm_prefix_len_at` (ADR §4.1) — the new declarative-prefix measurement API, saving/restoring `LTM_DECLARATIVE_MODE`/`LTM_PREFIX_TERMINATED` exactly like the existing `declarative_prefix_match_len` (they must nest).
  - Shared `ltm_atom_mode` classifier (ADR §4.2), consulted by all three atom matchers (`regex_match_atom_all_with_capture_in_pkg`, `regex_match_atom_with_capture_in_pkg`, `regex_match_atom_in_pkg`) so they stay in sync: `WsRule`/`<.ws>`/`<ws>`, backreferences, `$var` interpolation, closure interpolation, conjunction (`&`/`&&`), and negated/lookbehind lookaround now **terminate** the declarative prefix (previously only a plain `{ … }` code block did — ADR-0009's original scope). Positive lookahead (`<?before X>`) inlines `X`'s consumption first, then terminates.
  - `** {code}` quantifiers terminate too (token-level check in `walk_tokens`, since the quantifier sits on the token, not the atom) — without evaluating the code block.
  - `SequentialAlternation` (`X || Y`) gets its own epsilon-bypass measurement (`ltm_seqalt_candidates` / `ltm_seqalt_best`): only the first branch participates in the prefix, plus a zero-width bypass, so the group can never be the sole reason a fully-declarative measurement returns `None`.
- Extracted `named_lookup_is_ws` out of a nested closure in `regex_parse_core.rs` into a shared `regex_helpers` function, reused by both the parser's `<.ws>` detection and the new atom classifier.

## Verification

- **No behavior change to `|` yet**: `roast/S05-grammar/protoregex.t` passes unchanged; `roast/S05-metasyntax/longest-alternative.t` shows the exact same 4 failures (26, 28, 50, 54) as a clean `main` checkout with zero changes applied (verified via `git stash -u` A/B).
- 18 new `#[test]`s in `regex_ltm_rank.rs` covering every atom-mode case, the `SequentialAlternation` epsilon-bypass, `** {code}` termination, and cross-subrule descent.
- Extended `t/regex-ltm-declarative-prefix.t` with two new proto-dispatch cases (backreference, `ws`) — each raku-verified (2026-08-10) to fail the same way mutsu now does, since `Grammar.parse`'s start-rule candidate selection (`dispatch.rs::eval_token_call_values_at`) already ranks by declarative prefix (ADR-0009) and is what this slice's extended atom-mode table changes the *measurement* for. (A `<name>` subrule reference from *inside* another pattern's body resolves through a different, untouched mechanism — noted in the test file.)
- `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings` all clean.
- `make test`: 28219/28219 tests pass.

## Test plan

- [x] `cargo test --lib regex_ltm_rank` — 18/18 pass
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S05-grammar/protoregex.t` — unchanged (ok)
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S05-metasyntax/longest-alternative.t` — same 4 pre-existing failures as clean `main`
- [x] `prove -e target/debug/mutsu t/regex-ltm-declarative-prefix.t` — 11/11 pass
- [x] `make test` — full suite green
- [ ] CI (`make test` + `make roast`) — auto-merge enabled, will land once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)