### PR TITLE
fix(parser): diffy comparison operators raise X::Syntax::CannotMeta for the = metaop

### DIFF
--- a/news/2026-08/diffy-comparison-assign-metaop-cannotmeta.md
+++ b/news/2026-08/diffy-comparison-assign-metaop-cannotmeta.md
@@ -1,0 +1,57 @@
+# Diffy comparison operators used as an assignment-metaop base now raise `X::Syntax::CannotMeta`
+
+Chaining comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`, `eq`, `ne`,
+`lt`, `le`, `gt`, `ge`, `eqv`, `~~`, `!~~`, `before`, `after`, `===`, `=:=`,
+`=~=`, ...) and structural (non-associative) ones (`cmp`, `leg`, `<=>`,
+`coll`, `unicmp`, and the range operators `..`, `..^`, `^..`, `^..^`) cannot
+be the base of Raku's `OP=` assignment metaoperator: `$x OP= $y` desugars to
+`$x = $x OP $y`, which only makes sense when `OP` combines exactly two
+operands into a single result. A chaining comparison (`1 < 2 < 3`) and a
+non-associative structural one aren't that, so rakudo rejects the metaop
+with `X::Syntax::CannotMeta` — e.g. `raku -e '6 >== 2'` gives:
+
+```
+Cannot make assignment out of >= because chaining operators are too diffy
+```
+
+mutsu previously had no dedicated diagnosis for this construct: `6 >== 2`
+and `6 ~~= 2` fell through to the parser's generic "Confused" error instead
+of naming the actual problem. This surfaced as
+`roast/S03-operators/assign.t` failing two `throws-like …,
+X::Syntax::CannotMeta` assertions when run against the real, vendored
+`Test.rakumod` (`MUTSU_REAL_TEST=1`) rather than mutsu's native `Test`
+provider — one of the 14 files in the `vendor-real-test-module.md` campaign
+whose first failing assertion was `Got: X::Syntax::Confused` where a
+specifically-typed exception was expected.
+
+The fix adds a general check across every site that consumes a comparison or
+range operator during parsing (`comparison_expr_mode` and
+`structural_comparison_expr_mode` in `src/parser/expr/precedence/`, plus the
+four range-operator branches in `range_expr`): if the matched operator is
+immediately followed by a bare `=` (not `==` or `=>`, matching the
+`OP=`-adjacency convention used for every other compound-assignment form in
+the parser) and the operator is diffy, it raises `X::Syntax::CannotMeta`
+with the same `.meta`/`.operator`/`.reason`/`.dba` attributes and message
+text rakudo produces, verified case-by-case against `raku -e '...'`. The
+check is a genuine operator-category classification
+(`ComparisonOp::source_spelling()`, `is_structural_comparison_op()`, and the
+new `diffy_assign_meta_dba()` in `src/parser/expr/precedence/ternary.rs`),
+not a hardcoded list of the two roast-tested spellings, so it applies
+uniformly to every chaining and structural operator including their negated
+(`!before=`) and Unicode-alias forms.
+
+One operator was deliberately excluded: `NotDivisibleBy` (`!%%`). Rakudo
+parses `6 !%%= 2` as the METAOP_NEGATE of the *compound-assignment* operator
+`%%=` (`"Cannot negate %%= because assignment operator operators are not
+iffy enough"`), a different and separately-tracked gap, not this
+diffy-base-of-assignment case — folding it into this fix would have produced
+an incorrect exception message for that input.
+
+`t/diffy-assign-metaop.t` pins 17 operators (9 chaining, 3 structural, 4
+range operators, plus the negated-smartmatch and identity-operator forms)
+against the exact class, `.operator`, `.dba`, and `.message` rakudo
+produces, and confirms plain (non-metaop) uses of the same operators —
+including `===`/`!==`, which are themselves distinct operators rather than
+`==`/`!=` plus the `=` metaop — are unaffected. `make test` and the full
+`roast/S03-operators/` + `roast/S03-metaops/` suites (79 files, 18654
+assertions) pass with no regressions.

--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -68,6 +68,43 @@ impl ComparisonOp {
             ComparisonOp::ContainerNe => TokenKind::Ident("!=:=".to_string()),
         }
     }
+
+    /// The operator's Raku surface spelling, matching rakudo's own
+    /// `X::Syntax::CannotMeta.operator` attribute value (verified against
+    /// `raku -e '6 >== 2'` and friends -- see
+    /// `src/parser/expr/precedence/ternary.rs::reject_diffy_assign_meta`).
+    pub(super) fn source_spelling(self) -> &'static str {
+        match self {
+            ComparisonOp::StrictEq => "===",
+            ComparisonOp::StrictNe => "!===",
+            ComparisonOp::NumEq => "==",
+            ComparisonOp::NotDivisibleBy => "!%%",
+            ComparisonOp::NumNe => "!=",
+            ComparisonOp::SmartNotMatch => "!~~",
+            ComparisonOp::SmartMatch => "~~",
+            ComparisonOp::Spaceship => "<=>",
+            ComparisonOp::NumLe => "<=",
+            ComparisonOp::NumGe => ">=",
+            ComparisonOp::NumLt => "<",
+            ComparisonOp::NumGt => ">",
+            ComparisonOp::StrEq => "eq",
+            ComparisonOp::StrNe => "ne",
+            ComparisonOp::StrLt => "lt",
+            ComparisonOp::StrGt => "gt",
+            ComparisonOp::StrLe => "le",
+            ComparisonOp::StrGe => "ge",
+            ComparisonOp::Leg => "leg",
+            ComparisonOp::Cmp => "cmp",
+            ComparisonOp::Coll => "coll",
+            ComparisonOp::Unicmp => "unicmp",
+            ComparisonOp::Eqv => "eqv",
+            ComparisonOp::Before => "before",
+            ComparisonOp::After => "after",
+            ComparisonOp::ApproxEq => "=~=",
+            ComparisonOp::ContainerEq => "=:=",
+            ComparisonOp::ContainerNe => "!=:=",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -47,6 +47,7 @@ pub(super) use ternary::{ternary, ternary_mode, ternary_no_assign};
 pub(super) use chain_cmp::{parse_comparison_op, parse_negated_meta_comparison_op};
 pub(super) use feed::make_feed_node;
 pub(super) use ternary::is_structural_comparison_op;
+pub(super) use ternary::reject_diffy_assign_meta;
 
 pub(in crate::parser) use ternary::call_arg_expr;
 
@@ -64,8 +65,9 @@ pub(crate) use chain_cmp::{
 pub(crate) use comparison::comparison_expr_mode;
 pub(crate) use custom_infix::{ListInfixOperand, parse_flipflop_infix};
 pub(crate) use errors::{
-    check_range_precedence_worry, conditional_precedence_too_loose_error, non_associative_error,
-    non_associative_pair_error, non_list_associative_error, syntax_exception,
+    cannot_meta_assign_diffy_error, check_range_precedence_worry,
+    conditional_precedence_too_loose_error, non_associative_error, non_associative_pair_error,
+    non_list_associative_error, syntax_exception,
 };
 pub(crate) use list_infix::{sequence_expr, sequence_only_expr};
 pub(crate) use list_infix_loop::{

--- a/src/parser/expr/precedence/chain_cmp.rs
+++ b/src/parser/expr/precedence/chain_cmp.rs
@@ -247,6 +247,25 @@ fn reject_chained_range(after_rhs: &str, left_op: &'static str) -> Result<(), PE
     }
 }
 
+/// Range operators are structural (non-associative) per rakudo's own
+/// precedence table, so `OP=` over one is the same rejected assignment
+/// metaop as `cmp=`/`<=>=`: `Cannot make assignment out of .. because
+/// structural infix operators are too diffy` (verified against
+/// `raku -e '6 ..= 2'` and the `^..`/`..^`/`^..^` siblings). Unlike the
+/// comparison operators in `comparison.rs`, ranges are matched by literal
+/// spelling here rather than through `ComparisonOp`, so the check is a
+/// direct string peek instead of going through `reject_diffy_assign_meta`.
+fn reject_range_diffy_assign(after_op: &str, op_str: &'static str) -> Result<(), PError> {
+    if after_op.starts_with('=') && !after_op.starts_with("==") && !after_op.starts_with("=>") {
+        return Err(cannot_meta_assign_diffy_error(
+            op_str,
+            "structural infix",
+            after_op.len(),
+        ));
+    }
+    Ok(())
+}
+
 /// Range: ..  ..^  ^..  ^..^
 pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
     let (rest, left) = structural_expr(input)?;
@@ -254,6 +273,7 @@ pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
 
     if let Some(stripped) = r.strip_prefix("^..^") {
         check_range_precedence_worry(input)?;
+        reject_range_diffy_assign(stripped, "^..^")?;
         let (r, _) = ws(stripped)?;
         let (r, right) = structural_expr(r).map_err(|err| {
             enrich_expected_error(err, "expected range RHS after '^..^'", r.len())
@@ -271,6 +291,7 @@ pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
     if r.starts_with("^..") && !r.starts_with("^...") {
         check_range_precedence_worry(input)?;
         let stripped = &r[3..];
+        reject_range_diffy_assign(stripped, "^..")?;
         let (r, _) = ws(stripped)?;
         let (r, right) = structural_expr(r)
             .map_err(|err| enrich_expected_error(err, "expected range RHS after '^..'", r.len()))?;
@@ -286,6 +307,7 @@ pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
     }
     if let Some(stripped) = r.strip_prefix("..^") {
         check_range_precedence_worry(input)?;
+        reject_range_diffy_assign(stripped, "..^")?;
         let (r, _) = ws(stripped)?;
         let (r, right) = structural_expr(r)
             .map_err(|err| enrich_expected_error(err, "expected range RHS after '..^'", r.len()))?;
@@ -302,6 +324,7 @@ pub(crate) fn range_expr(input: &str) -> PResult<'_, Expr> {
     if r.starts_with("..") && !r.starts_with("...") {
         check_range_precedence_worry(input)?;
         let r = &r[2..];
+        reject_range_diffy_assign(r, "..")?;
         let (r, _) = ws(r)?;
         let (r, right) = structural_expr(r)
             .map_err(|err| enrich_expected_error(err, "expected range RHS after '..'", r.len()))?;

--- a/src/parser/expr/precedence/comparison.rs
+++ b/src/parser/expr/precedence/comparison.rs
@@ -150,6 +150,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
         }
     }
     if let Some((op, len)) = parse_negated_meta_comparison_op(r) {
+        reject_diffy_assign_meta(op, r, len)?;
         let r = &r[len..];
         let (r, _) = ws(r)?;
         let (r, right) = if mode == ExprMode::Full {
@@ -179,6 +180,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
             let (r2, _) = ws(r)?;
             // Try negated meta comparison for chaining
             if let Some((cop, chain_len)) = parse_negated_meta_comparison_op(r2) {
+                reject_diffy_assign_meta(cop, r2, chain_len)?;
                 let r2 = &r2[chain_len..];
                 let (r2, _) = ws(r2)?;
                 let (r2, next_right) = junctive_expr_mode(r2, mode).map_err(|err| PError {
@@ -208,6 +210,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
             }
             // Also try regular comparison for mixed chaining
             if let Some((cop, chain_len)) = parse_comparison_op(r2) {
+                reject_diffy_assign_meta(cop, r2, chain_len)?;
                 let r2 = &r2[chain_len..];
                 let (r2, _) = ws(r2)?;
                 let (r2, next_right) = junctive_expr_mode(r2, mode).map_err(|err| PError {
@@ -237,6 +240,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
         return Ok((r, result));
     }
     if let Some((op, len)) = parse_comparison_op(r) {
+        reject_diffy_assign_meta(op, r, len)?;
         let r = &r[len..];
         let (r, _) = ws(r)?;
         // Start of the (whitespace-trimmed) RHS input — used below to tell a bare
@@ -387,6 +391,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
                 if is_structural_comparison_op(cop) {
                     break;
                 }
+                reject_diffy_assign_meta(cop, r2, chain_len)?;
                 let r2 = &r2[chain_len..];
                 let (r2, _) = ws(r2)?;
                 let (r2, next_right) =
@@ -413,6 +418,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
                 if is_structural_comparison_op(cop) {
                     break;
                 }
+                reject_diffy_assign_meta(cop, r2, chain_len)?;
                 let r2 = &r2[chain_len..];
                 let (r2, _) = ws(r2)?;
                 let (r2, next_right) =

--- a/src/parser/expr/precedence/errors.rs
+++ b/src/parser/expr/precedence/errors.rs
@@ -67,6 +67,39 @@ pub(crate) fn non_associative_pair_error(left: &str, right: &str) -> PError {
     PError::fatal_with_exception(message, Box::new(exception))
 }
 
+/// `X::Syntax::CannotMeta` for `OP=` where `OP` is a chaining or structural
+/// comparison operator (`6 >== 2`, `6 cmp= 2`, `6 ~~= 2`, `6 ..= 2`, ...).
+/// rakudo's METAOP_ASSIGN refuses to compose an assignment out of a diffy
+/// operator: `$x OP= $y` desugars to `$x = $x OP $y`, which only makes sense
+/// when `OP` combines exactly two operands into one result. A chaining
+/// comparison (`1 < 2 < 3`) and a non-associative structural one (`1 cmp 2`,
+/// which cannot itself be chained) aren't that, so rakudo rejects the metaop
+/// outright rather than silently picking a meaning. `dba` is rakudo's own
+/// vocabulary for the operator category ("chaining" / "structural infix")
+/// and appears verbatim in both the message and the `.dba` attribute;
+/// `.meta`/`.operator`/`.reason` mirror rakudo's own `X::Syntax::CannotMeta`
+/// attributes (verified against `raku -e '6 >== 2'`).
+pub(crate) fn cannot_meta_assign_diffy_error(op: &str, dba: &str, remaining_len: usize) -> PError {
+    let message =
+        format!("Cannot make assignment out of {op} because {dba} operators are too diffy");
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    attrs.insert(
+        "meta".to_string(),
+        Value::str("make assignment out of".to_string()),
+    );
+    attrs.insert("operator".to_string(), Value::str(op.to_string()));
+    attrs.insert("reason".to_string(), Value::str("too diffy".to_string()));
+    attrs.insert("dba".to_string(), Value::str(dba.to_string()));
+    let exception = Value::make_instance(Symbol::intern("X::Syntax::CannotMeta"), attrs);
+    let mut err = PError::raw(
+        format!("X::Syntax::CannotMeta: {message}"),
+        Some(remaining_len),
+    );
+    err.exception = Some(Box::new(exception));
+    err
+}
+
 pub(crate) fn conditional_precedence_too_loose_error() -> PError {
     syntax_exception(
         "X::Syntax::ConditionalOperator::PrecedenceTooLoose",

--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -69,6 +69,51 @@ pub(in crate::parser::expr) fn is_structural_comparison_op(op: ComparisonOp) -> 
     )
 }
 
+/// Rakudo's category name ("chaining" / "structural infix") for `op` when
+/// used as the base of an `OP=` assignment metaoperator, or `None` when `op`
+/// is a valid assignment-metaop base. `NotDivisibleBy` (`!%%`) is excluded:
+/// rakudo parses a trailing `=` there as the METAOP_NEGATE of the
+/// *compound-assignment* operator `%%=` (`!(%%=)`, "Cannot negate %%= because
+/// assignment operator operators are not iffy enough") instead of this
+/// diffy-base-of-assignment case -- a different, unrelated gap.
+pub(in crate::parser::expr) fn diffy_assign_meta_dba(op: ComparisonOp) -> Option<&'static str> {
+    if matches!(op, ComparisonOp::NotDivisibleBy) {
+        return None;
+    }
+    Some(if is_structural_comparison_op(op) {
+        "structural infix"
+    } else {
+        "chaining"
+    })
+}
+
+/// If `op` (spelled at the start of `r`, `len` bytes long) is immediately
+/// followed by a bare `=` -- `>==`, `eq=`, `~~=`, `cmp=`, ... -- that is
+/// rakudo's rejected `OP=` assignment metaoperator over a diffy comparison
+/// operator, diagnosed as `X::Syntax::CannotMeta`
+/// (`roast/S03-operators/assign.t` "Can't use diffy >= with the = metaop").
+/// A `==` or `=>` continuation is a distinct operator, not this metaop, and
+/// is left alone (mirrors the `starts_with('=') && !starts_with("==")`
+/// convention used throughout the parser for every other `OP=` form).
+pub(in crate::parser::expr) fn reject_diffy_assign_meta(
+    op: ComparisonOp,
+    r: &str,
+    len: usize,
+) -> Result<(), PError> {
+    let after_op = &r[len..];
+    if !after_op.starts_with('=') || after_op.starts_with("==") || after_op.starts_with("=>") {
+        return Ok(());
+    }
+    let Some(dba) = diffy_assign_meta_dba(op) else {
+        return Ok(());
+    };
+    Err(cannot_meta_assign_diffy_error(
+        op.source_spelling(),
+        dba,
+        r.len(),
+    ))
+}
+
 pub(crate) fn structural_comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     let (rest, left) = junctive_expr_mode(input, mode)?;
     let (r, _) = ws(rest)?;
@@ -78,6 +123,7 @@ pub(crate) fn structural_comparison_expr_mode(input: &str, mode: ExprMode) -> PR
     if !is_structural_comparison_op(op) {
         return Ok((rest, left));
     }
+    reject_diffy_assign_meta(op, r, len)?;
     let r = &r[len..];
     let (r, _) = ws(r)?;
     let (r, right) = if mode == ExprMode::Full {

--- a/t/diffy-assign-metaop.t
+++ b/t/diffy-assign-metaop.t
@@ -1,0 +1,65 @@
+use v6;
+use Test;
+
+# Chaining and structural (non-associative) comparison operators cannot be
+# the base of the `=` assignment metaoperator: `$x OP= $y` desugars to
+# `$x = $x OP $y`, which only makes sense when `OP` combines exactly two
+# operands into one result. rakudo rejects the metaop with
+# `X::Syntax::CannotMeta` ("... because chaining operators are too diffy" /
+# "... because structural infix operators are too diffy"), verified against
+# `raku -e '6 >== 2'` and friends -- see roast/S03-operators/assign.t
+# ("Can't use diffy >= with the = metaop") and
+# todo/tickets/vendor-real-test-module.md.
+
+sub cannot-meta-assign(&code, $desc, $operator, $dba) {
+    my $ex;
+    try {
+        code();
+        CATCH { default { $ex = $_; } }
+    }
+    isa-ok $ex, X::Syntax::CannotMeta, "$desc: right exception type";
+    is $ex.^name eq 'X::Syntax::CannotMeta' ?? $ex.operator !! Nil,
+        $operator, "$desc: .operator";
+    is $ex.^name eq 'X::Syntax::CannotMeta' ?? $ex.dba !! Nil,
+        $dba, "$desc: .dba";
+    is $ex.^name eq 'X::Syntax::CannotMeta' ?? $ex.message !! Nil,
+        "Cannot make assignment out of $operator because $dba operators are too diffy",
+        "$desc: .message";
+}
+
+# Chaining comparison operators.
+cannot-meta-assign { EVAL '6 >== 2' }, 'numeric >=', '>=', 'chaining';
+cannot-meta-assign { EVAL '6 ==== 2' }, 'identity ===', '===', 'chaining';
+cannot-meta-assign { EVAL '6 eq= 2' }, 'string eq', 'eq', 'chaining';
+cannot-meta-assign { EVAL '6 ne= 2' }, 'string ne', 'ne', 'chaining';
+cannot-meta-assign { EVAL '6 before= 2' }, 'before', 'before', 'chaining';
+cannot-meta-assign { EVAL '6 after= 2' }, 'after', 'after', 'chaining';
+cannot-meta-assign { EVAL '6 eqv= 2' }, 'eqv', 'eqv', 'chaining';
+cannot-meta-assign { EVAL '6 ~~= 2' }, 'smartmatch', '~~', 'chaining';
+cannot-meta-assign { EVAL '6 !~~= 2' }, 'negated smartmatch', '!~~', 'chaining';
+
+# Structural (non-associative) comparison operators.
+cannot-meta-assign { EVAL '6 cmp= 2' }, 'cmp', 'cmp', 'structural infix';
+cannot-meta-assign { EVAL '6 leg= 2' }, 'leg', 'leg', 'structural infix';
+cannot-meta-assign { EVAL '6 <=>= 2' }, 'spaceship', '<=>', 'structural infix';
+
+# Range operators are structural too.
+cannot-meta-assign { EVAL '6 ..= 2' }, 'range ..', '..', 'structural infix';
+cannot-meta-assign { EVAL '6 ..^= 2' }, 'range ..^', '..^', 'structural infix';
+cannot-meta-assign { EVAL '6 ^..= 2' }, 'range ^..', '^..', 'structural infix';
+cannot-meta-assign { EVAL '6 ^..^= 2' }, 'range ^..^', '^..^', 'structural infix';
+
+# `>=`, `~~`, `<=>`, `..` still work fine on their own -- only the `=`
+# metaop over them is rejected.
+ok (6 >= 2), 'plain >= still works';
+ok !(6 ~~ Str), 'plain ~~ still works';
+is (1 <=> 2), Less, 'plain <=> still works';
+is (1..5).elems, 5, 'plain .. still works';
+
+# `===`/`!==` are themselves distinct operators (identity / negated
+# identity), not `==`/`!=` followed by the `=` metaop, so they must NOT
+# raise CannotMeta.
+ok !(6 === 2), '=== is a plain operator, not a rejected metaop';
+ok (6 !== 2), '!== is a plain operator, not a rejected metaop';
+
+done-testing;

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1038,3 +1038,30 @@ symptom**, not a signal that leverage is exhausted. What actually predicts a
 Write the next status note as "the largest *mechanism* cluster is N", and only
 after trying to merge symptom buckets that share a mechanism. Do not write
 "one at a time" again without that step.
+
+## `X::Syntax::CannotMeta` for diffy comparison operators as an assign-metaop base (2026-08-15)
+
+Picked up the named-but-not-yet-fixed example from the 2026-08-14 entry:
+`roast/S03-operators/assign.t` failed two `throws-like …, X::Syntax::CannotMeta`
+assertions under `MUTSU_REAL_TEST=1` (`6 >== 2`, `6 ~~= 2`) because the parser
+had no diagnosis at all for a chaining/structural comparison operator used as
+the base of the `=` assignment metaoperator — it fell through to the generic
+"Confused" error instead. Fixed generally (`ComparisonOp::source_spelling()`
++ `diffy_assign_meta_dba()` in `src/parser/expr/precedence/ternary.rs`, wired
+into every site that consumes a comparison or range operator during parsing),
+not as a two-spelling special case — it now covers all chaining ops (`==`,
+`!=`, `<`, `<=`, `>`, `>=`, `eq`, `ne`, `lt`, `le`, `gt`, `ge`, `eqv`, `~~`,
+`!~~`, `before`, `after`, `===`, `=:=`, `=~=`, ...), all structural ops
+(`cmp`, `leg`, `<=>`, `coll`, `unicmp`), and the range operators (`..`,
+`..^`, `^..`, `^..^`), each verified message-for-message against
+`raku -e '...'`. `NotDivisibleBy` (`!%%`) was deliberately excluded — rakudo
+parses `6 !%%= 2` as METAOP_NEGATE of the compound-assignment operator `%%=`
+instead, a different, still-unimplemented gap. Pin: `t/diffy-assign-metaop.t`
+(70 assertions, green under `raku` too). `news/2026-08/diffy-comparison-assign-metaop-cannotmeta.md`.
+`roast/S03-operators/assign.t` now passes under both the native `Test`
+provider and `MUTSU_REAL_TEST=1`. This was the only file in the "14 files
+fail on `Got: X::Syntax::Confused`" cluster whose expected class was
+`X::Syntax::CannotMeta`; the other 13 (different expected classes:
+`X::Syntax::Comment::Embedded`, `X::Syntax::Signature::InvocantNotAllowed`,
+`X::Comp::Group`, `X::Worry::Precedence::Range`, `X::Syntax::Malformed`,
+...) remain open, each needing its own individual parser diagnosis.


### PR DESCRIPTION
## Summary
- Chaining comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`, `eq`, `ne`, `lt`, `le`, `gt`, `ge`, `eqv`, `~~`, `!~~`, `before`, `after`, `===`, `=:=`, `=~=`, ...) and structural (non-associative) ones (`cmp`, `leg`, `<=>`, `coll`, `unicmp`, and the range operators `..`, `..^`, `^..`, `^..^`) cannot be the base of Raku's `OP=` assignment metaoperator (`6 >== 2`, `6 ~~= 2`, `6 cmp= 2`, ...). rakudo rejects this with `X::Syntax::CannotMeta` ("... because chaining/structural infix operators are too diffy").
- mutsu previously fell through to a generic "Confused" parse error instead of naming the problem. This is what `roast/S03-operators/assign.t` exercises via `throws-like` under the real, vendored `Test.rakumod` (`MUTSU_REAL_TEST=1`) -- see `todo/tickets/vendor-real-test-module.md`.
- Fixed generally: a new `ComparisonOp::source_spelling()` + `diffy_assign_meta_dba()` classification, wired into every parser site that consumes a comparison or range operator (`comparison_expr_mode`, `structural_comparison_expr_mode`, `range_expr`), not a two-spelling special case. Each message/attribute set was verified against `raku -e '...'`.
- `NotDivisibleBy` (`!%%`) is deliberately excluded: rakudo parses `6 !%%= 2` as `METAOP_NEGATE` of the compound-assignment operator `%%=` instead -- a different, separately-tracked gap (would have produced a wrong message if folded in).

## Test plan
- [x] New pin test `t/diffy-assign-metaop.t` (70 assertions covering 9 chaining ops, 3 structural ops, 4 range ops, negated-smartmatch, and `===`/`!==` non-regression) -- green under both `raku` and `mutsu`.
- [x] `roast/S03-operators/assign.t` passes under both the native `Test` provider and `MUTSU_REAL_TEST=1`.
- [x] Full `roast/S03-operators/` + `roast/S03-metaops/` (79 files, 18654 assertions) -- no regressions.
- [x] `make test` (full `t/` suite, 3169 files / 29527 tests) -- `Result: PASS`.
- [x] `cargo clippy -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)