### PR TITLE
docs(adr): close ADR-0027 Slice 3 (retirement path) and cross-link related tickets

### DIFF
--- a/docs/adr/0027-loop-frozen-value-capture-cascade.md
+++ b/docs/adr/0027-loop-frozen-value-capture-cascade.md
@@ -1,6 +1,6 @@
 # ADR-0027: Loop-frozen value captures cascade through nested closure creation — frame-owned vouching gated on the live value kind
 
-- Status: Accepted (Slice 1 implemented; Slice 2 audited, no gaps found; Slice 3 planned)
+- Status: Accepted (Slice 1 implemented; Slice 2 audited, no gaps found; Slice 3 documented)
 - Date: 2026-08-12
 - Related: ADR-0018 (slot-addressed lexical capture), ADR-0023 (binding
   provenance for spawn capture), ADR-0025 (value-kind-blind cell boxing),
@@ -82,8 +82,27 @@ One genuine divergence surfaced while constructing these repros (a `for
 and calls later): confirmed via a worktree build at the commit immediately
 before this ADR's Slice 1 merged that it is **pre-existing and unrelated**
 to the loop-freeze cascade — filed separately as
-`todo/tickets/for-loop-rw-element-alias-lost-through-deferred-closure.md`,
-not pursued under this ADR.
+`todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md`
+(moved to `todo/deep/` after root-causing it to the same class of
+element-level `ContainerRef` gap Alternative 4 below describes, not
+pursued under this ADR).
+
+## Outcome (Slice 3, 2026-08-12)
+
+Documentation-only, as scoped: the retirement path was already written into
+this ADR at authoring time (see "Slice 3 — retirement path" and Alternative
+4 below) rather than deferred to a follow-up edit, so there is no separate
+content to add. This outcome note exists to close the Status line and
+record one forward link found since: `todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md`
+(the Slice-2 divergence above) independently root-caused its bug to the
+*same* missing primitive this ADR's retirement path is written against — a
+genuine per-binding `ContainerRef` cell, there for an array *element*
+rather than a loop *capture*. Neither ticket should be read as blocking or
+subsuming the other (an element-store share-vs-bind distinction is a
+different piece of surface than closure-capture cell identity), but a
+future "per-iteration/per-binding fresh cells" campaign scoping pass should
+read both before committing to a shape, since a single underlying
+`ContainerRef`-lifecycle primitive may end up serving both call sites.
 
 ## Context
 

--- a/todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md
+++ b/todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md
@@ -85,16 +85,26 @@ ticket — see "Where this connects" below before starting design.
   also applies here (same `GcBox`/`UnsafeCell` interior-mutability layer),
   worth checking when scoping a fix design.
 - `todo/tickets/native-pointy-param-is-rw-writeback-missing.md` (filed the
-  same session) is a sibling symptom — a `given`/`with`-pointy-param `is rw`
-  writeback gap for native types — but per that ticket's own repro it may be
-  a narrower, native-type-specific issue rather than this same element-alias
-  gap; verify independently before assuming a shared fix.
+  same session) was a sibling symptom — a `given`/`with`-pointy-param `is rw`
+  writeback gap for native types — but it turned out to be an unrelated,
+  narrower bug (a compiler detection gap: the native-typed pointy-param
+  branch never populated `Given`'s `pointy_param_idx`, so `exec_given_op`
+  never knew a pointy param existed at all). Fixed in PR #6334 with a local
+  compiler-marker fix; **confirms** this ticket's element-alias gap is a
+  genuinely separate, deeper issue, not the same fix in disguise.
 - PR #6304 (`given`/`with` pointy-scalar writeback, session 107) fixed a
   *different* instance of "pointy param mutation lost on scope exit" using a
   compile-time-slot-based capture/restore around `BlockLocalScope`'s Nil
   reset — that mechanism does NOT apply here, because the loss here is not a
   scope-exit Nil reset, it is a **snapshot-vs-live-alias representation gap**
   at the array-element level.
+- `docs/adr/0027-loop-frozen-value-capture-cascade.md` (loop-var closure
+  capture freezing, unrelated bug but adjacent architecture) independently
+  arrives at the same "a genuine per-binding `ContainerRef` cell is the
+  clean end state" conclusion in its Slice 3 retirement-path note and
+  Alternative 4 — for closure-CAPTURE cell identity there, for array-ELEMENT
+  aliasing here. Different surface, possibly a shared underlying primitive;
+  read both before scoping a "fresh cell per binding" campaign.
 
 ## Suggested next steps
 


### PR DESCRIPTION
## Summary

- Closes ADR-0027 Slice 3 (retirement-path documentation) — the content was already written into the ADR at authoring time, so this just closes the Status line and adds a forward cross-link.
- `todo/deep/for-loop-rw-element-alias-lost-through-deferred-closure.md` (surfaced during the ADR's Slice 2 audit, filed separately) independently root-caused to the same "a genuine per-binding `ContainerRef` cell is the clean end state" conclusion as this ADR's retirement path — for array elements rather than loop-capture cells. Cross-linked both ways.
- Fixes a stale path reference in the ADR (the ticket moved from `todo/tickets/` to `todo/deep/` after root-causing).
- Records that `native-pointy-param-is-rw-writeback-missing.md` (flagged as a possible sibling of the element-alias ticket) turned out to be an unrelated, narrower compiler bug — fixed in PR #6334 — confirming the element-alias gap is genuinely separate, not the same fix in disguise.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)