### PR TITLE
fix(runtime): three general bugs surfaced by Text::CSV 90_csv.t — &param alias leak, append Range, for-loop live-array name collision

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2381,15 +2381,19 @@ impl Compiler {
         }
     }
 
-    /// Bake the local slot for a `for @a` live-array source (§1.5). Mirrors the
-    /// VM's runtime resolution order (bare name, then the `@`-sigiled name), which
-    /// — since `code.locals` is built from `local_map` — is exactly this lookup.
+    /// Bake the local slot for a `for @a` live-array source (§1.5). The source
+    /// is an `@`-variable by construction (`for_single_array_source` only
+    /// matches `Expr::ArrayVar`), so the `@`-sigiled local key is tried FIRST:
+    /// a bare-name-first lookup resolved `for @in` to a same-named scalar
+    /// param `$in` (scalar locals are stored sigil-less), making the VM's
+    /// live-array growth check read the wrong container and re-run the last
+    /// iteration (Text::CSV 90_csv.t emitted the final row twice).
     /// `None` when the source is not a local (keeps the VM's env fallback).
     fn for_single_array_source_local(&self, source: &Option<String>) -> Option<u32> {
         let name = source.as_ref()?;
         self.local_map
-            .get(name)
-            .or_else(|| self.local_map.get(&format!("@{name}")))
+            .get(&format!("@{name}"))
+            .or_else(|| self.local_map.get(name))
             .copied()
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -72,6 +72,13 @@ pub(crate) fn flatten_append_args(args: Vec<Value>) -> Vec<Value> {
                 }
                 result
             }
+            // A single Range flattens to its elements (`@x.append: 1..3` /
+            // `"a".."c"`), same one-arg rule as an Array/List argument.
+            ValueView::Range(..)
+            | ValueView::RangeExcl(..)
+            | ValueView::RangeExclStart(..)
+            | ValueView::RangeExclBoth(..)
+            | ValueView::GenericRange { .. } => crate::runtime::utils::value_to_list(&args[0]),
             _ => args,
         }
     } else {

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -913,6 +913,31 @@ impl Interpreter {
                         {
                             self.unmark_readonly(name);
                         }
+                        // Restore the loop param's prior binding on abnormal exit
+                        // (`return`, an exception, an outer loop's `last`/`next`):
+                        // the normal path defers this to `RestoreForParam`, which
+                        // never runs when the frame unwinds past it. Leaving the
+                        // final iteration value bound leaked it out of the routine
+                        // via merge_method_env when the CALLER had a same-named
+                        // binding (`for @!ranges -> $r { ... and return True }`
+                        // inside a method clobbered the caller's `-> $r` param —
+                        // Text::CSV RangeSet.in vs method CSV's gather loop).
+                        if let Some((name, saved_val, colliding_slot)) = &saved_param {
+                            if let Some(slot) = colliding_slot
+                                && (*slot as usize) < self.locals.len()
+                            {
+                                self.locals[*slot as usize] =
+                                    saved_val.clone().unwrap_or(Value::NIL);
+                            }
+                            match saved_val {
+                                Some(v) => {
+                                    self.env_mut().insert(name.clone(), v.clone());
+                                }
+                                None => {
+                                    self.env_mut().remove(name);
+                                }
+                            }
+                        }
                         self.restore_loop_topic(saved_topic.clone(), saved_topic_local.clone());
                         self.pop_loop_local_scope(code);
                         self.unmask_for_multi_params(&masked_multi_params);

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -365,12 +365,22 @@ impl Interpreter {
             }
             // Re-read the live source array. In the single-store model `@a` is
             // authoritative in its local slot (the env copy can be stale), so try
-            // the local slot first (the compiler-baked slot §1.5, else by name —
-            // bare and `@`-sigiled), then env.
-            let live = self
-                .resolve_local_slot(code, spec.single_array_source_local, name)
-                .or_else(|| self.find_local_slot(code, &format!("@{name}")))
+            // the local slot first (the compiler-baked slot §1.5, else by name),
+            // then env. The source is an `@`-variable, so the `@`-sigiled key is
+            // tried before the bare name at every tier — a bare-first lookup
+            // resolves to a same-named scalar (`$in` vs `@in`; scalar locals and
+            // env entries are stored sigil-less) and misreads its length as
+            // live-array growth.
+            let slot = match spec.single_array_source_local {
+                Some(s) if (s as usize) < self.locals.len() => Some(s as usize),
+                Some(_) => None,
+                None => self
+                    .find_local_slot(code, &format!("@{name}"))
+                    .or_else(|| self.find_local_slot(code, name)),
+            };
+            let live = slot
                 .map(|s| self.locals[s].clone())
+                .or_else(|| self.env().get(&format!("@{name}")).cloned())
                 .or_else(|| self.env().get(name).cloned());
             let grown = match live.as_ref().map(Value::view) {
                 Some(ValueView::Array(arc, _)) if arc.len() > all_items.len() => {

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1968,6 +1968,12 @@ fn merge_method_env(
             // method call for a set consulted only against the few overlay keys).
             if k.with_str(|s| {
                 is_method_local(s)
+                    // A Callable argument bound to a frame param/local also gets
+                    // an `&name` alias in the frame env (`bind_param_value`), so
+                    // `$in()` can dispatch by name. The alias is frame-internal:
+                    // merging it would shadow the caller's same-named package sub
+                    // with the argument value (`sub in` vs `csv(in => ...)`).
+                    || s.strip_prefix('&').is_some_and(is_method_local)
                     // Per-call-site index-rw temps are frame-internal; merging a
                     // callee's same-named entries corrupts the caller's pending
                     // post-call writeback compare (see is_index_rw_call_temp).

--- a/t/array-append-range.t
+++ b/t/array-append-range.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# `.append` / `.prepend` follow the one-arg rule: a single Range argument
+# flattens to its elements (rakudo-verified 2026-08-12). Text::CSV's
+# RangeSet.list does `my Int @x; @x.append: $from .. $to` — the typed array
+# rejected the unflattened Range with a type-check error.
+
+plan 6;
+
+my Int @x;
+@x.append: 1..3;
+is-deeply @x, Array[Int].new(1, 2, 3), "typed array append flattens a Range";
+
+my @y;
+@y.append: 1..3;
+is-deeply @y, [1, 2, 3], "untyped append flattens a single Range";
+
+my @m;
+@m.append: (1..3), 5;
+is @m.elems, 2, "multiple args are not flattened (one-arg rule)";
+isa-ok @m[0], Range, "the Range stays a Range with multiple args";
+
+my @s;
+@s.append: "a".."c";
+is-deeply @s, ["a", "b", "c"], "string Range flattens too";
+
+my @p;
+@p.prepend: 1..3;
+is-deeply @p, [1, 2, 3], "prepend flattens a single Range";
+
+done-testing;

--- a/t/for-live-array-name-collision.t
+++ b/t/for-live-array-name-collision.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+
+# `for @in` live-array iteration (RT113026) re-reads its source after each
+# pass to pick up growth. The source slot was resolved bare-name-first, so a
+# same-named scalar (`$in` — scalar locals are stored sigil-less) was read
+# instead of `@in`: its larger length was misread as "the array grew" and the
+# loop re-ran the final iteration (Text::CSV 90_csv.t emitted the last row
+# twice through Block/Channel/Supplier outputs).
+
+plan 4;
+
+{
+    my $in = [1, 2, 3];
+    my @in = $in.list;
+    @in.shift;
+    my @seen;
+    for @in -> $row { @seen.push: $row }
+    is-deeply @seen, [2, 3], 'for @in iterates the array, not the same-named scalar';
+}
+
+{
+    sub f(:$in!) {
+        my @in = $in.list;
+        @in.shift;
+        my $n = 0;
+        for @in -> $r { $n++ }
+        $n;
+    }
+    is f(in => [[1], [2], [3]]), 2, 'named param $in does not confuse a for over @in';
+}
+
+{
+    # Live-array growth must still work (RT113026).
+    my @a = 1, 2;
+    for @a -> $n { @a.push($n + 10) if $n < 3 }
+    is-deeply @a, [1, 2, 11, 12], 'live-array growth during for still iterates the new tail';
+}
+
+{
+    # Shrinking the same-named scalar's array must not truncate the loop.
+    my $xs = [1, 2];
+    my @xs = |$xs, 3, 4;
+    my $n = 0;
+    for @xs -> $x { $n++ }
+    is $n, 4, 'loop count comes from @xs, not $xs';
+}
+
+done-testing;

--- a/t/for-param-restore-on-return.t
+++ b/t/for-param-restore-on-return.t
@@ -1,0 +1,73 @@
+use v6;
+use Test;
+
+# A for-loop's pointy param must not stay bound when the loop exits
+# abnormally (`return` from inside the body, an exception, an outer loop's
+# `last`). The normal path restores the prior binding via a post-phaser
+# opcode that an unwinding frame skips; the leftover final-iteration value
+# then leaked out of the routine into a same-named caller binding via the
+# method env merge. Text::CSV: RangeSet.in's `for @!ranges -> $r { ... and
+# return True }` clobbered method CSV's `while $in() -> $r` param, turning
+# every CSV row into the RangeSet's internal Pair.
+
+plan 3;
+
+class RS {
+    has Pair @!ranges;
+    method add(Pair $p) { @!ranges.push: $p }
+    method in(Int $i) {
+        for @!ranges -> $r {
+            $i >= $r.key && $i <= $r.value and return True;
+        }
+        False;
+    }
+}
+
+{
+    my $rs = RS.new;
+    $rs.add(1 => 100);
+    my @seen;
+    my @rows = ["a", "b"], ["c", "d"], ["e", "f"];
+    my $i = 0;
+    my $n = 0;
+    while @rows[$n++] -> $r {
+        if $rs.in($i++) {
+            @seen.push: $r;
+        }
+        last if $n >= 3;
+    }
+    is-deeply @seen, [["c", "d"], ["e", "f"]],
+        'caller loop param survives a callee method returning from inside its own for';
+}
+
+{
+    sub inner($x) {
+        for 10, 20, 30 -> $r {
+            return "inner:$r" if $r == 20;
+        }
+        "none";
+    }
+    my @got;
+    for 1, 2 -> $r {
+        my $res = inner($r);
+        @got.push: "$r/$res";
+    }
+    is-deeply @got, ["1/inner:20", "2/inner:20"],
+        'sub returning from inside a for does not clobber the caller loop param';
+}
+
+{
+    my $outer-r;
+    sub thrower {
+        for 1, 2, 3 -> $r {
+            die "boom" if $r == 2;
+        }
+    }
+    for 42 -> $r {
+        try thrower();
+        $outer-r = $r;
+    }
+    is $outer-r, 42, 'exception unwind restores the loop param binding';
+}
+
+done-testing;

--- a/t/method-callable-param-alias-no-leak.t
+++ b/t/method-callable-param-alias-no-leak.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# A Callable argument bound to a method's named parameter must not leak an
+# `&name` alias into the caller's scope when the method returns. Text::CSV's
+# `method csv(:$in)` receives `in => &provider`; the caller's own `sub in`
+# must still be what a later `in()` call dispatches to (90_csv.t's in-format
+# sweep re-enumerates inputs via `sub in` after every csv() call).
+#
+# The leak needed a nested method call: the callee frame's env (holding the
+# `&in` param alias) was merged back into the caller env on return, and the
+# merge kept every `&`-prefixed key unconditionally.
+
+plan 6;
+
+class Outer {
+    method inner(Any :$in!) { 42 }
+    method outer(Any :$in) { self.inner(:$in) }
+    method outer-noargs(Any :$in) { self.inner(in => 1) }
+}
+
+sub in { "SUB IN" }
+
+my $r = Outer.outer(in => -> { False });
+is $r, 42, "nested method call with Callable named arg returns normally";
+is in(), "SUB IN", "caller's sub in() still dispatches to the package sub";
+
+my $r2 = Outer.outer-noargs(in => -> { "leak" });
+is $r2, 42, "nested call passing a different arg returns normally";
+is in(), "SUB IN", "outer param alias does not leak either";
+
+# Positional Callable params leak the same alias mechanism.
+class Pos {
+    method inner($cb) { $cb() }
+    method outer($cb) { self.inner($cb) }
+}
+sub cb { "SUB CB" }
+is Pos.outer(-> { "arg cb" }), "arg cb", "positional Callable param dispatches inside the method";
+is cb(), "SUB CB", "positional Callable param does not shadow the caller's sub";
+
+done-testing;

--- a/todo/tickets/supply-done-in-tap-callback-load-flaky.t.md
+++ b/todo/tickets/supply-done-in-tap-callback-load-flaky.t.md
@@ -1,0 +1,26 @@
+# t/supply-done-in-tap-callback-is-not-a-failure.t test 3 is load-flaky on main
+
+Measured 2026-08-12 during the Text::CSV campaign (session running the
+for-loop param-restore fix): under 24-way parallel invocation of the same
+file on a debug build, **test 3 fails 10/24 runs** on a binary built from
+main (commit 09ab95642, pre-change control build), and it failed once in an
+ordinary `make test` (Files=3064). Serial re-runs pass 5/5, so this is
+load/timing sensitivity, not a deterministic regression.
+
+Repro:
+
+```
+cargo build
+for i in $(seq 1 24); do
+  (timeout 30 target/debug/mutsu t/supply-done-in-tap-callback-is-not-a-failure.t \
+     >/dev/null 2>&1; echo "exit=$?") &
+done; wait
+# ~10/24 exit=1 on a loaded machine
+```
+
+Next step: root-cause the timing hole (test 3 asserts a `done` emitted from
+inside a tap callback is not treated as a failure — likely a race between
+the tap callback thread and the supply completion bookkeeping), or if it
+proves genuinely non-deterministic by design, quarantine it via
+`flaky-tests.txt` following docs/flaky-test-policy.md (this measurement
+satisfies the evidence standard; note the 10/24 rate).


### PR DESCRIPTION
Four general fixes surfaced by Text::CSV's `90_csv.t` in-format sweep (CSV battery campaign, PLAN.md B1). 90_csv.t: **36 → 448 subtests reached, 11 → 1 remaining failure**.

## 1. `merge_method_env` leaked a Callable param's `&name` alias into the caller

`bind_param_value` gives a Callable argument bound to a method param an `&name` env alias (so `$in()` can dispatch by name). `merge_method_env` kept **every** `&`-prefixed callee overlay key unconditionally, so when the method body made a nested method call (which forces the env merge path), the alias — e.g. `&in` from `Text::CSV.csv(in => &provider)` — was merged into the **caller's** env on return. A later `in()` call at the call site then dispatched to the leaked argument value (treated as a lexical override) instead of the caller's package `sub in`. 90_csv.t re-enumerates its in-formats via `sub in` after every csv() call, so the whole Method/Sub scope section aborted.

Fix: exclude `&X` from the merge when bare `X` is a frame param/local (the alias is frame-internal by construction).

```raku
class C {
    method inner(Any :$in!) { 42 }
    method outer(Any :$in) { self.inner(:$in) }
}
sub in { "SUB IN" }
C.outer(in => -> { False });
say in();   # raku: SUB IN / mutsu before: Bool::False (called the leaked block!)
```

## 2. `.append`/`.prepend` did not flatten a single Range (one-arg rule)

`my Int @x; @x.append: $from .. $to` (Text::CSV's `RangeSet.list`) failed with "expected Int but got Range"; untyped arrays kept the Range as one element (`[1..3,]`). `flatten_append_args` now expands all Range variants via `value_to_list` (string ranges included); multiple args stay unflattened. Rakudo-verified.

## 3. for-loop live-array re-read resolved to a same-named scalar

The RT113026 live-array growth check re-reads `for @in`'s source after each pass. Both the compiler-baked slot and the VM's by-name/env fallbacks looked the **bare** name up first, so a same-named scalar `$in` (scalar locals/env entries are sigil-less) shadowed the array: its larger length was misread as live-array growth and the loop re-ran the final iteration. `method CSV` has both `:$in` and `my @in`, so every Block/Channel/Supplier/prefill output emitted the last row twice.

```raku
my $in = [1,2,3];
my @in = $in.list;
@in.shift;
for @in -> $row { }   # iterated 3 times (last element twice); now 2
```

All three tiers now try the `@`-sigiled key before the bare name (the source is an `@`-variable by construction).

## Remaining 90_csv.t failures (next slices)

159 (`fragment col=`), 211/214 (Hash + skip over Sub/Block input), and an end-of-file abort — separate issues.

Pins: `t/method-callable-param-alias-no-leak.t`, `t/array-append-range.t`, `t/for-live-array-name-collision.t` (all rakudo-verified). Local `make test` PASS both commits; S12-methods + S32-array/push.t spot-check PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 4. for-loop param binding leaked on abnormal exit

The pointy param of `for ... -> $r` is env-bound by bare name; the prior binding is normally restored by the `RestoreForParam` opcode after the post/LAST phasers. An abnormal exit (`return` from inside the body, an exception, an outer loop's `last`) unwinds past that opcode, so the final iteration value stayed bound in the callee frame — and `merge_method_env` wrote it back into a same-named **caller** binding. Text::CSV: `RangeSet.in`'s `for @!ranges -> $r { ... and return True }` clobbered `method CSV`'s `while $in() -> $r` param, so every row of a skip/fragment-filtered `csv()` became the RangeSet's internal Pair (`1 => Inf`).

Pin: `t/for-param-restore-on-return.t`.

(Also recorded: `t/supply-done-in-tap-callback-is-not-a-failure.t` test 3 measured load-flaky on unmodified main, 10/24 under 24-way load — `todo/tickets/supply-done-in-tap-callback-load-flaky.t.md`.)