### PR TITLE
fix(compiler): untyped expression-position decl clears stale bare-name type constraints

### DIFF
--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -197,8 +197,32 @@ impl Compiler {
                         let name_idx = self.code.add_constant(Value::str(name.clone()));
                         let tc_idx = self.code.add_constant(Value::str(pre_tc));
                         self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                    } else if type_constraint.is_none() && !name.contains("__ANON") {
+                        // An UNTYPED expression-position declaration must clear a
+                        // stale constraint the bare-name-keyed registry holds from
+                        // an unrelated earlier lexical (a module sub's
+                        // `my Int @r` made the test script's `(my @r = ...)`
+                        // reject its rows — Text::CSV t/79_callbacks.t). The
+                        // statement-position decl clears via SetVarDynamic, which
+                        // this path never emits; an empty constraint means CLEAR.
+                        let name_idx = self.code.add_constant(Value::str(name.clone()));
+                        let tc_idx = self.code.add_constant(Value::str(String::new()));
+                        self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
                     }
                     self.compile_expr(expr);
+                    // Re-clear AFTER the initializer: evaluating the RHS can call
+                    // into code that declares its own typed same-named lexical
+                    // (Text::CSV's `my Int @r = @!crange` runs inside
+                    // `getline_all`), re-registering the bare-name constraint the
+                    // pre-clear just removed — the SetGlobal below must not see it.
+                    if type_constraint.is_none()
+                        && !name.contains("__ANON")
+                        && Self::expr_decl_settable_constraint(name, type_constraint).is_none()
+                    {
+                        let name_idx = self.code.add_constant(Value::str(name.clone()));
+                        let tc_idx = self.code.add_constant(Value::str(String::new()));
+                        self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                    }
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
                     // Mark a fresh declaration so SetGlobal creates a NEW container
                     // (not an in-place reuse of the previous evaluation's), keeping

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1717,6 +1717,14 @@ impl Interpreter {
             OpCode::SetVarType { name_idx, tc_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
                 let raw_constraint = Self::const_str(code, *tc_idx).to_string();
+                // Empty constraint = CLEAR: an untyped expression-position
+                // declaration dropping a stale same-named constraint (the
+                // compiler never emits an empty string for a real type).
+                if raw_constraint.is_empty() {
+                    self.vm_set_var_type_constraint(&name, None);
+                    *ip += 1;
+                    return Ok(());
+                }
                 // Resolve type capture variables (e.g., `T` → `Int` when `::T`
                 // was captured earlier in the signature).
                 let constraint = loan_env!(self, resolved_type_capture_name(&raw_constraint));

--- a/t/expr-decl-stale-type-constraint.t
+++ b/t/expr-decl-stale-type-constraint.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+plan 4;
+
+# The type-constraint registry is keyed by bare name; an UNTYPED
+# expression-position declaration (`ok ((my @r = ...), ...)`) must not
+# inherit a constraint left by an unrelated same-named typed lexical —
+# including one registered DURING the initializer (Text::CSV's
+# `getline_all` runs `my Int @r = @!crange` internally, and the caller's
+# `(my @r = $csv.getline_all($fh))` then rejected its own rows;
+# t/79_callbacks.t aborted at test 31).
+
+sub inner() { my Int @r = 1, 2; @r.elems }
+inner();
+sub pass-through($x, $) { $x }
+
+my $got = pass-through((my @r = ["a"], ["b"]), "t");
+is-deeply @r, [["a"], ["b"]], 'untyped expr-position decl ignores a stale same-named Int constraint';
+ok $got, 'the declaration expression yields the value';
+
+sub rows() { my Int @q = 3, 4; ([<x y>], [<z w>]) }
+my $got2 = pass-through((my @q = rows()), "t");
+is-deeply @q, [[<x y>], [<z w>]], 'a constraint registered DURING the initializer does not apply either';
+
+# A genuinely typed expression-position declaration still enforces.
+my $died = False;
+try { pass-through((my Int @t = "nope",), "t"); CATCH { default { $died = True } } }
+ok $died, 'a typed expr-position decl still type-checks its elements';


### PR DESCRIPTION
## Summary

The var type-constraint registry is keyed by bare name. An untyped **expression-position** declaration (`ok ((my @r = ...), "msg")`) never emits `SetVarDynamic` (the statement-position op that clears stale constraints), so it inherited a constraint left by any unrelated same-named typed lexical — even one registered **during its own initializer**: Text::CSV's `getline_all` runs `my Int @r = @!crange` internally (CSV.rakumod:890), so the test script's `(my @r = $csv.getline_all($fh))` died with "Type check failed for an element of @r; expected Int but got Array" and `t/79_callbacks.t` aborted at test 31.

Fix: the untyped expr-decl path emits `SetVarType` with an **empty** constraint — a value the compiler never produces for a real type, which the exec now interprets as CLEAR — both before the initializer and again right before the declaring store.

## Impact

- Text::CSV `t/79_callbacks.t`: abort-at-30 → runs 38 (the remaining failure + abort are two separate module-behavior bugs: predefined `not-blank` filter, callbacks arg validation — next slices).
- Pin: `t/expr-decl-stale-type-constraint.t` (rakudo-verified; also pins that typed expr-decls still enforce).

## Testing

- `make test` green (serialized run).
- 296 `t/*type*|*constraint*|*decl*` files: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)