### PR TITLE
feat(adr0019): E8c -- cut proto-method dispatch over to method_entries

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3671,7 +3671,7 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   were systematically under-tested against introspection/reflection call paths before this box, even
   though ordinary method *invocation* on a mixin worked correctly throughout). **Next Phase E box: E8
   — model multi/proto/submethod ordering in the candidate sequence**, per this ADR's own box ordering.
-- [ ] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
+- [x] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
   **Design 2026-08-10** (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`):
   candidates carry `level`/`stored_idx` so winner selection (existing ladder, per call) and
@@ -3785,16 +3785,59 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   local `make test` (3071 files / 28661 tests) green. Zero real-behavior change:
   `lookup_proto_method`'s own return value, and every real proto-method dispatch decision,
   are untouched — `proto_methods` stays the sole table actually read for dispatch.
-  **Next E8 sub-slice: E8c — cutover.** Given zero mismatches on both sweeps, `proto_methods`
-  and `lookup_proto_method`'s standalone MRO walk are ready to retire in favor of reading
-  `method_entries` directly (the slice plan's original E8b text), but that is left as its own
-  small, easily-revertible slice rather than folded into this one, matching E1a→E1b's own
-  two-step precedent — a cutover is a different risk class from a table addition even when
-  the measurement is clean. After E8c, the next Phase E box is **E9-pre**: the mandatory raku
-  verification campaign for `samewith`/`nextsame`/`callsame`/`nextwith` cursor semantics
-  (design decision 3 in `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) — the
-  highest-semantic-risk box of the whole phase (拙速厳禁), required before any E9a/b/c cursor
-  cutover work starts.
+  **Progress 2026-08-12** (E8c, proto-method cutover): landed the deferred cutover exactly as
+  E8b's own note scoped it, matching E1a→E1b's precedent — `Interpreter::lookup_proto_method`'s
+  real MRO walk now reads `MethodEntry.proto` via `Registry::method_entry_proto` directly
+  (`dispatch_proto.rs`), the same lookup E8b's shadow probe already proved agrees with the old
+  walk everywhere tested (171+24 checks, 0 mismatches). `git grep -n "proto_methods" src/`
+  confirmed the standalone `HashMap<(String, String), FunctionDef>` table had exactly the two
+  readers E8b's own design already assumed (the real walk and its now-obsolete shadow probe,
+  both in `dispatch_proto.rs`) and one writer (`Registry::set_proto_method`) — no `.^methods`/
+  `.^lookup`/`.^find_method` introspection path or anything else touched it — so it is genuinely
+  dead code, not merely superseded, and is deleted outright rather than kept as a secondary
+  store. Its role as `lookup_proto_method`'s whole-program "skip the MRO walk entirely" fast path
+  (`proto_methods.is_empty()`) is replaced by a new monotonic `Registry::has_proto_methods: bool`
+  flag set once by `set_proto_method` (proto bodies are never unregistered, so a flag suffices —
+  no count or set needed). The now-redundant `shadow_check_proto_method` probe and its
+  `PROTO_METHOD_SHADOW_CHECKS`/`_MISMATCHES` counter pair (`vm_stats.rs`, including their
+  `adr0019-e8b` stats-report lines) are deleted — once the shadow answer IS the real answer,
+  there is nothing left to compare it against, the same reasoning E1b used to retire E1a's
+  probes at its own cutover sites. Two registry unit tests updated for the new shape (one
+  renamed and simplified to check `method_entries` + the fast-path flag instead of the retired
+  table; the per-owner-scoping test unchanged). No new test added beyond that: this is a
+  same-answer read-path swap with no new observable behavior to pin, and the existing proto-
+  method suite (`t/proto-method-body.t`, `t/proto-method-rw-redispatch.t`,
+  `t/proto-cross-module-invocant.t`, `t/handles-proto-dispatch-mut-invocant.t`,
+  `t/proto-multi-captured-writeback-coherence.t`, `t/proto-new-no-match.t`,
+  `t/proto-multi-method-role-composition.t`, `t/multi-udismiley-ambiguity-leak.t`,
+  `t/role-ud-multi-dispatch.t`, `t/qualified-mu-coercion.t` — 72 assertions across plain-class,
+  inherited, and role-composed proto shapes) already exercises the cut-over path end to end and
+  stays green. Per CLAUDE.md's "touched name/type resolution" rule (this is a real dispatch
+  read-path change, even though risk-free by measurement), ran a local roast slice touching
+  proto/multi/wrap dispatch (`S06-multi/{proto,type-based,syntax,redispatch}`,
+  `S12-methods/{defer-next,defer-call,lastcall,multi,parallel-dispatch}`,
+  `S06-advanced/{callsame,dispatching,wrap}`, `6.c/S12-class/mro-6c`,
+  `S12-class/{inheritance,basic}`, `6.c/S14-roles/mixin-6c`, 16 files, 524 assertions) — all
+  green. `cargo build`/`cargo clippy -- -D warnings`/`cargo fmt --check` clean; `cargo test --lib`
+  (814 tests, same count as E8b — one renamed, none added or removed) and full local `make test`
+  (3074 files / 28683 tests) green. Zero real-behavior change confirmed by construction (E8b's
+  own shadow measurement) and by the roast/`t/` sweeps above, not merely asserted.
+  **E8 is now closed as a whole.** E8a (sequence structural fields: `level`/`stored_idx`,
+  `drop_flattened_role_duplicate_candidates` at build time, the deferral-list shadow probe) +
+  E8b (proto methods folded into `MethodEntry`, shadow mode, plus a real `sync_user_method_
+  entries` bug fix) + E8c (this slice, the proto-method cutover) together cover everything the
+  box's own text scoped: candidates carry `level`/`stored_idx` so winner selection and deferral
+  order both derive from one sequence; `Registry::proto_methods` has folded into `MethodEntry`
+  and is gone; unifying the method-vs-sub ranking ladders stayed explicitly out of scope, as
+  designed. The one open item from E8a — `resolve_sequence`'s per-level lookup silently missing
+  an un-punned role's own methods (`todo/deep/method-entries-never-covers-unpunned-roles.md`) —
+  is a pre-existing, separately-tracked gap in a different lookup path (`user_method_overloads`,
+  not anything E8c touched), not part of this box's scope. **Next Phase E box: E9-pre** — the
+  mandatory raku verification campaign for `samewith`/`nextsame`/`callsame`/`nextwith` cursor
+  semantics (design decision 3 in `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`),
+  the highest-semantic-risk box of the whole phase (拙速厳禁) — it must run as its own dedicated
+  session, not be attempted inline here, and is required before any E9a/b/c cursor cutover work
+  starts.
 - [ ] **E9 — Add resolver cursors for `samewith`/`nextsame`/`callsame`/`nextwith`.** Continue within
   the resolved sequence instead of re-entering name-based resolution.
   **Design 2026-08-10** (same doc): one `DispatchCursor {seq, next, invocant, args}` replaces

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -218,67 +218,24 @@ impl Interpreter {
 
     /// Look up a `proto method` body for `method_name` in `class_name`'s MRO.
     /// Returns the nearest (owner_class, proto `FunctionDef`). Cheap no-op when
-    /// no proto methods are declared anywhere.
+    /// no proto methods are declared anywhere (ADR-0019 E8c: reads
+    /// `MethodEntry.proto` via `Registry::method_entry_proto`, one probe per
+    /// MRO level, guarded by the whole-program `Registry::has_proto_methods`
+    /// flag).
     pub(crate) fn lookup_proto_method(
         &mut self,
         class_name: &str,
         method_name: &str,
     ) -> Option<(String, FunctionDef)> {
-        if self.registry().proto_methods.is_empty() {
+        if !self.registry().has_proto_methods {
             return None;
         }
         let mro = self.class_mro(class_name);
-        let result = mro.iter().map(|s| s.resolve()).find_map(|cn| {
-            self.registry()
-                .proto_methods
-                .get(&(cn.clone(), method_name.to_string()))
-                .cloned()
-                .map(|f| (cn, f))
-        });
-        if crate::vm::vm_stats::enabled() {
-            self.shadow_check_proto_method(&mro, method_name, result.as_ref());
-        }
-        result
-    }
-
-    /// ADR-0019 E8b shadow probe (`MUTSU_VM_STATS`-gated, a no-op otherwise):
-    /// does the same MRO walk, read against the new `MethodEntry.proto`
-    /// column (`Registry::method_entry_proto`) instead of the legacy
-    /// standalone `proto_methods` table, find the same nearest proto body as
-    /// [`Self::lookup_proto_method`]'s real walk? Both tables are written
-    /// together by the single `Registry::set_proto_method` call site, so this
-    /// is expected to be a zero-mismatch measurement before `proto_methods`
-    /// is retired and `lookup_proto_method` is cut over to read
-    /// `method_entries` directly — see `todo/deep/
-    /// adr0019-e8-e11-candidate-sequence-semantics.md`'s E8b note. Compares
-    /// by owner name and body fingerprint (mirrors every other Phase E
-    /// winner-shadow probe, e.g. `Interpreter::shadow_check_resolver_chain`),
-    /// not `Option` equality — `FunctionDef` has no `PartialEq`.
-    fn shadow_check_proto_method(
-        &mut self,
-        mro: &[Symbol],
-        method_name: &str,
-        real: Option<&(String, FunctionDef)>,
-    ) {
-        let shadow = mro.iter().map(|s| s.resolve()).find_map(|cn| {
+        mro.iter().map(|s| s.resolve()).find_map(|cn| {
             self.registry()
                 .method_entry_proto(&cn, method_name)
                 .map(|f| (cn, f))
-        });
-        let matched = match (real, shadow.as_ref()) {
-            (None, None) => true,
-            (Some((ro, rf)), Some((so, sf))) => {
-                ro == so && rf.body_fingerprint() == sf.body_fingerprint()
-            }
-            _ => false,
-        };
-        crate::vm::vm_stats::record_proto_method_shadow_check(matched, || {
-            format!(
-                "method={method_name} real={:?} shadow={:?}",
-                real.map(|(o, _)| o.as_str()),
-                shadow.as_ref().map(|(o, _)| o.as_str()),
-            )
-        });
+        })
     }
 
     /// Run a `proto method` body, with `{*}` dispatching to the matching multi

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -60,13 +60,10 @@ pub(crate) struct MethodEntry {
     /// this is synced from).
     pub(crate) accessor: Option<bool>,
     /// `proto method`/`proto submethod` body declared directly on this
-    /// `(owner, name)` (ADR-0019 E8b): the `MethodEntry` fold of the
-    /// formerly-standalone `Registry::proto_methods` table. Written by
-    /// [`Registry::set_proto_method`] alongside `proto_methods` — shadow
-    /// mode: `proto_methods` stays the sole table `Interpreter::
-    /// lookup_proto_method` reads for real dispatch, this field is compared
-    /// against it under `MUTSU_VM_STATS` (`Interpreter::
-    /// shadow_check_proto_method`) before any cutover.
+    /// `(owner, name)` (ADR-0019 E8, folded from the formerly-standalone
+    /// `Registry::proto_methods` table in E8b/E8c). Written by
+    /// [`Registry::set_proto_method`]; read by `Interpreter::
+    /// lookup_proto_method`'s MRO walk via [`Registry::method_entry_proto`].
     pub(crate) proto: Option<FunctionDef>,
 }
 
@@ -273,11 +270,16 @@ pub(crate) struct Registry {
     pub(crate) proto_subs: HashSet<String>,
     /// `proto token`/`proto rule` declaration markers (existence set).
     pub(crate) proto_tokens: HashSet<String>,
-    /// `proto method`/`proto submethod` bodies: (class_name, method_name) ->
-    /// proto `FunctionDef`. When a multi method is dispatched and its class (or
-    /// an ancestor in the MRO) has a proto body here, the body runs first and
-    /// its `{*}` dispatches to the matching multi candidate.
-    pub(crate) proto_methods: HashMap<(String, String), FunctionDef>,
+    /// Whether ANY `proto method`/`proto submethod` has been declared
+    /// anywhere in the program (ADR-0019 E8c). A monotonic flag — proto
+    /// bodies are never unregistered — set by [`Registry::set_proto_method`]
+    /// and consulted by `Interpreter::lookup_proto_method` as a cheap
+    /// whole-program fast path (skip the MRO walk entirely when no class has
+    /// ever declared a proto method), the same role the now-retired
+    /// `proto_methods.is_empty()` check on the standalone table used to
+    /// play. The actual proto bodies live in `MethodEntry::proto`
+    /// (`method_entries`), read per-owner via [`Registry::method_entry_proto`].
+    pub(crate) has_proto_methods: bool,
 }
 
 impl Registry {
@@ -441,10 +443,7 @@ impl Registry {
     }
 
     /// Register a `proto method`/`proto submethod` body for `(class_name,
-    /// method_name)` (ADR-0019 E8b). Writes to both the legacy `proto_methods`
-    /// table (still the only one `Interpreter::lookup_proto_method` actually
-    /// reads for dispatch) and the new `MethodEntry.proto` column, so the two
-    /// can be shadow-compared before any cutover. Single call site
+    /// method_name)` (ADR-0019 E8, authoritative since E8c). Single call site
     /// (`registration_class_body.rs`'s `class_body_proto_method_decl`).
     pub(crate) fn set_proto_method(
         &mut self,
@@ -452,10 +451,6 @@ impl Registry {
         method_name: &str,
         def: FunctionDef,
     ) {
-        self.proto_methods.insert(
-            (class_name.to_string(), method_name.to_string()),
-            def.clone(),
-        );
         self.method_entries
             .entry(MethodEntryKey {
                 owner: Symbol::intern(class_name),
@@ -463,14 +458,15 @@ impl Registry {
             })
             .or_default()
             .proto = Some(def);
+        self.has_proto_methods = true;
         self.bump_method_generation();
     }
 
     /// The `MethodEntry.proto` column at exactly `(class_name, method_name)`
     /// — no MRO walk (the caller supplies the chain, mirroring how
-    /// `user_method_overloads` is a per-level, not per-chain, probe).
-    /// ADR-0019 E8b shadow-check helper for [`Interpreter::
-    /// shadow_check_proto_method`]; not read by real dispatch yet.
+    /// `user_method_overloads` is a per-level, not per-chain, probe). The
+    /// single read site for `Interpreter::lookup_proto_method`'s MRO walk
+    /// (ADR-0019 E8c).
     pub(crate) fn method_entry_proto(
         &self,
         class_name: &str,
@@ -1201,23 +1197,19 @@ mod tests {
         }
     }
 
-    /// ADR-0019 E8b: `set_proto_method` writes both the legacy `proto_methods`
-    /// table and the new `MethodEntry.proto` column, and both agree.
+    /// ADR-0019 E8c: `set_proto_method` populates the `MethodEntry.proto`
+    /// column (the sole store since the E8c cutover) and flips the
+    /// whole-program `has_proto_methods` fast-path flag.
     #[test]
-    fn set_proto_method_populates_both_the_legacy_table_and_method_entries() {
+    fn set_proto_method_populates_method_entries_and_the_fast_path_flag() {
         let mut registry = Registry::default();
         let seeded_generation = registry.method_generation;
+        assert!(!registry.has_proto_methods);
         let def = dummy_proto_def("Foo", "bar");
         registry.set_proto_method("Foo", "bar", def.clone());
         assert!(registry.method_generation > seeded_generation);
+        assert!(registry.has_proto_methods);
 
-        assert_eq!(
-            registry
-                .proto_methods
-                .get(&("Foo".to_string(), "bar".to_string()))
-                .map(FunctionDef::body_fingerprint),
-            Some(def.body_fingerprint())
-        );
         assert_eq!(
             registry
                 .method_entry_proto("Foo", "bar")
@@ -1229,7 +1221,7 @@ mod tests {
     /// `method_entry_proto` is a per-name probe (no MRO walk): a class that
     /// never declared its own proto method reports `None` even if an
     /// ancestor did — the MRO walk is the caller's job
-    /// (`Interpreter::lookup_proto_method`/`shadow_check_proto_method`).
+    /// (`Interpreter::lookup_proto_method`).
     #[test]
     fn method_entry_proto_is_scoped_to_the_exact_owner() {
         let mut registry = Registry::default();

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -648,40 +648,6 @@ pub(crate) fn record_deferral_shadow_check(matched: bool, detail: impl FnOnce() 
     }
 }
 
-// ADR-0019 Phase E box E8b (`todo/deep/adr0019-e8-e11-candidate-sequence-
-// semantics.md`): shadow comparison between `Interpreter::
-// lookup_proto_method`'s real MRO walk over the standalone `Registry::
-// proto_methods` table and the same walk read against the new `MethodEntry.
-// proto` column (`Registry::method_entry_proto`) both tables are written to
-// together by `Registry::set_proto_method`. A dedicated counter pair (not
-// `RESOLVER_SHADOW_*`) for the same reason every other Phase E probe family
-// gets its own pair: this measures one specific consolidation, not a general
-// resolver-winner comparison. Nothing reads these counters to make a
-// dispatch decision: shadow-only, zero behavior change.
-static PROTO_METHOD_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
-static PROTO_METHOD_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
-
-fn proto_method_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
-    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
-    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-/// Record one E8b proto-method shadow comparison. `detail` is only
-/// evaluated on a mismatch, mirroring [`record_deferral_shadow_check`].
-#[inline]
-pub(crate) fn record_proto_method_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
-    if !enabled() {
-        return;
-    }
-    PROTO_METHOD_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
-    if !matched {
-        PROTO_METHOD_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
-        if let Ok(mut map) = proto_method_shadow_mismatch_by_key().lock() {
-            *map.entry(detail()).or_insert(0) += 1;
-        }
-    }
-}
-
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1229,27 +1195,6 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e8a deferral-shadow mismatches (top {}): {}",
-            top.len(),
-            top.join(" ")
-        );
-    }
-    let proto_method_shadow_checks = PROTO_METHOD_SHADOW_CHECKS.load(Ordering::Relaxed);
-    let proto_method_shadow_mismatches = PROTO_METHOD_SHADOW_MISMATCHES.load(Ordering::Relaxed);
-    eprintln!(
-        "[mutsu vm-stats] adr0019-e8b: proto_method_shadow_checks={proto_method_shadow_checks} proto_method_shadow_mismatches={proto_method_shadow_mismatches}"
-    );
-    if let Ok(map) = proto_method_shadow_mismatch_by_key().lock()
-        && !map.is_empty()
-    {
-        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
-        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
-        let top: Vec<String> = entries
-            .iter()
-            .take(25)
-            .map(|(name, count)| format!("{name}={count}"))
-            .collect();
-        eprintln!(
-            "[mutsu vm-stats] adr0019-e8b proto-method-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );

--- a/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
+++ b/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
@@ -405,3 +405,73 @@ its own slice rather than folded into this one — matching E1a→E1b's two-step
 cutover changes what real dispatch reads even when the measurement backing it is clean. After
 E8c, the next Phase E box is **E9-pre**: the mandatory raku verification campaign for
 `samewith`/`nextsame`/`callsame`/`nextwith` cursor semantics (design decision 3 above) — 拙速厳禁.
+
+## E8c: proto-method cutover — `Registry::proto_methods` retired, `E8` closes
+
+Landed 2026-08-12, immediately after E8b. Recovers the slice plan's original E8b text ("proto
+methods into `MethodEntry`; `lookup_proto_method` deleted") now that E8b's shadow measurement
+(171+24 checks, 0 mismatches across both a `t/` sweep and a roast slice) made the cutover a
+same-answer swap rather than a guess, matching how E1b cashed in E1a's `TypeId` shadow column.
+
+**The cutover itself.** `Interpreter::lookup_proto_method`'s real MRO walk (`dispatch_proto.rs`)
+now calls `Registry::method_entry_proto` per MRO level directly — exactly the loop body E8b's
+`shadow_check_proto_method` was already running, just promoted from shadow to real. The
+standalone `proto_methods: HashMap<(String, String), FunctionDef>` field is deleted from
+`Registry` outright, not kept as a secondary/debug store: `git grep -n "proto_methods" src/`
+before the change showed exactly two readers (the real walk and its own shadow probe, both in
+`dispatch_proto.rs`, both now gone or rewritten) and one writer (`Registry::set_proto_method`).
+No `.^methods`/`.^lookup`/`.^find_method`/other MOP introspection call site ever read
+`proto_methods` — those all resolve through `method_entries`'s `user_candidates`/`builtin`
+columns for their own purposes and never needed a separate proto lookup — so there was no
+"something else still legitimately needs it" case to preserve; the table was genuinely dead
+once its two readers moved off it.
+
+**Fast-path replacement.** The old `proto_methods.is_empty()` check let
+`lookup_proto_method` skip the MRO walk entirely for the (common) case where no class in the
+whole program has ever declared a proto method. Since `method_entries` has no single cheap
+"any row has `.proto` set" query, this is replaced by a new field, `Registry::
+has_proto_methods: bool`, flipped to `true` once by `set_proto_method` and never reset — proto
+bodies are never unregistered in mutsu (no equivalent of removing a method from a class at
+runtime), so a monotonic flag is sound and cheaper than a counter or a second set.
+
+**Probe teardown.** `shadow_check_proto_method` and the `PROTO_METHOD_SHADOW_CHECKS`/
+`_MISMATCHES` counter pair (`vm_stats.rs`), including their `adr0019-e8b` stats-report lines,
+are deleted. This mirrors E1b's own teardown of E1a's probes at each site E1b cut over: once
+the shadow answer IS the real answer, comparing them is comparing a value to itself.
+
+**Tests.** Two `registry.rs` unit tests updated: `set_proto_method_populates_both_the_legacy_
+table_and_method_entries` renamed to `set_proto_method_populates_method_entries_and_the_fast_
+path_flag` and rewritten to assert against `method_entries`/`has_proto_methods` instead of the
+retired table (plus a new assertion that the flag starts `false` and flips `true`);
+`method_entry_proto_is_scoped_to_the_exact_owner` unchanged (it only ever read the new column).
+No new `t/` test: this is a same-answer read-path swap with nothing new to pin, and the existing
+proto-method suite already exercises plain-class, inherited, and role-composed proto shapes
+end to end (10 files, 72 assertions: `t/proto-method-body.t`, `t/proto-method-rw-redispatch.t`,
+`t/proto-cross-module-invocant.t`, `t/handles-proto-dispatch-mut-invocant.t`, `t/proto-multi-
+captured-writeback-coherence.t`, `t/proto-new-no-match.t`, `t/proto-multi-method-role-
+composition.t`, `t/multi-udismiley-ambiguity-leak.t`, `t/role-ud-multi-dispatch.t`, `t/qualified-
+mu-coercion.t`) and stayed green through the cutover.
+
+**Verification.** `cargo build`/`cargo clippy -- -D warnings`/`cargo fmt --check` clean; `cargo
+test --lib` (814 tests, same count as E8b — one rename, no net add/remove) and the full local
+`make test` (3074 files / 28683 tests) green. Per CLAUDE.md's "touched name/type resolution"
+rule — this changes a real dispatch read path even though the risk was already retired by
+measurement — a local roast slice (the same 16-file list E8a/E8b used:
+`S06-multi/{proto,type-based,syntax,redispatch}`, `S12-methods/{defer-next,defer-call,lastcall,
+multi,parallel-dispatch}`, `S06-advanced/{callsame,dispatching,wrap}`, `6.c/S12-class/mro-6c`,
+`S12-class/{inheritance,basic}`, `6.c/S14-roles/mixin-6c`) found 524 assertions, all green.
+
+**E8 closes.** E8a + E8b + E8c together deliver everything this box's own text scoped:
+candidates carry `level`/`stored_idx` so winner selection and deferral order both derive from
+one sequence (E8a); `Registry::proto_methods` has folded into `MethodEntry` and the standalone
+table is gone (E8b structural + E8c cutover); the method-vs-sub ranking ladders stayed
+deliberately unmerged, as designed from the start. The one item E8a's own sweep found but did
+NOT fix — `resolve_sequence`'s per-level lookup silently missing an un-punned role's own method
+(`todo/deep/method-entries-never-covers-unpunned-roles.md`) — remains open, but lives in a
+different lookup path (`user_method_overloads`) that neither E8b nor E8c touched; it is not part
+of E8's own closing scope.
+
+**Next Phase E box: E9-pre.** The mandatory raku verification campaign for `samewith`/
+`nextsame`/`callsame`/`nextwith` cursor semantics (design decision 3 above), flagged as the
+highest-semantic-risk box of the whole phase (拙速厳禁). It needs its own dedicated session —
+not a tail slice bolted onto E8c — and must land before any E9a/b/c cursor-cutover work starts.


### PR DESCRIPTION
## Summary

- ADR-0019 Phase E box E8, sub-slice E8c (the cutover, deferred from E8b #6320): `Interpreter::lookup_proto_method`'s real MRO walk now reads `Registry::method_entry_proto` (backed by `MethodEntry.proto` on `method_entries`) directly, instead of the standalone `Registry::proto_methods: HashMap<(String, String), FunctionDef>` table.
- `proto_methods` is deleted outright (confirmed via `git grep` to have no reader/writer left once the walk and its shadow probe moved off it) rather than kept as a secondary store.
- Its whole-program "skip the MRO walk when nothing declares a proto anywhere" fast path is replaced by a new monotonic `Registry::has_proto_methods: bool` flag, set once by `set_proto_method`.
- The now-redundant `shadow_check_proto_method` probe and its `PROTO_METHOD_SHADOW_CHECKS`/`_MISMATCHES` counters (`vm_stats.rs`) are deleted -- E8b already measured zero mismatches (171+24 checks) between the two lookups, so nothing is left to shadow-check.
- **E8 closes as a whole** (E8a + E8b + E8c). Next Phase E box: **E9-pre**, the mandatory raku verification campaign for `samewith`/`nextsame`/`callsame`/`nextwith` cursor semantics -- flagged as the highest-semantic-risk box of the phase, deliberately left for its own dedicated session.

Full detail in `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (E8c progress note + E8 closing summary) and `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` (`## E8c:` section).

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean
- [x] `cargo test --lib` -- 814 tests green (two registry unit tests updated for the new shape)
- [x] Full local `make test` -- 3074 files / 28683 tests green
- [x] Local roast slice touching proto/multi/wrap dispatch (16 files, 524 assertions): `S06-multi/{proto,type-based,syntax,redispatch}`, `S12-methods/{defer-next,defer-call,lastcall,multi,parallel-dispatch}`, `S06-advanced/{callsame,dispatching,wrap}`, `6.c/S12-class/mro-6c`, `S12-class/{inheritance,basic}`, `6.c/S14-roles/mixin-6c` -- all green
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)