### PR TITLE
feat(adr0019): F4c-5 -- role pun / mixin class dual-write cutover

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1631,6 +1631,32 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     panics), the 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (only the pre-existing tracked
     `S12-attributes/trusts.t` failure), and `scripts/battery-testsuite.sh` (GATE PASSED); `cargo
     clippy -- -D warnings` and `cargo fmt` clean.
+
+    **Progress (F4c-5, #TBD):** converted the role-pun/mixin-class family. `ensure_role_punned_to_
+    class`'s (formerly `ensure_role_pun_class` in this bullet's own text -- renamed since) fresh
+    `ClassDef` insert now also dual-writes every composed method through `set_user_methods` (no
+    R8 hazard here: it is a brand-new registry row, not a mutation of an already-borrowed one).
+    `withdraw_role_pun` now calls `clear_user_methods_for_owner` + `sync_accessor_entries`
+    directly instead of `sync_user_method_entries` -- behaviorally identical today (with the
+    `classes.remove` immediately above, the old call would only ever take its "pure clear"
+    early-return path, which already *is* exactly those two calls per the F4c-2 rewrite) and
+    forward-looking for F4c-9b's eventual deletion of `sync_user_method_entries` itself.
+    `rename_generic_composed_class` now calls `rename_method_owner` for the user-method column
+    (replacing the old "sync old, sync new" idiom) plus the same `sync_accessor_entries` pair as
+    before for the accessor column (no owner-rename mutator exists for that column by design --
+    it stays keyed off `ClassDef::attributes`). `types/role_mixin_class.rs:305-312`, named in this
+    bullet's own text, turned out to be stale -- that file's only `class_def.methods` write
+    (`compose_mixin_role_submethods`) was already converted in F4c-4; grepping the whole file for
+    `.methods` confirms nothing else touches it. This slice also retired the now-satisfied
+    `#[allow(dead_code)]` markers on `push_user_method`, `retain_user_methods`,
+    `remove_user_methods`, and `user_method_rows_for_owner` in `registry_method_table.rs` --
+    `map_user_methods_in_place` and `restore_user_method_rows` (F4c-3's `compile_class_methods`
+    site and F4c-8's rollback, respectively) remain the only unused mutators. Verified with the
+    full local `t/` suite (3183 files, 29636 tests) under `MUTSU_CHECK_METHOD_INDEX=1` (0
+    index/table-drift assertions, 0 lock-reentrancy panics), the 312-file
+    `S04`/`S06`/`S09`/`S12`/`S14` roast subset (only the pre-existing tracked
+    `S12-attributes/trusts.t` failure), and `scripts/battery-testsuite.sh` (GATE PASSED); `cargo
+    clippy -- -D warnings` and `cargo fmt` clean.
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -206,7 +206,16 @@ impl Interpreter {
         self.registry_mut().classes.remove(role_name);
         self.registry_mut().hidden_classes.remove(role_name);
         self.registry_mut().class_composed_roles.remove(role_name);
-        self.registry_mut().sync_user_method_entries(role_name);
+        // ADR-0019 F4c-5: calls the mutator API directly instead of
+        // `sync_user_method_entries(role_name)` -- equivalent today (with
+        // `classes.remove` just above, that call would only take its
+        // "pure clear" early-return path, which is exactly
+        // `clear_user_methods_for_owner` + `sync_accessor_entries` per the
+        // F4c-2 rewrite), and forward-looking for F4c-9b's eventual
+        // deletion of `sync_user_method_entries` itself.
+        let owner = Symbol::intern(role_name);
+        self.registry_mut().clear_user_methods_for_owner(owner);
+        self.registry_mut().sync_accessor_entries(owner);
         self.clear_private_zeroarg_method_cache();
         self.native_ctor_plan_cache.clear();
     }

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1207,6 +1207,8 @@ impl Interpreter {
                 }
             }
         }
+        // ADR-0019 F4c-5: kept for the registry dual-write below.
+        let all_methods_for_registry = all_methods.clone();
         let punned_class = ClassDef {
             parents: Vec::new(),
             attributes: all_attributes,
@@ -1223,6 +1225,15 @@ impl Interpreter {
         self.registry_mut()
             .classes
             .insert(role_name.to_string(), punned_class);
+        // Dual-write the pun's methods through the mutator API too -- this
+        // is a brand-new `ClassDef` (not a mutation of an already-borrowed
+        // one), so there is no R8 held-guard hazard here; each
+        // `set_user_methods` call is its own short-lived guard.
+        let owner = Symbol::intern(role_name);
+        for (name, defs) in all_methods_for_registry {
+            self.registry_mut()
+                .set_user_methods(owner, Symbol::intern(&name), defs);
+        }
         // Register the role and its composed roles
         self.registry_mut()
             .class_composed_roles

--- a/src/runtime/registration_class_compose_body.rs
+++ b/src/runtime/registration_class_compose_body.rs
@@ -42,8 +42,20 @@ impl Interpreter {
         let mut def = self.registry_mut().classes.remove(old_name)?;
         def.mro = std::sync::Arc::from(Vec::<Symbol>::new());
         self.registry_mut().classes.insert(new_name.clone(), def);
-        self.registry_mut().sync_user_method_entries(old_name);
-        self.registry_mut().sync_user_method_entries(&new_name);
+        // ADR-0019 F4c-5: `rename_method_owner` replaces the old "sync old
+        // (clears via the pure-clear path), sync new (re-derives from
+        // `def.methods`)" idiom for the user-method column; the accessor
+        // column has no owner-rename mutator (design: it stays keyed off
+        // `ClassDef::attributes`, which the `classes.insert` above already
+        // moved to `new_name`), so it still goes through the same
+        // `sync_accessor_entries` calls the old `sync_user_method_entries`
+        // pair made internally.
+        let old_owner = Symbol::intern(old_name);
+        let new_owner = Symbol::intern(&new_name);
+        self.registry_mut()
+            .rename_method_owner(old_owner, new_owner);
+        self.registry_mut().sync_accessor_entries(old_owner);
+        self.registry_mut().sync_accessor_entries(new_owner);
         if self.user_declared_classes.remove(old_name) {
             self.user_declared_classes.insert(new_name.clone());
         }

--- a/src/runtime/registry_method_table.rs
+++ b/src/runtime/registry_method_table.rs
@@ -5,19 +5,18 @@
 //! note's own reasoning for `registry_method_table.rs`).
 //!
 //! `Registry::owner_method_names` (the field) is declared on `registry.rs`;
-//! every read AND write goes through this file's API instead. As of F4c-2
-//! the only caller of the write side is still `registry.rs`'s
-//! `sync_user_method_entries` (routed through these mutators rather than
-//! inlining the retain/re-populate logic it used to) — F4c-3 onward moves
-//! individual class-declaration/augment/MOP write sites onto this API
-//! directly, per the ADR-0019 F4c design note section (3)'s ordered slices.
-//! Mutators not yet called by production code outside `sync_user_method_
-//! entries` (`push_user_method`, `retain_user_methods`, `remove_user_
-//! methods`, `rename_method_owner`, `map_user_methods_in_place`, `user_
-//! method_rows_for_owner`, `restore_user_method_rows`) are `#[allow(dead_
-//! code)]` until their slice lands, and are exercised by this file's own
-//! unit tests per design note (5) R2's mitigation ("a unit test per mutator
-//! for the `registry.rs:361-365` liveness interaction").
+//! every read AND write goes through this file's API instead. `registry.rs`'s
+//! `sync_user_method_entries` was the first caller (F4c-2, routed through
+//! these mutators rather than inlining the retain/re-populate logic it used
+//! to); F4c-3 (class-declaration family), F4c-4 (augment family), and F4c-5
+//! (role pun / mixin classes) have since moved their own write sites onto
+//! this API directly, per the ADR-0019 F4c design note section (3)'s ordered
+//! slices. `map_user_methods_in_place` and `restore_user_method_rows` remain
+//! `#[allow(dead_code)]` until F4c-3's `compile_class_methods` site and
+//! F4c-8's snapshot/rollback land respectively; every mutator (used or not
+//! yet) is exercised by this file's own unit tests per design note (5) R2's
+//! mitigation ("a unit test per mutator for the `registry.rs:361-365`
+//! liveness interaction").
 //!
 //! Every mutator bumps `method_generation` on its own call, per design note
 //! (3) ("Every mutator ... bumps `method_generation`"). This is a
@@ -187,7 +186,6 @@ impl Registry {
     /// Appends one candidate to `(owner, name)`'s user candidate list -- the
     /// `multi` declaration case, where a later declaration adds a candidate
     /// rather than replacing the row.
-    #[allow(dead_code)] // ADR-0019 F4c-3 wires this into the class-body `multi` write site.
     pub(crate) fn push_user_method(&mut self, owner: Symbol, name: Symbol, def: MethodDef) {
         let key = MethodEntryKey { owner, name };
         self.method_entries
@@ -204,7 +202,6 @@ impl Registry {
     /// privacy-preserving non-`multi` replace
     /// (`registration_class_body_method.rs:219-222`'s current shape). A
     /// no-op if the row does not exist.
-    #[allow(dead_code)] // ADR-0019 F4c-3 wires this into the class-body non-multi replace site.
     pub(crate) fn retain_user_methods(
         &mut self,
         owner: Symbol,
@@ -226,7 +223,6 @@ impl Registry {
     }
 
     /// Clears `(owner, name)`'s user candidate list entirely.
-    #[allow(dead_code)] // ADR-0019 F4c-3 wires this into `withdraw_role_pun`-style single-row clears.
     pub(crate) fn remove_user_methods(&mut self, owner: Symbol, name: Symbol) {
         self.set_user_methods(owner, name, Vec::new());
     }
@@ -259,7 +255,6 @@ impl Registry {
     /// are gone afterward; any pre-existing `new`-owned row with the same
     /// name is overwritten, matching `set_user_methods`' own replace
     /// semantics.
-    #[allow(dead_code)] // ADR-0019 F4c-5 wires this into role-pun renaming.
     pub(crate) fn rename_method_owner(&mut self, old: Symbol, new: Symbol) {
         let rows = self.user_method_rows_for_owner(old);
         self.clear_user_methods_for_owner(old);
@@ -296,7 +291,6 @@ impl Registry {
     /// Snapshots every user-owned row `owner` currently has, for rollback
     /// (ADR-0019 F4c design note (4)'s `ClassRegSnapshot`/EVAL-rollback
     /// mechanisms). `MethodDef` clones are shallow (`body` is an `Arc`).
-    #[allow(dead_code)] // ADR-0019 F4c-8 wires this into snapshot/rollback.
     pub(crate) fn user_method_rows_for_owner(
         &self,
         owner: Symbol,


### PR DESCRIPTION
## Summary
- Converts the role-pun/mixin-class family named in the ADR-0019 F4c design note section (3):
  - `registration_class_augment.rs::ensure_role_punned_to_class`: the fresh `ClassDef` insert now also dual-writes every composed method through `set_user_methods` (no R8 hazard — a brand-new registry row, not a mutation of an already-borrowed one).
  - `methods_object_dispatch_new.rs::withdraw_role_pun`: now calls `clear_user_methods_for_owner` + `sync_accessor_entries` directly instead of `sync_user_method_entries` — behaviorally identical today, forward-looking for F4c-9b.
  - `registration_class_compose_body.rs::rename_generic_composed_class`: now calls `rename_method_owner` for the user-method column (replacing the old "sync old, sync new" idiom) plus the same `sync_accessor_entries` pair for the accessor column.
- `types/role_mixin_class.rs:305-312`, named in the design note's own text, turned out to be stale — that file's only `class_def.methods` write (`compose_mixin_role_submethods`) was already converted in F4c-4.
- Retires the now-satisfied `#[allow(dead_code)]` markers on `push_user_method`, `retain_user_methods`, `remove_user_methods`, and `user_method_rows_for_owner` in `registry_method_table.rs` — `map_user_methods_in_place` and `restore_user_method_rows` remain the only unused mutators (F4c-3's `compile_class_methods` site and F4c-8's rollback, respectively).

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] Full local `t/` suite (3183 files, 29636 tests) under `MUTSU_CHECK_METHOD_INDEX=1` — 0 index/table-drift assertions, 0 lock-reentrancy panics
- [x] 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — only the pre-existing tracked `S12-attributes/trusts.t` failure
- [x] `scripts/battery-testsuite.sh` — GATE PASSED
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)