### PR TITLE
fix: expose CatHandle iterators as eager Seqs

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1194,7 +1194,7 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             // Forcing here would defeat e.g. `(my $l = $cat.lines).cache` whose
             // later `$l[2,3]` must reflect mid-iteration attribute changes.
             if let ValueView::LazyList(ll) = target.view()
-                && ll.is_genuinely_lazy()
+                && (ll.is_genuinely_lazy() || ll.is_cat_pull())
             {
                 return Some(Ok(Value::lazy_list(crate::gc::Gc::new(
                     ll.with_cached_no_sink().with_list_context(),

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -954,7 +954,7 @@ fn is_infinite_range(value: &Value) -> bool {
 }
 
 pub(crate) fn is_value_lazy(value: &Value) -> bool {
-    matches!(value.view(), ValueView::LazyList(_))
+    matches!(value.view(), ValueView::LazyList(ll) if ll.is_genuinely_lazy())
         || matches!(value.view(), ValueView::Array(_, kind) if kind.is_lazy())
         || is_infinite_range(value)
         || matches!(value.view(), ValueView::Seq(items) if crate::value::seq_is_lazy(&items))

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -954,7 +954,11 @@ fn is_infinite_range(value: &Value) -> bool {
 }
 
 pub(crate) fn is_value_lazy(value: &Value) -> bool {
-    matches!(value.view(), ValueView::LazyList(ll) if ll.is_genuinely_lazy())
+    // CatHandle pullers are internally on-demand but expose eager Seq
+    // semantics; every other LazyList remains eligible for `.lazy` handling,
+    // including plain gather lists whose laziness is established by that
+    // method rather than by `is_genuinely_lazy()`.
+    matches!(value.view(), ValueView::LazyList(ll) if !ll.is_cat_pull())
         || matches!(value.view(), ValueView::Array(_, kind) if kind.is_lazy())
         || is_infinite_range(value)
         || matches!(value.view(), ValueView::Seq(items) if crate::value::seq_is_lazy(&items))

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3525,7 +3525,7 @@ impl Interpreter {
         // mid-iteration changes to the cat's `.nl-in`/`.chomp`.
         if let ValueView::LazyList(ll) = target.view()
             && method == "cache"
-            && ll.is_genuinely_lazy()
+            && (ll.is_genuinely_lazy() || ll.is_cat_pull())
         {
             return Ok(Value::lazy_list(crate::gc::Gc::new(
                 ll.with_cached_no_sink().with_list_context(),

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -411,6 +411,11 @@ impl Interpreter {
                 ValueView::Str(_) => constraint == "Str",
                 ValueView::Bool(_) => constraint == "Bool",
                 ValueView::Instance { class_name, .. } => class_name.as_str() == constraint,
+                // CatHandle pullers are represented by a live LazyList so they
+                // can observe mid-iteration changes, but their public Raku
+                // type is Seq (and they are not lazy from the type system's
+                // point of view).
+                ValueView::LazyList(list) if list.is_cat_pull() => constraint == "Seq",
                 _ => false,
             }
         };

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -23,6 +23,9 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         // without forcing reification, so honour those context markers first.
         ValueView::LazyList(ll) if ll.in_array_context() => "Array",
         ValueView::LazyList(ll) if ll.in_list_context() => "List",
+        // CatHandle iterators pull from the live handle on demand internally,
+        // but Rakudo exposes both `.lines` and `.handles` as eager `Seq`s.
+        ValueView::LazyList(ll) if ll.is_cat_pull() => "Seq",
         ValueView::LazyList(ll) if ll.is_from_gather() => "Seq",
         ValueView::LazyList(_) => "Array",
         ValueView::Hash(ref h) if h.declared_type.as_deref() == Some("Map") => "Map",

--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -65,7 +65,9 @@ impl LazyList {
     }
 
     /// True when this list is genuinely lazy (`.is-lazy`), so gist/Str/raku
-    /// render a placeholder instead of materializing it.
+    /// render a placeholder instead of materializing it. CatHandle pullers
+    /// are intentionally excluded: their backing iterator is lazy internally,
+    /// but Rakudo exposes them as eager `Seq`s.
     ///
     /// An infinite sequence/closure/scan/map-grep generator is only ever stored
     /// as a *live* `LazyList` when actually infinite (finite ones materialize to
@@ -78,7 +80,6 @@ impl LazyList {
             || self.lazy_pipe.is_some()
             || self.closure_seq.is_some()
             || self.scan_spec.is_some()
-            || self.cat_pull.is_some()
             // The `__mutsu_preserve_lazy_on_array_assign` marker is set
             // exclusively by an explicit `lazy` prefix / `.lazy` method call
             // (see `dispatch_core_str.rs`), including on an already-finite
@@ -97,6 +98,13 @@ impl LazyList {
         self.is_genuinely_lazy() && self.cat_pull.is_none()
     }
 
+    /// Whether this list is backed by a live `IO::CatHandle` iterator.
+    /// CatHandle iterators pull lazily internally, but Rakudo exposes both
+    /// `.lines` and `.handles` as eager `Seq` values (`.is-lazy` is `False`).
+    pub(crate) fn is_cat_pull(&self) -> bool {
+        self.cat_pull.is_some()
+    }
+
     /// Whether iterating this list could hang or be unsafe to consume twice
     /// right now (a live generator with no complete cache yet) — as opposed
     /// to `is_genuinely_lazy()`, which answers `.is-lazy` and is also True for
@@ -111,7 +119,6 @@ impl LazyList {
             || self.lazy_pipe.is_some()
             || self.closure_seq.is_some()
             || self.scan_spec.is_some()
-            || self.cat_pull.is_some()
             || ((self.coroutine.is_some() || !self.body.is_empty() || self.compiled_code.is_some())
                 && self.is_lazy_marked())
     }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -819,7 +819,7 @@ impl Interpreter {
         // the matching note in the non-mut dispatch path.
         if let ValueView::LazyList(ll) = target.view()
             && method == "cache"
-            && ll.is_genuinely_lazy()
+            && (ll.is_genuinely_lazy() || ll.is_cat_pull())
         {
             crate::vm::vm_stats::record_dispatch_entry_intercept("callmethodmut", "lazy-cache");
             self.stack.push(Value::lazy_list(crate::gc::Gc::new(

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1124,7 +1124,7 @@ impl Interpreter {
         // mid-iteration changes to the cat's `.nl-in`/`.chomp`.
         if let ValueView::LazyList(ll) = target.view()
             && method == "cache"
-            && ll.is_genuinely_lazy()
+            && (ll.is_genuinely_lazy() || ll.is_cat_pull())
         {
             crate::vm::vm_stats::record_dispatch_entry_intercept("callmethod", "lazy-cache");
             self.stack.push(Value::lazy_list(crate::gc::Gc::new(

--- a/t/io-cathandle-lazy.t
+++ b/t/io-cathandle-lazy.t
@@ -5,7 +5,7 @@ use Test;
 # concurrently, CR-LF is one line ending and normalizes to "\n", and a lazy
 # `for $cat.lines` interleaves with the body so the cat stays mid-stream.
 
-plan 9;
+plan 13;
 
 my $seq = 0;
 sub tmpfile($content) {
@@ -32,13 +32,19 @@ sub tmpfile($content) {
 # --- CR-LF is one line ending (longest-match separator) ---
 {
     my $cat = IO::CatHandle.new: tmpfile("a\r\nb\r\nc");
-    is-deeply $cat.lines, ("a", "b", "c"), 'CR-LF is a single line ending';
+    my $lines = $cat.lines;
+    is $lines.^name, 'Seq', 'lines reports Seq';
+    nok $lines.is-lazy, 'lines is not lazy externally';
+    is-deeply $lines, ("a", "b", "c"), 'CR-LF is a single line ending';
 }
 
 # --- lazy .handles is consumable concurrently with the cat ---
 {
     my $cat := IO::CatHandle.new: tmpfile("a1\na2\na3\na4"), tmpfile("b1\nb2\nb3\nb4"), tmpfile("c1\nc2\nc3\nc4");
-    is-deeply $cat.handles.map({ eager .lines: 2 }),
+    my $handles = $cat.handles;
+    is $handles.^name, 'Seq', 'handles reports Seq';
+    nok $handles.is-lazy, 'handles is not lazy externally';
+    is-deeply $handles.map({ eager .lines: 2 }),
         (<a1 a2>, <b1 b2>, <c1 c2>).Seq, 'lazy .handles: reads 2 lines per handle';
 }
 


### PR DESCRIPTION
## Summary

- expose `IO::CatHandle.lines` and `.handles` as `Seq` values with `.is-lazy == False`
- preserve internal lazy pulling so live CatHandle state changes still work
- add regression coverage for public type and laziness semantics

## Root cause

CatHandle iterators were represented as genuinely lazy `LazyList` values. That made type reporting, `Seq:D` dispatch, and real `Test.is-deeply` comparisons observe them as lazy Arrays.

## Validation

- `MUTSU_REAL_TEST=1 prove -e target/debug/mutsu t/io-cathandle-lazy.t`
- `cargo test`
- `cargo clippy -- -D warnings`