### PR TITLE
refactor(adr0019): F3 -- verify RAW_ROWS covers every introspection name in order

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -826,10 +826,18 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   catalog that dispatch itself consumes.
   **Scoping (2026-08-14):** this box's "generated native entry catalog" target
   (`native_method_row.rs`'s `RAW_ROWS`) turns out to have drifted from the 14 arrays since its
-  2026-08-10 generation — missing an owner (`Sub`) entirely, with ~90+ extra dispatch-recognized
-  names across other owners not vetted for `.^methods` inclusion, and at least one owner
-  (`Signature`) in a different order. Not a mechanical cutover; needs its own raku-verification
-  pass first. See `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md`.
+  2026-08-10 generation — apparently missing an owner (`Sub`) entirely, with ~90+ extra
+  dispatch-recognized names across other owners not vetted for `.^methods` inclusion, and at least
+  one owner (`Signature`) in a different order. Not a mechanical cutover; needs its own
+  raku-verification pass first. See `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md`.
+  **Progress (2026-08-14, step 1):** the "`Sub` missing entirely" claim was a probe artifact (an
+  owner-folding mismatch in the ad hoc diff, not a real gap — `RAW_ROWS` already carries all 10
+  `Code`-folded rows `Sub` needs). Verified for real with a new permanent test,
+  `raw_rows_cover_every_introspection_name_in_order`: **zero missing names for all 18 owners.**
+  Fixed the two owners (`Signature`, `Any`) whose `RAW_ROWS` order genuinely diverged from their
+  introspection array (rows were scattered into unrelated hand-added blocks); order now matches for
+  all 18. The ~90+ extra dispatch-recognized names per owner (step 2's raku-verification triage) are
+  still untouched — that remains the real blocker before the actual cutover (step 3).
 - [ ] **F4 — Remove `ClassDef::methods` as a dispatch/registration mirror.** Leave type structure
   metadata beside the canonical method table and update snapshots/rollback to copy one source.
 - [ ] **F5 — Remove superseded method caches and manual invalidation.** Keep only the

--- a/news/2026-08/adr0019-f3-raw-rows-coverage-verified.md
+++ b/news/2026-08/adr0019-f3-raw-rows-coverage-verified.md
@@ -1,0 +1,29 @@
+# ADR-0019 F3 step 1: verified RAW_ROWS covers every introspection name, in order
+
+ADR-0019's Phase F box F3 ("delete the per-type method-name lists ... retain only the generated
+native entry catalog") was scoped in `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md`
+as blocked on a raku-verification pass, because an ad hoc diff claimed the target catalog
+(`native_method_row.rs`'s `RAW_ROWS`) had drifted from the 14 `builtin_type_methods.rs` name arrays
+since its 2026-08-10 generation — most alarmingly, that owner `Sub` had zero rows at all, which would
+make a naive cutover silently empty out `Sub.^methods`.
+
+Re-checked with real code instead of the earlier ad hoc grep. The "`Sub` has zero rows" claim turned
+out to be a probe-script bug: it filtered `RAW_ROWS` by the literal string `"Sub"`, but both
+`RAW_ROWS` and `builtin_method_entries` key `Sub`/`Method`/`Block`/`Routine`/`Code` under the *folded*
+owner `"Code"` (`canonical_builtin_owner`). Once folding is applied consistently on both sides, `Sub`
+already has all 10 expected rows, correctly ordered. A new permanent test,
+`raw_rows_cover_every_introspection_name_in_order` (`src/builtins/native_method_row.rs`), checks this
+for real across all 18 `BUILTIN_METHOD_OWNERS`: every introspection-array name has a matching
+`RAW_ROWS` entry, and the relative order of shared names matches. Result: **zero missing names for
+every owner** — the previous 5-owner length-only check (`native_method_rows_matches_builtin_entry_count`)
+is now a genuine, order-sensitive, 18-owner coverage guard.
+
+Two owners' order genuinely did diverge from the introspection arrays — `Signature` and `Any` — because
+their rows had been scattered into unrelated hand-added blocks by earlier E2b slices. Fixed by moving
+the misplaced rows to the position their introspection array implies (`native_method_row_table.rs`);
+no row content changed, only position.
+
+What remains open for F3: the ~90+ extra dispatch-recognized names per owner beyond what the
+introspection arrays list still need per-name raku verification (genuine `.^methods` gap vs.
+deliberately-internal/protocol method) before the actual array-deletion cutover can happen safely —
+see the todo file's updated "Progress" section.

--- a/src/builtins/native_method_row.rs
+++ b/src/builtins/native_method_row.rs
@@ -412,6 +412,47 @@ mod tests {
         }
     }
 
+    /// ADR-0019 F3 scoping (`todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md`):
+    /// every introspection-array name must have a matching `RAW_ROWS` entry
+    /// under the *folded* owner (`canonical_builtin_owner`), and among the
+    /// names the two sources share, `RAW_ROWS`'s relative order must match
+    /// the introspection array's -- a future F3 cutover that enumerates
+    /// straight from `RAW_ROWS` would otherwise silently drop or reorder
+    /// `.^methods` output. `RAW_ROWS` is allowed to carry EXTRA
+    /// dispatch-recognized names the introspection arrays omit (tracked
+    /// separately, not this test's job -- see the doc's step 2 triage).
+    #[test]
+    fn raw_rows_cover_every_introspection_name_in_order() {
+        use super::super::builtin_type_methods::BUILTIN_METHOD_OWNERS;
+        for &owner in BUILTIN_METHOD_OWNERS {
+            let folded = super::super::builtin_type_methods::canonical_builtin_owner(owner);
+            let introspection: Vec<&str> = builtin_method_entries(owner)
+                .into_iter()
+                .map(|e| e.name)
+                .collect();
+            let raw: Vec<&str> = RAW_ROWS
+                .iter()
+                .filter(|&&(o, _, _, _)| o == folded)
+                .map(|&(_, n, _, _)| n)
+                .collect();
+            for name in &introspection {
+                assert!(
+                    raw.contains(name),
+                    "{owner} (folded {folded}): introspection name {name:?} has no RAW_ROWS entry"
+                );
+            }
+            let raw_common: Vec<&str> = raw
+                .iter()
+                .filter(|n| introspection.contains(n))
+                .copied()
+                .collect();
+            assert_eq!(
+                introspection, raw_common,
+                "{owner} (folded {folded}): RAW_ROWS order of shared names diverges from the introspection array"
+            );
+        }
+    }
+
     /// The inverse probe from the design doc (decision 2): for every row that
     /// claims a pure arity bit and is not flagged `SPECIAL`/`MUTATES_RECEIVER`,
     /// actually call the corresponding cascade with a representative receiver

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -404,20 +404,6 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Blob", "read-uint16", 6, 0),
     ("Blob", "read-int16", 6, 0),
     ("Blob", "read-uint32", 6, 0),
-    // ADR-0019 E2b: universal Any/Mu methods, added by hand (not probed via
-    // `builtin_sample_value`, which has no representative sample for an
-    // abstract owner) after `dispatch_owner_coverage`'s 2026-08-10 sweep
-    // showed these dominating `native_call_unmodeled` (Str x so alone was
-    // 54% of ~38k hits) -- `dispatch_core_str::dispatch`/`dispatch_core_coerce::dispatch`
-    // recognize `so`/`not`/`defined` unconditionally for every receiver type
-    // (see the `try_dispatch!` chain in `methods_0arg/mod.rs`), so one row
-    // per name at the owner that actually declares it (`Any`) is correct and
-    // complete once the coverage check walks the MRO chain to find it (see
-    // `Interpreter::record_native_row_coverage`) rather than doing a flat
-    // point lookup at the receiver's own concrete owner.
-    ("Any", "so", 1, 0),
-    ("Any", "not", 1, 0),
-    ("Any", "defined", 1, 1),
     // `.DEFINITE` is a quoted pseudo-method (like `.WHAT`/`.HOW`/`.WHICH`),
     // deliberately excluded from `MU_METHODS`'s `.^methods` introspection
     // list since it is a compiler-level construct rather than an ordinary
@@ -603,7 +589,6 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     // `native_method_row.rs`.
     ("Any", "self", 1, 0),
     ("Any", "clone", 1, 0),
-    ("Any", "WHERE", 1, 0),
     ("Any", "WHICH", 1, 0),
     ("Any", "sink", 1, 0),
     ("Any", "item", 1, 0),
@@ -919,8 +904,6 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     //   more-specific row above -- verified against three previously-unmodeled
     //   types (`X::Method::NotFound`, `X::Str::Sprintf::Directives::Unsupported`,
     //   `X::Str::Numeric`) without adding a row for any of them individually.
-    ("Any", "gist", 1, 0),
-    ("Any", "raku", 1, 0),
     ("Any", "hash", 1, 0),
     ("Mu", "defined", 1, 0),
     ("Nil", "gist", 1, 0),
@@ -962,8 +945,6 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Duration", "Int", 1, 0),
     ("Duration", "gist", 1, 0),
     ("Duration", "raku", 1, 0),
-    ("Signature", "gist", 1, 0),
-    ("Signature", "raku", 1, 0),
     ("Backtrace", "list", 1, 0),
     ("Backtrace", "Str", 3, 0),
     ("Backtrace", "gist", 1, 0),
@@ -1239,7 +1220,22 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Any", "put", 8, 4),
     ("Any", "print", 8, 4),
     ("Any", "note", 8, 4),
+    // ADR-0019 E2b: universal Any/Mu methods, added by hand (not probed via
+    // `builtin_sample_value`, which has no representative sample for an
+    // abstract owner) after `dispatch_owner_coverage`'s 2026-08-10 sweep
+    // showed these dominating `native_call_unmodeled` (Str x so alone was
+    // 54% of ~38k hits) -- `dispatch_core_str::dispatch`/`dispatch_core_coerce::dispatch`
+    // recognize `so`/`not`/`defined` unconditionally for every receiver type
+    // (see the `try_dispatch!` chain in `methods_0arg/mod.rs`), so one row
+    // per name at the owner that actually declares it (`Any`) is correct and
+    // complete once the coverage check walks the MRO chain to find it (see
+    // `Interpreter::record_native_row_coverage`) rather than doing a flat
+    // point lookup at the receiver's own concrete owner.
+    ("Any", "so", 1, 0),
+    ("Any", "not", 1, 0),
+    ("Any", "defined", 1, 1),
     ("Any", "WHAT", 8, 4),
+    ("Any", "WHERE", 1, 0),
     ("Any", "HOW", 8, 4),
     ("Any", "WHY", 8, 4),
     ("Any", "iterator", 8, 4),
@@ -1279,6 +1275,8 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Any", "batch", 2, 0),
     ("Any", "Bool", 1, 0),
     ("Any", "Str", 2, 0),
+    ("Any", "gist", 1, 0),
+    ("Any", "raku", 1, 0),
     ("Any", "Numeric", 8, 4),
     ("Any", "Int", 8, 4),
     ("Mu", "WHAT", 8, 4),
@@ -1308,6 +1306,8 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Signature", "returns", 8, 4),
     ("Signature", "Bool", 1, 1),
     ("Signature", "Str", 2, 1),
+    ("Signature", "gist", 1, 0),
+    ("Signature", "raku", 1, 0),
     ("IO::Path", "absolute", 8, 4),
     ("IO::Path", "basename", 8, 4),
     ("IO::Path", "cleanup", 8, 4),

--- a/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
+++ b/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
@@ -96,3 +96,37 @@ Given the size of step 2 (raku-verifying ~90+ names across 18 owners), this is c
 F1's own "dedicated raku ground-truth session" than to a mechanical plumbing change. Filed here so
 the finding isn't lost; not started. Suggest treating this as its own dedicated slice/session rather
 than folding into whatever slice picks F3 up next.
+
+## Progress (2026-08-14): step 1 done, and the "`Sub` has ZERO rows" claim above was a probe artifact
+
+Ran step 1 for real instead of trusting the ad hoc diff above: added a permanent test,
+`raw_rows_cover_every_introspection_name_in_order` (`src/builtins/native_method_row.rs`), that for
+every owner in `BUILTIN_METHOD_OWNERS` (a) asserts every introspection-array name has a matching
+`RAW_ROWS` row under the *folded* owner (`canonical_builtin_owner`) and (b) asserts `RAW_ROWS`'s
+relative order of the names the two sources share matches the introspection array's order.
+
+**Finding: nothing was actually missing.** The "`Sub` has ZERO rows in `RAW_ROWS`" claim above came
+from filtering `RAW_ROWS` by the literal string `"Sub"` and comparing against
+`builtin_method_entries("Sub")` — but `builtin_method_entries` already returns `owner: "Code"` (the
+folded owner) for every `Sub`/`Method`/`Block`/`Routine`/`Code` entry, and `RAW_ROWS` already stores
+all 10 `CODE_METHODS` rows under the key `"Code"` (`name`, `signature`, `arity`, `count`, `of`,
+`returns`, `Bool`, `Str`, `gist`, `raku`) in the right order. Filtering the raw table by the
+*unfolded* `"Sub"` string and diffing that against the *folded* `builtin_method_entries("Sub")`
+output was comparing rows keyed two different ways — a bug in the ad hoc probe script, not a real
+gap. Re-running the diff with folding applied on both sides (the permanent test above) found
+**zero missing names for all 18 owners**, not just `Sub`.
+
+**Order did diverge for real, for two owners**: `Signature` (its `gist`/`raku` rows were interleaved
+into an unrelated hand-added block far from its other six rows) and `Any` (`so`/`not`/`defined`,
+`WHERE`, and `gist`/`raku` were similarly scattered into unrelated E2b hand-added blocks). Both
+fixed by moving the misplaced rows to the position their introspection array implies
+(`native_method_row_table.rs`); no row content changed, order only. The new test now passes for all
+18 owners and is a permanent regression guard (previously only 5 owners had even a length check,
+`native_method_rows_matches_builtin_entry_count`).
+
+**What step 1 does NOT resolve**: the ~90+ extra `RAW_ROWS` names per owner beyond what the
+introspection arrays list (step 2's job) are untouched by this pass — those still need per-name raku
+verification before F3 can decide "genuine `.^methods` gap" vs. "deliberately internal/protocol,
+dispatch-only" for each one. Step 1 only closes the "is `RAW_ROWS` even a safe superset, in the right
+order" question, and the answer for the *introspection-array* side is now yes, permanently enforced.
+Step 3 (the actual cutover) still needs step 2 first.


### PR DESCRIPTION
## Summary
- ADR-0019 Phase F box F3 was scoped as blocked on a raku-verification pass, with the alarming claim that `native_method_row.rs`'s `RAW_ROWS` catalog was missing owner `Sub` entirely.
- Re-verified with real code instead of the earlier ad hoc grep: that claim was a probe-script bug (it didn't apply the `Sub`→`Code` owner fold both `RAW_ROWS` and `builtin_method_entries` already use). With folding applied consistently, `Sub` already has all 10 expected rows.
- Added a permanent regression test, `raw_rows_cover_every_introspection_name_in_order`, checking all 18 `BUILTIN_METHOD_OWNERS`: every introspection-array name has a matching `RAW_ROWS` row, in the same relative order. Result: zero missing names anywhere.
- Fixed the two owners whose order genuinely diverged (`Signature`, `Any` — rows scattered into unrelated hand-added blocks by earlier E2b slices) by moving rows to the position the introspection array implies. No row content changed, only position.
- Corrected the stale finding in `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` and the ADR's F3 progress note.

The real remaining F3 blocker is unchanged: ~90+ extra dispatch-recognized names per owner beyond the introspection arrays still need per-name raku verification (genuine `.^methods` gap vs. deliberately-internal/protocol method) before the 14 arrays can actually be deleted.

## Test plan
- [x] `cargo test --lib builtins::native_method_row` (30/30 pass, including the new coverage/order test)
- [x] `make test` (2996 files, all green)
- [x] `MUTSU_FUDGE=1 prove -e scripts/run-roast-test.sh` on `S12-introspection/{can,meta-class,walk}.t`, `S12-enums/thorough.t` (introspection-sensitive roast files)
- [x] `cargo fmt` / `cargo clippy --lib -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)