### PR TITLE
feat(supply): ADR-0028 Slice 2 — defer schedule-on delivery through whenever-in-supply and derived ops

### DIFF
--- a/docs/adr/0028-supply-schedule-on-deferred-tap-delivery.md
+++ b/docs/adr/0028-supply-schedule-on-deferred-tap-delivery.md
@@ -1,7 +1,8 @@
 # ADR-0028: `Supply.schedule-on` genuinely defers tap delivery — callback shims at the tap-registration chokepoint, with a serialized per-tap drain
 
 - Status: Accepted (Slice 1 implemented and Cro-verified 2026-08-13; Slice 2
-  bypass-path audit remaining)
+  bypass-path audit complete 2026-08-13 — two confirmed gaps fixed, one
+  deferred to a new deep ticket, two probed and found not to be gaps)
 - Date: 2026-08-12
 - Related: [ADR-0020](0020-shared-worker-pool.md) (the worker pool the drain
   runs on; supply-lifetime pumps are a sanctioned slice-3 shape there),
@@ -420,8 +421,87 @@ Cro::HTTP suite: 34/35 fully-green (up from 33/35), remaining gap being that
 file plus the unrelated pre-existing `http2-request-parser.rakutest`
 concurrent-stream ticket. Cro::Core stays 9/9.
 
-**Slice 2 (bypass-path audit) is NOT done** — still open, tracked by this
-ADR's own Slice 2 section above, not a separate ticket.
+**Slice 2 (bypass-path audit) is done (2026-08-13).** Each of the four
+candidates in the Slice-2 section above was probed against real `raku` with a
+thread-identity probe and, where that showed a difference, a deadlock-shape
+probe mirroring the Slice-1 repro (mutsu deadlocks — `Planned` — exactly where
+raku resolves — `Kept` — confirms a *real* gap, not just a cosmetic thread-id
+difference; several probes needed a same-thread-race fix, or hit unrelated
+raku quirks, before they were trustworthy — see below):
+
+- **Confirmed gap, fixed:** `whenever $scheduled-supply { ... }` inside
+  another `supply { }` block. Its direct `register_supplier_tap(supplier_id,
+  body_cb, 0.0)` call (bypassing the chokepoint) now routes through a new
+  shared helper, `wrap_scheduled_callbacks` (extracted from the `"tap"|"act"`
+  arm's inline scheduler-classification code, zero behavior change there —
+  verified against the existing Slice-1 pins before adding anything new),
+  keyed off the *inner* (whenever-source) Supply's own attrs rather than the
+  outer supply block's. A `ThreadPoolScheduler` pump created this way is
+  threaded onto the upstream-close cascade as a nested synthetic `Tap`
+  instance (reusing `close_upstream_taps`'s existing Instance-recursion
+  branch) so `Tap.close` on the *outer* supply block still reclaims the
+  nested pump — no separate cleanup mechanism needed.
+- **Confirmed gap, fixed:** deferred-registration derived operators
+  (`.lines`, `.words`, `.unique`, `.elems`, `.produce` — `.head` already
+  worked, since its live branch `attributes.clone()`s the whole map) applied
+  *after* `.schedule-on()`. These build a fresh attrs map carrying
+  `supplier_id` forward and defer actual tap registration to whenever the
+  caller eventually calls `.tap()`/`.act()` on the derived Supply — which
+  *does* hit the chokepoint, so the only gap was that none of them copied
+  `"scheduler"` into that fresh map. Fixed by copying it forward alongside
+  the existing `supplier_id` copy at each of the 5 sites (mechanical,
+  low-risk).
+- **Confirmed gap, NOT fixed — new deep ticket:** `.map`/`.grep`/`.do` (all
+  three share `make_live_transform_supply`) and `.flat` register their
+  transform tap *immediately* at call time, directly on the source's raw
+  `supplier_id` via `register_supplier_transform_tap`/`register_supplier_flat_tap`
+  — a `TransformState` consulted synchronously at the emit sites, which never
+  sees the "scheduler" attribute (it isn't visible from there; the Supply
+  *value* that carries it isn't in scope at that layer). This is
+  architecturally different from the two fixes above — no attrs map to
+  thread `"scheduler"` through, and no existing tap-callback registration
+  point to route through `wrap_scheduled_callbacks`. A correct fix needs a
+  new synthesized-shim class following the `__ScheduledTapPump` idiom;
+  design sketch, confirmed repro, and affected-file inventory are in
+  `todo/deep/schedule-on-live-transform-operators-bypass-deferral.md`.
+- **Probed, NOT a gap:** `react whenever $scheduled-supply { ... }`. A naive
+  thread-identity probe was misleading here — mutsu's react drive loop
+  already runs on its own dedicated driving thread even *without*
+  `.schedule-on()` (architecturally different from Rakudo, where an
+  unscheduled `whenever` inside `react` runs synchronously on the emitting
+  thread), so "different thread" doesn't distinguish scheduled from
+  unscheduled in mutsu's react. A deadlock-shape probe (mirroring the other
+  two confirmed gaps, with a blocking `await` + `done` phaser inside the
+  whenever body) was inconclusive in a different way: it hit a **pre-existing
+  raku quirk unrelated to scheduling** — the same non-`Kept` outcome
+  reproduced in real raku *with and without* `.schedule-on()`, isolating it
+  as an await/react/`done`-phaser interaction quirk, not a scheduling gap.
+  No fix, no pin — recorded here per the ADR's "each non-gap gets a line"
+  rule.
+- **Probed, NOT a gap:** the internal taps of `.Promise`/`.list`. The first
+  attempt at a `.Promise` probe showed a false gap (`Planned` in mutsu vs
+  `Kept` in raku) that turned out to be a **test race**, not a real one: the
+  probe spawned the emitting `start {}` concurrently with the `.Promise`
+  coercion's own tap registration, so the emit could beat the tap into
+  existence. Removing the race (register the Promise coercion on the main
+  thread *before* spawning the emitter) showed `Kept` for both scheduled and
+  unscheduled sources in mutsu, matching raku — no gap. `.list` on a *live*
+  (Supplier-backed, cross-thread) source returned an empty list in mutsu
+  **even without `.schedule-on()`** — a real bug, but unrelated to this ADR
+  (out of scope for Slice 2; not filed as a new ticket in this pass, since
+  `Supply.list` on a static/eager source works fine per the existing
+  `t/supply-list.t` coverage and this narrower live-cross-thread shape wasn't
+  independently confirmed beyond the one probe).
+
+Pinned in `t/supply-schedule-on-defer-nested-whenever.t` (3 cases, all
+cross-checked against real `raku` first): the `whenever`-in-supply deadlock
+repro, the `.lines`-after-`schedule-on` deadlock repro, and a `Tap.close`
+cascade-reclaims-the-nested-pump case. `make test` and the whitelisted
+`roast/S17-supply` (release) stay green; the Slice-1 pins
+(`t/supply-schedule-on-defer.t`, `t/supply-schedule-on.t`,
+`t/schedule-on-whenever-env.t`, `t/supply-interval-scheduler.t`) are
+unaffected by the `wrap_scheduled_callbacks` extraction (verified before and
+after — identical pass/fail).
 
 ## Risks
 

--- a/src/runtime/methods_supply_dispatch.rs
+++ b/src/runtime/methods_supply_dispatch.rs
@@ -440,6 +440,12 @@ impl Interpreter {
             elems_attrs.insert("taps".to_string(), Value::array(Vec::new()));
             elems_attrs.insert("live".to_string(), Value::FALSE);
             elems_attrs.insert("supplier_id".to_string(), Value::int(supplier_id));
+            // ADR-0028 Slice 2: deferred to tap-time — copy `"scheduler"`
+            // forward so the `"tap"|"act"` chokepoint still classifies it
+            // when the eventual `.tap()` runs.
+            if let Some(scheduler) = attributes.get("scheduler") {
+                elems_attrs.insert("scheduler".to_string(), scheduler.clone());
+            }
             elems_attrs.insert("supplier_done".to_string(), Value::truth(done));
             elems_attrs.insert("elems_filter".to_string(), Value::TRUE);
             elems_attrs.insert("elems_interval".to_string(), Value::num(interval));

--- a/src/runtime/native_supply_dispatch.rs
+++ b/src/runtime/native_supply_dispatch.rs
@@ -493,6 +493,15 @@ impl Interpreter {
                 if let Some(supplier_id) = attributes.get("supplier_id") {
                     new_attrs.insert("supplier_id".to_string(), supplier_id.clone());
                 }
+                // ADR-0028 Slice 2: this method defers registration to
+                // whenever `.tap()` is eventually called on the derived
+                // Supply (it just carries `supplier_id` + a mode flag
+                // forward), so the `"tap"|"act"` chokepoint sees this exact
+                // attrs map — copy `"scheduler"` forward so it still
+                // classifies correctly.
+                if let Some(scheduler) = attributes.get("scheduler") {
+                    new_attrs.insert("scheduler".to_string(), scheduler.clone());
+                }
                 if let Some(done) = attributes.get("supplier_done") {
                     new_attrs.insert("supplier_done".to_string(), done.clone());
                 }
@@ -740,6 +749,11 @@ impl Interpreter {
                     if let Some(sid) = attributes.get("supplier_id") {
                         new_attrs.insert("supplier_id".to_string(), sid.clone());
                     }
+                    // ADR-0028 Slice 2: deferred to tap-time — copy
+                    // `"scheduler"` forward (see the `.lines` comment above).
+                    if let Some(scheduler) = attributes.get("scheduler") {
+                        new_attrs.insert("scheduler".to_string(), scheduler.clone());
+                    }
                     new_attrs.insert("produce_callable".to_string(), reducer);
                     new_attrs.insert("live".to_string(), Value::FALSE);
                     return Ok(Value::make_instance(Symbol::intern("Supply"), new_attrs));
@@ -909,6 +923,15 @@ impl Interpreter {
                 }
                 if let Some(supplier_id) = attributes.get("supplier_id") {
                     new_attrs.insert("supplier_id".to_string(), supplier_id.clone());
+                }
+                // ADR-0028 Slice 2: this method defers registration to
+                // whenever `.tap()` is eventually called on the derived
+                // Supply (it just carries `supplier_id` + a mode flag
+                // forward), so the `"tap"|"act"` chokepoint sees this exact
+                // attrs map — copy `"scheduler"` forward so it still
+                // classifies correctly.
+                if let Some(scheduler) = attributes.get("scheduler") {
+                    new_attrs.insert("scheduler".to_string(), scheduler.clone());
                 }
                 if let Some(done) = attributes.get("supplier_done") {
                     new_attrs.insert("supplier_done".to_string(), done.clone());

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -59,79 +59,12 @@ impl Interpreter {
                 // scheduler wiring (`cue_scheduler_interval` below), which
                 // already delivers on the scheduler for a different reason
                 // (it drives the ticks, not just delivery).
-                let mut scheduled_pump_id: Option<u64> = None;
-                if attrs.contains_key("scheduler") && !attrs.contains_key("scheduler_interval") {
-                    let scheduler = attrs.get("scheduler").cloned().unwrap_or(Value::NIL);
-                    // A scheduler may be a concrete instance (`$*SCHEDULER`)
-                    // or a bare type object used directly (`CurrentThreadScheduler`,
-                    // undefined but a legal Scheduler.cue invocant — real Raku
-                    // dispatches `.cue` on it as a class method).
-                    let class_name = match scheduler.view() {
-                        ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
-                        ValueView::Package(sym) => Some(sym.resolve()),
-                        _ => None,
-                    };
-                    match class_name.as_deref() {
-                        // Rakudo's CurrentThreadScheduler.cue runs its block
-                        // inline, so synchronous delivery is already correct
-                        // — no wrapping.
-                        Some("CurrentThreadScheduler") => {}
-                        Some("ThreadPoolScheduler") => {
-                            let (pump_id, rx) = register_scheduled_pump();
-                            let real_tap = tap_cb.clone();
-                            let real_done = done_cb.clone();
-                            let real_quit = quit_cb.clone();
-                            let real_delay = delay_seconds;
-                            if Self::supply_has_active_callback(&tap_cb) {
-                                tap_cb = Self::build_scheduled_pump_shim(pump_id, "emit");
-                            }
-                            done_cb = Some(Self::build_scheduled_pump_shim(pump_id, "done"));
-                            quit_cb = Some(Self::build_scheduled_pump_shim(pump_id, "quit"));
-                            // The tap's own `:delay` moves into the drain
-                            // loop, which is where a per-event sleep belongs
-                            // now — sleeping on the emitting thread is
-                            // exactly the deadlock class this defers away.
-                            delay_seconds = 0.0;
-                            let mut thread_interp = self.clone_for_thread();
-                            crate::runtime::worker_pool::submit(move || {
-                                Self::run_supply_act_loop(
-                                    &mut thread_interp,
-                                    &rx,
-                                    &real_tap,
-                                    real_delay,
-                                    real_done,
-                                    real_quit,
-                                );
-                            });
-                            scheduled_pump_id = Some(pump_id);
-                        }
-                        // Any other Scheduler (FakeScheduler, a user-written
-                        // one): its own `.cue` is the contract, honored
-                        // per-event rather than bypassed with a hardcoded
-                        // pool submit.
-                        _ => {
-                            if Self::supply_has_active_callback(&tap_cb) {
-                                tap_cb = Self::build_scheduled_cue_shim(
-                                    scheduler.clone(),
-                                    tap_cb.clone(),
-                                    "emit",
-                                );
-                            }
-                            if let Some(real_done) = done_cb.take() {
-                                done_cb = Some(Self::build_scheduled_cue_shim(
-                                    scheduler.clone(),
-                                    real_done,
-                                    "done",
-                                ));
-                            }
-                            if let Some(real_quit) = quit_cb.take() {
-                                quit_cb = Some(Self::build_scheduled_cue_shim(
-                                    scheduler, real_quit, "quit",
-                                ));
-                            }
-                        }
-                    }
-                }
+                let (new_tap_cb, new_done_cb, new_quit_cb, new_delay_seconds, scheduled_pump_id) =
+                    self.wrap_scheduled_callbacks(&attrs, tap_cb, done_cb, quit_cb, delay_seconds);
+                tap_cb = new_tap_cb;
+                done_cb = new_done_cb;
+                quit_cb = new_quit_cb;
+                delay_seconds = new_delay_seconds;
 
                 if let Some(ValueView::Int(supplier_id)) = attrs.get("supplier_id").map(Value::view)
                 {
@@ -495,12 +428,46 @@ impl Interpreter {
                                     inner_attrs.as_map().get("supplier_id").map(Value::view)
                             {
                                 let supplier_id = sid as u64;
-                                register_supplier_tap(supplier_id, body_cb.clone(), 0.0);
+                                // ADR-0028 Slice 2: this registration bypasses
+                                // the `"tap"|"act"` chokepoint entirely (it
+                                // calls `register_supplier_tap` directly), so
+                                // a `whenever` on a `.schedule-on()`'d nested
+                                // source needs its own scheduler-kind wrap
+                                // here, keyed off the *source*'s own attrs.
+                                let (wrapped_body_cb, _, _, _, whenever_pump_id) = self
+                                    .wrap_scheduled_callbacks(
+                                        &inner_attrs.as_map(),
+                                        body_cb.clone(),
+                                        None,
+                                        None,
+                                        0.0,
+                                    );
+                                register_supplier_tap(supplier_id, wrapped_body_cb, 0.0);
                                 if let Some(tid) = last_supplier_tap_id(supplier_id) {
-                                    upstream_taps.push(Value::array(vec![
-                                        Value::int(supplier_id as i64),
-                                        Value::int(tid as i64),
-                                    ]));
+                                    if let Some(pump_id) = whenever_pump_id {
+                                        // Route the upstream-close cascade
+                                        // through a nested Tap handle so
+                                        // `close_upstream_taps` also drops
+                                        // this pump (its `Instance{class_name
+                                        // == "Tap"}` branch recurses into
+                                        // `native_tap`'s "close", which
+                                        // already knows how to release a
+                                        // `pump_id`).
+                                        let mut h = HashMap::new();
+                                        h.insert(
+                                            "supplier_id".to_string(),
+                                            Value::int(supplier_id as i64),
+                                        );
+                                        h.insert("tap_id".to_string(), Value::int(tid as i64));
+                                        h.insert("pump_id".to_string(), Value::int(pump_id as i64));
+                                        upstream_taps
+                                            .push(Value::make_instance(Symbol::intern("Tap"), h));
+                                    } else {
+                                        upstream_taps.push(Value::array(vec![
+                                            Value::int(supplier_id as i64),
+                                            Value::int(tid as i64),
+                                        ]));
+                                    }
                                 }
                                 // Raku serializes all `whenever` handlers of one
                                 // supply block ("only in one whenever block at a
@@ -1264,6 +1231,98 @@ impl Interpreter {
                 method
             ))),
         }
+    }
+
+    /// ADR-0028 Slice 2: classify `attrs`'s `"scheduler"` (if any, and not a
+    /// `"scheduler_interval"` tick wiring — see the chokepoint comment) and
+    /// substitute the emit/done/quit callbacks so delivery genuinely defers,
+    /// exactly like the `"tap"|"act"` chokepoint above. Shared by that
+    /// chokepoint and by the registration paths Slice 1 left bypassing it: a
+    /// `whenever` on a nested on-demand source registers its body tap
+    /// directly via `register_supplier_tap` rather than going through
+    /// `native_supply_mut`, so it must call this itself with the *source*
+    /// Supply's attrs. Returns the (possibly substituted) callbacks, the
+    /// delay override, and a pump id to track for cleanup (`None` unless a
+    /// `ThreadPoolScheduler` pump was actually created).
+    pub(super) fn wrap_scheduled_callbacks(
+        &mut self,
+        attrs: &AttrMap,
+        mut tap_cb: Value,
+        mut done_cb: Option<Value>,
+        mut quit_cb: Option<Value>,
+        mut delay_seconds: f64,
+    ) -> (Value, Option<Value>, Option<Value>, f64, Option<u64>) {
+        let mut scheduled_pump_id: Option<u64> = None;
+        if attrs.contains_key("scheduler") && !attrs.contains_key("scheduler_interval") {
+            let scheduler = attrs.get("scheduler").cloned().unwrap_or(Value::NIL);
+            // A scheduler may be a concrete instance (`$*SCHEDULER`) or a bare
+            // type object used directly (`CurrentThreadScheduler`, undefined
+            // but a legal Scheduler.cue invocant — real Raku dispatches
+            // `.cue` on it as a class method).
+            let class_name = match scheduler.view() {
+                ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
+                ValueView::Package(sym) => Some(sym.resolve()),
+                _ => None,
+            };
+            match class_name.as_deref() {
+                // Rakudo's CurrentThreadScheduler.cue runs its block inline,
+                // so synchronous delivery is already correct — no wrapping.
+                Some("CurrentThreadScheduler") => {}
+                Some("ThreadPoolScheduler") => {
+                    let (pump_id, rx) = register_scheduled_pump();
+                    let real_tap = tap_cb.clone();
+                    let real_done = done_cb.clone();
+                    let real_quit = quit_cb.clone();
+                    let real_delay = delay_seconds;
+                    if Self::supply_has_active_callback(&tap_cb) {
+                        tap_cb = Self::build_scheduled_pump_shim(pump_id, "emit");
+                    }
+                    done_cb = Some(Self::build_scheduled_pump_shim(pump_id, "done"));
+                    quit_cb = Some(Self::build_scheduled_pump_shim(pump_id, "quit"));
+                    // The tap's own `:delay` moves into the drain loop, which
+                    // is where a per-event sleep belongs now — sleeping on
+                    // the emitting thread is exactly the deadlock class this
+                    // defers away.
+                    delay_seconds = 0.0;
+                    let mut thread_interp = self.clone_for_thread();
+                    crate::runtime::worker_pool::submit(move || {
+                        Self::run_supply_act_loop(
+                            &mut thread_interp,
+                            &rx,
+                            &real_tap,
+                            real_delay,
+                            real_done,
+                            real_quit,
+                        );
+                    });
+                    scheduled_pump_id = Some(pump_id);
+                }
+                // Any other Scheduler (FakeScheduler, a user-written one):
+                // its own `.cue` is the contract, honored per-event rather
+                // than bypassed with a hardcoded pool submit.
+                _ => {
+                    if Self::supply_has_active_callback(&tap_cb) {
+                        tap_cb = Self::build_scheduled_cue_shim(
+                            scheduler.clone(),
+                            tap_cb.clone(),
+                            "emit",
+                        );
+                    }
+                    if let Some(real_done) = done_cb.take() {
+                        done_cb = Some(Self::build_scheduled_cue_shim(
+                            scheduler.clone(),
+                            real_done,
+                            "done",
+                        ));
+                    }
+                    if let Some(real_quit) = quit_cb.take() {
+                        quit_cb =
+                            Some(Self::build_scheduled_cue_shim(scheduler, real_quit, "quit"));
+                    }
+                }
+            }
+        }
+        (tap_cb, done_cb, quit_cb, delay_seconds, scheduled_pump_id)
     }
 
     /// Cue a scheduler-driven `Supply.interval`'s ticks on its Scheduler.

--- a/src/runtime/supply_classify.rs
+++ b/src/runtime/supply_classify.rs
@@ -32,6 +32,12 @@ impl Interpreter {
             if let Some(sid) = attributes.get("supplier_id") {
                 new_attrs.insert("supplier_id".to_string(), sid.clone());
             }
+            // ADR-0028 Slice 2: deferred to tap-time — copy `"scheduler"`
+            // forward so the `"tap"|"act"` chokepoint still classifies it
+            // when the eventual `.tap()` runs.
+            if let Some(scheduler) = attributes.get("scheduler") {
+                new_attrs.insert("scheduler".to_string(), scheduler.clone());
+            }
             if let Some(d) = attributes.get("supplier_done") {
                 new_attrs.insert("supplier_done".to_string(), d.clone());
             }

--- a/t/supply-schedule-on-defer-nested-whenever.t
+++ b/t/supply-schedule-on-defer-nested-whenever.t
@@ -1,0 +1,91 @@
+use Test;
+
+# ADR-0028 Slice 2: `Supply.schedule-on($scheduler)` must genuinely defer
+# delivery not only through a direct `.tap()`/`.act()` (Slice 1), but also
+# through registration paths that bypass that chokepoint entirely --
+# `whenever $scheduled-supply { ... }` inside another `supply { }` block
+# (registers its body callback directly via `register_supplier_tap`), and
+# deferred-registration derived operators (`.lines`, `.words`, `.unique`,
+# `.elems`, `.produce`) applied AFTER `.schedule-on()`, which build a fresh
+# attrs map that must carry the `"scheduler"` attribute forward so the
+# eventual `.tap()` still classifies it. Every pin here is synchronized
+# through a Promise -- no sleep-based timing assertions for the positive
+# cases, so this cannot flake by construction.
+
+plan 3;
+
+# 1. whenever $scheduled-supply { ... } inside another supply block: a
+# blocking `await` inside the whenever body must not deadlock a sibling
+# `start {}` emit, exactly like the direct-tap Slice-1 repro.
+{
+    my $supplier = Supplier.new;
+    my $inner = Promise.new;
+    my $done = Promise.new;
+    my $inner-status;
+
+    my $s = supply {
+        whenever $supplier.Supply.schedule-on(ThreadPoolScheduler.new) -> $v {
+            await Promise.anyof($inner, Promise.in(3));
+            $inner-status = $inner.status;
+            $done.keep(True);
+        }
+    };
+    $s.tap(-> $v { });
+
+    start {
+        $supplier.emit('x');
+        $inner.keep(True);
+    };
+    await Promise.anyof($done, Promise.in(5));
+    ok $inner-status === Kept,
+        "whenever on a schedule-on'd nested source defers delivery instead of deadlocking a sibling start{} emit";
+}
+
+# 2. A deferred-registration derived operator (.lines) applied AFTER
+# .schedule-on must still defer: the "scheduler" attribute has to survive
+# into the fresh attrs .lines builds so the eventual .tap() classifies it.
+{
+    my $supplier = Supplier.new;
+    my $inner = Promise.new;
+    my $done = Promise.new;
+    my $inner-status;
+
+    $supplier.Supply.schedule-on(ThreadPoolScheduler.new).lines.tap: -> $v {
+        await Promise.anyof($inner, Promise.in(3));
+        $inner-status = $inner.status;
+        $done.keep(True);
+    };
+    start {
+        $supplier.emit("x\n");
+        $inner.keep(True);
+    };
+    await Promise.anyof($done, Promise.in(5));
+    ok $inner-status === Kept,
+        ".lines applied after schedule-on(ThreadPoolScheduler) still defers delivery";
+}
+
+# 3. Closing the outer tap on a supply block whose whenever taps a
+# schedule-on'd nested source must reclaim that nested pump too (no leaked
+# drain worker still delivering after close).
+{
+    my $supplier = Supplier.new;
+    my @seen;
+    my $got-one = Promise.new;
+
+    my $s = supply {
+        whenever $supplier.Supply.schedule-on(ThreadPoolScheduler.new) -> $v {
+            @seen.push($v);
+            $got-one.keep(True) if $v == 1;
+        }
+    };
+    my $tap = $s.tap(-> $v { });
+    $supplier.emit(1);
+    await Promise.anyof($got-one, Promise.in(5));
+    $tap.close;
+    $supplier.emit(2);
+    sleep 0.2; # give a leaked drain a chance to misbehave before asserting
+    is-deeply @seen, [1],
+        "closing the outer tap reclaims a nested whenever's schedule-on pump";
+}
+
+# vim: expandtab shiftwidth=4

--- a/todo/deep/schedule-on-live-transform-operators-bypass-deferral.md
+++ b/todo/deep/schedule-on-live-transform-operators-bypass-deferral.md
@@ -1,0 +1,146 @@
+# `.map`/`.grep`/`.do` (and `.flat`) applied on a `.schedule-on()`'d Supply still deliver synchronously
+
+## Root cause
+
+ADR-0028 Slice 1 fixed `Supply.schedule-on($scheduler)` to genuinely defer
+delivery, by wrapping the emit/done/quit callbacks at the single `"tap"|"act"`
+chokepoint (`native_supply_mut_methods.rs`). Slice 2 (this campaign's current
+work) audited the registration paths that bypass that chokepoint and found
+two categories of gap:
+
+1. **Deferred-registration derived ops** (`.lines`, `.words`, `.unique`,
+   `.elems`, `.produce`, `.head`) just copy `supplier_id` forward into a
+   fresh attrs map and set a mode flag; the actual tap registration happens
+   later, when the user eventually calls `.tap()`/`.act()` on the derived
+   Supply — which *does* hit the chokepoint. These were fixed by also
+   copying the `"scheduler"` attribute forward (a small, low-risk, mechanical
+   change, landed alongside the `whenever`-in-supply fix below).
+
+2. **Immediate-registration live-transform ops** (`.map`, `.grep`, `.do` —
+   all three funnel through `make_live_transform_supply` in
+   `methods_supply_dispatch.rs` — and `.flat`, via `register_supplier_flat_tap`
+   in `native_supply_dispatch.rs`) register a transform tap **immediately**,
+   at `.map()`/`.grep()`/`.do()`/`.flat()` call time, directly on the
+   *source*'s `supplier_id` via `register_supplier_transform_tap` /
+   `register_supplier_flat_tap` — independent of if/when the caller later
+   taps the *downstream* Supply. This bypass is architecturally different
+   from category 1 and from the `whenever`-in-supply fix (both of which just
+   needed to route through the existing `wrap_scheduled_callbacks` helper
+   before calling the existing `register_supplier_tap`): the transform
+   application itself is a Rust-side `TransformState` consulted synchronously
+   at the ~33 `supplier_emit_callbacks` call sites
+   (`SupplierEmitAction::TransformCall` → `handle_supply_transform_emit` in
+   `native_supplier_methods.rs`), which never even looks up the "scheduler"
+   attribute — it isn't visible from where the transform is applied.
+
+This category-2 gap remains unfixed. Confirmed against real `raku` with a
+Cro-free deadlock-shape repro (mirroring the Slice-1 repro, just with `.map`
+spliced in before `.tap`):
+
+```raku
+my $supplier = Supplier.new;
+my $inner = Promise.new;
+my $done = Promise.new;
+my $inner-status;
+
+$supplier.Supply.schedule-on(ThreadPoolScheduler.new).map(-> $v { $v }).tap: -> $v {
+    await Promise.anyof($inner, Promise.in(3));
+    $inner-status = $inner.status;
+    $done.keep(True);
+};
+start {
+    $supplier.emit('x');
+    $inner.keep(True);
+};
+await Promise.anyof($done, Promise.in(5));
+say "inner-status: $inner-status";   # raku: Kept.  mutsu: Planned (deadlocked).
+```
+
+Real Raku resolves the inner promise because `.map` is implemented in Rakudo
+as `supply { whenever self -> \v { emit(f(v)) } }` — the map's *own* internal
+`whenever` taps the scheduled source, so its body (and therefore its
+`emit`, which drives the downstream Supply's delivery) runs deferred on the
+scheduler. mutsu's `TransformState` mechanism has no equivalent hook.
+
+## Affected files
+
+- `src/runtime/methods_supply_dispatch.rs` — `dispatch_supply_map`,
+  `make_live_transform_supply` (shared by Map/Grep/Do modes).
+- `src/runtime/native_supply_dispatch.rs` — the `"do"` dispatch arm (line
+  ~385, also calls `make_live_transform_supply`), the `"flat"` arm (line
+  ~688, calls `register_supplier_flat_tap` directly — same category).
+- `src/runtime/native_methods/state_supplier.rs` — `TransformState`,
+  `register_supplier_transform_tap`, `register_supplier_flat_tap`.
+- `src/runtime/native_supplier_methods.rs` — the ~2 `TransformCall`
+  consultation sites, `handle_supply_transform_emit`.
+- `src/runtime/native_supply_mut_methods.rs` — `wrap_scheduled_callbacks`
+  (the Slice-1/Slice-2 shared helper this fix would need to route through),
+  `__ScheduledTapPump` and its native methods (`state_scheduled_pump.rs`) —
+  the reusable pump/cue shim machinery.
+
+## Why it is large
+
+A correct fix needs a new synthesized-callable shim (mirroring the existing
+`__ScheduledTapPump` idiom) that a `.map`/`.grep`/`.do`/`.flat` call can
+register via the *plain* `register_supplier_tap` (not `register_supplier_transform_tap`)
+when the source carries `"scheduler"`, so `wrap_scheduled_callbacks` can wrap
+it like any other tap callback and the existing pump/cue drain delivers it.
+Sketch:
+
+1. Add a new internal native class, e.g. `__ScheduledTransformApply`, holding
+   `(mapper, mode, downstream_supplier_id)` — mirrors `__ScheduledTapPump`'s
+   `(pump_id)` / `(scheduler, real_cb)` shape.
+2. Give it a one-arg native method (e.g. `__mutsu_scheduled_transform_apply`)
+   whose Rust implementation is exactly what `handle_supply_transform_emit`
+   already does (call the mapper per `mode`, then `supplier_emit` into
+   `downstream_supplier_id`) — reuse that function directly, do not
+   reimplement the mode logic.
+3. In `make_live_transform_supply` (and the `.flat` arm), branch on whether
+   `attributes` contains `"scheduler"` (and not `"scheduler_interval"`):
+   - unscheduled (today's behavior, unchanged): `register_supplier_transform_tap`
+     as now — zero behavior/perf change for the common case.
+   - scheduled: build the `__ScheduledTransformApply` shim sub (same
+     synthesized-`SubData`-calls-one-`MethodCall` idiom as
+     `build_scheduled_pump_shim`), pass it through
+     `self.wrap_scheduled_callbacks(attributes, shim, None, None, 0.0)`, and
+     register the *wrapped* result via the ordinary `register_supplier_tap`
+     on the source's `supplier_id` instead of `register_supplier_transform_tap`.
+4. Handle `Tap.close`/pump cleanup the same way the `whenever`-in-supply fix
+   (ADR-0028 Slice 2, already landed) does: track the returned pump id and
+   thread it onto whatever handle owns the downstream Supply's lifetime.
+5. Decide `done`/`quit` propagation into the downstream supplier — today
+   `TransformCall`'s `done`/`quit` presumably reach the downstream supplier
+   through a separate mechanism (need to trace `get_transform_output_supplier_ids`
+   consumers); the new path must preserve that.
+
+This is a real, scoped design (not a shortcut), but it is a new subsystem
+(shim class + registry-free pass-through since `wrap_scheduled_callbacks`
+already returns everything needed) touching 4 files, and needs its own test
+matrix (map/grep/do × scheduled/unscheduled × close-cascade) before landing —
+hence `todo/deep/` rather than folding into the Slice-2 PR that fixed the
+lower-risk categories 1 and the `whenever`-in-supply chokepoint bypass.
+
+## Repro
+
+Save as `tmp/schedule-on-map-deadlock.raku` and run with
+`timeout 15 target/debug/mutsu tmp/schedule-on-map-deadlock.raku` — prints
+`inner-status: Planned` (mutsu) vs `inner-status: Kept` (raku):
+
+```raku
+my $supplier = Supplier.new;
+my $inner = Promise.new;
+my $done = Promise.new;
+my $inner-status;
+
+$supplier.Supply.schedule-on(ThreadPoolScheduler.new).map(-> $v { $v }).tap: -> $v {
+    await Promise.anyof($inner, Promise.in(3));
+    $inner-status = $inner.status;
+    $done.keep(True);
+};
+start {
+    $supplier.emit('x');
+    $inner.keep(True);
+};
+await Promise.anyof($done, Promise.in(5));
+say "inner-status: $inner-status";
+```


### PR DESCRIPTION
## Summary
- ADR-0028 Slice 1 fixed `Supply.schedule-on()` deferral for the direct `.tap()`/`.act()` chokepoint only. This is the Slice 2 audit of registration paths that bypass that chokepoint.
- **Confirmed gap, fixed:** `whenever $scheduled-supply { ... }` inside another `supply { }` block registered its body callback directly via `register_supplier_tap`, bypassing the scheduler wrap. Extracted the chokepoint's inline scheduler-classification logic into a shared `wrap_scheduled_callbacks` helper (pure refactor, verified against the Slice-1 pins) and applied it here too, keyed off the whenever-source's own attrs. A `ThreadPoolScheduler` pump created this way is threaded onto the upstream-close cascade as a nested synthetic `Tap` instance so the outer `Tap.close` still reclaims it.
- **Confirmed gap, fixed:** deferred-registration derived operators (`.lines`, `.words`, `.unique`, `.elems`, `.produce`) applied after `.schedule-on()` build a fresh attrs map that didn't carry `"scheduler"` forward, so the eventual `.tap()` never saw it. Fixed by copying it forward at each site (`.head` already worked, since it clones the whole attrs map).
- **Confirmed gap, NOT fixed — new deep ticket:** `.map`/`.grep`/`.do`/`.flat` register their transform tap immediately at call time (a `TransformState` consulted synchronously at emit sites, with no attrs map to thread `"scheduler"` through). Architecturally different bypass; design sketch in `todo/deep/schedule-on-live-transform-operators-bypass-deferral.md`.
- **Probed, not gaps:** `react whenever` on a scheduled source (mutsu's react loop already runs on its own drive thread regardless of scheduling; a deadlock-shape probe hit an unrelated pre-existing raku await/react/`done`-phaser quirk, reproducing identically with and without `.schedule-on()`) and `.Promise`/`.list` (first probe showed a false gap that was a test race; race-free retest matched raku for both scheduled and unscheduled). Documented in the ADR rather than filed as tickets.
- Every probe was verified against real `raku` first (several needed fixing — a naive thread-id comparison and a start{}/start{} race both gave misleading first results) before any code changed, per ADR-0027's "probe before change" discipline.

## Test plan
- [x] New pin `t/supply-schedule-on-defer-nested-whenever.t` (3 cases: whenever-in-supply deadlock repro, `.lines`-after-`schedule-on` deadlock repro, `Tap.close` cascade reclaims the nested pump) — all cross-checked against real `raku` first.
- [x] Existing Slice-1 pins (`t/supply-schedule-on-defer.t`, `t/supply-schedule-on.t`, `t/schedule-on-whenever-env.t`, `t/supply-interval-scheduler.t`) pass unchanged, confirming the `wrap_scheduled_callbacks` extraction is behavior-preserving.
- [x] `t/supply*.t`, `t/whenever*.t`, `t/react*.t` (94 files / 437 tests) green.
- [x] `roast/S17-supply/*.t` (release, `MUTSU_FUDGE=1`) green, no `not ok`.
- [x] `make test` — 3101 files / 28823 tests, PASS.
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean.
- [ ] Full `make roast` — delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)