### PR TITLE
fix(vm): try's implicit fatal must not retroactively flag a closure's own soft Seq

### DIFF
--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2785,19 +2785,30 @@ impl Interpreter {
                 // Peek (do not pop): a trailing unhandled Failure must be thrown
                 // so the enclosing CATCH handler (or `try`) sees it, while a
                 // normal value remains on the stack as the block's return value.
-                if let Some(val) = self.stack.last() {
-                    if let Some(err) = self.failure_to_runtime_error_if_unhandled(val) {
-                        return Err(err);
-                    }
-                    // Under `use fatal`, a block/routine that returns a reified
-                    // list/Seq whose element is an unhandled Failure throws too
-                    // (`use fatal; { "a".map: *.Int }()`).
-                    if self.fatal_mode
-                        && let Some(err) = self.unhandled_failure_in_list_for_fatal(val)
-                    {
-                        return Err(err);
-                    }
+                if let Some(val) = self.stack.last()
+                    && let Some(err) = self.failure_to_runtime_error_if_unhandled(val)
+                {
+                    return Err(err);
                 }
+                // Deliberately no `unhandled_failure_in_list_for_fatal` descent
+                // here: unlike a bare Failure (created directly in this frame,
+                // so `self.fatal_mode` here really does describe the state it
+                // was made under), a reified list/Seq may be the *return value*
+                // of a call that crossed its own `call_compiled_closure` save/
+                // restore boundary — by the time control gets back here,
+                // `self.fatal_mode` has been restored to *this* frame's state,
+                // which can differ from the state the list's elements were
+                // actually produced under (e.g. `try { c() }` where `c`'s own
+                // body ran with fatal off, but `try` restores fatal on for its
+                // own tail-position check). Checking the restored, ambient
+                // value here retroactively imposed the try's fatal-ness on a
+                // Failure the callee legitimately created as soft
+                // (`t/whatever-code-fixes.t`, "without fatal, a map of
+                // Failures is a soft list"). `.map`/`.grep`'s own native loop
+                // (`resolution_map_grep.rs`) already throws at the correct,
+                // per-element time using the fatal state active while each
+                // element is actually computed, so this redundant recheck can
+                // only ever be *wrong*, never additionally correct.
                 *ip += 1;
             }
             OpCode::WarnSuppressPush => {
@@ -2953,16 +2964,15 @@ impl Interpreter {
                             {
                                 return Err(err);
                             }
-                            // Under `use fatal`, sinking a reified list/Seq whose
-                            // element is an unhandled Failure also throws (e.g.
-                            // `use fatal; "a".map: *.Int`). Non-fatal code keeps
-                            // its soft-Failure lists (a plain `[Failure]` sink is a
-                            // no-op without fatal).
-                            if self.fatal_mode
-                                && let Some(err) = self.unhandled_failure_in_list_for_fatal(&val)
-                            {
-                                return Err(err);
-                            }
+                            // Deliberately no `unhandled_failure_in_list_for_fatal`
+                            // descent here — see the identical note on
+                            // `OpCode::ThrowIfFailure` above: the ambient
+                            // `self.fatal_mode` at this sink can be the
+                            // *caller's* restored state, not the state the
+                            // sunk list's elements were actually produced
+                            // under, and `.map`/`.grep`'s own native loop
+                            // already enforces `use fatal` at the correct,
+                            // per-element time.
                             // Sinking a Proc with non-zero exitcode throws X::Proc::Unsuccessful
                             if let ValueView::Instance {
                                 class_name,

--- a/t/try-fatal-does-not-retroactively-flag-closure-seq.t
+++ b/t/try-fatal-does-not-retroactively-flag-closure-seq.t
@@ -1,0 +1,64 @@
+use Test;
+
+plan 3;
+
+# `try` implicitly turns on `use fatal` for its own lexical scope
+# (try-block-implicit-use-fatal.t), so a Failure produced *directly* inside a
+# try body's tail expression is sunk-fatal there. But when the try's tail
+# expression is instead the return value of a *separately declared* closure
+# whose own body did NOT run under fatal, that returned value must stay soft
+# — `use fatal` describes the state active when a Failure was actually
+# created, not the ambient state of whoever later happens to receive it.
+#
+# This matters specifically for a `Seq`/`Slip` return value: `.map`'s own
+# native loop already enforces `use fatal` at the correct, per-element time
+# (`resolution_map_grep.rs`), so a later, ambient recheck of the returned
+# list at the try's own sink point can only be *wrong* — it retroactively
+# stamps the try's fatal-ness onto a list the callee legitimately built as
+# soft.
+
+# A closure with no `use fatal` of its own, returning a Seq whose lone
+# element is an unhandled Failure: calling it as a try's tail statement must
+# not explode.
+{
+    my &c = { "a".map: *.Int };
+    my $died = False;
+    try {
+        c();
+        CATCH { default { $died = True } }
+    }
+    ok !$died, 'try does not retroactively fatal a Seq a plain closure returned soft';
+}
+
+# Sanity check in the other direction: a closure that DOES declare its own
+# `use fatal` still throws when called the same way (this is not a
+# "fatal from map never fires" regression).
+{
+    my &f = { use fatal; "a".map: *.Int };
+    my $died = False;
+    try {
+        f();
+        CATCH { default { $died = True } }
+    }
+    ok $died, 'a closure that itself declares use fatal still throws its own Seq';
+}
+
+# A bare Failure (not list-wrapped) created directly in the try's own body
+# still throws — this is try's own implicit-fatal doing its job, unrelated
+# to the closure-boundary case above.
+{
+    my $died = False;
+    try {
+        "a".Int;
+        CATCH { default { $died = True } }
+    }
+    ok $died, 'a bare Failure created directly in the try body still throws';
+}
+
+# NOTE: a *bare* (not list-wrapped) soft Failure created *before* a `try`,
+# then merely read as the try's tail expression, is ALSO retroactively
+# exploded by mutsu today (raku keeps it soft — creation-time semantics, not
+# consumption-time). That is a separate, pre-existing gap in the unconditional
+# `failure_to_runtime_error_if_unhandled` check (not the `use fatal`-gated
+# list-descend check fixed here) and is out of scope for this file; see
+# `todo/tickets/bare-failure-sink-is-consumption-time-not-creation-time.md`.

--- a/todo/tickets/bare-failure-sink-is-consumption-time-not-creation-time.md
+++ b/todo/tickets/bare-failure-sink-is-consumption-time-not-creation-time.md
@@ -1,0 +1,71 @@
+# A bare unhandled Failure's fatal-throw decision is made at sink time, not creation time
+
+Found while fixing the `unhandled_failure_in_list_for_fatal` closure-boundary
+bug (`t/try-fatal-does-not-retroactively-flag-closure-seq.t`,
+`todo/deep/vendor-real-test-module.md`'s `t/whatever-code-fixes.t` residue).
+
+Real Raku decides whether a Failure throws under `use fatal` **at the moment
+the Failure is constructed**, using whichever fatal state is active then. A
+Failure that stays soft because it was made outside `use fatal` stays soft
+forever after — reading it later, even from inside a scope where fatal is
+now on, does not retroactively explode it:
+
+```raku
+my $f = "a".Int;      # created without fatal -> soft
+{
+    use fatal;
+    $f;                # sunk under fatal here -- but NOT thrown
+}
+say 'reached';         # raku: prints this
+```
+
+mutsu instead decides at the **sink site**, using whatever `self.fatal_mode`
+happens to be *right now* — `failure_to_runtime_error_if_unhandled` is called
+unconditionally (not gated on `self.fatal_mode` at all — it always throws an
+unhandled Failure on sink) — so the example above throws in mutsu instead of
+printing `reached`. This is unrelated to the list-descend bug just fixed
+(`unhandled_failure_in_list_for_fatal`, which *is* fatal-gated): this is the
+unconditional bare-Failure check at `OpCode::SinkPop` / `OpCode::ThrowIfFailure`
+/ `sink_discarded_call_value` (`failure_to_runtime_error_if_unhandled`, no
+`self.fatal_mode` involved).
+
+## Why this is bigger than a one-line fix
+
+Real Raku's actual mechanism is that `Failure.new` conditionally throws
+**immediately at construction** when fatal is active then — there is no
+separate "check again later" step at all. mutsu's architecture is the
+opposite: every `.Int`/`.Num`/... coercion site (~33 call sites building a
+`Failure` instance, spread across `dispatch_core_coerce.rs`,
+`error_construct.rs`, `runtime/utils.rs`, and more — see
+`grep -rn 'make_instance(Symbol::intern("Failure")'`) always builds a soft
+Failure, with zero knowledge of `fatal_mode`, and defers the decision to a
+scattered set of consumption-time checks (`SinkPop`, `SinkPopAssign`,
+`ThrowIfFailure`, `ExecCall`'s sink, method-dispatch coercion sites, ...).
+
+Matching real semantics exactly would mean stamping each Failure with the
+`fatal_mode` active at its own creation (mirroring the existing
+`captured_fatal_mode` pattern already used for closures,
+`vm_closure_dispatch.rs`) and having every consumption-time check read that
+stamp instead of the ambient `self.fatal_mode` — a much larger change,
+touching every Failure-construction call site, not scoped to this ticket.
+
+## Minimal repro
+
+```raku
+my $f = "a".Int;
+{
+    use fatal;
+    $f;
+}
+say 'reached';
+```
+
+`raku`: prints `reached` (with a "Useless use of $f in sink context"
+warning). `mutsu` (current, both native and `MUTSU_REAL_TEST=1`): dies before
+printing `reached`.
+
+## Note: this is a *pre-existing* gap, not introduced by the list-descend fix
+
+Confirmed via `git stash` + rebuild that this reproduces identically on
+`main` before that fix landed — the two bugs are independent; only the
+list-wrapped (`use fatal`-gated) one was in scope for that PR.


### PR DESCRIPTION
## Summary
- `try {}`'s implicit `use fatal` was being consulted at the *sink* site (ambient `self.fatal_mode`) to decide whether a returned list/Seq's unhandled Failure element should throw — but by the time `try { c() }`'s tail call returns, `self.fatal_mode` has been restored to the *caller's* (try's) state, not the state `c`'s own body actually ran under. This retroactively imposed `try`'s fatal-ness on a `Seq` a plain (non-fatal) closure legitimately built as soft — e.g. `t/whatever-code-fixes.t`'s "without fatal, a map of Failures is a soft list" only failed under `MUTSU_REAL_TEST=1` (the vendored real `Test.rakumod`, `todo/deep/vendor-real-test-module.md`), because its `lives-ok`/`throws-like` route the user's block through exactly this call-then-sink shape.
- `.map`/`.grep`'s own native loop (`resolution_map_grep.rs`) already enforces `use fatal` at the correct, per-element time, so the ambient recheck at `SinkPop`/`ThrowIfFailure` was redundant for its own originally-documented case and actively wrong for the closure-boundary one. Removed both call sites; left the correctly-scoped `resolution_eval.rs` check (uses the block's own captured fatal state) untouched.
- Filed `todo/tickets/bare-failure-sink-is-consumption-time-not-creation-time.md` for a related, pre-existing (unrelated to this fix, confirmed via `git stash` + rebuild) gap: a *bare* soft Failure created outside fatal is still wrongly re-exploded when later sunk inside an unrelated fatal scope.

## Test plan
- [x] New pin: `t/try-fatal-does-not-retroactively-flag-closure-seq.t`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Full local `prove -j8 -e target/debug/mutsu t/` — 3231/3231 files pass
- [x] `scripts/test-module-sweep.sh` (release build) — `t/whatever-code-fixes.t` no longer regresses under `MUTSU_REAL_TEST=1`; the 12 remaining regressions are all pre-existing (confirmed against `main`), unrelated to this change
- [x] Targeted roast: `S02-types/whatever.t`, `S04-exceptions/*.t`, `S17-supply/*.t`, `S03-operators/*.t` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)