### PR TITLE
docs(adr0019): resolve compile-dedup remnants ticket item 2, spin off shell-compile finding

### DIFF
--- a/news/2026-08/adr0019-compiled-holder-fallback-confirmed-rare.md
+++ b/news/2026-08/adr0019-compiled-holder-fallback-confirmed-rare.md
@@ -1,0 +1,39 @@
+# The class-dispatch `compiled_holder` on-demand recompile is confirmed rare, not a live hot path
+
+`todo/tickets/adr0019-method-body-compile-dedup-remnants.md` item 2 asked whether
+`run_resolved_method_celled`'s on-demand-compile fallback in `src/runtime/class_dispatch.rs`
+(the `compiled_holder: Option<MethodDef>` local clone-and-compile, for a method resolved before
+its owner's registration compile pass ran, or added purely at runtime) was still reachable
+post the Phase E dispatch-resolver unification, or had become a dead/rare corner the resolver
+bypasses.
+
+It turned out to be very much reachable — and, before this fix, unboundedly hot. Investigating
+with the `method_body_runtime_compiles` `MUTSU_VM_STATS` counter (wired for exactly this
+question in ADR-0019 D3-8), a sweep of every `t/*.t` file found 526 files with a nonzero count,
+several in the hundreds (`t/where-named-param-sibling-ref.t`: 265, `t/mustache-battery.t`: 191).
+`rust-gdb` breakpoints on `compile_method_def_in_place_with_dist` traced the dominant shape to
+`Interpreter::run_proto_method` (`src/runtime/dispatch_proto.rs`): every `proto method` /
+`proto submethod` call built a brand-new synthetic `MethodDef` with `compiled_code: None`
+hardcoded, so the `compiled_holder` fallback recompiled the same proto body from AST on every
+single dispatch — not once per registration, forever.
+
+Fixed with `Registry::proto_compiled_cache` (keyed by `(owner, method_name)`, cleared whenever
+`set_proto_method` installs a new body so a class/EVAL redeclaration can never see a stale
+compile): `run_proto_method` now checks the cache before building the synthetic `MethodDef`,
+compiles once on a genuine miss, and reuses the cached result on every later call.
+`where-named-param-sibling-ref.t` went 265 → 1, `mustache-battery.t` 191 → 1, with the full `t/`
+suite (3242 files, 30036 tests) still green. Pinned by `tests/proto_method_body_compiled_once.rs`.
+
+A same-day follow-up reverified the `compiled_holder` site itself directly (rather than only its
+dominant caller): with the proto-method hot path eliminated, the fallback now serves only its
+intended rare purpose — a method reached before its owner's registration compile pass, or one
+added at runtime (a role method punned via `does`, a custom-HOW method) — and is no longer a
+live per-call bug for ordinary dispatch. No further change was needed at that call site.
+
+That reverification also surfaced a distinct, more general gap in the same neighborhood — every
+hoisted class/role forward-reference shell pays a throwaway per-method compile that is
+discarded unread when the real declaration supersedes it moments later, which affects
+`compile_class_methods` as much as `compile_role_methods`. That is a separate, higher-blast-radius
+finding, recorded as its own investigation in
+`todo/deep/adr0019-hoisted-type-shell-throwaway-method-compile.md` rather than folded into this
+fix.

--- a/todo/deep/adr0019-hoisted-type-shell-throwaway-method-compile.md
+++ b/todo/deep/adr0019-hoisted-type-shell-throwaway-method-compile.md
@@ -1,0 +1,115 @@
+# A hoisted class/role forward-reference shell always pays a throwaway per-method compile that D3-8 exists to eliminate
+
+While reverifying `todo/tickets/adr0019-method-body-compile-dedup-remnants.md` item 2's
+"separate finding" footnote (`compile_role_methods`'s eager per-registration compile, flagged
+2026-08-19 as "not root-caused to the same certainty" as the proto-method fix and needing "a
+future session" to gdb a hit-count sweep), this session did that sweep and found a precise,
+general root cause — bigger than the footnote assumed, and affecting **classes as much as
+roles**, not just roles.
+
+## Root cause
+
+`add_class_decl_plan` (`src/compiler/decl_plan.rs:182-227`) and `add_role_decl_plan`
+(`:511-542`) both compute `package_name: None` — and therefore leave every entry of
+`method_compiled_keys` (from `compile_method_body_keys`) `None` — whenever the statement being
+compiled is a `__hoisted` forward-reference shell (`is_hoisted_shell` from
+`hoist_type_decl_shells`, `src/compiler/helpers_ast_utils.rs:630-692`). The comment at
+`decl_plan.rs:200-210` explains the intent: "only the SOURCE-ORDER declaration's plan is ever
+the one D3-8b/c would install from ... Skip the (otherwise-redundant) compile there."
+
+That premise is only half right. The *plan* computed for the shell is indeed redundant — the
+shell's own class/role identity is superseded when the real, source-position declaration
+registers moments later — but skipping the **compile-key** does not skip the **runtime
+registration-time throwaway compile**. `exec_register_class_op` / `exec_register_role_op` still
+unconditionally call `compile_class_methods` / `compile_role_methods`
+(`src/runtime/accessors_resolve.rs`) for the shell's own registration pass, same as any other
+registration. Since the shell's `CompiledMethodDecl`s all have `compiled_routine_key: None`,
+`class_body_method_decl` / `role_body_method_decl`'s `matched_compiled_fn` lookup
+(`src/runtime/registration_class_body_method.rs:140-155`,
+`src/runtime/registration_role_method.rs:218-233`) always misses, so every method on the shell
+gets the full pre-D3-8 registration-time compile (`compile_method_def_in_place_with_dist`,
+`src/vm/vm_stats::record_method_body_runtime_compile()`) — and then that compiled
+`MethodDef`/`compiled_code` is thrown away wholesale when the real declaration's registration
+runs moments later and replaces it with a *freshly built* `MethodDef` set (this one correctly
+keyed, since the real declaration is not a shell — `matched_compiled_fn` succeeds for it, no
+throwaway compile). So the throwaway compile the shell pays for is not merely redundant with
+the real one — it is **100% wasted work**: its result is never read by anything before being
+discarded.
+
+## Confirmed reproduction
+
+`MUTSU_VM_STATS=1 ./target/debug/mutsu <file>` reports
+`method_body_runtime_compiles` (`src/vm/vm_stats.rs`). Two synthetic checks, run this session:
+
+```raku
+# no hoisting trigger: method_body_runtime_compiles=0
+class Foo { method a { 1 }; method b { 2 }; method c { 3 } }
+Foo.new.a;
+```
+
+```raku
+say "hello";  # ANY runtime statement before the class triggers hoisting
+class Foo { method a { 1 }; method b { 2 }; method c { 3 } }
+Foo.new.a;
+```
+→ `method_body_runtime_compiles=3` (exactly the 3 methods, once each — not scaling with
+`.new`/method-call count, confirming it is a one-time-per-shell-registration cost, not the
+same *unbounded per-call* shape the proto-method bug had, which was already fixed separately —
+see below).
+
+`hoist_type_decl_shells` (`helpers_ast_utils.rs:630-651`) hoists **every** class/role
+declaration that appears after the first non-declaration/non-pragma statement in its
+containing block (`seen_runtime_stmt`), regardless of whether anything actually
+forward-references it. In practice this means most real files trigger it: `t/*.t` files
+routinely open with `use Test; plan N;` (a `Call` statement, not in the exclusion list), so
+essentially every class/role declared anywhere in the file after that point is hoisted-shelled.
+This is confirmed by the numbers already on record in
+`todo/tickets/adr0019-method-body-compile-dedup-remnants.md`'s 2026-08-19 update:
+`t/role-pun-build-tweak.t` (21, one throwaway compile per role-method declaration — ~20 roles
+each with 1-2 methods, each declared and used exactly once) and `t/text-csv-battery.t` (150,
+from the bundled Text::CSV module's own class/role bodies loading once at `use` time) — both
+counts track 1:1 with *declaration* count, not *call* count, matching the shell-registration
+root cause identified here rather than a per-call bug.
+
+## Why this is `todo/deep/`, not a same-session ticket fix
+
+- **Breadth**: this affects essentially all non-trivial OO Raku code compiled by mutsu (any
+  class/role declared after an earlier runtime statement in its lexical scope), not a narrow
+  corner — so a wrong fix has broad blast radius.
+- **Needs a correctness check before optimizing**: the natural fix is to skip the method-body
+  compile entirely during a shell's own registration (since its `compiled_code` is never read
+  before being discarded), not to try to give the shell a working compile key (the class side
+  cannot share a key with the real declaration anyway — `type_decl_shell_body` truncates the
+  shell's class body to a declaration-only subset, a genuinely different body from the real
+  one, per the comment at `helpers_ast_utils.rs:694`). Before skipping the compile, it must be
+  verified that **no code path between the hoist point and the real declaration's source
+  position ever calls a method on the shell-registered type** (forward-referenced types are
+  used for signature/`.isa`-style type-checking prior to their real body running, as far as
+  this session confirmed by reading, but this needs verification against roast/spec, not an
+  assumption baked into a low-risk-looking skip).
+- **Needs new plumbing**: `is_hoisted_shell` is known at compile time
+  (`decl_plan.rs`) but is not currently carried into `CompiledClassDeclPlan` /
+  `CompiledRoleDeclPlan` (`src/opcode.rs:2808`, `:3189`) for `exec_register_class_op` /
+  `exec_register_role_op` to read at runtime and pass down to
+  `compile_class_methods` / `compile_role_methods` as a skip flag.
+
+## Relationship to the two items already tracked
+
+- This is **not** the same bug the proto-method fix (`PR #6655`,
+  `Registry::proto_compiled_cache`) addressed: that was an *unbounded, per-call* recompile
+  (`run_proto_method` built a fresh uncompiled `MethodDef` on every dispatch). This is a
+  *bounded, one-per-hoisted-declaration* wasted compile — annoying but not runaway.
+- This generalizes and supersedes the "separate finding, needs its own investigation" footnote
+  on `todo/tickets/adr0019-method-body-compile-dedup-remnants.md` item 2 (which attributed the
+  symptom only to `compile_role_methods`/roles); it is now confirmed to be a `hoist_type_decl_shells`-wide
+  issue affecting `compile_class_methods` identically. That ticket has been narrowed to drop the
+  footnote and point here instead.
+
+## Suggested direction (not attempted this session)
+
+Thread a `skip_method_compile: bool` (or equivalent) from `is_hoisted_shell` through
+`CompiledClassDeclPlan` / `CompiledRoleDeclPlan` into `exec_register_class_op` /
+`exec_register_role_op`, and have `compile_class_methods` / `compile_role_methods` (or their
+callers) skip the throwaway compile when the current registration is a shell pass — after the
+forward-reference-usage verification above. This removes the wasted compile without needing
+the shell to have a working `compiled_routine_key`.

--- a/todo/tickets/adr0019-method-body-compile-dedup-remnants.md
+++ b/todo/tickets/adr0019-method-body-compile-dedup-remnants.md
@@ -1,53 +1,23 @@
-# Two method-body compile paths still duplicate work D3-8's cutover was meant to make one-shot
-
-> **Update (2026-08-19): item 2 was NOT a rare/dead corner — it was live, hot, and
-> unbounded.** Investigated with the `method_body_runtime_compiles` `MUTSU_VM_STATS`
-> counter (already wired for exactly this question — see
-> `docs/adr/0019-compiled-declarations-and-unified-method-dispatch.md`'s D3-8 entry,
-> which claims it "dropped to zero for ordinary class/role methods"). A sweep of every
-> `t/*.t` file found **526 of them** with a nonzero count, several in the hundreds
-> (`t/where-named-param-sibling-ref.t`: 265, `t/mustache-battery.t`: 191,
-> `t/text-csv-battery.t`: 150). `rust-gdb -batch` breakpoints on
-> `compile_method_def_in_place_with_dist` traced the dominant shape straight to
-> `Interpreter::run_proto_method` (`src/runtime/dispatch_proto.rs`): every `proto
-> method`/`proto submethod` call built a **brand-new synthetic `MethodDef` with
-> `compiled_code: None` hardcoded**, so `run_resolved_method_celled`'s on-demand-compile
-> path (the exact mechanism item 2 described) recompiled the SAME proto body from AST
-> on **every single call** — not once per registration, not "before the owner's
-> registration pass", but forever, unbounded by call count (265 recompiles for one
-> 9-line recursive-`proto method` roast-shaped test).
->
-> Fixed (this session): added `Registry::proto_compiled_cache` (keyed by
-> `(owner, method_name)`, cleared whenever `set_proto_method` installs a new body for
-> the same key so a class/EVAL redeclaration can never see a stale compile).
-> `run_proto_method` now checks the cache before building the synthetic `MethodDef`,
-> compiles once on a genuine miss, and caches the result for every later call.
-> Verified: `where-named-param-sibling-ref.t` 265 → 1, `mustache-battery.t` 191 → 1,
-> full `t/` suite (3242 files, 30036 tests) still green, `cargo clippy -- -D warnings`
-> clean.
->
-> **Not fixed, separate finding, needs its own investigation:** `t/text-csv-battery.t`
-> (150), `t/role-pun-build-tweak.t` (21), `t/self-is-lexical-in-blocks.t` (26) stayed
-> nonzero — a different call path, traced via the same gdb technique to
-> `exec_register_role_op` → `Interpreter::compile_role_methods` →
-> `compile_methods_for_map` (`src/runtime/accessors_resolve.rs`): every `RegisterDecl`
-> execution of a role eagerly compiles all its method bodies via the same throwaway
-> `Compiler::new()` machinery `compile_method_def_in_place_with_dist` uses, with no
-> cache keyed on the role/method identity across separate registrations (e.g. repeated
-> punning/composition of the same role). Unlike the proto case this did NOT show the
-> same unbounded-by-call-count scaling in a quick check (a `RegisterRole` op fires once
-> per registration, not once per method call), so it may just be "one throwaway compile
-> per registration" — annoying but bounded — rather than a live per-call bug. Not
-> root-caused to the same certainty as the proto fix above; a future session should gdb
-> a hit-count sweep the way this one did before assuming it needs the same fix shape.
+# `record_type_body_captures` runs a second, throwaway compile
 
 Spun off from `todo/deep/adr0019-d3-8-method-body-main-pass-compilation.md` (ADR-0019 D3-8, now
-closed) before that design doc is retired. D3-8 landed the main-pass-compile-once mechanism for
-method bodies, but two call sites the original survey flagged still do redundant compiles;
-neither is a correctness bug, both are pure architecture/perf cleanup (CLAUDE.md's "gain" sense —
-removing a duplicate mechanism), low priority.
+closed). D3-8 landed the main-pass-compile-once mechanism for method bodies, but this call site
+the original survey flagged still does a redundant compile; not a correctness bug, pure
+architecture/perf cleanup (CLAUDE.md's "gain" sense — removing a duplicate mechanism), low
+priority.
 
-## 1. `record_type_body_captures` runs a second, throwaway compile
+> **Update (2026-08-19): the ticket originally had two items; item 2 is resolved, this file is
+> narrowed to the one still-open item.** Item 2 (`class_dispatch.rs`'s `compiled_holder`
+> per-call recompile) turned out to be live and, via one caller, unboundedly hot — fixed the
+> same day (`Registry::proto_compiled_cache`, PR #6655) and reverified afterward: the
+> `compiled_holder` fallback itself is now confirmed to serve only its intended rare purpose.
+> Full account in `news/2026-08/adr0019-compiled-holder-fallback-confirmed-rare.md`. That
+> reverification also surfaced a related but distinct, more general finding (every hoisted
+> class/role forward-reference shell pays a throwaway per-method compile that gets discarded
+> unread) — spun off separately as
+> `todo/deep/adr0019-hoisted-type-shell-throwaway-method-compile.md`, since it is
+> higher-blast-radius than this ticket's low-priority scope and needs a correctness check before
+> any fix. This file now tracks only the remaining item below.
 
 `src/compiler/helpers_sub_body.rs` (`record_type_body_captures`, still present) runs a full
 `compile_closure_body` per top-level method statement purely to harvest `free_var_writes` for
@@ -57,28 +27,23 @@ Merging this into the parity compile (single main-pass compile per method body, 
 captures as a byproduct) was explicitly deferred by D3-8's own design doc as future work, not
 attempted there.
 
-**2026-08-19 investigation:** the two compiles are not trivially mergeable — they deliberately use
-different compiler contexts for different reasons. `record_type_body_captures` compiles via
-`self.compile_closure_body` (the OUTER, main-pass `Compiler`, with full access to the enclosing
-frame's lexical scope) specifically because its job is to detect which OUTER lexicals the method
-body writes. `compile_method_body` (the D3-8 main-pass method compile it would merge with) compiles
-via a bare `Compiler::new()` that **deliberately does not inherit** the outer compiler's
-scopes/fold_ctx/outer_code_var_names (see its own doc comment, "design decision 2") — because it
-must byte-for-bit match the registration-time throwaway compile, which also starts scope-blind. A
-merge would need `compile_method_body` to somehow ALSO see outer-scope free-var info without
-breaking that parity guarantee — not attempted this session; still open.
-
-## 2. `class_dispatch.rs`'s `compiled_holder` still recompiles into a local clone per call
-
-`src/runtime/class_dispatch.rs` (~line 562, `compiled_holder: Option<MethodDef>`) builds a local
-owned clone and compiles into it, discarding the result after the call, on one dispatch path.
-D3-8's design doc explicitly named persisting this "residual fallback" as an accepted risk, not a
-fixed one — confirm at investigation time whether this path is actually still reachable post the
-Phase E dispatch-resolver unification (E1-E11) before assuming it's live traffic; it may now be a
-rare/dead corner the resolver bypasses.
+**2026-08-19 investigation (reconfirmed, unchanged):** the two compiles are not trivially
+mergeable — they deliberately use different compiler contexts for different reasons.
+`record_type_body_captures` compiles via `self.compile_closure_body` (the OUTER, main-pass
+`Compiler`, with full access to the enclosing frame's lexical scope) specifically because its
+job is to detect which OUTER lexicals the method body writes. `compile_method_body` (the D3-8
+main-pass method compile it would merge with,
+`src/compiler/helpers_method_body.rs`) compiles via a bare `Compiler::new()` that **deliberately
+does not inherit** the outer compiler's scopes/fold_ctx/outer_code_var_names (see its own doc
+comment, "design decision 2") — because it must byte-for-bit match the registration-time
+throwaway compile, which also starts scope-blind. A merge would need `compile_method_body` to
+somehow ALSO see outer-scope free-var info without breaking that parity guarantee — not
+attempted this session (or the one before it); still open.
 
 ## Priority
 
-Low — neither is a correctness bug (unlike the D3-8 lexical-capture bug this same survey also
-flagged, which turned out to already be fixed by the time this ticket was filed — reverify before
-assuming either of the two items above is still live, the same way that one was reverified stale).
+Low — not a correctness bug. No safe, low-risk merge shape has been found across two
+independent investigations; a real fix would need to either give `compile_method_body` outer-scope
+visibility without breaking its registration-time-compile parity guarantee, or restructure
+`type_body_written_lexicals` capture to not need a second compile at all. Left open rather than
+forced.


### PR DESCRIPTION
## Summary
- Reverified both items in `todo/tickets/adr0019-method-body-compile-dedup-remnants.md` per the ticket's own explicit warning that a sibling item from the same original survey turned out to already be fixed.
- Item 2 (`class_dispatch.rs`'s `compiled_holder` on-demand recompile): the ticket file already documented that this was found live and unboundedly hot via `run_proto_method`, fixed same-day with `Registry::proto_compiled_cache` (PR #6655, already merged). This PR reverifies the `compiled_holder` fallback site itself directly and confirms it is now an appropriately rare corner (method reached before registration, or added at runtime) rather than a live per-call bug — recorded in `news/2026-08/adr0019-compiled-holder-fallback-confirmed-rare.md`.
- That reverification surfaced a distinct, more general, higher-blast-radius finding: every hoisted class/role forward-reference shell pays a throwaway per-method compile that is discarded unread when the real declaration supersedes it moments later — confirmed via `MUTSU_VM_STATS`'s `method_body_runtime_compiles` counter to affect `compile_class_methods` identically to `compile_role_methods` (not role-only, as the ticket's footnote assumed). Root-caused precisely and spun off as `todo/deep/adr0019-hoisted-type-shell-throwaway-method-compile.md`, since it needs a correctness check (does any code path call a shell-registered method before the real declaration supersedes it?) before any fix, and touches the hot class/role registration path broadly.
- Item 1 (`record_type_body_captures`'s second throwaway compile): reconfirmed via independent code reading that it's genuinely not mergeable with the D3-8 main-pass method compile without deeper redesign (the two compiles deliberately use different compiler contexts — outer-scope-aware vs. scope-blind-for-parity). The ticket is narrowed to track only this remaining item.

No source code changed — this is a docs-only investigation/reclassification PR.

## Test plan
- [x] `bash scripts/ci-docs-only.sh --self-test` passes (confirms this diff classifies as docs-only, matching CI's expected skip of the heavy jobs)
- [x] No `.rs` files touched; no build/test changes needed