### PR TITLE
feat(adr0019): F6 new-dispatch family shadow-check tagging

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2335,6 +2335,21 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   (3189 files, `cargo build`/`clippy`/`fmt` all clean), the 309-file whitelisted subset of the
   standard `S04`/`S06`/`S09`/`S12`/`S14` roast slice (release), and `scripts/battery-testsuite.sh`
   (GATE PASSED).
+
+  **Progress (new-dispatch family, #TBD):** `methods_object_dispatch_new.rs`'s three named
+  `.new`-dispatch sites (the augmented-builtin-`.new` fallback, the role-punned `.new` branch, and
+  the general new-dispatch fallback) tagged `run_instance_method_at("newdispatch", ...)`. The
+  role-punned `.new` site is the same `ensure_role_punned_to_class` shape the mut-dispatch family's
+  fix above targeted, so its evidence sweep (full local `t/`, 3190 files, before this branch was
+  rebased onto that fix) found the identical self-referential-pun mismatch pattern at 4 call sites
+  (`t/class-type-object-coercion-call.t`, `t/punned-role-user-new.t` x2,
+  `t/role-pun-dispatches-on-type-object.t`'s `WithNew.new`) — no new root cause, just more corpus
+  instances of the same bug. After rebasing onto the merged fix, the full sweep finds zero
+  `"newdispatch"` mismatches (the only 2 remaining corpus-wide are the pre-existing, unrelated
+  `"privatedispatch"` pair every prior sweep in this box has recorded). Verified with the full local
+  `t/` suite (3190 files, `cargo build`/`clippy`/`fmt` all clean), the 309-file whitelisted subset of
+  the standard `S04`/`S06`/`S09`/`S12`/`S14` roast slice (release), and
+  `scripts/battery-testsuite.sh` (GATE PASSED).
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -58,7 +58,14 @@ impl Interpreter {
             return Ok(None);
         }
         let empty_attrs = AttrMap::new();
-        match self.run_instance_method(class_key, empty_attrs, "new", args.to_vec(), None) {
+        match self.run_instance_method_at(
+            "newdispatch",
+            class_key,
+            empty_attrs,
+            "new",
+            args.to_vec(),
+            None,
+        ) {
             Ok((result, _updated)) => Ok(Some(result)),
             Err(e) if e.is_multi_no_match() => Ok(None),
             Err(e) => Err(e),
@@ -1435,7 +1442,8 @@ impl Interpreter {
                 if role.methods.contains_key("new") {
                     let role_name = class_name.resolve();
                     self.ensure_role_punned_to_class(&role_name)?;
-                    let dispatched = self.run_instance_method(
+                    let dispatched = self.run_instance_method_at(
+                        "newdispatch",
                         &class_name.resolve(),
                         AttrMap::new(),
                         "new",
@@ -1594,7 +1602,8 @@ impl Interpreter {
                 // Check for user-defined .new method first
                 if self.has_user_method(class_key, "new") {
                     let empty_attrs = AttrMap::new();
-                    match self.run_instance_method(
+                    match self.run_instance_method_at(
+                        "newdispatch",
                         &class_name.resolve(),
                         empty_attrs,
                         "new",


### PR DESCRIPTION
## Summary
- ADR-0019 F6: tags `methods_object_dispatch_new.rs`'s three `.new`-dispatch `run_instance_method` call sites (augmented-builtin-`.new` fallback, role-punned `.new` branch, general new-dispatch fallback) with `run_instance_method_at("newdispatch", ...)`, following the same evidence-gathering pattern as the coercion/mut-lvalue/qualified-dispatch/instance-ops/mut-dispatch families.
- The role-punned `.new` site hits the same `ensure_role_punned_to_class` self-referential-pun shape the mut-dispatch family's already-merged `drop_flattened_role_duplicate_candidates` fix (#6528) targets. After rebasing onto that fix, a full corpus sweep finds zero new `"newdispatch"` mismatches.

## Test plan
- [x] Full local `t/` suite (3190 files) green
- [x] `cargo clippy -- -D warnings` / `cargo fmt --check` clean
- [x] `S04`/`S06`/`S09`/`S12`/`S14` whitelisted roast subset (309 files, release) green
- [x] `scripts/battery-testsuite.sh` — GATE PASSED
- [x] Full `MUTSU_VM_STATS=1` shadow-check sweep: zero `newdispatch` mismatches corpus-wide (only the pre-existing, unrelated `privatedispatch` pair remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)