### PR TITLE
fix(parser): whenever accepts a sigilless pointy param (-> \row)

### DIFF
--- a/news/2026-08/whenever-sigilless-param.md
+++ b/news/2026-08/whenever-sigilless-param.md
@@ -1,0 +1,33 @@
+# whenever accepts a sigilless pointy param (Text::CSV runtime sweep round 8)
+
+`whenever $source -> \row { ... }` never delivered a single event: the
+`whenever` statement parser accepted only sigiled pointy params (`-> $x`,
+with an optional type constraint) and type-only blocks (`-> Int { }`). A
+sigilless param made the whole statement fail to parse, so it silently
+fragmented into a bare `whenever` word plus a standalone pointy-block
+expression statement — the subscription never registered, and the
+enclosing `react` completed with zero events (no error anywhere).
+
+Text::CSV's Supply and Channel in-format loops are exactly this shape:
+
+    react {
+        whenever $in -> \row {
+            @in.push: row ~~ Str ?? $[ self.getline (row) ] !! row;
+            LAST { done; }
+            }
+        }
+
+so `csv(in => $channel)` and `csv(in => $supply)` returned empty row sets
+(90_csv.t tests 34-36). The parser now binds `\name` as the whenever
+parameter — the same bare-name env key a sigilless read resolves — and the
+existing react machinery (including the direct-Channel subscription source
+with its drain-until-closed polling) does the rest.
+
+90_csv.t: the whole first (Class) scope now passes, 36/36 up from 33/36.
+The file still aborts at the second (Method) scope — a separate,
+pre-existing env-map leak: after the Channel iteration, a closure reading
+the test's file-scope `@in` by name sees the CSV method's same-named
+internal `@in` rows while the file-scope slot itself stays correct
+(dual-store divergence; the next slice).
+
+Pin: `t/whenever-sigilless-param.t` (4 assertions, raku-verified).

--- a/src/parser/stmt/control/react.rs
+++ b/src/parser/stmt/control/react.rs
@@ -59,8 +59,23 @@ pub(crate) fn whenever_stmt(input: &str) -> PResult<'_, Stmt> {
         };
         match var_name(r) {
             Ok((r, name)) => (r, Some(name)),
-            // Type-only pointy block (`-> Int { }`) binds no variable.
-            Err(_) => (r, None),
+            Err(_) => {
+                // Sigilless pointy param (`whenever $ch -> \row { }`,
+                // Text::CSV's Channel/Supply in-format loops): binds the raw
+                // value under the bare name — the same env key a sigil-less
+                // read resolves. Without this the whole statement failed to
+                // parse and fragmented into a bare `whenever` word plus a
+                // standalone pointy block, so the subscription never
+                // registered and the react saw zero events.
+                if let Some(stripped) = r.strip_prefix('\\')
+                    && let Ok((r2, name)) = crate::parser::stmt::idents::ident(stripped)
+                {
+                    (r2, Some(name))
+                } else {
+                    // Type-only pointy block (`-> Int { }`) binds no variable.
+                    (r, None)
+                }
+            }
         }
     } else {
         (rest, None)

--- a/t/whenever-sigilless-param.t
+++ b/t/whenever-sigilless-param.t
@@ -1,0 +1,64 @@
+use v6;
+use Test;
+
+# `whenever <source> -> \row { }` — a SIGILLESS pointy param. The whenever
+# statement parser only accepted sigiled variables (and type-only blocks), so
+# the whole statement failed to parse and silently fragmented into a bare
+# `whenever` word plus a standalone pointy block: the subscription never
+# registered and the react saw zero events. Text::CSV's Supply and Channel
+# in-format loops are exactly this shape (`react { whenever $in -> \row {`).
+
+plan 4;
+
+{
+    my @in;
+    react {
+        whenever Supply.from-list(1, 2, 3) -> \x {
+            @in.push: x;
+        }
+    }
+    is-deeply @in, [1, 2, 3], 'whenever Supply -> \x receives every value';
+}
+
+{
+    my $ch = Channel.new;
+    $ch.send($_) for "a", "b";
+    $ch.close;
+    my @in;
+    react {
+        whenever $ch -> \row {
+            @in.push: row;
+            LAST { done }
+        }
+    }
+    is-deeply @in, ["a", "b"], 'whenever Channel -> \row drains a pre-filled channel';
+}
+
+{
+    my $ch = Channel.new;
+    start {
+        $ch.send($_) for 1 .. 3;
+        $ch.close;
+    }
+    my $sum = 0;
+    react {
+        whenever $ch -> \n {
+            $sum += n;
+            LAST { done }
+        }
+    }
+    is $sum, 6, 'whenever Channel -> \n with a concurrent producer';
+}
+
+{
+    # The sigiled form keeps working.
+    my @in;
+    react {
+        whenever Supply.from-list(<p q>) -> $v {
+            @in.push: $v;
+        }
+    }
+    is-deeply @in, [<p q>], 'whenever -> $v still works';
+}
+
+done-testing;


### PR DESCRIPTION
`whenever $source -> \row { ... }` never delivered a single event: the whenever statement parser accepted only sigiled pointy params (`-> $x`, optionally typed) and type-only blocks (`-> Int { }`). A sigilless param made the whole statement fail to parse, silently fragmenting into a bare `whenever` word plus a standalone pointy-block expression statement — the subscription never registered, and the enclosing `react` completed with zero events and no error.

Text::CSV's Supply and Channel in-format loops are exactly this shape (`react { whenever $in -> \row { @in.push: ... ; LAST { done } } }`), so `csv(in => $channel)` / `csv(in => $supply)` returned empty row sets (90_csv.t tests 34-36). The parser now binds `\name` as the whenever parameter — the same bare-name env key a sigilless read resolves — and the existing react machinery (including the direct-Channel subscription source with drain-until-closed polling) does the rest.

90_csv.t: the whole first (Class) scope now passes, 36/36 up from 33/36. The file's remaining Method-scope abort is a separate pre-existing env-map name leak (a closure reading the test's file-scope `@in` by name sees the CSV method's same-named internal rows) — pinned in the campaign notes for the next slice.

Pin: `t/whenever-sigilless-param.t` (4 assertions, passes under raku too). S17-supply/syntax.t and S17-channel/basic.t verified green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)