### PR TITLE
feat(adr0019): F4c-3 -- class-declaration family dual-write cutover

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1556,6 +1556,56 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (only the pre-existing tracked
     `S12-attributes/trusts.t` failure), and `scripts/battery-testsuite.sh` (GATE PASSED); `cargo
     clippy -- -D warnings` and `cargo fmt` clean.
+
+    **Progress (F4c-3, #TBD):** converted the class-declaration family's write sites to dual-write
+    through the mutator API (`cx.class_def.methods`/`class_def.methods` unchanged, each site ALSO
+    calls the matching registry mutator): `registration_class_body_method.rs`'s multi-candidate
+    push, non-multi retain+push, and both `HandleSpec` delegation-forwarder pushes;
+    `registration_class_body.rs`'s code-alias write; `registration_class_compose.rs` and
+    `registration_class_compose_body.rs`'s role-method composition (both the direct-parent and
+    grandparent-role-propagation paths); `registration_class.rs`'s `apply_handle_specs` (now
+    `&mut self` plus a `class_name` parameter, its one call site updated); and
+    `registration.rs`'s `resolve_class_stub_requirements` write-back (safe despite this function's
+    own mid-loop `Err` returns: its only caller, `finalize_class_registration`, rolls back via
+    `ClassRegSnapshot::restore`, which always ends with a full `sync_user_method_entries` re-derive
+    from the restored pre-attempt `class_def` -- any registry state a failed attempt's mutator
+    calls left behind is overwritten by that unconditional re-derive, exactly as it already
+    overwrites `class_def` itself). The periodic per-statement `sync_user_method_entries` call
+    (`registration_class_body.rs:208` and friends) is deliberately left untouched in this slice --
+    per design note (3)'s framing it "degenerates to an assertion that the two agree" only once
+    read cutover (F4c-9a) removes the last consumer of `class_def.methods`, so for now it stays the
+    actual mechanism and these mutator calls are additive/shadow-provable, not a behavior change.
+
+    **`registration_class_body_attr.rs:172-178`'s merge-back is deliberately NOT deleted in this
+    slice**, contrary to this box's own bullet -- read carefully before assuming otherwise. Its
+    root cause is that a user `trait_mod:<is>` (Attribute::Predicate's `is predicate` being the
+    real-world case) can call `.^add_method`, which writes directly into the registry with no way
+    to reach `cx.class_def` (the in-flight `ClassBodyCx` has no visibility into a MOP call). F4c-6
+    (`^add_method`) has not landed yet, so `.^add_method`'s write still bypasses `class_def.methods`
+    entirely; deleting the merge-back now would let the later unconditional `class_def.methods`
+    re-publish (`registration_class_body.rs:208`'s per-statement sync, unchanged in this slice, per
+    above) silently drop that method again -- reintroducing the exact bug the merge-back exists to
+    fix. Revisit once F4c-6 makes `^add_method` dual-write-aware.
+
+    **A real R8 lock-reentrancy panic was hit and fixed while implementing this slice** --
+    `propagate_composed_role_parent_specs` (`registration_class_compose_body.rs`) had two
+    `if let Some(x) = self.registry()....cloned() { <body> }` sites; Rust's temporary-lifetime-
+    extension rule keeps the `RegistryReadGuard` produced by `self.registry()` alive for the
+    *entire* `if let` body, not just the condition, so adding a `self.registry_mut()` call inside
+    either body panics on a same-thread read -> write lock upgrade (caught by the debug-only
+    `lock_reentry.rs` guard, not a silent deadlock -- see that module's own docs). Fixed by hoisting
+    each clone into its own `let` statement first (ordinary `let` does not extend the temporary's
+    lifetime past the statement), then branching on the *owned* result. This is exactly the R8
+    hazard the design note names, just found in the sibling composition-propagation function
+    rather than in `resolve_class_stub_requirements` itself, and just as easy to trip on any future
+    F4c-4+ site that adds a `registry_mut()` call inside an existing `if let Some(x) =
+    self.registry()... { }` -- grep for that shape before adding a write inside one.
+
+    Verified with the full local `t/` suite (3182 files, 29634 tests) under
+    `MUTSU_CHECK_METHOD_INDEX=1` (0 index/table-drift assertions, 0 lock-reentrancy panics after
+    the fix above), the 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release; only the
+    pre-existing tracked `S12-attributes/trusts.t` failure), and `scripts/battery-testsuite.sh`
+    (GATE PASSED); `cargo clippy -- -D warnings` and `cargo fmt` clean.
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -372,12 +372,31 @@ impl Interpreter {
                         .any(|cm| Self::method_signatures_match(m, cm))
                 });
             }
+            // ADR-0019 F4c-3: dual-write, see class_body_method_decl's own
+            // comment in registration_class_body_method.rs. Safe even though
+            // this loop can still return `Err` on a later `method_name`
+            // (leaving these registry writes uncommitted-to-`class_def`
+            // stragglers): `finalize_class_registration`'s only caller
+            // rolls back via `ClassRegSnapshot::restore`, which always ends
+            // with a full `sync_user_method_entries(name)` re-derive from
+            // the restored (pre-attempt) `class_def` -- that unconditional
+            // full re-derive overwrites any partial state a failed attempt
+            // left in the registry, exactly as it already does for
+            // `class_def` itself.
+            let owner = Symbol::intern(class_name);
             if concrete.is_empty() {
                 if stubs.is_empty() {
                     continue; // nothing changed, skip update
                 }
+                self.registry_mut()
+                    .remove_user_methods(owner, Symbol::intern(&method_name));
                 class_def.methods.remove(&method_name);
             } else {
+                self.registry_mut().set_user_methods(
+                    owner,
+                    Symbol::intern(&method_name),
+                    concrete.clone(),
+                );
                 class_def.methods.insert(method_name, concrete);
             }
         }

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::ast::{HandleSpec, ParamDef};
+use crate::symbol::Symbol;
 
 pub(super) type ResolvedRoleCandidate = (RoleDef, Vec<String>, Vec<Value>);
 
@@ -392,12 +393,36 @@ impl Interpreter {
     /// For type-based handles, collects method names from the referenced type
     /// first, then applies them without holding borrows on self.
     pub(crate) fn apply_handle_specs(
-        &self,
+        &mut self,
+        class_name: &str,
         specs: &[HandleSpec],
         attr_var_name: &str,
         class_def: &mut ClassDef,
     ) {
         let resolved = self.resolve_handle_specs_to_names(specs, attr_var_name);
+        // ADR-0019 F4c-3: dual-write, see class_body_method_decl's own
+        // comment in registration_class_body_method.rs. `apply_resolved_
+        // handles` stays the shared class/role implementation (`RoleDef::
+        // methods` is out of scope for the registry index, see the F4c
+        // design note section (1)), so only the class-only wrapper here
+        // additionally writes through the registry.
+        let owner = Symbol::intern(class_name);
+        let mut registry = self.registry_mut();
+        for handle in &resolved {
+            if let ResolvedHandle::Method {
+                exposed,
+                target,
+                attr_var,
+            } = handle
+            {
+                registry.push_user_method(
+                    owner,
+                    Symbol::intern(exposed),
+                    make_delegation_method(attr_var, target),
+                );
+            }
+        }
+        drop(registry);
         apply_resolved_handles(
             &resolved,
             &mut class_def.methods,

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -249,6 +249,15 @@ impl Interpreter {
         };
         let alias = var_name.trim_start_matches('&').to_string();
         if let Some(overloads) = cx.class_def.methods.get(source_name).cloned() {
+            // ADR-0019 F4c-3: dual-write, see class_body_method_decl's own
+            // comment -- this function republishes `cx.class_def` wholesale
+            // to the registry a few lines below anyway, so this is a
+            // redundant-but-cheap early confirmation, not the sole write.
+            self.registry_mut().set_user_methods(
+                Symbol::intern(cx.name),
+                Symbol::intern(&alias),
+                overloads.clone(),
+            );
             cx.class_def.methods.insert(alias, overloads);
         }
         // Also execute the statement so the code variable is set

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -326,7 +326,7 @@ impl Interpreter {
         } else {
             format!("!{}", attr_name_str)
         };
-        self.apply_handle_specs(&decl.handles, &attr_var_name, &mut cx.class_def);
+        self.apply_handle_specs(cx.name, &decl.handles, &attr_var_name, &mut cx.class_def);
         Ok(ClassBodyFlow::RunTail)
     }
 }

--- a/src/runtime/registration_class_body_method.rs
+++ b/src/runtime/registration_class_body_method.rs
@@ -187,7 +187,18 @@ impl Interpreter {
         let is_lexical_only = decl.is_my && !decl.is_submethod;
         let is_our_only = decl.is_our && !decl.our_variable_form;
         if !is_lexical_only && !is_our_only {
+            // ADR-0019 F4c-3: dual-write -- `cx.class_def.methods` stays the
+            // authoritative in-flight state (still re-derived wholesale into
+            // the registry by the per-statement `sync_user_method_entries`
+            // call right after this returns, per F4c design note (3)'s
+            // bridge), but each write also goes straight through the
+            // registry mutator API so the two agree at every point, not
+            // just at statement boundaries.
+            let owner = Symbol::intern(cx.name);
+            let method_sym = Symbol::intern(&resolved_method_name);
             if decl.multi {
+                self.registry_mut()
+                    .push_user_method(owner, method_sym, def.clone());
                 cx.class_def
                     .methods
                     .entry(resolved_method_name.clone())
@@ -216,6 +227,10 @@ impl Interpreter {
                 // A non-multi method replaces prior same-privacy
                 // candidates but must preserve methods of the OTHER
                 // privacy stored under the same name.
+                self.registry_mut()
+                    .retain_user_methods(owner, method_sym, |m| m.is_private != new_is_private);
+                self.registry_mut()
+                    .push_user_method(owner, method_sym, def.clone());
                 let entry = cx
                     .class_def
                     .methods
@@ -340,18 +355,30 @@ impl Interpreter {
             for spec in &decl.handles {
                 match spec {
                     HandleSpec::Name(target) => {
+                        let delegation = make_delegation_method(&source_attr_marker, target);
+                        self.registry_mut().push_user_method(
+                            Symbol::intern(cx.name),
+                            Symbol::intern(target),
+                            delegation.clone(),
+                        );
                         cx.class_def
                             .methods
                             .entry(target.clone())
                             .or_default()
-                            .push(make_delegation_method(&source_attr_marker, target));
+                            .push(delegation);
                     }
                     HandleSpec::Rename { exposed, target } => {
+                        let delegation = make_delegation_method(&source_attr_marker, target);
+                        self.registry_mut().push_user_method(
+                            Symbol::intern(cx.name),
+                            Symbol::intern(exposed),
+                            delegation.clone(),
+                        );
                         cx.class_def
                             .methods
                             .entry(exposed.clone())
                             .or_default()
-                            .push(make_delegation_method(&source_attr_marker, target));
+                            .push(delegation);
                     }
                     HandleSpec::Wildcard => {
                         cx.class_def

--- a/src/runtime/registration_class_compose.rs
+++ b/src/runtime/registration_class_compose.rs
@@ -9,6 +9,7 @@ use super::registration_class::{
 };
 use super::registration_class_decl::BUILTIN_PARENT_TYPES;
 use super::*;
+use crate::symbol::Symbol;
 
 /// Replace whole type-name tokens in `name` that exactly match a role type
 /// parameter with its concrete type name. Tokens are delimited by `[`, `]`,
@@ -349,6 +350,19 @@ impl Interpreter {
                     })
                     .collect()
             };
+            // ADR-0019 F4c-3: dual-write, see class_body_method_decl's own
+            // comment in registration_class_body_method.rs -- the periodic
+            // per-statement `sync_user_method_entries` call re-derives the
+            // registry from `cx.class_def.methods` regardless, so this is
+            // additive, not the sole write.
+            {
+                let owner = Symbol::intern(cx.name);
+                let method_sym = Symbol::intern(mname);
+                let mut registry = self.registry_mut();
+                for def in &composed {
+                    registry.push_user_method(owner, method_sym, def.clone());
+                }
+            }
             cx.class_def
                 .methods
                 .entry(mname.clone())

--- a/src/runtime/registration_class_compose_body.rs
+++ b/src/runtime/registration_class_compose_body.rs
@@ -282,7 +282,13 @@ impl Interpreter {
         role: &RoleDef,
         role_param_values: &HashMap<String, Value>,
     ) {
-        if let Some(parent_specs) = self.registry().role_parents.get(base_role_name).cloned() {
+        // ADR-0019 F4c-3: hoisted out of `if let Some(x) = self.registry()
+        // ....cloned() { .. }` -- see the matching comment further down in
+        // this function for why (temporary-lifetime-extension keeps the
+        // `RegistryReadGuard` alive for the whole body, which now contains a
+        // `self.registry_mut()` call).
+        let maybe_parent_specs = self.registry().role_parents.get(base_role_name).cloned();
+        if let Some(parent_specs) = maybe_parent_specs {
             for parent_spec in parent_specs {
                 let resolved_parent = if let Some(v) = role_param_values.get(&parent_spec) {
                     type_value_name(v)
@@ -312,7 +318,16 @@ impl Interpreter {
                     .split_once('[')
                     .map(|(b, _)| b)
                     .unwrap_or(resolved_parent.as_str());
-                if let Some(parent_role) = self.registry().roles.get(parent_base).cloned() {
+                // ADR-0019 F4c-3: bind the clone in its own `let` rather
+                // than `if let Some(x) = self.registry()....cloned() { ...
+                // }` -- the latter's temporary-lifetime-extension rule keeps
+                // the `RegistryReadGuard` alive for the WHOLE if-let body
+                // (not just the condition), which panics the moment that
+                // body calls `self.registry_mut()` (read -> write reentrant
+                // lock upgrade; see `lock_reentry.rs`). This is the exact
+                // hazard the F4c design note's R8 warns about.
+                let maybe_parent_role = self.registry().roles.get(parent_base).cloned();
+                if let Some(parent_role) = maybe_parent_role {
                     if !cx.out.composed_roles_list.contains(&resolved_parent) {
                         cx.out.composed_roles_list.push(resolved_parent.clone());
                     }
@@ -386,6 +401,17 @@ impl Interpreter {
                                 })
                                 .collect()
                         };
+                        // ADR-0019 F4c-3: dual-write, see
+                        // class_body_method_decl's own comment in
+                        // registration_class_body_method.rs.
+                        {
+                            let owner = Symbol::intern(cx.name);
+                            let method_sym = Symbol::intern(mname);
+                            let mut registry = self.registry_mut();
+                            for def in &composed {
+                                registry.push_user_method(owner, method_sym, def.clone());
+                            }
+                        }
                         cx.class_def
                             .methods
                             .entry(mname.clone())


### PR DESCRIPTION
## Summary
- Converts the class-declaration write sites named in the ADR-0019 F4c design note section (3) to dual-write through the F4c-2 mutator API: `cx.class_def.methods`/`class_def.methods` mutations stay exactly as before, and each site additionally calls the matching registry mutator.
- Sites converted: `registration_class_body_method.rs` (multi-candidate push, non-multi retain+push, both `HandleSpec` delegation-forwarder pushes), `registration_class_body.rs` (code-alias write), `registration_class_compose.rs`/`registration_class_compose_body.rs` (role-method composition, both direct-parent and grandparent-propagation paths), `registration_class.rs` (`apply_handle_specs`, now `&mut self` + a `class_name` param), `registration.rs` (`resolve_class_stub_requirements`'s write-back).
- `registration_class_body_attr.rs`'s merge-back hack is **deliberately NOT deleted**, despite the box's own bullet — its root cause (`.^add_method` bypassing the in-flight `ClassBodyCx`) isn't fixed until F4c-6 makes `^add_method` dual-write-aware; deleting it now would reintroduce the bug it exists to prevent.
- The periodic per-statement `sync_user_method_entries` call is left untouched — it stays the actual mechanism until F4c-9a's read cutover, so these mutator calls are additive/shadow-provable in this slice, not a behavior change.
- **Caught and fixed a real lock-reentrancy bug (design note's own R8 risk) during implementation**: `propagate_composed_role_parent_specs` had `if let Some(x) = self.registry()....cloned() { <body> }` sites where Rust's temporary-lifetime-extension rule keeps the read guard alive for the whole `if let` body — adding a `registry_mut()` call inside panicked on a same-thread read→write lock upgrade (caught cleanly by the debug-only `lock_reentry.rs` guard, not a silent deadlock). Fixed by hoisting each clone into its own `let` statement first.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] Full local `t/` suite (3182 files, 29634 tests) under `MUTSU_CHECK_METHOD_INDEX=1` — 0 index/table-drift assertions, 0 lock-reentrancy panics after the fix
- [x] 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — only the pre-existing tracked `S12-attributes/trusts.t` failure
- [x] `scripts/battery-testsuite.sh` — GATE PASSED
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)