### PR TITLE
docs(todo): close the OTF gate's sigilless-scalar exclusion

### DIFF
--- a/todo/tickets/otf-compilation-gate-leftovers.md
+++ b/todo/tickets/otf-compilation-gate-leftovers.md
@@ -1,23 +1,32 @@
-# OTF (module-sub on-the-fly compilation) gate — the two remaining exclusions
+# OTF (module-sub on-the-fly compilation) gate — the remaining exclusion
 
 Extracted from PLAN.md §3 (2026-08-02). The module-sub OTF gate relaxation campaign
 (#4427 → #4429 → #4431 → #4437) is complete; the gate itself is
 `def_is_otf_compilable_module_single` (`src/vm/vm_call_func_ops.rs`). The frontier of "just remove
 the gate and experiment" is exhausted — each remaining exclusion needs mechanism work first.
 
-## 1. `start` blocks — needs per-call capture cells
+**Sigilless scalar (`\x`) parameters — done.** Verified 2026-08-14: `def_is_otf_compilable_module_single`'s
+own comment now says "sigilless scalars (`\x`) are compiled-safe since ADR-0019 C6e-2a (the compiled
+return path flushes the alias chain before the caller-env merge, covering the EVAL-boundary
+writeback)". `t/sigilless-params.t` ("sigilless aliases are writable through EVAL calls") passes. No
+longer an open exclusion; removed from this ticket.
+
+## `start` blocks — needs per-call capture cells
 
 When a recursive sub's `start` closure captures a parameter, the re-bind of the recursive call
 clobbers the captured value, so `start` is excluded wholesale. Regression pin:
 `t/start-block-return-value.t` test 3. The proof of infeasibility and the history are in
-`news/2026-07.md`. The real fix is per-call capture cells — the same cell-based capture work as
-[needs-env-sync-blanket-removal.md](../deep/needs-env-sync-blanket-removal.md).
+`news/2026-07.md`. The real fix is per-call capture cells.
 
-## 2. Sigilless scalar (`\x`) parameters — needs a caller-slot mechanism
-
-Caller writeback of raw aliases across `EVAL` needs a mechanism equivalent to #4091 (the `is rw`
-compile-time caller slot). FAIL pin: `t/sigilless-params.t`, "sigilless aliases are writable through
-EVAL calls".
+**Still excluded, confirmed 2026-08-14**: `expr_needs_interpreter` (`src/vm/vm_call_func_ops.rs`, ~line
+1996) still has `name.resolve() == "start"` unconditionally forcing the interpreter fallback, with the
+comment "start blocks need the interpreter for proper thread spawning". `t/start-block-return-value.t`
+currently passes, but only via that fallback path — it does not demonstrate the OTF-compiled path is
+safe, since the gate routes it away from OTF entirely. Not re-attempted this round: this is the same
+capture-cell mechanism gap as `todo/tickets/inline-start-blocks-clobber-a-later-declared-variable.md`
+(a *different*, currently-reproducing `start`-block cross-thread env bug narrowed the same day — see
+that ticket for a live repro and root-cause leads in the current, post-ADR-0018 architecture), so the
+two should likely be picked up together rather than independently.
 
 ## Intentionally excluded (decided not to do)
 


### PR DESCRIPTION
## Summary
- `todo/tickets/otf-compilation-gate-leftovers.md` listed two remaining OTF-compilation gate exclusions. Verified 2026-08-14: the sigilless scalar (`\x`) parameter exclusion is already resolved (ADR-0019 C6e-2a/C6e-2b) — the gate's own code comment confirms it, and `t/sigilless-params.t` passes.
- Only the `start`-block exclusion remains genuinely open (`expr_needs_interpreter` still forces the interpreter fallback for it). Cross-referenced it to `todo/tickets/inline-start-blocks-clobber-a-later-declared-variable.md`, whose same-day investigation found a live, currently-reproducing bug in the same start-block capture-cell territory — the two should likely be picked up together.

Docs-only change (todo/ ledger cleanup).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>