### PR TITLE
refactor(adr0019): E4b step 3 -- give is_native_method its own resolver candidate kind

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2403,6 +2403,37 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     This closes the scoping note's step 2 as answered rather than open: the
     row table cannot decide category 1 for you, full stop, given the adopted
     fallback contract. No code changed; docs-only.
+    **Progress 2026-08-11** (step 3): gave category 2 (`is_native_method`) its own
+    candidate kind rather than folding it into `resolve_user_method_or_accessor`,
+    per step 1's finding that the two are genuinely disjoint. `ResolvedCandidate`
+    gains `NativeCallBinding { owner: TypeId }` (`resolution_sequence.rs`); `resolve_sequence`
+    detects it per chain, mirroring `is_native_method`'s own two-part check —
+    the five hardcoded classes (`IO::Pipe`/`IO::Special`/`IO::Handle`/`Thread`/`VM`,
+    extracted into a shared `Interpreter::hardcoded_native_method` so the two
+    checks cannot drift apart) only at level 0 (the receiver's own class, exact-name,
+    matching `is_native_method`'s non-MRO-aware fast checks), and `ClassDef::native_methods`
+    (the `is native(&sym)` registry) walked across the full chain, first hit wins — at
+    most one `NativeCallBinding` candidate per sequence, since `is_native_method` itself
+    is a boolean "does any level bind this", not a per-level fact.
+    `shadow_check_bypass_user_method_categories` (step 1's probe) now ORs this candidate's
+    presence into `shadow` for Instance receivers. Verified with a fixed t/-wide sweep
+    (each process's `MUTSU_VM_STATS` output to its own file — the original single-shared-file
+    sweep script produced torn/interleaved lines under `-P 8`, caught by a sanity check
+    when a totals line briefly read `mismatches=8072721`, impossibly larger than
+    `checks`): **baseline (pre-step-3) 4172/20635 mismatches (20.2%) → post-step-3
+    34/20634 (0.16%)**, a 99.2% reduction, with the same 2996-file corpus shape as step 1's
+    sweep. All 34 remaining mismatches carry `native_binding_owner=None` on both sides
+    (`grep -l native_binding_owner=Some` over the full per-file log set: zero hits) — none
+    are new, and their shape (`WHAT`/`WHO`/`WHY`/`HOW`/`WHICH`/`WHERE`/`DEFINITE` on
+    generic test-fixture classes, plus `new`/`shared`/`val`/`name`/`tag`/`label`) matches
+    step 1's already-noted "opposite shape, not chased further" residual — unrelated to
+    category 2, out of this step's scope. `cargo test --lib` (769 tests) and
+    `prove -j4 t/` (3011 files / 28230 tests) both green. Category 2 is now shadow-verified
+    safe as a resolver candidate; category 3 was already shadow-verified in step 1. What
+    remains before the authoritative switch: category 1's guard list (step 2's per-case
+    disposition) still needs to be implemented as explicit resolver guards, and the
+    switch itself needs the E2 native-row catalog wired in per design decision 4's
+    `Native` variant (not yet added — `NativeCallBinding` is a distinct, fourth kind).
 - [ ] **E5 — Route ordinary VM method calls through the resolver.** Cover zero/n-arg and named-call
   opcodes while retaining mutation/writeback semantics at the caller boundary.
   **Design 2026-08-10** (`todo/deep/adr0019-e5-e7-entry-routing.md`): the cutover shape is

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -60,7 +60,15 @@ impl Interpreter {
         false
     }
 
-    pub(crate) fn is_native_method(&mut self, class_name: &str, method_name: &str) -> bool {
+    /// Hardcoded native-method names for the handful of built-in classes
+    /// whose getters/setters are implemented by dedicated `native_io_*`/
+    /// native dispatch helpers rather than through `ClassDef::native_methods`
+    /// (the `is native(&sym)` trait registry). Exact class-name match only —
+    /// does not apply to subclasses. Shared with `resolve_sequence`'s
+    /// `ResolvedCandidate::NativeCallBinding` detection (ADR-0019 E4b step 3,
+    /// `todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md`)
+    /// so the two stay in lockstep by construction rather than by discipline.
+    pub(super) fn hardcoded_native_method(class_name: &str, method_name: &str) -> bool {
         // IO::Pipe has native methods handled by native_io_pipe
         if class_name == "IO::Pipe"
             && matches!(
@@ -207,6 +215,13 @@ impl Interpreter {
                     | "Str"
             )
         {
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn is_native_method(&mut self, class_name: &str, method_name: &str) -> bool {
+        if Self::hardcoded_native_method(class_name, method_name) {
             return true;
         }
         let mro = self.class_mro(class_name);

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -1,3 +1,4 @@
+use super::resolution_sequence::ResolvedCandidate;
 use super::*;
 use crate::symbol::Symbol;
 
@@ -224,19 +225,25 @@ impl Interpreter {
             || (!is_pseudo_method && self.mixin_role_has_method(target, method))
     }
 
-    /// ADR-0019 E4b step-1 shadow probe (`MUTSU_VM_STATS`-gated, a no-op
-    /// otherwise): compare `should_bypass_native_fastpath`'s "does a user
-    /// method/accessor/class-level-attr (or, for an Instance, a NativeCall
-    /// binding) win" categories — the scoping doc's categories 2 and 3,
+    /// ADR-0019 E4b shadow probe (`MUTSU_VM_STATS`-gated, a no-op otherwise):
+    /// compare `should_bypass_native_fastpath`'s "does a user method/
+    /// accessor/class-level-attr (or, for an Instance, a NativeCall binding)
+    /// win" categories — the scoping doc's categories 2 and 3,
     /// `todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md`
-    /// — against `resolve_user_method_or_accessor`'s single-MRO-walk answer
-    /// for the receiver's own class. Recomputes the same sub-expression
-    /// `should_bypass_native_fastpath` evaluates at lines 179-180/214-224,
-    /// independent of whatever the real bypass decision turned out to be
-    /// (a category-1 special case can make the real decision `true` while
-    /// this probe's `real` is `false`, and that is expected — this only
-    /// asks whether the two answer this one sub-question the same way).
-    /// Purely observational: nothing here feeds a dispatch decision.
+    /// — against the resolver's answer for the receiver's own class.
+    /// Recomputes the same sub-expression `should_bypass_native_fastpath`
+    /// evaluates at lines 179-180/214-224, independent of whatever the real
+    /// bypass decision turned out to be (a category-1 special case can make
+    /// the real decision `true` while this probe's `real` is `false`, and
+    /// that is expected — this only asks whether the two answer this one
+    /// sub-question the same way). Purely observational: nothing here feeds a
+    /// dispatch decision.
+    ///
+    /// Step 3 (2026-08-11): category 2 (`is_native_method`) is not visible to
+    /// `resolve_user_method_or_accessor` on its own (a pure native-method
+    /// binding with no matching accessor, e.g. `Supply.tap`, ~82% of step 1's
+    /// mismatches) — it now has its own `ResolvedCandidate::NativeCallBinding`
+    /// entry in `resolve_sequence`, OR'd in here for an Instance receiver.
     pub(super) fn shadow_check_bypass_user_method_categories(
         &mut self,
         target: &Value,
@@ -264,11 +271,24 @@ impl Interpreter {
                     || (self.has_class_level_attr(&class_name, method)
                         && !self.has_public_accessor(&class_name, method)))
         };
-        let shadow = self
-            .resolve_user_method_or_accessor(&class_name, method)
-            .is_some();
+        let native_binding_owner = if is_instance {
+            let chain = self.dispatch_mro(target);
+            let seq = self.resolve_sequence(&chain, Symbol::intern(method));
+            seq.candidates.iter().find_map(|c| match c {
+                ResolvedCandidate::NativeCallBinding { owner } => Some(owner.as_str().to_string()),
+                ResolvedCandidate::User { .. } => None,
+            })
+        } else {
+            None
+        };
+        let shadow = native_binding_owner.is_some()
+            || self
+                .resolve_user_method_or_accessor(&class_name, method)
+                .is_some();
         crate::vm::vm_stats::record_bypass_shadow_check(real == shadow, || {
-            format!("class={class_name} method={method} real={real} shadow={shadow}")
+            format!(
+                "class={class_name} method={method} real={real} shadow={shadow} native_binding_owner={native_binding_owner:?}"
+            )
         });
     }
 

--- a/src/runtime/resolution_sequence.rs
+++ b/src/runtime/resolution_sequence.rs
@@ -45,6 +45,17 @@ pub(crate) enum ResolvedCandidate {
     /// A user-declared method, at its MRO level, in the class's stored
     /// declaration order.
     User { owner: TypeId, def: Arc<MethodDef> },
+    /// A `ClassDef::native_methods` binding — an `is native(&sym)` NativeCall
+    /// trait, or one of the handful of built-in classes whose getters are
+    /// implemented by dedicated `native_io_*` dispatch helpers
+    /// (`Interpreter::hardcoded_native_method`). This is the E4b decomposition
+    /// note's "category 2": a third candidate kind, distinct from both `User`
+    /// and design decision 4's `Native` row-catalog variant (not yet added) —
+    /// see `todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md`.
+    /// At most one appears per sequence: `is_native_method` is a boolean "does
+    /// any MRO level bind this name", not a per-level fact, so the sequence
+    /// records only the first (most-derived) owner that has it.
+    NativeCallBinding { owner: TypeId },
 }
 
 /// The shape-independent ordered candidate universe for one `(receiver chain,
@@ -69,22 +80,39 @@ impl Interpreter {
     pub(crate) fn resolve_sequence(&mut self, chain: &[TypeId], name: Symbol) -> ResolvedSequence {
         let generation = self.registry().method_generation;
         let mut candidates = Vec::new();
+        let mut native_binding_found = false;
         for (level, owner) in chain.iter().enumerate() {
             let is_ancestor = level > 0;
-            let Some(overloads) = self
+            let owner_str = owner.as_str();
+            if let Some(overloads) = self
                 .registry()
-                .user_method_overloads(owner.as_str(), name.as_str())
-            else {
-                continue;
-            };
-            for def in overloads {
-                if def.is_private || (def.is_my && is_ancestor) {
-                    continue;
+                .user_method_overloads(owner_str, name.as_str())
+            {
+                for def in overloads {
+                    if def.is_private || (def.is_my && is_ancestor) {
+                        continue;
+                    }
+                    candidates.push(ResolvedCandidate::User {
+                        owner: *owner,
+                        def: Arc::new(def),
+                    });
                 }
-                candidates.push(ResolvedCandidate::User {
-                    owner: *owner,
-                    def: Arc::new(def),
-                });
+            }
+            // `hardcoded_native_method` only ever fires for the receiver's own
+            // (most-derived) class name, mirroring `is_native_method` — it is
+            // never checked against an ancestor level.
+            if !native_binding_found {
+                let hardcoded =
+                    level == 0 && Interpreter::hardcoded_native_method(owner_str, name.as_str());
+                let registered = self
+                    .registry()
+                    .classes
+                    .get(owner_str)
+                    .is_some_and(|cd| cd.native_methods.contains(name.as_str()));
+                if hardcoded || registered {
+                    candidates.push(ResolvedCandidate::NativeCallBinding { owner: *owner });
+                    native_binding_found = true;
+                }
             }
         }
         ResolvedSequence {
@@ -131,7 +159,9 @@ impl Interpreter {
         let chain = self.dispatch_mro(invocant);
         let seq = self.resolve_sequence(&chain, method_sym);
         let has_where_candidate = seq.candidates.iter().any(|c| {
-            let ResolvedCandidate::User { def, .. } = c;
+            let ResolvedCandidate::User { def, .. } = c else {
+                return false;
+            };
             def.param_defs.iter().any(|p| p.where_constraint.is_some())
         });
         if has_where_candidate {
@@ -142,7 +172,9 @@ impl Interpreter {
         let mro: Vec<Symbol> = chain.iter().map(|t| t.symbol()).collect();
         let mut matched: Vec<(Symbol, MethodDef)> = Vec::new();
         for c in &seq.candidates {
-            let ResolvedCandidate::User { owner, def } = c;
+            let ResolvedCandidate::User { owner, def } = c else {
+                continue;
+            };
             if self.method_args_match_for_invocant(
                 class_name,
                 def,
@@ -188,7 +220,10 @@ mod tests {
         let owners: Vec<&str> = seq
             .candidates
             .iter()
-            .map(|ResolvedCandidate::User { owner, .. }| owner.as_str())
+            .filter_map(|c| match c {
+                ResolvedCandidate::User { owner, .. } => Some(owner.as_str()),
+                ResolvedCandidate::NativeCallBinding { .. } => None,
+            })
             .collect();
         assert_eq!(owners, vec!["Child", "Base"]);
     }
@@ -223,5 +258,39 @@ mod tests {
         let chain = vec![TypeId::intern("Base")];
         let seq = i.resolve_sequence(&chain, Symbol::intern("nope"));
         assert!(seq.candidates.is_empty());
+    }
+
+    /// ADR-0019 E4b step 3: a pure `is native(&sym)` binding with no matching
+    /// accessor (the `Supply.tap` shape the step-1 shadow sweep found
+    /// invisible to `resolve_user_method_or_accessor`) must now surface as
+    /// its own candidate.
+    #[test]
+    fn resolve_sequence_finds_a_registry_native_call_binding() {
+        let mut i = interp();
+        assert!(i.is_native_method("Supply", "tap"));
+        let chain = vec![TypeId::intern("Supply")];
+        let seq = i.resolve_sequence(&chain, Symbol::intern("tap"));
+        assert!(
+            seq.candidates.iter().any(
+                |c| matches!(c, ResolvedCandidate::NativeCallBinding { owner }
+                    if owner.as_str() == "Supply")
+            ),
+            "expected a NativeCallBinding candidate for Supply.tap"
+        );
+    }
+
+    /// The hardcoded native-method table (`IO::Handle`, etc.) only applies at
+    /// the receiver's own (most-derived) level, mirroring `is_native_method` —
+    /// an ancestor level must not spuriously pick it up.
+    #[test]
+    fn resolve_sequence_hardcoded_native_binding_is_not_seen_at_an_ancestor_level() {
+        let mut i = interp();
+        assert!(i.is_native_method("IO::Handle", "chomp"));
+        let chain = vec![TypeId::intern("Base"), TypeId::intern("IO::Handle")];
+        let seq = i.resolve_sequence(&chain, Symbol::intern("chomp"));
+        assert!(
+            seq.candidates.is_empty(),
+            "hardcoded native-method names must not apply to an ancestor level"
+        );
     }
 }

--- a/todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md
+++ b/todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md
@@ -1,16 +1,23 @@
 # ADR-0019 E4b: decomposing `should_bypass_native_fastpath` for the resolver cutover
 
-**Status update (2026-08-11):** steps 1 and 2 below are answered — see the
-ADR's E4b "Progress 2026-08-11" notes (both step-1 and step-2 entries). Step
-1: `resolve_user_method_or_accessor` shadow-verified NOT to subsume category
-2 (`is_native_method`) — confirmed via a `t/`-wide sweep, 99.95% of shadow
+**Status update (2026-08-11):** steps 1-3 below are answered — see the ADR's
+E4b "Progress 2026-08-11" notes (step-1/2/3 entries). Step 1:
+`resolve_user_method_or_accessor` shadow-verified NOT to subsume category 2
+(`is_native_method`) — confirmed via a `t/`-wide sweep, 99.95% of shadow
 mismatches were `Supply.tap`-shaped (a pure native method with no matching
 accessor). Step 2: category 1 does **not** reduce to "the row table has no
 entry" the way this doc originally hoped, because the adopted gate
 renegotiation makes E4b's resolver fall back to the cascade on any row miss
-— row absence no longer implies "the resolver skips it." Read the ADR notes
-for the full per-case disposition before starting step 3 (the actual
-authoritative switch).
+— row absence no longer implies "the resolver skips it." Step 3: category 2
+now has its own `ResolvedCandidate::NativeCallBinding` kind in
+`resolution_sequence.rs`, shadow-verified against the same sweep methodology
+— mismatches fell from 4172/20635 (20.2%) to 34/20634 (0.16%), and the
+residual 34 are the pre-existing category-3-only shape already noted in step
+1, not category 2. What's left before the actual authoritative switch:
+implement category 1's guard list (step 2's per-case disposition) as explicit
+resolver guards, and add design decision 4's E2-row-catalog `Native`
+candidate variant (a fourth kind, distinct from `NativeCallBinding`) so the
+switch has every candidate kind it needs.
 
 E4b ("authoritative switch at the cached-resolve boundaries, native rows
 included, `should_bypass_native_fastpath` deleted") is the next unstarted box


### PR DESCRIPTION
## Summary
- ADR-0019 E4b decomposition step 3: `is_native_method` (category 2 — NativeCall class-level bindings, plus a handful of hardcoded built-in native getters) gets its own `ResolvedCandidate::NativeCallBinding` kind in `resolution_sequence.rs`, since step 1's shadow sweep found it invisible to `resolve_user_method_or_accessor` (category 3's helper) — the `Supply.tap` shape was ~82% of that sweep's mismatches.
- `resolve_sequence` now detects a native-call binding per MRO chain, mirroring `is_native_method` exactly: the five hardcoded classes (`IO::Pipe`/`IO::Special`/`IO::Handle`/`Thread`/`VM`) only at the receiver's own (most-derived) level, and `ClassDef::native_methods` (the `is native(&sym)` registry) walked across the full chain. The hardcoded table is extracted into a shared `Interpreter::hardcoded_native_method` so `is_native_method` and the new resolver check can't drift apart.
- `shadow_check_bypass_user_method_categories` (the E4b step-1 probe) now ORs this candidate's presence into its shadow answer for Instance receivers.
- Shadow-only, zero behavior change — nothing here feeds a real dispatch decision yet.

## Verification
- A `MUTSU_VM_STATS`-gated t/-wide sweep (E1a/E4a methodology, one log file per process to avoid interleaved output under parallel `xargs`): baseline (pre-step-3) 4172/20635 mismatches (20.2%) -> post-step-3 34/20634 (0.16%), a 99.2% reduction. The residual 34 all carry `native_binding_owner=None` on both sides — the same pre-existing category-3-only shape step 1 already flagged as out of scope (`WHAT`/`WHO`/`WHY`/etc. reflection methods, `new`/`shared`/`val` accessor edge cases), not category 2.
- `cargo test --lib` (769 tests) green, two new unit tests for the candidate detection.
- `prove -j4 -e target/debug/mutsu t/` (3011 files / 28230 tests) green.
- Targeted `make roast`-equivalent sweep via `scripts/run-roast-test.sh` over S12/S14/S17/S32 (481 whitelisted files, native-method-heavy: Supply/IO/Thread/objects/roles) — all pass.
- Full `make roast` left to CI per project convention.

## Test plan
- [x] `cargo test --lib`
- [x] `prove -j4 t/`
- [x] targeted roast subset (S12/S14/S17/S32)
- [ ] CI: `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)