### PR TITLE
refactor(dispatch): consolidate samewith context into one SamewithContext stack (ADR-0019 E9c-1)

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -740,9 +740,7 @@ impl Interpreter {
         args: &[Value],
         invocant: Option<Value>,
     ) {
-        self.samewith_context_stack
-            .push((method_name.to_string(), invocant));
-        self.samewith_call_args_stack.push(args.to_vec());
+        self.push_samewith_context(method_name, invocant, Some(args.to_vec()));
         if self.is_metamodel_how_class(receiver_class) {
             self.metamodel_dispatch_stack.push((
                 self.samewith_context_stack.len(),
@@ -1106,8 +1104,7 @@ impl Interpreter {
         {
             self.metamodel_dispatch_stack.pop();
         }
-        self.samewith_context_stack.pop();
-        self.samewith_call_args_stack.pop();
+        self.pop_samewith_context();
     }
 
     /// Push a multi dispatch frame for callsame/nextsame/callwith/nextwith support.
@@ -1193,10 +1190,25 @@ impl Interpreter {
         self.proto_dispatch_stack.last().cloned()
     }
 
-    /// Push a samewith context for a multi sub dispatch.
-    pub(crate) fn push_samewith_context(&mut self, name: &str, invocant: Option<Value>) {
-        self.samewith_context_stack
-            .push((name.to_string(), invocant));
+    /// Push a samewith context (ADR-0019 E9c-1: the single push/pop helper
+    /// pair every call site funnels through, so `samewith_context_stack`'s
+    /// `args` can never desync from `name`/`invocant` the way the former
+    /// separate `samewith_call_args_stack` could). `args` is `None` when the
+    /// caller has no original-args carrier to attach (a plain sub/proto
+    /// samewith context, or a captured `gather`-body re-push) —
+    /// `push_method_samewith_context` is the sole caller that passes
+    /// `Some(..)`. Always pair with `pop_samewith_context`.
+    pub(crate) fn push_samewith_context(
+        &mut self,
+        name: &str,
+        invocant: Option<Value>,
+        args: Option<Vec<Value>>,
+    ) {
+        self.samewith_context_stack.push(super::SamewithContext {
+            name: name.to_string(),
+            invocant,
+            args,
+        });
     }
 
     /// Pop a samewith context.

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -145,13 +145,13 @@ impl Interpreter {
         // A lazy `gather` body re-pushes the context it captured at creation for
         // the duration of its force (see `push_captured_samewith_context`), so
         // this stack is correct there too.
-        if let Some((name, invocant)) = self.samewith_context_stack.last().cloned() {
-            if let Some(inv) = invocant {
+        if let Some(ctx) = self.samewith_context_stack.last().cloned() {
+            if let Some(inv) = ctx.invocant {
                 // Method dispatch: re-call the method on the same invocant
-                return self.call_method_with_values(inv, &name, args.to_vec());
+                return self.call_method_with_values(inv, &ctx.name, args.to_vec());
             } else {
                 // Sub dispatch: re-call the function by name
-                return self.call_function(&name, args.to_vec());
+                return self.call_function(&ctx.name, args.to_vec());
             }
         }
         Err(RuntimeError::new(
@@ -177,14 +177,14 @@ impl Interpreter {
     /// Record the innermost dynamic samewith context into `env` so a closure
     /// captured from it (today: a lazy `gather` body) can still redispatch.
     pub(crate) fn capture_samewith_context_into(&self, env: &mut crate::env::Env) {
-        let Some((name, invocant)) = self.samewith_context_stack.last() else {
+        let Some(ctx) = self.samewith_context_stack.last() else {
             return;
         };
         env.insert(
             Self::SAMEWITH_LEXICAL_NAME_KEY.to_string(),
-            Value::str(name.clone()),
+            Value::str(ctx.name.clone()),
         );
-        if let Some(inv) = invocant {
+        if let Some(inv) = &ctx.invocant {
             env.insert(Self::SAMEWITH_LEXICAL_INVOCANT_KEY.to_string(), inv.clone());
         }
     }
@@ -204,14 +204,14 @@ impl Interpreter {
         };
         let name = name.to_string_value();
         let invocant = env.get(Self::SAMEWITH_LEXICAL_INVOCANT_KEY).cloned();
-        self.samewith_context_stack.push((name, invocant));
+        self.push_samewith_context(&name, invocant, None);
         true
     }
 
     /// Undo a [`Self::push_captured_samewith_context`] that returned `true`.
     pub(crate) fn pop_captured_samewith_context(&mut self, pushed: bool) {
         if pushed {
-            self.samewith_context_stack.pop();
+            self.pop_samewith_context();
         }
     }
 
@@ -231,7 +231,7 @@ impl Interpreter {
         if self
             .samewith_context_stack
             .last()
-            .is_none_or(|(n, _)| n != &method_name)
+            .is_none_or(|ctx| ctx.name != method_name)
         {
             return None;
         }
@@ -273,7 +273,10 @@ impl Interpreter {
         &mut self,
         override_args: Option<&[Value]>,
     ) -> Option<Result<Value, RuntimeError>> {
-        let method_name = self.samewith_context_stack.last().map(|(n, _)| n.clone())?;
+        let method_name = self
+            .samewith_context_stack
+            .last()
+            .map(|ctx| ctx.name.clone())?;
         if !matches!(method_name.as_str(), "BUILDALL" | "POPULATE" | "clone") {
             return None;
         }
@@ -306,7 +309,15 @@ impl Interpreter {
         &mut self,
         override_args: Option<&[Value]>,
     ) -> Option<Result<Value, RuntimeError>> {
-        let method_name = self.samewith_context_stack.last().map(|(n, _)| n.clone())?;
+        // ADR-0019 E9c-1: read name/invocant/args off the SAME
+        // `samewith_context_stack` entry (a single clone) rather than
+        // name/invocant from one stack and args from a separately
+        // pushed/popped stack — the former dual-stack shape could pair the
+        // top-of-args-stack entry with a DIFFERENT (deeper, stale)
+        // context if a raw push sat above the pairing `push_method_
+        // samewith_context` push; see `SamewithContext`'s doc comment.
+        let ctx = self.samewith_context_stack.last().cloned();
+        let method_name = ctx.as_ref().map(|c| c.name.clone())?;
         // A single (non-multi, non-wrapped) compiled method pushes no
         // `method_dispatch_stack` frame, so the invocant/args must come from
         // the samewith context and `self` rather than a dispatch frame (mirrors
@@ -315,11 +326,7 @@ impl Interpreter {
             .method_dispatch_stack
             .last()
             .map(|f| f.invocant.clone())
-            .or_else(|| {
-                self.samewith_context_stack
-                    .last()
-                    .and_then(|(_, i)| i.clone())
-            })
+            .or_else(|| ctx.as_ref().and_then(|c| c.invocant.clone()))
             .or_else(|| self.env.get("self").cloned())?;
         let args: Vec<Value> = match override_args {
             Some(a) => a.to_vec(),
@@ -330,12 +337,12 @@ impl Interpreter {
                 // A single (non-multi, non-wrapped) compiled method — the
                 // common case for a `method push(...) { nextsame }` override on
                 // an `is Array` subclass — pushes no `method_dispatch_stack`
-                // frame at all, so the original call args live only in
-                // `samewith_call_args_stack` (pushed alongside the samewith
-                // context by `push_method_samewith_context`). Without this,
-                // `args` silently defaulted to empty and the deferred push
-                // appended nothing.
-                .or_else(|| self.samewith_call_args_stack.last().cloned())
+                // frame at all, so the original call args live only in the
+                // samewith context's own `args` field (set by
+                // `push_method_samewith_context`). Without this, `args`
+                // silently defaulted to empty and the deferred push appended
+                // nothing.
+                .or_else(|| ctx.as_ref().and_then(|c| c.args.clone()))
                 .unwrap_or_default(),
         };
         let ValueView::Instance {
@@ -395,7 +402,10 @@ impl Interpreter {
         &mut self,
         override_args: Option<&[Value]>,
     ) -> Option<Result<Value, RuntimeError>> {
-        let method_name = self.samewith_context_stack.last().map(|(n, _)| n.clone())?;
+        let method_name = self
+            .samewith_context_stack
+            .last()
+            .map(|ctx| ctx.name.clone())?;
         if !matches!(method_name.as_str(), "parse" | "subparse" | "parsefile") {
             return None;
         }
@@ -513,7 +523,7 @@ impl Interpreter {
                 let method_name_now = self
                     .samewith_context_stack
                     .last()
-                    .map(|(n, _)| n.clone())
+                    .map(|ctx| ctx.name.clone())
                     .unwrap_or_default();
                 if method_name_now.is_empty() {
                     break;
@@ -816,7 +826,7 @@ impl Interpreter {
             let method_name_for_dispatch = self
                 .samewith_context_stack
                 .last()
-                .map(|(n, _)| n.clone())
+                .map(|ctx| ctx.name.clone())
                 .unwrap_or_default();
             let empty_fns = crate::opcode::CompiledFns::default();
             let fns_ref = method_def.compiled_fns.as_deref().unwrap_or(&empty_fns);
@@ -1114,7 +1124,7 @@ impl Interpreter {
                 || self
                     .samewith_context_stack
                     .last()
-                    .is_some_and(|(name, _)| name == "new");
+                    .is_some_and(|ctx| ctx.name == "new");
             if in_new && let Some(invocant) = self.env.get("self").cloned() {
                 let call_args = override_args.unwrap_or_default();
                 let result = self.call_method_with_values(invocant, "bless", call_args)?;

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -459,7 +459,7 @@ impl Interpreter {
                     dispatch_token,
                 ));
             }
-            self.samewith_context_stack.push((name.to_string(), None));
+            self.push_samewith_context(name, None, None);
             // ADR-0019 C6d-5: a compiled-eligible routine runs its plan-attached
             // (or memoized OTF) bytecode through the shared compiled entry
             // instead of the per-call `eval_block_value_with_pre_post` compile
@@ -481,7 +481,7 @@ impl Interpreter {
             if Self::def_module_single_sig_body_ok_ignoring_state(&def) {
                 let fold_is_rw = !def.is_raw;
                 let result = self.call_routine_def(&def, args.to_vec());
-                self.samewith_context_stack.pop();
+                self.pop_samewith_context();
                 if pushed_dispatch {
                     self.multi_dispatch_stack.pop();
                 }
@@ -502,7 +502,7 @@ impl Interpreter {
                 });
             }
             if def.empty_sig && !args.is_empty() {
-                self.samewith_context_stack.pop();
+                self.pop_samewith_context();
                 return Err(Self::reject_args_for_empty_sig(args));
             }
             let routine_is_rw = !def.is_raw;
@@ -546,7 +546,7 @@ impl Interpreter {
                         self.pop_caller_env();
                         self.env = saved_env;
                         self.exit_readonly_frame(saved_readonly);
-                        self.samewith_context_stack.pop();
+                        self.pop_samewith_context();
                         return Err(Self::enhance_binding_error(
                             e,
                             &def.name.resolve(),
@@ -675,7 +675,7 @@ impl Interpreter {
                 .map(|spec| self.resolved_type_capture_name(spec));
             self.env = restored_env;
             self.exit_readonly_frame(saved_readonly);
-            self.samewith_context_stack.pop();
+            self.pop_samewith_context();
             if pushed_dispatch {
                 self.multi_dispatch_stack.pop();
             }

--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -195,6 +195,30 @@ pub(crate) enum DeferralEntry {
     },
 }
 
+/// One entry of `Interpreter::samewith_context_stack` (ADR-0019 E9c-1).
+/// Replaces the former dual-stack shape (`samewith_context_stack:
+/// Vec<(String, Option<Value>)>` alongside a separately pushed/popped
+/// `samewith_call_args_stack: Vec<Vec<Value>>`), which relied on every push
+/// site pushing both stacks in lockstep by CONVENTION — several raw push
+/// sites pushed only the context, leaving `samewith_call_args_stack.last()`
+/// free to pair with the wrong (stale, deeper) context entry. Folding `args`
+/// into the same struct as `name`/`invocant` makes that desync structurally
+/// impossible: a site with no original-args carrier to attach passes `args:
+/// None` for its own entry instead of silently leaving a separate stack
+/// short by one.
+#[derive(Debug, Clone)]
+pub(crate) struct SamewithContext {
+    /// The enclosing multi sub / method / proto's dispatch name.
+    pub(crate) name: String,
+    /// The invocant for a method dispatch; `None` for a plain sub.
+    pub(crate) invocant: Option<Value>,
+    /// The original call args, when this push site has them to carry
+    /// (`push_method_samewith_context`); `None` otherwise — e.g. a plain sub
+    /// samewith context, or a captured `gather`-body re-push, never carried
+    /// args here even before this consolidation.
+    pub(crate) args: Option<Vec<Value>>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct MethodDispatchFrame {
     pub(crate) receiver_class: String,

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -136,7 +136,7 @@ impl Interpreter {
                 dispatch_token,
             ));
         }
-        self.samewith_context_stack.push((proto_name.clone(), None));
+        self.push_samewith_context(&proto_name, None, None);
         // The compiled entry replaces the run_block(&def.body) body run that
         // lived here (ADR-0019 C6d-3): it enforces empty_sig, binds parameters
         // (including the rw writeback), pushes the routine frame, and performs
@@ -145,7 +145,7 @@ impl Interpreter {
         // Err-with-return_value is a non-local return targeting an outer
         // callable and must propagate.
         let result = self.call_routine_def(&def, args);
-        self.samewith_context_stack.pop();
+        self.pop_samewith_context();
         if pushed_dispatch {
             self.multi_dispatch_stack.pop();
         }

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -146,11 +146,11 @@ impl Interpreter {
                 }
             }
         }
-        for (_, v) in &self.samewith_context_stack {
-            visit_opt(visitor, v);
-        }
-        for args in &self.samewith_call_args_stack {
-            visit_slice(visitor, args);
+        for ctx in &self.samewith_context_stack {
+            visit_opt(visitor, &ctx.invocant);
+            if let Some(args) = &ctx.args {
+                visit_slice(visitor, args);
+            }
         }
         for chain in self.wrap_chains.values() {
             for (_, v) in chain {

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -213,8 +213,7 @@ impl Interpreter {
                 if pushed_base_dispatch {
                     let rw_params =
                         super::builtins_dispatch_next::rw_scalar_positional_params(&def.param_defs);
-                    self.samewith_context_stack
-                        .push((lookup_name.to_string(), Some(target.clone())));
+                    self.push_samewith_context(lookup_name, Some(target.clone()), None);
                     let dispatch_token = self.next_dispatch_token();
                     self.method_dispatch_stack.push(super::MethodDispatchFrame {
                         receiver_class: base_class.clone().unwrap_or_default(),
@@ -238,7 +237,7 @@ impl Interpreter {
                 );
                 if pushed_base_dispatch {
                     self.method_dispatch_stack.pop();
-                    self.samewith_context_stack.pop();
+                    self.pop_samewith_context();
                 }
                 for (name, previous) in &saved_role_params {
                     if let Some(prev) = previous {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1867,18 +1867,13 @@ pub struct Interpreter {
     /// candidate's exit flush clobbering it with its own stale value (§D capstone).
     multi_dispatch_stack: Vec<MultiDispatchEntry>,
     method_dispatch_stack: Vec<MethodDispatchFrame>,
-    /// Stack of samewith dispatch contexts.
-    /// Each entry is (function_or_method_name, optional_invocant).
-    /// Pushed whenever a multi sub or multi method is entered, popped on exit.
-    samewith_context_stack: Vec<(String, Option<Value>)>,
-    /// Original call args for each `push_method_samewith_context` push, in
-    /// lockstep with `samewith_context_stack` (pushed/popped together by
-    /// `push_method_samewith_context`/`pop_method_samewith_context`). A single
-    /// (non-multi, non-wrapped) compiled method pushes NO `method_dispatch_stack`
-    /// frame at all — so `native_array_storage_next_candidate`'s `nextsame`/
-    /// `callsame` fallback (the only reader) has nowhere else to recover the
-    /// original call args from in that case.
-    samewith_call_args_stack: Vec<Vec<Value>>,
+    /// Stack of samewith dispatch contexts, pushed whenever a multi sub,
+    /// multi method, or proto is entered, popped on exit. ADR-0019 E9c-1:
+    /// a single `Vec<SamewithContext>` — every push site funnels through
+    /// `push_samewith_context`/`push_method_samewith_context`, so `args` can
+    /// never desync from `name`/`invocant` the way the former separate
+    /// `samewith_call_args_stack` could (see `SamewithContext`'s doc comment).
+    samewith_context_stack: Vec<SamewithContext>,
     /// Metamodel-method dispatch contexts:
     /// (samewith_depth, receiver_class, method_name, args).
     /// Pushed alongside the samewith context when the receiver's MRO includes

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2310,7 +2310,6 @@ impl Interpreter {
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),
             samewith_context_stack: Vec::new(),
-            samewith_call_args_stack: Vec::new(),
             metamodel_dispatch_stack: Vec::new(),
             wrap_chains: HashMap::new(),
             wrap_sub_names: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -675,7 +675,6 @@ impl Interpreter {
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),
             samewith_context_stack: Vec::new(),
-            samewith_call_args_stack: Vec::new(),
             metamodel_dispatch_stack: Vec::new(),
             wrap_chains: self.wrap_chains.clone(),
             wrap_sub_names: self.wrap_sub_names.clone(),

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -354,7 +354,7 @@ impl Interpreter {
                     let routine = self
                         .samewith_context_stack
                         .last()
-                        .map(|(name, _)| name.as_str())
+                        .map(|ctx| ctx.name.as_str())
                         .unwrap_or("<anon>");
                     return Err(RuntimeError::parameter_invalid_concreteness(
                         base_type,

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -292,7 +292,7 @@ impl Interpreter {
 
         // Set up samewith and multi-dispatch context that call_compiled_function_named
         // expects the caller to manage (mirrors exec_call_fn_op).
-        self.push_samewith_context(&name, None);
+        self.push_samewith_context(&name, None, None);
         let pushed_dispatch = loan_env!(self, push_multi_dispatch_frame(&name, &args));
 
         // Prefer the routine's own nested-sub table over the caller's: a

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -624,7 +624,7 @@ impl Interpreter {
                             // The body must run under its *defining* package, not
                             // the callsite's (see `otf_call_cache`'s doc comment).
                             let pkg = def_pkg_sym.resolve();
-                            self.push_samewith_context(name_str, None);
+                            self.push_samewith_context(name_str, None, None);
                             let pushed_dispatch =
                                 loan_env!(self, push_multi_dispatch_frame(name_str, &args));
                             // The named-share writeback reads the arg sources;
@@ -1230,7 +1230,7 @@ impl Interpreter {
                 }
                 self.set_pending_call_arg_sources(arg_sources.clone());
                 let pushed_dispatch = loan_env!(self, push_multi_dispatch_frame(name, &args));
-                self.push_samewith_context(name, None);
+                self.push_samewith_context(name, None, None);
                 // Use the function's defining package so that lookups inside the
                 // function body resolve against the correct namespace.
                 let pkg = if let Some(cached_pkg) = self.cached_fn_package(name, args.len()) {

--- a/t/samewith-proto-body-rerun.t
+++ b/t/samewith-proto-body-rerun.t
@@ -1,0 +1,29 @@
+use Test;
+
+# ADR-0019 E9c design pin (verified against Rakudo v2026.06, 2026-08-13):
+# `samewith` re-runs the governing PROTO BODY, not just the sequence's ranked
+# candidate list -- a full dispatcher restart, not a same-sequence re-rank.
+# See probe P3 in
+# todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md ("E9c design
+# (2026-08-13): proto {*} resolves directly within the governing boundary;
+# samewith's by-name restart is CONFIRMED correct and stays").
+
+plan 2;
+
+my @ev;
+class C {
+    proto method m($x) { @ev.push("proto($x)"); {*} }
+    multi method m(Int $x) { @ev.push("int($x)"); samewith($x + 10) if $x < 10; }
+    multi method m(Str $s) { @ev.push("str($s)") }
+}
+C.new.m(1);
+is @ev.join("|"), "proto(1)|int(1)|proto(11)|int(11)",
+    "samewith re-runs the governing proto method body (method case)";
+
+@ev = ();
+proto sub f($x) { @ev.push("proto($x)"); {*} }
+multi sub f(Int $x) { @ev.push("int($x)"); samewith("s") if $x != 0; }
+multi sub f(Str $s) { @ev.push("str($s)") }
+f(1);
+is @ev.join("|"), "proto(1)|int(1)|proto(s)|str(s)",
+    "samewith re-runs the governing proto sub body (sub case)";


### PR DESCRIPTION
## Summary

- Merges `samewith_context_stack: Vec<(String, Option<Value>)>` and `samewith_call_args_stack: Vec<Vec<Value>>` into a single `Vec<SamewithContext { name, invocant, args }>`.
- The two stacks were kept in sync only by CONVENTION: several raw push sites (`methods_mixin_dispatch.rs`, `dispatch_proto_call.rs`, `builtins_operators_fallback.rs`, `builtins_dispatch_next.rs`, and the VM sub paths in `vm_call_dispatch.rs` / `vm_call_func_ops.rs`) pushed only the context stack, leaving `samewith_call_args_stack.last()` free to pair with a stale, deeper context entry whenever such a raw push sat above a `push_method_samewith_context` push — a latent desync class. Folding `args` into the same struct makes that structurally impossible.
- Mechanical, zero behavior change: every push site now goes through `push_samewith_context`/`push_method_samewith_context` (`args: None` where no original-args carrier applies), and every reader (`builtin_samewith`, the native metamodel/array-storage/grammar-parse `nextsame` fallbacks, the wrap peek) reads the merged struct instead of correlating two stacks by position.

This is ADR-0019 Phase E box E9c's first slice — see `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`'s "E9c design" section. E9b (sibling box) closed this session (#6361/#6363/#6369). E9c-2 (the `{*}` direct-resolution cutover) follows as a separate slice.

## Test plan

- [x] `t/samewith-proto-body-rerun.t` (P3 ground truth pin: `samewith` re-runs the governing proto BODY — must not regress)
- [x] `t/samewith-*.t`, `t/proto-*.t`, `t/wrap*.t`, `t/method-wrap-*.t`, `t/defer-*.t`, `t/nextsame-role-mixin.t`, `t/lastcall-*.t` — 38 files, 223 tests, all green
- [x] Full local `make test` (3122 files) — green
- [x] Targeted release-build roast slice (`S06-advanced/{callsame,dispatching,wrap}`, `S06-multi/{redispatch,type-based,syntax,proto}`, `S12-methods/{defer-call,defer-next,lastcall,multi,parallel-dispatch}`, `6.c/S12-class/mro-6c`, `S12-class/{inheritance,basic}`, `6.c/S14-roles/mixin-6c`) — 16 files, 524 tests, all green
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check` — clean
- [ ] CI (`make test` + `make roast`) — watching

🤖 Generated with [Claude Code](https://claude.com/claude-code)