### PR TITLE
fix(binding+runtime): container-descriptor .VAR.name for @/% parameters — unsupplied binds "element"

### DIFF
--- a/news/2026-08/var-name-container-descriptor.md
+++ b/news/2026-08/var-name-container-descriptor.md
@@ -1,0 +1,58 @@
+# Container-descriptor .VAR.name for @/% parameters (Text::CSV runtime sweep round 7)
+
+Rakudo's `.VAR.name` on a `@`/`%` parameter reports the *container
+descriptor*'s name, not the parameter's syntactic name: an unsupplied
+optional (`sub t(:@kh) { }; t()`), a literal argument, a slurpy, and an
+`is copy` param all bind a fresh anonymous container named **"element"**,
+while a param aliasing a caller's named container reports that caller's
+sigiled name (`t(kh => @x)` → `"@x"`). mutsu always answered the param's own
+name (`"@kh"`).
+
+This mattered because Text::CSV's `method CSV` contains a rakudo#2483
+workaround that gates its entire output-mode defaulting on exactly this:
+
+    if (@kh.VAR.name ne "element") { # @kh = "@kh" or [] = "element"
+        $out     //= Hash if $out === Any;
+        $headers //= "auto";
+        }
+
+With mutsu's always-`"@kh"` answer the guard was always true, so every
+`csv(in => ...)` call silently switched to AoH output mode, shifted the
+header row into column names, and (for AoH input) emitted empty hashes —
+the bulk of 90_csv.t's 22 failures.
+
+Mechanism (three pieces):
+
+- **A fresh unsupplied-default container is tagged in its own data**:
+  `missing_optional_param_value` now builds the `@`/`%` seed via
+  `Value::element_descriptor_array()/_hash()`, which set a new
+  `descriptor_name: Option<Box<str>>` field on `ArrayData`/`HashData`
+  ("element"). The tag travels with the value, so both the light and slow
+  bind paths are covered at one chokepoint.
+- **The slow binder records caller sources**: positional by-ref container
+  params already registered `(param, source)` in `rw_bindings`; supplied
+  *named* container params now record theirs in a parallel list, and a pass
+  at the end of `bind_function_args_values` writes
+  `__mutsu_var_source_name::` env metadata (caller's name, or "element" for
+  literal/copy/slurpy bindings).
+- **The `.VAR` reflector validates its cache**: the built Variable-meta
+  instance is cached per name (`var_meta_value`), which froze the FIRST
+  call's answer for every later call of the same sub (call 1 unsupplied →
+  "element" forever, even once supplied). The reflector now recomputes the
+  descriptor name (value tag → env metadata → syntactic name) and rebuilds
+  the meta instance when the cached one's `name` disagrees.
+
+Also fixed on the way: a supplied `@`/`%` named param in the light bind path
+now always refreshes the env entry alongside its slot (`bind_value` with
+forced `needs_env`) — a previous unsupplied call's seed otherwise stayed
+visible to env-reading ops in the body while the slot held the real
+argument.
+
+Deviation kept deliberately: for a supplied-from-variable *named* param the
+light path reports the param's own name (`"@kh"`) rather than rakudo's
+caller name (`"@x"`) — the argument value carries no source there. Both
+satisfy the `ne "element"` contract; the pin asserts exactly that shape.
+
+90_csv.t: 22 failures → 3 (only the Channel in-format and its follow-on
+abort remain). Pin: `t/var-name-container-descriptor.t` (14 assertions,
+raku-verified).

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -147,8 +147,55 @@ impl Interpreter {
             ) {
                 return Ok(target);
             }
+            // A `@`/`%` parameter's container descriptor carries its BINDING
+            // source name, not the param's syntactic name: "element" for the
+            // fresh anonymous container an unsupplied param binds (tagged in
+            // its own data by `missing_optional_param_value`, so it survives
+            // every bind path), or the caller's variable recorded by the slow
+            // binder as `__mutsu_var_source_name::` env metadata. Text::CSV's
+            // `method CSV` gates on `@kh.VAR.name ne "element"`.
+            let container_source_name = (target_var.starts_with('@')
+                || target_var.starts_with('%'))
+            .then(|| {
+                target
+                    .with_deref(|v| match v.view() {
+                        ValueView::Array(data, _) => {
+                            data.descriptor_name.as_ref().map(|s| s.to_string())
+                        }
+                        ValueView::Hash(data) => {
+                            data.descriptor_name.as_ref().map(|s| s.to_string())
+                        }
+                        _ => None,
+                    })
+                    .or_else(|| {
+                        self.env
+                            .get(&format!("__mutsu_var_source_name::{}", target_var))
+                            .map(Value::to_string_value)
+                    })
+            })
+            .flatten();
             if let Some(existing) = self.var_meta_value(target_var) {
-                return Ok(existing);
+                // The cached meta instance goes stale when the SAME param name
+                // is re-bound differently on a later call of the sub (call 1
+                // unsupplied -> "element", call 2 supplied -> the param /
+                // caller name): only reuse it when its recorded name matches
+                // the current binding's descriptor name.
+                let expected = container_source_name
+                    .clone()
+                    .unwrap_or_else(|| target_var.to_string());
+                let cached_name = match existing.view() {
+                    ValueView::Instance { attributes, .. } => attributes
+                        .as_map()
+                        .get("name")
+                        .map(Value::to_string_value)
+                        .unwrap_or_default(),
+                    _ => expected.clone(),
+                };
+                if !(target_var.starts_with('@') || target_var.starts_with('%'))
+                    || cached_name == expected
+                {
+                    return Ok(existing);
+                }
             }
             let readonly_key = format!("__mutsu_sigilless_readonly::{}", target_var);
             let alias_key = format!("__mutsu_sigilless_alias::{}", target_var);
@@ -193,7 +240,9 @@ impl Interpreter {
             } else {
                 "Scalar"
             };
-            let display_name = if target_var.starts_with('$')
+            let display_name = if let Some(src) = container_source_name {
+                src
+            } else if target_var.starts_with('$')
                 || target_var.starts_with('@')
                 || target_var.starts_with('%')
                 || target_var.starts_with('&')

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -551,6 +551,12 @@ impl Interpreter {
         // by an unrelated later writeback of the same name in this frame.
         let arg_source_slots = std::mem::take(&mut self.pending_call_arg_source_slots);
         let mut rw_bindings = Vec::new();
+        // `@`/`%` params whose argument came from a named caller container but
+        // which take no `rw_bindings` entry (supplied *named* container params
+        // don't register an exit writeback) — recorded solely so the
+        // container-descriptor `.name` pass at the end can report the caller's
+        // name instead of "element".
+        let mut container_param_sources: Vec<(String, String)> = Vec::new();
         let mut raw_nonlvalue_params: Vec<String> = Vec::new();
         if let Some(invocant_value) = self
             .env
@@ -1273,6 +1279,25 @@ impl Interpreter {
                         // (`:$n` shorthand over `my $n = @a`) is excluded — it shares
                         // by reference already, like the positional scalar source.
                         let mut bound_value = val.clone();
+                        // Supplied `@`/`%` named param bound from a caller
+                        // container variable: record the source for the
+                        // container-descriptor `.name` pass at the end.
+                        if (pd.name.starts_with('@') || pd.name.starts_with('%'))
+                            && !pd.name[1..].starts_with(['!', '.'])
+                            && let Some(source_name) = arg_sources
+                                .as_ref()
+                                .and_then(|names| names.get(arg_idx))
+                                .and_then(|n| n.as_ref())
+                                .and_then(|encoded| {
+                                    encoded.split_once('=').map(|(_, s)| s.to_string())
+                                })
+                                .or_else(|| {
+                                    varref_from_value(val).map(|(name, _)| name.to_string())
+                                })
+                                .filter(|s| s.starts_with('@') || s.starts_with('%'))
+                        {
+                            container_param_sources.push((pd.name.clone(), source_name));
+                        }
                         // A named param's declared type constraint (built-in,
                         // user class, or user `subset`) must be enforced here
                         // too — this used to be positional-only (see
@@ -2309,6 +2334,39 @@ impl Interpreter {
                     self.unmark_readonly(&pd.name);
                 }
             }
+        }
+        // Rakudo's container-descriptor `.name` for `@`/`%` parameters
+        // (`@kh.VAR.name`): a param aliasing a caller's named container reports
+        // the CALLER's sigiled name; every other binding (unsupplied default,
+        // literal argument, slurpy, `is copy` — all fresh containers) reports
+        // "element". Text::CSV's `method CSV` gates its whole out/headers
+        // defaulting on `@kh.VAR.name ne "element"` (its rakudo#2483
+        // workaround), so answering the param's own syntactic name here
+        // silently rewrote csv()'s output mode into AoH. Recorded as frame env
+        // metadata; the `.VAR` reflector prefers it over the syntactic name.
+        for pd in param_defs {
+            if !(pd.name.starts_with('@') || pd.name.starts_with('%'))
+                || pd.name[1..].starts_with(['!', '.'])
+            {
+                continue;
+            }
+            let is_copy = pd.traits.iter().any(|t| t == "copy");
+            let source = (!is_copy)
+                .then(|| {
+                    rw_bindings
+                        .iter()
+                        .chain(container_param_sources.iter())
+                        .find_map(|(name, src)| {
+                            (name == &pd.name && (src.starts_with('@') || src.starts_with('%')))
+                                .then(|| src.clone())
+                        })
+                })
+                .flatten()
+                .unwrap_or_else(|| "element".to_string());
+            self.env.insert(
+                format!("__mutsu_var_source_name::{}", pd.name),
+                Value::str(source),
+            );
         }
         self.fold_rw_writeback_slots(&rw_bindings, &arg_source_slots);
         Ok(rw_bindings)

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -549,11 +549,16 @@ impl Interpreter {
     }
 
     pub(crate) fn missing_optional_param_value(pd: &ParamDef) -> Value {
+        // An unsupplied `@`/`%` param binds a fresh anonymous container whose
+        // rakudo container-descriptor name is "element" — tag the value so
+        // `.VAR.name` reports it (Text::CSV's `@kh.VAR.name ne "element"`
+        // guard, its rakudo#2483 workaround). The tag travels with the value,
+        // so both the light and slow bind paths are covered here.
         if pd.name.starts_with('@') {
-            return Value::real_array(Vec::new());
+            return Value::element_descriptor_array();
         }
         if pd.name.starts_with('%') {
-            return Value::hash(std::collections::HashMap::new());
+            return Value::element_descriptor_hash();
         }
         if pd.name.starts_with('&') && pd.type_constraint.is_none() {
             // An unsupplied `&`-sigil param's implicit nominal type is

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1177,6 +1177,13 @@ pub struct HashData {
     /// table broke whenever the backing `Arc` was rebuilt. Mirrors the array
     /// `ArrayData::default` field.
     pub default: Option<Box<Value>>,
+    /// Rakudo container-descriptor name override for `.VAR.name`. `Some` only
+    /// on the fresh anonymous container an unsupplied `%`-param binds
+    /// ("element"), so `%o.VAR.name` distinguishes it from a supplied one
+    /// (Text::CSV's `@kh.VAR.name ne "element"` guard). `None` keeps the
+    /// reflector's syntactic-name fallback. Mirrors
+    /// `ArrayData::descriptor_name`.
+    pub descriptor_name: Option<Box<str>>,
 }
 
 /// Backing data for `Value::Array`: the element vector plus embedded
@@ -1225,6 +1232,12 @@ pub struct ArrayData {
     /// filled from inside a method/closure (e.g. HTTP::Status's `method sink`
     /// populating `@codes`) reported every gap as existing.
     pub initialized: Option<std::collections::HashSet<usize>>,
+    /// Rakudo container-descriptor name override for `.VAR.name`. `Some` only
+    /// on the fresh anonymous container an unsupplied `@`-param binds
+    /// ("element"), so `@kh.VAR.name` distinguishes it from a supplied one
+    /// (Text::CSV's `@kh.VAR.name ne "element"` guard — its rakudo#2483
+    /// workaround). `None` keeps the reflector's syntactic-name fallback.
+    pub descriptor_name: Option<Box<str>>,
 }
 
 /// Value stored in an enum variant: an integer, a string, or an arbitrary Value.

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -49,6 +49,7 @@ impl HashData {
             declared_type: None,
             original_keys: None,
             default: None,
+            descriptor_name: None,
         }
     }
 
@@ -162,6 +163,7 @@ impl ArrayData {
             default: None,
             shape: None,
             initialized: None,
+            descriptor_name: None,
         }
     }
 

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -220,6 +220,21 @@ impl Value {
     pub fn real_array(items: Vec<Value>) -> Self {
         Value::Array(crate::gc::Gc::new(ArrayData::new(items)), ArrayKind::Array)
     }
+    /// Fresh empty Array tagged with the "element" container-descriptor name —
+    /// what an unsupplied `@`-param binds (rakudo: `@kh.VAR.name` is
+    /// "element" there, and Text::CSV's `method CSV` gates on it).
+    pub(crate) fn element_descriptor_array() -> Self {
+        let mut data = ArrayData::new(Vec::new());
+        data.descriptor_name = Some("element".into());
+        Value::Array(crate::gc::Gc::new(data), ArrayKind::Array)
+    }
+    /// Fresh empty Hash tagged with the "element" container-descriptor name —
+    /// the `%`-param twin of [`Value::element_descriptor_array`].
+    pub(crate) fn element_descriptor_hash() -> Self {
+        let mut data = HashData::new(std::collections::HashMap::new());
+        data.descriptor_name = Some("element".into());
+        Value::hash(data)
+    }
     /// Create a true Array value with a single explicitly-assigned index
     /// recorded in the embedded `initialized` set (used when autovivifying a
     /// missing variable via `@a[i] = …`, so the autovivification gaps below `i`
@@ -281,6 +296,7 @@ impl Value {
             default: like.default.clone(),
             shape: like.shape.clone(),
             initialized: like.initialized.clone(),
+            descriptor_name: like.descriptor_name.clone(),
         })
     }
     /// Construct a `Value::Hash`. Accepts either a bare `HashMap` (fresh hash)

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -311,7 +311,15 @@ impl Interpreter {
                 }
                 self.env_mut().insert(alias_name.clone(), v.clone());
             }
-            bind_value!(npb.slot, npb.needs_env, v);
+            // A supplied `@`/`%` named param must also refresh the env entry: a
+            // previous call of this sub may have left its UNSUPPLIED seed (the
+            // "element"-tagged fresh container) there via the miss arm's forced
+            // env write, and env-reading ops in the body (`.VAR` reflection,
+            // the CallMethodMut by-name re-read) would see that stale container
+            // while the slot holds the real argument.
+            let pn = &cf.param_defs[i].name;
+            let is_container_param = pn.starts_with('@') || pn.starts_with('%');
+            bind_value!(npb.slot, npb.needs_env || is_container_param, v);
         }
         // Surplus positional args are an arity error (mixed signatures only —
         // all-named signatures keep their historical lax behavior for a stray

--- a/t/var-name-container-descriptor.t
+++ b/t/var-name-container-descriptor.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# Rakudo's container-descriptor `.name` (`.VAR.name`) for @/% parameters:
+# an unsupplied / literal-bound / slurpy / `is copy` param binds a FRESH
+# anonymous container whose descriptor name is "element"; a param aliasing a
+# caller's named container reports a non-"element" name (rakudo: the caller's
+# name; mutsu may report the param's own name — both satisfy the contract).
+# Text::CSV's `method CSV` gates its whole out/headers defaulting on exactly
+# `@kh.VAR.name ne "element"` (its rakudo#2483 workaround), so getting the
+# unsupplied case wrong silently rewrote csv()'s output mode (90_csv.t).
+
+plan 14;
+
+sub named(:@kh) { @kh.VAR.name }
+is named(), "element", 'unsupplied :@kh binds an "element" container';
+my @x = 1, 2;
+isnt named(kh => @x), "element", 'supplied :@kh (from a variable) is not "element"';
+is named(), "element", 'unsupplied again after a supplied call (no stale meta cache)';
+
+sub named-default(:@kh = [9]) { @kh.VAR.name }
+is named-default(), "element", 'unsupplied :@kh with a default is still "element"';
+
+sub named-hash(:%o) { %o.VAR.name }
+is named-hash(), "element", 'unsupplied :%o binds an "element" container';
+my %y = a => 1;
+isnt named-hash(o => %y), "element", 'supplied :%o is not "element"';
+is named-hash(), "element", 'unsupplied :%o again after a supplied call';
+
+sub positional(@a) { @a.VAR.name }
+is positional(@x), '@x', 'positional @a bound from @x reports the caller name';
+is positional([1, 2]), "element", 'positional @a bound from a literal is "element"';
+
+sub positional-hash(%h) { %h.VAR.name }
+is positional-hash(%y), '%y', 'positional %h bound from %y reports the caller name';
+
+sub slurpy-arr(*@r) { @r.VAR.name }
+is slurpy-arr(1, 2), "element", 'slurpy *@r is a fresh "element" container';
+
+sub copied(@a is copy) { @a.VAR.name }
+is copied(@x), "element", 'is copy binds a fresh "element" container';
+
+my @z = 3, 4;
+is @z.VAR.name, '@z', 'a plain my @z keeps its own name';
+my %w = k => 1;
+is %w.VAR.name, '%w', 'a plain my %w keeps its own name';
+
+done-testing;


### PR DESCRIPTION
Rakudo's `.VAR.name` on a `@`/`%` parameter reports the *container descriptor*'s name: **"element"** for the fresh anonymous container an unsupplied optional / literal argument / slurpy / `is copy` param binds, and the caller's sigiled name for a by-reference alias (`f(@x)` → `"@x"`). mutsu always answered the param's own syntactic name.

Text::CSV's `method CSV` gates its whole output-mode defaulting on exactly `@kh.VAR.name ne "element"` (its rakudo#2483 workaround), so the always-true guard silently switched every `csv(in => ...)` call into AoH output mode, shifted the header row into column names, and emitted empty hashes. **90_csv.t: 22 failures → 3** (only the Channel in-format and its follow-on abort remain — next slice). Details in `news/2026-08/var-name-container-descriptor.md`.

Mechanism:
1. `missing_optional_param_value` tags the fresh `@`/`%` seed in its own `ArrayData`/`HashData` (new `descriptor_name` field) — one chokepoint covers both the light and slow bind paths.
2. `bind_function_args_values` records caller sources for supplied container params (positional via the existing `rw_bindings`, supplied *named* container params via a new parallel list) as `__mutsu_var_source_name::` env metadata.
3. The `.VAR` reflector recomputes the descriptor name (value tag → env metadata → syntactic name) and rebuilds its cached Variable-meta instance when the cached name disagrees — the per-name cache froze call 1's answer for every later call of the same sub.
4. The light bind path refreshes the env entry for a supplied `@`/`%` named param (forced `needs_env`) so a previous unsupplied call's tagged seed can't shadow the real argument for env-reading ops.

Deviation kept deliberately: a supplied-from-variable *named* param reports the param's own name (`"@kh"`) rather than rakudo's caller name where the argument value carries no source — both satisfy the `ne "element"` contract, and the pin asserts that shape (`isnt ..., "element"`).

Pin: `t/var-name-container-descriptor.t` (14 assertions, passes under raku too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)