### PR TITLE
feat(adr0019): F6 instance-ops family shadow-check + double-resolve fix

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2252,6 +2252,35 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   `roast/S12-introspection/attributes.t`, and `roast/S12-class/attributes.t` (release, via
   `scripts/run-roast-test.sh`) all green. Call-site migration off the API itself remains open, same
   as the coercion family.
+
+  **Progress (instance-ops/pseudo-method family, #TBD):** `methods_instance_ops.rs`'s four named
+  sites. Three (accessor-vs-method resolution ~1308, Package/type-object dispatch ~1661,
+  Routine/Block/Code/Callable ancestor dispatch ~1699) tagged `run_instance_method_at("instanceops",
+  ...)`, same additive tag-and-gather pattern as coercion/mut-lvalue. The fourth (`.raku`/`.perl`
+  rendering of a `Junction`'s member Instances, ~1891) already had a discarded pre-resolved
+  `(owner, method_def)` from `resolve_method_with_owner` — same shape the qualified-dispatch slice
+  above just fixed — so it was migrated straight to `run_resolved_method_compiled_or_treewalk`
+  reusing that value, not merely tagged.
+
+  **Real finding, not just a no-op:** the full local `t/` sweep (3187 files, `MUTSU_VM_STATS=1`) this
+  time surfaced genuine mismatches — 9 of them, all `"instanceops"`, all shape `real=Some(owner)
+  shadow=None` (the ad-hoc `run_instance_method` walk finds the method; the E4 `resolve_sequence`
+  resolver does not; never the reverse). All 9 trace to the Package/type-object dispatch branch
+  (~1661): `t/role-pun-dispatches-on-type-object.t` (6), `t/nested-type-short-name-owner-scope.t` (1,
+  a qualified nested-package type object), `t/role-instantiation.t`'s `NotNewPun.x` (a role pun's
+  non-`.new` method), and a `role R { multi method COERCE {...} }` type-object coercion call —
+  i.e. every case is a **type-object receiver** (`Definedness::TypeObject`, not a live instance).
+  Filed as `todo/tickets/adr0019-e4-sequence-resolver-misses-type-object-dispatch.md`: harmless today
+  (shadow-only, nothing consumes the comparison to make a real dispatch decision) but it means the
+  Package-dispatch branch specifically **cannot** be migrated off `run_instance_method` to the
+  sequence resolver until that gap is closed — this box's own "gather evidence before migrating"
+  discipline (F6's box text) working exactly as intended. The other two tagged sites (~1308, ~1699)
+  and the fourth (migrated) site show zero mismatches.
+
+  Verified with the full local `t/` suite (3187 files, `MUTSU_VM_STATS=1` for the shadow sweep,
+  `cargo build`/`clippy`/`fmt` all clean) and the standard 312-file `S04`/`S06`/`S09`/`S12`/`S14`
+  roast subset (release), both green — the 9 mismatches are diagnostic-only and change no observed
+  behavior. `scripts/battery-testsuite.sh` GATE PASSED.
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1305,7 +1305,8 @@ impl Interpreter {
                 Some(UserMethodOrAccessor::Accessor)
             );
             if !accessor_wins && self.has_user_method(&cn_resolved, method) {
-                let (result, updated) = self.run_instance_method(
+                let (result, updated) = self.run_instance_method_at(
+                    "instanceops",
                     &class_name.resolve(),
                     attributes.to_map(),
                     method,
@@ -1657,8 +1658,14 @@ impl Interpreter {
             // Package (type object) dispatch -- check user-defined methods
             if self.has_user_method(&name.resolve(), method) {
                 let attrs = AttrMap::new();
-                let (result, _updated) =
-                    self.run_instance_method(&name.resolve(), attrs, method, args, None)?;
+                let (result, _updated) = self.run_instance_method_at(
+                    "instanceops",
+                    &name.resolve(),
+                    attrs,
+                    method,
+                    args,
+                    None,
+                )?;
                 return Ok(result);
             }
         }
@@ -1696,7 +1703,8 @@ impl Interpreter {
             };
             if let Some(dispatch_class) = dispatch_class {
                 let attrs = AttrMap::new();
-                let (result, _updated) = self.run_instance_method(
+                let (result, _updated) = self.run_instance_method_at(
+                    "instanceops",
                     dispatch_class,
                     attrs,
                     method,
@@ -1883,18 +1891,25 @@ impl Interpreter {
                             attributes,
                             ..
                         } = value.view()
-                            && self
-                                .resolve_method_with_owner(&class_name.resolve(), "raku", &[])
-                                .is_some()
+                            && let Some((owner, method_def)) =
+                                self.resolve_method_with_owner(&class_name.resolve(), "raku", &[])
                         {
                             let attrs_map = attributes.to_map();
-                            if let Ok((rendered, _)) = self.run_instance_method(
-                                &class_name.resolve(),
-                                attrs_map,
-                                "raku",
-                                Vec::new(),
-                                None,
-                            ) {
+                            // Reuse the resolved (owner, method_def) instead
+                            // of re-deriving it a second time inside
+                            // `run_instance_method`'s own ad-hoc walk
+                            // (ADR-0019 F6).
+                            if let Ok((rendered, _)) = self
+                                .run_resolved_method_compiled_or_treewalk(
+                                    &class_name.resolve(),
+                                    &owner.resolve(),
+                                    "raku",
+                                    method_def,
+                                    attrs_map,
+                                    Vec::new(),
+                                    None,
+                                )
+                            {
                                 parts.push(rendered.to_string_value());
                                 continue;
                             }

--- a/todo/tickets/adr0019-e4-sequence-resolver-misses-type-object-dispatch.md
+++ b/todo/tickets/adr0019-e4-sequence-resolver-misses-type-object-dispatch.md
@@ -1,0 +1,65 @@
+# `resolve_sequence` (ADR-0019 E4) misses methods reachable via `run_instance_method` on a type-object receiver
+
+Found by ADR-0019 F6's "instanceops" shadow-check tagging (see the design note's F6 progress
+notes), gathering corpus evidence before migrating `methods_instance_ops.rs`'s package/type-object
+dispatch call site off `run_instance_method`.
+
+## Repro
+
+```raku
+role NotNewPun {
+    method x { 69 }
+}
+say NotNewPun.x;   # 69 -- a role type object puns for a non-`.new` method
+```
+
+`t/role-instantiation.t` and `t/role-pun-dispatches-on-type-object.t` already exercise this shape.
+Also seen with `t/nested-type-short-name-owner-scope.t` (`Elsewhere::Header.tag` — a qualified,
+nested-package type object) and a `role R { multi method COERCE {...} }` type-object coercion call.
+
+## What's happening
+
+`methods_instance_ops.rs`'s "Package (type object) dispatch" branch (~line 1658, tagged
+`"instanceops"` for shadow-checking) resolves these calls correctly via `has_user_method` +
+`run_instance_method`'s ad-hoc `resolve_method_with_owner_invocant` walk. The `MUTSU_VM_STATS`-gated
+shadow probe added alongside it compares that answer against the modern
+`resolution_sequence::resolve_sequence` resolver (the E4 candidate-sequence builder) for the same
+`(chain, method, NativeCallShape)` and finds it comes back empty:
+
+```
+[mutsu vm-stats] adr0019-e4a resolver-shadow mismatches by site: instanceops
+  [class=NotNewPun method=x real=Some("NotNewPun") shadow=None]
+```
+
+A full local `t/` sweep (3187 files, `MUTSU_VM_STATS=1`) found 9 such mismatches, all `real=Some(...)
+shadow=None` (the ad-hoc walk finds the method, the sequence resolver does not) — never the reverse.
+All 9 involve a `Package`/type-object receiver (`dispatch_mro`'s invocant is
+`Value::package(Symbol::intern(receiver_class_name))`, `Definedness::TypeObject`), not a live
+instance. The `vm_stats.rs` module doc already flags one related, deliberately-accepted gap
+(`resolve_sequence` not modeling `resolve_method_with_owner_impl`'s "a non-multi method resolves by
+name alone, independent of whether the call's arguments actually bind it" early-stopping rule) — this
+may be the same root cause manifesting for type-object receivers specifically (a bare, no-`:D`/`:U`
+method should be name-resolvable on a type object same as an instance), or a distinct definedness-
+filtering gap in `method_args_match_for_invocant` / `NativeCallShape` construction. Not yet
+root-caused to a specific line.
+
+## Why this matters, and why it isn't fixed here
+
+This is currently harmless: the shadow check is purely diagnostic (`record_resolver_shadow_check`),
+nothing consults it to make a real dispatch decision, so production behavior is unaffected. But it
+means **`methods_instance_ops.rs`'s Package-dispatch call site cannot be migrated from
+`run_instance_method` to the sequence resolver** (ADR-0019 F6's eventual goal for this family) until
+this gap is closed — the sequence resolver would silently fail every `SomeType.role_pun_method` /
+`SomeQualifiedType.method` call that currently works. Root-causing requires reading
+`resolve_sequence`/`method_args_match_for_invocant` closely for how they treat a `TypeObject`
+invocant, which is its own, separate investigation from F6's tagging slice — filed here rather than
+bundled into that PR, per this repo's "fix what you can, record the rest, move on" rule for
+multi-prerequisite work.
+
+## Suggested next step
+
+Read `resolution_sequence.rs`'s `resolve_sequence` and `method_args_match_for_invocant` for how they
+handle a `Definedness::TypeObject` invocant with a plain (non-`:D`/`:U`-constrained) method
+candidate, using `NotNewPun.x` as the minimal repro. Compare against
+`resolve_method_with_owner_impl`'s corresponding logic in `resolution_method.rs` to find exactly
+where the two diverge.


### PR DESCRIPTION
## Summary
- Continues ADR-0019 Phase F6, following up on #6522/#6523/#6524, with the `methods_instance_ops.rs` family. Three sites tagged `run_instance_method_at("instanceops", ...)`; the fourth (`.raku`/`.perl` rendering of a Junction's member Instances) had a discarded pre-resolved `(owner, method_def)` — migrated to `run_resolved_method_compiled_or_treewalk` directly, same double-resolve fix as #6524.
- **Real finding, not a clean no-op:** the shadow-check sweep surfaced 9 genuine mismatches, all on the Package/type-object dispatch branch, all shape "the ad-hoc walk finds the method, the E4 sequence resolver does not" (role/class type-object puns calling a non-`.new` method, e.g. `role R { method x { 69 } }; R.x`). Harmless today (shadow-only diagnostic, nothing consumes it for a real dispatch decision), but it blocks ever migrating that branch to the sequence resolver until fixed. Filed as `todo/tickets/adr0019-e4-sequence-resolver-misses-type-object-dispatch.md`.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` all clean
- [x] Full local `t/` suite (3187 files) under `MUTSU_VM_STATS=1`: the 9 mismatches above (all diagnostic-only, `real=Some shadow=None`), same 2 pre-existing unrelated `privatedispatch` mismatches as every other sweep in this box, zero test failures
- [x] Standard 312-file `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release build) all green
- [x] `scripts/battery-testsuite.sh` — GATE PASSED (245/271, matching baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)