### PR TITLE
fix: seven Text::CSV runtime-sweep unblocking fixes

### DIFF
--- a/src/builtins/iterator_construct.rs
+++ b/src/builtins/iterator_construct.rs
@@ -45,6 +45,15 @@ pub(crate) fn build_iterator_instance(target: &Value) -> Value {
     };
     let items = if crate::runtime::utils::is_shaped_array(target) {
         crate::runtime::utils::shaped_array_leaves(target)
+    } else if let ValueView::Array(arr, kind) = target.view()
+        && kind.is_itemized()
+    {
+        // `.iterator` on an ITEMIZED array (`$[1,2,3].iterator`) still iterates
+        // the array's elements — itemization only prevents flattening in list
+        // context, which `value_to_list` below models by returning the array as
+        // one opaque item (that made `pull-one` yield the whole array once;
+        // Text::CSV's `CSV::Diag.iterator` returns `$[...].iterator`).
+        arr.iter().cloned().collect()
     } else if let Some(bytes) = blob_elements(target) {
         // A Buf/Blob is an Instance holding its elements in a `bytes` attribute,
         // so `value_to_list` would see one opaque object. It iterates its elements

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1875,6 +1875,17 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         return Ok((rest, make_call_expr(name, input, vec![])));
     }
 
+    // A bare `return` in EXPRESSION position (`$err and return;`) transfers
+    // control with Nil: compile it as the zero-arg `return` call (which raises
+    // the return control exception), not an inert BareWord — that resolved to
+    // the `&return` routine object and fell through, so Text::CSV's
+    // `$error and return;` guard kept executing the rest of the sub. A
+    // user-declared `\return` term never reaches this fallback (term_literals
+    // resolves it first).
+    if name == "return" {
+        return Ok((rest, make_call_expr(name, input, vec![])));
+    }
+
     // Perl 5 unary functions used bare (no argument). `ord`/`chr`/`lc`/`uc`/`abs`
     // defaulted to `$_` in Perl 5 but require an explicit argument/invocant in
     // Raku, so a bare use — end of statement or immediately a `.method` (i.e. no

--- a/src/parser/stmt/control/for_loops.rs
+++ b/src/parser/stmt/control/for_loops.rs
@@ -80,6 +80,16 @@ fn paren_has_toplevel_semicolon(input: &str) -> bool {
                 }
             }
             ';' if depth == 1 => return true,
+            // Skip a `#` line comment: a `;` inside one is prose, not a
+            // C-style separator (`for (1, # has no ;\n 2) {}` — Text::CSV's
+            // t/80_diag.t annotates its fragment-spec list this way).
+            '#' => {
+                for c2 in chars.by_ref() {
+                    if c2 == '\n' {
+                        break;
+                    }
+                }
+            }
             // Skip a backslash-escaped char so an escaped delimiter is ignored.
             '\\' => {
                 chars.next();

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -551,7 +551,12 @@ pub(crate) fn known_call_stmt(input: &str) -> PResult<'_, Stmt> {
 
     // In Raku, `foo(args)` (no space) = paren call, but `foo (expr)` (space) = listop call.
     // When there was whitespace before `(`, treat `(` as expression grouping, not call parens.
-    let (rest, args) = if had_ws {
+    // Under the slang spaced-call mode (ADR-0026, Slang::Tuxic's
+    // `term:sym<identifier>` override) `is ($a, $b, $desc)` IS a paren call:
+    // the parenthesized contents bind as the argument list.
+    let spaced_paren_call =
+        had_ws && rest.starts_with('(') && crate::parser::stmt::simple::slang_spaced_call();
+    let (rest, args) = if had_ws && !spaced_paren_call {
         parse_stmt_call_args_no_paren(rest).map_err(|err| PError {
             messages: merge_expected_messages("expected known call arguments", &err.messages),
             remaining_len: err.remaining_len.or(Some(rest.len())),

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -648,6 +648,34 @@ impl Interpreter {
                 let ValueView::Sub(sub_data) = method_value.view() else {
                     return Ok(Value::NIL);
                 };
+                // `^find_method` on a *multi* method family returns its first
+                // candidate as a carrier Sub tagged with `__mutsu_lookup_class`
+                // / `__mutsu_lookup_method` and no candidate index. Registering
+                // just that carrier would freeze the alias to one signature
+                // (Text::CSV's BEGIN-time `alias` helper maps `column-names`
+                // onto the four-candidate `column_names` multi). Clone the
+                // whole candidate family for the new name instead.
+                let multi_family: Option<Vec<MethodDef>> = (|| {
+                    if sub_data.env.get("__mutsu_lookup_candidate_idx").is_some() {
+                        return None;
+                    }
+                    let ValueView::Str(src_class) =
+                        sub_data.env.get("__mutsu_lookup_class").map(Value::view)?
+                    else {
+                        return None;
+                    };
+                    let ValueView::Str(src_method) =
+                        sub_data.env.get("__mutsu_lookup_method").map(Value::view)?
+                    else {
+                        return None;
+                    };
+                    self.registry()
+                        .classes
+                        .get(src_class.as_ref())
+                        .and_then(|cd| cd.methods.get(src_method.as_ref()))
+                        .filter(|defs| defs.iter().any(|d| d.is_multi))
+                        .cloned()
+                })();
                 // Filter out invocant params from param_defs since MethodDef
                 // stores only the user-visible parameters (the invocant is
                 // added implicitly during dispatch).
@@ -759,7 +787,9 @@ impl Interpreter {
                     );
                 }
                 if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
-                    class_def.methods.insert(method_name, vec![def]);
+                    class_def
+                        .methods
+                        .insert(method_name, multi_family.unwrap_or_else(|| vec![def]));
                 }
                 self.registry_mut().sync_user_method_entries(&class_name);
                 // Class shape changed (an added BUILD/TWEAK/new flips ctor

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -704,7 +704,13 @@ impl Interpreter {
                         | '|'
                         | ':'
                         | '#'
+                        // Both quote chars: an unescaped `"` (or `'`) in the
+                        // spliced pattern reads as a quoted-literal opener and
+                        // swallows the rest of the source — `my $q = '"';
+                        // / $q | x /` lost the alternation split entirely
+                        // (Text::CSV's combine/string quoting).
                         | '\''
+                        | '"'
                         // `%` (and `%%`) is the separator-quantifier infix and `&`
                         // is the conjunction infix; an interpolated scalar matches
                         // *literally* (raku does not re-parse it as regex source),

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -230,10 +230,13 @@ impl Interpreter {
             false
         };
         if container_kind_matches && let Some(source) = source_constraint {
-            return self.type_matches_value(
-                &resolved_constraint,
-                &Value::package(Symbol::intern(source)),
-            );
+            // Like the metadata path below, compare declared element types with
+            // any :D/:U smiley stripped — the smiley constrains the elements'
+            // definedness, not the source variable's element TYPE OBJECT
+            // (`my Field @f` must satisfy `Field:D @fld`, Text::CSV's
+            // `multi method string`).
+            let (base, _smiley) = crate::runtime::types::strip_type_smiley(&resolved_constraint);
+            return self.type_matches_value(base, &Value::package(Symbol::intern(source)));
         }
         if let Some(metadata) = self.container_type_metadata(value)
             && !metadata.value_type.is_empty()

--- a/t/addmethod-multi-alias.t
+++ b/t/addmethod-multi-alias.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# `^find_method` on a multi method returns a carrier for the whole candidate
+# family; registering it under a new name via `^add_method` must alias ALL
+# candidates, not freeze the alias to the first one's signature.
+# (Text::CSV's BEGIN-time `alias` helper: `column-names` -> the four-candidate
+# `column_names` multi.)
+
+plan 6;
+
+class Aliased {
+    has @!names;
+    multi method cn (Bool:D $b where *.not) { @!names = (); }
+    multi method cn (Any:U) { @!names = (); }
+    multi method cn (*@c) {
+        @c.elems and @!names = @c.map(*.Str);
+        @!names;
+    }
+}
+
+BEGIN {
+    my $r := Aliased.^find_method("cn");
+    Aliased.^add_method("cn-alias", $r);
+}
+
+my $a = Aliased.new;
+is $a.cn.elems, 0, 'original multi: zero-arg call hits the slurpy candidate';
+is $a.cn-alias.elems, 0, 'alias: zero-arg call still dispatches (slurpy candidate)';
+is $a.cn-alias("x", "y").elems, 2, 'alias: setter candidate stores values';
+is $a.cn-alias.elems, 2, 'alias: state visible through zero-arg getter';
+is-deeply $a.cn-alias(False), [], 'alias: Bool:D candidate clears';
+is $a.cn.elems, 0, 'original sees the cleared state';

--- a/t/bare-return-expression.t
+++ b/t/bare-return-expression.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# A bare `return` in EXPRESSION position transfers control with Nil — it is
+# the zero-arg &return call, not an inert bareword (Text::CSV's t/20_file.t
+# guard `$error and return;` kept executing the rest of the sub).
+
+plan 5;
+
+sub guard ($e) { $e and return; "fell through" }
+is guard(2034), Nil, 'truthy LHS: `$x and return` returns Nil';
+is guard(0), "fell through", 'falsy LHS: body continues';
+
+sub guard-or ($e) { $e or return; "ran" }
+is guard-or(1), "ran", 'truthy LHS: `$x or return` continues';
+is guard-or(0), Nil, 'falsy LHS: `$x or return` returns Nil';
+
+my @out;
+sub collect (*@xs) {
+    for @xs -> $x {
+        $x %% 2 or return;
+        @out.push($x);
+    }
+    "end";
+}
+is collect(2, 4, 5, 6), Nil, 'bare return exits the whole routine from a loop';

--- a/t/for-paren-comment-semicolon.t
+++ b/t/for-paren-comment-semicolon.t
@@ -1,0 +1,18 @@
+use v6;
+use Test;
+
+# The obsolete C-style `for (init; test; incr)` detector scans the paren group
+# for a top-level `;` — a semicolon inside a `#` line comment is prose, not a
+# separator (Text::CSV's t/80_diag.t annotates its fragment-spec list with
+# comments like "cell has no ;").
+
+plan 2;
+
+my @got;
+for (1,   # has no ;
+     2,   # another; note
+     3) { @got.push($_) }
+is-deeply @got, [1, 2, 3], 'comment semicolons inside for (...) are ignored';
+
+dies-ok { EVAL q[for (my $i = 0; $i < 3; $i++) { }] },
+    'a real C-style for is still rejected';

--- a/t/iterator-itemized-array.t
+++ b/t/iterator-itemized-array.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# `.iterator` on an itemized array iterates the ELEMENTS: itemization only
+# prevents flattening in list context; the iterator protocol still walks the
+# array (Text::CSV's CSV::Diag.iterator returns `$[ ... ].iterator`).
+
+plan 6;
+
+my $i = $[1, 2, 3].iterator;
+is $i.pull-one, 1, 'pull-one yields the first element';
+is $i.pull-one, 2, 'pull-one advances';
+is $i.pull-one, 3, 'pull-one reaches the last element';
+
+# A user class doing Iterable via such an iterator populates an array
+# assignment element-wise.
+class D does Iterable does Positional {
+    has Int $.error = 42;
+    method iterator { $[ $!error, "msg", 7 ].iterator }
+    method AT-POS (int $i) { $i == 0 ?? $!error !! $i == 1 ?? "msg" !! 7 }
+}
+
+my @ed = D.new;
+is @ed.elems, 3, 'my @a = $iterable reifies the user iterator';
+is @ed[0], 42, 'first element';
+is @ed[2], 7, 'third element';

--- a/t/multi-typed-array-param.t
+++ b/t/multi-typed-array-param.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# Multi dispatch on a typed array parameter with a definedness smiley:
+# `Field:D @fld` accepts a `my Field @f` argument — the :D constrains the
+# ELEMENTS, not the declared element type object, so the declared-type
+# comparison must strip it (Text::CSV's `multi method string`).
+
+plan 4;
+
+class Field { has $.v }
+
+multi sub g (--> Str) { my Field @f; g(@f) }
+multi sub g (Field:D @fld --> Str) { "sub got " ~ @fld.elems }
+
+is g(), "sub got 0", 'sub multi: empty typed array picks the @-candidate';
+
+class C {
+    multi method string (--> Str) {
+        my Field @f;
+        self.string(@f);
+    }
+    multi method string (Field:D @fld --> Str) {
+        "got " ~ @fld.elems;
+    }
+}
+
+my Field @e;
+is C.new.string(@e), "got 0", 'method multi: empty typed array from caller';
+is C.new.string, "got 0", 'method multi: internal re-dispatch with empty typed array';
+
+my Field @g2 = Field.new(:v(1)), Field.new(:v(2));
+is C.new.string(@g2), "got 2", 'method multi: populated typed array';

--- a/t/regex-interp-quote-var.t
+++ b/t/regex-interp-quote-var.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+# A scalar interpolated into a regex matches literally even when its value is
+# a quote character: the spliced `"` must be escaped or it reads as a
+# quoted-literal opener and swallows the rest of the pattern (Text::CSV's
+# combine/string quoting: / $q | $e /, s/// with quote vars).
+
+plan 7;
+
+my Str $q = '"';
+my Str $e = '"';
+my Str $s = ',';
+
+ok '"' ~~ / $e | x /, 'quote-var as FIRST alternation branch matches';
+ok 'x' ~~ / $e | x /, 'other branch still reachable';
+nok 'y' ~~ / $e | x /, 'non-matching input still fails';
+ok '"' ~~ /( $e | $s )/, 'quote-var inside a capture group parses';
+ok ',' ~~ / $e | $s | \r | \n /, 'comma matches through the alternation';
+
+my Str $t = 'I said, "Hi!"';
+$t.subst-mutate(/( $q | $e )/, { "$e$0" }, :g);
+is $t, 'I said, ""Hi!""', 'subst-mutate doubles embedded quotes';
+
+my Str $u = 'plain';
+$u.subst-mutate(/( $q )/, { "$e$0" }, :g);
+is $u, 'plain', 'no spurious matches on quote-free input';

--- a/t/slang-tuxic-activation.t
+++ b/t/slang-tuxic-activation.t
@@ -8,7 +8,7 @@ use Slang::Tuxic;
 # overrides flip the parser's spaced-call / spaced-methodop modes for the
 # rest of this compilation unit — and only this unit.
 
-plan 9;
+plan 11;
 
 sub foo($a, $b) { $a * $b }
 is foo (3, 5), 15, 'spaced call passes the paren contents as an arg list';
@@ -40,3 +40,9 @@ class WithPrivate {
     method pub () { self!mul (6, 7) }
     }
 is WithPrivate.new.pub, 42, 'spaced private methodop (self!m (args))';
+
+# IMPORTED functions (statement-level known calls like Test's `is`) take the
+# spaced-call reading too: `is (a, b, desc)` is a 3-arg call, not a listop
+# applied to one parenthesized List (every Text::CSV test line).
+is (3 + 4, 7, 'imported function spaced call binds the arg list');
+ok (1, 'imported ok spaced call keeps its description');


### PR DESCRIPTION
## Summary

First runtime-bug sweep of the Text::CSV suite (ADR-0026 CSV campaign). Baseline after the slang activation PRs: all 33 files parsed but every file aborted at the top — ~45 assertions ran of 22697 planned. Seven general-purpose interpreter fixes, each reduced to a slang-free minimal repro and pinned by a rakudo-verified `t/` test:

1. **`^add_method` aliasing a multi freezes to one candidate** (`runtime/methods_classhow_dispatch.rs`) — a `^find_method` carrier of a multi method is tagged `__mutsu_lookup_class/method` with no candidate index; `^add_method` now clones the whole candidate family for the new name instead of registering just the first candidate's signature. Text::CSV's BEGIN-time `alias` helper (`column-names` → the 4-candidate `column_names` multi) died with "Too few positionals" on every accessor alias. Pin: `t/addmethod-multi-alias.t`.

2. **Imported-function spaced calls under Slang::Tuxic** (`parser/stmt/simple/control_stmts.rs`) — statement-level known calls (Test's `is (...)`, `ok (...)`) treated the space-separated paren as one parenthesized List argument even in Tuxic mode; they now honor the spaced-call override like the expression-level path, so every Text::CSV assertion line binds its 3-arg list. Pin: two new cases in `t/slang-tuxic-activation.t`.

3. **Typed-array multi dispatch vs. `:D` element smiley** (`runtime/types/type_matching.rs`) — the source-constraint path compared `Field:D` against the source array's element type object `Field` without stripping the smiley (the metadata path already stripped it), so `my Field @f` never satisfied `Field:D @fld` and `Text::CSV.string` was unresolvable. Pin: `t/multi-typed-array-param.t`.

4. **Interpolated `"` breaks the regex alternation split** (`runtime/regex_parse_modifier.rs`) — `escape_regex_scalar_literal` escaped `'` but not `"`, so a scalar holding a quote char spliced a bare `"` into the pattern, which the alternation splitter read as a quoted-literal opener: `/ $q | x /` lost its `|` entirely (and `/( $q )/` died with "Unmatched ("). All of Text::CSV's combine/string quoting depends on this. Pin: `t/regex-interp-quote-var.t`.

5. **`.iterator` on an itemized array returns one opaque item** (`builtins/iterator_construct.rs`) — `$[1,2,3].iterator.pull-one` yielded the whole array once; it now iterates the elements (itemization only suppresses list-context flattening). `my @a = $iterable` on a class whose `iterator` returns `$[...] .iterator` (CSV::Diag) reified a single element. Pin: `t/iterator-itemized-array.t`.

6. **Bare `return` in expression position is inert** (`parser/primary/ident/identifier_call.rs`) — `$error and return;` parsed the RHS as a BareWord that resolved to the `&return` routine object and fell through; it now compiles as the zero-arg `&return` call (the control exception), like the `callframe`/`caller` precedent. A user-declared `\return` term still resolves first. Text::CSV `t/20_file.t`: aborted at test 18 → 176/176. Pin: `t/bare-return-expression.t`.

7. **C-style-for detector reads `;` inside paren comments** (`parser/stmt/control/for_loops.rs`) — `paren_has_toplevel_semicolon` skipped quoted strings but not `#` line comments, so `for (1, # has no ;\n 2) { }` was rejected as the obsolete C-style form. Text::CSV `t/80_diag.t` annotates its RFC7111 spec list exactly like that (file went 0 → 129 tests running). Pin: `t/for-paren-comment-semicolon.t`.

## Results

- Text::CSV `t/10_base.t`: **1/70 → 70/70**; `t/20_file.t`: **abort at 18 → 176/176**; `t/80_diag.t`: **0 → 129 running**.
- Whole suite: from ~45 assertions total to **3900+ assertions running across all 33 files** (most files now reach their tail; remaining failures are the next sweep's targets, e.g. `65_allow.t` 25 subtest failures, an `X::Assignment::RO` in `fragment`, an `Array[Str]` return-type check in `csv()`).
- Local `make test`: 3038 files / 28422 tests, all green. All new pins verified against rakudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)