### PR TITLE
feat(adr0019): F4c-4 -- augment family dual-write cutover

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1606,6 +1606,31 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     the fix above), the 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release; only the
     pre-existing tracked `S12-attributes/trusts.t` failure), and `scripts/battery-testsuite.sh`
     (GATE PASSED); `cargo clippy -- -D warnings` and `cargo fmt` clean.
+
+    **Progress (F4c-4, #TBD):** converted the augment family's write sites to the same dual-write
+    shape as F4c-3 -- `registration_class_augment.rs`'s method-decl push, both `handles` sites
+    (method-level and attribute-level), and `compose_role_into_augmented_class`'s role-method
+    merge; plus `types/role_mixin_class.rs::compose_mixin_role_submethods`. Confirms this box's own
+    reasoning for splitting F4c-4 from F4c-3: augment mutates the **already-registered** `ClassDef`
+    via `self.registry_mut().classes.get_mut(name)`, so `class_def` here is *always* a live
+    sub-borrow of a held write guard (not conditionally, the way F4c-3's `if let` temporaries
+    sometimes were) -- every site in this file hits the R8 hazard the moment a second registry call
+    is added inside the same block, not just the ones using the `if let Some(x) =
+    self.registry()...` shape. Two different fixes were used depending on the existing structure:
+    (a) most sites keep the original `class_def.methods` mutation block completely unchanged and
+    add a **separate, subsequent, independently-short-lived** `self.registry()`/`self.registry_mut()`
+    block after it closes (re-deriving the same decision from a fresh read where needed --
+    `compose_role_into_augmented_class`'s per-name "does the class already have a local method"
+    check re-queries `user_method_overloads` instead of reading the now-out-of-scope `class_def`);
+    (b) `compose_mixin_role_submethods` already named its write guard (`let mut registry =
+    self.registry_mut();`) rather than using an inline temporary, so its dual-write reuses that
+    *same* guard for the mutator calls once `class_def`'s borrow ends (its last use), which is
+    simpler and clearly not a new lock acquisition at all -- prefer this shape over (a) when a
+    named guard is already in scope. Verified with the full local `t/` suite (3182 files, 29634
+    tests) under `MUTSU_CHECK_METHOD_INDEX=1` (0 index/table-drift assertions, 0 lock-reentrancy
+    panics), the 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (only the pre-existing tracked
+    `S12-attributes/trusts.t` failure), and `scripts/battery-testsuite.sh` (GATE PASSED); `cargo
+    clippy -- -D warnings` and `cargo fmt` clean.
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1,5 +1,5 @@
 use super::registration_class::{
-    AttrValidationCtx, apply_resolved_handles, make_delegation_method,
+    AttrValidationCtx, ResolvedHandle, apply_resolved_handles, make_delegation_method,
 };
 use super::registration_class_body_method_forms::method_sub_form_params;
 use super::*;
@@ -294,7 +294,7 @@ impl Interpreter {
                                 .methods
                                 .entry(resolved_method_name.clone())
                                 .or_default()
-                                .push(def);
+                                .push(def.clone());
                         } else {
                             // Check for duplicate non-multi method
                             // definition. Only error if the existing
@@ -323,7 +323,36 @@ impl Interpreter {
                                 .entry(resolved_method_name.clone())
                                 .or_default();
                             entry.retain(|m| m.is_private != new_is_private);
-                            entry.push(def);
+                            entry.push(def.clone());
+                        }
+                    }
+                    // ADR-0019 F4c-4: dual-write, mirroring the block above
+                    // but on its own short-lived registry guard -- it
+                    // CANNOT share the `class_def` borrow above. Unlike
+                    // F4c-3's in-flight `ClassBodyCx`, augment mutates the
+                    // already-registered `ClassDef` in place, so `class_def`
+                    // there is a live sub-borrow of a held write guard; a
+                    // second `registry_mut()` call while it is still alive
+                    // is the R8 lock-reentrancy hazard, not a hypothetical
+                    // one (see the F4c-3 progress note for where this bit).
+                    // The conflict check itself does not need repeating: if
+                    // it would have failed, the block above already
+                    // returned `Err` before this point.
+                    if !is_lexical_only
+                        && !is_our_only
+                        && self.registry().classes.contains_key(name)
+                    {
+                        let owner = Symbol::intern(name);
+                        let method_sym = Symbol::intern(&resolved_method_name);
+                        if decl.multi {
+                            self.registry_mut().push_user_method(owner, method_sym, def);
+                        } else {
+                            let new_is_private = def.is_private;
+                            self.registry_mut()
+                                .retain_user_methods(owner, method_sym, |m| {
+                                    m.is_private != new_is_private
+                                });
+                            self.registry_mut().push_user_method(owner, method_sym, def);
                         }
                     }
                     // ADR-0019 D3-5: `our method` also registers as a
@@ -535,6 +564,27 @@ impl Interpreter {
                             }
                         }
                     }
+                    // ADR-0019 F4c-4: dual-write on a separate short-lived
+                    // guard, see this function's earlier F4c-4 comment for
+                    // why it cannot share the `class_def` borrow above.
+                    if !decl.handles.is_empty() && self.registry().classes.contains_key(name) {
+                        let owner = Symbol::intern(name);
+                        let source_attr_marker = format!("&{}", resolved_method_name);
+                        for spec in &decl.handles {
+                            let (exposed, target) = match spec {
+                                HandleSpec::Name(target) => (target, target),
+                                HandleSpec::Rename { exposed, target } => (exposed, target),
+                                HandleSpec::Wildcard
+                                | HandleSpec::Regex(_)
+                                | HandleSpec::Type(_) => continue,
+                            };
+                            self.registry_mut().push_user_method(
+                                owner,
+                                Symbol::intern(exposed),
+                                make_delegation_method(&source_attr_marker, target),
+                            );
+                        }
+                    }
                 }
                 Stmt::HasDecl { .. } => {
                     let decl = crate::opcode::CompiledAttrDecl::from_stmt(
@@ -574,6 +624,27 @@ impl Interpreter {
                             &mut class_def.methods,
                             &mut class_def.wildcard_handles,
                         );
+                    }
+                    // ADR-0019 F4c-4: dual-write on a separate short-lived
+                    // guard -- `resolved` was already computed above,
+                    // before any registry borrow, so it is safe to reuse
+                    // here without re-resolving.
+                    if self.registry().classes.contains_key(name) {
+                        let owner = Symbol::intern(name);
+                        for handle in &resolved {
+                            if let ResolvedHandle::Method {
+                                exposed,
+                                target,
+                                attr_var,
+                            } = handle
+                            {
+                                self.registry_mut().push_user_method(
+                                    owner,
+                                    Symbol::intern(exposed),
+                                    make_delegation_method(attr_var, target),
+                                );
+                            }
+                        }
                     }
                 }
                 // Sub declarations in the class body should persist across scope
@@ -662,6 +733,10 @@ impl Interpreter {
                 }
             }
         }
+        // ADR-0019 F4c-4: kept for the registry dual-write below, which
+        // cannot share the `class_def` borrow this block takes (see this
+        // file's earlier F4c-4 comments for why).
+        let all_methods_for_registry = all_methods.clone();
         if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
             for (mname, mdefs) in all_methods {
                 // Only add a role method the class does not already define
@@ -680,6 +755,24 @@ impl Interpreter {
             for attr in all_attributes {
                 if !class_def.attributes.iter().any(|a| a.name == attr.name) {
                     class_def.attributes.push(attr);
+                }
+            }
+        }
+        if self.registry().classes.contains_key(name) {
+            let owner = Symbol::intern(name);
+            for (mname, mdefs) in all_methods_for_registry {
+                let has_local = self
+                    .registry()
+                    .user_method_overloads(name, &mname)
+                    .is_some_and(|defs| defs.iter().any(|d| d.role_origin.is_none()));
+                if !has_local {
+                    let method_sym = Symbol::intern(&mname);
+                    for mut d in mdefs {
+                        if d.role_origin.is_none() {
+                            d.role_origin = Some(base_role.to_string());
+                        }
+                        self.registry_mut().push_user_method(owner, method_sym, d);
+                    }
                 }
             }
         }

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -209,6 +209,8 @@ impl Interpreter {
             return;
         }
         self.clear_private_zeroarg_method_cache();
+        // ADR-0019 F4c-4: kept for the registry dual-write below.
+        let composed_for_registry = composed.clone();
         let mut registry = self.registry_mut();
         let Some(class_def) = registry.classes.get_mut(class_name) else {
             return;
@@ -219,6 +221,18 @@ impl Interpreter {
                 .entry(method_name)
                 .or_default()
                 .extend(defs);
+        }
+        // Dual-write via the SAME already-held `registry` guard -- not a
+        // fresh `self.registry_mut()` call. `class_def`'s borrow ended
+        // with the loop above (its last use), so this is just another
+        // method call on `registry`, not a reentrant lock acquisition
+        // (the R8 hazard other F4c-4 sites in this ADR box hit).
+        let owner = Symbol::intern(class_name);
+        for (method_name, defs) in composed_for_registry {
+            let method_sym = Symbol::intern(&method_name);
+            for def in defs {
+                registry.push_user_method(owner, method_sym, def);
+            }
         }
         drop(registry);
         // These submethods are added after register_class_decl has compiled the


### PR DESCRIPTION
## Summary
- Converts the augment write sites named in the ADR-0019 F4c design note section (3) to dual-write through the F4c-2 mutator API, mirroring F4c-3's approach for the class-declaration family: `registration_class_augment.rs`'s method-decl push (multi and non-multi), both `handles` sites (method-level and attribute-level), `compose_role_into_augmented_class`'s role-method merge, and `types/role_mixin_class.rs::compose_mixin_role_submethods`.
- Augment mutates the **already-registered** `ClassDef` in place (`self.registry_mut().classes.get_mut(name)`), unlike F4c-3's in-flight `ClassBodyCx` — so `class_def` here is *always* a live sub-borrow of a held write guard. Adding a second registry call inside the same block hits the R8 lock-reentrancy hazard unconditionally, not just when an `if let` temporary happens to extend a guard's lifetime (the shape F4c-3 hit).
- Two fixes used depending on existing structure: most sites keep the original `class_def.methods` mutation block untouched and add a **separate, independently short-lived** registry block after it closes (re-deriving the same decision from a fresh read where needed); `compose_mixin_role_submethods` already named its write guard, so its dual-write reuses that *same* guard once `class_def`'s borrow ends — simpler, and provably not a new lock acquisition.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] Full local `t/` suite (3182 files, 29634 tests) under `MUTSU_CHECK_METHOD_INDEX=1` — 0 index/table-drift assertions, 0 lock-reentrancy panics
- [x] 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — only the pre-existing tracked `S12-attributes/trusts.t` failure
- [x] `scripts/battery-testsuite.sh` — GATE PASSED
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)