### PR TITLE
refactor(adr0019): F5 -- cut over module-op and sub-registration eager cache clears

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -944,8 +944,26 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   standing regression guard (same pattern as other ADR-0019 boxes' post-cutover assertions):
   it still fires on every class registration under `MUTSU_VM_STATS=1` and would flag any future
   change that lets a real class mutation through without bumping the generation.
-  **Still open:** `vm_module_ops.rs`'s four sites (module load/import/no/need) remain fully
-  untraced and are a separate future slice.
+  **Progress (`vm_module_ops.rs` shadow-check + cutover):** the four module-op sites left
+  untraced above (`exec_use_module_op`/`exec_import_module_op`/`exec_no_module_op`/
+  `exec_need_module_op`) got the same shadow-check-then-cutover treatment. Reasoning: a module
+  load can install classes and subs, but each installation already invalidates dispatch caches at
+  its OWN registration site regardless of the outer module op -- `exec_register_class_op` bumps
+  `Registry::method_generation` unconditionally on every real change (established above), and
+  `exec_register_sub_op` (`vm_register_sub_ops.rs:316`) calls `invalidate_method_dispatch_caches()`
+  itself, including its unconditional `fn_resolve_gen` bump, on every actual install (skipped only
+  for an idempotent re-registration of an already-installed identical sub -- confirmed by reading
+  `SubRegisterOutcome::Installed` gating). So the module-op's own eager call was a second,
+  redundant layer on top of per-declaration invalidation already happening deeper in the same call
+  stack. A `MUTSU_VM_STATS`-gated shadow check (mirroring `record_class_reg_gen_shadow_check`)
+  confirmed this: a full `t/` suite sweep (debug, one process per file) recorded 4049 checks with
+  164 generation bumps, and a roast-whitelist sweep (release) recorded 2479 checks with 89 bumps --
+  every bump traced to a `use`/`need` of a module that genuinely installs a class (e.g.
+  `OO::Monitors`, `Cro::*`, `URI::DefaultPort`), and `import`/`no` (exercised in 6+9 and 2 files
+  respectively across both corpora) never bumped, consistent with those ops not re-running a
+  module's class declarations. With that evidence, the eager `invalidate_method_dispatch_caches()`
+  call is removed from all four sites; the shadow check remains as a standing regression guard.
+  `make test` (3164 files, all green) and `make roast` confirm no behavior change.
 - [ ] **F6 — Delete compatibility call carriers and dead resolver modules.** Remove the
   `run_instance_method` family — three live functions plus two resolved-path helpers in
   `class_dispatch.rs` and the `vm_run_instance_method` carrier, ~700 lines with ~40 references —

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -964,6 +964,26 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   module's class declarations. With that evidence, the eager `invalidate_method_dispatch_caches()`
   call is removed from all four sites; the shadow check remains as a standing regression guard.
   `make test` (3164 files, all green) and `make roast` confirm no behavior change.
+  **Progress (`exec_register_sub_op` cutover):** the remaining audited-but-unresolved call site,
+  `vm_register_sub_ops.rs:316` (plain `sub` installation), is also cut over -- by construction, not
+  by corpus sampling. Its eager `invalidate_method_dispatch_caches()` clears two disjoint cache
+  families: the *function*-namespace ones (`func_multi_resolve_cache`/`func_multi_type_cacheable`
+  and the light/otf/multi-candidates call caches), all guarded by `fn_resolve_gen`; and the
+  *method*-namespace ones (`method_resolve_cache`/`fast_method_cache`/`native_ctor_plan_cache`/
+  `multi_resolve_cache`/`multi_type_cacheable`/`resolved_seq_cache`/`dispatch_multi_candidate`),
+  all keyed on `(owner type, method name)`. A bare `sub` is never a method-table entry under any
+  key those caches use -- `register_compiled_sub_decl` is called only from this site and
+  `run_prelude.rs`'s prelude-sub bootstrap, never from method/class registration -- so it can never
+  make a method-namespace cache stale, unlike a class/method declaration. Direct precedent: the
+  fast re-install path just above this call (the `prepared_fn_defs` branch, for a `my sub`
+  re-entering its declaring block) already only bumps `fn_resolve_gen` for the identical "install a
+  sub" event, with no method-cache clear at all. The call is replaced with a bare `fn_resolve_gen +=
+  1`. `make test` (3164 files, all green) and `make roast` (1436 files, all green) confirm no
+  behavior change.
+  **Still open:** `accessors_misc.rs:351` (block-scope-exit routine-registry restore) stays --
+  traced and confirmed load-bearing earlier in this box (restores `token_defs`, which changes a
+  block-scoped grammar's method set without bumping `Registry::method_generation`). With the module
+  and sub sites now closed, this is F5's only remaining eager-clear call site.
 - [ ] **F6 — Delete compatibility call carriers and dead resolver modules.** Remove the
   `run_instance_method` family — three live functions plus two resolved-path helpers in
   `class_dispatch.rs` and the `vm_run_instance_method` carrier, ~700 lines with ~40 references —

--- a/src/vm/vm_module_ops.rs
+++ b/src/vm/vm_module_ops.rs
@@ -35,8 +35,32 @@ impl Interpreter {
                 _ => None,
             })
             .unwrap_or_default();
+        // ADR-0019 Phase F box F5 cutover: a module load can install classes
+        // and subs, but each such installation already invalidates dispatch
+        // caches at its OWN registration site (`exec_register_class_op`
+        // bumps `Registry::method_generation` unconditionally on every real
+        // change; `exec_register_sub_op` calls
+        // `invalidate_method_dispatch_caches()`, including its unconditional
+        // `fn_resolve_gen` bump, on every actual install). This USED to be
+        // reinforced by a second, redundant `invalidate_method_dispatch_caches()`
+        // call right here, after the module finished loading. Verified via the
+        // `MUTSU_VM_STATS`-gated shadow check below across the full `t/` suite
+        // (4049 checks, 164 generation bumps) and the roast whitelist (2479
+        // checks, 89 bumps): every bump traces to a module that genuinely
+        // installs a class (`use`/`need`), and no bump was ever needed for a
+        // module with nothing to install. See the box's progress notes in
+        // `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`.
+        let f5_gen_before = self.registry().method_generation;
         self.vm_use_module_with_tags(module, &tags)?;
-        self.invalidate_method_dispatch_caches();
+        // Shadow-only: confirms the claim above holds; does not affect
+        // dispatch (see `record_module_reg_gen_shadow_check`'s doc comment).
+        {
+            let f5_gen_after = self.registry().method_generation;
+            crate::vm::vm_stats::record_module_reg_gen_shadow_check(
+                f5_gen_after != f5_gen_before,
+                || format!("use module={module}"),
+            );
+        }
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
         // sync_locals_from_env here is unsafe: it can clobber a fresh in-place
@@ -65,8 +89,16 @@ impl Interpreter {
                 _ => None,
             })
             .unwrap_or_default();
+        // ADR-0019 Phase F box F5 cutover: see `exec_use_module_op`'s comment.
+        let f5_gen_before = self.registry().method_generation;
         loan_env!(self, import_module(module, &tags))?;
-        self.invalidate_method_dispatch_caches();
+        {
+            let f5_gen_after = self.registry().method_generation;
+            crate::vm::vm_stats::record_module_reg_gen_shadow_check(
+                f5_gen_after != f5_gen_before,
+                || format!("import module={module}"),
+            );
+        }
         // Slice F: write imported symbols through to the caller's local slots
         // (import_module recorded their names); keeps an imported `constant c`
         // coherent without the reverse pull. This op holds the outer `code`.
@@ -86,8 +118,16 @@ impl Interpreter {
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let module = Self::const_str(code, name_idx);
+        // ADR-0019 Phase F box F5 cutover: see `exec_use_module_op`'s comment.
+        let f5_gen_before = self.registry().method_generation;
         self.no_module(module)?;
-        self.invalidate_method_dispatch_caches();
+        {
+            let f5_gen_after = self.registry().method_generation;
+            crate::vm::vm_stats::record_module_reg_gen_shadow_check(
+                f5_gen_after != f5_gen_before,
+                || format!("no module={module}"),
+            );
+        }
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
         // sync_locals_from_env here is unsafe: it can clobber a fresh in-place
@@ -103,8 +143,16 @@ impl Interpreter {
         name_idx: u32,
     ) -> Result<(), RuntimeError> {
         let module = Self::const_str(code, name_idx);
+        // ADR-0019 Phase F box F5 cutover: see `exec_use_module_op`'s comment.
+        let f5_gen_before = self.registry().method_generation;
         self.need_module(module)?;
-        self.invalidate_method_dispatch_caches();
+        {
+            let f5_gen_after = self.registry().method_generation;
+            crate::vm::vm_stats::record_module_reg_gen_shadow_check(
+                f5_gen_after != f5_gen_before,
+                || format!("need module={module}"),
+            );
+        }
         // A module load writes imported symbols into env by name; flag the env so
         // the next GetLocal barrier reconciles them into locals. (An eager
         // sync_locals_from_env here is unsafe: it can clobber a fresh in-place

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -313,7 +313,22 @@ impl Interpreter {
                         custom_traits,
                     )?;
                 }
-                self.invalidate_method_dispatch_caches();
+                // ADR-0019 Phase F box F5: a plain `sub` installation only needs
+                // to invalidate the *function*-namespace resolution caches
+                // (`func_multi_resolve_cache`/`func_multi_type_cacheable`, the
+                // light/otf/multi-candidates call caches) -- all guarded by
+                // `fn_resolve_gen` and self-refreshing at their own read site.
+                // The *method*-namespace caches this used to also eagerly clear
+                // (`method_resolve_cache`/`fast_method_cache`/
+                // `native_ctor_plan_cache`/`multi_resolve_cache`/
+                // `multi_type_cacheable`/`resolved_seq_cache`/
+                // `dispatch_multi_candidate`) are keyed on `(owner type, method
+                // name)` -- a bare `sub` is never a method-table entry under any
+                // key those caches use, so it can never make one of them stale.
+                // This mirrors the fast re-install path just above (the
+                // `prepared_fn_defs` branch), which already only bumps
+                // `fn_resolve_gen` for the identical "install a sub" event.
+                self.fn_resolve_gen += 1;
                 // Record `&`-sigil parameter names so calls to a same-named routine
                 // inside this sub bypass the name-keyed light-call caches (the param
                 // can shadow a package sub of the same name).

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -654,6 +654,46 @@ pub(crate) fn record_class_reg_gen_shadow_check(matched: bool, detail: impl FnOn
     }
 }
 
+// ADR-0019 Phase F box F5 (`vm_module_ops.rs`'s `exec_use_module_op` /
+// `exec_import_module_op` / `exec_no_module_op` / `exec_need_module_op`):
+// shadow check mirroring `record_class_reg_gen_shadow_check`, but for the
+// four module-op eager `invalidate_method_dispatch_caches()` sites the F5
+// box's progress notes left "fully untraced". Compares `method_generation`
+// before/after the module op; `matched` is `gen_after != gen_before`. Unlike
+// class registration, a module load/import/no/need only touches the method
+// registry indirectly (via any class/role the module defines), so a
+// non-bump is the COMMON case here (e.g. importing a module with no classes,
+// or a `no` that only toggles a pragma) -- the by-key detail exists to find
+// the shape of the *bumping* cases, not to confirm mismatches are benign.
+// Nothing reads this counter to make a dispatch decision: shadow-only, zero
+// behavior change. See
+// `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` box F5.
+static MODULE_REG_GEN_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static MODULE_REG_GEN_SHADOW_BUMPED: AtomicU64 = AtomicU64::new(0);
+
+fn module_reg_gen_shadow_bumped_by_key() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_KEY: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_KEY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one F5 module-op generation-bump shadow comparison. `detail` is
+/// only evaluated when the generation DID bump (the interesting case here --
+/// see the static docs above), mirroring [`record_class_reg_gen_shadow_check`]
+/// but inverted since a bump, not a non-bump, is the rare signal.
+#[inline]
+pub(crate) fn record_module_reg_gen_shadow_check(bumped: bool, detail: impl FnOnce() -> String) {
+    if !enabled() {
+        return;
+    }
+    MODULE_REG_GEN_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if bumped {
+        MODULE_REG_GEN_SHADOW_BUMPED.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = module_reg_gen_shadow_bumped_by_key().lock() {
+            *map.entry(detail()).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0024: mainline named subs resolving free variables through
 // unit-lexical cells. `MAINLINE_LEXICAL_BOXES` counts every NEW `ContainerRef`
 // cell created by `exec_register_sub_op`'s mainline capture (registration
@@ -1201,6 +1241,27 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-f5 class-reg-gen-shadow mismatches (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let module_reg_gen_shadow_checks = MODULE_REG_GEN_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let module_reg_gen_shadow_bumped = MODULE_REG_GEN_SHADOW_BUMPED.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-f5: module_reg_gen_shadow_checks={module_reg_gen_shadow_checks} module_reg_gen_shadow_bumped={module_reg_gen_shadow_bumped}"
+    );
+    if let Ok(map) = module_reg_gen_shadow_bumped_by_key().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-f5 module-reg-gen-shadow bumped (top {}): {}",
             top.len(),
             top.join(" ")
         );


### PR DESCRIPTION
## Summary
- ADR-0019 Phase F box F5: removes the redundant post-load `invalidate_method_dispatch_caches()` call at the four module-op sites (`use`/`import`/`no`/`need`) -- each class/sub installed by a loaded module already invalidates dispatch caches at its own registration site.
- Also cuts over `exec_register_sub_op` (plain `sub` installation): its eager clear touched method-namespace caches keyed on `(owner type, method name)`, which a bare `sub` can never populate/invalidate -- the existing fast `my sub` re-install path already only bumps `fn_resolve_gen` for the same event.
- Adds a `MUTSU_VM_STATS`-gated shadow check (`record_module_reg_gen_shadow_check`, mirroring the class-registration one) for the module-op sites, kept as a standing regression guard.

## Evidence
- Module ops: `t/` suite sweep (debug, one process per file): 4049 checks, 164 generation bumps, all traced to genuine class-installing `use`/`need`. Roast whitelist sweep (release): 2479 checks, 89 bumps, same pattern. `import`/`no` never bumped in either corpus.
- Sub registration: by-construction argument (disjoint cache-key namespaces) plus direct precedent from the existing fast re-install path.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] `make test` (3164 files, PASS)
- [x] `make roast` (1436 files, PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)