### PR TITLE
fix(compiler): if branches and bare blocks with LEAVE no longer clobber $_

### DIFF
--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -48,7 +48,7 @@ impl Compiler {
                 // A tail block with ENTER/LEAVE/... phasers must run them through a
                 // real `BlockScope` rather than being inlined (which drops them).
                 if Self::has_block_enter_leave_phasers(inner) {
-                    self.compile_phaser_block_scope(inner, true);
+                    self.compile_phaser_block_scope(inner, PhaserBlockResult::Push);
                 } else {
                     self.compile_block_inline(inner);
                 }
@@ -192,7 +192,7 @@ impl Compiler {
                         // `result_on_stack` keeps its value on the stack, matching
                         // the inline path.
                         if Self::has_block_enter_leave_phasers(inner) {
-                            self.compile_phaser_block_scope(inner, true);
+                            self.compile_phaser_block_scope(inner, PhaserBlockResult::Push);
                         } else if matches!(stmt, Stmt::Block(_)) {
                             // Genuine source `{ ... }` is a callframe.
                             self.compile_bare_block_inline(inner);

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -323,7 +323,7 @@ impl Compiler {
         // re-cloned per execution — see `OpCode::ResetStateLocals`.
         let then_state_reset = self.emit_branch_state_reset(then_branch, is_statement_modifier);
         if Self::has_block_enter_leave_phasers(then_branch) {
-            self.compile_phaser_block_scope(then_branch, true);
+            self.compile_phaser_block_scope(then_branch, PhaserBlockResult::Push);
         } else {
             self.compile_stmts_value(then_branch);
         }
@@ -340,7 +340,7 @@ impl Compiler {
         } else {
             let else_state_reset = self.emit_branch_state_reset(else_branch, is_statement_modifier);
             if Self::has_block_enter_leave_phasers(else_branch) {
-                self.compile_phaser_block_scope(else_branch, true);
+                self.compile_phaser_block_scope(else_branch, PhaserBlockResult::Push);
             } else {
                 self.compile_stmts_value(else_branch);
             }
@@ -519,7 +519,7 @@ impl Compiler {
             // "mirrors" the ordinary arm without actually doing so for this
             // one case. Deliberately `has_block_leave_worthy_phasers`, not
             // `has_block_enter_leave_phasers` — see that function's doc.
-            self.compile_phaser_block_scope(stmts, false);
+            self.compile_phaser_block_scope(stmts, PhaserBlockResult::Discard);
         } else if Self::body_mutates_topic(stmts) {
             self.synthetic_block_body = true;
             self.compile_stmt(&Stmt::Block(stmts.to_vec()));

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -79,7 +79,7 @@ impl Compiler {
                 isolate_decls_idx: u32::MAX,
             });
             let saved = self.push_dynamic_scope_lexical();
-            self.compile_phaser_block_scope(body, true);
+            self.compile_phaser_block_scope(body, PhaserBlockResult::Push);
             self.pop_dynamic_scope_lexical(saved);
             self.code.patch_body_end(do_idx);
             return;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1467,6 +1467,26 @@ pub(crate) struct Compiler {
     outer_constant_values: HashMap<String, Value>,
 }
 
+/// How [`Compiler::compile_phaser_block_scope`] should dispose of a
+/// phaser-bearing block's trailing value.
+pub(super) enum PhaserBlockResult {
+    /// Leave the value on the VM stack for the caller to consume (an
+    /// expression-context block, e.g. a `do { ... }` block or an `if`/`given`
+    /// used as an expression).
+    Push,
+    /// Route the value through the topic register as this compiled unit's
+    /// own implicit return value. Only safe when `stmts` is a fresh call
+    /// frame's own body (a routine's compiled body) — that frame's topic
+    /// register is its own, so this cannot leak into a caller's `$_`.
+    ReturnViaTopic,
+    /// Discard the value entirely, without touching the topic. Used for
+    /// same-frame statement contexts (a bare `{ ... }` statement, an
+    /// `if`/`given` body compiled as a statement) where the enclosing
+    /// scope's live `$_` (e.g. a `given`'s topicalized value) must survive
+    /// the body's own trailing statement.
+    Discard,
+}
+
 impl Compiler {
     pub(crate) fn new() -> Self {
         Self {
@@ -2975,7 +2995,7 @@ impl Compiler {
             self.compile_implicit_try(stmts);
             self.code.emit(OpCode::SetTopic);
         } else if self.is_routine && Self::has_block_enter_leave_phasers(stmts) {
-            self.compile_phaser_block_scope(stmts, false);
+            self.compile_phaser_block_scope(stmts, PhaserBlockResult::ReturnViaTopic);
         } else {
             for (i, stmt) in stmts.iter().enumerate() {
                 let is_last = i == stmts.len() - 1;
@@ -3011,7 +3031,10 @@ impl Compiler {
                             // block value via the topic (matching the SetTopic the
                             // inline path emits).
                             if Self::has_block_enter_leave_phasers(body) {
-                                self.compile_phaser_block_scope(body, false);
+                                self.compile_phaser_block_scope(
+                                    body,
+                                    PhaserBlockResult::ReturnViaTopic,
+                                );
                                 continue;
                             }
                             // A genuine source `{ ... }` is a Raku callframe; a
@@ -3081,11 +3104,17 @@ impl Compiler {
     /// semantics (trailing ENTER as block value, `SetLine`-marker handling) stay
     /// in one place.
     ///
-    /// `result_on_stack` selects how the block's value is delivered: `false`
-    /// (statement context) routes it through the topic (`SetTopic`, stack-neutral);
-    /// `true` (expression context, e.g. `do { ... }`) leaves it on the value stack
-    /// for the enclosing `DoBlockExpr` to consume.
-    pub(super) fn compile_phaser_block_scope(&mut self, stmts: &[Stmt], result_on_stack: bool) {
+    /// `mode` selects how the block's trailing value is disposed of — see
+    /// [`PhaserBlockResult`]. Do NOT use `ReturnViaTopic` for a same-frame
+    /// statement context (a bare block statement, an `if`/`given` body): real
+    /// Raku never sets `$_` from a block's own trailing statement value (`{
+    /// 1; 2 }` does not make `$_` become `2`), and `SetTopic` there would
+    /// clobber whatever `$_` the enclosing scope (e.g. a `given`'s
+    /// topicalized value) already has live, since such a body shares the
+    /// current frame's topic register rather than getting a fresh one. It is
+    /// only safe for a routine's own compiled body, which always runs in its
+    /// own fresh call frame (see `news/2026-08/given-if-block-scope-topic-clobber.md`).
+    pub(super) fn compile_phaser_block_scope(&mut self, stmts: &[Stmt], mode: PhaserBlockResult) {
         let idx = self.code.emit(OpCode::BlockScope {
             pre_end: 0,
             enter_end: 0,
@@ -3174,7 +3203,13 @@ impl Compiler {
                 self.compile_stmt(s);
             }
             self.code.emit(OpCode::LoadEnterResult);
-            if !result_on_stack {
+            // `Discard` behaves like `Push` here (the value stays on the VM
+            // stack through the LEAVE/KEEP/UNDO/POST sections below, so their
+            // truthy/falsy KEEP-vs-UNDO check and any POST-phaser read of it
+            // still see the real value) -- the trailing `Pop` that actually
+            // discards it is emitted once, after those sections, at the very
+            // end of this function.
+            if matches!(mode, PhaserBlockResult::ReturnViaTopic) {
                 self.code.emit(OpCode::SetTopic);
             }
         } else {
@@ -3187,18 +3222,26 @@ impl Compiler {
                 .rposition(|s| !matches!(s, Stmt::SetLine(_)));
             for (i, s) in body_stmts.iter().enumerate() {
                 if Some(i) == last_value_idx {
-                    if result_on_stack {
-                        self.compile_last_stmt_as_value(s);
-                    } else {
-                        self.compile_last_stmt_as_topic(s);
+                    match mode {
+                        // `Discard` leaves the value on the stack too (see the
+                        // trailing `Pop` at the end of this function) so the
+                        // LEAVE/KEEP/UNDO/POST sections below can still see it.
+                        PhaserBlockResult::Push | PhaserBlockResult::Discard => {
+                            self.compile_last_stmt_as_value(s)
+                        }
+                        PhaserBlockResult::ReturnViaTopic => self.compile_last_stmt_as_topic(s),
                     }
                 } else {
                     self.compile_stmt(s);
                 }
             }
-            // A phaser-only block (no value-producing statement) in expression
-            // context still needs a value on the stack for the consumer.
-            if result_on_stack && last_value_idx.is_none() {
+            // A phaser-only block (no value-producing statement) still needs a
+            // value on the stack: for `Push`, the consumer needs one; for
+            // `Discard`, the trailing `Pop` at the end of this function always
+            // runs and needs something to pop.
+            if matches!(mode, PhaserBlockResult::Push | PhaserBlockResult::Discard)
+                && last_value_idx.is_none()
+            {
                 self.emit_nil_value();
             }
         }
@@ -3248,5 +3291,11 @@ impl Compiler {
         self.code.patch_block_post_start(idx);
         Self::compile_post_phasers(self, stmts);
         self.code.patch_loop_end(idx);
+        // `Discard` kept the value on the stack through the sections above (so
+        // KEEP/UNDO's truthy check and POST's topic read see the real value);
+        // now that they have run, actually discard it.
+        if matches!(mode, PhaserBlockResult::Discard) {
+            self.code.emit(OpCode::Pop);
+        }
     }
 }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -815,7 +815,7 @@ impl Compiler {
                     self.next_try_is_bare_block = false;
                     self.code.emit(OpCode::Pop);
                 } else if Self::has_block_enter_leave_phasers(stmts) {
-                    self.compile_phaser_block_scope(stmts, false);
+                    self.compile_phaser_block_scope(stmts, PhaserBlockResult::Discard);
                 } else if Self::has_let_deep(stmts) {
                     // Block contains `let`/`temp` — wrap in LetBlock for save/restore
                     let idx = self.code.emit(OpCode::LetBlock { body_end: 0 });
@@ -2073,7 +2073,7 @@ impl Compiler {
                     // A branch with ENTER/LEAVE/KEEP/UNDO phasers is a real
                     // block scope: its LEAVE must fire when the branch exits
                     // (OO::Monitors unlocks its monitor lock this way).
-                    self.compile_phaser_block_scope(then_branch, false);
+                    self.compile_phaser_block_scope(then_branch, PhaserBlockResult::Discard);
                 } else if Self::body_mutates_topic(then_branch) {
                     self.synthetic_block_body = true;
                     self.compile_stmt(&Stmt::Block(then_branch.clone()));
@@ -2101,7 +2101,7 @@ impl Compiler {
                     if else_branch.len() == 1 && matches!(else_branch[0], Stmt::If { .. }) {
                         self.compile_stmt(&else_branch[0]);
                     } else if Self::has_block_enter_leave_phasers(else_branch) {
-                        self.compile_phaser_block_scope(else_branch, false);
+                        self.compile_phaser_block_scope(else_branch, PhaserBlockResult::Discard);
                     } else if Self::body_mutates_topic(else_branch) {
                         self.synthetic_block_body = true;
                         self.compile_stmt(&Stmt::Block(else_branch.clone()));
@@ -3011,18 +3011,26 @@ impl Compiler {
                     // phaser-only body through `compile_phaser_block_scope`
                     // left its topic unset, breaking POST/PRE inside loops.
                     //
-                    // `result_on_stack: true` (unlike the `Stmt::If` arm's
-                    // `false`): the ordinary (non-phaser) `else` branch below
-                    // already leaves the body's tail value on the stack via
-                    // `compile_when_tail_stmt` for `exec_given_op`'s `last`
-                    // tracking, with `$_` staying the given's own topic the
-                    // whole time. `result_on_stack: false` instead routes the
-                    // tail value through `SetTopic` — reassigning `$_` to the
-                    // body's own last-statement value — which clobbered the
-                    // topic a LEAVE phaser needs (`given open $path, :w { LEAVE
-                    // .close; say $_ }` made `.close` see the `say`'s `Bool`
-                    // result instead of the file handle).
-                    self.compile_phaser_block_scope(body, true);
+                    // This is a *statement*-context `given` (an expression-
+                    // context one, e.g. `do given ... { ... }`, compiles
+                    // through a different, `Push`-mode path) sharing the
+                    // enclosing frame's `$_` register. `PhaserBlockResult::
+                    // Discard` (not `ReturnViaTopic`, unlike the `Stmt::If`
+                    // arm before this same fix): routing the body's own
+                    // trailing value through `SetTopic` reassigned `$_` to
+                    // it, clobbering the topic a LEAVE phaser needs (`given
+                    // open $path, :w { LEAVE .close; say $_ }` made `.close`
+                    // see `say`'s `Bool` result instead of the file handle,
+                    // breaking roast/S32-io/open.t and spurt.t). `Discard`
+                    // still lets the value survive on the stack through
+                    // LEAVE/KEEP/UNDO/POST (so their own checks/reads still
+                    // see it), then pops it once at the very end instead of
+                    // ever routing it through `$_` -- verified against real
+                    // raku for both statement-context `given` (a trailing
+                    // sink-context warning, same as raku) and `do given`
+                    // expression context (the value still comes through
+                    // correctly, via the separate `Push`-mode path).
+                    self.compile_phaser_block_scope(body, PhaserBlockResult::Discard);
                 } else if Self::has_catch_or_control(body) {
                     self.compile_implicit_try(body);
                     self.code.emit(OpCode::Pop);

--- a/t/block-scope-trailing-value-does-not-clobber-topic.t
+++ b/t/block-scope-trailing-value-does-not-clobber-topic.t
@@ -1,0 +1,80 @@
+use Test;
+
+plan 9;
+
+# A block's own trailing statement value must never become `$_`: real raku
+# never sets `$_` from a block's own last statement value (`{ 1; 2 }` does not
+# make `$_` become `2`). A LEAVE-phaser-bearing bare block, if-branch, or
+# given body is compiled through a dedicated `BlockScope` opcode
+# (compile_phaser_block_scope) so LEAVE actually fires on any exit -- but
+# that path used to route the trailing value through `SetTopic`
+# unconditionally, clobbering whatever `$_` the enclosing scope (or a
+# `given`'s own topicalized value) had live. Found investigating a CI
+# regression on roast/S32-io/open.t's `given open(...) { LEAVE .close; ... }`
+# shape. See news/2026-08/given-if-block-scope-topic-clobber.md.
+
+{
+    $_ = 'outer';
+    { 'x'.chars; LEAVE { is $_, 'outer', 'bare block with LEAVE does not clobber the outer topic' } }
+}
+
+{
+    $_ = 'outer';
+    if True { 'x'.chars; LEAVE { is $_, 'outer', 'if-branch with LEAVE does not clobber the outer topic' } }
+}
+
+{
+    $_ = 'outer';
+    if False { } else { 'x'.chars; LEAVE { is $_, 'outer', 'if-else branch with LEAVE does not clobber the outer topic' } }
+}
+
+{
+    my $seen;
+    given 'x' {
+        .chars;
+        LEAVE { $seen = $_ }
+    }
+    is $seen, 'x', "given's LEAVE sees the given topic, not the body's trailing value";
+}
+
+{
+    my $log = '';
+    given (my $fh = 42) {
+        .Numeric;
+        LEAVE { $log ~= "close:{.raku} " }
+    }
+    is $log, 'close:42 ', "given's LEAVE topic survives multiple non-trailing method calls on it";
+}
+
+# Regression guard: the fix must not break KEEP/UNDO's truthy-value check,
+# which depends on actually seeing the block's real trailing value (just not
+# via `$_`).
+{
+    my $str;
+    {
+        KEEP { $str ~= 'K1 ' }
+        UNDO { $str ~= 'U1 ' }
+        1;
+    }
+    is $str, 'K1 ', 'block ending in a truthy value still runs KEEP';
+}
+
+{
+    my $str = '';
+    try {
+        KEEP { $str ~= 'K1 ' }
+        UNDO { $str ~= 'U1 ' }
+        die 'boom';
+    }
+    is $str, 'U1 ', 'a block that dies still runs UNDO';
+}
+
+# Regression guard: a routine's own implicit return value (threaded via the
+# topic register internally, since it runs in its own fresh call frame) must
+# still work, and must not leak into the caller's `$_`.
+{
+    $_ = 'outer';
+    sub f() { my $y = 5; LEAVE { }; 42 };
+    is f(), 42, "a routine's own LEAVE-bearing body still returns its trailing value";
+    is $_, 'outer', "a called routine's internal topic threading does not leak into the caller's \$_";
+}

--- a/todo/tickets/keep-undo-decided-by-value-truthiness-not-completion.md
+++ b/todo/tickets/keep-undo-decided-by-value-truthiness-not-completion.md
@@ -1,0 +1,63 @@
+# KEEP/UNDO are decided by the block's trailing-value truthiness, but real raku decides by normal-completion-vs-exception
+
+Found while fixing `todo/tickets` (given/if `LEAVE`-phaser topic-clobber
+regression, PR #6635) and writing its regression test
+(`t/block-scope-trailing-value-does-not-clobber-topic.t`): the *existing*
+local test `t/enter-phaser-rvalue.t` test 13 ("block ending in a falsy value
+runs UNDO") does not actually match real `raku`.
+
+## Repro
+
+```raku
+my $s = "";
+{ KEEP { $s ~= "K" }; UNDO { $s ~= "U" }; 0 }
+say $s;
+$s = "";
+{ KEEP { $s ~= "K" }; UNDO { $s ~= "U" }; False }
+say $s;
+```
+
+```
+raku:  K
+       K
+mutsu: K
+       U     <- wrong: mutsu runs UNDO because the trailing value (False) is falsy
+```
+
+Confirmed with `try`/`die` that real `raku`'s actual rule is normal
+completion vs. exception, not value truthiness:
+
+```raku
+my $s = "";
+try { KEEP { $s ~= "K1 " }; UNDO { $s ~= "U1 " }; die "boom" }
+say $s;   # raku: U1  (both raku and mutsu agree here)
+```
+
+So a block ending in `0`/`False`/any falsy-but-non-exceptional value still
+runs **KEEP** in real Raku; only an actual thrown exception (or presumably
+`fail`, not yet separately verified) runs **UNDO**. mutsu's
+`should_run_success_queue` (`src/vm/vm_misc_scope.rs`, consulted by
+`exec_block_scope_op`) currently treats a falsy `body_value` as "the block
+failed" and routes to UNDO instead of KEEP, which is wrong.
+
+## Where it goes
+
+`src/vm/vm_misc_scope.rs`, `Self::should_run_success_queue(&body_result,
+body_value)` — currently checks `body_value`'s truthiness (grep its
+definition; not read in detail during this investigation). It should instead
+only look at `body_result` (`Err` = exceptional exit -> UNDO, `Ok` = normal
+completion -> KEEP), ignoring the value entirely.
+
+## Existing test with a wrong assertion
+
+`t/enter-phaser-rvalue.t` test 13 ("block ending in a falsy value runs
+UNDO") asserts the current (wrong) mutsu behavior, not real raku's. Whoever
+fixes this ticket should also fix that assertion (verified against real
+raku: KEEP fires for a falsy-but-normal trailing value; only an exceptional
+exit runs UNDO).
+
+## Severity
+
+Unclear how many other tests key off this rule; not yet checked whether
+roast has a specific test for KEEP/UNDO truthiness vs. completion semantics.
+Not blocking anything currently in progress — flagged for a future session.


### PR DESCRIPTION
## Summary
- Follow-up to #6635 (merged as commit 031ec2dc0), which fixed the `given`+LEAVE `$_`-clobber regression but left an identical bug in `if`/`if-else` branches and plain bare `{ ... }` block statements — that commit's own message claimed SetTopic was "correct for an if branch," which is not the case (verified against real raku).
- `compile_phaser_block_scope`'s `result_on_stack: bool` conflated two different things under `false`: a routine's own compiled body legitimately threads its trailing value out via the topic register as that fresh call frame's own implicit return value (safe — each frame's topic storage is its own). But an `if`-branch or bare-block statement runs in the *same* frame as the enclosing scope, so the same `SetTopic` clobbers whatever `$_` that scope already had live with the block's own trailing value — something real raku never does (`{ 1; 2 }` doesn't make `$_` become `2`).
  ```raku
  $_ = "outer";
  if True { "x".chars; LEAVE { say $_ } }   # raku: outer, mutsu (before): True
  { "x".chars; LEAVE { say $_ } }           # raku: outer, mutsu (before): True
  ```
- Replaced the bool with a three-way `PhaserBlockResult` enum (`Push` / `ReturnViaTopic` / `Discard`) and routed the if-branch and bare-block-statement call sites through `Discard` (matching `given`'s existing #6635 fix). `Discard` still lets the trailing value survive on the VM stack through the LEAVE/KEEP/UNDO/POST sections (so KEEP-vs-UNDO's truthy check and POST's topic read keep working), then pops it once at the very end instead of ever routing it through `$_`.
- Found but out of scope: writing the regression test surfaced that KEEP/UNDO in mutsu are decided by the block's trailing-value truthiness, but real raku decides by normal-completion-vs-exception (`0`/`False` still runs KEEP in real raku). Filed as `todo/tickets/keep-undo-decided-by-value-truthiness-not-completion.md`.

## Test plan
- [x] New regression test `t/block-scope-trailing-value-does-not-clobber-topic.t` (9 assertions, all verified against real raku): bare block, if-branch, if-else branch, given, KEEP/UNDO, and routine-return-value cases together.
- [x] `prove -e target/debug/mutsu t/*phaser*.t t/*given*.t t/*leave*.t t/*enter*.t t/*undo*.t t/*keep*.t` — 61 files / 524 tests, clean.
- [x] `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S32-io/open.t roast/S32-io/spurt.t roast/S04-phasers/*.t roast/S04-declarations/*.t` — 28 files / 706 tests, clean.
- [x] `make test` — `Files=3236, Tests=30001, ... Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)