### PR TITLE
feat(adr0019): F6 — instance-ops family fully migrated off run_instance_method

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2493,13 +2493,39 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   `"instanceops"` fallback traffic for those runs), `cargo build`/`clippy -- -D warnings`/`fmt` clean, the
   314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release — the same 7 non-whitelisted
   files fail identically before and after this change, confirmed by an A/B run via `git stash`), and
-  `scripts/battery-testsuite.sh` (GATE PASSED, 245/271 unchanged). The instance-ops family's other two
-  sites (Package/type-object dispatch, `Routine`/`Block`/`Code`/`Callable` ancestor dispatch) and every
+  `scripts/battery-testsuite.sh` (GATE PASSED, 245/271 unchanged).
+
+  **Progress (instance-ops family, remaining two sites, #TBD) — family closed.** Migrated the
+  Package (type-object) dispatch branch (`~line 1687`, invocant `None`) onto
+  `try_dispatch_compiled_method_direct` directly (target is already a `Package` view, matching the
+  helper's own derivation), and the value-type dispatch branch (`~line 1732`, the
+  `augment class Array`/`Routine`/`Block`/`Code`/`Callable` fallback for a bare non-Instance/
+  non-Package receiver) onto the new `try_dispatch_compiled_method_direct_as` variant, which takes
+  an explicit `dispatch_class` symbol instead of deriving the owner class from `target`'s own
+  `ValueView` — needed here because `dispatch_class` (e.g. `"Array"`, `"Routine"`) is deliberately
+  *not* the receiver's own runtime type (a bare `Sub` dispatching against the `Routine`/`Block`/
+  `Code`/`Callable` MRO chain it doesn't literally carry as its `ValueView` tag). Both still fall
+  back to `run_instance_method_at("instanceops", ...)` when the direct path returns `None`.
+  Evidence gathered with a temporary env-gated probe (`MUTSU_DEBUG_F6_PROBE`, removed before
+  commit — see the debugging guidelines' "temporary instrumented build" allowance) run across the
+  full local `t/` corpus: the package-dispatch site hit the direct path 1527/1529 times, falling
+  back only for a `COERCE` call with no matching candidate (`t/class-type-object-coercion-call.t`
+  test 13, "a non-matching COERCE falls back to new" — the fallback's own ad-hoc `new`-redirect
+  logic, not a resolver bug); the value-type dispatch site hit the direct path 14/14 times (no
+  fallback observed in-corpus). A dedicated `use MONKEY-TYPING; augment class Routine {...}` /
+  `augment class Block {...}` repro (raku-compared) confirmed correct output, and an `rust-gdb`
+  breakpoint on each site's fallback call line confirmed it never fires for that repro (both sites
+  serve the call directly). Verified with the full local `t/` suite (3191 files, all green — no
+  recursion, no regression), `cargo build`/`clippy -- -D warnings`/`fmt` clean, the 314-file
+  whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release — the same 7 non-whitelisted
+  files fail identically before and after), and `scripts/battery-testsuite.sh` (GATE PASSED,
+  245/271 unchanged). **This closes the instance-ops family**: all three of its named sites are now
+  migrated off the carrier (falling back to it only for the residual COERCE edge case above). Every
   other blocked family (new-dispatch, mut-dispatch's remaining site, general-call-dispatch,
-  qualified-dispatch's shared helper) remain open — each needs its own per-site review of what it does
-  with the returned value beyond the resolved method (same "no shared-helper-by-pattern-match" discipline
-  this box has followed throughout), but now has a concrete, verified-safe direct-dispatch path to migrate
-  onto instead of the blocked `call_method_with_values`/`call_method_mut_with_values` swap.
+  qualified-dispatch's shared helper) remains open — each needs its own per-site review of what it
+  does with the returned value beyond the resolved method (same "no shared-helper-by-pattern-match"
+  discipline this box has followed throughout), but now has the same concrete, verified-safe
+  direct-dispatch path (`try_dispatch_compiled_method_direct`/`_as`) to migrate onto.
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1685,6 +1685,13 @@ impl Interpreter {
             }
             // Package (type object) dispatch -- check user-defined methods
             if self.has_user_method(&name.resolve(), method) {
+                // ADR-0019 F6: VM-level direct-dispatch path first (see
+                // `try_dispatch_compiled_method_direct`'s doc comment).
+                if let Some(result) =
+                    self.try_dispatch_compiled_method_direct(&target, method, &args)
+                {
+                    return result;
+                }
                 let attrs = AttrMap::new();
                 let (result, _updated) = self.run_instance_method_at(
                     "instanceops",
@@ -1730,6 +1737,18 @@ impl Interpreter {
                 None
             };
             if let Some(dispatch_class) = dispatch_class {
+                // ADR-0019 F6: VM-level direct-dispatch path first, resolving
+                // against the explicit `dispatch_class` (which may differ
+                // from `target`'s own runtime type — see
+                // `try_dispatch_compiled_method_direct_as`'s doc comment).
+                if let Some(result) = self.try_dispatch_compiled_method_direct_as(
+                    crate::symbol::Symbol::intern(dispatch_class),
+                    &target,
+                    method,
+                    &args,
+                ) {
+                    return result;
+                }
                 let attrs = AttrMap::new();
                 let (result, _updated) = self.run_instance_method_at(
                     "instanceops",

--- a/src/vm/vm_call_method_compiled_direct.rs
+++ b/src/vm/vm_call_method_compiled_direct.rs
@@ -35,6 +35,26 @@ impl Interpreter {
             ValueView::Package(name) => name,
             _ => return None,
         };
+        self.try_dispatch_compiled_method_direct_as(class_sym, target, method, args)
+    }
+
+    /// Same as `try_dispatch_compiled_method_direct`, but resolves against an
+    /// explicit `dispatch_class` symbol instead of deriving the owner class
+    /// from `target`'s own runtime type. Needed for "value-type dispatch" —
+    /// e.g. `augment class Array`/`augment class Routine` methods invoked on
+    /// a bare `Array`/`Sub` value, where the dispatch class (`"Array"`,
+    /// `"Routine"`, ...) is not the receiver's own `ValueView` variant, so
+    /// the plain `target.view()`-derived lookup above can't find it. `target`
+    /// itself is still passed through unchanged as the actual invocant
+    /// (`dispatch_compiled_method` binds it as `self` in the method body
+    /// regardless of the `cn`/owner class strings used for resolution).
+    pub(crate) fn try_dispatch_compiled_method_direct_as(
+        &mut self,
+        class_sym: crate::symbol::Symbol,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
         self.refresh_method_caches_for_generation();
         let cn = class_sym.as_str();
         let method_sym = crate::symbol::Symbol::intern(method);


### PR DESCRIPTION
## Summary

Follow-up to #6539 (VM-level direct-dispatch helper). Migrates the instance-ops family's remaining
two call sites onto the new helper, closing the family:

- Package (type-object) dispatch (`methods_instance_ops.rs`, invocant `None`) — uses
  `try_dispatch_compiled_method_direct` directly (target is already a `Package` view).
- Value-type dispatch for `augment class Array`/`Routine`/`Block`/`Code`/`Callable` on a bare
  non-Instance/non-Package receiver — uses the new `try_dispatch_compiled_method_direct_as`
  variant, which resolves against an explicit `dispatch_class` symbol instead of deriving the owner
  class from the receiver's own `ValueView` (needed since e.g. a bare `Sub` dispatches against the
  `Routine`/`Block`/`Code`/`Callable` MRO chain it doesn't literally carry as its own tag).

Both sites still fall back to `run_instance_method_at("instanceops", ...)` when the direct path
returns `None`.

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] Full local `t/` suite (3191 files) green — no recursion, no regression
- [x] Temporary env-gated probe (removed before commit) across the full local `t/` corpus: the
      package-dispatch site hit the direct path 1527/1529 times (the 2 fallbacks are a legitimate
      `COERCE`-with-no-matching-candidate case, `t/class-type-object-coercion-call.t` test 13); the
      value-type dispatch site hit the direct path 14/14 times
- [x] Dedicated `use MONKEY-TYPING; augment class Routine {...}` / `augment class Block {...}`
      repro (raku-compared, correct output), confirmed via `rust-gdb` breakpoint that each site's
      fallback call never fires for it
- [x] 314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — the same 7
      non-whitelisted files fail identically before/after
- [x] `scripts/battery-testsuite.sh` — GATE PASSED, 245/271 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)