### PR TITLE
fix(ast): placeholder collectors see IndexAssign/MultiDimIndexAssign targets

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2043,6 +2043,30 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
             collect_ph_expr(target, out);
             collect_ph_expr(index, out);
         }
+        // A placeholder can be the TARGET of an element assignment
+        // (`{ $^x<a> = 3 }` — Text::CSV's on_in callbacks); without this arm
+        // the block compiled with arity 0 and never bound its argument.
+        Expr::IndexAssign {
+            target,
+            index,
+            value,
+            ..
+        } => {
+            collect_ph_expr(target, out);
+            collect_ph_expr(index, out);
+            collect_ph_expr(value, out);
+        }
+        Expr::MultiDimIndexAssign {
+            target,
+            dimensions,
+            value,
+        } => {
+            collect_ph_expr(target, out);
+            for d in dimensions {
+                collect_ph_expr(d, out);
+            }
+            collect_ph_expr(value, out);
+        }
         Expr::Ternary {
             cond,
             then_expr,
@@ -2381,6 +2405,29 @@ fn collect_ph_expr_shallow(expr: &Expr, out: &mut Vec<String>) {
         Expr::Index { target, index, .. } => {
             collect_ph_expr_shallow(target, out);
             collect_ph_expr_shallow(index, out);
+        }
+        // Element-assignment TARGET placeholders (`{ $^x<a> = 3 }`) — see the
+        // matching arm in `collect_ph_expr`.
+        Expr::IndexAssign {
+            target,
+            index,
+            value,
+            ..
+        } => {
+            collect_ph_expr_shallow(target, out);
+            collect_ph_expr_shallow(index, out);
+            collect_ph_expr_shallow(value, out);
+        }
+        Expr::MultiDimIndexAssign {
+            target,
+            dimensions,
+            value,
+        } => {
+            collect_ph_expr_shallow(target, out);
+            for d in dimensions {
+                collect_ph_expr_shallow(d, out);
+            }
+            collect_ph_expr_shallow(value, out);
         }
         Expr::Ternary {
             cond,

--- a/t/placeholder-index-assign-target.t
+++ b/t/placeholder-index-assign-target.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A placeholder used ONLY as the target of an element assignment
+# (`{ $^x<a> = v }`) must still make the block arity-1: the placeholder
+# collectors walked `Expr::Index` (reads) but not `Expr::IndexAssign`, so the
+# block compiled with arity 0, never bound its argument, and the assignment
+# autovivified a private hash instead of dispatching ASSIGN-KEY on the
+# argument (Text::CSV `on_in => { $^r<bar> = "" }`, 91_csv_cb.t tests 27-28).
+
+class R {
+    has %.h = (a => 1);
+    method AT-KEY(Str $k) { %!h{$k} }
+    method ASSIGN-KEY(Str $k, $v) { %!h{$k} = $v }
+    method AT-POS(int $i) { $i }
+    method ASSIGN-POS(int $i, $v) { %!h{"p$i"} = $v }
+}
+
+my $r = R.new;
+my &cb = { $^x<a> = 3 };
+is &cb.arity, 1, 'assign-target placeholder gives the block arity 1';
+cb($r);
+is $r.h<a>, 3, 'keyed element assignment reaches the argument (ASSIGN-KEY)';
+
+my &cb2 = { $^x[1] = 9 };
+cb2($r);
+is $r.h<p1>, 9, 'positional element assignment reaches the argument (ASSIGN-POS)';
+
+my &cb3 = { $^y<b> = $^x<a> };
+is &cb3.arity, 2, 'placeholders in target and value both count';
+cb3($r, $r);
+is $r.h<b>, 3, 'both placeholders bound their arguments';
+
+my %h = (k => 1);
+my &cb4 = { $^m<k> = 42 };
+cb4(%h);
+is %h<k>, 42, 'plain hash argument is element-assigned too';


### PR DESCRIPTION
## Summary

`{ $^x<a> = v }` compiled with **arity 0**: the placeholder collectors (`collect_ph_expr` / `collect_ph_expr_shallow`) walk `Expr::Index` (reads) but not `Expr::IndexAssign` / `Expr::MultiDimIndexAssign`, so a placeholder appearing only as an element-assignment target was never registered as a parameter. The block never bound its argument and the assignment autovivified a private `^x` hash — Text::CSV's `on_in => { $^r<bar> = "" }` callbacks silently did nothing (91_csv_cb.t tests 27-28).

Both collectors gain the two assignment arms (target + index/dimensions + value).

## Testing

- Pin `t/placeholder-index-assign-target.t` (6 subtests, rakudo-verified — arity, ASSIGN-KEY, ASSIGN-POS, multi-placeholder, plain hash).
- 26 `t/placeholder*|whatever*` files: PASS; roast S06-signature/arity.t + S02-magicals/block.t: PASS.

Together with #6328 and #6329 this closes the three real mutsu bugs 91_csv_cb.t exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)