### PR TITLE
feat(adr0029): mechanically capture real X:: exception shape from raku

### DIFF
--- a/TODO_roast/x-exception-role-membership-diff.tsv
+++ b/TODO_roast/x-exception-role-membership-diff.tsv
@@ -1,0 +1,324 @@
+name	category	raku_mro	mutsu_mro	raku_roles_all	mutsu_roles_all
+X::Anon::Augment	missing	X::Anon::Augment,Exception,Any,Mu		X::Comp	
+X::Anon::Multi	missing	X::Anon::Multi,Exception,Any,Mu		X::Comp	
+X::ArrayShapeMismatch	missing	X::ArrayShapeMismatch,Exception,Any,Mu			
+X::Assignment::ArrayShapeMismatch	missing	X::Assignment::ArrayShapeMismatch,X::ArrayShapeMismatch,Exception,Any,Mu			
+X::Assignment::RO::Comp	missing	X::Assignment::RO::Comp,Exception,Any,Mu		X::Comp	
+X::Assignment::ToShaped	missing	X::Assignment::ToShaped,Exception,Any,Mu			
+X::Attribute::NoPackage	missing	X::Attribute::NoPackage,Exception,Any,Mu		X::Comp	
+X::Attribute::Package	missing	X::Attribute::Package,Exception,Any,Mu		X::Comp	
+X::Attribute::Regex	missing	X::Attribute::Regex,X::Undeclared,Exception,Any,Mu		X::Comp,X::Comp	
+X::Attribute::Required	wrong_roles	X::Attribute::Required,Exception,Any,Mu	X::Attribute::Required,Exception,Any,Mu	X::MOP	
+X::Attribute::Scope::Package	missing	X::Attribute::Scope::Package,Exception,Any,Mu		X::Comp	
+X::Attribute::Undeclared	wrong_mro	X::Attribute::Undeclared,X::Undeclared,Exception,Any,Mu	X::Attribute::Undeclared,X::Comp,Exception,Any,Mu	X::Comp,X::Comp	
+X::Augment::NoSuchType	missing	X::Augment::NoSuchType,Exception,Any,Mu		X::Comp	
+X::Backslash::NonVariableDollar	missing	X::Backslash::NonVariableDollar,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Backslash::UnrecognizedSequence	wrong_mro	X::Backslash::UnrecognizedSequence,Exception,Any,Mu	X::Backslash::UnrecognizedSequence,X::Backslash,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Bind::NativeType	wrong_mro	X::Bind::NativeType,Exception,Any,Mu	X::Bind::NativeType,X::Bind,Exception,Any,Mu	X::Comp	
+X::Bind::Rebind	missing	X::Bind::Rebind,X::Bind,Exception,Any,Mu			
+X::Bind::ZenSlice	missing	X::Bind::ZenSlice,X::Bind::Slice,Exception,Any,Mu			
+X::Buf::AsStr	missing	X::Buf::AsStr,Exception,Any,Mu			
+X::Buf::Pack	missing	X::Buf::Pack,Exception,Any,Mu			
+X::Buf::Pack::NonASCII	missing	X::Buf::Pack::NonASCII,Exception,Any,Mu			
+X::Caller::NotDynamic	missing	X::Caller::NotDynamic,X::Symbol::Kind,Exception,Any,Mu			
+X::Cannot::Empty	missing	X::Cannot::Empty,Exception,Any,Mu			
+X::Cannot::Map	missing	X::Cannot::Map,Exception,Any,Mu			
+X::Cannot::New	missing	X::Cannot::New,Exception,Any,Mu			
+X::Coerce	missing	X::Coerce,Exception,Any,Mu			
+X::Coerce::Impossible	wrong_mro	X::Coerce::Impossible,X::Coerce,Exception,Any,Mu	X::Coerce::Impossible,Exception,Any,Mu		
+X::Coerce::Role	missing	X::Coerce::Role,X::Coerce,Exception,Any,Mu		X::Wrapper	
+X::Comp::AdHoc	wrong_mro	X::Comp::AdHoc,X::AdHoc,Exception,Any,Mu	X::Comp::AdHoc,X::Comp,X::AdHoc,Exception,Any,Mu	X::Comp	
+X::Comp::BeginTime	missing	X::Comp::BeginTime,Exception,Any,Mu		X::Comp	
+X::Comp::FailGoal	wrong_roles	X::Comp::FailGoal,Exception,Any,Mu	X::Comp::FailGoal,Exception,Any,Mu	X::Comp	
+X::Comp::Group	wrong_mro	X::Comp::Group,Exception,Any,Mu	X::Comp::Group,X::Comp,Exception,Any,Mu		
+X::Comp::NYI	wrong_mro	X::Comp::NYI,X::NYI,Exception,Any,Mu	X::Comp::NYI,X::Comp,Exception,Any,Mu	X::Comp	
+X::Comp::Trait::Invalid	missing	X::Comp::Trait::Invalid,X::Trait::Invalid,Exception,Any,Mu		X::Comp,X::Trait,X::Trait	
+X::Comp::Trait::NotOnNative	missing	X::Comp::Trait::NotOnNative,X::Trait::NotOnNative,Exception,Any,Mu		X::Comp,X::Trait,X::Trait	
+X::Comp::Trait::Scope	missing	X::Comp::Trait::Scope,X::Trait::Scope,Exception,Any,Mu		X::Comp,X::Trait,X::Trait	
+X::Comp::Trait::Unknown	missing	X::Comp::Trait::Unknown,X::Trait::Unknown,Exception,Any,Mu		X::Comp,X::Trait,X::Trait	
+X::Comp::TypeCheck	missing	X::Comp::TypeCheck,X::TypeCheck,Exception,Any,Mu		X::Comp	
+X::Comp::WheneverOutOfScope	missing	X::Comp::WheneverOutOfScope,Exception,Any,Mu		X::Comp	
+X::Composition::NotComposable	wrong_roles	X::Composition::NotComposable,Exception,Any,Mu	X::Composition::NotComposable,Exception,Any,Mu	X::Comp	
+X::Constructor::BadType	missing	X::Constructor::BadType,Exception,Any,Mu		X::BadType	
+X::Constructor::Positional	missing	X::Constructor::Positional,Exception,Any,Mu			
+X::ControlFlow::Return	wrong_mro	X::ControlFlow::Return,X::ControlFlow,Exception,Any,Mu	X::ControlFlow::Return,Exception,Any,Mu		
+X::DateTime::InvalidDeltaUnit	missing	X::DateTime::InvalidDeltaUnit,Exception,Any,Mu		X::Temporal	
+X::DateTime::TimezoneClash	missing	X::DateTime::TimezoneClash,Exception,Any,Mu		X::Temporal	
+X::Declaration::OurScopeInRole	wrong_roles	X::Declaration::OurScopeInRole,Exception,Any,Mu	X::Declaration::OurScopeInRole,Exception,Any,Mu	X::Comp	
+X::Declaration::Scope	missing	X::Declaration::Scope,Exception,Any,Mu		X::Comp	
+X::Declaration::Scope::Multi	missing	X::Declaration::Scope::Multi,X::Declaration::Scope,Exception,Any,Mu		X::Comp,X::Comp	
+X::Delete	missing	X::Delete,Exception,Any,Mu			
+X::Does::TypeObject	missing	X::Does::TypeObject,Exception,Any,Mu			
+X::Dynamic::Package	missing	X::Dynamic::Package,Exception,Any,Mu		X::Comp	
+X::Dynamic::Postdeclaration	missing	X::Dynamic::Postdeclaration,Exception,Any,Mu		X::Comp	
+X::EXPORTHOW::Conflict	missing	X::EXPORTHOW::Conflict,Exception,Any,Mu		X::Comp	
+X::EXPORTHOW::InvalidDirective	missing	X::EXPORTHOW::InvalidDirective,Exception,Any,Mu		X::Comp	
+X::EXPORTHOW::NothingToSupersede	missing	X::EXPORTHOW::NothingToSupersede,Exception,Any,Mu		X::Comp	
+X::Encoding::AlreadyRegistered	missing	X::Encoding::AlreadyRegistered,Exception,Any,Mu		X::Encoding	
+X::Encoding::Unknown	missing	X::Encoding::Unknown,Exception,Any,Mu		X::Encoding	
+X::Enum::NoValue	missing	X::Enum::NoValue,Exception,Any,Mu			
+X::Eval::NoSuchLang	missing	X::Eval::NoSuchLang,Exception,Any,Mu			
+X::Exhausted	missing	X::Exhausted,Exception,Any,Mu			
+X::Experimental	missing	X::Experimental,Exception,Any,Mu		X::Comp	
+X::Export::NameClash	missing	X::Export::NameClash,Exception,Any,Mu		X::Comp	
+X::HyperOp::Infinite	missing	X::HyperOp::Infinite,Exception,Any,Mu			
+X::HyperOp::NonDWIM	missing	X::HyperOp::NonDWIM,Exception,Any,Mu			
+X::HyperWhatever::Multiple	missing	X::HyperWhatever::Multiple,Exception,Any,Mu			
+X::IO::BinaryAndEncoding	missing	X::IO::BinaryAndEncoding,Exception,Any,Mu		X::IO,X::OS	
+X::IO::BinaryMode	missing	X::IO::BinaryMode,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Chdir	missing	X::IO::Chdir,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Chmod	missing	X::IO::Chmod,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Chown	missing	X::IO::Chown,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Closed	wrong_roles	X::IO::Closed,Exception,Any,Mu	X::IO::Closed,Exception,Any,Mu	X::IO,X::OS	
+X::IO::Copy	missing	X::IO::Copy,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Cwd	missing	X::IO::Cwd,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Dir	missing	X::IO::Dir,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Directory	missing	X::IO::Directory,Exception,Any,Mu		X::IO,X::OS	
+X::IO::DoesNotExist	missing	X::IO::DoesNotExist,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Flush	missing	X::IO::Flush,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Link	missing	X::IO::Link,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Lock	missing	X::IO::Lock,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Mkdir	missing	X::IO::Mkdir,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Move	missing	X::IO::Move,Exception,Any,Mu		X::IO,X::OS	
+X::IO::NotAChild	wrong_roles	X::IO::NotAChild,Exception,Any,Mu	X::IO::NotAChild,Exception,Any,Mu	X::IO,X::OS	
+X::IO::NotAFile	missing	X::IO::NotAFile,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Null	missing	X::IO::Null,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Rename	missing	X::IO::Rename,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Resolve	wrong_roles	X::IO::Resolve,Exception,Any,Mu	X::IO::Resolve,Exception,Any,Mu	X::IO,X::OS	
+X::IO::Rmdir	missing	X::IO::Rmdir,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Symlink	missing	X::IO::Symlink,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Unknown	missing	X::IO::Unknown,Exception,Any,Mu		X::IO,X::OS	
+X::IO::Unlink	wrong_roles	X::IO::Unlink,Exception,Any,Mu	X::IO::Unlink,Exception,Any,Mu	X::IO,X::OS	
+X::IllegalOnFixedDimensionArray	missing	X::IllegalOnFixedDimensionArray,Exception,Any,Mu			
+X::Import::MissingSymbols	missing	X::Import::MissingSymbols,Exception,Any,Mu			
+X::Import::NoSuchTag	missing	X::Import::NoSuchTag,Exception,Any,Mu			
+X::Import::OnlystarProto	missing	X::Import::OnlystarProto,Exception,Any,Mu		X::Comp	
+X::Import::Positional	missing	X::Import::Positional,Exception,Any,Mu			
+X::Import::Redeclaration	missing	X::Import::Redeclaration,Exception,Any,Mu		X::Comp	
+X::Inheritance::NotComposed	missing	X::Inheritance::NotComposed,Exception,Any,Mu		X::MOP	
+X::Inheritance::Unsupported	missing	X::Inheritance::Unsupported,Exception,Any,Mu		X::Comp	
+X::Invalid::ComputedValue	missing	X::Invalid::ComputedValue,Exception,Any,Mu			
+X::Invalid::Value	missing	X::Invalid::Value,Exception,Any,Mu			
+X::InvalidCodepoint	missing	X::InvalidCodepoint,Exception,Any,Mu			
+X::InvalidType	missing	X::InvalidType,Exception,Any,Mu		X::Comp	
+X::InvalidTypeSmiley	missing	X::InvalidTypeSmiley,Exception,Any,Mu		X::Comp	
+X::Ism::Unknown	missing	X::Ism::Unknown,Exception,Any,Mu			
+X::Item	missing	X::Item,Exception,Any,Mu			
+X::Language::IncompatRevisions	missing	X::Language::IncompatRevisions,Exception,Any,Mu			
+X::Language::ModRequired	missing	X::Language::ModRequired,Exception,Any,Mu			
+X::Language::TooLate	missing	X::Language::TooLate,Exception,Any,Mu			
+X::Language::Unsupported	missing	X::Language::Unsupported,Exception,Any,Mu			
+X::LibEmpty	missing	X::LibEmpty,Exception,Any,Mu		X::Comp	
+X::LibNone	missing	X::LibNone,Exception,Any,Mu		X::Comp	
+X::Localizer::NoContainer	missing	X::Localizer::NoContainer,Exception,Any,Mu			
+X::Lock::Async::NotLocked	missing	X::Lock::Async::NotLocked,Exception,Any,Mu			
+X::Lock::ConditionVariable::Duplicate	missing	X::Lock::ConditionVariable::Duplicate,Exception,Any,Mu			
+X::Lock::ConditionVariable::New	missing	X::Lock::ConditionVariable::New,Exception,Any,Mu			
+X::Lock::ConditionVariable::NoMutex	missing	X::Lock::ConditionVariable::NoMutex,Exception,Any,Mu			
+X::Lock::ConditionVariable::WrongThread	missing	X::Lock::ConditionVariable::WrongThread,Exception,Any,Mu			
+X::Lock::Unlock::NoMutex	missing	X::Lock::Unlock::NoMutex,Exception,Any,Mu			
+X::Lock::Unlock::WrongThread	missing	X::Lock::Unlock::WrongThread,Exception,Any,Mu			
+X::Make::MatchRequired	missing	X::Make::MatchRequired,Exception,Any,Mu			
+X::Method::Duplicate	missing	X::Method::Duplicate,Exception,Any,Mu			
+X::Method::InvalidQualifier	missing	X::Method::InvalidQualifier,Exception,Any,Mu			
+X::Method::Private::Permission	wrong_roles	X::Method::Private::Permission,Exception,Any,Mu	X::Method::Private::Permission,Exception,Any,Mu	X::Comp	
+X::Method::Private::Unqualified	wrong_roles	X::Method::Private::Unqualified,Exception,Any,Mu	X::Method::Private::Unqualified,Exception,Any,Mu	X::Comp	
+X::MultipleTypeSmiley	missing	X::MultipleTypeSmiley,Exception,Any,Mu		X::Comp	
+X::MustBeParametric	missing	X::MustBeParametric,Exception,Any,Mu			
+X::NQP::NotFound	missing	X::NQP::NotFound,Exception,Any,Mu			
+X::NYI::Available	missing	X::NYI::Available,X::NYI,Exception,Any,Mu			
+X::NYI::BigInt	missing	X::NYI::BigInt,Exception,Any,Mu			
+X::NoCoreRevision	missing	X::NoCoreRevision,Exception,Any,Mu			
+X::NoDispatcher	missing	X::NoDispatcher,Exception,Any,Mu			
+X::NoSuchSymbol	missing	X::NoSuchSymbol,Exception,Any,Mu			
+X::Nominalizable::NoKind	missing	X::Nominalizable::NoKind,Exception,Any,Mu		X::Nominalizable	
+X::Nominalizable::NoWrappee	missing	X::Nominalizable::NoWrappee,Exception,Any,Mu		X::Nominalizable	
+X::NotFoundInRepository	missing	X::NotFoundInRepository,Exception,Any,Mu			
+X::NotParametric	missing	X::NotParametric,Exception,Any,Mu			
+X::NotSingleGrapheme	missing	X::NotSingleGrapheme,Exception,Any,Mu			
+X::Numeric::Confused	missing	X::Numeric::Confused,Exception,Any,Mu			
+X::Numeric::Overflow	missing	X::Numeric::Overflow,Exception,Any,Mu			
+X::Numeric::Real	wrong_mro	X::Numeric::Real,X::Numeric::CannotConvert,Exception,Any,Mu	X::Numeric::Real,Exception,Any,Mu		
+X::Numeric::Underflow	missing	X::Numeric::Underflow,Exception,Any,Mu			
+X::Obsolete	wrong_mro	X::Obsolete,Exception,Any,Mu	X::Obsolete,X::Comp,Exception,Any,Mu	X::Comp	
+X::Package::SameNameAsEnclosing	missing	X::Package::SameNameAsEnclosing,Exception,Any,Mu		X::Comp	
+X::Package::Stubbed	missing	X::Package::Stubbed,Exception,Any,Mu		X::Comp	
+X::Package::UseLib	missing	X::Package::UseLib,Exception,Any,Mu		X::Comp	
+X::Pairup::OddNumber	missing	X::Pairup::OddNumber,Exception,Any,Mu			
+X::Parameter::AfterDefault	missing	X::Parameter::AfterDefault,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Parameter::BadType	wrong_mro	X::Parameter::BadType,Exception,Any,Mu	X::Parameter::BadType,X::Parameter,Exception,Any,Mu	X::BadType,X::Comp	
+X::Parameter::Default	missing	X::Parameter::Default,Exception,Any,Mu		X::Comp	
+X::Parameter::Default::TypeCheck	missing	X::Parameter::Default::TypeCheck,Exception,Any,Mu		X::Comp	
+X::Parameter::InvalidConcreteness	wrong_mro	X::Parameter::InvalidConcreteness,Exception,Any,Mu	X::Parameter::InvalidConcreteness,X::Parameter,Exception,Any,Mu		
+X::Parameter::InvalidType	missing	X::Parameter::InvalidType,Exception,Any,Mu		X::Comp	
+X::Parameter::MultipleTypeConstraints	missing	X::Parameter::MultipleTypeConstraints,Exception,Any,Mu		X::Comp	
+X::Parameter::Named::SubsetTypeWithoutDefault	missing	X::Parameter::Named::SubsetTypeWithoutDefault,Exception,Any,Mu		X::Comp	
+X::Parameter::Placeholder	missing	X::Parameter::Placeholder,Exception,Any,Mu		X::Comp	
+X::Parameter::RW	missing	X::Parameter::RW,Exception,Any,Mu			
+X::Parameter::Twigil	missing	X::Parameter::Twigil,Exception,Any,Mu		X::Comp	
+X::Parameter::TypedSlurpy	missing	X::Parameter::TypedSlurpy,Exception,Any,Mu		X::Comp	
+X::Parameter::WrongOrder	missing	X::Parameter::WrongOrder,Exception,Any,Mu		X::Comp	
+X::Phaser::Multiple	missing	X::Phaser::Multiple,Exception,Any,Mu		X::Comp	
+X::Phaser::PrePost	missing	X::Phaser::PrePost,Exception,Any,Mu			
+X::PhaserExceptions	missing	X::PhaserExceptions,Exception,Any,Mu			
+X::Placeholder::Attribute	missing	X::Placeholder::Attribute,X::Placeholder::Block,Exception,Any,Mu		X::Comp,X::Comp	
+X::Placeholder::Block	missing	X::Placeholder::Block,Exception,Any,Mu		X::Comp	
+X::Placeholder::Mainline	missing	X::Placeholder::Mainline,X::Placeholder::Block,Exception,Any,Mu		X::Comp,X::Comp	
+X::Placeholder::NonPlaceholder	missing	X::Placeholder::NonPlaceholder,Exception,Any,Mu		X::Comp	
+X::PoisonedAlias	missing	X::PoisonedAlias,Exception,Any,Mu		X::Comp	
+X::Pragma::CannotPrecomp	missing	X::Pragma::CannotPrecomp,Exception,Any,Mu			
+X::Pragma::CannotWhat	missing	X::Pragma::CannotWhat,Exception,Any,Mu			
+X::Pragma::MustOneOf	missing	X::Pragma::MustOneOf,Exception,Any,Mu			
+X::Pragma::NoArgs	missing	X::Pragma::NoArgs,Exception,Any,Mu			
+X::Pragma::OnlyOne	missing	X::Pragma::OnlyOne,Exception,Any,Mu			
+X::Pragma::Unknown	missing	X::Pragma::Unknown,Exception,Any,Mu			
+X::Pragma::UnknownArg	missing	X::Pragma::UnknownArg,Exception,Any,Mu			
+X::Proc::Async::AlreadyStarted	missing	X::Proc::Async::AlreadyStarted,Exception,Any,Mu		X::Proc::Async	
+X::Proc::Async::BindOrUse	missing	X::Proc::Async::BindOrUse,Exception,Any,Mu		X::Proc::Async	
+X::Proc::Async::CharsOrBytes	missing	X::Proc::Async::CharsOrBytes,Exception,Any,Mu		X::Proc::Async	
+X::Proc::Async::MissingColsRows	missing	X::Proc::Async::MissingColsRows,Exception,Any,Mu		X::Proc::Async	
+X::Proc::Async::MustBeStarted	missing	X::Proc::Async::MustBeStarted,Exception,Any,Mu		X::Proc::Async	
+X::Proc::Async::OpenForWriting	missing	X::Proc::Async::OpenForWriting,Exception,Any,Mu		X::Proc::Async	
+X::Proc::Async::SupplyOrStd	missing	X::Proc::Async::SupplyOrStd,Exception,Any,Mu		X::Proc::Async	
+X::Proc::Async::TapBeforeSpawn	missing	X::Proc::Async::TapBeforeSpawn,Exception,Any,Mu		X::Proc::Async	
+X::Proc::Unsuccessful	missing	X::Proc::Unsuccessful,Exception,Any,Mu			
+X::Promise::Combinator	missing	X::Promise::Combinator,Exception,Any,Mu			
+X::PseudoPackage::InDeclaration	missing	X::PseudoPackage::InDeclaration,Exception,Any,Mu		X::Comp	
+X::QuoteWords::Missing::Closer	missing	X::QuoteWords::Missing::Closer,Exception,Any,Mu		X::Comp	
+X::REPL::InvalidEnvironment	missing	X::REPL::InvalidEnvironment,Exception,Any,Mu			
+X::Range::CannotIterate	missing	X::Range::CannotIterate,Exception,Any,Mu			
+X::Range::Incomparable	missing	X::Range::Incomparable,Exception,Any,Mu			
+X::Range::InvalidArg	missing	X::Range::InvalidArg,Exception,Any,Mu			
+X::Range::Rand::InvalidEndpoints	missing	X::Range::Rand::InvalidEndpoints,Exception,Any,Mu			
+X::Redeclaration	wrong_mro	X::Redeclaration,Exception,Any,Mu	X::Redeclaration,X::Comp,Exception,Any,Mu	X::Comp	
+X::Redeclaration::Multi	missing	X::Redeclaration::Multi,Exception,Any,Mu		X::Comp	
+X::Redeclaration::Outer	missing	X::Redeclaration::Outer,Exception,Any,Mu		X::Comp	
+X::Role::Attribute::Conflicts	missing	X::Role::Attribute::Conflicts,Exception,Any,Mu		X::Role::Attribute,X::RoleApplier	
+X::Role::Attribute::Exists	missing	X::Role::Attribute::Exists,Exception,Any,Mu		X::Role::Attribute,X::RoleApplier	
+X::Role::BodyReturn	missing	X::Role::BodyReturn,Exception,Any,Mu			
+X::Role::Group::Documenting	missing	X::Role::Group::Documenting,Exception,Any,Mu			
+X::Role::Initialization	missing	X::Role::Initialization,Exception,Any,Mu			
+X::Role::Instantiation	wrong_roles	X::Role::Instantiation,Exception,Any,Mu	X::Role::Instantiation,Exception,Any,Mu	X::Wrapper	
+X::Role::Unimplemented::Multi	wrong_roles	X::Role::Unimplemented::Multi,Exception,Any,Mu	X::Role::Unimplemented::Multi,Exception,Any,Mu	X::RoleApplier::Method,X::RoleApplier	
+X::Role::Unresolved	missing	X::Role::Unresolved,Exception,Any,Mu		X::RoleApplier::Method,X::RoleApplier	
+X::Role::Unresolved::Method	missing	X::Role::Unresolved::Method,X::Role::Unresolved,Exception,Any,Mu		X::RoleApplier::Method,X::RoleApplier,X::RoleApplier::Method,X::RoleApplier	
+X::Role::Unresolved::Multi	missing	X::Role::Unresolved::Multi,X::Role::Unresolved,Exception,Any,Mu		X::RoleApplier::Method,X::RoleApplier,X::RoleApplier::Method,X::RoleApplier	
+X::Role::Unresolved::Private	missing	X::Role::Unresolved::Private,X::Role::Unresolved,Exception,Any,Mu		X::RoleApplier::Method,X::RoleApplier,X::RoleApplier::Method,X::RoleApplier	
+X::Scheduler::CueInNaNSeconds	missing	X::Scheduler::CueInNaNSeconds,Exception,Any,Mu			
+X::SecurityPolicy::Eval	missing	X::SecurityPolicy::Eval,X::SecurityPolicy,Exception,Any,Mu			
+X::Seq::NotIndexable	missing	X::Seq::NotIndexable,Exception,Any,Mu			
+X::Sequence::Deduction	missing	X::Sequence::Deduction,Exception,Any,Mu			
+X::Sequence::Endpoint	missing	X::Sequence::Endpoint,Exception,Any,Mu			
+X::Set::Coerce	missing	X::Set::Coerce,Exception,Any,Mu			
+X::Signature::NameClash	wrong_mro	X::Signature::NameClash,Exception,Any,Mu	X::Signature::NameClash,X::Comp,Exception,Any,Mu	X::Comp	
+X::Signature::Placeholder	wrong_roles	X::Signature::Placeholder,Exception,Any,Mu	X::Signature::Placeholder,Exception,Any,Mu	X::Comp	
+X::Str::InvalidCharName	missing	X::Str::InvalidCharName,Exception,Any,Mu			
+X::Str::Sprintf::Directives::BadType	missing	X::Str::Sprintf::Directives::BadType,Exception,Any,Mu			
+X::Str::Subst::Adverb	missing	X::Str::Subst::Adverb,Exception,Any,Mu			
+X::Subscript::Negative	missing	X::Subscript::Negative,Exception,Any,Mu			
+X::Supply::Migrate::Needs	missing	X::Supply::Migrate::Needs,Exception,Any,Mu			
+X::Supply::New	missing	X::Supply::New,Exception,Any,Mu			
+X::Symbol::Kind	missing	X::Symbol::Kind,Exception,Any,Mu			
+X::Symbol::NotDynamic	missing	X::Symbol::NotDynamic,X::Symbol::Kind,Exception,Any,Mu			
+X::Symbol::NotLexical	missing	X::Symbol::NotLexical,X::Symbol::Kind,Exception,Any,Mu			
+X::Syntax::AddCategorical::TooFewParts	missing	X::Syntax::AddCategorical::TooFewParts,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::AddCategorical::TooManyParts	missing	X::Syntax::AddCategorical::TooManyParts,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Adverb	missing	X::Syntax::Adverb,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::AmbiguousAdverb	missing	X::Syntax::AmbiguousAdverb,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Argument::MOPMacro	missing	X::Syntax::Argument::MOPMacro,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Augment::Adverb	missing	X::Syntax::Augment::Adverb,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Augment::Illegal	missing	X::Syntax::Augment::Illegal,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Augment::WithoutMonkeyTyping	missing	X::Syntax::Augment::WithoutMonkeyTyping,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::BlockGobbled	wrong_roles	X::Syntax::BlockGobbled,Exception,Any,Mu	X::Syntax::BlockGobbled,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::CannotMeta	wrong_roles	X::Syntax::CannotMeta,Exception,Any,Mu	X::Syntax::CannotMeta,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Coercer::TooComplex	missing	X::Syntax::Coercer::TooComplex,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Comment::Embedded	wrong_mro	X::Syntax::Comment::Embedded,Exception,Any,Mu	X::Syntax::Comment::Embedded,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::ConditionalOperator::PrecedenceTooLoose	missing	X::Syntax::ConditionalOperator::PrecedenceTooLoose,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::ConditionalOperator::SecondPartGobbled	missing	X::Syntax::ConditionalOperator::SecondPartGobbled,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::ConditionalOperator::SecondPartInvalid	missing	X::Syntax::ConditionalOperator::SecondPartInvalid,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Confused	wrong_mro	X::Syntax::Confused,Exception,Any,Mu	X::Syntax::Confused,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Doc::Declarator::MissingDeclarand	missing	X::Syntax::Doc::Declarator::MissingDeclarand,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::DuplicatedPrefix	missing	X::Syntax::DuplicatedPrefix,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Extension::Category	wrong_roles	X::Syntax::Extension::Category,Exception,Any,Mu	X::Syntax::Extension::Category,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Extension::Null	wrong_mro	X::Syntax::Extension::Null,Exception,Any,Mu	X::Syntax::Extension::Null,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Extension::SpecialForm	missing	X::Syntax::Extension::SpecialForm,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Extension::TooComplex	wrong_roles	X::Syntax::Extension::TooComplex,Exception,Any,Mu	X::Syntax::Extension::TooComplex,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::InfixInTermPosition	missing	X::Syntax::InfixInTermPosition,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::KeywordAsFunction	wrong_mro	X::Syntax::KeywordAsFunction,Exception,Any,Mu	X::Syntax::KeywordAsFunction,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Malformed	wrong_mro	X::Syntax::Malformed,Exception,Any,Mu	X::Syntax::Malformed,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Malformed::Elsif	missing	X::Syntax::Malformed::Elsif,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Missing	wrong_mro	X::Syntax::Missing,Exception,Any,Mu	X::Syntax::Missing,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Name::Null	wrong_mro	X::Syntax::Name::Null,Exception,Any,Mu	X::Syntax::Name::Null,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::NegatedPair	wrong_mro	X::Syntax::NegatedPair,Exception,Any,Mu	X::Syntax::NegatedPair,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::NoSelf	wrong_mro	X::Syntax::NoSelf,Exception,Any,Mu	X::Syntax::NoSelf,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::NonAssociative	missing	X::Syntax::NonAssociative,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::NonListAssociative	missing	X::Syntax::NonListAssociative,X::Syntax::NonAssociative,Exception,Any,Mu		X::Syntax,X::Comp,X::Syntax,X::Comp	
+X::Syntax::Number::IllegalDecimal	missing	X::Syntax::Number::IllegalDecimal,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Number::LiteralType	wrong_mro	X::Syntax::Number::LiteralType,X::TypeCheck::Assignment,X::TypeCheck,Exception,Any,Mu	X::Syntax::Number::LiteralType,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Number::RadixOutOfRange	missing	X::Syntax::Number::RadixOutOfRange,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::P5	missing	X::Syntax::P5,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::ParentAsHash	missing	X::Syntax::ParentAsHash,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Perl5Var	missing	X::Syntax::Perl5Var,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Pod::BeginWithDirective	missing	X::Syntax::Pod::BeginWithDirective,Exception,Any,Mu		X::Pod,X::Syntax,X::Comp	
+X::Syntax::Pod::BeginWithoutEnd	missing	X::Syntax::Pod::BeginWithoutEnd,Exception,Any,Mu		X::Pod,X::Syntax,X::Comp	
+X::Syntax::Pod::BeginWithoutIdentifier	missing	X::Syntax::Pod::BeginWithoutIdentifier,Exception,Any,Mu		X::Pod,X::Syntax,X::Comp	
+X::Syntax::Pod::DeclaratorLeading	missing	X::Syntax::Pod::DeclaratorLeading,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Pod::DeclaratorTrailing	missing	X::Syntax::Pod::DeclaratorTrailing,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Regex::Adverb	wrong_mro	X::Syntax::Regex::Adverb,Exception,Any,Mu	X::Syntax::Regex::Adverb,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Regex::Alias::LongName	missing	X::Syntax::Regex::Alias::LongName,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Regex::InsignificantWhitespace	missing	X::Syntax::Regex::InsignificantWhitespace,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Regex::MalformedRange	missing	X::Syntax::Regex::MalformedRange,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Regex::NonQuantifiable	wrong_mro	X::Syntax::Regex::NonQuantifiable,Exception,Any,Mu	X::Syntax::Regex::NonQuantifiable,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Regex::NullRegex	wrong_mro	X::Syntax::Regex::NullRegex,Exception,Any,Mu	X::Syntax::Regex::NullRegex,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Regex::QuantifierValue	wrong_mro	X::Syntax::Regex::QuantifierValue,Exception,Any,Mu	X::Syntax::Regex::QuantifierValue,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Regex::SolitaryBacktrackControl	missing	X::Syntax::Regex::SolitaryBacktrackControl,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Regex::SolitaryQuantifier	wrong_mro	X::Syntax::Regex::SolitaryQuantifier,Exception,Any,Mu	X::Syntax::Regex::SolitaryQuantifier,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Regex::SpacesInBareRange	missing	X::Syntax::Regex::SpacesInBareRange,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Regex::UnrecognizedMetachar	missing	X::Syntax::Regex::UnrecognizedMetachar,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Regex::UnrecognizedModifier	missing	X::Syntax::Regex::UnrecognizedModifier,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Regex::Unspace	missing	X::Syntax::Regex::Unspace,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Regex::Unterminated	missing	X::Syntax::Regex::Unterminated,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Reserved	wrong_mro	X::Syntax::Reserved,Exception,Any,Mu	X::Syntax::Reserved,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Self::WithoutObject	missing	X::Syntax::Self::WithoutObject,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Signature::InvocantMarker	wrong_mro	X::Syntax::Signature::InvocantMarker,Exception,Any,Mu	X::Syntax::Signature::InvocantMarker,X::Syntax::Signature,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Signature::InvocantNotAllowed	wrong_mro	X::Syntax::Signature::InvocantNotAllowed,Exception,Any,Mu	X::Syntax::Signature::InvocantNotAllowed,X::Syntax::Signature,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Term::MissingInitializer	wrong_mro	X::Syntax::Term::MissingInitializer,Exception,Any,Mu	X::Syntax::Term::MissingInitializer,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Type::Adverb	missing	X::Syntax::Type::Adverb,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::UnlessElse	wrong_mro	X::Syntax::UnlessElse,Exception,Any,Mu	X::Syntax::UnlessElse,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Variable::BadType	missing	X::Syntax::Variable::BadType,Exception,Any,Mu		X::BadType,X::Comp	
+X::Syntax::Variable::ConflictingTypes	wrong_mro	X::Syntax::Variable::ConflictingTypes,Exception,Any,Mu	X::Syntax::Variable::ConflictingTypes,X::Syntax,X::Comp,Exception,Any,Mu	X::Comp	
+X::Syntax::Variable::IndirectDeclaration	wrong_mro	X::Syntax::Variable::IndirectDeclaration,Exception,Any,Mu	X::Syntax::Variable::IndirectDeclaration,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Variable::Initializer	wrong_mro	X::Syntax::Variable::Initializer,Exception,Any,Mu	X::Syntax::Variable::Initializer,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Variable::Match	missing	X::Syntax::Variable::Match,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Variable::MissingInitializer	missing	X::Syntax::Variable::MissingInitializer,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Variable::Numeric	wrong_mro	X::Syntax::Variable::Numeric,Exception,Any,Mu	X::Syntax::Variable::Numeric,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::Variable::SignatureAssignment	missing	X::Syntax::Variable::SignatureAssignment,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Variable::SignatureWithoutInitializer	missing	X::Syntax::Variable::SignatureWithoutInitializer,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::Variable::Twigil	missing	X::Syntax::Variable::Twigil,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Syntax::VirtualCall	wrong_mro	X::Syntax::VirtualCall,Exception,Any,Mu	X::Syntax::VirtualCall,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Syntax::WithoutElse	wrong_mro	X::Syntax::WithoutElse,Exception,Any,Mu	X::Syntax::WithoutElse,X::Syntax,X::Comp,Exception,Any,Mu	X::Syntax,X::Comp	
+X::Temporal::InvalidFormat	missing	X::Temporal::InvalidFormat,Exception,Any,Mu		X::Temporal	
+X::Temporal::OutOfRange	missing	X::Temporal::OutOfRange,X::OutOfRange,Exception,Any,Mu		X::Temporal	
+X::TooLateForREPR	missing	X::TooLateForREPR,X::Comp,Exception,Any,Mu		X::Comp,X::Comp	
+X::TooManyDimensions	missing	X::TooManyDimensions,Exception,Any,Mu			
+X::Trait::Invalid	missing	X::Trait::Invalid,Exception,Any,Mu		X::Trait	
+X::Trait::NotOnNative	missing	X::Trait::NotOnNative,Exception,Any,Mu		X::Trait	
+X::Trait::Scope	missing	X::Trait::Scope,Exception,Any,Mu		X::Trait	
+X::Trait::Unknown	missing	X::Trait::Unknown,Exception,Any,Mu		X::Trait	
+X::TypeCheck::Attribute::Default	missing	X::TypeCheck::Attribute::Default,X::TypeCheck,Exception,Any,Mu		X::Comp	
+X::TypeCheck::Return	wrong_mro	X::TypeCheck::Return,X::TypeCheck,Exception,Any,Mu	X::TypeCheck::Return,Exception,Any,Mu		
+X::TypeCheck::Splice	missing	X::TypeCheck::Splice,X::TypeCheck,Exception,Any,Mu		X::Comp	
+X::Undeclared	wrong_mro	X::Undeclared,Exception,Any,Mu	X::Undeclared,X::Comp,Exception,Any,Mu	X::Comp	
+X::Undeclared::Symbols	wrong_mro	X::Undeclared::Symbols,Exception,Any,Mu	X::Undeclared::Symbols,X::Comp,Exception,Any,Mu	X::Comp	
+X::UnitScope::Invalid	wrong_roles	X::UnitScope::Invalid,Exception,Any,Mu	X::UnitScope::Invalid,Exception,Any,Mu	X::Syntax,X::Comp	
+X::UnitScope::MustHaveUnit	missing	X::UnitScope::MustHaveUnit,Exception,Any,Mu		X::Syntax,X::Comp	
+X::UnitScope::TooLate	missing	X::UnitScope::TooLate,Exception,Any,Mu		X::Syntax,X::Comp	
+X::Useless::Declaration	missing	X::Useless::Declaration,Exception,Any,Mu		X::Comp	
+X::Value::Dynamic	wrong_mro	X::Value::Dynamic,Exception,Any,Mu	X::Value::Dynamic,X::Value,Exception,Any,Mu	X::Comp	
+X::WheneverOutOfScope	missing	X::WheneverOutOfScope,Exception,Any,Mu			
+X::Worry	missing	X::Worry,Exception,Any,Mu			
+X::Worry::P5	missing	X::Worry::P5,X::Worry,Exception,Any,Mu			
+X::Worry::P5::BackReference	missing	X::Worry::P5::BackReference,X::Worry::P5,X::Worry,Exception,Any,Mu			
+X::Worry::P5::LeadingZero	missing	X::Worry::P5::LeadingZero,X::Worry::P5,X::Worry,Exception,Any,Mu			
+X::Worry::P5::Reference	missing	X::Worry::P5::Reference,X::Worry::P5,X::Worry,Exception,Any,Mu			
+X::Worry::Precedence::Range	missing	X::Worry::Precedence::Range,X::Worry,Exception,Any,Mu			

--- a/TODO_roast/x-exception-role-membership.tsv
+++ b/TODO_roast/x-exception-role-membership.tsv
@@ -1,0 +1,374 @@
+name	mro	roles_direct	roles_all
+X::AdHoc	X::AdHoc,Exception,Any,Mu		
+X::Adverb	X::Adverb,Exception,Any,Mu		
+X::Anon::Augment	X::Anon::Augment,Exception,Any,Mu	X::Comp	X::Comp
+X::Anon::Multi	X::Anon::Multi,Exception,Any,Mu	X::Comp	X::Comp
+X::ArrayShapeMismatch	X::ArrayShapeMismatch,Exception,Any,Mu		
+X::Assignment::ArrayShapeMismatch	X::Assignment::ArrayShapeMismatch,X::ArrayShapeMismatch,Exception,Any,Mu		
+X::Assignment::RO	X::Assignment::RO,Exception,Any,Mu		
+X::Assignment::RO::Comp	X::Assignment::RO::Comp,Exception,Any,Mu	X::Comp	X::Comp
+X::Assignment::ToShaped	X::Assignment::ToShaped,Exception,Any,Mu		
+X::Attribute::NoPackage	X::Attribute::NoPackage,Exception,Any,Mu	X::Comp	X::Comp
+X::Attribute::Package	X::Attribute::Package,Exception,Any,Mu	X::Comp	X::Comp
+X::Attribute::Regex	X::Attribute::Regex,X::Undeclared,Exception,Any,Mu	X::Comp	X::Comp,X::Comp
+X::Attribute::Required	X::Attribute::Required,Exception,Any,Mu	X::MOP	X::MOP
+X::Attribute::Scope::Package	X::Attribute::Scope::Package,Exception,Any,Mu	X::Comp	X::Comp
+X::Attribute::Undeclared	X::Attribute::Undeclared,X::Undeclared,Exception,Any,Mu	X::Comp	X::Comp,X::Comp
+X::Augment::NoSuchType	X::Augment::NoSuchType,Exception,Any,Mu	X::Comp	X::Comp
+X::Backslash::NonVariableDollar	X::Backslash::NonVariableDollar,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Backslash::UnrecognizedSequence	X::Backslash::UnrecognizedSequence,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Bind	X::Bind,Exception,Any,Mu		
+X::Bind::NativeType	X::Bind::NativeType,Exception,Any,Mu	X::Comp	X::Comp
+X::Bind::Rebind	X::Bind::Rebind,X::Bind,Exception,Any,Mu		
+X::Bind::Slice	X::Bind::Slice,Exception,Any,Mu		
+X::Bind::ZenSlice	X::Bind::ZenSlice,X::Bind::Slice,Exception,Any,Mu		
+X::Buf::AsStr	X::Buf::AsStr,Exception,Any,Mu		
+X::Buf::Pack	X::Buf::Pack,Exception,Any,Mu		
+X::Buf::Pack::NonASCII	X::Buf::Pack::NonASCII,Exception,Any,Mu		
+X::Caller::NotDynamic	X::Caller::NotDynamic,X::Symbol::Kind,Exception,Any,Mu		
+X::Cannot::Capture	X::Cannot::Capture,Exception,Any,Mu		
+X::Cannot::Empty	X::Cannot::Empty,Exception,Any,Mu		
+X::Cannot::Lazy	X::Cannot::Lazy,Exception,Any,Mu		
+X::Cannot::Map	X::Cannot::Map,Exception,Any,Mu		
+X::Cannot::New	X::Cannot::New,Exception,Any,Mu		
+X::Channel::ReceiveOnClosed	X::Channel::ReceiveOnClosed,Exception,Any,Mu		
+X::Channel::SendOnClosed	X::Channel::SendOnClosed,Exception,Any,Mu		
+X::Coerce	X::Coerce,Exception,Any,Mu		
+X::Coerce::Impossible	X::Coerce::Impossible,X::Coerce,Exception,Any,Mu		
+X::Coerce::Role	X::Coerce::Role,X::Coerce,Exception,Any,Mu	X::Wrapper	X::Wrapper
+X::Comp::AdHoc	X::Comp::AdHoc,X::AdHoc,Exception,Any,Mu	X::Comp	X::Comp
+X::Comp::BeginTime	X::Comp::BeginTime,Exception,Any,Mu	X::Comp	X::Comp
+X::Comp::FailGoal	X::Comp::FailGoal,Exception,Any,Mu	X::Comp	X::Comp
+X::Comp::Group	X::Comp::Group,Exception,Any,Mu		
+X::Comp::NYI	X::Comp::NYI,X::NYI,Exception,Any,Mu	X::Comp	X::Comp
+X::Comp::Trait::Invalid	X::Comp::Trait::Invalid,X::Trait::Invalid,Exception,Any,Mu	X::Comp,X::Trait	X::Comp,X::Trait,X::Trait
+X::Comp::Trait::NotOnNative	X::Comp::Trait::NotOnNative,X::Trait::NotOnNative,Exception,Any,Mu	X::Comp,X::Trait	X::Comp,X::Trait,X::Trait
+X::Comp::Trait::Scope	X::Comp::Trait::Scope,X::Trait::Scope,Exception,Any,Mu	X::Comp,X::Trait	X::Comp,X::Trait,X::Trait
+X::Comp::Trait::Unknown	X::Comp::Trait::Unknown,X::Trait::Unknown,Exception,Any,Mu	X::Comp,X::Trait	X::Comp,X::Trait,X::Trait
+X::Comp::TypeCheck	X::Comp::TypeCheck,X::TypeCheck,Exception,Any,Mu	X::Comp	X::Comp
+X::Comp::WheneverOutOfScope	X::Comp::WheneverOutOfScope,Exception,Any,Mu	X::Comp	X::Comp
+X::CompUnit::UnsatisfiedDependency	X::CompUnit::UnsatisfiedDependency,Exception,Any,Mu		
+X::Composition::NotComposable	X::Composition::NotComposable,Exception,Any,Mu	X::Comp	X::Comp
+X::Constructor::BadType	X::Constructor::BadType,Exception,Any,Mu	X::BadType	X::BadType
+X::Constructor::Positional	X::Constructor::Positional,Exception,Any,Mu		
+X::ControlFlow	X::ControlFlow,Exception,Any,Mu		
+X::ControlFlow::Return	X::ControlFlow::Return,X::ControlFlow,Exception,Any,Mu		
+X::DateTime::InvalidDeltaUnit	X::DateTime::InvalidDeltaUnit,Exception,Any,Mu	X::Temporal	X::Temporal
+X::DateTime::TimezoneClash	X::DateTime::TimezoneClash,Exception,Any,Mu	X::Temporal	X::Temporal
+X::Declaration::OurScopeInRole	X::Declaration::OurScopeInRole,Exception,Any,Mu	X::Comp	X::Comp
+X::Declaration::Scope	X::Declaration::Scope,Exception,Any,Mu	X::Comp	X::Comp
+X::Declaration::Scope::Multi	X::Declaration::Scope::Multi,X::Declaration::Scope,Exception,Any,Mu	X::Comp	X::Comp,X::Comp
+X::Delete	X::Delete,Exception,Any,Mu		
+X::Does::TypeObject	X::Does::TypeObject,Exception,Any,Mu		
+X::Dynamic::NotFound	X::Dynamic::NotFound,Exception,Any,Mu		
+X::Dynamic::Package	X::Dynamic::Package,Exception,Any,Mu	X::Comp	X::Comp
+X::Dynamic::Postdeclaration	X::Dynamic::Postdeclaration,Exception,Any,Mu	X::Comp	X::Comp
+X::EXPORTHOW::Conflict	X::EXPORTHOW::Conflict,Exception,Any,Mu	X::Comp	X::Comp
+X::EXPORTHOW::InvalidDirective	X::EXPORTHOW::InvalidDirective,Exception,Any,Mu	X::Comp	X::Comp
+X::EXPORTHOW::NothingToSupersede	X::EXPORTHOW::NothingToSupersede,Exception,Any,Mu	X::Comp	X::Comp
+X::Encoding::AlreadyRegistered	X::Encoding::AlreadyRegistered,Exception,Any,Mu	X::Encoding	X::Encoding
+X::Encoding::Unknown	X::Encoding::Unknown,Exception,Any,Mu	X::Encoding	X::Encoding
+X::Enum::NoValue	X::Enum::NoValue,Exception,Any,Mu		
+X::Eval::NoSuchLang	X::Eval::NoSuchLang,Exception,Any,Mu		
+X::Exhausted	X::Exhausted,Exception,Any,Mu		
+X::Experimental	X::Experimental,Exception,Any,Mu	X::Comp	X::Comp
+X::Export::NameClash	X::Export::NameClash,Exception,Any,Mu	X::Comp	X::Comp
+X::Hash::Store::OddNumber	X::Hash::Store::OddNumber,Exception,Any,Mu		
+X::HyperOp::Infinite	X::HyperOp::Infinite,Exception,Any,Mu		
+X::HyperOp::NonDWIM	X::HyperOp::NonDWIM,Exception,Any,Mu		
+X::HyperWhatever::Multiple	X::HyperWhatever::Multiple,Exception,Any,Mu		
+X::IO::BinaryAndEncoding	X::IO::BinaryAndEncoding,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::BinaryMode	X::IO::BinaryMode,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Chdir	X::IO::Chdir,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Chmod	X::IO::Chmod,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Chown	X::IO::Chown,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Closed	X::IO::Closed,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Copy	X::IO::Copy,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Cwd	X::IO::Cwd,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Dir	X::IO::Dir,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Directory	X::IO::Directory,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::DoesNotExist	X::IO::DoesNotExist,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Flush	X::IO::Flush,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Link	X::IO::Link,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Lock	X::IO::Lock,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Mkdir	X::IO::Mkdir,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Move	X::IO::Move,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::NotAChild	X::IO::NotAChild,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::NotAFile	X::IO::NotAFile,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Null	X::IO::Null,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Rename	X::IO::Rename,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Resolve	X::IO::Resolve,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Rmdir	X::IO::Rmdir,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Symlink	X::IO::Symlink,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Unknown	X::IO::Unknown,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IO::Unlink	X::IO::Unlink,Exception,Any,Mu	X::IO	X::IO,X::OS
+X::IllegalDimensionInShape	X::IllegalDimensionInShape,Exception,Any,Mu		
+X::IllegalOnFixedDimensionArray	X::IllegalOnFixedDimensionArray,Exception,Any,Mu		
+X::Immutable	X::Immutable,Exception,Any,Mu		
+X::Import::MissingSymbols	X::Import::MissingSymbols,Exception,Any,Mu		
+X::Import::NoSuchTag	X::Import::NoSuchTag,Exception,Any,Mu		
+X::Import::OnlystarProto	X::Import::OnlystarProto,Exception,Any,Mu	X::Comp	X::Comp
+X::Import::Positional	X::Import::Positional,Exception,Any,Mu		
+X::Import::Redeclaration	X::Import::Redeclaration,Exception,Any,Mu	X::Comp	X::Comp
+X::Inheritance::NotComposed	X::Inheritance::NotComposed,Exception,Any,Mu	X::MOP	X::MOP
+X::Inheritance::SelfInherit	X::Inheritance::SelfInherit,Exception,Any,Mu		
+X::Inheritance::UnknownParent	X::Inheritance::UnknownParent,Exception,Any,Mu		
+X::Inheritance::Unsupported	X::Inheritance::Unsupported,Exception,Any,Mu	X::Comp	X::Comp
+X::Invalid::ComputedValue	X::Invalid::ComputedValue,Exception,Any,Mu		
+X::Invalid::Value	X::Invalid::Value,Exception,Any,Mu		
+X::InvalidCodepoint	X::InvalidCodepoint,Exception,Any,Mu		
+X::InvalidType	X::InvalidType,Exception,Any,Mu	X::Comp	X::Comp
+X::InvalidTypeSmiley	X::InvalidTypeSmiley,Exception,Any,Mu	X::Comp	X::Comp
+X::Ism::Unknown	X::Ism::Unknown,Exception,Any,Mu		
+X::Item	X::Item,Exception,Any,Mu		
+X::Language::IncompatRevisions	X::Language::IncompatRevisions,Exception,Any,Mu		
+X::Language::ModRequired	X::Language::ModRequired,Exception,Any,Mu		
+X::Language::TooLate	X::Language::TooLate,Exception,Any,Mu		
+X::Language::Unsupported	X::Language::Unsupported,Exception,Any,Mu		
+X::LibEmpty	X::LibEmpty,Exception,Any,Mu	X::Comp	X::Comp
+X::LibNone	X::LibNone,Exception,Any,Mu	X::Comp	X::Comp
+X::Localizer::NoContainer	X::Localizer::NoContainer,Exception,Any,Mu		
+X::Lock::Async::NotLocked	X::Lock::Async::NotLocked,Exception,Any,Mu		
+X::Lock::ConditionVariable::Duplicate	X::Lock::ConditionVariable::Duplicate,Exception,Any,Mu		
+X::Lock::ConditionVariable::New	X::Lock::ConditionVariable::New,Exception,Any,Mu		
+X::Lock::ConditionVariable::NoMutex	X::Lock::ConditionVariable::NoMutex,Exception,Any,Mu		
+X::Lock::ConditionVariable::WrongThread	X::Lock::ConditionVariable::WrongThread,Exception,Any,Mu		
+X::Lock::Unlock::NoMutex	X::Lock::Unlock::NoMutex,Exception,Any,Mu		
+X::Lock::Unlock::WrongThread	X::Lock::Unlock::WrongThread,Exception,Any,Mu		
+X::Make::MatchRequired	X::Make::MatchRequired,Exception,Any,Mu		
+X::Match::Bool	X::Match::Bool,Exception,Any,Mu		
+X::Method::Duplicate	X::Method::Duplicate,Exception,Any,Mu		
+X::Method::InvalidQualifier	X::Method::InvalidQualifier,Exception,Any,Mu		
+X::Method::NotFound	X::Method::NotFound,Exception,Any,Mu		
+X::Method::Private::Permission	X::Method::Private::Permission,Exception,Any,Mu	X::Comp	X::Comp
+X::Method::Private::Unqualified	X::Method::Private::Unqualified,Exception,Any,Mu	X::Comp	X::Comp
+X::Mixin::NotComposable	X::Mixin::NotComposable,Exception,Any,Mu		
+X::Multi::Ambiguous	X::Multi::Ambiguous,Exception,Any,Mu		
+X::Multi::NoMatch	X::Multi::NoMatch,Exception,Any,Mu		
+X::MultipleTypeSmiley	X::MultipleTypeSmiley,Exception,Any,Mu	X::Comp	X::Comp
+X::MustBeParametric	X::MustBeParametric,Exception,Any,Mu		
+X::NQP::NotFound	X::NQP::NotFound,Exception,Any,Mu		
+X::NYI	X::NYI,Exception,Any,Mu		
+X::NYI::Available	X::NYI::Available,X::NYI,Exception,Any,Mu		
+X::NYI::BigInt	X::NYI::BigInt,Exception,Any,Mu		
+X::NoCoreRevision	X::NoCoreRevision,Exception,Any,Mu		
+X::NoDispatcher	X::NoDispatcher,Exception,Any,Mu		
+X::NoSuchSymbol	X::NoSuchSymbol,Exception,Any,Mu		
+X::NoZeroArgMeaning	X::NoZeroArgMeaning,Exception,Any,Mu		
+X::Nominalizable::NoKind	X::Nominalizable::NoKind,Exception,Any,Mu	X::Nominalizable	X::Nominalizable
+X::Nominalizable::NoWrappee	X::Nominalizable::NoWrappee,Exception,Any,Mu	X::Nominalizable	X::Nominalizable
+X::NotEnoughDimensions	X::NotEnoughDimensions,Exception,Any,Mu		
+X::NotFoundInRepository	X::NotFoundInRepository,Exception,Any,Mu		
+X::NotParametric	X::NotParametric,Exception,Any,Mu		
+X::NotSingleGrapheme	X::NotSingleGrapheme,Exception,Any,Mu		
+X::Numeric::CannotConvert	X::Numeric::CannotConvert,Exception,Any,Mu		
+X::Numeric::Confused	X::Numeric::Confused,Exception,Any,Mu		
+X::Numeric::DivideByZero	X::Numeric::DivideByZero,Exception,Any,Mu		
+X::Numeric::Overflow	X::Numeric::Overflow,Exception,Any,Mu		
+X::Numeric::Real	X::Numeric::Real,X::Numeric::CannotConvert,Exception,Any,Mu		
+X::Numeric::Underflow	X::Numeric::Underflow,Exception,Any,Mu		
+X::Numeric::Uninitialized	X::Numeric::Uninitialized,Exception,Any,Mu		
+X::Obsolete	X::Obsolete,Exception,Any,Mu	X::Comp	X::Comp
+X::OutOfRange	X::OutOfRange,Exception,Any,Mu		
+X::Package::SameNameAsEnclosing	X::Package::SameNameAsEnclosing,Exception,Any,Mu	X::Comp	X::Comp
+X::Package::Stubbed	X::Package::Stubbed,Exception,Any,Mu	X::Comp	X::Comp
+X::Package::UseLib	X::Package::UseLib,Exception,Any,Mu	X::Comp	X::Comp
+X::Pairup::OddNumber	X::Pairup::OddNumber,Exception,Any,Mu		
+X::Parameter::AfterDefault	X::Parameter::AfterDefault,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Parameter::BadType	X::Parameter::BadType,Exception,Any,Mu	X::BadType,X::Comp	X::BadType,X::Comp
+X::Parameter::Default	X::Parameter::Default,Exception,Any,Mu	X::Comp	X::Comp
+X::Parameter::Default::TypeCheck	X::Parameter::Default::TypeCheck,Exception,Any,Mu	X::Comp	X::Comp
+X::Parameter::InvalidConcreteness	X::Parameter::InvalidConcreteness,Exception,Any,Mu		
+X::Parameter::InvalidType	X::Parameter::InvalidType,Exception,Any,Mu	X::Comp	X::Comp
+X::Parameter::MultipleTypeConstraints	X::Parameter::MultipleTypeConstraints,Exception,Any,Mu	X::Comp	X::Comp
+X::Parameter::Named::SubsetTypeWithoutDefault	X::Parameter::Named::SubsetTypeWithoutDefault,Exception,Any,Mu	X::Comp	X::Comp
+X::Parameter::Placeholder	X::Parameter::Placeholder,Exception,Any,Mu	X::Comp	X::Comp
+X::Parameter::RW	X::Parameter::RW,Exception,Any,Mu		
+X::Parameter::Twigil	X::Parameter::Twigil,Exception,Any,Mu	X::Comp	X::Comp
+X::Parameter::TypedSlurpy	X::Parameter::TypedSlurpy,Exception,Any,Mu	X::Comp	X::Comp
+X::Parameter::WrongOrder	X::Parameter::WrongOrder,Exception,Any,Mu	X::Comp	X::Comp
+X::ParametricConstant	X::ParametricConstant,Exception,Any,Mu		
+X::Phaser::Multiple	X::Phaser::Multiple,Exception,Any,Mu	X::Comp	X::Comp
+X::Phaser::PrePost	X::Phaser::PrePost,Exception,Any,Mu		
+X::PhaserExceptions	X::PhaserExceptions,Exception,Any,Mu		
+X::Placeholder::Attribute	X::Placeholder::Attribute,X::Placeholder::Block,Exception,Any,Mu	X::Comp	X::Comp,X::Comp
+X::Placeholder::Block	X::Placeholder::Block,Exception,Any,Mu	X::Comp	X::Comp
+X::Placeholder::Mainline	X::Placeholder::Mainline,X::Placeholder::Block,Exception,Any,Mu	X::Comp	X::Comp,X::Comp
+X::Placeholder::NonPlaceholder	X::Placeholder::NonPlaceholder,Exception,Any,Mu	X::Comp	X::Comp
+X::PoisonedAlias	X::PoisonedAlias,Exception,Any,Mu	X::Comp	X::Comp
+X::Pragma::CannotPrecomp	X::Pragma::CannotPrecomp,Exception,Any,Mu		
+X::Pragma::CannotWhat	X::Pragma::CannotWhat,Exception,Any,Mu		
+X::Pragma::MustOneOf	X::Pragma::MustOneOf,Exception,Any,Mu		
+X::Pragma::NoArgs	X::Pragma::NoArgs,Exception,Any,Mu		
+X::Pragma::OnlyOne	X::Pragma::OnlyOne,Exception,Any,Mu		
+X::Pragma::Unknown	X::Pragma::Unknown,Exception,Any,Mu		
+X::Pragma::UnknownArg	X::Pragma::UnknownArg,Exception,Any,Mu		
+X::Proc::Async::AlreadyStarted	X::Proc::Async::AlreadyStarted,Exception,Any,Mu	X::Proc::Async	X::Proc::Async
+X::Proc::Async::BindOrUse	X::Proc::Async::BindOrUse,Exception,Any,Mu	X::Proc::Async	X::Proc::Async
+X::Proc::Async::CharsOrBytes	X::Proc::Async::CharsOrBytes,Exception,Any,Mu	X::Proc::Async	X::Proc::Async
+X::Proc::Async::MissingColsRows	X::Proc::Async::MissingColsRows,Exception,Any,Mu	X::Proc::Async	X::Proc::Async
+X::Proc::Async::MustBeStarted	X::Proc::Async::MustBeStarted,Exception,Any,Mu	X::Proc::Async	X::Proc::Async
+X::Proc::Async::OpenForWriting	X::Proc::Async::OpenForWriting,Exception,Any,Mu	X::Proc::Async	X::Proc::Async
+X::Proc::Async::SupplyOrStd	X::Proc::Async::SupplyOrStd,Exception,Any,Mu	X::Proc::Async	X::Proc::Async
+X::Proc::Async::TapBeforeSpawn	X::Proc::Async::TapBeforeSpawn,Exception,Any,Mu	X::Proc::Async	X::Proc::Async
+X::Proc::Unsuccessful	X::Proc::Unsuccessful,Exception,Any,Mu		
+X::Promise::CauseOnlyValidOnBroken	X::Promise::CauseOnlyValidOnBroken,Exception,Any,Mu		
+X::Promise::Combinator	X::Promise::Combinator,Exception,Any,Mu		
+X::Promise::Resolved	X::Promise::Resolved,Exception,Any,Mu		
+X::Promise::Vowed	X::Promise::Vowed,Exception,Any,Mu		
+X::PseudoPackage::InDeclaration	X::PseudoPackage::InDeclaration,Exception,Any,Mu	X::Comp	X::Comp
+X::QuoteWords::Missing::Closer	X::QuoteWords::Missing::Closer,Exception,Any,Mu	X::Comp	X::Comp
+X::REPL::InvalidEnvironment	X::REPL::InvalidEnvironment,Exception,Any,Mu		
+X::Range::CannotIterate	X::Range::CannotIterate,Exception,Any,Mu		
+X::Range::Incomparable	X::Range::Incomparable,Exception,Any,Mu		
+X::Range::InvalidArg	X::Range::InvalidArg,Exception,Any,Mu		
+X::Range::Rand::InvalidEndpoints	X::Range::Rand::InvalidEndpoints,Exception,Any,Mu		
+X::Redeclaration	X::Redeclaration,Exception,Any,Mu	X::Comp	X::Comp
+X::Redeclaration::Multi	X::Redeclaration::Multi,Exception,Any,Mu	X::Comp	X::Comp
+X::Redeclaration::Outer	X::Redeclaration::Outer,Exception,Any,Mu	X::Comp	X::Comp
+X::Role::Attribute::Conflicts	X::Role::Attribute::Conflicts,Exception,Any,Mu	X::Role::Attribute	X::Role::Attribute,X::RoleApplier
+X::Role::Attribute::Exists	X::Role::Attribute::Exists,Exception,Any,Mu	X::Role::Attribute	X::Role::Attribute,X::RoleApplier
+X::Role::BodyReturn	X::Role::BodyReturn,Exception,Any,Mu		
+X::Role::Group::Documenting	X::Role::Group::Documenting,Exception,Any,Mu		
+X::Role::Initialization	X::Role::Initialization,Exception,Any,Mu		
+X::Role::Instantiation	X::Role::Instantiation,Exception,Any,Mu	X::Wrapper	X::Wrapper
+X::Role::Parametric::NoSuchCandidate	X::Role::Parametric::NoSuchCandidate,Exception,Any,Mu		
+X::Role::Unimplemented::Multi	X::Role::Unimplemented::Multi,Exception,Any,Mu	X::RoleApplier::Method,X::RoleApplier	X::RoleApplier::Method,X::RoleApplier
+X::Role::Unresolved	X::Role::Unresolved,Exception,Any,Mu	X::RoleApplier::Method,X::RoleApplier	X::RoleApplier::Method,X::RoleApplier
+X::Role::Unresolved::Method	X::Role::Unresolved::Method,X::Role::Unresolved,Exception,Any,Mu	X::RoleApplier::Method,X::RoleApplier	X::RoleApplier::Method,X::RoleApplier,X::RoleApplier::Method,X::RoleApplier
+X::Role::Unresolved::Multi	X::Role::Unresolved::Multi,X::Role::Unresolved,Exception,Any,Mu	X::RoleApplier::Method,X::RoleApplier	X::RoleApplier::Method,X::RoleApplier,X::RoleApplier::Method,X::RoleApplier
+X::Role::Unresolved::Private	X::Role::Unresolved::Private,X::Role::Unresolved,Exception,Any,Mu	X::RoleApplier::Method,X::RoleApplier	X::RoleApplier::Method,X::RoleApplier,X::RoleApplier::Method,X::RoleApplier
+X::Routine::Unwrap	X::Routine::Unwrap,Exception,Any,Mu		
+X::Scheduler::CueInNaNSeconds	X::Scheduler::CueInNaNSeconds,Exception,Any,Mu		
+X::SecurityPolicy	X::SecurityPolicy,Exception,Any,Mu		
+X::SecurityPolicy::Eval	X::SecurityPolicy::Eval,X::SecurityPolicy,Exception,Any,Mu		
+X::Seq::Consumed	X::Seq::Consumed,Exception,Any,Mu		
+X::Seq::NotIndexable	X::Seq::NotIndexable,Exception,Any,Mu		
+X::Sequence::Deduction	X::Sequence::Deduction,Exception,Any,Mu		
+X::Sequence::Endpoint	X::Sequence::Endpoint,Exception,Any,Mu		
+X::Set::Coerce	X::Set::Coerce,Exception,Any,Mu		
+X::Signature::NameClash	X::Signature::NameClash,Exception,Any,Mu	X::Comp	X::Comp
+X::Signature::Placeholder	X::Signature::Placeholder,Exception,Any,Mu	X::Comp	X::Comp
+X::Str::InvalidCharName	X::Str::InvalidCharName,Exception,Any,Mu		
+X::Str::Match::x	X::Str::Match::x,Exception,Any,Mu		
+X::Str::Numeric	X::Str::Numeric,Exception,Any,Mu		
+X::Str::Sprintf::Directives::BadType	X::Str::Sprintf::Directives::BadType,Exception,Any,Mu		
+X::Str::Sprintf::Directives::Count	X::Str::Sprintf::Directives::Count,Exception,Any,Mu		
+X::Str::Sprintf::Directives::Unsupported	X::Str::Sprintf::Directives::Unsupported,Exception,Any,Mu		
+X::Str::Subst::Adverb	X::Str::Subst::Adverb,Exception,Any,Mu		
+X::Str::Trans::IllegalKey	X::Str::Trans::IllegalKey,Exception,Any,Mu		
+X::Str::Trans::InvalidArg	X::Str::Trans::InvalidArg,Exception,Any,Mu		
+X::StubCode	X::StubCode,Exception,Any,Mu		
+X::Subscript::Negative	X::Subscript::Negative,Exception,Any,Mu		
+X::Supply::Combinator	X::Supply::Combinator,Exception,Any,Mu		
+X::Supply::Migrate::Needs	X::Supply::Migrate::Needs,Exception,Any,Mu		
+X::Supply::New	X::Supply::New,Exception,Any,Mu		
+X::Symbol::Kind	X::Symbol::Kind,Exception,Any,Mu		
+X::Symbol::NotDynamic	X::Symbol::NotDynamic,X::Symbol::Kind,Exception,Any,Mu		
+X::Symbol::NotLexical	X::Symbol::NotLexical,X::Symbol::Kind,Exception,Any,Mu		
+X::Syntax::AddCategorical::TooFewParts	X::Syntax::AddCategorical::TooFewParts,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::AddCategorical::TooManyParts	X::Syntax::AddCategorical::TooManyParts,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Adverb	X::Syntax::Adverb,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::AmbiguousAdverb	X::Syntax::AmbiguousAdverb,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Argument::MOPMacro	X::Syntax::Argument::MOPMacro,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Augment::Adverb	X::Syntax::Augment::Adverb,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Augment::Illegal	X::Syntax::Augment::Illegal,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Augment::WithoutMonkeyTyping	X::Syntax::Augment::WithoutMonkeyTyping,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::BlockGobbled	X::Syntax::BlockGobbled,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::CannotMeta	X::Syntax::CannotMeta,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Coercer::TooComplex	X::Syntax::Coercer::TooComplex,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Comment::Embedded	X::Syntax::Comment::Embedded,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::ConditionalOperator::PrecedenceTooLoose	X::Syntax::ConditionalOperator::PrecedenceTooLoose,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::ConditionalOperator::SecondPartGobbled	X::Syntax::ConditionalOperator::SecondPartGobbled,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::ConditionalOperator::SecondPartInvalid	X::Syntax::ConditionalOperator::SecondPartInvalid,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Confused	X::Syntax::Confused,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Doc::Declarator::MissingDeclarand	X::Syntax::Doc::Declarator::MissingDeclarand,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::DuplicatedPrefix	X::Syntax::DuplicatedPrefix,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Extension::Category	X::Syntax::Extension::Category,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Extension::Null	X::Syntax::Extension::Null,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Extension::SpecialForm	X::Syntax::Extension::SpecialForm,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Extension::TooComplex	X::Syntax::Extension::TooComplex,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::InfixInTermPosition	X::Syntax::InfixInTermPosition,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::KeywordAsFunction	X::Syntax::KeywordAsFunction,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Malformed	X::Syntax::Malformed,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Malformed::Elsif	X::Syntax::Malformed::Elsif,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Missing	X::Syntax::Missing,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Name::Null	X::Syntax::Name::Null,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::NegatedPair	X::Syntax::NegatedPair,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::NoSelf	X::Syntax::NoSelf,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::NonAssociative	X::Syntax::NonAssociative,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::NonListAssociative	X::Syntax::NonListAssociative,X::Syntax::NonAssociative,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp,X::Syntax,X::Comp
+X::Syntax::Number::IllegalDecimal	X::Syntax::Number::IllegalDecimal,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Number::LiteralType	X::Syntax::Number::LiteralType,X::TypeCheck::Assignment,X::TypeCheck,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Number::RadixOutOfRange	X::Syntax::Number::RadixOutOfRange,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::P5	X::Syntax::P5,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::ParentAsHash	X::Syntax::ParentAsHash,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Perl5Var	X::Syntax::Perl5Var,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Pod::BeginWithDirective	X::Syntax::Pod::BeginWithDirective,Exception,Any,Mu	X::Pod,X::Syntax	X::Pod,X::Syntax,X::Comp
+X::Syntax::Pod::BeginWithoutEnd	X::Syntax::Pod::BeginWithoutEnd,Exception,Any,Mu	X::Pod,X::Syntax	X::Pod,X::Syntax,X::Comp
+X::Syntax::Pod::BeginWithoutIdentifier	X::Syntax::Pod::BeginWithoutIdentifier,Exception,Any,Mu	X::Pod,X::Syntax	X::Pod,X::Syntax,X::Comp
+X::Syntax::Pod::DeclaratorLeading	X::Syntax::Pod::DeclaratorLeading,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Pod::DeclaratorTrailing	X::Syntax::Pod::DeclaratorTrailing,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::Adverb	X::Syntax::Regex::Adverb,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::Alias::LongName	X::Syntax::Regex::Alias::LongName,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::InsignificantWhitespace	X::Syntax::Regex::InsignificantWhitespace,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::MalformedRange	X::Syntax::Regex::MalformedRange,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::NonQuantifiable	X::Syntax::Regex::NonQuantifiable,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::NullRegex	X::Syntax::Regex::NullRegex,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::QuantifierValue	X::Syntax::Regex::QuantifierValue,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::SolitaryBacktrackControl	X::Syntax::Regex::SolitaryBacktrackControl,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::SolitaryQuantifier	X::Syntax::Regex::SolitaryQuantifier,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::SpacesInBareRange	X::Syntax::Regex::SpacesInBareRange,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::UnrecognizedMetachar	X::Syntax::Regex::UnrecognizedMetachar,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::UnrecognizedModifier	X::Syntax::Regex::UnrecognizedModifier,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::Unspace	X::Syntax::Regex::Unspace,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Regex::Unterminated	X::Syntax::Regex::Unterminated,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Reserved	X::Syntax::Reserved,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Self::WithoutObject	X::Syntax::Self::WithoutObject,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Signature::InvocantMarker	X::Syntax::Signature::InvocantMarker,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Signature::InvocantNotAllowed	X::Syntax::Signature::InvocantNotAllowed,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Term::MissingInitializer	X::Syntax::Term::MissingInitializer,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Type::Adverb	X::Syntax::Type::Adverb,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::UnlessElse	X::Syntax::UnlessElse,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Variable::BadType	X::Syntax::Variable::BadType,Exception,Any,Mu	X::BadType,X::Comp	X::BadType,X::Comp
+X::Syntax::Variable::ConflictingTypes	X::Syntax::Variable::ConflictingTypes,Exception,Any,Mu	X::Comp	X::Comp
+X::Syntax::Variable::IndirectDeclaration	X::Syntax::Variable::IndirectDeclaration,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Variable::Initializer	X::Syntax::Variable::Initializer,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Variable::Match	X::Syntax::Variable::Match,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Variable::MissingInitializer	X::Syntax::Variable::MissingInitializer,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Variable::Numeric	X::Syntax::Variable::Numeric,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Variable::SignatureAssignment	X::Syntax::Variable::SignatureAssignment,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Variable::SignatureWithoutInitializer	X::Syntax::Variable::SignatureWithoutInitializer,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::Variable::Twigil	X::Syntax::Variable::Twigil,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::VirtualCall	X::Syntax::VirtualCall,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Syntax::WithoutElse	X::Syntax::WithoutElse,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Temporal::InvalidFormat	X::Temporal::InvalidFormat,Exception,Any,Mu	X::Temporal	X::Temporal
+X::Temporal::OutOfRange	X::Temporal::OutOfRange,X::OutOfRange,Exception,Any,Mu	X::Temporal	X::Temporal
+X::TooLateForREPR	X::TooLateForREPR,X::Comp,Exception,Any,Mu	X::Comp	X::Comp,X::Comp
+X::TooManyDimensions	X::TooManyDimensions,Exception,Any,Mu		
+X::Trait::Invalid	X::Trait::Invalid,Exception,Any,Mu	X::Trait	X::Trait
+X::Trait::NotOnNative	X::Trait::NotOnNative,Exception,Any,Mu	X::Trait	X::Trait
+X::Trait::Scope	X::Trait::Scope,Exception,Any,Mu	X::Trait	X::Trait
+X::Trait::Unknown	X::Trait::Unknown,Exception,Any,Mu	X::Trait	X::Trait
+X::TypeCheck	X::TypeCheck,Exception,Any,Mu		
+X::TypeCheck::Argument	X::TypeCheck::Argument,X::TypeCheck,Exception,Any,Mu		
+X::TypeCheck::Assignment	X::TypeCheck::Assignment,X::TypeCheck,Exception,Any,Mu		
+X::TypeCheck::Attribute::Default	X::TypeCheck::Attribute::Default,X::TypeCheck,Exception,Any,Mu	X::Comp	X::Comp
+X::TypeCheck::Binding	X::TypeCheck::Binding,X::TypeCheck,Exception,Any,Mu		
+X::TypeCheck::Binding::Parameter	X::TypeCheck::Binding::Parameter,X::TypeCheck::Binding,X::TypeCheck,Exception,Any,Mu		
+X::TypeCheck::Return	X::TypeCheck::Return,X::TypeCheck,Exception,Any,Mu		
+X::TypeCheck::Splice	X::TypeCheck::Splice,X::TypeCheck,Exception,Any,Mu	X::Comp	X::Comp
+X::Undeclared	X::Undeclared,Exception,Any,Mu	X::Comp	X::Comp
+X::Undeclared::Symbols	X::Undeclared::Symbols,Exception,Any,Mu	X::Comp	X::Comp
+X::UnitScope::Invalid	X::UnitScope::Invalid,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::UnitScope::MustHaveUnit	X::UnitScope::MustHaveUnit,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::UnitScope::TooLate	X::UnitScope::TooLate,Exception,Any,Mu	X::Syntax	X::Syntax,X::Comp
+X::Useless::Declaration	X::Useless::Declaration,Exception,Any,Mu	X::Comp	X::Comp
+X::Value::Dynamic	X::Value::Dynamic,Exception,Any,Mu	X::Comp	X::Comp
+X::WheneverOutOfScope	X::WheneverOutOfScope,Exception,Any,Mu		
+X::Worry	X::Worry,Exception,Any,Mu		
+X::Worry::P5	X::Worry::P5,X::Worry,Exception,Any,Mu		
+X::Worry::P5::BackReference	X::Worry::P5::BackReference,X::Worry::P5,X::Worry,Exception,Any,Mu		
+X::Worry::P5::LeadingZero	X::Worry::P5::LeadingZero,X::Worry::P5,X::Worry,Exception,Any,Mu		
+X::Worry::P5::Reference	X::Worry::P5::Reference,X::Worry::P5,X::Worry,Exception,Any,Mu		
+X::Worry::Precedence::Range	X::Worry::Precedence::Range,X::Worry,Exception,Any,Mu		

--- a/scripts/adr0029-capture-x-exception-data.py
+++ b/scripts/adr0029-capture-x-exception-data.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""ADR-0029 Slice 2: mechanically capture the real `X::` exception shape.
+
+Per ADR-0029 (docs/adr/0029-exception-class-role-membership.md), mutsu's
+`register_x` hand-modelled `X::` ancestry as single inheritance for years,
+which is wrong for the ~59% of `X::` classes that actually compose one or
+more marker roles in rakudo (X::Comp, X::Syntax, X::IO, ...). This script is
+the "never hand transcription" data source the ADR requires: it derives a
+name list mechanically (never from an `X::`-prefix enumeration), asks a
+*single* real `raku` process for each name's true `.^mro` / `.^roles`, and
+diffs that against what mutsu currently reports (also via a single mutsu
+process, using the same probe program).
+
+Regeneration recipe:
+    python3 scripts/adr0029-capture-x-exception-data.py
+    # writes:
+    #   TODO_roast/x-exception-role-membership.tsv       (Slice 3's input)
+    #   TODO_roast/x-exception-role-membership-diff.tsv  (mutsu vs raku, today)
+    # and prints a summary to stdout.
+
+Requires `raku` on PATH and a built `target/debug/mutsu` (or set MUTSU_BIN).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROBE = REPO_ROOT / "scripts" / "probe-x-exception-shape.raku"
+OUT_DATA = REPO_ROOT / "TODO_roast" / "x-exception-role-membership.tsv"
+OUT_DIFF = REPO_ROOT / "TODO_roast" / "x-exception-role-membership-diff.tsv"
+
+# Hard rule (ADR-0029 Slice 2): the name list comes from what mutsu raises or
+# is tested against -- never an `X::`-prefix enumeration. Two sources:
+#   1. `throws-like` / `fails-like` / `isa-ok` expected types in t/ + roast/.
+#   2. `X::...` string literals in mutsu's own source (what it can raise).
+# Names that don't resolve to a real rakudo Exception subtype (test-local
+# classes like `X::Boom`, or bare-package namespaces like `X::Numeric`) are
+# dropped by the raku probe itself, not guessed at here.
+TEST_ASSERTION_RE = re.compile(
+    r"(?:throws-like|fails-like)\s*\{?[^,\n]*,\s*(X::[A-Za-z0-9_:]+)"
+    r"|isa-ok\s+\S+,\s*(X::[A-Za-z0-9_:]+)"
+)
+SRC_LITERAL_RE = re.compile(r'"(X::[A-Za-z0-9_:]+)"')
+
+
+def derive_name_list() -> list[str]:
+    names: set[str] = set()
+    for base in (REPO_ROOT / "t", REPO_ROOT / "roast"):
+        for path in base.rglob("*.t"):
+            text = path.read_text(errors="replace")
+            for m in TEST_ASSERTION_RE.finditer(text):
+                names.add(m.group(1) or m.group(2))
+    for path in (REPO_ROOT / "src").rglob("*.rs"):
+        text = path.read_text(errors="replace")
+        for m in SRC_LITERAL_RE.finditer(text):
+            names.add(m.group(1))
+    return sorted(names)
+
+
+def run_probe(interpreter: list[str], names: list[str]) -> dict[str, tuple[str, str, str] | None]:
+    """Run the probe script once, feeding all names over stdin. Returns
+    name -> None (not a real Exception subtype) or (mro, roles_direct,
+    roles_all), each a comma-joined `.^name` list."""
+    proc = subprocess.run(
+        [*interpreter, str(PROBE)],
+        input="\n".join(names) + "\n",
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    if proc.returncode != 0:
+        print(f"probe failed ({' '.join(interpreter)}): {proc.stderr}", file=sys.stderr)
+        sys.exit(1)
+    result: dict[str, tuple[str, str, str] | None] = {}
+    for line in proc.stdout.splitlines():
+        cols = line.split("\t")
+        if len(cols) == 2 and cols[1] == "0":
+            result[cols[0]] = None
+        elif len(cols) == 5:
+            result[cols[0]] = (cols[2], cols[3], cols[4])
+    return result
+
+
+def main() -> None:
+    mutsu_bin = REPO_ROOT / "target" / "debug" / "mutsu"
+    names = derive_name_list()
+    print(f"derived {len(names)} candidate names (never hand-typed)")
+
+    raku_data = run_probe(["raku"], names)
+    real = {n: shape for n, shape in raku_data.items() if shape is not None}
+    print(f"{len(real)} / {len(names)} are real rakudo Exception subtypes")
+
+    OUT_DATA.parent.mkdir(parents=True, exist_ok=True)
+    with OUT_DATA.open("w") as f:
+        f.write("name\tmro\troles_direct\troles_all\n")
+        for name in sorted(real):
+            mro, roles_direct, roles_all = real[name]
+            f.write(f"{name}\t{mro}\t{roles_direct}\t{roles_all}\n")
+    print(f"wrote {OUT_DATA.relative_to(REPO_ROOT)}")
+
+    mutsu_data = run_probe([str(mutsu_bin)], sorted(real))
+    counts: Counter[str] = Counter()
+    with OUT_DIFF.open("w") as f:
+        f.write("name\tcategory\traku_mro\tmutsu_mro\traku_roles_all\tmutsu_roles_all\n")
+        for name in sorted(real):
+            raku_mro, _raku_roles_direct, raku_roles_all = real[name]
+            mutsu_shape = mutsu_data.get(name)
+            if mutsu_shape is None:
+                category = "missing"
+                mutsu_mro = mutsu_roles_all = ""
+            else:
+                mutsu_mro, _mutsu_roles_direct, mutsu_roles_all = mutsu_shape
+                if mutsu_mro != raku_mro:
+                    category = "wrong_mro"
+                elif mutsu_roles_all != raku_roles_all:
+                    category = "wrong_roles"
+                else:
+                    category = "match"
+            counts[category] += 1
+            if category != "match":
+                f.write(
+                    f"{name}\t{category}\t{raku_mro}\t{mutsu_mro}\t"
+                    f"{raku_roles_all}\t{mutsu_roles_all}\n"
+                )
+    print(f"wrote {OUT_DIFF.relative_to(REPO_ROOT)}")
+    for category in ("match", "wrong_mro", "wrong_roles", "missing"):
+        print(f"  {category}: {counts[category]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe-x-exception-shape.raku
+++ b/scripts/probe-x-exception-shape.raku
@@ -1,0 +1,48 @@
+#!/usr/bin/env raku
+# ADR-0029 Slice 2: probe the real shape of a list of `X::` (or any) type
+# names -- one process, one pass, run identically under both `raku` (the
+# oracle) and `mutsu` (to diff against).
+#
+# Reads one name per line from STDIN (e.g. "X::Comp::AdHoc"). For each name
+# that resolves to a real Exception subtype, prints a TSV row:
+#   name  found  mro          roles_direct   roles_all
+# `mro`/`roles_direct`/`roles_all` are comma-joined `.^name` lists in the
+# order the metamodel returns them. A name that does not resolve (mutsu has
+# not registered it yet, or the name is test-local, e.g. a roast-only
+# `X::Boom`) prints only `name  0` -- callers must not guess at its shape.
+#
+# Usage: raku scripts/probe-x-exception-shape.raku < names.txt > out.tsv
+#        mutsu scripts/probe-x-exception-shape.raku < names.txt > out.tsv
+
+for lines() -> $name {
+    next unless $name.chars;
+    my $type = ::($name);
+    # Type objects are legitimately undefined -- do NOT gate on `.defined`.
+    # An unresolved symbol comes back as a `Failure`, which does not smartmatch
+    # `Exception` (it is not itself an exception type), so this one check
+    # covers both "unknown name" and "resolves to something that isn't an
+    # Exception subtype".
+    # A role that composes into Exception subtypes (e.g. `X::Comp` itself)
+    # smartmatches `Exception` too, but has no `.^mro` -- only classes are
+    # `register_x` candidates, so treat a role-shaped name (anything not a
+    # plain ClassHOW) as not-found here.
+    if !($type ~~ Exception) || !($type.HOW ~~ Metamodel::ClassHOW) {
+        say "$name\t0";
+        next;
+    }
+    my @mro = $type.^mro.map(*.^name);
+    # mutsu's `::($name)` dynamic lookup auto-vivifies a phantom stub class
+    # for a name it has never registered (mro `(name Any Mu)`, no Exception
+    # in it -- a separate mutsu bug, see
+    # todo/tickets/dynamic-package-lookup-autovivifies-unknown-class.md).
+    # A genuinely-registered `X::` exception class's mro always contains
+    # `Exception` (`register_x` guarantees it), so this also doubles as the
+    # "not really found" signal for that stub.
+    if $name ne 'Exception' && !@mro.grep('Exception') {
+        say "$name\t0";
+        next;
+    }
+    my @roles-direct = $type.^roles(:!transitive).map(*.^name);
+    my @roles-all = $type.^roles.map(*.^name);
+    say "$name\t1\t{@mro.join(',')}\t{@roles-direct.join(',')}\t{@roles-all.join(',')}";
+}

--- a/todo/tickets/dynamic-symbol-lookup-phantom-class-for-known-type-name.md
+++ b/todo/tickets/dynamic-symbol-lookup-phantom-class-for-known-type-name.md
@@ -1,0 +1,91 @@
+# Dynamic symbol lookup (`::($name)`) returns a phantom class for a "known type name" that isn't actually registered
+
+Discovered while building ADR-0029 Slice 2's mechanical raku-vs-mutsu diff
+script (`scripts/adr0029-capture-x-exception-data.py`,
+`scripts/probe-x-exception-shape.raku`): dynamic symbol lookup on a compound
+name (`::($name)` where `$name` contains `::`) does not distinguish "a real
+registered class" from "a name the parser/type-checker layer merely
+*recognizes* as a valid type constraint" (`is_known_compound_type` /
+`is_known_type_constraint` in `src/runtime/utils/type_constraints.rs`, a
+large hardcoded match list consulted from a dozen call sites across the
+parser and runtime for signature/`given`/ternary/role-body type-name
+disambiguation).
+
+## Repro
+
+```
+$ target/debug/mutsu -e '
+my $type = ::("X::Anon::Augment");
+say $type.^name;             # X::Anon::Augment (looks right)
+say $type.^mro.map(*.^name); # (X::Anon::Augment Any Mu)  -- no Exception!
+say $type ~~ Exception;      # True                       -- inconsistent
+say $type.WHAT;              # (Augment)                  -- wrong short name in gist
+'
+$ target/debug/mutsu -e 'X::Anon::Augment.new'
+X::Method::NotFound: Unknown method value dispatch (fallback disabled): new on X::Anon::Augment
+```
+
+So `X::Anon::Augment` is genuinely unregistered (`.new` correctly fails), but
+`::("X::Anon::Augment")` silently returns *something* that smartmatches
+`Exception` and carries a `ClassHOW`, rather than the `Failure` real `raku`
+returns for the same unregistered name. This makes any code path that
+resolves a type by dynamic string and then trusts `~~`/`.HOW` (rather than
+calling a method on it) get a false positive.
+
+## Root cause
+
+`src/runtime/accessors_stash.rs` (~line 253-259), the dynamic-symbol-lookup
+helper:
+
+```rust
+if name.contains("::")
+    && (crate::runtime::utils::is_known_compound_type(name)
+        || self.has_class(name)
+        || self.is_role(name))
+{
+    return Value::package(Symbol::intern(name));
+}
+```
+
+`is_known_compound_type` succeeds for any name in the large hardcoded
+whitelist in `type_constraints.rs` (which includes almost every `X::` name
+mentioned anywhere, including ones never registered via `register_x`), and
+the branch returns a *bare* `Value::package(Symbol::intern(name))` with no
+check that the class actually exists in `registry.classes`. Downstream,
+`.^mro` for this unregistered-but-"known" name falls through to
+`classhow_mro_names`'s builtin/default branch (`vec![class_name.clone()]`
+plus `Any`/`Mu`), which is why `Exception` is missing from the chain, and
+some other path (not yet identified) makes `~~ Exception` answer `True`
+anyway despite `Exception` not being in that mro — that inconsistency is
+itself worth another look once the root symbol-resolution gap is fixed.
+
+## Why this is a separate finding, not part of ADR-0029
+
+`docs/adr/0029-exception-class-role-membership.md` is about *modelling* `X::`
+ancestry correctly for classes that *are* registered; it doesn't touch
+`::($name)`/`is_known_type_constraint`. This bug is about the gap between
+"the parser accepts this bareword as a type-shaped name" and "the runtime
+has actually registered a class for it" -- a different, and probably
+architecturally bigger, seam (the `is_known_type_constraint` whitelist is
+consulted from ~14 call sites; fixing this properly likely means making
+dynamic lookup consult the *same* registry check `X::Foo.new` already uses,
+not adding another special case).
+
+## Suggested fix direction (not investigated further)
+
+`accessors_stash.rs`'s compound-name branch should not treat
+`is_known_compound_type` as sufficient on its own to return a package value
+identical in shape to a real registered class -- either gate it on
+`self.has_class(name) || self.is_role(name)` (dropping the
+`is_known_compound_type` disjunct entirely, if nothing relies on the
+loose acceptance for `::($name)` specifically), or mark the returned package
+value as an unresolved/"known-but-not-a-class" stub that `~~`/`.^mro`
+consumers can distinguish from a real registration.
+
+## How it was worked around for Slice 2
+
+`scripts/probe-x-exception-shape.raku` treats a resolved type as "not
+really found" whenever `Exception` is absent from its `.^mro` list (true
+for every genuinely `register_x`-registered class, since `register_x`
+always appends `Exception` if missing) -- this is a correct proxy for Slice
+2's purposes and does not need this ticket fixed first.


### PR DESCRIPTION
## Summary
ADR-0029 Slice 2: a checked-in probe (`scripts/probe-x-exception-shape.raku`, run identically under `raku` and `mutsu`) plus a driver (`scripts/adr0029-capture-x-exception-data.py`) that derives an `X::` name list mechanically — from `throws-like`/`fails-like`/`isa-ok` expected types in `t/`+`roast/` and `X::`-string literals in `src/`, **never an `X::`-prefix enumeration** — and asks a single real `raku` process for each name's true `.^mro` / `.^roles(:!transitive)` / `.^roles`.

- `TODO_roast/x-exception-role-membership.tsv`: the 373 real rakudo Exception subtypes found, with their real ancestry. This is Slice 3's input.
- `TODO_roast/x-exception-role-membership-diff.tsv`: mutsu's current answer for each, diffed against raku (50 match, 44 wrong_mro, 18 wrong_roles, 261 missing/unregistered). The wrong_mro/wrong_roles counts line up with the ADR's own measurement (43 wrong `.^mro` / 52 wrong `.^roles` on the narrower corpus it hand-checked).
- `todo/tickets/dynamic-symbol-lookup-phantom-class-for-known-type-name.md`: building the mutsu-side probe surfaced that `::($name)` dynamic symbol lookup returns a phantom `ClassHOW` package (missing `Exception` from its mro, yet smartmatching `Exception` anyway) for any name in the large `is_known_type_constraint` whitelist, even when the class was never registered — a real, separate bug, worked around in the probe by treating "`Exception` not in `.^mro`" as not-found (true for every genuinely `register_x`-registered class). Filed as its own ticket, out of scope for this ADR.

Regeneration recipe is in the driver script's module docstring: `python3 scripts/adr0029-capture-x-exception-data.py` (requires `raku` on PATH and a built `target/debug/mutsu`).

## Test plan
- [x] Manually verified the probe against known-good (`X::Comp::AdHoc`, `X::Syntax::Confused`) and known-bad (`X::Boom`, `X::Numeric`) names under both `raku` and `mutsu`.
- [x] Full driver run reproduces the ADR's §1 hand-measured 43-wrong-mro figure almost exactly (44 here, on a slightly different/broader candidate list).
- No Rust changes in this PR (script + data only); `cargo fmt --check` / `cargo clippy` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)