### PR TITLE
fix(parser): sigilless `\name := $var` bind writes through, not readonly

### DIFF
--- a/news/2026-08/sigilless-bind-writable-alias.md
+++ b/news/2026-08/sigilless-bind-writable-alias.md
@@ -1,0 +1,71 @@
+# A sigilless `\name := $var` bind is a real alias, not a readonly snapshot
+
+Triaging `Math::Interval` from the un-triaged `test_die` list in
+`todo/tickets/dist-test-suite-failures-batch.md` turned up a general bug in how
+mutsu handles sigilless (`\name`) variable declarations.
+
+`lib/Math/Interval.rakumod`'s `TWEAK` for the 2D interval type does:
+
+```raku
+my (\x1, \x2, \y1, \y2) := my ($x1, $x2, $y1, $y2);
+...
+submethod TWEAK {
+    ($x1, $x2) = ($!x.min, $!x.max);
+    ...
+}
+```
+
+reducing to the much smaller:
+
+```raku
+my $x1 = 5;
+my \x1 := $x1;
+x1 = 10;
+say $x1;   # raku: 10 — mutsu: "Cannot modify an immutable value (x1)"
+```
+
+## Root cause
+
+raku's rule for a sigilless `my \name := expr` (or the plain-`=` form, which
+means the same thing for a sigilless term since there is no container to
+assign into) is: when `expr` is itself a plain variable, `name` becomes a
+writable ALIAS of that variable's container — assigning through `name` writes
+through to the original variable. When `expr` is any other rvalue (a literal,
+a computed expression), `name` stays genuinely readonly.
+
+mutsu's parser (`parse_sigilless_decl` in
+`src/parser/stmt/decl/my_decl_helpers.rs`) decided mutability purely from
+whether a *type constraint* was written — `my \a := $a` was unconditionally
+marked readonly, `my Mu \a := $a` was unconditionally marked writable —
+without ever looking at what `expr` actually was. This was wrong in both
+directions:
+
+- **Untyped bind to a variable** (`my \a := $a`) was wrongly readonly, even
+  though the RHS was a plain container reference.
+- **Typed bind to a variable** (`my Int \a := $x`) was marked writable, but
+  never actually aliased the source container — it silently became an
+  independent local copy, so `a = 10` mutated only `a`, leaving `$x`
+  unchanged. That's arguably worse: no error, but silently wrong semantics.
+- **Typed bind to a literal** (`my Int \a := 5`) was also wrongly writable
+  (`a = 10; say a` printed `10` instead of dying).
+
+The sigilled case (`my $b := expr`) already had the right rule in
+`my_decl_assign::handle_binding`: `scalar_binding_rhs_is_readonly` plus a
+`bind_to_var` check on the RHS shape, routing a variable-RHS bind through the
+existing `MarkBind` → `WrapVarRef` → `bind_source` alias machinery. The fix
+extracts that same RHS-shape decision into a shared helper
+(`build_sigilless_bind_stmt`) used by all three sigilless forms (`:=`, `::=`,
+plain `=`), so mutability now follows what the sigilless name is bound to,
+not whether a type was written on it.
+
+## What's still open
+
+`Math::Interval`'s actual `TWEAK` binds four names from a **list
+destructuring** in one shot (`my (\x1, \x2, ...) := my ($x1, $x2, ...)`).
+That shape still fails: mutsu's destructuring-bind desugaring reads each
+element back out of a temp array by index, which loses per-element container
+identity entirely — a distinct, deeper gap already tracked in
+`todo/deep/element-itemization-lost-in-scalar-binding.md`. So the general
+single-variable sigilless-bind bug is fixed and pinned
+(`t/sigilless-bind-writable-alias.t`), but `Math::Interval`'s own test suite
+still needs that separate architectural fix to pass fully.

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -12,6 +12,49 @@ use crate::value::Value;
 
 use super::parse_assign_expr_or_comma;
 
+/// Build the statement for a sigilless bind/declaration (`my \name := expr`,
+/// `my \name ::= expr`, or `my \name = expr` — all three bind the sigilless
+/// name to `expr` rather than assigning into a container, since a sigilless
+/// term has none).
+///
+/// Mirrors the sigilled `:=` logic in `my_decl_assign::handle_binding`: when
+/// `expr` is itself a plain variable reference (`Expr::Var`), the sigilless
+/// name becomes a writable ALIAS of that variable's container (raku:
+/// `my $a = 5; my \x := $a; x = 10; say $a` prints `10`) via the same
+/// `MarkBind`/`WrapVarRef`/`bind_source` machinery the sigilled case uses.
+/// Otherwise (binding to a literal or any other computed rvalue) the name
+/// stays genuinely readonly (raku: `my \x := 5; x = 10` dies).
+///
+/// This does NOT depend on whether a type constraint was written — `my Mu
+/// \a := $a` and `my \a := $a` behave the same way in raku; only the shape
+/// of the RHS decides mutability.
+fn build_sigilless_bind_stmt(
+    name: String,
+    expr: Expr,
+    type_constraint: Option<String>,
+    is_state: bool,
+    is_our: bool,
+) -> Stmt {
+    let bind_to_var = matches!(expr, Expr::Var(_));
+    let decl = Stmt::VarDecl {
+        name: name.clone(),
+        expr,
+        type_constraint,
+        is_state,
+        is_our,
+        is_dynamic: false,
+        is_export: false,
+        export_tags: Vec::new(),
+        custom_traits: Vec::new(),
+        where_constraint: None,
+    };
+    if bind_to_var {
+        Stmt::SyntheticBlock(vec![Stmt::MarkBind, decl, Stmt::MarkSigilless(name)])
+    } else {
+        Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigillessReadonly(name)])
+    }
+}
+
 /// Parse a sigilless variable declaration: `my \name = expr`
 pub(super) fn parse_sigilless_decl(
     input: &str,
@@ -26,28 +69,7 @@ pub(super) fn parse_sigilless_decl(
     if let Some(r) = r.strip_prefix("::=").or_else(|| r.strip_prefix(":=")) {
         let (r, _) = ws(r)?;
         let (r, expr) = parse_assign_expr_or_comma(r)?;
-        let decl = Stmt::VarDecl {
-            name: name.clone(),
-            expr,
-            type_constraint: type_constraint.clone(),
-            is_state,
-            is_our,
-            is_dynamic: false,
-            is_export: false,
-            export_tags: Vec::new(),
-            custom_traits: Vec::new(),
-            where_constraint: None,
-        };
-        // Sigilless variables without type constraint are always readonly.
-        // With a type constraint (e.g. `my Mu \a := $a`), the variable
-        // binds to the container, preserving mutability — but it must still be
-        // registered as a sigilless local so a bare-word read resolves to its
-        // slot (not `env`), so wrap it with the non-readonly `MarkSigilless`.
-        let stmt = if type_constraint.is_none() {
-            Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigillessReadonly(name)])
-        } else {
-            Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigilless(name)])
-        };
+        let stmt = build_sigilless_bind_stmt(name, expr, type_constraint.clone(), is_state, is_our);
         if apply_modifier {
             return parse_statement_modifier(r, stmt);
         }
@@ -109,23 +131,7 @@ pub(super) fn parse_sigilless_decl(
         let r = &r[1..];
         let (r, _) = ws(r)?;
         let (r, expr) = parse_assign_expr_or_comma(r)?;
-        let decl = Stmt::VarDecl {
-            name: name.clone(),
-            expr,
-            type_constraint: type_constraint.clone(),
-            is_state,
-            is_our,
-            is_dynamic: false,
-            is_export: false,
-            export_tags: Vec::new(),
-            custom_traits: Vec::new(),
-            where_constraint: None,
-        };
-        let stmt = if type_constraint.is_none() {
-            Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigillessReadonly(name)])
-        } else {
-            Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigilless(name)])
-        };
+        let stmt = build_sigilless_bind_stmt(name, expr, type_constraint.clone(), is_state, is_our);
         if apply_modifier {
             return parse_statement_modifier(r, stmt);
         }

--- a/t/sigilless-bind-writable-alias.t
+++ b/t/sigilless-bind-writable-alias.t
@@ -1,0 +1,107 @@
+use v6;
+use Test;
+
+# A sigilless declaration (`my \name := expr` / `my \name = expr`) binds the
+# name to `expr` rather than assigning into a container, since a sigilless
+# term has none. When `expr` is itself a plain variable reference, raku makes
+# the sigilless name a writable ALIAS of that variable's underlying
+# container — assigning through the alias writes through to the original
+# variable. When `expr` is any other rvalue (a literal, a computed value),
+# the sigilless name stays genuinely readonly.
+#
+# mutsu previously blanket-marked every untyped sigilless bind as readonly
+# (ignoring what it was bound to) and, conversely, blanket-marked every
+# TYPED sigilless bind as writable but WITHOUT actually aliasing the source
+# container — so `my Int \x := $x; x = 10` silently mutated only the local
+# `x`, leaving `$x` unchanged. See todo/tickets/dist-test-suite-failures-batch.md
+# (Math::Interval triage) for how this was found.
+
+# --- := bind to a plain variable: writes through to the source ---
+{
+    my $x = 5;
+    my \x := $x;
+    x = 10;
+    is $x, 10, ':= bind to $var writes through on assignment via the alias';
+}
+
+{
+    my $x = 5;
+    my \x := $x;
+    $x = 20;
+    is x, 20, ':= bind to $var reflects a write to the source variable too';
+}
+
+# --- := bind to a literal/computed rvalue: stays readonly ---
+{
+    my \x := 5;
+    dies-ok { x = 10 }, ':= bind to a literal stays readonly';
+}
+
+{
+    dies-ok { my \x := 5 + 3; x = 10 }, ':= bind to a computed rvalue stays readonly';
+}
+
+# --- typed sigilless bind: mutability follows the RHS shape too, not the
+#     presence of a type constraint ---
+{
+    my Int $x = 5;
+    my Int \x := $x;
+    x = 10;
+    is $x, 10, 'typed := bind to $var truly aliases the source (writes through)';
+}
+
+{
+    dies-ok { my Int \x := 5; x = 10 }, 'typed := bind to a literal still stays readonly';
+}
+
+# --- plain `=` on a sigilless decl behaves like `:=` (no container to
+#     assign into, so it binds too) ---
+{
+    my $a = 5;
+    my \x = $a;
+    x = 10;
+    is $a, 10, '= form bind to $var also writes through (raku: no assignment target exists)';
+}
+
+{
+    dies-ok { my \x = 5; x = 10 }, '= form bind to a literal stays readonly';
+}
+
+# --- multiple independent sigilless binds in the same scope ---
+{
+    my ($a, $b) = (1, 2);
+    my \x := $a;
+    my \y := $b;
+    x = 100;
+    y = 200;
+    is $a, 100, 'first of two independent := binds writes through';
+    is $b, 200, 'second of two independent := binds writes through';
+}
+
+# --- reading through the alias reflects the current value ---
+{
+    my $x = 1;
+    my \x := $x;
+    $x++;
+    $x++;
+    is x, 3, 'reading the sigilless alias reflects mutation of the source var';
+}
+
+# --- sigilless bind still works for common idioms not touching write-through ---
+{
+    my \pi = 3.14159;
+    is pi, 3.14159, 'sigilless constant-style decl reads back correctly';
+}
+
+{
+    sub double(\n) { n * 2 }
+    is double(21), 42, 'sigilless sub parameter still works (unrelated path, no regression)';
+}
+
+{
+    my @a = (1, 2, 3);
+    my \first = @a[0];
+    is first, 1, 'sigilless bind to an array element read (not a bare $var) stays readonly-safe';
+}
+
+done-testing;

--- a/todo/deep/element-itemization-lost-in-scalar-binding.md
+++ b/todo/deep/element-itemization-lost-in-scalar-binding.md
@@ -54,6 +54,15 @@ just not as a drive-by.
 - Implicit-topic iteration over `@`-arrays whose body relies on the element
   being ONE item in list context (the sprintf shape, now only reachable via
   `for @c { ... $_ ... }` — the `-> $v` form is fixed).
+- List-destructuring bind write-through: `my (\a, \b) := my ($x, $y); a = 10;`
+  (or the sigilled `my ($a, $b) := ($x, $y);`) never propagates to `$x`,
+  because the destructuring desugar reads each target's RHS out of a temp
+  array by index (`Expr::Index { target: ArrayVar("__destructure_tmp__"),
+  index: i }`), which has no per-element container to alias. Found triaging
+  `Math::Interval`'s `TWEAK` (`todo/tickets/dist-test-suite-failures-batch.md`);
+  the single-variable case (`my \a := $x`) was fixed separately in
+  `news/2026-08/sigilless-bind-writable-alias.md`, but the list-bind form
+  needs this store-side fix.
 
 ## Verification once fixed
 

--- a/todo/tickets/dist-test-suite-failures-batch.md
+++ b/todo/tickets/dist-test-suite-failures-batch.md
@@ -126,9 +126,31 @@ resolution / `inherit_enclosing_scopes` / `constant_vars_in_scope`) and why
 it needs a design pass rather than a quick patch:
 [todo/tickets/sigilless-constant-invisible-in-nested-sub-inside-module.md](sigilless-constant-invisible-in-nested-sub-inside-module.md).
 
+### `Math::Interval` — triaged, one general bug fixed, one remains (needs a design pass)
+
+A sigilless `\name := $var` bind (used by the 2D-interval `TWEAK`, minimally:
+`my $x1 = 5; my \x1 := $x1; x1 = 10; say $x1;`) was wrongly treated as
+readonly, because mutsu decided mutability purely from whether a type
+constraint was written on the sigilless declaration, never looking at what
+the RHS actually was — the sigilled `$b := expr` path already had the right
+rule (writable alias when the RHS is a plain variable, readonly otherwise)
+but the sigilless path didn't share it. Fixed generally in
+`src/parser/stmt/decl/my_decl_helpers.rs` (a shared `build_sigilless_bind_stmt`
+helper now applies the same RHS-shape rule to all three sigilless bind forms:
+`:=`, `::=`, plain `=`); pinned by `t/sigilless-bind-writable-alias.t`. See
+`news/2026-08/sigilless-bind-writable-alias.md`.
+
+The dist's own `TWEAK` actually binds four names from one **list
+destructuring** (`my (\x1, \x2, \y1, \y2) := my ($x1, $x2, $y1, $y2);`),
+which still fails: mutsu's destructuring-bind desugaring reads each element
+back out of a temp array by index, losing per-element container identity —
+the same class of gap as
+[todo/deep/element-itemization-lost-in-scalar-binding.md](../deep/element-itemization-lost-in-scalar-binding.md),
+tracked there.
+
 ## Un-triaged `test_die` / `test_fail`
 
-`Math::Interval`, `Native::Overflow`, `App::SudokuHelper`, `P5tie`,
+`Native::Overflow`, `App::SudokuHelper`, `P5tie`,
 `Mathematica::Serializer::Encoder`, `Hash::Restricted`, `Crypt::RC4`,
 `Random::Choice` (die).
 


### PR DESCRIPTION
## Summary

- Triaging `Math::Interval` (from the un-triaged `test_die` list in `todo/tickets/dist-test-suite-failures-batch.md`) found that a sigilless bind (`my \name := expr`) decided mutability purely from whether a type constraint was written, never from what `expr` actually was.
- raku's rule: `my \name := $var` (RHS is a plain variable) makes `name` a writable ALIAS of `$var`'s container; binding to any other rvalue (a literal, a computed expression) stays genuinely readonly.
- mutsu got this backwards in two ways: an untyped bind-to-var (`my \a := $a`) was wrongly readonly, and a typed bind-to-var (`my Int \a := $x`) was wrongly *writable* but never actually aliased the source — `a = 10` silently mutated only the fresh local, leaving `$x` unchanged.
- Fix: extract the same RHS-shape decision the sigilled `$b := expr` path already uses (`scalar_binding_rhs_is_readonly` / `bind_to_var` in `my_decl_assign::handle_binding`) into a shared `build_sigilless_bind_stmt`, used by all three sigilless bind forms (`:=`, `::=`, plain `=`). A variable-RHS bind now routes through the existing `MarkBind` -> `WrapVarRef` -> `bind_source` alias machinery instead of unconditionally `MarkSigillessReadonly`.
- `Math::Interval`'s actual `TWEAK` binds four names from one **list destructuring** (`my (\x1, \x2, \y1, \y2) := my ($x1, $x2, $y1, $y2);`), which still fails for a separate, deeper reason (the destructuring desugar loses per-element container identity) — documented as an addition to `todo/deep/element-itemization-lost-in-scalar-binding.md` rather than attempted here. Ticket updated accordingly.

## Test plan

- [x] `raku -e '...'` confirms the expected behavior for every case in the new test (both the fixed writable-alias cases and the still-readonly cases), including the reference baseline of the new `t/` file itself (`raku t/sigilless-bind-writable-alias.t` — 14/14 ok).
- [x] `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings` clean.
- [x] `make test` — 3141 files, 29092 tests, all successful (no regressions; grepped `tmp/make-test.log` for real failures, not just exit status).
- [x] New regression test: `t/sigilless-bind-writable-alias.t`.
- [x] Targeted existing sigilless/bind tests re-run and pass: `t/gate-b-sigilless-typed-bind.t`, `t/for-sigilless-rw.t`, `t/destructuring-sigilless-params.t`, `t/given-sigilless-instance.t`, `t/if-pointy-sigilless-binding.t`, and ~30 more sigilless-related `t/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)