### PR TITLE
fix: MONKEY-TYPING no longer leaks into a separately EVAL'd string

### DIFF
--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -259,6 +259,8 @@ impl Interpreter {
                 self.strict_mode = true;
             } else if module == "fatal" {
                 self.fatal_mode = true;
+            } else if module == "MONKEY-TYPING" || module == "MONKEY" {
+                self.monkey_typing = true;
             }
             // The module stays loaded, so this `use` is a no-op — but a scope
             // that restored `env` wholesale since the load (a sub call around a

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -251,6 +251,21 @@ impl Interpreter {
         // long after the EVAL returned. (`throws-like 'use fatal; ...'` is a
         // common assertion shape, so one of them poisoned the rest of the file.)
         let saved_fatal_mode = self.fatal_mode;
+        // Unlike `fatal` (a runtime dynamic-scope check the EVAL'd unit
+        // legitimately inherits from its caller -- `raku -e 'use
+        // MONKEY-SEE-NO-EVAL; use fatal; try { EVAL q["bar"[5]] }; say
+        // $!.^name'` prints X::OutOfRange, so the caller's `fatal` IS live
+        // inside the EVAL), `MONKEY-TYPING` gates a COMPILE-TIME check
+        // (`augment class Foo {}` is only legal syntax when it's active) and
+        // EVAL is a fresh compilation unit for that check: an outer `use
+        // MONKEY-TYPING;` does NOT make an `augment` inside a *separately
+        // EVAL'd* string legal (verified against `raku -e 'use MONKEY-TYPING;
+        // try { EVAL q[class C { method f {} }; augment class C { method f
+        // {} }] }; say $!.^name'` -> X::Syntax::Augment::WithoutMonkeyTyping,
+        // not the method-clash error an inherited pragma would reach).
+        // `roast/S12-class/augment-supersede.t` exercises exactly this shape.
+        let saved_monkey_typing = self.monkey_typing;
+        self.monkey_typing = false;
         // CALLER:: from the EVAL'd unit's mainline must not resolve directly in
         // the scope that invoked EVAL (see push_eval_caller_frames for the
         // frame layout raku exposes).
@@ -371,6 +386,7 @@ impl Interpreter {
             self.env.remove("__mutsu_in_eval");
         }
         self.fatal_mode = saved_fatal_mode;
+        self.monkey_typing = saved_monkey_typing;
         self.restore_routine_registry_eval(routine_snapshot);
         let current_roles = self.registry().roles.clone();
         let current_role_candidates = self.registry().role_candidates.clone();

--- a/t/monkey-typing-lexical.t
+++ b/t/monkey-typing-lexical.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 4;
+plan 6;
 
 # `use MONKEY-TYPING` is lexical: a `use` inside a block does not enable
 # augmentation outside that block.
@@ -20,3 +20,26 @@ is EVAL('{ use MONKEY-TYPING; augment class Int { method ttt { 7 } }; 3.ttt }'),
 # Top-level MONKEY-TYPING enables augmentation for the rest of the unit.
 is EVAL('use MONKEY-TYPING; augment class Int { method uuu { 9 } }; 5.uuu'),
     9, 'top-level MONKEY-TYPING enables augmentation';
+
+# EVAL is a fresh compilation unit for this (compile-time-checked) pragma:
+# a `use MONKEY-TYPING` active in the CALLER's lexical scope does not extend
+# into a separately EVAL'd string, unlike a runtime dynamic-scope pragma such
+# as `fatal` (verified against `raku -e 'use MONKEY-TYPING; try { EVAL q[class
+# C { method f {} }; augment class C { method f {} }] }; say $!.^name'` ->
+# X::Syntax::Augment::WithoutMonkeyTyping, not the method-clash error an
+# inherited pragma would reach).
+use MONKEY-TYPING;
+try {
+    EVAL 'class MonkeyC { method f { 1 } }; augment class MonkeyC { method f { 2 } }';
+}
+is $!.^name, 'X::Syntax::Augment::WithoutMonkeyTyping',
+    "an outer use MONKEY-TYPING doesn't leak into a separately EVAL'd string";
+
+# ...and an EVAL'd string that turns MONKEY-TYPING on itself still works, even
+# after the caller has already `use`d it (the `loaded_modules` fast path that
+# re-arms `strict`/`fatal` on a repeat `use` of an already-loaded module had
+# no matching arm for MONKEY-TYPING, so this regressed while fixing the case
+# above -- see the `loaded_modules.contains(module)` branch in
+# `runtime_module.rs`).
+is EVAL('use MONKEY-TYPING; augment class Int { method vvv { 11 } }; 5.vvv'),
+    11, "an EVAL'd string's own use MONKEY-TYPING still works after the caller already used it";

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1564,3 +1564,61 @@ removes a stale `roast/temp-file-RT-126006-test` before starting (see
 CLAUDE.md); this looks like the same class of leftover-file-from-a-prior-run
 issue, not caught this round since `prove` was run directly for speed. If it
 recurs as a genuine `make roast` failure, look there first.
+
+## `MONKEY-TYPING` leaking into (and then failing to re-arm inside) `EVAL` (2026-08-16)
+
+Follow-on from the ternary round above: re-ran the sweep and picked
+`roast/S12-class/augment-supersede.t`'s remaining `Got: X::AdHoc` failure —
+a `throws-like` expecting `X::Syntax::Augment::WithoutMonkeyTyping` instead
+observed a *different* error (a method-clash `X::AdHoc`), meaning mutsu let
+an `augment` inside an `EVAL`'d string succeed when it should have been
+rejected outright.
+
+**Root cause: an outer `use MONKEY-TYPING;` (active in the script that calls
+`EVAL`) was leaking into the separately-`EVAL`'d string**, unlike real
+`raku` — verified directly: `raku -e 'use MONKEY-TYPING; try { EVAL q[class C
+{ method f {} }; augment class C { method f {} }] }; say $!.^name'` prints
+`X::Syntax::Augment::WithoutMonkeyTyping`, not the method-clash error an
+inherited pragma would reach. This differs from `fatal` (a genuine runtime
+dynamic-scope pragma the caller's `EVAL` legitimately inherits — see the
+`eval-does-not-leak-use-fatal` fix elsewhere in this repo, which is about the
+*opposite* leak direction, EVAL-out-to-caller): `MONKEY-TYPING` gates a
+compile-time check (`augment class Foo {}` is only legal *syntax* when it's
+active), and `EVAL` is a fresh compilation unit for that check.
+
+Fix: `eval_eval_string` (`src/runtime/system_eval_string.rs`) now saves and
+resets `self.monkey_typing` to `false` before compiling+running the EVAL'd
+unit (mirroring the existing `fatal_mode` save/restore skeleton, but with a
+forced reset rather than a straight save/restore, since the two pragmas have
+opposite inheritance semantics), and restores the caller's value afterward.
+
+**This surfaced a second, previously-invisible latent bug**, caught only by
+testing the fix against a full script sequence rather than a single isolated
+snippet (per this file's own repeated lesson about order-dependent state):
+resetting `monkey_typing` to false around `EVAL` meant an EVAL'd string's
+*own* `use MONKEY-TYPING;` now had to actually re-arm the flag — and it
+didn't, whenever the CALLER had already `use`d the same module once.
+`use_module_with_tags_inner`'s `if self.loaded_modules.contains(module) { ...
+}` fast path (`src/runtime/runtime_module.rs`) already re-arms `strict_mode`/
+`fatal_mode` on a repeat `use` of an already-loaded module (a scope that
+restored `env` wholesale since the original load may have lost the runtime
+effect even though the module stays recorded as loaded) — but had no
+matching arm for `MONKEY-TYPING`/`MONKEY`. This was invisible before because
+`monkey_typing` was never independently reset anywhere, so the omission
+never had a way to manifest. Added the missing arm, mirroring `strict`/
+`fatal` exactly.
+
+Pin: extended `t/monkey-typing-lexical.t` (4 → 6 assertions) with both the
+leak-prevention case and the re-arm-after-reset case, verified against `raku`
+too. `roast/S12-class/augment-supersede.t`'s TAP output is now 15/15 clean
+under `MUTSU_REAL_TEST=1` (previously failed one, and a second went from
+"passing only because a preceding failure happened to route through a
+different, uninstrumented path" to genuinely passing) — its remaining
+non-zero exit code under `MUTSU_REAL_TEST=1` is an unrelated, pre-existing
+issue (a `class ::F { ... }` stub declared inside a deliberately-broken `try
+EVAL '...'` in the file's own "used to crash rakudo" regression tests never
+resolves and trips the end-of-program `check_unresolved_stubs()` check;
+confirmed present on a clean `main` checkout too via `git stash`, not
+investigated further this round). `roast/S32-exceptions/misc2.t` also
+improved (6 → 5 remaining failures). Full `t/` suite (3185 files) and `cargo
+clippy -- -D warnings` both clean.


### PR DESCRIPTION
## Summary
- `use MONKEY-TYPING` gates a compile-time check (`augment class Foo {}` is only legal syntax when it's active), and `EVAL` is a fresh compilation unit for that check — unlike a runtime dynamic-scope pragma such as `fatal`, which the caller's `EVAL` legitimately inherits. An outer `use MONKEY-TYPING` was leaking into a separately `EVAL`'d string, letting an `augment` succeed there when real `raku` rejects it outright.
- Fixing that (resetting the flag around `EVAL`) surfaced a second, previously-invisible latent bug: the `loaded_modules` fast path that re-arms `strict_mode`/`fatal_mode` on a repeat `use` of an already-loaded module had no matching arm for `MONKEY-TYPING`, so an EVAL'd string's own `use MONKEY-TYPING` stopped working once the caller had already used it once. Fixed both in the same PR.
- `roast/S12-class/augment-supersede.t` goes to 15/15 clean under `MUTSU_REAL_TEST=1` — part of the `todo/tickets/vendor-real-test-module.md` campaign (vendoring rakudo's real `Test` module).

## Test plan
- [x] Extended pin `t/monkey-typing-lexical.t` (4 → 6 assertions) with both the leak-prevention case and the re-arm-after-reset case, verified against `raku`
- [x] `roast/S12-class/augment-supersede.t` and 27 other whitelisted MONKEY-TYPING/`augment`-related roast files pass under the native `Test` provider
- [x] Full `t/` suite (3185 files) green
- [x] `cargo clippy -- -D warnings` clean
- [x] Full roast whitelist re-run under `MUTSU_REAL_TEST=1`, confirmed improvement (`augment-supersede.t` 15/15, `misc2.t` one more assertion fixed) with no regressions elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)