### PR TITLE
feat(adr0019): F4c-8 -- snapshot/rollback dual-write + repair-loop fix

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1707,6 +1707,39 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     `require`-alias territory; only the pre-existing tracked `S11-modules/re-export.t` SORRY-abort
     and `S12-attributes/trusts.t` failures), and `scripts/battery-testsuite.sh` (GATE PASSED);
     `cargo clippy -- -D warnings` and `cargo fmt` clean.
+
+    **Progress (F4c-8, #TBD):** of the five mechanisms (4) names, two were already done by earlier
+    slices -- **(c)** `Registry::replace_method_entries_from` already copied the reverse index
+    (fixed in F4c-1's own progress note) and **(d)** `rename_generic_composed_class` already uses
+    `rename_method_owner` (F4c-5) -- so this slice covers the remaining three. **(a)
+    `ClassRegSnapshot`** gained `prev_method_rows: Vec<(Symbol, Vec<MethodDef>)>`, captured via
+    `user_method_rows_for_owner` and restored via `restore_user_method_rows`; the restore call sits
+    before the pre-existing `sync_user_method_entries(name)` call, which stays authoritative during
+    the bridge and will simply have nothing left to correct once F4c-9b arrives. Both pre-existing
+    gaps preserved deliberately, not silently fixed: `restore_user_method_rows` only ever touches
+    `user_candidates`, so `MethodEntry::proto` is untouched exactly as before; `method_wrap_chains`
+    is untouched by either path, also exactly as before. Filed the proto gap as
+    `todo/tickets/class-redeclaration-rollback-loses-proto-method.md` per this box's own
+    instruction not to fold a behavior change into F4c. **(b) EVAL-string rollback**
+    (`system_eval_string.rs`) keeps its `classes = snapshot; classes.extend(current)` merge exactly
+    as-is (still correct, still needs no redesign) but the O(all classes) `for class_name in
+    self.registry().classes.keys() { sync }` repair loop is now scoped to `resurrected_classes`
+    (`classes_snapshot`'s keys minus `current_classes`'s, computed *before* the merge consumes
+    `classes_snapshot`) -- a genuine algorithmic win (O(all classes) x O(total table) down to
+    O(resurrected) x O(total table)), not just a mechanical dual-write, since every non-resurrected
+    class's `method_entries` rows are already correct (kept live-synced by whatever ran during the
+    EVAL). Confirmed this path still never touches `RoleDef::methods` -- unchanged, the `roles`
+    field restore/extend pair is untouched by this slice. **(e)** all three no-sync `classes.remove`
+    sites (`builtins.rs`'s `__MUTSU_UNREGISTER_CLASS__`, `runtime_encoding.rs`'s
+    `shadow_suppressed_type_with_package`, `registration_role_decl.rs`'s stale-pun cleanup) now
+    call `clear_user_methods_for_owner` + `sync_accessor_entries` explicitly, per the design note's
+    own instruction not to inherit the latent permanently-stale-rows bug into the new world.
+    Verified with the full local `t/` suite (3184 files, 29653 tests) under
+    `MUTSU_CHECK_METHOD_INDEX=1` (0 index/table-drift assertions), the 312-file
+    `S04`/`S06`/`S09`/`S11`/`S12`/`S14` roast subset plus the EVAL-specific
+    `S29-context/eval.t`/`evalfile.t`, `S06-other/main-eval.t`, `S04-phasers/in-eval.t` (only the
+    same two pre-existing tracked failures), and `scripts/battery-testsuite.sh` (GATE PASSED);
+    `cargo clippy -- -D warnings` and `cargo fmt` clean.
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -512,6 +512,16 @@ impl Interpreter {
                 if let Some(name) = args.first() {
                     let class_name = name.to_string_value();
                     self.registry_mut().classes.remove(&class_name);
+                    // ADR-0019 F4c-8(e): this `classes.remove` called no
+                    // sync at all, leaving permanently stale `method_entries`
+                    // rows behind -- masked only because every dispatcher
+                    // checks `classes.contains_key` first. Explicit mutator
+                    // calls instead of `sync_user_method_entries`, per the
+                    // design note's own instruction not to inherit this
+                    // latent bug into the new world.
+                    let owner = crate::symbol::Symbol::intern(&class_name);
+                    self.registry_mut().clear_user_methods_for_owner(owner);
+                    self.registry_mut().sync_accessor_entries(owner);
                     self.env.remove(&class_name);
                     self.suppress_name(&class_name);
                 }

--- a/src/runtime/registration_class_validate.rs
+++ b/src/runtime/registration_class_validate.rs
@@ -22,6 +22,13 @@ pub(super) struct ClassRegSnapshot {
     prev_hidden_defer: Option<rustc_hash::FxHashSet<String>>,
     prev_composed_roles: Option<Vec<String>>,
     prev_role_param_bindings: Option<rustc_hash::FxHashMap<String, Value>>,
+    /// ADR-0019 F4c-8(a): dual-write mirror of `prev_class`'s methods
+    /// through the mutator API, forward-looking for F4c-9b -- once
+    /// `ClassDef::methods` is deleted, `prev_class.clone()` alone can no
+    /// longer capture them. Deliberately does NOT capture `MethodEntry::
+    /// proto` or `method_wrap_chains` -- see `restore`'s own comment for
+    /// why both gaps are preserved on purpose, not silently inherited.
+    prev_method_rows: Vec<(crate::symbol::Symbol, Vec<MethodDef>)>,
 }
 
 impl ClassRegSnapshot {
@@ -33,6 +40,7 @@ impl ClassRegSnapshot {
             prev_hidden_defer: reg.hidden_defer_parents.get(name).cloned(),
             prev_composed_roles: reg.class_composed_roles.get(name).cloned(),
             prev_role_param_bindings: reg.class_role_param_bindings.get(name).cloned(),
+            prev_method_rows: reg.user_method_rows_for_owner(crate::symbol::Symbol::intern(name)),
         }
     }
 
@@ -66,6 +74,21 @@ impl ClassRegSnapshot {
         } else {
             reg.class_role_param_bindings.remove(name);
         }
+        // ADR-0019 F4c-8(a): dual-write the method rows through the mutator
+        // API too. Redundant with the `sync_user_method_entries` call below
+        // today (which re-derives from the just-restored `prev_class.
+        // methods` and wins), but this is the mechanism F4c-9b needs once
+        // that field and that function are gone. `restore_user_method_rows`
+        // only ever touches `user_candidates`, so `MethodEntry::proto`
+        // survives untouched here exactly as the pre-existing behavior
+        // leaves it; `method_wrap_chains` is untouched by either path,
+        // also matching pre-existing behavior. Both are deliberate,
+        // pre-existing gaps -- see the design note's own instruction not to
+        // fold that behavior change into this box.
+        reg.restore_user_method_rows(
+            crate::symbol::Symbol::intern(name),
+            self.prev_method_rows.clone(),
+        );
         drop(reg);
         this.registry_mut().sync_user_method_entries(name);
     }

--- a/src/runtime/registration_role_decl.rs
+++ b/src/runtime/registration_role_decl.rs
@@ -97,6 +97,13 @@ impl Interpreter {
     ) -> Option<Vec<String>> {
         // Clean up stale punned class entry for this role name.
         self.registry_mut().classes.remove(name);
+        // ADR-0019 F4c-8(e): explicit mutator calls, matching
+        // `__MUTSU_UNREGISTER_CLASS__`'s own F4c-8(e) fix -- this
+        // `classes.remove` called no sync at all, leaving permanently stale
+        // `method_entries` rows behind from the withdrawn pun.
+        let owner = crate::symbol::Symbol::intern(name);
+        self.registry_mut().clear_user_methods_for_owner(owner);
+        self.registry_mut().sync_accessor_entries(owner);
         self.registry_mut().hidden_classes.remove(name);
         self.registry_mut().class_composed_roles.remove(name);
         // When registering a parametric variant of an existing non-parametric role

--- a/src/runtime/registry_method_table.rs
+++ b/src/runtime/registry_method_table.rs
@@ -310,7 +310,6 @@ impl Registry {
     /// Inverse of [`user_method_rows_for_owner`](Self::
     /// user_method_rows_for_owner): replaces `owner`'s entire user-owned row
     /// set with `rows`, clearing anything not present in `rows` first.
-    #[allow(dead_code)] // ADR-0019 F4c-8 wires this into snapshot/rollback.
     pub(crate) fn restore_user_method_rows(
         &mut self,
         owner: Symbol,

--- a/src/runtime/runtime_encoding.rs
+++ b/src/runtime/runtime_encoding.rs
@@ -261,6 +261,13 @@ impl Interpreter {
         self.registry_mut().roles.remove(name);
         self.registry_mut().enum_types.remove(name);
         self.registry_mut().subsets.remove(name);
+        // ADR-0019 F4c-8(e): explicit mutator calls, matching
+        // `__MUTSU_UNREGISTER_CLASS__`'s own F4c-8(e) fix -- this
+        // `classes.remove` called no sync at all, leaving permanently stale
+        // `method_entries` rows behind.
+        let owner = crate::symbol::Symbol::intern(name);
+        self.registry_mut().clear_user_methods_for_owner(owner);
+        self.registry_mut().sync_accessor_entries(owner);
         self.suppressed_names.remove(name);
     }
 

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -397,6 +397,20 @@ impl Interpreter {
             .chain(classes_snapshot.keys())
             .cloned()
             .collect();
+        // ADR-0019 F4c-8(b): the classes whose canonical method table
+        // actually needs a registry re-derive after the `classes = snapshot;
+        // classes.extend(current)` merge below -- computed now, before that
+        // merge consumes `classes_snapshot`. `extend` makes `current` win
+        // for every key `current` has, so the merge's only real effect is
+        // *resurrecting* keys the EVAL removed (`withdraw_role_pun`,
+        // `__MUTSU_UNREGISTER_CLASS__`, ...); every other class's
+        // `method_entries` rows are already correct, kept in sync live by
+        // whatever ran during the EVAL itself.
+        let resurrected_classes: Vec<String> = classes_snapshot
+            .keys()
+            .filter(|name| !current_classes.contains_key(*name))
+            .cloned()
+            .collect();
         self.registry_mut().roles = roles_snapshot;
         self.registry_mut().user_declared_roles = user_declared_roles_snapshot;
         self.registry_mut().role_candidates = role_candidates_snapshot;
@@ -438,8 +452,13 @@ impl Interpreter {
         self.registry_mut()
             .class_role_param_bindings
             .extend(current_class_role_param_bindings);
-        let class_names: Vec<String> = self.registry().classes.keys().cloned().collect();
-        for class_name in class_names {
+        // ADR-0019 F4c-8(b): this used to loop over every class in the
+        // registry (O(all classes) x O(total table rows), to repair at most
+        // a handful of owners); scoping to `resurrected_classes` (computed
+        // above, before the merge) is O(resurrected) instead. Every other
+        // class's `method_entries` rows are already correct and untouched
+        // by the snapshot/extend dance.
+        for class_name in resurrected_classes {
             self.registry_mut().sync_user_method_entries(&class_name);
         }
         for key in current_type_keys.union(&snapshot_type_keys) {

--- a/todo/tickets/class-redeclaration-rollback-loses-proto-method.md
+++ b/todo/tickets/class-redeclaration-rollback-loses-proto-method.md
@@ -1,0 +1,42 @@
+# A failed class redeclaration's rollback does not restore a `proto method` it declared
+
+`ClassRegSnapshot::restore` (`src/runtime/registration_class_validate.rs`) rolls back a class
+redefinition that failed partway through (a body statement returned `Err`) by restoring the
+registry's user-method rows, attributes, composed-role bookkeeping, etc. from the pre-attempt
+snapshot. This is a pre-existing gap, not something ADR-0019 F4c-8 introduced or is expected to
+fix — recorded per that box's design note (4)(a), which explicitly says to file this rather than
+fold a behavior change into F4c.
+
+**The gap:** `MethodEntry::proto` (the `proto method`/`proto submethod` column added in ADR-0019
+E8/E8b/E8c) is not part of either the old world's rollback (`registry.rs`'s `sync_user_method_
+entries` retain step deliberately spares the `proto` column so a repair-sync doesn't wipe it) or
+F4c-8's own `prev_method_rows`/`restore_user_method_rows` mechanism (`restore_user_method_rows`
+only ever touches `user_candidates`, by design — see `Registry::set_user_methods`'s row-liveness
+predicate). So: a class redeclaration that (1) declares a `proto method foo {*}` and (2) later in
+the same body fails and rolls back, leaves the `proto` row for `foo` installed on the class even
+though every other side effect of the failed attempt was undone.
+
+**Why this survives unnoticed today:** a `proto` method with no candidates is essentially inert
+until a same-named regular method is also declared — dispatch through a proto with zero candidates
+either falls through or errors depending on call site, so the dangling proto rarely produces a
+directly-visible symptom. It would only manifest if the SAME class name is redeclared again later
+in the same program and the new declaration expects a clean slate for that method name, or if
+introspection (`.^can`, `.^find_method`) surfaces the stale proto.
+
+**Repro sketch (not yet verified/reduced):**
+```raku
+class Foo {
+    proto method bar {*}
+    method missing-thing { CALLS-SOMETHING-UNDECLARED() }  # or any statement that dies
+}
+# `class Foo {...}` fails and (depending on how the failure surfaces -- EVAL,
+# try/CATCH around the whole declaration, etc.) the registration rolls back.
+# Foo.^find_method('bar') may still report a (candidate-less) proto.
+```
+
+**Fix sketch:** either (a) add a `prev_proto: Option<FunctionDef>` (or a small per-name map) to
+`ClassRegSnapshot`, captured via a new `Registry::method_entry_proto`-based read and restored via
+a new mutator that writes just the `proto` column, mirroring `prev_method_rows`'s shape; or (b)
+decide this specific gap is acceptable permanently and downgrade this ticket to documentation only.
+Either way, resolve with a real `raku` behavior check first — Rakudo's own semantics for what a
+failed-and-rolled-back class redeclaration leaves behind is the ground truth, not assumption.


### PR DESCRIPTION
## Summary
Of the five mechanisms the ADR-0019 F4c design note section (4) names, two were already done by earlier slices — **(c)** `Registry::replace_method_entries_from` already copied the reverse index (fixed in F4c-1) and **(d)** `rename_generic_composed_class` already uses `rename_method_owner` (F4c-5) — so this slice covers the remaining three:

- **(a) `ClassRegSnapshot`** gained `prev_method_rows` (captured via `user_method_rows_for_owner`, restored via `restore_user_method_rows`) before the pre-existing `sync_user_method_entries(name)` call. Both pre-existing gaps preserved deliberately: `MethodEntry::proto` and `method_wrap_chains` stay untouched by rollback, exactly as before — the proto gap is filed as `todo/tickets/class-redeclaration-rollback-loses-proto-method.md` per the design note's own instruction not to fold a behavior change into F4c.
- **(b) EVAL-string rollback** (`system_eval_string.rs`) keeps its `classes = snapshot; classes.extend(current)` merge exactly as-is, but the O(all classes) repair loop is now scoped to `resurrected_classes` — a genuine algorithmic win (O(all classes) × O(total table) down to O(resurrected) × O(total table)), since every non-resurrected class's `method_entries` rows are already correct. Confirmed this path still never touches `RoleDef::methods`.
- **(e)** All three no-sync `classes.remove` sites (`builtins.rs`'s `__MUTSU_UNREGISTER_CLASS__`, `runtime_encoding.rs`'s `shadow_suppressed_type_with_package`, `registration_role_decl.rs`'s stale-pun cleanup) now call `clear_user_methods_for_owner` + `sync_accessor_entries` explicitly, closing a pre-existing latent bug (permanently stale `method_entries` rows, masked only because every dispatcher checks `classes.contains_key` first).

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] Full local `t/` suite (3184 files, 29653 tests) under `MUTSU_CHECK_METHOD_INDEX=1` — 0 index/table-drift assertions
- [x] 312-file `S04`/`S06`/`S09`/`S11`/`S12`/`S14` roast subset plus the EVAL-specific `S29-context/eval.t`/`evalfile.t`, `S06-other/main-eval.t`, `S04-phasers/in-eval.t` (release) — only the two pre-existing tracked failures
- [x] `scripts/battery-testsuite.sh` — GATE PASSED
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)