### PR TITLE
fix(adr0019): F3 step 2 -- Mu/Any/Hash/Cool introspection gaps + Pair.^can bug

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -864,6 +864,24 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   and pinned in `t/can-methods-drift.t`. Running total: 3 of 18 owners triaged (`Mu`, `Any`,
   `Hash`); `Str` (25 extras), `Int`/`Num`/`Rat`/`Complex` (25), `Cool` (11) remain the largest
   untriaged owners.
+  **Progress (2026-08-15, step 2, `Cool`):** triaged `Cool`'s 11 extras — the native-sized-integer
+  coercion methods (`int8`..`uint64`, `byte`, `int`, `uint`). All 11 raku-verified as genuine
+  `Cool.^methods` entries and confirmed to already dispatch correctly on mutsu. Added a new
+  `COOL_NATIVE_INT_COERCE_TAIL` array (appended after `NUMERIC_COERCIONS` in `builtin_type_
+  method_names`'s `"Cool"` arm, matching the block's position in `RAW_ROWS`). **Found and fixed a
+  real bug this exposed**, not just a list gap: `is_builtin_type_method`
+  (`methods_classhow_lookup.rs`, feeding `.^find_method`/`.can` on a `Package` receiver) checked
+  `["type_name", "Cool", "Any", "Mu"]` as a hardcoded ancestor list for *every* type regardless of
+  whether `Cool` was actually an ancestor — harmless while `Cool`'s own list had no name likely to
+  collide, but once `int8` etc. joined `Cool`'s list, `Pair.^can('int8')` (`Pair`'s real MRO is
+  `[Pair, Any, Mu]`, no `Cool`) went from correctly `False` to a false-positive `True`. Fixed by
+  reading the receiver type's real MRO from `registry().class_mro_readonly()` (the builtin type
+  catalog's own authoritative source) instead of guessing, with the old hardcoded list kept only as
+  a fallback for a type the catalog doesn't recognize. Regression-pinned (`Pair cannot int8`) in
+  `t/can-methods-drift.t` alongside the new `Cool` names. Full local `t/` suite (3166 files) and the
+  targeted `S12-introspection`/`S02-types/hash.t`/`S09-typed-arrays/hashes.t` roast files stay
+  green. Running total: 4 of 18 owners triaged (`Mu`, `Any`, `Hash`, `Cool`); `Str` (25 extras) and
+  `Int`/`Num`/`Rat`/`Complex` (25, likely shared) remain the largest untriaged owners.
 - [ ] **F4 — Remove `ClassDef::methods` as a dispatch/registration mirror.** Leave type structure
   metadata beside the canonical method table and update snapshots/rollback to copy one source.
 - [x] **F5 — Remove superseded method caches and manual invalidation.** Keep only the

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -838,6 +838,15 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   introspection array (rows were scattered into unrelated hand-added blocks); order now matches for
   all 18. The ~90+ extra dispatch-recognized names per owner (step 2's raku-verification triage) are
   still untouched — that remains the real blocker before the actual cutover (step 3).
+  **Progress (2026-08-15, step 2, first name):** raku-verified the first of the ~90+ extra names —
+  `Mu`'s single extra, `DEFINITE` (`RAW_ROWS` had it via E2b; `MU_METHODS` did not). Confirmed a
+  genuine gap, not dispatch-only noise: `raku -e 'say 5.DEFINITE'` works and real Rakudo's
+  `Mu.^methods` lists `DEFINITE` (mutsu's `Mu.DEFINITE` already dispatched correctly before this
+  fix — only introspection was missing it). Added to `MU_METHODS` at the position matching its
+  `RAW_ROWS`-relative order (first, ahead of `defined`), keeping
+  `raw_rows_cover_every_introspection_name_in_order` green, and pinned in
+  `t/can-methods-drift.t`. Step 2 remains open for the other ~89+ names across the other 17 owners —
+  this is one triaged name, not a batch.
 - [ ] **F4 — Remove `ClassDef::methods` as a dispatch/registration mirror.** Leave type structure
   metadata beside the canonical method table and update snapshots/rollback to copy one source.
 - [x] **F5 — Remove superseded method caches and manual invalidation.** Keep only the

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -847,6 +847,23 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   `raw_rows_cover_every_introspection_name_in_order` green, and pinned in
   `t/can-methods-drift.t`. Step 2 remains open for the other ~89+ names across the other 17 owners —
   this is one triaged name, not a batch.
+  **Progress (2026-08-15, step 2, `Any` and `Hash`):** triaged `Any`'s 7 extras and `Hash`'s 11.
+  For `Any`: `serial` and `hash` are genuine `.^methods` gaps (real Rakudo's `Any.^methods` lists
+  both, and mutsu already dispatches both correctly); `self`/`clone`/`WHICH`/`sink`/`item` are
+  confirmed dispatch-only/internal (real Rakudo's `Any.^methods` does not list any of them —
+  `WHICH` is a `Mu`-declared method appearing on `Any`'s inherited view, not `Any`'s own). Added
+  `serial`/`hash` to `ANY_METHODS`. For `Hash`: `pick`/`EXISTS-KEY`/`AT-KEY`/`List`/`invert`/`flat`/
+  `dynamic`/`roll` are genuine gaps (all confirmed present on real Rakudo's `Hash.^methods` and
+  already dispatch correctly on mutsu); `Array`/`AT-POS`/`EXISTS-POS`/`perl` are confirmed
+  dispatch-only (not on real Rakudo's `Hash.^methods`). Added the 8 genuine names to
+  `HASH_METHODS`, in `RAW_ROWS`-relative order (both owners' rows arrive in two separate blocks in
+  `native_method_row_table.rs`, an artifact of how E2b originally landed them; the newly-added
+  names had to be appended after the array's existing tail to keep
+  `raw_rows_cover_every_introspection_name_in_order` green, since that test only requires the
+  *shared* names' relative order to match, not raku's true `.^methods` order). All raku-verified
+  and pinned in `t/can-methods-drift.t`. Running total: 3 of 18 owners triaged (`Mu`, `Any`,
+  `Hash`); `Str` (25 extras), `Int`/`Num`/`Rat`/`Complex` (25), `Cool` (11) remain the largest
+  untriaged owners.
 - [ ] **F4 — Remove `ClassDef::methods` as a dispatch/registration mirror.** Leave type structure
   metadata beside the canonical method table and update snapshots/rollback to copy one source.
 - [x] **F5 — Remove superseded method caches and manual invalidation.** Keep only the

--- a/news/2026-08/adr0019-f3-step2-mu-definite.md
+++ b/news/2026-08/adr0019-f3-step2-mu-definite.md
@@ -1,0 +1,21 @@
+# ADR-0019 F3 step 2: `Mu.^methods` was missing `DEFINITE`
+
+ADR-0019 Phase F box F3 ("delete the per-type method-name lists, retain only the generated native
+entry catalog") found in an earlier scoping pass that its target catalog, `native_method_row.rs`'s
+`RAW_ROWS`, carries roughly 90+ names per owner that the 14 hand `builtin_type_methods.rs` arrays
+don't list. Each of those names needs a raku ground-truth check before F3 can classify it as a
+genuine `.^methods` gap or a deliberately-internal/protocol-only name dispatch recognizes but
+introspection correctly omits.
+
+Triaged the first and smallest case: `Mu`'s sole extra name, `DEFINITE`. `raku -e 'say
+5.DEFINITE'` works in real Rakudo and `Mu.^methods` lists it there. mutsu already dispatched
+`.DEFINITE` correctly (an earlier E2b slice had added it to `RAW_ROWS` for cascade coverage) — only
+the introspection-facing `MU_METHODS` array was missing it, so `Mu.^methods`/`.^can('DEFINITE')`
+under-reported. Added `DEFINITE` to `MU_METHODS` at the position matching its `RAW_ROWS`-relative
+order (ahead of `defined`), which keeps the `raw_rows_cover_every_introspection_name_in_order`
+regression guard green, and pinned it in `t/can-methods-drift.t` (verified against real `raku`
+output).
+
+Step 2 remains open for the ~89+ other names across the other 17 catalog owners; see
+`todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` for the running list and
+suggested owner-by-owner ordering.

--- a/news/2026-08/adr0019-f3-step2-mu-definite.md
+++ b/news/2026-08/adr0019-f3-step2-mu-definite.md
@@ -1,4 +1,4 @@
-# ADR-0019 F3 step 2: `Mu.^methods` was missing `DEFINITE`
+# ADR-0019 F3 step 2: `Mu`, `Any`, and `Hash` introspection gaps
 
 ADR-0019 Phase F box F3 ("delete the per-type method-name lists, retain only the generated native
 entry catalog") found in an earlier scoping pass that its target catalog, `native_method_row.rs`'s
@@ -16,6 +16,15 @@ order (ahead of `defined`), which keeps the `raw_rows_cover_every_introspection_
 regression guard green, and pinned it in `t/can-methods-drift.t` (verified against real `raku`
 output).
 
-Step 2 remains open for the ~89+ other names across the other 17 catalog owners; see
-`todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` for the running list and
-suggested owner-by-owner ordering.
+Continued the same triage for `Any` (7 extras) and `Hash` (11 extras). `Any`'s `serial` and
+`hash` and `Hash`'s `pick`/`EXISTS-KEY`/`AT-KEY`/`List`/`invert`/`flat`/`dynamic`/`roll` were all
+confirmed as genuine `.^methods` gaps against real `raku` output and already-working dispatch;
+`Any`'s `self`/`clone`/`WHICH`/`sink`/`item` and `Hash`'s `Array`/`AT-POS`/`EXISTS-POS`/`perl`
+were confirmed as deliberately dispatch-only names real Rakudo's `.^methods` correctly omits.
+Added the genuine names to `ANY_METHODS`/`HASH_METHODS` and pinned all of them in
+`t/can-methods-drift.t`.
+
+3 of 18 catalog owners are now fully triaged (`Mu`, `Any`, `Hash`). Step 2 remains open for the
+~80+ names across the other 15 owners (`Str` has 25, `Int`/`Num`/`Rat`/`Complex` 25, `Cool` 11
+being the largest); see `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` for the
+running list and suggested owner-by-owner ordering.

--- a/news/2026-08/adr0019-f3-step2-mu-definite.md
+++ b/news/2026-08/adr0019-f3-step2-mu-definite.md
@@ -1,4 +1,4 @@
-# ADR-0019 F3 step 2: `Mu`, `Any`, and `Hash` introspection gaps
+# ADR-0019 F3 step 2: `Mu`, `Any`, `Hash`, `Cool` introspection gaps (plus a real `.^can` bug)
 
 ADR-0019 Phase F box F3 ("delete the per-type method-name lists, retain only the generated native
 entry catalog") found in an earlier scoping pass that its target catalog, `native_method_row.rs`'s
@@ -24,7 +24,19 @@ were confirmed as deliberately dispatch-only names real Rakudo's `.^methods` cor
 Added the genuine names to `ANY_METHODS`/`HASH_METHODS` and pinned all of them in
 `t/can-methods-drift.t`.
 
-3 of 18 catalog owners are now fully triaged (`Mu`, `Any`, `Hash`). Step 2 remains open for the
-~80+ names across the other 15 owners (`Str` has 25, `Int`/`Num`/`Rat`/`Complex` 25, `Cool` 11
-being the largest); see `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` for the
-running list and suggested owner-by-owner ordering.
+Then triaged `Cool`'s 11 extras — the native-sized-integer coercion methods (`int8`..`uint64`,
+`byte`, `int`, `uint`). All 11 raku-verified as genuine `Cool.^methods` entries that already
+dispatch correctly on mutsu. Adding them surfaced a real bug, not just a list gap:
+`is_builtin_type_method` (backing `.^find_method`/`.can` on a `Package` receiver) unconditionally
+checked `["type_name", "Cool", "Any", "Mu"]` as every type's ancestor list, regardless of whether
+`Cool` genuinely was one. That was harmless until `Cool`'s own list grew to include a name likely
+to collide — once `int8` joined it, `Pair.^can('int8')` (`Pair`'s real MRO has no `Cool`) flipped
+from correctly `False` to a false-positive `True`, caught immediately by the pre-existing
+`t/native-int-coerce-methods-are-cool-only.t` pin. Fixed by reading the receiver type's real MRO
+from the builtin type catalog instead of guessing, with a new regression pin added alongside the
+`Cool` names.
+
+4 of 18 catalog owners are now fully triaged (`Mu`, `Any`, `Hash`, `Cool`). Step 2 remains open for
+the largest remaining owners, `Str` (25 extras) and `Int`/`Num`/`Rat`/`Complex` (25, likely shared
+via `NUMERIC_OWN`); see `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` for the
+running list.

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -206,6 +206,14 @@ const HASH_METHODS: &[&str] = &[
     "raku",
     "Numeric",
     "Int",
+    "pick",
+    "EXISTS-KEY",
+    "AT-KEY",
+    "List",
+    "invert",
+    "flat",
+    "dynamic",
+    "roll",
 ];
 
 const RANGE_METHODS: &[&str] = &[
@@ -351,6 +359,8 @@ const IO_HANDLE_METHODS: &[&str] = &[
 ];
 
 const ANY_METHODS: &[&str] = &[
+    "serial",
+    "hash",
     "say",
     "put",
     "print",

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -132,6 +132,22 @@ const COOL_OWN: &[&str] = &[
     "polymod",
 ];
 
+/// The native-sized-integer coercion methods (`42.int8`, `"42".byte`, ...)
+/// declared on `Cool` — same 11 names, same order, as
+/// `runtime::native_types::NATIVE_INT_COERCE_METHODS`. Kept as a separate
+/// tail (appended after `NUMERIC_COERCIONS` in `builtin_type_method_names`,
+/// not folded into `COOL_OWN`) because `RAW_ROWS` lists them after `Cool`'s
+/// `gist`/`raku` rows, and `raw_rows_cover_every_introspection_name_in_order`
+/// requires the introspection array's order to match. Confirmed a genuine
+/// `.^methods` gap (real Rakudo's `Cool.^methods` lists all 11) rather than
+/// dispatch-only noise, ADR-0019 Phase F box F3 step 2 (`todo/deep/
+/// adr0019-f3-raw-rows-drift-from-introspection-arrays.md`); dispatch and
+/// `.^can` already worked before this list existed (`t/native-int-coerce-
+/// methods-are-cool-only.t`), only `.^methods` enumeration was missing them.
+const COOL_NATIVE_INT_COERCE_TAIL: &[&str] = &[
+    "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "byte", "int", "uint",
+];
+
 const LIST_METHODS: &[&str] = &[
     "elems",
     "end",
@@ -470,7 +486,7 @@ pub(crate) fn builtin_type_method_names(type_name: &str) -> Vec<&'static str> {
         "Signature" => SIGNATURE_METHODS.to_vec(),
         "IO::Path" => IO_PATH_METHODS.to_vec(),
         "IO::Handle" => IO_HANDLE_METHODS.to_vec(),
-        "Cool" => [COOL_OWN, NUMERIC_COERCIONS].concat(),
+        "Cool" => [COOL_OWN, NUMERIC_COERCIONS, COOL_NATIVE_INT_COERCE_TAIL].concat(),
         "Any" => ANY_METHODS.to_vec(),
         "Mu" => MU_METHODS.to_vec(),
         _ => Vec::new(),

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -406,8 +406,8 @@ const ANY_METHODS: &[&str] = &[
 ];
 
 const MU_METHODS: &[&str] = &[
-    "defined", "WHAT", "WHERE", "HOW", "WHY", "WHICH", "Bool", "Str", "gist", "raku", "clone",
-    "new",
+    "DEFINITE", "defined", "WHAT", "WHERE", "HOW", "WHY", "WHICH", "Bool", "Str", "gist", "raku",
+    "clone", "new",
 ];
 
 /// The method names a built-in `type_name` responds to, in `.^methods` order.

--- a/src/builtins/native_method_row_table.rs
+++ b/src/builtins/native_method_row_table.rs
@@ -1190,21 +1190,34 @@ pub(super) const RAW_ROWS: &[(&str, &str, u8, u8)] = &[
     ("Cool", "gist", 1, 1),
     ("Cool", "raku", 1, 1),
     // ADR-0019 E11 slice 2 (2026-08-14, follow-up): the native-int-coercion
-    // method family (`42.int8`, `"42".byte`, ...) -- NOT in `COOL_OWN`
-    // (`is_native_int_coerce_method`'s doc comment explains why: they are
-    // deliberately excluded from `.^methods`/`.^can`-by-list to avoid making
-    // every value spuriously "can" a C-width alias like `bool`), but
-    // genuinely dispatched via `target.isa_check("Cool")` for the eleven
-    // real coercion names, unconditionally for the whole `Cool` family
-    // (`methods_0arg/mod.rs`). Found via a `MUTSU_VM_STATS=1` sweep of the
-    // full `t/` suite after the rest of this slice landed: one can-shadow
-    // mismatch remained (`class=List method=int8 real=true shadow=false`,
-    // `t/native-int-coerce-methods-are-cool-only.t`) alongside the
-    // known-and-out-of-scope `class=Cancellation method=cancel` (see the ADR
-    // E11 progress note). Hand-probed against the same `Int(2)`/`Str("5")`
-    // pair as the rest of the `Cool` rows above, plus the bare `Cool` type
-    // object (all eleven recognize at arity 0 there too, unlike most of the
-    // `Cool` block).
+    // method family (`42.int8`, `"42".byte`, ...), genuinely dispatched via
+    // `target.isa_check("Cool")` for the eleven real coercion names,
+    // unconditionally for the whole `Cool` family (`methods_0arg/mod.rs`).
+    // Found via a `MUTSU_VM_STATS=1` sweep of the full `t/` suite after the
+    // rest of this slice landed: one can-shadow mismatch remained
+    // (`class=List method=int8 real=true shadow=false`, `t/native-int-
+    // coerce-methods-are-cool-only.t`) alongside the known-and-out-of-scope
+    // `class=Cancellation method=cancel` (see the ADR E11 progress note).
+    // Hand-probed against the same `Int(2)`/`Str("5")` pair as the rest of
+    // the `Cool` rows above, plus the bare `Cool` type object (all eleven
+    // recognize at arity 0 there too, unlike most of the `Cool` block).
+    //
+    // **Correction (ADR-0019 Phase F box F3 step 2, 2026-08-15):** this
+    // comment used to say these were "NOT in `COOL_OWN` ... deliberately
+    // excluded from `.^methods`/`.^can`-by-list to avoid making every value
+    // spuriously 'can' a C-width alias like `bool`". That conflated two
+    // different lists: `is_native_int_coerce_method`'s exclusion concern is
+    // about `NATIVE_INT_TYPES` (`bool`/`long`/`ulong`/... name a *type*, not
+    // a method, and must never be dispatched as one) and is unrelated to
+    // whether the eleven real coercion methods appear in `COOL_OWN`. `.^can`
+    // already answered correctly for these eleven via this row's own arity
+    // cascade regardless of `COOL_OWN` membership (`t/native-int-coerce-
+    // methods-are-cool-only.t` pins exactly that). Only `.^methods`
+    // enumeration was missing them, confirmed a genuine gap against real
+    // Rakudo's `Cool.^methods` (F3 step 2's raku-verification triage) and
+    // now closed via `COOL_NATIVE_INT_COERCE_TAIL` (`builtin_type_
+    // methods.rs`), appended after `NUMERIC_COERCIONS` to match this block's
+    // own position in `RAW_ROWS`.
     ("Cool", "int8", 1, 1),
     ("Cool", "int16", 1, 1),
     ("Cool", "int32", 1, 1),

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -351,8 +351,25 @@ impl Interpreter {
     /// Check if a method name belongs to a built-in type (Str, Int, etc.)
     /// by checking the hardcoded method lists for the type and its ancestors.
     fn is_builtin_type_method(&self, type_name: &str, method_name: &str) -> bool {
-        // Check the type itself and common ancestors (Cool, Any, Mu)
-        for tn in &[type_name, "Cool", "Any", "Mu"] {
+        // Check the type itself and its real ancestors, per the builtin type
+        // catalog's own MRO -- NOT an unconditional ["Cool", "Any", "Mu"]
+        // guess. `Pair`'s real MRO is `[Pair, Any, Mu]` (no `Cool`); blindly
+        // probing `Cool`'s method list here made `Pair.^can($any_cool_
+        // coercion_method)` a false positive once `Cool`'s own list grew
+        // past the handful of names that happened not to collide (ADR-0019
+        // Phase F box F3 step 2, `t/native-int-coerce-methods-are-cool-
+        // only.t`'s "Pair cannot int8" pin).
+        let ancestors = self
+            .registry()
+            .class_mro_readonly(type_name)
+            .map(|mro| mro.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+            .unwrap_or_else(|| {
+                [type_name, "Cool", "Any", "Mu"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            });
+        for tn in &ancestors {
             let mut methods = Vec::new();
             self.collect_builtin_type_methods(tn, &mut methods);
             if methods.iter().any(|m| m.to_string_value() == method_name) {

--- a/t/can-methods-drift.t
+++ b/t/can-methods-drift.t
@@ -5,7 +5,7 @@ use Test;
 # methods were missing, so `.^can` lied (returned False) and `.^methods` omitted
 # them. These pin the methods back in sync — each one both works AND introspects.
 
-plan 53;
+plan 57;
 
 # Helper: the method genuinely dispatches (so the list entry is honest) and
 # `.^can` agrees.
@@ -46,6 +46,15 @@ works-and-can %h, 'flat',        { %h.flat };
 works-and-can %h, 'dynamic',     { %h.dynamic };
 works-and-can %h, 'roll',        { %h.roll };
 
+# --- Cool (native-sized-integer coercion methods) ---
+works-and-can 300, 'int8', { 300.int8 };
+
+# A type that is NOT Cool-derived must not spuriously pick up Cool's own
+# coercion methods -- regression pin for the `is_builtin_type_method`
+# ancestor-list bug this Cool-list growth exposed (it used to hardcode
+# ["Cool", "Any", "Mu"] as ancestors for every type, unconditionally).
+nok (a => 1).^can('int8').Bool, 'Pair is not Cool, so it cannot int8';
+
 # The fixed names also appear in `.^methods`.
 ok 'x'.^methods.map(*.Str).grep('trans'),        'Str.^methods includes trans';
 ok 'x'.^methods.map(*.Str).grep('substr-rw'),    'Str.^methods includes substr-rw';
@@ -61,6 +70,7 @@ ok %h.^methods.map(*.Str).grep('invert'),        'Hash.^methods includes invert'
 ok %h.^methods.map(*.Str).grep('flat'),          'Hash.^methods includes flat';
 ok %h.^methods.map(*.Str).grep('dynamic'),       'Hash.^methods includes dynamic';
 ok %h.^methods.map(*.Str).grep('roll'),          'Hash.^methods includes roll';
+ok Cool.^methods.map(*.Str).grep('int8'),        'Cool.^methods includes int8';
 
 # Methods that mutsu does NOT implement must still report False (no over-claim).
 nok 'abc'.^can('samespace').Bool, 'unimplemented samespace is not over-claimed';

--- a/t/can-methods-drift.t
+++ b/t/can-methods-drift.t
@@ -5,7 +5,7 @@ use Test;
 # methods were missing, so `.^can` lied (returned False) and `.^methods` omitted
 # them. These pin the methods back in sync — each one both works AND introspects.
 
-plan 20;
+plan 23;
 
 # Helper: the method genuinely dispatches (so the list entry is honest) and
 # `.^can` agrees.
@@ -28,10 +28,14 @@ works-and-can 5, 'expmod', { 4.expmod(2, 5) };
 works-and-can (1, 2, 3), 'minpairs', { (1, 2, 3).minpairs };
 works-and-can (1, 2, 3), 'maxpairs', { (1, 2, 3).maxpairs };
 
+# --- Mu ---
+works-and-can 5, 'DEFINITE', { 5.DEFINITE };
+
 # The fixed names also appear in `.^methods`.
 ok 'x'.^methods.map(*.Str).grep('trans'),        'Str.^methods includes trans';
 ok 'x'.^methods.map(*.Str).grep('substr-rw'),    'Str.^methods includes substr-rw';
 ok (1, 2).^methods.map(*.Str).grep('minpairs'),  'List.^methods includes minpairs';
+ok Mu.^methods.map(*.Str).grep('DEFINITE'),      'Mu.^methods includes DEFINITE';
 
 # Methods that mutsu does NOT implement must still report False (no over-claim).
 nok 'abc'.^can('samespace').Bool, 'unimplemented samespace is not over-claimed';

--- a/t/can-methods-drift.t
+++ b/t/can-methods-drift.t
@@ -5,7 +5,7 @@ use Test;
 # methods were missing, so `.^can` lied (returned False) and `.^methods` omitted
 # them. These pin the methods back in sync — each one both works AND introspects.
 
-plan 23;
+plan 53;
 
 # Helper: the method genuinely dispatches (so the list entry is honest) and
 # `.^can` agrees.
@@ -31,11 +31,36 @@ works-and-can (1, 2, 3), 'maxpairs', { (1, 2, 3).maxpairs };
 # --- Mu ---
 works-and-can 5, 'DEFINITE', { 5.DEFINITE };
 
+# --- Any ---
+works-and-can (1, 2, 3), 'serial', { (1, 2, 3).serial };
+works-and-can (a => 1, b => 2), 'hash', { (a => 1, b => 2).hash };
+
+# --- Hash ---
+my %h = a => 1, b => 2;
+works-and-can %h, 'pick',        { %h.pick };
+works-and-can %h, 'EXISTS-KEY',  { %h.EXISTS-KEY('a') };
+works-and-can %h, 'AT-KEY',      { %h.AT-KEY('a') };
+works-and-can %h, 'List',        { %h.List };
+works-and-can %h, 'invert',      { %h.invert };
+works-and-can %h, 'flat',        { %h.flat };
+works-and-can %h, 'dynamic',     { %h.dynamic };
+works-and-can %h, 'roll',        { %h.roll };
+
 # The fixed names also appear in `.^methods`.
 ok 'x'.^methods.map(*.Str).grep('trans'),        'Str.^methods includes trans';
 ok 'x'.^methods.map(*.Str).grep('substr-rw'),    'Str.^methods includes substr-rw';
 ok (1, 2).^methods.map(*.Str).grep('minpairs'),  'List.^methods includes minpairs';
 ok Mu.^methods.map(*.Str).grep('DEFINITE'),      'Mu.^methods includes DEFINITE';
+ok Any.^methods.map(*.Str).grep('serial'),       'Any.^methods includes serial';
+ok Any.^methods.map(*.Str).grep('hash'),         'Any.^methods includes hash';
+ok %h.^methods.map(*.Str).grep('pick'),          'Hash.^methods includes pick';
+ok %h.^methods.map(*.Str).grep('EXISTS-KEY'),    'Hash.^methods includes EXISTS-KEY';
+ok %h.^methods.map(*.Str).grep('AT-KEY'),        'Hash.^methods includes AT-KEY';
+ok %h.^methods.map(*.Str).grep('List'),          'Hash.^methods includes List';
+ok %h.^methods.map(*.Str).grep('invert'),        'Hash.^methods includes invert';
+ok %h.^methods.map(*.Str).grep('flat'),          'Hash.^methods includes flat';
+ok %h.^methods.map(*.Str).grep('dynamic'),       'Hash.^methods includes dynamic';
+ok %h.^methods.map(*.Str).grep('roll'),          'Hash.^methods includes roll';
 
 # Methods that mutsu does NOT implement must still report False (no over-claim).
 nok 'abc'.^can('samespace').Bool, 'unimplemented samespace is not over-claimed';

--- a/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
+++ b/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
@@ -170,3 +170,38 @@ Added the 8 genuine names to `HASH_METHODS`, appended after the array's existing
 
 Running total: 3 of 18 owners fully triaged (`Mu`, `Any`, `Hash`). Largest remaining: `Str` (25
 extras), `Int`/`Num`/`Rat`/`Complex` (25, likely shared via `NUMERIC_OWN`), `Cool` (11).
+
+## Progress (2026-08-15, continued): `Cool` (11 extras) triaged, plus a real bug found
+
+`Cool`'s 11 extras are the native-sized-integer coercion methods (`int8`, `int16`, `int32`,
+`int64`, `uint8`, `uint16`, `uint32`, `uint64`, `byte`, `int`, `uint`). All 11 raku-verified as
+genuine `Cool.^methods` entries (`raku -e 'say Cool.^methods.grep(*.name eq "int8").elems'` → 1,
+same for the rest) and already dispatch correctly on mutsu (`300.int8` → 44, etc.) — the
+`native_method_row_table.rs` comment above these rows previously claimed they were "deliberately
+excluded from `.^methods`/`.^can`-by-list", but that conflated two different concerns: the actual
+exclusion (`NATIVE_INT_TYPES` vs. `NATIVE_INT_COERCE_METHODS` in `runtime/native_types.rs`) is
+about *type-alias* names (`bool`, `long`, `ulong`, ...) that name a type but are not methods, which
+is unrelated to whether the 11 real coercion methods belong in `COOL_OWN`. Corrected that comment
+in place. Added a new `COOL_NATIVE_INT_COERCE_TAIL` array, appended after `NUMERIC_COERCIONS` in
+the `"Cool"` match arm (matching the block's position in `RAW_ROWS`, required to keep
+`raw_rows_cover_every_introspection_name_in_order` green).
+
+**This surfaced a real, previously-latent bug**: `is_builtin_type_method`
+(`methods_classhow_lookup.rs`), which backs `.^find_method`/`.can` on a `Package` receiver via
+`classhow_find_method`, unconditionally checked `["type_name", "Cool", "Any", "Mu"]` as the
+ancestor list for every type, regardless of whether `Cool` was genuinely an ancestor. This was
+harmless while `Cool`'s own introspection list had no method name likely to collide with a
+non-Cool type's probe, but the moment `int8` etc. joined `Cool`'s list, `Pair.^can('int8')`
+(`Pair`'s real MRO is `[Pair, Any, Mu]` per `builtin_type_catalog.rs` — no `Cool`) flipped from
+correctly `False` to a false-positive `True`, caught immediately by the existing
+`t/native-int-coerce-methods-are-cool-only.t` pin ("Pair is not Cool, so it cannot int8"). Fixed by
+reading the receiver type's real MRO via `registry().class_mro_readonly()` (the same authoritative
+builtin-type-catalog source `classhow_lookup_impl` already uses a few lines above) instead of the
+hardcoded guess, falling back to the old `[type_name, "Cool", "Any", "Mu"]` heuristic only when the
+catalog doesn't recognize the type name at all. Added a matching regression pin to
+`t/can-methods-drift.t`. Full local `t/` suite (3166 files, all green) plus the targeted
+`S12-introspection/*`, `S02-types/hash.t`, `S09-typed-arrays/hashes.t` roast files confirm no other
+regression.
+
+Running total: 4 of 18 owners fully triaged (`Mu`, `Any`, `Hash`, `Cool`). Largest remaining: `Str`
+(25 extras), `Int`/`Num`/`Rat`/`Complex` (25, likely shared via `NUMERIC_OWN`).

--- a/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
+++ b/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
@@ -147,3 +147,26 @@ Remaining for step 2: ~89+ names across the other 17 owners (`Any` has 7, `Str` 
 same raku-verify-then-classify treatment (genuine `.^methods` gap vs. deliberately-internal
 dispatch-only name). Suggest continuing owner-by-owner in ascending extra-name-count order (small,
 independently-landable slices, same pattern as this one), rather than a single large sweep.
+
+## Progress (2026-08-15, continued): `Any` (7 extras) and `Hash` (11 extras) triaged
+
+`Any`: `serial` and `hash` confirmed as genuine `.^methods` gaps (`raku -e 'say
+Any.^methods.grep(*.name eq "serial").elems'` → 1, same for `hash`; both already dispatch
+correctly on mutsu, e.g. `(1,2,3).serial`, `(a=>1,b=>2).hash`). `self`, `clone`, `WHICH`, `sink`,
+`item` confirmed dispatch-only/internal — raku's `Any.^methods` does not list any of them (`elems`
+0 for each); these stay unlisted in `ANY_METHODS` by design, not oversight. Added `serial`/`hash`
+to `ANY_METHODS`, ahead of `say` (their `RAW_ROWS`-relative position).
+
+`Hash`: of the 11 extras (`pick`, `EXISTS-KEY`, `AT-KEY`, `List`, `invert`, `flat`, `Array`,
+`AT-POS`, `EXISTS-POS`, `dynamic`, `roll`, `perl` — 12 listed in the original survey, one,
+`perl`, was miscounted as one of the "11"), 8 are genuine gaps (`pick`, `EXISTS-KEY`, `AT-KEY`,
+`List`, `invert`, `flat`, `dynamic`, `roll` — each confirmed present on real `Hash.^methods` and
+already dispatching correctly, e.g. `%h.pick`, `%h.EXISTS-KEY('a')`, `%h.List`, `%h.invert`).
+`Array`, `AT-POS`, `EXISTS-POS`, `perl` confirmed dispatch-only (not on real `Hash.^methods`).
+Added the 8 genuine names to `HASH_METHODS`, appended after the array's existing tail (their
+`RAW_ROWS` rows arrive in a second block, after `Int`) to keep
+`raw_rows_cover_every_introspection_name_in_order` green. All raku-verified and pinned in
+`t/can-methods-drift.t`.
+
+Running total: 3 of 18 owners fully triaged (`Mu`, `Any`, `Hash`). Largest remaining: `Str` (25
+extras), `Int`/`Num`/`Rat`/`Complex` (25, likely shared via `NUMERIC_OWN`), `Cool` (11).

--- a/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
+++ b/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
@@ -130,3 +130,20 @@ verification before F3 can decide "genuine `.^methods` gap" vs. "deliberately in
 dispatch-only" for each one. Step 1 only closes the "is `RAW_ROWS` even a safe superset, in the right
 order" question, and the answer for the *introspection-array* side is now yes, permanently enforced.
 Step 3 (the actual cutover) still needs step 2 first.
+
+## Progress (2026-08-15): step 2 started, one name (`Mu`'s `DEFINITE`)
+
+Triaged the smallest owner first (`Mu` had exactly one extra name per the survey above). Raku
+ground truth: `Mu.^methods` lists `DEFINITE` in real Rakudo, and mutsu already dispatches
+`.DEFINITE` correctly (`RAW_ROWS` picked it up via an earlier E2b slice) — introspection was simply
+missing it, a genuine gap, not one of the deliberately-internal/protocol names this step also needs
+to identify. Added `"DEFINITE"` to `MU_METHODS` (`builtin_type_methods.rs`) at the position
+matching its `RAW_ROWS`-relative order (ahead of `defined`), keeping
+`raw_rows_cover_every_introspection_name_in_order` green, and pinned with a `works-and-can`/
+`.^methods` pair in `t/can-methods-drift.t` (verified against real `raku` output too).
+
+Remaining for step 2: ~89+ names across the other 17 owners (`Any` has 7, `Str` 25, `Int` 25,
+`Cool` 11, `Hash` 11, plus smaller counts elsewhere per the survey table above), each needing the
+same raku-verify-then-classify treatment (genuine `.^methods` gap vs. deliberately-internal
+dispatch-only name). Suggest continuing owner-by-owner in ascending extra-name-count order (small,
+independently-landable slices, same pattern as this one), rather than a single large sweep.


### PR DESCRIPTION
## Summary
- ADR-0019 Phase F box F3 needs each of the ~90+ names `RAW_ROWS` recognizes for dispatch but the 14 hand `builtin_type_methods.rs` introspection arrays don't list, raku-verified one at a time before F3's cutover.
- Triaged 4 of 18 catalog owners: `Mu` (`DEFINITE`), `Any` (`serial`, `hash`), `Hash` (`pick`/`EXISTS-KEY`/`AT-KEY`/`List`/`invert`/`flat`/`dynamic`/`roll`), `Cool` (the 11 native-sized-integer coercion methods `int8`..`uint64`/`byte`/`int`/`uint`). All confirmed as genuine `.^methods` gaps against real `raku` output; all already dispatch correctly on mutsu.
- For the names confirmed as deliberately dispatch-only (`Any`'s `self`/`clone`/`WHICH`/`sink`/`item`, `Hash`'s `Array`/`AT-POS`/`EXISTS-POS`/`perl`), left them out of the introspection arrays -- real Rakudo's own `.^methods` omits them too.
- **Found and fixed a real bug** while adding `Cool`'s names: `is_builtin_type_method` (backing `.^find_method`/`.can` on a `Package` receiver) unconditionally checked `["type_name", "Cool", "Any", "Mu"]` as every type's ancestor list. Once `Cool`'s own list grew to include `int8`, `Pair.^can('int8')` (`Pair`'s real MRO has no `Cool`) flipped from correctly `False` to a false positive. Fixed by reading the receiver type's real MRO from the builtin type catalog instead of guessing.
- Also corrected a stale comment in `native_method_row_table.rs` that had conflated the type-alias-vs-method distinction with an "excluded from `.^methods`" claim that didn't actually hold.

## Test plan
- [x] `cargo test --lib raw_rows_cover_every_introspection_name_in_order`
- [x] `timeout 30 ./target/debug/mutsu t/can-methods-drift.t` (all new pins pass, 57 assertions)
- [x] `timeout 30 ./target/debug/mutsu t/native-int-coerce-methods-are-cool-only.t` (the `Pair.^can('int8')` regression this PR fixes)
- [x] `raku t/can-methods-drift.t` -- every new assertion added by this PR passes against real Rakudo too
- [x] Full local `t/` suite (`prove -e target/debug/mutsu t/ -j4`, 3166 files) green
- [x] `roast/S12-introspection/{can,meta-class,walk}.t`, `roast/S12-enums/thorough.t`, `roast/S32-exceptions/misc2.t`, `roast/S02-types/hash.t`, `roast/S09-typed-arrays/hashes.t` green
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)