### PR TITLE
docs+instrumentation(adr): ADR-0019 E6d closes -- ArrayPush augment guard verified moot

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3216,6 +3216,22 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   resolution was already deduped -- no code change needed; classifying the surrounding cascade
   surfaced a real, unrelated dispatch-order bug instead". **All of E6b (steps 1-2) is now closed.**
   Next: E6c (the two dynamic gaps) or E6d (`ArrayPush`'s `array_dispatch_pristine` bit).
+  **Progress 2026-08-11** (E6d, closing with no code change): ran V2's own raku baseline first —
+  `augment class Array { method push(...) }` and its `multi method push` variant are both illegal
+  in raku (`X::Redeclaration` / `X::Multi::Ambiguous`, on both `Array` and `List` — the same
+  "already a legitimate program shape" exemption E5b step 2 established for `augment class Str {
+  method uc {...} }`), so `ArrayPush`'s bypass of an illegal augment is not a new gap. The one
+  legal override mechanism (a `does`-mixin: `@a does Loud` where `Loud` declares `push`) already
+  dispatches correctly with zero code change — `exec_array_push_op`'s existing `is_simple_array`
+  gate rebinds a mixed-in array away from `ValueView::Array`, so the fast path never runs and the
+  call falls through to `call_method_with_values`, matching raku byte-for-byte. `Method.wrap` on a
+  `.^lookup`-ed builtin (raku's own legal mechanism for intercepting `Array.push`) is out of scope
+  — mutsu has no `Method.wrap` support at all, an unrelated missing-feature gap. **Conclusion: the
+  `array_dispatch_pristine` generation-refreshed bit the design doc proposed is not needed — it
+  would defend against a divergence that does not exist for any legal program.** Full detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"E6d: ArrayPush's augmented-Array divergence (V2) --
+  raku-verified moot, array_dispatch_pristine not built". **E6a, E6b, and E6d are now closed; E6c
+  (the two dynamic gaps) is the only remaining open box in E6.**
 - [ ] **E7 — Route metaobject, qualified, and re-entrant calls through the resolver.** Cover HOW,
   `.^lookup`/`.^can`, qualified/private dispatch, EVAL carriers, and method objects.
   **Design 2026-08-10** (same doc): one consumer family per sub-PR (`run_instance_method`

--- a/news/2026-08/adr0019-e6d-arraypush-verified-moot.md
+++ b/news/2026-08/adr0019-e6d-arraypush-verified-moot.md
@@ -1,0 +1,48 @@
+# ADR-0019 E6d closes: `ArrayPush`'s proposed augmented-Array guard was solving a non-problem
+
+E6's design doc flagged one open verification item (V2) for the `ArrayPush` fast-path
+opcode: does `augment class Array { method push(...) }` diverge from the opcode's
+direct-Arc-append shortcut? The proposed fix was a generation-refreshed
+`array_dispatch_pristine` bit that would fall `ArrayPush` back to full method dispatch
+whenever any user/wrap row existed under `Array`/`List`.
+
+Running the actual raku baseline first (per this campaign's standing rule — measure
+before naming the fix) showed the premise doesn't hold:
+
+```raku
+use MONKEY-TYPING;
+augment class Array { method push($x) { say "USER-PUSH: $x"; self } }
+# raku: ===SORRY!=== Package 'Array' already has a method 'push'
+#       (did you mean to declare a multi method?)
+```
+
+Both the plain and `multi method` forms are illegal in raku, on both `Array` and its
+parent `List` — the same "illegal program" shape ADR-0019's E5b step 2 already found for
+`augment class Str { method uc {...} }`, and explicitly declined to fix, since raku
+itself rejects the program before any dispatch-ordering question can arise. mutsu
+silently accepts the same illegal augment (a separate, pre-existing, general
+compile-time gap — missing redeclaration/multi-ambiguity detection for `augment` — not a
+dispatch-ordering defect), so `ArrayPush`'s bypass of it is not a new bug.
+
+The one *legal* way to override `.push` on an array value — a `does`-mixin — already
+works correctly today, with no code change:
+
+```raku
+role Loud { method push($x) { say "ROLE-PUSH: $x"; self } }
+my @a = (1, 2, 3);
+@a does Loud;
+@a.push(4);   # raku and mutsu: identical, "ROLE-PUSH: 4" then [1 2 3]
+```
+
+`exec_array_push_op`'s existing `is_simple_array` gate already excludes a mixed-in
+array — `@a does Loud` rebinds `@a` away from a plain `ValueView::Array`, so the fast
+path never even runs and the call falls through to the always-correct generic dispatch.
+This is the third time this campaign has found "the receiver-shape check the fast path
+already has to make IS the safety net" — after `CallMethod`'s native probe (E5b step 2)
+and the augmented native collection methods fix (E6b step 2) — now confirmed at a
+completely different, much simpler opcode.
+
+Conclusion: the proposed `array_dispatch_pristine` bit is not needed. Building it would
+add a permanent per-push registry-generation check to defend against a divergence that
+does not exist for any legal raku program. E6a, E6b, and E6d are now closed; E6c (the two
+dynamic-call gaps) is the only remaining open box in ADR-0019 Phase E's E6.

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -1732,3 +1732,66 @@ independent, general dispatch-order bug affecting any augmented builtin collecti
 correctly for multi-level builtin ancestry. **All of E6b (steps 1-2) is now closed.** Next: E6c
 (the two dynamic gaps -- inventory corrections 3/4 -- fixed by routing through the same decision)
 or E6d (`ArrayPush`'s `array_dispatch_pristine` bit).
+
+## E6d: `ArrayPush`'s augmented-Array divergence (V2) -- raku-verified moot, `array_dispatch_pristine` not built
+
+V2 asked for a raku baseline of `augment class Array { method push(...) }` + `@a.push($x)` vs
+`@a.push($x,$y)`, with the design doc's fix being a generation-refreshed `array_dispatch_pristine`
+bit that would fall the `ArrayPush` opcode back to full dispatch whenever any user/wrap row exists
+under `Array`/`List`. Ran the actual raku baseline first, per this campaign's standing rule
+(measure before naming the fix; see `[[feedback-measure-before-naming-the-fix]]`):
+
+```raku
+use MONKEY-TYPING;
+augment class Array { method push($x) { say "USER-PUSH: $x"; self } }
+my @a = (1, 2, 3);
+@a.push(4);
+# raku: ===SORRY!=== Error while compiling -e
+#       Package 'Array' already has a method 'push' (did you mean to declare a multi method?)
+
+augment class Array { multi method push($x) { say "USER-PUSH: $x"; self } }
+# raku: Died with X::Multi::Ambiguous
+```
+
+Both forms are illegal in raku, on both `Array` and `List` (the parent also already declares its
+own `push`) -- **exactly the same "illegal program" shape E5b step 2 already found for
+`augment class Str { method uc {...} }`** and explicitly declined to fix, because raku itself
+rejects it before the dispatch-ordering question can even arise. Confirmed the parity: mutsu
+silently accepts the same illegal augment (no redeclaration/multi-ambiguity detection, a
+pre-existing, general, *compile-time* gap unrelated to E6d) and `ArrayPush` bypasses it --
+identical root cause and identical "not a legitimate program shape worth a dedicated ticket by
+itself" conclusion, not a new E6d-specific finding.
+
+**The one legal mechanism for overriding `.push` on an array value -- a `does`-mixin -- already
+works correctly, with no code change needed, for the same structural reason E5b step 2 found for
+`"hello" but Loud`:**
+
+```raku
+role Loud { method push($x) { say "ROLE-PUSH: $x"; self } }
+my @a = (1, 2, 3);
+@a does Loud;
+@a.push(4);   # raku: ROLE-PUSH: 4 / [1 2 3] -- mutsu: identical, byte-for-byte
+```
+
+`exec_array_push_op`'s own `is_simple_array` gate (`self.env().get(target_name).is_some_and(|v|
+matches!(v.view(), ValueView::Array(..)))`) already excludes a mixed-in value -- `@a does Loud`
+rebinds `@a` to a `ValueView::Mixin`, not a plain `ValueView::Array`, so the fast path never even
+attempts to run and the call falls through to the always-correct `call_method_with_values`. This
+is the *same* "the shape check already is the safety net" pattern E5b step 2 established for
+`mixin_role_has_method`, now confirmed a third time (after `CallMethod`'s native probe and `.uc`)
+at a completely different opcode (`ArrayPush`, which has no native-probe cascade at all -- it is a
+single hardcoded shape check, simpler than either prior case). `Method.wrap` on a `.^lookup`-ed
+builtin method (the mechanism raku itself uses to legally intercept `Array.push` without an
+illegal redeclaration -- `Array.^lookup("push").wrap: -> |c {...}`) is not attempted here: mutsu
+does not implement `.wrap` on a retrieved `Method` object at all (`No such method 'wrap' for
+invocant of type 'Method'`), a separate, unrelated, larger missing-feature gap (the MOP `Method`
+object protocol), not an `ArrayPush` dispatch-ordering question.
+
+**Conclusion: E6d closes with no code change.** The `array_dispatch_pristine` generation-refreshed
+guard the design doc proposed would have added a permanent per-push registry-generation check to
+defend against a divergence that, per actual raku verification, does not exist for any legal
+program -- building it would be solving a problem this step's own verification item shows is
+already moot, the same outcome E5c parts 1 and 2 reached for their own entries. **E6a, E6b, and
+E6d are now closed; E6c (the two dynamic gaps) is the only remaining open box in E6.** Next: E6c,
+or move on to E7 (metaobject/qualified/re-entrant calls) if E6c is judged low-value after its own
+raku-verification step (V1).


### PR DESCRIPTION
## Summary
- ADR-0019 E6's design doc flagged one open verification item (V2): does `augment class Array { method push(...) }` diverge from the `ArrayPush` fast-path opcode's direct-Arc-append shortcut? The proposed fix was a generation-refreshed `array_dispatch_pristine` bit.
- Ran the actual raku baseline first (measure before naming the fix): both the plain and `multi method` augment forms are illegal in raku on `Array` and `List` (`X::Redeclaration` / `X::Multi::Ambiguous`) — the same "illegal program" shape E5b step 2 already established for `augment class Str { method uc {...} }` and explicitly declined to fix. mutsu silently accepts the same illegal augment (a separate, pre-existing, general compile-time gap, not a dispatch-ordering defect).
- The one *legal* override mechanism (a `does`-mixin) already dispatches correctly today with zero code change: `exec_array_push_op`'s existing `is_simple_array` gate already excludes a mixed-in array by construction, falling through to the always-correct generic dispatch.
- **Conclusion: no code change needed.** The proposed `array_dispatch_pristine` bit would defend against a divergence that does not exist for any legal raku program. E6a, E6b, and E6d are now closed; E6c is the only remaining open box in E6.

Docs-only change (ADR + todo/deep design doc + news entry) — no source files touched.

## Test plan
- N/A (docs-only; CI's docs-only classification should skip the four heavy jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)