### PR TITLE
fix(regex,runtime): ClassHOW nativesize/unsigned, alternation angle-depth mis-split, native-int param defaults

### DIFF
--- a/news/2026-08/regex-alternation-angle-depth-and-native-int-defaults.md
+++ b/news/2026-08/regex-alternation-angle-depth-and-native-int-defaults.md
@@ -1,0 +1,88 @@
+# Regex alternation `<...>` mis-split, missing `.^nativesize`/`.^unsigned`, and native-int params silently uninitialized
+
+Continuing the Cro::HTTP campaign, re-measuring `t/http-router.rakutest`
+after the ADR-0022 Slice 3 milestone (83/83) turned up a second wave of
+failures once the suite's native-int route parameter tests
+(`int8`/`uint8`/.../`int64`/`uint64`, 88 more subtests than the previous
+83/83 count covered) were exercised: first a hard crash building the route
+table, then near-total 404s, then 8 stray warnings. Three independent,
+general-purpose interpreter bugs were involved — none of them Cro-specific.
+
+## `ClassHOW` was missing `.^nativesize` / `.^unsigned`
+
+`Cro::HTTP::Router`'s route compiler computes each native-int parameter's
+bounds via `$type.^nativesize` and `$type.^unsigned` (Rakudo's `ClassHOW`
+introspection for native types). mutsu had neither method, so building any
+route with a bounds-checked native-int parameter threw "No such method
+'nativesize'" and aborted the whole route table. Added both to
+`dispatch_classhow_method` (`src/runtime/methods_classhow_dispatch.rs`),
+backed by the existing `native_types::native_type_bits` /
+`is_signed_native` tables, and whitelisted them in
+`Self::is_classhow_method` (`src/runtime/methods_native_bypass.rs`) so the
+`.^meta_method` dispatch path reaches them at all.
+
+## A code assertion's `<=`/`>=` desynchronized alternation splitting
+
+With the crash above fixed, every native-int route still 404'd. Isolated to
+a regex bug with no Cro dependency at all:
+
+```raku
+say "/x" ~~ / ^ [ '/' 'x' <?{ 1 <= 127 }> | <!> ] $ /;   # raku: True, mutsu: False
+```
+
+`split_top_level_alternation` (`src/runtime/regex_parse_ltm.rs`) finds a
+`[ A | B ]` group's top-level `|` by tracking `<`/`>` depth so it can tell a
+real alternation bar from one buried inside a `<...>` assertion. It did not
+know that a code assertion's body (`<?{ ... }>`) is arbitrary Raku code that
+may contain unbalanced `<`/`>` from ordinary operators. The `<` in `<=`
+incremented the depth counter with no matching `>` to close it, so the
+counter never returned to zero and the `|` that followed the assertion was
+never recognized as a separator — the whole `[ ... | ... ]` collapsed into
+one un-split, unmatchable branch. Added `consume_code_assertion_verbatim`,
+which recognizes a code-assertion/closure-interpolation opener (`<?{`,
+`<!{`, `<{`) and consumes it as one opaque unit via brace-depth tracking
+(mirroring the real `CodeAssertion` scanner in `regex_parse_core.rs`,
+which never looked at `<`/`>` in the first place) instead of feeding its
+characters through the generic angle-depth counter.
+
+## An unpassed native-int parameter had no zero default
+
+With route matching fixed, every route whose native-int parameter used the
+Cro-idiomatic *omit the query string entirely* shape (`get -> 'id_int8',
+int8 :$id { ... }`, called at `/id_int8` with no `?id=`) failed with "Use
+of uninitialized value ... in string context" instead of getting the
+native `0`:
+
+```raku
+sub f(int8 :$id) { say "id=$id" }
+f();   # raku: "id=0", mutsu (before): warns and prints "id="
+```
+
+`missing_optional_param_value` (`src/runtime/types/mod.rs`) is the single
+shared helper every unpassed optional/named parameter binds through
+(9 call sites: named/positional binding, method dispatch, the VM's
+light-typed call fast path, and the compiler's default-folding). It always
+produced a `Value::package(...)` type object for a typed constraint,
+correct for object types (`Int` unpassed is the `Int` type object) but
+wrong for native ints, which have no undefined state at all — `my int8
+$x;` is already `0`, never a type object. Added a native-int check ahead
+of the type-object fallback, mirroring how `wrap_native_int_for_binding`
+already special-cases native ints on the *passed* path.
+
+## Result
+
+`t/http-router.rakutest` (vendored `Cro::HTTP::Router` test suite, run via
+`bash tmp/cro-suite-run.sh http`): all 171 subtests that run now pass. The
+suite still exits non-zero because of one remaining, already-tracked issue —
+`todo/tickets/parameter-type-not-nominalized-for-user-subsets.md`
+(`Parameter.type` for a user-declared `subset ... of Str` isn't
+nominalized to `Str`, so the route compiler's `$type =:= Str` check
+doesn't recognize it) — which is unrelated to the three bugs above and
+needs its own plumbing work.
+
+`make test` (28368 tests across 3029 files) and the full `S05-*` /
+`integration/*` whitelisted roast subsets are green; three new local
+regression tests were added
+(`t/native-int-classhow-nativesize-unsigned.t`,
+`t/regex-alternation-code-assertion-relop.t`,
+`t/missing-optional-native-int-param-defaults-zero.t`).

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -1198,6 +1198,27 @@ impl Interpreter {
                 }
                 Ok(Value::hash(table))
             }
+            "nativesize" if args.len() == 1 => {
+                let type_name = self.mop_receiver_owner(&args[0]);
+                match native_types::native_type_bits(&type_name) {
+                    Some(bits) => Ok(Value::int(i64::from(bits))),
+                    None => Err(RuntimeError::new(
+                        "X::Method::NotFound: Unknown method value dispatch (fallback disabled): nativesize",
+                    )),
+                }
+            }
+            "unsigned" if args.len() == 1 => {
+                let type_name = self.mop_receiver_owner(&args[0]);
+                if native_types::native_type_bits(&type_name).is_some() {
+                    Ok(Value::int(i64::from(!native_types::is_signed_native(
+                        &type_name,
+                    ))))
+                } else {
+                    Err(RuntimeError::new(
+                        "X::Method::NotFound: Unknown method value dispatch (fallback disabled): unsigned",
+                    ))
+                }
+            }
             _ => Err(RuntimeError::new(format!(
                 "X::Method::NotFound: Unknown method value dispatch (fallback disabled): {}",
                 method

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -56,6 +56,8 @@ impl Interpreter {
                 | "language-revision"
                 | "method_table"
                 | "submethod_table"
+                | "nativesize"
+                | "unsigned"
         )
     }
 

--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -123,7 +123,7 @@ pub(crate) fn native_int_bounds(type_name: &str) -> Option<(NumBigInt, NumBigInt
 }
 
 /// Number of bits for each native type.
-fn native_type_bits(type_name: &str) -> Option<u32> {
+pub(crate) fn native_type_bits(type_name: &str) -> Option<u32> {
     match type_name {
         "int8" | "uint8" | "byte" | "bool" => Some(8),
         "int16" | "uint16" => Some(16),
@@ -135,7 +135,7 @@ fn native_type_bits(type_name: &str) -> Option<u32> {
 }
 
 /// Whether the native type is signed.
-fn is_signed_native(type_name: &str) -> bool {
+pub(crate) fn is_signed_native(type_name: &str) -> bool {
     matches!(
         type_name,
         "int8" | "int16" | "int32" | "int64" | "int" | "long" | "longlong" | "ssize_t" | "bool"

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -2,6 +2,51 @@ use super::regex_parse::*;
 use super::*;
 use ::regex::Regex;
 
+/// If the iterator is positioned right after a `<` that opens a code
+/// assertion (`<?{ ... }>`, `<!{ ... }>`) or closure interpolation
+/// (`<{ ... }>`), consume the whole thing verbatim into `current` and
+/// return `true`. Otherwise leave the iterator untouched and return `false`.
+///
+/// The body is arbitrary Raku code and may contain unbalanced `<`/`>` (e.g.
+/// `<=`, `>=`), which would desynchronize a naive angle-bracket depth
+/// counter and hide a top-level `|` that follows the assertion — see
+/// `split_top_level_alternation`. Mirrors the real `CodeAssertion` scanner
+/// in `regex_parse_core.rs`, which tracks braces only, not angle brackets.
+pub(super) fn consume_code_assertion_verbatim(
+    open_ch: char,
+    chars: &mut std::iter::Peekable<std::str::Chars>,
+    current: &mut String,
+) -> bool {
+    let mut lookahead = chars.clone();
+    let marker = lookahead.next();
+    let opens_code = matches!(marker, Some('?') | Some('!')) && lookahead.peek() == Some(&'{')
+        || marker == Some('{');
+    if !opens_code {
+        return false;
+    }
+    current.push(open_ch); // '<'
+    if marker != Some('{') {
+        current.push(chars.next().unwrap()); // '?' or '!'
+    }
+    current.push(chars.next().unwrap()); // '{'
+    let mut brace_depth = 1usize;
+    for ch in chars.by_ref() {
+        current.push(ch);
+        if ch == '{' {
+            brace_depth += 1;
+        } else if ch == '}' {
+            brace_depth -= 1;
+            if brace_depth == 0 {
+                break;
+            }
+        }
+    }
+    if chars.peek() == Some(&'>') {
+        current.push(chars.next().unwrap());
+    }
+    true
+}
+
 impl Interpreter {
     fn regex_alternation_separator(out: &str) -> Option<&'static str> {
         let trimmed = out.trim_end_matches(char::is_whitespace);
@@ -113,6 +158,9 @@ impl Interpreter {
                         continue;
                     }
                     if skip_char_class_content(&mut chars, &mut current, ch) {
+                        continue;
+                    }
+                    if consume_code_assertion_verbatim(ch, &mut chars, &mut current) {
                         continue;
                     }
                     depth_angle += 1;

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -556,6 +556,15 @@ impl Interpreter {
             return Value::hash(std::collections::HashMap::new());
         }
         if let Some(constraint) = &pd.type_constraint {
+            // A native int type has no undefined state (`int8 $x;` is 0, not
+            // an uninitialized `Int`), so an unpassed `int8 :$id` / `int8 $y?`
+            // must bind the native zero, not a type object — mirrors how
+            // `wrap_native_int_for_binding` special-cases native ints when a
+            // real value IS passed.
+            let (base, _) = strip_type_smiley(constraint);
+            if native_types::is_native_int_type(base) {
+                return Value::int(0);
+            }
             return Value::package(Symbol::intern(&Self::optional_type_object_name(constraint)));
         }
         // An unpassed untyped optional binds the parameter's implicit nominal

--- a/t/missing-optional-native-int-param-defaults-zero.t
+++ b/t/missing-optional-native-int-param-defaults-zero.t
@@ -1,0 +1,19 @@
+use Test;
+
+plan 4;
+
+# A native int type has no undefined state (`my int8 $x;` is 0, not an
+# uninitialized Int), so an unpassed optional native-int parameter must bind
+# the native zero, not a generic type-object placeholder.
+
+sub named-int8(int8 :$id) { $id }
+is named-int8(), 0, 'unpassed named int8 param defaults to 0';
+
+sub positional-optional-int32(int32 $y?) { $y }
+is positional-optional-int32(), 0, 'unpassed optional positional int32 param defaults to 0';
+
+my $blk = -> int8 :$id { $id };
+is $blk(), 0, 'unpassed named int8 block param defaults to 0';
+
+sub named-int8-passed(int8 :$id) { $id }
+is named-int8-passed(id => 5), 5, 'passed named int8 param still works';

--- a/t/native-int-classhow-nativesize-unsigned.t
+++ b/t/native-int-classhow-nativesize-unsigned.t
@@ -1,0 +1,18 @@
+use Test;
+
+plan 12;
+
+is int8.^nativesize, 8, 'int8.^nativesize';
+is int16.^nativesize, 16, 'int16.^nativesize';
+is int32.^nativesize, 32, 'int32.^nativesize';
+is int64.^nativesize, 64, 'int64.^nativesize';
+is uint8.^nativesize, 8, 'uint8.^nativesize';
+is uint64.^nativesize, 64, 'uint64.^nativesize';
+
+is int8.^unsigned, 0, 'int8.^unsigned is signed';
+is int64.^unsigned, 0, 'int64.^unsigned is signed';
+is uint8.^unsigned, 1, 'uint8.^unsigned is unsigned';
+is uint64.^unsigned, 1, 'uint64.^unsigned is unsigned';
+
+dies-ok { Int.^nativesize }, 'Int.^nativesize dies (not a native type)';
+dies-ok { Str.^unsigned }, 'Str.^unsigned dies (not a native type)';

--- a/t/regex-alternation-code-assertion-relop.t
+++ b/t/regex-alternation-code-assertion-relop.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 4;
+
+# A `<?{ ... }>` code assertion containing a relational operator (`<=`, `<`,
+# `>=`, `>`) desynchronized `split_top_level_alternation`'s angle-bracket
+# depth counter when the assertion sat inside a `[ A | B ]` alternation: the
+# stray `<` from `<=` was counted as opening a NEW `<...>` assertion with no
+# matching `>`, so the alternation's own `|` was never recognized as a
+# top-level separator and the whole `[ ... ]` was mis-parsed as one branch
+# (Cro::HTTP::Router's route matcher hits this shape for every bounds-checked
+# native-int route parameter).
+ok "/x" ~~ / ^ [ '/' 'x' <?{ -128 <= 1 <= 127 }> | <!> ] $ /,
+    'chained comparison in code assertion inside alternation matches';
+
+ok "/x" ~~ / ^ [ '/' 'x' <?{ 1 <= 127 }> | <!> ] $ /,
+    'single <= comparison in code assertion inside alternation matches';
+
+ok "/x" ~~ / ^ [ '/' 'x' <?{ 1 >= -128 }> | <!> ] $ /,
+    'single >= comparison in code assertion inside alternation matches';
+
+nok "/y" ~~ / ^ [ '/' 'x' <?{ 1 <= 127 }> | <!> ] $ /,
+    'non-matching literal still fails via the <!> fallback branch';


### PR DESCRIPTION
## Summary

Continuing the Cro::HTTP campaign, re-measuring `t/http-router.rakutest` (vendored `Cro::HTTP::Router` test suite) turned up three independent, general-purpose interpreter bugs — none of them Cro-specific:

- `ClassHOW` was missing `.^nativesize`/`.^unsigned` (Rakudo's native-type introspection), so building any route with a bounds-checked native-int parameter (`int8`/`uint8`/.../`int64`/`uint64`) threw "No such method 'nativesize'" and aborted the route table.
- `split_top_level_alternation`'s `<...>` depth counter treated every `<` inside a `<?{ ... }>` code assertion's body the same as a real assertion opener. A relational operator like `<=` (or `>=`) inside the assertion desynchronized the counter, hiding the top-level `|` that followed and silently merging a two-branch alternation into one unmatchable branch — e.g. `"/x" ~~ / ^ [ '/' 'x' <?{ 1 <= 127 }> | <!> ] $ /` was `False` in mutsu, `True` in raku.
- `missing_optional_param_value` (the single shared helper every unpassed optional/named parameter binds through) always bound a typed optional to a type-object placeholder when absent — correct for object types, but wrong for native ints, which have no undefined state at all (`my int8 $x;` is already `0`, never a type object).

## Result

`t/http-router.rakutest` (`bash tmp/cro-suite-run.sh http`): all 171 subtests that run now pass. The suite still exits non-zero from one remaining, already-tracked, unrelated issue (`todo/tickets/parameter-type-not-nominalized-for-user-subsets.md`).

Full details in `news/2026-08/regex-alternation-angle-depth-and-native-int-defaults.md`.

## Test plan

- [x] `make test` (28368 tests / 3029 files) — all green
- [x] Full `S05-*` and `integration/*` whitelisted roast subsets — no regressions (two debug-build-only timeouts confirmed to pass on the release binary, per the repo's known-flaky triage protocol)
- [x] Three new local regression tests: `t/native-int-classhow-nativesize-unsigned.t`, `t/regex-alternation-code-assertion-relop.t`, `t/missing-optional-native-int-param-defaults-zero.t`
- [x] `cargo clippy -- -D warnings` / `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)