### PR TITLE
refactor(vm): ADR-0019 E5 step 3 -- measurement counters for the hyper non-mut paths

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2845,6 +2845,40 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   CallMethodDynamic (E5 step 2)". Still to do: the hyper non-mut paths and
   `call_method_all_with_fallback` measurement slices, and all cutover
   sub-slices (E5b/E5c/E5d).
+  **Progress 2026-08-11** (E5 step 3, measurement slice for the hyper
+  non-mut paths): instrumented `exec_hyper_method_call_op`
+  (`HyperMethodCall`, entry `hypermethodcall`) and
+  `exec_hyper_method_call_dynamic_op` (`HyperMethodCallDynamic`, entry
+  `hypermethodcalldynamic`), both in `src/vm/vm_hyper_method_ops.rs`, with
+  the same step-1 counter functions — no new counter functions. Pure
+  insertions, zero behavior change; `make test` (3018 files, 28265
+  subtests) unchanged. Unlike `CallMethod`/`CallMethodDynamic`, a hyper
+  opcode loops over every target element and dispatches once per element
+  (design decision 4's "per-element probe"), so the verification identity
+  here is element-level plausibility, not `sum(outcomes) ==
+  opcode-histogram count` — confirmed directly that outcome sums exceed
+  opcode counts on multi-element targets (`t/hyper-nested-itemize.t`: 12
+  `HyperMethodCall` opcodes, 18 recorded outcomes). Full `t/` sweep (3018
+  files, 50 hyper-active): `hypermethodcall` disjoint element dispatches
+  `native=575`/`user=191`/`intercept=99` (native/user dominate ~75%/25%,
+  same ordering conclusion as step 1 — E5c's plain-probe conversion is the
+  highest-value single change); `hypermethodcalldynamic` recorded only
+  `intercept=65` (mostly `callable-descend`/`callable-nodal`, i.e.
+  `>>.&sub`) and **zero** `native`/`user` locally — real bug-adjacent
+  finding, not dead code: `t/` never exercises `».method`/`».$name(...)`
+  the string-dispatch branch, but three whitelisted roast files do, and
+  running two directly confirmed real traffic (`roast/S03-metaops/hyper.t`
+  `native=8`, `roast/S12-methods/parallel-dispatch.t` `user=12`, both still
+  all-`ok`). Also re-confirmed inventory correction 4 from the design
+  doc's "Facts that shape the cutover": `exec_hyper_method_call_dynamic_op`
+  genuinely has no `skip_native`/`has_user_method` gate anywhere, unlike
+  its static twin — V1 (raku-verify this gap) is still open, to be closed
+  by the E6/E5c cutover per the doc. Full taxonomy tables (both entries,
+  classes a-d) and the sweep detail are in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results —
+  hyper non-mut paths (E5 step 3)". Still to do: the
+  `call_method_all_with_fallback` measurement slice (the last of the four),
+  then E5b/E5c/E5d cutovers.
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/news/2026-08/adr0019-e5-step3-hyper-measurement.md
+++ b/news/2026-08/adr0019-e5-step3-hyper-measurement.md
@@ -1,0 +1,40 @@
+# ADR-0019 E5 step 3: measurement counters for the hyper non-mut paths
+
+Instrumented `exec_hyper_method_call_op` (`HyperMethodCall`) and
+`exec_hyper_method_call_dynamic_op` (`HyperMethodCallDynamic`), both in
+`src/vm/vm_hyper_method_ops.rs`, with the same `MUTSU_VM_STATS`-gated
+dispatch-entry counters E5 step 1 introduced for `CallMethod`. This is the
+third of the four E5 measurement slices for ADR-0019 Phase E (routing VM
+method-call opcodes through the resolver): pure insertions, zero behavior
+change, reusing the same two generic counter functions with
+`entry = "hypermethodcall"` / `"hypermethodcalldynamic"`.
+
+Unlike `CallMethod`/`CallMethodDynamic`, a hyper opcode loops over every
+element of its target and dispatches once per element, so the outcome sum
+here counts element-level dispatches rather than opcode executions — a hyper
+over a multi-element array legitimately records more outcomes than the
+opcode ran. This was confirmed directly and is documented as the expected
+verification identity for this pair of entries, distinct from step 1/2's
+`sum(outcomes) == opcode-histogram count` check.
+
+A full `t/` sweep (3018 files, 50 hyper-active) shows `hypermethodcall`
+dominated by `native`/`user` (575/191, ~75%/25% of its disjoint element
+dispatches, same conclusion as step 1). `hypermethodcalldynamic` recorded
+intercept traffic only (`>>.&sub` forms) and zero `native`/`user` locally —
+not dead code, just missing local coverage: two whitelisted roast files
+(`S03-metaops/hyper.t`, `S12-methods/parallel-dispatch.t`) exercise the
+`».method`/`».$name(...)` string-dispatch branch directly and confirm real
+`native`/`user` traffic there. Also re-confirmed a real behavior gap named
+in the design doc: `exec_hyper_method_call_dynamic_op` has no
+`skip_native`/`has_user_method` gate anywhere, unlike its static twin — an
+open verification item for the eventual E5c/E6 cutover, not something this
+slice changes.
+
+`make test` (full `t/`, 3018 files, 28265 subtests) passes unchanged. This is
+one slice of an ongoing campaign: the last E5 measurement entry
+(`call_method_all_with_fallback`) and all cutover sub-slices
+(E5b/E5c/E5d) are still to do. Full taxonomy tables and sweep detail:
+`todo/deep/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
+hyper non-mut paths (E5 step 3)") and
+`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (E5
+bullet).

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -479,6 +479,10 @@ impl Interpreter {
         // target is not consumed. `.WHICH`/`.WHY`/`.VAR` *are* ordinary methods
         // and do hyper, so they are deliberately absent here.
         if arity == 0 && !quoted && Self::is_target_level_introspector(method_raw) {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "hypermethodcall",
+                "target-introspector",
+            );
             let (result, _) =
                 self.call_method_mut_with_temp_target(&target, method_raw, vec![], 0)?;
             self.stack.push(result);
@@ -499,6 +503,10 @@ impl Interpreter {
                 ValueView::Bag(..) | ValueView::Mix(..) | ValueView::Set(..)
             )
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "hypermethodcall",
+                "quant-postfix",
+            );
             return self.exec_hyper_quant_postfix(
                 code,
                 &target,
@@ -571,6 +579,7 @@ impl Interpreter {
                         | ValueView::Mixin(..)
                 )
             {
+                crate::vm::vm_stats::record_dispatch_entry_intercept("hypermethodcall", "call-me");
                 let val = self.vm_call_on_value(item.clone(), args.clone(), None)?;
                 results.push(val);
                 continue;
@@ -581,6 +590,10 @@ impl Interpreter {
             if method.starts_with("postfix:<")
                 && !matches!(method.as_str(), "postfix:<++>" | "postfix:<-->")
             {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "hypermethodcall",
+                    "user-postfix-op",
+                );
                 let mut call_args = vec![item.clone()];
                 call_args.extend(args.clone());
                 let empty_fns = CompiledFns::default();
@@ -597,6 +610,10 @@ impl Interpreter {
             if matches!(method.as_str(), "postfix:<++>" | "postfix:<-->")
                 && let ValueView::ContainerRef(cell) = item.view()
             {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "hypermethodcall",
+                    "containerref-postfix",
+                );
                 let inner = cell.lock().unwrap().clone();
                 let new_val = if method == "postfix:<++>" {
                     self.increment_value_smart(&inner)?
@@ -658,8 +675,16 @@ impl Interpreter {
                         if let Some(native_result) =
                             self.try_native_method(item, Symbol::intern(&method), &item_args)
                         {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "hypermethodcall",
+                                "native",
+                            );
                             native_result.unwrap_or(Value::package(Symbol::intern("Any")))
                         } else {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "hypermethodcall",
+                                "user",
+                            );
                             match self
                                 .call_method_mut_with_temp_target(item, &method, item_args, idx)
                             {
@@ -671,6 +696,10 @@ impl Interpreter {
                             }
                         }
                     } else {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcall",
+                            "user",
+                        );
                         match self.call_method_mut_with_temp_target(item, &method, item_args, idx) {
                             Ok((v, updated)) => {
                                 *item = updated;
@@ -686,18 +715,30 @@ impl Interpreter {
                         if let Some(native_result) =
                             self.try_native_method(item, Symbol::intern(&method), &item_args)
                         {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "hypermethodcall",
+                                "native",
+                            );
                             // One result per MRO level defining the method
                             // (builtin-MRO all-candidates; hyper `».+`).
                             let r = native_result?;
                             let count = self.builtin_mro_method_candidate_count(item, &method);
                             vec![r; count]
                         } else {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "hypermethodcall",
+                                "user",
+                            );
                             let (v, updated) = self
                                 .call_method_all_with_temp_target(item, &method, item_args, idx)?;
                             *item = updated;
                             v
                         }
                     } else {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcall",
+                            "user",
+                        );
                         let (v, updated) =
                             self.call_method_all_with_temp_target(item, &method, item_args, idx)?;
                         *item = updated;
@@ -711,6 +752,10 @@ impl Interpreter {
                         && let Some(native_result) =
                             self.try_native_method(item, Symbol::intern(&method), &item_args)
                     {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcall",
+                            "native",
+                        );
                         match native_result {
                             Ok(v) => {
                                 let count = self.builtin_mro_method_candidate_count(item, &method);
@@ -719,6 +764,10 @@ impl Interpreter {
                             Err(_) => results.push(Value::array(vec![])),
                         }
                     } else {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcall",
+                            "user",
+                        );
                         match self.call_method_all_with_temp_target(item, &method, item_args, idx) {
                             Ok((vals, updated)) => {
                                 *item = updated;
@@ -737,6 +786,10 @@ impl Interpreter {
                     // `%h>>.{1,2}`): apply the postcircumfix subscript to each
                     // element (which slices) rather than the single-key accessor
                     // method (which returns Nil for a Range/list key).
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "hypermethodcall",
+                        "subscript-slice",
+                    );
                     let is_positional = method == "AT-POS";
                     self.stack.push(item.clone());
                     self.stack.push(item_args[0].clone());
@@ -771,6 +824,10 @@ impl Interpreter {
                         method_is_nodal = true;
                     }
                     if is_iterable_item && !is_list_native_method {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "hypermethodcall",
+                            "descend-recursive",
+                        );
                         // Hyper methods descend recursively through nested
                         // Iterables (and Hash values) down to the leaves, and
                         // any in-place leaf mutation (e.g. `@a>>++` on nested
@@ -794,12 +851,20 @@ impl Interpreter {
                         // leaf raised "No such method 'ast' for ... 'Any'", which
                         // silently aborted grammar action methods doing
                         // `@<op>».ast` over an absent capture (99problems P47).
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "hypermethodcall",
+                            "nil-absorb",
+                        );
                         results.push(Value::NIL);
                     } else {
                         let val = if !skip_native {
                             if let Some(native_result) =
                                 self.try_native_method(item, Symbol::intern(&method), &item_args)
                             {
+                                crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                    "hypermethodcall",
+                                    "native",
+                                );
                                 match native_result {
                                     Ok(v) => v,
                                     // Resumable warn from a per-element native
@@ -815,6 +880,10 @@ impl Interpreter {
                                     Err(e) => return Err(e),
                                 }
                             } else {
+                                crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                    "hypermethodcall",
+                                    "user",
+                                );
                                 let (v, updated) = self.call_method_mut_with_temp_target(
                                     item, &method, item_args, idx,
                                 )?;
@@ -822,6 +891,10 @@ impl Interpreter {
                                 v
                             }
                         } else {
+                            crate::vm::vm_stats::record_dispatch_entry_outcome(
+                                "hypermethodcall",
+                                "user",
+                            );
                             let (v, updated) = self
                                 .call_method_mut_with_temp_target(item, &method, item_args, idx)?;
                             *item = updated;
@@ -1197,6 +1270,10 @@ impl Interpreter {
                 };
                 let callable_is_nodal = is_nodal_list_method(&callable_name);
                 if callable_is_nodal {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "hypermethodcalldynamic",
+                        "callable-nodal",
+                    );
                     // Node level: apply the callable to each top-level element.
                     let mut call_args = Vec::with_capacity(item_args.len() + 1);
                     call_args.push(item.clone());
@@ -1221,6 +1298,10 @@ impl Interpreter {
                     results.push(val);
                     continue;
                 }
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "hypermethodcalldynamic",
+                    "callable-descend",
+                );
                 let r = self.hyper_sub_apply_recursive(&name_val, item, &item_args, modifier)?;
                 push_hyper_result(&mut results, itemize_if_descended(item, r));
                 continue;
@@ -1233,8 +1314,16 @@ impl Interpreter {
                     let val = if let Some(native_result) =
                         self.try_native_method(item, Symbol::intern(method), &item_args)
                     {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcalldynamic",
+                            "native",
+                        );
                         native_result.unwrap_or(Value::package(Symbol::intern("Any")))
                     } else {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcalldynamic",
+                            "user",
+                        );
                         match self.call_method_mut_with_temp_target(item, method, item_args, idx) {
                             Ok((v, updated)) => {
                                 *item = updated;
@@ -1249,10 +1338,18 @@ impl Interpreter {
                     let vals = if let Some(native_result) =
                         self.try_native_method(item, Symbol::intern(method), &item_args)
                     {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcalldynamic",
+                            "native",
+                        );
                         let r = native_result?;
                         let count = self.builtin_mro_method_candidate_count(item, method);
                         vec![r; count]
                     } else {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcalldynamic",
+                            "user",
+                        );
                         let (v, updated) =
                             self.call_method_all_with_temp_target(item, method, item_args, idx)?;
                         *item = updated;
@@ -1264,6 +1361,10 @@ impl Interpreter {
                     if let Some(native_result) =
                         self.try_native_method(item, Symbol::intern(method), &item_args)
                     {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcalldynamic",
+                            "native",
+                        );
                         match native_result {
                             Ok(v) => {
                                 let count = self.builtin_mro_method_candidate_count(item, method);
@@ -1272,6 +1373,10 @@ impl Interpreter {
                             Err(_) => results.push(Value::array(vec![])),
                         }
                     } else {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcalldynamic",
+                            "user",
+                        );
                         match self.call_method_all_with_temp_target(item, method, item_args, idx) {
                             Ok((vals, updated)) => {
                                 *item = updated;
@@ -1285,8 +1390,16 @@ impl Interpreter {
                     let val = if let Some(native_result) =
                         self.try_native_method(item, Symbol::intern(method), &item_args)
                     {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcalldynamic",
+                            "native",
+                        );
                         native_result?
                     } else {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "hypermethodcalldynamic",
+                            "user",
+                        );
                         let (v, updated) =
                             self.call_method_mut_with_temp_target(item, method, item_args, idx)?;
                         *item = updated;

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -370,3 +370,126 @@ This is a smaller/simpler entry than `CallMethod` so that broader sweep is
 deferred rather than run locally; the box stays open regardless — the remaining
 E5 measurement entries (hyper non-mut paths, `call_method_all_with_fallback`)
 and all cutover sub-slices (E5b/E5c/E5d) are still to do.
+
+### Measurement slice results — hyper non-mut paths (E5 step 3)
+
+Landed 2026-08-11: instruments the two remaining opcode entries named in step
+1's "still to do" list, `exec_hyper_method_call_op` (`HyperMethodCall`,
+`src/vm/vm_hyper_method_ops.rs:446-984`, entry name `hypermethodcall`) and
+`exec_hyper_method_call_dynamic_op` (`HyperMethodCallDynamic`, same file
+`:1150-1385`, entry name `hypermethodcalldynamic`). Reuses the same two
+generic functions from step 1/2, no new counter functions. Pure insertions
+only — every new line is a `record_dispatch_entry_outcome`/
+`record_dispatch_entry_intercept` call; no branch, condition, guard, or
+return value changed. `make test` (full `t/`, 3018 files, 28265 subtests)
+passes unchanged after the insertion.
+
+**Granularity differs from `CallMethod`/`CallMethodDynamic` by design.**
+Those two entries dispatch exactly one method call per opcode execution, so
+`sum(outcomes) == opcode count` was the verification identity. A hyper
+opcode instead loops over every element of its target and dispatches once
+per element (design decision 4's "per-element probe" — the whole point of
+E5c's eventual cutover is to touch only that inner per-element probe pair).
+So here `sum(outcomes)` counts **element-level dispatches**, not opcode
+executions, and is expected to exceed the `HyperMethodCall`/
+`HyperMethodCallDynamic` opcode-histogram count whenever a target has more
+than one element (confirmed directly: `t/hyper-nested-itemize.t` executes
+`HyperMethodCall` 12 times per the opcode histogram but records 18
+`hypermethodcall:*` outcomes, from arrays with >1 element per call). Do not
+treat opcode-count parity as the correctness bar for these two entries —
+per-file *plausibility* (arm names matching the source's actual `>>`/`».`
+usage, no arm firing on a file that doesn't exercise its shape) is the
+check used instead, same as the informal spot-checks below.
+
+Taxonomy table — `HyperMethodCall` (line numbers as of this PR's revision):
+
+| Line range | Class | Arm name / description | Counter key | Notes |
+|---|---|---|---|---|
+| ~481-489 | b (op-level) | metaobject introspector (`.WHAT`/`.WHO`/`.HOW`/`.DEFINITE`/`.WHERE`) applies to the target itself, no per-element loop | `hypermethodcall:target-introspector` | consumes the whole opcode; entire result path elsewhere in this table does not run |
+| ~496-511 | b (op-level) | `>>++`/`>>--` on a Bag/Mix/Set (applies to weights, no per-element loop) | `hypermethodcall:quant-postfix` | consumes the whole opcode via `exec_hyper_quant_postfix` |
+| ~564-579 (per element) | b | `CALL-ME` on a callable item (`>>.(args)` syntax) | `hypermethodcall:call-me` | |
+| ~583-596 (per element) | b | user-defined `postfix:<...>` operator via hyper (excludes builtin `++`/`--`) | `hypermethodcall:user-postfix-op` | function call, not method dispatch |
+| ~601-616 (per element) | b | builtin `++`/`--` on a `ContainerRef` element (shared alias, e.g. `@a.grep(...)>>++`) | `hypermethodcall:containerref-postfix` | mutates through the cell in place |
+| ~663-696 (per element) | c | modifier `?` (`».?method`) native/user probe | `hypermethodcall:native` / `hypermethodcall:user` | errors swallowed to `Any`; no `notfound` overlay possible here |
+| ~697-733 (per element) | c | modifier `+` (`».+method`) native/user probe via `call_method_all_with_temp_target` | `hypermethodcall:native` / `hypermethodcall:user` | one result per MRO candidate |
+| ~734-757 (per element) | c | modifier `*` (`».*method`) native/user probe, same helper as `+` but swallows errors to `()` | `hypermethodcall:native` / `hypermethodcall:user` | |
+| ~758-775 (per element) | b | hyper subscript with a slice index (`@a>>.[0..2]`, `%h>>.{1,2}`) | `hypermethodcall:subscript-slice` | applies the postcircumfix subscript, not the single-key accessor |
+| ~791-806 (per element) | b | non-nodal descend into a nested Iterable/Hash element | `hypermethodcall:descend-recursive` | delegates to `hyper_method_apply_recursive`, itself uninstrumented (recursion-internal probes deliberately out of scope, same convention as `CallMethod`'s `junction-invocant`) |
+| ~807-819 (per element) | b | Nil absorbs an undefined method (`Nil.FALLBACK`) | `hypermethodcall:nil-absorb` | |
+| ~820-861 (per element) | c | plain (no modifier) native/user probe | `hypermethodcall:native` / `hypermethodcall:user` | includes the resumable-warn carry-through; errors otherwise propagate via `?` (no observable not-found completion at this entry, unlike `CallMethodDynamic`) |
+| ~866-984 | d | writeback tails (array/hash/QuantHash rebuild, `write_back_hyper_target_var`, identity-scan overwrite) | (none) | untouched per design decision 2 |
+
+Taxonomy table — `HyperMethodCallDynamic` (line numbers as of this PR's
+revision; this entry has no op-level early-return branches — hash-keys
+handling and the per-element loop are the only structure):
+
+| Line range | Class | Arm name / description | Counter key | Notes |
+|---|---|---|---|---|
+| ~1198-1225 (per element) | b | `>>.&callable` where the callable name is nodal (applies at the node level, one call per top-level element) | `hypermethodcalldynamic:callable-nodal` | approximated by name (`is_nodal_list_method`); see the pre-existing `TODO` at this site about a missing `is nodal` trait on user `Sub`s |
+| ~1226-1232 (per element) | b | `>>.&callable` where the callable is not nodal (descends recursively) | `hypermethodcalldynamic:callable-descend` | delegates to `hyper_sub_apply_recursive`, uninstrumented internally, same convention as `descend-recursive` above |
+| ~1237-1251 (per element) | c | modifier `?` native/user probe (name-value branch) | `hypermethodcalldynamic:native` / `hypermethodcalldynamic:user` | no `skip_native` gate exists at this entry at all — unlike the static `HyperMethodCall`, there is no `has_user_method` check anywhere in the dynamic dispatch path |
+| ~1252-1266 (per element) | c | modifier `+` native/user probe via `call_method_all_with_temp_target` | `hypermethodcalldynamic:native` / `hypermethodcalldynamic:user` | |
+| ~1267-1287 (per element) | c | modifier `*` native/user probe | `hypermethodcalldynamic:native` / `hypermethodcalldynamic:user` | |
+| ~1288-1301 (per element) | c | plain (no modifier) native/user probe | `hypermethodcalldynamic:native` / `hypermethodcalldynamic:user` | any error (including not-found) propagates via `?`, same as the static entry's plain-probe arm |
+| ~1302-1341 | d | writeback tails (array rebuild, QuantHash/Hash reassembly) | (none) | untouched |
+
+**Real finding from the classification pass, not just a table gap**: unlike
+`exec_hyper_method_call_op`, `exec_hyper_method_call_dynamic_op` has no
+`skip_native`/`has_user_method` gate anywhere — every per-element dispatch
+tries `try_native_method` first regardless of whether the item's class
+defines a same-named user method. This is exactly inventory correction 4 in
+the design doc's "Facts that shape the cutover" section (which named this
+gap for `exec_hyper_method_call_dynamic_op` vs its static twin). It was not
+re-verified against raku here (out of scope for a measurement-only slice —
+V1 in the doc's "Verification items" still needs to raku-verify it before
+the E6/E5c cutover fixes it by construction).
+
+### Sweep results
+
+Full `t/` sweep (debug build, all 3018 files, `MUTSU_VM_STATS=1`, one
+process per file): 50 files recorded at least one `hypermethodcall*`
+outcome. Aggregated element-level outcome totals:
+
+| Key | Count |
+|---|---|
+| `hypermethodcall:native` | 575 |
+| `hypermethodcall:user` | 191 |
+| `hypermethodcall:intercept` | 99 |
+| `hypermethodcalldynamic:intercept` | 65 |
+| `hypermethodcalldynamic:callable-descend` | 57 |
+| `hypermethodcall:descend-recursive` | 31 |
+| `hypermethodcall:user-postfix-op` | 25 |
+| `hypermethodcall:subscript-slice` | 10 |
+| `hypermethodcall:containerref-postfix` | 10 |
+| `hypermethodcalldynamic:callable-nodal` | 8 |
+| `hypermethodcall:target-introspector` | 7 |
+| `hypermethodcall:quant-postfix` | 7 |
+| `hypermethodcall:call-me` | 5 |
+| `hypermethodcall:nil-absorb` | 4 |
+
+`hypermethodcalldynamic:native` and `hypermethodcalldynamic:user` were
+**zero across the entire local `t/` sweep** — every `t/*.t` exercise of
+`HyperMethodCallDynamic` went through the `>>.&callable` branch
+(`callable-nodal`/`callable-descend`) or an intercept, never the plain
+`».method`/`».$name(...)` string-dispatch branch. This is a coverage gap in
+`t/`, not evidence the branch is dead: three whitelisted roast files use
+`»."name"`/`»."$name"` syntax (`roast/S03-metaops/hyper.t`,
+`roast/S12-methods/parallel-dispatch.t`, `roast/S05-mass/properties-script.t`),
+and running the first two directly (`MUTSU_FUDGE=1 MUTSU_VM_STATS=1`, debug
+build) confirms real traffic there: `hyper.t` records
+`hypermethodcalldynamic:native=8`, `parallel-dispatch.t` records
+`hypermethodcalldynamic:user=12` (both files' TAP output unaffected —
+all `ok`, same as pre-change). Sub-slice ordering (decision 3(i)):
+`hypermethodcall`'s `native`/`user` dominate (575/191, ~75%/25% of its
+disjoint element dispatches), so E5c's decision-match conversion of
+`HyperMethodCall`'s plain-probe arm is the highest-value single change
+in this pair; the dynamic entry's real native/user traffic requires the
+roast corpus, not `t/`, as its parity set.
+
+**What's left for E5 (per design decision 4's slicing)**: the last
+measurement entry, `call_method_all_with_fallback`
+(`vm_call_helpers.rs:303`, backing the `.+`/`.*` all-methods modifiers at
+the `CallMethod`/`CallMethodDynamic` entries — already visible as zero-detail
+intercept arms `modifier-plus`/`modifier-star` in steps 1/2's own tables).
+Once that lands, all four E5 measurement sub-slices are done and E5b
+(`CallMethod` cutover) can start.


### PR DESCRIPTION
## Summary
- Instruments `exec_hyper_method_call_op` (`HyperMethodCall`) and `exec_hyper_method_call_dynamic_op` (`HyperMethodCallDynamic`) with the `MUTSU_VM_STATS`-gated dispatch-entry counters E5 step 1 introduced, reusing the same generic counter functions -- pure insertions, zero behavior change.
- Documents that hyper opcodes dispatch once per target *element*, not once per opcode execution, so the verification identity differs from step 1/2 (`sum(outcomes) == opcode-histogram count` does not hold here by design).
- Full `t/` sweep + two targeted whitelisted roast files confirm sensible traffic split (`hypermethodcall` native/user-dominated like `CallMethod`; `hypermethodcalldynamic`'s string-dispatch branch is untested by `t/` but real in roast).
- Re-confirms a real gap noted in the E5-E7 design doc: `exec_hyper_method_call_dynamic_op` has no `skip_native`/`has_user_method` guard anywhere (open verification item for a later cutover, not fixed here).

## Test plan
- [x] `cargo build`
- [x] `cargo fmt` / `cargo clippy -- -D warnings` (pre-commit hooks passed)
- [x] `prove -j4 -e './target/debug/mutsu' t/` -- 3018 files, 28265 subtests, all pass
- [x] Spot-checked several `t/hyper-*.t` files and two whitelisted roast files (`S03-metaops/hyper.t`, `S12-methods/parallel-dispatch.t`) with `MUTSU_VM_STATS=1` to confirm counters fire correctly and TAP output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)