### PR TITLE
feat(slang): spaced private methodop — self!method (args) under Slang::Tuxic

### DIFF
--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1318,6 +1318,23 @@ fn postfix_expr_loop_from(
             let after_bang = &rest[1..];
             if let Some((r, name)) = parse_private_method_name(after_bang) {
                 let name = Symbol::intern(&name);
+                // Slang spaced-methodop mode (ADR-0026 §2.3): `self!method (args)`
+                // is a private method call with the parenthesized args — Tuxic's
+                // methodop override covers the `!` dotty too (Text::CSV's
+                // `self!ready (0, $cf)`).
+                let r = if !r.starts_with('(')
+                    && (r.starts_with(' ') || r.starts_with('\t'))
+                    && crate::parser::stmt::simple::slang_spaced_methodop()
+                {
+                    let after_ws = r.trim_start_matches([' ', '\t']);
+                    if after_ws.starts_with('(') {
+                        after_ws
+                    } else {
+                        r
+                    }
+                } else {
+                    r
+                };
                 if r.starts_with('(') {
                     let (r, _) = parse_char(r, '(')?;
                     let (r, _) = ws(r)?;

--- a/src/parser/stmt/simple/slang_modes.rs
+++ b/src/parser/stmt/simple/slang_modes.rs
@@ -165,6 +165,35 @@ mod tests {
     }
 
     #[test]
+    fn spaced_private_methodop_mode_parses_bang_ws_paren_as_call() {
+        let stmts = parse_with_modes(TUXIC, "self!ready (0, 2);").unwrap();
+        match first_expr(&stmts) {
+            Expr::MethodCall {
+                name,
+                args,
+                modifier,
+                ..
+            } => {
+                assert_eq!(name.as_str(), "ready");
+                assert_eq!(args.len(), 2);
+                assert_eq!(*modifier, Some('!'));
+            }
+            other => panic!("expected private MethodCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spaced_private_methodop_off_unchanged() {
+        // Stock grammar: `self!ready` is a no-arg private call; the
+        // parenthesized list does not attach to it as arguments.
+        if let Ok(stmts) = parse_with_modes(SlangModes::default(), "self!ready (0, 2);") {
+            if let Expr::MethodCall { args, .. } = first_expr(&stmts) {
+                assert!(args.len() < 2, "stock parse must not bind the spaced args");
+            }
+        }
+    }
+
+    #[test]
     fn spaced_call_mode_excludes_control_keywords() {
         let stmts = parse_with_modes(TUXIC, "if (1) { 2 }").unwrap();
         assert!(

--- a/t/slang-tuxic-activation.t
+++ b/t/slang-tuxic-activation.t
@@ -8,7 +8,7 @@ use Slang::Tuxic;
 # overrides flip the parser's spaced-call / spaced-methodop modes for the
 # rest of this compilation unit — and only this unit.
 
-plan 8;
+plan 9;
 
 sub foo($a, $b) { $a * $b }
 is foo (3, 5), 15, 'spaced call passes the paren contents as an arg list';
@@ -31,3 +31,12 @@ dies-ok { EVAL q[42.fmt ('-%d-')] },
 # The exclusion list: control keywords stay control flow under Tuxic mode.
 my $kw = do if (1) { 'kw' } else { 'no' };
 is $kw, 'kw', 'if (…) stays an if under Tuxic mode';
+
+# The methodop override covers the `!` dotty too: `self!method (args)` is a
+# private method call with the parenthesized args (Text::CSV's
+# `self!ready (0, $cf)` — its last parse blocker).
+class WithPrivate {
+    method !mul ($a, $b) { $a * $b }
+    method pub () { self!mul (6, 7) }
+    }
+is WithPrivate.new.pub, 42, 'spaced private methodop (self!m (args))';


### PR DESCRIPTION
Follow-up to #6278: Tuxic's `methodop` override covers the `!` dotty too, but the spaced-methodop mode only handled `.method (`. **Text::CSV's `self!ready (0, $cf)` was its last parse blocker — with this, `mutsu -I lib -e 'use Text::CSV; say "ok"'` prints `ok`**, the verification gate the ADR-0026 campaign was aimed at (`todo/deep/text-csv-needs-slang-tuxic-support.md`).

## What

The private-method arm of the postfix chain (`expr/postfix/loop_.rs`) now skips whitespace before `(` when `spaced_methodop` is on, mirroring the public-methodop arm from #6273. Stock grammar unchanged (mode off: byte-identical behavior).

## Tests

- 2 new unit tests in `slang_modes.rs` (mode on: two args bind with modifier `'!'`; mode off: unchanged) — 9/9 green.
- End-to-end case added to `t/slang-tuxic-activation.t` (a class with `method !mul` called as `self!mul (6, 7)`), **rakudo-verified 9/9 against the real upstream dists**.
- Local `make test` PASS (TAP 226s — the post-perf-fix baseline).

## Campaign state

The Text::CSV suite (33 files) now parses and runs; remaining failures are ordinary runtime bugs (the CSV::Table precedent), starting with a method-call-vs-file-local-sub misdispatch in `10_base.t`. Measurement and fixes continue as the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)