### PR TITLE
refactor(vm): ADR-0019 E5 step 4 -- measurement counters for call_method_all_with_fallback

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2879,6 +2879,26 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   hyper non-mut paths (E5 step 3)". Still to do: the
   `call_method_all_with_fallback` measurement slice (the last of the four),
   then E5b/E5c/E5d cutovers.
+  **Progress 2026-08-11** (E5 step 4, measurement slice for
+  `call_method_all_with_fallback`): instrumented the last of the four E5
+  measurement entries, `vm_call_helpers.rs::call_method_all_with_fallback`
+  (entry `callmethodallfallback`) — a shared helper (not an opcode handler)
+  with a trivial 2-outcome body (`native`/`user`), called from 6 sites
+  across 5 files: `CallMethod`'s own `.+`/`.*` modifier arms (already
+  measured at the caller in step 1), `CallMethodMut` and
+  `CallMethodDynamicMut` (2 sites each — E6 territory, not yet measured
+  independently), and three sites unrelated to the `.+`/`.*` modifiers
+  (`.cache`/`.Map` coercions, a cached scalar-accessor probe). Pure
+  insertion, zero behavior change; `make test` (3018 files, 28265 subtests)
+  unchanged. Full `t/` sweep: 7 files hit, `user=22`/`native=3`, all
+  confirmed by inspection to be `.+`/`.*` MRO-walk tests on *variable*
+  receivers (so routed through the Mut opcodes, not `CallMethod` itself) —
+  sample too small to draw a sub-slice-ordering conclusion on its own;
+  clearer once E6a's `CallMethodMut` sweep runs. **All four E5 measurement
+  sub-slices are done** (steps 1-4). Full detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results —
+  call_method_all_with_fallback (E5 step 4)". Next: E5b, the `CallMethod`
+  probe-section cutover to the E4 resolver decision.
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/news/2026-08/adr0019-e5-step4-callmethodallfallback-measurement.md
+++ b/news/2026-08/adr0019-e5-step4-callmethodallfallback-measurement.md
@@ -1,0 +1,35 @@
+# ADR-0019 E5 step 4: measurement counters for call_method_all_with_fallback
+
+Instrumented `call_method_all_with_fallback` (`src/vm/vm_call_helpers.rs`)
+with the same `MUTSU_VM_STATS`-gated dispatch-entry counters used by the
+prior E5 measurement slices, `entry = "callmethodallfallback"`. This is the
+fourth and last of the E5 measurement entries named in the E5-E7 design
+doc's decision 4, completing the measurement phase for Phase E's "ordinary
+VM method calls" box.
+
+Unlike the opcode handlers instrumented in earlier steps, this is a single
+shared helper function with a trivial two-outcome body (`native`/`user`),
+called from 6 sites across 5 files: `CallMethod`'s own `.+`/`.*` modifier
+arms, `CallMethodMut` and `CallMethodDynamicMut` (E6 territory — not yet
+measured independently), and three sites unrelated to the `.+`/`.*`
+modifiers at all (`.cache`/`.Map` coercions, a cached scalar-accessor
+probe). Pure insertion, zero behavior change.
+
+A full `t/` sweep found 7 files exercising this helper (`user=22`,
+`native=3`), all confirmed by inspection to be `.+`/`.*` MRO-walk tests on
+variable receivers — i.e. routed through the `Mut` opcodes rather than
+`CallMethod` directly, the same "bareword/variable receiver picks the Mut
+opcode" pattern earlier steps documented. The sample is small enough that
+this helper's real traffic profile will only be clear once the E6
+measurement slice for `CallMethodMut` runs.
+
+`make test` (full `t/`, 3018 files, 28265 subtests) passes unchanged (one
+known-flaky concurrency test, `t/supply-done-in-tap-callback-is-not-a-failure.t`,
+failed once and passed 5/5 on immediate re-runs — unrelated to this change).
+
+With all four E5 measurement sub-slices done, E5b (the `CallMethod`
+probe-section cutover to the E4 resolver decision) is next. Full detail:
+`todo/deep/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
+call_method_all_with_fallback (E5 step 4)") and
+`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (E5
+bullet).

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -317,6 +317,7 @@ impl Interpreter {
             && let Some(native_result) =
                 self.try_native_method(target, Symbol::intern(method), args)
         {
+            crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodallfallback", "native");
             let result = native_result?;
             // `.+`/`.*` on a built-in: emit one result per MRO level that defines
             // the method (all identical — same native handler). §2 builtin-MRO
@@ -324,6 +325,7 @@ impl Interpreter {
             let count = self.builtin_mro_method_candidate_count(target, method);
             return Ok(vec![result; count]);
         }
+        crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodallfallback", "user");
         loan_env!(
             self,
             call_method_all_with_values(target.clone(), method, args.to_vec())

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -493,3 +493,52 @@ the `CallMethod`/`CallMethodDynamic` entries — already visible as zero-detail
 intercept arms `modifier-plus`/`modifier-star` in steps 1/2's own tables).
 Once that lands, all four E5 measurement sub-slices are done and E5b
 (`CallMethod` cutover) can start.
+
+### Measurement slice results — call_method_all_with_fallback (E5 step 4)
+
+Landed 2026-08-11: instruments `call_method_all_with_fallback`
+(`src/vm/vm_call_helpers.rs:309-331`, entry name `callmethodallfallback`),
+the last of the four E5 measurement entries named in design decision 4. Pure
+insertion — one `record_dispatch_entry_outcome` call before the native early
+return, one before the `call_method_all_with_values` fallback; no branch,
+condition, or return value changed. `make test` (full `t/`, 3018 files,
+28265 subtests) passes unchanged.
+
+Unlike the opcode entries in steps 1-3, this is a single **shared helper
+function**, not an opcode handler — it has no opcode histogram to check
+disjoint-sum completeness against, and no receiver-normalization/intercept
+gauntlet of its own (its whole body is the two-arm `native`/`user` probe
+already shown above). Its taxonomy is therefore trivial (2 outcomes, 0
+intercept arms) but its *callers* are not: grep confirms 6 call sites
+across 5 files — `CallMethod`'s own `modifier-plus`/`modifier-star`
+intercept arms (measured at the caller in step 1, already known
+zero-detail there), `CallMethodMut` (2 call sites,
+`vm_call_method_mut_ops.rs:76/85`), `CallMethodDynamicMut`
+(`vm_call_method_mut_ops.rs:381/386`), and three call sites unrelated to
+the `.+`/`.*` modifiers entirely: `vm_exec_dispatch.rs:2616` (a `.cache`
+coercion), `vm_var_assign_coerce.rs:341` (a `.Map` coercion), and
+`vm_var_assign_set_local.rs:828` (a cached scalar-accessor probe). The E6
+measurement slice for `CallMethodMut`/`CallMethodDynamicMut` (E6a) will
+re-encounter this same helper as their own `.+`/`.*` outcome source — this
+slice measures the helper itself once, not per-caller, since it is exactly
+the entry the design doc's own inventory names standalone.
+
+Full `t/` sweep (3018 files): 7 files recorded any outcome —
+`callmethodallfallback:user=22`, `callmethodallfallback:native=3`. All 7
+hits were confirmed by inspection to be genuine `.+`/`.*` MRO-walk tests on
+*variable* receivers (`$b.*tag`, `$obj.+m`, `.VAR.+name`) — i.e. they
+compile to `CallMethodMut`/`CallMethodDynamicMut`, not `CallMethod`,
+matching the "bareword/variable receiver picks the Mut opcode" pattern
+steps 1/2 already documented. `t/builtin-mro-all-candidates.t` is the only
+file with `native` traffic (3 of 4 hits): a `.*`/`.+` walk over a built-in
+type, exercising the `builtin_mro_method_candidate_count` multiplication
+path. `user` dominates overall (22 vs 3) but the sample is small (25 total
+hits) — not enough to draw a sub-slice-ordering conclusion on its own; this
+helper's real traffic profile will be clearer once E6a's `CallMethodMut`
+sweep runs (its own `.+`/`.*` arms are the majority caller of this helper,
+per the call-site count above).
+
+**All four E5 measurement sub-slices are now done** (steps 1-4: `CallMethod`,
+`CallMethodDynamic`, the two hyper non-mut opcodes, and this shared helper).
+Per design decision 4's slicing, E5b (`CallMethod` probe-section cutover to
+the E4 resolver decision) can start next.


### PR DESCRIPTION
## Summary
- Instruments `call_method_all_with_fallback` (`src/vm/vm_call_helpers.rs`), the shared helper backing the `.+`/`.*` all-methods modifiers, with the same `MUTSU_VM_STATS`-gated dispatch-entry counters used by E5 steps 1-3. This is the last of the four E5 measurement entries named in the design doc's decision 4.
- Pure insertion, zero behavior change. Documents that this is a shared helper (not an opcode handler) called from 6 sites across 5 files, spanning `CallMethod`, `CallMethodMut`/`CallMethodDynamicMut` (E6 territory), and three unrelated call sites.
- Full `t/` sweep: 7 files hit (`user=22`, `native=3`), all confirmed to be `.+`/`.*` MRO-walk tests on variable receivers.
- With this, **all four E5 measurement sub-slices are done**; E5b (the `CallMethod` cutover) is next.

## Test plan
- [x] `cargo build`
- [x] `cargo fmt` / `cargo clippy -- -D warnings`
- [x] `prove -j4 -e './target/debug/mutsu' t/` -- 3018 files, 28265 subtests pass (one known-flaky concurrency test failed once, passed 5/5 on immediate re-run, unrelated to this change)
- [x] Spot-checked `MUTSU_VM_STATS=1` output on targeted `.+`/`.*` test files to confirm counters fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)