### PR TITLE
feat(dispatch): ADR-0019 E10 -- method wrap chains move into the registry

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -3838,7 +3838,7 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   the highest-semantic-risk box of the whole phase (拙速厳禁) — it must run as its own dedicated
   session, not be attempted inline here, and is required before any E9a/b/c cursor cutover work
   starts.
-- [ ] **E9 — Add resolver cursors for `samewith`/`nextsame`/`callsame`/`nextwith`.** Continue within
+- [x] **E9 — Add resolver cursors for `samewith`/`nextsame`/`callsame`/`nextwith`.** Continue within
   the resolved sequence instead of re-entering name-based resolution.
   **Design 2026-08-10** (same doc): one `DispatchCursor {seq, next, invocant, args}` replaces
   the recomputed `MethodDispatchFrame.remaining` + fingerprint winner-removal; wrap chains
@@ -4008,13 +4008,98 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   have to remember it. Full `t/` + targeted roast (`S06-advanced/*`,
   `S06-multi/*`, `S12-methods/{defer-call,defer-next,multi}.t`) green with no
   new pin (behavior is unchanged by construction).
-- [ ] **E10 — Move wrap/unwrap mutation into canonical entries.** Bump the generation and remove
+  **Progress 2026-08-13 (same day) — E9b-2 landed, the wrap-prefix cutover.**
+  Both method-wrap entry sites (interpreter `class_dispatch.rs` and VM
+  `vm_call_method_compiled.rs`) now build a SINGLE `MethodDispatchFrame` whose
+  `remaining` is `[Wrapper(prefix)..., Candidate(winner, wraps_spliced:
+  true), ...MRO tail]`, instead of a separate `WrapDispatchFrame` plus a
+  synthetic "original" sub re-entered by name. Deleted: the `sub_id == 0`
+  method-wrap sentinel and its exhaustion fallthrough, the
+  `__mutsu_method_wrap_original` marker and its by-name re-entry leg, the
+  global `is_inside_wrap_dispatch()` guards at both entry sites, the old
+  mid-MRO peek-and-intercept block (replaced by the lazy splice at advance
+  time E9b-1 already wired up), and the #6349 `wrap_chain_exhausted` bool.
+  Fixes P1 (`wrap-chain-skipped-inside-foreign-wrap-dispatch.md`): a wrapped
+  method called from inside a DIFFERENT method's wrapper no longer loses its
+  own wrap chain, since no global guard remains to suppress it. Pinned by
+  `t/wrap-chain-foreign-wrapper-not-shadowed.t`.
+  **Progress 2026-08-13 (same day) — E9c-1 landed, samewith carrier
+  consolidation.** Merges the two parallel stacks `samewith_context_stack:
+  Vec<(String, Option<Value>)>` and `samewith_call_args_stack: Vec<Vec<Value>>`
+  into one `Vec<SamewithContext { name, invocant, args }>`: several raw push
+  sites (`methods_mixin_dispatch.rs`, `dispatch_proto_call.rs`,
+  `builtins_operators_fallback.rs`, `builtins_dispatch_next.rs`, and the VM sub
+  paths) used to push only the context stack, leaving the args stack free to
+  pair with a stale, deeper context entry. Folding args into the same struct
+  makes that desync structurally impossible. Mechanical, zero behavior change.
+  **Progress 2026-08-13 (same day) — E9c-2 landed, direct proto `{*}`
+  resolution.** Replaces the by-name re-entry a proto method's `{*}` used for
+  redispatch (two `lookup_proto_method` walks, the one-shot
+  `proto_method_skip` flag, the ambient `proto_redispatch_boundary` field
+  bracketed around the whole re-dispatch pipeline) with a direct resolver,
+  `resolve_method_within_boundary(receiver_class, method_name, args,
+  invocant, boundary_owner)`, which picks the winning candidate in one MRO
+  walk truncated to the governing proto's owner —
+  `resolve_method_with_owner_impl`'s boundary parameter now expresses that
+  explicitly instead of reading ambient interpreter state. The resolved
+  winner runs through the same resolved-method path ordinary dispatch uses
+  (`run_instance_method_celled`'s two legs extracted into
+  `instance_method_not_found`/`run_resolved_instance_method`). Same-answer
+  mechanism swap against #6355 semantics; the earlier falsified `samewith`
+  design clause (§ decision 2 note above) is unaffected — `samewith` still
+  re-enters by name.
+  **Both E9b and E9c are now fully landed** (slice order E9b-0 → E9b-1 →
+  E9b-2 → E9c-1 → E9c-2, all merged 2026-08-13: #6361/#6363/#6369/#6372/#6375).
+  The `DispatchCursor{seq, next, invocant, args}` index-based rewrite
+  mentioned in the box's opening design remains explicitly out of scope (E9a's
+  progress note called it "orthogonal perf/cleanliness work, left for a
+  follow-up slice") — every load-bearing piece of E9's own scope (wrap
+  chains as cursor-prefix entries, proto `{*}` re-ranking instead of by-name
+  re-entry, and the deferral-order redraw from E9-pre/E9a) is done through
+  other means (`DeferralEntry`, `resolve_method_within_boundary`,
+  `resolve_deferral_expansion`), so this box closes here.
+- [x] **E10 — Move wrap/unwrap mutation into canonical entries.** Bump the generation and remove
   wrap-specific cache-clearing paths.
   **Design 2026-08-10** (same doc): `method_wrap_chains` moves into the registry; every
   wrap/unwrap/restore path — including the two that currently invalidate nothing — bumps
   `method_generation`; the global `has_any_wrap_chains()` prefilter (which disables the fast
   cache program-wide once any wrap exists) is deleted after E3; the `.unwrap` method-wrap leak
   is fixed en route.
+  **Progress 2026-08-13 — E10 landed.** `Registry::method_wrap_chains` replaces the
+  Interpreter-level `HashMap<(String,String,usize), Vec<(u64,Value)>>`; every mutation
+  (`push_method_wrap`/`pop_method_wrap`/`remove_method_wrap`/
+  `clear_method_wrap_chains_for_class`) now bumps `method_generation`, including the two push
+  sites that previously invalidated nothing at all (the `^lookup(...).candidates[N].wrap(...)`
+  Sub path and the `.^methods(:local)` `Method`-instance path). The one real "fast cache"
+  gate — `vm_call_method_compiled_interpret.rs`'s `!self.has_any_wrap_chains() &&` guard on
+  `fast_method_cache`, which disabled that cache for EVERY method call program-wide the instant
+  ANY method anywhere was wrapped — is deleted: `try_populate_fast_cache` is only ever reached
+  after `check_method_wrap_chain` has already returned `None` for that exact method, so a
+  wrapped method is never cached there in the first place, and a later wrap on a
+  previously-cached method evicts the stale entry via the generation bump
+  (`refresh_method_caches_for_generation`, already called just above). The other
+  `has_any_wrap_chains()` call sites (`class_dispatch.rs`, `ctor_phase_plan.rs`,
+  `builtins_dispatch_next.rs`, `check_method_wrap_chain` itself) guard a live
+  `find_method_candidate_index` scan rather than a cache and stay — they were never the
+  "program-wide" problem, and reproving that live scan every call would only cost, not gain.
+  **Fixed the `.unwrap` method-wrap leak**, confirmed against Rakudo v2026.06 first
+  (`Foo.^lookup('bar').candidates[0].wrap(...)` then `.restore`/`.unwrap($handle)`): neither
+  ever actually removed the `method_wrap_chains` entry before this fix.
+  `.restore()` looked in the sub-level `wrap_chains` map under a `"sub-id"` attribute that a
+  method-candidate `WrapHandle` never populated meaningfully (it held the candidate SUB's own
+  id, unrelated to the class-keyed chain it was actually stored under), so it silently did
+  nothing and still returned `Ok(TRUE)`; `.unwrap()` on the candidate itself never even checked
+  for the `^lookup` markers, so it fell straight to sub-level logic and always raised "not
+  wrapped". Fixed by giving a method-candidate `WrapHandle` its own attribute shape
+  (`wrap-class`/`wrap-method`/`wrap-candidate-idx`, built by the new
+  `method_wrap_handle_attrs` helper shared between the Sub and `Method`-instance wrap sites) and
+  teaching `.restore()`/`.unwrap()` to route through `Registry::remove_method_wrap`/
+  `pop_method_wrap` when those attributes are present. New pin:
+  `t/wrap-candidate-unwrap-restore.t` (10 assertions, raku-verified, including the multi-candidate
+  case). `cargo build`/`clippy -D warnings`/`fmt` clean; full local `make test` (3128 files, 29005
+  tests) and the targeted wrap/dispatch suite
+  (`roast/S06-advanced/{dispatching,wrap}.t`, `roast/S14-traits/routines.t`,
+  `roast/integration/failure-and-callsame.t`, `t/wrap.t`, `t/wrap-closure-capture.t`) green.
 - [ ] **E11 — Retire arity-specific lookup entry points.** Keep native arity functions only as
   handler implementations selected by `MethodEntry`.
   **Design 2026-08-10** (same doc): grep-based completion criterion — no caller of

--- a/news/2026-08/adr0019-e10-wrap-registry-and-unwrap-leak.md
+++ b/news/2026-08/adr0019-e10-wrap-registry-and-unwrap-leak.md
@@ -1,0 +1,70 @@
+# ADR-0019 E10: method wrap chains move into the registry, and `.restore()` stops lying
+
+ADR-0019's Phase E box E10 asked for two things: move `method_wrap_chains` (the
+side table backing `.wrap()` on a method *candidate* obtained via
+`^lookup(...).candidates[N]`) into the canonical `Registry`, and delete the
+`has_any_wrap_chains()` prefilter that disabled a hot dispatch cache for the
+*entire program* the instant any method anywhere got wrapped. Doing the move
+surfaced a real, previously-untested bug along the way: `.restore()` and
+`.unwrap()` on a method-candidate wrap handle never actually removed the
+wrapper.
+
+## The program-wide cache gate
+
+`vm_call_method_compiled_interpret.rs`'s hot dispatch path keeps a
+`fast_method_cache` keyed by `(class, method)`, generation-checked against
+`Registry::method_generation` so it clears automatically whenever a class,
+role, or method table changes. Before this box, the cache read was also gated
+on `!self.has_any_wrap_chains()` — a cheap `HashMap::is_empty()` check, but a
+*global* one: if a single method anywhere in the whole program had ever been
+wrapped, every other method call, wrapped or not, fell off the fast path and
+paid the full resolve-and-dispatch machinery.
+
+The gate is gone now. It turns out to be unnecessary once wrap mutations bump
+`method_generation` like every other canonical dispatch write: a method is
+only ever inserted into `fast_method_cache` after `check_method_wrap_chain`
+has already returned `None` for it, so a wrapped method is never cached in the
+first place, and wrapping a method that *was* cached evicts the stale entry
+through the same generation bump that already clears the cache on any other
+registry mutation. The other `has_any_wrap_chains()` call sites
+(`class_dispatch.rs`, `ctor_phase_plan.rs`, `builtins_dispatch_next.rs`,
+`check_method_wrap_chain` itself) guard a live `find_method_candidate_index`
+scan, not a cache, so they stay — removing them would only add cost for
+programs with no wraps at all.
+
+## The leak
+
+Confirming the design against Rakudo first surfaced a bug the design doc had
+flagged but not diagnosed:
+
+```raku
+class Foo { method bar($x) { $x * 2 } }
+my $inst = Foo.new;
+my $wh = Foo.^lookup('bar').candidates[0].wrap(-> $self, $x { callsame() + 100 });
+say $inst.bar(5);   # 110
+$wh.restore;
+say $inst.bar(5);   # raku: 10 -- mutsu (before this fix): 110
+```
+
+`.restore()`'s implementation only knew how to remove an entry keyed by
+sub-id from the sub-level `wrap_chains` map. A method-candidate `WrapHandle`
+never populated a meaningful `"sub-id"` — it held the candidate `Sub`'s own
+identity, which has nothing to do with the `(class, method, candidate_idx)`
+key its wrapper actually lived under in `method_wrap_chains` — so the lookup
+always missed, `.restore()` silently did nothing, and still returned `True`.
+`.unwrap($handle)` called directly on the candidate was worse: it never even
+checked for the `^lookup` markers that `.wrap()` itself uses to detect a
+candidate, so it fell straight through to sub-level logic and unconditionally
+raised "not wrapped".
+
+The fix gives a method-candidate `WrapHandle` its own attribute shape
+(`wrap-class`/`wrap-method`/`wrap-candidate-idx`, plus the shared
+`handle-id`), built by one helper shared between the `Sub`-from-`^lookup` wrap
+site and the `Method`-instance wrap site (`.^methods(:local)`). `.restore()`
+and `.unwrap()` now check for those attributes first and route through
+`Registry::remove_method_wrap`/`pop_method_wrap`, which remove the entry and
+bump `method_generation` in one step — the same mutation path `push_method_wrap`
+already used, so there's exactly one place that knows how to touch this table.
+
+Pin: `t/wrap-candidate-unwrap-restore.t`, 10 assertions verified against
+Rakudo v2026.06 first, including the multi-candidate case.

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -1021,7 +1021,7 @@ impl Interpreter {
     }
 
     pub(crate) fn has_any_wrap_chains(&self) -> bool {
-        !self.method_wrap_chains.is_empty()
+        self.registry().has_any_method_wrap_chains()
     }
 
     pub(crate) fn push_wrap_dispatch_frame(&mut self, mut frame: super::WrapDispatchFrame) {
@@ -1046,13 +1046,10 @@ impl Interpreter {
         class_name: &str,
         method_name: &str,
         candidate_idx: usize,
-    ) -> Option<&Vec<(u64, Value)>> {
-        let key = (
-            class_name.to_string(),
-            method_name.to_string(),
-            candidate_idx,
-        );
-        self.method_wrap_chains.get(&key).filter(|c| !c.is_empty())
+    ) -> Option<Vec<(u64, Value)>> {
+        self.registry()
+            .method_wrap_chain(class_name, method_name, candidate_idx)
+            .cloned()
     }
 
     /// Find the candidate index for a method definition in its class.

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -542,9 +542,8 @@ impl Interpreter {
                 else {
                     break;
                 };
-                let Some(chain) = self
-                    .get_method_wrap_chain(&owner_class, &method_name_now, cand_idx)
-                    .cloned()
+                let Some(chain) =
+                    self.get_method_wrap_chain(&owner_class, &method_name_now, cand_idx)
                 else {
                     break;
                 };

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -371,9 +371,8 @@ impl Interpreter {
         if self.has_any_wrap_chains()
             && let Some(cand_idx) =
                 self.find_method_candidate_index(owner_class.as_str(), method_name, &method_def)
-            && let Some(chain) = self
-                .get_method_wrap_chain(owner_class.as_str(), method_name, cand_idx)
-                .cloned()
+            && let Some(chain) =
+                self.get_method_wrap_chain(owner_class.as_str(), method_name, cand_idx)
         {
             let invocant_for_dispatch = make_invocant_for_dispatch(&invocant, attributes);
             self.push_method_samewith_context(

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -162,7 +162,7 @@ impl Interpreter {
             visit_slice(visitor, &frame.remaining);
             visit_slice(visitor, &frame.args);
         }
-        for chain in self.method_wrap_chains.values() {
+        for chain in self.registry().method_wrap_chains.values() {
             for (_, v) in chain {
                 visitor.visit_value(v);
             }

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2295,13 +2295,44 @@ impl Interpreter {
             && class_name.resolve() == "Routine::WrapHandle"
             && method == "restore"
         {
-            let sub_id = attributes
-                .as_map()
-                .get("sub-id")
-                .and_then(|v| v.as_int().map(|i| i as u64));
             let handle_id = attributes
                 .as_map()
                 .get("handle-id")
+                .and_then(|v| v.as_int().map(|i| i as u64));
+            // Method-candidate handle (`.^lookup(...).candidates[N].wrap(...)`):
+            // ADR-0019 E10's "unwrap method-wrap leak" fix — this handle shape
+            // used to carry no way to locate its `Registry::method_wrap_chains`
+            // entry, so `.restore()` silently did nothing and still reported
+            // success. See `method_wrap_handle_attrs` (`methods_sub.rs`).
+            let method_candidate_key = attributes
+                .as_map()
+                .get("wrap-class")
+                .and_then(|v| v.as_str().map(str::to_string))
+                .zip(
+                    attributes
+                        .as_map()
+                        .get("wrap-method")
+                        .and_then(|v| v.as_str().map(str::to_string)),
+                )
+                .zip(
+                    attributes
+                        .as_map()
+                        .get("wrap-candidate-idx")
+                        .and_then(|v| v.as_int().map(|i| i as usize)),
+                );
+            if let (Some(((cls, meth), idx)), Some(handle_id)) = (method_candidate_key, handle_id) {
+                return if self
+                    .registry_mut()
+                    .remove_method_wrap(&cls, &meth, idx, handle_id)
+                {
+                    Ok(Value::TRUE)
+                } else {
+                    Err(RuntimeError::new("Invalid WrapHandle: not wrapped"))
+                };
+            }
+            let sub_id = attributes
+                .as_map()
+                .get("sub-id")
                 .and_then(|v| v.as_int().map(|i| i as u64));
             if let (Some(sub_id), Some(handle_id)) = (sub_id, handle_id) {
                 if let Some(chain) = self.wrap_chains.get_mut(&sub_id) {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2219,14 +2219,12 @@ impl Interpreter {
                     ) {
                         self.wrap_handle_counter += 1;
                         let handle_id = self.wrap_handle_counter;
-                        let key = (cls.to_string(), meth.to_string(), idx as usize);
-                        self.method_wrap_chains
-                            .entry(key)
-                            .or_default()
-                            .push((handle_id, wrapper));
-                        let mut wh = std::collections::HashMap::new();
-                        wh.insert("handle-id".to_string(), Value::int(handle_id as i64));
-                        wh.insert("wrapped-sub".to_string(), target.clone());
+                        let (cls, meth, idx) = (cls.to_string(), meth.to_string(), idx as usize);
+                        self.registry_mut()
+                            .push_method_wrap(&cls, &meth, idx, handle_id, wrapper);
+                        let wh = super::methods_sub::method_wrap_handle_attrs(
+                            &cls, &meth, idx, handle_id, &target,
+                        );
                         return Ok(Value::make_instance(
                             Symbol::intern("Routine::WrapHandle"),
                             wh,

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -14,6 +14,36 @@ fn routine_unwrap_error(message: &str) -> RuntimeError {
     err
 }
 
+/// Attributes for a `Routine::WrapHandle` returned by wrapping a method
+/// CANDIDATE (`.^lookup(...).candidates[N].wrap(...)`, or the `Method`
+/// instance path in `methods_instance_ops.rs`) — as opposed to a plain sub
+/// wrap, which is keyed by `sub-id` instead. Carrying the owning class,
+/// method name, and candidate index lets `.unwrap()`/`.restore()` find and
+/// remove the right `Registry::method_wrap_chains` entry later (ADR-0019
+/// E10's "unwrap method-wrap leak" fix — previously these attrs carried no
+/// way to locate the entry at all, so it was never removed).
+pub(super) fn method_wrap_handle_attrs(
+    class_name: &str,
+    method_name: &str,
+    candidate_idx: usize,
+    handle_id: u64,
+    wrapped: &Value,
+) -> std::collections::HashMap<String, Value> {
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("wrap-class".to_string(), Value::str(class_name.to_string()));
+    attrs.insert(
+        "wrap-method".to_string(),
+        Value::str(method_name.to_string()),
+    );
+    attrs.insert(
+        "wrap-candidate-idx".to_string(),
+        Value::int(candidate_idx as i64),
+    );
+    attrs.insert("handle-id".to_string(), Value::int(handle_id as i64));
+    attrs.insert("wrapped-sub".to_string(), wrapped.clone());
+    attrs
+}
+
 impl Interpreter {
     /// Dispatch methods on callable values (Routine, Sub, WeakSub).
     /// Returns Some(result) if handled, None to fall through to common dispatch.
@@ -792,15 +822,10 @@ impl Interpreter {
                     .get("__mutsu_lookup_candidate_idx")
                     .map(Value::view)
             {
-                let key = (cls.to_string(), meth.to_string(), idx as usize);
-                self.method_wrap_chains
-                    .entry(key)
-                    .or_default()
-                    .push((handle_id, wrapper));
-                let mut attrs = std::collections::HashMap::new();
-                attrs.insert("sub-id".to_string(), Value::int(data.id as i64));
-                attrs.insert("handle-id".to_string(), Value::int(handle_id as i64));
-                attrs.insert("wrapped-sub".to_string(), target.clone());
+                let (cls, meth, idx) = (cls.to_string(), meth.to_string(), idx as usize);
+                self.registry_mut()
+                    .push_method_wrap(&cls, &meth, idx, handle_id, wrapper);
+                let attrs = method_wrap_handle_attrs(&cls, &meth, idx, handle_id, target);
                 return Some(Ok(Value::make_instance(
                     Symbol::intern("Routine::WrapHandle"),
                     attrs,
@@ -901,6 +926,48 @@ impl Interpreter {
             )));
         }
         if method == "unwrap" {
+            // Method candidate unwrap: mirrors the `.wrap()` branch above —
+            // if this Sub came from `^lookup(...).candidates[N]`, remove from
+            // `Registry::method_wrap_chains` instead of the sub-level
+            // `wrap_chains` (ADR-0019 E10; previously this branch was never
+            // reached for a candidate Sub, so `.unwrap()` fell through to the
+            // sub-level logic below, found nothing under `data.id`, and
+            // always errored "not wrapped").
+            if let Some(ValueView::Str(cls)) = data.env.get("__mutsu_lookup_class").map(Value::view)
+                && let Some(ValueView::Str(meth)) =
+                    data.env.get("__mutsu_lookup_method").map(Value::view)
+                && let Some(ValueView::Int(idx)) = data
+                    .env
+                    .get("__mutsu_lookup_candidate_idx")
+                    .map(Value::view)
+            {
+                let (cls, meth, idx) = (cls.to_string(), meth.to_string(), idx as usize);
+                if args.is_empty() {
+                    return Some(
+                        match self.registry_mut().pop_method_wrap(&cls, &meth, idx) {
+                            Some(_) => Ok(Value::TRUE),
+                            None => Err(routine_unwrap_error("Cannot unwrap routine: not wrapped")),
+                        },
+                    );
+                }
+                let Some(handle_id) = self.extract_wrap_handle_id(&args[0]) else {
+                    return Some(Err(routine_unwrap_error(
+                        "Cannot unwrap routine: invalid wrap handle",
+                    )));
+                };
+                return Some(
+                    if self
+                        .registry_mut()
+                        .remove_method_wrap(&cls, &meth, idx, handle_id)
+                    {
+                        Ok(Value::TRUE)
+                    } else {
+                        Err(routine_unwrap_error(
+                            "Cannot unwrap routine: invalid wrap handle",
+                        ))
+                    },
+                );
+            }
             // Look up original sub_id by name, since &foo creates a fresh Sub each time
             let func_name = data.name.resolve();
             let sub_id = self

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1906,9 +1906,6 @@ pub struct Interpreter {
     /// `X::TypeCheck::Binding` identity a sequence endpoint check relies on
     /// (roast S03-sequence/misc.t).
     pub(crate) suppress_binding_error_enhance: bool,
-    /// Method-level wrap chains: (class_name, method_name, candidate_index) ->
-    /// stack of (handle_id, wrapper_sub).
-    method_wrap_chains: HashMap<(String, String, usize), Vec<(u64, Value)>>,
     /// Metamodel method fallbacks registered via `.^add_fallback(cond, calc)`:
     /// class_name -> list of (condition, calculator) code pairs. When a method
     /// is not found on a value of that class, each condition is called with

--- a/src/runtime/registration_class_validate.rs
+++ b/src/runtime/registration_class_validate.rs
@@ -374,7 +374,7 @@ impl Interpreter {
         // Make the class visible while its body executes so introspection calls
         // like `A.^add_method(...)` inside the declaration can resolve `A`.
         // Clear stale method wrap chains from a previous class with the same name.
-        self.method_wrap_chains.retain(|(cls, _, _), _| cls != name);
+        self.registry_mut().clear_method_wrap_chains_for_class(name);
         // `class C hides P` marks parent P hidden from C's (and descendants')
         // `.^mro_unhidden`. Record it so the mro_unhidden filter can drop P.
         if !hidden_parents.is_empty() {

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -82,6 +82,16 @@ pub(crate) struct Registry {
     pub(crate) method_entries: HashMap<MethodEntryKey, MethodEntry>,
     /// Monotonic invalidation generation for the canonical method table.
     pub(crate) method_generation: u64,
+    /// Method-candidate wrap chains: `(owner class, method name, candidate
+    /// index)` -> stack of `(handle_id, wrapper_sub)`, outermost (currently
+    /// active) last. Populated by `.wrap()` on a Sub/Method obtained via
+    /// `^lookup`/`^find_method(...).candidates[N]` (ADR-0019 E10: moved from
+    /// the Interpreter so every mutation runs through [`Registry`] and can
+    /// bump `method_generation` like any other canonical dispatch state,
+    /// letting the generation-checked `fast_method_cache` stay valid instead
+    /// of a program-wide `has_any_wrap_chains()` prefilter disabling it
+    /// whenever ANY method anywhere is wrapped).
+    pub(crate) method_wrap_chains: HashMap<(String, String, usize), Vec<(u64, Value)>>,
     /// `enum Name (...)` declarations: enum name -> [(variant name, value)].
     pub(crate) enum_types: HashMap<String, Vec<(String, EnumValue)>>,
     /// `subset Name of Base where { ... }` declarations.
@@ -484,6 +494,116 @@ impl Registry {
         self.method_generation = self.method_generation.wrapping_add(1);
         if self.method_generation == 0 {
             self.method_generation = 1;
+        }
+    }
+
+    /// Whether ANY method-candidate wrap chain exists anywhere in the
+    /// program — a cheap live short-circuit for the per-candidate scans in
+    /// `class_dispatch.rs`/`ctor_phase_plan.rs`/`builtins_dispatch_next.rs`/
+    /// `vm_call_method_compiled.rs`'s `check_method_wrap_chain` (ADR-0019
+    /// E10). Unlike the deleted `fast_method_cache` gate, these sites guard a
+    /// live `find_method_candidate_index` scan rather than a cache, so the
+    /// prefilter is still a correct, cheap win and stays.
+    pub(crate) fn has_any_method_wrap_chains(&self) -> bool {
+        !self.method_wrap_chains.is_empty()
+    }
+
+    /// The wrap chain for one method candidate, if non-empty.
+    pub(crate) fn method_wrap_chain(
+        &self,
+        class_name: &str,
+        method_name: &str,
+        candidate_idx: usize,
+    ) -> Option<&Vec<(u64, Value)>> {
+        self.method_wrap_chains
+            .get(&(
+                class_name.to_string(),
+                method_name.to_string(),
+                candidate_idx,
+            ))
+            .filter(|c| !c.is_empty())
+    }
+
+    /// Push a new wrapper onto a method candidate's chain (ADR-0019 E10).
+    pub(crate) fn push_method_wrap(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+        candidate_idx: usize,
+        handle_id: u64,
+        wrapper: Value,
+    ) {
+        self.method_wrap_chains
+            .entry((
+                class_name.to_string(),
+                method_name.to_string(),
+                candidate_idx,
+            ))
+            .or_default()
+            .push((handle_id, wrapper));
+        self.bump_method_generation();
+    }
+
+    /// Pop the outermost wrapper off a method candidate's chain, returning it
+    /// if the chain was non-empty (ADR-0019 E10's `.unwrap()`-with-no-args
+    /// leg).
+    pub(crate) fn pop_method_wrap(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+        candidate_idx: usize,
+    ) -> Option<(u64, Value)> {
+        let key = (
+            class_name.to_string(),
+            method_name.to_string(),
+            candidate_idx,
+        );
+        let popped = self.method_wrap_chains.get_mut(&key).and_then(Vec::pop);
+        if popped.is_some() {
+            self.bump_method_generation();
+        }
+        popped
+    }
+
+    /// Remove one wrapper by handle id from a method candidate's chain
+    /// (ADR-0019 E10's `.unwrap(handle)`/`.restore()` leg — fixes the
+    /// "unwrap method-wrap leak": previously nothing ever removed a
+    /// `method_wrap_chains` entry at all, so a restored/unwrapped
+    /// method-candidate handle silently kept the wrapper active forever).
+    /// Returns whether an entry was actually removed.
+    pub(crate) fn remove_method_wrap(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+        candidate_idx: usize,
+        handle_id: u64,
+    ) -> bool {
+        let key = (
+            class_name.to_string(),
+            method_name.to_string(),
+            candidate_idx,
+        );
+        let Some(chain) = self.method_wrap_chains.get_mut(&key) else {
+            return false;
+        };
+        let before = chain.len();
+        chain.retain(|(hid, _)| *hid != handle_id);
+        let removed = chain.len() != before;
+        if removed {
+            self.bump_method_generation();
+        }
+        removed
+    }
+
+    /// Drop every wrap chain owned by a class being redeclared (mirrors
+    /// `sync_user_method_entries`'s per-class reset). Bumps the generation
+    /// only when something was actually removed.
+    pub(crate) fn clear_method_wrap_chains_for_class(&mut self, class_name: &str) {
+        let before = self.method_wrap_chains.len();
+        self.method_wrap_chains
+            .retain(|(cls, _, _), _| cls != class_name);
+        if self.method_wrap_chains.len() != before {
+            self.bump_method_generation();
         }
     }
 }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2318,7 +2318,6 @@ impl Interpreter {
             dispatch_token_counter: 0,
             wrap_skip_once: None,
             suppress_binding_error_enhance: false,
-            method_wrap_chains: HashMap::new(),
             method_fallbacks: HashMap::new(),
             suppressed_names: HashSet::new(),
             class_scoped_short_names: HashSet::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -683,7 +683,6 @@ impl Interpreter {
             dispatch_token_counter: 0,
             wrap_skip_once: None,
             suppress_binding_error_enhance: false,
-            method_wrap_chains: self.method_wrap_chains.clone(),
             method_fallbacks: self.method_fallbacks.clone(),
             suppressed_names: self.suppressed_names.clone(),
             class_scoped_short_names: self.class_scoped_short_names.clone(),

--- a/src/vm/vm_call_method_compiled.rs
+++ b/src/vm/vm_call_method_compiled.rs
@@ -292,9 +292,7 @@ impl Interpreter {
             return None;
         }
         let cand_idx = self.find_method_candidate_index(owner_class, method, method_def)?;
-        let chain = self
-            .get_method_wrap_chain(owner_class, method, cand_idx)?
-            .clone();
+        let chain = self.get_method_wrap_chain(owner_class, method, cand_idx)?;
         let invocant_for_dispatch = target.clone();
         self.push_method_samewith_context(cn, method, args, Some(invocant_for_dispatch.clone()));
         self.push_wrapped_method_dispatch_frame(

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -503,8 +503,19 @@ impl Interpreter {
 
             // Fast method dispatch cache: skip wrap chain check, compiled_code
             // extraction, and param_def eligibility scans for known-fast methods.
-            if !self.has_any_wrap_chains()
-                && let Some(entry) = self.fast_method_cache.get(&cache_key)
+            //
+            // ADR-0019 E10: no `!self.has_any_wrap_chains()` guard here anymore.
+            // That used to disable this cache PROGRAM-WIDE the instant any method
+            // anywhere was wrapped, even for completely unrelated methods. It is
+            // safe to drop because `try_populate_fast_cache` (below) is only ever
+            // reached after `check_method_wrap_chain` has already returned `None`
+            // for this exact method, so a wrapped method is never cached here in
+            // the first place; and wrapping/unwrapping now bumps
+            // `Registry::method_generation` (`push_method_wrap`/`pop_method_wrap`/
+            // `remove_method_wrap`), which `refresh_method_caches_for_generation`
+            // (just above) already clears `fast_method_cache` on — evicting any
+            // entry cached before a method it names got wrapped.
+            if let Some(entry) = self.fast_method_cache.get(&cache_key)
                 && args.len() <= entry.positional_count
             {
                 let needs_default_eval =

--- a/t/wrap-candidate-unwrap-restore.t
+++ b/t/wrap-candidate-unwrap-restore.t
@@ -1,0 +1,40 @@
+use Test;
+
+plan 10;
+
+# ADR-0019 E10: `.wrap()` on a method CANDIDATE (`^lookup(...).candidates[N]`,
+# not a plain sub `&foo`) stores its wrapper in `Registry::method_wrap_chains`,
+# keyed by (class, method, candidate index) rather than by sub id. Before this
+# fix, neither `.restore()` on the returned WrapHandle nor `.unwrap($handle)`
+# on the candidate itself ever removed the entry -- `.restore()` silently
+# looked in the wrong (sub-id-keyed) map and still reported success, and
+# `.unwrap()` on the candidate fell through to sub-level logic and always
+# raised "not wrapped". Verified against Rakudo v2026.06 (`raku`).
+class Foo {
+    method bar($x) { return $x * 2; }
+    multi method baz(Int $x) { return $x + 1; }
+}
+
+my $inst = Foo.new;
+
+is $inst.bar(5), 10, 'unwrapped candidate: control value';
+
+my $wh = Foo.^lookup('bar').candidates[0].wrap(-> $self, $x { callsame() + 100 });
+is $inst.bar(5), 110, 'wrapped candidate applies the wrapper';
+$wh.restore;
+is $inst.bar(5), 10, '.restore() on a candidate WrapHandle actually removes the wrapper';
+
+my $cand = Foo.^lookup('bar').candidates[0];
+my $wh2 = $cand.wrap(-> $self, $x { callsame() + 100 });
+is $inst.bar(5), 110, 're-wrapped candidate applies the wrapper again';
+lives-ok { $cand.unwrap($wh2) }, '.unwrap(handle) on a candidate lives';
+is $inst.bar(5), 10, '.unwrap(handle) on a candidate actually removes the wrapper';
+
+dies-ok { $cand.unwrap($wh2) }, 'unwrapping an already-removed handle dies';
+
+# A multi candidate obtained via `^lookup` behaves the same way.
+is $inst.baz(1), 2, 'unwrapped multi candidate: control value';
+my $wh3 = Foo.^lookup('baz').candidates[0].wrap(-> $self, $x { callsame() + 1000 });
+is $inst.baz(1), 1002, 'wrapped multi candidate applies the wrapper';
+$wh3.restore;
+is $inst.baz(1), 2, '.restore() on a multi candidate WrapHandle removes the wrapper';


### PR DESCRIPTION
## Summary
- `Registry::method_wrap_chains` replaces the Interpreter-level side table backing `.wrap()` on a method *candidate* (`^lookup(...).candidates[N]`). Every mutation (push/pop/remove/class-clear) now bumps `method_generation` like any other canonical dispatch write.
- Deletes the `has_any_wrap_chains()` gate on `fast_method_cache` in `vm_call_method_compiled_interpret.rs`, which used to disable that cache for **every** method call program-wide the instant any method anywhere got wrapped. Safe because a wrapped method is never cached there in the first place (`check_method_wrap_chain` intercepts first), and wrapping a previously-cached method now evicts it via the generation bump. The other `has_any_wrap_chains()` sites guard a live scan, not a cache, and are unchanged.
- Fixes the "unwrap method-wrap leak" (confirmed against Rakudo v2026.06 first): neither `.restore()` nor `.unwrap(handle)` on a method-candidate `WrapHandle` ever actually removed the wrapper. `.restore()` looked in the wrong (sub-id-keyed) map and silently reported success; `.unwrap()` on the candidate itself never checked for the `^lookup` markers at all and always raised "not wrapped". Both now route through the new `Registry::remove_method_wrap`/`pop_method_wrap`.
- Backfills the ADR-0019 progress log for E9b-2/E9c-1/E9c-2, which landed in prior PRs (#6369/#6372/#6375) without their progress notes.

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean
- [x] New pin `t/wrap-candidate-unwrap-restore.t` (10 assertions), verified against real `raku` first
- [x] Targeted: `roast/S06-advanced/{dispatching,wrap}.t`, `roast/S14-traits/routines.t`, `roast/integration/failure-and-callsame.t`, `t/wrap.t`, `t/wrap-closure-capture.t` all green
- [x] Full local `make test`: 3128 files, 29005 tests, 0 failures
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)