### PR TITLE
fix(runtime): augmented native collection methods win over the native fast path (ADR-0019 E6b step 2)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3184,6 +3184,38 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   `todo/deep/adr0019-e5-e7-entry-routing.md` §"E6b step 1: shadow-verifying the Native candidate at
   CallMethodMut itself". Next: E6b step 2 (does `try_compiled_method_mut_or_interpret_sym`'s
   `User`-candidate resolution duplicate `resolve_method_cached`, mirroring E5b step 3/4's dedup?).
+  **Progress 2026-08-11** (E6b step 2, closing E6b): answered by inspection + git archaeology, no
+  dedup needed — `try_compiled_method_mut_or_interpret_sym`'s resolution block already calls
+  `resolve_method_cached` directly (that shared, `shadow_check_resolver`-instrumented function was
+  introduced *for this exact call site* pre-ADR-0019, #4583; E5b step 4 later deduped `CallMethod`'s
+  own separate inlined copy onto it, never touching the Mut path). Classifying the surrounding
+  cascade (mirroring E5b step 4's table) found every pre-resolution item structurally identical to
+  its non-mut twin (already annotated "mut path twin of the above" in source), but surfaced a real,
+  independent dispatch-order bug in the *post*-resolution "lever A" native probes
+  (`.sort`/`.map`/`.first`/coercions on a plain `Array`/`List`/`Str`/... receiver, `ValueView` not
+  `Instance`/`Package` so the resolution block's `has_user_method` check never runs for them):
+  `augment class Array { method sort {...} }` (legal raku — `Array` does not declare its own `sort`,
+  unlike the already-known `Str.uc` redeclaration case) was silently shadowed by the native fast
+  path, on three independent unguarded tiers (Tier-1 `try_native_method_raw`, the lever-A block, and
+  the interpreter fallback's own by-name dispatch). Fixed with one shared predicate
+  (`native_lever_a_user_override`) consulted at all three tiers plus both `call_method_with_values`
+  entry points. That predicate's own correctness exposed a second, pre-existing gap:
+  `class_mro`/`has_user_method` answered `false` for a bare unregistered builtin collection name
+  (`"Array"`) even though `.^mro` reports its full chain via a different path — `class_mro_readonly`
+  never consulted `builtin_type_catalog` for a *bare* name (only for the bracketed-parametrized
+  case), so it fell to `compute_class_mro`, which had no `ClassDef` to read parents from. Fixed by
+  teaching both `class_mro_readonly` and `compute_class_mro` to consult the catalog for a bare
+  builtin name (ordered strictly *after* the existing bracketed-parametrized branch — an earlier
+  version of this fix matched a bracketed name like `"Blob[uint8]"` too, dropping `Blob` from its
+  own MRO since the catalog's parametrized rows track their base via `roles` not `mro`; caught by
+  `t/digest-battery.t`'s SHA3 sub before landing). New regression test
+  `t/augment-native-lever-a-methods.t` (raku-verified). Full local `t/` (3032 files/28,384 tests)
+  green; a 192-file roast slice (S12-methods/S12-attributes/S14-roles/S02-types/S06-signature/
+  S32-array/S03-metaops, release binary, `MUTSU_FUDGE=1`) green, 19,320 tests; clippy/fmt clean.
+  Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E6b step 2: the User-candidate
+  resolution was already deduped -- no code change needed; classifying the surrounding cascade
+  surfaced a real, unrelated dispatch-order bug instead". **All of E6b (steps 1-2) is now closed.**
+  Next: E6c (the two dynamic gaps) or E6d (`ArrayPush`'s `array_dispatch_pristine` bit).
 - [ ] **E7 — Route metaobject, qualified, and re-entrant calls through the resolver.** Cover HOW,
   `.^lookup`/`.^can`, qualified/private dispatch, EVAL carriers, and method objects.
   **Design 2026-08-10** (same doc): one consumer family per sub-PR (`run_instance_method`

--- a/news/2026-08/augmented-native-collection-methods.md
+++ b/news/2026-08/augmented-native-collection-methods.md
@@ -1,0 +1,57 @@
+# Augmenting `sort`/`map`/`first` (and friends) on `Array`/`List` was silently ignored
+
+`augment class Array { method sort { ... } }` is legal raku — `Array` never declares its
+own `sort` (it comes from `List`), so there is no redeclaration error, unlike the
+already-known `augment class Str { method uc { ... } }` case. But calling `.sort` on a
+plain `@array` still ran mutsu's native fast path and ignored the override entirely:
+
+```raku
+use MONKEY-TYPING;
+augment class Array { method sort { "USER-SORT-OVERRIDE" } }
+my @a = (3, 1, 2);
+say @a.sort;   # raku: USER-SORT-OVERRIDE, mutsu (before): (1 2 3)
+```
+
+The same gap applied to `.map`, `.first`, `.min`/`.max`/`.minmax`, `.subst`, and the
+`.Set`/`.Bag`/`.Mix`/`.Map`/`.Hash`/`.Seq`/`.IO`/`.encode`/`.decode` coercions — mutsu's
+"lever A" native dispatch for these methods never checked whether the receiver's *native*
+type (`Array`, `List`, `Hash`, `Str`, ...) had a user-declared override, because that check
+only ever ran for `Instance`/`Package` receivers. A plain `Array` value carries neither, so
+it fell through every check silently. The gap existed on **three independent, unguarded
+tiers**: the arity-keyed Tier-1 native dispatch, the block-taking "lever A" fallback, and
+the interpreter's own final by-name dispatch — all three needed the same fix.
+
+Added one shared predicate, `Interpreter::native_lever_a_user_override`, consulted at all
+three tiers plus the top of both `call_method_with_values`/`call_method_mut_with_values`:
+a non-`Instance`/`Package` receiver now checks `has_user_method` against its native type
+name before taking any native path, and dispatches through `run_instance_method` — threading
+the receiver value itself as `self`, not a synthesized type object — when an override exists.
+
+## A second, deeper gap: `class_mro` didn't know `Array`'s built-in ancestors
+
+Making that predicate correct exposed a second, pre-existing bug: `has_user_method("Array",
+"first")` answered `false` even when `List` (not `Array`) was augmented with `first` —
+despite `@a.first` legitimately dispatching through `List` in Raku's MRO either way, and
+`Array.^mro` (a *different* code path) correctly reporting `(Array) (List) (Cool) (Any)
+(Mu)`. The cause: `class_mro_readonly`'s "not a registered class" branch only consulted a
+small hardcoded table (`Match`/`Capture`/`IO::Spec`/...) for a *bare* type name, and the
+richer `builtin_type_catalog` (which already carries every builtin leaf type's full ancestor
+chain) only for a *bracketed* parametrized name like `Array[Int]`. A bare `"Array"` matched
+neither and fell to `compute_class_mro`, which has no `ClassDef` to read parents from and
+returned the class name alone — silently dropping `List`/`Cool`/`Any`/`Mu`.
+
+Fixed by teaching both `class_mro_readonly` and `compute_class_mro` to consult the catalog
+for a bare name too — as well as for the immediate parent of a *directly*-augmented builtin
+type with no explicit `is` clause (`augment class Array {...}` previously defaulted to `Any`,
+also dropping `List`/`Cool`).
+
+The first version of that fix regressed `t/digest-battery.t`'s SHA3 implementation: it
+matched a *bracketed* name like `Blob[uint8]` against the bare-name catalog lookup too,
+short-circuiting the existing bracketed-handling branch that correctly includes `Blob` (the
+base class) in the chain — the catalog's own `mro` field for a parametrized row tracks its
+base via `roles`, not `mro`, so the naive lookup silently dropped `Blob` from a `blob8`
+receiver's MRO and broke placeholder-parameter (`@^b`) `Positional` signature binding for any
+sub taking a sized buffer argument. Fixed by ordering the bare-name catalog check strictly
+after the existing bracketed branch.
+
+Pin: `t/augment-native-lever-a-methods.t` (raku-verified byte-identical output).

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -54,6 +54,28 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // Augmented native-type dispatch: a plain Array/List/Hash/Str/Range/
+        // Set/Bag/Mix/... receiver is not `Instance`/`Package`, so none of this
+        // function's by-name native dispatch below (`dispatch_method_by_name_*`,
+        // the Tier-1/lever-A callers upstream) ever checks it for a
+        // user-declared/augmented override — route straight to the ordinary
+        // instance-method machinery when one exists, threading the receiver
+        // itself as `self` (not a synthesized type object). See
+        // `native_lever_a_user_override`'s doc comment.
+        if !matches!(
+            target.view(),
+            ValueView::Instance { .. } | ValueView::Package(_)
+        ) && self.native_lever_a_user_override(&target, method)
+        {
+            let (result, _) = self.run_instance_method(
+                crate::runtime::utils::value_type_name(&target),
+                AttrMap::new(),
+                method,
+                args,
+                Some(target),
+            )?;
+            return Ok(result);
+        }
         // `HyperConfiguration.batch`/`.degree` — read the stored attribute. The
         // instance is minted by `HyperSeq.configuration` (used by the `hyperize`
         // dist); it has no user-defined accessors, so answer them directly.

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -15,6 +15,25 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // Augmented native-type dispatch (mut-path twin of the non-mut guard in
+        // `call_method_with_values`): see `native_lever_a_user_override`'s doc
+        // comment. A native-typed receiver never carries an attribute cell, so
+        // there is nothing for an augmented method to write back through — a
+        // plain value dispatch (like the non-mut path) is the correct shape.
+        if !matches!(
+            target.view(),
+            ValueView::Instance { .. } | ValueView::Package(_)
+        ) && self.native_lever_a_user_override(&target, method)
+        {
+            let (result, _) = self.run_instance_method(
+                crate::runtime::utils::value_type_name(&target),
+                crate::value::AttrMap::new(),
+                method,
+                args,
+                Some(target),
+            )?;
+            return Ok(result);
+        }
         // Track B/Track C: an aggregate that lives in a shared `ContainerRef`
         // cell (a `state @a`/`state %h` under an active thread context — see
         // `exec_state_var_init_op`). Dispatch on the cell's CONTENT, then fold

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -460,9 +460,16 @@ impl Registry {
             .unwrap_or_default();
         // If a user-defined class has no explicit parents, it implicitly
         // inherits from Any (which in turn inherits from Mu).  This matches
-        // Raku's default class hierarchy.
+        // Raku's default class hierarchy. A directly-*augmented* builtin
+        // collection/Cool type (`augment class Array {...}`, which registers a
+        // `ClassDef` for "Array" with no `is` clause of its own) instead keeps
+        // its real builtin parent (`List`, not `Any`) so the rest of its
+        // catalog ancestor chain (`Cool`/`Any`/`Mu`) is still reachable below.
         let parents = if explicit_parents.is_empty() && self.classes.contains_key(class_name) {
-            vec!["Any".to_string()]
+            match crate::builtins::builtin_type_catalog::builtin_type_info(class_name) {
+                Some(info) if info.mro.len() > 1 => vec![info.mro[1].to_string()],
+                _ => vec!["Any".to_string()],
+            }
         } else {
             explicit_parents
         };
@@ -525,6 +532,16 @@ impl Registry {
                     seq.push(base.to_string());
                 }
                 seqs.push(seq);
+            } else if let Some(info) =
+                crate::builtins::builtin_type_catalog::builtin_type_info(parent)
+            {
+                // An unregistered bare (non-parametrized; the bracketed case is
+                // handled above) builtin collection/Cool parent (`List`,
+                // `Hash`, `Range`, ...): use the catalog's own full ancestor
+                // chain instead of stopping at the bare name (which would
+                // silently drop `Cool`/`Any`/`Mu`, the same gap `Any`/`Cool`
+                // are hardcoded above to avoid).
+                seqs.push(info.mro.iter().map(|s| s.to_string()).collect());
             } else {
                 seqs.push(vec![parent.clone()]);
             }
@@ -686,6 +703,25 @@ impl Registry {
                     mro.extend(info.mro.iter().map(|s| Symbol::intern(s)));
                     return Some(mro.into());
                 }
+            }
+            // A bare (non-parametrized) builtin collection/Cool type name
+            // (`Array`, `List`, `Hash`, `Range`, ...) that has never itself
+            // been augmented: the catalog already carries its full ancestor
+            // chain -- without this, an unregistered "Array" fell through to
+            // `compute_class_mro`, which has no `ClassDef` to read parents
+            // from and answers the singleton `[Array]`, silently losing
+            // `List`/`Cool`/`Any`/`Mu`. That made `has_user_method("Array",
+            // "first")` blind to a method the user augmented onto `List`
+            // instead of `Array` directly (still legal raku -- `@a.first`
+            // dispatches through `List` either way). Checked AFTER the
+            // bracketed-parametrized branch above: a catalog row for a
+            // parametrized name like `Blob[uint8]` deliberately omits its own
+            // base (`Blob`) from `mro` (tracked instead via `roles`), so
+            // matching it here first would drop `Blob` from the chain that
+            // branch already builds correctly.
+            if let Some(info) = crate::builtins::builtin_type_catalog::builtin_type_info(class_name)
+            {
+                return Some(info.mro.iter().map(|s| Symbol::intern(s)).collect());
             }
             // Not a registered class at all: the write side computes but has no
             // `ClassDef` to cache into, so the result is identical read-only.

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -142,6 +142,22 @@ impl Interpreter {
         cacheable
     }
 
+    /// True when `target`'s intrinsic native type (or an ancestor in its MRO,
+    /// e.g. `List` for `Array`) carries a user-declared/augmented method of this
+    /// name. Guards the "lever A" pure-value native probes (`.sort`/`.map`/
+    /// `.first`/the QuantHash/Map/Hash/IO/encode-decode coercions) in
+    /// `try_compiled_method_or_interpret_inner` / `try_compiled_method_mut_or_interpret_sym`:
+    /// those probes run for plain `Array`/`List`/`Hash`/`Str`/... values, not
+    /// `Instance` receivers, so the `has_user_method` gate the Instance branch
+    /// already applies earlier in the same functions never covers them. Without
+    /// this guard a legal `augment class Array { method sort {...} }` (legal
+    /// because `Array` itself does not declare `sort` — no redeclaration error,
+    /// unlike `augment class Str { method uc {...} }`) was silently shadowed by
+    /// the native fast path. See `t/augment-native-lever-a-methods.t`.
+    pub(crate) fn native_lever_a_user_override(&mut self, target: &Value, method: &str) -> bool {
+        self.has_user_method(crate::runtime::utils::value_type_name(target), method)
+    }
+
     /// Resolve a method, consulting the sound multi-resolution cache for a
     /// type+arity-deterministic multi (avoids the per-call MRO/specificity walk).
     /// Non-multi / uncacheable / un-keyable calls resolve fresh (the non-multi

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -656,31 +656,38 @@ impl Interpreter {
                 }
             }
         }
+        // Guard for the whole "lever A" native block below: a plain
+        // Array/List/Hash/Str/... receiver has no Instance-branch user-method
+        // check of its own, so an augmented native class must be checked here
+        // once (see `native_lever_a_user_override`'s doc comment).
+        let lever_a_blocked = self.native_lever_a_user_override(&target, method);
         // Native `.map` / `.grep` over a concrete array with a simple block: run
         // the iteration loop in the Interpreter instead of the interpreter (lever A). No
         // `target_name` here (the receiver is a value, not a mutable variable),
         // so `$_`-mutating blocks fall back to the interpreter.
-        if let Some(result) = self.try_native_array_map(None, &target, method, &args) {
+        if !lever_a_blocked
+            && let Some(result) = self.try_native_array_map(None, &target, method, &args)
+        {
             return result;
         }
         // Native `.subst` over a Str with a simple pattern/replacement (lever A).
-        if let Some(result) = self.try_native_subst(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_subst(&target, method, &args) {
             return result;
         }
         // Native `.sort` over a plain array with no/simple comparator (lever A).
-        if let Some(result) = self.try_native_sort(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_sort(&target, method, &args) {
             return result;
         }
         // Native `.min` / `.max` over a plain list, including `:by` blocks.
-        if let Some(result) = self.try_native_extrema(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_extrema(&target, method, &args) {
             return result;
         }
         // Native `.minmax` over a plain list, including `:by` blocks.
-        if let Some(result) = self.try_native_minmax(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_minmax(&target, method, &args) {
             return result;
         }
         // Native `.first` over a plain list (no-adverb forms), including blocks.
-        if let Some(result) = self.try_native_first(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_first(&target, method, &args) {
             return result;
         }
         // Native QuantHash coercion `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/
@@ -692,7 +699,8 @@ impl Interpreter {
         // value since #2952), so it is a pure value op like the others. A scalar
         // (`42.Set`) becomes a single-element collection. Instance/Package/Junction
         // receivers fall through.
-        if args.is_empty()
+        if !lever_a_blocked
+            && args.is_empty()
             && let Some(result) = Self::try_native_quanthash_coerce(&target, method)
         {
             return result;
@@ -701,7 +709,8 @@ impl Interpreter {
         // Cool scalar (pure value op; the `Map` declared-type is embedded in the
         // Hash Arc). A scalar (`42.Hash`) raises the same odd-number error as the
         // interpreter. Instance/Package/Junction fall through.
-        if args.is_empty()
+        if !lever_a_blocked
+            && args.is_empty()
             && let Some(result) = Self::try_native_map_hash_coerce(&target, method)
         {
             return result;
@@ -709,7 +718,8 @@ impl Interpreter {
         // Native `.Seq` coercion over a structural receiver (Seq/Array/Slip/
         // Range/bare scalar). Supply/LazyList/Instance need state and fall
         // through to the interpreter.
-        if args.is_empty()
+        if !lever_a_blocked
+            && args.is_empty()
             && method == "Seq"
             && let Some(result) = crate::builtins::seq_coerce::to_seq_structural(&target)
         {
@@ -720,7 +730,8 @@ impl Interpreter {
         // `builtins::iterator_construct` impl the interpreter also uses. `Seq`
         // (consumed-state + `squish` env mutation) and an already-built Iterator
         // fall through to the interpreter.
-        if args.is_empty()
+        if !lever_a_blocked
+            && args.is_empty()
             && let Some(result) = Self::try_native_iterator_construct(&target, method)
         {
             return Ok(result);
@@ -728,13 +739,17 @@ impl Interpreter {
         // Native `.IO` coercion over a Cool scalar (`"path".IO`, `42.IO`) — builds
         // an IO::Path via the shared `make_io_path_instance` (ledger §D). Instance /
         // non-IO Package / aggregate receivers fall through.
-        if let Some(result) = self.try_native_io_coercion(&target, method, &args) {
+        if !lever_a_blocked
+            && let Some(result) = self.try_native_io_coercion(&target, method, &args)
+        {
             return result;
         }
         // Native `.encode` (Cool scalar -> Buf) / `.decode` (Buf/Blob -> Str) —
         // pure transformation via the VM-owned encoding registry, no `io_handles`
         // (ledger §D). Single impl shared with the interpreter catch-all.
-        if let Some(result) = self.try_native_encode_decode(&target, method, &args) {
+        if !lever_a_blocked
+            && let Some(result) = self.try_native_encode_decode(&target, method, &args)
+        {
             return result;
         }
         // TODO: compile to bytecode — native/Buf/Failure method fork (ledger §1).

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -462,30 +462,37 @@ impl Interpreter {
                 return Ok(result);
             }
         }
+        // Guard for the whole "lever A" native block below — see
+        // `native_lever_a_user_override`'s doc comment (mut path twin of the
+        // non-mut guard in `try_compiled_method_or_interpret_inner`).
+        let lever_a_blocked = self.native_lever_a_user_override(&target, method);
         // Native `.map` / `.grep` over a concrete array with a simple block (lever A).
         // `target_name` is the receiver variable, enabling rw-binding writeback
         // for `$_`-mutating blocks (`@a.map({ $_++ })` mutates `@a`).
-        if let Some(result) = self.try_native_array_map(Some(target_name), &target, method, &args) {
+        if !lever_a_blocked
+            && let Some(result) =
+                self.try_native_array_map(Some(target_name), &target, method, &args)
+        {
             return result;
         }
         // Native `.subst` over a Str with a simple pattern/replacement (lever A).
-        if let Some(result) = self.try_native_subst(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_subst(&target, method, &args) {
             return result;
         }
         // Native `.sort` over a plain array with no/simple comparator (lever A).
-        if let Some(result) = self.try_native_sort(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_sort(&target, method, &args) {
             return result;
         }
         // Native `.min` / `.max` over a plain list, including `:by` blocks.
-        if let Some(result) = self.try_native_extrema(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_extrema(&target, method, &args) {
             return result;
         }
         // Native `.minmax` over a plain list, including `:by` blocks.
-        if let Some(result) = self.try_native_minmax(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_minmax(&target, method, &args) {
             return result;
         }
         // Native `.first` over a plain list (no-adverb forms), including blocks.
-        if let Some(result) = self.try_native_first(&target, method, &args) {
+        if !lever_a_blocked && let Some(result) = self.try_native_first(&target, method, &args) {
             return result;
         }
         // Native QuantHash coercion `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/
@@ -495,21 +502,24 @@ impl Interpreter {
         // coercion produces a *new* Set/Bag/Mix value and never mutates the
         // receiver variable, so there is no writeback — identical to the non-mut
         // path's native dispatch. Instance/Package receivers fall through.
-        if args.is_empty()
+        if !lever_a_blocked
+            && args.is_empty()
             && let Some(result) = Self::try_native_quanthash_coerce(&target, method)
         {
             return result;
         }
         // Native `.Map` / `.Hash` coercion for variable receivers (`%h.Map`,
         // `@a.Hash`) — same pure value op as the non-mut path, no writeback.
-        if args.is_empty()
+        if !lever_a_blocked
+            && args.is_empty()
             && let Some(result) = Self::try_native_map_hash_coerce(&target, method)
         {
             return result;
         }
         // Native `.Seq` coercion for variable receivers (`@a.Seq`) — structural
         // receivers only, same pure value op as the non-mut path.
-        if args.is_empty()
+        if !lever_a_blocked
+            && args.is_empty()
             && method == "Seq"
             && let Some(result) = crate::builtins::seq_coerce::to_seq_structural(&target)
         {
@@ -518,13 +528,17 @@ impl Interpreter {
         // Native `.IO` coercion over a Cool scalar for variable receivers
         // (`$s.IO`) — builds a *new* IO::Path and never mutates the receiver, so no
         // writeback. Instance / non-IO Package / aggregate receivers fall through.
-        if let Some(result) = self.try_native_io_coercion(&target, method, &args) {
+        if !lever_a_blocked
+            && let Some(result) = self.try_native_io_coercion(&target, method, &args)
+        {
             return result;
         }
         // Native `.encode` (Cool scalar -> Buf) / `.decode` (Buf/Blob -> Str) for
         // variable receivers (`$s.encode("utf-16")`) — same pure transformation as
         // the non-mut path; returns a *new* Buf/Str, no writeback.
-        if let Some(result) = self.try_native_encode_decode(&target, method, &args) {
+        if !lever_a_blocked
+            && let Some(result) = self.try_native_encode_decode(&target, method, &args)
+        {
             return result;
         }
         // TODO: compile to bytecode — native/Buf/Failure method fork, mut (ledger §1).

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -165,6 +165,21 @@ impl Interpreter {
         if self.mixin_role_has_method(target, &method_name) {
             return None;
         }
+        // Augmented native-type bypass: a plain Array/List/Hash/Str/Range/Set/
+        // Bag/Mix/... receiver is not `Instance`/`Package`, so it carries no
+        // per-call user-method check of its own here -- the callers' own
+        // `skip_native` gates only extract a class name for those two shapes.
+        // Without this, `augment class Array { method sort {...} }` (legal raku:
+        // `Array` does not declare its own `sort`, so no redeclaration error --
+        // unlike `augment class Str { method uc {...} }`) was silently shadowed
+        // by the native fast path below. See `t/augment-native-lever-a-methods.t`.
+        if !matches!(
+            target.view(),
+            ValueView::Instance { .. } | ValueView::Package(_)
+        ) && self.native_lever_a_user_override(target, &method_name)
+        {
+            return None;
+        }
         // Lazy Match: class is statically "Match" — mirror the Instance
         // bypasses below without materializing. (A Match never matches
         // Real/Numeric, and the Supply/Supplier arms cannot apply.)

--- a/t/augment-native-lever-a-methods.t
+++ b/t/augment-native-lever-a-methods.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# A user `augment class Array/List/... { method NAME {...} }` overriding a
+# builtin "lever A" method (sort/map/first/min/max/minmax/Set/...) must win
+# over the native fast path. These methods are legal augment targets in raku
+# because Array/List/... do not declare their own copy of them (unlike e.g.
+# `augment class Str { method uc {...} }`, which raku rejects as a
+# redeclaration) — so this is not the same "illegal program" class as that
+# one, and must actually dispatch to the user override.
+#
+# `augment` takes effect at compile time in raku (not at its runtime lexical
+# position), so every augment for this file lives up front, before any
+# assertion runs — do not interleave "plain" and "augmented" checks in the
+# same file/process.
+
+use MONKEY-TYPING;
+augment class Array {
+    method sort { "USER-SORT-OVERRIDE" }
+}
+augment class Array {
+    method map($f) { "USER-MAP-OVERRIDE" }
+}
+augment class List {
+    method first { "USER-FIRST-OVERRIDE" }
+}
+
+plan 4;
+
+my @a = (3, 1, 2);
+is @a.sort, "USER-SORT-OVERRIDE", 'augmented Array.sort wins over native .sort (mut receiver)';
+is (3, 1, 2).Array.sort, "USER-SORT-OVERRIDE",
+    'augmented Array.sort wins over native .sort (non-mut receiver)';
+is @a.map({ $_ }), "USER-MAP-OVERRIDE", 'augmented Array.map wins over native .map';
+is @a.first, "USER-FIRST-OVERRIDE", 'augmented List.first wins over native .first';
+
+done-testing;

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -1626,3 +1626,109 @@ scope for this step). What's still open, mirroring E5b step 2/3: does `try_compi
 `User`-candidate resolution duplicate `resolve_method_cached`'s three-tier cache the way
 `try_compiled_method_or_interpret_sym` did for `CallMethod` (E5b step 4's actual dedup)? That
 inspection is E6b step 2, not yet done.
+
+## E6b step 2: the `User`-candidate resolution was already deduped -- no code change needed; classifying the surrounding cascade surfaced a real, unrelated dispatch-order bug instead
+
+Answers step 1's open question by inspection plus git archaeology (`git log -p --follow --
+src/vm/vm_call_method_compiled_mut.rs`), mirroring E5b step 3/4's protocol.
+
+**`try_compiled_method_mut_or_interpret_sym`'s resolution block already calls
+`resolve_method_cached` directly** (`vm_call_method_compiled_mut.rs`, the `if let Some(cn) =
+class_name && ... self.resolve_method_cached(cn, method, class_sym, method_sym, &args, &target)`
+block) -- not an inlined duplicate of its three-tier cache, unlike `CallMethod`'s pre-E5b-step-4
+state. Git history confirms this is not a recent fix: `resolve_method_cached` itself was
+*introduced for this exact call site* by `73539eaa1` ("perf: store the resolved method owner as a
+Symbol in the resolve caches", pre-dating ADR-0019 entirely) -- the Mut path has called the shared,
+cached, `shadow_check_resolver`-instrumented resolver since before this campaign started. E5b step
+4 (`ae7d92e8e`) later deduped `CallMethod`'s *own* inlined copy onto this same pre-existing
+function; it did not touch the Mut path because there was nothing to dedup there. **Conclusion:
+E6b step 2 closes with zero code change**, exactly like E5d -- the `User` candidate at
+`CallMethodMut` has been sound and shadow-checked (via `resolve_method_cached`'s own two
+`shadow_check_resolver` call sites, unconditionally exercised by every caller including this one)
+for as long as E4a's shadow probe has existed.
+
+**Classifying the surrounding interceptor cascade** (mirroring E5b step 4's table, for the ~15
+`.new`/`bless`/IO::Handle/MOP/private-method/metamethod pre-checks before the resolution block, and
+the ~11 "lever A" pure-value native probes after it): every pre-resolution item is structurally
+identical to its non-mut twin -- the source comments in `vm_call_method_compiled_mut.rs` already
+say so explicitly ("mut path twin of the above") for every one of the ten `.new`/`bless` forks, so
+E5b step 4's classification (none fold into a decision match; each stays a self-guarding
+pre-check) transfers without re-deriving it. The genuinely new item was the *post*-resolution lever-A
+block (`try_native_array_map`/`try_native_subst`/`try_native_sort`/`try_native_extrema`/
+`try_native_minmax`/`try_native_first`/the QuantHash/Map-Hash/Seq/IO/encode-decode coercions) --
+these run for a receiver whose `ValueView` is not `Instance`/`Package` (a plain `Array`/`List`/
+`Hash`/`Str`/...), so `class_name` is `None` and the resolution block's `resolve_method_cached`
+call never even executes for them.
+
+**That gap is real, not hypothetical.** Raku-verified:
+
+```raku
+use MONKEY-TYPING;
+augment class Array { method sort { "USER-SORT-OVERRIDE" } }
+my @a = (3, 1, 2);
+say @a.sort;   # raku: USER-SORT-OVERRIDE (legal -- Array does not declare its own `sort`,
+               #       so no X::Redeclaration, unlike the already-known `augment class Str
+               #       { method uc {...} }` case E5b step 2 found and declined to fix)
+```
+
+mutsu printed `(1 2 3)` (native, ignoring the override) before this step, on **three independent,
+previously-unguarded tiers**, not just the lever-A block: (1) the arity-keyed Tier-1 native
+dispatch (`try_native_method_raw`, reached even earlier, before `try_compiled_method_mut_or_interpret_sym`
+is ever called, via the `CallMethodMut`/`CallMethod` opcodes' own `skip_native` gate — which, like
+the gate E5b step 2 already documented, only extracts a class name for `Instance`/`Package`
+receivers); (2) the lever-A block itself; (3) `call_method_with_values`/`call_method_mut_with_values`'s
+own internal by-name dispatch (`dispatch_method_by_name_2`'s `"sort"` arm and siblings), reached as
+the final interpreter fallback. All three needed the same fix, so a single shared predicate
+(`Interpreter::native_lever_a_user_override(target, method)`, `vm_call_method_compiled_cache.rs`)
+was added and consulted at all three tiers (`vm_native_dispatch.rs`'s `try_native_method_raw`,
+both lever-A blocks, and the top of both `call_method_with_values`/`call_method_mut_with_values`) —
+non-`Instance`/`Package` receivers now check `has_user_method(value_type_name(target), method)`
+before taking any native path, and dispatch through `run_instance_method` (threading the receiver
+value itself as `self`, not a synthesized type object) when it answers true.
+
+**That predicate exposed a second, independent, pre-existing bug**: `has_user_method`/`class_mro`
+answered `false` for a bare unregistered builtin collection name (`"Array"`, `"List"`, ...) even
+though `Array.^mro` (a *different* code path) correctly reports `(Array) (List) (Cool) (Any) (Mu)`.
+Root cause: `class_mro_readonly`'s "not a registered class" branch only ever consulted the small
+hardcoded `builtin_mro_table` (Match/Capture/IO::Spec/Distribution/CompUnit — an unrelated, older
+set) and, for a *bracketed* parametrized name only, `builtin_type_catalog::builtin_type_info`; a
+bare name like `"Array"` matched neither and fell to `compute_class_mro`, which has no `ClassDef`
+to read parents from and returns the class name alone. That made `has_user_method("Array",
+"first")` blind to `augment class List { method first {...} }` (List, not Array, still legal raku
+since `@a.first` dispatches through `List` in its MRO either way) even after the predicate itself
+was fixed. Fixed by teaching `class_mro_readonly` and `compute_class_mro` to consult
+`builtin_type_catalog::builtin_type_info` for a bare name too (the catalog already carries every
+builtin leaf type's full ancestor chain, previously read only for the bracketed-parametrized case)
+-- both for an unregistered class name directly, and as the immediate parent when a *previously
+unregistered* builtin type becomes registered via `augment` with no explicit `is` clause of its own
+(default-to-`Any` was too coarse there, dropping `List`/`Cool` for a direct `augment class Array`).
+
+**A real regression surfaced and was fixed before landing**: the first version of the
+`class_mro_readonly` fix matched a *bracketed* parametrized name too (e.g. `"Blob[uint8]"`) against
+the bare-name catalog lookup, short-circuiting the existing (correct) bracketed-handling branch
+below it -- which synthesizes `[Blob[uint8], Blob, Any, Mu]` (base class included) -- with the
+catalog row's own `mro` field for `"Blob[uint8]"`, `[Blob[uint8], Any, Mu]` (base class *excluded*
+-- parametrized rows track their base via `roles`, not `mro`). That silently dropped `Blob` from a
+`Blob[uint8]`/`buf8` receiver's MRO, breaking placeholder-parameter (`@^b`) "Positional" signature
+binding for any sub taking a sized buffer argument (caught by `t/digest-battery.t`'s SHA3
+implementation, `roast/packages/.../Digest/lib/Digest/SHA3.rakumod`'s `load64`, and by
+`t/sized-buffer-dispatch-narrowness.t`). Fixed by ordering the bare-name catalog check strictly
+*after* the existing bracketed branch, so it only ever answers for names that were never bracketed
+to begin with.
+
+**Verification**: new regression test `t/augment-native-lever-a-methods.t` (4 assertions, raku-
+verified byte-identical output) pins `augment class Array { method sort/map {...} }` and `augment
+class List { method first {...} }` overriding their native fast paths on both mut and non-mut
+receivers. Full local `t/` suite (3032 files / 28,384 tests, `-j8`) green. A relevant 192-file
+roast slice (S12-methods, S12-attributes, S14-roles, S02-types, S06-signature, S32-array,
+S03-metaops -- chosen for MRO/method-dispatch/class-hierarchy relevance) run against the release
+binary with `MUTSU_FUDGE=1`: 19,320 tests, all green. `cargo clippy -- -D warnings` / `cargo fmt`
+clean.
+
+**Conclusion: E6b step 2 is closed.** No code change was needed for the question it actually asked
+(the `User`-candidate dedup); the classification work that answers it surfaced and fixed a real,
+independent, general dispatch-order bug affecting any augmented builtin collection/Cool type's
+"lever A" methods, plus the `class_mro` gap that made the fix's own user-override predicate work
+correctly for multi-level builtin ancestry. **All of E6b (steps 1-2) is now closed.** Next: E6c
+(the two dynamic gaps -- inventory corrections 3/4 -- fixed by routing through the same decision)
+or E6d (`ArrayPush`'s `array_dispatch_pristine` bit).


### PR DESCRIPTION
## Summary
- `augment class Array { method sort {...} }` is legal raku (`Array` does not declare its own `sort`), but mutsu's "lever A" native dispatch for `sort`/`map`/`first`/`min`/`max`/`minmax`/`subst`/the Set/Bag/Mix/Map/Hash/Seq/IO/encode/decode coercions never checked a plain `Array`/`List`/`Hash`/`Str`/... receiver for a user-declared override on any of its three independent dispatch tiers (Tier-1 arity-keyed native dispatch, the block-taking lever-A fallback, and the interpreter's own by-name dispatch fallback) — only `Instance`/`Package` receivers were checked. Added one shared predicate (`native_lever_a_user_override`) consulted at all three tiers.
- Fixing that predicate exposed a second, pre-existing bug: `class_mro`/`has_user_method` answered `false` for a bare unregistered builtin collection name (e.g. `"Array"`) even though `.^mro` (a different code path) reports its full ancestor chain — `class_mro_readonly` only consulted `builtin_type_catalog` for a *bracketed* parametrized name, not a bare one. Fixed both `class_mro_readonly` and `compute_class_mro` to consult the catalog for a bare name too, carefully ordered strictly *after* the existing bracketed-parametrized branch (an earlier version of this fix regressed `t/digest-battery.t`'s SHA3 implementation by matching a bracketed name like `Blob[uint8]` against the bare-name lookup and dropping `Blob` from its own MRO — caught before landing).
- This closes ADR-0019 E6b step 2 (found while classifying `CallMethodMut`'s interceptor cascade, per the design doc's E5b-step-4-mirroring protocol). Full writeup in `todo/deep/adr0019-e5-e7-entry-routing.md` and the ADR's own progress log.

## Test plan
- [x] New regression test `t/augment-native-lever-a-methods.t` (4 assertions), raku-verified byte-identical output
- [x] Full local `t/` suite: 3032 files / 28,384 tests green
- [x] Relevant 192-file roast slice (S12-methods, S12-attributes, S14-roles, S02-types, S06-signature, S32-array, S03-metaops) against the release binary with `MUTSU_FUDGE=1`: 19,320 tests green
- [x] `cargo clippy -- -D warnings` / `cargo fmt --check` clean
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)