### PR TITLE
refactor(adr0019): E4b step 9 -- add design decision 4's Native row-catalog candidate

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2533,6 +2533,52 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     a genuine no-op: `cargo test --lib` (769 tests), the full local `prove -j4
     t/` suite (3011 files / 28230 tests), and a full `make roast` run (1435
     files / 218774 tests, `Result: PASS`, zero new failures) all green.
+    **Progress 2026-08-11** (step 9, design decision 4's `Native` candidate):
+    landed the row-catalog candidate kind the step-4 scoping note
+    (`todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md`)
+    flagged as needing a dedicated slice, in a smaller shape than that note
+    anticipated. `NativeCallShape { arity, definite }` (`resolution_sequence.rs`)
+    is the E4b-local subset of the design doc's future E3 `CallShape` the note
+    called for — just the two facts a row needs, not the full future cache-key
+    shape — threaded through `resolve_sequence`'s signature to both of its
+    production callers (`shadow_check_resolver`: arity from `arg_values.len()`,
+    definedness via a new `value_is_definite` helper; `shadow_check_bypass_user_method_categories`:
+    now takes `arg_count` from its caller). `ResolvedCandidate::Native { owner }`
+    is populated by a new production predicate, `native_row_servable`
+    (`native_method_row.rs`): a row is reachable for a call iff its arity mask
+    contains the call's arity, it is not `SPECIAL`/`MUTATES_RECEIVER` (both
+    bypass the pure cascade), and an indefinite receiver additionally needs
+    `TYPE_OBJECT_OK` — retried through `canonical_builtin_owner`'s fold
+    (`Buf`/`Blob`/...) the same way `record_native_row_coverage` already does.
+    This turned out to make the note's finding 3 (a new row-*existence*
+    predicate distinguishing "absent" from "genuinely SPECIAL") unnecessary:
+    both cases correctly answer "not servable" for `native_row_servable`'s
+    purpose, so no new absent-vs-classified distinction was needed after all
+    — only `TYPE_OBJECT_OK`/`MUTATES_RECEIVER`/`NativeRowFlags::contains` needed
+    un-gating from `#[cfg(test)]`, not the larger `NativeMethodRow` struct.
+    Shadow-verified with a genuinely new technique rather than the usual
+    t/-wide sweep: a new `shadow_check_native_row_candidate` compares the
+    `Native` candidate's presence against `native_result.is_some()` —
+    the real, already-computed arity-cascade result `call_method_with_values`
+    obtains right after (only called when `!bypass_native_fastpath`, i.e. the
+    cascade was actually consulted) — instead of re-invoking the cascade as a
+    probe, so there is no double-invocation side-effect risk even for a
+    mutating row. New `MUTSU_VM_STATS` counters `native_row_shadow_checks`/
+    `_mismatches` (`vm_stats.rs`). Verified: `cargo test --lib` (785 tests,
+    including new `native_row_servable` and `resolve_sequence` Native-row
+    unit tests), `cargo clippy -- -D warnings` clean, the full local `prove -j4
+    t/` suite (3011 files / 28230 tests, no `MUTSU_VM_STATS`) green, a targeted
+    `MUTSU_VM_STATS=1` spot-check (single files and `-e` snippets exercising
+    class methods, string/array native methods) showing
+    `native_row_shadow_checks>0 native_row_shadow_mismatches=0`, and a roast
+    smoke subset (`S02-types/`, `S12-methods/`, `S32-str/`, 151 files / 38791
+    tests via the proper `scripts/run-roast-test.sh` runner) with no failures
+    outside the pre-existing non-whitelisted `S02-types/quanthash.t`. Shadow
+    only: nothing reads `Native` to make a dispatch decision yet. What remains
+    before the authoritative switch: consuming `User`/`NativeCallBinding`/
+    `Native` together to make the actual bypass/dispatch decision at
+    `call_method_with_values`'s one call site, replacing
+    `should_bypass_native_fastpath` outright — not yet attempted.
 - [ ] **E5 — Route ordinary VM method calls through the resolver.** Cover zero/n-arg and named-call
   opcodes while retaining mutation/writeback semantics at the caller boundary.
   **Design 2026-08-10** (`todo/deep/adr0019-e5-e7-entry-routing.md`): the cutover shape is

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -74,24 +74,57 @@ pub(crate) struct NativeRowFlags(pub(crate) u8);
 
 impl NativeRowFlags {
     /// Callable on a type object (`Str:U`), not just a defined instance.
-    /// Only consumed by the E2a inverse probe today; E4 reads it once the
-    /// resolver admits type-object receivers to a candidate sequence.
-    #[cfg(test)]
+    /// E4b's [`native_row_servable`] is the first production reader (design
+    /// decision 4's `Native` candidate); before that it only backed the E2a
+    /// inverse probe.
     pub(crate) const TYPE_OBJECT_OK: NativeRowFlags = NativeRowFlags(1 << 0);
     /// Implemented by a Tier-A mutable-method helper (`vm_call_method_mut_ops.rs`)
     /// or a `&mut self` slow path, not the pure `native_method_*arg` layer.
-    /// Only consumed by the E2a inverse probe today; E6 is the real reader.
-    #[cfg(test)]
+    /// E4b's [`native_row_servable`] is the first production reader; E6 is
+    /// the eventual authoritative one.
     pub(crate) const MUTATES_RECEIVER: NativeRowFlags = NativeRowFlags(1 << 1);
     /// Handled by a named interceptor ahead of the arity cascades (or not
     /// natively recognized at all) -- never resolved by plain
     /// `native_method_*arg` name matching.
     pub(crate) const SPECIAL: NativeRowFlags = NativeRowFlags(1 << 2);
 
-    #[cfg(test)]
     pub(crate) const fn contains(self, bit: NativeRowFlags) -> bool {
         self.0 & bit.0 != 0
     }
+}
+
+/// ADR-0019 E4b design decision 4: is a `(owner, name)` row actually reachable
+/// by the pure `native_method_{0,1,2}arg` cascade for one specific call --
+/// not just "does some row exist", but "does it exist at the call's own
+/// arity, on a cascade path a `Native` resolver candidate may stand for".
+/// `SPECIAL` and `MUTATES_RECEIVER` rows never qualify (both bypass the pure
+/// arity cascade, matching how [`super::super::runtime::receiver_class`]'s
+/// `record_native_row_coverage` treats them as unmodeled/mutator paths, not
+/// as "the plain cascade would serve this"); an indefinite (type-object)
+/// receiver additionally needs `TYPE_OBJECT_OK`. `owner` is retried through
+/// [`super::builtin_type_methods::canonical_builtin_owner`]'s folding
+/// (`Buf`/`Blob`/... -> `Blob`, `Sub`/`Method`/... -> `Code`, etc.) the same
+/// way `record_native_row_coverage` does, since the row catalog is generated
+/// keyed by the folded owner and a plain lookup at the unfolded name would
+/// otherwise never find it.
+pub(crate) fn native_row_servable(
+    owner: &'static str,
+    name: &'static str,
+    call_arity: NativeArityMask,
+    definite: bool,
+) -> bool {
+    let reachable = |owner: &'static str| {
+        let (arity, flags) = native_method_row(owner, name);
+        arity.contains(call_arity)
+            && !flags.contains(NativeRowFlags::SPECIAL)
+            && !flags.contains(NativeRowFlags::MUTATES_RECEIVER)
+            && (definite || flags.contains(NativeRowFlags::TYPE_OBJECT_OK))
+    };
+    if reachable(owner) {
+        return true;
+    }
+    let folded = super::builtin_type_methods::canonical_builtin_owner(owner);
+    !folded.is_empty() && folded != owner && reachable(folded)
 }
 
 /// One canonical native (owner, method) recognition entry -- see the module
@@ -224,6 +257,102 @@ mod tests {
         for sample in [&str_sample, &int_sample] {
             assert!(native_method_arities(sample, "DEFINITE") & 1 != 0);
         }
+    }
+
+    /// `Str.chars` is `TYPE_OBJECT_OK` -- servable at arity 0 whether or not
+    /// the receiver is definite.
+    #[test]
+    fn native_row_servable_allows_type_object_ok_row_when_indefinite() {
+        assert!(native_row_servable(
+            "Str",
+            "chars",
+            NativeArityMask::A0,
+            true
+        ));
+        assert!(native_row_servable(
+            "Str",
+            "chars",
+            NativeArityMask::A0,
+            false
+        ));
+    }
+
+    /// `Str.ends-with` has no `TYPE_OBJECT_OK` flag -- servable at its arity
+    /// for a definite receiver, but not for an indefinite (type-object) one.
+    #[test]
+    fn native_row_servable_rejects_indefinite_receiver_without_type_object_ok() {
+        assert!(native_row_servable(
+            "Str",
+            "ends-with",
+            NativeArityMask::A1,
+            true
+        ));
+        assert!(!native_row_servable(
+            "Str",
+            "ends-with",
+            NativeArityMask::A1,
+            false
+        ));
+    }
+
+    /// `Str.match` is `SPECIAL` -- never reachable through the pure arity
+    /// cascade, at any arity.
+    #[test]
+    fn native_row_servable_rejects_special_row() {
+        for arity in [
+            NativeArityMask::A0,
+            NativeArityMask::A1,
+            NativeArityMask::A2,
+        ] {
+            assert!(!native_row_servable("Str", "match", arity, true));
+        }
+    }
+
+    /// A call at the wrong arity for the row's mask is not servable even
+    /// though the row itself is otherwise unremarkable.
+    #[test]
+    fn native_row_servable_rejects_mismatched_arity() {
+        assert!(!native_row_servable(
+            "Str",
+            "ends-with",
+            NativeArityMask::A0,
+            true
+        ));
+    }
+
+    /// An owner with no row at all (or a name the catalog does not
+    /// recognize) conservatively reports `(N, SPECIAL)` -- never servable.
+    #[test]
+    fn native_row_servable_rejects_unmodelled_pair() {
+        assert!(!native_row_servable(
+            "NoSuchOwner",
+            "no-such-method",
+            NativeArityMask::A0,
+            true
+        ));
+    }
+
+    /// The `Buf`/`Blob` family is catalogued under the folded owner `Blob`
+    /// (`canonical_builtin_owner`); a lookup at the unfolded owner name must
+    /// still find it, mirroring `record_native_row_coverage`'s own fold.
+    #[test]
+    fn native_row_servable_follows_the_canonical_owner_fold() {
+        assert_eq!(
+            crate::builtins::builtin_type_methods::canonical_builtin_owner("Buf"),
+            "Blob"
+        );
+        let (blob_arity, blob_flags) = native_method_row("Blob", "elems");
+        assert!(
+            blob_arity.contains(NativeArityMask::A0)
+                && !blob_flags.contains(NativeRowFlags::SPECIAL),
+            "test assumes Blob.elems is a plain A0 row; update the fixture if the table changes"
+        );
+        assert!(native_row_servable(
+            "Buf",
+            "elems",
+            NativeArityMask::A0,
+            true
+        ));
     }
 
     #[test]

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2788,7 +2788,12 @@ impl Interpreter {
             skip_pseudo,
             is_pseudo_method,
         );
-        self.shadow_check_bypass_user_method_categories(&target, method, is_pseudo_method);
+        self.shadow_check_bypass_user_method_categories(
+            &target,
+            method,
+            is_pseudo_method,
+            args.len(),
+        );
         let method_sym = crate::symbol::Symbol::intern(method);
         let native_result = if bypass_native_fastpath {
             None
@@ -2806,6 +2811,15 @@ impl Interpreter {
                 &target,
                 method_sym.as_str(),
                 args.len(),
+            );
+        }
+        if !bypass_native_fastpath {
+            self.shadow_check_native_row_candidate(
+                &target,
+                method,
+                method_sym,
+                args.len(),
+                native_result.is_some(),
             );
         }
         // `.Capture` on targets that must call user methods or drain a live source

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -273,6 +273,7 @@ impl Interpreter {
         target: &Value,
         method: &str,
         is_pseudo_method: bool,
+        arg_count: usize,
     ) {
         if !crate::vm::vm_stats::enabled() {
             return;
@@ -297,10 +298,12 @@ impl Interpreter {
         };
         let native_binding_owner = if is_instance {
             let chain = self.dispatch_mro(target);
-            let seq = self.resolve_sequence(&chain, Symbol::intern(method));
+            let native_shape =
+                super::resolution_sequence::NativeCallShape::new(arg_count, is_instance);
+            let seq = self.resolve_sequence(&chain, Symbol::intern(method), native_shape);
             seq.candidates.iter().find_map(|c| match c {
                 ResolvedCandidate::NativeCallBinding { owner } => Some(owner.as_str().to_string()),
-                ResolvedCandidate::User { .. } => None,
+                ResolvedCandidate::User { .. } | ResolvedCandidate::Native { .. } => None,
             })
         } else {
             None

--- a/src/runtime/resolution_sequence.rs
+++ b/src/runtime/resolution_sequence.rs
@@ -35,11 +35,37 @@
 //! so this exact rule becomes representable in the sequence itself).
 
 use super::*;
+use crate::builtins::native_method_row::{NativeArityMask, native_row_servable};
 use crate::type_id::TypeId;
 use std::sync::Arc;
 
-/// One candidate in a [`ResolvedSequence`]. E4a only ever constructs `User`; the
-/// accessor bit and native rows join in E4b (design decision 4).
+/// The E4b-local subset of call-shape facts design decision 4's `Native`
+/// candidate needs to decide whether a native row is actually reachable for
+/// one specific call: the call's own arity, and whether the receiver is a
+/// concrete value (`DEFINITE`) rather than a bare type object. This is
+/// deliberately smaller than the design doc's future E3 cache-key `CallShape`
+/// (`{ arity_bucket, has_named }`, `todo/deep/adr0019-e2-e4-resolver-core.md`)
+/// — see the step-4 scoping note in
+/// `todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md` for
+/// why the full shape is not needed here.
+#[derive(Clone, Copy)]
+pub(crate) struct NativeCallShape {
+    pub(crate) arity: NativeArityMask,
+    pub(crate) definite: bool,
+}
+
+impl NativeCallShape {
+    pub(crate) fn new(arg_count: usize, definite: bool) -> Self {
+        Self {
+            arity: NativeArityMask::for_arity(arg_count),
+            definite,
+        }
+    }
+}
+
+/// One candidate in a [`ResolvedSequence`]. E4a only ever constructed `User`;
+/// E4b adds the NativeCall-binding and native-row-catalog kinds (design
+/// decision 4).
 #[derive(Clone)]
 pub(crate) enum ResolvedCandidate {
     /// A user-declared method, at its MRO level, in the class's stored
@@ -50,12 +76,20 @@ pub(crate) enum ResolvedCandidate {
     /// implemented by dedicated `native_io_*` dispatch helpers
     /// (`Interpreter::hardcoded_native_method`). This is the E4b decomposition
     /// note's "category 2": a third candidate kind, distinct from both `User`
-    /// and design decision 4's `Native` row-catalog variant (not yet added) —
-    /// see `todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md`.
+    /// and `Native` below — see
+    /// `todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md`.
     /// At most one appears per sequence: `is_native_method` is a boolean "does
     /// any MRO level bind this name", not a per-level fact, so the sequence
     /// records only the first (most-derived) owner that has it.
     NativeCallBinding { owner: TypeId },
+    /// A `native_method_{0,1,2}arg` catalog row (E2's `native_method_row`
+    /// table) that is actually reachable for the call's shape — design
+    /// decision 4's `Native` variant. At most one appears per sequence: rows
+    /// are name-based (not per-level user overloads), so the first MRO level
+    /// (including its `canonical_builtin_owner` fold) with a servable row
+    /// wins, mirroring how the arity cascades themselves are name-dispatched
+    /// rather than per-level.
+    Native { owner: TypeId },
 }
 
 /// The shape-independent ordered candidate universe for one `(receiver chain,
@@ -70,6 +104,18 @@ pub(crate) struct ResolvedSequence {
     pub(crate) candidates: Vec<ResolvedCandidate>,
 }
 
+/// Whether `value` is a concrete instance rather than a bare type object —
+/// the same "DEFINITE" primitive `dispatch_core_coerce.rs`'s `.DEFINITE` arm
+/// implements, needed here to decide whether a `Native` candidate's row
+/// requires [`crate::builtins::native_method_row::NativeRowFlags::TYPE_OBJECT_OK`].
+fn value_is_definite(value: &Value) -> bool {
+    match value.view() {
+        ValueView::Nil | ValueView::Package(_) | ValueView::CustomType(..) => false,
+        ValueView::Slip(items) if items.is_empty() => false,
+        _ => true,
+    }
+}
+
 impl Interpreter {
     /// Build the ordered user-candidate sequence for `chain` (an E1 TypeId MRO,
     /// most-derived first) and `name`: every non-private, non-submethod-shadowed
@@ -77,10 +123,16 @@ impl Interpreter {
     /// membership rules `resolve_method_with_owner_impl` applies per candidate
     /// (`is_private` skip; `is_my` skip when the level is an ancestor) but not its
     /// early-stopping MRO-walk control flow — see the module doc.
-    pub(crate) fn resolve_sequence(&mut self, chain: &[TypeId], name: Symbol) -> ResolvedSequence {
+    pub(crate) fn resolve_sequence(
+        &mut self,
+        chain: &[TypeId],
+        name: Symbol,
+        native_shape: NativeCallShape,
+    ) -> ResolvedSequence {
         let generation = self.registry().method_generation;
         let mut candidates = Vec::new();
         let mut native_binding_found = false;
+        let mut native_row_found = false;
         for (level, owner) in chain.iter().enumerate() {
             let is_ancestor = level > 0;
             let owner_str = owner.as_str();
@@ -113,6 +165,21 @@ impl Interpreter {
                     candidates.push(ResolvedCandidate::NativeCallBinding { owner: *owner });
                     native_binding_found = true;
                 }
+            }
+            // Rows are name-based, not per-level user overloads: the arity
+            // cascades dispatch by name alone, so the first MRO level whose
+            // (possibly folded) owner has a servable row wins, same as
+            // `NativeCallBinding` above.
+            if !native_row_found
+                && native_row_servable(
+                    owner_str,
+                    name.as_str(),
+                    native_shape.arity,
+                    native_shape.definite,
+                )
+            {
+                candidates.push(ResolvedCandidate::Native { owner: *owner });
+                native_row_found = true;
             }
         }
         ResolvedSequence {
@@ -157,7 +224,8 @@ impl Interpreter {
         }
         let saved_ambiguous = self.dispatch_ambiguous;
         let chain = self.dispatch_mro(invocant);
-        let seq = self.resolve_sequence(&chain, method_sym);
+        let native_shape = NativeCallShape::new(arg_values.len(), value_is_definite(invocant));
+        let seq = self.resolve_sequence(&chain, method_sym, native_shape);
         let has_where_candidate = seq.candidates.iter().any(|c| {
             let ResolvedCandidate::User { def, .. } = c else {
                 return false;
@@ -200,6 +268,41 @@ impl Interpreter {
             )
         });
     }
+
+    /// ADR-0019 E4b step 4/9 shadow probe (`MUTSU_VM_STATS`-gated, a no-op
+    /// otherwise): does `resolve_sequence`'s new `Native` candidate agree
+    /// with whether the pure arity cascade actually served this call?
+    /// `real_served` must be a result the caller already computed by
+    /// actually invoking `native_method_{0,1,2}arg` (`call_method_with_values`
+    /// only calls this when `!bypass_native_fastpath`, i.e. the cascade was
+    /// genuinely consulted) — this function never invokes the cascade
+    /// itself, so it carries no double-invocation side-effect risk even for
+    /// a mutating row.
+    pub(crate) fn shadow_check_native_row_candidate(
+        &mut self,
+        target: &Value,
+        method: &str,
+        method_sym: Symbol,
+        arg_count: usize,
+        real_served: bool,
+    ) {
+        if !crate::vm::vm_stats::enabled() {
+            return;
+        }
+        let chain = self.dispatch_mro(target);
+        let native_shape = NativeCallShape::new(arg_count, value_is_definite(target));
+        let seq = self.resolve_sequence(&chain, method_sym, native_shape);
+        let native_row_owner = seq.candidates.iter().find_map(|c| match c {
+            ResolvedCandidate::Native { owner } => Some(owner.as_str()),
+            ResolvedCandidate::User { .. } | ResolvedCandidate::NativeCallBinding { .. } => None,
+        });
+        let shadow_served = native_row_owner.is_some();
+        crate::vm::vm_stats::record_native_row_shadow_check(real_served == shadow_served, || {
+            format!(
+                "method={method} arity={arg_count} real={real_served} shadow={shadow_served} native_row_owner={native_row_owner:?}"
+            )
+        });
+    }
 }
 
 #[cfg(test)]
@@ -216,15 +319,16 @@ mod tests {
         i.run("class Base { method greet { 'base' } }\nclass Child is Base { method greet { 'child' } }")
             .unwrap();
         let chain = vec![TypeId::intern("Child"), TypeId::intern("Base")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("greet"));
-        let owners: Vec<&str> = seq
-            .candidates
-            .iter()
-            .filter_map(|c| match c {
-                ResolvedCandidate::User { owner, .. } => Some(owner.as_str()),
-                ResolvedCandidate::NativeCallBinding { .. } => None,
-            })
-            .collect();
+        let seq = i.resolve_sequence(&chain, Symbol::intern("greet"), default_shape());
+        let owners: Vec<&str> =
+            seq.candidates
+                .iter()
+                .filter_map(|c| match c {
+                    ResolvedCandidate::User { owner, .. } => Some(owner.as_str()),
+                    ResolvedCandidate::NativeCallBinding { .. }
+                    | ResolvedCandidate::Native { .. } => None,
+                })
+                .collect();
         assert_eq!(owners, vec!["Child", "Base"]);
     }
 
@@ -234,7 +338,7 @@ mod tests {
         i.run("class Base { submethod only-base { } }\nclass Child is Base { }")
             .unwrap();
         let chain = vec![TypeId::intern("Child"), TypeId::intern("Base")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("only-base"));
+        let seq = i.resolve_sequence(&chain, Symbol::intern("only-base"), default_shape());
         assert!(
             seq.candidates.is_empty(),
             "a submethod on an ancestor level must not appear in a descendant's sequence"
@@ -247,7 +351,7 @@ mod tests {
         i.run("class Base { submethod only-base { } }\nclass Child is Base { }")
             .unwrap();
         let chain = vec![TypeId::intern("Base")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("only-base"));
+        let seq = i.resolve_sequence(&chain, Symbol::intern("only-base"), default_shape());
         assert_eq!(seq.candidates.len(), 1);
     }
 
@@ -256,7 +360,7 @@ mod tests {
         let mut i = interp();
         i.run("class Base { }").unwrap();
         let chain = vec![TypeId::intern("Base")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("nope"));
+        let seq = i.resolve_sequence(&chain, Symbol::intern("nope"), default_shape());
         assert!(seq.candidates.is_empty());
     }
 
@@ -269,13 +373,51 @@ mod tests {
         let mut i = interp();
         assert!(i.is_native_method("Supply", "tap"));
         let chain = vec![TypeId::intern("Supply")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("tap"));
+        let seq = i.resolve_sequence(&chain, Symbol::intern("tap"), default_shape());
         assert!(
             seq.candidates.iter().any(
                 |c| matches!(c, ResolvedCandidate::NativeCallBinding { owner }
                     if owner.as_str() == "Supply")
             ),
             "expected a NativeCallBinding candidate for Supply.tap"
+        );
+    }
+
+    /// ADR-0019 E4b step 4/9: design decision 4's `Native` variant -- a
+    /// catalog row that is actually reachable for the call's shape.
+    /// `Str.chars` is a plain `A0`/`TYPE_OBJECT_OK` row.
+    #[test]
+    fn resolve_sequence_finds_a_servable_native_row() {
+        let mut i = interp();
+        let chain = vec![TypeId::intern("Str")];
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("chars"),
+            NativeCallShape::new(0, true),
+        );
+        assert!(
+            seq.candidates.iter().any(
+                |c| matches!(c, ResolvedCandidate::Native { owner } if owner.as_str() == "Str")
+            ),
+            "expected a Native candidate for Str.chars at arity 0"
+        );
+    }
+
+    /// The same row is not offered at an arity the call doesn't have.
+    #[test]
+    fn resolve_sequence_omits_a_native_row_at_the_wrong_arity() {
+        let mut i = interp();
+        let chain = vec![TypeId::intern("Str")];
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("chars"),
+            NativeCallShape::new(1, true),
+        );
+        assert!(
+            !seq.candidates
+                .iter()
+                .any(|c| matches!(c, ResolvedCandidate::Native { .. })),
+            "Str.chars is an A0 row and must not surface for a 1-arg call"
         );
     }
 
@@ -287,10 +429,14 @@ mod tests {
         let mut i = interp();
         assert!(i.is_native_method("IO::Handle", "chomp"));
         let chain = vec![TypeId::intern("Base"), TypeId::intern("IO::Handle")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("chomp"));
+        let seq = i.resolve_sequence(&chain, Symbol::intern("chomp"), default_shape());
         assert!(
             seq.candidates.is_empty(),
             "hardcoded native-method names must not apply to an ancestor level"
         );
+    }
+
+    fn default_shape() -> NativeCallShape {
+        NativeCallShape::new(0, true)
     }
 }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -470,6 +470,40 @@ pub(crate) fn record_bypass_shadow_check(matched: bool, detail: impl FnOnce() ->
     }
 }
 
+// ADR-0019 Phase E box E4b (step 4/9, design decision 4's `Native` row-catalog
+// candidate): shadow comparison between `resolve_sequence`'s new `Native`
+// candidate presence and whether `native_method_{0,1,2}arg` actually served
+// the call -- a real, already-computed production result (`call_method_with_values`
+// only calls this when the cascade was actually consulted, i.e.
+// `!bypass_native_fastpath`), not a second invocation, so this carries no
+// double-invocation side-effect risk even for a mutating row.
+// `NATIVE_ROW_SHADOW_CHECKS`/`_MISMATCHES` are the totals; `native_row_shadow_mismatch_by_key`
+// breaks mismatches down by `"method=... arity=... real=... shadow=... native_row_owner=..."`.
+// Nothing reads these counters to make a dispatch decision: shadow-only, zero behavior change.
+static NATIVE_ROW_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static NATIVE_ROW_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn native_row_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one E4b step-4/9 shadow comparison. `detail` is only evaluated on a
+/// mismatch, mirroring [`record_bypass_shadow_check`].
+#[inline]
+pub(crate) fn record_native_row_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    NATIVE_ROW_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        NATIVE_ROW_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = native_row_shadow_mismatch_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -856,6 +890,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e4b bypass-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let native_row_shadow_checks = NATIVE_ROW_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let native_row_shadow_mismatches = NATIVE_ROW_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-e4b: native_row_shadow_checks={native_row_shadow_checks} native_row_shadow_mismatches={native_row_shadow_mismatches}"
+    );
+    if let Ok(map) = native_row_shadow_mismatch_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-e4b native-row-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );

--- a/todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md
+++ b/todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md
@@ -224,3 +224,25 @@ the four candidate kinds design decision 4 lists — plan a dedicated slice for
 it (signature change to `resolve_sequence` + its callers, a new
 production-safe row-existence predicate, then the usual shadow-verify sweep)
 rather than expecting it to be a small mechanical follow-on to step 3.
+
+**Update (step 9, 2026-08-11, landed):** the `Native` candidate is in
+(`ResolvedCandidate::Native { owner }`, `resolution_sequence.rs`), smaller
+than this note anticipated. `NativeCallShape { arity, definite }` is the
+E4b-local subset threaded through `resolve_sequence`'s signature (point 1
+above) rather than the full E3 `CallShape`. Point 3's "new row-existence
+predicate distinguishing absent from genuinely-SPECIAL" turned out
+unnecessary: `native_row_servable` (`native_method_row.rs`) only needs "is
+this call's arity servable, non-`SPECIAL`, non-`MUTATES_RECEIVER`, and
+`TYPE_OBJECT_OK` if indefinite" — both "no row" and "row classified special"
+correctly answer "not servable" for that question, so only
+`TYPE_OBJECT_OK`/`MUTATES_RECEIVER`/`NativeRowFlags::contains` needed
+un-gating from `#[cfg(test)]`, not a new predicate or the `NativeMethodRow`
+struct. Shadow-verified without a t/-wide sweep: a new
+`shadow_check_native_row_candidate` compares the candidate's presence
+against `native_result.is_some()` — the real cascade result
+`call_method_with_values` already computes, not a second invocation, so no
+double-invocation side-effect risk. See the ADR's step-9 progress note for
+the full verification record. Still open: actually consuming `User`/
+`NativeCallBinding`/`Native` together to replace `should_bypass_native_fastpath`
+at its one call site — that is the authoritative switch itself, not attempted
+here.


### PR DESCRIPTION
## Summary

Continues ADR-0019 Phase E box E4b. Design decision 4 listed four
`ResolvedCandidate` kinds; `User` (E4a) and `NativeCallBinding` (E4b step 3)
already landed. This lands the third, `Native` -- a `native_method_row`
catalog entry that is actually reachable for one specific call.

- `NativeCallShape { arity, definite }` (`resolution_sequence.rs`): the
  E4b-local subset of the design doc's future E3 `CallShape`, threaded
  through `resolve_sequence`'s signature and its two production callers.
- `native_row_servable(owner, name, call_arity, definite)`
  (`native_method_row.rs`): a new production predicate -- a row is
  reachable iff its arity mask contains the call's arity, it is not
  `SPECIAL`/`MUTATES_RECEIVER`, and an indefinite receiver additionally
  needs `TYPE_OBJECT_OK`. Retried through `canonical_builtin_owner`'s fold
  (`Buf`/`Blob`/...) the same way `record_native_row_coverage` does.
  Required un-gating `TYPE_OBJECT_OK`/`MUTATES_RECEIVER`/
  `NativeRowFlags::contains` from `#[cfg(test)]` -- their first production
  reader.
- `ResolvedCandidate::Native { owner }`: populated in `resolve_sequence`,
  first MRO level (including its folded synonym) with a servable row wins.
- Shadow-verified via a new technique rather than a t/-wide sweep: the new
  `shadow_check_native_row_candidate` compares the candidate's presence
  against `native_result.is_some()` -- the real, already-computed cascade
  result `call_method_with_values` obtains right after (only called when
  `!bypass_native_fastpath`) -- not a second invocation, so no
  double-invocation side-effect risk even for a mutating row. New
  `MUTSU_VM_STATS` counters `native_row_shadow_checks`/`_mismatches`.

See the scoping note
(`todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md`) and
the ADR's step-9 progress note for the full analysis, including why the
originally-anticipated new row-existence predicate (distinguishing "absent"
from "genuinely SPECIAL") turned out unnecessary.

Shadow-only: nothing reads `Native` to make a real dispatch decision yet.
The authoritative switch (consuming `User`/`NativeCallBinding`/`Native`
together to replace `should_bypass_native_fastpath`) is still open.

## Test plan

- [x] `cargo test --lib` (785 tests, including new `native_row_servable` and
  `resolve_sequence` Native-row unit tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Full local `prove -j4 -e target/debug/mutsu t/` (3011 files / 28230
  tests) green, no `MUTSU_VM_STATS`
- [x] Targeted `MUTSU_VM_STATS=1` spot-checks (single files, `-e` snippets
  exercising class methods and Str/Array native methods):
  `native_row_shadow_checks>0 native_row_shadow_mismatches=0`
- [x] Roast smoke subset (`S02-types/`, `S12-methods/`, `S32-str/`, 151
  files / 38791 tests via `scripts/run-roast-test.sh`), no failures outside
  the pre-existing non-whitelisted `S02-types/quanthash.t`
- [ ] CI: `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)