### PR TITLE
docs+instrumentation(adr): ADR-0019 E7 step 1, shadow-check run_instance_method's VM carrier sites

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3271,6 +3271,38 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   carrier sites, qualified, private-as-sequence-query, `.^lookup`/`.^can`/`.^methods` reading
   the call-path sequence, WALK, re-entrant carriers). The `.^can` dummy-`Value::NIL` probe is
   replaced by an E2 row lookup — a correctness fix as well as a routing change.
+  **Progress 2026-08-12** (first consumer family, `run_instance_method` carrier sites, shadow-
+  measurement only): `run_instance_method`/`run_instance_method_celled`
+  (`runtime/class_dispatch.rs`) gained an optional `site: &'static str` tag, threaded through
+  every one of their ~16 call sites as `""` (a no-op) except `vm_core_helpers::vm_run_instance_method`
+  — the carrier's **only** two live callers, `CallDefined`'s user `.defined` and `SinkPop`'s user
+  `.sink` in `vm_exec_dispatch.rs` — which now passes `"run_instance_method:vm-carrier"`. When
+  tagged, `run_instance_method_celled` reuses E4a's `Interpreter::shadow_check_resolver` (the
+  same probe already wired at `resolve_method_cached`'s two boundaries) to compare its own
+  ad-hoc `resolve_method_with_owner_invocant` MRO walk against the E4 resolver's
+  `resolve_sequence`, plus the E5/E6 generic `record_dispatch_entry_outcome`/`_intercept`
+  counters under a new `"runinstancemethod"` entry key (arm name = the called method name, since
+  this carrier's only two shapes are `.defined`/`.sink`). Pure insertion, zero behavior change
+  (every added branch is `MUTSU_VM_STATS`-gated). Swept full `t/` (3040 files) plus a 124-file
+  roast slice (`S12-methods`, `S12-attributes`, `S14-roles`, `S02-types` — chosen for
+  metaobject/instance-dispatch relevance): the new site fired 102 times across 4 `t/` files
+  (0 in the roast slice — those directories don't happen to exercise `.defined`/`.sink` on a
+  user-overridable receiver) with **zero shadow mismatches at this site in either sweep** — this
+  consumer family's ad-hoc resolution already agrees with the E4 resolver for all its actual
+  traffic, so (unlike E6c) there is no gap to fix here. The sweep did surface 10 (`t/`) + 1
+  (roast slice) mismatches overall, but every one is tagged `resolve_method_cached:fresh` — the
+  pre-existing, unrelated E4a boundary, not this box's new site — confirmed byte-identical
+  (same class/method/real/shadow detail strings) against the pre-E7 commit (10ecbd371) with this
+  change reverted. All belong to E4a's already-documented explained bucket (the E8-deferred
+  early-stopping rule: a non-multi method resolves by name in the real ad-hoc walk even when its
+  typed signature does not bind the call, e.g. `method set(Int $x)` called via `$h.set("x")`) —
+  this wider sweep just found more instances (10 vs. E4a's original 3) of the same bucket, not a
+  new finding; out of scope for E7. `cargo clippy -- -D warnings` / `cargo fmt` clean; full `t/`
+  (3040 files/28,437 tests) green. Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md`
+  §"E7 step 1: `run_instance_method` carrier sites — clean shadow-check, no cutover needed".
+  **This consumer family needs no further work** (a shadow-only zero-mismatch result is itself
+  the box's answer for this family — there is no ad-hoc-vs-resolver divergence to route around).
+  Next E7 sub-slice: qualified dispatch / private-as-sequence-query, per the design's ordering.
 - [ ] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
   **Design 2026-08-10** (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`):

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -57,6 +57,39 @@ impl Interpreter {
         args: Vec<Value>,
         invocant: Option<Value>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
+        self.run_instance_method_at(
+            "",
+            receiver_class_name,
+            attributes,
+            method_name,
+            args,
+            invocant,
+        )
+    }
+
+    /// Same as [`Self::run_instance_method`], but tags the call with an ADR-0019
+    /// Phase E box E7 dispatch-resolver measurement `site` so
+    /// [`Self::run_instance_method_celled`] shadow-checks its ad-hoc
+    /// `resolve_method_with_owner_invocant` MRO walk against the E4 resolver
+    /// (`resolution_sequence::resolve_sequence`) for that call specifically.
+    /// An empty `site` -- what [`Self::run_instance_method`] passes -- disables
+    /// the probe entirely, so this is a genuine no-op for every caller except
+    /// the one tagged by E7's first sub-slice
+    /// (`vm_core_helpers::vm_run_instance_method`, reached only from the two VM
+    /// call sites in `vm_exec_dispatch.rs`: `CallDefined`'s user `.defined` and
+    /// `SinkPop`'s user `.sink`). Per Phase E's "one consumer family per
+    /// sub-PR" rule, the ~14 other `run_instance_method` callers (`new`,
+    /// qualified dispatch, `handles`, coercion, ...) stay unmeasured until
+    /// their own E7 sub-slice tags them with a distinct site name.
+    pub(crate) fn run_instance_method_at(
+        &mut self,
+        site: &'static str,
+        receiver_class_name: &str,
+        attributes: AttrMap,
+        method_name: &str,
+        args: Vec<Value>,
+        invocant: Option<Value>,
+    ) -> Result<(Value, AttrMap), RuntimeError> {
         let cell = invocant.as_ref().and_then(Self::self_instance_attrs);
         let fallback = if cell.is_none() {
             Some(attributes.clone())
@@ -64,6 +97,7 @@ impl Interpreter {
             None
         };
         let (v, reconciled) = self.run_instance_method_celled(
+            site,
             receiver_class_name,
             &attributes,
             method_name,
@@ -89,6 +123,7 @@ impl Interpreter {
     /// so both this slow path and the VM fast path are covered.)
     pub(crate) fn run_instance_method_celled(
         &mut self,
+        site: &'static str,
         receiver_class_name: &str,
         attributes: &AttrMap,
         method_name: &str,
@@ -106,12 +141,45 @@ impl Interpreter {
                 attributes.clone(),
             )
         };
-        let Some((owner_class, method_def)) = self.resolve_method_with_owner_invocant(
+        let resolved = self.resolve_method_with_owner_invocant(
             receiver_class_name,
             method_name,
             &args,
             &inv_value,
-        ) else {
+        );
+        // ADR-0019 Phase E box E7 (first consumer family, see
+        // `Self::run_instance_method_at`'s doc comment): shadow-check this
+        // carrier's ad-hoc MRO walk against the E4 resolver's
+        // `resolve_sequence`, reusing the exact `shadow_check_resolver` probe
+        // E4a wired at `resolve_method_cached`'s two boundaries
+        // (`vm_call_method_compiled_cache.rs`). `record_dispatch_entry_intercept`/
+        // `_outcome` reuse the generic E5/E6 dispatch-entry counters under a new
+        // entry key ("runinstancemethod") -- the per-arm histogram (arm = method
+        // name) is the traffic-shape breakdown; `notfound` is the sole other
+        // outcome, since this carrier has no native/accessor fast path of its
+        // own to record. A no-op unless `site` is non-empty AND `MUTSU_VM_STATS`
+        // is set: zero behavior change.
+        if !site.is_empty() {
+            let method_sym = Symbol::intern(method_name);
+            self.shadow_check_resolver(
+                site,
+                receiver_class_name,
+                method_name,
+                method_sym,
+                &args,
+                &inv_value,
+                resolved.as_ref(),
+            );
+            if resolved.is_some() {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "runinstancemethod",
+                    method_name,
+                );
+            } else {
+                crate::vm::vm_stats::record_dispatch_entry_outcome("runinstancemethod", "notfound");
+            }
+        }
+        let Some((owner_class, method_def)) = resolved else {
             // Distinguish X::Multi::NoMatch (method exists but no candidate
             // matched) from X::Method::NotFound (method does not exist at all,
             // e.g. submethod on ancestor only).

--- a/src/runtime/ctor_phase_plan.rs
+++ b/src/runtime/ctor_phase_plan.rs
@@ -251,6 +251,7 @@ impl Interpreter {
                         r
                     } else {
                         self.run_instance_method_celled(
+                            "",
                             mro_class,
                             probe,
                             method_name,

--- a/src/vm/vm_core_helpers.rs
+++ b/src/vm/vm_core_helpers.rs
@@ -103,8 +103,21 @@ impl Interpreter {
         args: Vec<Value>,
         invocant: Option<Value>,
     ) -> Result<(Value, AttrMap), RuntimeError> {
+        // ADR-0019 Phase E box E7, first sub-slice: this is the carrier's ONLY
+        // two live callers (`CallDefined`'s user `.defined`, `SinkPop`'s user
+        // `.sink` in `vm_exec_dispatch.rs`), so tag them with a dedicated
+        // measurement site -- see `Interpreter::run_instance_method_at`'s doc
+        // comment for what the tag enables and why every other
+        // `run_instance_method` caller stays untagged (`""`).
         self.loan_env_for(|i| {
-            i.run_instance_method(receiver_class_name, attributes, method_name, args, invocant)
+            i.run_instance_method_at(
+                "run_instance_method:vm-carrier",
+                receiver_class_name,
+                attributes,
+                method_name,
+                args,
+                invocant,
+            )
         })
     }
 

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -1882,3 +1882,53 @@ confirmed pre-existing, not a regression. `cargo clippy -- -D warnings` / `cargo
 needed a two-line fix one level below the opcode it was filed against, closing the same hole for
 both dynamic and static mut dispatch at once. **All of E6 (E6a, E6b, E6c, E6d) is now closed.**
 Next: E7 (metaobject, qualified, and re-entrant calls).
+
+## E7 step 1: `run_instance_method` carrier sites — clean shadow-check, no cutover needed
+
+`run_instance_method`/`run_instance_method_celled` (`runtime/class_dispatch.rs`) is the
+interpreter slow-path carrier for instance-method dispatch used by ~16 call sites across
+`runtime/` (`new`, coercion, `handles`, qualified dispatch, ...) plus exactly two VM opcode
+sites, reached via `vm_core_helpers::vm_run_instance_method`: `CallDefined`'s user `.defined`
+and `SinkPop`'s user `.sink` (`vm_exec_dispatch.rs`). Per the design's "one consumer family per
+sub-PR" rule, this slice measures only those two VM sites — the carrier's other ~14 callers stay
+untouched and untagged for a later E7 sub-slice.
+
+**Mechanism**: both functions gained an optional `site: &'static str` parameter. Every existing
+caller passes `""` through a preserved-signature `run_instance_method` (now a thin wrapper over
+a new `run_instance_method_at(site, ...)`), so the change is behavior-invisible everywhere except
+`vm_run_instance_method`, which now passes `"run_instance_method:vm-carrier"`. When `site` is
+non-empty, `run_instance_method_celled` calls E4a's existing `Interpreter::shadow_check_resolver`
+(the same probe already wired at `resolve_method_cached`'s two boundaries) to compare this
+carrier's own ad-hoc `resolve_method_with_owner_invocant` MRO walk against the E4 resolver's
+`resolve_sequence` answer for the identical `(receiver, method, args)`, and records the outcome
+under the E5/E6 generic dispatch-entry counters with entry key `"runinstancemethod"` (the arm
+name is the called method name — always `defined` or `sink` at this site, confirming no other
+call ever exercises the tagged carrier).
+
+**Sweep**: full local `t/` (3040 files, debug binary) plus a 124-file roast slice
+(`S12-methods`, `S12-attributes`, `S14-roles`, `S02-types` — chosen for metaobject/instance
+dispatch relevance). The new `runinstancemethod` counters fired 102 times across 4 `t/` files
+(0 in the roast slice — those directories don't happen to call `.defined`/`.sink` on a receiver
+where the ad-hoc/resolver answer could plausibly diverge) — **zero shadow mismatches at the new
+site in either sweep**.
+
+**The 10 (`t/`) + 1 (roast slice) mismatches the raw sweep total did show are a false lead**: the
+`resolver_shadow_checks`/`_mismatches` atomics are shared globally across every
+`shadow_check_resolver` call site, so a naive total conflates this box's new site with E4a's
+pre-existing `resolve_method_cached:fresh`/`:cached` boundaries. Every one of the 11 mismatches
+is tagged `resolve_method_cached:fresh` in the per-mismatch detail string, not
+`run_instance_method:vm-carrier`. Rebuilding at the pre-E7 commit (10ecbd371, this change fully
+reverted) and re-running the same 7 files reproduces byte-identical counts and detail strings
+(e.g. `t/type-check.t`: `class=Holder method=set real=Some("Holder") shadow=None`), proving these
+are pre-existing E4a findings, not something this slice introduced or need fix. They all match
+E4a's own already-documented explained bucket (the E8-deferred early-stopping rule: a non-multi
+method resolves by name in the real ad-hoc walk even when its typed signature does not bind the
+call — e.g. `method set(Int $x)` called via `$h.set("x")`, a `Str`) — this wider full-`t/` sweep
+just surfaced more instances of that same bucket (10-11 vs. E4a's original narrower-sweep count
+of 3), not a new mismatch class. No action needed; still tracked under E4a/E8.
+
+**Conclusion**: this consumer family needs no cutover fix — a clean, zero-mismatch shadow-check
+result is itself the box's answer here (unlike E6c, which found and fixed a real divergence).
+`cargo clippy -- -D warnings` / `cargo fmt` clean; full `t/` (3040 files/28,437 tests) green.
+Next E7 sub-slice: qualified dispatch / private-as-sequence-query, per the design's consumer
+ordering above.


### PR DESCRIPTION
## Summary
- Starts ADR-0019 Phase E box E7 (metaobject/qualified/re-entrant calls through the resolver), now that E1-E6 are all closed. First consumer family: `run_instance_method`'s two live VM call sites (`CallDefined`'s user `.defined`, `SinkPop`'s user `.sink`).
- Tags those two sites with a dedicated `MUTSU_VM_STATS` site so `run_instance_method_celled`'s ad-hoc `resolve_method_with_owner_invocant` MRO walk is shadow-compared against the E4 resolver's `resolve_sequence`, reusing E4a's existing `shadow_check_resolver` probe. Pure insertion, zero behavior change (every new branch is gated on `MUTSU_VM_STATS`).
- A full `t/` (3040 files) + 124-file roast slice (S12-methods, S12-attributes, S14-roles, S02-types) sweep found **zero mismatches at the new site** — this consumer family's ad-hoc resolution already agrees with the resolver for all its actual traffic, so no cutover fix is needed here (unlike E6c, which found a real gap). Full write-up in the ADR and `todo/deep/adr0019-e5-e7-entry-routing.md`.
- The sweep's other 10 (`t/`) + 1 (roast) mismatches all belong to E4a's pre-existing, already-documented explained bucket at a *different*, unrelated site (`resolve_method_cached:fresh`) — confirmed by reproducing them byte-identically on the pre-E7 commit (10ecbd371) with this change reverted. Not a new finding, out of scope here.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` all clean
- [x] Full local `t/` suite: 3040 files / 28,437 tests, PASS
- [x] Targeted `MUTSU_VM_STATS=1` sweep over `t/` + a 124-file roast slice confirming zero mismatches at the new shadow-check site
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)