### PR TITLE
refactor(dispatch): method wraps become deferral-frame prefix entries (ADR-0019 E9b-2)

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -763,6 +763,145 @@ impl Interpreter {
         self.dispatch_token_counter
     }
 
+    /// ADR-0019 E9a/E9b-2: candidates from the deferral expansion whose
+    /// signature matches this call's args (invocant-blind, per E8a finding
+    /// 1). Shared first half of [`Self::push_method_dispatch_frame`]'s and
+    /// [`Self::deferral_tail_entries`]'s computation, before either applies
+    /// its own "skip the chosen winner" step.
+    fn matched_deferral_candidates(
+        &mut self,
+        receiver_class: &str,
+        method_name: &str,
+        args: &[Value],
+    ) -> Vec<(Symbol, super::MethodDef)> {
+        let role_bindings = self.registry().get_role_param_bindings(receiver_class);
+        let expansion = self.resolve_deferral_expansion(receiver_class, method_name);
+        let mut all_candidates: Vec<(Symbol, super::MethodDef)> = Vec::new();
+        for (owner, def) in expansion {
+            if self.method_args_match_for_invocant(
+                receiver_class,
+                &def,
+                args,
+                role_bindings.as_ref(),
+                None,
+            ) {
+                all_candidates.push((owner, def));
+            }
+        }
+        all_candidates
+    }
+
+    /// ADR-0019 E9b-2: the plain MRO-tail deferral entries following an
+    /// ALREADY-KNOWN winning candidate `chosen_def` — shared by the two
+    /// method-wrap entry sites (`class_dispatch.rs`'s
+    /// `run_instance_method_celled`, `vm_call_method_compiled.rs`'s
+    /// `check_method_wrap_chain`), which resolve their own winner
+    /// independently (it is the wrapped candidate) and only need the tail to
+    /// append after their own Wrapper-prefixed `Candidate{wraps_spliced:
+    /// true}` entry. Every entry here is `wraps_spliced: false` — a later
+    /// entry with its OWN wrap chain is spliced lazily at advance time
+    /// (`dispatch_next_candidate`), not here (decision 3 of the E9b design).
+    pub(crate) fn deferral_tail_entries(
+        &mut self,
+        receiver_class: &str,
+        method_name: &str,
+        args: &[Value],
+        chosen_def: &super::MethodDef,
+    ) -> Vec<super::DeferralEntry> {
+        // Submethod fast path, mirroring `push_method_dispatch_frame`'s own
+        // `<=1` guard: a submethod is never inherited, so a single visible
+        // candidate can never produce a deferral tail.
+        if (chosen_def.is_my || chosen_def.is_submethod)
+            && self.count_visible_method_candidates(receiver_class, method_name) <= 1
+        {
+            return Vec::new();
+        }
+        let all_candidates = self.matched_deferral_candidates(receiver_class, method_name, args);
+        let chosen_fp = self.method_def_fingerprint(chosen_def);
+        let mut remaining = Vec::new();
+        let mut skipped = false;
+        for (owner, def) in all_candidates {
+            let fp = self.method_def_fingerprint(&def);
+            if !skipped && fp == chosen_fp {
+                skipped = true;
+                continue;
+            }
+            if self.should_skip_defer_method_candidate(receiver_class, owner.as_str()) {
+                continue;
+            }
+            remaining.push(super::DeferralEntry::Candidate {
+                owner,
+                def: Box::new(def),
+                wraps_spliced: false,
+            });
+        }
+        remaining
+    }
+
+    /// ADR-0019 E9b-2: build and push the SINGLE wrap-prefixed
+    /// `MethodDispatchFrame` for a method-wrap entry site — the below-
+    /// outermost wrappers (in call order), the winner as a `wraps_spliced:
+    /// true` `Candidate`, then the MRO tail. Shared by the two method-wrap
+    /// entry sites (`class_dispatch.rs`'s `run_instance_method_celled`,
+    /// `vm_call_method_compiled.rs`'s `check_method_wrap_chain`), which then
+    /// invoke `chain`'s outermost wrapper (`chain.last()`) directly with
+    /// `[invocant, ...args]` — mirrors the pattern every other VM call site
+    /// uses `push_method_dispatch_frame` for, kept as a `pub(crate)`
+    /// Interpreter method (rather than the caller touching
+    /// `method_dispatch_stack` directly) so `vm/` call sites do not need
+    /// visibility into private `runtime` fields/modules.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn push_wrapped_method_dispatch_frame(
+        &mut self,
+        receiver_class: &str,
+        method_name: &str,
+        args: &[Value],
+        invocant: Value,
+        owner_class: Symbol,
+        method_def: &super::MethodDef,
+        chain: &[(u64, Value)],
+    ) {
+        let mro_tail = self.deferral_tail_entries(receiver_class, method_name, args, method_def);
+        let rw_params =
+            super::builtins_dispatch_next::rw_scalar_positional_params(&method_def.param_defs);
+        let dispatch_token = self.next_dispatch_token();
+        // Save the pending call-site arg sources BEFORE the outermost
+        // wrapper's own binding consumes them: the `Wrapper`/wraps_spliced
+        // `Candidate` advance legs in `dispatch_next_candidate` restore this
+        // so an `is rw`/sigilless param anywhere in the chain still binds to
+        // the true call-site variable (`t/wrap-invocant-arg-source.t`).
+        let arg_sources = self.pending_call_arg_sources().cloned();
+        // Below-outermost wrappers, in call order (second-outermost first,
+        // innermost/oldest last) — the outermost is invoked directly by the
+        // caller, mirroring today's "outermost runs, the rest are remaining"
+        // shape.
+        let mut remaining: Vec<super::DeferralEntry> =
+            Vec::with_capacity(chain.len() + mro_tail.len());
+        for i in (0..chain.len() - 1).rev() {
+            remaining.push(super::DeferralEntry::Wrapper(chain[i].1.clone()));
+        }
+        remaining.push(super::DeferralEntry::Candidate {
+            owner: owner_class,
+            def: Box::new(method_def.clone()),
+            wraps_spliced: true,
+        });
+        remaining.extend(mro_tail);
+        self.method_dispatch_stack.push(super::MethodDispatchFrame {
+            receiver_class: receiver_class.to_string(),
+            invocant,
+            args: args.to_vec(),
+            remaining,
+            rw_params,
+            dispatch_token,
+            arg_sources,
+            // The caller invokes chain's outermost wrapper directly right
+            // after this push, so this frame always STARTS inside wrapper
+            // code (even when `chain.len() == 1` and `remaining` holds no
+            // `Wrapper` entry at all).
+            in_wrapper: true,
+        });
+    }
+
     pub(crate) fn push_method_dispatch_frame(
         &mut self,
         receiver_class: &str,
@@ -810,20 +949,7 @@ impl Interpreter {
         // a `multi method` spans MRO levels. The expansion is structural (unfiltered); apply the
         // same per-call, invocant-blind argument match `resolve_all_methods_with_owner` used to
         // apply internally.
-        let role_bindings = self.registry().get_role_param_bindings(receiver_class);
-        let expansion = self.resolve_deferral_expansion(receiver_class, method_name);
-        let mut all_candidates: Vec<(Symbol, super::MethodDef)> = Vec::new();
-        for (owner, def) in expansion {
-            if self.method_args_match_for_invocant(
-                receiver_class,
-                &def,
-                args,
-                role_bindings.as_ref(),
-                None,
-            ) {
-                all_candidates.push((owner, def));
-            }
-        }
+        let all_candidates = self.matched_deferral_candidates(receiver_class, method_name, args);
         // Fast path: with zero or one candidate there is nothing to defer to, so no
         // dispatch frame is ever pushed (the single candidate is the chosen one and
         // gets skipped, leaving `remaining` empty). Returning early here avoids the
@@ -890,13 +1016,10 @@ impl Interpreter {
                 rw_params,
                 dispatch_token,
                 arg_sources: None,
+                in_wrapper: false,
             });
         }
         pushed
-    }
-
-    pub(crate) fn is_inside_wrap_dispatch(&self) -> bool {
-        !self.wrap_dispatch_stack.is_empty()
     }
 
     pub(crate) fn has_any_wrap_chains(&self) -> bool {
@@ -904,6 +1027,13 @@ impl Interpreter {
     }
 
     pub(crate) fn push_wrap_dispatch_frame(&mut self, mut frame: super::WrapDispatchFrame) {
+        // ADR-0019 E9b-2: method wraps moved to `MethodDispatchFrame::remaining`
+        // (`DeferralEntry::Wrapper`) — this stack now carries SUB wraps only,
+        // whose `sub_id` is always a real (non-zero) sub id.
+        debug_assert!(
+            frame.sub_id != 0,
+            "ADR-0019 E9b-2: WrapDispatchFrame is sub-only; sub_id == 0 was the retired method-wrap sentinel"
+        );
         frame.dispatch_token = self.next_dispatch_token();
         self.wrap_dispatch_stack.push(frame);
     }

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -437,20 +437,15 @@ impl Interpreter {
         override_args: Option<Vec<Value>>,
         tail_call: bool,
     ) -> Result<Value, RuntimeError> {
-        // Whether this call fell through an exhausted method-wrap frame
-        // (sub_id == 0, remaining now empty): raku's `lastcall` inside a
-        // method wrapper empties the chain, so a following callsame must
-        // resolve to Nil -- we are still inside the wrap dispatcher, even
-        // when there is no method_dispatch_stack/method_class_stack frame to
-        // say so (a plain, unwrapped-by-MRO method has neither).
-        let mut wrap_chain_exhausted = false;
         // ADR-0019 E9b-0: resolve to the innermost live dispatch context (by
         // dispatch_token) instead of a fixed wrap-then-method-then-multi order,
         // so an outer sub/method wrap does not shadow a more recently pushed
         // frame on a different stack (and vice versa).
         let innermost = self.innermost_dispatch_stack();
-        // Try wrap dispatch stack first (wrapper chains) — only when it is
-        // genuinely the innermost context.
+        // Try wrap dispatch stack first (SUB wraps only — ADR-0019 E9b-2 moved
+        // method wraps into `method_dispatch_stack` as `DeferralEntry::Wrapper`
+        // prefix entries, so this stack no longer carries a `sub_id == 0`
+        // entry) — only when it is genuinely the innermost context.
         if innermost == Some(DispatchFrameKind::Wrap)
             && let Some(frame) = self.wrap_dispatch_stack.last_mut()
         {
@@ -458,7 +453,6 @@ impl Interpreter {
                 frame.remaining.remove(0);
                 let is_override = override_args.is_some();
                 let call_args = override_args.unwrap_or_else(|| frame.args.clone());
-                let is_method_wrap = frame.sub_id == 0;
                 // Restore the original call site's arg-source names: the
                 // outermost wrapper's own binding consumed the pending ones, so
                 // an `is rw` parameter of the next callee (a wrappee or the
@@ -470,30 +464,10 @@ impl Interpreter {
                 if restore_sources {
                     self.set_pending_call_arg_sources(frame_arg_sources);
                 }
-                // If this is a method wrap original, separate the invocant
-                // from the args and dispatch as a method call.
-                let result = if let ValueView::Sub(data) = next.view()
-                    && data.env.get("__mutsu_method_wrap_original").is_some()
-                    && !call_args.is_empty()
-                {
-                    let invocant = call_args[0].clone();
-                    let method_args = call_args[1..].to_vec();
-                    let method_name = data.name.resolve();
-                    self.call_method_with_values(invocant, &method_name, method_args)?
-                } else {
-                    // This exact call continues the active wrap chain — it must
-                    // run `next` directly, not re-enter the chain from the top.
-                    // An inner *wrapper* sees the same invocant-prepended
-                    // argument list the outermost one did, so its sources need
-                    // the same shift.
-                    if restore_sources && is_method_wrap {
-                        self.shift_arg_sources_for_wrap_invocant();
-                    }
-                    if let ValueView::Sub(data) = next.view() {
-                        self.wrap_skip_once = Some(data.id);
-                    }
-                    self.call_sub_value(next, call_args, false)?
-                };
+                if let ValueView::Sub(data) = next.view() {
+                    self.wrap_skip_once = Some(data.id);
+                }
+                let result = self.call_sub_value(next, call_args, false)?;
                 if tail_call {
                     return Err(RuntimeError {
                         return_value: Some(result),
@@ -502,115 +476,99 @@ impl Interpreter {
                 }
                 return Ok(result);
             }
-            // Remaining is empty.
-            if frame.sub_id != 0 {
-                // Non-method wrap: exhausted — return Nil
-                if tail_call {
-                    return Err(RuntimeError {
-                        return_value: Some(Value::NIL),
-                        ..RuntimeError::new("")
-                    });
-                }
-                return Ok(Value::NIL);
+            // Remaining is empty: exhausted — return Nil.
+            if tail_call {
+                return Err(RuntimeError {
+                    return_value: Some(Value::NIL),
+                    ..RuntimeError::new("")
+                });
             }
-            // Method wraps (sub_id == 0): fall through to method dispatch stack
-            // so callsame inside the original method can continue the MRO chain.
-            wrap_chain_exhausted = true;
+            return Ok(Value::NIL);
         }
-        // Try method dispatch stack — either it is genuinely the innermost
-        // context, or we just fell through an exhausted method-wrap sentinel
-        // above: today's paired method+wrap frames (wrap pushed second, so it
-        // wins the innermost check first) still hand off to the SAME paired
-        // method frame once the wrap chain is exhausted.
-        if (innermost == Some(DispatchFrameKind::Method) || wrap_chain_exhausted)
-            && !self.method_dispatch_stack.is_empty()
-        {
+        // Try method dispatch stack — only when it is genuinely the innermost context.
+        if innermost == Some(DispatchFrameKind::Method) && !self.method_dispatch_stack.is_empty() {
             let frame_idx = self.method_dispatch_stack.len() - 1;
             let is_override = override_args.is_some();
-            // If the next MRO candidate carries a method-level wrap chain, route the
-            // call through its wrappers so a `nextsame` reaching a wrapped parent
-            // method runs ...->wrapper->original->... in order (S06-advanced/wrap.t
-            // GH#2178). The initial dispatch (class_dispatch.rs) applies wraps only
-            // to the first method called; without this, a wrapper added to a parent
-            // method via `^find_method(...).wrap(...)` is skipped on `nextsame`.
-            //
-            // The candidate is NOT removed here: only the wrappers are pushed onto
-            // the wrap-dispatch stack. When the wrappers' `nextsame` chain is
-            // exhausted (sub_id == 0) it falls through to this same method frame,
-            // and the `!is_inside_wrap_dispatch()` guard is then true — so the
-            // original candidate body runs once via the normal path below and its
-            // own `nextsame` continues the rest of the MRO.
-            if !is_override && !self.is_inside_wrap_dispatch() {
-                let peeked = self.method_dispatch_stack[frame_idx]
+            // ADR-0019 E9b-2 decision 3: lazy mid-MRO wrap splice. When the
+            // front entry is an un-spliced Candidate that itself carries a
+            // method-level wrap chain (e.g. `^find_method(...).wrap(...)` on
+            // a PARENT method, reached via nextsame/callsame), splice
+            // `[Wrapper(chain, outermost included)..., Candidate{
+            // wraps_spliced: true}]` in its place so the match below advances
+            // into the first Wrapper. Replaces the old mid-MRO
+            // peek-and-intercept block entirely (no separate
+            // WrapDispatchFrame, no re-entry dance) — S06-advanced/wrap.t
+            // GH#2178.
+            loop {
+                let is_unspliced_candidate = matches!(
+                    self.method_dispatch_stack[frame_idx].remaining.first(),
+                    Some(DeferralEntry::Candidate {
+                        wraps_spliced: false,
+                        ..
+                    })
+                );
+                if !is_unspliced_candidate || is_override || !self.has_any_wrap_chains() {
+                    break;
+                }
+                let method_name_now = self
+                    .samewith_context_stack
+                    .last()
+                    .map(|(n, _)| n.clone())
+                    .unwrap_or_default();
+                if method_name_now.is_empty() {
+                    break;
+                }
+                let Some(DeferralEntry::Candidate { owner, def, .. }) = self.method_dispatch_stack
+                    [frame_idx]
                     .remaining
                     .first()
-                    .cloned();
-                // ADR-0019 E9b-1: no builder emits `Wrapper` yet, so every
-                // peeked entry is a Candidate (E9b-2 adds the Wrapper leg).
-                if let Some(DeferralEntry::Candidate {
-                    owner: owner_sym,
-                    def: method_def,
-                    ..
-                }) = peeked
-                {
-                    let owner_class = owner_sym.resolve();
-                    let method_name_now = self
-                        .samewith_context_stack
-                        .last()
-                        .map(|(n, _)| n.clone())
-                        .unwrap_or_default();
-                    if !method_name_now.is_empty()
-                        && self.has_any_wrap_chains()
-                        && let Some(cand_idx) = self.find_method_candidate_index(
-                            &owner_class,
-                            &method_name_now,
-                            &method_def,
-                        )
-                        && let Some(chain) = self
-                            .get_method_wrap_chain(&owner_class, &method_name_now, cand_idx)
-                            .cloned()
-                    {
-                        let invocant = self.env.get("self").cloned().unwrap_or_else(|| {
-                            self.method_dispatch_stack[frame_idx].invocant.clone()
-                        });
-                        // The wrap dispatch expects the invocant at position 0; the
-                        // method frame's stored args do not include it.
-                        let mut wrap_call_args = vec![invocant];
-                        wrap_call_args.extend(self.method_dispatch_stack[frame_idx].args.clone());
-                        let outermost = chain.last().unwrap().1.clone();
-                        let mut wrap_remaining: Vec<Value> = Vec::new();
-                        for i in (0..chain.len() - 1).rev() {
-                            wrap_remaining.push(chain[i].1.clone());
-                        }
-                        let frame = WrapDispatchFrame {
-                            sub_id: 0,
-                            remaining: wrap_remaining,
-                            args: wrap_call_args.clone(),
-                            arg_sources: self.pending_call_arg_sources().cloned(),
-                            dispatch_token: 0,
-                        };
-                        self.push_wrap_dispatch_frame(frame);
-                        self.shift_arg_sources_for_wrap_invocant();
-                        let result = self.call_sub_value(outermost, wrap_call_args, false);
-                        self.wrap_dispatch_stack.pop();
-                        let result = result?;
-                        if tail_call {
-                            return Err(RuntimeError {
-                                return_value: Some(result),
-                                ..RuntimeError::new("")
-                            });
-                        }
-                        return Ok(result);
-                    }
+                    .cloned()
+                else {
+                    break;
+                };
+                let owner_class = owner.resolve();
+                let Some(cand_idx) =
+                    self.find_method_candidate_index(&owner_class, &method_name_now, &def)
+                else {
+                    break;
+                };
+                let Some(chain) = self
+                    .get_method_wrap_chain(&owner_class, &method_name_now, cand_idx)
+                    .cloned()
+                else {
+                    break;
+                };
+                // Unlike the winner's own prefix (built once at frame
+                // construction, outermost invoked directly), nobody invokes
+                // the outermost directly here — the WHOLE chain becomes
+                // Wrapper entries, followed by the spliced candidate.
+                let mut splice: Vec<DeferralEntry> = Vec::with_capacity(chain.len() + 1);
+                for i in (0..chain.len()).rev() {
+                    splice.push(DeferralEntry::Wrapper(chain[i].1.clone()));
                 }
+                splice.push(DeferralEntry::Candidate {
+                    owner,
+                    def,
+                    wraps_spliced: true,
+                });
+                self.method_dispatch_stack[frame_idx]
+                    .remaining
+                    .splice(0..1, splice);
+                // Loop back: the front entry is now Wrapper(outermost).
             }
-            let (receiver_class, invocant, mut call_args, owner_class, mut method_def, rw_params) = {
-                let frame = &mut self.method_dispatch_stack[frame_idx];
-                let Some(entry) = frame.remaining.first().cloned() else {
+            match self.method_dispatch_stack[frame_idx]
+                .remaining
+                .first()
+                .cloned()
+            {
+                None => {
                     // User MRO exhausted: a grammar `parse`/`subparse` override, an
                     // `is Array` subclass's Positional override, or a metamodel-HOW
                     // dispatch falls through to the native implementation as the
-                    // last candidate before giving up.
+                    // last candidate before giving up. ADR-0019 E9b-2: a wrapped
+                    // method now always has a frame, so "frame exists, remaining
+                    // empty" is the single exhaustion signal (the #6349
+                    // `wrap_chain_exhausted` bool is retired).
                     let result = if let Some(res) =
                         self.native_grammar_parse_next_candidate(override_args.as_deref())
                     {
@@ -636,37 +594,152 @@ impl Interpreter {
                         });
                     }
                     return Ok(result);
-                };
-                // ADR-0019 E9b-1: no builder emits `Wrapper` yet, so every
-                // entry here is a Candidate (E9b-2 adds the Wrapper leg).
+                }
+                Some(DeferralEntry::Wrapper(code)) => {
+                    // ADR-0019 E9b-2: advance leg for a wrap-prefix entry —
+                    // invoke it with [invocant, ...args] and the (shifted)
+                    // wrap-captured call-site arg sources, mirroring today's
+                    // (now sub-only) WrapDispatchFrame wrapper leg.
+                    self.method_dispatch_stack[frame_idx].remaining.remove(0);
+                    let caller_in_wrapper = self.method_dispatch_stack[frame_idx].in_wrapper;
+                    if let Some(new_args) = override_args {
+                        // `callwith`'s args are invocant-INCLUSIVE (element 0
+                        // is the new SELF) exactly when the CALLER is itself
+                        // a wrapper block — a wrapper's own positional
+                        // signature is `(invocant, ...args)`. A candidate
+                        // body landing here via a freshly mid-MRO-spliced
+                        // wrap chain (decision 3) is NOT a wrapper, so its
+                        // override args stay invocant-exclusive
+                        // (S06-advanced/dispatching.t "Args to callwith in
+                        // wrapper/multi are used by enclosing ...").
+                        let frame = &mut self.method_dispatch_stack[frame_idx];
+                        if caller_in_wrapper {
+                            let mut it = new_args.into_iter();
+                            if let Some(inv) = it.next() {
+                                frame.invocant = inv;
+                            }
+                            frame.args = it.collect();
+                        } else {
+                            frame.args = new_args;
+                        }
+                    }
+                    let frame = &mut self.method_dispatch_stack[frame_idx];
+                    // ADR-0019 E9b-2: unlike the plain-Candidate advance leg
+                    // below, this call runs from INSIDE a wrapper block's own
+                    // execution, not from a method body — `self.env`'s "self"
+                    // binding at this point (if any) is leftover from the
+                    // wrapper closure's LEXICAL capture (e.g. OO::Monitors'
+                    // wrapper closes over `add_method`'s own `self`, the HOW
+                    // instance), not the true invocant. `frame.invocant` is
+                    // the correct, stable value captured at frame-push time
+                    // (and kept live via the shared attribute cell — no
+                    // snapshot to go stale), mirroring how the pre-E9b-2
+                    // `WrapDispatchFrame.args[0]` was used unconditionally,
+                    // with no env lookup, for every wrap-stack advance.
+                    frame.in_wrapper = true;
+                    let current_invocant = frame.invocant.clone();
+                    let mut call_args = vec![current_invocant];
+                    call_args.extend(frame.args.clone());
+                    let frame_arg_sources = frame.arg_sources.clone();
+                    let restore_sources = !is_override && frame_arg_sources.is_some();
+                    if restore_sources {
+                        self.set_pending_call_arg_sources(frame_arg_sources);
+                        self.shift_arg_sources_for_wrap_invocant();
+                    }
+                    if let ValueView::Sub(data) = code.view() {
+                        self.wrap_skip_once = Some(data.id);
+                    }
+                    let result = self.call_sub_value(code, call_args, false)?;
+                    if tail_call {
+                        return Err(RuntimeError {
+                            return_value: Some(result),
+                            ..RuntimeError::new("")
+                        });
+                    }
+                    return Ok(result);
+                }
+                Some(DeferralEntry::Candidate { .. }) => {}
+            }
+            let (
+                receiver_class,
+                invocant,
+                mut call_args,
+                owner_class,
+                mut method_def,
+                rw_params,
+                came_from_wrapper,
+                frame_wrap_arg_sources,
+            ) = {
+                let frame = &mut self.method_dispatch_stack[frame_idx];
+                let entry = frame.remaining.first().cloned().expect(
+                    "ADR-0019 E9b-2: the match above only falls through here for a Candidate",
+                );
                 let DeferralEntry::Candidate {
                     owner: owner_sym,
                     def: method_def,
                     ..
                 } = entry
                 else {
-                    unreachable!("ADR-0019 E9b-1: no builder emits DeferralEntry::Wrapper yet")
+                    unreachable!(
+                        "ADR-0019 E9b-2: the match above only falls through here for a Candidate"
+                    )
                 };
                 let owner_class = owner_sym.resolve();
                 let method_def = *method_def;
                 frame.remaining.remove(0);
                 let rw_params = frame.rw_params.clone();
-                let call_args = if let Some(new_args) = override_args {
-                    // Update the frame's args so subsequent callsame uses the new args
-                    frame.args = new_args.clone();
-                    new_args
-                } else {
-                    frame.args.clone()
-                };
+                let frame_wrap_arg_sources = frame.arg_sources.clone();
+                // ADR-0019 E9b-2: whether the code CURRENTLY executing (the
+                // thing whose callsame/callwith call reached this Candidate)
+                // is a wrapper block rather than a real method body — reached
+                // either directly from the caller's single outermost wrapper
+                // (chain.len() == 1, so no `Wrapper` entry ever ran), from
+                // the `Wrapper` advance leg above, or NOT at all when a plain
+                // candidate's own nextsame/nextwith lands here in the
+                // ordinary (non-wrap) MRO tail.
+                let came_from_wrapper = frame.in_wrapper;
                 // Use the current `self` from the environment instead of the stale
                 // frame invocant.  The method body may have mutated attributes
                 // (e.g. `$.tracker ~= "bar,"`) before calling callsame/callwith,
                 // so the frame's snapshot is outdated.
-                let current_invocant = self
-                    .env
-                    .get("self")
-                    .cloned()
-                    .unwrap_or_else(|| frame.invocant.clone());
+                //
+                // ADR-0019 E9b-2 exception: when `came_from_wrapper`, the
+                // CURRENT execution context is a wrapper BLOCK, not this
+                // candidate's own method body, so `self.env`'s "self"
+                // binding (if any) is leftover from the wrapper closure's
+                // lexical capture (e.g. OO::Monitors' wrapper closes over
+                // `add_method`'s own `self`, the HOW instance), not the true
+                // invocant — using it here dispatched `bump()` against the
+                // HOW and died "no such attribute '$!n'". `frame.invocant`
+                // is the correct, stable value (kept live via the shared
+                // attribute cell, so there is no staleness to guard against
+                // on this leg).
+                let base_invocant = if came_from_wrapper {
+                    frame.invocant.clone()
+                } else {
+                    self.env
+                        .get("self")
+                        .cloned()
+                        .unwrap_or_else(|| frame.invocant.clone())
+                };
+                // `callwith`'s args are invocant-INCLUSIVE (element 0 is the
+                // new SELF) exactly when the caller is a wrapper block —
+                // mirrors the `Wrapper` advance leg's own split above
+                // (S06-advanced/dispatching.t "Args to callwith in
+                // wrapper/multi are used by enclosing multi and method
+                // dispatch").
+                let (current_invocant, call_args) = match override_args {
+                    Some(new_args) if came_from_wrapper => {
+                        let mut it = new_args.into_iter();
+                        let inv = it.next().unwrap_or_else(|| base_invocant.clone());
+                        (inv, it.collect::<Vec<_>>())
+                    }
+                    Some(new_args) => (base_invocant, new_args),
+                    None => (base_invocant, frame.args.clone()),
+                };
+                frame.args = call_args.clone();
+                frame.invocant = current_invocant.clone();
+                frame.in_wrapper = false;
                 (
                     frame.receiver_class.clone(),
                     current_invocant,
@@ -674,6 +747,8 @@ impl Interpreter {
                     owner_class,
                     method_def,
                     rw_params,
+                    came_from_wrapper,
+                    frame_wrap_arg_sources,
                 )
             };
             // §B: compile the next MRO candidate on-demand if it has no compiled code
@@ -685,30 +760,47 @@ impl Interpreter {
                 let dist = self.resolve_package_distribution(&owner_class);
                 Self::compile_method_def_in_place_with_dist(&mut method_def, &owner_class, dist);
             }
-            // nextsame/callsame+rw chaining for methods (§D capstone): the stored
-            // method args are plain values (no varref), so without an arg source the
-            // next candidate's `is rw` param dies with X::Parameter::RW. Forward the
-            // first candidate's CURRENT rw value and name the FIRST candidate's param
-            // as the source, so the next candidate writes back into it (env-only, all
-            // method candidates run via the interpreter) and the first candidate's own
-            // exit writeback then propagates the chained result to the caller.
-            let mut rw_sources: Vec<Option<String>> = Vec::new();
+            // ADR-0019 E9b-2: a candidate freshly reached right after a
+            // Wrapper group (the former by-name "original" re-entry, or a
+            // lazily mid-MRO-spliced wrapped parent) restores the wrap's TRUE
+            // outer call-site arg sources directly, instead of the rw_params
+            // synthetic self-referential handoff name below — an `is rw`
+            // parameter must still write back to the CALLER's variable, not a
+            // synthetic name (`t/wrap-invocant-arg-source.t` test E). When the
+            // frame carries no wrap arg sources (an ordinary non-wrap
+            // nextsame/callsame chain, or a mid-MRO wrap whose winner wasn't
+            // itself wrapped), fall back to the pre-existing rw_params
+            // chain-forwarding dance unchanged.
+            let use_wrap_sources =
+                came_from_wrapper && frame_wrap_arg_sources.is_some() && !is_override;
             let mut have_rw_source = false;
-            if !rw_params.is_empty() && !is_override {
-                rw_sources = vec![None; call_args.len()];
-                for (pos, first_param) in &rw_params {
-                    if *pos >= call_args.len() {
-                        continue;
+            if use_wrap_sources {
+                self.set_pending_call_arg_sources(frame_wrap_arg_sources);
+            } else {
+                // nextsame/callsame+rw chaining for methods (§D capstone): the stored
+                // method args are plain values (no varref), so without an arg source the
+                // next candidate's `is rw` param dies with X::Parameter::RW. Forward the
+                // first candidate's CURRENT rw value and name the FIRST candidate's param
+                // as the source, so the next candidate writes back into it (env-only, all
+                // method candidates run via the interpreter) and the first candidate's own
+                // exit writeback then propagates the chained result to the caller.
+                let mut rw_sources: Vec<Option<String>> = Vec::new();
+                if !rw_params.is_empty() && !is_override {
+                    rw_sources = vec![None; call_args.len()];
+                    for (pos, first_param) in &rw_params {
+                        if *pos >= call_args.len() {
+                            continue;
+                        }
+                        if let Some(cur) = self.first_candidate_rw_value(first_param) {
+                            call_args[*pos] = crate::runtime::types::unwrap_varref_value(cur);
+                        }
+                        rw_sources[*pos] = Some(first_param.clone());
+                        have_rw_source = true;
                     }
-                    if let Some(cur) = self.first_candidate_rw_value(first_param) {
-                        call_args[*pos] = crate::runtime::types::unwrap_varref_value(cur);
-                    }
-                    rw_sources[*pos] = Some(first_param.clone());
-                    have_rw_source = true;
                 }
-            }
-            if have_rw_source {
-                self.set_pending_call_arg_sources(Some(rw_sources));
+                if have_rw_source {
+                    self.set_pending_call_arg_sources(Some(rw_sources));
+                }
             }
             // The first method candidate runs as compiled bytecode (VM slots), so
             // its exit flush reads its rw-param slot. Capture its frame code now to
@@ -813,14 +905,19 @@ impl Interpreter {
                     }
                 }
             };
-            if have_rw_source {
+            if use_wrap_sources || have_rw_source {
                 self.set_pending_call_arg_sources(None);
             }
             let (result, updated_invocant) = dispatch_result?;
             // Write the chain's final value (now in env under each first-candidate
             // param name) back into the first (compiled) candidate's VM local slot
             // so its exit flush propagates it instead of its own pre-nextsame value.
-            if caller_code != 0 && have_rw_source {
+            // ADR-0019 E9b-2: skipped for `use_wrap_sources` — that path
+            // mirrors the deleted by-name "original" re-entry, which never
+            // ran this rw_params-specific chain-forwarding dance either (the
+            // wrap's own arg_sources already routed the writeback through the
+            // TRUE call-site variable name, not a synthetic per-candidate one).
+            if !use_wrap_sources && caller_code != 0 && have_rw_source {
                 // SAFETY: caller_code is the address of the CompiledCode of the
                 // first (compiled) method candidate, the live ancestor frame
                 // currently executing this nextsame/callsame.
@@ -1049,7 +1146,10 @@ impl Interpreter {
         // If we're inside a method but there's simply no next candidate in the MRO,
         // return Nil (this is the Raku behavior for callsame/callwith at the end of
         // the MRO).  Plain subs without multi dispatch should still throw.
-        if !self.method_class_stack.is_empty() || wrap_chain_exhausted {
+        // ADR-0019 E9b-2: the `wrap_chain_exhausted` bool (#6349) is retired — a
+        // wrapped method now always has a `method_dispatch_stack` frame, so its
+        // exhaustion is already handled by the Method branch above.
+        if !self.method_class_stack.is_empty() {
             if tail_call {
                 return Err(RuntimeError {
                     return_value: Some(Value::NIL),

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -274,60 +274,6 @@ impl Interpreter {
                 &sigs,
             ));
         }
-        // Helper to build remaining candidates, skipping the chosen one.
-        // Submethod prefilter: a submethod is never inherited, so when the
-        // visible-candidate table holds at most one entry the remaining list is
-        // empty by construction — skip the full `resolve_all_methods_with_owner`
-        // pass (per-MRO-class overload-Vec clones + signature matching +
-        // fingerprints) that every construction-phase BUILD/TWEAK dispatch
-        // otherwise pays just to learn "nothing to defer to".
-        let skip_remaining = (method_def.is_my || method_def.is_submethod)
-            && self.count_visible_method_candidates(receiver_class_name, method_name) <= 1;
-        let build_remaining = |this: &mut Self, method_def: &MethodDef| -> Vec<DeferralEntry> {
-            if skip_remaining {
-                return Vec::new();
-            }
-            // ADR-0019 E9a: the flat deferral expansion (`resolution_deferral.rs`) replaces
-            // `resolve_all_methods_with_owner` as the ordering source — see its module doc.
-            // The expansion is structural (unfiltered); apply the same per-call, invocant-blind
-            // argument match `resolve_all_methods_with_owner` used to apply internally.
-            let role_bindings = this.registry().get_role_param_bindings(receiver_class_name);
-            let expansion = this.resolve_deferral_expansion(receiver_class_name, method_name);
-            let mut all: Vec<(Symbol, MethodDef)> = Vec::new();
-            for (owner, def) in expansion {
-                if this.method_args_match_for_invocant(
-                    receiver_class_name,
-                    &def,
-                    &args,
-                    role_bindings.as_ref(),
-                    None,
-                ) {
-                    all.push((owner, def));
-                }
-            }
-            let chosen_fp = this.method_def_fingerprint(method_def);
-            let mut remaining = Vec::new();
-            let mut skipped = false;
-            for (owner, def) in all {
-                let fp = this.method_def_fingerprint(&def);
-                if !skipped && fp == chosen_fp {
-                    skipped = true;
-                    continue;
-                }
-                if this.should_skip_defer_method_candidate(receiver_class_name, owner.as_str()) {
-                    continue;
-                }
-                // ADR-0019 E9b-1: every entry is a plain Candidate here — this
-                // builder never wraps a method's own chain into the frame
-                // (that is E9b-2).
-                remaining.push(DeferralEntry::Candidate {
-                    owner,
-                    def: Box::new(def),
-                    wraps_spliced: false,
-                });
-            }
-            remaining
-        };
         let make_invocant_for_dispatch =
             |invocant: &Option<Value>, attributes: &AttrMap| -> Value {
                 if let Some(inv) = invocant {
@@ -343,8 +289,17 @@ impl Interpreter {
         // instance call (e.g. every bless/TWEAK) pays a candidate-index scan
         // even though no `.wrap` exists in the whole program (mirrors the
         // compiled path's guard in vm_call_method_compiled.rs).
+        //
+        // ADR-0019 E9b-2: a SINGLE `MethodDispatchFrame` carries the
+        // below-outermost wrappers, the winner (as an ordinary resolved
+        // `Candidate`), and the MRO tail — replacing the separate
+        // `WrapDispatchFrame` + by-name "original" re-entry. This is the P1
+        // fix (`todo/tickets/wrap-chain-skipped-inside-foreign-wrap-dispatch.md`):
+        // no `is_inside_wrap_dispatch()` guard is needed anymore, since the
+        // "original" is never re-entered by name — a nested call to a
+        // DIFFERENT wrapped method now enters its own chain like any fresh
+        // dispatch.
         if self.has_any_wrap_chains()
-            && !self.is_inside_wrap_dispatch()
             && let Some(cand_idx) =
                 self.find_method_candidate_index(owner_class.as_str(), method_name, &method_def)
             && let Some(chain) = self
@@ -352,64 +307,31 @@ impl Interpreter {
                 .cloned()
         {
             let invocant_for_dispatch = make_invocant_for_dispatch(&invocant, attributes);
-            let remaining = build_remaining(self, &method_def);
-            let pushed_dispatch = !remaining.is_empty();
             self.push_method_samewith_context(
                 receiver_class_name,
                 method_name,
                 &args,
                 Some(invocant_for_dispatch.clone()),
             );
-            if pushed_dispatch {
-                let rw_params = super::builtins_dispatch_next::rw_scalar_positional_params(
-                    &method_def.param_defs,
-                );
-                let dispatch_token = self.next_dispatch_token();
-                self.method_dispatch_stack.push(MethodDispatchFrame {
-                    receiver_class: receiver_class_name.to_string(),
-                    invocant: invocant_for_dispatch,
-                    args: args.clone(),
-                    remaining,
-                    rw_params,
-                    dispatch_token,
-                    arg_sources: None,
-                });
-            }
-            let mut orig_env = crate::env::Env::new();
-            orig_env.insert("__mutsu_method_wrap_original".to_string(), Value::TRUE);
-            let original_sub = Value::make_sub(
+            self.push_wrapped_method_dispatch_frame(
+                receiver_class_name,
+                method_name,
+                &args,
+                invocant_for_dispatch,
                 owner_class,
-                Symbol::intern(method_name),
-                method_def.params.clone(),
-                method_def.param_defs.clone(),
-                (*method_def.body).clone(),
-                method_def.is_rw,
-                orig_env,
+                &method_def,
+                &chain,
             );
             let outermost = chain.last().unwrap().1.clone();
-            let mut wrap_remaining: Vec<Value> = Vec::new();
-            for i in (0..chain.len() - 1).rev() {
-                wrap_remaining.push(chain[i].1.clone());
-            }
-            wrap_remaining.push(original_sub);
             let mut call_args = vec![inv_value.clone()];
             call_args.extend(args);
-            let frame = WrapDispatchFrame {
-                sub_id: 0,
-                remaining: wrap_remaining,
-                args: call_args.clone(),
-                arg_sources: self.pending_call_arg_sources().cloned(),
-                dispatch_token: 0,
-            };
             let wrapper_id = if let ValueView::Sub(wd) = outermost.view() {
                 Some(wd.id)
             } else {
                 None
             };
-            self.push_wrap_dispatch_frame(frame);
             self.shift_arg_sources_for_wrap_invocant();
             let result = self.call_sub_value(outermost, call_args, false);
-            self.wrap_dispatch_stack.pop();
             // Propagate closure variable mutations from the wrapper back to
             // the current env so captured variables are visible to the caller.
             if let Some(wid) = wrapper_id
@@ -422,15 +344,14 @@ impl Interpreter {
                 }
             }
             self.pop_method_samewith_context();
-            if pushed_dispatch {
-                self.method_dispatch_stack.pop();
-            }
+            self.method_dispatch_stack.pop();
             // The wrapped call mutated attributes (if any) through the live
             // cell; there is no `:=` reconcile on this path.
             return result.map(|v| (v, None));
         }
         let invocant_for_dispatch = make_invocant_for_dispatch(&invocant, attributes);
-        let remaining = build_remaining(self, &method_def);
+        let remaining =
+            self.deferral_tail_entries(receiver_class_name, method_name, &args, &method_def);
         // A user-overridden grammar `parse`/`subparse`/`parsefile` still needs an MRO
         // frame even with no further USER candidate, so a `nextsame`/`nextwith` inside
         // it can defer to the NATIVE grammar parse — the base candidate that is not a
@@ -458,6 +379,7 @@ impl Interpreter {
                 rw_params,
                 dispatch_token,
                 arg_sources: None,
+                in_wrapper: false,
             });
         }
         // Check for `is DEPRECATED` trait on the method

--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -164,16 +164,17 @@ pub(crate) type MultiDispatchEntry = (
     u64,
 );
 
-/// One entry of `MethodDispatchFrame::remaining` (ADR-0019 E9b-1). A
-/// `Candidate` is the pre-E9b-1 `(owner, MethodDef)` shape unchanged in
-/// substance; `Wrapper` lets a method's own `.wrap()` chain fold into the same
-/// `remaining` list as prefix entries instead of a separate stack (E9b-2 —
-/// no builder emits `Wrapper` yet in this slice, so it is currently inert).
+/// One entry of `MethodDispatchFrame::remaining` (ADR-0019 E9b-1/E9b-2). A
+/// `Candidate` is invoked directly as a resolved method; `Wrapper` lets a
+/// method's own `.wrap()` chain fold into the same `remaining` list as prefix
+/// entries instead of a separate `WrapDispatchFrame` — both variants are
+/// built and consumed as of E9b-2 (`class_dispatch.rs`,
+/// `vm_call_method_compiled.rs`'s wrap entry sites; the lazy mid-MRO splice
+/// and advance legs in `builtins_dispatch_next.rs`).
 #[derive(Debug, Clone)]
 pub(crate) enum DeferralEntry {
     /// A wrapper code object; invoked with `[invocant, args...]` and shifted
     /// arg sources, mirroring today's `WrapDispatchFrame` wrapper leg.
-    #[allow(dead_code)]
     Wrapper(Value),
     /// A user method candidate; invoked directly as a resolved method (the
     /// existing method-frame advance leg, unchanged in substance).
@@ -183,7 +184,13 @@ pub(crate) enum DeferralEntry {
         // DeferralEntry (including the small Wrapper(Value) variant) pay that
         // size (clippy::large_enum_variant).
         def: Box<MethodDef>,
-        #[allow(dead_code)]
+        /// Whether this entry's own method-level wrap chain (if any) has
+        /// already been spliced into `remaining` as `Wrapper` prefix entries
+        /// — `true` for the winner's own entry (built at frame-construction
+        /// time by the two wrap entry sites) and for a mid-MRO candidate
+        /// after the lazy splice (`dispatch_next_candidate`); `false` for
+        /// every other MRO-tail candidate, whose wrap chain (if any) is only
+        /// checked when advancement actually reaches it.
         wraps_spliced: bool,
     },
 }
@@ -203,26 +210,51 @@ pub(crate) struct MethodDispatchFrame {
     /// `MultiDispatchEntry`. callsame/nextsame/lastcall/nextcallee compare tokens
     /// across all three deferral stacks and pick the highest (innermost) live frame.
     pub(crate) dispatch_token: u64,
-    /// ADR-0019 E9b-1: call-site source variable names for the wrapped
-    /// method's arguments, mirroring `WrapDispatchFrame::arg_sources`. Unused
-    /// until E9b-2's `Wrapper` advance leg restores them for an `is rw`
-    /// parameter of the next callee; every E9b-1 builder sets this to `None`.
-    #[allow(dead_code)]
+    /// ADR-0019 E9b-1/E9b-2: call-site source variable names for a wrapped
+    /// method's arguments, mirroring `WrapDispatchFrame::arg_sources`.
+    /// `Some` only when this frame was built at a method-wrap entry site
+    /// (`class_dispatch.rs`, `vm_call_method_compiled.rs`); every other
+    /// builder sets `None`. Restored (and shifted for a `Wrapper` leg's
+    /// `[invocant, ...args]` call shape) so an `is rw`/sigilless parameter
+    /// anywhere in the wrap chain — including the wrapped original method
+    /// itself — still binds to the TRUE call-site variable
+    /// (`t/wrap-invocant-arg-source.t`).
     pub(crate) arg_sources: Option<Vec<Option<String>>>,
+    /// ADR-0019 E9b-2: whether the code CURRENTLY executing under this frame
+    /// (the thing whose `callsame`/`callwith` call is about to run through
+    /// `dispatch_next_candidate`) is a `.wrap()` wrapper BLOCK rather than a
+    /// real method body. A wrapper's own positional signature is
+    /// `(invocant, ...args)` (its first param is bound to SELF), so
+    /// `callwith`/`nextwith`'s override args, when called from inside a
+    /// wrapper, include the invocant as element 0 — the same convention the
+    /// pre-E9b-2 `WrapDispatchFrame.args` used unconditionally. A real
+    /// method's signature never includes the invocant positionally, so
+    /// override args from a method body are invocant-EXCLUSIVE. Only
+    /// `push_wrapped_method_dispatch_frame` starts this `true` (the caller
+    /// always invokes the outermost wrapper directly); every other builder
+    /// leaves it `false` since none of them ever enter wrapper code. Updated
+    /// by `dispatch_next_candidate` immediately before each advance so a
+    /// NESTED `callwith` call reads the context it is actually running in.
+    pub(crate) in_wrapper: bool,
 }
 
-/// Frame for navigating through wrapper chain during callsame/callwith.
+/// Frame for navigating through a SUB wrapper chain during callsame/callwith.
+///
+/// ADR-0019 E9b-2: method wraps no longer use this frame — they fold into
+/// `MethodDispatchFrame::remaining` as `DeferralEntry::Wrapper` prefix
+/// entries instead, so `sub_id` is now always a real (non-zero) sub id. The
+/// push helper (`Interpreter::push_wrap_dispatch_frame`) asserts this.
 #[derive(Debug, Clone)]
 pub(crate) struct WrapDispatchFrame {
     /// The sub id being wrapped (to prevent re-entrant wrap dispatch).
+    /// Always non-zero as of E9b-2 (see the struct doc comment).
     pub(crate) sub_id: u64,
     /// Remaining callables: inner wrappers then original sub. Next to call is first.
     pub(crate) remaining: Vec<Value>,
     /// Original call arguments.
     pub(crate) args: Vec<Value>,
-    /// Call-site source variable names for the *wrapped routine's* arguments
-    /// (for a method wrap: excluding the invocant, which `args` carries at
-    /// index 0). The outermost wrapper consumes the pending arg sources when
+    /// Call-site source variable names for the wrapped sub's arguments.
+    /// The outermost wrapper consumes the pending arg sources when
     /// its own signature binds, so `callsame` reaching the original would
     /// otherwise see none and reject an `is rw` parameter.
     pub(crate) arg_sources: Option<Vec<Option<String>>>,

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -224,6 +224,7 @@ impl Interpreter {
                         rw_params,
                         dispatch_token,
                         arg_sources: None,
+                        in_wrapper: false,
                     });
                 }
                 let method_result = self.run_resolved_method_compiled_or_treewalk(

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -265,7 +265,7 @@ impl Interpreter {
                 };
                 self.push_wrap_dispatch_frame(frame);
                 let result = self.call_sub_value(outermost, sanitized_args, false);
-                self.wrap_dispatch_stack.pop();
+                self.pop_wrap_dispatch_frame();
                 // Propagate closure variable mutations from the wrapper back to
                 // the current env so captured variables (e.g. $seen = True) are
                 // visible to the caller. Only write back keys the wrapper actually

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -270,6 +270,15 @@ impl Interpreter {
 
     /// Check if a method candidate has a wrap chain from ^lookup().candidates[N].wrap().
     /// If so, dispatch through the wrapper and return Some(result).
+    ///
+    /// ADR-0019 E9b-2: builds a SINGLE `MethodDispatchFrame` (below-outermost
+    /// wrappers, the winner as an ordinary resolved `Candidate`, then the MRO
+    /// tail) instead of a separate `WrapDispatchFrame` + by-name "original"
+    /// re-entry — the P1 fix
+    /// (`todo/tickets/wrap-chain-skipped-inside-foreign-wrap-dispatch.md`):
+    /// no `is_inside_wrap_dispatch()` guard is needed anymore, since the
+    /// "original" is never re-entered by name. Mirrors
+    /// `class_dispatch.rs`'s `run_instance_method_celled` wrap branch.
     pub(crate) fn check_method_wrap_chain(
         &mut self,
         cn: &str,
@@ -279,7 +288,7 @@ impl Interpreter {
         target: &Value,
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
-        if !self.has_any_wrap_chains() || self.is_inside_wrap_dispatch() {
+        if !self.has_any_wrap_chains() {
             return None;
         }
         let cand_idx = self.find_method_candidate_index(owner_class, method, method_def)?;
@@ -287,36 +296,19 @@ impl Interpreter {
             .get_method_wrap_chain(owner_class, method, cand_idx)?
             .clone();
         let invocant_for_dispatch = target.clone();
-        let pushed_dispatch = loan_env!(
-            self,
-            push_method_dispatch_frame(cn, method, args, invocant_for_dispatch)
-        );
-        let mut orig_env = crate::env::Env::new();
-        orig_env.insert("__mutsu_method_wrap_original".to_string(), Value::TRUE);
-        let original_sub = Value::make_sub(
+        self.push_method_samewith_context(cn, method, args, Some(invocant_for_dispatch.clone()));
+        self.push_wrapped_method_dispatch_frame(
+            cn,
+            method,
+            args,
+            invocant_for_dispatch,
             crate::symbol::Symbol::intern(owner_class),
-            crate::symbol::Symbol::intern(method),
-            method_def.params.clone(),
-            method_def.param_defs.clone(),
-            (*method_def.body).clone(),
-            method_def.is_rw,
-            orig_env,
+            method_def,
+            &chain,
         );
         let outermost = chain.last().unwrap().1.clone();
-        let mut remaining: Vec<Value> = Vec::new();
-        for i in (0..chain.len() - 1).rev() {
-            remaining.push(chain[i].1.clone());
-        }
-        remaining.push(original_sub);
         let mut call_args = vec![target.clone()];
         call_args.extend(args.to_vec());
-        let frame = crate::runtime::WrapDispatchFrame {
-            sub_id: 0,
-            remaining,
-            args: call_args.clone(),
-            arg_sources: self.pending_call_arg_sources().cloned(),
-            dispatch_token: 0,
-        };
         let wrapper_id = if let ValueView::Sub(wd) = outermost.view() {
             Some(wd.id)
         } else {
@@ -339,10 +331,8 @@ impl Interpreter {
                     _ => None,
                 })
         });
-        self.push_wrap_dispatch_frame(frame);
         self.shift_arg_sources_for_wrap_invocant();
         let result = self.vm_call_sub_value(outermost, call_args, false);
-        self.pop_wrap_dispatch_frame();
         // Propagate closure variable mutations from the wrapper back to the
         // current env so captured variables are visible to the caller.
         if let Some(wid) = wrapper_id
@@ -396,9 +386,7 @@ impl Interpreter {
                 }
             }
         }
-        if pushed_dispatch {
-            self.pop_method_dispatch();
-        }
+        self.pop_method_dispatch();
         self.pop_method_samewith_context();
         Some(result)
     }

--- a/t/wrap-chain-foreign-wrapper-not-shadowed.t
+++ b/t/wrap-chain-foreign-wrapper-not-shadowed.t
@@ -1,0 +1,19 @@
+use Test;
+
+plan 1;
+
+# ADR-0019 E9b-2 (P1): a wrapped method called from inside a FOREIGN
+# wrapper's dispatch loses its own wrap chain, because a global
+# `is_inside_wrap_dispatch()` guard suppressed EVERY wrap chain while ANY
+# wrap dispatch was live, not just the one it was meant to protect. Verified
+# against Rakudo v2026.06 (`raku`): the expected output is
+# 'x-wrap[x-orig]+y-wrap[y-orig]' -- both wrap chains fire. Before the E9b-2
+# fix, mutsu printed 'x-wrap[x-orig]+y-orig': B's wrap chain was silently
+# skipped because A's own wrap dispatch was still active on the stack.
+class A { method x() { "x-orig" } }
+class B { method y() { "y-orig" } }
+A.^lookup('x').wrap(-> $self { "x-wrap[" ~ callsame() ~ "]+" ~ B.new.y });
+B.^lookup('y').wrap(-> $self { "y-wrap[" ~ callsame() ~ "]" });
+
+is A.new.x, 'x-wrap[x-orig]+y-wrap[y-orig]',
+    'a wrapped method called from inside a foreign wrapper still enters its own wrap chain';


### PR DESCRIPTION
## Summary

- Cuts over both method-wrap entry sites (interpreter `class_dispatch.rs` and VM `vm_call_method_compiled.rs`) to build a SINGLE `MethodDispatchFrame` whose `remaining` is `[Wrapper(prefix)..., Candidate(winner), ...MRO tail]`, replacing the separate `WrapDispatchFrame` + synthetic `__mutsu_method_wrap_original` by-name re-entry.
- Deletes the `sub_id == 0` method-wrap sentinel and its exhaustion fallthrough, the global `is_inside_wrap_dispatch()` guards, the old mid-MRO peek-and-intercept block (replaced by a lazy splice at advance time), and the #6349 `wrap_chain_exhausted` bool.
- Fixes P1 (`todo/tickets/wrap-chain-skipped-inside-foreign-wrap-dispatch.md`): a wrapped method called from inside a DIFFERENT method's wrapper no longer loses its own wrap chain. Pinned by `t/wrap-chain-foreign-wrapper-not-shadowed.t` (verified against real raku first).
- Fixes two invocant/args-shape bugs found during verification (both regressions this refactor itself introduced, caught before merge):
  - A wrapper block's `self.env` "self" binding is leftover from the wrapper closure's lexical capture (not the true invocant) — broke `OO::Monitors` (`t/scoped-custom-declarator.t`). Fixed by sourcing the invocant from `frame.invocant` whenever the immediately preceding advance came from a wrapper.
  - `callwith`/`nextwith` override args are invocant-inclusive from inside a wrapper block but invocant-exclusive from a real method body. A new per-frame `in_wrapper` flag tracks which convention applies (`roast/S06-advanced/dispatching.t`).

This is ADR-0019 Phase E box E9b's final slice — see `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`'s "E9b design" section for the full design and slice plan (E9b-0 and E9b-1 already merged).

## Test plan

- [x] `t/wrap*.t`, `t/method-wrap-*.t`, `t/lastcall-in-wrapper-callsame-dies.t`, `t/lastcall-then-nextsame.t`, `t/defer-*.t`, `t/nextsame-role-mixin.t` — green
- [x] All OO::Monitors / monitor-declarator `t/` tests — green
- [x] Full local `make test` (3120 files) — green
- [x] Targeted release-build roast slice (`S06-advanced/{callsame,dispatching,wrap}`, `S06-multi/{redispatch,type-based,syntax,proto}`, `S12-methods/{defer-call,defer-next,lastcall,multi,parallel-dispatch}`, `6.c/S12-class/mro-6c`, `S12-class/{inheritance,basic}`, `6.c/S14-roles/mixin-6c`) — green
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check` — clean
- [ ] CI (`make test` + `make roast`) — watching

🤖 Generated with [Claude Code](https://claude.com/claude-code)