### PR TITLE
fix(vm): dispatch user postcircumfix:<[ ]>/<{ }> multi candidates for Instance subscripts

### DIFF
--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -439,6 +439,27 @@ impl Interpreter {
             self.stack.push(target);
             return Ok(());
         }
+        // A user-declared `multi sub postcircumfix:<[ ]>`/`postcircumfix:<{ }>`
+        // intercepts the bracket-subscript OPERATOR itself for a matching
+        // (invocant, index) type pair — this must be consulted before the
+        // built-in AT-POS/AT-KEY protocol dispatch below, mirroring how
+        // `prefix:<~>`/`infix:<...>` operator overloads are checked ahead of
+        // their native fallback (`vm_misc_coerce.rs`, `builtins_operators_infix.rs`).
+        // See todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md.
+        if let ValueView::Instance { .. } = target.view() {
+            let op_name = if is_positional {
+                "postcircumfix:<[ ]>"
+            } else {
+                "postcircumfix:<{ }>"
+            };
+            let args = vec![target.clone(), index.clone()];
+            if let Some(def) = self.resolve_function_with_types(op_name, &args) {
+                let empty_fns = crate::opcode::CompiledFns::default();
+                let result = self.compile_and_call_function_def(&def, args, &empty_fns)?;
+                self.stack.push(result);
+                return Ok(());
+            }
+        }
         if let ValueView::LazyIoLines {
             handle, kv, words, ..
         } = target.view()

--- a/t/user-postcircumfix-index-instance.t
+++ b/t/user-postcircumfix-index-instance.t
@@ -1,0 +1,63 @@
+use v6;
+use Test;
+
+plan 7;
+
+# A user-declared `multi sub postcircumfix:<[ ]>` / `postcircumfix:<{ }>` must
+# intercept the bracket-subscript OPERATOR for a matching (invocant, index)
+# type pair on an Instance target, ahead of the built-in AT-POS/AT-KEY
+# protocol dispatch — the mechanism modules like `Array::Rounded` rely on to
+# reinterpret a non-Int subscript before it ever reaches AT-POS.
+# See todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md.
+
+class PCFoo is Array {
+    method AT-POS(\i) { "AT-POS(" ~ i ~ ")" }
+}
+
+multi sub postcircumfix:<[ ]>(PCFoo:D \self, Str:D $key) {
+    "custom(" ~ $key ~ ")"
+}
+
+my @f is PCFoo = 1, 2, 3;
+is @f[0], 'AT-POS(0)', 'plain Int index still reaches AT-POS when no candidate matches it';
+is @f["hi"], 'custom(hi)', 'Str index is intercepted by the user postcircumfix:<[ ]> candidate';
+
+# Candidate specificity: a narrower `Int:D` candidate must win over a broader
+# `Any:D` one for an actual Int index, and the fractional/other-typed index
+# must reach the `Any:D` candidate WITHOUT being truncated first (unlike a
+# plain AT-POS dispatch, which does truncate).
+class PCRounded is Array {
+    method AT-POS(\i) { "AT-POS(" ~ i ~ ")" }
+}
+
+multi sub postcircumfix:<[ ]>(PCRounded:D \self, Int:D $index) {
+    "int-candidate(" ~ $index ~ ")"
+}
+multi sub postcircumfix:<[ ]>(PCRounded:D \self, Any:D \index) {
+    "any-candidate(" ~ index ~ ")"
+}
+
+my @r is PCRounded = 1, 2, 3;
+is @r[2], 'int-candidate(2)', 'Int:D candidate wins over Any:D for a plain Int index';
+is @r[1.5], 'any-candidate(1.5)', 'a Rat index reaches Any:D with its raw (untruncated) value';
+is @r["k"], 'any-candidate(k)', 'a Str index also reaches the Any:D candidate';
+
+# A class with no postcircumfix:<[ ]> declared at all is unaffected — the
+# native AT-POS dispatch (and its existing Rat-truncation behavior) still
+# applies exactly as before this change.
+class PCPlain is Array {
+    method AT-POS(\i) { "AT-POS(" ~ i ~ ")" }
+}
+my @p is PCPlain = 1, 2, 3;
+is @p[1.9], 'AT-POS(1)', 'no user postcircumfix candidate: subscript still truncates before AT-POS';
+
+# A `postcircumfix:<{ }>` candidate is checked independently of `[ ]`, keyed
+# on the `is_positional` flag of the subscript syntax used.
+class PCHash is Hash {
+    method AT-KEY(\k) { "AT-KEY(" ~ k ~ ")" }
+}
+multi sub postcircumfix:<{ }>(PCHash:D \self, Int:D $key) {
+    "hashcustom(" ~ $key ~ ")"
+}
+my %h is PCHash;
+is %h{5}, 'hashcustom(5)', 'postcircumfix:<{ }> is checked independently for associative subscripts';

--- a/todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md
+++ b/todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md
@@ -1,5 +1,48 @@
 # A user-exported `postcircumfix:&lt;[ ]&gt;` multi candidate is never dispatched for `@obj[...]` subscript syntax
 
+## Status update: the READ-path dispatch gap is fixed
+
+The core claim below — that `@obj[...]`/`%obj{...}` *read* access never consults
+a user-declared `postcircumfix:&lt;[ ]&gt;`/`postcircumfix:&lt;{ }&gt;` multi
+candidate for an `Instance` target — is fixed: `exec_index_op_with_positional`
+(`src/vm/vm_var_index_ops.rs`) now probes `resolve_function_with_types` for the
+op name against `[target, index]` *before* the built-in AT-POS/AT-KEY arms,
+mirroring how `prefix:&lt;~&gt;`/`infix:&lt;...&gt;` operator overloads are
+checked ahead of their native fallback. Candidate specificity (`Int:D` beating
+`Any:D`) and the "no candidate declared at all" fast path (`Registry::functions`
+name-existence gate, same one `prefix:&lt;~&gt;` already relies on) both work
+as in real `raku` — pinned in `t/user-postcircumfix-index-instance.t`.
+
+**Still open** (do not re-close this ticket on the strength of the above):
+
+1. **The *assignment* path is untouched.** `@obj[i] = v` / `%obj{k} = v` still
+   lowers straight to `IndexAssign`/`ASSIGN-POS`/`ASSIGN-KEY`
+   (`vm_var_assign_index_named.rs`, `builtins_multidim_assign.rs`) without ever
+   consulting a user `postcircumfix:&lt;[ ]&gt;` candidate. In real Raku this
+   normally isn't a *separate* mechanism — assignment targets whatever
+   container the read side handed back — but mutsu's element storage is not
+   uniformly container/Proxy-based (ADR-0013), so "read via the multi
+   candidate, then STORE into what it returns" needs its own design pass
+   rather than a copy of the read-side fix above.
+2. **`&postcircumfix:&lt;[ ]&gt;` does not exist as a callable term at all.**
+   The `Array::Rounded`-style idiom this ticket was filed for depends on
+   `my constant &old-same = &postcircumfix:&lt;[ ]&gt;;` capturing the
+   *pre-augmentation* native dispatcher so the module's own candidates can
+   delegate back to native indexing (`old-same SELF, $index`) without infinite
+   recursion into their own just-added candidates. mutsu has no native Sub
+   value registered under this name at all — bareword resolution of
+   `&postcircumfix:&lt;[ ]&gt;` currently fails outright. This is a distinct,
+   still-unstarted gap: it needs a native callable wrapping the same
+   AT-POS/AT-KEY dispatch logic the read-path fix above added inline, exposed
+   as a term *before* any user candidates exist, frozen at the point captured
+   (not a live re-lookup of the growing multi table).
+3. The constant-alias `is` trait gap in "What's still broken" below is
+   unrelated and still fully open.
+
+Do not close `Array::Rounded`'s row in `dist-test-suite-failures-batch.md`
+until items 1-3 above are resolved, in addition to everything already listed
+under "What's still broken".
+
 Found while investigating `Array::Rounded` (`todo/tickets/dist-test-suite-failures-batch.md`'s
 Un-triaged list). The dist's actual rounding mechanism is NOT the `AT-POS` method override it also
 declares (that one only matters for a *direct* `.AT-POS(...)` call, or the Positional protocol paths


### PR DESCRIPTION
## Summary
- `@obj[...]`/`%obj{...}` read access on an `Instance` target always fell straight to the built-in `AT-POS`/`AT-KEY` protocol methods, never consulting a user-declared `multi sub postcircumfix:<[ ]>`/`postcircumfix:<{ }>` candidate scoped to the target's class — the mechanism modules like `Array::Rounded` use to reinterpret a non-`Int` subscript before it reaches `AT-POS`.
- `exec_index_op_with_positional` now probes `resolve_function_with_types` for the op name against `[target, index]` before the `AT-POS`/`AT-KEY` arms, mirroring how `prefix:<~>`/`infix:<...>` operator overloads are already checked ahead of their native fallback. Candidate specificity (`Int:D` beating `Any:D`) falls out of the existing multi-resolution machinery, verified against real `raku`.
- Updates `todo/deep/user-postcircumfix-index-not-dispatched-for-instances.md`: marks the read-path dispatch gap fixed, keeps the ticket open for the assignment path and a native `&postcircumfix:<[ ]>` callable term (needed for the `my constant &old-same = &postcircumfix:<[ ]>;` idiom).

## Test plan
- [x] New `t/user-postcircumfix-index-instance.t` (7 assertions) verified identical against real `raku` and mutsu (debug + release)
- [x] `MUTSU_BIN=target/debug/mutsu prove -e 'target/debug/mutsu' t/` — 3130 files, 29018 tests, all pass
- [x] Targeted roast files (`S02-types/{hash,array,array-shapes,anon_block,range}.t`) pass under release build
- [x] `cargo clippy -- -D warnings` / `cargo fmt` clean
- [ ] CI (`make test` + `make roast`)