### PR TITLE
feat(adr0019): F1 item 1 -- shadow-check ClassDef::methods vs canonical user_candidates

### DIFF
--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -9,41 +9,86 @@ impl Interpreter {
         include_private: bool,
         result: &mut Vec<Value>,
     ) {
-        if let Some(class_def) = self.registry().classes.get(class_name) {
-            // First add accessor methods for public attributes (in order)
-            for attr in &class_def.attributes {
-                if attr.is_public && !class_def.methods.contains_key(&attr.name) {
-                    result.push(self.make_native_method_object(&attr.name));
-                }
-            }
-            // Then add explicit methods
-            for (method_name, overloads) in &class_def.methods {
-                if overloads.is_empty() {
-                    continue;
-                }
-                // Skip private methods unless :private
-                let first = &overloads[0];
-                if first.is_private && !include_private {
-                    continue;
-                }
-                let is_multi = overloads.len() > 1;
-                let return_type = first.return_type.clone();
-                let method_obj = self.make_method_object_with_owner(
-                    method_name,
-                    first,
-                    is_multi,
-                    return_type,
-                    Some(overloads),
-                    Some(class_name),
-                );
-                result.push(method_obj);
-            }
-            // Also include native (built-in) methods
-            for native_name in &class_def.native_methods {
-                let method_obj = self.make_native_method_object(native_name);
-                result.push(method_obj);
+        let registry = self.registry();
+        let Some(class_def) = registry.classes.get(class_name) else {
+            return;
+        };
+        // First add accessor methods for public attributes (in order)
+        for attr in &class_def.attributes {
+            if attr.is_public && !class_def.methods.contains_key(&attr.name) {
+                result.push(self.make_native_method_object(&attr.name));
             }
         }
+        // Then add explicit methods
+        for (method_name, overloads) in &class_def.methods {
+            if overloads.is_empty() {
+                continue;
+            }
+            self.shadow_check_user_candidates(&registry, class_name, method_name, overloads);
+            // Skip private methods unless :private
+            let first = &overloads[0];
+            if first.is_private && !include_private {
+                continue;
+            }
+            let is_multi = overloads.len() > 1;
+            let return_type = first.return_type.clone();
+            let method_obj = self.make_method_object_with_owner(
+                method_name,
+                first,
+                is_multi,
+                return_type,
+                Some(overloads),
+                Some(class_name),
+            );
+            result.push(method_obj);
+        }
+        // Also include native (built-in) methods
+        for native_name in &class_def.native_methods {
+            let method_obj = self.make_native_method_object(native_name);
+            result.push(method_obj);
+        }
+    }
+
+    /// ADR-0019 Phase F box F1 item 1 (`todo/deep/adr0019-f1-f2-
+    /// introspection-canonical-source.md`): shadow comparison between
+    /// `ClassDef::methods` (the source `collect_class_methods`/
+    /// `class_method_table` read directly today) and
+    /// `Registry::method_entries[(owner, name)].user_candidates`
+    /// (`Registry::user_method_overloads`) -- the canonical table Phase E's
+    /// dispatch path already reads exclusively, kept in sync by
+    /// `Registry::sync_user_method_entries`. `Arc::ptr_eq` on each
+    /// candidate's body is enough to prove identity: `sync_user_method_
+    /// entries` writes `user_candidates` via a full clone of `class_def.
+    /// methods`, and `MethodDef::body` is an `Arc` that clone only bumps the
+    /// refcount of, so a match here proves the two rows share the same
+    /// clone lineage (i.e. the last sync call actually ran against this
+    /// exact `ClassDef::methods` state) rather than merely looking similar.
+    /// Shadow-only, zero behavior change -- callers still build every
+    /// `Method` object from `overloads` (the `ClassDef::methods` value).
+    fn shadow_check_user_candidates(
+        &self,
+        registry: &Registry,
+        class_name: &str,
+        method_name: &str,
+        overloads: &[MethodDef],
+    ) {
+        if !crate::vm::vm_stats::enabled() {
+            return;
+        }
+        let canonical = registry.user_method_overloads(class_name, method_name);
+        let matched = match &canonical {
+            Some(candidates) => {
+                candidates.len() == overloads.len()
+                    && candidates
+                        .iter()
+                        .zip(overloads.iter())
+                        .all(|(a, b)| std::sync::Arc::ptr_eq(&a.body, &b.body))
+            }
+            None => false,
+        };
+        crate::vm::vm_stats::record_user_candidates_shadow_check(matched, || {
+            format!("{class_name}::{method_name}")
+        });
     }
 
     /// Build the class's own method table (`.^method_table`): the methods
@@ -80,6 +125,7 @@ impl Interpreter {
             let Some(first) = overloads.first() else {
                 continue;
             };
+            self.shadow_check_user_candidates(&registry, class_name, method_name, overloads);
             if first.is_private || first.is_submethod {
                 continue;
             }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -613,6 +613,42 @@ pub(crate) fn record_deferral_shadow_check(matched: bool, detail: impl FnOnce() 
     }
 }
 
+// ADR-0019 Phase F box F1 item 1 (`todo/deep/adr0019-f1-f2-introspection-
+// canonical-source.md`): shadow comparison between `ClassDef::methods` (the
+// source `collect_class_methods`/`class_method_table` read directly today)
+// and `Registry::method_entries[(owner, name)].user_candidates` (the
+// canonical table Phase E's dispatch path already reads exclusively, kept in
+// sync by `Registry::sync_user_method_entries`). Proves the write-side sync
+// never drifts from `ClassDef::methods` before either reader is cut over to
+// the canonical table. A dedicated counter pair, not the shared
+// `RESOLVER_SHADOW_*` infra: this compares a per-class candidate LIST (one
+// row's overload vector), the same reasoning that gave E7 steps 4/6/7 and
+// E8a's list/chain comparisons their own pairs. Nothing reads these counters
+// to make a dispatch decision: shadow-only, zero behavior change.
+static USER_CANDIDATES_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static USER_CANDIDATES_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn user_candidates_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one F1-item-1 `user_candidates` shadow comparison. `detail` is
+/// only evaluated on a mismatch, mirroring [`record_deferral_shadow_check`].
+#[inline]
+pub(crate) fn record_user_candidates_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    USER_CANDIDATES_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        USER_CANDIDATES_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = user_candidates_shadow_mismatch_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1139,6 +1175,28 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e8a deferral-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let user_candidates_shadow_checks = USER_CANDIDATES_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let user_candidates_shadow_mismatches =
+        USER_CANDIDATES_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-f1: user_candidates_shadow_checks={user_candidates_shadow_checks} user_candidates_shadow_mismatches={user_candidates_shadow_mismatches}"
+    );
+    if let Ok(map) = user_candidates_shadow_mismatch_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-f1 user-candidates-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );


### PR DESCRIPTION
## Summary

ADR-0019 Phase F box F1 (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`, item 1): before cutting `collect_class_methods`/`class_method_table` (`.^methods`/`.^method_table`) over to read `Registry::method_entries[(owner, name)].user_candidates` -- the canonical table Phase E's dispatch path already reads exclusively -- prove the write-side sync (`Registry::sync_user_method_entries`) never drifts from the `ClassDef::methods` these two introspection readers consult directly today.

- Both readers now run a shadow comparison per `(class, method)` row against `Registry::user_method_overloads`, using `Arc::ptr_eq` on each candidate's `body` to detect true clone-lineage identity (proves the last sync call actually ran against this exact `ClassDef::methods` state) rather than shape-alone similarity.
- New `MUTSU_VM_STATS=1` counter pair (`user_candidates_shadow_checks`/`_mismatches`) plus a by-`class::method` mismatch histogram, following the same pattern as E7/E8a's shadow checks.
- Shadow-only, zero behavior change: callers still build every `Method` object from `ClassDef::methods`.

## Verification

- `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`: clean.
- Full `t/` suite (debug build, 3140 files): `Result: PASS`, no regressions.
- Targeted `MUTSU_VM_STATS=1` sweep over every `t/` and roast file that exercises `.^methods`/`.^method_table`/`.WALK` (24 files, 73 total shadow checks): zero mismatches.

## Next step

If CI's full roast run confirms no mismatches at scale, a follow-up PR cuts `collect_class_methods`/`class_method_table` over to read `user_candidates` directly (the E1a-style cutover half of this slice).

## Test plan

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt`
- [x] Local `t/` suite + targeted introspection-path roast sweep
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)