### PR TITLE
docs(diagnosis): loop-param hijack behind named-urls failures; session-expiry as capture-bug mirror

### DIFF
--- a/todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md
+++ b/todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md
@@ -102,12 +102,39 @@ the closure's creation point", or making the merge overwrite for
 the merge site). Needs an ADR-level decision on boxing scope + perf
 measurement (boxing cost was the reason lever C stayed narrow, #2749).
 
+## Second manifestation: http-session expiration (the OPPOSITE direction)
+
+`t/http-session-inmemory.rakutest` / `t/http-session-persistent.rakutest`
+"Session expires appropriately" (expected 'Visit 1', got 'Visit 4'): the
+test passes `now => { $fake-now }` into
+`Cro::HTTP::Session::InMemory[...]`, then advances the mainline
+`$fake-now += Duration.new(...)` between requests. The closure is stored in
+the middleware's `&.now` attribute and called on the server's worker
+threads; under mutsu it returns the CREATION-time value forever (verified
+by shadow-lib instrumentation of `SessionStore!delete-expired`: `&!now()`
+stayed at the initial Instant across all requests while head-exp never
+moved, so sessions never expire). This is the mirror image of the
+`$encoder` hijack: there the capture must win over an unrelated caller
+binding; here the creator's POST-capture mutations must stay visible to
+the (cross-thread) closure. A trivial Channel-based synthetic
+(`tmp/cross-thread-live-read.raku`) works — the name-keyed lane sync
+covers it — but the real path (closure stored in an attribute, invoked on
+a worker several spawn generations deep) loses the update. A shared-cell
+capture satisfies both directions at once, which is why the cell route is
+the fix direction rather than merge-order tweaks.
+
+Related same-family ticket (a THIRD direction — captured value wins over
+the closure's own inner for-loop parameter):
+`todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md`.
+Any fix here must be validated against its 11-line repro too.
+
 ## Verification (once fixed)
 
 - `tmp/h2-bisect14.raku`: `in-check enc WHICH` must equal `mainline WHICH`.
 - `bash tmp/cro-suite-run.sh http`: `http2-request-serializer.rakutest`,
   `http2-response-serializer.rakutest`, `http2-request-parser.rakutest`
-  all `notok=0`.
+  all `notok=0`; `http-session-inmemory.rakutest` /
+  `http-session-persistent.rakutest` "Session expires appropriately" pass.
 - The merge-site comment's regression example must keep passing:
   `my $s = 0; my @cb; for 1..3 { @cb.push({ $s }) }; $s = 42; say @cb[0]()`
   → 42.

--- a/todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md
+++ b/todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md
@@ -1,0 +1,80 @@
+# A for-loop parameter inside an escaping closure reads the same-named captured OUTER lexical instead of the iteration value
+
+## Minimal deterministic repro (11 lines, no dependencies)
+
+```raku
+sub make() {
+    my $i = -1;
+    my @parts = 1,;
+    for 1..3 { $i++ }
+    -> {
+        for @parts -> $i {
+            say "i=", $i;
+        }
+    }
+}
+make()();
+```
+
+raku prints `i=1` (the iteration value); mutsu prints `i=2` (the value the
+OUTER `my $i` had when the closure was created). The closure captures the
+enclosing `$i` as a free... it is NOT even a free variable of the closure —
+the inner `for @parts -> $i` declares its own parameter — yet the captured
+env entry for "i" wins over the per-iteration binding when the closure body
+executes. Repro file: `tmp/loop-param-captured-shadow.raku`.
+
+Sensitivities (verified): the outer `$i` must be MUTATED after
+initialization (`$i++` in a loop — matching the shape where the outer `$i`
+is a counter); the closure must escape `make()` and be invoked later.
+
+## Real-world failure: `t/http-router-named-urls.t` (Cro::HTTP), 2 subtests
+
+`Cro::HTTP::Router::LinkGenerator.rakumod`'s `signature-to-sub` builds
+`@path-parts` (static segments) / `@fn-parts` (variable-segment indices)
+using a counter `my $i = -1; for $s.params[] { ...; $i++; ... }`, then
+returns the closure
+
+```raku
+-> *@args, *%nameds {
+    my @result = @path-parts;
+    for @fn-parts -> $i {
+        @result[$i] = @args.shift;
+        ...
+    }
+    ...
+}
+```
+
+Under mutsu, the closure's `for @fn-parts -> $i` sees `$i` frozen at the
+BUILD counter's final value: for route `-> 'search', $category, :$query`
+(3 params, counter ends at 2) every iteration runs with `$i == 2`, so
+`abs-link('qs', 'tools', ...)` produces `["search", Any, "tools"]` →
+`/search//tools?...` instead of `/search/tools?...` ("Escaped named
+param"); for `-> 'product', $id, 'docs', $file` (counter ends at 3) both
+iterations write index 3 — the second overwrites the first, dropping `42`
+→ `/product//docs/foo%20bar.jpg` ("Escaped positional"). Instrumented
+shadow-lib trace confirmed: `S2S fn-parts=[1]` at build, `GEN loop i=2` at
+call; `fn-parts=[1, 3]` at build, `i=3, i=3` at call — exactly the outer
+counter's final values.
+
+## Relationship to other open findings
+
+Same family as `todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md`
+(closure-call captured-env merge vs. same-named bindings), but the opposite
+direction: there a captured value LOSES to the caller env; here a captured
+value WINS over the closure's own inner loop-parameter binding. A fix for
+either should be checked against the other's repro. Also adjacent to
+ADR-0023 (for-loop params as fresh per-iteration bindings) — the loop
+param's read inside the closure body is apparently resolving by NAME
+through the merged captured env (`cap_overrides` / `owned_captures` /
+per-instance state installed at closure entry) instead of through the loop
+binding.
+
+## Verification (once fixed)
+
+- The 11-line repro prints `i=1`.
+- `t/http-router-named-urls.t` "Escaped named param" / "Escaped
+  positional" pass (the file's rc=124 timeout at the end is a SEPARATE,
+  still-undiagnosed issue — see the note in BLOCKERS/cro handoff; do not
+  expect notok=0 rc=0 from this fix alone).
+- roast: no regression in S04-statements/for*.t, S06-*/closure*.t.


### PR DESCRIPTION
Part 2 of the Fable diagnosis session (see #6214 for part 1).

## http-router-named-urls.t — 2 failures root-caused, 11-line repro

`for @fn-parts -> $i { @result[$i] = @args.shift }` inside LinkGenerator's generated closure runs every iteration with `$i` equal to the **build-time counter's final value** (the enclosing `my $i = -1; for ... { $i++ }`), not the iteration value. Shadow-lib trace: `fn-parts=[1]` at build → `i=2` at call for the 3-param route; `fn-parts=[1,3]` → `i=3, i=3` for the 4-param route (second write overwrites the first, dropping `42`). Minimal repro (no Cro, deterministic):

```raku
sub make() {
    my $i = -1;
    my @parts = 1,;
    for 1..3 { $i++ }
    -> { for @parts -> $i { say "i=", $i } }
}
make()();   # raku: i=1, mutsu: i=2
```

Filed as `todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md`. The file's trailing rc=124 hang is a separate undiagnosed issue (noted in the ticket).

## http-session 'Session expires appropriately' — appended to the deep capture ticket

`now => { $fake-now }` returns its creation-time value forever on server worker threads (instrumented `&!now()` never advances despite mainline `$fake-now +=`), so sessions never expire → 'Visit 4' instead of 'Visit 1'. This is the mirror image of the `$encoder` hijack from #6214: post-capture creator mutations must stay visible, while $encoder needs the capture to win over unrelated caller bindings. Only a shared-cell capture satisfies both directions — recorded in `todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md` to constrain the eventual ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)