### PR TITLE
docs(adr): ADR-0019 E5c/E5d -- classify CallMethodDynamic and hyper entries, close all of E5

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3017,6 +3017,37 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 4". Next:
   E5c/E5d (`CallMethodDynamic` + the two hyper entries, already measured in E5 steps
   2-3).
+  **Progress 2026-08-11** (E5c, both parts, closing E5c): classified
+  `CallMethodDynamic`'s 14 named intercept arms and confirmed its general-case
+  fallthrough already calls the shared `try_native_method`/`try_compiled_method_or_interpret`
+  pair directly, with no inline cache or inlined resolution logic anywhere in the file
+  -- unlike `CallMethod`, this entry never had a duplicate to converge, so it inherited
+  E5b's closure automatically: no code change. For the hyper entries' per-element probe
+  (part 2), raku-verified the gap E5 step 3 flagged (`HyperMethodCallDynamic` has no
+  `skip_native`/`has_user_method` gate, unlike its static twin) against six collision
+  attempts (Instance overrides + a `but`-mixin) -- zero divergence found, generalizing
+  step 2's "the real safety net lives inside `try_native_method_raw` itself, not the
+  caller's outer gate" conclusion to a second entry; downgrades that gap from "must
+  fix" to "redundant defense-in-depth", no code change needed. The raku-verification
+  pass did surface two real, unrelated bugs, both filed rather than fixed here: `.WHICH`/
+  `.WHY` user overrides are silently ignored except via a compile-time-literal quoted
+  call (two independent "skip native pseudo dispatch" mechanisms, neither aware these
+  two of the eight MOP pseudo-methods are genuinely overridable --
+  `todo/deep/pseudo-method-which-why-user-override-ignored-in-bareword-and-dynamic-form.md`),
+  and unquoted `.$name` accepts a bare-string name where raku requires Callable/`CALL-ME`
+  (`todo/tickets/dollar-dot-dynamic-method-name-should-require-callable.md`). Full detail
+  in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5c, part 1"/"part 2". **E5c is closed.**
+  Next: **E5d** (JIT-shim parity check, no code change expected).
+  **Progress 2026-08-11** (E5d, closing all of E5): confirmed by inspection, not
+  assumption -- of the two JIT shims in E5/E6's scope (`vm_jit_helpers.rs:314/367`),
+  only `call_method` (`OpCode::CallMethod`) is E5's; it re-enters `exec_call_method_op`
+  itself (the same entry point the non-JIT dispatch arm calls) with a byte-identical
+  post-call tail, so every E5b/E5c change inside that function is covered under JIT
+  automatically, no shim-side change needed. `CallMethodDynamic` and the two hyper
+  opcodes have no JIT shim at all, so the check does not apply to them. **All of E5
+  (steps 1-4, E5b, E5c parts 1-2, E5d) is closed.** Full detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5d". Next: **E6** (mutation-aware and
+  container calls).
 - [ ] **E6 — Route mutation-aware and container calls through the resolver.** Cover celled,
   lvalue/rw, Proxy, index/attribute writeback, and mutable aggregate entry points.
   **Design 2026-08-10** (same doc): includes `call_method_mut_with_values` (the second slow

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -884,3 +884,146 @@ probe (step 2), the `User` candidate resolution is deduped onto the shared cache
 step), and the surrounding interceptor cascade stays as direct self-guarding pre-checks (this
 step). What is left for E5c/E5d is the two `CallMethodDynamic`/hyper entries measured in E5 steps
 2-3, not further work on `CallMethod` itself.
+
+### E5c, part 1: `CallMethodDynamic` -- already closed by inheritance from E5b, no code change
+
+Per design decision 4's slicing, E5c covers `CallMethodDynamic` plus the two hyper entries' per-
+element probe. This is part 1 (the `CallMethodDynamic` opcode itself); the hyper entries are a
+separate part (below).
+
+`exec_call_method_dynamic_op` (`src/vm/vm_call_method_mut_ops.rs:30-345`) was already fully
+taxonomized by E5 step 2's measurement slice (see that section's table above) -- this pass turned
+that table into the per-arm numbered classification design decision 2 asks for, and checked
+whether the general-case fallthrough is genuinely already in target end-state shape rather than
+assuming it from the table alone.
+
+**Every one of the 14 named intercept arms is class (a) or (b)**: LazyIoLines force (a); `.+`/`.*`
+modifiers, `$obj.$coderef(...)` (unique to this entry -- the name-value is itself a `Sub`/
+`WeakSub`/`Routine`, bypassing method lookup via `vm_call_on_value` entirely), `.return`,
+`.hyper`/`.race` config, and the 9 HyperSeq/RaceSeq delegate arms (all (b) -- method-identity
+intercepts, receiver-shape-independent for the 7 pure ones, wrapping their own inner (c) probe
+pair for `map`/`grep`/the catch-all, matching `CallMethod`'s own established convention for
+identically-shaped wrapped arms). No arm needed reclassification against the E5 step 2 table.
+
+**The general-case fallthrough (`:310-318` current revision) is the target decision-match shape
+already, not a duplicate to converge**:
+
+```rust
+if let Some(native_result) =
+    self.try_native_method(&target, Symbol::intern(&method), &args)
+{
+    /* native */
+} else {
+    /* user */
+    self.try_compiled_method_or_interpret(target, &method, args)
+}
+```
+
+`grep -n "cache\|resolve_method" src/vm/vm_call_method_mut_ops.rs` confirms there is no inline
+cache and no inlined resolution logic anywhere in this file between the native probe and this
+call -- unlike `CallMethod`'s own entry point (E5b step 3/4's find), this entry never inlined a
+duplicate of `resolve_method_cached`'s three-tier cache; it always called the shared
+`try_compiled_method_or_interpret` function directly. Since that function is the exact one E5b
+step 3 shadow-verified and step 4 deduped onto `resolve_method_cached`, `CallMethodDynamic`'s
+`User` candidate inherited E5b's closure for free -- there was never a second implementation here
+to shadow-check or dedup. The same 2-line idiom repeats identically inside the two HyperSeq
+delegate arms (`hyperseq-map-grep`/the catch-all) against an `array_target` receiver -- also
+already end-state shape, not a duplicate.
+
+**No dedup opportunity found**, and this is a structurally different situation from E5b step 4:
+that step's find was two *independent implementations* of the same cache (one inlined, one
+shared) that had to be shadow-verified before converging. Nothing like that exists here -- every
+dispatch-probe call site in this entry already calls the same shared `try_native_method`/
+`try_compiled_method_or_interpret` pair directly, so there is no second implementation to
+converge onto the first. (The 2-line idiom's 3x textual repetition inside one function is a
+DRY/line-count nit at best -- all three sites already call the identical functions in the
+identical order, so there is nothing to drift; not treated as blocking closure.)
+
+**`CallMethodDynamicMut` (E6-scoped) reconfirmed unchanged**: still reaches the interpreter with
+no native-method probe and no compiled-method probe at all (`vm_call_method_mut_ops.rs:347-433`)
+-- after `.+`/`.*` handling and the `call-sub-value` branch, the only native-ish check is
+`try_native_buf_mut` (Buf write-method fast path only), and everything else falls straight
+through to `vm_call_method_mut_with_values` behind a pre-existing
+`// TODO: compile to bytecode -- generic mut method fork (ledger §1).` comment. Matches the design
+doc's inventory correction 3 exactly; correctly out of scope for E5c (it is E6's job).
+
+**Real finding, out of scope for this campaign**: raku-verifying representative dynamic-call
+shapes turned up a genuine, pre-existing correctness gap unrelated to native-vs-user dispatch
+ordering -- `.$name` (unquoted) should require `$name` to be Callable/type-object/`CALL-ME`-able
+(raku: `No such method 'CALL-ME' for string 'uc'` for a bare-string `$name`), but mutsu's
+`dynamic_method_name` (`vm_call_method_mut_ops.rs:23-28`) accepts any value via
+`.to_string_value()`, so `.$m()` and `."$m"()` compile to the identical AST and behave
+identically. Filed as `todo/tickets/dollar-dot-dynamic-method-name-should-require-callable.md`,
+not fixed here.
+
+**Conclusion: E5c part 1 (`CallMethodDynamic`) is closed, docs-only, no code change.** The `Native`
+candidate is a direct self-guarding probe at every dispatch point in this entry (generalizing E5b
+step 2's rule), and the `User` candidate already routes through the exact function E5b closed --
+this entry inherited that closure automatically, with nothing local to shadow-check or dedup.
+
+### E5c, part 2: the hyper entries' per-element probe -- raku-verified, no live divergence found; downgrades inventory correction 4 from "must fix" to "redundant gate", but surfaces an unrelated real bug
+
+E5 step 3's measurement slice already flagged (its "real finding" note, reproduced from the
+design doc's own inventory correction 4) that `exec_hyper_method_call_dynamic_op`
+(`HyperMethodCallDynamic`) has **no `skip_native`/`has_user_method` gate anywhere** in its
+per-element probe, unlike its static twin `exec_hyper_method_call_op` (`HyperMethodCall`), which
+computes a per-element `skip_native` from `has_user_method(class_name, method)`
+(`vm_hyper_method_ops.rs:643-670`) before its four modifier-keyed native/user probe arms. That
+note left it explicitly unverified: "V1 in the doc's Verification items still needs to
+raku-verify it before the E6/E5c cutover fixes it by construction."
+
+Raku-verified now, with three targeted collision attempts (Instance method override colliding
+with a name `try_native_method` could plausibly intercept, a `but`-mixin role override, per E5b
+step 2's own precedent for finding this class of gap): a user Instance overriding `.reverse`,
+`.gist`, `.Str`, `.raku`, `.perl`, and a `but Loud { method uc {...} }` string mixin, all
+dispatched via `@a»."name"()` (the dynamic per-element probe's plain string-dispatch branch) --
+**every one matched raku exactly**, no divergence found. This means, per the same generalization
+step 2 already established for `CallMethod`'s top-level `skip_native` gate: `try_native_method`/
+`try_native_method_raw`'s own internal self-guards (the `mixin_role_has_method` bypass, the
+`render_overridden` check for `gist`/`Str`/`Stringy`/`raku`/`perl`, the `is_native_method`
+Instance check, ...) already provide the real safety net *inside the shared function itself*,
+independent of whether the caller computes an outer `skip_native` gate first. `HyperMethodCall`'s
+own outer gate is therefore a fast-path bypass (skip the `try_native_method_raw` call entirely
+for the common case), not a distinct correctness mechanism -- exactly what step 2 concluded, now
+confirmed at a second entry. **Inventory correction 4 downgrades from "a live ordering bug" to
+"an redundant defense-in-depth gate `HyperMethodCallDynamic` happens not to have" -- no code
+change needed to close it.**
+
+**But the raku-verification pass did find a real, different divergence**: `@a»."WHICH"()`/a plain
+`.WHICH`/`.WHY` override is silently ignored (native answer wins) in every call form except a
+compile-time-literal quoted method call (`.'WHICH'()`). This is *not* a native-vs-user dispatch-
+ordering bug in the ADR-0019 sense -- it traces to a narrower, pre-existing gap specific to
+`WHICH`/`WHY` (the two MOP pseudo-methods that are genuinely user-overridable in raku, unlike the
+other six) across two independent "skip native pseudo dispatch" mechanisms (one VM-opcode-level,
+one interpreter-level). Root-caused and filed as
+`todo/deep/pseudo-method-which-why-user-override-ignored-in-bareword-and-dynamic-form.md` -- out
+of scope for this campaign, not fixed here.
+
+**Conclusion: E5c part 2 (hyper per-element probes) is closed, docs-only, no code change.**
+`HyperMethodCall`'s existing outer gate and `HyperMethodCallDynamic`'s absent one both resolve to
+the same safety net inside `try_native_method_raw`, matching step 2's generalized finding. **E5c
+is now fully closed** (both parts); **E5d** (JIT-shim parity check, no code change expected) is
+the only remaining E5 item.
+
+### E5d: JIT-shim parity check -- confirmed, no code change
+
+Per design decision 4, E5d is "assert the shims still just re-enter the rewritten ops." Of the
+two JIT shims named in the corrected entry inventory (`vm_jit_helpers.rs:314/367`), only
+`call_method` (`OpCode::CallMethod`, :314-362) is in E5's scope -- `call_method_mut`
+(`OpCode::CallMethodMut`, :367+) is E6's `CallMethodMut`, not an E5 entry. `CallMethodDynamic` and
+the two hyper opcodes have **no JIT shim at all** (`grep -n 'extern "C" fn' vm_jit_helpers.rs`
+lists no dynamic/hyper method-call shim), so they are not JIT-compiled and this check does not
+apply to them.
+
+Read `call_method` (:314-362) directly: it reads the `OpCode::CallMethod` payload in place, calls
+`interp.sync_source_line(...)` then `interp.exec_call_method_op(code, *name_idx, *arity,
+*modifier_idx, *quoted, *arg_sources_idx)` -- the exact same entry point `vm_exec_dispatch.rs`'s
+own `CallMethod` arm calls -- and its post-call tail (`apply_pending_rw_writeback`,
+`drain_pending_local_updates_after_call`, resume-point recording on error) is byte-identical to
+the non-JIT dispatch arm's tail, unchanged by E5b/E5c. Since the shim re-enters
+`exec_call_method_op` itself rather than duplicating any of its logic, every change E5b/E5c made
+inside that function (the `resolve_method_cached` dedup, the cascade classification) is
+automatically covered under JIT with zero shim-side change needed -- confirmed by inspection, not
+just assumed. **E5d is closed, docs-only, no code change. All of E5 (steps 1-4, E5b, E5c parts
+1-2, E5d) is now closed.** Next up per design decision 4's slicing is E6 (mutation-aware and
+container calls).

--- a/todo/deep/pseudo-method-which-why-user-override-ignored-in-bareword-and-dynamic-form.md
+++ b/todo/deep/pseudo-method-which-why-user-override-ignored-in-bareword-and-dynamic-form.md
@@ -1,0 +1,101 @@
+# `.WHICH`/`.WHY` ignore a user-defined override except via a compile-time-literal quoted method call
+
+## Repro
+
+```raku
+class Foo {
+    method WHICH { "USER-WHICH" }
+}
+say Foo.new.WHICH;          # bareword: raku USER-WHICH, mutsu Foo|<hash>  -- WRONG
+say Foo.new.'WHICH'();      # quoted literal: raku USER-WHICH, mutsu USER-WHICH -- correct
+my $m = "WHICH";
+say Foo.new."$m"();         # dynamic (CallMethodDynamic): raku USER-WHICH, mutsu Foo|<hash> -- WRONG
+```
+
+Same shape for `.WHY` (`method WHY { "USER-WHY" }` -> raku `USER-WHY` bareword and dynamic, mutsu
+`Nil` bareword, `Foo|<hash>`-style native answer via `try_native_method` for dynamic).
+
+The other six MOP pseudo-methods (`DEFINITE`/`WHAT`/`WHO`/`HOW`/`WHERE`/`VAR`) are **not** affected
+by this bug — raku itself never consults a same-named user method for those in *any* call form
+(verified: bareword `.WHAT`/`.WHO`/`.HOW`/`.DEFINITE`/`.WHERE`/`.VAR` on a class defining
+`method WHAT {...}` etc. still returns the true reflection value in real raku, ignoring the user
+method entirely — they are genuine compile-time-special MOP macros, not overridable). Only
+`WHICH` (the documented mechanism for giving a class custom value-identity semantics) and `WHY`
+(the Pod-doc accessor) are real, ordinary, overridable methods in raku regardless of call syntax.
+mutsu's quoted-literal call form (`.'WHICH'()`/`."WHICH"()` with a compile-time-known string)
+already gets this right; every other call form does not.
+
+## Root cause: two independent, redundant "skip native pseudo dispatch" mechanisms, neither aware that WHICH/WHY are exceptions
+
+**Mechanism 1 (VM opcode level, `skip_native`).** `exec_call_method_op_impl`
+(`src/vm/vm_call_method_ops.rs:948-953`) and `exec_call_method_mut_op_impl`
+(`src/vm/vm_call_method_mut_ops.rs:1126-1130`) each compute a per-call `skip_native: bool` that is
+`true` for all 8 pseudo-method names **only when `quoted` is true** (a compile-time flag on the
+`CallMethod`/`CallMethodMut` opcode itself, set when the AST shows a literal quoted method name
+like `.'WHICH'`/`."WHICH"()`, distinct from `.WHICH` bareword). Separately, the same function's
+has-user-method check (`vm_call_method_ops.rs:964-968`, `vm_call_method_mut_ops.rs:1141-1145`)
+**explicitly excludes all 8 pseudo names** from ever setting `skip_native` via
+`has_user_method`, with the comment "but NOT for pseudo-methods like DEFINITE, WHAT, etc. which
+are macros" -- correct for the other six, wrong for `WHICH`/`WHY`. When `skip_native` is `true`,
+`self.skip_pseudo_method_native = Some(method)` is recorded
+(`vm_call_method_ops.rs:1031-1039`, gated on `quoted && skip_native`;
+`vm_call_method_mut_ops.rs:1215-1217`, gated only on `skip_native`).
+
+`exec_call_method_dynamic_op`/`exec_call_method_dynamic_mut_op` (the `.$var`/`."$var"()` runtime-
+string forms, same file, `CallMethodDynamic`/`CallMethodDynamicMut`) and
+`exec_hyper_method_call_op`/`exec_hyper_method_call_dynamic_op`
+(`src/vm/vm_hyper_method_ops.rs`) have **no `skip_native`/pseudo-method concept at all** -- their
+general fallthrough calls `self.try_native_method(target, method_sym, args)` unconditionally, so
+for these four entries `WHICH`/`WHY` are *always* native-computed regardless of quoting.
+
+**Mechanism 2 (interpreter level, inside `call_method_with_values`).**
+`methods_call_dispatch.rs:2770-2802` computes its own `is_pseudo_method` +
+`bypass_native_fastpath` (via `should_bypass_native_fastpath`) and separately consumes
+`skip_pseudo_method_native` inside `dispatch_method_by_name_1`
+(`methods_dispatch_match.rs:20-31`) to let the `WHAT`/`HOW`/`WHO`/`WHY` match arms
+(`methods_dispatch_match.rs:199-202`) fall through to normal method resolution instead of
+computing the macro value -- but only when the caller (mechanism 1) actually set the flag for
+this exact method name. There is no `"WHICH"` arm in `dispatch_method_by_name_1`'s match at all
+(nor in the other `dispatch_method_by_name_N` files, per a full grep) -- `WHICH` apparently only
+resolves via the generic/native fallback further down `call_method_with_values`, which is where
+the actual native `native_method_0arg` "WHICH" arm (`builtins/methods_0arg/dispatch_core_coerce.rs:343`)
+gets consulted for the case that reaches the interpreter at all.
+
+## Why this needs a design pass, not a quick patch
+
+1. **`try_native_method_raw` itself has no has-user-method guard for `WHICH`/`WHY`** (its
+   Instance-specific bypass block, `vm_native_dispatch.rs:191-265`, guards `gist`/`Str`/`Stringy`/
+   `raku`/`perl` via a `render_overridden` check at lines 235-246 but nothing analogous for
+   `WHICH`/`WHY`). Adding one there (mirroring `render_overridden`) is necessary to fix the four
+   entries (`CallMethodDynamic`/`CallMethodDynamicMut`/`HyperMethodCall`/`HyperMethodCallDynamic`)
+   that call `try_native_method` unconditionally with no opcode-level pseudo-method gate at all.
+2. **But that alone is not sufficient**, because mechanism 2's `skip_pseudo_method_native` flag
+   is a *separate* signal consumed by `dispatch_method_by_name_1`'s WHAT/HOW/WHO/WHY match arms --
+   and per the point above, WHICH has no arm there at all, meaning its actual resolution path
+   through the interpreter (once `try_native_method` correctly declines) is not yet mapped. This
+   needs tracing before a fix can be written with confidence: does `call_method_with_values` fall
+   through to ordinary MRO method resolution for `WHICH` once native is declined, or does it hit
+   some *other* native-style computation further down that would need its own has-user-method
+   guard too?
+3. **Five call sites, two independent mechanisms.** A correct, non-duplicated fix likely wants the
+   guard to live once in `try_native_method_raw` (mechanism 1's shared self-guard, per
+   `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`'s Phase E finding that the
+   `Native` candidate's real safety net is always inside `try_native_method_raw`'s own per-shape
+   checks, not scattered per-entry) -- but the opcode-level `skip_native`/`quoted` gates
+   (mechanism 1) and the interpreter-level `skip_pseudo_method_native` consumption (mechanism 2)
+   both need auditing for whether they still serve a purpose after that, or become redundant/
+   inconsistent with each other for `WHICH`/`WHY` specifically (they'd stay load-bearing as-is
+   for the other six pseudo names).
+4. **Verification surface is real but narrow**: `WHICH`/`WHY` overrides are a real, documented
+   Raku idiom (custom value-identity types), but likely rare in practice -- worth fixing
+   correctly, not worth rushing given the mechanism complexity above.
+
+## Where found
+
+Discovered during ADR-0019 E5c (`CallMethodDynamic` dispatch-ordering classification,
+`todo/deep/adr0019-e5-e7-entry-routing.md` §"E5c") while raku-verifying whether
+`HyperMethodCallDynamic`'s missing `skip_native`/`has_user_method` gate (inventory correction 4)
+produces observable divergence -- it does, but the same divergence traces back to a pre-existing,
+narrower-than-suspected bug (only `WHICH`/`WHY`, not the full MOP pseudo-method set) unrelated to
+the E5 native-vs-user routing campaign itself. Not part of that campaign's scope; filed
+separately.

--- a/todo/tickets/dollar-dot-dynamic-method-name-should-require-callable.md
+++ b/todo/tickets/dollar-dot-dynamic-method-name-should-require-callable.md
@@ -1,0 +1,51 @@
+# `.$name` (unquoted dynamic method call) should require `$name` to be Callable/type-object/CALL-ME, not accept a bare string
+
+## Repro
+
+```raku
+my $m = "uc";
+say "hi".$m();
+# raku:  No such method 'CALL-ME' for string 'uc'
+# mutsu: HI  -- silently accepts it as string-name dispatch
+```
+
+Only the **quoted** form (`."$name"()`, the `.""` operator -- see
+`raku-doc/doc/Language/objects.rakudoc:458-468`, "Method names can be resolved at runtime with the
+`.""` operator") is the general indirect-by-string-name dispatch. The unquoted `.$name` form
+requires the name-value to be Callable, a type object (which dispatches by its own short name,
+e.g. `$str.$Int` calls `.Int`), or otherwise support `CALL-ME` -- a bare `Str` in `$name` is none
+of those, and real raku raises `X::Method::NotFound` naming the missing `CALL-ME` method.
+
+## Root cause
+
+`Interpreter::dynamic_method_name` (`src/vm/vm_call_method_mut_ops.rs:23-28`) falls back to
+`.to_string_value()` for *any* non-`Package` name value:
+
+```rust
+fn dynamic_method_name(name_val: &Value) -> String {
+    match name_val.view() {
+        ValueView::Package(name) => name.resolve(),
+        _ => name_val.to_string_value(),
+    }
+}
+```
+
+So `.$m()` and `."$m"()` compile to the identical AST node (`Expr::DynamicMethodCall`) and behave
+identically in mutsu, accepting a program shape raku rejects at the unquoted call site.
+
+## Why this is a ticket, not a fix-now
+
+Fixing it correctly means threading whether the *original call syntax* was quoted (`.""`) or
+unquoted (`.$name`) through to `dynamic_method_name`/`exec_call_method_dynamic_op`, and for the
+unquoted case, raising `X::Method::NotFound` (naming `CALL-ME`) when the name value is a bare
+scalar with no `CALL-ME` method -- narrower than a full redesign but touches parser/compiler AST
+shape (does `Expr::DynamicMethodCall` currently carry enough info to distinguish the two source
+forms?) as well as the VM handler, so it needs its own scoped investigation rather than a drive-by
+patch.
+
+## Where found
+
+Discovered during ADR-0019 E5c (`CallMethodDynamic` classification,
+`todo/deep/adr0019-e5-e7-entry-routing.md` §"E5c") while raku-verifying representative
+`CallMethodDynamic` call shapes. Unrelated to the E5 native-vs-user dispatch-ordering campaign
+itself -- a pre-existing "which name values are legal" gap upstream of dispatch routing.


### PR DESCRIPTION
## Summary
- **E5c part 1** (`CallMethodDynamic`): classifies all 14 named intercept arms and confirms the general-case native/user fallthrough already calls the shared `try_native_method`/`try_compiled_method_or_interpret` pair directly -- unlike `CallMethod`, this entry never had a duplicate implementation to converge, so it inherited E5b's closure automatically. No code change.
- **E5c part 2** (hyper per-element probes): raku-verifies the gap E5 step 3 flagged (`HyperMethodCallDynamic` missing a `skip_native`/`has_user_method` gate) -- zero divergence found across six collision attempts, generalizing E5b step 2's "the safety net lives inside `try_native_method_raw` itself" finding to a second entry. No code change needed.
- **E5d** (JIT-shim parity): confirms by inspection that the one E5-scoped JIT shim (`call_method`) re-enters `exec_call_method_op` with a byte-identical tail, so E5b/E5c's changes are covered under JIT automatically.
- Files two real, unrelated bugs found while raku-verifying (out of scope for this campaign, not fixed here): `WHICH`/`WHY` user-method overrides silently ignored except via a quoted call, and unquoted `.$name` accepting a bare string where raku requires `CALL-ME`.

**All of E5 is now closed.** Next is E6 (mutation-aware and container calls).

Docs-only change (`docs/adr/`, `todo/deep/`, `todo/tickets/`) -- no source files touched.

## Test plan
- Docs-only PR; no `make test`/`make roast` impact expected (CI's docs-only fast path should skip the four heavy jobs).
- Findings verified empirically against `raku` and `target/debug/mutsu` during research (repros described in the filed docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)