### PR TITLE
fix(dispatch): ADR-0019 E9a -- flat deferral expansion replaces bare MRO-walk ordering

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3873,6 +3873,17 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   That prerequisite was fixed the same day (the Int/Rat→Num "numeric widening" removed from the
   shared matcher and binder — `news/2026-08/multi-num-param-strictness.md`), so E9a's remaining
   blocker is only the cursor sequence-builder work itself.
+  **Progress 2026-08-12 (same day) — E9a sequence-builder landed for the both-levels-multi-order
+  shape.** `src/runtime/resolution_deferral.rs`'s `resolve_deferral_expansion` replaces
+  `resolve_all_methods_with_owner` as the ordering source at both "remaining"-building call
+  sites; both design-doc probes are now exact hits against Rakudo v2026.06 (not just
+  predictions), pinned by `t/defer-multi-cross-level-proto-block.t`. Deliberately narrower than
+  the full box: the winner-removal mechanism and `MethodDispatchFrame`'s `Vec`-based storage are
+  unchanged (the `DispatchCursor{seq, next, invocant, args}` index-based rewrite is orthogonal
+  perf/cleanliness work, left for a follow-up slice), and the role-shadow/explicit-proto-isolation
+  divergence tickets remain open (distinct fixes, not implied by decision 2's redraw — see the
+  design doc's 2026-08-12 progress note for detail). E9b (wrap-prefix) and E9c (proto `{*}`
+  rewrite, `samewith`) are unstarted.
 - [ ] **E10 — Move wrap/unwrap mutation into canonical entries.** Bump the generation and remove
   wrap-specific cache-clearing paths.
   **Design 2026-08-10** (same doc): `method_wrap_chains` moves into the registry; every

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -793,7 +793,26 @@ impl Interpreter {
         {
             return false;
         }
-        let all_candidates = self.resolve_all_methods_with_owner(receiver_class, method_name, args);
+        // ADR-0019 E9a: the flat deferral expansion (`resolution_deferral.rs`) replaces
+        // `resolve_all_methods_with_owner` as the ordering source — see its module doc for why
+        // a raw MRO walk in declaration order does not reproduce raku's own deferral order once
+        // a `multi method` spans MRO levels. The expansion is structural (unfiltered); apply the
+        // same per-call, invocant-blind argument match `resolve_all_methods_with_owner` used to
+        // apply internally.
+        let role_bindings = self.registry().get_role_param_bindings(receiver_class);
+        let expansion = self.resolve_deferral_expansion(receiver_class, method_name);
+        let mut all_candidates: Vec<(Symbol, super::MethodDef)> = Vec::new();
+        for (owner, def) in expansion {
+            if self.method_args_match_for_invocant(
+                receiver_class,
+                &def,
+                args,
+                role_bindings.as_ref(),
+                None,
+            ) {
+                all_candidates.push((owner, def));
+            }
+        }
         // Fast path: with zero or one candidate there is nothing to defer to, so no
         // dispatch frame is ever pushed (the single candidate is the chosen one and
         // gets skipped, leaving `remaining` empty). Returning early here avoids the

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -289,7 +289,24 @@ impl Interpreter {
             if skip_remaining {
                 return Vec::new();
             }
-            let all = this.resolve_all_methods_with_owner(receiver_class_name, method_name, &args);
+            // ADR-0019 E9a: the flat deferral expansion (`resolution_deferral.rs`) replaces
+            // `resolve_all_methods_with_owner` as the ordering source — see its module doc.
+            // The expansion is structural (unfiltered); apply the same per-call, invocant-blind
+            // argument match `resolve_all_methods_with_owner` used to apply internally.
+            let role_bindings = this.registry().get_role_param_bindings(receiver_class_name);
+            let expansion = this.resolve_deferral_expansion(receiver_class_name, method_name);
+            let mut all: Vec<(Symbol, MethodDef)> = Vec::new();
+            for (owner, def) in expansion {
+                if this.method_args_match_for_invocant(
+                    receiver_class_name,
+                    &def,
+                    &args,
+                    role_bindings.as_ref(),
+                    None,
+                ) {
+                    all.push((owner, def));
+                }
+            }
             let chosen_fp = this.method_def_fingerprint(method_def);
             let mut remaining = Vec::new();
             let mut skipped = false;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -373,6 +373,7 @@ pub(crate) mod registration_sub;
 mod registry;
 pub(crate) mod resolution;
 mod resolution_call_sub;
+mod resolution_deferral;
 mod resolution_eval;
 mod resolution_lazy;
 pub(crate) mod resolution_map_grep;

--- a/src/runtime/resolution_deferral.rs
+++ b/src/runtime/resolution_deferral.rs
@@ -1,0 +1,185 @@
+//! ADR-0019 Phase E box E9a: the flat deferral expansion.
+//!
+//! [`Interpreter::resolve_deferral_expansion`] replaces [`Self::resolve_all_methods_with_owner`]
+//! as the ordering source for a method dispatch's `nextsame`/`callsame`/`nextwith`/`callwith`
+//! "remaining" candidate list. The two functions answer the same question (every candidate a
+//! deferral from `class_name.method_name` can still reach) but order it differently:
+//! `resolve_all_methods_with_owner` walks the MRO once, per-level, in stored declaration order;
+//! this box instead builds the ordering raku itself uses — one block per MRO class, where a
+//! class with `multi method` candidates contributes its *governing proto's specificity-ranked
+//! candidate block* rather than its own bare declaration order. See "E9 design decision 2 —
+//! REDRAWN" in `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` for the raku ground
+//! truth (two confirmed predictions, `t/defer-multi-cross-level-proto-block.t`) this
+//! reproduces.
+//!
+//! **The governing block, recursively.** For an MRO class `K` that declares its own `multi
+//! method` candidates for `name`:
+//! - if `K` declares its OWN `proto method name` (explicit), `K`'s block is exactly `K`'s own
+//!   candidates, ranked — ancestor candidates are NOT merged in (an explicit proto isolates the
+//!   subtree it roots from whatever the same name means further up the MRO);
+//! - otherwise (an implicit proto), `K`'s block is `K`'s own candidates merged with the nearest
+//!   ancestor's own governing block (found by walking the MRO past `K`), all ranked together as
+//!   one set.
+//!
+//! Ranking is **nominal** (declared-type narrowness, not a distance to any particular call's
+//! argument values — the block is a structural fact of the class hierarchy, consulted the same
+//! way regardless of which args a later `nextwith`/`callwith` substitutes), with MRO depth
+//! (more-derived first) then declaration order breaking ties. Per-call argument matching still
+//! happens exactly where it always has — the caller of [`Self::resolve_deferral_expansion`]
+//! filters this list with [`Self::method_args_match_for_invocant`], same as it filtered
+//! `resolve_all_methods_with_owner`'s output.
+//!
+//! The same candidate can legitimately occur more than once in the expansion (once per governing
+//! block it is merged into) — this is not a dedup bug. A parent's multi candidate that also
+//! covers the child's own governing block re-runs when deferral walks past the child's block
+//! into the parent's own block (raku ground truth, `defer-multi-cross-level-proto-block.t`).
+
+use super::*;
+
+impl Interpreter {
+    /// The overloads `class_name` declares directly for `method_name` (not inherited) —
+    /// identical read to [`Self::resolve_all_methods_with_owner`]'s per-level lookup (class
+    /// table, falling back to the role table for an MRO entry that is a punned role rather than
+    /// a class). Deliberately NOT [`crate::runtime::registry::Registry::user_method_overloads`]
+    /// (aka `get_method_overloads`): that table has a known gap for a role that was never
+    /// punned (see `resolution_sequence.rs`'s module doc) which `resolve_all_methods_with_owner`
+    /// does not share, and this function must not regress it.
+    fn own_overloads_at_level(&mut self, owner: &str, method_name: &str) -> Option<Vec<MethodDef>> {
+        let registry = self.registry();
+        registry
+            .classes
+            .get(owner)
+            .and_then(|c| c.methods.get(method_name))
+            .or_else(|| {
+                registry
+                    .roles
+                    .get(owner)
+                    .and_then(|r| r.methods.get(method_name))
+            })
+            .cloned()
+    }
+
+    /// Nominal (argument-independent) narrowness of `def`'s positional, non-slurpy parameter
+    /// types: the sum of each type constraint's own MRO depth (an `Int` constraint scores
+    /// higher than an `Any` one because `Int`'s MRO chain is longer), mirroring how
+    /// [`Self::pick_method_winner`]'s distance-based ranking treats a deeper nominal type as
+    /// more specific, but without reference to any call's actual argument values. A subset
+    /// resolves to its ultimate base type first, same as the arg-distance ranking does.
+    fn nominal_positional_narrowness(&mut self, def: &MethodDef) -> usize {
+        let mut total = 0usize;
+        for pd in &def.param_defs {
+            if pd.is_invocant || pd.named || pd.slurpy || pd.double_slurpy {
+                continue;
+            }
+            let Some(tc) = pd.type_constraint.as_deref() else {
+                continue;
+            };
+            let base = Self::constraint_base_for_distance(tc);
+            if base == "Any" || base == "Mu" {
+                continue;
+            }
+            let resolved = if self.registry().subsets.contains_key(base) {
+                self.resolve_subset_base_type(base)
+            } else {
+                base.to_string()
+            };
+            total += self.class_mro(&resolved).len();
+        }
+        total
+    }
+
+    /// Rank `block` in place by nominal narrowness (descending), then MRO depth (ascending —
+    /// more-derived first), stably preserving each entry's incoming relative order (declaration
+    /// order within one owner, or the already-ranked order of a merged-in ancestor block) as the
+    /// final tie-break.
+    fn rank_deferral_block(
+        &mut self,
+        mro_depth: &HashMap<Symbol, usize>,
+        block: &mut [(Symbol, MethodDef)],
+    ) {
+        let scored: Vec<(usize, usize)> = block
+            .iter()
+            .map(|(owner, def)| {
+                (
+                    self.nominal_positional_narrowness(def),
+                    *mro_depth.get(owner).unwrap_or(&usize::MAX),
+                )
+            })
+            .collect();
+        let mut indexed: Vec<usize> = (0..block.len()).collect();
+        indexed.sort_by(|&a, &b| {
+            scored[b]
+                .0
+                .cmp(&scored[a].0)
+                .then(scored[a].1.cmp(&scored[b].1))
+        });
+        let reordered: Vec<(Symbol, MethodDef)> =
+            indexed.into_iter().map(|i| block[i].clone()).collect();
+        block.clone_from_slice(&reordered);
+    }
+
+    /// Build the flat deferral expansion for `(class_name, method_name)` — see the module doc.
+    /// Structural (no argument filtering): the caller matches this against a specific call's
+    /// `arg_values` exactly as it did `resolve_all_methods_with_owner`'s output.
+    pub(crate) fn resolve_deferral_expansion(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Vec<(Symbol, MethodDef)> {
+        let mro = self.class_mro(class_name);
+        let mro_depth: HashMap<Symbol, usize> =
+            mro.iter().enumerate().map(|(idx, s)| (*s, idx)).collect();
+        // Pass 1: bottom-up (nearest-ancestor-first among those still to visit), so a level's
+        // own governing block can merge in an already-computed ancestor block.
+        let mut governing: HashMap<Symbol, Vec<(Symbol, MethodDef)>> = HashMap::new();
+        for (idx, owner) in mro.iter().enumerate().rev() {
+            let is_ancestor = idx > 0;
+            let owner_str = owner.as_str();
+            let own_multis: Vec<MethodDef> = self
+                .own_overloads_at_level(owner_str, method_name)
+                .into_iter()
+                .flatten()
+                .filter(|d| d.is_multi && !d.is_private && !(d.is_my && is_ancestor))
+                .collect();
+            let explicit_proto = self
+                .registry()
+                .method_entry_proto(owner_str, method_name)
+                .is_some();
+            if own_multis.is_empty() && !explicit_proto {
+                continue;
+            }
+            let mut block: Vec<(Symbol, MethodDef)> =
+                own_multis.into_iter().map(|d| (*owner, d)).collect();
+            if !explicit_proto
+                && let Some(ancestor_block) = mro[idx + 1..].iter().find_map(|a| governing.get(a))
+            {
+                block.extend(ancestor_block.iter().cloned());
+            }
+            self.rank_deferral_block(&mro_depth, &mut block);
+            governing.insert(*owner, block);
+        }
+        // Pass 2: top-down (receiver first), concatenating each level's contribution.
+        let mut expansion = Vec::new();
+        for (idx, owner) in mro.iter().enumerate() {
+            let is_ancestor = idx > 0;
+            let owner_str = owner.as_str();
+            let Some(overloads) = self.own_overloads_at_level(owner_str, method_name) else {
+                continue;
+            };
+            if overloads.iter().any(|d| d.is_multi) {
+                if let Some(block) = governing.get(owner) {
+                    expansion.extend(block.iter().cloned());
+                }
+            } else {
+                for def in overloads {
+                    if def.is_private || (def.is_my && is_ancestor) {
+                        continue;
+                    }
+                    expansion.push((*owner, def));
+                }
+            }
+        }
+        Self::drop_flattened_role_duplicates(&mut expansion);
+        expansion
+    }
+}

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -456,7 +456,7 @@ impl Interpreter {
         total
     }
 
-    fn constraint_base_for_distance(constraint: &str) -> &str {
+    pub(crate) fn constraint_base_for_distance(constraint: &str) -> &str {
         let s = if constraint.ends_with(":D") || constraint.ends_with(":U") {
             &constraint[..constraint.len() - 2]
         } else {
@@ -629,7 +629,7 @@ impl Interpreter {
     /// `nextsame`/`callsame` chain. (Rakudo does not keep the role in the MRO at
     /// all, which is why it never sees the duplicate.) Drop the role's own copy
     /// whenever a class level already carries the flattened one.
-    fn drop_flattened_role_duplicates(matches: &mut Vec<(Symbol, MethodDef)>) {
+    pub(crate) fn drop_flattened_role_duplicates(matches: &mut Vec<(Symbol, MethodDef)>) {
         let flattened: HashSet<&str> = matches
             .iter()
             .filter_map(|(_, def)| def.role_origin.as_deref())

--- a/t/defer-multi-cross-level-proto-block.t
+++ b/t/defer-multi-cross-level-proto-block.t
@@ -1,0 +1,45 @@
+use Test;
+
+# ADR-0019 E9a ground-truth pin (verified against Rakudo v2026.06, 2026-08-12):
+# when a `multi method` spans several MRO levels with no explicit proto anywhere
+# (an implicit proto), the deferral order is the FLAT per-MRO-class expansion of
+# "E9 design decision 2 -- REDRAWN" (todo/deep/adr0019-e8-e11-candidate-sequence-
+# semantics.md), not a bare MRO-level walk in stored declaration order:
+#
+#   for each MRO class K that declares its own multi candidates:
+#     K's block = K's own candidates merged with the nearest ancestor's own
+#     governing block (all ranked together, narrowest first, MRO depth then
+#     declaration order breaking ties) -- unless K declares its OWN explicit
+#     proto, which isolates the block to K's own candidates only.
+#
+# Two confirmed predictions (made against the model before running raku), now
+# pinned. (todo/tickets/role-shadowed-method-in-defer-chain.md and
+# todo/tickets/explicit-child-proto-assumes-parent-candidates.md remain open --
+# NOT covered by this pin.)
+
+plan 2;
+
+# Probe 1: exhausting the merged block falls to the parent proto's OWN block,
+# re-running its candidate -- a legitimate re-visit, not a dedup bug.
+my @ev1;
+class P {
+    multi method m(Int $x) { @ev1.push("P:Int"); nextsame; @ev1.push("P:u") }
+}
+class C is P {
+    multi method m(Int $x) { @ev1.push("C:Int"); nextsame; @ev1.push("C:u") }
+    multi method m(Any $x) { @ev1.push("C:Any"); nextsame; @ev1.push("C:A-u") }
+}
+C.new.m(1);
+is @ev1.join("|"), "C:Int|P:Int|C:Any|P:Int",
+    "cross-level multi expansion: C:Int, P:Int, C:Any, P:Int (P:Int visited twice)";
+
+# Probe 2: three-level implicit-clone chain; the per-call signature filter
+# (strict, per multi-num-param-strictness) skips the Str/Num candidates at
+# every level, leaving only A:Int -- reached three times, once per block.
+my @ev2;
+class A { multi method m(Int $x) { @ev2.push("A:Int"); nextsame; @ev2.push("A:u") } }
+class B is A { multi method m(Str $x) { @ev2.push("B:Str"); nextsame; @ev2.push("B:u") } }
+class Ch is B { multi method m(Num $x) { @ev2.push("Ch:Num"); nextsame; @ev2.push("Ch:u") } }
+Ch.new.m(1);
+is @ev2.join("|"), "A:Int|A:Int|A:Int",
+    "cross-level implicit-clone chain with a strict per-call filter: A:Int x3";

--- a/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
+++ b/todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md
@@ -629,3 +629,34 @@ exclusion, explicit-proto isolation, probes 1/2 above) written with raku's expec
 the same PR, and (iii) a local `make roast` per the house rule for dispatch-semantics changes.
 The matcher-strictness ticket is a prerequisite or co-requisite: without it the stricter
 advance filter cannot be expressed.
+
+**Progress 2026-08-12 (same day) — E9a landed for the both-levels-multi-order shape only; the
+DispatchCursor struct itself is deferred.** `src/runtime/resolution_deferral.rs` adds
+`Interpreter::resolve_deferral_expansion`, a new ordering source that replaces
+`resolve_all_methods_with_owner` at the two "remaining"-building call sites
+(`accessors_state.rs::push_method_dispatch_frame`, `class_dispatch.rs`'s `build_remaining`
+closure): it builds the flat per-MRO-class expansion described above (implicit-clone-merge
+ranked by nominal narrowness/MRO-depth/decl-order, explicit-proto isolation) instead of a bare
+per-level declaration-order walk. Both probes 1 and 2 above are exact hits against Rakudo
+v2026.06 (verified with `raku` directly, not just predicted) and pinned in
+`t/defer-multi-cross-level-proto-block.t`; all 12 E9-pre pins plus the full `multi`/`nextsame`/
+`callsame`/`wrap`/`proto`/`defer`/`samewith` corner of `t/` (148 files) stay green.
+
+Two scope decisions, both deliberate:
+- **The winner-removal mechanism (fingerprint-compare-and-skip) is UNCHANGED** — only its input
+  ordering changed, from `resolve_all_methods_with_owner`'s output to
+  `resolve_deferral_expansion`'s. This is a smaller, lower-risk slice than decision 2's full
+  `DispatchCursor{seq, next, invocant, args}` (index-based, no re-walk) — that mechanical
+  refactor is orthogonal to the *ordering* fix that raku ground truth actually demands and is
+  left for a follow-up (`MethodDispatchFrame` still carries a re-derived `Vec`, not an `Arc`
+  sequence + cursor index). No observable behavior depends on which storage shape is used.
+- **`role-shadowed-method-in-defer-chain.md` and `explicit-child-proto-assumes-parent-
+  candidates.md` remain OPEN, not fixed by this slice.** The role-shadow ticket needs
+  `resolve_deferral_expansion` (or its shared `own_overloads_at_level` read) to also drop a
+  role's raw MRO entry when a class level shadows it with an independently-authored override —
+  a distinct fix from the ordering redraw, not implied by decision 2. The explicit-proto ticket
+  is about the `{*}` re-entry itself (`dispatch_proto_call.rs` re-entering
+  `call_method_with_values` by name, which still walks the OLD `resolve_method_with_owner_impl`
+  MRO walker for the *winner*, unaffected by this box) — that is E9c's job per decision 2's own
+  migration order. Filing new pins for either shape now would encode a still-open mutsu bug as
+  a passing test; both tickets stay as-is.


### PR DESCRIPTION
## Summary
- `nextsame`/`callsame`/`nextwith`/`callwith` previously deferred through a receiver's MRO in plain per-level declaration order. When a `multi method` spans several MRO levels with no explicit proto, raku instead defers along a per-MRO-class "governing proto" block, per `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`'s "E9 design decision 2 -- REDRAWN".
- Adds `Interpreter::resolve_deferral_expansion` (`src/runtime/resolution_deferral.rs`) as the new ordering source at both `push_method_dispatch_frame` call sites, replacing `resolve_all_methods_with_owner` there.
- Both raku ground-truth probes from the design doc are now exact hits against Rakudo v2026.06 (verified directly, not just predicted), pinned by `t/defer-multi-cross-level-proto-block.t`.
- Deliberately scoped: only the ordering changes. `MethodDispatchFrame`'s existing `Vec`-based storage and fingerprint-based winner-removal are unchanged (the `DispatchCursor` index-based rewrite is orthogonal follow-up work); the role-shadow-exclusion and explicit-proto-isolation divergence tickets remain open (distinct root causes, not implied by this redraw).

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] New pin `t/defer-multi-cross-level-proto-block.t` passes and matches `raku` exactly for both probes
- [x] All 12 existing E9-pre pins + 148 `multi`/`nextsame`/`callsame`/`wrap`/`proto`/`defer`/`samewith` `t/` files pass
- [x] `make test` (full TAP suite, debug build): PASS, 28780 tests
- [x] `make roast` (full whitelist, release build): PASS, 218836 tests, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)