### PR TITLE
perf(vm): skip the constant-var marker removal until a constant is seen

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2519,6 +2519,15 @@ pub struct Interpreter {
     /// set per active loop (ADR-0023). Bare names (no `$` sigil), matching
     /// env keys. Consulted by `block_captured_scalars` only; never persisted.
     pub(crate) active_loop_param_names: Vec<rustc_hash::FxHashSet<String>>,
+    /// Set once a `constant $name = ...` scalar has ever been declared in
+    /// this run (ADR-0022 Slice 5's `__mutsu_constant_var::` marker). Lets
+    /// `exec_set_local_op_inner` skip the marker-removal `format!` + env
+    /// lookup on every ordinary (non-constant) scalar `my`/`state` — the
+    /// overwhelming common case — since there is nothing to remove until a
+    /// `constant` scalar has actually been seen. Never reset to `false`;
+    /// once true the plain removal path runs as before (still correct, just
+    /// no longer free to skip).
+    pub(crate) any_constant_var_marker_set: bool,
     /// Per loop-body scope: what each body-local `my` name must be restored to
     /// when the loop exits. `Some(v)` is a genuine shadow (re-expose the outer
     /// binding's value); `None` means the name did not exist before the loop, so

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2372,6 +2372,7 @@ impl Interpreter {
             given_pointy_captured: Vec::new(),
             loop_local_vars: Vec::new(),
             active_loop_param_names: Vec::new(),
+            any_constant_var_marker_set: false,
             loop_local_saved_env: Vec::new(),
             loop_cond_active: false,
             outer_scope_locals: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -804,6 +804,7 @@ impl Interpreter {
             given_pointy_captured: Vec::new(),
             loop_local_vars: Vec::new(),
             active_loop_param_names: Vec::new(),
+            any_constant_var_marker_set: false,
             loop_local_saved_env: Vec::new(),
             loop_cond_active: false,
             outer_scope_locals: Vec::new(),

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1961,9 +1961,10 @@ impl Interpreter {
         // interpolation).
         if !name.starts_with('@') && !name.starts_with('%') && !name.starts_with('&') {
             if is_constant {
+                self.any_constant_var_marker_set = true;
                 self.env_mut()
                     .insert(format!("__mutsu_constant_var::{name}"), Value::TRUE);
-            } else if is_vardecl && !is_bind {
+            } else if is_vardecl && !is_bind && self.any_constant_var_marker_set {
                 self.env_mut()
                     .remove(&format!("__mutsu_constant_var::{name}"));
             }


### PR DESCRIPTION
## Summary
- ADR-0022 Slice 5 (`0448be29a`) added a `__mutsu_constant_var::<name>` env
  marker that `exec_set_local_op_inner` maintains on every scalar `my`/`state`
  vardecl, but the removal branch runs unconditionally (`format!` + `env.remove`)
  even when no `constant` has ever been declared — the overwhelming common case.
- In a tight loop with several plain `my` assignments per iteration this is a
  real wall-clock cost: direct A/B benchmarking (7/31 commit vs current `main`
  HEAD, same machine, same binary build methodology as `scripts/bench-ci.sh`)
  showed `benchmarks/time-parts.raku` ~20% slower, and manual commit bisection
  pinned the jump specifically to `0448be29a`'s change in
  `src/vm/vm_var_assign_set_local.rs`.
- Fix: track whether any constant scalar has ever been marked
  (`any_constant_var_marker_set`); skip the `format!`+`remove` on the common
  path where it can never find anything, falling back to the original
  behavior once a constant has actually been declared. Correctness is
  unchanged — the removal path still runs exactly as before whenever it could
  matter.
- Local verification: same-machine A/B of `main` HEAD vs this fix shows
  `time-parts` ~11.5% faster, other benchmarks (`debug-guard`, `method-call`,
  `bench-class`, `bench-ctor`) unaffected (within measurement noise).

Related to ADR-0019 G3 (performance gate) — this was found while doing the
direct A/B comparison G3 asked for.

## Test plan
- [x] `cargo build` (debug)
- [x] `prove -e target/debug/mutsu t/regex-ltm-alternation.t t/regex-declarative-modifiers.t t/regex-interp-method-call.t`
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S05-metasyntax/longest-alternative.t`
- [x] `make test` (full TAP suite, all green)
- [x] `cargo clippy -- -D warnings`, `cargo fmt`
- [x] Release-build A/B against `main` HEAD confirms the fix and no regressions
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)