### PR TITLE
feat(adr0019): F4c-9b -- flip mutators to single write, delete ClassDef::methods

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1822,6 +1822,115 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     battery-testsuite.sh` (GATE PASSED, 245/271); `cargo build`, `cargo clippy -- -D warnings`,
     `cargo fmt` all clean (confirming no other caller depended on the retired shadow-check API).
     **F4c-9a is now fully closed** apart from re-auditing the write-family files at F4c-9b time.
+
+    **Progress (F4c-9b, #TBD): F4c is now fully closed.** Flipped every remaining dual-write site
+    to single-write-through-the-mutator-API, deleted `ClassDef::methods`, and deleted
+    `sync_user_method_entries` itself. This is the box's headline "invert the write direction and
+    remove the field" step, done as one coherent PR (per CLAUDE.md's "prefer one coherent
+    architectural PR over ten micro-PRs" -- the write sites are too interdependent to split
+    safely: deleting the field is an all-or-nothing compile-time fact). Twenty-three files.
+
+    **(1) Write-site conversions**, each dropping the `class_def.methods` half and keeping only
+    the mutator call already dual-writing there since F4c-3/4/5/6: `registration_class_body_
+    method.rs` (multi push, non-multi retain+push, `handles` delegation), `registration_class_
+    body.rs` (`our &alias ::= &m`), `registration_class_compose.rs` and `_compose_body.rs` (role-
+    method composition into the class), `registration_class.rs`'s `apply_handle_specs` (split the
+    shared `apply_resolved_handles` helper so the class path only still uses it for the wildcard
+    half -- the method half writes straight to the registry now; the role path,
+    `apply_handle_specs_to_role`, is untouched, still using the full shared helper since `RoleDef::
+    methods` stays), `registration_class_augment.rs` (five sites: method decl, both `handles`
+    blocks, `compose_role_into_augmented_class`, and the role-pun class literal in `ensure_role_
+    pun_class` -- this last one drops the `methods:` field from the `ClassDef` struct literal
+    entirely and moves its content to a post-insert `set_user_methods` loop), `methods_classhow_
+    dispatch.rs` (`^add_method`/`^add_multi_method` -- `^add_multi_method` keeps its `classes.
+    contains_key` existence gate per design note (0)(iii), now checked directly instead of via an
+    `Option<&mut ClassDef>` match), `system.rs` (BEGIN-time method statements), and `types/role_
+    mixin_class.rs`'s `compose_mixin_role_submethods`.
+
+    **(2) The redeclaration self-healing gap (R1, the headline risk) -- found and fixed, not just
+    inherited.** Composition's dual-writes are *appends* (`push_user_method`), and pre-9b this was
+    masked because `publish_class_shell`'s `sync_user_method_entries` call *rebuilt* the registry
+    from the freshly-composed `class_def.methods` afterward, silently discarding whatever the
+    dual-write had appended onto a stale prior declaration's rows. Deleting that rebuild step
+    would have let a redeclared class accumulate duplicate role-composed methods forever. Fixed by
+    moving the clear earlier: `register_class_decl` now calls `clear_user_methods_for_owner`
+    immediately after `begin_class_def`, before composition runs, so composition always appends
+    onto a clean slate. This also closes a *pre-existing*, independent gap: composition's `?`
+    early-return on failure had no rollback at all before this change (a failed `does` composition
+    could already leave dangling `method_entries` rows with no owning `ClassDef`, pre-9b too,
+    just less consequential because `class_def.methods` was the actually-consulted copy at read
+    time -- the field deletion makes the registry the sole record, so this pre-existing gap had to
+    be closed in the same slice). Fixed by adding an explicit `snapshot.restore` on composition
+    failure. `publish_class_shell`'s own trailing `sync_user_method_entries` calls (both the
+    normal and `is_stub_body` paths) are now dead weight and deleted outright -- the owner's rows
+    are already correct by the time it runs.
+
+    **(3) The other four `sync_user_method_entries` calling contexts**, each replaced with the
+    mechanism actually needed instead of a blanket rebuild: `finalize_class_registration`'s
+    trailing call (`registration_class_body_exit.rs`) was a pure no-op by the time it ran (the
+    per-statement loop and `resolve_class_stub_requirements` had already kept the registry
+    correct) -- deleted with no replacement. `ClassRegSnapshot::restore` (`registration_class_
+    validate.rs`, the F4c-8 rollback path) already had `restore_user_method_rows` doing the real
+    work; only needed to add the accessor re-derive (`sync_accessor_entries`) it was implicitly
+    getting as `sync_user_method_entries`'s surviving half. `compose_role_into_augmented_class`
+    (`registration_class_augment.rs`) similarly only needed the accessor re-derive, not a method
+    rebuild (its own method rows are already correct going in). The EVAL rollback path
+    (`system_eval_string.rs`, F4c-8(b)) needed real new machinery: since `classes_snapshot` no
+    longer carries method rows, a parallel `method_rows_snapshot: HashMap<String, Vec<(Symbol,
+    Vec<MethodDef>)>>` is captured for every class alongside it (before the EVAL runs), and the
+    resurrected-classes repair loop now calls `restore_user_method_rows` + `sync_accessor_entries`
+    per resurrected owner instead of a rebuild. The `require`-alias copy (`builtins_system_
+    require.rs`, F4c-7's territory) similarly needed a real replacement: `user_method_rows_for_
+    owner` on the source name, `restore_user_method_rows` + `sync_accessor_entries` on the alias
+    name -- copying between two different owners, which `restore_user_method_rows`'s signature
+    (rows carry no owner of their own) supports directly. `runtime_init.rs`'s startup builtin-
+    class seeding loop (`for class_name in classes.keys() { sync_user_method_entries }`) is now
+    `sync_accessor_entries` only -- every seeded `ClassDef` has zero methods by construction, so
+    only the accessor derive from `attributes` was ever doing anything there.
+
+    **(4) Remaining readers migrated as a prerequisite for field deletion** (not previously caught
+    by F4c-9a-1/2's downstream-consumer sweep, since these are write-adjacent files that sweep
+    deliberately skipped): `resolve_class_stub_requirements` and `check_private_calls_exist_expr`
+    (`registration.rs`, both now read `Registry::user_method_overloads` instead of the in-flight/
+    fetched `ClassDef`; `resolve_class_stub_requirements` also lost its now-fully-unused
+    `class_def: &mut ClassDef` parameter, and its caller `finalize_class_registration` stopped
+    passing it), `methods_object.rs`'s `is_native_default_constructible` (the one F4c-9a-1 missed
+    from the design note's own (0)(iv) ground-truth correction list), `accessors_resolve.rs`'s
+    `check_class_native_readonly_param_errors` and `compile_class_methods` (the latter now uses
+    the purpose-built `Registry::map_user_methods_in_place` mutator instead of mutating `class_def.
+    methods` in place then rebuilding), and `class_dispatch.rs:228`
+    (`instance_method_not_found`'s `has_visible_method` scan) -- the one site the F4c design note
+    explicitly said to *skip* as "F6's carrier, cut over for free" is no longer skippable: the
+    field is gone, so every remaining reference had to move regardless of which future box would
+    otherwise have deleted it. F6's own text (this box, a few lines below) is stale on this one
+    point now -- `class_dispatch.rs:228` reads `user_method_overloads` today, not `class_def.
+    methods`, though the surrounding `run_instance_method` carrier F6 targets is otherwise
+    unchanged.
+
+    **(5) Registry unit test.** `user_override_shares_the_builtin_method_entry`
+    (`registry.rs`) constructed a `ClassDef` with a `methods` field and called `sync_user_method_
+    entries` to exercise the builtin/user-row-sharing invariant; rewritten to call `set_user_
+    methods`/`clear_user_methods_for_owner` directly, same assertions.
+
+    **(6) `ClassDef::methods` field deletion mechanics.** Beyond the write/read sites above, ~90
+    `methods: HashMap::new()` struct-literal fields across `runtime_init.rs` (71 `ClassDef`
+    literals, mechanically stripped with a script that tracked `ClassDef{`/`RoleDef{` brace depth
+    so the 7 `RoleDef` literals in the same file -- which keep their `methods` field -- were left
+    untouched) and five other files (`registration_class_validate.rs`, `registration_class_
+    compose_body.rs`, `methods_object_native_ctors_io.rs`, `methods_classhow_dispatch.rs`,
+    `methods_object_dispatch_new.rs`) needed the field dropped, per the box's own "these merely
+    lose a field" framing for the seed initializers.
+
+    Verified with the full local `t/` suite (3185 files, 29668 tests, green) under
+    `MUTSU_CHECK_METHOD_INDEX=1` (0 index/table-drift assertions -- the index invariant this
+    checks is unaffected by the write-direction inversion, since both sides of that invariant are
+    registry-internal); the same 243-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset producing
+    byte-identical failure output against a `main`-baseline release build (same 7 pre-existing
+    non-whitelisted failures, zero new breakage); `scripts/battery-testsuite.sh` (GATE PASSED,
+    245/271, identical to the F4c-9a runs -- notably exercises `OO::Monitors`, the EXPORTHOW::
+    DECLARE/MOP-heaviest battery and the one most likely to catch a `^add_method`/`^add_multi_
+    method` regression from item (1)); `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
+    all clean.
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1931,6 +1931,29 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
     DECLARE/MOP-heaviest battery and the one most likely to catch a `^add_method`/`^add_multi_
     method` regression from item (1)); `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt`
     all clean.
+
+    **Correction/fix found by CI, not local verification (R8, the lock-reentrancy hazard).**
+    `class_body_code_alias` (item (1)'s `registration_class_body.rs` entry, `our &alias ::= &m`)
+    originally read `if let Some(overloads) = self.registry().user_method_overloads(cx.name,
+    source_name) { self.registry_mut().set_user_methods(...); }` -- exactly the R8 shape this
+    ADR's own F4c-3/F4c-4/F4c-6 progress notes already warn about: a `self.registry()` temporary
+    used directly as an `if let` scrutinee has its `RegistryReadGuard` lifetime-extended for the
+    WHOLE if-let body by Rust's temporary-extension rule, so the nested `self.registry_mut()` call
+    is a same-thread recursive `RwLock` acquisition -- a deadlock, not a panic, so it surfaced as a
+    CI timeout (`roast/S13-syntax/aliasing.t`, exit 124) rather than a local test failure; none of
+    this box's own local verification (full `t/`, the roast subset, the battery gate) exercises
+    `our &alias ::= &method` inside a class body, so it passed clean locally and only CI's fuller
+    roast run caught it. Fixed by hoisting the `Option<Vec<MethodDef>>` to an owned `let` binding
+    before the `if let`, matching the established safe idiom this file and `registration_class_
+    compose_body.rs` already use elsewhere (with their own explanatory comments predating this
+    box). Audited every other `if let Some(...) = self.registry()...` site this box's diff touches
+    or added for the same shape (`registration_class_body_method.rs`, `registration_class_augment.
+    rs` — both already safe, the `registry_mut()` calls sit after the `if let` block closes, not
+    inside it) -- no second instance found. Regression-pinned locally in `t/method-alias-decl-no-
+    deadlock.t` (roast's own `S13-syntax/aliasing.t` already covers it, but is not always run
+    locally). Re-verified after the fix: full local `t/` (3185 files, 29668 tests, green), the same
+    243-file roast subset (byte-identical to `main` baseline), `scripts/battery-testsuite.sh`
+    (GATE PASSED, 245/271).
   F6 does not have to wait on F4 as a whole: only `class_dispatch.rs:228` couples them, so F6's
   caller-reduction slices (migrating the ~40 `run_instance_method` references off the carrier,
   one family at a time) can proceed in parallel with F4a/b/c and simply pick up that one site

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -85,9 +85,14 @@ impl Interpreter {
         // No user-code re-entry here (only the static compiler check runs), so a
         // let-bound guard is safe.
         let registry = self.registry();
-        let class_def = registry.classes.get(class_name)?;
-        for overloads in class_def.methods.values() {
-            for def in overloads {
+        registry.classes.get(class_name)?;
+        for method_name in registry.owner_method_names(class_name) {
+            let Some(overloads) =
+                registry.user_method_overloads(class_name, &method_name.resolve())
+            else {
+                continue;
+            };
+            for def in &overloads {
                 if let Some(err_val) =
                     crate::compiler::Compiler::check_native_readonly_param_assignment(
                         &def.param_defs,
@@ -115,10 +120,10 @@ impl Interpreter {
     /// Compile method bodies for a given class using the bytecode compiler.
     pub(crate) fn compile_class_methods(&mut self, class_name: &str) {
         let dist = self.resolve_package_distribution(class_name);
-        if let Some(class_def) = self.registry_mut().classes.get_mut(class_name) {
-            Self::compile_methods_for_map(&mut class_def.methods, class_name, dist);
-        }
-        self.registry_mut().sync_user_method_entries(class_name);
+        self.registry_mut()
+            .map_user_methods_in_place(Symbol::intern(class_name), |def| {
+                Self::compile_method_def_in_place_with_dist(def, class_name, dist.clone());
+            });
     }
 
     /// Compile method bodies for a given role.

--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -224,7 +224,7 @@ impl Interpreter {
                 self.env.insert(alias, value);
             }
 
-            let mut class_aliases: Vec<(String, ClassDef)> = Vec::new();
+            let mut class_aliases: Vec<(String, String, ClassDef)> = Vec::new();
             for (name, class_def) in &self.registry().classes {
                 if before_class_keys.contains(name) {
                     continue;
@@ -232,18 +232,22 @@ impl Interpreter {
                 let tail = name.rsplit_once("::").map(|(_, t)| t).unwrap_or(name);
                 let alias = format!("{pkg}::{tail}");
                 if !self.registry().classes.contains_key(&alias) {
-                    class_aliases.push((alias, class_def.clone()));
+                    class_aliases.push((name.clone(), alias, class_def.clone()));
                 }
             }
-            for (alias, class_def) in class_aliases {
+            for (name, alias, class_def) in class_aliases {
                 self.registry_mut().classes.insert(alias.clone(), class_def);
-                // ADR-0019 F4c-7: the aliased `ClassDef`'s methods must also
+                // ADR-0019 F4c-9b: the aliased class's method rows must also
                 // land in the registry's canonical `method_entries` table
-                // under the alias name, or every F4c-1-cut-over enumeration
-                // site (`.^methods`, etc.) sees the alias as method-less
-                // even though `class_def.methods` (still consulted by the
-                // yet-to-be-cut-over dispatch paths) has them.
-                self.registry_mut().sync_user_method_entries(&alias);
+                // under the alias name -- there is no `ClassDef::methods`
+                // left for a `sync_user_method_entries`-style re-derive to
+                // copy from, so copy the rows directly instead.
+                let name_owner = crate::symbol::Symbol::intern(&name);
+                let alias_owner = crate::symbol::Symbol::intern(&alias);
+                let rows = self.registry().user_method_rows_for_owner(name_owner);
+                self.registry_mut()
+                    .restore_user_method_rows(alias_owner, rows);
+                self.registry_mut().sync_accessor_entries(alias_owner);
             }
         }
 

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -223,9 +223,7 @@ impl Interpreter {
         // e.g. submethod on ancestor only).
         let has_visible_method = self.class_mro(receiver_class_name).iter().any(|cn| {
             self.registry()
-                .classes
-                .get(cn.as_str())
-                .and_then(|c| c.methods.get(method_name))
+                .user_method_overloads(cn.as_str(), method_name)
                 .is_some_and(|ovs| {
                     let is_ancestor = cn.as_str() != receiver_class_name;
                     ovs.iter()

--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -26,7 +26,6 @@ pub(crate) struct ClassDef {
     /// Attributes declared with `has $x` (no twigil) — the bare name is an alias
     /// for `$!x` inside class methods.
     pub(crate) alias_attributes: HashSet<String>,
-    pub(crate) methods: HashMap<String, Vec<MethodDef>>, // name -> overloads
     pub(crate) native_methods: HashSet<String>,
     pub(crate) mro: std::sync::Arc<[crate::symbol::Symbol]>,
     /// Attribute var names (e.g. "!foo") that have `handles *` wildcard delegation.

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -862,7 +862,6 @@ impl Interpreter {
                             attribute_smileys: HashMap::new(),
                             attribute_built: HashMap::new(),
                             alias_attributes: HashSet::new(),
-                            methods: HashMap::new(),
                             native_methods: HashSet::new(),
                             mro: sym_mro(&[&class_name]),
                             wildcard_handles: vec![],
@@ -871,20 +870,11 @@ impl Interpreter {
                     );
                 }
                 let defs = multi_family.unwrap_or_else(|| vec![def]);
-                if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
-                    class_def.methods.insert(method_name.clone(), defs.clone());
-                }
-                // ADR-0019 F4c-6: dual-write on a separate short-lived
-                // guard, matching this function's F4c-4 sibling
-                // (`registration_class_augment.rs`) -- cannot share the
-                // `class_def` borrow above, which is a live sub-borrow of
-                // the held write guard for its whole block.
                 self.registry_mut().set_user_methods(
                     Symbol::intern(&class_name),
                     Symbol::intern(&method_name),
                     defs,
                 );
-                self.registry_mut().sync_user_method_entries(&class_name);
                 // Class shape changed (an added BUILD/TWEAK/new flips ctor
                 // eligibility) — drop cached construction plans.
                 self.native_ctor_plan_cache.clear();
@@ -936,26 +926,15 @@ impl Interpreter {
                     source_file: sub_data.source_file.clone(),
                     role_param_bindings: None,
                 };
-                let inserted =
-                    if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
-                        class_def
-                            .methods
-                            .entry(method_name.clone())
-                            .or_default()
-                            .push(def.clone());
-                        true
-                    } else {
-                        false
-                    };
-                if inserted {
-                    // ADR-0019 F4c-6: dual-write on a separate short-lived
-                    // guard -- see `add_method`'s own F4c-6 comment above.
+                // `^add_multi_method` must still *error* for an unregistered
+                // class -- existence keys off `classes.contains_key`, not the
+                // method table (ADR-0019 F4c design note (0)(iii)).
+                if self.registry().classes.contains_key(&class_name) {
                     self.registry_mut().push_user_method(
                         Symbol::intern(&class_name),
                         Symbol::intern(&method_name),
                         def,
                     );
-                    self.registry_mut().sync_user_method_entries(&class_name);
                     self.native_ctor_plan_cache.clear();
                     return Ok(Value::NIL);
                 }

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -92,8 +92,8 @@ impl Interpreter {
             // fall through. A class with an unprovided `is required` or unset
             // class-typed attribute also falls through at build time (it may be
             // set by BUILD, which the conservative native path does not assume).
-            let simple = !class_def.methods.contains_key("BUILDALL")
-                && !class_def.methods.contains_key("new")
+            let simple = registry.user_method_overloads(&cls, "BUILDALL").is_none()
+                && registry.user_method_overloads(&cls, "new").is_none()
                 && class_def.native_methods.is_empty()
                 // An `is built(Bool)` trait only flips whether an attribute is
                 // assigned from a named arg — the native builder already honours

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -642,7 +642,6 @@ impl Interpreter {
                     ClassDef {
                         parents: vec!["IO::Path".to_string()],
                         attributes: Vec::new(),
-                        methods: HashMap::new(),
                         native_methods: std::collections::HashSet::new(),
                         mro: [].into(),
                         attribute_types: HashMap::new(),

--- a/src/runtime/methods_object_native_ctors_io.rs
+++ b/src/runtime/methods_object_native_ctors_io.rs
@@ -22,7 +22,6 @@ impl Interpreter {
                 ClassDef {
                     parents: vec!["IO::Path".to_string()],
                     attributes: Vec::new(),
-                    methods: HashMap::new(),
                     native_methods: std::collections::HashSet::new(),
                     mro: [].into(),
                     attribute_types: HashMap::new(),

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -196,15 +196,10 @@ impl Interpreter {
     pub(super) fn resolve_class_stub_requirements(
         &mut self,
         class_name: &str,
-        class_def: &mut ClassDef,
     ) -> Result<(), RuntimeError> {
-        // ADR-0019 F4c-1: enumerate via the canonical reverse index instead
-        // of `class_def.methods.keys()`. `class_def` here is the very state
-        // `run_class_body`'s own last per-statement `sync_user_method_entries`
-        // call already published to the registry (this function runs before
-        // `class_def` gets mutated below), so the two are guaranteed in sync
-        // -- zero-mismatch shadow-checked across the full local `t/` suite
-        // before this cutover.
+        // ADR-0019 F4c-9b: the registry's `method_entries` table is the sole
+        // store now, so this function reads/writes it directly instead of an
+        // in-flight `ClassDef` parameter.
         let method_names: Vec<String> = self
             .registry()
             .owner_method_names(class_name)
@@ -318,9 +313,9 @@ impl Interpreter {
                             // because it is required by roles: C1, R1." — an
                             // X::Comp-flavored compile error naming every role
                             // that requires the method.
-                            let mut role_names: Vec<String> = class_def
-                                .methods
-                                .get(&method_name)
+                            let mut role_names: Vec<String> = self
+                                .registry()
+                                .user_method_overloads(class_name, &method_name)
                                 .map(|defs| {
                                     defs.iter()
                                         .filter(|d| {
@@ -372,14 +367,13 @@ impl Interpreter {
             // ADR-0019 F4c-3: dual-write, see class_body_method_decl's own
             // comment in registration_class_body_method.rs. Safe even though
             // this loop can still return `Err` on a later `method_name`
-            // (leaving these registry writes uncommitted-to-`class_def`
-            // stragglers): `finalize_class_registration`'s only caller
-            // rolls back via `ClassRegSnapshot::restore`, which always ends
-            // with a full `sync_user_method_entries(name)` re-derive from
-            // the restored (pre-attempt) `class_def` -- that unconditional
-            // full re-derive overwrites any partial state a failed attempt
-            // left in the registry, exactly as it already does for
-            // `class_def` itself.
+            // (ADR-0019 F4c-9b: the registry is now the sole store, so there
+            // is no `class_def` straggler to worry about): `finalize_class_
+            // registration`'s only caller rolls back via `ClassRegSnapshot::
+            // restore`, which always restores the full pre-attempt row set
+            // for this owner via `restore_user_method_rows` -- self-
+            // sufficient repair of any partial state a failed attempt left
+            // behind, needing no `class_def`-derived re-sync.
             let owner = Symbol::intern(class_name);
             if concrete.is_empty() {
                 if stubs.is_empty() {
@@ -387,14 +381,9 @@ impl Interpreter {
                 }
                 self.registry_mut()
                     .remove_user_methods(owner, Symbol::intern(&method_name));
-                class_def.methods.remove(&method_name);
             } else {
-                self.registry_mut().set_user_methods(
-                    owner,
-                    Symbol::intern(&method_name),
-                    concrete.clone(),
-                );
-                class_def.methods.insert(method_name, concrete);
+                self.registry_mut()
+                    .set_user_methods(owner, Symbol::intern(&method_name), concrete);
             }
         }
         Ok(())
@@ -785,9 +774,9 @@ impl Interpreter {
                     let method_name = name.resolve();
                     // Skip owner-qualified calls (e.g., Class::method)
                     if !method_name.contains("::") {
-                        let has_method = class_def
-                            .methods
-                            .get(&method_name)
+                        let has_method = self
+                            .registry()
+                            .user_method_overloads(class_name, &method_name)
                             .is_some_and(|overloads| overloads.iter().any(|md| md.is_private));
                         if !has_method {
                             return Err(

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -402,34 +402,37 @@ impl Interpreter {
         class_def: &mut ClassDef,
     ) {
         let resolved = self.resolve_handle_specs_to_names(specs, attr_var_name);
-        // ADR-0019 F4c-3: dual-write, see class_body_method_decl's own
-        // comment in registration_class_body_method.rs. `apply_resolved_
-        // handles` stays the shared class/role implementation (`RoleDef::
-        // methods` is out of scope for the registry index, see the F4c
-        // design note section (1)), so only the class-only wrapper here
-        // additionally writes through the registry.
+        // ADR-0019 F4c-9b: unlike `apply_handle_specs_to_role` below, the
+        // class path writes methods straight to the registry -- there is no
+        // `ClassDef::methods` for `apply_resolved_handles`' shared
+        // implementation to target anymore (`RoleDef::methods` stays out of
+        // scope for the registry index, see the F4c design note section
+        // (1), so the role path keeps using that shared helper unchanged).
         let owner = Symbol::intern(class_name);
         let mut registry = self.registry_mut();
         for handle in &resolved {
-            if let ResolvedHandle::Method {
-                exposed,
-                target,
-                attr_var,
-            } = handle
-            {
-                registry.push_user_method(
-                    owner,
-                    Symbol::intern(exposed),
-                    make_delegation_method(attr_var, target),
-                );
+            match handle {
+                ResolvedHandle::Method {
+                    exposed,
+                    target,
+                    attr_var,
+                } => {
+                    registry.push_user_method(
+                        owner,
+                        Symbol::intern(exposed),
+                        make_delegation_method(attr_var, target),
+                    );
+                }
+                ResolvedHandle::Regex { attr_var, pattern } => {
+                    class_def
+                        .wildcard_handles
+                        .push(format!("{}:regex:{}", attr_var, pattern));
+                }
+                ResolvedHandle::WildcardHandle(attr_var) => {
+                    class_def.wildcard_handles.push(attr_var.clone());
+                }
             }
         }
-        drop(registry);
-        apply_resolved_handles(
-            &resolved,
-            &mut class_def.methods,
-            &mut class_def.wildcard_handles,
-        );
     }
 
     /// Apply `handles` specifications to a role definition.

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -1,6 +1,4 @@
-use super::registration_class::{
-    AttrValidationCtx, ResolvedHandle, apply_resolved_handles, make_delegation_method,
-};
+use super::registration_class::{AttrValidationCtx, ResolvedHandle, make_delegation_method};
 use super::registration_class_body_method_forms::method_sub_form_params;
 use super::*;
 use crate::ast::HandleSpec;
@@ -286,16 +284,21 @@ impl Interpreter {
                     // `is_my=true` from the parser.
                     let is_lexical_only = decl.is_my && !decl.is_submethod;
                     let is_our_only = decl.is_our && !decl.our_variable_form;
+                    // ADR-0019 F4c-9b: single write through the registry
+                    // mutator API -- augment mutates the already-registered
+                    // `ClassDef`, but there is no `ClassDef::methods` left to
+                    // mutate in place, so the conflict check reads the
+                    // canonical table directly instead of the local
+                    // short-lived `class_def` borrow the pre-9b dual-write
+                    // needed.
                     if !is_lexical_only
                         && !is_our_only
-                        && let Some(class_def) = self.registry_mut().classes.get_mut(name)
+                        && self.registry().classes.contains_key(name)
                     {
+                        let owner = Symbol::intern(name);
+                        let method_sym = Symbol::intern(&resolved_method_name);
                         if decl.multi {
-                            class_def
-                                .methods
-                                .entry(resolved_method_name.clone())
-                                .or_default()
-                                .push(def.clone());
+                            self.registry_mut().push_user_method(owner, method_sym, def);
                         } else {
                             // Check for duplicate non-multi method
                             // definition. Only error if the existing
@@ -308,7 +311,10 @@ impl Interpreter {
                             // walker's privacy-aware check (ADR-0019
                             // D3-5).
                             let new_is_private = def.is_private;
-                            if let Some(existing) = class_def.methods.get(&resolved_method_name) {
+                            if let Some(existing) = self
+                                .registry()
+                                .user_method_overloads(name, &resolved_method_name)
+                            {
                                 let conflicts = existing.iter().any(|m| {
                                     m.role_origin.is_none() && m.is_private == new_is_private
                                 });
@@ -319,36 +325,6 @@ impl Interpreter {
                                     )));
                                 }
                             }
-                            let entry = class_def
-                                .methods
-                                .entry(resolved_method_name.clone())
-                                .or_default();
-                            entry.retain(|m| m.is_private != new_is_private);
-                            entry.push(def.clone());
-                        }
-                    }
-                    // ADR-0019 F4c-4: dual-write, mirroring the block above
-                    // but on its own short-lived registry guard -- it
-                    // CANNOT share the `class_def` borrow above. Unlike
-                    // F4c-3's in-flight `ClassBodyCx`, augment mutates the
-                    // already-registered `ClassDef` in place, so `class_def`
-                    // there is a live sub-borrow of a held write guard; a
-                    // second `registry_mut()` call while it is still alive
-                    // is the R8 lock-reentrancy hazard, not a hypothetical
-                    // one (see the F4c-3 progress note for where this bit).
-                    // The conflict check itself does not need repeating: if
-                    // it would have failed, the block above already
-                    // returned `Err` before this point.
-                    if !is_lexical_only
-                        && !is_our_only
-                        && self.registry().classes.contains_key(name)
-                    {
-                        let owner = Symbol::intern(name);
-                        let method_sym = Symbol::intern(&resolved_method_name);
-                        if decl.multi {
-                            self.registry_mut().push_user_method(owner, method_sym, def);
-                        } else {
-                            let new_is_private = def.is_private;
                             self.registry_mut()
                                 .retain_user_methods(owner, method_sym, |m| {
                                     m.is_private != new_is_private
@@ -533,57 +509,44 @@ impl Interpreter {
                     // `augment class Foo { method inner() handles 'uc'
                     // {...} }` makes `Foo.new.uc` dispatch through
                     // `inner`).
-                    if !decl.handles.is_empty()
-                        && let Some(class_def) = self.registry_mut().classes.get_mut(name)
-                    {
-                        let source_attr_marker = format!("&{}", resolved_method_name);
-                        for spec in &decl.handles {
-                            match spec {
-                                HandleSpec::Name(target) => {
-                                    class_def
-                                        .methods
-                                        .entry(target.clone())
-                                        .or_default()
-                                        .push(make_delegation_method(&source_attr_marker, target));
-                                }
-                                HandleSpec::Rename { exposed, target } => {
-                                    class_def
-                                        .methods
-                                        .entry(exposed.clone())
-                                        .or_default()
-                                        .push(make_delegation_method(&source_attr_marker, target));
-                                }
-                                HandleSpec::Wildcard => {
-                                    class_def.wildcard_handles.push(source_attr_marker.clone());
-                                }
-                                HandleSpec::Regex(pattern) => {
-                                    class_def
-                                        .wildcard_handles
-                                        .push(format!("{}:regex:{}", source_attr_marker, pattern));
-                                }
-                                HandleSpec::Type(_) => {}
-                            }
-                        }
-                    }
-                    // ADR-0019 F4c-4: dual-write on a separate short-lived
-                    // guard, see this function's earlier F4c-4 comment for
-                    // why it cannot share the `class_def` borrow above.
                     if !decl.handles.is_empty() && self.registry().classes.contains_key(name) {
                         let owner = Symbol::intern(name);
                         let source_attr_marker = format!("&{}", resolved_method_name);
                         for spec in &decl.handles {
-                            let (exposed, target) = match spec {
-                                HandleSpec::Name(target) => (target, target),
-                                HandleSpec::Rename { exposed, target } => (exposed, target),
-                                HandleSpec::Wildcard
-                                | HandleSpec::Regex(_)
-                                | HandleSpec::Type(_) => continue,
-                            };
-                            self.registry_mut().push_user_method(
-                                owner,
-                                Symbol::intern(exposed),
-                                make_delegation_method(&source_attr_marker, target),
-                            );
+                            match spec {
+                                HandleSpec::Name(target) => {
+                                    self.registry_mut().push_user_method(
+                                        owner,
+                                        Symbol::intern(target),
+                                        make_delegation_method(&source_attr_marker, target),
+                                    );
+                                }
+                                HandleSpec::Rename { exposed, target } => {
+                                    self.registry_mut().push_user_method(
+                                        owner,
+                                        Symbol::intern(exposed),
+                                        make_delegation_method(&source_attr_marker, target),
+                                    );
+                                }
+                                HandleSpec::Wildcard => {
+                                    if let Some(class_def) =
+                                        self.registry_mut().classes.get_mut(name)
+                                    {
+                                        class_def.wildcard_handles.push(source_attr_marker.clone());
+                                    }
+                                }
+                                HandleSpec::Regex(pattern) => {
+                                    if let Some(class_def) =
+                                        self.registry_mut().classes.get_mut(name)
+                                    {
+                                        class_def.wildcard_handles.push(format!(
+                                            "{}:regex:{}",
+                                            source_attr_marker, pattern
+                                        ));
+                                    }
+                                }
+                                HandleSpec::Type(_) => {}
+                            }
                         }
                     }
                 }
@@ -620,16 +583,25 @@ impl Interpreter {
                                 .attribute_types
                                 .insert(attr_name_str.clone(), tc.clone());
                         }
-                        apply_resolved_handles(
-                            &resolved,
-                            &mut class_def.methods,
-                            &mut class_def.wildcard_handles,
-                        );
+                        // ADR-0019 F4c-9b: only the wildcard half of
+                        // `apply_resolved_handles` applies here now -- a
+                        // `ResolvedHandle::Method` writes straight to the
+                        // registry below, there is no `ClassDef::methods`
+                        // left for the shared helper to target.
+                        for handle in &resolved {
+                            match handle {
+                                ResolvedHandle::Regex { attr_var, pattern } => {
+                                    class_def
+                                        .wildcard_handles
+                                        .push(format!("{}:regex:{}", attr_var, pattern));
+                                }
+                                ResolvedHandle::WildcardHandle(attr_var) => {
+                                    class_def.wildcard_handles.push(attr_var.clone());
+                                }
+                                ResolvedHandle::Method { .. } => {}
+                            }
+                        }
                     }
-                    // ADR-0019 F4c-4: dual-write on a separate short-lived
-                    // guard -- `resolved` was already computed above,
-                    // before any registry borrow, so it is safe to reuse
-                    // here without re-resolving.
                     if self.registry().classes.contains_key(name) {
                         let owner = Symbol::intern(name);
                         for handle in &resolved {
@@ -734,34 +706,18 @@ impl Interpreter {
                 }
             }
         }
-        // ADR-0019 F4c-4: kept for the registry dual-write below, which
-        // cannot share the `class_def` borrow this block takes (see this
-        // file's earlier F4c-4 comments for why).
-        let all_methods_for_registry = all_methods.clone();
         if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
-            for (mname, mdefs) in all_methods {
-                // Only add a role method the class does not already define
-                // itself (a class-local method wins over a composed one).
-                let entry = class_def.methods.entry(mname).or_default();
-                let has_local = entry.iter().any(|d| d.role_origin.is_none());
-                if !has_local {
-                    for mut d in mdefs {
-                        if d.role_origin.is_none() {
-                            d.role_origin = Some(base_role.to_string());
-                        }
-                        entry.push(d);
-                    }
-                }
-            }
             for attr in all_attributes {
                 if !class_def.attributes.iter().any(|a| a.name == attr.name) {
                     class_def.attributes.push(attr);
                 }
             }
         }
+        // Only add a role method the class does not already define itself
+        // (a class-local method wins over a composed one).
         if self.registry().classes.contains_key(name) {
             let owner = Symbol::intern(name);
-            for (mname, mdefs) in all_methods_for_registry {
+            for (mname, mdefs) in all_methods {
                 let has_local = self
                     .registry()
                     .user_method_overloads(name, &mname)
@@ -788,7 +744,8 @@ impl Interpreter {
             .entry(name.to_string())
             .or_default()
             .extend(composed);
-        self.registry_mut().sync_user_method_entries(name);
+        self.registry_mut()
+            .sync_accessor_entries(Symbol::intern(name));
         // Recompile so the fast path sees the newly composed methods.
         self.compile_class_methods(name);
     }
@@ -1208,15 +1165,12 @@ impl Interpreter {
                 }
             }
         }
-        // ADR-0019 F4c-5: kept for the registry dual-write below.
-        let all_methods_for_registry = all_methods.clone();
         let punned_class = ClassDef {
             parents: Vec::new(),
             attributes: all_attributes,
             attribute_types,
             attribute_smileys,
             attribute_built: HashMap::new(),
-            methods: all_methods,
             native_methods: HashSet::new(),
             mro: super::sym_mro(&[role_name, "Any", "Mu"]),
             wildcard_handles: all_wildcard_handles,
@@ -1226,12 +1180,8 @@ impl Interpreter {
         self.registry_mut()
             .classes
             .insert(role_name.to_string(), punned_class);
-        // Dual-write the pun's methods through the mutator API too -- this
-        // is a brand-new `ClassDef` (not a mutation of an already-borrowed
-        // one), so there is no R8 held-guard hazard here; each
-        // `set_user_methods` call is its own short-lived guard.
         let owner = Symbol::intern(role_name);
-        for (name, defs) in all_methods_for_registry {
+        for (name, defs) in all_methods {
             self.registry_mut()
                 .set_user_methods(owner, Symbol::intern(&name), defs);
         }

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -205,7 +205,8 @@ impl Interpreter {
             self.registry_mut()
                 .classes
                 .insert(cx.name.to_string(), cx.class_def.clone());
-            self.registry_mut().sync_user_method_entries(cx.name);
+            self.registry_mut()
+                .sync_accessor_entries(Symbol::intern(cx.name));
         }
         self.run_class_body_leave_phasers(&cx, &class_leave_phasers)?;
         self.persist_class_body_statics(&cx, declared_static_names);
@@ -248,23 +249,19 @@ impl Interpreter {
             unreachable!("class_body_code_alias called on a non-CodeVar VarDecl");
         };
         let alias = var_name.trim_start_matches('&').to_string();
-        if let Some(overloads) = cx.class_def.methods.get(source_name).cloned() {
-            // ADR-0019 F4c-3: dual-write, see class_body_method_decl's own
-            // comment -- this function republishes `cx.class_def` wholesale
-            // to the registry a few lines below anyway, so this is a
-            // redundant-but-cheap early confirmation, not the sole write.
+        if let Some(overloads) = self.registry().user_method_overloads(cx.name, source_name) {
             self.registry_mut().set_user_methods(
                 Symbol::intern(cx.name),
                 Symbol::intern(&alias),
-                overloads.clone(),
+                overloads,
             );
-            cx.class_def.methods.insert(alias, overloads);
         }
         // Also execute the statement so the code variable is set
         self.registry_mut()
             .classes
             .insert(cx.name.to_string(), cx.class_def.clone());
-        self.registry_mut().sync_user_method_entries(cx.name);
+        self.registry_mut()
+            .sync_accessor_entries(Symbol::intern(cx.name));
         self.run_class_body_chunk_or_raw(chunk, std::slice::from_ref(stmt))?;
         for outer_name in cx.saved_env.keys() {
             let class_scoped_name = format!("{}::{}", cx.name, outer_name);
@@ -369,7 +366,8 @@ impl Interpreter {
         self.registry_mut()
             .classes
             .insert(cx.name.to_string(), cx.class_def.clone());
-        self.registry_mut().sync_user_method_entries(cx.name);
+        self.registry_mut()
+            .sync_accessor_entries(Symbol::intern(cx.name));
         // Mark this class as "being defined" so a `has`-attribute
         // declaration executed by a *compile-time* phaser
         // (`class Foo { BEGIN EVAL q[has $.x] }`) attaches to it

--- a/src/runtime/registration_class_body.rs
+++ b/src/runtime/registration_class_body.rs
@@ -249,7 +249,13 @@ impl Interpreter {
             unreachable!("class_body_code_alias called on a non-CodeVar VarDecl");
         };
         let alias = var_name.trim_start_matches('&').to_string();
-        if let Some(overloads) = self.registry().user_method_overloads(cx.name, source_name) {
+        // The `Option<Vec<MethodDef>>` must be bound to an owned local before
+        // the `if let` so the `self.registry()` read guard drops before
+        // `self.registry_mut()` below -- otherwise this is a same-thread
+        // recursive `RwLock` acquisition (the R8 hazard: `if let Some(x) =
+        // self.registry()....cloned() { ... self.registry_mut() ... }`).
+        let overloads = self.registry().user_method_overloads(cx.name, source_name);
+        if let Some(overloads) = overloads {
             self.registry_mut().set_user_methods(
                 Symbol::intern(cx.name),
                 Symbol::intern(&alias),

--- a/src/runtime/registration_class_body_attr.rs
+++ b/src/runtime/registration_class_body_attr.rs
@@ -146,38 +146,25 @@ impl Interpreter {
         // to it with an Attribute introspection object; otherwise raise
         // X::Comp::Trait::Unknown. Kept in a separate method so its
         // locals don't inflate this already-large function's frame.
-        if !decl.unknown_traits.is_empty() {
-            if let Err(err) = self.apply_attribute_traits(
+        // ADR-0019 F4c-9b: a user-defined `trait_mod:<is>` calling
+        // `.^add_method` mid-body (e.g. Attribute::Predicate's `is
+        // predicate`) writes straight to the canonical `method_entries`
+        // table now — there is no local `class_def.methods` copy left for
+        // it to be clobbered by, so (unlike pre-9b) nothing needs merging
+        // back afterward.
+        if !decl.unknown_traits.is_empty()
+            && let Err(err) = self.apply_attribute_traits(
                 &decl.unknown_traits,
                 &attr_name_str,
                 decl.sigil,
                 decl.is_public,
                 cx.name,
                 decl.type_constraint.as_deref(),
-            ) {
-                self.set_current_package(cx.saved_package.clone());
-                self.env = cx.saved_env.clone();
-                return Err(err);
-            }
-            // A user-defined `trait_mod:<is>` may have called
-            // `.^add_method` on the class currently being composed
-            // (e.g. Attribute::Predicate's `is predicate` adds a
-            // `has-foo` accessor). Those methods land directly in the
-            // registry entry, but the local `class_def` — re-inserted
-            // at the end of body processing — would clobber them.
-            // Merge any registry methods not already present locally,
-            // mirroring the class_def re-sync done after run_block_raw.
-            if let Some(reg_cd) = self.registry().classes.get(cx.name) {
-                let added: Vec<(String, Vec<MethodDef>)> = reg_cd
-                    .methods
-                    .iter()
-                    .filter(|(mname, _)| !cx.class_def.methods.contains_key(*mname))
-                    .map(|(mname, mdefs)| (mname.clone(), mdefs.clone()))
-                    .collect();
-                for (mname, mdefs) in added {
-                    cx.class_def.methods.insert(mname, mdefs);
-                }
-            }
+            )
+        {
+            self.set_current_package(cx.saved_package.clone());
+            self.env = cx.saved_env.clone();
+            return Err(err);
         }
 
         // Handle class-level attributes (our $.x / my $.x)

--- a/src/runtime/registration_class_body_exit.rs
+++ b/src/runtime/registration_class_body_exit.rs
@@ -209,10 +209,10 @@ impl Interpreter {
         &mut self,
         name: &str,
         parents: &[String],
-        mut class_def: ClassDef,
+        class_def: ClassDef,
         snapshot: &ClassRegSnapshot,
     ) -> Result<(), RuntimeError> {
-        if let Err(err) = self.resolve_class_stub_requirements(name, &mut class_def) {
+        if let Err(err) = self.resolve_class_stub_requirements(name) {
             snapshot.restore(self, name);
             return Err(err);
         }
@@ -223,7 +223,6 @@ impl Interpreter {
         self.registry_mut()
             .classes
             .insert(name.to_string(), class_def);
-        self.registry_mut().sync_user_method_entries(name);
         let mut stack = Vec::new();
         if let Err(err) = self.compute_class_mro(name, &mut stack) {
             snapshot.restore(self, name);

--- a/src/runtime/registration_class_body_method.rs
+++ b/src/runtime/registration_class_body_method.rs
@@ -188,23 +188,14 @@ impl Interpreter {
         let is_lexical_only = decl.is_my && !decl.is_submethod;
         let is_our_only = decl.is_our && !decl.our_variable_form;
         if !is_lexical_only && !is_our_only {
-            // ADR-0019 F4c-3: dual-write -- `cx.class_def.methods` stays the
-            // authoritative in-flight state (still re-derived wholesale into
-            // the registry by the per-statement `sync_user_method_entries`
-            // call right after this returns, per F4c design note (3)'s
-            // bridge), but each write also goes straight through the
-            // registry mutator API so the two agree at every point, not
-            // just at statement boundaries.
+            // ADR-0019 F4c-9b: the registry's `method_entries` table is the
+            // sole store now -- every write goes straight through the
+            // mutator API, with no `cx.class_def.methods` half left to keep
+            // in lockstep.
             let owner = Symbol::intern(cx.name);
             let method_sym = Symbol::intern(&resolved_method_name);
             if decl.multi {
-                self.registry_mut()
-                    .push_user_method(owner, method_sym, def.clone());
-                cx.class_def
-                    .methods
-                    .entry(resolved_method_name.clone())
-                    .or_default()
-                    .push(def);
+                self.registry_mut().push_user_method(owner, method_sym, def);
             } else {
                 // Check for duplicate non-multi method definition.
                 // Only error if the existing method was defined in
@@ -214,7 +205,10 @@ impl Interpreter {
                 // collide (they are stored together but dispatch filters
                 // on `is_private`).
                 let new_is_private = def.is_private;
-                if let Some(existing) = cx.class_def.methods.get(&resolved_method_name) {
+                if let Some(existing) = self
+                    .registry()
+                    .user_method_overloads(cx.name, &resolved_method_name)
+                {
                     let conflicts = existing
                         .iter()
                         .any(|m| m.role_origin.is_none() && m.is_private == new_is_private);
@@ -230,15 +224,7 @@ impl Interpreter {
                 // privacy stored under the same name.
                 self.registry_mut()
                     .retain_user_methods(owner, method_sym, |m| m.is_private != new_is_private);
-                self.registry_mut()
-                    .push_user_method(owner, method_sym, def.clone());
-                let entry = cx
-                    .class_def
-                    .methods
-                    .entry(resolved_method_name.clone())
-                    .or_default();
-                entry.retain(|m| m.is_private != new_is_private);
-                entry.push(def);
+                self.registry_mut().push_user_method(owner, method_sym, def);
             }
         }
         // A method declared `is export` is importable as a *sub* whose
@@ -360,26 +346,16 @@ impl Interpreter {
                         self.registry_mut().push_user_method(
                             Symbol::intern(cx.name),
                             Symbol::intern(target),
-                            delegation.clone(),
+                            delegation,
                         );
-                        cx.class_def
-                            .methods
-                            .entry(target.clone())
-                            .or_default()
-                            .push(delegation);
                     }
                     HandleSpec::Rename { exposed, target } => {
                         let delegation = make_delegation_method(&source_attr_marker, target);
                         self.registry_mut().push_user_method(
                             Symbol::intern(cx.name),
                             Symbol::intern(exposed),
-                            delegation.clone(),
+                            delegation,
                         );
-                        cx.class_def
-                            .methods
-                            .entry(exposed.clone())
-                            .or_default()
-                            .push(delegation);
                     }
                     HandleSpec::Wildcard => {
                         cx.class_def

--- a/src/runtime/registration_class_compose.rs
+++ b/src/runtime/registration_class_compose.rs
@@ -372,24 +372,12 @@ impl Interpreter {
                     })
                     .collect()
             };
-            // ADR-0019 F4c-3: dual-write, see class_body_method_decl's own
-            // comment in registration_class_body_method.rs -- the periodic
-            // per-statement `sync_user_method_entries` call re-derives the
-            // registry from `cx.class_def.methods` regardless, so this is
-            // additive, not the sole write.
-            {
-                let owner = Symbol::intern(cx.name);
-                let method_sym = Symbol::intern(mname);
-                let mut registry = self.registry_mut();
-                for def in &composed {
-                    registry.push_user_method(owner, method_sym, def.clone());
-                }
+            let owner = Symbol::intern(cx.name);
+            let method_sym = Symbol::intern(mname);
+            let mut registry = self.registry_mut();
+            for def in composed {
+                registry.push_user_method(owner, method_sym, def);
             }
-            cx.class_def
-                .methods
-                .entry(mname.clone())
-                .or_default()
-                .extend(composed);
         }
         // Transfer wildcard handles from role to class
         for wh in &role.wildcard_handles {

--- a/src/runtime/registration_class_compose_body.rs
+++ b/src/runtime/registration_class_compose_body.rs
@@ -413,22 +413,12 @@ impl Interpreter {
                                 })
                                 .collect()
                         };
-                        // ADR-0019 F4c-3: dual-write, see
-                        // class_body_method_decl's own comment in
-                        // registration_class_body_method.rs.
-                        {
-                            let owner = Symbol::intern(cx.name);
-                            let method_sym = Symbol::intern(mname);
-                            let mut registry = self.registry_mut();
-                            for def in &composed {
-                                registry.push_user_method(owner, method_sym, def.clone());
-                            }
+                        let owner = Symbol::intern(cx.name);
+                        let method_sym = Symbol::intern(mname);
+                        let mut registry = self.registry_mut();
+                        for def in composed {
+                            registry.push_user_method(owner, method_sym, def);
                         }
-                        cx.class_def
-                            .methods
-                            .entry(mname.clone())
-                            .or_default()
-                            .extend(composed);
                     }
                 } else if self.registry().classes.contains_key(parent_base)
                     && !cx.class_def.parents.iter().any(|p| p == &resolved_parent)
@@ -487,7 +477,6 @@ impl Interpreter {
                     attribute_types: HashMap::new(),
                     attribute_smileys: HashMap::new(),
                     attribute_built: HashMap::new(),
-                    methods: HashMap::new(),
                     native_methods: HashSet::new(),
                     mro: [].into(),
                     wildcard_handles: Vec::new(),

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -180,6 +180,21 @@ impl Interpreter {
             is_hidden,
             hidden_parents,
         );
+        // ADR-0019 F4c-9b: composition writes methods straight to the
+        // registry now (there is no `ClassDef::methods` buffer for
+        // `publish_class_shell` to later rebuild the table from), so a
+        // redeclaration must start this owner's method rows from a clean
+        // slate right here, before composition runs -- otherwise a stale
+        // row from the PREVIOUS declaration would survive alongside the
+        // freshly composed one (`push_user_method` appends, it does not
+        // replace). Only `user_candidates` are cleared (the `builtin`/
+        // `accessor`/`proto` columns are untouched, matching every other
+        // mutator's liveness semantics). If composition itself fails,
+        // restore from `snapshot` so the attempt does not leave the
+        // still-valid previous class (whose `ClassDef` in `registry.
+        // classes` is untouched at this point either way) methodless.
+        self.registry_mut()
+            .clear_user_methods_for_owner(crate::symbol::Symbol::intern(name));
         // Compose roles listed in the parents (from "does Role" or "is Role" in class header)
         let RoleCompositionOutcome {
             composed_roles_list,
@@ -194,7 +209,12 @@ impl Interpreter {
                 class_def: &mut class_def,
                 out: RoleCompositionOutcome::default(),
             };
-            self.compose_class_parent_roles(&mut cx, parents, does_parents, parent_pre_args)?;
+            if let Err(err) =
+                self.compose_class_parent_roles(&mut cx, parents, does_parents, parent_pre_args)
+            {
+                snapshot.restore(self, name);
+                return Err(err);
+            }
             cx.out
         };
         if class_role_param_bindings.is_empty() {

--- a/src/runtime/registration_class_validate.rs
+++ b/src/runtime/registration_class_validate.rs
@@ -74,23 +74,21 @@ impl ClassRegSnapshot {
         } else {
             reg.class_role_param_bindings.remove(name);
         }
-        // ADR-0019 F4c-8(a): dual-write the method rows through the mutator
-        // API too. Redundant with the `sync_user_method_entries` call below
-        // today (which re-derives from the just-restored `prev_class.
-        // methods` and wins), but this is the mechanism F4c-9b needs once
-        // that field and that function are gone. `restore_user_method_rows`
-        // only ever touches `user_candidates`, so `MethodEntry::proto`
-        // survives untouched here exactly as the pre-existing behavior
-        // leaves it; `method_wrap_chains` is untouched by either path,
-        // also matching pre-existing behavior. Both are deliberate,
-        // pre-existing gaps -- see the design note's own instruction not to
-        // fold that behavior change into this box.
-        reg.restore_user_method_rows(
-            crate::symbol::Symbol::intern(name),
-            self.prev_method_rows.clone(),
-        );
-        drop(reg);
-        this.registry_mut().sync_user_method_entries(name);
+        // ADR-0019 F4c-9b: `restore_user_method_rows` is now the sole
+        // mechanism restoring the method rows (there is no `ClassDef::
+        // methods` left for a `sync_user_method_entries`-style re-derive to
+        // read). `restore_user_method_rows` only ever touches
+        // `user_candidates`, so `MethodEntry::proto` survives untouched
+        // here exactly as pre-existing behavior left it; `method_wrap_
+        // chains` is untouched by either path, also matching pre-existing
+        // behavior. Both are deliberate, pre-existing gaps -- see the
+        // design note's own instruction not to fold that behavior change
+        // into this box. The accessor column still needs its own re-derive
+        // from the just-restored `prev_class.attributes`, which
+        // `sync_user_method_entries` used to also do as its surviving half.
+        let owner = crate::symbol::Symbol::intern(name);
+        reg.restore_user_method_rows(owner, self.prev_method_rows.clone());
+        reg.sync_accessor_entries(owner);
     }
 }
 
@@ -355,7 +353,6 @@ impl Interpreter {
             attribute_types: HashMap::new(),
             attribute_smileys: HashMap::new(),
             attribute_built: HashMap::new(),
-            methods: HashMap::new(),
             native_methods: HashSet::new(),
             mro: [].into(),
             wildcard_handles: Vec::new(),
@@ -429,16 +426,18 @@ impl Interpreter {
                     .extend(does_roles);
             }
         }
+        // ADR-0019 F4c-9b: no `sync_user_method_entries` needed here anymore
+        // -- the registry's method rows for `name` were already brought to
+        // a clean, fully-composed state before this call (see
+        // `register_class_decl`'s pre-composition clear).
         self.registry_mut()
             .classes
             .insert(name.to_string(), class_def.clone());
-        self.registry_mut().sync_user_method_entries(name);
         if is_stub_body {
             self.registry_mut().class_stubs.insert(name.to_string());
             self.registry_mut()
                 .classes
                 .insert(name.to_string(), class_def.clone());
-            self.registry_mut().sync_user_method_entries(name);
             let mut stack = Vec::new();
             let _ = self.compute_class_mro(name, &mut stack)?;
             return Ok(true);

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -361,41 +361,6 @@ impl Registry {
         entries.into_iter().map(|entry| entry.name).collect()
     }
 
-    /// Re-derives `method_entries`' user-owned columns for `class_name` from
-    /// `ClassDef::methods`/`ClassDef::attributes` — the sole writer of the
-    /// user/accessor columns until ADR-0019 F4c-3 starts moving individual
-    /// class-declaration write sites onto the mutator API directly. As of
-    /// F4c-2 this function is itself just a caller of that API (`clear_user_
-    /// methods_for_owner`, `set_user_methods`, `sync_accessor_entries`, all
-    /// in `registry_method_table.rs`) rather than inlining the retain/
-    /// re-populate logic — see the ADR-0019 F4c design note section (3).
-    /// `entry.proto` (ADR-0019 E8b) is untouched by any of these: unlike
-    /// `user_candidates`/`accessor` it has no `ClassDef`-backed source to
-    /// re-derive from (written once, directly, by `Registry::
-    /// set_proto_method`), and every mutator's liveness check already counts
-    /// it toward keeping a row alive, so a proto-only entry survives this
-    /// call exactly as before.
-    pub(crate) fn sync_user_method_entries(&mut self, class_name: &str) {
-        let owner = Symbol::intern(class_name);
-        self.clear_user_methods_for_owner(owner);
-        let Some(class_def) = self.classes.get(class_name) else {
-            // A pure clear (`withdraw_role_pun`, `rename_generic_composed_
-            // class`'s old-name half, ...): `classes.get` misses, so there is
-            // nothing to re-derive rows from beyond the accessor clear below.
-            self.sync_accessor_entries(owner);
-            return;
-        };
-        let methods = class_def.methods.clone();
-        for (name, candidates) in methods {
-            self.set_user_methods(owner, Symbol::intern(&name), candidates);
-        }
-        // A later same-name declaration within the class overrides an
-        // earlier one; `sync_accessor_entries` iterates `ClassDef::
-        // attributes` in declaration order and lets each write clobber the
-        // last, giving the same "most recent wins" result as before.
-        self.sync_accessor_entries(owner);
-    }
-
     pub(crate) fn user_method_overloads(
         &self,
         class_name: &str,
@@ -1317,10 +1282,10 @@ mod tests {
             source_file: None,
             role_param_bindings: None,
         };
-        let mut class = ClassDef::default();
-        class.methods.insert("chars".to_string(), vec![method]);
-        registry.classes.insert("Str".to_string(), class);
-        registry.sync_user_method_entries("Str");
+        registry
+            .classes
+            .insert("Str".to_string(), ClassDef::default());
+        registry.set_user_methods(Symbol::intern("Str"), Symbol::intern("chars"), vec![method]);
         assert!(registry.method_generation > seeded_generation);
 
         let entry = registry
@@ -1335,7 +1300,7 @@ mod tests {
 
         let override_generation = registry.method_generation;
         registry.classes.remove("Str");
-        registry.sync_user_method_entries("Str");
+        registry.clear_user_methods_for_owner(Symbol::intern("Str"));
         assert!(registry.method_generation > override_generation);
         let entry = registry
             .method_entries

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -72,7 +72,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Mu"]),
                 attribute_types: HashMap::new(),
@@ -88,7 +87,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Mu".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Any", "Mu"]),
                 attribute_types: HashMap::new(),
@@ -104,7 +102,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Any".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["IterationBuffer", "Any", "Mu"]),
                 attribute_types: HashMap::new(),
@@ -120,7 +117,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["keep", "result", "status", "then"]
                     .iter()
                     .map(|s| s.to_string())
@@ -139,7 +135,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["keep", "break"].iter().map(|s| s.to_string()).collect(),
                 mro: sym_mro(&["Promise::Vow"]),
                 attribute_types: HashMap::new(),
@@ -155,7 +150,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["send", "receive", "close", "closed"]
                     .iter()
                     .map(|s| s.to_string())
@@ -174,7 +168,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Collation"]),
                 attribute_types: HashMap::new(),
@@ -190,7 +183,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["finish", "id"].iter().map(|s| s.to_string()).collect(),
                 mro: sym_mro(&["Thread"]),
                 attribute_types: HashMap::new(),
@@ -206,7 +198,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "emit",
                     "tap",
@@ -253,7 +244,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["utf8"]),
                 attribute_types: HashMap::new(),
@@ -269,7 +259,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["utf16"]),
                 attribute_types: HashMap::new(),
@@ -285,7 +274,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Any".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Blob", "Any", "Mu"]),
                 attribute_types: HashMap::new(),
@@ -301,7 +289,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Blob".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Buf", "Blob", "Any", "Mu"]),
                 attribute_types: HashMap::new(),
@@ -317,7 +304,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "emit",
                     "done",
@@ -343,7 +329,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Supplier".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Supplier::Preserving", "Supplier"]),
                 attribute_types: HashMap::new(),
@@ -359,7 +344,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "start",
                     "command",
@@ -427,7 +411,6 @@ impl Interpreter {
                     proc_attr("pid", '$', nil_default()),
                     proc_attr("command", '@', None),
                 ],
-                methods: HashMap::new(),
                 // `Str`/`gist` are NOT native: Rakudo's Proc has no stringifier
                 // of its own, so the default instance repr applies (`Proc.new`),
                 // not the exitcode number the old native arm rendered.
@@ -452,7 +435,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["cancel", "close", "socket-port", "socket-host"]
                     .iter()
                     .map(|s| s.to_string())
@@ -471,7 +453,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 // ADR-0028 Slice 1: the callback-shim target `Supply.
                 // schedule-on()` taps invoke instead of the real tap/done/
                 // quit callback — see `native_methods::scheduled_tap_pump`.
@@ -498,7 +479,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 // `Scheduler` is a composable role (`class Test::Scheduler does
                 // Scheduler {...}`) with NO native implementation of its own --
                 // only the concrete schedulers below have one, and each lists
@@ -521,7 +501,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Scheduler".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["cue", "uncaught_handler", "loads"]
                     .iter()
                     .map(|s| s.to_string())
@@ -540,7 +519,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Scheduler".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["cue", "uncaught_handler", "loads"]
                     .iter()
                     .map(|s| s.to_string())
@@ -559,7 +537,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Scheduler".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["cue", "progress-by", "time"]
                     .iter()
                     .map(|s| s.to_string())
@@ -578,7 +555,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["cancel"].iter().map(|s| s.to_string()).collect(),
                 mro: sym_mro(&["Cancellation"]),
                 attribute_types: HashMap::new(),
@@ -594,7 +570,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["protect", "lock", "unlock", "condition"]
                     .iter()
                     .map(|s| s.to_string())
@@ -613,7 +588,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Lock".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Lock::Async", "Lock"]),
                 attribute_types: HashMap::new(),
@@ -629,7 +603,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Lock".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Lock::Soft", "Lock"]),
                 attribute_types: HashMap::new(),
@@ -645,7 +618,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["wait", "signal", "signal_all"]
                     .iter()
                     .map(|s| s.to_string())
@@ -664,7 +636,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["acquire", "try_acquire", "release"]
                     .iter()
                     .map(|s| s.to_string())
@@ -683,7 +654,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "Str",
                     "gist",
@@ -766,7 +736,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "path",
                     "IO",
@@ -819,7 +788,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "get",
                     "getc",
@@ -887,7 +855,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Backtrace"]),
                 attribute_types: HashMap::new(),
@@ -903,7 +870,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["CompUnit::Repository::FileSystem"]),
                 attribute_types: HashMap::new(),
@@ -919,7 +885,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["slurp", "slurp-rest", "Str", "gist", "print", "close"]
                     .iter()
                     .map(|s| s.to_string())
@@ -938,7 +903,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "close",
                     "getpeername",
@@ -971,7 +935,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "close",
                     "write",
@@ -1002,7 +965,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["tap", "act"].iter().map(|s| s.to_string()).collect(),
                 mro: sym_mro(&["IO::Socket::Async::Listener"]),
                 attribute_types: HashMap::new(),
@@ -1018,7 +980,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "name",
                     "auth",
@@ -1050,7 +1011,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "DISTROnames",
                     "KERNELnames",
@@ -1085,7 +1045,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "name",
                     "auth",
@@ -1122,7 +1081,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "name",
                     "auth",
@@ -1151,7 +1109,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "name",
                     "auth",
@@ -1183,7 +1140,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["name", "alternative-names", "encoder", "decoder"]
                     .iter()
                     .map(|s| s.to_string())
@@ -1202,7 +1158,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["encode-chars"].iter().map(|s| s.to_string()).collect(),
                 mro: sym_mro(&["Encoding::Encoder"]),
                 attribute_types: HashMap::new(),
@@ -1218,7 +1173,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: [
                     "decode-chars",
                     "add-bytes",
@@ -1247,7 +1201,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: ["find", "register"].iter().map(|s| s.to_string()).collect(),
                 mro: sym_mro(&["Encoding::Registry"]),
                 attribute_types: HashMap::new(),
@@ -1263,7 +1216,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::Block"]),
                 attribute_types: HashMap::new(),
@@ -1279,7 +1231,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Pod::Block".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::Block::Code", "Pod::Block"]),
                 attribute_types: HashMap::new(),
@@ -1295,7 +1246,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Pod::Block".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::FormattingCode", "Pod::Block"]),
                 attribute_types: HashMap::new(),
@@ -1311,7 +1261,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Pod::Block".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::Block::Comment", "Pod::Block"]),
                 attribute_types: HashMap::new(),
@@ -1327,7 +1276,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Pod::Block".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::Block::Para", "Pod::Block"]),
                 attribute_types: HashMap::new(),
@@ -1343,7 +1291,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Pod::Block".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::Block::Named", "Pod::Block"]),
                 attribute_types: HashMap::new(),
@@ -1359,7 +1306,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Pod::Block".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::Heading", "Pod::Block"]),
                 attribute_types: HashMap::new(),
@@ -1375,7 +1321,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Pod::Block".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::Block::Table", "Pod::Block"]),
                 attribute_types: HashMap::new(),
@@ -1391,7 +1336,6 @@ impl Interpreter {
             ClassDef {
                 parents: Vec::new(),
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::Config"]),
                 attribute_types: HashMap::new(),
@@ -1407,7 +1351,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Pod::Block".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Pod::Item", "Pod::Block"]),
                 attribute_types: HashMap::new(),
@@ -1423,7 +1366,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec![],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["Exception"]),
                 attribute_types: HashMap::new(),
@@ -1439,7 +1381,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Exception".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::AdHoc", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1455,7 +1396,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Exception".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::TypeCheck", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1471,7 +1411,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["X::TypeCheck".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::TypeCheck::Binding", "X::TypeCheck", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1487,7 +1426,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["X::TypeCheck::Binding".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&[
                     "X::TypeCheck::Binding::Parameter",
@@ -1508,7 +1446,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Exception".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::Parameter", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1524,7 +1461,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["X::Parameter".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&[
                     "X::Parameter::InvalidConcreteness",
@@ -1544,7 +1480,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Exception".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::Supply::Combinator", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1560,7 +1495,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["X::TypeCheck".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::TypeCheck::Argument", "X::TypeCheck", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1576,7 +1510,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["X::TypeCheck".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::TypeCheck::Assignment", "X::TypeCheck", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1592,7 +1525,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Exception".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::Numeric::Real", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1608,7 +1540,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Exception".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::TypeCheck::Return", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1624,7 +1555,6 @@ impl Interpreter {
             ClassDef {
                 parents: vec!["Exception".to_string()],
                 attributes: Vec::new(),
-                methods: HashMap::new(),
                 native_methods: HashSet::new(),
                 mro: sym_mro(&["X::Coerce::Impossible", "Exception"]),
                 attribute_types: HashMap::new(),
@@ -1662,7 +1592,6 @@ impl Interpreter {
                 ClassDef {
                     parents: vec![parent.to_string()],
                     attributes: Vec::new(),
-                    methods: HashMap::new(),
                     native_methods: HashSet::new(),
                     mro,
                     attribute_types: HashMap::new(),
@@ -2199,7 +2128,7 @@ impl Interpreter {
                 };
                 let class_names: Vec<String> = registry.classes.keys().cloned().collect();
                 for class_name in class_names {
-                    registry.sync_user_method_entries(&class_name);
+                    registry.sync_accessor_entries(crate::symbol::Symbol::intern(&class_name));
                 }
                 Arc::new(RwLock::new(Arc::new(registry)))
             },

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -364,21 +364,6 @@ impl Interpreter {
                     source_file: self.current_source_file(),
                     role_param_bindings: None,
                 };
-                if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
-                    if *multi {
-                        class_def
-                            .methods
-                            .entry(resolved_method_name.clone())
-                            .or_default()
-                            .push(def.clone());
-                    } else {
-                        class_def
-                            .methods
-                            .insert(resolved_method_name.clone(), vec![def.clone()]);
-                    }
-                }
-                // ADR-0019 F4c-6: dual-write on a separate short-lived
-                // guard -- cannot share the `class_def` borrow above.
                 let owner = crate::symbol::Symbol::intern(&class_name);
                 let method_sym = crate::symbol::Symbol::intern(&resolved_method_name);
                 if *multi {
@@ -387,7 +372,6 @@ impl Interpreter {
                     self.registry_mut()
                         .set_user_methods(owner, method_sym, vec![def]);
                 }
-                self.registry_mut().sync_user_method_entries(&class_name);
             } else {
                 remaining.push(stmt);
             }

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -227,6 +227,22 @@ impl Interpreter {
         let role_parents_snapshot = self.registry().role_parents.clone();
         let role_hides_snapshot = self.registry().role_hides.clone();
         let classes_snapshot = self.registry().classes.clone();
+        // ADR-0019 F4c-9b: `classes_snapshot` no longer carries method rows
+        // (there is no `ClassDef::methods` field left), so snapshot the
+        // canonical table's rows for every class here too -- before the
+        // EVAL runs and can mutate/clear them -- for the resurrected-class
+        // repair below to restore from.
+        let method_rows_snapshot: HashMap<String, Vec<(crate::symbol::Symbol, Vec<MethodDef>)>> =
+            classes_snapshot
+                .keys()
+                .map(|name| {
+                    let owner = crate::symbol::Symbol::intern(name);
+                    (
+                        name.clone(),
+                        self.registry().user_method_rows_for_owner(owner),
+                    )
+                })
+                .collect();
         let hidden_classes_snapshot = self.registry().hidden_classes.clone();
         let hidden_defer_parents_snapshot = self.registry().hidden_defer_parents.clone();
         let class_composed_roles_snapshot = self.registry().class_composed_roles.clone();
@@ -459,7 +475,13 @@ impl Interpreter {
         // class's `method_entries` rows are already correct and untouched
         // by the snapshot/extend dance.
         for class_name in resurrected_classes {
-            self.registry_mut().sync_user_method_entries(&class_name);
+            let owner = crate::symbol::Symbol::intern(&class_name);
+            let rows = method_rows_snapshot
+                .get(&class_name)
+                .cloned()
+                .unwrap_or_default();
+            self.registry_mut().restore_user_method_rows(owner, rows);
+            self.registry_mut().sync_accessor_entries(owner);
         }
         for key in current_type_keys.union(&snapshot_type_keys) {
             if let Some(value) = current_env.get(key).cloned() {

--- a/src/runtime/types/role_mixin_class.rs
+++ b/src/runtime/types/role_mixin_class.rs
@@ -209,26 +209,12 @@ impl Interpreter {
             return;
         }
         self.clear_private_zeroarg_method_cache();
-        // ADR-0019 F4c-4: kept for the registry dual-write below.
-        let composed_for_registry = composed.clone();
         let mut registry = self.registry_mut();
-        let Some(class_def) = registry.classes.get_mut(class_name) else {
+        if !registry.classes.contains_key(class_name) {
             return;
-        };
-        for (method_name, defs) in composed {
-            class_def
-                .methods
-                .entry(method_name)
-                .or_default()
-                .extend(defs);
         }
-        // Dual-write via the SAME already-held `registry` guard -- not a
-        // fresh `self.registry_mut()` call. `class_def`'s borrow ended
-        // with the loop above (its last use), so this is just another
-        // method call on `registry`, not a reentrant lock acquisition
-        // (the R8 hazard other F4c-4 sites in this ADR box hit).
         let owner = Symbol::intern(class_name);
-        for (method_name, defs) in composed_for_registry {
+        for (method_name, defs) in composed {
             let method_sym = Symbol::intern(&method_name);
             for def in defs {
                 registry.push_user_method(owner, method_sym, def);

--- a/t/method-alias-decl-no-deadlock.t
+++ b/t/method-alias-decl-no-deadlock.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 2;
+
+# ADR-0019 F4c-9b regression: `our &alias ::= &method` inside a class body
+# used to deadlock (same-thread recursive RwLock acquisition) because
+# `class_body_code_alias` held the `self.registry()` read guard alive
+# through an `if let Some(overloads) = self.registry().user_method_overloads(...)`
+# block that then called `self.registry_mut()` inside it. Mirrors
+# roast/S13-syntax/aliasing.t's own repro.
+
+my class Baz {
+    method bar() { 42 }
+    our &baz ::= &bar;
+}
+
+my $ret;
+lives-ok {
+    my $obj = Baz.new;
+    $ret    = $obj.baz();
+}, 'calling an aliased method does not deadlock';
+is $ret, 42, 'the aliased method returned the right thing';


### PR DESCRIPTION
## Summary
The final slice of ADR-0019 F4c (following the F4c-9a reader cutover, #6516). Flips every write site from dual-write (registry mutator + `class_def.methods`) to single-write (registry mutator only), deletes the `ClassDef::methods` field, and deletes `sync_user_method_entries` itself. **F4c is now fully closed.**

Done as one coherent PR rather than split further — the write sites are too interdependent to split safely (deleting the field is an all-or-nothing compile-time fact).

### Two real bugs found and fixed, not just inherited
- **The redeclaration self-healing gap (R1, the design note's headline risk).** Composition's dual-writes are appends (`push_user_method`), and this was only safe pre-9b because `publish_class_shell`'s `sync_user_method_entries` call rebuilt the registry from the freshly-composed `class_def.methods` afterward, silently discarding whatever the dual-write had appended onto a stale prior declaration's rows. Fixed by clearing the owner's method rows in `register_class_decl` right before composition runs, so composition always appends onto a clean slate.
- **A pre-existing gap where a failed role composition had no rollback at all**, leaving dangling `method_entries` rows behind (masked pre-9b because `class_def.methods` was the actually-consulted copy at read time). Fixed by restoring the snapshot on composition failure.

### Scope
- Write-site conversions across 12 files (`registration_class_body_method.rs`, `registration_class_body.rs`, `registration_class_compose{,_body}.rs`, `registration_class.rs`, `registration_class_augment.rs`, `methods_classhow_dispatch.rs`, `system.rs`, `types/role_mixin_class.rs`).
- The other `sync_user_method_entries` call sites replaced with exactly the mechanism each one actually needs (`sync_accessor_entries`-only where methods were already correct, a new `method_rows_snapshot`-based repair for the EVAL rollback path, and a `user_method_rows_for_owner`/`restore_user_method_rows` copy for the `require`-alias path).
- A handful of `ClassDef::methods` readers the F4c-9a sweep didn't reach (write-adjacent files it deliberately skipped, plus `class_dispatch.rs:228` — no longer skippable as "F6's job" once the field itself is gone).
- ~90 now-vestigial `methods: HashMap::new()` struct-literal fields dropped (mechanically, `RoleDef` literals — which keep their own `methods` field — left untouched).

Full design rationale and per-item notes are in the new "Progress (F4c-9b, #TBD)" entry in `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` all clean
- [x] Full local `t/` suite (3185 files, 29668 tests) green under `MUTSU_CHECK_METHOD_INDEX=1` (0 index/table-drift assertions)
- [x] 243-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset produces byte-identical failure output against a `main`-baseline release build (same 7 pre-existing non-whitelisted failures, zero new breakage)
- [x] `scripts/battery-testsuite.sh` — GATE PASSED (245/271, identical to the F4c-9a runs; exercises `OO::Monitors`, the EXPORTHOW::DECLARE/MOP-heaviest battery and the one most likely to catch an `^add_method`/`^add_multi_method` regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)