### PR TITLE
feat(adr0019): F4c-1 -- reverse index + seven-of-eight enumeration cutovers

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1489,6 +1489,50 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     most of the extras are role-only reads, which (1) puts out of F4c entirely. "Augment
     rollback" as a distinct named mechanism does not exist — `registration_class_augment.rs` has
     no snapshot/restore path; there are five mechanisms and they are the ones enumerated in (4).
+
+    **Progress (F4c-1, #TBD):** added the reverse index (`Registry::owner_method_names`, a private
+    `HashMap<Symbol, Vec<Symbol>>` maintained only inside `sync_user_method_entries`) plus its
+    `#[cfg(debug_assertions)]` + `MUTSU_CHECK_METHOD_INDEX=1`-gated full-table verifier, per (2).
+    `replace_method_entries_from` (item (4)(c)) now copies the index alongside the table, or a
+    nested EVAL/`eval-lives-ok`/`throws-like`/`fails-like` interpreter would run the parent's
+    `method_entries` against its own empty index. A shared `Registry::shadow_check_owner_method_names`
+    helper (set comparison, `MUTSU_VM_STATS`-gated) was added and used to instrument all eight
+    enumeration sites named in (0)(i); a full local `t/` sweep (3179 files, 15127 checks) came back
+    clean at **seven** of the eight — `methods_classhow_dispatch::submethod_table`,
+    `methods_classhow_method_obj::collect_class_methods`/`class_method_table`,
+    `metamodel::declare_drive_how_protocol` (closing F4b's own deferral),
+    `registration_class::collect_type_method_names`,
+    `registration::resolve_class_stub_requirements`/`validate_private_method_existence` — which
+    were cut over to `owner_method_names` and verified with the full local `t/` suite (3179 files),
+    the 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset, and `scripts/battery-testsuite.sh`
+    (GATE PASSED), all green; `cargo clippy -- -D warnings` and `cargo fmt` clean.
+
+    The eighth, `class::detect_unresolved_role_method_conflicts`, showed 12 mismatches (all under
+    `Cro::HTTP`/`Cro::TCP`/`Cro::TLS`/`Log::Timeline`/local `t/` role fixtures) and was
+    **deliberately left on the old `class_def.methods` read** — this is exactly the kind of
+    ordering hazard R4 warns about, confirmed by reading, not assumed: `finalize_class_registration`
+    calls `resolve_class_stub_requirements` (which can *remove* a resolved-away stub's entry from
+    the in-flight `class_def.methods` in place) immediately before this site, and does not re-sync
+    the registry until after both calls return — so at this exact point `class_def.methods` can be
+    a proper subset of what `owner_method_names` (last synced before the stub-resolution mutation)
+    still lists. Every one of the 12 mismatches was `new ⊇ old`, matching that theory exactly (no
+    case of `old` containing a name `new` lacked). This is expected reader/writer skew from the
+    dual-representation window, not a bug in either side; the shadow check stays in place
+    (uninstrumented sites don't get silently dropped) and this site's cutover moves to F4c-9a,
+    after F4c-3's write-through machinery makes `class_def.methods` and the registry agree at every
+    point in `finalize_class_registration`, not just at statement boundaries.
+
+    Along the way, the verifier itself caught a real index/table desync before it shipped: the
+    early-return branch of `sync_user_method_entries` (taken when `classes.get(class_name)` misses
+    — the "pure clear" shape `withdraw_role_pun`/`rename_generic_composed_class`'s old-name half
+    use, per (0)(iii)) cleared the affected rows' `user_candidates` via the leading `retain` but
+    returned before the index update, leaving `owner_method_names` pointing at now-dead rows.
+    Caught by a `MUTSU_CHECK_METHOD_INDEX=1` sweep of the full local `t/` suite (6 crashes, all role-pun
+    tests: `role-instantiation.t`, `punned-role-container-attribute.t`, `role-pun-private-attribute.t`,
+    `role-body-composition-timing.t`, `role-diamond-stub-concrete.t`,
+    `positional-role-attr-writeback-coherence.t`) before any cutover read it, so the coverage gap
+    of (0)(iii)'s "pure clear" callers never reached production behavior. Fixed by clearing the
+    index in that branch too; the same sweep is clean (0 crashes) after the fix.
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -171,6 +171,22 @@ impl Interpreter {
         class_name: &str,
         class_def: &ClassDef,
     ) -> Result<(), RuntimeError> {
+        // ADR-0019 F4c-1 shadow check. NOTE: unlike the other seven sites,
+        // this `class_def` is NOT guaranteed to match the registry's
+        // `owner_method_names` at this point -- `finalize_class_registration`
+        // calls this immediately after `resolve_class_stub_requirements`,
+        // which can mutate/remove entries from `class_def.methods` in place
+        // (an unsatisfied stub whose requirement got resolved away), and the
+        // registry is not re-synced until after this call returns. A
+        // mismatch here is therefore expected whenever stub resolution
+        // changed the method set, not necessarily a bug -- do NOT cut this
+        // site over without first confirming (via the mismatch detail) which
+        // mismatches are this expected staleness vs. a real gap.
+        self.registry().shadow_check_owner_method_names(
+            "class::detect_unresolved_role_method_conflicts",
+            class_name,
+            class_def.methods.keys().map(String::as_str),
+        );
         for (method_name, defs) in &class_def.methods {
             // Submethods (like BUILD, TWEAK) from multiple roles do not conflict —
             // they are accumulated and all called during construction. Skip them.

--- a/src/runtime/metamodel.rs
+++ b/src/runtime/metamodel.rs
@@ -400,22 +400,26 @@ impl Interpreter {
             // deterministic protocol order. Each is passed as a Method object
             // carrying its owner markers so a `.wrap` inside the user
             // `add_method` becomes a class-keyed wrap chain.
-            let mut method_names: Vec<String> = self
-                .registry()
-                .classes
-                .get(class_name)
-                .map(|cd| {
-                    cd.methods
-                        .iter()
-                        .filter(|(_, overloads)| {
+            // ADR-0019 F4c-1: enumerate via the canonical reverse index
+            // instead of `class_def.methods.keys()` (the enumeration site
+            // F4b deferred here; zero-mismatch shadow-checked across the
+            // full local `t/` suite before this cutover).
+            let registry = self.registry();
+            let mut method_names: Vec<String> = registry
+                .owner_method_names(class_name)
+                .into_iter()
+                .map(|name| name.resolve())
+                .filter(|name| {
+                    registry
+                        .user_method_overloads(class_name, name)
+                        .is_some_and(|overloads| {
                             overloads.first().is_some_and(|first| {
                                 !first.is_private && !first.is_submethod && !first.is_multi
                             })
                         })
-                        .map(|(name, _)| name.clone())
-                        .collect()
                 })
-                .unwrap_or_default();
+                .collect();
+            drop(registry);
             method_names.sort();
             for method_name in method_names {
                 let Some(overloads) = self

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -1325,13 +1325,19 @@ impl Interpreter {
                 Ok(Value::hash(self.class_method_table(&type_name)))
             }
             "submethod_table" if !args.is_empty() => {
+                // ADR-0019 F4c-1: enumerate via the canonical reverse index
+                // instead of `class_def.methods.keys()` (zero-mismatch
+                // shadow-checked across the full local `t/` suite).
                 let type_name = self.mop_receiver_owner(&args[0]);
                 let mut table = HashMap::new();
-                if let Some(class_def) = self.registry().classes.get(&type_name) {
-                    for (name, defs) in &class_def.methods {
-                        if defs.iter().any(|d| d.is_my) {
-                            table.insert(name.clone(), Value::str(name.clone()));
-                        }
+                let registry = self.registry();
+                for name in registry.owner_method_names(&type_name) {
+                    let name = name.resolve();
+                    if registry
+                        .user_method_overloads(&type_name, &name)
+                        .is_some_and(|defs| defs.iter().any(|d| d.is_my))
+                    {
+                        table.insert(name.clone(), Value::str(name));
                     }
                 }
                 Ok(Value::hash(table))

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -19,15 +19,15 @@ impl Interpreter {
                 result.push(self.make_native_method_object(&attr.name, class_name));
             }
         }
-        // Then add explicit methods. `ClassDef::methods` drives the name
-        // enumeration; the overload data itself comes from the canonical
-        // `Registry::method_entries[(owner, name)].user_candidates` table
-        // (ADR-0019 Phase F box F1 item 1) rather than `ClassDef::methods`
-        // directly -- `sync_user_method_entries` keeps the two in lockstep,
-        // verified with zero mismatches across a full `t/`+roast sweep by
-        // the shadow check this cutover retires (#6399).
-        for method_name in class_def.methods.keys() {
-            let Some(overloads) = registry.user_method_overloads(class_name, method_name) else {
+        // Then add explicit methods. The overload data comes from the
+        // canonical `Registry::method_entries[(owner, name)].user_candidates`
+        // table (ADR-0019 Phase F box F1 item 1); the name enumeration itself
+        // is the canonical reverse index (F4c-1: `owner_method_names`,
+        // zero-mismatch shadow-checked against `ClassDef::methods.keys()`
+        // across the full local `t/` suite before this cutover).
+        for method_name in registry.owner_method_names(class_name) {
+            let method_name = method_name.resolve();
+            let Some(overloads) = registry.user_method_overloads(class_name, &method_name) else {
                 continue;
             };
             if overloads.is_empty() {
@@ -41,7 +41,7 @@ impl Interpreter {
             let is_multi = overloads.len() > 1;
             let return_type = first.return_type.clone();
             let method_obj = self.make_method_object_with_owner(
-                method_name,
+                &method_name,
                 first,
                 is_multi,
                 return_type,
@@ -90,8 +90,12 @@ impl Interpreter {
                 );
             }
         }
-        for method_name in class_def.methods.keys() {
-            let Some(overloads) = registry.user_method_overloads(class_name, method_name) else {
+        // ADR-0019 F4c-1: enumerate via the canonical reverse index instead
+        // of `class_def.methods.keys()` (zero-mismatch shadow-checked across
+        // the full local `t/` suite before this cutover).
+        for method_name in registry.owner_method_names(class_name) {
+            let method_name = method_name.resolve();
+            let Some(overloads) = registry.user_method_overloads(class_name, &method_name) else {
                 continue;
             };
             let Some(first) = overloads.first() else {
@@ -103,7 +107,7 @@ impl Interpreter {
             table.insert(
                 method_name.clone(),
                 self.make_method_object_with_owner(
-                    method_name,
+                    &method_name,
                     first,
                     overloads.len() > 1,
                     first.return_type.clone(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -413,6 +413,7 @@ mod registration_role_decl;
 mod registration_role_method;
 pub(crate) mod registration_sub;
 mod registry;
+mod registry_method_table;
 pub(crate) mod resolution;
 mod resolution_call_sub;
 mod resolution_deferral;

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -204,7 +204,19 @@ impl Interpreter {
         class_name: &str,
         class_def: &mut ClassDef,
     ) -> Result<(), RuntimeError> {
-        let method_names: Vec<String> = class_def.methods.keys().cloned().collect();
+        // ADR-0019 F4c-1: enumerate via the canonical reverse index instead
+        // of `class_def.methods.keys()`. `class_def` here is the very state
+        // `run_class_body`'s own last per-statement `sync_user_method_entries`
+        // call already published to the registry (this function runs before
+        // `class_def` gets mutated below), so the two are guaranteed in sync
+        // -- zero-mismatch shadow-checked across the full local `t/` suite
+        // before this cutover.
+        let method_names: Vec<String> = self
+            .registry()
+            .owner_method_names(class_name)
+            .iter()
+            .map(Symbol::resolve)
+            .collect();
         for method_name in method_names {
             let Some(all_defs) = class_def.methods.get(&method_name).cloned() else {
                 continue;
@@ -633,8 +645,16 @@ impl Interpreter {
             Some(cd) => cd.clone(),
             None => return Ok(()),
         };
-        for overloads in class_def.methods.values() {
-            for method_def in overloads {
+        // ADR-0019 F4c-1: enumerate via the canonical reverse index instead
+        // of `class_def.methods.values()` (zero-mismatch shadow-checked
+        // across the full local `t/` suite before this cutover).
+        let registry = self.registry();
+        for method_name in registry.owner_method_names(class_name) {
+            let method_name = method_name.resolve();
+            let Some(overloads) = registry.user_method_overloads(class_name, &method_name) else {
+                continue;
+            };
+            for method_def in &overloads {
                 self.check_private_calls_exist(class_name, &class_def, &method_def.body)?;
             }
         }

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -482,9 +482,22 @@ impl Interpreter {
     /// Collect method names from a class or role by name.
     fn collect_type_method_names(&self, type_name: &str) -> Vec<String> {
         let mut names = Vec::new();
-        if let Some(class_def) = self.registry().classes.get(type_name) {
-            names.extend(class_def.methods.keys().cloned());
-        } else if let Some(role_def) = self.registry().roles.get(type_name) {
+        let registry = self.registry();
+        if registry.classes.contains_key(type_name) {
+            // ADR-0019 F4c-1: enumerate via the canonical reverse index
+            // instead of `class_def.methods.keys()` (zero-mismatch
+            // shadow-checked across the full local `t/` suite before this
+            // cutover). The existence check stays on `classes` -- an empty
+            // `owner_method_names(type_name)` cannot distinguish "no class of
+            // this name" from "a class with zero declared methods", and only
+            // the former should fall through to the role branch below.
+            names.extend(
+                registry
+                    .owner_method_names(type_name)
+                    .iter()
+                    .map(Symbol::resolve),
+            );
+        } else if let Some(role_def) = registry.roles.get(type_name) {
             names.extend(role_def.methods.keys().cloned());
             // Also include methods from composed roles
             if let Some(composed) = self.registry().class_composed_roles.get(type_name) {

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -82,6 +82,29 @@ pub(crate) struct Registry {
     pub(crate) method_entries: HashMap<MethodEntryKey, MethodEntry>,
     /// Monotonic invalidation generation for the canonical method table.
     pub(crate) method_generation: u64,
+    /// Reverse index (ADR-0019 F4c-1): owner -> every `name` for which
+    /// `(owner, name)` currently has a non-empty `user_candidates` row in
+    /// [`method_entries`](Self::method_entries), i.e. exactly the names
+    /// `ClassDef::methods.keys()` holds for that owner today. Deliberately
+    /// scoped to the user column only -- NOT every live row -- because rows
+    /// also exist for `builtin`/`accessor`/`proto`, and indexing those would
+    /// make `.^methods`/`^method_table` start reporting names `class_def.
+    /// methods.keys()` never contained. Insertion-ordered (a `Vec`, not a
+    /// set): `ClassDef::methods` is itself an unordered `HashMap` whose
+    /// `RandomState` reseeds per process, so today's enumeration order is
+    /// already nondeterministic between runs and no consumer can depend on
+    /// it; a `Vec` merely avoids adding a second, different nondeterminism
+    /// (hash-set iteration order) on top. Private to this module -- for now
+    /// (F4c-1) maintained only by [`sync_user_method_entries`](Self::
+    /// sync_user_method_entries); F4c-2 adds the full mutator API and routes
+    /// every write through it. See the ADR-0019 F4c design note.
+    ///
+    /// `pub(crate)` only because `Registry { .. Registry::default() }`
+    /// struct-update syntax (`runtime_init.rs`) requires field visibility at
+    /// the construction site; every actual read/write outside this impl
+    /// block should go through [`owner_method_names`](Self::owner_method_names)
+    /// rather than touching the field directly.
+    pub(crate) owner_method_names: HashMap<Symbol, Vec<Symbol>>,
     /// Method-candidate wrap chains: `(owner class, method name, candidate
     /// index)` -> stack of `(handle_id, wrapper_sub)`, outermost (currently
     /// active) last. Populated by `.wrap()` on a Sub/Method obtained via
@@ -364,19 +387,35 @@ impl Registry {
                 || entry.proto.is_some()
         });
         let Some(class_def) = self.classes.get(class_name) else {
+            // A pure clear (`withdraw_role_pun`, `rename_generic_composed_
+            // class`'s old-name half, ...): `classes.get` misses, so there is
+            // nothing to re-derive rows from -- but the `retain` above may
+            // just have zeroed this owner's `user_candidates`, so the index
+            // must drop it too, or `owner_method_names` keeps listing a name
+            // whose row is now dead (caught by `MUTSU_CHECK_METHOD_INDEX`).
+            self.owner_method_names.remove(&owner);
             self.bump_method_generation();
+            self.debug_verify_owner_method_names_index();
             return;
         };
         let methods = class_def.methods.clone();
         let attributes = class_def.attributes.clone();
+        let mut names = Vec::with_capacity(methods.len());
         for (name, candidates) in methods {
+            let name = Symbol::intern(&name);
+            let is_empty = candidates.is_empty();
             self.method_entries
-                .entry(MethodEntryKey {
-                    owner,
-                    name: Symbol::intern(&name),
-                })
+                .entry(MethodEntryKey { owner, name })
                 .or_default()
                 .user_candidates = candidates;
+            if !is_empty {
+                names.push(name);
+            }
+        }
+        if names.is_empty() {
+            self.owner_method_names.remove(&owner);
+        } else {
+            self.owner_method_names.insert(owner, names);
         }
         // A later same-name declaration within the class overrides an earlier
         // one (mirrors `collect_class_attributes`'/`has_public_accessor`'s
@@ -393,6 +432,7 @@ impl Registry {
                 .accessor = Some(attr.is_public);
         }
         self.bump_method_generation();
+        self.debug_verify_owner_method_names_index();
     }
 
     pub(crate) fn user_method_overloads(
@@ -458,6 +498,11 @@ impl Registry {
 
     pub(crate) fn replace_method_entries_from(&mut self, source: &Self) {
         self.method_entries = source.method_entries.clone();
+        // F4c-1: copy the reverse index alongside the table it derives from,
+        // or a nested interpreter built via this path (EVAL/`eval-lives-ok`/
+        // `throws-like`/`fails-like`) would run the parent's `method_entries`
+        // against its own `Interpreter::new()`'s empty `owner_method_names`.
+        self.owner_method_names = source.owner_method_names.clone();
         self.bump_method_generation();
     }
 

--- a/src/runtime/registry_method_table.rs
+++ b/src/runtime/registry_method_table.rs
@@ -1,0 +1,123 @@
+//! ADR-0019 F4c: the canonical-method-table reverse index and its read/verify
+//! API, split out of `registry.rs` (already 1402 lines before this file
+//! existed — the 500-line convention forbids growing it further, per the F4c
+//! design note's own reasoning for `registry_method_table.rs`). This starts
+//! as a second `impl Registry` block holding just the F4c-1 read side
+//! (`owner_method_names`, the shadow check, and the debug verifier); F4c-2
+//! adds the mutator surface (`set_user_methods`, `push_user_method`, ...)
+//! here too.
+//!
+//! `Registry::owner_method_names` (the field) is declared and maintained on
+//! `registry.rs`'s `sync_user_method_entries`, since that is where the data
+//! it derives from (`ClassDef::methods`) is read — the split is call-site
+//! surface, not data ownership.
+
+#[cfg(debug_assertions)]
+use rustc_hash::FxHashSet as HashSet;
+
+use crate::symbol::Symbol;
+
+#[cfg(debug_assertions)]
+use super::registry::MethodEntryKey;
+use super::registry::Registry;
+
+impl Registry {
+    /// F4c-1 read accessor for [`owner_method_names`](Registry::owner_method_names):
+    /// every user-declared method/attribute-accessor name `owner` currently
+    /// has a non-empty candidate row for, i.e. the F4c replacement for
+    /// `ClassDef::methods.keys()`. Empty for an owner with no user rows
+    /// (including any owner that is only a role -- `RoleDef::methods` is
+    /// explicitly out of scope for this index, see the ADR-0019 F4c design
+    /// note section (1)).
+    pub(crate) fn owner_method_names(&self, owner: &str) -> Vec<Symbol> {
+        self.owner_method_names
+            .get(&Symbol::intern(owner))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Shared F4c-1 shadow check for the eight `class_def.methods.keys()`
+    /// full-name-enumeration read sites the ADR-0019 F4c design note's
+    /// ground-truth correction (0)(i) named. `old_names` is today's read (a
+    /// borrow, so the caller pays nothing when `MUTSU_VM_STATS` is
+    /// disabled); compared against [`owner_method_names`](Registry::
+    /// owner_method_names) as a SET (declaration order is not a meaningful
+    /// invariant here -- see that field's own doc). Zero behavior change:
+    /// this only records a counter, the caller's existing read is untouched.
+    pub(crate) fn shadow_check_owner_method_names<'a>(
+        &self,
+        site: &str,
+        owner: &str,
+        old_names: impl Iterator<Item = &'a str>,
+    ) {
+        if !crate::vm::vm_stats::enabled() {
+            return;
+        }
+        let mut old: Vec<&str> = old_names.collect();
+        old.sort_unstable();
+        old.dedup();
+        let mut new: Vec<String> = self
+            .owner_method_names(owner)
+            .iter()
+            .map(Symbol::resolve)
+            .collect();
+        new.sort_unstable();
+        new.dedup();
+        let matched = old.iter().copied().eq(new.iter().map(String::as_str));
+        crate::vm::vm_stats::record_owner_method_names_shadow_check(site, matched, || {
+            format!("owner={owner} old={old:?} new={new:?}")
+        });
+    }
+
+    /// Full-table consistency check between [`owner_method_names`](Registry::
+    /// owner_method_names) and the `user_candidates` half of `method_entries`:
+    /// every indexed name must have a live row and every row with a
+    /// non-empty `user_candidates` must be indexed under its owner. No-op
+    /// unless built with `debug_assertions` AND `MUTSU_CHECK_METHOD_INDEX`
+    /// is set (ADR-0019 F4c design note section (2)) -- this is an O(total
+    /// rows) full scan, deliberately not run on every build.
+    #[cfg(debug_assertions)]
+    pub(super) fn debug_verify_owner_method_names_index(&self) {
+        use std::sync::OnceLock;
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        if !*ENABLED.get_or_init(|| std::env::var_os("MUTSU_CHECK_METHOD_INDEX").is_some()) {
+            return;
+        }
+        for (owner, names) in &self.owner_method_names {
+            let mut seen = HashSet::default();
+            for name in names {
+                assert!(
+                    seen.insert(*name),
+                    "MUTSU_CHECK_METHOD_INDEX: owner_method_names[{owner:?}] lists {name:?} twice"
+                );
+                let live = self
+                    .method_entries
+                    .get(&MethodEntryKey {
+                        owner: *owner,
+                        name: *name,
+                    })
+                    .is_some_and(|entry| !entry.user_candidates.is_empty());
+                assert!(
+                    live,
+                    "MUTSU_CHECK_METHOD_INDEX: owner_method_names[{owner:?}] lists {name:?} but its row has no live user_candidates"
+                );
+            }
+        }
+        for (key, entry) in &self.method_entries {
+            if entry.user_candidates.is_empty() {
+                continue;
+            }
+            let indexed = self
+                .owner_method_names
+                .get(&key.owner)
+                .is_some_and(|names| names.contains(&key.name));
+            assert!(
+                indexed,
+                "MUTSU_CHECK_METHOD_INDEX: method_entries[{key:?}] has live user_candidates but is missing from owner_method_names"
+            );
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub(super) fn debug_verify_owner_method_names_index(&self) {}
+}

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -364,6 +364,45 @@ pub(crate) fn record_owner_shadow_check(
     }
 }
 
+// ADR-0019 Phase F box F4c-1: shadow comparison between the eight
+// `class_def.methods.keys()`-style full-name-enumeration reads the F4c
+// design note's ground-truth correction (0)(i) named and the new
+// `Registry::owner_method_names` reverse index for the same owner, as a
+// SET (declaration order is not compared -- see the field's own doc for why
+// order is not a meaningful invariant here). `OWNER_METHOD_NAMES_SHADOW_
+// CHECKS`/`_MISMATCHES` are the totals across all eight sites;
+// `owner_method_names_shadow_mismatch_by_site` breaks mismatches down by
+// site so each can be triaged independently before its read is cut over.
+// Nothing reads these counters to make a dispatch decision: shadow-only,
+// zero behavior change.
+static OWNER_METHOD_NAMES_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
+static OWNER_METHOD_NAMES_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn owner_method_names_shadow_mismatch_by_site() -> &'static Mutex<HashMap<String, u64>> {
+    static BY_SITE: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    BY_SITE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one F4c-1 owner-method-names shadow comparison at `site`. `detail`
+/// is only evaluated on a mismatch, mirroring [`record_owner_shadow_check`].
+#[inline]
+pub(crate) fn record_owner_method_names_shadow_check(
+    site: &str,
+    matched: bool,
+    detail: impl FnOnce() -> String,
+) {
+    if !enabled() {
+        return;
+    }
+    OWNER_METHOD_NAMES_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
+    if !matched {
+        OWNER_METHOD_NAMES_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = owner_method_names_shadow_mismatch_by_site().lock() {
+            *map.entry(format!("{site} [{}]", detail())).or_insert(0) += 1;
+        }
+    }
+}
+
 // ADR-0019 Phase E box E2a: coverage gap between the native-method-row catalog
 // (`crate::builtins::native_method_row`) and what the real `native_method_{0,1,2}arg`
 // cascades actually recognize. Bumped whenever a cascade call returns `Some(..)`
@@ -1076,6 +1115,28 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e1a owner-shadow mismatches by site (top {}): {}",
+            top.len(),
+            top.join(" ")
+        );
+    }
+    let owner_method_names_shadow_checks = OWNER_METHOD_NAMES_SHADOW_CHECKS.load(Ordering::Relaxed);
+    let owner_method_names_shadow_mismatches =
+        OWNER_METHOD_NAMES_SHADOW_MISMATCHES.load(Ordering::Relaxed);
+    eprintln!(
+        "[mutsu vm-stats] adr0019-f4c-1: owner_method_names_shadow_checks={owner_method_names_shadow_checks} owner_method_names_shadow_mismatches={owner_method_names_shadow_mismatches}"
+    );
+    if let Ok(map) = owner_method_names_shadow_mismatch_by_site().lock()
+        && !map.is_empty()
+    {
+        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
+        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = entries
+            .iter()
+            .take(25)
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        eprintln!(
+            "[mutsu vm-stats] adr0019-f4c-1 owner-method-names-shadow mismatches by site (top {}): {}",
             top.len(),
             top.join(" ")
         );


### PR DESCRIPTION
## Summary
- Adds `Registry::owner_method_names`, a reverse index (`owner -> Vec<Symbol>`) maintained inside `sync_user_method_entries`, as the ADR-0019 F4c replacement for `ClassDef::methods.keys()`, per the F4c design note sections (2)/(3).
- Instruments all eight `class_def.methods.keys()` full-name-enumeration sites the design note's ground-truth correction (0)(i) named with a `MUTSU_VM_STATS`-gated shadow check, and cuts over the seven that came back clean across a full local `t/` sweep (3179 files, 15127 checks, 0 mismatches).
- Leaves `class::detect_unresolved_role_method_conflicts` (the eighth site) on the old read: it showed 12 expected reader/writer-skew mismatches caused by `finalize_class_registration` mutating `class_def.methods` (via `resolve_class_stub_requirements`) before this site runs and before the registry is re-synced. Deferred to F4c-9a, after F4c-3's write-through machinery closes that window. The shadow check stays in place.
- Adds a `#[cfg(debug_assertions)]` + `MUTSU_CHECK_METHOD_INDEX=1`-gated full-table verifier, which caught a real index/table desync before any cutover read it: `sync_user_method_entries`'s early-return ("pure clear") branch cleared `user_candidates` via `retain` but skipped the index update, leaving `owner_method_names` pointing at dead rows for `withdraw_role_pun`-style callers. Fixed.
- Splits the new read/verify API into `src/runtime/registry_method_table.rs` (`registry.rs` was already 1402 lines, over the 500-line convention -- matches the design note's own reasoning for that file).

## Test plan
- [x] `cargo build` / `cargo build --release` clean, `cargo fmt` / `cargo clippy -- -D warnings` (debug + release) clean
- [x] Full local `t/` suite (3179 files) green, twice (before and after the index-desync fix)
- [x] `MUTSU_CHECK_METHOD_INDEX=1` sweep of the full local `t/` suite: 0 crashes (was 6, all role-pun tests, before the fix)
- [x] `MUTSU_VM_STATS=1` sweep of the full local `t/` suite: 7/8 enumeration sites zero-mismatch; the 8th's 12 mismatches triaged and explained (see summary)
- [x] 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) green
- [x] `scripts/battery-testsuite.sh` -- GATE PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)