### PR TITLE
fix(runtime): Iterable-instance iteration methods use the user iterator; class-body hash/array reads find sibling my lexicals

### DIFF
--- a/news/2026-08/iterable-instance-dispatch-and-class-body-lexical-reads.md
+++ b/news/2026-08/iterable-instance-dispatch-and-class-body-lexical-reads.md
@@ -1,0 +1,50 @@
+# Iterable-instance iteration methods and class-body lexical reads (Text::CSV 79_callbacks green)
+
+Two general interpreter bugs found via Text::CSV's `t/79_callbacks.t`
+(predefined filter hooks), which now passes 90/90 (was: aborting at 38).
+
+## 1. `.first`/`.map`/... on a user Iterable instance ignored its iterator
+
+A class that `does Iterable` and defines `method iterator` was treated as a
+single opaque item by Any's iteration methods — `$row.first: { $_ ne "" }`
+tested the row object itself (whose `Str` is the joined line, hence truthy
+for any multi-field row), so Text::CSV's `not_empty`/`filled` predefined
+filters passed all-empty rows.
+
+Fix: `call_method_with_values` now routes exactly the methods Rakudo sends
+through `self.iterator` — `first`/`map`/`grep`/`sort`/`head`/`tail`/`flat`
+(measured; `join`/`reverse`/`list`/`elems`/`kv`/`pairs`/`values`/`Array`/
+`cache`/`eager` deliberately keep single-item semantics to match Rakudo) —
+through `try_iterable_instance_items` (the same driver `for $obj` uses),
+only when the class does not provide the method itself. A matching bypass
+in `try_native_method_raw` keeps the native `flat` impl from intercepting
+first. Pin: `t/iterable-instance-list-methods.t`.
+
+## 2. Class-body reads of a sibling statement's `my` hash/array got a fresh empty one
+
+Each class-body statement compiles as its own chunk, so a read of a `my`
+hash/array declared by an earlier body statement was compiled
+package-qualified (`%C::predef`) while the declaration flushed to env under
+the bare sigiled name (`%predef`). `GetHashVar`/`GetArrayVar` had no
+qualifier-stripping fallback (scalars already had one in `GetGlobal`) and
+silently produced a brand-new empty Hash/Array. Text::CSV's
+
+```raku
+%predef-hooks<not-empty> = %predef-hooks<not_empty>;
+```
+
+alias rows therefore assigned `Any`, and `callbacks("filter", "not-empty")`
+died with error 1004.
+
+Fix: `auto_qualified_bare_env_read` (mirrors the `GetGlobal` bare-component
+fallback; only fires when the qualifier is exactly the current package, so
+foreign `%Other::h` reads still cannot reach another package's `my`
+lexicals). Pin: `t/class-body-lexical-read.t`.
+
+Residue filed as `todo/tickets/class-body-scalar-reassignment-lost.md`: the
+WRITE side of the same asymmetry (`$x = 20` in a class body lands under
+`C::x`, which nothing reads back).
+
+Text::CSV suite frontier after this: `55_combi` (regex-engine panic at
+test 78), `66_formula` (type-check failure at line 129), `46_eol_si`
+(typed-array `.raku` parameterization + a type-object-gist row).

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -260,6 +260,28 @@ impl Interpreter {
                 .unwrap_or_else(|| Value::array(vec![]));
             return self.call_method_with_values(frames, method, args);
         }
+        // A user class that `does Iterable` and defines its own `iterator`
+        // method is list-like for Any's ITERATION methods: `.first`/`.map`/...
+        // operate on the iterator's elements (as `for $obj` already does via
+        // `try_iterable_instance_items`), not on the instance as one opaque
+        // item. The method set is exactly what Rakudo routes through
+        // `self.iterator` — measured 2026-08-12 on such an instance:
+        // first/map/grep/sort/head/tail/flat iterate, while join/reverse/
+        // list/List/elems/kv/pairs/values/Array/cache/eager all treat the
+        // instance as a single item (even non-itemized), so those must NOT
+        // be routed. Only methods the class itself does not provide qualify.
+        if matches!(
+            method,
+            "grep" | "map" | "first" | "sort" | "head" | "tail" | "flat"
+        ) && let ValueView::Instance { class_name, .. } = target.view()
+        {
+            let cn = class_name.as_str().to_string();
+            if !self.has_user_method(&cn, method)
+                && let Some(items) = self.try_iterable_instance_items(&target)?
+            {
+                return self.call_method_with_values(Value::array(items), method, args);
+            }
+        }
         // Scalar containers are transparent for method dispatch (except .item,
         // .VAR, and .raku/.perl). `.raku`/`.perl` must see the `Scalar` wrapper
         // so an itemized aggregate shows its `$` sigil (`${a=>1}.raku` →

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -355,6 +355,32 @@ impl Interpreter {
             .cloned()
     }
 
+    /// Outer-lexical fallback for auto-qualified `@`/`%` reads, mirroring the
+    /// bare-component fallback in `GetGlobal`. Each class-body statement
+    /// compiles as its own chunk under the class package, so a read of a `my`
+    /// declared by an EARLIER body statement is compiled package-qualified
+    /// (`%C::predef`) while the declaration flushed to env under the bare
+    /// sigiled name (`%predef`). When the qualifier is exactly the current
+    /// package (i.e. the compiler added it, not the user), retry env with the
+    /// bare sigiled name. An explicitly written foreign qualifier
+    /// (`%Other::h`) never matches `current_package`, so `my` lexicals stay
+    /// invisible across packages.
+    pub(super) fn auto_qualified_bare_env_read(&self, name: &str) -> Option<Value> {
+        let cur = self.current_package();
+        if cur.is_empty() || cur == "GLOBAL" {
+            return None;
+        }
+        let (sigil, rest) = match name.as_bytes().first() {
+            Some(b @ (b'@' | b'%')) => (*b as char, &name[1..]),
+            _ => return None,
+        };
+        let (pkg, bare) = rest.rsplit_once("::")?;
+        if bare.is_empty() || pkg != cur {
+            return None;
+        }
+        self.get_env_with_main_alias(&format!("{sigil}{bare}"))
+    }
+
     /// Read a file-scope `my` lexical of the compunit the running routine belongs
     /// to (see [`Interpreter::unit_lexicals`]). Consulted BEFORE `env`, because the
     /// whole point of the store is that the loading scope's same-named `my` — which

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -627,6 +627,8 @@ impl Interpreter {
                     // A file-scope `my @a` of the running routine's own module
                     // (see `module_scope_lexicals`; keys keep the `@` sigil).
                     .or_else(|| self.module_scope_lexical(name).cloned())
+                    // Class-body outer-lexical fallback — see the GetHashVar twin.
+                    .or_else(|| self.auto_qualified_bare_env_read(name))
                     .unwrap_or_else(|| {
                         // An undeclared `@`-sigil variable defaults to an empty
                         // Array (raku auto-declares it as Array under `no strict`):
@@ -733,7 +735,14 @@ impl Interpreter {
                     // belongs to (see `module_scope_lexicals`; the table keys
                     // keep the `%` sigil). Last resort, after every live store —
                     // mirrors the scalar fallback in `GetGlobal`.
-                    .or_else(|| self.module_scope_lexical(name).cloned());
+                    .or_else(|| self.module_scope_lexical(name).cloned())
+                    // Outer-lexical fallback, mirroring GetGlobal: each class-body
+                    // statement compiles as its own chunk, so a read of a `my`
+                    // declared by an earlier body statement was auto-qualified
+                    // (`%C::predef`) while the declaration flushed to env under the
+                    // bare sigiled name (`%predef`). Strip the qualifier and retry
+                    // when it names the current package.
+                    .or_else(|| self.auto_qualified_bare_env_read(name));
                 match val {
                     // Decontainerize a top-level `ContainerRef` cell from a
                     // whole-container `:=` bind (`my %h2 := %h`); the read

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -69,6 +69,32 @@ impl Interpreter {
             }
         }
         let method_name = method_sym.resolve();
+        // An Iterable user instance with its own `iterator` method routes the
+        // Any iteration methods through that iterator (the arm in
+        // `call_method_with_values`); a native impl (e.g. `flat`) would treat
+        // the instance as one opaque item instead, so decline it here.
+        if matches!(
+            method_name.as_str(),
+            "grep" | "map" | "first" | "sort" | "head" | "tail" | "flat"
+        ) {
+            let cn = match target.view() {
+                ValueView::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } if !attributes.contains_key("__mutsu_array_storage") => {
+                    Some(class_name.as_str().to_string())
+                }
+                _ => None,
+            };
+            if let Some(cn) = cn
+                && self.class_does_role(&cn, "Iterable")
+                && self.has_user_method(&cn, "iterator")
+                && !self.has_user_method(&cn, method_name.as_str())
+            {
+                return None;
+            }
+        }
         // A `Seq.new($iterator)` stores its iterator deferred (empty backing vec).
         // The native impls below read that empty vec directly and would yield
         // nothing (`.List`/`.elems`/`.Array`/...). Defer such a Seq to the

--- a/t/class-body-lexical-read.t
+++ b/t/class-body-lexical-read.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# Each class-body statement compiles as its own chunk, so a read of a `my`
+# hash/array declared by an EARLIER body statement was compiled
+# package-qualified (%C::predef) while the declaration flushed to env under
+# the bare sigiled name (%predef). Without the bare-name fallback the read
+# silently produced a fresh empty Hash/Array.
+# (Text::CSV's `%predef-hooks<not-empty> = %predef-hooks<not_empty>;` alias
+# rows assigned Any because the RHS read an empty hash.)
+
+plan 6;
+
+class C {
+    my %predef = a => 1, b => 2;
+    %predef<c> = %predef<a>;          # RHS reads the class-body my hash
+    my $keys-in-body = %predef.keys.sort.join(",");
+    my @arr = 1, 2;
+    my $arr-in-body = @arr.join(",");
+    @arr.push(@arr[0] + @arr[1]);     # element read + push
+    method keys-in-body { $keys-in-body }
+    method arr-in-body  { $arr-in-body }
+    method h { %predef.keys.sort.join(",") }
+    method c-val { %predef<c> }
+    method a { @arr.join(",") }
+}
+
+is C.keys-in-body, "a,b,c", "class-body statement reads the my hash declared earlier";
+is C.h, "a,b,c", "method sees all class-body writes";
+is C.c-val, 1, "element copied from a class-body hash read is the real value";
+is C.arr-in-body, "1,2", "class-body statement reads the my array declared earlier";
+is C.a, "1,2,3", "array element reads during class body see the real elements";
+
+# A foreign qualifier must NOT reach another package's my lexical
+class D {
+    my %hidden = secret => 1;
+    method peek { %hidden.elems }
+}
+is D.peek, 1, "sibling class my hash stays intact";

--- a/t/iterable-instance-list-methods.t
+++ b/t/iterable-instance-list-methods.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# A user class that does Iterable and defines its own `iterator` method is
+# list-like for Any's ITERATION methods: .first/.map/.grep/.sort/.head/.tail/
+# .flat operate on the iterator's elements, not on the instance as a single
+# opaque item. (Text::CSV's CSV::Row predefined filters rely on this: the
+# not_empty hook is `{ $^row.first: { .defined && $_ ne "" } }` — treating the
+# row as one item made every multi-field all-empty row pass the filter.)
+# NOTE (measured against rakudo 2026-08-12): join/reverse/list/List/elems/kv/
+# pairs/values/Array/cache/eager do NOT iterate such an instance — they treat
+# it as one item — so they are deliberately absent here.
+
+plan 11;
+
+class Row does Iterable does Positional {
+    has @.fields;
+    method iterator () { @!fields.iterator }
+    method AT-POS (int $i) { @!fields.AT-POS($i) }
+    method elems { @!fields.elems }
+}
+
+my $empty = Row.new(fields => ["", ""]);
+my $mixed = Row.new(fields => ["", "x", ""]);
+
+# .first iterates the fields, so an all-empty row yields no match
+my $hit = $empty.first: { .defined && $_ ne "" };
+nok $hit.defined, '.first on all-empty Iterable instance finds nothing';
+is ($mixed.first: { .defined && $_ ne "" }), "x",
+    '.first on Iterable instance finds the matching element';
+
+# .map / .grep iterate elements
+is $mixed.map({ "<$_>" }).join("|"), "<>|<x>|<>",
+    '.map iterates the user iterator elements';
+is $mixed.grep({ $_ ne "" }).elems, 1, '.grep iterates elements';
+
+# .sort / .head / .tail / .flat
+is Row.new(fields => ["b", "a", "c"]).sort.join(""), "abc", '.sort iterates elements';
+is $mixed.head, "", '.head reads the first element';
+is $mixed.tail, "", '.tail reads the last element';
+is $mixed.flat.elems, 3, '.flat iterates elements';
+
+# A method the class itself defines still wins over the routed fallback
+is $mixed.elems, 3, "user-defined elems method still dispatches";
+
+# join does NOT iterate: the instance is one item (rakudo-verified)
+my $joined = Row.new(fields => ["1", "2"]).join(",");
+nok $joined.contains(","), '.join treats the instance as a single item';
+
+# elems without a user method: one item, not the iterator length
+class Row2 does Iterable {
+    method iterator () { ("a", "b", "c").iterator }
+}
+is Row2.new.elems, 1, '.elems treats the instance as a single item';

--- a/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
+++ b/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
@@ -1,0 +1,58 @@
+# Bare-name type-constraint store is scope-blind (constraint leaks across frames)
+
+`Interpreter::var_type_constraints` is a single global `HashMap<String,
+String>` keyed by BARE variable name. Every typed `my` declaration writes it
+(`set_var_type_constraint`, `src/runtime/runtime_var_meta.rs`), and it is
+never frame-scoped, so a typed lexical in ANY frame leaks its constraint
+onto every same-named variable that is assigned later — across routines,
+even across compunits.
+
+## The shapes seen so far
+
+1. **Fixed case-by-case:** PR #6337 (2026-08-12) made an untyped
+   expression-position decl CLEAR a stale same-named constraint at
+   declaration time. Typed params already avoid the global map entirely
+   (`bind_param_type_constraint` writes env-scoped `__mutsu_type::` only,
+   restored with the frame).
+2. **Open (Text::CSV `t/66_formula.t` line 129):** clearing at declaration
+   is not enough when the leak happens AFTER the victim's declaration. The
+   test script declares untyped `my $e;` (clears fine), then calls
+   `$csv.string`, and Text/CSV.rakumod:921 `my Str $e = $!esc;` inside
+   `method string` re-registers bare "e" → Str in the global map. The
+   module frame exits (its env-scoped entry dies with it) but the global
+   entry survives, so the script's next `CATCH { default { $e = $_ } }`
+   dies "Type check failed in assignment to $e; expected Str but got Any".
+   Repro:
+
+   ```raku
+   class C { method m () { my Str $s = "x"; } }
+   my $s;
+   C.m;
+   $s = 42;   # mutsu: type check failed; raku: fine
+   ```
+
+## Why the quick fixes don't compose
+
+- Making routine-body typed `my` env-only (like params) breaks the global
+  fallback that `bind_param_type_constraint`'s comment documents (EVAL'd
+  re-assignment to a subset-typed lexical), and closures that outlive the
+  frame lose enforcement either way.
+- Restore-on-return bookkeeping (save/restore the global entry per frame)
+  has the same closure problem in the other direction: a closure captured
+  from the dead frame should STILL enforce its lexical's constraint.
+
+## The sound architecture
+
+Rakudo attaches the constraint to the Scalar CONTAINER, not to a name: a
+container created by `my Str $e` carries `of Str` wherever it flows —
+closures keep enforcement, frames leak nothing, names never collide. mutsu
+already has per-container metadata precedents (ArrayData/HashData type
+metadata, ADR-0013 GcBox cells). The fix direction is to carry scalar
+constraints on the container cell (ContainerRef/GcBox layer) and make
+assignment check the TARGET CONTAINER's constraint instead of consulting a
+name-keyed side table; the name-keyed store then shrinks to compile-time /
+EVAL bridging only.
+
+Blocks: Text::CSV `t/66_formula.t` (test after 72, line 129; the suite is
+otherwise expected green through that file). Related pins:
+`t/expr-decl-stale-type-constraint.t` (#6337).

--- a/todo/tickets/class-body-scalar-reassignment-lost.md
+++ b/todo/tickets/class-body-scalar-reassignment-lost.md
@@ -1,0 +1,54 @@
+# Class-body scalar reassignment writes a key nothing reads
+
+A plain reassignment of a class-body `my` scalar by a LATER body statement
+never lands in the store methods close over:
+
+```raku
+class C {
+    my $x = 10;
+    $x = 20;
+    method x { $x }
+}
+say C.x;   # raku: 20, mutsu: 10
+```
+
+## Root cause
+
+Each class-body statement compiles as its own chunk under the class package
+(`compile_decl_stmts_chunk_in_package`, `src/compiler/decl_plan.rs`), so
+reads and writes of a sibling statement's `my` lexical are name-mediated
+through `env` — and the name forms are asymmetric:
+
+- The `my $x = 10` chunk flushes the local to env under the bare sigil-less
+  name `"x"` (`flush_local_to_env`).
+- The `$x = 20` chunk compiles via `emit_set_named_var`
+  (`src/compiler/mod.rs` ~1788) which package-qualifies: `SetGlobal("C::x")`.
+  The value lands under `"C::x"`, which nothing reads back.
+- At body exit `persist_class_body_statics`
+  (`src/runtime/registration_class_body_exit.rs`) copies the BARE env key
+  (`"x"` = 10) into `package_lexicals[C]` — and its skip check
+  (`env.contains_key("C::x")`) can even drop `x` from the store entirely.
+
+The READ side of the same asymmetry (auto-qualified `%C::h` / `@C::a` reads
+missing the bare-name env entry) was fixed 2026-08-13 by
+`auto_qualified_bare_env_read` (`src/vm/vm_env_helpers.rs`, pinned by
+`t/class-body-lexical-read.t`); scalar reads already had the equivalent
+fallback in `GetGlobal`. The WRITE side remains: hash/array ELEMENT writes
+use the bare name (`index_assign_target_name` never qualifies) and so land
+correctly, but whole-scalar (and presumably whole-hash/whole-array)
+reassignment goes to the qualified key.
+
+## Fix directions (pick one)
+
+1. Make `persist_class_body_statics` prefer the qualified env key
+   (`C::x`) over the bare one when both exist for a declared static —
+   smallest fix, makes the method-visible copy correct; in-body reads
+   already see `C::x` via `GetGlobal`'s qualified-first lookup.
+2. Make `emit_set_named_var` not qualify a name that an earlier chunk of
+   the same class body declared (needs cross-chunk declared-name tracking
+   in `class_body_plan`, which `class_declared_static_names` already has —
+   thread it into the chunk compiler's local_map or a no-qualify set).
+
+Found during the Text::CSV 79_callbacks campaign (the hash-read twin was
+the actual blocker; this scalar residue is not needed by the CSV suite).
+Repro: `tmp/repro-b2.raku` shape above.


### PR DESCRIPTION
Two general interpreter bugs found via Text::CSV's `t/79_callbacks.t` (predefined filter hooks), which now passes **90/90** (was: aborting at test 38).

## 1. `.first`/`.map`/... on a user Iterable instance ignored its iterator

A class that `does Iterable` and defines `method iterator` was treated as a single opaque item by Any's iteration methods — `$row.first: { $_ ne "" }` tested the row object itself (whose `Str` is the joined line, truthy for any multi-field row), so Text::CSV's `not_empty`/`filled` predefined filters passed all-empty rows.

`call_method_with_values` now routes **exactly the methods Rakudo sends through `self.iterator`** — `first`/`map`/`grep`/`sort`/`head`/`tail`/`flat` (measured against rakudo; `join`/`reverse`/`list`/`elems`/`kv`/`pairs`/`values`/`Array`/`cache`/`eager` deliberately keep single-item semantics, also rakudo-verified) — through `try_iterable_instance_items` (the same driver `for $obj` uses), only when the class does not provide the method itself. A matching decline in `try_native_method_raw` keeps the native `flat` impl from intercepting first.

Pin: `t/iterable-instance-list-methods.t`.

## 2. Class-body reads of a sibling statement's `my` hash/array got a fresh empty one

Each class-body statement compiles as its own chunk, so a read of a `my` hash/array declared by an earlier body statement was compiled package-qualified (`%C::predef`) while the declaration flushed to env under the bare sigiled name (`%predef`). `GetHashVar`/`GetArrayVar` had no qualifier-stripping fallback (scalars already had one in `GetGlobal`) and silently produced a brand-new empty Hash/Array. Text::CSV's

```raku
%predef-hooks<not-empty> = %predef-hooks<not_empty>;
```

alias rows therefore assigned `Any`, and `callbacks("filter", "not-empty")` died with error 1004.

New `auto_qualified_bare_env_read` mirrors `GetGlobal`'s bare-component fallback; it only fires when the qualifier is exactly the current package, so a foreign `%Other::h` read still cannot reach another package's `my` lexicals.

Pin: `t/class-body-lexical-read.t`.

## Residues filed

- `todo/tickets/class-body-scalar-reassignment-lost.md` — the WRITE side of the same asymmetry (`$x = 20` in a class body lands under `C::x`, which nothing reads back).
- `todo/deep/bare-name-type-constraint-store-is-scope-blind.md` — the `66_formula` blocker (module-method `my Str $e` leaks its constraint onto the script's untyped `$e` via the global bare-name map).

## Verification

- `make test` PASS (full local suite)
- Text::CSV: `79_callbacks` 90/90 (was abort at 38); `90_csv`, `91_csv_cb` 28/28, `92_csv_encoding` unchanged; `55_combi`/`66_formula`/`46_eol_si` unchanged (independent blockers)
- Spot roast: S02 bag/range iterators, S07 iterationbuffer/range-iterator PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)