### PR TITLE
fix(vm): eqv FETCHes a Proxy nested inside an Array/List/Hash/Pair

### DIFF
--- a/news/2026-08/eqv-fetches-nested-proxy-elements.md
+++ b/news/2026-08/eqv-fetches-nested-proxy-elements.md
@@ -1,0 +1,26 @@
+# `eqv` now FETCHes a `Proxy` nested inside an Array/List/Hash/Pair
+
+`Value::eqv` is a pure, interpreter-free comparison with no `&mut Interpreter`
+access, so it cannot call a `Proxy` element's `FETCH` callback itself.
+`eval_binary_with_junctions` already auto-FETCHed a *top-level* `Proxy`
+operand before dispatching to `eqv`, but a `Proxy` nested one level down —
+inside an Array/List/Hash/Pair, e.g. `(1, 2).map({ Proxy.new(...) }).List` —
+passed through untouched, so `$got eqv $expected` compared the raw `Proxy`
+objects instead of their fetched values and always returned `False`.
+
+This is exactly what the real, vendored `Test.rakumod`'s `is-deeply` reduces
+to (`_is_deeply(Mu $got, Mu $expected) { $got eqv $expected }`), so
+`is-deeply` on a list of Proxy-produced values (the URI::Query read-only
+Proxy-list shape) always failed under `MUTSU_REAL_TEST=1`, closing
+`t/proxy-list-transparency.t`'s last failing assertion.
+
+Fixed in `exec_eqv_op` (`src/vm/vm_comparison_order_ops.rs`) by deep-resolving
+Proxies in both operands (the existing `resolve_proxies_in_value` helper,
+already used for `t/`'s native-Test-provider argument path) before comparing
+— a cheap no-allocation scan in the common Proxy-free case, and a real FETCH
+of every nested Proxy otherwise. Pin:
+`t/eqv-fetches-nested-proxy-elements.t`, verified byte-for-byte against
+`raku`.
+
+Part of the ongoing `todo/deep/vendor-real-test-module.md` campaign
+(vendoring rakudo's real `Test.rakumod`); its `t/` residue is down to 5 files.

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -578,6 +578,13 @@ impl Interpreter {
             }
             _ => {}
         }
+        // `Value::eqv` is a pure, interpreter-free comparison, so it cannot call
+        // a `Proxy` element's FETCH callback itself. `eval_binary_with_junctions`
+        // already auto-FETCHes a top-level Proxy; resolve any Proxy elements
+        // nested inside an Array/List/Hash/... here too, matching raku (`(1,
+        // 2).map({ Proxy.new(...) }).List eqv (1, 2)` reads each element).
+        let left = self.resolve_proxies_in_value(&left)?;
+        let right = self.resolve_proxies_in_value(&right)?;
         let result =
             self.eval_binary_with_junctions(left, right, |_, l, r| Ok(Value::truth(l.eqv(&r))))?;
         self.stack.push(result);

--- a/t/eqv-fetches-nested-proxy-elements.t
+++ b/t/eqv-fetches-nested-proxy-elements.t
@@ -1,0 +1,36 @@
+use Test;
+
+# `eqv` on a List whose elements are raw Proxy containers (not wrapped in a
+# Scalar, e.g. `.map`'s return values) must FETCH each element before
+# comparing -- matching raku, which reads through a container on any
+# value-context access. `eval_binary_with_junctions` already auto-FETCHes a
+# *top-level* Proxy operand; this pins the deeper case, nested inside an
+# Array/List/Hash/Pair.
+
+plan 6;
+
+my $v = 5;
+my $p = Proxy.new(
+    FETCH => method () { $v },
+    STORE => method ($n) { $v = $n },
+);
+
+is $p eqv 5, True, 'top-level Proxy operand still FETCHes (pre-existing)';
+
+my $l = (1, 2).map({
+    my $inner = $_;
+    Proxy.new(
+        FETCH => method () { $inner },
+        STORE => method ($n) { $inner = $n },
+    );
+}).List;
+
+is-deeply $l, $(1, 2), 'nested Proxy list elements FETCH for is-deeply (eqv)';
+ok $l eqv $(1, 2), 'nested Proxy list elements FETCH for a direct eqv';
+nok $l eqv $(1, 3), 'a genuinely different nested Proxy list is not eqv';
+
+my %h = a => $p;
+ok %h eqv { a => 5 }, 'a Proxy nested inside a Hash value FETCHes for eqv';
+
+my $pair = (a => $p);
+ok $pair eqv (a => 5), 'a Proxy nested inside a Pair value FETCHes for eqv';

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -2387,3 +2387,51 @@ re-measure above, minus this file): `exception-role-membership.t`,
 `scripts/test-module-sweep.sh` run next session to confirm and re-measure the
 roast side (`S03-metaops/infix.t` and the other roast regressions named in
 the 2026-08-18 sections above were not re-swept this session).
+
+## Re-measured 2026-08-19: residue down to 6 after main picked up `has-attr-binding.t`'s fix; `proxy-list-transparency.t` closed
+
+`main` had already picked up the SetGlobal bind-source fix
+(`news/2026-08/attr-bind-source-write-tracked-through-nested-call-chain.md`,
+PR #6675) and the loop-body keep/undo fix since the last measurement in this
+file; pulling it and re-running `scripts/test-module-sweep.sh` (debug, 8-way)
+dropped the residue to **6 / 3225** with no code change:
+`exception-role-membership.t`, `is-lazy-io-lines.t` (×2 assertions),
+`proxy-list-transparency.t`, `subscript-adverbs.t` (×2),
+`throws-like-gather-sink.t`, `undeclared-when-type.t`.
+`malformed-syntax-classes.t` and `has-attr-binding.t` are gone from the list
+without further work here.
+
+`proxy-list-transparency.t` is now closed too. Root cause: `Value::eqv` is a
+pure, interpreter-free comparison (no `&mut Interpreter`), so it cannot call
+a `Proxy` element's FETCH callback. `eval_binary_with_junctions` already
+auto-FETCHes a *top-level* Proxy operand before calling `eqv`
+(`vm_helpers_junction.rs`), but a Proxy nested one level down — inside an
+Array/List/Hash/Pair, e.g. `(1, 2).map({ Proxy.new(...) }).List` — was passed
+through untouched, so `$got eqv $expected` (what the real `Test.rakumod`'s
+`is-deeply` reduces to, `_is_deeply` at line 713-715) compared the raw
+`Proxy` objects instead of their fetched values and always returned `False`.
+Fixed in `exec_eqv_op` (`vm_comparison_order_ops.rs`) by calling the existing
+`resolve_proxies_in_value` (added for `t/`'s native-provider test-argument
+path, `builtins_lvalue.rs`) on both operands before comparing — a cheap
+no-allocation scan in the common Proxy-free case, deep-FETCHing every nested
+Proxy otherwise. `undeclared-when-type.t`'s failing assertion turned out to
+be the same underlying `throws-like` case duplicated in
+`exception-role-membership.t` (`when SomeUndeclaredType { ... }` should be a
+compile-time `X::Comp::Group`/"needs parens to avoid gobbling block" parse
+ambiguity, which mutsu's parser does not currently diagnose at all — a
+genuine parser feature gap, not a `Test`-shape issue; left open, tracked by
+those two files' own `not ok` lines rather than a fresh ticket since neither
+new investigation happened this session).
+
+Pin: `t/eqv-fetches-nested-proxy-elements.t` (top-level Proxy still FETCHes,
+nested inside Array/List/Hash/Pair now FETCHes too, and a genuinely-different
+nested-Proxy list correctly stays not-`eqv`) — verified byte-for-byte against
+`raku`. Full local `t/` suite and `cargo clippy -- -D warnings` clean;
+`t/autoviv-index-guard.t` timed out under `-j` load during the same `make
+test` run but reproduces identically on `main` with the fix `git stash`-ed
+out (confirmed directly, not this change) — pre-existing, unrelated to
+`eqv`/`Proxy`.
+
+Residue is now **5**: `exception-role-membership.t`, `is-lazy-io-lines.t`
+(×2), `subscript-adverbs.t` (×2), `throws-like-gather-sink.t`,
+`undeclared-when-type.t`.


### PR DESCRIPTION
## Summary
- `Value::eqv` is a pure, interpreter-free comparison, so it can't call a `Proxy` element's `FETCH`. `eval_binary_with_junctions` already auto-FETCHed a *top-level* Proxy operand, but one nested inside an Array/List/Hash/Pair (e.g. `(1, 2).map({ Proxy.new(...) }).List`) passed through untouched — `$got eqv $expected` compared raw `Proxy` objects and always answered `False`.
- This is exactly what the real, vendored `Test.rakumod`'s `is-deeply` reduces to (`_is_deeply` is `$got eqv $expected`), so `is-deeply` on a Proxy-produced list always failed under `MUTSU_REAL_TEST=1` — closing `t/proxy-list-transparency.t`'s last failing assertion, part of the `todo/deep/vendor-real-test-module.md` campaign.
- Fixed in `exec_eqv_op` by deep-resolving Proxies in both operands via the existing `resolve_proxies_in_value` helper before comparing.

## Test plan
- [x] New pin `t/eqv-fetches-nested-proxy-elements.t`, verified byte-for-byte against `raku`
- [x] `t/proxy-list-transparency.t` now passes fully under both `Test` providers
- [x] Full local `t/` suite green; `t/autoviv-index-guard.t`'s timeout under `-j` load reproduces identically on `main` without this change (pre-existing, unrelated)
- [x] `cargo clippy -- -D warnings` clean, `cargo fmt` clean
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)