### PR TITLE
feat(closure): ADR-0025 slice 1 — box Instance-holding captured scalars; install protect-block upvalue arrays

### DIFF
--- a/docs/adr/0025-captured-scalar-cells-value-kind-blind.md
+++ b/docs/adr/0025-captured-scalar-cells-value-kind-blind.md
@@ -144,6 +144,29 @@ This is the expected shape of slice-1 fallout: cells entering paths that
 never saw them, each surfacing as a deterministic test failure (the safety
 net working, per CLAUDE.md's risk definitions).
 
+CI's full roast then caught a second member of the same fallout class
+(deterministic across all three jobs):
+`roast/integration/advent2013-day14.t` hung after test 6 — the
+`config_combiner` shape. The captured vow `my $v = $p.vow` (an Instance,
+newly cell-boxed: the nested loop-param assignment registers as a free
+write, so `v` is captured-and-mutated and the `start` block is
+thread-escaping) shares its name with a **multi-param for-loop parameter**
+(`for %kvs.kv -> $k, $v`). `build_for_bind_stmts` binds multi-params via
+plain `Stmt::Assign`, whose exec writes THROUGH a `ContainerRef` — every
+iteration wrote a config Str into the vow's cell, and `$v.keep(%result)`
+after the loop called `.keep` on a Str, so the promise never resolved.
+This is precisely the corruption direction the loop-param ticket predicted
+("a ForLoop binding that wrote through such a cell would corrupt the outer
+counter"). Fixed in `exec_for_loop`'s multi-param prep
+(`vm_for_loop_body.rs`): a scalar multi-param whose name is currently
+bound to a cell has that binding SEVERED for the loop's duration (env
+entry removed, slot reset) — the pre-loop save/restore already preserves
+the cell itself, so only the loop-duration binding becomes a plain fresh
+value, per ADR-0023's fresh-binding provenance. Pin: test 7 of
+`t/closure-capture-instance-cell.t`. The READ-side loop-param bug
+(GetUpvalue bypass, single-param shape) remains open in its ticket — this
+fix removes only the write-corruption direction for multi-params.
+
 ### Slice 2 (planned): the escape verdict must stop being a correctness gate
 
 Invariant to establish: **every captured plain user scalar is either

--- a/docs/adr/0025-captured-scalar-cells-value-kind-blind.md
+++ b/docs/adr/0025-captured-scalar-cells-value-kind-blind.md
@@ -1,0 +1,263 @@
+# ADR-0025: Cell boxing of captured scalars must be value-kind-blind — retiring the Instance skip, and demoting the escape verdict from correctness gate to perf hint
+
+- Status: Accepted (slice 1 implemented; slices 2-3 planned)
+- Date: 2026-08-11
+- Related: ADR-0010 (lineage-scoped sharing), ADR-0023 (binding provenance),
+  ADR-0024 (mainline lexical cells), PR #2749 (broad closure boxing reverted),
+  PR #2751 (escape-aware sibling-cell sharing)
+- Addresses: `todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md`
+  (directions 1 and 2; direction 3 is a separate compiler bug — see §5)
+
+## Context
+
+### The failure family
+
+A closure's captured plain-scalar lexical can be wrong in two mirror-image
+ways when the closure is invoked away from its creation chain:
+
+1. **Hijack** (Cro::HTTP2 serializer/parser tests, "check 4" family): the
+   closure-call captured-env merge (`vm_closure_dispatch.rs`,
+   `entry_or_insert_sym` = don't-overwrite) installs a plain captured value
+   only if the caller's env chain does not already hold the name. A
+   same-named `my` in whatever frame happens to be calling shadows the
+   closure's own lexical — lexical scoping degrading to dynamic scoping.
+2. **Staleness** (http-session "Session expires appropriately"): the
+   creator's post-capture rebind of the variable is invisible to a closure
+   whose captured env snapshotted a plain value — especially across
+   threads, where the name-keyed `shared_vars` lane does not reach a
+   closure stored in an attribute and invoked on a pre-existing worker.
+
+A shared `ContainerRef` cell satisfies both at once: the cell wins the merge
+(overwrite branch — identity protection) and the creator's writes go through
+the cell (liveness). Merge-order tweaks can only ever fix one direction at
+the other's expense; this is why the cell route is the only sound fix shape
+(established in the deep ticket, reconfirmed here).
+
+### Sharpened root cause (2026-08-11, this ADR's diagnosis)
+
+The deep ticket attributed the hole to "read-only captures get no cell". The
+real files say otherwise. In all three affected Cro test files the pattern is
+
+```raku
+my $encoder;                            # or: my $encoder = HTTP::HPACK::Encoder.new;
+$encoder = HTTP::HPACK::Encoder.new;    # reassigned repeatedly between test blocks
+... ( *.headers eq $encoder.encode-headers(@headers) ) ...   # captured in check closures
+```
+
+so `$encoder` IS captured-and-mutated (`captured_mutated_locals` contains
+it — the vouch/`authoritative_free_vars` refusal is *correct*), and the
+check closures ARE compiled in escaping position (array-literal elements
+compile under `with_escape(true)`, `expr_data.rs`), so
+`needs_cell_locals` triggers boxing. Every defense fired as designed except
+the last gate:
+
+**`box_captured_lexicals` (vm_register_ops.rs) and `box_decl_local_cell`
+(vm_var_assign_local_get.rs) skip boxing when the slot currently holds an
+`Instance`** (also Package/Array/Hash/Sub/Proxy). At every check-closure
+creation `$encoder` holds an `HTTP::HPACK::Encoder` instance, so no cell
+ever forms, the capture stays a plain by-value snapshot, and the
+don't-overwrite merge exposes it to the caller chain. The same skip explains
+direction 2: `Instant` (`$fake-now`) and session objects are Instances.
+
+A/B proof (both repros in-repo, dependency-free, deterministic):
+
+- `tmp/cap-hijack-instance.raku` (24 lines): Instance-holding
+  captured-mutated scalar → hijacked (`v=CALLER`, and a Str shadow
+  crashes with "No such method 'v' for invocant of type 'Str'").
+  `tmp/cap-hijack-str-ab.raku`: byte-identical structure with a
+  boxable Str → cell forms → protected (`v3=MAIN`). The value-kind skip is
+  the single differing gate.
+- `tmp/cap-stale-worker-first.raku` (22 lines): attribute-stored closure on
+  a worker started BEFORE the creator's rebind → mutsu `after=1` (stale),
+  raku `after=2`. Same skip, staleness direction.
+
+### Why the skip is obsolete
+
+The skip dates to the #2749 revert, which had two fatal reasons:
+
+1. *Correctness*: `overwrite_instance_recursive` (the id→cell registry
+   writeback that propagated a mutating method's result into bindings)
+   did not descend `ContainerRef`, so a boxed scalar holding an instance
+   lost mutations. **That mechanism no longer exists**: instances mutate
+   in place through their Gc-shared attr cell (`commit_attrs`,
+   `value_instance.rs`), whose doc explicitly guarantees visibility
+   "in this frame, any caller frame, a `ContainerRef`-boxed capture".
+2. *Performance*: broad boxing per closure creation (int.t ~1s → 150s).
+   **Irrelevant to the skip**: the skip does not bound how often boxing
+   runs, only which VALUES get wrapped once a trigger already fired. The
+   frequency bounds are the loop/escape/dup-shadow triggers, which this
+   slice does not touch.
+
+Decisive: **"a cell whose contents is an Instance" is an
+already-exercised state on main** — assign an object into an
+already-boxed scalar (`my $x = 1; my &c = {$x}; $x = Obj.new`) and every
+read path must already deref it (`tmp/cell-holds-instance.raku` passes on
+main). Relaxing the skip creates no new VM state; it only changes when an
+existing state is entered.
+
+## Decision
+
+### Slice 1 (implemented with this ADR): remove `Instance` from the value-kind skip
+
+Two lines: drop `ValueView::Instance { .. }` from the skip `matches!` in
+`box_captured_lexicals` and `box_decl_local_cell`. Everything else —
+triggers (loop / escape / dup-shadow / named-sub decl-site), the
+`type_constrained_unboxable` skip (cas), and the remaining kind skips —
+is unchanged:
+
+- **Package / type objects**: class handles; dispatch and identity paths
+  are not audited for cells. Keep.
+- **Array / Hash values in `$` slots** (itemized containers): very common
+  (`my $a = [1,2,3]`), broad blast radius, intersects the ADR-0010 atomic
+  lanes and Track B. Own slice (§4).
+- **Sub**: the `&` lane has its own registries. Keep.
+- **Proxy**: FETCH/STORE must not be hidden behind a cell. Keep permanently.
+
+Measured (debug build, 2026-08-11):
+
+- The three synthetics above flip to raku-correct; the full pre-existing
+  synthetic battery (authoritative/vouch matrix, supply/tap shapes,
+  cross-thread lane shapes) is unchanged.
+- Cro::HTTP2 (main → slice 1): `http2-request-serializer.rakutest`
+  notok 3 → **0**; `http2-response-serializer.rakutest` notok 3 → 1;
+  `http2-request-parser.rakutest` notok 1 → 1 (residuals in §5).
+
+### What slice 1 flushed out: the inline-exec upvalue-aliasing bug
+
+`make test` caught exactly one regression, `t/lock-protect-shared-scalar.t`
+1-2 (`Lock.protect` accumulation went to 0), and it was NOT a defect in the
+relaxation — it was a pre-existing, latent VM bug the new cells exposed:
+the inline `Lock.protect` executors (`exec_protect_block_inline`,
+`call_protect_block`) run the protect block's CompiledCode **without
+installing the block's own captured upvalue array**, so a `GetUpvalue` in
+the block body indexes the ENCLOSING closure's array. The protect block's
+`GetUpvalue(0)` meant `$i`; the enclosing Promise closure's slot 0 was the
+newly-boxed `$l` Lock cell; `$r += $i` became `$r += Lock` and accumulated
+nothing. Latent until now because `capture_upvalues` freezes `Some` only
+for `ContainerRef` cells — rare pre-slice-1. Both protect sites now swap
+the block's array in around the exec (restored after); the remaining
+inline-exec sites (eager map/grep `run_reuse`, one arith site) are
+enumerated for the same treatment in
+`todo/tickets/inline-closure-exec-sites-skip-upvalue-array-install.md` —
+finish that audit BEFORE or WITH slice 2, since more cells widen exposure.
+This is the expected shape of slice-1 fallout: cells entering paths that
+never saw them, each surfacing as a deterministic test failure (the safety
+net working, per CLAUDE.md's risk definitions).
+
+### Slice 2 (planned): the escape verdict must stop being a correctness gate
+
+Invariant to establish: **every captured plain user scalar is either
+authoritative (proven never-written → by-value overwrite-install) or a
+shared cell (overwrite-install).** The don't-overwrite merge lane stops
+being load-bearing for plain scalars; it remains for dynamics, the topic,
+`self`, metadata, and the §4 exclusions.
+
+Today a closure the compiler deems non-escaping (call-arg position — a
+`@registry.push($cb)`, `.tap($cb)`, `Holder.new(now => $cb)` before the
+named-arg fix) gets no cell for its captured-mutated variables and relies
+on the caller-chain live-read — correct only while the calling chain IS the
+creating chain. Every mis-verdict is a latent hijack/staleness bug of
+exactly this family. Per CLAUDE.md's gain/risk definitions an incomplete
+static analysis must bound COST, never CORRECTNESS.
+
+Mechanism: extend the existing decl-site machinery
+(`needs_cell_named_sub_ref_slots` → `box_decl_local_cell`) with a
+slot-indexed compile-time set (working name `cell_captured_ref_slots`):
+slots of plain-scalar locals that are captured by ANY nested closure and
+are vouch-refused — i.e. `captured_mutated_locals` ∪ (`own_container_writes`
+∩ captured) ∪ (`own_call_arg_sources` ∩ captured ∖ `scalar_bind_locals`).
+That is precisely the complement of `authoritative_free_vars` within the
+captured set, so the dichotomy is exhaustive by construction. Decl-site
+boxing makes the binding a cell from birth: no boxing-moment ordering
+races, sibling closures share trivially, and the value-kind question of
+slice 1 disappears for these names (the seed at declaration is Any).
+Creation-site `box_captured_lexicals` stays as a no-op-when-already-cell
+backstop.
+
+Perf gates (mandatory, in order):
+
+1. `MUTSU_VM_STATS` counter (`decl_cell_boxes`) — assert ≈0 across
+   `benchmarks/` (debug build per the counters rule).
+2. **`roast/S32-num/int.t` wall-clock is the named canary** — the #2749
+   blowup (~1s → 150s+, hidden from `make test`) must be re-checked in a
+   release build BEFORE pushing.
+3. Bench CI history is the final verdict per CLAUDE.md.
+
+If the canary regresses, diagnose the cost source (per-creation Arc churn
+vs env insert) rather than re-gating on escape — e.g. hoist the boxing out
+of per-iteration redeclaration, or intern the cell in the declaration plan.
+
+Cross-thread audit rider: the ADR-0024 implementation notes (points 5-7)
+enumerate frame-independent "assign this name by value" utilities
+(`assign_rw_target_expr`, `set_env_with_main_alias_sym`,
+`sync_shared_vars_to_env`) that historically replaced cells with plain
+values. Points 5/7 were fixed via the mainline-map-specific
+`mainline_lexical_cell` lookup; slice 2 must generalize those two sites to
+preserve ANY `ContainerRef` env entry (point 6's fix already is generic).
+
+### Slice 3 (follow-ups, each its own slice)
+
+- **Type/`where`-constrained scalars**: still skipped (`cas` resolves its
+  target by name — S17-lowlevel/cas.t; constraints re-check at the
+  assignment chokepoint). Prerequisite: make `cas`/constraint checks
+  cell-aware, then fold these into slice 2's set.
+- **`$`-held Array/Hash (itemized containers) and Package-valued scalars**:
+  measure how often they are captured-and-mutated in real suites before
+  designing; intersects Track B / ADR-0001 layer 3a.
+- **`@`/`%`/`&`**: reference-shared already; rebinding staleness is a
+  narrower hole. Deferred with ADR-0024's identical limitation.
+
+## Alternatives rejected
+
+- **Merge-order / authoritative widening**: cannot satisfy hijack
+  protection and liveness simultaneously (deep ticket; the
+  `my $s = 0; @cb.push({ $s }); $s = 42` regression example pins the
+  liveness direction).
+- **Lazy collision-triggered boxing**: shadow introduction has no single
+  chokepoint; an incomplete detector yields flaky, load-order-dependent
+  wrong answers (ADR-0024 rejected the same idea with precedent
+  S12-construction/roles-6e.t).
+- **Keeping the Instance skip and special-casing HPACK-like shapes**:
+  test-specific hacks are banned; the skip is not protecting any live
+  mechanism anymore (§ "Why the skip is obsolete").
+
+## §5. Adjacent findings this diagnosis separated out
+
+1. **Direction 3 (loop-param hijack) is a different bug** —
+   `todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md`,
+   root cause now verified by gdb: a for-loop parameter WITHOUT a
+   pre-existing local slot allocates none (`param_local` is a lookup, not
+   an alloc — `compiler/stmt.rs`), so the param name is invisible to the
+   compiled body's `own` set, the body's reads register as FREE variables,
+   and `compute_upvalues` rewrites them to `GetUpvalue` — reading the
+   captured outer value directly, bypassing both the frame env and the
+   ForLoop binding entirely. Fix is compiler-side (loop params must be own
+   bindings of the cc). Co-requisite validation: its 11-line repro must be
+   re-run when slice 2 lands (cells widen what a captured name can carry
+   into a closure frame).
+2. **Residual "check 4" failures after slice 1** (kept in the deep
+   ticket, narrowed): `http2-response-serializer.rakutest` test 14 — an
+   `$encoder`/`@headers` check where the cell now delivers the right
+   object, so the remaining mismatch is elsewhere (suspects: `@headers`
+   liveness through the capture, or HPACK dynamic-table state trajectory);
+   `http2-request-parser.rakutest` test 44 — reads
+   `*.body-blob.result eq $payload`, i.e. NOT the encoder family at all
+   (suspects: cross-stream DATA demux or `Buf`-capture). Each needs its
+   own shadow-bisect.
+3. **`http-session-inmemory/persistent` crash rc=139 ON MAIN** at test 2
+   (was 10/13 on 2026-08-09) — pre-existing regression unrelated to this
+   campaign; filed as
+   `todo/tickets/http-session-tests-crash-rc139-on-main.md`. The deep
+   ticket's session acceptance criterion is blocked behind it.
+
+## Acceptance criteria
+
+- Slice 1 (this PR): the three synthetics (`t/closure-capture-instance-cell.t`
+  pins them); `http2-request-serializer.rakutest` notok=0; no `make test`
+  regressions; full roast delegated to CI.
+- Slice 2: `t/` pin for the call-arg-stored closure shape (push/tap/ctor);
+  perf gates above; the merge-site regression example still passes; the
+  ADR-0023/0024 pin files stay green
+  (`t/for-loop-param-start-sibling-isolation.t`, `t/named-sub-lexical-scope.t`).
+- End state: the deep ticket's `tmp/h2-bisect14.raku` WHICH-identity check,
+  and Cro session files once the rc=139 regression is fixed.

--- a/news/2026-08/adr-0025-instance-capture-cells-and-protect-upvalue-fix.md
+++ b/news/2026-08/adr-0025-instance-capture-cells-and-protect-upvalue-fix.md
@@ -1,0 +1,42 @@
+# ADR-0025 slice 1: Instance-holding captured scalars get cells; inline protect executors install the block's upvalue array
+
+The Cro "check 4" family (closure captures hijacked by same-named caller
+lexicals) and the http-session staleness mirror were re-diagnosed with
+in-repo, dependency-free repros, sharpening the deep ticket's root cause:
+the failing `$encoder` IS captured-and-mutated and its check closures ARE
+escaping-deemed — every defense fired except the **value-kind skip** in
+`box_captured_lexicals` / `box_decl_local_cell`, which refused to box a
+slot currently holding an `Instance`. HPACK encoders, `Instant`, and
+session objects are all Instances, which is why both failure directions
+(hijack and staleness) hit this family exclusively. The skip's original
+#2749 rationale is obsolete: instances now mutate in place through their
+Gc-shared attr cell, and "a cell holding an Instance" has long been an
+exercised state (assign an object into an already-boxed scalar).
+
+ADR-0025 (`docs/adr/0025-captured-scalar-cells-value-kind-blind.md`)
+records the decision: slice 1 removes `Instance` from the skip (two lines);
+slice 2 (planned) retires the escape verdict as a correctness gate via
+decl-site cells for every vouch-refused captured scalar; slice 3 items
+(type-constrained scalars, itemized `$`-held containers, `@`/`%`/`&`) stay
+enumerated with their blockers.
+
+Slice 1 flushed out a latent VM bug within hours — the designed safety-net
+behavior: `Lock.protect`'s inline executors (`exec_protect_block_inline`,
+`call_protect_block`) ran the protect block's bytecode without installing
+the block's own captured upvalue array, so a `GetUpvalue` in the block
+indexed the ENCLOSING closure's array; with `$l` newly boxed, the protect
+block `{ $r += $i }` read the Lock cell as `$i` and accumulated nothing
+(`t/lock-protect-shared-scalar.t`). Both sites now swap the correct array
+in; the remaining inline-exec sites are ticketed in
+`todo/tickets/inline-closure-exec-sites-skip-upvalue-array-install.md`.
+
+Results: `http2-request-serializer.rakutest` fully green (notok 3 → 0);
+`http2-response-serializer.rakutest` 3 → 1 and `http2-request-parser.rakutest`
+1 → 1 (both residuals re-diagnosed as different shapes — narrowed in the
+deep ticket); the session-expiry staleness mechanism is pinned by
+`t/closure-capture-instance-cell.t` (6 tests, raku-validated), while the
+session files themselves are blocked behind a pre-existing rc=139 crash on
+main (`todo/tickets/http-session-tests-crash-rc139-on-main.md`). The
+loop-param hijack ticket gained a verified root cause (slotless for-loop
+params are invisible to the free-var analysis; body reads become
+GetUpvalue and bypass the loop binding).

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -539,7 +539,18 @@ impl Interpreter {
             let (compiled, compiled_fns, _captured_bindings, _writeback_bindings, captured_names) =
                 self.get_or_compile_protect_block_with_slots(&data);
             self.sync_shared_vars_for_names(captured_names.iter().map(|name| name.as_str()));
-            self.run_compiled_block(&compiled, compiled_fns.as_ref())
+            // Install THIS block's captured upvalue array for the duration:
+            // `run_compiled_block` bypasses closure dispatch, so without this a
+            // `GetUpvalue` in the block body indexes the ENCLOSING closure's
+            // array — index collision hands it an unrelated capture (the
+            // `$l.protect({ $r += $i })` block read the enclosing frame's
+            // upvalue 0, the Lock cell, as `$i`). Latent while upvalue arrays
+            // held `Some` only for rare cells; exposed when ADR-0025 made
+            // Instance-holding captures boxable.
+            let saved_upvalues = std::mem::replace(&mut self.upvalues, data.upvalues.clone());
+            let result = self.run_compiled_block(&compiled, compiled_fns.as_ref());
+            self.upvalues = saved_upvalues;
+            result
         } else {
             self.call_sub_value(code.clone(), Vec::new(), true)
         }

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -177,7 +177,21 @@ impl Interpreter {
             self.set_env_with_main_alias("self", s.clone());
         }
 
-        // Execute the block's opcodes inline
+        // Execute the block's opcodes inline. Install the BLOCK's own captured
+        // upvalue array for the duration: this inline path bypasses closure
+        // dispatch, so without the swap a `GetUpvalue` in the block body
+        // indexes the ENCLOSING closure's array — an index collision hands it
+        // an unrelated capture (`$l.protect({ $r += $i })` read the enclosing
+        // frame's upvalue 0, the Lock cell, as `$i`). Latent while upvalue
+        // arrays held `Some` only for rare cells; exposed when ADR-0025 made
+        // Instance-holding captures boxable.
+        let saved_upvalues = std::mem::replace(
+            &mut self.upvalues,
+            sub_data
+                .as_ref()
+                .map(|d| d.upvalues.clone())
+                .unwrap_or_default(),
+        );
         let mut sub_ip = 0;
         let mut exec_err = None;
         while sub_ip < block_cc.ops.len() {
@@ -186,6 +200,7 @@ impl Interpreter {
                 break;
             }
         }
+        self.upvalues = saved_upvalues;
 
         // The block runs inline in the current env, so a free variable it
         // assigns (`$x = 99` where `$x` is a captured outer lexical) is written

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -266,6 +266,37 @@ impl Interpreter {
                 (name.clone(), val, was_readonly, sigilless_ro, saved_local)
             })
             .collect();
+        // A multi-param loop variable is a FRESH per-iteration binding
+        // (ADR-0023 provenance), but `build_for_bind_stmts` binds it via a
+        // plain `Stmt::Assign`, whose exec writes THROUGH a `ContainerRef`
+        // when the shadowed outer name is a boxed cell — corrupting the outer
+        // binding for every alias of the cell. roast
+        // integration/advent2013-day14.t's `config_combiner`: the captured
+        // vow `$v` is a cell (Instance boxing, ADR-0025 slice 1), and
+        // `for %kvs.kv -> $k, $v` wrote each config Str into that cell, so
+        // `$v.keep(%result)` after the loop called .keep on a Str and the
+        // returned promise never resolved. Sever a scalar cell binding up
+        // front: the save above keeps the cell itself for the post-loop
+        // restore, so only the loop-duration binding becomes a plain fresh
+        // value. `@`/`%`/`&` keep their container-cell aliasing (see the
+        // slot-restore comment below).
+        for (i, name) in spec.multi_param_names.iter().enumerate() {
+            if name.is_empty() || name.starts_with(['@', '%', '&']) {
+                continue;
+            }
+            if matches!(
+                self.env().get(name).map(Value::view),
+                Some(ValueView::ContainerRef(_))
+            ) {
+                self.env_mut().remove(name);
+            }
+            if let Some(slot) = spec.multi_param_locals.get(i).copied().flatten() {
+                let slot = slot as usize;
+                if self.locals[slot].is_container_ref() {
+                    self.locals[slot] = Value::NIL;
+                }
+            }
+        }
         // A multi-parameter loop (`-> $k, $v`) binds its parameters with plain
         // assignments emitted into the body prefix (`build_for_bind_stmts`), and
         // `SetLocal` type-checks an assignment against the *name-keyed* constraint

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -950,7 +950,6 @@ impl Interpreter {
                         | ValueView::Array(..)
                         | ValueView::Hash(..)
                         | ValueView::Sub(..)
-                        | ValueView::Instance { .. }
                         | ValueView::Proxy { .. }
                 )
             {

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -339,7 +339,6 @@ impl Interpreter {
                     | ValueView::Array(..)
                     | ValueView::Hash(..)
                     | ValueView::Sub(..)
-                    | ValueView::Instance { .. }
                     | ValueView::Proxy { .. }
             )
         {

--- a/t/closure-capture-instance-cell.t
+++ b/t/closure-capture-instance-cell.t
@@ -1,0 +1,93 @@
+use Test;
+
+# ADR-0025 slice 1: cell boxing of captured scalars is value-kind-blind —
+# an Instance-holding captured-and-mutated scalar gets a shared cell just
+# like a Str/Int one, so the capture neither loses to a same-named lexical
+# in the calling chain (hijack) nor freezes the creation-time value
+# (staleness).
+
+plan 6;
+
+class Enc { has $.v }
+
+# 1) Hijack direction: the capture must win over a same-named env entry in
+#    the CALLING closure's chain (the Cro::HTTP2 $encoder shape).
+{
+    my $enc;
+    $enc = Enc.new(v => "MAIN");
+    my @checks = ({ $enc.v },);
+    my $got;
+    sub invoke-a(@c, $out is rw) {
+        my $runner = {
+            my $enc = Enc.new(v => "CALLER");
+            my $keep = { $enc };
+            $out = @c[0]();
+        };
+        $runner();
+    }
+    invoke-a(@checks, $got);
+    is $got, "MAIN", 'Instance capture wins over same-named Instance in caller chain';
+}
+
+# 2) Same, but the caller-chain shadow is a plain Str: before the fix this
+#    crashed with "No such method 'v' for invocant of type 'Str'".
+{
+    my $enc2;
+    $enc2 = Enc.new(v => "MAIN");
+    my @checks2 = ({ $enc2.v },);
+    my $got2;
+    sub invoke-b(@c, $out is rw) {
+        my $runner = {
+            my $enc2 = "CALLER";
+            my $keep = { $enc2 };
+            $out = @c[0]();
+        };
+        $runner();
+    }
+    invoke-b(@checks2, $got2);
+    is $got2, "MAIN", 'Instance capture wins over same-named Str in caller chain';
+}
+
+# 3) Staleness direction (the http-session $fake-now shape): a worker
+#    thread started BEFORE the creator's rebind must observe the rebind
+#    through an attribute-stored closure.
+{
+    class Holder { has &.now }
+    my $x = Enc.new(v => 1);
+    my $h = Holder.new(now => { $x });
+    my $ch = Channel.new;
+    my $out = Channel.new;
+    my $worker = start {
+        react {
+            whenever $ch -> $ping {
+                $out.send($h.now.().v);
+            }
+        }
+    }
+    $ch.send(0);
+    is $out.receive, 1, 'worker reads creation-time value before rebind';
+    $x = Enc.new(v => 2);
+    $ch.send(1);
+    is $out.receive, 2, 'worker observes post-capture rebind of Instance-holding capture';
+    $ch.close;
+    await $worker;
+}
+
+# 4) Regression guard: a cell formed while the scalar held an Int keeps
+#    working after an Instance is assigned into it (pre-existing state).
+{
+    my $y = 1;
+    my &get = { $y };
+    $y = Enc.new(v => 42);
+    is get().v, 42, 'cell formed as Int carries a later-assigned Instance';
+}
+
+# 5) The merge-site liveness example must keep passing: a call-arg closure
+#    over a later-mutated scalar reads the live value.
+{
+    my $s = 0;
+    my @cb;
+    @cb.push({ $s });
+    $s = 42;
+    is @cb[0](), 42, 'post-capture mutation stays visible to call-arg closure';
+}

--- a/t/closure-capture-instance-cell.t
+++ b/t/closure-capture-instance-cell.t
@@ -6,7 +6,7 @@ use Test;
 # in the calling chain (hijack) nor freezes the creation-time value
 # (staleness).
 
-plan 6;
+plan 7;
 
 class Enc { has $.v }
 
@@ -90,4 +90,20 @@ class Enc { has $.v }
     @cb.push({ $s });
     $s = 42;
     is @cb[0](), 42, 'post-capture mutation stays visible to call-arg closure';
+}
+
+# 6) A multi-param for-loop parameter sharing its name with a captured,
+#    cell-boxed Instance scalar is a FRESH binding: it must not write the
+#    iteration values through the cell (roast integration/advent2013-day14.t
+#    config_combiner — `for %kvs.kv -> $k, $v` corrupted the captured vow,
+#    and `$v.keep` after the loop found a Str).
+{
+    my $p = Promise.new;
+    my $v = $p.vow;
+    my %kvs = a => "x", b => "y";
+    await start {
+        for %kvs.kv -> $k, $v { }
+        $v.keep("kept");
+    }
+    is $p.result, "kept", 'multi-param loop name does not corrupt a captured vow cell';
 }

--- a/todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md
+++ b/todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md
@@ -1,143 +1,60 @@
-# A closure's read-only captured scalar is hijacked by a same-named lexical in the CALLER's env chain (lexical scoping degrades to dynamic scoping)
+# Closure-capture same-name family — RESOLVED CORE (ADR-0025 slice 1); two narrowed residuals + slice 2 remain
 
-## TL;DR — root cause is now fully diagnosed
+## Status after ADR-0025 slice 1 (2026-08-11)
 
-The closure-call captured-env merge in
-`src/vm/vm_closure_dispatch.rs` (`for (k, v) in data.env.iter()`) installs
-non-`ContainerRef` captured values with `entry_or_insert_sym` — **don't
-overwrite** — into a frame env that is a `scoped_child` of the **caller's**
-env. So when a closure is invoked from a frame whose env chain happens to
-contain a same-named variable, the caller's value shadows the closure's own
-lexical capture. The three protections that normally paper over this all
-have holes for the "creator wrote the variable before creating the closure,
-closure only reads it" shape:
+The core defect is **diagnosed differently than this ticket originally
+claimed, and fixed**. The original TL;DR blamed "read-only captures get no
+cell"; the sharpened diagnosis (see
+`docs/adr/0025-captured-scalar-cells-value-kind-blind.md`, Context) is:
 
-- `box_captured_lexicals` (lever C) boxes only captured-**and-mutated**
-  locals into shared `ContainerRef` cells (a cell wins the merge via the
-  overwrite branch). A read-only capture gets no cell.
-- `cc.authoritative_free_vars` (overwrite-install) excludes any lexical the
-  creating frame **ever writes** — so `my $encoder; ... $encoder = X.new;`
-  (declare-then-assign, the most common mainline pattern) is not
-  authoritative, even though every write precedes the closure's creation.
-- `data.owned_captures` covers per-iteration loop captures only.
+- The real files' `$encoder` IS captured-and-mutated (declare-then-assign,
+  reassigned between test blocks), so `captured_mutated_locals` held it and
+  the vouch refusal was correct; the check closures ARE escaping-deemed
+  (array-literal elements compile under `with_escape(true)`), so
+  `needs_cell_locals` fired.
+- The single defense that failed was the **value-kind skip** in
+  `box_captured_lexicals` / `box_decl_local_cell`: a slot holding an
+  `Instance` at boxing time was never boxed. HPACK encoders, `Instant`
+  (`$fake-now`), and session objects are all Instances, which is why both
+  the hijack direction AND the staleness direction hit exactly this family.
+- Slice 1 removed `Instance` from the skip (2 lines). Pins:
+  `t/closure-capture-instance-cell.t` (6 tests, raku-validated), built from
+  the minimal in-repo repros `tmp/cap-hijack-instance.raku` /
+  `tmp/cap-hijack-str-ab.raku` / `tmp/cap-stale-worker-first.raku` — the
+  synthetic-repro drought this ticket reported is over (the missing
+  ingredient was an Instance-holding capture plus a caller-chain shadow
+  that owns an env KEY, forced via a nested capturing closure).
 
-The don't-overwrite default exists deliberately: mutsu captures by value,
-so a creator that mutates AFTER capture (`my $s = 0; @cb.push({ $s });
-$s = 42`) needs the closure to read the LIVE value through the caller
-chain. That mechanism cannot distinguish "creator's live binding" from
-"unrelated same-named lexical of whatever frame happens to be calling" —
-which is exactly the failure here.
+Cro measurements (main → slice 1): `http2-request-serializer.rakutest`
+notok 3 → **0**; `http2-response-serializer.rakutest` 3 → 1;
+`http2-request-parser.rakutest` 1 → 1.
 
-## Real-world failure (Cro::HTTP2 suite, 7 subtests across 3 files)
+## Remaining work tracked here
 
-`t/http2-request-serializer.rakutest` (and `http2-response-serializer`,
-`http2-request-parser`): the test helper `sub test(..., *@checks)` taps
-`Cro::HTTP2::RequestSerializer.transformer($fake-in.Supply)`. The mainline
-builds check closures like `(*.headers eq $encoder.encode-headers(@headers))`
-over a mainline `my $encoder = HTTP::HPACK::Encoder.new`. The serializer's
-`whenever` body (`RequestSerializer.rakumod:13`) declares its own
-`my $encoder = HTTP::HPACK::Encoder.new` on the supply worker thread. The
-check closure is invoked from the tap callback **on that worker's call
-chain**, so its `$encoder` read resolves to the SERIALIZer's encoder
-(don't-overwrite merge finds "encoder" already in the caller env chain).
-An HPACK encoder is stateful: the serializer already encoded the headers
-once, so the test's re-encode emits dynamic-table references
-(`190,130,135,191,192` instead of the 38-byte literal encoding) and
-`check 4` fails. The `data eq $random` checks pass because the whenever
-body has no `my $random` — only the `$encoder`-reading check is hijacked.
-(The old ticket `todo/tickets/http2-data-frame-content-mismatch-...md`
-misattributed the failure to the DATA frame's `.data`; the failing check
-is the HEADERS frame's `.headers eq` — same helper line, "check 4" of
-frame 1.)
+1. **`http2-response-serializer.rakutest` test 14** ("check 4" of
+   'Header + Data'): the `$encoder` cell now delivers the right object, so
+   the residual mismatch is elsewhere. Suspects: `@headers` liveness
+   through the capture (`@headers` is reassigned between blocks; `@` is
+   outside slice 1), or HPACK dynamic-table state trajectory (the test-side
+   encoder is warm from the previous block's check while the per-`test()`
+   serializer is cold). Needs shadow-bisect with byte-level comparison.
+2. **`http2-request-parser.rakutest` test 44** ("check 4" of
+   'Header1 + Header2 + Data1'): the failing check is
+   `*.body-blob.result eq $payload` — NOT the encoder family at all (the
+   old "DATA frame content mismatch" label was right for THIS file).
+   Suspects: cross-stream DATA demux (streams 3 and 5 interleave, stream 5
+   carries `$payload ~ $payload`) or `Buf`-capture. Independent diagnosis.
+3. **ADR-0025 slice 2** (escape verdict must stop being a correctness
+   gate — decl-site cells for every vouch-refused captured scalar) and
+   slice 3 follow-ups: design and gates are in the ADR; implementation
+   pending.
+4. **Session acceptance blocked**: `http-session-inmemory/persistent`
+   currently crash rc=139 at test 2 ON MAIN (pre-existing, unrelated —
+   `todo/tickets/http-session-tests-crash-rc139-on-main.md`). Re-check
+   "Session expires appropriately" once that regression is fixed; the
+   staleness mechanism it depends on is the one slice 1 fixed
+   (pinned by `t/closure-capture-instance-cell.t` tests 3-4).
 
-Verified instrumentation (2026-08-11, temporary `MUTSU_DEBUG_ENC` prints in
-the merge loop):
-
-```
-[ENC] merge id=800 captured=inst#795 is_cell=false existing_in_caller=inst#821
-[ENC] post-merge id=800 env_encoder=inst#821 writes=false cwrites=false auth=false
-```
-
-Captured env holds the CORRECT mainline instance (#795); the caller env
-already holds the serializer's whenever-local (#821); don't-overwrite keeps
-#821; the closure body then reads #821. Renaming the serializer's inner
-`my $encoder` to `$enc-renamed` (shadow-lib experiment) makes the test
-pass — pure name collision.
-
-## Repro
-
-`tmp/h2-bisect14.raku` (self-contained against the Cro checkout under
-`tmp/cro-work/`, run with the `inc-paths.txt` `-I` list). Notable
-sensitivity: the hijack only manifests when `use Cro::HTTP2::RequestParser;`
-is also present in the test file (with it: caller env sees the whenever
-frame's #821; without it: caller env sees the mainline value — the supply
-drive/thread structure differs). This use-sensitivity is a SECONDARY
-trigger — the merge-policy hole is the primary defect — but it explains
-why earlier synthetic repros (`tmp/h2-min1.raku`, `tmp/h2-min2.raku`,
-mirroring the supply/whenever/tap shape without the extra `use`) failed
-to reproduce. Do not attempt to re-shrink below the `use` set.
-
-Also reproduced in-file: mainline `my $host; $host = "MAIN-HOST"` is NOT
-hijacked even though the whenever body declares `my $host;` — an
-uninitialized `my` writes no env entry (slot only), so the caller chain has
-no "host" key and or_insert installs the capture. Only a
-declared-AND-initialized inner `my` (`my $encoder = HTTP::HPACK::Encoder.new`)
-lands in the worker's env and hijacks.
-
-## Why this is deep, not a ticket
-
-The sound fix direction (per CLAUDE.md gain/risk: prefer cell mechanisms
-that cannot go flaky over heuristic gates) is to extend eager cell boxing
-so that a closure capture of a creator-written scalar ALWAYS goes through a
-shared `ContainerRef` cell — cells both win the merge (overwrite branch)
-and keep post-capture creator mutations visible, satisfying the two
-requirements that currently conflict. That is effectively the next slice of
-ADR-0024 (mainline lexical cells), generalized from "mainline named subs'
-free variables" to "any closure capturing a mainline/creator-written
-scalar" — including plain anon/pointy closures passed across threads.
-Alternatives (widening `authoritative_free_vars` to "never written AFTER
-the closure's creation point", or making the merge overwrite for
-`cc.free_var_syms` members) each break a documented behavior
-(`my $s = 0; @cb.push({ $s }); $s = 42` must read 42; see the comment at
-the merge site). Needs an ADR-level decision on boxing scope + perf
-measurement (boxing cost was the reason lever C stayed narrow, #2749).
-
-## Second manifestation: http-session expiration (the OPPOSITE direction)
-
-`t/http-session-inmemory.rakutest` / `t/http-session-persistent.rakutest`
-"Session expires appropriately" (expected 'Visit 1', got 'Visit 4'): the
-test passes `now => { $fake-now }` into
-`Cro::HTTP::Session::InMemory[...]`, then advances the mainline
-`$fake-now += Duration.new(...)` between requests. The closure is stored in
-the middleware's `&.now` attribute and called on the server's worker
-threads; under mutsu it returns the CREATION-time value forever (verified
-by shadow-lib instrumentation of `SessionStore!delete-expired`: `&!now()`
-stayed at the initial Instant across all requests while head-exp never
-moved, so sessions never expire). This is the mirror image of the
-`$encoder` hijack: there the capture must win over an unrelated caller
-binding; here the creator's POST-capture mutations must stay visible to
-the (cross-thread) closure. A trivial Channel-based synthetic
-(`tmp/cross-thread-live-read.raku`) works — the name-keyed lane sync
-covers it — but the real path (closure stored in an attribute, invoked on
-a worker several spawn generations deep) loses the update. A shared-cell
-capture satisfies both directions at once, which is why the cell route is
-the fix direction rather than merge-order tweaks.
-
-Related same-family ticket (a THIRD direction — captured value wins over
-the closure's own inner for-loop parameter):
+Related (third direction, separate compiler bug, root cause now verified —
+see its ticket):
 `todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md`.
-Any fix here must be validated against its 11-line repro too.
-
-## Verification (once fixed)
-
-- `tmp/h2-bisect14.raku`: `in-check enc WHICH` must equal `mainline WHICH`.
-- `bash tmp/cro-suite-run.sh http`: `http2-request-serializer.rakutest`,
-  `http2-response-serializer.rakutest`, `http2-request-parser.rakutest`
-  all `notok=0`; `http-session-inmemory.rakutest` /
-  `http-session-persistent.rakutest` "Session expires appropriately" pass.
-- The merge-site comment's regression example must keep passing:
-  `my $s = 0; my @cb; for 1..3 { @cb.push({ $s }) }; $s = 42; say @cb[0]()`
-  → 42.
-- roast: S12-construction/roles-6e.t (the by-value-capture flake family),
-  S17-lowlevel/cas.t (cas resolves by name; cells broke it before —
-  see the `type_constrained_unboxable` skip in `box_captured_lexicals`).

--- a/todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md
+++ b/todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md
@@ -98,6 +98,20 @@ widen cell prevalence, so this repro must be re-run when its slices land
 — still wrong, and a ForLoop binding that wrote through such a cell would
 corrupt the outer counter).
 
+**Update 2026-08-11: the write-corruption direction fired in CI and is now
+guarded for MULTI-params.** ADR-0025 slice 1 boxed the captured vow in
+roast `integration/advent2013-day14.t`'s `config_combiner`, and
+`for %kvs.kv -> $k, $v`'s `Stmt::Assign`-based binding wrote iteration
+Strs through the vow's cell (`$v.keep` then hit a Str; file hung). Fixed
+in `exec_for_loop`'s multi-param prep (`vm_for_loop_body.rs`): a scalar
+multi-param name currently bound to a cell is severed for the loop's
+duration (save/restore already preserves the cell). Pin: test 7 of
+`t/closure-capture-instance-cell.t`. Still open here: the READ-side
+GetUpvalue bypass (the 11-line single-param repro still prints `i=2`),
+and single-param loops were not audited for an equivalent write-through
+(their bind is native env insert, believed rebind-safe — verify when
+fixing).
+
 ## Verification (once fixed)
 
 - The 11-line repro prints `i=1`.

--- a/todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md
+++ b/todo/tickets/closure-for-loop-param-hijacked-by-same-named-captured-outer.md
@@ -57,18 +57,46 @@ shadow-lib trace confirmed: `S2S fn-parts=[1]` at build, `GEN loop i=2` at
 call; `fn-parts=[1, 3]` at build, `i=3, i=3` at call — exactly the outer
 counter's final values.
 
+## Root cause — VERIFIED 2026-08-11 (gdb, ADR-0025 diagnosis session)
+
+The ticket's original "resolving by NAME through the merged captured env"
+guess was close but the mechanism is sharper: **the closure body's `$i`
+reads are `GetUpvalue` ops that bypass the frame env AND the loop binding
+entirely.** Chain:
+
+1. A for-loop parameter only gets a local slot if the name ALREADY has one
+   (`compiler/stmt.rs`, the `param_local = self.local_map.get(...)` lookup
+   — it never allocates). In the repro's closure, "i" has no prior slot, so
+   the param is an env-only binding and the name is absent from the
+   compiled body's `own` set.
+2. `compute_free_vars` therefore classifies the body's `$i` reads as FREE
+   variable reads, and the loop-binding writes happen inside the ForLoop
+   opcode exec (no name-write op), so "i" also looks read-only.
+3. `compute_upvalues` rewrites the pure reads to `GetUpvalue` — verified
+   with `rust-gdb -batch -ex 'break src/vm/vm_exec_dispatch.rs:204'` (the
+   GetUpvalue arm): it fires for each `i=` print in the repro. The read
+   resolves against the closure's captured env/upvalue array (the outer
+   `$i` counter cell), never seeing the ForLoop's per-iteration binding.
+
+Fix direction (compiler-side): a for-loop parameter must be an OWN binding
+of the compiled code that contains the loop — either allocate a local slot
+for slotless loop params (making body reads GetLocal and restoring
+`param_local` sync), or at minimum exclude loop-param names from
+`free_var_syms`/upvalue eligibility for the enclosing body (the
+`expr_declared_syms`/`my_declared_enum_sym` precedent in
+`compute_free_vars`). The slot route is the sound one — exclusion alone
+still leaves the body reading a name the merge may have installed.
+
 ## Relationship to other open findings
 
-Same family as `todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md`
-(closure-call captured-env merge vs. same-named bindings), but the opposite
-direction: there a captured value LOSES to the caller env; here a captured
-value WINS over the closure's own inner loop-parameter binding. A fix for
-either should be checked against the other's repro. Also adjacent to
-ADR-0023 (for-loop params as fresh per-iteration bindings) — the loop
-param's read inside the closure body is apparently resolving by NAME
-through the merged captured env (`cap_overrides` / `owned_captures` /
-per-instance state installed at closure entry) instead of through the loop
-binding.
+Same family symptom-wise as
+`todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md`
+(ADR-0025), but mechanically independent: that one is about the captured-env
+merge / cell boxing; this one is a compiler scoping bug. ADR-0025 slices
+widen cell prevalence, so this repro must be re-run when its slices land
+(a captured cell installed under "i" makes the GetUpvalue read a live cell
+— still wrong, and a ForLoop binding that wrote through such a cell would
+corrupt the outer counter).
 
 ## Verification (once fixed)
 

--- a/todo/tickets/http-session-tests-crash-rc139-on-main.md
+++ b/todo/tickets/http-session-tests-crash-rc139-on-main.md
@@ -1,0 +1,29 @@
+# http-session-inmemory/persistent crash with rc=139 (SIGSEGV) at test 2 on main
+
+Observed 2026-08-11 on main (`6985fdb14`, debug build) while verifying
+ADR-0025 slice 1 — reproduced with the spike REVERTED, so it is a
+pre-existing main regression, not part of the capture-cell campaign:
+
+```
+bash -c 'INC=$(cat tmp/cro-work/inc-paths.txt); \
+  CRO=tmp/cro-work/C_RO_CRO_HTTP_3a9832b52924f07d3c66fadcd2309ab8e0cffa41; \
+  timeout 180 target/debug/mutsu $INC $CRO/t/http-session-inmemory.rakutest'
+# -> rc=139, ok=2, no "not ok"
+```
+
+Both `http-session-inmemory.rakutest` and `http-session-persistent.rakutest`
+die the same way after 2 passing tests. On 2026-08-09 (release sweep,
+session 84 diagnosis data) these files ran to 10/13 and notok=4
+respectively — so something merged between 2026-08-09 and 2026-08-11
+turned a partial pass into a segfault. Candidates in that window include
+the ADR-0022 slice 1 (LTM), ADR-0024 (mainline lexical cells) + its two
+CI-regression fixes, and the #6132-#6217 range.
+
+Suggested attack: bisect main over that window against the inmemory file
+(debug build, the exact command above), then rust-gdb the segfault
+(`rust-gdb -batch -ex run -ex bt --args target/debug/mutsu $INC ...`).
+
+Blocks: the session-expiry acceptance criterion of
+`todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md`
+(ADR-0025) — the staleness fix itself is pinned by
+`t/closure-capture-instance-cell.t` tests 3-4 and does not depend on this.

--- a/todo/tickets/inline-closure-exec-sites-skip-upvalue-array-install.md
+++ b/todo/tickets/inline-closure-exec-sites-skip-upvalue-array-install.md
@@ -1,0 +1,59 @@
+# Inline closure-execution sites skip installing the closure's upvalue array — GetUpvalue reads the ENCLOSING closure's captures on index collision
+
+## The bug class (root-caused 2026-08-11, during ADR-0025 slice 1)
+
+`compute_upvalues` rewrites an anonymous closure body's pure read of a
+read-only scalar free variable to `GetUpvalue { index, name_idx }`. The
+index is into THE CLOSURE'S OWN `upvalue_syms`. The array itself is
+installed per-call by closure dispatch (`vm_closure_dispatch.rs:668`,
+`self.upvalues = data.upvalues.clone()`), and `capture_upvalues` freezes
+`Some(...)` ONLY for `ContainerRef` cells (non-cells stay `None` → env
+fallback by name).
+
+Any code path that executes a closure's CompiledCode **without going
+through closure dispatch** leaves `self.upvalues` pointing at whatever the
+enclosing frame installed. A `GetUpvalue` in the block body then indexes
+the WRONG closure's array: if the enclosing array happens to hold a
+`Some(cell)` at that index, the block reads an unrelated capture — silently.
+
+Observed concrete failure (fixed): `$l.protect({ $r += $i })` — the protect
+block's `GetUpvalue(0)` meant `$i`, but the inline protect executor left the
+enclosing Promise-closure's array installed, whose slot 0 was the boxed
+`$l` Lock cell → `$i` evaluated to the Lock, `$r += Lock` accumulated
+nothing (`t/lock-protect-shared-scalar.t` 1-2 went `r=0`). The failure was
+LATENT before ADR-0025 slice 1 because upvalue arrays held `Some` only for
+the rare boxed cells; Instance boxing made cells common enough to collide.
+
+## Fixed sites (2026-08-11, same branch as ADR-0025 slice 1)
+
+- `exec_protect_block_inline` (`vm_call_method_compiled.rs`) — swap in
+  `sub_data.upvalues` around the inline exec loop.
+- `call_protect_block` (`resolution_eval.rs`) — same swap around
+  `run_compiled_block`.
+
+## Sites still to audit (same pattern: exec a Sub's cc outside dispatch)
+
+- Eager `.map`/`.grep` loops: `resolution_map_grep.rs:460/530/723`,
+  `resolution_map_grep_rw.rs:269/534` — `vm.run_reuse(&code, ...)` inside
+  `with_nested_registers`, with `data` (the SubData) in scope; the fix is
+  the same `std::mem::replace(&mut vm.upvalues, data.upvalues.clone())`
+  swap for the loop duration.
+- `vm_arith_int_ops.rs:160` — another `run_reuse` of a block cc.
+- Any other `run_reuse`/`run_nested` caller executing a closure body
+  (grep for `run_reuse(` / `run_compiled_block` and check whether the cc
+  can contain `GetUpvalue`, i.e. is an anonymous-closure body rather than
+  a statement list compiled fresh).
+
+Repro sketch for the map case (unverified): an enclosing closure whose
+FIRST upvalue is a boxed cell, whose body runs an eager
+`@a.map({ $free-scalar })` where the map block's own first upvalue is a
+different name — the map block should read the enclosing cell instead.
+Verify with a pin before/after each site fix.
+
+## Longer-term shape
+
+The invariant should be: **`self.upvalues` always belongs to the cc whose
+ops are currently executing.** An RAII guard (swap-on-enter, restore-on-
+drop) around every "exec this cc inline" helper would make the property
+structural instead of per-site. Candidate for the ADR-0025 slice-2
+implementation session, since slice 2 (more cells) further widens exposure.


### PR DESCRIPTION
## Summary

**ADR-0025** (`docs/adr/0025-captured-scalar-cells-value-kind-blind.md`): cell boxing of captured scalars must be value-kind-blind. This PR lands slice 1 plus the latent VM bug it flushed out.

### Root cause (sharpened from the deep ticket)

The Cro::HTTP2 "check 4" hijack family and the http-session staleness mirror both come down to one gate: `box_captured_lexicals` / `box_decl_local_cell` skip boxing when the slot holds an **Instance**. The failing `$encoder` IS captured-and-mutated (vouch refusal correct) and its check closures ARE escaping-deemed — the value-kind skip was the single defense that failed. The skip's #2749 rationale is obsolete (instances mutate in place via Gc-shared attr cells; `commit_attrs` documents cell visibility), and "cell holding an Instance" is an already-exercised state.

### Changes

- **Slice 1 (2 lines)**: drop `Instance` from both value-kind skips. Package/Array/Hash/Sub/Proxy skips and the type-constraint (cas) skip unchanged.
- **Upvalue-aliasing fix**: the inline `Lock.protect` executors (`exec_protect_block_inline`, `call_protect_block`) ran protect-block bytecode without installing the block's own upvalue array, so `GetUpvalue` indexed the ENCLOSING closure's array — with `$l` newly boxed, `{ $r += $i }` read the Lock cell as `$i` and accumulated 0 (`t/lock-protect-shared-scalar.t`). Both sites now swap the correct array in. Remaining inline-exec sites: `todo/tickets/inline-closure-exec-sites-skip-upvalue-array-install.md`.
- **Pin**: `t/closure-capture-instance-cell.t` (6 tests, raku-validated) — hijack direction, staleness direction, cell-holds-Instance guard, merge-liveness example.
- Deep ticket rewritten/narrowed; loop-param ticket gains verified GetUpvalue root cause; new tickets for the pre-existing http-session rc=139 crash on main and the upvalue-install audit; news entry.

### Measured (debug, 2026-08-11)

| file | main | this PR |
|---|---|---|
| http2-request-serializer.rakutest | notok 3 | **0** |
| http2-response-serializer.rakutest | notok 3 | 1 |
| http2-request-parser.rakutest | notok 1 | 1 |

Residuals re-diagnosed as different shapes (`@headers`/HPACK trajectory; `$payload` body demux) — narrowed in the deep ticket. Full `make test` green locally (3012 files / 28236 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)