### PR TITLE
fix(vm): frame-scope typed routine lexicals' constraints (SetVarTypeScoped)

### DIFF
--- a/news/2026-08/typed-lexical-constraint-frame-scoped.md
+++ b/news/2026-08/typed-lexical-constraint-frame-scoped.md
@@ -1,0 +1,45 @@
+# Typed routine lexicals no longer leak their constraint across frames (Text::CSV fully green)
+
+A typed scalar `my` inside a routine used to register its type constraint in
+the global bare-name-keyed `var_type_constraints` map, which survives the
+routine's return. Any same-named variable assigned later — in the caller, in
+another routine, even in another compunit — was then checked against the dead
+frame's constraint. Text::CSV `t/66_formula.t` aborted on exactly this: the
+script's untyped `my $e;` was poisoned to `Str` by `method string`'s
+`my Str $e = $!esc;`, so the script's `CATCH { default { $e = $_ } }` died
+with "Type check failed in assignment to $e; expected Str but got Any"
+(`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`).
+
+The fix aligns typed scalar `my`/`state` declarations lexically inside
+routines with what typed *parameters* already did (`bind_param_type_constraint`):
+
+- The compiler emits a new `SetVarTypeScoped` opcode for them (decided at
+  compile time from `is_routine || lexically_in_routine`; `our`, dynamics,
+  `@`/`%` containers, and mainline declarations keep the both-store
+  `SetVarType`). It registers the constraint ONLY in the env-scoped
+  `__mutsu_type::` metadata, which dies with the frame and travels with a
+  captured closure env — so closures escaping the frame keep enforcement,
+  and EVAL'd re-assignment inside the frame still sees it.
+- The return merges no longer copy a callee's own `__mutsu_type::<local>`
+  entry back into the caller env: `is_callee_local_sym` unwraps the metadata
+  prefix, and `merge_method_env`'s skip predicate does the same. This also
+  fixes the pre-existing *overwrite* leak, where `sub f(Int $x is copy)`
+  replaced a caller's `my Str $x` env metadata with `Int` on return.
+- Nil-reset for typed scalars moved from the read paths into the SetLocal
+  store path (`typed_scalar_nil_seed_value`, shared with the declaration
+  seeding): a Nil ASSIGNED to a typed scalar stores the nominal type object
+  (native zero/empty for native types) instead of relying on the reader to
+  consult the global map. The Nil-read type-object conversion sites keep the
+  global-map-only fast probe on purpose — a `Mu $b = Nil` parameter default
+  must read as Nil, not as `Mu`.
+
+Pinned by `t/typed-lexical-constraint-frame-scoped.t` (12 tests: the method
+and 0-arg-fast-path leak shapes, the overwrite shape, in-frame and escaped-
+closure enforcement, EVAL, state, unassigned-read-as-type-object, and outer
+constraint survival across a shadowing call).
+
+With this, Text::CSV `t/66_formula.t` passes 83/83 and the functional suite
+is fully green: 33/33 files minus only `t/99_meta.t` (needs ecosystem
+`Test::META`, a dist-metadata QA test unrelated to CSV). The residual
+scope-blindness (`@`/`%` containers, mainline bare blocks, the
+untyped-shadow clear) stays tracked in the deep ticket.

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -150,7 +150,7 @@ impl Compiler {
                     if let Some(tc) = type_constraint {
                         let name_idx = self.code.add_constant(Value::str(name.clone()));
                         let tc_idx = self.code.add_constant(Value::str(tc.clone()));
-                        self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                        self.emit_set_var_type(name, name_idx, tc_idx, *is_our);
                     }
                     self.compile_expr(expr);
                     let slot = self.alloc_local(name);
@@ -365,10 +365,7 @@ impl Compiler {
                             // Set type constraint so future assignments also wrap
                             let name_idx2 = self.code.add_constant(Value::str(name.clone()));
                             let tc_idx = self.code.add_constant(Value::str(tc.clone()));
-                            self.code.emit(OpCode::SetVarType {
-                                name_idx: name_idx2,
-                                tc_idx,
-                            });
+                            self.emit_set_var_type(name, name_idx2, tc_idx, false);
                             // TypeCheck wraps the value on the stack for native types
                             let tc_idx2 = self.code.add_constant(Value::str(tc.clone()));
                             self.code.emit(OpCode::TypeCheck(tc_idx2, None));
@@ -392,10 +389,7 @@ impl Compiler {
                                 // subset's `where` predicate against Nil.
                                 let name_idx2 = self.code.add_constant(Value::str(name.clone()));
                                 let tc_idx = self.code.add_constant(Value::str(tc.clone()));
-                                self.code.emit(OpCode::SetVarType {
-                                    name_idx: name_idx2,
-                                    tc_idx,
-                                });
+                                self.emit_set_var_type(name, name_idx2, tc_idx, false);
                                 self.code.emit(OpCode::MarkVarDeclContext);
                                 self.emit_set_named_var(name);
                                 self.emit_get_named_var(name);

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -506,7 +506,7 @@ impl Compiler {
             {
                 let name_idx = self.code.add_constant(Value::str(name.clone()));
                 let tc_idx = self.code.add_constant(Value::str(tc.clone()));
-                self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                self.emit_set_var_type(name, name_idx, tc_idx, false);
             }
         }
     }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1799,6 +1799,33 @@ impl Compiler {
         }
     }
 
+    /// Emit the declaration-time type-constraint registration op for a
+    /// `my TYPE $x`-family declaration. A SCALAR `my`/`state` lexically inside
+    /// a routine gets `SetVarTypeScoped` — env-only registration, exactly like
+    /// a typed parameter — so its constraint dies with the frame instead of
+    /// leaking onto a same-named variable in another frame through the global
+    /// name-keyed store (`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`).
+    /// Everything else keeps the both-store `SetVarType`: `@`/`%` containers
+    /// (their element/key metadata is consulted through the global map by the
+    /// push/subscript fast paths), `our` (package-scoped, outlives the frame),
+    /// dynamics (`$*x`, read cross-frame by design), and mainline declarations
+    /// (no frame to scope to).
+    fn emit_set_var_type(&mut self, name: &str, name_idx: u32, tc_idx: u32, is_our: bool) {
+        let scoped = !is_our
+            && (self.is_routine || self.lexically_in_routine)
+            && !name.starts_with('@')
+            && !name.starts_with('%')
+            && !name.starts_with('&')
+            && !name.starts_with('*')
+            && !name.contains("::");
+        if scoped {
+            self.code
+                .emit(OpCode::SetVarTypeScoped { name_idx, tc_idx });
+        } else {
+            self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+        }
+    }
+
     /// For a genuine assignment (`$*x = ...`) to a dynamic variable, emit a
     /// runtime guard that throws X::Dynamic::NotFound when the dynamic var is
     /// not in scope (Raku requires `my $*x` first). Called ONLY from the plain

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1289,7 +1289,7 @@ impl Compiler {
                 // the trait is applied so the default value can be set first.
                 if !has_default_trait && let Some(tc) = type_constraint {
                     let tc_idx = self.code.add_constant(Value::str(tc.clone()));
-                    self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                    self.emit_set_var_type(name, name_idx, tc_idx, *is_our);
                 }
                 // Record type constraint for compile-time literal type checks
                 if let Some(tc) = type_constraint {
@@ -1756,7 +1756,7 @@ impl Compiler {
                 // Deferred type constraint registration after traits are applied
                 if has_default_trait && let Some(tc) = type_constraint {
                     let tc_idx = self.code.add_constant(Value::str(tc.clone()));
-                    self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                    self.emit_set_var_type(name, name_idx, tc_idx, *is_our);
                 }
                 // Mark constant variables as readonly so that subsequent
                 // assignments are rejected at runtime.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -661,6 +661,17 @@ pub(crate) enum OpCode {
         name_idx: u32,
         tc_idx: u32,
     },
+    /// [`Self::SetVarType`] for a scalar `my`/`state` declaration LEXICALLY
+    /// INSIDE a routine: registers the constraint in the env-scoped
+    /// `__mutsu_type::` metadata ONLY (exactly like a typed parameter), never
+    /// in the global name-keyed `var_type_constraints` map. The env entry dies
+    /// with the routine frame (and travels with a captured closure env), so
+    /// the constraint cannot leak onto a same-named variable in another frame
+    /// (`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`).
+    SetVarTypeScoped {
+        name_idx: u32,
+        tc_idx: u32,
+    },
     SetTopic,
     SaveTopic,
     RestoreTopic,
@@ -6966,6 +6977,25 @@ impl CompiledFunction {
     /// exactly as the call sites did before.
     #[inline]
     pub(crate) fn is_callee_local_sym(&self, sym: Symbol) -> bool {
+        if self.is_callee_local_sym_direct(sym) {
+            return true;
+        }
+        // A callee's own typed-lexical metadata (`__mutsu_type::<local>`,
+        // written env-scoped by a typed parameter bind or `SetVarTypeScoped`)
+        // is frame state: merging it back into the caller env would re-create
+        // the cross-frame constraint leak through the env store (see
+        // `todo/deep/bare-name-type-constraint-store-is-scope-blind.md`).
+        sym.with_str(|s| {
+            s.strip_prefix("__mutsu_type::")
+                .is_some_and(|base| self.is_callee_local_sym_direct(Symbol::intern(base)))
+        })
+    }
+
+    /// [`Self::is_callee_local_sym`] without the `__mutsu_type::` metadata-key
+    /// unwrapping — the bare membership test over params / `my` decls / `for`
+    /// params.
+    #[inline]
+    fn is_callee_local_sym_direct(&self, sym: Symbol) -> bool {
         match &self.declared_locals {
             Some(declared) => declared.contains(&sym),
             None if self.code.locals_sym.len() == self.code.locals.len() => {

--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -544,7 +544,10 @@ impl Interpreter {
     fn unwrap_varref_for_dispatch(&self, value: &Value) -> (Value, Option<String>) {
         match value.as_varref() {
             Some((name, inner, _)) => {
-                let var_type = name.with_str(|n| self.var_type_constraint_fast(n).cloned());
+                // Full (env-first) lookup: a typed routine lexical is env-scoped
+                // only (`SetVarTypeScoped`), invisible to the global-map-only
+                // fast probe.
+                let var_type = name.with_str(|n| self.var_type_constraint(n));
                 (inner.clone(), var_type)
             }
             None => (value.clone(), None),

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -86,6 +86,33 @@ impl Interpreter {
         self.set_var_type_constraint_impl(name, constraint, false);
     }
 
+    /// [`Self::set_var_type_constraint_decl`] for a scalar `my`/`state`
+    /// declared LEXICALLY INSIDE a routine (`OpCode::SetVarTypeScoped`):
+    /// registers the constraint ONLY in the env-scoped `__mutsu_type::`
+    /// metadata, exactly like a typed parameter
+    /// ([`Self::bind_param_type_constraint`]), and never in the global
+    /// name-keyed `var_type_constraints` map. The env entry is dropped with
+    /// the routine frame and travels with a captured closure env, so the
+    /// constraint cannot leak onto a same-named variable in another frame —
+    /// the Text::CSV `t/66_formula.t` shape, where a module method's
+    /// `my Str $e = ...` poisoned the caller script's untyped `$e` (see
+    /// `todo/deep/bare-name-type-constraint-store-is-scope-blind.md`).
+    /// A stale same-named GLOBAL entry (an outer frame's typed lexical) is
+    /// left untouched: the env-first read in [`Self::var_type_constraint`]
+    /// shadows it while this frame is live, and the outer frame's own
+    /// enforcement must survive this frame's return.
+    pub(crate) fn set_var_type_constraint_routine_scoped(&mut self, name: &str, constraint: &str) {
+        let info = Self::parse_container_constraint(name, constraint);
+        if info.value_type == "atomicint" || constraint.contains("atomicint") {
+            self.mark_atomic_var_seen();
+        }
+        self.env.insert(
+            format!("__mutsu_type::{}", name),
+            Value::str(info.value_type),
+        );
+        self.env_type_constraint_seen = true;
+    }
+
     fn set_var_type_constraint_impl(
         &mut self,
         name: &str,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -251,6 +251,7 @@ mod vm_var_multidim_helpers;
 mod vm_var_multidim_ops;
 mod vm_var_ops;
 mod vm_var_trait_ops;
+mod vm_var_type_ops;
 
 fn cmp_values(left: &Value, right: &Value) -> std::cmp::Ordering {
     crate::runtime::compare_values(left, right).cmp(&0)

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -513,6 +513,11 @@ impl Interpreter {
                 let val = if val.is_nil() {
                     if let Some(def) = self.var_default(name) {
                         def.clone()
+                    // Global-map-only on purpose: an env-scoped constraint (a
+                    // typed param / `SetVarTypeScoped` lexical) must not turn a
+                    // genuinely-Nil read (a `= Nil` param default) into the
+                    // type object; see the matching comment in
+                    // `vm_var_assign_local_get.rs`.
                     } else if let Some(constraint) = self.var_type_constraint_fast(name).cloned() {
                         let nominal =
                             loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
@@ -1724,87 +1729,10 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::SetVarType { name_idx, tc_idx } => {
-                let name = Self::const_str(code, *name_idx).to_string();
-                let raw_constraint = Self::const_str(code, *tc_idx).to_string();
-                // Empty constraint = CLEAR: an untyped expression-position
-                // declaration dropping a stale same-named constraint (the
-                // compiler never emits an empty string for a real type).
-                if raw_constraint.is_empty() {
-                    self.vm_set_var_type_constraint(&name, None);
-                    *ip += 1;
-                    return Ok(());
-                }
-                // Resolve type capture variables (e.g., `T` → `Int` when `::T`
-                // was captured earlier in the signature).
-                let constraint = loan_env!(self, resolved_type_capture_name(&raw_constraint));
-                // Clear stale atomic CAS state when an @-variable is
-                // (re-)declared with a type constraint like atomicint.
-                if name.starts_with('@') && constraint == "atomicint" {
-                    self.clear_atomic_array_state(&name);
-                }
-                self.vm_set_var_type_constraint_decl(&name, Some(constraint.clone()));
-                // For scalar variables, if the current value is Nil, set it to the type object.
-                // Exception: if the constraint is "Nil", keep the value as Nil
-                // (the Nil type object is Nil itself, not the Package "Nil").
-                if !name.starts_with('@') && !name.starts_with('%') && constraint != "Nil" {
-                    let is_nil = matches!(
-                        self.env().get(&name).map(Value::view),
-                        Some(ValueView::Nil) | None
-                    );
-                    if is_nil {
-                        // Native types get zero/empty defaults instead of type objects.
-                        let init_val =
-                            if crate::runtime::native_types::is_native_int_type(&constraint) {
-                                Value::int(0)
-                            } else if matches!(constraint.as_str(), "num" | "num32" | "num64") {
-                                Value::num(0.0)
-                            } else if constraint == "str" {
-                                Value::str(String::new())
-                            } else {
-                                // A parameterized role constraint (`my Cup of
-                                // EggNog $mug` / `my Cup[EggNog] $mug`) resolves
-                                // to the ParametricRole type object so .WHAT /
-                                // .raku keep the type arguments. The stored
-                                // constraint metadata normalizes to the base
-                                // name, so probe the raw constraint here.
-                                let parametric = constraint.contains('[').then(|| {
-                                    loan_env!(self, type_arg_value_from_name(&constraint))
-                                });
-                                match parametric {
-                                    Some(v)
-                                        if matches!(v.view(), ValueView::ParametricRole { .. }) =>
-                                    {
-                                        v
-                                    }
-                                    _ => Value::package(Symbol::intern(
-                                        &loan_env!(self, var_type_constraint(&name))
-                                            .unwrap_or(constraint.clone()),
-                                    )),
-                                }
-                            };
-                        self.set_env_with_main_alias(&name, init_val.clone());
-                        self.update_local_if_exists(code, &name, &init_val);
-                    }
-                } else if let Some(value) = self.get_env_with_main_alias(&name) {
-                    let info = crate::runtime::ContainerTypeInfo {
-                        value_type: loan_env!(self, var_type_constraint(&name))
-                            .unwrap_or(constraint),
-                        key_type: if name.starts_with('%') {
-                            loan_env!(self, var_hash_key_constraint(&name))
-                        } else {
-                            None
-                        },
-                        declared_type: None,
-                    };
-                    // Hashes embed metadata in `HashData`; write the tagged value
-                    // back (no-op Arc for array/instance side-table containers).
-                    // Tagging an object hash also re-keys it by `.WHICH`
-                    // (see `tag_container_metadata`).
-                    let tagged = self.tag_container_metadata(value, info);
-                    self.set_env_with_main_alias(&name, tagged.clone());
-                    self.update_local_if_exists(code, &name, &tagged);
-                }
-                *ip += 1;
+                self.exec_set_var_type(code, ip, *name_idx, *tc_idx, false)?;
+            }
+            OpCode::SetVarTypeScoped { name_idx, tc_idx } => {
+                self.exec_set_var_type(code, ip, *name_idx, *tc_idx, true)?;
             }
             OpCode::SetTopic => {
                 let val = self.stack.pop().unwrap_or(Value::NIL);

--- a/src/vm/vm_jit_support.rs
+++ b/src/vm/vm_jit_support.rs
@@ -72,6 +72,7 @@ pub(super) fn step_supported(op: &OpCode) -> bool {
             | OpCode::SetGlobalRaw(_)
             | OpCode::SetVarDynamic { .. }
             | OpCode::SetVarType { .. }
+            | OpCode::SetVarTypeScoped { .. }
             | OpCode::AssignExpr(_)
             | OpCode::TopicDotAssign(_)
             | OpCode::AtomicCompoundVar { .. }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1987,6 +1987,13 @@ fn merge_method_env(
                     // afterwards (a later closure's `return` then escapes its
                     // routine instead of returning from it).
                     || s == "__mutsu_callable_id"
+                    // A typed method-lexical's env-scoped constraint metadata
+                    // (`__mutsu_type::<local>`, from a typed param bind or
+                    // `SetVarTypeScoped`) is frame state: merging it back would
+                    // impose the method's constraint on a same-named caller
+                    // variable (the Text::CSV 66_formula.t leak, via env
+                    // instead of the global map).
+                    || s.strip_prefix("__mutsu_type::").is_some_and(is_method_local)
             }) {
                 return None;
             }

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -288,6 +288,13 @@ impl Interpreter {
                 self.stack.push(def.clone());
                 return Ok(());
             }
+            // Deliberately the global-map-only fast probe: an env-scoped
+            // constraint (`SetVarTypeScoped` / a typed param bind) must NOT
+            // convert a Nil read into the type object here — a `Mu $b = Nil`
+            // parameter's default really is Nil. A typed routine LEXICAL never
+            // reads Nil in the first place: its declaration seeds the type
+            // object and a Nil assignment resets to it in the SetLocal store
+            // path (`typed_scalar_nil_seed_value`).
             if let Some(constraint) = self.var_type_constraint_fast(name).cloned() {
                 let nominal = loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
                 // Nil type constraint: the type object for Nil is the Nil value

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1211,26 +1211,38 @@ impl Interpreter {
                     ));
                 }
             }
-            // A `:=` bind stores a `ContainerRef` cell (e.g. `my Offset $o := @a[$i]`
-            // aliases the array element). The type constraint applies to the
-            // *contained* value, so deref the cell before matching -- otherwise the
-            // check inspects the container itself and reports the bogus "got Any".
-            // Only the (rare) bind path derefs; the common assignment path borrows
-            // `val` directly with no clone.
-            let bind_derefed = is_bind.then(|| val.deref_container());
-            let check_val = bind_derefed.as_ref().unwrap_or(&val);
-            if !check_val.is_nil() && !self.type_matches_value(&constraint, check_val) {
-                return Err(runtime::utils::type_check_assignment_typed_error(
-                    name,
-                    &constraint,
-                    check_val,
-                ));
+            // A Nil ASSIGNED to a typed scalar resets it to its type object
+            // (`my Str $x = "a"; $x = Nil` leaves `$x === Str`). The reset must
+            // happen in the STORE: a routine lexical's constraint is env-scoped
+            // (`SetVarTypeScoped`), invisible to the read paths' global-map
+            // probe — which deliberately leaves a genuinely-Nil `= Nil`
+            // parameter default as Nil — so the stored value itself must carry
+            // the type object. Binds keep the Nil (`:=` stores the value as
+            // is), and an `is default(...)` value takes over the Nil read.
+            if val.is_nil() && !is_bind && constraint != "Nil" && self.var_default(name).is_none() {
+                val = self.typed_scalar_nil_seed_value(name, &constraint);
+            } else {
+                // A `:=` bind stores a `ContainerRef` cell (e.g. `my Offset $o := @a[$i]`
+                // aliases the array element). The type constraint applies to the
+                // *contained* value, so deref the cell before matching -- otherwise the
+                // check inspects the container itself and reports the bogus "got Any".
+                // Only the (rare) bind path derefs; the common assignment path borrows
+                // `val` directly with no clone.
+                let bind_derefed = is_bind.then(|| val.deref_container());
+                let check_val = bind_derefed.as_ref().unwrap_or(&val);
+                if !check_val.is_nil() && !self.type_matches_value(&constraint, check_val) {
+                    return Err(runtime::utils::type_check_assignment_typed_error(
+                        name,
+                        &constraint,
+                        check_val,
+                    ));
+                }
+                if !val.is_nil() {
+                    val = loan_env!(self, try_coerce_value_for_constraint(&constraint, val))?;
+                }
+                // Wrap native integer values on assignment (overflow wrapping)
+                val = Self::wrap_native_int_by_constraint(&constraint, val)?;
             }
-            if !val.is_nil() {
-                val = loan_env!(self, try_coerce_value_for_constraint(&constraint, val))?;
-            }
-            // Wrap native integer values on assignment (overflow wrapping)
-            val = Self::wrap_native_int_by_constraint(&constraint, val)?;
         } else if !is_bind && (!is_vardecl || has_explicit_initializer) {
             // Untyped scalar: assigning Nil resets it to the default type
             // object Any (`$x = Nil` / `my $x = Nil` leave `$x === Any`,

--- a/src/vm/vm_var_type_ops.rs
+++ b/src/vm/vm_var_type_ops.rs
@@ -99,10 +99,16 @@ impl Interpreter {
                 .then(|| loan_env!(self, type_arg_value_from_name(constraint)));
             match parametric {
                 Some(v) if matches!(v.view(), ValueView::ParametricRole { .. }) => v,
-                _ => Value::package(Symbol::intern(
-                    &loan_env!(self, var_type_constraint(name))
-                        .unwrap_or_else(|| constraint.to_string()),
-                )),
+                _ => {
+                    // The seeded package must carry the NOMINAL type name —
+                    // smileys stripped (`my Int:_ $a` seeds `Int`, not
+                    // `Int:_`) and coercion parens unwrapped — same as the
+                    // read-path Nil→type-object conversion it replaces.
+                    let base = loan_env!(self, var_type_constraint(name))
+                        .unwrap_or_else(|| constraint.to_string());
+                    let nominal = loan_env!(self, nominal_type_object_name_for_constraint(&base));
+                    Value::package(Symbol::intern(&nominal))
+                }
             }
         }
     }

--- a/src/vm/vm_var_type_ops.rs
+++ b/src/vm/vm_var_type_ops.rs
@@ -1,0 +1,109 @@
+//! `SetVarType` / `SetVarTypeScoped` — declaration-time type-constraint
+//! registration for `my TYPE $x` (and the typed `@`/`%` container forms).
+use super::*;
+
+impl Interpreter {
+    /// Execute a `SetVarType` / `SetVarTypeScoped` op. `scoped` selects the
+    /// env-only registration used for a scalar `my`/`state` lexically inside a
+    /// routine (see `OpCode::SetVarTypeScoped`); the registration store is the
+    /// ONLY difference between the two ops — the Nil→type-object seeding and
+    /// container tagging below are shared.
+    pub(super) fn exec_set_var_type(
+        &mut self,
+        code: &CompiledCode,
+        ip: &mut usize,
+        name_idx: u32,
+        tc_idx: u32,
+        scoped: bool,
+    ) -> Result<(), RuntimeError> {
+        let name = Self::const_str(code, name_idx).to_string();
+        let raw_constraint = Self::const_str(code, tc_idx).to_string();
+        // Empty constraint = CLEAR: an untyped expression-position
+        // declaration dropping a stale same-named constraint (the
+        // compiler never emits an empty string for a real type).
+        if raw_constraint.is_empty() {
+            self.vm_set_var_type_constraint(&name, None);
+            *ip += 1;
+            return Ok(());
+        }
+        // Resolve type capture variables (e.g., `T` → `Int` when `::T`
+        // was captured earlier in the signature).
+        let constraint = loan_env!(self, resolved_type_capture_name(&raw_constraint));
+        // Clear stale atomic CAS state when an @-variable is
+        // (re-)declared with a type constraint like atomicint.
+        if name.starts_with('@') && constraint == "atomicint" {
+            self.clear_atomic_array_state(&name);
+        }
+        if scoped {
+            self.loan_env_for(|i| i.set_var_type_constraint_routine_scoped(&name, &constraint));
+        } else {
+            self.vm_set_var_type_constraint_decl(&name, Some(constraint.clone()));
+        }
+        // For scalar variables, if the current value is Nil, set it to the type object.
+        // Exception: if the constraint is "Nil", keep the value as Nil
+        // (the Nil type object is Nil itself, not the Package "Nil").
+        if !name.starts_with('@') && !name.starts_with('%') && constraint != "Nil" {
+            let is_nil = matches!(
+                self.env().get(&name).map(Value::view),
+                Some(ValueView::Nil) | None
+            );
+            if is_nil {
+                let init_val = self.typed_scalar_nil_seed_value(&name, &constraint);
+                self.set_env_with_main_alias(&name, init_val.clone());
+                self.update_local_if_exists(code, &name, &init_val);
+            }
+        } else if let Some(value) = self.get_env_with_main_alias(&name) {
+            let info = crate::runtime::ContainerTypeInfo {
+                value_type: loan_env!(self, var_type_constraint(&name)).unwrap_or(constraint),
+                key_type: if name.starts_with('%') {
+                    loan_env!(self, var_hash_key_constraint(&name))
+                } else {
+                    None
+                },
+                declared_type: None,
+            };
+            // Hashes embed metadata in `HashData`; write the tagged value
+            // back (no-op Arc for array/instance side-table containers).
+            // Tagging an object hash also re-keys it by `.WHICH`
+            // (see `tag_container_metadata`).
+            let tagged = self.tag_container_metadata(value, info);
+            self.set_env_with_main_alias(&name, tagged.clone());
+            self.update_local_if_exists(code, &name, &tagged);
+        }
+        *ip += 1;
+        Ok(())
+    }
+
+    /// The value a Nil-valued typed scalar holds under constraint `constraint`:
+    /// the nominal type object, except native types (zero/empty defaults) and
+    /// parameterized roles (the ParametricRole type object, so `.WHAT`/`.raku`
+    /// keep the type arguments). Used both by the declaration-time seeding
+    /// above and by the SetLocal store path when a Nil is ASSIGNED to a typed
+    /// scalar — the read paths deliberately do not consult env-scoped
+    /// constraints for Nil→type-object conversion (a `= Nil` parameter default
+    /// must stay Nil), so the stored value itself must carry the type object.
+    pub(crate) fn typed_scalar_nil_seed_value(&mut self, name: &str, constraint: &str) -> Value {
+        if crate::runtime::native_types::is_native_int_type(constraint) {
+            Value::int(0)
+        } else if matches!(constraint, "num" | "num32" | "num64") {
+            Value::num(0.0)
+        } else if constraint == "str" {
+            Value::str(String::new())
+        } else {
+            // A parameterized role constraint (`my Cup of EggNog $mug` /
+            // `my Cup[EggNog] $mug`) resolves to the ParametricRole type
+            // object. The stored constraint metadata normalizes to the base
+            // name, so probe the raw constraint here.
+            let parametric = constraint
+                .contains('[')
+                .then(|| loan_env!(self, type_arg_value_from_name(constraint)));
+            match parametric {
+                Some(v) if matches!(v.view(), ValueView::ParametricRole { .. }) => v,
+                _ => Value::package(Symbol::intern(
+                    &loan_env!(self, var_type_constraint(name))
+                        .unwrap_or_else(|| constraint.to_string()),
+                )),
+            }
+        }
+    }
+}

--- a/t/typed-lexical-constraint-frame-scoped.t
+++ b/t/typed-lexical-constraint-frame-scoped.t
@@ -1,0 +1,87 @@
+use v6;
+use Test;
+
+# A typed scalar `my` inside a routine must not leak its constraint onto a
+# same-named variable in another frame (the bare-name-keyed constraint store
+# was scope-blind — todo/deep/bare-name-type-constraint-store-is-scope-blind.md,
+# Text::CSV t/66_formula.t line 129).
+
+plan 12;
+
+# The Text::CSV shape: a module method's `my Str $e = ...` must not poison
+# the caller script's untyped `$e` declared BEFORE the call.
+{
+    class TC { method m () { my Str $s = "x"; $s } }
+    my $s;
+    TC.m;
+    lives-ok { $s = 42 }, 'method-scoped my Str $s does not constrain caller $s';
+    is $s, 42, 'caller $s holds the assigned Int';
+}
+
+# Same shape through a plain sub call (0-arg fast path).
+{
+    sub leak0 { my Str $e = "x"; $e }
+    my $e;
+    leak0; leak0; leak0;
+    lives-ok { $e = 42 }, 'sub-scoped my Str $e does not constrain caller $e';
+}
+
+# The overwrite shape: the callee's constraint must not REPLACE the caller's
+# own constraint on a same-named typed lexical.
+{
+    sub over(Int $x is copy) { $x = 5 }
+    my Str $x = "a";
+    over(3);
+    lives-ok { $x = "b" }, 'caller Str constraint survives callee Int param';
+    throws-like { $x = 42 }, Exception, message => /'expected Str'/,
+        'caller Str constraint still enforced after the call';
+}
+
+# Enforcement INSIDE the routine still works (env-scoped registration).
+{
+    sub inside { my Str $s = "x"; $s = 42; }
+    dies-ok { inside() }, 'constraint enforced inside the declaring routine';
+}
+
+# A closure escaping the frame keeps enforcement through its captured env.
+{
+    sub outer { my Str $c = "a"; sub { $c = 42 } }
+    my &esc = outer();
+    dies-ok { esc() }, 'escaped closure still enforces the dead frame constraint';
+}
+
+# EVAL'd re-assignment inside the declaring frame sees the constraint.
+{
+    subset EvenT of Int where * %% 2;
+    sub evens { my EvenT $n = 2; EVAL '$n = 3'; }
+    dies-ok { evens() }, 'subset constraint enforced via EVAL in the frame';
+}
+
+# An unassigned typed scalar in a routine still reads as its type object.
+{
+    sub unassigned { my Str $u; $u.^name }
+    is unassigned(), 'Str', 'Nil-valued typed routine lexical reads as type object';
+}
+
+# state variables keep enforcement too.
+{
+    sub st { state Str $s = "s"; $s = 99; }
+    dies-ok { st() }, 'state Str constraint enforced in routine';
+}
+
+# A typed my inside a nested block of a method is frame-scoped as well.
+{
+    class TB { method m { if True { my Int $q = 1; } } }
+    my $q;
+    TB.m;
+    lives-ok { $q = "str" }, 'block-in-method typed my does not leak';
+}
+
+# An outer typed lexical keeps enforcement while a routine shadows the name.
+{
+    sub shadow { my Int $o = 1; $o }
+    my Str $o = "s";
+    shadow();
+    throws-like { $o = 42 }, Exception, message => /'expected Str'/,
+        'outer Str constraint intact after routine-scoped Int shadow';
+}

--- a/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
+++ b/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
@@ -1,82 +1,50 @@
-# Bare-name type-constraint store is scope-blind (constraint leaks across frames)
+# Bare-name type-constraint store is scope-blind (residual: containers and mainline blocks)
 
 `Interpreter::var_type_constraints` is a single global `HashMap<String,
-String>` keyed by BARE variable name. Every typed `my` declaration writes it
-(`set_var_type_constraint`, `src/runtime/runtime_var_meta.rs`), and it is
-never frame-scoped, so a typed lexical in ANY frame leaks its constraint
-onto every same-named variable that is assigned later — across routines,
-even across compunits.
+String>` keyed by BARE variable name, and it is never frame-scoped.
 
-## The shapes seen so far
+## Status 2026-08-13: routine-scoped SCALARS are fixed
 
-1. **Fixed case-by-case:** PR #6337 (2026-08-12) made an untyped
-   expression-position decl CLEAR a stale same-named constraint at
-   declaration time. Typed params already avoid the global map entirely
-   (`bind_param_type_constraint` writes env-scoped `__mutsu_type::` only,
-   restored with the frame).
-2. **Open (Text::CSV `t/66_formula.t` line 129):** clearing at declaration
-   is not enough when the leak happens AFTER the victim's declaration. The
-   test script declares untyped `my $e;` (clears fine), then calls
-   `$csv.string`, and Text/CSV.rakumod:921 `my Str $e = $!esc;` inside
-   `method string` re-registers bare "e" → Str in the global map. The
-   module frame exits (its env-scoped entry dies with it) but the global
-   entry survives, so the script's next `CATCH { default { $e = $_ } }`
-   dies "Type check failed in assignment to $e; expected Str but got Any".
-   Repro:
+The main leak — a typed scalar `my` inside a routine poisoning a same-named
+variable in another frame — is fixed (see
+`news/2026-08/typed-lexical-constraint-frame-scoped.md`): the compiler now
+emits `SetVarTypeScoped` for a scalar `my`/`state` lexically inside a
+routine, which registers the constraint env-scoped only (exactly like a
+typed parameter), and the return merges drop `__mutsu_type::<callee-local>`
+keys. Nil-assignment reset moved into the SetLocal store path
+(`typed_scalar_nil_seed_value`) so the read paths no longer need the global
+map for typed routine lexicals. Pinned by
+`t/typed-lexical-constraint-frame-scoped.t`; unblocked Text::CSV
+`t/66_formula.t` (the last real CSV suite blocker).
 
-   ```raku
-   class C { method m () { my Str $s = "x"; } }
-   my $s;
-   C.m;
-   $s = 42;   # mutsu: type check failed; raku: fine
-   ```
+## What is still scope-blind
 
-## Why the quick fixes don't compose
+1. **`@`/`%` containers**: `my Int @a` inside a routine still registers the
+   bare name in the global map (their element/key-type metadata is consulted
+   through `var_type_constraint_fast` by the push/subscript/element-assign
+   fast paths, which never probe env). A module method's `my Int @r` can
+   still poison a caller's same-named untyped `@r` — the shape #6337 and the
+   expr-position clears (`expr_block.rs`) patch case-by-case.
+2. **Mainline blocks**: a typed scalar in a bare block at mainline
+   (`{ my Str $x = "a" } ; my $x; $x = 42`) leaks within the mainline frame
+   — `lexically_in_routine` is false there, so the declaration still writes
+   the global map, and blocks do not restore it.
+3. **Untyped shadow destroys outer enforcement**: an untyped `my $e` /
+   untyped param inside a routine REMOVES the global entry of a same-named
+   outer typed lexical (the clear path in `set_var_type_constraint_impl` /
+   `bind_param_type_constraint`), so after the call the outer variable loses
+   enforcement through the fast paths. The env-scoped entry keeps the slow
+   (env-first) paths honest.
+4. **`for`-loop typed params** (`for @a -> Str $x {}`) still save/restore
+   the global map by name (`vm_for_loop_body.rs`).
 
-- Making routine-body typed `my` env-only (like params) breaks the global
-  fallback that `bind_param_type_constraint`'s comment documents (EVAL'd
-  re-assignment to a subset-typed lexical), and closures that outlive the
-  frame lose enforcement either way.
-- Restore-on-return bookkeeping (save/restore the global entry per frame)
-  has the same closure problem in the other direction: a closure captured
-  from the dead frame should STILL enforce its lexical's constraint.
+## The sound architecture (unchanged)
 
-## The sound architecture
-
-Rakudo attaches the constraint to the Scalar CONTAINER, not to a name: a
-container created by `my Str $e` carries `of Str` wherever it flows —
-closures keep enforcement, frames leak nothing, names never collide. mutsu
-already has per-container metadata precedents (ArrayData/HashData type
-metadata, ADR-0013 GcBox cells). The fix direction is to carry scalar
-constraints on the container cell (ContainerRef/GcBox layer) and make
-assignment check the TARGET CONTAINER's constraint instead of consulting a
-name-keyed side table; the name-keyed store then shrinks to compile-time /
-EVAL bridging only.
-
-Blocks: Text::CSV `t/66_formula.t` (test after 72, line 129). Related pins:
-`t/expr-decl-stale-type-constraint.t` (#6337).
-
-## Status 2026-08-13: this is the LAST real Text::CSV suite blocker
-
-After the `TagContainerRef` frame-leak fix (#6347) the full Text::CSV suite
-(33 files, 22685 tests) is green except:
-
-- `t/66_formula.t` — aborts after 72/72-passing tests at exactly this
-  ticket's line-129 shape (`my $e;` in the script poisoned to `Str` by
-  `method string`'s `my Str $e = $!esc;`). Fixing this ticket finishes the
-  file.
-- `t/99_meta.t` — `Unknown function: meta-ok`: needs the ecosystem
-  `Test::META` module (a dist-metadata QA test), unrelated to this ticket
-  and to CSV functionality.
-
-Scoping note for the fix: mutsu scalars in locals are bare NaN-boxed values
-(no Scalar container object exists unless boxed into a `ContainerRef`), so
-"attach the constraint to the container" concretely means either (a) keying
-enforcement by *declaration site* — a compile-time slot→constraint table on
-`CompiledCode` for slot-resident scalars, plus the existing env-scoped
-`__mutsu_type::` for env-resident ones — with the global name-keyed map
-shrinking to EVAL bridging; or (b) boxing typed scalars into cells that
-carry `of`. (a) preserves the no-boxing perf profile and matches how the
-compiler already knows the constraint statically at every `my Str $x` site;
-closures that capture the lexical get the constraint through the captured
-cell in either design.
+Rakudo attaches the constraint to the Scalar CONTAINER: a container created
+by `my Str $e` carries `of Str` wherever it flows. The remaining fix
+direction for the residuals is the same as the ticket originally proposed —
+carry constraints on the container/cell (ArrayData/HashData already carry
+element types; scalars would need cell-carried `of`) and make the
+name-keyed store compile-time/EVAL bridging only. The container residual
+(1) is the meaningful one: it needs the `_fast` consultation sites
+(push/subscript) to read per-container metadata instead of the name map.


### PR DESCRIPTION
## Summary

A typed scalar `my` inside a routine registered its type constraint in the global bare-name-keyed `var_type_constraints` map, which survives the frame — so any same-named variable assigned later, in ANY frame, was checked against the dead frame's constraint. Text::CSV `t/66_formula.t` aborted after 72 passing tests on exactly this shape: the script's untyped `my $e;` was poisoned to `Str` by `method string`'s `my Str $e = $!esc;`, so the script's `CATCH { default { $e = $_ } }` died with "Type check failed in assignment to \$e" (`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`).

## Changes

- **New `SetVarTypeScoped` opcode**, emitted (compile-time decision: `is_routine || lexically_in_routine`) for scalar `my`/`state` declarations lexically inside routines. It registers the constraint env-scoped only (`__mutsu_type::` metadata) — exactly like a typed parameter bind — so it dies with the frame and travels with a captured closure env. `our`, dynamics, `@`/`%` containers, and mainline declarations keep the both-store `SetVarType`.
- **Return merges drop callee constraint metadata**: `is_callee_local_sym` now unwraps the `__mutsu_type::` prefix, and `merge_method_env`'s skip predicate does the same. This also fixes the pre-existing *overwrite* leak, where `sub f(Int $x is copy)` replaced a caller's `my Str $x` env metadata with `Int` on return.
- **Nil-reset moved to the store path**: assigning Nil to a typed scalar now stores the nominal type object (native zero/empty for native types) via `typed_scalar_nil_seed_value`, shared with declaration seeding. The Nil-read conversion sites keep the global-map-only fast probe on purpose — a `Mu $b = Nil` parameter default must read as Nil, not `Mu` (caught by `t/role-samename-composition-and-nested-class.t` during development).
- varref multi-dispatch uses the full env-first constraint lookup so typed routine lexicals keep declared-type dispatch.

## Testing

- New pin: `t/typed-lexical-constraint-frame-scoped.t` (12 tests, verified against raku): method/0-arg-fast-path leak shapes, the overwrite shape, in-frame + escaped-closure enforcement, EVAL'd subset re-assignment, `state`, unassigned-read-as-type-object, outer-constraint survival across a shadowing call.
- `make test` full: PASS (3108 files / 28865 tests).
- Text::CSV suite (fixed build): 32/32 files, 22696 tests PASS — **`t/66_formula.t` now 83/83**, leaving only `99_meta.t` (needs ecosystem `Test::META`) in the whole 33-file suite.
- Typed-variable/signature roast batch (38 files, 1269 tests): PASS.

Residual scope-blindness (`@`/`%` containers, mainline bare blocks, untyped-shadow clears, for-loop typed params) stays tracked in the deep ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)