### PR TITLE
fix(adr0019): F3 step 2 complete -- introspection gaps across all 18 catalog owners

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -882,6 +882,24 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   targeted `S12-introspection`/`S02-types/hash.t`/`S09-typed-arrays/hashes.t` roast files stay
   green. Running total: 4 of 18 owners triaged (`Mu`, `Any`, `Hash`, `Cool`); `Str` (25 extras) and
   `Int`/`Num`/`Rat`/`Complex` (25, likely shared) remain the largest untriaged owners.
+  **Progress (2026-08-15, step 2, `Int`/`Num`/`Rat`/`Complex`):** the "25 extras, likely shared"
+  guess above was wrong — checked `RAW_ROWS` directly per owner instead of assuming: only `Int` has
+  a real 25-name extras block; `Num` has none; `Rat` has 2 (`FatRat`, `nude`); `Complex` has 8. Of
+  `Int`'s 25, 7 are genuine `Int.^methods` gaps (`rand`, `uniprop`, `lsb`, `msb`, `int8`, `Real`,
+  `Complex`), all raku-verified and already dispatching correctly; the other 18 are confirmed
+  dispatch-only. `Rat`'s both extras are genuine (`FatRat`, `nude`). Of `Complex`'s 8, 6 are genuine
+  (`isNaN`, `re`, `im`, `reals`, `conj`, `Complex`); `UInt`/`reverse` are dispatch-only. Since
+  `NUMERIC_OWN` is one array shared by all four owners but these extras are NOT shared (e.g. `rand`
+  is `Int`-only per `RAW_ROWS`, even though real Rakudo also has `Num`/`Rat` `.rand` — a separate,
+  still-open gap `RAW_ROWS` itself doesn't cover, out of F3's own "match `RAW_ROWS`" scope), split
+  the `"Int" | "Num" | "Rat" | "Complex"` match arm into four, each with its own optional extra tail
+  (`INT_EXTRA_TAIL`, `RAT_EXTRA_TAIL`, `COMPLEX_EXTRA_TAIL`) appended after `NUMERIC_COERCIONS`,
+  matching each block's `RAW_ROWS` position. All raku-verified and pinned in
+  `t/can-methods-drift.t` (96 assertions total now). Full local `t/` suite (3167 files) and the
+  targeted `S12-introspection/*`/`S32-num/*` roast files stay green. Running total: 8 of 18 owners
+  now settled (`Mu`, `Any`, `Hash`, `Cool`, `Int`, `Num`, `Rat`, `Complex` — `Num` needed no
+  changes, its extras block was empty). `Str` (25 extras) is now the only large owner left
+  untriaged; the remaining 10 owners are the small-count ones the original survey table lists.
 - [ ] **F4 — Remove `ClassDef::methods` as a dispatch/registration mirror.** Leave type structure
   metadata beside the canonical method table and update snapshots/rollback to copy one source.
 - [x] **F5 — Remove superseded method caches and manual invalidation.** Keep only the

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -917,6 +917,26 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   `Cool`, `Complex`, `Any`) are now triaged. The remaining ~10 small owners (1-3 extras each per the
   original survey table) are still open for step 2 but are far smaller individually; step 3 (the
   actual `RAW_ROWS`-as-single-source cutover) can reasonably start once those are swept too.
+  **Progress (2026-08-15, step 2, `List`/`Array`/`Range`/`Blob`):** the "1-3 extras each" estimate
+  for the remaining owners above was also wrong for these four — a fresh `RAW_ROWS`-vs-introspection
+  diff (not the original survey's rough read) found `List` has 18 extras, `Array` 19, `Range` 13,
+  `Blob` 7; `Bool`/`Sub`/`Signature`/`IO::Path`/`IO::Handle` genuinely have zero (already fully
+  covered). `List` gains 13 (`list`, `item`, `Slip`, `sink`, `invert`, `AT-POS`, `EXISTS-POS`,
+  `is-lazy`, `Capture`, `hyper`, `race`, `Supply`, `fmt`); `Array` gains those same 13 plus two more
+  real Rakudo answers only for `Array` specifically (`WHICH`, `dynamic`) — confirmed by raku, not
+  assumed, since `LIST_METHODS` is one array shared by both owners but `RAW_ROWS` itself lists
+  `WHICH` only under `Array`, not `List`. `Range` gains 7 (`hyper`, `lazy`, `int-bounds`, `AT-POS`,
+  `race`, `in-range`, `EXISTS-POS`). `Blob`/`Buf` gain 5 (`read-uint8`, `read-int8`, `read-uint16`,
+  `read-int16`, `read-uint32`). All 25 additions raku-verified and already dispatched correctly
+  before this change. Since `List`/`Array` need different extra sets from the same shared base,
+  split their match arm into two with separate `LIST_EXTRA_TAIL`/`ARRAY_EXTRA_TAIL` tails (same
+  pattern as the `Int`/`Rat`/`Complex` split earlier in this box). All raku-verified and pinned in
+  `t/can-methods-drift.t` (193 assertions total now). Full local `t/` suite (3167 files) green;
+  `roast/S12-introspection/*`, `S02-types/{array,list,range}.t`, `S32-container/buf.t`,
+  `S03-operators/buf.t`, and every `S03-buf/*.t` file green (via `scripts/run-roast-test.sh`).
+  Running total: 13 of 18 owners now settled. Remaining 5 (`Sub`/`Signature`/`IO::Path`/
+  `IO::Handle`/`Bool` per the fresh diff) all have **zero** extras — F3 step 2's owner-by-owner
+  triage is therefore complete; step 3 (the actual cutover) is unblocked.
 - [ ] **F4 — Remove `ClassDef::methods` as a dispatch/registration mirror.** Leave type structure
   metadata beside the canonical method table and update snapshots/rollback to copy one source.
 - [x] **F5 — Remove superseded method caches and manual invalidation.** Keep only the

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -900,6 +900,23 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   now settled (`Mu`, `Any`, `Hash`, `Cool`, `Int`, `Num`, `Rat`, `Complex` — `Num` needed no
   changes, its extras block was empty). `Str` (25 extras) is now the only large owner left
   untriaged; the remaining 10 owners are the small-count ones the original survey table lists.
+  **Progress (2026-08-15, step 2, `Str`):** triaged `Str`'s 24-name extras block (the survey's "25"
+  count off by one). 11 genuine `Str.^methods` gaps (`uniprop`, `indent`, `ord`, `uniname`,
+  `uninames`, `unival`, `univals`, `tclc`, `Version`, `Date`, `DateTime`), all raku-verified and
+  already dispatching correctly (e.g. `'A'.ord`, `65.uniname`, `'1.2.3'.Version`). The other 13
+  (`AST`, `list`, `UInt`, `FatRat`, `sprintf`, `chrs`, `bytes`, `Range`, `Complex`, `Real`,
+  `reverse`, `byte`, `perl`) confirmed dispatch-only — real Rakudo's `Str.^methods` lists none of
+  them. Added a new `STR_EXTRA_TAIL`, appended after the existing `&["elems", "fmt"]` tail in the
+  `"Str"` match arm, matching the block's `RAW_ROWS` position. All raku-verified and pinned in
+  `t/can-methods-drift.t` (129 assertions total now). Full local `t/` suite (3167 files) green;
+  `roast/S12-introspection/*` and every `roast/S32-str/*.t` file green too (invoked via
+  `scripts/run-roast-test.sh`, not a bare `prove` — the bare invocation spuriously "fails" 3 of the
+  encoding-conversion files on missing fixture paths that only resolve inside that wrapper, an
+  invocation artifact unrelated to this change, not a regression). **This closes F3 step 2's
+  large-owner sweep**: all 5 owners the original survey flagged as having 7+ extras (`Str`, `Int`,
+  `Cool`, `Complex`, `Any`) are now triaged. The remaining ~10 small owners (1-3 extras each per the
+  original survey table) are still open for step 2 but are far smaller individually; step 3 (the
+  actual `RAW_ROWS`-as-single-source cutover) can reasonably start once those are swept too.
 - [ ] **F4 — Remove `ClassDef::methods` as a dispatch/registration mirror.** Leave type structure
   metadata beside the canonical method table and update snapshots/rollback to copy one source.
 - [x] **F5 — Remove superseded method caches and manual invalidation.** Keep only the

--- a/news/2026-08/adr0019-f3-step2-complete.md
+++ b/news/2026-08/adr0019-f3-step2-complete.md
@@ -1,0 +1,33 @@
+# ADR-0019 F3 step 2 complete: every catalog owner's introspection gap triaged
+
+Finished the ADR-0019 Phase F box F3 raku-verification triage that started earlier this week: for
+every one of the 18 `BUILTIN_METHOD_OWNERS`, checking each name `native_method_row.rs`'s `RAW_ROWS`
+catalog recognizes for dispatch but the per-type `.^methods` introspection arrays in
+`builtin_type_methods.rs` don't list, and classifying it as a genuine `.^methods` gap (add it,
+raku-verified) or deliberately dispatch-only (leave it out, real Rakudo's own `.^methods` omits it
+too).
+
+The original survey's rough extras counts for the remaining owners ("1-3 extras each") turned out
+to be as inaccurate as the earlier "shared 25 extras" guess for the numeric family: a fresh direct
+diff found `List` actually carries 18 extras, `Array` 19, `Range` 13, and `Blob` 7. `List` gained
+13 genuine names (`list`, `item`, `Slip`, `sink`, `invert`, `AT-POS`, `EXISTS-POS`, `is-lazy`,
+`Capture`, `hyper`, `race`, `Supply`, `fmt`); `Array` gained those same 13 plus two more real
+Rakudo answers only for `Array` specifically (`WHICH`, `dynamic`) — confirmed directly against
+raku, not assumed. `Range` gained 7 (`hyper`, `lazy`, `int-bounds`, `AT-POS`, `race`, `in-range`,
+`EXISTS-POS`). `Blob`/`Buf` gained 5 (`read-uint8`, `read-int8`, `read-uint16`, `read-int16`,
+`read-uint32`). All 25 already dispatched correctly before this change. Since `List`/`Array` share
+one introspection array (`LIST_METHODS`) but need different extras, split their lookup into
+separate `LIST_EXTRA_TAIL`/`ARRAY_EXTRA_TAIL` tails, mirroring the split already used for
+`Int`/`Rat`/`Complex`.
+
+The remaining 5 owners (`Sub`, `Signature`, `IO::Path`, `IO::Handle`, `Bool`) turned out to already
+have zero drift — nothing to add. All additions across this whole triage effort are pinned in
+`t/can-methods-drift.t`, which now carries 193 assertions, each verified against real `raku`
+output.
+
+**Every one of the 18 catalog owners has now been triaged.** Step 3 — the actual cutover that lets
+`builtin_method_entries`/`builtin_type_method_names` read from `RAW_ROWS` directly and retires the
+14 hand-written arrays — is unblocked, though it still needs its own design pass for how to encode
+"dispatch-only, not introspectable" as data (a flag on `NativeMethodRow`) rather than by omission
+from a second array. See `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` for the
+full history and the suggested next step.

--- a/news/2026-08/adr0019-f3-step2-numeric-family.md
+++ b/news/2026-08/adr0019-f3-step2-numeric-family.md
@@ -1,0 +1,26 @@
+# ADR-0019 F3 step 2: `Int`/`Rat`/`Complex` introspection gaps
+
+Continued the ADR-0019 Phase F box F3 raku-verification triage of names `native_method_row.rs`'s
+`RAW_ROWS` catalog recognizes for dispatch but the per-type `.^methods` arrays in
+`builtin_type_methods.rs` don't list.
+
+The numeric family (`Int`/`Num`/`Rat`/`Complex`) was previously assumed to share one 25-name extras
+set via the common `NUMERIC_OWN` array. Checking `RAW_ROWS` directly instead of assuming showed
+that guess was wrong: only `Int` actually carries a 25-name extras block; `Num` has none; `Rat` has
+2 (`FatRat`, `nude`); `Complex` has 8.
+
+Raku-verified each: `Int` gained `rand`, `uniprop`, `lsb`, `msb`, `int8`, `Real`, and `Complex` (7
+of its 25 extras — the other 18 confirmed dispatch-only, real Rakudo's `Int.^methods` doesn't list
+them). `Rat` gained both `FatRat` and `nude`. `Complex` gained `isNaN`, `re`, `im`, `reals`,
+`conj`, and `Complex` (6 of 8 — `UInt`/`reverse` confirmed dispatch-only). All 15 additions
+already dispatched correctly before this change; only `.^methods` enumeration was missing them.
+
+Since these extras are genuinely per-owner rather than shared, the combined
+`"Int" | "Num" | "Rat" | "Complex"` match arm in `builtin_type_method_names` was split into four,
+each with its own optional extra tail appended after the shared coercion methods. All raku-verified
+and pinned in `t/can-methods-drift.t`, which now carries 96 assertions.
+
+8 of 18 catalog owners are now settled (`Mu`, `Any`, `Hash`, `Cool`, `Int`, `Num`, `Rat`, `Complex`
+— `Num` needed no changes, its extras block was empty). `Str` (25 extras) is the only large owner
+left untriaged; see `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` for the
+running list.

--- a/news/2026-08/adr0019-f3-step2-str.md
+++ b/news/2026-08/adr0019-f3-step2-str.md
@@ -1,0 +1,19 @@
+# ADR-0019 F3 step 2: `Str.^methods` introspection gaps close the large-owner sweep
+
+Continued the ADR-0019 Phase F box F3 raku-verification triage of names `RAW_ROWS` recognizes for
+dispatch but the per-type `.^methods` introspection arrays don't list. `Str` carried a 24-name
+extras block (the original survey's "25" count was off by one).
+
+Raku-verified all 24: `uniprop`, `indent`, `ord`, `uniname`, `uninames`, `unival`, `univals`,
+`tclc`, `Version`, `Date`, and `DateTime` are genuine `Str.^methods` gaps — all already dispatch
+correctly on mutsu (`'A'.ord` → 65, `65.uniname` → "LATIN CAPITAL LETTER A", `'1.2.3'.Version` →
+v1.2.3, etc.). The other 13 (`AST`, `list`, `UInt`, `FatRat`, `sprintf`, `chrs`, `bytes`, `Range`,
+`Complex`, `Real`, `reverse`, `byte`, `perl`) are confirmed dispatch-only — real Rakudo's
+`Str.^methods` lists none of them. Added a new `STR_EXTRA_TAIL` array and pinned all 11 additions
+in `t/can-methods-drift.t`, which now carries 129 assertions.
+
+This closes F3 step 2's sweep of every large owner the original survey flagged with 7+ extras
+(`Str`, `Int`, `Cool`, `Complex`, `Any`) — 9 of 18 catalog owners are now fully settled. The
+remaining ~9 owners each have only 1-3 extras per the original survey, much smaller individual
+slices; see `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md` for the running
+list.

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -83,6 +83,28 @@ const NUMERIC_OWN: &[&str] = &[
     "chr", "base", "polymod", "expmod", "pred", "succ",
 ];
 
+/// `Int`-only extras beyond the shared `NUMERIC_OWN`/`NUMERIC_COERCIONS` tail.
+/// ADR-0019 Phase F box F3 step 2 (`todo/deep/
+/// adr0019-f3-raw-rows-drift-from-introspection-arrays.md`): `RAW_ROWS` lists
+/// these 7 only under the `"Int"` owner (not `Num`/`Rat`/`Complex`), and all 7
+/// are raku-verified genuine `Int.^methods` entries that already dispatch
+/// correctly. `rand` is also real on `Num`/`Rat` in Rakudo, but `RAW_ROWS` has
+/// no row for it there either -- that's a separate, still-open introspection
+/// gap outside this array's scope (F3 tracks `RAW_ROWS` parity, not a full
+/// raku-fidelity sweep of the whole numeric family).
+const INT_EXTRA_TAIL: &[&str] = &["rand", "uniprop", "lsb", "msb", "int8", "Real", "Complex"];
+
+/// `Rat`-only extras beyond the shared `NUMERIC_OWN`/`NUMERIC_COERCIONS` tail
+/// (ADR-0019 Phase F box F3 step 2), raku-verified genuine `Rat.^methods`
+/// entries that already dispatch correctly.
+const RAT_EXTRA_TAIL: &[&str] = &["FatRat", "nude"];
+
+/// `Complex`-only extras beyond the shared `NUMERIC_OWN`/`NUMERIC_COERCIONS`
+/// tail (ADR-0019 Phase F box F3 step 2). `RAW_ROWS` also lists `UInt` and
+/// `reverse` under `Complex`, but real Rakudo's `Complex.^methods` does not
+/// include either -- confirmed dispatch-only, left out.
+const COMPLEX_EXTRA_TAIL: &[&str] = &["isNaN", "re", "im", "reals", "conj", "Complex"];
+
 /// `Bool` methods, up to the coercion tail.
 const BOOL_OWN: &[&str] = &["pred", "succ", "pick", "roll"];
 
@@ -477,7 +499,10 @@ pub(crate) fn builtin_type_method_names(type_name: &str) -> Vec<&'static str> {
     }
     match type_name {
         "Str" => [STR_OWN, NUMERIC_COERCIONS, &["elems", "fmt"]].concat(),
-        "Int" | "Num" | "Rat" | "Complex" => [NUMERIC_OWN, NUMERIC_COERCIONS].concat(),
+        "Int" => [NUMERIC_OWN, NUMERIC_COERCIONS, INT_EXTRA_TAIL].concat(),
+        "Rat" => [NUMERIC_OWN, NUMERIC_COERCIONS, RAT_EXTRA_TAIL].concat(),
+        "Complex" => [NUMERIC_OWN, NUMERIC_COERCIONS, COMPLEX_EXTRA_TAIL].concat(),
+        "Num" => [NUMERIC_OWN, NUMERIC_COERCIONS].concat(),
         "List" | "Array" => LIST_METHODS.to_vec(),
         "Hash" => HASH_METHODS.to_vec(),
         "Bool" => [BOOL_OWN, NUMERIC_COERCIONS].concat(),

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -239,6 +239,53 @@ const LIST_METHODS: &[&str] = &[
     "List",
 ];
 
+/// `List`-only extras beyond `LIST_METHODS` (ADR-0019 Phase F box F3 step 2,
+/// `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md`),
+/// raku-verified genuine `List.^methods` entries that already dispatch
+/// correctly. `RAW_ROWS` also lists `cache`/`WHICH`/`tree`/`pairup`/`hash`
+/// under `List`, but real Rakudo's `List.^methods` does not include any of
+/// those -- confirmed dispatch-only, left out. (`WHICH` genuinely is on
+/// `Array.^methods` -- see `ARRAY_EXTRA_TAIL` -- but not on plain `List`'s.)
+const LIST_EXTRA_TAIL: &[&str] = &[
+    "list",
+    "item",
+    "Slip",
+    "sink",
+    "invert",
+    "AT-POS",
+    "EXISTS-POS",
+    "is-lazy",
+    "Capture",
+    "hyper",
+    "race",
+    "Supply",
+    "fmt",
+];
+
+/// `Array`-only extras beyond `LIST_METHODS` (ADR-0019 Phase F box F3 step
+/// 2), raku-verified genuine `Array.^methods` entries that already dispatch
+/// correctly. Differs from `LIST_EXTRA_TAIL` by two names Rakudo's `Array`
+/// answers but plain `List` doesn't: `WHICH` and `dynamic`. `RAW_ROWS` also
+/// lists `cache`/`tree`/`pairup`/`hash` under `Array`, confirmed
+/// dispatch-only like `List`'s, left out.
+const ARRAY_EXTRA_TAIL: &[&str] = &[
+    "list",
+    "item",
+    "Slip",
+    "sink",
+    "invert",
+    "WHICH",
+    "AT-POS",
+    "EXISTS-POS",
+    "is-lazy",
+    "Capture",
+    "dynamic",
+    "hyper",
+    "race",
+    "Supply",
+    "fmt",
+];
+
 const HASH_METHODS: &[&str] = &[
     "elems",
     "keys",
@@ -289,6 +336,21 @@ const RANGE_METHODS: &[&str] = &[
     "Int",
     "excludes-min",
     "excludes-max",
+];
+
+/// `Range`-only extras beyond `RANGE_METHODS` (ADR-0019 Phase F box F3 step
+/// 2), raku-verified genuine `Range.^methods` entries that already dispatch
+/// correctly. `RAW_ROWS` also lists `Array`/`join`/`Supply`/`List`/`head`/
+/// `batch` under `Range`, but real Rakudo's `Range.^methods` does not
+/// include any of those -- confirmed dispatch-only, left out.
+const RANGE_EXTRA_TAIL: &[&str] = &[
+    "hyper",
+    "lazy",
+    "int-bounds",
+    "AT-POS",
+    "race",
+    "in-range",
+    "EXISTS-POS",
 ];
 
 const CODE_METHODS: &[&str] = &[
@@ -505,9 +567,22 @@ const BUF_METHODS: &[&str] = &[
     "raku",
 ];
 
+/// `Blob`/`Buf`-only extras beyond `BUF_METHODS` (ADR-0019 Phase F box F3
+/// step 2), raku-verified genuine `.^methods` entries that already dispatch
+/// correctly (`$buf.read-uint8(0)`, etc.). `RAW_ROWS` also lists `values`/
+/// `List` under `Blob`, but real Rakudo's `Blob.^methods` does not include
+/// either -- confirmed dispatch-only, left out.
+const BUF_EXTRA_TAIL: &[&str] = &[
+    "read-uint8",
+    "read-int8",
+    "read-uint16",
+    "read-int16",
+    "read-uint32",
+];
+
 pub(crate) fn builtin_type_method_names(type_name: &str) -> Vec<&'static str> {
     if crate::runtime::utils::is_buf_or_blob_class(type_name) {
-        return BUF_METHODS.to_vec();
+        return [BUF_METHODS, BUF_EXTRA_TAIL].concat();
     }
     match type_name {
         "Str" => [
@@ -521,10 +596,11 @@ pub(crate) fn builtin_type_method_names(type_name: &str) -> Vec<&'static str> {
         "Rat" => [NUMERIC_OWN, NUMERIC_COERCIONS, RAT_EXTRA_TAIL].concat(),
         "Complex" => [NUMERIC_OWN, NUMERIC_COERCIONS, COMPLEX_EXTRA_TAIL].concat(),
         "Num" => [NUMERIC_OWN, NUMERIC_COERCIONS].concat(),
-        "List" | "Array" => LIST_METHODS.to_vec(),
+        "List" => [LIST_METHODS, LIST_EXTRA_TAIL].concat(),
+        "Array" => [LIST_METHODS, ARRAY_EXTRA_TAIL].concat(),
         "Hash" => HASH_METHODS.to_vec(),
         "Bool" => [BOOL_OWN, NUMERIC_COERCIONS].concat(),
-        "Range" => RANGE_METHODS.to_vec(),
+        "Range" => [RANGE_METHODS, RANGE_EXTRA_TAIL].concat(),
         "Sub" | "Method" | "Block" | "Routine" | "Code" => CODE_METHODS.to_vec(),
         "Signature" => SIGNATURE_METHODS.to_vec(),
         "IO::Path" => IO_PATH_METHODS.to_vec(),

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -77,6 +77,18 @@ const STR_OWN: &[&str] = &[
     "IO",
 ];
 
+/// `Str`-only extras beyond the shared coercion tail (ADR-0019 Phase F box F3
+/// step 2, `todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md`),
+/// raku-verified genuine `Str.^methods` entries that already dispatch
+/// correctly. `RAW_ROWS` also lists `AST`/`list`/`UInt`/`FatRat`/`sprintf`/
+/// `chrs`/`bytes`/`Range`/`Complex`/`Real`/`reverse`/`byte`/`perl` under
+/// `Str`, but real Rakudo's `Str.^methods` does not include any of those --
+/// confirmed dispatch-only, left out.
+const STR_EXTRA_TAIL: &[&str] = &[
+    "uniprop", "indent", "ord", "uniname", "uninames", "unival", "univals", "tclc", "Version",
+    "Date", "DateTime",
+];
+
 /// Numeric leaf (`Int`/`Num`/`Rat`/`Complex`) methods, up to the coercion tail.
 const NUMERIC_OWN: &[&str] = &[
     "abs", "ceiling", "floor", "round", "sign", "sqrt", "log", "log10", "exp", "roots", "is-prime",
@@ -498,7 +510,13 @@ pub(crate) fn builtin_type_method_names(type_name: &str) -> Vec<&'static str> {
         return BUF_METHODS.to_vec();
     }
     match type_name {
-        "Str" => [STR_OWN, NUMERIC_COERCIONS, &["elems", "fmt"]].concat(),
+        "Str" => [
+            STR_OWN,
+            NUMERIC_COERCIONS,
+            &["elems", "fmt"],
+            STR_EXTRA_TAIL,
+        ]
+        .concat(),
         "Int" => [NUMERIC_OWN, NUMERIC_COERCIONS, INT_EXTRA_TAIL].concat(),
         "Rat" => [NUMERIC_OWN, NUMERIC_COERCIONS, RAT_EXTRA_TAIL].concat(),
         "Complex" => [NUMERIC_OWN, NUMERIC_COERCIONS, COMPLEX_EXTRA_TAIL].concat(),

--- a/t/can-methods-drift.t
+++ b/t/can-methods-drift.t
@@ -5,7 +5,7 @@ use Test;
 # methods were missing, so `.^can` lied (returned False) and `.^methods` omitted
 # them. These pin the methods back in sync — each one both works AND introspects.
 
-plan 129;
+plan 193;
 
 # Helper: the method genuinely dispatches (so the list entry is honest) and
 # `.^can` agrees.
@@ -55,6 +55,41 @@ works-and-can (1+2i), 'Complex', { (1+2i).Complex };
 # --- List / Array ---
 works-and-can (1, 2, 3), 'minpairs', { (1, 2, 3).minpairs };
 works-and-can (1, 2, 3), 'maxpairs', { (1, 2, 3).maxpairs };
+works-and-can (1, 2, 3), 'list',        { (1, 2, 3).list };
+works-and-can (1, 2, 3), 'item',        { (1, 2, 3).item };
+works-and-can (1, 2, 3), 'Slip',        { (1, 2, 3).Slip };
+works-and-can (1, 2, 3), 'sink',        { (1, 2, 3).sink };
+works-and-can (a => 1, b => 2), 'invert', { (a => 1, b => 2).invert };
+works-and-can (1, 2, 3), 'AT-POS',      { (1, 2, 3).AT-POS(0) };
+works-and-can (1, 2, 3), 'EXISTS-POS',  { (1, 2, 3).EXISTS-POS(0) };
+works-and-can (1, 2, 3), 'is-lazy',     { (1, 2, 3).is-lazy };
+works-and-can (1, 2, 3), 'Capture',     { (1, 2, 3).Capture };
+works-and-can (1, 2, 3), 'hyper',       { (1, 2, 3).hyper };
+works-and-can (1, 2, 3), 'race',        { (1, 2, 3).race };
+works-and-can (1, 2, 3), 'Supply',      { (1, 2, 3).Supply };
+works-and-can (1, 2, 3), 'fmt',         { (1, 2, 3).fmt('%d') };
+
+my @arr = (1, 2, 3);
+works-and-can @arr, 'WHICH',   { @arr.WHICH };
+works-and-can @arr, 'dynamic', { @arr.dynamic };
+
+# --- Range ---
+my $rng = 1..5;
+works-and-can $rng, 'hyper',       { $rng.hyper };
+works-and-can $rng, 'lazy',        { $rng.lazy };
+works-and-can $rng, 'int-bounds',  { $rng.int-bounds };
+works-and-can $rng, 'AT-POS',      { $rng.AT-POS(0) };
+works-and-can $rng, 'race',        { $rng.race };
+works-and-can $rng, 'in-range',    { $rng.in-range(3) };
+works-and-can $rng, 'EXISTS-POS',  { $rng.EXISTS-POS(0) };
+
+# --- Blob / Buf ---
+my $buf = Buf.new(1, 2, 3, 4, 5, 6, 7, 8);
+works-and-can $buf, 'read-uint8',  { $buf.read-uint8(0) };
+works-and-can $buf, 'read-int8',   { $buf.read-int8(0) };
+works-and-can $buf, 'read-uint16', { $buf.read-uint16(0) };
+works-and-can $buf, 'read-int16',  { $buf.read-int16(0) };
+works-and-can $buf, 'read-uint32', { $buf.read-uint32(0) };
 
 # --- Mu ---
 works-and-can 5, 'DEFINITE', { 5.DEFINITE };
@@ -98,6 +133,16 @@ ok 'x'.^methods.map(*.Str).grep('Version'),      'Str.^methods includes Version'
 ok 'x'.^methods.map(*.Str).grep('Date'),         'Str.^methods includes Date';
 ok 'x'.^methods.map(*.Str).grep('DateTime'),     'Str.^methods includes DateTime';
 ok (1, 2).^methods.map(*.Str).grep('minpairs'),  'List.^methods includes minpairs';
+ok (1, 2).^methods.map(*.Str).grep('Slip'),      'List.^methods includes Slip';
+ok (1, 2).^methods.map(*.Str).grep('hyper'),     'List.^methods includes hyper';
+ok (1, 2).^methods.map(*.Str).grep('fmt'),       'List.^methods includes fmt';
+ok @arr.^methods.map(*.Str).grep('WHICH'),       'Array.^methods includes WHICH';
+ok @arr.^methods.map(*.Str).grep('dynamic'),     'Array.^methods includes dynamic';
+ok $rng.^methods.map(*.Str).grep('hyper'),       'Range.^methods includes hyper';
+ok $rng.^methods.map(*.Str).grep('int-bounds'),  'Range.^methods includes int-bounds';
+ok $rng.^methods.map(*.Str).grep('in-range'),    'Range.^methods includes in-range';
+ok $buf.^methods.map(*.Str).grep('read-uint8'),  'Blob.^methods includes read-uint8';
+ok $buf.^methods.map(*.Str).grep('read-uint32'), 'Blob.^methods includes read-uint32';
 ok Mu.^methods.map(*.Str).grep('DEFINITE'),      'Mu.^methods includes DEFINITE';
 ok Any.^methods.map(*.Str).grep('serial'),       'Any.^methods includes serial';
 ok Any.^methods.map(*.Str).grep('hash'),         'Any.^methods includes hash';

--- a/t/can-methods-drift.t
+++ b/t/can-methods-drift.t
@@ -5,7 +5,7 @@ use Test;
 # methods were missing, so `.^can` lied (returned False) and `.^methods` omitted
 # them. These pin the methods back in sync — each one both works AND introspects.
 
-plan 57;
+plan 96;
 
 # Helper: the method genuinely dispatches (so the list entry is honest) and
 # `.^can` agrees.
@@ -22,7 +22,24 @@ works-and-can 'abc', 'substr-rw',    { my $s = 'abc'; $s.substr-rw(0, 1) = 'Z' }
 works-and-can 'abc', 'substr-eq',    { 'abc'.substr-eq('bc', 1) };
 
 # --- Int ---
-works-and-can 5, 'expmod', { 4.expmod(2, 5) };
+works-and-can 5, 'expmod',  { 4.expmod(2, 5) };
+works-and-can 5, 'rand',    { 5.rand };
+works-and-can 65, 'uniprop', { 65.uniprop('Alpha') };
+works-and-can 5, 'lsb',     { 5.lsb };
+works-and-can 5, 'msb',     { 5.msb };
+works-and-can 5, 'Real',    { 5.Real };
+
+# --- Rat ---
+works-and-can (1/3), 'FatRat', { (1/3).FatRat };
+works-and-can (1/3), 'nude',   { (1/3).nude };
+
+# --- Complex ---
+works-and-can (1+2i), 'isNaN', { (1+2i).isNaN };
+works-and-can (1+2i), 're',    { (1+2i).re };
+works-and-can (1+2i), 'im',    { (1+2i).im };
+works-and-can (1+2i), 'reals', { (1+2i).reals };
+works-and-can (1+2i), 'conj',  { (1+2i).conj };
+works-and-can (1+2i), 'Complex', { (1+2i).Complex };
 
 # --- List / Array ---
 works-and-can (1, 2, 3), 'minpairs', { (1, 2, 3).minpairs };
@@ -71,6 +88,19 @@ ok %h.^methods.map(*.Str).grep('flat'),          'Hash.^methods includes flat';
 ok %h.^methods.map(*.Str).grep('dynamic'),       'Hash.^methods includes dynamic';
 ok %h.^methods.map(*.Str).grep('roll'),          'Hash.^methods includes roll';
 ok Cool.^methods.map(*.Str).grep('int8'),        'Cool.^methods includes int8';
+ok 5.^methods.map(*.Str).grep('rand'),           'Int.^methods includes rand';
+ok 5.^methods.map(*.Str).grep('uniprop'),        'Int.^methods includes uniprop';
+ok 5.^methods.map(*.Str).grep('lsb'),            'Int.^methods includes lsb';
+ok 5.^methods.map(*.Str).grep('msb'),            'Int.^methods includes msb';
+ok 5.^methods.map(*.Str).grep('Real'),           'Int.^methods includes Real';
+ok 5.^methods.map(*.Str).grep('int8'),           'Int.^methods includes int8';
+ok (1/3).^methods.map(*.Str).grep('FatRat'),     'Rat.^methods includes FatRat';
+ok (1/3).^methods.map(*.Str).grep('nude'),       'Rat.^methods includes nude';
+ok (1+2i).^methods.map(*.Str).grep('isNaN'),     'Complex.^methods includes isNaN';
+ok (1+2i).^methods.map(*.Str).grep('re'),        'Complex.^methods includes re';
+ok (1+2i).^methods.map(*.Str).grep('im'),        'Complex.^methods includes im';
+ok (1+2i).^methods.map(*.Str).grep('reals'),     'Complex.^methods includes reals';
+ok (1+2i).^methods.map(*.Str).grep('conj'),      'Complex.^methods includes conj';
 
 # Methods that mutsu does NOT implement must still report False (no over-claim).
 nok 'abc'.^can('samespace').Bool, 'unimplemented samespace is not over-claimed';

--- a/t/can-methods-drift.t
+++ b/t/can-methods-drift.t
@@ -5,7 +5,7 @@ use Test;
 # methods were missing, so `.^can` lied (returned False) and `.^methods` omitted
 # them. These pin the methods back in sync — each one both works AND introspects.
 
-plan 96;
+plan 129;
 
 # Helper: the method genuinely dispatches (so the list entry is honest) and
 # `.^can` agrees.
@@ -20,6 +20,17 @@ works-and-can 'abc', 'subst',        { 'abc'.subst('a', 'X') };
 works-and-can 'abc', 'subst-mutate', { my $s = 'abc'; $s.subst-mutate(/a/, 'X') };
 works-and-can 'abc', 'substr-rw',    { my $s = 'abc'; $s.substr-rw(0, 1) = 'Z' };
 works-and-can 'abc', 'substr-eq',    { 'abc'.substr-eq('bc', 1) };
+works-and-can 'A', 'uniprop',   { 'A'.uniprop('Alpha') };
+works-and-can 'hi', 'indent',   { 'hi'.indent(2) };
+works-and-can 'A', 'ord',       { 'A'.ord };
+works-and-can 'A', 'uniname',   { 'A'.uniname };
+works-and-can 'AB', 'uninames', { 'AB'.uninames };
+works-and-can '5', 'unival',    { '5'.unival };
+works-and-can '12', 'univals',  { '12'.univals };
+works-and-can 'hi', 'tclc',     { 'hi'.tclc };
+works-and-can '1.2.3', 'Version',  { '1.2.3'.Version };
+works-and-can '2024-01-01', 'Date', { '2024-01-01'.Date };
+works-and-can '2024-01-01T00:00:00Z', 'DateTime', { '2024-01-01T00:00:00Z'.DateTime };
 
 # --- Int ---
 works-and-can 5, 'expmod',  { 4.expmod(2, 5) };
@@ -75,6 +86,17 @@ nok (a => 1).^can('int8').Bool, 'Pair is not Cool, so it cannot int8';
 # The fixed names also appear in `.^methods`.
 ok 'x'.^methods.map(*.Str).grep('trans'),        'Str.^methods includes trans';
 ok 'x'.^methods.map(*.Str).grep('substr-rw'),    'Str.^methods includes substr-rw';
+ok 'x'.^methods.map(*.Str).grep('uniprop'),      'Str.^methods includes uniprop';
+ok 'x'.^methods.map(*.Str).grep('indent'),       'Str.^methods includes indent';
+ok 'x'.^methods.map(*.Str).grep('ord'),          'Str.^methods includes ord';
+ok 'x'.^methods.map(*.Str).grep('uniname'),      'Str.^methods includes uniname';
+ok 'x'.^methods.map(*.Str).grep('uninames'),     'Str.^methods includes uninames';
+ok 'x'.^methods.map(*.Str).grep('unival'),       'Str.^methods includes unival';
+ok 'x'.^methods.map(*.Str).grep('univals'),      'Str.^methods includes univals';
+ok 'x'.^methods.map(*.Str).grep('tclc'),         'Str.^methods includes tclc';
+ok 'x'.^methods.map(*.Str).grep('Version'),      'Str.^methods includes Version';
+ok 'x'.^methods.map(*.Str).grep('Date'),         'Str.^methods includes Date';
+ok 'x'.^methods.map(*.Str).grep('DateTime'),     'Str.^methods includes DateTime';
 ok (1, 2).^methods.map(*.Str).grep('minpairs'),  'List.^methods includes minpairs';
 ok Mu.^methods.map(*.Str).grep('DEFINITE'),      'Mu.^methods includes DEFINITE';
 ok Any.^methods.map(*.Str).grep('serial'),       'Any.^methods includes serial';

--- a/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
+++ b/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
@@ -205,3 +205,36 @@ regression.
 
 Running total: 4 of 18 owners fully triaged (`Mu`, `Any`, `Hash`, `Cool`). Largest remaining: `Str`
 (25 extras), `Int`/`Num`/`Rat`/`Complex` (25, likely shared via `NUMERIC_OWN`).
+
+## Progress (2026-08-15, continued): `Int`/`Num`/`Rat`/`Complex` triaged -- the "shared" guess was wrong
+
+The earlier note above guessed `Int`/`Num`/`Rat`/`Complex` share the same 25 extras via the common
+`NUMERIC_OWN` array. Checked `RAW_ROWS` directly instead of assuming: only `Int` actually has a
+25-name extras block; `Num` has zero; `Rat` has 2 (`FatRat`, `nude`); `Complex` has 8
+(`UInt`, `isNaN`, `re`, `im`, `reals`, `conj`, `reverse`, `Complex`).
+
+`Int`: 7 of 25 genuine (`rand`, `uniprop`, `lsb`, `msb`, `int8`, `Real`, `Complex` -- all
+raku-verified present on `Int.^methods` and already dispatching, e.g. `5.rand`, `65.uniprop`,
+`5.lsb`, `5.msb`, `5.int8`, `5.Real`, `5.Complex`). The other 18 confirmed dispatch-only.
+
+`Rat`: both extras genuine (`(1/3).FatRat`, `(1/3).nude` both raku-verified and dispatch
+correctly).
+
+`Complex`: 6 of 8 genuine (`isNaN`, `re`, `im`, `reals`, `conj`, `Complex` -- raku-verified and
+dispatching, e.g. `(1+2i).isNaN`, `.re`, `.im`, `.reals`, `.conj`, `.Complex`). `UInt`/`reverse`
+confirmed dispatch-only (real `Complex.^methods` doesn't list either).
+
+Since `NUMERIC_OWN` is one array shared by all four owners but these extras are genuinely
+per-owner (not shared) -- `RAW_ROWS` itself only lists `rand` under `"Int"`, even though real
+Rakudo's `Num`/`Rat` also have a working `.rand` (a separate, still-open gap outside `RAW_ROWS`'s
+own claims, so outside F3's "match `RAW_ROWS`" scope) -- split the combined
+`"Int" | "Num" | "Rat" | "Complex"` match arm into four, each with its own optional extra tail
+(`INT_EXTRA_TAIL`, `RAT_EXTRA_TAIL`, `COMPLEX_EXTRA_TAIL`) appended after `NUMERIC_COERCIONS`,
+positioned to match each block's location in `RAW_ROWS`. All raku-verified and pinned in
+`t/can-methods-drift.t` (96 assertions total). Full local `t/` suite (3167 files) and the targeted
+`S12-introspection/*` plus every `S32-num/*.t` roast file stay green.
+
+Running total: 8 of 18 owners now settled (`Mu`, `Any`, `Hash`, `Cool`, `Int`, `Num`, `Rat`,
+`Complex` -- `Num` needed no changes, its `RAW_ROWS` extras block was empty). `Str` (25 extras) is
+now the only large owner left untriaged; the rest are the smaller-count owners from the original
+survey.

--- a/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
+++ b/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
@@ -266,3 +266,51 @@ owner the original survey flagged with 7+ extras -- are now triaged (9 of 18 own
 counting `Mu`/`Hash`/`Rat`/`Num` too). The remaining ~9 owners left for step 2 each have only 1-3
 extras per the original survey table (much smaller individual slices); step 3 (the actual
 `RAW_ROWS`-as-single-source cutover) can reasonably start once those are swept.
+
+## Progress (2026-08-15, continued): `List`/`Array`/`Range`/`Blob` triaged -- the "1-3 extras" estimate was also wrong, and step 2 is now COMPLETE
+
+Rather than trust the original survey's rough per-owner extras counts for the remaining 9 owners,
+ran a fresh throwaway probe (temporary `#[cfg(test)]` in `native_method_row.rs`, not committed --
+iterate `BUILTIN_METHOD_OWNERS`, diff each owner's `RAW_ROWS` names against its current
+introspection array, print non-empty diffs) to get exact current numbers. Result: `List` has 18
+extras, `Array` 19, `Range` 13, `Blob` 7 -- all far larger than "1-3". `Bool`, `Sub`, `Signature`,
+`IO::Path`, `IO::Handle` printed nothing at all: genuinely **zero** extras, already fully covered.
+
+`List`: 13 of 18 genuine (`list`, `item`, `Slip`, `sink`, `invert`, `AT-POS`, `EXISTS-POS`,
+`is-lazy`, `Capture`, `hyper`, `race`, `Supply`, `fmt`), raku-verified and already dispatching
+(`(1,2,3).list`, `.item`, `.Slip`, `.sink`, pair-list `.invert`, `.AT-POS(0)`, `.EXISTS-POS(0)`,
+`.is-lazy`, `.Capture`, `.hyper`, `.race`, `.Supply`, `.fmt('%d')`). `cache`/`WHICH`/`tree`/
+`pairup`/`hash` confirmed dispatch-only for `List` specifically -- real `List.^methods` omits them.
+
+`Array`: same 13 as `List` PLUS 2 more real Rakudo answers only for `Array`: `WHICH` and
+`dynamic` -- confirmed against raku directly (`Array.^methods` includes `WHICH`, `List.^methods`
+doesn't), not assumed from `RAW_ROWS` alone. Since `LIST_METHODS` is one array shared by both
+`"List"` and `"Array"` match arms but their genuine extras differ, split into
+`LIST_EXTRA_TAIL`/`ARRAY_EXTRA_TAIL` (same shared-base-plus-per-owner-tail pattern as the
+`Int`/`Rat`/`Complex` split earlier in this file).
+
+`Range`: 7 of 13 genuine (`hyper`, `lazy`, `int-bounds`, `AT-POS`, `race`, `in-range`,
+`EXISTS-POS`), raku-verified and dispatching (`(1..5).hyper`, `.lazy`, `.int-bounds`, `.AT-POS(0)`,
+`.race`, `.in-range(3)`, `.EXISTS-POS(0)`). `Array`/`join`/`Supply`/`List`/`head`/`batch`
+confirmed dispatch-only for `Range`.
+
+`Blob`/`Buf`: 5 of 7 genuine (`read-uint8`, `read-int8`, `read-uint16`, `read-int16`,
+`read-uint32`), raku-verified and dispatching (`Buf.new(...).read-uint8(0)` etc.). `values`/`List`
+confirmed dispatch-only for `Blob`.
+
+All 25 additions pinned in `t/can-methods-drift.t` (now 193 assertions). Full local `t/` suite
+(3167 files) green; `roast/S12-introspection/*`, `S02-types/{array,list,range}.t`,
+`S32-container/buf.t`, `S03-operators/buf.t`, and every `S03-buf/*.t` file green (via
+`scripts/run-roast-test.sh`).
+
+**F3 step 2 is now complete**: 13 of 18 owners needed real additions (`Mu`, `Any`, `Hash`, `Cool`,
+`Int`, `Rat`, `Complex`, `Str`, `List`, `Array`, `Range`, `Blob` -- 12 -- plus `Num` confirmed
+zero-change). The other 5 (`Sub`, `Signature`, `IO::Path`, `IO::Handle`, `Bool`) were confirmed to
+already have zero `RAW_ROWS`/introspection drift. Every one of the 18 `BUILTIN_METHOD_OWNERS` has
+now been raku-verified against its `RAW_ROWS` extras. **Step 3 (the actual "delete the 14 arrays,
+read `builtin_method_entries`/`builtin_type_method_names` from `RAW_ROWS` directly" cutover) is
+now unblocked** -- every genuine gap this step's classification needed has been closed, and every
+dispatch-only name has been confirmed and left out on purpose. Step 3 itself still needs its own
+design pass (how to encode "dispatch-only, not introspectable" as a flag on `NativeMethodRow`
+rather than by omission from a second array, per this file's original "suggested next step"
+section) -- not started here.

--- a/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
+++ b/todo/deep/adr0019-f3-raw-rows-drift-from-introspection-arrays.md
@@ -238,3 +238,31 @@ Running total: 8 of 18 owners now settled (`Mu`, `Any`, `Hash`, `Cool`, `Int`, `
 `Complex` -- `Num` needed no changes, its `RAW_ROWS` extras block was empty). `Str` (25 extras) is
 now the only large owner left untriaged; the rest are the smaller-count owners from the original
 survey.
+
+## Progress (2026-08-15, continued): `Str` (24 extras, the survey's "25" was off by one) triaged
+
+11 of 24 genuine `Str.^methods` gaps: `uniprop`, `indent`, `ord`, `uniname`, `uninames`, `unival`,
+`univals`, `tclc`, `Version`, `Date`, `DateTime` -- all raku-verified present on `Str.^methods` and
+already dispatching correctly (`'A'.ord` -> 65, `65.uniname` -> "LATIN CAPITAL LETTER A",
+`'1.2.3'.Version` -> v1.2.3, etc.). The other 13 (`AST`, `list`, `UInt`, `FatRat`, `sprintf`,
+`chrs`, `bytes`, `Range`, `Complex`, `Real`, `reverse`, `byte`, `perl`) confirmed dispatch-only --
+real Rakudo's `Str.^methods` lists none of them.
+
+Added a new `STR_EXTRA_TAIL`, appended after the `&["elems", "fmt"]` tail already in the `"Str"`
+match arm, positioned to match the extras block's location in `RAW_ROWS`. All raku-verified and
+pinned in `t/can-methods-drift.t` (129 assertions total). Full local `t/` suite (3167 files) green.
+
+**Invocation gotcha hit while verifying roast, not a regression**: a bare `prove -e
+'target/debug/mutsu' roast/S32-str/*.t` spuriously fails 3 files
+(`gb18030-encode-decode.t`/`gb2312-encode-decode.t`/`shiftjis-encode-decode.t`) with "No such file
+or directory" on their fixture paths -- those tests resolve `t/spec/...` relative paths that only
+exist when run through `scripts/run-roast-test.sh` (per `MUTSU_BIN=... prove -e
+'scripts/run-roast-test.sh' roast/<path>.t` from CLAUDE.md), which the direct-binary invocation
+skips. Re-ran the correct way and all of `roast/S32-str/*.t` passes clean; unrelated to this
+change.
+
+**This closes F3 step 2's large-owner sweep**: `Str`, `Int`, `Cool`, `Complex`, and `Any` -- every
+owner the original survey flagged with 7+ extras -- are now triaged (9 of 18 owners settled
+counting `Mu`/`Hash`/`Rat`/`Num` too). The remaining ~9 owners left for step 2 each have only 1-3
+extras per the original survey table (much smaller individual slices); step 3 (the actual
+`RAW_ROWS`-as-single-source cutover) can reasonably start once those are swept.


### PR DESCRIPTION
## Summary
- Completes ADR-0019 Phase F box F3's raku-verification triage of `RAW_ROWS`-recognized names missing from `.^methods` introspection arrays (see #6463 for `Mu`/`Any`/`Hash`/`Cool`).
- `Int`/`Rat`/`Complex`/`Str`: the "shared 25 extras" assumption for the numeric family was wrong -- checked `RAW_ROWS` directly per owner. `Int` gains 7, `Rat` gains 2, `Complex` gains 6, `Str` gains 11. `Num` needed no changes.
- `List`/`Array`/`Range`/`Blob`: the "1-3 extras each" estimate for the remaining owners was also wrong. `List` gains 13, `Array` gains those 13 plus `WHICH`/`dynamic` (real Rakudo answers only for `Array`), `Range` gains 7, `Blob`/`Buf` gains 5.
- All 51 additions in this PR raku-verified and already dispatching correctly on mutsu; only `.^methods` enumeration was missing them. Every remaining dispatch-only name was checked against real Rakudo and confirmed correctly excluded.
- `Sub`/`Signature`/`IO::Path`/`IO::Handle`/`Bool` were confirmed to already have zero drift.
- **F3 step 2 is now complete**: every one of the 18 `BUILTIN_METHOD_OWNERS` has been raku-verified against its `RAW_ROWS` extras. Step 3 (the actual cutover) is unblocked.

## Test plan
- [x] `cargo test --lib raw_rows_cover_every_introspection_name_in_order`
- [x] `timeout 30 ./target/debug/mutsu t/can-methods-drift.t` (193 assertions, all pass)
- [x] `raku t/can-methods-drift.t` -- every new assertion added by this PR passes against real Rakudo too
- [x] Full local `t/` suite (`prove -e target/debug/mutsu t/ -j4`, 3167 files) green
- [x] `roast/S12-introspection/*`, every `roast/S32-num/*.t`, every `roast/S32-str/*.t`, `S02-types/{array,list,range}.t`, `S32-container/buf.t`, `S03-operators/buf.t`, every `S03-buf/*.t` (via `scripts/run-roast-test.sh`) green
- [x] `cargo clippy -- -D warnings`, `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)