### PR TITLE
fix: hash-scalar symbolic hyper op keeps object-hash identity

### DIFF
--- a/news/2026-08/hash-scalar-hyperop-keeps-object-hash-identity.md
+++ b/news/2026-08/hash-scalar-hyperop-keeps-object-hash-identity.md
@@ -1,0 +1,29 @@
+# A symbolic hash-scalar hyper op no longer demotes an object hash to a plain Hash
+
+`%h{Any} >>op>> scalar` (and the other dwim-valid arrow combinations —
+`<<op>>`/`3 <<op<<`/`3 <<op>>`) silently lost the hash's object-hash identity:
+`(%h{Any} >>~>> 3).WHAT` reported `(Hash)` instead of `(Hash[Any,Any])`, and
+`.raku` rendered the plain `{...}` form instead of the typed
+`(my Any %{Any} = ...)` form.
+
+Root cause: `Interpreter::hyper_op_pair`'s two hash-vs-scalar branches
+(`vm/vm_hyper_ops.rs`) built a fresh `HashData` for the result, copying only
+the key/value pairs and dropping `key_type`/`value_type`/`declared_type`/
+`original_keys` — even though the key set does not change in this branch, so
+there is no reason the metadata should be lost. The hash-vs-hash branch
+immediately above it already carried this metadata over correctly; the
+hash-vs-scalar branches were simply missed.
+
+Fixed by copying the source hash's type metadata onto the result, mirroring
+the hash-hash branch and the `tagged_hash` helper `vm_hyper_func.rs` already
+uses for the same purpose on the `&op`/`&metaop` lexical-variable call path.
+
+Pinned by `t/hyper-hash-scalar-object-hash-type.t` (8 assertions, covering
+all four dwim-valid arrow combinations in both operand orders, plus a
+non-`Str`-keyed object hash), verified against `raku`.
+
+Found while investigating `roast/S03-metaops/infix.t`'s regression under the
+real `Test.rakumod` (`todo/deep/vendor-real-test-module.md`); the file's own
+171 failing subtests turned out to be a different, deeper bug in hash
+container-identity write-through, tracked separately in
+`todo/deep/hash-pointy-param-writeback-loses-object-hash-identity.md`.

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -321,6 +321,10 @@ impl Interpreter {
         }
         // Hyper op between a hash and a scalar: apply the op to each value with
         // the scalar broadcast over every key (`%h >>*>> 4`, `2 <<**<< %h`).
+        // The key set is untouched, so object-hash / typed-hash identity
+        // (`key_type`/`value_type`/`declared_type`/`original_keys`) carries
+        // straight over from the source hash -- otherwise `%h{Any} >>op>> 3`
+        // silently demotes to a plain Hash.
         if let ValueView::Hash(map) = left.view()
             && !Self::is_listy(right)
         {
@@ -330,7 +334,12 @@ impl Interpreter {
                 let v = self.hyper_op_pair(op, value, right, dwim_left, dwim_right)?;
                 result.insert(key.clone(), v);
             }
-            return Ok(Value::hash_with_data(Value::hash_arc(result)));
+            let mut data = crate::value::HashData::new(result);
+            data.key_type = map.key_type.clone();
+            data.value_type = map.value_type.clone();
+            data.declared_type = map.declared_type.clone();
+            data.original_keys = map.original_keys.clone();
+            return Ok(Value::hash_with_data(Value::hash_arc(data)));
         }
         if let ValueView::Hash(map) = right.view()
             && !Self::is_listy(left)
@@ -341,7 +350,12 @@ impl Interpreter {
                 let v = self.hyper_op_pair(op, left, value, dwim_left, dwim_right)?;
                 result.insert(key.clone(), v);
             }
-            return Ok(Value::hash_with_data(Value::hash_arc(result)));
+            let mut data = crate::value::HashData::new(result);
+            data.key_type = map.key_type.clone();
+            data.value_type = map.value_type.clone();
+            data.declared_type = map.declared_type.clone();
+            data.original_keys = map.original_keys.clone();
+            return Ok(Value::hash_with_data(Value::hash_arc(data)));
         }
         // A Pair leaf broadcasts the op into its `.value`, keeping `.key`
         // unchanged (https://github.com/rakudo/rakudo/issues/4700). Only

--- a/t/hyper-hash-scalar-object-hash-type.t
+++ b/t/hyper-hash-scalar-object-hash-type.t
@@ -1,0 +1,30 @@
+use Test;
+
+plan 8;
+
+# A symbolic hyper op (`>>op>>`/`<<op<<`) between an object hash and a
+# scalar must preserve the hash's object-hash identity (key_type /
+# original_keys) -- the key set does not change, only the values, so the
+# result should still report `Hash[Any,Any]`, not degrade to a plain Hash.
+# Regression: `hyper_op_pair`'s hash-scalar branches built a fresh plain
+# HashData, dropping `key_type`/`value_type`/`declared_type`/`original_keys`.
+
+my %a{Any} = a => 1, b => 2, c => 3;
+
+# The scalar operand must be on a dwim-adjacent side to broadcast, so only
+# these arrow combinations are valid hash-vs-scalar hyper ops (verified
+# against `raku`; the others die with X::HyperOp::NonDWIM).
+is (%a >>~>> 3).WHAT.raku, 'Hash[Any,Any]', '%h{Any} >>op>> scalar keeps object-hash type';
+is (%a <<~>> 3).WHAT.raku, 'Hash[Any,Any]', '%h{Any} <<op>> scalar keeps object-hash type';
+is (3 <<~<< %a).WHAT.raku, 'Hash[Any,Any]', 'scalar <<op<< %h{Any} keeps object-hash type';
+is (3 <<~>> %a).WHAT.raku, 'Hash[Any,Any]', 'scalar <<op>> %h{Any} keeps object-hash type';
+
+is-deeply (%a >>~>> 3).raku, '(my Any %{Any} = :a("13"), :b("23"), :c("33"))',
+    '%h{Any} >>op>> scalar renders as a typed object hash';
+
+# A key-type-mismatched key object (non-Str) is preserved through the op too.
+my %o{Any} = 1 => "x", 2 => "y";
+is-deeply %o.keys.map(*.^name).sort.list, ("Int", "Int"), 'sanity: %o has Int keys';
+is (%o >>~>> "!").WHAT.raku, 'Hash[Any,Any]', '%h{Any} with non-Str keys keeps object-hash type through hyper op';
+is-deeply (%o >>~>> "!").keys.map(*.^name).sort.list, ("Int", "Int"),
+    'non-Str original keys survive the hyper op';

--- a/todo/deep/hash-pointy-param-writeback-loses-object-hash-identity.md
+++ b/todo/deep/hash-pointy-param-writeback-loses-object-hash-identity.md
@@ -1,0 +1,159 @@
+# A hash `for`-loop pointy-block parameter loses object-hash identity when written back through a hyper-func-op
+
+`roast/S03-metaops/infix.t` under `MUTSU_REAL_TEST=1` (the vendored real
+`Test.rakumod`, see `todo/deep/vendor-real-test-module.md`) aborts after 2086
+of 5076 planned tests, 171 of them failing, all in the hash section:
+
+```raku
+for (%a, %b, %reset, ...) -> %a, %b, %reset, ... {
+    is-deeply %a <<[&metaop]>> 3, %resultop3, "%a <<$name=>> 3";
+    is-deeply %a, %resultop3, "%a assigned from %a <<$name=>> 3";
+    ...
+}
+```
+
+`%a` here is a `for`-loop pointy-block parameter bound (aliased) to one of
+the outer object hashes (`%ao{Any}`, `%ac` typed, etc — see the file, lines
+160-238). Real `raku` keeps `%a` (and the thing it is aliased to) an object
+hash (`Hash[Any,Any]`) across the `<<[&metaop]>>` writeback:
+
+```
+$ raku -e '
+my &metaop = &[~=];
+my %a = "a".."e" Z=> 1..5;
+my %ao{Any} = %a;
+for (%ao,) -> %x {
+    %x <<[&metaop]>> 3;
+    say %x.WHAT;                # (Hash[Any,Any])
+}
+say %ao.raku;                   # (my Any %{Any} = ...) -- %ao itself mutated
+'
+```
+
+mutsu instead demotes `%x` to a plain `Hash` with garbled `.WHICH`-encoded
+string keys (`"Str|a"` etc rendered raw), and the outer `%ao` is never
+updated at all — the two containers are not actually aliased.
+
+## What was fixed in this pass (PR TODO)
+
+`hyper_op_pair`'s hash-scalar branches (`vm/vm_hyper_ops.rs`, the *symbolic*
+literal-operator path, e.g. `%a{Any} >>~>> 3`) built a fresh plain `HashData`
+for the result, dropping `key_type`/`value_type`/`declared_type`/
+`original_keys` even though the key set is untouched. Fixed to carry that
+metadata over, mirroring the hash-hash branch immediately above it and the
+already-correct `tagged_hash` helper in `vm_hyper_func.rs`. Pinned by
+`t/hyper-hash-scalar-object-hash-type.t`. This does **not** touch
+`S03-metaops/infix.t`'s failures — that file always calls through a lexical
+`&op`/`&metaop` variable (`vm_hyper_func.rs`'s `exec_hyper_func_op_hash`,
+already metadata-correct on its own), not the symbolic-operator path.
+
+## The actual remaining bug: two independent, unconditional "materialize a fresh plain hash" passes
+
+Chasing the `S03-metaops/infix.t` failures traced to `%a`'s value losing its
+`key_type` on **every** store back into the loop's own bare name `%a` — both
+for a genuine mutation (`do_writeback == true`, `&metaop` ends in `=`) and
+for a pure no-op re-store (`do_writeback == false`, the compiler always
+re-emits a store after `HyperFuncOp` when the LHS is a simple `Var`/
+`HashVar`, even for a non-mutating op — see `compile_expr_hyper_func_op` in
+`compiler/expr_ops.rs`).
+
+Every `%`-assignment goes through **two** coercion passes in sequence
+(`src/vm/vm_var_assign_set_local.rs:exec_set_local_op_inner`):
+
+1. `coerce_hash_var_value` (`vm_var_assign_coerce.rs`) — for a `Hash` RHS
+   with `h.has_typed_keys()`, rebuilds a fresh map with **plain-encoded**
+   keys (`Value::hash_key_encode`, not `.WHICH`), while **unconditionally
+   copying `key_type`/`value_type`/`declared_type`** from the source. The
+   comment there explains the intent: a plain (unconstrained) target is
+   supposed to see stringified keys and revert to a plain `Hash` (matching
+   `raku`: `my %o{Any} = ...; my %p = %o; %p.WHAT` is `(Hash)`), while a
+   *constrained* target is supposed to get re-`.WHICH`-keyed later by
+   `coerce_typed_container_assignment` when `tag_container_metadata` runs.
+2. `coerce_typed_container_assignment` (`vm_var_assign_typed.rs`) — called
+   **unconditionally** for every `%`/`@` store
+   (`vm_var_assign_set_local.rs:1145-1146`, no gate on whether the target
+   actually has a declared constraint). For a hash target with
+   `key_constraint == None` (our `%a`, an untyped pointy-block name), it
+   rebuilds **again** via `Value::hash(coerced_map)` — a fresh `HashData`
+   whose `key_type` defaults to `None` regardless of what the input carried.
+
+For an ordinary `my %p = %o;` these two passes net out consistently by
+accident: pass 1 leaves plain keys + stale `key_type: Some(..)`, pass 2 drops
+`key_type` to `None` and leaves the (already-plain) keys alone — the correct
+final state (`key_type: None`, plain keys). That is why
+`t/object-hash-which-keys.t`'s "object hash assigned to a plain hash
+stringifies keys" test (and everything else exercising a genuine fresh
+declaration) already passed before touching anything.
+
+But for the `for`-loop pointy-block case the *intended* behaviour (per the
+`raku` trace above) is neither of these: `%a` is not receiving "a fresh
+value" at all — it is an **alias** being mutated/re-stored through, and
+should keep the aliased container's identity (including its `key_type` and,
+critically, the *outer* container's own mutation) completely untouched by
+either coercion pass. Neither pass has any way to distinguish "a fresh `my`
+assignment" from "a write-through re-store of an existing bound alias" — both
+just see `(var_name, incoming_value)`.
+
+### An attempted fix, and why it was reverted
+
+The direct patch — making pass 1's rebuilt map call
+`ensure_object_hash_which_keys` when `key_type.is_some()` so the two passes'
+key-encoding conventions actually agree — makes `S03-metaops/infix.t` pass
+5076/5076 (both providers), but **regresses six `t/` files**
+(`t/object-hash-which-keys.t` test 20, `t/classify-bucket-itemized.t`,
+`t/classify-hash-any-mu-raku.t`, `t/classify-pair-iteration.t`,
+`t/list-bind-trailing-array.t`, `t/named-array-destructure-absent-key.t`,
+`t/return-coercion-lazy-gather.t`) because pass 2 still unconditionally
+strips `key_type` afterward while now leaving `.WHICH`-encoded keys in place
+(instead of the plain keys it was written assuming) — the exact same
+invariant violation, just introduced one step later and in the *other*
+direction. Reverted; not shipped.
+
+### The real fix needs container-identity write-through, not key-encoding patching
+
+This codebase already has the right pattern for the underlying problem —
+`Interpreter::quanthash_store_preserving_identity` in
+`vm_var_assign_coerce.rs` (used for `my %s is SetHash = ...`
+re-declaration): when the *existing* value at a name is the same kind of
+container as the incoming one, it writes the new contents **into the
+existing `Gc` node in place** (`unsafe { *gc_contents_mut(&old) = data; }`,
+under the audited aliasing contract in `gc/gc_ptr.rs`'s `gc_contents_mut`
+docs / ADR-0013 §8), so every other holder of that same node — env mirrors,
+`:=` binds, closures — observes the mutation, instead of returning a
+disconnected fresh value that only the local slot sees.
+
+The likely correct fix is the hash analogue of that helper, gated the same
+way `inplace_old_hash` already is (`!is_bind && !is_rebind && !is_vardecl &&
+!is_anon_container` — i.e. skip for a genuine fresh `my` declaration, which
+is exactly where the "materialize plain" behavior is *supposed* to fire):
+when the *existing* value at this local slot is already an object hash
+(`inplace_old_hash.key_type.is_some()`), write the new key/value pairs into
+that **same** `Gc<HashData>` node instead of building a fresh one via either
+coercion pass, and skip both `coerce_hash_var_value`'s "materialize fresh
+entries" branch and `coerce_typed_container_assignment`'s unconditional
+rebuild for that store (a `bool` flag threaded from the identity-preserving
+branch through to the `!skip && ...` guard around the
+`coerce_typed_container_assignment` call would do it). That also happens to
+be the fix that would make `%ao` itself observe the mutation performed
+through its `%x` alias (still broken today; not even the reverted attempt
+above fixed that half — the roast test only asserts on `%a`'s own value, not
+`%ao`'s, so it does not currently catch this).
+
+This was not attempted in this pass: it requires auditing the `unsafe`
+aliasing contract carefully against every hash-value caller
+(`gc_contents_mut`'s docs are explicit that "no other `&`/`&mut` into this
+value is *dereferenced* for the lifetime of the returned borrow" on this
+thread), which is a correctness-critical, easy-to-get-subtly-wrong change
+and deserved a dedicated session rather than being folded into an unrelated
+hash-hyperop-metadata fix.
+
+## Where this sits in the `vendor-real-test-module.md` campaign
+
+`S03-metaops/infix.t` is (as of 2026-08-18) the single largest cluster in
+that campaign's roast residue (171 of the total ~148 raw / 141 genuine
+regressed files' worth of failing subtests come from this one file alone —
+see that ticket's latest sweep). Fixing this unblocks the file outright
+(verified: with the reverted patch in, `MUTSU_FUDGE=1 MUTSU_REAL_TEST=1
+target/debug/mutsu roast/S03-metaops/infix.t` ran clean 5076/5076 under both
+providers) and is worth prioritizing on a fresh session with room for the
+`unsafe`-audit work.

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -2006,3 +2006,61 @@ whitelisted roast files (`S02-types/fatrat.t`, `S02-types/num.t`,
 `S32-num/cool-num.t`, `S32-num/fatrat.t`, `S03-metaops/infix.t`,
 `S03-operators/infixed-function.t`, `S06-operator-overloading/infix.t`)
 clean on a release build.
+
+## Re-measured 2026-08-18: t/ residue down to 17, and the single largest roast cluster is `S03-metaops/infix.t`
+
+Fresh `scripts/test-module-sweep.sh` run (debug build): `t/` is down to
+**3175/3209 clean, 17 regressed under the real `Test`** (mostly individual
+gaps already named earlier in this file — `is-lazy-io-lines.t`,
+`proxy-list-transparency.t`, `subscript-adverbs.t`,
+`throws-like-gather-sink.t`, `whatever-code-fixes.t`,
+`undeclared-when-type.t` — plus several new small ones not yet triaged:
+`emit-done-controlflow.t`/`take-without-gather.t` (`emit without supply or
+react`), `error-reporting-quality.t`, `exception-methods.t`,
+`exception-role-membership.t`, `for-modifier-placeholder-scope.t`,
+`malformed-syntax-classes.t`, `proto-new-no-match.t`,
+`undeclared-symbol-exception-class.t`,
+`user-trait-mod-does-not-consume-every-trait.t`,
+`warn-resumes-at-the-raise-site.t`).
+
+A full `roast-whitelist.txt` sweep (1436 files, release build) followed by an
+alone/4x-timeout re-check of every raw regression: **141/1436 genuine
+regressions** — up from the 90 last recorded here on 2026-08-14, despite
+several individual fixes landing in between (2026-08-15/16 rounds above).
+Not investigated further this session (the user explicitly said not to chase
+why the count moved) — worth a fresh look next time this ticket is picked
+up, since a rising count while unrelated general-interpreter work lands
+implies something is regressing under `MUTSU_REAL_TEST=1` that nothing
+currently monitors (this mode is not in CI).
+
+Sorted by failed-subtest count, one file dominates: **`roast/S03-metaops/infix.t`,
+171 of 2086 tests failing** (the file aborts mid-run on an unrelated,
+pre-existing `Attempt to divide 4 by zero` a bit further in — same abort
+point as before this session, not a new regression). Second place is
+`S03-operators/range.t` at 40/181; nothing else exceeds 10.
+
+Root-caused and partially fixed — full writeup, including a fix that was
+tried, verified to make the file pass 5076/5076, and then **reverted** for
+regressing 6 `t/` files, is in
+`todo/deep/hash-pointy-param-writeback-loses-object-hash-identity.md`. Short
+version: a `for`-loop hash pointy-block parameter aliased to an object hash
+(`%ao{Any}`) loses its object-hash identity (`key_type`, `.WHICH`-keying) the
+moment anything stores back into the loop's own bare name, because two
+independent "materialize a fresh plain hash" coercion passes
+(`coerce_hash_var_value` and the always-unconditional
+`coerce_typed_container_assignment`) both assume every `%name = value` store
+is a brand-new `my`-style declaration, with no way to recognize a write-through
+re-store of an existing bound alias. The one genuinely *shipped* fix from
+this investigation — `hyper_op_pair`'s hash-scalar branches (the *symbolic*
+`%h{Any} >>op>> scalar` path, `vm_hyper_ops.rs`) dropping object-hash
+identity — is unrelated to `S03-metaops/infix.t` itself (which always calls
+through a lexical `&op`/`&metaop`, a different code path that was already
+metadata-correct) but is a real, independently-pinned bug
+(`t/hyper-hash-scalar-object-hash-type.t`).
+
+The deep-ticket writeup names the actual fix shape needed: a hash analogue of
+`Interpreter::quanthash_store_preserving_identity` (container-identity
+in-place write via the audited `gc_contents_mut` unsafe primitive, ADR-0013
+§8), gated the same way `inplace_old_hash` already is. Deferred to a
+dedicated session — the `unsafe` aliasing contract needs careful auditing
+against every hash-value caller, not a fold-in alongside an unrelated fix.


### PR DESCRIPTION
## Summary
- `hyper_op_pair`'s hash-vs-scalar branches (`vm/vm_hyper_ops.rs`) built a fresh `HashData` for the result, dropping `key_type`/`value_type`/`declared_type`/`original_keys` even though the key set is untouched — so `%h{Any} >>op>> scalar` (and the other dwim-valid arrow forms) silently demoted an object hash to a plain `Hash`.
- Fixed by carrying the source hash's type metadata over, mirroring the hash-hash branch immediately above and the already-correct `tagged_hash` helper `vm_hyper_func.rs` uses for the `&op`/`&metaop` lexical-variable call path.
- Found while investigating `roast/S03-metaops/infix.t`'s regression under the real `Test.rakumod` (`todo/deep/vendor-real-test-module.md`). That file's own 171 failing subtests turned out to be a separate, deeper bug — a `for`-loop hash pointy-block parameter loses container identity on writeback — documented in a new `todo/deep/hash-pointy-param-writeback-loses-object-hash-identity.md` for a dedicated follow-up session (it needs an audited `unsafe` `Gc` in-place-write fix, not something to fold into this PR).

## Test plan
- [x] New pin `t/hyper-hash-scalar-object-hash-type.t` (8 assertions, all four dwim-valid arrow combinations + non-`Str`-keyed object hash), verified byte-identical against `raku`.
- [x] Confirmed the new test fails on `main` and passes with the fix.
- [x] Full `prove -j8 -e target/debug/mutsu t/` (3210 files) clean.
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean.
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)