### PR TITLE
perf(runtime): two G3 fixes -- pre-size AttrMap, per-name constant-var gate

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -352,7 +352,7 @@ impl Interpreter {
         // being re-collected on every bless.
         let plan = self.native_ctor_plan(class_name);
         let cn_resolved = class_name.as_str();
-        let mut attributes = AttrMap::new();
+        let mut attributes = AttrMap::with_capacity(plan.class_attrs.len());
         let mut deferred_defaults: Vec<super::attr_build_defaults::DeferredAttrDefault> =
             Vec::new();
         for (attr, &attr_sym) in plan.class_attrs.iter().zip(plan.attr_syms.iter()) {
@@ -752,26 +752,28 @@ impl Interpreter {
     /// `Any` when untyped). Unlike `bless`, this does not evaluate
     /// `has $.x = EXPR` default expressions.
     fn create_default_attr_slots(&mut self, class_name: &str) -> AttrMap {
-        let mut attributes = AttrMap::new();
-        if self.registry().classes.contains_key(class_name) {
-            for attr in self.collect_class_attributes(class_name) {
-                let attr_name = attr.name;
-                let type_constraint = self.get_attr_type_constraint(class_name, &attr_name);
-                let val = match type_constraint.as_deref() {
-                    Some(
-                        "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
-                        | "uint32" | "uint64" | "byte" | "atomicint",
-                    ) => Value::int(0),
-                    Some("num" | "num32" | "num64") => Value::num(0.0),
-                    Some("str") => Value::str("".to_string()),
-                    Some(tc) => {
-                        let nominal = self.nominal_type_object_name_for_constraint(tc);
-                        Value::package(crate::symbol::Symbol::intern(&nominal))
-                    }
-                    None => Value::package(crate::symbol::Symbol::intern("Any")),
-                };
-                attributes.insert(attr_name, val);
-            }
+        if !self.registry().classes.contains_key(class_name) {
+            return AttrMap::new();
+        }
+        let class_attrs = self.collect_class_attributes(class_name);
+        let mut attributes = AttrMap::with_capacity(class_attrs.len());
+        for attr in class_attrs {
+            let attr_name = attr.name;
+            let type_constraint = self.get_attr_type_constraint(class_name, &attr_name);
+            let val = match type_constraint.as_deref() {
+                Some(
+                    "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
+                    | "uint32" | "uint64" | "byte" | "atomicint",
+                ) => Value::int(0),
+                Some("num" | "num32" | "num64") => Value::num(0.0),
+                Some("str") => Value::str("".to_string()),
+                Some(tc) => {
+                    let nominal = self.nominal_type_object_name_for_constraint(tc);
+                    Value::package(crate::symbol::Symbol::intern(&nominal))
+                }
+                None => Value::package(crate::symbol::Symbol::intern("Any")),
+            };
+            attributes.insert(attr_name, val);
         }
         attributes
     }

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -49,7 +49,7 @@ impl Interpreter {
             Default::default()
         };
 
-        let mut attrs = AttrMap::new();
+        let mut attrs = AttrMap::with_capacity(class_attrs.len());
         for arg in args {
             if let ValueView::Pair(key, val) = arg.view()
                 && !build_owned_attrs.contains(key.as_str())

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2519,15 +2519,21 @@ pub struct Interpreter {
     /// set per active loop (ADR-0023). Bare names (no `$` sigil), matching
     /// env keys. Consulted by `block_captured_scalars` only; never persisted.
     pub(crate) active_loop_param_names: Vec<rustc_hash::FxHashSet<String>>,
-    /// Set once a `constant $name = ...` scalar has ever been declared in
-    /// this run (ADR-0022 Slice 5's `__mutsu_constant_var::` marker). Lets
+    /// Names of every `constant $name = ...` scalar ever declared in this run
+    /// (ADR-0022 Slice 5's `__mutsu_constant_var::` marker). Lets
     /// `exec_set_local_op_inner` skip the marker-removal `format!` + env
-    /// lookup on every ordinary (non-constant) scalar `my`/`state` — the
-    /// overwhelming common case — since there is nothing to remove until a
-    /// `constant` scalar has actually been seen. Never reset to `false`;
-    /// once true the plain removal path runs as before (still correct, just
-    /// no longer free to skip).
-    pub(crate) any_constant_var_marker_set: bool,
+    /// lookup on an ordinary (non-constant) scalar `my`/`state` whose name was
+    /// never used by a `constant` — the overwhelming common case, and NOT the
+    /// same as "no constant has been declared anywhere": a single
+    /// program-wide bool here previously made every subsequent `my`/`state`
+    /// in the whole program (any name) pay the removal cost the instant just
+    /// one `constant` existed anywhere (`benchmarks/debug-guard.raku`'s
+    /// `constant DEBUG = False` followed by a hot-loop `my $y`, e.g.). Per-name
+    /// membership is the actual precondition for the marker existing at all.
+    /// Entries are never removed; a name is either "never a constant" (never
+    /// pays the removal) or "was once a constant" (pays it — still correct,
+    /// just no longer free to skip for THAT name).
+    pub(crate) constant_var_names_seen: rustc_hash::FxHashSet<String>,
     /// Per loop-body scope: what each body-local `my` name must be restored to
     /// when the loop exits. `Some(v)` is a genuine shadow (re-expose the outer
     /// binding's value); `None` means the name did not exist before the loop, so

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2372,7 +2372,7 @@ impl Interpreter {
             given_pointy_captured: Vec::new(),
             loop_local_vars: Vec::new(),
             active_loop_param_names: Vec::new(),
-            any_constant_var_marker_set: false,
+            constant_var_names_seen: rustc_hash::FxHashSet::default(),
             loop_local_saved_env: Vec::new(),
             loop_cond_active: false,
             outer_scope_locals: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -804,7 +804,7 @@ impl Interpreter {
             given_pointy_captured: Vec::new(),
             loop_local_vars: Vec::new(),
             active_loop_param_names: Vec::new(),
-            any_constant_var_marker_set: false,
+            constant_var_names_seen: rustc_hash::FxHashSet::default(),
             loop_local_saved_env: Vec::new(),
             loop_cond_active: false,
             outer_scope_locals: Vec::new(),

--- a/src/value/attr_map.rs
+++ b/src/value/attr_map.rs
@@ -129,6 +129,19 @@ impl AttrMap {
         Self::default()
     }
 
+    /// Like [`Self::new`] but pre-sized for `capacity` entries, so a
+    /// construction path that knows its final attribute count up front (e.g.
+    /// `bless`/`CREATE`/the native default ctor, all driven by a per-class
+    /// attribute list of known length) avoids `hashbrown`'s incremental
+    /// `reserve_rehash` growth on every `insert`.
+    #[inline]
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self(FxHashMap::with_capacity_and_hasher(
+            capacity,
+            Default::default(),
+        ))
+    }
+
     #[inline]
     pub(crate) fn get<K: AttrKey>(&self, key: K) -> Option<&Value> {
         let sym = key.lookup_symbol()?;

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1961,10 +1961,10 @@ impl Interpreter {
         // interpolation).
         if !name.starts_with('@') && !name.starts_with('%') && !name.starts_with('&') {
             if is_constant {
-                self.any_constant_var_marker_set = true;
+                self.constant_var_names_seen.insert(name.to_string());
                 self.env_mut()
                     .insert(format!("__mutsu_constant_var::{name}"), Value::TRUE);
-            } else if is_vardecl && !is_bind && self.any_constant_var_marker_set {
+            } else if is_vardecl && !is_bind && self.constant_var_names_seen.contains(name) {
                 self.env_mut()
                     .remove(&format!("__mutsu_constant_var::{name}"));
             }

--- a/todo/deep/adr0019-g3-diffuse-bless-allocation-cost.md
+++ b/todo/deep/adr0019-g3-diffuse-bless-allocation-cost.md
@@ -123,3 +123,40 @@ GC-candidate-push family are still diffuse cost, matching the "no single hot fun
 conclusion from the earlier profile. Next dedicated-session step is still the counting-allocator
 build (previous section) if further attribution is wanted, or checking the bench-CI trend after
 this PR merges to see how much of the 7/31-vs-HEAD drift narrows.
+
+## 2026-08-17 (same session): `debug-guard`'s real cause found — a per-name, not per-program, gate
+
+The original A/B list at the top of this ticket also names `debug-guard +11.6%`, left uninvestigated
+alongside `bench-ctor`/`bench-class`. `benchmarks/debug-guard.raku` has nothing to do with
+construction — it's `constant DEBUG = False;` followed by a hot loop calling a `sub` with a plain
+`my $y = ...`. That shape is a red flag for the *same* commit (`0448be29a`, ADR-0022 Slice 5) whose
+`time-parts` bug was already fixed this session, and turned out to be a second, unfixed bug in the
+same mechanism.
+
+The #6575 fix gated the `__mutsu_constant_var::` marker-removal `format!` + `env.remove()` on a
+single **program-wide** `bool` (`any_constant_var_marker_set`): once *any* `constant` scalar was
+ever declared anywhere in the program, every subsequent ordinary `my`/`state` scalar declaration —
+any name, anywhere, for the rest of the run — paid the removal cost, because the bool has no way to
+say "but not for *this* name." `debug-guard.raku` declares exactly one constant (`DEBUG`) at the
+top, which immediately flips that bool permanently — so the hot loop's 1,000,000 `my $y = ...`
+declarations (unrelated name, unrelated scope) all still pay full `format!`-allocate-a-string +
+`HashMap::remove` cost, identical to before #6575's fix for a program with *zero* constants. The
+fix only ever helped the "no `constant` anywhere in the whole program" case, which `time-parts`
+happened to be but `debug-guard` (and any real program mixing `constant` with hot-loop `my`s) is
+not.
+
+**Fix:** replaced the single `bool` with `constant_var_names_seen: FxHashSet<String>` (same field,
+`src/runtime/mod.rs`), populated only on an actual `constant` declaration (rare) and consulted by
+*name* on every `my`/`state` vardecl (`src/vm/vm_var_assign_set_local.rs`) — `my $y` in a program
+that only ever declared `constant DEBUG` now does a cheap hash-set miss on `"y"` instead of an
+allocate + remove on `"y"`'s marker key. Thread-clone init (`runtime_thread.rs`) keeps the same
+"start empty" semantics the old bool had (unrelated pre-existing behavior, not touched).
+
+Local A/B (same worktree-baseline methodology, `MUTSU_JIT=off`, min-of-8/10, order-swapped, using a
+throwaway 10x-iteration variant of `debug-guard.raku` in `tmp/` for a clearer signal against
+process-startup noise): consistently ~7-8% faster, both orders (round 1: new 1.12s / base 1.22s;
+round 2 swapped: new 1.13s / base 1.21s). `t/*constant*.t` (18 files) and the full `t/` suite
+(29792 tests) pass; `cargo clippy -- -D warnings` clean.
+
+Landed as a second commit on the same PR as the `AttrMap` pre-sizing fix (both are G3-investigation
+findings from this session; see the PR for the combined test plan).

--- a/todo/deep/adr0019-g3-diffuse-bless-allocation-cost.md
+++ b/todo/deep/adr0019-g3-diffuse-bless-allocation-cost.md
@@ -85,9 +85,41 @@ TWEAK submethod dispatch chain? Symbol interning of 20 distinct attribute names 
   be extended) to count allocations per `bless`/`TWEAK` call directly — deterministic, environment-
   independent, and answers "how many allocations does constructing a 20-attr object cost" without
   needing symbolized call graphs at all.
-- If the allocation count turns out to be dominated by the attribute-cell `HashMap<Symbol, Value>`
-  construction itself (one per instance, 20 inserts each), consider whether `bless` can pre-size
-  the map from the class's known attribute count instead of growing it via repeated `insert`
-  (avoiding `hashbrown::RawTable::reserve_rehash`, which showed up in the flat profile).
 - Re-run the same A/B methodology from this session (build 7/31 and HEAD, `MUTSU_JIT=off`,
   order-swapped) once a fix lands, to confirm the drift actually narrows.
+
+## 2026-08-17 (later session): `AttrMap` pre-sizing
+
+Picked up the "pre-size the map from the class's known attribute count" idea from the previous
+session's next-steps list and landed it: `AttrMap::with_capacity` (new method) is now used at the
+three construction sites that already know their final attribute count up front from a per-class
+list —
+
+- `dispatch_bless`'s default-attribute-value loop (`plan.class_attrs.len()`)
+- `create_default_attr_slots` (the `CREATE` path, `collect_class_attributes(..).len()`)
+- `build_native_default_instance` (the native default-ctor fast path, `class_attrs.len()`)
+
+— avoiding `hashbrown`'s incremental `RawTable::reserve_rehash` growth (visible in the flat
+profile at ~2% `hashbrown::HashMap::insert`/`SipHasher::write`) when the final size is already
+known. `cargo build` + `cargo clippy -- -D warnings` clean; `t/class*.t t/bless*.t t/new*.t
+t/attribute*.t t/role*.t t/mixin*.t t/create*.t` (998 tests) and the full `t/` suite (29792 tests)
+pass.
+
+Local A/B (worktree baseline at `main` HEAD `3a3a2713b` vs this change, `MUTSU_JIT=off`,
+min-of-12/15 per side, order-swapped across three rounds) on a machine under variable background
+load (uptime load average 6-13 on 12 cores during measurement):
+
+- `bench-ctor` (20 attributes): consistently faster across all three rounds — roughly 10-20%
+  (e.g. round 3: new 0.39s vs baseline 0.49s). This is the shape the fix targets.
+- `bench-class` (3 attributes): no consistent direction, differences within noise — expected,
+  since a 3-entry map barely pays incremental-growth cost either way.
+
+This is a small, structurally-safe change (pre-sizing a `HashMap` never changes its contents), so
+it was not gated on a clean local measurement — the project convention is that documented bench
+numbers come from the bench CI trend (`bench-history.tsv`), not local runs, and this container's
+load made a tight local confirmation unreliable regardless. Left this ticket open rather than
+closing it: `env_deep_copies` (S2, `todo/tickets/bench-ctor-construction-parity.md`) and the
+GC-candidate-push family are still diffuse cost, matching the "no single hot function dominates"
+conclusion from the earlier profile. Next dedicated-session step is still the counting-allocator
+build (previous section) if further attribution is wanted, or checking the bench-CI trend after
+this PR merges to see how much of the 7/31-vs-HEAD drift narrows.


### PR DESCRIPTION
## Summary

Two independent fixes found during the ADR-0019 G3 (performance gate) investigation
(`todo/deep/adr0019-g3-diffuse-bless-allocation-cost.md`):

1. **Pre-size `AttrMap` when the attribute count is known.** `bless`, `CREATE`, and the native
   default-ctor fast path all build an instance's attribute map from a per-class attribute list of
   known length, but started from an empty `AttrMap` and grew it via repeated `insert` -- paying
   `hashbrown`'s incremental `reserve_rehash` on every construction. Add `AttrMap::with_capacity`
   and use it at the three sites that already know their final size up front.
2. **Gate the `__mutsu_constant_var::` marker-removal per-name, not per-program.** The earlier
   #6575 fix gated a `format!` + `env.remove()` (run on every plain `my`/`state` scalar decl) on a
   single program-wide bool: once *any* `constant` was declared anywhere, every subsequent
   unrelated `my`/`state` declaration paid the removal cost for the rest of the run.
   `benchmarks/debug-guard.raku` (`constant DEBUG = False` + a hot-loop `my $y`) hits exactly this
   -- its one constant permanently flips the bool, so the hot loop pays full cost identical to
   pre-#6575. Replaced the bool with a per-name `FxHashSet<String>`, checked by name so an
   unrelated var name misses cheaply instead of paying allocate+remove.

## Test plan
- [x] `cargo build` / `cargo clippy -- -D warnings` clean
- [x] `prove -e target/debug/mutsu t/class*.t t/bless*.t t/new*.t t/attribute*.t t/role*.t t/mixin*.t t/create*.t t/*constant*.t` pass
- [x] Full `prove -e target/debug/mutsu -j4 t/` (29792 tests) passes
- [x] Local A/B vs `main` HEAD (worktree baseline, `MUTSU_JIT=off`, order-swapped across multiple rounds):
      - `bench-ctor` (20 attrs): consistently ~10-20% faster; `bench-class` (3 attrs) within noise, as expected
      - `debug-guard` (10x-iteration variant): consistently ~7-8% faster, both orders
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)