### PR TITLE
fix(vm): a block bound to a &-param sees its own captured $! (dies-ok fix)

### DIFF
--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -340,19 +340,31 @@ impl Interpreter {
                 // A method's own invocant is bound from its args further below,
                 // after this merge, so it still wins over the captured value.
                 self.env_mut().insert_sym(*k, v.clone());
-            } else if !cc.is_routine && k.with_str(|s| s == "_") {
-                // `$_` (the topic) is LEXICAL in a block: a block lexically captures
-                // `$_` from its creation scope and must see that value when called
-                // from another routine. The don't-overwrite default hides it because
-                // the caller (a `sub`) resets `$_` to Any (line below), which ends
-                // up in the parent env that `entry_or_insert_sym` finds and stops at.
+            } else if !cc.is_routine && k.with_str(|s| s == "_" || s == "!") {
+                // `$_` (the topic) and `$!` (the last error) are LEXICAL in a
+                // block: a block lexically captures them from its creation
+                // scope and must see those values when called from another
+                // routine. The don't-overwrite default (`entry_or_insert_sym`,
+                // which checks the chain-walking `contains_key_sym`) hides
+                // them because the caller (a `sub`) already reset its OWN
+                // `$_`/`$!` before calling this block, so the closure's
+                // freshly-empty overlay sees the CALLER's fresh reset via the
+                // parent chain and treats that as "already present" — losing
+                // the closure's own captured value entirely:
                 //
                 //     given 42 { my &b = { say $_ }; call-block(&b) }
+                //     sub f(&code) { my $d=1; try { code(); $d=0 } }
+                //     try { 1+1 }; f { $!.message }   # dies-ok's own shape
                 //
-                // Without this, `$_` inside the block is Any (the callee routine's
-                // fresh topic) instead of 42. Routines reset `$_` explicitly (at the
-                // `is_routine && !param` guard in call_compiled_function_named_inner),
-                // so this overwrite is safe for non-routine blocks only.
+                // Without this, `$_`/`$!` inside the block are the callee
+                // routine's fresh `Any`/`Nil` instead of the creation scope's
+                // real values — `f { $!.message }` above silently returned
+                // `Nil` instead of dying, since `Nil.message` doesn't raise
+                // the way `Any.message` does (`t/exception-methods.t`).
+                // Routines reset both explicitly (`$_` at the `is_routine &&
+                // !param` guard in `call_compiled_function_named_inner`; `$!`
+                // just below in this function), so this overwrite is safe for
+                // non-routine blocks only.
                 self.env_mut().insert_sym(*k, v.clone());
             } else {
                 self.env_mut().entry_or_insert_sym(*k, v.clone());
@@ -625,8 +637,18 @@ impl Interpreter {
             );
         }
 
-        // Raku: $! is scoped per routine — fresh Nil on entry
-        if !data.name.is_empty() {
+        // Raku: $! is scoped per routine — fresh Nil on entry. Gated on
+        // `cc.is_routine`, matching the `$_` reset just above: a bare block
+        // bound to a `&`-sigiled parameter (`sub f(&code) { code() }`, called
+        // as `f { $!.message }`) picks up that parameter's name for
+        // introspection (`&?ROUTINE`/backtrace naming) even though it is not
+        // a routine boundary. The old `!data.name.is_empty()` guard fired for
+        // such a block too, clobbering its correctly-captured `$!` (installed
+        // by the merge above) with `Nil` before the body ran — so
+        // `dies-ok { $!.message }` never actually died (`Nil.message` doesn't
+        // raise the way `Any.message` does), losing a die the caller expected
+        // to observe.
+        if cc.is_routine {
             self.env_mut()
                 .insert_sym(crate::symbol::Symbol::intern("!"), Value::NIL);
         }

--- a/t/closure-captured-bang-var-through-code-param.t
+++ b/t/closure-captured-bang-var-through-code-param.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# Regression: `$!` is lexical in a block — a block called from inside another
+# routine must still see the `$!` from its own creation scope, the same way
+# `$_` already does (`vm_closure_dispatch.rs`'s closure-entry merge). The
+# merge's default "don't overwrite an existing name" (`entry_or_insert_sym`)
+# used the chain-walking `contains_key_sym`, so a block bound to a `&`-sigiled
+# parameter and called from inside a `sub` saw the *caller sub's own* fresh
+# `$!` reset (visible through the parent chain) instead of its own captured
+# value — losing the block's real `$!` entirely. Concretely, this made
+# `dies-ok { $!.message }` (exactly `Test.rakumod`'s own `dies-ok` shape)
+# silently succeed instead of dying, since `Nil.message` does not raise the
+# way `Any.message` does. Found investigating `t/exception-methods.t`'s
+# regression under `MUTSU_REAL_TEST=1`.
+
+plan 3;
+
+sub calls-code(&code) {
+    my $died = False;
+    try {
+        code();
+        CATCH { default { $died = True } }
+    }
+    $died;
+}
+
+try { 1 + 1 };
+ok calls-code({ $!.message }),
+    'a block bound to a &-sigiled param sees its own captured $! (not the caller sub\'s fresh reset)';
+
+my $topic-seen;
+for 'abc' {
+    calls-code({ $topic-seen = $_ });
+}
+is $topic-seen, 'abc',
+    'the same mechanism keeps working for $_ (not just $!)';
+
+try { die "boom" };
+my $msg;
+calls-code({ $msg = $!.message });
+is $msg, 'boom',
+    'a genuinely-set $! is captured correctly too, not just Any';

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -2096,3 +2096,29 @@ has loaded the real, large vendored module; an empty synthetic module does
 not trigger it, ruling out "any module load" as the cause. Root cause not
 yet found (JIT and bare-name collision were both ruled out). Full repro and
 findings: `todo/deep/control-warn-resume-list-assign-first-target-stale-on-repeat-call.md`.
+
+## `t/exception-methods.t` closed: `$!` was not lexical in a `&`-param block (2026-08-18)
+
+Same investigation session, next residue item. `dies-ok { $!.message }` (the
+real `dies-ok`'s own shape: `sub dies-ok(Callable $code, ...) { ...; try {
+$code(); $death = 0 } ... }`) silently reported "did not die" instead of
+dying — `Nil.message` doesn't raise the way `Any.message` does, and the block
+was reading `Nil` instead of the caller's real `$!`.
+
+Root cause: `vm_closure_dispatch.rs`'s closure-entry merge already force-
+installs a captured `$_` over the don't-overwrite default (`entry_or_insert_sym`,
+which uses the chain-walking `contains_key_sym`) for exactly this reason — see
+the comment there — but had no matching case for `$!`. A block bound to a
+`&`-sigiled parameter and called from inside a `sub` therefore saw the
+*caller sub's own* fresh `$!` (reset to `Nil` on that sub's own entry,
+visible through the parent chain) instead of its own captured value from its
+creation scope. Fixed by adding `$!` to the same force-install branch as
+`$_`, and separately corrected an unrelated but adjacent bug in the same
+function: the "`$!` is scoped per routine" reset just below was gated on
+`!data.name.is_empty()` (true for a `&`-bound block, which picks up its
+parameter's name for introspection) instead of `cc.is_routine` (matching the
+`$_` reset's own, correct guard) — harmless once the capture fix landed, but
+still worth fixing for the same reason. Pin:
+`t/closure-captured-bang-var-through-code-param.t`. `t/exception-methods.t`
+now passes fully under both `Test` providers; full local `t/` suite (3222
+files) and `cargo clippy -- -D warnings` both clean.


### PR DESCRIPTION
## Summary
- \`vm_closure_dispatch.rs\`'s closure-entry merge already force-installs a captured \`\$_\` over the don't-overwrite default (\`entry_or_insert_sym\`, chain-walking \`contains_key_sym\`) so a block sees the topic from its own creation scope. \`\$!\` needed the same treatment and didn't have it: a block bound to a \`&\`-sigiled parameter and called from inside a \`sub\` saw the *caller sub's own* fresh \`\$!\` (reset to \`Nil\` on its own entry, reachable through the parent chain) instead of the block's real captured value.
- Concretely this made \`dies-ok { \$!.message }\` — the real \`Test.rakumod\` \`dies-ok\`'s own shape — silently report "did not die": \`Nil.message\` doesn't raise the way \`Any.message\` does.
- Also fixed an adjacent bug in the same function: the "\$! is scoped per routine" reset was gated on \`!data.name.is_empty()\` (true for a \`&\`-bound block, which picks up its parameter's name for introspection) instead of \`cc.is_routine\` (matching the \`\$_\` reset's own correct guard).
- Fixes \`t/exception-methods.t\` under \`MUTSU_REAL_TEST=1\` (part of the \`vendor-real-test-module.md\` campaign).

## Test plan
- [x] \`cargo build\`
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] New pin: \`t/closure-captured-bang-var-through-code-param.t\` — verified it fails before the fix and passes after
- [x] Full local \`t/\` suite: \`prove -j8 -e target/debug/mutsu t/\` — 3222 files, all pass
- [x] \`t/exception-methods.t\` passes under both native and \`MUTSU_REAL_TEST=1\`
- [ ] CI \`make roast\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)