### PR TITLE
fix(runtime): user methods shadow inherited native methods; container args read element type from value metadata

### DIFF
--- a/news/2026-08/native-shadow-and-container-arg-constraint.md
+++ b/news/2026-08/native-shadow-and-container-arg-constraint.md
@@ -1,0 +1,46 @@
+# User methods shadow inherited native methods; container args stop inheriting stale name constraints (46_eol_si 718/718)
+
+Two general dispatch bugs found via Text::CSV's `t/46_eol_si.t`, which now
+passes 718/718 (was: 61 failures and an early abort at 373).
+
+## 1. Inherited native methods beat the subclass's own methods
+
+`dispatch_instance_and_fallback`'s native fallback fired whenever
+`is_native_method` found the method anywhere in the MRO — so for a user
+subclass of a builtin (`Text::IO::String is IO::Handle` with its own
+`method Str`), `~$fh` stringified through the native IO::Handle `Str`
+(`"IO::Handle()"`) instead of the user method. Text::IO::String's close-time
+writeback (`$!str = ~ self`) therefore wrote garbage into the test's string
+buffer, and every second-pass `getline` read `["IO::Handle()"]`. The
+fallback is now gated on `!has_user_method` (the user-method block further
+down dispatches it). Explicit `.Str` already worked — only the nested
+dispatch path (`~` → `Stringy` → `Str`) hit the native arm first.
+Pin: `t/native-method-user-shadow.t`.
+
+## 2. Binding a container argument consulted the scope-blind name store
+
+`bind_function_args_values` derived a parameter's element-type constraint
+from `var_type_constraint(source_name)` — the NAME of the caller's argument
+variable in the global, scope-blind store. A module method's own
+`my CSV::Field @f` declaration leaves a global `"@f"` entry behind, so a
+caller's UNTYPED `@f` passed to ANY later method call got retyped: tagged
+`Array[CSV::Field]`, rendering `.raku` as `Array[CSV::Field].new(...)` (the
+test compared it against plain `[...]` — 59 failures). Container arguments
+now read the element/key type from the VALUE's embedded metadata (tagged at
+a typed declaration's assignment), which is immune to name collisions;
+scalar sources keep the name-store lookup. Legitimate propagation
+(`my Int @a; f(@a)` → `.of` is `Int`) still works — verified along with the
+full S09-typed-arrays roast set.
+Pin: `t/container-arg-no-stale-name-constraint.t`.
+
+Also hardened in passing: `SetVarType` (declaration position) no longer
+tags a pre-existing same-named env value with container metadata — at
+declaration time that value belongs to an outer scope or a previous loop
+iteration (`set_var_type_constraint_decl`).
+
+Both are instances of the scope-blind name-keyed store disease tracked in
+`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`.
+
+Text::CSV suite after this: everything green except `66_formula` (blocked
+on that deep ticket), `90_csv` 159/507/508 (raku-parity + kh ticket), and
+`99_meta` (fails under rakudo too).

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -930,7 +930,17 @@ impl Interpreter {
                 attributes.commit_attrs(updated);
                 return Ok(result);
             }
-            if self.is_native_method(&class_name.resolve(), method) {
+            // A user-defined method shadows an inherited native one: for a user
+            // subclass of a builtin (`class S is IO::Handle { method Str {...} }`),
+            // `is_native_method` finds the base class's native `Str` via the MRO,
+            // but the subclass's own method is more derived and must win — it is
+            // dispatched by the `has_user_method` block further down. Without
+            // this gate, `~$fh` on a Text::IO::String stringified through the
+            // native IO::Handle `Str` ("IO::Handle()") instead of the user
+            // `method Str` (Text::CSV 46_eol_si).
+            if self.is_native_method(&class_name.resolve(), method)
+                && !self.has_user_method(&class_name.resolve(), method)
+            {
                 return self.call_native_instance_method(
                     &class_name.resolve(),
                     &(attributes).as_map(),

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -69,6 +69,29 @@ impl Interpreter {
     }
 
     pub(crate) fn set_var_type_constraint(&mut self, name: &str, constraint: Option<String>) {
+        self.set_var_type_constraint_impl(name, constraint, true);
+    }
+
+    /// [`Self::set_var_type_constraint`] for DECLARATION position (`my Int
+    /// @a`): registers the name-keyed constraint but does NOT tag whatever
+    /// same-named value currently sits in `env` with container type metadata.
+    /// At declaration time the initializer has not run yet, so the env value —
+    /// when one exists at all — belongs to an OUTER scope or a previous loop
+    /// iteration (env frames are inherited): a module method's `my CSV::Field
+    /// @f` tagged the CALLER script's `@f` Arc, making its `.raku` render
+    /// `Array[CSV::Field].new(...)` (Text::CSV 46_eol_si). The declared
+    /// variable's own value is tagged by the assignment/default paths, which
+    /// consult the name-keyed constraint registered here.
+    pub(crate) fn set_var_type_constraint_decl(&mut self, name: &str, constraint: Option<String>) {
+        self.set_var_type_constraint_impl(name, constraint, false);
+    }
+
+    fn set_var_type_constraint_impl(
+        &mut self,
+        name: &str,
+        constraint: Option<String>,
+        tag_env_value: bool,
+    ) {
         if let Some(constraint) = constraint {
             let key = name.to_string();
             let meta_key = format!("__mutsu_type::{}", key);
@@ -95,7 +118,7 @@ impl Interpreter {
             // may share an `Arc` with a caller's container, and tagging that Arc
             // would corrupt the caller's container type metadata via Arc pointer
             // keying (and Arc pointer reuse after drop).
-            if name.starts_with('@') || name.starts_with('%') {
+            if tag_env_value && (name.starts_with('@') || name.starts_with('%')) {
                 self.register_var_container_type_metadata(&key, &info);
             }
         } else {

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1749,6 +1749,25 @@ impl Interpreter {
                             ValueView::Array(..) | ValueView::Hash(..)
                         );
                     let source_type_constraint = source_name.as_deref().and_then(|source_name| {
+                        // A container argument carries its element/key type
+                        // EMBEDDED in the value (tagged at its typed
+                        // declaration's assignment) — read it from there. The
+                        // name-keyed `var_type_constraints` store is scope-blind:
+                        // a module method's own `my CSV::Field @f` leaves a
+                        // global "@f" entry behind, and consulting it here
+                        // retyped an UNTYPED caller array that merely shared the
+                        // name (Text::CSV 46_eol_si: script `@f` rendered as
+                        // `Array[CSV::Field].new(...)` after one getline call).
+                        if source_name.starts_with('@') || source_name.starts_with('%') {
+                            let val = unwrap_varref_value(raw_arg.clone());
+                            return self
+                                .container_type_metadata(&val)
+                                .filter(|info| !info.value_type.is_empty())
+                                .map(|info| match info.key_type {
+                                    Some(kt) => format!("{}{{{}}}", info.value_type, kt),
+                                    None => info.value_type,
+                                });
+                        }
                         self.var_type_constraint(source_name).or_else(|| {
                             self.var_type_constraint(
                                 source_name.trim_start_matches(['$', '@', '%', '&']),

--- a/src/vm/vm_core_helpers.rs
+++ b/src/vm/vm_core_helpers.rs
@@ -258,6 +258,18 @@ impl Interpreter {
         self.loan_env_for(|i| i.set_var_type_constraint(name, constraint))
     }
 
+    /// Declaration-position variant (`my Int @a`): registers the constraint
+    /// without tagging a pre-existing same-named env value — see
+    /// `set_var_type_constraint_decl`.
+    #[inline]
+    pub(crate) fn vm_set_var_type_constraint_decl(
+        &mut self,
+        name: &str,
+        constraint: Option<String>,
+    ) {
+        self.loan_env_for(|i| i.set_var_type_constraint_decl(name, constraint))
+    }
+
     pub(crate) fn last_stack_value(&self) -> Option<&Value> {
         if self.stack.len() == 1 {
             self.stack.last()

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1742,7 +1742,7 @@ impl Interpreter {
                 if name.starts_with('@') && constraint == "atomicint" {
                     self.clear_atomic_array_state(&name);
                 }
-                self.vm_set_var_type_constraint(&name, Some(constraint.clone()));
+                self.vm_set_var_type_constraint_decl(&name, Some(constraint.clone()));
                 // For scalar variables, if the current value is Nil, set it to the type object.
                 // Exception: if the constraint is "Nil", keep the value as Nil
                 // (the Nil type object is Nil itself, not the Package "Nil").

--- a/t/container-arg-no-stale-name-constraint.t
+++ b/t/container-arg-no-stale-name-constraint.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# Binding a container argument to a parameter must read the element type
+# from the VALUE's embedded metadata, not from the name-keyed constraint
+# store: that store is scope-blind, so a method's own `my Field @f`
+# declaration leaves a global "@f" entry behind, and a caller's UNTYPED
+# `@f` passed to any method afterwards got retyped to Array[Field]
+# (Text::CSV 46_eol_si: `.raku` rendered `Array[CSV::Field].new(...)`).
+
+plan 4;
+
+class Field { has $.x }
+
+class M {
+    method poison () {
+        # registers a bare-name "@f" -> Field constraint in the method frame
+        my Field @f = Field.new(x => 1),;
+        @f.elems;
+    }
+    method take (@f) { @f.elems }
+}
+
+my $m = M.new;
+
+for ("p", "q") -> $tag {
+    my @f = ("a$tag", "b");
+    $m.take(@f);
+    is @f.raku, qq/["a$tag", "b"]/,
+        "untyped \@f stays plain after method binding (iteration $tag)";
+    $m.poison;
+}
+
+# The legitimate propagation still works: a TYPED caller array's element
+# type reaches an untyped parameter via the value's embedded metadata.
+my Int @typed = 1, 2, 3;
+sub of-it (@x) { @x.of }
+is of-it(@typed), Int, "typed caller array propagates .of through binding";
+is @typed.raku, "Array[Int].new(1, 2, 3)", "typed array keeps its own repr";

--- a/t/native-method-user-shadow.t
+++ b/t/native-method-user-shadow.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# A user-defined method shadows an inherited NATIVE method: for a user
+# subclass of a builtin (`class S is IO::Handle`), the base class's native
+# method set is found via the MRO, but the subclass's own method is more
+# derived and must win. `~$fh` on a Text::IO::String stringified through the
+# native IO::Handle Str ("IO::Handle()") instead of the user `method Str`
+# (Text::CSV 46_eol_si), which broke its close-time writeback
+# (`$!str = ~self`).
+
+plan 5;
+
+class S is IO::Handle {
+    has Str @!content;
+    method add ($s) { @!content.push: $s }
+    method Str  { @!content.join("") }
+    method gist { "S[" ~ @!content.elems ~ "]" }
+}
+
+my $s = S.new;
+$s.add("hel");
+$s.add("lo");
+
+is $s.Str, "hello", "explicit .Str calls the user method";
+is ~$s, "hello", "prefix ~ dispatches the user Str, not the native IO::Handle one";
+is "$s", "hello", "string interpolation dispatches the user Str";
+is $s.gist, "S[2]", "user gist shadows the native gist";
+
+# The 46_eol_si shape: assignment writes ~self back through a bound Str
+class Sink is IO::Handle {
+    has Str $!str;
+    method bind-str (Str $s is rw) { $!str := $s }
+    method fill ($v) { $!str = $v }
+    method Str { "CONTENT" }
+    method close-like { $!str.defined and $!str = ~ self }
+}
+my Str $out = "";
+my $k = Sink.new;
+$k.bind-str($out);
+$k.close-like;
+is $out, "CONTENT", "~self inside a method uses the user Str";


### PR DESCRIPTION
Two general dispatch bugs found via Text::CSV's `t/46_eol_si.t`, which now passes **718/718** (was: 61 failures and an early abort at 373 tests).

## 1. Inherited native methods beat the subclass's own methods

`dispatch_instance_and_fallback`'s native fallback fired whenever `is_native_method` found the method anywhere in the MRO — so for a user subclass of a builtin (`Text::IO::String is IO::Handle` with its own `method Str`), `~$fh` stringified through the native IO::Handle `Str` (`"IO::Handle()"`) instead of the user method. Text::IO::String's close-time writeback (`$!str = ~ self`) therefore wrote `"IO::Handle()"` into the test's string buffer, and every second-pass `getline` read `["IO::Handle()"]`.

Explicit `.Str` already worked — only the nested dispatch path (`~` → `Stringy` → `Str` via `call_method_with_values`) hit the native arm before the user-method block. The fallback is now gated on `!has_user_method`.

Pin: `t/native-method-user-shadow.t` (rakudo-verified).

## 2. Binding a container argument consulted the scope-blind name store

`bind_function_args_values` derived a parameter's element-type constraint from `var_type_constraint(source_name)` — the caller argument's **name** in the global, scope-blind store. A module method's own `my CSV::Field @f` declaration leaves a global `"@f"` entry behind, so a caller's UNTYPED `@f` passed to ANY later method call got retyped: tagged `Array[CSV::Field]`, rendering `.raku` as `Array[CSV::Field].new(...)` (59 of the 61 failures).

Container arguments now read the element/key type from the VALUE's embedded metadata (tagged at a typed declaration's assignment), which is immune to name collisions; scalar sources keep the name-store lookup. Legitimate propagation (`my Int @a; f(@a)` → `.of` is `Int`) verified, plus the full S09-typed-arrays roast set (10 files, 4261 tests, green).

Pin: `t/container-arg-no-stale-name-constraint.t`.

Also hardened in passing: `SetVarType` (declaration position) no longer tags a pre-existing same-named env value with container metadata (`set_var_type_constraint_decl`) — at declaration time that value belongs to an outer scope or a previous loop iteration.

Both are instances of the scope-blind name-keyed store disease tracked in `todo/deep/bare-name-type-constraint-store-is-scope-blind.md`.

## Verification

- `make test` PASS (full local suite)
- S09-typed-arrays roast: 10 files / 4261 tests PASS
- Text::CSV: `46_eol_si` **718/718**; `79_callbacks` 90/90, `55_combi` 17009/17009, `91_csv_cb` 28/28, `92_csv_encoding` 1/1, `90_csv` unchanged (159 raku-parity + 507/508 kh ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)