### PR TITLE
fix: ignore comments when splitting regex operators

### DIFF
--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -118,6 +118,75 @@ pub(crate) fn regex_pattern_is_static(pattern: &str) -> bool {
     true
 }
 
+/// Return the character index immediately after a regex comment beginning at
+/// `start`, or `None` when `start` is not a comment marker.
+///
+/// A plain `#` comment ends before the newline. An embedded ``#`[...]`` (or
+/// another bracket-delimited form) consumes the matching, possibly nested,
+/// closing bracket. Keeping this scan in one place is important: structural
+/// scanners must not mistake operators appearing in comments for regex
+/// operators.
+pub(super) fn regex_comment_end(chars: &[char], start: usize) -> Option<usize> {
+    if chars.get(start) != Some(&'#') {
+        return None;
+    }
+    if chars.get(start + 1) != Some(&'`') {
+        return Some(
+            (start + 1..chars.len())
+                .find(|&i| chars[i] == '\n')
+                .unwrap_or(chars.len()),
+        );
+    }
+
+    let bracket = match chars.get(start + 2).copied() {
+        Some(bracket) => bracket,
+        None => return Some(chars.len()),
+    };
+    let close = crate::parser::helpers::matching_bracket(bracket).unwrap_or(bracket);
+    let mut depth = 1u32;
+    let mut i = start + 3;
+    while i < chars.len() {
+        if chars[i] == bracket && bracket != close {
+            depth += 1;
+        } else if chars[i] == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i + 1);
+            }
+        }
+        i += 1;
+    }
+    Some(chars.len())
+}
+
+/// Consume a regex comment from a peekable stream after its `#` marker was
+/// read. The comment text is copied to `current` so callers preserve source
+/// spans for later blank-branch checks.
+pub(super) fn consume_regex_comment<I>(
+    marker: char,
+    chars: &mut std::iter::Peekable<I>,
+    current: &mut String,
+) -> bool
+where
+    I: Iterator<Item = char> + Clone,
+{
+    if marker != '#' {
+        return false;
+    }
+    let mut remaining = vec![marker];
+    remaining.extend(chars.clone());
+    let Some(end) = regex_comment_end(&remaining, 0) else {
+        return false;
+    };
+    current.push(marker);
+    for _ in 1..end {
+        if let Some(ch) = chars.next() {
+            current.push(ch);
+        }
+    }
+    true
+}
+
 #[cfg(test)]
 mod static_pattern_tests {
     use super::regex_pattern_is_static;

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -797,30 +797,8 @@ impl Interpreter {
             // bracket-delimited embedded comment (may sit mid-line with pattern
             // after it); a plain `#` is a line comment (until end of line).
             if c == '#' {
-                if chars.peek() == Some(&'`') {
-                    chars.next(); // consume `
-                    if let Some(bracket) = chars.next() {
-                        let close =
-                            crate::parser::helpers::matching_bracket(bracket).unwrap_or(bracket);
-                        let mut embed_depth = 1u32;
-                        for ch in chars.by_ref() {
-                            if ch == bracket && bracket != close {
-                                embed_depth += 1;
-                            } else if ch == close {
-                                embed_depth -= 1;
-                                if embed_depth == 0 {
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    continue;
-                }
-                for ch in chars.by_ref() {
-                    if ch == '\n' {
-                        break;
-                    }
-                }
+                let mut comment = String::new();
+                consume_regex_comment(c, &mut chars, &mut comment);
                 continue;
             }
             if c == '^' {

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -105,7 +105,11 @@ impl Interpreter {
                 escaped = true;
                 continue;
             }
-            if consume_regex_comment(ch, &mut chars, &mut current) {
+            if depth_angle == 0
+                && !in_single_quote
+                && !in_double_quote
+                && consume_regex_comment(ch, &mut chars, &mut current)
+            {
                 continue;
             }
             // Inside a `<...>` assertion, `'` and `"` are ordinary characters, not
@@ -226,7 +230,11 @@ impl Interpreter {
                 escaped = true;
                 continue;
             }
-            if consume_regex_comment(ch, &mut chars, &mut current) {
+            if depth_angle == 0
+                && !in_single_quote
+                && !in_double_quote
+                && consume_regex_comment(ch, &mut chars, &mut current)
+            {
                 continue;
             }
             // See `split_top_level_alternation`: `'`/`"` inside a `<...>` assertion

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -105,6 +105,9 @@ impl Interpreter {
                 escaped = true;
                 continue;
             }
+            if consume_regex_comment(ch, &mut chars, &mut current) {
+                continue;
+            }
             // Inside a `<...>` assertion, `'` and `"` are ordinary characters, not
             // quote delimiters: a `< a b ' c >` alternation may list a lone quote
             // as a one-character word (the HTTP `tchar` set does). Toggling on it
@@ -221,6 +224,9 @@ impl Interpreter {
             if ch == '\\' {
                 current.push(ch);
                 escaped = true;
+                continue;
+            }
+            if consume_regex_comment(ch, &mut chars, &mut current) {
                 continue;
             }
             // See `split_top_level_alternation`: `'`/`"` inside a `<...>` assertion

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -173,35 +173,10 @@ impl Interpreter {
             // # starts a comment — skip without interpolation.
             // #`[...] is an embedded comment; plain # is a line comment.
             if ch == '#' {
-                if i + 1 < chars.len() && chars[i + 1] == '`' {
-                    out.push(chars[i]);
-                    i += 1;
-                    out.push(chars[i]); // `
-                    i += 1;
-                    if i < chars.len() {
-                        let bracket = chars[i];
-                        let close =
-                            crate::parser::helpers::matching_bracket(bracket).unwrap_or(bracket);
-                        out.push(bracket);
-                        i += 1;
-                        let mut embed_depth = 1u32;
-                        while i < chars.len() && embed_depth > 0 {
-                            let c = chars[i];
-                            if c == bracket && bracket != close {
-                                embed_depth += 1;
-                            } else if c == close {
-                                embed_depth -= 1;
-                            }
-                            out.push(c);
-                            i += 1;
-                        }
-                    }
-                } else {
-                    while i < chars.len() && chars[i] != '\n' {
-                        out.push(chars[i]);
-                        i += 1;
-                    }
-                }
+                let end = super::regex_parse::regex_comment_end(&chars, i)
+                    .expect("comment marker was checked");
+                out.extend(chars[i..end].iter());
+                i = end;
                 continue;
             }
             // Skip code blocks { ... } — don't interpolate variables inside them

--- a/t/regex-alternation-leading-comment-branch.t
+++ b/t/regex-alternation-leading-comment-branch.t
@@ -52,4 +52,15 @@ is ~$/, "bar", 'a comment before an aligned leading `|` inside a capture group i
     | 'bar' | 'baz' ] /;
 is ~$/, "bar", 'a comment before an aligned leading `|` inside a non-capturing group is elided too';
 
+# Operators inside regex comments are inert and must not become top-level
+# alternation/conjunction separators.
+"bar" ~~ / # a comment mentioning `|` and & operators
+    | 'bar'
+    | 'baz'
+/;
+is ~$/, "bar", 'operators in a line comment do not split alternation';
+
+ok 'bar' ~~ / #`[an embedded comment containing | and &] 'bar' /,
+    'operators in an embedded comment do not split alternation or conjunction';
+
 done-testing;


### PR DESCRIPTION
## Summary

Fix regex operator splitting when comments contain `|`, `||`, `&`, or `&&`.

## Root cause

The top-level regex alternation and conjunction scanners treated operator characters inside line and embedded regex comments as real separators. This could create spurious branches and fail to parse otherwise valid patterns.

## Changes

- Centralize regex comment scanning for structural parsing and scalar interpolation.
- Make alternation and conjunction splitting skip comment spans.
- Add regression coverage for line and embedded comments containing operators.

## Validation

- `cargo test --lib regex_parse -- --nocapture`
- `prove -v -e target/debug/mutsu t/regex-alternation-leading-comment-branch.t`
- `cargo clippy -- -D warnings`
- `cargo fmt --all`
