### PR TITLE
fix: trait_mod:<is> no-candidate fallback for attribute/class/role traits

### DIFF
--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -502,8 +502,23 @@ impl Interpreter {
                         .class_attribute_trait_objects
                         .insert((owner.to_string(), attr_name_str.to_string()), mixin_val);
                 }
-                call_result?;
-                continue;
+                // Raku dispatches `trait_mod:<is>` as an ordinary multi: the
+                // built-in candidates and any user-declared one (e.g.
+                // Test.rakumod's own `trait_mod:<is>(Routine:D $r,
+                // :$test-assertion!)`, exported into scope by `use Test`)
+                // share one multi, so a user candidate whose signature does
+                // not match THIS trait's shape simply does not claim it --
+                // dispatch falls through to the unknown-trait diagnosis
+                // below, exactly like the sibling variable-trait path
+                // (`is_trait_mod_no_candidate`, `vm_var_trait_ops.rs`,
+                // `news/2026-08/user-trait-mod-does-not-consume-every-trait.md`).
+                // An error raised from *inside* a handler that DID match is a
+                // real error and still propagates.
+                match call_result {
+                    Ok(_) => continue,
+                    Err(err) if Self::is_trait_mod_no_candidate(&err) => {}
+                    Err(err) => return Err(err),
+                }
             }
             let msg = format!(
                 "Can't use unknown trait '{}' -> '{}' in an attribute declaration.",

--- a/src/runtime/registration_class_validate.rs
+++ b/src/runtime/registration_class_validate.rs
@@ -111,6 +111,45 @@ impl Interpreter {
         Ok(())
     }
 
+    /// `X::Inheritance::UnknownParent`: `name` (the class being declared)
+    /// gave `parent_name` as an `is` parent that names no known class, role,
+    /// enum, or builtin type. Shared by the immediate check below and by the
+    /// deferred-custom-trait dispatch (`vm_typedecl_ops.rs`) for when a
+    /// lowercase parent name was optimistically deferred to a user
+    /// `trait_mod:<is>` candidate that turns out not to match this call's
+    /// shape after all (mirrors the sibling variable-/attribute-trait
+    /// no-candidate fallback).
+    pub(crate) fn unknown_parent_error(&self, name: &str, parent_name: &str) -> RuntimeError {
+        // Suggest close known type names (Did-you-mean).
+        let suggestions = self.suggest_type_names(parent_name);
+        let mut msg = format!(
+            "'{}' cannot inherit from '{}' because it is unknown.",
+            name, parent_name
+        );
+        if suggestions.len() == 1 {
+            msg.push_str(&format!("\nDid you mean '{}'?", suggestions[0]));
+        } else if suggestions.len() > 1 {
+            msg.push_str("\nDid you mean one of these?\n");
+            for s in &suggestions {
+                msg.push_str(&format!("    '{}'\n", s));
+            }
+        }
+        let mut attrs = HashMap::new();
+        attrs.insert("child-name".to_string(), Value::str(name.to_string()));
+        attrs.insert("child".to_string(), Value::str(name.to_string()));
+        attrs.insert(
+            "parent-name".to_string(),
+            Value::str(parent_name.to_string()),
+        );
+        attrs.insert("parent".to_string(), Value::str(parent_name.to_string()));
+        attrs.insert(
+            "suggestions".to_string(),
+            Value::array(suggestions.into_iter().map(Value::str).collect()),
+        );
+        attrs.insert("message".to_string(), Value::str(msg));
+        RuntimeError::typed("X::Inheritance::UnknownParent", attrs)
+    }
+
     /// Validate that all parent classes exist.
     /// Allow inheriting from built-in types that may not be in the classes HashMap.
     /// Returns the parents that must NOT enter the C3 inheritance MRO because
@@ -212,39 +251,7 @@ impl Interpreter {
                     attrs.insert("message".to_string(), Value::str(msg));
                     return Err(RuntimeError::typed("X::Inheritance::Unsupported", attrs));
                 }
-                {
-                    // Suggest close known type names (Did-you-mean).
-                    let suggestions = self.suggest_type_names(resolved_parent_name.as_str());
-                    let mut msg = format!(
-                        "'{}' cannot inherit from '{}' because it is unknown.",
-                        name, resolved_parent_name
-                    );
-                    if suggestions.len() == 1 {
-                        msg.push_str(&format!("\nDid you mean '{}'?", suggestions[0]));
-                    } else if suggestions.len() > 1 {
-                        msg.push_str("\nDid you mean one of these?\n");
-                        for s in &suggestions {
-                            msg.push_str(&format!("    '{}'\n", s));
-                        }
-                    }
-                    let mut attrs = HashMap::new();
-                    attrs.insert("child-name".to_string(), Value::str(name.to_string()));
-                    attrs.insert("child".to_string(), Value::str(name.to_string()));
-                    attrs.insert(
-                        "parent-name".to_string(),
-                        Value::str(resolved_parent_name.to_string()),
-                    );
-                    attrs.insert(
-                        "parent".to_string(),
-                        Value::str(resolved_parent_name.to_string()),
-                    );
-                    attrs.insert(
-                        "suggestions".to_string(),
-                        Value::array(suggestions.into_iter().map(Value::str).collect()),
-                    );
-                    attrs.insert("message".to_string(), Value::str(msg));
-                    return Err(RuntimeError::typed("X::Inheritance::UnknownParent", attrs));
-                }
+                return Err(self.unknown_parent_error(name, resolved_parent_name.as_str()));
             }
             // A `does` target that is a non-composable built-in concrete class
             // (Int, Str, Num, Cool, Any, Mu, ...) — as opposed to a composable

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -516,10 +516,23 @@ impl Interpreter {
                     let named_arg = Value::pair(trait_name.clone(), trait_value);
                     self.vm_call_function("trait_mod:<is>", vec![type_obj.clone(), named_arg])?;
                 }
-                // Dispatch deferred unknown parents as custom traits (no args)
+                // Dispatch deferred unknown parents as custom traits (no
+                // args). `validate_class_parents` optimistically deferred
+                // these lowercase names on seeing *any* `trait_mod:<is>`
+                // proto/multi at all -- if none of its candidates actually
+                // match this shape, that guess was wrong and it really was
+                // an unknown parent all along (mirrors the sibling
+                // variable-/attribute-trait no-candidate fallback).
                 for trait_name in &deferred_traits {
                     let named_arg = Value::pair(trait_name.clone(), Value::TRUE);
-                    self.vm_call_function("trait_mod:<is>", vec![type_obj.clone(), named_arg])?;
+                    match self.vm_call_function("trait_mod:<is>", vec![type_obj.clone(), named_arg])
+                    {
+                        Ok(_) => {}
+                        Err(err) if Self::is_trait_mod_no_candidate(&err) => {
+                            return Err(self.unknown_parent_error(&storage_name, trait_name));
+                        }
+                        Err(err) => return Err(err),
+                    }
                 }
             }
             // Raku desugars `is Parent` to `trait_mod:<is>($type, Parent)`; when a
@@ -793,10 +806,20 @@ impl Interpreter {
                     let named_arg = Value::pair(trait_name.clone(), trait_value);
                     self.vm_call_function("trait_mod:<is>", vec![type_obj.clone(), named_arg])?;
                 }
-                // Dispatch deferred unknown parents as custom traits (no args)
+                // Dispatch deferred unknown parents as custom traits (no
+                // args); fall back to the unknown-parent diagnosis if no
+                // candidate actually matches this shape (see the matching
+                // comment on the class-registration site above).
                 for trait_name in &role_deferred {
                     let named_arg = Value::pair(trait_name.clone(), Value::TRUE);
-                    self.vm_call_function("trait_mod:<is>", vec![type_obj.clone(), named_arg])?;
+                    match self.vm_call_function("trait_mod:<is>", vec![type_obj.clone(), named_arg])
+                    {
+                        Ok(_) => {}
+                        Err(err) if Self::is_trait_mod_no_candidate(&err) => {
+                            return Err(self.unknown_parent_error(&qualified_name, trait_name));
+                        }
+                        Err(err) => return Err(err),
+                    }
                 }
             }
 

--- a/t/user-trait-mod-does-not-consume-every-trait.t
+++ b/t/user-trait-mod-does-not-consume-every-trait.t
@@ -8,7 +8,7 @@ use Test;
 # `Test` was enough to trigger, since Test.rakumod exports
 # `multi sub trait_mod:<is>(Routine:D $r, :$test-assertion!)`.
 
-plan 6;
+plan 10;
 
 use MONKEY-SEE-NO-EVAL;
 
@@ -37,3 +37,24 @@ lives-ok { EVAL 'sub marked() is test-assertion { }' },
 multi sub trait_mod:<is>(Variable:D $v, :$explodes!) { die "boom from handler" }
 throws-like 'my $x is explodes = 1', X::AdHoc,
     'an error from inside a matching handler still propagates';
+
+# Two more independent code paths share the exact same bug shape: an
+# attribute's `is`/`will` trait, and a class/role's `is Parent` (both
+# dispatch through the same trait_mod:<is> multi and both optimistically
+# deferred to it as soon as ANY user candidate existed at all, regardless of
+# whether its signature could ever match).
+
+throws-like 'class Zap { has $.a is bar; }', X::Comp::Trait::Unknown,
+    'an unknown ATTRIBUTE trait is also X::Comp::Trait::Unknown, not X::Multi::NoMatch';
+
+throws-like 'class Zork is nosuchtrait { }', X::Inheritance::UnknownParent,
+    'an unknown CLASS parent is X::Inheritance::UnknownParent, not X::Multi::NoMatch';
+
+throws-like 'role Zorb is nosuchtrait { }', X::Inheritance::UnknownParent,
+    'an unknown ROLE parent is likewise X::Inheritance::UnknownParent';
+
+# Same negative control for the class-level path: a matching handler's own
+# error still propagates.
+multi sub trait_mod:<is>(Mu:U $type, :$blowsup!) { die "boom from class handler" }
+throws-like 'class Y is blowsup { }', X::AdHoc,
+    'an error from inside a matching CLASS-level handler still propagates';

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1622,3 +1622,59 @@ confirmed present on a clean `main` checkout too via `git stash`, not
 investigated further this round). `roast/S32-exceptions/misc2.t` also
 improved (6 → 5 remaining failures). Full `t/` suite (3185 files) and `cargo
 clippy -- -D warnings` both clean.
+
+## `trait_mod:<is>` no-candidate fallback missing for attribute/class/role traits (2026-08-16)
+
+The same round found two more `Got: X::Multi::NoMatch` files —
+`roast/S12-attributes/instance.t` and `roast/S12-class/inheritance.t` — and
+both trace to the exact bug already fixed once for *variable* traits
+(`news/2026-08/user-trait-mod-does-not-consume-every-trait.md`,
+`todo/tickets/user-trait-mod-multi-shadows-builtin-traits.md`, closed as
+#5689): a user-declared `trait_mod:<is>` multi (Test.rakumod itself exports
+`multi sub trait_mod:<is>(Routine:D $r, :$test-assertion!)`) shares its
+dispatch with the built-ins, so a trait shape it doesn't match must fall
+through to the built-in unknown-trait diagnosis — but that fallback had only
+ever been wired into the *variable*-trait code path
+(`vm_var_trait_ops.rs::exec_apply_var_trait_op`), not the two siblings:
+
+- **Attribute traits** (`has $.a is bar`) — `apply_attribute_traits`
+  (`src/runtime/methods_classhow_attribute.rs`) unconditionally propagated
+  `call_result?` from the `trait_mod:<is>` dispatch, so a non-matching user
+  candidate's `X::Multi::NoMatch` reached the caller instead of the
+  `X::Comp::Trait::Unknown` built below it in the same function.
+- **Class/role inheritance traits** (`class X is nosuchtrait { }`,
+  `role R is nosuchtrait { }`) — `validate_class_parents`
+  (`src/runtime/registration_class_validate.rs`) defers ANY lowercase parent
+  name to custom-trait dispatch as soon as `has_proto("trait_mod:<is>") ||
+  has_multi_candidates(...)` is true, regardless of whether that candidate's
+  *signature* could ever match a `(Package, Pair)` call — and the two
+  deferred-dispatch sites that actually run it (`exec_register_class_op`/
+  `exec_register_role_op`, `src/vm/vm_typedecl_ops.rs`) likewise propagated
+  the dispatch failure verbatim instead of falling back to
+  `X::Inheritance::UnknownParent`.
+
+Fixed both the same way as the variable-trait precedent: match on the
+dispatch `Result`, and only when `Interpreter::is_trait_mod_no_candidate`
+(the existing shared predicate) says "no candidate matched at all" does
+execution fall through to the unknown-trait/unknown-parent error; a real
+error raised from *inside* a candidate that DID match still propagates
+unchanged. Extracted the `X::Inheritance::UnknownParent`-building code (used
+at three call sites now — the immediate check, and the class/role deferred
+paths) into a shared `Interpreter::unknown_parent_error` helper rather than
+duplicating the suggestion/attrs logic three times.
+
+Pin: extended `t/user-trait-mod-does-not-consume-every-trait.t` (6 → 10
+assertions) with the attribute-trait case, both the class and role
+inheritance cases, and a negative control (an error from inside a matching
+class-level handler still propagates) — all verified against `raku` too.
+`roast/S12-attributes/instance.t` and `roast/S12-class/inheritance.t` both
+pass fully under both `Test` providers. Full `t/` suite (3187 files),
+`cargo clippy -- -D warnings`, and the full roast whitelist under the native
+provider (only the pre-existing unrelated `S32-io/spurt.t` artifact) all
+clean.
+
+**Lesson for the next `Got: X::Multi::NoMatch` file:** `trait_mod:<is>` has
+(at least) four independent dispatch sites sharing this exact bug shape —
+variable, attribute, class, and role. All four are now fixed, but any FUTURE
+new `is`-trait dispatch site should wire in `is_trait_mod_no_candidate` from
+day one rather than adding a fifth latent instance.


### PR DESCRIPTION
## Summary
- A user-declared `trait_mod:<is>` multi shares its dispatch with the built-ins (`Test.rakumod` itself exports one, for `is test-assertion`), so a trait shape it doesn't match must fall through to the built-in unknown-trait diagnosis. That fallback was already wired into the *variable*-trait path (`news/2026-08/user-trait-mod-does-not-consume-every-trait.md`, #5689) but not its two siblings: attribute traits (`has $.a is bar`) and class/role inheritance traits (`class X is nosuchtrait {}`), which both let a non-matching candidate's `X::Multi::NoMatch` reach the caller instead of `X::Comp::Trait::Unknown` / `X::Inheritance::UnknownParent`.
- Fixed both the same way: match on the dispatch `Result`, and only fall through when `Interpreter::is_trait_mod_no_candidate` says no candidate matched at all — a real error from inside a matching candidate still propagates. Extracted the `X::Inheritance::UnknownParent` builder (now used at three call sites) into a shared `Interpreter::unknown_parent_error`.
- `roast/S12-attributes/instance.t` and `roast/S12-class/inheritance.t` both pass fully under both `Test` providers — part of the `todo/tickets/vendor-real-test-module.md` campaign.

## Test plan
- [x] Extended pin `t/user-trait-mod-does-not-consume-every-trait.t` (6 → 10 assertions) covering the attribute-trait case, class/role inheritance cases, and a negative control, all verified against `raku`
- [x] `roast/S12-attributes/instance.t`, `roast/S12-class/inheritance.t`, `roast/S06-traits/misc.t` pass under both `Test` providers
- [x] Full `t/` suite (3187 files) green
- [x] `cargo clippy -- -D warnings` clean
- [x] Full roast whitelist (1436 files) re-run under the native provider, no regressions (only the pre-existing unrelated `S32-io/spurt.t` artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)