### PR TITLE
fix(runtime): .WALK accepts a runtime mixin receiver (ADR-0019 E7 step 7)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3558,6 +3558,62 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   above is that check. Full detail in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 6:
   `.^methods` — a real mixin-enumeration fix, plus a clean chain shadow-check". Next E7 sub-slice:
   WALK and the EVAL/`subtest` re-entrant carriers, per the design's consumer ordering.
+  **Progress 2026-08-12** (seventh consumer family, `.WALK`, two real bugs plus a clean chain
+  shadow-check — not a "just add a shadow check" box like steps 1/2): scoping
+  (`src/runtime/methods_walk.rs`) found `try_walk_method` never recognized a runtime mixin
+  (`ValueView::Mixin`) as a valid receiver at all — `(5 but R1).WALK("zork")` raised
+  `X::Method::NotFound` where real `raku` returns `(R1::zork)`, confirmed by direct comparison
+  during scoping the same way steps 5/6 found their gaps. **Fix 1**: `try_walk_method` now extracts
+  `mixin_role_names` from a `Mixin` receiver (mirroring step 6's `dispatch_classhow_methods` fix)
+  and prepends a new `WalkKind::MixinRole` target per role — unlike a statically-`does`-composed
+  role (`WalkKind::Role`, submethods only, since regular methods are already composed into the
+  consuming class's own method table), a *runtime* mixin's role is never composed anywhere, so its
+  own regular (non-private) methods are the only place to find them; `lookup_own_walk_method` grew
+  a matching arm. Investigating the fix surfaced a second, independent bug: `walk_list_invoke_direct`
+  read a Mixin invocant's attributes via a direct `ValueView::Instance` match, which is `None` for a
+  `Mixin`-wrapped instance — any WALK candidate on the *base* class of a mixin ran with an empty
+  attribute map. **Fix 2**: reuse the existing general Mixin-unwrap helper
+  (`Interpreter::self_instance_attrs`, already used by ordinary method dispatch for the same purpose)
+  instead of the ad hoc match. Testing fix 1 surfaced a third, unrelated bug while checking `say`
+  output: `$obj.WALK(...)().gist`/`.Str` printed `()`/empty on an otherwise-correct, already-working
+  (pre-mixin, plain-class) WALK result. Root cause: `Interpreter::force_lazy_list`
+  (`runtime/resolution_lazy.rs`), the forcer that `.gist`/`.Str`/`say` route through (via
+  `call_method_with_values`'s "force LazyList and re-dispatch as Seq" branch), had a `cat_pull`
+  branch but no `walk_pending` branch — and a WALK-produced `LazyList` starts with a **non-empty**
+  `Some(Vec::new())` cache (`LazyList::new_cached`), so the function's cache short-circuit
+  (`if let Some(cached) = list.cache... { return Ok(cached) }`) returned the still-empty initial
+  cache before ever pulling a candidate, exactly the failure mode the existing `cat_pull` comment
+  already warned about for its own case ("cache always starts non-empty, so this must run before the
+  cache short-circuit"). **Fix 3**: added the missing `walk_pending` branch in the same position,
+  delegating to the existing `force_walk_pending` (already used correctly by the VM's own opcode-level
+  forcer, `force_lazy_list_vm` in `vm_helpers_lazy.rs`, which is why `for`-iteration and array
+  coercion — a separate, already-correct forcing path — never showed this bug). **Shadow-check**
+  added too, matching step 6's "the check is the other half of the fix" pattern: a new
+  `MUTSU_VM_STATS`-gated `WALK_SHADOW_*` pair (`vm_stats.rs`) compares the CLASS-kind portion of the
+  chain WALK's default (`:canonical`) ordering walks (`build_walk_targets`, ultimately
+  `class_mro_readonly`) against the E4 resolver's own canonical chain for the same receiver
+  (`dispatch_owner_chain`) — deliberately scoped to `:canonical` only, since WALK's other orderings
+  (`:super`/`:breadth`/`:ascendant`/`:descendant`) are legitimate alternate traversals documented by
+  raku's own WALK spec, not MRO restatements, so comparing them against the resolver's MRO chain
+  would be a guaranteed, meaningless mismatch. Swept the existing `t/walk-lazy.t`/`t/walk-orderings.t`
+  suite plus a hand-built mixin/two-role/ordering probe: 12 + 5 checks, 0 mismatches, once a
+  same-name-as-a-builtin-type test class (`Sub`, colliding with the builtin `Sub`/`Routine` type) was
+  renamed out of the probe — that collision is the SAME already-tracked owner-name-collision gap the
+  E1a ledger already records (`multi_arg_type_keys`), not a new finding. New `t/walk-mixin-role.t` (11
+  assertions: mixin-onto-builtin, mixin-onto-instance base-chain-still-walkable,
+  mixin-role-method-found, absent-method-empty, two-stacked-mixin-roles, mixin-overriding-base,
+  attribute-access-through-a-mixin-wrapped-candidate, plain-builtin-type-receiver-regression-guard)
+  plus two new assertions appended to `t/walk-lazy.t` (`.gist`/`.Str` forcing). `cargo build`/`cargo
+  clippy -- -D warnings`/`cargo fmt` clean; full local `make test` green. Since fixes 1-3 change real
+  `.WALK` answers (not just a shadow-only probe), this counts as CLAUDE.md's "touched name/type
+  resolution" case: `roast/S12-introspection/walk.t` and `roast/S14-roles/attributes-6e.t` (the two
+  whitelisted files that call `.WALK(`) both green locally with `MUTSU_FUDGE=1`. `git grep -n "WALK"
+  src/runtime/ src/vm/` confirmed WALK has no other internal caller in mutsu (no TWEAK/BUILDALL
+  construction-phaser use, unlike the ADR's general phrasing might suggest) — the blast radius is
+  exactly the `.WALK(...)`/`WalkList` dispatch sites this box touched, nothing wider. Full detail in
+  `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 7: `.WALK` — two real bugs (mixin receivers,
+  lazy-forcing gap) plus a clean chain shadow-check". **Next (and last) E7 sub-slice: the EVAL/
+  `subtest` re-entrant carriers** — after that, E7 as a whole is closed and E8 is next.
 - [ ] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
   **Design 2026-08-10** (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`):

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -15,6 +15,12 @@
 //! - `:method` / `:submethod` — currently both are looked up via the same
 //!   per-class method table; this is enough for what roast tests exercise.
 //!
+//! A runtime mixin (`$obj but Role`) is also a valid receiver: the mixed-in
+//! role's own methods are visited FIRST, ahead of the base class chain (real
+//! raku puts the mixin's anonymous pun class first in `.^mro`), regardless of
+//! whether `:roles` was passed -- `:roles` only controls whether *statically
+//! composed* (`class C does Role {}`) roles are additionally walked.
+//!
 //! The implementation pre-evaluates each method call eagerly when WALK is
 //! invoked, then returns a no-arg `Sub` whose body returns the resulting
 //! list literal. This keeps the result trivially callable as `WALK(...)()`
@@ -33,13 +39,29 @@ impl Interpreter {
         target: &Value,
         args: &[Value],
     ) -> Result<Option<Value>, RuntimeError> {
-        // Only handle WALK on instances or type objects backed by a class def.
-        let receiver_class_name = match target.view() {
-            ValueView::Instance { class_name, .. } => class_name.resolve(),
-            ValueView::Package(name) => name.resolve(),
+        // Handle WALK on instances, type objects backed by a class def, or a
+        // runtime mixin (`but`) layered on either. `mixin_role_names` collects
+        // the role(s) mixed onto `target`: real raku puts a mixin's own pun
+        // class FIRST in `.^mro` (`(Sub.new but R1).^mro` is `(Sub+{R1}) Sub
+        // ... Any Mu`), so those roles' own candidates must be visited before
+        // the base class chain below -- the same fix ADR-0019 E7 step 6 made
+        // for `.^methods()`. See `todo/deep/adr0019-e5-e7-entry-routing.md`
+        // "E7 step 7".
+        let (receiver_class_name, mixin_role_names): (String, Vec<String>) = match target.view() {
+            ValueView::Instance { class_name, .. } => (class_name.resolve(), Vec::new()),
+            ValueView::Package(name) => (name.resolve(), Vec::new()),
+            ValueView::Mixin(_, mixins) => {
+                let roles: Vec<String> = mixins
+                    .keys()
+                    .filter_map(|k| k.strip_prefix("__mutsu_role__").map(String::from))
+                    .collect();
+                (self.mop_receiver_owner(target), roles)
+            }
             _ => return Ok(None),
         };
-        if !self.registry().classes.contains_key(&receiver_class_name) {
+        if mixin_role_names.is_empty()
+            && !self.registry().classes.contains_key(&receiver_class_name)
+        {
             // A built-in type (e.g. `Grammar`) has no user `class_def`, but WALK
             // must still find its native methods. Resolve the method name from a
             // small table of WALKable built-in methods and return a single
@@ -88,9 +110,43 @@ impl Interpreter {
             return Ok(None);
         };
 
-        // Build the walk order over the class hierarchy in the requested order,
-        // optionally including composed roles.
-        let walk_targets = self.build_walk_targets(&receiver_class_name, order, want_roles);
+        // Build the walk order: any runtime-mixed-in roles' OWN candidates come
+        // first, UNCONDITIONALLY -- `:roles` only affects statically-composed
+        // roles' submethods further down (they are visited via the class
+        // chain already; see `build_walk_targets`'s own doc). A mixin role is
+        // never composed into any class's method table, so its regular
+        // methods are only reachable here. Then the class hierarchy, in the
+        // requested order, optionally including composed roles.
+        let mut walk_targets: Vec<(WalkKind, String)> = mixin_role_names
+            .iter()
+            .map(|r| (WalkKind::MixinRole, r.clone()))
+            .collect();
+        walk_targets.extend(self.build_walk_targets(&receiver_class_name, order, want_roles));
+
+        // ADR-0019 Phase E box E7 step 7: shadow-check the CLASS-kind portion
+        // of the default (`:canonical`) chain above (`build_walk_targets` /
+        // ultimately `class_mro_readonly`) against the E4 resolver's own
+        // canonical chain for the same receiver (`dispatch_owner_chain`,
+        // TypeId-based). Scoped to `:canonical` only -- WALK's other
+        // orderings are legitimate non-MRO traversals, not restatements of
+        // MRO. `MUTSU_VM_STATS`-gated, zero behavior change.
+        if matches!(order, WalkOrder::Canonical) && crate::vm::vm_stats::enabled() {
+            let real_names: Vec<&str> = walk_targets
+                .iter()
+                .filter(|(k, _)| matches!(k, WalkKind::Class))
+                .map(|(_, o)| o.as_str())
+                .collect();
+            let shadow_chain = self.dispatch_owner_chain(target);
+            let shadow_names: Vec<&str> = shadow_chain
+                .iter()
+                .map(|t| t.as_str())
+                .filter(|n| !matches!(*n, "Any" | "Mu" | "Cool"))
+                .collect();
+            let matched = real_names == shadow_names;
+            crate::vm::vm_stats::record_walk_shadow_check(matched, || {
+                format!("class={receiver_class_name} real={real_names:?} shadow={shadow_names:?}")
+            });
+        }
 
         // For each (kind, owner-name) that has an "own" candidate for the named
         // method, build a candidate closure `-> $inst, *@a { $inst.OWNER::name(|@a) }`.
@@ -230,6 +286,7 @@ impl Interpreter {
                 let tag = match kind {
                     WalkKind::Class => "C",
                     WalkKind::Role => "R",
+                    WalkKind::MixinRole => "M",
                 };
                 Value::str(format!("{tag}|{owner}"))
             })
@@ -297,10 +354,14 @@ impl Interpreter {
                 quiet,
             )
         };
-        let attributes_map = match invocant.view() {
-            ValueView::Instance { attributes, .. } => attributes.to_map(),
-            _ => AttrMap::new(),
-        };
+        // Unwrap a `Mixin` invocant (`Sub.new but R1`) to the inner instance's
+        // shared attribute cell, matching the general `does`-mixin unwrap
+        // (`Self::self_instance_attrs`, `vm_var_assign_computed_attr.rs`) --
+        // without it, a mixin's OWN (base-class) method candidates ran with an
+        // empty attribute map.
+        let attributes_map = Self::self_instance_attrs(&invocant)
+            .map(|a| a.to_map())
+            .unwrap_or_default();
         let mut order: Vec<String> = targets;
         if reversed {
             order.reverse();
@@ -355,6 +416,7 @@ impl Interpreter {
             let (kind, owner) = match tag.split_once('|') {
                 Some(("C", o)) => (WalkKind::Class, o.to_string()),
                 Some(("R", o)) => (WalkKind::Role, o.to_string()),
+                Some(("M", o)) => (WalkKind::MixinRole, o.to_string()),
                 _ => continue,
             };
             let Some(method_def) =
@@ -637,6 +699,17 @@ impl Interpreter {
                     })
                     .cloned()
             }
+            WalkKind::MixinRole => {
+                // A role mixed onto the receiver at runtime (`but`/`does`) is
+                // never composed into any class's method table -- unlike
+                // `WalkKind::Role` above, its own REGULAR methods (not just
+                // submethods) are only reachable through the role's own
+                // table, so any non-private "own" candidate counts.
+                let registry = self.registry();
+                let role_def = registry.roles.get(owner)?;
+                let overloads = role_def.methods.get(method_name)?;
+                overloads.iter().find(|m| !m.is_private).cloned()
+            }
         }
     }
 }
@@ -682,7 +755,14 @@ fn walk_param(name: &str, slurpy: bool) -> crate::ast::ParamDef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum WalkKind {
     Class,
+    /// A statically-composed role's own SUBMETHOD (regular methods of a
+    /// composed role are already visited via the class chain).
     Role,
+    /// A role mixed onto the receiver at runtime (`but`/`does`). Unlike a
+    /// composed role, none of its methods are copied into any class's method
+    /// table, so every one of its own (non-private) methods -- not just
+    /// submethods -- is visited here.
+    MixinRole,
 }
 
 /// Traversal ordering for `WALK`. `:preorder` is an alias for `:ascendant`.

--- a/src/runtime/resolution_lazy.rs
+++ b/src/runtime/resolution_lazy.rs
@@ -28,6 +28,17 @@ impl Interpreter {
         if list.cat_pull.is_some() {
             return self.force_cat_pull(list, usize::MAX);
         }
+        // A lazy `WALK(method)()` candidate-invocation list (ADR-0019 E7 step
+        // 7, `todo/deep/adr0019-e5-e7-entry-routing.md`): pull every remaining
+        // MRO-level candidate. Its cache starts non-empty too
+        // (`LazyList::new_cached(Vec::new())`), so this must run before the
+        // cache short-circuit below for the same reason as `cat_pull` above --
+        // without it, `.gist`/`.Str`/`say`/list-coercion on a fresh
+        // `$x.WALK(...)()` (before anything else has pulled it) read the
+        // still-empty initial cache and silently printed/produced `()`.
+        if list.walk_pending.is_some() {
+            return self.force_walk_pending(list, usize::MAX);
+        }
         if let Some(cached) = list.cache.lock().unwrap().clone() {
             return Ok(cached);
         }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -574,6 +574,44 @@ pub(crate) fn record_methods_shadow_check(matched: bool, detail: impl FnOnce() -
     }
 }
 
+// ADR-0019 Phase E box E7 step 7 (`.WALK`, `todo/deep/adr0019-e5-e7-entry-
+// routing.md` "E7 step 7"): shadow comparison between the CLASS-kind portion
+// of the chain `try_walk_method`'s default (`:canonical`) ordering walks
+// (`Interpreter::class_mro_readonly`, via `build_walk_targets`) and the E4
+// resolver's own canonical chain (`Interpreter::dispatch_owner_chain`) for
+// the same receiver. Scoped to `:canonical`-order-only, unlike E7 step 6's
+// `.^methods` check: WALK's OTHER orderings (`:super`/`:breadth`/`:ascendant`/
+// `:descendant`) are legitimate alternate traversals documented by raku's own
+// WALK spec, not MRO restatements, so comparing them against the resolver's
+// MRO chain would be a guaranteed, meaningless mismatch. A dedicated counter
+// pair for the same "whole MRO CHAIN, not a single dispatch-winner pick"
+// reason as `CAN_SHADOW_*`/`METHODS_SHADOW_*`. Shadow-only, zero behavior
+// change: `class_mro_readonly` alone still drives WALK's own chain.
+static WALK_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static WALK_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn walk_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one E7 step-7 `.WALK` (`:canonical` order only) chain-shadow
+/// comparison. `detail` is only evaluated on a mismatch, mirroring
+/// [`record_methods_shadow_check`].
+#[inline]
+pub(crate) fn record_walk_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    WALK_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        WALK_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = walk_shadow_mismatch_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1079,6 +1117,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e7 methods-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let walk_shadow_checks = WALK_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let walk_shadow_mismatches = WALK_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-e7: walk_shadow_checks={walk_shadow_checks} walk_shadow_mismatches={walk_shadow_mismatches}"
+    );
+    if let Ok(map) = walk_shadow_mismatch_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-e7 walk-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );

--- a/t/walk-lazy.t
+++ b/t/walk-lazy.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 5;
+plan 7;
 
 # `WALK(method)()` invokes the MRO-level candidates LAZILY — one method call per
 # pulled element (Rakudo). `for $obj.WALK("foo")() { ... }` calls exactly one
@@ -36,3 +36,16 @@ my class B is A { method m { 2 } }
 my @r = B.new.WALK("m")();
 is @r.elems, 2, 'WALK result reifies to an array eagerly';
 is-deeply @r, [2, 1], 'eager WALK collects all candidate results';
+
+# ADR-0019 E7 step 7 (`todo/deep/adr0019-e5-e7-entry-routing.md`): a WALK
+# result must also force correctly under `.gist`/`.Str` (say/print), not just
+# `for`-iteration and array coercion above. Those two contexts go through the
+# VM's own opcode-level lazy-list forcing (`force_lazy_list_vm`), which
+# already knew about `walk_pending`; `.gist`/`.Str` route through
+# method-dispatch-triggered forcing (`Interpreter::force_lazy_list`, used by
+# `render_gist_value`), which did not check `walk_pending` at all and read
+# the still-empty initial cache before ever pulling a candidate --
+# `$obj.WALK("m")().gist` printed `()` instead of the candidate results.
+my $g = B.new.WALK("m")();
+is $g.gist, '(2 1)', 'WALK result forces correctly under .gist (say)';
+is $g.Str, '2 1', 'WALK result forces correctly under .Str';

--- a/t/walk-mixin-role.t
+++ b/t/walk-mixin-role.t
@@ -1,0 +1,63 @@
+use Test;
+
+plan 11;
+
+# ADR-0019 Phase E box E7 step 7 (`.WALK`, `todo/deep/
+# adr0019-e5-e7-entry-routing.md` "E7 step 7"): `.WALK` must also accept a
+# runtime mixin (`$obj but Role`) as its receiver, visiting the mixed-in
+# role's OWN methods ahead of the base class chain -- real raku puts a
+# mixin's anonymous pun class FIRST in `.^mro` (`(WSub.new but R1).^mro` is
+# `(WSub+{R1}) WSub WBase Any Mu`), so `R1`'s methods must be found even
+# though they are never composed into any class's method table. Before this
+# fix, WALK did not recognize a Mixin receiver at all and raised
+# X::Method::NotFound.
+
+role R1 { method zork { "R1::zork" } }
+role R2 { method quux { "R2::quux" } }
+class WBase { method foo { "WBase::foo" } }
+class WSub is WBase { method foo { "WSub::foo" } }
+
+# A role mixed onto a plain (non-instance) builtin value.
+my $i = 5 but R1;
+is $i.WALK("zork")().Str, 'R1::zork', 'WALK finds a role mixed onto a builtin Int';
+
+# A role mixed onto a user-class instance: the base class chain is still
+# walkable through the mixin ...
+my $x = WSub.new but R1;
+is $x.WALK("foo")().Str, 'WSub::foo WBase::foo',
+  'WALK still walks the base class chain through a mixin';
+# ... and the mixed-in role's own method is found too, even though it is not
+# composed into WSub's or WBase's method table.
+is $x.WALK("zork")().Str, 'R1::zork', 'WALK finds the mixed-in role method too';
+# A method neither the base chain nor the mixin has is still unmatched.
+is $x.WALK("quux")().elems, 0, 'WALK finds nothing for an absent method name';
+
+# Two roles mixed onto the same value: each contributes its own method
+# independently.
+my $y = (WSub.new but R1) but R2;
+is $y.WALK("zork")().Str, 'R1::zork', 'first mixed-in role of a two-role stack';
+is $y.WALK("quux")().Str, 'R2::quux', 'second mixed-in role of a two-role stack';
+is $y.WALK("foo")().Str, 'WSub::foo WBase::foo',
+  'base class chain is unaffected by a two-role mixin stack';
+
+# A mixin role's own method wins ordinary (non-WALK) qualified/unqualified
+# dispatch too -- WALK's mixin-role candidates must agree with this, not
+# introduce a second answer.
+class WOverride { method foo { "WOverride::foo" } }
+role ROverride { method foo { "ROverride::foo" } }
+my $z = WOverride.new but ROverride;
+is $z.foo, 'ROverride::foo', 'sanity: the mixin itself wins ordinary dispatch';
+is $z.WALK("foo")().Str, 'ROverride::foo WOverride::foo',
+  'WALK visits the winning mixin candidate before the shadowed base one';
+
+# Attribute access through a mixin-wrapped instance's own (base-class) WALK
+# candidate must reach the live instance, not an empty snapshot.
+class WAttr { has $.n = 42; method get { $!n } }
+my $w = WAttr.new but R1;
+is $w.WALK("get")().Str, '42', 'a mixin-wrapped base-class candidate sees the instance attrs';
+
+# A builtin receiver with no user class_def and no mixin still uses the
+# pre-existing builtin-type WALK table (regression guard for the branch this
+# fix narrowed with `mixin_role_names.is_empty()`).
+grammar GBase { token TOP { . } }
+ok GBase.WALK(:name<parse>).elems >= 1, 'a plain (non-mixin) builtin-type WALK receiver is unaffected';

--- a/todo/deep/adr0019-e5-e7-entry-routing.md
+++ b/todo/deep/adr0019-e5-e7-entry-routing.md
@@ -2504,3 +2504,149 @@ not in an MRO-walk primitive. The shadow-check half added alongside it is clean 
 matching steps 1/2's zero-gap result for the chain-construction question specifically. Next E7
 sub-slice: WALK and the EVAL/`subtest` re-entrant carriers, per the design's consumer ordering — the
 last two items in the box's original consumer list.
+
+## E7 step 7: `.WALK` — two real bugs (mixin receivers, lazy-forcing gap) plus a clean chain shadow-check
+
+**Scoping**: the ADR's own framing for this box (`src/runtime/methods_walk.rs`'s module doc: "walks
+the receiver's class hierarchy... looking up *own* candidates of the named method on each level...
+returns a callable") flagged `WalkOrder`/`build_walk_targets` as "meaningfully more complex than any
+single-name lookup the previous E7 steps handled" and warned not to assume a quick fix. Reading the
+whole file first (per the assignment) rather than jumping straight to a shadow check paid off: the
+receiver-resolution match at the top of `try_walk_method`,
+
+```rust
+let receiver_class_name = match target.view() {
+    ValueView::Instance { class_name, .. } => class_name.resolve(),
+    ValueView::Package(name) => name.resolve(),
+    _ => return Ok(None),
+};
+```
+
+has no arm for `ValueView::Mixin` at all — falling to `_ => return Ok(None)`, which the method-call
+dispatch site (`methods_call_dispatch.rs`) turns into `X::Method::NotFound`. Confirmed directly:
+
+```raku
+role R1 { method zork { "R1::zork" } }
+my $x = 5 but R1;
+say $x.WALK("zork")();   # raku: (R1::zork)
+```
+
+`mutsu` raised `No such method 'WALK' for invocant of type 'Int'` on the identical script (before this
+fix) — a full-stop rejection, not a wrong answer, on ANY receiver `but`-mixed with a role: WALK simply
+never worked on a mixin at all. This is the same shape of gap step 6 found for `.^methods()` (a mixin
+receiver silently loses its role's own methods), one E7 step later in the ADR's consumer list, and the
+fix follows the exact same template step 6 established.
+
+**Fix 1 (the mixin receiver gap)**: `try_walk_method` now matches `ValueView::Mixin(_, mixins)` too,
+extracting `mixin_role_names` from the `__mutsu_role__`-prefixed keys (identical extraction to step
+6's `dispatch_classhow_methods` fix) and resolving the base class name via
+`self.mop_receiver_owner(target)` — which internally calls `dispatch_owner_chain`, whose documented
+Mixin-specific skip (`receiver_class.rs`) already strips the role prefix and returns the INNER value's
+own chain, exactly the base name WALK's existing class-chain logic needs (`"Sub"` for `Sub.new but
+R1`, `"Int"` for `5 but R1`). A new `WalkKind::MixinRole` variant is prepended to `walk_targets`
+UNCONDITIONALLY (not gated on `:roles`, which the module doc already scopes to STATICALLY composed
+roles only): a runtime mixin's role is never copied into any class's method table the way a
+`does`-composed role's methods are, so its own (non-private) methods — not just its submethods, unlike
+the existing `WalkKind::Role` arm — are only reachable by looking directly at the role's own method
+table. `lookup_own_walk_method` grew the matching arm: `registry().roles.get(owner)?.methods.get(name)?`,
+first non-private overload. Confirmed against real `raku` that this is also the right ORDER (mixin
+role first, base chain after) via `.^mro`: `(WSub.new but R1).^mro` is `(WSub+{R1}) WSub WBase Any Mu`
+— the anonymous pun class holding the mixed-in role's methods sits first, matching where the new
+`WalkKind::MixinRole` entries are prepended.
+
+**Fix 2 (attribute access through a mixin, found while testing fix 1)**: `walk_list_invoke_direct`
+computed the attribute map to run each matched candidate against with a direct match:
+
+```rust
+let attributes_map = match invocant.view() {
+    ValueView::Instance { attributes, .. } => attributes.to_map(),
+    _ => AttrMap::new(),
+};
+```
+
+For a `Mixin`-wrapped instance this is `_` — an empty map — so any WALK candidate that resolves to the
+*base class's own* method (e.g. `WSub::foo` reached via `WSub.new but R1`) ran against a blank
+attribute snapshot instead of the live instance. Fixed by reusing the general-purpose helper the rest
+of the interpreter already uses for exactly this unwrap
+(`Interpreter::self_instance_attrs`, `vm_var_assign_computed_attr.rs` — its own doc comment already
+documents the Mixin-unwrap case), rather than inventing a second, narrower one. Pinned in
+`t/walk-mixin-role.t` (a `has $.n` attribute read through a `WAttr.new but R1` candidate).
+
+**Fix 3 (lazy-forcing gap, found while writing tests for fix 1 — NOT a mixin bug)**: testing fix 1
+with `say` surfaced a THIRD, unrelated pre-existing bug: `$obj.WALK("m")().gist` (and `.Str`) printed
+`()`/empty even for an already-correct, non-mixin, plain-class WALK result that `for`-iteration and
+`my @r = ...()` (the two contexts `t/walk-lazy.t` already exercised) handled correctly. Root cause,
+found by reading `should_force_lazy_list`'s "gist" entry through to where it forces
+(`methods_call_dispatch.rs`'s "Force LazyList and re-dispatch as Seq" branch calls
+`force_lazy_list_bridge` -> `Interpreter::force_lazy_list`, `runtime/resolution_lazy.rs`):
+`force_lazy_list` has a `cat_pull` branch and a general cache-short-circuit
+(`if let Some(cached) = list.cache.lock().unwrap().clone() { return Ok(cached); }`) but NO
+`walk_pending` branch. A WALK-produced `LazyList` starts with a **non-empty-`Option`** cache
+(`LazyList::new_cached(Vec::new())` — `Some(vec![])`, not `None`), so the cache short-circuit fired
+immediately and returned the still-unpulled empty vec, before `force_walk_pending` (the function that
+actually invokes candidates) ever ran. This is precisely the failure mode the adjacent `cat_pull`
+comment already calls out for its own case ("cache always starts non-empty, so this must run before
+the cache short-circuit below") — `walk_pending` needed the identical positioning and never got it.
+**Why the two other forcing paths never hit this**: `t/walk-lazy.t`'s existing `for
+$obj.WALK("foo")() {...}` and `my @r = $obj.WALK("m")();` both go through the VM's OWN opcode-level
+forcer, `force_lazy_list_vm` (`vm/vm_helpers_lazy.rs`), which already has an explicit
+`walk_pending`-aware branch (`if let Some(ref wp) = list.walk_pending { ... return
+self.force_walk_pending(list, total); }`) — a second, independent forcing implementation that got the
+`walk_pending` case right from the start. `force_lazy_list` (the method-dispatch-triggered one) is a
+different function entirely and simply never learned about `walk_pending`. **Fix**: added the missing
+branch, in the same position as `cat_pull`, delegating to the SAME `force_walk_pending` the VM-side
+forcer already calls (`self.force_walk_pending(list, usize::MAX)` pulls every remaining candidate,
+mirroring `force_cat_pull(list, usize::MAX)` two lines above it) — no new mechanism, just reaching the
+existing one from the second call site that needed it. Pinned as two new assertions appended to
+`t/walk-lazy.t` (`.gist`/`.Str` on an existing, non-mixin, already-passing WALK scenario).
+
+**The shadow-check half of this box** (matching steps 1/2/4/6's "reading the call-path sequence"
+framing — a `MUTSU_VM_STATS`-gated comparison against the E4 resolver, zero behavior change): unlike
+step 6's `.^methods()`, WALK has MULTIPLE orderings (`:canonical`/`:super`/`:breadth`/`:ascendant`/
+`:descendant`), and only `:canonical` is actually an MRO restatement — the others are alternate,
+raku-spec-documented traversals (declared-parents-only, BFS, DFS-preorder, DFS-postorder) that are
+SUPPOSED to disagree with the resolver's canonical MRO chain, so comparing them would only ever
+produce a guaranteed, uninformative mismatch. The check is therefore scoped to `order ==
+WalkOrder::Canonical` only, comparing the `WalkKind::Class`-only names in `walk_targets` (i.e.
+excluding the new `WalkKind::MixinRole`/pre-existing `WalkKind::Role` entries, which have no resolver-
+chain analogue) against `self.dispatch_owner_chain(target)`'s names (`Any`/`Mu`/`Cool` stripped from
+both sides, matching `build_walk_targets`'s own filter). A new dedicated `WALK_SHADOW_*` counter pair
+(`vm_stats.rs`), not the shared `RESOLVER_SHADOW_*` family — same "whole chain, not a single
+dispatch-winner pick" reasoning as `CAN_SHADOW_*`/`METHODS_SHADOW_*`. Swept the existing
+`t/walk-lazy.t` + `t/walk-orderings.t` suite (12 checks) and a hand-built mixin/two-role/multi-ordering
+probe (5 checks): 17 checks total, 0 mismatches — but only after renaming a probe class from `Sub` to
+`WSub`: naming a test class `Sub` (colliding with the builtin `Sub`/`Routine` type) made
+`dispatch_owner_chain` answer the BUILTIN `Sub` type's chain (`Sub Routine Block Code ...`) instead of
+the user class's, a mismatch every time. This is not a new finding — it is the same class of
+owner-name-collision gap the E1a ledger already tracks as `multi_arg_type_keys`
+(`todo/tickets/multi-arg-type-keys-package-collision.md`) — so it was worked around in the probe
+(renamed the class) rather than re-investigated here.
+
+**Verification**: `cargo build`/`cargo clippy -- -D warnings`/`cargo fmt` clean. New
+`t/walk-mixin-role.t` (11 assertions, every one independently checked against real `raku` first): role
+mixed onto a builtin (`5 but R1`), base class chain still walkable through a mixin, the mixed-in role's
+own method found, an absent method name still yields nothing, two roles stacked on the same value each
+answering independently, a mixin overriding a same-named base method (ordinary dispatch sanity-checked
+alongside WALK's own answer for the identical case), attribute access through a mixin-wrapped
+candidate (fix 2's pin), and a plain non-mixin builtin-type receiver (`Grammar`) as a regression guard
+for the branch this fix narrowed with `mixin_role_names.is_empty()`. Two new assertions appended to
+`t/walk-lazy.t` for fix 3. Full local `make test` green. `git grep -n "WALK" src/runtime/ src/vm/
+src/builtins/` (excluding the files this box touched) confirmed WALK has exactly one internal call
+site in mutsu — the `.WALK`/`WalkList` dispatch arms in `methods_call_dispatch.rs` — with no
+TWEAK/BUILDALL construction-phaser use, so the blast radius is exactly what this box touched, nothing
+wider. Since fixes 1-3 change real `.WALK` answers (not just a shadow-only probe), this counts as
+CLAUDE.md's "touched name/type resolution" case: the two whitelisted roast files calling `.WALK(`
+(`roast/S12-introspection/walk.t`, `roast/S14-roles/attributes-6e.t`, found by grepping roast for
+`\.WALK\(`) both green locally under `MUTSU_FUDGE=1`.
+
+**Conclusion**: unlike steps 1/2/4 (clean shadow-checks) but like steps 5/6, this sub-slice found and
+fixed real, confirmed `raku`-vs-`mutsu` behavioral gaps through direct comparison — three of them here,
+not one, all found by following the assignment's own instruction not to assume a quick fix and to
+verify against real `raku` rather than trust the module doc's "Supported options for now" list at face
+value. Two (mixin receivers, mixin attribute access) are genuinely WALK-specific; the third (lazy-
+forcing gap) is a pre-existing bug in a shared forcing primitive that this box's own testing happened
+to surface, not something introduced by fix 1. The shadow-check half is clean (0/17), matching steps
+1/2/6's zero-gap result for the chain-construction question specifically, once scoped to the one
+ordering (`:canonical`) that is actually an MRO restatement. **Next (and last) E7 sub-slice: the EVAL/
+`subtest` re-entrant carriers** — the final item in the box's original consumer list; once that lands,
+E7 as a whole closes and E8 (multi/proto/submethod candidate-sequence ordering) is next.


### PR DESCRIPTION
## Summary
- `.WALK` never recognized a `ValueView::Mixin` receiver at all — `(5 but R1).WALK("zork")` raised `X::Method::NotFound` where real raku returns `(R1::zork)`. `try_walk_method` now visits a mixed-in role's own (non-private) methods via a new `WalkKind::MixinRole`, ahead of the base class chain (matching raku's pun-class-first `.^mro` ordering).
- Fixed two bugs surfaced while investigating: `walk_list_invoke_direct` read a Mixin invocant's attributes via a bare `ValueView::Instance` match (empty for a Mixin, so a base-class WALK candidate ran with a blank attribute snapshot) — now reuses the existing `Interpreter::self_instance_attrs` Mixin-unwrap helper. `Interpreter::force_lazy_list` (the forcer `.gist`/`.Str`/`say` route through) had no `walk_pending` branch, so its cache short-circuit returned the WALK list's still-empty initial cache before ever pulling a candidate — `$obj.WALK(...)().gist` printed `()` even for an already-correct, non-mixin WALK result.
- Added a `MUTSU_VM_STATS`-gated shadow check comparing WALK's default (`:canonical`) class-chain ordering against the E4 resolver's own canonical chain for the same receiver — scoped to `:canonical` only, since WALK's other orderings are legitimate non-MRO traversals per raku's own WALK spec. Clean: 0 mismatches.

Full investigation notes: `todo/deep/adr0019-e5-e7-entry-routing.md` §"E7 step 7". ADR-0019's E7 checklist item updated with a matching progress paragraph. Next E7 sub-slice: the EVAL/`subtest` re-entrant carriers (last item before E7 closes).

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] Full local `make test` green (3063 files / 28613 tests)
- [x] New `t/walk-mixin-role.t` (11 assertions, each independently checked against real `raku` first)
- [x] Two new assertions appended to `t/walk-lazy.t` (gist/Str forcing)
- [x] `roast/S12-introspection/walk.t` and `roast/S14-roles/attributes-6e.t` (the two whitelisted files calling `.WALK(`) green locally with `MUTSU_FUDGE=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)