### PR TITLE
feat(adr0019): F6 — VM-level direct-dispatch helper unblocks recursion-hazard sites

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2458,6 +2458,48 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   (`methods_mut_dispatch.rs:2777`, the general mut-dispatch fallback) stays on `run_instance_method_at`
   — it is the mut-path's own analog of `dispatch_instance_and_fallback`/`dispatch_new` and is
   presumed blocked by the same recursion shape (not yet attempted).
+
+  **Progress (VM-level direct-dispatch helper, #TBD) — unblocks the recursion-hazard sites.**
+  Implemented `Interpreter::try_dispatch_compiled_method_direct`
+  (`src/vm/vm_call_method_compiled_direct.rs`, new file), the helper
+  `todo/deep/adr0019-f6-vm-level-dispatch-helper-needed.md` scoped: it extracts the
+  `resolve_method_cached` -> `check_method_wrap_chain` -> on-demand-compile ->
+  `dispatch_compiled_method` sequence that `try_compiled_method_or_interpret_inner`
+  (`vm_call_method_compiled_interpret.rs`) already runs for the VM's own `CallMethod` opcode path,
+  minus that function's accessor-vs-method arbitration branch (which recurses into
+  `call_method_with_values` and is therefore exactly the hazard this helper exists to avoid). Confirmed
+  by direct call-graph inspection that neither `try_compiled_method_or_interpret_inner` nor any function
+  it calls (`resolve_method_cached`, `check_method_wrap_chain`, `populate_uncompiled_method`,
+  `dispatch_compiled_method`) is reachable from `call_method_with_values`/`call_method_mut_with_values`'s
+  own bodies (`grep` for `try_compiled_method_or_interpret` in `methods_call_dispatch.rs`/
+  `methods_mut_dispatch.rs` finds nothing) — so a call site inside either function's call graph can call
+  this new helper without risking the self-reentry that broke the naive `call_method_with_values` swap.
+  Returns `None` (caller falls back to `run_instance_method_at`) when no compiled resolution exists, when
+  the resolved method still lacks bytecode after an on-demand compile attempt, or — implicitly, since the
+  helper does no accessor arbitration of its own — the caller is responsible for excluding the
+  accessor-should-win case before calling it (every currently-known blocked site already does this itself,
+  e.g. instance-ops's `!accessor_wins &&` guard below).
+
+  **First application (instance-ops family, accessor-vs-method resolution site,
+  `methods_instance_ops.rs:~1307`):** the `!accessor_wins && self.has_user_method(...)` branch now tries
+  `try_dispatch_compiled_method_direct` first and only falls back to `run_instance_method_at("instanceops",
+  ...)` when it returns `None`. Per the mut-lvalue family's own finding, `target` and `attributes` share
+  the same underlying cell (ADR-0013) and `dispatch_compiled_method` already commits any reconciled
+  attribute map back through that cell, so re-reading `attributes.to_map()` after the direct-dispatch call
+  reflects the post-mutation state without needing the carrier's own returned snapshot. Verified with the
+  full local `t/` suite (3190 files, all green — no recursion, no regression), the exact `t/` files that
+  exercise this branch's accessor-vs-method priority logic (`t/accessor-mro-shadowing.t`,
+  `t/role-class-prioritization.t`, `t/method-table.t`, all green with `MUTSU_VM_STATS=1` confirming zero
+  `"instanceops"` fallback traffic for those runs), `cargo build`/`clippy -- -D warnings`/`fmt` clean, the
+  314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release — the same 7 non-whitelisted
+  files fail identically before and after this change, confirmed by an A/B run via `git stash`), and
+  `scripts/battery-testsuite.sh` (GATE PASSED, 245/271 unchanged). The instance-ops family's other two
+  sites (Package/type-object dispatch, `Routine`/`Block`/`Code`/`Callable` ancestor dispatch) and every
+  other blocked family (new-dispatch, mut-dispatch's remaining site, general-call-dispatch,
+  qualified-dispatch's shared helper) remain open — each needs its own per-site review of what it does
+  with the returned value beyond the resolved method (same "no shared-helper-by-pattern-match" discipline
+  this box has followed throughout), but now has a concrete, verified-safe direct-dispatch path to migrate
+  onto instead of the blocked `call_method_with_values`/`call_method_mut_with_values` swap.
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1305,6 +1305,34 @@ impl Interpreter {
                 Some(UserMethodOrAccessor::Accessor)
             );
             if !accessor_wins && self.has_user_method(&cn_resolved, method) {
+                // ADR-0019 F6: try the VM-level direct compiled-dispatch path
+                // first (no `run_instance_method` carrier, no recursion risk —
+                // see `try_dispatch_compiled_method_direct`'s doc comment).
+                // `target` and `attributes` share the same underlying cell
+                // (ADR-0013), and `dispatch_compiled_method` already commits
+                // any reconciled attribute map back through that cell, so a
+                // fresh `attributes.to_map()` read after the call reflects the
+                // post-mutation state without needing the carrier's own
+                // returned snapshot (same reasoning as the mut-lvalue family's
+                // migration).
+                if let Some(result) =
+                    self.try_dispatch_compiled_method_direct(&target, method, &args)
+                {
+                    let result = result?;
+                    let updated = attributes.to_map();
+                    if !self.in_lvalue_assignment
+                        && let ValueView::Proxy { fetcher, .. } = result.view()
+                    {
+                        return self.proxy_fetch(
+                            fetcher,
+                            None,
+                            &class_name.resolve(),
+                            &updated,
+                            target_id,
+                        );
+                    }
+                    return Ok(result);
+                }
                 let (result, updated) = self.run_instance_method_at(
                     "instanceops",
                     &class_name.resolve(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -137,6 +137,7 @@ mod vm_call_light_typed;
 mod vm_call_method_compiled;
 mod vm_call_method_compiled_cache;
 mod vm_call_method_compiled_coerce;
+mod vm_call_method_compiled_direct;
 mod vm_call_method_compiled_interpret;
 mod vm_call_method_compiled_io;
 mod vm_call_method_compiled_mut;

--- a/src/vm/vm_call_method_compiled_direct.rs
+++ b/src/vm/vm_call_method_compiled_direct.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+impl Interpreter {
+    /// Resolve and dispatch a method call directly through the VM's cached
+    /// compiled-method path (`resolve_method_cached`, `check_method_wrap_chain`,
+    /// and `dispatch_compiled_method`), without going through
+    /// `call_method_with_values` / `call_method_mut_with_values`. Returns
+    /// `None` when no compiled resolution is available: either no user method
+    /// was found, or the resolved method still lacks compiled bytecode after
+    /// an on-demand compile attempt. The caller should fall back to
+    /// `run_instance_method_at` (or its own existing native handling) then.
+    ///
+    /// ADR-0019 F6: `call_method_with_values` and `call_method_mut_with_values`
+    /// each call several `run_instance_method`-family fallback sites
+    /// (`dispatch_instance_and_fallback`, `dispatch_new`, their own
+    /// native-lever-A/general fallback branches, ...) from *within* their own
+    /// ~3900/~2800-line bodies. Swapping one of those sites' carrier call for
+    /// a call back into `call_method_with_values`/`call_method_mut_with_values`
+    /// itself recurses whenever the modern resolver falls through to the same
+    /// fallback again for the same `(target, method)` — confirmed as a real,
+    /// reproducible stack overflow, not a theoretical concern (see
+    /// `todo/deep/adr0019-f6-vm-level-dispatch-helper-needed.md`). This helper
+    /// exists so those sites can migrate off the carrier without that hazard:
+    /// unlike `call_method_with_values`, it performs no accessor-vs-method
+    /// arbitration and never calls either dispatch entry point, so it cannot
+    /// re-enter its own caller's call graph.
+    pub(crate) fn try_dispatch_compiled_method_direct(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let class_sym = match target.view() {
+            ValueView::Instance { class_name, .. } => class_name,
+            ValueView::Package(name) => name,
+            _ => return None,
+        };
+        self.refresh_method_caches_for_generation();
+        let cn = class_sym.as_str();
+        let method_sym = crate::symbol::Symbol::intern(method);
+        let (owner_class, method_def) =
+            self.resolve_method_cached(cn, method, class_sym, method_sym, args, target)?;
+        if let Some(result) = self.check_method_wrap_chain(
+            cn,
+            owner_class.as_str(),
+            method,
+            &method_def,
+            target,
+            args,
+        ) {
+            return Some(result);
+        }
+        let (owner_class, method_def) = if method_def.compiled_code.is_some() {
+            (owner_class, method_def)
+        } else if !method_def.body.is_empty()
+            && let Some((owner, def)) =
+                self.populate_uncompiled_method(cn, owner_class.as_str(), method, args, target)
+        {
+            // Refresh the resolve caches so future calls take the
+            // already-compiled fast path without re-resolving (mirrors
+            // `try_compiled_method_or_interpret_inner`'s own on-demand-compile
+            // cache refresh).
+            let cache_key = (class_sym, method_sym);
+            self.method_resolve_cache
+                .insert(cache_key, Some((owner, def.clone())));
+            if !def.is_multi {
+                self.last_method_resolve = Some((class_sym, method_sym, owner, def.clone()));
+            }
+            (owner, def)
+        } else {
+            return None;
+        };
+        let cc = method_def
+            .compiled_code
+            .clone()
+            .expect("compiled_code set above");
+        Some(self.dispatch_compiled_method(
+            cn,
+            owner_class.as_str(),
+            method,
+            &method_def,
+            &cc,
+            target.clone(),
+            args.to_vec(),
+            None,
+        ))
+    }
+}

--- a/todo/deep/adr0019-f6-vm-level-dispatch-helper-needed.md
+++ b/todo/deep/adr0019-f6-vm-level-dispatch-helper-needed.md
@@ -1,5 +1,16 @@
 # ADR-0019 F6: remaining `run_instance_method` families need a VM-level dispatch helper, not `call_method_with_values`
 
+**Status update:** the helper this doc calls for is now implemented —
+`Interpreter::try_dispatch_compiled_method_direct` (`src/vm/vm_call_method_compiled_direct.rs`) —
+and applied to its first site (instance-ops family's accessor-vs-method resolution branch,
+`methods_instance_ops.rs:~1307`). See ADR-0019's F6 box, "Progress (VM-level direct-dispatch
+helper, ...)", for the verification writeup. The remaining call sites this doc enumerates
+(instance-ops's other two sites, new-dispatch's three sites, mut-dispatch's general fallback,
+general-call-dispatch's three sites, qualified-dispatch's shared helper) are still open — each
+needs its own per-site migration onto the new helper, following the same discipline as every prior
+F6 slice (review what the site does with the returned value beyond the resolved method; verify with
+`t/` + a relevant roast subset + the battery gate).
+
 ## Summary
 
 ADR-0019 Phase F6 (delete the `run_instance_method` compatibility carrier) established a working


### PR DESCRIPTION
## Summary

ADR-0019 Phase F6 (delete the `run_instance_method` compatibility carrier) previously found that
every remaining scoped family's call sites live *inside* `call_method_with_values`'s or
`call_method_mut_with_values`'s own call graph, so swapping their `run_instance_method_at` call for
a direct `call_method_with_values` call (the pattern that worked for the coercion/mut-lvalue
families) causes unbounded recursion — confirmed with a reproducible stack overflow on the
instance-ops family (see `todo/deep/adr0019-f6-vm-level-dispatch-helper-needed.md`).

This PR adds the VM-level direct-dispatch helper that doc flagged as the real fix:
`Interpreter::try_dispatch_compiled_method_direct` (`src/vm/vm_call_method_compiled_direct.rs`),
extracting the `resolve_method_cached` -> `check_method_wrap_chain` -> on-demand-compile ->
`dispatch_compiled_method` sequence `try_compiled_method_or_interpret_inner` already uses for the
VM's own `CallMethod` opcode path — minus that function's accessor-vs-method arbitration branch
(the one that recurses into `call_method_with_values`). Neither this sequence nor anything it calls
is reachable from `call_method_with_values`/`call_method_mut_with_values`'s own bodies, so it's safe
to call from within their call graph without risk of re-entry.

**First application:** the instance-ops family's accessor-vs-method resolution site
(`methods_instance_ops.rs`, the `!accessor_wins && has_user_method(...)` branch) now tries the new
helper first and only falls back to `run_instance_method_at("instanceops", ...)` when it returns
`None`.

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] Full local `t/` suite (3191 files) green — no recursion, no regression
- [x] `t/accessor-mro-shadowing.t`, `t/role-class-prioritization.t`, `t/method-table.t` (the tests
      exercising this branch's accessor-vs-method priority logic) green, `MUTSU_VM_STATS=1`
      confirms zero `"instanceops"` fallback traffic
- [x] 314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — the same 7
      non-whitelisted files fail identically before and after this change (verified via `git stash`
      A/B)
- [x] `scripts/battery-testsuite.sh` — GATE PASSED, 245/271 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)