### PR TITLE
feat(adr0019): F6 — new-dispatch family fully migrated off run_instance_method

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2548,6 +2548,38 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   **This closes the mut-dispatch family**: both its named sites (the native-lever-A branch, migrated
   in the prior mut-dispatch slice, and this general fallback) are now off the carrier. Remaining open
   families: new-dispatch, general-call-dispatch, qualified-dispatch's shared helper.
+
+  **Progress (new-dispatch family, all three sites — family closed, #TBD).** Migrated all three
+  `methods_object_dispatch_new.rs` sites onto `try_dispatch_compiled_method_direct`: the
+  augmented-builtin-`.new` fallback (`try_augmented_builtin_new`, invocant `None`, dispatches
+  against a freshly-constructed `Value::package(Symbol::intern(class_key))`), the role-punned
+  `.new` branch (dispatches against `target`, already the role's own type object freshly punned to
+  a class by the preceding `ensure_role_punned_to_class` call), and the general new-dispatch
+  fallback (dispatches against `target`, which is `Package(class_name)` throughout `dispatch_new`
+  by construction — every `Instance` receiver is redirected to `Value::package(class_name)` before
+  reaching this point). Each site wraps the direct-dispatch attempt to produce the exact same
+  `Result<(Value, AttrMap), RuntimeError>` shape the site's own (unmodified) downstream
+  error-handling logic already expects — e.g. the general fallback's proto-method/positional-arg/
+  default-constructor fallthrough chain, and `try_augmented_builtin_new`'s
+  `is_multi_no_match -> Ok(None)` translation — so none of that existing logic needed to change,
+  only the single `run_instance_method_at` call each site made.
+
+  Gathered evidence with the same temporary env-gated probe technique (removed before commit)
+  across the full local `t/` corpus: the augmented-builtin-`.new` site fell back 100% of the time
+  (4/4, all in `t/augment-builtin-datetime.t`, which fully passes either way — the fast resolver
+  path apparently doesn't cover this augmented-native-type shape, so this site gets no speed
+  benefit yet but is still correctly carrier-free-by-default with a safe fallback); the role-pun
+  site hit the direct path 4/7 times (`t/role-instantiation.t` et al., all pass); the general
+  fallback hit 13/58 times, with the majority of fallbacks tracing to value-dependent `multi method
+  new` candidates (`t/multi-new-default-fallback.t`, `t/proto-new-no-match.t`, ...) — the same
+  cacheable-multi-gate shape already validated safe by the mut-dispatch family's own evidence, not
+  a new risk. Verified with the full local `t/` suite (3191 files, all green — no recursion, no
+  regression), `cargo build`/`clippy -- -D warnings`/`fmt` clean, the 314-file whitelisted
+  `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release — the same 7 non-whitelisted files fail
+  identically before/after), and `scripts/battery-testsuite.sh` (GATE PASSED, 245/271 unchanged —
+  notably exercises real `.new` construction across every bundled library, e.g. Cro/DBIish/
+  JSON::Tiny). **This closes the new-dispatch family.** Remaining open families:
+  general-call-dispatch, qualified-dispatch's shared helper.
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -57,16 +57,26 @@ impl Interpreter {
         if !self.has_user_method(class_key, "new") {
             return Ok(None);
         }
-        let empty_attrs = AttrMap::new();
-        match self.run_instance_method_at(
-            "newdispatch",
-            class_key,
-            empty_attrs,
-            "new",
-            args.to_vec(),
-            None,
-        ) {
-            Ok((result, _updated)) => Ok(Some(result)),
+        // ADR-0019 F6: VM-level direct-dispatch path first (see
+        // `try_dispatch_compiled_method_direct`'s doc comment).
+        let target = Value::package(Symbol::intern(class_key));
+        let dispatched =
+            if let Some(result) = self.try_dispatch_compiled_method_direct(&target, "new", args) {
+                result
+            } else {
+                let empty_attrs = AttrMap::new();
+                self.run_instance_method_at(
+                    "newdispatch",
+                    class_key,
+                    empty_attrs,
+                    "new",
+                    args.to_vec(),
+                    None,
+                )
+                .map(|(v, _updated)| v)
+            };
+        match dispatched {
+            Ok(result) => Ok(Some(result)),
             Err(e) if e.is_multi_no_match() => Ok(None),
             Err(e) => Err(e),
         }
@@ -1442,14 +1452,25 @@ impl Interpreter {
                 if role.methods.contains_key("new") {
                     let role_name = class_name.resolve();
                     self.ensure_role_punned_to_class(&role_name)?;
-                    let dispatched = self.run_instance_method_at(
-                        "newdispatch",
-                        &class_name.resolve(),
-                        AttrMap::new(),
-                        "new",
-                        args.clone(),
-                        None,
-                    );
+                    // ADR-0019 F6: VM-level direct-dispatch path first (see
+                    // `try_dispatch_compiled_method_direct`'s doc comment).
+                    // `target` is the role's own type object, freshly punned
+                    // to a class above, so it already carries the right
+                    // `Package` symbol for resolution.
+                    let dispatched = if let Some(result) =
+                        self.try_dispatch_compiled_method_direct(&target, "new", &args)
+                    {
+                        result.map(|v| (v, AttrMap::new()))
+                    } else {
+                        self.run_instance_method_at(
+                            "newdispatch",
+                            &class_name.resolve(),
+                            AttrMap::new(),
+                            "new",
+                            args.clone(),
+                            None,
+                        )
+                    };
                     self.withdraw_role_pun(&role_name);
                     match dispatched {
                         Ok((result, _)) => {
@@ -1601,15 +1622,27 @@ impl Interpreter {
                 }
                 // Check for user-defined .new method first
                 if self.has_user_method(class_key, "new") {
-                    let empty_attrs = AttrMap::new();
-                    match self.run_instance_method_at(
-                        "newdispatch",
-                        &class_name.resolve(),
-                        empty_attrs,
-                        "new",
-                        args.clone(),
-                        None,
-                    ) {
+                    // ADR-0019 F6: VM-level direct-dispatch path first (see
+                    // `try_dispatch_compiled_method_direct`'s doc comment).
+                    // `target` is `Package(class_name)` here (see the
+                    // destructure above), matching the class name this site
+                    // has always dispatched against.
+                    let dispatched = if let Some(result) =
+                        self.try_dispatch_compiled_method_direct(&target, "new", &args)
+                    {
+                        result.map(|v| (v, AttrMap::new()))
+                    } else {
+                        let empty_attrs = AttrMap::new();
+                        self.run_instance_method_at(
+                            "newdispatch",
+                            &class_name.resolve(),
+                            empty_attrs,
+                            "new",
+                            args.clone(),
+                            None,
+                        )
+                    };
+                    match dispatched {
                         Ok((result, _updated)) => return Ok(result),
                         Err(e) => {
                             // If multi dispatch failed (no matching candidate),


### PR DESCRIPTION
## Summary

Follow-up to #6539/#6540/#6541. Migrates all three `methods_object_dispatch_new.rs` call sites onto
`try_dispatch_compiled_method_direct`, closing the new-dispatch family:

- `try_augmented_builtin_new` — the augmented-builtin-`.new` fallback (Date/DateTime MONKEY-TYPING),
  invocant `None`.
- The role-punned `.new` branch — dispatches against `target`, the role's own type object freshly
  punned to a class.
- The general new-dispatch fallback — dispatches against `target`, which is `Package(class_name)`
  throughout `dispatch_new` by construction.

Each site wraps the direct-dispatch attempt to produce the same `Result<(Value, AttrMap),
RuntimeError>` shape the site's existing (unmodified) error-handling logic already expects — the
proto-method/positional-arg/default-constructor fallthrough chain, and the
`is_multi_no_match -> Ok(None)` translation — so none of that logic needed to change.

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] Full local `t/` suite (3191 files) green — no recursion, no regression
- [x] Temporary env-gated probe (removed before commit) across the full local `t/` corpus: hit
      rates are 0/4 (augmented-builtin, always safely falls back — `t/augment-builtin-datetime.t`
      passes), 4/7 (role-pun), 13/58 (general fallback, majority of fallbacks are value-dependent
      `multi method new` — same shape already validated safe by the mut-dispatch family)
- [x] 314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — the same 7
      non-whitelisted files fail identically before/after
- [x] `scripts/battery-testsuite.sh` — GATE PASSED, 245/271 unchanged (exercises real `.new`
      construction across every bundled library)

🤖 Generated with [Claude Code](https://claude.com/claude-code)