### PR TITLE
refactor(adr0019): E4b step 7 -- drop IO::Handle's redundant guard group, split Stash's

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2492,6 +2492,27 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     `roast/S17-procasync/` subset (10 files, 155 tests) all green.
     `Stash`'s `AT-KEY`/`keys`/`values` and the mixed `IO::Handle`
     `encoding`/`opened`/`DESTROY` group remain open.
+    **Progress 2026-08-11** (step 7, category 1): closed the `IO::Handle`
+    "mixed" group and split `Stash`'s group. `IO::Handle`'s `encoding`/
+    `opened`/`DESTROY` have no matching arm anywhere in the native fast-path
+    cascade (exhaustive grep, same as `chomp`'s already-confirmed
+    self-guarding arm), so the entire four-name guard is redundant and was
+    deleted outright — the fourth confirmed instance of the "cascade already
+    self-guards or never matches" reduction axis. `Stash` splits instead of
+    reducing wholesale: `AT-KEY` has no cascade arm at all and was dropped,
+    but `keys`/`values` do have arms (`methods_0arg/collection.rs`) whose
+    generic catch-all (`Value::seq(positional_keys(&value_to_list(target)))`
+    for `keys`, `Value::seq(value_to_list(target))` for `values`) would wrap
+    an Instance receiver as if it were a one-element list instead of reading
+    the Stash's own hash — the same shape as the already-known `Hash.keys`
+    0-arg guard, so those two names stay gated. Verified empirically: `cargo
+    test --lib` (769 tests), the full local `Stash`/`IO::Handle` test set (24
+    files, 261 tests: `t/who-stash.t`, `t/stash-exists-key.t`,
+    `t/stash-values.t`, `t/destroy.t`, `t/io-cathandle*.t`,
+    `t/io-handle-*.t`, plus adjacent Stash/destroy coverage), and the
+    `roast/S32-io/{tell,io-path,lock,open,io-handle,slurp,io-cathandle,spurt}.t`
+    subset (8 files, 239 tests) all green. All four "likely reduces"/"mixed"
+    category-1 groups from step 2's audit are now resolved.
 - [ ] **E5 — Route ordinary VM method calls through the resolver.** Cover zero/n-arg and named-call
   opcodes while retaining mutation/writeback semantics at the caller boundary.
   **Design 2026-08-10** (`todo/deep/adr0019-e5-e7-entry-routing.md`): the cutover shape is

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -182,8 +182,14 @@ impl Interpreter {
                     if self.exception_render_needs_interpreter(target, &class_name.resolve())))
             || matches!(target.view(), ValueView::Instance { class_name, .. }
                 if self.is_native_method(&class_name.resolve(), method))
-            || (matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "IO::Handle")
-                && matches!(method, "chomp" | "encoding" | "opened" | "DESTROY"))
+            // No explicit `IO::Handle` `chomp`/`encoding`/`opened`/`DESTROY` gate
+            // here: `chomp`'s own cascade arm (`dispatch_core_str.rs:216-221`)
+            // already returns `None` for `IO::Handle`, and `encoding`/`opened`/
+            // `DESTROY` have no arm anywhere in the native fast-path cascade
+            // (`native_method_{0,1,2}arg`) — confirmed by exhaustive grep,
+            // ADR-0019 E4b step 7 — so the whole group was redundant
+            // belt-and-suspenders, the same shape as the `Supplier.Supply` case
+            // step 5 removed.
             || (matches!(target.view(), ValueView::Instance { .. })
                 && (target.does_check("Real") || target.does_check("Numeric")))
             || matches!(target.view(), ValueView::Instance { class_name, .. } if self.has_user_method(&class_name.resolve(), "Bridge"))
@@ -202,8 +208,15 @@ impl Interpreter {
             // step 5 already removed.
             || (matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Proc::Async")
                 && method == "Supply")
-            || (matches!(method, "AT-KEY" | "keys" | "values")
-                && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash"))
+            // No explicit `Stash` `AT-KEY` gate here: it has no arm anywhere in
+            // the native fast-path cascade, so a row-miss falls through to the
+            // runtime method identically — confirmed by exhaustive grep,
+            // ADR-0019 E4b step 7. `keys`/`values` stay gated: their cascade
+            // arms (`methods_0arg/collection.rs`) have a generic catch-all
+            // (`value_to_list(target)`) that would wrongly serve an Instance
+            // receiver, unlike `AT-KEY`.
+            || (matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash")
+                && matches!(method, "keys" | "values"))
             || (method == "keys"
                 && args.is_empty()
                 && (matches!(target.view(), ValueView::Hash(_))


### PR DESCRIPTION
## Summary
- ADR-0019 E4b category-1 audit (step 7): closes the two remaining "likely reduces"/"mixed" groups from step 2's audit that step 6 didn't cover.
- `IO::Handle`'s `encoding`/`opened`/`DESTROY` have no matching arm anywhere in the native fast-path cascade (`native_method_{0,1,2}arg`), the same shape as `chomp`'s already-confirmed self-guarding arm (`dispatch_core_str.rs:216-221`) — the whole four-name guard is deleted outright.
- `Stash` splits instead of reducing wholesale: `AT-KEY` has no cascade arm and is dropped, but `keys`/`values` keep an explicit guard — their cascade arms in `methods_0arg/collection.rs` have a generic catch-all (`value_to_list(target)`) that would misread a Stash Instance as a one-element list instead of its own hash, the same shape as the existing `Hash.keys` 0-arg guard.
- Docs: records the finding in `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` under E4b step 7.

## Test plan
- [x] `cargo test --lib` (769 tests)
- [x] `prove -e target/debug/mutsu` local Stash/IO::Handle test set (24 files, 261 tests)
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu` on `roast/S32-io/{tell,io-path,lock,open,io-handle,slurp,io-cathandle,spurt}.t` (8 files, 239 tests)
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check`
- [ ] CI: `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)