### PR TITLE
fix: single Iterable instance in a bracket array reifies via its iterator

### DIFF
--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -1,7 +1,12 @@
 use super::*;
 
 impl Interpreter {
-    pub(super) fn exec_make_array_op(&mut self, code: &CompiledCode, n: u32, is_real_array: bool) {
+    pub(super) fn exec_make_array_op(
+        &mut self,
+        code: &CompiledCode,
+        n: u32,
+        is_real_array: bool,
+    ) -> Result<(), RuntimeError> {
         let n = n as usize;
         let start = self.stack.len() - n;
         let raw: Vec<Value> = self.stack.drain(start..).collect();
@@ -88,7 +93,7 @@ impl Interpreter {
                     && let Some(lazy) = runtime::utils::infinite_int_range_to_lazy_array(&val) =>
                 {
                     self.stack.push(lazy);
-                    return;
+                    return Ok(());
                 }
                 // A single genuinely-*infinite* lazy list (an infinite `...`
                 // sequence like `[1,2,3...*]` / `[-Inf...Inf]`, or a lazy map/grep
@@ -105,13 +110,27 @@ impl Interpreter {
                     self.stack.push(Value::lazy_list(crate::gc::Gc::new(
                         ll.with_array_context(),
                     )));
-                    return;
+                    return Ok(());
                 }
                 // In bracket-array literals (`[...]`), a single element is in
                 // list context and should flatten one level (e.g. `[2..6]`,
                 // `[@a]`, `[(1,2,3)]`), while multi-element forms keep each
                 // element itemized (e.g. `[(1,2),(3,4)]`).
-                _ if is_real_array && n == 1 => elems.extend(runtime::value_to_list(&val)),
+                _ if is_real_array && n == 1 => {
+                    // A single user Iterable instance reifies through its own
+                    // `iterator` method, exactly like `my @a = $iterable`
+                    // (`[ $csv.error_diag ]` lists CSV::Diag's six fields —
+                    // Text::CSV t/80_diag.t). Multi-element forms keep the
+                    // instance whole, matching raku. (A Buf/Blob instance has
+                    // no user `iterator`, so it takes its dedicated arm above.)
+                    if matches!(val.view(), ValueView::Instance { .. })
+                        && let Some(items) = self.try_iterable_instance_items(&val)?
+                    {
+                        elems.extend(items);
+                    } else {
+                        elems.extend(runtime::value_to_list(&val));
+                    }
+                }
                 _ => elems.push(val),
             }
         }
@@ -120,6 +139,7 @@ impl Interpreter {
         } else {
             self.stack.push(Value::array(elems));
         }
+        Ok(())
     }
 
     /// Like `exec_make_array_op` with `is_real_array=true` but never flattens

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3014,12 +3014,12 @@ impl Interpreter {
                 // A user-overloaded list-associative `infix:<,>` intercepts the
                 // bare value-list before it becomes a List.
                 if !self.try_comma_overload(*n)? {
-                    self.exec_make_array_op(code, *n, false);
+                    self.exec_make_array_op(code, *n, false)?;
                 }
                 *ip += 1;
             }
             OpCode::MakeRealArray(n) => {
-                self.exec_make_array_op(code, *n, true);
+                self.exec_make_array_op(code, *n, true)?;
                 *ip += 1;
             }
             OpCode::MakeRealArrayNoFlatten(n) => {

--- a/t/array-composer-iterable-instance.t
+++ b/t/array-composer-iterable-instance.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+# A SINGLE user Iterable instance in a bracket array reifies through its own
+# `iterator` method — `[ $csv.error_diag ]` lists CSV::Diag's six fields
+# (Text::CSV t/80_diag.t "OK in list context"). Multi-element forms and
+# $-variable elements keep the instance whole, matching raku.
+
+plan 5;
+
+class D does Iterable does Positional {
+    has Int $.a = 1;
+    method iterator { $[ $!a, "b", 3 ].iterator }
+    method AT-POS (int $i) { $i == 0 ?? $!a !! $i == 1 ?? "b" !! 3 }
+}
+
+is [ D.new ].elems, 3, 'single Iterable instance flattens via its iterator';
+is-deeply [ D.new ], [1, "b", 3], 'elements come from the user iterator';
+is [ D.new, D.new ].elems, 2, 'multi-element form keeps instances whole';
+
+my $d = D.new;
+is [ $d ].elems, 1, '$-variable element stays itemized';
+
+class Plain { has $.x = 5 }
+is [ Plain.new ].elems, 1, 'non-Iterable instance stays whole';


### PR DESCRIPTION
## Summary

Text::CSV runtime sweep, round 3 (follows #6284/#6287). `[ $csv.error_diag ]` kept the CSV::Diag instance as ONE element where raku lists its six fields: the `[x]` single-element flatten used `value_to_list`, which treats a user Iterable instance as opaque. Route it through `try_iterable_instance_items` (the same helper `my @a = $iterable` uses since #6284), only in the single-element real-array arm — multi-element forms and `[$scalar]` (MakeRealArrayNoFlatten) keep the instance whole, matching raku (all three shapes verified against rakudo: `[D.new]` → 3, `[D.new, D.new]` → 2, `[$d]` → 1).

`exec_make_array_op` becomes `Result`-returning so the user-iterator drive can propagate errors.

- Pin: `t/array-composer-iterable-instance.t` (rakudo-verified, 5 cases incl. the kept-whole shapes).
- Text::CSV `t/80_diag.t` test 3 "OK in list context" passes (the file's remaining gate is #6287's readonly fix).
- Local `make test`: 3040 files / 28434 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)