### PR TITLE
fix(adr0019): F4a multi-cacheability gate consults the un-punned-role fallback

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1103,6 +1103,29 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     before this change and out of this box's scope. This closes every site F4a's own gap-ticket
     named; the informally-flagged sites above remain unconfirmed and out of scope per the box's own
     rule.
+
+    **Progress (informally-flagged sites, triaged):** read all six: `methods_qualified.rs`,
+    `methods_classhow_lookup.rs`, `accessors_state.rs`, `methods_walk.rs`, and
+    `class_introspection.rs:262` (`has_user_method_including_role`) each ALREADY implement their own
+    explicit class-then-role fallback (`registry().classes.get(cn)...methods.get(name)` followed by
+    a separate `registry().roles.get(cn)...methods.get(name)` check, the same shape `.^lookup`'s
+    unification already established) — none of them has the F4a gap; their remaining work is purely
+    reading the `class_def.methods`/`role_def.methods` fields directly instead of the canonical
+    table, which is F4c's "invert the write direction" scope, not F4a's. `methods_classhow_dispatch.
+    rs`, the sixth, does NOT have its own role fallback at the one flagged line (750, inside
+    `^add_method`'s "clone the whole multi candidate family when aliasing a `^find_method`/`^lookup`
+    carrier" helper) — and unlike the other five, this is a REAL, raku-confirmed gap, not just an
+    F4c-shaped field read: `role R { multi method m(Int $x){...}; multi method m(Str $x){...} };
+    class C {}; C.^add_method('n', R.^find_method('m'))` (the role never punned, never composed
+    anywhere) loses every multi candidate but the carrier's own on mutsu, while real Rakudo keeps
+    the whole family — confirmed by direct `raku` comparison. Fixed by swapping the site's
+    `classes.get(src_class).and_then(|cd| cd.methods.get(src_method))` to
+    `get_method_overloads_with_role_fallback(src_class, src_method)` (also moves it onto the
+    canonical table as a byproduct, matching the `vm_call_method_compiled_cache.rs` cutover above).
+    Regression-pinned in `t/add-method-alias-unpunned-role-multi.t`. Verified with the full local
+    `t/` suite (3176 files) and the same 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset, both
+    green. This closes F4a's entire informally-flagged list — one confirmed real gap fixed, five
+    confirmed already-safe and reclassified into F4c.
   - [ ] **F4b — Cutover the class-level-only read clusters.** The read sites that never touch a
     role at all (`methods_object.rs`'s six BUILD/TWEAK existence checks, `metamodel.rs`,
     `class_introspection.rs:39`, `ctor_phase_plan.rs:67,103`) move from `class_def.methods` to

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1073,6 +1073,36 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     (`methods_qualified.rs`, `methods_classhow_lookup.rs`, `methods_classhow_dispatch.rs`,
     `accessors_state.rs`, `methods_walk.rs`, `class_introspection.rs:262`) remain unconfirmed and
     out of scope, per the box's own rule above.
+
+    **Progress (`vm_call_method_compiled_cache.rs:97` family, closes F4a's named-site list):**
+    unlike the private-method family, this site's `MUTSU_VM_STATS`-free corpus probe (a temporary
+    `eprintln!` gated on a throwaway env var, not committed) found the fallback is NOT a no-op here:
+    a full local `t/` sweep (3175 files, debug) recorded 162 opportunities where `multi_dispatch_
+    type_cacheable`'s own `class_mro` walk reached a role's own MRO slot with no `method_entries`
+    row (an un-punned role composed via `does`, e.g. diamond compositions in `S14-roles` fixtures),
+    and a `roast-whitelist.txt` sweep (release, 1436 files) recorded 102 more — role names really do
+    appear as their own `class_mro` entries in role-heavy code, unlike the rare private-method call
+    shape. Reasoning for why this is safe to cut over despite the non-zero hit rate: the walk only
+    *accumulates* `any_multi`/`value_dependent` across every MRO level (no early return on first
+    match), so the role fallback can only ever ADD information the plain lookup missed, never
+    remove any the class-level flattened copy already contributed — it can flip `any_multi`/
+    `value_dependent` from false to true, never the reverse. A false-negative `value_dependent`
+    (a `where`/literal/rw/signature-shaped candidate that lives only on the un-punned role, invisible
+    to the old code) is the dangerous direction: it would let the type-keyed `multi_resolve_cache`
+    memoize a resolution that is not actually type-deterministic. This box's own explicit
+    prohibition on winner selection consulting the fallback is respected — `resolve_via_sequence_
+    cache` (the actual resolver both cache paths 3 and 4 call) is untouched, so the resolved value
+    for any given call is unaffected either way; only the caching *gate* changes, and only toward
+    being more conservative about what it treats as type-cacheable. Cut over
+    `get_method_overloads` -> `get_method_overloads_with_role_fallback` at this one site. Verified
+    with the full local `t/` suite (3175 files, all green) and a 312-file `S04`/`S06`/`S09`/`S12`/
+    `S14` roast subset (release, all green) — the multi/role-heaviest synopses, chosen to exercise
+    this exact cacheability gate. `cargo clippy -- -D warnings` (the pre-commit hook's own
+    invocation) is clean; a separate `--all-targets` clippy run surfaces 3 pre-existing lint
+    failures in unrelated files (`match_lazy.rs`, `vm_jit_layout.rs`), confirmed present on `main`
+    before this change and out of this box's scope. This closes every site F4a's own gap-ticket
+    named; the informally-flagged sites above remain unconfirmed and out of scope per the box's own
+    rule.
   - [ ] **F4b — Cutover the class-level-only read clusters.** The read sites that never touch a
     role at all (`methods_object.rs`'s six BUILD/TWEAK existence checks, `metamodel.rs`,
     `class_introspection.rs:39`, `ctor_phase_plan.rs:67,103`) move from `class_def.methods` to

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -744,12 +744,19 @@ impl Interpreter {
                     else {
                         return None;
                     };
+                    // ADR-0019 F4a: `src_class` can name a role directly
+                    // (`R.^find_method('m')` with `R` never `.new`-punned or
+                    // `does`-composed anywhere), which has no row in the
+                    // canonical method table -- the role fallback is required
+                    // here, not optional, confirmed against real Rakudo (a
+                    // role-owned multi aliased this way keeps every
+                    // candidate, not just the carrier's own signature).
                     self.registry()
-                        .classes
-                        .get(src_class.as_ref())
-                        .and_then(|cd| cd.methods.get(src_method.as_ref()))
+                        .get_method_overloads_with_role_fallback(
+                            src_class.as_ref(),
+                            src_method.as_ref(),
+                        )
                         .filter(|defs| defs.iter().any(|d| d.is_multi))
-                        .cloned()
                 })();
                 // Filter out invocant params from param_defs since MethodDef
                 // stores only the user-visible parameters (the invocant is

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -93,9 +93,24 @@ impl Interpreter {
         let mut any_multi = false;
         let mut value_dependent = false;
         'outer: for cn in mro.iter() {
+            // ADR-0019 F4a: `Registry::method_entries` (and thus the plain
+            // `get_method_overloads`) has no row at all for a role that is
+            // never `.new`-punned, so an un-punned role's own MRO slot always
+            // came back empty here even though `class_mro` can list the role
+            // by name directly (common in role-heavy diamond compositions).
+            // Missing a role-only candidate can only make this cacheability
+            // gate UNDER-report: a `where`/literal/rw/signature-shaped
+            // candidate that lives only on the role would be invisible, so
+            // `value_dependent` could wrongly stay `false` and the type-keyed
+            // multi cache would then memoize a resolution that is not
+            // actually type-deterministic. The role fallback closes that gap;
+            // it cannot remove information the plain lookup already found, so
+            // it can only push `any_multi`/`value_dependent` from false to
+            // true, never the reverse. Winner selection itself
+            // (`resolve_via_sequence_cache`) is untouched by this box's rule.
             let Some(overloads) = self
                 .registry()
-                .get_method_overloads(cn.as_str(), method_name)
+                .get_method_overloads_with_role_fallback(cn.as_str(), method_name)
             else {
                 continue;
             };

--- a/t/add-method-alias-unpunned-role-multi.t
+++ b/t/add-method-alias-unpunned-role-multi.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# ADR-0019 F4a: `^add_method` aliasing a `^find_method` carrier clones the
+# whole multi candidate family (t/can-multi-dispatcher.t already covers the
+# class-owned case). When the carrier comes from a role that is never
+# `.new`-punned and never `does`-composed anywhere -- `R.^find_method('m')`
+# with `R` a bare role type object -- the source class name tagged on the
+# carrier names the role itself, which has no row in the canonical method
+# table. Without the un-punned-role fallback, only the carrier's own single
+# candidate survived the clone, silently dropping every other multi
+# candidate.
+
+plan 2;
+
+role R {
+    multi method m (Int $x) { "int $x" }
+    multi method m (Str $x) { "str $x" }
+}
+class C { }
+BEGIN {
+    C.^add_method('n', R.^find_method('m'));
+}
+
+is C.new.n(5), 'int 5', 'aliasing an unpunned role multi keeps the Int candidate';
+is C.new.n("a"), 'str a', 'aliasing an unpunned role multi keeps the Str candidate too';


### PR DESCRIPTION
## Summary
- ADR-0019 F4a: `multi_dispatch_type_cacheable`'s `class_mro` walk (`vm_call_method_compiled_cache.rs:97`) used plain `get_method_overloads`, which has no row for a role that is never `.new`-punned.
- Unlike the private-method family (already merged as a documented no-op), a corpus probe found this site is a real gap: 162 opportunities across the full local `t/` suite and 102 more across the roast whitelist.
- The walk only accumulates `any_multi`/`value_dependent` across MRO levels, so the fallback can only push those flags false->true, never the reverse. The dangerous direction is a false-negative `value_dependent` (a `where`/literal/rw-shaped candidate visible only on the un-punned role), which could let the type-keyed `multi_resolve_cache` memoize a resolution that isn't actually type-deterministic. `resolve_via_sequence_cache` (the actual resolver) is untouched, so this only tightens the caching gate — winner selection still never consults the role fallback, per the box's own prohibition.
- Cuts over `get_method_overloads` -> `get_method_overloads_with_role_fallback` at this one site. Closes every site F4a's gap ticket named.

## Test plan
- [x] `cargo build` + full local `t/` suite (3175 files, debug) — all green
- [x] `roast-whitelist.txt` S04/S06/S09/S12/S14 subset (312 files, release) — all green
- [x] `cargo clippy -- -D warnings` (pre-commit hook invocation) clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)