### PR TITLE
feat(adr0019): E8a — candidate sequence gains level/stored_idx + deferral-list shadow check

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3679,6 +3679,71 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   submethod visibility and `drop_flattened_role_duplicates` apply at build time.
   `Registry::proto_methods` folds into `MethodEntry`. Unifying the method-vs-sub ranking
   ladders is explicitly out of scope.
+  **Progress 2026-08-12** (E8a, sequence structural fields + shadow comparison): landed the
+  slice plan's E8a exactly as scoped. `ResolvedCandidate::User` gained `level: u16`/
+  `stored_idx: u16` (its position in the chain / within that level's stored declaration order —
+  `resolution_sequence.rs`), set from `resolve_sequence`'s existing per-level, per-overload
+  loop, so the sequence's own construction order already IS `(level, stored_idx)`-ascending
+  with no extra sort needed. `drop_flattened_role_duplicate_candidates` (the build-time twin of
+  `resolution_method.rs`'s post-match `drop_flattened_role_duplicates`) now runs inside
+  `resolve_sequence` itself, before any per-call filtering — behavior-preserving, since the
+  dedup removes candidates purely by owner identity and the flattened copy it keeps has the
+  same signature as the raw one it drops. The "ranker extracted to consume a candidate slice"
+  part of the slice plan became `Interpreter::match_sequence_candidates`, pulling the
+  signature-match loop out of `shadow_check_resolver_chain` (E4a's winner probe) so a second
+  probe could reuse it verbatim instead of copying the loop. That second probe,
+  `Interpreter::shadow_check_deferral_sequence`, hooks the single real call site that builds
+  the `nextsame`/`callsame` deferral list — `Interpreter::push_method_dispatch_frame`
+  (`accessors_state.rs`) — and compares the sequence's own `(level, stored_idx)`-ordered,
+  per-call-filtered, winner-fingerprint-removed candidate list against the real "remaining"
+  list `resolve_all_methods_with_owner` + fingerprint dedup already computes there, under a new
+  `DEFERRAL_SHADOW_CHECKS`/`_MISMATCHES` counter pair (list equality by fingerprint, exactly as
+  the slice plan specifies) — a dedicated pair, not the shared `RESOLVER_SHADOW_*` infra, same
+  reasoning as E7 steps 4/6/7's own dedicated pairs (comparing an ordered LIST, not a single
+  winner pick). The winner side of "shadow-compare winner AND deferral list" needed no new
+  code: per design decision 1 the winner ranking ladder is unchanged by `level`/`stored_idx`
+  (deferral-order-only facts), so E4a's existing `shadow_check_resolver`/`_chain` at the
+  `resolve_method_cached` boundaries already covers it, now exercising the enriched candidate
+  shape for free. Two real findings surfaced building this, both fixed or bucketed honestly
+  rather than force-fit to zero:
+  1. **A real bug in the new probe itself, fixed**: the first version passed the call's
+     invocant to the per-candidate signature match, but the REAL target
+     (`resolve_all_methods_with_owner`) always calls `method_args_match_for_invocant` with
+     `invocant: None` — the deferral list is invocant-BLIND (it never checks `:U:`/`:D:`
+     smileys), matching raku's own `nextsame`/`callsame` walk. An invocant-aware shadow probe
+     is stricter than its own target, not a shadow of it; every `::?ROLE:U:`/`::?ROLE:D:` multi
+     pair in the sweep (`t/role-ud-multi-dispatch.t`, `t/multi-method-invocant-definedness.t`,
+     `t/qualified-mu-coercion.t`) mismatched until the probe's `match_sequence_candidates` call
+     switched to `invocant: None` to match.
+  2. **A pre-existing, accepted divergence, documented not fixed**: `resolve_sequence`'s
+     per-level lookup (`Registry::user_method_overloads`) silently returns nothing for a role
+     owner that has never been *punned* — `Registry::method_entries` (the E1/E2 canonical
+     table) is only ever populated from `self.classes`, and a role is not a key there unless a
+     `RoleName.new` pun briefly registered (and later withdrew) a synthetic `ClassDef` for it.
+     `resolve_all_methods_with_owner` has no such gap (it reads `self.registry().roles`
+     directly), so it still finds a role's own un-flattened method the deferral probe misses.
+     Root-caused and written up in full, including why this is not fixed inside E8a (it also
+     feeds several REAL production dispatch paths — winner selection included — so populating
+     it is a real-behavior change outside a shadow-only box's scope) and a suggested fix, in
+     `todo/deep/method-entries-never-covers-unpunned-roles.md`.
+  A `MUTSU_VM_STATS=1` sweep of the full local `t/` suite (3070 files) found 160 deferral-shadow
+  checks across 46 files, 58 mismatches — every single one the shape `real_len` exactly one
+  candidate ahead of `shadow_len`, confirmed by hand on every mismatching file
+  (`t/anon-class-does-imported-role.t`, `t/builtin-distribution-role.t`,
+  `t/callsame-punned-role-and-hyper-infix-sub.t`, `t/multi-udismiley-ambiguity-leak.t`,
+  `t/qualified-method-call.t`, `t/role-conflict.t`, `t/role-required-method-name-based.t`,
+  `t/role-required-universal-method.t`, `t/supply-nested-whenever-emitter.t`,
+  `t/yaml-battery.t`) to be finding 2's gap, not a new bug. A roast slice touching multi/role/
+  submethod/wrap dispatch (`S06-advanced/{callsame,dispatching,wrap}`, `S06-multi/{redispatch,
+  type-based,syntax}`, `S12-methods/{defer-call,defer-next,lastcall,multi,parallel-dispatch}`,
+  `S12-class/{mro-6c,inheritance,basic}`, `S14-roles/mixin-6c`, 16 files) found 37 checks, 0
+  mismatches. Two new unit tests (`resolve_sequence_assigns_level_and_stored_idx`,
+  `resolve_sequence_drops_a_flattened_role_duplicate_at_build_time`). `cargo build`/`cargo
+  clippy -- -D warnings`/`cargo fmt --check` clean; `cargo test --lib` (812 tests) and full
+  local `make test` (3070 files / 28652 tests) green. Zero real-behavior change: `resolve_
+  all_methods_with_owner`, `push_method_dispatch_frame`'s own logic, and every real dispatch
+  decision are untouched by this slice. **Next E8 sub-slice: E8b — proto methods into
+  `MethodEntry`**, per the slice plan.
 - [ ] **E9 — Add resolver cursors for `samewith`/`nextsame`/`callsame`/`nextwith`.** Continue within
   the resolved sequence instead of re-entering name-based resolution.
   **Design 2026-08-10** (same doc): one `DispatchCursor {seq, next, invocant, args}` replaces

--- a/news/2026-08/adr0019-e8a-sequence-level-stored-idx.md
+++ b/news/2026-08/adr0019-e8a-sequence-level-stored-idx.md
@@ -1,0 +1,56 @@
+# ADR-0019 E8a: the candidate sequence gains structural ordering fields
+
+Phase E's dispatch resolver (ADR-0019) starts box E8 — modeling multi/proto/submethod
+ordering in the shape-independent candidate sequence introduced by E4a. E8a's slice: give
+`ResolvedCandidate::User` (`src/runtime/resolution_sequence.rs`) two new fields, `level: u16`
+(the candidate's position in the MRO chain it was built from, 0 = the receiver's own class) and
+`stored_idx: u16` (its position within that level's stored declaration order), set from
+`resolve_sequence`'s existing per-level, per-overload loop. No extra sort is needed: the
+sequence's own construction order already is `(level, stored_idx)`-ascending — these fields
+exist as the queryable structural facts a later box (E9's dispatch cursor) will need.
+
+A composed role's own raw MRO-level candidate is now dropped at sequence *build* time via a new
+`drop_flattened_role_duplicate_candidates` helper, mirroring the existing post-match
+`drop_flattened_role_duplicates` in `resolution_method.rs` but applied earlier — a
+behavior-preserving move, since the dedup only removes by owner identity and the flattened copy
+that survives has the same signature as the raw one it replaces.
+
+The signature-match filtering loop shared by E4a's winner probe and this box's own deferral
+probe was extracted into `Interpreter::match_sequence_candidates`, a pure code-motion refactor
+so both probes consume the same candidate-slice filter instead of each carrying a copy.
+
+The new `Interpreter::shadow_check_deferral_sequence`, gated behind `MUTSU_VM_STATS` like every
+prior Phase E probe, hooks `Interpreter::push_method_dispatch_frame` — the single real call site
+that builds the `nextsame`/`callsame` "remaining" deferral list today via
+`resolve_all_methods_with_owner` plus fingerprint-based winner removal. It builds the same list
+from the sequence's own `(level, stored_idx)` order, filtered per-call and with the winner's
+fingerprint removed the same way the real code does it, and compares the two fingerprint lists
+under a new `DEFERRAL_SHADOW_CHECKS`/`_MISMATCHES` counter pair. The winner-selection half of
+"shadow-compare winner and deferral list" needed no new code: E4a's existing winner probe
+already covers it, since the new fields do not change ranking at all.
+
+Building this surfaced two findings. First, a real bug in the new probe itself: an early version
+passed the call's invocant into the signature match, but the real target
+(`resolve_all_methods_with_owner`) always matches invocant-BLIND (it never checks `:U:`/`:D:`
+smiley constraints on the deferral list, mirroring raku's own `nextsame`/`callsame` semantics) —
+an invocant-aware probe was stricter than its own target and mismatched on every
+`::?ROLE:U:`/`::?ROLE:D:` multi pair in the sweep. Fixed by matching invocant-blind, the same
+way the real code does.
+
+Second, a pre-existing, accepted divergence: `resolve_sequence`'s per-level lookup silently
+misses a role's own methods unless the role has been *punned* at some point — the E1/E2
+canonical `method_entries` table is only ever populated from `self.classes`, never directly from
+`self.roles`. The real deferral walker has no such gap (it reads the role table directly), so
+every remaining shadow mismatch (58 of 160 checks across 46 `t/` files, one root cause confirmed
+by hand on all ten mismatching files) traced to this single, already-latent gap. Left
+undisturbed rather than fixed inline — the same table also feeds several REAL production
+dispatch paths including winner selection, so extending its role coverage is a genuine
+behavior change outside this shadow-only box's scope — and written up in full, with a suggested
+fix and verification plan, in `todo/deep/method-entries-never-covers-unpunned-roles.md`.
+
+A `MUTSU_VM_STATS=1` sweep of the local `t/` suite (3070 files) plus a roast slice touching
+multi/role/submethod/wrap dispatch (16 files, `S06-advanced`/`S06-multi`/`S12-methods`/
+`S12-class`/`S14-roles`) found 37 roast checks with 0 mismatches, and 160 `t/` checks with 58
+mismatches, all attributed to the documented role-coverage gap above. Two new unit tests pin
+the level/stored_idx computation and the build-time role-dedup. `make test` (3070 files / 28652
+tests) is green; nothing in real dispatch changed.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -823,6 +823,16 @@ impl Interpreter {
             }
             remaining.push((owner.resolve(), def));
         }
+        // ADR-0019 E8a shadow probe (zero behavior change): see
+        // `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`.
+        self.shadow_check_deferral_sequence(
+            receiver_class,
+            method_name,
+            args,
+            &invocant,
+            chosen_fp,
+            &remaining,
+        );
         let pushed = !remaining.is_empty() || native_base_override;
         if pushed {
             let rw_params = chosen

--- a/src/runtime/resolution_sequence.rs
+++ b/src/runtime/resolution_sequence.rs
@@ -33,6 +33,26 @@
 //! literal). Expected on the sweep and bucketed (like E1a's ledger) rather than
 //! blocking the box; unifying it is E8's job (candidates carry `level`/`stored_idx`
 //! so this exact rule becomes representable in the sequence itself).
+//!
+//! **E8a's own accepted divergence, found by the new deferral-list shadow check**
+//! ([`Interpreter::shadow_check_deferral_sequence`]): [`Self::resolve_sequence`]'s
+//! per-level lookup, `Registry::user_method_overloads`, silently returns nothing
+//! for a **role** owner that has never been *punned* (used as a standalone type
+//! via `RoleName.new`) — `Registry::method_entries` (the E1/E2 canonical table
+//! `user_method_overloads` reads) is only ever populated for `self.classes`
+//! keys, and a role is not one unless a pun briefly registered (and then
+//! withdrew) a synthetic `ClassDef` for it. `resolve_all_methods_with_owner`
+//! (the real deferral-list walker `push_method_dispatch_frame` still uses) does
+//! not have this gap — it reads `self.registry().roles` directly, bypassing
+//! `method_entries` — so every mismatch this shadow check found (2026-08-12
+//! sweep) had the same shape: the sequence is missing exactly the role-owned
+//! candidate the real walker still finds (a role's un-flattened method the
+//! composing class overrides with its own, or a role-qualified call
+//! `self.R::name()`). Full root-cause and fix plan in
+//! `todo/deep/method-entries-never-covers-unpunned-roles.md` — not fixed here
+//! because `method_entries` also feeds several REAL dispatch paths (winner
+//! selection included), so populating it for roles is a real-behavior-change
+//! outside this shadow-only box's scope.
 
 use super::*;
 use crate::builtins::native_method_row::{NativeArityMask, native_row_servable};
@@ -91,8 +111,35 @@ pub(crate) enum MethodVisibility {
 #[derive(Clone)]
 pub(crate) enum ResolvedCandidate {
     /// A user-declared method, at its MRO level, in the class's stored
-    /// declaration order.
-    User { owner: TypeId, def: Arc<MethodDef> },
+    /// declaration order. `level`/`stored_idx` are ADR-0019 E8a's structural
+    /// additions (design decision 1 in
+    /// `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`): `level` is
+    /// this candidate's position in the `chain` it was built from (0 =
+    /// receiver's own class), `stored_idx` its position within that level's
+    /// `user_method_overloads` (declaration order). Together they reproduce
+    /// today's observable deferral order (MRO level, then stored index,
+    /// filtered per-call by signature match) without re-deriving it from a
+    /// second walk — see [`Interpreter::shadow_check_deferral_sequence`].
+    User {
+        owner: TypeId,
+        def: Arc<MethodDef>,
+        // Not read by any production code path yet: E8a's own shadow probe
+        // ([`Interpreter::shadow_check_deferral_sequence`]) relies on the
+        // candidate Vec's own construction (insertion) order already being
+        // `(level, stored_idx)`-ascending rather than re-deriving it from
+        // these fields, and no real dispatch path consumes a sequence at
+        // all yet (E9 is the box that builds a `DispatchCursor` over one).
+        // Kept as struct fields now (not deferred to E9) because they are
+        // structural facts of *this* box's own model — see the `User`
+        // variant doc above — exercised directly by unit tests
+        // (`#[cfg(test)]`, which `cargo build`/`clippy`'s dead-code pass
+        // does not see). Mirrors [`ResolvedSequence::generation`]'s same
+        // "measurement/future aid, not consulted yet" `#[allow(dead_code)]`.
+        #[allow(dead_code)]
+        level: u16,
+        #[allow(dead_code)]
+        stored_idx: u16,
+    },
     /// A `ClassDef::native_methods` binding — an `is native(&sym)` NativeCall
     /// trait, or one of the handful of built-in classes whose getters are
     /// implemented by dedicated `native_io_*` dispatch helpers
@@ -163,7 +210,7 @@ impl Interpreter {
                 .registry()
                 .user_method_overloads(owner_str, name.as_str())
             {
-                for def in overloads {
+                for (stored_idx, def) in overloads.into_iter().enumerate() {
                     let visible = match visibility {
                         MethodVisibility::Public => !(def.is_private || (def.is_my && is_ancestor)),
                         MethodVisibility::Private => def.is_private,
@@ -174,6 +221,8 @@ impl Interpreter {
                     candidates.push(ResolvedCandidate::User {
                         owner: *owner,
                         def: Arc::new(def),
+                        level: level as u16,
+                        stored_idx: stored_idx as u16,
                     });
                 }
             }
@@ -217,10 +266,83 @@ impl Interpreter {
                 native_row_found = true;
             }
         }
+        Self::drop_flattened_role_duplicate_candidates(&mut candidates);
         ResolvedSequence {
             generation,
             candidates,
         }
+    }
+
+    /// ADR-0019 E8a: the sequence-builder twin of
+    /// `resolve_all_methods_with_owner`'s post-match
+    /// `drop_flattened_role_duplicates` (`resolution_method.rs`), applied here
+    /// at sequence *build* time instead — before any per-call argument
+    /// matching, per design decision 1 ("submethod visibility and
+    /// `drop_flattened_role_duplicates` are applied at sequence build time").
+    /// Moving the dedup earlier is behavior-preserving: it removes candidates
+    /// purely by owner identity (a role's own raw copy once a class level
+    /// already carries the role-flattened copy), which does not interact with
+    /// per-call argument matching -- the flattened copy has the same
+    /// signature as the raw one it replaces, so filtering by owner before or
+    /// after a `method_args_match_for_invocant` pass yields the same final
+    /// matched set. See `resolution_method.rs`'s `drop_flattened_role_duplicates`
+    /// doc comment for why the duplicate exists at all (mutsu keeps a composed
+    /// role in the class's MRO; rakudo does not).
+    fn drop_flattened_role_duplicate_candidates(candidates: &mut Vec<ResolvedCandidate>) {
+        let flattened: HashSet<String> = candidates
+            .iter()
+            .filter_map(|c| match c {
+                ResolvedCandidate::User { def, .. } => def.role_origin.clone(),
+                ResolvedCandidate::NativeCallBinding { .. } | ResolvedCandidate::Native { .. } => {
+                    None
+                }
+            })
+            .collect();
+        if flattened.is_empty() {
+            return;
+        }
+        candidates.retain(|c| match c {
+            ResolvedCandidate::User { owner, .. } => !flattened.contains(owner.as_str()),
+            ResolvedCandidate::NativeCallBinding { .. } | ResolvedCandidate::Native { .. } => true,
+        });
+    }
+
+    /// ADR-0019 E8a: "ranker extracted to consume a candidate slice" — the
+    /// per-call signature-match filtering step both
+    /// [`Self::shadow_check_resolver_chain`] (E4a's winner probe) and
+    /// [`Self::shadow_check_deferral_sequence`] (this box's deferral-list
+    /// probe) need before ranking or fingerprinting a sequence's `User`
+    /// candidates. Extracted so the two probes share one filtering pass
+    /// instead of each carrying its own copy of the loop. Skips every
+    /// non-`User` candidate (`Native`/`NativeCallBinding` never enter the
+    /// method ranking ladder). Returns matches in the sequence's own order
+    /// (`(level, stored_idx)` construction order), unchanged by this
+    /// extraction — ranking itself stays [`Self::pick_method_winner`],
+    /// called separately by the winner probe; this only produces its input.
+    pub(crate) fn match_sequence_candidates(
+        &mut self,
+        class_name: &str,
+        candidates: &[ResolvedCandidate],
+        arg_values: &[Value],
+        invocant: Option<&Value>,
+        role_bindings: Option<&rustc_hash::FxHashMap<String, Value>>,
+    ) -> Vec<(Symbol, MethodDef)> {
+        let mut matched: Vec<(Symbol, MethodDef)> = Vec::new();
+        for c in candidates {
+            let ResolvedCandidate::User { owner, def, .. } = c else {
+                continue;
+            };
+            if self.method_args_match_for_invocant(
+                class_name,
+                def,
+                arg_values,
+                role_bindings,
+                invocant,
+            ) {
+                matched.push((owner.symbol(), (**def).clone()));
+            }
+        }
+        matched
     }
 
     /// ADR-0019 E4a shadow probe (`MUTSU_VM_STATS`-gated, a no-op otherwise):
@@ -330,21 +452,13 @@ impl Interpreter {
         }
         let role_bindings = self.registry().get_role_param_bindings(class_name);
         let mro: Vec<Symbol> = chain.iter().map(|t| t.symbol()).collect();
-        let mut matched: Vec<(Symbol, MethodDef)> = Vec::new();
-        for c in &seq.candidates {
-            let ResolvedCandidate::User { owner, def } = c else {
-                continue;
-            };
-            if self.method_args_match_for_invocant(
-                class_name,
-                def,
-                arg_values,
-                role_bindings.as_ref(),
-                invocant,
-            ) {
-                matched.push((owner.symbol(), (**def).clone()));
-            }
-        }
+        let matched = self.match_sequence_candidates(
+            class_name,
+            &seq.candidates,
+            arg_values,
+            invocant,
+            role_bindings.as_ref(),
+        );
         let shadow = self.pick_method_winner(&mro, arg_values, invocant, matched);
         self.dispatch_ambiguous = saved_ambiguous;
         let matched_ok = match (real, shadow.as_ref()) {
@@ -392,6 +506,120 @@ impl Interpreter {
         crate::vm::vm_stats::record_native_row_shadow_check(real_served == shadow_served, || {
             format!(
                 "method={method} arity={arg_count} real={real_served} shadow={shadow_served} native_row_owner={native_row_owner:?}"
+            )
+        });
+    }
+
+    /// ADR-0019 E8a shadow probe (`MUTSU_VM_STATS`-gated, a no-op otherwise):
+    /// does the sequence's own `(level, stored_idx)` construction order,
+    /// filtered per-call by [`Self::method_args_match_for_invocant`] and with
+    /// the chosen winner's fingerprint removed, reproduce the "remaining"
+    /// deferral list [`Interpreter::push_method_dispatch_frame`] builds today
+    /// via a second, unranked `resolve_all_methods_with_owner` walk plus
+    /// fingerprint-based winner removal? Per design decision 1 in
+    /// `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`, that
+    /// walk's own output IS the target this box's `level`/`stored_idx`
+    /// fields are meant to reproduce — deferral order = sequence order (MRO
+    /// level, then stored index) filtered by per-call signature match.
+    /// Comparison is **order-sensitive** (a `Vec<u64>` equality, not a set):
+    /// deferral order is user-observable through repeated `nextsame`/
+    /// `callsame`.
+    ///
+    /// `chosen_fp` is the caller's already-computed fingerprint of the
+    /// dispatch winner (`None` when no candidate was chosen at all); passing
+    /// it in avoids re-deriving the winner here, which this probe does not
+    /// need to do — [`Self::shadow_check_resolver`] already shadow-checks
+    /// winner selection independently at the `resolve_method_cached`
+    /// boundaries, and per design decision 1 the winner ranking itself is
+    /// unchanged by `level`/`stored_idx` (they are deferral-order-only
+    /// facts), so there is no new winner-selection logic here to verify.
+    ///
+    /// Same `where`-clause care point as
+    /// [`Self::shadow_check_resolver_chain`]: a `where` clause is user code
+    /// whose dynamic-variable writes are an observable side effect of the
+    /// REAL match already performed by `push_method_dispatch_frame`'s own
+    /// `resolve_all_methods_with_owner` call — running
+    /// `method_args_match_for_invocant` a second time here for a
+    /// `where`-carrying candidate would duplicate that side effect, so any
+    /// candidate with a `where` clause anywhere in the sequence skips the
+    /// whole probe.
+    ///
+    /// **Invocant-blind matching, deliberately**: `resolve_all_methods_with_owner`
+    /// itself always calls `method_args_match_for_invocant(..., invocant:
+    /// None)` (`resolution_method.rs`) — the deferral list is NOT filtered by
+    /// the invocant's type/definedness (`:U:`/`:D:` smileys), only by the
+    /// call's non-invocant argument shape. A first version of this probe
+    /// passed `Some(invocant)` here, which is *stricter* than the real
+    /// target and produced spurious mismatches on every `::?ROLE:U:`/
+    /// `::?ROLE:D:` multi pair (`t/role-ud-multi-dispatch.t` et al.): the
+    /// real "remaining" list still contains the sibling smiley candidate
+    /// (raku's own `nextsame`/`callsame` walk does not re-check the
+    /// invocant), so the shadow list must be built the same invocant-blind
+    /// way to actually be a shadow of this target, not an improvement on it.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn shadow_check_deferral_sequence(
+        &mut self,
+        receiver_class: &str,
+        method: &str,
+        arg_values: &[Value],
+        invocant: &Value,
+        chosen_fp: Option<u64>,
+        real_remaining: &[(String, MethodDef)],
+    ) {
+        if !crate::vm::vm_stats::enabled() {
+            return;
+        }
+        let method_sym = Symbol::intern(method);
+        let mro = self.class_mro(receiver_class);
+        let chain: Vec<TypeId> = mro.iter().map(|s| TypeId::from_symbol(*s)).collect();
+        let native_shape = NativeCallShape::new(arg_values.len(), value_is_definite(invocant));
+        let seq = self.resolve_sequence(&chain, method_sym, native_shape, MethodVisibility::Public);
+        let has_where_candidate = seq.candidates.iter().any(|c| {
+            let ResolvedCandidate::User { def, .. } = c else {
+                return false;
+            };
+            def.param_defs.iter().any(|p| p.where_constraint.is_some())
+        });
+        if has_where_candidate {
+            return;
+        }
+        let role_bindings = self.registry().get_role_param_bindings(receiver_class);
+        let matched = self.match_sequence_candidates(
+            receiver_class,
+            &seq.candidates,
+            arg_values,
+            None,
+            role_bindings.as_ref(),
+        );
+        // Mirrors `push_method_dispatch_frame`'s own loop shape exactly (fp
+        // compare against `chosen_fp` first, THEN the hidden-defer-parent
+        // filter `should_skip_defer_method_candidate`) so a candidate that
+        // happens to be both the winner AND nominally hidden is still
+        // dropped for the winner reason, not double-counted as a hidden-
+        // parent divergence.
+        let mut shadow_fps: Vec<u64> = Vec::new();
+        let mut skipped_chosen = false;
+        for (owner, def) in &matched {
+            let fp = self.method_def_fingerprint(def);
+            if !skipped_chosen && Some(fp) == chosen_fp {
+                skipped_chosen = true;
+                continue;
+            }
+            if self.should_skip_defer_method_candidate(receiver_class, owner.as_str()) {
+                continue;
+            }
+            shadow_fps.push(fp);
+        }
+        let real_fps: Vec<u64> = real_remaining
+            .iter()
+            .map(|(_, def)| self.method_def_fingerprint(def))
+            .collect();
+        let matched = shadow_fps == real_fps;
+        crate::vm::vm_stats::record_deferral_shadow_check(matched, || {
+            format!(
+                "class={receiver_class} method={method} real_len={} shadow_len={}",
+                real_fps.len(),
+                shadow_fps.len()
             )
         });
     }
@@ -622,6 +850,88 @@ mod tests {
         assert!(
             seq.candidates.is_empty(),
             "hardcoded native-method names must not apply to an ancestor level"
+        );
+    }
+
+    /// ADR-0019 E8a: `level` is the candidate's position in the chain (0 =
+    /// receiver's own class); `stored_idx` is its position within that
+    /// level's own declaration order. Two `multi method` overloads on the
+    /// receiver's class come before the single ancestor override.
+    #[test]
+    fn resolve_sequence_assigns_level_and_stored_idx() {
+        let mut i = interp();
+        i.run(
+            "class Base { method greet { 'base' } }\n\
+             class Child is Base {\n\
+               multi method greet(Int $x) { 'child-int' }\n\
+               multi method greet(Str $x) { 'child-str' }\n\
+             }",
+        )
+        .unwrap();
+        let chain = vec![TypeId::intern("Child"), TypeId::intern("Base")];
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("greet"),
+            default_shape(),
+            MethodVisibility::Public,
+        );
+        let facts: Vec<(&str, u16, u16)> =
+            seq.candidates
+                .iter()
+                .filter_map(|c| match c {
+                    ResolvedCandidate::User {
+                        owner,
+                        level,
+                        stored_idx,
+                        ..
+                    } => Some((owner.as_str(), *level, *stored_idx)),
+                    ResolvedCandidate::NativeCallBinding { .. }
+                    | ResolvedCandidate::Native { .. } => None,
+                })
+                .collect();
+        assert_eq!(
+            facts,
+            vec![("Child", 0, 0), ("Child", 0, 1), ("Base", 1, 0)],
+            "expected declaration-order stored_idx within Child's level 0, then Base at level 1"
+        );
+    }
+
+    /// ADR-0019 E8a: `drop_flattened_role_duplicate_candidates` (applied
+    /// inside `resolve_sequence` at build time) removes a composed role's own
+    /// raw MRO entry once a class level already carries the flattened copy —
+    /// the sequence-builder twin of `resolution_method.rs`'s
+    /// `drop_flattened_role_duplicates`, moved to build time per design
+    /// decision 1.
+    #[test]
+    fn resolve_sequence_drops_a_flattened_role_duplicate_at_build_time() {
+        let mut i = interp();
+        i.run("role R { method greet { 'r' } }\nclass C does R { }")
+            .unwrap();
+        let mro = i.class_mro("C");
+        let chain: Vec<TypeId> = mro.iter().map(|s| TypeId::from_symbol(*s)).collect();
+        assert!(
+            chain.iter().any(|t| t.as_str() == "R"),
+            "a composed role stays in mutsu's own MRO (see the module-level doc on the dedup)"
+        );
+        let seq = i.resolve_sequence(
+            &chain,
+            Symbol::intern("greet"),
+            default_shape(),
+            MethodVisibility::Public,
+        );
+        let owners: Vec<&str> =
+            seq.candidates
+                .iter()
+                .filter_map(|c| match c {
+                    ResolvedCandidate::User { owner, .. } => Some(owner.as_str()),
+                    ResolvedCandidate::NativeCallBinding { .. }
+                    | ResolvedCandidate::Native { .. } => None,
+                })
+                .collect();
+        assert_eq!(
+            owners,
+            vec!["C"],
+            "only the class-level flattened copy should remain; the role's own raw copy is dropped"
         );
     }
 

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -612,6 +612,42 @@ pub(crate) fn record_walk_shadow_check(matched: bool, detail: impl FnOnce() -> S
     }
 }
 
+// ADR-0019 Phase E box E8a (`todo/deep/adr0019-e8-e11-candidate-sequence-
+// semantics.md`, design decision 1): shadow comparison between the
+// `resolve_sequence` candidate's new `level`/`stored_idx` fields -- filtered
+// per-call and with the winner's fingerprint removed -- and the
+// `nextsame`/`callsame` deferral list `push_method_dispatch_frame` builds
+// today via `resolve_all_methods_with_owner` + fingerprint-based winner
+// removal (`Interpreter::shadow_check_deferral_sequence`). A dedicated
+// counter pair, not the shared `RESOLVER_SHADOW_*` infra: this compares an
+// ORDERED LIST of remaining candidates, not a single dispatch-winner pick,
+// the same reasoning that kept E7 steps 4/6/7's chain/existence checks on
+// their own pairs. Nothing reads these counters to make a dispatch
+// decision: shadow-only, zero behavior change.
+static DEFERRAL_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static DEFERRAL_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn deferral_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one E8a deferral-list shadow comparison. `detail` is only
+/// evaluated on a mismatch, mirroring [`record_walk_shadow_check`].
+#[inline]
+pub(crate) fn record_deferral_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    DEFERRAL_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        DEFERRAL_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = deferral_shadow_mismatch_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1138,6 +1174,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e7 walk-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let deferral_shadow_checks = DEFERRAL_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let deferral_shadow_mismatches = DEFERRAL_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-e8a: deferral_shadow_checks={deferral_shadow_checks} deferral_shadow_mismatches={deferral_shadow_mismatches}"
+    );
+    if let Ok(map) = deferral_shadow_mismatch_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-e8a deferral-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );

--- a/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
+++ b/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
@@ -208,3 +208,128 @@ Hence the mandatory pre-campaign and per-slice `make roast`. E10's registry move
 thread-fork COW path (`runtime_thread.rs`) — wraps created in a child must not leak to the
 parent (today's interpreter-owned maps get that isolation for free; the registry COW gives the
 same, but add a test). E11 is mechanical once E5-E7 land; do not start it earlier.
+
+## E8a: sequence structural fields land; deferral-list shadow check finds one real bug (fixed) and one pre-existing gap (documented, not fixed)
+
+Landed 2026-08-12, exactly as scoped by the slice plan above. Full detail also in the ADR's E8
+progress note (`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`); this
+section is the design doc's own record of the same slice.
+
+**Structural fields.** `ResolvedCandidate::User` (`resolution_sequence.rs`) gained `level: u16`
+(position in the chain, 0 = receiver's own class) and `stored_idx: u16` (position within that
+level's `user_method_overloads`, i.e. declaration order), set in `resolve_sequence`'s existing
+per-level loop via `overloads.into_iter().enumerate()`. No separate sort was needed: the
+sequence's own `Vec<ResolvedCandidate>` construction order (outer loop over MRO levels, inner
+loop over each level's stored overloads) already IS `(level, stored_idx)`-ascending by
+construction — the fields exist as the queryable structural facts a future consumer (E9's
+cursor) needs, not because today's code needs to re-derive the order from them.
+
+**Build-time dedup.** `drop_flattened_role_duplicate_candidates`, a new private helper called at
+the end of `resolve_sequence` (before the `ResolvedSequence` is returned), mirrors
+`resolution_method.rs`'s `drop_flattened_role_duplicates` — dropping a composed role's own raw
+MRO-level candidate once a class level already carries the role-flattened copy — but runs it
+at sequence *build* time instead of the original's post-match-filter time. This is
+behavior-preserving: the dedup removes by owner identity only, and the flattened copy that
+survives has the same signature as the raw copy it replaces, so filtering before or after a
+`method_args_match_for_invocant` pass yields the same final matched set either way.
+
+**Ranker extraction.** `Interpreter::match_sequence_candidates` pulls the "filter a sequence's
+`User` candidates by per-call signature match, producing `Vec<(Symbol, MethodDef)>`" loop out of
+`shadow_check_resolver_chain` (E4a's own winner probe), so [`Interpreter::shadow_check_deferral_sequence`]
+below can reuse it instead of carrying a second copy of the same loop. Ranking itself is
+untouched — [`Interpreter::pick_method_winner`] is still the only ranker, called separately, and
+by design decision 1 `level`/`stored_idx` do not feed it (they are deferral-order-only facts).
+
+**The deferral-list shadow check.** `Interpreter::shadow_check_deferral_sequence`
+(`resolution_sequence.rs`), gated behind `MUTSU_VM_STATS` like every prior Phase E probe, hooks
+`Interpreter::push_method_dispatch_frame` (`accessors_state.rs`) — the single real call site
+that builds the `nextsame`/`callsame` "remaining" deferral list, via `resolve_all_methods_with_
+owner` + fingerprint-based winner removal, consumed by all six `push_method_dispatch_frame(...)`
+call sites in `vm/vm_call_method_compiled*.rs`. The shadow computation: build the sequence for
+`receiver_class`'s MRO, run it through `match_sequence_candidates` (invocant-BLIND — see finding
+1 below), remove the caller's own already-computed winner fingerprint (mirroring
+`push_method_dispatch_frame`'s exact loop shape: fingerprint-compare against the winner FIRST,
+THEN the `should_skip_defer_method_candidate` hidden-parent filter, so a candidate that is both
+the winner and nominally hidden is dropped for the winner reason only), and compare the
+resulting `Vec<u64>` fingerprint list — order-sensitive, since deferral ORDER is user-observable
+through repeated `nextsame` — against the real `remaining` list's own fingerprints, under a new
+`DEFERRAL_SHADOW_CHECKS`/`_MISMATCHES` counter pair (`vm_stats.rs`), dedicated rather than
+shared with `RESOLVER_SHADOW_*` for the same "comparing an ordered LIST, not a single winner
+pick" reason E7 steps 4/6/7 already established for their own dedicated pairs. Same `where`-
+clause care point as every prior probe: any candidate carrying a `where` clause anywhere in the
+sequence skips the whole check, since re-running `method_args_match_for_invocant` a second time
+would duplicate that clause's dynamic-variable side effects.
+
+**"Shadow-compare winner AND deferral list" — the winner half needed no new code.** Per design
+decision 1, `level`/`stored_idx` do not change winner ranking at all, so E4a's existing
+`shadow_check_resolver`/`shadow_check_resolver_chain` at the two `resolve_method_cached`
+boundaries already IS the winner-side shadow check the slice plan calls for; it now simply
+exercises the enriched `ResolvedCandidate::User` shape (with `level`/`stored_idx` present but
+unread by the winner ranker) for free. No new winner-probing call sites were added.
+
+**Finding 1 (real bug in the new probe, fixed before landing): invocant-blind matching.** The
+first version of `shadow_check_deferral_sequence` passed `Some(invocant)` to
+`match_sequence_candidates`, reasoning that the real invocant should narrow the match. But the
+REAL target it shadows — `resolve_all_methods_with_owner` — always calls
+`method_args_match_for_invocant(..., invocant: None)` (a pre-existing property of that function,
+unrelated to this box), so the deferral list is invocant-BLIND: it never checks `:U:`/`:D:`
+smiley constraints, only the non-invocant argument shape. This mirrors raku's own semantics —
+`nextsame`/`callsame` inside a `:U:`/`:D:` multi pair CAN walk to the sibling smiley candidate,
+since the deferral list is not re-filtered by the invocant a second time. An invocant-aware
+shadow probe is therefore *stricter* than the thing it is supposed to shadow, which produced
+mismatches on every `::?ROLE:U:`/`::?ROLE:D:`-shaped test in the sweep
+(`t/role-ud-multi-dispatch.t`: 6/6 mismatched → 0/6 after the fix;
+`t/multi-method-invocant-definedness.t`: 6/6 → 0/6; `t/qualified-mu-coercion.t`: 4/4 → 0/4).
+Switching the `match_sequence_candidates` call to `invocant: None` fixed all of them, dropping
+the sweep's total mismatch count from 73 to 58 (see below). Documented at length in the
+function's own doc comment so a future reader does not re-introduce the "more accurate must be
+better" mistake.
+
+**Finding 2 (pre-existing, accepted divergence — documented, not fixed): `method_entries`
+never covers an un-punned role.** After fix 1, every remaining mismatch traced to one root
+cause, confirmed by hand on all ten mismatching files: `resolve_sequence`'s per-level lookup
+(`Registry::user_method_overloads`, reading the E1/E2 canonical `method_entries` table) silently
+returns `None` for a role owner that has never been *punned* (`RoleName.new`, which briefly
+registers — then, on withdrawal, un-registers — a synthetic `ClassDef` for the pun; see
+`Registry::sync_user_method_entries`, which only ever reads `self.classes`). The real deferral
+walker, `resolve_all_methods_with_owner`, has no such gap: it reads `self.registry().roles`
+directly, bypassing `method_entries` entirely. So a role's own un-flattened method — reachable
+whenever the class overrides the role's method with its own (`t/supply-nested-whenever-
+emitter.t`, `t/multi-udismiley-ambiguity-leak.t`), when two role methods conflict and the class
+resolves the conflict itself (`t/role-conflict.t`), or via a role-qualified call
+`self.R::name()` (`t/qualified-method-call.t`) — is invisible to `resolve_sequence` but visible
+to the real walker. Every one of the 58 remaining mismatches (46 files with checks, 160 total
+checks) had the exact shape `real_len` one candidate ahead of `shadow_len`, confirmed on all ten
+mismatching files (`t/anon-class-does-imported-role.t` 4/4, `t/builtin-distribution-role.t` 1/1,
+`t/callsame-punned-role-and-hyper-infix-sub.t` 2/2, `t/multi-udismiley-ambiguity-leak.t` 18/12,
+`t/qualified-method-call.t` 1/1, `t/role-conflict.t` 1/1, `t/role-required-method-name-based.t`
+1/1, `t/role-required-universal-method.t` 3/3, `t/supply-nested-whenever-emitter.t` 1/1,
+`t/yaml-battery.t` 39/32). **Not fixed inside E8a**: `get_method_overloads` (the same table) also
+feeds several REAL production dispatch paths — `resolve_method_with_owner_impl` (winner
+selection itself), `ctor_phase_plan.rs`, `vm_call_method_compiled_cache.rs`, and all three
+`resolution_private_method.rs` call sites — so populating role entries there is a real
+dispatch-behavior change (most likely a latent bugfix, masked for winner selection today by
+early-stopping short-circuiting before reaching an un-punned role's MRO level in the common
+case, but unverified for every call site), outside a shadow-only box's "zero real behavior
+change" mandate. Root-caused, documented, and left with a suggested fix and verification plan in
+`todo/deep/method-entries-never-covers-unpunned-roles.md` — a new, standalone finding, not
+something that evaporates once E8a merges.
+
+**Verification.** A `MUTSU_VM_STATS=1` sweep of the full local `t/` suite (3070 files) found 160
+deferral-shadow checks across 46 files with any nextsame/callsame-shaped candidate, 58
+mismatches, all attributed to finding 2 above (confirmed by hand on every mismatching file, not
+inferred from the aggregate shape alone). A roast slice touching multi/role/submethod/wrap
+dispatch — `roast/S06-advanced/{callsame,dispatching,wrap}.t`,
+`roast/S06-multi/{redispatch,type-based,syntax}.t`,
+`roast/S12-methods/{defer-call,defer-next,lastcall,multi,parallel-dispatch}.t`,
+`roast/6.c/S12-class/mro-6c.t`, `roast/S12-class/{inheritance,basic}.t`,
+`roast/6.c/S14-roles/mixin-6c.t` (16 files) — found 37 checks, 0 mismatches (the roast
+whitelist's own corpus does not happen to exercise an un-punned role's nextsame/callsame
+deferral path the way the hand-written `t/` regression tests do). Two new unit tests:
+`resolve_sequence_assigns_level_and_stored_idx`,
+`resolve_sequence_drops_a_flattened_role_duplicate_at_build_time`. `cargo build`/`cargo clippy
+-- -D warnings`/`cargo fmt --check` clean; `cargo test --lib` (812 tests) and the full local
+`make test` (3070 files / 28652 tests) green. `resolve_all_methods_with_owner`,
+`push_method_dispatch_frame`'s own logic, and every real dispatch decision are untouched.
+
+**Next E8 sub-slice: E8b — proto methods into `MethodEntry`**, per the slice plan above.

--- a/todo/deep/method-entries-never-covers-unpunned-roles.md
+++ b/todo/deep/method-entries-never-covers-unpunned-roles.md
@@ -1,0 +1,103 @@
+# `method_entries` (the E1/E2 canonical method table) never covers an un-punned role owner
+
+## Root cause
+
+`Registry::sync_user_method_entries(class_name)` (`src/runtime/registry.rs`) is the only
+writer of `Registry::method_entries` for user-declared methods (the `MethodEntryKey { owner,
+name } -> MethodEntry { user_candidates, .. }` table introduced by ADR-0019's E1/E2 boxes).
+Its body reads `self.classes.get(class_name)` and returns early (after clearing any stale
+entries for that owner) when the lookup fails:
+
+```rust
+let Some(class_def) = self.classes.get(class_name) else {
+    self.bump_method_generation();
+    return;
+};
+```
+
+A **role** is never a key in `self.classes` unless it has been *punned* (used as a standalone
+type via `RoleName.new`, which briefly registers a synthetic `ClassDef` for the pun and calls
+`sync_user_method_entries` on it — see `methods_object_dispatch_new.rs`'s `withdraw_role_pun`,
+which also calls `sync_user_method_entries` again on withdrawal, clearing the entries right
+back out). So for a role that is never punned during a run — the overwhelmingly common case,
+since roles are normally only composed into a class, not instantiated directly —
+`Registry::method_entries` has NO entry at all for that role's own name, at any point.
+
+Consequently `Registry::user_method_overloads(role_name, method_name)` (and its alias
+`get_method_overloads`) always return `None` for such a role, even though the role's own
+methods are fully present in `Registry::roles[role_name].methods` (the older, still-live raw
+storage) the whole time.
+
+## Where this actually bites today
+
+`resolve_all_methods_with_owner` (`resolution_method.rs`, the "remaining"/deferral-list walker
+`push_method_dispatch_frame` uses for `nextsame`/`callsame`) does **not** go through
+`get_method_overloads` — it reads `self.registry().classes.get(cn)... .or_else(|| ...roles.get(cn)...)`
+directly, so it sees a role's raw methods regardless of punning. This is why the REAL
+`nextsame`/`callsame` deferral list has always correctly included an un-flattened role method
+(e.g. a role's stub `method process(...) { ... }` that a composing class overrides with its
+own `method process`, `t/supply-nested-whenever-emitter.t`; two conflicting same-named role
+methods left un-flattened when the class itself supplies the resolving override,
+`t/role-conflict.t`; a role-qualified call `self.R::me()`, `t/qualified-method-call.t`).
+
+But **`resolve_method_with_owner_impl`'s own per-level walk DOES go through
+`get_method_overloads`** (`resolution_method.rs:140`) — the production WINNER-selection path.
+Today this gap is *masked* for winner selection in the ordinary case: a composed role's method
+is normally flattened onto the class itself (a `ClassDef.methods` copy, tagged
+`role_origin`), so the walk's early-stopping return (the first MRO level with `Some(overloads)`
+at all — usually the class's own level, which precedes any role in the MRO) fires before the
+walk ever reaches the role's own un-punned MRO level. The gap would only surface for winner
+selection if a role-owned candidate were the FIRST usable candidate reached in an MRO walk with
+no preceding class-level entry for that name at all — not observed as a live production bug,
+but not proven absent either; it has simply never been exercised by the existing `t/`/roast
+corpus in a way that surfaces as a wrong *answer* (as opposed to `resolve_sequence`'s new
+shadow-check, which walks the FULL sequence without early-stopping and so sees the gap on the
+DEFERRAL side directly).
+
+`ctor_phase_plan.rs:133`, `vm_call_method_compiled_cache.rs:97`, and all three call sites in
+`resolution_private_method.rs` also read through `get_method_overloads`, so all of them share
+this same latent role-coverage gap.
+
+## Why this was found now
+
+ADR-0019 Phase E box E8a (`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`,
+`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) added `Interpreter::resolve_sequence`
+-based shadow-checking of the `nextsame`/`callsame` deferral list
+(`Interpreter::shadow_check_deferral_sequence`, `src/runtime/resolution_sequence.rs`).
+`resolve_sequence` builds its candidate universe via `Registry::user_method_overloads` (the
+E1/E2 canonical table), so it inherits this exact gap: it silently omits any un-punned role's
+own raw candidates. A `MUTSU_VM_STATS=1` sweep of `t/` (2026-08-12) found every deferral-list
+shadow mismatch traced to this one root cause (`real_len` one candidate ahead of `shadow_len`,
+the missing candidate always owned by an un-punned role reachable in the receiver's MRO) —
+see the E8a landing note in the ADR and in
+`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` for the exact file list and counts.
+
+## Why this is not fixed inside E8a
+
+Extending `sync_user_method_entries` to also populate role owners (the obvious fix — mirror the
+class branch, reading `self.roles.get(class_name)` when `self.classes.get(class_name)` misses)
+is not a "shadow-only, zero-real-behavior-change" edit: `get_method_overloads` is read by
+**real production dispatch** at the sites listed above, including winner selection
+(`resolve_method_with_owner_impl`) and private-method resolution (all three
+`resolution_private_method.rs` sites). Populating previously-empty role entries could change a
+real dispatch OUTCOME for some MRO shape not covered by today's tests (most likely a genuine
+bugfix, but an unverified one), which is out of scope for a box whose own definition
+(`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`, E8a slice) is limited to adding
+sequence structure and shadow-comparing it — not changing what any real call resolves to. E8a
+therefore left this as a **documented, accepted shadow-check divergence** (mirroring E4a's own
+accepted-divergence bucket for the winner probe) rather than fixing it inline.
+
+## Suggested fix, for whoever picks this up
+
+- Add a role branch to `sync_user_method_entries` mirroring the class branch (`self.roles.get(class_name)`
+  when `self.classes.get(class_name)` is `None`), and call it from wherever a role finishes composing
+  (parallel to the class-body-exit call sites) so a role's `method_entries` are populated the moment
+  it exists, without depending on punning at all.
+- Before landing, raku-verify (per this repo's "measure before assuming" house rule) that no MRO shape
+  changes its resolved winner because of the newly-visible role-level entries — the concern above is
+  theoretical, not a confirmed bug, but the four production call sites this feeds need a dedicated pass,
+  not a drive-by fix bundled into an unrelated box.
+- Once fixed, re-run E8a's `MUTSU_VM_STATS=1` sweep over `t/` + the relevant roast slice
+  (`roast/S06-advanced/*`, `roast/S12-methods/*`, `roast/S14-roles/*`) — the deferral-shadow mismatch
+  count should drop to (or very near) zero, and the explained-divergence note in
+  `src/runtime/resolution_sequence.rs`'s module doc / the ADR's E8a progress note can be removed.


### PR DESCRIPTION
## Summary

ADR-0019 Phase E box **E8a** (per `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`'s
slice plan) — the first landed slice of box E8, closing on the heels of E7's closure.

- `ResolvedCandidate::User` (`src/runtime/resolution_sequence.rs`) gains `level: u16` (MRO chain
  position, 0 = receiver's own class) and `stored_idx: u16` (position within that level's stored
  declaration order), set from `resolve_sequence`'s existing per-level loop. No extra sort
  needed — the sequence's own construction order is already `(level, stored_idx)`-ascending.
- Submethod visibility already applied at build time (unchanged); a composed role's flattened
  duplicate is now ALSO dropped at build time (`drop_flattened_role_duplicate_candidates`,
  mirroring `resolution_method.rs`'s post-match `drop_flattened_role_duplicates`, moved earlier
  — behavior-preserving since it only filters by owner identity).
- The signature-match filtering loop shared by E4a's winner probe and this box's new deferral
  probe was extracted into `Interpreter::match_sequence_candidates` (the slice plan's "ranker
  extracted to consume a candidate slice").
- New `Interpreter::shadow_check_deferral_sequence`, gated behind `MUTSU_VM_STATS` like every
  prior Phase E probe, hooks `Interpreter::push_method_dispatch_frame` — the single real call
  site that builds the `nextsame`/`callsame` deferral list — and compares the sequence's own
  ordered candidate list against the real list by fingerprint, under a new
  `DEFERRAL_SHADOW_CHECKS`/`_MISMATCHES` counter pair. The winner-selection half needed no new
  code: `level`/`stored_idx` don't change ranking, so E4a's existing winner probe already covers
  it.

Two findings surfaced while building this:

1. **Fixed**: the probe's first version matched the invocant-aware signature, but the real
   target (`resolve_all_methods_with_owner`) always matches invocant-BLIND — mismatched on
   every `::?ROLE:U:`/`::?ROLE:D:` multi pair until fixed to match the same way.
2. **Documented, not fixed**: `resolve_sequence`'s per-level lookup silently misses a role's own
   methods unless the role has been punned — `method_entries` (E1/E2's canonical table) is only
   ever populated from `self.classes`. This also feeds several REAL production dispatch paths
   (winner selection included), so extending it is out of scope for this shadow-only box. Full
   root cause and fix plan in `todo/deep/method-entries-never-covers-unpunned-roles.md`.

Zero real dispatch behavior change — `resolve_all_methods_with_owner` and
`push_method_dispatch_frame`'s own logic are untouched.

## Verification

- `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check`: clean.
- `cargo test --lib`: 812 passed (2 new tests: `resolve_sequence_assigns_level_and_stored_idx`,
  `resolve_sequence_drops_a_flattened_role_duplicate_at_build_time`).
- `MUTSU_VM_STATS=1` sweep of the full local `t/` suite (3070 files): 160 deferral-shadow
  checks across 46 files, 58 mismatches, ALL confirmed by hand to be finding 2's gap (not a new
  bug) — same `real_len` one candidate ahead of `shadow_len` shape on all ten mismatching files.
- `MUTSU_VM_STATS=1` sweep of a roast slice touching multi/role/submethod/wrap dispatch (16
  files: `S06-advanced/{callsame,dispatching,wrap}`, `S06-multi/{redispatch,type-based,syntax}`,
  `S12-methods/{defer-call,defer-next,lastcall,multi,parallel-dispatch}`,
  `S12-class/{mro-6c,inheritance,basic}`, `S14-roles/mixin-6c`): 37 checks, 0 mismatches.
- Full local `make test`: 3070 files / 28652 tests, PASS.

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean
- [x] `cargo test --lib` green (812 tests)
- [x] Full local `make test` green (3070 files / 28652 tests)
- [ ] CI `make test` + `make roast` green (auto-merge enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)