### PR TITLE
docs(todo): root-cause CBOR-Simple test blocker as a general use-lib parser bug

### DIFF
--- a/todo/deep/use-lib-dynamic-path-defers-declaration-visibility-to-parser.md
+++ b/todo/deep/use-lib-dynamic-path-defers-declaration-visibility-to-parser.md
@@ -1,0 +1,94 @@
+# `use lib EXPR` with a non-literal path defers the imported module's declarations from the PARSER, breaking later bareword-listop-call parsing
+
+Found while investigating `todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md`'s
+`01-basic.rakutest` failure ("No matching candidates for proto sub: matches" at test 12). The
+CBOR::Simple angle turned out to be a red herring — this is a general, module-system-independent
+parser bug, reduced to a 6-line repro with no CBOR involved at all.
+
+## Repro
+
+```
+mkdir -p /tmp/mtest/t/lib
+cat > /tmp/mtest/t/lib/Foo.rakumod <<'EOF'
+unit module Foo;
+multi matches(Mu $value, Str:D $cbor) is export { say "str: $value $cbor" }
+multi matches(Mu $value, Buf:D $cbor) is export { say "buf: $value" }
+EOF
+cat > /tmp/mtest/t/dynamic-lib.rakutest <<'EOF'
+use lib $*PROGRAM.sibling('lib');
+use Foo;
+matches -18446744073709551616, '3bffffffffffffffff';
+EOF
+mutsu /tmp/mtest/t/dynamic-lib.rakutest
+```
+
+mutsu:
+
+```
+Useless use of constant string "3bffffffffffffffff" in sink context
+    at /tmp/mtest/t/dynamic-lib.rakutest:3
+No matching candidates for proto sub: matches
+  in block <unit> at /tmp/mtest/t/dynamic-lib.rakutest line 3
+```
+
+`raku`: prints `str: -18446744073709551616 3bffffffffffffffff` (the correct 2-arg dispatch), no
+warning.
+
+## Root cause hypothesis (not yet confirmed by reading the compiler internals)
+
+The determining factor is NOT whether `Foo` is actually found (tested: even when `use lib
+$*PROGRAM.sibling('lib')` resolves to a NONEXISTENT directory and `use Foo` fails outright with
+"Could not find Foo", the SAME "Useless use of constant string ... in sink context" parse-time
+warning still fires for the exact same later statement) and NOT the mere presence of a `use lib
+EXPR;` statement (tested: `use lib $*PROGRAM.sibling('lib'); use Foo;` PLUS an explicit `-I
+/path/to/lib` on the command line works correctly — no warning, correct dispatch). The determining
+factor, isolated by a 2x2 matrix of (module found via `-I` vs found via `use lib EXPR`) x (`EXPR`
+literal vs computed):
+
+| how `Foo` resolves | later `matches -NUM, STR` parses correctly? |
+| --- | --- |
+| `-I /path/to/lib` (command line) | yes |
+| `use lib 'lib';` (string literal, relative) | yes |
+| `use lib $*PROGRAM.sibling('lib');` (computed, no `-I`) | **no** |
+| `use lib $libdir;` where `my $libdir = $*PROGRAM.sibling('lib').Str;` (computed, no `-I`) | **no** |
+| `use lib $*PROGRAM.sibling('lib'); use Foo;` PLUS an ALSO-present `-I` for the same dir | yes |
+
+So: a `use lib` argument that is a **literal string** (however it resolves, even relatively) behaves
+like `-I` — the imported module's declarations become visible to the PARSER before it reaches later
+statements in the same file. A `use lib` argument that is **not a literal** (a method call, or a
+`my`-bound variable holding one) requires evaluating an expression to know the path, which can only
+happen at RUNTIME — so the import of `Foo` (and therefore its `multi matches` declarations)
+necessarily happens interleaved with mainline EXECUTION, not before mainline PARSING. By the time
+the parser reaches the `matches -18446744073709551616, '...'` statement (parsing the WHOLE file
+before running anything, in mutsu's architecture), it does not yet know `matches` is a declared
+multi sub that takes bare listop-style arguments — so it presumably falls back to treating `matches`
+as an unrecognized bareword, and the ` -NUM, STR` tail misparses (the unary minus on the first
+argument is the specific trigger — every failing `matches` call in `01-basic.rakutest` has a
+negative first argument; the positive-number sibling calls parse fine even with the SAME dynamic
+`use lib`). This produces two visible symptoms from ONE root cause: the "Useless use of constant
+string ... in sink context" warning (the string argument got split into its own statement) and,
+when it happens to a multi sub whose only candidates are 2-arity, "No matching candidates" (the
+call that actually executes now has only 1 positional arg).
+
+## Why this is `todo/deep`, not a quick ticket
+
+Confirming this requires reading how mutsu's parser distinguishes "known sub, apply listop-argument
+parsing" from "unknown bareword" — and whether/how a `RegisterDecl`-style declaration from an
+EVAL'd/dynamically-`use`d module can retroactively make itself visible to a parse pass that already
+ran ahead of it. This is the same fundamental two-phase (parse-then-run vs. Raku's real
+interleaved-compile-and-run) tension CLAUDE.md's "Raku's context-dependent parsing (slangs)" section
+already flags as an open architecture question — not a narrow, single-call-site fix. A real fix
+likely needs either (a) a genuine BEGIN-time-evaluable `use lib` fast path that runs the path
+expression during an early parse pass when possible, or (b) making the parser's bareword-vs-listop
+decision robust to "unknown sub name" in a way that still parses `-NUM, STR` as two positional
+arguments rather than misparsing — a general parsing-robustness improvement, not a `use lib`-specific
+patch.
+
+## Not a `Digest`/CBOR blocker
+
+Confirmed independent of CBOR::Simple/Digest — the minimal repro above uses a throwaway `Foo`
+module. `todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md`'s remaining
+`01-basic.rakutest`/`03`/`04`/`06` triage should be re-attempted with an explicit `-I` (bypassing
+the vendored suite's own `use lib $*PROGRAM.sibling('lib');`) to separate this bug's noise from any
+other real per-file issues, since the vendored `battery-testsuite.sh` harness presumably invokes
+files in place (hitting this bug) rather than via `-I`.

--- a/todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md
+++ b/todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md
@@ -1,5 +1,24 @@
 # `CBOR::Simple`'s own upstream suite fails broadly outside the narrow slice Cro::HTTP/Log::Timeline exercise
 
+> **Update (2026-08-19): the `01-basic.rakutest` "No matching candidates for proto sub: matches"
+> failure (test 12) is NOT a CBOR::Simple bug at all — root-caused and reduced to a 6-line,
+> CBOR-independent repro.** The vendored test file's own `use lib $*PROGRAM.sibling('lib');`
+> (a computed, non-literal `use lib` argument, used to find its sibling `CodecMatches.rakumod`)
+> defers that module's declarations from becoming visible to mutsu's PARSER until mainline
+> execution reaches the `use` statement — unlike `-I` or a literal `use lib 'path'`, whose
+> declarations ARE visible to the parser before it processes later statements in the same file.
+> By the time the parser reaches `matches -18446744073709551616, '...'` (a bareword call to a
+> multi sub whose declaration it does not yet statically know about), the negative-number first
+> argument's leading `-` misparses, splitting the call into a 1-arg statement plus a dangling
+> string literal — which is exactly why every failing `matches` call in this file has a NEGATIVE
+> first argument and every passing one is positive. Full mechanism, the isolating 2x2 test
+> matrix, and why this needs a `todo/deep` (not a quick fix) are in
+> `todo/deep/use-lib-dynamic-path-defers-declaration-visibility-to-parser.md`. **Re-running the
+> CBOR::Simple suite with an explicit `-I <path-to-t/lib>` instead of letting the file's own
+> `use lib $*PROGRAM.sibling('lib')` resolve it should route around this bug** and let the
+> `01`/`03`/`04`/`06` triage below continue on real per-file issues, if any remain, without this
+> noise. Not attempted this session — the next session picking this up should start there.
+
 ## Symptom
 
 Bundling `CBOR::Simple` (a `Log::Timeline` → `Cro::HTTP` dependency, see
@@ -153,3 +172,26 @@ bug, not a proto-dispatch bug at all.
 **Next steps for whoever picks this up:** reduce the `01-basic.rakutest`
 nested-array decode aliasing bug (test 68) and the stack overflow into a
 standalone repro (not yet attempted) before touching `03`/`04`/`06`.
+
+## Update (2026-08-19): the `01-basic.rakutest` blocker before test 68 was a general parser bug, not CBOR::Simple's — worked around, test 68's bug confirmed still real but is STATE-dependent
+
+The "No matching candidates for proto sub: matches" failure that stopped the file at test 12 is a
+general `use lib`-with-a-computed-argument parser bug, unrelated to CBOR::Simple — full
+root-cause and a 6-line standalone repro are in
+`todo/deep/use-lib-dynamic-path-defers-declaration-visibility-to-parser.md`. Running the file with
+an explicit `-I <path-to-t/lib>` (bypassing its own `use lib $*PROGRAM.sibling('lib');`) routes
+around it: `mutsu -I modules/CBOR-Simple/lib -I modules/TinyFloats/lib -I
+<cbor-simple-checkout>/t/lib <cbor-simple-checkout>/t/01-basic.rakutest` now reaches **test 68/74**
+(1-67 pass), reproducing exactly the nested-array decode aliasing bug + stack overflow this
+ticket's 2026-08-18 update already found.
+
+**Important correction for whoever reduces test 68 next:** decoding the SAME CBOR blob
+(`9F01820203820405FF`) in ISOLATION (a fresh `use CBOR::Simple; cbor-decode(Buf.new(0x9F, 0x01,
+0x82, 0x02, 0x03, 0x82, 0x04, 0x05, 0xFF))` with nothing else in the program) produces the
+CORRECT `$[1, [2, 3], [4, 5]]` on current `main` — verified directly. The bug only reproduces
+after the other 67 subtests' worth of accumulated program state (many prior `cbor-encode`/
+`cbor-decode` calls, `matches` multi-dispatch resolutions, etc.) — i.e. it is NOT simply "decoding
+this exact blob is broken", it needs a warm/stale cache or similar accumulated state to trigger.
+Reducing it will need trimming the FULL file from the top (keeping all/most prior subtests) rather
+than isolating just the failing blob, or bisecting which EARLIER subtest(s) are the prerequisite —
+neither attempted yet.


### PR DESCRIPTION
## Summary
Docs-only: investigated `todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md`'s `01-basic.rakutest` "No matching candidates for proto sub: matches" failure. It's not a CBOR::Simple bug — reduced to a 6-line, CBOR-independent repro.

- `use lib EXPR` with a non-literal (computed) path argument defers the imported module's declarations from being visible to the parser until mainline execution reaches the `use` statement, unlike `-I` or a literal `use lib 'path'`. A later bareword call to one of that module's multi subs, when its first argument starts with a unary minus, then misparses.
- Filed the general finding as `todo/deep/use-lib-dynamic-path-defers-declaration-visibility-to-parser.md` with the isolating repro matrix.
- Working around it with an explicit `-I` unblocks `01-basic.rakutest` through test 68, reproducing the already-documented nested-array decode aliasing bug + stack overflow. Also confirmed that bug needs accumulated program state to trigger — the same CBOR blob decodes correctly when run in isolation, so a future reduction attempt should trim the file from the top rather than isolate just the failing blob.

No code changes — `todo/` and `news/` only, so this should skip the heavy CI jobs per the docs-only classifier.

## Test plan
- N/A (documentation only)