### PR TITLE
feat(dispatch): ADR-0019 E11 slice 3 -- collection unary builtins route through the resolver

### DIFF
--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -359,29 +359,40 @@ impl Interpreter {
         Ok(Value::value_pair(Value::str(key), val))
     }
 
-    pub(super) fn builtin_keys(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_keys(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         self.builtin_unary_collection_method(args, "keys")
     }
 
-    pub(super) fn builtin_values(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_values(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         self.builtin_unary_collection_method(args, "values")
     }
 
-    pub(super) fn builtin_kv(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_kv(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         self.builtin_unary_collection_method(args, "kv")
     }
 
-    pub(super) fn builtin_pairs(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_pairs(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         self.builtin_unary_collection_method(args, "pairs")
     }
 
+    // ADR-0019 Phase E box E11: route through the canonical resolver entry
+    // point (`call_method_with_values`) instead of calling `native_method_0arg`
+    // directly. The E2 catalog existence check
+    // (`Interpreter::e2_native_method_exists`) stands in for the old
+    // `Option`-based "did the native cascade recognize this name at all"
+    // probe, preserving the exact fallback: an unrecognized `(target, method)`
+    // pair (e.g. a bare `keys()` call, `target` defaulting to `Value::NIL`)
+    // still yields an empty list rather than a dispatch error.
     fn builtin_unary_collection_method(
-        &self,
+        &mut self,
         args: &[Value],
-        method: &str,
+        method: &'static str,
     ) -> Result<Value, RuntimeError> {
         let target = args.first().cloned().unwrap_or(Value::NIL);
-        crate::builtins::native_method_0arg(&target, crate::symbol::Symbol::intern(method))
-            .unwrap_or_else(|| Ok(Value::array(Vec::new())))
+        if self.e2_native_method_exists(&target, method) {
+            self.call_method_with_values(target, method, Vec::new())
+        } else {
+            Ok(Value::array(Vec::new()))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- The free-function `keys()`/`values()`/`kv()`/`pairs()` builtins called `native_method_0arg()` directly instead of the canonical resolver entry point. Route them through `call_method_with_values()`, guarded by the E2 catalog's `e2_native_method_exists()` existence check (landed in #6385) to preserve the exact prior fallback: an unrecognized `(target, method)` pair -- e.g. a bare `keys()` call with no target -- still yields an empty list instead of a dispatch error.
- Part of ADR-0019 Phase E box E11 ("retire arity-specific lookup entry points").

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean
- [x] `cargo test --lib` (815 tests)
- [x] Verified against real `raku` across Hash/Array/Int/Any receivers (including the `keys(5)` Cool-bridge case and the `keys()` no-args edge case)
- [x] `make test` (3131 files) green
- [x] Targeted roast (`S32-hash`/`S32-array` keys/values/kv/pairs, `S02-types` set/bag/mix family) green via `prove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)