### PR TITLE
fix(runtime): EVAL's undeclared-var pre-check knows about a method's implicit *%_

### DIFF
--- a/src/runtime/system_eval_vars.rs
+++ b/src/runtime/system_eval_vars.rs
@@ -303,22 +303,15 @@ impl Interpreter {
                 Self::add_sub_signature_locals(param_defs, &mut inner);
                 self.find_undeclared_var_in_body(body, &inner)
             }
-            Stmt::ClassDecl { body, .. } | Stmt::RoleDecl { body, .. } => {
-                // Attributes become `$!x` / `$.x` (and a bare `$x` only for
-                // `has $x` aliases). Methods in the body see them in scope.
-                let mut inner = declared.clone();
-                Self::add_class_attributes(body, &mut inner);
-                // Class-body lexicals (`my @a`) are also in scope for sibling
-                // statements/methods; collect them all up front.
-                for s in body {
-                    Self::collect_declared_vars(s, &mut inner);
-                }
-                for s in body {
-                    if let Some(result) = self.find_undeclared_var_in_stmt(s, &inner) {
-                        return Some(result);
-                    }
-                }
-                None
+            Stmt::ClassDecl {
+                body, is_hidden, ..
+            } => self.check_class_or_role_body_undeclared(body, declared, *is_hidden),
+            Stmt::RoleDecl { body, .. } => {
+                // A role's AST has no `is_hidden` concept -- the registry-level
+                // `role_def.is_hidden` flag set later (`registration_role_body.rs`)
+                // gates method-resolution *visibility*, unrelated to whether the
+                // implicit `*%_` slurpy is inserted; role methods always get one.
+                self.check_class_or_role_body_undeclared(body, declared, false)
             }
             _ => None,
         }
@@ -375,6 +368,81 @@ impl Interpreter {
         } else {
             Expr::Var(name.trim_start_matches('$').to_string())
         }
+    }
+
+    /// Check a class/role body statement-by-statement. Like the old combined
+    /// `Stmt::ClassDecl | Stmt::RoleDecl` arm, but a `Stmt::MethodDecl` inside
+    /// is checked with the class/role's own implicit-`*%_`/`*@_` rules seeded
+    /// into its scope (mirroring `method_signature_shared::
+    /// effective_method_param_defs`/`needs_direct_positional_placeholder_die`)
+    /// instead of only the user-written signature -- otherwise a method body
+    /// that legitimately reads `%_`/`@_` (every signature-less method gets an
+    /// implicit `*%_`, and a body that reads a bare `@_` directly still binds
+    /// any call arity before a runtime die) was wrongly flagged as
+    /// `X::Undeclared` when reached through `EVAL`/`throws-like`'s string
+    /// form, even though calling the same method directly works fine. See
+    /// todo/tickets/eval-undeclared-check-blind-to-implicit-method-slurpy.md.
+    fn check_class_or_role_body_undeclared(
+        &self,
+        body: &[Stmt],
+        declared: &HashSet<String>,
+        class_is_hidden: bool,
+    ) -> Option<(&'static str, String, Vec<String>)> {
+        // Attributes become `$!x` / `$.x` (and a bare `$x` only for
+        // `has $x` aliases). Methods in the body see them in scope.
+        let mut inner = declared.clone();
+        Self::add_class_attributes(body, &mut inner);
+        // Class-body lexicals (`my @a`) are also in scope for sibling
+        // statements/methods; collect them all up front.
+        for s in body {
+            Self::collect_declared_vars(s, &mut inner);
+        }
+        for s in body {
+            let Stmt::MethodDecl {
+                params,
+                param_defs,
+                body: method_body,
+                ..
+            } = s
+            else {
+                if let Some(result) = self.find_undeclared_var_in_stmt(s, &inner) {
+                    return Some(result);
+                }
+                continue;
+            };
+            if let Some(r) = Self::find_undeclared_var_in_param_wheres(param_defs) {
+                return Some(r);
+            }
+            let mut method_scope = inner.clone();
+            Self::add_routine_locals(params, method_body, &mut method_scope);
+            Self::add_sub_signature_locals(param_defs, &mut method_scope);
+            let effective = crate::method_signature_shared::effective_method_param_defs(
+                param_defs,
+                class_is_hidden,
+            );
+            for pd in &effective {
+                if !pd.name.is_empty() {
+                    method_scope
+                        .insert(pd.name.trim_start_matches(['$', '@', '%', '&']).to_string());
+                }
+            }
+            // A signature-less method body that reads a bare `@_` directly
+            // still binds any call arity (before dying with a specific
+            // message at call time) -- seed it too so this pre-check does not
+            // flag it as X::Undeclared ahead of that real runtime behavior.
+            // Unlike `%_`, this does not depend on `class_is_hidden`.
+            if param_defs.is_empty() {
+                let (use_positional, _) =
+                    crate::method_signature_shared::auto_signature_uses(method_body);
+                if use_positional {
+                    method_scope.insert("_".to_string());
+                }
+            }
+            if let Some(result) = self.find_undeclared_var_in_body(method_body, &method_scope) {
+                return Some(result);
+            }
+        }
+        None
     }
 
     /// Seed a lexical scope with a routine's parameters and any variables its

--- a/t/eval-method-implicit-slurpy-not-undeclared.t
+++ b/t/eval-method-implicit-slurpy-not-undeclared.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 5;
+
+# EVAL/throws-like's string form runs a static undeclared-variable pre-check
+# over the parsed AST before execution. It walked a Stmt::MethodDecl's
+# user-written params only, with no knowledge that a signature-less method
+# body legitimately gets an implicit `*%_` (unless the class is `is hidden`
+# or the signature already names an explicit named slurpy) or, if it reads
+# a bare `@_` directly, an implicit `*@_` that binds any arity before a
+# runtime die -- so `%_`/`@_` inside a method body reached through EVAL's
+# string form were wrongly flagged X::Undeclared, even though calling the
+# identical method directly (not through EVAL) works fine. See
+# todo/tickets/eval-undeclared-check-blind-to-implicit-method-slurpy.md.
+
+is EVAL(q[class EvalSlurpyD1 { method m { %_.elems } }; EvalSlurpyD1.new.m(a=>1,b=>2)]), 2,
+    'a class method reading the implicit %_ works through EVAL';
+
+is EVAL(q[role EvalSlurpyR2 { method m { %_.elems } }; class EvalSlurpyD2 does EvalSlurpyR2 {}; EvalSlurpyD2.new.m(a=>1,b=>2)]), 2,
+    'a role method reading the implicit %_ works through EVAL';
+
+is EVAL(q[class EvalSlurpyD3 { has $.x; method m { %_.elems + $.x } }; EvalSlurpyD3.new(x=>10).m(a=>1,b=>2)]), 12,
+    '%_ combined with an attribute read still works through EVAL';
+
+{
+    my $is_undeclared;
+    try {
+        EVAL(q[class EvalSlurpyD4 { method m { @_ } }; EvalSlurpyD4.new.m(1,2,3)]);
+        CATCH {
+            default { $is_undeclared = $_ ~~ X::Undeclared }
+        }
+    }
+    is $is_undeclared, False,
+        'a direct bare @_ read in a method body dies via its own specific placeholder check, not X::Undeclared, through EVAL';
+}
+
+# Sanity: EVAL still catches a genuinely undeclared variable in a method body.
+throws-like
+    q[class EvalSlurpyD5 { method m { $totally_undeclared_var_xyz } }; EvalSlurpyD5.new.m],
+    X::Undeclared,
+    'EVAL still flags a genuinely undeclared variable inside a method body';


### PR DESCRIPTION
## Summary
- `check_eval_undeclared_vars` (EVAL/`throws-like`'s string-form static pre-check) walked a `Stmt::MethodDecl`'s user-written params only, with no knowledge that a signature-less method body legitimately gets an implicit `*%_` (unless the class is `is hidden` or the signature already names an explicit named slurpy) or, if it reads a bare `@_` directly, an implicit `*@_` that binds any call arity before a runtime die — so a method body reading `%_`/`@_` was wrongly flagged `X::Undeclared` when reached through EVAL's string form, even though calling the identical method directly works fine:
  ```
  $ mutsu -e 'EVAL(q[class D { method m { %_.elems } }; say D.new.m(a=>1,b=>2)])'
  Runtime error: X::Undeclared: Variable '%_' is not declared.
  ```
- Replaced the combined `Stmt::ClassDecl | Stmt::RoleDecl` arm in `src/runtime/system_eval_vars.rs` with a new `check_class_or_role_body_undeclared` helper that special-cases a `MethodDecl` inside: it seeds the method's scope from `method_signature_shared::effective_method_param_defs` (the same single source of truth the real registration/compile path uses, gated on the class's own `is_hidden` — roles have no such AST-level concept and always get the implicit `*%_`), plus a direct-`@_`-read check mirroring `needs_direct_positional_placeholder_die`.

## Test plan
- [x] New regression test `t/eval-method-implicit-slurpy-not-undeclared.t` (5 assertions, verified against real raku): a class method, a role method, `%_` combined with an attribute read, a direct bare `@_` read (still dies via its own specific placeholder check, not `X::Undeclared`), and a sanity check that a genuinely undeclared variable is still caught.
- [x] `prove -e target/debug/mutsu t/*eval*.t t/*undeclared*.t t/*method*.t t/*slurpy*.t` — 336 files / 2791 tests, clean.
- [x] `make test` — `Files=3236, Tests=29997, ... Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)