### PR TITLE
refactor(adr0019): E5 step 1 -- CallMethod dispatch-outcome measurement slice

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2793,6 +2793,27 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   `MUTSU_VM_STATS` counters + an interceptor-taxonomy table per entry) precedes and orders the
   cutovers, C6d-style. JIT shims are asserted tail-identical, not rewritten. The interpreter
   slow paths shrink by attrition (one probe section at a time), never by a one-PR rewrite.
+  **Progress 2026-08-11** (E5 step 1, measurement slice for `CallMethod`): the design
+  doc's decision-3 counters landed — generic `dispatch_entry_outcome_by_key` /
+  `dispatch_entry_intercept_by_arm` histograms in `vm_stats.rs` (keyed
+  `"<entry>:<outcome>"` / `"<entry>:<arm>"` so later E5/E6 entries reuse them), and
+  `exec_call_method_op_impl` instrumented at every completion point: 45 intercept arm
+  names, plus `native`/`user`/`accessor`/`notfound` outcome records at the probe
+  section. Pure insertions (0 deletions), zero behavior change; per-file cross-check
+  `sum(disjoint outcomes) == opcode-histogram CallMethod` holds (`notfound` is a
+  documented overlay subset of `user`). The taxonomy table (decision 2's classes a-d,
+  one row per arm, with the uninstrumentable gaps noted) and the sweep results live in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results — CallMethod".
+  Headline sweep numbers (full `t/` + roast S12/S14 subset, 3075 files): disjoint total
+  26924 — `user=13258` (49.2%), `native=11794` (43.8%), `intercept=968` (3.6%),
+  `accessor=904` (3.4%), overlay `notfound=52`; top intercept arm `nil-absorb=675`;
+  18 of 45 arms scored zero, most explained by the same receiver shapes compiling to
+  `CallMethodMut` (bareword/variable receivers) — NOT dead code until the E6a mut-twin
+  sweep says so. Consequence for slicing: E5b's decision match must nail the user- and
+  native-candidate paths first; the intercept gauntlet is an order of magnitude
+  smaller. This is ONE slice — the box stays open: the remaining E5 measurement
+  entries (`CallMethodDynamic`, hyper non-mut paths, `call_method_all_with_fallback`)
+  and all cutover sub-slices (E5b/E5c/E5d) are still to do.
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -567,6 +567,10 @@ impl Interpreter {
         // `$obj.attr.VAR.^name` is "Scalar", not the inner value's type).
         let target = if matches!(target.view(), ValueView::ContainerRef(_)) && method != "VAR" {
             if args.is_empty() && matches!(method, "^name" | "WHAT") {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethod",
+                    "containerref-scalar-meta",
+                );
                 self.stack.push(if method == "^name" {
                     Value::str("Scalar".to_string())
                 } else {
@@ -584,6 +588,7 @@ impl Interpreter {
         // and dispatched without reaching the resolver's native hook.
         if let Some(result) = loan_env!(self, try_native_method_on_receiver(&target, method, &args))
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "nativecall");
             self.stack.push(result?);
             return Ok(());
         }
@@ -603,6 +608,7 @@ impl Interpreter {
                 ValueView::Array(..) | ValueView::Seq(_) | ValueView::Slip(_)
             )
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "hash-on-list");
             let items: Vec<Value> = match target.view() {
                 ValueView::Array(items, _) => items.iter().cloned().collect(),
                 ValueView::Seq(items) | ValueView::Slip(items) => items.iter().cloned().collect(),
@@ -622,12 +628,14 @@ impl Interpreter {
                 ValueView::Pair(..) | ValueView::ValuePair(..)
             )
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "pair-freeze");
             let frozen = self.pair_freeze(&target, "");
             self.stack.push(frozen);
             return Ok(());
         }
         // `proto method` body dispatch (see try_proto_method_body).
         if let Some(result) = self.try_proto_method_body(&target, method, &args) {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "proto");
             let v = result?;
             // Drain captured-outer writeback recorded by the dispatched multi
             // candidate body (e.g. `multi method l(%t,*@l){ $r ~= '%'; ... }`
@@ -644,12 +652,17 @@ impl Interpreter {
         // `message` is a user *method* rather than an attribute. See
         // `try_exception_str_via_user_message`.
         if let Some(out) = self.try_exception_str_via_user_message(&target, method, &args)? {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethod",
+                "exception-str-message",
+            );
             self.stack.push(out);
             return Ok(());
         }
         // .return method: triggers a return from the enclosing sub with the invocant
         // as the return value. Does NOT auto-thread over junctions.
         if method == "return" && args.is_empty() {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "return");
             let mut err = RuntimeError::new("return");
             err.return_value = Some(target);
             return Err(err);
@@ -699,6 +712,10 @@ impl Interpreter {
         // invocant. Calling one on an Exception *type object* (e.g. `X::NYI.throw`)
         // is X::Parameter::InvalidConcreteness, not "no such method".
         if let Some(err) = self.exception_concreteness_error(method, &args, &target) {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethod",
+                "exception-concreteness",
+            );
             return Err(err);
         }
         // Autovivify a typed array element when a mutating array method is called
@@ -710,6 +727,10 @@ impl Interpreter {
             && matches!(method, "push" | "append" | "unshift" | "prepend")
             && let Some(result) = self.autoviv_typed_array_push(&type_name.resolve(), &args)?
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethod",
+                "autoviv-typed-array",
+            );
             self.stack.push(result);
             return Ok(());
         }
@@ -723,6 +744,7 @@ impl Interpreter {
                 ValueView::Instance { class_name, .. } if class_name == "Supplier"
             )
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "emit");
             if let Some(buf) = self.supply_emit_buffer.last_mut() {
                 buf.push(target);
                 self.stack.push(Value::NIL);
@@ -747,6 +769,7 @@ impl Interpreter {
             // Pure attribute read: touches no env (see comment above), so it does
             // not dirty the caller's locals (Slice 6.3 — removes the per-accessor
             // env->locals pull that dominated method-heavy code like bench-class).
+            crate::vm::vm_stats::record_dispatch_entry_outcome("callmethod", "accessor");
             self.stack.push(val);
             return Ok(());
         }
@@ -763,6 +786,10 @@ impl Interpreter {
             if let Some(cn) = user_bool_owner
                 && loan_env!(self, resolve_method_with_owner(&cn, "Bool", &[])).is_some()
             {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethod",
+                    "so-not-user-bool",
+                );
                 let t = self.eval_truthy(&target);
                 self.stack
                     .push(Value::truth(if method == "not" { !t } else { t }));
@@ -792,6 +819,7 @@ impl Interpreter {
                     | "note"
             )
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "junction-invocant");
             let mut results = Vec::new();
             // Accumulate EVERY eigenstate's by-name caller write (see the matching
             // CallMethodMut junction path for the full rationale).
@@ -830,6 +858,7 @@ impl Interpreter {
         // Junction auto-threading for method arguments:
         // If any method arg is a Junction, auto-thread over it.
         if let Some(result) = self.maybe_autothread_method_args(&target, method, &args)? {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "junction-args");
             self.stack.push(result);
             return Ok(());
         }
@@ -838,6 +867,10 @@ impl Interpreter {
         if method == "report"
             && matches!(target.view(), ValueView::Package(name) if name.resolve() == "Deprecation")
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethod",
+                "deprecation-report",
+            );
             let result = match crate::runtime::deprecation::take_report() {
                 Some(report) => Value::str(report),
                 None => Value::NIL,
@@ -863,6 +896,10 @@ impl Interpreter {
                 && (args.len() != 1
                     || !matches!(args[0].view(), ValueView::Sub(..) | ValueView::WeakSub(..)));
             if is_lock_type_object || is_lock_instance_bad_arg {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethod",
+                    "lock-protect-nomatch",
+                );
                 return Err(
                     crate::runtime::methods_signature_errors::make_multi_no_match_error("protect"),
                 );
@@ -878,6 +915,7 @@ impl Interpreter {
             } = target.view()
             && (class_name.resolve() == "Lock::Async" || class_name.resolve() == "Lock")
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "lock-protect");
             let lock_id = match attributes.as_map().get("lock-id").map(Value::view) {
                 Some(ValueView::Int(id)) if id > 0 => id as u64,
                 _ => {
@@ -1033,6 +1071,7 @@ impl Interpreter {
             && matches!(method, "gist" | "Str" | "raku" | "perl")
             && ll.renders_lazy_placeholder()
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "lazy-placeholder");
             self.stack
                 .push(Value::str(crate::value::lazy_list_placeholder(
                     method,
@@ -1053,6 +1092,7 @@ impl Interpreter {
             && method == "first"
             && let Some(result) = self.try_lazy_gather_first(&ll, &args)
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "lazy-first");
             self.stack.push(result?);
             return Ok(());
         }
@@ -1065,6 +1105,7 @@ impl Interpreter {
             && args.is_empty()
             && matches!(method, "kv" | "pairs" | "antipairs")
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "lazy-index-pipe");
             let transform = match method {
                 "pairs" => crate::value::IndexTransform::Pairs,
                 "antipairs" => crate::value::IndexTransform::AntiPairs,
@@ -1085,6 +1126,7 @@ impl Interpreter {
             && method == "cache"
             && ll.is_genuinely_lazy()
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "lazy-cache");
             self.stack.push(Value::lazy_list(crate::gc::Gc::new(
                 ll.with_cached_no_sink(),
             )));
@@ -1148,6 +1190,7 @@ impl Interpreter {
         };
         // .hyper/.race with named arguments (batch, degree): validate and wrap
         if matches!(method, "hyper" | "race") && !args.is_empty() {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "hyper-race-config");
             // Extract named args (batch, degree) and validate
             let mut batch: Option<i64> = None;
             let mut degree: Option<i64> = None;
@@ -1220,6 +1263,10 @@ impl Interpreter {
                         ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => items.clone(),
                         _ => unreachable!(),
                     };
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-hyper",
+                    );
                     self.stack.push(Value::hyper_seq_arc(items_arc));
                     // Pure rewrap (no env write): no env_dirty mark needed.
                     return Ok(());
@@ -1229,16 +1276,28 @@ impl Interpreter {
                         ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => items.clone(),
                         _ => unreachable!(),
                     };
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-race",
+                    );
                     self.stack.push(Value::race_seq_arc(items_arc));
                     // Pure rewrap (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "is-lazy" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-is-lazy",
+                    );
                     self.stack.push(Value::FALSE);
                     // Pure reflection (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "configuration" if args.is_empty() => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-configuration",
+                    );
                     // `HyperSeq.configuration` — expose the `.batch`/`.degree` the
                     // sequence was hyperized with (defaults otherwise). Used by the
                     // `hyperize` dist.
@@ -1254,6 +1313,10 @@ impl Interpreter {
                     return Ok(());
                 }
                 "^name" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-name",
+                    );
                     let name = if matches!(target.view(), ValueView::HyperSeq(_)) {
                         "HyperSeq"
                     } else {
@@ -1264,6 +1327,10 @@ impl Interpreter {
                     return Ok(());
                 }
                 "WHAT" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-what",
+                    );
                     let name = if matches!(target.view(), ValueView::HyperSeq(_)) {
                         "HyperSeq"
                     } else {
@@ -1274,6 +1341,10 @@ impl Interpreter {
                     return Ok(());
                 }
                 "isa" | "does" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-isa",
+                    );
                     let type_name = if !args.is_empty() {
                         match args[0].view() {
                             ValueView::Package(name) => name.resolve(),
@@ -1290,6 +1361,10 @@ impl Interpreter {
                     return Ok(());
                 }
                 "defined" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-defined",
+                    );
                     self.stack.push(Value::TRUE);
                     // Pure reflection (no env write): no env_dirty mark needed.
                     return Ok(());
@@ -1318,6 +1393,10 @@ impl Interpreter {
                         } else {
                             Value::race_seq_arc(Arc::new(result))
                         };
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethod",
+                            "hyperseq-map-grep",
+                        );
                         self.stack.push(wrapped);
                         return Ok(());
                     }
@@ -1325,6 +1404,10 @@ impl Interpreter {
                     Some(matches!(target.view(), ValueView::HyperSeq(_)))
                 }
                 "iterator" if args.is_empty() => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "hyperseq-iterator",
+                    );
                     // A HyperSeq/RaceSeq allows only a single iterator (rakudo #4413):
                     // a second `.iterator` throws X::Seq::Consumed. The consumed-state
                     // is tracked on the inner Arc via the shared Seq registry.
@@ -1374,6 +1457,7 @@ impl Interpreter {
                     | ValueView::Routine { is_regex: true, .. }
             )
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "regex-bool-topic");
             let topic = self.env().get("_").cloned().unwrap_or(Value::NIL);
             let matched = self.vm_smart_match(&topic, &target);
             self.stack.push(Value::truth(matched));
@@ -1385,6 +1469,10 @@ impl Interpreter {
             && args.is_empty()
             && matches!(target.view(), ValueView::Package(name) if Self::is_pseudo_package_bare(&name.resolve()))
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethod",
+                "who-pseudo-package",
+            );
             if let ValueView::Package(pkg_name) = target.view() {
                 let stash = self.build_pseudo_stash(code, &pkg_name.resolve());
                 self.stack.push(stash);
@@ -1405,6 +1493,10 @@ impl Interpreter {
             && class_name.resolve() == "Failure"
             && !target.is_failure_handled()
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethod",
+                "failure-print-nomatch",
+            );
             return Err(Self::print_routine_no_match_error(method, &target, &args));
         }
         // Unhandled Failure explosion: calling a non-Failure method on an unhandled
@@ -1438,6 +1530,7 @@ impl Interpreter {
             )
             && let Some(err) = self.failure_to_runtime_error_if_unhandled(&target)
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "failure-explode");
             return Err(err);
         }
         // Pseudo-methods (WHAT, WHICH, etc.) cannot be used with .* or .+
@@ -1447,6 +1540,10 @@ impl Interpreter {
                 "WHAT" | "WHICH" | "WHERE" | "HOW" | "WHY" | "WHO" | "DEFINITE" | "VAR"
             )
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethod",
+                "modifier-pseudo-error",
+            );
             return Err(RuntimeError::new(format!(
                 "Cannot use .{} on a non-identifier method call",
                 modifier.unwrap()
@@ -1456,11 +1553,13 @@ impl Interpreter {
         // directly to the all-methods-in-MRO path to avoid double execution.
         match modifier {
             Some("+") => {
+                crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "modifier-plus");
                 let vals =
                     self.call_method_all_with_fallback(&target, method, &args, skip_native)?;
                 self.stack.push(Value::array(vals));
             }
             Some("*") => {
+                crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "modifier-star");
                 match self.call_method_all_with_fallback(&target, method, &args, skip_native) {
                     Ok(vals) => self.stack.push(Value::array(vals)),
                     Err(e) if Self::is_method_not_found_error(&e) => {
@@ -1500,6 +1599,10 @@ impl Interpreter {
                         {
                             // Native method on the by-value backing storage is
                             // env-pure: no env_dirty mark needed.
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "callmethod",
+                                "native",
+                            );
                             self.stack.push(native_result?);
                             return Ok(());
                         }
@@ -1509,6 +1612,10 @@ impl Interpreter {
                             args.clone(),
                         );
                         if let Ok(val) = result {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "callmethod",
+                                "user",
+                            );
                             self.stack.push(val);
                             return Ok(());
                         }
@@ -1529,6 +1636,10 @@ impl Interpreter {
                     // named-receiver opcode (`exec_call_method_mut_op_impl`)
                     // so `my $v := Nil; $v.Int` reaches the same verdict.
                     if let Some(err) = nil_predispatch_error(method, args.is_empty()) {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethod",
+                            "nil-predispatch",
+                        );
                         return Err(err);
                     }
                     match method {
@@ -1560,6 +1671,10 @@ impl Interpreter {
                                 "unshift" => args.to_vec(),
                                 _ => args,
                             };
+                            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                                "callmethod",
+                                "nil-autoviv",
+                            );
                             self.stack.push(Value::real_array(arr));
                             return Ok(());
                         }
@@ -1594,6 +1709,10 @@ impl Interpreter {
                         }
                         _ => {
                             // Nil-absorbing method returns Nil and touches no env.
+                            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                                "callmethod",
+                                "nil-absorb",
+                            );
                             self.stack.push(Value::NIL);
                             return Ok(());
                         }
@@ -1623,6 +1742,10 @@ impl Interpreter {
                         "unshift" => args.to_vec(),
                         _ => args,
                     };
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "any-autoviv",
+                    );
                     self.stack.push(Value::real_array(arr));
                     return Ok(());
                 }
@@ -1635,6 +1758,10 @@ impl Interpreter {
                 ) && matches!(target.view(), ValueView::Array(..))
                     && let Some((attrs_ref, attr_name)) = self.pending_proxy_subclass_attr.take()
                 {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethod",
+                        "proxy-subclass-mutate",
+                    );
                     let result =
                         self.proxy_subclass_array_mutate(&attrs_ref, &attr_name, method, &args)?;
                     self.stack.push(result);
@@ -1660,6 +1787,7 @@ impl Interpreter {
                     // Native array node mutation on a by-value target: env-pure
                     // (no named binding is written).
                     self.method_dispatch_pure = true;
+                    crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "shift-pop");
                     if let ValueView::Array(_, kind) = target.view()
                         && kind.is_lazy()
                     {
@@ -1692,6 +1820,10 @@ impl Interpreter {
                         if let Some(native_result) =
                             self.try_native_method(&resolved, method_sym, &args)
                         {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "callmethod",
+                                "native",
+                            );
                             let result = native_result;
                             // Native method on a by-value resolved hash is env-pure
                             // (see the sibling native-method branches below that set
@@ -1730,14 +1862,26 @@ impl Interpreter {
                                 .collect();
                             // Pure array transform: env-pure.
                             self.method_dispatch_pure = true;
+                            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                                "callmethod",
+                                "slip-default",
+                            );
                             Ok(Value::slip(converted))
                         } else if let Some(native_result) =
                             self.try_native_method(&target, method_sym, &args)
                         {
                             // Native method on a by-value (read) target: env-pure.
                             self.method_dispatch_pure = true;
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "callmethod",
+                                "native",
+                            );
                             native_result
                         } else {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "callmethod",
+                                "user",
+                            );
                             self.try_compiled_method_or_interpret_sym(target, method_sym, args)
                         }
                     } else if let Some(native_result) =
@@ -1745,11 +1889,14 @@ impl Interpreter {
                     {
                         // Native method on a by-value (read) target: env-pure.
                         self.method_dispatch_pure = true;
+                        crate::vm::vm_stats::record_dispatch_entry_outcome("callmethod", "native");
                         native_result
                     } else {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome("callmethod", "user");
                         self.try_compiled_method_or_interpret_sym(target, method_sym, args)
                     }
                 } else {
+                    crate::vm::vm_stats::record_dispatch_entry_outcome("callmethod", "user");
                     self.try_compiled_method_or_interpret_sym(target, method_sym, args)
                 };
                 // Slice 6.3: mark env dirty only when the dispatch was not a
@@ -1762,12 +1909,24 @@ impl Interpreter {
                             if mark_dirty {}
                         }
                         Err(e) if Self::is_method_not_found_error(&e) => {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "callmethod",
+                                "notfound",
+                            );
                             self.stack.push(Value::NIL);
                             if mark_dirty {}
                         }
                         Err(e) => return Err(e),
                     },
                     _ => {
+                        if let Err(e) = &call_result
+                            && Self::is_method_not_found_error(e)
+                        {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "callmethod",
+                                "notfound",
+                            );
+                        }
                         self.stack.push(call_result?);
                         if mark_dirty {}
                     }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -536,6 +536,62 @@ pub(crate) fn record_mainline_lexical_hit() {
     }
 }
 
+// ADR-0019 Phase E box E5 (measurement slice, design decision 3 in
+// `todo/deep/adr0019-e5-e7-entry-routing.md`): per-entry, per-outcome dispatch
+// counters for the VM call entries (`CallMethod`, and in later slices
+// `CallMethodMut`, `CallMethodDynamic`, the hyper entries, ...). Each entry
+// records exactly one outcome per executed dispatch — `intercept` (a
+// method-identity special-case arm fully handled the call before the general
+// probes), `native` (the `try_native_method` cascade served it), `user` (the
+// compiled/interpreted user-method fallthrough ran), `accessor` (the fast
+// 0-arg public-attribute read served it), or `notfound` (an explicitly
+// observed X::Method::NotFound completion; see the taxonomy table in the E5-E7
+// doc for the one documented overlap with `user`). The by-key histogram is
+// keyed `"<entry>:<outcome>"` so every future E5/E6 entry reuses this family
+// instead of growing bespoke statics; the by-arm histogram is keyed
+// `"<entry>:<arm-name>"` and is what lets the sweep identify dead/near-dead
+// intercepts (design decision 3(ii): deletion candidates rather than porting
+// targets). The sweep over full `t/` + whitelisted roast decides sub-slice
+// order (3(i)) and the parity corpus for each cutover (3(iii)). Nothing reads
+// these counters to make a dispatch decision: measurement-only, zero behavior
+// change.
+fn dispatch_entry_outcome_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn dispatch_entry_intercept_by_arm() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_ARM: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_ARM.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one dispatch outcome for VM call entry `entry` (e.g. `"callmethod"`)
+/// with `outcome` one of `intercept`/`native`/`user`/`accessor`/`notfound`.
+#[inline]
+pub(crate) fn record_dispatch_entry_outcome(entry: &str, outcome: &str) {
+    if !enabled() {
+        return;
+    }
+    if let Ok(mut map) = dispatch_entry_outcome_by_key().lock() {
+        *map.entry(format!("{entry}:{outcome}")).or_insert(0) += 1;
+    }
+}
+
+/// Record one method-identity intercept at VM call entry `entry`: bumps the
+/// `intercept` outcome via [`record_dispatch_entry_outcome`] AND the per-arm
+/// histogram under `"<entry>:<arm>"` (short stable arm names, e.g.
+/// `"callmethod:pair-freeze"`).
+#[inline]
+pub(crate) fn record_dispatch_entry_intercept(entry: &str, arm: &str) {
+    if !enabled() {
+        return;
+    }
+    record_dispatch_entry_outcome(entry, "intercept");
+    if let Ok(mut map) = dispatch_entry_intercept_by_arm().lock() {
+        *map.entry(format!("{entry}:{arm}")).or_insert(0) += 1;
+    }
+}
+
 /// Whether instrumentation is active. Resolved once from the environment so the
 /// hot path is a single cached boolean load when the feature is off.
 #[inline]
@@ -911,6 +967,42 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e4b native-row-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    if let Ok(map) = dispatch_entry_outcome_by_key().lock()
+        && !map.is_empty()
+    {
+        let total: u64 = map.values().sum();
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-e5 dispatch-entry outcomes total={} (top {}): {}",
+            total,
+            top.len(),
+            top.join(" ")
+        );
+    }
+    if let Ok(map) = dispatch_entry_intercept_by_arm().lock()
+        && !map.is_empty()
+    {
+        let total: u64 = map.values().sum();
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(40)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-e5 intercept arms total={} (top {}): {}",
+            total,
             top.len(),
             top.join(" ")
         );

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -178,3 +178,121 @@ cutover changes one entry and ships with its taxonomy table and sweep evidence, 
 tails and interceptors do not move, and (iv) local `make roast` before every cutover PR
 (semantics-adjacent). Perf: each cutover PR cites the bench-CI rows for its main-merge commit;
 a regression on fib/bench-tak blocks the next slice until explained.
+
+## Measurement slice results — CallMethod (E5 step 1)
+
+Landed 2026-08-11: `MUTSU_VM_STATS`-gated counters per design decision 3 —
+`record_dispatch_entry_outcome(entry, outcome)` (histogram keyed
+`"<entry>:<outcome>"`, outcomes `intercept`/`native`/`user`/`accessor`/`notfound`) and
+`record_dispatch_entry_intercept(entry, arm)` (bumps `intercept` AND a per-arm histogram
+keyed `"<entry>:<arm>"`), both in `src/vm/vm_stats.rs` and generic so every later E5/E6
+entry reuses them. This slice instruments exactly one entry: `CallMethod`
+(`exec_call_method_op_impl`, `src/vm/vm_call_method_ops.rs`). Pure insertions only — the
+diff is 0 deletions; no branch, condition, or return value changed.
+
+Counting semantics: each executed `CallMethod` records exactly one of
+`intercept`/`native`/`user`/`accessor` (verified per-file:
+`sum(disjoint outcomes) == CallMethod` in the opcode histogram, e.g.
+`roast/S12-methods/instance.t`: 11 == 11). `notfound` is a deliberate **overlay subset of
+`user`**: `user` is recorded when the compiled/interpret fallthrough is *entered* (the only
+pure-insertion point), and `notfound` is recorded additionally at the two visible
+not-found completions (the `.?` Nil absorb and the propagated-`Err` peek before
+`call_result?`) — X::Method::NotFound originates inside
+`try_compiled_method_or_interpret_sym`, so there is no disjoint not-found tail at this
+entry without restructuring. Disjoint total = `intercept + native + accessor + user`.
+Note `METHOD_TOTAL` (`record_method_dispatch`) fires for all four `CallMethod*` opcodes,
+so it does NOT equal the `callmethod:*` sum; cross-check against the opcode histogram's
+`CallMethod` row instead.
+
+Taxonomy table (line numbers as of this PR's revision of `vm_call_method_ops.rs`; the
+anchor for each instrumented row is its `record_dispatch_entry_*` call):
+
+| Line range | Class | Arm name / description | Counter key | Notes |
+|---|---|---|---|---|
+| ~500-550 | — | entry bookkeeping (arg decode, slip flatten, stack pops) | (none) | stack-underflow errors uninstrumented: internal errors, not dispatch outcomes |
+| ~551-566 | a | LazyIoLines force | (none) | |
+| ~567-586 | a+b | ContainerRef deref; `.^name`/`.WHAT`-on-cell Scalar-meta early return | `callmethod:containerref-scalar-meta` | the deref itself is (a); only the Scalar-meta return counts |
+| ~589-597 | b | `is native(...)` NativeCall-bound method | `callmethod:nativecall` | |
+| ~600-625 | b | `.hash`/`.Hash` on bare positional list | `callmethod:hash-on-list` | |
+| ~627-641 | b | `Pair.freeze` on non-variable receiver | `callmethod:pair-freeze` | |
+| ~636-652 | b | `proto method` body dispatch | `callmethod:proto` | includes its own `apply_pending_rw_writeback` tail (stays put) |
+| ~653-662 | b | Exception `.Str`/`.gist` via user `message` method | `callmethod:exception-str-message` | |
+| ~663-670 | b | `.return` control flow | `callmethod:return` | |
+| ~672-711 | a | `.throw`/`.rethrow` backtrace attach | (none) | rebuilds target only; no completion |
+| ~713-721 | b | `fail`/`die`/`throw`/... on Exception type object | `callmethod:exception-concreteness` | 0 in sweep — bareword receivers (`X::NYI.throw`) compile to CallMethodMut |
+| ~722-737 | b | typed-array autoviv `push`/... on type object | `callmethod:autoviv-typed-array` | |
+| ~738-757 | b | `.emit` supply-buffer / CX::Emit | `callmethod:emit` | one arm name for both completions |
+| ~759-778 | c | fast 0-arg public-accessor read | `callmethod:accessor` | dispatch-probe outcome, not an intercept |
+| ~780-797 | b | `.so`/`.not` via user-defined `Bool` | `callmethod:so-not-user-bool` | |
+| ~798-799 | a | `flatten_scoped_env` | (none) | |
+| ~800-857 | b | junction-invocant auto-threading | `callmethod:junction-invocant` | one count per call, not per eigenstate; inner per-eigenstate native/user probes deliberately uninstrumented |
+| ~859-866 | b | junction-argument auto-threading | `callmethod:junction-args` | |
+| ~867-882 | b | `Deprecation.report` | `callmethod:deprecation-report` | |
+| ~884-905 | b | `Lock.protect` X::Multi::NoMatch guard | `callmethod:lock-protect-nomatch` | |
+| ~906-947 | b | `Lock`/`Lock::Async.protect` inline fast path | `callmethod:lock-protect` | 0 in sweep — `$lock.protect` on a variable compiles to CallMethodMut |
+| ~949-1043 | c | `skip_native` gate computation | (none) | pure gate, no completion; becomes resolver input at cutover |
+| ~1044-1067 | a | Proxy auto-FETCH | (none) | |
+| ~1069-1084 | b | lazy-list `gist`/`Str` placeholder | `callmethod:lazy-placeholder` | |
+| ~1086-1100 | b | lazy gather `.first` incremental pull | `callmethod:lazy-first` | |
+| ~1102-1121 | b | lazy `.pairs`/`.antipairs`/`.kv` index pipe | `callmethod:lazy-index-pipe` | |
+| ~1123-1135 | b | lazy `.cache` identity | `callmethod:lazy-cache` | |
+| ~1136-1190 | a | lazy-list forcing | (none) | the mid-normalization `X::Cannot::Lazy` return is an uninstrumented gap (error inside normalization, not a probe outcome) |
+| ~1192-1255 | b | `.hyper`/`.race` with `batch`/`degree` | `callmethod:hyper-race-config` | branch-entry record also covers the two X::Invalid::Value completions |
+| ~1257-1450 | b | HyperSeq/RaceSeq delegation (10 arms) | `callmethod:hyperseq-{hyper,race,is-lazy,configuration,name,what,isa,defined,map-grep,iterator}` | `map-grep` counted only at the <1000-item inline completion; larger lists fall through to the general probes (sets `hyper_race_wrap`) |
+| ~1451-1457 | a | HyperSeq/RaceSeq → List conversion | (none) | |
+| ~1458-1470 | b | Regex `.Bool`/`.so` topic smartmatch | `callmethod:regex-bool-topic` | 0 in sweep — variable receivers compile to CallMethodMut |
+| ~1471-1484 | b | `.WHO` on pseudo-package | `callmethod:who-pseudo-package` | |
+| ~1486-1501 | b | Failure `.print`/`.say`/... positional X::Multi::NoMatch | `callmethod:failure-print-nomatch` | |
+| ~1503-1537 | b | unhandled-Failure explosion | `callmethod:failure-explode` | |
+| ~1539-1551 | b | `.*`/`.+` on pseudo-method error | `callmethod:modifier-pseudo-error` | |
+| ~1554-1560 | b | `.+` all-methods dispatch | `callmethod:modifier-plus` | delegates to `call_method_all_with_fallback` (its own E5 measurement entry, later slice) |
+| ~1561-1576 | b | `.*` all-methods dispatch | `callmethod:modifier-star` | its not-found→empty-list completion is covered by this arm, not `notfound` |
+| ~1578-1626 | c | Array-subclass `__mutsu_array_storage` delegation | `callmethod:native` / `callmethod:user` | a failed compiled delegation falls through to normal dispatch *uncounted* (recording at entry would double-count); gap noted |
+| ~1630-1723 | b | Nil pre-dispatch block | `callmethod:nil-predispatch` / `callmethod:nil-autoviv` / `callmethod:nil-absorb` | the fall-through names (`defined`, `grep`, `say`, ...) reach the general probes and count there |
+| ~1725-1751 | b | Any/Mu autoviv `push`/... | `callmethod:any-autoviv` | |
+| ~1753-1768 | b | Proxy-subclass array mutate | `callmethod:proxy-subclass-mutate` | |
+| ~1780-1817 | b | `shift`/`pop` value fast path | `callmethod:shift-pop` | method-identity arm inside the probe section |
+| ~1818-1846 | c | hash-sentinel resolve + native probe | `callmethod:native` | |
+| ~1847-1886 | b+c | `.Slip` `is default` fill / native / fallthrough | `callmethod:slip-default` / `callmethod:native` / `callmethod:user` | |
+| ~1887-1901 | c | plain native probe + compiled/interpret fallthrough (incl. `skip_native` route) | `callmethod:native` / `callmethod:user` | `user` includes calls that later fail with X::Method::NotFound (see overlay note) |
+| ~1903-1937 | c | not-found completions (`.?` Nil absorb; propagated-Err peek) | `callmethod:notfound` | overlay subset of `user` |
+| ~1938-1976 | d | writeback tails (`drain_and_reconcile_after_cached_call`, hyper rewrap) | (none) | untouched per design decision 2 |
+
+Summary: 45 distinct intercept arm names over ~40 class-(b) arms (the HyperSeq family
+alone is 10), 6 class-(a) normalization regions, the class-(c) probe section with 4
+outcome kinds, 1 class-(d) tail region. No surprises in kind, one surprise in *shape*:
+several arms that look CallMethod-owned are in practice unreachable from this entry
+because their receiver shapes (bareword type names, plain variables) compile to
+`CallMethodMut` — the sweep confirms this (see below), which means the E6a measurement
+for `CallMethodMut` is where those twins' real traffic will show up. Zero counts here
+must NOT be read as dead code until the E6a sweep of the mut twin lands.
+
+### Sweep results (2026-08-11, debug build, full `t/` 3014 files + roast S12-attributes/S12-methods/S14-roles, 3075 processes, 0 timeouts)
+
+Outcomes (disjoint): `callmethod:user=13258` (49.2%), `callmethod:native=11794`
+(43.8%), `callmethod:intercept=968` (3.6%), `callmethod:accessor=904` (3.4%);
+overlay `callmethod:notfound=52` (0.4% of user). Disjoint total 26924.
+
+Sub-slice ordering consequence (decision 3(i)): the `user` and `native` outcomes
+dominate roughly equally — the E5b cutover's decision match must get the
+user-candidate and native-row paths right first; accessor and the intercept gauntlet
+are an order of magnitude smaller.
+
+Intercept arms by count (27 of 45 fired): `nil-absorb=675`, `lazy-first=92`,
+`hyperseq-map-grep=38`, `nil-predispatch=33`, `hash-on-list=32`, `proto=27`,
+`junction-invocant=10`, `lazy-index-pipe=9`, `who-pseudo-package=6`,
+`modifier-star=5`, `lazy-placeholder=5`, `modifier-plus=4`,
+`hyperseq-configuration=4`, `hyper-race-config=4`, `junction-args=3`, `emit=3`,
+`failure-print-nomatch=3`, `containerref-scalar-meta=2`, `hyperseq-iterator=2`,
+`shift-pop=2`, `failure-explode=2`, `so-not-user-bool=2`, `lock-protect-nomatch=1`,
+`lazy-cache=1`, `pair-freeze=1`, `return=1`, `modifier-pseudo-error=1`.
+
+Zero-count arms (18): `nativecall`, `exception-str-message`,
+`exception-concreteness`, `autoviv-typed-array`, `deprecation-report`,
+`lock-protect`, `hyperseq-{hyper,race,is-lazy,name,what,isa,defined}`,
+`regex-bool-topic`, `nil-autoviv`, `any-autoviv`, `proxy-subclass-mutate`,
+`slip-default`. These are *deletion candidates for a later sweep, not deletions now*
+(decision 3(ii)) — and most are explained rather than dead: bareword/variable
+receivers route the same shapes through `CallMethodMut`, and this sweep covered
+`t/` plus only three roast directories, not the whole whitelist. Re-run the sweep
+over whitelisted roast (CI-scale) before proposing any arm removal.


### PR DESCRIPTION
## What

ADR-0019 Phase E, box E5, step 1: the measurement slice mandated by design decision 3 of `todo/deep/adr0019-e5-e7-entry-routing.md`, scoped to exactly ONE entry — `CallMethod` (`exec_call_method_op_impl`, `src/vm/vm_call_method_ops.rs`).

- **Counter plumbing** (`src/vm/vm_stats.rs`): generic `dispatch_entry_outcome_by_key` histogram keyed `"<entry>:<outcome>"` (outcomes `intercept`/`native`/`user`/`accessor`/`notfound`) and `dispatch_entry_intercept_by_arm` keyed `"<entry>:<arm>"`, with `record_dispatch_entry_outcome` / `record_dispatch_entry_intercept` (no-ops unless `MUTSU_VM_STATS=1`) and `dump()` print blocks following the file's existing sorted-top-N pattern. Generic keys so future E5/E6 entries (`CallMethodMut`, `CallMethodDynamic`, hyper, ...) reuse the same family instead of bespoke statics.
- **Instrumentation** (`src/vm/vm_call_method_ops.rs`): every completion point classified per design decision 2's taxonomy — (a) receiver normalization uncounted, (b) 45 method-identity intercept arm names, (c) probe outcomes `native`/`user`/`accessor`/`notfound`, (d) writeback tails untouched. **Pure insertions only: the diff has 0 deletions; no branch, condition, or return value changed.**
- **Taxonomy table** (the review artifact for the eventual E5b cutover) + sweep results appended to the E5-E7 design doc; a terse progress note added after the ADR E5 bullet's Design paragraph. The E5 checkbox stays unchecked.

## Sweep results (debug build, `MUTSU_VM_STATS=1`, full `t/` 3014 files + roast S12-attributes/S12-methods/S14-roles, 3075 processes, 0 timeouts)

Disjoint total 26924: `user=13258` (49.2%), `native=11794` (43.8%), `intercept=968` (3.6%), `accessor=904` (3.4%); overlay `notfound=52` (a documented subset of `user` — X::Method::NotFound originates inside the fallthrough callee, so there is no disjoint not-found tail at this entry without restructuring). Top intercept arm: `nil-absorb=675`. 18 of 45 arms scored zero — mostly explained by the same receiver shapes (barewords, plain variables) compiling to `CallMethodMut`, so they are deletion *candidates* pending the E6a mut-twin sweep, not deletions now.

Cross-check: per file, `sum(disjoint outcomes) == opcode-histogram CallMethod` (e.g. `roast/S12-methods/instance.t`: 11 == 11). Note `METHOD_TOTAL` fires for all four `CallMethod*` opcodes and intentionally does not match.

## Verification

- `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo test --lib` (779 tests) all clean.
- Targeted prove run (t/lock.t, anon-class, augment-class, array-subclass, builtin-subclass-method-override, junction; roast S12-methods/instance.t, S14-roles/basic.t) green.
- No new test file: measurement infrastructure, zero behavior change by construction (every changed hunk is an insertion of a self-guarded record call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)