### PR TITLE
docs(todo): correct and deepen the attr-bind cross-frame write-loss root cause

### DIFF
--- a/todo/deep/attr-bind-source-write-lost-through-nested-sub-call-chain.md
+++ b/todo/deep/attr-bind-source-write-lost-through-nested-sub-call-chain.md
@@ -200,6 +200,166 @@ no way to opt into the more-correct behavior at all.
    code/locals-name reference (real architectural addition, matches this
    repo's "refactor boldly" guidance), vs. a narrower restore-from-saved_env
    reconciliation specifically for attribute-bind targets.
-4. Cross-check against
+4. ~~Cross-check against
    `todo/deep/control-warn-resume-list-assign-first-target-stale-on-repeat-call.md`
-   for a shared root cause before fixing either in isolation.
+   for a shared root cause before fixing either in isolation.~~ That ticket
+   (renamed along the way to
+   `todo/deep/sunk-list-reassign-leaks-containerref-into-shared-env.md`) is
+   now closed (`news/2026-08/sunk-list-reassign-containerref-leak.md`) and
+   was a genuinely **different** root cause (a compiler-side discarded-rvalue
+   leak, not this VM-side frame-propagation gap) — see the note below.
+
+## 2026-08-19: "sigilless is immune" was wrong; it's a general `:=`-bind bug, not attribute-specific — and the obvious VM fix does not work
+
+Picked this ticket up next after closing the sunk-list-reassign ticket above
+(different bug, same `t/` residue sweep). Two findings that change the shape
+of the problem, plus a fix attempt that was tried, built, tested, and
+**reverted** because it did not actually work — recorded here so the next
+session does not retry the same dead end.
+
+### Finding 1: the bug is NOT attribute-specific, and NOT twigil-specific
+
+Suggested next step 1 above assumed the sigilless (`has $x`) case is immune
+to this bug and asked to find out *why*, as a model for fixing the twigil'd
+case. That premise was wrong. The "immunity" in `t/has-attr-binding.t` tests
+1-3 is solely because those tests call `.bind()` **directly**, never through
+a `lives-ok { ... }`-style multi-frame chain — the same thing that makes the
+`$!x` case (tests 4-6) pass when called directly too:
+
+```raku
+# sigilless, direct call: PASSES
+my $var = 100;
+my class Klass1 { has $x; method bind { $x := $var } method getx { $x } }
+my $obj = Klass1.new;
+$obj.bind();                  # no lives-ok wrapper
+is $obj.getx, 100; $var = 200; is $obj.getx, 200;   # both pass
+
+# sigilless, wrapped in lives-ok: FAILS exactly like $!x does
+lives-ok { $obj.bind() }, '...';
+...                            # tracks-source-changes fails, got 100 not 200
+
+# twigil'd $!x, direct call: PASSES too
+my class Klass2 { has $.x; method bind { $!x := $var } }
+$obj.bind();                   # no lives-ok wrapper
+is $obj.x, 100; $var = 200; is $obj.x, 200;         # both pass
+```
+
+So the real variable is **call depth**, not the bind target's shape at all.
+An even smaller repro confirms it needs no class/attribute machinery
+whatsoever — a bare lexical bind inside a named sub, called through one
+wrapper layer:
+
+```raku
+use Test;
+my $var = 100;
+my $alias;
+sub bindit { $alias := $var }
+lives-ok { bindit() }, 'binding lives';
+is $alias, 100, 'reads bound value';       # ok
+$var = 200;
+is $alias, 200, 'tracks source changes';   # FAILS: got 100, raku gets 200
+```
+
+This reproduces byte-for-byte the same way, confirmed against `raku` (which
+passes all three). It needs `MUTSU_REAL_TEST=1` for the SAME reason the
+original repro did — not because `Test.rakumod` is special, but because
+`lives-ok`'s own real implementation (`try { $code(); } ...`) is what
+supplies the extra call-frame depth; a bare `sub wrap(&c) { c() }` wrapper
+was NOT tried as a substitute and might reproduce it just as well with no
+`Test` module involved at all — worth checking first in the next session,
+since it would make the repro even smaller and faster to iterate on.
+
+### Finding 2: the exact same broken propagation pattern is duplicated in a SECOND location, and it fires for this repro — not the one this ticket originally traced
+
+The ticket's step 4 traced the bug into `vm_var_assign_set_local.rs`'s
+generic `bind_source` block (`exec_set_local_op_inner`, reached via the
+`SetLocal` opcode). That block is **not the path this repro takes at all**.
+`$alias`/`$var` inside `sub bindit` are free variables — not declared as
+locals of `bindit` — so the compiler's `emit_set_named_var`
+(`compiler/mod.rs`) does not find them in `self.local_map` and emits
+`OpCode::SetGlobal`, not `OpCode::SetLocal`. Confirmed with `rust-gdb`
+breakpoints: every breakpoint placed inside
+`vm_var_assign_set_local.rs`'s `bind_source` block (lines ~1300-1580) had
+**zero hits** for this repro, across the whole program.
+
+The real path is a **second, independently-written copy of the same
+mechanism**, inline inside the `OpCode::SetGlobal` handler in
+`vm_exec_dispatch.rs` (~line 1327 onward, `if let Some(source_name) =
+bind_source.as_ref() { ... }`). It has the exact same shape and the exact
+same bug as the one this ticket documented: an ancestor-frame propagation
+loop that correctly splices the new `ContainerRef` into `frame.saved_env`
+(gated on `frame.saved_env.contains_key_own_tier(&resolved_source)`), paired
+with a **broken** attempt to also patch `frame.saved_locals[i]` by searching
+`code.locals` — `code` here is `bindit`'s own compiled code, not the
+ancestor frame's, so the search is against the wrong frame's layout, exactly
+per this ticket's step 4 analysis of the sibling block. Confirmed with a
+`rust-gdb` breakpoint at that exact `for frame in self.call_frames.iter_mut()`
+loop: it fires, resolves `resolved_source == "var"`, and the
+"frame owns it, splice" branch is taken for **two** of the frames on the
+stack (traced via a breakpoint inside that `if` arm) — so the `saved_env`
+side of the propagation genuinely does run for multiple ancestor frames, not
+zero.
+
+**Two separate, independently-broken copies of the same mechanism** is
+itself worth fixing regardless of the fix shape eventually chosen — whatever
+the correct mechanism turns out to be, it should not be duplicated between
+the `SetLocal` and `SetGlobal` opcode handlers.
+
+### Fix attempted and reverted: routing through `pending_rw_writeback_sources` does not close the gap
+
+The obvious-looking fix, given `pending_rw_writeback_sources` /
+`apply_pending_rw_writeback` (`vm_env_helpers.rs`) already exists as the
+established "record this name, let the call-return site with the CORRECT
+`code` resolve the local slot" mechanism (used a few hundred lines away in
+the very same file for the sigilless-alias-chain write path, and is exactly
+what `apply_pending_rw_writeback`'s own doc comment describes as the
+intended cross-frame propagation route): delete the broken
+`frame.saved_locals[i]` search in BOTH copies (the `SetLocal` block in
+`vm_var_assign_set_local.rs` and the `SetGlobal` block in
+`vm_exec_dispatch.rs`), keep the (working) `frame.saved_env` splice, and
+additionally `self.pending_rw_writeback_sources.push(resolved_source)` once
+per bind, mirroring the sigilless-alias-chain code's own
+`self.pending_rw_writeback_sources.push(current_alias.clone())`.
+
+This was implemented, built cleanly, and **did not fix the repro** — `$alias`
+(and, separately re-tested, `$!x`) still read back `100` instead of `200`
+after the fix, byte-identical to before. Reverted (`git checkout --`) rather
+than left half-working in the tree. Two live hypotheses for why the drain
+alone is insufficient, neither yet confirmed:
+
+- `find_local_slot`/`apply_pending_rw_writeback` only patch `self.locals`
+  (the per-frame slot array) for whichever frame's call-return site actually
+  runs the drain. If **mainline's own top-level `my $var = 100;`** never
+  allocates a "locals slot" at all — i.e. mainline reads/writes it purely
+  through `env` (`GetGlobal`/`SetGlobal`), not `self.locals[idx]` — then the
+  drain has nothing useful to do for the frame that actually matters, and
+  the bug is not really about `self.locals` staleness at all for this
+  specific repro shape (it may still be for a nested-`my`-inside-a-block
+  shape, which was never isolated separately). This was NOT checked before
+  reverting — checking whether mainline-scope scalars use a locals slot at
+  all is the fastest next step.
+- The interpreter's `Env` is a layered/COW structure (`scoped_child`,
+  `cow_mut`/`Arc::make_mut`, mentioned throughout `vm_closure_dispatch.rs`
+  and `env.rs`), not a flat single map. `contains_key_own_tier` checks only
+  a frame's own immediate overlay layer. It is not yet established whether
+  splicing into `frame.saved_env`'s own tier for a frame that returns
+  *before* the frame that is later popped back into mainline's own live
+  `self.env` is actually sufficient to make mainline observe the update, or
+  whether a frame with `contains_key_own_tier == false` (the ticket's
+  original trace saw exactly one such frame in the middle of the chain, "index
+  1 — the presumed `try {}` frame — was `false`") sits between the updated
+  frames and mainline, and popping THAT frame overwrites `self.env` with an
+  overlay whose chain-parent was never touched by any of this. If so, the
+  fix has to reach the actual chain-parent tier the un-owning frame's overlay
+  points to, not just the leaf frames that happen to pass the
+  `contains_key_own_tier` check.
+
+Whoever picks this up next should instrument `self.env()` state (which keys
+are present, and at which chain depth) right before and right after each
+frame pop between `bindit`'s return and mainline's own continuation, for the
+minimal `bindit`/`lives-ok` repro above — that is the missing piece both
+hypotheses above need to distinguish between, and it was not done this
+session (ran out of budget after the revert). A `rust-gdb` breakpoint at
+each `pop_call_frame` call site, printing whether `self.env().get("var")` is
+a plain `Int` or a `ContainerRef` right after the pop, should answer it
+directly without needing a rebuild per guess.


### PR DESCRIPTION
## Summary
- Investigated `todo/deep/attr-bind-source-write-lost-through-nested-sub-call-chain.md` (next item in the `t/` residue for `todo/deep/vendor-real-test-module.md`).
- Corrected the ticket's "sigilless is immune" premise: it's actually a general `:=` bind bug triggered by call depth, not by the attribute/twigil shape. A bare lexical bind in a named sub through one `lives-ok`-style wrapper layer reproduces it with no class/attribute involved at all.
- Found the actual code path this repro takes: a second, independently-written copy of the same broken ancestor-frame-propagation pattern, inline in the `SetGlobal` opcode handler (`vm_exec_dispatch.rs`) — not the `SetLocal` block this ticket originally traced (confirmed via `rust-gdb` breakpoints; zero hits in the originally-traced block, two hits in the previously-unknown `SetGlobal` copy).
- Attempted the obvious fix (route through the existing `pending_rw_writeback_sources` drain mechanism instead of the broken `frame.saved_locals[i]` search) in both locations — built and tested, but it did **not** close the gap. Reverted rather than merging a fix that doesn't work; recorded two live hypotheses for why, so the next session doesn't retry the same dead end blind.

Docs-only change (no code), per this repo's "file a deep ticket / investigation note" convention.

## Test plan
- N/A — documentation only, no code changed (the attempted fix was reverted before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)