### PR TITLE
fix(parser): invocant-marker/attr-param signature exceptions compose X::Comp

### DIFF
--- a/news/2026-08/comment-embedded-exception-class.md
+++ b/news/2026-08/comment-embedded-exception-class.md
@@ -1,0 +1,35 @@
+# `#\`` without an immediate opening bracket now raises `X::Syntax::Comment::Embedded`
+
+Continuing the `todo/tickets/vendor-real-test-module.md` campaign's residue of
+"`Got: X::Syntax::Confused`" files: `#\`` (the embedded-comment sigil) not
+immediately followed by an opening bracket used to fall through to the
+generic "Confused." diagnosis instead of the specific
+`X::Syntax::Comment::Embedded` rakudo raises, even though the parser had
+already produced the exact right message ("Opening bracket required for #\`
+comment") — it just was not spelled in the `"X::Type: text"` convention that
+`RuntimeError::split_typed_message_convention` looks for, so it stayed
+untyped.
+
+Two independent gaps had to be fixed, not one:
+
+1. **The message itself wasn't typed.** `src/parser/helpers.rs`'s `ws()`
+   raised a plain `PError::expected(...)` for this case; switched to
+   `PError::fatal_at` (this diagnosis is never something another alternative
+   could still match, exactly like its sibling "Couldn't find terminator for
+   #\` comment" a few lines above) with the message prefixed
+   `X::Syntax::Comment::Embedded: `.
+2. **The class wasn't registered at all.** Even after typing the message,
+   `X::Syntax::Comment::Embedded` was missing from `runtime_init.rs`'s
+   `register_x` calls entirely, so `$! ~~ X::Comp` — the check
+   `roast/S02-lexical-conventions/comments.t` uses for the "no space
+   allowed"/"no tab allowed" variants it can't yet classify more precisely —
+   failed even once the class name was right. Registered under `X::Syntax`
+   (which already does `X::Comp`), matching `old-design-docs/S32-setting-library/Exception.pod`'s
+   `X::Syntax::Comment::Embedded does X::Syntax`.
+
+`roast/S32-exceptions/misc2.t` and `roast/S02-lexical-conventions/comments.t`
+both stay fully green under the native `Test` provider (no behavior change on
+the paths those exercise) and each lose one failure under
+`MUTSU_REAL_TEST=1` (comments.t: 4 → 1 remaining, the unrelated unspace-in-
+comment "sanity check"; misc2.t: 7 → 6). Pinned by
+`t/comment-embedded-exception-class.t`, verified byte-identical to `raku`.

--- a/news/2026-08/invocant-marker-exception-classes.md
+++ b/news/2026-08/invocant-marker-exception-classes.md
@@ -1,0 +1,35 @@
+# `X::Syntax::Signature::InvocantNotAllowed` and `X::Syntax::NoSelf` now compose `X::Comp`
+
+More residue from the `todo/tickets/vendor-real-test-module.md` campaign's
+"`Got: X::Syntax::Confused`" cluster: `sub foo($a:) { }` (an invocant marker
+in a *sub*, not a method) and `sub bar($!x) { }` (an attribute-twigil
+parameter, which needs `self`) already raised the correctly-named exception
+class — `reject_invocant_in_sub`/`reject_attr_params_in_sub`
+(`src/parser/stmt/sub/traits.rs`) built the right `Value::make_instance` —
+but `roast/S06-signature/errors.t` still saw `X::Syntax::Confused`.
+
+Two bugs, the same shape as the preceding `X::Syntax::Comment::Embedded` fix:
+
+1. **Neither class was registered under `X::Syntax` in `runtime_init.rs`.**
+   `throws-like X::Syntax::Signature::InvocantNotAllowed` matches by class,
+   but roast's neighboring `~~ X::Comp`-style checks (and the class's own MRO)
+   never resolved without a `register_x` entry. Registered
+   `X::Syntax::Signature::InvocantNotAllowed` under `X::Syntax::Signature` and
+   `X::Syntax::NoSelf` under `X::Syntax` directly, matching
+   `old-design-docs/S32-setting-library/Exception.pod`.
+2. **Both `.message` attributes leaked the `"X::Type: "` message-convention
+   prefix verbatim** instead of storing just the description text — a caller
+   reading `$!.message` (rather than `.^name`) got the redundant class name
+   glued to the front. Fixed by storing the bare description in the
+   exception's `message` attribute while keeping the prefixed form only in
+   the `PError` used for outer classification. Also updated
+   `InvocantNotAllowed`'s wording to rakudo's actual message ("Can only use
+   the : invocant marker in the signature for a method" — it previously said
+   something rakudo doesn't).
+
+`roast/S06-signature/errors.t` goes from 4 to 2 remaining failures under
+`MUTSU_REAL_TEST=1` (the other 2, `-> $a: { }` / `-> $a: $b { }`, are a
+separate, unfixed gap: pointy-block signatures don't even parse the `:`
+invocant marker, so `reject_invocant_in_sub` — only wired into `sub`
+declarations — never runs for them). Pinned by
+`t/invocant-marker-exception-classes.t`, verified byte-identical to `raku`.

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -63,7 +63,17 @@ fn ws_inner_with_bol(input: &str, bol: bool) -> PResult<'_, ()> {
                         r,
                     ));
                 }
-                return Err(PError::expected("Opening bracket required for #` comment"));
+                // `#\`` not immediately followed by an opening bracket is
+                // always invalid in Raku (`X::Syntax::Comment::Embedded`,
+                // whose `.message` has no dynamic content — see
+                // `old-design-docs/S32-setting-library/Exception.pod`), never
+                // a construct another alternative could still match, so this
+                // is fatal like the "no terminator" case above.
+                return Err(PError::fatal_at(
+                    "X::Syntax::Comment::Embedded: Opening bracket required for #` comment"
+                        .to_string(),
+                    r,
+                ));
             }
             let end = r.find('\n').unwrap_or(r.len());
             rest = &r[end..];

--- a/src/parser/stmt/sub/traits.rs
+++ b/src/parser/stmt/sub/traits.rs
@@ -415,7 +415,13 @@ pub(crate) fn reject_attr_params_in_sub(params: &[ParamDef]) -> Result<(), PErro
                 variable
             );
             let mut attrs = std::collections::HashMap::new();
-            attrs.insert("message".to_string(), Value::str(msg.clone()));
+            attrs.insert(
+                "message".to_string(),
+                Value::str(format!(
+                    "Variable {} used where no 'self' is available",
+                    variable
+                )),
+            );
             attrs.insert("variable".to_string(), Value::str(variable));
             let ex = Value::make_instance(Symbol::intern("X::Syntax::NoSelf"), attrs);
             return Err(PError::fatal_with_exception(msg, Box::new(ex)));
@@ -429,10 +435,10 @@ pub(crate) fn reject_invocant_in_sub(params: &[ParamDef]) -> Result<(), PError> 
         .iter()
         .any(|p| p.is_invocant || p.traits.iter().any(|t| t == "invocant"))
     {
-        let msg = "X::Syntax::Signature::InvocantNotAllowed: Invocant not allowed in sub signature"
-            .to_string();
+        let text = "Can only use the : invocant marker in the signature for a method";
+        let msg = format!("X::Syntax::Signature::InvocantNotAllowed: {}", text);
         let mut attrs = std::collections::HashMap::new();
-        attrs.insert("message".to_string(), Value::str(msg.clone()));
+        attrs.insert("message".to_string(), Value::str(text.to_string()));
         let ex = Value::make_instance(
             Symbol::intern("X::Syntax::Signature::InvocantNotAllowed"),
             attrs,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1715,6 +1715,11 @@ impl Interpreter {
             "X::Syntax::Signature::InvocantMarker",
             "X::Syntax::Signature",
         );
+        register_x(
+            "X::Syntax::Signature::InvocantNotAllowed",
+            "X::Syntax::Signature",
+        );
+        register_x("X::Syntax::NoSelf", "X::Syntax");
 
         // X::Obsolete (compile-time, subtype of X::Comp)
         register_x("X::Obsolete", "X::Comp");

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1709,6 +1709,7 @@ impl Interpreter {
         register_x("X::Syntax::Reserved", "X::Syntax");
         register_x("X::Syntax::KeywordAsFunction", "X::Syntax");
         register_x("X::Syntax::Name::Null", "X::Syntax");
+        register_x("X::Syntax::Comment::Embedded", "X::Syntax");
         register_x("X::Syntax::Signature", "X::Syntax");
         register_x(
             "X::Syntax::Signature::InvocantMarker",

--- a/t/comment-embedded-exception-class.t
+++ b/t/comment-embedded-exception-class.t
@@ -1,0 +1,22 @@
+use Test;
+
+# `#\`` not immediately followed by an opening bracket used to fall through to
+# the generic "Confused." diagnosis (X::Syntax::Confused) instead of the
+# specific X::Syntax::Comment::Embedded rakudo raises. Fixed by tagging the
+# parser's "Opening bracket required for #` comment" message with the
+# "X::Type: text" convention and registering the class under X::Syntax (it was
+# entirely unregistered, so even a correctly-typed instance failed
+# `~~ X::Comp`).
+#
+# roast/S32-exceptions/misc2.t and roast/S02-lexical-conventions/comments.t
+# assert this under the real Test module (MUTSU_REAL_TEST=1).
+
+plan 4;
+
+try { EVAL '3 * #` (no closing bracket adjacency) 2' };
+is $!.^name, 'X::Syntax::Comment::Embedded',
+    'a #` not immediately followed by a bracket is X::Syntax::Comment::Embedded';
+is $!.message, "Opening bracket required for #` comment",
+    'the message matches rakudo exactly';
+ok $! ~~ X::Comp, 'X::Syntax::Comment::Embedded does X::Comp (compile-time error)';
+ok $! ~~ X::Syntax, 'X::Syntax::Comment::Embedded does X::Syntax';

--- a/t/invocant-marker-exception-classes.t
+++ b/t/invocant-marker-exception-classes.t
@@ -1,0 +1,30 @@
+use Test;
+
+# `sub foo($a:) { }` (an invocant marker in a *sub*, not a method) and
+# `sub bar($!x) { }` (an attribute-twigil parameter outside a method, which
+# needs `self`) were already raising the right exception class, but two
+# things kept roast's `~~ X::Comp` / `~~ X::Syntax` checks from seeing it:
+#
+# - X::Syntax::Signature::InvocantNotAllowed and X::Syntax::NoSelf were never
+#   registered under X::Syntax at all, so a correctly-typed instance still
+#   failed `~~ X::Comp` (roast/S06-signature/errors.t,
+#   roast/S32-exceptions/misc2.t and others check this class hierarchy, not
+#   just the leaf class).
+# - Both exceptions' `.message` attribute leaked the "X::Type: " message-
+#   convention prefix verbatim instead of just the description text.
+
+plan 6;
+
+try { EVAL 'sub foo($a:) { }' };
+is $!.^name, 'X::Syntax::Signature::InvocantNotAllowed',
+    'invocant marker in a sub signature is X::Syntax::Signature::InvocantNotAllowed';
+is $!.message, 'Can only use the : invocant marker in the signature for a method',
+    'the message matches rakudo exactly and does not repeat the class name';
+ok $! ~~ X::Comp, 'X::Syntax::Signature::InvocantNotAllowed does X::Comp';
+
+try { EVAL 'sub bar($!x) { }' };
+is $!.^name, 'X::Syntax::NoSelf',
+    'an attribute-twigil sub parameter is X::Syntax::NoSelf';
+is $!.message, q{Variable $!x used where no 'self' is available},
+    'the message does not repeat the class name';
+ok $! ~~ X::Comp, 'X::Syntax::NoSelf does X::Comp';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1091,3 +1091,22 @@ correctly is necessary but not sufficient — always re-check the class's
 `register_x` entry exists too, since `runtime_init.rs`'s X::Syntax family has
 several gaps of exactly this shape (`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`
 already covers the general problem; this was one concrete instance of it).
+
+## `X::Syntax::Signature::InvocantNotAllowed` and `X::Syntax::NoSelf` (2026-08-15)
+
+Same shape again, found via `roast/S06-signature/errors.t` (not itself in the
+"14 files" cluster list, but the same mechanism): both classes already had
+correctly-named exceptions built in `src/parser/stmt/sub/traits.rs`, but
+neither was registered under `X::Syntax` in `runtime_init.rs`, so `~~
+X::Comp` failed. Also fixed a `.message`-attribute bug found on the way (both
+sites stored the full `"X::Type: text"` string in the `message` attribute
+instead of just `text`) and corrected `InvocantNotAllowed`'s wording to
+rakudo's actual text. `news/2026-08/invocant-marker-exception-classes.md`,
+pin `t/invocant-marker-exception-classes.t`. `errors.t` goes from 4 to 2
+remaining failures under `MUTSU_REAL_TEST=1` — the other 2
+(`-> $a: { }` / `-> $a: $b { }`) are a distinct, unfixed gap: pointy-block
+signatures don't parse the `:` invocant marker at all (a parse-level gap, not
+a missing semantic check — `reject_invocant_in_sub` is only wired into `sub`
+declarations, not the pointy-block param parser in
+`src/parser/stmt/control/pointy_param.rs`), so the diagnosis is lost to
+generic "Confused." before any check can run. Left open for a future round.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1062,6 +1062,32 @@ instead, a different, still-unimplemented gap. Pin: `t/diffy-assign-metaop.t`
 provider and `MUTSU_REAL_TEST=1`. This was the only file in the "14 files
 fail on `Got: X::Syntax::Confused`" cluster whose expected class was
 `X::Syntax::CannotMeta`; the other 13 (different expected classes:
-`X::Syntax::Comment::Embedded`, `X::Syntax::Signature::InvocantNotAllowed`,
+~~`X::Syntax::Comment::Embedded`~~, `X::Syntax::Signature::InvocantNotAllowed`,
 `X::Comp::Group`, `X::Worry::Precedence::Range`, `X::Syntax::Malformed`,
 ...) remain open, each needing its own individual parser diagnosis.
+
+## `X::Syntax::Comment::Embedded` for `#\`` without an immediate bracket (2026-08-15)
+
+Picked the `X::Syntax::Comment::Embedded` example named above. Two
+independent gaps, not one: the parser's "Opening bracket required for #\`
+comment" diagnosis (`src/parser/helpers.rs`'s `ws()`) was never spelled in
+the `"X::Type: text"` convention (fixed: `PError::fatal_at` with the class
+prefix, same treatment as the sibling "Couldn't find terminator" case a few
+lines above), and — found only after fixing the first — the class was not
+registered under `X::Syntax` in `runtime_init.rs` at all, so
+`roast/S02-lexical-conventions/comments.t`'s three "no space/tab allowed"
+variants (which check the looser `~~ X::Comp`, marked "no exception type
+yet" in the roast source) regressed until the registration was added too.
+Fixed both; `news/2026-08/comment-embedded-exception-class.md`, pin
+`t/comment-embedded-exception-class.t`. `comments.t` goes from 4 to 1
+remaining failure under `MUTSU_REAL_TEST=1` (the last is the unrelated
+unspace-in-comment "sanity check" at line 167 — `#\`\  (comment) 32` reads
+the backslash as unspace and produces a differently-wrong parse rather than
+the `X::Syntax::Comment::Embedded` the roast assertion at line 157 wants;
+not investigated this round); `misc2.t` goes from 7 to 6.
+
+**Lesson for the next `Got: X::Syntax::Confused` file:** typing the message
+correctly is necessary but not sufficient — always re-check the class's
+`register_x` entry exists too, since `runtime_init.rs`'s X::Syntax family has
+several gaps of exactly this shape (`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`
+already covers the general problem; this was one concrete instance of it).


### PR DESCRIPTION
## Summary
- Stacked on #6472 (same campaign, same mechanism) — merge that one first.
- `reject_invocant_in_sub` / `reject_attr_params_in_sub` (`src/parser/stmt/sub/traits.rs`) already built the correctly-named `X::Syntax::Signature::InvocantNotAllowed` / `X::Syntax::NoSelf` exceptions, but neither class was registered under `X::Syntax` in `runtime_init.rs`, so `~~ X::Comp` failed even on a correctly-typed instance.
- Also fixes both sites' `.message` attribute leaking the `"X::Type: "` message-convention prefix verbatim, and corrects `InvocantNotAllowed`'s wording to rakudo's actual text.
- Part of the `todo/tickets/vendor-real-test-module.md` campaign's residue of `Got: X::Syntax::Confused` files.

## Test plan
- [x] New pin `t/invocant-marker-exception-classes.t`, verified byte-identical to `raku`.
- [x] `roast/S06-signature/errors.t` and the `X::Syntax::NoSelf`-asserting files stay fully green under the native `Test` provider.
- [x] `roast/S06-signature/errors.t` loses 2 of 4 failures under `MUTSU_REAL_TEST=1` (the other 2 are a separate, unfixed gap: pointy-block signatures don't parse the `:` invocant marker at all).
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean.
- [x] Full local `make test` (3172 files, 29561 tests): PASS.
- [ ] CI `make roast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)