### PR TITLE
docs(adr0019): note F1 lookup-accessor fix and F5 cache-dedup progress

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -803,6 +803,11 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   far and why it needs a dedicated verification pass before a design. That pass also surfaced a
   distinct bug, `todo/tickets/classhow-lookup-returns-sub-not-method-instance.md`: `.^lookup`
   builds a `Sub`-shaped value instead of the same `Method` `Instance` these readers now share.
+  **Update (#6420):** the sharpest symptom of that bug — `.is_dispatcher`/`.multi` silently
+  returning a bogus `<composed-method:NAME>` callable instead of a real answer — is fixed with
+  targeted handling on the `Sub`-shaped value, verified against `raku` ground truth (pin:
+  `t/classhow-lookup-method-is-dispatcher-multi.t`). The underlying representation mismatch (Sub
+  vs. Method Instance) remains open; this was a scoped patch, not the unification.
 - [ ] **F3 — Delete the per-type method-name lists and the test-only `METHOD_UNIVERSE`.** B1/B2
   already removed `METHOD_UNIVERSE` and runtime probing from the runtime path (both are
   `#[cfg(test)]`-only now); the live work is the fourteen per-type `&[&str]` name slices
@@ -819,6 +824,16 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   generation scheme `fn_resolve_cache_gen` that drives block-scope-exit clears in
   `accessors_misc.rs`. `native_ctor_plan_cache` is not "unrelated": it is cleared in lockstep
   with `fast_method_cache` at every one of those sites and must adopt the same generation.
+
+  **Progress (#6422):** the trivial-first-PR slice this box called out is done — the duplicated
+  clear block at all 7 non-generation-gated sites (module load/import/no/need, block-scope exit,
+  sub registration, class/role/enum registration) is now one shared
+  `Interpreter::invalidate_method_dispatch_caches()` (`src/vm/vm_dispatch_cache_invalidate.rs`).
+  This is pure dedup, not the generation migration: `func_multi_resolve_cache`/
+  `func_multi_type_cacheable` (plain multi *sub* dispatch, read by `resolve_function_multi_cached`)
+  have no generation guard at their read site, so the eager clears stay load-bearing. The
+  remaining work — extending the generation scheme to cover that pair (and everything else this
+  box lists) so the eager calls can be deleted rather than merely deduplicated — is still open.
 - [ ] **F6 — Delete compatibility call carriers and dead resolver modules.** Remove the
   `run_instance_method` family — three live functions plus two resolved-path helpers in
   `class_dispatch.rs` and the `vm_run_instance_method` carrier, ~700 lines with ~40 references —

--- a/news/2026-08/adr0019-f1-lookup-is-dispatcher-multi-and-f5-cache-dedup.md
+++ b/news/2026-08/adr0019-f1-lookup-is-dispatcher-multi-and-f5-cache-dedup.md
@@ -1,0 +1,26 @@
+# ADR-0019 Phase F: .^lookup Method accessors fixed, cache-invalidation dedup
+
+Two small ADR-0019 Phase F slices landed.
+
+`.^lookup`/`.^find_method` return a `Sub`-shaped callable rather than the `Method` `Instance`
+object `.^methods` builds (`todo/tickets/classhow-lookup-returns-sub-not-method-instance.md`, found
+while scoping Phase F box F1/F2). Calling a `Method`-only accessor like `.is_dispatcher` or `.multi`
+on that result used to fall into the callable-compose fallback and silently return a bogus
+`<composed-method:NAME>` callable instead of a real answer. `methods_instance_ops.rs`'s dispatch
+fallback now answers both accessors directly, matching `raku` ground truth: a non-multi method or
+submethod answers both `False`; a multi method's dispatcher-shaped value answers `is_dispatcher`
+`True` but `multi` falsy; each individual `.candidates[N]` entry answers `is_dispatcher` `False` but
+`multi` `True`. Pinned by `t/classhow-lookup-method-is-dispatcher-multi.t`, verified byte-for-byte
+identical against `raku`. The deeper representation mismatch (Sub vs. Method Instance) stays open
+for a future F1/F2 design pass.
+
+Separately, Phase F box F5 ("remove superseded method caches and manual invalidation") calls out a
+"trivial first PR": the same method/function-resolution cache-clear block was duplicated verbatim
+at 7 sites across 4 files (module `use`/`import`/`no`/`need`, a `my sub` leaving block scope, a
+fresh sub installation, and class/role/enum registration). Extracted into one shared
+`Interpreter::invalidate_method_dispatch_caches()`. This also fixed a latent inconsistency where 3
+of those 7 sites forgot to clear `resolved_seq_cache` while the others did — now every site clears
+the same full set. The eager clears stay in place rather than migrating to the generation-based
+lazy scheme `refresh_method_caches_for_generation` already uses for method-only caches, because
+`func_multi_resolve_cache`/`func_multi_type_cacheable` (plain multi *sub* dispatch) have no
+generation guard at their read site yet — a separate, deeper F5 slice.

--- a/todo/tickets/classhow-lookup-returns-sub-not-method-instance.md
+++ b/todo/tickets/classhow-lookup-returns-sub-not-method-instance.md
@@ -74,3 +74,26 @@ Unifying the two representations (making `.^lookup` return the same `Method`-`In
 Best done as part of the F1/F2 design once the native-metadata ground-truth pass
 (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`) lands, since both are about making
 introspection surfaces agree with each other and with the canonical dispatch table.
+
+## Progress (2026-08-14, #6420)
+
+The `.is_dispatcher`/`.multi` symptom is fixed with a scoped patch, not the representation
+unification this file describes. `methods_instance_ops.rs`'s general method-dispatch fallback now
+answers both accessors directly on the `Sub`-shaped value (keyed off the existing
+`__mutsu_lookup_*`/`__mutsu_callable_type` env tags, plus a new `__mutsu_is_multi_candidate` tag
+set only on `.candidates[N]` entries), matching `raku` ground truth: a non-multi method or
+submethod answers both `False`; a multi method's dispatcher-shaped value (what `.^lookup`/
+`.^find_method` return for the whole family) answers `is_dispatcher` `True` but `multi` falsy;
+each individual `.candidates[N]` entry answers `is_dispatcher` `False` but `multi` `True`. Pin:
+`t/classhow-lookup-method-is-dispatcher-multi.t` (byte-for-byte identical TAP output against
+`raku`).
+
+Note the exact repro at the top of this file (`(42).^lookup("floor")`, the *native*-method case)
+no longer reproduces the `<composed-method:NAME>` bug on current `main` — it now raises a clean
+"No such method 'is_dispatcher' for invocant of type 'Method'" error instead (unchanged by this
+patch; some other change fixed that path independently before this session). The user-defined-class
+case shown further down (`class A { method foo {} }; A.^lookup("foo").is_dispatcher`) DID still
+reproduce the bogus-callable bug and is what this patch fixes.
+
+The representation mismatch itself (Sub vs. Method Instance) — and everything in "Why this is deep,
+not a quick ticket" above — remains open.


### PR DESCRIPTION
## Summary

Docs-only follow-up recording this session's two ADR-0019 Phase F merges in the execution plan and linked ticket:

- #6420 — `.^lookup`/`.^find_method` Method/Submethod values now answer `.is_dispatcher`/`.multi` correctly instead of a bogus composed-callable.
- #6422 — dedup the 7-site duplicated method-resolution cache-invalidation block into one shared `invalidate_method_dispatch_caches()` helper (Phase F box F5's suggested "trivial first PR").

Plus a `news/2026-08/` entry per project convention.

## Test plan

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)