### PR TITLE
feat(adr0019): F6 -- migrate the ^metamethod dispatch site to the direct-dispatch helper

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2594,17 +2594,36 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release — same 7 non-whitelisted failures before/after),
   and `scripts/battery-testsuite.sh` (GATE PASSED, 245/271 unchanged).
 
-  **The other two general-call-dispatch sites are deliberately deferred, not attempted:**
-  - The `^metamethod` dispatch branch (`method ^foo(Mu) {...}`, `~line 584`) passes `invocant: None`
-    to `run_instance_method_at` even though `target` is Instance/Package — the VM caller already
-    prepends the type object as an explicit positional arg instead of binding it as `self`, per this
-    site's own comment. `try_dispatch_compiled_method_direct` always threads `target` as the bound
-    invocant into `dispatch_compiled_method`, which is a different calling convention (self-binding
-    vs. a plain leading positional) that could shift a compiled method's own positional-slot
-    accounting. This shape has **zero coverage in the local `t/` corpus** (`grep -rl 'method \^'
-    t/*.t` finds nothing) and only one roast file (`S14-traits/routines.t`), too thin a signal to
-    trust a behavior-changing swap here — left on `run_instance_method_at` pending either a wider
-    repro corpus or a helper variant that accepts an explicit invocant-vs-args split.
+  **Progress (general-call-dispatch family, `^metamethod` site migrated, #TBD).** Wrote
+  `t/metamethod-dispatch.t` first (6 cases: type-object receiver, inherited metamethod, extra
+  positional args after the prepended type object, calling through a live instance, and repeated
+  calls proving the body actually executes with retained `my`-scoped class state) — this shape had
+  **zero coverage in the local `t/` corpus** before this slice (`grep -rl 'method \^' t/*.t` found
+  nothing), only `roast/S14-traits/routines.t`'s indirect `is foo`-trait/`wrap` interaction test.
+  Confirmed against `raku` (all 6 cases match). Re-reading the calling convention this box's prior
+  note flagged as the blocker: `run_instance_method_celled`'s own `inv_value` derivation resolves
+  `invocant: None` + this site's hardcoded-empty `AttrMap::new()` to `Value::package(receiver_class_
+  name)` — i.e. even on today's carrier, `self` inside a metamethod is NEVER the real receiver, only
+  a synthesized type-object value (matching `raku`'s own `self.WHO` returning an empty/type-like
+  value there, not the instance). `dispatch_compiled_method` performs the identical `attrs_empty ->
+  Value::package(cn)` computation when its own `target` carries no attribute cell. So passing that
+  SAME synthesized `Value::package(class_sym)` as `try_dispatch_compiled_method_direct_as`'s
+  `target` reproduces bit-identical invocant semantics — no calling-convention shift after all; the
+  type object the metamethod body actually receives as its own first declared param continues to
+  arrive via `args[0]` (still prepended by the VM caller), entirely independent of the invocant
+  value threaded into `dispatch_compiled_method`, since positional-param binding and `self`-binding
+  are separate code paths (`call_compiled_method`'s `base`/`invocant` computation vs. its
+  `bind_function_args_values` call over `args`). Migrated the branch to try
+  `try_dispatch_compiled_method_direct_as(class_sym, &Value::package(class_sym), method, &args)`
+  first, falling back to `run_instance_method_at("generalcalldispatch", ...)` on `None`, same
+  pattern as every other migrated site. Verified with the full local `t/` suite (3193 files, all
+  green), the new `t/metamethod-dispatch.t`, `roast/S14-traits/routines.t` (release), the standard
+  314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release — the same 7
+  non-whitelisted files fail identically before/after, matching every prior slice in this box),
+  `cargo build`/`clippy -- -D warnings`/`fmt` clean, and `scripts/battery-testsuite.sh` (GATE
+  PASSED, 245/271 unchanged).
+
+  **The remaining general-call-dispatch site is still deliberately deferred, not attempted:**
   - The mixin fallback (`ValueView::Mixin(inner, mixins)` class-method branch, `~line 3960`) passes
     `target.clone()` (the whole mixin wrapper) as invocant so a nested `self.foo` inside the method
     re-dispatches through the mixin's role overrides, but separately extracts `inner`'s own

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -582,18 +582,38 @@ impl Interpreter {
         // The caller (VM) already prepends the type object to args.
         // Route through run_instance_method to execute the method body.
         if method.starts_with('^') && method.len() > 1 && !Self::is_classhow_method(&method[1..]) {
-            let class_name = match target.view() {
-                ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
-                ValueView::Package(name) => Some(name.resolve()),
+            let class_sym = match target.view() {
+                ValueView::Instance { class_name, .. } => Some(class_name),
+                ValueView::Package(name) => Some(name),
                 _ => None,
             };
-            if let Some(cn) = class_name
-                && self.has_user_method(&cn, method)
+            if let Some(class_sym) = class_sym
+                && self.has_user_method(class_sym.as_str(), method)
             {
+                // ADR-0019 F6: VM-level direct-dispatch path first (see
+                // `try_dispatch_compiled_method_direct_as`'s doc comment).
+                // A metamethod's `self` is never the receiver: the carrier
+                // below always resolves `invocant: None` + empty attributes
+                // to `Value::package(cn)` (`run_instance_method_celled`'s own
+                // `inv_value` fallback), so passing that SAME synthesized
+                // package value as the direct helper's `target` reproduces
+                // identical invocant semantics — no calling-convention shift,
+                // since the type object the metamethod actually receives is
+                // already `args[0]` (prepended by the VM caller), not this
+                // invocant.
+                let dispatch_target = Value::package(class_sym);
+                if let Some(result) = self.try_dispatch_compiled_method_direct_as(
+                    class_sym,
+                    &dispatch_target,
+                    method,
+                    &args,
+                ) {
+                    return result;
+                }
                 let attrs = AttrMap::new();
                 let (result, _) = self.run_instance_method_at(
                     "generalcalldispatch",
-                    &cn,
+                    class_sym.as_str(),
                     attrs,
                     method,
                     args,

--- a/t/metamethod-dispatch.t
+++ b/t/metamethod-dispatch.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+# User-defined metamethods (`method ^foo(Mu) {...}`) dispatch through a
+# dedicated fallback in `call_method_with_values`
+# (`src/runtime/methods_call_dispatch.rs`, the "generalcalldispatch" site
+# guarded by `method.starts_with('^')`). The VM prepends the type object as
+# a plain leading positional argument (NOT bound as `self`/invocant) before
+# reaching this fallback -- confirmed against `raku`. This file pins that
+# calling convention, since it previously had zero coverage in the local
+# `t/` corpus (see ADR-0019 F6's general-call-dispatch progress notes).
+
+plan 6;
+
+class Base {
+    method ^describe(Mu \type) {
+        "I am {type.^name}";
+    }
+}
+
+is Base.^describe, 'I am Base', 'metamethod called on the declaring type object';
+
+class Derived is Base {}
+
+is Derived.^describe, 'I am Derived', 'inherited metamethod sees the calling subtype';
+
+class WithArgs {
+    method ^combine(Mu \type, *@rest) {
+        "{type.^name}: " ~ @rest.join(',');
+    }
+}
+
+is WithArgs.^combine(1, 2, 3), 'WithArgs: 1,2,3',
+    'metamethod receives extra positional args after the type object';
+
+my $inst = WithArgs.new;
+is $inst.^combine('a', 'b'), 'WithArgs: a,b',
+    'metamethod is callable through an instance, not just the type object';
+
+class Counter {
+    my $calls = 0;
+    method ^bump(Mu \type) {
+        $calls++;
+        $calls;
+    }
+}
+
+is Counter.^bump, 1, 'metamethod body executes (first call)';
+is Counter.^bump, 2, 'metamethod body executes and retains state (second call)';
+
+done-testing;


### PR DESCRIPTION
## Summary
- ADR-0019 F6's general-call-dispatch family had one site left deferred: the `^metamethod` dispatch branch (`method ^foo(Mu) {...}`), previously blocked by a suspected calling-convention mismatch and zero local test coverage.
- Adds `t/metamethod-dispatch.t` first (6 cases, all verified against `raku`): type-object receiver, inherited metamethod, extra positional args after the VM-prepended type object, calling through a live instance, and repeated calls proving the body executes with retained class-level state.
- Re-derived the calling-convention concern from the ADR box: the existing carrier resolves `invocant: None` + this site's hardcoded-empty `AttrMap` to `Value::package(receiver_class_name)` — `self` inside a metamethod is never the real receiver. `dispatch_compiled_method` performs the identical computation when its own target carries no attribute cell, so passing that same synthesized package value into `try_dispatch_compiled_method_direct_as` reproduces bit-identical invocant semantics. The metamethod's own declared param still binds from `args[0]` (prepended by the VM caller), independent of the invocant.
- Migrates the site onto `try_dispatch_compiled_method_direct_as`, falling back to `run_instance_method_at("generalcalldispatch", ...)` on `None`, same pattern as every other F6 migration in this box.
- Updates the ADR-0019 progress notes.

## Test plan
- [x] `t/metamethod-dispatch.t` (new) — 6/6 pass, matches `raku`
- [x] Full local `t/` suite (3193 files) — all green
- [x] `roast/S14-traits/routines.t` (release) — pass
- [x] 314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — same 7 pre-existing non-whitelisted failures before/after, no regression
- [x] `scripts/battery-testsuite.sh` — GATE PASSED, 245/271 unchanged
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean