### PR TITLE
refactor(vm): ADR-0019 E5 step 2 -- measurement counters for CallMethodDynamic

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2814,6 +2814,37 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   smaller. This is ONE slice — the box stays open: the remaining E5 measurement
   entries (`CallMethodDynamic`, hyper non-mut paths, `call_method_all_with_fallback`)
   and all cutover sub-slices (E5b/E5c/E5d) are still to do.
+  **Progress 2026-08-11** (E5 step 2, measurement slice for `CallMethodDynamic`):
+  instrumented `exec_call_method_dynamic_op`
+  (`src/vm/vm_call_method_mut_ops.rs:30-345`) with the same two step-1 counter
+  functions, `entry = "callmethoddynamic"` — no new counter functions added.
+  15 intercept arm names (`modifier-plus`/`modifier-star`, `call-sub-value`
+  for `$obj.$coderef(...)`, `return`, `hyper-race-config`, 9 HyperSeq/RaceSeq
+  delegate arms), plus `native`/`user` at the plain probe and `notfound` as the
+  same documented overlay-of-`user` pattern step 1 used. No `accessor` outcome
+  exists at this entry (no fast 0-arg accessor probe here). Pure insertions (70
+  insertions / 1 rewrap of an unchanged single-statement match arm, 0 behavior
+  change). Re-checked the design doc's inventory-correction item 3 ("no native
+  probe and no compiled-method probe gap") against current code: that item is
+  actually about the *Mut* twin (`exec_call_method_dynamic_mut_op`,
+  `CallMethodDynamicMut`, an E6 entry) — `exec_call_method_dynamic_op` itself
+  has both probes, so the design doc's framing for this entry was correct,
+  nothing stale. Verification used 5 targeted `t/` files (of 161 candidates
+  matching dynamic-call syntax or filename) rather than a full sweep — this
+  entry is far lower-traffic than `CallMethod`, so a handful of files sufficed
+  for a clean disjoint-and-complete proof: `array-value-path-mutation.t`
+  (`user=8` of 8), `buf-write-native.t` (`native=5` of 5),
+  `dynamic-method-type-object.t` (`native=3`+`user=1` of 4, overlay
+  `notfound=1`), `format-class.t` (`user=11` of 11), `topic-quoted-method-call.t`
+  (`native=1` of 1) — all five `sum(disjoint outcomes) == CallMethodDynamic`
+  opcode-histogram count, 0 mismatches. No intercept-arm traffic was observed in
+  this targeted set; a full `t/` + whitelisted-roast sweep (CI-scale, as step 1
+  ran) is deferred as out of proportion for this smaller entry. Full taxonomy
+  table and verification detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results —
+  CallMethodDynamic (E5 step 2)". Still to do: the hyper non-mut paths and
+  `call_method_all_with_fallback` measurement slices, and all cutover
+  sub-slices (E5b/E5c/E5d).
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/news/2026-08/adr0019-e5-step2-callmethoddynamic-measurement.md
+++ b/news/2026-08/adr0019-e5-step2-callmethoddynamic-measurement.md
@@ -1,0 +1,30 @@
+# ADR-0019 E5 step 2: measurement counters for CallMethodDynamic
+
+Instrumented `exec_call_method_dynamic_op` (the `CallMethodDynamic` opcode
+handler, `src/vm/vm_call_method_mut_ops.rs`) with the `MUTSU_VM_STATS`-gated
+dispatch-entry counters introduced by E5 step 1 for `CallMethod`
+(`record_dispatch_entry_outcome`/`record_dispatch_entry_intercept` in
+`src/vm/vm_stats.rs`). This is the second of the E5 measurement slices for
+ADR-0019 Phase E (routing VM method-call opcodes through the resolver):
+pure insertions, zero behavior change, reusing the same two generic counter
+functions with `entry = "callmethoddynamic"` rather than adding new ones.
+
+15 intercept arm names were classified and instrumented (the `.+`/`.*`
+all-methods modifiers, `$obj.$coderef(...)` direct-Sub dispatch, `.return`,
+`.hyper`/`.race` config validation, and nine HyperSeq/RaceSeq delegate-method
+arms), plus `native`/`user` outcomes at the plain dispatch probe and a
+`notfound` overlay matching step 1's convention. Verified disjoint-and-complete
+(`sum(outcomes) == CallMethodDynamic` opcode-histogram count) against five
+targeted `t/` files with zero mismatches — this entry sees far less traffic
+than `CallMethod`, so a full `t/`-wide sweep was not run, per the task's own
+guidance not to over-invest in sweep tooling for a smaller entry.
+
+This is one slice of an ongoing campaign, not a standalone feature: the
+remaining E5 measurement entries (hyper non-mut paths,
+`call_method_all_with_fallback`) and all cutover sub-slices (E5b/E5c/E5d) that
+actually route dispatch through the resolver are still to do. Full taxonomy
+table and verification detail:
+`todo/deep/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
+CallMethodDynamic (E5 step 2)") and
+`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (E5
+bullet).

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -69,11 +69,19 @@ impl Interpreter {
         // Handle .* and .+ modifiers
         match modifier {
             Some("+") => {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethoddynamic",
+                    "modifier-plus",
+                );
                 let vals = self.call_method_all_with_fallback(&target, &method, &args, false)?;
                 self.stack.push(Value::array(vals));
                 return Ok(());
             }
             Some("*") => {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethoddynamic",
+                    "modifier-star",
+                );
                 match self.call_method_all_with_fallback(&target, &method, &args, false) {
                     Ok(vals) => self.stack.push(Value::array(vals)),
                     Err(e) if Self::is_method_not_found_error(&e) => {
@@ -89,6 +97,10 @@ impl Interpreter {
             name_val.view(),
             ValueView::Sub(_) | ValueView::WeakSub(_) | ValueView::Routine { .. }
         ) {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethoddynamic",
+                "call-sub-value",
+            );
             let mut call_args = Vec::with_capacity(args.len() + 1);
             call_args.push(Self::invocant_as_positional(target));
             call_args.extend(args);
@@ -97,12 +109,17 @@ impl Interpreter {
             let method = Self::dynamic_method_name(&name_val);
             // .return method: triggers a return from the enclosing sub
             if method == "return" && args.is_empty() {
+                crate::vm::vm_stats::record_dispatch_entry_intercept("callmethoddynamic", "return");
                 let mut err = RuntimeError::new("return");
                 err.return_value = Some(target);
                 return Err(err);
             }
             // .hyper/.race with named arguments: validate, then create HyperSeq/RaceSeq
             if matches!(method.as_str(), "hyper" | "race") {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethoddynamic",
+                    "hyper-race-config",
+                );
                 // Extract batch/degree for validation
                 let mut batch: Option<i64> = None;
                 let mut degree: Option<i64> = None;
@@ -175,14 +192,26 @@ impl Interpreter {
                 };
                 match method.as_str() {
                     "hyper" => {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethoddynamic",
+                            "hyperseq-hyper",
+                        );
                         self.stack.push(Value::hyper_seq_arc(items_arc));
                         return Ok(());
                     }
                     "race" => {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethoddynamic",
+                            "hyperseq-race",
+                        );
                         self.stack.push(Value::race_seq_arc(items_arc));
                         return Ok(());
                     }
                     "is-lazy" => {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethoddynamic",
+                            "hyperseq-is-lazy",
+                        );
                         self.stack.push(Value::FALSE);
                         return Ok(());
                     }
@@ -190,6 +219,10 @@ impl Interpreter {
                         // `HyperSeq.configuration` — expose the `.batch`/`.degree`
                         // the sequence was hyperized with (defaults otherwise).
                         // Used by the `hyperize` dist.
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethoddynamic",
+                            "hyperseq-configuration",
+                        );
                         let (batch, degree) =
                             crate::value::hyper_config_get(&items_arc).unwrap_or((None, None));
                         self.stack
@@ -197,12 +230,20 @@ impl Interpreter {
                         return Ok(());
                     }
                     "^name" => {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethoddynamic",
+                            "hyperseq-name",
+                        );
                         self.stack.push(Value::str(
                             if is_hyper { "HyperSeq" } else { "RaceSeq" }.to_string(),
                         ));
                         return Ok(());
                     }
                     "WHAT" => {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethoddynamic",
+                            "hyperseq-what",
+                        );
                         self.stack.push(Value::package(Symbol::intern(if is_hyper {
                             "HyperSeq"
                         } else {
@@ -211,10 +252,18 @@ impl Interpreter {
                         return Ok(());
                     }
                     "defined" => {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethoddynamic",
+                            "hyperseq-defined",
+                        );
                         self.stack.push(Value::TRUE);
                         return Ok(());
                     }
                     "map" | "grep" => {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethoddynamic",
+                            "hyperseq-map-grep",
+                        );
                         let array_target = Value::array_with_kind(
                             crate::value::Value::array_arc(items_arc.to_vec()),
                             crate::value::ArrayKind::List,
@@ -238,6 +287,10 @@ impl Interpreter {
                     }
                     _ => {
                         // Convert to array and delegate
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethoddynamic",
+                            "hyperseq-delegate",
+                        );
                         let array_target = Value::array_with_kind(
                             crate::value::Value::array_arc(items_arc.to_vec()),
                             crate::value::ArrayKind::List,
@@ -257,18 +310,34 @@ impl Interpreter {
             if let Some(native_result) =
                 self.try_native_method(&target, Symbol::intern(&method), &args)
             {
+                crate::vm::vm_stats::record_dispatch_entry_outcome("callmethoddynamic", "native");
                 native_result
             } else {
+                crate::vm::vm_stats::record_dispatch_entry_outcome("callmethoddynamic", "user");
                 self.try_compiled_method_or_interpret(target, &method, args)
             }
         };
         match modifier {
             Some("?") => match call_result {
                 Ok(val) => self.stack.push(val),
-                Err(e) if Self::is_method_not_found_error(&e) => self.stack.push(Value::NIL),
+                Err(e) if Self::is_method_not_found_error(&e) => {
+                    crate::vm::vm_stats::record_dispatch_entry_outcome(
+                        "callmethoddynamic",
+                        "notfound",
+                    );
+                    self.stack.push(Value::NIL)
+                }
                 Err(e) => return Err(e),
             },
             _ => {
+                if let Err(e) = &call_result
+                    && Self::is_method_not_found_error(e)
+                {
+                    crate::vm::vm_stats::record_dispatch_entry_outcome(
+                        "callmethoddynamic",
+                        "notfound",
+                    );
+                }
                 self.stack.push(call_result?);
             }
         }

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -296,3 +296,77 @@ Zero-count arms (18): `nativecall`, `exception-str-message`,
 receivers route the same shapes through `CallMethodMut`, and this sweep covered
 `t/` plus only three roast directories, not the whole whitelist. Re-run the sweep
 over whitelisted roast (CI-scale) before proposing any arm removal.
+
+### Measurement slice results — CallMethodDynamic (E5 step 2)
+
+Landed 2026-08-11: instruments the second E5 measurement entry named in step 1's
+"still to do" list, `exec_call_method_dynamic_op`
+(`src/vm/vm_call_method_mut_ops.rs:30-345`, current revision — grew from the
+~250-line estimate in the corrected entry inventory to ~315 lines purely from
+this slice's own insertions). Reuses the exact same two generic functions step 1
+added (`record_dispatch_entry_outcome`, `record_dispatch_entry_intercept`) with
+`entry = "callmethoddynamic"` — no new counter functions. Pure insertions only:
+the diff is 70 insertions / 1 "deletion", and that one line is a single-statement
+match arm (`Err(e) if is_method_not_found_error(&e) => self.stack.push(Value::NIL)`)
+rewrapped in braces so a counter call could precede the identical push — no
+branch, condition, or return value changed.
+
+Re-verifying the design doc's inventory-correction note (item 3) against the
+current code: that note is about `exec_call_method_dynamic_mut_op` (the *Mut*
+twin, `CallMethodDynamicMut`, a separate E6 entry, out of scope here), not this
+one. `exec_call_method_dynamic_op` itself does have both a native probe and a
+compiled/interpret fallthrough (:310-318) — the design doc's "no native probe
+and no compiled-method probe gap" framing for this entry is correct as written;
+nothing was stale.
+
+Taxonomy table (line numbers as of this PR's revision; anchor is each
+`record_dispatch_entry_*` call site):
+
+| Line range | Class | Arm name / description | Counter key | Notes |
+|---|---|---|---|---|
+| ~30-56 | — | entry bookkeeping (arg decode, flatten, stack pops) | (none) | stack-underflow errors uninstrumented: internal errors, not dispatch outcomes |
+| ~57-68 | a | LazyIoLines force | (none) | |
+| ~70-94 | b | `.+`/`.*` all-methods modifiers | `callmethoddynamic:modifier-plus` / `callmethoddynamic:modifier-star` | delegates to `call_method_all_with_fallback` (its own E5 measurement entry, later slice); `.*`'s not-found→empty-list completion is covered by this arm, not `notfound`, matching CallMethod's own convention |
+| ~96-107 | b | name-value is a `Sub`/`WeakSub`/`Routine` (`$obj.$coderef(...)`) — invocant bound positionally, dispatched via `vm_call_on_value` | `callmethoddynamic:call-sub-value` | unique to this entry: `CallMethod`'s name is always a literal identifier, never a callable value |
+| ~111-116 | b | `.return` control flow | `callmethoddynamic:return` | |
+| ~118-182 | b | `.hyper`/`.race` with named-arg validation, creates HyperSeq/RaceSeq | `callmethoddynamic:hyper-race-config` | branch-entry record also covers the two X::Invalid::Value completions, matching CallMethod's convention |
+| ~184-192 | a | HyperSeq/RaceSeq receiver unwrap (`is_hyper`, `items_arc`) | (none) | normalization only, no completion |
+| ~193-308 | b | HyperSeq/RaceSeq delegate-method dispatch (9 arms) | `callmethoddynamic:hyperseq-{hyper,race,is-lazy,configuration,name,what,defined,map-grep,delegate}` | `map-grep` and the catch-all `delegate` arm each wrap their own inner native/compiled probe, but per CallMethod's own `hyperseq-map-grep` convention the arm name is the single count — no additional `native`/`user` recorded inside |
+| ~310-318 | c | plain native probe + compiled/interpret fallthrough | `callmethoddynamic:native` / `callmethoddynamic:user` | `user` includes calls that later fail with X::Method::NotFound (see overlay note below) |
+| ~320-343 | c | not-found completions (`.?` Nil absorb; propagated-Err peek) | `callmethoddynamic:notfound` | overlay subset of `user`, same pattern as CallMethod |
+| ~344 | d | (none — no writeback tail at this entry; the result is pushed inline at each completion point) | (none) | this entry has no separate writeback-tail region distinct from its outcome completions, unlike `CallMethod`'s dedicated tail (`drain_and_reconcile_after_cached_call`) |
+
+Counting semantics mirror CallMethod exactly: each executed `CallMethodDynamic`
+records exactly one of `intercept`/`native`/`user` (no `accessor` outcome exists
+at this entry — there is no fast 0-arg public-accessor read probe here, only at
+`CallMethod`). `notfound` is an overlay subset of `user`. Disjoint total =
+`intercept + native + user`.
+
+Verification (debug build, targeted files rather than a full `t/` sweep — this
+entry is far smaller-traffic than `CallMethod` and a handful of files gave a
+clean disjoint-sum proof quickly, so the full multi-process `t/`-wide sweep
+infrastructure from step 1 was not reused, per the task's own guidance not to
+over-invest): ran every `t/*.t` file matching `.$name`/`."$name"` dynamic-call
+syntax or a `dynamic`/`dispatch`/`indirect`/`hyper`/`proxy` filename (161
+candidates). 5 files actually exercised `CallMethodDynamic` (most `.$name`/`."$"`
+call sites on a plain variable receiver compile to `CallMethodDynamicMut`
+instead — the same "bareword/variable receiver picks the Mut opcode" pattern
+CallMethod's own sweep documented). All 5 are disjoint-and-complete
+(`sum(intercept+native+user) == CallMethodDynamic` opcode-histogram count):
+
+| File | CallMethodDynamic (opcode histogram) | Outcome sum | Detail |
+|---|---|---|---|
+| `t/array-value-path-mutation.t` | 8 | 8 | `user=8` |
+| `t/buf-write-native.t` | 5 | 5 | `native=5` |
+| `t/dynamic-method-type-object.t` | 4 | 4 | `native=3`, `user=1` (overlay `notfound=1`) |
+| `t/format-class.t` | 11 | 11 | `user=11` |
+| `t/topic-quoted-method-call.t` | 1 | 1 | `native=1` |
+
+No intercept-arm traffic was observed in this targeted set (`.$coderef(...)`,
+`.hyper`/`.race`, HyperSeq/RaceSeq delegation, and the `.*`/`.+` modifiers were
+not exercised by these particular files) — those arms remain unmeasured until a
+broader sweep (full `t/` + whitelisted roast, CI-scale, as step 1 ran) is done.
+This is a smaller/simpler entry than `CallMethod` so that broader sweep is
+deferred rather than run locally; the box stays open regardless — the remaining
+E5 measurement entries (hyper non-mut paths, `call_method_all_with_fallback`)
+and all cutover sub-slices (E5b/E5c/E5d) are still to do.


### PR DESCRIPTION
## Summary

- Second E5 measurement slice (ADR-0019 Phase E, "route ordinary VM method calls through the resolver"): instruments `exec_call_method_dynamic_op` (the `CallMethodDynamic` opcode handler, `src/vm/vm_call_method_mut_ops.rs`) with the `MUTSU_VM_STATS`-gated dispatch-entry counters E5 step 1 (#6234) added for `CallMethod` -- reusing the same two generic functions (`record_dispatch_entry_outcome`/`record_dispatch_entry_intercept`) with `entry = "callmethoddynamic"`, no new counter functions.
- 15 intercept arm names classified and instrumented (`.+`/`.*` all-methods modifiers, `$obj.$coderef(...)` direct-Sub dispatch, `.return`, `.hyper`/`.race` config validation, nine HyperSeq/RaceSeq delegate-method arms), plus `native`/`user` outcomes at the plain dispatch probe and a `notfound` overlay of `user` matching step 1's convention.
- Pure insertions only: 0 behavior change, no branch/condition/return-value changes (the one non-insertion line is a single-statement match arm rewrapped in braces so a counter call could precede the identical push).
- **This is measurement-only. No dispatch-routing behavior change.** The E5 box stays open -- cutover sub-slices (E5b/E5c/E5d) and the remaining measurement entries (hyper non-mut paths, `call_method_all_with_fallback`) are still to do.

Full taxonomy table and verification detail: `todo/deep/adr0019-e5-e7-entry-routing.md` (new "Measurement slice results -- CallMethodDynamic (E5 step 2)" section). ADR progress note added to `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`'s E5 bullet.

## Verification

Ran a targeted `t/` sweep (161 candidate files matching `.$name`/`."$name"` dynamic-call syntax or a `dynamic`/`dispatch`/`indirect`/`hyper`/`proxy` filename) rather than the full `t/`-wide multi-process sweep step 1 built, since this entry is much lower-traffic -- a handful of files gave a clean disjoint-and-complete proof:

| File | CallMethodDynamic (opcode histogram) | Outcome sum | Detail |
|---|---|---|---|
| `t/array-value-path-mutation.t` | 8 | 8 | `user=8` |
| `t/buf-write-native.t` | 5 | 5 | `native=5` |
| `t/dynamic-method-type-object.t` | 4 | 4 | `native=3`, `user=1` (overlay `notfound=1`) |
| `t/format-class.t` | 11 | 11 | `user=11` |
| `t/topic-quoted-method-call.t` | 1 | 1 | `native=1` |

All five: `sum(disjoint outcomes) == CallMethodDynamic` opcode-histogram count, 0 mismatches.

## Test plan

- [x] `cargo build`
- [x] `cargo test --lib` (779 passed)
- [x] `cargo clippy -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `make test` (local TAP suite, debug binary): 3016 files, 28253 tests, `Result: PASS`, 0 failures
- [ ] CI (`make test` + `make roast`) -- watching in background
- Skipped a targeted roast subset for dynamic dispatch: no obviously-relevant whitelisted S12/S02 file was identified quickly, and this is instrumentation-only (per E5 step 1's own precedent, which also skipped a local roast run) -- CI's full `make roast` covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)