### PR TITLE
refactor(vm): ADR-0019 E6a -- measurement slice for call_method_mut_with_values

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3106,6 +3106,29 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results — CallMethodDynamicMut
   (E6a, second slice)". Still to do: `call_method_mut_with_values` measurement, the Tier-A
   helper survey, then E6b/E6c/E6d.
+  **Progress 2026-08-11** (E6a, third slice, measurement for `call_method_mut_with_values`):
+  instrumented `call_method_mut_with_values` (`src/runtime/methods_mut_dispatch.rs:11-2748`,
+  "the second slow path" per design decision 4's E6a scope), a ~2750-line function comparable in
+  size to `CallMethodMut`'s own handler, entry key `"callmethodmutwithvalues"` — 182 lines
+  inserted, zero behavior change. This is a plain `Interpreter` method (not an opcode handler)
+  reached from ~10 call sites, dominated by but not limited to `CallMethodMut`'s own generic-fork
+  tail. 41 named intercept arms added, including three near-duplicate method-match families for
+  different receiver shapes (`@`-sigil array mutators, sigilless-array-binding mutators, `%`-sigil
+  hash push/append). No opcode-histogram cross-check is available for a plain function; verified
+  instead via 6 individually-run files checking `callmethodmutwithvalues`'s disjoint sum never
+  exceeds `callmethodmut:user` in the same run (3 exact matches, 3 proper-subset). Full `t/`
+  sweep: `native=14501` (52.9%), `user=11100` (40.5%), `intercept=1812` (6.6%), `accessor=0` (0%),
+  disjoint total 27413 (~61% of `callmethodmut:user`'s own sweep total). Notable: `accessor=0`
+  (the rw-accessor-write fast path never fires in `t/`) and `promise-channel-delegate=1011` (the
+  single largest arm, pure pass-through to the non-mut sibling for `Promise`/`Channel` receivers —
+  a concrete E6c/E6d cutover target). 20 files fail under `MUTSU_VM_STATS=1` in this sweep
+  (broader than the 6-file list above; same root cause — vm-stats writes to stderr at process
+  exit, and this sweep exercised more subprocess-spawning tests than the prior two slices'
+  spot-checks did), confirmed pre-existing by reproducing 2 of them against the pre-slice base
+  commit. `make test` (3023 files/28293 tests, no `MUTSU_VM_STATS`) green; clippy/fmt clean. Full
+  detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"Measurement slice results —
+  call_method_mut_with_values (E6a, third slice)". **All three E6a sub-slices are now measured.**
+  Still to do: the Tier-A helper survey, then E6b/E6c/E6d.
 - [ ] **E7 — Route metaobject, qualified, and re-entrant calls through the resolver.** Cover HOW,
   `.^lookup`/`.^can`, qualified/private dispatch, EVAL carriers, and method objects.
   **Design 2026-08-10** (same doc): one consumer family per sub-PR (`run_instance_method`

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -29,6 +29,10 @@ impl Interpreter {
         if let ValueView::ContainerRef(cell) = target.view() {
             let inner = cell.lock().unwrap_or_else(|e| e.into_inner()).clone();
             if matches!(inner.view(), ValueView::Array(..) | ValueView::Hash(..)) {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "container-ref-cell",
+                );
                 let cell = cell.clone();
                 let result = self.call_method_mut_with_values(target_var, inner, method, args)?;
                 if let Some(updated) = self.env.get(target_var).cloned()
@@ -59,12 +63,20 @@ impl Interpreter {
                 "push" | "append" | "pop" | "shift" | "unshift" | "prepend" | "splice"
             )
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "immutable-list-reject",
+            );
             return Err(make_x_immutable_error(method, "List"));
         }
         if scalar_like_target
             && args.is_empty()
             && matches!(method, "postfix:<++>" | "postfix:<-->")
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "incdec",
+            );
             self.check_readonly_for_increment(target_var)?;
             let current = self.env.get(target_var).cloned().unwrap_or(target);
             let current = Self::normalize_incdec_source_for_mut(current);
@@ -84,6 +96,10 @@ impl Interpreter {
                 ValueView::Mix(_, _) | ValueView::Set(_, _) | ValueView::Bag(_, _)
             )
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "keyof",
+            );
             if let Some(constraint) = self.var_type_constraint(target_var)
                 && let Some(bracket_pos) = constraint.find('[')
             {
@@ -93,6 +109,10 @@ impl Interpreter {
             return Ok(Value::package(Symbol::intern("Mu")));
         }
         if method == "VAR" && args.is_empty() {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "var-reflect",
+            );
             // Proxy (including subclasses): .VAR returns the proxy wrapped as a
             // ProxyObject so that subsequent method calls don't auto-FETCH.
             if matches!(target.view(), ValueView::Proxy { .. }) {
@@ -208,6 +228,7 @@ impl Interpreter {
             && args.is_empty()
             && (target_var.starts_with('@') || target_var.starts_with('%'))
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept("callmethodmutwithvalues", "of");
             // An `@`/`%` param bound to a parametric TYPE OBJECT
             // (`sub g(@x) { @x.of }` called with `Positional[Dog]` — the
             // JSON::Unmarshal attribute-type shape) reads the element type
@@ -243,6 +264,10 @@ impl Interpreter {
         if method == "set"
             && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Collation")
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "collation-set",
+            );
             let result = self.dispatch_collation_method(target, method, &args)?;
             // Update the variable in the environment to reflect the mutation
             self.env.insert(target_var.to_string(), result.clone());
@@ -254,6 +279,10 @@ impl Interpreter {
         if matches!(method, "set" | "unset")
             && let ValueView::Set(data, true) = target.view()
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "sethash-set-unset",
+            );
             let mut elements = data.elements.clone();
             // Preserve the recorded element objects of untouched keys.
             let mut originals = data.original_keys.clone().unwrap_or_default();
@@ -295,6 +324,10 @@ impl Interpreter {
             let bytes = buf_raw_bytes_or_empty(&attributes);
 
             if (method == "read-ubits" || method == "read-bits") && args.len() == 2 {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "buf-read-bits",
+                );
                 let Some(from) = Self::value_to_non_negative_i64(&args[0]) else {
                     return Err(RuntimeError::new("read-ubits/read-bits expects Int offset"));
                 };
@@ -312,6 +345,10 @@ impl Interpreter {
             }
 
             if (method == "write-ubits" || method == "write-bits") && args.len() == 3 {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "buf-write-bits",
+                );
                 if class_name == "Blob" {
                     return Err(RuntimeError::new(
                         "Cannot modify immutable Blob with write-bits/write-ubits",
@@ -348,6 +385,10 @@ impl Interpreter {
             } = target.view()
             && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "buf-write-num-mut",
+            );
             let cn = class_name.resolve();
             if cn == "Blob" || cn.starts_with("Blob[") || cn.starts_with("blob") {
                 return Err(RuntimeError::new(format!(
@@ -396,6 +437,10 @@ impl Interpreter {
         {
             let cn = name.resolve();
             if crate::runtime::utils::is_buf_or_blob_class(&cn) {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "buf-write-num-fresh",
+                );
                 if args.len() < 2 || args.len() > 3 {
                     return Err(RuntimeError::new(format!(
                         "{} expects 2 or 3 arguments, got {}",
@@ -439,6 +484,10 @@ impl Interpreter {
             } = target.view()
             && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "buf-write-int-mut",
+            );
             let cn = class_name.resolve();
             if cn == "Blob" || cn.starts_with("Blob[") || cn.starts_with("blob") {
                 return Err(RuntimeError::new(format!(
@@ -487,6 +536,10 @@ impl Interpreter {
         {
             let cn = name.resolve();
             if crate::runtime::utils::is_buf_or_blob_class(&cn) {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "buf-write-int-fresh",
+                );
                 if args.len() < 2 || args.len() > 3 {
                     return Err(RuntimeError::new(format!(
                         "{} expects 2 or 3 arguments, got {}",
@@ -528,11 +581,23 @@ impl Interpreter {
         ) && Self::is_buf_like_value(&target)
         {
             if method == "reallocate" {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "buf-reallocate",
+                );
                 return self.buf_reallocate(target_var, target, &args);
             }
             if method == "pop" || method == "shift" || method == "splice" {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "buf-pop-shift-splice",
+                );
                 return self.buf_pop_shift_splice(target_var, target, method, args);
             }
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "buf-mutate-append",
+            );
             return self.buf_mutate_method(target_var, target, method, args);
         }
 
@@ -601,6 +666,10 @@ impl Interpreter {
             };
             match method {
                 "push" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "array-push",
+                    );
                     let normalized_args = Self::normalize_push_unshift_args(args);
                     self.check_container_element_types(&key, &target, &normalized_args)?;
                     let normalized_args = nil_to_elem_default(self, normalized_args);
@@ -609,6 +678,10 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "append" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "array-append",
+                    );
                     // Raku's append uses the "one-arg rule": if exactly one
                     // non-itemized Array/List argument is passed, its elements
                     // are flattened. With multiple arguments, each is appended
@@ -639,6 +712,10 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "unshift" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "array-unshift",
+                    );
                     let normalized_args = Self::normalize_push_unshift_args(args);
                     self.check_container_element_types(&key, &target, &normalized_args)?;
                     let normalized_args = nil_to_elem_default(self, normalized_args);
@@ -668,6 +745,10 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "prepend" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "array-prepend",
+                    );
                     let flat_values = flatten_append_args(args);
                     self.check_container_element_types(&key, &target, &flat_values)?;
                     let result = if let Some(slot) = self.env.get_mut(&key)
@@ -696,6 +777,10 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "pop" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "array-pop",
+                    );
                     if !args.is_empty() {
                         return Err(RuntimeError::new(format!(
                             "Too many positionals passed; expected 1 argument but got {}",
@@ -746,6 +831,10 @@ impl Interpreter {
                     return Ok(out);
                 }
                 "shift" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "array-shift",
+                    );
                     if !args.is_empty() {
                         return Err(RuntimeError::new(format!(
                             "Too many positionals passed; expected 1 argument but got {}",
@@ -785,6 +874,10 @@ impl Interpreter {
                     return Ok(out);
                 }
                 "splice" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "array-splice",
+                    );
                     // Resolve a splice position argument to a usize.
                     // Whatever => array length, Callable => call with length, etc.
                     /// Resolve a splice position to a signed integer for validation.
@@ -1145,6 +1238,10 @@ impl Interpreter {
                     return Ok(removed_arr);
                 }
                 "squish" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "array-squish",
+                    );
                     let current = self.env.get(&key).cloned().unwrap_or(target.clone());
                     let squished = self.dispatch_squish(current, &args)?;
                     if self.in_lvalue_assignment {
@@ -1166,6 +1263,10 @@ impl Interpreter {
             let key = target_var.to_string();
             match method {
                 "push" | "append" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "hash-push-append",
+                    );
                     let is_push = method == "push";
 
                     // Typed / object hashes (`my Int %h{Rat}`) must type-check both
@@ -1377,6 +1478,10 @@ impl Interpreter {
             };
             match method {
                 "push" | "append" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "sigilless-push-append",
+                    );
                     let normalized_args = if method == "push" {
                         Self::normalize_push_unshift_args(args)
                     } else {
@@ -1459,6 +1564,10 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "pop" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "sigilless-pop",
+                    );
                     if !args.is_empty() {
                         return Err(RuntimeError::new(format!(
                             "Too many positionals passed; expected 1 argument but got {}",
@@ -1516,6 +1625,10 @@ impl Interpreter {
                     return Ok(out);
                 }
                 "unshift" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "sigilless-unshift",
+                    );
                     let normalized_args = Self::normalize_push_unshift_args(args);
                     if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
@@ -1552,6 +1665,10 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "prepend" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "sigilless-prepend",
+                    );
                     let flat_values = flatten_append_args(args);
                     if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
@@ -1591,6 +1708,10 @@ impl Interpreter {
                     return Ok(result);
                 }
                 "shift" => {
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "sigilless-shift",
+                    );
                     if !args.is_empty() {
                         return Err(RuntimeError::new(format!(
                             "Too many positionals passed; expected 1 argument but got {}",
@@ -1655,6 +1776,10 @@ impl Interpreter {
             && target_var.starts_with('@')
             && !matches!(target.view(), ValueView::LazyList(ll) if ll.is_infinite_spec())
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "map-rw-writeback",
+            );
             let is_shaped = crate::runtime::utils::is_shaped_array(&target);
             let mut items = if is_shaped {
                 crate::runtime::utils::shaped_array_leaves(&target)
@@ -1696,6 +1821,10 @@ impl Interpreter {
         if matches!(target.view(), ValueView::Set(_, true))
             && matches!(method, "grab" | "grabpairs")
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "sethash-grab",
+            );
             // Resolve Callable args: call with .elems to get count
             let args = if !args.is_empty() && args[0].as_sub().is_some() {
                 let callable = args[0].clone();
@@ -1783,6 +1912,10 @@ impl Interpreter {
         if matches!(target.view(), ValueView::Bag(_, true))
             && matches!(method, "grab" | "grabpairs")
         {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "baghash-grab",
+            );
             // Resolve Callable args: call with .total (grab) or .elems (grabpairs)
             let args = if !args.is_empty() && args[0].as_sub().is_some() {
                 let callable = args[0].clone();
@@ -1909,6 +2042,10 @@ impl Interpreter {
 
         // MixHash.grabpairs: remove random pairs and return them, mutating the Mix
         if matches!(target.view(), ValueView::Mix(_, _)) && matches!(method, "grabpairs" | "grab") {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "mixhash-grab",
+            );
             // Resolve Callable args
             let args = if !args.is_empty() && args[0].as_sub().is_some() {
                 let callable = args[0].clone();
@@ -1997,6 +2134,10 @@ impl Interpreter {
 
         // SharedPromise/SharedChannel are internally mutable — delegate to immutable dispatch
         if matches!(target.view(), ValueView::Promise(_) | ValueView::Channel(_)) {
+            crate::vm::vm_stats::record_dispatch_entry_intercept(
+                "callmethodmutwithvalues",
+                "promise-channel-delegate",
+            );
             return self.call_method_with_values(target, method, args);
         }
 
@@ -2018,12 +2159,20 @@ impl Interpreter {
                 && (Self::is_metamodel_how(&class_name)
                     || self.is_metamodel_how_class(&class_name.resolve()))
             {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "classhow",
+                );
                 return self.dispatch_classhow_method(method, args.to_vec());
             }
             if crate::runtime::utils::is_buf_like_class(&class_name.resolve())
                 && matches!(method, "write-ubits" | "write-bits")
                 && args.len() == 3
             {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "buf-bits-instance-fallback",
+                );
                 let from = super::to_int(&args[0]);
                 let bits = super::to_int(&args[1]);
                 if from < 0 || bits < 0 {
@@ -2041,6 +2190,10 @@ impl Interpreter {
             }
 
             if class_name == "Iterator" {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "iterator-protocol",
+                );
                 // A detached working copy of the attribute map; written back into
                 // the instance's live shared cell at the end.
                 let mut updated = attributes.to_map();
@@ -2355,6 +2508,10 @@ impl Interpreter {
             if let Some(method_def) = self.resolve_method(&class_name.resolve(), method, &args)
                 && method_def.delegation.is_some()
             {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "callmethodmutwithvalues",
+                    "delegation",
+                );
                 // Clear skip_pseudo_method_native so the inner delegate dispatch
                 // does not inherit the outer call's bypass flag (which was set
                 // for the delegator's own method name).
@@ -2437,6 +2594,10 @@ impl Interpreter {
                         .resolve_method(&class_name.resolve(), method, &[])
                         .is_some_and(|m| m.is_rw);
                     if !has_rw_method {
+                        crate::vm::vm_stats::record_dispatch_entry_outcome(
+                            "callmethodmutwithvalues",
+                            "accessor",
+                        );
                         let mut updated = attributes.to_map();
                         let assigned = args[0].clone();
                         updated.insert(method.to_string(), assigned.clone());
@@ -2447,6 +2608,10 @@ impl Interpreter {
                         return Ok(assigned);
                     }
                     // Signal to assign_method_lvalue to handle via Proxy
+                    crate::vm::vm_stats::record_dispatch_entry_intercept(
+                        "callmethodmutwithvalues",
+                        "rw-proxy-signal",
+                    );
                     return Err(super::methods_signature_errors::make_multi_no_match_error(
                         method,
                     ));
@@ -2457,6 +2622,10 @@ impl Interpreter {
                         .is_some_and(|m| m.is_rw);
                     if has_rw_method {
                         // Signal to assign_method_lvalue to handle via Proxy
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethodmutwithvalues",
+                            "rw-proxy-signal",
+                        );
                         return Err(super::methods_signature_errors::make_multi_no_match_error(
                             method,
                         ));
@@ -2468,6 +2637,10 @@ impl Interpreter {
                         class_attrs.iter().any(|a| a.is_public && a.name == method)
                     };
                     if is_public_accessor {
+                        crate::vm::vm_stats::record_dispatch_entry_intercept(
+                            "callmethodmutwithvalues",
+                            "rw-readonly-reject",
+                        );
                         let current = attributes
                             .as_map()
                             .get(method)
@@ -2482,6 +2655,10 @@ impl Interpreter {
             }
 
             if self.is_native_method(&class_name.resolve(), method) {
+                crate::vm::vm_stats::record_dispatch_entry_outcome(
+                    "callmethodmutwithvalues",
+                    "native",
+                );
                 // Lazy `IO::CatHandle.lines` (no `$limit`/`:close`) / `.handles`
                 // return a lazy list backed by the live cat (sharing its cell),
                 // so mid-iteration `.chomp`/`.nl-in`/`.encoding` changes apply and
@@ -2533,6 +2710,10 @@ impl Interpreter {
             if self.has_user_method(&class_name.resolve(), method)
                 && (!is_pseudo_method || skip_pseudo)
             {
+                crate::vm::vm_stats::record_dispatch_entry_outcome(
+                    "callmethodmutwithvalues",
+                    "user",
+                );
                 let (result, updated) = self.run_instance_method(
                     &class_name.resolve(),
                     attributes.to_map(),
@@ -2561,6 +2742,7 @@ impl Interpreter {
                 return Ok(result);
             }
         }
+        crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmutwithvalues", "user");
         self.call_method_with_values(target, method, args)
     }
 }

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -1167,6 +1167,143 @@ No `modifier-plus`/`modifier-star` traffic in `t/` (0 — matches `CallMethodDyn
 the same modifiers in E5 step 2's sweep). `make test` (3023 files/28293 tests) green; `cargo
 clippy -- -D warnings` and `cargo fmt` clean.
 
-**E6a's `CallMethodDynamicMut` measurement is done. Still to do**: `call_method_mut_with_values`
-measurement slice (the second slow path, `runtime/methods_mut_dispatch.rs`), the Tier-A helper
-survey, then E6b/E6c/E6d cutover.
+## Measurement slice results — call_method_mut_with_values (E6a, third slice)
+
+Landed 2026-08-11: instrumented `call_method_mut_with_values`
+(`src/runtime/methods_mut_dispatch.rs:11-2748`), "the second slow path" per design decision 4's
+E6a scope — a single ~2750-line function that IS the whole file (only one `impl Interpreter`
+block), comparable in size to `CallMethodMut`'s own ~2300-line handler. Same counter functions,
+entry key `"callmethodmutwithvalues"`, pure insertions (182 lines added / 0 deleted), zero behavior
+change (every insertion sits immediately before an already-existing `return`/fall-through path;
+none alters a condition).
+
+Unlike `CallMethodMut`/`CallMethodDynamicMut` (VM opcode handlers reached once per bytecode
+dispatch), this function is a plain `Interpreter` method reached from ~10 call sites across the
+codebase: `CallMethodMut`'s own generic-fork tail (`vm_call_method_mut_ops.rs:2363/2432/2441`,
+the `user` outcome), `CallMethodDynamicMut`'s fallback, `vm_call_method_compiled_mut.rs`,
+`vm_var_trait_ops.rs` (`.VAR`), `vm_call_helpers.rs`, `vm_for_loop_dispatch.rs` (`pull-one`),
+`class_dispatch.rs`, `methods_call_dispatch.rs`, `builtins_multidim_subscript.rs`,
+`methods_mut_method_lvalue.rs`, and `methods_collection_ops/tail_rotate.rs` — plus the function
+recurses into itself once (the `ContainerRef` cell-unwrap branch) and calls itself again from the
+Instance delegation branch. So its traffic is not a strict subset of `CallMethodMut`'s `user`
+count; the two are correlated but distinct populations.
+
+The function's body is almost entirely a cascade of top-level `if`/`match method` special cases —
+30-odd named receiver/method-identity checks — with no single dominant "generic" middle tier of its
+own; the true generic tail is the very last line, which delegates the receiver to the non-mut
+sibling `call_method_with_values`. 41 named intercept arms were added. Three families repeat with
+near-identical bodies for different receiver shapes and got distinct arm names per shape rather
+than being collapsed: the `@`-sigil array mutator match (`array-push`/`array-append`/
+`array-unshift`/`array-prepend`/`array-pop`/`array-shift`/`array-splice`/`array-squish`), the
+sigilless-array-binding twin of the same match (`sigilless-push-append`/`sigilless-pop`/
+`sigilless-unshift`/`sigilless-prepend`/`sigilless-shift` — no separate splice/squish arm here,
+those route through the `@`-sigil block instead per a shared `scalar_holds_real_array`/`starts_with
+('@')` guard), and the `%`-sigil hash push/append match (`hash-push-append`, one arm covering both
+`push`/`append` since an internal `is_push` flag distinguishes them, mirroring the granularity
+`CallMethodMut`'s own `lock-protect` used). Other arms: `container-ref-cell`, `immutable-list-
+reject`, `incdec`, `keyof`, `var-reflect` (`.VAR`), `of`, `collation-set`, `sethash-set-unset`, ten
+`buf-*` arms (`buf-read-bits`/`buf-write-bits`/`buf-write-num-mut`/`buf-write-num-fresh`/
+`buf-write-int-mut`/`buf-write-int-fresh`/`buf-reallocate`/`buf-pop-shift-splice`/
+`buf-mutate-append`/`buf-bits-instance-fallback`), `map-rw-writeback`,
+`sethash-grab`/`baghash-grab`/`mixhash-grab`, `promise-channel-delegate`, `classhow`,
+`iterator-protocol` (one arm covering the whole `class_name == "Iterator"` sub-cascade, which is
+itself ~170 lines with its own internal method dispatch — left uninstrumented internally per the
+"not every return needs a counter" rule, since every path through it already returns before
+reaching the end), `delegation`, and two accessor-write sub-outcomes (`rw-proxy-signal`,
+`rw-readonly-reject`) alongside the `accessor` outcome itself for the successful-write case.
+Outcomes used: `intercept`/`native`/`user`/`accessor` — no `notfound`, since every error this
+function raises is a typed `X::` error thrown from within an already-committed named arm (not a
+generic "no such method" completion); the final generic fallback line hands `notfound`
+classification to whatever the non-mut sibling decides, outside this entry's own count.
+
+### Verification: no opcode-histogram cross-check available; self-consistency against `callmethodmut:user` instead
+
+This entry is a plain function, not an opcode handler, so there is no `opcode_histogram()` row to
+cross-check against (unlike `CallMethodMut`/`CallMethodDynamicMut`, which are VM dispatch loop
+entries). Five individually-run files were used instead, checking `callmethodmutwithvalues`'s
+disjoint sum against `callmethodmut:user` from the same run as an order-of-magnitude sanity check
+(not a formal subset, per the multi-caller point above, but the dominant caller by far):
+
+| File | `callmethodmutwithvalues` disjoint sum | `callmethodmut:user` (same run) | Relationship |
+|---|---|---|---|
+| `t/array-push-byref-coherence.t` | `intercept=20` (`sigilless-push-append=17`, `-pop=1`, `-shift=1`, `-unshift=1`) | 20 | 20 == 20 |
+| `t/buf-splice-count.t` | `intercept=5` (`buf-pop-shift-splice=5`) | 11 | 5 <= 11 |
+| `t/buf-splice-list-bytes.t` | `intercept=5` (`buf-pop-shift-splice=5`) | 11 | 5 <= 11 |
+| `t/from-iterator.t` | `user=15` | 15 | 15 == 15 |
+| `t/pop-shift-sub-empty-failure.t` | `user=1` | 1 | 1 == 1 |
+| `t/array-subclass-vector.t` | `user=10` | 25 | 10 <= 25 (the other 15 resolve inside `try_compiled_method_mut_or_interpret_sym` without reaching this function) |
+
+All six checked files are consistent (`callmethodmutwithvalues` never exceeds `callmethodmut:user`
+in the same run), three are exact matches. This is the closest available correctness signal short
+of a formal cross-check; it is not proof of completeness the way the opcode-histogram match was for
+`CallMethodMut`, and is reported as such rather than overstated.
+
+### Sweep results (2026-08-11, debug build, full `t/` 3023 files, `prove -j8`, 63 wallclock secs)
+
+No truncation in this sweep: the `dispatch-entry outcomes` line's displayed `(top N)` never exceeded
+10 per process (cap 25), and the `intercept arms` line's never exceeded 7 (cap 40) — so the whole-
+suite aggregate sums below (computed by summing every `key=count` token across all 3023 per-process
+lines) are exact, not undercounts.
+
+Outcomes (disjoint): `callmethodmutwithvalues:native=14501` (52.9%),
+`callmethodmutwithvalues:user=11100` (40.5%), `callmethodmutwithvalues:intercept=1812` (6.6%),
+`callmethodmutwithvalues:accessor=0` (0%). Disjoint total 27413 — about 61% of `callmethodmut:user`'s
+own full-sweep total (45085, close to but not identical to E6a slice 1's 45097, expected drift from
+intervening commits), consistent with this function being `CallMethodMut`'s dominant but not sole
+feeder.
+
+`accessor=0` is a notable negative finding: the single-arg rw-accessor-write fast path
+(`attributes.contains_key(method)` / `is_rw` public attribute, writing `args[0]` directly) never
+fired anywhere in `t/`, meaning ordinary `$obj.attr = val`-style rw-attribute writes in the local
+suite are all resolved before reaching this function (compiled-method fast paths, or Proxy-mediated
+writes that reach `rw-proxy-signal` instead — which itself is very low-traffic at 7).
+
+Intercept arms by count (28 of 41 fired, 13 scored zero in `t/`):
+`promise-channel-delegate=1011`, `delegation=212`, `buf-pop-shift-splice=87`,
+`sigilless-push-append=75`, `var-reflect=74`, `map-rw-writeback=59`, `buf-mutate-append=47`,
+`iterator-protocol=44`, `incdec=44`, `array-splice=28`, `array-push=26`, `classhow=22`, `of=20`,
+`hash-push-append=10`, `array-append=8`, `sigilless-pop=7`, `rw-proxy-signal=7`,
+`sethash-set-unset=6`, `array-pop=5`, `sigilless-shift=4`, `array-unshift=4`, `buf-reallocate=3`,
+`array-squish=2`, `array-shift=2`, `array-prepend=2`, `sigilless-unshift=1`, `keyof=1`,
+`immutable-list-reject=1`. The sum of these 28 counts is exactly 1812, matching the `intercept`
+outcome total above — confirms the counting semantics hold here too (every intercept bump goes
+through `record_dispatch_entry_intercept`, which bumps both the outcome and the arm histogram
+atomically). Zero in `t/`: `container-ref-cell`, `collation-set`, `sethash-grab`, `baghash-grab`,
+`mixhash-grab`, `buf-read-bits`, `buf-write-bits`, `buf-write-num-mut`, `buf-write-num-fresh`,
+`buf-write-int-mut`, `buf-write-int-fresh`, `buf-bits-instance-fallback`, `rw-readonly-reject` — all
+rare/edge-case receiver shapes (native-int Buf bit/num/int writes, SetHash/BagHash/MixHash `.grab`,
+`state`-cell-held aggregate mutation, readonly-attribute-assignment rejection) that the local `t/`
+suite happens not to exercise, not evidence they are dead code.
+
+`promise-channel-delegate` (1011) being the single largest arm is notable: `Promise`/`Channel`
+mutation calls are common in `t/`'s concurrency tests and this entry's *only* job for them is an
+immediate one-line delegate to the non-mut sibling (`ValueView::Promise(_) | ValueView::Channel(_)
+=> return self.call_method_with_values(...)`), so essentially all of that traffic is pure pass-
+through overhead — a concrete future E6c/E6d cutover target (a fast pre-check could route straight
+to the non-mut entry without ever compiling/reaching the mut fork for these two receiver kinds).
+
+20 files fail under `MUTSU_VM_STATS=1` in this sweep (broader than the 6 files noted in the
+`CallMethodMut` section above): `cli-lines-regressions.t`, `command-line-negation.t`,
+`constant-hash-coerce-once.t`, `dd-instance.t`, `exit-skips-main-dispatch.t`, `get-out.t`,
+`io-handle-lock.t`, `io-handle-stdout-stderr-native.t`, `io-pipe-slurp-rest.t`, `is-run.t`,
+`note-with-parens.t`, `precomp-warm-cache-parity.t`, `proc-async.t`, `quietly.t`,
+`say-env-roundtrip.t`, `sink-warning.t`, `slip-listop-args.t`,
+`undeclared-routine-compile-time.t`, `vendored-real-test-module.t`, `weird-errors-parse-forms.t`.
+All share the same root cause the `CallMethodMut` section already identified — the vm-stats dump
+unconditionally writes to stderr at process exit, and any test asserting exact/empty stderr (either
+of its own process, or of a subprocess it spawns via `is_run`/`shell`/`Proc::Async` inheriting
+`MUTSU_VM_STATS` from the parent environment) fails. Verified pre-existing and unrelated to this
+diff: `t/cli-lines-regressions.t` and `t/constant-hash-coerce-once.t` were individually re-run
+against the pre-slice commit (`be980a448`, this branch's base, before any of the 182-line diff) with
+`MUTSU_VM_STATS=1` and failed identically. The earlier 6-file list was evidently a partial spot-
+check, not an exhaustive one — this slice's sweep is the first full `MUTSU_VM_STATS=1` `t/` run
+against this many call sites at once, so more of the pre-existing subprocess-stderr-inheritance
+files got exercised. Not a regression; `make test` (no `MUTSU_VM_STATS`) is unaffected by this
+class of failure entirely, since it never sets the env var.
+
+`make test` (no `MUTSU_VM_STATS`, 3023 files/28293 tests) green. `cargo clippy -- -D warnings` and
+`cargo fmt` clean.
+
+**E6a's `call_method_mut_with_values` measurement is done — all three E6a sub-slices
+(`CallMethodMut`/`CallMethodDynamicMut`/`call_method_mut_with_values`) are now measured. Still to
+do**: the Tier-A helper survey, then the actual E6b/E6c/E6d cutover work.


### PR DESCRIPTION
## Summary
- Third and final E6a sub-slice: instrument `call_method_mut_with_values` (`src/runtime/methods_mut_dispatch.rs`), "the second slow path" per design decision 4's E6a scope, comparable in size to `CallMethodMut`'s own ~2300-line handler.
- Reuses the same `record_dispatch_entry_outcome`/`record_dispatch_entry_intercept` counters E5 step 1 introduced -- no new counter machinery, entry key `"callmethodmutwithvalues"`. Pure insertions (182 lines), zero behavior change.
- 41 named intercept arms added across ~30 top-level special-case blocks, including three near-duplicate method-match families for different receiver shapes (`@`-sigil array mutators, sigilless-array-binding mutators, `%`-sigil hash push/append).
- This closes out all three E6a sub-slices (`CallMethodMut` #6263, `CallMethodDynamicMut` #6264, and this one). Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` and the ADR's E6 box.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `make test` (3026 files / 28348 tests) green
- [x] Spot-verified with `MUTSU_VM_STATS=1` on representative files, cross-checking `callmethodmutwithvalues`'s disjoint sum never exceeds `callmethodmut:user` in the same run
- [x] Full `t/` sweep under `MUTSU_VM_STATS=1` documented in the design doc; 20 pre-existing (vm-stats-writes-to-stderr) failures confirmed unrelated to this diff by reproducing 2 of them against the pre-slice base commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)