### PR TITLE
fix(regex): blanket-escape interpolated scalar values instead of an enumerated metachar list

### DIFF
--- a/news/2026-08/regex-scalar-interp-blanket-escape.md
+++ b/news/2026-08/regex-scalar-interp-blanket-escape.md
@@ -1,0 +1,33 @@
+# Regex scalar interpolation escapes every metachar (Text::CSV 55_combi 17009/17009)
+
+An interpolated scalar in a regex matches its value literally — raku never
+re-parses the value as regex source. mutsu's `escape_regex_scalar_literal`
+(src/runtime/regex_parse_modifier.rs) enforced this with an ENUMERATED
+metachar list, which leaked whichever char it forgot: `~` (the goal-match
+marker) survived to the structural parser as a bare `TildeMarker` atom and
+hit the matcher's `unreachable!()` — a hard Rust panic. Text::CSV's
+`t/55_combi.t` aborted at test 77 exactly there: its `@special` char pool
+includes `"~"`, and the module's
+
+```raku
+$t.subst-mutate (/( $q | $e )/, { "$e$0" }, :g);
+```
+
+interpolates the quote/escape chars into an alternation. Minimal repro:
+`my $e = "~"; "a~b" ~~ m/ $e /`.
+
+The list had already grown `'`/`"` and `%`/`&` entries from earlier
+Text::CSV rounds — the enumeration itself was the bug. It is now a blanket
+rule: every char that is not alphanumeric/`_` gets a backslash (whitespace
+keeps its `\x[..]` codepoint form; a backslash before any non-alphanumeric
+char is always a literal in regex slang, while alphanumerics must stay bare
+so escaping cannot CREATE class shorthands like `\d`).
+
+`t/55_combi.t` now runs all **17009/17009** tests green (it exercises the
+full sep/quote/escape combination matrix). Pin:
+`t/regex-scalar-interp-metachar-literal.t`.
+
+Residue filed as
+`todo/tickets/quantified-scalar-regex-interpolation-broken.md`: a
+QUANTIFIED interpolation (`$s?`) never matches — a pre-existing,
+independent defect of the text-splicing design.

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -768,40 +768,17 @@ impl Interpreter {
                 out.push_str(&format!("\\x[{:02X}]", ch as u32));
                 continue;
             }
-            if matches!(
-                ch,
-                '\\' | '.'
-                        | '^'
-                        | '$'
-                        | '*'
-                        | '+'
-                        | '?'
-                        | '('
-                        | ')'
-                        | '['
-                        | ']'
-                        | '{'
-                        | '}'
-                        | '<'
-                        | '>'
-                        | '|'
-                        | ':'
-                        | '#'
-                        // Both quote chars: an unescaped `"` (or `'`) in the
-                        // spliced pattern reads as a quoted-literal opener and
-                        // swallows the rest of the source — `my $q = '"';
-                        // / $q | x /` lost the alternation split entirely
-                        // (Text::CSV's combine/string quoting).
-                        | '\''
-                        | '"'
-                        // `%` (and `%%`) is the separator-quantifier infix and `&`
-                        // is the conjunction infix; an interpolated scalar matches
-                        // *literally* (raku does not re-parse it as regex source),
-                        // so e.g. a `%>` delimiter after `\h*` must not bind as a
-                        // `\h* % ...` separator. Escape them to force literal match.
-                        | '%'
-                        | '&'
-            ) {
+            // Escape EVERY non-identifier char, not an enumerated metachar
+            // list: an interpolated scalar matches *literally* (raku does not
+            // re-parse it as regex source), and the enumerated approach leaked
+            // whichever metachar it forgot — `~` (the goal-match marker)
+            // survived to the structural parser as a bare `TildeMarker` atom
+            // and panicked the matcher (Text::CSV 55_combi with `~` as a
+            // quote/sep/escape char). A backslash before any non-alphanumeric
+            // char is always a literal in regex slang, so blanket-escaping is
+            // safe; alphanumerics and `_` must stay bare (escaping them would
+            // CREATE class shorthands like `\d`/`\w`).
+            if !ch.is_alphanumeric() && ch != '_' {
                 out.push('\\');
             }
             out.push(ch);

--- a/t/regex-scalar-interp-metachar-literal.t
+++ b/t/regex-scalar-interp-metachar-literal.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# An interpolated scalar in a regex matches its value LITERALLY — raku does
+# not re-parse the value as regex source. The escape helper used to carry an
+# enumerated metachar list and leaked whichever char it forgot: `~` (the
+# goal-match marker) survived to the structural parser and PANICKED the
+# matcher (Text::CSV 55_combi with `~` as quote/sep/escape char). Now every
+# non-identifier char is escaped.
+
+plan 14;
+
+# The 55_combi shape: tilde as an alternation branch
+my $e = "~";
+ok "a~b" ~~ m/ $e /, 'interpolated "~" matches literally';
+is $/.Str, "~", 'match is the tilde';
+
+my $q = Q/"/;
+my $t = "a~b";
+$t ~~ s:g/( $q | $e )/X$0/;
+is $t, "aX~b", 'tilde in alternation with capture substitutes correctly';
+
+# Tilde between other atoms must not become the goal-match rewrite.
+# (A QUANTIFIED interpolation `$sep?` is a separate pre-existing bug —
+# todo/tickets/quantified-scalar-regex-interpolation-broken.md.)
+my $sep = "~";
+ok "(~y)" ~~ m/ "(" $sep /, 'tilde after another atom stays literal';
+
+# Every historical leak candidate, one by one
+for < ! = , ; ` / - > -> $ch {
+    my $v = $ch;
+    ok $v ~~ m/^ $v $/, "interpolated {$v.raku} matches itself";
+}
+
+# Alphanumerics must stay bare (escaping them would create class shorthands)
+my $d = "d";
+nok "5" ~~ m/ $d /, 'interpolated "d" does not become \\d';
+ok "d" ~~ m/ $d /, 'interpolated "d" matches literal d';
+
+# A Regex-valued scalar still interpolates as a regex, not a literal
+my $rx = rx/\d+/;
+ok "a42" ~~ m/ $rx /, 'Regex-valued scalar interpolates as regex';

--- a/todo/tickets/quantified-scalar-regex-interpolation-broken.md
+++ b/todo/tickets/quantified-scalar-regex-interpolation-broken.md
@@ -1,0 +1,34 @@
+# Quantified scalar interpolation in regex never matches (`$s?` / `$s+`)
+
+A quantifier attached to an interpolated scalar fails to match:
+
+```raku
+my $s = "z";
+say "(xy)" ~~ m/ $s? /;   # raku: ｢｣ (empty match), mutsu: False
+my $p = "%";
+say "ab" ~~ m/ $p? b /;   # raku: ｢b｣, mutsu: False
+```
+
+Pre-existing (not introduced by the 2026-08-13 blanket-escape fix — the
+same failure reproduces with alphanumeric values that were never escaped).
+
+## Root cause direction
+
+`interpolate_regex_scalars` (src/runtime/regex_parse_modifier.rs) splices
+the scalar's escaped VALUE into the pattern text, wrapped in
+`NON_DECLARATIVE_INTERP_MARK` sentinels, and leaves the following `?`/`+`/
+`*` in place. The structural parser then fails to attach the quantifier to
+the mark-wrapped span (and for a multi-char value it could at best
+quantify the LAST char, while raku quantifies the whole interpolated value
+as ONE atom: `my $s = "abc"; m/ $s? /` optionally matches the whole
+"abc").
+
+The text-splicing design cannot express "this spliced span is one atom".
+Fix direction: lower a quantified `$var` to a real token (like the
+existing match-time `VarInterp` atom, which already exists for `:my`
+regex-locals) instead of splicing text, or make the parser treat a
+MARK...MARK span as a single group atom so a trailing quantifier binds to
+all of it.
+
+Found while pinning the tilde-escape fix (t/regex-scalar-interp-
+metachar-literal.t); Text::CSV does not need it, so it was deferred.


### PR DESCRIPTION
An interpolated scalar in a regex matches its value **literally** — raku never re-parses the value as regex source. mutsu's `escape_regex_scalar_literal` (`src/runtime/regex_parse_modifier.rs`) enforced this with an ENUMERATED metachar list, which leaked whichever char it forgot: an interpolated `"~"` survived to the structural parser as a bare `TildeMarker` atom and hit the matcher's `unreachable!()` — a hard Rust panic.

Text::CSV's `t/55_combi.t` aborted at test 77 exactly there: its `@special` char pool includes `"~"` for sep/quote/escape chars, and the module interpolates them into an alternation (`$t.subst-mutate (/( $q | $e )/, ...)`). Minimal repro:

```raku
my $e = "~"; say "a~b" ~~ m/ $e /;   # panicked; now ｢~｣ (matches raku)
```

The list had already grown `'`/`"` and `%`/`&` entries from earlier Text::CSV rounds — the enumeration itself was the bug. It is now a blanket rule: every char that is not alphanumeric/`_` gets a backslash (whitespace keeps its `\x[..]` codepoint form). A backslash before any non-alphanumeric char is always a literal in regex slang, while alphanumerics must stay bare so escaping cannot CREATE class shorthands like `\d`.

**`t/55_combi.t` now runs all 17009/17009 tests green** (the full sep/quote/escape combination matrix; it was a 0-fail panic-abort at 77).

Pin: `t/regex-scalar-interp-metachar-literal.t` (rakudo-verified, including the `Regex`-valued scalar still interpolating as regex and alphanumerics staying bare).

Residue filed: `todo/tickets/quantified-scalar-regex-interpolation-broken.md` — a QUANTIFIED interpolation (`$s?`) never matches; pre-existing and independent (reproduces with never-escaped alphanumeric values too).

## Verification

- `make test` PASS (full local suite)
- Text::CSV: `55_combi` 17009/17009; `90_csv` / `91_csv_cb` / `66_formula` / `46_eol_si` unchanged
- `raku t/regex-scalar-interp-metachar-literal.t` PASS (spec-faithful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)