### PR TITLE
docs(batteries): tighten CSV slot criteria to no-native-dep + read/write

### DIFF
--- a/docs/batteries/csv.md
+++ b/docs/batteries/csv.md
@@ -23,6 +23,15 @@ followed later by a `qq:to/…/` heredoc referencing `$x`, inside the same
 `sub`" — nothing CSV-specific about it. Fixing that one compiler bug is
 likely the highest-leverage next step for this slot, not picking a winner.
 
+**Selection criteria for this slot (user decision, 2026-08-11):** no
+external native/C-library dependency (rules out `Text::CSV::LibCSV`'s
+`libcsv` wrapper and `Duck::CSV`'s DuckDB binding outright — see "Ruled out"
+below, which independently arrived at the same two rejections on license/
+scope grounds before this criterion was stated), and the candidate must
+support **both reading and generating** CSV data, not reading alone. This
+last point demotes `CSV::Parser` from "pragmatic stopgap" to **disqualified**
+— see its section below, updated accordingly.
+
 ## The field
 
 Enumerated from `~/.zef/store/{rea,fez}/*.json` (the same indices `mzef`
@@ -32,15 +41,15 @@ general-purpose tools (a grep-alike, a data-reshaping toolkit) that merely
 support CSV as one input format among several — excluded as not CSV-slot
 candidates.
 
-| Candidate | Version | Released | License | Runtime deps | Dependents¹ | raku | **mutsu** |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| **`Text::CSV`** | 0.022 | 2023-10-30 | Artistic-2.0 | `Slang::Tuxic`, `File::Temp` | 0 | **33/33** (22697 tests) | **0/33** — blocked at `use` |
-| **`CSV::Table`** | 0.0.2 | 2025-05-31 | Artistic-2.0 | `YAMLish`, `JSON::Fast`, `File::Temp`, `Text::Utils` | 0 | **10/10** (184 tests) | **0/10** — blocked at `use` |
-| **`CSV::Parser`** | 0.1.4 | 2023-06-06 | *(README only — see below)* | **0** | 0 | **5/5** | **5/5** ✅ |
-| `CSV-AutoClass` | 0.2.0 | 2023-11-19 | Artistic-2.0 | `CSV::Parser`, `File::Find`, `Text::Utils` | 0 | 0/2 (missing test fixture on this checkout) | 0/2 — blocked at `use` |
-| `Duck::CSV` | 0.0.2 | 2026-05-30 | MIT | `Duckie` (→ system `libduckdb`) | 0 | not measured² | not measured² |
-| `Text::CSV::LibCSV` | 0.0.3 | 2022-09-09 | **none declared anywhere** | native `libcsv` (build-time C compile) | 0 | 0/5 — missing test fixtures | not measured³ |
-| `JSON-CSV` | 0.0.1 | 2022-07-11 | Artistic-2.0 | `Text::CSV`, `JSON::Fast`, `JSON::Stream` | 0 | not measured | not measured |
+| Candidate | Version | Released | License | Runtime deps | Read+generate? | Native/C dep? | Dependents¹ | raku | **mutsu** |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **`Text::CSV`** | 0.022 | 2023-10-30 | Artistic-2.0 | `Slang::Tuxic`, `File::Temp` | ✅ both, incl. from-scratch `csv(out=>…)` | none | 0 | **33/33** (22697 tests) | **0/33** — blocked at `use` |
+| **`CSV::Table`** | 0.0.2 | 2025-05-31 | Artistic-2.0 | `YAMLish`, `JSON::Fast`, `File::Temp`, `Text::Utils` | ✅ both, but write needs an existing file to load first | none | 0 | **10/10** (184 tests) | **0/10** — blocked at `use` |
+| `CSV::Parser` | 0.1.4 | 2023-06-06 | *(README only — see below)* | **0** | ❌ read-only — **disqualified** | none | 0 | **5/5** | **5/5** ✅ |
+| `CSV-AutoClass` | 0.2.0 | 2023-11-19 | Artistic-2.0 | `CSV::Parser`, `File::Find`, `Text::Utils` | ❌ codegen utility, not a reader/writer | none | 0 | 0/2 (missing test fixture on this checkout) | 0/2 — blocked at `use` |
+| `Duck::CSV` | 0.0.2 | 2026-05-30 | MIT | `Duckie` (→ system `libduckdb`) | not evaluated — disqualified below | **DuckDB (native)** | 0 | not measured² | not measured² |
+| `Text::CSV::LibCSV` | 0.0.3 | 2022-09-09 | **none declared anywhere** | native `libcsv` (build-time C compile) | not evaluated — disqualified below | **libcsv (native)** | 0 | 0/5 — missing test fixtures | not measured³ |
+| `JSON-CSV` | 0.0.1 | 2022-07-11 | Artistic-2.0 | `Text::CSV`, `JSON::Fast`, `JSON::Stream` | conversion scripts, not a library API | none | 0 | not measured | not measured |
 
 ¹ Distributions in the local REA index whose `depends` names the candidate —
 same method as [templates.md](templates.md). **Zero for every candidate in
@@ -133,7 +142,7 @@ support (a standing architectural gap tracked independently of this survey)
 or a deliberate decision to hand-patch the ~500 call sites, which is not
 recommended.
 
-### `CSV::Parser` — works today, unusually thin field otherwise
+### `CSV::Parser` — works today, but disqualified: read-only
 
 ```raku
 use CSV::Parser;
@@ -144,35 +153,17 @@ my %row = %($parser.get_line());
 
 The **only candidate in the field that is not blocked** — `use CSV::Parser`
 loads cleanly (no heredoc, no slang) and its own suite is **5/5 under both
-raku and mutsu**, unmodified. But it comes with real weaknesses that keep it
-from being an obvious "just bundle it" pick:
-
-- **License is declared only in the README**, not `META6.json` and not a
-  `LICENSE` file: "This library is free software; you can redistribute it
-  and/or modify it under the Artistic License 2.0." Per
-  [selection-method.md](selection-method.md)'s hard gate ("no declared
-  license anywhere → out"), a README statement counts as *declared*, so this
-  does not disqualify it outright the way `Text::CSV::LibCSV`'s total silence
-  does — but it is thinner evidence than every other bundled battery has, and
-  worth getting the author to add a proper `LICENSE` file / `META6.json`
-  field before shipping it, rather than relying on prose that could be edited
-  or dropped in a future release.
-- **Test coverage is thin**: 5 files, 1 assertion apiece (`t/01_multiline_csv.t`
-  … `t/05_normalizer.t`). It does cover the right shapes (multiline quoted
-  fields, escaped quotes, custom delimiters, binary mode, a field normalizer
-  callback) but nowhere near the depth `Text::CSV`'s 22697-assertion suite
-  does.
-- **Zero dependents, single author (`tony-o`), last released 2023-06-06** —
-  no ecosystem signal that anyone relies on it, and the README's own tone
-  ("This module is pretty badass... parse your binary CSV files like a pro")
-  reads as a personal utility rather than a maintained library aimed at
-  general reuse.
-- **API is minimal**: line-at-a-time `get_line()` returning a `Hash`/positional
-  parse, no writer/composer half (no `Text::CSV`-style `combine`/`getline_all`/
-  round-trip story) — reading only.
-
-It is the pragmatic "unblock something today" option, not a confident
-long-term pick.
+raku and mutsu**, unmodified. Under this slot's read-*and*-generate
+criterion it is disqualified anyway: its **API is read-only** —
+line-at-a-time `get_line()` returning a `Hash`/positional parse, with no
+writer/composer half at all (no `Text::CSV`-style `combine`/`print`/`csv(out
+=> …)` round-trip story). It also carries weaker secondary signals than
+either read+write candidate: license declared only in its README (not
+`META6.json`/`LICENSE`), 5 thin test files (1 assertion apiece) against
+`Text::CSV`'s 22697 assertions, and zero dependents from a single author
+whose README tone ("This module is pretty badass... parse your binary CSV
+files like a pro") reads as a personal utility. Kept in the table for
+completeness, not as a candidate to bundle.
 
 ## Ruled out before a full measurement
 
@@ -180,16 +171,16 @@ long-term pick.
   no `LICENSE` file, no `META6.json` `license` field, no README mention.
   Per the selection-method.md hard gate, this is disqualified outright — the
   exact precedent that dropped `HTML::Template`/`Text::Template` from the
-  template slot. Also structurally heavier than the other options regardless:
-  it build-compiles a native `libcsvwrap.so`/`.dll`/`.dylib` C wrapper around
-  `libcsv` (`build-depends: LibraryMake`), i.e. a NativeCall + system-library
-  dependency for a task the pure-Raku candidates handle without one.
+  template slot. Independently disqualified by the no-native-dependency
+  criterion too: it build-compiles a native `libcsvwrap.so`/`.dll`/`.dylib` C
+  wrapper around `libcsv` (`build-depends: LibraryMake`), i.e. a NativeCall +
+  system-library dependency for a task the pure-Raku candidates handle
+  without one.
 - **`Duck::CSV`** (0.0.2, MIT) — depends on `Duckie`, a NativeCall binding to
-  **DuckDB**, a full embedded analytical database engine. Wildly
-  disproportionate machinery for "read/write a CSV file" — the kind of
-  heavyweight native dependency this slot should specifically avoid when
-  pure-Raku options exist and are healthy under raku. Not installed/measured
-  for that reason.
+  **DuckDB**, a full embedded analytical database engine. Disqualified by the
+  no-native-dependency criterion — wildly disproportionate machinery for
+  "read/write a CSV file" when pure-Raku options exist and are healthy under
+  raku. Not installed/measured for that reason.
 - **`CSV-AutoClass`** (0.2.0, Artistic-2.0, `tbrowder`) — a narrow
   code-generation utility (define a class whose attributes come from a CSV
   file's header row) layered on `CSV::Parser`, not a general CSV
@@ -201,29 +192,46 @@ long-term pick.
 
 ## Recommendation
 
+Under the stated criteria (no native/C-library dependency, real
+read-and-generate API), the field narrows to exactly two live candidates —
+`Text::CSV` and `CSV::Table` — both pure Raku, both blocked purely by mutsu
+bugs rather than by anything wrong with the module itself:
+
 1. **Fix the heredoc-in-sub-body false positive first**
    (`todo/tickets/heredoc-scope-check-false-positive-on-sub-body.md`). It is a
-   general compiler bug, not a CSV-specific one, and it is the single blocker
-   standing between mutsu and `CSV::Table` (10/10 under raku, 0/10 today) —
-   plausibly cheap, on the same "one bug unblocks a healthy module" shape the
-   template slot found with `Template::Mustache`.
-2. **Re-measure `CSV::Table` after that fix lands.** If it comes up clean, it
-   is a stronger long-term candidate than `CSV::Parser`: real dependents-free
-   ecosystem standing is a wash either way (both 0), but `CSV::Table` has 46×
-   the test depth (184 vs 5 assertions) and a richer table/matrix API
-   (row/column slicing, save-back, header handling) versus `CSV::Parser`'s
-   bare line-at-a-time reader.
-3. **`Text::CSV` stays blocked on a second, harder problem** (slang support)
-   even after the heredoc fix, so it is not the near-term unblock candidate
-   despite being the most CPAN-familiar API (`Text::CSV_XS`-alike) and having
-   by far the deepest test suite (22697 assertions). Revisit once/if
-   slang-switching architecture exists for other reasons.
-4. **If a CSV story is needed before either fix lands**, `CSV::Parser` is the
-   only thing that works today — zero deps, passes its own (thin) suite
-   unmodified — but its license-in-README-only status and single-author,
-   no-dependents standing mean it should be treated as a stopgap, not a
-   final answer, and re-surveyed once the heredoc fix unblocks the stronger
-   candidates.
+   general compiler bug, not a CSV-specific one, and it is the **only**
+   blocker standing between mutsu and `CSV::Table` (10/10 under raku, 0/10
+   today), and one of two blockers for `Text::CSV`. Plausibly cheap, on the
+   same "one bug unblocks a healthy module" shape the template slot found
+   with `Template::Mustache`.
+2. **Re-measure both `Text::CSV` and `CSV::Table` after that fix lands.**
+   - `Text::CSV` has the fuller generation story: `combine`/`print`/`say` for
+     line-at-a-time composition plus a top-level `csv(in => @data, out =>
+     $file)` functional form that builds a CSV file directly from an
+     in-memory data structure — no pre-existing file needed. It is also the
+     deeper-tested candidate by far (22697 vs 184 assertions) and the most
+     CPAN-familiar API (`Text::CSV_XS`-alike). But it **stays blocked on a
+     second, harder problem** even after the heredoc fix: `use
+     Slang::Tuxic;` at the top of `Text::CSV.rakumod` itself needs real
+     slang-switching support, a standing architectural gap (see "What blocks
+     mutsu today" above) — not something to build just for this slot.
+   - `CSV::Table` clears with the heredoc fix **alone**, making it the
+     nearer-term option. Its write side is real (`.save`, cell mutation,
+     `save($stem)` to a new path) but structurally anchored: the class
+     constructor requires an *existing* `:csv($file)` to load
+     (`has $.csv; #is required;`, `lib/CSV/Table.rakumod:7`) — there is no
+     from-scratch "build a CSV out of `@data-structure` alone" entry point
+     the way `Text::CSV`'s functional `csv()` sub has. In practice this means
+     "generate a new CSV" with `CSV::Table` means starting from a (possibly
+     header-only or otherwise minimal) template file, not calling a
+     constructor with just Raku data. Worth confirming this is acceptable
+     for the actual use cases this slot is meant to serve before treating it
+     as equivalent to `Text::CSV`'s generation story.
+3. **No stopgap is recommended before the heredoc fix lands.** `CSV::Parser`
+   would have been the "unblock something today" pick, but it is read-only
+   and therefore disqualified by this slot's own criteria — bundling it now
+   would mean re-surveying and likely replacing it shortly after, which is
+   worse than simply waiting for the shared compiler fix.
 
 No candidate is bundled as of this writing; this document exists to make the
 next pass at the slot start from measurements instead of guesswork.

--- a/docs/batteries/python-stdlib-comparison.md
+++ b/docs/batteries/python-stdlib-comparison.md
@@ -127,7 +127,7 @@ module).
 
 | Python | Raku / mutsu | Status | Notes |
 | --- | --- | --- | --- |
-| `csv` | — | Ecosystem (not bundled) | Surveyed 2026-08-11: [csv.md](csv.md). `Text::CSV` (33/33 raku) and `CSV::Table` (10/10 raku) are both healthy under raku but currently blocked on mutsu by one shared, general compiler bug (`todo/tickets/heredoc-scope-check-false-positive-on-sub-body.md`); `CSV::Parser` (5/5) already works today as a thinner stopgap. |
+| `csv` | — | Ecosystem (not bundled) | Surveyed 2026-08-11: [csv.md](csv.md). Under a no-native-dependency + read-and-generate criterion, `Text::CSV` and `CSV::Table` are the only live candidates (both healthy under raku — 33/33 and 10/10 files — but blocked on mutsu by one shared, general compiler bug, `todo/tickets/heredoc-scope-check-false-positive-on-sub-body.md`); read-only `CSV::Parser` is disqualified despite already working today. |
 | `configparser` | — | Ecosystem (not bundled) | INI-style config modules exist on the ecosystem; none bundled. |
 | `tomllib` | — | Gap | No bundled TOML parser (mutsu's own `META6.json` handling is JSON, not TOML, so this hasn't been needed internally). |
 | `netrc` / `plistlib` | — | Gap | Niche. |


### PR DESCRIPTION
## Summary
- Follow-up to #6232 with a user-supplied selection criterion: the CSV battery must have no external native/C-library dependency and must support both reading and generating CSV, not reading alone.
- This disqualifies `CSV::Parser` (read-only) despite it being the only candidate that already works on mutsu today, and confirms the existing `Text::CSV::LibCSV` / `Duck::CSV` rejections (native deps) on independent grounds.
- The live field narrows to `Text::CSV` and `CSV::Table` — both pure Raku with real read+write APIs, both still blocked purely by the shared heredoc-in-sub-body compiler bug (`todo/tickets/heredoc-scope-check-false-positive-on-sub-body.md`, filed in #6232); `Text::CSV` additionally needs slang support.
- Notes an honest caveat on `CSV::Table`'s write API: it requires loading an existing `:csv($file)` first (no from-scratch constructor from a bare data structure), unlike `Text::CSV`'s functional `csv(out => ...)` form.

## Test plan
- Docs-only change; no code touched. CI's docs-only classification should skip the heavy jobs as it did for #6232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)