### PR TITLE
fix(runtime): .^methods includes a runtime-mixed-in role's methods (ADR-0019 E7 step 6)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3510,6 +3510,54 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   name/type resolution" case CLAUDE.md's testing rule names — the roast slice above is that
   targeted local check. Next E7 sub-slice: `.^methods` reading the call-path sequence (WALK and the
   EVAL/re-entrant carriers come after, per the design's consumer ordering).
+  **Progress 2026-08-12** (sixth consumer family, `.^methods`, a real mixin-enumeration fix plus a
+  shadow-measurement, not a clean zero-mismatch result like steps 1/2): scoping started from the
+  hypothesis (per this design paragraph's own framing) that `dispatch_classhow_methods`'s
+  (`runtime/methods_classhow_builtin_methods.rs`) main (non-`:local`) branch was already
+  MRO-correct, since it already walks `self.class_mro(&class_name)` — unlike step 5's `.^lookup`,
+  which had never walked the MRO at all before that fix. Direct `raku`-vs-`mutsu` comparison during
+  scoping confirmed the MRO walk itself IS correct for plain inheritance (including submethods,
+  private methods, and multi-method-as-single-dispatcher-entry, all already exercised end-to-end by
+  the pinned `roast/S12-introspection/methods.t`, which passes cleanly both before and after this
+  box), but surfaced a different, genuine gap: `(5 but R1).^methods()` (no `:local`) never included
+  `R1`'s own mixed-in method (`zork`), even though `(5 but R1).zork` is directly callable and
+  `(5 but R1).^methods(:local)` (a sibling branch) already collected it correctly. Confirmed against
+  real `raku`: a `but`-mixin's `.^mro` puts an anonymous composite pun class FIRST — `(5 but
+  R1).^mro` is `((Int+{R1}) (Int) (Cool) (Any) (Mu))` — and that pun class's own methods are exactly
+  the mixed-in role's methods, so `zork` appears as the very first entry of `(5 but
+  R1).^methods.map(*.name)` on real `raku`. **Fix**: the non-`:local` branch now extracts
+  `mixin_role_names` (already computed once, above the `if local {...} else {...}` split, for the
+  `:local` branch's own existing handling) and calls `self.collect_role_methods(role_name, private,
+  &mut result)` for each BEFORE the base `class_name`'s own `class_mro` walk — mirroring the
+  `:local` branch's pre-existing pattern verbatim, not a new mechanism, and matching the pun-class-
+  first ordering confirmed against `raku` above. Two roles mixed onto the same value
+  (`5 but R1 but R2`) both contribute their methods, pinned alongside the base repro. **Shadow-check
+  added as well** (this box's other half, following the design paragraph's "reading the call-path
+  sequence" framing): a new `MUTSU_VM_STATS`-gated comparison, `record_methods_shadow_check`
+  (`vm/vm_stats.rs`, its own dedicated counter pair — not the shared `RESOLVER_SHADOW_*` family,
+  since this compares two whole MRO CHAINS rather than a single dispatch-winner pick, the same
+  reasoning step 4's `.^can` check already established for its own dedicated pair), comparing the
+  chain the walk actually enumerates (`class_mro(class_name)`, the registry MRO primitive) against
+  the E4 resolver's own canonical chain for the same receiver (`Interpreter::dispatch_owner_chain`,
+  TypeId-based). Pure insertion, zero behavior change: `mro` alone still drives the enumeration.
+  Swept a 10-case hand-built probe (plain classes, role composition, `but`-mixins, `List`/`Str`/
+  `Int` builtins, an instance and a type-object receiver): 10 checks, 0 mismatches — the two chain
+  computations already agree everywhere probed, once the mixin-methods fix above made the enumerated
+  RESULT match `raku` too (the shadow check compares the underlying CHAIN, not the final method set,
+  so it was unaffected by the mixin fix either way, but both are reported together as this sub-slice
+  since they were found and fixed in the same investigation). `cargo build`/`cargo clippy -- -D
+  warnings`/`cargo fmt` clean. New `t/classhow-methods-mixin-role.t` (9 assertions: the confirmed
+  repro, two-roles-mixed-in, base-type-methods-still-present, plain-inheritance regression guard,
+  and `:all` combined with a mixin). All 6 already-whitelisted roast files that call `.^methods(`
+  (found by grepping roast for `\.\^methods\(`), including the two role-mixin files
+  (`roast/6.c/S14-roles/mixin-6c.t`, `roast/S14-roles/mixin-6e.t`) and the dedicated introspection
+  spec (`roast/S12-introspection/methods.t`, 57 assertions covering `:local`/`:all`/`:tree`/
+  `:private`/multi-dispatcher-shape/attribute-order), green (`MUTSU_FUDGE=1`). Since this changes a
+  real `.^methods()` answer (not just a shadow-only probe), this counts as CLAUDE.md's "touched
+  name/type resolution" case requiring a local roast check before opening the PR — the 6-file sweep
+  above is that check. Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 6:
+  `.^methods` — a real mixin-enumeration fix, plus a clean chain shadow-check". Next E7 sub-slice:
+  WALK and the EVAL/`subtest` re-entrant carriers, per the design's consumer ordering.
 - [ ] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
   **Design 2026-08-10** (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`):

--- a/src/runtime/methods_classhow_builtin_methods.rs
+++ b/src/runtime/methods_classhow_builtin_methods.rs
@@ -66,8 +66,39 @@ impl Interpreter {
                 self.push_native_method_objects(&names, &mut result);
             }
         } else {
+            // Runtime-mixed-in role methods sit ahead of the base class in the
+            // MRO (raku puts the anonymous composite pun class first: `(5 but
+            // R).^mro` is `((Int+{R}) (Int) (Cool) (Any) (Mu))`), so collect
+            // them before the base `class_name`'s own MRO walk below --
+            // mirroring the `:local` branch above, which already did this for
+            // its own (narrower) enumeration but this default (non-`:local`)
+            // branch never did. Confirmed missing against real `raku`:
+            // `(5 but R).zork` was callable but absent from `(5 but
+            // R).^methods` (no `:local`) before this fix; see
+            // `t/classhow-methods-mixin-role.t`.
+            for role_name in &mixin_role_names {
+                self.collect_role_methods(role_name, private, &mut result);
+            }
+
             // Walk MRO (already includes the class itself)
             let mro = self.class_mro(&class_name);
+
+            // ADR-0019 Phase E box E7 step 6 (`.^methods`, `todo/deep/
+            // adr0019-e5-e7-entry-routing.md` "E7 step 6"): shadow-check the
+            // chain this walk actually enumerates (`class_mro(class_name)`,
+            // the registry MRO primitive) against the E4 resolver's own
+            // canonical chain for the same receiver (`dispatch_owner_chain`,
+            // TypeId-based). `MUTSU_VM_STATS`-gated, zero behavior change:
+            // `mro` alone still drives the enumeration below.
+            if crate::vm::vm_stats::enabled() {
+                let real_names: Vec<&str> = mro.iter().map(|s| s.as_str()).collect();
+                let shadow_chain = self.dispatch_owner_chain(invocant);
+                let shadow_names: Vec<&str> = shadow_chain.iter().map(|t| t.as_str()).collect();
+                let matched = real_names == shadow_names;
+                crate::vm::vm_stats::record_methods_shadow_check(matched, || {
+                    format!("class={class_name} real={real_names:?} shadow={shadow_names:?}")
+                });
+            }
 
             for cn in mro.iter().map(|s| s.as_str()) {
                 if !all && (cn == "Any" || cn == "Mu") {

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -540,6 +540,40 @@ pub(crate) fn record_can_shadow_check(matched: bool, detail: impl FnOnce() -> St
     }
 }
 
+// ADR-0019 Phase E box E7 step 6 (`.^methods`, `todo/deep/adr0019-e5-e7-
+// entry-routing.md` "E7 step 6"): shadow comparison between the existing
+// `class_mro`-based chain `dispatch_classhow_methods` walks to enumerate
+// `.^methods()` and the E4 resolver's own canonical chain
+// (`Interpreter::dispatch_owner_chain`) for the same receiver. A dedicated
+// counter pair, not the shared `RESOLVER_SHADOW_*` infra: this compares two
+// whole MRO CHAINS, not a single dispatch-winner pick, the same reasoning
+// that kept E7 step 4's `.^can` check on its own `CAN_SHADOW_*` pair.
+// Nothing reads these counters to make a dispatch decision: shadow-only,
+// zero behavior change.
+static METHODS_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static METHODS_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn methods_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one E7 step-6 `.^methods` chain-shadow comparison. `detail` is only
+/// evaluated on a mismatch, mirroring [`record_can_shadow_check`].
+#[inline]
+pub(crate) fn record_methods_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    METHODS_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        METHODS_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = methods_shadow_mismatch_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1024,6 +1058,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e7 can-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let methods_shadow_checks = METHODS_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let methods_shadow_mismatches = METHODS_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-e7: methods_shadow_checks={methods_shadow_checks} methods_shadow_mismatches={methods_shadow_mismatches}"
+    );
+    if let Ok(map) = methods_shadow_mismatch_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-e7 methods-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );

--- a/t/classhow-methods-mixin-role.t
+++ b/t/classhow-methods-mixin-role.t
@@ -1,0 +1,45 @@
+use Test;
+
+# ADR-0019 E7 step 6: `.^methods()` (`Interpreter::dispatch_classhow_methods`,
+# `src/runtime/methods_classhow_builtin_methods.rs`) already extracted a
+# runtime-mixed-in role's method names (`(5 but R)`-style values) and folded
+# them into `.^methods(:local)`'s output, but the default (non-`:local`)
+# branch never did the same -- so `(5 but R).zork` was callable via ordinary
+# dispatch, yet absent from `(5 but R).^methods` (no `:local`). Confirmed
+# against real `raku`: `(5 but R).^methods.map(*.name)` includes `zork`
+# because a `but` mixin's `.^mro` puts an anonymous composite pun class
+# (`Int+{R}`) FIRST, ahead of the base type -- `((Int+{R}) (Int) (Cool) (Any)
+# (Mu))` -- and that pun class's own methods are exactly the mixed-in role's
+# methods.
+
+plan 9;
+
+role R1 { method zork { "zork!" } }
+
+my $x = 5 but R1;
+ok "zork" (elem) $x.^methods.map(*.name), 'mixed-in role method appears in .^methods (no :local)';
+ok "zork" (elem) $x.^methods(:local).map(*.name), 'mixed-in role method still appears in .^methods(:local)';
+is $x.zork, "zork!", 'the mixed-in role method actually runs';
+
+# A second role method, to confirm both are collected, not just the first.
+role R2 { method quux { "quux!" } }
+my $y = 5 but R1 but R2;
+ok "zork" (elem) $y.^methods.map(*.name), 'first mixed-in role method found with two roles mixed in';
+ok "quux" (elem) $y.^methods.map(*.name), 'second mixed-in role method found with two roles mixed in';
+
+# The base type's own (builtin) methods are still present alongside the
+# mixed-in role's methods -- the fix must not have replaced the base walk.
+ok "abs" (elem) $x.^methods.map(*.name), 'base Int type still contributes its own methods';
+
+# A value with no mixed-in role is unaffected (regression guard for the
+# ordinary, non-mixin case this box's shadow-check also covers).
+class A1 { method foo { "A1::foo" } }
+class B1 is A1 { method bar { "B1::bar" } }
+my @names = B1.^methods.map(*.name);
+ok "foo" (elem) @names, 'plain inheritance: ancestor method still found without any mixin';
+ok "bar" (elem) @names, 'plain inheritance: own method still found without any mixin';
+
+# `:all` still works together with a mixed-in role.
+ok "zork" (elem) $x.^methods(:all).map(*.name), 'mixed-in role method still appears with :all';
+
+done-testing;

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -2394,3 +2394,113 @@ step 4 deferred a real cutover pending catalog coverage) — found by direct `ra
 comparison during scoping, not by a shadow-check counter. Next E7 sub-slice: `.^methods` reading the
 call-path sequence (WALK and the EVAL/`subtest` re-entrant carriers come after, per the design's
 consumer ordering).
+
+## E7 step 6: `.^methods` — a real mixin-enumeration fix, plus a clean chain shadow-check
+
+**Scoping**: the design paragraph's own hint (`.^lookup`/`.^can`/`.^methods` reading the call-path
+sequence) plus the ADR's own note that `dispatch_classhow_methods`'s main branch already walks
+`self.class_mro(&class_name)` suggested this box was more likely a clean shadow-measurement (steps
+1/2's shape) than a bug hunt (step 5's shape). Verifying that assessment directly against `raku`
+before committing to either shape (as the ADR paragraph instructed) is what actually found this
+box's real finding — a different gap from the one initially suspected.
+
+**A suspected gap that turned out NOT to be real, recorded so it is not re-investigated**: real
+`raku`'s default (non-`:all`) `.^methods()` documentation says it "stops at Cool, Any, or Mu"
+(`raku-doc/doc/Type/Metamodel/MethodContainer.rakudoc`), and `dispatch_classhow_methods`'s MRO-walk
+loop only explicitly skips `"Any"`/`"Mu"`, never `"Cool"` — `Str.^mro` includes `Cool` as an
+intermediate ancestor, and the loop calls `self.collect_class_methods("Cool", ...)` for it, which
+looks like it ought to leak Cool's own registry-keyed methods into the default (non-`:all`) list.
+This does NOT happen in practice: `collect_class_methods` only ever finds something in
+`self.registry().classes` (the USER-defined class table), and `Cool` — like every other builtin —
+has no `ClassDef` entry there, so the loop iteration for `cn == "Cool"` always contributes nothing.
+The methods a builtin type like `Str` responds to come from an entirely separate mechanism instead:
+`builtin_type_method_names("Str")` (`builtins/builtin_type_methods.rs`) is a hand-maintained,
+ALREADY-FLATTENED per-type list (`STR_OWN` literally repeats `"trim"`, `"chars"`, etc. — the exact
+names `COOL_OWN` also lists for the `"Cool"` owner key) rather than a true composed MRO walk, so
+Cool's contribution is baked into Str's own list directly regardless of the `:all` flag. Confirmed
+directly: `"trim" ~~ Str.^methods.map(*.name).any` is `True` in `mutsu` both with and without
+`:all`. The visible numeric gap between `mutsu`'s `Str.^methods()` count and real `raku`'s (56 vs.
+79 locally) is ordinary native-catalog incompleteness (mutsu has not modelled every Cool/Str method
+`raku` has) — the same "catalog coverage gap" category step 4's `.^can` findings were, not a
+structural MRO-walk bug, so not investigated further here.
+
+**The real finding**, from the same direct-comparison pass:
+
+```raku
+role R1 { method zork { "zork!" } }
+my $x = 5 but R1;
+say "zork" ~~ $x.^methods.map(*.name).any;   # raku: True
+```
+
+`mutsu` answered `False` for the identical script (while `(5 but R1).zork` itself was directly
+callable, and `$x.^methods(:local).map(*.name)` — the SIBLING branch — already answered `True`).
+Root cause: `dispatch_classhow_methods`'s `local` branch extracts `mixin_role_names` from the
+invocant (`ValueView::Mixin(_, mixins)` -> the `__mutsu_role__`-prefixed keys) and calls
+`self.collect_role_methods(role_name, private, &mut result)` for each — but the sibling `else`
+(default, non-`:local`) branch never did the same; it only ever walked `class_mro(&class_name)`,
+and `mop_receiver_owner`/`dispatch_owner_chain` DELIBERATELY strip the role prefix from a Mixin's
+chain before returning it (documented in `receiver_class.rs`'s `dispatch_owner_chain` doc comment,
+for unrelated reasons: role methods are meant to be tried by a dedicated role-registry-aware path
+BEFORE this chain is ever consulted at its other call sites), so `class_name` for `(5 but R1)` is
+plain `"Int"`, with no trace of `R1` left to walk into.
+
+Confirmed against real `raku` WHY the fix belongs exactly where the `:local` branch's own handling
+already lived: a `but`-mixin's `.^mro` puts an anonymous composite pun class FIRST, ahead of the
+base type — `(5 but R1).^mro` is `((Int+{R1}) (Int) (Cool) (Any) (Mu))` — and that pun class's own
+methods are precisely the mixed-in role's methods, which is also why `zork` is literally the FIRST
+name in real `raku`'s unsorted `$x.^methods.map(*.name).List` output, ahead of every one of `Int`'s
+own methods.
+
+**Fix**: the `else` (non-`:local`) branch now runs the identical
+`for role_name in &mixin_role_names { self.collect_role_methods(role_name, private, &mut result); }`
+loop the `:local` branch already had, placed BEFORE the `class_mro(&class_name)` walk (matching the
+pun-class-first ordering confirmed above) — not a new mechanism, the same helper and the same
+`mixin_role_names` extraction (computed once, above the `if local {...} else {...}` split) the
+sibling branch already used. Two roles mixed onto the same value (`5 but R1 but R2`) both
+contribute, confirmed with a second role in the new test.
+
+**The shadow-check half of this box** (the design paragraph's "reading the call-path sequence"
+framing, applied the way steps 1/2/4 applied it — a `MUTSU_VM_STATS`-gated comparison against the E4
+resolver machinery, zero behavior change): unlike a single-method resolution, `.^methods()`
+enumerates a WHOLE set, so there is no single "dispatch winner" to compare against
+`resolve_sequence`. The natural analogue instead is comparing the CHAIN the enumeration walks
+(`class_mro(&class_name)`, the plain registry MRO primitive) against the E4 resolver's own canonical
+chain for the identical receiver (`Interpreter::dispatch_owner_chain`, TypeId-based — the same chain
+qualified dispatch (step 2) and private dispatch (step 3) both already reuse). A new dedicated
+counter pair, `record_methods_shadow_check` (`vm/vm_stats.rs`), rather than the shared
+`RESOLVER_SHADOW_*` family — the same reasoning step 4's `.^can` check already established for its
+own `CAN_SHADOW_*` pair: this compares two whole ordered name sequences, not a single dispatch-winner
+pick, and mixing it into a shared total would repeat the "false lead" step 1's own progress note
+warns about. Placed right after `let mro = self.class_mro(&class_name);`, comparing `mro`'s names
+against `self.dispatch_owner_chain(invocant)`'s `TypeId::as_str()` names for exact sequence equality.
+Swept a 10-case hand-built probe (plain classes with inheritance, role composition via `does`, a
+`but`-mixin, `List`/`Str`/`Int` builtins, both an instance and a type-object receiver): 10 checks, 0
+mismatches — the two chain computations already agree everywhere probed. (This shadow check compares
+the underlying CHAIN, not the final collected method SET, so it was never going to catch the mixin
+gap above by itself — that gap is in what the `else` branch does with the chain it already had
+right, not in the chain itself; both findings are reported together because they came out of the
+same investigation pass, not because one caused the other.)
+
+**Verification**: `cargo build`/`cargo clippy -- -D warnings`/`cargo fmt` clean. New
+`t/classhow-methods-mixin-role.t` (9 assertions): the confirmed repro (no `:local`), the same case
+confirmed still working `:local`, the method actually running, two roles mixed in simultaneously
+(both found), the base type's own methods still present alongside the mixed-in ones (regression
+guard that the fix didn't replace the base walk), a plain-inheritance case with no mixin at all
+(regression guard for the ordinary case), and `:all` combined with a mixin. All 6 already-whitelisted
+roast files that call `.^methods(` (found by grepping roast for `\.\^methods\(`) green under
+`MUTSU_FUDGE=1`: `roast/S12-introspection/methods.t` (57 assertions — the dedicated `.^methods` spec,
+covering `:local`/`:all`/`:tree`/`:private`/multi-dispatcher-single-entry-shape/attribute-declaration-
+order, unaffected by this fix and confirmed still fully green), `roast/6.c/S14-roles/mixin-6c.t`,
+`roast/S14-roles/mixin-6e.t` (the two role-mixin-relevant files), and
+`roast/integration/{advent2009-day11,advent2010-day22}.t` /
+`roast/integration/weird-errors.t`. Since this changes a real `.^methods()` answer (not just a
+shadow-only probe), this counts as CLAUDE.md's "touched name/type resolution" case requiring a local
+roast check before opening the PR — the 6-file sweep above is that check.
+
+**Conclusion**: unlike steps 1/2/4 (clean shadow-checks, no real-behavior change) but like step 5,
+this sub-slice found and fixed a real, confirmed `raku`-vs-`mutsu` behavioral gap through direct
+comparison during scoping — this time in the DEFAULT (non-`:local`) branch's mixin-role handling,
+not in an MRO-walk primitive. The shadow-check half added alongside it is clean (0/10 mismatches),
+matching steps 1/2's zero-gap result for the chain-construction question specifically. Next E7
+sub-slice: WALK and the EVAL/`subtest` re-entrant carriers, per the design's consumer ordering — the
+last two items in the box's original consumer list.


### PR DESCRIPTION
## Summary

`dispatch_classhow_methods`'s default (non-`:local`) branch already walked the receiver's `class_mro` correctly, but never folded in a runtime `but`-mixed-in role's own methods the way the `:local` branch already did — so `(5 but R).zork` was directly callable yet absent from `(5 but R).^methods`. Confirmed against real Raku: a `but`-mixin's `.^mro` puts an anonymous composite pun class first (`(5 but R).^mro` is `((Int+{R}) (Int) (Cool) (Any) (Mu))`), and that pun class's own methods are exactly the mixed-in role's methods. Fixed by collecting the mixin role's methods before the base `class_mro` walk, mirroring the `:local` branch's existing pattern.

Also adds a `MUTSU_VM_STATS`-gated shadow-check comparing the `class_mro` chain this walk enumerates against the E4 resolver's own canonical `dispatch_owner_chain` for the same receiver — zero mismatches across a 10-case probe once the mixin fix above made the enumerated method set match `raku` too. Pure insertion, zero behavior change on its own.

This is ADR-0019 Phase E box E7's sixth sub-slice. Full write-up in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 6".

## Test plan

- [x] New `t/classhow-methods-mixin-role.t` (9 assertions): the confirmed repro, two-roles-mixed-in, base-type-methods-still-present, plain-inheritance regression guard, `:all` combined with a mixin.
- [x] `cargo clippy -- -D warnings` / `cargo fmt` clean.
- [x] Full local `make test` green (3062 files/28,600 tests).
- [x] Six canary files that caught E7 step 5's regressions (`t/can-does.t`, `t/classhow-lookup-mro.t`, `t/method-wrap-writeback-only-mutations.t`, `t/monitor-method-does-not-leak-topic-or-self.t`, `t/declarator-trailing-wherefore.t`, `t/exporthow-grammar-how.t`) all still pass.
- [x] All 6 whitelisted roast files that call `.^methods(` (including the role-mixin specs `roast/6.c/S14-roles/mixin-6c.t`/`roast/S14-roles/mixin-6e.t` and `roast/S12-introspection/methods.t`) green, per CLAUDE.md's "touched name/type resolution" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)