### PR TITLE
fix(adr0019): F4b class-only BUILD/TWEAK/HOW-protocol checks read the canonical method table

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1050,6 +1050,28 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     `class_dispatch.rs:228` — it lives inside the `run_instance_method` carrier F6 deletes
     outright, so cutting it over here is throwaway work; let F6's carrier deletion remove it for
     free.
+
+    **Progress (the class-only cluster, #TBD):** the class-level-only reads named above are
+    migrated to `Registry::user_method_overloads` (a thin, already-existing wrapper over the
+    canonical `MethodEntry` table): `methods_object.rs`'s `mro_has_build_or_tweak`,
+    `native_ctor_plan`'s has_build/has_tweak probes, and `build_owning_attr_names`;
+    `ctor_phase_plan.rs:67,103` (`build_construction_phase_steps`'s class_has_own /
+    has_non_submethod probes); `metamodel.rs`'s three custom-HOW existence checks
+    (`install_custom_grammar_how`'s `find_method`, `install_custom_class_how`'s `compose`,
+    `declare_how_has_user_method`'s arbitrary method_name); `class_introspection.rs:39`
+    (`class_has_new_accepting_positional`'s `new` lookup). Each site already bailed on a
+    non-class MRO entry before this change (`registry.classes.get(cls)` returning `None`), so
+    the swap is behavior-preserving by construction — no separate shadow-check instrumentation
+    was needed on top of that existing bail. `metamodel.rs`'s `declare_drive_how_protocol`
+    (~line 406-428, full-method-name enumeration for a class) is deliberately left on
+    `class_def.methods`: it needs every method name a class owns, which the `(owner,
+    name)`-keyed table has no index for yet — the same gap F4c's own text already calls out.
+    `ctor_phase_plan.rs:133` (`get_method_overloads` inside `try_pin_phase_candidate`) already
+    reads the canonical table and needs no change; its only caller passes `mro_class` after the
+    loop's own role-skip (`roles.contains_key && !classes.contains_key` -> `continue`), so it is
+    structurally never called with a role receiver today. Verified with the full local `t/`
+    suite (3173 files) and a 64-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (class
+    declarations, multi, typed arrays, introspection, roles), all green.
   - [ ] **F4c — Invert the write direction and remove the field.** Make `MethodEntry`/the
     canonical table the write-side source (`sync_user_method_entries`'s write sites in
     `registration.rs`, `registration_class_body_attr.rs`, `registration_class_body_method.rs`,

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -35,10 +35,7 @@ impl Interpreter {
     ) -> bool {
         let mro = self.class_mro(class_name);
         for cn in mro.iter() {
-            let methods = match self.registry().classes.get(cn.as_str()) {
-                Some(cd) => cd.methods.get("new").cloned(),
-                None => None,
-            };
+            let methods = self.registry().user_method_overloads(cn.as_str(), "new");
             if let Some(overloads) = methods {
                 for method in &overloads {
                     // Look for a positional (non-named, non-invocant) param

--- a/src/runtime/ctor_phase_plan.rs
+++ b/src/runtime/ctor_phase_plan.rs
@@ -62,11 +62,8 @@ impl Interpreter {
             // Does the class itself declare the submethod (not role-composed)?
             let class_has_own = self
                 .registry()
-                .classes
-                .get(mro_class)
-                .and_then(|def| def.methods.get(method_name))
-                .map(|overloads| overloads.iter().any(|md| md.role_origin.is_none()))
-                .unwrap_or(false);
+                .user_method_overloads(mro_class, method_name)
+                .is_some_and(|overloads| overloads.iter().any(|md| md.role_origin.is_none()));
             // Role-composed submethods, with the same 6.c/6.e rules as the
             // former per-construction loops:
             // - Always call role submethods (both 6.c and 6.e classes)
@@ -98,15 +95,12 @@ impl Interpreter {
             // the receiver, exactly as before.
             let has_non_submethod = self
                 .registry()
-                .classes
-                .get(mro_class)
-                .and_then(|def| def.methods.get(method_name))
-                .map(|overloads| {
+                .user_method_overloads(mro_class, method_name)
+                .is_some_and(|overloads| {
                     overloads
                         .iter()
                         .any(|md| md.role_origin.is_none() || !md.is_my)
-                })
-                .unwrap_or(false);
+                });
             if has_non_submethod {
                 let pinned = self.try_pin_phase_candidate(mro_class, method_name);
                 steps.push(ConstructionPhaseStep::Class {

--- a/src/runtime/metamodel.rs
+++ b/src/runtime/metamodel.rs
@@ -298,9 +298,8 @@ impl Interpreter {
         // itself is lazily filled and still empty right after a module load.
         let has_user_find_method = self.class_mro(&how_class).iter().any(|c| {
             self.registry()
-                .classes
-                .get(c.as_str())
-                .is_some_and(|cd| cd.methods.contains_key("find_method"))
+                .user_method_overloads(c.as_str(), "find_method")
+                .is_some()
         });
         let mut reg = self.registry_mut();
         reg.class_how_values
@@ -337,9 +336,8 @@ impl Interpreter {
         // itself is lazily filled and still empty right after a module load.
         let has_user_compose = self.class_mro(&how_class).iter().any(|c| {
             self.registry()
-                .classes
-                .get(c.as_str())
-                .is_some_and(|cd| cd.methods.contains_key("compose"))
+                .user_method_overloads(c.as_str(), "compose")
+                .is_some()
         });
         let instance = self.call_method_with_values(how_type, "new", Vec::new())?;
         self.registry_mut()
@@ -360,9 +358,8 @@ impl Interpreter {
         };
         self.class_mro(&how_class.resolve()).iter().any(|c| {
             self.registry()
-                .classes
-                .get(c.as_str())
-                .is_some_and(|cd| cd.methods.contains_key(method_name))
+                .user_method_overloads(c.as_str(), method_name)
+                .is_some()
         })
     }
 

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -249,9 +249,9 @@ impl Interpreter {
     /// dispatch to set `method_dispatch_pure` correctly.
     pub(crate) fn mro_has_build_or_tweak(&self, cn: &str) -> bool {
         self.mro_readonly(cn).iter().any(|cls| {
-            self.registry().classes.get(cls).is_some_and(|cd| {
-                cd.methods.contains_key("BUILD") || cd.methods.contains_key("TWEAK")
-            })
+            let registry = self.registry();
+            registry.user_method_overloads(cls, "BUILD").is_some()
+                || registry.user_method_overloads(cls, "TWEAK").is_some()
         })
     }
 
@@ -300,18 +300,12 @@ impl Interpreter {
                 std::sync::Arc::new(self.collect_attribute_type_constraints(cn_resolved));
             let mro = self.mro_readonly(cn_resolved);
             let registry = self.registry();
-            let mut has_build = mro.iter().any(|cls| {
-                registry
-                    .classes
-                    .get(cls)
-                    .is_some_and(|cd| cd.methods.contains_key("BUILD"))
-            });
-            let mut has_tweak = mro.iter().any(|cls| {
-                registry
-                    .classes
-                    .get(cls)
-                    .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
-            });
+            let mut has_build = mro
+                .iter()
+                .any(|cls| registry.user_method_overloads(cls, "BUILD").is_some());
+            let mut has_tweak = mro
+                .iter()
+                .any(|cls| registry.user_method_overloads(cls, "TWEAK").is_some());
             let has_smiley = mro.iter().any(|cls| {
                 registry
                     .classes
@@ -478,9 +472,8 @@ impl Interpreter {
             }
             let has_own_build = self
                 .registry()
-                .classes
-                .get(cls)
-                .is_some_and(|cd| cd.methods.contains_key("BUILD"))
+                .user_method_overloads(cls, "BUILD")
+                .is_some()
                 || !self
                     .ordered_role_submethods_for_class(cls, "BUILD")
                     .is_empty();


### PR DESCRIPTION
## Summary
- ADR-0019 Phase F box F4b: cut over the "class-level-only" read clusters (never touch a role — each site already bails on a non-class MRO entry) from raw `ClassDef::methods.contains_key`/`.get` reads to the canonical E1/E2 `MethodEntry` table via `Registry::user_method_overloads`.
- Sites migrated: `methods_object.rs`'s `mro_has_build_or_tweak`/`native_ctor_plan` BUILD-TWEAK probes/`build_owning_attr_names`; `ctor_phase_plan.rs:67,103`; `metamodel.rs`'s three custom-HOW existence checks; `class_introspection.rs:39`.
- Left untouched (documented why in the ADR): `metamodel.rs`'s full-method-name enumeration (`declare_drive_how_protocol`, needs an index the table doesn't have yet — F4c's job) and `ctor_phase_plan.rs:133` (already reads the canonical table and is structurally unreachable with a role receiver today).
- Updates the ADR-0019 F4b progress note with the rationale and verification.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
- [x] Targeted `t/` files (BUILD/TWEAK/native-ctor/MOP-HOW/classhow, 40 files, 617 assertions) green
- [x] Full local `make test` (3173 files) green
- [x] Release-build roast subset: S04-declarations, S06-multi, S09-typed-arrays, S12-introspection, S14-roles (64 files) green (`S14-roles/versioning.t` flaked once under `-j4` load, passes cleanly alone and via `prove -e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)