### PR TITLE
refactor(adr0019): F5 -- cut over class registration's eager cache clear

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -930,7 +930,7 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   again right after a successful `register_class_decl` returns, and recorded a mismatch (via
   `record_class_reg_gen_shadow_check`, mirroring `record_deferral_shadow_check`) whenever the
   generation did *not* advance.
-  **Progress (corpus evidence + cutover, #6449):** a `MUTSU_VM_STATS=1` sweep of the full `t/`
+  **Progress (corpus evidence + cutover, #6452):** a `MUTSU_VM_STATS=1` sweep of the full `t/`
   suite (debug build, one process per file) recorded 1296 shadow checks with exactly **1**
   mismatch (`t/eval-private-and-stubs.t`, `class=Base is_stub=true`); a second sweep over the
   class/role/multi-heavy roast whitelist subset (`S12-*`, `S14-*`, `S06-multi`, `S02-types`,

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -924,16 +924,28 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   out of scope for this specific box regardless). Removing the line is deliberately deferred to a
   dedicated shadow-check slice rather than done on trace evidence alone. `vm_module_ops.rs`'s four
   sites (module load/import/no/need) remain fully untraced.
-  **Progress (shadow-check landed):** `exec_register_class_op` now runs the actual verification
-  the trace above called for, `MUTSU_VM_STATS`-gated and zero behavior change: it snapshots
+  **Progress (shadow-check landed, #6448):** `exec_register_class_op` ran the actual verification
+  the trace above called for, `MUTSU_VM_STATS`-gated and zero behavior change: it snapshotted
   `Registry::method_generation` before the eager `invalidate_method_dispatch_caches()` call and
-  again right after a successful `register_class_decl` returns, and records a mismatch (via
+  again right after a successful `register_class_decl` returns, and recorded a mismatch (via
   `record_class_reg_gen_shadow_check`, mirroring `record_deferral_shadow_check`) whenever the
-  generation did *not* advance. The eager clear itself is untouched — this only measures whether
-  it would have been safe to remove. A `t/*.t` sweep (`MUTSU_VM_STATS=1` per file, debug build)
-  is the next step to accumulate corpus evidence before cutover; see the counter's doc comment
-  in `src/vm/vm_stats.rs` for the one known-benign mismatch shape (the `is_stub_body` re-declare
-  no-op).
+  generation did *not* advance.
+  **Progress (corpus evidence + cutover, #6449):** a `MUTSU_VM_STATS=1` sweep of the full `t/`
+  suite (debug build, one process per file) recorded 1296 shadow checks with exactly **1**
+  mismatch (`t/eval-private-and-stubs.t`, `class=Base is_stub=true`); a second sweep over the
+  class/role/multi-heavy roast whitelist subset (`S12-*`, `S14-*`, `S06-multi`, `S02-types`,
+  `S04-declarations`) recorded **5** mismatches, all `is_stub=true`. Every mismatch across both
+  sweeps was the one known-benign shape traced above (a stub re-declaring an already-non-stub
+  class of the same name — a true no-op, so no invalidation was needed for it either). With that
+  corpus evidence in hand, the eager `invalidate_method_dispatch_caches()` call at
+  `vm_typedecl_ops.rs:116` is removed for the class-registration path (`exec_register_class_op`
+  only — role/enum registration and `vm_module_ops.rs`'s four module sites are untouched and
+  still out of scope per the trace above). The shadow check itself is kept in place as a
+  standing regression guard (same pattern as other ADR-0019 boxes' post-cutover assertions):
+  it still fires on every class registration under `MUTSU_VM_STATS=1` and would flag any future
+  change that lets a real class mutation through without bumping the generation.
+  **Still open:** `vm_module_ops.rs`'s four sites (module load/import/no/need) remain fully
+  untraced and are a separate future slice.
 - [ ] **F6 — Delete compatibility call carriers and dead resolver modules.** Remove the
   `run_instance_method` family — three live functions plus two resolved-path helpers in
   `class_dispatch.rs` and the `vm_run_instance_method` carrier, ~700 lines with ~40 references —

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -108,14 +108,30 @@ impl Interpreter {
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
         // Registering a class can shadow a same-named earlier class (`my class A`
-        // in a fresh lexical scope) with different method bodies/candidates, so the
-        // method-resolution caches — keyed on the class NAME symbol — must be
-        // invalidated, or a cached resolution from the old class would be reused for
-        // the new one. (The multi-resolution cache made this observable:
-        // S12-methods/multi.t reuses `my class A`/`B` with multi submethods.)
-        self.invalidate_method_dispatch_caches();
-        // ADR-0019 Phase F box F5 shadow check: see
-        // `record_class_reg_gen_shadow_check`'s doc comment.
+        // in a fresh lexical scope) with different method bodies/candidates, so a
+        // cached resolution from the old class must not be reused for the new one.
+        // (The multi-resolution cache made this observable: S12-methods/multi.t
+        // reuses `my class A`/`B` with multi submethods.) This USED to be enforced
+        // by a preemptive `invalidate_method_dispatch_caches()` call right here,
+        // before `register_class_decl` ran. ADR-0019 Phase F box F5 cutover: that
+        // eager clear is redundant and removed. Every live path through
+        // `register_class_decl` that actually changes the class calls
+        // `sync_user_method_entries` unconditionally, which bumps
+        // `Registry::method_generation`; every cache the eager clear used to clear
+        // (`method_resolve_cache`/`fast_method_cache`/`native_ctor_plan_cache`/
+        // `multi_resolve_cache`/`multi_type_cacheable`/`resolved_seq_cache`/
+        // `dispatch_multi_candidate`/the private-zeroarg cache) already
+        // self-refreshes at its own read site keyed on that same generation
+        // (`refresh_method_caches_for_generation`), so by the time any of them is
+        // read again the new class's generation has already superseded the old
+        // one. The one path that does NOT bump the generation is a true no-op (a
+        // stub re-declaring an already-non-stub class of the same name, which
+        // leaves the class completely unchanged) and needs no invalidation either.
+        // Verified via the `MUTSU_VM_STATS`-gated shadow check below across the
+        // full `t/` suite (1296 checks, 1 mismatch) and a class/role/multi-heavy
+        // roast whitelist subset (5 mismatches): every mismatch was exactly that
+        // no-op shape. See the box's progress notes in
+        // `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`.
         let f5_gen_before = self.registry().method_generation;
         if let Some(crate::opcode::CompiledClassDeclPlan {
             name,


### PR DESCRIPTION
## Summary
- Removes the preemptive `invalidate_method_dispatch_caches()` call in `exec_register_class_op` (`src/vm/vm_typedecl_ops.rs`).
- Follow-up to #6448's shadow check. Corpus evidence: a full `t/` sweep (`MUTSU_VM_STATS=1`, debug build) recorded 1296 `class_reg_gen_shadow_checks` with exactly 1 mismatch, and a class/role/multi-heavy roast whitelist subset (`S12-*`/`S14-*`/`S06-multi`/`S02-types`/`S04-declarations`) recorded 5 mismatches -- **every single mismatch across both sweeps** was the one known-benign shape: a stub re-declaring an already-non-stub class of the same name (`is_stub=true`), which is a true no-op that changes nothing and therefore needs no invalidation either way.
- Every cache the eager clear used to touch (`method_resolve_cache`/`fast_method_cache`/`native_ctor_plan_cache`/`multi_resolve_cache`/`multi_type_cacheable`/`resolved_seq_cache`/`dispatch_multi_candidate`/the private-zeroarg cache) already self-refreshes at its own read site (`refresh_method_caches_for_generation`) keyed on the same `Registry::method_generation` that every live `register_class_decl` path bumps unconditionally via `sync_user_method_entries`.
- Scope: `exec_register_class_op` only. Role/enum registration (which don't call `invalidate_method_dispatch_caches` at all) and `vm_module_ops.rs`'s four module-load sites are untouched and remain a separate future slice.
- The `MUTSU_VM_STATS`-gated shadow check from #6448 is kept in place as a standing regression guard.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `target/debug/mutsu t/class.t`, `roast/S12-methods/multi.t`, `roast/S12-class/stubs.t`, `t/eval-private-and-stubs.t`
- [x] `make test` (3161 files, 29226 tests, all pass)
- [ ] CI: `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)