### PR TITLE
docs(adr0019): record F1 item-2 raku ground truth + file the .^lookup Sub-vs-Method finding

### DIFF
--- a/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
+++ b/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
@@ -76,3 +76,48 @@ questions above (signature shape, `.candidates` for multi natives, `.package`/`.
 own methods, wrap/multi/submethod flags), landing as pins under `t/`, before writing the F1 design
 doc. The user-method half (item 1 above) can proceed independently and sooner — it is a mechanical
 shadow-then-cutover slice once `user_candidates`'s sync fidelity is confirmed.
+
+## Progress (2026-08-14)
+
+Item 1's user-method cutover is done, across all three MRO/table readers that used to walk
+`ClassDef::methods` directly:
+
+- `collect_class_methods`/`class_method_table` (`.^methods`/`.^method_table`) — shadow-check
+  #6399, cutover #6400.
+- `collect_can_methods` (`.^can`/`.can`) — shadow-check #6402, cutover #6406, same
+  shadow-then-cutover pattern, zero mismatches across a full `t/` sweep plus the
+  `S12-introspection/{can,meta-class,walk}.t`, `S12-enums/thorough.t`, `S32-exceptions/misc2.t`
+  roast files.
+
+Item 2 (native/builtin method metadata) remains untouched and is still the real open work — the
+raku ground-truth pass below narrows it further but does not resolve the F3-tension question in
+item 2's option (a) vs (b).
+
+**Raku ground truth gathered while scoping item 2** (`raku -e`, not yet mutsu pins under `t/`):
+
+- Native-method `.signature.gist` is real Rakudo behavior, not a stub — but it is **not**
+  arity-derivable in general: `(42).^lookup("floor").signature.gist` is
+  `(Int:D $:: *%_ --> Int:D)` (generic named-catchall, no positional info at all despite `floor`
+  taking zero args beyond the invocant); `"abc".^lookup("substr").signature.gist` is
+  `(Cool $:: |)` (a raw capture, arity fully erased); `Array.^lookup("push").signature.gist` is
+  `($:: |)`; `Hash.^lookup("push").signature.gist` is `(Hash $:: +values, *%_)` (this one *does*
+  show a real slurpy-positional name). So Rakudo's own native signatures range from "fully generic
+  capture" to "one specific slurpy param name" with no discernible single pattern — confirms this
+  needs per-method hand data to match exactly (option (a)'s tension with F3 is real, not
+  hypothetical), or an intentionally-generic placeholder (option (b), accepting it won't match
+  Rakudo exactly since Rakudo itself isn't derivable from arity alone).
+- `.is_dispatcher` is a real accessor Rakudo exposes on any `Method` (`$m.is_dispatcher` → `False`
+  for `floor`, `True` for a multi's dispatcher Method) and `.multi` too (`True`/`False`). Checked
+  against mutsu: **`.is_dispatcher`/`.multi` are unreachable on any `Method`-shaped value returned
+  by `.^lookup`** (`(42).^lookup("floor").is_dispatcher` prints `<composed-method:is_dispatcher>`
+  instead of `False`) — this is not an item-2-only gap, it reproduces on `.^lookup` of a plain user
+  method too. Root cause found: `classhow_lookup`/`classhow_lookup_impl`
+  (`methods_classhow_lookup.rs`) builds its return value as a **`Sub`-shaped** `Value::make_sub`,
+  not the `Method`-`Instance`-shaped value `collect_can_methods`/`collect_class_methods` build via
+  `make_method_object_with_owner`. Calling an unknown method on a `Sub` value falls into the
+  callable-compose fallback in `methods_instance_ops.rs` (~line 2117), which silently returns a
+  bogus composed-callable instead of erroring — so `.^lookup(...).is_dispatcher` (or any other
+  `Method`-only accessor) never reaches a real answer. This is a distinct, smaller, well-scoped bug
+  (two representations of "a method" that don't interoperate) — separate from F1/F2's native-metadata
+  question and not blocked on the raku ground-truth session above. Filed as
+  `todo/tickets/classhow-lookup-returns-sub-not-method-instance.md`.

--- a/todo/tickets/classhow-lookup-returns-sub-not-method-instance.md
+++ b/todo/tickets/classhow-lookup-returns-sub-not-method-instance.md
@@ -1,0 +1,76 @@
+# `.^lookup`/`.^find_method` return a `Sub`-shaped value, not a `Method` instance, so `Method`-only accessors silently misbehave
+
+Found while scoping ADR-0019 Phase F box F1 item 2
+(`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`).
+
+## Repro
+
+```
+$ raku -e 'my $m = (42).^lookup("floor"); say $m.is_dispatcher; say $m.multi'
+False
+0
+$ ./target/debug/mutsu -e 'my $m = (42).^lookup("floor"); say $m.is_dispatcher; say $m.multi'
+<composed-method:is_dispatcher>
+<composed-method:multi>
+```
+
+Real Raku prints `False`/`0` (a `Method`'s `is_dispatcher`/`multi` accessors). mutsu prints a bogus
+`<composed-method:NAME>` string for *any* unrecognized method call on the value — it never errors
+and never returns the right answer.
+
+Also reproduces on a plain user method, not just native ones:
+
+```
+$ ./target/debug/mutsu -e 'class A { method foo {} }; say A.^lookup("foo").is_dispatcher'
+<composed-method:is_dispatcher>
+```
+
+## Root cause
+
+`.^methods`/`.^method_table`/`.can` (`src/runtime/methods_classhow_method_obj.rs`,
+`collect_class_methods`/`class_method_table`/`collect_can_methods`) build a `Method`
+**`Instance`**-shaped `Value` via `make_method_object_with_owner`, carrying `is_dispatcher`,
+`signature`, `candidates`, etc. as real instance attributes.
+
+`.^lookup`/`.^find_method` (`src/runtime/methods_classhow_lookup.rs`, `classhow_lookup`/
+`classhow_lookup_impl`) instead build a **`Sub`**-shaped `Value::make_sub` — a callable, not an
+`Instance` with `Method`'s attributes.
+
+When an unrecognized method (`is_dispatcher`, `multi`, ...) is called on a `Sub` value, dispatch
+falls into the "method calls on callables compose" fallback in
+`src/runtime/methods_instance_ops.rs` (~line 2117): "calling `.foo` on a `Sub` means apply `foo` to
+the Sub's *return value*". That fallback builds a new composed-callable `Sub` named
+`<composed-method:foo>` and returns it — since nothing ever calls it, printing it just shows the
+placeholder name, and no error is ever raised.
+
+## Why this is a real (not cosmetic) gap
+
+Any `Method`-only introspection accessor (`is_dispatcher`, `multi`, `candidates` in some cases,
+`package`/`name` happen to already work because those are special-cased elsewhere) is unreachable
+on the result of `.^lookup`/`.^find_method`, silently returning garbage instead of erroring or
+answering correctly. This is exactly the kind of surface ADR-0019 Phase F (F1/F2, "derive
+`.^methods`/`.^can`/method MRO views from the resolver/table" — same unification PLAN.md §5 calls
+for) is meant to fix, but it is a distinct, smaller bug from F1's native-metadata gap: it's a
+representation mismatch (two different "this is a method" `Value` shapes that don't interoperate),
+not a missing-data problem.
+
+## Why this is deep, not a quick ticket
+
+Unifying the two representations (making `.^lookup` return the same `Method`-`Instance` shape
+`.^methods` does, or vice versa) touches:
+
+- `.wrap` on a `.^lookup` result, which today relies on the `Sub` shape's env-carried
+  `__mutsu_lookup_class`/`__mutsu_lookup_method` tags (see `make_method_object_with_owner`'s doc
+  comment) to register a wrap chain — a `Method`-`Instance`-shaped lookup result would need the
+  same wrap-registration path wired differently (the `Instance` already carries these same tags for
+  `.wrap` from `.^methods(:local)`, so this may already be closer to solved than it looks, but needs
+  verification).
+- Direct callability: `.^lookup("foo")(invocant, args)` presumably still needs to work, which is
+  why `.^lookup` returns something callable today — a `Method`-`Instance` is not directly callable
+  without dispatch support for calling an `Instance`.
+- All existing callers of `classhow_lookup`/`classhow_find_method` that assume a `Sub`-shaped
+  result (arity/param inspection, `.wrap`, `.^can`'s reuse in some paths) need an audit.
+
+Best done as part of the F1/F2 design once the native-metadata ground-truth pass
+(`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`) lands, since both are about making
+introspection surfaces agree with each other and with the canonical dispatch table.


### PR DESCRIPTION
## Summary

- Records that ADR-0019 Phase F box F1's user-method half is now fully cut over: both the `.^methods`/`.^method_table` pair (#6399/#6400) and the `.^can`/`.can` pair (#6402/#6406).
- Records the raku ground truth gathered while scoping item 2 (native-method metadata): `.signature.gist` ranges from a fully generic capture to one real slurpy-param name depending on the method, confirming the hand-table/F3 tension flagged in the original scoping note is real.
- Files a distinct, smaller bug found along the way: `.^lookup`/`.^find_method` return a `Sub`-shaped value rather than the `Method` `Instance` `.^methods`/`.can` build, so `Method`-only accessors (`.is_dispatcher`, `.multi`) silently return a bogus `<composed-method:NAME>` value instead of erroring or answering correctly. Filed as `todo/tickets/classhow-lookup-returns-sub-not-method-instance.md` rather than fixed inline, since unifying the two representations needs a `.wrap` and call-site audit.

Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)