### PR TITLE
fix(runtime): .^lookup walks the MRO instead of only the receiver's own class (ADR-0019 E7 step 5)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3445,6 +3445,71 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   but the correct response to a catalog-coverage gap (not a dispatch-path bug) is to defer the
   cutover, not force it.** Next E7 sub-slice: `.^lookup`/`.^methods` reading the call-path sequence
   (WALK and the EVAL/re-entrant carriers come after those, per the design's consumer ordering).
+  **Progress 2026-08-12** (fifth consumer family, `.^lookup`, a real MRO-walk correctness fix — not
+  a shadow-measurement box): unlike steps 1-4, this one started from a confirmed, already-reproduced
+  bug rather than a shadow-check-driven discovery. `Interpreter::classhow_lookup`
+  (`runtime/methods_classhow_lookup.rs`) — the sole implementation of `.^lookup`, one call site in
+  `methods_classhow_dispatch.rs`'s `"lookup"` arm — only ever consulted the receiver's OWN
+  registered class (`self.registry().classes.get(&class_name_str)`), never walking the MRO to an
+  ancestor: `class A{method foo{...}}; class B is A{}; B.^lookup("foo")` returned `Nil` instead of
+  the inherited method real Raku finds (confirmed: `raku`'s `B.^lookup("foo").defined` is `True`).
+  Fixed by replacing the single-class lookup with a `self.class_mro(&class_name_str)` walk
+  (most-derived first, same registry MRO primitive `resolve_method_with_owner`/
+  `resolve_private_method_any_owner` already use elsewhere), taking the first class whose own
+  `class_def.methods` has the name — the per-level `Value::make_sub` construction (callable-type/
+  return-type/wrap-chain-index env tags) is otherwise unchanged from before this fix. Confirmed via
+  `raku` that `.^lookup` deliberately does NOT filter by `is_my`/`is_multi`/visibility at all — it
+  finds an ancestor's submethod (`class M{submethod boot{}}; class N is M{}; N.^lookup("boot")` is
+  defined) and an inherited multi (returning just the first candidate, matching this fix's own
+  per-level "first def wins" shape; true multi/proto candidate-sequence modeling is E8's job, out of
+  scope here). **A second, more subtle bug surfaced mid-fix and was fixed in the same PR (small,
+  obviously safe, not deferred — matching step 3's precedent)**: `Interpreter::classhow_find_method`
+  (same file — the implementation of `.^find_method`, and indirectly of `.can` on a Package
+  receiver via its `methods_instance_ops.rs` fallback) used to delegate its own "does this name
+  exist" fallback straight to `classhow_lookup`. Once `classhow_lookup` became MRO-walking, that
+  delegation started leaking `.^lookup`'s permissive ancestor-submethod visibility into
+  `.^find_method`/`.can`, which real Raku keeps strict (`N.^find_method("boot").defined` and
+  `N.can("boot").elems` are both false/0 — confirmed against `raku`; only the DECLARING class `M`
+  finds it via either) — caught by a full `t/`-suite regression (`t/can-does.t` test 15, "`.can`
+  does not inherit submethods into subclasses"). Fixed by extracting the shared per-level
+  construction into `classhow_lookup_impl(invocant, method_name, include_ancestor_submethods: bool)`
+  — `classhow_lookup` calls it with `true` (unchanged `.^lookup` behavior), `classhow_find_method`'s
+  fallback with `false` (skips a level's def when `is_my` and the owning class is not the receiver's
+  own). Two dead-end approaches tried and reverted before this one: (1) routing
+  `classhow_find_method` through `collect_can_methods` directly recurses infinitely (that function's
+  own native-method fallback tier calls `classhow_find_method`, confirmed by an actual stack
+  overflow); (2) extracting `collect_can_methods`'s non-recursive tiers into a shared
+  `collect_can_user_methods` helper avoided the recursion but dropped `.^find_method`'s
+  `__mutsu_callable_type`/`__mutsu_lookup_*` env tagging for a non-multi method (regressing
+  `t/declarator-trailing-wherefore.t` test 6, `.^name` reporting the generic `"Sub"` instead of
+  `"Method"`) — and, when that tagging was added back unconditionally, broke `.wrap()` writeback for
+  `.can`'s own OTHER callers instead (`t/method-wrap-writeback-only-mutations.t` test 3,
+  `t/monitor-method-does-not-leak-topic-or-self.t` test 6, `t/exporthow-grammar-how.t`), because some
+  wrap-chain-registration path apparently keys off that metadata's mere presence on a
+  `.can`-obtained Sub. The `classhow_lookup_impl` split above avoids all of this: `classhow_find_method`
+  never touches `collect_can_methods`/`collect_can_user_methods` at all, so `.can`'s own construction
+  path (`methods_classhow_method_obj.rs`) is completely untouched by this PR. Two follow-up findings
+  filed as their own tickets rather than expanding this PR's scope (per the "one bug per sub-PR"
+  discipline): `todo/tickets/classhow-lookup-all-candidates-non-multi-mro-gap.md` (the sibling
+  `classhow_lookup_all_candidates`, backing `.^find_method(name).candidates`, has the identical
+  single-class-only bug in its non-multi branch) and
+  `todo/tickets/classhow-lookup-surfaces-private-methods.md` (`.^lookup` surfaces a private method by
+  its bare name, which real Raku's `.^lookup` does not — a separate, pre-existing visibility-
+  filtering gap unrelated to the MRO-walk shape this fix targets). New `t/classhow-lookup-mro.t` (14
+  assertions: the exact repro, own-class/2-levels-deep/role-composed/nonexistent/override-wins/
+  inherited-multi/ancestor-submethod cases for `.^lookup`, plus 4 regression assertions pinning
+  `.^find_method`/`.can`'s stricter ancestor-submethod exclusion). `cargo build`/`cargo clippy -- -D
+  warnings`/`cargo fmt` clean; full local `make test` green (3059 files/28,585 tests, confirmed
+  clean AFTER a `cargo clean -p mutsu` full rebuild ruled out stale-incremental-cache artifacts from
+  an earlier concurrent-build mishap in this session); a 18-file roast slice (found by grepping
+  roast for `\.\^lookup\(`/`HOW\.lookup` and intersecting with `roast-whitelist.txt`) green (898
+  tests, `MUTSU_FUDGE=1`; `roast/S32-io/spurt.t`'s one failure on the first attempt was the known
+  stale `temp-file-RT-126006-test` artifact `make roast` normally clears before starting, not a
+  regression — confirmed clean after removing it). Since this changes a real `classhow_lookup`/
+  `classhow_find_method` answer (not just a shadow-measurement probe), this counts as the "touched
+  name/type resolution" case CLAUDE.md's testing rule names — the roast slice above is that
+  targeted local check. Next E7 sub-slice: `.^methods` reading the call-path sequence (WALK and the
+  EVAL/re-entrant carriers come after, per the design's consumer ordering).
 - [ ] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
   **Design 2026-08-10** (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`):

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -3,6 +3,28 @@ use crate::symbol::Symbol;
 
 impl Interpreter {
     pub(super) fn classhow_lookup(&mut self, invocant: &Value, method_name: &str) -> Option<Value> {
+        self.classhow_lookup_impl(invocant, method_name, true)
+    }
+
+    /// Shared implementation for `.^lookup` (`include_ancestor_submethods =
+    /// true`) and `classhow_find_method`'s fallback -- which backs
+    /// `.^find_method` directly, and `.can` on a Package receiver indirectly
+    /// -- (`include_ancestor_submethods = false`).
+    ///
+    /// Real Raku's `.^lookup` walks the whole MRO unconditionally, including
+    /// finding an ancestor's submethod (confirmed: `class M{submethod
+    /// boot{}}; class N is M{}; N.^lookup("boot").defined` is `True`), while
+    /// `.^find_method`/`.can` do NOT surface an ancestor's submethod
+    /// (`N.^find_method("boot").defined` and `N.can("boot").elems` are both
+    /// false/0; only the DECLARING class finds it via either). Rather than
+    /// duplicating the whole per-level `Value::make_sub` construction twice,
+    /// `classhow_find_method` calls this with `false` instead.
+    fn classhow_lookup_impl(
+        &mut self,
+        invocant: &Value,
+        method_name: &str,
+        include_ancestor_submethods: bool,
+    ) -> Option<Value> {
         let (class_name, class_name_str) = match invocant.view() {
             ValueView::Package(name) => (name, name.resolve()),
             // An instance of a user class carries its class name; `value_type_name` would
@@ -15,19 +37,45 @@ impl Interpreter {
                 (Symbol::intern(&type_name), type_name)
             }
         };
-        // Check user-defined class methods first
-        if let Some(class_def) = self.registry().classes.get(&class_name_str)
-            && let Some(defs) = class_def.methods.get(method_name)
-            && let Some(def) = defs.first()
-        {
-            let has_multi = defs.iter().any(|d| d.is_multi);
+        // Check user-defined class methods first, walking the receiver's full
+        // MRO rather than only its own class — `B.^lookup('foo')` must find a
+        // `foo` declared only on an ancestor `A` (`class B is A {}`), exactly
+        // as real Raku does. The per-level construction logic below
+        // (has_multi/is_submethod/return type/...) is unchanged from before
+        // this fix; only the search now spans the whole chain instead of
+        // stopping at the receiver's own class. Matches the `owner`-not-
+        // `class_name` convention `classhow_lookup_all_candidates` below
+        // already uses for an inherited method's declaring class.
+        let mro = self.class_mro(&class_name_str);
+        for owner_sym in mro.iter() {
+            let owner_str = owner_sym.as_str();
+            let (defs_first, has_multi) = {
+                let registry = self.registry();
+                let Some(class_def) = registry.classes.get(owner_str) else {
+                    continue;
+                };
+                let Some(defs) = class_def.methods.get(method_name) else {
+                    continue;
+                };
+                let Some(def) = defs.first() else {
+                    continue;
+                };
+                // A submethod (`is_my`) is visible only at its own declaring
+                // level for `.^find_method`/`.can` (`include_ancestor_
+                // submethods = false`) -- `.^lookup` has no such restriction.
+                if def.is_my && owner_str != class_name_str && !include_ancestor_submethods {
+                    continue;
+                }
+                (def.clone(), defs.iter().any(|d| d.is_multi))
+            };
+            let def = &defs_first;
             let has_explicit_invocant = def
                 .param_defs
                 .iter()
                 .any(|pd| pd.is_invocant || pd.traits.iter().any(|t| t == "invocant"));
             let mut full_param_defs = Vec::with_capacity(def.param_defs.len() + 1);
             if !has_explicit_invocant {
-                full_param_defs.push(Self::make_invocant_param(&class_name_str));
+                full_param_defs.push(Self::make_invocant_param(owner_str));
             }
             full_param_defs.extend(def.param_defs.iter().cloned());
             let mut env = crate::env::Env::new();
@@ -48,7 +96,7 @@ impl Interpreter {
             }
             env.insert(
                 "__mutsu_lookup_class".to_string(),
-                Value::str(class_name_str.clone()),
+                Value::str(owner_str.to_string()),
             );
             env.insert(
                 "__mutsu_lookup_method".to_string(),
@@ -62,7 +110,7 @@ impl Interpreter {
                 env.insert("__mutsu_lookup_candidate_idx".to_string(), Value::int(0));
             }
             return Some(Value::make_sub(
-                class_name,
+                *owner_sym,
                 Symbol::intern(method_name),
                 def.params.clone(),
                 full_param_defs,
@@ -347,7 +395,10 @@ impl Interpreter {
         ) {
             return Some(Value::str(method_name.to_string()));
         }
-        if let Some(value) = self.classhow_lookup(invocant, method_name) {
+        // `false`: `.^find_method` (and `.can` on a Package receiver, which
+        // routes through this function) is stricter than `.^lookup` about
+        // ancestor submethods -- see `classhow_lookup_impl`'s doc comment.
+        if let Some(value) = self.classhow_lookup_impl(invocant, method_name, false) {
             return Some(value);
         }
         // CREATE is a built-in method on all types

--- a/t/classhow-lookup-mro.t
+++ b/t/classhow-lookup-mro.t
@@ -1,0 +1,85 @@
+use Test;
+
+# ADR-0019 E7 step 5: `.^lookup` (`Interpreter::classhow_lookup`,
+# `src/runtime/methods_classhow_lookup.rs`) used to consult only the
+# receiver's OWN class registration, never walking the MRO to an ancestor —
+# so a method declared solely on a parent class was invisible to
+# `.^lookup` on a subclass, even though real `raku` finds it. Confirmed
+# against `raku`: `B.^lookup('foo').defined` is `True` for `class B is A {}`
+# when `foo` is declared only on `A`.
+
+plan 14;
+
+# (a) The exact confirmed repro: a method declared on a parent class only.
+class A1 { method foo { "A1::foo" } }
+class B1 is A1 {}
+ok B1.^lookup("foo").defined, 'inherited method is found via .^lookup on the subclass';
+is B1.new.foo, "A1::foo", 'the inherited method actually runs too';
+
+# (b) A method declared on the receiver's own class directly must still work
+# (do not regress the pre-existing own-class behavior).
+class C1 { method bar { "C1::bar" } }
+ok C1.^lookup("bar").defined, '.^lookup still finds an own-class method';
+
+# (c) A role-composed method: role methods are flattened into the composing
+# class's own method table at composition time, so this path already worked
+# before this fix and must keep working.
+role R1 { method baz { "R1::baz" } }
+class D1 does R1 {}
+ok D1.^lookup("baz").defined, '.^lookup finds a role-composed method';
+
+# (d) A method declared 2+ levels up the inheritance chain.
+class E1 { method deep { "E1::deep" } }
+class F1 is E1 {}
+class G1 is F1 {}
+ok G1.^lookup("deep").defined, '.^lookup walks 2+ levels up the MRO';
+is G1.new.deep, "E1::deep", 'the 2-levels-up inherited method actually runs';
+
+# (e) A method that does not exist anywhere in the chain must still answer Nil.
+class H1 is E1 {}
+nok H1.^lookup("nonexistent").defined,
+    '.^lookup on a nonexistent method stays Nil even with a populated MRO';
+
+# A more-derived override still wins over an ancestor's method of the same name.
+class I1 { method who { "I1" } }
+class J1 is I1 { method who { "J1" } }
+is J1.^lookup("who").(J1.new), "J1", 'a more-derived override wins over the ancestor';
+
+# An inherited multi method is also found (E8 will unify multi/proto
+# candidate-sequence modeling; today's `.^lookup` answer for an own-class
+# multi already returns just the first candidate, and the MRO walk fix
+# generalizes that same per-level behavior to an inherited multi without
+# combining candidates across levels -- confirmed matching `raku`'s own
+# `B.^lookup('greet').defined` answer for this shape).
+class K1 {
+    multi method greet(Int $x) { "int $x" }
+    multi method greet(Str $x) { "str $x" }
+}
+class L1 is K1 {}
+ok L1.^lookup("greet").defined, '.^lookup finds an inherited multi method';
+
+# A submethod on an ancestor is still visible to `.^lookup` on a subclass
+# (raku confirms: `.^lookup` finds it even though submethods are not
+# actually inherited by ordinary dispatch -- `.^lookup` is a raw MRO
+# textual search, not a dispatch simulation).
+class M1 { submethod boot { "M1 boot" } }
+class N1 is M1 {}
+ok N1.^lookup("boot").defined,
+    '.^lookup finds an ancestor submethod (raku: lookup search is unfiltered by is_my)';
+
+# `.^find_method` and `.can` are STRICTER than `.^lookup` about ancestor
+# submethods -- raku confirms `N1.^find_method("boot").defined` and
+# `N1.can("boot").elems` are both false/0, unlike `.^lookup` above, while the
+# DECLARING class (M1) still finds it via either. This is a regression test
+# for a bug this same fix introduced and then fixed: naively routing
+# `classhow_find_method`'s fallback through the new MRO-walking
+# `classhow_lookup` broke `.can`'s submethod-exclusion rule (`t/can-does.t`
+# test 15) because `.can` on a Package receiver reuses `classhow_find_method`.
+ok M1.^find_method("boot").defined,
+    '.^find_method finds a submethod on its own declaring class';
+nok N1.^find_method("boot").defined,
+    '.^find_method does NOT find an ancestor submethod (unlike .^lookup)';
+ok M1.can("boot"), '.can finds a submethod on its own declaring class';
+nok N1.can("boot"), '.can does NOT find an ancestor submethod (unlike .^lookup)';
+
+done-testing;

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -2229,3 +2229,168 @@ result the way steps 1/2 were") — but the right response to a non-clean result
 catalog incompleteness (not a real dispatch-path bug) is to defer the cutover, not force it through.
 Next E7 sub-slice: `.^lookup`/`.^methods` reading the call-path sequence, per the design's consumer
 ordering (WALK and the EVAL/re-entrant carriers come after those).
+
+## E7 step 5: `.^lookup` — a real MRO-walk bug, found and fixed (not a shadow-measurement box)
+
+Unlike steps 1-4, this sub-slice did not start from a shadow-check counter surfacing a gap — it
+started from a manual `raku`-vs-`mutsu` comparison during scoping, which found a confirmed,
+already-reproduced correctness bug before any code changed:
+
+```raku
+class A { method foo { "A::foo" } }
+class B is A {}
+say B.^lookup("foo").defined;   # raku: True
+```
+
+`target/debug/mutsu` answered `False` (`Nil`) for the identical script. `Interpreter::classhow_lookup`
+(`runtime/methods_classhow_lookup.rs`) — the sole implementation of `.^lookup`, reached from exactly
+one call site, the `"lookup"` arm of `methods_classhow_dispatch.rs`'s big `.^`-method match — only
+ever consulted `self.registry().classes.get(&class_name_str)` where `class_name_str` is the
+receiver's own exact class: no MRO walk at all. A method declared solely on a parent class was
+therefore invisible, even though real Raku's `.^lookup` walks the whole MRO.
+
+**Fix**: replace the single-class `Option`-chain lookup with a loop over `self.class_mro(&class_name_str)`
+(most-derived first — the plain registry MRO primitive `resolve_method_with_owner`/
+`resolve_private_method_any_owner` already use elsewhere in the codebase, not a new mechanism),
+taking the first class in the chain whose own `class_def.methods` has an entry for the name. The
+per-level `Value::make_sub` construction (callable-type tag, return-type tag, wrap-chain candidate
+index) is otherwise byte-identical to before this fix — only the search now spans the chain instead
+of stopping at the receiver's own class, and the constructed Sub's owner symbol is the actual owning
+class (`*owner_sym`) rather than always the receiver's own `class_name`.
+
+**Confirmed against real `raku` that `.^lookup` deliberately does NOT filter by visibility/shape at
+all** — three cases pinned in `t/classhow-lookup-mro.t`:
+- An ancestor's **submethod** is found (`class M{submethod boot{}}; class N is M{}; N.^lookup("boot")`
+  is defined) — even though submethods are not inherited by ordinary dispatch; `.^lookup` is a raw
+  MRO-level textual search, not a dispatch simulation.
+- An inherited **multi** method is found — this fix's per-level "first def wins" shape generalizes
+  unchanged to the inherited case (matching `raku`'s own answer for this shape); true multi/proto
+  candidate-SEQUENCE modeling across levels is explicitly E8's job (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`),
+  out of scope here.
+- A more-derived override still wins over an ancestor's same-named method (the MRO walk's
+  most-derived-first order already guarantees this — pinned as a sanity check, not a new mechanism).
+
+**A second bug surfaced mid-fix, found by running the full local `t/` suite, not by shadow-checking**:
+`Interpreter::classhow_find_method` (same file) implements `.^find_method`, and is also `.can`'s
+Package-receiver fallback (`methods_instance_ops.rs:1736-1749` calls it after `class_has_method`/
+`has_user_method` both answer true). Before this box, `classhow_find_method`'s own "does this
+arbitrary name exist" fallback tier delegated straight to `classhow_lookup` — harmless while
+`classhow_lookup` only checked the receiver's own class (so `.^find_method`/`.can` never saw an
+ancestor submethod either, by accident of the OLD bug rather than by design). Once `classhow_lookup`
+became MRO-walking, that same delegation started leaking `.^lookup`'s permissive ancestor-submethod
+visibility into `.^find_method`/`.can`, which real Raku keeps strict:
+
+```raku
+class M { submethod boot { "M boot" } }
+class N is M {}
+say N.^lookup("boot").defined;        # True  (raku's .^lookup: unfiltered)
+say N.^find_method("boot").defined;   # False (raku's .^find_method: strict)
+say N.can("boot").elems;              # 0     (raku's .can: strict, same as .^find_method)
+say M.^find_method("boot").defined;   # True  (the DECLARING class still finds it via either)
+say M.can("boot").elems;              # 1
+```
+
+Caught by the full local `t/` suite (not this box's own new test, and not a shadow-check counter):
+`t/can-does.t` test 15, "`.can` does not inherit submethods into subclasses", started failing
+deterministically (confirmed NOT a build-corruption artifact from an unrelated concurrent-build
+mishap earlier in this session — reproduced against a clean `cargo clean -p mutsu` rebuild, and
+confirmed absent on a fresh `main`-branch worktree build of the identical test file).
+
+**Fix, and two dead ends tried and reverted first** (recorded for anyone touching this area again):
+
+1. **First attempt: route `classhow_find_method`'s fallback through `collect_can_methods`
+   (`methods_classhow_method_obj.rs`) directly.** `collect_can_methods` already implements exactly
+   the right "own-class submethod visible, ancestor submethod hidden" filter
+   (`!def.is_my || cn == class_name`) for its OWN purpose (`.can`'s Instance-receiver path). But
+   `collect_can_methods`'s own native-method fallback tier (entered when no user-declared method
+   matches) itself calls `classhow_find_method` (to check a user class's registered `native_methods`
+   set) — so calling `collect_can_methods` FROM `classhow_find_method` is direct mutual recursion.
+   Confirmed by an actual stack overflow (`thread '<unknown>' has overflowed its stack`) the moment
+   a probed name resolved to neither a user method nor a role method nor an attribute accessor.
+2. **Second attempt: extract `collect_can_methods`'s non-recursive tiers (user-method MRO walk +
+   role-method tier + attribute-accessor tier — everything before the native-fallback tier that
+   causes the recursion) into a new shared helper, `collect_can_user_methods`, called by both
+   `collect_can_methods` and `classhow_find_method`.** This avoided the recursion, and
+   `t/can-does.t` passed — but broke a DIFFERENT test: `t/declarator-trailing-wherefore.t` test 6
+   (`Sheep.^find_method('roar').^name` reported the generic `"Sub"` instead of `"Method"`), because
+   `collect_can_user_methods`'s single-(non-multi)-def branch (unlike its multi branch, and unlike
+   `classhow_lookup`'s per-level construction) never set the `__mutsu_callable_type`/
+   `__mutsu_lookup_*` env tags `.^name` reads — that gap pre-existed in `collect_can_methods` itself
+   (harmless there, since `.can`'s own callers never inspected those tags) but became visible once
+   `.^find_method` started reusing the same code path. Adding the tagging back UNCONDITIONALLY (a
+   `tag_callable_type: bool` parameter, `true` from `classhow_find_method`, `false` from
+   `collect_can_methods`'s own call) fixed that regression but caused a THIRD, worse one: even
+   `false` alone (i.e. leaving `.can`'s own path completely unchanged from its pre-existing
+   behavior) reproduced cleanly, so the parameter itself was not the problem — but the FIRST
+   (uncustomized) version of this attempt, which set the tags unconditionally for both callers to
+   test the idea, broke `.wrap()` writeback for `.can`'s own OTHER, unrelated callers
+   (`t/method-wrap-writeback-only-mutations.t` test 3, `t/monitor-method-does-not-leak-topic-or-self.t`
+   test 6, `t/exporthow-grammar-how.t`'s custom-HOW grammar profiling all regressed) — apparently
+   some `.wrap()`-chain-registration path keys off the mere PRESENCE of `__mutsu_lookup_class`/
+   `__mutsu_lookup_method` on a Sub obtained via `.can`, not just via `.^lookup`/`.^find_method`.
+   Confirmed all four of those files pass cleanly on a fresh `main`-branch build of the identical
+   test files, ruling out pre-existing flakiness. This whole approach was abandoned rather than
+   chased further once it became clear `collect_can_user_methods` was a genuinely shared,
+   two-different-consumer-shape function whose "harmless-looking" tweaks for one consumer kept
+   surfacing as regressions in the other's unrelated tests.
+3. **Landed fix: keep `classhow_find_method` entirely OUT of `collect_can_methods`'s object graph**,
+   and instead parameterize `classhow_lookup` itself. `classhow_lookup_impl(invocant, method_name,
+   include_ancestor_submethods: bool)` is now the single per-level construction implementation;
+   `classhow_lookup` (`.^lookup`'s own entry point) calls it with `true` (unchanged behavior, byte-
+   identical to this box's own first (MRO-walk-only) fix); `classhow_find_method`'s fallback calls
+   it with `false`, which adds exactly one skip condition to the MRO loop: `if def.is_my &&
+   owner_str != class_name_str && !include_ancestor_submethods { continue; }` — do not accept an
+   ancestor level's submethod, keep walking. This is the smallest change that fixes the regression
+   without ever touching `methods_classhow_method_obj.rs` at all, so `.can`'s own construction path
+   (and everything the second attempt's `tag_callable_type`/wrap-chain investigation touched) is
+   completely unaffected by this PR — confirmed by re-running all four previously-regressed files
+   plus the full local `t/` suite clean.
+
+**Two follow-up findings filed as their own tickets, not folded into this PR** (per the "one bug per
+sub-PR" discipline every E7 step so far has followed):
+
+- `todo/tickets/classhow-lookup-all-candidates-non-multi-mro-gap.md` — the sibling
+  `classhow_lookup_all_candidates` (backing `.^find_method(name).candidates`, the function
+  immediately after `classhow_lookup` in the same file) has the IDENTICAL single-class-only bug, but
+  only in its non-multi branch (`owners: Vec<String> = if class_method_is_multi(...) { ...correct
+  MRO walk... } else { vec![class_name.to_string()] }` — the multi branch was already correct). Not
+  a literal one-line-shaped fix like `classhow_lookup`'s own MRO-walk change, so left for its own
+  slice rather than expanding this PR's scope, per the same reasoning that kept `classhow_lookup_impl`
+  a *targeted* filter rather than a rewrite.
+- `todo/tickets/classhow-lookup-surfaces-private-methods.md` — `.^lookup("secret")` finds a private
+  method (`method !secret {...}`) by its bare unqualified name; real Raku's `.^lookup` answers
+  `False`/undefined for the same probe. This is a pre-existing gap (the receiver's-own-class-only
+  lookup never filtered `is_private` either, before OR after this box's MRO-walk fix) — a visibility-
+  filtering bug, not an MRO-walk bug, so a different bug shape from what this slice targeted. Left
+  open with a suggested fix shape (skip a level's `defs.first()` when `is_private`, or reuse
+  `resolve_sequence`'s `MethodVisibility::Public` filter from E7 step 3 directly — the more unified
+  answer, consistent with E7's general direction).
+
+**Verification**: `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean. New
+`t/classhow-lookup-mro.t` (14 assertions): the confirmed repro plus own-class/2-levels-deep/role-
+composed/nonexistent/override-wins/inherited-multi/ancestor-submethod cases for `.^lookup` itself
+(10 assertions), plus 4 regression-pinning assertions for `.^find_method`/`.can`'s stricter
+ancestor-submethod exclusion (the exact shape of the bug found and fixed above). Full local `make
+test` green (3059 files/28,585 tests) — run twice: once after a full `cargo clean -p mutsu` rebuild,
+specifically to rule out stale-incremental-cache artifacts from an EARLIER, UNRELATED concurrent-
+build mishap in this same session (several overlapping `cargo build`/`cargo build --release`/`cargo
+test` invocations from a background agent's repeatedly-resumed "waiting for the build" non-report —
+see `feedback-background-agent-self-report-loop.md` in the assistant's memory system for that
+pattern — had left multiple stacked builds racing in this worktree's `target/` directory; killing
+them and rebuilding clean was necessary before any test failure here could be trusted as real rather
+than a corrupted-binary artifact). An 18-file roast slice, found by grepping roast for
+`\.\^lookup\(`/`HOW\.lookup` and intersecting with `roast-whitelist.txt`, green (898 tests,
+`MUTSU_FUDGE=1`) — `roast/S32-io/spurt.t`'s one failure on the first pass was the documented stale
+`temp-file-RT-126006-test` artifact `make roast` normally clears before starting (CLAUDE.md), not a
+regression; confirmed clean after removing the stale file. Since this changes real
+`classhow_lookup`/`classhow_find_method` answers (not a shadow-only probe), this counts as CLAUDE.md's
+"touched name/type resolution" case requiring a local roast check before opening the PR, not just
+CI's — the slice above is that check.
+
+**Conclusion**: this is the first E7 sub-slice that is a genuine, real-behavior-changing correctness
+fix rather than a shadow-measurement box (steps 1-2 were clean shadow-checks with no cutover needed;
+step 3 found and fixed a bug in its own shadow PROBE's chain construction, not in real dispatch;
+step 4 deferred a real cutover pending catalog coverage) — found by direct `raku`-vs-`mutsu`
+comparison during scoping, not by a shadow-check counter. Next E7 sub-slice: `.^methods` reading the
+call-path sequence (WALK and the EVAL/`subtest` re-entrant carriers come after, per the design's
+consumer ordering).

--- a/todo/tickets/classhow-lookup-all-candidates-non-multi-mro-gap.md
+++ b/todo/tickets/classhow-lookup-all-candidates-non-multi-mro-gap.md
@@ -1,0 +1,47 @@
+# `.^find_method(name).candidates` misses an inherited non-multi method
+
+`Interpreter::classhow_lookup_all_candidates` (`src/runtime/methods_classhow_lookup.rs`,
+the function immediately after `classhow_lookup`, used by `.^find_method(name).candidates`)
+has the same "receiver's own class only" bug that `classhow_lookup` had before ADR-0019 E7
+step 5 fixed it (`todo/deep/adr0019-e5-e7-entry-routing.md` "E7 step 5"), but only for the
+**non-multi** branch:
+
+```rust
+let owners: Vec<String> = if class_method_is_multi(class_name) {
+    // ... correctly computes and reverses the full MRO, filtering to
+    // levels whose own `method_name` is multi ...
+} else {
+    vec![class_name.to_string()]   // <-- only the receiver's own class, no MRO walk
+};
+```
+
+When `method_name` is a plain (non-multi) method that only the receiver's own class defines,
+this is correct. But when it is declared only on an ancestor, `owners` never includes that
+ancestor, so `.^find_method(name).candidates` returns an empty list instead of the one
+candidate real Raku reports.
+
+**Confirmed with `raku`** (`tmp/lookup-candidates.raku` style repro):
+
+```raku
+class A { method foo { "A::foo" } }
+class B is A {}
+say B.^find_method("foo").candidates.elems;   # raku: 1
+```
+
+mutsu currently answers `0` for this (unverified against the exact current build at time of
+filing — verify before fixing, since E7 step 5 landed on the same day and touched the
+sibling `classhow_lookup` function in the same file; `classhow_lookup_all_candidates` itself
+was NOT touched by that PR).
+
+**Why this was not folded into E7 step 5's fix**: it is a different function with a
+different candidate-list shape (multi-vs-non-multi owners, not "first def wins"), so the fix
+is not a literal one-line change of the same shape — it needs its own MRO walk that finds
+the first (most-derived) owning class for the non-multi case, mirroring what E7 step 5 did
+for `classhow_lookup`. Per the ADR-0019 Phase E "one consumer family per sub-PR" discipline,
+this is left as a follow-up rather than expanding that PR's scope.
+
+**Suggested fix shape**: in the `else` branch, walk `self.class_mro(class_name)`
+(most-derived first) and take the first level whose own `class_def.methods` contains
+`method_name`, using that level's class name as the sole owner (`vec![owner]`) instead of
+always `vec![class_name.to_string()]`. This mirrors the MRO walk `classhow_lookup` now does
+for its own non-multi tier.

--- a/todo/tickets/classhow-lookup-surfaces-private-methods.md
+++ b/todo/tickets/classhow-lookup-surfaces-private-methods.md
@@ -1,0 +1,41 @@
+# `.^lookup(name)` finds a private method; real Raku answers `Nil`
+
+Found while investigating ADR-0019 E7 step 5 (`todo/deep/adr0019-e5-e7-entry-routing.md`
+"E7 step 5"), a real correctness fix for `Interpreter::classhow_lookup`
+(`src/runtime/methods_classhow_lookup.rs`). Unrelated to that fix's MRO-walk scope, so
+recorded here instead of expanding the E7 step 5 PR.
+
+**Repro**:
+
+```raku
+class A {
+    method !secret { "shh" }
+}
+say A.^lookup("secret").defined;
+```
+
+- `raku`: `False` — `.^lookup` does not surface a private method by its bare (unqualified,
+  no `!`) name.
+- mutsu (`target/debug/mutsu`, confirmed on the pre-E7-step-5 and post-E7-step-5 code —
+  this is not something the MRO-walk fix touches): `True`.
+
+**Root cause (read from the code, not yet fixed)**: `classhow_lookup`'s first tier
+(`class_def.methods.get(method_name)`) never checks `def.is_private` before building and
+returning a `Value::make_sub` for the match — every other visibility-aware dispatch path in
+the codebase (`resolve_method_with_owner_impl`'s `Public` filtering,
+`resolve_sequence`'s `MethodVisibility::Public` tier from ADR-0019 E7 step 3) explicitly
+skips `is_private` defs, but `classhow_lookup` does not.
+
+**Why this is left open**: it is a visibility-filtering bug, not an MRO-walk bug — a
+different bug shape from what E7 step 5 targeted, so folding it in would violate the
+"one consumer family / one bug per sub-PR" discipline the whole E7 box has followed.
+Fixing it requires deciding whether ALL of `classhow_lookup`'s per-level candidates
+(own-class and inherited, after the E7 step 5 MRO-walk fix) should skip `is_private`, and
+whether that should reuse `resolve_sequence`'s `MethodVisibility::Public` filter directly
+(architecturally the more unified answer, consistent with E7's general direction) instead
+of a local ad-hoc `!def.is_private` check.
+
+**Suggested fix shape**: in `classhow_lookup`'s per-level lookup loop, skip a level's
+`defs.first()` when `is_private` (or, more thoroughly, filter `defs` to non-private before
+taking `.first()`), matching the `is_private` skip every other visibility-aware resolver in
+the codebase already applies.


### PR DESCRIPTION
## Summary

`Interpreter::classhow_lookup` (`.^lookup`) only ever consulted the receiver's own registered class, so `class B is A {}; B.^lookup("foo")` returned `Nil` for a method declared solely on `A`, even though real Raku finds it (confirmed with `raku`). Fixed by walking `self.class_mro()` most-derived-first, matching the primitive `resolve_method_with_owner`/`resolve_private_method_any_owner` already use elsewhere.

`classhow_find_method` (`.^find_method`, and `.can`'s Package-receiver fallback) used to delegate its own "does this name exist" probe straight to `classhow_lookup`. Once `classhow_lookup` started walking the MRO, that delegation began leaking `.^lookup`'s permissive ancestor-submethod visibility into `.^find_method`/`.can`, which real Raku keeps strict — caught by a full `t/`-suite regression (`t/can-does.t` test 15). Fixed by splitting `classhow_lookup` into `classhow_lookup_impl(invocant, method_name, include_ancestor_submethods)`, with `.^lookup` passing `true` and `classhow_find_method`'s fallback passing `false`.

Two related gaps found along the way are filed as their own tickets rather than folded into this change (`todo/tickets/`), per the ADR-0019 Phase E "one bug per sub-PR" discipline:
- `classhow_lookup_all_candidates` has the same single-class-only bug in its non-multi branch.
- `.^lookup` surfaces a private method by its bare name — a pre-existing visibility-filtering gap, not an MRO-walk gap.

This is ADR-0019 Phase E box E7's fifth sub-slice. Full write-up (including two dead-end approaches tried and reverted) in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 5".

## Test plan

- [x] New `t/classhow-lookup-mro.t` (14 assertions): the confirmed repro, own-class/2-levels-deep/role-composed/nonexistent/override-wins/inherited-multi/ancestor-submethod cases for `.^lookup`, plus 4 regression-pinning assertions for `.^find_method`/`.can`'s stricter ancestor-submethod exclusion.
- [x] `cargo clippy -- -D warnings` / `cargo fmt` clean.
- [x] Full local `make test` green (3059 files/28,585 tests).
- [x] Targeted local roast slice (18 files found by grepping for `.^lookup`/`HOW.lookup`, intersected with `roast-whitelist.txt`) green, per CLAUDE.md's "touched name/type resolution" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)