### PR TITLE
fix: triage dist-test-suite-failures-batch round 2 (3 bugs fixed, 4 deep findings)

### DIFF
--- a/news/2026-08/bind-vardecl-leaks-into-nested-do-block-decl.md
+++ b/news/2026-08/bind-vardecl-leaks-into-nested-do-block-decl.md
@@ -1,0 +1,28 @@
+# A `:=` bind's compile-time flag no longer leaks into a nested declaration
+
+While root-causing `Crypt::RC4`'s test-suite failure (`todo/tickets/dist-test-suite-failures-batch.md`),
+found and fixed a general compiler bug: `my @x := do { ...; my uint8 @y =
+0..N; @y[$i] = v; @y };` — a `:=` bind whose RHS is a `do {}` block that
+itself declares and mutates a typed native array — died with "Cannot modify
+an immutable Range", even though the identical code with plain `=` (or at
+top level with no bind at all) worked correctly.
+
+Root cause: the compiler's `bind_vardecl` field is a one-shot flag, set on
+`self` right before a `:=` bind target's own store is compiled, meant to be
+consumed by that declaration's `SetLocalDecl`. But it was set *before* the
+RHS expression was compiled, and nothing cleared it while that RHS
+compilation recursed — so a `my`-declared variable found anywhere inside
+the RHS (here, `@y` inside the `do {}` block) wrongly inherited the outer
+bind's context too, skipping the Range-to-array materialization a typed
+native array declaration needs.
+
+Fixed by snapshotting `bind_vardecl` immediately on entering
+`Stmt::VarDecl`'s compilation and clearing the field before any RHS
+compilation happens, threading the snapshot through the handful of sites
+that previously read the (now correctly scoped) field directly. Pinned by
+`t/bind-do-block-nested-vardecl-leak.t`.
+
+A related but architecturally distinct issue — the same *runtime* flag
+family (`self.bind_context` et al.) leaking across a live *function call*
+boundary rather than a same-compile-unit nested block — remains open; see
+`todo/deep/mark-context-flags-leak-across-live-call-boundary.md`.

--- a/news/2026-08/blob-coercion-of-a-native-array.md
+++ b/news/2026-08/blob-coercion-of-a-native-array.md
@@ -1,0 +1,23 @@
+# `Blob() :$key!`-style coercion of an Array now works
+
+Triaging `Crypt::RC4`'s test suite (a row in
+`todo/tickets/dist-test-suite-failures-batch.md`) found that a `Blob()`
+coercion parameter given an `Array` argument (`submethod TWEAK(Blob()
+:$key!)` called with `my uint8 @passphrase = ...`) died with "Impossible
+coercion from 'Array' into 'Blob': no acceptable coercion method found" —
+even though calling `Blob.new(@array)` directly works fine.
+
+The coercion fallback in `try_coerce_value_with_method`
+(`src/runtime/types/coercion.rs`) only tries a target type's
+`.new(positional)` constructor when the target is a *user*-registered class
+(present in `registry().classes`). `Blob`/`Buf` (and their typed variants
+like `blob8`, `Buf[uint8]`) are native types built by a dedicated
+`build_native_buf_value` helper with no `registry().classes` entry, so the
+fallback never reached them, regardless of the target actually being
+constructible from a positional list. Fixed generally: when the coercion
+target is `is_native_buf_constructible`, build it via the same native buf
+constructor the explicit `.new()` path already uses.
+
+This was one of two independent bugs blocking `Crypt::RC4`'s suite; see
+`todo/deep/mark-context-flags-leak-across-live-call-boundary.md` for the
+remaining one.

--- a/news/2026-08/nil-does-not-smartmatch-uint.md
+++ b/news/2026-08/nil-does-not-smartmatch-uint.md
@@ -1,0 +1,20 @@
+# `Nil` no longer smart-matches `UInt`
+
+`Mathematica::Serializer::Encoder`'s own test suite (a triaged row in
+`todo/tickets/dist-test-suite-failures-batch.md`) had one near-miss: its
+`given $obj { ... when UInt {...}; when $_.isa(Any) { self.Nil-to-WL() } }`
+dispatch serialized a `Nil` pair value as an empty string instead of
+`NULL`, because `Nil ~~ UInt` returned `True` in mutsu (raku: `False`), so
+the `when UInt` branch matched instead of falling through to the `Any`
+branch that produces `NULL`.
+
+Root cause: `type_matching.rs`'s `UInt` constraint branch had a stray
+`ValueView::Nil => true` arm, added in #851 to let `$u = Nil` reset a
+`UInt`-typed variable to its default. That specific case is already handled
+generically, *before* `type_matches_value` is ever called for it — the
+`TypeCheck` opcode skips the whole check with a `!value.is_nil()` guard
+(`vm_misc_typecheck.rs`) — so the arm was dead weight for its original
+purpose and only surfaced as this `~~`/`given`-`when` regression. Removed;
+`roast/S32-num/int.t` (#851's original motivating test) still passes
+165/165. Pinned by `t/nil-uint-smartmatch.t`.
+`Mathematica::Serializer::Encoder`'s suite now passes 3/3, matching raku.

--- a/news/2026-08/nqp-native-num-arithmetic-ops.md
+++ b/news/2026-08/nqp-native-num-arithmetic-ops.md
@@ -1,0 +1,15 @@
+# `nqp::add_n`/`sub_n`/`mul_n`/`div_n`/`neg_n`/`abs_n` were missing
+
+Triaging the dist-test-suite-failures batch's un-triaged `Random::Choice`
+row (`todo/tickets/dist-test-suite-failures-batch.md`) turned up a gap in
+the `nqp::` op table: native `num` (floating point) arithmetic ops were
+entirely unimplemented, even though the native `int` family (`add_i`,
+`sub_i`, `mul_i`, ...) and the native `num` *comparisons* (`iseq_n`,
+`islt_n`, ...) already existed in `src/runtime/nqp_ops.rs`.
+
+`Random::Choice`'s alias-method sampler is written directly against these
+ops (`nqp::mul_n(nqp::div_n(Num($x), $total), $!n)`), so it died with
+"Unsupported nqp:: op: nqp::div_n" before running a single test. Added the
+missing six ops generally, matching the existing `_i` pattern. Pinned by
+`t/nqp-native-num-arith.t`. `Random::Choice`'s own test suite now passes
+6/6, matching raku.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1083,6 +1083,18 @@ impl Compiler {
                 custom_traits,
                 where_constraint,
             } => {
+                // Snapshot-and-clear `bind_vardecl` immediately: it is a
+                // one-shot signal meant for THIS declaration's own store
+                // (set by an enclosing `SyntheticBlock`/inline-block for a
+                // `:=` bind). Left set on `self` while the RHS below is
+                // compiled, it would leak into any nested `my`-declared
+                // variable inside that RHS (e.g. `@state` in `my @x := do {
+                // my uint8 @state = 0..255; ...; @state }`), wrongly giving
+                // that unrelated declaration bind-context treatment and
+                // skipping the array-from-Range materialization it needs
+                // ("Cannot modify an immutable Range").
+                let bind_vardecl = self.bind_vardecl;
+                self.bind_vardecl = false;
                 // `my &infix:<+> = ...` installs a user operator just like a
                 // `sub infix:<+>` does — disable constant folding (ADR-0006 §2.1).
                 self.note_operator_decl(name);
@@ -1247,7 +1259,7 @@ impl Compiler {
                 let is_plain_my = !*is_state
                     && !*is_our
                     && !is_constant_decl
-                    && !self.bind_vardecl
+                    && !bind_vardecl
                     && where_constraint.is_none();
                 if is_plain_my {
                     let has_init = custom_traits.iter().any(|(n, _)| n == "__has_initializer");
@@ -1339,14 +1351,14 @@ impl Compiler {
                 // Used by the `our` global store to skip the readonly check (the
                 // var was marked readonly purely as a bind signal).
                 let is_bound_container_vardecl =
-                    self.bind_vardecl && (name.starts_with('@') || name.starts_with('%'));
+                    bind_vardecl && (name.starts_with('@') || name.starts_with('%'));
                 // A scalar `:=` bind (`my $x := EXPR`). Captured before the RHS
                 // branches consume `bind_vardecl`; recorded on the CompiledCode so
                 // `compute_free_vars` can vouch for it despite it reaching a call as
                 // an argument (an immutable binding never goes stale). Both the
                 // MarkBind form (`my $x := $y`, sets `bind_vardecl`) and the inline
                 // `__scalar_bind` trait form (`my $x := my $y`) count.
-                let is_scalar_colon_bind = (self.bind_vardecl || scalar_bind_decont)
+                let is_scalar_colon_bind = (bind_vardecl || scalar_bind_decont)
                     && !name.starts_with('@')
                     && !name.starts_with('%')
                     && !name.starts_with('&');
@@ -1366,7 +1378,7 @@ impl Compiler {
                     let qualified = self.qualify_variable_name(name);
                     let idx = self.code.add_constant(Value::str(qualified));
                     self.code.emit(OpCode::GetOurVar(idx));
-                } else if self.bind_vardecl
+                } else if bind_vardecl
                     && (!name.starts_with('@') && !name.starts_with('%')
                         || Self::is_simple_var_expr(expr)
                         // `my @slice := @array[1,2]` (an `@`-sigil bind to an
@@ -1383,7 +1395,6 @@ impl Compiler {
                     // `:=` binding for VarDecl: use compile_call_arg so WrapVarRef
                     // is emitted and the VM can set up aliases.  For @/% targets,
                     // only emit WrapVarRef when the RHS is a simple variable.
-                    self.bind_vardecl = false;
                     self.scalar_bind_autovivify = true;
                     self.bind_terminal = true;
                     self.bind_target_direct = true;
@@ -1568,7 +1579,7 @@ impl Compiler {
                         && !shadows_outer_constant
                         && !is_constant
                         && !is_scalar_colon_bind
-                        && !self.bind_vardecl
+                        && !bind_vardecl
                         && type_constraint.is_none()
                         && !name.starts_with('@')
                         && !name.starts_with('%')
@@ -1598,9 +1609,8 @@ impl Compiler {
                         if *is_our && !is_constant {
                             self.code.emit(OpCode::Dup);
                         }
-                        if self.bind_vardecl && (name.starts_with('@') || name.starts_with('%')) {
+                        if bind_vardecl && (name.starts_with('@') || name.starts_with('%')) {
                             self.code.emit(OpCode::MarkBindContext);
-                            self.bind_vardecl = false;
                         }
                         // Mark constant context so SetLocal uses List coercion for @ and
                         // skips Hash coercion for %, matching Raku's constant semantics.

--- a/src/runtime/nqp_ops.rs
+++ b/src/runtime/nqp_ops.rs
@@ -134,6 +134,14 @@ impl Interpreter {
             "isge_i" => Ok(bool_int(iarg(args, 0) >= iarg(args, 1))),
             "not_i" => Ok(bool_int(iarg(args, 0) == 0)),
 
+            // -- native num arithmetic --
+            "add_n" => Ok(Value::num(narg(args, 0) + narg(args, 1))),
+            "sub_n" => Ok(Value::num(narg(args, 0) - narg(args, 1))),
+            "mul_n" => Ok(Value::num(narg(args, 0) * narg(args, 1))),
+            "div_n" => Ok(Value::num(narg(args, 0) / narg(args, 1))),
+            "neg_n" => Ok(Value::num(-narg(args, 0))),
+            "abs_n" => Ok(Value::num(narg(args, 0).abs())),
+
             // -- native num comparisons --
             "iseq_n" => Ok(bool_int(narg(args, 0) == narg(args, 1))),
             "isne_n" => Ok(bool_int(narg(args, 0) != narg(args, 1))),

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -245,6 +245,20 @@ impl Interpreter {
             }
             return Err(coerce_impossible_error(target, &value));
         }
+        // Buf/Blob (and their typed variants) are native types with no
+        // registry::classes entry, so the user-class `new` fallback below
+        // never reaches them. `Blob() :$key!`-style coercion of a list of
+        // integers (e.g. Crypt::RC4's `submethod TWEAK(Blob() :$key!)`)
+        // needs the same construction `.new(@list)` already uses.
+        if Self::is_native_buf_constructible(base_target) {
+            let coerced = Self::build_native_buf_value(
+                Symbol::intern(base_target),
+                std::slice::from_ref(&value),
+            );
+            if self.type_matches_value(base_target, &coerced) {
+                return Ok(coerced);
+            }
+        }
         if self.registry().classes.contains_key(base_target) {
             // Wrap Pair values in a Scalar container so they are passed as
             // positional arguments to COERCE/new rather than being flattened

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -484,7 +484,6 @@ impl Interpreter {
             return match value.view() {
                 ValueView::Int(i) => i >= 0,
                 ValueView::BigInt(n) => n.sign() != num_bigint::Sign::Minus,
-                ValueView::Nil => true,
                 ValueView::Package(name) => {
                     let name = name.resolve();
                     name == "UInt" || name == "Int"

--- a/t/bind-do-block-nested-vardecl-leak.t
+++ b/t/bind-do-block-nested-vardecl-leak.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+# `my @x := do { ...; @y }` compiled a stray `MarkBindContext` in front of a
+# NESTED `my`-declared variable's own store (e.g. `@y` above), not just the
+# outer `@x`'s. The compiler's one-shot `bind_vardecl` flag, set for `@x`'s
+# store before its RHS (the do-block) was compiled, stayed set on `self`
+# throughout that recursive RHS compilation and leaked into any `my @z = ...`
+# found inside — skipping the normal Range-to-array materialization a typed
+# native array needs. Blocked Random::Choice's/Crypt::RC4's dist test suites
+# (`my uint8 @state = 0..255; @state[$x] = ...;` inside a helper sub/block
+# whose result is bound to a class attribute).
+
+plan 2;
+
+my @result := do {
+    my uint8 @state = 0..5;
+    @state[2] = 99;
+    @state;
+};
+is @result.join(','), '0,1,99,3,4,5', 'nested typed-array decl inside a := bound do-block materializes and mutates correctly';
+
+my uint8 @plain = 0..5;
+@plain[2] = 99;
+is @plain.join(','), '0,1,99,3,4,5', 'plain (non-bind) typed-array-from-Range declaration still works';

--- a/t/nil-uint-smartmatch.t
+++ b/t/nil-uint-smartmatch.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+# `Nil` must never smart-match `UInt`: `type_matches_value`'s UInt branch had
+# a stray `Nil => true` arm (added for a since-superseded TypeCheck path —
+# assignment of Nil to a typed variable is already handled generically by a
+# `!value.is_nil()` guard before `type_matches_value` is even called), which
+# made `given $obj { when UInt { ... } }` wrongly classify a Nil value as
+# UInt. Blocked Mathematica::Serializer::Encoder's `Nil`-to-`NULL` dispatch.
+
+plan 3;
+
+nok Nil ~~ UInt, 'Nil does not smart-match UInt';
+
+my $classified = do given Nil {
+    when UInt { 'UInt' }
+    when Any  { 'Any' }
+    default   { 'other' }
+};
+is $classified, 'Any', 'given/when does not misclassify Nil as UInt';
+
+my UInt $u;
+$u = Nil;
+is-deeply $u, UInt, 'assigning Nil to a UInt-typed variable still resets to the type object';

--- a/t/nqp-native-num-arith.t
+++ b/t/nqp-native-num-arith.t
@@ -1,0 +1,16 @@
+use v6;
+use Test;
+use nqp;
+
+# nqp::add_n/sub_n/mul_n/div_n/neg_n/abs_n were unimplemented ("Unsupported
+# nqp:: op"), blocking Random::Choice (`my num @np = @p.map(-> $x {
+# nqp::mul_n(nqp::div_n(Num($x),$total), $!n) });`).
+
+plan 6;
+
+is nqp::add_n(1.5e0, 2.25e0), 3.75e0, 'nqp::add_n';
+is nqp::sub_n(5e0, 1.5e0), 3.5e0, 'nqp::sub_n';
+is nqp::mul_n(2.5e0, 4e0), 10e0, 'nqp::mul_n';
+is nqp::div_n(9e0, 4e0), 2.25e0, 'nqp::div_n';
+is nqp::neg_n(3.5e0), -3.5e0, 'nqp::neg_n';
+is nqp::abs_n(-3.5e0), 3.5e0, 'nqp::abs_n';

--- a/todo/deep/mark-context-flags-leak-across-live-call-boundary.md
+++ b/todo/deep/mark-context-flags-leak-across-live-call-boundary.md
@@ -1,0 +1,139 @@
+# VM "mark context" flags (`bind_context` et al.) leak across a live function-call boundary
+
+## Symptom
+
+`Crypt::RC4`'s own test suite (`t/00basic.t`, one of the un-triaged `test_die`
+rows in [todo/tickets/dist-test-suite-failures-batch.md](../tickets/dist-test-suite-failures-batch.md))
+dies with `Cannot modify an immutable Range` while running code that looks
+completely unrelated to the actual bind expression:
+
+```raku
+class Crypt::RC4 {
+    has uint8 @!state;
+    submethod TWEAK(Blob() :$key!) {
+        @!state := setup( $key );   # <-- the bind
+    }
+}
+sub setup( $key --> array[uint8] ) {
+    my uint8 @state = 0..255;       # <-- fails HERE: @state stays a Range
+    ...
+    @state[$x] = ...;               # "Cannot modify an immutable Range"
+    @state;
+}
+```
+
+Minimal repro (no module, no Blob coercion, no RC4 specifics):
+
+```raku
+class Foo {
+    has uint8 @!other;
+    method go() {
+        @!other := make();   # a normal function CALL, not an inline do-block
+    }
+}
+sub make() {
+    my uint8 @state = 0..5;
+    @state[2] = 99;   # dies: Cannot modify an immutable Range (0 1 2 3 4 5)
+    @state;
+}
+Foo.new.go;
+```
+
+Raku: no error, `$obj.other` is `[0 1 99 3 4 5]`.
+
+## Root cause
+
+`MarkBindContext` is a VM opcode that sets `self.bind_context = true`
+(`vm_exec_dispatch.rs` `OpCode::MarkBindContext` arm). It is emitted by the
+compiler right before a `:=` bind target's own store op, meant to be consumed
+by the very next `SetLocal`/`SetGlobal`-family opcode
+(`vm_var_assign_set_local.rs:256,352`) so that op knows to preserve the RHS
+container instead of copying it.
+
+`self.bind_context` is a single `Interpreter`-wide field, not scoped to a
+call frame. `Foo::go`'s compiled body is:
+
+```
+0: MarkBindContext
+1: MarkRebindContext
+2: LoadConst(1)
+3: CallFuncNamed { name_idx: "make", arity: 1, ... }
+4: ContainerizePair
+5: SetGlobal(0)          # @!other's real store — the intended consumer
+6: GetGlobal(0)
+```
+
+Between `MarkBindContext` (instr 0) and its intended consumer `SetGlobal`
+(instr 5) sits a full function CALL (instr 3). `make()`'s own body executes
+with `self.bind_context` still `true` (nothing clears it for a normal call),
+so `make`'s own `my uint8 @state = 0..255;` declaration is wrongly compiled^Wexecuted
+as if IT were a bind target too, skipping the Range-to-array materialization
+a typed native array needs — hence the later index assignment finds a bare
+Range in the slot.
+
+This is a **runtime** analog of a **compile-time** bug fixed alongside this
+finding in `src/compiler/stmt.rs` (the `bind_vardecl` flag leaking into a
+nested `my`-declared variable inside a `do {}` block bound via `:=` — see
+`t/bind-do-block-nested-vardecl-leak.t`). That fix only covers same-compile-unit
+inlining (`do {}` blocks, `compile_block_inline`); it cannot help here because
+`make()` is a genuinely separate compiled function invoked through a real
+`CallFuncNamed` — there is no static/AST-level relationship for the compiler
+to see, and the leak happens at VM runtime instead.
+
+## Why this needs a design pass, not a quick patch
+
+`self.bind_context` is one of a *family* of similar one-shot VM context flags
+that share the exact same shape (set before a Set-op, meant to be consumed
+immediately after): `scalar_bind_context`, `rebind_context`,
+`constant_context`, `array_share_context`, `vardecl_context`,
+`explicit_initializer_context`, `param_raw_bind_context`. Any of them could in
+principle leak the same way across a call.
+
+There is already a **precedent fix** for exactly this class of bug:
+`vm_run_loop.rs`'s "nested run" boundary (used for `EVAL`, `dies-ok`/`lives-ok`
+blocks, etc.) explicitly saves, clears, and restores this entire flag family
+around `f(self)` (lines ~324-410). That mechanism does NOT run for an ordinary
+compiled function/method call — those go through a flat bytecode dispatch
+loop with call frames pushed in-place, not a nested Rust-level `run()`
+invocation, so there is no single boundary to hook.
+
+A correct general fix needs to:
+
+1. Identify **every** call-boundary function that dispatches into a callee's
+   compiled body without going through `vm_run_loop.rs`'s nested-run save/
+   restore — at least `call_compiled_function_light_spec`
+   (`vm_call_light_typed.rs`), `vm_call_light.rs`, `vm_call_fast.rs`'s
+   positional-light path, `call_compiled_function_named`, and
+   `call_compiled_closure` (`vm_closure_dispatch.rs`) for method calls. These
+   already save/restore an ad-hoc set of caller-local state (see
+   `call_compiled_function_light_spec`'s `saved_loop_local_vars` /
+   `saved_block_declared_vars` / `saved_active_loop_param_names` pattern) —
+   the "mark context" flag family should join that existing isolation
+   pattern, not invent a new mechanism.
+2. Decide whether to isolate the whole flag family (matching
+   `vm_run_loop.rs`'s existing precedent) or just `bind_context` (the one
+   flag proven to leak so far) — the former is safer against the next
+   instance of this bug class but touches every call boundary; audit for
+   perf impact on the hot light-call path (this is exactly the path recent
+   sessions have been tuning — see `docs/adr/0001-gc-strategy-and-phasing.md`
+   §7 JIT/light-call work).
+3. Verify no call boundary *relies* on the current leaky behavior (e.g. a
+   tail call intentionally propagating one of these flags) before clearing
+   unconditionally — grep each flag's write sites first.
+
+## Affected / blocked
+
+- `Crypt::RC4`'s own test suite (`t/00basic.t` in
+  [todo/tickets/dist-test-suite-failures-batch.md](../tickets/dist-test-suite-failures-batch.md)'s
+  un-triaged list) — blocked on this.
+- Any other dist/user code with the shape `@!attr := some_sub_call()` where
+  `some_sub_call` internally declares and mutates a typed native array (or
+  any other construct whose materialization depends on one of these
+  bind-family flags being unset).
+
+## Repro files
+
+Kept as throwaway scratch, not committed:
+`tmp/t10.raku` (minimal, no dist), `tmp/rc4-inline.raku` (full Crypt::RC4
+flow inlined, no module boundary) — regenerate from the "Minimal repro" block
+above if needed; `tmp/` is gitignored so nothing to clean up.

--- a/todo/deep/p5tie-container-protocol-and-array-parse-bug.md
+++ b/todo/deep/p5tie-container-protocol-and-array-parse-bug.md
@@ -1,0 +1,70 @@
+# P5tie needs a real container-tie protocol; `array.rakutest` also hits a parse bug
+
+## Symptom
+
+`P5tie`'s test suite (un-triaged `test_die` row in
+[todo/tickets/dist-test-suite-failures-batch.md](../tickets/dist-test-suite-failures-batch.md))
+splits into two independent problems, both confirmed against a clean raku
+baseline (`raku -I lib t/<file>` passes all subtests for all three files):
+
+### 1. `scalar.rakutest` / `hash.rakutest`: `Stash` has no `BIND-KEY`
+
+```
+No such method 'BIND-KEY' for invocant of type 'Stash'
+  in sub tie at lib/P5tie.rakumod line 38   # scalar.rakutest
+  in sub tie at lib/P5tie.rakumod line 311  # hash.rakutest
+```
+
+`P5tie` implements Perl 5's `tie()` by binding a variable's storage to a
+user-supplied class instance (`TIESCALAR`/`TIEARRAY`/`TIEHASH` + `FETCH`/
+`STORE`/... trap methods) via Raku's low-level container-binding protocol —
+`BIND-KEY` on a `Stash` (a package/lexical-pad reflection object) is part of
+that machinery in real Raku's CORE.setting. mutsu's `Stash`-equivalent value
+does not implement `BIND-KEY` at all.
+
+### 2. `array.rakutest`: parse-time failure before any test runs
+
+```
+Runtime error: X::Syntax::NoSelf
+```
+
+This is a **separate, unrelated** bug — a parse/compile-time error, not a
+missing method. Needs its own minimal repro/bisection (not done yet); do not
+assume it shares a root cause with the `BIND-KEY` gap above.
+
+## Why this needs a design pass
+
+Implementing `tie()` properly means implementing enough of the real
+container-binding protocol (`BIND-KEY`/`BIND-POS` or whatever the actual
+underlying primitive is on a `Scalar`/`Array`/`Hash` container, dispatching
+through to a user-supplied proxy object's FETCH/STORE) generally — not just
+enough to make this one dist's trap methods fire. This is genuine MOP/
+container-model work, not a quick patch. Per `CLAUDE.md`'s BATTERIES.md
+rung-3 ban, `tie` semantics should be real interpreter machinery (rung 2),
+not a native P5tie-specific stopgap.
+
+## Next steps (not started)
+
+1. Bisect `array.rakutest`'s `X::Syntax::NoSelf` down to a minimal repro
+   independent of `tie` — it fails before any `tie` call, so it is likely a
+   plain parser bug in whatever array.rakutest's early lines do differently
+   from scalar.rakutest/hash.rakutest (diff the two files' preambles).
+2. For the `BIND-KEY` gap: find/design whatever the real container-binding
+   primitive should be (a `ContainerRef`-level operation, given mutsu already
+   has a `ContainerRef` cell abstraction for aliasing — see ADR-0013 §7) and
+   implement `Stash.BIND-KEY` (and any sibling ops P5tie's `tie`/`untie`/
+   `tied` need) in terms of it.
+
+## Repro
+
+```
+cd <extracted P5tie dist>
+raku -I lib t/scalar.rakutest   # passes, 21 subtests via TAP
+target/debug/mutsu -I lib t/scalar.rakutest   # dies: No such method 'BIND-KEY'
+target/debug/mutsu -I lib t/array.rakutest    # dies at parse time: X::Syntax::NoSelf
+```
+
+Dist tarball cached at
+`~/.cache/mutsu-dist-sweep/P_5T_P5TIE_*.tar.gz` (from
+`scripts/dist-compat-sweep.py`'s cache; re-run the sweep or extract that
+tarball to reproduce — not vendored into this repo).

--- a/todo/deep/sigilless-alias-assignment-skips-type-constraint.md
+++ b/todo/deep/sigilless-alias-assignment-skips-type-constraint.md
@@ -1,0 +1,93 @@
+# Assigning through a sigilless `\x := $var` alias skips the target's type constraint
+
+## Symptom
+
+`Native::Overflow`'s test suite (`t/01-basic.rakutest`, un-triaged `test_die`
+row in
+[todo/tickets/dist-test-suite-failures-batch.md](../tickets/dist-test-suite-failures-batch.md))
+plans 30 tests but runs 0 — every assertion lives inside a `CATCH` block that
+never fires, because the type-check exception it expects never gets thrown.
+
+Minimal repro, independent of the dist:
+
+```raku
+subset SmallInt of Int where -128 <= $_ <= 127;
+my SmallInt $a = 5;
+my \x := $a;
+x = 1000;
+say $a;
+```
+
+Raku: `Type check failed in assignment to $a; expected SmallInt but got Int
+(1000)`.
+
+mutsu: prints `1000` — the assignment silently succeeds, the subset's `where`
+constraint is never checked.
+
+A **direct** assignment to the same variable (`$a = 1000;`, no alias) IS
+correctly type-checked in mutsu — confirmed working via
+`t/nil-uint-smartmatch.t`-adjacent testing this session and
+`roast/S32-num/int.t` (165/165 passing). The gap is specific to writing
+**through a sigilless bind alias**.
+
+## Root cause (partial — compile-time half confirmed, runtime half not investigated)
+
+The compiler emits an `OpCode::TypeCheck` before a variable's store based on
+`self.local_types: HashMap<String, String>`, populated at each `my TYPE
+$var` declaration site (`src/compiler/stmt.rs:1316`,
+`src/compiler/helpers_block_inline.rs:284`) — keyed by the **declared
+variable's own name**.
+
+`my \x := $a;` declares a NEW sigilless name `x` with no type annotation of
+its own (the AST's `type_constraint` field is `None` for this decl) — so
+`local_types` never gets an entry for `"x"`, even though `$a` (the bind
+target) has one (`"a" -> "SmallInt"`). When `x = 1000;` is later compiled,
+there is no `local_types["x"]` to consult, so no `TypeCheck` opcode is
+emitted at all for this store.
+
+## Why this needs a design pass, not a quick patch
+
+A **narrow** fix — when compiling a sigilless `:=` bind whose RHS is a
+simple `Expr::Var(name)`, copy `local_types.get(name)` into
+`local_types[alias]` too — would only cover the same-compile-unit, statically
+resolvable case (exactly this repro, and the dist's `for LIST -> \x, $value
+{ }` shape, since `x` binds to `$a`/`$b`, both plain locals with a static
+constraint). It would NOT cover:
+
+- Binding across a function boundary (`sub f(\x) { x = 1000 }; f($a);` — `x`
+  is a parameter alias, `$a`'s type is not visible at `f`'s compile time at
+  all).
+- Binding to a computed/indexed target (`\x := @arr[$i]`) where the element's
+  type constraint (for a typed array) is dynamic.
+- Any case where the alias crosses an `EVAL`/closure boundary.
+
+The architecturally correct fix is for the **container itself** to carry its
+type constraint at runtime (so any alias reaching the same container is
+checked, regardless of what name compiled it), not a compile-time
+name-keyed map. This is the same shape of gap the `ContainerRef`/interior-
+mutability work already targets (see ADR-0013 §7, "GcBox/UnsafeCell interior
+mutability refinement") — worth checking whether that machinery already
+carries (or could easily carry) a type-constraint field before implementing
+a separate mechanism.
+
+## Repro
+
+```raku
+subset SmallInt of Int where -128 <= $_ <= 127;
+my SmallInt $a = 5;
+my \x := $a;
+x = 1000;
+say $a;   # raku: dies at the assignment; mutsu: prints 1000
+```
+
+The dist's own shape (also confirmed failing, same root cause):
+
+```raku
+use Native::Overflow;   # lexically shadows int8/int16/... with `subset ... where ...`
+my int8 $a;
+my int16 $b;
+for $a, 1_000, $b, 1_000_000 -> \x, $value {
+    CATCH { say "caught: {.^name}"; next }
+    x = $value;   # should throw X::TypeCheck::Assignment; silently succeeds in mutsu
+}
+```

--- a/todo/deep/trait-mod-does-not-callable-and-no-variable-mop.md
+++ b/todo/deep/trait-mod-does-not-callable-and-no-variable-mop.md
@@ -1,0 +1,73 @@
+# `trait_mod:<does>` is not a callable sub; no `Variable` MOP object to apply it to
+
+## Symptom
+
+`Hash::Restricted`'s test suite (`roast/`-style dist sweep, un-triaged
+`test_die` row in
+[todo/tickets/dist-test-suite-failures-batch.md](../tickets/dist-test-suite-failures-batch.md))
+dies immediately on `use Hash::Restricted;`:
+
+```
+Unknown function: trait_mod:<does>
+  in sub trait_mod:<is> at lib/Hash/Restricted.rakumod line 75
+```
+
+Raku: loads and all 32 subtests pass.
+
+## What the dist needs
+
+`lib/Hash/Restricted.rakumod` defines a custom `is restricted` trait that
+dynamically mixes a role into the DECLARED VARIABLE's type (not an instance)
+at `my %h is restricted = ...` declaration time:
+
+```raku
+multi sub trait_mod:<is>(Variable:D \v, Bool:D :$restricted!) is export {
+    die "..." unless v.var.WHAT ~~ Map;
+    my $name = v.var.^name;
+    if $restricted {
+        trait_mod:<does>(v, restrict-current);   # <-- calls trait_mod:<does> as a plain sub
+        v.var.WHAT.^set_name("$name\(restricted)");
+    }
+}
+```
+
+This requires, as CORE-provided (not this dist's own) machinery:
+
+1. A real `Variable` MOP object type, produced when a `\v` capture parameter
+   is typed `Variable:D` in a `trait_mod:<is>` candidate — mutsu already has
+   a partial notion of this (`type_matches_value`/`type_matching_static.rs`
+   match `Variable` as a type CONSTRAINT against `varref_from_value`), but
+   there is no actual `Variable` instance with a `.var` accessor exposing the
+   underlying container.
+2. `trait_mod:<does>` as a genuinely **callable multi sub** (not just special
+   parser/compiler handling for the `does` trait keyword) that mixes a role
+   into a `Variable`'s declared type at runtime.
+3. `.WHAT.^set_name(...)` on the resulting (possibly type-object) value,
+   renaming the class for introspection (`.^name` becomes `"Hash(restricted)"`).
+
+## Why this needs a design pass
+
+This is dynamic-MOP territory of a similar shape to the retired native
+`monitor` declarator stopgap (see `news/2026-08/exporthow-declare-mop.md`) —
+it needs real `Variable` reflection plus a working `does`-as-a-sub entry
+point, not a hardcoded trait handler. Per `CLAUDE.md`'s BATTERIES.md rung-3
+ban, this should grow the interpreter's MOP rather than be special-cased for
+this one dist. Before starting: check whether any OTHER un-triaged/triaged
+dist in the batch sweep needs `Variable:D \v` + `trait_mod:<does>` (grep the
+fez sample corpus) to judge whether it is worth the investment now or should
+wait for a broader MOP campaign.
+
+## Repro
+
+```raku
+class Foo { }
+multi sub trait_mod:<does>(Mu \v, Mu \r) is export {
+    say "would mix {r.^name} into {v.VAR.name}";
+}
+my $x;
+trait_mod:<does>($x, Foo);
+```
+
+mutsu: `Unknown function: trait_mod:<does>`. Not yet verified against raku
+(this synthetic repro is illustrative of the missing-callable-sub gap only;
+the real dist's `Variable:D \v` signature is the actual blocker — see above).

--- a/todo/tickets/dist-test-suite-failures-batch.md
+++ b/todo/tickets/dist-test-suite-failures-batch.md
@@ -148,11 +148,107 @@ the same class of gap as
 [todo/deep/element-itemization-lost-in-scalar-binding.md](../deep/element-itemization-lost-in-scalar-binding.md),
 tracked there.
 
-## Un-triaged `test_die` / `test_fail`
+## Triaged (round 2, 2026-08-14)
 
-`Native::Overflow`, `App::SudokuHelper`, `P5tie`,
-`Mathematica::Serializer::Encoder`, `Hash::Restricted`, `Crypt::RC4`,
-`Random::Choice` (die).
+### ~~`Random::Choice`~~ — FIXED
+
+`nqp::add_n`/`sub_n`/`mul_n`/`div_n`/`neg_n`/`abs_n` (native `num` arithmetic)
+were entirely unimplemented ("Unsupported nqp:: op") — only the `_i` (native
+int) family and `_n` comparisons existed in `src/runtime/nqp_ops.rs`. Added
+generally; pinned by `t/nqp-native-num-arith.t`. Full suite now 6/6.
+
+### ~~`App::SudokuHelper`~~ — not reproducible on current main
+
+Both `t/basic.t` (9/9) and `t/combo-multi.t` (3/3) pass cleanly already —
+fixed as a side effect of unrelated work between the original sweep and now.
+
+### ~~`Mathematica::Serializer::Encoder`~~ — FIXED
+
+`Nil ~~ UInt` wrongly returned `True` (`type_matching.rs`'s `UInt` branch had
+a stray `ValueView::Nil => true` arm), so `given $obj { when UInt {...} }`
+misclassified a `Nil` element and the encoder's `Pair["condo", Nil]` lost its
+`NULL` output. The arm was originally added to let `$u = Nil` reset a
+`UInt`-typed variable to its default (`d6fe2e3b7`, #851) — but that path is
+already handled generically by a `!value.is_nil()` guard *before*
+`type_matches_value` is even called (`vm_misc_typecheck.rs`), so the arm was
+dead for its original purpose and only caused this smart-match regression.
+Removed; `roast/S32-num/int.t` (its original motivating test, 165/165) still
+passes. Pinned by `t/nil-uint-smartmatch.t`. Full suite now 3/3.
+
+### `Crypt::RC4` — two bugs, one fixed, one deep
+
+1. **FIXED**: `Blob() :$key!`-style coercion of an Array (`submethod
+   TWEAK(Blob() :$key!)` called with a `uint8` array argument) raised
+   "Impossible coercion from 'Array' into 'Blob'" — the coercion fallback in
+   `try_coerce_value_with_method` only tries a target's `.new(positional)`
+   when the target is a *user*-registered class (`registry().classes`);
+   `Blob`/`Buf` are native types with no such registry entry, so the fallback
+   never reached them even though `Blob.new(@array)` works fine when called
+   directly. Fixed generally by also trying the native buf constructor for
+   any `is_native_buf_constructible` target.
+2. **Deep, not fixed**: after the coercion fix, the suite still dies with
+   "Cannot modify an immutable Range" inside `setup()`, called from `TWEAK`
+   via `@!state := setup($key)`. Root-caused to a VM-level "mark context"
+   flag (`self.bind_context`, set by `MarkBindContext`) leaking across a
+   *live function call* boundary — `setup()`'s own `my uint8 @state =
+   0..255;` wrongly inherits the caller's pending bind-context and skips
+   Range-to-array materialization. Full analysis, minimal repro, and why it
+   needs auditing every compiled-function call boundary (not a local patch):
+   [todo/deep/mark-context-flags-leak-across-live-call-boundary.md](../deep/mark-context-flags-leak-across-live-call-boundary.md).
+
+   A **related but distinct** compile-time version of the same flag-leak
+   class (the compiler's `bind_vardecl`, not the VM's `bind_context`) was
+   found and fixed in the same investigation: `my @x := do { ...; my
+   uint8 @y = 0..N; ...; @y }` leaked bind-context into the *nested* `@y`
+   declaration. Fixed in `src/compiler/stmt.rs` (snapshot-and-clear
+   `bind_vardecl` on entry to `Stmt::VarDecl`); pinned by
+   `t/bind-do-block-nested-vardecl-leak.t`.
+
+### `Hash::Restricted` — deep, not fixed
+
+`trait_mod:<does>` is not a callable sub, and there is no real `Variable` MOP
+object with a `.var` accessor to apply it to — `lib/Hash/Restricted.rakumod`
+dynamically mixes a role into a *declared variable's* type at `my %h is
+restricted = ...` time via `trait_mod:<is>(Variable:D \v, ...) {
+trait_mod:<does>(v, SomeRole); v.var.WHAT.^set_name(...) }`. Genuine MOP work
+per BATTERIES.md rung-2 (not a native stopgap). Full analysis:
+[todo/deep/trait-mod-does-not-callable-and-no-variable-mop.md](../deep/trait-mod-does-not-callable-and-no-variable-mop.md).
+
+### `P5tie` — deep, not fixed; two independent bugs
+
+`scalar.rakutest`/`hash.rakutest` die with `No such method 'BIND-KEY' for
+invocant of type 'Stash'` — P5tie's Perl-5-`tie()` emulation needs a real
+container-binding protocol mutsu doesn't implement at all.
+`array.rakutest` fails separately, at *parse* time, with
+`X::Syntax::NoSelf` — not yet bisected, likely unrelated to the `tie`
+gap. Full analysis:
+[todo/deep/p5tie-container-protocol-and-array-parse-bug.md](../deep/p5tie-container-protocol-and-array-parse-bug.md).
+
+### `Native::Overflow` — deep, not fixed
+
+Plans 30 tests, runs 0: every assertion lives inside a `CATCH` that never
+fires because the expected exception never gets thrown. Root cause: the dist
+lexically shadows native type names (`int8`, `uint16`, ...) with `subset ...
+where <range>` via its `EXPORT` sub — a real Raku feature that works fine in
+mutsu for a **direct** assignment (`$a = 1000;` IS correctly type-checked).
+The dist's actual test writes through a **sigilless bind alias** instead
+(`my \x := $a; ...; x = $value;`, produced by a `for LIST -> \x, $value {
+}` loop over a flattened variable/value list) — and assigning through such
+an alias skips the target's type constraint entirely, general and
+reproducible with no native-type involvement at all
+(`my SmallInt $a = 5; my \x := $a; x = 1000;` — raku dies, mutsu silently
+succeeds). Root cause and why a full fix needs the type constraint to live on
+the container rather than a compile-time name-keyed map:
+[todo/deep/sigilless-alias-assignment-skips-type-constraint.md](../deep/sigilless-alias-assignment-skips-type-constraint.md).
+
+## Status
+
+All dists from the original sweep's `test_die` bucket are now triaged (see
+"Triaged" sections above): `Random::Choice` and `Mathematica::Serializer::Encoder`
+fully fixed; `App::SudokuHelper` not reproducible; `Crypt::RC4` partially
+fixed (one bug fixed, one filed as deep); `Hash::Restricted`, `P5tie`, and
+`Native::Overflow` each filed as deep findings needing a design pass. None
+remain un-triaged.
 
 ## How to work this list
 


### PR DESCRIPTION
## Summary

Continues working `todo/tickets/` oldest-first. Triaged all remaining
un-triaged dists in `todo/tickets/dist-test-suite-failures-batch.md`:

**Fixed (general, non-dist-specific bugs):**
- `Random::Choice`: missing `nqp::` native num arithmetic ops
  (`add_n`/`sub_n`/`mul_n`/`div_n`/`neg_n`/`abs_n`) — suite now 6/6.
- `Mathematica::Serializer::Encoder`: `Nil` wrongly smart-matched `UInt`
  (dead special-case left over from #851, since the actual use case it was
  added for is already handled elsewhere) — suite now 3/3.
- `Crypt::RC4`: `Blob() :$key!` coercion of a native `Array` argument, and a
  compiler `bind_vardecl` flag leaking into a nested typed-array declaration
  inside a `:=`-bound `do {}` block.
- `App::SudokuHelper`: confirmed not reproducible on current main.

**Filed as `todo/deep/` (need a design pass):**
- VM `bind_context`-family flags leaking across a *live function call*
  boundary — the remaining `Crypt::RC4` blocker (root-caused, not fixed).
- `Hash::Restricted`: needs a real `Variable` MOP object + callable
  `trait_mod:<does>`.
- `P5tie`: needs a real `tie()`/container-binding protocol, plus an
  unrelated parse bug in one test file.
- Assigning through a sigilless `\x := $var` alias skips the target's type
  constraint — blocks `Native::Overflow`.

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] New pinning tests: `t/nqp-native-num-arith.t`,
  `t/nil-uint-smartmatch.t`, `t/bind-do-block-nested-vardecl-leak.t`
- [x] `make test` — full suite green (3152 files, 29152 tests, 0 failures)
- [x] `roast/S32-num/int.t` (the original motivator for the removed `UInt`
  special case) still passes 165/165
- [x] Re-ran all fixed dists' own test suites against the fix
- [ ] CI (`make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)