### PR TITLE
fix(regex): a stored regex captures its defining scope's live bindings

### DIFF
--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -702,21 +702,21 @@ impl Compiler {
     /// The lexicals a regex literal must close over, or `None` when it is an
     /// ordinary literal that can load as a plain constant.
     ///
-    /// Only *code-bearing* patterns qualify: without an embedded `{ … }` /
-    /// `<?{ … }>` block or a `:my`/`:let` initializer there is no code whose
-    /// free variables could be stranded, and the existing match-time
-    /// interpolation path already resolves a bare `/$x/`. Names are keyed the
-    /// way `locals`/`env` key them, and paired with the creating frame's local
-    /// slot when there is one.
+    /// Any pattern with at least one resolvable interpolated name qualifies —
+    /// plain interpolation (`/$x/`, `/<$pat>/`) closes over its defining
+    /// scope's *binding* exactly like a code-bearing pattern (`{ … }`,
+    /// `<?{ … }>`, `:my`/`:let`): a stored regex re-parses its pattern on
+    /// every match, so the match-site env is the wrong place to resolve a
+    /// name once the regex has escaped the frame that built it (see
+    /// `todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md`, bug
+    /// 1). Names are keyed the way `locals`/`env` key them, and paired with
+    /// the creating frame's local slot when there is one.
     pub(super) fn regex_literal_closure_captures(&self, v: &Value) -> Option<Vec<(Symbol, u32)>> {
         let pattern = match v.view() {
             ValueView::Regex(p) => p.as_str().to_string(),
             ValueView::RegexWithAdverbs(a) => a.pattern.as_str().to_string(),
             _ => return None,
         };
-        if !pattern.contains('{') && !pattern.contains(":my ") && !pattern.contains(":let ") {
-            return None;
-        }
         let mut captures: Vec<(Symbol, u32)> = Vec::new();
         for name in crate::opcode::CompiledCode::regex_interpolated_var_names(&pattern) {
             // `$_`, `$/` and the numeric captures are match state, never a

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3642,6 +3642,20 @@ pub(crate) struct CompiledCode {
     /// call args / control blocks) non-boxed, avoiding the broad-boxing
     /// perf/correctness regression (see #2749).
     pub(crate) needs_cell_locals: Vec<Symbol>,
+    /// Own locals interpolated into a regex constant of this same frame
+    /// (`rx/ $word /`) AND mutated after the regex is constructed. A regex
+    /// literal loaded via `OpCode::LoadRegexClosure` closes over its defining
+    /// scope's *bindings*, not a value snapshot (`my $x = 1; my $re = rx/ abc
+    /// <?{ $x == 2 }> /; $x = 2; "abc" ~~ $re` must match — see
+    /// `todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md`). Only a
+    /// name in this set is boxed into a shared `ContainerRef` cell at capture
+    /// time (`capture_regex_closure`); an unmutated capture stays a cheap
+    /// by-value snapshot, since nothing can ever change it. Deliberately kept
+    /// separate from `needs_cell_locals` (closure-escape driven) and
+    /// `needs_cell_named_sub` (named-sub-write driven) — over-boxing an
+    /// unrelated same-named local through the wrong signal is the historical
+    /// bug class in this area (see the `needs_cell_locals` doc comment above).
+    pub(crate) needs_cell_regex: Vec<Symbol>,
     /// Frame lexicals that a `class`/`role` body's methods WRITE. A method is
     /// installed by `RegisterClass`/`RegisterRole` and is invoked with no
     /// closure-creation op, so the capture analysis behind
@@ -4113,6 +4127,7 @@ impl CompiledCode {
             needs_cell_escaping_our_sub_free: Vec::new(),
             captured_mutated_locals: Vec::new(),
             needs_cell_locals: Vec::new(),
+            needs_cell_regex: Vec::new(),
             type_body_written_lexicals: Vec::new(),
             thread_escaping: false,
             authoritative_free_vars: Vec::new(),
@@ -5452,6 +5467,17 @@ impl CompiledCode {
         // such a regex (e.g. `-> $r { * ~~ /<$r>/ }`) must still capture `$r`, so
         // scan every regex constant for sigil'd variable references and treat them
         // as free vars (unless this body declares them).
+        //
+        // A name that IS one of `own`'s locals is an own capture instead: the
+        // regex literal (loaded via `OpCode::LoadRegexClosure`, see
+        // `regex_literal_closure_captures`) closes over the name out of THIS
+        // frame's own locals rather than a parent's. Track those separately
+        // (`regex_captured_own`) so, once `self_mutated` is fully known below,
+        // we can compute which own regex-captured names are also mutated after
+        // the regex is constructed — those need a shared cell (bug 1 of
+        // `todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md`).
+        let mut regex_captured_own: std::collections::HashSet<Symbol> =
+            std::collections::HashSet::new();
         for c in &self.constants {
             let pattern = match c.view() {
                 ValueView::Regex(s) => Some(s.clone()),
@@ -5460,7 +5486,9 @@ impl CompiledCode {
             };
             if let Some(pattern) = pattern {
                 for name in Self::regex_interpolated_var_names(&pattern) {
-                    if !own.contains(name.as_str()) {
+                    if own.contains(name.as_str()) {
+                        regex_captured_own.insert(Symbol::intern(&name));
+                    } else {
                         free.insert(Symbol::intern(&name));
                     }
                 }
@@ -5492,6 +5520,18 @@ impl CompiledCode {
                 }
             }
         }
+        // `self_mutated` is fully known now (nothing below this point adds to
+        // it — the loops that follow only read it). An own local interpolated
+        // into one of our own regex constants AND mutated after declaration
+        // needs a shared cell so the stored regex observes later writes
+        // (raku-verified: `my $x = 1; my $re = rx/ abc <?{ $x == 2 }> /; $x =
+        // 2; "abc" ~~ $re` matches). Purely additive — does not touch `free`,
+        // `free_var_writes`, `captured_mutated`, or `needs_cell_locals`.
+        let needs_cell_regex: std::collections::HashSet<Symbol> = regex_captured_own
+            .iter()
+            .filter(|sym| self_mutated.contains(*sym))
+            .copied()
+            .collect();
         // Own locals captured by a nested closure AND mutated -> must be boxed
         // into a shared container at capture time. `captured_mutated` drives the
         // loop (path A) boxing and the VM's capture filter. `needs_cell` is the
@@ -5641,6 +5681,7 @@ impl CompiledCode {
         self.free_var_container_writes = free_container_writes.into_iter().collect();
         self.captured_mutated_locals = captured_mutated.into_iter().collect();
         self.needs_cell_locals = needs_cell.into_iter().collect();
+        self.needs_cell_regex = needs_cell_regex.into_iter().collect();
         // A self-capturing declaration only matters when the local actually gets a
         // cell — otherwise there is no cell for the declaration to preserve.
         self.self_capture_decl_locals = self_capture_decl

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3277,7 +3277,12 @@ impl Interpreter {
             && !matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Supply" || class_name == "IO::Handle" || class_name == "IO::Pipe" || class_name == "IO::CatHandle")
             && !matches!(target.view(), ValueView::Package(name) if name.resolve().starts_with("IO::Spec"))
         {
-            return self.handle_split_method(target, args);
+            // The splitter argument may be a stored regex closed over its
+            // defining scope; install it around the split the same way `~~`
+            // and `.match`/`.subst` do.
+            let splitter = args.first().cloned();
+            return self
+                .with_regex_closure_scope(splitter, |me| me.handle_split_method(target, args));
         }
 
         // .of on Array/Hash

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -240,7 +240,13 @@ impl Interpreter {
                     // Defer to native IO dispatch so file content is read first.
                     None
                 } else {
-                    self.dispatch_comb_with_args(target, &args)
+                    // The matcher argument may be a stored regex closed over
+                    // its defining scope; install it around the comb the same
+                    // way `~~`/`.match`/`.subst` do.
+                    let matcher = args.first().cloned();
+                    self.with_regex_closure_scope(matcher, |me| {
+                        me.dispatch_comb_with_args(target, &args)
+                    })
                 }
             }
             // `.IO` takes only named adverbs (`:CWD`, `:SPEC`); accept and IGNORE

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -2581,9 +2581,20 @@ impl Interpreter {
                                     // assertion; the runtime `Match` path below resolves it.
                                     RegexAtom::Named(name.clone())
                                 } else if let Some(var_name) = trimmed.strip_prefix('$') {
-                                    // <$var> — look up scalar variable and compile as regex
-                                    let value = match self.env.get(var_name).cloned() {
-                                        Some(v) => v,
+                                    // <$var> — look up scalar variable and compile as regex.
+                                    // The `${name}` fallback and `.into_deref()` mirror the
+                                    // bare-`$name` interpolation path above: a defining-scope
+                                    // capture (`LoadRegexClosure`) may have boxed a mutated
+                                    // scalar into a shared `ContainerRef` cell (bug 1 of
+                                    // `todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md`),
+                                    // which must be dereferenced before it is stringified.
+                                    let value = match self
+                                        .env
+                                        .get(var_name)
+                                        .cloned()
+                                        .or_else(|| self.env.get(&format!("${var_name}")).cloned())
+                                    {
+                                        Some(v) => v.into_deref(),
                                         None => {
                                             // Variable not declared — X::Undeclared
                                             let symbol = format!("${var_name}");

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -183,7 +183,11 @@ impl Interpreter {
                 const_idx,
                 captures,
             } => {
-                let v = self.capture_regex_closure(&code.constants[*const_idx as usize], captures);
+                let v = self.capture_regex_closure(
+                    code,
+                    &code.constants[*const_idx as usize],
+                    captures,
+                );
                 self.stack.push(v);
                 *ip += 1;
             }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -16,7 +16,7 @@ impl Interpreter {
         })
     }
 
-    /// Attach the defining scope to a code-bearing regex literal
+    /// Attach the defining scope to an interpolating regex literal
     /// (`OpCode::LoadRegexClosure`).
     ///
     /// Reads each listed name out of the creating frame — its local slot when
@@ -26,14 +26,27 @@ impl Interpreter {
     /// value is byte-equivalent to today's plain constant when nothing is
     /// captured. A capture that is already a shared `ContainerRef` cell is kept
     /// AS the cell, so later writes through it stay visible to the regex.
+    ///
+    /// A name flagged in `code.needs_cell_regex` (own, and mutated after this
+    /// regex literal is constructed — see that field's doc comment) is boxed
+    /// into a shared cell via `box_decl_local_cell` BEFORE being read, so the
+    /// captured value IS the cell: later writes to the defining frame's local
+    /// flow through it, and the stored regex observes them at match time
+    /// (raku-verified same-scope mutation semantics; bug 1 of
+    /// `todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md`).
+    /// Unmutated captures stay cheap by-value snapshots.
     pub(super) fn capture_regex_closure(
         &mut self,
+        code: &CompiledCode,
         base: &Value,
         captures: &[(Symbol, u32)],
     ) -> Value {
         let mut scope: HashMap<String, Value> = HashMap::new();
         for (sym, slot) in captures {
             let name = sym.resolve();
+            if *slot != crate::opcode::NOT_A_LOCAL && code.needs_cell_regex.contains(sym) {
+                self.box_decl_local_cell(code, *slot as usize);
+            }
             let from_local = (*slot != crate::opcode::NOT_A_LOCAL)
                 .then(|| self.locals.get(*slot as usize))
                 .flatten()

--- a/t/regex-stored-closure-scope.t
+++ b/t/regex-stored-closure-scope.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+plan 13;
+
+# --- Bug 1: a stored regex keeps its defining scope ---------------------------
+
+sub make() { my $word = 'abc'; return rx/ $word /; }
+my $r = make();
+ok ("xx abc yy" ~~ $r).defined, 'escaped regex still resolves its lexical (main repro)';
+
+sub mk($w) { my $word = $w; return rx/ $word /; }
+my $ra = mk('aaa');
+my $rb = mk('bbb');
+ok ("aaa" ~~ $ra).defined, 'first call keeps its own value';
+ok ("bbb" ~~ $rb).defined, 'second call keeps its own value';
+nok ("bbb" ~~ $ra).defined, 'calls do not share a frame (snapshot-vs-shared-frame discriminator)';
+
+my @res;
+for <one two> -> $w { @res.push: rx/ $w /; }
+ok ("one" ~~ @res[0]).defined, 'loop iteration 0 keeps its value';
+ok ("two" ~~ @res[1]).defined, 'loop iteration 1 keeps its value';
+nok ("two" ~~ @res[0]).defined, 'iterations do not share';
+
+my %h;
+sub outer { my $x = 'qq'; sub inner { return rx/ $x /; }; %h<r> = inner(); }
+outer();
+ok ("a qq b" ~~ %h<r>).defined, 'nested sub, stored in a hash, matched later';
+
+sub mk5 { my $pat = 'ab'; return rx/ <$pat> /; }
+ok ("xaby" ~~ mk5()).defined, '<$var> assertion form survives the frame';
+
+# Match-time evaluation: mutation after construction is visible (raku-verified).
+{
+    my $pat = 'abc';
+    my $re = rx/ $pat /;
+    $pat = 'zzz';
+    nok ("abc" ~~ $re).defined, 'interpolation sees the mutated value, not a snapshot (1)';
+    ok  ("zzz" ~~ $re).defined, 'interpolation sees the mutated value, not a snapshot (2)';
+}
+
+# The code-bearing capture must be a live cell, not a stale snapshot (W5/W6).
+{
+    my $x = 1;
+    my $re = rx/ abc <?{ $x == 2 }> /;
+    $x = 2;
+    ok ("abc" ~~ $re).defined, 'embedded code sees a same-scope mutation after construction';
+}
+sub mk6 { my $w = 'no'; my $r2 = rx/ abc <?{ $w eq 'yes' }> /; $w = 'yes'; return $r2; }
+ok ("abc" ~~ mk6()).defined, 'embedded code sees a mutation made before the frame died';

--- a/todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md
+++ b/todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md
@@ -3,6 +3,11 @@
 Extracted from PLAN.md §1 B4 (2026-08-02) and re-verified on `main` the same day. Originally found
 while running the (now-retired) Tubu web framework; it is a general interpreter bug on its own axis.
 
+**Status (2026-08-14): Bug 1 is SHIPPED** — see "Fix plan — bug 1 (PR 1)" below, all six steps
+implemented, `t/regex-stored-closure-scope.t` added (13 subtests, bug-1 subset), all regression
+hazards verified green. **Bug 2 (the `<$var>` capture leak) is still open** — its fix plan is
+unchanged below; a future session should pick it up as its own PR.
+
 ## Repro
 
 ```raku
@@ -143,7 +148,13 @@ Repro scripts kept the session: `tmp/rx-variants.raku`, `tmp/rx-variants2.raku`.
 
 ### Fix plan — bug 1 (PR 1): regex literals capture their defining scope as shared cells
 
-Everything reuses the `b07ee6627` machinery; no new Value variant, no new opcode.
+**Shipped 2026-08-14.** All six steps below were implemented as designed, with two small
+audit-driven additions to step 5 (`.split`/`.comb`, found to be actual stored-regex entry points;
+`s///`/`TR///` were audited and confirmed to need no change — their pattern is always compiled
+inline via `OpCode::Subst`/`Transliterate` with the literal pattern text baked into the frame that
+executes it, never as a `Value::RegexCaptured` that could escape, so they structurally cannot reach
+`install_regex_closure_scope`). Everything reuses the `b07ee6627` machinery; no new Value variant,
+no new opcode.
 
 1. **Widen the compiler trigger** — `src/compiler/expr_helpers.rs:717`: delete the code-bearing
    gate (`if !pattern.contains('{') && … return None;`). Any pattern whose


### PR DESCRIPTION
## Summary

- A regex literal that interpolates a lexical (`/ $word /`, `/<$pat>/`) is a closure over the scope it was written in, but the compiler only routed *code-bearing* patterns (`{ ... }`, `<?{ ... }>`, `:my`/`:let`) through `LoadRegexClosure`. A plain interpolating pattern compiled to a bare constant, so a regex returned from a sub (`sub make() { my $word = 'abc'; return rx/ $word /; }`) lost `$word` once the defining frame was gone — and even a same-frame code-bearing regex read a stale by-value snapshot instead of the live binding after a later mutation.
- Widen the compiler trigger (`regex_literal_closure_captures()`) to cover any pattern with a resolvable interpolated name, and box only the *mutated* own-captures into a shared `ContainerRef` cell at capture time (`CompiledCode::needs_cell_regex`, computed alongside the existing `needs_cell_locals` free-var analysis, purely additive — does not touch `free`/`captured_mutated`/`needs_cell_locals`). Unmutated captures stay cheap by-value snapshots.
- The `<$var>` assertion's variable lookup now derefs a captured cell and gets the same `${name}` env fallback the bare-`$name` interpolation path already has.
- Audited every other entry point where a *stored* regex value can reach a match and wrapped `.split`/`.comb` with `with_regex_closure_scope` (both can take a Regex-valued matcher argument) — `~~`/`.match`/`.subst` were already wrapped. `s///`/`TR///` were audited and confirmed to need no change: their pattern is always compiled inline via `OpCode::Subst`/`Transliterate` with the literal text baked into the executing frame, so they never carry an escaping `Value::RegexCaptured`.

This is bug 1 of a two-bug ticket (`todo/tickets/stored-regex-loses-its-defining-scope-lexicals.md`); bug 2 (a `<$var>` assertion leaking its inner regex's captures into the outer match — a disjoint root cause in the tokenizer) is left for a follow-up PR. The ticket is updated in this PR to mark bug 1 shipped.

## Test plan

- [x] New `t/regex-stored-closure-scope.t` (13 subtests) — verified byte-identical against real `raku`.
- [x] Regression-hazard tests all green: `t/regex-literal-is-a-closure.t`, `t/gate-b-regex-interp-env-sync.t`, `t/regex-array-var-lookahead.t`, `t/match-subst-named-regex-arg.t`, `t/regex-alias-subrule-captures.t`.
- [x] Roast spot-checks (`MUTSU_FUDGE=1 prove -e target/debug/mutsu`): `roast/S05-interpolation/regex-in-variable.t`, `roast/S05-interpolation/lexicals.t`, `roast/S05-capture/subrule.t`, `roast/S05-metasyntax/regex.t`, `roast/S05-capture/caps.t` — all pass.
- [x] `cargo fmt`, `RUSTUP_TOOLCHAIN=1.96.1 cargo clippy -- -D warnings` clean.
- [x] Full `make test`: 29201 tests, all passing.
- [ ] CI (`make test` + `make roast`, including `gc-stress`) — watching in background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)