### PR TITLE
refactor(vm): ADR-0019 E5b step 3 -- shadow-verify User candidate at try_compiled_method_or_interpret

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2964,6 +2964,34 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   native-ordering question this step closes. Full detail in
   `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 2: the top-level
   `skip_native` gate does NOT settle the ordering question".
+  **Progress 2026-08-11** (E5b step 3, shadow-verify the `User` candidate
+  at `try_compiled_method_or_interpret`'s own resolution point): closes
+  the "`User` candidate" half of step 2's open item 4. That function's
+  Instance/Package resolution block turned out to be an inlined duplicate
+  of `resolve_method_cached`'s exact three-tier cache and its two
+  `resolve_method_with_owner_invocant` calls -- but reached only from the
+  higher-traffic non-mut `CallMethod` opcode, which `resolve_method_cached`
+  itself does not serve (only the Mut path does), so E4a's shadow probe had
+  never actually run on this call site. Added the same
+  `shadow_check_resolver` call `resolve_method_cached` already makes at its
+  two resolve points, here too (sites `try_compiled_method_or_interpret:multi`/
+  `:fresh`) -- pure instrumentation, zero behavior change. Full `t/` sweep
+  (3022 files, `-P8`): 15085 total checks (both this box's new sites and
+  `resolve_method_cached`'s existing ones), 25 mismatches (0.166%), every
+  one decomposing to the single already-documented divergence class (a
+  non-multi candidate whose signature doesn't match the call, e.g.
+  `assign-rw($a is rw)` called with a literal) -- no new divergence class,
+  confirming E4a's resolver is trustworthy at the busiest call site too, not
+  just inferred from the Mut-path sweep. `make test`-equivalent (`prove -j8
+  t/*.t`, 3022 files/28279 tests) green, unchanged. Still open: whether any
+  of the ~430-line pre-lookup interceptor cascade ahead of this resolution
+  block (Seq reification, the `.new`/`bless` native construction forks,
+  IO::Handle/IO::Path native methods, MOP pseudo-methods, private methods,
+  `^`-metamethods) can fold into a decision match, or must stay direct
+  self-guarding pre-checks like the `Native` candidate -- most already gate
+  on `has_user_method`/`is_native_method` internally, the same
+  irreplaceable per-shape-check pattern step 2 found for `Native`. Full
+  detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 3".
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -584,6 +584,23 @@ impl Interpreter {
                                 self,
                                 resolve_method_with_owner_invocant(cn, method, &args, &target)
                             );
+                            // ADR-0019 E5b step 3 shadow probe (zero behavior
+                            // change): E4a's `resolve_sequence`/
+                            // `pick_method_winner` was shadow-verified only at
+                            // `resolve_method_cached` (the Mut path); this is
+                            // the equivalent resolution point on the hotter
+                            // non-mut `CallMethod` path, previously unchecked.
+                            // See `todo/deep/adr0019-e5-e7-entry-routing.md`
+                            // §"E5b step 3".
+                            self.shadow_check_resolver(
+                                "try_compiled_method_or_interpret:multi",
+                                cn,
+                                method,
+                                method_sym,
+                                &args,
+                                &target,
+                                resolved.as_ref(),
+                            );
                             let resolved_arc =
                                 resolved.map(|(owner, def)| (owner, std::sync::Arc::new(def)));
                             // Never cache an ambiguous multi resolution — it must
@@ -597,6 +614,17 @@ impl Interpreter {
                         let resolved = loan_env!(
                             self,
                             resolve_method_with_owner_invocant(cn, method, &args, &target)
+                        );
+                        // ADR-0019 E5b step 3 shadow probe (zero behavior
+                        // change): see the note above.
+                        self.shadow_check_resolver(
+                            "try_compiled_method_or_interpret:fresh",
+                            cn,
+                            method,
+                            method_sym,
+                            &args,
+                            &target,
+                            resolved.as_ref(),
                         );
                         let resolved_arc =
                             resolved.map(|(owner, def)| (owner, std::sync::Arc::new(def)));

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -726,3 +726,54 @@ worth a dedicated ticket by itself).
    Scoping how much of *that* is safe to fold into a decision match is real,
    unstarted work for the cutover PR itself, separate from the native-ordering
    question this step closes.
+
+### E5b step 3: shadow-verifying the `User` candidate at `try_compiled_method_or_interpret`'s own resolution point -- confirms E4a's trust extends to the hottest, previously-unchecked call site
+
+Closes part of step 2's item 4 (the "`User` candidate" half, not the interceptor-cascade
+half, which is still open). Inspection of `vm_call_method_compiled_interpret.rs`'s
+Instance/Package resolution block (the code the ADR's step-2 note calls "the actual
+compiled/interpreted method lookup") shows it duplicates `resolve_method_cached`'s exact
+three-tier cache (monomorphic inline cache -> non-multi `HashMap` -> sound multi-resolution
+cache) and its two `resolve_method_with_owner_invocant` calls almost verbatim -- but as an
+inlined copy, not a shared call. **`resolve_method_cached` already carries E4a's
+`shadow_check_resolver` probe at both of its own resolve call sites; this inlined duplicate,
+reached from `CallMethod` -- the higher-traffic non-mut opcode `resolve_method_cached`'s own
+caller (`vm_call_method_compiled_mut.rs`, the Mut path) does not serve -- carried no shadow
+probe at all.** So E4a's "resolver is trustworthy" conclusion, to date, had only ever been
+measured on the Mut path; the busier non-mut path was untested by construction.
+
+**Change (zero behavior change, pure instrumentation):** added the same
+`self.shadow_check_resolver(...)` call `resolve_method_cached` already makes, at the
+equivalent two points inside `try_compiled_method_or_interpret_inner`'s resolution block
+(`vm_call_method_compiled_interpret.rs`) -- the multi-resolve-cache-miss branch (site
+`try_compiled_method_or_interpret:multi`) and the fresh-resolve branch (site
+`try_compiled_method_or_interpret:fresh`). Both pass the `Option<(Symbol, MethodDef)>`
+already computed by the existing `resolve_method_with_owner_invocant` call, before it is
+Arc-wrapped and cached -- identical shape to the two call sites in `resolve_method_cached`.
+
+**Sweep (debug build, `MUTSU_VM_STATS=1`, full `t/*.t`, 3022 files, `-P8`):** 15,085 total
+`resolver_shadow_checks` across both `resolve_method_cached`'s and this box's two new sites,
+25 mismatches (0.166%) -- same order of magnitude as E4a's original near-zero baseline. Every
+mismatch decomposed by the existing per-site breakdown (`resolver-shadow mismatches by site`)
+to the **single already-documented, already-accepted divergence class** from the
+`resolution_sequence` module doc: a non-multi candidate whose own signature does not match the
+call (e.g. `method assign-rw($a is rw)` invoked with a literal argument) -- the real resolver
+returns that sole visible candidate anyway (Raku resolves a non-multi method by name alone,
+raising the signature-bind error only after resolution), while the E4a shadow winner correctly
+answers `None` since it only ranks candidates that already passed
+`method_args_match_for_invocant`. All 25 mismatches showed `shadow=None` opposite a `real=Some(...)`
+non-multi candidate; none were the reverse direction, and none touched a new method/class pattern
+not already named in the module doc. `make test`-equivalent local suite (`prove -j8 t/*.t`, 3022
+files / 28,279 tests) green, unchanged.
+
+**Conclusion:** E4a's resolver is now empirically confirmed trustworthy at the actual
+highest-traffic non-mut call site, not just inferred by construction from the Mut-path sweep --
+closing the "`User` candidate" half of step 2's open item 4. **Still open, unstarted:** whether
+any of the pre-lookup interceptor cascade (`try_compiled_method_or_interpret_inner`'s ~430
+lines before this resolution block -- Seq reification, the seven `.new`/`bless` native
+construction forks, the IO::Handle/IO::Path native-method chain, MOP pseudo-methods, private
+methods, `^`-metamethods) can be folded into a decision match, or whether (per step 2's general
+conclusion about the `Native` candidate) each must stay a direct, self-guarding pre-check for
+the same reason the native probe does -- most of them already gate on `has_user_method`/
+`is_native_method` internally, which is exactly the per-shape-check pattern step 2 found
+irreplaceable for `Native`. That inventory and classification is the next E5b sub-slice.


### PR DESCRIPTION
## Summary
- Extends the ADR-0019 E4a shadow-verification of `resolve_sequence`/`pick_method_winner` to `try_compiled_method_or_interpret_inner`'s own resolution block (the non-mut `CallMethod` opcode's path), which was previously untested: `resolve_method_cached` (used only by the Mut path) already carried the `shadow_check_resolver` probe at its two resolve points, but this function's inlined duplicate of the same three-tier cache did not.
- Pure instrumentation, zero behavior change -- no dispatch decision reads the new probe's result.
- Full `t/*.t` sweep under `MUTSU_VM_STATS=1`: 15085 total resolver-shadow checks (across both this box's new sites and `resolve_method_cached`'s existing ones), 25 mismatches (0.166%), all decomposing to the single already-documented, already-accepted divergence class from E4a (a non-multi candidate whose own signature doesn't match the call, e.g. `assign-rw($a is rw)` invoked with a literal). No new divergence class found.
- Confirms the resolver is trustworthy at the highest-traffic call site too, closing the "`User` candidate" half of E5b step 2's open item 4. Design and sweep detail recorded in `todo/deep/adr0019-e5-e7-entry-routing.md` ("E5b step 3") and `docs/adr/0019-...md`.

## Test plan
- [x] `cargo build`
- [x] `cargo fmt` / `cargo clippy -- -D warnings` (pre-commit hooks)
- [x] `prove -j8 -e target/debug/mutsu t/*.t` (3022 files / 28279 tests) green
- [x] `MUTSU_VM_STATS=1` full `t/` sweep to confirm the shadow-check mismatch rate (25/15085, all pre-explained)
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)