### PR TITLE
fix(vm): guard remaining unguarded LazyThunk .view() sites

### DIFF
--- a/news/2026-08/lazy-thunk-view-guards-getglobal-getupvalue-setlocal.md
+++ b/news/2026-08/lazy-thunk-view-guards-getglobal-getupvalue-setlocal.md
@@ -1,0 +1,18 @@
+# Guard the remaining unguarded LazyThunk `.view()` sites
+
+`OpCode::GetGlobal`, `exec_get_upvalue_op` (`OpCode::GetUpvalue`), and the `SetLocal`
+readonly-marking check each called `Value::view()` unconditionally to check "is this a
+`LazyThunk`" before forcing it — and `view()` fully materializes a lazily-represented
+`Match` value as a side effect, so a Match read via any of these three ops paid an
+unnecessary full materialization even though it was never a thunk.
+
+`exec_get_local_op` (`OpCode::GetLocal`) already guarded the same check behind a cheap
+`is_lazy_thunk_value()` tag probe first, with a comment noting the exact reason. The
+other three sites were identified as the same class of bug during
+`todo/tickets/yaml-parse-throughput.md`'s round 7 investigation but left unfixed pending
+a higher-value dominant-call-site fix (round 8). This closes that follow-up: all three
+now probe `is_lazy_thunk_value()` before calling `.view()`, mirroring `exec_get_local_op`.
+
+The fix is a pure decision-preserving change (the answer to "is this a LazyThunk" is
+unchanged, only whether reaching it forces a `view()`), confirmed by the full `t/` suite
+(3168 files, 29458 tests) passing with no output differences.

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -532,8 +532,11 @@ impl Interpreter {
                 } else {
                     val
                 };
-                // Force lazy thunks transparently on access
-                let val = if let ValueView::LazyThunk(thunk_data) = val.view() {
+                // Force lazy thunks transparently on access. Tag-probed first: a
+                // `view()` would materialize a lazy Match (see `exec_get_local_op`).
+                let val = if val.is_lazy_thunk_value()
+                    && let ValueView::LazyThunk(thunk_data) = val.view()
+                {
                     self.force_lazy_thunk(&thunk_data)?
                 } else {
                     val

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -55,7 +55,11 @@ impl Interpreter {
                 }
             }
         };
-        let val = if let ValueView::LazyThunk(thunk_data) = val.view() {
+        // Tag-probed first: a `view()` would materialize a lazy Match (see
+        // `exec_get_local_op` below).
+        let val = if val.is_lazy_thunk_value()
+            && let ValueView::LazyThunk(thunk_data) = val.view()
+        {
             let thunk_data = thunk_data.clone();
             self.force_lazy_thunk(&thunk_data)?
         } else {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1813,8 +1813,9 @@ impl Interpreter {
         }
         // Use the potentially fixed-up value for env/shared_vars.
         let val = self.locals[idx].clone();
-        // Mark variable as readonly when storing a LazyThunk
-        if matches!(val.view(), ValueView::LazyThunk(..)) {
+        // Mark variable as readonly when storing a LazyThunk. Tag-probed first:
+        // a `view()` would materialize a lazy Match (see `exec_get_local_op`).
+        if val.is_lazy_thunk_value() && matches!(val.view(), ValueView::LazyThunk(..)) {
             self.mark_readonly(name);
         }
         // `(B)` per-store env-write: a slot-authoritative plain lexical skips its

--- a/todo/tickets/yaml-parse-throughput.md
+++ b/todo/tickets/yaml-parse-throughput.md
@@ -1,5 +1,25 @@
 # Parsing YAML with the bundled `YAMLish` is still ~5-35x slower than raku
 
+**Update (2026-08-15, round 9): the three round-7-identified-but-unfixed unguarded
+`Value::view()` sites are now fixed** — `OpCode::GetGlobal` (`vm_exec_dispatch.rs`),
+`exec_get_upvalue_op` (`OpCode::GetUpvalue`, `vm_var_assign_local_get.rs`), and the
+`SetLocal` readonly-marking check (`vm_var_assign_set_local.rs`) each now probe
+`is_lazy_thunk_value()` before calling `.view()`, mirroring the pattern already used by
+`exec_get_local_op`. As predicted in round 7/8, this benchmark's own
+`match_materializations` counter is unchanged (still 1749) — `GetGlobal` only fires 49
+times here, far too few to matter — since these three sites gate a *different* laziness
+mechanism (`LazyThunk`, not `Match`) from the round-8 fix; any Match value read via
+`GetGlobal`/`GetUpvalue`, or stored via a guarded `SetLocal`, now avoids an unnecessary
+full materialization on programs that DO exercise those ops on a lazy Match, which this
+synthetic benchmark does not. `cargo build`, `cargo clippy -- -D warnings`, and the full
+`t/` suite (3168 files, 29458 tests) all pass with no behavior change (expected — every
+fix is provably a no-op on the *decision*, only on whether `view()` is forced to reach
+it, same as round 8). This closes round 7/8's remaining named follow-up item; the ticket
+itself stays open for item 3 (candidate enumeration) and whatever `invoke_grammar_actions`
+work remains per round 8's item (b).
+
+---
+
 **Update (2026-08-15, round 8): the post-P5 drift's dominant call site is
 found and fixed — `match_materializations` drops from 20949 to 1749 on
 `benchmarks/bench-yaml-parse.raku` (matches the P5-merge-day baseline


### PR DESCRIPTION
## Summary
- `GetGlobal`, `exec_get_upvalue_op` (`GetUpvalue`), and the `SetLocal` readonly-marking check each called `Value::view()` unconditionally to test for a `LazyThunk`, forcing full materialization of a lazily-represented `Match` as an unwanted side effect.
- Probe `is_lazy_thunk_value()` first at all three sites, mirroring the guard `exec_get_local_op` already uses.
- Closes the round-7/8 follow-up item recorded in `todo/tickets/yaml-parse-throughput.md`.

## Test plan
- [x] `cargo build`
- [x] `cargo fmt` / `cargo clippy -- -D warnings`
- [x] `prove -e target/debug/mutsu t/` — 3168 files, 29458 tests, all pass
- [x] `MUTSU_VM_STATS=1` on `benchmarks/bench-yaml-parse.raku` shows `match_materializations` unchanged at 1749 (expected — `GetGlobal` fires only 49 times in this benchmark; the fix's value is on programs that read a lazy Match through these ops, not this synthetic file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)