### PR TITLE
fix(regex): character class inside a lookaround must not desync quote/angle scanning

### DIFF
--- a/src/parser/primary/regex/scan.rs
+++ b/src/parser/primary/regex/scan.rs
@@ -184,6 +184,75 @@ pub(in crate::parser) fn scan_to_delim_p5(
     scan_to_delim_inner(input, open_ch, close_ch, is_paired, true, false)
 }
 
+/// Skip a character-class body (`<[...]>`, `<-[...]>`, `<+[...]>`, `<![...]>`,
+/// including compound classes like `<-[...]+[...]>`). The iterator must be
+/// positioned just after the leading `<`. Consumes through the class's closing
+/// `>`. Class content is literal — quote characters and brackets inside it
+/// must not affect any outer quote/bracket state. Inside each `[...]`, an
+/// unescaped `[` is a literal character (only `\]` escapes `]`).
+fn skip_char_class(chars: &mut std::str::CharIndices<'_>) -> Option<()> {
+    // Advance past any prefix chars before '['
+    loop {
+        if let Some((_, ch)) = chars.next() {
+            if ch == '[' {
+                break;
+            }
+        } else {
+            return None;
+        }
+    }
+    // Scan bracket groups sequentially. After ']', check for compound class
+    // operators (+[, -[) or the closing '>'.
+    'char_class: loop {
+        // Scan inside a [...] group until unescaped ']'
+        loop {
+            match chars.next() {
+                Some((_, '\\')) => {
+                    chars.next(); // skip escaped char
+                }
+                Some((_, ']')) => {
+                    break; // end of this bracket group
+                }
+                Some(_) => {}
+                None => return None,
+            }
+        }
+        // After ']', check for compound class or closing '>'
+        let saved = chars.clone();
+        match chars.next() {
+            Some((_, '>')) => break, // done
+            Some((_, '+' | '-')) => {
+                if let Some((_, '[')) = chars.next() {
+                    continue 'char_class;
+                }
+                // Not a compound group; try consuming '>'
+                *chars = saved;
+                if let Some((_, '>')) = chars.next() {
+                    break;
+                }
+                break;
+            }
+            Some((_, '[')) => continue 'char_class,
+            _ => {
+                *chars = saved;
+                if let Some((_, '>')) = chars.next() {
+                    break;
+                }
+                break;
+            }
+        }
+    }
+    Some(())
+}
+
+/// Does `rest` (the text just after a `<`) open a character class?
+fn starts_char_class(rest: &str) -> bool {
+    rest.starts_with('[')
+        || rest.starts_with("-[")
+        || rest.starts_with("+[")
+        || rest.starts_with("![")
+}
+
 fn scan_to_delim_inner(
     input: &str,
     open_ch: char,
@@ -250,69 +319,10 @@ fn scan_to_delim_inner(
             // (`/ (\d) { say $/ } \d+ /`) — does not end the regex early. In P5
             // mode `{n,m}` is a quantifier, not code, so this is Raku-only.
             skip_interp_block(&mut chars)?;
-        } else if !p5_mode
-            && c == '<'
-            && (input[i + 1..].starts_with('[')
-                || input[i + 1..].starts_with("-[")
-                || input[i + 1..].starts_with("+[")
-                || input[i + 1..].starts_with("!["))
-        {
+        } else if !p5_mode && c == '<' && starts_char_class(&input[i + 1..]) {
             // Skip character class <[...]>, <-[...]>, <+[...]>, <![...]> content
             // without interpreting quotes. Handles <['"]>, <-["\\\t]>, etc.
-            // Advance past any prefix chars before '['
-            loop {
-                if let Some((_, ch)) = chars.next() {
-                    if ch == '[' {
-                        break;
-                    }
-                } else {
-                    return None;
-                }
-            }
-            // Inside a Raku character class like <[...]>, <-[...]+[...]>, etc.
-            // We scan bracket groups sequentially. Inside each [...], an
-            // unescaped '[' is a literal character (only '\]' escapes ']').
-            // After ']', we check for compound class operators (+[, -[) or
-            // the closing '>'.
-            'char_class: loop {
-                // Scan inside a [...] group until unescaped ']'
-                loop {
-                    match chars.next() {
-                        Some((_, '\\')) => {
-                            chars.next(); // skip escaped char
-                        }
-                        Some((_, ']')) => {
-                            break; // end of this bracket group
-                        }
-                        Some(_) => {}
-                        None => return None,
-                    }
-                }
-                // After ']', check for compound class or closing '>'
-                let saved = chars.clone();
-                match chars.next() {
-                    Some((_, '>')) => break, // done
-                    Some((_, '+' | '-')) => {
-                        if let Some((_, '[')) = chars.next() {
-                            continue 'char_class;
-                        }
-                        // Not a compound group; try consuming '>'
-                        chars = saved;
-                        if let Some((_, '>')) = chars.next() {
-                            break;
-                        }
-                        break;
-                    }
-                    Some((_, '[')) => continue 'char_class,
-                    _ => {
-                        chars = saved;
-                        if let Some((_, '>')) = chars.next() {
-                            break;
-                        }
-                        break;
-                    }
-                }
-            }
+            skip_char_class(&mut chars)?;
         } else if !p5_mode
             && c == '<'
             && !input[i + 1..].starts_with('[')
@@ -386,6 +396,17 @@ fn scan_to_delim_inner(
                                 None => return None,
                             }
                         },
+                        // A nested character class inside the assertion
+                        // (`<!before '"' <-["]>*? >`): its content is literal,
+                        // so a quote or bracket char in it must not move the
+                        // quote/angle state. Without this, the class's `"`
+                        // opens a bogus quote (when honor_quotes) that
+                        // swallows the rest of the regex.
+                        Some((i2, '<'))
+                            if paren_depth == 0 && starts_char_class(&input[i2 + 1..]) =>
+                        {
+                            skip_char_class(&mut chars)?;
+                        }
                         Some((_, '(')) => paren_depth += 1,
                         Some((_, ')')) => paren_depth = paren_depth.saturating_sub(1),
                         Some((_, '<')) if paren_depth == 0 => angle_depth += 1,

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -2000,6 +2000,69 @@ impl Interpreter {
                                 if ch == '\'' || ch == '"' {
                                     quote = Some(ch);
                                     inner.push(ch);
+                                } else if ch == '<' && {
+                                    let mut la = chars.clone();
+                                    match la.next() {
+                                        Some('[') => true,
+                                        Some('-' | '+' | '!') => la.next() == Some('['),
+                                        _ => false,
+                                    }
+                                } {
+                                    // A character class inside the assertion
+                                    // (`<!before '"' <-["]>*? >`): copy its
+                                    // content verbatim — a quote or bracket char
+                                    // in it must not move the quote/angle state.
+                                    // Only `\]` escapes `]` inside `[...]`.
+                                    inner.push(ch);
+                                    for c2 in chars.by_ref() {
+                                        inner.push(c2);
+                                        if c2 == '[' {
+                                            break;
+                                        }
+                                    }
+                                    'char_class: loop {
+                                        loop {
+                                            match chars.next() {
+                                                Some('\\') => {
+                                                    inner.push('\\');
+                                                    if let Some(n) = chars.next() {
+                                                        inner.push(n);
+                                                    }
+                                                }
+                                                Some(']') => {
+                                                    inner.push(']');
+                                                    break;
+                                                }
+                                                Some(c2) => inner.push(c2),
+                                                None => break 'char_class,
+                                            }
+                                        }
+                                        // After ']': '>' closes the class;
+                                        // `+[` / `-[` / `[` continue a compound
+                                        // class. Anything else falls back to the
+                                        // outer loop.
+                                        let mut la = chars.clone();
+                                        match la.next() {
+                                            Some('>') => {
+                                                chars.next();
+                                                inner.push('>');
+                                                break 'char_class;
+                                            }
+                                            Some(p @ ('+' | '-')) if la.next() == Some('[') => {
+                                                chars.next();
+                                                chars.next();
+                                                inner.push(p);
+                                                inner.push('[');
+                                                continue 'char_class;
+                                            }
+                                            Some('[') => {
+                                                chars.next();
+                                                inner.push('[');
+                                                continue 'char_class;
+                                            }
+                                            _ => break 'char_class,
+                                        }
+                                    }
                                 } else if ch == '<' {
                                     angle_depth += 1;
                                     inner.push(ch);

--- a/t/regex-charclass-in-lookaround.t
+++ b/t/regex-charclass-in-lookaround.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+# A character class nested inside a lookaround assertion must not desync the
+# regex scanner or the lookaround-body parser: its content is literal, so a
+# quote character in it (`<-["]>`) must not open a bogus string that swallows
+# the rest of the regex. Discovered vendoring Slang::Tuxic (ADR-0026), whose
+# methodop token contains `<!before '"' <-["]>*? [\s|$] >`.
+
+plan 10;
+
+ok "ab" ~~ / a <?before <-["]> > b /, 'char class in lookahead matches';
+nok 'a"' ~~ / a <?before <-["]> > /, 'char class in lookahead rejects quote char';
+ok 'a"b' ~~ / a <!before '"' <-["]>*? '"' > /,
+    'quoted literal + char class + quoted literal in negative lookahead';
+ok "axxb" ~~ / a <?before <-["]>*? b > /, 'lazy-quantified char class in lookahead';
+
+# The Slang::Tuxic methodop shape: alternation, code assertions, and a
+# char class with a quote — all inside one group.
+my $r = rx/ [ | <?['"]> [ <!{$*QSIGIL}> || <!before '"' <-["]>*? [\s|$] > ] ] /;
+ok '"x' ~~ $r, 'Tuxic-shaped regex matches a double quote';
+ok "'x" ~~ $r, 'Tuxic-shaped regex matches a single quote';
+nok "x" ~~ $r, 'Tuxic-shaped regex rejects a non-quote';
+
+# The same shape inside a token body of a role must parse (the role is data
+# until composed; parsing the file must not blow up on the token body).
+my role TuxicShape {
+    token m {
+        [
+          | <?['"]>
+            [ <!{$*QSIGIL}> || <!before '"' <-["]>*? [\s|$] > ]
+            <quote>
+        ] \s* <.unspace>?
+    }
+}
+ok TuxicShape.^name eq 'TuxicShape', 'role with Tuxic-shaped token body parses';
+
+# Compound char class inside a lookaround.
+ok "a5" ~~ / a <?before <[0..9]+[x]> > /, 'compound char class in lookahead';
+nok "ay" ~~ / a <?before <[0..9]+[x]> > /, 'compound char class in lookahead rejects';


### PR DESCRIPTION
Two layers had the same blind spot: a character class nested inside a lookaround assertion (`<!before '"' <-["]>*? [\s|$] >`) contains literal quote/bracket characters, but both the regex-literal scanner and the lookaround-body parser interpreted them as string quotes — the class's `"` opened a bogus quote that swallowed the rest of the regex, surfacing as `Regex not terminated`, `Two terms in a row`, or the array-composer "couldn't find final ']'" error depending on context.

## Fixes

- **`scan_to_delim_inner`** (`src/parser/primary/regex/scan.rs`): the named-assertion scanning loop now skips `<[...]>` / `<-[...]>` / `<+[...]>` / `<![...]>` content without interpreting it. The skip logic is a `skip_char_class` helper factored out of the existing top-level char-class arm (identical semantics, including compound classes like `<[..]+[..]>`), now used by both.
- **Lookaround-body extraction** (`src/runtime/regex_parse_core.rs`): copies a nested character class verbatim into the inner pattern instead of letting its quote chars open a string or its brackets move the angle depth.

## Context

Found while vendoring `Slang::Tuxic` for the ADR-0026 slang activation campaign — its `methodop` token carries exactly this shape, so the whole module failed to parse. After this fix the full `Slang/Tuxic.rakumod` parses, and the Tuxic-shaped regex matches identically under raku and mutsu (7-case oracle). The fix is a general scanner/parser correctness fix, independent of slangs.

## Tests

`t/regex-charclass-in-lookaround.t` — 10 assertions, all raku-verified: char classes in lookaheads (positive/negative, lazy-quantified, compound), the full Tuxic-shaped regex as an `rx//` literal (match + reject), and the same shape inside a role's token body. Local `make test` PASS; S05 spot checks (`charset.t`, `lookaround.t`, `assertions.t`, `regex.t`, `charsets.t`, `delimiters.t`) all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)