### PR TITLE
fix(vm): for-loop over @$scalar aliases the inner array's elements

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -2356,6 +2356,26 @@ impl Compiler {
             Expr::MethodCall {
                 target, name, args, ..
             } if args.is_empty() && *name == "reverse" => Self::for_iterable_source_name(target),
+            // `@$h` desugars to `($h).list`: the loop iterates the scalar's
+            // inner array and must alias its elements (`$_ .= uc for @$hdr`
+            // uppercases in place — Text::CSV's header munge). Tag the source
+            // SIGILED ("$h") so the runtime's per-element writeback recognizes
+            // the deref'd-container shape, while the whole-topic scalar
+            // writeback (keyed on the bare name, `for $x {...}`) stays off.
+            // `@a.list` re-tags the array itself, same as bare `for @a`.
+            Expr::MethodCall {
+                target, name, args, ..
+            } if args.is_empty() && *name == "list" => {
+                let inner = match target.as_ref() {
+                    Expr::Grouped(g) => g.as_ref(),
+                    other => other,
+                };
+                match inner {
+                    Expr::Var(name) => Some(format!("${}", name)),
+                    Expr::ArrayVar(name) => Some(format!("@{}", name)),
+                    _ => None,
+                }
+            }
             _ => None,
         }
     }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1630,6 +1630,10 @@ impl Interpreter {
                     && let Some(ref source_var) = self.topic_source_var
                     && !source_var.starts_with('@')
                     && !source_var.starts_with('%')
+                    // A sigiled "$h" tag is the deref'd-container source
+                    // (`for @$h`): the per-element loop writeback owns it; the
+                    // whole-topic scalar write would pollute a "$h" env key.
+                    && !source_var.starts_with('$')
                 {
                     let source_name = source_var.clone();
                     self.set_env_with_main_alias(&source_name, val.clone());

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -307,7 +307,16 @@ impl Interpreter {
         // wholesale into the scalar. `$_ .= uc for @$hdr` is Text::CSV's
         // header munge (91_csv_cb.t tests 20-23).
         if let Some(bare) = source.strip_prefix('$') {
-            let loop_var = param_name.as_deref().unwrap_or("_");
+            // Only the implicit-topic form writes back (`$_ .= uc for @$hdr`).
+            // A named param (`for $l.list -> $v { }`) keeps the pre-existing
+            // no-writeback behavior for this iterable shape: the bound value of
+            // a merely-FETCHed Proxy element differs from the element, and
+            // "different" here must not replace the Proxy with its fetched
+            // value (t/proxy-list-transparency.t).
+            if param_name.is_some() {
+                return;
+            }
+            let loop_var = "_";
             let Some(current_topic) = self.env().get(loop_var).cloned() else {
                 return;
             };
@@ -336,6 +345,10 @@ impl Interpreter {
             };
             if actual_idx >= items.len()
                 || Self::loop_var_unchanged(&current_topic, &items[actual_idx])
+                // A Proxy element mediates its own STORE; replacing it with the
+                // topic (its FETCHed value on a read-only pass) would destroy
+                // the Proxy.
+                || matches!(items[actual_idx].view(), ValueView::Proxy { .. })
             {
                 return;
             }

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -300,6 +300,63 @@ impl Interpreter {
             }
             return;
         }
+        // A SIGILED scalar source (`"$h"`) is the deref'd-container tag emitted
+        // for `for @$h` / `for $h.list`: the loop iterates the scalar's inner
+        // array, so a mutated topic writes back into that element THROUGH the
+        // shared node (container identity — every holder observes it), never
+        // wholesale into the scalar. `$_ .= uc for @$hdr` is Text::CSV's
+        // header munge (91_csv_cb.t tests 20-23).
+        if let Some(bare) = source.strip_prefix('$') {
+            let loop_var = param_name.as_deref().unwrap_or("_");
+            let Some(current_topic) = self.env().get(loop_var).cloned() else {
+                return;
+            };
+            // A plain scalar local is slot-only (never mirrored to env), so
+            // resolve the holder through its local slot first; the env read
+            // covers globals and `:=`-bound cells.
+            let source_local = self.find_local_slot(code, bare);
+            let raw_source = source_local
+                .and_then(|s| self.locals.get(s))
+                .filter(|v| !v.is_nil())
+                .cloned()
+                .map(Some)
+                .unwrap_or_else(|| self.get_env_with_main_alias(bare));
+            // The scalar may hold the array itemized (`Scalar(Array)`) or via a
+            // `ContainerRef` cell — strip both wrappers to the backing array.
+            let Some((items, kind)) = raw_source
+                .as_ref()
+                .and_then(|v| v.deref_container().into_descalarized().into_array())
+            else {
+                return;
+            };
+            let actual_idx = if reversed && total_items > 0 {
+                total_items - 1 - idx
+            } else {
+                idx
+            };
+            if actual_idx >= items.len()
+                || Self::loop_var_unchanged(&current_topic, &items[actual_idx])
+            {
+                return;
+            }
+            // Same rebuild-and-store as the `@`-source path below: clone the
+            // ArrayData (keeping its kind/metadata, so the scalar's itemization
+            // survives) with the one mutated element, and let
+            // `write_back_container_source` update env, the local slot, and a
+            // `ContainerRef` cell uniformly.
+            let mut new_data = (*items).clone();
+            new_data.items_mut()[actual_idx] = current_topic;
+            let mut updated_value = Value::array_with_kind(crate::gc::Gc::new(new_data), kind);
+            // Keep the scalar's itemization wrapper if it had one.
+            if raw_source
+                .as_ref()
+                .is_some_and(|v| matches!(v.view(), crate::value::ValueView::Scalar(_)))
+            {
+                updated_value = Value::scalar(updated_value);
+            }
+            self.write_back_container_source(code, bare, None, &raw_source, updated_value);
+            return;
+        }
         // A scalar source iterated via `.values` binding a mutable QuantHash is
         // written back by `write_back_quanthash_value_item`, called *before* the
         // body-result match (its coercion can raise X::Str::Numeric, which must

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -604,6 +604,9 @@ impl Interpreter {
             && let Some(ref source_var) = self.topic_source_var
             && !source_var.starts_with('@')
             && !source_var.starts_with('%')
+            // Sigiled "$h" = deref'd-container tag (`for @$h`); the loop's
+            // per-element writeback owns it (see vm_loop_writeback.rs).
+            && !source_var.starts_with('$')
         {
             let sv = source_var.clone();
             self.set_env_with_main_alias(&sv, val.clone());

--- a/t/for-deref-list-topic-writeback.t
+++ b/t/for-deref-list-topic-writeback.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+plan 8;
+
+# `for @$h { $_ .= uc }` iterates the scalar's inner array and must alias its
+# elements: a topic mutation writes back into the array (rakudo-verified).
+# This is Text::CSV's header munge (`$_ .= uc for @$hdr`, 91_csv_cb.t 20-23).
+
+my $hdr = ["foo", "bar"];
+$_ .= uc for @$hdr;
+is-deeply $hdr, ["FOO", "BAR"], 'topic .= mutation writes back through @$scalar';
+
+my $h2 = ["a", "b"];
+$_ = "X" ~ $_ for @$h2;
+is-deeply $h2, ["Xa", "Xb"], 'topic = assignment writes back through @$scalar';
+
+my @a = "p", "q";
+$_ .= uc for @a.list;
+is-deeply @a, ["P", "Q"], '@arr.list aliases the array elements too';
+
+my @b = "r";
+my $hb := @b;
+$_ .= uc for @$hb;
+is-deeply @b, ["R"], 'a :=-bound scalar derefs to the bound array';
+
+my $block = ["m", "n"];
+for @$block { $_ .= tc }
+is-deeply $block, ["M", "N"], 'block form writes back too';
+
+# Guard rails: shapes that must NOT gain a writeback.
+my $s = "keep";
+for $s { }
+is $s, "keep", 'a plain scalar topic source is untouched by a read-only loop';
+
+my $one = [1, 2];
+for $one { }
+is-deeply $one, [1, 2], 'single-item scalar wrap (for $x) is not element-written';
+
+my $ro = [3];
+for @$ro { }
+is-deeply $ro, [3], 'read-only loop over @$x leaves the array alone';


### PR DESCRIPTION
## Summary

`$_ .= uc for @$hdr` left the array untouched — `@$h` desugars to `($h).list`, which compiled with no container-source tag, so the for-loop's per-element topic writeback never ran. This is Text::CSV's header munge: every `headers => "uc"/"tclc"/callable/hash` mode silently did nothing (91_csv_cb.t tests 20-23; only "lc" passed, vacuously, because the test file's headers are already lowercase).

## Approach

- Compiler: `for_iterable_source_name` now recognizes `.list` on a (possibly parenthesized) scalar/array var. A scalar source is tagged **sigiled** ("$h") so the runtime can tell the deref'd-container shape apart from the whole-topic scalar source (`for $x {...}`, tagged bare) — the two have opposite writeback semantics.
- Runtime (`write_back_for_topic_item`): a "$h" tag resolves the holder through the **local slot** first (a plain scalar is slot-only under ADR-0018 — the env read returns `Any`), strips `ContainerRef`/`Scalar` wrappers to the backing array, and stores the rebuilt array through the existing `write_back_container_source` (env + slot + cell, itemization preserved).
- The two whole-topic scalar writeback consumers (topic assignment handlers) skip sigiled tags so `$_ = v` inside such a loop cannot pollute a "$h" env key.

Known residual (out of scope, not needed by Text::CSV): `for @$g -> $x is rw { ... }` — the rw-param writeback lane (`write_back_for_rw_param`) still keys on `@`/`%` sources only.

## Testing

- Pin `t/for-deref-list-topic-writeback.t` (8 subtests, rakudo-verified) including guard shapes: `for $x` single-wrap and read-only loops stay writeback-free.
- 72 `t/for*|loop*|topic*|given*` files: PASS. Targeted roast (S04 for/for-scope, S32 map, S02 mixhash): PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)