### PR TITLE
feat(adr0019): F6 mut-lvalue-family shadow-check tagging

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2238,6 +2238,20 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   user-method-named-after-a-type call would actually reach, is deliberately deferred to its own
   follow-up slice rather than bundled here, matching this box's "post-migration commit logic needs
   individual review per family" caution.
+
+  **Progress (mut-lvalue family, step 1 — tag + gather evidence, #TBD):**
+  `assign_method_lvalue_with_values`'s sole call (`methods_mut_method_lvalue.rs`, the "method body
+  doesn't directly expose an attribute — run it and check for Proxy" fallback used for `is rw`
+  method/STORE-dispatch lvalue assignment, `invocant: None`) tagged with `run_instance_method_at
+  ("mutlvalue", ...)`, same pattern as the coercion family's step 1 above. Verified with a full local
+  `t/` sweep (3187 files, `MUTSU_VM_STATS=1`): the "mutlvalue" site never appears in the
+  mismatch-by-site breakdown (the same 2 pre-existing `privatedispatch` mismatches as every other
+  sweep in this box, unrelated to this site); `t/dot-assign-accessor.t` confirms the site is
+  genuinely exercised (`resolver_shadow_checks=1 resolver_shadow_mismatches=0` for that file alone).
+  `roast/S06-routine-modifiers/{lvalue-subroutines,proxy}.t`, `roast/S12-attributes/mutators.t`,
+  `roast/S12-introspection/attributes.t`, and `roast/S12-class/attributes.t` (release, via
+  `scripts/run-roast-test.sh`) all green. Call-site migration off the API itself remains open, same
+  as the coercion family.
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -1535,7 +1535,8 @@ impl Interpreter {
         // results, allowing the raw Proxy to flow back for STORE dispatch.
         let was_lvalue = self.in_lvalue_assignment;
         self.in_lvalue_assignment = true;
-        let method_result = self.run_instance_method(
+        let method_result = self.run_instance_method_at(
+            "mutlvalue",
             &class_name.resolve(),
             attributes.to_map(),
             method,


### PR DESCRIPTION
## Summary
- Continues ADR-0019 Phase F6 (delete the `run_instance_method` compatibility carrier), following up on the coercion family (#6522) with the "mut lvalue" family: `assign_method_lvalue_with_values`'s sole `run_instance_method` call (`methods_mut_method_lvalue.rs`, the `is rw` method / Proxy-STORE dispatch fallback) is tagged with a `"mutlvalue"` site string via `run_instance_method_at`.
- Purely additive — gathers shadow-check corpus evidence that the ad-hoc MRO walk agrees with the modern sequence resolver, before a later call-site migration off the API.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` all clean
- [x] Full local `t/` sweep (3187 files) under `MUTSU_VM_STATS=1`: zero shadow-check mismatches attributable to the new `"mutlvalue"` site (same 2 pre-existing, unrelated `privatedispatch` mismatches as every other sweep in this box)
- [x] `t/dot-assign-accessor.t` confirms the site is genuinely exercised (`resolver_shadow_checks=1 resolver_shadow_mismatches=0`)
- [x] `roast/S06-routine-modifiers/{lvalue-subroutines,proxy}.t`, `roast/S12-attributes/mutators.t`, `roast/S12-introspection/attributes.t`, `roast/S12-class/attributes.t` (release build) all green
- [x] `scripts/battery-testsuite.sh` — GATE PASSED (245/271, matching baseline)

Note: this PR and #6522 both touch the same ADR progress-note region; expect a rebase conflict on whichever lands second (documented in CLAUDE.md's PR workflow as the expected shape for parallel slices touching a shared ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)