### PR TITLE
fix(parser): returns/of trait with unparseable type raises X::Syntax::Malformed

### DIFF
--- a/src/parser/stmt/sub/traits.rs
+++ b/src/parser/stmt/sub/traits.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+/// A `returns`/`of` trait whose type-name expression fails to parse at all
+/// (`sub foo() returns !!!wtf??? { }`) is rakudo's `X::Syntax::Malformed:
+/// Malformed trait` — not the generic "Confused" the unconverted parse error
+/// would otherwise surface as. Mirrors `malformed_initializer`'s contract
+/// (`stmt/decl/my_decl_assign.rs`): only convert an error that failed
+/// immediately (no partial parse to prefer) and isn't already a fatal or
+/// structured-exception error.
+fn malformed_trait(err: PError, type_input: &str) -> PError {
+    let failed_immediately = err.remaining_len.is_none_or(|len| len >= type_input.len());
+    if err.exception.is_some() || err.is_fatal() || !failed_immediately {
+        return err;
+    }
+    PError::malformed("trait")
+}
+
 /// Parse the type named by `returns` / `of` / `-->`, including a coercion type's
 /// parenthesized source: `Str`, `Str()`, `Int(Str)`. Without this, `returns Str()`
 /// stopped at the `(` and the trailing `()` was left to be parsed as a sub body.
@@ -265,7 +280,7 @@ pub(crate) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
         }
         if let Some(r) = keyword("returns", r) {
             let (r, _) = ws(r)?;
-            let (r, type_name) = parse_trait_type_name(r)?;
+            let (r, type_name) = parse_trait_type_name(r).map_err(|e| malformed_trait(e, r))?;
             return_type = Some(type_name);
             // Mark that the return type came from a `returns`/`of` trait (not a
             // `-->` signature arrow): an undeclared one is X::InvalidType, while
@@ -278,7 +293,7 @@ pub(crate) fn parse_sub_traits(mut input: &str) -> PResult<'_, SubTraits> {
         }
         if let Some(r) = keyword("of", r) {
             let (r, _) = ws(r)?;
-            let (r, type_name) = parse_trait_type_name(r)?;
+            let (r, type_name) = parse_trait_type_name(r).map_err(|e| malformed_trait(e, r))?;
             // `of` parameterizes a preceding `returns`/role type, e.g.
             // `returns Positional of Int` means return type `Positional[Int]`.
             return_type = Some(match return_type {

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1375,10 +1375,8 @@ Continued picking off `misc.t`'s remaining 6 individual assertion gaps
 **Remaining after this round:** the `X::Comp::Group` cases (an undeclared
 type in a `when` clause, and a bare `5.` term needing a method name — both
 rakudo parser-ambiguity diagnostics, not simple "detect X and throw Y"
-fixes), the malformed-return-type gap (`sub foo() returns !!!wtf??? { }`,
-also `X::Syntax::Malformed` vs mutsu's generic `X::Syntax::Confused`), the
-order-dependent `X::Parameter::BadType` leak (ticket above), and
-`X::ControlFlow::Return` (deep ticket above) — 5 items, none picked up yet.
+fixes), the order-dependent `X::Parameter::BadType` leak (ticket above), and
+`X::ControlFlow::Return` (deep ticket above) — 3 items, none picked up yet.
 
 Full `t/` suite (3183 files, 29636 tests), `cargo build --release`, and
 `cargo clippy -- -D warnings` all clean. Verified the 3 whitelisted files
@@ -1387,3 +1385,27 @@ touched by these changes (`roast/S32-exceptions/misc.t`,
 under the *default* (native `Test`) mode too, since the `register_x`
 registrations and `RuntimeError::typed` conversions are not gated on
 `MUTSU_REAL_TEST`.
+
+## `sub foo() returns !!!wtf??? { }` malformed-return-type gap, fixed (2026-08-16)
+
+Picked up the malformed-return-type item this round's earlier entry left
+open. A `returns`/`of` trait whose type-name expression fails to parse at
+all (`!!!wtf???` doesn't start with an identifier character) propagated the
+generic parse error unconverted, surfacing as `X::Syntax::Confused` instead
+of rakudo's `X::Syntax::Malformed: Malformed trait`. Fixed in
+`src/parser/stmt/sub/traits.rs`: added `malformed_trait()`, mirroring the
+existing `malformed_initializer()` helper's contract
+(`stmt/decl/my_decl_assign.rs`) — only converts an error that failed
+*immediately* with no partial parse, and leaves an already-fatal or
+structured-exception error alone — and wired it into both the `returns` and
+`of` trait branches (verified against real `raku`: both give "Malformed
+trait"; `-->` gives a different, unrelated "Missing block" error via a
+different grammar path and was left untouched). Full `t/` suite (3183
+files), `cargo build --release`, `cargo clippy -- -D warnings` clean;
+targeted sweep of all 93 whitelisted `S06-signature`/`S06-traits` files
+(the area most likely to exercise `returns`/`of` traits) plus
+`S32-exceptions/misc.t` on release, all pass.
+
+**Remaining: 3 items** (the two `X::Comp::Group` parser-ambiguity cases, the
+order-dependent `X::Parameter::BadType` leak, and the deep
+`X::ControlFlow::Return` ticket) — none picked up yet.


### PR DESCRIPTION
## Summary

Continuing `todo/tickets/vendor-real-test-module.md`'s
`roast/S32-exceptions/misc.t` gap-closing:

`sub foo() returns !!!wtf??? { }` left the raw parse-error from parsing the
type-name expression after `returns`/`of` propagate unconverted, surfacing
as generic `X::Syntax::Confused` instead of rakudo's `X::Syntax::Malformed:
Malformed trait`. Added `malformed_trait()` in
`src/parser/stmt/sub/traits.rs`, mirroring the existing
`malformed_initializer()` helper's careful contract (only convert an error
that failed *immediately*, with no partial parse to prefer, and leave an
already-fatal/structured-exception error alone), and wired it into both the
`returns` and `of` trait branches. `-->`'s different grammar path was left
alone (verified against real `raku` it gives a different, unrelated
"Missing block" error).

## Test plan

- [x] Verified against real `raku` for both `returns`/`of` (both:
      `X::Syntax::Malformed: Malformed trait`) and `-->` (different error,
      untouched)
- [x] Full `t/` suite (3183 files) clean
- [x] `cargo clippy -- -D warnings`, `cargo fmt`
- [x] `roast/S32-exceptions/misc.t` under `MUTSU_REAL_TEST=1` — this
      assertion no longer fails
- [x] All 93 whitelisted `S06-signature`/`S06-traits` files (return-type-
      heavy area) plus `S32-exceptions/misc.t` on release — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)