### PR TITLE
feat(adr0019): F6 -- migrate the mixin fallback dispatch site, closing general-call-dispatch

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2623,19 +2623,50 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   `cargo build`/`clippy -- -D warnings`/`fmt` clean, and `scripts/battery-testsuite.sh` (GATE
   PASSED, 245/271 unchanged).
 
-  **The remaining general-call-dispatch site is still deliberately deferred, not attempted:**
-  - The mixin fallback (`ValueView::Mixin(inner, mixins)` class-method branch, `~line 3960`) passes
-    `target.clone()` (the whole mixin wrapper) as invocant so a nested `self.foo` inside the method
-    re-dispatches through the mixin's role overrides, but separately extracts `inner`'s own
-    `AttrMap` and, after the call, manually commits the carrier's returned `updated` map back onto
-    `inner`'s attribute cell (`attributes.commit_attrs(updated)`) — because the invocant
-    (`target`, a `Mixin`) has no attribute cell of its own for `dispatch_compiled_method`'s automatic
-    commit path to find. `try_dispatch_compiled_method_direct`/`_as` only returns the plain `Value`
-    result, with no equivalent commit target when the invocant and the attribute-owning value
-    differ. Using it here would silently drop attribute mutations made by a class method invoked
-    through a mixin wrapper — a real correctness regression, not a missed optimization. Needs a new
-    helper shape (or this site's own bespoke wiring) that accepts an explicit attrs-cell to commit
-    through, separate from the dispatch invocant; left on `run_instance_method_at` until that exists.
+  **Progress (general-call-dispatch family, mixin fallback site — family closed, #TBD).** Built the
+  "new helper shape" this box's own prior note called for: `dispatch_compiled_method_with_attrs_cell`
+  (`vm_call_method_compiled_cache.rs`) and its resolve-and-dispatch wrapper
+  `try_dispatch_compiled_method_direct_with_attrs_cell` (`vm_call_method_compiled_direct.rs`), a
+  sibling of `dispatch_compiled_method`/`try_dispatch_compiled_method_direct_as` that takes an
+  EXPLICIT `attrs_cell: &Gc<InstanceAttrs>` separate from the dispatch invocant `target`, instead of
+  deriving the cell from `target.view()`. Always takes the slow (`call_compiled_method`) path, never
+  the fast (`call_compiled_method_fast`) one: the fast path's live-cell optimization reads attributes
+  directly off `self`'s own `ValueView`, which requires `self` to literally be `ValueView::Instance` —
+  not true for a `Mixin` wrapper, so there is no live cell for it to find; an acceptable trade for
+  this cold path (role-mixin class-method dispatch is not hot-loop code). Confirmed the existing
+  carrier path itself (`run_resolved_instance_method`, `class_dispatch.rs:593`) never performs the
+  compiled VM opcode path's eager `ValueView::Proxy` auto-fetch either (that logic lives only in
+  `dispatch_compiled_method`'s own tail, called from the VM's `CallMethod` opcode handler and
+  `try_dispatch_compiled_method_direct[_as]`, never from the tree-walk-carrier's own
+  `call_compiled_method` call) — so omitting it from the new helper is not a NEW behavior gap, it
+  matches the site's pre-migration behavior exactly (no roast/local-`t/` file combines a mixin class
+  method with a `Proxy`-returning `is rw` accessor, confirmed by `grep -l Proxy t/*.t | xargs grep -l
+  'mixin\|but role'` finding nothing).
+
+  Migrated the mixin fallback (`ValueView::Mixin(inner, mixins)` class-method branch,
+  `methods_call_dispatch.rs:~3990`) to try `try_dispatch_compiled_method_direct_with_attrs_cell`
+  first — passing `class_name`/`target` (the Mixin wrapper, so nested `self.foo` still redispatches
+  through the mixin's role overrides) and `attributes` (the `GcRef` destructured from `inner`'s own
+  `ValueView::Instance`, deref-coercing to the `&Gc<InstanceAttrs>` the helper wants) — falling back
+  to `run_instance_method_at("generalcalldispatch", ...)` on `None`, same pattern as every other F6
+  migration in this box. This site already had solid pre-existing local `t/` coverage (unlike the
+  `^metamethod` site above): `t/mixin-inherited-method-self-dispatch.t` (8 cases: direct/inherited
+  override via both mixin forms, attribute-mutation persistence through an inherited method,
+  multi-hop self-dispatch, args), `t/mixin-private-method-self-dispatch.t` (5 cases, the sibling
+  private-method branch just above this one — unchanged by this slice), and
+  `t/mixin-compiled-attr-writeback.t` (9 cases: scalar/array/hash attribute mutation through a
+  compiled mixin method, multi `.*` dispatch, nested self-dispatch back to a class method) — all
+  re-verified green after the migration, including every attribute-mutation-persistence case. Per
+  this box's own "gather evidence before migrating" discipline, no NEW test file was needed here
+  (contrast the `^metamethod` site, which had zero coverage and got `t/metamethod-dispatch.t`
+  first). Verified with the full local `t/` suite (3193 files, all green), the three named mixin
+  test files individually, `cargo build`/`clippy -- -D warnings`/`fmt` clean, the 314-file
+  whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release — the same 7 non-whitelisted files
+  fail identically before/after, matching every prior slice in this box), and
+  `scripts/battery-testsuite.sh` (GATE PASSED, 245/271 unchanged). **This closes the
+  general-call-dispatch family: all 3 of its named sites are now migrated off the carrier.** The only
+  remaining open F6 item is qualified-dispatch's shared helper (a different, larger problem — see
+  this box's own note above, "qualified-dispatch's shared helper is a DIFFERENT, bigger problem").
 - [ ] **F7 — Delete obsolete declaration payloads and generic statement-pool entries.** Remove old
   `Register*` compatibility code and assert that migrated sub/class/role declarations retain no
   executable source AST.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3988,6 +3988,23 @@ impl Interpreter {
                     }
                 }
                 if self.class_has_method(&cls, method) {
+                    // ADR-0019 F6: VM-level direct-dispatch path first (see
+                    // `dispatch_compiled_method_with_attrs_cell`'s doc comment).
+                    // `self` must stay bound to the Mixin wrapper (`target`) so a
+                    // nested `self.foo` inside the method redispatches through the
+                    // mixin's role overrides, but the real attribute storage lives
+                    // on `inner` — so the real cell is threaded through explicitly
+                    // rather than derived from `target`'s own (nonexistent)
+                    // attribute cell.
+                    if let Some(result) = self.try_dispatch_compiled_method_direct_with_attrs_cell(
+                        class_name,
+                        &target,
+                        &attributes,
+                        method,
+                        &args,
+                    ) {
+                        return result;
+                    }
                     let attrs = attributes.to_map();
                     let (result, updated) = self.run_instance_method_at(
                         "generalcalldispatch",

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -411,6 +411,70 @@ impl Interpreter {
         Ok(result)
     }
 
+    /// Variant of [`Self::dispatch_compiled_method`] for callers whose bound
+    /// `self`/invocant carries no attribute cell of its own — e.g. a role-mixin
+    /// wrapper (`ValueView::Mixin`), whose real attribute storage lives on a
+    /// DIFFERENT value (the mixin's `inner` instance) — but where `self` must
+    /// still be the wrapper itself so a nested `self.foo` inside the method
+    /// redispatches through the mixin's role overrides. `attrs_cell` supplies
+    /// the actual attribute storage to read from and commit mutations back
+    /// onto; `target` is the value bound as `self`.
+    ///
+    /// Always takes the slow (`call_compiled_method`) path, never the fast
+    /// (`call_compiled_method_fast`) one: the fast path's live-cell
+    /// optimization reads attributes directly off `self`'s own `ValueView`,
+    /// which requires `self` to literally be `ValueView::Instance` — not true
+    /// here by construction, so there is no live cell for it to find. This is
+    /// an acceptable trade for a cold path (role-mixin class-method dispatch),
+    /// matching ADR-0019 F6's box note that the general-call-dispatch family's
+    /// mixin fallback "needs a new helper shape" rather than reusing
+    /// `try_dispatch_compiled_method_direct`/`_as` as-is (those would silently
+    /// derive an empty attribute map from the wrapper and drop mutations).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn dispatch_compiled_method_with_attrs_cell(
+        &mut self,
+        cn: &str,
+        owner_class: &str,
+        method: &str,
+        method_def: &std::sync::Arc<crate::runtime::MethodDef>,
+        cc: &std::sync::Arc<CompiledCode>,
+        target: Value,
+        attrs_cell: &crate::gc::Gc<crate::value::InstanceAttrs>,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        let empty_fns = CompiledFns::default();
+        let fns_ref = method_def.compiled_fns.as_deref().unwrap_or(&empty_fns);
+        let attributes = attrs_cell.to_map();
+        let pushed_dispatch = loan_env!(
+            self,
+            push_method_dispatch_frame(cn, method, &args, target.clone(),)
+        );
+        let invocant = Some(target);
+        let result = self.call_compiled_method(
+            cn,
+            owner_class,
+            method,
+            method_def,
+            cc,
+            &attributes,
+            args,
+            invocant,
+            fns_ref,
+        );
+        if pushed_dispatch {
+            self.pop_method_dispatch();
+        }
+        self.pop_method_samewith_context();
+        let (result, reconciled) = result?;
+        // Same "only commit a `:=`-adjusted snapshot" reasoning as
+        // `dispatch_compiled_method`: an unadjusted result equals the cell
+        // already, so a whole-map write would race with concurrent cell-CAS.
+        if let Some(m) = &reconciled {
+            attrs_cell.commit_attrs(m.clone());
+        }
+        Ok(result)
+    }
+
     /// Pre-compute and cache fast dispatch eligibility for a method.
     pub(crate) fn try_populate_fast_cache(
         &mut self,

--- a/src/vm/vm_call_method_compiled_direct.rs
+++ b/src/vm/vm_call_method_compiled_direct.rs
@@ -105,4 +105,67 @@ impl Interpreter {
             None,
         ))
     }
+
+    /// Same as `try_dispatch_compiled_method_direct_as`, but for a `self`/
+    /// invocant that carries no attribute cell of its own — `attrs_cell`
+    /// supplies the real attribute storage separately (see
+    /// `dispatch_compiled_method_with_attrs_cell`'s doc comment). Used by the
+    /// role-mixin class-method dispatch fallback, where `target` is the
+    /// `Mixin` wrapper (so nested `self.foo` redispatches through the mixin's
+    /// role overrides) but the actual attributes live on the mixin's `inner`
+    /// instance.
+    pub(crate) fn try_dispatch_compiled_method_direct_with_attrs_cell(
+        &mut self,
+        class_sym: crate::symbol::Symbol,
+        target: &Value,
+        attrs_cell: &crate::gc::Gc<crate::value::InstanceAttrs>,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        self.refresh_method_caches_for_generation();
+        let cn = class_sym.as_str();
+        let method_sym = crate::symbol::Symbol::intern(method);
+        let (owner_class, method_def) =
+            self.resolve_method_cached(cn, method, class_sym, method_sym, args, target)?;
+        if let Some(result) = self.check_method_wrap_chain(
+            cn,
+            owner_class.as_str(),
+            method,
+            &method_def,
+            target,
+            args,
+        ) {
+            return Some(result);
+        }
+        let (owner_class, method_def) = if method_def.compiled_code.is_some() {
+            (owner_class, method_def)
+        } else if !method_def.body.is_empty()
+            && let Some((owner, def)) =
+                self.populate_uncompiled_method(cn, owner_class.as_str(), method, args, target)
+        {
+            let cache_key = (class_sym, method_sym);
+            self.method_resolve_cache
+                .insert(cache_key, Some((owner, def.clone())));
+            if !def.is_multi {
+                self.last_method_resolve = Some((class_sym, method_sym, owner, def.clone()));
+            }
+            (owner, def)
+        } else {
+            return None;
+        };
+        let cc = method_def
+            .compiled_code
+            .clone()
+            .expect("compiled_code set above");
+        Some(self.dispatch_compiled_method_with_attrs_cell(
+            cn,
+            owner_class.as_str(),
+            method,
+            &method_def,
+            &cc,
+            target.clone(),
+            attrs_cell,
+            args.to_vec(),
+        ))
+    }
 }


### PR DESCRIPTION
## Summary
- ADR-0019 F6's general-call-dispatch family had one site left deferred: the role-mixin class-method dispatch fallback (`ValueView::Mixin(inner, mixins)` branch in `call_method_with_values`).
- This site is unusual: `self` must stay bound to the whole `Mixin` wrapper (so a nested `self.foo` inside an inherited method redispatches through the mixin's role overrides), but the real attribute storage lives on the mixin's `inner` instance, not on the wrapper. `try_dispatch_compiled_method_direct`/`_as` derive the attribute cell from `target.view()` alone, which would silently produce an empty attribute map and drop mutations here — a real correctness risk the ADR box explicitly flagged, not just a missed optimization.
- Builds the "new helper shape" the box's own prior note called for: `dispatch_compiled_method_with_attrs_cell` (a sibling of `dispatch_compiled_method` that takes an explicit `attrs_cell` separate from the dispatch invocant) and its resolve-and-dispatch wrapper `try_dispatch_compiled_method_direct_with_attrs_cell`. Always takes the slow (`call_compiled_method`) path, since the fast path's live-cell optimization requires `self` to literally be `ValueView::Instance`.
- Confirmed the existing carrier itself never does the compiled VM opcode path's eager `Proxy` auto-fetch either, so omitting it from the new helper matches pre-migration behavior exactly (no `t/`/roast file combines a mixin class method with a `Proxy`-returning accessor).
- This site already had solid pre-existing local `t/` coverage (22 cases across 3 files, including attribute-mutation persistence through an inherited method), so unlike the `^metamethod` site migrated in the prior PR, no new test file was needed here.
- **Closes the general-call-dispatch family**: all 3 named sites are now migrated off the `run_instance_method` carrier. The only remaining open F6 item is qualified-dispatch's shared helper (a separate, larger problem per the ADR box's own note).

## Test plan
- [x] `t/mixin-inherited-method-self-dispatch.t` (8 cases) — pass
- [x] `t/mixin-private-method-self-dispatch.t` (5 cases, sibling branch, unchanged) — pass
- [x] `t/mixin-compiled-attr-writeback.t` (9 cases, including scalar/array/hash attribute mutation) — pass
- [x] Full local `t/` suite (3193 files) — all green
- [x] 314-file whitelisted `S04`/`S06`/`S09`/`S12`/`S14` roast subset (release) — same 7 pre-existing non-whitelisted failures before/after, no regression
- [x] `scripts/battery-testsuite.sh` — GATE PASSED, 245/271 unchanged
- [x] `cargo build` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean