### PR TITLE
feat(parser): slang mode flags for spaced call / spaced methodop (ADR-0026 slice 1)

### DIFF
--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1028,6 +1028,7 @@ fn postfix_expr_loop_from(
                     (r, Symbol::intern(&method_name))
                 };
                 // Detect illegal space between method name and parens
+                let mut r = r;
                 if (r.starts_with(' ') || r.starts_with('\t')) && !r.starts_with('\\') {
                     let after_ws = r.trim_start_matches([' ', '\t']);
                     // A `(...)`-delimited set/baggy infix operator after a method
@@ -1040,10 +1041,17 @@ fn postfix_expr_loop_from(
                     ];
                     let is_set_infix_op = SET_INFIX_OPS.iter().any(|op| after_ws.starts_with(op));
                     if after_ws.starts_with('(') && !is_set_infix_op {
-                        return Err(PError::expected_at(
-                            "Confused. no space allowed between method name and the left parenthesis",
-                            r,
-                        ));
+                        // Slang spaced-methodop mode (ADR-0026 §2.3,
+                        // Slang::Tuxic's `methodop` override): `.method (args)`
+                        // is a method call with the parenthesized arguments.
+                        if crate::parser::stmt::simple::slang_spaced_methodop() {
+                            r = after_ws;
+                        } else {
+                            return Err(PError::expected_at(
+                                "Confused. no space allowed between method name and the left parenthesis",
+                                r,
+                            ));
+                        }
                     }
                 }
                 // Handle unspace between method name and parens: .method\ (args)

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1206,6 +1206,29 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
 
     // Check if followed by `(` for function call (including degenerate unspace: `foo\(42)`)
     let rest_unspaced = consume_unspace(rest);
+    // Slang spaced-call mode (ADR-0026 §2.3, Slang::Tuxic's
+    // `term:sym<identifier>` override): an identifier followed by whitespace
+    // and `(` parses as a call with the parenthesized arguments — except for
+    // control keywords and known type names (the token's own exclusion list).
+    let rest_unspaced = if !rest_unspaced.starts_with('(')
+        && rest_unspaced.starts_with(char::is_whitespace)
+        && crate::parser::stmt::simple::slang_spaced_call()
+        && !matches!(
+            name.as_str(),
+            "sub" | "if" | "elsif" | "while" | "until" | "for"
+        )
+        && !crate::runtime::utils::is_known_type_constraint(&name)
+        && !crate::parser::stmt::simple::is_user_declared_type(&name)
+    {
+        let trimmed = rest_unspaced.trim_start();
+        if trimmed.starts_with('(') {
+            trimmed
+        } else {
+            rest_unspaced
+        }
+    } else {
+        rest_unspaced
+    };
     if rest_unspaced.starts_with('(') {
         let (rest, _) = parse_char(rest_unspaced, '(')?;
         let (rest, _) = ws(rest)?;

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -1397,13 +1397,20 @@ pub(in crate::parser::primary) fn topic_method_call(input: &str) -> PResult<'_, 
     let name = Symbol::intern(name);
     // Detect illegal space between method name and parens: .method (args) is Confused
     // Raku requires no space between method name and opening paren.
+    let mut rest = rest;
     if (rest.starts_with(' ') || rest.starts_with('\t')) && !rest.starts_with('\\') {
         let after_ws = rest.trim_start_matches([' ', '\t']);
         if after_ws.starts_with('(') {
-            return Err(PError::expected_at(
-                "Confused. no space allowed between method name and the left parenthesis",
-                rest,
-            ));
+            // Slang spaced-methodop mode (ADR-0026 §2.3): `.method (args)`
+            // is a method call with the parenthesized arguments.
+            if crate::parser::stmt::simple::slang_spaced_methodop() {
+                rest = after_ws;
+            } else {
+                return Err(PError::expected_at(
+                    "Confused. no space allowed between method name and the left parenthesis",
+                    rest,
+                ));
+            }
         }
     }
     // Handle unspace between method name and parens: .method\ (args)

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -33,6 +33,7 @@ mod lib_paths;
 mod module_exports;
 mod pragma_preseed;
 mod registry;
+mod slang_modes;
 mod user_ops;
 
 // `pub` re-exports.
@@ -45,6 +46,7 @@ pub(crate) use lib_paths::{parser_program_path, parser_source_file};
 pub(crate) use compile_consts::is_imported_function;
 pub(crate) use registry::{current_language_version, set_current_language_version};
 pub(crate) use registry::{declare_keyword_names, register_declare_keyword};
+pub(crate) use slang_modes::{slang_spaced_call, slang_spaced_methodop};
 
 // `pub(super)` re-exports.
 pub(super) use control_stmts::{
@@ -80,6 +82,7 @@ pub(in crate::parser) use registry::{
     reset_user_subs, resolve_op_precedence, restore_declare_keywords,
     set_eval_language_version_preseed,
 };
+pub(in crate::parser) use slang_modes::{restore_slang_modes, slang_modes_snapshot};
 pub(in crate::parser) use user_ops::{
     is_circumfix_close_delimiter, is_user_declared_prefix_sub, is_user_declared_value_term,
     is_user_defined_infix, match_user_declared_circumfix_op, match_user_declared_infix_symbol_op,

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -365,6 +365,10 @@ fn scan_module_source(source: &str) -> ModuleScanResult {
     // wholesale, so keywords the scanned module itself imports stay lexical
     // to that module.
     let saved_declare_keywords = declare_keywords_snapshot();
+    // Slang modes are unit-scoped the same way: the scanned module's slang
+    // activation is lexical to that module, and the importer's modes must
+    // survive the nested parse's reset (ADR-0026 §2.1 scoping).
+    let saved_slang_modes = super::slang_modes_snapshot();
     let (stmts, _) = crate::parser::parse_program_partial(source);
     // A `package X::Foo { }` block installs its contents into GLOBAL, so the
     // types it declares are visible to whoever loads the module — including
@@ -397,6 +401,7 @@ fn scan_module_source(source: &str) -> ModuleScanResult {
     });
     set_current_language_version(&saved_language_version);
     restore_declare_keywords(saved_declare_keywords);
+    super::restore_slang_modes(saved_slang_modes);
     // Collect the module's declared type names (classes/roles/enums/grammars)
     // for the importer's scope. A `use`d module makes its `our`-scoped and
     // exported types visible to the importer, but mutsu loads modules at run

--- a/src/parser/stmt/simple/registry.rs
+++ b/src/parser/stmt/simple/registry.rs
@@ -185,6 +185,7 @@ pub(crate) fn reset_user_subs() {
         }
     });
     DECLARE_KEYWORDS.with(|m| m.borrow_mut().clear());
+    super::slang_modes::reset_slang_modes();
 }
 
 /// Seed the language version an EVAL's nested parse starts at. `None` restores

--- a/src/parser/stmt/simple/slang_modes.rs
+++ b/src/parser/stmt/simple/slang_modes.rs
@@ -1,0 +1,204 @@
+//! Slang activation parser modes (ADR-0026 §2.3).
+//!
+//! A slang-activating `use` (e.g. `use Slang::Tuxic;`) maps the grammar
+//! rules its roles override onto these mode flags for the remainder of the
+//! current compilation unit. The flags are unit-scoped parser state modeled
+//! on `CURRENT_LANGUAGE_VERSION` / `DECLARE_KEYWORDS`: cleared at parse
+//! start (`reset_user_subs`) and snapshot/restored around nested module
+//! scans. Slang state does not leak into EVAL strings or importing units.
+
+use std::cell::Cell;
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+pub(crate) struct SlangModes {
+    /// `term:sym<identifier>` override: an identifier followed by
+    /// whitespace and `(` parses as a call with the parenthesized
+    /// arguments (Tuxic's `foo (42)`), except for control keywords and
+    /// known type names.
+    pub spaced_call: bool,
+    /// `methodop` override: `.method (args)` parses as a method call with
+    /// the parenthesized arguments instead of the "no space allowed
+    /// between method name and the left parenthesis" error.
+    pub spaced_methodop: bool,
+}
+
+thread_local! {
+    static SLANG_MODES: Cell<SlangModes> = const { Cell::new(SlangModes {
+        spaced_call: false,
+        spaced_methodop: false,
+    }) };
+}
+
+pub(crate) fn slang_modes() -> SlangModes {
+    SLANG_MODES.with(|m| m.get())
+}
+
+/// Enable/replace the slang mode set for the remainder of the current
+/// compilation unit. Callers that flip modes mid-parse must also reset the
+/// statement/term memo tables (a memoized parse from before the flip would
+/// otherwise be replayed under the wrong grammar).
+pub(crate) fn set_slang_modes(modes: SlangModes) {
+    SLANG_MODES.with(|m| m.set(modes));
+}
+
+pub(in crate::parser) fn reset_slang_modes() {
+    set_slang_modes(SlangModes::default());
+}
+
+/// Snapshot / restore around a nested module scan: the scanned module's
+/// slang state is lexical to that module, not to the importer (and vice
+/// versa).
+pub(in crate::parser) fn slang_modes_snapshot() -> SlangModes {
+    slang_modes()
+}
+
+pub(in crate::parser) fn restore_slang_modes(saved: SlangModes) {
+    set_slang_modes(saved);
+}
+
+pub(crate) fn slang_spaced_call() -> bool {
+    slang_modes().spaced_call
+}
+
+pub(crate) fn slang_spaced_methodop() -> bool {
+    slang_modes().spaced_methodop
+}
+
+/// The recognized-override map (ADR-0026 §2.3): apply one overridden
+/// grammar-rule name from a slang role to the mode set. Returns `None` when
+/// the rule is not supported — the caller must raise a hard compile-time
+/// error naming the rule (an unknown override means the slang's semantics
+/// would be silently wrong), never ignore it.
+// Consumed by the `$*LANG.define_slang` plumbing (ADR-0026 §2.2) in the next
+// campaign slice; until then only tests exercise it.
+#[allow(dead_code)]
+pub(crate) fn apply_slang_rule_override(modes: &mut SlangModes, rule: &str) -> Option<()> {
+    match rule {
+        "term:sym<identifier>" => modes.spaced_call = true,
+        "methodop" => modes.spaced_methodop = true,
+        // Tuxic's override re-states the stock sub-declarator rule so the
+        // spaced form composes with sub declarations; stock mutsu already
+        // accepts `sub foo ($x) { }`, so this maps to a no-op.
+        "routine-declarator:sym<sub>" | "routine_declarator:sym<sub>" => {}
+        _ => return None,
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{Expr, Stmt};
+
+    const TUXIC: SlangModes = SlangModes {
+        spaced_call: true,
+        spaced_methodop: true,
+    };
+
+    fn parse_with_modes(modes: SlangModes, input: &str) -> Result<Vec<Stmt>, String> {
+        crate::parser::stmt::simple::reset_user_subs();
+        crate::parser::stmt::reset_statement_memo();
+        set_slang_modes(modes);
+        let result = crate::parser::stmt::program(input);
+        reset_slang_modes();
+        match result {
+            Ok((rest, stmts)) if rest.trim().is_empty() => Ok(stmts),
+            Ok((rest, _)) => Err(format!("unparsed trailing input: {rest:?}")),
+            Err(e) => Err(format!("{e:?}")),
+        }
+    }
+
+    fn first_expr(stmts: &[Stmt]) -> &Expr {
+        stmts
+            .iter()
+            .find_map(|s| match s {
+                Stmt::Expr(e) => Some(e),
+                _ => None,
+            })
+            .expect("expected an expression statement")
+    }
+
+    #[test]
+    fn spaced_call_mode_parses_identifier_ws_paren_as_call() {
+        let stmts = parse_with_modes(TUXIC, "foo (1, 2);").unwrap();
+        match first_expr(&stmts) {
+            Expr::Call { name, args } => {
+                assert_eq!(name.as_str(), "foo");
+                assert_eq!(
+                    args.len(),
+                    2,
+                    "spaced call must take the paren contents as an arg list, got {args:?}"
+                );
+            }
+            other => panic!("expected Call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spaced_call_off_keeps_listop_semantics() {
+        let stmts = parse_with_modes(SlangModes::default(), "foo (1, 2);").unwrap();
+        match first_expr(&stmts) {
+            Expr::Call { name, args } => {
+                assert_eq!(name.as_str(), "foo");
+                assert_eq!(
+                    args.len(),
+                    1,
+                    "stock grammar: one parenthesized List argument"
+                );
+            }
+            other => panic!("expected Call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spaced_methodop_mode_parses_method_ws_paren_as_call() {
+        let stmts = parse_with_modes(TUXIC, "$x.blah (1, 2);").unwrap();
+        match first_expr(&stmts) {
+            Expr::MethodCall { name, args, .. } => {
+                assert_eq!(name.as_str(), "blah");
+                assert_eq!(args.len(), 2);
+            }
+            other => panic!("expected MethodCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spaced_methodop_off_stays_an_error() {
+        assert!(parse_with_modes(SlangModes::default(), "$x.blah (1, 2);").is_err());
+    }
+
+    #[test]
+    fn spaced_call_mode_excludes_control_keywords() {
+        let stmts = parse_with_modes(TUXIC, "if (1) { 2 }").unwrap();
+        assert!(
+            stmts.iter().any(|s| matches!(s, Stmt::If { .. })),
+            "`if (1) {{ }}` must stay an if statement under Tuxic mode, got {stmts:?}"
+        );
+    }
+
+    #[test]
+    fn reset_user_subs_clears_slang_modes() {
+        set_slang_modes(TUXIC);
+        crate::parser::stmt::simple::reset_user_subs();
+        assert_eq!(slang_modes(), SlangModes::default());
+    }
+
+    #[test]
+    fn rule_override_map_matches_adr_0026() {
+        let mut modes = SlangModes::default();
+        assert!(apply_slang_rule_override(&mut modes, "term:sym<identifier>").is_some());
+        assert!(apply_slang_rule_override(&mut modes, "methodop").is_some());
+        assert!(apply_slang_rule_override(&mut modes, "routine-declarator:sym<sub>").is_some());
+        assert!(apply_slang_rule_override(&mut modes, "routine_declarator:sym<sub>").is_some());
+        assert_eq!(
+            modes,
+            SlangModes {
+                spaced_call: true,
+                spaced_methodop: true,
+            }
+        );
+        let mut fresh = SlangModes::default();
+        assert!(apply_slang_rule_override(&mut fresh, "term:sym<colonpair>").is_none());
+        assert_eq!(fresh, SlangModes::default());
+    }
+}


### PR DESCRIPTION
First slice of the slang activation campaign ([ADR-0026](docs/adr/0026-slang-activation-architecture.md), Accepted 2026-08-11).

## What

- New `SlangModes` parser state (`src/parser/stmt/simple/slang_modes.rs`): unit-scoped thread-local flags modeled on `CURRENT_LANGUAGE_VERSION` / `DECLARE_KEYWORDS` — cleared at parse start (`reset_user_subs`), snapshot/restored around nested module scans (`scan_module_source`), so slang state stays lexical to the compilation unit that activates it (ADR §2.1 scoping).
- The two ADR §2.3 grammar behaviors, gated on the flags:
  - **`term:sym<identifier>` override** (`spaced_call`): `foo (1, 2)` parses as a call with the parenthesized arg list (two args, named args bind as named), instead of the stock listop form (one parenthesized `List` argument). Control keywords (`sub if elsif while until for`) and known type names are excluded, matching the Tuxic token's own exclusion list.
  - **`methodop` override** (`spaced_methodop`): `.method (args)` parses as a method call with the args instead of the `Confused. no space allowed between method name and the left parenthesis` error — both in the postfix chain (`expr/postfix/loop_.rs`) and in regex-embedded method calls (`primary/regex/lit.rs`). The set/baggy-infix exclusion (`@a.Set (|) @b.Set`) is preserved in both modes.
- The ADR §2.3 recognized-override map (`apply_slang_rule_override`): the three Tuxic rule names map to modes (`routine-declarator:sym<sub>` is a recognized no-op — stock mutsu already accepts `sub foo ($x) { }`); an unknown rule returns `None` so the §2.2 caller can raise the hard compile-time error the ADR requires instead of silently ignoring it.

## What this does NOT do yet

Nothing can enable the modes outside tests: the parse-time `use` execution path (§2.1), the `$*LANG` object (§2.2), and vendoring Slangify + Slang::Tuxic (§2.4) land in the next slices. With the modes off every touched code path is behaviorally identical to before.

## Tests

7 Rust unit tests in `slang_modes.rs`: both behaviors on/off, keyword exclusion under Tuxic mode, reset-at-parse-start scoping, and the override map incl. the unknown-rule case. `make test` PASS locally; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)