### PR TITLE
feat(adr0019): E3 — generation-keyed resolved-sequence cache

### DIFF
--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -355,6 +355,7 @@ impl Interpreter {
         self.native_ctor_plan_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.resolved_seq_cache.clear();
         self.func_multi_resolve_cache.clear();
         self.func_multi_type_cacheable.clear();
         self.dispatch_multi_candidate.clear();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2277,6 +2277,22 @@ pub struct Interpreter {
     pub(crate) prepared_fn_defs: HashMap<Symbol, (u64, Arc<FunctionDef>)>,
     pub(crate) method_resolve_cache:
         rustc_hash::FxHashMap<(Symbol, Symbol), crate::vm::MethodResolveEntry>,
+    /// ADR-0019 E3: the generation-keyed resolved-sequence cache (design
+    /// decision 5, `todo/deep/adr0019-e2-e4-resolver-core.md`). Caches the
+    /// ordered candidate universe for `(receiver TypeId, method, call shape)`
+    /// — not a resolved winner, so unlike `multi_resolve_cache` an ambiguous
+    /// per-call ranking never disqualifies an entry from being cached; ranking
+    /// against fresh call args happens every time from the cached candidates.
+    /// Cleared with the other method caches on any registry generation change
+    /// ([`crate::vm::vm_call_method_compiled_cache::Interpreter::refresh_method_caches_for_generation`]).
+    pub(crate) resolved_seq_cache: rustc_hash::FxHashMap<
+        (
+            crate::type_id::TypeId,
+            Symbol,
+            resolution_sequence::CallShape,
+        ),
+        Arc<resolution_sequence::ResolvedSequence>,
+    >,
     /// Registry method generation observed when the method caches were last valid.
     pub(crate) method_cache_generation: u64,
     #[allow(clippy::type_complexity)]

--- a/src/runtime/resolution_sequence.rs
+++ b/src/runtime/resolution_sequence.rs
@@ -173,7 +173,7 @@ pub(crate) struct ResolvedSequence {
 /// the same "DEFINITE" primitive `dispatch_core_coerce.rs`'s `.DEFINITE` arm
 /// implements, needed here to decide whether a `Native` candidate's row
 /// requires [`crate::builtins::native_method_row::NativeRowFlags::TYPE_OBJECT_OK`].
-fn value_is_definite(value: &Value) -> bool {
+pub(crate) fn value_is_definite(value: &Value) -> bool {
     match value.view() {
         ValueView::Nil | ValueView::Package(_) | ValueView::CustomType(..) => false,
         ValueView::Slip(items) if items.is_empty() => false,
@@ -181,7 +181,102 @@ fn value_is_definite(value: &Value) -> bool {
     }
 }
 
+/// ADR-0019 E3 (design decision 5, `todo/deep/adr0019-e2-e4-resolver-core.md`):
+/// the call-shape component of `resolved_seq_cache`'s key
+/// `(TypeId, Symbol, CallShape)`. A [`ResolvedSequence`] only depends on the
+/// receiver's owner chain and the call's arity/named-ness (via
+/// [`NativeCallShape`]'s effect on which `Native` row, if any, is servable) —
+/// not on the concrete argument values — so this is a small, `Copy` hash key
+/// bucketing arity into `0 | 1 | 2 | 3+` and tracking whether any argument is
+/// a named pair.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct CallShape {
+    arity_bucket: u8,
+    has_named: bool,
+}
+
+impl CallShape {
+    pub(crate) fn for_args(args: &[Value]) -> CallShape {
+        let has_named = args
+            .iter()
+            .any(|a| matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)));
+        CallShape {
+            arity_bucket: args.len().min(3) as u8,
+            has_named,
+        }
+    }
+
+    fn arg_count_for_native_shape(self) -> usize {
+        self.arity_bucket as usize
+    }
+}
+
 impl Interpreter {
+    /// ADR-0019 E3 (design decision 5, `todo/deep/adr0019-e2-e4-resolver-core.md`):
+    /// resolve `(cn, method)` for `args`/`target` via the cached
+    /// [`ResolvedSequence`], replacing the live per-call MRO walk
+    /// (`resolve_method_with_owner_impl`, reached via
+    /// `resolve_method_with_owner_invocant`) `resolve_method_cached` used to
+    /// perform at both of its cache-miss paths. The winner-selection algorithm
+    /// itself, [`Self::pick_method_winner_from_sequence`], was verified
+    /// (E3 slice 1) to reproduce `resolve_method_with_owner_impl` exactly —
+    /// zero shadow-check mismatches across the full `t/` suite and the
+    /// dispatch-heaviest roast directories — so this is authoritative, not a
+    /// shadow probe.
+    ///
+    /// The sequence itself is cached per `(receiver TypeId, method, call
+    /// shape)`: unlike `multi_resolve_cache` (which caches a resolved winner
+    /// and therefore must never cache an ambiguous outcome), caching the
+    /// candidate *universe* is safe regardless of ambiguity — ranking against
+    /// the call's actual args happens fresh on every call from the cached
+    /// candidates, exactly as it would from a freshly-walked one.
+    pub(crate) fn resolve_via_sequence_cache(
+        &mut self,
+        cn: &str,
+        method_sym: Symbol,
+        args: &[Value],
+        target: &Value,
+    ) -> Option<(Symbol, MethodDef)> {
+        // `resolve_method_with_owner_impl` resets this at the top of every
+        // call (`resolution_method.rs:164`) — `pick_method_winner` only ever
+        // sets it `true` on ambiguity, never clears it, so callers that check
+        // it right after resolving (multi-resolve-cache's "never cache an
+        // ambiguous outcome" rule) need it reset here too.
+        self.dispatch_ambiguous = false;
+        let owner = TypeId::intern(cn);
+        let shape = CallShape::for_args(args);
+        let mro_arc = self.class_mro(cn);
+        let mro: Vec<Symbol> = mro_arc.iter().copied().collect();
+        let seq = match self.resolved_seq_cache.get(&(owner, method_sym, shape)) {
+            Some(cached) => cached.clone(),
+            None => {
+                let chain: Vec<TypeId> = mro.iter().map(|s| TypeId::from_symbol(*s)).collect();
+                let native_shape = NativeCallShape::new(
+                    shape.arg_count_for_native_shape(),
+                    value_is_definite(target),
+                );
+                let built = Arc::new(self.resolve_sequence(
+                    &chain,
+                    method_sym,
+                    native_shape,
+                    MethodVisibility::Public,
+                ));
+                self.resolved_seq_cache
+                    .insert((owner, method_sym, shape), built.clone());
+                built
+            }
+        };
+        let role_bindings = self.registry().get_role_param_bindings(cn);
+        self.pick_method_winner_from_sequence(
+            &mro,
+            cn,
+            &seq.candidates,
+            args,
+            Some(target),
+            role_bindings.as_ref(),
+        )
+    }
+
     /// Build the ordered user-candidate sequence for `chain` (an E1 TypeId MRO,
     /// most-derived first) and `name`: every non-private, non-submethod-shadowed
     /// candidate at every level, in stored declaration order. Mirrors the

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2416,6 +2416,7 @@ impl Interpreter {
             native_ctor_plan_cache: rustc_hash::FxHashMap::default(),
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
+            resolved_seq_cache: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
             func_multi_resolve_cache: rustc_hash::FxHashMap::default(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -789,6 +789,7 @@ impl Interpreter {
             native_ctor_plan_cache: rustc_hash::FxHashMap::default(),
             multi_resolve_cache: rustc_hash::FxHashMap::default(),
             multi_type_cacheable: rustc_hash::FxHashMap::default(),
+            resolved_seq_cache: rustc_hash::FxHashMap::default(),
             dispatch_multi_candidate: rustc_hash::FxHashMap::default(),
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
             func_multi_resolve_cache: rustc_hash::FxHashMap::default(),

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -13,6 +13,7 @@ impl Interpreter {
         self.native_ctor_plan_cache.clear();
         self.multi_resolve_cache.clear();
         self.multi_type_cacheable.clear();
+        self.resolved_seq_cache.clear();
         self.dispatch_multi_candidate.clear();
         self.clear_private_zeroarg_method_cache();
     }
@@ -222,21 +223,10 @@ impl Interpreter {
             if let Some(hit) = self.multi_resolve_cache.get(&mkey) {
                 return hit.clone();
             }
-            let resolved = loan_env!(
-                self,
-                resolve_method_with_owner_invocant(cn, method, args, target)
-            );
-            // ADR-0019 E4a shadow probe (zero behavior change): see
-            // `todo/deep/adr0019-e2-e4-resolver-core.md`.
-            self.shadow_check_resolver(
-                "resolve_method_cached:multi",
-                cn,
-                method,
-                method_sym,
-                args,
-                target,
-                resolved.as_ref(),
-            );
+            // ADR-0019 E3: resolve via the cached candidate sequence instead
+            // of a live per-call MRO walk. See
+            // `todo/deep/adr0019-e2-e4-resolver-core.md` design decision 5.
+            let resolved = self.resolve_via_sequence_cache(cn, method_sym, args, target);
             let resolved_arc = resolved.map(|(o, d)| (o, std::sync::Arc::new(d)));
             if !self.dispatch_ambiguous {
                 self.multi_resolve_cache.insert(mkey, resolved_arc.clone());
@@ -244,21 +234,10 @@ impl Interpreter {
             return resolved_arc;
         }
         // 4. Resolve fresh; cache the result when it is non-multi.
-        let resolved = loan_env!(
-            self,
-            resolve_method_with_owner_invocant(cn, method, args, target)
-        );
-        // ADR-0019 E4a shadow probe (zero behavior change): see
-        // `todo/deep/adr0019-e2-e4-resolver-core.md`.
-        self.shadow_check_resolver(
-            "resolve_method_cached:fresh",
-            cn,
-            method,
-            method_sym,
-            args,
-            target,
-            resolved.as_ref(),
-        );
+        // ADR-0019 E3: resolve via the cached candidate sequence instead of a
+        // live per-call MRO walk. See
+        // `todo/deep/adr0019-e2-e4-resolver-core.md` design decision 5.
+        let resolved = self.resolve_via_sequence_cache(cn, method_sym, args, target);
         let resolved_arc = resolved.map(|(o, d)| (o, std::sync::Arc::new(d)));
         if resolved_arc.as_ref().is_none_or(|(_, def)| !def.is_multi) {
             self.method_resolve_cache


### PR DESCRIPTION
## Summary

ADR-0019 Phase E box E3 (design decision 5, `todo/deep/adr0019-e2-e4-resolver-core.md`): cache the ordered candidate sequence for `(receiver TypeId, method, call shape)` instead of re-walking the MRO/registry on every uncached call.

- Add `CallShape` (arity bucket `0|1|2|3+`, has-named) and `resolved_seq_cache: FxHashMap<(TypeId, Symbol, CallShape), Arc<ResolvedSequence>>`, cleared alongside the other method caches on every registry-generation change and reset (not cloned) on thread fork, matching every sibling method cache.
- Add `Interpreter::resolve_via_sequence_cache`: builds/looks up the cached sequence, then ranks it with `pick_method_winner_from_sequence` (landed in #6395, already verified byte-for-byte against `resolve_method_with_owner_impl` with zero shadow-check mismatches across the full `t/` suite and the dispatch-heaviest roast directories).
- `resolve_method_cached`'s two cache-miss paths (the sound multi-resolve cache's miss branch, and the final "resolve fresh" branch) now call this instead of `resolve_method_with_owner_invocant`'s live MRO walk. The now-redundant `shadow_check_resolver` calls at these two sites are removed — they would only be comparing the new path against itself.
- `dispatch_ambiguous` is explicitly reset at the top of the new function, matching `resolve_method_with_owner_impl`'s own reset that the old call path relied on (caught this by inspection before testing — `pick_method_winner` only ever sets it `true`, never clears it).
- `fast_method_cache` and the monomorphic IC / non-multi HashMap cache (items 1/2 of `resolve_method_cached`) are untouched — out of this box's scope (F5 retires `fast_method_cache` later, per the design doc).

## Verification

- `cargo test --lib`: 821 passed.
- Full `t/` suite (debug build): `Result: PASS`, no regressions.
- `roast/S12-class` + `S14-roles` + `S06-multi` + `S06-signature` + `S02-lexical_conventions` + `S12-methods` + `S14-traits` (110 files, 2059 tests): only the one pre-existing, non-whitelisted, roast-authored typo in `open_closed.t` (`method h {'called Qux.i'}` vs. the test's own `'called Qux.h'` expectation — confirmed unrelated to dispatch before this PR).
- Local A/B on `benchmarks/bench-class.raku` (method-dispatch heavy) and `bench-tak.raku` (function-call only, a no-dispatch control): interleaved release-binary runs show no measurable difference between the pre-E3 and post-E3 binaries once system-load noise is controlled for. A naive back-to-back (build-all-of-A, then build-all-of-B) comparison initially showed a ~50-60% regression on *both* benchmarks — including `bench-tak`, which never touches method dispatch, so that can only be concurrent-load noise from other sessions on this shared machine (load average 3.5-6 at the time), not a real effect of this change. Re-running with interleaved baseline/cutover invocations back-to-back showed parity. Authoritative numbers will come from bench-CI on merge per CLAUDE.md's benchmark policy — flagging in case the next bench-CI point shows something this local A/B missed.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo test --lib`
- [x] Local `t/` + targeted roast sweep
- [x] Local interleaved bench A/B (see above)
- [ ] CI (`make test` + `make roast`)
- [ ] Watch next bench-CI point on `bench-data` for real perf confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)