### PR TITLE
docs+instrumentation(adr): ADR-0019 E7 step 3, shadow-check private method dispatch as a sequence query

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3340,6 +3340,63 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   `resolve_method_with_owner` fallback shape but are deliberately left untagged for a later E7
   sub-slice (one consumer family per sub-PR). Next E7 sub-slice: private-as-sequence-query, per
   `todo/deep/adr0019-e5-e7-entry-routing.md`'s consumer list.
+  **Progress 2026-08-12** (third consumer family, private-as-sequence-query, shadow-measurement
+  only): `resolve_private_method_for_vm` (`runtime/resolution_private_method.rs`) — the single VM-
+  facing entry point for both private-method call shapes, `$obj!m(...)` (unqualified,
+  `resolve_private_method_any_owner`) and `$obj!Owner::m(...)` (owner-qualified,
+  `resolve_private_method_with_owner`) — has exactly two callers in the whole codebase, both VM
+  carrier sites (`vm_call_method_compiled_interpret.rs` / `vm_call_method_compiled_mut.rs`), the
+  same "exactly two live callers" shape as step 1's carrier; the probe is gated inline like step 2
+  (a single logical entry point, no second call site to tag differently). This step also does the
+  "private-as-sequence-query" work the ADR's own E7 description names: `resolve_sequence`
+  (`resolution_sequence.rs`) gained a `MethodVisibility` parameter (`Public`/`Private`) — `Public`
+  is byte-for-byte the pre-existing filter (`is_private` skip, ancestor-submethod skip) and every
+  existing caller (both `resolve_method_cached` boundaries, E7 step 1, E7 step 2, both
+  `methods_native_bypass.rs` sites) now passes it explicitly, unchanged behavior; `Private` collects
+  every `is_private` def at every chain level with no `is_my` exclusion (mirroring that neither
+  ad-hoc private resolver ever checks `is_my`) and skips the `NativeCallBinding`/`Native` candidate
+  blocks entirely (a private name can coincidentally collide with a public builtin/row name, and
+  private dispatch can never reach either). `shadow_check_resolver_chain` gained the same
+  `visibility` parameter threaded through from its existing callers (`Public`) plus the new private
+  call site (`Private`). The owner-qualified chain is scoped to exactly `[owner]` — but ONLY when
+  `owner` is actually present in the receiver's OWN MRO (`self.class_mro(class_name)`); the
+  unqualified chain is the receiver's full `class_mro(class_name)`, both matching what the real
+  ad-hoc walks consult. **The sweep found and fixed one real bug before landing**: the first cut
+  built the qualified chain as `[TypeId::intern(owner)]` unconditionally, so a call like
+  `$b!A::p()` where `$b`'s class does not inherit from `A` incorrectly found `A`'s own private `p`
+  as a shadow candidate (`class=B method=p real=None shadow=Some("A")`, `t/private-owner-qualified-
+  permission.t`) even though the real walk (rooted at `B`'s own MRO, which never contains `A`)
+  correctly answers `None`. Guarding the chain to empty when `owner` is absent from the receiver's
+  MRO fixed it — cheap and safe per the box's own "small, obviously safe" allowance, not deferred.
+  **Sweep** (after the fix): full local `t/` (3047 files, debug binary, run both `-j2`/`-j4` and
+  serially) plus an 11-file roast slice (found by grepping roast for `!\w+\(`/`self!`/`$_!Owner::`
+  patterns under `S12-*`/`S14-*` and intersecting with `roast-whitelist.txt`): `S12-attributes/
+  {class,instance}.t`, `S12-class/inheritance.t`, `S12-enums/thorough.t`, `S12-introspection/
+  methods.t`, `S12-methods/{instance,private,trusts}.t`, `S14-roles/{basic,conflicts,stubs}.t` — all
+  eleven already whitelisted; `S12-methods/private.t` in particular is the private-dispatch spec
+  file itself and includes a `for ^10000` role-private-method-caching stress loop, so the slice
+  exercises this dispatch shape heavily rather than getting a misleadingly clean zero-traffic
+  result (`privatedispatch` fired ~260,600 times in that one file alone). **Zero shadow mismatches
+  tagged `privatedispatch` in either sweep** post-fix: the roast slice recorded 260,566
+  `resolver_shadow_checks` / 1 mismatch, and the `t/` sweep recorded 15,600 checks / 10 mismatches
+  (246 of the checks were `privatedispatch`, fired across 30 distinct `t/` files) — every one of
+  the 11 total mismatches is tagged `resolve_method_cached:fresh`, the same pre-existing E4a "non-
+  multi method resolves by name independent of argument bind" bucket steps 1/2 already root-caused;
+  none are tagged `privatedispatch`. The apparent `-j4`/`-j2` parallel-`prove` failures in ~20
+  unrelated `t/` files (`proc-async.t`, `io-handle-*.t`, `is-run.t`, `quietly.t`, ...) were
+  confirmed to be local concurrent-subprocess resource contention, not a regression: every one of
+  those files passes individually, and the sequential `make test` run (the CI-matching invocation)
+  is fully green. `cargo build`/`cargo test --lib` (804 tests, including 3 new `resolve_sequence`
+  unit tests: two for the new `Private` tier plus one confirming the unchanged `Public` tier still
+  excludes a private method) / `cargo clippy -- -D warnings` / `cargo fmt` clean; `make test` (3047
+  files/28,481 tests) green; the 11-file roast slice green (491 tests, `MUTSU_FUDGE=1`).
+  Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 3: private-as-sequence-query
+  — one real chain-scoping bug found and fixed". **This consumer family needed one small fix, now
+  closed** (unlike steps 1/2's zero-mismatch results, but the fix was in the shadow probe's own
+  chain construction, not in the real dispatch path — still zero real-behavior change). Next E7
+  sub-slice: `.^lookup`/`.^can`/`.^methods` reading the call-path sequence, per the design's
+  consumer ordering (the `.^can` dummy-`Value::NIL` probe replacement is called out specifically in
+  the design paragraph above).
 - [ ] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
   **Design 2026-08-10** (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`):

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -339,7 +339,12 @@ impl Interpreter {
         // consume `resolve_sequence` uniformly for both receiver kinds.
         let chain = self.dispatch_mro(target);
         let native_shape = super::resolution_sequence::NativeCallShape::new(arg_count, is_instance);
-        let seq = self.resolve_sequence(&chain, Symbol::intern(method), native_shape);
+        let seq = self.resolve_sequence(
+            &chain,
+            Symbol::intern(method),
+            native_shape,
+            super::resolution_sequence::MethodVisibility::Public,
+        );
         let native_binding_owner = seq.candidates.iter().find_map(|c| match c {
             ResolvedCandidate::NativeCallBinding { owner } => Some(owner.as_str().to_string()),
             ResolvedCandidate::User { .. } | ResolvedCandidate::Native { .. } => None,
@@ -591,6 +596,7 @@ mod tests {
             &chain,
             Symbol::intern("bar"),
             super::resolution_sequence::NativeCallShape::new(0, false),
+            super::resolution_sequence::MethodVisibility::Public,
         );
         assert!(
             seq.candidates.is_empty(),

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -380,6 +380,7 @@ impl Interpreter {
                 &args,
                 None,
                 &qualifier_chain,
+                super::resolution_sequence::MethodVisibility::Public,
                 resolved.as_ref(),
             );
             if resolved.is_some() {

--- a/src/runtime/resolution_private_method.rs
+++ b/src/runtime/resolution_private_method.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::type_id::TypeId;
 
 impl Interpreter {
     pub(crate) fn should_skip_defer_method_candidate(
@@ -208,11 +209,85 @@ impl Interpreter {
         arg_values: &[Value],
     ) -> Option<(String, MethodDef)> {
         let private_rest = method.strip_prefix('!')?;
-        if let Some((owner_class, pm_name)) = private_rest.split_once("::") {
-            self.resolve_private_method_with_owner(class_name, owner_class, pm_name, arg_values)
-        } else {
-            self.resolve_private_method_any_owner(class_name, private_rest, arg_values)
+        let split = private_rest.split_once("::");
+        let owner_class = split.map(|(o, _)| o);
+        let pm_name = split.map(|(_, n)| n).unwrap_or(private_rest);
+        let real = match owner_class {
+            Some(owner) => {
+                self.resolve_private_method_with_owner(class_name, owner, pm_name, arg_values)
+            }
+            None => self.resolve_private_method_any_owner(class_name, pm_name, arg_values),
+        };
+        // ADR-0019 Phase E box E7 (third consumer family, private-as-
+        // sequence-query -- see `todo/deep/adr0019-e5-e7-entry-routing.md`
+        // "E7 step 3"): shadow-check this ad-hoc private-method MRO walk
+        // against the E4 resolver's `resolve_sequence`, now extended with a
+        // `MethodVisibility::Private` tier (E7 steps 1/2 only ever built the
+        // `Public` tier). The owner-qualified form (`$obj!Owner::m`)
+        // restricts the shadow chain to exactly `[owner]` -- but ONLY when
+        // `owner` actually appears in the RECEIVER's own MRO
+        // (`self.class_mro(class_name)`), matching
+        // `resolve_private_method_with_owner`'s own `for cn in
+        // self.class_mro(class_name) { if cn != owner_class { continue } }`:
+        // the real walk is rooted at the receiver's MRO and merely filters it
+        // down to one level, it is not a direct lookup on `owner_class`'s own
+        // methods regardless of relation to the receiver. An unrelated
+        // `owner` (e.g. `$b!A::p()` where `$b`'s class `B` does not inherit
+        // from `A`) must yield an EMPTY chain, not `[A]` -- an empty chain
+        // was exactly the fix for the one mismatch the initial sweep found
+        // (`t/private-owner-qualified-permission.t`, `class=B method=p
+        // real=None shadow=Some("A")`): `class_mro("B")` is just `[B]`, so
+        // `A` never appears and the real walk finds nothing, but a naive
+        // `[TypeId::intern("A")]` chain found `A`'s own private `p` anyway.
+        // The unqualified form (`$obj!m`) walks the receiver's own full MRO
+        // via `self.class_mro(class_name)`, exactly what
+        // `resolve_private_method_any_owner` itself walks (`class_name` here
+        // is already the receiver's class, not an arbitrary qualifier, so no
+        // `Value::package(...)` round-trip through `dispatch_mro` is needed
+        // the way E7 step 2's qualifier-rooted chain required one).
+        // `resolve_private_method_for_vm` has exactly two callers in the
+        // whole codebase (both VM carrier sites,
+        // `vm_call_method_compiled_interpret.rs` /
+        // `vm_call_method_compiled_mut.rs`), so -- like E7 step 2 -- this is
+        // gated inline rather than threaded through a `site` parameter. A
+        // no-op unless `MUTSU_VM_STATS` is set: zero behavior change.
+        if crate::vm::vm_stats::enabled() {
+            let method_sym = Symbol::intern(pm_name);
+            let receiver_mro = self.class_mro(class_name);
+            let chain: Vec<TypeId> = match owner_class {
+                Some(owner) => {
+                    if receiver_mro.iter().any(|s| s.as_str() == owner) {
+                        vec![TypeId::intern(owner)]
+                    } else {
+                        Vec::new()
+                    }
+                }
+                None => receiver_mro
+                    .iter()
+                    .map(|s| TypeId::intern(s.as_str()))
+                    .collect(),
+            };
+            let real_sym = real
+                .as_ref()
+                .map(|(owner, def)| (Symbol::intern(owner), def.clone()));
+            self.shadow_check_resolver_chain(
+                "privatedispatch",
+                class_name,
+                pm_name,
+                method_sym,
+                arg_values,
+                None,
+                &chain,
+                super::resolution_sequence::MethodVisibility::Private,
+                real_sym.as_ref(),
+            );
+            if real.is_some() {
+                crate::vm::vm_stats::record_dispatch_entry_intercept("privatedispatch", pm_name);
+            } else {
+                crate::vm::vm_stats::record_dispatch_entry_outcome("privatedispatch", "notfound");
+            }
         }
+        real
     }
 
     pub(crate) fn can_fast_dispatch_private_method_vm(&self, owner_class: &str) -> bool {

--- a/src/runtime/resolution_sequence.rs
+++ b/src/runtime/resolution_sequence.rs
@@ -63,6 +63,28 @@ impl NativeCallShape {
     }
 }
 
+/// Which visibility tier [`Interpreter::resolve_sequence`] should collect.
+/// Added for ADR-0019 Phase E box E7 step 3 (private-as-sequence-query,
+/// `todo/deep/adr0019-e5-e7-entry-routing.md` "E7 step 3") so the same
+/// sequence builder can answer a private-method shadow probe without
+/// disturbing any existing `Public` caller.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MethodVisibility {
+    /// The E4a/E6/E7-step-1/E7-step-2 behavior, unchanged: skip `is_private`
+    /// defs and skip an ancestor-level submethod (`is_my && is_ancestor`).
+    /// Also the only tier that consults `NativeCallBinding`/`Native`
+    /// candidates — a private name (post `!`-stripping) can coincidentally
+    /// collide with a public builtin/native row name, and neither native
+    /// candidate kind is ever reachable through `self!name` dispatch, so
+    /// `Private` skips both blocks entirely rather than surface a false hit.
+    Public,
+    /// Every `is_private` def at every chain level, with no `is_my`
+    /// exclusion — mirrors `resolve_private_method_with_owner`/
+    /// `resolve_private_method_any_owner` (`resolution_private_method.rs`),
+    /// neither of which checks `is_my` at all.
+    Private,
+}
+
 /// One candidate in a [`ResolvedSequence`]. E4a only ever constructed `User`;
 /// E4b adds the NativeCall-binding and native-row-catalog kinds (design
 /// decision 4).
@@ -128,6 +150,7 @@ impl Interpreter {
         chain: &[TypeId],
         name: Symbol,
         native_shape: NativeCallShape,
+        visibility: MethodVisibility,
     ) -> ResolvedSequence {
         let generation = self.registry().method_generation;
         let mut candidates = Vec::new();
@@ -141,7 +164,11 @@ impl Interpreter {
                 .user_method_overloads(owner_str, name.as_str())
             {
                 for def in overloads {
-                    if def.is_private || (def.is_my && is_ancestor) {
+                    let visible = match visibility {
+                        MethodVisibility::Public => !(def.is_private || (def.is_my && is_ancestor)),
+                        MethodVisibility::Private => def.is_private,
+                    };
+                    if !visible {
                         continue;
                     }
                     candidates.push(ResolvedCandidate::User {
@@ -149,6 +176,14 @@ impl Interpreter {
                         def: Arc::new(def),
                     });
                 }
+            }
+            if visibility == MethodVisibility::Private {
+                // Private dispatch (`self!name`) never reaches a NativeCall
+                // binding or a native-row catalog entry — both are indexed by
+                // public builtin/binding names, and a coincidental name match
+                // (e.g. a user `method !chars` vs. the `Str.chars` row) must
+                // not surface as a false candidate here.
+                continue;
             }
             // `hardcoded_native_method` only ever fires for the receiver's own
             // (most-derived) class name, mirroring `is_native_method` — it is
@@ -231,6 +266,7 @@ impl Interpreter {
             arg_values,
             Some(invocant),
             &chain,
+            MethodVisibility::Public,
             real,
         );
     }
@@ -255,6 +291,13 @@ impl Interpreter {
     /// `resolve_method_with_owner`'s registry-only walk itself calls
     /// `resolve_method_with_owner_impl(..., invocant: None)` for the case
     /// this is shadowing.
+    ///
+    /// `visibility` (added for ADR-0019 Phase E box E7 step 3,
+    /// private-as-sequence-query) selects which
+    /// [`MethodVisibility`] tier `resolve_sequence` collects — every existing
+    /// caller (both `Public`-chain callers above, plus qualified dispatch's
+    /// `dispatch_qualified_instance_method`) passes `MethodVisibility::Public`
+    /// unchanged; only the new private-dispatch shadow probe passes `Private`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn shadow_check_resolver_chain(
         &mut self,
@@ -265,6 +308,7 @@ impl Interpreter {
         arg_values: &[Value],
         invocant: Option<&Value>,
         chain: &[TypeId],
+        visibility: MethodVisibility,
         real: Option<&(Symbol, MethodDef)>,
     ) {
         if !crate::vm::vm_stats::enabled() {
@@ -273,7 +317,7 @@ impl Interpreter {
         let saved_ambiguous = self.dispatch_ambiguous;
         let definite = invocant.map(value_is_definite).unwrap_or(false);
         let native_shape = NativeCallShape::new(arg_values.len(), definite);
-        let seq = self.resolve_sequence(chain, method_sym, native_shape);
+        let seq = self.resolve_sequence(chain, method_sym, native_shape, visibility);
         let has_where_candidate = seq.candidates.iter().any(|c| {
             let ResolvedCandidate::User { def, .. } = c else {
                 return false;
@@ -339,7 +383,7 @@ impl Interpreter {
         }
         let chain = self.dispatch_mro(target);
         let native_shape = NativeCallShape::new(arg_count, value_is_definite(target));
-        let seq = self.resolve_sequence(&chain, method_sym, native_shape);
+        let seq = self.resolve_sequence(&chain, method_sym, native_shape, MethodVisibility::Public);
         let native_row_owner = seq.candidates.iter().find_map(|c| match c {
             ResolvedCandidate::Native { owner } => Some(owner.as_str()),
             ResolvedCandidate::User { .. } | ResolvedCandidate::NativeCallBinding { .. } => None,
@@ -367,7 +411,12 @@ mod tests {
         i.run("class Base { method greet { 'base' } }\nclass Child is Base { method greet { 'child' } }")
             .unwrap();
         let chain = vec![TypeId::intern("Child"), TypeId::intern("Base")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("greet"), default_shape());
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("greet"),
+            default_shape(),
+            MethodVisibility::Public,
+        );
         let owners: Vec<&str> =
             seq.candidates
                 .iter()
@@ -386,7 +435,12 @@ mod tests {
         i.run("class Base { submethod only-base { } }\nclass Child is Base { }")
             .unwrap();
         let chain = vec![TypeId::intern("Child"), TypeId::intern("Base")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("only-base"), default_shape());
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("only-base"),
+            default_shape(),
+            MethodVisibility::Public,
+        );
         assert!(
             seq.candidates.is_empty(),
             "a submethod on an ancestor level must not appear in a descendant's sequence"
@@ -399,7 +453,12 @@ mod tests {
         i.run("class Base { submethod only-base { } }\nclass Child is Base { }")
             .unwrap();
         let chain = vec![TypeId::intern("Base")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("only-base"), default_shape());
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("only-base"),
+            default_shape(),
+            MethodVisibility::Public,
+        );
         assert_eq!(seq.candidates.len(), 1);
     }
 
@@ -408,7 +467,12 @@ mod tests {
         let mut i = interp();
         i.run("class Base { }").unwrap();
         let chain = vec![TypeId::intern("Base")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("nope"), default_shape());
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("nope"),
+            default_shape(),
+            MethodVisibility::Public,
+        );
         assert!(seq.candidates.is_empty());
     }
 
@@ -421,7 +485,12 @@ mod tests {
         let mut i = interp();
         assert!(i.is_native_method("Supply", "tap"));
         let chain = vec![TypeId::intern("Supply")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("tap"), default_shape());
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("tap"),
+            default_shape(),
+            MethodVisibility::Public,
+        );
         assert!(
             seq.candidates.iter().any(
                 |c| matches!(c, ResolvedCandidate::NativeCallBinding { owner }
@@ -442,6 +511,7 @@ mod tests {
             &chain,
             Symbol::intern("chars"),
             NativeCallShape::new(0, true),
+            MethodVisibility::Public,
         );
         assert!(
             seq.candidates.iter().any(
@@ -460,12 +530,78 @@ mod tests {
             &chain,
             Symbol::intern("chars"),
             NativeCallShape::new(1, true),
+            MethodVisibility::Public,
         );
         assert!(
             !seq.candidates
                 .iter()
                 .any(|c| matches!(c, ResolvedCandidate::Native { .. })),
             "Str.chars is an A0 row and must not surface for a 1-arg call"
+        );
+    }
+
+    /// ADR-0019 E7 step 3: `MethodVisibility::Private` finds a private
+    /// method, and (unlike `Public`) does not exclude it from an ancestor
+    /// level — neither `resolve_private_method_with_owner` nor
+    /// `resolve_private_method_any_owner` checks `is_my` at all.
+    #[test]
+    fn resolve_sequence_private_finds_a_private_method() {
+        let mut i = interp();
+        i.run("class Base { method !secret { 'shh' } }").unwrap();
+        let chain = vec![TypeId::intern("Base")];
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("secret"),
+            default_shape(),
+            MethodVisibility::Private,
+        );
+        let owners: Vec<&str> =
+            seq.candidates
+                .iter()
+                .filter_map(|c| match c {
+                    ResolvedCandidate::User { owner, .. } => Some(owner.as_str()),
+                    ResolvedCandidate::NativeCallBinding { .. }
+                    | ResolvedCandidate::Native { .. } => None,
+                })
+                .collect();
+        assert_eq!(owners, vec!["Base"]);
+    }
+
+    /// The `Public` tier's existing behavior is unchanged by adding
+    /// `Private`: a private method must never appear in a `Public` sequence.
+    #[test]
+    fn resolve_sequence_public_excludes_a_private_method() {
+        let mut i = interp();
+        i.run("class Base { method !secret { 'shh' } }").unwrap();
+        let chain = vec![TypeId::intern("Base")];
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("secret"),
+            default_shape(),
+            MethodVisibility::Public,
+        );
+        assert!(
+            seq.candidates.is_empty(),
+            "a private method must not appear in a Public sequence"
+        );
+    }
+
+    /// `Private` never surfaces a `NativeCallBinding`/`Native` candidate,
+    /// even when the (post-`!`-stripping) name coincides with a public
+    /// builtin/native row name — private dispatch can never reach either.
+    #[test]
+    fn resolve_sequence_private_never_surfaces_a_native_candidate() {
+        let mut i = interp();
+        let chain = vec![TypeId::intern("Str")];
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("chars"),
+            NativeCallShape::new(0, true),
+            MethodVisibility::Private,
+        );
+        assert!(
+            seq.candidates.is_empty(),
+            "Private must not surface Str.chars's public Native row"
         );
     }
 
@@ -477,7 +613,12 @@ mod tests {
         let mut i = interp();
         assert!(i.is_native_method("IO::Handle", "chomp"));
         let chain = vec![TypeId::intern("Base"), TypeId::intern("IO::Handle")];
-        let seq = i.resolve_sequence(&chain, Symbol::intern("chomp"), default_shape());
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("chomp"),
+            default_shape(),
+            MethodVisibility::Public,
+        );
         assert!(
             seq.candidates.is_empty(),
             "hardcoded native-method names must not apply to an ancestor level"

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -2012,3 +2012,106 @@ name directly). Next E7 sub-slice: private-as-sequence-query, per the design's c
 above (`dispatch_qualified_mixin_method`/`dispatch_qualified_non_instance_method`'s own
 `resolve_method_with_owner` fallbacks remain untagged, available for a later qualified-dispatch
 sub-slice too).
+
+## E7 step 3: private-as-sequence-query — one real chain-scoping bug found and fixed
+
+`resolve_private_method_for_vm` (`runtime/resolution_private_method.rs`) is the single VM-facing
+entry point for `self!method(...)`-style private-method calls, both the unqualified form
+(`$obj!m(...)`, delegates to `resolve_private_method_any_owner`) and the owner-qualified form
+(`$obj!Owner::m(...)`, delegates to `resolve_private_method_with_owner`). It has exactly two
+callers in the whole codebase — `vm_call_method_compiled_interpret.rs:382` and
+`vm_call_method_compiled_mut.rs:278`, both `loan_env!(self, resolve_private_method_for_vm(...))` —
+the same "exactly two live VM callers" shape as E7 step 1's carrier, and (like step 2) there is only
+one logical call site to tag, so the probe is gated inline (`if crate::vm::vm_stats::enabled()`)
+rather than threaded through a `site` parameter.
+
+**The "private-as-sequence-query" work.** Unlike steps 1/2, which only ever asked `resolve_sequence`
+for the `Public` tier, this step is the one the ADR's own E7 line item names directly ("private-
+method dispatch ... becomes a sequence query with a private-visibility flag"). `resolve_sequence`
+(`resolution_sequence.rs`) gained a `MethodVisibility` enum parameter:
+
+- `Public` is byte-for-byte the pre-existing filter (`is_private` skip; ancestor-level submethod
+  skip) — every existing caller (`shadow_check_resolver_chain`'s three receiver-chain callers via
+  `shadow_check_resolver`, `dispatch_qualified_instance_method`'s qualifier-chain call, both
+  `methods_native_bypass.rs` bypass/native-row shadow probes, and all pre-existing unit tests) now
+  passes `MethodVisibility::Public` explicitly. Zero behavior change at any of those sites.
+- `Private` collects every `is_private` def at every chain level, with **no** `is_my` exclusion —
+  read directly off the two ad-hoc resolvers being shadowed, neither of which ever checks `is_my`
+  at all (confirmed by reading both function bodies, not assumed). It also skips the
+  `NativeCallBinding`/`Native` candidate blocks entirely: a private name (post `!`-stripping) can
+  coincidentally collide with a public builtin/native-row name (e.g. a user `method !chars`), and
+  neither native candidate kind is ever reachable through `self!name` dispatch — surfacing one as a
+  candidate would be a false hit invisible to any real caller. A new unit test
+  (`resolve_sequence_private_never_surfaces_a_native_candidate`) pins this directly against
+  `Str.chars`.
+
+`shadow_check_resolver_chain` gained the same `visibility: MethodVisibility` parameter, threaded
+through unchanged from its existing three `Public` callers plus the new private call site.
+
+**Chain construction — read from the real ad-hoc walk, not guessed.** The owner-qualified form's
+shadow chain must be exactly `[owner]`, mirroring `resolve_private_method_with_owner`'s own `for cn
+in self.class_mro(class_name) { if cn != owner_class { continue } }`. The unqualified form's shadow
+chain is the receiver's full `self.class_mro(class_name)`, exactly what
+`resolve_private_method_any_owner` itself walks — and since `resolve_private_method_for_vm`'s
+`class_name` parameter is already the receiver's own class (not an arbitrary qualifier the way E7
+step 2's `qualifier` was), no `Value::package(...)` round-trip through `dispatch_mro` is needed the
+way step 2's qualifier-rooted chain required one.
+
+**The sweep found and fixed one real bug before landing.** The first cut built the qualified
+chain as `[TypeId::intern(owner)]` unconditionally — i.e. it queried `owner`'s own private methods
+directly, without checking whether `owner` is actually reachable from the receiver's own MRO. The
+very first sweep caught it immediately: `t/private-owner-qualified-permission.t` (`class B { }`,
+`class A { method !p() { 42 } }`, `my $_ = B.new; '$_!A::p()'` — `B` does not inherit from `A`)
+produced `class=B method=p real=None shadow=Some("A")`. The real walk is correct (`B`'s MRO is just
+`[B]`, `A` never appears, so the `cn != owner_class` filter admits nothing and the loop body never
+runs); the naive shadow chain was wrong — it treated the qualified form as a direct lookup on
+`owner`'s own methods regardless of the receiver's relationship to `owner`, which is not what the
+real resolver does. Fixed by computing `receiver_mro = self.class_mro(class_name)` once and using
+`if receiver_mro.iter().any(|s| s.as_str() == owner) { vec![TypeId::intern(owner)] } else {
+Vec::new() }` — an empty chain for an unrelated owner, matching the real `None`. Re-running the same
+file after the fix: `resolver_shadow_mismatches=0`, `privatedispatch:notfound=1` (correctly
+matching `real=None`). This is exactly the kind of "small, obviously safe" fix the box's own
+guidance allows landing inline rather than deferring, and — unlike the accepted E4a early-stopping
+bucket steps 1/2 catalogued — it was a bug in this step's own new shadow-probe code, not a
+pre-existing, already-documented divergence.
+
+**Sweep** (post-fix): full local `t/` (3047 files, debug binary; run both `-j2`/`-j4`-parallel and
+serially) plus an 11-file roast slice, found by grepping roast for `!\w+\(`/`self!`/`\$\w+!Owner::`
+patterns under `S12-*`/`S14-*` and intersecting with `roast-whitelist.txt`: `S12-attributes/
+{class,instance}.t`, `S12-class/inheritance.t`, `S12-enums/thorough.t`,
+`S12-introspection/methods.t`, `S12-methods/{instance,private,trusts}.t`,
+`S14-roles/{basic,conflicts,stubs}.t` (an unwhitelisted twelfth candidate,
+`S12-attributes/trusts.t`, was excluded — it has a pre-existing, unrelated failure). `S12-methods/
+private.t` is the private-dispatch spec file itself and its last subtest is a `for ^10000`
+role-private-method-caching stress loop (deliberately heavy on a debug build — it took ~40-60s,
+which briefly looked like a hang before a longer `timeout` confirmed it completes and passes), so
+the slice exercises this dispatch shape far more heavily than a token grep-based selection would:
+`privatedispatch` fired ~260,600 times in that one file alone. **Zero shadow mismatches tagged
+`privatedispatch` in either sweep post-fix**: the roast slice recorded 260,566
+`resolver_shadow_checks` / 1 mismatch total, and the `t/` sweep recorded 15,600 checks / 10
+mismatches total (246 of the checks were `privatedispatch`, fired across 30 distinct `t/` files) —
+every one of the 11 total mismatches (across both sweeps) is tagged `resolve_method_cached:fresh`,
+the exact pre-existing E4a "non-multi method resolves by name independent of whether the call's
+arguments actually bind it" bucket steps 1/2 already root-caused and confirmed reproduces on the
+pre-E7 baseline; none are tagged `privatedispatch`.
+
+**A parallel-`prove` red herring.** The first `-j4`/`-j2` full-`t/` sweep runs showed ~20 unrelated
+files failing (`proc-async.t`, `io-handle-stdout-stderr-native.t`, `io-pipe-slurp-rest.t`,
+`is-run.t`, `quietly.t`, `sink-warning.t`, `command-line-negation.t`, ...) — none of them exercise
+private-method dispatch. Re-running exactly those files with plain serial `prove` (no `-j`) passed
+every one, confirming local concurrent-subprocess resource contention (many are IO/subprocess-
+spawning tests), not a regression; the CI-matching sequential `make test` run is fully green.
+
+`cargo build` / `cargo test --lib` (804 tests, including 3 new `resolve_sequence` unit tests: two
+for the new `Private` tier plus one confirming the unchanged `Public` tier still excludes a private
+method) / `cargo clippy -- -D warnings` / `cargo fmt` clean; `make test` (3047 files/28,481 tests)
+green; the 11-file roast slice green (491 tests, `MUTSU_FUDGE=1`).
+
+**Conclusion**: this consumer family needed one small, safe fix in the shadow probe's own chain
+construction — not in any real dispatch path, so still zero real-behavior change end to end. After
+the fix, the ad-hoc private-method resolvers agree with the E4 resolver's `resolve_sequence` (now
+extended with the `Private` visibility tier) for every observed call in both sweeps. Next E7
+sub-slice: `.^lookup`/`.^can`/`.^methods` reading the call-path sequence, per the design's consumer
+ordering — the design paragraph calls out the `.^can` dummy-`Value::NIL` probe replacement
+specifically as "a correctness fix as well as a routing change," so that sub-slice is not expected
+to be another clean zero-mismatch/zero-fix result the way steps 1/2 were.


### PR DESCRIPTION
## Summary

Third E7 consumer family (per `todo/deep/adr0019-e5-e7-entry-routing.md`'s consumer ordering): `resolve_private_method_for_vm` (`runtime/resolution_private_method.rs`), the sole VM-facing entry point for both `$obj!method(...)` and `$obj!Owner::method(...)` private-method dispatch, is now shadow-checked against the E4 resolver's `resolve_sequence` — extended with a `MethodVisibility::{Public,Private}` tier so it can answer a private-method query, per the ADR's own E7 line item ("private method dispatch ... becomes a sequence query with a private-visibility flag").

- `resolve_private_method_for_vm` has exactly two callers in the whole codebase (both VM carrier sites), so the probe is gated inline (`MUTSU_VM_STATS`), same shape as E7 step 2.
- `resolve_sequence` gained a `MethodVisibility` parameter; `Public` is byte-for-byte unchanged and every existing caller now passes it explicitly (both `resolve_method_cached` boundaries, E7 steps 1/2, both `methods_native_bypass.rs` sites). `Private` collects every `is_private` def with no `is_my` exclusion (mirroring what the real ad-hoc resolvers actually check) and skips the native-binding/native-row candidate blocks entirely (private dispatch can never reach either).
- **The sweep found and fixed one real bug before landing**: the owner-qualified shadow chain must be scoped to `[owner]` *only when `owner` is actually present in the receiver's own MRO* — an unrelated owner (e.g. `$b!A::p()` where `$b`'s class does not inherit from `A`) must yield an empty chain, matching the real walk's `None`. The first cut built `[owner]` unconditionally and a local sweep caught the divergence on `t/private-owner-qualified-permission.t` immediately. Fixed with a one-line MRO-membership guard.
- Post-fix: full `t/` (3047 files) + an 11-file roast slice (`roast/S12-methods/private.t` alone fires the new site ~260,600 times via its role-private-method-caching stress loop) shows **zero shadow mismatches tagged `privatedispatch`**; the remaining handful of mismatches are all the pre-existing E4a "non-multi method resolves by name independent of argument bind" bucket steps 1/2 already root-caused.

Pure insertion, gated by `MUTSU_VM_STATS`: zero real-behavior change. Full writeup in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 3".

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] `cargo test --lib` (804 tests, incl. 3 new `resolve_sequence` unit tests)
- [x] `make test` (3047 files/28,481 tests) green
- [x] 11-file roast slice green (491 tests, `MUTSU_FUDGE=1`)
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)