### PR TITLE
docs(adr0019): native is_dispatcher=True is common, not rare; revert guess

### DIFF
--- a/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
+++ b/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
@@ -194,14 +194,26 @@ Consulted and confirmed with the user. Resolution, adopted as the plan going for
    sweep of all ~350 native methods. A guard test ties every override to a live catalog row (fails
    loudly if a row is renamed/removed out from under its override), preventing the drift the
    rejected-alternative worried about.
-4. **The dispatcher/multi/candidates axis needs no hand data at all.** It is a uniform structural
-   rule (the `.^lookup` result is the dispatcher: `is_dispatcher=True`/`multi=False`; each element
-   of its `.candidates` is a candidate: `is_dispatcher=False`/`multi=True`; a non-multi method's own
-   `.candidates` is itself, one element) that generalized correctly across every case tested,
-   *including* the native-multi case (`Int.^lookup("Numeric")`) #6420's narrower env-tag patch does
-   not yet cover. F1's mechanism slice should implement this as general code in
-   `make_native_method_object`/`classhow_lookup`, replacing the tag-matching patch, not add more
-   tags.
+4. **Revised (2026-08-14): the dispatcher/multi/candidates *rule* needs no hand data, but *applying*
+   it to native methods does.** The structural rule itself (the `.^lookup` result is the dispatcher:
+   `is_dispatcher=True`/`multi=False`; each element of its `.candidates` is a candidate:
+   `is_dispatcher=False`/`multi=True`; a non-multi method's own `.candidates` is itself, one element)
+   generalized correctly across every *user*-method case tested — for a user method,
+   `MethodDef` overload count already tells mutsu whether a name is multi, so this needs no new
+   data. It does NOT extend to native methods for free: a wider raku sweep found
+   `is_dispatcher=True` is the *majority* case for Cool/Any-declared native methods (`round`,
+   `trim`, `substr`, `Str`, `chars`, `flip`, `uc`, `lc`, ... on `Int`/`Str` all answer `True`; only a
+   minority like `floor`/`ceiling`/`Int` answer `False`) — not the rare edge case earlier entries in
+   this file and the linked ticket assumed. A tried-and-reverted fix (default `False`/`False` for
+   any `ValueView::Routine` native lookup result, since mutsu tracks no native-method multiplicity
+   data) would have been wrong more often than right, which is worse than the current clean error
+   per this project's no-stubs convention — see the ticket's "Progress (2026-08-14, continued)"
+   entry. **So native `is_dispatcher`/`multi`/`.candidates` moves from "mechanism, no data needed"
+   into the fidelity slice**, at roughly the same per-native-method data-volume scale as
+   `.signature`/`.package` (point 3 above) — plausibly the SAME override column work, since knowing
+   a native method's real candidate list would answer signature, package, AND multiplicity together.
+   F1's mechanism slice therefore only covers the `Sub`-shaped (user-method) side cleanly; the
+   `Routine`-shaped (native) side waits for the fidelity slice's real data, not a guessed default.
 5. **Sequencing** (keeps F1 and F3 independently landable, F3 first since it has no F1 dependency):
    - **F3** (next slice): cut `builtin_type_method_names()`'s three call sites
      (`methods_classhow_method_obj.rs`, `vm_call_helpers.rs`, `methods_classhow_builtin_methods.rs`)

--- a/todo/tickets/classhow-lookup-returns-sub-not-method-instance.md
+++ b/todo/tickets/classhow-lookup-returns-sub-not-method-instance.md
@@ -110,3 +110,43 @@ a native multi method's `.^lookup` result never gets those tags set, so it falls
 still-open "no such method" error rather than the bogus `<composed-method:NAME>` the original repro
 showed. Same root cause, different symptom, not yet pinned. Confirms this is best fixed by the
 representation unification, not another tag-based patch.
+
+## Progress (2026-08-14, continued): native `is_dispatcher=True` is the COMMON case, not a rare edge
+
+Attempted a narrow, non-representation-unifying fix: extend the `is_dispatcher`/`multi` match arms
+in `methods_instance_ops.rs` to also handle `ValueView::Routine` (the shape `.^lookup` returns for a
+*native* method, distinct from the `ValueView::Sub` shape `#6420`'s tags live on), defaulting to
+`False`/`False` since mutsu has no data on which native methods are Rakudo-core multis. Before
+committing this, checked how often that default would actually be wrong via a wider raku sweep —
+and it is wrong far more often than expected:
+
+```
+$ raku -e 'for <floor ceiling round trim substr Str Int> -> $m { say "$m (Int): " ~ 42.^lookup($m).is_dispatcher }'
+floor (Int): False
+ceiling (Int): False
+round (Int): True
+trim (Int): True
+substr (Int): True
+Str (Int): True
+Int (Int): False
+$ raku -e 'for <chars flip uc lc trim substr Str Int> -> $m { say "$m (Str): " ~ "abc".^lookup($m).is_dispatcher }'
+chars (Str): True
+flip (Str): True
+uc (Str): True
+lc (Str): True
+trim (Str): True
+substr (Str): True
+Str (Str): True
+Int (Str): False
+```
+
+**`is_dispatcher = True` is the majority case for Cool/Any-declared native methods in real Rakudo**
+(most core methods are declared `multi method` for invocant-type-flexibility reasons), not the rare
+exception this ticket's earlier entries assumed. A blanket `False` default would therefore be wrong
+*more often than right* for this accessor — silently wrong, not just incomplete. Per this project's
+"no stubs/hardcoded outputs to fake a result" convention, that is worse than the current clean error,
+not better, so **the narrow fix was reverted, not committed**. This sharpens (does not resolve) the
+F1 fidelity-slice scope: `is_dispatcher`/`multi`/`.candidates` for native methods is not a rarely-hit
+corner needing a handful of hand overrides — it needs real per-native-method multiplicity data across
+most of the catalog, on the same order of effort as the `.signature`/`.package` fidelity work already
+scoped. See `todo/deep/adr0019-f1-f2-introspection-canonical-source.md`.


### PR DESCRIPTION
## Summary

Attempted a narrow fix for the native `.^lookup` `.is_dispatcher`/`.multi`
gap (`Int.^lookup("Numeric").is_dispatcher` raising "No such method"):
extend the existing `ValueView::Sub` match arms in
`methods_instance_ops.rs` to also handle `ValueView::Routine` (the shape
a *native* method's `.^lookup` result takes), defaulting to `False`/
`False` since mutsu tracks no native-method multiplicity data.

Before committing, checked how often that default would actually be
wrong via a wider `raku` sweep — and it's wrong far more often than
expected. `is_dispatcher=True` turns out to be the **majority** case for
Cool/Any-declared native methods (`round`, `trim`, `substr`, `Str`,
`chars`, `flip`, `uc`, `lc` on `Int`/`Str` all answer `True`; only a
minority like `floor`/`ceiling`/`Int` answer `False`) — not the rare
edge case earlier ground-truth entries assumed from testing just a
couple of names. A blanket `False` default would be silently wrong more
often than right, which is worse than the current clean error per this
project's no-stubs-to-fake-a-result convention (CLAUDE.md), so **the fix
was reverted, not committed**.

Records the corrected finding on the ticket and the F1 decision doc:
native `is_dispatcher`/`multi`/`.candidates` moves from "mechanism, zero
data needed" into the fidelity slice, at the same data-volume scale as
`.signature`/`.package` — plausibly the same override-column work.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)