### PR TITLE
feat(adr0019): F6 — general-call-dispatch native-lever-A site migrated

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2580,6 +2580,43 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   notably exercises real `.new` construction across every bundled library, e.g. Cro/DBIish/
   JSON::Tiny). **This closes the new-dispatch family.** Remaining open families:
   general-call-dispatch, qualified-dispatch's shared helper.
+
+  **Progress (general-call-dispatch family, partial — 1 of 3 named sites, #TBD).** Migrated the
+  native-lever-A user-override branch at the very top of `call_method_with_values`
+  (`methods_call_dispatch.rs:~65`) onto `try_dispatch_compiled_method_direct_as`, the same explicit-
+  class-name variant the instance-ops value-type dispatch site used: `target` here is a plain native
+  value (Array/Str/Range/...), not `Instance`/`Package`, so the dispatch class comes from
+  `value_type_name(&target)` rather than `target.view()`. No attrs-cell propagation concern (native
+  values carry no attribute cell; the original code already discarded the carrier's `updated` map).
+  Verified with the full local `t/` suite (3191 files, all green), `t/augment-native-lever-a-methods.t`
+  plus an `rust-gdb` breakpoint on the fallback call confirming it never fires for that file, `cargo
+  build`/`clippy -- -D warnings`/`fmt` clean, the 314-file whitelisted
+  `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release — same 7 non-whitelisted failures before/after),
+  and `scripts/battery-testsuite.sh` (GATE PASSED, 245/271 unchanged).
+
+  **The other two general-call-dispatch sites are deliberately deferred, not attempted:**
+  - The `^metamethod` dispatch branch (`method ^foo(Mu) {...}`, `~line 584`) passes `invocant: None`
+    to `run_instance_method_at` even though `target` is Instance/Package — the VM caller already
+    prepends the type object as an explicit positional arg instead of binding it as `self`, per this
+    site's own comment. `try_dispatch_compiled_method_direct` always threads `target` as the bound
+    invocant into `dispatch_compiled_method`, which is a different calling convention (self-binding
+    vs. a plain leading positional) that could shift a compiled method's own positional-slot
+    accounting. This shape has **zero coverage in the local `t/` corpus** (`grep -rl 'method \^'
+    t/*.t` finds nothing) and only one roast file (`S14-traits/routines.t`), too thin a signal to
+    trust a behavior-changing swap here — left on `run_instance_method_at` pending either a wider
+    repro corpus or a helper variant that accepts an explicit invocant-vs-args split.
+  - The mixin fallback (`ValueView::Mixin(inner, mixins)` class-method branch, `~line 3960`) passes
+    `target.clone()` (the whole mixin wrapper) as invocant so a nested `self.foo` inside the method
+    re-dispatches through the mixin's role overrides, but separately extracts `inner`'s own
+    `AttrMap` and, after the call, manually commits the carrier's returned `updated` map back onto
+    `inner`'s attribute cell (`attributes.commit_attrs(updated)`) — because the invocant
+    (`target`, a `Mixin`) has no attribute cell of its own for `dispatch_compiled_method`'s automatic
+    commit path to find. `try_dispatch_compiled_method_direct`/`_as` only returns the plain `Value`
+    result, with no equivalent commit target when the invocant and the attribute-owning value
+    differ. Using it here would silently drop attribute mutations made by a class method invoked
+    through a mixin wrapper — a real correctness regression, not a missed optimization. Needs a new
+    helper shape (or this site's own bespoke wiring) that accepts an explicit attrs-cell to commit
+    through, separate from the dispatch invocant; left on `run_instance_method_at` until that exists.
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -67,6 +67,18 @@ impl Interpreter {
             ValueView::Instance { .. } | ValueView::Package(_)
         ) && self.native_lever_a_user_override(&target, method)
         {
+            // ADR-0019 F6: VM-level direct-dispatch path first (see
+            // `try_dispatch_compiled_method_direct_as`'s doc comment). `target`
+            // is a native value here (no attribute cell), so there is nothing
+            // for the original code's discarded `updated` map to propagate —
+            // matches the plain `Value` this returns.
+            let class_sym =
+                crate::symbol::Symbol::intern(crate::runtime::utils::value_type_name(&target));
+            if let Some(result) =
+                self.try_dispatch_compiled_method_direct_as(class_sym, &target, method, &args)
+            {
+                return result;
+            }
             let (result, _) = self.run_instance_method_at(
                 "generalcalldispatch",
                 crate::runtime::utils::value_type_name(&target),


### PR DESCRIPTION
## Summary

Follow-up to #6539/#6540/#6541/#6545. Migrates one of the three general-call-dispatch sites
(`call_method_with_values`'s native-lever-A branch, for augmented `Array`/`List`/`Hash`/`Str`/...
methods on a plain native value) onto `try_dispatch_compiled_method_direct_as` — using the explicit-
class-name variant since the receiver's own `ValueView` isn't `Instance`/`Package`, so the dispatch
class comes from `value_type_name(&target)`.

**The other two general-call-dispatch sites are deliberately left open**, each for a distinct,
documented reason (see the ADR box for full detail):

- The `^metamethod` branch passes `invocant: None` with the type object as a plain positional arg —
  a different calling convention than the direct helper's self-binding. It also has zero coverage
  in the local `t/` corpus and only one roast file, too thin a signal to trust a behavior-changing
  swap here.
- The mixin fallback separately extracts the inner instance's `AttrMap` and manually commits the
  carrier's returned map back onto it, since the invocant (the `Mixin` wrapper) has no attribute
  cell of its own for the direct helper's automatic commit path to find. Using the direct helper
  here would silently drop attribute mutations — a correctness regression, not just a missed
  optimization.

## Test plan

- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt` clean
- [x] Full local `t/` suite (3191 files) green — no recursion, no regression
- [x] `t/augment-native-lever-a-methods.t` plus an `rust-gdb` breakpoint on the fallback call
      confirming it never fires for that file
- [x] 314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — the same 7
      non-whitelisted files fail identically before/after
- [x] `scripts/battery-testsuite.sh` — GATE PASSED, 245/271 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)