### PR TITLE
refactor(vm): ADR-0019 E6a -- measurement slice for CallMethodDynamicMut

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3089,6 +3089,23 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   and `cargo fmt` clean. Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md`
   §"Measurement slice results — CallMethodMut (E6a)". Still to do: `CallMethodDynamicMut` and
   `call_method_mut_with_values` measurement slices, the Tier-A helper survey, then E6b/E6c/E6d.
+  **Progress 2026-08-11** (E6a, second slice, measurement for `CallMethodDynamicMut`):
+  instrumented `exec_call_method_dynamic_mut_op` (`src/vm/vm_call_method_mut_ops.rs:347-433`, a
+  small ~87-line function) with the same counters, entry key `"callmethoddynamicmut"` — 14 lines
+  inserted, zero behavior change. Only four completion shapes exist: `.+`/`.*` modifiers
+  (delegate to the already-measured `call_method_all_with_fallback`), a `$obj.$coderef(...)`
+  call-sub-value form, a narrow `try_native_buf_mut` fast path (dynamic-name Buf mutating
+  writes only), and the generic `vm_call_method_mut_with_values` interpreter fallback — no
+  accessor probe, no distinct not-found completion, confirming the design doc's inventory
+  correction that this entry has no general native/compiled probe. Verified via 5
+  individually-run files (the same set E5 step 2 used for `CallMethodDynamic`), all exact
+  `sum(disjoint outcomes) == CallMethodDynamicMut`-opcode-histogram matches. Full `t/` sweep:
+  `user=29`, `call-sub-value=11` (== `intercept=11`), `native=1`, disjoint total 41 — low
+  traffic, consistent with `CallMethodDynamic`'s own low-traffic finding in E5 step 2.
+  `make test` (3023 files/28293 tests) green; clippy/fmt clean. Full detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results — CallMethodDynamicMut
+  (E6a, second slice)". Still to do: `call_method_mut_with_values` measurement, the Tier-A
+  helper survey, then E6b/E6c/E6d.
 - [ ] **E7 — Route metaobject, qualified, and re-entrant calls through the resolver.** Cover HOW,
   `.^lookup`/`.^can`, qualified/private dispatch, EVAL carriers, and method objects.
   **Design 2026-08-10** (same doc): one consumer family per sub-PR (`run_instance_method`

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -378,11 +378,19 @@ impl Interpreter {
         // Handle .* and .+ modifiers
         match modifier {
             Some("+") => {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethoddynamicmut",
+                    "modifier-plus",
+                );
                 let vals = self.call_method_all_with_fallback(&target, &method, &args, false)?;
                 self.stack.push(Value::array(vals));
                 return Ok(());
             }
             Some("*") => {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethoddynamicmut",
+                    "modifier-star",
+                );
                 match self.call_method_all_with_fallback(&target, &method, &args, false) {
                     Ok(vals) => self.stack.push(Value::array(vals)),
                     Err(e) if Self::is_method_not_found_error(&e) => {
@@ -404,6 +412,10 @@ impl Interpreter {
             name_val.view(),
             ValueView::Sub(_) | ValueView::WeakSub(_) | ValueView::Routine { .. }
         ) {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethoddynamicmut",
+                "call-sub-value",
+            );
             let mut call_args = Vec::with_capacity(args.len() + 1);
             call_args.push(Self::invocant_as_positional(target));
             call_args.extend(args);
@@ -416,9 +428,11 @@ impl Interpreter {
             // (`$buf."$write"(...)`) on a mutable Buf instance — mirror the static
             // CallMethodMut path (ledger §D(b)). Type-object / non-Buf receivers and
             // bad arity fall through to the generic fork unchanged.
+            crate::vm::vm_stats::record_dispatch_entry_outcome("callmethoddynamicmut", "native");
             result
         } else {
             // TODO: compile to bytecode — generic mut method fork (ledger §1).
+            crate::vm::vm_stats::record_dispatch_entry_outcome("callmethoddynamicmut", "user");
             self.vm_call_method_mut_with_values(&target_name, target, &method, args)
         };
         match saved_self {

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -1135,3 +1135,38 @@ reproducing the same 6 failures on `main` with `MUTSU_VM_STATS=1` before this ch
 **E6a's `CallMethodMut` measurement is done. Still to do**: `CallMethodDynamicMut` and
 `call_method_mut_with_values` measurement slices (mirroring E5 steps 2/4), then the Tier-A helper
 survey, then the actual E6b/E6c/E6d cutover work.
+
+## Measurement slice results — CallMethodDynamicMut (E6a, second slice)
+
+Landed 2026-08-11: instrumented `exec_call_method_dynamic_mut_op`
+(`src/vm/vm_call_method_mut_ops.rs:347-433`), a much smaller function than `CallMethodMut`'s
+~87 lines vs ~2300. Same counter functions, entry key `"callmethoddynamicmut"`, pure insertions
+(14 lines), zero behavior change.
+
+The function has exactly four completion shapes: the `.+`/`.*` modifiers (`modifier-plus`/
+`modifier-star` intercepts, delegating to `call_method_all_with_fallback`, its own already-measured
+entry), a `$obj.$coderef(...)` call-sub-value form (`call-sub-value` intercept), a narrow native fast
+path for dynamic-name Buf mutating writes (`try_native_buf_mut`, outcome `native`), and the generic
+fallback to `vm_call_method_mut_with_values` (outcome `user`, the interpreter slow path — marked
+`// TODO: compile to bytecode` in the source already). No accessor probe, no distinct not-found
+completion (the error just propagates via `?`), matching the design doc's inventory-correction
+observation that this entry "reaches the interpreter with no [compiled-method] probe at all" — the
+`try_native_buf_mut` fast path is narrow (Buf-only) rather than a general native probe.
+
+Verified via 5 individually-run files (the same file set E5 step 2 used for `CallMethodDynamic`,
+since this is its Mut twin): `buf-write-native.t` (`native=1` == opcode `CallMethodDynamicMut=1`),
+`format-class.t` (`user=4` == 4), `indirect-method-call-lvalue.t` (`user=1` == 1),
+`self-in-nested-sub-coherence.t` (`user=1` == 1), `array-value-path-mutation.t` (0 in both — the
+entry simply isn't exercised by that file). 5/5 exact matches.
+
+Full `t/` sweep (3023 files, same 6 pre-existing `MUTSU_VM_STATS`-stderr files noted in the
+`CallMethodMut` section above, unrelated): `user=29`, `call-sub-value=11` (== `intercept=11`),
+`native=1`. Disjoint total 41 — a low-traffic entry, consistent with E5 step 2's finding that
+`CallMethodDynamic` itself (this entry's non-mut twin) was "far lower-traffic" than `CallMethod`.
+No `modifier-plus`/`modifier-star` traffic in `t/` (0 — matches `CallMethodDynamic`'s own 0 for
+the same modifiers in E5 step 2's sweep). `make test` (3023 files/28293 tests) green; `cargo
+clippy -- -D warnings` and `cargo fmt` clean.
+
+**E6a's `CallMethodDynamicMut` measurement is done. Still to do**: `call_method_mut_with_values`
+measurement slice (the second slow path, `runtime/methods_mut_dispatch.rs`), the Tier-A helper
+survey, then E6b/E6c/E6d cutover.


### PR DESCRIPTION
## Summary
- Second E6a sub-slice: instruments `exec_call_method_dynamic_mut_op` (`src/vm/vm_call_method_mut_ops.rs:347-433`) with the same `record_dispatch_entry_outcome`/`record_dispatch_entry_intercept` counters, entry key `"callmethoddynamicmut"`. Pure insertions (14 lines), zero behavior change. Follow-up to #6263 (`CallMethodMut` measurement).
- This entry has only four completion shapes: `.+`/`.*` modifiers, a `$obj.$coderef(...)` call-sub-value form, a narrow native Buf-write fast path, and the generic interpreter fallback — no accessor probe, no distinct not-found completion, confirming the design doc's inventory correction that this entry has no general native/compiled probe.
- Verified via 5 individually-run files (exact `sum(disjoint outcomes) == CallMethodDynamicMut` opcode-histogram match each time). Full `t/` sweep: disjoint total 41 (`user=29`, `call-sub-value=11`, `native=1`) — low traffic, consistent with `CallMethodDynamic`'s own low-traffic finding at E5 step 2.

Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results — CallMethodDynamicMut (E6a, second slice)" and the ADR-0019 E6 box.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt`
- [x] `make test` (3023 files, 28293 tests) — all green
- [x] `MUTSU_VM_STATS=1` full `t/` sweep + 5-file per-file cross-check for the taxonomy numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)