### PR TITLE
test(adr0019): G2 -- comprehensive stmt_pool sweep across every migrated declaration kind

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -2920,13 +2920,20 @@ full slice-by-slice history; the checklist below keeps only the architectural ou
   `type_declarations_leave_the_generic_statement_pool` (A3, class/role),
   `nontrivial_proto_declarations_compile_their_dispatch_body` (C8, proto), and the new
   `token_rule_declarations_leave_the_generic_statement_pool` (F7, covering both the top-level and
-  class-body registration paths). No single test asserts the invariant for every declaration kind
-  at once — this is a real gap: a future declaration kind could regress `stmt_pool` without
-  tripping any existing test. The `legacy_body`/`dispatch bypasses MethodEntry`/`introspection
-  reads a hand name table` clauses have no dedicated guard tests yet, though each was verified
+  class-body registration paths), and now
+  `every_migrated_declaration_kind_together_leaves_the_generic_statement_pool` — one program
+  declaring `sub`/`proto sub`+`multi sub`/`token`/`rule`/`class` together (plus a class body's own
+  nested `method`/`token`/`rule`), checked against the top-level `stmt_pool`, every nested compiled
+  function's own `stmt_pool`, and each class body op's `Other`/`ClassSub` raw payload — closing the
+  "isolated per-kind tests could miss a kind-vs-kind interaction" gap the per-kind tests alone left
+  open. Deliberately excludes role bodies: `RoleBodyOp::Deferred` keeps a raw `Stmt` for ANY
+  deferred statement kind by design (a role's composing package is unknown until composition, ADR
+  D8-1/D8-2), so it is an accepted carve-out bucket, not a regression surface this sweep should
+  police. The `legacy_body`/`dispatch bypasses MethodEntry`/`introspection
+  reads a hand name table` clauses still have no dedicated guard tests, though each was verified
   ad hoc at its own closing box (e.g. D6-4/D9-5's `legacy_body` field removal, E4-E7's dispatch
   entry-routing verification, F1/F2's `.^methods`/`.^can` canonical-table cutover) — formalizing
-  those as permanent regression tests, and adding the missing "every declaration kind" sweep, is
+  those as permanent regression tests is
   still open, unscoped work.
 - [ ] **G3 — Performance gate.** Benchmarks show no regression from initialization probing,
   per-call owner scans, registry locking, or repeated string interning; cache-hit dispatch remains

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -176,6 +176,84 @@ mod declaration_plan_tests {
         )));
     }
 
+    /// ADR-0019 G2 (architectural guard, comprehensive sweep): one program
+    /// declaring every migrated declaration kind at once — top-level `sub`,
+    /// `proto sub`/`multi sub`, `token`, `rule`, `class`, and a class body's
+    /// own nested `method`/`token`/`rule` — leaves NO declaration-shaped
+    /// `Stmt` in `stmt_pool` (top level, nested compiled functions, or a
+    /// class body's own `ClassBodyOp::Other`/`ClassSub` raw payload). The
+    /// per-kind tests above each cover one declaration kind in isolation;
+    /// this test exists because that isolation could hide a kind-vs-kind
+    /// interaction (e.g. a nested declaration only regressing when a
+    /// sibling kind is also present) that no single-kind test would catch.
+    /// `stmt_pool` itself is not asserted empty — it also carries
+    /// non-declaration payloads (`gather` bodies, closures) — only that it
+    /// holds none of the six migrated declaration `Stmt` variants.
+    ///
+    /// A **role body** is deliberately NOT swept the same way: every
+    /// `RoleBodyOp::Deferred` statement (not just `token`/`rule`) keeps a
+    /// raw `Stmt` by design — a role's composing package is unknown until
+    /// composition (ADR-0019 D8-1/D8-2), so `Deferred` is the accepted
+    /// carve-out bucket for any deferred statement kind, not a regression
+    /// surface this guard should police.
+    #[test]
+    fn every_migrated_declaration_kind_together_leaves_the_generic_statement_pool() {
+        let (stmts, _) = crate::parse_dispatch::parse_source(
+            "sub f($x) { $x };
+             proto sub p($x) {*}; multi sub p(Int $x) { $x };
+             token t1 { \\d+ };
+             rule r1 { \\d+ };
+             class C {
+                 method cm { 2 }
+                 token ct { 'y' }
+                 rule cr { 'z' }
+             }",
+        )
+        .expect("source parses");
+        let (code, compiled_fns) = Compiler::new().compile(&stmts);
+
+        let is_migrated_decl = |stmt: &Stmt| {
+            matches!(
+                stmt,
+                Stmt::SubDecl { .. }
+                    | Stmt::ProtoDecl { .. }
+                    | Stmt::TokenDecl { .. }
+                    | Stmt::RuleDecl { .. }
+                    | Stmt::ClassDecl { .. }
+                    | Stmt::RoleDecl { .. }
+            )
+        };
+        assert!(
+            code.stmt_pool.iter().all(|stmt| !is_migrated_decl(stmt)),
+            "top-level stmt_pool: {:?}",
+            code.stmt_pool
+        );
+        for function in compiled_fns.values() {
+            assert!(
+                function
+                    .code
+                    .stmt_pool
+                    .iter()
+                    .all(|stmt| !is_migrated_decl(stmt)),
+                "nested compiled-function stmt_pool: {:?}",
+                function.code.stmt_pool
+            );
+        }
+        for plan in &code.class_decl_plans {
+            for op in &plan.body_plan {
+                if let crate::opcode::ClassBodyOp::Other { raw, .. }
+                | crate::opcode::ClassBodyOp::ClassSub { raw, .. } = op
+                {
+                    assert!(
+                        !is_migrated_decl(raw),
+                        "class {} body op: {raw:?}",
+                        plan.name
+                    );
+                }
+            }
+        }
+    }
+
     /// ADR-0019 C8: a non-trivial proto body compiles its `{*}`-rewritten
     /// dispatch once, at declaration time, instead of leaving the VM to
     /// rewrite and OTF-compile the AST on every call.


### PR DESCRIPTION
## Summary
- Adds `every_migrated_declaration_kind_together_leaves_the_generic_statement_pool`: one program declaring `sub`/`proto sub`+`multi sub`/`token`/`rule`/`class` together (plus a class body's own nested `method`/`token`/`rule`), checked against the top-level `stmt_pool`, every nested compiled function's own `stmt_pool`, and each class body op's `Other`/`ClassSub` raw payload.
- The existing per-kind guard tests (`sub_declarations_leave_the_generic_statement_pool`, `type_declarations_leave_the_generic_statement_pool`, `nontrivial_proto_declarations_compile_their_dispatch_body`, `token_rule_declarations_leave_the_generic_statement_pool`) each cover one declaration kind in isolation, which could miss a kind-vs-kind interaction (e.g. a nested declaration only regressing when a sibling kind is also present); this closes that gap.
- Deliberately excludes role bodies: `RoleBodyOp::Deferred` keeps a raw `Stmt` for ANY deferred statement kind by design (a role's composing package is unknown until composition, ADR-0019 D8-1/D8-2), so it is an accepted carve-out bucket, not a regression surface this sweep should police.

Continues ADR-0019's G2 completion-gate work (see #6566).

## Test plan
- [x] `cargo test --lib` (841 tests)
- [x] `cargo build` / `clippy -- -D warnings` / `fmt` clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>