### PR TITLE
fix(runtime): $obj.accessor[i][j]=v writes through a plain Array/Hash accessor

### DIFF
--- a/news/2026-08/nested-index-assign-through-method-accessor.md
+++ b/news/2026-08/nested-index-assign-through-method-accessor.md
@@ -1,0 +1,38 @@
+# `$obj.accessor[i][j] = v` now writes through a plain Array/Hash attribute accessor
+
+A nested subscript assignment through a no-arg method accessor —
+`$obj.method[i][j] = v` or `$obj.method<k>[i] = v` — silently dropped the
+write whenever the accessor returned a plain Array or Hash (rather than an
+`Instance` with its own subscript protocol):
+
+```raku
+class Table {
+    has @.cell;
+}
+my $t = Table.new(cell => [[1, 2, 3], [4, 5, 6]]);
+$t.cell[0][1] = 48;
+say $t.raku;   # was: Table.new(cell => [[1, 2, 3], [4, 5, 6]]) -- now: Table.new(cell => [[1, 48, 3], [4, 5, 6]])
+```
+
+`builtin_index_assign_method_lvalue_nested`
+(`src/runtime/builtins_multidim_assign.rs`), which backs this call shape,
+already handled the `Instance`-returning case (dispatch through
+`AT-POS`/`AT-KEY`/`ASSIGN-POS`) and the typed-attribute autovivification
+check, but the actual write for a plain container fell through to a `TODO:
+implement proper nested assignment for non-Nil elements` that just discarded
+the value. mutsu's containers are copy-on-write (no interior mutability for
+element cells), so writing through two subscript levels needs the same
+"read, rebuild by value, write back through the accessor's setter" shape the
+single-level `builtin_index_assign_method_lvalue` already used — applied
+twice (rebuild the inner element, then rebuild the outer container around
+it), including the existing shared-Arc propagation to other aliases of the
+same container.
+
+Found while re-measuring `CSV::Table`'s own test suite as part of the CSV
+battery survey (`docs/batteries/csv.md`) after fixing its `return-rw`/
+`AT-POS` blocker: `t/1-delimiters.t` exercises exactly this pattern
+(`$t.cell[0][1] = 48`) via the module's own `@.cell` (array-of-arrays)
+attribute.
+
+Pinned by `t/nested-index-assign-method-accessor.t` (array-of-arrays and
+hash-of-arrays accessor cases), verified against `raku` directly.

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -501,13 +501,98 @@ impl Interpreter {
             }
         }
 
-        // If we get here (element is not Nil or no type constraint),
-        // fall through to do the actual nested assignment on the current element.
-        // For now, just return the value (the assignment silently does nothing
-        // if the intermediate value is not a container).
-        // TODO: implement proper nested assignment for non-Nil elements.
-        let _ = value;
-        Ok(Value::NIL)
+        // The accessor returned a plain Array/Hash container (e.g. `has @.cell`
+        // — `.cell` exposes the shared attribute array). mutsu's containers are
+        // copy-on-write (no interior mutability for element cells), so writing
+        // `$t.cell[0][1] = v` requires rebuilding both the inner and outer
+        // container and writing the outer one back through the accessor's
+        // setter — the same COW + write-back shape as the single-level
+        // `builtin_index_assign_method_lvalue` above, applied twice.
+        let var_name = args.get(5).map(|v| v.to_string_value()).unwrap_or_default();
+        let old_array_arc = match container.view() {
+            ValueView::Array(arc, ..) => Some(arc.clone()),
+            _ => None,
+        };
+        let old_hash_arc = match container.view() {
+            ValueView::Hash(arc) => Some(arc.clone()),
+            _ => None,
+        };
+        let updated = match container.view() {
+            ValueView::Array(items, kind) => {
+                let idx = crate::runtime::to_int(&inner_index) as usize;
+                let Some(inner) = items.get(idx).cloned() else {
+                    return Ok(Value::NIL);
+                };
+                let new_inner = Self::assign_indexed_element(&inner, &_outer_index, &value)?;
+                let mut new_items = (**items).clone();
+                new_items[idx] = new_inner;
+                Value::array_with_kind(crate::gc::Gc::new(new_items), kind)
+            }
+            ValueView::Hash(h) => {
+                let key = inner_index.to_string_value();
+                let Some(inner) = h.get(&key).cloned() else {
+                    return Ok(Value::NIL);
+                };
+                let new_inner = Self::assign_indexed_element(&inner, &_outer_index, &value)?;
+                let mut new_hash = (**h).clone();
+                new_hash.insert(key, new_inner);
+                Value::hash(new_hash)
+            }
+            _ => return Ok(Value::NIL),
+        };
+
+        if let Some(old_arc) = &old_array_arc {
+            self.propagate_shared_array_in_instances(old_arc, &updated);
+            self.overwrite_array_bindings_by_identity(old_arc, updated.clone());
+        }
+        if let Some(old_arc) = &old_hash_arc {
+            self.propagate_shared_hash_in_instances(old_arc, &updated);
+            self.overwrite_hash_bindings_by_identity(old_arc, updated.clone());
+        }
+
+        self.assign_method_lvalue_with_values(
+            if var_name.is_empty() {
+                None
+            } else {
+                Some(var_name.as_str())
+            },
+            target,
+            &method,
+            Vec::new(),
+            updated,
+            true,
+        )?;
+        Ok(value)
+    }
+
+    /// Rebuild `container` (an Array or Hash) with `value` assigned at `index`,
+    /// copy-on-write. Shared by the nested method-accessor index-assign above.
+    fn assign_indexed_element(
+        container: &Value,
+        index: &Value,
+        value: &Value,
+    ) -> Result<Value, RuntimeError> {
+        match container.view() {
+            ValueView::Array(items, kind) => {
+                let idx = crate::runtime::to_int(index) as usize;
+                let mut new_items = (**items).clone();
+                if idx >= new_items.len() {
+                    new_items.resize(
+                        idx + 1,
+                        Value::package(crate::symbol::Symbol::intern("Any")),
+                    );
+                }
+                new_items[idx] = value.clone();
+                Ok(Value::array_with_kind(crate::gc::Gc::new(new_items), kind))
+            }
+            ValueView::Hash(h) => {
+                let key = index.to_string_value();
+                let mut new_hash = (**h).clone();
+                new_hash.insert(key, value.clone());
+                Ok(Value::hash(new_hash))
+            }
+            _ => Ok(container.clone()),
+        }
     }
 
     /// Assign a value into a nested multi-dimensional array structure.

--- a/t/nested-index-assign-method-accessor.t
+++ b/t/nested-index-assign-method-accessor.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 4;
+
+# `$obj.accessor[i][j] = v` where `accessor` returns a plain Array-of-Arrays
+# attribute (`has @.cell`) must write through both index levels back into the
+# attribute, the same as a direct `@!attr[i][j] = v` would.
+
+class Table {
+    has @.cell;
+}
+
+my $t = Table.new(cell => [[1, 2, 3], [4, 5, 6]]);
+$t.cell[0][1] = 48;
+is $t.cell[0][1], 48, 'array-of-arrays accessor: nested index write then read back';
+is $t.raku, 'Table.new(cell => [[1, 48, 3], [4, 5, 6]])', 'array-of-arrays accessor: .raku reflects the write';
+
+class Rows {
+    has %.row;
+}
+
+my $r = Rows.new(row => { a => [1, 2], b => [3, 4] });
+$r.row<a>[1] = 99;
+is $r.row<a>[1], 99, 'hash-of-arrays accessor: nested key+index write then read back';
+is $r.row<b>[0], 3, 'hash-of-arrays accessor: sibling entry unaffected';


### PR DESCRIPTION
## Summary
- `builtin_index_assign_method_lvalue_nested` (backs `$obj.method[i][j] = v` / `$obj.method<k>[i] = v`) already dispatched correctly when the accessor returned an `Instance` with its own `AT-POS`/`AT-KEY`/`ASSIGN-POS` protocol, and already checked typed-attribute autovivification — but fell through to a `TODO` stub that silently discarded the write when the accessor returned a plain `Array`/`Hash` (e.g. `has @.cell`).
- mutsu's containers are copy-on-write, so this needed the same "rebuild by value, write back through the accessor's setter" shape the single-level `builtin_index_assign_method_lvalue` above it already uses — applied twice (rebuild the inner element, then the outer container around it), including the existing shared-Arc propagation to other aliases.
- Found while re-measuring `CSV::Table`'s own test suite (`docs/batteries/csv.md` CSV battery survey) after the `return-rw`/`AT-POS` postcircumfix fix (#6250): `t/1-delimiters.t` exercises exactly this pattern through the module's own `@.cell` attribute.
- Independent of #6250 (different code path — plain-container accessor nesting vs. instance postcircumfix subscript); both are needed for `CSV::Table`'s suite to fully pass, but neither depends on the other.

## Test plan
- [x] New `t/nested-index-assign-method-accessor.t` (array-of-arrays and hash-of-arrays accessor cases), verified matching `raku` directly.
- [x] `prove -e target/debug/mutsu t/attr-subscript-assignment.t t/container-identity-mutation.t t/container-identity-phase2-complete.t t/lvalue-method-writeback-coherence.t t/nested-assoc-user-assign-key.t t/whole-container-bind.t` — no regression in adjacent nested/container-mutation coverage.
- [x] `make test` — full suite passes.
- [x] `cargo clippy -- -D warnings` / `cargo fmt` clean.
- [x] Re-ran `CSV::Table`'s own `t/1-delimiters.t` (with this fix + #6250 stacked) — went from 1 failing assertion to fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)