### PR TITLE
docs(adr0019): E9 decision 2 redrawn -- flat deferral expansion, confirmed by prediction

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3861,6 +3861,15 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   `unwrap`/`restore` no-op, `lastcall`-in-wrapper killing the dispatcher scope, callsame to
   native Mu methods (gist/Str/raku/new) yielding Nil/Any, and a cosmetic Signature.gist
   invocant format. Full scenario table in the E8-E11 design doc's E9-pre section.
+  **Progress 2026-08-12 (same day) — decision 2 redrawn; E9a design-unblocked.** The re-draw
+  landed in the same design doc ("E9 design decision 2 — REDRAWN"): the cursor sequence is a
+  FLAT deferral expansion — per-MRO-class entries, each a plain method or that class's proto's
+  specificity-ranked candidate block (implicit protos clone the nearest MRO proto and merge;
+  explicit protos stand alone), with duplicate candidate occurrences across blocks being
+  correct re-visit semantics. Confirmed by two exact-hit predictions against raku before any
+  implementation. E9a is now a deliberate behavior-changing cutover (the old walker is wrong
+  where the E9-pre tickets point) gated on new raku-valued pins + local `make roast`, with the
+  matcher-strictness ticket (`multi-matcher-admits-int-for-num`) as prerequisite/co-requisite.
 - [ ] **E10 — Move wrap/unwrap mutation into canonical entries.** Bump the generation and remove
   wrap-specific cache-clearing paths.
   **Design 2026-08-10** (same doc): `method_wrap_chains` moves into the registry; every

--- a/news/2026-08/adr0019-e9-decision2-redraw.md
+++ b/news/2026-08/adr0019-e9-decision2-redraw.md
@@ -1,0 +1,23 @@
+# ADR-0019 E9: deferral-cursor design redrawn as a flat expansion, confirmed by prediction
+
+Follow-up to the E9-pre campaign (same day): the two probes run after the campaign PR
+confirmed a concrete replacement for the falsified part of E9's design decision 2, and the
+re-draw is now written into `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`
+("E9 design decision 2 — REDRAWN") with the ADR's E9 checkbox carrying the progress note.
+
+The model: the deferral sequence is a FLAT expansion — concat over MRO classes of, per class,
+either its plain method or its proto's specificity-ranked candidate block, where an implicit
+proto clones the nearest MRO proto and merges its own candidates (an explicit proto stands
+alone), and the same candidate appearing in several blocks is correct re-visit semantics, not
+a dedup bug. Both confirming probes were predicted before running raku and hit exactly:
+a parent candidate legitimately runs twice in one call (block re-visit), and a three-level
+implicit-clone chain runs the same inherited candidate three times while skipping non-matching
+candidates per-call. A flat cursor index therefore suffices for E9a/b/c — only the sequence
+builder changes, not the cursor mechanics.
+
+Probe 2 also surfaced one more real divergence, filed as
+`todo/tickets/multi-matcher-admits-int-for-num.md`: mutsu's multi candidate matcher admits an
+Int argument for a `Num $x` parameter and then dies in the binder
+(X::TypeCheck::Binding::Parameter) where raku rejects at dispatch (X::Multi::NoMatch) — a
+matcher/binder inconsistency that would kill the redrawn cursor's advance filter mid-chain,
+so it is listed as a prerequisite/co-requisite for E9a.

--- a/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
+++ b/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
@@ -547,3 +547,82 @@ real walker. The reconciliation note is in `todo/tickets/role-shadowed-method-in
 and cross-linked from `todo/deep/method-entries-never-covers-unpunned-roles.md`'s fix plan: that
 sweep's mismatch ledger must be re-audited against raku per-shape, not resolved wholesale toward
 the real walker.
+
+## E9 design decision 2 — REDRAWN: the flat deferral expansion (confirmed by prediction)
+
+Immediately after the campaign PR (#6325) two follow-up probes CONFIRMED a concrete replacement
+for decision 2's sequence layout — each probe's chain order was predicted from the model BEFORE
+running raku, and both predictions were exact hits. This section supersedes the "matching
+today's 'remaining = signature-matching candidates in MRO order' semantics" clause of decision
+2 above; everything else in decision 2 (one cursor struct, wrap prefix entries, native tail
+entries, `samewith` = re-rank, `lastcall` = `next := len`, frame-by-frame E9a/b/c migration)
+stands as written.
+
+**The deferral expansion.** For a call of `name` on a receiver whose MRO is `K0, K1, ...`:
+
+```
+DeferralSequence(receiver, name) =
+  concat over MRO classes K that install an entry for `name`:
+    - plain method (or submethod, with the existing level-0 visibility rule): [ Method(K) ]
+    - proto (explicit or implicit): [ the proto's RANKED candidate block ]
+```
+
+- An IMPLICIT proto at K (a `multi method` declaration with no proto at K) clones the nearest
+  proto above K in the MRO and merges K's own candidates into it; the block is ranked by
+  narrowness, with MRO depth then declaration order breaking ties. An EXPLICIT proto's block
+  contains only its own class's candidates
+  (`todo/tickets/explicit-child-proto-assumes-parent-candidates.md`).
+- The SAME candidate may appear in several blocks (its own class's block plus every
+  descendant's merged block). This is CORRECT, not a dedup bug: deferral runs it once per
+  occurrence (probe 1 below shows a parent candidate legitimately running twice in one call).
+  A flat cursor index over this expansion reproduces raku exactly — the cursor mechanics of
+  decision 2 need no two-level structure; only the sequence BUILDER changes.
+- Winner selection = the existing ranker over the receiver's nearest entry; the cursor starts
+  immediately after the winner's occurrence in the expansion.
+- Advancement applies the per-call signature filter (invocant-blind, per E8a finding 1) with
+  the CURRENT args — original args for `callsame`/`nextsame`, replacement args for
+  `callwith`/`nextwith`. The filter must be raku-strict: mutsu's matcher currently admits Int
+  for a `Num $x` candidate and would call a candidate raku's dispatcher skips
+  (`todo/tickets/multi-matcher-admits-int-for-num.md`, found by probe 2 dying mid-chain).
+- Role composition: the class-level entry carries the flattened copies; a `does`-composed
+  role's own MRO appearance contributes NO entries when the class overrides the method
+  (`todo/tickets/role-shadowed-method-in-defer-chain.md`).
+
+**Confirming probes** (inlined because `tmp/` is gitignored; predictions made before running):
+
+Probe 1 — exhausting the merged block falls to the parent proto's OWN block, re-running its
+candidate:
+
+```raku
+class P { multi method m(Int $x) { say "P:Int"; nextsame; say "P:u" } }
+class C is P {
+    multi method m(Int $x) { say "C:Int"; nextsame; say "C:u" }
+    multi method m(Any $x) { say "C:Any"; nextsame; say "C:A-u" }
+}
+C.new.m(1)
+# expansion: C-block[C:Int, P:Int, C:Any], P-block[P:Int]
+# predicted & observed (raku): C:Int, P:Int, C:Any, P:Int, Nil
+# mutsu today:                 C:Int, C:Any, P:Int, Nil
+```
+
+Probe 2 — three-level implicit-clone chain, strict per-call filter during advance:
+
+```raku
+class A { multi method m(Int $x) { say "A:Int"; nextsame; say "A:u" } }
+class B is A { multi method m(Str $x) { say "B:Str"; nextsame; say "B:u" } }
+class C is B { multi method m(Num $x) { say "C:Num"; nextsame; say "C:u" } }
+C.new.m(1)
+# expansion for arg 1 (Str and Num candidates filtered out — 1 !~~ Num in raku):
+#   C-block[A:Int], B-block[A:Int], A-block[A:Int]
+# predicted & observed (raku): A:Int, A:Int, A:Int, Nil
+# mutsu today: A:Int, then DIES X::TypeCheck::Binding::Parameter calling the Num candidate
+```
+
+**E9a discipline inversion.** Unlike every earlier Phase E box, E9a cannot prove itself by
+shadow-comparing against the real walker: the real walker is WRONG wherever the E9-pre tickets
+point. E9a is therefore a deliberate behavior-CHANGING cutover justified by (i) the E9-pre pins
+staying green, (ii) NEW pins for the flipping shapes (both-levels-multi order, role-shadowed
+exclusion, explicit-proto isolation, probes 1/2 above) written with raku's expected values in
+the same PR, and (iii) a local `make roast` per the house rule for dispatch-semantics changes.
+The matcher-strictness ticket is a prerequisite or co-requisite: without it the stricter
+advance filter cannot be expressed.

--- a/todo/deep/defer-chain-ranked-multi-order.md
+++ b/todo/deep/defer-chain-ranked-multi-order.md
@@ -83,6 +83,15 @@ point). Either way it needs design alignment with
 `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` first — that doc's decision 2 should
 be amended before E9a starts.
 
+**Update (same day): the amendment landed, and the "two-level structure" concern above is
+resolved** — the "E9 design decision 2 — REDRAWN" section of
+`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` records a FLAT expansion (per-class
+entries, each a plain method or a proto's ranked block, duplicates across blocks allowed) that
+reproduces raku exactly, confirmed by two exact-hit predictions (probe 1: parent candidate runs
+twice via block re-visit; probe 2: three-level implicit-clone chain). A flat cursor index
+suffices; only the sequence BUILDER changes. This ticket remains open as the tracking item for
+the actual behavior fix, which is E9a's cutover.
+
 ## Repro harness
 
 Campaign probes lived in `tmp/e9pre/` (gitignored); the two order-diverging scripts are inlined

--- a/todo/tickets/multi-matcher-admits-int-for-num.md
+++ b/todo/tickets/multi-matcher-admits-int-for-num.md
@@ -1,0 +1,42 @@
+# Multi candidate matcher admits Int for a `Num $x` parameter; raku rejects at dispatch
+
+Found by the ADR-0019 E9-pre follow-up probes (2026-08-12, Rakudo v2026.06).
+
+## Divergence
+
+```raku
+class X1 { multi method m(Num $x) { say "num" } }
+X1.new.m(1);
+# raku:  dies X::Multi::NoMatch — the dispatcher's filter rejects an Int argument
+#        for a Num parameter (1 !~~ Num; Num means floating point, not Numeric)
+# mutsu: the candidate MATCHER accepts it, dispatch selects the candidate, then the
+#        binder dies X::TypeCheck::Binding::Parameter ("expected Num, got Int")
+```
+
+So mutsu's matcher and binder disagree about Int-vs-Num: the matcher applies a numeric
+leniency the binder (correctly) does not. The user-visible exception type is wrong
+(X::TypeCheck::Binding::Parameter instead of X::Multi::NoMatch), and worse, in a deferral
+chain the over-admission KILLS the walk mid-flight: E9-pre model probe 2 (`nextsame` through a
+3-level hierarchy whose child candidate is `Num $x`, inlined in the E9 redrawn-decision-2
+section of `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) dies at the second step
+in mutsu where raku simply skips the Num candidate and completes the chain.
+
+## Where to look
+
+The method-multi match ladder (`method_candidate_type_distance` / the `narrowness` tuple,
+`src/runtime/resolution_method.rs`) and/or `method_args_match_for_invocant` — wherever an Int
+argument is scored as compatible with a `Num` type constraint. Sub multis share the risk via
+their own hand-synchronized ladder (`candidate_specificity_rank`/`candidate_type_distance`,
+`src/runtime/dispatch_candidates.rs`) — check `multi sub f(Num $x) {}; f(1)` too (raku: also
+X::Multi::NoMatch).
+
+Scope the fix carefully: `Num` must not match Int/Rat arguments, but `Numeric`/`Real`/`Cool`
+must keep matching them, and literal `Num` arguments (`1e0`) must keep matching `Num`. Also
+verify coercion types (`Num() $x`) still accept Int — only the plain nominal `Num` constraint
+is affected.
+
+## Why it matters for ADR-0019 E9
+
+The redrawn E9 cursor advances through the deferral expansion applying a per-call signature
+filter; that filter must be raku-strict or the cursor will invoke candidates raku skips (and
+die in the binder, as probe 2 shows). Listed there as a prerequisite/co-requisite for E9a.


### PR DESCRIPTION
## Summary

Follow-up to #6325 (E9-pre campaign), same day. Writes the confirmed replacement for the falsified part of E9's design decision 2 into `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` ("E9 design decision 2 — REDRAWN"):

- **The deferral sequence is a FLAT expansion**: concat over MRO classes of, per class, either its plain method or its proto's **specificity-ranked candidate block**. An implicit proto clones the nearest MRO proto and merges its own candidates; an explicit proto stands alone. The same candidate appearing in several blocks is **correct re-visit semantics** (a parent candidate legitimately runs twice in one call), not a dedup bug.
- Both confirming probes were **predicted before running raku and hit exactly** (probe 1: block re-visit `C:Int, P:Int, C:Any, P:Int, Nil`; probe 2: three-level implicit-clone chain `A:Int ×3, Nil` with per-call filtering). So a flat cursor index suffices for E9a/b/c — only the sequence **builder** changes, not the cursor mechanics of decision 2.
- **E9a is design-unblocked** with an explicit discipline inversion: the old walker is wrong where the E9-pre tickets point, so E9a is a deliberate behavior-changing cutover gated on new raku-valued pins + local `make roast`, not a shadow comparison.
- Probe 2 surfaced one more real divergence, filed as `todo/tickets/multi-matcher-admits-int-for-num.md`: mutsu's multi matcher admits Int for `Num $x` then dies in the binder (`X::TypeCheck::Binding::Parameter`) where raku rejects at dispatch (`X::Multi::NoMatch`) — a matcher/binder inconsistency listed as prerequisite/co-requisite for E9a (it would kill the redrawn advance filter mid-chain).

Cross-references updated: ADR E9 checkbox progress note, `todo/deep/defer-chain-ranked-multi-order.md` (the "two-level structure" concern is resolved by the flat expansion), and a news entry.

## Testing

Docs-only PR (the four heavy CI jobs skip by design via the `changes` classifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)