### PR TITLE
feat(dispatch): ADR-0019 E11 slice 4 -- is-deeply/is-eqv diagnostic formatter routes through the resolver

### DIFF
--- a/src/runtime/test_functions/comparison.rs
+++ b/src/runtime/test_functions/comparison.rs
@@ -251,8 +251,8 @@ impl Interpreter {
         };
         self.test_ok(ok, &desc, todo)?;
         if !ok {
-            let got_raku = left.map(Self::value_raku_repr).unwrap_or_default();
-            let expected_raku = right.map(Self::value_raku_repr).unwrap_or_default();
+            let got_raku = left.map(|v| self.value_raku_repr(v)).unwrap_or_default();
+            let expected_raku = right.map(|v| self.value_raku_repr(v)).unwrap_or_default();
             self.emit_output(&format!(
                 "# expected: {}\n#      got: {}\n",
                 expected_raku, got_raku
@@ -568,8 +568,8 @@ impl Interpreter {
         let ok = got.eqv(&expected);
         self.test_ok(ok, &desc, false)?;
         if !ok {
-            let got_raku = Self::value_raku_repr(&got);
-            let expected_raku = Self::value_raku_repr(&expected);
+            let got_raku = self.value_raku_repr(&got);
+            let expected_raku = self.value_raku_repr(&expected);
             self.emit_output(&format!(
                 "# expected: {}\n#      got: {}\n",
                 expected_raku, got_raku

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -333,9 +333,16 @@ impl Interpreter {
         val.to_string_value()
     }
 
-    pub(crate) fn value_raku_repr(val: &Value) -> String {
-        if let Some(Ok(v)) =
-            crate::builtins::native_method_0arg(val, crate::symbol::Symbol::intern("raku"))
+    /// ADR-0019 Phase E box E11: routes through the canonical resolver entry
+    /// point (`call_method_with_values`) instead of calling `native_method_0arg`
+    /// directly, so a user-defined `.raku` override on an `Instance` is
+    /// honored too. The E2 catalog existence check
+    /// (`Interpreter::e2_native_method_exists`) preserves the exact prior
+    /// fallback: a `(val, "raku")` pair the catalog does not recognize still
+    /// falls back to `to_string_value()` instead of a dispatch error.
+    pub(crate) fn value_raku_repr(&mut self, val: &Value) -> String {
+        if self.e2_native_method_exists(val, "raku")
+            && let Ok(v) = self.call_method_with_values(val.clone(), "raku", Vec::new())
             && let Some(s) = v.as_str()
         {
             s.to_string()

--- a/t/is-deeply-user-raku-diagnostic.t
+++ b/t/is-deeply-user-raku-diagnostic.t
@@ -1,0 +1,30 @@
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test::Util;
+
+plan 2;
+
+# Regression: ADR-0019 Phase E box E11. `value_raku_repr`, the diagnostic
+# formatter behind `is-deeply`/`is-eqv`'s "expected:"/"got:" lines, used to
+# call `native_method_0arg` directly -- which never recognizes a
+# user-defined `.raku` override on an `Instance`, so the diagnostic silently
+# fell back to a generic stringification instead of the user's own `.raku`.
+# Verified against real raku 2026-08-14: it prints the user-defined `.raku`.
+
+is_run
+    'use Test; class Foo { has $.x; method raku { "MyFoo(" ~ $.x ~ ")" } };'
+    ~ 'is-deeply Foo.new(x=>1), Foo.new(x=>2);',
+    {
+        :out(/'expected: MyFoo(2)' .+ 'got: MyFoo(1)'/),
+        :1status,
+    },
+    'is-deeply diagnostic honors a user-defined .raku override';
+
+is_run
+    'use Test; class Bar { has $.y; method raku { "MyBar(" ~ $.y ~ ")" } };'
+    ~ 'is-eqv Bar.new(y=>1), Bar.new(y=>2);',
+    {
+        :out(/'expected: MyBar(2)' .+ 'got: MyBar(1)'/),
+        :1status,
+    },
+    'is-eqv diagnostic honors a user-defined .raku override';


### PR DESCRIPTION
## Summary
- `value_raku_repr`, the "expected:"/"got:" diagnostic formatter behind `is-deeply`/`is-eqv`, was a free function that called `native_method_0arg()` directly -- which never recognizes a user-defined `.raku` override on an `Instance`, so the diagnostic silently fell back to a generic stringification instead of the user's own `.raku`.
- Converted to a `&mut self` method routing through `call_method_with_values()`, guarded by `e2_native_method_exists()` (from #6385) to preserve the exact prior fallback: an unrecognized `(val, "raku")` pair still falls back to `to_string_value()`, not a dispatch error.
- Part of ADR-0019 Phase E box E11 ("retire arity-specific lookup entry points").

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean
- [x] `cargo test --lib` (815 tests)
- [x] New `t/is-deeply-user-raku-diagnostic.t`, verified the user-defined `.raku` override shows up in the diagnostic in real `raku` too
- [x] `make test` (3132 files) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)