### PR TITLE
docs(cro): root-cause the two HTTP/2 residuals; ADR-0025 slice-2 implementation plan

### DIFF
--- a/todo/deep/adr0025-slice2-implementation-plan.md
+++ b/todo/deep/adr0025-slice2-implementation-plan.md
@@ -1,0 +1,123 @@
+# ADR-0025 slice 2 — concrete implementation plan (decl-site cells for vouch-refused captured scalars + cross-thread rider)
+
+Companion to `docs/adr/0025-captured-scalar-cells-value-kind-blind.md`
+("Slice 2 (planned)"). This file turns the ADR's mechanism paragraph into a
+step-by-step, Sonnet-implementable plan, updated with the 2026-08-11
+diagnosis evidence (see the parent ticket
+`todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md`,
+item 1).
+
+## Ordering change vs the ADR text: do the rider FIRST
+
+The ADR listed the "cross-thread audit rider" as a companion to the
+decl-site set extension. The response-serializer evidence inverts the
+priority: in the real failing file the cell ALREADY forms (slice 1's
+trigger fires — `$encoder` is creator-reassigned, the check closures are
+escaping array-literal elements) and mainline write-through works; what
+fails is the WORKER-side chain, where a stale plain `encoder` entry beats
+or replaces the cell during cross-thread dispatch. So:
+
+### Step 0 (independent, highest value): find and fix the stale-plain-over-cell lane
+
+1. Repro: `tmp/h2rs-probe.raku` run via
+   `bash -c 'INC=$(cat tmp/cro-work/inc-paths.txt); target/debug/mutsu $INC tmp/h2rs-probe.raku'`
+   — deterministic. The `$pre`/`$probe` closures print `Encoder|<new>` from
+   mainline and `Encoder|<old>` from the tap thread.
+2. Use `rust-gdb -batch` (per CLAUDE.md; do NOT eprintln-rebuild): break on
+   the closure-dispatch captured-env merge (`vm_closure_dispatch.rs`,
+   `entry_or_insert_sym` / the overwrite branch for `ContainerRef` and
+   `authoritative_free_vars`), and on `sync_shared_vars_to_env` and
+   `set_env_with_main_alias_sym`, conditioned on the `encoder` key, in the
+   tap-dispatch thread. The question is purely control-flow ("who installs
+   the plain value / who skips the cell"), which gdb answers without
+   decoding NaN-boxed values.
+3. Candidate sites (ADR-0024 implementation notes points 5-7): the two
+   sites fixed via the mainline-map-specific `mainline_lexical_cell` lookup
+   (`assign_rw_target_expr`, `set_env_with_main_alias_sym`) must preserve
+   ANY `ContainerRef` env entry, not just mainline-map hits; point 6's fix
+   is already generic and is the model. Also audit
+   `sync_shared_vars_to_env`'s overlay direction: a plain store entry must
+   never overwrite a `ContainerRef` env entry for the same name (deref and
+   write INTO the cell, or skip).
+4. Acceptance: `http2-response-serializer.rakutest` passes fully (test 18
+   is its only remaining failure); pin a `t/` test if a Cro-free repro
+   falls out of the gdb session (the current Cro-free reduction does NOT
+   reproduce — the extra ingredient is in Cro's transformer internals, so
+   the pin may have to wait for the mechanism to be named).
+
+### Step 1: compiler — the `cell_captured_ref_slots` set
+
+Location: `compute_free_vars` in `src/opcode.rs` (~line 5085 already
+computes `own_container_writes` and `own_call_arg_sources`; the vouch set
+`authoritative_free_vars` is baked nearby).
+
+- New `CompiledCode` field `cell_captured_ref_slots: Vec<u32>` (slot
+  indices, mirroring `needs_cell_named_sub_ref_slots`; keep
+  `size_of::<OpCode>() <= 48` — this is a `CompiledCode` field, not an
+  OpCode payload, so the guard is unaffected, but check `opcode_size_guard`
+  anyway).
+- Contents: slots of plain-scalar OWN locals that are (a) captured by any
+  nested closure, and (b) NOT in `authoritative_free_vars`'s vouch set —
+  computed as `captured_mutated_locals ∪ (own_container_writes ∩ captured)
+  ∪ (own_call_arg_sources ∩ captured ∖ scalar_bind_locals)` per the ADR
+  (this is the exact complement of the authoritative set within the
+  captured set, so the dichotomy is exhaustive by construction).
+- Exclusions stay as in slice 1: `type_constrained_unboxable` (cas,
+  S17-lowlevel/cas.t), Package/Array/Hash/Sub/Proxy VALUE kinds are no
+  longer relevant at decl time (the seed at declaration is Any/initializer
+  result), but the `@`/`%`/`&` SIGIL lanes and Proxy remain out of scope.
+
+### Step 2: VM — box at declaration
+
+- Extend the existing consumption path: `vm_var_assign_set_local.rs`
+  (~lines 245-268) gates declaration-time boxing on
+  `needs_cell_named_sub_ref_slots`; add `cell_captured_ref_slots` to the
+  same gates so `box_decl_local_cell`
+  (`vm_var_assign_local_get.rs:316`) fires for these slots at their
+  declaration site.
+- `box_captured_lexicals` (`vm_register_ops.rs:819`) stays as the
+  no-op-when-already-cell backstop.
+- Watch the `self_capture_decl_locals` interaction: the "clear the stale
+  ContainerRef on redeclaration" step must keep its existing skip rules
+  (see the field docs in `opcode.rs`), and a loop redeclaration must still
+  get a FRESH cell per iteration (ADR-0023 fresh-binding provenance; pin
+  `t/for-loop-param-start-sibling-isolation.t`).
+
+### Step 3: perf gates (mandatory, in order — ADR-0025)
+
+1. Add a `MUTSU_VM_STATS` counter `decl_cell_boxes` (pattern:
+   `record_spawn_seeding` in `src/vm/vm_stats.rs`). Assert ≈0 across
+   `benchmarks/` in a DEBUG build (counters are optimization-independent
+   per CLAUDE.md).
+2. `roast/S32-num/int.t` wall-clock in a RELEASE build before pushing —
+   the #2749 blowup (~1s → 150s) is the named canary.
+3. Bench CI history (`git show origin/bench-data:bench-history.tsv`) is
+   the final verdict after merge.
+4. If the canary regresses: diagnose the cost source (per-iteration
+   redeclaration re-boxing vs env insert) — hoist boxing out of
+   per-iteration redeclaration or intern the cell in the declaration plan.
+   Do NOT re-add an escape/value-kind gate (correctness must not be
+   bounded by an incomplete analysis; CLAUDE.md gain/risk).
+
+### Step 4: tests / acceptance
+
+- New `t/` pin for the call-arg-stored closure shape
+  (`@registry.push($cb)` / `.tap($cb)` / ctor named-arg) reading a
+  creator-mutated scalar after rebind — the shape slice 2's set newly
+  covers.
+- The ADR's listed pins stay green: `t/closure-capture-instance-cell.t`,
+  `t/for-loop-param-start-sibling-isolation.t`,
+  `t/named-sub-lexical-scope.t`, the merge-site liveness example
+  (`my $s = 0; @cb.push({ $s }); $s = 42` must read 42).
+- End state (with step 0): `http2-response-serializer.rakutest` fully
+  green; re-run the loop-param repro from the (now-resolved) loop-param
+  ticket per the ADR's co-requisite note; Cro session files re-check waits
+  on `todo/tickets/http-session-tests-crash-rc139-on-main.md`.
+
+## What slice 2 does NOT cover (unchanged)
+
+- `http2-request-parser.rakutest` test 49 — aggregate (`%`) clobber via
+  nested-whenever registration, its own deep ticket
+  (`nested-whenever-registration-clobbers-sibling-event-aggregate-writes.md`).
+- Type/`where`-constrained scalars, `$`-held Array/Hash, `@`/`%`/`&`
+  rebinding staleness — ADR-0025 slice 3.

--- a/todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md
+++ b/todo/deep/closure-read-only-capture-loses-to-caller-env-same-name.md
@@ -31,19 +31,62 @@ notok 3 → **0**; `http2-response-serializer.rakutest` 3 → 1;
 
 ## Remaining work tracked here
 
-1. **`http2-response-serializer.rakutest` test 14** ("check 4" of
-   'Header + Data'): the `$encoder` cell now delivers the right object, so
-   the residual mismatch is elsewhere. Suspects: `@headers` liveness
-   through the capture (`@headers` is reassigned between blocks; `@` is
-   outside slice 1), or HPACK dynamic-table state trajectory (the test-side
-   encoder is warm from the previous block's check while the per-`test()`
-   serializer is cold). Needs shadow-bisect with byte-level comparison.
-2. **`http2-request-parser.rakutest` test 44** ("check 4" of
-   'Header1 + Header2 + Data1'): the failing check is
-   `*.body-blob.result eq $payload` — NOT the encoder family at all (the
-   old "DATA frame content mismatch" label was right for THIS file).
-   Suspects: cross-stream DATA demux (streams 3 and 5 interleave, stream 5
-   carries `$payload ~ $payload`) or `Buf`-capture. Independent diagnosis.
+0. **RESOLVED (PR #6238): the "test 14"/"test 44" labels were artifacts of a
+   TAP counter desync.** A thread spawned before the first test call never
+   shared the TAP counter (`TapState::clone_for_thread` only shares an
+   EXISTING `TestState`, created lazily by the first `ok`), so the first
+   tap's increments were lost and every subsequent test number shifted by
+   the first check batch — all three HTTP/2 files failed prove with "Tests
+   out of sequence" even where every assertion passed. Fixed; pin
+   `t/test-counter-spawn-before-first-test.t`. With correct numbering,
+   `http2-request-serializer.rakutest` passes COMPLETELY, and the two
+   residuals below are tests 18 and 49 respectively.
+1. **`http2-response-serializer.rakutest` test 18** ("check 4" of
+   'Header + Data - Content-Length unspecified', block 3 — NOT block 2, and
+   NOT `@headers`): re-diagnosed 2026-08-11 with byte-level probe
+   (`tmp/h2rs-probe.raku`). The captured `@headers` is correct (2 entries),
+   but the check closure computes `$encoder.encode-headers(@headers)` =
+   `88 BE` — an HPACK dynamic-table reference, meaning it used the OLD
+   warm encoder: WHICH-trace shows mainline holds the fresh
+   `Encoder|1068` (created line 74) while the tap-thread check — and a
+   `$probe = { $encoder.WHICH }` closure created right after the line-74
+   rebind and invoked from inside the check — both resolve `$encoder` to
+   the stale `|928`. Crucially, a `$pre = { $encoder.WHICH }` closure
+   created BEFORE the line-74 rebind sees the NEW object when invoked
+   from mainline — **the ContainerRef cell exists and mainline
+   write-through works** (slice 1 did its job; a plain snapshot would
+   show the old object in mainline too). The SAME `$pre` closure invoked
+   from the tap thread sees the old `|928`. So the defect is on the
+   worker-side resolution chain: a stale PLAIN `encoder` entry beats (or
+   replaced) the cell during cross-thread dispatch — exactly the
+   ADR-0025 "cross-thread audit rider" family
+   (`sync_shared_vars_to_env` / `set_env_with_main_alias_sym` /
+   spawn-seeding staleness). The spawn-seeding walk itself
+   (`clone_for_thread_excluding`) seeds the raw env value, which
+   preserves a cell, so the stale-plain lane is one of the other sites —
+   pinpoint with rust-gdb on `tmp/h2rs-probe.raku` (break on the
+   closure-dispatch merge and on `sync_shared_vars_to_env`, watch who
+   installs `encoder` in the tap thread's env). Note: a Cro-free
+   reduction (`tmp/tap-check-stale.raku`: named sub + supply/whenever
+   pass-through + tap + start-driven emit + rebind between calls) does
+   NOT reproduce — the missing ingredient is in Cro's transformer
+   internals (ConnectionState nested whenevers / `Supplier::Preserving`),
+   which may link this to the nested-whenever adoption bug in
+   `todo/deep/nested-whenever-registration-clobbers-sibling-event-aggregate-writes.md`.
+   **Fix-order implication: ADR-0025 slice 2's "cross-thread audit
+   rider" (generalize the cell-preserving rule to every
+   frame-independent assign/sync utility) is load-bearing for this file
+   and may be a smaller targeted fix than the full decl-site-cell set
+   extension.** The ADR's block-2/HPACK-trajectory and `@headers`
+   suspects are exonerated (probe shows `+@headers == 2`, correct).
+2. **`http2-request-parser.rakutest` test 49** ("check 4" of
+   'Header1 + Header2 + Data1 + Data2'): root-caused 2026-08-11 — NOT a
+   capture bug and NOT expected to be fixed by slice 2. A nested
+   `whenever` registered inside a `whenever` body makes a later sibling
+   event's `%streams{...}` write resolve to a stale forked container,
+   clobbering the supply block's hash; DATA frames are then demux-dropped.
+   Dependency-free 22-line repro + bisect matrix in
+   `todo/deep/nested-whenever-registration-clobbers-sibling-event-aggregate-writes.md`.
 3. **ADR-0025 slice 2** (escape verdict must stop being a correctness
    gate — decl-site cells for every vouch-refused captured scalar) and
    slice 3 follow-ups: design and gates are in the ADR; implementation

--- a/todo/deep/nested-whenever-registration-clobbers-sibling-event-aggregate-writes.md
+++ b/todo/deep/nested-whenever-registration-clobbers-sibling-event-aggregate-writes.md
@@ -1,0 +1,106 @@
+# Nested `whenever` registration makes a later sibling event's aggregate write clobber the supply block's hash
+
+Root cause of the sole remaining failure in the vendored Cro::HTTP
+`http2-request-parser.rakutest` (test 49, "check 4" of
+'Header1 + Header2 + Data1 + Data2') — and the reason HTTP/2 stream demux
+loses DATA frames.
+
+## Minimal repro (dependency-free, deterministic, single-threaded)
+
+`tmp/streams-hash-clobber.raku` (also inlined here). Note there is NO `start`
+block — everything runs on the main thread through the emit-driven tap path:
+
+```raku
+my $trigger = Supplier.new;
+my $done = Promise.new;
+my $s = supply {
+    my %streams;
+    whenever $trigger.Supply -> $sid {
+        unless %streams{$sid}:exists {
+            %streams{$sid} = "S$sid";
+            my $cancellation = Promise.new;
+            whenever $cancellation { note "cancelled" }   # <-- the poison
+        }
+        note "after write $sid: keys={%streams.keys.sort.join(',')}";
+        emit $sid;
+    }
+};
+$s.tap: -> $v { $done.keep if $v == 5 };
+$trigger.emit(3);
+$trigger.emit(5);
+await Promise.anyof($done, Promise.in(3));
+```
+
+raku: `after write 5: keys=3,5`. mutsu: `after write 5: keys=5` — the
+event-3 entry is gone.
+
+## Bisect matrix (all in `tmp/streams-hash-clobber*.raku`, raku-validated)
+
+| variant | shape | mutsu result |
+|---|---|---|
+| A (`...2`) | no nested `whenever` at all | correct (`3,5`) |
+| B (`...3`) | nested `whenever` every event, write BEFORE registration | broken (`5`) |
+| C (`...4`) | nested `whenever` only on event 3, write BEFORE registration | broken, and the smoking gun: event 5 **reads** `keys=3` at its start, then after its own `%streams{5} = ...` **reads back `keys=5`** |
+| D (`...5`) | nested `whenever` only on event 3, registration BEFORE the write | correct (`3,5`) |
+
+Variant C proves the corruption point precisely: within one callback
+invocation, consecutive statements see `{3}` (read) then `{5}` (after
+writing key 5). The indexed-assignment write resolved `%streams` to a
+DIFFERENT, stale container (one that predates event 3's write — i.e. the
+empty creation-time state), wrote into that fork, and installed it, after
+which reads follow the fork. At event end the fork is published, clobbering
+the live `{3}` container that the enclosing supply body (and the Cro DATA
+handler) uses.
+
+Variant D shows the fork's base tracks writes made BEFORE the registration
+in the same event — registering first and writing after stays consistent.
+So the stale base is captured/forked by the nested-whenever registration
+machinery, not by the write itself.
+
+## Where to look
+
+- `run_whenever_with_value` (`src/runtime/subtest.rs`): whenever callbacks
+  are built with `self.env.clone()` and `owned_lexicals` marked
+  authoritative (overwrite-install at dispatch). A nested `whenever`
+  registered mid-event goes through the
+  `!self.supply_emit_buffer.is_empty() || self.react_active > 0` branch or
+  the dispatch-time group-join path below it.
+- The emit-driven tap dispatch (`native_supply_mut_methods.rs`,
+  `call_supply_tap` family) — how the outer callback's env is installed per
+  event, and what changes about that installation once a nested marker has
+  been adopted (variant A vs B/C differ only in that adoption).
+- The aggregate name lane: `%`-sigil containers are reference-shared
+  (writes normally hit the one shared `HashData` in place via
+  `arc_contents_mut`), so the observed divergence means the name got
+  REBOUND to a forked container somewhere in the adoption path, not that a
+  COW write missed.
+
+## Cro mapping
+
+`Cro::HTTP2::GeneralParser.transformer` registers `whenever $cancellation`
+inside the `when Cro::HTTP2::Frame::Headers` branch, after writing
+`%streams{$curr-sid} = Stream.new(...)` — exactly variant C. Instrumented
+run (shadow copy of GeneralParser) shows: HEADERS(5) reads
+`known-before=3`, writes, and the hash becomes `{5}`; the subsequent
+DATA(3) frame finds no stream and is silently dropped (`if $stream` guard),
+so request 0's body promise never resolves; stream 5's Stream object in the
+forked hash is disconnected from the one whose body supply the emitted
+request actually holds, so its 246-byte DATA emit is lost too and the body
+resolves empty (`body-len=0`; raku: 123/246). Probe:
+`tmp/h2rp-probe.raku` + instrumented shadow recipe in
+`tmp/shadow/lib/Cro/HTTP2/GeneralParser.rakumod` (rebuild from the vendored
+original + the DBG notes if the shadow was cleaned).
+
+Note: `@`/`%` aggregates are explicitly OUT of ADR-0025 slice 1/2 scope
+(the cell campaign covers plain `$` scalars), so this is not expected to be
+fixed by slice 2 — it is its own dispatch/env-provenance bug in the
+supply/whenever machinery, closest in spirit to ADR-0023 binding
+provenance and the ADR-0010 lane rules.
+
+## Acceptance
+
+- The four repro variants match raku.
+- `http2-request-parser.rakutest` passes fully (with the TAP-counter fix
+  from PR #6238 already in, test 49 is the only remaining failure).
+- Watch `http2-response-parser.rakutest` too — same GeneralParser code path
+  drives it.


### PR DESCRIPTION
Docs-only PR from the 2026-08-11 Cro shadow-bisect session (companion to #6238, which fixed the TAP counter desync).

## Contents

1. **New deep ticket** `todo/deep/nested-whenever-registration-clobbers-sibling-event-aggregate-writes.md`: root cause of `http2-request-parser.rakutest` test 49. A nested `whenever` registered inside a `whenever` body makes a later sibling event's `%streams{...}` write resolve to a stale forked container, clobbering the supply block's hash — HTTP/2 DATA frames are then demux-dropped. Dependency-free, single-threaded 22-line repro + 4-variant bisect matrix (variant C shows a read of `{3}` followed immediately by a write producing `{5}` within one callback invocation).

2. **Parent ticket update** (`closure-read-only-capture-loses-to-caller-env-same-name.md`): the old "test 14/44" labels were TAP-desync artifacts; `http2-response-serializer.rakutest` test 18 re-diagnosed with WHICH-traces — the ContainerRef cell EXISTS and mainline write-through works; the failure is a stale plain entry beating the cell on the worker-side chain (the ADR-0025 cross-thread rider family). `@headers` and HPACK-trajectory suspects exonerated.

3. **New deep ticket** `todo/deep/adr0025-slice2-implementation-plan.md`: Sonnet-implementable step-by-step plan for ADR-0025 slice 2, reordered rider-first per the new evidence, with file/function names, perf gates (decl_cell_boxes counter, int.t canary, bench CI), and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)