### PR TITLE
feat(adr0019): F6 — mut-dispatch family fully migrated off run_instance_method

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2526,6 +2526,28 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   does with the returned value beyond the resolved method (same "no shared-helper-by-pattern-match"
   discipline this box has followed throughout), but now has the same concrete, verified-safe
   direct-dispatch path (`try_dispatch_compiled_method_direct`/`_as`) to migrate onto.
+
+  **Progress (mut-dispatch family, remaining site — family closed, #TBD).** Migrated the general
+  mut-dispatch fallback (`call_method_mut_with_values`'s own `has_user_method(...)` branch,
+  `methods_mut_dispatch.rs:~2763`) onto `try_dispatch_compiled_method_direct`, falling back to
+  `run_instance_method_at("mutdispatch", ...)` when it returns `None`. Same write-back reasoning as
+  the instance-ops and mut-lvalue families: `target` and `attributes` share the cell
+  (`Value::instance_sharing_cell`/ADR-0013), so a fresh `attributes.to_map()` read after the direct
+  call reflects the post-mutation state without the carrier's own returned snapshot. Gathered
+  evidence with the same temporary env-gated probe technique as the instance-ops slice (removed
+  before commit): across the full local `t/` corpus the direct path hit 107/111 times, falling back
+  only for value-dependent multi-method resolution the modern resolver's cacheable-multi gate
+  correctly declines to fast-path (`t/multi-method.t`, `t/multi-new-default-fallback.t`,
+  `t/multi-num-param-strictness.t` — all pass either way). Verified with the full local `t/` suite
+  (3191 files; one run hit `t/supply-done-in-tap-callback-is-not-a-failure.t` test 3, a
+  thread-emit-timing Supply test unrelated to method dispatch — 5/5 direct reruns and a full
+  suite re-run were clean, consistent with load-sensitive flakiness rather than a regression),
+  `cargo build`/`clippy -- -D warnings`/`fmt` clean, the 314-file whitelisted
+  `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release — the same 7 non-whitelisted files fail
+  identically before/after), and `scripts/battery-testsuite.sh` (GATE PASSED, 245/271 unchanged).
+  **This closes the mut-dispatch family**: both its named sites (the native-lever-A branch, migrated
+  in the prior mut-dispatch slice, and this general fallback) are now off the carrier. Remaining open
+  families: new-dispatch, general-call-dispatch, qualified-dispatch's shared helper.
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2767,6 +2767,37 @@ impl Interpreter {
                     "callmethodmutwithvalues",
                     "user",
                 );
+                // ADR-0019 F6: VM-level direct-dispatch path first (see
+                // `try_dispatch_compiled_method_direct`'s doc comment). `target`
+                // and `attributes` share the same underlying cell (ADR-0013),
+                // and `dispatch_compiled_method` already commits any reconciled
+                // attribute map back through that cell, so a fresh
+                // `attributes.to_map()` read after the call reflects the
+                // post-mutation state without needing the carrier's own
+                // returned snapshot (same reasoning as the mut-lvalue and
+                // instance-ops families' own migrations).
+                if let Some(result) =
+                    self.try_dispatch_compiled_method_direct(&target, method, &args)
+                {
+                    let result = result?;
+                    let updated_clone = attributes.to_map();
+                    self.env.insert(
+                        target_var.to_string(),
+                        Value::instance_sharing_cell(&attributes, class_name, target_id),
+                    );
+                    if !self.in_lvalue_assignment
+                        && let ValueView::Proxy { fetcher, .. } = result.view()
+                    {
+                        return self.proxy_fetch(
+                            fetcher,
+                            Some(target_var),
+                            &class_name.resolve(),
+                            &updated_clone,
+                            target_id,
+                        );
+                    }
+                    return Ok(result);
+                }
                 let (result, updated) = self.run_instance_method_at(
                     "mutdispatch",
                     &class_name.resolve(),


### PR DESCRIPTION
## Summary

Follow-up to #6539/#6540 (VM-level direct-dispatch helper, instance-ops family). Migrates
`call_method_mut_with_values`'s general fallback (`methods_mut_dispatch.rs`, the
`has_user_method(...)` branch) onto `try_dispatch_compiled_method_direct`, closing the mut-dispatch
family (its other site, the native-lever-A branch, was migrated in an earlier PR).

Falls back to `run_instance_method_at("mutdispatch", ...)` only when the direct path returns `None`.

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] Full local `t/` suite (3191 files) green, twice — no recursion, no regression (one run hit a
      known-shape thread-timing Supply test flake unrelated to method dispatch, clean on rerun)
- [x] Temporary env-gated probe (removed before commit) across the full local `t/` corpus: the
      direct path hit 107/111 times; the 4 fallbacks are legitimate value-dependent multi-method
      cases the modern resolver's cacheable-multi gate correctly declines to fast-path
      (`t/multi-method.t`, `t/multi-new-default-fallback.t`, `t/multi-num-param-strictness.t` — all
      pass either way)
- [x] 314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — the same 7
      non-whitelisted files fail identically before/after
- [x] `scripts/battery-testsuite.sh` — GATE PASSED, 245/271 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)