### PR TITLE
feat(dispatch): ADR-0019 E7 step 4, shadow-check .^can against E2 row lookup

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3397,6 +3397,54 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   sub-slice: `.^lookup`/`.^can`/`.^methods` reading the call-path sequence, per the design's
   consumer ordering (the `.^can` dummy-`Value::NIL` probe replacement is called out specifically in
   the design paragraph above).
+  **Progress 2026-08-12** (fourth consumer family, `.^can`, shadow-measurement — cutover
+  DEFERRED): `Interpreter::collect_can_methods`'s (`runtime/methods_classhow_method_obj.rs`) last
+  fallback tier is exactly the dummy-`Value::NIL`-arg probe this design paragraph names
+  (`native_method_1arg(target, method_sym, &Value::NIL)`, invoking the real 1-arg cascade with a
+  fake arg just to see if `Some(_)` comes back — no 2-arg check exists at all). A new existence
+  predicate, `Interpreter::e2_native_method_exists` (`runtime/receiver_class.rs`), asks the E2
+  catalog directly instead: it walks the receiver's full `dispatch_owner_chain` (sharing a new
+  `chain_owner_probe` helper with `record_native_row_coverage`) and, at each level, checks a new
+  `native_method_row::native_method_row_exists(owner, name)` — table PRESENCE, not
+  `native_method_row`'s returned arity/flags, which cannot answer "does this method exist at all"
+  by itself (a missing key and a genuinely-probed "exists but only via a special/mutating path" row
+  like `List.push` share the identical `(N, ...)` bit pattern, confirmed by a unit test). Unlike
+  E4b's `native_row_servable` (which `resolve_sequence`'s `Native` candidate uses to ask "is this
+  row reachable for THIS call's shape"), this deliberately ignores `SPECIAL`/`MUTATES_RECEIVER`/
+  arity/definedness — `.can` asks "does Raku consider this a method at all", confirmed against real
+  Raku (`List.can("push")` is true on an indefinite type object). `collect_can_methods` computes
+  both answers under `MUTSU_VM_STATS` and records agreement via a NEW dedicated counter pair
+  (`record_can_shadow_check`, `vm/vm_stats.rs`) rather than the shared E4a/E4b/E7-steps-1-3
+  `RESOLVER_SHADOW_*`/`NATIVE_ROW_SHADOW_*` infra, since this compares two existence predicates and
+  never touches `resolve_sequence` — reusing the shared total would repeat the exact "false lead"
+  step 1's progress note above describes. Pure insertion, zero behavior change: the dummy-arg probe
+  alone still drives `.can`'s real answer. **Swept a 16-case hand-built probe script, all 16
+  already-whitelisted roast files that call `.can`/`.^can` (found by grepping roast for
+  `\.\^?can\(`), and the full local `t/` suite (3057 files/28,557 tests)**: 115 total
+  `can_shadow_checks`, 3 `can_shadow_mismatches`, every one `real=true shadow=false` (the E2 lookup
+  under-answers, never over-answers) — `IO::Path.can("e")` (`IO::Path` is one of the owners
+  `native_method_row.rs`'s own module doc already names as never probed by E2a/E2b at all),
+  `(1,2).^can('int8')` (`t/native-int-coerce-methods-are-cool-only.t:18` — `Cool` is an ABSTRACT
+  owner the row-*generation* probe skipped for lack of a sample value, even though
+  `builtin_type_method_names("Cool")` does list `int8`), and `$c.can("cancel")` on a scheduler
+  `Cancellation` handle (`t/scheduler-cue-times.t:18` — a class entirely outside the 14-owner
+  E2a/E2b campaign scope, answered by the dummy probe's separate `classhow_find_method` tier). Every
+  mismatch traces to a documented, already-known catalog-coverage gap, not a real dispatch-path bug
+  — so, per this box's own "if the catalog's incompleteness would make `.can` wrongly answer `false`
+  for something genuinely callable, do NOT cut over" guidance, **the cutover is deferred, not
+  landed**: `e2_native_method_exists` stays shadow-only, and `has_native`'s existing tiers keep
+  driving `.can`/`.^can` unchanged. `cargo build`/`cargo test --lib` (810 tests, 6 new: 2 pin the
+  `native_method_row_exists` table-presence-vs-return-value distinction, 4 exercise
+  `e2_native_method_exists`'s chain walk including a 2-arg-only-method case the dummy probe's
+  0/1-arg-only cascade calls cannot see) / `cargo clippy -- -D warnings` / `cargo fmt` clean; `make
+  test` green. Because `.can`/`.^can` is a public API surface, this step's local verification went
+  beyond the usual single-slice scope (full `t/`, every roast file that calls `.can` at all, not a
+  sample). Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 4: `.^can` —
+  shadow-measured, cutover DEFERRED (E2 catalog coverage gap)". **This is the first E7 sub-slice
+  that is not a clean zero-mismatch/zero-fix result — as this design paragraph itself predicted —
+  but the correct response to a catalog-coverage gap (not a dispatch-path bug) is to defer the
+  cutover, not force it.** Next E7 sub-slice: `.^lookup`/`.^methods` reading the call-path sequence
+  (WALK and the EVAL/re-entrant carriers come after those, per the design's consumer ordering).
 - [ ] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
   **Design 2026-08-10** (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`):

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -181,6 +181,23 @@ pub(crate) fn native_method_row(
         .unwrap_or((NativeArityMask::N, NativeRowFlags::SPECIAL))
 }
 
+/// Whether the catalog has an EXPLICIT recognition row for `(owner, name)` --
+/// i.e. E2a/E2b's probe actually classified this pair as a real method on
+/// `owner`, at some arity, via some path. ADR-0019 Phase E box E7 step 4
+/// (`.^can`, `todo/deep/adr0019-e5-e7-entry-routing.md` "E7 step 4") is the
+/// first production reader, and needs exactly this "does this method exist
+/// at all" question -- which [`native_method_row`]'s *return value* cannot
+/// answer by itself: a missing key falls back to the same `(N, SPECIAL)` bit
+/// pattern a genuinely-probed "exists, but only via a special/mutating path
+/// outside the pure arity cascades" row also carries (e.g. `Str.match`,
+/// `List.push` are both `(N, ...)` despite being real methods), so checking
+/// the returned mask can never distinguish "not a method" from "a method,
+/// just not reachable by `native_method_{0,1,2}arg`". Presence in the table
+/// is the only signal E2's data actually carries for that question.
+pub(crate) fn native_method_row_exists(owner: &'static str, name: &'static str) -> bool {
+    classification_table().contains_key(&(owner, name))
+}
+
 /// The full native-method-row catalog for one built-in owner, in `.^methods`
 /// catalog order -- the [`NativeMethodRow`] counterpart of
 /// [`builtin_method_entries`]. `#[cfg(test)]`: see [`NativeMethodRow`]'s doc.
@@ -224,6 +241,36 @@ mod tests {
         let (arity, flags) = native_method_row("NoSuchOwner", "no-such-method");
         assert_eq!(arity, NativeArityMask::N);
         assert!(flags.contains(NativeRowFlags::SPECIAL));
+    }
+
+    /// ADR-0019 E7 step 4: `native_method_row_exists` answers "is this a
+    /// real method at all", distinct from `native_method_row`'s
+    /// arity/flags -- which, as the two assertions below show, cannot be
+    /// used for that question on its own.
+    #[test]
+    fn row_exists_is_true_for_a_known_pair_and_false_for_an_unprobed_one() {
+        assert!(native_method_row_exists("Str", "chars"));
+        assert!(!native_method_row_exists("NoSuchOwner", "no-such-method"));
+    }
+
+    /// The exact ambiguity `native_method_row_exists`'s doc comment warns
+    /// about: `List.push` is a real method (E2a/E2b probed and confirmed
+    /// it), but its row is `(N, MUTATES_RECEIVER)` -- the identical bit
+    /// pattern `native_method_row` returns for a pair it never saw. Only
+    /// `native_method_row_exists` (table presence) tells the two apart;
+    /// `native_method_row`'s returned mask alone cannot, since both cases
+    /// share the same `NativeArityMask::N` value.
+    #[test]
+    fn row_exists_distinguishes_special_only_method_from_unprobed_miss() {
+        let (push_arity, push_flags) = native_method_row("List", "push");
+        assert_eq!(push_arity, NativeArityMask::N);
+        assert!(push_flags.contains(NativeRowFlags::MUTATES_RECEIVER));
+        assert!(native_method_row_exists("List", "push"));
+
+        let (miss_arity, miss_flags) = native_method_row("List", "no-such-method");
+        assert_eq!(miss_arity, NativeArityMask::N);
+        assert!(miss_flags.contains(NativeRowFlags::SPECIAL));
+        assert!(!native_method_row_exists("List", "no-such-method"));
     }
 
     /// ADR-0019 E2b: the hand-added `Any`/`Mu` universal rows (`so`, `not`,

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -447,6 +447,23 @@ impl Interpreter {
                     let pkg = Value::package(Symbol::intern(&class_name));
                     self.classhow_find_method(&pkg, method_name).is_some()
                 };
+            // ADR-0019 Phase E box E7 step 4 (`todo/deep/adr0019-e5-e7-entry-
+            // routing.md` "E7 step 4"): shadow-check the dummy-`Value::NIL`-arg
+            // probe above against an E2 native-method-row catalog lookup
+            // (`Interpreter::e2_native_method_exists`) for the SAME question
+            // ("does target have a native method_name at all"). A dedicated
+            // counter pair (not the E4a/E7 `resolve_sequence`-winner shadow
+            // infra those steps reused) because this compares two EXISTENCE
+            // predicates, not two dispatch-winner picks. `MUTSU_VM_STATS`-gated,
+            // zero behavior change: `has_native` alone still drives `results`.
+            if crate::vm::vm_stats::enabled() {
+                let e2_says = self.e2_native_method_exists(target, method_sym.as_str());
+                crate::vm::vm_stats::record_can_shadow_check(has_native == e2_says, || {
+                    format!(
+                        "class={class_name} method={method_name} real={has_native} shadow={e2_says}"
+                    )
+                });
+            }
             if has_native {
                 results.push(Value::routine_parts(
                     Symbol::intern(&class_name),

--- a/src/runtime/receiver_class.rs
+++ b/src/runtime/receiver_class.rs
@@ -431,20 +431,10 @@ impl Interpreter {
         }
         let chain = self.dispatch_owner_chain(target);
         let mask = crate::builtins::native_method_row::NativeArityMask::for_arity(arity);
-        let covered = chain.iter().any(|owner| {
-            let owner = owner.as_str();
-            if crate::builtins::native_method_row::native_method_row(owner, name)
+        let covered = chain_owner_probe(&chain, |owner| {
+            crate::builtins::native_method_row::native_method_row(owner, name)
                 .0
                 .contains(mask)
-            {
-                return true;
-            }
-            let folded = crate::builtins::builtin_type_methods::canonical_builtin_owner(owner);
-            !folded.is_empty()
-                && folded != owner
-                && crate::builtins::native_method_row::native_method_row(folded, name)
-                    .0
-                    .contains(mask)
         });
         let owner = chain
             .first()
@@ -452,6 +442,48 @@ impl Interpreter {
             .unwrap_or_else(|| crate::type_id::well_known_types().any.as_str());
         crate::vm::vm_stats::record_native_call_recognition(site, owner, name, covered);
     }
+
+    /// ADR-0019 Phase E box E7 step 4 (`.^can`,
+    /// `todo/deep/adr0019-e5-e7-entry-routing.md` "E7 step 4"): does the E2
+    /// native-method-row catalog have an explicit recognition row for `name`
+    /// at ANY level of `target`'s dispatch chain -- the "does Raku consider
+    /// this name a method on this type at all" existence question `.^can`
+    /// asks. This is deliberately a DIFFERENT question from
+    /// [`crate::runtime::resolution_sequence::native_row_servable`]'s
+    /// call-shape-specific "is this row reachable for THIS call" (E4b's
+    /// `Native` resolver candidate): unlike that function, this does NOT
+    /// exclude `SPECIAL`/`MUTATES_RECEIVER` rows (a mutating method like
+    /// `List.push` still IS a method `.can` should find) and ignores
+    /// arity/definedness entirely (a method existing at any arity, or
+    /// requiring definedness, still means `.can` is true) -- confirmed
+    /// against real Raku behavior (`raku -e 'say List.can("push")'` is
+    /// `(&push)`, true, on an INDEFINITE type object). Shares the same
+    /// chain-walk-plus-`canonical_builtin_owner`-fold traversal as
+    /// [`Self::record_native_row_coverage`] via [`chain_owner_probe`].
+    pub(crate) fn e2_native_method_exists(&mut self, target: &Value, name: &'static str) -> bool {
+        let chain = self.dispatch_owner_chain(target);
+        chain_owner_probe(&chain, |owner| {
+            crate::builtins::native_method_row::native_method_row_exists(owner, name)
+        })
+    }
+}
+
+/// Shared chain-walk-plus-fold traversal for [`Interpreter::record_native_row_coverage`]
+/// and [`Interpreter::e2_native_method_exists`]: try `probe` at each level of
+/// `chain` (most-derived first), and, when it fails, retry through
+/// [`crate::builtins::builtin_type_methods::canonical_builtin_owner`]'s fold
+/// (`Buf`/`Blob`/... -> `Blob`, `Sub`/`Method`/... -> `Code`, etc.) -- the
+/// catalog is keyed by the folded owner, so a plain per-level lookup would
+/// otherwise never find a Buf/Blob-family (or Sub/Method/...-family) row.
+fn chain_owner_probe(chain: &[TypeId], mut probe: impl FnMut(&'static str) -> bool) -> bool {
+    chain.iter().any(|owner| {
+        let owner = owner.as_str();
+        if probe(owner) {
+            return true;
+        }
+        let folded = crate::builtins::builtin_type_methods::canonical_builtin_owner(owner);
+        !folded.is_empty() && folded != owner && probe(folded)
+    })
 }
 
 #[cfg(test)]
@@ -557,5 +589,43 @@ mod tests {
         let chain = i.dispatch_mro(&Value::hash(std::collections::HashMap::new()));
         let names: Vec<&str> = chain.iter().map(|t| t.as_str()).collect();
         assert_eq!(names, vec!["Hash", "Map", "Cool", "Any", "Mu"]);
+    }
+
+    /// ADR-0019 E7 step 4: a plain 1-arg-recognized row is found at the
+    /// receiver's own (most-derived) chain level.
+    #[test]
+    fn e2_native_method_exists_finds_own_level_row() {
+        let mut i = interp();
+        assert!(i.e2_native_method_exists(&Value::str_from("abc"), "chars"));
+    }
+
+    /// The dummy-`Value::NIL`-arg probe this box replaces only ever calls
+    /// `native_method_0arg`/`native_method_1arg` -- never a 2-arg cascade --
+    /// so a 2-arg-only method is invisible to it. `Str.substr-eq(pos, needle)`
+    /// is exactly such a row (`("Str", "substr-eq", NativeArityMask::A2, ...)`
+    /// in the generated table); the E2-row lookup finds it because it asks
+    /// about EXISTENCE, not about whether a 0/1-arg cascade call happens to
+    /// answer `Some`.
+    #[test]
+    fn e2_native_method_exists_finds_a_two_arg_only_method() {
+        let mut i = interp();
+        assert!(i.e2_native_method_exists(&Value::str_from("abc"), "substr-eq"));
+    }
+
+    /// A method that IS recognized, but only via a special/mutating path
+    /// outside the pure arity cascades (`List.push`), still exists.
+    #[test]
+    fn e2_native_method_exists_finds_a_mutating_only_method() {
+        let mut i = interp();
+        let arr = Value::array(vec![Value::int(1)]);
+        assert!(i.e2_native_method_exists(&arr, "push"));
+    }
+
+    /// A name the catalog never claims for this chain at all is correctly
+    /// reported absent.
+    #[test]
+    fn e2_native_method_exists_is_false_for_an_unknown_name() {
+        let mut i = interp();
+        assert!(!i.e2_native_method_exists(&Value::int(1), "no-such-method-at-all"));
     }
 }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -504,6 +504,42 @@ pub(crate) fn record_native_row_shadow_check(matched: bool, detail: impl FnOnce(
     }
 }
 
+// ADR-0019 Phase E box E7 step 4 (`.^can`, `todo/deep/adr0019-e5-e7-entry-
+// routing.md` "E7 step 4"): shadow comparison between `collect_can_methods`'s
+// existing dummy-`Value::NIL`-arg native probe and the new E2-row-catalog
+// existence check (`Interpreter::e2_native_method_exists`), for the same
+// `(receiver, method_name)` question. Deliberately a SEPARATE counter pair
+// from `RESOLVER_SHADOW_*`/`NATIVE_ROW_SHADOW_*` above: those compare a
+// dispatch-WINNER pick against `resolve_sequence`; this compares two
+// EXISTENCE predicates that never invoke `resolve_sequence` at all, so
+// mixing them into a shared total would repeat the "false lead" step 1 had
+// to disentangle (see the ADR's E7 step 1 progress note). Nothing reads
+// these counters to make a dispatch decision: shadow-only, zero behavior
+// change.
+static CAN_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static CAN_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn can_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one E7 step-4 `.^can` shadow comparison. `detail` is only
+/// evaluated on a mismatch, mirroring [`record_native_row_shadow_check`].
+#[inline]
+pub(crate) fn record_can_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    CAN_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        CAN_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = can_shadow_mismatch_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -967,6 +1003,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e4b native-row-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let can_shadow_checks = CAN_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let can_shadow_mismatches = CAN_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-e7: can_shadow_checks={can_shadow_checks} can_shadow_mismatches={can_shadow_mismatches}"
+    );
+    if let Ok(map) = can_shadow_mismatch_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-e7 can-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -2115,3 +2115,117 @@ sub-slice: `.^lookup`/`.^can`/`.^methods` reading the call-path sequence, per th
 ordering — the design paragraph calls out the `.^can` dummy-`Value::NIL` probe replacement
 specifically as "a correctness fix as well as a routing change," so that sub-slice is not expected
 to be another clean zero-mismatch/zero-fix result the way steps 1/2 were.
+
+## E7 step 4: `.^can` — shadow-measured, cutover DEFERRED (E2 catalog coverage gap)
+
+`Interpreter::collect_can_methods` (`runtime/methods_classhow_method_obj.rs`) implements
+`.can`/`.^can`. When no user-declared method/attribute-accessor answers a probe, it falls back to a
+"does the native layer serve this name" check whose last tier is exactly the dummy-`Value::NIL`-arg
+probe the design paragraph above names: `native_method_1arg(target, method_sym, &Value::NIL)`
+literally invokes the real 1-arg dispatch cascade with a fake argument and checks for `Some(_)` —
+fragile (a method that branches on its argument's type/value could answer wrong, or run a real side
+effect) and incomplete (there is no 2-arg check at all, so a 2-arg-only method is invisible to this
+tier specifically; the surrounding `builtin_type_method_names(&class_name)` name-list tier fills
+some, but not all, of that gap — see below).
+
+**The two questions are structurally different, so this step could not reuse E4b's existing
+`native_row_servable`.** That function (`resolve_sequence`'s `Native` candidate, `resolution_sequence.rs`)
+answers "is this row reachable by the pure arity cascade for THIS SPECIFIC call" — it excludes
+`SPECIAL`/`MUTATES_RECEIVER` rows and requires `TYPE_OBJECT_OK` for an indefinite receiver. `.can`
+asks a different, broader question: "does Raku consider this name a method on this type at all" —
+confirmed against real Raku (`raku -e 'say List.can("push")'` is `(&push)`, true, on the INDEFINITE
+type object, even though `push` is a `MUTATES_RECEIVER` row). So E7 step 4 needed a new, simpler
+existence predicate.
+
+**A second subtlety, only found by reading `native_method_row`'s own return-value contract, not by
+guessing:** `native_method_row(owner, name)`'s *return value* cannot answer "does this method exist"
+by itself. A missing key conservatively falls back to `(NativeArityMask::N, NativeRowFlags::SPECIAL)`
+— but a genuinely-probed row that exists ONLY via a special/mutating path outside the pure arity
+cascades (e.g. `("List", "push", N, MUTATES_RECEIVER)`, `("Str", "match", N, SPECIAL)`) carries the
+*exact same* `(N, ...)` bit pattern. Checking "is the returned arity mask non-empty" (the task's own
+first-pass suggestion) is therefore useless — `NativeArityMask::N`'s bit is always set in the
+fallback too, so the mask is never empty either way. The only signal the catalog actually carries for
+existence is TABLE PRESENCE, which needed a new function,
+`native_method_row::native_method_row_exists(owner, name) -> bool` (`classification_table().contains_key(...)`)
+— confirmed directly with a unit test that puts `List.push`'s row (a real, probed "special-only"
+method) side by side with an unprobed miss and shows both share `(N, SPECIAL)`/`(N, MUTATES_RECEIVER)`-flavored
+masks yet only one is `_exists`.
+
+**Mechanism**: `Interpreter::e2_native_method_exists(target, name)` (`runtime/receiver_class.rs`,
+next to `record_native_row_coverage`, which it now shares a chain-walk-plus-fold helper with,
+`chain_owner_probe`) walks `target`'s full `dispatch_owner_chain` and, at each level, tries
+`native_method_row_exists(owner, name)` and then `canonical_builtin_owner(owner)`'s fold — the exact
+traversal `record_native_row_coverage` already used, extracted so this box does not re-derive the
+fold logic a third time. Deliberately does NOT exclude `SPECIAL`/`MUTATES_RECEIVER` rows (unlike
+`native_row_servable`) and ignores arity/definedness entirely — existence, not invocability.
+`collect_can_methods` computes this alongside the existing dummy-probe `has_native` answer, under
+`MUTSU_VM_STATS`, and records agreement via a NEW dedicated counter pair,
+`record_can_shadow_check`/`CAN_SHADOW_CHECKS`/`_MISMATCHES` (`vm/vm_stats.rs`) — deliberately NOT the
+shared `RESOLVER_SHADOW_*`/`NATIVE_ROW_SHADOW_*` infra E4a/E4b/E7-steps-1-3 use, because this
+compares two EXISTENCE predicates and never calls `resolve_sequence` at all; reusing a shared total
+would repeat the exact "false lead" step 1 had to disentangle (see that section above). Pure
+insertion, zero behavior change: `has_native` alone still drives `results`.
+
+**Sweep found a real, well-understood gap — and it says DEFER, not cut over.** Three sources: (1) a
+16-case hand-built probe script (`Array`/`List`/`Str`/`Int`/`Buf`/`Hash`/`IO::Path` receivers against
+a spread of 0-arg/1-arg/2-arg/mutating rows); (2) the 16 already-whitelisted roast files found by
+grepping roast for `\.\^?can\(` (`S03-operators/repeat.t`, `S05-match/capturing-contexts.t`,
+`S10-packages/precompilation.t`, `S12-attributes/instance.t`, `S12-enums/thorough.t`,
+`S12-introspection/{can,meta-class,methods,walk}.t`, `S12-meta/classhow.t`,
+`S14-roles/versioning.t`, `S17-scheduler/{at,basic,in,times}.t`, `S32-exceptions/misc2.t`); (3) the
+full local `t/` suite (3057 files/28,557 tests). Combined: 115 `can_shadow_checks`, 3
+`can_shadow_mismatches` — **every one `real=true shadow=false`** (the E2 lookup is a conservative
+under-answer here, never a false positive):
+
+- `IO::Path.can("e")` (hand-built probe) — `native_method_row.rs`'s own module doc already names
+  `IO::Path`/`IO::Handle`/`Sub`/`Signature`/`Cool` as owners "E2a's probe did not cover" at all.
+- `(1, 2).^can('int8')` (`t/native-int-coerce-methods-are-cool-only.t:18`, a `List`, "is `Cool`, so it
+  can `int8`") — `int8` is one of `NUMERIC_COERCIONS`, which `builtin_type_method_names("Cool")`
+  does list, but `Cool` is exactly one of the abstract owners the row-GENERATION probe skipped
+  (`builtin_sample_value`'s doc: "Abstract types (`Any`/`Mu`/`Cool`) ... return `None`" — no sample
+  value to probe with, so no row was ever generated for `(Cool, int8)`), so the chain walk
+  (`List -> Cool -> Any -> Mu`) never finds it even though the real dummy-arg probe (which calls the
+  generic coercion cascade directly, not gated by owner) does.
+- `$c.can("cancel")` (`t/scheduler-cue-times.t:18`, a `Cancellation`-shaped scheduler handle) —
+  `Cancellation` is not one of the 14 owners `builtin_type_method_names`/the E2a/E2b campaign ever
+  modeled at all; the real answer comes from the dummy probe's `classhow_find_method` tier (a
+  registered `native_methods` binding), which the E2 catalog has no way to represent.
+
+No mismatch in either direction pointed at a real *dispatch-path* bug — every one traces to a
+documented, already-known catalog gap (abstract owners with no sample value; owners outside the
+original 14-name-list campaign scope entirely). Per this box's own "if the E2 catalog's incompleteness
+would make `.can` return a WRONG `false` for something that genuinely IS callable, do NOT cut over"
+guidance: **cutover is deferred, not landed.** `has_native` (the dummy-arg probe plus its
+`builtin_type_method_names`/`classhow_find_method` fallback tiers) keeps driving `.can`/`.^can`
+unchanged; `e2_native_method_exists` stays shadow-only. A future slice can revisit cutover once (a)
+`Cool` gets a synthetic/representative sample value in the row-generation probe (or the abstract
+owners are hand-added the way `Any`/`Mu`'s `so`/`not`/`defined`/`DEFINITE` rows already were in
+E2b) and (b) either `Cancellation`-style scheduler-internal classes get real rows or `.can`'s fallback
+keeps a permanent `classhow_find_method`/registered-native-methods escape hatch alongside the E2
+lookup (not a full replacement of it) — worth scoping as its own follow-up, not blocking this box.
+
+(The apparent `t/proc-async.t`/`t/quietly.t`/`t/sink-warning.t`/... failures under the full `t/`
+sweep are a `MUTSU_VM_STATS=1` sweep artifact, not a regression: those tests spawn a mutsu
+subprocess via `is_run`/`shell`/`run`, which inherits `MUTSU_VM_STATS=1` from the outer `prove`
+process and prints its own stats summary to stderr, corrupting the parent test's captured-output
+assertions. Confirmed by re-running the same files with the env var unset: `Files=8, Tests=111,
+Result: PASS`. Same root cause as `roast/S10-packages/precompilation.t` and
+`roast/S14-roles/versioning.t`'s failures during the `MUTSU_VM_STATS=1` roast slice run, both of
+which also pass cleanly without the env var. Not this box's bug — a pre-existing property of
+`MUTSU_VM_STATS` combined with subprocess-spawning tests, unrelated to `.^can`.)
+
+`cargo build` / `cargo test --lib` (810 tests, including 6 new unit tests: 2 for
+`native_method_row_exists`'s table-presence-vs-return-value distinction, 4 for
+`e2_native_method_exists`'s chain walk, including the 2-arg-only-method case the dummy probe's
+0/1-arg-only cascade calls cannot see) / `cargo clippy -- -D warnings` / `cargo fmt` clean; `make
+test` green. Given `.can`/`.^can` is a public API surface (not just an internal dispatch path), this
+step's local verification went beyond the usual single-slice scope: the full `t/` suite (not a
+sample), plus every already-whitelisted roast file that calls `.can`/`.^can` at all (not just a
+sample), both swept under `MUTSU_VM_STATS=1` specifically to exercise the new shadow-check path.
+
+**Conclusion**: this is the first E7 sub-slice that is NOT a clean zero-mismatch/zero-fix result —
+exactly as the design paragraph predicted ("not expected to be another clean zero-mismatch/zero-fix
+result the way steps 1/2 were") — but the right response to a non-clean result that traces to
+catalog incompleteness (not a real dispatch-path bug) is to defer the cutover, not force it through.
+Next E7 sub-slice: `.^lookup`/`.^methods` reading the call-path sequence, per the design's consumer
+ordering (WALK and the EVAL/re-entrant carriers come after those).


### PR DESCRIPTION
## Summary

ADR-0019 Phase E box E7, fourth consumer family: `.^can`. Per the design's own note, this sub-slice was expected NOT to be another clean zero-mismatch result (unlike E7 steps 1/2) — and it wasn't, but the finding is a catalog-coverage gap rather than a dispatch-path bug, so cutover is deferred rather than forced through.

- Adds `Interpreter::e2_native_method_exists` (`runtime/receiver_class.rs`): walks the receiver's `dispatch_owner_chain` and checks a new `native_method_row::native_method_row_exists(owner, name)` — table PRESENCE, not `native_method_row`'s returned arity/flags mask, which cannot answer "does this method exist at all" by itself (a missing key and a genuinely-probed "exists only via a special/mutating path" row like `List.push` share the identical `(N, ...)` bit pattern — pinned by a new unit test).
- `collect_can_methods`'s existing dummy-`Value::NIL`-arg native probe — the exact mechanism the ADR's E7 design paragraph names as needing replacement — now shadow-checks its answer against the new predicate under `MUTSU_VM_STATS`, via a dedicated counter pair (`record_can_shadow_check`) kept separate from the shared `resolve_sequence`-winner shadow infra E4a/E4b/E7 steps 1-3 reuse (this compares two existence predicates and never touches `resolve_sequence`, so sharing a total would repeat the "false lead" step 1 had to disentangle).
- Zero behavior change: the dummy-arg probe alone still drives `.can`/`.^can`'s real answer.

## Measurement result: cutover deferred

A combined sweep — a 16-case hand-built probe script, all 16 already-whitelisted roast files that call `.can`/`.^can`, and the full local `t/` suite (3057 files/28,557 tests) — found 115 total shadow checks, 3 mismatches, **every one `real=true shadow=false`** (the E2 lookup under-answers, never gives a false positive):

- `IO::Path.can("e")` — `IO::Path` is one of the owners the E2a/E2b campaign's own module doc already names as never probed.
- `(1,2).^can('int8')` — `Cool` is an ABSTRACT owner the row-*generation* probe skipped for lack of a sample value, even though `Cool`'s declared name list does include `int8`.
- `$c.can("cancel")` on a scheduler `Cancellation` handle — a class entirely outside the 14-owner E2a/E2b campaign scope.

Every mismatch traces to a documented, already-known catalog-coverage gap, not a real dispatch bug. Per this box's own guidance ("if the catalog's incompleteness would make `.can` wrongly answer `false` for something genuinely callable, do NOT cut over"), the cutover is deferred: `e2_native_method_exists` stays shadow-only, `has_native`'s existing tiers keep driving `.can`/`.^can` unchanged.

Full writeup: `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 4: `.^can` — shadow-measured, cutover DEFERRED (E2 catalog coverage gap)", and the matching ADR-0019 progress paragraph.

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] `cargo test --lib` (810 tests, 6 new: 2 pin `native_method_row_exists`'s table-presence-vs-return-value distinction, 4 exercise `e2_native_method_exists`'s chain walk including a 2-arg-only-method case)
- [x] `make test` green (3057 files / 28,557 tests)
- [x] Targeted `MUTSU_VM_STATS=1` sweep of all 16 roast files calling `.can`/`.^can` — clean (given `.can`/`.^can` is a public API surface, verification went beyond the usual single-slice scope)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>