### PR TITLE
fix(compiler): scope a mainline block's typed my Str $x to the block

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -974,6 +974,21 @@ pub(crate) struct Compiler {
     /// Used to decide whether `return` in a non-routine block should perform
     /// a non-local return (via CX::Return) or throw X::ControlFlow::Return.
     pub(crate) lexically_in_routine: bool,
+    /// Whether we are directly compiling the body statements of a plain
+    /// `Stmt::Block` that emits `OpCode::BlockScope` (see the `Stmt::Block`
+    /// arm in `stmt.rs`). That opcode snapshots `env` before the body and
+    /// restores it after, dropping any new env key the body introduced — so
+    /// a `my TYPE $x` declaration compiled while this flag is set can safely
+    /// use the env-only `SetVarTypeScoped` opcode instead of the both-store
+    /// `SetVarType`, exactly like inside a routine
+    /// (`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`, issue
+    /// 2 "Mainline blocks"). Set/restored narrowly around that one branch —
+    /// the other `Stmt::Block` branches (implicit try, phaser scope,
+    /// `LetBlock`, import scope) do not perform this env restore, so a `my`
+    /// directly inside one of those keeps using the unscoped opcode; a
+    /// plain block nested inside any of them still gets its own
+    /// `BlockScope` and sets this flag again for its own body.
+    pub(crate) lexically_in_block: bool,
     /// Whether the enclosing routine is a `method` (or submethod). A method
     /// always carries an implicit `*%_` / `*@_` slurpy, so the legacy argument
     /// variables `%_` / `@_` are valid lexicals throughout its body — including
@@ -1208,6 +1223,7 @@ impl Compiler {
             callframe_block_depth: 0,
             is_routine: false,
             lexically_in_routine: false,
+            lexically_in_block: false,
             lexically_in_method: false,
             bind_vardecl: false,
             whenever_bind_target: false,
@@ -1805,22 +1821,31 @@ impl Compiler {
 
     /// Emit the declaration-time type-constraint registration op for a
     /// `my TYPE $x`-family declaration. A SCALAR `my`/`state` lexically inside
-    /// a routine gets `SetVarTypeScoped` — env-only registration, exactly like
-    /// a typed parameter — so its constraint dies with the frame instead of
-    /// leaking onto a same-named variable in another frame through the global
-    /// name-keyed store (`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`).
+    /// a routine, or directly inside a plain `{ ... }` block (see
+    /// `lexically_in_block`), gets `SetVarTypeScoped` — env-only
+    /// registration, exactly like a typed parameter — so its constraint dies
+    /// with the frame/block instead of leaking onto a same-named variable
+    /// elsewhere through the global name-keyed store
+    /// (`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`).
     /// Everything else keeps the both-store `SetVarType`: `@`/`%` containers
     /// (their element/key metadata is consulted through the global map by the
     /// push/subscript fast paths), `our` (package-scoped, outlives the frame),
-    /// dynamics (`$*x`, read cross-frame by design), and mainline declarations
-    /// (no frame to scope to).
+    /// dynamics (`$*x`, read cross-frame by design), an anonymous scalar
+    /// (`my T $`, name `__ANON_STATE__` — stored via `SetGlobal`/`GetGlobal`
+    /// rather than a local slot, immediately consumed into a
+    /// `WrapTypedContainer` cell, so there is no per-declaration slot for a
+    /// block/frame exit to scope; going through the env-only opcode here
+    /// starved that read of the global-map registration it depends on — see
+    /// `t/pair-typed-value-container.t`), and mainline declarations outside
+    /// any block (no frame/scope to scope to).
     fn emit_set_var_type(&mut self, name: &str, name_idx: u32, tc_idx: u32, is_our: bool) {
         let scoped = !is_our
-            && (self.is_routine || self.lexically_in_routine)
+            && (self.is_routine || self.lexically_in_routine || self.lexically_in_block)
             && !name.starts_with('@')
             && !name.starts_with('%')
             && !name.starts_with('&')
             && !name.starts_with('*')
+            && name != "__ANON_STATE__"
             && !name.contains("::");
         if scoped {
             self.code

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -841,6 +841,13 @@ impl Compiler {
                     self.code.emit(OpCode::PopImportScope);
                 } else {
                     // Plain blocks still create a lexical routine scope.
+                    // `BlockScope` snapshots env before the body and restores
+                    // it after (dropping any new env key), so a `my TYPE $x`
+                    // compiled while this flag is set can safely use the
+                    // env-only SetVarTypeScoped opcode — see
+                    // `lexically_in_block`'s doc comment.
+                    let saved_lexically_in_block =
+                        std::mem::replace(&mut self.lexically_in_block, true);
                     let idx = self.code.emit(OpCode::BlockScope {
                         pre_end: 0,
                         enter_end: 0,
@@ -929,6 +936,7 @@ impl Compiler {
                     self.code.patch_block_undo_start(idx);
                     self.code.patch_block_post_start(idx);
                     self.code.patch_loop_end(idx);
+                    self.lexically_in_block = saved_lexically_in_block;
                 }
                 self.sigilless_locals.retain(|n| {
                     sigilless_type_names_before.contains(n)

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -269,7 +269,10 @@ impl Interpreter {
         nested.set_current_package(self.current_package());
         nested.var_dynamic_flags = self.var_dynamic_flags.clone();
         for (k, v) in &self.env {
-            if k.contains_str("::") {
+            // Skip genuine package-qualified names, but not an internal
+            // `__mutsu_` metadata key (e.g. `__mutsu_type::x`) — see the
+            // matching comment in `throws_like.rs`.
+            if k.contains_str("::") && !k.with_str(|s| s.starts_with("__mutsu_")) {
                 continue;
             }
             if matches!(v.view(), ValueView::Sub(_) | ValueView::Routine { .. }) {
@@ -372,7 +375,10 @@ impl Interpreter {
         nested.set_current_package(self.current_package());
         nested.var_dynamic_flags = self.var_dynamic_flags.clone();
         for (k, v) in &self.env {
-            if k.contains_str("::") {
+            // Skip genuine package-qualified names, but not an internal
+            // `__mutsu_` metadata key (e.g. `__mutsu_type::x`) — see the
+            // matching comment in `throws_like.rs`.
+            if k.contains_str("::") && !k.with_str(|s| s.starts_with("__mutsu_")) {
                 continue;
             }
             if matches!(v.view(), ValueView::Sub(_) | ValueView::Routine { .. }) {

--- a/src/runtime/test_functions/fails_like.rs
+++ b/src/runtime/test_functions/fails_like.rs
@@ -77,7 +77,11 @@ impl Interpreter {
                 nested.set_current_package(self.current_package());
                 nested.var_dynamic_flags = self.var_dynamic_flags.clone();
                 for (k, v) in &self.env {
-                    if k.contains_str("::") {
+                    // Skip genuine package-qualified names, but not an
+                    // internal `__mutsu_` metadata key (e.g.
+                    // `__mutsu_type::x`) — see the matching comment in
+                    // `throws_like.rs`.
+                    if k.contains_str("::") && !k.with_str(|s| s.starts_with("__mutsu_")) {
                         continue;
                     }
                     if matches!(v.view(), ValueView::Sub(_) | ValueView::Routine { .. }) {

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -77,11 +77,43 @@ impl Interpreter {
                 // must be visible to the caller afterwards.
                 let mut shared_var_names: Vec<Symbol> = Vec::new();
                 for (k, v) in &self.env {
-                    if k.contains_str("::") {
+                    // Skip genuine package-qualified names (`Foo::bar`) — those
+                    // are handled separately — but NOT an internal `__mutsu_`
+                    // metadata key, which also contains `::` (e.g.
+                    // `__mutsu_type::text`, the env-scoped type-constraint
+                    // registration a block-local `my TYPE $x` writes — see
+                    // `Interpreter::set_var_type_constraint_routine_scoped`).
+                    // Dropping it here made `throws-like q[$text = 'oops']`
+                    // blind to a block-scoped typed lexical's constraint even
+                    // though a direct (non-EVAL'd) assignment enforced it fine
+                    // (roast S02-types/subset-6c.t).
+                    if k.contains_str("::") && !k.with_str(|s| s.starts_with("__mutsu_")) {
                         continue;
                     }
                     nested.env.insert_sym(*k, v.clone());
                     shared_var_names.push(*k);
+                }
+                // The nested interpreter has no local slot for any of these
+                // copied names (they arrive purely through env), so the
+                // bytecode `EVAL`'d code compiles for a plain assignment to
+                // one (e.g. `$text = 'oops'`) resolves it as a package-global
+                // reference and its runtime type-check goes through the
+                // MAP-ONLY `var_type_constraint_fast`, which never consults
+                // env. A block-local typed `my TYPE $x` registers its
+                // constraint env-scoped ONLY (`SetVarTypeScoped`), so without
+                // this it is invisible here even though the env key itself
+                // was just copied above. Resolve each copied name's EFFECTIVE
+                // constraint (env-first, matching normal reads) in the
+                // caller and fold it into the nested interpreter's own map.
+                for name_sym in &shared_var_names {
+                    name_sym.with_str(|name| {
+                        if name.starts_with("__mutsu_") || name.contains("::") {
+                            return;
+                        }
+                        if let Some(tc) = self.var_type_constraint(name) {
+                            nested.var_type_constraints.insert(name.to_string(), tc);
+                        }
+                    });
                 }
                 // Under the (B) per-store env-write gate the caller's plain lexicals
                 // keep only their decl-seed `Any` in `self.env` (their initializing
@@ -584,7 +616,10 @@ impl Interpreter {
                 nested.operator_assoc = self.operator_assoc.clone();
                 nested.user_declared_infix_ops = self.user_declared_infix_ops.clone();
                 for (k, v) in &self.env {
-                    if !k.contains_str("::") {
+                    // Skip genuine package-qualified names, but not an
+                    // internal `__mutsu_` metadata key — see the matching
+                    // comment above in `test_fn_throws_like`.
+                    if !k.contains_str("::") || k.with_str(|s| s.starts_with("__mutsu_")) {
                         nested.env.insert_sym(*k, v.clone());
                     }
                 }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1236,27 +1236,50 @@ impl Interpreter {
                     && !name.starts_with('%')
                     && !name.starts_with('@')
                 {
-                    if !val.is_nil() && !self.type_matches_value(&constraint, &val) {
-                        // When assigning an unhandled Failure to a typed variable
-                        // that can't hold it, explode the Failure first (Raku behavior)
-                        if let ValueView::Instance { class_name, .. } = val.view()
-                            && class_name.resolve() == "Failure"
-                            && !val.is_failure_handled()
-                            && let Some(err) = self.failure_to_runtime_error_if_unhandled(&val)
-                        {
-                            return Err(err);
+                    // A Nil ASSIGNED to a typed scalar resets it to its type
+                    // object (`my Str $x = "a"; $x = Nil` leaves `$x === Str`),
+                    // mirroring `exec_set_local_op`'s STORE-time reset. This
+                    // SetGlobal path is reached when the writer has no local
+                    // slot for the name (a closure/embedded-regex-code-block
+                    // write to a captured typed scalar, `$Foo::x = Nil`, ...):
+                    // without the reset here, the raw Nil got stored as-is,
+                    // and the GetGlobal read path deliberately does NOT
+                    // convert a Nil read into the type object via an
+                    // env-scoped constraint (a genuine `Mu $b = Nil` parameter
+                    // default must stay Nil) — so the value never became the
+                    // type object at all (roast S02-types/nil.t,
+                    // S02-types/subset-6e.t "assigns to subset type object").
+                    if val.is_nil()
+                        && !is_bind_ctx
+                        && !is_rebind
+                        && constraint != "Nil"
+                        && self.var_default(&name).is_none()
+                    {
+                        val = self.typed_scalar_nil_seed_value(&name, &constraint);
+                    } else {
+                        if !val.is_nil() && !self.type_matches_value(&constraint, &val) {
+                            // When assigning an unhandled Failure to a typed variable
+                            // that can't hold it, explode the Failure first (Raku behavior)
+                            if let ValueView::Instance { class_name, .. } = val.view()
+                                && class_name.resolve() == "Failure"
+                                && !val.is_failure_handled()
+                                && let Some(err) = self.failure_to_runtime_error_if_unhandled(&val)
+                            {
+                                return Err(err);
+                            }
+                            return Err(runtime::utils::type_check_assignment_typed_error(
+                                &name,
+                                &constraint,
+                                &val,
+                            ));
                         }
-                        return Err(runtime::utils::type_check_assignment_typed_error(
-                            &name,
-                            &constraint,
-                            &val,
-                        ));
+                        if !val.is_nil() {
+                            val =
+                                loan_env!(self, try_coerce_value_for_constraint(&constraint, val))?;
+                        }
+                        // Wrap native integer values on assignment (overflow wrapping)
+                        val = Self::wrap_native_int_by_constraint(&constraint, val)?;
                     }
-                    if !val.is_nil() {
-                        val = loan_env!(self, try_coerce_value_for_constraint(&constraint, val))?;
-                    }
-                    // Wrap native integer values on assignment (overflow wrapping)
-                    val = Self::wrap_native_int_by_constraint(&constraint, val)?;
                 }
                 if self.fatal_mode
                     && !name.contains("__mutsu_")

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -499,7 +499,25 @@ impl Interpreter {
                 // Variables declared with `my` inside this block should not
                 // propagate their values to the outer scope. Restore the outer
                 // scope's original value instead.
-                if block_declared.contains(&k) {
+                //
+                // A name-derived metadata key (`__mutsu_type::o`,
+                // `__mutsu_hash_key_type::o`) is not itself in `block_declared`
+                // — that set only records the bare variable name a `my`
+                // declared, e.g. "o" — so a block-local typed `my Int $o`
+                // shadowing an outer typed `my Str $o` would otherwise look
+                // like an ordinary reassignment of an outer key and propagate
+                // the block's own type constraint out (breaking the outer
+                // `Str` enforcement after the block exits). Strip a known
+                // metadata prefix and check the base name instead.
+                let owned_by_block_declared_name = block_declared.contains(&k)
+                    || k.with_str(|s| {
+                        s.strip_prefix("__mutsu_type::")
+                            .or_else(|| s.strip_prefix("__mutsu_hash_key_type::"))
+                            .is_some_and(|base| {
+                                block_declared.contains(&crate::symbol::Symbol::intern(base))
+                            })
+                    });
+                if owned_by_block_declared_name {
                     continue;
                 }
                 restored_env.insert_sym(k, v);

--- a/t/typed-lexical-constraint-block-scoped.t
+++ b/t/typed-lexical-constraint-block-scoped.t
@@ -1,0 +1,61 @@
+use v6;
+use Test;
+
+# A typed scalar `my` inside a plain mainline block must not leak its
+# constraint onto a same-named variable outside the block (the bare-name-keyed
+# constraint store was scope-blind —
+# todo/deep/bare-name-type-constraint-store-is-scope-blind.md, issue 2
+# "Mainline blocks"). Companion to t/typed-lexical-constraint-frame-scoped.t,
+# which covers the routine-scoped half of the same fix.
+#
+# Scope: this covers only a genuine source `{ ... }` block (compiled to
+# `OpCode::BlockScope`). An `if`/`while`/`for`/C-style-loop BODY with a
+# block-local `my` compiles through two different, still-unfixed paths
+# (`OpCode::BlockLocalScope`, and plain inlining for a `while`/loop body with
+# no topic rebind) — see the todo file for the remaining gap.
+
+plan 7;
+
+# A pre-existing outer untyped $x must not be poisoned by a typed $x declared
+# inside a bare block.
+{
+    my $x;
+    { my Str $x = "a"; }
+    lives-ok { $x = 42 }, 'bare-block-scoped my Str $x does not constrain outer $x';
+    is $x, 42, 'outer $x holds the assigned Int';
+}
+
+# The literal repro shape from the todo: block runs and exits BEFORE the
+# outer `my $x` is (re-)declared.
+{
+    { my Str $x = "a"; }
+    my $x;
+    lives-ok { $x = 42 }, 'block exiting before outer redeclaration does not leak';
+}
+
+# Enforcement INSIDE the block still works (env-scoped registration).
+{
+    { my Str $s = "a"; dies-ok { $s = 42 }, 'constraint enforced inside the declaring block'; }
+}
+
+# A closure escaping the block keeps enforcement through its captured env.
+{
+    my &esc;
+    { my Str $c = "a"; &esc = sub { $c = 42 } }
+    dies-ok { esc() }, 'escaped closure still enforces the dead block constraint';
+}
+
+# Nested block: the leak must not survive even one extra level of nesting.
+{
+    my $x;
+    { { my Str $x = "a"; } }
+    lives-ok { $x = 42 }, 'nested-block-scoped my Str $x does not constrain outer $x';
+}
+
+# An outer typed lexical keeps enforcement while a block shadows the name.
+{
+    my Str $o = "s";
+    { my Int $o = 1; }
+    throws-like { $o = 42 }, Exception, message => /'expected Str'/,
+        'outer Str constraint intact after block-scoped Int shadow';
+}

--- a/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
+++ b/todo/deep/bare-name-type-constraint-store-is-scope-blind.md
@@ -17,6 +17,35 @@ map for typed routine lexicals. Pinned by
 `t/typed-lexical-constraint-frame-scoped.t`; unblocked Text::CSV
 `t/66_formula.t` (the last real CSV suite blocker).
 
+## Status 2026-08-13 (later same day): genuine bare-block SCALARS are fixed
+
+Issue 2's literal shape — a typed scalar `my` directly inside a genuine
+source `{ ... }` block at mainline (compiled to `OpCode::BlockScope`) — is
+now fixed the same way as the routine case: `Compiler::lexically_in_block`
+(set/restored around that block's own body compilation, `stmt.rs`'s
+`Stmt::Block` arm, the plain-`BlockScope` branch only) makes
+`emit_set_var_type` (`compiler/mod.rs`) choose the env-only
+`SetVarTypeScoped` opcode there too, and `BlockScope`'s existing env
+snapshot/restore (`vm_misc_scope.rs::exec_block_scope_op`) now cleans it up
+on block exit.
+
+Fixing this exposed a SEPARATE, more general bug in that same restore: the
+env-restore loop decided whether an env key was "block-local" (and so
+restore-not-propagate) by checking `block_declared` (a set of *bare variable
+name* symbols) directly against the key. A name-derived metadata key
+(`__mutsu_type::o`, `__mutsu_hash_key_type::o`) is never itself in that set,
+so a block-local `my Int $o` shadowing an outer `my Str $o` looked like an
+ordinary reassignment of an outer key and propagated the block's own `Int`
+constraint out, permanently overwriting the outer `Str` constraint even
+after the block exited (independent of the scalar-scoping fix above — this
+would affect ANY same-named-metadata-key shape, not just type constraints,
+though type constraints are the only current user). Fixed by stripping the
+known `__mutsu_type::`/`__mutsu_hash_key_type::` prefixes and checking the
+base name against `block_declared` too.
+
+Pinned by `t/typed-lexical-constraint-block-scoped.t` (verified against
+`raku` directly, all 7 assertions match).
+
 ## What is still scope-blind
 
 1. **`@`/`%` containers**: `my Int @a` inside a routine still registers the
@@ -25,10 +54,37 @@ map for typed routine lexicals. Pinned by
    fast paths, which never probe env). A module method's `my Int @r` can
    still poison a caller's same-named untyped `@r` — the shape #6337 and the
    expr-position clears (`expr_block.rs`) patch case-by-case.
-2. **Mainline blocks**: a typed scalar in a bare block at mainline
-   (`{ my Str $x = "a" } ; my $x; $x = 42`) leaks within the mainline frame
-   — `lexically_in_routine` is false there, so the declaration still writes
-   the global map, and blocks do not restore it.
+2. **`if`/`while`/`for`/C-style-loop BODIES with a block-local typed scalar
+   still leak.** Only a genuine source `{ ... }` block was fixed above. A
+   typed scalar directly in one of these bodies reaches the leak through two
+   OTHER, distinct compile paths that were deliberately left untouched
+   (extending the fix there needs its own VM-side work, not just the
+   compiler flag):
+   - **`if`/`unless`/`else` branches that declare a block-local `my`**
+     compile through `Compiler::compile_block_local_branch`
+     (`helpers_control_flow.rs`) → `OpCode::BlockLocalScope`, executed by
+     `Interpreter::exec_block_local_scope_op` (`vm_control_ops.rs`). That
+     opcode's exit cleanup only removes the bare-name env entry for a name in
+     `block_declared`/`env_had_before` (`vm_control_ops.rs:326-347`) — it has
+     no equivalent of `BlockScope`'s snapshot/restore, so it never touches
+     `__mutsu_type::*` at all. Repro: `my $y; if True { my Str $y = "a"; };
+     $y = 42` throws in mutsu, assigns fine in raku.
+   - **A `while`/C-style-loop body with no topic rebind** compiles via
+     `Compiler::compile_body_with_implicit_try` (`helpers_control_flow.rs`),
+     which just inlines the body's statements into the current frame with NO
+     scope wrapper of any kind (`Stmt::While` in `stmt.rs`). Repro: `my $x;
+     while $i++ < 2 { my Str $x = "a"; }; $x = 42` throws in mutsu (once the
+     loop body actually runs at least once — a body that never executes,
+     e.g. `while False`, is a false negative), assigns fine in raku.
+   - The likely fix shape for the `BlockLocalScope` path: snapshot the
+     pre-shadow value of `__mutsu_type::<name>` (and the hash-key-type twin)
+     into the SAME `Interpreter::loop_local_saved_env` map the bare name's
+     shadow value already uses (`vm_var_assign_set_local.rs`'s
+     `SetLocalDecl` handling, ~line 2038-2129) — that map's restore
+     (`pop_loop_local_scope`) is already generic over the key string, so no
+     new restore mechanism would be needed, only a second snapshot write at
+     declaration time. The raw-inline `while`/loop-body path has no scope
+     boundary opcode at all to hook into and would need one first.
 3. **Untyped shadow destroys outer enforcement**: an untyped `my $e` /
    untyped param inside a routine REMOVES the global entry of a same-named
    outer typed lexical (the clear path in `set_var_type_constraint_impl` /


### PR DESCRIPTION
## Summary
- Extends the routine-scoped typed-scalar `my`/`state` fix
  (`todo/deep/bare-name-type-constraint-store-is-scope-blind.md`, issue 2) to
  a genuine mainline `{ ... }` block: `Compiler::lexically_in_block` makes a
  typed scalar declared directly in such a block use the env-only
  `SetVarTypeScoped` opcode too, so it no longer poisons a same-named
  variable outside the block through the global bare-name-keyed constraint
  store.
- Fixes a second bug this exposed in `BlockScope`'s env restore: it decided
  whether to propagate an env key by checking the bare declared-variable name
  only, so a block-local typed `my` shadowing an outer typed `my` of the same
  name propagated its own type-metadata key out instead of restoring the
  outer one.
- Excludes the anonymous-scalar sentinel (`__ANON_STATE__`, used by `my T $`
  in expression position) from scoped registration in both the routine and
  block cases — it is stored via `SetGlobal`/`GetGlobal` rather than a local
  slot, so scoping it starved a downstream read of the global-map
  registration it depends on. This was a pre-existing gap in the earlier
  routine-scoped fix too (confirmed with a `sub`-based repro), just not
  previously covered by a test.
- Updates the todo file: documents both fixes, and records the remaining gap
  — `if`/`while`/`for`/C-style-loop bodies with a block-local typed scalar
  still leak through two other, distinct compile paths.

## Test plan
- [x] New `t/typed-lexical-constraint-block-scoped.t` (7 assertions, verified
      byte-for-byte against `raku` output)
- [x] `t/typed-lexical-constraint-frame-scoped.t` (existing routine-scoped
      suite) still passes
- [x] `t/pair-typed-value-container.t` (regression caught during development,
      now fixed) passes
- [x] Full `make test` passes clean
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` clean
- [ ] CI `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)