### PR TITLE
feat(vm): add use strict read-side check for undeclared scalar variables

### DIFF
--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -501,6 +501,18 @@ impl Interpreter {
                             // uninitialized scalar: it reads as the Any type
                             // object, like `my $x` (S03-operators/context.t).
                             Ok(Value::package(Symbol::intern("Any")))
+                        } else if self.strict_mode && !Self::strict_read_exempt(name) {
+                            // Read-side counterpart of the `SetGlobal` write
+                            // check above: a plain scalar name that resolved
+                            // through NONE of the real stores tried above
+                            // (env, unit/package/module lexicals, `our`-vars,
+                            // per-call state, ...) is genuinely undeclared —
+                            // `use strict` must reject it instead of silently
+                            // yielding Nil (`my $x = $y;` under `use strict`).
+                            // `strict_read_exempt` carves out the pseudo-
+                            // variable / dynamic-scope shapes `GetGlobal`
+                            // also carries that are not ordinary lexicals.
+                            Err(self.strict_undeclared_error(name))
                         } else {
                             Ok(Value::NIL)
                         }

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -300,6 +300,41 @@ impl Interpreter {
         err
     }
 
+    /// True when a `GetGlobal` read of `name` that resolved through none of
+    /// the real stores (env, unit/package/module lexicals, `our`-vars,
+    /// per-call state, ...) should still NOT be reported as undeclared by
+    /// `use strict`, because it is one of several pseudo-variable / dynamic-
+    /// scope shapes `GetGlobal` also carries that are not ordinary lexicals:
+    ///
+    /// - `*`-prefixed dynamic variables (`$*FOO`): an undeclared dynamic var
+    ///   is a *runtime* "Dynamic variable ... not found" error in real Raku,
+    ///   raised unconditionally (not gated by `use strict`) by a mechanism
+    ///   mutsu does not implement yet (see the read-side ticket this
+    ///   exemption came from) — `use strict` must not invent a different
+    ///   error for the same case.
+    /// - `?`-prefixed compile-time pseudo vars (`$?CLASS`, `$?FILE`, ...):
+    ///   these are validated by a separate compile-time mechanism in real
+    ///   Raku (also unconditional, not `use strict`-gated); out of scope
+    ///   here.
+    /// - Internal compiler temporaries (leading `__`), mirroring the
+    ///   `SetGlobal` write-side check.
+    /// - Fully-qualified names (containing `::`), mirroring the `SetGlobal`
+    ///   write-side check.
+    /// - Bare `$!` / `$/` (the exception/match magic vars with no twigil
+    ///   attached) and pure-digit names (`$0`, `$1`, ... positional
+    ///   captures): all legitimately read as Nil when unset, in both raku
+    ///   and mutsu, regardless of `use strict`.
+    pub(super) fn strict_read_exempt(name: &str) -> bool {
+        name.is_empty()
+            || name.starts_with('*')
+            || name.starts_with('?')
+            || name.starts_with("__")
+            || name.contains("::")
+            || name == "!"
+            || name == "/"
+            || name.bytes().all(|b| b.is_ascii_digit())
+    }
+
     /// Check if a bare word is a pseudo-package name (MY, OUTER, CORE, etc.)
     pub(crate) fn is_pseudo_package_bare(name: &str) -> bool {
         crate::runtime::Interpreter::is_pseudo_package_name(name)

--- a/t/strict-undeclared-variable-read.t
+++ b/t/strict-undeclared-variable-read.t
@@ -1,0 +1,79 @@
+use Test;
+
+plan 12;
+
+# Read-side counterpart of t/strict-declared-bind-forms.t: `use strict` must
+# reject a READ of a name that resolves through NONE of the real variable
+# stores, the same way it already rejects a WRITE (SetGlobal). Before this
+# test, `GetGlobal` had no such check at all — `use strict; my $x = $y;`
+# silently read `$y` as Nil instead of raising X::Undeclared
+# (todo/tickets/remaining-language-feature-gaps.md item 2, first bullet).
+
+# 1: the ticket's exact repro.
+throws-like '{ use strict; my $x = $y; }', X::Undeclared,
+    'reading a never-declared variable under `use strict` throws X::Undeclared';
+
+# 2: a declared `my $x` still reads fine.
+{
+    use strict;
+    my $x = 5;
+    is $x, 5, 'a declared my $x reads fine under strict';
+}
+
+# 3: `our`-declared package variables read fine.
+{
+    use strict;
+    our $strict_read_our_var = 7;
+    is $strict_read_our_var, 7, 'an our-declared variable reads fine under strict';
+}
+
+# 4-5: `state` variables read fine (and persist across calls).
+{
+    use strict;
+    sub strict_read_state_counter { state $n = 0; $n++; }
+    is strict_read_state_counter(), 0, 'a state variable reads fine under strict (1st call)';
+    is strict_read_state_counter(), 1, 'a state variable reads fine under strict (2nd call)';
+}
+
+# 6: a dynamic variable (`$*FOO`) declared somewhere in the dynamic scope
+# reads fine under strict — dynamic-scope lookup is a different mechanism
+# from lexical declaration and must not be flagged by this check.
+{
+    use strict;
+    sub strict_read_dynamic_reader { $*strict_read_dyn }
+    my $*strict_read_dyn = 99;
+    is strict_read_dynamic_reader(), 99, 'a dynamic variable reads fine under strict';
+}
+
+# 7-9: magic vars ($_, $/, $!) read fine under strict, whether or not they
+# currently hold a value.
+{
+    use strict;
+    for 1..3 -> $_ { }
+    lives-ok { my $t = $_ }, 'bare $_ reads fine under strict';
+    lives-ok { my $t = $/ }, 'bare $/ reads fine under strict';
+    try { die "boom" };
+    lives-ok { my $t = $! }, '$! reads fine under strict after a try/die';
+}
+
+# 10: a closure reading a captured outer `my` reads fine under strict.
+{
+    use strict;
+    my $outer = 10;
+    my $f = sub { $outer };
+    is $f(), 10, 'a closure reading a captured outer my reads fine under strict';
+}
+
+# 11: a class/package name read as a bare term reads fine under strict.
+{
+    use strict;
+    class StrictReadBareTermClass {}
+    ok StrictReadBareTermClass ~~ Mu, 'a class name read as a bare term reads fine under strict';
+}
+
+# 12: `no strict` must not throw for a never-declared read.
+{
+    no strict;
+    my $x = $strict_read_never_declared;
+    lives-ok { 1 }, '`no strict` does not throw reading a never-declared variable';
+}

--- a/todo/tickets/remaining-language-feature-gaps.md
+++ b/todo/tickets/remaining-language-feature-gaps.md
@@ -40,21 +40,42 @@ repro was used. Closing as resolved; re-open with a genuine failing repro if one
 `==>>` / `<<==` and `~<` / `~>` are still unimplemented/unspecified **in Rakudo itself**, so they still
 cannot be started (no oracle) — unchanged from the original filing.
 
-## 2. Typed-exception gaps needing compile-time scope analysis — still open
+## 2. Typed-exception gaps needing compile-time scope analysis
 
-- strict-mode undeclared-variable detection
-- cross-`EVAL` detection of class redeclaration
-- `X::Redeclaration::Outer`
+- ~~strict-mode undeclared-variable detection~~ — **resolved 2026-08-17**, see below.
+- cross-`EVAL` detection of class redeclaration — still open
+- `X::Redeclaration::Outer` — still open
 
-All three need compile-time scope analysis that mutsu does not currently perform; each is
-non-trivial on its own. Re-verified the first bullet 2026-08-14:
+The remaining two bullets need compile-time scope analysis that mutsu does not currently perform;
+each is non-trivial on its own and is left for a future session.
+
+### strict-mode undeclared-variable *read* detection — resolved 2026-08-17
 
 ```raku
-use strict; my $x = $y;
+use strict; my $x = $y; say "no error";
 ```
 
-`raku`: compile-time `X::Undeclared` ("Variable '$y' is not declared..."). mutsu: exits 0, no error at
-all — `$y` is silently treated as an undeclared-but-tolerated read. Still open.
+`raku` dies at compile time with `X::Undeclared` ("Variable '$y' is not declared..."); mutsu used to
+exit 0 and print `no error` — `$y` was silently read as Nil.
+
+`use strict` already had a WRITE-side check (`SetGlobal` in `src/vm/vm_exec_dispatch.rs`) but no
+symmetric READ-side check. Added one to the tail of the `OpCode::GetGlobal` handler — the one place a
+scalar-variable read falls through every real store (env, unit/package/module lexicals, `our`-vars,
+per-call state, escaping-`our` captures, ...) and would otherwise silently yield `Value::NIL` for a
+name that resolves nowhere. When `self.strict_mode` is set and the name isn't one of several
+pseudo-variable / dynamic-scope shapes `GetGlobal` also carries (dynamic vars `$*FOO`, compile-time
+pseudo vars `$?FOO`, internal `__`-prefixed temporaries, `::`-qualified names, bare `$!`/`$/`, and
+`$0`/`$1`/... positional captures — see `Interpreter::strict_read_exempt` in
+`src/vm/vm_value_helpers.rs`), it now raises the same `X::Undeclared` the write side already throws
+(`strict_undeclared_error`).
+
+Array/hash sigil reads (`GetArrayVar`/`GetHashVar`) are separate opcodes and were not touched — the
+ticket's repro and the write-side precedent are both scalar-only.
+
+Verified: full local `t/` suite (3191 files, 29730 tests) clean; targeted roast sweep
+(`S02-names-vars`, `S04-declarations`, `S06-signature`, `S12-*`) shows only pre-existing,
+unrelated failures (none mention `Undeclared`); the dedicated `roast/S02-names/strict.t` (already
+whitelisted) still passes in full. New pinned test: `t/strict-undeclared-variable-read.t`.
 
 ## 3. `exits-ok($code, $exit, $reason)` — already implemented, ticket was stale
 


### PR DESCRIPTION
## Summary

- `use strict` already rejected a WRITE to an undeclared bareword global (`SetGlobal`) but had no symmetric READ-side check, so `use strict; my $x = $y;` silently read the never-declared `$y` as Nil instead of raising `X::Undeclared` like real `raku` does.
- Adds the check to the tail of the `OpCode::GetGlobal` handler — the one place a scalar read falls through every real store (env, unit/package/module lexicals, `our`-vars, per-call state, ...) and would otherwise yield `Value::NIL` for a name that resolves nowhere.
- A new `strict_read_exempt` helper (`src/vm/vm_value_helpers.rs`) exempts the several pseudo-variable / dynamic-scope shapes `GetGlobal` also carries that are not ordinary lexicals: dynamic vars (`$*FOO`), compile-time pseudo vars (`$?FOO`), internal `__`-prefixed temporaries, `::`-qualified names, bare `$!`/`$/`, and `$0`/`$1`/... positional captures — mirroring the existing `SetGlobal` write-side exemptions.
- Array/hash sigil reads (`GetArrayVar`/`GetHashVar`) are separate opcodes and are not touched, matching the write-side precedent and the ticket's scalar-only repro.

Resolves the first bullet of `todo/tickets/remaining-language-feature-gaps.md` item 2 ("strict-mode undeclared-variable detection"). The other two bullets (cross-`EVAL` class redeclaration detection, `X::Redeclaration::Outer`) remain open for a future session — unchanged, not touched by this PR.

## Test plan

- [x] New pinned test `t/strict-undeclared-variable-read.t` (12 assertions), verified to produce byte-identical TAP output against real `raku`.
- [x] Full local `t/` suite (3192 files, 29742 tests) clean.
- [x] Targeted roast sweep (`S02-names-vars`, `S04-declarations`, `S06-signature`, `S12-*`) — the handful of failures found are pre-existing and unrelated (PseudoStash reflection, cross-class `trusts` attribute access, a multi-param invocant-marker parse limitation, etc.); none mention `Undeclared`.
- [x] The dedicated `roast/S02-names/strict.t` (already whitelisted) still passes in full.
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean.
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)