### PR TITLE
test(adr0019): G2 -- token/rule declarations never re-enter stmt_pool

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2913,6 +2913,21 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
 - [ ] **G2 — Architectural guard tests.** Tests fail if a migrated declaration enters
   `stmt_pool`, retains `legacy_body`, dispatch bypasses `MethodEntry`, or introspection reads a hand
   name table.
+
+  **Progress (2026-08-17):** the `stmt_pool` clause already has scattered per-declaration-kind
+  coverage, one test per migrated kind, all in `src/compiler/mod.rs`'s `declaration_plan_tests`
+  module: `sub_declarations_leave_the_generic_statement_pool` (A2),
+  `type_declarations_leave_the_generic_statement_pool` (A3, class/role),
+  `nontrivial_proto_declarations_compile_their_dispatch_body` (C8, proto), and the new
+  `token_rule_declarations_leave_the_generic_statement_pool` (F7, covering both the top-level and
+  class-body registration paths). No single test asserts the invariant for every declaration kind
+  at once — this is a real gap: a future declaration kind could regress `stmt_pool` without
+  tripping any existing test. The `legacy_body`/`dispatch bypasses MethodEntry`/`introspection
+  reads a hand name table` clauses have no dedicated guard tests yet, though each was verified
+  ad hoc at its own closing box (e.g. D6-4/D9-5's `legacy_body` field removal, E4-E7's dispatch
+  entry-routing verification, F1/F2's `.^methods`/`.^can` canonical-table cutover) — formalizing
+  those as permanent regression tests, and adding the missing "every declaration kind" sweep, is
+  still open, unscoped work.
 - [ ] **G3 — Performance gate.** Benchmarks show no regression from initialization probing,
   per-call owner scans, registry locking, or repeated string interning; cache-hit dispatch remains
   generation-checked O(1).

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -123,6 +123,59 @@ mod declaration_plan_tests {
         )));
     }
 
+    /// ADR-0019 G2 (architectural guard): a `token`/`rule` declaration —
+    /// whether at the top level (F7 slice 1) or inside a class body (F7
+    /// slice 2) — never leaves an executable `Stmt::TokenDecl`/`RuleDecl`
+    /// clone in the generic `stmt_pool`, mirroring the sub/class/proto
+    /// guard tests above. The regex body itself stays an opaque payload on
+    /// the typed plan (`CompiledTokenDeclPlan::raw_body`/`ClassBodyOp::TokenRule`'s
+    /// own `raw_body`) — ADR-0009's accepted execution model, not something
+    /// this guard checks.
+    #[test]
+    fn token_rule_declarations_leave_the_generic_statement_pool() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            "token top_level { \\d+ }; class A { rule in_class { \\d+ } }",
+        )
+        .expect("source parses");
+        let (code, _) = Compiler::new().compile(&stmts);
+
+        assert!(
+            code.stmt_pool.iter().all(|stmt| !matches!(
+                stmt,
+                crate::ast::Stmt::TokenDecl { .. } | crate::ast::Stmt::RuleDecl { .. }
+            )),
+            "compiled token/rule declarations must not remain executable generic statements"
+        );
+
+        // Top-level: registers via RegisterDecl(CompiledDeclPlanRef::Token).
+        assert!(!code.token_decl_plans.is_empty());
+        assert!(
+            code.token_decl_plans
+                .iter()
+                .any(|plan| plan.name.as_str() == "top_level")
+        );
+        assert!(code.ops.iter().any(|op| matches!(
+            op,
+            crate::opcode::OpCode::RegisterDecl(idx)
+                if matches!(
+                    code.decl_plans.get(*idx as usize),
+                    Some(crate::opcode::CompiledDeclPlanRef::Token(_))
+                )
+        )));
+
+        // Class body: registers via ClassBodyOp::TokenRule, not Other/chunk.
+        let plan_a = code
+            .class_decl_plans
+            .iter()
+            .find(|plan| plan.name.as_str() == "A")
+            .expect("class A declaration plan");
+        assert!(plan_a.body_plan.iter().any(|op| matches!(
+            op,
+            crate::opcode::ClassBodyOp::TokenRule { plan }
+                if plan.name.as_str() == "in_class"
+        )));
+    }
+
     /// ADR-0019 C8: a non-trivial proto body compiles its `{*}`-rewritten
     /// dispatch once, at declaration time, instead of leaving the VM to
     /// rewrite and OTF-compile the AST on every call.


### PR DESCRIPTION
## Summary
- Adds `token_rule_declarations_leave_the_generic_statement_pool`, mirroring the existing sub/class/proto `stmt_pool` guard tests in `declaration_plan_tests` -- formalizes ADR-0019 F7's own invariant (top-level and class-body `token`/`rule` declarations register from a typed plan, never a raw `Stmt` clone in `stmt_pool`) as a permanent regression pin.
- Documents G2's current partial coverage in the ADR: the `stmt_pool` clause now has one guard test per migrated declaration kind, but no single sweep covers every kind at once, and the `legacy_body`/`MethodEntry`-bypass/introspection clauses have no dedicated guard tests yet (each was verified ad hoc at its own closing box instead).

Small, focused contribution toward ADR-0019's G2 completion gate.

## Test plan
- [x] `cargo test --lib` (840 tests)
- [x] `cargo build` / `clippy -- -D warnings` / `fmt` clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>