### PR TITLE
feat(adr0019): F6 mut-dispatch family — native-lever-A carrier call site removed

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2416,6 +2416,30 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   for `call_method_with_values`'s OWN native-lever-A site, for the identical infinite-regress
   reason). `methods_instance_ops.rs` is reverted to its pre-attempt state, byte-identical to before
   this slice; no functional change landed from this attempt.
+
+  **Progress (mut-dispatch family, step 2 — one carrier call site removed, #TBD):** the instance-ops
+  finding above generalizes across every remaining family — see
+  `todo/deep/adr0019-f6-vm-level-dispatch-helper-needed.md` for the full call-graph survey. One site
+  turned out safe despite that survey's caution: `call_method_mut_with_values`'s own native-lever-A
+  branch (`methods_mut_dispatch.rs`, the "augmented native-typed receiver" mirror of
+  `call_method_with_values`'s identically-shaped top branch). Its own doc comment already establishes
+  that a native-typed receiver here carries no attribute cell, so "a plain value dispatch (like the
+  non-mut path) is the correct shape" — meaning this branch never needed the mut-specific machinery
+  at all. Migrated `run_instance_method_at("mutdispatch", ...)` to
+  `self.call_method_with_values(target, method, args)` (the plain non-mut sibling, NOT a self-call —
+  `call_method_with_values` does not call back into `call_method_mut_with_values` for this shape, so
+  none of the instance-ops recursion risk applies here). This does not remove the carrier dependency
+  itself (`call_method_with_values`'s own identically-shaped branch still calls
+  `run_instance_method_at("generalcalldispatch", ...)` internally, per the general-call-dispatch
+  family's own known self-reference blocker) — it centralizes what used to be two independent
+  carrier call sites into the one the general-call-dispatch family will eventually fix, removing one
+  more distinct `run_instance_method` reference and one more duplicated implementation of the same
+  dispatch shape. Verified with the full local `t/` suite (3190 files, all green, no recursion),
+  `t/augment-native-lever-a-methods.t`, `cargo build`/`clippy -- -D warnings`/`fmt` clean, and
+  `scripts/battery-testsuite.sh` (GATE PASSED). `mut-dispatch`'s remaining site
+  (`methods_mut_dispatch.rs:2777`, the general mut-dispatch fallback) stays on `run_instance_method_at`
+  — it is the mut-path's own analog of `dispatch_instance_and_fallback`/`dispatch_new` and is
+  presumed blocked by the same recursion shape (not yet attempted).
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -25,15 +25,7 @@ impl Interpreter {
             ValueView::Instance { .. } | ValueView::Package(_)
         ) && self.native_lever_a_user_override(&target, method)
         {
-            let (result, _) = self.run_instance_method_at(
-                "mutdispatch",
-                crate::runtime::utils::value_type_name(&target),
-                crate::value::AttrMap::new(),
-                method,
-                args,
-                Some(target),
-            )?;
-            return Ok(result);
+            return self.call_method_with_values(target, method, args);
         }
         // Track B/Track C: an aggregate that lives in a shared `ContainerRef`
         // cell (a `state @a`/`state %h` under an active thread context — see


### PR DESCRIPTION
## Summary
- Continues ADR-0019 Phase F6.
- `call_method_mut_with_values`'s own native-lever-A branch (`methods_mut_dispatch.rs`, the augmented native-typed receiver shape) migrated off `run_instance_method_at("mutdispatch", ...)` onto `call_method_with_values(target, method, args)` — the plain non-mut sibling function, not a self-call, so none of the recursion risk documented in `todo/deep/adr0019-f6-vm-level-dispatch-helper-needed.md` applies here.
- The branch's own existing doc comment already established this shape never needed mut-specific writeback machinery (a native receiver carries no attribute cell), so this is a safe, verified centralization: it collapses two independent implementations of the same "augmented native type" dispatch into the one `call_method_with_values` already has, removing one more distinct `run_instance_method` call site.
- Does not yet remove the underlying carrier dependency — `call_method_with_values`'s own identically-shaped branch still calls `run_instance_method_at` internally for this shape, tracked as the general-call-dispatch family's known self-reference blocker (needs the VM-level `resolve_method_cached`/`dispatch_compiled_method` direct path per the linked todo).
- Updates the ADR-0019 design note with this family's progress.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` all clean
- [x] Full local `t/` suite (3190 files) green — confirmed no recursion
- [x] `t/augment-native-lever-a-methods.t`, `roast/S12-attributes/mutators.t`, `roast/S06-routine-modifiers/proxy.t` green (release, via `scripts/run-roast-test.sh`)
- [x] `scripts/battery-testsuite.sh` GATE PASSED (245/271, unchanged baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)