### PR TITLE
fix(dispatch+runtime+compiler): 85_util four fixes — rw-multi cache soundness, inherited IO::Handle chomp, $self assignment, QuantHash slice adverbs

### DIFF
--- a/news/2026-08/text-csv-85-util-four-fixes.md
+++ b/news/2026-08/text-csv-85-util-four-fixes.md
@@ -1,0 +1,50 @@
+# Text::CSV runtime sweep round 6: rw-multi cache soundness, inherited IO::Handle chomp, $self assignment, QuantHash slice adverbs
+
+Four general interpreter fixes found by chasing Text::CSV's `85_util.t`
+(github.com/Tux/CSV) from aborting at test 5 to fully passing (110/110),
+bringing the suite to 29/33 fully-green files.
+
+1. **The type-keyed multi resolution cache must exclude `is rw`
+   candidates.** `multi_resolve_cache` (and its sub twin) caches the winner
+   for a multi whose dispatch is "purely type+arity based", but an `is rw`
+   candidate matches only a writable-lvalue argument — a call-site property
+   invisible to the type key. Text::IO::String's `multi method new (Str $str!
+   is rw, ...)` / `(Str $str!, ...)` pair meant whichever call ran first froze
+   the winner: `new($data)` then `new($str.Str)` threw X::Parameter::RW, the
+   reverse order routed variables to the copy candidate. Both cacheability
+   scans now treat an `is rw` param as value-dependent. Pin:
+   `t/rw-multi-dispatch-cache.t`.
+
+2. **A pure-Raku `is IO::Handle` subclass inherits the `$.chomp is rw`
+   accessor.** mutsu's IO::Handle is native (exact-class checks plus a handle
+   id); a blessed subclass instance has neither, so `.chomp` fell through to
+   the native *Str* chomp (returning `"Text::IO::String()"` — the stringified
+   invocant) and assignment died. The native fast path now routes every
+   instance to the slow path, which answers the read (stored attribute, else
+   the IO::Handle default True) and the lvalue assign (stores the attribute)
+   for any class whose MRO includes IO::Handle without a user-declared
+   `chomp`. Pin: `t/io-handle-subclass-chomp.t`.
+
+3. **`my $self` is assignable outside method bodies.** Scalars are stored
+   sigil-less, so the compile-time "`self` is immutable" check (emitting
+   `AssignReadOnly` for the invocant keyword) also fired for a user variable
+   named `$self` — `$self = $csv.header($fh)` threw X::Assignment::RO before
+   header even ran, and the test's CATCH captured the wrong exception. The
+   check is now gated on `lexically_in_method`, keeping the roast pin
+   (`S12-class/basic.t`: `method f { self = 5 }` throws). Pin:
+   `t/self-var-assign.t`.
+
+4. **Subscript adverbs work on QuantHash slices.** `$bag{@keys}:kv` /
+   `:v` / `:k` / `:p` returned empty: the adverb builtin had Array and Hash
+   arms only, and a Set/Bag/Mix target fell into the
+   "associative-on-non-associative" everything-is-missing path. The target is
+   now projected through `.hash` (which decodes the internal WHICH-encoded
+   keys — the raw-internal-map projection kept `Str|,`-style keys and matched
+   nothing) and the Hash arm owns the logic. Text::CSV's header separator
+   detection is exactly `$hdr.comb.Bag{$sep-set.list}:kv`, so `header` never
+   detected `;`/tab separators and never raised the 1011 sep-conflict error.
+   Pin: `t/quanthash-slice-adverbs.t`.
+
+Suite status: `85_util.t` joins the green set (29/33). Remaining: 90_csv
+(csv() header semantics), 91_csv_cb, 92_csv_encoding, and 99_meta (needs
+external Test::META).

--- a/src/builtins/methods_0arg/dispatch_core_str.rs
+++ b/src/builtins/methods_0arg/dispatch_core_str.rs
@@ -214,9 +214,12 @@ pub(super) fn dispatch(
             )))))
         }
         "chomp" => {
-            // IO::Handle.chomp is an attribute accessor, not the Str method
-            if matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "IO::Handle")
-            {
+            // IO::Handle.chomp (and any IO::Handle-derived class, e.g.
+            // Text::IO::String) is an attribute accessor, not the Str method.
+            // This layer cannot see the MRO, so route EVERY instance to the
+            // slow path — it dispatches user/parent methods and still reaches
+            // the native Str chomp for Str-derived instances.
+            if matches!(target.view(), ValueView::Instance { .. }) {
                 return Some(None);
             }
             Some(Some(Ok(Value::str(crate::builtins::chomp_one(

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1799,8 +1799,14 @@ impl Compiler {
                     }
                     return;
                 }
-                // `self` is immutable — reject assignments at compile time
-                if name == "self" {
+                // The invocant `self` is immutable — reject assignments at
+                // compile time, but only inside a method body, where a bare
+                // `self` names the invocant (roast S12-class/basic.t pins
+                // `method f { self = 5 }` throwing). Outside a method the name
+                // can only be an ordinary user variable (`my $self;
+                // $self = $csv.header($fh)` — Text::CSV's 85_util.t), since
+                // scalars are stored sigil-less and would otherwise collide.
+                if name == "self" && self.lexically_in_method {
                     self.code.emit(OpCode::AssignReadOnly);
                     return;
                 }

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -629,6 +629,13 @@ impl Interpreter {
                     value_dependent = true;
                     break 'outer;
                 }
+                // An `is rw` candidate matches only a writable-lvalue argument —
+                // a call-site property, not an arg-type one — so `f($var)` and
+                // `f("lit")` need different winners under one type key.
+                if pd.traits.iter().any(|t| t == "rw") {
+                    value_dependent = true;
+                    break 'outer;
+                }
                 if let Some(tc) = &pd.type_constraint {
                     // `:D`/`:U`/`:_` smiley or `Int(Str)` coercion => value/identity
                     // dependent; a subset type carries an implicit `where`. The `:`

--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -252,6 +252,25 @@ impl Interpreter {
         } else {
             target
         };
+        // A QuantHash target (Set/Bag/Mix and their mutable *Hash twins): the
+        // slice adverbs behave as on the equivalent `key => weight` hash, with
+        // unreached keys absent (Text::CSV's separator detection is exactly
+        // `$hdr.comb.Bag{$sep-set.list}:kv`). Project through `.hash` — which
+        // decodes the internal WHICH-encoded keys — and let the Hash arm below
+        // own the key/value logic.
+        // TODO: `:delete` on a mutable SetHash/BagHash/MixHash should write
+        // back through the original container; the projection makes the delete
+        // a no-op on the source (previously the whole slice returned empty).
+        let target = if target.with_deref(|v| {
+            matches!(
+                v.view(),
+                ValueView::Set(..) | ValueView::Bag(..) | ValueView::Mix(..)
+            )
+        }) {
+            self.call_method_with_values(target.deref_container(), "hash", vec![])?
+        } else {
+            target
+        };
         let index = args[1].clone();
         let mode = args[2].to_string_value();
         let var_name = args

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -91,6 +91,36 @@ impl Interpreter {
         {
             return Ok(v.clone());
         }
+        // IO::Handle's `$.chomp is rw` attribute, inherited by a pure-Raku
+        // subclass (`class Text::IO::String is IO::Handle`): a blessed instance
+        // carries no native handle state and no "chomp" attribute, so nothing
+        // else answers the read. Return the stored attribute when a setter has
+        // written one, else the IO::Handle default (True). Exact `IO::Handle`
+        // instances keep their native-state path, and a user-declared `chomp`
+        // method/attribute outranks this.
+        if method == "chomp"
+            && args.is_empty()
+            && let ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } = target.view()
+            && class_name != "IO::Handle"
+        {
+            let cls = class_name.resolve();
+            if !self.class_has_user_method(&cls, "chomp")
+                && self
+                    .class_mro(&cls)
+                    .iter()
+                    .any(|c| c.as_str() == "IO::Handle")
+            {
+                return Ok(attributes
+                    .as_map()
+                    .get("chomp")
+                    .cloned()
+                    .unwrap_or(Value::truth(true)));
+            }
+        }
         // `.REPR` / `.WHERE` on a NativeCall handle. Both need the class
         // registry to tell a `nativecast`ed CStruct/CUnion/CArray from an
         // ordinary instance, so they cannot be answered on the pure native fast

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -413,6 +413,35 @@ impl Interpreter {
             }
             return Ok(value);
         }
+        // `$.chomp is rw` inherited by a pure-Raku IO::Handle subclass
+        // (`class Text::IO::String is IO::Handle`): no native handle state to
+        // update — store the instance attribute directly; the reader in
+        // `methods_call_dispatch` answers from it (default True).
+        if method == "chomp"
+            && method_args.is_empty()
+            && let ValueView::Instance {
+                class_name,
+                attributes,
+                id: inst_id,
+            } = target.view()
+            && class_name != "IO::Handle"
+            && !self.class_has_user_method(&class_name.resolve(), "chomp")
+            && self
+                .class_mro(&class_name.resolve())
+                .iter()
+                .any(|c| c.as_str() == "IO::Handle")
+        {
+            let mut new_attrs = attributes.to_map();
+            new_attrs.insert("chomp".to_string(), value.clone());
+            attributes.commit_attrs(new_attrs);
+            if let Some(var_name) = target_var {
+                self.env.insert_through(
+                    var_name.to_string(),
+                    Value::instance_sharing_cell(&attributes, class_name, inst_id),
+                );
+            }
+            return Ok(value);
+        }
         if method == "value"
             && let ValueView::Instance {
                 class_name,

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -114,6 +114,15 @@ impl Interpreter {
                         value_dependent = true;
                         break 'outer;
                     }
+                    // An `is rw` candidate matches only a writable-lvalue
+                    // argument — a property of the call site, not of the arg's
+                    // type — so `m($var)` and `m("lit")` need different winners
+                    // under one type key (Text::IO::String's `new (Str $s! is
+                    // rw)` / `new (Str $s!)` pair).
+                    if pd.traits.iter().any(|t| t == "rw") {
+                        value_dependent = true;
+                        break 'outer;
+                    }
                     if let Some(tc) = &pd.type_constraint {
                         // `:D`/`:U`/`:_` smiley or `Int(Str)` coercion => value/identity
                         // dependent; a subset type carries an implicit `where`.

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -480,7 +480,7 @@ impl Interpreter {
     /// Project a QuantHash to a plain `key => weight` Hash so the existing hash
     /// hyper logic applies. Set membership becomes `True`, Bag/Mix weights become
     /// Int/Num. Non-QuantHash values pass through unchanged (scalar broadcast).
-    pub(super) fn quanthash_to_hash(v: &Value) -> Value {
+    pub(crate) fn quanthash_to_hash(v: &Value) -> Value {
         let map: std::collections::HashMap<String, Value> = match v.view() {
             ValueView::Set(d, _) => d
                 .elements

--- a/t/io-handle-subclass-chomp.t
+++ b/t/io-handle-subclass-chomp.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+# IO::Handle has `$.chomp is rw = True`; a pure-Raku subclass created via
+# bless carries no native handle state, but the inherited accessor must still
+# read (default True) and write. (Text::CSV's 85_util.t: Text::IO::String
+# `is IO::Handle`, and getline does `my Bool $chomped = $io.chomp`.)
+
+plan 5;
+
+class MyIO is IO::Handle { }
+
+my $io = MyIO.new;
+is $io.chomp, True, 'inherited chomp reads the IO::Handle default (True)';
+ok $io.chomp ~~ Bool, 'default is a Bool, not a Str coercion of the invocant';
+
+$io.chomp = False;
+is $io.chomp, False, 'chomp is writable through the inherited rw accessor';
+$io.chomp = True;
+is $io.chomp, True, 'and writable back';
+
+# A user-declared chomp method outranks the inherited accessor.
+class Custom is IO::Handle {
+    method chomp { "custom" }
+}
+is Custom.new.chomp, "custom", 'user-declared chomp method wins';
+
+done-testing;

--- a/t/quanthash-slice-adverbs.t
+++ b/t/quanthash-slice-adverbs.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# Subscript adverbs on QuantHash (Set/Bag/Mix) slices behave as on the
+# equivalent key => weight hash, with unreached keys absent.
+# (Text::CSV's header separator detection: `$hdr.comb.Bag{$sep-set.list}:kv`)
+
+plan 10;
+
+my $b = "a,b;c,d".comb.Bag;
+is-deeply ($b{",", ";"}:kv), (",", 2, ";", 1), 'Bag slice :kv';
+is-deeply ($b{",", ";"}:v),  (2, 1),           'Bag slice :v';
+is-deeply ($b{",", ";"}:k),  (",", ";"),       'Bag slice :k';
+is-deeply ($b{",", "!"}:kv), (",", 2),         'Bag slice :kv drops missing keys';
+is-deeply ($b{","}:kv),      (",", 2),         'Bag single-key :kv';
+
+my $s = <x y>.Set;
+is-deeply ($s{"x", "z"}:kv), ("x", True), 'Set slice :kv (missing key dropped)';
+is-deeply ($s{"x", "z"}:v),  (True,),     'Set slice :v';
+
+my $m = (a => 0.5, b => 1.5).Mix;
+is-deeply ($m{"a", "b"}:v).sort, (0.5, 1.5), 'Mix slice :v';
+
+# The header-detection shape itself.
+my $hdr = "bAr;foo";
+my @sep-set = ",", ";";
+my %sep = $hdr.comb.Bag{@sep-set.list}:kv;
+is-deeply %sep, {";" => 1}, 'Bag slice :kv into a hash keeps only present separators';
+my %conflict = "a,b;c,d".comb.Bag{@sep-set.list}:kv;
+is %conflict.elems, 2, 'conflicting separators are both reported';
+
+done-testing;

--- a/t/rw-multi-dispatch-cache.t
+++ b/t/rw-multi-dispatch-cache.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# An `is rw` multi candidate matches only a writable-lvalue argument — a
+# call-site property, not an arg-type one. The type-keyed multi resolution
+# cache must therefore never cache such a multi: `m($var)` and `m("lit")`
+# carry the same type key but need different winners.
+# (found via Text::IO::String's `multi method new (Str $str! is rw)` /
+#  `(Str $str!)` pair in Text::CSV's 85_util.t)
+
+plan 8;
+
+class C {
+    multi method m (Str $s! is rw) { "rw:" ~ $s }
+    multi method m (Str $s!)       { "ro:" ~ $s }
+}
+
+my Str $d = "x";
+is C.m($d),    "rw:x",   'writable variable arg picks the rw candidate';
+is C.m("lit"), "ro:lit", 'literal arg falls to the non-rw candidate (not the cached rw winner)';
+is C.m($d),    "rw:x",   'variable arg picks rw again after the literal call';
+
+# Reverse order: the literal must not freeze the ro candidate for variables.
+class D {
+    multi method m (Str $s! is rw) { "rw" }
+    multi method m (Str $s!)       { "ro" }
+}
+is D.m("lit"), "ro", 'literal first: ro candidate';
+my Str $e = "y";
+is D.m($e),    "rw", 'variable after literal still reaches the rw candidate';
+
+multi sub f(Str $x is rw) { "rw" }
+multi sub f(Str $x)       { "ro" }
+is f("lit"), "ro", 'sub multi: literal picks non-rw';
+my Str $y = "z";
+is f($y),    "rw", 'sub multi: variable picks rw';
+is f("q"),   "ro", 'sub multi: literal after variable still non-rw';
+
+done-testing;

--- a/t/self-var-assign.t
+++ b/t/self-var-assign.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+# `my $self` is an ordinary variable — scalars are stored sigil-less in
+# mutsu, so it must not collide with the compile-time "cannot assign to the
+# invocant self" check, which applies only inside a method body.
+# (Text::CSV's 85_util.t: `my $self; { $self = $csv.header($fh); CATCH ... }`)
+
+plan 4;
+
+my $self;
+$self = 42;
+is $self, 42, 'assignment to a my $self variable works at top level';
+
+{
+    $self = "in-block";
+}
+is $self, "in-block", 'assignment inside a nested block too';
+
+sub takes-self { my $self = "sub"; $self = "reassigned"; $self }
+is takes-self(), "reassigned", 'and inside a sub body';
+
+# The invocant keyword stays immutable inside a method (roast
+# S12-class/basic.t pins the exception).
+class WritableSelf { method f { self = 5 } }
+dies-ok { WritableSelf.new.f }, 'self = ... inside a method still dies';
+
+done-testing;


### PR DESCRIPTION
Four general interpreter fixes found by chasing Text::CSV's `85_util.t` (github.com/Tux/CSV) from aborting at test 5 to fully passing (110/110), bringing the suite to 29/33 fully-green files. Details in `news/2026-08/text-csv-85-util-four-fixes.md`.

1. **The type-keyed multi resolution cache excludes `is rw` candidates.** An `is rw` candidate matches only a writable-lvalue argument — a call-site property invisible to the type key — so Text::IO::String's `new (Str $str! is rw)` / `new (Str $str!)` pair froze whichever winner ran first (`new($data)` then `new($str.Str)` threw X::Parameter::RW; the reverse order routed variables to the copy candidate). Both cacheability scans now treat `is rw` as value-dependent. Pin: `t/rw-multi-dispatch-cache.t`.

2. **A pure-Raku `is IO::Handle` subclass inherits `$.chomp is rw`.** A blessed subclass instance has no native handle state, so `.chomp` fell through to the native *Str* chomp (returning the stringified invocant) and assignment died. The native fast path routes every instance to the slow path, which answers the read (stored attribute, else default True) and the lvalue assign for MRO-includes-IO::Handle classes without a user `chomp`. Pin: `t/io-handle-subclass-chomp.t`.

3. **`my $self` is assignable outside method bodies.** Scalars are stored sigil-less, so the compile-time "self is immutable" check also fired for a user variable named `$self` — `$self = $csv.header($fh)` threw X::Assignment::RO before header ran. Now gated on `lexically_in_method`; roast `S12-class/basic.t`'s method-body pin is kept. Pin: `t/self-var-assign.t`.

4. **Subscript adverbs work on QuantHash slices.** `$bag{@keys}:kv`/`:v`/`:k`/`:p` returned empty (the Set/Bag/Mix target fell into the everything-is-missing path). The target is now projected through `.hash` — decoding the internal WHICH-encoded keys — and the Hash arm owns the logic. This is exactly Text::CSV's header separator detection (`$hdr.comb.Bag{$sep-set.list}:kv`), so `;`/tab separators were never detected. Pin: `t/quanthash-slice-adverbs.t`.

Remaining suite failures: 90_csv (csv() in-format semantics: AoH header synthesis, callable providers, Supply/Channel), 91_csv_cb, 92_csv_encoding, 99_meta (external Test::META).

🤖 Generated with [Claude Code](https://claude.com/claude-code)