### PR TITLE
feat(dispatch): ADR-0019 E11 slice 5 -- REPL gist display cutover, closes E11

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -4100,7 +4100,7 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   tests) and the targeted wrap/dispatch suite
   (`roast/S06-advanced/{dispatching,wrap}.t`, `roast/S14-traits/routines.t`,
   `roast/integration/failure-and-callsame.t`, `t/wrap.t`, `t/wrap-closure-capture.t`) green.
-- [ ] **E11 — Retire arity-specific lookup entry points.** Keep native arity functions only as
+- [x] **E11 — Retire arity-specific lookup entry points.** Keep native arity functions only as
   handler implementations selected by `MethodEntry`.
   **Design 2026-08-10** (same doc): grep-based completion criterion — no caller of
   `native_method_{0,1,2}arg` outside the resolver's native-invocation helper, `builtins/`
@@ -4202,6 +4202,42 @@ phase are `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1),
   signature, `test_functions/mod.rs::value_raku_repr`'s free-function callers, or `repl_core.rs`'s
   `.gist` display), or revisit the grep-based completion criterion now that the two `.^can` sites are
   closed.
+  **Progress 2026-08-14 — slice 3 landed.** `runtime/builtins_collection.rs`'s
+  `builtin_unary_collection_method` (backing the free-function `keys()`/`values()`/`kv()`/`pairs()`
+  builtins) took `&self` and called `native_method_0arg()` directly. Changed its signature to
+  `&mut self` and routed it through `call_method_with_values()`, guarded by `e2_native_method_exists()`
+  to preserve the exact prior fallback (an unrecognized `(target, method)` pair — e.g. a bare `keys()`
+  call with no target — still yields an empty list instead of a dispatch error). Verified against real
+  `raku` across `Hash`/`Array`/`Int`/`Any` receivers; `roast/S32-hash`/`S32-array`
+  `keys`/`values`/`kv`/`pairs` and the `S02-types` `set`/`bag`/`mix` family, plus full local `make test`
+  (3131 files), all green.
+  **Progress 2026-08-14 — slice 4 landed.** `test_functions/mod.rs::value_raku_repr`, the
+  "expected:"/"got:" diagnostic formatter behind `is-deeply`/`is-eqv`, was a free function calling
+  `native_method_0arg()` directly — which never recognizes a user-defined `.raku` override on an
+  `Instance`, so the diagnostic silently fell back to a generic stringification. Converted to a
+  `&mut self` method routing through `call_method_with_values()`, guarded by `e2_native_method_exists()`
+  to preserve the exact prior fallback (an unrecognized `(val, "raku")` pair still falls back to
+  `to_string_value()`, not a dispatch error); the four `.map(Self::value_raku_repr)` call sites in
+  `test_functions/comparison.rs` became closures over `&mut self`. New pin:
+  `t/is-deeply-user-raku-diagnostic.t`, verified against real `raku` first. Full local `make test`
+  (3132 files) green.
+  **Progress 2026-08-14 — slice 5 landed.** `repl_core.rs`'s last-value display was the last deferred
+  site: it called `native_method_0arg(&value, "gist")` directly, falling back to
+  `value.to_string_value()` on a miss — a native-only probe that never sees a user-defined `.gist` on
+  an `Instance`. Routed the display through `call_method_with_values(value, "gist", vec![])`, keeping
+  the identical fallback shape (any error still falls back to `to_string_value()`). Verified against
+  real `raku`'s REPL (`class Foo { has $.x; method gist { "Foo<{$!x}>" } }; Foo.new(x=>42)` answers
+  `Foo<42>` in both). New pin: `test_user_defined_gist_wins_in_repl_display` in `repl_core.rs`'s test
+  module. Full local `make test` (3137 files) green.
+  **Every site in the original deferred-sites inventory is now cut over.** Re-checked the grep-based
+  completion criterion: `grep -rn 'native_method_[012]arg' src --include='*.rs'` outside
+  `src/builtins/` now returns only the two canonical invocation points
+  (`Interpreter::call_method_with_values`'s by-arity match in `methods_call_dispatch.rs` and
+  `Interpreter::try_native_method`/`try_native_method_raw` in `vm/vm_native_dispatch.rs`) plus doc
+  comments — every other match found before slice 1 is gone. **E11 closes here.** No dedicated guard
+  test was added (G1/G2 in "Completion gates" cover the whole ADR at the end, not per-box); a future
+  regression would need a new caller of the arity functions outside those two sites, which `cargo
+  clippy`/code review would catch since the functions are `pub(crate)` with a narrow call surface.
 
 ### Phase F — derive introspection and remove compatibility state
 

--- a/news/2026-08/adr0019-e11-slice3-collection-unary-cutover.md
+++ b/news/2026-08/adr0019-e11-slice3-collection-unary-cutover.md
@@ -1,0 +1,19 @@
+# ADR-0019 E11 slice 3: collection unary builtins route through the resolver
+
+ADR-0019 Phase E box E11 retires direct callers of the
+`native_method_{0,1,2}arg` arity cascades outside the resolver's two canonical
+invocation points. The free-function `keys()`/`values()`/`kv()`/`pairs()`
+builtins in `runtime/builtins_collection.rs` were still one of the deferred
+sites: `builtin_unary_collection_method` took `&self` and called
+`native_method_0arg()` directly, bypassing `call_method_with_values()`.
+
+This slice routes the four builtins through `call_method_with_values()`,
+guarded by the E2 catalog's `e2_native_method_exists()` existence check (added
+in slice 2) to preserve the exact prior fallback: an unrecognized
+`(target, method)` pair — e.g. a bare `keys()` call with no target — still
+yields an empty list instead of a dispatch error.
+
+Verified against real `raku` across `Hash`/`Array`/`Int`/`Any` receivers.
+`make test` (3131 files) and the relevant roast files
+(`S32-hash`/`S32-array` `keys`/`values`/`kv`/`pairs`, `S02-types`
+`set`/`bag`/`mix` family) all green.

--- a/news/2026-08/adr0019-e11-slice4-value-raku-repr-cutover.md
+++ b/news/2026-08/adr0019-e11-slice4-value-raku-repr-cutover.md
@@ -1,0 +1,18 @@
+# ADR-0019 E11 slice 4: is-deeply/is-eqv diagnostic formatter routes through the resolver
+
+`value_raku_repr`, the "expected:"/"got:" diagnostic formatter behind
+`is-deeply`/`is-eqv`, was a free function that called `native_method_0arg()`
+directly — which never recognizes a user-defined `.raku` override on an
+`Instance`, so the diagnostic silently fell back to a generic
+stringification instead of the user's own `.raku`.
+
+This slice converts it to a `&mut self` method routing through
+`call_method_with_values()`, guarded by `e2_native_method_exists()` (from
+slice 2) to preserve the exact prior fallback: an unrecognized
+`(val, "raku")` pair still falls back to `to_string_value()`, not a dispatch
+error. The four call sites in `test_functions/comparison.rs`'s combinator
+chains were converted to closures over `&mut self`.
+
+New pin: `t/is-deeply-user-raku-diagnostic.t` (verified against real `raku` —
+the user-defined `.raku` override shows up in the diagnostic there too).
+`make test` (3132 files) green.

--- a/news/2026-08/adr0019-e11-slice5-repl-gist-cutover.md
+++ b/news/2026-08/adr0019-e11-slice5-repl-gist-cutover.md
@@ -1,0 +1,24 @@
+# ADR-0019 E11 slice 5: REPL last-value gist display routes through the resolver
+
+The REPL's last-value display (`repl_core.rs::process_line`) called
+`native_method_0arg(&value, "gist")` directly, falling back to
+`value.to_string_value()` on a miss. That native-only probe never sees a
+user-defined `.gist` method on an `Instance`, so a class overriding `.gist`
+displayed as a generic stringification instead of its own representation —
+this was the last of the four sites deferred from ADR-0019's E11 slice 1/2
+inventory (`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`).
+
+Routed the display through `Interpreter::call_method_with_values(value, "gist",
+vec![])`, keeping the exact same fallback shape: any error (no `gist` handler
+recognized) still falls back to `to_string_value()`.
+
+Verified against real `raku`'s REPL: `class Foo { has $.x; method gist {
+"Foo<{$!x}>" } }; Foo.new(x=>42)` answers `Foo<42>` in both. New pin:
+`test_user_defined_gist_wins_in_repl_display` in `repl_core.rs`'s test module.
+`cargo build`/`clippy -D warnings`/`fmt` clean; full local `make test` (3137
+files) green.
+
+This closes every site in ADR-0019 E11's original deferred-sites inventory;
+the grep-based completion criterion (no caller of `native_method_{0,1,2}arg`
+outside the resolver's two canonical entry points, `builtins/` internal
+recursion, and `#[cfg(test)]`) can be re-checked next.

--- a/src/repl_core.rs
+++ b/src/repl_core.rs
@@ -5,7 +5,6 @@
 //! the exact same line-accumulation and value-display semantics.
 
 use crate::Interpreter;
-use crate::builtins::native_method_0arg;
 
 /// Check if the input has unbalanced brackets, suggesting more input is needed.
 pub(crate) fn is_incomplete(input: &str) -> bool {
@@ -108,8 +107,8 @@ pub(crate) fn process_line(
                 && let Some(value) = interpreter.last_value.take()
                 && !value.is_nil()
             {
-                let text = if let Some(Ok(gist)) =
-                    native_method_0arg(&value, crate::symbol::Symbol::intern("gist"))
+                let text = if let Ok(gist) =
+                    interpreter.call_method_with_values(value.clone(), "gist", Vec::new())
                 {
                     format!("{}\n", gist.to_string_value())
                 } else {
@@ -295,5 +294,19 @@ mod tests {
     fn test_multiline_paren_continuation() {
         let out = repl_session(&["say (1,", "2).elems"]);
         assert_eq!(out, vec!["2\n"]);
+    }
+
+    /// A user-defined `.gist` override must win over the native fallback when
+    /// the REPL displays a line's last value — the native probe alone never
+    /// sees an `Instance`'s own method. Confirmed against real `raku`'s REPL
+    /// (`class Foo { has $.x; method gist { "Foo<{$!x}>" } }; Foo.new(x=>42)`
+    /// answers `Foo<42>`, not the default positional gist).
+    #[test]
+    fn test_user_defined_gist_wins_in_repl_display() {
+        let out = repl_session(&[
+            "class Foo { has $.x; method gist { \"Foo<{$!x}>\" } }",
+            "Foo.new(x => 42)",
+        ]);
+        assert_eq!(out, vec!["Foo<42>\n"]);
     }
 }


### PR DESCRIPTION
## Summary
- The REPL's last-value display (`repl_core.rs::process_line`) called `native_method_0arg(&value, "gist")` directly, falling back to `value.to_string_value()` on a miss -- a native-only probe that never sees a user-defined `.gist` on an `Instance`. Routed the display through `Interpreter::call_method_with_values(value, "gist", vec![])`, keeping the identical fallback shape (any error still falls back to `to_string_value()`).
- This closes every site in ADR-0019 E11's deferred-sites inventory. Re-checked the grep-based completion criterion: `native_method_{0,1,2}arg` now has no caller outside the resolver's two canonical entry points (`call_method_with_values`, `try_native_method`) and `builtins/` internal recursion -- **E11's checkbox flips to done**.
- Also backfills the ADR progress notes and `news/` entries for slices 3 and 4 (collection unary builtins, is-deeply/is-eqv diagnostic formatter), which landed in #6386/#6387 without them.

## Test plan
- [x] Verified against real `raku`'s REPL first: `class Foo { has $.x; method gist { "Foo<{$!x}>" } }; Foo.new(x=>42)` answers `Foo<42>` in both.
- [x] New pin: `test_user_defined_gist_wins_in_repl_display` in `repl_core.rs`
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] full local `make test` (3137 files, PASS)
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)