### PR TITLE
docs+instrumentation(adr): ADR-0019 E7 step 2, shadow-check qualified dispatch's resolve_method_with_owner fallback

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3303,6 +3303,43 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   **This consumer family needs no further work** (a shadow-only zero-mismatch result is itself
   the box's answer for this family — there is no ad-hoc-vs-resolver divergence to route around).
   Next E7 sub-slice: qualified dispatch / private-as-sequence-query, per the design's ordering.
+  **Progress 2026-08-12** (second consumer family, qualified dispatch, shadow-measurement only):
+  `dispatch_qualified_instance_method`'s (`runtime/methods_qualified.rs`) sole generic fallback —
+  `self.resolve_method_with_owner(qualifier, actual_method, &args)`, reached for `self.Owner::method(...)`
+  calls after the read-attribute/role-concretization/metamodel/qualified-`new`/native-ancestor
+  special cases all miss — is now shadow-checked. Unlike E7 step 1, this callsite has no receiver
+  *value* of the resolution target's type to derive an MRO chain from (the walk is rooted at the
+  qualifier class NAME, not the instance), so `shadow_check_resolver` (E4a) was split: it is now a
+  thin wrapper that derives `chain = self.dispatch_mro(invocant)` and delegates to a new
+  `shadow_check_resolver_chain(site, class_name, method, method_sym, arg_values, invocant:
+  Option<&Value>, chain: &[TypeId], real)` — the existing three callers (the two
+  `resolve_method_cached` boundaries plus E7 step 1's `run_instance_method_celled`) are unchanged
+  by the split. The new call site builds its own chain via
+  `self.dispatch_mro(&Value::package(Symbol::intern(qualifier)))` and passes `invocant: None`
+  (matching how `resolve_method_with_owner` itself calls `resolve_method_with_owner_impl(...,
+  invocant: None)` for this exact case), recording outcomes under a new `"qualifieddispatch"`
+  entry key (arm = the called method name). `dispatch_qualified_instance_method` has exactly one
+  caller, so the probe is gated inline with `crate::vm::vm_stats::enabled()` rather than threaded
+  through a `site` parameter — there is no second call site to tag differently yet.
+  **Sweep**: full local `t/` (3047 files) plus the same 10-file roast slice used for the search
+  (`S12-class/inheritance.t`, `S12-construction/new.t`, `S12-methods/{delegation,qualified,
+  accessors,submethods}.t`, `S14-roles/{basic,conflicts,lexical,submethods-6e}.t`, all already
+  whitelisted, found by grepping roast for `self.Owner::method`/`$obj.Owner::method` patterns).
+  Unlike step 1, this consumer family sees real traffic: the new site fired 113 times across 13
+  `t/` files and 40 times across 8 of the 10 roast files — **zero shadow mismatches at
+  `qualifieddispatch` in either sweep**. The sweep's 10 total `resolver_shadow_mismatches` (all in
+  the `t/` portion; the roast slice alone was 247 checks / 0 mismatches) are every one tagged
+  `resolve_method_cached:fresh` in the mismatch detail, the same pre-existing E4a "non-multi method
+  resolves by name independent of argument bind" bucket step 1 already root-caused and confirmed
+  reproduces on the pre-E7 baseline — not a new finding, and not this box's site.
+  `cargo clippy -- -D warnings` / `cargo fmt` clean; full `t/` (3047 files/28,481 tests) green; the
+  10-file roast slice green (203 tests). Full detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 2: qualified dispatch — clean shadow-check,
+  no cutover needed". **This consumer family also needs no further work.** `dispatch_qualified_mixin_method`
+  and `dispatch_qualified_non_instance_method` in the same file share the identical
+  `resolve_method_with_owner` fallback shape but are deliberately left untagged for a later E7
+  sub-slice (one consumer family per sub-PR). Next E7 sub-slice: private-as-sequence-query, per
+  `todo/deep/adr0019-e5-e7-entry-routing.md`'s consumer list.
 - [ ] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
   **Design 2026-08-10** (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`):

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -352,9 +352,46 @@ impl Interpreter {
             }
         }
         // Try running the actual method on the qualifier class
-        if let Some((_owner, method_def)) =
-            self.resolve_method_with_owner(qualifier, actual_method, &args)
-        {
+        let resolved = self.resolve_method_with_owner(qualifier, actual_method, &args);
+        // ADR-0019 Phase E box E7 (second consumer family, qualified dispatch —
+        // see `todo/deep/adr0019-e5-e7-entry-routing.md` "E7 step 2"):
+        // shadow-check this ad-hoc `resolve_method_with_owner` MRO walk
+        // against the E4 resolver's `resolve_sequence`, for the chain rooted
+        // at the QUALIFIER class (not the receiver's own chain — a qualified
+        // call resolves relative to `qualifier`, e.g. `self.Mu::Str`, so the
+        // shadow chain must be too). `dispatch_qualified_instance_method` has
+        // exactly one caller (`methods_call_dispatch.rs`), so this is gated
+        // inline rather than threaded through a `site` parameter like
+        // `run_instance_method_at` (E7 step 1) — no other call site exists to
+        // tag differently. `record_dispatch_entry_intercept`/`_outcome` reuse
+        // the generic E5/E6 dispatch-entry counters under a new entry key
+        // ("qualifieddispatch"); the per-arm histogram (arm = the called
+        // method name) is the traffic-shape breakdown, mirroring E7 step 1's
+        // choice. A no-op unless `MUTSU_VM_STATS` is set: zero behavior
+        // change.
+        if crate::vm::vm_stats::enabled() {
+            let method_sym = Symbol::intern(actual_method);
+            let qualifier_chain = self.dispatch_mro(&Value::package(Symbol::intern(qualifier)));
+            self.shadow_check_resolver_chain(
+                "qualifieddispatch",
+                qualifier,
+                actual_method,
+                method_sym,
+                &args,
+                None,
+                &qualifier_chain,
+                resolved.as_ref(),
+            );
+            if resolved.is_some() {
+                crate::vm::vm_stats::record_dispatch_entry_intercept(
+                    "qualifieddispatch",
+                    actual_method,
+                );
+            } else {
+                crate::vm::vm_stats::record_dispatch_entry_outcome("qualifieddispatch", "notfound");
+            }
+        }
+        if let Some((_owner, method_def)) = resolved {
             let attrs_map = attributes.to_map();
             let (result, updated) = match self.run_instance_method(
                 qualifier,

--- a/src/runtime/resolution_sequence.rs
+++ b/src/runtime/resolution_sequence.rs
@@ -222,10 +222,58 @@ impl Interpreter {
         if !crate::vm::vm_stats::enabled() {
             return;
         }
-        let saved_ambiguous = self.dispatch_ambiguous;
         let chain = self.dispatch_mro(invocant);
-        let native_shape = NativeCallShape::new(arg_values.len(), value_is_definite(invocant));
-        let seq = self.resolve_sequence(&chain, method_sym, native_shape);
+        self.shadow_check_resolver_chain(
+            site,
+            class_name,
+            method,
+            method_sym,
+            arg_values,
+            Some(invocant),
+            &chain,
+            real,
+        );
+    }
+
+    /// The `chain`/`invocant`-parametrized core of [`Self::shadow_check_resolver`]
+    /// (ADR-0019 Phase E box E7, second consumer family — qualified dispatch,
+    /// `todo/deep/adr0019-e5-e7-entry-routing.md` "E7 step 2"). Extracted so a
+    /// caller with no receiver *value* of the resolution target's type — e.g.
+    /// `self.Owner::method(...)`, where the chain must be rooted at the
+    /// qualifier class NAME rather than derived from an instance — can still
+    /// reuse the exact same shadow-ranking logic by passing a chain it built
+    /// itself (typically via `self.dispatch_mro(&Value::package(...))`) and
+    /// `invocant: None`. [`Self::shadow_check_resolver`] remains a thin
+    /// wrapper over this for its own receiver-chain callers, so their
+    /// behavior is unchanged by this split.
+    ///
+    /// A `None` invocant is treated as "not DEFINITE" for the native-row
+    /// shape (mirroring [`value_is_definite`]'s treatment of a bare type
+    /// object/`Package`) and skips the invocant type-constraint check inside
+    /// `method_args_match_for_invocant` entirely (that function already
+    /// handles `Option<&Value>` this way) — both match how
+    /// `resolve_method_with_owner`'s registry-only walk itself calls
+    /// `resolve_method_with_owner_impl(..., invocant: None)` for the case
+    /// this is shadowing.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn shadow_check_resolver_chain(
+        &mut self,
+        site: &'static str,
+        class_name: &str,
+        method: &str,
+        method_sym: Symbol,
+        arg_values: &[Value],
+        invocant: Option<&Value>,
+        chain: &[TypeId],
+        real: Option<&(Symbol, MethodDef)>,
+    ) {
+        if !crate::vm::vm_stats::enabled() {
+            return;
+        }
+        let saved_ambiguous = self.dispatch_ambiguous;
+        let definite = invocant.map(value_is_definite).unwrap_or(false);
+        let native_shape = NativeCallShape::new(arg_values.len(), definite);
+        let seq = self.resolve_sequence(chain, method_sym, native_shape);
         let has_where_candidate = seq.candidates.iter().any(|c| {
             let ResolvedCandidate::User { def, .. } = c else {
                 return false;
@@ -248,12 +296,12 @@ impl Interpreter {
                 def,
                 arg_values,
                 role_bindings.as_ref(),
-                Some(invocant),
+                invocant,
             ) {
                 matched.push((owner.symbol(), (**def).clone()));
             }
         }
-        let shadow = self.pick_method_winner(&mro, arg_values, Some(invocant), matched);
+        let shadow = self.pick_method_winner(&mro, arg_values, invocant, matched);
         self.dispatch_ambiguous = saved_ambiguous;
         let matched_ok = match (real, shadow.as_ref()) {
             (None, None) => true,

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -1932,3 +1932,83 @@ result is itself the box's answer here (unlike E6c, which found and fixed a real
 `cargo clippy -- -D warnings` / `cargo fmt` clean; full `t/` (3040 files/28,437 tests) green.
 Next E7 sub-slice: qualified dispatch / private-as-sequence-query, per the design's consumer
 ordering above.
+
+## E7 step 2: qualified dispatch — clean shadow-check, no cutover needed
+
+`dispatch_qualified_instance_method` (`runtime/methods_qualified.rs`) handles
+`self.Owner::method(...)`-style qualified calls (`self.Mu::Str`, `$obj.SomeRole::method`, ...). It
+runs several special-cased branches first (public-attribute read, single-concretization role
+dispatch, metamodel `Metamodel::ClassHOW::*` dispatch, qualified `new` on an existing instance,
+native-ancestor fallback) before reaching its one *generic* fallback: `self.resolve_method_with_owner
+(qualifier, actual_method, &args)`, an ad-hoc registry-only MRO walk rooted at the qualifier class
+name (`resolve_method_with_owner_impl(..., invocant: None)`, `runtime/resolution_method.rs`). This
+step measures only that one generic fallback in that one function — `dispatch_qualified_mixin_method`
+and `dispatch_qualified_non_instance_method` in the same file share an identical-shaped
+`resolve_method_with_owner` fallback (for a run-time `Mixin` receiver and a non-Instance receiver,
+respectively) but stay untagged for a later sub-slice, per the "one consumer family per sub-PR" rule.
+
+**The chain-rooting problem this step had to solve.** E4a's existing `shadow_check_resolver`
+(`runtime/resolution_sequence.rs`) was written for E7 step 1 and the two `resolve_method_cached`
+boundaries, all of which shadow-check a call against the *receiver's own* MRO chain, derived via
+`self.dispatch_mro(invocant)` from a concrete `Value`. A qualified call has no such value: the
+resolution target is the qualifier CLASS NAME, not the receiver's own type — `self.Mu::Str` must
+resolve against `Mu`'s chain (`[Mu]`), not the receiver's full chain, even though the receiver is
+some deeply-derived class. So `shadow_check_resolver` was split into a thin wrapper (unchanged
+behavior, unchanged signature, unchanged three existing callers) over a new
+`shadow_check_resolver_chain(site, class_name, method, method_sym, arg_values, invocant:
+Option<&Value>, chain: &[TypeId], real)`, which takes the chain and an `Option<&Value>` invocant
+directly instead of deriving both from a single `&Value`. The qualified-dispatch call site builds
+its own chain the same way this file's own code already builds a package value elsewhere
+(`Value::package(Symbol::intern(qualifier))`, line ~465): `self.dispatch_mro(&Value::package
+(Symbol::intern(qualifier)))`, which `dispatch_mro`'s `ValueView::Package(name) => self.class_chain
+(name.as_str())` arm resolves to exactly the E1 catalog-spliced chain for that class name — the
+correct analogue of what `resolve_method_with_owner`'s own `self.class_mro(class_name)` walk
+consults. `invocant: None` is passed through unchanged to `method_args_match_for_invocant` (which
+already treats a `None` invocant as "skip the invocant type-constraint check", exactly matching
+`resolve_method_with_owner_impl`'s own `invocant: None` call) and to `NativeCallShape::new`'s
+`definite` flag (`invocant.map(value_is_definite).unwrap_or(false)` — a `None` invocant is treated
+as "not DEFINITE", the same as a bare type object/`Package` value would be).
+
+**Mechanism**: `dispatch_qualified_instance_method` has exactly one caller in the whole codebase
+(`methods_call_dispatch.rs`), confirmed by grep, so — unlike E7 step 1's `run_instance_method_at`
+— there is no second call site to tag differently yet, and the probe is gated inline with
+`if crate::vm::vm_stats::enabled() { ... }` around the whole block (skipping the chain/arg work
+entirely when unmeasured) rather than threaded through a `site` parameter. The gated block calls
+`resolve_method_with_owner` first (the real, unmodified call, unconditionally — this cannot be
+skipped even when unmeasured), then, only under the stats gate, calls
+`shadow_check_resolver_chain("qualifieddispatch", qualifier, actual_method, method_sym, &args,
+None, &qualifier_chain, resolved.as_ref())` and records
+`record_dispatch_entry_intercept`/`_outcome` under the new `"qualifieddispatch"` entry key (arm =
+the called method name) — the same E5/E6 generic dispatch-entry counters E7 step 1 reused. Pure
+insertion, zero behavior change: `resolved` (the real dispatch decision) is computed identically
+to before, and the whole probe block is a no-op unless `MUTSU_VM_STATS` is set.
+
+**Sweep**: full local `t/` (3047 files, debug binary) plus a targeted 10-file roast slice, found
+by grepping roast for both `self\.[A-Z][A-Za-z0-9:]*::[a-zA-Z_]` and
+`\$[a-zA-Z_]\w*\.[A-Z][A-Za-z0-9:]*::[a-zA-Z_]` (qualified calls on `self` and on a plain
+variable): `S12-class/inheritance.t`, `S12-construction/new.t`, `S12-methods/delegation.t`,
+`S12-methods/qualified.t`, `S12-methods/accessors.t`, `S12-methods/submethods.t`,
+`S14-roles/basic.t`, `S14-roles/conflicts.t`, `S14-roles/lexical.t`,
+`S14-roles/submethods-6e.t` — all ten already on `roast-whitelist.txt`. Unlike step 1 (whose two
+VM carrier sites saw zero roast traffic), this consumer family fires constantly: 113 times across
+13 `t/` files and 40 times across 8 of the 10 roast files, split roughly 40% `notfound` / 60%
+`intercept` by outcome. **Zero shadow mismatches tagged `qualifieddispatch` in either sweep** — the
+roast slice alone recorded 247 `resolver_shadow_checks` / 0 `resolver_shadow_mismatches` across all
+sites, and the wider `t/` sweep's 10 total mismatches are every one tagged
+`resolve_method_cached:fresh` in the per-mismatch detail string (e.g. `class=Holder method=set
+real=Some("Holder") shadow=None`) — the exact E4a "non-multi method resolves by name independent of
+whether the call's arguments actually bind it" bucket step 1 already root-caused, confirmed
+reproduces on the pre-E7 baseline, and is tracked under E4a/E8. None of the 10 are tagged
+`qualifieddispatch`.
+
+**Conclusion**: this consumer family also needs no cutover fix — the ad-hoc
+`resolve_method_with_owner` walk already agrees with the E4 resolver's `resolve_sequence` for
+every observed qualified-dispatch call, in both `t/` and the roast slice, despite (unlike step 1)
+seeing substantial real traffic. `cargo clippy -- -D warnings` / `cargo fmt` clean; full `t/`
+(3047 files/28,481 tests) green; the 10-file roast slice green (203 tests, `MUTSU_FUDGE=1`).
+`shadow_check_resolver_chain`'s extraction is itself reusable infrastructure for future E7
+sub-slices that also lack a receiver value (e.g. `.^lookup`/`.^can`/`.^methods` querying a type
+name directly). Next E7 sub-slice: private-as-sequence-query, per the design's consumer ordering
+above (`dispatch_qualified_mixin_method`/`dispatch_qualified_non_instance_method`'s own
+`resolve_method_with_owner` fallbacks remain untagged, available for a later qualified-dispatch
+sub-slice too).


### PR DESCRIPTION
## Summary

- Extends ADR-0019 Phase E box E7 to its second consumer family: `dispatch_qualified_instance_method`'s (`self.Owner::method(...)`) sole generic fallback, `resolve_method_with_owner`, is now shadow-compared against the E4 resolver's `resolve_sequence`, reusing and extending E4a's existing probe.
- Unlike E7 step 1, this call site has no receiver value of the resolution target's type to derive an MRO chain from — the walk is rooted at the qualifier class NAME. `shadow_check_resolver` was split into a thin wrapper (unchanged behavior for its three existing callers) over a new `shadow_check_resolver_chain(..., invocant: Option<&Value>, chain: &[TypeId], ...)` that a chain-rooted caller can drive directly.
- Pure insertion, zero behavior change: the probe is gated behind `MUTSU_VM_STATS`, and the real `resolve_method_with_owner` call/decision is unmodified.

## Findings

A full `t/` (3047 files) + 10-file roast slice sweep (`S12-class/inheritance.t`, `S12-construction/new.t`, `S12-methods/{delegation,qualified,accessors,submethods}.t`, `S14-roles/{basic,conflicts,lexical,submethods-6e}.t` — found by grepping roast for qualified `self.Owner::method` / `$obj.Owner::method` call patterns) found the new `"qualifieddispatch"` site fires substantially (113 times across 13 `t/` files, 40 times across 8 of 10 roast files) with **zero shadow mismatches** — unlike step 1 (which saw no roast traffic at all), this consumer family has real traffic and still agrees cleanly. The sweep's other 10 mismatches are all the pre-existing, already-documented E4a `resolve_method_cached:fresh` bucket (a non-multi method resolving by name independent of whether its typed signature actually binds the call), not this site.

**Conclusion: this consumer family needs no cutover fix.** `dispatch_qualified_mixin_method` and `dispatch_qualified_non_instance_method` in the same file share the identical `resolve_method_with_owner` fallback shape but stay untagged for a later sub-slice, per the "one consumer family per sub-PR" rule. Full detail in `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (E7 checklist item) and `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 2".

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` clean
- [x] Full local `t/` (3047 files/28,481 tests) — `make test` PASS
- [x] Targeted 10-file roast slice, `MUTSU_FUDGE=1 prove -e target/debug/mutsu <files>` — 203 tests PASS
- [x] `MUTSU_VM_STATS=1` sweep confirms zero mismatches at the new `qualifieddispatch` site
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)