### PR TITLE
fix(value): sync native array cache before marking dirty, drop redundant clone

### DIFF
--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -180,6 +180,11 @@ impl ArrayData {
 
     /// Mutably borrow the element vector through the representation chokepoint.
     pub(crate) fn items_mut(&mut self) -> &mut Vec<Value> {
+        // Sync first: if native-side code wrote the buffer since the last
+        // read, `items` is stale. Marking dirty without syncing would make
+        // the next sync encode that stale cache back over the native bytes,
+        // silently discarding the native write.
+        self.sync_native_items();
         self.native_dirty = self.native_storage.is_some();
         &mut self.items
     }
@@ -247,8 +252,7 @@ impl ArrayData {
         let Some(node) = &self.native_storage else {
             return;
         };
-        let current_bytes = node.bytes.clone();
-        if !self.native_dirty && self.native_snapshot.as_ref() == Some(&current_bytes) {
+        if !self.native_dirty && self.native_snapshot.as_deref() == Some(node.bytes.as_slice()) {
             return;
         }
         let (bytes, decoded) = if self.native_dirty {
@@ -258,7 +262,7 @@ impl ArrayData {
             )
         } else {
             (
-                current_bytes.clone(),
+                node.bytes.clone(),
                 crate::value::value_buf::decode_storage(node),
             )
         };

--- a/t/native-array-storage.t
+++ b/t/native-array-storage.t
@@ -8,7 +8,7 @@ class MVMArrayB is repr('CStruct') {
     has Pointer $.any;
 }
 
-plan 8;
+plan 10;
 
 my int @a = 10, 20;
 is @a.REPR, 'VMArray', 'native array reports VMArray';
@@ -20,6 +20,26 @@ my $payload = nativecast(CArray[int64], $body.any);
 is $payload[0], 10, 'body payload points at array storage';
 $payload[1] = 42;
 is @a[1], 42, 'C writes through retained payload are visible in Raku';
+
+# ADR-0030 §1.2: a Raku write to a *different* index must not silently
+# discard a pending C write that has not been read back into Raku yet.
+my int @b = 10, 20, 30;
+my $bbody = nativecast(MVMArrayB, Pointer.new(@b.WHERE));
+my $bpayload = nativecast(CArray[int64], $bbody.any);
+$bpayload[2] = 99;
+@b[0] = 7;
+is "@b[0] @b[2]", "7 99",
+    'a Raku write to another index does not discard an unread C write';
+
+# ADR-0030 §1.3-3: repeated reads after a C write must keep seeing the
+# synced value (exercises the read path's snapshot comparison).
+my int @c = 1, 2, 3;
+my $cbody = nativecast(MVMArrayB, Pointer.new(@c.WHERE));
+my $cpayload = nativecast(CArray[int64], $cbody.any);
+$cpayload[1] = 55;
+my $sum = 0;
+for ^3 -> $i { $sum += @c[$i] }
+is $sum, 1 + 55 + 3, 'repeated reads after a native write stay consistent';
 
 my num @n = 1e0, 2e0;
 is @n.REPR, 'VMArray', 'native num array reports VMArray';


### PR DESCRIPTION
## Summary

ADR-0030 (`docs/adr/0030-native-array-decode-cache-interior-mutability.md`) Step 1:
fix the two plain logic bugs in `ArrayData`'s native-array decode cache
(`src/value/value_collections.rs`) that sit independently of the
interior-mutability UB the ADR's later steps address.

- **`items_mut()` never synced before marking the cache dirty.** If native code
  (e.g. via `NativeCall`) wrote the backing buffer and Raku had not read the
  array since, the next sync would take the encode branch and write the stale
  boxed `items` back over the native bytes — silently discarding the native
  write.
- **`sync_native_items()` cloned the entire native buffer on every read** just to
  compare it against the snapshot. Replaced with a slice comparison
  (`native_snapshot.as_deref() == Some(node.bytes.as_slice())`), so every
  `items()`/`Deref` read of a native array no longer allocates on the
  already-synced fast path.

This fixes the debug-observable half only, per the ADR's plan — the
release-only miscompilation from the `self as *const Self as *mut Self` raw
pointer write is tracked by ADR-0030 steps 2-5 (a follow-up PR introducing
`SyncUnsafeCell`).

## Test plan

- [x] Added two subtests to `t/native-array-storage.t` (now 10) pinning the fix:
  a Raku write to a different array index no longer discards an unread native
  write, and repeated reads after a native write stay consistent.
- [x] `prove -e target/debug/mutsu t/native-array-storage.t` — 10/10 pass.
- [x] `make test` — 3244 files / 30046 tests, all pass.
- [x] `cargo clippy -- -D warnings` / `cargo fmt --check` — clean.
- [x] Verified against ADR-0030's own repro: debug build now correctly
  preserves both writes (`7 99`); release build still shows the known,
  separately-tracked UB failure (`7 30`), confirming this PR does not touch
  that half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)