### PR TITLE
feat(adr0019): F4c-6 -- runtime-reflective MOP family dual-write cutover

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1657,6 +1657,36 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     `S04`/`S06`/`S09`/`S12`/`S14` roast subset (only the pre-existing tracked
     `S12-attributes/trusts.t` failure), and `scripts/battery-testsuite.sh` (GATE PASSED); `cargo
     clippy -- -D warnings` and `cargo fmt` clean.
+
+    **Progress (F4c-6, #TBD):** converted the runtime-reflective MOP family --
+    `methods_classhow_dispatch.rs`'s `^add_method` (including the "create a stub `ClassDef`"
+    branch, which needed no separate handling: the dual-write call works purely against
+    `method_entries`/`owner_method_names`, independent of whether `self.classes` already had a row)
+    and `^add_multi_method`, plus `system.rs`'s BEGIN-time method-statement injection. Same
+    separate-short-lived-guard shape as F4c-4/F4c-5's `if let Some(class_def) =
+    self.registry_mut().classes.get_mut(...)` sites.
+
+    **Correction to this box's own stated payoff:** the bullet frames F4c-6 as what "the F4c-3
+    merge-back deletion depends on" -- landing this slice does NOT make deleting
+    `registration_class_body_attr.rs`'s merge-back safe, and it stays in place. The merge-back's
+    job is to pull a `.^add_method`-installed method back into `cx.class_def` before body
+    processing's own periodic `sync_user_method_entries` call re-derives the registry from that
+    local snapshot -- and that periodic full-clear-then-repopulate-from-`class_def.methods` call is
+    *itself* untouched through the whole F4c-3..F4c-8 bridge (per F4c-3's own progress note: it
+    stays the actual mechanism, not just an assertion, until F4c-9a). So even with `^add_method` now
+    ALSO writing through `set_user_methods`, the very next per-statement sync (which knows nothing
+    about that out-of-band write, only about `cx.class_def.methods`) unconditionally clears and
+    re-derives the owner's rows from the still-unaware local snapshot, silently dropping it again --
+    identically to before this slice. The merge-back can only go away once F4c-9b actually removes
+    `class_def.methods`/`sync_user_method_entries`, leaving `method_entries` as the only place left
+    to write. Verified this holds by re-running the merge-back's own regression coverage (the role
+    pun / `is predicate`-flavored `t/` files already in the standard sweep below) with no change in
+    outcome, confirming the guard is still load-bearing. Verified with the full local `t/` suite
+    (3183 files, 29636 tests) under `MUTSU_CHECK_METHOD_INDEX=1` (0 index/table-drift assertions, 0
+    lock-reentrancy panics), the 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (only the
+    pre-existing tracked `S12-attributes/trusts.t` failure), and `scripts/battery-testsuite.sh`
+    (GATE PASSED, including OO::Monitors which exercises `^add_method` via `EXPORTHOW::DECLARE`);
+    `cargo clippy -- -D warnings` and `cargo fmt` clean.
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -869,11 +869,20 @@ impl Interpreter {
                         },
                     );
                 }
+                let defs = multi_family.unwrap_or_else(|| vec![def]);
                 if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
-                    class_def
-                        .methods
-                        .insert(method_name, multi_family.unwrap_or_else(|| vec![def]));
+                    class_def.methods.insert(method_name.clone(), defs.clone());
                 }
+                // ADR-0019 F4c-6: dual-write on a separate short-lived
+                // guard, matching this function's F4c-4 sibling
+                // (`registration_class_augment.rs`) -- cannot share the
+                // `class_def` borrow above, which is a live sub-borrow of
+                // the held write guard for its whole block.
+                self.registry_mut().set_user_methods(
+                    Symbol::intern(&class_name),
+                    Symbol::intern(&method_name),
+                    defs,
+                );
                 self.registry_mut().sync_user_method_entries(&class_name);
                 // Class shape changed (an added BUILD/TWEAK/new flips ctor
                 // eligibility) — drop cached construction plans.
@@ -927,12 +936,23 @@ impl Interpreter {
                 };
                 let inserted =
                     if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
-                        class_def.methods.entry(method_name).or_default().push(def);
+                        class_def
+                            .methods
+                            .entry(method_name.clone())
+                            .or_default()
+                            .push(def.clone());
                         true
                     } else {
                         false
                     };
                 if inserted {
+                    // ADR-0019 F4c-6: dual-write on a separate short-lived
+                    // guard -- see `add_method`'s own F4c-6 comment above.
+                    self.registry_mut().push_user_method(
+                        Symbol::intern(&class_name),
+                        Symbol::intern(&method_name),
+                        def,
+                    );
                     self.registry_mut().sync_user_method_entries(&class_name);
                     self.native_ctor_plan_cache.clear();
                     return Ok(Value::NIL);

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -350,12 +350,24 @@ impl Interpreter {
                     if *multi {
                         class_def
                             .methods
-                            .entry(resolved_method_name)
+                            .entry(resolved_method_name.clone())
                             .or_default()
-                            .push(def);
+                            .push(def.clone());
                     } else {
-                        class_def.methods.insert(resolved_method_name, vec![def]);
+                        class_def
+                            .methods
+                            .insert(resolved_method_name.clone(), vec![def.clone()]);
                     }
+                }
+                // ADR-0019 F4c-6: dual-write on a separate short-lived
+                // guard -- cannot share the `class_def` borrow above.
+                let owner = crate::symbol::Symbol::intern(&class_name);
+                let method_sym = crate::symbol::Symbol::intern(&resolved_method_name);
+                if *multi {
+                    self.registry_mut().push_user_method(owner, method_sym, def);
+                } else {
+                    self.registry_mut()
+                        .set_user_methods(owner, method_sym, vec![def]);
                 }
                 self.registry_mut().sync_user_method_entries(&class_name);
             } else {


### PR DESCRIPTION
## Summary
- Converts the MOP write sites named in the ADR-0019 F4c design note section (3): `methods_classhow_dispatch.rs`'s `^add_method` (including the "create a stub `ClassDef`" branch) and `^add_multi_method`, plus `system.rs`'s BEGIN-time method-statement injection. Same separate-short-lived-guard shape as F4c-4/F4c-5's `if let Some(class_def) = self.registry_mut().classes.get_mut(...)` sites.
- **Correction to this box's own stated payoff**: the design note frames F4c-6 as what "the F4c-3 merge-back deletion depends on" — landing this slice does **not** make deleting `registration_class_body_attr.rs`'s merge-back safe, and it stays in place. Verified empirically: temporarily disabling the merge-back regresses `t/attribute-trait-adds-method.t` ("No such method 'has-a'") even with this slice's dual-write in place, because the periodic per-statement `sync_user_method_entries` call (unconditionally re-deriving from `cx.class_def.methods`, unaware of `^add_method`'s out-of-band write) is itself untouched through the whole F4c-3..F4c-8 bridge and immediately clobbers it again. The merge-back can only go away once F4c-9b actually removes `class_def.methods`/`sync_user_method_entries`.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] Full local `t/` suite (3183 files, 29636 tests) under `MUTSU_CHECK_METHOD_INDEX=1` — 0 index/table-drift assertions, 0 lock-reentrancy panics
- [x] 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — only the pre-existing tracked `S12-attributes/trusts.t` failure
- [x] `scripts/battery-testsuite.sh` — GATE PASSED (including OO::Monitors, which exercises `^add_method` via `EXPORTHOW::DECLARE`)
- [x] Empirically confirmed the merge-back is still load-bearing (temporarily disabled it, saw the predicted regression, reverted)
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)