### PR TITLE
feat: accept is repr<...> angle-bracket trait and the native package declarator

### DIFF
--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -615,6 +615,35 @@ pub(super) fn skip_balanced_parens(input: &str) -> &str {
     }
 }
 
+/// Parse a `<...>` trait argument (e.g. `is repr<CStruct>`, `is ctype<long>`),
+/// depth-tracking nested `<...>` and `\`-escapes. Returns the trimmed content
+/// and the input past the closing `>`.
+pub(super) fn parse_trait_angle_arg(input: &str) -> PResult<'_, String> {
+    let after_open = input
+        .strip_prefix('<')
+        .ok_or_else(|| PError::expected("trait angle argument"))?;
+    let mut depth = 1u32;
+    let mut chars = after_open.char_indices();
+    while let Some((i, c)) = chars.next() {
+        match c {
+            '>' => {
+                depth -= 1;
+                if depth == 0 {
+                    let arg = after_open[..i].trim().to_string();
+                    let after_close = &after_open[i + 1..];
+                    return Ok((after_close, arg));
+                }
+            }
+            '<' => depth += 1,
+            '\\' => {
+                chars.next();
+            }
+            _ => {}
+        }
+    }
+    Err(PError::expected("closing '>' in trait argument"))
+}
+
 /// Require at least one whitespace character (or comment).
 pub(super) fn ws1(input: &str) -> PResult<'_, ()> {
     let (rest, _) = ws(input)?;

--- a/src/parser/stmt/class.rs
+++ b/src/parser/stmt/class.rs
@@ -35,7 +35,9 @@ pub(crate) use package_decl::{
 
 // Public entry points — preserve each function's original visibility.
 pub(super) use class_decl::{also_trait_stmt, class_decl_body};
-pub(crate) use class_decl::{anon_class_decl, augment_class_decl, class_decl, declare_decl};
+pub(crate) use class_decl::{
+    anon_class_decl, augment_class_decl, class_decl, declare_decl, native_decl,
+};
 pub(super) use grammar_module::{does_decl, grammar_decl, module_decl, token_decl, trusts_decl};
 pub(super) use package_decl::{
     package_decl, package_decl_my, proto_decl, proto_decl_scoped, unit_module_stmt,

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -6,7 +6,7 @@ use crate::value::Value;
 use crate::value::ValueView;
 
 use crate::parser::expr::expression;
-use crate::parser::helpers::{skip_balanced_parens, ws, ws1};
+use crate::parser::helpers::{parse_trait_angle_arg, skip_balanced_parens, ws, ws1};
 use crate::parser::parse_result::{PError, PResult, opt_char, take_while1};
 use crate::parser::stmt::sub::parse_indirect_decl_name;
 use crate::parser::stmt::{block, keyword, qualified_ident};
@@ -195,6 +195,23 @@ pub(crate) fn class_decl(input: &str) -> PResult<'_, Stmt> {
     Ok((rest, stmt))
 }
 
+/// Parse `native` declaration: a package declarator peer to `class`/`role`,
+/// used by rakudo's `NativeCall::Types` to define native scalar types
+/// (`native long is Int is ctype<long> is repr<P6int> { }`). Parses exactly
+/// like `class`; the resulting ClassDecl carries a `__mutsu_native_decl`
+/// marker trait so a `native`-declared type can be told apart from an
+/// ordinary class if that ever matters.
+pub(crate) fn native_decl(input: &str) -> PResult<'_, Stmt> {
+    let rest = keyword("native", input).ok_or_else(|| PError::expected("native declaration"))?;
+    let (rest, _) = ws1(rest)?;
+    let (rest, mut stmt) = class_decl_body(rest, false)?;
+    if let Stmt::ClassDecl { custom_traits, .. } = &mut stmt {
+        custom_traits.push(("__mutsu_native_decl".to_string(), None));
+    }
+    reject_trailing_postfix(rest)?;
+    Ok((rest, stmt))
+}
+
 /// Parse a declarator registered through a `use`d module's EXPORTHOW::DECLARE
 /// block (`my package EXPORTHOW { package DECLARE { constant kw = SomeHOW } }`):
 /// `kw Name { ... }` parses exactly like `class`, and the resulting ClassDecl
@@ -326,6 +343,13 @@ pub(crate) fn anon_class_decl(input: &str) -> PResult<'_, Stmt> {
         let (r2, _) = ws1(r2)?;
         let (r2, parent) = qualified_ident(r2)?;
         if parent == "repr" {
+            if r2.starts_with('<') {
+                let (r3, repr_val) = parse_trait_angle_arg(r2)?;
+                anon_repr = Some(repr_val);
+                let (r3, _) = ws(r3)?;
+                r = r3;
+                continue;
+            }
             if let Some(inner) = r2.strip_prefix('(') {
                 let end = inner.find(')').unwrap_or(inner.len());
                 let repr_val = inner[..end].trim().trim_matches('\'').trim_matches('"');
@@ -418,7 +442,14 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             } else if parent == "rw" {
                 class_is_rw = true;
             } else if parent == "repr" {
-                // Extract repr value from `is repr('CUnion')` etc.
+                // Extract repr value from `is repr('CUnion')` or `is repr<CUnion>`.
+                if r2.starts_with('<') {
+                    let (r3, repr_val) = parse_trait_angle_arg(r2)?;
+                    is_repr = Some(repr_val);
+                    let (r3, _) = ws(r3)?;
+                    r = r3;
+                    continue;
+                }
                 if let Some(inner) = r2.strip_prefix('(') {
                     // Find the content between parens, stripping quotes
                     let end = inner.find(')').unwrap_or(inner.len());
@@ -486,6 +517,15 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
                     | "repr"
                     | "open"
             ) {
+                // Check for an angle-bracket argument: `is trait-name<arg>`
+                // (e.g. `is ctype<long>`), as used by NativeCall-style traits.
+                if r2.starts_with('<') {
+                    let (r3, arg) = parse_trait_angle_arg(r2)?;
+                    custom_traits.push((parent.clone(), Some(Expr::Literal(Value::str(arg)))));
+                    let (r3, _) = ws(r3)?;
+                    r = r3;
+                    continue;
+                }
                 // Check for parenthesized argument: `is trait-name('arg')`
                 // This indicates a custom trait_mod:<is> call.
                 if let Some(inner_start) = r2.strip_prefix('(') {

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -4,7 +4,7 @@ use crate::ast::Stmt;
 use crate::symbol::Symbol;
 use crate::value::Value;
 
-use crate::parser::helpers::{skip_balanced_parens, ws, ws1};
+use crate::parser::helpers::{parse_trait_angle_arg, skip_balanced_parens, ws, ws1};
 use crate::parser::parse_result::{PError, PResult, opt_char, parse_char};
 use crate::parser::primary::var::is_pseudo_package;
 use crate::parser::stmt::sub::parse_sub_name;
@@ -188,6 +188,8 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         let mut is_hidden = false;
         let mut hidden_parents = Vec::new();
         let mut parent_args: Vec<(String, Vec<crate::ast::Expr>)> = Vec::new();
+        let mut is_repr: Option<String> = None;
+        let mut custom_traits: Vec<(String, Option<crate::ast::Expr>)> = Vec::new();
         let mut r = r;
         loop {
             if let Some(r2) = keyword("is", r) {
@@ -208,6 +210,24 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     let (r2, _) = ws(r2)?;
                     r = r2;
                     continue;
+                } else if parent == "repr" {
+                    // `unit class Foo is repr('CStruct');` / `is repr<CStruct>;`
+                    if r2.starts_with('<') {
+                        let (r3, repr_val) = parse_trait_angle_arg(r2)?;
+                        is_repr = Some(repr_val);
+                        let (r3, _) = ws(r3)?;
+                        r = r3;
+                        continue;
+                    }
+                    if let Some(inner) = r2.strip_prefix('(') {
+                        let end = inner.find(')').unwrap_or(inner.len());
+                        let repr_val = inner[..end].trim().trim_matches('\'').trim_matches('"');
+                        is_repr = Some(repr_val.to_string());
+                    }
+                    let r2 = skip_balanced_parens(r2);
+                    let (r2, _) = ws(r2)?;
+                    r = r2;
+                    continue;
                 } else if parent.starts_with(|c: char| c.is_ascii_uppercase())
                     || parent.starts_with("::")
                 {
@@ -225,9 +245,20 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     continue;
                 }
                 // A lowercase `is` name on a `unit class` is a trait
-                // (`export`, `repr('CStruct')`, `DEPRECATED`, custom trait_mod,
-                // ...), NOT a parent class. Skip it and any parenthesized
-                // argument rather than mis-recording it as a superclass.
+                // (`export`, `DEPRECATED`, `ctype<...>`, a custom trait_mod,
+                // ...), NOT a parent class. Record name + angle/paren
+                // argument (if any) as a custom trait rather than mis-recording
+                // it as a superclass.
+                if r2.starts_with('<') {
+                    let (r3, arg) = parse_trait_angle_arg(r2)?;
+                    custom_traits.push((
+                        parent.clone(),
+                        Some(crate::ast::Expr::Literal(Value::str(arg))),
+                    ));
+                    let (r3, _) = ws(r3)?;
+                    r = r3;
+                    continue;
+                }
                 let r2 = skip_balanced_parens(r2);
                 let (r2, _) = ws(r2)?;
                 r = r2;
@@ -267,10 +298,10 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     is_lexical: false,
                     hidden_parents,
                     does_parents,
-                    repr: None,
+                    repr: is_repr,
                     body: Vec::new(),
                     language_version: super::super::simple::current_language_version(),
-                    custom_traits: Vec::new(),
+                    custom_traits,
                     is_unit: true,
                     decl_id: crate::ast::next_class_decl_id(),
                     parent_args,
@@ -334,6 +365,16 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                     let r2 = skip_balanced_parens(r2);
                     let (r2, _) = ws(r2)?;
                     r = r2;
+                } else if r2.starts_with('<') {
+                    // `is repr<CStruct>` / `is ctype<long>` — angle-bracket
+                    // trait argument (no dedicated field on RoleDecl, so it
+                    // is recorded via custom_traits like an unrecognized
+                    // `is` trait with a parenthesized argument).
+                    let (r3, arg) = parse_trait_angle_arg(r2)?;
+                    custom_traits
+                        .push((trait_name, Some(crate::ast::Expr::Literal(Value::str(arg)))));
+                    let (r3, _) = ws(r3)?;
+                    r = r3;
                 } else {
                     // Unknown lowercase trait: skip any parenthesized argument.
                     // An uppercase bare name would be a parent role, but a
@@ -617,4 +658,48 @@ pub(crate) fn proto_decl_scoped(input: &str, is_our: bool) -> PResult<'_, Stmt> 
             is_our,
         },
     ))
+}
+
+#[cfg(test)]
+mod unit_repr_tests {
+    use super::*;
+
+    // `unit class`/`unit role` extend to the end of the file, so their
+    // angle-bracket trait parsing (`is repr<...>`, `is ctype<...>`) is
+    // exercised here directly rather than via a t/*.t script — see
+    // t/is-repr-angle-bracket-trait.t for the block-form (`class`/`role`)
+    // coverage of the same underlying `parse_trait_angle_arg` mechanism.
+
+    #[test]
+    fn unit_class_accepts_repr_angle_trait() {
+        let (_, stmt) = unit_module_stmt("unit class Foo is repr<CStruct>;").unwrap();
+        let Stmt::ClassDecl { repr, .. } = stmt else {
+            panic!("expected ClassDecl, got {stmt:?}");
+        };
+        assert_eq!(repr.as_deref(), Some("CStruct"));
+    }
+
+    #[test]
+    fn unit_class_accepts_ctype_angle_trait_as_custom_trait() {
+        let (_, stmt) = unit_module_stmt("unit class Foo is ctype<long>;").unwrap();
+        let Stmt::ClassDecl { custom_traits, .. } = stmt else {
+            panic!("expected ClassDecl, got {stmt:?}");
+        };
+        assert!(
+            custom_traits.iter().any(|(name, _)| name == "ctype"),
+            "expected a 'ctype' custom trait, got {custom_traits:?}"
+        );
+    }
+
+    #[test]
+    fn unit_role_accepts_ctype_angle_trait_as_custom_trait() {
+        let (_, stmt) = unit_module_stmt("unit role Foo is ctype<long>;").unwrap();
+        let Stmt::RoleDecl { custom_traits, .. } = stmt else {
+            panic!("expected RoleDecl, got {stmt:?}");
+        };
+        assert!(
+            custom_traits.iter().any(|(name, _)| name == "ctype"),
+            "expected a 'ctype' custom trait, got {custom_traits:?}"
+        );
+    }
 }

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -5,7 +5,7 @@ use crate::symbol::Symbol;
 use crate::value::Value;
 
 use crate::parser::expr::expression;
-use crate::parser::helpers::{skip_balanced_parens, ws, ws1};
+use crate::parser::helpers::{parse_trait_angle_arg, skip_balanced_parens, ws, ws1};
 use crate::parser::parse_result::{PError, PResult, parse_char};
 use crate::parser::stmt::sub::parse_single_param;
 use crate::parser::stmt::{block, ident, keyword, parse_param_list, qualified_ident};
@@ -349,11 +349,31 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
                     | "nodal"
                     | "pure"
             ) {
-                // Known lowercase trait keywords are skipped
-                let r = skip_balanced_parens(r);
+                // Known lowercase trait keywords are skipped (RoleDecl has no
+                // dedicated `repr` field, unlike ClassDecl — this only makes
+                // `is repr<...>`/`is repr(...)` parse, matching the
+                // pre-existing paren-only behaviour of silently discarding
+                // the value rather than newly wiring it into trait_mod:<is>
+                // dispatch, which would misfire on unrelated user-defined
+                // trait_mod:<is> candidates that don't accept a `:$repr`).
+                let r = if r.starts_with('<') {
+                    parse_trait_angle_arg(r)?.0
+                } else {
+                    skip_balanced_parens(r)
+                };
                 let (r, _) = ws(r)?;
                 rest = r;
             } else {
+                // Unknown trait (e.g. `ctype`, which has no dedicated field
+                // on RoleDecl either) — record name + argument via
+                // custom_traits, same as a class's generic `is` fallback.
+                if r.starts_with('<') {
+                    let (r2, arg) = parse_trait_angle_arg(r)?;
+                    custom_traits.push((trait_name.clone(), Some(Expr::Literal(Value::str(arg)))));
+                    let (r2, _) = ws(r2)?;
+                    rest = r2;
+                    continue;
+                }
                 // Unknown trait — check for parenthesized argument for
                 // custom trait_mod:<is> dispatch.
                 if let Some(inner_start) = r.strip_prefix('(') {

--- a/src/parser/stmt/decl/my_decl_dispatch.rs
+++ b/src/parser/stmt/decl/my_decl_dispatch.rs
@@ -200,6 +200,15 @@ pub(super) fn try_keyword_dispatch(
         let (r, _) = ws1(r)?;
         return class_decl_body(r, !is_our).map(Some);
     }
+    // our native Name is Type is ctype<...> is repr<...> { ... }
+    if let Some(r) = keyword("native", rest) {
+        let (r, _) = ws1(r)?;
+        let (r, mut stmt) = class_decl_body(r, !is_our)?;
+        if let Stmt::ClassDecl { custom_traits, .. } = &mut stmt {
+            custom_traits.push(("__mutsu_native_decl".to_string(), None));
+        }
+        return Ok(Some((r, stmt)));
+    }
     // my grammar Name { ... }
     if keyword("grammar", rest).is_some() {
         return super::super::class::grammar_decl(rest).map(Some);

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -133,6 +133,7 @@ const STMT_PARSERS: &[StmtParser] = &[
     class::augment_class_decl,
     class::anon_class_decl,
     class::class_decl,
+    class::native_decl,
     class::declare_decl,
     class::role_decl,
     class::grammar_decl,

--- a/src/parser/stmt/sub.rs
+++ b/src/parser/stmt/sub.rs
@@ -1,5 +1,5 @@
 use super::super::expr::expression;
-use super::super::helpers::{skip_balanced_parens, ws, ws1};
+use super::super::helpers::{parse_trait_angle_arg, skip_balanced_parens, ws, ws1};
 use super::super::parse_result::{PError, PResult, parse_char, take_while1};
 use crate::token_kind::{TokenKind, lookup_unicode_char_by_name};
 

--- a/src/parser/stmt/sub/traits.rs
+++ b/src/parser/stmt/sub/traits.rs
@@ -316,32 +316,6 @@ pub(crate) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
     }
 }
 
-pub(crate) fn parse_trait_angle_arg(input: &str) -> PResult<'_, String> {
-    let after_open = input
-        .strip_prefix('<')
-        .ok_or_else(|| PError::expected("trait angle argument"))?;
-    let mut depth = 1u32;
-    let mut chars = after_open.char_indices();
-    while let Some((i, c)) = chars.next() {
-        match c {
-            '>' => {
-                depth -= 1;
-                if depth == 0 {
-                    let arg = after_open[..i].trim().to_string();
-                    let after_close = &after_open[i + 1..];
-                    return Ok((after_close, arg));
-                }
-            }
-            '<' => depth += 1,
-            '\\' => {
-                chars.next();
-            }
-            _ => {}
-        }
-    }
-    Err(PError::expected("closing '>' in trait argument"))
-}
-
 pub(crate) fn parse_export_trait_tags(input: &str) -> PResult<'_, Vec<String>> {
     let mut tags = Vec::new();
     let (mut rest, _) = ws(input)?;

--- a/t/is-repr-angle-bracket-trait.t
+++ b/t/is-repr-angle-bracket-trait.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 8;
+
+# Raku accepts `is repr<Name>` (angle/word-quoting) as an alternative spelling
+# of `is repr('Name')` for the `repr` trait — real dists such as
+# NativeCall::Types use the angle form exclusively (`native long is Int is
+# ctype<long> is repr<P6int> { }`). Previously mutsu's `is`/`does`/`hides`
+# loops only recognised a parenthesized trait argument, so `is repr<...>`
+# silently failed to parse the class and the parser fell back to treating
+# `class Foo` and `is repr<CStruct> { }` as separate (nonsensical)
+# expressions, surfacing as a confusing `Unknown function: is` runtime error.
+
+class AStruct is repr<CStruct> {
+    has uint64 $.a;
+}
+is AStruct.REPR, 'CStruct', 'class: is repr<CStruct> (angle form) sets REPR like is repr(\'CStruct\')';
+
+class Uninstantiable is repr<Uninstantiable> { }
+is Uninstantiable.^name, 'Uninstantiable', 'class: is repr<Uninstantiable> parses (non-C repr name)';
+
+# --- trait_mod:<is> dispatch: an angle-bracket argument reaches user code
+# exactly like a parenthesized one, both for classes and for roles. `ctype`
+# has no dedicated AST field (unlike `repr`), so it is only observable
+# through the custom_traits -> trait_mod:<is> dispatch mechanism.
+
+my @log;
+multi sub trait_mod:<is>(Mu:U $t, :$ctype!) { @log.push("{$t.^name}:ctype:{$ctype}") }
+
+class WithCtype is ctype<long> { }
+ok @log.grep('WithCtype:ctype:long'),
+    'class: is ctype<long> (angle form, no dedicated field) reaches trait_mod:<is>';
+
+@log = ();
+role RoleWithRepr is repr<CStruct> { }
+is +@log, 0, 'role: is repr<...> does not spuriously dispatch an unrelated trait';
+
+@log = ();
+role RoleWithCtype is ctype<long> { }
+ok @log.grep('RoleWithCtype:ctype:long'),
+    'role: is ctype<long> (angle form) reaches trait_mod:<is>, same as class';
+
+# --- sanity: the pre-existing parenthesized form keeps working unchanged.
+
+class ParenStruct is repr('CStruct') {
+    has uint64 $.a;
+}
+is ParenStruct.REPR, 'CStruct', 'sanity: is repr(\'CStruct\') (paren form) still works';
+
+@log = ();
+class ParenCtype is ctype('long') { }
+ok @log.grep('ParenCtype:ctype:long'),
+    'sanity: is ctype(\'long\') (paren form) still reaches trait_mod:<is>';
+
+class Ordinary { has $.x }
+is Ordinary.REPR, 'P6opaque', 'sanity: an ordinary class is still P6opaque';

--- a/t/native-package-declarator.t
+++ b/t/native-package-declarator.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 8;
+
+# `native` is a package declarator peer to `class`/`role`/`grammar` that
+# rakudo's NativeCall::Types uses to define native scalar types, e.g.
+# `native long is Int is ctype<long> is repr<P6int> { }`. mutsu had no
+# statement-level handling for the `native` keyword at all, so `our native
+# long is Int is ctype<long> is repr<P6int> { }` failed with
+# `X::Syntax::Malformed: Malformed my`. This is unrelated to full NativeCall
+# support: `native` parses like `class` (same `is`/`does`/`hides` loop, same
+# body), it's just a different declarator keyword.
+
+native mynativeint is Int is ctype<long> is repr<P6int> { }
+is mynativeint.^name, 'mynativeint', 'bare "native Name is Type { }" declares a type';
+is mynativeint.^parents(:all).map(*.^name).grep('Int').elems, 1,
+    '"native Name is Type" makes Type a parent, same as "class Name is Type"';
+
+our native mynativebyte is Int { }
+is mynativebyte.^name, 'mynativebyte', '"our native Name is Type { }" also parses';
+
+my $r = do {
+    my native mynativeshort is Int { }
+    mynativeshort.^name;
+};
+is $r, 'mynativeshort', '"my native Name is Type { }" also parses';
+
+# --- trait_mod:<is> dispatch: `ctype` (no dedicated field) still reaches
+# user code from a `native` declaration, same as it does from a class.
+
+my @log;
+multi sub trait_mod:<is>(Mu:U $t, :$ctype!) { @log.push("{$t.^name}:ctype:{$ctype}") }
+
+native mynativelong is Int is ctype<long> { }
+ok @log.grep('mynativelong:ctype:long'),
+    'native: is ctype<long> reaches trait_mod:<is>, same as a class';
+
+# --- an ordinary method still works on a `native`-declared type, confirming
+# the body parses exactly like a class body (not just the declarator line).
+
+native mynativecounter is Int {
+    method describe() { "native:ok" }
+}
+is mynativecounter.new.describe, 'native:ok', 'a native-declared type has a working body/methods';
+
+# --- sanity: `native` used as a sub trait (`is native('libname')`) in its
+# existing, unrelated position is unaffected by the new statement-level
+# `native` keyword — it must not be misparsed as the package declarator.
+sub some_c_call() is native('libc') { * }
+ok True, '"is native(...)" as a sub trait still parses (no collision)';
+
+is 1 + 1, 2, 'sanity: ordinary code after native declarations still parses';

--- a/t/unit-class-repr-angle-trait.t
+++ b/t/unit-class-repr-angle-trait.t
@@ -1,0 +1,17 @@
+use Test;
+
+plan 1;
+
+# `unit class Foo is repr<CStruct>;` had the same paren-only-trait-argument
+# limitation as the block form (`t/is-repr-angle-bracket-trait.t`), plus its
+# own separate hand-duplicated `is`/`does`/`hides` loop that discarded `repr`
+# entirely regardless of syntax. A `unit class` statement extends to the end
+# of the file, so this needs its own file. (The parsed `repr` value itself is
+# pinned by a Rust unit test in src/parser/stmt/class/package_decl.rs, since
+# `unit class ... is repr(...)` not actually setting `.REPR` at runtime is a
+# separate, pre-existing gap unrelated to this angle-bracket parsing fix.)
+
+unit class Foo is repr<CStruct>;
+has uint64 $.x;
+
+is Foo.^name, 'Foo', 'unit class: is repr<CStruct> (angle form) still declares the type';

--- a/todo/tickets/unit-class-repr-not-registered.md
+++ b/todo/tickets/unit-class-repr-not-registered.md
@@ -1,0 +1,61 @@
+# `unit class Foo is repr('CStruct');` does not set `.REPR` at runtime
+
+Discovered while adding angle-bracket (`is repr<...>`) trait-argument support
+(the parser fix in `src/parser/stmt/class/{class_decl,role_decl,package_decl}.rs`,
+`src/parser/helpers.rs::parse_trait_angle_arg`).
+
+## Repro
+
+```
+$ cargo run -q --bin mutsu -- -e "unit class Foo is repr('CStruct'); has uint64 \$.x; say Foo.REPR"
+P6opaque   # expected: CStruct
+```
+
+The block form works correctly:
+
+```
+$ cargo run -q --bin mutsu -- -e "class Foo is repr('CStruct') { has uint64 \$.x }; say Foo.REPR"
+CStruct
+```
+
+This is **pre-existing** and independent of the angle-bracket-vs-paren
+syntax — both `is repr('CStruct')` and `is repr<CStruct>` fail identically
+for `unit class`, confirmed by AST dump: `--dump-ast` on the `unit class`
+one-liner shows `ClassDecl { repr: Some("CStruct"), body: [.., HasDecl { .. }], is_unit: true, .. }`
+— the parser and the AST-consolidation step that folds the rest of the file
+into the unit class's `body` are both correct. The bug is downstream, in
+either the compiler's plan-building (`compiler/decl_plan.rs::add_class_decl_plan`)
+or the VM's `exec_register_class_op` (`vm/vm_typedecl_ops.rs`) not receiving
+or not acting on `repr` for the `is_unit: true` path the way it does for the
+block form — not yet isolated further.
+
+## Why this is filed separately
+
+Out of scope for the angle-bracket trait-parsing task this was found during:
+that task's job is "the parser accepts and records `is repr<...>`/`is
+ctype<...>`", not "make every existing `is repr(...)` combination register
+correctly at runtime". Fixing this needs tracing `add_class_decl_plan` /
+`exec_register_class_op` for the `is_unit` branch specifically, which is a
+separate, self-contained investigation.
+
+## Where to look first
+
+- `src/compiler/decl_plan.rs::add_class_decl_plan` — confirm `repr` from the
+  `Stmt::ClassDecl` actually reaches `CompiledClassDeclPlan.repr` for an
+  `is_unit: true` declaration (vs. block form).
+- `src/vm/vm_typedecl_ops.rs::exec_register_class_op` (around lines 104-301
+  as of this writing) — confirm the `if let Some(repr_name) = repr { ... }`
+  branch (CStruct/CUnion/CPointer registration) actually runs for a
+  `unit class`-declared type; if it does run, check `register_cstruct_class`/
+  `declared_class_repr` name-matching (`src/runtime/cstruct_layout.rs`) for a
+  package-name qualification mismatch (`Foo` vs. a qualified `GLOBAL::Foo`
+  or similar) between what gets inserted into `registry.cstruct_classes` and
+  what `.REPR`'s lookup queries.
+
+## Regression test once fixed
+
+None yet — `t/unit-class-repr-angle-trait.t` only asserts `Foo.^name` (the
+angle-bracket parsing this was found during, block-form covered by
+`t/is-repr-angle-bracket-trait.t`) and explicitly notes this gap rather than
+asserting the broken `.REPR` value. Once fixed, extend that test (or this
+file) with `is Foo.REPR, 'CStruct', ...` for both the paren and angle forms.


### PR DESCRIPTION
## Summary

Two independent parser gaps identified in `todo/deep/nativecall-cannot-be-vendored.md`'s "Salvageable pieces" section as worth doing on their own merits, independent of the (rejected) full NativeCall vendoring decision:

- `is repr<CStruct>` / `is ctype<long>` (angle/word-quoting trait argument) previously only worked in the parenthesized form (`is repr('CStruct')`); the angle form silently failed to parse the class/role and fell back to a confusing `Unknown function: is` runtime error. Fixed across `class`, `role`, `unit class`, `unit role`, and `anon class`, reusing the angle-bracket scanner already used for sub traits (moved to `parser/helpers.rs` so both class and sub traits share it).
- `native Name is Type is ctype<...> is repr<...> { }` is a package declarator peer to `class`/`role`/`grammar`, used by rakudo's `NativeCall::Types` to define native scalar types. It parses like `class` (reusing `class_decl_body`), tagged with a `__mutsu_native_decl` marker trait, and is wired into both the bare and `my`/`our`-prefixed dispatch paths.

Neither change moves mutsu toward providing `NativeCall` itself — both are missing Raku syntax independent of that decision, per the todo file.

Also filed (not fixed here): `unit class Foo is repr('CStruct');` does not set `.REPR` at runtime even though the block form does — pre-existing, independent of paren vs. angle syntax, discovered while writing tests for this change (`todo/tickets/unit-class-repr-not-registered.md`).

## Test plan

- [x] `cargo build` clean, `cargo fmt`, `cargo clippy -- -D warnings` clean
- [x] New tests: `t/is-repr-angle-bracket-trait.t`, `t/native-package-declarator.t`, `t/unit-class-repr-angle-trait.t`, plus 3 Rust `#[test]`s in `src/parser/stmt/class/package_decl.rs` for the `unit class`/`unit role` forms
- [x] `make test` (cargo tests + full `t/` TAP suite): all green, no regressions
- [ ] CI (`make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)