### PR TITLE
refactor(dispatch): proto {*} resolves directly within the governing boundary (ADR-0019 E9c-2)

### DIFF
--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -294,25 +294,22 @@ impl Interpreter {
     /// Format the candidate signatures of a (multi) method across the
     /// receiver class's MRO, e.g. `(WorkingTie: Int $z, *%_)`. Used to build a
     /// Raku-style `X::Multi::NoMatch` message naming the invocant type and the
-    /// available candidates.
+    /// available candidates. `boundary_owner`, when `Some`, mirrors
+    /// `resolve_method_with_owner_impl`'s boundary parameter (ADR-0019 E9c-2):
+    /// a proto `{*}` redispatch's no-match diagnostic should list only the
+    /// candidates that redispatch can actually reach (at or below the
+    /// proto's owner), not an ancestor's candidates beyond it. Ordinary
+    /// (non-proto) dispatch passes `None`.
     pub(crate) fn format_method_candidate_signatures(
         &self,
         receiver_class_name: &str,
         method_name: &str,
+        boundary_owner: Option<Symbol>,
     ) -> Vec<String> {
         let mut sigs = Vec::new();
         let mro = self.mro_readonly(receiver_class_name);
-        // Mirror `resolve_method_with_owner_impl`'s proto-redispatch boundary
-        // (this ticket): when the active `{*}` redispatch is for THIS method
-        // and its declaring class is in this MRO, the diagnostic should list
-        // only the candidates that redispatch can actually reach (at or
-        // below the proto's owner), not an ancestor's candidates beyond it.
-        let truncate_at = match self.proto_redispatch_boundary {
-            Some((boundary_method, owner)) if boundary_method == Symbol::intern(method_name) => {
-                mro.iter().position(|cn| Symbol::intern(cn) == owner)
-            }
-            _ => None,
-        };
+        let truncate_at =
+            boundary_owner.and_then(|owner| mro.iter().position(|cn| Symbol::intern(cn) == owner));
         let mro = match truncate_at {
             Some(pos) => &mro[..=pos],
             None => &mro[..],

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -180,81 +180,146 @@ impl Interpreter {
             }
         }
         let Some((owner_class, method_def)) = resolved else {
-            // Distinguish X::Multi::NoMatch (method exists but no candidate
-            // matched) from X::Method::NotFound (method does not exist at all,
-            // e.g. submethod on ancestor only).
-            let has_visible_method = self.class_mro(receiver_class_name).iter().any(|cn| {
-                self.registry()
-                    .classes
-                    .get(cn.as_str())
-                    .and_then(|c| c.methods.get(method_name))
-                    .is_some_and(|ovs| {
-                        let is_ancestor = cn.as_str() != receiver_class_name;
-                        ovs.iter()
-                            .any(|d| !d.is_private && (!d.is_my || !is_ancestor))
-                    })
-            });
-            if has_visible_method {
-                // `self.new(:named)` on a concrete invocant whose class declares
-                // user multi `new` candidates that don't match: Mu.new(*%attrinit)
-                // is always available as a fallback multi candidate, exactly as
-                // `dispatch_new` provides for type-object targets. An explicit
-                // `proto method new` owns dispatch, so no fallback then. Gated on
-                // a concrete invocant: `dispatch_new`'s own user-new probe runs
-                // with a Package invocant and must surface no-match to reach its
-                // default-constructor fall-through (not recurse through here).
-                if method_name == "new"
-                    && matches!(
-                        inv_value.view(),
-                        ValueView::Instance { .. } | ValueView::Mixin(..)
-                    )
-                    && self
-                        .lookup_proto_method(receiver_class_name, "new")
-                        .is_none()
-                    && args
-                        .iter()
-                        .all(|a| matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
-                {
-                    let v = self.dispatch_new(
-                        Value::package(crate::symbol::Symbol::intern(receiver_class_name)),
-                        args,
-                    )?;
-                    return Ok((v, None));
-                }
-                let sigs =
-                    self.format_method_candidate_signatures(receiver_class_name, method_name);
-                let profile = self.format_call_arg_profile(&args);
-                let concrete = !matches!(inv_value.view(), ValueView::Package(_));
-                return Err(
-                    super::methods_signature_errors::make_multi_no_match_error_detailed(
-                        method_name,
-                        receiver_class_name,
-                        concrete,
-                        &profile,
-                        &sigs,
-                    ),
-                );
-            }
-            // A field read on an `is repr('CStruct')` handle: the instance
-            // carries the C pointer, so resolve the name against the struct's
-            // declared field layout and read it out of native memory
-            // (`$ssl.server`, `nativecast(evp_cipher_st, $c).key_len`). The
-            // class declares the fields as attributes but has no storage for
-            // them, so accessor resolution reaches here.
-            if args.is_empty()
-                && let Some(field) = self.cstruct_field_value(&inv_value, method_name)
-            {
-                return Ok((field, None));
-            }
-            let type_name = receiver_class_name.to_string();
-            return Err(
-                super::methods_signature_errors::make_method_not_found_error(
-                    method_name,
-                    &type_name,
-                    false,
-                ),
+            return self.instance_method_not_found(
+                receiver_class_name,
+                method_name,
+                args,
+                inv_value,
+                None,
             );
         };
+        self.run_resolved_instance_method(
+            receiver_class_name,
+            attributes,
+            method_name,
+            args,
+            invocant,
+            inv_value,
+            owner_class,
+            method_def,
+            None,
+        )
+    }
+
+    /// The `resolved == None` leg of [`Self::run_instance_method_celled`],
+    /// extracted (ADR-0019 E9c-2) so a proto `{*}` redispatch's own
+    /// boundary-resolved no-match
+    /// (`resolve_method_within_boundary` returning `None`) can reuse the same
+    /// error-shape logic with its own `boundary_owner` instead of by-name
+    /// re-entering the whole dispatch pipeline. `boundary_owner` narrows the
+    /// `X::Multi::NoMatch` candidate listing exactly as
+    /// `resolve_method_with_owner_impl`'s own boundary narrowed the walk that
+    /// failed to resolve; ordinary dispatch passes `None`.
+    pub(crate) fn instance_method_not_found(
+        &mut self,
+        receiver_class_name: &str,
+        method_name: &str,
+        args: Vec<Value>,
+        inv_value: Value,
+        boundary_owner: Option<Symbol>,
+    ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
+        // Distinguish X::Multi::NoMatch (method exists but no candidate
+        // matched) from X::Method::NotFound (method does not exist at all,
+        // e.g. submethod on ancestor only).
+        let has_visible_method = self.class_mro(receiver_class_name).iter().any(|cn| {
+            self.registry()
+                .classes
+                .get(cn.as_str())
+                .and_then(|c| c.methods.get(method_name))
+                .is_some_and(|ovs| {
+                    let is_ancestor = cn.as_str() != receiver_class_name;
+                    ovs.iter()
+                        .any(|d| !d.is_private && (!d.is_my || !is_ancestor))
+                })
+        });
+        if has_visible_method {
+            // `self.new(:named)` on a concrete invocant whose class declares
+            // user multi `new` candidates that don't match: Mu.new(*%attrinit)
+            // is always available as a fallback multi candidate, exactly as
+            // `dispatch_new` provides for type-object targets. An explicit
+            // `proto method new` owns dispatch, so no fallback then. Gated on
+            // a concrete invocant: `dispatch_new`'s own user-new probe runs
+            // with a Package invocant and must surface no-match to reach its
+            // default-constructor fall-through (not recurse through here).
+            if method_name == "new"
+                && matches!(
+                    inv_value.view(),
+                    ValueView::Instance { .. } | ValueView::Mixin(..)
+                )
+                && self
+                    .lookup_proto_method(receiver_class_name, "new")
+                    .is_none()
+                && args
+                    .iter()
+                    .all(|a| matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
+            {
+                let v = self.dispatch_new(
+                    Value::package(crate::symbol::Symbol::intern(receiver_class_name)),
+                    args,
+                )?;
+                return Ok((v, None));
+            }
+            let sigs = self.format_method_candidate_signatures(
+                receiver_class_name,
+                method_name,
+                boundary_owner,
+            );
+            let profile = self.format_call_arg_profile(&args);
+            let concrete = !matches!(inv_value.view(), ValueView::Package(_));
+            return Err(
+                super::methods_signature_errors::make_multi_no_match_error_detailed(
+                    method_name,
+                    receiver_class_name,
+                    concrete,
+                    &profile,
+                    &sigs,
+                ),
+            );
+        }
+        // A field read on an `is repr('CStruct')` handle: the instance
+        // carries the C pointer, so resolve the name against the struct's
+        // declared field layout and read it out of native memory
+        // (`$ssl.server`, `nativecast(evp_cipher_st, $c).key_len`). The
+        // class declares the fields as attributes but has no storage for
+        // them, so accessor resolution reaches here.
+        if args.is_empty()
+            && let Some(field) = self.cstruct_field_value(&inv_value, method_name)
+        {
+            return Ok((field, None));
+        }
+        let type_name = receiver_class_name.to_string();
+        Err(
+            super::methods_signature_errors::make_method_not_found_error(
+                method_name,
+                &type_name,
+                false,
+            ),
+        )
+    }
+
+    /// The `resolved == Some((owner_class, method_def))` leg of
+    /// [`Self::run_instance_method_celled`], extracted (ADR-0019 E9c-2) so a
+    /// proto `{*}` redispatch can invoke an ALREADY-resolved winning
+    /// candidate (from `resolve_method_within_boundary`) through the exact
+    /// same run path ordinary dispatch uses — native-call check, ambiguous
+    /// check, wrap-chain interception, MRO deferral-tail frame push, and the
+    /// compiled run leg — instead of re-entering the whole dispatch pipeline
+    /// by name. `boundary_owner` narrows the `X::Multi::Ambiguous` candidate
+    /// listing exactly as the resolution that produced `method_def` was
+    /// itself narrowed; ordinary dispatch passes `None`.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn run_resolved_instance_method(
+        &mut self,
+        receiver_class_name: &str,
+        attributes: &AttrMap,
+        method_name: &str,
+        args: Vec<Value>,
+        invocant: Option<Value>,
+        inv_value: Value,
+        owner_class: Symbol,
+        method_def: MethodDef,
+        boundary_owner: Option<Symbol>,
+    ) -> Result<(Value, Option<AttrMap>), RuntimeError> {
         // An `is native(...)` method: its body is the `{ * }` stub, and the
         // call belongs to NativeCall. Keyed by the class that *declared* it, so
         // an inherited native method resolves to the owner's descriptor.
@@ -267,7 +332,11 @@ impl Interpreter {
         // specific. Raise X::Multi::Ambiguous rather than silently choosing.
         if self.dispatch_ambiguous {
             self.dispatch_ambiguous = false;
-            let sigs = self.format_method_candidate_signatures(receiver_class_name, method_name);
+            let sigs = self.format_method_candidate_signatures(
+                receiver_class_name,
+                method_name,
+                boundary_owner,
+            );
             return Err(super::methods_signature_errors::make_multi_ambiguous_error(
                 method_name,
                 receiver_class_name,

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -301,8 +301,14 @@ impl Interpreter {
     /// `call_method_with_values`. If `target`'s class (or an ancestor) declares a
     /// `proto method`/`proto submethod` body for `method`, run that body (its
     /// `{*}` dispatches to the matching multi candidate) and return `Some(result)`.
-    /// Returns `None` when the caller should dispatch normally — including the
-    /// one-shot redispatch case, where the `proto_method_skip` flag is consumed.
+    /// Returns `None` when the caller should dispatch normally.
+    ///
+    /// ADR-0019 E9c-2: `{*}`'s redispatch no longer re-enters this interception
+    /// by name (`call_proto_dispatch`'s method branch resolves the winning
+    /// candidate directly via `resolve_method_within_boundary` and invokes it
+    /// through the ordinary resolved-method run leg), so the former one-shot
+    /// `proto_method_skip` guard that used to suppress re-interception here has
+    /// no re-entry left to guard against and was deleted.
     ///
     /// TODO: methods reached via `handles` delegation forwarders run through
     /// `assign_method_lvalue_with_values` rather than the method-call op handlers
@@ -318,10 +324,6 @@ impl Interpreter {
             ValueView::Instance { class_name, .. } => class_name.resolve(),
             _ => return None,
         };
-        if self.proto_method_skip.as_deref() == Some(method) {
-            self.proto_method_skip = None;
-            return None;
-        }
         let (owner, proto) = self.lookup_proto_method(&cn, method)?;
         // env_dirty substrate (docs/captured-outer-cell-sharing.md §10): a multi
         // candidate dispatched through the proto body's `{*}` runs via the slow

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -19,6 +19,54 @@ impl Interpreter {
         // `proto_redispatch_boundary` field. No re-entry is left to guard
         // against, so the former one-shot `proto_method_skip` flag is gone too.
         if let Some(ctx) = method_ctx {
+            // ADR-0019 E9c-2 fix: Junction auto-threading. The pre-E9c-2
+            // by-name re-entry into `call_method_with_values` incidentally
+            // provided this — that function's own top-of-body Junction check
+            // (`methods_call_dispatch.rs`) fired on the re-entry's `args`,
+            // which for a slurpy `proto method f(|) {*}` are exactly the
+            // outer call's original arguments (still containing an
+            // unresolved Junction whenever the OUTER call reached here via a
+            // fast/compiled path that itself never autothreaded). Direct
+            // resolution has no such incidental checkpoint, so a Junction
+            // argument reaching `{*}` — e.g. `self.contains-spec(any(@specs),
+            // :$strict)` recursing through `Zef::Distribution`'s
+            // `proto method contains-spec` — failed to resolve against any
+            // concrete-typed multi candidate. Restored explicitly here,
+            // mirroring `methods_call_dispatch.rs`'s own target/arg checks.
+            if Self::should_autothread_method(&proto_name) {
+                if let ValueView::Junction { kind, values } = ctx.invocant.view() {
+                    let mut results = Vec::with_capacity(values.len());
+                    for value in values.iter() {
+                        results.push(self.call_method_with_values(
+                            value.clone(),
+                            &proto_name,
+                            args.clone(),
+                        )?);
+                    }
+                    return Ok(Value::junction(kind, results));
+                }
+                if let Some((idx, kind, values)) = args.iter().enumerate().find_map(|(idx, arg)| {
+                    if !arg.is_junction_value() {
+                        return None;
+                    }
+                    match arg.view() {
+                        ValueView::Junction { kind, values } => Some((idx, kind, values.clone())),
+                        _ => None,
+                    }
+                }) {
+                    let mut results = Vec::with_capacity(values.len());
+                    for value in values.iter() {
+                        let mut threaded_args = args.clone();
+                        threaded_args[idx] = value.clone();
+                        results.push(self.call_method_with_values(
+                            ctx.invocant.clone(),
+                            &proto_name,
+                            threaded_args,
+                        )?);
+                    }
+                    return Ok(Value::junction(kind, results));
+                }
+            }
             // `{*}` rw-redispatch for a proto *method* (ledger §D): like the proto
             // *sub* path (`vm_call_proto_dispatch`), Rakudo redispatches with the
             // proto's CURRENT (body-mutated) parameter, and a candidate's `is rw`

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -9,8 +9,15 @@ impl Interpreter {
             .cloned()
             .ok_or_else(|| RuntimeError::new("{*} used outside proto".to_string()))?;
         // `proto method` body: `{*}` redispatches to the matching multi *method*
-        // candidate on the invocant. The one-shot `proto_method_skip` flag makes
-        // the re-entry bypass proto interception so it reaches the real candidate.
+        // candidate on the invocant.
+        //
+        // ADR-0019 E9c-2: resolves the winning candidate DIRECTLY within the
+        // governing boundary (`resolve_method_within_boundary`) and invokes it
+        // through the same resolved-method run path ordinary dispatch uses
+        // (`run_resolved_instance_method`), instead of the former by-name
+        // re-entry into `call_method_with_values` bracketed by the ambient
+        // `proto_redispatch_boundary` field. No re-entry is left to guard
+        // against, so the former one-shot `proto_method_skip` flag is gone too.
         if let Some(ctx) = method_ctx {
             // `{*}` rw-redispatch for a proto *method* (ledger §D): like the proto
             // *sub* path (`vm_call_proto_dispatch`), Rakudo redispatches with the
@@ -23,8 +30,15 @@ impl Interpreter {
             // which is exactly that frame at the `{*}`/`__PROTO_DISPATCH__` point) so
             // `proto_rw_redispatch_args` reads slot-first. Gate OFF keeps `None`
             // (env mirrors the slot, byte-identical).
+            //
+            // `invocant_class` covers both an `Instance` (the ordinary
+            // `proto method` case, always reached via `try_proto_method_body`'s
+            // Instance-only gate) and a `Package` type object (the `.new`
+            // constructor-proto case, `dispatch_new` -> `run_proto_method`) so
+            // the governing owner can be re-derived for either shape.
             let invocant_class = match ctx.invocant.view() {
                 ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
+                ValueView::Package(name) => Some(name.resolve()),
                 _ => None,
             };
             let proto_body_code: Option<&CompiledCode> = if self.current_code != 0 {
@@ -39,39 +53,74 @@ impl Interpreter {
             // (`lookup_proto_method`'s MRO walk stops at the nearest EXPLICIT
             // proto, whether that is the receiver's own class or an
             // ancestor's). It doubles as the candidate-set boundary below.
-            let owner_and_proto =
-                invocant_class.and_then(|cn| self.lookup_proto_method(&cn, &proto_name));
+            let owner_and_proto = invocant_class
+                .as_deref()
+                .and_then(|cn| self.lookup_proto_method(cn, &proto_name));
             let (args, rw_sources) = match owner_and_proto.as_ref().and_then(|(_, proto)| {
                 self.proto_rw_redispatch_args(&proto.param_defs, &args, proto_body_code)
             }) {
                 Some((rebuilt, sources)) => (rebuilt, Some(sources)),
                 None => (args, None),
             };
-            self.proto_method_skip = Some(proto_name.clone());
+            let Some((owner, _)) = owner_and_proto else {
+                // No governing owner could be re-derived from the invocant (an
+                // exotic non-Instance/non-Package view). Preserve the pre-E9c-2
+                // fallback: an untruncated by-name redispatch.
+                // `try_proto_method_body`'s Instance-only gate means this can
+                // never actually re-intercept for such an invocant.
+                if rw_sources.is_some() {
+                    self.set_pending_call_arg_sources(rw_sources);
+                } else if ctx.call_arg_sources.is_some() {
+                    self.set_pending_call_arg_sources(ctx.call_arg_sources.clone());
+                }
+                return self.call_method_with_values(ctx.invocant, &proto_name, args);
+            };
+            // "Part B", shrunk to a tight scope immediately before the
+            // resolved-method invocation (formerly it spanned the whole
+            // by-name re-dispatch pipeline): restore the original call site's
+            // argument sources so an `is rw` candidate can bind through.
             if rw_sources.is_some() {
                 self.set_pending_call_arg_sources(rw_sources);
             } else if ctx.call_arg_sources.is_some() {
-                // The proto declares no rw parameter of its own (`proto method
-                // f(|) {*}` is the common shape), so nothing was rebuilt — but
-                // the ORIGINAL call site's argument sources still decide whether
-                // an `is rw` candidate is eligible. Running the proto body has
-                // long since cleared them, so restore them here.
                 self.set_pending_call_arg_sources(ctx.call_arg_sources.clone());
             }
-            // Fresh-candidate-set boundary (this ticket): restrict the
-            // redispatch to multi candidates declared at or below the
-            // proto's declaring class in the MRO — see the field doc on
-            // `Interpreter::proto_redispatch_boundary`. Bracket-style: save
-            // and restore rather than a one-shot flag, so a candidate that
-            // itself triggers a nested proto method redispatch doesn't
-            // clobber this outer boundary.
-            let saved_boundary = self.proto_redispatch_boundary;
-            self.proto_redispatch_boundary = owner_and_proto
-                .as_ref()
-                .map(|(owner, _)| (Symbol::intern(&proto_name), Symbol::intern(owner)));
-            let result = self.call_method_with_values(ctx.invocant, &proto_name, args);
-            self.proto_redispatch_boundary = saved_boundary;
-            return result;
+            let boundary_owner = Some(Symbol::intern(&owner));
+            let receiver_class_name = invocant_class.expect("owner_and_proto implies Some");
+            let attributes = match ctx.invocant.view() {
+                ValueView::Instance { attributes, .. } => attributes.as_map().clone(),
+                _ => crate::value::AttrMap::new(),
+            };
+            let resolved = self.resolve_method_within_boundary(
+                &receiver_class_name,
+                &proto_name,
+                &args,
+                Some(&ctx.invocant),
+                boundary_owner,
+            );
+            return match resolved {
+                Some((resolved_owner, method_def)) => self
+                    .run_resolved_instance_method(
+                        &receiver_class_name,
+                        &attributes,
+                        &proto_name,
+                        args,
+                        Some(ctx.invocant.clone()),
+                        ctx.invocant,
+                        resolved_owner,
+                        method_def,
+                        boundary_owner,
+                    )
+                    .map(|(v, _)| v),
+                None => self
+                    .instance_method_not_found(
+                        &receiver_class_name,
+                        &proto_name,
+                        args,
+                        ctx.invocant,
+                        boundary_owner,
+                    )
+                    .map(|(v, _)| v),
+            };
         }
         self.clear_pending_dispatch_error();
         let Some(def) = self.resolve_proto_candidate_with_types(&proto_name, &args) else {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1174,27 +1174,6 @@ pub struct Interpreter {
     /// `{*}` redispatches to a multi *method* candidate on the invocant rather
     /// than a proto sub candidate.
     proto_dispatch_stack: Vec<(String, Vec<Value>, Option<ProtoMethodCtx>)>,
-    /// One-shot guard set by a proto method's `{*}` redispatch: the next method
-    /// call of this name bypasses proto-body interception (so it reaches the
-    /// real multi candidate). Recursive calls from within the candidate, which
-    /// happen after this flag is consumed, run the proto body again (matching raku).
-    pub(crate) proto_method_skip: Option<String>,
-    /// Owner-class boundary for an EXPLICIT `proto method`'s `{*}` redispatch
-    /// (`(method_name, owner_class)`). An explicit `proto method` declared on
-    /// some class in the MRO starts a fresh candidate set: its `{*}`
-    /// redispatch may only see multi candidates declared at or below that
-    /// class in the MRO, never a candidate from an ancestor beyond it (a
-    /// parent's own multi candidates of the same name are NOT inherited
-    /// through a child's explicit proto — the inverse, a proto in a PARENT
-    /// governing candidates a child adds with no proto of its own, still
-    /// works because the "owner" found by `lookup_proto_method` is that
-    /// ancestor, and the whole tail from the receiver down through it stays
-    /// in scope). Set bracket-style by `call_proto_dispatch`'s method_ctx
-    /// branch immediately around the redispatch call (saved/restored, not a
-    /// one-shot consumed flag, so nested proto redispatches — a candidate
-    /// that itself triggers another proto method — do not clobber an outer
-    /// boundary). Consulted by `resolve_method_with_owner_impl`'s MRO walk.
-    pub(crate) proto_redispatch_boundary: Option<(Symbol, Symbol)>,
     pending_dispatch_error: Option<RuntimeError>,
     /// Distribution selectors (`:ver`/`:auth`/`:api`) of the `use` currently
     /// being resolved, split off the module name by `use_module_with_tags` and

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -100,7 +100,7 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Option<(Symbol, MethodDef)> {
-        self.resolve_method_with_owner_impl(class_name, method_name, arg_values, None)
+        self.resolve_method_with_owner_impl(class_name, method_name, arg_values, None, None)
     }
 
     pub(crate) fn resolve_method_with_owner_invocant(
@@ -110,7 +110,47 @@ impl Interpreter {
         arg_values: &[Value],
         invocant: &Value,
     ) -> Option<(Symbol, MethodDef)> {
-        self.resolve_method_with_owner_impl(class_name, method_name, arg_values, Some(invocant))
+        self.resolve_method_with_owner_impl(
+            class_name,
+            method_name,
+            arg_values,
+            Some(invocant),
+            None,
+        )
+    }
+
+    /// Same as [`Self::resolve_method_with_owner_invocant`], but restricts the
+    /// MRO walk to `boundary_owner`'s class and everything below it (i.e. the
+    /// receiver's own class down through `boundary_owner`, inclusive) —
+    /// ancestors beyond `boundary_owner` are not visible, even though they
+    /// would be reachable in an ordinary (non-proto) multi-method dispatch.
+    ///
+    /// ADR-0019 E9c-2: this is the direct-resolution replacement for an
+    /// EXPLICIT `proto method`'s `{*}` redispatch (formerly a by-name
+    /// re-entry into `call_method_with_values` bracketed by the ambient
+    /// `proto_redispatch_boundary` field, which this parameter replaces). See
+    /// `todo/tickets/explicit-child-proto-assumes-parent-candidates.md` for
+    /// why the boundary exists at all: an explicit `proto method` on some
+    /// class in the MRO starts a fresh candidate set that does NOT inherit an
+    /// ancestor's candidates of the same name (the inverse — a proto in a
+    /// PARENT governing candidates a child adds with no proto of its own —
+    /// still works, because `boundary_owner` is then that ancestor and the
+    /// whole tail from the receiver down through it stays in scope).
+    pub(crate) fn resolve_method_within_boundary(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+        arg_values: &[Value],
+        invocant: Option<&Value>,
+        boundary_owner: Option<Symbol>,
+    ) -> Option<(Symbol, MethodDef)> {
+        self.resolve_method_with_owner_impl(
+            class_name,
+            method_name,
+            arg_values,
+            invocant,
+            boundary_owner,
+        )
     }
 
     fn resolve_method_with_owner_impl(
@@ -119,25 +159,13 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
         invocant: Option<&Value>,
+        boundary_owner: Option<Symbol>,
     ) -> Option<(Symbol, MethodDef)> {
         self.dispatch_ambiguous = false;
         let role_bindings = self.registry().get_role_param_bindings(class_name);
         let mro_full = self.class_mro(class_name);
-        // An explicit `proto method`'s `{*}` redispatch starts a fresh
-        // candidate set (todo/tickets/explicit-child-proto-assumes-parent-
-        // candidates.md): when `proto_redispatch_boundary` names THIS
-        // method and its declaring class is in this MRO, only classes at or
-        // below that owner (i.e. the receiver's own class down through the
-        // owner, inclusive) are visible — an ancestor beyond the owner is
-        // not, even though it would be reachable in an ordinary (non-proto)
-        // multi-method dispatch. See the field doc on
-        // `Interpreter::proto_redispatch_boundary`.
-        let truncate_at: Option<usize> = match self.proto_redispatch_boundary {
-            Some((boundary_method, owner)) if boundary_method == Symbol::intern(method_name) => {
-                mro_full.iter().position(|s| *s == owner)
-            }
-            _ => None,
-        };
+        let truncate_at: Option<usize> =
+            boundary_owner.and_then(|owner| mro_full.iter().position(|s| *s == owner));
         let mro: &[Symbol] = match truncate_at {
             Some(pos) => &mro_full[..=pos],
             None => &mro_full[..],
@@ -749,9 +777,13 @@ impl Interpreter {
         let mut matches = Vec::new();
         let mut any_failed = false;
         for cn in &defining_levels {
-            if let Some(resolved) =
-                self.resolve_method_with_owner_impl(cn.as_str(), method_name, arg_values, None)
-            {
+            if let Some(resolved) = self.resolve_method_with_owner_impl(
+                cn.as_str(),
+                method_name,
+                arg_values,
+                None,
+                None,
+            ) {
                 matches.push(resolved);
             } else {
                 any_failed = true;

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2191,8 +2191,6 @@ impl Interpreter {
             },
             registry_write_gen: std::sync::atomic::AtomicU64::new(0),
             proto_dispatch_stack: Vec::new(),
-            proto_method_skip: None,
-            proto_redispatch_boundary: None,
             pending_dispatch_error: None,
             pending_dist_selectors: Vec::new(),
             pending_use_export_args: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -499,8 +499,6 @@ impl Interpreter {
             registry: Arc::new(RwLock::new(Arc::clone(&self.registry.read().unwrap()))),
             registry_write_gen: std::sync::atomic::AtomicU64::new(0),
             proto_dispatch_stack: Vec::new(),
-            proto_method_skip: None,
-            proto_redispatch_boundary: None,
             pending_dispatch_error: None,
             pending_dist_selectors: Vec::new(),
             pending_use_export_args: None,

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1742,8 +1742,9 @@ impl Interpreter {
             // `{*}` outside a proto — let the interpreter raise the proper error.
             return self.loan_env_for(|i| i.call_proto_dispatch());
         };
-        // `proto method` redispatch needs the invocant + one-shot `proto_method_skip`
-        // bookkeeping the interpreter owns; only proto *subs* run compiled here.
+        // `proto method` redispatch needs the invocant + the boundary-resolved
+        // dispatch (ADR-0019 E9c-2) the interpreter owns; only proto *subs* run
+        // compiled here.
         if method_ctx.is_some() {
             return self.loan_env_for(|i| i.call_proto_dispatch());
         }

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -367,7 +367,7 @@ impl Interpreter {
             // well. Raise X::Multi::Ambiguous instead of silently picking one.
             if self.dispatch_ambiguous {
                 self.dispatch_ambiguous = false;
-                let sigs = self.format_method_candidate_signatures(cn, method);
+                let sigs = self.format_method_candidate_signatures(cn, method, None);
                 return Err(
                     crate::runtime::methods_signature_errors::make_multi_ambiguous_error(
                         method, cn, &sigs,


### PR DESCRIPTION
## Summary

- Replaces a proto method's `{*}` by-name re-entry (two `lookup_proto_method` walks, the one-shot `proto_method_skip` flag, the ambient `proto_redispatch_boundary` field bracketed around the whole re-dispatch pipeline) with a direct resolver: `resolve_method_within_boundary(receiver_class, method_name, args, invocant, boundary_owner)` picks the winning candidate in one MRO walk, truncated to the governing proto's owner as an explicit parameter instead of ambient interpreter state.
- The resolved winner runs through the SAME resolved-method path ordinary dispatch uses: `run_instance_method_celled`'s two legs are extracted into `instance_method_not_found` and `run_resolved_instance_method` (native-call check, ambiguous check, wrap-chain interception, MRO deferral-tail frame push, compiled run leg), both taking an optional `boundary_owner` so a proto redispatch's diagnostics narrow the same way the resolution itself was narrowed.
- Deleted: `proto_method_skip`, `proto_redispatch_boundary` (field + init/fork sites + save/restore bracket).
- Untouched (explicitly out of scope, per the design doc): `samewith` (P3 already confirmed its by-name restart is correct — this box only consolidated its storage in E9c-1, #6372), the VM `{*}` arm (still delegates the method case to the interpreter), the sub branch of `call_proto_dispatch`, the sub-side `multi_dispatch_stack`, and the P4 type-object-invocant bug (`todo/tickets/proto-method-body-skipped-for-type-object-invocant.md` — a different, adjacent bug in `try_proto_method_body`'s interception gate).

This is ADR-0019 Phase E box E9c's second and final slice — see `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`'s "E9c design" section. E9b (PRs #6361/#6363/#6369) and E9c-1 (#6372) closed earlier this session.

## Test plan

- [x] `t/proto-*.t`, `t/multi-*.t`, `t/samewith-*.t`, `t/wrap*.t`, `t/method-wrap-*.t`, `t/defer-*.t`, `t/nextsame-role-mixin.t`, `t/lastcall-*.t` — 82 files, 646 tests, all green
- [x] Full local `make test` (3125 files) — green
- [x] Full local `make roast` (1436 files, 218836 tests) — per CLAUDE.md's house rule for a real dispatch-path rewrite — green
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check` — clean
- [ ] CI (`make test` + `make roast`) — watching

🤖 Generated with [Claude Code](https://claude.com/claude-code)