### PR TITLE
fix(vm): :exists resolves a Scalar-wrapped (itemized hash) subscript target

### DIFF
--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -93,6 +93,17 @@ impl Interpreter {
             }
             let target = self.stack.pop().unwrap_or(Value::NIL);
             Self::throw_if_failure(&target)?;
+            // Resolve slot refs and Scalar containers to the underlying value,
+            // like every subscript READ does (vm_var_index_ops): a chained
+            // `@in[0]{$key}:exists` pops the element as an itemized (`$%(...)`)
+            // hash — a Scalar wrapper — which no target arm below matched, so
+            // the lookup always answered False (Text::CSV's csv(key => ...)
+            // died with error 4001 on data whose key existed).
+            let target = match target.view() {
+                ValueView::HashEntryRef { .. } => target.hash_entry_read(),
+                ValueView::Scalar(inner) => inner.clone(),
+                _ => target,
+            };
             // A nested single-dim slice (`@a[(3, (30, (5,)))]:exists`) preserves
             // its index-tree shape in the result, so it recurses rather than
             // walking a flat pair list. Distinct from a multidim `@a[1;2]` walk.

--- a/t/exists-itemized-hash-element.t
+++ b/t/exists-itemized-hash-element.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# `:exists` on a subscript whose target is an itemized (`$%(...)` / `${...}`)
+# hash — e.g. the chained `@in[0]{$key}:exists` — popped the element as a
+# Scalar-wrapped hash, which no target arm of the exists op matched, so the
+# answer was always False. Every subscript READ resolves the Scalar wrapper;
+# the exists op now does the same. (Text::CSV's csv(key => ...) gates on
+# `@in[0]{$key}:exists` over rows built with `$%( @h Z=> @r )` and died with
+# error 4001 on data whose key existed.)
+
+plan 6;
+
+my @b = ${bar => 1, baz => 2}, ${bar => 3};
+ok @b[0]{"bar"}:exists, 'chained [0]{key}:exists on an itemized hash element';
+ok @b[0]<baz>:exists, 'angle form too';
+nok @b[0]{"nope"}:exists, 'missing key still False';
+
+my $x = @b[1];
+ok $x{"bar"}:exists, ':exists through a scalar variable holding an itemized hash';
+nok $x{"baz"}:exists, 'missing key through the scalar is False';
+
+my $key = "bar";
+my @rows = ["1", "2"], ["3", "4"];
+my @h = <bar baz>;
+my @aoh = @rows.map(-> @r { $%( @h Z=> @r ) });
+ok @aoh[0]{$key}:exists, 'the Text::CSV shape: mapped $%(Z=>) rows answer :exists';
+
+done-testing;


### PR DESCRIPTION
Fifth fix from the Text::CSV `90_csv.t` sweep (follows #6307).

A chained subscript with the exists adverb (`@in[0]{$key}:exists`) pops its target off the stack as the element value — for rows built with `$%( @h Z=> @r )` that is an **itemized hash**, i.e. a Scalar wrapper, which no target arm of `exec_exists_index_adv_op` matched, so the answer was always False:

```raku
my @b = ${bar => 1},;
say @b[0]{"bar"}:exists;   # raku: True / mutsu before: False
```

Every subscript READ resolves `HashEntryRef`/`Scalar` first (`vm_var_index_ops`); the exists op now does the same.

Text::CSV impact: `method CSV`'s key handling gates on `@in[0]{$key}:exists or self!fail (4001)`, so `csv(key => ...)` died with "PRM - The key does not exist as field in the data" on data whose key existed. 90_csv.t now reaches 477 subtests (was 448); remaining: 159 (`fragment col=`), 474/476 + an abort, all rooted in a separate slow-path multi-dispatch env writeback bug (`self.rowrange(...)` clobbers the `$in` param — forensics recorded for the next slice).

Pin: `t/exists-itemized-hash-element.t` (rakudo-verified). Local `make test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)