### PR TITLE
feat(adr0019): F4c-9a -- migrate ClassDef::methods readers to the canonical table, retire F4c-1 shadow check

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1793,9 +1793,35 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     `S12-class/open_closed.t`, `S12-meta/exporthow.t`, `S12-traits/basic.t`, `S12-traits/
     parameterized.t`); `scripts/battery-testsuite.sh` (GATE PASSED, 245/271); `cargo clippy -- -D
     warnings` and `cargo fmt` clean. **Remaining F4c-9a scope** (deferred, not done by this
-    slice): `detect_unresolved_role_method_conflicts` (needs its own careful pass per its
-    staleness note above), and re-auditing the write-family files once F4c-9b is ready to retire
-    their `class_def.methods` half.
+    slice): re-auditing the write-family files once F4c-9b is ready to retire their
+    `class_def.methods` half.
+
+    **Progress (F4c-9a-2, #TBD):** closes out `class.rs`'s `detect_unresolved_role_method_
+    conflicts`, the one site F4c-9a-1 deliberately left alone because its own comment warned that
+    `class_def` is not guaranteed to match the registry's `owner_method_names` mid-`finalize_
+    class_registration` (the call runs right after `resolve_class_stub_requirements`, before the
+    post-stub-resolution `class_def` is re-synced). That staleness gap turned out to already be
+    closed: `resolve_class_stub_requirements`'s own mutation loop (F4c-3) dual-writes every
+    `class_def.methods` add/remove straight to the registry via the mutator API, so the two are
+    kept in lockstep even mid-call now. Confirmed empirically, not just by re-reading the code,
+    before touching the site: this function's own pre-existing F4c-1 shadow check
+    (`shadow_check_owner_method_names`) was run under `MUTSU_VM_STATS=1` across the full local
+    `t/` suite (3185 files) and the 122-file `S12`/`S14` role-composition-conflict-heavy roast
+    subset -- zero mismatches in either sweep, i.e. the shadow check itself supplied the
+    confirmation its own comment demanded. Cut over to `Registry::owner_method_names` +
+    `Registry::user_method_overloads`, matching the other seven F4c-1 sites; dropped the now-dead
+    `class_def: &ClassDef` parameter (its one caller, `finalize_class_registration`, updated) and,
+    since this was the shadow check's last remaining caller, retired the whole F4c-1 shadow-check
+    apparatus it was the last user of: `Registry::shadow_check_owner_method_names`
+    (`registry_method_table.rs`) and `vm_stats::record_owner_method_names_shadow_check` plus its
+    two atomics, per-site mismatch map, and exit-time print block (`vm_stats.rs`) -- the box's own
+    "write-through deletes existing workarounds" payoff pattern, applied to a verification
+    scaffold instead of a runtime workaround. Verified with the full local `t/` suite (3185 files,
+    29665 tests, green) and the same 243-file roast subset producing byte-identical failure output
+    against the `main` baseline (same 7 pre-existing failures, zero new breakage); `scripts/
+    battery-testsuite.sh` (GATE PASSED, 245/271); `cargo build`, `cargo clippy -- -D warnings`,
+    `cargo fmt` all clean (confirming no other caller depended on the retired shadow-check API).
+    **F4c-9a is now fully closed** apart from re-auditing the write-family files at F4c-9b time.
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1740,6 +1740,62 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     `S29-context/eval.t`/`evalfile.t`, `S06-other/main-eval.t`, `S04-phasers/in-eval.t` (only the
     same two pre-existing tracked failures), and `scripts/battery-testsuite.sh` (GATE PASSED);
     `cargo clippy -- -D warnings` and `cargo fmt` clean.
+
+    **Progress (F4c-9a-1, #TBD):** first slice of the read cutover (F4c-9a); not the whole box —
+    see the remaining scope below. Migrated every `ClassDef::methods` direct-read site that is a
+    genuine *downstream dispatch/introspection consumer* (not a write-family's own in-flight
+    bookkeeping, and not a `RoleDef::methods` read, which (1) keeps in place) onto
+    `Registry::user_method_overloads`/`get_method_overloads` (class-only sites) or
+    `Registry::get_method_overloads_with_role_fallback` (the class-then-role sites R4 names).
+    Seventeen files: `resolution_method.rs` (`count_visible_method_candidates`,
+    `resolve_all_methods_with_owner` — the two sites R4 explicitly requires on the fallback
+    helper; `resolve_method_with_owner_impl` at `:168` is untouched, confirmed still class-only
+    via `get_method_overloads` per R4's own warning against unifying the file), `resolution_
+    deferral.rs` (`own_overloads_at_level`, whose doc comment warned against the bare helper —
+    now correctly reads as a pointer at the *with-fallback* one), `accessors_state.rs`
+    (`has_multiple_dispatch_candidates` moved to the fallback helper, dropping its own manual
+    class-then-role duplication; `find_method_candidate_index` at `:1116`, the R4-flagged
+    "different from `:588,593`" site, moved to the class-only helper as R4 requires), `class.rs`
+    (`registry_has_destroy_methods`'s class half, the per-level DESTROY fetch, and `format_
+    method_candidate_signatures`; `detect_unresolved_role_method_conflicts` at `:169` is
+    deliberately left untouched per its own comment — `class_def` there is not guaranteed to
+    match the registry mid-call), `class_introspection.rs` (`has_user_method`; `has_user_method_
+    including_role`'s role half is untouched, out of scope), `methods_walk.rs` (`WalkKind::Class`
+    and `WalkKind::Role`'s receiver-class submethod fallback; `WalkKind::Role`'s own role-table
+    probe and `WalkKind::MixinRole` are untouched, out of scope), `methods_classhow_lookup.rs`
+    (the MRO-walk in `classhow_lookup`, both lookups in `classhow_lookup_all_candidates`; the
+    role-only fallback outside the MRO loop is untouched), `methods_classhow_method_obj.rs`
+    (the two public-attribute-shadow checks in `collect_class_methods`/`class_method_table` —
+    the enumeration halves of these same two functions were already migrated in F4c-1),
+    `methods_qualified.rs`, `methods_signature_shaped.rs` (both `method_exists` MRO scans),
+    `methods_dispatch_new.rs` (`run_user_buildall_hook`'s `has_user` closure),
+    `methods_object_dispatch_new.rs` (`any_build`/`any_tweak`), `metamodel.rs`
+    (`declare_drive_how_protocol`'s per-name value fetch — its enumeration half was already
+    migrated in F4c-1; this closes out the function's own leftover redundant class_def re-lookup),
+    `registration.rs` (`inherited_matching_method_count`, `inherited_any_concrete_method`, and
+    `resolve_class_stub_requirements`'s per-name value read — the last of these reads via
+    `self.registry()` instead of the `&mut ClassDef` parameter, relying on the same "already
+    published to the registry by this point" invariant the function's own F4c-1-era comment
+    already documents for the enumeration half; verified safe because the parameter is a plain
+    owned local, not borrowed from `self`, so no aliasing risk), `regex/regex_match_atom.rs`, and
+    `compiler/helpers_method_body.rs` (a test-only fixture-comparison helper, moved to the
+    fallback helper for symmetry with `resolve_all_methods_with_owner`). Every write-family site
+    (registration_class_body*.rs, registration_class_augment.rs, registration_class_compose*.rs,
+    methods_classhow_dispatch.rs's MOP writers, system.rs, builtins_system_require.rs,
+    accessors_resolve.rs's `compile_class_methods`) is untouched — those still read/write
+    `class_def.methods` as part of the dual-write bridge itself and are F4c-9b's job, not 9a's.
+    `class_dispatch.rs:228` is untouched per the box's own instruction (F6's carrier deletes it
+    for free). Verified with the full local `t/` suite (3185 files, 29665 tests) under
+    `MUTSU_CHECK_METHOD_INDEX=1` (0 index/table-drift assertions); the same 243-file
+    `S04`/`S06`/`S09`/`S12`/`S14` roast subset produced byte-identical failure output against a
+    `main` baseline build (the same 7 pre-existing non-whitelisted failures, none newly broken —
+    `S06-advanced/caller.t`, `S06-advanced/return_function.t`, `S12-attributes/trusts.t`,
+    `S12-class/open_closed.t`, `S12-meta/exporthow.t`, `S12-traits/basic.t`, `S12-traits/
+    parameterized.t`); `scripts/battery-testsuite.sh` (GATE PASSED, 245/271); `cargo clippy -- -D
+    warnings` and `cargo fmt` clean. **Remaining F4c-9a scope** (deferred, not done by this
+    slice): `detect_unresolved_role_method_conflicts` (needs its own careful pass per its
+    staleness note above), and re-auditing the write-family files once F4c-9b is ready to retire
+    their `class_def.methods` half.
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/src/compiler/helpers_method_body.rs
+++ b/src/compiler/helpers_method_body.rs
@@ -323,16 +323,9 @@ mod d3_8a_byte_parity_tests {
             .run(source)
             .unwrap_or_else(|e| panic!("fixture source runs: {e:?}"));
         let registry = interp.registry();
-        let runtime_code = registry
-            .classes
-            .get(type_name)
-            .and_then(|c| c.methods.get(method_name))
-            .or_else(|| {
-                registry
-                    .roles
-                    .get(type_name)
-                    .and_then(|r| r.methods.get(method_name))
-            })
+        let overloads = registry.get_method_overloads_with_role_fallback(type_name, method_name);
+        let runtime_code = overloads
+            .as_ref()
             .and_then(|defs| defs.first())
             .and_then(|def| def.compiled_code.as_ref())
             .unwrap_or_else(|| {

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -582,18 +582,10 @@ impl Interpreter {
         'outer: for cn in mro.iter() {
             let is_ancestor = cn.as_str() != class_name;
             let registry = self.registry();
-            let overloads = registry
-                .classes
-                .get(cn.as_str())
-                .and_then(|c| c.methods.get(method_name))
-                .or_else(|| {
-                    registry
-                        .roles
-                        .get(cn.as_str())
-                        .and_then(|r| r.methods.get(method_name))
-                });
+            let overloads =
+                registry.get_method_overloads_with_role_fallback(cn.as_str(), method_name);
             if let Some(overloads) = overloads {
-                for def in overloads {
+                for def in &overloads {
                     if def.is_private {
                         continue;
                     }
@@ -1112,8 +1104,7 @@ impl Interpreter {
     ) -> Option<usize> {
         // No user-code re-entry here, so a let-bound guard is safe.
         let registry = self.registry();
-        let class_def = registry.classes.get(class_name)?;
-        let defs = class_def.methods.get(method_name)?;
+        let defs = registry.user_method_overloads(class_name, method_name)?;
         // Fast path: a resolved MethodDef is a clone of a registry entry, so
         // its body Arc points at the same allocation — pointer identity finds
         // the candidate without traversing any AST. The structural-fingerprint

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -30,8 +30,8 @@ impl Interpreter {
     pub(crate) fn registry_has_destroy_methods(&self) -> bool {
         let reg = self.registry();
         reg.classes
-            .values()
-            .any(|cd| cd.methods.contains_key("DESTROY"))
+            .keys()
+            .any(|name| reg.user_method_overloads(name, "DESTROY").is_some())
             || reg
                 .roles
                 .values()
@@ -82,10 +82,10 @@ impl Interpreter {
                 }
                 // Clone DESTROY overloads out and drop the guard before re-entering
                 // user code (run_instance_method_resolved).
-                let destroy_overloads = match self.registry().classes.get(mro_class) {
-                    Some(class_def) => class_def.methods.get("DESTROY").cloned(),
-                    None => continue,
-                };
+                if !self.registry().classes.contains_key(mro_class) {
+                    continue;
+                }
+                let destroy_overloads = self.registry().user_method_overloads(mro_class, "DESTROY");
                 // Call class's own DESTROY submethod
                 if let Some(overloads) = destroy_overloads
                     && let Some(method_def) = overloads.into_iter().find(|def| {
@@ -335,13 +335,10 @@ impl Interpreter {
             // No user-code re-entry in this loop body (pure signature-string
             // building), so a let-bound guard is safe.
             let registry = self.registry();
-            let Some(class_def) = registry.classes.get(cn.as_str()) else {
+            let Some(overloads) = registry.user_method_overloads(cn.as_str(), method_name) else {
                 continue;
             };
-            let Some(overloads) = class_def.methods.get(method_name) else {
-                continue;
-            };
-            for def in overloads {
+            for def in &overloads {
                 if def.is_private || (def.is_my && is_ancestor) {
                     continue;
                 }

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -169,25 +169,23 @@ impl Interpreter {
     pub(super) fn detect_unresolved_role_method_conflicts(
         &self,
         class_name: &str,
-        class_def: &ClassDef,
     ) -> Result<(), RuntimeError> {
-        // ADR-0019 F4c-1 shadow check. NOTE: unlike the other seven sites,
-        // this `class_def` is NOT guaranteed to match the registry's
-        // `owner_method_names` at this point -- `finalize_class_registration`
-        // calls this immediately after `resolve_class_stub_requirements`,
-        // which can mutate/remove entries from `class_def.methods` in place
-        // (an unsatisfied stub whose requirement got resolved away), and the
-        // registry is not re-synced until after this call returns. A
-        // mismatch here is therefore expected whenever stub resolution
-        // changed the method set, not necessarily a bug -- do NOT cut this
-        // site over without first confirming (via the mismatch detail) which
-        // mismatches are this expected staleness vs. a real gap.
-        self.registry().shadow_check_owner_method_names(
-            "class::detect_unresolved_role_method_conflicts",
-            class_name,
-            class_def.methods.keys().map(String::as_str),
-        );
-        for (method_name, defs) in &class_def.methods {
+        // ADR-0019 F4c-9a-1: cut over from `class_def.methods` to the
+        // canonical table. `resolve_class_stub_requirements` (called just
+        // before this by `finalize_class_registration`) dual-writes every
+        // `class_def.methods` mutation to the registry via the mutator API
+        // (F4c-3), so unlike the pre-dual-write-bridge era this function's
+        // own F4c-1 shadow check used to worry about, the two are now kept
+        // in lockstep even mid-`finalize_class_registration` -- confirmed
+        // empirically via that same shadow check reporting zero mismatches
+        // across the full local `t/` suite (3185 files) and the S12/S14
+        // role-composition roast subset (122 files) before this cutover.
+        let registry = self.registry();
+        for method_name in registry.owner_method_names(class_name) {
+            let method_name = method_name.resolve();
+            let Some(defs) = registry.user_method_overloads(class_name, &method_name) else {
+                continue;
+            };
             // Submethods (like BUILD, TWEAK) from multiple roles do not conflict —
             // they are accumulated and all called during construction. Skip them.
             if defs.iter().all(|d| d.is_submethod) {

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -235,8 +235,9 @@ impl Interpreter {
     pub(crate) fn has_user_method(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
         for cn in mro.iter() {
-            if let Some(class_def) = self.registry().classes.get(cn.as_str())
-                && let Some(defs) = class_def.methods.get(method_name)
+            if let Some(defs) = self
+                .registry()
+                .user_method_overloads(cn.as_str(), method_name)
             {
                 return defs.iter().any(|d| !d.is_private);
             }

--- a/src/runtime/metamodel.rs
+++ b/src/runtime/metamodel.rs
@@ -424,9 +424,7 @@ impl Interpreter {
             for method_name in method_names {
                 let Some(overloads) = self
                     .registry()
-                    .classes
-                    .get(class_name)
-                    .and_then(|cd| cd.methods.get(&method_name).cloned())
+                    .user_method_overloads(class_name, &method_name)
                 else {
                     continue;
                 };

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -51,10 +51,7 @@ impl Interpreter {
             let owner_str = owner_sym.as_str();
             let defs_all: Vec<MethodDef> = {
                 let registry = self.registry();
-                let Some(class_def) = registry.classes.get(owner_str) else {
-                    continue;
-                };
-                let Some(defs) = class_def.methods.get(method_name) else {
+                let Some(defs) = registry.user_method_overloads(owner_str, method_name) else {
                     continue;
                 };
                 let Some(first) = defs.first() else {
@@ -66,7 +63,7 @@ impl Interpreter {
                 if first.is_my && owner_str != class_name_str && !include_ancestor_submethods {
                     continue;
                 }
-                defs.clone()
+                defs
             };
             let first = &defs_all[0];
             let has_multi = defs_all.iter().any(|d| d.is_multi);
@@ -293,11 +290,8 @@ impl Interpreter {
 
         let class_method_is_multi = |cls: &str| -> bool {
             registry
-                .classes
-                .get(cls)
-                .and_then(|cd| cd.methods.get(method_name))
-                .map(|defs| defs.iter().any(|d| d.is_multi))
-                .unwrap_or(false)
+                .user_method_overloads(cls, method_name)
+                .is_some_and(|defs| defs.iter().any(|d| d.is_multi))
         };
 
         // Build the owner list base-class-first. A non-multi resolved method
@@ -318,10 +312,7 @@ impl Interpreter {
 
         let mut out = Vec::new();
         for owner in &owners {
-            let Some(class_def) = registry.classes.get(owner) else {
-                continue;
-            };
-            let Some(defs) = class_def.methods.get(method_name) else {
+            let Some(defs) = registry.user_method_overloads(owner, method_name) else {
                 continue;
             };
             for (idx, def) in defs.iter().enumerate() {

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -15,7 +15,11 @@ impl Interpreter {
         };
         // First add accessor methods for public attributes (in order)
         for attr in &class_def.attributes {
-            if attr.is_public && !class_def.methods.contains_key(&attr.name) {
+            if attr.is_public
+                && registry
+                    .user_method_overloads(class_name, &attr.name)
+                    .is_none()
+            {
                 result.push(self.make_native_method_object(&attr.name, class_name));
             }
         }
@@ -83,7 +87,11 @@ impl Interpreter {
             return table;
         };
         for attr in &class_def.attributes {
-            if attr.is_public && !class_def.methods.contains_key(&attr.name) {
+            if attr.is_public
+                && registry
+                    .user_method_overloads(class_name, &attr.name)
+                    .is_none()
+            {
                 table.insert(
                     attr.name.clone(),
                     self.make_native_method_object(&attr.name, class_name),

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -561,9 +561,8 @@ impl Interpreter {
         let has_user = |zelf: &mut Self, m: &str| {
             zelf.class_mro(class_key).iter().any(|c| {
                 zelf.registry()
-                    .classes
-                    .get(c.as_str())
-                    .is_some_and(|cd| cd.methods.contains_key(m))
+                    .user_method_overloads(c.as_str(), m)
+                    .is_some()
             })
         };
         let method = if has_user(self, "BUILDALL") {

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1716,12 +1716,7 @@ impl Interpreter {
                 let any_build = class_mro.iter().map(|s| s.as_str()).any(|cn| {
                     cn != "Any"
                         && cn != "Mu"
-                        && self
-                            .registry()
-                            .classes
-                            .get(cn)
-                            .and_then(|def| def.methods.get("BUILD"))
-                            .is_some()
+                        && self.registry().user_method_overloads(cn, "BUILD").is_some()
                 });
                 // Role-composed BUILD submethods count as a BUILD phase too, for
                 // the attribute-initializer ordering below (not for the
@@ -2093,12 +2088,7 @@ impl Interpreter {
                 let any_tweak = mro.iter().map(|s| s.as_str()).any(|cn| {
                     cn != "Any"
                         && cn != "Mu"
-                        && (self
-                            .registry()
-                            .classes
-                            .get(cn)
-                            .and_then(|def| def.methods.get("TWEAK"))
-                            .is_some()
+                        && (self.registry().user_method_overloads(cn, "TWEAK").is_some()
                             || !self
                                 .ordered_role_submethods_for_class(cn, "TWEAK")
                                 .is_empty())

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -417,10 +417,7 @@ impl Interpreter {
         // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
         let overloads = self
             .registry()
-            .classes
-            .get(&inst_cn_str)
-            .and_then(|c| c.methods.get(actual_method))
-            .cloned();
+            .user_method_overloads(&inst_cn_str, actual_method);
         if let Some(overloads) = overloads {
             for def in overloads {
                 if def.role_origin.as_deref() == Some(qualifier)

--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -295,9 +295,7 @@ impl Interpreter {
             let own_class = class_name.resolve();
             let method_exists = self.class_mro(&own_class).iter().any(|cn| {
                 self.registry()
-                    .classes
-                    .get(cn.as_str())
-                    .and_then(|c| c.methods.get(method))
+                    .user_method_overloads(cn.as_str(), method)
                     .is_some_and(|ovs| {
                         // A submethod on an ancestor class is not visible to
                         // the receiver, so don't count it as "method exists".
@@ -344,9 +342,7 @@ impl Interpreter {
                 // matched: raise a dispatch error, mirroring the Instance path.
                 let method_exists = self.class_mro(&class_name).iter().any(|cn| {
                     self.registry()
-                        .classes
-                        .get(cn.as_str())
-                        .and_then(|c| c.methods.get(method))
+                        .user_method_overloads(cn.as_str(), method)
                         .is_some_and(|ovs| {
                             let is_ancestor = cn.as_str() != class_name.as_str();
                             ovs.iter()

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -654,8 +654,7 @@ impl Interpreter {
                 // For the receiver's own class, "own" is any candidate stored
                 // on the class with role_origin == None.
                 let registry = self.registry();
-                let class_def = registry.classes.get(owner)?;
-                let overloads = class_def.methods.get(method_name)?;
+                let overloads = registry.user_method_overloads(owner, method_name)?;
                 if owner == receiver_class {
                     overloads
                         .iter()
@@ -689,8 +688,7 @@ impl Interpreter {
                 // Fall back to a submethod composed into the receiver's class
                 // table whose role origin matches this role.
                 let registry = self.registry();
-                let class_def = registry.classes.get(receiver_class)?;
-                let overloads = class_def.methods.get(method_name)?;
+                let overloads = registry.user_method_overloads(receiver_class, method_name)?;
                 overloads
                     .iter()
                     .find(|m| {

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -707,9 +707,8 @@ impl Interpreter {
         // already cover).
         let is_user_method = self
             .registry()
-            .classes
-            .get(pkg)
-            .is_some_and(|cd| cd.methods.contains_key(&spec.lookup_name));
+            .user_method_overloads(pkg, &spec.lookup_name)
+            .is_some();
         if !is_user_method {
             return None;
         }

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -147,13 +147,10 @@ impl Interpreter {
             // No user-code re-entry in this loop body (only static helpers), so a
             // let-bound guard is safe.
             let registry = self.registry();
-            let Some(class_def) = registry.classes.get(parent.as_str()) else {
+            let Some(defs) = registry.user_method_overloads(parent.as_str(), method_name) else {
                 continue;
             };
-            let Some(defs) = class_def.methods.get(method_name) else {
-                continue;
-            };
-            for def in defs {
+            for def in &defs {
                 if Self::is_stub_method_def(def) {
                     continue;
                 }
@@ -172,10 +169,7 @@ impl Interpreter {
         let mro = self.class_mro(class_name);
         for parent in mro.iter().skip(1) {
             let registry = self.registry();
-            let Some(class_def) = registry.classes.get(parent.as_str()) else {
-                continue;
-            };
-            let Some(defs) = class_def.methods.get(method_name) else {
+            let Some(defs) = registry.user_method_overloads(parent.as_str(), method_name) else {
                 continue;
             };
             if defs.iter().any(|def| !Self::is_stub_method_def(def)) {
@@ -218,7 +212,10 @@ impl Interpreter {
             .map(Symbol::resolve)
             .collect();
         for method_name in method_names {
-            let Some(all_defs) = class_def.methods.get(&method_name).cloned() else {
+            let Some(all_defs) = self
+                .registry()
+                .user_method_overloads(class_name, &method_name)
+            else {
                 continue;
             };
             let mut stubs = Vec::new();

--- a/src/runtime/registration_class_body_exit.rs
+++ b/src/runtime/registration_class_body_exit.rs
@@ -216,7 +216,7 @@ impl Interpreter {
             snapshot.restore(self, name);
             return Err(err);
         }
-        if let Err(err) = self.detect_unresolved_role_method_conflicts(name, &class_def) {
+        if let Err(err) = self.detect_unresolved_role_method_conflicts(name) {
             snapshot.restore(self, name);
             return Err(err);
         }

--- a/src/runtime/registry_method_table.rs
+++ b/src/runtime/registry_method_table.rs
@@ -60,39 +60,6 @@ impl Registry {
             .unwrap_or_default()
     }
 
-    /// Shared F4c-1 shadow check for the eight `class_def.methods.keys()`
-    /// full-name-enumeration read sites the ADR-0019 F4c design note's
-    /// ground-truth correction (0)(i) named. `old_names` is today's read (a
-    /// borrow, so the caller pays nothing when `MUTSU_VM_STATS` is
-    /// disabled); compared against [`owner_method_names`](Registry::
-    /// owner_method_names) as a SET (declaration order is not a meaningful
-    /// invariant here -- see that field's own doc). Zero behavior change:
-    /// this only records a counter, the caller's existing read is untouched.
-    pub(crate) fn shadow_check_owner_method_names<'a>(
-        &self,
-        site: &str,
-        owner: &str,
-        old_names: impl Iterator<Item = &'a str>,
-    ) {
-        if !crate::vm::vm_stats::enabled() {
-            return;
-        }
-        let mut old: Vec<&str> = old_names.collect();
-        old.sort_unstable();
-        old.dedup();
-        let mut new: Vec<String> = self
-            .owner_method_names(owner)
-            .iter()
-            .map(Symbol::resolve)
-            .collect();
-        new.sort_unstable();
-        new.dedup();
-        let matched = old.iter().copied().eq(new.iter().map(String::as_str));
-        crate::vm::vm_stats::record_owner_method_names_shadow_check(site, matched, || {
-            format!("owner={owner} old={old:?} new={new:?}")
-        });
-    }
-
     /// Full-table consistency check between [`owner_method_names`](Registry::
     /// owner_method_names) and the `user_candidates` half of `method_entries`:
     /// every indexed name must have a live row and every row with a

--- a/src/runtime/resolution_deferral.rs
+++ b/src/runtime/resolution_deferral.rs
@@ -40,23 +40,14 @@ impl Interpreter {
     /// The overloads `class_name` declares directly for `method_name` (not inherited) —
     /// identical read to [`Self::resolve_all_methods_with_owner`]'s per-level lookup (class
     /// table, falling back to the role table for an MRO entry that is a punned role rather than
-    /// a class). Deliberately NOT [`crate::runtime::registry::Registry::user_method_overloads`]
-    /// (aka `get_method_overloads`): that table has a known gap for a role that was never
-    /// punned (see `resolution_sequence.rs`'s module doc) which `resolve_all_methods_with_owner`
-    /// does not share, and this function must not regress it.
+    /// a class): [`crate::runtime::registry::Registry::get_method_overloads_with_role_fallback`].
+    /// Deliberately NOT the bare `user_method_overloads`/`get_method_overloads`: that table has
+    /// a known gap for a role that was never punned (see `resolution_sequence.rs`'s module doc)
+    /// which `resolve_all_methods_with_owner` does not share, and this function must not
+    /// regress it.
     fn own_overloads_at_level(&mut self, owner: &str, method_name: &str) -> Option<Vec<MethodDef>> {
-        let registry = self.registry();
-        registry
-            .classes
-            .get(owner)
-            .and_then(|c| c.methods.get(method_name))
-            .or_else(|| {
-                registry
-                    .roles
-                    .get(owner)
-                    .and_then(|r| r.methods.get(method_name))
-            })
-            .cloned()
+        self.registry()
+            .get_method_overloads_with_role_fallback(owner, method_name)
     }
 
     /// Nominal (argument-independent) narrowness of `def`'s positional, non-slurpy parameter

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -603,16 +603,8 @@ impl Interpreter {
         let mut count = 0usize;
         for cn in mro.iter() {
             let is_ancestor = cn.as_str() != class_name;
-            let overloads = registry
-                .classes
-                .get(cn.as_str())
-                .and_then(|c| c.methods.get(method_name))
-                .or_else(|| {
-                    registry
-                        .roles
-                        .get(cn.as_str())
-                        .and_then(|r| r.methods.get(method_name))
-                });
+            let overloads =
+                registry.get_method_overloads_with_role_fallback(cn.as_str(), method_name);
             if let Some(ovs) = overloads {
                 count += ovs
                     .iter()
@@ -641,20 +633,9 @@ impl Interpreter {
             // `self.registry().roles`, so fall back there when the entry is not a class.
             // Single guard for both the class and role method tables; clone the
             // matched overload Vec out so the guard drops before re-entry below.
-            let overloads = {
-                let registry = self.registry();
-                registry
-                    .classes
-                    .get(cn.as_str())
-                    .and_then(|c| c.methods.get(method_name))
-                    .or_else(|| {
-                        registry
-                            .roles
-                            .get(cn.as_str())
-                            .and_then(|r| r.methods.get(method_name))
-                    })
-                    .cloned()
-            };
+            let overloads = self
+                .registry()
+                .get_method_overloads_with_role_fallback(cn.as_str(), method_name);
             if let Some(overloads) = overloads {
                 let is_ancestor = cn.as_str() != class_name;
                 for def in overloads {

--- a/src/runtime/resolution_private_method.rs
+++ b/src/runtime/resolution_private_method.rs
@@ -86,13 +86,9 @@ impl Interpreter {
             let mut resolved: Option<(String, MethodDef)> = None;
             'scan: for cn in mro.iter() {
                 let registry = self.registry();
-                if let Some(overloads) = registry
-                    .classes
-                    .get(cn.as_str())
-                    .and_then(|c| c.methods.get(method_name))
-                {
+                if let Some(overloads) = registry.user_method_overloads(cn.as_str(), method_name) {
                     // First pass: skip stubs
-                    for def in overloads {
+                    for def in &overloads {
                         if !def.is_private {
                             continue;
                         }
@@ -109,7 +105,7 @@ impl Interpreter {
                         }
                     }
                     // Second pass: include stubs
-                    for def in overloads {
+                    for def in &overloads {
                         if !def.is_private {
                             continue;
                         }

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -364,45 +364,6 @@ pub(crate) fn record_owner_shadow_check(
     }
 }
 
-// ADR-0019 Phase F box F4c-1: shadow comparison between the eight
-// `class_def.methods.keys()`-style full-name-enumeration reads the F4c
-// design note's ground-truth correction (0)(i) named and the new
-// `Registry::owner_method_names` reverse index for the same owner, as a
-// SET (declaration order is not compared -- see the field's own doc for why
-// order is not a meaningful invariant here). `OWNER_METHOD_NAMES_SHADOW_
-// CHECKS`/`_MISMATCHES` are the totals across all eight sites;
-// `owner_method_names_shadow_mismatch_by_site` breaks mismatches down by
-// site so each can be triaged independently before its read is cut over.
-// Nothing reads these counters to make a dispatch decision: shadow-only,
-// zero behavior change.
-static OWNER_METHOD_NAMES_SHADOW_CHECKS: AtomicU64 = AtomicU64::new(0);
-static OWNER_METHOD_NAMES_SHADOW_MISMATCHES: AtomicU64 = AtomicU64::new(0);
-
-fn owner_method_names_shadow_mismatch_by_site() -> &'static Mutex<HashMap<String, u64>> {
-    static BY_SITE: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
-    BY_SITE.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-/// Record one F4c-1 owner-method-names shadow comparison at `site`. `detail`
-/// is only evaluated on a mismatch, mirroring [`record_owner_shadow_check`].
-#[inline]
-pub(crate) fn record_owner_method_names_shadow_check(
-    site: &str,
-    matched: bool,
-    detail: impl FnOnce() -> String,
-) {
-    if !enabled() {
-        return;
-    }
-    OWNER_METHOD_NAMES_SHADOW_CHECKS.fetch_add(1, Ordering::Relaxed);
-    if !matched {
-        OWNER_METHOD_NAMES_SHADOW_MISMATCHES.fetch_add(1, Ordering::Relaxed);
-        if let Ok(mut map) = owner_method_names_shadow_mismatch_by_site().lock() {
-            *map.entry(format!("{site} [{}]", detail())).or_insert(0) += 1;
-        }
-    }
-}
-
 // ADR-0019 Phase E box E2a: coverage gap between the native-method-row catalog
 // (`crate::builtins::native_method_row`) and what the real `native_method_{0,1,2}arg`
 // cascades actually recognize. Bumped whenever a cascade call returns `Some(..)`
@@ -1115,28 +1076,6 @@ pub(crate) fn dump() {
             .collect();
         eprintln!(
             "[mutsu vm-stats] adr0019-e1a owner-shadow mismatches by site (top {}): {}",
-            top.len(),
-            top.join(" ")
-        );
-    }
-    let owner_method_names_shadow_checks = OWNER_METHOD_NAMES_SHADOW_CHECKS.load(Ordering::Relaxed);
-    let owner_method_names_shadow_mismatches =
-        OWNER_METHOD_NAMES_SHADOW_MISMATCHES.load(Ordering::Relaxed);
-    eprintln!(
-        "[mutsu vm-stats] adr0019-f4c-1: owner_method_names_shadow_checks={owner_method_names_shadow_checks} owner_method_names_shadow_mismatches={owner_method_names_shadow_mismatches}"
-    );
-    if let Ok(map) = owner_method_names_shadow_mismatch_by_site().lock()
-        && !map.is_empty()
-    {
-        let mut entries: Vec<(&String, &u64)> = map.iter().collect();
-        entries.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
-        let top: Vec<String> = entries
-            .iter()
-            .take(25)
-            .map(|(name, count)| format!("{name}={count}"))
-            .collect();
-        eprintln!(
-            "[mutsu vm-stats] adr0019-f4c-1 owner-method-names-shadow mismatches by site (top {}): {}",
             top.len(),
             top.join(" ")
         );


### PR DESCRIPTION
## Summary
Completes ADR-0019 F4c-9a (the read cutover, following F4c-8's snapshot/rollback). Two slices, both included:

**F4c-9a-1** migrates every genuine downstream dispatch/introspection consumer of `ClassDef::methods` — not a write-family's own in-flight bookkeeping, not a `RoleDef::methods` read (out of scope per the design note's item (1)) — onto `Registry::user_method_overloads`/`get_method_overloads` (class-only sites) or `Registry::get_method_overloads_with_role_fallback` (the class-then-role sites R4 explicitly names). 16 files: `resolution_method.rs`, `resolution_deferral.rs`, `accessors_state.rs`, `class.rs`, `class_introspection.rs`, `methods_walk.rs`, `methods_classhow_lookup.rs`, `methods_classhow_method_obj.rs`, `methods_qualified.rs`, `methods_signature_shaped.rs`, `methods_dispatch_new.rs`, `methods_object_dispatch_new.rs`, `metamodel.rs`, `registration.rs`, `regex/regex_match_atom.rs`, `compiler/helpers_method_body.rs`.

**F4c-9a-2** closes out the one site F4c-9a-1 deliberately deferred: `class.rs`'s `detect_unresolved_role_method_conflicts`. Its own comment warned `class_def` might be stale relative to the registry mid-`finalize_class_registration`; empirically confirmed (via its own pre-existing F4c-1 shadow check under `MUTSU_VM_STATS=1`, zero mismatches across the full `t/` suite and a 122-file S12/S14 role-conflict roast subset) that the F4c-3 dual-write bridge already closed that gap. Cutting this site over made it the shadow check's last caller, so this slice also retires the whole now-dead F4c-1 shadow-check apparatus (`Registry::shadow_check_owner_method_names`, `vm_stats::record_owner_method_names_shadow_check` and its counters/print block).

F4c-9a is now fully closed. F4c-9b (flip the mutators to single-write and delete `ClassDef::methods`) is next.

Full design rationale and per-site notes are in the two new "Progress (F4c-9a-1/2, #TBD)" entries in `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` all clean (both slices)
- [x] Full local `t/` suite (3185 files, 29665 tests) green under `MUTSU_CHECK_METHOD_INDEX=1` (0 index/table-drift assertions), both slices
- [x] 243-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset produces byte-identical failure output against a `main`-baseline release build (same 7 pre-existing non-whitelisted failures, zero new breakage), both slices
- [x] `scripts/battery-testsuite.sh` — GATE PASSED (245/271), both slices
- [x] F4c-9a-2's cutover additionally verified via its own F4c-1 shadow check (`MUTSU_VM_STATS=1`) reporting zero mismatches across `t/` and the S12/S14 subset before the cutover landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)