### PR TITLE
fix(vm): cache proto method compiled bytecode instead of recompiling per call

### DIFF
--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -261,7 +261,7 @@ impl Interpreter {
         proto: FunctionDef,
     ) -> Result<Value, RuntimeError> {
         let rewritten = Self::rewrite_proto_dispatch_stmts(&proto.body);
-        let method_def = MethodDef {
+        let mut method_def = MethodDef {
             lexical_package: proto.package.resolve(),
             params: proto.params.clone(),
             param_defs: proto.param_defs.clone(),
@@ -283,6 +283,28 @@ impl Interpreter {
             source_file: proto.source_file.clone(),
             role_param_bindings: None,
         };
+        // ADR-0019 D3-8 never compiled proto method bodies at plan-lowering
+        // time (`todo/tickets/adr0019-method-body-compile-dedup-remnants.md`
+        // item 2): without this cache, `method_def` above always started with
+        // `compiled_code: None`, forcing `run_resolved_method_compiled_or_treewalk`'s
+        // on-demand-compile path to recompile the SAME proto body from AST on
+        // every single call rather than once. Reuse a prior compile of this
+        // exact `(owner_class, method_name)` proto if one exists; otherwise
+        // compile once here and cache it for every later call.
+        if let Some((cc, fns)) = self.registry().get_proto_compiled(owner_class, method_name) {
+            method_def.compiled_code = Some(cc);
+            method_def.compiled_fns = fns;
+        } else {
+            let dist = self.resolve_package_distribution(owner_class);
+            Self::compile_method_def_in_place_with_dist(&mut method_def, owner_class, dist);
+            if let Some(cc) = method_def.compiled_code.clone() {
+                self.registry_mut().set_proto_compiled(
+                    owner_class,
+                    method_name,
+                    (cc, method_def.compiled_fns.clone()),
+                );
+            }
+        }
         let attributes = match invocant.view() {
             ValueView::Instance { attributes, .. } => attributes.as_map().clone(),
             _ => crate::value::AttrMap::new(),

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -340,6 +340,23 @@ pub(crate) struct Registry {
     /// play. The actual proto bodies live in `MethodEntry::proto`
     /// (`method_entries`), read per-owner via [`Registry::method_entry_proto`].
     pub(crate) has_proto_methods: bool,
+    /// Compiled bytecode for a `proto method`/`proto submethod` body, keyed by
+    /// `(owner, method_name)`. ADR-0019 D3-8 (`todo/tickets/
+    /// adr0019-method-body-compile-dedup-remnants.md` item 2) never covered
+    /// proto method bodies: `Interpreter::run_proto_method` used to rebuild an
+    /// uncompiled `MethodDef` and recompile the body from AST on EVERY call
+    /// (via the on-demand-compile path in `run_resolved_method_celled`), not
+    /// just once at registration. Cleared for a key whenever
+    /// [`Registry::set_proto_method`] installs a new body there (class
+    /// redeclaration / EVAL), so a stale compile can never survive a real
+    /// body change.
+    pub(crate) proto_compiled_cache: HashMap<
+        MethodEntryKey,
+        (
+            Arc<crate::opcode::CompiledCode>,
+            Option<Arc<crate::opcode::CompiledFns>>,
+        ),
+    >,
 }
 
 impl Registry {
@@ -459,15 +476,54 @@ impl Registry {
         method_name: &str,
         def: FunctionDef,
     ) {
-        self.method_entries
-            .entry(MethodEntryKey {
-                owner: Symbol::intern(class_name),
-                name: Symbol::intern(method_name),
-            })
-            .or_default()
-            .proto = Some(def);
+        let key = MethodEntryKey {
+            owner: Symbol::intern(class_name),
+            name: Symbol::intern(method_name),
+        };
+        self.method_entries.entry(key).or_default().proto = Some(def);
+        self.proto_compiled_cache.remove(&key);
         self.has_proto_methods = true;
         self.bump_method_generation();
+    }
+
+    /// Cached compiled bytecode for a proto method body, if this exact
+    /// `(owner, method_name)` proto has already been compiled once by
+    /// [`Self::set_proto_compiled`]. See `proto_compiled_cache`'s field doc.
+    pub(crate) fn get_proto_compiled(
+        &self,
+        owner: &str,
+        method_name: &str,
+    ) -> Option<(
+        Arc<crate::opcode::CompiledCode>,
+        Option<Arc<crate::opcode::CompiledFns>>,
+    )> {
+        self.proto_compiled_cache
+            .get(&MethodEntryKey {
+                owner: Symbol::intern(owner),
+                name: Symbol::intern(method_name),
+            })
+            .cloned()
+    }
+
+    /// Cache a proto method body's compiled bytecode after the first
+    /// on-demand compile, so every later call reuses it instead of
+    /// recompiling from AST. See `proto_compiled_cache`'s field doc.
+    pub(crate) fn set_proto_compiled(
+        &mut self,
+        owner: &str,
+        method_name: &str,
+        compiled: (
+            Arc<crate::opcode::CompiledCode>,
+            Option<Arc<crate::opcode::CompiledFns>>,
+        ),
+    ) {
+        self.proto_compiled_cache.insert(
+            MethodEntryKey {
+                owner: Symbol::intern(owner),
+                name: Symbol::intern(method_name),
+            },
+            compiled,
+        );
     }
 
     /// The `MethodEntry.proto` column at exactly `(class_name, method_name)`

--- a/tests/proto_method_body_compiled_once.rs
+++ b/tests/proto_method_body_compiled_once.rs
@@ -1,0 +1,48 @@
+//! Pins the `todo/tickets/adr0019-method-body-compile-dedup-remnants.md`
+//! (item 2) fix: `Interpreter::run_proto_method` used to rebuild a fresh,
+//! uncompiled `MethodDef` for a `proto method`/`proto submethod` body on
+//! EVERY call, forcing `run_resolved_method_celled`'s on-demand-compile path
+//! to recompile the same body from AST every time instead of once. A
+//! recursive `proto method` dispatch (`t/where-named-param-sibling-ref.t`'s
+//! binomial-triangle shape) used to trigger 265 recompiles; the fix caches
+//! the compiled body on `Registry::proto_compiled_cache`, keyed by
+//! `(owner, method_name)`. A regression here reintroduces the per-call
+//! recompile.
+
+use std::process::Command;
+
+#[test]
+fn recursive_proto_method_body_compiles_once_not_per_call() {
+    let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("t")
+        .join("where-named-param-sibling-ref.t");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mutsu"));
+    cmd.arg(&script);
+    cmd.env("MUTSU_VM_STATS", "1");
+    let out = cmd.output().expect("failed to spawn mutsu");
+    assert!(
+        out.status.success(),
+        "test file run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stats_line = stderr
+        .lines()
+        .find(|l| l.contains("adr0019-d3-8:"))
+        .unwrap_or_else(|| panic!("no adr0019-d3-8 stats line in stderr: {stderr}"));
+    let compiles: u64 = stats_line
+        .split_whitespace()
+        .find_map(|w| w.strip_prefix("method_body_runtime_compiles="))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("missing method_body_runtime_compiles= in: {stats_line}"));
+    // Before the fix this was 265 (one recompile per recursive `.get` call).
+    // A generous ceiling well under that catches a reintroduced per-call
+    // recompile without pinning the exact count.
+    assert!(
+        compiles < 10,
+        "method_body_runtime_compiles={compiles} — a proto method body is being \
+         recompiled from AST on every call again (see \
+         todo/tickets/adr0019-method-body-compile-dedup-remnants.md item 2); \
+         full stats line: {stats_line}"
+    );
+}

--- a/todo/tickets/adr0019-method-body-compile-dedup-remnants.md
+++ b/todo/tickets/adr0019-method-body-compile-dedup-remnants.md
@@ -1,5 +1,46 @@
 # Two method-body compile paths still duplicate work D3-8's cutover was meant to make one-shot
 
+> **Update (2026-08-19): item 2 was NOT a rare/dead corner — it was live, hot, and
+> unbounded.** Investigated with the `method_body_runtime_compiles` `MUTSU_VM_STATS`
+> counter (already wired for exactly this question — see
+> `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`'s D3-8 entry,
+> which claims it "dropped to zero for ordinary class/role methods"). A sweep of every
+> `t/*.t` file found **526 of them** with a nonzero count, several in the hundreds
+> (`t/where-named-param-sibling-ref.t`: 265, `t/mustache-battery.t`: 191,
+> `t/text-csv-battery.t`: 150). `rust-gdb -batch` breakpoints on
+> `compile_method_def_in_place_with_dist` traced the dominant shape straight to
+> `Interpreter::run_proto_method` (`src/runtime/dispatch_proto.rs`): every `proto
+> method`/`proto submethod` call built a **brand-new synthetic `MethodDef` with
+> `compiled_code: None` hardcoded**, so `run_resolved_method_celled`'s on-demand-compile
+> path (the exact mechanism item 2 described) recompiled the SAME proto body from AST
+> on **every single call** — not once per registration, not "before the owner's
+> registration pass", but forever, unbounded by call count (265 recompiles for one
+> 9-line recursive-`proto method` roast-shaped test).
+>
+> Fixed (this session): added `Registry::proto_compiled_cache` (keyed by
+> `(owner, method_name)`, cleared whenever `set_proto_method` installs a new body for
+> the same key so a class/EVAL redeclaration can never see a stale compile).
+> `run_proto_method` now checks the cache before building the synthetic `MethodDef`,
+> compiles once on a genuine miss, and caches the result for every later call.
+> Verified: `where-named-param-sibling-ref.t` 265 → 1, `mustache-battery.t` 191 → 1,
+> full `t/` suite (3242 files, 30036 tests) still green, `cargo clippy -- -D warnings`
+> clean.
+>
+> **Not fixed, separate finding, needs its own investigation:** `t/text-csv-battery.t`
+> (150), `t/role-pun-build-tweak.t` (21), `t/self-is-lexical-in-blocks.t` (26) stayed
+> nonzero — a different call path, traced via the same gdb technique to
+> `exec_register_role_op` → `Interpreter::compile_role_methods` →
+> `compile_methods_for_map` (`src/runtime/accessors_resolve.rs`): every `RegisterDecl`
+> execution of a role eagerly compiles all its method bodies via the same throwaway
+> `Compiler::new()` machinery `compile_method_def_in_place_with_dist` uses, with no
+> cache keyed on the role/method identity across separate registrations (e.g. repeated
+> punning/composition of the same role). Unlike the proto case this did NOT show the
+> same unbounded-by-call-count scaling in a quick check (a `RegisterRole` op fires once
+> per registration, not once per method call), so it may just be "one throwaway compile
+> per registration" — annoying but bounded — rather than a live per-call bug. Not
+> root-caused to the same certainty as the proto fix above; a future session should gdb
+> a hit-count sweep the way this one did before assuming it needs the same fix shape.
+
 Spun off from `todo/deep/adr0019-d3-8-method-body-main-pass-compilation.md` (ADR-0019 D3-8, now
 closed) before that design doc is retired. D3-8 landed the main-pass-compile-once mechanism for
 method bodies, but two call sites the original survey flagged still do redundant compiles;
@@ -15,6 +56,17 @@ removing a duplicate mechanism), low priority.
 Merging this into the parity compile (single main-pass compile per method body, harvesting
 captures as a byproduct) was explicitly deferred by D3-8's own design doc as future work, not
 attempted there.
+
+**2026-08-19 investigation:** the two compiles are not trivially mergeable — they deliberately use
+different compiler contexts for different reasons. `record_type_body_captures` compiles via
+`self.compile_closure_body` (the OUTER, main-pass `Compiler`, with full access to the enclosing
+frame's lexical scope) specifically because its job is to detect which OUTER lexicals the method
+body writes. `compile_method_body` (the D3-8 main-pass method compile it would merge with) compiles
+via a bare `Compiler::new()` that **deliberately does not inherit** the outer compiler's
+scopes/fold_ctx/outer_code_var_names (see its own doc comment, "design decision 2") — because it
+must byte-for-bit match the registration-time throwaway compile, which also starts scope-blind. A
+merge would need `compile_method_body` to somehow ALSO see outer-scope free-var info without
+breaking that parity guarantee — not attempted this session; still open.
 
 ## 2. `class_dispatch.rs`'s `compiled_holder` still recompiles into a local clone per call
 


### PR DESCRIPTION
## Summary
- `Interpreter::run_proto_method` rebuilt a fresh, uncompiled `MethodDef` for a `proto method`/`proto submethod` body on every dispatch, so the on-demand-compile fallback in `run_resolved_method_celled` recompiled the same AST body on every single call instead of once. Found while investigating `todo/tickets/adr0019-method-body-compile-dedup-remnants.md` item 2 — a `MUTSU_VM_STATS` sweep of `t/*.t` found 526 files with a nonzero `method_body_runtime_compiles` counter, several in the hundreds (`t/where-named-param-sibling-ref.t`: 265, `t/mustache-battery.t`: 191).
- Add `Registry::proto_compiled_cache`, keyed by `(owner, method_name)`, cleared whenever `set_proto_method` installs a new body for the same key (so a class/EVAL redeclaration can never see a stale compile). `run_proto_method` checks the cache before building the synthetic `MethodDef`, compiles once on a genuine miss, and reuses the cached bytecode on every later call.
- Verified: `where-named-param-sibling-ref.t` 265 → 1 recompiles, `mustache-battery.t` 191 → 1, full `t/` suite (3242 files, 30036 tests) green, whitelisted proto-method roast tests pass on release.
- Updated the ticket with this finding, plus a separate not-yet-fixed observation (role registration's `compile_role_methods` path also shows nonzero counts, but appears to be a bounded once-per-registration cost rather than the same unbounded per-call bug — left for a future session to confirm).

## Test plan
- [x] `cargo test --test proto_method_body_compiled_once` (new regression test pinning the counter)
- [x] `make test` (3242 files, 30036 tests, all pass)
- [x] `cargo clippy -- -D warnings` clean
- [x] Whitelisted proto-method-using roast tests pass on a release build