### PR TITLE
feat(adr0019): F6 mut-lvalue family — carrier migration

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2390,6 +2390,24 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   `S12-coercion`/`S13-overloading` roast subset (release), and `scripts/battery-testsuite.sh`
   (GATE PASSED).
 
+  **Progress (mut-lvalue family, step 2 — carrier migration, #TBD):**
+  `assign_method_lvalue_with_values`'s sole site (`methods_mut_method_lvalue.rs`, the "method body
+  doesn't directly expose an attribute — run it and check for Proxy" fallback) migrated off
+  `run_instance_method_at("mutlvalue", ...)` onto `call_method_with_values(target.clone(), method,
+  method_args)`. Unlike the coercion family, the caller here still needed the post-call `AttrMap`
+  snapshot (`proxy_store`'s `attributes` param, fed to the `STORE` callback's Proxy context) — but
+  since `target` and the pre-extracted `attributes: Gc<InstanceAttrs>` share the same underlying
+  cell, and self-mutations inside the called method already write through that cell in place (the
+  interior-mutability guarantee ADR-0013 established), the old `run_instance_method`-returned
+  `updated_attrs` snapshot was redundant: re-reading `attributes.to_map()` *after* the
+  `call_method_with_values` call yields the identical post-mutation state. No functional change,
+  one fewer `(Value, AttrMap)`-shaped return to thread through. Verified with the full local `t/`
+  suite (3190 files, all green), `cargo build`/`clippy -- -D warnings`/`fmt` clean,
+  `roast/S06-routine-modifiers/{lvalue-subroutines,proxy}.t`, `roast/S12-attributes/mutators.t`,
+  `roast/S12-introspection/attributes.t`, and `roast/S12-class/attributes.t` (release, via
+  `scripts/run-roast-test.sh`), and `scripts/battery-testsuite.sh` (GATE PASSED, 245/271 unchanged).
+  The `"mutlvalue"` `site` tag is now unused (no remaining caller).
+
   **Negative result (instance-ops family, attempted and reverted, #TBD):** tried the same
   `call_method_with_values` swap on two of `methods_instance_ops.rs`'s three tagged sites (the
   accessor-vs-method resolution branch ~1308, and the Package/type-object dispatch branch ~1657 —

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -1535,17 +1535,14 @@ impl Interpreter {
         // results, allowing the raw Proxy to flow back for STORE dispatch.
         let was_lvalue = self.in_lvalue_assignment;
         self.in_lvalue_assignment = true;
-        let method_result = self.run_instance_method_at(
-            "mutlvalue",
-            &class_name.resolve(),
-            attributes.to_map(),
-            method,
-            method_args,
-            None,
-        );
+        let method_result = self.call_method_with_values(target.clone(), method, method_args);
         self.in_lvalue_assignment = was_lvalue;
-        let (method_result, updated_attrs) = method_result?;
+        let method_result = method_result?;
         if let ValueView::Proxy { storer, .. } = method_result.view() {
+            // The method call above shares `attributes`' underlying cell with
+            // `target`, so any self-mutation the method body made is already
+            // visible here — re-snapshot rather than reuse a pre-call copy.
+            let updated_attrs = attributes.to_map();
             return self.proxy_store(
                 storer,
                 target_var,


### PR DESCRIPTION
## Summary
- Continues ADR-0019 Phase F6 (delete the `run_instance_method` compatibility carrier).
- Migrates the mut-lvalue family's sole call site (`assign_method_lvalue_with_values`'s Proxy-fallback branch in `methods_mut_method_lvalue.rs`) off `run_instance_method_at("mutlvalue", ...)` onto `call_method_with_values`, the second family (after coercion) to complete its actual carrier-caller migration rather than just tag-and-gather.
- The pre-extracted `attributes: Gc<InstanceAttrs>` cell shares identity with `target`, so self-mutations the called method makes are already visible in place (ADR-0013 interior mutability) — re-snapshotting `attributes.to_map()` after the call replaces the old `run_instance_method`-returned `AttrMap` with no functional change.
- Updates the ADR-0019 design note with this family's progress.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` all clean
- [x] Full local `t/` suite (3190 files) green, including `t/dot-assign-accessor.t`
- [x] `roast/S06-routine-modifiers/{lvalue-subroutines,proxy}.t`, `roast/S12-attributes/mutators.t`, `roast/S12-introspection/attributes.t`, `roast/S12-class/attributes.t` green (release, via `scripts/run-roast-test.sh`)
- [x] `scripts/battery-testsuite.sh` GATE PASSED (245/271, unchanged baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)