### PR TITLE
feat(adr0019): F1 item 2 -- shadow-check collect_can_methods vs canonical user_candidates

### DIFF
--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -368,6 +368,7 @@ impl Interpreter {
             if let Some(class_def) = self.registry().classes.get(cn)
                 && let Some(defs) = class_def.methods.get(method_name)
             {
+                self.shadow_check_can_methods(cn, method_name, defs);
                 let visible: Vec<&MethodDef> = defs
                     .iter()
                     .filter(|def| !def.is_my || cn == &class_name)
@@ -562,5 +563,39 @@ impl Interpreter {
             ));
         }
         results
+    }
+
+    /// ADR-0019 Phase F box F1 item 2 (`todo/deep/adr0019-f1-f2-
+    /// introspection-canonical-source.md`): shadow comparison between
+    /// `ClassDef::methods` (the source `collect_can_methods`'s MRO walk
+    /// reads directly today for `.^can`/`.can`) and `Registry::method_
+    /// entries[(owner, name)].user_candidates` (`Registry::user_method_
+    /// overloads`) -- the canonical table Phase E's dispatch path already
+    /// reads exclusively, kept in sync by `Registry::sync_user_method_
+    /// entries`. `Arc::ptr_eq` on each candidate's body is enough to prove
+    /// identity, the same reasoning F1 item 1's (now-retired)
+    /// `shadow_check_user_candidates` used. Shadow-only, zero behavior
+    /// change -- `collect_can_methods` still builds every Sub from `defs`
+    /// (the `ClassDef::methods` value).
+    fn shadow_check_can_methods(&self, class_name: &str, method_name: &str, defs: &[MethodDef]) {
+        if !crate::vm::vm_stats::enabled() {
+            return;
+        }
+        let canonical = self
+            .registry()
+            .user_method_overloads(class_name, method_name);
+        let matched = match &canonical {
+            Some(candidates) => {
+                candidates.len() == defs.len()
+                    && candidates
+                        .iter()
+                        .zip(defs.iter())
+                        .all(|(a, b)| std::sync::Arc::ptr_eq(&a.body, &b.body))
+            }
+            None => false,
+        };
+        crate::vm::vm_stats::record_can_methods_shadow_check(matched, || {
+            format!("{class_name}::{method_name}")
+        });
     }
 }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -613,6 +613,40 @@ pub(crate) fn record_deferral_shadow_check(matched: bool, detail: impl FnOnce() 
     }
 }
 
+// ADR-0019 Phase F box F1 item 2 (`todo/deep/adr0019-f1-f2-introspection-
+// canonical-source.md`): shadow comparison between `ClassDef::methods` (the
+// source `collect_can_methods`'s MRO walk reads directly today for `.^can`/
+// `.can`) and `Registry::method_entries[(owner, name)].user_candidates`
+// (`Registry::user_method_overloads`) -- the canonical table Phase E's
+// dispatch path already reads exclusively. Same reasoning as F1 item 1's
+// (now-removed) `user_candidates` shadow pair, kept as its own counter
+// because it compares a different reader's per-(class, method) candidate
+// list. Nothing reads these counters to make a dispatch decision:
+// shadow-only, zero behavior change.
+static CAN_METHODS_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static CAN_METHODS_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn can_methods_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one F1-item-2 `collect_can_methods` shadow comparison. `detail` is
+/// only evaluated on a mismatch, mirroring [`record_deferral_shadow_check`].
+#[inline]
+pub(crate) fn record_can_methods_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    CAN_METHODS_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        CAN_METHODS_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = can_methods_shadow_mismatch_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1139,6 +1173,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e8a deferral-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let can_methods_shadow_checks = CAN_METHODS_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let can_methods_shadow_mismatches = CAN_METHODS_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-f1-item2: can_methods_shadow_checks={can_methods_shadow_checks} can_methods_shadow_mismatches={can_methods_shadow_mismatches}"
+    );
+    if let Ok(map) = can_methods_shadow_mismatch_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-f1-item2 can-methods-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );


### PR DESCRIPTION
## Summary

- ADR-0019 Phase F box F1 (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`): the `.^can`/`.can` sibling of F1 item 1's already-merged `.^methods`/`.^method_table` cutover (#6399/#6400).
- Before cutting `collect_can_methods`'s MRO walk over to read `Registry::method_entries[(owner, name)].user_candidates` instead of `ClassDef::methods` directly, prove the write-side sync never drifts -- the same shadow-then-cutover pattern as item 1.
- Shadow-only, zero behavior change: adds a per-(class, method) comparison in the MRO loop, using `Arc::ptr_eq` on candidate bodies to detect true clone-lineage identity. Follow-up PR does the cutover once this lands clean on CI.

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] Full `t/` suite (3140 files) under `MUTSU_VM_STATS=1`: `can_methods_shadow_mismatches=0` across every check (~39 checks fired in `t/`). The 21 files that fail under `MUTSU_VM_STATS=1` are a known unrelated artifact -- the stats dump's stderr lines break subprocess-output assertions (confirmed via `t/dd-instance.t`, which passes cleanly without the env var and shows zero shadow checks fired).
- [x] Sampled roast files exercising `.^can`/`.can` (`S12-introspection/can.t`, `S12-introspection/meta-class.t`, `S12-introspection/walk.t`, `S02-names/pseudo-6e.t`): zero mismatches, ~30 additional checks.
- [x] CI will run `make test` + `make roast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)