### PR TITLE
fix(runtime): BigInt negation downcast and Int+Rat numerator overflow precision

### DIFF
--- a/news/2026-08/bigint-negate-and-rat-overflow-precision.md
+++ b/news/2026-08/bigint-negate-and-rat-overflow-precision.md
@@ -1,0 +1,91 @@
+# Negating a BigInt that lands back in i64 range no longer silently reads as 0 (plus a Rat-precision regression it surfaced)
+
+```raku
+my $big = 9223372036854775808;   # 2**63, one past i64::MAX -- parses as BigInt
+say -$big;                        # -9223372036854775808 (i64::MIN, fits in Int)
+
+enum CBORMinMax (CBOR_Min_NInt_63Bit => -9223372036854775808);
+say +CBOR_Min_NInt_63Bit;         # raku: -9223372036854775808   mutsu (before): 0
+say CBOR_Min_NInt_63Bit <= -1;    # raku: True                   mutsu (before): False
+```
+
+Found while investigating
+`todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md`: the
+vendored `CBOR::Simple` dist's own integer boundary constants
+(`enum CBORMinMax (... CBOR_Min_NInt_63Bit => -9223372036854775808, ...)`)
+made every negative-integer `cbor-encode` call pick the wrong branch of a
+chained comparison, encoding plain negative integers (even `-1`) as
+tag-3 BigInt instead of their compact native form.
+
+## Root cause
+
+`9223372036854775808` (2^63) is one past `i64::MAX`, so it parses as a
+`BigInt`. `arith_negate` (`src/builtins/arith/pow_negate.rs`)'s `BigInt` arm
+negated it and wrapped the result with the raw `Value::bigint` constructor —
+`Value::bigint(-(**i).clone())` — instead of the normalizing
+`Value::from_bigint`, which downcasts back to a plain `Int` whenever the
+result fits in `i64` (exactly the case here: `-2^63` is `i64::MIN`, which
+does fit). The negated value stayed BigInt-tagged even though it was, for
+every practical purpose, an ordinary `Int`.
+
+An enum declaration (`registration_sub.rs`) checks `ValueView::Int` to decide
+whether a variant's value stores as `EnumValue::Int` or falls back to
+`EnumValue::Generic` (a boxed catch-all `Value`) — a still-BigInt-tagged
+`-9223372036854775808` took the `Generic` path. `EnumValue::as_i64()`
+(`src/value/value_enum.rs`), the numeric-extraction helper every fast-path
+`ValueView::Enum` numeric coercion uses (unary `+`, binary `+`, comparison
+operators, `.polymod`, `.abs`, ...), simply returned `0` for any `Generic`
+variant — it never tried to numify the wrapped value at all. `.Int`/`.Numeric`
+method calls happened to be unaffected (they go through `EnumValue::to_value`,
+which correctly unwraps `Generic`), which is why the bug looked narrower than
+it was until the fast paths were checked directly.
+
+## Fix
+
+- `arith_negate`'s `BigInt` arm now uses `Value::from_bigint`, so a BigInt
+  negation that lands back in `i64` range downcasts to a plain `Int`
+  immediately, matching every other BigInt-producing arithmetic op's existing
+  normalization convention.
+- `EnumValue::as_i64()` now numifies a `Generic` variant's wrapped value
+  (`Int`/`BigInt`/`Num`/`Bool`) instead of unconditionally returning `0`, as
+  defense in depth — any other path that produces a `Generic`-stored enum
+  value (not just this specific BigInt-negation shape) now numifies
+  correctly too.
+
+Found (but not fixed, out of scope) along the way: a `Rat`/`Num`-valued enum's
+numeric coercion still truncates to an `Int` via a separate, unrelated bug in
+`coerce_to_numeric`'s own `Enum` arm — filed as
+`todo/tickets/rat-valued-enum-numeric-coercion-loses-fraction.md`.
+
+## A second bug the fix surfaced: `Int + Rat` precision loss on numerator overflow
+
+Making `-2**63` correctly a plain `Int` (instead of accidentally staying
+BigInt-tagged) exposed a **pre-existing, unrelated regression** in a
+previously-whitelisted test (`t/bigrat-sort-compare.t`): `(-2**63 + 0.1).FatRat`
+lost its `.9` fractional part, printing `-9223372036854775807` instead of
+`-9223372036854775807.9`. Reproduces with any plain large-magnitude `Int`,
+not just `-2**63`:
+
+```
+$ mutsu -e 'say (9223372036854775807 + 0.1).FatRat'   # i64::MAX + 0.1
+9223372036854775807          # before this fix — the .1 vanished
+$ raku  -e 'say (9223372036854775807 + 0.1).FatRat'
+9223372036854775807.1
+```
+
+Root cause: `rat_from_i128_or_num` (`src/builtins/arith/rat.rs`), the
+overflow-checked i128 path `rat_add_checked`/`rat_sub_checked`/`rat_mul_checked`/
+`rat_div_checked` all funnel through, degraded to a lossy `Num` whenever
+EITHER the numerator or the denominator failed to fit back into `i64` after
+GCD reduction. Real Rakudo's `Rat` only has that size constraint on its
+**denominator** — the numerator can be arbitrarily large while `.WHAT` still
+reports `Rat` (Rakudo backs it with a bigint numerator internally). mutsu
+already has the correct distinction implemented in `make_big_rat_arith`
+(`src/value/mod.rs`) — used by the separate BigRat/BigInt arithmetic path —
+which only degrades to `Num` when the **denominator** specifically exceeds
+`u64` range, promoting to `BigRat` otherwise. `rat_from_i128_or_num`
+duplicated a NARROWER (and wrong) version of the same check instead of
+reusing it; now delegates to `make_big_rat_arith` directly, removing the
+duplicate GCD/overflow logic entirely.
+
+Regression tests: `t/bigint-negate-and-rat-overflow-precision.t`.

--- a/src/builtins/arith/pow_negate.rs
+++ b/src/builtins/arith/pow_negate.rs
@@ -353,7 +353,17 @@ pub(crate) fn arith_negate(val: Value) -> Result<Value, RuntimeError> {
                 Ok(Value::num(-(i as f64)))
             }
         }
-        ValueView::BigInt(i) => Ok(Value::bigint(-(**i).clone())),
+        // Negating a BigInt can bring the result back into i64 range (the
+        // canonical case: `9223372036854775808` — one past i64::MAX, so it
+        // parses as BigInt — negated is exactly i64::MIN, which fits).
+        // `from_bigint` downcasts when possible; the raw `bigint` constructor
+        // does not, leaving a BigInt-tagged Value that downstream numeric
+        // extraction (`EnumValue::as_i64`, the NaN-box `as_int` fast path)
+        // does not expect for a value that should be a plain Int — a
+        // `-9223372036854775808` enum constant's own `.Int` coercion still
+        // worked (it goes through `EnumValue::to_value`), but arithmetic
+        // fast paths reading it as a plain Int silently saw 0 instead.
+        ValueView::BigInt(i) => Ok(Value::from_bigint(-(**i).clone())),
         ValueView::Num(f) => Ok(Value::num(-f)),
         ValueView::Rat(n, d) => {
             if let Some(neg) = n.checked_neg() {

--- a/src/builtins/arith/rat.rs
+++ b/src/builtins/arith/rat.rs
@@ -34,43 +34,20 @@ pub(crate) fn rat_div_checked(an: i64, ad: i64, bn: i64, bd: i64) -> Value {
     rat_from_i128_or_num(n, d)
 }
 
-/// Convert i128 numerator/denominator to Rat, or Num on overflow.
-/// Raku spec: Rat denominators are limited to uint64 range.
-/// When the denominator exceeds this after GCD reduction, degrade to Num.
+/// Convert i128 numerator/denominator to a Rat/BigRat, or Num only when the
+/// DENOMINATOR itself (after GCD reduction) exceeds uint64 range.
+///
+/// A large NUMERATOR alone (the common case: `9223372036854775807 + 0.1`,
+/// where the sum's integer part exceeds i64::MAX but the denominator stays a
+/// small 10) must NOT degrade to a lossy `Num` — real Rakudo's `Rat` keeps an
+/// arbitrary-precision numerator with a small denominator exactly (`.WHAT`
+/// still reports `Rat`; mutsu represents that as `BigRat`, which prints
+/// identically). Delegates to `make_big_rat_arith`, which already implements
+/// this exact distinction for the BigRat-based arithmetic path — this
+/// function previously duplicated (and got wrong) the same GCD+overflow
+/// logic for the plain-Rat i128 fast path.
 pub(crate) fn rat_from_i128_or_num(n: i128, d: i128) -> Value {
-    if d == 0 {
-        return if n == 0 {
-            Value::rat_raw(0, 0)
-        } else if n > 0 {
-            Value::rat_raw(1, 0)
-        } else {
-            Value::rat_raw(-1, 0)
-        };
-    }
-    // Normalize sign
-    let (mut n, mut d) = if d < 0 { (-n, -d) } else { (n, d) };
-    // GCD
-    fn gcd128(mut a: i128, mut b: i128) -> i128 {
-        a = a.abs();
-        b = b.abs();
-        while b != 0 {
-            let t = b;
-            b = a % b;
-            a = t;
-        }
-        a
-    }
-    let g = gcd128(n, d);
-    if g != 0 {
-        n /= g;
-        d /= g;
-    }
-    // Check if result fits in i64 (denominator must also fit in uint64 per Raku spec)
-    if let (Ok(n64), Ok(d64)) = (i64::try_from(n), i64::try_from(d)) {
-        return Value::rat_raw(n64, d64);
-    }
-    // Overflow: degrade to Num
-    Value::num(n as f64 / d as f64)
+    crate::value::make_big_rat_arith(NumBigInt::from(n), NumBigInt::from(d))
 }
 
 /// Check if BigRat arithmetic is needed: at least one operand requires BigInt precision

--- a/src/value/value_enum.rs
+++ b/src/value/value_enum.rs
@@ -1,11 +1,25 @@
 use super::*;
 
 impl EnumValue {
-    /// Return the integer value, or 0 for string/generic enums.
+    /// Return the integer value, or 0 for string enums.
+    ///
+    /// A `Generic` enum value (any non-Int/Bool/Str variant initializer —
+    /// e.g. a `BigInt` that fit back into `i64` after arithmetic, or a
+    /// `Rat`/`Num`-valued enum) numifies its wrapped `Value` rather than
+    /// blindly returning 0: `enum E (B => 9223372036854775808 - 2**64)`
+    /// (one past `i64::MAX`, negated back into range) stores as `Generic`
+    /// even though its value is a perfectly ordinary `i64`.
     pub fn as_i64(&self) -> i64 {
         match self {
             EnumValue::Int(i) => *i,
-            EnumValue::Str(_) | EnumValue::Generic(_) => 0,
+            EnumValue::Str(_) => 0,
+            EnumValue::Generic(v) => match v.view() {
+                ValueView::Int(i) => i,
+                ValueView::BigInt(n) => n.to_i64().unwrap_or(0),
+                ValueView::Num(f) => f as i64,
+                ValueView::Bool(b) => i64::from(b),
+                _ => 0,
+            },
         }
     }
 

--- a/t/bigint-negate-and-rat-overflow-precision.t
+++ b/t/bigint-negate-and-rat-overflow-precision.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 11;
+
+# `9223372036854775808` (2**63, one past i64::MAX) parses as a BigInt.
+# Negating it lands exactly on i64::MIN (-9223372036854775808), which DOES
+# fit in a plain Int -- but `arith_negate`'s BigInt arm used the raw
+# `Value::bigint` constructor instead of the normalizing `Value::from_bigint`
+# (which downcasts back to Int when the result fits), leaving a BigInt-typed
+# value that a downstream numeric fast path (`Value::as_int`, an enum's
+# `EnumValue::as_i64`) silently read as 0 instead of the real value. Found
+# investigating CBOR::Simple's own bounds-checking constants
+# (`enum CBORMinMax (... CBOR_Min_NInt_63Bit => -9223372036854775808)`),
+# which triggered exactly this shape. See
+# news/2026-08/bigint-negate-i64-min-downcast.md.
+
+is -9223372036854775808 - 9223372036854775808 + 9223372036854775808, -9223372036854775808,
+    'sanity: i64::MIN arithmetic without an enum still works (regression guard)';
+
+my $big = 9223372036854775808;
+isa-ok $big, Int, 'the boundary literal parses as Int (allomorph)';
+is -$big, -9223372036854775808, 'negating one-past-i64::MAX lands on i64::MIN correctly';
+is (-$big).WHAT, Int, 'the negated value is a plain Int type object, not a BigInt-only shape';
+
+# The exact shape that surfaced the bug: an enum constant computed from a
+# negated BigInt boundary, then read numerically via +, binary +, and a
+# chained comparison.
+enum CBORMinMax (
+    CBOR_Max_UInt_63Bit => 9223372036854775807,
+    CBOR_Min_NInt_63Bit => -9223372036854775808,
+);
+is +CBOR_Min_NInt_63Bit, -9223372036854775808, 'unary + on the enum constant reads its real value';
+is CBOR_Min_NInt_63Bit + 0, -9223372036854775808, 'binary + on the enum constant reads its real value';
+ok (CBOR_Min_NInt_63Bit <= -1 <= CBOR_Max_UInt_63Bit),
+    'a chained comparison against the enum constant is correct for a negative operand';
+ok (CBOR_Min_NInt_63Bit <= -9223372036854775808 <= CBOR_Max_UInt_63Bit),
+    'a chained comparison against the enum constant is correct at its own boundary';
+
+# A second, separate bug surfaced by the fix above: making `-2**63` a plain
+# Int (correctly, matching Rakudo) exposed that Int+Rat addition for a
+# large-magnitude Int degraded to a lossy Num whenever the sum's NUMERATOR
+# (not its denominator) overflowed i64, instead of promoting to BigRat --
+# `rat_from_i128_or_num` (src/builtins/arith/rat.rs) duplicated (and got
+# wrong) the numerator/denominator distinction `make_big_rat_arith` already
+# implements correctly; now delegates to it instead. Real Rakudo's `Rat`
+# keeps an arbitrary-precision numerator with a small denominator exactly.
+is (9223372036854775807 + 0.1).FatRat, "9223372036854775807.1",
+    'Int + Rat keeps exact precision when only the numerator overflows i64';
+is ((-2**63) + 0.1).FatRat, "-9223372036854775807.9",
+    'the exact CBOR::Simple-adjacent shape (Int::MIN + 0.1) keeps precision';
+is (9223372036854775807 + 0.1).WHAT, Rat,
+    'the result stays a Rat (BigRat internally), not a lossy Num';

--- a/todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md
+++ b/todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md
@@ -113,3 +113,43 @@ git clone https://github.com/japhb/CBOR-Simple.git /tmp/cbor-simple
 cd /tmp/cbor-simple && git checkout 0.1.4
 timeout 20 mutsu -I /path/to/mutsu/modules/CBOR-Simple/lib -I /path/to/mutsu/modules/TinyFloats/lib t/06-typed-arrays.rakutest
 ```
+
+## Update (2026-08-18): root-caused and fixed the "No matching candidates for proto sub: matches" fatal in `01`/`04`
+
+That symptom was a misleading downstream effect, not a real multi-dispatch
+bug: `CBOR::Simple`'s own integer-boundary constants
+(`enum CBORMinMax (... CBOR_Min_NInt_63Bit => -9223372036854775808, ...)`)
+made `cbor-encode`'s `CBOR_Min_NInt_63Bit <= $_ <= CBOR_Max_UInt_63Bit`
+chained comparison wrongly reject every negative integer, so `cbor-encode`
+produced the wrong CBOR blob for any negative value (tag-3 BigInt instead of
+compact native encoding) — a general interpreter bug (`arith_negate` not
+downcasting a BigInt negation back to `Int` when it lands in `i64` range,
+combined with `EnumValue::as_i64` returning `0` for the resulting
+BigInt-backed `Generic` enum variant), unrelated to `CBOR::Simple` itself.
+Fixed in `news/2026-08/bigint-negate-i64-min-downcast.md`. The "No matching
+candidates" error was `CodecMatches.rakumod`'s own `matches` multi silently
+running out of test count/exiting oddly after enough subtest assertions
+failed earlier in the file — a real symptom, but downstream of the encoding
+bug, not a proto-dispatch bug at all.
+
+**Re-measured after the fix:**
+
+- `01-basic.rakutest`: now runs to test 68/74 (previously died at test 12) —
+  1-67 pass; test 68 fails on a **different, new** bug: `cbor-decode` of a
+  nested-array structure (`9F01820203820405FF`) returns
+  `$[1, [4, 5], [4, 5]]` instead of `$[1, [2, 3], [4, 5]]` — looks like a
+  decoded sub-array aliasing/caching bug (the first nested array's decoded
+  value gets overwritten by the second). The run then hits a **stack
+  overflow** shortly after (`thread '<unknown>' has overflowed its stack`) —
+  needs its own investigation, not yet started.
+- `02-malformed.rakutest`, `05-malformed-tags.rakutest`: already mostly
+  passing before this fix (94/94 and 23/23 with only 1-2 stray failures each
+  per a fresh run) — not re-verified whether the encoding fix changed
+  anything here, likely unrelated (malformed-input tests don't exercise
+  valid negative-integer encoding).
+- `03-diagnostic.rakutest`, `04-tags.rakutest`, `06-typed-arrays.rakutest`:
+  not re-triaged this round.
+
+**Next steps for whoever picks this up:** reduce the `01-basic.rakutest`
+nested-array decode aliasing bug (test 68) and the stack overflow into a
+standalone repro (not yet attempted) before touching `03`/`04`/`06`.

--- a/todo/tickets/rat-valued-enum-numeric-coercion-loses-fraction.md
+++ b/todo/tickets/rat-valued-enum-numeric-coercion-loses-fraction.md
@@ -1,0 +1,36 @@
+# A Rat/Num-valued enum's numeric coercion (unary `+`, binary `+`, etc.) truncates to an Int
+
+Found while writing a regression test for
+`news/2026-08/bigint-negate-i64-min-downcast.md` (unrelated fix).
+
+## Repro
+
+```raku
+enum RatE (Half => 1/2);
+say +Half;
+```
+
+```
+raku:  0.5
+mutsu: 0
+```
+
+## Root cause
+
+`coerce_to_numeric` (`src/runtime/utils/radix_numeric.rs`)'s `ValueView::Enum`
+arm unconditionally does `Value::int(value.as_i64())` — forcing the result to
+a plain `Int` regardless of what the enum's underlying value actually is.
+For an `Int`-valued enum this is correct; for a `Rat`/`Num`-valued enum (any
+`EnumValue::Generic` wrapping a non-Int numeric type) it silently truncates
+away the fractional part.
+
+## Suggested fix
+
+`coerce_to_numeric`'s `Enum` arm should numify via `value.to_value()`
+followed by a recursive `coerce_to_numeric` call (or an equivalent that
+preserves the wrapped type), not `Value::int(value.as_i64())` specifically.
+
+## Severity
+
+Low: a Rat/Num-valued enum is an unusual shape (most enums are Int- or
+Str-valued); no roast test currently depends on this.


### PR DESCRIPTION
## Summary
- `arith_negate`'s `BigInt` arm now uses `Value::from_bigint` (not the raw `Value::bigint`), so negating a BigInt that lands back in `i64` range (e.g. `-2**63`) downcasts to a plain `Int` like every other BigInt-producing op already does.
- `EnumValue::as_i64()` now numifies a `Generic`-stored enum variant's wrapped value instead of unconditionally returning `0`, as defense in depth.
- `rat_from_i128_or_num` (`src/builtins/arith/rat.rs`) now delegates to the already-correct `make_big_rat_arith` instead of duplicating a narrower, wrong overflow check — fixes a real regression the BigInt fix surfaced in `t/bigrat-sort-compare.t`: `Int + Rat` addition lost fractional precision whenever only the **numerator** (not the denominator) overflowed `i64`, even though Raku's `Rat` has no numerator size bound.
- Filed `todo/tickets/rat-valued-enum-numeric-coercion-loses-fraction.md` for a separate, out-of-scope bug found along the way (a `Rat`-valued enum's numeric coercion still truncates to `Int`).
- Updated `todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md` with the root-cause finding (the "No matching candidates for proto sub: matches" fatal in CBOR::Simple's own suite was a downstream symptom of this bug, not a proto-dispatch bug) and re-measured progress.

Found investigating `CBOR::Simple`'s own integer-boundary enum constants (`enum CBORMinMax (... CBOR_Min_NInt_63Bit => -9223372036854775808, ...)`), which triggered exactly this negation shape and made every negative-integer `cbor-encode` call take the wrong branch of a chained comparison.

## Test plan
- [x] New regression test `t/bigint-negate-and-rat-overflow-precision.t` (11 assertions), all verified against real `raku`.
- [x] `prove -e target/debug/mutsu t/*enum*.t t/*bigint*.t t/*negat*.t` and `t/*rat*.t t/*arith*.t` — clean.
- [x] `make test` — `Files=3232, Tests=29974, ... Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)