### PR TITLE
docs(adr): ADR-0019 E5b step 2 -- resolve the Native-vs-User ordering question

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2932,6 +2932,38 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   detail, mismatch examples, and the two-option resolution in
   `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 1: shadow-verifying
   the Native candidate at CallMethod itself".
+  **Progress 2026-08-11** (E5b step 2, answers step 1's open question --
+  analysis only, no code change): the top-level `skip_native` gate does
+  **not** by itself guarantee `User` outranks `Native` (it only extracts a
+  `class_name` for `Instance`/`Package` receivers, missing e.g. a
+  `Mixin`-shaped `"hello" but SomeRole` receiver). Yet raku-verified
+  behavior is already correct (`$s.uc` on a `but`-mixed `Loud` role prints
+  `MIXED-UC` in both raku and mutsu) because a *second*, independent bypass
+  lives inside `try_native_method_raw` itself
+  (`mixin_role_has_method(target, &method_name) => return None`,
+  `vm_native_dispatch.rs:164-166`) -- one of 22 distinct per-shape
+  `return None` bypass sites in that file alone. The augment-collision
+  angle (`augment class Str { method uc {...} }`) isn't a real threat
+  either, but because raku itself rejects it at compile time (redeclaring
+  an already-declared core method without `multi` is a hard error; with
+  `multi` it's an unimplemented multi-dispatch ambiguity) -- not an E5b
+  ordering gap. **Conclusion: option (b) is confirmed as more than
+  "cheaper" -- it is the only mechanism keeping today's dispatch correct**;
+  option (a) is now actively discouraged, since making the `Native`
+  candidate alone safe to route on would require reimplementing the same
+  ~22 scattered shape-specific checks, ending up with two copies to keep in
+  sync. **This generalizes past `CallMethod`: the `Native` candidate from
+  `resolve_sequence` is measurement/hint-only at every E5/E6/E7 entry, not
+  a routing decision** -- decision 1's "decision match" applies to the
+  `User`/`NativeCallBinding` candidates only; the native probe stays a
+  direct, self-guarding call in its existing cascade position through
+  E5b-E7. Left open for the actual E5b cutover PR: how much of
+  `try_compiled_method_or_interpret_sym`'s own pre-lookup interceptor
+  cascade (default construction, Buf/Blob construction, Seq reification,
+  ...) is safe to fold into a decision match, separate from the
+  native-ordering question this step closes. Full detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 2: the top-level
+  `skip_native` gate does NOT settle the ordering question".
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -629,3 +629,100 @@ candidate at this specific arm, which would make option (b) sufficient and
 this whole `Native`-candidate refinement moot for `CallMethod` specifically
 (though not for other E5/E6 entries that reach this arm's twin without an
 equivalent gate).
+
+### E5b step 2: the top-level `skip_native` gate does NOT settle the ordering question -- the real guarantee is ~22 scattered per-shape bypass checks inside `try_native_method_raw` itself; option (b) confirmed, option (a) is now actively discouraged
+
+Answers step 1's open next question directly, by raku-verified experiment plus code
+inspection (no code change; this step is analysis only, like several prior scoping
+slices in this campaign).
+
+**The top-level gate does not cover every receiver shape that can carry a user
+override.** `exec_call_method_op_impl`'s `skip_native`/`has_user_method` computation
+(`vm_call_method_ops.rs:964-980`) only extracts a `class_name` to check for
+`ValueView::Instance`/`ValueView::Package` receivers -- a `Mixin`-shaped receiver
+(`"hello" but SomeRole`, the standard `but`-mixin idiom) falls through the `_ => None`
+arm and never sets `skip_native`. So the top-level gate, by itself, does **not**
+guarantee `User` outranks `Native` for a mixed-in method whose name collides with a
+native row.
+
+**Yet the actual behavior is already correct.** Verified directly:
+
+```raku
+role Loud { method uc { "MIXED-UC" } }
+my $s = "hello" but Loud;
+say $s.uc;   # raku: MIXED-UC, mutsu: MIXED-UC (confirmed, tmp/mixin-native-outrank.raku)
+```
+
+The reason is NOT the top-level gate -- it is a *second*, independent bypass check
+living inside `try_native_method_raw` itself (`vm_native_dispatch.rs:164-166`):
+
+```rust
+// Mixin role method bypass
+if self.mixin_role_has_method(target, &method_name) {
+    return None;
+}
+```
+
+This is one of **22 distinct `return None` bypass sites in `vm_native_dispatch.rs`
+alone** (grep count, this file only -- `builtins/` and the row-cascade modules likely
+add more), several of which exist specifically to decline native dispatch when a user
+override applies to a receiver *shape* the top-level `skip_native` gate cannot see:
+`mixin_role_has_method` (Mixin), `has_user_method("Match", ...)` +
+`exception_render_needs_interpreter` (lazy Match render overrides), the parallel
+`has_user_method(&cn, ...)` + `exception_render_needs_interpreter` block for realized
+Instance/Exception receivers (lines 239-263, a second, finer-grained check than the
+top-level gate's own Instance handling -- it additionally distinguishes "pure render"
+methods from others and checks a `Bridge` method), plus Seq-deferred-iterator and
+Buf-write-method bypasses unrelated to user overrides at all.
+
+**The augment-collision angle is not a real threat either, but for a different
+reason: raku itself forbids it.** Tried to construct a case where a *plain* builtin
+value (not mixin) has a colliding augmented method:
+
+```raku
+augment class Str { method uc { "AUGMENTED-UC" } }
+# raku: ===SORRY!=== Package 'Str' already has a method 'uc' (did you mean to declare a multi method?)
+augment class Str { multi method uc { "AUGMENTED-UC" } }
+# raku: Ambiguous call to 'uc(Str: )'; ... (real multi-dispatch ambiguity, a separate unimplemented feature)
+```
+
+Both forms raku rejects before the ordering question even arises (mutsu currently
+does neither -- it silently native-dispatches to the builtin `uc`, `HELLO` -- a
+latent gap, but a *compile-time-redeclaration/multi-ambiguity-detection* gap, not an
+E5b dispatch-ordering gap; out of scope here, not filed separately since augmenting
+an already-declared core method without `multi` is not a legitimate program shape
+worth a dedicated ticket by itself).
+
+**Conclusion, closing step 1's open question:**
+
+1. **Option (b) is confirmed correct** -- and more than "cheaper": it is *already
+   the only mechanism keeping today's dispatch correct*. The top-level `skip_native`
+   gate is a fast common-case bypass (avoids the `try_native_method_raw` call
+   entirely for the frequent Instance/Package-with-user-override case), not the
+   safety mechanism itself.
+2. **Option (a) (refining `native_row_servable` to be shape-aware) is now actively
+   discouraged, not just unnecessary.** To make the `Native` candidate alone safe to
+   route on, it would have to absorb the same ~22-and-growing scattered per-shape
+   checks `try_native_method_raw` already encodes -- at which point the resolver
+   candidate *is* a reimplementation of the cascade's own guard logic, with two
+   copies to keep in sync instead of one. That is strictly worse than calling the
+   real function.
+3. **This generalizes past `CallMethod`.** Every E5/E6/E7 entry that currently calls
+   `try_native_method`/`try_native_method_raw` inherits the same guarantee from the
+   same shared function -- the `Native` candidate from `resolve_sequence` should be
+   treated as **measurement/hint-only, never a routing decision, at every entry**,
+   not re-litigated per entry. Design decision 1's "decision match" framing should be
+   read as applying to the `User`/`NativeCallBinding` candidates (which E4a's
+   `shadow_check_resolver` already proved trustworthy) -- the native probe stays a
+   direct, self-guarding call in its existing cascade position at every cutover,
+   E5b through E7.
+4. **Left open for the actual E5b cutover PR** (not resolved by this analysis step):
+   whether the `User` candidate can cleanly replace any part of
+   `try_compiled_method_or_interpret_sym`'s own dispatch. Inspection shows that
+   function (`vm_call_method_compiled_interpret.rs`) is not a simple MRO-walk call
+   sitting behind the native probe -- it carries its own substantial native-ish
+   interceptor cascade first (default construction, Buf/Blob construction, Seq
+   reification, ...) before reaching the actual compiled/interpreted method lookup.
+   Scoping how much of *that* is safe to fold into a decision match is real,
+   unstarted work for the cutover PR itself, separate from the native-ordering
+   question this step closes.


### PR DESCRIPTION
## Summary
- Answers E5b step 1's open question (`todo/deep/adr0019-e5-e7-entry-routing.md`): does `CallMethod`'s existing `skip_native`/`has_user_method` gate already prevent the `Native` resolver candidate from ever needing to outrank a matching `User` candidate?
- Finding: the top-level gate does **not** by itself guarantee this (it misses e.g. a `Mixin`-shaped `"hello" but SomeRole` receiver), but the actual dispatch is already correct because `try_native_method_raw` carries its own independent per-shape bypass checks (22 distinct `return None` sites in that file alone, including a dedicated `mixin_role_has_method` check) -- raku-verified against a `but`-mixin repro.
- Conclusion: option (b) from step 1 (keep the native probe as a direct, self-guarding call) is confirmed as the *only* mechanism keeping dispatch correct today; option (a) (a shape-aware `native_row_servable`) is now actively discouraged. This generalizes past `CallMethod` -- the `Native` candidate is measurement/hint-only at every E5/E6/E7 entry, never a routing decision.

Analysis-only slice, no code change (`docs/adr/0019-...md` and `todo/deep/adr0019-e5-e7-entry-routing.md` only), following the campaign's established measurement-before-cutover methodology.

## Test plan
- Docs-only change; no `make test`/`make roast` impact expected.
- Repro programs used for the investigation were run locally against both `raku` and `target/debug/mutsu` and removed from `tmp/` afterward (not part of the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)