### PR TITLE
fix(eval): EVAL's own compile-check pipeline enforces type-capture inheritance rejection

### DIFF
--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -101,6 +101,7 @@ impl Interpreter {
                 self.check_eval_post_declared_types(&stmts)?;
                 self.check_eval_begin_forward_calls(&stmts)?;
                 self.check_eval_param_type_constraints(&stmts)?;
+                self.check_type_capture_inheritance(&stmts)?;
                 // When EVAL is called inside a class body, MethodDecl statements
                 // should be added to the enclosing class rather than lowered to subs.
                 let mut stmts = self.inject_eval_methods_into_class(stmts);

--- a/t/eval-type-capture-inheritance-compile-check.t
+++ b/t/eval-type-capture-inheritance-compile-check.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 3;
+
+# Rakudo rejects `class C is T {}` where `T` is an enclosing routine/block's
+# type-capture parameter (`::T`) at compile time — before the enclosing
+# block/routine is ever called, and even when it is never called at all
+# (X::Inheritance::Unsupported). `run.rs`'s top-level mainline pipeline
+# already ran this check (`check_type_capture_inheritance`), but the general
+# `EVAL` builtin's own parse-and-check pipeline
+# (`Interpreter::parse_and_eval_with_operators`) did not, so an `EVAL`'d
+# string with this shape silently defined the block/class instead of dying —
+# only reachable in practice through the vendored real `Test.rakumod`'s
+# `throws-like`, whose string form is a genuine `EVAL $code, context => ...`
+# (`todo/deep/vendor-real-test-module.md`, `t/error-reporting-quality.t`
+# under `MUTSU_REAL_TEST=1`).
+
+throws-like q{ -> ::TC129906 { class :: is TC129906 {} } },
+    X::Inheritance::Unsupported, message => /TC129906/,
+    'EVAL of a pointy-block type-capture inheritance dies without being called';
+
+throws-like q{ sub f(::T $x) { class C-tc is T {} } },
+    X::Inheritance::Unsupported, message => /'C-tc'/,
+    'EVAL of a sub-scoped type-capture inheritance dies without being called';
+
+# Same shape, but through EVAL's `context => CALLER::` form specifically —
+# the exact call the real Test.rakumod's throws-like makes.
+{
+    sub outer() {
+        EVAL '-> ::TC129906 { class :: is TC129906 {} }', context => CALLER::;
+    }
+    dies-ok { outer() }, 'EVAL with an explicit context => still runs the check';
+}


### PR DESCRIPTION
## Summary
- Rakudo rejects \`class C is T {}\` at *compile time* when \`T\` is an enclosing routine/block's type-capture parameter (\`::T\`), even when that routine/block is never called. mutsu already had this check (\`check_type_capture_inheritance\`) wired into the top-level mainline pipeline (\`run.rs\`), but the general \`EVAL\` builtin's own parse-and-check pipeline (\`Interpreter::parse_and_eval_with_operators\`, \`src/runtime/system.rs\`) never called it, so \`EVAL '-> ::T { class :: is T {} }'\` silently defined the block instead of dying.
- Only surfaced through the vendored real \`Test.rakumod\`: its string-form \`throws-like\` is a genuine \`EVAL \$code, context => ...\`, while mutsu's *native* \`throws-like\` provider spins up a whole nested \`Interpreter\` and runs the top-level pipeline directly (which already had the check) — masking the gap. \`t/error-reporting-quality.t\` under \`MUTSU_REAL_TEST=1\` (part of the ongoing \`todo/deep/vendor-real-test-module.md\` campaign) is what surfaced it.
- One-line fix: call the existing, already-correct check from EVAL's own pipeline too.

## Test plan
- [x] New pin: \`t/eval-type-capture-inheritance-compile-check.t\` (verified byte-identical against \`raku\`)
- [x] \`cargo clippy -- -D warnings\` / \`cargo fmt --check\` clean
- [x] Full local \`prove -j8 -e target/debug/mutsu t/\` — 3233/3233 files pass
- [x] \`scripts/test-module-sweep.sh\` (release build) — \`t/error-reporting-quality.t\` no longer regresses under \`MUTSU_REAL_TEST=1\`; the remaining regressions are all confirmed pre-existing on \`main\` (checked via \`git stash\` + rebuild), unrelated to this change
- [x] Targeted roast: \`S12-class/*.t\`, \`S02-types/whatever.t\`, \`S04-exceptions/*.t\`, plus the full whitelist sweep, all clean (one \`S32-io/spurt.t\` blip was a known stale-fixture artifact from repeated local runs, not a real failure — confirmed pre-existing and unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)