### PR TITLE
fix: X::Parameter::RW survives the binding-error enhancement wrap

### DIFF
--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -388,6 +388,17 @@ impl Interpreter {
         if err.message.starts_with("Constraint type check failed") {
             return err;
         }
+        // Likewise `is rw`/`is raw` binding a non-writable argument
+        // (`X::Parameter::RW`) is a genuine runtime check, not a compile-time
+        // shape mismatch -- and unlike the exception-carrying errors handled
+        // below, this call site only spells its class via the "X::Type: text"
+        // message convention (`RuntimeError::new`, no `.exception` attached),
+        // so wrapping it in "Calling f(Int) will never work..." would destroy
+        // the only place its class is recorded, losing it to the generic
+        // X::AdHoc fallback (`roast/S06-traits/misc.t`).
+        if err.message.starts_with("X::Parameter::RW:") {
+            return err;
+        }
         // Capture the hint before `err.exception` is (possibly) moved out below,
         // so the later `set_hint` does not clash with that partial move.
         let hint = err.take_hint();

--- a/t/rw-param-typed-exception-class.t
+++ b/t/rw-param-typed-exception-class.t
@@ -1,0 +1,30 @@
+use Test;
+
+# Passing a non-writable argument (a literal, an itemized array) to an `is
+# rw` parameter must raise the typed X::Parameter::RW, not the generic
+# X::AdHoc. mutsu's binding-error "enhancement" step (which wraps a failed
+# call's error in "Calling f(Int) will never work with declared signature
+# (...)") used to swallow this specific class, because the RW check spells
+# its class only via the "X::Type: text" message convention (no `.exception`
+# object attached) and the wrap prepended text in front of that convention
+# prefix, breaking the later class-recovery parse.
+
+plan 4;
+
+sub takes-rw ($x is rw) { $x }
+
+try { takes-rw(1) };
+is $!.^name, 'X::Parameter::RW',
+    'a literal argument to an is rw parameter raises X::Parameter::RW';
+
+try { takes-rw($[1, 2]) };
+is $!.^name, 'X::Parameter::RW',
+    'an itemized array argument to an is rw parameter also raises X::Parameter::RW';
+
+my $writable = 5;
+is takes-rw($writable), 5, 'a genuine writable variable still binds fine';
+
+sub takes-raw (\x) { x }
+try { takes-raw(1) };
+isnt $!.^name, 'X::Parameter::RW',
+    'a plain sigilless \\x parameter (not is rw) is unaffected by the fix';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1678,3 +1678,44 @@ clean.
 variable, attribute, class, and role. All four are now fixed, but any FUTURE
 new `is`-trait dispatch site should wire in `is_trait_mod_no_candidate` from
 day one rather than adding a fifth latent instance.
+
+## `X::Parameter::RW` lost through the binding-error "enhancement" wrap (2026-08-16)
+
+Another `Got: X::AdHoc` file: `roast/S06-traits/misc.t` expected
+`X::Parameter::RW` for a literal/itemized-array argument passed to an `is rw`
+parameter (`sub f ($x is rw) {}; f(1)`), but observed a generic
+`X::AdHoc` whose message was the wrapped-and-buried original text:
+`"Calling f(Int) will never work with declared signature ($x)\n
+X::Parameter::RW: 'x' expects a writable variable argument"`.
+
+**Root cause, same family as the `X::Anon::Multi` double-prefix bug earlier
+in this file, different mechanism:** the RW-binding check
+(`src/runtime/types/binding_signature.rs`, two call sites) spells its class
+only via the `"X::Type: text"` message convention — `RuntimeError::new(...)`,
+no `.exception` object attached. `Interpreter::enhance_binding_error`
+(`src/runtime/calls.rs`) wraps every call-failure message in a "Calling
+f(Int) will never work with declared signature (...)" prefix for
+compile-flavored diagnostics, and it already has a precedent exclusion for
+exactly this shape of problem — a subset/where constraint failure is
+excluded because it "is a genuine *runtime* check in raku; it surfaces
+verbatim, never as a compile-flavored 'will never work'" — but `is rw`
+binding failure (equally a runtime check, and real `raku`'s own message for
+it has no such prefix either) had no matching exclusion. Once wrapped, the
+prefixed text no longer starts with `"X::Parameter::RW:"`, so the later
+generic typed-message-convention parser can't recover the class and falls
+back to `X::AdHoc`.
+
+Fixed by adding a second exclusion, `err.message.starts_with("X::Parameter::RW:")`,
+mirroring the existing subset/where one exactly. `roast/S06-traits/misc.t`
+passes fully under both `Test` providers. Pin:
+`t/rw-param-typed-exception-class.t` (4 assertions, verified against `raku`
+too, including a negative control that a sigilless `\x` parameter — not `is
+rw` — is unaffected).
+
+**Lesson for the next `Got: X::AdHoc` file:** `enhance_binding_error`'s
+message-prefix exclusion list is the first place to check whenever a binding
+failure's class goes missing — a call site spelling its class only through
+the message convention (no `.exception`) is invisible to the two branches
+that DO preserve a class (`is_arity_error || is_type_only_mismatch`, and the
+`else if let Some(ex) = err.exception` branch), so it silently loses its
+typing the moment this wrap fires.


### PR DESCRIPTION
## Summary
- `sub f ($x is rw) {}; f(1)` should raise typed `X::Parameter::RW`, but the RW-binding check spells its class only via the `"X::Type: text"` message convention (no `.exception` object). `Interpreter::enhance_binding_error` wraps every call-failure message in a "Calling f(Int) will never work with declared signature (...)" prefix, which broke the convention parse and lost the class to the generic `X::AdHoc` fallback.
- Fixed by excluding this message shape from the wrap, the same way the existing subset/where constraint case already is excluded — both are genuine runtime checks, not compile-flavored shape mismatches, and neither carries that prefix in real `raku`'s own message.
- `roast/S06-traits/misc.t` passes fully under both `Test` providers — part of the `todo/tickets/vendor-real-test-module.md` campaign.

## Test plan
- [x] New pin `t/rw-param-typed-exception-class.t` (4 assertions), verified against `raku` including a negative control (a sigilless `\x` parameter is unaffected)
- [x] `roast/S06-traits/misc.t` passes under both the native and the real `Test` module
- [x] Full `t/` suite (3187 files) green
- [x] `cargo clippy -- -D warnings` clean
- [x] Full roast whitelist (1436 files) re-run under the native provider, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)