### PR TITLE
refactor(vm): ADR-0019 E5b step 1 -- shadow-verify the Native candidate at CallMethod (blocker finding)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2899,6 +2899,39 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results —
   call_method_all_with_fallback (E5 step 4)". Next: E5b, the `CallMethod`
   probe-section cutover to the E4 resolver decision.
+  **Progress 2026-08-11** (E5b step 1, shadow-verify the `Native` candidate
+  at `CallMethod` itself — **blocker finding, resolver decision NOT yet
+  safe to build on it**): reused the existing E4b step 9 shadow-check
+  function (`shadow_check_native_row_candidate`, unmodified, no new counter)
+  at `CallMethod`'s own highest-traffic plain-probe arm, passing the
+  already-computed `native_result.is_some()` — pure insertion, zero behavior
+  change, `make test`-equivalent local suite green. Full `t/` sweep: 39558
+  checks, ~965 mismatches (~2.4%), across 253 files, both directions
+  (`real=false/shadow=true` ~545, `real=true/shadow=false` ~409), no single
+  method dominant (`gist`/`raku` largest, but `join`/`sprintf`/`comb`/
+  `DEFINITE`/`head`/`Int`/`substr`/... all contribute). **This contradicts
+  E4b step 9's "essentially zero mismatches" only because that check ran at
+  a low-traffic site (`call_method_with_values`, the interpreter slow path)
+  — a sampling artifact, not evidence the underlying `native_row_servable`
+  predicate is sound.** Two root causes identified by inspection: (1) the
+  predicate checks only `(owner, method, arity, definite)`, blind to
+  concrete-value-shape exceptions (`Sub.gist`/`.raku` decline the generic
+  `"Any"`-owner row and use bespoke rendering instead — the same class of
+  gap E4b step 2 already named for `should_bypass_native_fastpath`'s
+  category-1 gates); (2) some methods the cascade genuinely serves
+  (`DEFINITE` at 0 arity) have no row in `native_method_row_table.rs` at
+  all. **Consequence: E5b must NOT build its "native or user" branch purely
+  from the `Native` candidate** — either refine the predicate per-shape
+  first, or keep the actual invocation as a direct, self-guarding
+  `try_native_method` call (matching how `NativeCallBinding` was already
+  found "no gain over a direct call" at E4b step 12) rather than a resolver
+  decision that skips calling it. Open next question: does `CallMethod`'s
+  pre-existing `skip_native`/`has_user_method` gate already make this moot
+  for `CallMethod` specifically (by construction preventing `Native` from
+  ever needing to outrank a matching `User` candidate at this arm)? Full
+  detail, mismatch examples, and the two-option resolution in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 1: shadow-verifying
+  the Native candidate at CallMethod itself".
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2879,6 +2879,26 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   hyper non-mut paths (E5 step 3)". Still to do: the
   `call_method_all_with_fallback` measurement slice (the last of the four),
   then E5b/E5c/E5d cutovers.
+  **Progress 2026-08-11** (E5 step 4, measurement slice for
+  `call_method_all_with_fallback`): instrumented the last of the four E5
+  measurement entries, `vm_call_helpers.rs::call_method_all_with_fallback`
+  (entry `callmethodallfallback`) — a shared helper (not an opcode handler)
+  with a trivial 2-outcome body (`native`/`user`), called from 6 sites
+  across 5 files: `CallMethod`'s own `.+`/`.*` modifier arms (already
+  measured at the caller in step 1), `CallMethodMut` and
+  `CallMethodDynamicMut` (2 sites each — E6 territory, not yet measured
+  independently), and three sites unrelated to the `.+`/`.*` modifiers
+  (`.cache`/`.Map` coercions, a cached scalar-accessor probe). Pure
+  insertion, zero behavior change; `make test` (3018 files, 28265 subtests)
+  unchanged. Full `t/` sweep: 7 files hit, `user=22`/`native=3`, all
+  confirmed by inspection to be `.+`/`.*` MRO-walk tests on *variable*
+  receivers (so routed through the Mut opcodes, not `CallMethod` itself) —
+  sample too small to draw a sub-slice-ordering conclusion on its own;
+  clearer once E6a's `CallMethodMut` sweep runs. **All four E5 measurement
+  sub-slices are done** (steps 1-4). Full detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results —
+  call_method_all_with_fallback (E5 step 4)". Next: E5b, the `CallMethod`
+  probe-section cutover to the E4 resolver decision.
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/news/2026-08/adr0019-e5-step4-callmethodallfallback-measurement.md
+++ b/news/2026-08/adr0019-e5-step4-callmethodallfallback-measurement.md
@@ -1,0 +1,35 @@
+# ADR-0019 E5 step 4: measurement counters for call_method_all_with_fallback
+
+Instrumented `call_method_all_with_fallback` (`src/vm/vm_call_helpers.rs`)
+with the same `MUTSU_VM_STATS`-gated dispatch-entry counters used by the
+prior E5 measurement slices, `entry = "callmethodallfallback"`. This is the
+fourth and last of the E5 measurement entries named in the E5-E7 design
+doc's decision 4, completing the measurement phase for Phase E's "ordinary
+VM method calls" box.
+
+Unlike the opcode handlers instrumented in earlier steps, this is a single
+shared helper function with a trivial two-outcome body (`native`/`user`),
+called from 6 sites across 5 files: `CallMethod`'s own `.+`/`.*` modifier
+arms, `CallMethodMut` and `CallMethodDynamicMut` (E6 territory — not yet
+measured independently), and three sites unrelated to the `.+`/`.*`
+modifiers at all (`.cache`/`.Map` coercions, a cached scalar-accessor
+probe). Pure insertion, zero behavior change.
+
+A full `t/` sweep found 7 files exercising this helper (`user=22`,
+`native=3`), all confirmed by inspection to be `.+`/`.*` MRO-walk tests on
+variable receivers — i.e. routed through the `Mut` opcodes rather than
+`CallMethod` directly, the same "bareword/variable receiver picks the Mut
+opcode" pattern earlier steps documented. The sample is small enough that
+this helper's real traffic profile will only be clear once the E6
+measurement slice for `CallMethodMut` runs.
+
+`make test` (full `t/`, 3018 files, 28265 subtests) passes unchanged (one
+known-flaky concurrency test, `t/supply-done-in-tap-callback-is-not-a-failure.t`,
+failed once and passed 5/5 on immediate re-runs — unrelated to this change).
+
+With all four E5 measurement sub-slices done, E5b (the `CallMethod`
+probe-section cutover to the E4 resolver decision) is next. Full detail:
+`todo/deep/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
+call_method_all_with_fallback (E5 step 4)") and
+`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (E5
+bullet).

--- a/news/2026-08/adr0019-e5b-step1-native-candidate-divergence-found.md
+++ b/news/2026-08/adr0019-e5b-step1-native-candidate-divergence-found.md
@@ -1,0 +1,38 @@
+# ADR-0019 E5b step 1: the Native candidate is not yet safe to route CallMethod's dispatch decision
+
+With all four E5 measurement slices done, this step began E5b (the
+`CallMethod` cutover to the E4 resolver decision) the same way every prior
+Phase E box has: shadow-verify before switching. It reused the existing E4b
+step 9 shadow-check function unmodified at `CallMethod`'s own
+highest-traffic plain-probe arm, comparing design decision 4's `Native`
+candidate against what `try_native_method` actually did — pure insertion,
+zero behavior change.
+
+The result is a real finding, not a clean bill of health: a full `t/` sweep
+found ~965 mismatches out of 39558 checks (~2.4%), spread across 253 files,
+in both directions and with no single dominant method. This directly
+contradicts E4b step 9's earlier report of essentially zero mismatches for
+the *same* shadow-check function — but that check ran at a much
+lower-traffic call site (the interpreter's slow path), so its clean result
+was a sampling artifact of where it was placed, not evidence the underlying
+`native_row_servable` predicate actually holds across `CallMethod`'s real
+traffic. Two concrete root causes: the predicate is blind to
+concrete-value-shape exceptions (`Sub.gist`/`.raku` decline a generic row
+that claims to cover them), and some methods the cascade genuinely serves
+(`DEFINITE` at 0 arity) have no catalog row at all.
+
+Consequence: E5b's planned "native or user" branch cannot be built purely
+from the `Native` candidate as originally sketched — it would silently
+mis-route roughly one in forty calls on this arm. The fix is either a
+per-shape refinement of the predicate, or keeping the actual dispatch as a
+direct, self-guarding `try_native_method` call rather than a resolver
+decision that skips calling it (mirroring how `NativeCallBinding` was
+already found not worth routing through the resolver at E4b step 12). This
+is exactly the kind of correctness risk the project's shadow-verify-first
+methodology exists to catch before a large cutover PR, not after.
+
+Full detail, mismatch examples, and the open next question (whether
+`CallMethod`'s existing `skip_native` gate already makes this moot for this
+one entry) are in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 1"
+and `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`
+(E5 bullet).

--- a/src/vm/vm_call_helpers.rs
+++ b/src/vm/vm_call_helpers.rs
@@ -317,6 +317,7 @@ impl Interpreter {
             && let Some(native_result) =
                 self.try_native_method(target, Symbol::intern(method), args)
         {
+            crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodallfallback", "native");
             let result = native_result?;
             // `.+`/`.*` on a built-in: emit one result per MRO level that defines
             // the method (all identical — same native handler). §2 builtin-MRO
@@ -324,6 +325,7 @@ impl Interpreter {
             let count = self.builtin_mro_method_candidate_count(target, method);
             return Ok(vec![result; count]);
         }
+        crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodallfallback", "user");
         loan_env!(
             self,
             call_method_all_with_values(target.clone(), method, args.to_vec())

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1890,9 +1890,28 @@ impl Interpreter {
                         // Native method on a by-value (read) target: env-pure.
                         self.method_dispatch_pure = true;
                         crate::vm::vm_stats::record_dispatch_entry_outcome("callmethod", "native");
+                        // ADR-0019 E5b step 1: shadow-verify design decision
+                        // 4's `Native` candidate (already zero-mismatch at
+                        // `call_method_with_values`, E4b step 9) against
+                        // CallMethod's own separate native-probe call site,
+                        // observational only.
+                        self.shadow_check_native_row_candidate(
+                            &target,
+                            method,
+                            method_sym,
+                            args.len(),
+                            true,
+                        );
                         native_result
                     } else {
                         crate::vm::vm_stats::record_dispatch_entry_outcome("callmethod", "user");
+                        self.shadow_check_native_row_candidate(
+                            &target,
+                            method,
+                            method_sym,
+                            args.len(),
+                            false,
+                        );
                         self.try_compiled_method_or_interpret_sym(target, method_sym, args)
                     }
                 } else {

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -542,3 +542,90 @@ per the call-site count above).
 `CallMethodDynamic`, the two hyper non-mut opcodes, and this shared helper).
 Per design decision 4's slicing, E5b (`CallMethod` probe-section cutover to
 the E4 resolver decision) can start next.
+
+### E5b step 1: shadow-verifying the `Native` candidate at CallMethod itself — a real divergence found, NOT safe to consume yet
+
+Design decision 1's cutover shape needs `resolve_dispatch(&receiver, method_sym,
+shape)` to answer "native row or user candidate?" for `CallMethod`'s own
+highest-traffic arm (the plain probe at the end of its cascade, `native=43.8%`/
+`user=49.2%` per step 1's sweep). Before writing that function, this step
+reused the *existing*, already-landed E4b step 9 machinery
+(`Interpreter::shadow_check_native_row_candidate`, `src/runtime/resolution_sequence.rs`)
+and called it — unmodified, no new counter function — from `CallMethod`'s own
+plain-probe arm (`vm_call_method_ops.rs`, both the `native`-outcome and
+`user`-outcome branches), passing the already-computed `native_result.is_some()`
+as `real_served` so the cascade is never invoked twice. Pure insertion, zero
+behavior change (`cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`, and
+the full local `prove -j4 t/` suite — 3018 files, 28265 subtests — all green,
+identical to before the insertion).
+
+**Finding: the `Native` candidate does NOT reliably predict `try_native_method`'s
+real outcome at this call site.** Full `t/` sweep (3018 files, `MUTSU_VM_STATS=1`):
+39558 shadow checks, ~965 mismatches (~2.4%), spread across 253 distinct files —
+both directions occur in comparable volume (row says servable but the cascade
+declined: ~545; cascade served but no row exists: ~409), and no single method
+dominates (`gist`/`raku` are the largest single buckets at roughly 120-190
+combined mismatches each, but `join`/`sprintf`/`comb`/`DEFINITE`/`head`/`Int`/
+`List`/`substr`/`Str`/`split`/`contains`/`AT-KEY`/`EXISTS-POS`/`EXISTS-KEY`/
+`throw`/... all contribute tens of hits each). This is qualitatively different
+from E4b step 9's own report of the *same* shadow-check function at its
+original call site (`call_method_with_values`), which found essentially zero
+mismatches — that site is the interpreter's slow-path fallback, reached far
+less often and with a narrower receiver/method mix than `CallMethod`'s own
+hot-path probe, so its clean result was a **sampling artifact of where it was
+placed**, not evidence the underlying `native_row_servable` predicate
+(`native_method_row_table.rs` + arity/definite gating) is actually sound
+across the full traffic `CallMethod` sees. The two concrete mismatch shapes,
+by direct inspection:
+
+- **`real=false shadow=true`** (row claims servable, cascade declined): e.g.
+  `t/anon-sub-name-gist.t`'s `anon sub foo {...}.gist`/`.raku` — a `Sub` value
+  whose `gist`/`raku` rendering the row table's generic `"Any"`-owner row
+  predicts as servable, but `try_native_method`'s actual dispatch for a `Sub`
+  receiver declines (returns `None`) so the call falls through to the
+  interpreted/compiled path instead, which has its own bespoke Sub-rendering
+  logic not modeled by the row catalog at all. `native_row_servable` checks
+  only `(owner, method, arity, definite)` — it has no notion of "this
+  receiver's *concrete value shape* makes the generic row inapplicable",
+  the same class of gap E4b step 2 already named for
+  `should_bypass_native_fastpath`'s category-1 gates ("row presence/absence
+  is the wrong axis... what matters is whether the cascade itself would
+  misbehave if reached").
+- **`real=true shadow=false`** (cascade served, no row at all): e.g. `DEFINITE`
+  at 0 arity (the very first mismatch found, `t/hyper-nodality.t`) — a
+  pseudo-method handled directly inside `try_native_method`'s own dispatch
+  (or a pre/post step around the row cascade) without ever being registered
+  as a `native_method_row_table.rs` entry, so `native_row_servable` can never
+  see it regardless of receiver shape.
+
+**Consequence for E5b's real cutover: do not build `resolve_dispatch`'s
+"native or user" branch purely from `native_row_servable`/the `Native`
+candidate — it will silently mis-route ~2.4% of `CallMethod`'s highest-traffic
+arm.** This is a genuine blocker finding, not a design-doc typo: design
+decision 4's `Native` candidate needs either (a) a per-method-shape refinement
+so it stops over/under-claiming for cases like `Sub.gist`/`DEFINITE`, mirroring
+the E4b category-1 audit's granularity, or (b) E5b's decision match keeping a
+"try the real cascade, and only consult the `Native` candidate as a routing
+*hint*, never as ground truth" shape — i.e. the actual invocation stays
+`try_native_method` itself (self-guarding, returns `None` on no match) rather
+than a resolver decision that skips calling it. Option (b) is cheaper and
+matches how `is_native_method`/`NativeCallBinding` was already found not worth
+routing through the resolver at the E4b step 12 call site ("no gain over a
+direct call") — the same reasoning likely applies here too, but has NOT been
+verified for the User-vs-Native ordering question this finding is really about
+(does `Native` ever need to *outrank* a matching `User` candidate, or does
+`CallMethod`'s pre-existing `skip_native`/`has_user_method` gate already
+settle that before the plain-probe arm is reached? — open, next step).
+
+No code was fixed here (this is a measurement/shadow-verify slice per the
+project's own established methodology, same as E4a/E4b); the mismatch
+buckets are the review artifact, not a to-do list to clear item-by-item.
+**Next E5b step**: before writing any real `resolve_dispatch` consumption,
+decide between options (a)/(b) above — likely by checking whether
+`CallMethod`'s existing `skip_native` gate (computed earlier in the function,
+the class-c "skip_native gate computation" row in step 1's own taxonomy
+table) already prevents `Native` from ever needing to outrank a `User`
+candidate at this specific arm, which would make option (b) sufficient and
+this whole `Native`-candidate refinement moot for `CallMethod` specifically
+(though not for other E5/E6 entries that reach this arm's twin without an
+equivalent gate).

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -493,3 +493,52 @@ the `CallMethod`/`CallMethodDynamic` entries — already visible as zero-detail
 intercept arms `modifier-plus`/`modifier-star` in steps 1/2's own tables).
 Once that lands, all four E5 measurement sub-slices are done and E5b
 (`CallMethod` cutover) can start.
+
+### Measurement slice results — call_method_all_with_fallback (E5 step 4)
+
+Landed 2026-08-11: instruments `call_method_all_with_fallback`
+(`src/vm/vm_call_helpers.rs:309-331`, entry name `callmethodallfallback`),
+the last of the four E5 measurement entries named in design decision 4. Pure
+insertion — one `record_dispatch_entry_outcome` call before the native early
+return, one before the `call_method_all_with_values` fallback; no branch,
+condition, or return value changed. `make test` (full `t/`, 3018 files,
+28265 subtests) passes unchanged.
+
+Unlike the opcode entries in steps 1-3, this is a single **shared helper
+function**, not an opcode handler — it has no opcode histogram to check
+disjoint-sum completeness against, and no receiver-normalization/intercept
+gauntlet of its own (its whole body is the two-arm `native`/`user` probe
+already shown above). Its taxonomy is therefore trivial (2 outcomes, 0
+intercept arms) but its *callers* are not: grep confirms 6 call sites
+across 5 files — `CallMethod`'s own `modifier-plus`/`modifier-star`
+intercept arms (measured at the caller in step 1, already known
+zero-detail there), `CallMethodMut` (2 call sites,
+`vm_call_method_mut_ops.rs:76/85`), `CallMethodDynamicMut`
+(`vm_call_method_mut_ops.rs:381/386`), and three call sites unrelated to
+the `.+`/`.*` modifiers entirely: `vm_exec_dispatch.rs:2616` (a `.cache`
+coercion), `vm_var_assign_coerce.rs:341` (a `.Map` coercion), and
+`vm_var_assign_set_local.rs:828` (a cached scalar-accessor probe). The E6
+measurement slice for `CallMethodMut`/`CallMethodDynamicMut` (E6a) will
+re-encounter this same helper as their own `.+`/`.*` outcome source — this
+slice measures the helper itself once, not per-caller, since it is exactly
+the entry the design doc's own inventory names standalone.
+
+Full `t/` sweep (3018 files): 7 files recorded any outcome —
+`callmethodallfallback:user=22`, `callmethodallfallback:native=3`. All 7
+hits were confirmed by inspection to be genuine `.+`/`.*` MRO-walk tests on
+*variable* receivers (`$b.*tag`, `$obj.+m`, `.VAR.+name`) — i.e. they
+compile to `CallMethodMut`/`CallMethodDynamicMut`, not `CallMethod`,
+matching the "bareword/variable receiver picks the Mut opcode" pattern
+steps 1/2 already documented. `t/builtin-mro-all-candidates.t` is the only
+file with `native` traffic (3 of 4 hits): a `.*`/`.+` walk over a built-in
+type, exercising the `builtin_mro_method_candidate_count` multiplication
+path. `user` dominates overall (22 vs 3) but the sample is small (25 total
+hits) — not enough to draw a sub-slice-ordering conclusion on its own; this
+helper's real traffic profile will be clearer once E6a's `CallMethodMut`
+sweep runs (its own `.+`/`.*` arms are the majority caller of this helper,
+per the call-site count above).
+
+**All four E5 measurement sub-slices are now done** (steps 1-4: `CallMethod`,
+`CallMethodDynamic`, the two hyper non-mut opcodes, and this shared helper).
+Per design decision 4's slicing, E5b (`CallMethod` probe-section cutover to
+the E4 resolver decision) can start next.


### PR DESCRIPTION
## Summary
- Begins E5b (the `CallMethod` cutover to the E4 resolver decision) with a shadow-verify step, reusing the existing E4b step 9 shadow-check function unmodified at `CallMethod`'s own highest-traffic plain-probe arm. Pure insertion, zero behavior change.
- **Finding**: the `Native` candidate does not reliably predict `try_native_method`'s real outcome at this call site -- ~965 mismatches out of 39558 checks (~2.4%) across 253 `t/` files, in both directions, with no single dominant method. This contradicts E4b step 9's earlier "essentially zero mismatches" report for the same function, because that check ran at a much lower-traffic site (the interpreter slow path) -- a sampling artifact, not evidence the underlying predicate is sound.
- **Consequence**: E5b's planned "native or user" branch cannot be built purely from the `Native` candidate as originally sketched. Full detail, root-cause examples, and two resolution options are in `todo/deep/adr0019-e5-e7-entry-routing.md`.
- This branch is stacked on the still-open `adr0019-e5-step4-call-method-all-fallback` PR (#6247) -- its diff will settle once that one merges into `main`.

## Test plan
- [x] `cargo build`
- [x] `cargo fmt` / `cargo clippy -- -D warnings`
- [x] `prove -j4 -e './target/debug/mutsu' t/` -- 3018 files, 28265 subtests, all pass (zero behavior change confirmed)
- [x] Full `t/` sweep with `MUTSU_VM_STATS=1` to characterize the mismatch (39558 checks, ~965 mismatches, both directions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)