### PR TITLE
perf(carrier-compile-cache): reuse eval_block_value's compile across repeated calls to the same block

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -157,6 +157,47 @@ type ProtectBlockCacheEntry = (
 );
 type ProtectBlockCache = HashMap<u64, ProtectBlockCacheEntry>;
 
+/// The ambient interpreter state `compile_block_value_opts` folds into a
+/// fresh `Compiler` before compiling a carrier block's body (`is_routine`/
+/// `lexically_in_routine`, the enclosing package scope, sigilless/placeholder
+/// seeding, `$?DISTRIBUTION`). A block invoked repeatedly from the SAME call
+/// site (the overwhelmingly common shape — a `lives-ok { ... }` in a loop, a
+/// comparator called many times) has an identical context on every call, so
+/// this is the key `carrier_compile_cache` matches on to decide whether a
+/// cached compile from a previous call is reusable. `PartialEq`, not `Eq`/
+/// `Hash`: `distribution` is a `Value` (no `Hash` impl, and its `PartialEq`
+/// is Raku's semantic equality) — see the doc comment on `CarrierCompileCache`
+/// for why this rules out a plain `HashMap<Key, _>`.
+#[derive(Clone, PartialEq)]
+struct CarrierCompileCtxKey {
+    is_eval_unit: bool,
+    in_routine: bool,
+    /// The fully-resolved package scope string `compile_block_value_opts`
+    /// passes to `compiler.set_current_package` — already encodes whether an
+    /// enclosing routine frame was present (`"{pkg}::&{name}"`) or not (bare
+    /// `self.current_package()`), so no separate `enclosing_package` field is
+    /// needed.
+    scope: String,
+    sigilless: Vec<String>,
+    placeholder_params: Vec<String>,
+    distribution: Option<Value>,
+}
+
+/// Per-`SubData.id` cache of `(context, compiled)` pairs for
+/// `eval_block_value_inner`'s carrier-block compile (see
+/// `todo/deep/eval-block-value-recompiles-every-call.md`). A `Vec` rather
+/// than a nested `HashMap` because `CarrierCompileCtxKey` cannot implement
+/// `Hash`/`Eq` (it embeds a `Value`, compared by Raku's semantic `PartialEq`,
+/// not a total order) — and because the realistic size is 1 entry per id
+/// (the same block invoked from the same call site every time), so a linear
+/// scan against `CarrierCompileCtxKey::eq` costs nothing. Capped at
+/// `CARRIER_COMPILE_CACHE_MAX_CONTEXTS_PER_ID` entries per id to bound memory
+/// for the rare block invoked from many distinct contexts.
+type CarrierCompileCache =
+    HashMap<u64, Vec<(CarrierCompileCtxKey, Arc<CompiledCode>, Arc<CompiledFns>)>>;
+
+const CARRIER_COMPILE_CACHE_MAX_CONTEXTS_PER_ID: usize = 4;
+
 mod accessors;
 mod accessors_misc;
 mod accessors_resolve;
@@ -1317,6 +1358,12 @@ pub struct Interpreter {
     /// TODO: entries are never reclaimed; acceptable as predictive Seqs are rare.
     predictive_seq_iters: HashMap<usize, Value>,
     protect_block_cache: ProtectBlockCache,
+    /// See `CarrierCompileCache`: reuses `eval_block_value_inner`'s carrier
+    /// compile across repeated calls to the same `SubData` id instead of
+    /// recompiling its AST every time. Opt-in per call site via
+    /// `eval_block_value_cached`/`eval_test_block_value`'s `cache_id`
+    /// parameter — starts empty per thread (pure recomputable optimization).
+    carrier_compile_cache: CarrierCompileCache,
     /// Compiled bytecode for subset `where` predicates, keyed by subset name.
     /// A subset's predicate is a fixed `Expr`, so it is compiled once and reused
     /// across all type checks instead of recompiling + cloning the entire

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -755,7 +755,7 @@ impl Interpreter {
             // across `run_nested`'s register reset via `pending_nested_state_scope`,
             // which is what actually installs it (see `with_nested_registers`).
             self.pending_nested_state_scope = Some(self.sub_state_scope_id(&data));
-            let body_result = self.eval_block_value(&data.body);
+            let body_result = self.eval_block_value_cached(&data.body, data.id);
             self.pending_nested_state_scope = None;
             self.pending_supply_block_body = false;
             self.pending_supply_emitter_sym = None;

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -157,6 +157,22 @@ impl Interpreter {
         self.eval_block_value_opts(body, false)
     }
 
+    /// `eval_block_value`, but for a body that belongs to a specific,
+    /// stable `SubData` instance (`cache_id`, its `.id`) — reuses a compiled
+    /// chunk from a previous call with the same ambient compile context
+    /// instead of recompiling the AST every time (see
+    /// `todo/deep/eval-block-value-recompiles-every-call.md`). Safe to call
+    /// repeatedly on the same `data.id`/`body` pair: a mismatched context
+    /// (rare — the same block invoked from a differently-scoped call site)
+    /// falls back to a fresh compile rather than serving a wrong result.
+    pub(crate) fn eval_block_value_cached(
+        &mut self,
+        body: &[Stmt],
+        cache_id: u64,
+    ) -> Result<Value, RuntimeError> {
+        self.eval_block_value_inner(body, false, false, Some(cache_id))
+    }
+
     /// `eval_block_value`, additionally recording the block's compile-time
     /// `free_var_writes` for the caller-slot writeback (retain-on-miss list).
     ///
@@ -172,7 +188,7 @@ impl Interpreter {
         &mut self,
         body: &[Stmt],
     ) -> Result<Value, RuntimeError> {
-        self.eval_block_value_inner(body, false, true)
+        self.eval_block_value_inner(body, false, true, None)
     }
 
     /// `eval_block_value`, with `is_eval_unit` marking `body` as an EVAL'd
@@ -182,7 +198,73 @@ impl Interpreter {
         body: &[Stmt],
         is_eval_unit: bool,
     ) -> Result<Value, RuntimeError> {
-        self.eval_block_value_inner(body, is_eval_unit, false)
+        self.eval_block_value_inner(body, is_eval_unit, false, None)
+    }
+
+    /// The ambient compile context `compile_block_value_opts` folds into a
+    /// fresh `Compiler` for `body`, WITHOUT actually compiling — used as the
+    /// carrier-compile cache's lookup/store key. Must stay in exact sync
+    /// with `compile_block_value_opts`'s own derivation of `in_routine`,
+    /// `scope`, and `compiler.current_distribution`; a divergence here would
+    /// only cause spurious cache misses (safe), never a wrong cache hit,
+    /// since a genuine wrong-key situation just means the two computations
+    /// disagree and this key stops matching future identical calls — but
+    /// keep them matching so the cache actually helps.
+    fn carrier_compile_ctx_key(&self, is_eval_unit: bool) -> CarrierCompileCtxKey {
+        let in_routine = if is_eval_unit {
+            self.enclosing_routine_exists()
+        } else {
+            !self.routine_stack.is_empty()
+        };
+        let scope = if let Some(frame) = self.routine_stack.last() {
+            format!("{}::&{}", frame.package, frame.name)
+        } else {
+            self.current_package()
+        };
+        let distribution = self.current_distribution.clone().or_else(|| {
+            self.package_distributions
+                .get(&self.current_package())
+                .cloned()
+        });
+        CarrierCompileCtxKey {
+            is_eval_unit,
+            in_routine,
+            scope,
+            sigilless: self.pending_eval_sigilless.clone(),
+            placeholder_params: self.pending_eval_placeholder_params.clone(),
+            distribution,
+        }
+    }
+
+    /// Compile `body` for `eval_block_value_inner`, reusing a previous
+    /// compile for the same `(cache_id, ambient context)` pair when one
+    /// exists. See `CarrierCompileCache`'s doc comment for why this is sound
+    /// and why the `Arc` is what re-enables JIT hotness tracking (cloning a
+    /// `CompiledCode` resets its `JitCodeState`; cloning the `Arc` does not).
+    fn compile_block_value_cached(
+        &mut self,
+        body: &[Stmt],
+        is_eval_unit: bool,
+        cache_id: u64,
+    ) -> (
+        std::sync::Arc<crate::opcode::CompiledCode>,
+        std::sync::Arc<crate::opcode::CompiledFns>,
+    ) {
+        let key = self.carrier_compile_ctx_key(is_eval_unit);
+        if let Some(entries) = self.carrier_compile_cache.get(&cache_id)
+            && let Some((_, code, fns)) = entries.iter().find(|(k, ..)| *k == key)
+        {
+            return (code.clone(), fns.clone());
+        }
+        let (code, fns) = self.compile_block_value_opts(body, is_eval_unit);
+        let code = std::sync::Arc::new(code);
+        let fns = std::sync::Arc::new(fns);
+        let entries = self.carrier_compile_cache.entry(cache_id).or_default();
+        if entries.len() >= CARRIER_COMPILE_CACHE_MAX_CONTEXTS_PER_ID {
+            entries.remove(0);
+        }
+        entries.push((key, code.clone(), fns.clone()));
+        (code, fns)
     }
 
     fn eval_block_value_inner(
@@ -190,6 +272,7 @@ impl Interpreter {
         body: &[Stmt],
         is_eval_unit: bool,
         record_free_var_writes: bool,
+        cache_id: Option<u64>,
     ) -> Result<Value, RuntimeError> {
         if body.is_empty() {
             return Ok(Value::NIL);
@@ -233,15 +316,31 @@ impl Interpreter {
             .filter(|(k, _)| k.starts_with("&") || k.starts_with("__mutsu_callable_id::"))
             .map(|(k, v)| (*k, v.clone()))
             .collect();
-        let (mut code, compiled_fns) = self.compile_block_value_opts(body, is_eval_unit);
-        code.is_supply_block_body = is_supply_block_body;
-        code.supply_emitter_sym = supply_emitter_sym;
-        code.inherited_owned_lexicals = whenever_inherited_owned;
-        for sym in supply_authoritative_free_vars {
-            if !code.authoritative_free_vars.contains(&sym) {
-                code.authoritative_free_vars.push(sym);
+        // The compiled chunk can be reused across calls to the SAME `SubData`
+        // (cache_id) only when nothing below would mutate it per-call — a
+        // cached `Arc` must stay byte-identical to what a fresh compile would
+        // have produced every time it is served, and these four fields are
+        // exactly what the plain (uncached) path below mutates post-compile.
+        // Bypass the cache (compile fresh, don't store) rather than caching a
+        // wrong/stale mutation.
+        let needs_fresh_mutation = is_supply_block_body
+            || supply_emitter_sym.is_some()
+            || !supply_authoritative_free_vars.is_empty()
+            || !whenever_inherited_owned.is_empty();
+        let (code, compiled_fns) = if !needs_fresh_mutation && let Some(id) = cache_id {
+            self.compile_block_value_cached(body, is_eval_unit, id)
+        } else {
+            let (mut code, fns) = self.compile_block_value_opts(body, is_eval_unit);
+            code.is_supply_block_body = is_supply_block_body;
+            code.supply_emitter_sym = supply_emitter_sym;
+            code.inherited_owned_lexicals = whenever_inherited_owned;
+            for sym in supply_authoritative_free_vars {
+                if !code.authoritative_free_vars.contains(&sym) {
+                    code.authoritative_free_vars.push(sym);
+                }
             }
-        }
+            (std::sync::Arc::new(code), std::sync::Arc::new(fns))
+        };
         // Multi-frame coherence (env_dirty-deletion path): box any captured-outer
         // scalar this carrier body writes into a shared cell across env + saved
         // frames, so the by-name write survives the owner frame's env restore.
@@ -401,10 +500,20 @@ impl Interpreter {
         if data.body.is_empty() && data.compiled_routine.is_some() {
             return self.call_sub_value(Value::sub_value(data.clone()), Vec::new(), false);
         }
-        self.eval_test_block_value(&data.body)
+        self.eval_test_block_value(&data.body, Some(data.id))
     }
 
-    pub(crate) fn eval_test_block_value(&mut self, body: &[Stmt]) -> Result<Value, RuntimeError> {
+    /// `cache_id`: the invoking `SubData.id`, when known, so repeated calls
+    /// to the SAME test-assertion block (e.g. `lives-ok { ... }` inside a
+    /// loop) reuse a compiled chunk instead of recompiling the AST every
+    /// call — see `eval_block_value_cached`. `None` for callers that only
+    /// have a bare `body: &[Stmt]` with no associated `SubData` (rare for
+    /// this entry point in practice, but keeps the signature honest).
+    pub(crate) fn eval_test_block_value(
+        &mut self,
+        body: &[Stmt],
+        cache_id: Option<u64>,
+    ) -> Result<Value, RuntimeError> {
         let pre_lexicals: std::collections::HashSet<Symbol> = self
             .env
             .keys()
@@ -428,7 +537,10 @@ impl Interpreter {
         // an already-on fatal keeps it off (roast S04-exceptions/fail.t, where an
         // earlier sub leaked fatal on and a later subtest turns it back off).
         let saved_fatal_mode = self.fatal_mode;
-        let result = self.eval_block_value(body);
+        let result = match cache_id {
+            Some(id) => self.eval_block_value_cached(body, id),
+            None => self.eval_block_value(body),
+        };
         // Whether `use fatal` was in effect at the block's end (before the
         // scope-restore below) drives the trailing-Failure check further down.
         let block_fatal_mode = self.fatal_mode;

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2220,6 +2220,7 @@ impl Interpreter {
             last_block_my_declared: Vec::new(),
             predictive_seq_iters: HashMap::new(),
             protect_block_cache: HashMap::new(),
+            carrier_compile_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
             subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -528,6 +528,7 @@ impl Interpreter {
             last_block_my_declared: Vec::new(),
             predictive_seq_iters: self.predictive_seq_iters.clone(),
             protect_block_cache: HashMap::new(),
+            carrier_compile_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
             subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),

--- a/src/runtime/test_functions/fails_like.rs
+++ b/src/runtime/test_functions/fails_like.rs
@@ -44,7 +44,7 @@ impl Interpreter {
         let saved_topic = self.env.get("_").cloned();
         let saved_dollar_topic = self.env.get("$_").cloned();
         let result = match code_val.view() {
-            ValueView::Sub(data) => self.eval_test_block_value(&data.body),
+            ValueView::Sub(data) => self.eval_test_block_value(&data.body, Some(data.id)),
             ValueView::Str(code) => {
                 let mut nested = Interpreter::new();
                 nested.strict_mode = self.strict_mode;

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -25,7 +25,7 @@ impl Interpreter {
                 // into the caller, where a subsequent `EVAL` would surface it as
                 // its own result. Save and restore the outer last_value.
                 let saved_last_value = self.last_value.take();
-                let r = self.eval_test_block_value(&data.body);
+                let r = self.eval_test_block_value(&data.body, Some(data.id));
                 self.last_value = saved_last_value;
                 r
             }
@@ -591,7 +591,7 @@ impl Interpreter {
         let result = match code_val.view() {
             ValueView::Sub(data) => {
                 let saved_last_value = self.last_value.take();
-                let r = self.eval_test_block_value(&data.body);
+                let r = self.eval_test_block_value(&data.body, Some(data.id));
                 self.last_value = saved_last_value;
                 r
             }

--- a/todo/deep/call-compiled-closure-lacks-merge-all-and-dual-persistence-store.md
+++ b/todo/deep/call-compiled-closure-lacks-merge-all-and-dual-persistence-store.md
@@ -1,0 +1,124 @@
+# `call_compiled_closure` has no `merge_all`-equivalent knob, and its per-instance state lives in a different store than the tree-walk branch's — both block a general `call_sub_value` → `call_compiled_closure` fork
+
+## Context
+
+`todo/deep/eval-block-value-recompiles-every-call.md` names, as its "larger
+fix", making `call_sub_value`'s general `ValueView::Sub(data)` branch (the
+~400-line tree-walk closure-call path in `src/runtime/resolution_call_sub.rs`)
+prefer `call_compiled_closure(&data, cc, args, fns)` whenever
+`data.compiled_code` is `Some`, mirroring the fork that already exists for
+`data.compiled_routine`. An audit was run to check whether
+`call_compiled_closure` (`src/vm/vm_closure_dispatch.rs`) is a strict superset
+of the tree-walk branch's behavior. It is not. This ticket records the two
+structural (not just missing-detail) gaps found; the two smaller, independently
+fixable bugs found in the same audit are filed separately as
+`todo/tickets/call-compiled-closure-underscore-arg-binding-bug.md` and
+`todo/tickets/call-compiled-closure-missing-rw-lazylist-tail.md`.
+
+## Gap 1: `merge_all` has no equivalent in `call_compiled_closure`
+
+`call_sub_value(target, args, merge_all: bool)` takes a `merge_all` parameter
+that changes how the closure's captured free-var env is merged against the
+caller's live env (tree-walk branch, `resolution_call_sub.rs` around line
+449-514):
+
+- `merge_all == false` (the default, used by most calls into `call_sub_value`):
+  for every non-`ContainerRef`/non-`self` free var, the closure's OWN captured
+  value unconditionally **overwrites** whatever the caller's env currently
+  holds under that name (`new_env.insert_sym(*k, v.clone())`).
+- `merge_all == true`: for every free var that is not in the closure's
+  `authoritative_free_vars`/`authoritative_captures` (the compiler-proven
+  "this closure owns this binding and never sees it mutated after capture"
+  set), the CALLER's existing value wins if present
+  (`new_env.entry_or_insert(...)`) — used where a native-invoked callback must
+  observe live, possibly-mutated state (a `Proxy` FETCH/STORE pair, a
+  `Promise` executor, a `unique`/`squish`/`min`/`max` comparator, an atomic
+  `cas` code block, etc).
+
+`call_compiled_closure_with_topic`'s own env-merge loop
+(`vm_closure_dispatch.rs` around line 310-360) has a single, fixed policy: it
+force-overwrites only `ContainerRef` captures, `self`, and (for non-routine
+blocks) the topic `_`; every other free var uses `entry_or_insert_sym`
+(caller-priority) by default, with `cc.authoritative_free_vars` and
+`data.authoritative_captures` separately force-overwritten afterward (line
+390-404). This is structurally the same shape as the tree-walk branch's
+`merge_all == true` policy — there is no way to get the tree-walk branch's
+`merge_all == false` **default** behavior (unconditional closure-value-wins
+for every non-authoritative free var) out of `call_compiled_closure` today.
+
+**Grep count:** 97 call sites currently pass `merge_all: true` explicitly
+(saved list regenerable via `git grep -n 'call_sub_value(.*, true)' src/`,
+spanning `Promise`/`.then`, Supply taps, `unique`/`squish` comparators,
+`min`/`max`/reduce comparators, atomic `cas` code blocks, `Proxy` FETCH/STORE
+in `builtins_lvalue.rs`, subtest callbacks, scheduler callbacks). These sites'
+desired semantics already match `call_compiled_closure`'s default, so routing
+them through it is plausible. The remaining, much larger population of
+`merge_all == false` call sites is the one at risk: whether
+`call_compiled_closure`'s caller-priority-except-authoritative default
+produces the *same observable result* as tree-walk's unconditional overwrite
+depends on how complete the compiler's `authoritative_free_vars`/
+`authoritative_captures` computation is for arbitrary closures reached via
+this general branch — which has not been verified. The two policies provably
+diverge only when a closure's free-var name collides with an unrelated,
+non-authoritative, same-named caller lexical; this is exactly the scenario the
+tree-walk branch's own inline comments (`resolution_call_sub.rs` line
+449-458) say the codebase has hit and fixed before (roast
+`S14-roles/anonymous.t`, `integration/99problems-41-to-50.t` P46), so the
+collision case is not merely theoretical.
+
+## Gap 2: two independent, non-communicating per-closure-instance state stores
+
+Per-instance persisted state for a closure that mutates its own captured free
+variables across calls is stored in two different maps, both keyed by
+`data.id` (the `SubData`'s stable identity):
+
+- Tree-walk branch: `self.closure_env_overrides: HashMap<u64, Env>`
+  (`src/runtime/mod.rs:1260`) — a whole-env snapshot, written at
+  `resolution_call_sub.rs` line 820-829 (`persist_closure_env`).
+- `call_compiled_closure`: `self.closure_captured_state: HashMap<(u64,
+  Symbol), Value>` (`src/runtime/mod.rs:1617`) — per-free-var, written at
+  `vm_closure_dispatch.rs` line 1064-1083 via
+  `get_closure_captured_state`/`set_closure_captured_state`.
+
+A single closure instance (one `data.id`) that is invoked through both paths
+accumulates two disjoint persistence records that never see each other's
+writes. **This dual-store situation already exists today**, independent of
+this ticket's proposed fork: `.()` and any other call reaching
+`vm_call_on_value`'s existing `data.compiled_code.is_some()` fast path
+(`src/vm/vm_dispatch_helpers.rs` line 549-569) already use
+`closure_captured_state`, while every call still reaching `call_sub_value`'s
+tree-walk branch uses `closure_env_overrides` — so a closure already invoked
+both via `.()` and via a `merge_all`-using native builtin is already exposed
+to this split. Routing *more* of `call_sub_value`'s traffic through
+`call_compiled_closure` does not introduce the hazard, but it does widen how
+often it can bite, and does so unevenly if the fork ends up conditional (e.g.
+gated on `!merge_all`) — a `merge_all == true` call and a `merge_all == false`
+call on the *same* closure instance would then deterministically split across
+stores every time, rather than only occasionally colliding with an unrelated
+`.()` call.
+
+## What would need to happen to make the general fork safe
+
+1. Give `call_compiled_closure_with_topic` a `merge_all`-equivalent mode (an
+   extra bool parameter, or a fourth env-merge policy alongside the current
+   ContainerRef/self/topic special cases) that reproduces tree-walk's
+   unconditional-overwrite-for-non-authoritative-free-vars default, and route
+   `merge_all == false` calls through it using that mode.
+2. Decide whether the two persistence stores should be unified (one map,
+   consulted by both call paths) or whether it's acceptable to leave them
+   separate as long as a single conditional fork keeps a given closure's calls
+   consistently on one path or the other — this needs auditing whether any
+   single `SubData` in practice gets called with a mix of `merge_all` values
+   across its lifetime (plausible for a generic wrap/callback combinator
+   passed to multiple different consumers).
+3. Re-run the parity audit against `call_compiled_closure` once (1) lands, to
+   confirm the divergence class described in Gap 1 is actually closed and not
+   just narrowed.
+
+## How this was found
+
+Investigating `todo/deep/eval-block-value-recompiles-every-call.md`'s "larger
+fix". A dedicated audit agent read both `resolution_call_sub.rs`'s tree-walk
+branch and the entirety of `vm_closure_dispatch.rs`, traced `merge_all` call
+sites via `grep`, and verified the two `HashMap` definitions independently in
+`src/runtime/mod.rs`.

--- a/todo/deep/eval-block-value-recompiles-every-call.md
+++ b/todo/deep/eval-block-value-recompiles-every-call.md
@@ -205,6 +205,187 @@ existing, narrower precedents that already reuse `data.compiled_code` for
 their specific carrier shape — worth checking whether either has quietly
 hit (or avoided) the same trap.
 
+## 2026-08-14 re-investigation: the "larger fix" audited, not yet attempted
+
+Re-verified the reverted attempt's numbers on the exact doc repro (`sub foo ()
+{$ = 42}; for ^2_000_000 { $ = foo }` wrapped in `lives-ok { ... }`, release
+build): baseline recompile-every-call runs in ~7.6s with
+`interpreter_fallbacks=0`, `jit: compiles=0 bailouts=2
+(StateVarInitGuard)` — matches the numbers already recorded above.
+
+Pursued the "recommended next step" above: is `compile_block_value_opts`'s
+call-site-context-sensitivity itself the bug, fixable by capturing the right
+context explicitly at `exec_make_anon_sub_op` time instead of re-deriving it
+from ambient state? **No — this framing undersold the problem.**
+`compile_block_value_opts` (`resolution_eval.rs:99-154`) is not "almost the
+same compile with one flag wrong": the real per-closure compile
+(`compile_closure_body_with_routine_flag`,
+`compiler/helpers_sub_body.rs:855-913`) inherits the *entire* parent-compiler
+state into the child compiler — `fold_ctx` (constant-folding context),
+`outer_code_var_names`, `enclosing_scopes`/`enclosing_sigilless`/
+`enclosing_local_names` (the full lexical scope chain),
+`user_listop_shadows`, `outer_constant_names`, `lexically_in_method`. None of
+that exists anywhere at `eval_block_value` call time — the original
+`Compiler` instance that held it is long gone. `compile_block_value_opts`
+re-derives only a handful of scalar flags (`is_routine`, package scope,
+sigilless/placeholder seeds) from ambient interpreter state and otherwise
+starts from a bare `Compiler::new()`. So a block's compiled shape is NOT
+"context-free apart from a couple of flags" — reusing `data.compiled_code`
+(the properly-context-inherited compile) is therefore not just a different
+recompile, it can be a *more complete* one, which is consistent with why the
+reverted attempt's "fixed" version differed in shape (an extra `RoutineScope`
+opcode) even though `self.routine_stack` was independently confirmed (via
+`rust-gdb` breakpoints, no rebuild) to be empty in both the ambient recompile
+AND the real compile at the point `sub foo` is declared — i.e. the divergence
+is not a simple `is_routine` flag mismatch as originally suspected; it comes
+from the missing scope-chain/fold-context inheritance, which the ambient path
+cannot reconstruct at call time even in principle (the information doesn't
+exist to reconstruct — it was never generated). **Conclusion: a narrow "make
+`compile_block_value_opts` context-aware enough" fix is not tractable.** The
+tractable direction really is the "larger fix" below (prefer
+`data.compiled_code` via `call_compiled_closure`, not a smarter ambient
+recompile).
+
+Tried to pin down *why* the reused-`compiled_code` version regressed 2.4x
+(the extra `RoutineScope` opcode / `light_call_blocked_by_mainline_capture`
+categorization) by checking whether `sub foo`'s `RegisterSub` op was getting
+wrongly added to `self.mainline_lexical_subs` (`vm_register_sub_ops.rs:429`,
+gated on `self.block_scope_depth() == 0 && self.routine_stack().is_empty() &&
+...`) — the theory being that `call_compiled_closure` never calls
+`push_block_scope_depth`/`pop_block_scope_depth` (confirmed: no match for
+`block_scope_depth` anywhere in `vm_closure_dispatch.rs`), so running the
+reused block through it instead of through `eval_block_value_inner` (which
+does `self.block_scope_depth += 1` around every nested block, including this
+one) could make `RegisterSub(foo)` see `block_scope_depth() == 0` and
+wrongly qualify as a mainline-lexical sub. **This hypothesis was tested and
+ruled out**: a `rust-gdb` breakpoint at `vm_register_sub_ops.rs:430` never
+fired at all for this exact repro shape (`sub foo () {$ = 42}`) — the state
+variable `$` is an anonymous `state`, and `state`-declared names are
+excluded from `code.my_declared_sym` (`vm_register_sub_ops.rs:465-469`,
+"`our`/`state`/`dynamic`-declared names are excluded"), so `foo` has no
+`my`-declared free var to trigger this boxing path in the first place. **The
+actual mechanism behind the `RoutineScope`/`light_call_blocked_by_mainline_
+capture` categorization for this specific repro remains unidentified** —
+worth checking next time before attempting another reuse: instrument
+`light_call_blocked_by_mainline_capture`'s call sites
+(`vm_call_func_ops.rs:19,589,717,1168,1213`) directly to see which one
+actually rejects `foo`'s calls, rather than assuming the
+`mainline_lexical_subs` path from first principles again.
+
+Separately audited whether `call_sub_value`'s general
+`ValueView::Sub(data)` branch (the actual "larger fix" target — not just
+the Test-module `eval_test_callable_body` entry point the reverted attempt
+touched) could safely be routed through `call_compiled_closure` whenever
+`data.compiled_code.is_some()`, the same fork that already exists for
+`data.compiled_routine` (`resolution_call_sub.rs:417-431`). **Not a strict
+superset relationship** — two structural gaps and two smaller concrete bugs
+were found, filed separately so they can be fixed/attempted independently of
+this ticket's larger question:
+
+- `todo/deep/call-compiled-closure-lacks-merge-all-and-dual-persistence-store.md`
+  — `call_compiled_closure` has no equivalent of `call_sub_value`'s
+  `merge_all` parameter (which ~97 call sites depend on), and per-closure
+  persisted state lives in two independent stores (`closure_env_overrides`
+  vs `closure_captured_state`) depending on which path a given closure
+  instance is invoked through. This is the main blocker for an unconditional
+  general fork.
+- `todo/tickets/call-compiled-closure-underscore-arg-binding-bug.md` — a
+  live, already-present bug: `call_compiled_closure` binds `$_` for a bare
+  block even when the body reads `@_` instead (confirmed via `.()` vs
+  `Promise.then` giving different, and differently-correct, results today).
+- `todo/tickets/call-compiled-closure-missing-rw-lazylist-tail.md` — the
+  tree-walk branch's `is rw`/`LazyList` return-value post-processing has no
+  equivalent in `call_compiled_closure` (already affects the existing
+  `compiled_routine` fork, not just a hypothetical future one).
+
+None of these are fundamental blockers on their own, but together they mean
+the general fork is not a small patch — it needs `call_compiled_closure` to
+grow a `merge_all`-equivalent mode (or the two persistence stores unified)
+before it can be attempted safely across all ~265 call sites the fork would
+affect (97 `merge_all: true` + the larger `merge_all: false` population).
+
+## 2026-08-14 Fable design consultation: recommended sequencing
+
+Consulted for advice given the two blockers found in the same-day
+re-investigation above. Full reasoning is in the session; key conclusions
+recorded here for whoever picks this up next:
+
+1. **The "cache `compile_block_value_opts`'s result" option (option C, a
+   `HashMap<(u64, CompileCtxFingerprint), (Arc<CompiledCode>,
+   Arc<CompiledFns>)>` keyed by `data.id`) is NOT a lesser option that only
+   fixes "wasted compile work" while leaving "JIT never gets a chance"
+   unaddressed** — both costs are the same underlying cause. `JitCodeState`
+   (`opcode.rs:3798`) is embedded per-`CompiledCode` object; its own doc
+   comment says cloning a chunk resets hotness tracking because "a clone is a
+   distinct compilation identity." A cache that returns the same `Arc` on
+   every call lets the hotness counter accumulate across calls and JIT-compile
+   — for free, as a side effect of caching. This makes C worth doing
+   regardless of what happens with the larger `call_sub_value` fork.
+2. **The cache-key soundness worry (pointer/GC-address reuse) is moot**:
+   `SubData.id` is a monotonic `u64` from `next_instance_id()`
+   (`value/mod.rs:730`), never reused, and is already the established key for
+   exactly this shape of cache — `protect_block_cache`
+   (`resolution_eval.rs:559-670`, used by `Lock::Async.protect`) already
+   caches compiled code per `data.id`. C is a third instance of an existing
+   pattern, not a novel mechanism.
+3. **`state.t`'s 12x-vs-raku gap is caused by neither of this ticket's two
+   costs.** See `todo/tickets/state-var-init-guard-jit-bailout-blocks-hot-loop.md`
+   — `lives-ok` runs its block once, so recompilation cost is negligible, and
+   `interpreter_fallbacks=0` at baseline. The actual cause is the JIT bailing
+   on `StateVarInitGuard` and running the `for` loop interpreted. **Stop
+   measuring this ticket's success against `state.t`** — use a
+   repeatedly-invoked carrier block instead (e.g. 100,000x `lives-ok { ... }`
+   in a loop).
+4. **Reframing the 2.4x regression**: the creation-time compile
+   (`data.compiled_code`) is the MORE correct one — it emits `RoutineScope`
+   (`compiler/helpers_sub_body.rs:962`) because a `sub` declared inside a
+   block is genuinely block-lexical, and needs a registry save/restore
+   bracket. The ambient recompile skips `RoutineScope` only because
+   `routine_stack` happens to be non-empty at invocation time, and gets
+   correct block-lexicality *for free* from the carrier's own registry
+   snapshot/restore in `eval_block_value_inner`. So baseline being fast is
+   "borrowing" correctness from the carrier rather than the compile itself.
+   The durable fix is a **separate, standalone perf bug**: make calls to a
+   `RoutineScope`-registered sub eligible for fast compiled dispatch, instead
+   of falling to `record_function_fallback` ~50% of the time. Next debugging
+   step: break on `vm_stats::record_function_fallback` (`vm_stats.rs:782`,
+   4 call sites: `vm_call_dispatch.rs:131`,
+   `vm_call_func_ops.rs:1345/1408/1513`) with `bt`, NOT on
+   `light_call_blocked_by_mainline_capture`'s 5 call sites (already proven
+   irrelevant — `mainline_lexical_subs` stays empty for this repro). Prime
+   suspect: `RoutineScope`'s `snapshot_routine_registry`/
+   `restore_routine_registry` (`vm_misc_scope.rs:218-234`) bumping a
+   registry generation that invalidates a resolution cache
+   (`fn_resolve_gen`/`otf_call_cache_gen`, see the eligibility chain at
+   `vm_call_func_ops.rs:704-719`) — unverified, check with the breakpoint
+   before trusting it.
+5. **Recommended sequencing**:
+   - Now: land `todo/tickets/call-compiled-closure-underscore-arg-binding-bug.md`
+     and `todo/tickets/call-compiled-closure-missing-rw-lazylist-tail.md`
+     (independent, small), and implement option C (the compile-result cache)
+     per the design above — safe, mechanical, reuses the `protect_block_cache`
+     pattern.
+   - Next: the `record_function_fallback` breakpoint session; fix the
+     `RoutineScope` dispatch-eligibility bug. Standalone perf win, and a
+     prerequisite for the larger fork (without it, the fork re-imports the
+     2.4x cliff for any nested-sub-in-block shape).
+   - Then: attempt `todo/deep/call-compiled-closure-lacks-merge-all-and-dual-persistence-store.md`'s
+     fork, under a `Proposed` ADR written first. Recommended ADR framing:
+     "`call_compiled_closure` is the canonical closure-invocation mechanism;
+     the `call_sub_value` tree-walk branch is transitional debt, retired via:
+     bug-parity fixes → `CapturePriority` mode (see that ticket) →
+     `RoutineScope` dispatch-eligibility fix → unconditional fork on
+     `compiled_code.is_some()` → delete the branch and
+     `closure_env_overrides`." Key simplification: gate the fork ONLY on
+     `data.compiled_code.is_some()` (a stable per-instance property), never on
+     `merge_all` — that avoids the dual-persistence-store split hazard
+     entirely, since a given closure instance then always uses the same store
+     regardless of which call site invokes it.
+   - The C cache remains useful even after the fork lands — it stays the
+     carrier-level mechanism for `eval_block_value`'s surviving callers with
+     no `SubData` in hand (EVAL, regex code blocks, phasers, class/role
+     bodies).
+
 ## Verification protocol for a future attempt
 
 - `MUTSU_VM_STATS=1` before/after on a loop-in-block-argument repro: confirm

--- a/todo/tickets/call-compiled-closure-missing-rw-lazylist-tail.md
+++ b/todo/tickets/call-compiled-closure-missing-rw-lazylist-tail.md
@@ -1,0 +1,62 @@
+# `call_compiled_closure` has no equivalent of the tree-walk branch's `is rw`/LazyList return-value post-processing
+
+## Summary
+
+The tree-walk closure-call branch in `call_sub_value`
+(`src/runtime/resolution_call_sub.rs`, tail around line 1058-1103) does two
+things to the closure body's return value before handing it back to the
+caller:
+
+1. Rebuilds a returned `LazyList`'s env with
+   `__mutsu_preserve_lazy_on_array_assign` set.
+2. Calls `self.maybe_fetch_rw_proxy(v, data.is_rw && !data.is_raw)`, which
+   wraps the value in an rw proxy when the closure/sub is declared `is rw`.
+
+`call_compiled_closure`/`call_compiled_closure_with_topic`
+(`src/vm/vm_closure_dispatch.rs`) has no equivalent anywhere — it returns
+straight from `finalize_return_with_spec` at the end of
+`call_compiled_closure_with_topic` (around line 1448-1459). Confirmed via
+`grep -n "fetch_rw\|is_rw\|maybe_fetch_rw_proxy\|LazyList"
+src/vm/vm_closure_dispatch.rs`, which returns nothing.
+
+## This is not hypothetical for the *existing* code — it already affects the `compiled_routine` fork
+
+`call_sub_value` already has an earlier fork that goes straight to
+`call_compiled_closure` and returns immediately, bypassing this tail entirely:
+the `data.compiled_routine.is_some()` branch at
+`src/runtime/resolution_call_sub.rs` around line 417-431. Any `is rw`
+routine-Sub invoked as a first-class value through that fork today already
+loses `maybe_fetch_rw_proxy` handling. This ticket is about the general gap in
+`call_compiled_closure` itself, not a new problem introduced by any pending
+change.
+
+## Status: gap identified by static audit, not yet reduced to a failing test
+
+This was found by an audit comparing the tree-walk branch against
+`call_compiled_closure` line-by-line while investigating whether
+`call_sub_value`'s general branch could safely be routed through
+`call_compiled_closure` (see
+`todo/deep/eval-block-value-recompiles-every-call.md`). No concrete
+roast/`t/` repro has been constructed yet that demonstrates an observably
+wrong result — the gap is confirmed by code inspection (the tail simply does
+not exist on the compiled path), not by a failing assertion. Constructing a
+repro (an `is rw` block/routine Sub invoked as a first-class value whose
+return should be an rw proxy, or a lazy sequence returned from a block called
+via `.()`/a wrap chain) is the next step before fixing this.
+
+## Fix direction
+
+Add the same tail logic (LazyList preserve-on-array-assign,
+`maybe_fetch_rw_proxy`) either:
+
+- as a thin wrapper applied at the call sites that invoke `call_compiled_closure`
+  in `call_sub_value` and `vm_call_on_value` (`src/vm/vm_dispatch_helpers.rs`), or
+- inlined into `call_compiled_closure` itself, so every existing caller
+  (including the two `compiled_routine` fork sites and `vm_call_on_value`'s own
+  fast path) benefits without each call site having to remember to add it.
+
+The second option is probably right long-term, but check whether
+`maybe_fetch_rw_proxy`'s `data.is_rw && !data.is_raw` condition is safe to
+apply unconditionally to every `call_compiled_closure` caller (e.g. map/grep
+callback invocations, which also route through this function) or whether it
+needs to stay opt-in per call site.

--- a/todo/tickets/call-compiled-closure-underscore-arg-binding-bug.md
+++ b/todo/tickets/call-compiled-closure-underscore-arg-binding-bug.md
@@ -1,0 +1,61 @@
+# `call_compiled_closure` binds `$_` for a bare block even when the body wants `@_` instead
+
+## Summary
+
+`call_compiled_closure_with_topic` (`src/vm/vm_closure_dispatch.rs`, the
+`uses_positional` check around line 559) unconditionally binds the implicit
+topic `$_` to the first positional argument of a bare block whenever
+`data.params` contains no non-`_`/non-`:` entry — regardless of whether the
+block's body actually reads `@_` instead of `$_`. The tree-walk closure-call
+branch in `call_sub_value` (`src/runtime/resolution_call_sub.rs`, around line
+559-560) gets this right: it additionally calls
+`crate::method_signature_shared::auto_signature_uses(&data.body)`, an AST scan
+that detects a bare `@_` read in the body, and skips the `$_` bind in that
+case.
+
+Both code paths compute `data.params` identically for a plain bare block
+(`{ ... }` with no explicit signature) — it is empty either way, since
+`collect_placeholders_shallow` does not treat `@_` as a placeholder param — so
+`call_compiled_closure`'s narrower params-only check cannot tell the two
+shapes apart and always binds `$_`.
+
+## Repro
+
+Confirmed live against the current binary, comparing two call paths for the
+identical body shape:
+
+```
+# .() direct call routes to call_compiled_closure via vm_call_on_value
+$ raku -e '{ say "topic=$_ args=@_[]" }.(1,2,3)'
+topic= args=1 2 3
+$ target/debug/mutsu -e '{ say "topic=$_ args=@_[]" }.(1,2,3)'
+topic=1 args=1 2 3          # WRONG — $_ should stay empty since the body uses @_
+
+# Promise.then routes through call_sub_value's tree-walk branch (merge_all=true)
+$ target/debug/mutsu -e 'await Promise.new.keep(1).then({ say "topic=$_ args=@_[]" })'
+topic= args=Promise(Kept)   # correct — matches raku
+```
+
+## Affected files
+
+- `src/vm/vm_closure_dispatch.rs` — `call_compiled_closure_with_topic`,
+  `uses_positional` computation around line 559.
+- `src/method_signature_shared.rs` — `auto_signature_uses` (the correct
+  reference implementation, already used by the tree-walk branch).
+
+## Fix direction
+
+Call `auto_signature_uses(&data.body)` from `call_compiled_closure_with_topic`
+the same way the tree-walk branch does, and skip the implicit `$_` bind when
+the body reads `@_` instead. `data.body` is already available on the `SubData`
+passed in, so this needs no new plumbing — just reusing the existing helper.
+
+## How this was found
+
+Investigating `todo/deep/eval-block-value-recompiles-every-call.md`'s "larger
+fix" (routing `call_sub_value`'s general closure branch through
+`call_compiled_closure`). An audit agent comparing the two closure-invocation
+paths for feature parity found this as a live, already-present divergence
+between `.()` (which already uses `call_compiled_closure` via
+`vm_call_on_value`) and other call sites still on the tree-walk branch —
+independent of whatever the audit concludes about the larger fork.

--- a/todo/tickets/state-var-init-guard-jit-bailout-blocks-hot-loop.md
+++ b/todo/tickets/state-var-init-guard-jit-bailout-blocks-hot-loop.md
@@ -1,0 +1,53 @@
+# `state.t`'s 12x-vs-raku slowdown is a JIT bailout on `StateVarInitGuard`, not a recompilation problem
+
+## Summary
+
+`roast/S04-declarations/state.t`'s "Intensive use of state variable in
+inline-friendly sub does not hit problems" subtest (`sub foo () {$ = 42}; for
+^2_000_000 { $ = foo }`, wrapped in `lives-ok { ... }`) was the original
+motivating repro for `todo/deep/eval-block-value-recompiles-every-call.md`.
+Re-measured on 2026-08-14 (release build, `MUTSU_VM_STATS=1`):
+
+```
+baseline: ~7.6-8.5s, function-call opcodes=4000000 interpreter_fallbacks=0 (0.0%)
+jit: compiles=0 entries=0 bailouts=2 (StateVarInitGuard)
+```
+
+`lives-ok`'s block argument runs exactly **once** — its own recompilation
+cost (what `eval_block_value_inner`/`compile_block_value_opts` pays per
+invocation) is therefore negligible here regardless of whether it is fixed.
+`interpreter_fallbacks=0` confirms `foo()`'s 2,000,000 calls are NOT falling
+back to tree-walk dispatch either. The actual bottleneck is that the JIT
+bails out on the `StateVarInitGuard` opcode (`compiler/stmt.rs:1320`) and the
+whole loop runs interpreted instead of JIT-compiled — that is where the
+12x-vs-raku gap comes from.
+
+**This means none of the fixes discussed in
+`eval-block-value-recompiles-every-call.md` (compile-result caching, or the
+larger `call_sub_value` → `call_compiled_closure` fork) will move this
+specific benchmark.** That ticket's own success should be measured against a
+carrier block invoked *repeatedly* (e.g. `lives-ok { ... }` called 100,000
+times in a loop, or any block passed many times to a native Test/comparator
+function), not against `state.t`, which calls its `lives-ok` block once.
+
+## Fix direction (not yet investigated)
+
+Teach the JIT to handle the state-var-init guard shape, or restructure how a
+`state` variable's one-time initialization check compiles so it doesn't
+require a guard the JIT tier can't yet compile. Start by reading the JIT's
+existing bailout handling around `StateVarInitGuard` (`vm/vm_jit.rs` or
+wherever `try_enter`/JIT tier-A compilation lives — grep
+`StateVarInitGuard` across `src/vm/vm_jit*.rs`) to see what makes this
+opcode currently JIT-incompatible, and whether it's a fundamental limitation
+or a missing case.
+
+## How this was found
+
+Investigating `todo/deep/eval-block-value-recompiles-every-call.md`. A
+design-consultation (Fable, 2026-08-14) pointed out that the ticket's own
+motivating benchmark had never actually been re-measured against the
+dispatch-cost theory being discussed — `MUTSU_VM_STATS` for the baseline
+already shows `interpreter_fallbacks=0`, which rules out both "wasted
+recompile work" and "falls back to tree-walk dispatch" as the cause for this
+specific file. The `bailouts=2 (StateVarInitGuard)` line was there in the
+stats output the whole time.


### PR DESCRIPTION
## Summary

- `eval_block_value_inner` recompiled a block/closure's AST body from scratch on **every** invocation, even for the same `SubData` instance called repeatedly (e.g. a stored `&blk` passed to `lives-ok` inside a loop). Add a per-`SubData.id`, per-ambient-context compile cache (`carrier_compile_cache`) so a repeated call to the same block reuses the previous compile's `Arc<CompiledCode>`/`Arc<CompiledFns>` instead of recompiling. Keyed by `SubData.id` (a stable, never-reused instance id — same pattern already used by `protect_block_cache`).
- Reusing the same `Arc` also re-enables JIT hotness accumulation for these carrier blocks (`JitCodeState` lives on the `CompiledCode` object itself, and a fresh compile resets its counter to zero every call).
- The cache is bypassed (not stored) whenever the compiled chunk needs a per-call mutation (supply-block/`whenever`-emitter flags), so it never serves a stale or wrong chunk.
- Wires the cache through `call_sub_value`'s general tree-walk closure branch and the Test-module assertion-block entry points (`eval_test_callable_body`/`eval_test_block_value`, used by `lives-ok`/`dies-ok`/`throws-like`/`fails-like`/`warns-like`).
- Files four investigation findings from the same audit as `todo/deep`/`todo/tickets` entries (see below) — none block this PR, they scope out follow-up work.

## Measurements

`my &blk = {...}; for ^100_000 { lives-ok &blk, ... }` (release build, `perf stat instructions:u`):

| | instructions | wall clock |
|---|---|---|
| before | 9.60B | 1.24s |
| after | 5.78B | 0.58s |

`roast/S04-declarations/state.t`'s "Intensive use of state variable in inline-friendly sub" subtest (this ticket's original motivating repro, where the `lives-ok` block runs only **once**) is unaffected: ~7.4s both before and after, confirming the cache is correctly a no-op there.

## Follow-up tickets filed from the same investigation (not part of this PR)

- `todo/deep/call-compiled-closure-lacks-merge-all-and-dual-persistence-store.md` — why the larger `call_sub_value` → `call_compiled_closure` fork (the "larger fix" originally proposed) is still blocked, and what needs to happen first.
- `todo/tickets/call-compiled-closure-underscore-arg-binding-bug.md` — a live bug: `.()` mis-binds `$_`/`@_` for a bare block that reads `@_`.
- `todo/tickets/call-compiled-closure-missing-rw-lazylist-tail.md` — `call_compiled_closure` is missing `is rw`/`LazyList` return-value post-processing.
- `todo/tickets/state-var-init-guard-jit-bailout-blocks-hot-loop.md` — the actual cause of `state.t`'s 12x-vs-raku gap (a JIT bailout on `StateVarInitGuard`), unrelated to this ticket's recompilation cost.

## Test plan

- [x] `make test` (29079 tests, all pass)
- [x] Targeted roast: `state.t`, `S04-declarations/*`, `S06-signature/*`, plus a 25-file sample of Test-module-heavy files — all pass
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)