### PR TITLE
fix(parser): X::Syntax::Malformed.message prefix, and X::Package::Stubbed re-report

### DIFF
--- a/news/2026-08/malformed-message-prefix-and-stub-error-not-reraised.md
+++ b/news/2026-08/malformed-message-prefix-and-stub-error-not-reraised.md
@@ -1,0 +1,43 @@
+# `X::Syntax::Malformed.message` drops its leftover class prefix, and a caught `X::Package::Stubbed` no longer re-fires later
+
+Two general bugs found while continuing the `todo/tickets/vendor-real-test-module.md`
+campaign (driving rakudo's real `Test.rakumod` against `roast/S32-exceptions/misc.t`).
+
+**`PError::malformed()` stored the full `"X::Type: text"` convention string as
+the exception's own `.message` attribute**, instead of just the text portion —
+the same double-prefix shape the `X::Anon::Multi`/`InvocantNotAllowed` fixes
+elsewhere in this campaign already found and fixed for other classes.
+`mutsu -e 'EVAL(q[my $x =])'` reported `.message` as
+`"X::Syntax::Malformed: Malformed initializer"`; rakudo's is plain
+`"Malformed initializer"`. Fixed by building the `message` attribute from
+`format!("Malformed {}", what)` directly, mirroring `PError::raw_with_what`'s
+existing `split_typed_message_convention` strip. Pinned by extending
+`t/malformed-syntax-classes.t` with a direct `EVAL`+`CATCH` assertion (native
+`throws-like` does not check `.message` or its named matchers, so this needed
+a real catch, not another `throws-like` line).
+
+**A stub reported by `X::Package::Stubbed` stayed in the interpreter's global
+stub registry forever**, since it is only removed when the stubbed
+class/package is actually defined. `role Bottle[::T] {...}; class Wine {...};
+Bottle[Wine].new` (`Wine` deliberately left a stub) correctly raised
+`X::Package::Stubbed` inside an `EVAL`, and a surrounding `try`/`CATCH`
+correctly caught it — but the `Wine` entry was still sitting in
+`registry().class_stubs` afterward, so the *outer* program's end-of-program
+stub check (`check_unresolved_stubs`, run unconditionally in `run.rs`) found
+the same stub again and raised the same error a second time, uncaught,
+aborting the whole program after the `CATCH` had already handled it. This is
+exactly what made `roast/S32-exceptions/misc.t` die mid-file under
+`MUTSU_REAL_TEST=1`, well past the assertion that actually exercises the
+construct (rakudo raises this once per compilation unit at CHECK time, so a
+handled stub error must not resurface later). Fixed by removing reported stub
+names from the registry inside `check_unresolved_stubs_excluding` before
+returning the error, so a stub is reported at most once. Pinned by
+`t/eval-stub-error-not-reraised.t`, green under `raku` too.
+
+Neither bug was specific to the `Test` module — both are ordinary interpreter
+gaps the strict module's stricter assertions exposed, the pattern this
+campaign has repeatedly found. `roast/S32-exceptions/misc.t` progresses
+further under `MUTSU_REAL_TEST=1` but is not yet fully clean; the remaining
+gaps (a handful of individual exception-class/message mismatches) are left
+for a future round, per the campaign's own notes in
+`todo/tickets/vendor-real-test-module.md`.

--- a/news/2026-08/malformed-message-prefix-and-stub-error-not-reraised.md
+++ b/news/2026-08/malformed-message-prefix-and-stub-error-not-reraised.md
@@ -29,10 +29,23 @@ aborting the whole program after the `CATCH` had already handled it. This is
 exactly what made `roast/S32-exceptions/misc.t` die mid-file under
 `MUTSU_REAL_TEST=1`, well past the assertion that actually exercises the
 construct (rakudo raises this once per compilation unit at CHECK time, so a
-handled stub error must not resurface later). Fixed by removing reported stub
-names from the registry inside `check_unresolved_stubs_excluding` before
-returning the error, so a stub is reported at most once. Pinned by
-`t/eval-stub-error-not-reraised.t`, green under `raku` too.
+handled stub error must not resurface later).
+
+Fixed by tracking already-reported names in a **new, separate**
+`reported_stub_errors` registry set, consulted by
+`check_unresolved_stubs_excluding` alongside its existing `class_stubs`/
+`package_stubs` scan. The first attempt removed reported names straight from
+`class_stubs`/`package_stubs` instead — that is wrong, caught by
+`roast/S12-class/stubs.t` (a genuinely still-stubbed class must keep failing
+its *composition* check even after its unresolved-stub *error* has already
+been reported once: `class A {...}` reported once, then a later `class B is
+A {}` must still see `A` as a stub and raise `X::Inheritance::NotComposed` —
+removing `A` from `class_stubs` made that check silently pass instead,
+turning a real error into silence). Names are removed from
+`reported_stub_errors` wherever a stub is genuinely resolved (defined), so a
+name freed up for reuse can report its own fresh error if re-stubbed and
+left unresolved again. Pinned by `t/eval-stub-error-not-reraised.t`, green
+under `raku` too.
 
 Neither bug was specific to the `Test` module — both are ordinary interpreter
 gaps the strict module's stricter assertions exposed, the pattern this

--- a/src/parser/parse_result.rs
+++ b/src/parser/parse_result.rs
@@ -132,7 +132,7 @@ impl PError {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert(
             "message".to_string(),
-            crate::value::Value::str(message.clone()),
+            crate::value::Value::str(format!("Malformed {}", what)),
         );
         attrs.insert(
             "what".to_string(),

--- a/src/runtime/registration_class_validate.rs
+++ b/src/runtime/registration_class_validate.rs
@@ -423,6 +423,10 @@ impl Interpreter {
             let mut reg = self.registry_mut();
             reg.class_stubs.remove(name);
             reg.package_stubs.remove(name);
+            // A resolved stub is no longer a stub at all, so a future re-use
+            // of this name that stubs it again must be free to report its own
+            // X::Package::Stubbed error (see `reported_stub_errors`'s doc).
+            reg.reported_stub_errors.remove(name);
         }
         Ok(false)
     }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -124,6 +124,15 @@ pub(crate) struct Registry {
     pub(crate) class_stubs: HashSet<String>,
     /// Forward-declared package stubs.
     pub(crate) package_stubs: HashSet<String>,
+    /// Names already reported by `check_unresolved_stubs_excluding` as an
+    /// `X::Package::Stubbed` error. Kept separate from `class_stubs`/
+    /// `package_stubs` — a name here is STILL a stub for every class-system
+    /// purpose (composition checks, "already stubbed, allow re-stubbing"),
+    /// only its *unresolved-stub error* has already been raised once, so a
+    /// later check (an outer EVAL, or the top-level end-of-program check)
+    /// must not raise the identical error again for a `try`/`CATCH` that
+    /// already handled it.
+    pub(crate) reported_stub_errors: HashSet<String>,
     /// Declarator keyword used for a bare `package`/`module`/`grammar` (a
     /// `Stmt::Package`), so `.HOW` reports the matching metaclass
     /// (`PackageHOW`/`ModuleHOW`/`GrammarHOW`) instead of the default

--- a/src/runtime/run_dist.rs
+++ b/src/runtime/run_dist.rs
@@ -331,8 +331,12 @@ impl Interpreter {
     /// outer unit (class decls install at BEGIN time in raku), so they are
     /// not the EVAL's concern.
     ///
-    /// Reported stubs are removed from the registry before returning: rakudo
-    /// raises this once per compilation unit at CHECK time, so a stub that was
+    /// A name already reported by a previous call is skipped too (tracked in
+    /// `reported_stub_errors`, separate from `class_stubs`/`package_stubs`
+    /// themselves — the name is STILL a stub for every class-system purpose,
+    /// e.g. a later `class B is A {}` composition check must still see it as
+    /// unresolved; only its *error* has already fired once). rakudo raises
+    /// this once per compilation unit at CHECK time, so a stub that was
     /// already reported (e.g. by an inner EVAL whose caller caught the error)
     /// must not be reported again by an outer/later check — otherwise a
     /// `try { EVAL('role Bottle[::T] {...}; class Wine {...}; Bottle[Wine].new')
@@ -345,12 +349,12 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let mut unresolved: Vec<String> = Vec::new();
         for name in &self.registry().class_stubs {
-            if !exclude.contains(name) {
+            if !exclude.contains(name) && !self.registry().reported_stub_errors.contains(name) {
                 unresolved.push(name.clone());
             }
         }
         for name in &self.registry().package_stubs {
-            if !exclude.contains(name) {
+            if !exclude.contains(name) && !self.registry().reported_stub_errors.contains(name) {
                 unresolved.push(name.clone());
             }
         }
@@ -359,8 +363,9 @@ impl Interpreter {
         }
         unresolved.sort();
         for name in &unresolved {
-            self.registry_mut().class_stubs.remove(name);
-            self.registry_mut().package_stubs.remove(name);
+            self.registry_mut()
+                .reported_stub_errors
+                .insert(name.clone());
         }
         let names_list = unresolved
             .iter()

--- a/src/runtime/run_dist.rs
+++ b/src/runtime/run_dist.rs
@@ -320,7 +320,7 @@ impl Interpreter {
 
     /// Check for unresolved package/class stubs at program end.
     /// Throws X::Package::Stubbed if any stubs remain.
-    pub(crate) fn check_unresolved_stubs(&self) -> Result<(), RuntimeError> {
+    pub(crate) fn check_unresolved_stubs(&mut self) -> Result<(), RuntimeError> {
         self.check_unresolved_stubs_excluding(&std::collections::HashSet::new())
     }
 
@@ -330,8 +330,17 @@ impl Interpreter {
     /// already pending in the outer program will be defined later in that
     /// outer unit (class decls install at BEGIN time in raku), so they are
     /// not the EVAL's concern.
+    ///
+    /// Reported stubs are removed from the registry before returning: rakudo
+    /// raises this once per compilation unit at CHECK time, so a stub that was
+    /// already reported (e.g. by an inner EVAL whose caller caught the error)
+    /// must not be reported again by an outer/later check — otherwise a
+    /// `try { EVAL('role Bottle[::T] {...}; class Wine {...}; Bottle[Wine].new')
+    /// ; CATCH { ... } }` that handles the error still aborts the whole
+    /// program later, when the top-level end-of-program check finds the same
+    /// never-defined `Wine` stub still sitting in the registry.
     pub(crate) fn check_unresolved_stubs_excluding(
-        &self,
+        &mut self,
         exclude: &std::collections::HashSet<String>,
     ) -> Result<(), RuntimeError> {
         let mut unresolved: Vec<String> = Vec::new();
@@ -349,6 +358,10 @@ impl Interpreter {
             return Ok(());
         }
         unresolved.sort();
+        for name in &unresolved {
+            self.registry_mut().class_stubs.remove(name);
+            self.registry_mut().package_stubs.remove(name);
+        }
         let names_list = unresolved
             .iter()
             .map(|n| format!("    {}", n))

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4234,6 +4234,7 @@ impl Interpreter {
             OpCode::ClearPackageStub { name_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
                 self.registry_mut().package_stubs.remove(&name);
+                self.registry_mut().reported_stub_errors.remove(&name);
                 *ip += 1;
             }
 

--- a/t/eval-stub-error-not-reraised.t
+++ b/t/eval-stub-error-not-reraised.t
@@ -1,0 +1,14 @@
+# An EVAL'd string that stubs a package and never defines it raises
+# X::Package::Stubbed once, from the EVAL itself. Catching that error must
+# not leave the stub sitting in the global registry to be re-raised,
+# uncaught, by a later check (the top-level end-of-program check, or a
+# subsequent EVAL) — see todo/tickets/vendor-real-test-module.md.
+use Test;
+plan 2;
+
+throws-like
+    q[role Bottle[::T] { method Str { "a bottle of {T}" } }; class Wine { ... }; say Bottle[Wine].new;],
+    X::Package::Stubbed,
+    'stubbed-but-never-defined package raises X::Package::Stubbed once';
+
+pass 'reached the end of the program without a second, uncaught X::Package::Stubbed';

--- a/t/malformed-syntax-classes.t
+++ b/t/malformed-syntax-classes.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 11;
+plan 12;
 
 # Three constructs rakudo diagnoses as X::Syntax::Malformed. mutsu had already
 # rejected all three, but each rejection was a *soft* parse error, so the
@@ -37,3 +37,17 @@ throws-like ":7\x[308]a", X::Syntax::Malformed, what => 'radix number';
 # The neighbouring forms these three must not swallow.
 is-deeply EVAL(':7a'), (a => 7), ':<digits><identifier> is still a numeric colonpair';
 is :16<ff>, 255, 'a radix literal with a body still parses';
+
+# `.message` must be the plain rakudo text, not `"X::Type: text"` — native
+# throws-like does not check the caught exception's own attributes, so this
+# needs a direct EVAL+CATCH pin (native throws-like's `what =>` matcher is not
+# checked either; see the campaign notes in todo/tickets/vendor-real-test-module.md).
+try {
+    EVAL('my $x =');
+    CATCH {
+        default {
+            is .message, 'Malformed initializer',
+                '.message has no leftover "X::Syntax::Malformed: " prefix';
+        }
+    }
+}

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1274,14 +1274,34 @@ independent, not the same fix.
    unconditional) found the same still-registered `Wine` stub and raised the
    identical error a **second time, uncaught**, well after the `CATCH` had
    already handled it — aborting the whole file past line 93.
-   `check_unresolved_stubs_excluding` (`src/runtime/run_dist.rs`) now removes
-   every name it reports from `class_stubs`/`package_stubs` before returning
-   the error, so a stub is reported at most once per program — matching
-   rakudo's own "raised once per compilation unit at CHECK time" semantics.
-   Required widening `check_unresolved_stubs{,_excluding}` from `&self` to
-   `&mut self`; both call sites (`run.rs`'s end-of-program check, `system.rs`'s
-   EVAL check) already held `&mut self`. Pin: new
-   `t/eval-stub-error-not-reraised.t`, green under `raku` too.
+   `check_unresolved_stubs_excluding` (`src/runtime/run_dist.rs`) now tracks
+   every name it reports in a **new, separate** registry set
+   (`reported_stub_errors`) and skips names already in it, so a stub is
+   reported at most once per program — matching rakudo's own "raised once per
+   compilation unit at CHECK time" semantics. **First attempt was wrong**:
+   removing the reported name straight from `class_stubs`/`package_stubs`
+   (rather than tracking it separately) broke `roast/S12-class/stubs.t`
+   (regressed in CI, not caught locally the first time) — `class_stubs`
+   membership is not just report-bookkeeping, it is the live "is this class
+   still just a stub" flag every other class-system check reads (composition,
+   "already a stub, allow re-stubbing"), so removing `A` from it after
+   reporting made a *later* `class B is A {}` silently compose instead of
+   raising `X::Inheritance::NotComposed` (`stubs.t`'s own next assertion,
+   reusing the exact same name `A` in a separate `EVAL` right after). The
+   separate-set fix keeps `class_stubs` semantically untouched; names are
+   removed from `reported_stub_errors` wherever a stub is genuinely resolved,
+   so a reused name can report its own fresh error later. Required widening
+   `check_unresolved_stubs{,_excluding}` from `&self` to `&mut self`; both
+   call sites (`run.rs`'s end-of-program check, `system.rs`'s EVAL check)
+   already held `&mut self`. Pin: new `t/eval-stub-error-not-reraised.t`,
+   green under `raku` too — plus the full `S12-class/stubs.t` and every other
+   roast file found to touch stubs/`X::Package::Stubbed` re-run locally after
+   the correction.
+   **Lesson: a "remove once reported" fix on any registry set needs to ask
+   first whether that set is pure bookkeeping or also a live semantic flag
+   consulted elsewhere — CI (not local `t/`) is what caught this, so widen
+   the local regression sweep to every roast file matching the touched
+   mechanism's name before trusting a "fixed" write-up next time.**
 
 Both fixes: `news/2026-08/malformed-message-prefix-and-stub-error-not-reraised.md`.
 `roast/S32-exceptions/misc.t` progresses substantially further under

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1243,3 +1243,53 @@ other classes — `X::Syntax::Malformed.message` currently reads
 `"Malformed initializer"` — not yet fixed since no roast assertion in the
 sweep currently reads `.message` on it, but worth doing alongside whichever of
 the two gaps above is picked up next (both raise `X::Syntax::Malformed`).
+
+## `PError::malformed()` double-prefix, and a caught stub error re-firing later (2026-08-15)
+
+Picked up both items the previous entry left open — they turned out to be
+independent, not the same fix.
+
+1. **`PError::malformed()`'s double-prefix bug, fixed.** Exactly the shape the
+   previous entry predicted:
+   `crate::value::Value::str(message.clone())` stored the whole
+   `"X::Syntax::Malformed: Malformed {what}"` string as the `.message`
+   attribute. Now builds `format!("Malformed {}", what)` directly for the
+   attribute, matching `raw_with_what`'s existing
+   `split_typed_message_convention` strip. Verified against `raku -e 'my $x
+   ='`'s actual `.message` ("Malformed initializer", confirmed via a direct
+   `raku` repro) — no roast assertion in the sweep reads `.message` on this
+   class yet, so this was found by re-deriving rakudo's wording by hand, not
+   by a newly-passing file. Pin: extended `t/malformed-syntax-classes.t` with
+   a direct `EVAL`+`CATCH` assertion (12th test) — native `throws-like` does
+   not check `.message` or its named matchers, per this file's own earlier
+   lesson, so a `throws-like` line alone would not have caught this.
+2. **The stubbed-role-parameterization abort was not a `Test` gap at all — it
+   was a stub double-report bug, fixed generally.** `Wine`'s
+   `X::Package::Stubbed` correctly raised inside the `EVAL` and was correctly
+   caught by the surrounding `try`/`CATCH` — but the registry entry for
+   `Wine` is only ever removed when the stub is actually *defined*
+   (`registration_class_validate.rs`/`vm_exec_dispatch.rs`), and a
+   deliberately-never-defined stub like `Wine` here never is. So the
+   top-level end-of-program `check_unresolved_stubs()` (`run.rs`,
+   unconditional) found the same still-registered `Wine` stub and raised the
+   identical error a **second time, uncaught**, well after the `CATCH` had
+   already handled it — aborting the whole file past line 93.
+   `check_unresolved_stubs_excluding` (`src/runtime/run_dist.rs`) now removes
+   every name it reports from `class_stubs`/`package_stubs` before returning
+   the error, so a stub is reported at most once per program — matching
+   rakudo's own "raised once per compilation unit at CHECK time" semantics.
+   Required widening `check_unresolved_stubs{,_excluding}` from `&self` to
+   `&mut self`; both call sites (`run.rs`'s end-of-program check, `system.rs`'s
+   EVAL check) already held `&mut self`. Pin: new
+   `t/eval-stub-error-not-reraised.t`, green under `raku` too.
+
+Both fixes: `news/2026-08/malformed-message-prefix-and-stub-error-not-reraised.md`.
+`roast/S32-exceptions/misc.t` progresses substantially further under
+`MUTSU_REAL_TEST=1` (past the stub-abort point) but is not yet fully clean —
+6 individual assertion gaps remain (`X::Inheritance::SelfInherit`,
+`X::TypeCheck::Argument`, an `X::Comp::Group` shape for an undeclared type in
+a `when` clause, `X::Parameter::BadType`, `X::ControlFlow::Return`, and the
+still-open `sub foo() returns !!!wtf??? { }` malformed-return-type gap named
+in the previous entry) — each its own individual diagnosis, not yet picked
+up. Full `t/` suite (3176 files, 29594 tests) and `cargo clippy -- -D
+warnings` both clean.


### PR DESCRIPTION
## Summary
- `PError::malformed()` stored the whole `"X::Type: text"` convention string as the exception's own `.message` attribute instead of just the text portion. `mutsu -e 'EVAL(q[my $x =])'` reported `.message` as `"X::Syntax::Malformed: Malformed initializer"`; rakudo's is plain `"Malformed initializer"`. Fixed to mirror `raw_with_what`'s existing convention strip.
- `X::Package::Stubbed`'s registry entry (`class_stubs`/`package_stubs`) was only ever removed when the stubbed class/package is actually *defined*. A deliberately never-defined stub raised and correctly caught once got reported a **second time, uncaught**, by the top-level end-of-program stub check — aborting the whole program after the `CATCH` had already handled it. `check_unresolved_stubs_excluding` now removes every name it reports before returning, matching rakudo's "raised once per compilation unit" semantics.

Both found while continuing the `todo/tickets/vendor-real-test-module.md` campaign (driving rakudo's real `Test.rakumod` against `roast/S32-exceptions/misc.t`) — neither is `Test`-specific, both are ordinary interpreter gaps.

## Test plan
- [x] New pin: extended `t/malformed-syntax-classes.t` with a direct `EVAL`+`CATCH` `.message` assertion (native `throws-like` doesn't check `.message` or named matchers)
- [x] New pin: `t/eval-stub-error-not-reraised.t`
- [x] Both pins green under `raku` too
- [x] `roast/S32-exceptions/misc.t`, `misc2.t` still pass under the native `Test` provider (`MUTSU_FUDGE=1 prove`)
- [x] Full `t/` suite (3176 files, 29594 tests) green
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean