### PR TITLE
docs(adr0019): split F4 into F4a/F4b/F4c, file any_failed gate as its own ticket

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -117,8 +117,10 @@ unchecked even if its original PR merged. PRs are sequential branches from the t
 
 **Current progress:** Phases A, B, and C are fully closed. Phase D is closed except for the
 optional, low-priority D2c-5. Phase E is closed except E2 (still-open cleanup, no longer gating —
-E1, E3-E11 are all closed). Phase F has started: F5 is closed; F1-F4, F6, F7, and the completion
-gates (G1-G4) remain open. See each box's entry below for its own status, and
+E1, E3-E11 are all closed). Phase F has started: F3 and F5 are closed; F1/F2 are done except a
+deliberately-parked fidelity slice; F4 is split into F4a/F4b/F4c (none closed yet — see F4's own
+entry); F6, F7, and the completion gates (G1-G4) remain open. See each box's entry below for its
+own status, and
 `todo/deep/adr0019-*.md` for the underlying design docs — `d2-remainder-attr-plan-lowering.md`,
 `d4-parent-expr-chunks.md`, `d5-plan-driven-how-ops.md`, `d6-d9-legacy-body-removal.md`,
 `d7-d8-role-plan-encoding.md`, `d3-8-method-body-main-pass-compilation.md` for Phase D, and
@@ -995,6 +997,62 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   E4b) is also the sole `.^methods` source.
 - [ ] **F4 — Remove `ClassDef::methods` as a dispatch/registration mirror.** Leave type structure
   metadata beside the canonical method table and update snapshots/rollback to copy one source.
+  **Split in place (2026-08-15), following the C6/D2/E1-E11 precedent** — a read-site
+  classification pass (`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`'s sibling
+  survey, and the earlier `todo/deep/adr0019-f4-classdef-methods-still-load-bearing.md` scoping)
+  found `Registry::sync_user_method_entries` currently writes the canonical table FROM
+  `ClassDef::methods` (the opposite of what F4 wants), with ~15-20 files of live dispatch/MOP/
+  BUILD-TWEAK read sites and ~10 files of write sites. That work does not fit one PR or one
+  design decision, so it is now three sub-boxes:
+  - [ ] **F4a — Decide and implement the role-owner read policy.** `Registry::method_entries` has
+    no row at all for a role that is never `.new`-punned (the common case — a role only ever
+    `does`-composed into a class, never instantiated directly): see
+    `todo/deep/method-entries-never-covers-unpunned-roles.md`. **Do NOT close this gap by
+    populating role-owner rows into `Registry::method_entries` through the shared
+    `sync_user_method_entries`/`get_method_overloads` write-and-read path** — tried exactly that
+    on 2026-08-15 (mirror the class branch, populate on role-registration-finish) and it
+    regressed composed-role multi-method `.*`/`.+` dispatch
+    (`resolve_methods_per_mro_level`'s all-or-nothing `any_failed` gate, an existing landmine
+    unrelated to this box, treats a newly-visible role-owned MRO level as a hard requirement even
+    when its candidates are already fully represented via a more-derived flattened class level —
+    reverted, PR #6478, repro and full trace in the ticket). The general lesson: **when a change
+    writes through a function every dispatcher reads, the risk inventory is every transitive
+    reader of that function, found by grep — not just the call sites a ticket happens to name.**
+    The gap ticket originally named 4 "bites here" sites; a 5th, unnamed one
+    (`resolve_method_with_owner_impl`'s own per-level walk, reached transitively through
+    `resolve_methods_per_mro_level`) is the one that broke. Instead: add an explicit
+    `role_method_overloads(owner, name)` helper reading `Registry::roles` directly (role method
+    definitions are composition inputs, not dispatch entries — the dispatchable form is always
+    the flattened copy on the composing class), and migrate ONLY the originally-named 4
+    production call sites (qualified-call resolution, the deferral/`nextsame`-`callsame` chain,
+    private-method resolution, the ctor phase plan) to consult it as an explicit fallback, one
+    consumer family per sub-PR, each raku-verified — the same discipline E1a/E4a/E7 already used
+    successfully. Winner selection (`resolve_method_with_owner_impl`,
+    `resolve_methods_per_mro_level`) must NOT call this helper.
+  - [ ] **F4b — Cutover the class-level-only read clusters.** The read sites that never touch a
+    role at all (`methods_object.rs`'s six BUILD/TWEAK existence checks, `metamodel.rs`,
+    `class_introspection.rs:39`, `ctor_phase_plan.rs:67,103`, and the Cluster B sites once F4a's
+    helper exists) move from `class_def.methods` to `MethodEntry.user_candidates` (+ the F4a
+    helper where a role fallback applies), shadow-checked per the usual pattern. Skip
+    `class_dispatch.rs:228` — it lives inside the `run_instance_method` carrier F6 deletes
+    outright, so cutting it over here is throwaway work; let F6's carrier deletion remove it for
+    free.
+  - [ ] **F4c — Invert the write direction and remove the field.** Make `MethodEntry`/the
+    canonical table the write-side source (`sync_user_method_entries`'s write sites in
+    `registration.rs`, `registration_class_body_attr.rs`, `registration_class_body_method.rs`,
+    `registration_class_compose.rs`, `registration_role_*.rs`, `system.rs`,
+    `methods_classhow_dispatch.rs:862,923` write `MethodEntry` directly instead of
+    `class_def.methods`), solve the full-name-enumeration need
+    (`methods_classhow_dispatch.rs:1324` needs "every method name owner X has," which the
+    `(owner, name)`-keyed table has no index for today), then delete `ClassDef::methods`/
+    `RoleDef::methods` and update snapshot/rollback (class redeclaration, augment rollback, EVAL
+    class restoration) to copy the one remaining source. Needs its own design note before code —
+    this is the box's own original "field deletion" framing, now correctly scoped as the last
+    step rather than the first.
+  F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
+  caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
+  one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site
+  last, right before the carrier itself is deleted.
 - [x] **F5 — Remove superseded method caches and manual invalidation.** Keep only the
   generation-keyed resolved-call cache plus data caches that type mutation cannot invalidate.
   The inventory this box retires: ~72 manual clear sites across 12 files (the 32 in

--- a/todo/tickets/resolve-methods-per-mro-level-any-failed-discards-matches.md
+++ b/todo/tickets/resolve-methods-per-mro-level-any-failed-discards-matches.md
@@ -1,0 +1,84 @@
+# `resolve_methods_per_mro_level`'s `any_failed` gate discards every successful `.*`/`.+` match
+
+## What's wrong
+
+`Interpreter::resolve_methods_per_mro_level` (`src/runtime/resolution_method.rs:742`), the winner
+list builder behind `.*name`/`.+name` (all-candidates dispatch, used e.g. by
+`call_method_all_with_values`), collects every MRO level that defines the method into
+`defining_levels`, then — for a multi method — resolves each defining level independently via
+`resolve_method_with_owner_impl(cn, method_name, arg_values, None, None)`, using that level's own
+name as a fresh MRO-walk start. If **any single level** fails to resolve a matching candidate for
+the given call's arguments, the function sets `any_failed = true` and a few lines later does:
+
+```rust
+if any_failed {
+    return Vec::new();
+}
+```
+
+This discards every match, including ones that DID resolve successfully at other levels. The
+caller (`call_method_all_with_values`) then can't distinguish "no candidate anywhere matched" from
+"some candidates matched, but this one defining level's own candidate set doesn't cover these
+args" — both look like an empty candidate list, and `X::Multi::NotFound` is raised even though a
+real call site of `.*name`/`.+name` should get back the successful matches.
+
+## How this was found
+
+Discovered 2026-08-15 while implementing (and then reverting) a fix for
+`todo/deep/method-entries-never-covers-unpunned-roles.md` — see that file's "Update 2026-08-15"
+section for the full trace. That specific change made an un-punned role's own MRO level newly
+visible to `get_method_overloads`, which is what made this pre-existing gate actually fire in
+practice; the gate itself is independent of that change and file, and worth fixing on its own
+merits, not as a side effect of populating `Registry::method_entries` for roles. **Do not use this
+ticket to justify populating role-owner rows into the shared method-entries table** — the two
+concerns are being kept deliberately decoupled (see the ADR-0019 F4 box's F4a/F4b/F4c split for
+why).
+
+## Minimal repro (no Test module, no role-gap fix needed)
+
+Not yet re-confirmed as reproducing on a totally clean `main` (the trace above happened with an
+in-progress, since-reverted code change active) — this needs to be re-verified from scratch as the
+very first step of picking this up. If it turns out this exact repro needs an un-punned role's MRO
+level to be visible (i.e. does NOT reproduce on clean `main` today), the bug may currently be
+latent/unreachable via ordinary composed-role dispatch and only surfaces once some future change
+(this ticket's own fix, or F4a/b) makes more MRO levels visible to `get_method_overloads` — in that
+case this ticket becomes a "must fix before/alongside" prerequisite for that future change rather
+than an independently-reachable bug today. Confirm which case this is before designing a fix.
+
+```raku
+role R5 {
+    multi method rt()       { say 'empty' }
+    multi method rt(Str $a) { say 'Str'   }
+}
+role R6 {
+    multi method rt(Numeric $a) { say 'Numeric' }
+}
+class C { has @.order }
+my C $b1 .= new();
+$b1 does (R5, R6);
+$b1.*rt;
+```
+
+`raku` prints `empty`. On the branch with the (reverted) role-method_entries-population change,
+mutsu threw `X::Multi::NotFound` ("No matching candidates for method: rt") instead — `R6`'s own
+`rt(Numeric $a)` doesn't match zero args, and that single failure discarded the class-level
+flattened match (`rt()`) and `R5`'s own matching `rt()`, both of which had resolved correctly.
+
+## Suggested fix direction
+
+Change the multi-candidate branch of `resolve_methods_per_mro_level` so a defining level's failure
+to produce a matching candidate for this call's arguments is not fatal to the whole result — only
+levels that resolve should contribute to the output, mirroring how a single-dispatch multi-method
+call already tolerates "this MRO level's overloads exist but none match, keep walking" (see
+`resolve_method_with_owner_impl`'s own loop). The `any_failed` flag's current all-or-nothing
+semantics may have been written on the (previously true) assumption that `defining_levels` only
+ever contains levels the receiver can actually resolve `method_name` on with *some* signature
+compatible with any call — worth understanding why that assumption held before removing it, in
+case there's a real invariant (e.g. distinguishing "signature mismatch" from "ambiguous multi
+match," which should probably still propagate as an error) that a naive "just skip failures" fix
+would silently break.
+
+Raku-verify the desired `.*`/`.+` semantics across a few shapes (a level whose candidates don't
+cover the args at all vs. a level with an ambiguous match vs. a level with a private-only
+candidate) before landing — this sits on real production dispatch, not introspection, so the usual
+"measure before assuming" discipline applies.


### PR DESCRIPTION
## Summary
- Following the 2026-08-15 regression found and reverted in #6478 (PR that recorded why naively populating `Registry::method_entries` for un-punned roles breaks composed-role `.*`/`.+` multi-method dispatch), consulted on strategy and split ADR-0019 Phase F box F4 into three sub-boxes in place, matching the C6/D2/E1-E11 "measure first, then split" precedent:
  - **F4a** — decide the role-owner read policy (explicit `role_method_overloads()` helper, NOT populating the shared table; migrate only the 4 originally-named production call sites, one consumer family per sub-PR, winner selection untouched).
  - **F4b** — cutover the class-level-only read clusters to `MethodEntry.user_candidates` (skips `class_dispatch.rs:228`, which F6 deletes outright).
  - **F4c** — invert the write direction and remove `ClassDef::methods`/`RoleDef::methods`.
- Notes that F6 (deleting the `run_instance_method` carrier) is only coupled to F4 through that one `class_dispatch.rs:228` site, so F6's caller-reduction slices can proceed in parallel.
- Files `resolve_methods_per_mro_level`'s pre-existing "any single defining MRO level fails to resolve -> discard every match" gate as its own standalone ticket (`todo/tickets/resolve-methods-per-mro-level-any-failed-discards-matches.md`), decoupled from the role-entries work that surfaced it.

Docs-only; no code changes.

## Test plan
- N/A (docs-only; CI's docs-only classifier should skip the heavy jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)