### PR TITLE
fix(try): try blocks must implicitly turn on use fatal for their whole scope

### DIFF
--- a/news/2026-08/try-block-implicit-use-fatal.md
+++ b/news/2026-08/try-block-implicit-use-fatal.md
@@ -1,0 +1,51 @@
+# `try` blocks now implicitly turn on `use fatal` for their whole scope
+
+Per `raku-doc/doc/Language/exceptions.rakudoc`'s "try blocks" section: "A
+`try` block is a normal block which implicitly turns on the `use fatal`
+pragma". mutsu already had full `use fatal` pragma machinery (a
+`fatal_mode` flag on `Interpreter`, consulted at assignment and other sink
+points throughout the VM) for the explicit `use fatal;` form, but `try {}`
+never set it — only a Failure that happened to be the `try` block's own
+*trailing* expression was ever caught (a narrow special case already
+handled at the end of `exec_try_catch_op_inner`). Any other `fail()` inside
+the body — e.g. one assigned to a `my` variable mid-block — stayed a soft,
+unthrown `Failure`, so the `CATCH` block that was supposed to catch it never
+ran.
+
+Fixed by toggling `self.fatal_mode` around the whole `try`/`CATCH`/`CONTROL`
+region in `exec_try_catch_op` (`src/vm/vm_try_catch_ops.rs`), gated on
+`traps` — the flag that already distinguishes a genuine `try` from the
+implicit `TryCatch` wrapper the compiler adds around any block that merely
+*contains* a `CATCH`/`CONTROL` phaser (that wrapper is not `try` itself and
+correctly does not get implicit fatal, matching raku). This reuses all of
+the existing `fatal_mode`-gated sink points rather than adding a new
+mechanism.
+
+## Effect
+
+This was a general (Cro-independent) binding-semantics gap, not specific to
+any one construct — any code of the shape
+
+```raku
+try {
+    my $x = a_call_that_might_fail();
+    ...
+    CATCH { default { ... } }
+}
+```
+
+silently skipped its `CATCH` handler whenever the failing call was not the
+try block's last statement. In the Cro compatibility campaign, this exact
+pattern is `Cro::HTTP::Session::Persistent::process-requests`'s session
+loading (`try { my $session = self.load($cookie-value); $req.auth =
+$session; CATCH { default { $req.remove-cookie($!cookie-name); } } }`) — an
+expired or missing session's `fail('No such session')` never reached the
+`CATCH`, so `$req.auth` stayed a raw unhandled `Failure` instead of falling
+back to a fresh session, and the router's route param binding blew up with
+a 401 instead of serving a fresh session.
+
+`t/http-session-persistent.rakutest` (vendored Cro::HTTP suite): 12/19 (rc=1,
+died) → 19/19. `t/http-session-inmemory.rakutest`: also reaches 13/13
+(same root cause, a sibling `Session::InMemory` implementation).
+
+Pin: `t/try-block-implicit-use-fatal.t`.

--- a/src/vm/vm_try_catch_ops.rs
+++ b/src/vm/vm_try_catch_ops.rs
@@ -37,6 +37,18 @@ impl Interpreter {
                 None,
             );
         }
+        // A genuine `try` block implicitly turns on `use fatal` for its whole
+        // lexical scope (body and CATCH/CONTROL handlers alike) — an unhandled
+        // Failure sunk anywhere inside it throws immediately instead of staying
+        // a soft value, per raku-doc/doc/Language/exceptions.rakudoc's `try
+        // blocks` section. `traps` distinguishes a real `try` from the implicit
+        // TryCatch wrapper the compiler adds around any block that merely
+        // *contains* a CATCH/CONTROL phaser (that wrapper is not `try` itself
+        // and must not turn on fatal).
+        let saved_fatal_mode = self.fatal_mode;
+        if traps {
+            self.fatal_mode = true;
+        }
         let result = self.exec_try_catch_op_inner(
             code,
             catch_start,
@@ -48,6 +60,9 @@ impl Interpreter {
             ip,
             compiled_fns,
         );
+        if traps {
+            self.fatal_mode = saved_fatal_mode;
+        }
         if is_bare_block {
             self.truncate_routine_stack(routine_base);
         }

--- a/t/try-block-implicit-use-fatal.t
+++ b/t/try-block-implicit-use-fatal.t
@@ -1,0 +1,89 @@
+use Test;
+
+plan 8;
+
+# A `try` block is a normal block which implicitly turns on `use fatal` for
+# its whole lexical scope — body and CATCH/CONTROL handlers alike
+# (raku-doc/doc/Language/exceptions.rakudoc, "try blocks"). An unhandled
+# Failure sunk anywhere inside a `try` must throw immediately instead of
+# staying a soft value, even when it is not the try block's own final
+# expression (a mid-body statement's Failure was previously never sunk,
+# which broke code like Cro::HTTP::Session::Persistent's
+# `try { my $s = self.load($id); $req.auth = $s; CATCH { ... } }` — the
+# CATCH never fired for an expired/missing session).
+
+sub loadit() { fail("nope") }
+
+# The same call with no surrounding `try` stays a soft Failure (sanity check
+# that this is `try`-specific, not a general fail()-is-now-fatal change).
+{
+    my $x = loadit();
+    ok !$x.defined, "outside try, fail() stays a soft, undefined Failure";
+}
+
+# Inside `try`, an unhandled Failure assigned mid-body (not the try's last
+# expression) throws and is caught by CATCH.
+{
+    my $caught = False;
+    try {
+        my $y = loadit();
+        $caught = False; # would run if the assignment above didn't explode
+        CATCH { default { $caught = True; } }
+    }
+    ok $caught, "try makes a mid-body fail() throw, caught by CATCH";
+}
+
+# Without an explicit CATCH, `try` still contains the exception (implicit
+# CATCH), so the mid-body statement after the failing one never runs.
+{
+    my $ran-after = False;
+    try {
+        my $y = loadit();
+        $ran-after = True;
+    }
+    ok !$ran-after, "try without explicit CATCH still stops at the fail()";
+}
+
+# A bare block with a user CATCH (no `try`) does NOT get implicit fatal —
+# only genuine `try` does.
+{
+    my $ran-after = False;
+    {
+        my $y = loadit();
+        $ran-after = True;
+        CATCH { default { } }
+    }
+    ok $ran-after, "a bare block with CATCH (not try) does not imply use fatal";
+}
+
+# A declared return type on the callee does not, by itself, make fail() throw
+# outside of a `try` (this is `try`'s doing, not a return-type check).
+{
+    sub loadit_typed(--> Int) { fail("nope int") }
+    my $z = loadit_typed();
+    ok !$z.defined, "declared return type alone does not force an immediate throw";
+}
+
+# fatal_mode set by `try` extends into the CATCH handler body too.
+{
+    my $threw-in-catch = False;
+    dies-ok {
+        try {
+            die "boom";
+            CATCH {
+                default {
+                    loadit(); # this must throw, escaping the CATCH itself
+                    $threw-in-catch = False;
+                }
+            }
+        }
+    }, "fatal mode set by try is still active inside its own CATCH handler";
+}
+
+# The try's own final-expression Failure is still just caught into $! (not
+# exploded) — only a Failure *sunk mid-body* explodes.
+{
+    my $r = try { loadit() };
+    ok !$r.defined, "the try block's own trailing Failure result is not exploded";
+    is $!.^name, 'X::AdHoc', '$! is set to the trailing Failure exception';
+}


### PR DESCRIPTION
## Summary
- Per `raku-doc/doc/Language/exceptions.rakudoc`'s "try blocks" section: "A `try` block is a normal block which implicitly turns on the `use fatal` pragma".
- mutsu already has full `fatal_mode` machinery for explicit `use fatal;` (an `Interpreter` flag consulted at assignment and other sink points throughout the VM), but `try {}` never set it. Only a `Failure` that happened to be the try block's own *trailing* expression was ever caught (a narrow special case already handled separately at the end of `exec_try_catch_op_inner`) — a `fail()` result assigned to a `my` variable mid-body stayed a soft, unthrown `Failure`, so its `CATCH` handler never ran.
- Fix: toggle `self.fatal_mode` around the whole try/CATCH/CONTROL region in `exec_try_catch_op` (`src/vm/vm_try_catch_ops.rs`), gated on `traps` — the existing flag that distinguishes a genuine `try` from the implicit `TryCatch` wrapper the compiler adds around any block that merely *contains* a `CATCH`/`CONTROL` phaser (that wrapper is not `try` itself and correctly does not get implicit fatal, matching raku — verified against `raku` directly).
- Found via `Cro::HTTP::Session::Persistent`'s session loading (vendored Cro::HTTP suite, part of the ongoing Cro compatibility campaign), which uses exactly this pattern: `try { my $session = self.load($cookie-value); $req.auth = $session; CATCH { default { $req.remove-cookie($!cookie-name); } } }`. An expired/missing session's `fail('No such session')` never reached `CATCH`, so `$req.auth` stayed a raw unhandled `Failure` and the router's route param binding blew up with a 401 instead of falling back to a fresh session.

## Test plan
- [x] New pin test `t/try-block-implicit-use-fatal.t` (verified to also pass under real `raku`)
- [x] `make test` — all green
- [x] Existing `use fatal`/`try`/`Failure` test files (`t/use-fatal-pragma-scope.t`, `t/try-failure-bang.t`, `t/try-does-not-recatch-a-handled-failure.t`, `t/eval-does-not-leak-use-fatal.t`, and the broader `t/*fail*.t`/`t/*try*.t` sweep) still pass — no regression to the existing trailing-Failure / explicit-`use fatal` behavior
- [x] `t/http-session-persistent.rakutest` (vendored Cro::HTTP suite, not part of this repo): 12/19 (rc=1, died) → 19/19; `t/http-session-inmemory.rakutest` also reaches 13/13 (same root cause)
- [x] `cargo fmt` / `cargo clippy -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)