### PR TITLE
docs(adr): accept ADR-0026; queue the slang activation campaign in PLAN.md

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -59,6 +59,11 @@ gaps with general interpreter fixes.
       value: [python-stdlib-comparison.md](docs/batteries/python-stdlib-comparison.md).
 - [ ] **Web-framework slot: make Cro run** — the campaign that fills the last hole in that criterion.
       Target, rationale, and gate order: [docs/batteries/web-framework.md](docs/batteries/web-framework.md).
+- [ ] **CSV slot: slang activation campaign ([ADR-0026](docs/adr/0026-slang-activation-architecture.md), Accepted 2026-08-11)** —
+      bundle Slangify + Slang::Tuxic verbatim and grow the interpreter (compile-time `use` →
+      `$*LANG`/`define_slang` mapping recognized rule overrides onto parser modes) until
+      `use Text::CSV` parses; then measure its 33-file suite. Survey and status:
+      [docs/batteries/csv.md](docs/batteries/csv.md) (CSV::Table already 10/10 as the fallback).
 - [ ] **Documentation per battery** — a usage document (no install needed, API, examples) for each
       bundled library. "Well-documented" is an explicit goal requirement, so this is mandatory when
       adding a module.

--- a/docs/adr/0026-slang-activation-architecture.md
+++ b/docs/adr/0026-slang-activation-architecture.md
@@ -1,6 +1,7 @@
 # ADR-0026: Slang activation — bundle Slangify + Slang::Tuxic verbatim, map recognized grammar-mixin overrides onto parser modes
 
-- Status: Proposed
+- Status: Accepted (2026-08-11 — approved by tokuhirom same day; implementation
+  to start as its own campaign, slices in dependency order §2.1 → §2.2 → §2.3 → §2.4)
 - Date: 2026-08-11
 - Deciders: tokuhirom, Claude
 - Related: [BATTERIES.md](../../BATTERIES.md) §1 (rung 2: grow the interpreter


### PR DESCRIPTION
ADR-0026 (slang activation via bundled Slangify + Slang::Tuxic) is approved by tokuhirom (2026-08-11) — status flipped to Accepted, with the slice order noted (§2.1 compile-time `use` → §2.2 `$*LANG` API → §2.3 Tuxic rule modes → §2.4 vendoring). PLAN.md §B1 gains the campaign entry so next-session task selection picks it up; CSV::Table 10/10 is noted as the standing fallback for the CSV slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)