### PR TITLE
feat(adr0019): F5 -- shadow-check class registration's generation bump

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -924,6 +924,16 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   out of scope for this specific box regardless). Removing the line is deliberately deferred to a
   dedicated shadow-check slice rather than done on trace evidence alone. `vm_module_ops.rs`'s four
   sites (module load/import/no/need) remain fully untraced.
+  **Progress (shadow-check landed):** `exec_register_class_op` now runs the actual verification
+  the trace above called for, `MUTSU_VM_STATS`-gated and zero behavior change: it snapshots
+  `Registry::method_generation` before the eager `invalidate_method_dispatch_caches()` call and
+  again right after a successful `register_class_decl` returns, and records a mismatch (via
+  `record_class_reg_gen_shadow_check`, mirroring `record_deferral_shadow_check`) whenever the
+  generation did *not* advance. The eager clear itself is untouched — this only measures whether
+  it would have been safe to remove. A `t/*.t` sweep (`MUTSU_VM_STATS=1` per file, debug build)
+  is the next step to accumulate corpus evidence before cutover; see the counter's doc comment
+  in `src/vm/vm_stats.rs` for the one known-benign mismatch shape (the `is_stub_body` re-declare
+  no-op).
 - [ ] **F6 — Delete compatibility call carriers and dead resolver modules.** Remove the
   `run_instance_method` family — three live functions plus two resolved-path helpers in
   `class_dispatch.rs` and the `vm_run_instance_method` carrier, ~700 lines with ~40 references —

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -613,6 +613,47 @@ pub(crate) fn record_deferral_shadow_check(matched: bool, detail: impl FnOnce() 
     }
 }
 
+// ADR-0019 Phase F box F5 (`vm_typedecl_ops.rs`'s `exec_register_class_op`):
+// shadow check for the claim documented in the ADR's F5 progress notes --
+// that the preemptive `invalidate_method_dispatch_caches()` call at class
+// registration is redundant because every live path through
+// `register_class_decl` that actually changes the class unconditionally
+// bumps `Registry::method_generation` via `sync_user_method_entries` before
+// the opcode returns (so the three read-site-refreshed caches would pick up
+// the change on their own). Compares `method_generation` before/after a
+// successful `register_class_decl` call; `matched` is `gen_after !=
+// gen_before`. A mismatch is *expected and benign* for the one traced no-op
+// path (`is_stub_body` re-declaring an already-non-stub class, which returns
+// `Ok(Vec::new())` with the class left completely unchanged) -- the by-key
+// detail lets a real corpus run confirm every mismatch is that case before
+// cutover. Nothing reads this counter to make a dispatch decision: shadow-
+// only, zero behavior change. See
+// `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` box F5.
+static CLASS_REG_GEN_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static CLASS_REG_GEN_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn class_reg_gen_shadow_mismatch_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one F5 class-registration generation-bump shadow comparison.
+/// `detail` is only evaluated on a mismatch, mirroring
+/// [`record_deferral_shadow_check`].
+#[inline]
+pub(crate) fn record_class_reg_gen_shadow_check(matched: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    CLASS_REG_GEN_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        CLASS_REG_GEN_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = class_reg_gen_shadow_mismatch_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1139,6 +1180,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e8a deferral-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let class_reg_gen_shadow_checks = CLASS_REG_GEN_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let class_reg_gen_shadow_mismatches = CLASS_REG_GEN_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-f5: class_reg_gen_shadow_checks={class_reg_gen_shadow_checks} class_reg_gen_shadow_mismatches={class_reg_gen_shadow_mismatches}"
+    );
+    if let Ok(map) = class_reg_gen_shadow_mismatch_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-f5 class-reg-gen-shadow mismatches (top {}): {}",
             top.len(),
             top.join(" ")
         );

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -114,6 +114,9 @@ impl Interpreter {
         // the new one. (The multi-resolution cache made this observable:
         // S12-methods/multi.t reuses `my class A`/`B` with multi submethods.)
         self.invalidate_method_dispatch_caches();
+        // ADR-0019 Phase F box F5 shadow check: see
+        // `record_class_reg_gen_shadow_check`'s doc comment.
+        let f5_gen_before = self.registry().method_generation;
         if let Some(crate::opcode::CompiledClassDeclPlan {
             name,
             name_chunk,
@@ -274,6 +277,18 @@ impl Interpreter {
                     },
                 )
             )?;
+            // ADR-0019 Phase F box F5 shadow check: confirm this successful
+            // registration bumped `Registry::method_generation` (see
+            // `record_class_reg_gen_shadow_check`'s doc comment). Shadow-only
+            // -- does not affect the eager `invalidate_method_dispatch_caches()`
+            // call above.
+            {
+                let f5_gen_after = self.registry().method_generation;
+                crate::vm::vm_stats::record_class_reg_gen_shadow_check(
+                    f5_gen_after != f5_gen_before,
+                    || format!("class={qualified_name} is_stub={is_stub}"),
+                );
+            }
             // Check for assignment to native read-only params before
             // compiling (X::Assignment::RO::Comp).
             if let Some(err) = self.check_class_native_readonly_param_errors(&storage_name) {


### PR DESCRIPTION
## Summary
- Adds a `MUTSU_VM_STATS`-gated, zero-behavior-change shadow check inside `exec_register_class_op` (`src/vm/vm_typedecl_ops.rs`): compares `Registry::method_generation` before the eager `invalidate_method_dispatch_caches()` call and after a successful `register_class_decl`, recording a mismatch when the generation did not advance.
- This is the "dedicated shadow-check slice" ADR-0019's Phase F box F5 progress notes said was needed before removing that preemptive clear on trace evidence alone (docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md).
- Follows the established E7/E8a shadow-check-then-cutover pattern (`record_deferral_shadow_check` etc. in `src/vm/vm_stats.rs`).
- Pure instrumentation: the eager clear itself is untouched, so this cannot change interpreter behavior. Verified manually with `MUTSU_VM_STATS=1` against a small repro (class inheritance, lexical `my class` redeclaration in a loop) -- 6 checks, 0 mismatches.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `target/debug/mutsu t/class.t`
- [x] `MUTSU_FUDGE=1 target/debug/mutsu roast/S12-methods/multi.t`
- [ ] CI: `make test` + `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)