### PR TITLE
fix(vm): itemize values bound to plain $-sigil parameters

### DIFF
--- a/docs/batteries/csv.md
+++ b/docs/batteries/csv.md
@@ -13,8 +13,11 @@ at the slot: enumerate the field from the local REA/fez indices, measure
 license + dependents + raku baseline + mutsu result for each candidate, and
 record what would have to happen before any of them can be bundled.
 
-**Headline finding: nothing in the field is bundle-ready today, but not for
-the reason usually seen in these surveys.** The two credible RFC4180-style
+**Headline finding (updated 2026-08-11): `CSV::Table` now runs its full suite
+10/10 under mutsu — the field has a measurement-green candidate; what remains
+for bundling is the API-fit call in Recommendation point 3.** The original
+finding stands as history: nothing was bundle-ready at survey time, but not
+for the reason usually seen in these surveys. The two credible RFC4180-style
 candidates are *healthy under raku* (Text::CSV 33/33 files, CSV::Table
 10/10). What originally blocked both on mutsu was **one shared, general,
 false-positive compiler bug** that misfired on the ordinary pattern "`my $x
@@ -47,7 +50,7 @@ candidates.
 | Candidate | Version | Released | License | Runtime deps | Read+generate? | Native/C dep? | Dependents¹ | raku | **mutsu** |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | **`Text::CSV`** | 0.022 | 2023-10-30 | Artistic-2.0 | `Slang::Tuxic`, `File::Temp` | ✅ both, incl. from-scratch `csv(out=>…)` | none | 0 | **33/33** (22697 tests) | **0/33** — blocked at `use` by the slang dependency (heredoc fix does not touch this) |
-| **`CSV::Table`** | 0.0.2 | 2025-05-31 | Artistic-2.0 | `YAMLish`, `JSON::Fast`, `File::Temp`, `Text::Utils` | ✅ both, but write needs an existing file to load first | none | 0 | **10/10** (184 tests) | **9/10** — see below; only `t/5-save.t` left (element itemization → sprintf arity) |
+| **`CSV::Table`** | 0.0.2 | 2025-05-31 | Artistic-2.0 | `YAMLish`, `JSON::Fast`, `File::Temp`, `Text::Utils` | ✅ both, but write needs an existing file to load first | none | 0 | **10/10** (184 tests) | **10/10** ✅ — fully green as of 2026-08-11 (param-bind itemization fixed `t/5-save.t`) |
 | `CSV::Parser` | 0.1.4 | 2023-06-06 | *(README only — see below)* | **0** | ❌ read-only — **disqualified** | none | 0 | **5/5** | **5/5** ✅ |
 | `CSV-AutoClass` | 0.2.0 | 2023-11-19 | Artistic-2.0 | `CSV::Parser`, `File::Find`, `Text::Utils` | ❌ codegen utility, not a reader/writer | none | 0 | **2/2** | **2/2** ✅ — was 0/2, unblocked by the heredoc fix |
 | `Duck::CSV` | 0.0.2 | 2026-05-30 | MIT | `Duckie` (→ system `libduckdb`) | not evaluated — disqualified below | **DuckDB (native)** | 0 | not measured² | not measured² |
@@ -138,10 +141,12 @@ test files runs and constructs `CSV::Table` objects. The comment-handling
 failures (`t/1-delimiters.t`, `t/2-commented.t`, `t/7-half-matrix.t`) were all
 one bug — the `WrapVarRef` shadow-slot cell-capture state-sync defect
 (`news/2026-08/csv-table-comment-strip-loop-var-state-sync.md`) — fixed
-2026-08-11, bringing the suite to **9/10**. The one remaining failure,
-`t/5-save.t`, is the element-itemization gap (`sprintf "%-*.*s", $w, $w, $v`
-flattens a row Array bound to `$v`) —
-`todo/deep/element-itemization-lost-in-scalar-binding.md`.
+2026-08-11, bringing the suite to 9/10. The last failure, `t/5-save.t`
+(`sprintf "%-*.*s", $w, $w, $v` flattened a row Array bound to `$v`), fell to
+the `$`-parameter-bind itemization campaign the same day
+(`news/2026-08/param-bind-itemization.md`), making the suite **10/10 (184
+assertions)** — no known interpreter blockers remain on the `CSV::Table`
+path.
 
 ### `Text::CSV` also needs real slang support — a second, harder blocker
 
@@ -229,18 +234,16 @@ read-and-generate API), the field narrows to exactly two live candidates —
 compiler bug that blocked both is now fixed; each still has its own
 remaining blocker, and each blocker now has its own ticket:
 
-1. **`CSV::Table` is at 9/10.** All three parse/crash blockers on this path
-   (`@0` inside a `[...]` array literal; `dispatch:<.?>` method-syntax
-   parsing; the `return-rw`/`AT-POS` index-assign drop) are fixed
-   (`news/2026-08/numbered-capture-array-var-in-array-literal.md`,
-   `news/2026-08/method-dispatch-colon-question-syntax.md`,
-   `news/2026-08/return-rw-at-pos-postcircumfix-assign.md`; those two also
-   cleared `t/1-delimiters.t`), and the remaining comment-handling failures
-   (`t/2-commented.t`, `t/7-half-matrix.t`) turned out to be one interpreter
-   bug — the `WrapVarRef` shadow-slot cell capture
-   (`news/2026-08/csv-table-comment-strip-loop-var-state-sync.md`), fixed
-   2026-08-11. Only `t/5-save.t` remains, blocked on element itemization
-   (`todo/deep/element-itemization-lost-in-scalar-binding.md`).
+1. **`CSV::Table` is at 10/10 — bundle-ready on the measurement axis.** All
+   blockers on this path were fixed as general interpreter bugs, in order:
+   the shared heredoc-scope false positive; `@0` inside a `[...]` array
+   literal; `dispatch:<.?>` method-syntax parsing; the `return-rw`/`AT-POS`
+   index-assign drop; the `WrapVarRef` shadow-slot cell capture
+   (`t/1-delimiters.t`, `t/2-commented.t`, `t/7-half-matrix.t`); and finally
+   the `$`-parameter-bind itemization gap that flattened a row Array inside
+   sprintf (`t/5-save.t`, `news/2026-08/param-bind-itemization.md`). The
+   remaining question for bundling is not compatibility but the API-fit
+   caveat in point 3 below — a user decision, not more interpreter work.
 2. **`Text::CSV` stays blocked on the harder problem** —
    **[`todo/deep/text-csv-needs-slang-tuxic-support.md`](../../todo/deep/text-csv-needs-slang-tuxic-support.md)**.
    `use Slang::Tuxic;` at the top of `Text::CSV.rakumod` itself needs real

--- a/news/2026-08/param-bind-itemization.md
+++ b/news/2026-08/param-bind-itemization.md
@@ -1,0 +1,56 @@
+# `$`-parameter binding itemizes its argument — CSV::Table suite reaches 10/10
+
+Raku's signature binder places a value bound to a plain `$`-sigiled parameter
+into a Scalar container: the bound value is ONE element in list context and
+`.raku` shows the leading `$` (`sub f($v) {...}; f([1,2])` sees `$[1, 2]`).
+mutsu bound every parameter raw, so a row `Array` handed to `-> $i, $v` by
+`@!cell.kv` exploded inside a sprintf slurpy — `sprintf "%-*.*s", $w, $w, $v`
+died with "directives specify 3 arguments, but 4 were supplied", which was the
+last remaining failure (`t/5-save.t`) in `CSV::Table`'s suite
+(`docs/batteries/csv.md`).
+
+The semantics were verified against raku first: `$` params itemize (including
+`is copy`, named params, and explicit `$_` params), while `is raw`, `is rw`
+(which aliases a container), sigilless (`\v`), `@`/`%`/`&` params, and the
+*implicit* topic binding stay raw. `:=` binds never itemize.
+
+Itemization was applied at every parameter-bind site, all funnelling through
+one helper (`itemize_plain_scalar_param`) or `itemize_scalar_store` directly:
+
+- **`SetGlobal` scalar stores** (`vm_exec_dispatch.rs`) — the multi-param
+  for-loop bind statements (`build_for_bind_stmts` emits plain assignments)
+  compile to `SetGlobal` when the name has no local slot, and that path lacked
+  the `itemize_scalar_store` call the `SetLocal` path has had all along. This
+  also fixes `our $x = [1,2]` and closure-captured scalar assignments reached
+  by name. Binds, rebinds, and internal `__*` temporaries are excluded (an
+  itemized for-loop source temp would iterate as a single item).
+- **for-loop single-param binds** (`vm_for_loop_body.rs`, `vm_for_loop_lazy.rs`
+  both variants) — `for @c -> $v` now binds each element itemized. The backing
+  `Gc` is shared (only the `ArrayKind` flips), so `loop_var_unchanged`'s
+  `ptr_eq` still recognizes in-place mutations and the source-element
+  writeback stays a no-op for read-only loops.
+- **sub/closure call paths** — `vm_call_light.rs`, `vm_call_light_typed.rs`
+  (positional + named), the full binder's positional and named supplied-value
+  sites (`binding_signature.rs`), and its legacy params path (pointy blocks
+  whose defs don't survive, placeholders `$^a`). rw `ContainerRef` cells pass
+  through untouched (no `Array` view), so `is rw` writeback is unaffected.
+- **map/grep/first block params** (`resolution_map_grep.rs`) — `-> $v` and
+  `$^a` blocks bind itemized; the implicit topic stays raw.
+
+Two consumers assumed bare-bound values and were fixed as general bugs:
+
+- `.cache` on an itemized array returned the still-itemized value; a method
+  result is decontainerized in raku, so `for $node.cache` must iterate
+  elements. Left itemized, zef's `Zef::Config::plugin-lookup` recursed on the
+  same one-element item forever (stack overflow in `mzef --version`).
+- `&combinations(Iterable, $k)` treated an itemized first argument as the
+  numeric-n form's single element; the spec pins the function form to the
+  method form (`roast/S32-list/combinations.t` subtest 33), so it now deconts.
+
+With this, `CSV::Table`'s suite is **10/10 (184 assertions)** under mutsu —
+every blocker found by the CSV battery survey on that path is now fixed. The
+remaining half of the itemization gap is store-side: array/hash *elements*
+read directly (`@d[0].raku`, implicit-topic iteration over `@c`) are still
+bare — `todo/deep/element-itemization-lost-in-scalar-binding.md` tracks that
+follow-up. Pinned by `t/param-bind-itemization.t` (21 assertions, green under
+raku and mutsu).

--- a/src/builtins/functions/dispatch_2arg.rs
+++ b/src/builtins/functions/dispatch_2arg.rs
@@ -61,8 +61,15 @@ pub(crate) fn native_function_2arg(
     match name {
         "combinations" => {
             // combinations($n_or_iterable, $k_or_range)
-            // If first arg is an iterable, use its elements; otherwise treat as numeric n
+            // If first arg is an iterable, use its elements; otherwise treat as
+            // numeric n. An itemized Iterable (`combinations($n, $k)` with `$n`
+            // bound from a `$` param) still iterates its ELEMENTS — the spec
+            // pins `&combinations(Iterable, k)` to the method form
+            // (S32-list/combinations.t subtest 33).
             let items = match arg1.view() {
+                ValueView::Array(elems, kind) if kind.is_itemized() => runtime::value_to_list(
+                    &Value::array_with_kind(elems.clone(), kind.decontainerize()),
+                ),
                 ValueView::Array(..)
                 | ValueView::Seq(..)
                 | ValueView::Slip(..)

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1201,9 +1201,18 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 ))));
             }
             // An already-reified Positional caches as itself: `@a.cache` is
-            // `@a` (an Array, not a List view of it).
-            if matches!(target.view(), ValueView::Array(_, kind) if kind.is_real_array()) {
-                return Some(Ok(target.clone()));
+            // `@a` (an Array, not a List view of it). A method result is
+            // decontainerized in raku, so an itemized invocant (`$node.cache`)
+            // returns the PLAIN array — `for $node.cache` iterates elements,
+            // not the item (zef's `Zef::Config::plugin-lookup` recursion
+            // terminates on exactly this).
+            if let ValueView::Array(items, kind) = target.view()
+                && kind.is_real_array()
+            {
+                return Some(Ok(Value::array_with_kind(
+                    items.clone(),
+                    kind.decontainerize(),
+                )));
             }
             let items = target
                 .as_list_items()

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -402,11 +402,40 @@ impl Compiler {
                     .for_single_array_source_local(&Self::for_single_array_source(iterable)),
                 body_declares_routines: Self::stmts_declare_routines(&loop_body),
             })));
+        // Register sigilless for-params while compiling the (merged) body so
+        // their bind statements skip scalar-store itemization — mirrors the
+        // statement-form registration in `stmt.rs`.
+        let sigilless_param_names: Vec<String> = if has_sigilless {
+            let single_sigilless = param_def.as_ref().is_some_and(|def| def.sigilless);
+            param
+                .as_ref()
+                .filter(|_| single_sigilless)
+                .into_iter()
+                .map(|p| p.strip_prefix('\\').unwrap_or(p).to_string())
+                .chain(
+                    params
+                        .iter()
+                        .zip(params_def.iter())
+                        .filter(|(_, def)| def.sigilless)
+                        .map(|(p, _)| p.strip_prefix('\\').unwrap_or(p).to_string()),
+                )
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let newly_registered: Vec<String> = sigilless_param_names
+            .iter()
+            .filter(|n| self.sigilless_locals.insert((*n).clone()))
+            .cloned()
+            .collect();
         self.hoist_sub_decls(&loop_body, true);
         // A `for` body is its own Raku call frame (see `callframe_block_depth`).
         self.callframe_block_depth += 1;
         self.compile_collected_loop_body(&loop_body);
         self.callframe_block_depth -= 1;
+        for n in &newly_registered {
+            self.sigilless_locals.remove(n);
+        }
         self.code.patch_loop_end(loop_idx);
         // Balance the ForLoop opcode's deferred param-restore push (see the
         // Stmt::For compile path). Required even though this collected form has

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1897,6 +1897,17 @@ impl Compiler {
                     }
                     self.compile_assignment_rhs_for_target(effective_name, expr);
                 }
+                // An assignment whose target is a sigilless binding (`-> \v`
+                // loop-param bind stmts — `build_for_bind_stmts` strips the
+                // `\` so the runtime cannot tell — or a write through a
+                // sigilless alias) must NOT itemize the stored value: a
+                // sigilless name is a non-container alias, so `\seed` bound
+                // to a List stays a bare List (roast S03-sequence/exhaustive.t
+                // drives `-> \description, \seed, ...` through these binds).
+                if matches!(op, AssignOp::Assign) && self.sigilless_locals.contains(effective_name)
+                {
+                    self.code.emit(OpCode::MarkParamRawBindContext);
+                }
                 self.emit_set_named_var(effective_name);
             }
             Stmt::If {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -726,6 +726,10 @@ pub(crate) enum OpCode {
     /// Signal that the next SetLocal binds a `$` scalar to a Positional value via
     /// `:=`, so it must be recorded as decontainerized (so `@a = $bound` flattens).
     MarkScalarBindContext,
+    /// Marks the next SetLocal/SetGlobal as a raw (non-itemizing) bind of a
+    /// sigilless target (`-> \v` loop-param binds). Skips scalar-store
+    /// itemization ONLY — no readonly/decont/bind side effects.
+    MarkParamRawBindContext,
     /// Signal that the next SetLocal is a `:=` rebind (not a VarDecl).
     /// Triggers cleanup of old bind pairs and reverse aliases.
     MarkRebindContext,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2073,6 +2073,12 @@ pub struct Interpreter {
     pub(crate) jit_error: Option<RuntimeError>,
     pub(crate) bind_context: bool,
     pub(crate) scalar_bind_context: bool,
+    /// Set by `MarkParamRawBindContext` just before the SetLocal/SetGlobal of
+    /// an assignment whose target is a sigilless binding (`-> \v` loop-param
+    /// bind statements, writes through a sigilless alias). Its ONLY effect is
+    /// to skip scalar-store itemization — a sigilless name is a non-container
+    /// alias, so the stored value must stay bare. No other bind semantics.
+    pub(crate) param_raw_bind_context: bool,
     pub(crate) bound_decont_active: bool,
     pub(crate) rebind_context: bool,
     /// Set by `MarkAccessorRefContext` immediately before a CallMethod(Mut)

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -439,13 +439,32 @@ impl Interpreter {
                         if arity == 1 {
                             let item = list_items[i].clone();
                             if let Some(p) = data.params.get(assumed_count) {
-                                vm.env_mut().insert(p.clone(), item.clone());
+                                // A `-> $v` map param is an item binding — see
+                                // `itemize_plain_scalar_param`. The topic bind
+                                // below stays raw (implicit `$_` does not
+                                // itemize in raku).
+                                let bound = match data.param_defs.get(assumed_count) {
+                                    Some(pd) => Self::itemize_plain_scalar_param(pd, item.clone()),
+                                    None if !p.starts_with(['@', '%', '&', '\\']) => {
+                                        Self::itemize_scalar_store(p, item.clone())
+                                    }
+                                    None => item.clone(),
+                                };
+                                vm.env_mut().insert(p.clone(), bound);
                             }
                             bind_loop_topic(vm.env_mut(), &item, is_whatever_code, &outer_topic);
                         } else {
                             for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
                                 if i + idx < list_items.len() {
-                                    vm.env_mut().insert(p.clone(), list_items[i + idx].clone());
+                                    let item = list_items[i + idx].clone();
+                                    let bound = match data.param_defs.get(assumed_count + idx) {
+                                        Some(pd) => Self::itemize_plain_scalar_param(pd, item),
+                                        None if !p.starts_with(['@', '%', '&', '\\']) => {
+                                            Self::itemize_scalar_store(p, item)
+                                        }
+                                        None => item,
+                                    };
+                                    vm.env_mut().insert(p.clone(), bound);
                                 }
                             }
                             bind_loop_topic(
@@ -716,7 +735,15 @@ impl Interpreter {
                 let call_item = crate::runtime::utils::pair_as_positional(item);
                 'body_redo: loop {
                     if let Some(p) = data.params.first() {
-                        vm.env_mut().insert(p.clone(), call_item.clone());
+                        // `-> $v` grep/first param: item binding, like map.
+                        let bound = match data.param_defs.first() {
+                            Some(pd) => Self::itemize_plain_scalar_param(pd, call_item.clone()),
+                            None if !p.starts_with(['@', '%', '&', '\\']) => {
+                                Self::itemize_scalar_store(p, call_item.clone())
+                            }
+                            None => call_item.clone(),
+                        };
+                        vm.env_mut().insert(p.clone(), bound);
                     }
                     bind_loop_topic(vm.env_mut(), &call_item, keeps_outer_topic, &outer_topic);
                     let saved_when_matched = vm.when_matched();

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2343,6 +2343,7 @@ impl Interpreter {
             jit_error: None,
             bind_context: false,
             scalar_bind_context: false,
+            param_raw_bind_context: false,
             bound_decont_active: false,
             rebind_context: false,
             accessor_ref_pending: false,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -736,6 +736,7 @@ impl Interpreter {
             jit_error: None,
             bind_context: false,
             scalar_bind_context: false,
+            param_raw_bind_context: false,
             bound_decont_active: false,
             rebind_context: false,
             accessor_ref_pending: false,

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -432,6 +432,15 @@ impl Interpreter {
                             None,
                         ));
                     }
+                    // Legacy-path plain `$` params (pointy blocks whose defs
+                    // did not survive, placeholders `$^a`) are item bindings
+                    // too; aggregate/callable/sigilless params bind raw. The
+                    // topic name "_" is excluded inside the helper.
+                    let value = if !param.starts_with(['@', '%', '&', '\\']) {
+                        Self::itemize_scalar_store(param, value)
+                    } else {
+                        value
+                    };
                     self.bind_param_value(param, value);
                     positional_idx += 1;
                 } else if param.starts_with('^')
@@ -1109,6 +1118,10 @@ impl Interpreter {
                         if let Some(sub_params) = &pd.sub_signature {
                             bind_named_rename_sub_signature(self, sub_params, val)?;
                         } else {
+                            // Named `$` params are item bindings too (raku:
+                            // `f(v => [1,2])` binds `$v` as `$[1, 2]`); rw
+                            // cells pass through untouched.
+                            let bound_value = Self::itemize_plain_scalar_param(pd, bound_value);
                             self.bind_param_value(&pd.name, bound_value);
                             self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                         }
@@ -2070,6 +2083,11 @@ impl Interpreter {
                                 }
                             };
                         }
+                        // Plain `$` params are item bindings (raku: `f([1,2])`
+                        // binds `$v` as `$[1, 2]`); rw/raw cells and sigilless
+                        // params pass through untouched (a ContainerRef has no
+                        // Array view, so the itemize helper is a no-op on it).
+                        let value = Self::itemize_plain_scalar_param(pd, value);
                         self.bind_param_value(&pd.name, value);
                         self.bind_param_type_constraint(&pd.name, bound_type_constraint.clone());
                     }

--- a/src/runtime/utils/set_coerce.rs
+++ b/src/runtime/utils/set_coerce.rs
@@ -18,6 +18,19 @@ pub(crate) fn hash_elem_key(
     }
 }
 
+/// List view for quanthash coercion of a whole OPERAND: an itemized
+/// list/array (`$`-param bound, `.item`ed) contributes its ELEMENTS — raku
+/// decontainerizes coercion invocants (`$(<a b>).Bag` has two keys) — unlike
+/// `value_to_list`'s one-element treatment used by list assignment.
+pub(crate) fn quanthash_operand_list(v: &Value) -> Vec<Value> {
+    match v.view() {
+        ValueView::Array(items, kind) if kind.is_itemized() => value_to_list(
+            &Value::array_with_kind(items.clone(), kind.decontainerize()),
+        ),
+        _ => value_to_list(v),
+    }
+}
+
 pub(crate) fn coerce_to_set(
     val: &Value,
     originals: &mut HashMap<String, Value>,
@@ -321,7 +334,7 @@ pub(crate) fn to_mix_map(
         }
         _ => {
             // Count occurrences for list-like values (e.g. (a, a, b) → {a: 2.0, b: 1.0})
-            let items = value_to_list(v);
+            let items = quanthash_operand_list(v);
             let mut result = HashMap::new();
             for item in &items {
                 let (key, elem) = quanthash_elem_entry(item);
@@ -387,7 +400,7 @@ pub(crate) fn to_bag_map(
         }
         _ => {
             // Count occurrences for list-like values (e.g. (a, a, b) → {a: 2, b: 1})
-            let items = value_to_list(v);
+            let items = quanthash_operand_list(v);
             let mut result = HashMap::new();
             for item in &items {
                 let (key, elem) = quanthash_elem_entry(item);

--- a/src/runtime/utils/set_ops.rs
+++ b/src/runtime/utils/set_ops.rs
@@ -164,7 +164,7 @@ fn coerce_to_bag(val: &Value, originals: &mut HashMap<String, Value>) -> HashMap
         }
         _ => {
             // Count occurrences for list-like values
-            let items = value_to_list(val);
+            let items = quanthash_operand_list(val);
             let mut result = HashMap::new();
             for item in &items {
                 let (key, elem) = quanthash_elem_entry(item);
@@ -194,7 +194,7 @@ fn coerce_to_mix(val: &Value, originals: &mut HashMap<String, Value>) -> HashMap
         }
         _ => {
             // Count occurrences for list-like values
-            let items = value_to_list(val);
+            let items = quanthash_operand_list(val);
             let mut result = HashMap::new();
             for item in &items {
                 let (key, elem) = quanthash_elem_entry(item);

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -191,6 +191,7 @@ impl Interpreter {
                         return Err(RuntimeError::typed("X::TypeCheck::Argument", attrs));
                     }
                 }
+                let val = Self::itemize_plain_scalar_param(&cf.param_defs[param_idx], val);
                 let param_name = &cf.param_defs[param_idx].name;
                 self.locals[*slot] = val.clone();
                 let needs_env = write_all_params

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -211,6 +211,7 @@ impl Interpreter {
                             bind_err = Some(RuntimeError::typed("X::TypeCheck::Argument", attrs));
                             break 'bind;
                         }
+                        let val = Self::itemize_plain_scalar_param(&cf.param_defs[i], val);
                         bind_value!(ppb.slot, ppb.needs_env, val);
                     } else if ppb.required {
                         let got = args
@@ -301,7 +302,7 @@ impl Interpreter {
                 bind_value!(npb.slot, true, seed);
                 continue;
             };
-            let v = v.clone();
+            let v = Self::itemize_plain_scalar_param(&cf.param_defs[i], v.clone());
             // A sub_signature rename (`:color(:$colour)`) binds every inner
             // name to the value as well.
             for (alias_name, alias_slot) in &npb.alias_binds {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -807,6 +807,10 @@ impl Interpreter {
                 // value-bind and mark it readonly.
                 let was_scalar_bind = self.scalar_bind_context;
                 self.scalar_bind_context = false;
+                // A sigilless-target bind (`-> \v` loop-param bind stmts):
+                // skip itemization only, no other bind semantics.
+                let was_param_raw_bind = self.param_raw_bind_context;
+                self.param_raw_bind_context = false;
                 // Slice 2a: `our $n = @z` / a global scalar target reaches SetGlobal,
                 // not SetLocal/AssignExpr. Consume the array-share flag here (the
                 // global copies for now — reference sharing for globals is Slice 2d)
@@ -1139,6 +1143,7 @@ impl Interpreter {
                 } else if !is_bind_ctx
                     && !is_rebind
                     && !was_scalar_bind
+                    && !was_param_raw_bind
                     && bind_source.is_none()
                     && !is_internal_temp
                 {
@@ -1976,6 +1981,10 @@ impl Interpreter {
             }
             OpCode::MarkBindContext => {
                 self.bind_context = true;
+                *ip += 1;
+            }
+            OpCode::MarkParamRawBindContext => {
+                self.param_raw_bind_context = true;
                 *ip += 1;
             }
             OpCode::MarkScalarBindContext => {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -805,6 +805,7 @@ impl Interpreter {
                 // without this the flag leaks into the NEXT SetLocal (e.g. a
                 // following `my $a = 0`), which would spuriously treat it as a
                 // value-bind and mark it readonly.
+                let was_scalar_bind = self.scalar_bind_context;
                 self.scalar_bind_context = false;
                 // Slice 2a: `our $n = @z` / a global scalar target reaches SetGlobal,
                 // not SetLocal/AssignExpr. Consume the array-share flag here (the
@@ -1135,6 +1136,21 @@ impl Interpreter {
                     } else {
                         runtime::coerce_to_array(raw_val)
                     }
+                } else if !is_bind_ctx
+                    && !is_rebind
+                    && !was_scalar_bind
+                    && bind_source.is_none()
+                    && !is_internal_temp
+                {
+                    // A plain `=` into a `$` scalar reached by name (for-loop
+                    // multi-param binds, `our $x`, closure-captured scalars)
+                    // installs a Scalar container, exactly like the SetLocal
+                    // path: itemize the stored aggregate so `.raku` shows
+                    // `$[...]` and list context sees ONE element. Binds (`:=`),
+                    // rebinds, and internal `__*` temporaries (for-loop element
+                    // sources, `with` topic temps) keep the raw value — an
+                    // itemized loop source would iterate as a single item.
+                    Self::itemize_scalar_store(&name, raw_val)
                 } else {
                     raw_val
                 };

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -492,6 +492,21 @@ impl Interpreter {
             if param_name.is_none() {
                 self.set_loop_topic(topic_local, item.clone());
             }
+            // A plain `$`-sigiled loop parameter is an item binding: the bound
+            // element behaves as ONE value in list context (a row Array fed to
+            // a sprintf slurpy stays one argument; `.raku` shows `$[...]`),
+            // matching Raku's `-> $v` signature binding. Sigilless (`\v`) and
+            // `<->` rw params bind raw; `@`/`%`/`&` params bind the container
+            // itself; the implicit topic (param_name None) also stays raw.
+            // Itemizing keeps the SAME backing Gc (only the kind flips), so
+            // `loop_var_unchanged`'s ptr_eq still sees in-place mutations and
+            // the source-element writeback stays a no-op for read-only loops.
+            let item = match param_name.as_deref() {
+                Some(name) if !name.starts_with(['@', '%', '&', '\\']) && !spec.do_writeback => {
+                    Self::itemize_scalar_store(name, item)
+                }
+                _ => item,
+            };
             if let Some(ref name) = param_name {
                 self.env_mut().insert(name.clone(), item.clone());
                 // Create non-twigil alias for placeholder params: $^a → $a

--- a/src/vm/vm_for_loop_lazy.rs
+++ b/src/vm/vm_for_loop_lazy.rs
@@ -108,6 +108,14 @@ impl Interpreter {
             };
             idx += arity;
 
+            // Item binding for a plain `$` loop param — see the matching
+            // itemization in `vm_for_loop_body.rs` (the eager loop).
+            let item = match param_name.as_deref() {
+                Some(name) if !name.starts_with(['@', '%', '&', '\\']) && !spec.do_writeback => {
+                    Self::itemize_scalar_store(name, item)
+                }
+                _ => item,
+            };
             self.topic_source_var = None;
             if param_name.is_none() {
                 self.set_loop_topic(topic_local, item.clone());
@@ -351,6 +359,14 @@ impl Interpreter {
                 line_val
             };
 
+            // Item binding for a plain `$` loop param — see the matching
+            // itemization in `vm_for_loop_body.rs` (the eager loop).
+            let item = match param_name.as_deref() {
+                Some(name) if !name.starts_with(['@', '%', '&', '\\']) && !spec.do_writeback => {
+                    Self::itemize_scalar_store(name, item)
+                }
+                _ => item,
+            };
             // Set up parameters
             if param_name.is_none() {
                 self.set_loop_topic(topic_local, item.clone());

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -23,6 +23,25 @@ impl Interpreter {
         }
     }
 
+    /// Itemize an argument bound to a plain `$`-sigiled parameter. Raku's
+    /// signature binder puts the value in a Scalar container, so `f([1,2])`
+    /// binds `$v` as `$[1, 2]` — ONE element in list context, `.raku` shows
+    /// the `$`. Sigilless (`\v`), `is raw`, and `is rw` parameters bind the
+    /// raw value; `@`/`%`/`&` parameters bind the container itself. The
+    /// backing Gc is shared — only the container kind flips — so in-place
+    /// mutation through the param still reaches the caller's data.
+    #[inline]
+    pub(crate) fn itemize_plain_scalar_param(pd: &crate::ast::ParamDef, val: Value) -> Value {
+        if !pd.sigilless
+            && !pd.name.starts_with(['@', '%', '&'])
+            && !pd.traits.iter().any(|t| t == "raw" || t == "rw")
+        {
+            Self::itemize_scalar_store(&pd.name, val)
+        } else {
+            val
+        }
+    }
+
     /// Snapshot the lexical pragma state (`use fatal`, `use strict`,
     /// `use newline`, `use MONKEY-TYPING`) before entering a function body.
     /// Must be paired with `restore_pragma_state` on every exit path to prevent

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -333,9 +333,11 @@ impl Interpreter {
         let is_vardecl = self.vardecl_context;
         let is_shaped_decl = self.shaped_decl_context;
         let scalar_bind = self.scalar_bind_context;
+        let param_raw_bind = self.param_raw_bind_context;
         let array_share = self.array_share_context;
         self.bind_context = false;
         self.scalar_bind_context = false;
+        self.param_raw_bind_context = false;
         self.rebind_context = false;
         self.constant_context = false;
         self.array_share_context = false;
@@ -1071,6 +1073,7 @@ impl Interpreter {
             // (`:=`), rebinds, and `constant` install the value itself.
             if is_bind
                 || scalar_bind
+                || param_raw_bind
                 || is_rebind
                 || is_constant
                 || Self::is_identity_scalar_restore(&self.locals[idx], &v)

--- a/t/param-bind-itemization.t
+++ b/t/param-bind-itemization.t
@@ -6,7 +6,7 @@ use Test;
 # shows the leading `$`. Sigilless (`\v`), `is raw`, and implicit-topic
 # bindings stay raw. Verified against raku 2025.06 (see PR).
 
-plan 21;
+plan 24;
 
 # --- for-loop parameter binding ---
 {
@@ -111,6 +111,24 @@ plan 21;
 {
     our $g = [1,2];
     is $g.raku, '$[1, 2]', 'our $x = [...] itemizes like a my scalar';
+}
+
+# --- sigilless multi-params bind raw (roast S03-sequence/exhaustive.t shape) ---
+{
+    my @t = "d1", (1,3), "d2", (2,4);
+    my @got;
+    for @t -> \desc, \seed { @got.push(seed ~~ Array); @got.push(seed.elems) }
+    is-deeply @got, [False, 2, False, 2],
+        'sigilless multi-params bind the bare value (no itemize)';
+}
+
+# --- quanthash coercion deconts an itemized list operand ---
+{
+    my $r = <a b c d>;
+    is (bag(<a b c e>) (-) $r).raku, '("e"=>1).Bag',
+        'bag (-) itemized list subtracts the ELEMENTS';
+    is ($r (-) bag(<a b c e>)).raku, '("d"=>1).Bag',
+        'itemized list (-) bag contributes its elements';
 }
 
 done-testing;

--- a/t/param-bind-itemization.t
+++ b/t/param-bind-itemization.t
@@ -1,0 +1,116 @@
+use v6;
+use Test;
+
+# Raku's signature binder puts a value bound to a plain `$`-sigiled parameter
+# into a Scalar container: it is ONE element in list context and `.raku`
+# shows the leading `$`. Sigilless (`\v`), `is raw`, and implicit-topic
+# bindings stay raw. Verified against raku 2025.06 (see PR).
+
+plan 21;
+
+# --- for-loop parameter binding ---
+{
+    my @c = [<a b>], [<c d>];
+    my @got;
+    for @c -> $v { @got.push($v.raku) }
+    is @got[0], '$["a", "b"]', 'for @c -> $v itemizes the element';
+    is @got[1], '$["c", "d"]', 'for @c -> $v itemizes the second element';
+}
+
+{
+    my @got;
+    for [1,2], [3,4] -> $v { @got.push($v.raku) }
+    is @got[0], '$[1, 2]', 'literal-list for -> $v itemizes too';
+}
+
+{
+    my @c = [<a b>], [<c d>];
+    my @got;
+    for @c -> @row { @got.push(@row.raku) }
+    is @got[0], '["a", "b"]', '@-sigil loop param binds the bare container';
+}
+
+{
+    my @got;
+    for ([1,2],) -> \v { @got.push(v.raku) }
+    is @got[0], '[1, 2]', 'sigilless loop param binds raw';
+}
+
+{
+    my @got;
+    for ([1,2],) { @got.push(.raku) }
+    is @got[0], '[1, 2]', 'implicit topic stays raw for a bare list element';
+}
+
+# --- multi-param loop binding (the CSV::Table t/5-save.t shape) ---
+{
+    my @c = [<a b>], [<c d>];
+    my @got;
+    for @c.kv -> $i, $v { @got.push($v.raku) }
+    is @got[0], '$["a", "b"]', '.kv -> $i, $v itemizes the value param';
+    is @got[1], '$["c", "d"]', '.kv -> $i, $v itemizes the second value';
+}
+
+{
+    my @c = [<a b>], [<c d>];
+    my @out;
+    for @c.kv -> $i, $v { @out.push(sprintf "%-*.*s", 5, 5, $v) }
+    is @out[0], 'a b  ', 'itemized param is ONE sprintf argument (no flatten)';
+}
+
+# --- sub/block parameter binding ---
+{
+    sub f($v) { $v.raku }
+    is f([1,2]), '$[1, 2]', 'sub $ param itemizes an Array argument';
+    is f((1,2)), '$(1, 2)', 'sub $ param itemizes a List argument';
+    is f({:a(1)}), '${:a(1)}', 'sub $ param itemizes a Hash argument';
+}
+
+{
+    sub r($v is raw) { $v.raku }
+    is r([1,2]), '[1, 2]', 'is raw param binds the bare value';
+}
+
+{
+    sub c($v is copy) { $v.raku }
+    is c([1,2]), '$[1, 2]', 'is copy param itemizes';
+}
+
+{
+    sub n(:$v) { $v.raku }
+    is n(v => [1,2]), '$[1, 2]', 'named $ param itemizes';
+}
+
+{
+    my $x = [9];
+    sub w($v is rw) { $v.push(8) }
+    w($x);
+    is $x.raku, '$[9, 8]', 'is rw param still writes through to the caller';
+}
+
+# --- map/grep block parameters ---
+{
+    my @c = [1,2], [3,4];
+    is @c.map(-> $v { $v.raku }).join('|'), '$[1, 2]|$[3, 4]',
+        'map -> $v itemizes elements';
+    is @c.map({ $^a.raku }).join('|'), '$[1, 2]|$[3, 4]',
+        'placeholder $^a itemizes';
+    is @c.grep(-> $v { $v.elems == 2 }).elems, 2,
+        'grep -> $v still sees the array via methods';
+}
+
+# --- itemized invocant methods still iterate elements ---
+{
+    my $x = $[1,2];
+    my $n = 0;
+    for $x.cache { $n++ }
+    is $n, 2, '.cache on an itemized array returns the plain array (deconts)';
+}
+
+# --- our/global scalar assignment ---
+{
+    our $g = [1,2];
+    is $g.raku, '$[1, 2]', 'our $x = [...] itemizes like a my scalar';
+}
+
+done-testing;

--- a/todo/deep/element-itemization-lost-in-scalar-binding.md
+++ b/todo/deep/element-itemization-lost-in-scalar-binding.md
@@ -1,68 +1,60 @@
-# Array/Hash elements lose itemization when bound to a `$` scalar (loop params, element reads)
+# Array/Hash elements are stored bare — element reads lack itemization (store-side residue)
 
-## Symptom
+## Status
 
-`CSV::Table`'s `t/5-save.t` dies in `save`:
+The **bind-side half of this ticket is fixed** (2026-08-11,
+`news/2026-08/param-bind-itemization.md`): a value bound to a plain
+`$`-sigiled parameter — for-loop params (single and multi), sub/closure
+positional and named params, map/grep block params, placeholders — is now
+itemized, matching raku's signature binder. That fixed the original symptom
+(`CSV::Table` `t/5-save.t`'s sprintf explosion; the suite is 10/10) and the
+`for @c -> $v { $v.raku }` divergence. Pinned by
+`t/param-bind-itemization.t`.
 
-```
-Your printf-style directives specify 3 arguments, but 4 arguments were
-supplied to format '%-*.*s'.
-```
-
-The module does `for @!cell.kv -> $i, $v { sprintf "%-*.*s", $w, $w, $v }`
-where each `$v` is a row (an Array). In raku, `$v` is an *item* (an element
-container bound to a `$` parameter), so sprintf receives it as ONE argument
-and stringifies it. In mutsu the Array arrives bare and the sprintf slurpy
-flatten (`flatten_into_slurpy`, which correctly respects itemization when it
-is present) explodes it into its elements — wrong arg count.
-
-## Minimal repro
+What REMAINS is the store-side half: raku's model is that array/hash
+*elements are Scalar containers*, so an element read is itemized even with no
+parameter binding involved. mutsu stores elements bare:
 
 ```
-$ target/debug/mutsu -e 'my @c = [<a b>], [<c d>]; for @c.kv -> $i, $v { say sprintf "%-*.*s", 5, 5, $v }'
-Your printf-style directives specify 3 arguments, but 4 arguments were supplied ...
-$ raku -e 'my @c = [<a b>], [<c d>]; for @c.kv -> $i, $v { say sprintf "%-*.*s", 5, 5, $v }'
-a b
-c d
+$ target/debug/mutsu -e 'my @c = [<a b>],[<c d>]; my @d = @c; say @d[0].raku; for @c { say .raku }'
+["a", "b"]        # raku: $["a", "b"]
+["a", "b"] ...    # raku: $["a", "b"] (implicit topic binds the element CONTAINER)
 ```
 
-The underlying divergence is visible without sprintf:
-
-```
-$ target/debug/mutsu -e 'my @c = [<a b>],[<c d>]; for @c -> $v { say $v.raku }; my @d = @c; say @d[0].raku'
-["a", "b"] / ["c", "d"] / ["a", "b"]
-$ raku -e '...'
-$["a", "b"] / $["c", "d"] / $["a", "b"]
-```
-
-i.e. mutsu's element values are not itemized anywhere: not in the `for`/`.kv`
-`$`-param binding, and not on `@d[0]` reads. `my $v = [1,2]` DOES itemize
-(scalar assignment goes through `itemize_scalar_store`), so the gap is
-specifically *element* reads / `$`-param *binding*, not scalar assignment.
+(`my $v = @c[0]` DOES itemize — scalar assignment goes through
+`itemize_scalar_store` — so the gap is direct element reads: `@d[0].raku`,
+slices `@c[0,1]`, implicit-topic iteration, `.head`/`.tail`/`.first`/
+`.sort`/`.reverse` results, hash-value reads `%h<a>`.)
 
 ## Why this is deep, not a ticket
 
-Raku's model is that array/hash **elements are Scalar containers**; anything
-read out of one and bound to a `$` name is an item. mutsu stores elements as
-bare values, so itemization would have to be (re)applied at every element
-read / param-bind boundary — or elements become real containers, which is
-exactly ADR-0001's Track B ("element `ContainerRef` cells", §2.1), explicitly
-fused with the GC campaign and NOT to be started standalone. A shallow
-alternative — itemizing at `$`-sigil param binding (`for ... -> $v`, `.kv`,
-`.map`) and at `Index` reads feeding scalar contexts — would fix `.raku`
-output and the sprintf flatten, but it touches every loop/param path and
-needs a survey of tests that (incorrectly or not) rely on the current bare
-values flattening; do it as its own measured campaign, not as a drive-by.
+Fixing it read-side would mean touching every element-read site (indexing,
+slices, dozens of list methods, iterators) — each must know its source is a
+real Array/Hash, which `.kv`-through-Seq loses. Fixing it store-side (itemize
+at element *storage*: list-assign into `@`, push/unshift/splice, element
+assign, `[...]` construction) is the raku-faithful single model but changes
+what is IN every array — a survey-sized campaign with its own fallout class
+(the bind-side campaign hit two consumers: `.cache` identity-return and
+`&combinations`; store-side will hit more). Alternatively, elements become
+real containers — exactly ADR-0001's Track B ("element `ContainerRef` cells",
+§2.1), explicitly fused with the GC campaign and NOT to be started
+standalone.
+
+Do the shallow store-side campaign as its own measured effort, or fold it
+into Track B when the GC campaign starts — do not drive it as a drive-by.
 
 ## Affected
 
-- `CSV::Table` `t/5-save.t` (last remaining failure in that suite; 9/10 files
-  pass as of the `WrapVarRef` shadow-slot fix, see
-  `news/2026-08/csv-table-comment-strip-loop-var-state-sync.md`).
-- Every `.raku`/`.gist` of arrays-of-arrays read back element-wise
-  (`$[...]` vs `[...]` — the `.raku` residues family, PLAN §8 QA).
+- `.raku`/`.gist` of arrays-of-arrays read back element-wise (`$[...]` vs
+  `[...]` — the `.raku` residues family, PLAN §8 QA).
+- Implicit-topic iteration over `@`-arrays whose body relies on the element
+  being ONE item in list context (the sprintf shape, now only reachable via
+  `for @c { ... $_ ... }` — the `-> $v` form is fixed).
 
 ## Verification once fixed
 
-`cd ~/.zef/store/CSV-Table-0.0.2/*/ && prove -e '<mutsu> -I lib -I <Font-AFM>/lib -I <Text-Utils>/lib -I <AlgorithmsIT>/lib' t/`
-should reach 10/10, and the two one-liners above should match raku.
+```
+$ mutsu -e 'my @c = [<a b>],[<c d>]; my @d = @c; say @d[0].raku'   # $["a", "b"]
+$ mutsu -e 'my @c = [<a b>],; for @c { say .raku }'                # $["a", "b"]
+$ mutsu -e 'my %h = a => [1,2]; say %h<a>.raku'                    # $[1, 2]
+```


### PR DESCRIPTION
## Summary

Raku's signature binder places a value bound to a plain `$`-sigiled parameter into a Scalar container: the bound value is ONE element in list context and `.raku` shows the leading `$` (`sub f($v) {...}; f([1,2])` sees `$[1, 2]`). mutsu bound every parameter raw, so a row `Array` handed to `-> $i, $v` by `@!cell.kv` exploded inside a sprintf slurpy — the last remaining failure (`t/5-save.t`) in **CSV::Table's suite, which now reaches 10/10 (184 assertions)** (`docs/batteries/csv.md` campaign).

Semantics were verified against raku first: `$` params itemize (including `is copy` and named params); `is raw`, `is rw`, sigilless (`\v`), `@`/`%`/`&` params, the *implicit* topic, and `:=` binds stay raw.

## Bind sites covered

- **SetGlobal scalar stores** (`vm_exec_dispatch.rs`) — multi-param for-loop bind statements compile here when the name has no local slot; this path lacked the `itemize_scalar_store` call the SetLocal path has had all along. Also fixes `our $x = [...]` and closure-captured scalar assigns. Binds/rebinds/internal `__*` temps excluded.
- **for-loop single-param binds** (`vm_for_loop_body.rs`, both `vm_for_loop_lazy.rs` variants). The backing Gc is shared (only the ArrayKind flips), so `loop_var_unchanged`'s ptr_eq still sees in-place mutations — the source-element writeback stays a no-op for read-only loops.
- **sub/closure call paths** — `vm_call_light`, `vm_call_light_typed` (positional + named), full binder positional/named/legacy paths (`binding_signature.rs`), all through one helper (`itemize_plain_scalar_param`). rw `ContainerRef` cells pass through untouched.
- **map/grep/first block params** (`resolution_map_grep.rs`).

## Consumers fixed as general bugs

- `.cache` on an itemized array now deconts (method results are decontainerized in raku). Left itemized, zef's `Zef::Config::plugin-lookup` recursed on the same one-element item forever — `mzef --version` stack overflow, caught by `tests/mzef_shim.rs`.
- `&combinations(Iterable, $k)` deconts an itemized first argument (`roast/S32-list/combinations.t` subtest 33 pins function form == method form).

## Testing

- `t/param-bind-itemization.t` (new, 21 assertions) — green under **both raku and mutsu**.
- `make test` fully green locally (3023 files, 28292 tests, incl. mzef shim).
- CSV::Table suite: **10/10** (was 9/10).
- Local roast pre-screen: 261 whitelisted files across S02-types/S02-lists/S04/S06/S29/S32-list — all pass.

Store-side element itemization (`@d[0].raku` direct reads) remains open — `todo/deep/element-itemization-lost-in-scalar-binding.md` was narrowed to that residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)