### PR TITLE
feat(adr0019): E8b — proto methods gain a MethodEntry column (shadow mode)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3742,8 +3742,59 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   clippy -- -D warnings`/`cargo fmt --check` clean; `cargo test --lib` (812 tests) and full
   local `make test` (3070 files / 28652 tests) green. Zero real-behavior change: `resolve_
   all_methods_with_owner`, `push_method_dispatch_frame`'s own logic, and every real dispatch
-  decision are untouched by this slice. **Next E8 sub-slice: E8b — proto methods into
-  `MethodEntry`**, per the slice plan.
+  decision are untouched by this slice.
+  **Progress 2026-08-12** (E8b, proto methods into `MethodEntry`, shadow mode): scoped down
+  from the slice plan's full text ("`lookup_proto_method` deleted") to the same
+  measure-first shape every prior Phase E box used before a cutover — E1a's `TypeId` column
+  landing beside the still-authoritative string owner is the closest precedent. `MethodEntry`
+  (`registry.rs`) gained a `proto: Option<FunctionDef>` column; `Registry::set_proto_method`
+  (the single write site, called from `registration_class_body.rs`'s
+  `class_body_proto_method_decl`) writes it alongside the still-standalone, still-sole-real-
+  reader `proto_methods: HashMap<(String, String), FunctionDef>`. `Interpreter::
+  lookup_proto_method`'s real MRO walk is untouched; it now also calls a new
+  `MUTSU_VM_STATS`-gated probe, `shadow_check_proto_method`, which repeats the identical
+  `class_mro` walk reading the new `method_entries`-backed `Registry::method_entry_proto`
+  instead, and compares owner name + `FunctionDef::body_fingerprint()` against the real
+  result under a dedicated `PROTO_METHOD_SHADOW_CHECKS`/`_MISMATCHES` counter pair
+  (`vm_stats.rs`), following the same "own pair, not `RESOLVER_SHADOW_*`" reasoning as every
+  prior probe family in this ADR.
+  **One real bug found and fixed, in the registry's existing sync logic, not the new probe
+  itself**: the first sweep found *majority* mismatches (e.g. 10/13, 12/19 checks), always
+  `real=Some(owner) shadow=None` — the new column was silently losing its only entry.
+  Root cause: `Registry::sync_user_method_entries` (pre-existing, called from every one of
+  `registration_class_body.rs`'s own call sites *after* the proto decl already landed, plus
+  composition/augmentation/redeclaration elsewhere) `retain`s a `(owner, name)` row only when
+  `entry.builtin.is_some() || !entry.user_candidates.is_empty() || entry.accessor.is_some()` —
+  a row holding only a freshly-written `.proto` (no builtin/user_candidates/accessor) matched
+  none of those and was dropped from the map outright the next time anything synced that
+  owner. Fixed by adding `entry.proto.is_some()` to the keep condition; `.proto` itself is
+  deliberately NOT reset by the `key.owner == owner` clearing branch above it (unlike
+  `user_candidates`/`accessor`, it has no `ClassDef`-backed source that branch re-derives
+  from below — it is written once, directly, by `set_proto_method`). Confirmed zero real-
+  behavior impact: nothing outside this box's own shadow probe read `.proto` before the fix,
+  so the bug was entirely self-contained to the new, not-yet-consulted column. After the fix,
+  a `MUTSU_VM_STATS=1` sweep of every `t/` file mentioning `proto method`/`proto submethod`
+  (22 files) found 171 checks, 0 mismatches; a roast slice touching proto/multi/wrap dispatch
+  (`S06-multi/{proto,type-based,syntax,redispatch}`, `S12-methods/{defer-next,defer-call,
+  lastcall,multi,parallel-dispatch}`, `S06-advanced/{callsame,dispatching,wrap}`,
+  `6.c/S12-class/mro-6c`, `S12-class/{inheritance,basic}`, `6.c/S14-roles/mixin-6c`, 16 files)
+  found 24 checks (3 files actually exercise a proto method; the rest is coverage, not a
+  gap), 0 mismatches. Two new unit tests (`set_proto_method_populates_both_the_legacy_table_
+  and_method_entries`, `method_entry_proto_is_scoped_to_the_exact_owner`). `cargo build`/
+  `cargo clippy -- -D warnings`/`cargo fmt` clean; `cargo test --lib` (814 tests) and full
+  local `make test` (3071 files / 28661 tests) green. Zero real-behavior change:
+  `lookup_proto_method`'s own return value, and every real proto-method dispatch decision,
+  are untouched — `proto_methods` stays the sole table actually read for dispatch.
+  **Next E8 sub-slice: E8c — cutover.** Given zero mismatches on both sweeps, `proto_methods`
+  and `lookup_proto_method`'s standalone MRO walk are ready to retire in favor of reading
+  `method_entries` directly (the slice plan's original E8b text), but that is left as its own
+  small, easily-revertible slice rather than folded into this one, matching E1a→E1b's own
+  two-step precedent — a cutover is a different risk class from a table addition even when
+  the measurement is clean. After E8c, the next Phase E box is **E9-pre**: the mandatory raku
+  verification campaign for `samewith`/`nextsame`/`callsame`/`nextwith` cursor semantics
+  (design decision 3 in `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) — the
+  highest-semantic-risk box of the whole phase (拙速厳禁), required before any E9a/b/c cursor
+  cutover work starts.
 - [ ] **E9 — Add resolver cursors for `samewith`/`nextsame`/`callsame`/`nextwith`.** Continue within
   the resolved sequence instead of re-entering name-based resolution.
   **Design 2026-08-10** (same doc): one `DispatchCursor {seq, next, invocant, args}` replaces

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -228,16 +228,57 @@ impl Interpreter {
             return None;
         }
         let mro = self.class_mro(class_name);
-        for cn in mro.iter().map(|s| s.resolve()) {
-            if let Some(f) = self
-                .registry()
+        let result = mro.iter().map(|s| s.resolve()).find_map(|cn| {
+            self.registry()
                 .proto_methods
                 .get(&(cn.clone(), method_name.to_string()))
-            {
-                return Some((cn, f.clone()));
-            }
+                .cloned()
+                .map(|f| (cn, f))
+        });
+        if crate::vm::vm_stats::enabled() {
+            self.shadow_check_proto_method(&mro, method_name, result.as_ref());
         }
-        None
+        result
+    }
+
+    /// ADR-0019 E8b shadow probe (`MUTSU_VM_STATS`-gated, a no-op otherwise):
+    /// does the same MRO walk, read against the new `MethodEntry.proto`
+    /// column (`Registry::method_entry_proto`) instead of the legacy
+    /// standalone `proto_methods` table, find the same nearest proto body as
+    /// [`Self::lookup_proto_method`]'s real walk? Both tables are written
+    /// together by the single `Registry::set_proto_method` call site, so this
+    /// is expected to be a zero-mismatch measurement before `proto_methods`
+    /// is retired and `lookup_proto_method` is cut over to read
+    /// `method_entries` directly — see `todo/deep/
+    /// adr0019-e8-e11-candidate-sequence-semantics.md`'s E8b note. Compares
+    /// by owner name and body fingerprint (mirrors every other Phase E
+    /// winner-shadow probe, e.g. `Interpreter::shadow_check_resolver_chain`),
+    /// not `Option` equality — `FunctionDef` has no `PartialEq`.
+    fn shadow_check_proto_method(
+        &mut self,
+        mro: &[Symbol],
+        method_name: &str,
+        real: Option<&(String, FunctionDef)>,
+    ) {
+        let shadow = mro.iter().map(|s| s.resolve()).find_map(|cn| {
+            self.registry()
+                .method_entry_proto(&cn, method_name)
+                .map(|f| (cn, f))
+        });
+        let matched = match (real, shadow.as_ref()) {
+            (None, None) => true,
+            (Some((ro, rf)), Some((so, sf))) => {
+                ro == so && rf.body_fingerprint() == sf.body_fingerprint()
+            }
+            _ => false,
+        };
+        crate::vm::vm_stats::record_proto_method_shadow_check(matched, || {
+            format!(
+                "method={method_name} real={:?} shadow={:?}",
+                real.map(|(o, _)| o.as_str()),
+                shadow.as_ref().map(|(o, _)| o.as_str()),
+            )
+        });
     }
 
     /// Run a `proto method` body, with `{*}` dispatching to the matching multi

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -312,8 +312,7 @@ impl Interpreter {
             rw_tail_expr: None,
         };
         self.registry_mut()
-            .proto_methods
-            .insert((cx.name.to_string(), method_name), fdef);
+            .set_proto_method(cx.name, &method_name, fdef);
         Ok(())
     }
 

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -59,6 +59,15 @@ pub(crate) struct MethodEntry {
     /// `ClassAttributeDef` (that stays in `ClassDef::attributes`, the source
     /// this is synced from).
     pub(crate) accessor: Option<bool>,
+    /// `proto method`/`proto submethod` body declared directly on this
+    /// `(owner, name)` (ADR-0019 E8b): the `MethodEntry` fold of the
+    /// formerly-standalone `Registry::proto_methods` table. Written by
+    /// [`Registry::set_proto_method`] alongside `proto_methods` — shadow
+    /// mode: `proto_methods` stays the sole table `Interpreter::
+    /// lookup_proto_method` reads for real dispatch, this field is compared
+    /// against it under `MUTSU_VM_STATS` (`Interpreter::
+    /// shadow_check_proto_method`) before any cutover.
+    pub(crate) proto: Option<FunctionDef>,
 }
 
 /// Program declaration registry. See module docs.
@@ -315,7 +324,23 @@ impl Registry {
                 entry.user_candidates.clear();
                 entry.accessor = None;
             }
-            entry.builtin.is_some() || !entry.user_candidates.is_empty() || entry.accessor.is_some()
+            // `entry.proto` (ADR-0019 E8b) is NOT reset here even for a
+            // `key.owner == owner` row: unlike `user_candidates`/`accessor`,
+            // it has no `ClassDef`-backed source this function re-derives
+            // from below (it is written once, directly, by
+            // `Registry::set_proto_method` at proto-method declaration
+            // time) — clearing it here would just delete it with nothing to
+            // repopulate it. It must still count toward keeping the row
+            // alive, or a proto-only entry (no builtin/user_candidates/
+            // accessor) is silently dropped the next time ANY sync call
+            // touches this owner (composition, augmentation, re-declaration
+            // — all of `registration_class_body.rs`'s own call sites run
+            // this after the proto decl already landed), which is exactly
+            // what the E8b shadow probe caught during its first sweep.
+            entry.builtin.is_some()
+                || !entry.user_candidates.is_empty()
+                || entry.accessor.is_some()
+                || entry.proto.is_some()
         });
         let Some(class_def) = self.classes.get(class_name) else {
             self.bump_method_generation();
@@ -413,6 +438,50 @@ impl Registry {
     pub(crate) fn replace_method_entries_from(&mut self, source: &Self) {
         self.method_entries = source.method_entries.clone();
         self.bump_method_generation();
+    }
+
+    /// Register a `proto method`/`proto submethod` body for `(class_name,
+    /// method_name)` (ADR-0019 E8b). Writes to both the legacy `proto_methods`
+    /// table (still the only one `Interpreter::lookup_proto_method` actually
+    /// reads for dispatch) and the new `MethodEntry.proto` column, so the two
+    /// can be shadow-compared before any cutover. Single call site
+    /// (`registration_class_body.rs`'s `class_body_proto_method_decl`).
+    pub(crate) fn set_proto_method(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+        def: FunctionDef,
+    ) {
+        self.proto_methods.insert(
+            (class_name.to_string(), method_name.to_string()),
+            def.clone(),
+        );
+        self.method_entries
+            .entry(MethodEntryKey {
+                owner: Symbol::intern(class_name),
+                name: Symbol::intern(method_name),
+            })
+            .or_default()
+            .proto = Some(def);
+        self.bump_method_generation();
+    }
+
+    /// The `MethodEntry.proto` column at exactly `(class_name, method_name)`
+    /// — no MRO walk (the caller supplies the chain, mirroring how
+    /// `user_method_overloads` is a per-level, not per-chain, probe).
+    /// ADR-0019 E8b shadow-check helper for [`Interpreter::
+    /// shadow_check_proto_method`]; not read by real dispatch yet.
+    pub(crate) fn method_entry_proto(
+        &self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<FunctionDef> {
+        self.method_entries
+            .get(&MethodEntryKey {
+                owner: Symbol::intern(class_name),
+                name: Symbol::intern(method_name),
+            })
+            .and_then(|entry| entry.proto.clone())
     }
 
     fn bump_method_generation(&mut self) {
@@ -1105,5 +1174,68 @@ mod tests {
             .expect("built-in entry survives user removal");
         assert!(entry.builtin.is_some());
         assert!(entry.user_candidates.is_empty());
+    }
+
+    fn dummy_proto_def(owner: &str, name: &str) -> FunctionDef {
+        FunctionDef {
+            package: Symbol::intern(owner),
+            name: Symbol::intern(name),
+            params: Vec::new(),
+            param_defs: Vec::new(),
+            body: Vec::new(),
+            is_test_assertion: false,
+            is_rw: false,
+            is_raw: false,
+            is_method: true,
+            empty_sig: false,
+            is_stub: false,
+            return_type: None,
+            is_default: false,
+            deprecated_message: None,
+            source_file: None,
+            decl_order: 0,
+            compiled: None,
+            body_fp_cache: std::sync::OnceLock::new(),
+            body_facts_cache: std::sync::OnceLock::new(),
+            rw_tail_expr: None,
+        }
+    }
+
+    /// ADR-0019 E8b: `set_proto_method` writes both the legacy `proto_methods`
+    /// table and the new `MethodEntry.proto` column, and both agree.
+    #[test]
+    fn set_proto_method_populates_both_the_legacy_table_and_method_entries() {
+        let mut registry = Registry::default();
+        let seeded_generation = registry.method_generation;
+        let def = dummy_proto_def("Foo", "bar");
+        registry.set_proto_method("Foo", "bar", def.clone());
+        assert!(registry.method_generation > seeded_generation);
+
+        assert_eq!(
+            registry
+                .proto_methods
+                .get(&("Foo".to_string(), "bar".to_string()))
+                .map(FunctionDef::body_fingerprint),
+            Some(def.body_fingerprint())
+        );
+        assert_eq!(
+            registry
+                .method_entry_proto("Foo", "bar")
+                .map(|f| f.body_fingerprint()),
+            Some(def.body_fingerprint())
+        );
+    }
+
+    /// `method_entry_proto` is a per-name probe (no MRO walk): a class that
+    /// never declared its own proto method reports `None` even if an
+    /// ancestor did — the MRO walk is the caller's job
+    /// (`Interpreter::lookup_proto_method`/`shadow_check_proto_method`).
+    #[test]
+    fn method_entry_proto_is_scoped_to_the_exact_owner() {
+        let mut registry = Registry::default();
+        registry.set_proto_method("Base", "greet", dummy_proto_def("Base", "greet"));
+        assert!(registry.method_entry_proto("Base", "greet").is_some());
+        assert!(registry.method_entry_proto("Child", "greet").is_none());
+        assert!(registry.method_entry_proto("Base", "other").is_none());
     }
 }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -648,6 +648,40 @@ pub(crate) fn record_deferral_shadow_check(matched: bool, detail: impl FnOnce() 
     }
 }
 
+// ADR-0019 Phase E box E8b (`todo/deep/adr0019-e8-e11-candidate-sequence-
+// semantics.md`): shadow comparison between `Interpreter::
+// lookup_proto_method`'s real MRO walk over the standalone `Registry::
+// proto_methods` table and the same walk read against the new `MethodEntry.
+// proto` column (`Registry::method_entry_proto`) both tables are written to
+// together by `Registry::set_proto_method`. A dedicated counter pair (not
+// `RESOLVER_SHADOW_*`) for the same reason every other Phase E probe family
+// gets its own pair: this measures one specific consolidation, not a general
+// resolver-winner comparison. Nothing reads these counters to make a
+// dispatch decision: shadow-only, zero behavior change.
+static PROTO_METHOD_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static PROTO_METHOD_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn proto_method_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one E8b proto-method shadow comparison. `detail` is only
+/// evaluated on a mismatch, mirroring [`record_deferral_shadow_check`].
+#[inline]
+pub(crate) fn record_proto_method_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    PROTO_METHOD_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        PROTO_METHOD_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = proto_method_shadow_mismatch_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1195,6 +1229,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e8a deferral-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let proto_method_shadow_checks = PROTO_METHOD_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let proto_method_shadow_mismatches = PROTO_METHOD_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-e8b: proto_method_shadow_checks={proto_method_shadow_checks} proto_method_shadow_mismatches={proto_method_shadow_mismatches}"
+    );
+    if let Ok(map) = proto_method_shadow_mismatch_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-e8b proto-method-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );

--- a/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
+++ b/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
@@ -332,4 +332,76 @@ deferral path the way the hand-written `t/` regression tests do). Two new unit t
 `make test` (3070 files / 28652 tests) green. `resolve_all_methods_with_owner`,
 `push_method_dispatch_frame`'s own logic, and every real dispatch decision are untouched.
 
-**Next E8 sub-slice: E8b — proto methods into `MethodEntry`**, per the slice plan above.
+## E8b: proto methods gain a `MethodEntry` column in shadow mode; the registry's own sync logic was silently dropping proto-only rows
+
+Landed 2026-08-12. Scoped down from this slice plan's original text ("proto methods into
+`MethodEntry`; `lookup_proto_method` deleted") to a measure-first shape, matching E1a's own
+precedent (`TypeId` landed beside the still-authoritative string owner; a later box made it
+authoritative) rather than E8a's "shadow-check-then-immediate-cutover-in-the-same-PR" shape —
+proto methods have exactly one write site and one read site (both far lower blast radius than
+E1a's owner-string problem), but a *cutover* is still a different risk class from adding a
+column even when the write site is singular, so the cutover itself is deferred to E8c.
+
+**Structural change.** `MethodEntry` (`registry.rs`) gained `proto: Option<FunctionDef>`.
+`Registry::set_proto_method(class_name, method_name, def)` is the single write site (called
+from `registration_class_body.rs`'s `class_body_proto_method_decl`, replacing its old direct
+`proto_methods.insert(...)`): it writes `def` into both the still-standalone `proto_methods:
+HashMap<(String, String), FunctionDef>` (still the *only* table `Interpreter::
+lookup_proto_method` reads for real dispatch) and the new `MethodEntry.proto` column, keeping
+them in lockstep by construction. `Registry::method_entry_proto(class_name, method_name)` is
+the new column's read side — a single-level probe (no MRO walk), mirroring
+`user_method_overloads`'s own shape.
+
+**Shadow check.** `lookup_proto_method`'s real MRO walk (`class_mro` + `proto_methods` lookup
+per level) is untouched; it now also calls `shadow_check_proto_method` under
+`MUTSU_VM_STATS`, which repeats the identical MRO walk reading `method_entry_proto` instead and
+compares (owner name, `FunctionDef::body_fingerprint()`) against the real result — a dedicated
+`PROTO_METHOD_SHADOW_CHECKS`/`_MISMATCHES` counter pair (`vm_stats.rs`), following the same
+"one pair per probe family, not the shared `RESOLVER_SHADOW_*` infra" convention every prior
+box in this ADR established.
+
+**Finding (a real bug, in existing code the box merely lit up — fixed): `sync_user_method_
+entries` was dropping proto-only rows.** The first sweep found *majority* mismatches (e.g.
+10/13, 12/19 checks per file), always shaped `real=Some(owner) shadow=None` — the shadow
+column had nothing where the real table had an entry. Root cause: `Registry::
+sync_user_method_entries` (pre-existing, run from every one of `registration_class_body.rs`'s
+own call sites *after* a proto decl in the same class body already landed, plus composition/
+augmentation/redeclaration sites elsewhere) `retain`s a `(owner, name)` row only when
+`entry.builtin.is_some() || !entry.user_candidates.is_empty() || entry.accessor.is_some()`. A
+row holding only a freshly-written `.proto` matched none of those three and was dropped from
+the map outright the moment anything else synced that owner — which, for a proto method
+declared inside a class body, is *immediately*, since `class_body_proto_method_decl` runs
+mid-body and later statements in the same body trigger further syncs before the class exits.
+Fixed by adding `entry.proto.is_some()` to the retain's keep condition. `.proto` itself is
+deliberately left OUT of the `key.owner == owner` clearing branch just above that condition
+(the one that resets `user_candidates`/`accessor` before re-deriving them from `ClassDef`
+below): unlike those two, `.proto` has no `ClassDef`-backed source to re-derive from — it is
+written once, directly, only by `set_proto_method` — so clearing it there would delete it with
+nothing to repopulate it. Confirmed zero real-behavior impact from the bug itself: nothing
+outside this box's own new shadow probe read `.proto` before the fix landed, so the drop was
+entirely self-contained to a column no real dispatch path had started consuming yet — exactly
+the kind of "bug in the box's own new probe/scaffolding, not production" finding this ADR's
+prior boxes (E7, E8a) also hit and fixed before landing.
+
+**Verification.** After the fix, a `MUTSU_VM_STATS=1` sweep of every `t/` file mentioning
+`proto method`/`proto submethod` (22 files) found 171 checks, 0 mismatches. A roast slice
+touching proto/multi/wrap dispatch — the same 16-file list E8a's own verification used above
+(`S06-multi/{proto,type-based,syntax,redispatch}`, `S12-methods/{defer-next,defer-call,
+lastcall,multi,parallel-dispatch}`, `S06-advanced/{callsame,dispatching,wrap}`,
+`6.c/S12-class/mro-6c`, `S12-class/{inheritance,basic}`, `6.c/S14-roles/mixin-6c}`, plus
+`S06-multi/proto.t` added since it is the box's own dedicated roast file) — found 24 checks (3
+files actually exercise a proto method under `MUTSU_VM_STATS`; the rest is coverage against a
+false negative, not evidence of a gap), 0 mismatches. Two new unit tests: `set_proto_method_
+populates_both_the_legacy_table_and_method_entries`, `method_entry_proto_is_scoped_to_the_
+exact_owner`. `cargo build`/`cargo clippy -- -D warnings`/`cargo fmt` clean; `cargo test --lib`
+(814 tests) and the full local `make test` (3071 files / 28661 tests) green.
+`lookup_proto_method`'s own return value and every real proto-method dispatch decision are
+untouched — `proto_methods` stays the sole table actually read for dispatch.
+
+**Next E8 sub-slice: E8c — cutover.** With both sweeps at zero mismatches, `proto_methods` and
+`lookup_proto_method`'s standalone MRO walk are ready to retire in favor of reading
+`method_entries` directly (recovering the slice plan's original E8b scope), but that is left as
+its own slice rather than folded into this one — matching E1a→E1b's two-step precedent, since a
+cutover changes what real dispatch reads even when the measurement backing it is clean. After
+E8c, the next Phase E box is **E9-pre**: the mandatory raku verification campaign for
+`samewith`/`nextsame`/`callsame`/`nextwith` cursor semantics (design decision 3 above) — 拙速厳禁.


### PR DESCRIPTION
## Summary

ADR-0019 Phase E box E8, sub-slice E8b (per `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`'s slice plan, continuing E8a landed in #6316).

- `Registry::proto_methods` folds into `MethodEntry` as a new `proto: Option<FunctionDef>` column. `Registry::set_proto_method` is the single write site (`registration_class_body.rs`'s `class_body_proto_method_decl`), writing both the new column and the still-standalone, still-authoritative `proto_methods` table in lockstep.
- `Interpreter::lookup_proto_method`'s real MRO walk is unchanged. A new `MUTSU_VM_STATS`-gated `shadow_check_proto_method` repeats the same walk reading the new column instead, and compares it against the real result under a dedicated `PROTO_METHOD_SHADOW_CHECKS`/`_MISMATCHES` counter pair (matching every prior Phase E probe family's own dedicated pair).
- **A real bug found and fixed** in existing (pre-E8b) code: `Registry::sync_user_method_entries`'s `retain` predicate dropped a `(owner, name)` row that held only a freshly-written `.proto` (no builtin/user_candidates/accessor) — which happens on every sync that runs after a proto decl in the same class body, i.e. immediately. Fixed by adding `entry.proto.is_some()` to the keep condition. Confirmed self-contained: nothing outside this box's own new probe read `.proto` before the fix, so the bug never affected real dispatch.

Scoped down from the slice plan's original E8b text ("`lookup_proto_method` deleted") to a measure-first shape — proto methods have exactly one write site and one read site, but a cutover is still a different risk class from adding a column, so it's deferred to E8c, matching E1a→E1b's own two-step precedent.

## Verification

- `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean.
- `cargo test --lib`: 814 tests pass (2 new: `set_proto_method_populates_both_the_legacy_table_and_method_entries`, `method_entry_proto_is_scoped_to_the_exact_owner`).
- `MUTSU_VM_STATS=1` sweep of every `t/` file mentioning `proto method`/`proto submethod` (22 files): 171 shadow checks, 0 mismatches (after the fix above; before the fix, most files showed majority mismatches).
- Roast slice touching proto/multi/wrap dispatch (`S06-multi/{proto,type-based,syntax,redispatch}`, `S12-methods/{defer-next,defer-call,lastcall,multi,parallel-dispatch}`, `S06-advanced/{callsame,dispatching,wrap}`, `6.c/S12-class/mro-6c`, `S12-class/{inheritance,basic}`, `6.c/S14-roles/mixin-6c}`, 16 files): 24 shadow checks, 0 mismatches.
- Full local `make test`: 3071 files / 28661 tests, `Result: PASS`.
- Zero real-behavior change: `lookup_proto_method`'s own return value and every real proto-method dispatch decision are untouched — `proto_methods` stays the sole table actually read for dispatch.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --lib`
- [x] `MUTSU_VM_STATS=1` sweep of `t/` proto-touching files (0 mismatches)
- [x] Roast slice touching proto/multi/wrap dispatch (0 mismatches)
- [x] Full local `make test`
- [ ] CI `make test` + `make roast`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>