### PR TITLE
docs(adr0019): archive closed E5-E7/E8-E11 design docs to news

### DIFF
--- a/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
+++ b/docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md
@@ -537,11 +537,11 @@ for this phase were `todo/deep/adr0019-e1-typeid-receiver-owner.md` (E1, retired
 its one live spin-off, mixin composition order nondeterminism, was tracked separately as
 `todo/tickets/mixin-role-order-not-tracked.md` and is now fixed, see
 `news/2026-08/mixin-role-application-order-tracked.md`),
-`todo/deep/adr0019-e2-e4-resolver-core.md` (E2/E3/E4),
-`todo/deep/adr0019-e5-e7-entry-routing.md` (E5/E6/E7), and
-`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` (E8/E9/E10/E11) — consult the ones that
-still exist for full slice-by-slice history; the checklist below keeps only the architectural
-outcome.
+`todo/deep/adr0019-e2-e4-resolver-core.md` (E2/E3/E4, still open for E2's residual cleanup),
+`news/2026-08/adr0019-e5-e7-entry-routing.md` (E5/E6/E7, archived once closed), and
+`news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md` (E8/E9/E10/E11, archived once
+closed) — consult these for full slice-by-slice history; the checklist below keeps only the
+architectural outcome.
 
 - [x] **E1 — Introduce stable `TypeId` and receiver-owner resolution.** Resolve concrete values,
   type objects, user classes, builtin subclasses, role mixins, and representation aliases to an
@@ -752,7 +752,7 @@ outcome.
   traversed the registered class hierarchy, even though ordinary method *invocation* on a mixin
   worked correctly throughout — suggesting mixin receivers were systematically under-tested
   against introspection call paths before this box. **All of E7 (eight sub-slices) is closed.**
-  Full per-step detail in `todo/deep/adr0019-e5-e7-entry-routing.md`.
+  Full per-step detail in `news/2026-08/adr0019-e5-e7-entry-routing.md`.
 - [x] **E8 — Model multi/proto/submethod ordering in the candidate sequence.** Remove parallel
   multi and submethod resolver entry points without changing tie-breaking or role conflicts.
   Unifying the method-vs-sub ranking ladders is explicitly out of scope.
@@ -814,7 +814,7 @@ outcome.
   desync-prone parallel stacks into one `SamewithContext` stack).
   **All of E9 (E9-pre, E9a, E9b, E9c) is closed** (five PRs merged 2026-08-13: #6361/#6363/#6369/
   #6372/#6375). Full scenario tables and slice detail in
-  `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`.
+  `news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md`.
 - [x] **E10 — Move wrap/unwrap mutation into canonical entries.** Bump the generation and remove
   wrap-specific cache-clearing paths.
   **Landed 2026-08-13.** `Registry::method_wrap_chains` replaces the interpreter-level map; every

--- a/news/2026-08/adr0019-e5-e7-entry-routing.md
+++ b/news/2026-08/adr0019-e5-e7-entry-routing.md
@@ -1,5 +1,11 @@
 # ADR-0019 E5/E6/E7 design: routing every call entry through the resolver
 
+**Status: E5, E6, and E7 are all closed** (see their own `[x]` entries in
+`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`, which cites this file for
+"full per-step detail"). Archived here from `todo/deep/` now that the box is fully landed; kept
+as the ADR's linked detail record, not as an open finding -- do not treat the "no code has
+landed" line below as current.
+
 Design pass for Phase E boxes E5 (ordinary VM method calls), E6 (mutation-aware and container
 calls), and E7 (metaobject, qualified, and re-entrant calls). Depends on the E4 resolver and E2
 rows (`adr0019-e2-e4-resolver-core.md`). These boxes rewrite the largest functions in the
@@ -2265,7 +2271,7 @@ all** — three cases pinned in `t/classhow-lookup-mro.t`:
   MRO-level textual search, not a dispatch simulation.
 - An inherited **multi** method is found — this fix's per-level "first def wins" shape generalizes
   unchanged to the inherited case (matching `raku`'s own answer for this shape); true multi/proto
-  candidate-SEQUENCE modeling across levels is explicitly E8's job (`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`),
+  candidate-SEQUENCE modeling across levels is explicitly E8's job (`news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md`),
   out of scope here.
 - A more-derived override still wins over an ancestor's same-named method (the MRO walk's
   most-derived-first order already guarantees this — pinned as a sanity check, not a new mechanism).

--- a/news/2026-08/adr0019-e5-step2-callmethoddynamic-measurement.md
+++ b/news/2026-08/adr0019-e5-step2-callmethoddynamic-measurement.md
@@ -24,7 +24,7 @@ remaining E5 measurement entries (hyper non-mut paths,
 `call_method_all_with_fallback`) and all cutover sub-slices (E5b/E5c/E5d) that
 actually route dispatch through the resolver are still to do. Full taxonomy
 table and verification detail:
-`todo/deep/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
+`news/2026-08/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
 CallMethodDynamic (E5 step 2)") and
 `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (E5
 bullet).

--- a/news/2026-08/adr0019-e5-step3-hyper-measurement.md
+++ b/news/2026-08/adr0019-e5-step3-hyper-measurement.md
@@ -34,7 +34,7 @@ slice changes.
 one slice of an ongoing campaign: the last E5 measurement entry
 (`call_method_all_with_fallback`) and all cutover sub-slices
 (E5b/E5c/E5d) are still to do. Full taxonomy tables and sweep detail:
-`todo/deep/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
+`news/2026-08/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
 hyper non-mut paths (E5 step 3)") and
 `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (E5
 bullet).

--- a/news/2026-08/adr0019-e5-step4-callmethodallfallback-measurement.md
+++ b/news/2026-08/adr0019-e5-step4-callmethodallfallback-measurement.md
@@ -29,7 +29,7 @@ failed once and passed 5/5 on immediate re-runs — unrelated to this change).
 
 With all four E5 measurement sub-slices done, E5b (the `CallMethod`
 probe-section cutover to the E4 resolver decision) is next. Full detail:
-`todo/deep/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
+`news/2026-08/adr0019-e5-e7-entry-routing.md` (§"Measurement slice results —
 call_method_all_with_fallback (E5 step 4)") and
 `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (E5
 bullet).

--- a/news/2026-08/adr0019-e5b-step1-native-candidate-divergence-found.md
+++ b/news/2026-08/adr0019-e5b-step1-native-candidate-divergence-found.md
@@ -33,6 +33,6 @@ methodology exists to catch before a large cutover PR, not after.
 
 Full detail, mismatch examples, and the open next question (whether
 `CallMethod`'s existing `skip_native` gate already makes this moot for this
-one entry) are in `todo/deep/adr0019-e5-e7-entry-routing.md` §"E5b step 1"
+one entry) are in `news/2026-08/adr0019-e5-e7-entry-routing.md` §"E5b step 1"
 and `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`
 (E5 bullet).

--- a/news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md
+++ b/news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md
@@ -1,5 +1,12 @@
 # ADR-0019 E8/E9/E10/E11 design: multi ordering, deferral cursors, wrap generations, arity retirement
 
+**Status: E8, E9, E10, and E11 are all closed** (see their own `[x]` entries in
+`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`, which cites this file for
+"full scenario tables and slice detail"). Archived here from `todo/deep/` now that the box is
+fully landed; kept as the ADR's linked detail record, not as an open finding -- the later
+sections' "slice plan"/"not yet done" language describes work that has since landed; do not
+treat it as a live plan.
+
 Design pass for Phase E boxes E8 (multi/proto/submethod ordering in the candidate sequence),
 E9 (resolver cursors for `samewith`/`nextsame`/`callsame`/`nextwith`), E10 (wrap/unwrap into
 canonical entries + generation), and E11 (retire arity-specific lookup entry points). Depends

--- a/news/2026-08/adr0019-e9-decision2-redraw.md
+++ b/news/2026-08/adr0019-e9-decision2-redraw.md
@@ -2,7 +2,7 @@
 
 Follow-up to the E9-pre campaign (same day): the two probes run after the campaign PR
 confirmed a concrete replacement for the falsified part of E9's design decision 2, and the
-re-draw is now written into `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`
+re-draw is now written into `news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md`
 ("E9 design decision 2 — REDRAWN") with the ADR's E9 checkbox carrying the progress note.
 
 The model: the deferral sequence is a FLAT expansion — concat over MRO classes of, per class,

--- a/news/2026-08/adr0019-e9b-0-dispatch-token-frame-ordering.md
+++ b/news/2026-08/adr0019-e9b-0-dispatch-token-frame-ordering.md
@@ -40,7 +40,7 @@ sentinel-exhaustion fallthrough to the paired method frame is preserved
 explicitly. Only genuine cross-stack nesting — a method deferral inside a sub
 wrapper, or vice versa — changes behavior, which is exactly the bug above.
 
-ADR-0019 E9b-0 (see `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`,
+ADR-0019 E9b-0 (see `news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md`,
 "E9b design" § decision 4). Found and raku-confirmed during the E9b design
 pass; fixes
 `todo/tickets/callsame-in-method-consumes-enclosing-sub-wrap-chain.md`.

--- a/news/2026-08/adr0019-e9pre-verification-campaign.md
+++ b/news/2026-08/adr0019-e9pre-verification-campaign.md
@@ -1,7 +1,7 @@
 # ADR-0019 E9-pre: the raku ground-truth campaign for dispatch-deferral semantics
 
 Ran the mandatory pre-E9 verification campaign (ADR-0019 Phase E, design decision 3 in
-`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) as its own dedicated session: every
+`news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md`) as its own dedicated session: every
 `samewith`/`nextsame`/`callsame`/`nextwith`/`lastcall`/wrap/proto chain-order scenario was
 probed against real raku (Rakudo v2026.06) before any conclusion was drawn, matching behaviors
 were pinned, divergences were ticketed, and no cursor implementation code was written.
@@ -31,6 +31,6 @@ Deliverables:
   the native Mu implementations, and a cosmetic `Signature.gist` invocant-format difference.
 
 The full scenario-by-scenario table (a-m plus bonus probes, verdict and artifact per row) lives
-in the E9-pre section of `todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`, and the
+in the E9-pre section of `news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md`, and the
 ADR's E9 checkbox carries the progress note. Next up in Phase E: the decision-2 re-draw, then
 E9a (method frames → cursor).

--- a/news/2026-08/defer-chain-ranked-multi-order.md
+++ b/news/2026-08/defer-chain-ranked-multi-order.md
@@ -57,4 +57,4 @@ Both probes from the campaign are exact hits against Rakudo v2026.06 and pinned 
 green.
 
 See also: `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md` (ADR-0019 E9a),
-`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` (design decision 2, redrawn).
+`news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md` (design decision 2, redrawn).

--- a/todo/TRIAGE.md
+++ b/todo/TRIAGE.md
@@ -116,9 +116,15 @@ E3/E10/E11 remain open.
 
 | Ticket | Axis | Effort | Why here |
 |---|---|---|---|
-| [adr0019-e8-e11-candidate-sequence-semantics](deep/adr0019-e8-e11-candidate-sequence-semantics.md) | correctness §6 | XL | The live front: E8 closed, E9-pre done, E9a partially landed, E9b design in progress today (2026-08-13). E10 (wraps under the registry generation, killing the global `has_any_wrap_chains` prefilter — a measurable perf win) and E11 (arity-probe retirement) not started. |
-| [adr0019-e5-e7-entry-routing](deep/adr0019-e5-e7-entry-routing.md) | correctness §6 | XL | All four E5 measurement slices landed; E5b (`CallMethod` cutover) is mid-flight and just found the native-row candidate does NOT reliably predict the real cascade's outcome (~2.4% mismatch) — a genuine blocker finding that rules out a naive "resolver decides, cascade never runs" cutover shape. |
-| [adr0019-e2-e4-resolver-core](deep/adr0019-e2-e4-resolver-core.md) | perf §4 | XL | E4 (one resolver, native rows folded in) is closed; E2b coverage driven ~99% (37904→~400 unmodeled hits) and no longer gates anything (structural fallback replaces the literal-zero gate). Open: E1 TypeId-authoritative cutover, E3 sequence cache (now unblocked). |
+**STALE as of 2026-08-17: ADR-0019 is now Accepted/Implemented (all G1-G4 gates closed, E1-E11
+and F3-F7 all `[x]`).** E8-E11 and E5-E7 are done and their design docs archived to
+`news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md` and
+`news/2026-08/adr0019-e5-e7-entry-routing.md` respectively — not P1 work anymore. Only E2's
+residual, non-gating catalog cleanup remains open:
+
+| Ticket | Axis | Effort | Why here |
+|---|---|---|---|
+| [adr0019-e2-e4-resolver-core](deep/adr0019-e2-e4-resolver-core.md) | perf §4 | XL | E3/E4 closed; only E2 (exact handler-ID catalog) remains, and it no longer gates anything (structural fallback replaces the literal-zero coverage gate) — demote out of P1 on next full regen. |
 
 **ADR-0019 E8/E9 raku-divergence byproducts** — real, raku-confirmed bugs
 the verification campaign surfaced; several already root-caused with a

--- a/todo/deep/adr0019-e2-e4-resolver-core.md
+++ b/todo/deep/adr0019-e2-e4-resolver-core.md
@@ -1,5 +1,12 @@
 # ADR-0019 E2/E3/E4 design: native handler rows, the one resolver, and the resolved-call cache
 
+**Status: E3 and E4 are closed; E2 alone remains open**, as a non-gating cleanup (see the ADR's
+G4 closure note: "E2's exact-handler-ID catalog ... open cleanup, no longer gating dispatch
+correctness"). E2b coverage is driven to ~99% with a structural fallback in place, so the
+`native_call_unmodeled` counter and the row-completeness work below is the only live remnant of
+this doc; treat the E3/E4 sections as the ADR's linked closed-box detail record, and the "no code
+has landed for these boxes yet" line below as stale for E3/E4 specifically.
+
 Design pass for Phase E boxes E2 (exact handler IDs), E3 (generation-keyed resolved-call cache),
 and E4 (one MRO walk for native + user candidates). These three are one mechanism seen from
 three sides — the rows are what the resolver reads, the cache is where its result lives — so

--- a/todo/deep/method-entries-never-covers-unpunned-roles.md
+++ b/todo/deep/method-entries-never-covers-unpunned-roles.md
@@ -61,7 +61,7 @@ this same latent role-coverage gap.
 ## Why this was found now
 
 ADR-0019 Phase E box E8a (`docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`,
-`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) added `Interpreter::resolve_sequence`
+`news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md`) added `Interpreter::resolve_sequence`
 -based shadow-checking of the `nextsame`/`callsame` deferral list
 (`Interpreter::shadow_check_deferral_sequence`, `src/runtime/resolution_sequence.rs`).
 `resolve_sequence` builds its candidate universe via `Registry::user_method_overloads` (the
@@ -70,7 +70,7 @@ own raw candidates. A `MUTSU_VM_STATS=1` sweep of `t/` (2026-08-12) found every 
 shadow mismatch traced to this one root cause (`real_len` one candidate ahead of `shadow_len`,
 the missing candidate always owned by an un-punned role reachable in the receiver's MRO) —
 see the E8a landing note in the ADR and in
-`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md` for the exact file list and counts.
+`news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md` for the exact file list and counts.
 
 ## Why this is not fixed inside E8a
 
@@ -82,7 +82,7 @@ is not a "shadow-only, zero-real-behavior-change" edit: `get_method_overloads` i
 `resolution_private_method.rs` sites). Populating previously-empty role entries could change a
 real dispatch OUTCOME for some MRO shape not covered by today's tests (most likely a genuine
 bugfix, but an unverified one), which is out of scope for a box whose own definition
-(`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`, E8a slice) is limited to adding
+(`news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md`, E8a slice) is limited to adding
 sequence structure and shadow-comparing it — not changing what any real call resolves to. E8a
 therefore left this as a **documented, accepted shadow-check divergence** (mirroring E4a's own
 accepted-divergence bucket for the winner probe) rather than fixing it inline.

--- a/todo/deep/pseudo-method-which-why-user-override-ignored-in-bareword-and-dynamic-form.md
+++ b/todo/deep/pseudo-method-which-why-user-override-ignored-in-bareword-and-dynamic-form.md
@@ -93,7 +93,7 @@ gets consulted for the case that reaches the interpreter at all.
 ## Where found
 
 Discovered during ADR-0019 E5c (`CallMethodDynamic` dispatch-ordering classification,
-`todo/deep/adr0019-e5-e7-entry-routing.md` §"E5c") while raku-verifying whether
+`news/2026-08/adr0019-e5-e7-entry-routing.md` §"E5c") while raku-verifying whether
 `HyperMethodCallDynamic`'s missing `skip_native`/`has_user_method` gate (inventory correction 4)
 produces observable divergence -- it does, but the same divergence traces back to a pre-existing,
 narrower-than-suspected bug (only `WHICH`/`WHY`, not the full MOP pseudo-method set) unrelated to

--- a/todo/tickets/callsame-to-native-mu-methods-nil.md
+++ b/todo/tickets/callsame-to-native-mu-methods-nil.md
@@ -82,6 +82,6 @@ could be pushed there too. But:
    reachable without step 1-2.
 
 Alternatively: re-verify at the ADR-0019 E9 cursor-design boundary
-(`todo/deep/adr0019-e8-e11-candidate-sequence-semantics.md`) if that lands first — its
-stated goal is "all four fallbacks [become] ordinary sequence tail entries", which would
-plausibly subsume this gap by construction.
+(`news/2026-08/adr0019-e8-e11-candidate-sequence-semantics.md`, now closed and landed — the
+cursor rewrite itself stayed out of scope; re-check whether this gap survived the actual E9
+landing before assuming it's still open).


### PR DESCRIPTION
## Summary
- ADR-0019's E5/E6/E7 and E8/E9/E10/E11 boxes are all `[x]` closed in the checklist, so their `todo/deep/` design-pass docs no longer belong under `todo/` (open findings only) -- `git mv` both to `news/2026-08/`, matching the ADR's own citations of them as "full per-step detail" / "full scenario tables and slice detail".
- Fixed every cross-reference to the old `todo/deep/adr0019-e5-e7-entry-routing.md` / `adr0019-e8-e11-candidate-sequence-semantics.md` paths: the ADR itself, `todo/TRIAGE.md`, three sibling tickets, and eight already-published `news/2026-08/` entries that cited them.
- `todo/deep/adr0019-e2-e4-resolver-core.md` stays in `todo/deep/` (E2's handler-ID catalog is still genuinely open, non-gating cleanup) but gets a status header since E3/E4 closing made its "no code has landed" opening line stale for 2 of its 3 boxes.
- Corrected `TRIAGE.md`'s ADR-0019 Phase E row out of its stale "live front" P1 framing (the whole ADR is now Accepted/Implemented).

Docs-only change, no code touched.

## Test plan
- [x] `grep -rn "todo/deep/adr0019-e5-e7-entry-routing\|todo/deep/adr0019-e8-e11-candidate-sequence-semantics"` across the repo returns no hits (no dangling references)
- N/A build/tests (docs-only diff; CI's docs-only fast path applies)