### PR TITLE
feat(adr0019): F1 item 2 -- cut collect_can_methods over to canonical user_candidates

### DIFF
--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -365,10 +365,13 @@ impl Interpreter {
         let mro = self.classhow_mro_unhidden_names(target);
         let mut results = Vec::new();
         for cn in &mro {
-            if let Some(class_def) = self.registry().classes.get(cn)
-                && let Some(defs) = class_def.methods.get(method_name)
-            {
-                self.shadow_check_can_methods(cn, method_name, defs);
+            // The candidate list comes from the canonical `Registry::method_
+            // entries[(owner, name)].user_candidates` table (ADR-0019 Phase F
+            // box F1 item 2) rather than `ClassDef::methods` directly --
+            // `sync_user_method_entries` keeps the two in lockstep, verified
+            // with zero mismatches across a full `t/`+roast sweep by the
+            // shadow check this cutover retires (#6402).
+            if let Some(defs) = self.registry().user_method_overloads(cn, method_name) {
                 let visible: Vec<&MethodDef> = defs
                     .iter()
                     .filter(|def| !def.is_my || cn == &class_name)
@@ -563,39 +566,5 @@ impl Interpreter {
             ));
         }
         results
-    }
-
-    /// ADR-0019 Phase F box F1 item 2 (`todo/deep/adr0019-f1-f2-
-    /// introspection-canonical-source.md`): shadow comparison between
-    /// `ClassDef::methods` (the source `collect_can_methods`'s MRO walk
-    /// reads directly today for `.^can`/`.can`) and `Registry::method_
-    /// entries[(owner, name)].user_candidates` (`Registry::user_method_
-    /// overloads`) -- the canonical table Phase E's dispatch path already
-    /// reads exclusively, kept in sync by `Registry::sync_user_method_
-    /// entries`. `Arc::ptr_eq` on each candidate's body is enough to prove
-    /// identity, the same reasoning F1 item 1's (now-retired)
-    /// `shadow_check_user_candidates` used. Shadow-only, zero behavior
-    /// change -- `collect_can_methods` still builds every Sub from `defs`
-    /// (the `ClassDef::methods` value).
-    fn shadow_check_can_methods(&self, class_name: &str, method_name: &str, defs: &[MethodDef]) {
-        if !crate::vm::vm_stats::enabled() {
-            return;
-        }
-        let canonical = self
-            .registry()
-            .user_method_overloads(class_name, method_name);
-        let matched = match &canonical {
-            Some(candidates) => {
-                candidates.len() == defs.len()
-                    && candidates
-                        .iter()
-                        .zip(defs.iter())
-                        .all(|(a, b)| std::sync::Arc::ptr_eq(&a.body, &b.body))
-            }
-            None => false,
-        };
-        crate::vm::vm_stats::record_can_methods_shadow_check(matched, || {
-            format!("{class_name}::{method_name}")
-        });
     }
 }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -613,40 +613,6 @@ pub(crate) fn record_deferral_shadow_check(matched: bool, detail: impl FnOnce() 
     }
 }
 
-// ADR-0019 Phase F box F1 item 2 (`todo/deep/adr0019-f1-f2-introspection-
-// canonical-source.md`): shadow comparison between `ClassDef::methods` (the
-// source `collect_can_methods`'s MRO walk reads directly today for `.^can`/
-// `.can`) and `Registry::method_entries[(owner, name)].user_candidates`
-// (`Registry::user_method_overloads`) -- the canonical table Phase E's
-// dispatch path already reads exclusively. Same reasoning as F1 item 1's
-// (now-removed) `user_candidates` shadow pair, kept as its own counter
-// because it compares a different reader's per-(class, method) candidate
-// list. Nothing reads these counters to make a dispatch decision:
-// shadow-only, zero behavior change.
-static CAN_METHODS_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
-static CAN_METHODS_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
-
-fn can_methods_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
-    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
-    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-/// Record one F1-item-2 `collect_can_methods` shadow comparison. `detail` is
-/// only evaluated on a mismatch, mirroring [`record_deferral_shadow_check`].
-#[inline]
-pub(crate) fn record_can_methods_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
-    if !enabled() {
-        return;
-    }
-    CAN_METHODS_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
-    if !matched {
-        CAN_METHODS_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
-        if let Ok(mut map) = can_methods_shadow_mismatch_by_key().lock() {
-            *map.entry(detail()).or_insert(0) += 1;
-        }
-    }
-}
-
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1173,27 +1139,6 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e8a deferral-shadow mismatches (top {}): {}",
-            top.len(),
-            top.join(" ")
-        );
-    }
-    let can_methods_shadow_checks = CAN_METHODS_SHADOW_CHECKS.load(Ordering::Relaxed);
-    let can_methods_shadow_mismatches = CAN_METHODS_SHADOW_MISMATCHES.load(Ordering::Relaxed);
-    eprintln!(
-        "[mutsu vm-stats] adr0019-f1-item2: can_methods_shadow_checks={can_methods_shadow_checks} can_methods_shadow_mismatches={can_methods_shadow_mismatches}"
-    );
-    if let Ok(map) = can_methods_shadow_mismatch_by_key().lock()
-        && !map.is_empty()
-    {
-        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
-        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
-        let top: Vec<String> = entries
-            .iter()
-            .take(25)
-            .map(|(name, count)| format!("{name}={count}"))
-            .collect();
-        eprintln!(
-            "[mutsu vm-stats] adr0019-f1-item2 can-methods-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );


### PR DESCRIPTION
## Summary

- ADR-0019 Phase F box F1 (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`): the cutover half of #6402's shadow check.
- `.^can`/`.can` (`collect_can_methods`'s MRO walk) now build every candidate list from `Registry::method_entries[(owner, name)].user_candidates` (via `Registry::user_method_overloads`) instead of reading `ClassDef::methods` directly -- the same pattern F1 item 1 applied to `.^methods`/`.^method_table` (#6399/#6400).
- Removes the now-redundant `shadow_check_can_methods` helper and its `MUTSU_VM_STATS` counters added in #6402 (that shadow check already proved zero mismatches across a full `t/`+roast sweep; comparing the new path against itself adds nothing).

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] Full `t/` suite (3140 files): PASS
- [x] Whitelisted roast files exercising `.^can`/`.can`: `S12-introspection/{can,meta-class,walk}.t`, `S12-enums/thorough.t`, `S32-exceptions/misc2.t` -- all PASS
- [x] CI will run `make test` + `make roast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)