### PR TITLE
refactor(vm): ADR-0019 E5b step 4 -- classify interceptor cascade, dedup CallMethod's User resolution

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2992,6 +2992,31 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   on `has_user_method`/`is_native_method` internally, the same
   irreplaceable per-shape-check pattern step 2 found for `Native`. Full
   detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 3".
+  **Progress 2026-08-11** (E5b step 4, closing E5b at `CallMethod`): inventoried and
+  classified the ~430-line pre-lookup interceptor cascade step 3 left open (Seq
+  reification, ten `.new`/`bless`/class-method native construction forks, the
+  IO::Handle/IO::Path Instance chain, MOP pseudo-methods, private methods,
+  `^`-metamethods). None fold into a decision match -- each `.new`/`bless` fork is a
+  self-contained construction routine with side effects beyond ordinary dispatch
+  (registry mutation, deferred-iterator registration, real socket I/O), and the other
+  four items are foldable-shape catalogs, class-(b) method-identity intercepts,
+  a separate private-visibility tier (E7's job), or metamethod-specific invocation --
+  all stay direct, self-guarding pre-checks, generalizing step 2's `Native`-candidate
+  conclusion to this second cascade. Found and dispositioned a guard-completeness gap
+  shared by five forks (IO::Path family/`Failure`/`Seq`/`IO::Socket::INET`/builtin
+  class method: no `has_user_method` check, guarded only by exact class-name equality)
+  as the same pre-existing `augment`-redeclaration-detection gap step 2 already found
+  for `Str.uc` -- not a new ticket. **The resolution block itself did cut over**: since
+  step 3 shadow-verified it an exact duplicate of `resolve_method_cached` reading/
+  writing the same instance-level caches, replaced the ~90-line inlined duplicate with
+  a direct `self.resolve_method_cached(..)` call -- a pure dedup, zero behavior change,
+  closing step 2's open item 4 for the `User` candidate. `cargo test --lib` (779),
+  full local suite (3022 files / 28,279 tests), `cargo clippy -- -D warnings` all
+  green. **E5b is closed at `CallMethod`'s own entry point** -- native candidate stays
+  a direct probe, user candidate resolution is shared/deduped, cascade stays direct.
+  Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 4". Next:
+  E5c/E5d (`CallMethodDynamic` + the two hyper entries, already measured in E5 steps
+  2-3).
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -551,98 +551,27 @@ impl Interpreter {
                 }
             }
 
-            if let Some((owner_class, method_def)) = {
-                // Monomorphic inline cache: single-entry check before HashMap.
-                if let Some((cc, cm, co, ref cd)) = self.last_method_resolve
-                    && cc == class_sym
-                    && cm == method_sym
-                    && !cd.is_multi
-                {
-                    Some((co, cd.clone()))
-                } else {
-                    let cached = self.method_resolve_cache.get(&cache_key).cloned();
-                    let result: Option<(
-                        crate::symbol::Symbol,
-                        std::sync::Arc<crate::runtime::MethodDef>,
-                    )> = if let Some(ref hit) = cached
-                        && let Some((_, def)) = hit
-                        && !def.is_multi
-                    {
-                        hit.clone()
-                    } else if let Some(arg_keys) = self.multi_arg_type_keys(&args)
-                        && self.multi_dispatch_type_cacheable(class_sym, method_sym, cn, method)
-                    {
-                        // Sound multi-method resolution cache (§B): a type+arity-
-                        // deterministic multi resolves as a function of (class,
-                        // method, positional arg types), so key it on those types
-                        // rather than re-running the MRO/specificity walk per call.
-                        let mkey = (class_sym, method_sym, arg_keys);
-                        if let Some(hit) = self.multi_resolve_cache.get(&mkey) {
-                            hit.clone()
-                        } else {
-                            let resolved = loan_env!(
-                                self,
-                                resolve_method_with_owner_invocant(cn, method, &args, &target)
-                            );
-                            // ADR-0019 E5b step 3 shadow probe (zero behavior
-                            // change): E4a's `resolve_sequence`/
-                            // `pick_method_winner` was shadow-verified only at
-                            // `resolve_method_cached` (the Mut path); this is
-                            // the equivalent resolution point on the hotter
-                            // non-mut `CallMethod` path, previously unchecked.
-                            // See `todo/deep/adr0019-e5-e7-entry-routing.md`
-                            // §"E5b step 3".
-                            self.shadow_check_resolver(
-                                "try_compiled_method_or_interpret:multi",
-                                cn,
-                                method,
-                                method_sym,
-                                &args,
-                                &target,
-                                resolved.as_ref(),
-                            );
-                            let resolved_arc =
-                                resolved.map(|(owner, def)| (owner, std::sync::Arc::new(def)));
-                            // Never cache an ambiguous multi resolution — it must
-                            // re-raise X::Multi::Ambiguous on every call.
-                            if !self.dispatch_ambiguous {
-                                self.multi_resolve_cache.insert(mkey, resolved_arc.clone());
-                            }
-                            resolved_arc
-                        }
-                    } else {
-                        let resolved = loan_env!(
-                            self,
-                            resolve_method_with_owner_invocant(cn, method, &args, &target)
-                        );
-                        // ADR-0019 E5b step 3 shadow probe (zero behavior
-                        // change): see the note above.
-                        self.shadow_check_resolver(
-                            "try_compiled_method_or_interpret:fresh",
-                            cn,
-                            method,
-                            method_sym,
-                            &args,
-                            &target,
-                            resolved.as_ref(),
-                        );
-                        let resolved_arc =
-                            resolved.map(|(owner, def)| (owner, std::sync::Arc::new(def)));
-                        if resolved_arc.as_ref().is_none_or(|(_, def)| !def.is_multi) {
-                            self.method_resolve_cache
-                                .insert(cache_key, resolved_arc.clone());
-                        }
-                        resolved_arc
-                    };
-                    if let Some((owner, ref def)) = result
-                        && !def.is_multi
-                    {
-                        self.last_method_resolve =
-                            Some((class_sym, method_sym, owner, def.clone()));
-                    }
-                    result
-                }
-            } {
+            // ADR-0019 E5b step 4 cutover: this used to be an inlined duplicate
+            // of `resolve_method_cached`'s exact three-tier cache (monomorphic
+            // inline cache -> non-multi `HashMap` -> sound multi-resolution
+            // cache -> fresh resolve), reached only from this higher-traffic
+            // non-mut `CallMethod` opcode path (the Mut path already called
+            // `resolve_method_cached` directly). E5b step 3 added the same
+            // `shadow_check_resolver` probe here that `resolve_method_cached`
+            // already carries at its own two resolve points, and swept it
+            // clean (15,085 checks, 0.166% mismatches, all the single
+            // already-documented divergence class) -- confirming the two
+            // blocks are behaviorally identical, not just structurally
+            // similar. Calling the shared function directly removes the
+            // duplicate (and its now-redundant shadow probe) with zero
+            // behavior change: both call sites share the same instance-level
+            // caches (`last_method_resolve`/`method_resolve_cache`/
+            // `multi_resolve_cache`), so this is a pure dedup, not a
+            // caching-behavior change. See
+            // `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 4".
+            if let Some((owner_class, method_def)) =
+                self.resolve_method_cached(cn, method, class_sym, method_sym, &args, &target)
+            {
                 // A public attribute accessor can win over the method that
                 // resolution picked: a child class's accessor shadows a
                 // parent's explicit method (the accessor is a method at the

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -777,3 +777,110 @@ conclusion about the `Native` candidate) each must stay a direct, self-guarding 
 the same reason the native probe does -- most of them already gate on `has_user_method`/
 `is_native_method` internally, which is exactly the per-shape-check pattern step 2 found
 irreplaceable for `Native`. That inventory and classification is the next E5b sub-slice.
+
+### E5b step 4: inventory and classification of the pre-lookup interceptor cascade -- nothing folds into a decision match, but the resolution block itself dedups to a direct `resolve_method_cached` call, closing the User-candidate cutover
+
+Closes step 3's open item: whether any of `try_compiled_method_or_interpret_inner`'s ~430-line
+pre-lookup cascade (Seq reification, the ten `.new`/`bless`/class-method native construction
+forks, the IO::Handle/IO::Path Instance chain, MOP pseudo-methods, private methods,
+`^`-metamethods) can fold into a `resolve_sequence`-style decision match.
+
+**Self-guarding inventory, the ten `.new`/`bless`/class-method forks (item numbering matches the
+file's top-to-bottom order):**
+
+| Fork | Call-site guard | Internal guard | Guard mechanism |
+|---|---|---|---|
+| Native default `new` | none visible | yes | `try_native_default_construct` -> `native_ctor_plan(..).eligible` -> `is_native_default_constructible` (`src/runtime/methods_object.rs:95-96`) checks `!class_def.methods.contains_key("new")` |
+| Native builtin `new` (Buf/Blob/Version/...) | yes | n/a | `vm_call_method_compiled_interpret.rs:99`: `!self.has_user_method(&class_name.resolve(), "new")` |
+| Native QuantHash `new` (Set/Bag/Mix/...) | yes | n/a | `vm_call_method_compiled_interpret.rs:113`: `!self.user_declared_classes.contains(..)` |
+| Native aggregate `new` (Array/List/Hash/Map) | yes | n/a | same `user_declared_classes` pattern, `vm_call_method_compiled_interpret.rs:126` |
+| Native IO::Path family `new` | none | none | `try_native_io_path_construct` (`methods_object_native_ctors_io.rs:6-38`) gates only on `is_io_path_lexical_class` -- a fixed-name-list match, no user-method check anywhere in the chain |
+| Native `Failure.new` | none (`class_name == "Failure"`) | none | `build_native_failure_value` (`methods_object_native_ctors_misc.rs:230`) reads only args/`$!`/MRO, no user-method check |
+| Native `Seq.new` | none (`class_name == "Seq"`) | none | `try_native_seq_construct` (`methods_object_native_ctors_misc.rs:168-228`) -- pure iterator registration, no user-method check |
+| Native `IO::Socket::INET.new` | none (`class_name == "IO::Socket::INET"`) | none | `dispatch_socket_inet_new` (`methods_collection_ops/socket_inet_proc.rs:10`) -- pure arg-parse + bind/connect, no user-method check |
+| Native `bless` | via `loan_env!` | yes | `try_native_bless` (`methods_dispatch_new.rs:600`): `if self.native_ctor_plan(class_name).has_custom_bless { return None; }` |
+| Native builtin class method | none | none | `try_native_builtin_class_method` (`methods_object_native_ctors_io.rs:487-501`) currently handles only `Instant.from-posix`, no user-method check |
+
+Five forks (IO::Path family, `Failure`, `Seq`, `IO::Socket::INET`, builtin class method) have no
+`has_user_method`/`user_declared_classes` guard anywhere in the chain -- guarded only by exact
+class-name equality. Checked whether that is a real gap, raku-first, then on mutsu
+(`cargo build`, `target/debug/mutsu`):
+
+```raku
+class MySeq is Seq { method new(*%a) { "USER-SUBCLASS-OVERRIDE" } }
+say MySeq.new;   # raku: USER-SUBCLASS-OVERRIDE, mutsu: USER-SUBCLASS-OVERRIDE (subclassing is fine)
+
+use MONKEY-TYPING;
+augment class Seq { method new(*%a) { "USER-OVERRIDE" } }
+# raku: ===SORRY!=== Package 'Seq' already has a method 'new' (did you mean to declare a multi method?)
+```
+
+Identical redeclaration error from raku for `IO::Path`, `Failure`, `Instant` (`from-posix`);
+`IO::Socket::INET` rejects `augment` outright (`is a builtin type, not an external module`). The
+`multi method new` dodge fails too, with `X::Multi::Ambiguous` at the call site. mutsu, however,
+silently accepts the illegal `augment` and the native fork still wins (verified for all five --
+e.g. `mutsu -e 'use MONKEY-TYPING; augment class Seq { method new(*%a) {"USER-OVERRIDE"} }; say
+Seq.new;'` prints `()`, not `USER-OVERRIDE`). **This is not a new E5b gap** -- it is the same
+pre-existing bug class step 2 already found for `Str.uc` and explicitly declined to file
+separately ("augmenting an already-declared core method without `multi` is not a legitimate
+program shape worth a dedicated ticket by itself"). The root cause is mutsu's missing
+compile-time redeclaration/multi-ambiguity detection for `augment`, not a dispatch-ordering
+defect in these five forks -- each is unreachable via any *legal* raku program that collides
+with it. If that redeclaration-detection gap is ever closed, all five forks become moot
+automatically (the illegal program becomes a compile error before reaching them), so no
+independent action is needed on the forks themselves. (Aside, unrelated to this finding:
+`class MyInstant is Instant {...}` itself fails in mutsu today -- `'MyInstant' cannot inherit
+from 'Instant' because it is unknown` -- a separate, narrower limitation that makes the builtin
+class method fork's gap moot for `Instant` specifically regardless of the augment question.)
+
+**Items 12-15 (IO::Handle/IO::Path Instance chain, MOP pseudo-methods, private methods,
+`^`-metamethods): all four must stay direct pre-checks, for four different reasons:**
+
+1. **IO::Handle/IO::Path Instance chain** (~10 stacked probes, `vm_call_method_compiled_interpret.rs:213-361`):
+   each is its own shape-specific self-guarding check. Folding them into the resolver would mean
+   reimplementing the same shape catalog inside `resolve_sequence` -- step 2's "two copies to
+   keep in sync instead of one" trap, applied to a second cascade.
+2. **MOP pseudo-methods** (`DEFINITE`/`WHAT`/`WHO`/`HOW`/`WHY`/`WHICH`/`WHERE`/`VAR`, lines
+   365-371): not a dispatch probe at all -- a class-(b) method-identity intercept per design
+   decision 2's taxonomy, matching on method name alone regardless of receiver. The design doc
+   already assigns class-(b) intercepts to stay put through E5/E6 (moving them is F-phase
+   cleanup).
+3. **Private methods** (lines 374-455): not part of `resolve_sequence`'s public-method walk at
+   all -- `resolve_private_method_for_vm` is a wholly separate visibility-scoped tier, and the
+   design doc's own E7 slicing already assigns private-method dispatch's fold-in to E7, not E5b.
+4. **`^`-metamethods** (lines 458-476): closest to foldable -- its guard
+   (`self.has_user_method(cn, method)`) is literally the same predicate a resolver "does a User
+   candidate exist" answer would give -- but the invocation shape (`how_args = [target, ...args]`,
+   threading `target` as an explicit leading positional) is metamethod-specific calling
+   convention the decision match's existing "user candidate -> compiled/interpret path" arm
+   cannot drive as-is.
+
+**Conclusion: none of the pre-lookup cascade folds into a decision match.** Every `.new`/`bless`
+fork is not a guard-then-dispatch pair but a self-contained construction routine with side
+effects beyond ordinary method dispatch (registry mutation, deferred-iterator table
+registration, real socket I/O, `$!`-env reads). Per step 2's reasoning, routing these through a
+resolver decision would mean either reimplementing each one's side-effecting body inside the
+resolver (a regression) or having the resolver answer only the guard question and still call the
+same direct function (no simpler than today). All items 2-15 stay direct, self-guarding
+pre-checks, exactly like the `Native` candidate at `CallMethod`.
+
+**But the actual resolution block this cascade guards *does* cut over.** Step 3 already showed
+this function's Instance/Package resolution block (`vm_call_method_compiled_interpret.rs:554-644`,
+pre-cutover) was an inlined duplicate of `resolve_method_cached`'s exact three-tier cache and its
+two `resolve_method_with_owner_invocant` calls, and shadow-verified it trustworthy (15,085 checks,
+0.166% mismatches, the single already-documented divergence class). Since both blocks read and
+write the same instance-level caches (`last_method_resolve`/`method_resolve_cache`/
+`multi_resolve_cache`), replacing the ~90-line duplicate with a direct
+`self.resolve_method_cached(cn, method, class_sym, method_sym, &args, &target)` call is a pure
+dedup with no behavior change -- not a new decision match, but the concrete cutover step 2's
+open item 4 was asking about: "whether the `User` candidate can cleanly replace any part of
+`try_compiled_method_or_interpret_sym`'s own dispatch." It can, exactly at this one block. Landed
+together with this step's analysis (`adr0019-e5b-step4-callmethod-resolve-dedup` branch).
+Verified: `cargo test --lib` (779 tests), full local suite (`prove -e scripts/run-t-test.sh t/`,
+3022 files / 28,279 tests) green; `cargo clippy -- -D warnings` clean.
+
+**E5b is now closed at `CallMethod`'s own entry point.** The `Native` candidate stays a direct
+probe (step 2), the `User` candidate resolution is deduped onto the shared cached resolver (this
+step), and the surrounding interceptor cascade stays as direct self-guarding pre-checks (this
+step). What is left for E5c/E5d is the two `CallMethodDynamic`/hyper entries measured in E5 steps
+2-3, not further work on `CallMethod` itself.


### PR DESCRIPTION
## Summary
- Inventories and classifies the pre-lookup interceptor cascade in `try_compiled_method_or_interpret_inner` that E5b step 3 left open -- none of it folds into a resolver decision match; each `.new`/`bless`/class-method construction fork has side effects beyond ordinary dispatch, and the remaining items (IO::Handle chain, MOP pseudo-methods, private methods, `^`-metamethods) each have their own reason to stay a direct pre-check.
- Finds and dispositions a guard-completeness gap shared by five construction forks (no `has_user_method` check) as the same pre-existing `augment`-redeclaration-detection gap E5b step 2 already found for `Str.uc` -- not a new ticket.
- Cuts over the actual resolution block: replaces the ~90-line inlined duplicate of `resolve_method_cached`'s three-tier cache (shadow-verified identical in step 3) with a direct call to the shared cached resolver -- a pure dedup, zero behavior change, closing E5b at `CallMethod`'s own entry point.

Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 4" and the ADR progress log.

## Test plan
- [x] `cargo build` clean, `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` (779 tests) green
- [x] Full local suite: `MUTSU_BIN=target/debug/mutsu prove -e scripts/run-t-test.sh t/` (3022 files / 28,279 tests) green
- [x] Targeted roast subset (S12-methods, S12-attributes, S14-roles, S06-multi) against release build: only failure is `S12-attributes/trusts.t` (not in `roast-whitelist.txt`, pre-existing, unrelated to this change)
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)