### PR TITLE
fix(test): share TAP counter with threads spawned before the first test call

### DIFF
--- a/news/2026-08/tap-counter-shared-before-first-test.md
+++ b/news/2026-08/tap-counter-shared-before-first-test.md
@@ -1,0 +1,32 @@
+# TAP counter is shared with threads spawned before the first test call
+
+A thread spawned BEFORE the first test call never shared the TAP counter:
+`TapState::clone_for_thread` shares the counter of an *existing* `TestState`,
+but the state is created lazily by the first `plan`/`ok`. When the very first
+assertion of a program runs on a spawned thread — the Cro HTTP/2
+serializer/parser test shape, where every check of the first `test()` call
+fires inside a supply tap driven by a `start` block — the child lazily created
+a *private* `TestState`. Its increments never reached the parent, the parent
+then restarted numbering at `ok 1`, and prove failed the whole file with
+"Tests out of sequence" even when every assertion passed.
+
+Fix: `clone_for_thread_excluding` (`src/runtime/runtime_thread.rs`) now
+pre-creates the parent `TestState` before cloning the TAP state, gated on the
+Test module actually being loaded (an unconditional empty state would flip
+`test_mode_active` and change bare-word resolution for non-Test programs that
+spawn threads).
+
+Impact measured on the vendored Cro::HTTP suite: all three HTTP/2
+serializer/parser test files previously failed prove with ~26-55 TAP syntax
+errors each from the desynced numbering; with the fix,
+`http2-request-serializer.rakutest` passes completely (32 tests), and
+`http2-response-serializer.rakutest` / `http2-request-parser.rakutest` are
+down to exactly one real assertion failure each (tracked in
+`todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md`).
+
+Pin: `t/test-counter-spawn-before-first-test.t` (raku-validated).
+
+Known remaining hole in the same family (intentionally out of scope here): the
+child's `failed` count still does not propagate back to the parent, so a
+failure that happens only on a spawned thread is visible in the TAP stream
+(`not ok`) but not in the parent's plan summary / exit code.

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -145,6 +145,21 @@ impl Interpreter {
         &mut self,
         captured_scalars: &std::collections::HashSet<String>,
     ) -> Self {
+        // A thread spawned BEFORE the first test call must still share the TAP
+        // counter: the first `ok` of the whole program can run on the spawned
+        // thread (e.g. supply-tap check closures in Cro's HTTP/2 serializer
+        // tests, where every assertion of the first `test()` call fires inside
+        // the tap). Without a pre-created `TestState`,
+        // `TapState::clone_for_thread` has nothing to share; the child then
+        // lazily creates a private state whose increments never reach the
+        // parent, and the parent restarts numbering at 1 — "Tests out of
+        // sequence" under prove. Gate on the Test module being loaded: an
+        // empty `TestState` flips `test_mode_active`, which would otherwise
+        // change bare-word resolution for non-Test programs that spawn threads.
+        if self.test_module_loaded() && !self.tap.active() {
+            // `clone_for_thread` below shares the counter of an EXISTING state.
+            self.tap.ensure_state();
+        }
         // Collapse a scoped (multi-tier overlay) env to a flat one first: the
         // shared-var seeding and the child's env clone below iterate the env
         // overlay-only, which would miss parent-chain lexicals on a scoped env.

--- a/t/test-counter-spawn-before-first-test.t
+++ b/t/test-counter-spawn-before-first-test.t
@@ -1,0 +1,29 @@
+# A thread spawned BEFORE the first test call must share the TAP counter.
+# The first `ok` of the whole program runs inside a supply tap driven by a
+# `start` block (the Cro HTTP/2 serializer-test shape). Before the fix, the
+# spawned thread lazily created a private TestState: its increments never
+# reached the main thread, main restarted numbering at 1, and prove failed
+# the file with "Tests out of sequence" even though every assertion passed.
+use Test;
+
+plan 6;
+
+my $s = Supplier.new;
+my $done = Promise.new;
+$s.Supply.tap: -> $v {
+    ok True, "in tap $v";
+    $done.keep if $v == 2;
+};
+start { $s.emit(1); $s.emit(2); }
+await Promise.anyof($done, Promise.in(5));
+ok True, "main after first";
+
+my $s2 = Supplier.new;
+my $done2 = Promise.new;
+$s2.Supply.tap: -> $v {
+    ok True, "in tap2 $v";
+    $done2.keep if $v == 2;
+};
+start { $s2.emit(1); $s2.emit(2); }
+await Promise.anyof($done2, Promise.in(5));
+ok True, "main after second";


### PR DESCRIPTION
## Problem

`TapState::clone_for_thread` shares the TAP counter of an *existing* `TestState`, but the state is created lazily by the first `plan`/`ok`. A thread spawned BEFORE the first test call therefore got `state: None`; when the program's very first assertion ran on that thread (the Cro HTTP/2 serializer/parser test shape — every check of the first `test()` call fires inside a supply tap driven by a `start` block), the child lazily created a **private** `TestState`. Its increments never reached the parent, the parent restarted numbering at `ok 1`, and prove failed the whole file with "Tests out of sequence" even when every assertion passed.

Minimal repro (23 lines, dependency-free): first `ok` runs in a tap driven by `start` — mutsu numbered it 1,2 then main restarted at 1 with plan `1..4` for 6 test lines; raku numbers 1..6 continuously.

## Fix

`clone_for_thread_excluding` (`src/runtime/runtime_thread.rs`) pre-creates the parent `TestState` before cloning the TAP state, **gated on the Test module being loaded** — an unconditional empty state would flip `test_mode_active` and change bare-word resolution for non-Test programs that spawn threads.

## Impact (vendored Cro::HTTP suite)

- `http2-request-serializer.rakutest`: prove FAIL (29 TAP syntax errors) → **PASS** (32 tests)
- `http2-response-serializer.rakutest` / `http2-request-parser.rakutest`: prove FAIL with 26/55 TAP syntax errors → exactly one real assertion failure each (root causes tracked separately in `todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md`)

## Testing

- New pin: `t/test-counter-spawn-before-first-test.t` (raku-validated)
- Full `prove -e target/debug/mutsu t/` pass locally (exit 0)
- Full roast delegated to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)