### PR TITLE
fix(adr0019): F4a private-method resolution consults the un-punned-role fallback

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1039,6 +1039,40 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     per sub-PR, each raku-verified — the same discipline E1a/E4a/E7 already used successfully.
     Winner selection (`resolve_method_with_owner_impl`, `resolve_methods_per_mro_level`) must NOT
     call this helper.
+
+    **Progress (private-method family, #TBD):** added `Registry::role_method_overloads(owner,
+    name)` (reads `Registry::roles` directly, filtered non-empty like `user_method_overloads`)
+    and `Registry::get_method_overloads_with_role_fallback` (`get_method_overloads(...).or_else(||
+    role_method_overloads(...))`). Before wiring either into production, gathered corpus evidence
+    with a `MUTSU_VM_STATS`-gated pure probe at the three named `resolution_private_method.rs`
+    sites (`resolve_private_method_with_owner`, `resolve_private_method_any_owner`,
+    `private_method_candidates_by_name`): each site's own MRO walk already probed
+    `role_method_overloads` whenever its plain `get_method_overloads` call came back empty, purely
+    to count how often the fallback would have found something extra — never consulted for a real
+    answer. A full local `t/` sweep (3173 files) plus a full `roast-whitelist.txt` sweep (1436
+    files), one process per file, `MUTSU_VM_STATS=1`, recorded a combined 41 opportunities (the
+    plain lookup came back empty at some `cn` reached in an MRO walk) and **zero** hits — the role
+    fallback never once found anything beyond what `get_method_overloads` alone already returned.
+    This matches the theory: private methods are private specifically to their declaring
+    package, so a role's own private method is only reachable either (a) already flattened onto
+    the composing class (the common `does` case, where the class-level entry wins before the walk
+    ever reaches the role's own MRO position) or (b) through an owner-qualified `self!R::m()` call,
+    which requires an explicit `trusts` declaration Raku itself gates at compile time before
+    dispatch is ever attempted — so the un-punned-role gap this box's ticket describes structurally
+    cannot surface through these three sites' own call shape. With that evidence, cut the three
+    sites over from `get_method_overloads` to `get_method_overloads_with_role_fallback` for real
+    (removing the now-served-its-purpose probe): a documented no-op over the entire corpus, and a
+    correctness fix for any case the corpus doesn't exercise. Verified with the full local `t/`
+    suite (3173 files) and a 64-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset, both green
+    (`S14-roles/versioning.t` flaked once under `-j4` parallel load, passes individually and via
+    `prove -e`, the same known shape other boxes' progress notes have already hit). Remaining sites
+    from the ticket's confirmed list: `ctor_phase_plan.rs:133` needs no change — traced separately
+    (see F4b's own progress note) to be structurally unreachable with a role receiver, since its
+    only caller already filters to a real class first; `vm_call_method_compiled_cache.rs:97` is
+    still open, a separate consumer family for its own sub-PR. The informally-flagged sites
+    (`methods_qualified.rs`, `methods_classhow_lookup.rs`, `methods_classhow_dispatch.rs`,
+    `accessors_state.rs`, `methods_walk.rs`, `class_introspection.rs:262`) remain unconfirmed and
+    out of scope, per the box's own rule above.
   - [ ] **F4b — Cutover the class-level-only read clusters.** The read sites that never touch a
     role at all (`methods_object.rs`'s six BUILD/TWEAK existence checks, `metamodel.rs`,
     `class_introspection.rs:39`, `ctor_phase_plan.rs:67,103`) move from `class_def.methods` to

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -983,6 +983,45 @@ impl Registry {
         self.user_method_overloads(class_name, method_name)
     }
 
+    /// Fallback source for a role's own methods when `owner` is a role that was
+    /// never `.new`-punned (ADR-0019 F4a): `Registry::method_entries` (and thus
+    /// `get_method_overloads`/`user_method_overloads`) has no row at all for such
+    /// a role — see `todo/deep/method-entries-never-covers-unpunned-roles.md`.
+    /// Reads `Registry::roles` directly, the raw composition-input storage that
+    /// is always populated regardless of punning. Role method definitions are
+    /// composition inputs, not dispatch entries: the dispatchable form is always
+    /// the flattened copy on the composing class, so this must only be consulted
+    /// as an explicit fallback by confirmed-safe non-winner-selection call sites,
+    /// never by `resolve_method_with_owner_impl`/`resolve_methods_per_mro_level`.
+    pub(crate) fn role_method_overloads(
+        &self,
+        role_name: &str,
+        method_name: &str,
+    ) -> Option<Vec<MethodDef>> {
+        self.roles
+            .get(role_name)
+            .and_then(|role_def| role_def.methods.get(method_name))
+            .filter(|overloads| !overloads.is_empty())
+            .cloned()
+    }
+
+    /// [`Self::get_method_overloads`] widened with the [`Self::role_method_overloads`]
+    /// fallback (ADR-0019 F4a). For the confirmed-safe, non-winner-selection call
+    /// sites this box names: a `MUTSU_VM_STATS=1` corpus probe (the full local `t/`
+    /// suite plus the entire roast whitelist) found the fallback would add
+    /// candidates at these sites in exactly zero of the cases where the plain
+    /// lookup came back empty, so the fallback is a documented no-op over that
+    /// corpus and a real gap-closer beyond it (e.g. a role whose only reachable
+    /// MRO entry is itself, un-punned).
+    pub(crate) fn get_method_overloads_with_role_fallback(
+        &self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<Vec<MethodDef>> {
+        self.get_method_overloads(class_name, method_name)
+            .or_else(|| self.role_method_overloads(class_name, method_name))
+    }
+
     /// Bound role type parameters for `class_name` (e.g. the `::T` -> value map
     /// of a `class C does R[Int]`). Owned clone.
     pub(crate) fn get_role_param_bindings(

--- a/src/runtime/resolution_private_method.rs
+++ b/src/runtime/resolution_private_method.rs
@@ -28,7 +28,9 @@ impl Interpreter {
                 continue;
             }
             // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
-            let overloads = self.registry().get_method_overloads(cn, method_name);
+            let overloads = self
+                .registry()
+                .get_method_overloads_with_role_fallback(cn, method_name);
             if let Some(overloads) = overloads {
                 for def in overloads {
                     if !def.is_private {
@@ -132,7 +134,9 @@ impl Interpreter {
         }
         for cn in mro.iter().map(|s| s.as_str()) {
             // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
-            let overloads = self.registry().get_method_overloads(cn, method_name);
+            let overloads = self
+                .registry()
+                .get_method_overloads_with_role_fallback(cn, method_name);
             if let Some(overloads) = overloads {
                 for def in &overloads {
                     if !def.is_private {
@@ -200,7 +204,9 @@ impl Interpreter {
             {
                 continue;
             }
-            let overloads = self.registry().get_method_overloads(cn, method_name);
+            let overloads = self
+                .registry()
+                .get_method_overloads_with_role_fallback(cn, method_name);
             if let Some(overloads) = overloads {
                 for def in overloads {
                     if def.is_private && !Self::is_stub_method_body(&def.body) {


### PR DESCRIPTION
## Summary
- ADR-0019 Phase F box F4a: `Registry::method_entries` has no row at all for a role that is never `.new`-punned, so `get_method_overloads` silently misses such a role's own methods (`todo/deep/method-entries-never-covers-unpunned-roles.md`).
- Adds `Registry::role_method_overloads` (reads `Registry::roles` directly) and `get_method_overloads_with_role_fallback`, and wires the fallback into the three call sites the gap ticket names in `resolution_private_method.rs`.
- Winner selection (`resolve_method_with_owner_impl`/`resolve_methods_per_mro_level`) is untouched, per the box's explicit prohibition — a naive fix there previously regressed multi-method dispatch (PR #6478).
- Before cutover, gathered corpus evidence with a `MUTSU_VM_STATS`-gated pure probe (never consulted for a real answer): a full local `t/` sweep (3173 files) + the entire roast whitelist (1436 files) recorded 41 opportunities and **zero** hits, confirming the gap cannot surface through these three sites' own call shape. Full rationale in the ADR's updated F4a progress note.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
- [x] Targeted `t/` private-method/role files (20 files) green
- [x] Full local `make test` (3173 files) green
- [x] Release-build roast subset: S04-declarations, S06-multi, S09-typed-arrays, S12-introspection, S14-roles (64 files) green (`S14-roles/versioning.t` flaked once under `-j4` load, passes cleanly alone and via `prove -e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)