### PR TITLE
fix: type the ternary ?? !! second-part diagnoses

### DIFF
--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -66,7 +66,8 @@ pub(crate) use comparison::comparison_expr_mode;
 pub(crate) use custom_infix::{ListInfixOperand, parse_flipflop_infix};
 pub(crate) use errors::{
     cannot_meta_assign_diffy_error, check_range_precedence_worry,
-    conditional_precedence_too_loose_error, non_associative_error, non_associative_pair_error,
+    conditional_precedence_too_loose_error, conditional_second_part_gobbled_error,
+    conditional_second_part_invalid_error, non_associative_error, non_associative_pair_error,
     non_list_associative_error, syntax_exception,
 };
 pub(crate) use list_infix::{sequence_expr, sequence_only_expr};

--- a/src/parser/expr/precedence/errors.rs
+++ b/src/parser/expr/precedence/errors.rs
@@ -100,9 +100,55 @@ pub(crate) fn cannot_meta_assign_diffy_error(op: &str, dba: &str, remaining_len:
     err
 }
 
-pub(crate) fn conditional_precedence_too_loose_error() -> PError {
+/// `X::Syntax::ConditionalOperator::PrecedenceTooLoose`: something looser than
+/// the conditional `?? !!` sits inside a branch and needs parentheses -- an
+/// assignment operator (`$a ?? $a = 1 !! $a = 2`), the comma list separator
+/// (`1 ?? 2,3 !! 4,5`), or a colonpair adverb (`1 ?? 3 :foo !! 2`). `op` is
+/// rakudo's own spelling of the offending operator and appears verbatim in
+/// both the message and the `.operator` attribute (verified against
+/// `raku -e '...'` for each shape: the message is always exactly "Precedence
+/// of {op} is too loose to use inside ?? !!; please parenthesize").
+pub(crate) fn conditional_precedence_too_loose_error(op: &str) -> PError {
+    let message =
+        format!("Precedence of {op} is too loose to use inside ?? !!; please parenthesize");
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    attrs.insert("operator".to_string(), Value::str(op.to_string()));
+    let exception = Value::make_instance(
+        Symbol::intern("X::Syntax::ConditionalOperator::PrecedenceTooLoose"),
+        attrs,
+    );
+    PError::fatal_with_exception(message, Box::new(exception))
+}
+
+/// `X::Syntax::ConditionalOperator::SecondPartInvalid`: the else-branch was
+/// introduced with something other than `!!` -- rakudo recognizes `::` and a
+/// bare `:` as typos for it (`1 ?? 3 :: 2`, `1 ?? 3 : 2`) and names the
+/// offending spelling directly, both in the message and the `.second-part`
+/// attribute.
+pub(crate) fn conditional_second_part_invalid_error(second_part: &str) -> PError {
+    let message = format!("Please use !! rather than {second_part}");
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    attrs.insert(
+        "second-part".to_string(),
+        Value::str(second_part.to_string()),
+    );
+    let exception = Value::make_instance(
+        Symbol::intern("X::Syntax::ConditionalOperator::SecondPartInvalid"),
+        attrs,
+    );
+    PError::fatal_with_exception(message, Box::new(exception))
+}
+
+/// `X::Syntax::ConditionalOperator::SecondPartGobbled`: the then-branch was a
+/// bareword call parsed as a listop, which swallowed the `!!` as part of its
+/// own argument list (`1 ?? rt123115 !! 3`, where `!! 3` parses as the
+/// double-negation prefix operator applied to `3`, becoming `rt123115`'s sole
+/// argument).
+pub(crate) fn conditional_second_part_gobbled_error() -> PError {
     syntax_exception(
-        "X::Syntax::ConditionalOperator::PrecedenceTooLoose",
-        "Assignment operators inside ?? !! are too loose; parenthesize them",
+        "X::Syntax::ConditionalOperator::SecondPartGobbled",
+        "Your !! was gobbled by the expression in the middle; please parenthesize",
     )
 }

--- a/src/parser/expr/precedence/list_infix_top.rs
+++ b/src/parser/expr/precedence/list_infix_top.rs
@@ -1,5 +1,8 @@
 use super::list_infix::{attach_trailing_adverbs, wrap_left_exclusive_sequence};
-use super::ternary::{assign_operator_is_tight, is_assignment_expr};
+use super::ternary::{
+    assign_operator_is_tight, is_assignment_expr, spelled_assign_operator,
+    ternary_missing_bang_bang_error,
+};
 use super::*;
 
 /// The "item" level: Z/X's operand precedence.
@@ -50,12 +53,18 @@ pub(crate) fn item_expr(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
         && !crate::parser::stmt::simple::is_user_declared_value_term(name)
         && !crate::parser::stmt::simple::is_user_declared_enum_value(name)
     {
+        // Only diagnose the typed SecondPartGobbled when the bareword ends
+        // cleanly (see the matching comment on the top-level `ternary_mode`
+        // guard) -- a `\` glued directly onto the bareword is the generic
+        // "Bogus code" Confused instead.
+        if after_then.is_empty() || after_then.starts_with(char::is_whitespace) {
+            return Err(conditional_second_part_gobbled_error());
+        }
         return Err(PError::expected("expected '!!' in ternary expression"));
     }
     let (after_then, _) = ws(after_then)?;
-    let (after_bang, _) = parse_tag(after_then, "!!").map_err(|err| {
-        enrich_expected_error(err, "expected '!!' in ternary expression", after_then.len())
-    })?;
+    let (after_bang, _) = parse_tag(after_then, "!!")
+        .map_err(|err| ternary_missing_bang_bang_error(after_then, err, after_then.len()))?;
     let (after_bang, _) = ws(after_bang)?;
     let (rest, else_expr) = item_expr(after_bang, mode).map_err(|err| {
         enrich_expected_error(err, "expected else-expression after '!!'", after_bang.len())
@@ -63,10 +72,15 @@ pub(crate) fn item_expr(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     // Only a LOOSE assignment is an error here; the mutating method call `.=` is
     // at method-postfix precedence and is legal inside `?? !!` (see
     // `assign_operator_is_tight`).
-    if (is_assignment_expr(&then_expr) && !assign_operator_is_tight(after_q))
-        || (is_assignment_expr(&else_expr) && !assign_operator_is_tight(after_bang))
-    {
-        return Err(conditional_precedence_too_loose_error());
+    if is_assignment_expr(&then_expr) && !assign_operator_is_tight(after_q) {
+        return Err(conditional_precedence_too_loose_error(
+            &spelled_assign_operator(after_q),
+        ));
+    }
+    if is_assignment_expr(&else_expr) && !assign_operator_is_tight(after_bang) {
+        return Err(conditional_precedence_too_loose_error(
+            &spelled_assign_operator(after_bang),
+        ));
     }
     Ok((
         rest,

--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::parser::primary::misc::colonpair_expr;
 
 pub(crate) fn is_assignment_expr(expr: &Expr) -> bool {
     matches!(
@@ -25,12 +26,24 @@ pub(crate) fn is_assignment_expr(expr: &Expr) -> bool {
 /// else is reported as loose, preserving the previous behaviour.
 pub(crate) fn assign_operator_is_tight(src: &str) -> bool {
     let src = src.trim_start();
+    if !src.starts_with(['$', '@', '%', '&']) {
+        return false;
+    }
+    skip_lvalue_prefix(src).starts_with(".=")
+}
+
+/// Skip the sigil + name at the start of an assignment branch's source text
+/// (`$x`, `@a`, `%h`, `&c`), returning what follows -- shared by
+/// [`assign_operator_is_tight`] (does the operator look like `.=`?) and
+/// [`spelled_assign_operator`] (what does the operator actually spell?).
+fn skip_lvalue_prefix(src: &str) -> &str {
+    let src = src.trim_start();
     let mut chars = src.char_indices();
     let Some((_, sigil)) = chars.next() else {
-        return false;
+        return src;
     };
     if !matches!(sigil, '$' | '@' | '%' | '&') {
-        return false;
+        return src;
     }
     let mut end = sigil.len_utf8();
     for (idx, ch) in chars {
@@ -40,7 +53,53 @@ pub(crate) fn assign_operator_is_tight(src: &str) -> bool {
             break;
         }
     }
-    src[end..].trim_start().starts_with(".=")
+    src[end..].trim_start()
+}
+
+/// The exact assignment operator spelled in `src` (a ternary branch's source
+/// text, starting at its lvalue), for
+/// `X::Syntax::ConditionalOperator::PrecedenceTooLoose`'s message/`.operator`
+/// attribute -- `raku -e 'my $a=5; $a ?? $a += 1 !! $a'` reports "Precedence
+/// of += is too loose...", not a generic "=". Falls back to "=" when no
+/// compound-assignment spelling is found there (a plain `=`, or an lvalue
+/// this heuristic doesn't recognize -- should not happen for a branch already
+/// classified as `Expr::AssignExpr`).
+pub(crate) fn spelled_assign_operator(src: &str) -> String {
+    let after_lvalue = skip_lvalue_prefix(src);
+    if let Some((remaining, _op)) = parse_compound_assign_op(after_lvalue) {
+        let consumed = after_lvalue.len() - remaining.len();
+        return after_lvalue[..consumed].to_string();
+    }
+    "=".to_string()
+}
+
+/// Diagnose why `!!` wasn't found where expected in a ternary branch --
+/// rakudo has distinct messages for the common typos/precedence traps: `::`
+/// or a bare `:` meant to be `!!`, a colonpair adverb parsed at a precedence
+/// looser than the conditional (`1 ?? 3 :foo !! 2`), or the comma list
+/// separator (`1 ?? 2,3 !! 4,5`). `residual` is the unconsumed input right
+/// where `!!` was expected (already whitespace-skipped); `err`/`remaining_len`
+/// are the underlying `parse_tag` failure, used for the generic fallback.
+/// Verified against `raku -e '...'` for each named shape.
+pub(crate) fn ternary_missing_bang_bang_error(
+    residual: &str,
+    err: PError,
+    remaining_len: usize,
+) -> PError {
+    if residual.starts_with("::") {
+        return conditional_second_part_invalid_error("::");
+    }
+    if let Ok((rest, _)) = colonpair_expr(residual) {
+        let spelled = &residual[..residual.len() - rest.len()];
+        return conditional_precedence_too_loose_error(spelled);
+    }
+    if residual.starts_with(':') {
+        return conditional_second_part_invalid_error(":");
+    }
+    if residual.starts_with(',') {
+        return conditional_precedence_too_loose_error(",");
+    }
+    enrich_expected_error(err, "expected '!!' in ternary expression", remaining_len)
 }
 
 pub(crate) fn comparison_nonassoc_key(op: &TokenKind) -> Option<&'static str> {
@@ -288,13 +347,24 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             // -- so types are excluded from this guard above and accepted.
             // Likewise a sigilless term (`my \foo = …`; `1 ?? foo !! bar`, from
             // Astro::Utils) is a complete nullary term, not a listop head.
+            //
+            // Only diagnose the typed SecondPartGobbled when the bareword ends
+            // cleanly (residual is whitespace or end-of-input): `1 ?? b !! 2`
+            // gobbles regardless of whether `b` is declared. But `1 ?? b\n !!
+            // 2` (a LITERAL backslash-n, not a newline -- the roast source
+            // deliberately writes it inside a single-quoted EVAL string) has a
+            // `\` glued directly onto `b` with no separating whitespace, which
+            // rakudo reports as the generic "Bogus code found before the !!"
+            // (`X::Syntax::Confused`) instead -- the soft fallback below.
+            if input.is_empty() || input.starts_with(char::is_whitespace) {
+                return Err(conditional_second_part_gobbled_error());
+            }
             return Err(PError::expected("expected '!!' in ternary expression"));
         }
         let (input, _) = ws(input)?;
         let (input, _) = if mode == ExprMode::Full {
-            parse_tag(input, "!!").map_err(|err| {
-                enrich_expected_error(err, "expected '!!' in ternary expression", input.len())
-            })?
+            parse_tag(input, "!!")
+                .map_err(|err| ternary_missing_bang_bang_error(input, err, input.len()))?
         } else {
             parse_tag(input, "!!")?
         };
@@ -319,10 +389,15 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
         // call at method-postfix precedence (operators.rakudoc "Method call" /
         // "Dotty infix"), far tighter than `?? !!`, so `1 ?? $v .= uc !! 9` is
         // legal and must not be rejected.
-        if (is_assignment_expr(&then_expr) && !assign_operator_is_tight(then_src))
-            || (is_assignment_expr(&else_expr) && !assign_operator_is_tight(else_src))
-        {
-            return Err(conditional_precedence_too_loose_error());
+        if is_assignment_expr(&then_expr) && !assign_operator_is_tight(then_src) {
+            return Err(conditional_precedence_too_loose_error(
+                &spelled_assign_operator(then_src),
+            ));
+        }
+        if is_assignment_expr(&else_expr) && !assign_operator_is_tight(else_src) {
+            return Err(conditional_precedence_too_loose_error(
+                &spelled_assign_operator(else_src),
+            ));
         }
         let ternary_expr = if let Expr::Binary { left, op, right } = cond {
             // The loose word-logicals (`and`/`andthen`/`notandthen`/`or`/`orelse`)

--- a/src/parser/primary/container/paren.rs
+++ b/src/parser/primary/container/paren.rs
@@ -2,7 +2,22 @@ use crate::ast::Expr;
 use crate::parser::expr::{expression, expression_no_sequence};
 use crate::parser::helpers::ws;
 use crate::parser::parse_result::{PError, PResult, parse_char};
+use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
+use crate::value::Value;
+use std::collections::HashMap;
+
+/// `X::Syntax::Adverb`: a colonpair immediately follows a term that cannot
+/// take one. `spelled` is the term's own source text and appears in both the
+/// message and the `.what` attribute.
+fn adverb_not_allowed_error(spelled: &str) -> PError {
+    let message = format!("You can't adverb {spelled}");
+    let mut attrs = HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    attrs.insert("what".to_string(), Value::str(spelled.to_string()));
+    let exception = Value::make_instance(Symbol::intern("X::Syntax::Adverb"), attrs);
+    PError::fatal_with_exception(message, Box::new(exception))
+}
 
 use super::meta_ops::{
     finalize_paren_list, maybe_curry_xz_metaop, normalize_chained_zip_meta,
@@ -178,6 +193,18 @@ fn paren_expr_inner(input: &str) -> PResult<'_, Expr> {
         expression_no_sequence(input)?
     };
     let (input, _) = ws(input)?;
+    // A colonpair directly following a bare literal is illegal -- rakudo lets an
+    // adverb attach to a call (`foo :bar`, absorbed as a named arg) or even a
+    // binary-operator call (`1+2 :foo` -> `infix:<+>(1, 2, :foo)`), but not to a
+    // plain literal term (`(3 :foo)`, `("str" :foo)`). Diagnosed with the term's
+    // own source text, matching rakudo's exact wording (verified against
+    // `raku -e '(3 :foo)'`: "You can't adverb 3").
+    if matches!(&first, Expr::Literal(_) | Expr::LiteralSrc(_, _))
+        && looks_like_colonpair_start(input)
+    {
+        let spelled = content_start[..content_start.len() - input.len()].trim_end();
+        return Err(adverb_not_allowed_error(spelled));
+    }
     // If sequence syntax appears, try full expression parsing first.
     // This avoids mis-parsing cases like ("a"...* ~~ / z /) where
     // sequence is followed by another infix operator.

--- a/t/ternary-second-part-diagnoses.t
+++ b/t/ternary-second-part-diagnoses.t
@@ -1,0 +1,72 @@
+use Test;
+
+# rakudo has several distinct compile-time diagnoses for the ways a ternary
+# `?? !!`'s then-branch can fail to reach a `!!`: `::`/`:` typoed for `!!`
+# (X::Syntax::ConditionalOperator::SecondPartInvalid), a colonpair adverb or
+# the comma list separator sitting at a precedence looser than `?? !!`
+# (X::Syntax::ConditionalOperator::PrecedenceTooLoose), and a bareword whose
+# listop call swallows the `!!` as one of its own arguments
+# (X::Syntax::ConditionalOperator::SecondPartGobbled -- this happens even for
+# an UNDECLARED bareword, since rakudo always tries the listop-call parse).
+# mutsu previously collapsed all of these into the generic
+# X::Syntax::Confused. Also covers the related X::Syntax::Adverb gap this
+# fix's paren-parsing change closed: a colonpair immediately following a bare
+# literal (`(3 :foo)`).
+#
+# Every assertion here is verified byte-identical against `raku -e '...'`.
+
+plan 18;
+
+try { EVAL '1 ?? 2,3 !! 4,5' };
+is $!.^name, 'X::Syntax::ConditionalOperator::PrecedenceTooLoose',
+    'a comma in the then-branch is PrecedenceTooLoose';
+is $!.message, 'Precedence of , is too loose to use inside ?? !!; please parenthesize',
+    'comma PrecedenceTooLoose message matches rakudo';
+is $!.operator, ',', 'comma PrecedenceTooLoose .operator is the comma';
+
+try { EVAL '1 ?? 3 :: 2' };
+is $!.^name, 'X::Syntax::ConditionalOperator::SecondPartInvalid',
+    ':: instead of !! is SecondPartInvalid';
+is $!.message, 'Please use !! rather than ::', ':: message matches rakudo';
+is $!.second-part, '::', ':: .second-part is "::"';
+
+try { EVAL '1 ?? 3 : 2' };
+is $!.^name, 'X::Syntax::ConditionalOperator::SecondPartInvalid',
+    'a bare : instead of !! is SecondPartInvalid';
+is $!.second-part, ':', ': .second-part is ":"';
+
+try { EVAL '1 ?? 3 :foo :: 2' };
+is $!.^name, 'X::Syntax::ConditionalOperator::PrecedenceTooLoose',
+    'an adverb in the then-branch is PrecedenceTooLoose';
+is $!.operator, ':foo', 'adverb PrecedenceTooLoose .operator is the spelled adverb';
+
+try {
+    my @x = ^10;
+    my @y = 2..3;
+    EVAL 'my @z = @y ?? @x[@y] :v !! @x';
+}
+is $!.^name, 'X::Syntax::ConditionalOperator::PrecedenceTooLoose',
+    'an adverb on a subscript in the then-branch is also PrecedenceTooLoose';
+is $!.operator, ':v', 'subscript adverb .operator is ":v"';
+
+try { EVAL 'sub rt123115 { 2 }; 1 ?? rt123115 !! 3' };
+is $!.^name, 'X::Syntax::ConditionalOperator::SecondPartGobbled',
+    'a declared-sub bareword in then-position that swallows !! is SecondPartGobbled';
+is $!.message, 'Your !! was gobbled by the expression in the middle; please parenthesize',
+    'SecondPartGobbled message matches rakudo';
+
+try { EVAL '1 ?? b !! 2' };
+is $!.^name, 'X::Syntax::ConditionalOperator::SecondPartGobbled',
+    'an UNDECLARED bareword also gobbles -- rakudo always tries the listop-call parse';
+
+# A literal backslash-n (NOT a newline -- single-quoted, so \n is two chars)
+# glued directly onto the bareword with no separating whitespace is bogus
+# code, not a clean listop-call gobble, so this stays the generic Confused.
+try { EVAL '1 ?? b\n !! 2' };
+is $!.^name, 'X::Syntax::Confused',
+    'a bareword immediately followed by non-whitespace garbage is still the generic Confused';
+
+try { EVAL '(3 :foo)' };
+is $!.^name, 'X::Syntax::Adverb',
+    'a colonpair directly on a bare literal is X::Syntax::Adverb';
+is $!.message, q{You can't adverb 3}, 'the message names the literal itself';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1468,3 +1468,99 @@ test in the current suite depends on this either way; fixing it would mean
 touching `eval_eval_string`'s classes/roles snapshot-merge dance
 (`system_eval_string.rs`), which is broader and riskier than this round's
 fix. Left for a future round if a roast file ever needs it.
+
+## Re-measured 2026-08-16 (round N+1): ternary `?? !!` diagnoses, and one more `X::Syntax::Adverb` gap
+
+Re-ran the full sweep on a fresh `MUTSU_REAL_TEST=1` release build to find the
+next mechanism cluster after the `misc.t`/`X::Anon::Multi` work above (no
+dominant single-file blocker was left in the ledger, so this was a fresh
+`grep -l "Got: X::Syntax::Confused"` sweep over the `-j6` residue, alone-rerun
+to separate genuine failures from `-j6` contention per this file's own
+established method). One 7-assertion cluster in a single file stood out:
+`roast/S03-operators/ternary.t` failed 7 `throws-like …,
+X::Syntax::ConditionalOperator::*` assertions, all landing on the generic
+`X::Syntax::Confused` instead.
+
+**Root cause: mutsu's ternary (`?? !!`) parser had no typed diagnoses at all
+for the common ways rakudo's grammar reports a malformed then/else branch** —
+not a registration gap this time (the file closing this round's earlier
+entries were all "typed but not registered"; this one genuinely had zero
+mechanism). Implemented four distinct diagnoses, each verified message-for-
+message against `raku -e '...'`:
+
+| shape | class | rakudo message |
+| --- | --- | --- |
+| `1 ?? 2,3 !! 4,5` (comma inside a branch) | `X::Syntax::ConditionalOperator::PrecedenceTooLoose` | "Precedence of `{op}` is too loose to use inside ?? !!; please parenthesize" |
+| `1 ?? 3 :foo !! 2` (colonpair adverb inside a branch) | same class | same message, `op` = the spelled adverb (`:foo`, `:v`, ...) |
+| `$a ?? $a = 1 !! $a = 2` (assignment inside a branch — already partly handled) | same class | same message, `op` = the spelled assignment operator (`=`, `+=`, ...) |
+| `1 ?? 3 :: 2` / `1 ?? 3 : 2` | `X::Syntax::ConditionalOperator::SecondPartInvalid` | "Please use !! rather than `{second-part}`" |
+| `1 ?? rt123115 !! 3` (a bareword listop call swallows the `!!`) | `X::Syntax::ConditionalOperator::SecondPartGobbled` | "Your !! was gobbled by the expression in the middle; please parenthesize" |
+
+The existing `PrecedenceTooLoose` builder (`conditional_precedence_too_loose_error`,
+`src/parser/expr/precedence/errors.rs`) already fired for the assignment case
+but with a message that didn't match rakudo's wording at all ("Assignment
+operators inside ?? !! are too loose; parenthesize them") and no `.operator`
+attribute — discovered by checking real `raku`'s actual output for that case
+too, not just the untested ones (`raku -e 'my $a=5; $a ?? $a = 42 !! $a =
+43'` → "Precedence of = is too loose..."). Unified all three PrecedenceTooLoose
+producers (comma, adverb, assignment) onto one parameterized builder taking
+the exact spelled operator text, fixing a latent message-wording bug in the
+same pass as adding the two missing classes.
+
+**One trap, caught by testing against `raku` and not just by feel:** the
+initial fix made the bareword-gobble diagnosis fire unconditionally whenever
+a non-type bareword sat in then-position — reasoning that `1 ??
+UNDECLARED_NAME !! 2` must be a gobble the same way `1 ?? rt123115 !! 3` (a
+*declared* sub) is. Wrong on two counts, both caught only by running the roast
+file's own existing assertion (`1 ?? b\n !! 2` → `X::Syntax::Confused`,
+`roast/S03-operators/ternary.t` line 111) against real `raku` before trusting
+the fix:
+
+1. Declared-vs-undeclared doesn't matter — `raku -e '1 ?? b !! 2'` (a clean,
+   *undeclared* bareword) also gobbles and reports `SecondPartGobbled`; rakudo
+   always attempts the listop-call parse regardless of whether the name
+   resolves.
+2. The roast assertion's `1 ?? b\n !! 2` is not actually about an undeclared
+   name at all — it's a **literal backslash-n** (two characters; the source
+   is single-quoted inside `EVAL`, so `\n` is not a newline) glued directly
+   onto the bareword with no separating whitespace, which is genuinely bogus
+   trailing code, not a clean gobble.
+
+The real, general rule (implemented in both `ternary_mode` and its
+list-infix-layer twin `item_expr`, which duplicate this whole guard — see the
+`item_expr` doc comment's own note that it "mirrors" `ternary_mode`): a
+bareword then-branch is `SecondPartGobbled` only when the residual
+immediately after it is whitespace or end-of-input; anything else (adjacent
+non-whitespace garbage) falls through to the pre-existing generic Confused
+path unchanged.
+
+**A related, separate gap surfaced in the same file and was fixed alongside
+it:** `1 ?? (3 :foo) !! 2` (a parenthesized adverbed *literal*) also failed —
+not a ternary problem at all, but `(EXPR :adverb)` general paren-expression
+parsing having no diagnosis for a colonpair directly following a bare literal
+term. rakudo: `raku -e '(3 :foo)'` → `X::Syntax::Adverb`, "You can't adverb
+3" (confirmed this is specifically about *literal* terms — `(1+2 :foo)`
+legitimately attaches the colonpair as a named argument to the `infix:<+>`
+call in rakudo, a separate, pre-existing, still-open gap left untouched since
+no roast assertion needs it). Fixed narrowly for `Expr::Literal`/
+`Expr::LiteralSrc` in `src/parser/primary/container/paren.rs`, matching only
+the verified-correct shape rather than guessing at `Expr::Var`'s behaviour
+too (which `raku -e 'my $x=5; ($x :foo)'` suggests behaves the same way, but
+was not verified byte-for-byte and is not needed by any current test —
+left as a documented possible follow-up, not assumed).
+
+`roast/S03-operators/ternary.t` is now **28/28 clean** under
+`MUTSU_REAL_TEST=1` (previously 21/28). Full `t/` suite (3186 files, 29686
+tests) and `cargo clippy -- -D warnings` both clean. Pin:
+`t/ternary-second-part-diagnoses.t` (18 assertions, all verified
+byte-identical against `raku` including the two "stays Confused" negative
+cases).
+
+**Note found in passing, not investigated:** `roast/S32-io/spurt.t` test 36
+fails when run standalone with `prove` directly (both on this branch and on a
+clean `main` checkout via `git stash` — confirmed NOT a regression from this
+round's work), but the whitelisted `make roast` run passes it. `make roast`
+removes a stale `roast/temp-file-RT-126006-test` before starting (see
+CLAUDE.md); this looks like the same class of leftover-file-from-a-prior-run
+issue, not caught this round since `prove` was run directly for speed. If it
+recurs as a genuine `make roast` failure, look there first.


### PR DESCRIPTION
## Summary
- rakudo has four distinct compile-time diagnoses for the common ways a ternary's then/else branch fails to reach `!!`: `X::Syntax::ConditionalOperator::PrecedenceTooLoose` (a comma/colonpair-adverb/assignment sitting at a precedence looser than `?? !!`), `X::Syntax::ConditionalOperator::SecondPartInvalid` (`::`/`:` typoed for `!!`), and `X::Syntax::ConditionalOperator::SecondPartGobbled` (a bareword listop call that swallows the `!!` as its own argument). mutsu previously collapsed all of these into the generic `X::Syntax::Confused`.
- Also fixes a related gap in the same roast file: a colonpair directly following a bare literal inside parens (`(3 :foo)`) now raises `X::Syntax::Adverb` ("You can't adverb 3") instead of failing to parse at all.
- `roast/S03-operators/ternary.t` goes from 21/28 to 28/28 clean under `MUTSU_REAL_TEST=1` — part of the `todo/tickets/vendor-real-test-module.md` campaign (vendoring rakudo's real `Test` module).

## Test plan
- [x] New pin `t/ternary-second-part-diagnoses.t` (18 assertions), verified byte-identical against `raku` including two negative cases (undeclared-but-clean bareword still gobbles; a bareword immediately followed by non-whitespace garbage stays the generic Confused)
- [x] `roast/S03-operators/ternary.t` passes fully under both the native and the real `Test` module
- [x] Full `t/` suite (3186 files, 29686 tests) green
- [x] `cargo clippy -- -D warnings` clean
- [x] Full roast whitelist (1436 files) re-run under both providers, no regressions (one pre-existing, unrelated `S32-io/spurt.t` standalone-run artifact confirmed present on `main` too via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)