### PR TITLE
fix(parser): a statement immediately after `my constant ...;` no longer misparses

### DIFF
--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -137,7 +137,18 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
             quoted: false,
         };
         let (r, _) = ws(r)?;
-        let (r, _) = opt_char(r, ';');
+        // Leave a trailing `;` for the caller: `my_decl_dispatch.rs`'s "my
+        // constant" branch applies `parse_statement_modifier` to this
+        // function's returned remainder, which itself checks for a leading
+        // `;` to know the statement is already terminated (no modifier
+        // possible). Consuming it here first made that check see the NEXT
+        // line's content instead and misparse a following `if`/`unless`/...
+        // statement as a dangling modifier condition
+        // (`todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md`).
+        // A bare top-level `constant ...;` (no `my`) still parses fine: the
+        // statement-list driver skips a leftover `;` between statements
+        // generically (`stmt_list_with_mode`'s own `while input.starts_with(';')`
+        // loop).
         return Ok((
             r,
             Stmt::VarDecl {
@@ -171,7 +182,9 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
             super::super::simple::register_compile_time_constant(&name, s.to_string());
         }
         let (rest, _) = ws(rest)?;
-        let (rest, _) = opt_char(rest, ';');
+        // See the matching comment in the `.=` branch above: do not consume
+        // a trailing `;` here, so `parse_statement_modifier` (applied by
+        // `my_decl_dispatch.rs`'s "my constant" branch) can still see it.
         return Ok((
             rest,
             Stmt::VarDecl {

--- a/t/constant-elsif-statement-boundary.t
+++ b/t/constant-elsif-statement-boundary.t
@@ -1,0 +1,49 @@
+use Test;
+
+# `constant_decl` used to eagerly consume its own trailing `;` before
+# `my_decl_dispatch.rs`'s "my constant" branch applied
+# `parse_statement_modifier` to the remainder. That check relies on seeing a
+# leading `;` to know the statement is already terminated (no modifier
+# possible) -- with the `;` already gone, an immediately-following `if`/
+# `unless`/`for`/etc. statement was misparsed as a dangling statement
+# modifier on the constant declaration, and the block that should have been
+# the `if`'s body became an orphan bare-block statement, leaving `elsif` to
+# be parsed as an undeclared bareword function call.
+# todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md
+
+plan 5;
+
+{
+    my constant $x = 5;
+    if 1 == 2 { say "unreached" }
+    elsif 1 == 1 { pass 'my constant scalar followed immediately by if/elsif' }
+    else { flunk 'wrong branch' }
+}
+
+{
+    my constant %svals = 20 => False, 21 => True;
+    if 1 == 2 { say "unreached" }
+    elsif 1 == 1 { pass 'my constant hash followed immediately by if/elsif' }
+    else { flunk 'wrong branch' }
+}
+
+{
+    my Int constant $x = 5;
+    if 1 == 2 { say "unreached" }
+    elsif 1 == 1 { pass 'my typed constant followed immediately by if/elsif' }
+    else { flunk 'wrong branch' }
+}
+
+{
+    constant $y = 7;
+    if 1 == 2 { say "unreached" }
+    elsif 1 == 1 { pass 'bare (non-my) constant followed immediately by if/elsif' }
+    else { flunk 'wrong branch' }
+}
+
+{
+    my constant $z = 9;
+    unless False {
+        pass 'my constant followed immediately by unless';
+    }
+}

--- a/todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md
+++ b/todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md
@@ -84,6 +84,28 @@ next step is `--dump-ast` on the minimal repro to see how the parser's
 statement-boundary detection after `my constant` differs from after a plain
 `my`.
 
+## Update (2026-08-18): the `my constant` + `elsif` parser bug is fixed
+
+The minimal repro from the 2026-08-14 update above is fixed
+(`src/parser/stmt/decl/constant_subset.rs`): `constant_decl` was eagerly
+consuming its own trailing `;` before returning, so when
+`my_decl_dispatch.rs`'s "my constant" branch applied
+`parse_statement_modifier` to the remainder, that function's own "if there's
+a semicolon, the statement is already terminated" check never fired (the
+`;` was already gone) — it instead misparsed the immediately-following
+`if`/`elsif`/... statement as a dangling statement modifier on the constant
+declaration. Fixed by leaving the `;` for the caller (matching how a plain
+`my $x = 5;` already behaves); pinned by
+`t/constant-elsif-statement-boundary.t`. `decode-sval`'s `if`/`elsif` chain
+in `Simple.rakumod:734` should now parse correctly — not yet re-verified
+against the full round-trip or the `06-typed-arrays.rakutest` /
+`01`-`05` file triage below, which remain open.
+
+(A related but separate bug was found and filed apart from this one:
+`todo/tickets/constant-statement-modifier-value-lost.md` — a GENUINE
+statement modifier on `constant`, e.g. `my constant $w = 11 if True;`, parses
+fine but the bound value is lost, `$w` reads back `Any` instead of `11`.)
+
 ## Reproduce
 
 ```sh

--- a/todo/tickets/constant-statement-modifier-value-lost.md
+++ b/todo/tickets/constant-statement-modifier-value-lost.md
@@ -1,0 +1,41 @@
+# A statement-modifier `if`/`unless` on `constant`/`my constant` loses the value
+
+```raku
+my constant $w = 11 if True;
+say $w;
+# raku:  11
+# mutsu: (Any)
+```
+
+Confirmed pre-existing (reproduces identically before and after the
+`constant_decl` semicolon fix in
+`todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md`'s
+"Undeclared routine: elsif used" investigation — that fix only addressed a
+following NEW statement being misparsed as a modifier; this is about a
+GENUINE modifier not taking effect).
+
+## Root cause (not yet investigated)
+
+`parse_statement_modifier` (`src/parser/stmt/modifier.rs`) correctly parses
+`my constant $w = 11 if True;` as a statement-modifier-wrapped `VarDecl` (it
+must, since the file is accepted without a parse error), but whatever the
+compiler does with a modifier-wrapped `VarDecl` carrying `__constant` custom
+traits does not actually bind `$w` — it ends up `Any` (undefined) rather than
+`11`. Plausibly the modifier-wrapping produces an `Stmt::If`-like conditional
+execution shape around the `VarDecl`, and the compiler's constant-binding
+path (which likely evaluates/registers the constant at a fixed point,
+possibly compile-time-ish via `BEGIN`-like handling — see
+`constant-begin-initializer.t`) does not know how to handle being nested
+inside that conditional, silently skipping the bind.
+
+## Repro
+
+```raku
+my constant $w = 11 if True;
+say $w;   # raku: 11, mutsu: (Any)
+```
+
+Also worth checking whether a bare (non-`my`) `constant $w = 11 if True;`
+and a `False`-condition case (`... if False;` — should `$w` even be declared
+at all in that case? worth checking against raku) have the same or a
+different shape.


### PR DESCRIPTION
## Summary
- `constant_decl` (`src/parser/stmt/decl/constant_subset.rs`) consumed its own trailing `;` before returning, so `my_decl_dispatch.rs`'s "my constant" branch applying `parse_statement_modifier` to the remainder never saw a leading `;` — its own signal that the statement is already terminated (no modifier possible).
- An immediately-following `if`/`unless`/`for`/... statement was therefore misread as a dangling statement modifier on the constant declaration: `my constant $x = 5; if COND { A } elsif COND2 { B }` turned the `if`'s block into an orphan bare-block statement and left `elsif` to be parsed as an undeclared bareword call ("Undeclared routine: elsif used").
- Fix leaves the `;` for the caller instead, matching how a plain `my $x = 5;` already behaves — the statement-list driver's own leftover-`;` skip still handles the bare (non-`my`) `constant ...;` case correctly.
- Found while working `todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md` (this was blocking `CBOR::Simple`'s `decode-sval`'s `if`/`elsif` chain); files a separate ticket, `todo/tickets/constant-statement-modifier-value-lost.md`, for an unrelated pre-existing bug found while testing this fix: a genuine statement modifier on `constant` (`my constant $w = 11 if True;`) parses fine but loses the bound value.

## Test plan
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New `t/constant-elsif-statement-boundary.t` — scalar/hash/typed/bare `constant` forms, all immediately followed by `if`/`elsif`/`unless`
- [x] `make test` — 3208 files, all pass (this touches core statement parsing, ran the full local suite rather than a targeted subset)
- [ ] CI (`make roast`)