### PR TITLE
docs+instrumentation(adr): ADR-0019 E6b step 1, shadow-verify Native at CallMethodMut

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3159,6 +3159,31 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   dispatch today, and E5b's "Native candidate is hint-only, never routing" conclusion already
   generalizes here. Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"Tier-A helper
   survey (E6a, final sub-slice)". **All of E6a is now closed.** Next: E6b.
+  **Progress 2026-08-11** (E6b step 1, shadow-verify the `Native` candidate at `CallMethodMut`
+  itself — mirrors E5b step 1): instrumented all ~10 `record_dispatch_entry_outcome("callmethodmut",
+  "native"/"user")` sites inside `exec_call_method_mut_op_impl`
+  (`src/vm/vm_call_method_mut_ops.rs`) — the five Tier-A helper completions, the
+  `__mutsu_array_storage` delegation pair, and the generic-fork pair — with the same
+  `shadow_check_native_row_candidate` call E5b step 1 used, skipping only the `skip_native` branch
+  (no cascade-outcome to compare there). Pure insertion, 106 lines, 0 deletions, zero behavior
+  change. Full `t/` sweep (3026 files, `-j8`, `MUTSU_VM_STATS=1`): 118117 checks, 5756 mismatches
+  (4.88%, roughly double `CallMethod`'s 2.4%); the 20 stderr-assertion failures exactly match E6a
+  third slice's pre-existing list, confirming no regression. Mismatch breakdown, three classes: (1)
+  **2074 (36%), new to E6b** — Tier-A-served `push`/`shift`/`splice`/`append`/`unshift`/`pop`/
+  `prepend` calls are *structurally* invisible to the `Native` candidate (`native_row_servable`
+  excludes `MUTATES_RECEIVER` rows by construction, per the Tier-A helper survey's finding 4), not
+  a predicate bug; (2) 2934 (51%) reproduces `CallMethod`'s own two root causes — missing rows
+  (`DEFINITE`, 2066 alone, 36% of all mismatches) and shape-blind predicate exceptions
+  (`gist`/`raku`/`FatRat`/`pull-one`); (3) 748 (13%) reproduces the reverse class (predicate
+  over-claims by owner name, concrete shape declines — `raku`/`join`/`Int`/`sprintf`/`gist`/
+  `comb`). **Confirms and sharpens E5b step 2's generalization**: the `Native` candidate stays
+  hint-only at `CallMethodMut` too, and Tier-A traffic specifically could never route through it
+  even with a shape-complete predicate, since `MUTATES_RECEIVER` rows are excluded by design — a
+  future Tier-A-aware routing candidate would need to be a distinct kind, not attempted here.
+  `cargo build`/`clippy -- -D warnings`/`fmt --check` clean. Full detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"E6b step 1: shadow-verifying the Native candidate at
+  CallMethodMut itself". Next: E6b step 2 (does `try_compiled_method_mut_or_interpret_sym`'s
+  `User`-candidate resolution duplicate `resolve_method_cached`, mirroring E5b step 3/4's dedup?).
 - [ ] **E7 — Route metaobject, qualified, and re-entrant calls through the resolver.** Cover HOW,
   `.^lookup`/`.^can`, qualified/private dispatch, EVAL carriers, and method objects.
   **Design 2026-08-10** (same doc): one consumer family per sub-PR (`run_instance_method`

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2164,6 +2164,16 @@ impl Interpreter {
                         self.try_native_array_mut(&target_name, &target, &method, &args)
                 {
                     crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "native");
+                    // ADR-0019 E6b step 1: shadow-verify the `Native` candidate
+                    // (E5b step 1's template) at each of CallMethodMut's own
+                    // native-probe completion shapes, observational only.
+                    self.shadow_check_native_row_candidate(
+                        &target,
+                        &method,
+                        method_sym,
+                        args.len(),
+                        true,
+                    );
                     self.stack.push(result?);
                     return Ok(());
                 }
@@ -2178,6 +2188,13 @@ impl Interpreter {
                         self.try_native_hash_mut_bound(&target_name, &method, &args)
                 {
                     crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "native");
+                    self.shadow_check_native_row_candidate(
+                        &target,
+                        &method,
+                        method_sym,
+                        args.len(),
+                        true,
+                    );
                     self.stack.push(result?);
                     return Ok(());
                 }
@@ -2189,6 +2206,13 @@ impl Interpreter {
                         self.try_native_array_splice(&target_name, &target, &method, &args)
                 {
                     crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "native");
+                    self.shadow_check_native_row_candidate(
+                        &target,
+                        &method,
+                        method_sym,
+                        args.len(),
+                        true,
+                    );
                     self.stack.push(result?);
                     return Ok(());
                 }
@@ -2199,6 +2223,13 @@ impl Interpreter {
                         self.try_native_buf_mut(&target_name, &target, &method, &args)
                 {
                     crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "native");
+                    self.shadow_check_native_row_candidate(
+                        &target,
+                        &method,
+                        method_sym,
+                        args.len(),
+                        true,
+                    );
                     self.stack.push(result?);
                     return Ok(());
                 }
@@ -2210,6 +2241,13 @@ impl Interpreter {
                     && let Some(result) = self.try_native_iterator(&target, &method, &args)
                 {
                     crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "native");
+                    self.shadow_check_native_row_candidate(
+                        &target,
+                        &method,
+                        method_sym,
+                        args.len(),
+                        true,
+                    );
                     self.stack.push(result?);
                     return Ok(());
                 }
@@ -2316,6 +2354,18 @@ impl Interpreter {
                                 "callmethodmut",
                                 "native",
                             );
+                            // ADR-0019 E6b step 1: shadow-check against the actual
+                            // opcode receiver `target` (the Instance), not the
+                            // backing `storage` value the Tier-A helper above was
+                            // fed — `target` is what a real E6b cutover would
+                            // query resolve_sequence with.
+                            self.shadow_check_native_row_candidate(
+                                &target,
+                                &method,
+                                method_sym,
+                                args.len(),
+                                true,
+                            );
                             self.stack.push(result);
                             return Ok(());
                         }
@@ -2335,6 +2385,13 @@ impl Interpreter {
                                 "callmethodmut",
                                 "native",
                             );
+                            self.shadow_check_native_row_candidate(
+                                &target,
+                                &method,
+                                method_sym,
+                                args.len(),
+                                true,
+                            );
                             self.stack.push(r?);
                             return Ok(());
                         }
@@ -2343,6 +2400,13 @@ impl Interpreter {
                                 "callmethodmut",
                                 "native",
                             );
+                            self.shadow_check_native_row_candidate(
+                                &target,
+                                &method,
+                                method_sym,
+                                args.len(),
+                                true,
+                            );
                             self.stack.push(r?);
                             return Ok(());
                         }
@@ -2350,6 +2414,13 @@ impl Interpreter {
                             crate::vm::vm_stats::record_dispatch_entry_outcome(
                                 "callmethodmut",
                                 "native",
+                            );
+                            self.shadow_check_native_row_candidate(
+                                &target,
+                                &method,
+                                method_sym,
+                                args.len(),
+                                true,
                             );
                             self.stack.push(r?);
                             return Ok(());
@@ -2367,6 +2438,13 @@ impl Interpreter {
                                 "callmethodmut",
                                 "native",
                             );
+                            self.shadow_check_native_row_candidate(
+                                &target,
+                                &method,
+                                method_sym,
+                                args.len(),
+                                true,
+                            );
                             self.stack.push(r?);
                             return Ok(());
                         }
@@ -2375,6 +2453,13 @@ impl Interpreter {
                         // (non-simple methods on `is Array` storage). See ledger §1.
                         crate::vm::vm_stats::record_method_fallback(&method);
                         crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "user");
+                        self.shadow_check_native_row_candidate(
+                            &target,
+                            &method,
+                            method_sym,
+                            args.len(),
+                            false,
+                        );
                         let result = loan_env!(
                             self,
                             call_method_mut_with_values(
@@ -2441,9 +2526,23 @@ impl Interpreter {
                             "callmethodmut",
                             "native",
                         );
+                        self.shadow_check_native_row_candidate(
+                            dispatch_target,
+                            &method,
+                            method_sym,
+                            args.len(),
+                            true,
+                        );
                         native_result
                     } else {
                         crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "user");
+                        self.shadow_check_native_row_candidate(
+                            dispatch_target,
+                            &method,
+                            method_sym,
+                            args.len(),
+                            false,
+                        );
                         self.try_compiled_method_mut_or_interpret_sym(
                             &target_name,
                             target,
@@ -2452,6 +2551,13 @@ impl Interpreter {
                         )
                     }
                 } else {
+                    // ADR-0019 E6b step 1: NOT shadow-checked here. `skip_native`
+                    // means the arity cascade was deliberately never consulted for
+                    // this call (a user-defined method override, a pseudo-method
+                    // like WHAT/HOW, junction .gist, Stash AT-KEY, ...) -- there is
+                    // no "did the cascade serve this call" outcome to compare the
+                    // resolver's Native candidate against, unlike the genuine
+                    // native/user completions above.
                     crate::vm::vm_stats::record_dispatch_entry_outcome("callmethodmut", "user");
                     self.try_compiled_method_mut_or_interpret_sym(
                         &target_name,

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -1561,3 +1561,68 @@ a data-quality backlog for whoever eventually wants `native_row_servable` to bec
 for mutation-adjacent methods (relevant to a later Phase F cleanup, not to E6b's cutover shape).
 
 **All of E6a is now closed.** Next: E6b.
+
+## E6b step 1: shadow-verifying the Native candidate at CallMethodMut itself
+
+Mirrors E5b step 1's protocol exactly, applied to `CallMethodMut`'s own native-probe completion
+shapes instead of `CallMethod`'s. Reused `shadow_check_native_row_candidate`
+(`src/runtime/resolution_sequence.rs:281`, unmodified, no new counter) at every
+`record_dispatch_entry_outcome("callmethodmut", "native"/"user")` call site inside
+`exec_call_method_mut_op_impl` (`src/vm/vm_call_method_mut_ops.rs`, ~10 sites: the five Tier-A
+helper completions — `try_native_array_mut`, `try_native_hash_mut_bound`,
+`try_native_array_splice`, `try_native_buf_mut`, `try_native_iterator` — the `__mutsu_array_storage`
+delegation block's native/user pair, and the generic-fork native/user pair) — pure insertion, 106
+lines, 0 deletions, zero behavior change. One site was deliberately **not** instrumented: the
+`skip_native` branch (user-defined override / pseudo-method / Stash `AT-KEY` / junction `.gist`),
+because that path never consults the arity cascade at all — there is no "did the cascade serve
+this call" outcome to compare the `Native` candidate against there, unlike the genuine
+native/user completions.
+
+Full `t/` sweep (3026 files, `prove -j8`, `MUTSU_VM_STATS=1`): 118117 shadow checks, 5756
+mismatches (4.88% — about double `CallMethod`'s E5b step 1 rate of ~2.4%). The 20 files that fail
+under `MUTSU_VM_STATS=1` are exactly the pre-existing exact-stderr-assertion list E6a's third slice
+already catalogued (`cli-lines-regressions.t`, `command-line-negation.t`,
+`constant-hash-coerce-once.t`, `dd-instance.t`, `exit-skips-main-dispatch.t`, `get-out.t`,
+`io-handle-lock.t`, `io-handle-stdout-stderr-native.t`, `io-pipe-slurp-rest.t`, `is-run.t`,
+`note-with-parens.t`, `precomp-warm-cache-parity.t`, `proc-async.t`, `quietly.t`,
+`say-env-roundtrip.t`, `sink-warning.t`, `slip-listop-args.t`, `undeclared-routine-compile-time.t`,
+`vendored-real-test-module.t`, `weird-errors-parse-forms.t`) — no new failures, confirming zero
+behavior change. `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` clean.
+
+The mismatch breakdown splits into three classes, one of them new to E6b and not present in E5b's
+`CallMethod` data at all:
+
+1. **Tier-A structural exclusion (2074, 36% of mismatches) — real=true/shadow=false, all
+   `native_row_owner=None`, method in `push`(1459)/`shift`(422)/`splice`(65)/`append`(53)/
+   `unshift`(36)/`pop`(30)/`prepend`(7)/`classify`(1)/`categorize`(1).** This is **by design, not
+   a bug**: `native_row_servable` (`src/builtins/native_method_row.rs:110-128`) explicitly excludes
+   any row flagged `MUTATES_RECEIVER` (line 120), and the Tier-A helper survey above already found
+   every current `MUTATES_RECEIVER` row is arity-`N` — so `resolve_sequence`'s `Native` candidate
+   can *never* represent a call a Tier-A helper actually serves, by construction. `CallMethod` has
+   no Tier-A completions at all, so this class has no analog in E5b step 1's data; it alone
+   explains why `CallMethodMut`'s overall mismatch rate is roughly double `CallMethod`'s.
+2. **Missing rows / shape-blind predicate (2934, 51%) — real=true/shadow=false, other methods.**
+   The same two root causes E5b step 1 already identified for `CallMethod`, reproducing here:
+   0-arity `DEFINITE`/`defined` calls the cascade genuinely serves but that have no row in the
+   table at all (`DEFINITE` alone is 2066, 36% of all mismatches — the single largest arm by far,
+   same gap E5b step 1 flagged); and concrete-value-shape exceptions the generic owner-name lookup
+   is blind to (`gist`=144, `raku`=102, `FatRat`=88, `pull-one`=50, `^name`=28, `hash`=17,
+   `elems`=15 — bespoke rendering/coercion paths that decline the generic `Any`/`Cool` row).
+3. **Predicate over-claims (748, 13%) — real=false/shadow=true.** The mirror-image class E5b step
+   1 also found: the row claims servability by `(owner, name, arity)` alone, but the concrete
+   receiver's shape declines it in favor of a user override or bespoke path — `raku`(70, owner
+   `Any`)/`join`(46, `Array`)/`Int`(44)/`sprintf`(40, `Str`)/`gist`(38+32+20, `Any`/`Array`/`List`)/
+   `comb`(34, `Str`) dominate, all pre-existing `try_native_method_raw` shape-specific `return
+   None` guards the predicate cannot see.
+
+**Consequence for E6b step 2+**: classes 2 and 3 confirm E5b step 2's generalization holds at
+`CallMethodMut` too — the `Native` candidate stays measurement/hint-only, `try_native_method`
+(and the five Tier-A helper calls) remain direct, self-guarding pre-checks, never replaced by a
+decision match. Class 1 sharpens *why* for the mutation-aware entries specifically: even a
+hypothetically shape-complete `native_row_servable` could not route Tier-A traffic, since
+`MUTATES_RECEIVER` rows are structurally excluded from it — routing Tier-A dispatch order off any
+future resolver candidate would need a distinct "TierA" candidate kind (not attempted here, out of
+scope for this step). What's still open, mirroring E5b step 2/3: does `try_compiled_method_mut_or_interpret_sym`'s
+`User`-candidate resolution duplicate `resolve_method_cached`'s three-tier cache the way
+`try_compiled_method_or_interpret_sym` did for `CallMethod` (E5b step 4's actual dedup)? That
+inspection is E6b step 2, not yet done.


### PR DESCRIPTION
## Summary
- Continues ADR-0019 Phase E box E6 (mutation-aware calls). E6a is fully closed (measurement + Tier-A helper survey, #6271); this starts E6b (the `CallMethodMut` probe-section cutover) by repeating E5b step 1's protocol at the mutation-aware entry.
- Instruments all ~10 `record_dispatch_entry_outcome("callmethodmut", "native"/"user")` sites inside `exec_call_method_mut_op_impl` with the existing `shadow_check_native_row_candidate` probe (`MUTSU_VM_STATS`-gated, no-op otherwise) — pure insertion, zero behavior change.
- Full `t/` sweep (3026 files, `MUTSU_VM_STATS=1`): 118117 shadow checks, 5756 mismatches (4.88%). Breaks down into three classes, one new to E6b: Tier-A-served mutators (`push`/`shift`/`splice`/...) are *structurally* invisible to the resolver's `Native` candidate by design (`native_row_servable` excludes `MUTATES_RECEIVER` rows), plus the same two classes E5b step 1 already found for `CallMethod` (missing rows like `DEFINITE`, shape-blind predicate exceptions).
- Confirms/sharpens E5b step 2's generalization: the `Native` candidate stays measurement/hint-only at `CallMethodMut` too — a real E6b cutover routes on the `User` candidate, keeping `try_native_method`/Tier-A helper calls as direct self-guarding pre-checks.
- Full writeup: `todo/deep/adr0019-e5-e7-entry-routing.md` §"E6b step 1: shadow-verifying the Native candidate at CallMethodMut itself"; ADR progress log updated.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Full local `t/` sweep (3026 files) under `MUTSU_VM_STATS=1`: only the 20 known pre-existing exact-stderr-assertion failures (already catalogued in E6a's third slice), no new failures
- [x] `prove -e target/debug/mutsu t/*.t` (no `MUTSU_VM_STATS`) — relying on CI's `make test` for the authoritative run

🤖 Generated with [Claude Code](https://claude.com/claude-code)