### PR TITLE
refactor(adr0019): E4b step 12 -- collapse Instance category 2/3 checks

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2701,6 +2701,53 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
     No dispatch code changed; two new tests pin both gaps.
     Verified: `cargo build`, `cargo test --lib` (779 tests), `cargo clippy
     -- -D warnings`, `cargo fmt --check` all clean.
+    **Progress 2026-08-11** (step 12, category 3 landed live): implemented
+    the Instance-branch half of step 11's "eventual switch" shape —
+    `should_bypass_native_fastpath`'s two separate
+    `has_user_method(class_name, method) || has_public_accessor(class_name,
+    method)` calls collapse into one `resolve_user_method_or_accessor(class_name,
+    method).is_some()` call, exactly the substitution step 1 already
+    shadow-verified safe (2/36992 unrelated mismatches). The function was
+    restructured around a `match target.view()` with one arm per receiver
+    kind rather than the original flat OR-chain of `matches!` guards, so the
+    Instance and Package branches are now visibly separate blocks instead of
+    interleaved arms — making step 11's finding ("Package needs its own
+    narrower check, not a derivation of the Instance branch's helper")
+    structural rather than a comment to remember. `is_native_method`
+    (category 2) deliberately stays a direct call rather than routing
+    through `resolve_sequence`'s `NativeCallBinding` candidate: both compute
+    the identical MRO walk (`resolve_sequence`'s own detection mirrors
+    `is_native_method`, per its doc comment), so building a full sequence
+    here would add cost — one MRO walk plus wasted `User`/`Native` candidate
+    construction — for zero correctness gain over the existing single-fact
+    call; `NativeCallBinding` earns its keep at a future multi-candidate
+    consumer (E5-E7), not this one-boolean check. The class-level-attr arm
+    (category 4) and the Package branch's bare `has_user_method` stay
+    explicit, unchanged, per step 11. Verified: `cargo build`, `cargo test
+    --lib` (779 tests, including the three category-1-decomposition/step-11
+    pinning tests), `cargo clippy -- -D warnings`, `cargo fmt --check`, the
+    full local `prove -j4 t/` suite (3012 files / 28237 tests) all green;
+    a release-build roast smoke subset (`S12-attributes/`, `S17-supply/`,
+    `S17-procasync/`, `S32-io/`, 127 files / 3395 tests) has exactly one
+    failure, `S12-attributes/trusts.t`, confirmed pre-existing and unrelated
+    (reproduces identically against the unmodified `main` binary — a
+    `B trusts A` unresolved-attribute-visibility bug, not in
+    `roast-whitelist.txt`, out of scope here). **What remains before E4b can
+    be marked done:** this is one slice of the switch, not the whole box —
+    the Instance branch's `NativeCallBinding`-from-`resolve_sequence`
+    question above is now closed (deliberately not adopted, with a reason),
+    but nothing yet reads `resolve_sequence`'s `Native` candidate (design
+    decision 4's row-catalog kind, landed shadow-only in step 9) to replace
+    the native-cascade dispatch decision itself — `should_bypass_native_fastpath`
+    still gates a separate `native_method_{0,1,2}arg` call at its one call
+    site rather than the resolver deciding which candidate wins outright.
+    Whether that final consumption is worth doing given `Native`'s
+    candidate-vs-direct-cascade-call tradeoff mirrors the same "no gain over
+    a direct call" question step 12 answered for `NativeCallBinding` — the
+    next session should check that before assuming there is more E4b
+    plumbing work left to do, rather than treating the ADR bullet's original
+    "should_bypass_native_fastpath deleted" phrasing as still literally the
+    target shape.
 - [ ] **E5 — Route ordinary VM method calls through the resolver.** Cover zero/n-arg and named-call
   opcodes while retaining mutation/writeback semantics at the caller boundary.
   **Design 2026-08-10** (`todo/deep/adr0019-e5-e7-entry-routing.md`): the cutover shape is

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -231,22 +231,49 @@ impl Interpreter {
                         || (self.has_class_level_attr("Match", method)
                             && !self.has_public_accessor("Match", method))));
         }
-        skip_pseudo
-            || self.native_fastpath_receiver_state_guard(target, method, args)
-            || matches!(target.view(), ValueView::Instance { class_name, .. }
-                if self.is_native_method(&class_name.resolve(), method))
-            || matches!(target.view(), ValueView::Instance { class_name, .. } if self.has_user_method(&class_name.resolve(), "Bridge"))
-            || (!is_pseudo_method
-                && matches!(target.view(), ValueView::Instance { class_name, .. } if self.has_user_method(&class_name.resolve(), method)))
-            || (!is_pseudo_method
-                && matches!(target.view(), ValueView::Instance { class_name, .. } if self.has_public_accessor(&class_name.resolve(), method)))
-            || (!is_pseudo_method
-                && matches!(target.view(), ValueView::Package(class_name) if self.has_user_method(&class_name.resolve(), method)))
-            || (!is_pseudo_method
-                && matches!(target.view(), ValueView::Package(class_name) if self.has_class_level_attr(&class_name.resolve(), method) && !self.has_public_accessor(&class_name.resolve(), method)))
-            || (!is_pseudo_method
-                && matches!(target.view(), ValueView::Instance { class_name, .. } if self.has_class_level_attr(&class_name.resolve(), method) && !self.has_public_accessor(&class_name.resolve(), method)))
-            || (!is_pseudo_method && self.mixin_role_has_method(target, method))
+        if skip_pseudo || self.native_fastpath_receiver_state_guard(target, method, args) {
+            return true;
+        }
+        // ADR-0019 E4b step 12 (authoritative switch, category 3): the
+        // Instance branch's `has_user_method(..) || has_public_accessor(..)`
+        // pair collapses into one `resolve_user_method_or_accessor` call --
+        // shadow-verified equivalent in step 1 (`t/`-wide sweep, only 2/36992
+        // unrelated mismatches). The Package branch stays its own narrower
+        // `has_user_method` check with no accessor lookup (step 11: folding
+        // in `resolve_user_method_or_accessor` there would be a real behavior
+        // change, since an instance attribute's accessor is meaningless on
+        // the bare type object). `is_native_method` (category 2) stays a
+        // direct call rather than routing through `resolve_sequence`'s
+        // `NativeCallBinding` candidate: both compute the exact same MRO walk
+        // (`resolve_sequence`'s detection deliberately mirrors
+        // `is_native_method`), so building a full sequence here would only
+        // add cost, not correctness -- `NativeCallBinding` earns its keep at
+        // future multi-candidate consumers (E5-E7), not this single-fact
+        // check. The class-level-attr arm (category 4, `has_class_level_attr
+        // && !has_public_accessor`) is invisible to every resolver helper
+        // (step 11) and stays an explicit check on both branches.
+        let receiver_bypass = match target.view() {
+            ValueView::Instance { class_name, .. } => {
+                let class_name = class_name.resolve();
+                self.is_native_method(&class_name, method)
+                    || self.has_user_method(&class_name, "Bridge")
+                    || (!is_pseudo_method
+                        && (self
+                            .resolve_user_method_or_accessor(&class_name, method)
+                            .is_some()
+                            || (self.has_class_level_attr(&class_name, method)
+                                && !self.has_public_accessor(&class_name, method))))
+            }
+            ValueView::Package(class_name) => {
+                let class_name = class_name.resolve();
+                !is_pseudo_method
+                    && (self.has_user_method(&class_name, method)
+                        || (self.has_class_level_attr(&class_name, method)
+                            && !self.has_public_accessor(&class_name, method)))
+            }
+            _ => false,
+        };
+        receiver_bypass || (!is_pseudo_method && self.mixin_role_has_method(target, method))
     }
 
     /// ADR-0019 E4b shadow probe (`MUTSU_VM_STATS`-gated, a no-op otherwise):

--- a/todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md
+++ b/todo/deep/adr0019-e4b-should-bypass-native-fastpath-decomposition.md
@@ -262,3 +262,21 @@ category-2 term only ever checks it for `is_instance`. Whoever writes the
 authoritative switch must gate `NativeCallBinding` (like `Native` already
 gates on `definite`/`TYPE_OBJECT_OK`) by `is_instance`/`NativeCallShape::definite`
 at the point it drives a real decision, not trust bare candidate presence.
+
+**Update (step 12, 2026-08-11, landed):** the Instance branch's category-3
+cutover from step 1's finding is live: `has_user_method(..) ||
+has_public_accessor(..)` collapsed into one `resolve_user_method_or_accessor(..).is_some()`
+call, with the function restructured into a `match target.view()` (one arm
+per receiver kind) instead of the old flat OR-chain. Also decided,
+explicitly, NOT to route category 2 (`is_native_method`) through
+`resolve_sequence`'s `NativeCallBinding` candidate at this call site: both
+compute the exact same MRO walk, so swapping in the resolver here would only
+add the cost of building a full sequence (plus unused `User`/`Native`
+candidates) for zero correctness gain — `NativeCallBinding` is for a future
+multi-candidate consumer, not a drop-in replacement for a single boolean
+fact already answered by a direct, cheaper call. See the ADR's step-12
+progress note for the full verification record (`cargo test --lib`, `prove
+t/`, a roast smoke subset). Still open: whether `Native` (the row-catalog
+candidate) is ever worth consuming to replace the `native_method_{0,1,2}arg`
+dispatch decision itself, given the same tradeoff likely applies there too —
+check that before assuming there is more plumbing work before E4b is done.


### PR DESCRIPTION
## Summary
- ADR-0019 Phase E box E4b ("authoritative switch at the cached-resolve boundaries"): lands the Instance-branch half of step 11's target shape for `should_bypass_native_fastpath`.
- Collapses the separate `has_user_method(..) || has_public_accessor(..)` calls into one `resolve_user_method_or_accessor(..).is_some()` call for the Instance receiver kind -- the exact substitution step 1's `t/`-wide shadow sweep already verified safe (2/36992 unrelated mismatches).
- Restructures the function into a `match target.view()` (one arm per receiver kind) instead of the previous flat OR-chain of `matches!` guards, making step 11's finding ("Package needs its own narrower check, not a derivation of the Instance-branch helper") structural.
- Records a deliberate non-adoption: `is_native_method` (category 2) stays a direct call rather than routing through `resolve_sequence`'s `NativeCallBinding` candidate, since both compute the identical MRO walk -- building a full sequence here would only add cost for zero correctness gain.
- Docs-only companion updates: ADR step-12 progress note, and the E4b scoping doc's step-12 update pointer.

## Test plan
- [x] `cargo build`
- [x] `cargo test --lib` (779 tests)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `prove -j4 t/` (3012 files / 28237 tests, all green)
- [x] Release-build roast smoke subset: `S12-attributes/`, `S17-supply/`, `S17-procasync/`, `S32-io/` (127 files / 3395 tests) -- sole failure `S12-attributes/trusts.t` confirmed pre-existing against an unmodified `main` binary, unrelated, not in `roast-whitelist.txt`
- [ ] CI `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)