### PR TITLE
test(adr0019): E9-pre -- raku ground-truth campaign for deferral cursor semantics

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3847,6 +3847,20 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   sequence tail entries; proto `{*}` re-ranks the cursor's sequence instead of re-entering by
   name. **A mandatory raku verification campaign (E9-pre, 13 chain-order scenarios) lands as
   `t/` pins before any cursor cutover** — this is the highest-semantic-risk box of the phase.
+  **Progress 2026-08-12 — E9-pre landed (docs + pins only, no cursor code).** Every scenario
+  probed against Rakudo v2026.06 first; 12 new `t/` pins (38 assertions) each verified green
+  under BOTH `prove -e raku` and mutsu, so the pins encode raku's answer; 8 divergences filed
+  as tickets, none encoded into design. **Headline: the campaign falsified a design-2
+  assumption** — when multi candidates span MRO levels, raku defers along the
+  specificity-RANKED merged candidate list (implicit proto clones the nearest MRO proto;
+  plain middle methods are later outer-chain entries that re-enter lower protos on deferral),
+  not mutsu's `(level, decl-order)` walk. The cursor's sequence layout must be re-drawn
+  against `todo/deep/defer-chain-ranked-multi-order.md` (design task) **before E9a starts**.
+  Other divergence tickets: role-shadowed method wrongly in the chain, explicit child proto
+  wrongly assuming parent candidates, `is Array` native-push fallback not pushing, method-wrap
+  `unwrap`/`restore` no-op, `lastcall`-in-wrapper killing the dispatcher scope, callsame to
+  native Mu methods (gist/Str/raku/new) yielding Nil/Any, and a cosmetic Signature.gist
+  invocant format. Full scenario table in the E8-E11 design doc's E9-pre section.
 - [ ] **E10 — Move wrap/unwrap mutation into canonical entries.** Bump the generation and remove
   wrap-specific cache-clearing paths.
   **Design 2026-08-10** (same doc): `method_wrap_chains` moves into the registry; every

--- a/news/2026-08/adr0019-e9pre-verification-campaign.md
+++ b/news/2026-08/adr0019-e9pre-verification-campaign.md
@@ -1,0 +1,36 @@
+# ADR-0019 E9-pre: the raku ground-truth campaign for dispatch-deferral semantics
+
+Ran the mandatory pre-E9 verification campaign (ADR-0019 Phase E, design decision 3 in
+`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) as its own dedicated session: every
+`samewith`/`nextsame`/`callsame`/`nextwith`/`lastcall`/wrap/proto chain-order scenario was
+probed against real raku (Rakudo v2026.06) before any conclusion was drawn, matching behaviors
+were pinned, divergences were ticketed, and no cursor implementation code was written.
+
+Deliverables:
+
+- **12 new `t/` pins (38 assertions)**, each verified to pass under BOTH `prove -e raku` and
+  `prove -e target/debug/mutsu` — so the pins provably encode raku's answer, not mutsu's:
+  `defer-multi-single-class`, `defer-inherited-chain`, `defer-multi-plain-cross-level`,
+  `grammar-parse-override-defer`, `method-wrap-callsame-order`, `wrap-multi-candidate-scope`,
+  `wrap-mid-mro-callsame`, `lastcall-then-nextsame`, `samewith-restart-from-top`,
+  `callwith-rw-passthrough`, `proto-star-cross-mro-candidates`, `build-callsame-nil`.
+- **8 divergence findings filed as tickets** (1 deep + 7 tickets), the headline being
+  `todo/deep/defer-chain-ranked-multi-order.md`: when multi candidates span MRO levels, raku
+  defers along the specificity-ranked MERGED candidate list (an implicit proto clones the
+  nearest MRO proto; a plain method in a middle MRO level is a later outer-chain entry whose
+  own deferral re-enters lower protos — a parent candidate can legitimately run twice), while
+  mutsu walks `(MRO level, declaration order)`. This falsified the E9 cursor design's stated
+  assumption that today's "remaining = signature-matching candidates in MRO order" semantics
+  were the target — design decision 2 is amended in place, and E9a is blocked on re-drawing the
+  cursor's sequence layout against the raku model.
+- The other tickets: class-overridden `does`-role methods must not be in the chain (this also
+  re-opens E8a's "real walker is authoritative" attribution of its 58 accepted shadow
+  mismatches), an explicit child proto must not assume parent candidates, the `is Array` native
+  push fallback appends nothing, method-wrap `unwrap`/`restore` are no-ops, `lastcall` inside a
+  wrapper kills the dispatcher scope, callsame from gist/Str/raku/new overrides never reaches
+  the native Mu implementations, and a cosmetic `Signature.gist` invocant-format difference.
+
+The full scenario-by-scenario table (a-m plus bonus probes, verdict and artifact per row) lives
+in the E9-pre section of `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`, and the
+ADR's E9 checkbox carries the progress note. Next up in Phase E: the decision-2 re-draw, then
+E9a (method frames → cursor).

--- a/t/build-callsame-nil.t
+++ b/t/build-callsame-nil.t
@@ -1,0 +1,13 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# BUILDALL runs BUILD submethods parent-first; callsame inside a BUILD submethod
+# finds no next candidate (submethods do not inherit) and returns Nil.
+
+plan 1;
+
+my @ev;
+class P { submethod BUILD() { @ev.push("P") } }
+class C is P { submethod BUILD() { @ev.push("C"); my $r = callsame; @ev.push("got({$r // 'Nil'})") } }
+C.new;
+is @ev.join("|"), "P|C|got(Nil)", "parent-first BUILD order; callsame in BUILD yields Nil";

--- a/t/callwith-rw-passthrough.t
+++ b/t/callwith-rw-passthrough.t
@@ -1,0 +1,25 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# callwith/nextwith re-bind args but keep `is rw` containers live (a parent's
+# assignment writes back to the caller's variable), and callwith continues with
+# the NEXT candidate rather than restarting.
+
+plan 5;
+
+class P { method m($x is rw) { $x = 99; "p" } }
+class C is P { method m($x is rw) { my $r = callwith($x); "c-$r" } }
+my $v = 1;
+is C.new.m($v), "c-p", "callwith passes the parent's return back";
+is $v, 99, "rw container survives callwith re-binding";
+
+class C2 is P { method m($x is rw) { nextwith($x) } }
+my $w = 5;
+is C2.new.m($w), "p", "nextwith passes the return through";
+is $w, 99, "rw container survives nextwith re-binding";
+
+class Q {
+    multi method m(Int $x) { my $r = callwith($x + 1); "q-$r" }
+    multi method m(Any $x) { "any-$x" }
+}
+is Q.new.m(10), "q-any-11", "callwith advances to the NEXT candidate with new args";

--- a/t/defer-inherited-chain.t
+++ b/t/defer-inherited-chain.t
@@ -1,0 +1,20 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# callsame/nextsame walk a plain-method inheritance chain in MRO order; the top of
+# the user chain (no same-name parent method) yields Nil.
+
+plan 4;
+
+my @ev;
+class GP { method m() { @ev.push("GP"); "gp" } }
+class P is GP { method m() { @ev.push("P"); my $r = callsame; @ev.push("P-got($r)"); "p" } }
+class C is P { method m() { @ev.push("C"); my $r = callsame; @ev.push("C-got($r)"); "c" } }
+is C.new.m, "c", "3-level callsame returns receiver's own result";
+is @ev.join("|"), "C|P|GP|P-got(gp)|C-got(p)", "callsame chain order C -> P -> GP";
+
+class C3 is GP { method m() { nextsame } }
+is C3.new.m, "gp", "nextsame passes the parent's return value through";
+
+class Solo { method only() { my $r = callsame; $r // "was-nil" } }
+is Solo.new.only, "was-nil", "callsame at the top of the chain returns Nil";

--- a/t/defer-multi-plain-cross-level.t
+++ b/t/defer-multi-plain-cross-level.t
@@ -1,0 +1,24 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# a multi candidate in the child defers to a PLAIN same-name method in the parent,
+# and a plain child method defers into the parent's multi set (narrowest wins).
+# (The both-levels-multi ordering case deliberately has NO pin here: mutsu still
+# diverges from raku there — see todo/deep/defer-chain-ranked-multi-order.md.)
+
+plan 4;
+
+my @ev;
+class P { method m($x) { @ev.push("P"); "p" } }
+class C is P { multi method m(Int $x) { @ev.push("C:Int"); my $r = callsame; "c-$r" } }
+is C.new.m(1), "c-p", "multi child defers to the plain parent method";
+is @ev.join("|"), "C:Int|P", "multi-child -> plain-parent order";
+
+my @ev2;
+class P2 {
+    multi method m(Int $x) { @ev2.push("P2:Int"); "p2-int" }
+    multi method m(Any $x) { @ev2.push("P2:Any"); "p2-any" }
+}
+class C2 is P2 { method m($x) { @ev2.push("C2"); my $r = callsame; "c2-$r" } }
+is C2.new.m(1), "c2-p2-int", "plain child defers into the parent's multi set";
+is @ev2.join("|"), "C2|P2:Int", "narrowest parent candidate is chosen by the deferral";

--- a/t/defer-multi-single-class.t
+++ b/t/defer-multi-single-class.t
@@ -1,0 +1,31 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# nextsame/callsame walk multi candidates of one class narrowest-first, code after
+# nextsame never runs, and an exhausted chain yields Nil.
+
+plan 4;
+
+my @ev;
+class A {
+    multi method m(Int $x) { @ev.push("Int($x)"); nextsame; @ev.push("Int-after") }
+    multi method m(Cool $x) { @ev.push("Cool($x)"); nextsame; @ev.push("Cool-after") }
+    multi method m(Any $x) { @ev.push("Any($x)") }
+}
+A.new.m(42);
+is @ev.join("|"), "Int(42)|Cool(42)|Any(42)",
+    "nextsame walks Int -> Cool -> Any; code after nextsame never runs";
+
+class B {
+    multi method m(Int $x) { my $r = callsame; "int:" ~ ($r // "Nil") }
+    multi method m(Any $x) { "b-any" }
+}
+is B.new.m(1), "int:b-any", "callsame returns the next candidate's value";
+
+my @ev2;
+class C2 {
+    multi method m(Int $x) { @ev2.push("Int"); nextsame; @ev2.push("after") }
+}
+my $r = C2.new.m(7);
+ok !$r.defined, "nextsame with no next candidate returns Nil";
+is @ev2.join("|"), "Int", "code after a no-next nextsame does not run";

--- a/t/grammar-parse-override-defer.t
+++ b/t/grammar-parse-override-defer.t
@@ -1,0 +1,23 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# a Grammar .parse override reaches the real parse via callsame/nextsame and the
+# Match flows back through the deferral.
+
+plan 4;
+
+grammar G {
+    token TOP { (\d+) }
+    method parse(|c) { my $m = callsame; $m }
+}
+my $m = G.parse("123");
+ok ?$m, "callsame in a parse override reaches the real parse";
+is ~$m, "123", "match text flows back through callsame";
+
+grammar G2 {
+    token TOP { \w+ }
+    method parse(|c) { nextsame }
+}
+my $m2 = G2.parse("abc");
+ok ?$m2, "nextsame in a parse override reaches the real parse";
+is ~$m2, "abc", "match text flows back through nextsame";

--- a/t/lastcall-then-nextsame.t
+++ b/t/lastcall-then-nextsame.t
@@ -1,0 +1,16 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# lastcall empties the deferral chain, so a following nextsame finds nothing, the
+# call yields Nil, and neither the wider candidate nor post-nextsame code runs.
+
+plan 2;
+
+my @ev;
+class D {
+    multi method m(Int $x) { @ev.push("Int"); lastcall; nextsame; @ev.push("after") }
+    multi method m(Any $x) { @ev.push("Any"); "d-any" }
+}
+my $r = D.new.m(1);
+ok !$r.defined, "nextsame after lastcall returns Nil";
+is @ev.join("|"), "Int", "lastcall truncates the chain; nothing after runs";

--- a/t/method-wrap-callsame-order.t
+++ b/t/method-wrap-callsame-order.t
@@ -1,0 +1,18 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# callsame inside a method wrapper reaches the original; the most recently applied
+# wrapper is outermost.
+
+plan 3;
+
+my @ev;
+class C { method m($x) { @ev.push("orig($x)"); "orig" } }
+C.^lookup('m').wrap(-> |c { @ev.push("w1-in"); my $r = callsame; @ev.push("w1-out($r)"); "w1-$r" });
+is C.new.m(5), "w1-orig", "wrapper composes its result with the original's";
+
+C.^lookup('m').wrap(-> |c { @ev.push("w2-in"); my $r = callsame; @ev.push("w2-out($r)"); "w2-$r" });
+@ev = ();
+is C.new.m(6), "w2-w1-orig", "most recently applied wrapper runs outermost";
+is @ev.join("|"), "w2-in|w1-in|orig(6)|w1-out(orig)|w2-out(w1-orig)",
+    "double-wrap event order";

--- a/t/proto-star-cross-mro-candidates.t
+++ b/t/proto-star-cross-mro-candidates.t
@@ -1,0 +1,24 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# a proto declared in a PARENT governs multi candidates added by a child class
+# (the child's implicit proto clones the parent's), and nextsame walks between
+# candidates under an explicit proto.
+
+plan 3;
+
+my @ev;
+class P2 {
+    proto method n($x) { @ev.push("proto({$x})"); my $r = {*}; "P-$r" }
+    multi method n(Int $x) { @ev.push("Int"); "p2-int" }
+}
+class C2 is P2 { multi method n(Str $x) { @ev.push("Str"); "c2-str" } }
+is C2.new.n(1), "P-p2-int", "parent proto body governs the parent candidate";
+is C2.new.n("a"), "P-c2-str", "parent proto body governs a child-added candidate";
+
+class D {
+    proto method p($x) { {*} }
+    multi method p(Int $x) { nextsame }
+    multi method p(Any $x) { "d-any" }
+}
+is D.new.p(3), "d-any", "nextsame between candidates under an explicit proto";

--- a/t/samewith-restart-from-top.t
+++ b/t/samewith-restart-from-top.t
@@ -1,0 +1,21 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# samewith re-runs the dispatch from the top with new args — including when called
+# from a candidate that was itself reached via nextsame.
+
+plan 3;
+
+class C {
+    multi method m(Int $x) { my $r = samewith("hello"); "int-$r" }
+    multi method m(Str $x) { "str" }
+}
+is C.new.m(42), "int-str", "samewith with new args restarts dispatch from the top";
+
+my @ev;
+class D {
+    multi method m(Int $x) { @ev.push("Int"); nextsame }
+    multi method m(Any $x) { @ev.push("Any({$x.^name})"); $x ~~ Int ?? samewith("s") !! "any-done" }
+}
+is D.new.m(3), "any-done", "samewith from a nextsame-reached candidate restarts at the top";
+is @ev.join("|"), "Int|Any(Int)|Any(Str)", "restart re-enters the ranked list from the top";

--- a/t/wrap-mid-mro-callsame.t
+++ b/t/wrap-mid-mro-callsame.t
@@ -1,0 +1,19 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# a wrap applied mid-MRO (on the parent's method) is entered when the child's
+# callsame walks up; a wrap on the child wraps only the child's own entry.
+
+plan 3;
+
+my @ev;
+class P { method m() { @ev.push("P"); "p" } }
+class C is P { method m() { @ev.push("C"); my $r = callsame; "c-$r" } }
+P.^lookup('m').wrap(-> |c { @ev.push("Pw-in"); my $r = callsame; "pw-$r" });
+is C.new.m, "c-pw-p", "callsame from the child reaches the parent's wrapper first";
+is @ev.join("|"), "C|Pw-in|P", "mid-MRO wrap event order";
+
+class P2 { method m() { "p2" } }
+class C2 is P2 { method m() { my $r = callsame; "c2-$r" } }
+C2.^lookup('m').wrap(-> |c { my $r = callsame; "cw-$r" });
+is C2.new.m, "cw-c2-p2", "wrap on child: wrapper -> child body -> callsame to parent";

--- a/t/wrap-multi-candidate-scope.t
+++ b/t/wrap-multi-candidate-scope.t
@@ -1,0 +1,16 @@
+use Test;
+
+# ADR-0019 E9-pre ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# wrapping one multi candidate (via .^lookup(...).candidates) affects only that
+# candidate's dispatch; sibling candidates are untouched. Candidate order is
+# declaration order.
+
+plan 2;
+
+class C {
+    multi method m(Int $x) { "int" }
+    multi method m(Str $x) { "str" }
+}
+C.^lookup('m').candidates[0].wrap(-> |c { my $r = callsame; "w-$r" });
+is C.new.m(1), "w-int", "wrapping candidate 0 (Int) wraps Int dispatch";
+is C.new.m("a"), "str", "sibling candidate is unaffected by the wrap";

--- a/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
+++ b/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
@@ -475,3 +475,75 @@ of E8's own closing scope.
 `nextsame`/`callsame`/`nextwith` cursor semantics (design decision 3 above), flagged as the
 highest-semantic-risk box of the whole phase (拙速厳禁). It needs its own dedicated session —
 not a tail slice bolted onto E8c — and must land before any E9a/b/c cursor-cutover work starts.
+
+## E9-pre: the raku ground-truth campaign ran — 12 pins, 8 divergence findings, and design decision 2 is AMENDED
+
+Landed 2026-08-12 as its own dedicated session, exactly per decision 3's mandate: every scenario
+was probed against real raku (Rakudo v2026.06) FIRST, matching behaviors were pinned as `t/`
+tests (each pin verified to pass under BOTH `prove -e raku` and `prove -e target/debug/mutsu` —
+so the pins provably encode raku's answer, not mutsu's), and every divergence became a ticket —
+no divergence was encoded into cursor semantics, and no cursor code was written.
+
+### Scenario table (a-m from decision 3, plus bonus probes)
+
+| # | scenario | verdict | artifact |
+|---|----------|---------|----------|
+| a | nextsame/callsame through multi candidates in one class; no-next → Nil; post-nextsame code unreachable | MATCH | `t/defer-multi-single-class.t` |
+| b | callsame/nextsame through inherited plain methods (3 levels); top-of-chain → Nil | MATCH | `t/defer-inherited-chain.t` |
+| c | `does`-composed role method overridden by the class: raku EXCLUDES it from the chain (plain and same-sig multi both get Nil); mutsu walks the role's raw copy | DIVERGE | `todo/tickets/role-shadowed-method-in-defer-chain.md` |
+| d | `is Array` subclass `push` override → nextsame/callsame to native push: raku appends + returns self; mutsu appends nothing, callsame returns Any | DIVERGE | `todo/tickets/native-array-push-defer-fallback-broken.md` |
+| e | Grammar `.parse` override: callsame/nextsame reach the real parse, Match flows back | MATCH | `t/grammar-parse-override-defer.t` |
+| f | callsame in a method wrapper; double wrap = newest outermost | MATCH | `t/method-wrap-callsame-order.t` |
+| f' | …but method-wrap REMOVAL: `$handle.restore` silently no-ops, `.unwrap($h)` throws | DIVERGE | `todo/tickets/method-wrap-unwrap-restore-noop.md` |
+| g | wrap on ONE multi candidate (`.candidates[0].wrap`) scopes to that candidate; declaration-order candidate list | MATCH | `t/wrap-multi-candidate-scope.t` |
+| h | mid-MRO wrap: child's callsame enters the parent's wrapper first; wrap-on-child composes wrapper → child body → parent | MATCH | `t/wrap-mid-mro-callsame.t` |
+| i | `lastcall` inside a wrapper then callsame: raku → Nil (original never runs); mutsu dies "callsame is not in the dynamic scope of a dispatcher" | DIVERGE | `todo/tickets/lastcall-in-wrapper-callsame-dies.md` |
+| i' | `lastcall` then nextsame in a plain multi → Nil, nothing else runs | MATCH | `t/lastcall-then-nextsame.t` |
+| j | samewith restarts from the top with new args, incl. from a nextsame-reached candidate | MATCH | `t/samewith-restart-from-top.t` |
+| k | callwith/nextwith keep `is rw` containers live through re-binding; callwith advances (not restarts) | MATCH | `t/callwith-rw-passthrough.t` |
+| l | EXPLICIT proto in a child: `{*}` does NOT assume parent candidates (raku: X::Multi::NoMatch; mutsu: resolves the parent's) | DIVERGE | `todo/tickets/explicit-child-proto-assumes-parent-candidates.md` |
+| l' | proto in the PARENT governs child-added candidates; nextsame under an explicit proto | MATCH | `t/proto-star-cross-mro-candidates.t` |
+| m | BUILDALL parent-first; callsame inside a BUILD submethod → Nil | MATCH | `t/build-callsame-nil.t` |
+| + | multi child ↔ plain parent cross-level deferral (both directions) | MATCH | `t/defer-multi-plain-cross-level.t` |
+| + | **multi candidates at BOTH levels: chain order** (see below) | **DIVERGE** | `todo/deep/defer-chain-ranked-multi-order.md` |
+| + | callsame from overrides of built-in Mu methods (gist/Str/raku/new) → raku reaches the native impl; mutsu gets Nil/Any | DIVERGE | `todo/tickets/callsame-to-native-mu-methods-nil.md` |
+| + | Signature.gist invocant rendering `(C $:: ...)` vs `(C:, ...)` (cosmetic) | DIVERGE | `todo/tickets/signature-gist-invocant-format.md` |
+
+12 pin files, 38 assertions, all green under raku AND mutsu; `runtime mixin (but R)` was also
+spot-checked (match; already covered by `t/nextsame-role-mixin.t`).
+
+### THE headline finding — design decision 2 is amended
+
+Decision 2 above says the cursor should advance "applying the per-call signature filter as they
+go (matching today's 'remaining = signature-matching candidates in MRO order' semantics)".
+**That target is wrong: today's mutsu order itself diverges from raku whenever multi candidates
+span MRO levels.** raku's model (full derivation and probes in
+`todo/deep/defer-chain-ranked-multi-order.md`) is two-level:
+
+- The outer chain is per-class entries along the MRO (plain method or proto).
+- An IMPLICIT proto clones the nearest MRO proto and merges parent candidates into one
+  **specificity-ranked** list (MRO breaks ties); nextsame/callsame walk that ranked list first
+  and fall to the outer chain's next per-class entry only when it is exhausted. A plain method
+  in a middle MRO level is NOT part of the ranked list — it is a later outer-chain entry, and
+  deferring from it re-enters protos below it (so a parent multi candidate can legitimately run
+  twice in one call).
+- An EXPLICIT proto declared in a child does NOT assume parent candidates (finding l).
+
+Consequences for E9a/b/c: the `DispatchCursor`'s sequence for the multi portion must be the
+ranked merged list plus outer-chain fall-through (not the E4 `ResolvedSequence`'s flat
+`(level, stored_idx)` order), and `samewith`'s "re-run the ranker over the same sequence" in
+decision 2 stays correct as written. **E9a must not start until the cursor design is re-drawn
+against `defer-chain-ranked-multi-order.md`** — that re-draw is a design task (amend decision 2
+in this doc with the concrete sequence layout), not an implementation detail to discover
+mid-cutover.
+
+### Interaction with the E8a accepted divergence
+
+E8a's 58 accepted deferral-shadow mismatches were attributed to `method_entries` missing
+un-punned role owners, treating the REAL walker (`resolve_all_methods_with_owner`, which reads
+`registry().roles` directly) as authoritative. Finding (c) shows that for the
+class-overridden-role shape, raku agrees with the SEQUENCE side (role method absent), not the
+real walker. The reconciliation note is in `todo/tickets/role-shadowed-method-in-defer-chain.md`
+and cross-linked from `todo/deep/method-entries-never-covers-unpunned-roles.md`'s fix plan: that
+sweep's mismatch ledger must be re-audited against raku per-shape, not resolved wholesale toward
+the real walker.

--- a/todo/deep/defer-chain-ranked-multi-order.md
+++ b/todo/deep/defer-chain-ranked-multi-order.md
@@ -1,0 +1,90 @@
+# Deferral chain order for multi methods diverges from raku: ranked merged candidate list, not (MRO level, decl order)
+
+Found by the ADR-0019 E9-pre raku verification campaign (2026-08-12, Rakudo v2026.06). This is
+the highest-impact finding of the campaign: it invalidates a stated assumption of E9's cursor
+design (design decision 2 in `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` says the
+cursor should match "today's 'remaining = signature-matching candidates in MRO order' semantics"
+— but today's mutsu semantics are themselves wrong for multis; the cursor must implement raku's
+model instead).
+
+## The divergence
+
+When multi candidates for one method name exist at MORE THAN ONE MRO level, raku's
+`nextsame`/`callsame` deferral order is the **globally ranked (specificity-sorted) merged
+candidate list**, with MRO position only as a tie-break — NOT mutsu's "walk MRO levels outward,
+declaration order within a level, filtered by signature match".
+
+Minimal repro (raku left, mutsu right):
+
+```raku
+class P3 { multi method m(Int $x) { say "P3:Int"; "p3-int" } }
+class C3 is P3 {
+    multi method m(Int $x) { say "C3:Int"; nextsame; say "C3:unreached" }
+    multi method m(Any $x) { say "C3:Any"; my $r = callsame; say "got({$r // 'Nil'})"; "c3-any" }
+}
+say C3.new.m(1);
+# raku:  C3:Int -> P3:Int -> "p3-int"        (both Int candidates outrank C3:Any)
+# mutsu: C3:Int -> C3:Any -> P3:Int -> "c3-any"  (level 0 exhausted first)
+```
+
+## The raku model (confirmed by probes, all consistent)
+
+Method dispatch/deferral is **two-level**:
+
+1. An **outer chain** of per-class entries found along the MRO: each entry is the method object
+   installed at that class — either a plain method or a proto (explicit or implicit).
+2. When a class declares `multi method` without its own explicit proto, the **implicit proto
+   clones the nearest proto found in the MRO** and merges the parent's candidates with its own;
+   the merged list is **ranked by narrowness** (specificity), MRO order breaking ties.
+   `nextsame`/`callsame` from a multi candidate first walk the REST OF THAT RANKED LIST; only
+   when it is exhausted do they fall to the outer chain's next entry (the next per-class entry
+   AFTER the proto's own class).
+
+Consequences verified by probe (`tmp/e9pre/probe-mix.raku`, `probe-mix2.raku` during the
+campaign):
+
+- Both-levels-multi: chain is `[C:Int, P:Int, C:Any]` (ranked), not `[C:Int, C:Any, P:Int]`.
+- Plain method in the MIDDLE of the MRO (`A2` has `multi m(Int)`, `B2 is A2` has plain `m`,
+  `C2b is B2` has `multi m(Int)`): raku runs `C2b:Int -> A2:Int -> B2::m -> A2:Int (again) ->
+  Nil`. The child's implicit proto merged A2's candidate (skipping over B2's plain entry, which
+  is not a multi candidate), so A2:Int is reached FIRST via the ranked list; exhausting the list
+  falls to the outer chain entry after C2b, which is B2's plain method; B2::m's own callsame then
+  starts the walk BELOW B2, re-entering A2's proto — so **A2:Int legitimately runs twice**.
+  mutsu runs `C2b:Int -> B2::m -> A2:Int -> Nil` (strict MRO interleave, no re-visit).
+- Cases where the two models agree (single level; multi child + plain parent; plain child +
+  parent multi set; all-plain chains) are pinned by `t/defer-multi-single-class.t`,
+  `t/defer-multi-plain-cross-level.t`, `t/defer-inherited-chain.t`. The DIVERGING shapes are
+  deliberately NOT pinned yet — the pin lands with the fix.
+
+Related same-model findings, ticketed separately: an explicit child proto must NOT assume parent
+candidates (`todo/tickets/explicit-child-proto-assumes-parent-candidates.md`), and a
+class-overridden `does`-composed role method must not appear in the chain at all
+(`todo/tickets/role-shadowed-method-in-defer-chain.md`).
+
+## Affected mutsu code
+
+- `resolve_all_methods_with_owner` (`src/runtime/resolution_method.rs`) — the deferral-list
+  walker: walks MRO levels outward, declaration order within a level, signature-filtered. This
+  produces the wrong order whenever multi candidates span levels.
+- `push_method_dispatch_frame` (`src/runtime/accessors_state.rs`) and the
+  `MethodDispatchFrame.remaining` consumers (`src/runtime/builtins_dispatch_next.rs`).
+- E9's planned `DispatchCursor` (design decision 2) must build its sequence in the raku order:
+  the resolver's `ResolvedSequence` (E4) currently stores candidates in `(level, stored_idx)`
+  order — the cursor needs the RANKED order for the multi portion plus outer-chain fall-through
+  and the re-visit semantics for plain middle entries.
+
+## Why this is deep
+
+It is not a local fix: the deferral order is the load-bearing semantic E9a/E9b/E9c will encode
+into the cursor. Doing it inside today's `resolve_all_methods_with_owner` means re-implementing
+ranking in a walker E9 plans to delete; doing it in E9 means the cursor's sequence layout (one
+flat list) must grow the two-level structure (ranked multi block + outer chain + re-entry
+point). Either way it needs design alignment with
+`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` first — that doc's decision 2 should
+be amended before E9a starts.
+
+## Repro harness
+
+Campaign probes lived in `tmp/e9pre/` (gitignored); the two order-diverging scripts are inlined
+above and in the E9-pre progress note in
+`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`.

--- a/todo/deep/method-entries-never-covers-unpunned-roles.md
+++ b/todo/deep/method-entries-never-covers-unpunned-roles.md
@@ -87,6 +87,17 @@ sequence structure and shadow-comparing it — not changing what any real call r
 therefore left this as a **documented, accepted shadow-check divergence** (mirroring E4a's own
 accepted-divergence bucket for the winner probe) rather than fixing it inline.
 
+## Update 2026-08-12: E9-pre ground truth complicates "real walker is authoritative"
+
+The ADR-0019 E9-pre raku verification campaign found that for the class-overridden shape (a
+`does`-composed role method that the composing class overrides with its own same-name method),
+**raku EXCLUDES the role's method from the nextsame/callsame chain** — i.e. the sequence side's
+omission matches raku there and the real walker's inclusion is the bug
+(`todo/tickets/role-shadowed-method-in-defer-chain.md`). Do not resolve this ticket by simply
+populating role entries so the sequence matches the real walker: the E8a mismatch ledger must be
+re-audited per-shape against raku first (qualified `self.R::m()` calls and conflict-resolution
+shapes may still legitimately need the role's own entry; the shadowed-by-class shape must not).
+
 ## Suggested fix, for whoever picks this up
 
 - Add a role branch to `sync_user_method_entries` mirroring the class branch (`self.roles.get(class_name)`

--- a/todo/tickets/callsame-to-native-mu-methods-nil.md
+++ b/todo/tickets/callsame-to-native-mu-methods-nil.md
@@ -1,0 +1,41 @@
+# callsame from an override of a built-in Mu-level method (gist/Str/raku/new) returns Nil/Any instead of reaching the native implementation
+
+Found by the ADR-0019 E9-pre raku verification campaign (2026-08-12, Rakudo v2026.06). The
+`native_mu_base_next_candidate` synthesized fallback and the `Mu.new` fallback
+(`src/runtime/builtins_dispatch_next.rs`) do not deliver the native method's value to
+`callsame`.
+
+## Divergence
+
+```raku
+class C { method gist() { "custom+" ~ callsame } }
+say C.new;
+# raku:  custom+C.new          (callsame reaches Mu.gist)
+# mutsu: "Use of Nil in string context" warning, then "custom+"
+
+class D { has $.x; method new(|c) { my $obj = callsame; $obj } }
+say D.new(x => 5).x;
+# raku:  5                     (callsame reaches Mu.new, returns the built instance, .^name is D)
+# mutsu: callsame returns Any; then "No such method 'x' for invocant of type 'Any'"
+```
+
+Same shape for `method raku()` and `method Str()` overrides (`E-str[E<...>]` in raku vs
+`E-str[]` + Nil warning in mutsu). All four probes: `tmp/e9pre/n.raku`, `n2.raku`,
+`probe-n3.raku` during the campaign (gitignored; shapes inlined above).
+
+## Where to look
+
+The four synthesized native fallbacks are force-pushed with empty `remaining` when the user MRO
+is exhausted (`builtins_dispatch_next.rs:181-310` per the E8-E11 survey), and
+`dispatch_next_candidate`'s search ends in a `Mu.new` fallback arm (:358-903). Two separate
+symptoms: (1) for gist/Str/raku the native Mu-level implementation is either not invoked or its
+value is dropped on the way back to `callsame` (Nil); (2) for `new` the fallback runs but the
+constructed object is lost (Any comes back — check whether construction happens against the
+wrong invocant or the return value is swallowed by the frame plumbing).
+
+Sibling ticket for the same fallback family:
+`todo/tickets/native-array-push-defer-fallback-broken.md` (array storage). ADR-0019 E9's cursor
+design makes all four fallbacks ordinary sequence tail entries — fix here or re-verify at that
+boundary, whichever lands first.
+
+The E9-pre pins for these land with the fix.

--- a/todo/tickets/explicit-child-proto-assumes-parent-candidates.md
+++ b/todo/tickets/explicit-child-proto-assumes-parent-candidates.md
@@ -1,0 +1,37 @@
+# An explicit proto in a subclass must NOT assume parent multi candidates
+
+Found by the ADR-0019 E9-pre raku verification campaign (2026-08-12, Rakudo v2026.06).
+
+## Divergence
+
+```raku
+class P { multi method m(Int $x) { "p-int" } }
+class C is P {
+    proto method m($x) { {*} }
+    multi method m(Str $x) { "c-str" }
+}
+C.new.m(5);
+# raku:  X::Multi::NoMatch — the explicit child proto only sees C's own candidates
+#        ("Cannot resolve caller m(C:D: Int:D); none of these signatures matches: (C $:: Str $x, *%_)")
+# mutsu: resolves P's Int candidate through the child proto and returns "proto-p-int"
+```
+
+Only an IMPLICIT proto (a `multi method` declaration with no proto at that class) clones the
+nearest MRO proto and merges parent candidates. Writing `proto method m` explicitly in the
+child starts a fresh candidate set: parent multis of the same name become unreachable through
+it. The inverse direction — proto in the PARENT governing candidates a child adds — works in
+both and is pinned by `t/proto-star-cross-mro-candidates.t`.
+
+## Affected code
+
+Proto-method `{*}` dispatch: `src/runtime/dispatch_proto_call.rs` (re-enters
+`call_method_with_values` by name with `proto_method_skip`, which then walks the full MRO
+candidate set regardless of which class declared the governing proto). After ADR-0019 E8c the
+proto is found via `Registry::method_entry_proto` per MRO level (`dispatch_proto.rs`); the fix
+needs the candidate-collection step to stop at/filter by the proto's own declaring class when
+that proto is explicit.
+
+Requires distinguishing explicit from implicit protos in the registry (mutsu currently may not
+record which classes declared an explicit proto vs inherited one — verify while fixing).
+
+The E9-pre pin for this (a `throws-like X::Multi::NoMatch`) lands with the fix.

--- a/todo/tickets/lastcall-in-wrapper-callsame-dies.md
+++ b/todo/tickets/lastcall-in-wrapper-callsame-dies.md
@@ -1,0 +1,34 @@
+# `lastcall` inside a method wrapper makes a following callsame die instead of returning Nil
+
+Found by the ADR-0019 E9-pre raku verification campaign (2026-08-12, Rakudo v2026.06).
+
+## Divergence
+
+```raku
+class C { method m() { say "orig"; "o" } }
+C.^lookup('m').wrap(-> |c { say "wrap"; lastcall; my $r = callsame; say "after({$r // 'Nil'})"; "w" });
+say C.new.m;
+# raku:  wrap -> after(Nil) -> w      (lastcall empties the chain; callsame then yields Nil; orig never runs)
+# mutsu: wrap -> dies "callsame is not in the dynamic scope of a dispatcher"
+```
+
+The non-wrap variant (lastcall then nextsame inside a plain multi candidate) behaves correctly
+in both and is pinned by `t/lastcall-then-nextsame.t`.
+
+## Root cause guess
+
+`lastcall` truncates the topmost dispatch frame (`builtins_dispatch_next.rs:62-75` per the
+E8-E11 survey). For a `WrapDispatchFrame` the truncation appears to pop/destroy the frame
+itself rather than just emptying its `remaining`, so the subsequent `callsame` finds no
+dispatcher frame at all and raises the out-of-scope error instead of resolving to an exhausted
+chain (Nil).
+
+## Fix route
+
+Make lastcall-on-a-wrap-frame leave the frame in place with an emptied remaining list (both the
+wrapper tail AND the `sub_id == 0` fall-through to the method leg must be cut — in raku the
+original method does NOT run). ADR-0019 E9b (wrap frames folded into the DispatchCursor as
+prefix entries; `lastcall` becomes `next = seq.len()`) fixes this structurally — if E9b is
+close, fix it there and add the pin in the same PR.
+
+The E9-pre pin for this lands with the fix.

--- a/todo/tickets/method-wrap-unwrap-restore-noop.md
+++ b/todo/tickets/method-wrap-unwrap-restore-noop.md
@@ -1,0 +1,40 @@
+# Method wraps cannot be removed: handle.restore silently no-ops, .^lookup(...).unwrap throws
+
+Found by the ADR-0019 E9-pre raku verification campaign (2026-08-12, Rakudo v2026.06).
+Sub-side wrap/unwrap round-trips work (`t/wrap.t`, `t/routine-unwrap-error.t`); the METHOD side
+is broken in both removal forms.
+
+## Divergence
+
+```raku
+class C { method m() { "orig" } }
+my $h = C.^lookup('m').wrap(-> |c { "w-" ~ callsame });
+say C.new.m;    # both: w-orig
+$h.restore;
+say C.new.m;    # raku: orig    mutsu: w-orig (restore silently did nothing)
+```
+
+```raku
+my $h2 = C.^lookup('m').unwrap($h2-from-wrap);
+# raku:  unwraps, later calls run the original
+# mutsu: dies "Cannot unwrap a sub that has not been wrapped"
+```
+
+## Root cause (already surveyed by ADR-0019 E10's design)
+
+`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` (E10 facts + design decision 4)
+records this exact gap: `.unwrap`/`restore` never remove `method_wrap_chains` entries — only
+class redeclaration purges them (`registration_class_validate.rs:377`) — and the two
+method-wrap mutation paths invalidate nothing. The unwrap error comes from the sub-side unwrap
+looking for the handle in the sub-keyed `wrap_chains`, where a method wrap (keyed by
+`(class, method, candidate_idx)` in `method_wrap_chains`) never lives.
+
+## Fix route
+
+This is scoped to be fixed BY ADR-0019 E10a ("registry-owned method wraps + generation bumps on
+all wrap mutations (+ the unwrap leak fix)"). If E10a is far off, an interim fix teaching
+`.unwrap`/`.restore` to also search-and-remove `method_wrap_chains` entries is self-contained.
+raku-verify `.unwrap` edge semantics (out-of-order removal on methods, double restore) first —
+the sub-side tests cover those shapes for subs only.
+
+The E9-pre pin for this lands with the fix.

--- a/todo/tickets/native-array-push-defer-fallback-broken.md
+++ b/todo/tickets/native-array-push-defer-fallback-broken.md
@@ -1,0 +1,50 @@
+# nextsame/callsame from an overridden `push` on an `is Array` subclass does not reach the real native push
+
+Found by the ADR-0019 E9-pre raku verification campaign (2026-08-12, Rakudo v2026.06). This is
+scenario (d) of the campaign — the `native_array_storage_next_candidate` synthesized fallback
+(`src/runtime/builtins_dispatch_next.rs`) is the code under test, and it does not perform the
+push.
+
+## Divergence
+
+```raku
+class MyArr is Array {
+    method push(|c) { say "MyArr::push"; nextsame }
+}
+my $a = MyArr.new;
+$a.push(1);
+$a.push(2, 3);
+say $a.elems;   # raku: 3   mutsu: 0  (array stays empty; no error)
+```
+
+`callsame` variant additionally gets the wrong return value:
+
+```raku
+class MyArr2 is Array {
+    method push(|c) { my $r = callsame; $r }
+}
+my $b = MyArr2.new;
+$b.push(10);
+# raku:  $b[0] == 10, push returns self (=== $b is True, .^name is MyArr2)
+# mutsu: $b stays empty, callsame returns Any, === $b is False
+```
+
+So the fallback neither mutates the underlying array storage nor returns the invocant. In raku
+the deferral reaches the real `Array.push`, which appends and returns self.
+
+## Where to look
+
+`native_array_storage_next_candidate` is force-pushed with empty `remaining` when the user MRO
+is exhausted (`builtins_dispatch_next.rs:181-310` per the E8-E11 design survey). Its handler
+must (a) route to the same mutable native push the ordinary `$a.push(...)` dispatch uses
+(`&mut self` slow path via `call_method_mut_with_values` / the `CallMethodMut` family — note the
+E6c precedent: sigil-only routing there ignored overrides, same neighborhood), and (b) return
+the invocant. Verify the invocant reaching the fallback is the ContainerRef/box for the actual
+array so the mutation is visible to the caller's variable, not a detached copy — the observed
+"no error, no effect" smells like mutating a clone.
+
+Also worth covering when fixed: `pop`/`shift`/`unshift`/`append` through the same fallback, and
+ADR-0019 E9's cursor migration (design decision 2 makes the four synthesized fallbacks ordinary
+sequence tail entries — this bug should be fixed or explicitly re-tested at that boundary).
+
+The E9-pre pin for this lands with the fix.

--- a/todo/tickets/role-shadowed-method-in-defer-chain.md
+++ b/todo/tickets/role-shadowed-method-in-defer-chain.md
@@ -1,0 +1,48 @@
+# A `does`-composed role method overridden by the class must NOT be in the nextsame/callsame chain
+
+Found by the ADR-0019 E9-pre raku verification campaign (2026-08-12, Rakudo v2026.06).
+
+## Divergence
+
+```raku
+role R { method m() { say "R::m"; "r" } }
+class C does R { method m() { say "C::m"; my $r = callsame; say "C-got({$r // 'Nil'})"; "c" } }
+say C.new.m;
+# raku:  C::m -> C-got(Nil) -> c        (role method is fully shadowed, NOT a chain entry)
+# mutsu: C::m -> R::m -> C-got(r) -> c  (role's own copy is walked)
+```
+
+The same holds for a same-signature `multi method` pair (role's candidate is a dropped
+flattened duplicate in raku — callsame from the class's candidate yields Nil, but mutsu reaches
+`R2:Int`). A role candidate with a DIFFERENT (narrower) signature DOES participate in dispatch
+normally (both implementations agree there), and a runtime mixin (`but R` / `does R` on an
+instance) keeps its own MRO entry in both (pinned by `t/nextsame-role-mixin.t`,
+`t/callsame-punned-role-and-hyper-infix-sub.t` — those cover pun/mixin shapes, which are NOT
+affected by this ticket).
+
+## Root cause
+
+`resolve_all_methods_with_owner` (`src/runtime/resolution_method.rs`) reads
+`registry().roles.get(cn)` directly for MRO entries that are roles, so a composed role's raw
+(un-flattened) method lands in the deferral list even when the class's own method shadows it.
+raku's chain contains only the flattened copy — which, when the class defines its own method of
+the same name, is the class method alone.
+
+Note the cross-link: `todo/deep/method-entries-never-covers-unpunned-roles.md` records that the
+E8a sequence probe (reading `method_entries`) OMITS un-punned role methods and treats the real
+walker as authoritative. This campaign's ground truth shows that for the shadowed-by-class
+shape the real walker is the wrong side: the sequence's omission matches raku. The two must be
+reconciled together — whichever store wins, the chain must exclude class-shadowed composed role
+methods (while keeping qualified calls `self.R::m()` and role-conflict-resolution shapes
+working; those read different paths).
+
+## Fix sketch
+
+Drop a role's raw MRO-level entry from the deferral walk when a class level in the chain
+already carries a method of the same name originating from that role's flattening OR its own
+override — i.e. apply the same rule `drop_flattened_role_duplicates` implements for winner
+selection, plus the class-override shadow. Then re-run E8a's `MUTSU_VM_STATS=1` deferral-shadow
+sweep: the 58 accepted mismatches attributed to the un-punned-role gap should be re-audited
+against raku rather than assumed to be sequence-side omissions.
+
+The E9-pre pin for this lands with the fix (currently no `t/` pin encodes either behavior).

--- a/todo/tickets/signature-gist-invocant-format.md
+++ b/todo/tickets/signature-gist-invocant-format.md
@@ -1,0 +1,23 @@
+# Signature.gist formats the method invocant as `(C:, ...)` instead of raku's `(C $:: ...)`
+
+Minor cosmetic divergence found in passing by the ADR-0019 E9-pre campaign (2026-08-12,
+Rakudo v2026.06):
+
+```raku
+class C {
+    multi method m(Int $x) { }
+    multi method m(Str $x) { }
+}
+say C.^lookup('m').candidates.map(*.signature.gist).join(" | ");
+# raku:  (C $:: Int $x, *%_) | (C $:: Str $x, *%_)
+# mutsu: (C:, Int $x, *%_) | (C:, Str $x, *%_)
+```
+
+Dispatch behavior is identical (candidate order, wrap targeting — pinned by
+`t/wrap-multi-candidate-scope.t`); only the invocant's textual rendering differs. raku renders
+an unnamed typed invocant as `C $::` (type, anonymous scalar, `::` separator, then a space
+before the first ordinary parameter) where mutsu prints `C:` and a comma. Relevant when a test
+or error message compares signature strings (e.g. X::Multi::NoMatch candidate listings).
+
+Fix in the Signature stringification path (`.gist`/`.raku` for Signature values); check
+`X::Multi::NoMatch` message formatting shares the helper so both get corrected together.


### PR DESCRIPTION
## Summary

Runs ADR-0019 Phase E's mandatory **E9-pre** verification campaign (design decision 3 in `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) — the required gate before any E9a/b/c `DispatchCursor` cutover. Every `samewith`/`nextsame`/`callsame`/`nextwith`/`lastcall`/wrap/proto chain-order scenario was probed against real raku (Rakudo v2026.06) **first**; matching behaviors became `t/` pins, divergences became tickets, and no cursor implementation code was written.

## Deliverables

- **12 new `t/` pins (38 assertions)** — each verified green under BOTH `prove -e raku` and `prove -e target/debug/mutsu`, so the pins provably encode raku's answer, not mutsu's current behavior.
- **8 divergence findings** (1 `todo/deep/` + 7 `todo/tickets/`), none encoded into design:
  - **Headline** (`todo/deep/defer-chain-ranked-multi-order.md`): when multi candidates span MRO levels, raku defers along the **specificity-ranked merged candidate list** (an implicit proto clones the nearest MRO proto; a plain middle-MRO method is a later outer-chain entry whose own deferral re-enters lower protos — a parent candidate can legitimately run twice). mutsu walks `(MRO level, declaration order)`. This **falsifies the E9 design's stated assumption** ("match today's 'remaining = signature-matching candidates in MRO order' semantics"); design decision 2 is amended in place and **E9a is blocked on re-drawing the cursor sequence layout**.
  - Class-overridden `does`-role methods must NOT be in the chain (also re-opens E8a's "real walker is authoritative" attribution of its 58 accepted shadow mismatches — cross-linked in `todo/deep/method-entries-never-covers-unpunned-roles.md`).
  - Explicit child proto must not assume parent candidates (raku: `X::Multi::NoMatch`).
  - `is Array` native push deferral fallback appends nothing / returns Any.
  - Method-wrap `unwrap`/`restore` are silent no-ops.
  - `lastcall` inside a wrapper kills the dispatcher scope (raku: callsame → Nil).
  - callsame from gist/Str/raku/new overrides never reaches the native Mu implementations.
  - Cosmetic: `Signature.gist` invocant format `(C:, ...)` vs `(C $:: ...)`.

Full scenario-by-scenario table (a–m + bonus probes) is in the new E9-pre section of the E8–E11 design doc; the ADR's E9 checkbox carries the progress note; `news/2026-08/adr0019-e9pre-verification-campaign.md` records the accomplishment.

## Testing

- `prove -e 'target/debug/mutsu'` on the 12 new pins: PASS (38 assertions)
- `prove -e raku` on the same 12 pins: PASS (ground-truth check)
- No interpreter code changed (docs + tests only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)