### PR TITLE
refactor(adr0019): F5 -- generation-guard private_zeroarg_method_cache at its read site

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -853,11 +853,29 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   clear block at all 7 non-generation-gated sites (module load/import/no/need, block-scope exit,
   sub registration, class/role/enum registration) is now one shared
   `Interpreter::invalidate_method_dispatch_caches()` (`src/vm/vm_dispatch_cache_invalidate.rs`).
-  This is pure dedup, not the generation migration: `func_multi_resolve_cache`/
-  `func_multi_type_cacheable` (plain multi *sub* dispatch, read by `resolve_function_multi_cached`)
-  have no generation guard at their read site, so the eager clears stay load-bearing. The
-  remaining work — extending the generation scheme to cover that pair (and everything else this
-  box lists) so the eager calls can be deleted rather than merely deduplicated — is still open.
+  This is pure dedup, not the generation migration.
+  **Progress (#6425):** `func_multi_resolve_cache`/`func_multi_type_cacheable` (plain multi *sub*
+  dispatch, read by `resolve_function_multi_cached`) are now generation-guarded at their own read
+  site (`refresh_func_multi_caches_for_generation`, keyed on `fn_resolve_gen`, mirroring
+  `refresh_method_caches_for_generation`) — closing a real staleness gap the eager clear alone did
+  not cover (`fn_resolve_gen` is bumped at ~15 sub/multi-registration sites that never called
+  `invalidate_method_dispatch_caches`). Their `.clear()` calls in that function are now redundant
+  for correctness and kept only to drop the maps' allocated capacity promptly.
+  **Progress:** `private_zeroarg_method_cache` now also refreshes at its own read site
+  (`resolve_private_method_any_owner`, via the existing `refresh_method_caches_for_generation`,
+  keyed on `Registry::method_generation` — the same one `#[6420]`'s `.wrap`/`.is_dispatcher` work and
+  the class/role/augment registration paths already bump). This closed a real gap: only one of the
+  five call sites that read the cache (`resolve_private_method_for_vm`) went through the refreshing
+  entry point; the other four (`methods_call_dispatch.rs`, `methods_signature_shaped.rs`,
+  `methods_instance_ops.rs` ×2) called `resolve_private_method_any_owner` directly and depended
+  entirely on the nine eager `clear_private_zeroarg_method_cache()` call sites, same generation-blind
+  shape the `func_multi_*` pair had before #6425. Those nine eager clears are now redundant for
+  correctness (kept only to drop the map's capacity promptly, same as `func_multi_*`).
+  **Still open:** the second generation scheme `fn_resolve_cache_gen` (`accessors_misc.rs`) has not
+  been unified with `Registry::method_generation`/`fn_resolve_gen`; `method_resolve_cache`/
+  `fast_method_cache`/`native_ctor_plan_cache` remain eager-cleared at
+  `invalidate_method_dispatch_caches`'s 7 call sites (not yet audited as safe to drop, per that
+  function's own doc comment).
 - [ ] **F6 — Delete compatibility call carriers and dead resolver modules.** Remove the
   `run_instance_method` family — three live functions plus two resolved-path helpers in
   `class_dispatch.rs` and the `vm_run_instance_method` carrier, ~700 lines with ~40 references —

--- a/news/2026-08/adr0019-f5-private-zeroarg-cache-generation.md
+++ b/news/2026-08/adr0019-f5-private-zeroarg-cache-generation.md
@@ -1,0 +1,33 @@
+# ADR-0019 F5: private_zeroarg_method_cache gains a read-site generation refresh
+
+ADR-0019 Phase F box F5 ("remove superseded method caches and manual invalidation") listed
+`private_zeroarg_method_cache` as one of the caches still depending entirely on hand-written eager
+clear calls rather than the shared generation scheme, the same shape `func_multi_resolve_cache`/
+`func_multi_type_cacheable` had before #6425 added `refresh_func_multi_caches_for_generation`.
+
+Checked whether the same gap was real here. `resolve_private_method_for_vm` — one of five call sites
+that end up reading `private_zeroarg_method_cache` via `resolve_private_method_any_owner` — already
+called `refresh_method_caches_for_generation()` before the read. The other four
+(`methods_call_dispatch.rs`, `methods_signature_shaped.rs`, `methods_instance_ops.rs` ×2) call
+`resolve_private_method_any_owner` directly and skipped that refresh entirely, relying only on the
+nine `clear_private_zeroarg_method_cache()` calls scattered across class/role/augment registration —
+a real generation-blind gap for those four call sites, not just a cosmetic one.
+
+Fixed by moving the refresh into `resolve_private_method_any_owner` itself
+(`src/runtime/resolution_private_method.rs`), the function that actually owns the cache read, so
+every caller gets it regardless of which entry point they came through. `Registry::method_generation`
+is already bumped by every one of the nine class/role/augment registration paths that used to call
+`clear_private_zeroarg_method_cache()` by hand (the same generation Phase B/E1a's write side already
+maintains), so no new generation-bumping code was needed — those nine calls are now redundant for
+correctness and kept only to drop the cache's capacity promptly, the same tradeoff `func_multi_*`
+made in #6425.
+
+`make test` (3157 files) green; targeted private-method tests
+(`t/private-method-call-in-closure.t`, `t/private-method-compiled-dispatch.t`,
+`t/private-method-unqualified.t`, `t/role-public-private-same-name-method.t`,
+`t/mixin-private-method-self-dispatch.t`) pass.
+
+What's still open in F5: the second generation scheme `fn_resolve_cache_gen`
+(`accessors_misc.rs`) has not been unified with `Registry::method_generation`/`fn_resolve_gen`, and
+`method_resolve_cache`/`fast_method_cache`/`native_ctor_plan_cache` remain eager-cleared at
+`invalidate_method_dispatch_caches`'s 7 call sites.

--- a/src/runtime/resolution_private_method.rs
+++ b/src/runtime/resolution_private_method.rs
@@ -55,6 +55,16 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
     ) -> Option<(String, MethodDef)> {
+        // ADR-0019 Phase F box F5: refresh here, at the cache's own read site,
+        // rather than relying on every caller to have gone through
+        // `resolve_private_method_for_vm` first -- `methods_call_dispatch.rs`,
+        // `methods_signature_shaped.rs`, and `methods_instance_ops.rs` (two
+        // sites) all call this function directly and previously depended
+        // entirely on the eager `clear_private_zeroarg_method_cache()` calls at
+        // class/role/augment registration sites, the same generation-blind gap
+        // `func_multi_resolve_cache` had (#6425) before it gained its own
+        // read-site refresh.
+        self.refresh_method_caches_for_generation();
         let role_bindings = self.registry().get_role_param_bindings(class_name);
         if arg_values.is_empty()
             && let Some(cached) = self


### PR DESCRIPTION
## Summary
- ADR-0019 Phase F box F5 lists `private_zeroarg_method_cache` as a cache still depending entirely on hand-written eager clears (nine call sites) rather than the shared generation scheme -- the same shape `func_multi_resolve_cache`/`func_multi_type_cacheable` had before #6425.
- Confirmed the gap is real: only 1 of 5 call sites that read this cache (`resolve_private_method_for_vm`) went through the refreshing entry point (`refresh_method_caches_for_generation`); 4 others (`methods_call_dispatch.rs`, `methods_signature_shaped.rs`, `methods_instance_ops.rs` x2) call `resolve_private_method_any_owner` directly and bypassed it.
- Fixed by moving the refresh into `resolve_private_method_any_owner` itself, so every caller gets it regardless of entry point. No new generation-bumping code needed -- `Registry::method_generation` is already bumped by all nine class/role/augment registration paths that used to call `clear_private_zeroarg_method_cache()` by hand.

## Test plan
- [x] `cargo build`, `cargo fmt`, `cargo clippy --lib -- -D warnings`
- [x] `make test` (3157 files, all green)
- [x] Targeted private-method tests: `t/private-method-call-in-closure.t`, `t/private-method-compiled-dispatch.t`, `t/private-method-unqualified.t`, `t/role-public-private-same-name-method.t`, `t/mixin-private-method-self-dispatch.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)