### PR TITLE
fix(runtime): bare callsame/nextsame in a new() override reaches the native Mu.new fallback

### DIFF
--- a/news/2026-08/callsame-native-mu-new-fallback.md
+++ b/news/2026-08/callsame-native-mu-new-fallback.md
@@ -1,0 +1,30 @@
+# bare `callsame`/`nextsame` in a `new()` override now reaches the native Mu.new (bless)
+
+```raku
+class D { has $.x; method new(|c) { my $obj = callsame; $obj } }
+say D.new(x => 5).x;
+# raku:  5     (callsame reaches Mu.new, returns the built instance)
+# mutsu (before): callsame returns Any; "No such method 'x' for invocant of type 'Any'"
+```
+
+`dispatch_next_candidate`'s "we're inside `new`, dispatch to the native Mu.new
+(bless)" fallback (`src/runtime/builtins_dispatch_next.rs`) only triggered for
+`nextwith`/`callwith` — never the bare `nextsame`/`callsame` forms, which
+implicitly forward the original call's arguments rather than an explicit
+list. Widened the condition to include `nextsame`/`callsame`, and when
+`override_args` is `None` (the bare-call case), read the original call's
+args off the method dispatch frame or the samewith context — mirroring how
+`native_array_storage_next_candidate` resolves args for a no-frame single
+compiled method.
+
+The sibling divergence in the original ticket — `callsame` from a `gist`/
+`Str`/`raku` override not reaching the native Mu-level implementation — is
+NOT fixed by this change; it needs a bigger fix (compile-time detection of
+callsame/nextsame usage, plumbed through the hot compiled method-dispatch
+path's several exit points) and stays open as
+`todo/tickets/callsame-to-native-mu-methods-nil.md`, now narrowed to just
+that remaining gap with the root cause fully written up.
+
+Regression test: `t/new-callsame-native-mu-fallback.t` (also pins the
+already-working `nextwith`/`callwith` forms alongside the new
+`nextsame`/`callsame` coverage).

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -1111,11 +1111,17 @@ impl Interpreter {
             }
             return Ok(result);
         }
-        // Fallback: if we are inside a `new` method and nextwith/callwith is called,
-        // dispatch to the built-in Mu.new (i.e., bless) on the current invocant.
-        // In Raku, Mu.new(*%attrinit) is always the base candidate in the MRO for `new`.
-        // Check both routine_stack (VM path) and samewith_context_stack (interpreter path).
-        if matches!(func_name, "nextwith" | "callwith") {
+        // Fallback: if we are inside a `new` method and nextsame/callsame/
+        // nextwith/callwith is called, dispatch to the built-in Mu.new (i.e.,
+        // bless) on the current invocant. In Raku, Mu.new(*%attrinit) is
+        // always the base candidate in the MRO for `new`. Check both
+        // routine_stack (VM path) and samewith_context_stack (interpreter
+        // path). `nextsame`/`callsame` (override_args is None) implicitly
+        // forward the ORIGINAL call's args rather than an empty list — read
+        // them off the method dispatch frame / samewith context, mirroring
+        // `native_array_storage_next_candidate`'s same fallback for a
+        // no-frame single compiled method.
+        if matches!(func_name, "nextsame" | "callsame" | "nextwith" | "callwith") {
             let in_new = self
                 .routine_stack
                 .last()
@@ -1125,7 +1131,19 @@ impl Interpreter {
                     .last()
                     .is_some_and(|ctx| ctx.name == "new");
             if in_new && let Some(invocant) = self.env.get("self").cloned() {
-                let call_args = override_args.unwrap_or_default();
+                let call_args = match override_args {
+                    Some(args) => args,
+                    None => self
+                        .method_dispatch_stack
+                        .last()
+                        .map(|f| f.args.clone())
+                        .or_else(|| {
+                            self.samewith_context_stack
+                                .last()
+                                .and_then(|c| c.args.clone())
+                        })
+                        .unwrap_or_default(),
+                };
                 let result = self.call_method_with_values(invocant, "bless", call_args)?;
                 if tail_call {
                     return Err(RuntimeError {

--- a/t/new-callsame-native-mu-fallback.t
+++ b/t/new-callsame-native-mu-fallback.t
@@ -1,0 +1,39 @@
+use Test;
+
+# `dispatch_next_candidate`'s "we're inside `new`, dispatch to the native
+# Mu.new (bless)" fallback (src/runtime/builtins_dispatch_next.rs) used to
+# trigger only for `nextwith`/`callwith` — never for the bare `nextsame`/
+# `callsame` forms, which implicitly forward the original call's args. A
+# `method new(|c) { my $obj = callsame; $obj }` override therefore got Nil
+# back from callsame instead of the freshly bless'd instance.
+# todo/tickets/callsame-to-native-mu-methods-nil.md. Verified against Rakudo
+# v2026.06.
+
+plan 4;
+
+class D {
+    has $.x;
+    method new(|c) { my $obj = callsame; $obj }
+}
+is D.new(x => 5).x, 5, 'bare callsame in a new() override reaches the native Mu.new bless';
+
+class E {
+    has $.x;
+    method new(*%c) { my $obj = nextsame; $obj }
+}
+is E.new(x => 7).x, 7, 'bare nextsame in a new() override reaches the native Mu.new bless';
+
+# nextwith/callwith (explicit args) already worked before this fix -- pin
+# them alongside the new nextsame/callsame coverage so a future regression
+# in either form is caught by the same file.
+class F {
+    has $.x;
+    method new(*%c) { my $obj = callwith(|%c); $obj }
+}
+is F.new(x => 9).x, 9, 'callwith in a new() override still reaches the native Mu.new bless';
+
+class G {
+    has $.x;
+    method new(*%c) { nextwith(|%c) }
+}
+is G.new(x => 11).x, 11, 'nextwith in a new() override still reaches the native Mu.new bless';

--- a/todo/tickets/callsame-to-native-mu-methods-nil.md
+++ b/todo/tickets/callsame-to-native-mu-methods-nil.md
@@ -1,9 +1,11 @@
-# callsame from an override of a built-in Mu-level method (gist/Str/raku/new) returns Nil/Any instead of reaching the native implementation
+# callsame from an override of gist/Str/raku returns Nil instead of reaching the native implementation
 
-Found by the ADR-0019 E9-pre raku verification campaign (2026-08-12, Rakudo v2026.06). The
-`native_mu_base_next_candidate` synthesized fallback and the `Mu.new` fallback
-(`src/runtime/builtins_dispatch_next.rs`) do not deliver the native method's value to
-`callsame`.
+Found by the ADR-0019 E9-pre raku verification campaign (2026-08-12, Rakudo v2026.06).
+Narrowed 2026-08-17: the `new` half of this ticket is FIXED (see
+`news/2026-08/callsame-native-mu-new-fallback.md` — the "Fallback: if we are inside a
+`new` method" block in `dispatch_next_candidate`, `src/runtime/builtins_dispatch_next.rs`,
+used to trigger only for `nextwith`/`callwith`, never the bare `nextsame`/`callsame` forms).
+This ticket now covers only `gist`/`Str`/`raku`.
 
 ## Divergence
 
@@ -12,30 +14,74 @@ class C { method gist() { "custom+" ~ callsame } }
 say C.new;
 # raku:  custom+C.new          (callsame reaches Mu.gist)
 # mutsu: "Use of Nil in string context" warning, then "custom+"
-
-class D { has $.x; method new(|c) { my $obj = callsame; $obj } }
-say D.new(x => 5).x;
-# raku:  5                     (callsame reaches Mu.new, returns the built instance, .^name is D)
-# mutsu: callsame returns Any; then "No such method 'x' for invocant of type 'Any'"
 ```
 
-Same shape for `method raku()` and `method Str()` overrides (`E-str[E<...>]` in raku vs
-`E-str[]` + Nil warning in mutsu). All four probes: `tmp/e9pre/n.raku`, `n2.raku`,
-`probe-n3.raku` during the campaign (gitignored; shapes inlined above).
+Same shape for `method raku()` and `method Str()` overrides, for a role-composed
+override (`role R { method gist() {...} }; class C does R {}`), and for a `multi method
+gist()` override — all four shapes reproduce identically (verified 2026-08-17).
 
-## Where to look
+## Root cause (found 2026-08-17, root-caused precisely; NOT fixed — see below)
 
-The four synthesized native fallbacks are force-pushed with empty `remaining` when the user MRO
-is exhausted (`builtins_dispatch_next.rs:181-310` per the E8-E11 survey), and
-`dispatch_next_candidate`'s search ends in a `Mu.new` fallback arm (:358-903). Two separate
-symptoms: (1) for gist/Str/raku the native Mu-level implementation is either not invoked or its
-value is dropped on the way back to `callsame` (Nil); (2) for `new` the fallback runs but the
-constructed object is lost (Any comes back — check whether construction happens against the
-wrong invocant or the return value is swallowed by the frame plumbing).
+`dispatch_next_candidate`'s exhausted-MRO fallbacks (`native_mu_base_next_candidate` for
+BUILDALL/POPULATE/clone, the `new`-bless fallback) all key off
+`self.samewith_context_stack.last()` to learn "what method is currently executing" —
+but **a single (non-multi, non-wrapped) compiled method call never pushes a
+`SamewithContext` at all**. `push_method_samewith_context` is called from exactly three
+sites: `vm_call_method_compiled.rs`'s wrap-chain branch (gated on
+`self.has_any_wrap_chains()`), and `class_dispatch.rs`'s slow/interpreter-path dispatch
+(reached for constructor calls like `new`, and other paths that route through the
+tree-walk method dispatcher). The COMPILED fast path
+(`call_compiled_method`/`call_compiled_method_fast` in `vm_method_dispatch.rs`) — the one
+an ordinary `method gist() {...}` override with no wrap/multi/role complications takes —
+pushes `method_class_stack` (just the class name) but never a `SamewithContext`, so
+`samewith_context_stack.last()` is empty and any exhausted-MRO fallback keyed off it
+silently returns `None` before ever checking `method_name`.
 
-Sibling ticket for the same fallback family:
-`todo/tickets/native-array-push-defer-fallback-broken.md` (array storage). ADR-0019 E9's cursor
-design makes all four fallbacks ordinary sequence tail entries — fix here or re-verify at that
-boundary, whichever lands first.
+Confirmed via `rust-gdb`: breaking at the top of a would-be `gist`-fallback function, the
+breakpoint fired but `self.samewith_context_stack.last()` was `None`, so the function
+returned via its `?` before reaching the method-name match. The identical construction
+for `new` DOES work because constructor dispatch goes through the slow
+`class_dispatch.rs` path (which pushes a `SamewithContext` unconditionally), not the
+compiled fast path.
 
-The E9-pre pins for these land with the fix.
+## Why this needs a bigger fix than the `new` one
+
+`method_name` IS available as a plain parameter at the top of both
+`call_compiled_method`/`call_compiled_method_fast`, so in principle a `SamewithContext`
+could be pushed there too. But:
+
+- Both functions are **hot paths** (every method call in the interpreter goes through
+  one of them) with **6 separate `pop_method_class()` exit points** across
+  `vm_method_dispatch.rs` (lines ~435/579/791/910/1358/1754 as of this writing). A
+  new paired push/pop would need to mirror every one of those exits correctly, or risk
+  leaking/misaligning `samewith_context_stack` entries for calls that DON'T touch it
+  today.
+- An **unconditional** push (cheapest to get right) costs a String clone + Vec clone on
+  every compiled method call, including the overwhelming majority that never call
+  `callsame`/`nextsame` — a real regression for a path this hot (see the file's own
+  comments about avoiding "a redundant... pull" on the common case).
+- A **conditional** push (only for methods whose body might call
+  `callsame`/`nextsame`/`nextwith`/`callwith`) needs a compile-time flag on
+  `CompiledCode`, mirroring existing flags like `has_once`/`uses_callframe` — no such
+  flag (`uses_callsame`/similar) exists yet, and computing it requires a body scan at
+  compile time, not just a name-based check like the `new` fix's `in_new` test.
+
+## Suggested fix shape
+
+1. Add a `CompiledCode` flag (compile-time, body-scan-detected) for "this method body
+   references callsame/nextsame/nextwith/callwith" — call it e.g. `uses_dispatcher`.
+2. Gate a `push_method_samewith_context`/`pop_method_samewith_context` pair on that flag
+   at the SAME entry/exit points `push_method_class`/`pop_method_class` already bracket
+   in both `call_compiled_method` and `call_compiled_method_fast` (reuse those exact
+   6+2 sites so no new exit-path bookkeeping is needed).
+3. Then a `native_any_base_next_candidate`-shaped fallback (mirrors
+   `native_mu_base_next_candidate`) can read `samewith_context_stack.last()` for
+   `gist`/`Str`/`raku` and dispatch to `self.try_native_method(&invocant, method_sym,
+   &args)` — this part was prototyped and confirmed correct in isolation (verified it
+   fires and returns the right value once a `SamewithContext` is present), just never
+   reachable without step 1-2.
+
+Alternatively: re-verify at the ADR-0019 E9 cursor-design boundary
+(`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) if that lands first — its
+stated goal is "all four fallbacks [become] ordinary sequence tail entries", which would
+plausibly subsume this gap by construction.


### PR DESCRIPTION
## Summary
- `dispatch_next_candidate`'s "we're inside `new`, dispatch to the native Mu.new (bless)" fallback (`src/runtime/builtins_dispatch_next.rs`) only triggered for `nextwith`/`callwith` — never the bare `nextsame`/`callsame` forms, which implicitly forward the original call's args. A `method new(|c) { my $obj = callsame; $obj }` override got `Any` back instead of the built instance.
- Widened the condition to `nextsame | callsame | nextwith | callwith`; for the bare-call case (`override_args` is `None`), the original call's args are now read off the method dispatch frame or samewith context, mirroring `native_array_storage_next_candidate`'s existing pattern.
- The ticket's sibling divergence — `callsame` from a `gist`/`Str`/`raku` override not reaching the native Mu-level implementation — needs a bigger fix: I found (via `rust-gdb`) that the fast compiled method-dispatch path never pushes a `SamewithContext` at all (unlike the constructor path, which goes through the slow interpreter path), so any exhausted-MRO fallback keyed off it is unreachable for an ordinary method override. That's a hot-path change (6 exit points, needs compile-time dispatcher-usage detection to avoid a perf regression on the common no-callsame case) out of scope for this PR — root-caused and left open in a narrowed `todo/tickets/callsame-to-native-mu-methods-nil.md`.
- Closes the `new` half of the ticket; moved that part to `news/2026-08/`.

## Test plan
- [x] New `t/new-callsame-native-mu-fallback.t` — byte-identical against `raku`, covers `callsame`/`nextsame`/`callwith`/`nextwith` in a `new()` override.
- [x] `t/*callsame*.t t/*nextsame*.t t/*nextwith*.t t/*callwith*.t` and related (66 files, 551 tests) all pass.
- [x] Full local suite: `prove -e './target/debug/mutsu' t/` — 3200 files, 29792 tests, all pass.
- [x] `cargo clippy -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)