### PR TITLE
docs(adr0019): E4b step 10 -- NativeCallBinding does not generalize to Package receivers

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2579,6 +2579,62 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     `Native` together to make the actual bypass/dispatch decision at
     `call_method_with_values`'s one call site, replacing
     `should_bypass_native_fastpath` outright — not yet attempted.
+    **Progress 2026-08-11** (step 10, scoping finding, docs + shadow-widening
+    only): before attempting the authoritative switch, checked whether
+    `resolve_sequence`'s presence-only `NativeCallBinding` walk — which does
+    not distinguish receiver kind — safely generalizes to a `Package`
+    (type-object) receiver, since `should_bypass_native_fastpath`'s real
+    category-2 term (`is_native_method`) is deliberately checked *only* for
+    `is_instance` (`methods_native_bypass.rs` line ~287; the `!is_instance`
+    branch never calls it). `shadow_check_bypass_user_method_categories`
+    already built `native_binding_owner` behind an `if is_instance` guard
+    (step 3) — widening it to run unconditionally (still shadow-only,
+    `record_bypass_shadow_check` unchanged) let the existing
+    `bypass_shadow_checks`/`_mismatches` counters answer the question with
+    real data instead of a guess. **Answer: no, it does not generalize** — a
+    fixed per-process-file `MUTSU_VM_STATS` sweep (3011 `t/` files, `-P 8`,
+    same torn-output fix step 3 used) went from the already-landed baseline
+    34/20634 mismatches to **177/20634**, a real +143 increase, all
+    `real=false shadow=true` (the widened check now sees a `NativeCallBinding`
+    candidate for a call the real decision says is NOT bypassed). Root cause,
+    confirmed by reading both sides: `ClassDef::native_methods` for
+    `"Supply"` (`runtime_init.rs`) conflates two unrelated vocabularies under
+    one flag — genuine instance methods (`emit`/`tap`/`act`/...) AND
+    class-level factory-method names (`interval`/`delayed`/`merge`/`Channel`/
+    `Promise`/`collate`/`categorize`/..., called on the bare `Supply` type
+    object, e.g. `Supply.interval(1)`) — and `is_native_method` cannot tell
+    them apart from the flag alone. The factory names are answered by a
+    completely different mechanism, a hardcoded class-method special case in
+    `methods_instance_ops.rs` (`Supply.interval`/`Compiler.id`, alongside the
+    pre-existing `Instant.from_posix`) that never reaches
+    `call_method_with_values`/`should_bypass_native_fastpath` for these names
+    at all — so `is_native_method`'s true answer is simply irrelevant to the
+    real decision at a `Package` receiver, and category 2's `is_instance`
+    restriction was already the correct, deliberate fix for exactly this
+    conflation, not an oversight. 88% of the +143 (126) is `Supply.interval`
+    alone (one hot loop in the sweep corpus calling it repeatedly); the tail
+    is `Thread.is-initial-thread` (2, hardcoded-table, not registry, same
+    receiver-kind issue), `Supply.{schedule-on,Promise,collate,categorize}`
+    (4, same conflated-registry cause), `Encoding::Registry.find` (9), and
+    `Compiler.id` (2, the same special-cased-elsewhere shape as
+    `Supply.interval`). **Consequence for the authoritative switch:** a
+    `NativeCallBinding` candidate must stay gated by `is_instance` /
+    `NativeCallShape::definite` wherever it drives a real decision — mirroring
+    how `Native` (step 9) already gates on `definite`/`TYPE_OBJECT_OK` for the
+    exact same reason (a name meaning different things at different
+    definedness). `resolve_sequence` itself was NOT changed (still
+    unconditionally emits `NativeCallBinding` regardless of definedness,
+    since it is a shape-independent candidate universe by design — decision 4
+    says nothing should be filtered out at build time); the gating belongs at
+    the *consumer*, same as `Native`'s own filtering already lives in
+    `native_row_servable` rather than in candidate construction. Left as a
+    documented, empirically-grounded ledger entry (matching E1a's
+    accepted-mismatch precedent) rather than a code change beyond the
+    shadow-check widening itself, which stays landed since it is a strictly
+    more informative probe than the `is_instance`-gated version it replaces.
+    Verified: `cargo build`, `cargo test --lib`, `cargo clippy -- -D
+    warnings`, `cargo fmt --check` all clean; the widening is shadow-only
+    (`MUTSU_VM_STATS`-gated), zero real-dispatch behavior change.
 - [ ] **E5 — Route ordinary VM method calls through the resolver.** Cover zero/n-arg and named-call
   opcodes while retaining mutation/writeback semantics at the caller boundary.
   **Design 2026-08-10** (`todo/deep/adr0019-e5-e7-entry-routing.md`): the cutover shape is

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -296,18 +296,24 @@ impl Interpreter {
                     || (self.has_class_level_attr(&class_name, method)
                         && !self.has_public_accessor(&class_name, method)))
         };
-        let native_binding_owner = if is_instance {
-            let chain = self.dispatch_mro(target);
-            let native_shape =
-                super::resolution_sequence::NativeCallShape::new(arg_count, is_instance);
-            let seq = self.resolve_sequence(&chain, Symbol::intern(method), native_shape);
-            seq.candidates.iter().find_map(|c| match c {
-                ResolvedCandidate::NativeCallBinding { owner } => Some(owner.as_str().to_string()),
-                ResolvedCandidate::User { .. } | ResolvedCandidate::Native { .. } => None,
-            })
-        } else {
-            None
-        };
+        // ADR-0019 E4b step 10 scoping: built for BOTH receiver kinds, not just
+        // Instance. `is_native_method` (`real`'s category-2 term above) is
+        // deliberately never checked for a Package receiver -- calling an `is
+        // native(&sym)` binding through the bare type object rather than an
+        // instance is not a case the real bypass logic accounts for. Widening
+        // this shadow-only check to Package too (rather than short-circuiting
+        // to `None`) answers, empirically, whether `resolve_sequence`'s
+        // presence-only `NativeCallBinding` walk (which does not distinguish
+        // receiver kind) ever actually disagrees with that omission --
+        // load-bearing before the eventual authoritative switch can safely
+        // consume `resolve_sequence` uniformly for both receiver kinds.
+        let chain = self.dispatch_mro(target);
+        let native_shape = super::resolution_sequence::NativeCallShape::new(arg_count, is_instance);
+        let seq = self.resolve_sequence(&chain, Symbol::intern(method), native_shape);
+        let native_binding_owner = seq.candidates.iter().find_map(|c| match c {
+            ResolvedCandidate::NativeCallBinding { owner } => Some(owner.as_str().to_string()),
+            ResolvedCandidate::User { .. } | ResolvedCandidate::Native { .. } => None,
+        });
         let shadow = native_binding_owner.is_some()
             || self
                 .resolve_user_method_or_accessor(&class_name, method)

--- a/todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md
+++ b/todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md
@@ -246,3 +246,19 @@ the full verification record. Still open: actually consuming `User`/
 `NativeCallBinding`/`Native` together to replace `should_bypass_native_fastpath`
 at its one call site — that is the authoritative switch itself, not attempted
 here.
+
+**Update (step 10, 2026-08-11, scoping finding — read before attempting the
+authoritative switch):** `NativeCallBinding` does NOT generalize across
+receiver kind the way `Native` already does. A widened shadow sweep (see the
+ADR's step-10 note) found `resolve_sequence`'s presence-only
+`NativeCallBinding` walk disagreeing with the real bypass decision 143 times
+out of 20634 checks, always for a `Package` (type-object) receiver:
+`ClassDef::native_methods` conflates instance-method names with class-level
+factory-method names under one flag (`Supply.interval`/`Compiler.id`, answered
+by a hardcoded special case in `methods_instance_ops.rs`, never reaching
+`should_bypass_native_fastpath` at all), so `is_native_method`'s true answer
+is irrelevant at a `Package` receiver — which is exactly why the real
+category-2 term only ever checks it for `is_instance`. Whoever writes the
+authoritative switch must gate `NativeCallBinding` (like `Native` already
+gates on `definite`/`TYPE_OBJECT_OK`) by `is_instance`/`NativeCallShape::definite`
+at the point it drives a real decision, not trust bare candidate presence.


### PR DESCRIPTION
## Summary

Scoping investigation ahead of E4b's authoritative switch (which will
consume `resolve_sequence`'s candidates to replace
`should_bypass_native_fastpath`). Checked whether `NativeCallBinding`
(step 3) generalizes across receiver kind the same way `Native` (step 9)
does.

- Widened the existing `shadow_check_bypass_user_method_categories` probe
  (previously `is_instance`-gated) to build the `NativeCallBinding`
  sequence for `Package` (type-object) receivers too -- purely to get
  empirical data via the existing `bypass_shadow_checks`/`_mismatches`
  counters, not a production behavior change.
- **Answer: it does not generalize.** A fixed per-process-file
  `MUTSU_VM_STATS` sweep (3011 `t/` files) went from 34/20634 mismatches
  to 177/20634 -- a real +143, all `real=false shadow=true`.
- Root cause: `ClassDef::native_methods` for `"Supply"`
  (`runtime_init.rs`) conflates genuine instance methods
  (`emit`/`tap`/`act`/...) with class-level factory-method names
  (`interval`/`delayed`/`merge`/`Promise`/...) under one flag. The factory
  names are answered by a hardcoded class-method special case in
  `methods_instance_ops.rs` (`Supply.interval`, `Compiler.id`) that never
  reaches `should_bypass_native_fastpath` at all -- so `is_native_method`'s
  answer is simply irrelevant at a `Package` receiver, which is exactly why
  the real category-2 term only ever checks it for `is_instance`.
- Recorded as a scoping finding (ADR + `todo/deep/` note) for whoever
  writes the authoritative switch: `NativeCallBinding` must stay gated by
  `is_instance`/`NativeCallShape::definite` wherever it drives a real
  decision, mirroring how `Native` already gates on
  `definite`/`TYPE_OBJECT_OK` for the same underlying reason (a name
  meaning different things at different definedness).

`resolve_sequence` itself is unchanged -- it still unconditionally emits
`NativeCallBinding` regardless of definedness, since it's a
shape-independent candidate universe by design; the gating belongs at the
future consumer. The shadow-check widening stays landed since it's a
strictly more informative probe than the `is_instance`-gated version it
replaces.

Docs + shadow-check-widening only: zero real-dispatch behavior change.

## Test plan

- [x] `cargo build`, `cargo test --lib` (777 tests), `cargo clippy -- -D
  warnings`, `cargo fmt --check` all clean
- [x] Full local `prove -j4 -e target/debug/mutsu t/` (3012 files / 28237
  tests) green, no `MUTSU_VM_STATS`
- [x] The widened shadow probe itself run across the full `t/` corpus with
  `MUTSU_VM_STATS=1` (per-process-file sweep) to obtain the mismatch counts
  cited above
- [ ] CI: `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)