### PR TITLE
fix(introspection): .^lookup Method/Submethod values answer is_dispatcher/multi

### DIFF
--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -328,6 +328,12 @@ impl Interpreter {
                     "__mutsu_lookup_candidate_idx".to_string(),
                     Value::int(idx as i64),
                 );
+                // Real Raku: an individual `.candidates[N]` entry answers
+                // `.multi` True (it IS a declared multi candidate), unlike the
+                // dispatcher-shaped value `.^lookup`/`.^find_method` return for
+                // the family as a whole, which answers `.multi` falsy. See the
+                // `is_dispatcher`/`multi` handling in `methods_instance_ops.rs`.
+                env.insert("__mutsu_is_multi_candidate".to_string(), Value::TRUE);
                 out.push(Value::make_sub(
                     crate::symbol::Symbol::intern(owner),
                     crate::symbol::Symbol::intern(method_name),

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1912,6 +1912,31 @@ impl Interpreter {
                 ValueView::Routine { package, .. } => Ok(Value::package(package)),
                 _ => Ok(Value::NIL),
             },
+            // `.is_dispatcher`/`.multi` on a Method/Submethod value obtained from
+            // `.^lookup`/`.^find_method`/`.can` (a `Sub`-shaped callable, not the
+            // `Method` `Instance` `.^methods` builds -- see
+            // `todo/tickets/classhow-lookup-returns-sub-not-method-instance.md`).
+            // Real Raku: the dispatcher-shaped value for a multi method answers
+            // `is_dispatcher` True and `multi` falsy; each individual
+            // `.candidates[N]` entry answers `is_dispatcher` False and `multi`
+            // True; an ordinary (non-multi) method answers both False. Verified
+            // against `raku -e` ground truth 2026-08-14 (see the linked ticket).
+            "is_dispatcher" if args.is_empty() && matches!(target.view(), ValueView::Sub(_)) => {
+                let ValueView::Sub(data) = target.view() else {
+                    unreachable!()
+                };
+                Ok(Value::truth(
+                    Self::sub_multi_method_dispatcher_name(&data).is_some(),
+                ))
+            }
+            "multi" if args.is_empty() && matches!(target.view(), ValueView::Sub(_)) => {
+                let ValueView::Sub(data) = target.view() else {
+                    unreachable!()
+                };
+                Ok(Value::truth(
+                    data.env.get("__mutsu_is_multi_candidate").is_some(),
+                ))
+            }
             "isa" if args.len() == 1 && matches!(target.view(), ValueView::Package(_)) => {
                 let pkg_name = match target.view() {
                     ValueView::Package(name) => name.resolve(),

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -321,6 +321,9 @@ impl Interpreter {
                     | "gist"
                     | "can"
                     | "dispatcher"
+                    | "is_dispatcher"
+                    | "multi"
+                    | "package"
             );
             return Some(Ok(Value::truth(can)));
         }
@@ -1049,6 +1052,9 @@ impl Interpreter {
                     | "wrap"
                     | "unwrap"
                     | "callwith"
+                    | "is_dispatcher"
+                    | "multi"
+                    | "package"
             );
             return Some(Ok(Value::truth(can)));
         }

--- a/t/classhow-lookup-method-is-dispatcher-multi.t
+++ b/t/classhow-lookup-method-is-dispatcher-multi.t
@@ -1,0 +1,44 @@
+use Test;
+
+# ADR-0019 Phase F box F1/F2 (todo/tickets/classhow-lookup-returns-sub-not-
+# method-instance.md): `.^lookup`/`.^find_method` return a `Sub`-shaped
+# value, not the `Method` `Instance` `.^methods` builds, so `Method`-only
+# accessors like `.is_dispatcher` and `.multi` used to fall into the
+# callable-compose fallback and silently return a bogus
+# `<composed-method:NAME>` callable instead of a real answer. Ground truth
+# gathered against `raku` 2026-08-14:
+#
+#   - An ordinary (non-multi) method's lookup answers both False.
+#   - A multi method's dispatcher-shaped lookup (what `.^lookup`/
+#     `.^find_method` return for the family as a whole) answers
+#     `is_dispatcher` True but `multi` falsy.
+#   - Each individual `.candidates[N]` entry answers `is_dispatcher` False
+#     but `multi` True.
+#   - A submethod lookup answers both False, same as an ordinary method.
+
+class Plain { method foo { 1 } }
+my $plain = Plain.^lookup("foo");
+nok $plain.is_dispatcher, 'non-multi method: is_dispatcher is False';
+nok $plain.multi, 'non-multi method: multi is falsy';
+
+class Sub1 { submethod boot { 1 } }
+my $sub = Sub1.^lookup("boot");
+nok $sub.is_dispatcher, 'submethod: is_dispatcher is False';
+nok $sub.multi, 'submethod: multi is falsy';
+
+class Multi1 {
+    multi method bar(Int $x) { "int" }
+    multi method bar(Str $x) { "str" }
+}
+my $dispatcher = Multi1.^lookup("bar");
+ok $dispatcher.is_dispatcher, 'multi method dispatcher: is_dispatcher is True';
+nok $dispatcher.multi, 'multi method dispatcher: multi is falsy';
+
+my @candidates = $dispatcher.candidates;
+is @candidates.elems, 2, 'multi method dispatcher exposes both candidates';
+for @candidates -> $c {
+    nok $c.is_dispatcher, 'multi candidate: is_dispatcher is False';
+    ok $c.multi, 'multi candidate: multi is True';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

ADR-0019 Phase F box F1/F2 scoping (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`) surfaced a distinct bug filed as `todo/tickets/classhow-lookup-returns-sub-not-method-instance.md`: `.^lookup`/`.^find_method` return a `Sub`-shaped callable rather than the `Method` `Instance` `.^methods` builds. Calling a `Method`-only accessor like `.is_dispatcher` or `.multi` on that result fell into the callable-compose fallback (`methods_instance_ops.rs`, "method calls on callables compose") and silently returned a bogus `<composed-method:NAME>` callable instead of a real answer or an error.

This PR adds targeted handling for `.is_dispatcher` and `.multi` on Sub-shaped Method/Submethod values, matching `raku` ground truth gathered against real Rakudo:

- A non-multi method or submethod: both `False`.
- A multi method's dispatcher-shaped value (what `.^lookup`/`.^find_method` return for the family): `is_dispatcher` `True`, `multi` falsy.
- Each individual `.candidates[N]` entry: `is_dispatcher` `False`, `multi` `True`.

Also adds `is_dispatcher`/`multi`/`package` to the two `.can()` recognized-method lists in `methods_sub.rs` so `.can("is_dispatcher")` etc. report truthy, consistent with real Raku.

This is a scoped fix, not the full Sub-vs-Instance representation unification the linked ticket describes as still open (that remains deferred to the F1/F2 design, which needs its own broader raku-verification pass per `todo/deep/adr0019-f1-f2-introspection-canonical-source.md`).

## Test plan

- [x] New pin test `t/classhow-lookup-method-is-dispatcher-multi.t`, verified byte-for-byte identical TAP output against `raku` (11/11 both).
- [x] `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings` clean.
- [x] `make test`: Files=3147, Tests=29126, PASS.
- [x] `roast/S12-introspection/can.t`, `roast/S12-introspection/meta-class.t` unaffected (48/48 pass).
- [ ] CI (`make roast` full suite) — watching in background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)