### PR TITLE
refactor(dispatch): introduce DeferralEntry enum for method wrap-prefix entries (ADR-0019 E9b-1)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3993,6 +3993,21 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   (`wrap-chain-skipped-inside-foreign-wrap-dispatch.md`, the global
   `is_inside_wrap_dispatch()` guard) is untouched — that is E9b-2 scope, which
   deletes the guard entirely as part of the single-frame cutover.
+  **Progress 2026-08-13 (same day) — E9b-1 landed (mechanical, zero behavior
+  change).** `DeferralEntry` enum added (`Wrapper(Value)` /
+  `Candidate{owner: Symbol, def: Box<MethodDef>, wraps_spliced: bool}` —
+  `def` boxed to keep the enum small, clippy's `large_enum_variant`);
+  `MethodDispatchFrame.remaining` is now `Vec<DeferralEntry>` and the frame
+  gains an `arg_sources: Option<Vec<Option<String>>>` field (unused until
+  E9b-2's Wrapper advance leg). Every existing builder (the plain MRO
+  deferral push, the two method-wrap entry sites, the mixin base-dispatch
+  push) emits only `Candidate` entries — `Wrapper` is not constructed
+  anywhere yet, so the two consumer match sites in `dispatch_next_candidate`
+  hit an `unreachable!()` arm documented as E9b-2's job to fill in.
+  `gc_roots.rs` traces `Wrapper` values pre-emptively so the cutover doesn't
+  have to remember it. Full `t/` + targeted roast (`S06-advanced/*`,
+  `S06-multi/*`, `S12-methods/{defer-call,defer-next,multi}.t`) green with no
+  new pin (behavior is unchanged by construction).
 - [ ] **E10 — Move wrap/unwrap mutation into canonical entries.** Bump the generation and remove
   wrap-specific cache-clearing paths.
   **Design 2026-08-10** (same doc): `method_wrap_chains` moves into the registry; every

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -840,7 +840,7 @@ impl Interpreter {
         let chosen_fp = chosen
             .as_ref()
             .map(|(_, def)| self.method_def_fingerprint(def));
-        let mut remaining: Vec<(String, super::MethodDef)> = Vec::new();
+        let mut remaining: Vec<(Symbol, super::MethodDef)> = Vec::new();
         let mut skipped_chosen = false;
         for (owner, def) in all_candidates {
             let fp = self.method_def_fingerprint(&def);
@@ -851,7 +851,7 @@ impl Interpreter {
             if self.should_skip_defer_method_candidate(receiver_class, owner.as_str()) {
                 continue;
             }
-            remaining.push((owner.resolve(), def));
+            remaining.push((owner, def));
         }
         // ADR-0019 E8a shadow probe (zero behavior change): see
         // `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`.
@@ -872,6 +872,16 @@ impl Interpreter {
                 })
                 .unwrap_or_default();
             let dispatch_token = self.next_dispatch_token();
+            // ADR-0019 E9b-1: every entry is a plain Candidate — this builder
+            // never wraps a method's own chain into the frame (that is E9b-2).
+            let remaining = remaining
+                .into_iter()
+                .map(|(owner, def)| super::DeferralEntry::Candidate {
+                    owner,
+                    def: Box::new(def),
+                    wraps_spliced: false,
+                })
+                .collect();
             self.method_dispatch_stack.push(super::MethodDispatchFrame {
                 receiver_class: receiver_class.to_string(),
                 invocant,
@@ -879,6 +889,7 @@ impl Interpreter {
                 remaining,
                 rw_params,
                 dispatch_token,
+                arg_sources: None,
             });
         }
         pushed

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -545,7 +545,15 @@ impl Interpreter {
                     .remaining
                     .first()
                     .cloned();
-                if let Some((owner_class, method_def)) = peeked {
+                // ADR-0019 E9b-1: no builder emits `Wrapper` yet, so every
+                // peeked entry is a Candidate (E9b-2 adds the Wrapper leg).
+                if let Some(DeferralEntry::Candidate {
+                    owner: owner_sym,
+                    def: method_def,
+                    ..
+                }) = peeked
+                {
+                    let owner_class = owner_sym.resolve();
                     let method_name_now = self
                         .samewith_context_stack
                         .last()
@@ -598,7 +606,7 @@ impl Interpreter {
             }
             let (receiver_class, invocant, mut call_args, owner_class, mut method_def, rw_params) = {
                 let frame = &mut self.method_dispatch_stack[frame_idx];
-                let Some((owner_class, method_def)) = frame.remaining.first().cloned() else {
+                let Some(entry) = frame.remaining.first().cloned() else {
                     // User MRO exhausted: a grammar `parse`/`subparse` override, an
                     // `is Array` subclass's Positional override, or a metamodel-HOW
                     // dispatch falls through to the native implementation as the
@@ -629,6 +637,18 @@ impl Interpreter {
                     }
                     return Ok(result);
                 };
+                // ADR-0019 E9b-1: no builder emits `Wrapper` yet, so every
+                // entry here is a Candidate (E9b-2 adds the Wrapper leg).
+                let DeferralEntry::Candidate {
+                    owner: owner_sym,
+                    def: method_def,
+                    ..
+                } = entry
+                else {
+                    unreachable!("ADR-0019 E9b-1: no builder emits DeferralEntry::Wrapper yet")
+                };
+                let owner_class = owner_sym.resolve();
+                let method_def = *method_def;
                 frame.remaining.remove(0);
                 let rw_params = frame.rw_params.clone();
                 let call_args = if let Some(new_args) = override_args {

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -283,9 +283,7 @@ impl Interpreter {
         // otherwise pays just to learn "nothing to defer to".
         let skip_remaining = (method_def.is_my || method_def.is_submethod)
             && self.count_visible_method_candidates(receiver_class_name, method_name) <= 1;
-        let build_remaining = |this: &mut Self,
-                               method_def: &MethodDef|
-         -> Vec<(String, MethodDef)> {
+        let build_remaining = |this: &mut Self, method_def: &MethodDef| -> Vec<DeferralEntry> {
             if skip_remaining {
                 return Vec::new();
             }
@@ -319,7 +317,14 @@ impl Interpreter {
                 if this.should_skip_defer_method_candidate(receiver_class_name, owner.as_str()) {
                     continue;
                 }
-                remaining.push((owner.resolve(), def));
+                // ADR-0019 E9b-1: every entry is a plain Candidate here — this
+                // builder never wraps a method's own chain into the frame
+                // (that is E9b-2).
+                remaining.push(DeferralEntry::Candidate {
+                    owner,
+                    def: Box::new(def),
+                    wraps_spliced: false,
+                });
             }
             remaining
         };
@@ -367,6 +372,7 @@ impl Interpreter {
                     remaining,
                     rw_params,
                     dispatch_token,
+                    arg_sources: None,
                 });
             }
             let mut orig_env = crate::env::Env::new();
@@ -451,6 +457,7 @@ impl Interpreter {
                 remaining,
                 rw_params,
                 dispatch_token,
+                arg_sources: None,
             });
         }
         // Check for `is DEPRECATED` trait on the method

--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -164,12 +164,36 @@ pub(crate) type MultiDispatchEntry = (
     u64,
 );
 
+/// One entry of `MethodDispatchFrame::remaining` (ADR-0019 E9b-1). A
+/// `Candidate` is the pre-E9b-1 `(owner, MethodDef)` shape unchanged in
+/// substance; `Wrapper` lets a method's own `.wrap()` chain fold into the same
+/// `remaining` list as prefix entries instead of a separate stack (E9b-2 —
+/// no builder emits `Wrapper` yet in this slice, so it is currently inert).
+#[derive(Debug, Clone)]
+pub(crate) enum DeferralEntry {
+    /// A wrapper code object; invoked with `[invocant, args...]` and shifted
+    /// arg sources, mirroring today's `WrapDispatchFrame` wrapper leg.
+    #[allow(dead_code)]
+    Wrapper(Value),
+    /// A user method candidate; invoked directly as a resolved method (the
+    /// existing method-frame advance leg, unchanged in substance).
+    Candidate {
+        owner: crate::symbol::Symbol,
+        // Boxed: MethodDef is ~300 bytes, which would otherwise make every
+        // DeferralEntry (including the small Wrapper(Value) variant) pay that
+        // size (clippy::large_enum_variant).
+        def: Box<MethodDef>,
+        #[allow(dead_code)]
+        wraps_spliced: bool,
+    },
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct MethodDispatchFrame {
     pub(crate) receiver_class: String,
     pub(crate) invocant: Value,
     pub(crate) args: Vec<Value>,
-    pub(crate) remaining: Vec<(String, MethodDef)>,
+    pub(crate) remaining: Vec<DeferralEntry>,
     /// The FIRST (winning) candidate's scalar `is rw`/`is raw` positional params
     /// as (positional_arg_index, sigil-less_param_name). Stays fixed across the
     /// MRO chain so a `nextsame`+rw redispatch can forward the rw param's current
@@ -179,6 +203,12 @@ pub(crate) struct MethodDispatchFrame {
     /// `MultiDispatchEntry`. callsame/nextsame/lastcall/nextcallee compare tokens
     /// across all three deferral stacks and pick the highest (innermost) live frame.
     pub(crate) dispatch_token: u64,
+    /// ADR-0019 E9b-1: call-site source variable names for the wrapped
+    /// method's arguments, mirroring `WrapDispatchFrame::arg_sources`. Unused
+    /// until E9b-2's `Wrapper` advance leg restores them for an `is rw`
+    /// parameter of the next callee; every E9b-1 builder sets this to `None`.
+    #[allow(dead_code)]
+    pub(crate) arg_sources: Option<Vec<Option<String>>>,
 }
 
 /// Frame for navigating through wrapper chain during callsame/callwith.

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -137,6 +137,14 @@ impl Interpreter {
         for frame in &self.method_dispatch_stack {
             visitor.visit_value(&frame.invocant);
             visit_slice(visitor, &frame.args);
+            // ADR-0019 E9b-1: a `Wrapper` entry carries a live callable Value;
+            // no builder emits one yet (E9b-2), but tracing it now means the
+            // cutover never has to remember to add this.
+            for entry in &frame.remaining {
+                if let super::DeferralEntry::Wrapper(v) = entry {
+                    visitor.visit_value(v);
+                }
+            }
         }
         for (_, v) in &self.samewith_context_stack {
             visit_opt(visitor, v);

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -196,11 +196,15 @@ impl Interpreter {
                     }
                     _ => None,
                 };
-                let base_remaining: Vec<(String, MethodDef)> = if let Some(bc) = &base_class {
+                let base_remaining: Vec<super::DeferralEntry> = if let Some(bc) = &base_class {
                     self.resolve_all_methods_with_owner(bc, lookup_name, &args)
                         .into_iter()
                         .filter(|(_, d)| d.is_private == is_private_call)
-                        .map(|(o, d)| (o.resolve(), d))
+                        .map(|(owner, def)| super::DeferralEntry::Candidate {
+                            owner,
+                            def: Box::new(def),
+                            wraps_spliced: false,
+                        })
                         .collect()
                 } else {
                     Vec::new()
@@ -219,6 +223,7 @@ impl Interpreter {
                         remaining: base_remaining,
                         rw_params,
                         dispatch_token,
+                        arg_sources: None,
                     });
                 }
                 let method_result = self.run_resolved_method_compiled_or_treewalk(

--- a/src/runtime/resolution_sequence.rs
+++ b/src/runtime/resolution_sequence.rs
@@ -564,7 +564,7 @@ impl Interpreter {
         arg_values: &[Value],
         invocant: &Value,
         chosen_fp: Option<u64>,
-        real_remaining: &[(String, MethodDef)],
+        real_remaining: &[(Symbol, MethodDef)],
     ) {
         if !crate::vm::vm_stats::enabled() {
             return;


### PR DESCRIPTION
## Summary
- `MethodDispatchFrame.remaining` moves from `Vec<(String, MethodDef)>` to `Vec<DeferralEntry>`, where `DeferralEntry` is `Wrapper(Value) | Candidate{owner: Symbol, def: Box<MethodDef>, wraps_spliced: bool}` (`def` boxed to keep the enum small — `clippy::large_enum_variant`).
- The frame also gains an `arg_sources: Option<Vec<Option<String>>>` field, mirroring `WrapDispatchFrame`'s — unused until E9b-2's Wrapper advance leg.
- **Mechanical, zero-behavior-change slice**: every existing builder (the plain MRO deferral push, the two method-wrap entry sites, the mixin base-dispatch push) emits only `Candidate` entries. `Wrapper` is not constructed anywhere yet, so the two match sites in `dispatch_next_candidate` hit an `unreachable!()` arm documented as E9b-2's job to fill in when method wraps fold into this same list as prefix entries.
- `gc_roots.rs` traces `Wrapper` values pre-emptively so the E9b-2 cutover doesn't have to remember to add it.

This is ADR-0019 slice **E9b-1** (follows E9b-0, #6361), per `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` E9 box progress notes and `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` "E9b design" decision 1.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` clean.
- [x] Local `make test` (3117 files, 28923 tests) — all green.
- [x] Local roast: `roast/S06-advanced/*.t` (whitelisted), `roast/S06-multi/*.t` (11 files), `roast/S12-methods/{defer-call,defer-next,multi}.t` — all green.
- [x] No new pin needed — behavior is unchanged by construction (this slice is a pure representation change).
- [ ] CI `make roast` (full suite, watched in background).

🤖 Generated with [Claude Code](https://claude.com/claude-code)