### PR TITLE
fix(parser): #` without an immediate bracket raises X::Syntax::Comment::Embedded

### DIFF
--- a/news/2026-08/comment-embedded-exception-class.md
+++ b/news/2026-08/comment-embedded-exception-class.md
@@ -1,0 +1,35 @@
+# `#\`` without an immediate opening bracket now raises `X::Syntax::Comment::Embedded`
+
+Continuing the `todo/tickets/vendor-real-test-module.md` campaign's residue of
+"`Got: X::Syntax::Confused`" files: `#\`` (the embedded-comment sigil) not
+immediately followed by an opening bracket used to fall through to the
+generic "Confused." diagnosis instead of the specific
+`X::Syntax::Comment::Embedded` rakudo raises, even though the parser had
+already produced the exact right message ("Opening bracket required for #\`
+comment") — it just was not spelled in the `"X::Type: text"` convention that
+`RuntimeError::split_typed_message_convention` looks for, so it stayed
+untyped.
+
+Two independent gaps had to be fixed, not one:
+
+1. **The message itself wasn't typed.** `src/parser/helpers.rs`'s `ws()`
+   raised a plain `PError::expected(...)` for this case; switched to
+   `PError::fatal_at` (this diagnosis is never something another alternative
+   could still match, exactly like its sibling "Couldn't find terminator for
+   #\` comment" a few lines above) with the message prefixed
+   `X::Syntax::Comment::Embedded: `.
+2. **The class wasn't registered at all.** Even after typing the message,
+   `X::Syntax::Comment::Embedded` was missing from `runtime_init.rs`'s
+   `register_x` calls entirely, so `$! ~~ X::Comp` — the check
+   `roast/S02-lexical-conventions/comments.t` uses for the "no space
+   allowed"/"no tab allowed" variants it can't yet classify more precisely —
+   failed even once the class name was right. Registered under `X::Syntax`
+   (which already does `X::Comp`), matching `old-design-docs/S32-setting-library/Exception.pod`'s
+   `X::Syntax::Comment::Embedded does X::Syntax`.
+
+`roast/S32-exceptions/misc2.t` and `roast/S02-lexical-conventions/comments.t`
+both stay fully green under the native `Test` provider (no behavior change on
+the paths those exercise) and each lose one failure under
+`MUTSU_REAL_TEST=1` (comments.t: 4 → 1 remaining, the unrelated unspace-in-
+comment "sanity check"; misc2.t: 7 → 6). Pinned by
+`t/comment-embedded-exception-class.t`, verified byte-identical to `raku`.

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -63,7 +63,17 @@ fn ws_inner_with_bol(input: &str, bol: bool) -> PResult<'_, ()> {
                         r,
                     ));
                 }
-                return Err(PError::expected("Opening bracket required for #` comment"));
+                // `#\`` not immediately followed by an opening bracket is
+                // always invalid in Raku (`X::Syntax::Comment::Embedded`,
+                // whose `.message` has no dynamic content — see
+                // `old-design-docs/S32-setting-library/Exception.pod`), never
+                // a construct another alternative could still match, so this
+                // is fatal like the "no terminator" case above.
+                return Err(PError::fatal_at(
+                    "X::Syntax::Comment::Embedded: Opening bracket required for #` comment"
+                        .to_string(),
+                    r,
+                ));
             }
             let end = r.find('\n').unwrap_or(r.len());
             rest = &r[end..];

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1709,6 +1709,7 @@ impl Interpreter {
         register_x("X::Syntax::Reserved", "X::Syntax");
         register_x("X::Syntax::KeywordAsFunction", "X::Syntax");
         register_x("X::Syntax::Name::Null", "X::Syntax");
+        register_x("X::Syntax::Comment::Embedded", "X::Syntax");
         register_x("X::Syntax::Signature", "X::Syntax");
         register_x(
             "X::Syntax::Signature::InvocantMarker",

--- a/t/comment-embedded-exception-class.t
+++ b/t/comment-embedded-exception-class.t
@@ -1,0 +1,22 @@
+use Test;
+
+# `#\`` not immediately followed by an opening bracket used to fall through to
+# the generic "Confused." diagnosis (X::Syntax::Confused) instead of the
+# specific X::Syntax::Comment::Embedded rakudo raises. Fixed by tagging the
+# parser's "Opening bracket required for #` comment" message with the
+# "X::Type: text" convention and registering the class under X::Syntax (it was
+# entirely unregistered, so even a correctly-typed instance failed
+# `~~ X::Comp`).
+#
+# roast/S32-exceptions/misc2.t and roast/S02-lexical-conventions/comments.t
+# assert this under the real Test module (MUTSU_REAL_TEST=1).
+
+plan 4;
+
+try { EVAL '3 * #` (no closing bracket adjacency) 2' };
+is $!.^name, 'X::Syntax::Comment::Embedded',
+    'a #` not immediately followed by a bracket is X::Syntax::Comment::Embedded';
+is $!.message, "Opening bracket required for #` comment",
+    'the message matches rakudo exactly';
+ok $! ~~ X::Comp, 'X::Syntax::Comment::Embedded does X::Comp (compile-time error)';
+ok $! ~~ X::Syntax, 'X::Syntax::Comment::Embedded does X::Syntax';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1062,6 +1062,32 @@ instead, a different, still-unimplemented gap. Pin: `t/diffy-assign-metaop.t`
 provider and `MUTSU_REAL_TEST=1`. This was the only file in the "14 files
 fail on `Got: X::Syntax::Confused`" cluster whose expected class was
 `X::Syntax::CannotMeta`; the other 13 (different expected classes:
-`X::Syntax::Comment::Embedded`, `X::Syntax::Signature::InvocantNotAllowed`,
+~~`X::Syntax::Comment::Embedded`~~, `X::Syntax::Signature::InvocantNotAllowed`,
 `X::Comp::Group`, `X::Worry::Precedence::Range`, `X::Syntax::Malformed`,
 ...) remain open, each needing its own individual parser diagnosis.
+
+## `X::Syntax::Comment::Embedded` for `#\`` without an immediate bracket (2026-08-15)
+
+Picked the `X::Syntax::Comment::Embedded` example named above. Two
+independent gaps, not one: the parser's "Opening bracket required for #\`
+comment" diagnosis (`src/parser/helpers.rs`'s `ws()`) was never spelled in
+the `"X::Type: text"` convention (fixed: `PError::fatal_at` with the class
+prefix, same treatment as the sibling "Couldn't find terminator" case a few
+lines above), and — found only after fixing the first — the class was not
+registered under `X::Syntax` in `runtime_init.rs` at all, so
+`roast/S02-lexical-conventions/comments.t`'s three "no space/tab allowed"
+variants (which check the looser `~~ X::Comp`, marked "no exception type
+yet" in the roast source) regressed until the registration was added too.
+Fixed both; `news/2026-08/comment-embedded-exception-class.md`, pin
+`t/comment-embedded-exception-class.t`. `comments.t` goes from 4 to 1
+remaining failure under `MUTSU_REAL_TEST=1` (the last is the unrelated
+unspace-in-comment "sanity check" at line 167 — `#\`\  (comment) 32` reads
+the backslash as unspace and produces a differently-wrong parse rather than
+the `X::Syntax::Comment::Embedded` the roast assertion at line 157 wants;
+not investigated this round); `misc2.t` goes from 7 to 6.
+
+**Lesson for the next `Got: X::Syntax::Confused` file:** typing the message
+correctly is necessary but not sufficient — always re-check the class's
+`register_x` entry exists too, since `runtime_init.rs`'s X::Syntax family has
+several gaps of exactly this shape (`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`
+already covers the general problem; this was one concrete instance of it).


### PR DESCRIPTION
## Summary
- `#\`` (embedded comment) not immediately followed by an opening bracket used to fall through to the generic `X::Syntax::Confused` instead of the specific `X::Syntax::Comment::Embedded` rakudo raises, even though the parser already produced the exact right message text.
- Two independent gaps: the message wasn't spelled in the `"X::Type: text"` convention (`src/parser/helpers.rs`), and the class was never registered under `X::Syntax` in `runtime_init.rs` at all — so even a correctly-typed instance failed `~~ X::Comp`, which `roast/S02-lexical-conventions/comments.t` checks for the "no space/tab allowed" variants.
- Part of the `todo/tickets/vendor-real-test-module.md` campaign's residue of `Got: X::Syntax::Confused` files.

## Test plan
- [x] New pin `t/comment-embedded-exception-class.t`, verified byte-identical to `raku`.
- [x] `roast/S32-exceptions/misc2.t` and `roast/S02-lexical-conventions/comments.t` stay fully green under the native `Test` provider (no behavior change on whitelisted paths).
- [x] Both files lose failures under `MUTSU_REAL_TEST=1` (comments.t 4→1, misc2.t 7→6; both remainders are unrelated pre-existing gaps).
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean.
- [x] Full local `make test` (3171 files, 29555 tests): PASS.
- [ ] CI `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)