### PR TITLE
docs(todo): wide-buffer bit-accessor divergence likely leaks MoarVM memory layout

### DIFF
--- a/todo/tickets/wide-buffer-bit-accessor-width-divergence.md
+++ b/todo/tickets/wide-buffer-bit-accessor-width-divergence.md
@@ -24,3 +24,37 @@ unaffected, which is why this was never a bundling blocker.
 Buffer bit-accessor implementation (`read-ubits`/`read-bits`/`write-ubits`/`write-bits` methods on
 `Buf`/typed buffers) — search for where the existing byte-storage indexing fix landed and work out
 the width-aware offset semantics MoarVM actually uses for a >1-byte element buffer.
+
+## Update (2026-08-18): likely not worth chasing -- looks like leaked MoarVM memory layout, not a real semantic
+
+Probed further against real `raku` to find the actual rule (`bytes/rust src/builtins/buf_bits.rs`
+already implements a clean, self-consistent "raw byte slice, big-endian bit order" model for
+width-1 buffers, which is correct):
+
+```
+$ raku -e 'my $b = buf32.new(0x11223344, 0x55667788);
+for 0,1,4,7,8,15,16,31,32,33,40 -> $pos {
+  for 1,4,8,16,32 -> $bits {
+    next if $pos + $bits > 64;
+    say "pos=$pos bits=$bits -> " ~ $b.read-ubits($pos, $bits).base(16);
+  }
+}'
+pos=0 bits=1 -> 0
+pos=0 bits=4 -> 4
+pos=0 bits=8 -> 11223344
+pos=0 bits=16 -> 1177777788
+pos=0 bits=32 -> DIES: "Can only read 1..16 bits from position 0 in buffer '$b', you tried: 32"
+```
+
+`read-ubits(0, 8)` (asking for 8 bits) returns `0x11223344` — a 32-bit-magnitude number, not an
+8-bit one. `read-ubits(0, 16)` returns `0x1177777788`, a ~40-bit number that isn't a clean
+sub-range of either element either. And `bits=32` is rejected outright with a "1..16" range limit
+that has no documented rationale. None of this is explainable as "bit offset into a flat byte
+buffer, endian-adjusted" — it looks like MoarVM's `read_ubits` for a non-uint8 native-typed buffer
+does raw, alignment-sensitive pointer arithmetic over its internal C representation and leaks
+whatever bytes end up adjacent, rather than implementing a well-defined bit-addressing scheme. This
+reads as leaked implementation-defined/undefined behavior (likely even non-portable across
+MoarVM versions or host byte order), not a real Raku language semantic worth byte-for-byte
+replication. Combined with zero roast coverage and zero real dist impact (per the "Status" section
+above), this is a poor investment — recommend leaving unfixed unless a roast test or real dist
+surfaces a concrete, well-defined case.


### PR DESCRIPTION
## Summary
- Continued investigating `todo/tickets/wide-buffer-bit-accessor-width-divergence.md` (a `buf32`/`buf64` `read-ubits`/`write-bits` offset divergence from MoarVM found while bundling `Digest`, not a blocker there since every practical use is width-1 buffers).
- Probed real `raku`'s `read-ubits` on a `buf32` across several `pos`/`bits` combinations. The results aren't explainable as any well-defined bit-addressing scheme: `read-ubits(0, 8)` (asking for 8 bits) returns a 32-bit-magnitude number; `read-ubits(0, 16)` returns a ~40-bit number that isn't a clean sub-range of either element; `bits=32` is rejected with an undocumented "1..16" range limit.
- This looks like MoarVM's `read_ubits` doing raw, alignment-sensitive pointer arithmetic over its internal C representation for non-uint8 native-typed buffers and leaking adjacent bytes, rather than implementing a real bit-addressing semantic — likely non-portable even across MoarVM versions or host byte order.
- Recorded this finding in the ticket: combined with zero roast coverage and zero real dist impact, not worth byte-for-byte replication unless a roast test or real dist surfaces a concrete, well-defined case.

No code changes — this is a docs-only update to the ticket ledger.

## Test plan
- N/A (docs-only change; CI's docs-only fast path applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)