### PR TITLE
fix: three typed-exception gaps found via the vendor-real-Test campaign

### DIFF
--- a/src/runtime/registration_class_validate.rs
+++ b/src/runtime/registration_class_validate.rs
@@ -136,10 +136,13 @@ impl Interpreter {
                 continue;
             }
             if resolved_parent == name {
-                return Err(RuntimeError::new(format!(
-                    "X::Inheritance::SelfInherit: class '{}' cannot inherit from itself",
-                    name
-                )));
+                let mut attrs = HashMap::new();
+                attrs.insert("name".to_string(), Value::str(name.to_string()));
+                attrs.insert(
+                    "message".to_string(),
+                    Value::str(format!("'{}' cannot inherit from itself.", name)),
+                );
+                return Err(RuntimeError::typed("X::Inheritance::SelfInherit", attrs));
             }
             if !self.registry().classes.contains_key(base_parent)
                 && !BUILTIN_TYPES.contains(&base_parent)

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1863,8 +1863,10 @@ impl Interpreter {
         register_x("X::Dynamic::NotFound", "Exception");
         register_x("X::IO::Unlink", "Exception");
         register_x("X::IllegalDimensionInShape", "Exception");
+        register_x("X::Inheritance::SelfInherit", "Exception");
         register_x("X::Inheritance::UnknownParent", "Exception");
         register_x("X::Mixin::NotComposable", "Exception");
+        register_x("X::Parameter::BadType", "X::Parameter");
         register_x("X::NoZeroArgMeaning", "Exception");
         register_x("X::Numeric::CannotConvert", "Exception");
         register_x("X::Numeric::DivideByZero", "Exception");

--- a/src/runtime/system_eval_names.rs
+++ b/src/runtime/system_eval_names.rs
@@ -651,7 +651,9 @@ impl Interpreter {
 
     fn collect_declared_routine_names(stmt: &Stmt, out: &mut HashSet<String>) {
         match stmt {
-            Stmt::SubDecl { name, .. } | Stmt::MethodDecl { name, .. } => {
+            Stmt::SubDecl { name, .. }
+            | Stmt::MethodDecl { name, .. }
+            | Stmt::ProtoDecl { name, .. } => {
                 out.insert(name.resolve());
             }
             Stmt::EnumDecl { name, variants, .. } => {

--- a/todo/tickets/parameter-badtype-order-dependent-under-many-prior-evals.md
+++ b/todo/tickets/parameter-badtype-order-dependent-under-many-prior-evals.md
@@ -1,0 +1,75 @@
+# `X::Parameter::BadType` (package-as-type) stops firing after ~47 prior `throws-like` EVALs in the same file
+
+## Repro
+
+Found while working `todo/tickets/vendor-real-test-module.md`'s
+`roast/S32-exceptions/misc.t` gap list. The isolated two-line case works
+fine:
+
+```
+$ MUTSU_REAL_TEST=1 target/debug/mutsu -I modules/Rakudo-Core/lib -e '
+use Test;
+plan 2;
+throws-like q[my package A {}; my A $a;], X::Syntax::Variable::BadType;
+throws-like q[my package A {}; sub foo(A $a) { }], X::Parameter::BadType;
+'
+# both pass
+```
+
+But the SAME two lines, run as `roast/S32-exceptions/misc.t` lines 226-227
+after the file's preceding ~47 `throws-like`/other subtests have already
+run, fail — the second `throws-like` no longer dies at all (its code, `my
+package A {}; sub foo(A $a) { }`, silently succeeds where it should raise
+`X::Parameter::BadType`):
+
+```
+$ head -229 roast/S32-exceptions/misc.t > /tmp/t.t   # (run from roast/S32-exceptions/ so
+                                                       #  $*PROGRAM.parent(2) resolves)
+$ echo 'done-testing;' >> /tmp/t.t
+$ MUTSU_REAL_TEST=1 MUTSU_FUDGE=1 target/debug/mutsu -I modules/Rakudo-Core/lib /tmp/t.t
+...
+    not ok 1 - 'my package A {}; sub foo(A $a) { }' died
+```
+
+Bisected the *minimum trigger* by prepending truncated prefixes of the real
+file: appending the test's own two lines after `head -226` of the real file
+passes; appending them after `head -227` (i.e. running the file's own real
+line 227, `throws-like 'my package A {}; my A $a;',
+X::Syntax::Variable::BadType;`, for real before the target test) fails. So
+the trigger needs the REAL preceding ~226 lines of file state — not
+reproducible from the two lines alone, even including that exact preceding
+`throws-like` call, tried standalone above and it still passed.
+
+## Hypothesis (not confirmed)
+
+`misc.t` reuses generic single-letter names (`A`, `foo`, etc.) across many
+of its 182 independent `throws-like`-EVAL'd snippets. Working guess: some
+global counter or cache used to disambiguate/uniquify a lexically-scoped
+`package`/`class` declared inside an `EVAL` (needed so `A` in EVAL #40
+doesn't collide with `A` in EVAL #5) wraps around, saturates, or otherwise
+produces a colliding key after enough EVALs have run in the same process,
+so by EVAL #47ish a *fresh* `package A {}` gets silently treated as
+already-known (skipping the type-check pre-pass that raises
+`X::Parameter::BadType`) instead of being freshly registered. Not
+investigated further — the accumulated-state repro is expensive to run
+(the full preceding subtest sequence) and no smaller trigger was found in
+the time available this round.
+
+## Where this was found
+
+`todo/tickets/vendor-real-test-module.md`'s ongoing `roast/S32-exceptions/misc.t`
+gap-closing (this round also fixed the `X::Inheritance::SelfInherit`
+missing `.name` attribute, the EVAL-compiled `proto sub` being invisible to
+`check_eval_undeclared_routines`'s `X::TypeCheck::Argument` path, and
+`X::Parameter::BadType` itself missing from `register_x` — see that
+ticket's latest round entry). This is the one remaining gap in that file
+that looked deep enough to file separately rather than keep digging in the
+same session.
+
+## Suggested next step
+
+Reproduce with a synthetic loop (`for ^60 { EVAL('package A {}; ...') }`,
+varying what runs between iterations) to find the actual saturation
+trigger without needing the full roast file, then trace whatever counter/
+cache is implicated with `rust-gdb` breakpoints per CLAUDE.md's debugging
+guidance.

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1313,3 +1313,77 @@ still-open `sub foo() returns !!!wtf??? { }` malformed-return-type gap named
 in the previous entry) — each its own individual diagnosis, not yet picked
 up. Full `t/` suite (3176 files, 29594 tests) and `cargo clippy -- -D
 warnings` both clean.
+
+## Three more gaps closed in `misc.t`; `X::ControlFlow::Return` traced to an already-filed deep bug (2026-08-16)
+
+Continued picking off `misc.t`'s remaining 6 individual assertion gaps
+(under `MUTSU_REAL_TEST=1`). Down from 6 to 3 unresolved after this round:
+
+1. **`X::Inheritance::SelfInherit` (`my class Foobar is Foobar { }`), fixed.**
+   Raised via a bare `RuntimeError::new(format!(...))` — an untyped message,
+   not a typed exception at all — so `throws-like`'s `name => "Foobar"`
+   matcher read `.name` as `Nil`. Switched the throw site
+   (`registration_class_validate.rs`) to `RuntimeError::typed` with a `name`
+   attribute (verified against real `raku`'s `.name`/`.message` for this
+   exact class) and registered the class via `register_x` in
+   `runtime_init.rs` (it had no registry entry at all — every other
+   `X::Inheritance::*` sibling did).
+
+2. **`proto sub foo(Str) {*}; foo 42;` inside `EVAL`, fixed.** mutsu correctly
+   raises `X::TypeCheck::Argument` for this shape when compiled as the
+   program's own mainline — but under `EVAL` (what `throws-like` uses), it
+   died with a false `X::Undeclared::Symbols: Undeclared routine: foo`
+   instead. Root cause: `proto sub` parses to a *distinct* AST node,
+   `Stmt::ProtoDecl` — not `Stmt::SubDecl` — and
+   `system_eval_names.rs`'s `check_eval_undeclared_routines` (the
+   EVAL-specific "is every called name declared here" pre-pass) only added
+   `Stmt::SubDecl`/`Stmt::MethodDecl` names to its `declared` set, so a
+   proto-only sub was invisible to it. (The sibling mainline check in
+   `undeclared_routines.rs` already had a `Stmt::ProtoDecl` arm — this is
+   why the exact same code worked outside `EVAL`.) Added the missing arm.
+
+3. **`X::Parameter::BadType` (`my package A {}; sub foo(A $a) { }`) — the
+   general fix landed, but the roast subtest still has an unresolved,
+   order-dependent gap (see below).** The throw site
+   (`registration_sub.rs`) already correctly built `RuntimeError::typed`
+   with the right message and a `type` attribute — same "typed but never
+   registered" shape as gap 1 — but `X::Parameter::BadType` had no
+   `register_x` entry either. Registered it (parented on the pre-existing
+   `X::Parameter`). Verified in isolation against real `raku` — fixed. BUT:
+   the exact roast subtest at `misc.t` line 227 only reproduces the bug
+   after the file's preceding ~226 lines/~47 subtests have run for real; a
+   standalone repro of the same two lines (with or without the immediately
+   preceding sibling `throws-like` in the file) passes cleanly. This smells
+   like a *different*, order-dependent leak (something saturates or
+   collides after enough `EVAL`s reuse the same short class/package names,
+   `A` in this case) — filed separately as
+   `todo/tickets/parameter-badtype-order-dependent-under-many-prior-evals.md`
+   rather than chased further in this session, since the minimum repro
+   needs the full accumulated state and none of the usual bisection tricks
+   shrank it.
+
+4. **`X::ControlFlow::Return` (`gather { return  1}` via `EVAL`) — traced,
+   not fixed; already filed as a deep architectural bug in the previous
+   session** (`todo/deep/return-outside-routine-uncatchable-inside-nested-run.md`):
+   the escaping `return`'s conversion into a catchable
+   `X::ControlFlow::Return` is gated on `nested_run_depth == 0`, which is
+   never true inside `EVAL`'s nested run, so the raw control-flow signal
+   passes straight through `try`/`CATCH` and aborts the program instead.
+   Confirmed this is the same failure `misc.t` line 280 hits; no new work
+   done here this round, left for that ticket's own "needs design" path.
+
+**Remaining after this round:** the `X::Comp::Group` cases (an undeclared
+type in a `when` clause, and a bare `5.` term needing a method name — both
+rakudo parser-ambiguity diagnostics, not simple "detect X and throw Y"
+fixes), the malformed-return-type gap (`sub foo() returns !!!wtf??? { }`,
+also `X::Syntax::Malformed` vs mutsu's generic `X::Syntax::Confused`), the
+order-dependent `X::Parameter::BadType` leak (ticket above), and
+`X::ControlFlow::Return` (deep ticket above) — 5 items, none picked up yet.
+
+Full `t/` suite (3183 files, 29636 tests), `cargo build --release`, and
+`cargo clippy -- -D warnings` all clean. Verified the 3 whitelisted files
+touched by these changes (`roast/S32-exceptions/misc.t`,
+`roast/S12-class/self-inheritance.t`, `roast/S02-types/WHICH.t`) still pass
+under the *default* (native `Test`) mode too, since the `register_x`
+registrations and `RuntimeError::typed` conversions are not gated on
+`MUTSU_REAL_TEST`.


### PR DESCRIPTION
## Summary

Continuing `todo/tickets/vendor-real-test-module.md`'s
`roast/S32-exceptions/misc.t` gap-closing under `MUTSU_REAL_TEST=1`:

1. **`X::Inheritance::SelfInherit`** (`my class Foobar is Foobar { }`) was
   raised via a bare untyped `RuntimeError`, so `.name` read `Nil`.
   Switched to `RuntimeError::typed` with a `name` attribute (verified
   against real `raku`) and registered the class via `register_x` — it had
   no registry entry at all, unlike every sibling `X::Inheritance::*` class.

2. **`proto sub foo(Str) {*}; foo 42;` inside `EVAL`** raised a false
   `X::Undeclared::Symbols` instead of `X::TypeCheck::Argument`. `proto sub`
   parses to `Stmt::ProtoDecl`, not `Stmt::SubDecl`, and
   `check_eval_undeclared_routines`'s declared-name collector only knew
   about `SubDecl`/`MethodDecl`, so a proto-only sub was invisible to it
   under `EVAL` (the same construct already worked outside `EVAL`, since
   the sibling mainline check already had the `ProtoDecl` arm).

3. **`X::Parameter::BadType`** (`my package A {}; sub foo(A $a) { }`) was
   already correctly built via `RuntimeError::typed` at its throw site, but
   the class itself was never registered via `register_x` — same "typed but
   unregistered" shape as (1). Registered it. The isolated case is fully
   fixed and verified against `raku`; the exact roast subtest still has an
   unrelated, order-dependent gap only reproducible after ~47 prior `EVAL`s
   in the same file, filed separately as
   `todo/tickets/parameter-badtype-order-dependent-under-many-prior-evals.md`.

Also traced (but did not need to fix — already filed as a deep
architectural bug in a previous session) the remaining
`X::ControlFlow::Return` gap in the same file to
`todo/deep/return-outside-routine-uncatchable-inside-nested-run.md`.

## Test plan

- [x] Full `t/` suite (3183 files) clean on debug and release
- [x] `cargo clippy -- -D warnings`, `cargo fmt`
- [x] Verified the three whitelisted roast files these changes touch
      (`S32-exceptions/misc.t`, `S12-class/self-inheritance.t`,
      `S02-types/WHICH.t`) still pass under the *default* native-`Test`
      mode, since none of these fixes are gated on `MUTSU_REAL_TEST`
- [x] Broader sweep: `roast/S32-exceptions/`, `roast/S12-class/`,
      `roast/S02-types/WHICH.t` on release — only pre-existing,
      non-whitelisted `open_closed.t` fails (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)