### PR TITLE
fix(given): native-typed pointy param with is rw now writes back

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2851,9 +2851,20 @@ impl Compiler {
                 // the mutation back to the source. `is copy` carries a declaration
                 // marker instead, so it is not detected here and does not write
                 // back.
+                // A native-typed pointy param (`given $x -> int $v is rw {...}`)
+                // cannot use `:=` (see `pointy_topic_bind`'s native branch), so
+                // it carries `__pointy_native_param` instead of `MarkBind` —
+                // either bare (`is rw`) or wrapped in a `SyntheticBlock` with a
+                // trailing `MarkReadonly` (the default, readonly case).
+                let is_pointy_native_decl = |s: &Stmt| {
+                    matches!(s, Stmt::VarDecl { custom_traits, .. }
+                        if custom_traits.iter().any(|(t, _)| t == "__pointy_native_param"))
+                };
                 let pointy_param_name = match body.first() {
                     Some(Stmt::SyntheticBlock(inner))
-                        if inner.iter().any(|s| matches!(s, Stmt::MarkBind)) =>
+                        if inner
+                            .iter()
+                            .any(|s| matches!(s, Stmt::MarkBind) || is_pointy_native_decl(s)) =>
                     {
                         inner.iter().find_map(|s| match s {
                             Stmt::VarDecl { name, .. }
@@ -2865,6 +2876,9 @@ impl Compiler {
                             }
                             _ => None,
                         })
+                    }
+                    Some(s @ Stmt::VarDecl { name, .. }) if is_pointy_native_decl(s) => {
+                        Some(name.clone())
                     }
                     _ => None,
                 };

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -147,7 +147,12 @@ fn pointy_topic_bind(pd: &ParamDef) -> Stmt {
     {
         // Native-typed lexicals cannot participate in `:=` binding. A native
         // pointy parameter receives a checked/unboxed value in its own lexical
-        // container, matching ordinary native routine parameters.
+        // container, matching ordinary native routine parameters. It still
+        // needs `__pointy_native_param` so the compiler recognizes it as the
+        // given/with pointy parameter (see the matching detection in
+        // `compiler/stmt.rs`'s `pointy_param_name`) — without it, `is rw`
+        // writeback never fires because `Given`'s `pointy_param_idx` stays
+        // `None`, the same way the general branch below needs `MarkBind`.
         let decl = Stmt::VarDecl {
             name: pd.name.clone(),
             expr: topic,
@@ -157,7 +162,10 @@ fn pointy_topic_bind(pd: &ParamDef) -> Stmt {
             is_dynamic: false,
             is_export: false,
             export_tags: Vec::new(),
-            custom_traits: vec![("__has_initializer".to_string(), None)],
+            custom_traits: vec![
+                ("__has_initializer".to_string(), None),
+                ("__pointy_native_param".to_string(), None),
+            ],
             where_constraint: None,
         };
         if pd.traits.iter().any(|t| t == "rw") {

--- a/t/given-with-native-pointy-rw-writeback.t
+++ b/t/given-with-native-pointy-rw-writeback.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 6;
+
+{
+    my int $x = 1;
+    given $x -> int $v is rw { $v = 99 }
+    is $x, 99, 'given native int pointy param is rw writes back';
+}
+
+{
+    my int $x = 1;
+    with $x -> int $v is rw { $v = 99 }
+    is $x, 99, 'with native int pointy param is rw writes back';
+}
+
+{
+    my int $x = 1;
+    given $x -> int $v is rw { }
+    is $x, 1, 'given native int pointy param is rw, unchanged, no writeback';
+}
+
+{
+    my str $x = 'a';
+    given $x -> str $v is rw { $v = 'z' }
+    is $x, 'z', 'given native str pointy param is rw writes back';
+}
+
+{
+    my int $x = 5;
+    my int $sum = 0;
+    given $x -> int $v is rw {
+        $v = $v + 1;
+        $sum = $v;
+    }
+    is $x, 6, 'given native int pointy rw writeback reflects in-body mutation chain';
+    is $sum, 6, 'in-body read of the rw pointy param sees its own mutation';
+}


### PR DESCRIPTION
## Summary

- `given $x -> int $v is rw { $v = 99 }` (and the `with` equivalent) silently dropped the mutation — `$x` stayed unchanged, unlike the general (non-native) scalar pointy-param `is rw` case (already fixed in PR #6304).
- Root cause: `pointy_topic_bind`'s native-type branch (`src/parser/stmt/control.rs`) can't use `:=` binding for native lexicals, so it never emitted the `MarkBind` marker the compiler's pointy-param detection (`compiler/stmt.rs`) looks for. `Given`'s `pointy_param_idx` stayed `None`, so `exec_given_op` never knew a pointy param existed at all — not just that it needed writeback.
- Confirmed via `--dump-bytecode` that the native declaration already compiles to the right `SetLocalDecl` shape the writeback machinery expects; the only missing piece was `pointy_param_idx` detection.
- Confirmed `given`/`with`-specific: ordinary native `is rw` sub/block parameters already write back correctly (verified against a control case), so this was not a general native-parameter-aliasing gap.

## Fix

Added a `__pointy_native_param` custom-trait marker to the native branch's synthetic `VarDecl` (mirroring `MarkBind` for the general branch), and extended `pointy_param_name` detection in `compiler/stmt.rs` to recognize it in both shapes `pointy_topic_bind` produces (bare `VarDecl` for `is rw`, `SyntheticBlock` with a trailing `MarkReadonly` for the readonly default).

## Testing

- New pin: `t/given-with-native-pointy-rw-writeback.t` (6 cases: `given`/`with` int rw writeback, unchanged-no-writeback, `str` rw writeback, in-body mutation-chain visibility) — output byte-identical to real `raku`.
- `make test`: PASS (3091 files, 28753 tests).
- `cargo clippy -- -D warnings` / `cargo fmt`: clean.
- Targeted roast: `S04-statements/given.t`, `S04-statements/with.t`, `S04-statement-modifiers/given.t`, `S04-statement-modifiers/with.t`, `S04-statement-modifiers/without.t` — all PASS.
- All existing `t/given*.t` / `t/with*.t` / `t/*with*.t` (45 files, 408 tests) — all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)