### PR TITLE
fix: known-type-constraint registry was missing several genuine Raku types

### DIFF
--- a/src/parser/stmt/simple/pragma_preseed.rs
+++ b/src/parser/stmt/simple/pragma_preseed.rs
@@ -109,6 +109,30 @@ pub(crate) fn register_user_type_verbatim(name: &str) {
 /// Register a user-declared type name (class, role, grammar, enum).
 pub(crate) fn register_user_type(name: &str) {
     register_user_type_verbatim(name);
+    // A plain (non-`my`) declaration is installed non-lexically in Raku: it
+    // stays bareword-visible even after the bare `{ ... }` block it was
+    // written in exits (roast/S04-exception-handlers/catch.t: `class Naughty
+    // is Exception {}` inside one block, matched by `when Naughty { }` in a
+    // later, separate block). `register_user_type` does not currently
+    // distinguish `my`/non-`my` at all — every call site (class/role/grammar/
+    // subset declarations, `my`-scoped included) reaches this function
+    // identically — so promoting the bare name to the outermost scope here,
+    // unconditionally, matches the existing behaviour for the *composed*
+    // spelling below and is the same trade-off: a `my`-scoped type keeps
+    // parsing as "known" after its block exits too (this registry is a
+    // parse-time disambiguation heuristic only — used to decide whether an
+    // ambiguous bareword is "probably a type", e.g. before a `when`'s block
+    // or in `S`-vs-`S///` disambiguation — not the actual runtime class
+    // registry, which has its own correct lexical-scoping mechanism via
+    // `register_lexical_class`/`pop_lexical_class_scope`), which is a much
+    // rarer and lower-consequence miss than the false positive this fixes.
+    SCOPES.with(|s| {
+        let mut scopes = s.borrow_mut();
+        let outermost = scopes
+            .first_mut()
+            .expect("scope stack should never be empty");
+        outermost.user_types.insert(name.to_string());
+    });
     // A declaration nested inside `package`/`module`/`class`/`role` is installed
     // under its composed name, and stays visible after the enclosing body ends.
     // Register that spelling in the outermost scope so it outlives the body's

--- a/src/runtime/utils/type_constraints.rs
+++ b/src/runtime/utils/type_constraints.rs
@@ -22,6 +22,9 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
             | "Rat"
             | "FatRat"
             | "Complex"
+            | "Real"
+            | "Numeric"
+            | "Rational"
             | "atomicint"
             | "int"
             | "num"
@@ -65,6 +68,7 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
             | "Match"
             | "Regex"
             | "Block"
+            | "Callable"
             | "Code"
             | "Sub"
             | "Method"
@@ -161,15 +165,20 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
             | "Channel"
             | "CurrentThreadScheduler"
             | "Promise"
+            | "PromiseStatus"
             | "Semaphore"
             | "Supplier"
+            | "Supply"
             | "Tap"
             | "Thread"
             | "ThreadPoolScheduler"
+            | "Scheduler"
+            | "Telemetry"
             // Hyper/Parallel
             | "HyperConfiguration"
             | "HyperSeq"
             | "ParallelSequence"
+            | "RaceSeq"
             // Slang
             | "Slang"
             // Lock
@@ -178,6 +187,32 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
             | "CallFrame"
             // CompUnit
             | "CompUnit"
+            // Core roles
+            | "Associative"
+            | "Positional"
+            | "PositionalBindFailover"
+            | "Iterable"
+            | "Iterator"
+            | "PredictiveIterator"
+            | "Sequence"
+            | "Stringy"
+            | "Baggy"
+            | "Mixy"
+            | "Setty"
+            | "Dateish"
+            | "Systemic"
+            | "Encoding"
+            | "Formatter"
+            | "ForeignCode"
+            | "Collation"
+            // Process/system
+            | "Proc"
+            | "Signal"
+            | "Order"
+            | "Endian"
+            // RakuAST (top-level namespace only; RakuAST::* compound names are
+            // not covered here — see is_known_compound_type)
+            | "RakuAST"
     )
 }
 
@@ -191,6 +226,10 @@ pub(crate) fn is_builtin_enum_value(name: &str) -> bool {
         "Less" | "Same" | "More"
         // Endian
         | "LittleEndian" | "BigEndian" | "NativeEndian"
+        // PromiseStatus (mutsu represents Promise.status as a bare string, not
+        // a registered enum type — see roast/packages/Test-Helpers/lib/Test/Util.rakumod's
+        // `given $promise.status { when Kept { ... } }`)
+        | "Planned" | "Kept" | "Broken"
     )
 }
 

--- a/t/known-type-constraint-registry-gaps.t
+++ b/t/known-type-constraint-registry-gaps.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+plan 7;
+
+# `is_known_type_constraint` (src/runtime/utils/type_constraints.rs) is
+# consulted by the `?? then !!` ternary guard to decide whether a bare type
+# name in then-position is a complete term or the head of a gobbling listop
+# call. Several genuine builtin Raku types (Real, Callable, Supply, ...) were
+# simply missing from its list, so `1 ?? Real !! 2`-shaped code raised a false
+# "Your !! was gobbled" instead of evaluating normally.
+
+is (5 ~~ Int ?? Real !! Str).^name, 'Real', 'Real recognized as a type';
+is (5 ~~ Int ?? Callable !! Str).^name, 'Callable',
+    'Callable recognized as a type';
+is (5 ~~ Int ?? Numeric !! Str).^name, 'Numeric',
+    'Numeric recognized as a type';
+is (5 ~~ Int ?? Supply !! Str).^name, 'Supply', 'Supply recognized as a type';
+is (5 ~~ Int ?? Iterable !! Str).^name, 'Iterable',
+    'Iterable recognized as a type';
+
+# A plain (non-`my`) class declared inside a bare block stays bareword-visible
+# after the block exits, matching Raku's non-lexical class semantics — the
+# parser-time type registry now models this for the same disambiguation
+# purpose (roast/S04-exception-handlers/catch.t exercises the runtime side of
+# this, which was never broken; this pins the parser-time registry only).
+{
+    class KeepsVisibleAfterBlock {};
+}
+is (5 ~~ Int ?? KeepsVisibleAfterBlock !! Str).^name, 'KeepsVisibleAfterBlock',
+    'a plain class declared in a now-exited block is still a known type';
+
+# The builtin PromiseStatus-shaped constants are known enum values too.
+{
+    my $promise = Promise.new;
+    $promise.keep(1);
+    given $promise.status {
+        when Kept { pass 'Kept still matches as a when-clause value' }
+        default { flunk 'Kept still matches as a when-clause value' }
+    }
+}

--- a/todo/tickets/vendor-real-test-module.md
+++ b/todo/tickets/vendor-real-test-module.md
@@ -1870,3 +1870,70 @@ name outlives its declaring block the way its composed name already does —
 whichever is cheaper turns out to be first will likely also fix the other's
 symptom for free, since both are "the registry `when` would need to trust is
 not yet trustworthy" instances of the same root problem.**
+
+## Both prerequisites fixed (PR#6527) — and the `when` broadening *still* isn't safe (2026-08-16, same session)
+
+Did (a) and (b) both, in full, same session: audited `is_known_type_constraint`
+against every top-level (non-`::`-compound) type name documented under
+`raku-doc/doc/Type/*.rakudoc` (`comm -23` between the two name lists) and
+added every genuine gap found — `Real`, `Numeric`, `Rational`, `Callable`,
+`Supply`, `Iterable`, `Iterator`, `PredictiveIterator`, `Associative`,
+`Positional`, `PositionalBindFailover`, `Sequence`, `Stringy`, `Baggy`,
+`Mixy`, `Setty`, `Dateish`, `Systemic`, `Encoding`, `Formatter`,
+`ForeignCode`, `Collation`, `Proc`, `Signal`, `Order`, `Endian`,
+`PromiseStatus`, `Scheduler`, `Telemetry`, `RaceSeq`, `RakuAST` (28 entries).
+Fixed `register_user_type` (`pragma_preseed.rs`) to promote a plain
+declaration's bare name to the outermost scope unconditionally, exactly
+mirroring what it already did for the composed spelling — confirmed this is
+safe because the function has never distinguished `my`/non-`my` at any of its
+call sites, so the only behavioural change is that a `my`-scoped type now
+also stays "known" to this *parse-time heuristic* after its block exits,
+which is a strictly rarer and lower-consequence miss (a wrong exception
+*class* at parse time) than the false positive being fixed (this registry is
+never consulted by the actual runtime class registry, which has its own
+correct lexical-scoping mechanism).
+
+Re-applied the `given_when.rs` broadening from the previous entry with both
+fixes in place. All five previously-known false positives (`Kept`,
+`condition`, `Naughty` cross-block, plus a `Real`-shaped filler-type case)
+now resolve correctly, and the same ~24-file roast sample used before passes
+clean.
+
+**Then a full local `prove -e target/debug/mutsu t/` (not just the roast
+sample) surfaced 8 MORE previously-unknown false positives**, none
+overlapping the earlier ones: `t/if-pointy-topic-under-given.t`,
+`t/mustache-battery.t`, `t/pod-not-collected-from-heredoc.t`,
+`t/pod-to-text-bundled.t`, `t/prelude-helper-not-block-lexical.t`,
+`t/subst-smartmatch-topic-source.t`, `t/text-csv-battery.t`,
+`t/when-value-through-block-local.t`. Confirmed by bisection (revert only
+`given_when.rs`, keep the two registry fixes, re-run all 8) that every one of
+these is caused by the `when`-broadening itself, not by either registry fix —
+the registry fixes alone are clean against the full `t/` suite (3189 files)
+and the roast sample.
+
+**Final verdict, and why this ticket item stops here for now:** two
+consecutive genuine architectural prerequisites, each fully fixed and each
+independently valuable (shipped as PR#6527, the registry-only half), still
+were not enough — a *third* round of false positives appeared on a wider
+sweep, at roughly the same rate as the first two rounds (2-3 new ones per
+~25-30 files newly exercised). This is a strong signal that the true
+false-positive rate of "any undeclared/unknown bareword directly before `{`
+in a `when` clause is a gobble" is NOT bounded by a finite, auditable set of
+missing registry entries — `when`'s condition can legitimately be almost any
+term shape (block-lexical `my` bindings the parser scope-tracking doesn't see
+across certain block kinds, module-provided term symbols, battery-specific
+helper names, ...) far more often than the two other sites (`?? then !!`,
+list-infix) that this guard was borrowed from. **Extrapolating: fixing the
+current known set would very plausibly uncover a 4th, 5th, ... round at the
+same rate, each requiring a full-corpus (not sampled) sweep to catch — this
+is not converging fast enough to be worth continuing within a single
+session.** `given_when.rs` reverted to the original `X::`/`CX::`-only check
+one more time (verified clean against the full `t/` suite again). The
+registry fixes (PR#6527) are the net positive result of this investigation;
+the `when` broadening itself stays unimplemented. If picked up again: run the
+**full** `t/` suite (not a hand-picked roast sample) after every attempt,
+budget for several rounds of whack-a-mole, and consider whether a
+fundamentally different approach (e.g., a *runtime* fallback path in the VM
+that still raises the right exception if the gobble genuinely happens, rather
+than a parse-time static prediction) would be more tractable than trying to
+make the static prediction complete.


### PR DESCRIPTION
## Summary
- `Real`, `Callable`, `Numeric`, `Rational`, `Supply`, `Iterable`, and many other built-in types (audited against `raku-doc/doc/Type/`) were absent from `is_known_type_constraint`, so the `?? then !!` ternary guard falsely diagnosed `1 ?? Real !! 2`-shaped code as a gobbled `!!` instead of evaluating it normally. Verified byte-identical to `raku` before/after.
- Fixed a related scoping gap in `register_user_type`: a plain (non-`my`) class/role/grammar/subset declaration only stayed in the parser's type registry for as long as its declaring bare block was active, unlike Raku's actual non-lexical class visibility. Promotes the bare name to the outermost scope the same way the composed (package-prefixed) spelling already does.
- Added `Planned`/`Kept`/`Broken` (the `PromiseStatus` values mutsu represents as bare strings) to `is_builtin_enum_value`.

Discovered while investigating (and reverting) a broader `when`-clause gobbling-detection change — see `todo/tickets/vendor-real-test-module.md` for why that broader change wasn't shippable this session. These registry fixes are independently correct and low-risk on their own.

## Test plan
- [x] New pin `t/known-type-constraint-registry-gaps.t` (7 assertions), verified byte-identical against `raku`
- [x] `prove -e target/debug/mutsu t/` — full suite green (3190 files)
- [x] Broad roast sweep (27 files touching `when`/`given`/ternary/class-in-block patterns) — all pass
- [x] `cargo clippy -- -D warnings`, `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)