### PR TITLE
fix(adr0019): F1 mechanism slice -- synthesize a generic .signature for native Method objects

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -818,6 +818,22 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   default and the Sub-vs-Instance unification remain open. Pin: `t/classhow-methods-package.t`;
   design detail in `todo/deep/adr0019-f1-f2-introspection-canonical-source.md`'s "Progress
   (2026-08-14): F1 mechanism slice, `.package` only".
+  **Update (2026-08-15, F1 mechanism slice, `.signature` default):** `make_native_method_object`
+  hardcoded every native `Method` Instance's `.signature` as an empty `Signature()` — `.^methods`/
+  `.^method_table` on any built-in type answered zero params regardless of the method's real arity.
+  A raku ground-truth sweep of ~280 introspectable (owner, name) pairs found no single shape
+  dominates real Rakudo's native signatures (raw-capture `(Owner $:: |)`, generic named-catchall
+  `(Owner:D $:: *%_)`, and fully-typed explicit params were all common, with no pattern derivable
+  from `NativeArityMask` alone), so this slice synthesizes the plurality shape — `(Owner $:: |)`, an
+  invocant plus a raw capture — as the generic default (`crate::value::signature::
+  synthesize_native_signature`), replacing the hardcoded empty signature. Not exact parity by
+  design; per-method overrides are the fidelity slice's job. Surfaced (but did not fix, filed
+  separately as `todo/tickets/signature-arity-count-wrong-for-capture-params.md`) a pre-existing,
+  general bug: `Signature.arity`/`.count` are wrong for any signature containing a raw-capture
+  param, reproducing on plain user-declared subs too, not specific to this change. Pin:
+  `t/classhow-native-method-signature-default.t`. The Sub-vs-Instance representation unification for
+  `.^lookup`/`.^find_method` remains open — that surface still returns a `Sub`-shaped value with its
+  own, separate `.signature` rendering path, untouched by this slice.
 - [x] **F3 — Delete the per-type method-name lists and the test-only `METHOD_UNIVERSE`.** B1/B2
   already removed `METHOD_UNIVERSE` and runtime probing from the runtime path (both are
   `#[cfg(test)]`-only now); the live work is the fourteen per-type `&[&str]` name slices

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -160,24 +160,24 @@ impl Interpreter {
     }
 
     /// `owner` is the catalog type this native method is being reported for --
-    /// ADR-0019 Phase F box F1's mechanism slice: `.package` defaults to it.
-    /// This is not always Rakudo's true declaring type (e.g. `Str.uc`'s real
-    /// `.package` is `Cool`, not `Str`) -- that per-method fidelity data is a
-    /// later, separate slice (see
+    /// ADR-0019 Phase F box F1's mechanism slice: `.package` defaults to it,
+    /// and `.signature` defaults to a synthesized generic shape (see
+    /// [`crate::value::signature::synthesize_native_signature`]). Neither is
+    /// always Rakudo's true answer (e.g. `Str.uc`'s real `.package` is
+    /// `Cool`, not `Str`) -- that per-method fidelity data is a later,
+    /// separate slice (see
     /// `todo/deep/adr0019-f1-f2-introspection-canonical-source.md`).
     pub(super) fn make_native_method_object(&self, name: &str, owner: &str) -> Value {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert("name".to_string(), Value::str(name.to_string()));
         attrs.insert("is_dispatcher".to_string(), Value::FALSE);
         attrs.insert("package".to_string(), Value::package(Symbol::intern(owner)));
-        let sig_attrs = {
-            let mut sa = std::collections::HashMap::new();
-            sa.insert("params".to_string(), Value::array(Vec::new()));
-            sa
-        };
         attrs.insert(
             "signature".to_string(),
-            Value::make_instance(Symbol::intern("Signature"), sig_attrs),
+            crate::value::signature::make_signature_value(
+                crate::value::signature::synthesize_native_signature(owner),
+                Some(self),
+            ),
         );
         attrs.insert("returns".to_string(), Value::package(Symbol::intern("Mu")));
         attrs.insert("of".to_string(), Value::package(Symbol::intern("Mu")));

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 /// Lightweight representation of a signature parameter for runtime use.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct SigParam {
     pub(crate) name: String,
     pub(crate) type_constraint: Option<String>,
@@ -35,7 +35,7 @@ pub(crate) struct SigParam {
 }
 
 /// Complete signature info stored at runtime.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct SigInfo {
     pub(crate) params: Vec<SigParam>,
     pub(crate) return_type: Option<String>,
@@ -44,6 +44,37 @@ pub(crate) struct SigInfo {
 impl SigParam {
     fn is_optional(&self) -> bool {
         self.has_default || self.optional_marker
+    }
+}
+
+/// ADR-0019 Phase F box F1 mechanism slice: a synthesized generic `Signature`
+/// for a native method with no per-method fidelity override -- replaces the
+/// prior hardcoded empty `Signature()` every native `Method` object answered.
+/// Not a claim of exact Rakudo parity: a raku ground-truth sweep
+/// (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`) found real
+/// native signatures range from this raw-capture shape to a generic
+/// named-catchall to fully-typed explicit params, with no single pattern
+/// derivable from arity alone -- this is "close to correct for most, not
+/// exact for all" by design; per-method overrides are a later, separate
+/// fidelity slice.
+pub(crate) fn synthesize_native_signature(owner: &str) -> SigInfo {
+    let invocant = SigParam {
+        type_constraint: Some(owner.to_string()),
+        is_invocant: true,
+        multi_invocant: true,
+        sigil: '$',
+        required: true,
+        ..Default::default()
+    };
+    let capture = SigParam {
+        is_capture: true,
+        multi_invocant: true,
+        sigil: '$',
+        ..Default::default()
+    };
+    SigInfo {
+        params: vec![invocant, capture],
+        return_type: None,
     }
 }
 

--- a/t/classhow-native-method-signature-default.t
+++ b/t/classhow-native-method-signature-default.t
@@ -1,0 +1,46 @@
+use Test;
+
+# ADR-0019 Phase F box F1 mechanism slice (todo/deep/
+# adr0019-f1-f2-introspection-canonical-source.md "Decision (2026-08-14)",
+# sequencing point 5): `make_native_method_object` used to hardcode every
+# native `Method` Instance's `.signature` as an empty `Signature()` --
+# `.^methods`/`.^method_table` on any built-in type answered zero params
+# regardless of the method's real arity. It now synthesizes a generic
+# `(Owner $:: |)` shape (invocant + raw capture), matching the single most
+# common pattern in a raku ground-truth sweep of real native `.signature.gist`
+# output across ~280 introspectable (owner, name) pairs (raw-capture was the
+# plurality shape; a generic named-catchall and fully-typed explicit params
+# were the others, with no single pattern derivable from arity alone -- see
+# the linked design doc). This is NOT a claim of exact Rakudo parity: e.g.
+# real Rakudo's `Int.^lookup("floor").signature.gist` is
+# `(Int:D $:: *%_ --> Int:D)`, a different (also-common) shape. Per-method
+# overrides for exact fidelity are a later, separate slice.
+
+for <Int Str Array Hash Range Bool> -> $tyname {
+    my $type = ::($tyname);
+    my @methods = $type.^methods;
+    ok @methods.elems > 0, "$tyname has native methods to check";
+    my $still-empty = @methods.first(*.signature.params.elems == 0);
+    ok !$still-empty,
+        "$tyname has no native method left with an empty Signature()";
+}
+
+my $abs = Int.^methods.first(*.name eq 'abs');
+is $abs.signature.gist, '(Int $:: |)',
+    'native Method Instance signature synthesizes an (Owner $:: |) shape';
+is $abs.signature.params.elems, 2,
+    'synthesized signature has an invocant param and a capture param';
+ok $abs.signature.params[0].invocant,
+    'first param is flagged as the invocant';
+ok $abs.signature.params[1].capture,
+    'second param is flagged as a raw capture';
+
+my $chars = Str.^methods.first(*.name eq 'chars');
+is $chars.signature.gist, '(Str $:: |)',
+    'a different owner threads its own type into the invocant';
+
+my $push = Array.^methods.first(*.name eq 'push');
+is $push.signature.gist, '(Array $:: |)',
+    '.^methods native entries get the same synthesized signature regardless of owner';
+
+done-testing;

--- a/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
+++ b/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
@@ -330,3 +330,36 @@ that surface still returns a `Sub`-shaped value with a completely separate `.sig
 path this slice never touched. The F1 fidelity slice (per-method override columns on
 `NativeMethodRow`) is next per the original sequencing, once the unification lands or is
 independently scoped.
+
+## Progress (2026-08-15): checked whether the fidelity slice is ready to start in bulk -- it is not, by the decision's own design
+
+Before starting the fidelity slice, ran a `.package` divergence sweep the same shape as the
+`.signature` sweep above (raku, `.^lookup($name).package.gist` vs. the catalog owner, across the
+same 9 representative owners' `RAW_ROWS` `INTROSPECTABLE` rows -- `List` not yet included). Result:
+**199 divergent (owner, name, real-package) triples just from those 9 owners** (e.g. every
+`Str`-declared string method actually reports `(Cool)`; every universal coercion name like `Bool`/
+`Str`/`Numeric`/`gist`/`raku` reports `(Mu)` almost everywhere -- except `Str.Int`, which does NOT
+diverge, so even that "universal coercion = Mu" pattern isn't a clean mechanical rule; `Rat`/`Num`
+math methods mostly report `(Real)`/`(Rational)`/`(Numeric)`, not `(Rat)`/`(Num)`). Extrapolated
+across all ~650 introspectable rows and the 9 unsampled owners, this is easily 400+ entries, not the
+"~5-10 known corrections" the earlier ground-truth passes' handful of examples (`uc`->`Cool`,
+`push`->`Any`) suggested.
+
+**This confirms, rather than contradicts, the decision's own point 3**: "add overrides lazily, one
+at a time... NOT an upfront sweep of all ~350 native methods." Running the upfront sweep here was
+useful as a scale check, but populating even a fraction of its 199 findings right now would be
+exactly the upfront-hand-table campaign the decision explicitly rejected as the wrong shape for this
+work -- there is no `t/`/roast assertion today that exercises any of these 199 `.package` answers
+being wrong, so there is no forcing function yet, and hand-encoding them speculatively would be
+guessing at future demand rather than responding to it.
+
+**Where this leaves the fidelity slice**: it is not "not ready" so much as "correctly idle until
+something needs it." The override-column mechanism itself (an `Option<&'static str>` decorating a
+`NativeMethodRow`, or a small sparse `(owner, name, package) ` table guarded by a
+row-still-exists test, per point 2/3) is a short, well-scoped implementation whenever the first real
+demand shows up -- e.g. a roast test that asserts `.package` on a specific native method, or a user
+program that breaks on it. Until then, both mechanism-slice halves (`.package` defaulting to the
+catalog owner, `.signature` synthesizing a generic shape) are the correct, complete state of F1's
+"no hand data" tier. The two genuinely open threads for a future session are (a) the Sub-vs-Instance
+unification above (a real correctness bug, not an approximation gap) and (b) fidelity overrides
+added reactively, never as a bulk campaign.

--- a/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
+++ b/todo/deep/adr0019-f1-f2-introspection-canonical-source.md
@@ -270,3 +270,63 @@ Not done in this slice (left for follow-up, per point 5's own sequencing): `.sig
 synthesized-generic-shape default, and the `Method`-Instance-vs-`Sub` representation unification
 (`todo/tickets/classhow-lookup-returns-sub-not-method-instance.md`) -- `.^lookup` still returns a
 `Sub`-shaped value untouched by this slice. Pinned: `t/classhow-methods-package.t`.
+
+## Progress (2026-08-15): F1 mechanism slice, `.signature` synthesized default
+
+Landed the `.signature` half of the mechanism slice. `make_native_method_object` hardcoded every
+native `Method` Instance's `.signature` as an empty `Signature()` (zero params, `returns`/`of` both
+`Mu`), regardless of the method's real arity or Rakudo's actual declared signature.
+
+**Ran a wider raku ground-truth sweep first** (`raku`, all methods of 10 representative built-in
+type samples via `.^lookup($name).signature.gist`, cross-referenced against `RAW_ROWS`'s
+`INTROSPECTABLE`-flagged rows for the matching owner+arity, ~280 correlated pairs) to check whether
+a single template, or a template varying by `NativeArityMask`, would be "close to correct" as the
+decision above assumed. Neither held cleanly: within a single arity-mask bucket (e.g. the `A0`-only
+bucket, 180 samples) the observed shapes split roughly 3-way between a raw-capture form
+(`(Owner $:: |)`, plurality: 131/282), a generic named-catchall (`(Owner:D $:: *%_)`, 91/282), and
+assorted explicit-param shapes (60/282) -- arity mask alone does not predict which. Went with the
+overall plurality shape as the single generic default: an invocant param (`type_constraint: Some(
+owner)`, no `:D` -- bare owner names were also more common than `:D`-suffixed ones in the raw
+samples) plus one raw-capture param, i.e. `(Owner $:: |)`.
+
+**Implementation**: `crate::value::signature::synthesize_native_signature(owner)` builds a `SigInfo`
+with those two `SigParam`s (added `#[derive(Default)]` to `SigParam`/`SigInfo` so only the fields
+that matter need setting); `make_native_method_object` now calls
+`make_signature_value(synthesize_native_signature(owner), Some(self))` instead of hand-building an
+empty-params `Signature` instance directly.
+
+**A rendering bug found and fixed along the way, not native-method-specific**: the first attempt (
+invocant `multi_invocant: false`, matching the field's naive-sounding name) rendered as
+`(;; Owner $:: |)` -- a spurious leading `;;`. Traced `render_signature`'s `;;`-insertion logic
+(`src/value/signature.rs`) and the *parser's* own `multi_invocant` semantics
+(`src/parser/stmt/sub/param_list.rs:185-221`): the field does NOT mean "this param is one of several
+invocant candidates" (a plausible-sounding but wrong reading of the name) -- it means "this param
+appeared before any literal `;;` boundary in the signature source", and the parser sets it `true` on
+every param when the signature contains no `;;` at all (the overwhelmingly common case). Any
+hand-built `SigInfo` for a `;;`-free signature must therefore set `multi_invocant: true` on every
+param, not just the invocant -- fixed by setting it on both synthesized params, which produces the
+correct `(Owner $:: |)` gist with no separator artifact. This bug was latent before this slice: no
+existing code path in the whole codebase manually constructs a `SigParam` with `is_invocant: true`
+outside the AST-parser conversion path (`param_def_to_sig_param`, which always mirrors the parser's
+own `multi_invocant` bookkeeping automatically), so it had never been exercised.
+
+**A separate pre-existing bug surfaced, not fixed here**: comparing `.arity`/`.count` against real
+`raku` for a raw-capture signature (`sub foo(|c) {}`) found mutsu answers `arity=1, count=1` where
+real Rakudo answers `arity=0, count=Inf` -- a general bug in how `Signature.arity`/`.count` treat any
+`is_capture` param, reproducing on a plain user-declared sub, unrelated to native methods. Filed as
+`todo/tickets/signature-arity-count-wrong-for-capture-params.md`; out of scope for this slice (which
+only needs `.signature` to exist and gist-render sensibly, not exact arity/count fidelity).
+
+Verified: `t/classhow-native-method-signature-default.t` (new, 18 assertions, checks the gist shape,
+param flags, and that no native method across 6 sampled owners still answers an empty `Signature()`);
+`t/classhow-methods-package.t` and `t/can-methods-drift.t` stay green; `cargo test --lib` (826
+tests); full `t/` suite; `roast/S06-signature/introspection.t` (154/154, the one `not ok` is a
+pre-existing `# TODO`) and every `roast/S12-introspection/*.t` file (271 assertions) via
+`scripts/run-roast-test.sh`.
+
+Still open, per the original sequencing: the `Method`-Instance-vs-`Sub` representation unification
+for `.^lookup`/`.^find_method` (`todo/tickets/classhow-lookup-returns-sub-not-method-instance.md`) --
+that surface still returns a `Sub`-shaped value with a completely separate `.signature` rendering
+path this slice never touched. The F1 fidelity slice (per-method override columns on
+`NativeMethodRow`) is next per the original sequencing, once the unification lands or is
+independently scoped.

--- a/todo/tickets/classhow-lookup-returns-sub-not-method-instance.md
+++ b/todo/tickets/classhow-lookup-returns-sub-not-method-instance.md
@@ -75,6 +75,31 @@ Best done as part of the F1/F2 design once the native-metadata ground-truth pass
 (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`) lands, since both are about making
 introspection surfaces agree with each other and with the canonical dispatch table.
 
+## Progress (2026-08-15): the direct-caller audit is smaller than it looked
+
+After landing F1's mechanism slice (`.package` and `.signature` defaults for native `Method`
+Instances -- see the linked design doc), did a quick read-only grep-audit of the "all existing
+callers... need an audit" bullet above, since it was the vaguest of the three blockers. Only 5 real
+call sites in the whole codebase touch `classhow_lookup`/`classhow_find_method`:
+`methods_classhow_dispatch.rs` (2, the `.^lookup`/`.^find_method` opcode handlers themselves, which
+return the result straight to user code -- these are exactly the sites that need the result to be
+BOTH callable and Method-accessor-bearing, i.e. exactly where the representation choice matters
+most), `builtins_dispatch_next.rs` (1, `nextsame`-family redispatch), `methods_instance_ops.rs` (1,
+inside the general method-call fallback), and `methods_classhow_method_obj.rs` (1, a `.is_some()`
+existence check only -- does not touch the returned value's shape at all, so free of this concern).
+Not a large fan-out; the "audit" bullet is not the blocker the other two are.
+
+**The remaining two blockers (`.wrap`'s tag reuse and direct callability) are still the real
+open questions**, and still need real design/verification, not a grep. In particular: does making
+`.^lookup`'s result a `Method` Instance require teaching mutsu's call dispatch to invoke an
+`Instance` value directly (a new, general capability), or is there a narrower fix that keeps the
+returned value Sub-shaped for *calling* purposes while making every `Method`-only accessor
+(`is_dispatcher`, `multi`, `.candidates`, `.signature`, `.package`, ...) answer correctly on it --
+extending #6420's tag-based approach comprehensively instead of swapping representations? The
+narrower fix keeps the well-known #6420 pattern (env tags read by the general dispatch fallback) but
+risks becoming an ever-growing patch list, one accessor at a time, rather than closing the gap once.
+This design choice is the actual next step before any implementation.
+
 ## Progress (2026-08-14, #6420)
 
 The `.is_dispatcher`/`.multi` symptom is fixed with a scoped patch, not the representation

--- a/todo/tickets/signature-arity-count-wrong-for-capture-params.md
+++ b/todo/tickets/signature-arity-count-wrong-for-capture-params.md
@@ -1,0 +1,35 @@
+# `Signature.arity`/`.count` are wrong for any signature containing a raw-capture (`|c`) param
+
+Found while implementing ADR-0019 Phase F box F1's mechanism-slice `.signature` default for native
+methods (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`). Not caused by that change --
+reproduces on a plain user-declared sub, so it is a pre-existing, general bug in
+`src/value/signature.rs`'s arity/count computation, not specific to native methods.
+
+## Repro
+
+```
+$ raku -e 'sub foo(|c) {}; say &foo.signature.arity; say &foo.signature.count;'
+0
+Inf
+$ ./target/debug/mutsu -e 'sub foo(|c) {}; say &foo.signature.arity; say &foo.signature.count;'
+1
+1
+```
+
+Real Rakudo: a raw capture (`|c`) contributes 0 to `.arity` (it captures whatever remains, not a
+required positional) and makes `.count` unbounded (`Inf`), since the signature accepts any number of
+further arguments. mutsu counts the capture param itself as one required, bounded parameter.
+
+## Where to look
+
+`src/value/signature.rs` -- wherever `.arity`/`.count` are derived from `SigInfo`/`SigParam` (likely
+near `sig_param_to_parameter_instance`/`build_parameter_attrs` or a dedicated arity-computation
+helper). The fix is general: any `SigParam` with `is_capture: true` present in `params` should make
+`.count` answer `Inf` and should not itself count toward `.arity`.
+
+## Why not fixed inline
+
+Out of scope for the F1 mechanism slice that found it (that slice only needed `.signature` to exist
+and gist-render sensibly for native methods, not exact `.arity`/`.count` fidelity). Fixing arity/count
+touches the general signature-introspection surface for every capture-taking sub/method (user and
+native), which is a distinct, self-contained fix better landed and tested on its own.


### PR DESCRIPTION
## Summary
- ADR-0019 Phase F box F1's mechanism slice (`.signature` half; `.package` landed earlier): `make_native_method_object` hardcoded every native `Method` Instance's `.signature` as an empty `Signature()`, so `.^methods`/`.^method_table` on any built-in type always answered zero params.
- A raku ground-truth sweep of ~280 introspectable (owner, name) pairs found no single native-signature shape dominates real Rakudo, and none is derivable from `NativeArityMask` alone -- so this synthesizes the plurality shape observed, `(Owner $:: |)` (invocant + raw capture), as a generic default via the new `synthesize_native_signature()`. Not exact Rakudo parity by design (real Rakudo also commonly uses a generic named-catchall or fully-typed explicit params) -- per-method overrides are a later fidelity slice.
- Fixed a latent `render_signature` bug found along the way: a hand-built `;;`-free `SigInfo` needs `multi_invocant: true` on *every* param (not just the invocant), per the parser's own semantics for that field -- otherwise a spurious leading `;;` appears in the gist.
- Filed (not fixed, out of scope) a separate pre-existing bug this surfaced: `Signature.arity`/`.count` are wrong for any `is_capture` param, reproducing on a plain user-declared sub too -- `todo/tickets/signature-arity-count-wrong-for-capture-params.md`.

## Test plan
- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings` (clean on touched files)
- [x] `cargo fmt`
- [x] `cargo test --lib` -- 826 passed
- [x] `t/classhow-native-method-signature-default.t` (new, 18 assertions) and `t/classhow-methods-package.t`/`t/can-methods-drift.t` -- all green
- [x] `make test` -- 3169 files, 29476 tests, all green
- [x] `roast/S06-signature/introspection.t` (154/154 via `scripts/run-roast-test.sh`, the one `not ok` is a pre-existing `# TODO`) and every `roast/S12-introspection/*.t` file (271 assertions) -- all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)