### PR TITLE
docs(adr): close ADR-0019 -- Accepted/Implemented, G1-G4 all closed

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -64,9 +64,14 @@ Overall assessment as of rev12:
   `#[allow(` count improved slightly, 178→**176**, but it does not change the overall slope.
 
 None of the remaining issues is of the "the basic design is broken" kind. The shape of the
-debt has changed, though: the soundness and representation campaigns are closed. The active
-center is now **ADR-0019's half-migrated declaration/dispatch architecture**, followed by the
-exception type model and two missing policy/concurrency decisions.
+debt has changed, though: the soundness and representation campaigns are closed, and as of
+2026-08-17 **ADR-0019 (compiled declarations and unified method dispatch) is Accepted/
+Implemented** — declaration registration compiles to typed plans, and one TypeId/MRO resolver
+with a generation-checked O(1) cache serves every dispatch entry (§1.1, §3.3). Its own
+completion-gate investigation (G3) also found and fixed two real perf regressions, unrelated to
+the ADR's own mechanisms (§1.1). What is left of that campaign is deliberately non-gating
+residue, now tracked as independent tickets rather than inside the ADR. The active center
+moves to the exception type model and two missing policy/concurrency decisions.
 
 Where to look first:
 - §1: what architectural work remains (§1.8-§1.10 are new)
@@ -78,30 +83,39 @@ Where to look first:
 
 ## 1. Architecture
 
-### 1.1 Remaining tree-walk — declaration registration and dispatch entries only
+### 1.1 Declaration registration and dispatch entries — ADR-0019 closed (2026-08-17)
 
-User-code bodies (subs, methods, blocks) execute exclusively as bytecode. ADR-0019 now owns
-the remaining migration (14/51 slices merged as of 2026-08-04):
+User-code bodies (subs, methods, blocks) execute exclusively as bytecode. **ADR-0019 is now
+Accepted/Implemented**: declarations compile to immutable typed plans (`RegisterDecl`), user
+and native methods share one registry-owned `MethodEntry` write side and one generation
+invalidation boundary, and a single TypeId/MRO resolver (`resolve_sequence`,
+`resolved_seq_cache`) serves every dispatch read entry with generation-checked O(1) cache
+hits — see the ADR's completion-gate section for the full closure record (G1-G4).
 
-- **Declaration registration**: `register_class_decl`
-  (`runtime/registration_class_decl.rs`), `register_sub_decl`, and `register_role_decl`
-  consume temporary typed plans behind one `RegisterDecl` opcode. The plans have left the
-  generic statement pool, but still retain `legacy_body` adapters. Class system, MRO and role
-  composition remain uncompiled — registration, not body execution.
-  **This is no longer a static amount of debt.** The MOP campaign (§1.9) hung the user HOW
-  protocol off exactly this path: `declare_drive_how_protocol` drives `new_type` /
-  `add_method` / `compose` against a user metaobject from inside AST-walking registration,
-  and `registration_class_decl.rs` has grown to 2927 lines. Every future MOP feature adds
-  to a tree-walk that has been flagged since rev5.
-- **Dispatch resolver entries**: multi/submethod and `samewith`/`nextsame` enter through
-  `run_instance_method` (`runtime/class_dispatch.rs:52`, plus a `_celled` variant at `:90`);
-  bodies are compiled. The sound multi-method resolution cache + `fast_method_cache` still
-  amortize the resolver. ADR-0019 Phase B has landed the canonical method-table write side
-  and generation invalidation; the TypeId-based unified read side remains Phase E (§3.3).
+What is left is deliberately non-gating residue, each tracked as its own ticket rather than
+inside the ADR:
+
+- **`legacy_body` adapters and the class/role registration walker**
+  (`runtime/registration_class_decl.rs`, 2927 lines) still tree-walk MOP protocol calls
+  (`declare_drive_how_protocol` driving `new_type`/`add_method`/`compose`) — declaration
+  *registration*, not body execution, which is fully compiled. This is the largest remaining
+  tree-walk surface and the one most likely to keep growing with future MOP features (§1.9).
+- **Native/builtin method introspection fidelity** (F1/F2's remaining slice): user-method
+  `.^methods`/`.^can`/method MRO views are now derived from the canonical table (no longer
+  hand-maintained, closing most of §4 item 1 below); native method metadata (`.package` on
+  multi dispatchers, exact per-method `.signature`, the `.^lookup` Sub-vs-Method-Instance
+  representation mismatch) is not yet at full parity. Tracked in
+  `todo/deep/adr0019-f1-f2-introspection-canonical-source.md`.
+- **E2's exact-handler-ID catalog** (giving every native entry a static type×method row) is
+  open cleanup, no longer gating dispatch correctness — `native_call_unmodeled` is a
+  monitoring signal, not a precondition. Tracked in `todo/deep/adr0019-e2-e4-resolver-core.md`.
+- **D2c-5** (collapsing three near-duplicated default-evaluation env-setup shapes) is optional
+  de-duplication with no correctness impact. Tracked in
+  `todo/tickets/adr0019-d2c5-collapse-default-eval-env-setup.md`.
 - **Module-sub OTF compile gate** (`def_is_otf_compilable_module_single`,
-  `vm/vm_call_func_ops.rs:1991`): unchanged since rev10. The residual exclusions are
-  mechanism-level — `state`, sigilless `\x` params, `is encoded(...)`, `start` — each with a
-  documented blocker (PLAN §3).
+  `vm/vm_call_func_ops.rs:1991`): unchanged since rev10, outside ADR-0019's scope. The
+  residual exclusions are mechanism-level — `state`, sigilless `\x` params,
+  `is encoded(...)`, `start` — each with a documented blocker (PLAN §3).
 
 ### 1.2 Closure upvalues — indexed reads plus capture cells landed
 
@@ -338,19 +352,30 @@ duplicates `stmt.rs` logic for do/if/for/while/loop in expression position, incl
 `SubDecl` both registers an AST body (`RegisterSub`) and compiles the body
 (`compile_sub_body`). Collapses when §1.1's declaration registration is compiled.
 
-### 3.3 Method dispatch: canonical write side landed; read entries remain split
+### 3.3 Method dispatch: canonical write side and TypeId/MRO resolver both landed (ADR-0019 closed)
 
-ADR-0019 Phase B now gives built-in and user candidates one registry-owned `MethodEntry`
-write side and one generation invalidation boundary. Entry points remain unconsolidated:
-`call_method_with_values`
-(`runtime/methods_call_dispatch.rs:50`), `dispatch_method_by_name_{1,2,3}`
-(`runtime/methods_dispatch_match.rs:14` and siblings), `run_instance_method` /
-`run_instance_method_celled` (`runtime/class_dispatch.rs:52,90`), `native_method_{0,1,2}arg`
-(`builtins/`). Same-name string matches stay scattered — `"elems"` appears in **33 files**
-(rev10: 8+). `runtime/methods_call_dispatch.rs` is now 3875 lines.
+ADR-0019 Phase B gives built-in and user candidates one registry-owned `MethodEntry` write
+side and one generation invalidation boundary. Phase E added the read side: `resolve_sequence`
+builds the shape-independent ordered candidate universe (user candidates, accessor
+arbitration, native catalog rows, proto slot) from the same TypeId/MRO chain calls use, and
+`resolved_seq_cache` (keyed `(TypeId, Symbol, CallShape)`) makes a cache hit
+generation-checked O(1) — bench-CI parity confirmed on cutover (2026-08-14). Entry points
+still call into this resolver from multiple call sites rather than one funnel
+(`call_method_with_values` in `runtime/methods_call_dispatch.rs:50`,
+`dispatch_method_by_name_{1,2,3}` in `runtime/methods_dispatch_match.rs:14` and siblings,
+`run_instance_method`/`run_instance_method_celled` in `runtime/class_dispatch.rs:52,90`,
+`native_method_{0,1,2}arg` in `builtins/`), but all of them resolve through the same
+candidate-sequence logic rather than independently re-walking the MRO. Same-name string
+matches stay scattered — `"elems"` appears in **33 files** (rev10: 8+) — a cosmetic/lookup
+surface issue, not a second dispatch mechanism. `runtime/methods_call_dispatch.rs` is now
+3875 lines.
 
-The remaining work is the TypeId/MRO resolver, routing every read entry through it, deriving
-§4-1's introspection, and deleting the compatibility mirrors and caches (ADR-0019 E/F).
+What remains is the E2 exact-handler-ID catalog (giving every native entry a static row
+instead of the arity-cascade fallback) and deriving the last mile of introspection fidelity
+(§4 item 1) — both open cleanup tracked as independent tickets
+(`todo/deep/adr0019-e2-e4-resolver-core.md`,
+`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`), no longer gating dispatch
+correctness or performance.
 
 ---
 
@@ -358,9 +383,15 @@ The remaining work is the TypeId/MRO resolver, routing every read entry through 
 
 No test-specific hardcoded outputs found (re-checked). Two derivation shortcuts remain:
 
-1. **`.^methods`/`.^can`/`.^mro` tables are hand-maintained** — centralized in
-   `builtins/builtin_type_methods.rs` (960 lines, rev10: 874) and guarded by structural tests
-   plus `t/can-methods-drift.t`. True derivation awaits §3.3. The growth rate matters now
+1. **User-method `.^methods`/`.^can`/method MRO views are now derived** from the canonical
+   `Registry::method_entries[(owner, name)].user_candidates` table (ADR-0019 F1/F2, closed for
+   this half 2026-08-14) — no longer hand-maintained for user-declared types. **Native/builtin
+   method metadata stays a hand-maintained shortcut**: `builtins/builtin_type_methods.rs` (960
+   lines, rev10: 874) centralizes the native candidate-name universe, guarded by structural
+   tests plus `t/can-methods-drift.t`; per-method fidelity gaps (native `.package` on multi
+   dispatchers, synthesized-not-exact `.signature`, the `.^lookup` Sub-vs-Method-Instance
+   mismatch) remain open in
+   `todo/deep/adr0019-f1-f2-introspection-canonical-source.md`. The growth rate matters now
    that §1.9 lets user code introspect through the same surface.
 2. **Parser grammar relaxations for roast** (minor, unchanged): `is List` type-ish traits,
    the Test::Assuming colonpair, and the `throws-like` trailing-`)` special form.
@@ -411,30 +442,27 @@ priority reset, performance is polish and is not used as a ranking criterion her
 
 The ranking rule, stated so it can be argued with:
 
-1. **Finish the active half-migration before opening another broad implementation front.**
-   ADR-0019 already has transitional plans, mirrors, caches, and adapters on `main`; every
-   unrelated declaration/MOP change now pays both sides.
-2. **Design prerequisites before data sweeps or concurrency implementation.** Exception roles
+1. **Design prerequisites before data sweeps or concurrency implementation.** Exception roles
    need a type-metadata decision; a worker pool needs an `await` decision; batteries policy
    needs a durable adoption boundary.
-3. **Severity can override the queue only when the task is actionable.** A new crash artifact
+2. **Severity can override the queue only when the task is actionable.** A new crash artifact
    makes the Proc::Async SIGSEGV P0; without one, blind local loops have already been measured
    as unproductive.
-4. **Make hygiene a completion gate on the subsystem being replaced.** File splitting without
-   deleting a model is churn; deleting walkers, mirrors, and entry points through ADR-0019 is
-   structural progress.
-5. Feature breadth with no downstream consumer remains last.
+3. **Make hygiene a completion gate on the subsystem being replaced.** File splitting without
+   deleting a model is churn; the ADR-0019 registration walker
+   (`runtime/registration_class_decl.rs`, §1.1) is the next concrete case once a future MOP
+   feature forces it open.
+4. Feature breadth with no downstream consumer remains last.
 
 | # | Item | Kind | Why here |
 |---|------|------|----------|
-| 1 | **Continue ADR-0019: compiled declarations and unified method dispatch** (§1.1, §3.3, §4-1) | active design migration | 14/51 slices are merged. Typed plans and the canonical write-side table now coexist with `legacy_body`, class mirrors, multiple read resolvers, and hand introspection state. Stop after each phase gate if needed, but do not leave the repository indefinitely in this doubled state. |
-| 2 | **Exception role/type registration and error parity** (`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`) | correctness / type model | 124 core `X::` names cannot be constructed as types, and prefix-as-parent is semantically wrong because Rakudo expresses most membership through roles. Collect the role/MRO data now; align implementation with ADR-0019 E1's TypeId/MRO model rather than creating a second registry. |
-| 3 | **Write the batteries adoption-policy ADR, then follow the Cro/mzef compatibility frontier** (§1.8) | policy / product architecture | The project's main goal depends on the costly-to-reverse rule “vendor upstream verbatim; grow mutsu; no new native providers,” but the decision and exceptions live only in `BATTERIES.md`/`CLAUDE.md`. Preserve that boundary first; then let real downstream failures choose interpreter work. |
-| 4 | **Write the shared-worker-pool Proposed ADR** (`todo/deep/shared-worker-pool-adr.md`) | concurrency design | Thread-per-task at 19 sites reserves 256 MiB each. A bounded pool deadlocks nested blocking `await` without continuations, and idle workers must cooperate with GC stop-the-world. The next deliverable is the decision, not implementation. |
-| 5 | **Crash and panic-zero response lane** (§2.3, PLAN §6) | conditional P0 robustness | A fresh Proc::Async crash report preempts the roadmap immediately; the single historical CI SIGSEGV is otherwise evidence-starved and did not reproduce in 22 local runs. Supply panic propagation, deterministic hangs, and parser panic-zero work remain actionable correctness slices, not part of the worker-pool design. |
-| 6 | **Unify statement/expression compilation of control constructs** (§3.1) | design cleanup | The duplicated `do`/`if`/loop compilation is real but bounded and stable. Schedule it after the declaration/compiler migration stops moving adjacent structures. Opcode leftovers remain measurement-gated, not bundled into this task. |
-| 7 | **Pay hygiene debt through the work above** (§5, §6) | completion discipline | `runtime/mod.rs` reached 2700 lines and the >500/>1000 populations reached 302/83. ADR-0019 phase gates should delete walkers, mirrors, caches, and adapters; touched oversized files should be split when ownership boundaries become clear. A standalone line-moving campaign is not the priority. |
-| 8 | **RakuAST completion** (`todo/deep/rakuast-remaining.md`, ADR-0011 Phase 6) | demand-driven feature | No whitelisted roast file or bundled battery consumes the remaining forms or macros. Pick a slice only when a real downstream use case supplies acceptance tests. |
+| 1 | **Exception role/type registration and error parity** (`todo/deep/exception-class-hierarchy-is-mostly-unregistered.md`) | correctness / type model | 124 core `X::` names cannot be constructed as types, and prefix-as-parent is semantically wrong because Rakudo expresses most membership through roles. Collect the role/MRO data now; align implementation with ADR-0019's TypeId/MRO resolver model rather than creating a second registry. |
+| 2 | **Write the batteries adoption-policy ADR, then follow the Cro/mzef compatibility frontier** (§1.8) | policy / product architecture | The project's main goal depends on the costly-to-reverse rule “vendor upstream verbatim; grow mutsu; no new native providers,” but the decision and exceptions live only in `BATTERIES.md`/`CLAUDE.md`. Preserve that boundary first; then let real downstream failures choose interpreter work. |
+| 3 | **Write the shared-worker-pool Proposed ADR** (`todo/deep/shared-worker-pool-adr.md`) | concurrency design | Thread-per-task at 19 sites reserves 256 MiB each. A bounded pool deadlocks nested blocking `await` without continuations, and idle workers must cooperate with GC stop-the-world. The next deliverable is the decision, not implementation. |
+| 4 | **Crash and panic-zero response lane** (§2.3, PLAN §6) | conditional P0 robustness | A fresh Proc::Async crash report preempts the roadmap immediately; the single historical CI SIGSEGV is otherwise evidence-starved and did not reproduce in 22 local runs. Supply panic propagation, deterministic hangs, and parser panic-zero work remain actionable correctness slices, not part of the worker-pool design. |
+| 5 | **Unify statement/expression compilation of control constructs** (§3.1) | design cleanup | The duplicated `do`/`if`/loop compilation is real but bounded and stable. Opcode leftovers remain measurement-gated, not bundled into this task. |
+| 6 | **Pay hygiene debt through the work above** (§5, §6) | completion discipline | `runtime/mod.rs` reached 2700 lines and the >500/>1000 populations reached 302/83. `registration_class_decl.rs` (2927 lines, §1.1) is the next walker due for deletion once a MOP feature forces it open; touched oversized files should be split when ownership boundaries become clear. A standalone line-moving campaign is not the priority. |
+| 7 | **RakuAST completion** (`todo/deep/rakuast-remaining.md`, ADR-0011 Phase 6) | demand-driven feature | No whitelisted roast file or bundled battery consumes the remaining forms or macros. Pick a slice only when a real downstream use case supplies acceptance tests. |
 
 Explicitly **not** ranked as current architecture work: completed ADR-0013/0015-P3b/0016/0018
 campaigns; optional ADR-0015 P3c; ADR-0016's deliberately deferred eager replay carriers;
@@ -462,7 +490,7 @@ The rev11 corrections remain valid; rev12 adds the closure/progress deltas below
 | 0015 native-backed storage | The prior entry stopped at P3a and left the P3b completion unrecorded. | Recorded P3b (PR #5785) as landed, including the `ArrayData::items` chokepoint and native-boundary behavior; P3c remains optional. |
 | 0016 span-based captures | Status and all five phases remain accurate; the standing `view()` invariant was prose-only in rev11. | `match_materializations` now exposes each first lazy-node force under `MUTSU_VM_STATS=1`; capture-name keys are also interned. Deliberate replay/snapshot residue remains deferred. |
 | 0018 slot-addressed lexical capture | Added after rev11 to own the env-writeback/lexical-slot fused campaign. | Accepted and implemented; it replaces rev11's completed roadmap rows rather than remaining a current task. |
-| 0019 compiled declarations and unified dispatch | Added after rev11 to own §1.1/§3.3/§4-1 as one phased migration. | Proposed and active, 14/51 slices merged. Its execution checklist is now the source of truth for roadmap item 1. |
+| 0019 compiled declarations and unified dispatch | Added after rev11 to own §1.1/§3.3/§4-1 as one phased migration. | **Accepted/Implemented (2026-08-17).** All four completion gates (G1-G4) closed; the ADR's own execution checklist remains the historical record. Deliberately non-gating residue (native-method introspection fidelity, the E2 handler-ID catalog, D2c-5) now lives in independent tickets, not the ADR. |
 | 0003, 0004, 0005, 0006, 0009, 0010, 0012, 0014, 0017 | Accurate; 0004 and 0009 already carry closing addenda. | No change. |
 | 0002 | Historical gate record; still accurate. | No change. |
 
@@ -486,3 +514,8 @@ Two **missing** ADRs are worth writing, and are listed here rather than drafted 
 materialization counter, ADR-0018 completion, and ADR-0019's 14/51 progress recorded;
 live hygiene metrics refreshed; §7 reduced to current work and reordered by dependency,
 severity, and actionability.*
+*2026-08-17 addendum (not a full rev13 re-verification): ADR-0019 reached Accepted/Implemented
+(all four completion gates closed); §1.1, §3.3, §4 item 1, the §7 roadmap, and the §8 ADR-ledger
+row were updated in place to describe the closed architecture and point at the tickets tracking
+its non-gating residue. Other findings/metrics in this document were not re-verified as part of
+this addendum.*

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -1,6 +1,6 @@
 # ADR-0019: Compile declarations and unify method dispatch entries
 
-- **Status**: Proposed
+- **Status**: Accepted/Implemented (2026-08-17)
 - **Date**: 2026-08-03
 - **Related**: [ADR-0018](0018-slot-addressed-lexical-capture-and-env-sync.md),
   [ANALYSIS.md §1.1, §3.3, §4-1](../../ANALYSIS.md)
@@ -116,15 +116,18 @@ box is checked only after that PR has merged to `main` with required CI green. R
 unchecked even if its original PR merged. PRs are sequential branches from the then-current
 `main`; this is not a stacked-PR plan.
 
-**Current progress:** Phases A, B, and C are fully closed. Phase D is closed except for the
-optional, low-priority D2c-5. Phase E is closed except E2 (still-open cleanup, no longer gating —
-E1, E3-E11 are all closed). Phase F has started: F3, F4 (all of F4a/F4b/F4c), and F5 are closed;
-F1/F2 are done except a deliberately-parked fidelity slice; F6 is closed (with an amended
-completion criterion — see its entry); F7 is closed (with a role-body permanent-exception carve-out —
-see its entry); of the completion gates, G1 is closed (satisfied by the `main` branch ruleset's
-required status checks, after closing a `jit-stress` required-check gap found while verifying it) and
-G2 is closed (all four architectural-guard clauses now have permanent tests); G3 is closed (no
-regression traced to any of its four named mechanisms — see its entry); G4 remains open. See
+**Status: Accepted/Implemented (2026-08-17), all four completion gates closed.** Phases A, B, and
+C are fully closed. Phase D is closed except for the optional, low-priority D2c-5 (tracked as
+`todo/tickets/adr0019-d2c5-collapse-default-eval-env-setup.md`). Phase E is closed except E2
+(still-open cleanup, no longer gating — E1, E3-E11 are all closed). Phase F: F3, F4 (all of
+F4a/F4b/F4c), and F5 are closed; F1/F2 are done except a deliberately-parked fidelity slice; F6 is
+closed (with an amended completion criterion — see its entry); F7 is closed (with a role-body
+permanent-exception carve-out — see its entry). Of the completion gates, G1 is closed (satisfied
+by the `main` branch ruleset's required status checks, after closing a `jit-stress`
+required-check gap found while verifying it), G2 is closed (all four architectural-guard clauses
+now have permanent tests), G3 is closed (no regression traced to any of its four named
+mechanisms — see its entry), and G4 is closed (this status line and ANALYSIS.md §1.1/§3.3/§4-1
+were updated as G4's own action). See
 each
 box's entry below for its
 own status, and
@@ -3082,8 +3085,21 @@ outcome.
   to be tracked as ordinary perf work outside the ADR's scope
   (`todo/tickets/bench-ctor-construction-parity.md`), to be picked up opportunistically rather than
   gating ADR-0019's closure. **This closes G3.**
-- [ ] **G4 — Close the ADR and ANALYSIS items.** Mark ADR-0019 Accepted/Implemented and update
+- [x] **G4 — Close the ADR and ANALYSIS items.** Mark ADR-0019 Accepted/Implemented and update
   ANALYSIS §1.1, §3.3, and §4-1 only after G1–G3 and all required slices above are complete.
+
+  **Progress (2026-08-17).** G1-G3 closed (see their own entries). "All required slices above"
+  means every top-level box except the ones explicitly marked optional/no-longer-gating in this
+  file's "Current progress" line: D2c-5 (optional), E2 (open cleanup, no longer gating — its own
+  entry explicitly replaced the original "must reach zero" precondition), and F1/F2's fidelity
+  slice (deliberately parked, user-method half already done) — none of those block closure by the
+  ADR's own wording. Filed the one previously-untracked leftover
+  (`todo/tickets/adr0019-d2c5-collapse-default-eval-env-setup.md`) so it survives the ADR no
+  longer being actively read. Status set to Accepted/Implemented above; ANALYSIS.md §1.1, §3.3,
+  and §4 item 1 rewritten to describe the closed architecture and point at the surviving tickets
+  instead of describing an in-progress migration, and its §7 roadmap/§8 ADR-ledger rows updated
+  to match (user decision, 2026-08-17: close now, pick up any remaining detail via separate
+  tickets rather than holding the ADR open for polish). **This closes G4 and ADR-0019.**
 
 ## Rejected alternatives
 
@@ -3131,10 +3147,15 @@ each instruction.
 
 ## Implementation status
 
-The checklist above ("Execution plan and progress") is the authoritative, currently-maintained
-record of what has landed. Phases A-D and E1, E3-E11, F5, F7 are closed; E2 (open cleanup, no longer
-gating), the rest of Phase F (F1-F4, F6), and the completion gates are the remaining open work —
-see their entries above for
-current status and the linked `todo/deep/adr0019-*.md` design docs for full design and slice
-history. Individual accomplishments
-are additionally recorded per-PR under `news/2026-08/`.
+**Accepted/Implemented (2026-08-17).** The checklist above ("Execution plan and progress") is the
+authoritative, currently-maintained record of what has landed. Phases A-D, E (all of E1/E3-E11),
+and F (F3, F4, F5, F6, F7; F1/F2 for their user-method half) are closed, and all four completion
+gates (G1-G4) are closed — see each box's own entry above for full design and slice history, and
+the linked `todo/deep/adr0019-*.md` docs for design detail that outlived the checklist.
+
+Deliberately non-gating residue remains, tracked as independent tickets rather than inside this
+ADR: E2's exact-handler-ID catalog (`todo/deep/adr0019-e2-e4-resolver-core.md`, open cleanup, no
+longer gating dispatch correctness), F1/F2's native-method introspection fidelity
+(`todo/deep/adr0019-f1-f2-introspection-canonical-source.md`), and D2c-5's optional env-setup
+de-duplication (`todo/tickets/adr0019-d2c5-collapse-default-eval-env-setup.md`). Individual
+accomplishments are additionally recorded per-PR under `news/2026-08/`.

--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -123,7 +123,8 @@ F1/F2 are done except a deliberately-parked fidelity slice; F6 is closed (with a
 completion criterion — see its entry); F7 is closed (with a role-body permanent-exception carve-out —
 see its entry); of the completion gates, G1 is closed (satisfied by the `main` branch ruleset's
 required status checks, after closing a `jit-stress` required-check gap found while verifying it) and
-G2 is closed (all four architectural-guard clauses now have permanent tests); G3-G4 remain open. See
+G2 is closed (all four architectural-guard clauses now have permanent tests); G3 is closed (no
+regression traced to any of its four named mechanisms — see its entry); G4 remains open. See
 each
 box's entry below for its
 own status, and
@@ -3032,9 +3033,55 @@ outcome.
     order, for every builtin owner, on every test run. No new test needed for this clause.
 
   All four G2 sub-clauses are now enforced by permanent, always-run tests. This closes G2.
-- [ ] **G3 — Performance gate.** Benchmarks show no regression from initialization probing,
+- [x] **G3 — Performance gate.** Benchmarks show no regression from initialization probing,
   per-call owner scans, registry locking, or repeated string interning; cache-hit dispatch remains
   generation-checked O(1).
+
+  **Progress (2026-08-17).** The dispatch clause ("cache-hit dispatch remains generation-checked
+  O(1)") closed earlier, as part of E3 (`resolved_seq_cache`, keyed by `(TypeId, Symbol,
+  CallShape)` — see E3's own progress note above, including its 2026-08-14 bench-CI parity check).
+
+  The remaining clause — no regression from the four named ADR-0019 mechanisms — was investigated
+  by direct A/B (worktree builds of the pre-Phase-E commit `426b36cd1` vs current `main`,
+  `MUTSU_JIT=off`, order-swap-verified) in
+  `todo/deep/adr0019-g3-diffuse-bless-allocation-cost.md`. That surfaced real regressions on
+  `time-parts`, `debug-guard`, `bench-ctor`, and `bench-class`, but **every regression that was
+  actually traced to a cause turned out to be unrelated to ADR-0019's own mechanisms**:
+  - `time-parts` bisected to a single commit, `0448be29a` (ADR-0022 Slice 5, an unconditional
+    `format!` + `HashMap::remove` on every plain scalar `my`/`state` declaration to clear a
+    `constant`-shadowing marker) — fixed in #6575 by gating the removal on a program-wide "any
+    constant ever declared" flag.
+  - `debug-guard` turned out to be a second bug in that *same* ADR-0022 mechanism, missed by
+    #6575: the program-wide flag made *any* `constant` anywhere in the program (e.g.
+    `benchmarks/debug-guard.raku`'s `constant DEBUG = False`) force the removal cost onto every
+    subsequent unrelated `my`/`state` declaration for the rest of the run, not just ones that could
+    plausibly shadow that constant. Fixed in #6579 by replacing the program-wide bool with a
+    per-name `FxHashSet<String>`.
+  - `bench-ctor`/`bench-class` did **not** bisect to a single commit — a `perf record` flat profile
+    (call-graph attribution was not usable in this environment; see the ticket's "Tooling blocker"
+    section) showed cost spread across `malloc`/`free`, NaN-boxed value GC/refcount bookkeeping,
+    `hashbrown`/`SipHasher`, and thread-local access, with no single dominant function and no
+    owner-scan-, registry-lock-, or string-interning-specific symbol standing out. This reads as
+    general per-construction allocation/GC/hashing cost, not a mechanism G3 names. #6579 also
+    landed one concrete slice of this (`AttrMap::with_capacity`, pre-sizing the attribute map at
+    the three construction sites that already know their final size), narrowing but not closing the
+    gap; the rest (`env_deep_copies`, GC candidate-push churn) is explicitly blocked on the
+    closure-upvalue-cell prerequisite (`docs/vm-single-store.md` §3), a separate, already-tracked
+    architectural campaign, not an ADR-0019 regression.
+  - The other five pre-existing "seen"-gate marker families in `env.rs`
+    (`CLOSURE_META_KEY_SEEN`/`BOUND_KEY_SEEN`/`BOUND_SLICE_KEY_SEEN`/`ELEM_INDEX_META_SEEN`/
+    `PLACEHOLDER_KEY_SEEN`) were checked for the same per-program-vs-per-name flaw the
+    `debug-guard` bug exposed: verified via a temporary instrumented build that all five stay
+    `false` (no cost paid) on `bench-ctor`/`bench-class`/`debug-guard` and on a trivial program
+    (prelude loading does not trip them), so this is not a live issue for the mechanisms G3 covers.
+
+  Net: this investigation did not find a single regression attributable to initialization probing,
+  per-call owner scans, registry locking, or repeated string interning — the four things G3 asks
+  about. The `bench-ctor`/`bench-class` diffuse allocation cost that remains is real but
+  orthogonal (general construction-path cost, not an ADR-0019-introduced mechanism) and continues
+  to be tracked as ordinary perf work outside the ADR's scope
+  (`todo/tickets/bench-ctor-construction-parity.md`), to be picked up opportunistically rather than
+  gating ADR-0019's closure. **This closes G3.**
 - [ ] **G4 — Close the ADR and ANALYSIS items.** Mark ADR-0019 Accepted/Implemented and update
   ANALYSIS §1.1, §3.3, and §4-1 only after G1–G3 and all required slices above are complete.
 

--- a/todo/tickets/adr0019-d2c5-collapse-default-eval-env-setup.md
+++ b/todo/tickets/adr0019-d2c5-collapse-default-eval-env-setup.md
@@ -1,0 +1,38 @@
+# ADR-0019 D2c-5: collapse the three near-duplicated default-evaluation env-setup shapes
+
+Filed as a standalone ticket when ADR-0019 was marked Accepted/Implemented (G4) so this leftover
+does not get lost once the ADR stops being actively tracked.
+
+## Background
+
+ADR-0019's D2c box (compiling attribute defaults/constraints as child chunks via
+`CompiledAttrDecl`/`DeclTraitArg` and `eval_decl_trait_arg`) landed in full (D2c-1..4, 2026-08-07/08
+-- see `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`'s D2c entry). One
+optional sub-box was scoped but never started:
+
+> **D2c-5 (optional)** — collapse the three near-duplicated default-evaluation env-setup shapes
+> (class walker, default ctor, `dispatch_new`) into one; gated on raku-verifying shape B's
+> `has_class_scoped_subs` special case first. Not started, low priority.
+
+## Scope
+
+Three call sites independently set up the env before evaluating an attribute's default-value
+expression:
+
+1. The class-body attribute walker (used by e.g. `CREATE`'s slot initialization).
+2. The native default constructor fast path (`build_native_default_instance`,
+   `src/runtime/methods_object_default_ctor.rs`).
+3. `dispatch_bless`/`dispatch_new`-style construction (`src/runtime/methods_dispatch_new.rs`).
+
+Each independently builds (a variant of) the same env-setup shape around
+`eval_decl_trait_arg`/`run_decl_code` before evaluating a `has $.x = EXPR` default. Collapsing them
+into one shared helper removes drift risk between the three, but needs the `has_class_scoped_subs`
+special case (a class-scoped `sub` referenced from an attribute default) raku-verified first, to
+confirm all three sites actually need identical behavior there before merging them.
+
+## Why this is a separate ticket, not urgent
+
+Low priority, explicitly optional in the ADR-0019 checklist -- correctness is not at risk (D2c-1..4
+already migrated all three sites off raw `Expr`/`eval_block_value` onto the typed
+`CompiledAttrDecl`/`DeclTraitArg` representation; this ticket is pure de-duplication of the
+surrounding env-setup code, not a missing feature). Pick up opportunistically.


### PR DESCRIPTION
## Summary

Closes ADR-0019 (compiled declarations and unified method dispatch), per user decision
(2026-08-17): close now rather than holding it open for polish, pick up any remaining detail via
separate tickets.

- **G3 (performance gate) closed.** Direct A/B investigation (`todo/deep/adr0019-g3-diffuse-bless-allocation-cost.md`,
  #6577 + #6579) found real regressions on `time-parts`/`debug-guard`/`bench-ctor`/`bench-class`,
  but every one that was actually traced to a cause was unrelated to ADR-0019's own mechanisms
  (initialization probing, per-call owner scans, registry locking, repeated string interning) --
  both `time-parts` and `debug-guard` were the same pre-existing ADR-0022 marker-removal bug (now
  fixed), and the remaining `bench-ctor`/`bench-class` cost is general allocation/GC/hashing
  overhead with no owner-scan/registry-lock/interning-specific hot symbol in the profile. The
  dispatch clause (cache-hit O(1)) had already closed earlier as part of E3.
- **G4 closed.** Status -> Accepted/Implemented. The remaining unchecked boxes (D2c-5, E2, F1/F2's
  fidelity slice) are all explicitly optional or no-longer-gating per the ADR's own progress
  notes, so "all required slices above are complete" holds. Filed the one previously-untracked
  leftover as `todo/tickets/adr0019-d2c5-collapse-default-eval-env-setup.md`.
- `ANALYSIS.md` SS1.1, SS3.3, and SS4 item 1 rewritten to describe the closed architecture (typed
  declaration plans, one TypeId/MRO resolver with a generation-checked O(1) cache) instead of an
  in-progress migration, pointing at the surviving tickets for what's left. SS7 roadmap and the SS8
  ADR-ledger row updated to match, plus a dated addendum note (explicitly not a full rev13
  re-verification of the whole document).

Docs-only change (no code diff), so CI's heavy jobs are expected to report `skipped` (counts as
success per `scripts/ci-docs-only.sh`'s docs-only classification).

## Test plan
- [x] Docs-only diff; no build/test changes needed
- [ ] CI (label/changes gate; heavy jobs skip on a docs-only diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)