### PR TITLE
refactor(adr0019): F5 -- native_ctor_plan_cache self-refreshes on method_generation

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -885,6 +885,25 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   pairs above, unifying these needs auditing whether `Registry::method_generation` is actually
   bumped at all 7 of those sites (some, e.g. plain sub/module registration, are function-registry
   events that may not touch the method registry), not just adding a read-site refresh call.
+  **Progress:** `method_resolve_cache`/`fast_method_cache` already called
+  `refresh_method_caches_for_generation()` at their own read sites (`resolve_method_cached`,
+  `try_compiled_method_or_interpret_inner`'s fast-cache probe) — only `native_ctor_plan_cache`'s
+  read site (`native_ctor_plan`, `methods_object.rs`) was missing it, the same gap
+  `private_zeroarg_method_cache` had before #6420-adjacent work. Fixed: `native_ctor_plan` now
+  self-refreshes on `Registry::method_generation` first, same as the other two. This closes one
+  concrete staleness path (a `Registry::method_generation` bump — e.g. `.^add_method`'s
+  `sync_user_method_entries` — reaching `native_ctor_plan_cache` even at a call site with no
+  explicit `.clear()` of that cache) without yet answering the still-open audit question above:
+  the 7 `invalidate_method_dispatch_caches` call sites were separately traced by hand — module
+  load/import/no/need (`vm_module_ops.rs`) and class/role/enum registration
+  (`vm_typedecl_ops.rs:116`) plausibly reach `sync_user_method_entries` transitively for any
+  class/method content they carry, but plain `sub` registration (`vm_register_sub_ops.rs:316`) and
+  block-scope-exit routine-registry restore (`accessors_misc.rs:351`) confirmed do **not** bump
+  `Registry::method_generation` — and the latter is a genuine case where the eager clear is load
+  -bearing today (it restores `token_defs`, and grammar `token`/`rule` bodies are methods, so a
+  block-scoped grammar's token set changing must invalidate method caches, but nothing in that
+  restore path touches `Registry::method_generation`). The 7 eager clears therefore stay; only the
+  read-site gap closed above was safe to land without a wider generation-bump audit.
 - [ ] **F6 — Delete compatibility call carriers and dead resolver modules.** Remove the
   `run_instance_method` family — three live functions plus two resolved-path helpers in
   `class_dispatch.rs` and the `vm_run_instance_method` carrier, ~700 lines with ~40 references —

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -261,11 +261,19 @@ impl Interpreter {
     /// pure functions of the registry's class shape, yet they were re-derived
     /// (with Vec/HashMap clones and multiple MRO walks) on EVERY construction.
     /// The cache is invalidated with the method-dispatch caches at every
-    /// registry/type mutation site plus the MOP class-shape mutators.
+    /// registry/type mutation site plus the MOP class-shape mutators, and (ADR-0019
+    /// F5) also self-refreshes here on `Registry::method_generation` — mirroring
+    /// `resolve_method_cached`/`try_compiled_method_or_interpret_inner`'s own
+    /// `refresh_method_caches_for_generation()` call, which this read site lacked.
+    /// Without it, a `Registry::method_generation` bump (e.g. `sync_user_method_entries`
+    /// from `.^add_method`) that is not paired with an explicit
+    /// `native_ctor_plan_cache.clear()` at its call site could serve a plan computed
+    /// from the class's pre-mutation shape.
     pub(crate) fn native_ctor_plan(
         &mut self,
         class_name: Symbol,
     ) -> std::sync::Arc<super::NativeCtorPlan> {
+        self.refresh_method_caches_for_generation();
         if let Some(plan) = self.native_ctor_plan_cache.get(&class_name) {
             return plan.clone();
         }


### PR DESCRIPTION
## Summary
- ADR-0019 Phase F box F5 ("Remove superseded method caches and manual invalidation"): `method_resolve_cache`/`fast_method_cache` already called `refresh_method_caches_for_generation()` at their own read sites; `native_ctor_plan_cache`'s read site (`native_ctor_plan`) was missing it -- the same gap `private_zeroarg_method_cache` had before it was closed.
- Fixed: `native_ctor_plan` now self-refreshes on `Registry::method_generation` first, closing a real staleness path (a generation bump not paired with an explicit `.clear()` of this specific cache at its call site).
- Traced (but did not resolve) the box's remaining open audit question: whether `Registry::method_generation` is bumped at all 7 `invalidate_method_dispatch_caches` call sites. Confirmed plain `sub` registration and block-scope-exit routine-registry restore do not bump it, and the latter is load-bearing today (grammar `token`/`rule` bodies are methods), so those 7 eager clears stay for now.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] `make test` (full local suite, clean)
- [x] `MUTSU_FUDGE=1 MUTSU_BIN=target/release/mutsu prove -e 'scripts/run-roast-test.sh' roast/S12-class/*.t roast/S14-roles/*.t roast/S06-signature/*.t` -- one pre-existing, non-whitelisted failure (`open_closed.t` test 7) confirmed present on `main` too (verified via `git stash`), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)