### PR TITLE
fix(exceptions): X::Comp gains .pre/.post; X::InvalidType, X::Syntax::Adverb gain missing attributes

### DIFF
--- a/news/2026-08/comp-exception-pre-post-and-two-missing-attributes.md
+++ b/news/2026-08/comp-exception-pre-post-and-two-missing-attributes.md
@@ -1,0 +1,35 @@
+# X::Comp gains .pre/.post; X::InvalidType and X::Syntax::Adverb gain their missing attributes
+
+Continuing the `todo/tickets/vendor-real-test-module.md` campaign (replacing
+mutsu's native `Test` provider with the real, vendored `Test.rakumod`),
+`roast/S32-exceptions/misc.t` was crashing under `MUTSU_REAL_TEST=1` on three
+independent "typed exception, missing attribute" gaps — the same shape as
+several earlier fixes in this campaign, where `throws-like` reads an attribute
+that the class was never given, and a single missing method aborts the whole
+test file instead of just failing one subtest.
+
+1. rakudo's `X::Comp` base class — the ancestor of the whole `X::Syntax::*`
+   family — carries `.pre`/`.post` (the source text immediately around a
+   parse failure's eject point), but mutsu's generic derivation of attributes
+   from the `"X::Type: text"` message convention only ever derived
+   `X::Syntax::Missing.what`. `parser::parse_program()` is the one place that
+   unambiguously has both the full original source and the failure offset for
+   a recoverable, typed-convention-message parse diagnosis, so it now computes
+   `pre`/`post` there and carries them on two new `RuntimeError` cold fields;
+   the generic attribute derivation fills them in for any class that doesn't
+   already set its own (so existing call sites that build a fuller exception
+   themselves are untouched).
+2. `X::InvalidType` had `.typename` on its `returns`/`of`-trait raise site but
+   not on its `does`/`hides`-parent one. Fixed by deriving it from the message
+   text (`"Invalid typename '{typename}'"`), the same "derive it the way
+   rakudo derives it so the two cannot disagree" rule already used for
+   `X::Syntax::Missing.what`.
+3. `X::Syntax::Adverb` had no `.what` at either of its two raise sites (`my $x
+   :a`, and `infix:(&)` under `use MONKEY`).
+
+`roast/S32-exceptions/misc.t` now passes fully under both the native and the
+real `Test` module. Pin: `t/typed-exception-attributes.t` gained three new
+cases (16 → 21 assertions), green under `raku` too except the `pre`/`post`
+case, which exercises a construct where rakudo itself gets the eject position
+wrong (rakudo issue #4431, `#?rakudo todo`'d in the roast source) — the pin
+asserts mutsu's own correct eject point instead of reproducing rakudo's bug.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -449,6 +449,15 @@ pub(crate) fn parse_program(input: &str) -> Result<(Vec<Stmt>, Option<String>), 
                     if let Some(ex) = e.exception {
                         err.exception = Some(ex);
                     }
+                    // rakudo's X::Comp family also carries `.pre`/`.post` (the
+                    // source text immediately around the eject point, current
+                    // line only). This is the one place both the full original
+                    // source and the failure offset are unambiguously known, so
+                    // compute it here rather than at each individual raise site.
+                    let pre_full = &source[..consumed];
+                    let pre = pre_full.rsplit('\n').next().unwrap_or(pre_full).to_string();
+                    let post = tail.split('\n').next().unwrap_or(tail).to_string();
+                    err.set_pre_post_context(pre, post);
                     Err(with_parse_hint(err))
                 } else if let Some(context) = near_snippet(tail, 60) {
                     Err(with_parse_hint(RuntimeError::with_location(

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -411,10 +411,11 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
         } else {
             "$"
         };
+        let what = format!("{}{}", sigil, name);
         return Err(illegal_my_var_error(
             "X::Syntax::Adverb",
-            &format!("You can't adverb {}{}", sigil, name),
-            &[],
+            &format!("You can't adverb {}", what),
+            &[("what", &what)],
         ));
     }
 

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -118,6 +118,13 @@ pub struct RuntimeErrorCold {
     /// resume point (`resume_body_ip = ip + 1`), so statements after the take
     /// in the same iteration are not lost on coroutine resume.
     pub take_suspend_site: Option<(usize, usize)>,
+    /// Source text immediately before a parse failure's eject point (current
+    /// line only, matching rakudo's `X::Comp.pre`). Set alongside `line`/
+    /// `column` by `parse_program` when the full source and offset are known.
+    pub pre_context: Option<String>,
+    /// Source text immediately after a parse failure's eject point (current
+    /// line only, matching rakudo's `X::Comp.post`).
+    pub post_context: Option<String>,
 }
 
 #[derive(Debug)]
@@ -247,6 +254,17 @@ impl RuntimeError {
     }
     pub(crate) fn set_backtrace(&mut self, v: Option<String>) {
         self.cold_mut().backtrace = v;
+    }
+    pub(crate) fn set_pre_post_context(&mut self, pre: String, post: String) {
+        let cold = self.cold_mut();
+        cold.pre_context = Some(pre);
+        cold.post_context = Some(post);
+    }
+    pub(crate) fn pre_context(&self) -> Option<&str> {
+        self.cold.as_ref().and_then(|c| c.pre_context.as_deref())
+    }
+    pub(crate) fn post_context(&self) -> Option<&str> {
+        self.cold.as_ref().and_then(|c| c.post_context.as_deref())
     }
 
     pub(crate) fn failure_original_backtrace(&self) -> Option<&str> {

--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -228,6 +228,39 @@ impl RuntimeError {
         {
             attrs.insert("what".to_string(), Value::str_from(what));
         }
+        // `X::InvalidType`'s message IS `Invalid typename '{typename}'` in
+        // rakudo (same derive-don't-duplicate rule as `X::Syntax::Missing`
+        // above). Without it, `throws-like …, X::InvalidType, typename => …`
+        // matched the class and then died on "No such method 'typename'".
+        if class_name == "X::InvalidType"
+            && let Some(rest) = text.strip_prefix("Invalid typename '")
+            && let Some(typename) = rest.strip_suffix('\'')
+        {
+            attrs.insert("typename".to_string(), Value::str_from(typename));
+        }
+        // `X::Syntax::Adverb`'s message IS `You can't adverb {what}` in
+        // rakudo (same derive-don't-duplicate rule as the two above).
+        if class_name == "X::Syntax::Adverb"
+            && let Some(what) = text.strip_prefix("You can't adverb ")
+        {
+            let what = what.strip_suffix('.').unwrap_or(what);
+            attrs.insert("what".to_string(), Value::str_from(what));
+        }
+        // rakudo's whole X::Comp family carries `.pre`/`.post` (source text
+        // around the eject point); `parse_program` computes these for every
+        // typed parse diagnosis. Without them, a `throws-like …, X::…, pre =>
+        // …` (or a handler that merely reads `.post` to build a message)
+        // matched the class and then died on "No such method 'post'".
+        if let Some(pre) = self.pre_context() {
+            attrs
+                .entry("pre".to_string())
+                .or_insert_with(|| Value::str_from(pre));
+        }
+        if let Some(post) = self.post_context() {
+            attrs
+                .entry("post".to_string())
+                .or_insert_with(|| Value::str_from(post));
+        }
         if let Some(line) = self.line() {
             attrs.insert("line".to_string(), Value::int(line as i64));
         }

--- a/t/typed-exception-attributes.t
+++ b/t/typed-exception-attributes.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 16;
+plan 21;
 
 # A typed exception must carry the attributes rakudo declares for it, not just
 # a message that happens to name the class: `throws-like` matches on them.
@@ -53,3 +53,29 @@ throws-like 'module H { my $x is export = 42 }', X::Comp::Trait::Scope,
     throws-like { @list.grep(Mu, :!v) }, X::Adverb,
         what => 'grep', 'a negated :v is unexpected too';
 }
+
+# X::InvalidType: `.typename` for a `does`/`hides` parent that isn't declared.
+throws-like 'my class C hides Baz { }', X::InvalidType,
+    typename => 'Baz', 'hides names the missing typename';
+throws-like 'my class C does InNoWayExist { }', X::InvalidType,
+    typename => 'InNoWayExist', 'does names the missing typename';
+
+# X::Syntax::Adverb: `.what` on a variable declaration and on an operator
+# declarator, two independent raise sites for the same class.
+throws-like 'my $x :a', X::Syntax::Adverb,
+    what => '$x', 'a colonpair adverb on a declaration names the variable';
+{
+    use MONKEY;
+    throws-like { EVAL 'infix:(&)' }, X::Syntax::Adverb,
+        what => ':(&)', 'a signature-literal adverb on an operator names itself';
+}
+
+# X::Syntax::Missing: `.pre`/`.post` (source text around the eject point),
+# not just `.what`. rakudo itself gets the eject position wrong for this
+# construct (https://github.com/rakudo/rakudo/issues/4431, `#?rakudo todo` in
+# roast/S32-exceptions/misc.t) and reports `pre => 'if True if '`, `post =>
+# '{ };'` instead — this pin asserts mutsu's own (correct) eject point rather
+# than reproducing rakudo's bug.
+throws-like 'if True if { };', X::Syntax::Missing,
+    what => 'block', pre => 'if True ', post => 'if { };',
+    'a missing block carries pre/post context';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1164,3 +1164,82 @@ sub-side cases) with the two pointy-block assertions, both green under `raku`
 too. `roast/S06-signature/errors.t` now passes fully under both the native
 and the real `Test` module. Full `t/` suite (3171 files) and
 `cargo clippy -- -D warnings` both clean.
+
+## `X::Comp` missing `.pre`/`.post`, plus two more "typed but missing an
+attribute" gaps (2026-08-15)
+
+Continuing the campaign, picked `roast/S32-exceptions/misc.t` — still
+regressing under `MUTSU_REAL_TEST=1` — and triaged it in full before starting
+(per the "a file that fails at three unrelated layers" lesson above). Three
+independent gaps, all the same shape as every other entry in this file: the
+class was already typed correctly, but an attribute `throws-like` reads was
+missing, so the assertion crashed the whole file with "No such method" instead
+of just failing the one subtest.
+
+1. **`X::Comp`'s whole family (`X::Syntax::Missing` and friends) had no
+   `.pre`/`.post` at all.** rakudo's `X::Comp` base class carries these (the
+   source text immediately around the parse failure's eject point) for every
+   compile-time exception, but mutsu's generic "derive attrs from the typed
+   `"X::Type: text"` message" path (`RuntimeError::exception_value_with_backtrace`,
+   `src/value/error_construct.rs`) only derived `X::Syntax::Missing.what`. Fixed
+   generally rather than per-class: `parser::parse_program()`
+   (`src/parser/mod.rs`) is the one place that unambiguously has both the full
+   original source and the failure offset for a SOFT (recoverable,
+   typed-convention-message) parse diagnosis, so it now computes `pre`/`post`
+   there (current-line-only, same convention as the pre-existing
+   `source_span_at` helper `X::Syntax::Confused`'s "Missing semicolon" case
+   already used) and stores them on two new `RuntimeError` cold fields
+   (`pre_context`/`post_context`, `src/value/error.rs`). The generic attribute
+   derivation then fills `pre`/`post` from those fields for any class that
+   doesn't already carry them explicitly (`.entry(...).or_insert_with(...)`,
+   so a call site that built its own exception with its own `pre`/`post`
+   — e.g. the `modifier.rs` "Missing semicolon" site — is left alone).
+   **Caveat, not fixed:** this does not attempt to reproduce rakudo's `pre`/
+   `post` bug-for-bug — `roast/S32-exceptions/misc.t` line 92's own assertion
+   is `#?rakudo todo`'d as "Wrong eject position" (rakudo issue #4431), i.e.
+   rakudo itself gets this specific construct's eject point wrong, so no
+   fix here could match both rakudo and the assertion at once. mutsu now
+   computes its own eject point without crashing, which is strictly closer to
+   correct than raising nothing.
+2. **`X::InvalidType` had no `.typename`** on the `does`/`hides`-parent raise
+   site (`src/runtime/registration_class_validate.rs`) — only the sibling
+   `returns`/`of`-trait site (`src/runtime/registration_sub.rs`) set it. Fixed
+   the same way as `X::Syntax::Missing.what`: rakudo's message IS `Invalid
+   typename '{typename}'`, so `exception_value_with_backtrace` derives it from
+   the message text rather than duplicating it at the raise site.
+3. **`X::Syntax::Adverb` had no `.what`** at either of its two raise sites
+   (`my $x :a` in `src/parser/stmt/decl/my_decl.rs`, `infix:(&)` in
+   `src/parser/primary/ident/identifier_call.rs`). The first already builds a
+   full exception object with the sigil+name in hand, so it now passes `what`
+   as an extra attribute directly; the second only ever built a plain message
+   string, so it goes through the same message-derivation mechanism as item 2
+   (`"You can't adverb {what}"`).
+
+None of these three needed a message-text change (the trailing-period
+double-`X::Type:` prefix bug documented in the round-6-round-8
+`bench-ctor`-adjacent sessions elsewhere in this repo was checked for at both
+raise sites and not present here) — only additional attributes. Pin: extended
+`t/typed-exception-attributes.t` (16 → 21 assertions) with the three new
+cases, message text unchanged elsewhere in the file; all new assertions green
+under `raku` too except the `X::Syntax::Missing` `pre`/`post` one, which is
+annotated with the rakudo-bug caveat from item 1 instead. `misc.t` now passes
+fully under both the native and the real `Test` module. Full `t/` suite (3172
+files, 29568 tests) and `cargo clippy -- -D warnings` both clean.
+
+**Next lead:** `misc.t` was fully closed, but two more gaps surfaced past it
+while triaging (not fixed this round): `sub foo() returns !!!wtf??? { }`
+(expects `X::Syntax::Malformed`, `what => 'trait'`) parses as generic
+`X::Syntax::Confused` instead — the malformed-return-type name is not
+recognized as its own diagnosis; and a stubbed-role-parameterization test
+(`role Bottle[::T] { ... }; class Wine { ... }; say Bottle[Wine].new;`, around
+line 29) raised an uncaught "The following packages were stubbed but not
+defined: Wine" that aborted the file with exit 1 before the `pre`/`post` fix
+made it possible to see past line 93. Also still open in this file's
+neighbourhood: `PError::malformed()` (`src/parser/parse_result.rs`) has the
+same double-prefix `message`-attribute bug the `X::Anon::Multi` and
+`InvocantNotAllowed` fixes elsewhere in this file already found and fixed for
+other classes — `X::Syntax::Malformed.message` currently reads
+`"X::Syntax::Malformed: Malformed initializer"` instead of rakudo's plain
+`"Malformed initializer"` — not yet fixed since no roast assertion in the
+sweep currently reads `.message` on it, but worth doing alongside whichever of
+the two gaps above is picked up next (both raise `X::Syntax::Malformed`).


### PR DESCRIPTION
## Summary
- `roast/S32-exceptions/misc.t` crashed under `MUTSU_REAL_TEST=1` on three "typed exception, missing attribute" gaps (continuing `todo/tickets/vendor-real-test-module.md`):
  - rakudo's whole `X::Comp` family (`X::Syntax::Missing` and friends) had no `.pre`/`.post` — added generally by computing them once in `parser::parse_program()` (where the full source and failure offset are both known) and deriving them for any class that doesn't already set its own.
  - `X::InvalidType` had `.typename` on its `returns`/`of`-trait raise site but not on its `does`/`hides`-parent one — fixed by deriving it from the message text.
  - `X::Syntax::Adverb` had no `.what` at either of its two raise sites.
- `misc.t` now passes fully under both the native and the real `Test` module.

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` all clean
- [x] `prove -e target/debug/mutsu t/` — 3172 files, 29568 tests, all pass
- [x] `t/typed-exception-attributes.t` — extended 16 → 21 assertions, all green under `raku` too (except the documented rakudo-bug case)
- [x] `MUTSU_REAL_TEST=1 MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S32-exceptions/misc.t` — now passes (was crashing)
- [x] `roast/S32-exceptions/misc.t`, `misc2.t`, `S04-statements/terminator.t`, `S03-operators/range.t`, `S06-signature/errors.t` all still pass under the native provider (no whitelist regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)