### PR TITLE
feat(regex): ADR-0022 Slice 3 -- declarative-prefix LTM ranking for | alternation

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -118,7 +118,7 @@ noted.
 | No oracle | `S02-names/pseudo-6d.t` | aborts at 116/159 | SORRY (`::=` NYI) | `::("CALLER")::<$*bar>` CALLER pseudo-package deref unsupported. Even on v2026.06 rakudo SORRYs because `::=` binding is unimplemented |
 | No oracle | `S02-names/pseudo-6e.t` | aborts at 79/202 | SORRY (`$?` constant twigil NYI) | Same as above (the 6.e version). Still SORRY on v2026.06 |
 | No oracle | `S02-names-vars/names.t` | 144/156, notok 3 | SORRY (unfudged line) | test 142 "Null PMC access when printing a var typed as ::foo" edge. raku SORRYs on a fudge-dependent line (a bare `$`) |
-| No oracle | `S05-metasyntax/longest-alternative.t` | 59/62, notok 3 (28/50/54) | SORRY (`::` LTM stopper NYI) | Remaining 3 all need declarative-prefix LTM ranking — design complete in ADR-0022 (`docs/adr/0022-regex-alternation-ltm-ranking.md`): 28 = `<.ws>` prefix stopper, 50 = non-constant interpolation (ADR Slice 5), 54 = `\|\|` first-branch-only. Line 461 (negative lookahead) is `#?rakudo todo` upstream. Still SORRY on v2026.06 because rakudo has not implemented `::` |
+| No oracle | `S05-metasyntax/longest-alternative.t` | 61/62, notok 1 (50) | SORRY (`::` LTM stopper NYI) | ADR-0022 Slices 1-3 (declarative-prefix + litlen ranking) implemented and merged: tests 28 (`<.ws>` prefix stopper) and 54 (`\|\|` first-branch-only) now pass. Only 50 (non-constant interpolation must terminate the declarative prefix — ADR Slice 5, not yet implemented) remains. Line 461 (negative lookahead) is `#?rakudo todo` upstream. Still SORRY on v2026.06 because rakudo has not implemented `::` |
 | No oracle | `S10-packages/basic.t` | 59/83, notok 9 | 6/83 (mutsu ahead; same on v2026.06) | Error-detection edges for the semicolon form of package declarations |
 | No oracle | `S12-attributes/trusts.t` | 9/15, notok 4-9 | SORRY (forward reference `trusts B`) | Cross-class private access via `trusts` unsupported. Still SORRY on v2026.06. Failing set shifted 2026-07-15 (private-attr wrong-class throw): tests 4-9 read `$!an_A` which class B never declares (throws now, matching rakudo semantics — likely a typo for the lexical `$an_A` in the test), while the class-C "untrusted access dies" tests now pass |
 | No oracle | `S19-command-line-options/01-dash-uppercase-i.t` | 0/8 | 0/8 (`$*OS` unsupported; same on v2026.06) | `-I` + `@*INC` + `$*OS` introspection (is_run subprocess) |
@@ -157,17 +157,19 @@ completed fix history lives in `news/`.
   test 52: the `<$subrule>` block compiles a string containing a `{...}` code block as a regex
   → "Prohibited regex interpolation" (X::SecurityPolicy); real raku dies at the same point
   (no MONKEY-SEE-NO-EVAL). Later blocks additionally need `<*literal>` partial-match support.
-- **`S05-metasyntax/longest-alternative.t`** — down to 3 failures (28/50/54; the
-  IETF::RFC_Grammar and Gproto blocks pass now). All three require the declarative-prefix
-  LTM ranking model, fully designed in **ADR-0022**
+- **`S05-metasyntax/longest-alternative.t`** — down to 1 failure (50; the IETF::RFC_Grammar
+  and Gproto blocks pass, and tests 28/54 were fixed by **ADR-0022 Slices 1-3**
   (`docs/adr/0022-regex-alternation-ltm-ranking.md`, with a raku-validated acceptance
-  matrix): mutsu's `|` currently ranks by longest *actual* match with declaration-order
-  ties, rakudo ranks by longest *declarative prefix* with longest-literal (litlen) ties.
-  Test 28 = a `rule`'s implicit `<.ws>` stops the prefix; test 50 = a non-constant
-  interpolated alternative must not count toward LTM (ADR Slice 5); test 54 = a `||`
-  group contributes only its first branch (plus a zero-width bypass). Negative lookahead
-  (line 461) is `#?rakudo todo` upstream — mutsu matches rakudo. The same ranking gap is
-  the last failure in Cro::HTTP `t/http-router.rakutest` (test 61).
+  matrix, pinned locally by `t/regex-ltm-alternation.t`): mutsu's `|` now ranks by
+  declarative-prefix length with longest-literal (litlen) ties, matching rakudo, instead
+  of the old longest-*actual*-match-with-declaration-order-ties rule. Test 28 = a `rule`'s
+  implicit `<.ws>` stops the prefix (fixed); test 54 = a `||` group contributes only its
+  first branch, plus a zero-width bypass (fixed). Test 50 = a non-constant interpolated
+  alternative must not count toward LTM — needs ADR Slice 5 (not yet implemented: thread
+  interpolated-span info out of `interpolate_bound_regex_scalars` so the parser can flag a
+  token born from runtime interpolation as non-declarative). Negative lookahead (line 461)
+  is `#?rakudo todo` upstream — mutsu matches rakudo. The same ranking model fixed the last
+  failure in Cro::HTTP `t/http-router.rakutest` (test 61 → now 83/83 fully green).
 - **`S06-advanced/caller.t`** — unpassable on the plan count alone: `plan 22` but only 19
   assertions exist (the trailing "WRITEME: label tests" were never written). The 4 failing
   assertions are **stale old-Rakudo expectations that mutsu correctly diverges from** — do NOT

--- a/docs/adr/0022-regex-alternation-ltm-ranking.md
+++ b/docs/adr/0022-regex-alternation-ltm-ranking.md
@@ -1,6 +1,11 @@
 # ADR-0022: `|` alternation ranks branches by declarative-prefix LTM, not by longest actual match
 
-- **Status**: Proposed (2026-08-09). Design complete; implementation not started.
+- **Status**: Accepted (2026-08-09); Slices 1-3 implemented and merged 2026-08-11
+  (measurement infrastructure, litlen, and the ranking swap in all three consumer
+  arms — `roast/S05-metasyntax/longest-alternative.t` tests 28/54 and Cro::HTTP
+  `t/http-router.rakutest` test 61 now pass, pinned by `t/regex-ltm-alternation.t`
+  and `t/regex-ltm-declarative-prefix.t`). Slices 4 (ledger update) and 5 (non-constant
+  interpolation marking, needed for roast test 50) remain — see §5 and §2.
 - **Context**: `todo/deep/regex-alternation-ltm-longest-literal-prefix.md`;
   `Cro::HTTP` `t/http-router.rakutest` test 61 (the file's last remaining failure);
   `roast/S05-metasyntax/longest-alternative.t` tests 28/50/54 (the file's only failures,
@@ -123,6 +128,25 @@ Key mechanics of the reference implementation:
 - `:m` (ignoremark) literals: rakudo has no `_M_LL` edge (XXX comments in NFA.nqp), so
   they never extend litlen. mutsu may treat them like `:i` literals (which do, via
   `_I_LL`); no test pins the difference.
+- **mutsu-only quirk, found while implementing Slice 2**: a captureless, separator-less,
+  single-atom fixed-count `atom ** N` is string-unrolled into literal repeated text by the
+  pre-existing `expand_ltm_pattern` engine pass (`regex_parse_ltm.rs`, invoked from
+  `regex_parse_core.rs` whenever `mode == RegexParseMode::Match`) *before* the token parser
+  ever runs — this predates ADR-0022 and exists for matcher correctness/perf around small
+  fixed bounds, unrelated to LTM ranking. When such a `**N` is the ENTIRE text of a
+  standalone top-level pattern (`/'ab' ** 2/` parsed on its own), by the time
+  `ltm_litlen_at` walks it the quantifier boundary is already gone — it is
+  indistinguishable from a hand-written literal of the same expanded length, so litlen
+  extends fully through it instead of stopping at 0. Verified NOT to affect the §7
+  acceptance-matrix line it looks like it should break (`"abab" ~~ / (\w+) | 'ab' ** 2 /`):
+  when `'ab' ** 2` is a *branch inside* a larger alternation rather than a standalone
+  pattern, the anchored `expand_ltm_pattern` rewrite does not fire on it (its regex
+  requires the whole current parse-unit text to be exactly `atom**count`), so branch
+  ranking still measures litlen 0 there, correctly. The divergence is real but narrower
+  than it first appeared: a `**N` literal quantifier alone as an entire pattern (rare) can
+  rank differently than the same quantifier as one branch of an alternation (the common,
+  ADR-relevant case). No roast test pins the standalone-pattern case; `+`/`*`/`?` are
+  unaffected (`expand_ltm_pattern`'s trigger regex matches literal `**` only).
 
 ## 3. Current mutsu structure (what has to change)
 

--- a/src/runtime/regex/regex_ltm_rank.rs
+++ b/src/runtime/regex/regex_ltm_rank.rs
@@ -99,11 +99,6 @@ impl Interpreter {
     /// is neutralized by `ltm_atom_mode` or the `CodeAssertion` arm's
     /// existing mode check.
     ///
-    /// Not yet called from non-test code: this is ADR-0022 Slice 1
-    /// (measurement infrastructure only). Slice 3 wires it into the three
-    /// alternation-ranking consumer arms, at which point this attribute goes
-    /// away. TODO(ADR-0022 Slice 3): remove `#[allow(dead_code)]` once wired.
-    #[allow(dead_code)]
     pub(crate) fn ltm_prefix_len_at(
         &mut self,
         pattern: &RegexPattern,
@@ -171,9 +166,6 @@ impl Interpreter {
     /// `seen` cycle-guards subrule recursion by lookup name; `depth` is capped
     /// by `LTM_LITLEN_MAX_DEPTH`. Never executes user code and never runs the
     /// real matcher (so it cannot itself set `LTM_PREFIX_TERMINATED`).
-    // TODO(ADR-0022 Slice 3): remove once wired into the alternation-ranking
-    // consumer arms (only this module's own unit tests call it today).
-    #[allow(dead_code)]
     pub(crate) fn ltm_litlen_at(
         &mut self,
         pattern: &RegexPattern,
@@ -310,6 +302,28 @@ impl Interpreter {
             }
         }
         (acc, true)
+    }
+
+    /// ADR-0022 §4.4: the `(prefix_len, litlen)` rank key for one `|` branch
+    /// at `pos` — the two-part tie-break the three alternation-ranking
+    /// consumer arms sort branches by (declaration order, the third and
+    /// final tie-break, comes for free from a stable sort over the branches
+    /// in their original written order — no index needs to travel with this
+    /// key). Descending on both fields wins: `unwrap_or(0)` on a `None`
+    /// prefix measurement is safe here because a `None` with `stopped ==
+    /// false` (a sound "never matches" verdict) is filtered out by each
+    /// caller before ranking ever sees it — see ADR-0022 §4.1's contract.
+    pub(super) fn ltm_branch_rank_key(
+        &mut self,
+        alt: &RegexPattern,
+        chars: &[char],
+        pos: usize,
+        pkg: &str,
+    ) -> (usize, usize) {
+        let (plen, _stopped) = self.ltm_prefix_len_at(alt, chars, pos, pkg);
+        let mut seen = HashSet::new();
+        let litlen = self.ltm_litlen_at(alt, chars, pos, pkg, &mut seen, 0);
+        (plen.unwrap_or(0), litlen)
     }
 
     /// [`Self::ltm_seqalt_candidates`] collapsed to the single longest

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -31,6 +31,10 @@ thread_local! {
         = RefCell::new(HashSet::new());
 }
 
+/// ADR-0022 §4.4(a): one `|` branch's rank key (prefix_len, litlen) paired
+/// with its PLURAL ends (highest-priority-first).
+type RankedAlternationBranch = ((usize, usize), Vec<(usize, RegexCaptures)>);
+
 impl Interpreter {
     /// An alternation alternative that is a lone plain `{ … }` code block
     /// (`|| { die "no match" }`). Such a branch matches zero-width and exists
@@ -68,6 +72,47 @@ impl Interpreter {
             }
         }
         None
+    }
+
+    /// ADR-0022 §4.4(a) helper: rank each of `alts` by
+    /// [`Self::ltm_branch_rank_key`] and collect its PLURAL ends (highest-
+    /// priority-first, same convention as `regex_match_ends_from_caps_in_pkg`).
+    /// A branch whose real ends are empty (declaratively promising but not
+    /// an actual match here) contributes nothing and is dropped — the
+    /// rank-only "sound filter" from ADR-0022 §4.1 is subsumed by this
+    /// stronger, always-correct check. Caller sorts the returned vec by rank
+    /// key descending (stable, so ties keep `alts`' original order) and
+    /// flattens branch-major, worst-to-best, each branch's own ends
+    /// worst-to-best, to build this arm's lowest-priority-first output.
+    fn ltm_rank_and_collect_branches<'a>(
+        &mut self,
+        alts: impl Iterator<Item = &'a RegexPattern>,
+        chars: &[char],
+        pos: usize,
+        pkg: &str,
+    ) -> Vec<RankedAlternationBranch> {
+        let mut out = Vec::new();
+        for alt in alts {
+            let raw_ends = self.regex_match_ends_from_caps_in_pkg(alt, chars, pos, pkg);
+            if raw_ends.is_empty() {
+                continue;
+            }
+            let ends: Vec<(usize, RegexCaptures)> = raw_ends
+                .into_iter()
+                .map(|(end, mut inner_caps)| {
+                    let mut new_caps = RegexCaptures::default();
+                    for (k, v) in inner_caps.named.drain() {
+                        new_caps.named.entry(k).or_default().merge(v);
+                    }
+                    new_caps.positional.append(&mut inner_caps.positional);
+                    new_caps.code_blocks.append(&mut inner_caps.code_blocks);
+                    (end, new_caps)
+                })
+                .collect();
+            let rank = self.ltm_branch_rank_key(alt, chars, pos, pkg);
+            out.push((rank, ends));
+        }
+        out
     }
 
     pub(super) fn regex_match_atom_all_with_capture_in_pkg(
@@ -123,51 +168,43 @@ impl Interpreter {
         }
 
         if let RegexAtom::Alternation(alternatives) = atom {
-            // | (LTM): try all alternatives, longest match wins.
+            // ADR-0022 §4.4(a): rank branches by (prefix_len desc, litlen
+            // desc), ties broken by declaration order — free via a stable
+            // sort over the branches in their original written order, so no
+            // index needs to travel with the rank key. Collects PLURAL ends
+            // per branch (fixes ADR-0022 gap #4: backtracking into shorter
+            // ends of the chosen branch before falling to the next-ranked
+            // branch — `[ a+ | q ] ab` on "aaab" needs `a+`'s shorter ends
+            // available once `ab` fails against its greedy longest end).
             //
             // A side-effect-only alternative (`| { die ... }` — a lone plain
             // code block) is deferred: it matches zero-width, so it can only
             // win when NOTHING else matched, and running it eagerly would fire
             // its side effects (a `die`!) on paths raku never executes.
-            let mut indexed: Vec<(usize, usize, RegexCaptures)> = Vec::new();
-            let mut deferred_code: Vec<(usize, &RegexPattern)> = Vec::new();
-            for (i, alt) in alternatives.iter().enumerate() {
-                if Self::is_pure_code_block_alt(alt) {
-                    deferred_code.push((i, alt));
-                    continue;
-                }
-                if let Some((next, mut inner_caps)) =
-                    self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
-                {
-                    let mut new_caps = RegexCaptures::default();
-                    for (k, v) in inner_caps.named.drain() {
-                        new_caps.named.entry(k).or_default().merge(v);
-                    }
-                    new_caps.positional.append(&mut inner_caps.positional);
-                    new_caps.code_blocks.append(&mut inner_caps.code_blocks);
-                    indexed.push((i, next, new_caps));
-                }
+            let mut branches = self.ltm_rank_and_collect_branches(
+                alternatives
+                    .iter()
+                    .filter(|alt| !Self::is_pure_code_block_alt(alt)),
+                chars,
+                pos,
+                pkg,
+            );
+            if branches.is_empty() {
+                branches = self.ltm_rank_and_collect_branches(
+                    alternatives
+                        .iter()
+                        .filter(|alt| Self::is_pure_code_block_alt(alt)),
+                    chars,
+                    pos,
+                    pkg,
+                );
             }
-            if indexed.is_empty() {
-                for (i, alt) in deferred_code {
-                    if let Some((next, mut inner_caps)) =
-                        self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
-                    {
-                        let mut new_caps = RegexCaptures::default();
-                        for (k, v) in inner_caps.named.drain() {
-                            new_caps.named.entry(k).or_default().merge(v);
-                        }
-                        new_caps.positional.append(&mut inner_caps.positional);
-                        new_caps.code_blocks.append(&mut inner_caps.code_blocks);
-                        indexed.push((i, next, new_caps));
-                    }
-                }
+            branches.sort_by_key(|b| std::cmp::Reverse(b.0));
+            let mut out = Vec::new();
+            for (_, ends) in branches.into_iter().rev() {
+                out.extend(ends.into_iter().rev());
             }
-            indexed.sort_by(|a, b| a.1.cmp(&b.1).then(b.0.cmp(&a.0)));
-            return indexed
-                .into_iter()
-                .map(|(_, end, caps)| (end, caps))
-                .collect();
+            return out;
         }
         if let RegexAtom::SequentialAlternation(alternatives) = atom {
             if LTM_DECLARATIVE_MODE.with(std::cell::Cell::get) {

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -223,15 +223,25 @@ impl Interpreter {
                 return None;
             }
             RegexAtom::Alternation(alternatives) => {
-                let mut best: Option<usize> = None;
+                // ADR-0022 §4.4(c): same ranking rule as the singular
+                // capture-bearing matcher (`regex_match_capture.rs`) — keep
+                // the alternative ranked best by (prefix_len desc, litlen
+                // desc), ties broken by declaration order (iterating in
+                // written order, replacing only on a strict improvement).
+                let mut best: Option<((usize, usize), usize)> = None;
                 for alt in alternatives {
-                    if let Some(end) = self.regex_match_end_from_in_pkg(alt, chars, pos, pkg)
-                        && (best.is_none() || end > best.unwrap())
-                    {
-                        best = Some(end);
+                    if let Some(end) = self.regex_match_end_from_in_pkg(alt, chars, pos, pkg) {
+                        let rank = self.ltm_branch_rank_key(alt, chars, pos, pkg);
+                        let replace = best
+                            .as_ref()
+                            .map(|(best_rank, _)| rank > *best_rank)
+                            .unwrap_or(true);
+                        if replace {
+                            best = Some((rank, end));
+                        }
                     }
                 }
-                return best;
+                return best.map(|(_, end)| end);
             }
             RegexAtom::SequentialAlternation(alternatives) => {
                 if LTM_DECLARATIVE_MODE.with(std::cell::Cell::get) {

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -132,8 +132,13 @@ impl Interpreter {
                 return None;
             }
             RegexAtom::Alternation(alternatives) => {
-                // Explore all alternatives and keep the longest successful one.
-                let mut best: Option<(usize, RegexCaptures)> = None;
+                // ADR-0022 §4.4(b): explore all alternatives, keep the one
+                // ranked best by (prefix_len desc, litlen desc), ties broken
+                // by declaration order (iterating in written order and only
+                // replacing on a STRICT rank improvement keeps the earlier
+                // branch on a tie — no index needs to travel alongside the
+                // key). Replaces the old "longest end wins" rule.
+                let mut best: Option<((usize, usize), usize, RegexCaptures)> = None;
                 for alt in alternatives {
                     if let Some((next, mut inner_caps)) =
                         self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
@@ -148,16 +153,17 @@ impl Interpreter {
                         new_caps.positional.append(&mut inner_caps.positional);
                         new_caps.code_blocks.append(&mut inner_caps.code_blocks);
                         new_caps.regex_vars.extend(inner_caps.regex_vars);
+                        let rank = self.ltm_branch_rank_key(alt, chars, pos, pkg);
                         let replace = best
                             .as_ref()
-                            .map(|(best_next, _)| next > *best_next)
+                            .map(|(best_rank, _, _)| rank > *best_rank)
                             .unwrap_or(true);
                         if replace {
-                            best = Some((next, new_caps));
+                            best = Some((rank, next, new_caps));
                         }
                     }
                 }
-                return best;
+                return best.map(|(_, next, caps)| (next, caps));
             }
             RegexAtom::Conjunction(_) => {
                 // ALL branches must match the SAME substring (end at the same

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -516,6 +516,57 @@ pub(super) fn make_null_regex_error() -> RuntimeError {
     err
 }
 
+/// True if `s`, once regex comments (`#...` to end of line, and embedded
+/// `` #`[...] `` comments) are stripped, contains only whitespace. Comments
+/// are invisible to matching, so a branch consisting of just a comment must
+/// be treated the same as a whitespace-only branch by the "leading empty
+/// branch is allowed for alignment" idiom (`/ | a /`) and the null-regex
+/// check below — otherwise it parses into a spurious, always-succeeding empty
+/// `RegexPattern` alternative. That phantom branch used to be harmless (the
+/// old longest-actual-match ranking always ranked a zero-width match last),
+/// but ADR-0022's declarative-prefix ranking can tie it with a real branch
+/// that also terminates its measurement early (e.g. a leading code block) and
+/// then prefer it via the declaration-order tie-break
+/// (`roast/S05-grammar/signatures.t`).
+pub(super) fn regex_branch_is_blank(s: &str) -> bool {
+    let chars: Vec<char> = s.chars().collect();
+    let mut i = 0usize;
+    while i < chars.len() {
+        let c = chars[i];
+        if c.is_whitespace() {
+            i += 1;
+            continue;
+        }
+        if c == '#' {
+            if chars.get(i + 1) == Some(&'`') {
+                i += 2;
+                if i < chars.len() {
+                    let bracket = chars[i];
+                    let close =
+                        crate::parser::helpers::matching_bracket(bracket).unwrap_or(bracket);
+                    i += 1;
+                    let mut depth = 1u32;
+                    while i < chars.len() && depth > 0 {
+                        if chars[i] == bracket && bracket != close {
+                            depth += 1;
+                        } else if chars[i] == close {
+                            depth -= 1;
+                        }
+                        i += 1;
+                    }
+                }
+            } else {
+                while i < chars.len() && chars[i] != '\n' {
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        return false;
+    }
+    true
+}
+
 /// Detect a null branch among a split alternation/conjunction. Returns the
 /// NullRegex error if any branch is empty/whitespace-only, except that a single
 /// leading empty branch is permitted when `allow_leading_empty` is set (Raku
@@ -525,7 +576,7 @@ pub(super) fn null_regex_if_empty_branch(
     allow_leading_empty: bool,
 ) -> Option<RuntimeError> {
     for (i, b) in branches.iter().enumerate() {
-        if b.trim().is_empty() {
+        if regex_branch_is_blank(b) {
             if allow_leading_empty && i == 0 {
                 continue;
             }

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -587,7 +587,7 @@ impl Interpreter {
             let mut alt_patterns = Vec::new();
             for alt in &top_alts {
                 let alt_src = alt.trim();
-                if alt_src.is_empty() {
+                if regex_branch_is_blank(alt_src) {
                     continue;
                 }
                 // Re-apply inline adverbs for each alternative. Both `:i`
@@ -648,7 +648,7 @@ impl Interpreter {
             let mut conj_patterns = Vec::new();
             for part in &conj_parts {
                 let part_src = part.trim();
-                if part_src.is_empty() {
+                if regex_branch_is_blank(part_src) {
                     continue;
                 }
                 let part_pat = if ignore_case && !part_src.starts_with(":i") {
@@ -3000,10 +3000,10 @@ impl Interpreter {
                         let mut alt_patterns = Vec::new();
                         for (alt_idx, alt) in alternatives.iter().enumerate() {
                             // A leading null alternative is ignored in Raku: `( || X )`
-                            // and `( | X )` behave like `( X )`. Skip a whitespace-only
+                            // and `( | X )` behave like `( X )`. Skip a whitespace/comment-only
                             // first alternative so it does not contribute a spurious
                             // empty-matching (and, under ratchet, empty-winning) branch.
-                            if alt_idx == 0 && alt.trim().is_empty() {
+                            if alt_idx == 0 && regex_branch_is_blank(alt) {
                                 continue;
                             }
                             let parsed_alt = if needs_capture_scope {
@@ -3143,10 +3143,10 @@ impl Interpreter {
                         let mut alt_patterns = Vec::new();
                         for (alt_idx, alt) in alternatives.iter().enumerate() {
                             // A leading null alternative is ignored in Raku: `[ || X ]`
-                            // and `[ | X ]` behave like `[ X ]`. Skip a whitespace-only
+                            // and `[ | X ]` behave like `[ X ]`. Skip a whitespace/comment-only
                             // first alternative so it does not contribute a spurious
                             // empty-matching (and, under ratchet, empty-winning) branch.
-                            if alt_idx == 0 && alt.trim().is_empty() {
+                            if alt_idx == 0 && regex_branch_is_blank(alt) {
                                 continue;
                             }
                             let parsed_alt = if needs_scope {

--- a/t/regex-alternation-leading-comment-branch.t
+++ b/t/regex-alternation-leading-comment-branch.t
@@ -1,0 +1,55 @@
+use v6;
+use Test;
+
+# ADR-0022 Slice 3 regression (roast/S05-grammar/signatures.t): a `|`
+# alternation that opens with a leading `|` for visual alignment, where the
+# text before that first `|` is a comment (not pure whitespace), used to
+# parse into a real (but always zero-width-matching) empty `RegexPattern`
+# branch. The old longest-actual-match ranking silently deprioritized it
+# (0 < any real match length), but ADR-0022's declarative-prefix ranking can
+# tie it with a real branch that also terminates its measurement early (e.g.
+# a leading code block) and then prefer the phantom empty branch via the
+# declaration-order tie-break, making the whole match spuriously zero-width.
+
+"bar" ~~ /
+    #a leading comment before the aligned pipe
+    | 'bar'
+    | 'baz'
+/;
+is ~$/, "bar", 'a comment before an aligned leading pipe does not create a phantom empty branch';
+
+{
+    my $arg = 2;
+    my token fred($arg, $bar?) {    #OK not used
+        | { $arg == 1 } 'bar'
+        | { $arg == 2 } 'foo'
+    }
+    ok "foo" ~~ /<fred(2,3)>/, 'a comment right after the signature does not break code-gated LTM ranking';
+}
+
+{
+    grammar G {
+        token TOP {
+            <fred(1)>
+            <fred: 2, 3>
+        }
+
+        token fred($arg, $bar?) {    #OK not used
+            | { $arg == 1 } 'bar'
+            | { $arg == 2 } 'foo'
+        }
+    }
+    ok G.parse("barfoo"), 'grammar token with a signature comment and code-gated alternation parses correctly';
+}
+
+# The `()`/`[]` group forms share the same leading-empty-branch elision logic
+# (regex_branch_is_blank) — pin them too.
+"bar" ~~ / ( #comment
+    | 'bar' | 'baz' ) /;
+is ~$/, "bar", 'a comment before an aligned leading `|` inside a capture group is elided too';
+
+"bar" ~~ / [ #comment
+    | 'bar' | 'baz' ] /;
+is ~$/, "bar", 'a comment before an aligned leading `|` inside a non-capturing group is elided too';
+
+done-testing;

--- a/t/regex-ltm-alternation.t
+++ b/t/regex-ltm-alternation.t
@@ -1,0 +1,104 @@
+use v6;
+use Test;
+
+# ADR-0022 Slice 3 acceptance matrix (docs/adr/0022-regex-alternation-ltm-ranking.md
+# §7), raku-verified 2026-08-09: `|` alternation ranks branches by
+# (declarative-prefix length desc, leading-literal length ["litlen"] desc,
+# declaration order asc), NOT by longest actual (full-branch) match. Each
+# test below pins one line of that matrix.
+
+# ties broken by litlen
+"ab" ~~ / (\w\w) | 'ab' /;
+ok !$0.defined, 'tie: literal branch beats capture branch on litlen';
+
+"ab" ~~ / 'ab' | (\w\w) /;
+ok !$0.defined, 'tie: literal branch (first) beats capture branch on litlen';
+
+"/category/tree" ~~ / "/category/" (\w+) | "/category/tree" /;
+ok !$0.defined, 'tie: full-literal branch (litlen 14) beats prefix+capture (litlen 10)';
+
+"abc" ~~ / 'a' (\w\w) | 'abc' /;
+ok !$0.defined, 'tie: literal branch beats capture branch (capture kills litlen)';
+
+"abc" ~~ / 'a' \w\w | ('abc') /;
+ok !$0.defined, 'tie: FIRST (non-capturing) branch beats capture branch (capture kills b2 litlen)';
+
+"aab" ~~ / 'a' \w \w (<?>) | 'aa' \w /;
+ok !$0.defined, 'tie: second (no-capture) branch wins via higher litlen (2 > 1)';
+
+# capture groups transparent for length
+"/xy" ~~ / "/" \w | ("/xy") /;
+is ~$/, "/xy", 'capture branch wins on LENGTH (3 > 2) despite lower litlen';
+ok $0.defined, 'capture branch wins: $0 is defined';
+
+# groups/nested alternation extend litlen
+"/category/tree" ~~ / "/category/" (\w+) | "/category/" [ 'tree' ] /;
+ok !$0.defined, 'non-capturing group branch beats capture branch (group extends litlen)';
+
+"/c/tree" ~~ / "/c/" (\w+) | "/c/" [ 'tree' | 'x' ] /;
+ok !$0.defined, 'nested-alternation branch beats capture branch (all-pure-literal nested | extends litlen)';
+
+# quantifiers: length yes, litlen no
+"abab" ~~ / (\w+) | 'ab' ** 2 /;
+ok !$0.defined, 'tie: first (capture) branch wins by declaration order (litlen tie 0-0)';
+
+"aab" ~~ / 'a' | 'a' ** 1..2 'b' /;
+is ~$/, "aab", 'second branch wins on LENGTH (3 > 1), litlen irrelevant';
+
+# subrule descent (length + litlen)
+{
+    my token abb { 'abb' }
+    "abb" ~~ / (\w+) | <abb> /;
+    ok $<abb>.defined, 'subrule branch beats capture branch (subrule descent extends litlen)';
+}
+
+# code atoms
+"abcd" ~~ / 'ab' { ; } \w\w | 'abc' /;
+is ~$/, "abc", 'plain code block terminates the declarative prefix';
+
+"abcd" ~~ / 'ab' <?{ True }> \w\w | 'abc' /;
+is ~$/, "abcd", '<?{ }> code assertion is transparent (epsilon), first branch wins on length';
+
+# lookahead
+"abcd" ~~ / 'ab' <?before c> (\w\w) | 'abc' /;
+is ~$/, "abc", 'positive lookahead extends litlen through the tie (3 beats 2)';
+
+"abcde" ~~ / ab <![e]> cde | ab.. /;
+is ~$/, "abcd", 'negated lookahead terminates the prefix without extending it';
+
+# sequential alternation inside |
+"food" ~~ / 'foo' | ['doof' || 'food'] /;
+is ~$/, "foo", 'X || Y inside | only contributes its first branch to the declarative prefix';
+
+"food" ~~ / 'foo' | ['food' || 'doof'] /;
+is ~$/, "food", 'X || Y whose first branch matches wins on length';
+
+# ws stopper
+{
+    my rule  r {\w+ '-'+}
+    my token t {\w+ '-'}
+    "abc---" ~~ /<r>|<t>/;
+    is ~$/, "abc-", '<ws> stops the declarative prefix: the fully-declarative token wins';
+    ok $<t>.defined, 'the winning branch is <t>, not <r>';
+}
+
+# fall to next best when the winner's tail fails
+"food" ~~ / (f\w+) x | 'foo' /;
+is ~$/, "foo", "ranking's top branch failing outer-context falls back to the next-ranked branch";
+
+# within-branch backtracking preserved across the alternation
+"aaab" ~~ / [ a+ | q ] ab /;
+is ~$/, "aaab", 'plural ends per branch let the engine backtrack into a shorter end of the chosen branch';
+
+# ranking never overrides leftmost-position scan
+"xab" ~~ / 'ab' | b /;
+is ~$/, "ab", 'the earlier subject position wins regardless of branch ranking';
+
+# :i
+"AB" ~~ m:i/ (\w\w) | 'ab' /;
+ok !$0.defined, ':i literal still participates in litlen ranking (case-insensitive tie)';
+
+# ratchet interaction unchanged (roast S05 486-489 already pass)
+ok !('ab' ~~ / [ab | a ]: b /).defined, 'ratchet interaction with alternation ranking is unchanged';
+
+done-testing;

--- a/todo/tickets/regex-comment-containing-pipe-char-confuses-top-level-alternation-split.md
+++ b/todo/tickets/regex-comment-containing-pipe-char-confuses-top-level-alternation-split.md
@@ -1,0 +1,58 @@
+# A `|` character inside a `#` regex comment is misread as a real alternation separator
+
+`Interpreter::split_top_level_alternation` (`src/runtime/regex_parse_ltm.rs`) and its
+sibling `split_top_level_conjunction` scan a regex pattern character-by-character to find
+top-level `|`/`||`/`&`/`&&` operators, tracking `()`/`[]`/`{}`/`<>` nesting depth and
+`'`/`"` quote state — but they do NOT recognize `#...` (line) or `` #`[...] `` (embedded)
+regex comments. A literal `|` (or `&`) character that happens to appear inside a regex
+comment is therefore treated as a real top-level alternation/conjunction split point.
+
+## Repro
+
+```raku
+"bar" ~~ /
+    #a comment mentioning the pipe `|` character
+    | 'bar'
+    | 'baz'
+/;
+say ~$/;
+```
+
+mutsu: `Runtime error: Unrecognized regex metacharacter `` ` `` (must be quoted to match
+literally)` — the comment gets split into two spurious "branches" at its internal `|`,
+one of which starts mid-comment with a bare `` ` ``, which then fails to tokenize as a
+regex atom.
+
+Expected (raku): `bar` — the comment is inert; only the two real `| 'bar'` / `| 'baz'`
+branches (plus the leading whitespace/comment-only branch, elided by
+`regex_branch_is_blank`, see ADR-0022 Slice 3 follow-up fix) participate.
+
+## Root cause
+
+Neither `split_top_level_alternation` nor `split_top_level_conjunction` skips over
+`#...`/`` #`[...] `` comment spans before scanning for `|`/`||`/`&`/`&&`. The main
+tokenizer (`regex_parse_core.rs`'s token loop) and `interpolate_regex_scalars` both
+correctly recognize and skip these comment forms; the two `split_top_level_*` functions
+do not share that logic.
+
+## Why this is separate from the ADR-0022 Slice 3 fix
+
+Discovered while writing a regression test for the ADR-0022 Slice 3 leading-empty-branch
+bug (`t/regex-alternation-leading-comment-branch.t`) — an early draft of that test
+accidentally put a `|` inside the branch's own comment text and hit this different,
+pre-existing bug instead. It affects ordinary (non-declarative-prefix-ranking) alternation
+splitting and predates ADR-0022 — confirmed it reproduces identically against `main`.
+
+## Fix sketch
+
+Give `split_top_level_alternation`/`split_top_level_conjunction` the same `#`-comment
+skip logic already duplicated in the tokenizer and `interpolate_regex_scalars` (three
+copies of essentially the same scan now) — ideally factor all three into one shared
+comment-skipping cursor helper instead of a fourth copy-paste.
+
+## Affected files
+
+- `src/runtime/regex_parse_ltm.rs` (`split_top_level_alternation`,
+  `split_top_level_conjunction` presumably lives nearby or in `regex_parse_core.rs`)
+- `src/runtime/regex_parse_core.rs` (duplicate comment-skip logic to consolidate against)
+- `src/runtime/regex_parse_modifier.rs` (`interpolate_regex_scalars`'s duplicate)


### PR DESCRIPTION
## Summary
- ADR-0022 Slice 3 (the semantic change): all three `|` alternation-ranking
  consumer arms now rank branches by rakudo's own
  `(prefix_len desc, litlen desc, declaration index asc)` rule instead of the
  old "longest actual (full-branch) match, ties by declaration order".
  - `regex_match_atom.rs` (plural/backtracking path) — also switches from
    ONE end per branch to PLURAL ends, fixing ADR-0022 gap #4 (backtracking
    into a shorter end of the chosen branch before falling to the next-ranked
    branch — `[ a+ | q ] ab` on `"aaab"` needs this).
  - `regex_match_capture.rs` (singular path) and `regex_match_atom_simple.rs`
    (no-capture prober) — pick the best-ranked matching branch instead of the
    longest-end one.
  - Declaration-order tie-break is free: iterating/sorting in original
    written order preserves it without threading an index through the key.
- Adds `t/regex-ltm-alternation.t`, pinning all 24 raku-verified lines of the
  ADR §7 acceptance matrix (verified individually against the built binary
  before writing the assertions).
- Fixes `roast/S05-metasyntax/longest-alternative.t` tests 28 (`<.ws>` prefix
  stopper) and 54 (`||` first-branch-only): 59/62 → 61/62. Only test 50
  remains (needs ADR Slice 5 — non-constant interpolation marking, separate
  follow-up).
- Fixes Cro::HTTP `t/http-router.rakutest`'s last failure: **83/83**, up from
  82/83 (verified via `bash tmp/cro-suite-run.sh http`, single-instance rule
  — Cro::Core stays 9/9, no regressions across either suite).
- Updates `TODO_roast/BLOCKERS.md` and the ADR status/§2 non-goals (documents
  a real mutsu-only quirk found while testing: a captureless, separator-less,
  single-atom fixed-count `atom ** N` is string-unrolled into literal text by
  the pre-existing `expand_ltm_pattern` pass before the token parser runs, so
  litlen can't see the quantifier boundary when such a pattern is parsed
  standalone — branches inside a larger alternation are unaffected, verified
  against the acceptance matrix).

Builds on #6259 (ADR-0022 Slice 2, already merged).

## Test plan
- [x] `cargo test --lib regex` — 52/52
- [x] `cargo clippy -- -D warnings`, `cargo fmt`
- [x] Full local `prove -e target/debug/mutsu t/` — 3024 files, 28319 tests, all green
- [x] `t/regex-ltm-alternation.t` — new pin, 26/26
- [x] `MUTSU_FUDGE=1 prove roast/S05-metasyntax/longest-alternative.t` — 61/62 (was 59/62)
- [x] `bash tmp/cro-suite-run.sh http` — `http-router.rakutest` 83/83 (was 82/83), no other regressions
- [x] `bash tmp/cro-suite-run.sh core` — Cro::Core still 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)