### PR TITLE
fix(vm): a bare EVAL statement now forces a deferred gather/lazy-IO result

### DIFF
--- a/news/2026-08/eval-statement-sink-forces-lazy-result.md
+++ b/news/2026-08/eval-statement-sink-forces-lazy-result.md
@@ -1,0 +1,39 @@
+# A bare `EVAL '...';` statement now forces a deferred `gather`/lazy-IO-lines result
+
+A bare call statement sinks its return value, and `OpCode::SinkPop` already
+knew to *force* a deferred `LazyList` (e.g. a `gather` block) or
+`LazyIoLines` iterator when sinking one — matching raku, which reifies a
+lazy result at the point it is discarded. But `EVAL` compiles to a different,
+"statement-level call, no return value kept" bytecode form
+(`OpCode::ExecCall`/`ExecCallPairs`) that never reaches `SinkPop` at all, so
+`EVAL 'gather { ... }';` as a bare statement silently never ran the gather
+body:
+
+```raku
+EVAL 'gather { print "ran "; take 1 }';
+say "after";
+```
+
+raku prints `ran after`; mutsu printed only `after` — the body never ran.
+
+This matters beyond a synthetic repro: the real, vendored `Test.rakumod`'s
+`throws-like` runs `EVAL $code, context => $ctx;` as exactly this kind of
+bare, named-arg statement call (a mid-body statement, not the block's tail
+value), so `throws-like 'gather { return 1 }', X::ControlFlow::Return` never
+even entered the gather body under `MUTSU_REAL_TEST=1` —
+`t/throws-like-gather-sink.t`'s first subtest in the ongoing
+`todo/deep/vendor-real-test-module.md` campaign.
+
+Fixed by adding the same `LazyList`/`LazyIoLines`-forcing match arms
+`SinkPop` already has to `sink_discarded_call_value`
+(`src/vm/vm_call_exec_ops.rs`), the shared helper both `ExecCall` and
+`ExecCallPairs` already used for the Failure-exploding half of sink
+semantics. Pin: `t/eval-statement-sinks-lazy-result.t`, verified against
+`raku`.
+
+This closes one of the four subtests in `t/throws-like-gather-sink.t`; the
+other three ("a bare `return`/`return` in a `for` loop at mainline throws
+X::ControlFlow::Return" under a `context =>`-scoped `EVAL`) need the deeper
+"`EVAL`'s `context` argument must carry the *frame* a `return` should target,
+not just the package" mechanism described in
+`todo/deep/eval-context-frame-owns-the-return-target.md`, left open.

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -165,19 +165,38 @@ impl Interpreter {
     /// A statement-level call discards its value, so that value is *sunk* —
     /// and sinking an unhandled `Failure` throws, exactly as `OpCode::SinkPop`
     /// does for the call shapes that leave their result on the stack.
-    /// `OpCode::ExecCall` leaves nothing on the stack, so it never reached
-    /// `SinkPop` and swallowed the Failure instead: `EVAL 'use fatal;
-    /// "foo"[2]';` ran on to the next statement where raku throws.
+    /// `OpCode::ExecCall`/`ExecCallPairs` leave nothing on the stack, so they
+    /// never reached `SinkPop` and swallowed the Failure instead: `EVAL 'use
+    /// fatal; "foo"[2]';` ran on to the next statement where raku throws.
+    ///
+    /// A deferred `LazyList`/`LazyIoLines` (e.g. a bare `gather { ... }` as an
+    /// `EVAL`'d snippet's tail statement) must also be *forced* here, exactly
+    /// as `SinkPop` forces one — otherwise `EVAL 'gather { return 1 }';`
+    /// never runs the body at all, so `throws-like`'s own `EVAL $code, context
+    /// => $ctx;` call (a statement-level call with named args, routed through
+    /// `ExecCallPairs`) never sees the escaping `return`.
     fn sink_discarded_call_value(&mut self, value: &Value) -> Result<(), RuntimeError> {
-        if let Some(err) = self.failure_to_runtime_error_if_unhandled(value) {
-            return Err(err);
-        }
-        // Under `use fatal`, a sunk list/Seq holding an unhandled Failure throws
-        // too; without the pragma such a list stays soft. Same rule as SinkPop.
-        if self.fatal_mode
-            && let Some(err) = self.unhandled_failure_in_list_for_fatal(value)
-        {
-            return Err(err);
+        match value.view() {
+            ValueView::LazyList(list) if list.is_cached_no_sink() => {}
+            ValueView::LazyList(list) => {
+                self.force_lazy_list_vm(&list)?;
+            }
+            ValueView::LazyIoLines { handle, words, .. } => {
+                loan_env!(self, force_lazy_io_lines(handle, words))?;
+            }
+            _ => {
+                if let Some(err) = self.failure_to_runtime_error_if_unhandled(value) {
+                    return Err(err);
+                }
+                // Under `use fatal`, a sunk list/Seq holding an unhandled Failure
+                // throws too; without the pragma such a list stays soft. Same
+                // rule as SinkPop.
+                if self.fatal_mode
+                    && let Some(err) = self.unhandled_failure_in_list_for_fatal(value)
+                {
+                    return Err(err);
+                }
+            }
         }
         Ok(())
     }

--- a/t/eval-statement-sinks-lazy-result.t
+++ b/t/eval-statement-sinks-lazy-result.t
@@ -1,0 +1,57 @@
+use Test;
+
+# A bare `EVAL '...';` statement sinks its return value, like any other bare
+# call statement -- and sinking a deferred `gather`/lazy-IO-lines result must
+# FORCE it, exactly as `SinkPop` forces one for an ordinary bare statement.
+# `OpCode::ExecCall`/`ExecCallPairs` (the "statement-level call, no return
+# value kept" bytecode forms `EVAL` compiles to) never reached `SinkPop`'s
+# forcing logic at all, so `EVAL 'gather { ... }';` silently never ran the
+# gather body. This matters for the real, vendored `Test.rakumod`: its
+# `throws-like` runs `EVAL $code, context => $ctx;` as exactly this kind of
+# bare, named-arg statement call, so `throws-like 'gather { return 1 }', ...`
+# never even entered the gather body (`todo/deep/vendor-real-test-module.md`,
+# `t/throws-like-gather-sink.t`).
+
+use MONKEY-SEE-NO-EVAL;
+
+plan 3;
+
+my $marker = "tmp/eval-sink-marker.txt".IO;
+
+# Positional-only EVAL statement call (compiles to OpCode::ExecCall): the
+# gather body's side effect (a spurt) must run.
+{
+    $marker.unlink if $marker.e;
+    EVAL 'gather { "tmp/eval-sink-marker.txt".IO.spurt("ran"); take 1 }';
+    is $marker.e ?? $marker.slurp !! 'not run', 'ran',
+        'a bare, positional-only EVAL of a gather statement forces the body';
+    $marker.unlink;
+}
+
+# Named-arg EVAL statement call (compiles to OpCode::ExecCallPairs, keep_value:
+# false) -- the exact shape `Test.rakumod`'s `throws-like` uses: a bare,
+# MID-BODY (not tail-position) `EVAL $code, context => $ctx;` statement,
+# followed by more statements. A gather whose forced body hits an escaping
+# `return` throws.
+{
+    my $ctx = CALLER::;
+    my $died = False;
+    my $reached = False;
+    try {
+        EVAL 'gather { return 1 }', context => $ctx;
+        $reached = True; # keeps the EVAL call in non-tail (mid-body) position
+        CATCH { default { $died = True; } }
+    }
+    ok $died,
+        'a bare, named-arg EVAL of a gather-with-return forces the body and throws';
+}
+
+# A lazy IO-lines result must also be forced (drained) when EVAL sinks it --
+# not left as a still-open, never-iterated handle.
+{
+    my $path = "tmp/eval-sink-lazy-lines.txt".IO;
+    $path.spurt("L1\nL2\n");
+    lives-ok { EVAL '"tmp/eval-sink-lazy-lines.txt".IO.open(:r).lines' },
+        'a bare EVAL of a lazy IO .lines statement does not hang/crash';
+    $path.unlink;
+}

--- a/todo/deep/eval-context-frame-owns-the-return-target.md
+++ b/todo/deep/eval-context-frame-owns-the-return-target.md
@@ -73,7 +73,11 @@ never runs. raku sinks it inside the EVAL and raises `X::ControlFlow::Return`.
 
 ## What it blocks
 
-`t/throws-like-gather-sink.t` (all three `return` subtests) and part of
+`t/throws-like-gather-sink.t`'s three `return;`/`for ^5 { return; }` subtests
+(the fourth subtest, `throws-like 'gather { return 1 }', ...`, is now fixed —
+that one needed only a separate, narrower "EVAL as a bare statement never
+forces a deferred gather" bug, not this frame-depth mechanism; see
+`news/2026-08/eval-statement-sink-forces-lazy-result.md`) and part of
 `t/emit-done-controlflow.t` under `MUTSU_REAL_TEST=1` — the real
 `Test.rakumod`'s `throws-like` is exactly this shape:
 

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -2465,4 +2465,26 @@ compile-time `X::Comp::Group`/"needs parens to avoid gobbling block" parse
 ambiguity (raku's parser cannot tell whether an undeclared bareword followed
 by `{` is a type smart-match or a routine call taking the block as its sole
 argument), which mutsu's parser does not diagnose at all today — a genuine
-parser feature gap, not investigated further this session.
+parser feature gap.
+
+**Investigated 2026-08-19, not fixed — the obvious extension is unsafe.**
+`when_stmt` (`src/parser/stmt/control/given_when.rs`) already has exactly
+this "gobbled block" diagnosis, but deliberately scoped to bareword names
+under the `X::`/`CX::` reserved namespaces only (checked against
+`is_known_type_constraint`/`is_known_compound_type`/`is_user_declared_type`
+before erroring). The tempting fix is to drop the namespace restriction and
+run the same three checks for *any* bareword. This is unsafe: a survey of
+`modules/` (the vendored batteries) finds real `when SimpleTypeName { ... }`
+usages — e.g. `Cro::HTTP::ResponseParser`'s `when Header { ... }` — where the
+type is declared in a *different* file of the same distribution, loaded via
+`use` at runtime. `is_user_declared_type` only tracks types the *current*
+file declares with `class`/`role`/`enum`/`grammar` during parsing
+(mutsu registers imported/cross-file types at run time, not parse time — see
+the existing comment in `when_stmt` for the identical reasoning already
+applied to compound `X::`-adjacent names like `Day::Mon`). Broadening the
+check as-is would misdiagnose every one of those as a genuine
+parse-time "gobbled block" error, a real regression across the batteries
+corpus. A correct fix needs either a cross-file/cross-compunit type-name
+index available at parse time (a real architectural addition, not a small
+change) or some other way to distinguish "declared nowhere reachable" from
+"declared in a sibling file not yet parsed" — not attempted this session.

--- a/todo/deep/vendor-real-test-module.md
+++ b/todo/deep/vendor-real-test-module.md
@@ -2414,24 +2414,55 @@ Fixed in `exec_eqv_op` (`vm_comparison_order_ops.rs`) by calling the existing
 `resolve_proxies_in_value` (added for `t/`'s native-provider test-argument
 path, `builtins_lvalue.rs`) on both operands before comparing — a cheap
 no-allocation scan in the common Proxy-free case, deep-FETCHing every nested
-Proxy otherwise. `undeclared-when-type.t`'s failing assertion turned out to
-be the same underlying `throws-like` case duplicated in
-`exception-role-membership.t` (`when SomeUndeclaredType { ... }` should be a
+Proxy otherwise. Pin: `t/eqv-fetches-nested-proxy-elements.t` (top-level
+Proxy still FETCHes, nested inside Array/List/Hash/Pair now FETCHes too, and
+a genuinely-different nested-Proxy list correctly stays not-`eqv`) — verified
+byte-for-byte against `raku`. Full local `t/` suite and `cargo clippy -- -D
+warnings` clean; `t/autoviv-index-guard.t` timed out under `-j` load during
+the same `make test` run but reproduces identically on `main` with the fix
+`git stash`-ed out (confirmed directly, not this change) — pre-existing,
+unrelated to `eqv`/`Proxy`.
+
+## `throws-like-gather-sink.t` partly closed (1 of 4 subtests), same 2026-08-19 session
+
+Its first
+subtest — `throws-like 'gather { return 1 }', X::ControlFlow::Return` —
+turned out not to need the frame-depth mechanism this ticket's own
+`eval-context-frame-owns-the-return-target.md` describes at all. The real,
+narrower bug: a bare `EVAL '...';` statement never *forces* a deferred
+`gather`/lazy-IO-lines result at all, regardless of `context`. `SinkPop`
+(the bytecode a bare non-`EVAL` statement's discarded value goes through)
+already forces a `LazyList`/`LazyIoLines`, but `EVAL` compiles to a
+different, "statement-level call, no return value kept" form
+(`OpCode::ExecCall`/`ExecCallPairs`) that never reaches `SinkPop` at all —
+confirmed with `rust-gdb -batch` breakpoints: a `SinkPop` breakpoint fires
+for a bare top-level `gather {...};` statement but never fires for `EVAL
+'gather {...}';`. So `EVAL 'gather { return 1 }';` silently never ran the
+gather body, and `throws-like`'s own `EVAL $code, context => $ctx;` (a bare,
+named-arg, mid-body statement — exactly this shape) never saw the `return`
+at all. Fixed by adding the same `LazyList`/`LazyIoLines`-forcing arms
+`SinkPop` has to `sink_discarded_call_value`
+(`vm_call_exec_ops.rs`), the shared helper both `ExecCall` and
+`ExecCallPairs` already used for the Failure-exploding half of sink
+semantics. Pin: `t/eval-statement-sinks-lazy-result.t`, verified against
+`raku`. `news/2026-08/eval-statement-sink-forces-lazy-result.md`.
+
+The other 3 subtests of `t/throws-like-gather-sink.t` (`return;`/`for ^5 {
+return; }` at mainline, both wrapped in `throws-like`'s `context =>
+$caller-context`) still need the actual frame-depth mechanism —
+`todo/deep/eval-context-frame-owns-the-return-target.md` is unchanged and
+still the right next step there; do not assume the sink-forcing fix above
+covers it (it only fixed the "body never even ran" half of the file's first
+subtest).
+
+Residue after this session: **5 files, 5 assertions**:
+`exception-role-membership.t`, `is-lazy-io-lines.t` (×2), `subscript-adverbs.t`
+(×2), `throws-like-gather-sink.t` (3 remaining subtests, needs
+`eval-context-frame-owns-the-return-target.md`), `undeclared-when-type.t`.
+`exception-role-membership.t` and `undeclared-when-type.t` share the exact
+same underlying gap: `when SomeUndeclaredType { ... }` should be a
 compile-time `X::Comp::Group`/"needs parens to avoid gobbling block" parse
-ambiguity, which mutsu's parser does not currently diagnose at all — a
-genuine parser feature gap, not a `Test`-shape issue; left open, tracked by
-those two files' own `not ok` lines rather than a fresh ticket since neither
-new investigation happened this session).
-
-Pin: `t/eqv-fetches-nested-proxy-elements.t` (top-level Proxy still FETCHes,
-nested inside Array/List/Hash/Pair now FETCHes too, and a genuinely-different
-nested-Proxy list correctly stays not-`eqv`) — verified byte-for-byte against
-`raku`. Full local `t/` suite and `cargo clippy -- -D warnings` clean;
-`t/autoviv-index-guard.t` timed out under `-j` load during the same `make
-test` run but reproduces identically on `main` with the fix `git stash`-ed
-out (confirmed directly, not this change) — pre-existing, unrelated to
-`eqv`/`Proxy`.
-
-Residue is now **5**: `exception-role-membership.t`, `is-lazy-io-lines.t`
-(×2), `subscript-adverbs.t` (×2), `throws-like-gather-sink.t`,
-`undeclared-when-type.t`.
+ambiguity (raku's parser cannot tell whether an undeclared bareword followed
+by `{` is a type smart-match or a routine call taking the block as its sole
+argument), which mutsu's parser does not diagnose at all today — a genuine
+parser feature gap, not investigated further this session.


### PR DESCRIPTION
## Summary
- `OpCode::SinkPop` already forces a `LazyList` (e.g. a `gather` block) or `LazyIoLines` iterator when sinking a bare statement's discarded value. `EVAL` compiles to a different "statement-level call, no return value kept" bytecode form (`ExecCall`/`ExecCallPairs`) that never reaches `SinkPop`, so `EVAL 'gather { ... }';` as a bare statement silently never ran the gather body.
- This matters for the real, vendored `Test.rakumod`: its `throws-like` runs `EVAL $code, context => $ctx;` as exactly this kind of bare, named-arg mid-body statement, so `throws-like 'gather { return 1 }', ...` never entered the gather body under `MUTSU_REAL_TEST=1` — the first of four subtests in `t/throws-like-gather-sink.t`, part of the `todo/deep/vendor-real-test-module.md` campaign.
- Fixed by adding the same `LazyList`/`LazyIoLines`-forcing arms `SinkPop` already has to `sink_discarded_call_value`, the shared helper both `ExecCall` and `ExecCallPairs` use for the Failure-exploding half of sink semantics.
- The other 3 subtests of that file need a separate, deeper fix (`todo/deep/eval-context-frame-owns-the-return-target.md`, not touched here).

## Test plan
- [x] New pin `t/eval-statement-sinks-lazy-result.t`, verified byte-for-byte against `raku`
- [x] `t/throws-like-gather-sink.t`'s first subtest now passes under `MUTSU_REAL_TEST=1`
- [x] Full local `t/` suite green (`t/autoviv-index-guard.t`'s pre-existing timeout unrelated, reproduces on `main`)
- [x] `cargo clippy -- -D warnings` clean, `cargo fmt` clean
- [x] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)