### PR TITLE
docs: narrow http-router-named-urls.t hang, refute ParseMemo theory for trait-check flip

### DIFF
--- a/todo/deep/pointy-block-custom-param-trait-parse-time-check-fails-for-large-modules.md
+++ b/todo/deep/pointy-block-custom-param-trait-parse-time-check-fails-for-large-modules.md
@@ -153,6 +153,51 @@ the "full CLI parse path divergence" investigation below (the side where ~15
 synthetic repro attempts failed). Until then, treat the memo collision as the
 most plausible explanation and this ticket as watch-only.
 
+## 2026-08-11: the flip recurred — memo theory now REFUTED per the protocol above
+
+While investigating an unrelated hang
+(`todo/tickets/http-router-named-urls-rc124-timeout.md`), a plain `cargo
+build` from this session's starting commit (no functional source changes,
+just an unrelated one-line addition to `state_supplier.rs` later reverted)
+flipped `http-router.rakutest` back to **0/83** — first-route "unknown trait
+'is' -> 'query'" — and simultaneously made `http-router-named-urls.t` (a
+different file, no custom traits of its own, but same `-I` module set) fail
+identically with **"unknown trait 'is' -> 'cookie'"** before any subtest
+runs. Followed the decision protocol exactly:
+
+- Reproduced 5/5 on this one binary (fully deterministic *for this binary*,
+  consistent with prior observations).
+- **`MUTSU_PARSE_MEMO=0` did NOT fix it** — same "unknown trait" error, 3/3.
+  Per the protocol above, **this refutes the ParseMemo collision theory** as
+  the explanation for this occurrence (the generation-key fix from
+  2026-08-09 is doing its job; whatever is happening now is a different
+  mechanism, or the "genuine miss" / scan-truncation path the ticket already
+  flags as the alternative).
+- Rebuilding again (touching only `src/main.rs`, reverted after) did **not**
+  un-flip it — stayed broken across 2 more rebuilds in this session. This
+  session did not find a rebuild that returned to the "lucky" 64/83 state
+  once it had flipped, unlike the 2026-08-09 note's four-rebuild streak that
+  stayed "lucky." (Not enough rebuild attempts were made to know whether
+  "stuck on the unlucky side" is now the more common state or this session
+  was just unlucky — worth tracking.)
+- Confirmed the flip is **not scoped to `is query`/`http-router.rakutest`
+  specifically** — `http-router-named-urls.t`'s `is cookie`/`is header` (same
+  `Cro::HTTP::Router` module, different call site) fails the same way on the
+  same binary, and (per the "What has been ruled out" note in the
+  named-urls-hang ticket) even a *content-free* rebuild with zero source
+  changes at all reproduced the same "unknown trait" failure — so this is
+  not caused by any specific edit, just binary-layout non-determinism that
+  is apparently still present post-memo-fix.
+
+**Practical impact restated:** `http-router.rakutest`'s pass count (and by
+extension any Cro::HTTP suite file sharing this large `-I` module set) is
+*still* not a stable number to cite from a single build. Per the protocol,
+the next investigator should pick up the "genuine miss" path (suggested
+step 3 below: does `parse_program_partial`'s scan of `Router.rakumod`
+actually reach and return from the whole `module Cro::HTTP::Router { ... }`
+block on an "unlucky" binary, or silently truncate?) rather than revisiting
+the memo theory, which is now refuted for this occurrence.
+
 ## Suggested next steps
 
 1. Instrument `main.rs`'s actual parse call (not a substitute unit test) with a

--- a/todo/tickets/http-router-named-urls-rc124-timeout.md
+++ b/todo/tickets/http-router-named-urls-rc124-timeout.md
@@ -33,3 +33,99 @@ debug-build test can simply be slow rather than stuck).
    attach) to find the stuck opcode/call.
 3. Binary-search the test file's subtests (comment out the back half) to
    narrow which specific assertion or fixture setup after subtest 28 hangs.
+
+## 2026-08-11 investigation (narrowed further, still unresolved)
+
+Confirmed with both debug and release builds, 3+/3 reproductions each, via
+`bash tmp/cro-t.sh t/http-router-named-urls.t`: the hang is fully
+deterministic (not load-sensitive) and always stops at the exact same
+point — TAP shows `ok 30 -` (no description) as the last line, then hangs
+until killed.
+
+**Exact hang site identified.** `ok 30` is the *first* `is` assertion inside
+this block (source lines 104-110):
+
+```raku
+test-route-urls route {
+    get -> {
+        is abs-link('css'), '/css';                           # <- this one: ok 30
+        is abs-link('css', 'x', 'y', 'z'), '/css/x/y/z';       # <- hangs evaluating this one
+    }
+
+    get :name<css>, -> 'css', +a { };
+}
+```
+
+Both assertions run inside the *same* handler invocation for the *same*
+synthetic `GET /` request built by the `test-route-urls` helper (see top of
+file): `Supplier.new` → `$app.transformer($source.Supply).Channel` →
+`$source.emit(...)` → `$responses.receive`. So the hang is either (a) inside
+`abs-link('css', 'x', 'y', 'z')` itself — generating a link for a route
+whose only handler-side param is a bare (no-sigil) slurpy positional
+`+a` — filling it with 3 extra args, or (b) in whatever machinery is
+supposed to deliver the handler's completed response back through the
+Channel afterward.
+
+**Confirmed genuine deadlock, not an infinite/spinning loop.** `ps
+-o pid,etimes,time,pcpu,nlwp` on the hung process shows CPU time flatlines
+early (~6s of CPU time accumulated by ~6s wall-clock, then *zero* additional
+CPU time consumed over the next several seconds while still hung) — i.e.
+by the time it's stuck, no thread is doing computational work. All 4
+threads (`/proc/<pid>/task/*/status`) sit in state `S` with `wchan
+futex_do_wait`. A `perf record -e sched:sched_switch --call-graph dwarf`
+sample of the periodically-timed-out thread shows it repeatedly parked in:
+
+```
+mutsu::runtime::methods_call_dispatch::call_method_with_values
+  -> mutsu::runtime::methods_promise::dispatch_channel_method
+  -> mutsu::value::value_async::<impl SharedChannel>::receive_result
+  -> mutsu::gc::stw::wait_until -> stw_aware_wait -> Condvar::wait_timeout
+```
+
+i.e. it is literally sitting in the `.receive()` call of `test-route-urls`,
+waiting for a value that never arrives — meaning nothing in the request
+pipeline ever called `SharedChannel::send`/`close`/`fail` on this route's
+response Supply. The other 3 threads never woke during the sampling
+window (no timeout on their wait), so their stacks weren't captured —
+`ptrace` is not available in this environment (`rust-gdb -p` fails with
+`Could not attach to process` / yama `ptrace_scope`; only `perf` has
+passwordless sudo here, not `gdb`), so a full 4-thread backtrace at the
+moment of hang is still missing. Getting one (e.g. by asking the user to
+temporarily lower `ptrace_scope`, or starting `perf record
+-e sched:sched_switch --call-graph dwarf -a` *before* launching the
+process so switch-out events for all 4 threads land inside the recording
+window) is the natural next step.
+
+**Trap hit while trying to build a synthetic repro — do not lose more time
+to this:** editing/truncating `t/http-router-named-urls.t` in *any* way
+(even adding a handful of `note` calls, or truncating well past the
+target block) reliably flips the failure mode to `Runtime error: Can't use
+unknown trait 'is' -> 'cookie' in a parameter declaration` — a **different,
+already-tracked, size-sensitive parse-time bug**
+(`todo/deep/pointy-block-custom-param-trait-parse-time-check-fails-for-large-modules.md`).
+Verified this is NOT a shared-cache race (`MUTSU_PRECOMP=0` doesn't change
+it) — it really is in-process ParseMemo pointer-identity sensitivity to the
+compiled buffer's exact byte length. **Do not try to instrument this
+specific file by editing it** — any edit changes its length and falls into
+that unrelated bug instead. A Cro-independent minimal repro (own file,
+outside the `t/`/`-I` tree) has not been achieved yet either — two attempts
+both resolved `abs-link` calls fine outside of Cro's own module tree,
+because `abs-link`/`route{}` need context normally only set up by
+`Cro::HTTP::Router` internals (not yet replicated standalone).
+
+**Suggested next steps**, in order:
+1. Get a full 4-thread native backtrace at the hang (ptrace access needed —
+   ask the user, or find another route to it) rather than editing the `.t`
+   file.
+2. Alternatively, add temporary `eprintln!`-based instrumentation on the
+   **Rust side only** (e.g. in `native_supply_dispatch.rs`'s `"Channel"`
+   arm, and wherever a spawned thread executes a `whenever`/handler body
+   and would normally call `ch.send`/`ch.fail`) gated behind a scratch env
+   var — this avoids touching the `.raku` file's byte length entirely and
+   sidesteps the ParseMemo trap above.
+3. Read `Cro::HTTP::Router`'s route-matching/link-generation source
+   (`tmp/cro-work/C_RO_CRO_HTTP_*/lib/Cro/HTTP/Router.rakumod`) for how it
+   handles a slurpy positional (`+a`) with no sigil when building/matching
+   a link — compare against `raku`'s behavior for the same construct
+   (`raku` passes this test file fully) to see whether mutsu's slurpy
+   handling for a **bare (no-sigil) slurpy** specifically is diverging.


### PR DESCRIPTION
## Summary
- `todo/tickets/http-router-named-urls-rc124-timeout.md`: confirmed the rc=124 timeout is a genuine cross-thread deadlock (not a spin loop -- CPU flatlines, all 4 threads parked on futex), narrowed to the exact assertion (`abs-link` on a route with a bare no-sigil slurpy positional `+a`), and documented that ptrace is unavailable in this environment and that editing the `.t` file at all reliably triggers an unrelated bug instead.
- `todo/deep/pointy-block-custom-param-trait-parse-time-check-fails-for-large-modules.md`: the documented 64/83 <-> 0/83 build-to-build flip recurred this session. Followed the ticket's own decision protocol (`MUTSU_PARSE_MEMO=0`) and confirmed it does **not** fix the flip, refuting the ParseMemo collision theory for this occurrence and pointing the next investigator at the "genuine miss" / scan-truncation path instead.

Docs-only change, no source edits.

## Test plan
- N/A (docs-only; `ci-docs-only.sh` should route this to the skip path)