### PR TITLE
refactor(adr0019): E4b step 8 -- extract category-1 receiver-state guards into one function

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2513,6 +2513,26 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     `roast/S32-io/{tell,io-path,lock,open,io-handle,slurp,io-cathandle,spurt}.t`
     subset (8 files, 239 tests) all green. All four "likely reduces"/"mixed"
     category-1 groups from step 2's audit are now resolved.
+    **Progress 2026-08-11** (step 8, category 1): extracted every confirmed
+    category-1 check (steps 2/5/6/7's findings, plus the pre-existing `elems`/
+    exception-render/Real-Numeric-bridge/`Hash.keys` guards) into one
+    dedicated function, `native_fastpath_receiver_state_guard`
+    (`methods_native_bypass.rs`) — a pure reorganization, zero behavior
+    change, directly implementing design decision 3's "receiver-state facts
+    become resolver guards" bucket as the single list E4b's eventual
+    authoritative switch will consult, mirroring how categories 2
+    (`is_native_method`) and 3 (`resolve_user_method_or_accessor`) already
+    have their own dedicated functions well before their resolver-candidate
+    wiring landed. Categories 2/3 (`is_native_method`, `has_user_method`/
+    `has_public_accessor`/`has_class_level_attr`/`mixin_role_has_method`) are
+    deliberately NOT folded in — they stay separate per the three-way split.
+    The lazy-Match branch keeps its own small inline subset rather than
+    calling the new function, since it must avoid `target.view()` (would
+    materialize the lazy value) and only the `squish`/`elems`/exception-render
+    checks can ever apply to a Match receiver anyway. Verified empirically as
+    a genuine no-op: `cargo test --lib` (769 tests), the full local `prove -j4
+    t/` suite (3011 files / 28230 tests), and a full `make roast` run (1435
+    files / 218774 tests, `Result: PASS`, zero new failures) all green.
 - [ ] **E5 — Route ordinary VM method calls through the resolver.** Cover zero/n-arg and named-call
   opcodes while retaining mutation/writeback semantics at the caller boundary.
   **Design 2026-08-10** (`todo/deep/adr0019-e5-e7-entry-routing.md`): the cutover shape is

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -113,6 +113,96 @@ impl Interpreter {
         )
     }
 
+    /// ADR-0019 E4b design decision 3's "receiver-state facts become
+    /// resolver guards" bucket (category 1 of the three-way split in
+    /// `todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md`):
+    /// hazards where the native fast-path cascade itself would misbehave for
+    /// this receiver if reached, independent of whether a user method/
+    /// accessor/NativeCall binding also exists for the name (those are
+    /// categories 2/3 — `is_native_method`/`resolve_user_method_or_accessor`
+    /// — handled separately, not folded in here). The ADR's step-2 audit
+    /// (2026-08-11) confirmed these do NOT reduce to "the row table has no
+    /// entry for this (owner, method)": E4b's resolver falls back to the
+    /// pure arity cascade on any row miss, so row absence alone would not
+    /// stop the cascade from being (wrongly) tried — each of these stays an
+    /// explicit guard even after the eventual resolver cutover. Only used
+    /// from the main (non-lazy-Match) body of
+    /// [`Self::should_bypass_native_fastpath`]: the lazy-Match branch avoids
+    /// `target.view()` (it would materialize the lazy value) and instead
+    /// inlines the subset of these checks that can ever apply to a Match
+    /// receiver.
+    fn native_fastpath_receiver_state_guard(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> bool {
+        // `squish` always routes to the interpreter regardless of owner:
+        // `methods_0arg/collection.rs` implements it per-view, so a row miss
+        // must not fall through to a wrong native answer (ADR-0019 E4b step
+        // 2's "confirmed NOT reducible" finding).
+        method == "squish"
+            || (matches!(
+                method,
+                "max"
+                    | "min"
+                    | "head"
+                    | "flat"
+                    | "sort"
+                    | "comb"
+                    | "words"
+                    | "batch"
+                    | "rotor"
+                    | "rotate"
+                    | "produce"
+                    | "snip"
+                    | "minmax"
+                    | "start"
+                    | "wait"
+                    | "zip"
+                    | "zip-latest"
+                    | "list"
+                    | "Array"
+                    | "Seq"
+            ) && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Supply"))
+            || (method == "elems" && matches!(target.view(), ValueView::Instance { .. }))
+            // `.throw`/`.gist`/`.Str`/`.Stringy`/`.rethrow` render
+            // `$exc.message`; the native fast path can only read the stored
+            // `message` attribute, which is still undefined when the class
+            // computes its message lazily. See the twin gate in
+            // `vm_native_dispatch::try_native_method`.
+            || (matches!(method, "throw" | "rethrow" | "gist" | "Str" | "Stringy")
+                && matches!(target.view(), ValueView::Instance { class_name, .. }
+                    if self.exception_render_needs_interpreter(target, &class_name.resolve())))
+            || (matches!(target.view(), ValueView::Instance { .. })
+                && (target.does_check("Real") || target.does_check("Numeric")))
+            // Only `Proc::Async.Supply` needs an explicit gate: the coercion
+            // cascade's generic `"Supply"` arm (`methods_0arg/coercion.rs`)
+            // does not special-case `Proc::Async` the way it does
+            // `Supplier`, so a bare row-miss fallback would wrap the
+            // `Proc::Async` instance itself in a bogus values-Supply
+            // (ADR-0019 E4b step 6). `Supplier`/`Supplier::Preserving.Supply`
+            // needs no such gate — the coercion arm already returns `None`
+            // for both (step 5). `IO::Handle`'s `chomp`/`encoding`/`opened`/
+            // `DESTROY` need no gate either — `chomp`'s own cascade arm
+            // already self-guards and the other three have no cascade arm
+            // at all (step 7).
+            || (matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Proc::Async")
+                && method == "Supply")
+            // `Stash.keys`/`.values` need the interpreter's own package-stash
+            // enumeration; the generic `.keys`/`.values` cascade arms
+            // (`methods_0arg/collection.rs`) have a catch-all that would
+            // misread an Instance receiver as a one-element list instead of
+            // reading the Stash's own hash (step 7). `Stash.AT-KEY` needs no
+            // gate — it has no cascade arm at all.
+            || (matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash")
+                && matches!(method, "keys" | "values"))
+            || (method == "keys"
+                && args.is_empty()
+                && (matches!(target.view(), ValueView::Hash(_))
+                    || matches!(target.view(), ValueView::Mixin(inner, _) if matches!(inner.as_ref().view(), ValueView::Hash(_)))))
+    }
+
     /// Determine whether to bypass the native method fast path.
     pub(super) fn should_bypass_native_fastpath(
         &mut self,
@@ -122,7 +212,6 @@ impl Interpreter {
         skip_pseudo: bool,
         is_pseudo_method: bool,
     ) -> bool {
-        let _ = args;
         // Lazy-Match head branch: the chain below reads `target.view()`
         // repeatedly, which would materialize a lazy Match per method call.
         // Its class is statically "Match", so evaluate the Instance arms that
@@ -143,84 +232,10 @@ impl Interpreter {
                             && !self.has_public_accessor("Match", method))));
         }
         skip_pseudo
-            || method == "squish"
-            || (matches!(
-                method,
-                "max"
-                    | "min"
-                    | "head"
-                    | "flat"
-                    | "sort"
-                    | "comb"
-                    | "words"
-                    | "batch"
-                    | "rotor"
-                    | "rotate"
-                    | "produce"
-                    | "snip"
-                    | "minmax"
-                    | "start"
-                    | "wait"
-                    | "zip"
-                    | "zip-latest"
-            ) && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Supply"))
-            || (method == "elems" && matches!(target.view(), ValueView::Instance { .. }))
-            || (matches!(method, "list" | "Array" | "Seq")
-                && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Supply"))
-            // No explicit `Supplier`/`Supplier::Preserving` `.Supply` gate here:
-            // the coercion cascade arm itself already returns `None` for both
-            // classes (`methods_0arg/coercion.rs`'s `"Supply"` arm), so the
-            // native fast path naturally falls through to the runtime method
-            // without one — confirmed via ADR-0019 E4b's category-1 audit,
-            // `todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md`.
-            // `.throw`/`.gist`/`.Str` render `$exc.message`; the native fast path
-            // can only read the stored `message` attribute, which is still
-            // undefined when the class computes its message. See the twin gate in
-            // `vm_native_dispatch::try_native_method`.
-            || (matches!(method, "throw" | "rethrow" | "gist" | "Str" | "Stringy")
-                && matches!(target.view(), ValueView::Instance { class_name, .. }
-                    if self.exception_render_needs_interpreter(target, &class_name.resolve())))
+            || self.native_fastpath_receiver_state_guard(target, method, args)
             || matches!(target.view(), ValueView::Instance { class_name, .. }
                 if self.is_native_method(&class_name.resolve(), method))
-            // No explicit `IO::Handle` `chomp`/`encoding`/`opened`/`DESTROY` gate
-            // here: `chomp`'s own cascade arm (`dispatch_core_str.rs:216-221`)
-            // already returns `None` for `IO::Handle`, and `encoding`/`opened`/
-            // `DESTROY` have no arm anywhere in the native fast-path cascade
-            // (`native_method_{0,1,2}arg`) — confirmed by exhaustive grep,
-            // ADR-0019 E4b step 7 — so the whole group was redundant
-            // belt-and-suspenders, the same shape as the `Supplier.Supply` case
-            // step 5 removed.
-            || (matches!(target.view(), ValueView::Instance { .. })
-                && (target.does_check("Real") || target.does_check("Numeric")))
             || matches!(target.view(), ValueView::Instance { class_name, .. } if self.has_user_method(&class_name.resolve(), "Bridge"))
-            // Only `.Supply` needs an explicit gate: the coercion cascade's
-            // generic `"Supply"` arm (`methods_0arg/coercion.rs`) does not
-            // special-case `Proc::Async` the way it does `Supplier`, so a
-            // bare row-miss fallback would wrap the `Proc::Async` instance
-            // itself in a bogus values-Supply. The other sixteen names
-            // (`start`/`kill`/`write`/`close-stdin`/`bind-stdin`/
-            // `bind-stdout`/`bind-stderr`/`ready`/`print`/`put`/`say`/
-            // `command`/`started`/`w`/`pid`/`stdout`/`stderr`) have no arm
-            // anywhere in the native fast-path cascade
-            // (`native_method_{0,1,2}arg`) — confirmed by exhaustive grep,
-            // ADR-0019 E4b step 6 — so gating them here was redundant
-            // belt-and-suspenders identical to the `Supplier.Supply` case
-            // step 5 already removed.
-            || (matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Proc::Async")
-                && method == "Supply")
-            // No explicit `Stash` `AT-KEY` gate here: it has no arm anywhere in
-            // the native fast-path cascade, so a row-miss falls through to the
-            // runtime method identically — confirmed by exhaustive grep,
-            // ADR-0019 E4b step 7. `keys`/`values` stay gated: their cascade
-            // arms (`methods_0arg/collection.rs`) have a generic catch-all
-            // (`value_to_list(target)`) that would wrongly serve an Instance
-            // receiver, unlike `AT-KEY`.
-            || (matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash")
-                && matches!(method, "keys" | "values"))
-            || (method == "keys"
-                && args.is_empty()
-                && (matches!(target.view(), ValueView::Hash(_))
-                    || matches!(target.view(), ValueView::Mixin(inner, _) if matches!(inner.as_ref().view(), ValueView::Hash(_)))))
             || (!is_pseudo_method
                 && matches!(target.view(), ValueView::Instance { class_name, .. } if self.has_user_method(&class_name.resolve(), method)))
             || (!is_pseudo_method


### PR DESCRIPTION
## Summary
- ADR-0019 E4b (category-1 audit, step 8): pure reorganization of `should_bypass_native_fastpath` — zero behavior change.
- Extracts every confirmed category-1 check (steps 2/5/6/7's findings, plus the pre-existing `elems`/exception-render/Real-Numeric-bridge/`Hash.keys` guards) into one dedicated function, `native_fastpath_receiver_state_guard`.
- Directly implements design decision 3's "receiver-state facts become resolver guards" bucket (`todo/deep/adr0019-e2-e4-resolver-core.md`) as the single list E4b's eventual authoritative switch will consult — mirroring how categories 2 (`is_native_method`) and 3 (`resolve_user_method_or_accessor`) already have their own dedicated functions well before their resolver-candidate wiring landed.
- Categories 2/3 stay deliberately separate, not folded in.
- The lazy-Match branch keeps its own small inline subset (not calling the new function) since it must avoid `target.view()`, which would materialize the lazy value.
- Docs: records the finding in `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` under E4b step 8.

## Test plan
- [x] `cargo test --lib` (769 tests)
- [x] `prove -j4 -e target/debug/mutsu t/` (3011 files / 28230 tests)
- [x] full `make roast` (1435 files / 218774 tests, `Result: PASS`, zero new failures) — run locally since this touches the dispatch decision on every method call
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)