### PR TITLE
fix(compiler): accessor-lvalue writeback keeps the subscript's own axis

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -555,6 +555,7 @@ impl Compiler {
             && let Expr::Index {
                 target: index_target,
                 index: index_key,
+                is_positional: index_is_positional,
                 ..
             } = &args[0]
             && let Some(var_name) = Self::postfix_index_name(index_target)
@@ -590,9 +591,14 @@ impl Compiler {
 
             self.code.emit(OpCode::GetGlobal(tmp_target_idx));
             self.compile_expr(index_key);
+            // The element write-back must keep the subscript's own axis: an
+            // associative target (`$r<baz>.text = v` on a class with both
+            // ASSIGN-KEY and ASSIGN-POS) dispatches ASSIGN-KEY, not
+            // ASSIGN-POS("baz", ...) — Text::CSV's CSV::Row died on the int
+            // type check of its ASSIGN-POS (91_csv_cb.t test 16).
             self.code.emit(OpCode::IndexAssignExprNamed {
                 name_idx: var_name_idx,
-                is_positional: true,
+                is_positional: *index_is_positional,
                 target_slot,
             });
             self.code.emit(OpCode::Pop);

--- a/t/accessor-lvalue-writeback-positionality.t
+++ b/t/accessor-lvalue-writeback-positionality.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+plan 6;
+
+# `$obj<key>.accessor = v` on a class that is BOTH Positional and Associative
+# must write the element back along the subscript's own axis: the angle
+# subscript dispatches ASSIGN-KEY, never ASSIGN-POS("key", ...). The compiler's
+# accessor-lvalue writeback hardcoded the positional axis, so Text::CSV's
+# CSV::Row (whose ASSIGN-POS takes `int $i`) died with a type-check error on
+# `$r<baz>.text = "A"` (91_csv_cb.t test 16).
+
+my @pos-log;
+my @key-log;
+
+class Field {
+    has Str $.text is rw = "x";
+}
+
+class Row does Positional does Associative {
+    has @.names;
+    has @.fields;
+    method of() { Mu }
+    method AT-KEY(Str $k)  { @!fields[@!names.first($k, :k)] }
+    method AT-POS(int $i)  { @!fields[$i] }
+    method ASSIGN-KEY(Str $k, $v) { @key-log.push($k); @!fields[@!names.first($k, :k)] = $v }
+    method ASSIGN-POS(int $i, $v) { @pos-log.push($i); @!fields[$i] = $v }
+    method elems { @!fields.elems }
+}
+
+my $r = Row.new(names => <foo bar baz>, fields => [Field.new, Field.new, Field.new]);
+
+lives-ok { $r<baz>.text = "A" }, 'associative accessor-lvalue assign lives';
+is $r<baz>.text, "A", 'the keyed element was updated';
+is-deeply @pos-log, [], 'ASSIGN-POS was never called for the angle subscript';
+
+lives-ok { $r[1].text = "B" }, 'positional accessor-lvalue assign lives';
+is $r[1].text, "B", 'the indexed element was updated';
+is-deeply @key-log.grep(* eq "1").elems, 0, 'ASSIGN-KEY was not called with a stringified index';


### PR DESCRIPTION
## Summary

`$obj<key>.accessor = v` compiles to a read → mutate → element-write-back sequence; the write-back (`IndexAssignExprNamed`) hardcoded `is_positional: true`, ignoring the subscript's own axis. On a class that is BOTH Positional and Associative this dispatched `ASSIGN-POS("key", ...)` for an *angle* subscript — Text::CSV's `CSV::Row` (whose `ASSIGN-POS` takes `int $i`) died with `X::TypeCheck::Binding::Parameter` on `$r<baz>.text = "A"` inside an `after_in` callback.

One-line fix: use the `Expr::Index` node's own `is_positional`.

## Impact

- Text::CSV `t/91_csv_cb.t`: aborted at test 16 of 15-planned → now runs 28 tests (remaining failures 20-23 and 27-28 are two separate pre-existing bugs: `$_ .= uc for @$expr` topic write-back, and `$^r<k> = v` in a placeholder block — being fixed next).
- Pin: `t/accessor-lvalue-writeback-positionality.t`, rakudo-verified.

## Testing

- `prove` over all 158 `t/*lvalue*`/`t/*assign*`/`t/*subscript*` files: PASS
- Targeted roast (S02 array/hash, S03 subscript-adverbs, S32 roundrobin): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)