### PR TITLE
fix(docs): rephrase a doc comment tripping the value-wall ratchet

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -318,7 +318,7 @@ impl Interpreter {
 
     /// Reverse of `state_key_display`. Used only by the `__mutsu_state_key::*`
     /// env metadata bridge (a closure's free-var state writeback path, see
-    /// `vm_closure_dispatch.rs`), which persists the key as a `Value::Str`
+    /// `vm_closure_dispatch.rs`), which persists the key as a string `Value`
     /// since `Env` is string-keyed.
     pub(crate) fn state_key_from_display(s: &str) -> (Symbol, Option<u64>) {
         if let Some(pos) = s.rfind("#c")


### PR DESCRIPTION
## Summary
- `src/runtime/accessors_state.rs`'s `state_key_from_display` doc comment literally spelled `Value::Str`, which `scripts/check-value-wall.sh` counts as a direct `Value::<Variant>` use outside `src/value/`.
- This pushed the corpus count to 1 against the recorded 0 baseline, so `make test`'s `check-value-wall` prerequisite fails deterministically on current `main` for anyone running it locally or in CI.
- Reworded the comment to describe the same fact ("persists the key as a string `Value`") without matching the ratchet's regex. No behavior change.

## Test plan
- [x] `scripts/check-value-wall.sh` passes (`value-wall: 0 direct uses (== baseline)`)
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`