### PR TITLE
feat(adr0019): Method introspection objects answer .package (F1 mechanism slice)

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -808,6 +808,16 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   targeted handling on the `Sub`-shaped value, verified against `raku` ground truth (pin:
   `t/classhow-lookup-method-is-dispatcher-multi.t`). The underlying representation mismatch (Sub
   vs. Method Instance) remains open; this was a scoped patch, not the unification.
+  **Update (2026-08-14, F1 mechanism slice, `.package` only):** `make_native_method_object`/
+  `make_method_object_with_owner` never set a `.package` attribute at all (always `Nil`, not just
+  imprecise). Fixed: exact for user/role methods (declaring class/role, raku-verified); a multi
+  dispatcher's own `.package` stays deliberately unset (real Rakudo answers a synthetic `(Dummy)`
+  mutsu does not model) while its candidates get the correct owner; native methods default to the
+  catalog owner (an accepted imperfect mechanism-slice default, e.g. `Str.uc` answers `(Str)` not
+  Rakudo's true `(Cool)` — the fidelity slice closes that gap later). `.signature`'s synthesized
+  default and the Sub-vs-Instance unification remain open. Pin: `t/classhow-methods-package.t`;
+  design detail in `todo/deep/adr0019-f1-f2-introspection-canonical-source.md`'s "Progress
+  (2026-08-14): F1 mechanism slice, `.package` only".
 - [ ] **F3 — Delete the per-type method-name lists and the test-only `METHOD_UNIVERSE`.** B1/B2
   already removed `METHOD_UNIVERSE` and runtime probing from the runtime path (both are
   `#[cfg(test)]`-only now); the live work is the fourteen per-type `&[&str]` name slices

--- a/news/2026-08/adr0019-f1-method-package-mechanism-slice.md
+++ b/news/2026-08/adr0019-f1-method-package-mechanism-slice.md
@@ -1,0 +1,26 @@
+# ADR-0019 Phase F: `Method` introspection objects now answer `.package`
+
+`.^methods`, `.^method_table`, and `collect_class_methods` build `Method` `Instance` objects for
+every reported method, but `make_native_method_object`/`make_method_object_with_owner`
+(`src/runtime/methods_classhow_method_obj.rs`) never set a `.package` attribute at all -- so
+`.package` on any such object read as `Nil`, regardless of the method's actual owner.
+
+Fixed by threading the already-available owner (declaring class, role, or catalog type) through to
+a new `.package` attribute:
+
+- A user-declared class method's `.package` is exactly its declaring class; a runtime-mixed-in
+  role method's is exactly the role -- both verified byte-for-byte against `raku`.
+- A multi method's dispatcher-shaped entry deliberately leaves `.package` unset: real Rakudo
+  answers `(Dummy)`, an internal synthetic type mutsu does not model, and guessing a concrete class
+  there would be actively wrong. Each individual `.candidates[N]` entry still gets the correct
+  owner.
+- A native/built-in method's `.package` now defaults to the catalog type it was reported under
+  (e.g. `Str.^methods`'s `chars` entry answers `(Str)`). This is not always Rakudo's true
+  declaring type (`Str.uc`'s real `.package` is `(Cool)`) -- a deliberate, accepted mechanism-slice
+  default per ADR-0019 Phase F box F1's design decision, strictly better than the prior universal
+  `Nil` but not a claim of full parity. Closing that gap exactly is separate, tracked follow-up
+  work (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`).
+
+`make_method_object`/`make_method_object_with_candidates` were deleted as dead code once their
+only callers were switched to call `make_method_object_with_owner` directly with the owner
+threaded through. Pinned by `t/classhow-methods-package.t`.

--- a/src/runtime/methods_classhow_builtin_methods.rs
+++ b/src/runtime/methods_classhow_builtin_methods.rs
@@ -37,7 +37,7 @@ impl Interpreter {
         // model layer really implements so `.^methods(:local)` is useful (and
         // does not fall through to an empty built-in method list).
         if local && let Some(names) = crate::rakuast::local_method_names(&class_name) {
-            self.push_native_method_objects(&names, &mut result);
+            self.push_native_method_objects(&names, &class_name, &mut result);
             return Ok(Value::array(result));
         }
 
@@ -63,7 +63,7 @@ impl Interpreter {
             if result.is_empty() && !self.registry().classes.contains_key(&class_name) {
                 let names =
                     crate::builtins::builtin_type_methods::builtin_type_method_names(&class_name);
-                self.push_native_method_objects(&names, &mut result);
+                self.push_native_method_objects(&names, &class_name, &mut result);
             }
         } else {
             // Runtime-mixed-in role methods sit ahead of the base class in the
@@ -125,12 +125,17 @@ impl Interpreter {
         // construction is static and introspection does not construct or probe
         // a parallel entry set on every query.
         let methods = self.registry().builtin_method_names(type_name);
-        self.push_native_method_objects(&methods, result);
+        self.push_native_method_objects(&methods, type_name, result);
     }
 
     /// Append a native Method object for each name not already present in
-    /// `result` (dedup by the Method object's `name` attribute).
-    fn push_native_method_objects(&self, names: &[&str], result: &mut Vec<Value>) {
+    /// `result` (dedup by the Method object's `name` attribute). `owner` is the
+    /// catalog type these names were collected for -- ADR-0019 Phase F box F1's
+    /// mechanism slice: the resulting `Method` object's `.package` defaults to
+    /// it. This is not always Rakudo's true declaring type (e.g. `Str.uc`'s
+    /// real `.package` is `Cool`, not `Str`) -- that per-method fidelity data
+    /// is a later, separate slice (see `todo/deep/adr0019-f1-f2-introspection-canonical-source.md`).
+    fn push_native_method_objects(&self, names: &[&str], owner: &str, result: &mut Vec<Value>) {
         for name in names {
             if !result.iter().any(|v| {
                 if let ValueView::Instance { attributes, .. } = v.view() {
@@ -144,7 +149,7 @@ impl Interpreter {
                     false
                 }
             }) {
-                result.push(self.make_native_method_object(name));
+                result.push(self.make_native_method_object(name, owner));
             }
         }
     }

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -16,7 +16,7 @@ impl Interpreter {
         // First add accessor methods for public attributes (in order)
         for attr in &class_def.attributes {
             if attr.is_public && !class_def.methods.contains_key(&attr.name) {
-                result.push(self.make_native_method_object(&attr.name));
+                result.push(self.make_native_method_object(&attr.name, class_name));
             }
         }
         // Then add explicit methods. `ClassDef::methods` drives the name
@@ -52,7 +52,7 @@ impl Interpreter {
         }
         // Also include native (built-in) methods
         for native_name in &class_def.native_methods {
-            let method_obj = self.make_native_method_object(native_name);
+            let method_obj = self.make_native_method_object(native_name, class_name);
             result.push(method_obj);
         }
     }
@@ -71,7 +71,10 @@ impl Interpreter {
         // `.^methods(:local)` by deriving both from the same model metadata.
         if let Some(names) = crate::rakuast::local_method_names(class_name) {
             for name in names {
-                table.insert(name.to_string(), self.make_native_method_object(name));
+                table.insert(
+                    name.to_string(),
+                    self.make_native_method_object(name, class_name),
+                );
             }
             return table;
         }
@@ -83,7 +86,7 @@ impl Interpreter {
             if attr.is_public && !class_def.methods.contains_key(&attr.name) {
                 table.insert(
                     attr.name.clone(),
-                    self.make_native_method_object(&attr.name),
+                    self.make_native_method_object(&attr.name, class_name),
                 );
             }
         }
@@ -112,7 +115,7 @@ impl Interpreter {
         for native_name in &class_def.native_methods {
             table.insert(
                 native_name.clone(),
-                self.make_native_method_object(native_name),
+                self.make_native_method_object(native_name, class_name),
             );
         }
         table
@@ -129,7 +132,7 @@ impl Interpreter {
             // Add accessor methods for public attributes
             for attr in &role_def.attributes {
                 if attr.is_public && !role_def.methods.contains_key(&attr.name) {
-                    result.push(self.make_native_method_object(&attr.name));
+                    result.push(self.make_native_method_object(&attr.name, role_name));
                 }
             }
             // Add explicit methods
@@ -143,22 +146,30 @@ impl Interpreter {
                 }
                 let is_multi = overloads.len() > 1;
                 let return_type = first.return_type.clone();
-                let method_obj = self.make_method_object_with_candidates(
+                let method_obj = self.make_method_object_with_owner(
                     method_name,
                     first,
                     is_multi,
                     return_type,
                     Some(overloads),
+                    Some(role_name),
                 );
                 result.push(method_obj);
             }
         }
     }
 
-    pub(super) fn make_native_method_object(&self, name: &str) -> Value {
+    /// `owner` is the catalog type this native method is being reported for --
+    /// ADR-0019 Phase F box F1's mechanism slice: `.package` defaults to it.
+    /// This is not always Rakudo's true declaring type (e.g. `Str.uc`'s real
+    /// `.package` is `Cool`, not `Str`) -- that per-method fidelity data is a
+    /// later, separate slice (see
+    /// `todo/deep/adr0019-f1-f2-introspection-canonical-source.md`).
+    pub(super) fn make_native_method_object(&self, name: &str, owner: &str) -> Value {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert("name".to_string(), Value::str(name.to_string()));
         attrs.insert("is_dispatcher".to_string(), Value::FALSE);
+        attrs.insert("package".to_string(), Value::package(Symbol::intern(owner)));
         let sig_attrs = {
             let mut sa = std::collections::HashMap::new();
             sa.insert("params".to_string(), Value::array(Vec::new()));
@@ -173,41 +184,10 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("Method"), attrs)
     }
 
-    pub(super) fn make_method_object(
-        &self,
-        name: &str,
-        method_def: &MethodDef,
-        is_dispatcher: bool,
-        return_type: Option<String>,
-    ) -> Value {
-        self.make_method_object_with_candidates(name, method_def, is_dispatcher, return_type, None)
-    }
-
-    /// Build a Method object. When `is_dispatcher` is true and `overloads`
-    /// is supplied, a `candidates` attribute holding a Method object per
-    /// overload is attached so that `.candidates` works on a multi method.
-    pub(super) fn make_method_object_with_candidates(
-        &self,
-        name: &str,
-        method_def: &MethodDef,
-        is_dispatcher: bool,
-        return_type: Option<String>,
-        overloads: Option<&[MethodDef]>,
-    ) -> Value {
-        self.make_method_object_with_owner(
-            name,
-            method_def,
-            is_dispatcher,
-            return_type,
-            overloads,
-            None,
-        )
-    }
-
-    /// As `make_method_object_with_candidates`, but records the owning class so
-    /// a `.wrap` on the returned Method object (e.g. from `.^methods(:local)` in
-    /// a custom metaclass `compose`, `advent2011-day14`) can register into the
-    /// class-keyed `method_wrap_chains` and take effect for later dispatch.
+    /// Records the owning class/role so a `.wrap` on the returned Method
+    /// object (e.g. from `.^methods(:local)` in a custom metaclass `compose`,
+    /// `advent2011-day14`) can register into the class-keyed
+    /// `method_wrap_chains` and take effect for later dispatch.
     pub(super) fn make_method_object_with_owner(
         &self,
         name: &str,
@@ -231,6 +211,11 @@ impl Interpreter {
         // object can register a class-keyed wrap chain (see `wrap` dispatch for
         // Method instances). Single (non-multi) methods are candidate 0; multi
         // methods are wrapped through their `.candidates[N]` entries instead.
+        // `.package` shares the same gate: a real Rakudo multi *dispatcher*'s
+        // own `.package` is an internal synthetic type (`(Dummy)`), not the
+        // declaring class, so it is deliberately left unset here rather than
+        // guessed -- but each individual (non-dispatcher) candidate's
+        // `.package` is exactly `owner_class`, verified against `raku`.
         if let Some(owner) = owner_class
             && !is_dispatcher
         {
@@ -243,6 +228,7 @@ impl Interpreter {
                 Value::str(name.to_string()),
             );
             attrs.insert("__mutsu_lookup_candidate_idx".to_string(), Value::int(0));
+            attrs.insert("package".to_string(), Value::package(Symbol::intern(owner)));
         }
 
         // Build a Signature object for this method, threading the return type
@@ -266,7 +252,16 @@ impl Interpreter {
         let candidates: Vec<Value> = match overloads {
             Some(defs) if is_dispatcher => defs
                 .iter()
-                .map(|def| self.make_method_object(name, def, false, def.return_type.clone()))
+                .map(|def| {
+                    self.make_method_object_with_owner(
+                        name,
+                        def,
+                        false,
+                        def.return_type.clone(),
+                        None,
+                        owner_class,
+                    )
+                })
                 .collect(),
             _ => Vec::new(),
         };

--- a/t/classhow-methods-package.t
+++ b/t/classhow-methods-package.t
@@ -1,0 +1,57 @@
+use Test;
+
+# ADR-0019 Phase F box F1 mechanism slice (todo/deep/
+# adr0019-f1-f2-introspection-canonical-source.md "Decision (2026-08-14)"):
+# the `Method` `Instance` objects `.^methods`/`.^method_table` build never
+# set a `.package` attribute at all, so it always read `Nil` regardless of
+# receiver. Ground truth gathered against `raku` 2026-08-14:
+#
+#   - A user-declared class method's `.package` is exactly its declaring
+#     class.
+#   - A runtime-mixed-in role method's `.package` is exactly the role.
+#   - A multi method's *dispatcher*-shaped entry (what `.^methods` reports
+#     for the family as a whole) has `.package` `(Dummy)` in real Rakudo, a
+#     synthetic internal type mutsu does not model. mutsu deliberately leaves
+#     it unset (Nil) here rather than guess a wrong concrete class -- this
+#     is a known, accepted divergence from `raku`, not a claim of parity.
+#   - Each individual `.candidates[N]` entry's `.package` is exactly the
+#     declaring class, same as a non-multi method.
+#
+# Native/built-in methods are NOT pinned here: their true declaring type is
+# not mechanically derivable from mutsu's per-type catalog (e.g. `Str.uc`'s
+# real `.package` is `Cool`, not `Str` -- see the linked design doc's
+# fidelity-slice discussion), so this file only covers the user-declared
+# side the mechanism slice makes exact.
+
+class Plain { method foo { 1 } }
+is Plain.^lookup("foo").package.gist, '(Plain)',
+    'Sub-shaped .^lookup result already answered .package correctly (unaffected baseline)';
+
+my @plain-methods = Plain.^methods;
+my $foo-method = @plain-methods.first(*.name eq 'foo');
+is $foo-method.package.gist, '(Plain)',
+    '.^methods Method-Instance package is the declaring class';
+
+my %table = Plain.^method_table;
+is %table<foo>.package.gist, '(Plain)',
+    '.^method_table Method-Instance package is the declaring class';
+
+role R { method bar { 1 } }
+my $mixed = 5 but R;
+my $bar-method = $mixed.^methods.first(*.name eq 'bar');
+is $bar-method.package.gist, '(R)',
+    'runtime-mixed-in role method package is the role';
+
+class Multi1 {
+    multi method baz(Int $x) { "int" }
+    multi method baz(Str $x) { "str" }
+}
+my $dispatcher = Multi1.^methods.first(*.name eq 'baz');
+is $dispatcher.package.gist, 'Nil',
+    'multi dispatcher package stays unset rather than guessed';
+for $dispatcher.candidates -> $c {
+    is $c.package.gist, '(Multi1)',
+        'multi candidate package is the declaring class';
+}
+
+done-testing;

--- a/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
+++ b/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
@@ -232,3 +232,41 @@ Consulted and confirmed with the user. Resolution, adopted as the plan going for
    - **ADR edit**: fold point 1's definitional boundary into the ADR itself (near F1's box text or
      the "Build an introspection-only catalog" rejected alternative), so a future agent doesn't
      misread F3 as blocking this, or misread this as license to resurrect name lists.
+
+## Progress (2026-08-14): F1 mechanism slice, `.package` only
+
+Landed the `.package` half of the mechanism slice, ahead of F3 (F3's own scoping note found its
+"regenerate `RAW_ROWS`" step needs a real raku-verification triage pass of its own, not a
+mechanical cutover -- see `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` -- so
+this was picked up first as the smaller, independently-safe piece).
+
+`make_native_method_object`/`make_method_object_with_owner` (`methods_classhow_method_obj.rs`)
+never set a `.package` attribute at all, so every `Method` `Instance` object `.^methods`/
+`.^method_table`/`collect_class_methods` build answered `.package` as `Nil` regardless of
+receiver -- confirmed by raku ground truth this was simply missing, not merely imprecise. Fixed:
+
+- **User methods and role methods**: `.package` is now exactly the declaring class/role, threaded
+  through the existing `owner_class`/`role_name` parameters already present at every call site.
+  Verified exact against `raku` (`class A { method foo{} }`, `role R { method bar{} }`) -- no
+  fidelity gap here, this is a plain missing-feature fix, not an approximation.
+- **Multi dispatchers**: raku's own dispatcher-shaped `Method` (what `.^lookup`/`.^methods` return
+  for the family as a whole) answers `.package` with `(Dummy)`, a Rakudo-internal synthetic type
+  mutsu does not model. Left deliberately unset (`Nil`) rather than guessed wrong -- gated behind
+  the same `!is_dispatcher` condition the existing `__mutsu_lookup_*` wrap-registration tags
+  already used, so no new conditional logic was needed. Each individual `.candidates[N]` entry
+  (itself non-dispatcher) still gets the correct owner.
+- **Native methods**: `.package` now defaults to the catalog `owner` threaded through
+  `push_native_method_objects`/`collect_builtin_type_methods` -- e.g. `Str.^methods`'s `chars`
+  entry now answers `(Str)`. This is the accepted imperfect mechanism-slice default per point 4/5
+  above (raku's real answer for `chars`/`uc`/etc. is `(Cool)`, `Array.push` is `(Any)`) --
+  strictly better than the prior universal `Nil`, not a claim of Rakudo parity. The fidelity slice
+  (per-method override column) is still open for closing this gap exactly.
+
+Also deleted `make_method_object`/`make_method_object_with_candidates`, which became fully dead
+once their only call sites (the multi-candidate builder loop, `collect_role_methods`) were changed
+to call `make_method_object_with_owner` directly with the owner threaded through.
+
+Not done in this slice (left for follow-up, per point 5's own sequencing): `.signature`'s
+synthesized-generic-shape default, and the `Method`-Instance-vs-`Sub` representation unification
+(`todo/tickets/classhow-lookup-returns-sub-not-method-instance.md`) -- `.^lookup` still returns a
+`Sub`-shaped value untouched by this slice. Pinned: `t/classhow-methods-package.t`.


### PR DESCRIPTION
## Summary
- `make_native_method_object`/`make_method_object_with_owner` never set a `.package` attribute at all, so every `Method` `Instance` object `.^methods`/`.^method_table`/`collect_class_methods` build answered `.package` as `Nil` regardless of receiver.
- Fixed by threading the already-available owner (declaring class, role, or catalog type) through: exact for user/role methods (raku-verified byte-for-byte); deliberately left unset for a multi dispatcher's own entry (real Rakudo answers a synthetic `(Dummy)` type mutsu does not model) while its `.candidates[N]` entries get the correct owner; native methods default to the catalog owner (an accepted imperfect mechanism-slice default per ADR-0019 Phase F box F1's design decision — e.g. `Str.uc` answers `(Str)` not Rakudo's true `(Cool)` — strictly better than the prior universal `Nil`, fidelity slice closes the gap later).
- Deleted `make_method_object`/`make_method_object_with_candidates` as dead code once their only callers were switched to call `make_method_object_with_owner` directly with the owner threaded through.
- ADR-0019 checklist and `todo/deep/adr0019-f1-f2-introspection-canonical-source.md` updated with progress.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
- [x] New pin `t/classhow-methods-package.t`, verified against real `raku` output first
- [x] `make test` — full suite green (29170 tests)
- [x] Targeted roast: `roast/S14-roles/composition.t`, `roast/S02-names/caller.t` (both touch `.package` on Method-shaped values) — pass
- [x] Manual repro of every raku ground-truth case in the PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)