### PR TITLE
refactor(vm): generation-guard func_multi_resolve_cache/type_cacheable

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -603,6 +603,24 @@ impl Interpreter {
         fp
     }
 
+    /// Lazily clear `func_multi_resolve_cache`/`func_multi_type_cacheable` when
+    /// `fn_resolve_gen` has advanced since they were last built — the function-dispatch
+    /// analogue of `refresh_method_caches_for_generation`. ADR-0019 Phase F box F5: these
+    /// two caches used to depend entirely on the eager clear in
+    /// `invalidate_method_dispatch_caches`, which covered only 7 call sites even though
+    /// `fn_resolve_gen` itself is bumped at ~15 other sub/multi-registration sites
+    /// (`registration_sub.rs`, `methods_sub.rs`, module load/import, ...) that never called
+    /// it — a real staleness gap, not just duplicated cleanup, since those sites can add a
+    /// new multi-sub candidate that a cached resolution would then silently skip.
+    pub(crate) fn refresh_func_multi_caches_for_generation(&mut self) {
+        if self.func_multi_cache_generation == self.fn_resolve_gen {
+            return;
+        }
+        self.func_multi_cache_generation = self.fn_resolve_gen;
+        self.func_multi_resolve_cache.clear();
+        self.func_multi_type_cacheable.clear();
+    }
+
     /// Whether a multi *sub* `name` (in `pkg`) has a dispatch that is purely
     /// type+arity based — the function analogue of `multi_dispatch_type_cacheable`.
     /// False when any candidate is value-/identity-dependent (`where` / literal /
@@ -614,6 +632,7 @@ impl Interpreter {
         name_sym: Symbol,
         name: &str,
     ) -> bool {
+        self.refresh_func_multi_caches_for_generation();
         if let Some(&c) = self.func_multi_type_cacheable.get(&(pkg_sym, name_sym)) {
             return c;
         }
@@ -1238,5 +1257,57 @@ impl Interpreter {
             .class_role_param_bindings
             .get(class_name)
             .cloned()
+    }
+}
+
+#[cfg(test)]
+mod func_multi_cache_generation_tests {
+    use super::*;
+
+    // ADR-0019 Phase F box F5: `func_multi_resolve_cache`/`func_multi_type_cacheable`
+    // used to depend entirely on the eager clear in `invalidate_method_dispatch_caches`,
+    // which only ~7 of the ~20 `fn_resolve_gen`-bumping sites called -- a fresh multi-sub
+    // candidate registered at one of the other sites (e.g. `require`, `EVAL`) could leave
+    // a stale resolved candidate or a stale cacheable/uncacheable verdict cached under the
+    // old name. `refresh_func_multi_caches_for_generation` closes that gap by checking
+    // `fn_resolve_gen` at every read, independent of which site bumped it.
+    #[test]
+    fn stale_entries_are_dropped_when_fn_resolve_gen_advances() {
+        let mut i = Interpreter::new();
+        let pkg = Symbol::intern("GLOBAL");
+        let name = Symbol::intern("f");
+        i.func_multi_type_cacheable.insert((pkg, name), true);
+        i.func_multi_resolve_cache
+            .insert((pkg, name, vec![Symbol::intern("Int")]), None);
+        assert!(!i.func_multi_type_cacheable.is_empty());
+        assert!(!i.func_multi_resolve_cache.is_empty());
+
+        // No generation change yet: a stale-looking entry is left alone.
+        i.refresh_func_multi_caches_for_generation();
+        assert!(!i.func_multi_type_cacheable.is_empty());
+        assert!(!i.func_multi_resolve_cache.is_empty());
+
+        // Simulate a registration site that bumps `fn_resolve_gen` without going
+        // through `invalidate_method_dispatch_caches` (e.g. `require`/`EVAL`).
+        i.fn_resolve_gen += 1;
+        i.refresh_func_multi_caches_for_generation();
+        assert!(i.func_multi_type_cacheable.is_empty());
+        assert!(i.func_multi_resolve_cache.is_empty());
+        assert_eq!(i.func_multi_cache_generation, i.fn_resolve_gen);
+    }
+
+    #[test]
+    fn func_multi_dispatch_type_cacheable_self_refreshes() {
+        let mut i = Interpreter::new();
+        let pkg = Symbol::intern("GLOBAL");
+        let name = Symbol::intern("f");
+        // Seed a wrong verdict directly (bypassing the real scan) to prove the
+        // read path clears it on a generation mismatch rather than trusting it.
+        i.func_multi_type_cacheable.insert((pkg, name), true);
+        i.fn_resolve_gen += 1;
+        // `f` has no registered candidates at all, so a fresh scan answers `false`
+        // (not multi). If the stale `true` entry survived, this would wrongly
+        // return `true` instead.
+        assert!(!i.func_multi_dispatch_type_cacheable(pkg, name, "f"));
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2416,6 +2416,13 @@ pub struct Interpreter {
     /// deterministic` (i.e. cacheable in `func_multi_resolve_cache`). The
     /// function analogue of `multi_type_cacheable`.
     pub(crate) func_multi_type_cacheable: rustc_hash::FxHashMap<(Symbol, Symbol), bool>,
+    /// The `fn_resolve_gen` value `func_multi_resolve_cache`/`func_multi_type_cacheable`
+    /// were last cleared for (see `refresh_func_multi_caches_for_generation`, ADR-0019
+    /// Phase F box F5). Mirrors `method_cache_generation`'s role for the method-side
+    /// caches: a mismatch means a sub/multi registration happened since these caches
+    /// were built, so they are cleared lazily on next read instead of at every one of
+    /// `fn_resolve_gen`'s many bump sites.
+    pub(crate) func_multi_cache_generation: u64,
     /// Names of classes the user declared with a `class`/`role`/`grammar`/`enum`
     /// statement (`register_class_decl`). For such a class the collected public-
     /// attribute list is authoritative: a `.name` accessor resolves ONLY for a

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2425,6 +2425,7 @@ impl Interpreter {
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
             func_multi_resolve_cache: rustc_hash::FxHashMap::default(),
             func_multi_type_cacheable: rustc_hash::FxHashMap::default(),
+            func_multi_cache_generation: 0,
             block_declared_vars: Vec::new(),
             given_pointy_capture_slots: Vec::new(),
             given_pointy_captured: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -796,6 +796,7 @@ impl Interpreter {
             method_body_fp_cache: rustc_hash::FxHashMap::default(),
             func_multi_resolve_cache: rustc_hash::FxHashMap::default(),
             func_multi_type_cacheable: rustc_hash::FxHashMap::default(),
+            func_multi_cache_generation: 0,
             user_declared_classes: self.user_declared_classes.clone(),
             block_declared_vars: Vec::new(),
             given_pointy_capture_slots: Vec::new(),

--- a/src/vm/vm_dispatch_cache_invalidate.rs
+++ b/src/vm/vm_dispatch_cache_invalidate.rs
@@ -7,14 +7,26 @@ impl Interpreter {
     /// verbatim at every registry mutation site that can shadow or replace an
     /// already-cached resolution (module load/import/no/need, a `my sub`
     /// leaving block scope, a `my class`/role/enum redeclaration, a fresh sub
-    /// installation). `resolve_method_cached` also invalidates its own subset
-    /// lazily via `refresh_method_caches_for_generation`, keyed on
-    /// `Registry::method_generation` -- but `func_multi_resolve_cache` /
-    /// `func_multi_type_cacheable` (plain multi *sub* dispatch, read by
-    /// `resolve_function_multi_cached`) have no generation guard at their read
-    /// site and depend entirely on being cleared here. Do not drop this eager
-    /// call without first adding an equivalent generation check to that read
-    /// path -- see `todo/deep/adr0019-*.md` for the fuller F5 design.
+    /// installation).
+    ///
+    /// `func_multi_resolve_cache`/`func_multi_type_cacheable` now also
+    /// self-invalidate lazily via `refresh_func_multi_caches_for_generation`,
+    /// keyed on `fn_resolve_gen` (which this function bumps unconditionally) --
+    /// closing a real staleness gap the eager clear alone did not: `fn_resolve_gen`
+    /// is bumped at ~15 other sub/multi-registration sites that never called this
+    /// function, so those two caches could go stale from a fresh multi-sub
+    /// candidate added at one of them. Their `.clear()` calls below are therefore
+    /// now redundant at every one of *this* function's own call sites and are kept
+    /// only to drop the maps' allocated capacity immediately.
+    ///
+    /// The remaining caches (`method_resolve_cache`, `fast_method_cache`, ...) are
+    /// also generation-guarded at their own read site
+    /// (`refresh_method_caches_for_generation`, keyed on `Registry::method_generation`),
+    /// but that generation is not known to be bumped at every one of this
+    /// function's 7 call sites (module load/import/no/need, block-scope exit, sub
+    /// registration are all sub/function-registry events, not method-registry
+    /// ones) -- unlike the `func_multi_*` pair above, removing their eager clear
+    /// here has not been audited as safe, so they stay.
     pub(crate) fn invalidate_method_dispatch_caches(&mut self) {
         self.fn_resolve_gen += 1;
         self.method_resolve_cache.clear();


### PR DESCRIPTION
## Summary

ADR-0019 Phase F box F5 continuation (after #6422's shared-invalidation
dedup). `func_multi_resolve_cache`/`func_multi_type_cacheable` (the plain
multi-*sub* dispatch caches read by `resolve_function_multi_cached`) used
to depend entirely on the eager clear in `invalidate_method_dispatch_caches`,
which only ~7 of the ~20 `fn_resolve_gen`-bumping sites call. That left a
real staleness gap: `require`, `EVAL`, module export, and several
sub-registration paths bump `fn_resolve_gen` directly without going through
that function, so a fresh multi-sub candidate registered at one of those
sites could leave a stale resolved candidate — or a stale
cacheable/uncacheable verdict — cached under the old generation.

- Add `Interpreter::func_multi_cache_generation` and
  `refresh_func_multi_caches_for_generation`, mirroring
  `refresh_method_caches_for_generation`'s pattern but keyed on
  `fn_resolve_gen` instead of `Registry::method_generation`.
- Call it from `func_multi_dispatch_type_cacheable` before either cache is
  read (the entry point `resolve_function_multi_cached` always goes
  through).
- `invalidate_method_dispatch_caches`'s eager clears for this pair are now
  redundant at its own call sites and kept only to drop the maps'
  allocated capacity immediately; the doc comment now says so and
  explains why the *other* caches there stay eagerly cleared (their
  generation coverage across all 7 call sites has not been audited).

## Test plan

- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] New unit tests (`func_multi_cache_generation_tests`) pin the
  generation-refresh mechanism directly.
- [x] Full `t/` suite (debug binary): green except a known-flaky S17-style
  concurrency test (`t/supply-done-in-tap-callback-is-not-a-failure.t`,
  passes standalone; unrelated to this change).
- [x] Spot-checked `roast/S06-multi/proto.t`,
  `roast/S06-signature/multiple-signatures.t` under `MUTSU_FUDGE=1`.
- [ ] CI `make roast` (comprehensive suite, left to CI per project
  convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)