### PR TITLE
fix: typed container attrs keep element type; my-decl vs caller readonly param

### DIFF
--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1011,8 +1011,21 @@ impl Interpreter {
                                 | ValueView::Bag(_, false)
                         )
                     );
+                // A store with `vardecl_context` set IS a declaration (an
+                // expression-position `my` — `if (my $str = ...)` — compiles to
+                // MarkVarDeclContext + SetGlobal): it creates a FRESH variable,
+                // so a readonly marker left by a same-named CALLER binding (a
+                // method's readonly parameter `$str`) must not reject it, and
+                // the new variable is writable — unmark (journaled, so the
+                // caller's mark is restored when this frame exits).
+                // (Text::IO::String's `print` declaring `my Str $str` while
+                // called from `new (Str $str!)`.)
                 if !raw_mode && !is_bind_ctx && !is_bound_container {
-                    self.check_readonly_for_modify(&name)?;
+                    if self.vardecl_context {
+                        self.unmark_readonly(&name);
+                    } else {
+                        self.check_readonly_for_modify(&name)?;
+                    }
                 } else if raw_mode {
                     // Clear any previous readonly marking so this constant
                     // redeclaration can proceed (e.g., `constant sym` followed

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1201,6 +1201,10 @@ impl Interpreter {
                         val = self.tag_container_metadata(val, info);
                     }
                 }
+                // An attribute twigil (`@!c = ...` as a statement lands on
+                // SetGlobal): the element type lives in the class registry,
+                // which none of the name-keyed lookups above can see.
+                val = self.apply_attr_container_element_type(&name, val)?;
                 if let Some(constraint) = loan_env!(self, var_type_constraint(&name))
                     && !name.starts_with('%')
                     && !name.starts_with('@')

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -1,6 +1,57 @@
 use super::*;
 
 impl Interpreter {
+    /// `@!attr = ...` / `@.attr = ...` (and the `%` twins): the declared
+    /// element type lives in the class registry, not `var_type_constraints`,
+    /// so the plain container-assign paths produce an untyped Array/Hash.
+    /// Check the elements and re-embed the `Array[T]`/`Hash[T]` metadata so
+    /// the stored container keeps its type identity (`has Str @!cnames;` +
+    /// `@!cnames = @c.map(*.Str)` must still satisfy a `--> Array[Str]`
+    /// return check — Text::CSV's `column_names`). Non-attribute names and
+    /// unconstrained attributes pass through unchanged.
+    pub(super) fn apply_attr_container_element_type(
+        &mut self,
+        name: &str,
+        mut val: Value,
+    ) -> Result<Value, RuntimeError> {
+        if !(name.starts_with('@') || name.starts_with('%')) {
+            return Ok(val);
+        }
+        let Some((bare, _)) = crate::value::attr_twigil_base(name) else {
+            return Ok(val);
+        };
+        let Some(tc) = self.self_attr_type_constraint(bare) else {
+            return Ok(val);
+        };
+        if matches!(tc.as_str(), "Mu" | "Any") {
+            return Ok(val);
+        }
+        let elems: Option<Vec<Value>> = match val.view() {
+            ValueView::Array(items, _) => Some(items.iter().cloned().collect()),
+            ValueView::Hash(map) => Some(map.values().cloned().collect()),
+            _ => None,
+        };
+        let Some(elems) = elems else {
+            return Ok(val);
+        };
+        for item in &elems {
+            if !item.is_nil() && !self.type_matches_value(&tc, item) {
+                return Err(runtime::utils::type_check_element_typed_error(
+                    name, &tc, item,
+                ));
+            }
+        }
+        val = self.tag_container_metadata(
+            val,
+            crate::runtime::ContainerTypeInfo {
+                value_type: tc,
+                key_type: None,
+                declared_type: None,
+            },
+        );
+        Ok(val)
+    }
+
     pub(super) fn exec_assign_expr_op_inner(
         &mut self,
         code: &CompiledCode,
@@ -233,6 +284,7 @@ impl Interpreter {
         } else {
             Self::itemize_scalar_store(&name, Self::normalize_scalar_assignment_value(raw_val))
         };
+        val = self.apply_attr_container_element_type(&name, val)?;
         if val.is_nil()
             && let Some(def) = self.var_default(&name)
         {

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -245,6 +245,10 @@ impl Interpreter {
         }
         if name.starts_with('@') || name.starts_with('%') {
             val = self.coerce_typed_container_assignment(name, val, false)?;
+            // An attribute twigil's element type lives in the class registry,
+            // which the name-keyed coercion above cannot see.
+            let name = name.clone();
+            val = self.apply_attr_container_element_type(&name, val)?;
         }
         // Expression-context counterpart of the `SetLocal` attribute check: a
         // scalar attribute's declared type comes from the class registry, not

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1121,6 +1121,11 @@ impl Interpreter {
         // and the coercion above already produced the final value.
         if !is_bind && !is_constant && (name.starts_with('@') || name.starts_with('%')) {
             val = self.coerce_typed_container_assignment(name, val, has_explicit_initializer)?;
+            // An attribute twigil's element type lives in the class registry,
+            // which the name-keyed coercion above cannot see (`has Str @!c;
+            // @!c = @x` as a statement lands here).
+            let name = name.to_string();
+            val = self.apply_attr_container_element_type(&name, val)?;
         }
         // Raku `@array = ...` / `%hash = ...` assigns INTO the existing container,
         // so its `is default(...)` element default survives the reassignment

--- a/t/attr-typed-container-assign.t
+++ b/t/attr-typed-container-assign.t
@@ -1,0 +1,52 @@
+use v6;
+use Test;
+
+# Assignment to a typed container ATTRIBUTE (`has Str @!c`, `has Int %!h`)
+# keeps the declared element type: the stored container reads back as
+# Array[T]/Hash[T] and satisfies a matching return-type constraint, and a
+# wrong-typed element is rejected — the declared type lives in the class
+# registry, not the name-keyed lexical constraint map (Text::CSV's
+# `column_names (*@c --> Array[Str])` returning `has Str @!cnames`).
+
+plan 7;
+
+class WithArr {
+    has Str @!cnames;
+    method set (*@c --> Array[Str]) {
+        @c.elems and @!cnames = @c.map({.Str});
+        @!cnames;
+    }
+    method direct (*@x) { @!cnames = @x; @!cnames.WHAT }
+}
+
+my $c = WithArr.new;
+is-deeply $c.set("bar", "baz", "foo"), Array[Str].new("bar", "baz", "foo"),
+    'typed attr array returned through an Array[T] return constraint';
+is $c.set().elems, 3, 'state persists (empty call returns existing)';
+is $c.direct("a", "b").raku, 'Array[Str]', 'plain @!attr = @x keeps Array[T]';
+
+class WithHash {
+    has Int %!h;
+    method set (%v) { %!h = %v; %!h.WHAT }
+}
+is WithHash.new.set({a => 1}).raku, 'Hash[Int]', '%!attr = %v keeps Hash[T]';
+
+class BadElem {
+    has Int @!c;
+    method bad { @!c = "x" }
+}
+throws-like { BadElem.new.bad }, Exception,
+    message => /'expected Int but got Str'/,
+    'wrong-typed element is rejected';
+
+class Untyped {
+    has @!c;
+    method set (*@x) { @!c = @x; @!c.WHAT }
+}
+is Untyped.new.set(1, "b").raku, 'Array', 'untyped attr array stays plain Array';
+
+class MuTyped {
+    has Mu @!c;
+    method set (*@x) { @!c = @x; @!c.elems }
+}
+is MuTyped.new.set(1, Any), 2, 'Mu-typed attr accepts anything';

--- a/t/vardecl-shadows-readonly-param.t
+++ b/t/vardecl-shadows-readonly-param.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+# An expression-position `my` declaration (`if (my $str = ...)`) creates a
+# FRESH variable: a readonly marker left by a same-named parameter binding in
+# a CALLER frame must not reject it, and the new variable stays writable
+# (Text::IO::String's `print` declares `my Str $str` while called from
+# `multi method new (Str $str!)`).
+
+plan 4;
+
+class TS {
+    method print (*@what) {
+        if (my $str = @what.join("")) {
+            $str ~= "!";
+            return $str;
+        }
+        "empty";
+    }
+    method mk (Str $str!) { self.print($str) }
+}
+
+is TS.mk("abc"), "abc!", 'callee if-cond `my` shadows caller readonly param';
+is TS.mk(""), "empty", 'falsy branch unaffected';
+
+class RO {
+    method touch (Str $str!) {
+        # The parameter itself stays readonly even after a nested call
+        # declared (and unmarked) the same name in its own frame.
+        self.print-like($str);
+        try { $str = "nope" };
+        $! ?? "still-ro" !! "mutated";
+    }
+    method print-like (*@what) {
+        if (my $str = @what.join("")) { return $str }
+        "";
+    }
+}
+is RO.new.touch("x"), "still-ro", 'caller param mark restored after callee frame exits';
+
+sub outer (Str $str!) {
+    my $str2 = do if (my $str3 = $str ~ "y") { $str3 } else { "" };
+    $str2;
+}
+is outer("x"), "xy", 'sub frame variant parses and runs';

--- a/todo/deep/s17-supply-syntax-gc-stress-budget.md
+++ b/todo/deep/s17-supply-syntax-gc-stress-budget.md
@@ -1,0 +1,55 @@
+# S17-supply/syntax.t blows its gc-stress budget — interval/react wall-clock has regressed
+
+`roast/S17-supply/syntax.t` is the top entry in the CI flake survey (7
+failures, 6 of them on main pushes) and killed PR #6287's gc-stress job
+(run 31549980182: exit 124 at 75/90, `Failed: 0`). Measured 2026-08-12 on
+main (c42ec1e3b, release build, 12-core box):
+
+- Plain (no GC env): PASS in ~78 s wall / 515 CPU-s. The 2026-07-25 note
+  in `scripts/run-roast-test.sh` recorded 19-35 s for the same
+  configuration, so even the plain run is ~2-4x slower now (same box
+  class; background load differed, so treat as indicative).
+- gc-stress env (`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024
+  MUTSU_GC_VERIFY=1`) with CI's `MUTSU_ROAST_TIMEOUT_SCALE=2` (240 s
+  budget): **deterministic timeout at 70/90**, burning 2081 CPU-s at
+  ~950% CPU. Reproduced 4/4 (3x at scale 1 = 120 s stopping at 68/90,
+  1x at scale 2 = 240 s stopping at 70/90). Identical on the #6287
+  branch — this is main behavior, not a PR regression.
+
+The wall is at the interval-driven tests: test 70 (`No react guts crash
+...` — 5x react over `Supply.interval(.001)` with `done` after 50 ticks)
+and test 71 (`No races/crashes around interval that emits done` — 4
+threads x 500 reacts each over `supply { whenever Supply.interval(0.001)
+{ done } }`). Those 2000 short-lived reacts each poll a 1 ms interval;
+under GC_VERIFY each tick's allocation churn is verified, which is where
+the 950%-CPU spin goes.
+
+Why it matters: CI's gc-stress job passes or fails this file on runner
+load luck (PR #6289 passed the same code base minutes after #6287
+failed). Every red costs a manual re-trigger and erodes trust in
+gc-stress reds.
+
+What to do (in preference order per docs/flaky-test-policy.md):
+
+1. Root-cause the wall-clock regression since 2026-07-25 — candidates:
+   the worker-pool ADR-0020 slices (#5921-#5926, thread churn →
+   pooling changed interval scheduling), clone-slimming (#5928-#5934),
+   or interval polling itself. `perf` the test-70/71 loop under the
+   gc-stress env (`cargo build --profile profiling`).
+2. If the cost is inherent to GC_VERIFY on 1 ms interval churn, give the
+   file a bigger explicit budget in `scripts/run-roast-test.sh` (it
+   already has 120 s; the gc-stress 2x makes 240 s — measured need on a
+   loaded 12-core box is >240 s, so 240 base / 480 scaled) — with a
+   fresh measurement note.
+3. Only then consider `flaky-tests.txt` — but the policy bars
+   quarantining an ununderstood mechanism, and this one is a
+   deterministic-under-load budget miss, not non-determinism.
+
+Repro:
+
+```
+cargo build --release
+MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1 \
+MUTSU_ROAST_TIMEOUT_SCALE=2 MUTSU_FUDGE=1 MUTSU_BIN=target/release/mutsu \
+  prove -e 'scripts/run-roast-test.sh' roast/S17-supply/syntax.t
+```


### PR DESCRIPTION
## Summary

Text::CSV runtime sweep, round 2 (follows #6284). Two general-purpose fixes, both reduced to slang-free minimal repros and pinned by rakudo-verified `t/` tests:

1. **Typed container attributes lose their element type on assignment** (`vm/vm_misc_assign.rs` + the three container-assign paths) — `has Str @!cnames; @!cnames = @c.map(*.Str)` stored a plain untyped Array: the attribute's declared element type lives in the class registry, and none of the container-assign paths (SetGlobal for statement-form attr assigns, SetLocal/AssignExprLocal for slotted ones, AssignExpr for expression-context ones) consulted it — only *scalar* attributes had that fallback. The returned array then failed Text::CSV's `--> Array[Str]` return-type check on `column_names` (t/90_csv.t aborted at its first `csv()` call). New `apply_attr_container_element_type` resolves the element type via the existing `self_attr_type_constraint` MRO walk, type-checks the elements (raku rejects a wrong-typed element at assignment — error message matches rakudo verbatim), and re-embeds the `Array[T]`/`Hash[T]` metadata. Pin: `t/attr-typed-container-assign.t` (7 cases incl. untyped/Mu passthroughs).

2. **Expression-position `my` blocked by a caller's readonly parameter** (`vm/vm_exec_dispatch.rs`) — `if (my $str = ...)` in a method called from a frame whose readonly parameter is also named `$str` threw X::Assignment::RO: the MarkVarDeclContext + SetGlobal declaration path ran the readonly check as if it were a plain assignment. A declaration creates a fresh variable — unmark instead (journaled in the readonly undo log, so the caller's mark is restored on frame exit). This unblocked `Text::IO::String.new` entirely (its `print` declares `my Str $str` while called from `multi method new (Str $str!)`), which unblocks every Text::CSV test that builds an in-memory IO handle. Pin: `t/vardecl-shadows-readonly-param.t` (incl. the caller-mark-restored case).

## Results

- Text::CSV `t/80_diag.t`: aborted at the fragment loop → **170/171** (`fragment` now raises the proper CSV::Diag error 2013; the last failure is a separate `[ $iterable ]` list-composer bug).
- `t/90_csv.t`: past the `Array[Str]` return-type abort, now failing on `csv()` header semantics (next sweep target).
- Local `make test`: 3041 files / 28440 tests, all green. Targeted roast sanity (S12-attributes, S09-typed-arrays, S06-traits readonly/copy): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)