### PR TITLE
docs: reduce Template::Jinja2's two blockers to one-function bugs

### DIFF
--- a/docs/batteries/templates.md
+++ b/docs/batteries/templates.md
@@ -93,7 +93,7 @@ Enough to start root-causing; none of these are module rot, since raku runs them
 | --- | --- |
 | `Template::Mustache` | `Use of Nil in string context` from the `TOP` grammar action (`lib/Template/Mustache.rakumod:136`), reached via `parse-template` |
 | `Template6` | same warning, from `Parser.compile` — a `q:to/RAKU/` heredoc whose `\qq[$safe-delimiter]` / `\qq[$segment]` come out empty |
-| `Template::Jinja2` | `Cannot call private method without permission` at `Renderer.rakumod` load time — **22 of 23 files die on it**, the single biggest lever in the table |
+| `Template::Jinja2` | Two bugs, both reduced 2026-08-19. `01-lexer` fails on its own because a literal `{` inside `<-[{]>` makes mutsu's assertion scanner miss the class's closing `>`, swallowing the `+` and every atom after it; the other 22 files die at `Renderer.rakumod` load time on `Cannot call private method without permission`, because a qualified `$obj!Renderer::meth` inside `module Template::Jinja2::Renderer` compares the short owner name against the fully-qualified caller |
 | `Template::Mojo` | `No such method 'characters' for invocant of type 'Match'` — the grammar's `token characters` is not being resolved as a subrule (`.characters` is not a raku method either, so mutsu is falling back to method dispatch where it should be a named capture) |
 | `Template::Nest::Fast` | `Use of Nil in string context` |
 | `Template::Classic` | `X::Method::NotFound: Unknown method value dispatch (fallback dispatch)` |
@@ -107,6 +107,20 @@ Confirmed and separately filed so far:
 
 - `todo/tickets/q-heredoc-interpolates-qq-escape.md` — `Q:to/…/` wrongly honours
   `\qq[…]`; raku leaves it literal. Found while reducing the `Template6` failure.
+  (Fixed 2026-07-26; it was **not** the `Template6` blocker.)
+- `todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md`
+  — a literal `{` / `(` written inside a `<[...]>` char class makes
+  `scan_angle_assertion_body()` miss the assertion's closing `>`, so the
+  quantifier and every following atom are silently dropped. Reduced from
+  `Template::Jinja2`'s `01-lexer` (0/15 → 15/15 with the brace escaped by hand),
+  but it is a general grammar-slang bug: `<-[{]>+` ("text up to the next opening
+  delimiter") is idiomatic in template and config grammars.
+- `todo/tickets/qualified-private-method-call-uses-short-owner-name.md` — a
+  qualified private call `$obj!Renderer::meth` written inside
+  `module Template::Jinja2::Renderer` is rejected because the statically-checked
+  owner name is compared as written against the fully-qualified caller class.
+  This is what makes `Template::Jinja2` unloadable; it is **distinct** from the
+  private-method-in-closure bug fixed in #5466.
 - `todo/deep/template-engines-blocked-on-mutsu.md` — this matrix as a work item.
 
 ## How the field was surveyed
@@ -151,10 +165,13 @@ version and its own suite run under both `raku` and `target/debug/mutsu`
   `Template::Classic` embed Raku code. For "a small web blog", logic-free plus
   the host program's own code is the safer default, and it is what most of the
   ecosystem picked.
-- **`Template::Jinja2` deserves a second look after its blocker is fixed** — it
-  is the newest of the field (2026-04-29), 22/23 under raku, and its single mutsu
-  error kills 22 files at once, so it may be the cheapest of all to unblock. Its
-  ecosystem standing is weak (2 dependents, both by the same author).
+- **`Template::Jinja2` deserves a second look after its blockers are fixed** — it
+  is the newest of the field (2026-04-29), 22/23 under raku, and as of the
+  2026-08-19 reduction both of its mutsu blockers are **one-function interpreter
+  bugs** (a char-class scanning bug and a private-method permission check), one
+  of which kills 22 files at once. So it stays the cheapest of the field to
+  unblock. Its ecosystem standing is weak (2 dependents, both by the same
+  author).
 - **`Template::Protone` and `ERK` were never in contention**: they ship no tests
   at all, so there is nothing to gate at release time — a structural problem for
   a battery whose whole verification story is `scripts/battery-testsuite.sh`.

--- a/todo/deep/template-engines-blocked-on-mutsu.md
+++ b/todo/deep/template-engines-blocked-on-mutsu.md
@@ -10,7 +10,7 @@ and broken under mutsu**, so the battery decision is blocked on interpreter work
 | --- | --- | --- | --- |
 | `Template::Mustache` 1.2.6 | 11/13 | ~~1/13~~ → **11/13** | **FIXED** — hyper `».method` did not flatten a `Slip` result; pin `t/hyper-method-slip-result.t`. Two files remain: `06-logging` (2/3), `92-specs-file` (1/10) |
 | `Template6` 0.16.0 | 12/12 | **0/12** | `Use of Nil in string context` from `Parser.compile`: a `q:to/RAKU/` heredoc whose `\qq[$safe-delimiter]` / `\qq[$segment]` come out empty |
-| `Template::Jinja2` 0.2.0 | 22/23 | **0/23 files**, but no longer dies at load | **Load blocker FIXED 2026-07-26** (#5466, `news/2026-07/private-method-in-closure.md`): a closure created in a method lost its class, so `Renderer.rakumod`'s `sub (*@args) { self!cycle(|@args) }` was rejected and every file died before its first assertion. The suite now RUNS (re-measured 2026-07-26 with the dist from the REA archive) and fails on assertions instead — e.g. `01-lexer` reaches subtest 1 and fails "Correct value". A new reduction is needed for that next layer |
+| `Template::Jinja2` 0.2.0 | 22/23 | **0/23 files** | **REDUCED 2026-08-19 — two interpreter bugs, both filed as tickets.** (1) `todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md` — a literal `{` inside `<-[{]>` makes the assertion scanner miss its closing `>`, so the `+` and every following atom is swallowed; the lexer chunks plain text one character per token. Escaping that single brace by hand takes `01-lexer` from **0/15 to 15/15**. (2) `todo/tickets/qualified-private-method-call-uses-short-owner-name.md` — `$renderer!Renderer::…` inside `module Template::Jinja2::Renderer` is rejected because the owner is compared as written (`Renderer`) against the fully-qualified caller (`Template::Jinja2::Renderer::Renderer`); this kills the other 22 files at load |
 | `Template::Mojo` 0.2.2 | 5/5 | ~~0/5~~ → **4 of 5 files run** | **FIXED 2026-07-26** (#5468, `news/2026-07/regex-assertion-quoted-angle-brackets.md`): a quoted `<`/`>` inside a regex lookaround broke the parse — not a named-capture bug. Now 00-basic 15/17, 01-template 3/3, 02-complex 1/1, 04-native-named 1/1; residue in `todo/tickets/template-mojo-residual-failures.md` |
 | `Template::Nest::Fast` 0.3.0 | 10/10 | **0/10** | `Use of Nil in string context` |
 | `Template::HAML` 0.9.5 | 82/83 | 14/83 | many; also **2–3× slower to load than raku** (release) → `todo/tickets/grammar-heavy-module-load-slower-than-raku.md` |
@@ -19,6 +19,16 @@ and broken under mutsu**, so the battery decision is blocked on interpreter work
 
 Reproduce with `tmp/tmpl-survey.sh` (fetches each dist from the REA archive at a
 pinned version and runs its own suite; swap `MUTSU_BIN=raku` for the baseline).
+`tmp/` is gitignored, so that script does not survive a fresh checkout — rebuild
+it from the two steps it automates:
+
+1. Look the dist's `source-url` up in the local REA index, the same data `mzef`
+   uses: `~/.zef/store/rea/rea.json` is a JSON array of entries with `name`,
+   `version` and `source-url` (a `https://raw.githubusercontent.com/raku/REA/…`
+   tarball, URL-escaped `Name:ver<X>:auth<Y>.tar.gz`).
+2. `curl -sSL` it, untar into `tmp/`, and run each `t/*.rakutest` with
+   `-I lib` under `target/debug/mutsu` and under `raku`, counting whole files
+   that exit 0.
 
 ## Why this is a deep item, not a ticket
 
@@ -37,9 +47,13 @@ needs its own reduction before it can be scheduled. What *is* known:
   method call. Fixed in #5468. **Lesson for the remaining rows: the first error
   message is a symptom; reduce the real module by deleting constructs until a
   two-line repro falls out, rather than theorising from the message.**
-- `Template::Jinja2` was the cheapest lever by file count and its load-time
-  error is now fixed (#5466); the suite runs but fails on assertions, so it
-  needs a fresh reduction rather than a re-run.
+- `Template::Jinja2` was the cheapest lever by file count. Its 2026-07-26
+  "load blocker FIXED (#5466)" note was **too optimistic**: #5466 did fix the
+  `sub (*@args) { self!cycle(|@args) }` closure form, but the dist still dies at
+  `use Template::Jinja2::Renderer` on a *different* private-method path (the
+  qualified `$renderer!Renderer::…` form). Re-measured 2026-08-19 on the current
+  build: **0/23 files**. Both remaining causes are now reduced to one-function
+  bugs — see the two tickets in the row above.
 
 ## Already reduced and split out
 
@@ -55,11 +69,22 @@ needs its own reduction before it can be scheduled. What *is* known:
 1. ~~`Template::Mustache`~~ — **done 2026-07-25**, and it is the chosen engine for
    the slot. One general fix (hyper Slip flattening) took it 1/13 → 11/13. The
    last two files are tracked with the battery itself, not here.
-2. ~~`Template::Jinja2`'s private-method error~~ — **done 2026-07-26** (#5466);
-   the suite now runs. Its next layer (assertion failures, starting with
-   `01-lexer`'s "Correct value") is unreduced and is the natural follow-up.
+2. `Template::Jinja2` — **reduced 2026-08-19, ready to implement.** Both
+   remaining blockers are one-function interpreter bugs with pins specified:
+   `todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md`
+   (fixes `01-lexer` outright, and is a general grammar-slang bug that any
+   template/config grammar will hit) and
+   `todo/tickets/qualified-private-method-call-uses-short-owner-name.md` (which
+   makes the dist loadable at all). Do them in that order — the char-class one is
+   independently valuable and has the smaller diff.
 3. `Template6` — the runner-up candidate; worth fixing so the survey has a real
-   second option rather than a single viable choice.
+   second option rather than a single viable choice. Still **unreduced**:
+   re-checked 2026-08-19, `t/01-simple.rakutest` emits `Use of Nil in string
+   context` from `Parser.compile` at `lib/Template6/Parser.rakumod` lines
+   227/230/231 and yields empty output. Per the lesson above, that warning is a
+   pointer, not the diagnosis — reduce `Parser.compile` by deletion rather than
+   theorising about the heredoc. Confirmed **not** the char-class bug: Template6
+   uses no `{`/`(` inside a `<[...]>` class.
 4. The rest (`Mojo`, `Nest::Fast`, `HAML`, `SP6`, `Classic`) as ordinary
    compatibility work; each is also a data point that mutsu's grammar/list
    semantics still diverge in ways ordinary modules hit.

--- a/todo/tickets/qualified-private-method-call-uses-short-owner-name.md
+++ b/todo/tickets/qualified-private-method-call-uses-short-owner-name.md
@@ -1,0 +1,125 @@
+# `$obj!Class::method` is rejected when the class lives inside a module
+
+Reduced 2026-08-19 while working the `Template::Jinja2` row of
+[todo/deep/template-engines-blocked-on-mutsu.md](../deep/template-engines-blocked-on-mutsu.md).
+This is the blocker that stands **behind** the char-class bug: with
+[regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md](regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md)
+worked around by hand, 22 of the dist's 23 test files still die at module-load
+time on this one.
+
+## Repro
+
+```raku
+module Outer::Inner {
+    class Renderer is export {
+        method !secret($x) { "secret:$x" }
+        method go($x) {
+            my $r = self;
+            return $r!Renderer::secret($x);
+        }
+    }
+}
+import Outer::Inner;
+say Renderer.new.go(42);
+```
+
+raku prints `secret:42`. mutsu dies before running anything:
+
+```
+Cannot call private method without permission
+  in block <unit> at tmp/priv3.raku line 2
+```
+
+Two controls pin the cause exactly:
+
+- Drop the enclosing `module` (a bare top-level `class Renderer { … $r!Renderer::secret(…) }`)
+  and mutsu is **fine**.
+- Keep the module but write the owner fully qualified
+  (`$r!Outer::Inner::Renderer::secret($x)`) and mutsu is **fine**.
+
+## Root cause
+
+`validate_private_access_in_expr()` in `src/runtime/registration.rs` (~line 518)
+validates `$obj!Owner::meth` statically, at class-registration time:
+
+```rust
+if *modifier == Some('!')
+    && let Some((owner_class, _)) = name.resolve().rsplit_once("::")
+    && owner_class != caller_class
+    && !self.registry().class_trusts.get(owner_class)
+        .is_some_and(|trusted| trusted.contains(caller_class))
+{
+    return Err(RuntimeError::typed_msg("X::Method::Private::Permission", …));
+}
+```
+
+`owner_class` is taken verbatim from the source text — the *short* name the
+programmer wrote (`Renderer`) — while `caller_class` is the class's
+**fully-qualified** registered name (`Outer::Inner::Renderer`). The comparison is
+a plain string equality, so the two never match and the check false-positives on
+what is a perfectly legal self-call. The `class_trusts` lookup is keyed on the
+raw `owner_class` too, so the `trusts` escape hatch cannot rescue it either.
+
+Raku resolves `Renderer` in `$r!Renderer::secret` through the ordinary package
+lookup of the enclosing lexical scope, which inside `module Outer::Inner` finds
+`Outer::Inner::Renderer` — the same class — so access is granted.
+
+## Impact — measured
+
+`Template::Jinja2` 0.2.0's `lib/Template/Jinja2/Renderer.rakumod` is
+`module Template::Jinja2::Renderer { … class Renderer is export { … } }` and
+calls `$renderer!Renderer::render-block-with-super(…)`,
+`$renderer!Renderer::render-for-items(…)`, `$renderer!Renderer::eval(…)` and
+`$renderer!Renderer::render-body(…)` from closures inside the class body (5 call
+sites). `use Template::Jinja2::Renderer;` alone is enough to reproduce, so the
+whole dist is unloadable and 22 of its 23 files die before their first assertion.
+
+This is **not** the private-method-in-closure bug fixed in #5466
+(`news/2026-07/private-method-in-closure.md`) — the closure form from that fix
+works now; this is the *qualified* form with a short owner name, and it is a
+different code path (a static registration-time check, not a dispatch-time one).
+
+## Proposed fix
+
+Resolve the owner name to the same canonical class identity the registry uses
+before comparing, instead of comparing raw source text:
+
+1. Canonicalise `owner_class` through the package resolution already used when
+   registering / looking up a class — the enclosing package chain of
+   `caller_class` first, then the global registry. In the repro, `Renderer`
+   written inside `Outer::Inner::Renderer` must resolve to
+   `Outer::Inner::Renderer`.
+2. Compare the *canonical* names, and key the `class_trusts` lookup on the
+   canonical owner name too, so `trusts` keeps working for the short form.
+3. If the owner name does not resolve to any registered class, keep today's
+   behaviour (reject) rather than silently allowing — an unresolvable owner is
+   still an error, just not this one.
+
+The cheap, obviously-correct shape of step 1 is "accept when `caller_class` ==
+`owner_class`, or when `caller_class` ends with `::` + `owner_class`", but do the
+real resolution rather than a suffix test: a suffix test would wrongly accept
+`A::B::Renderer` calling `$x!Renderer::…` where `Renderer` lexically names an
+unrelated top-level class.
+
+## Pin to add
+
+`t/private-method-qualified-short-owner.t` — the repro above, plus:
+
+- the fully-qualified spelling (must keep working),
+- the bare top-level class (must keep working),
+- a genuine violation (`class A { method !s {…} }; class B { method go($a) { $a!A::s } }`)
+  which must still throw `X::Method::Private::Permission` (verified: mutsu
+  rejects this today, and must keep rejecting it),
+- the same pair with `class A { trusts B; … }`, which must be allowed (verified:
+  mutsu allows it today) — including when the owner is written short inside a
+  module.
+
+While in this function it is worth upgrading the message, too: raku says
+`Cannot call private method 's' on package 'A' because it does not trust the 'B'
+package.` where mutsu says only `Cannot call private method without permission`,
+which is what made this failure so opaque inside a 900-line module.
+
+## Affected files
+
+- `src/runtime/registration.rs` — `validate_private_access_in_expr()` and the
+  `class_trusts` lookup beside it.

--- a/todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md
+++ b/todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md
@@ -1,0 +1,130 @@
+# A `{` or `(` inside a `<[...]>` char class swallows the rest of the regex
+
+Reduced 2026-08-19 while working the `Template::Jinja2` row of
+[todo/deep/template-engines-blocked-on-mutsu.md](../deep/template-engines-blocked-on-mutsu.md).
+It is a **one-function** bug and it is the *entire* reason `Template::Jinja2`'s
+`t/01-lexer.rakutest` fails 0/15 under mutsu.
+
+## Repro
+
+```raku
+say ('Hello World' ~~ / <-[{]>+ /).Str;   # raku: Hello World   mutsu: H
+say ('Hello World' ~~ / <-[(]>+ /).Str;   # raku: Hello World   mutsu: H
+say ('Hello World' ~~ / <-[}{]>+ /).Str;  # raku: Hello World   mutsu: H
+say ('Hello World' ~~ / <-[{]> .+ /).Str; # raku: Hello World   mutsu: H
+say ('{{{x'        ~~ / <[{]>+  /).Str;   # raku: {{{          mutsu: (no match)
+say ('Hello World' ~~ / <-[[]>+ /).Str;   # raku: Hello World   mutsu: H
+```
+
+Cases that already work and delimit the bug precisely:
+
+| Pattern | mutsu | why |
+| --- | --- | --- |
+| `<-[}]>+` / `<-[)]>+` | OK | a lone *closing* brace/paren saturates the depth counter at 0 |
+| `<-[{}]>+` | OK | the pair balances |
+| `<-[<]>+` / `<-[>]>+` | OK | the `<` / `>` arms **already** carry a `bracket_depth == 0` guard |
+| `<-[\{]>+` | OK | the backslash escape path bypasses the brace arm |
+
+So the trigger is exactly: **an unbalanced opening `{` or `(` (or a literal `[`)
+written inside an enumerated character class**.
+
+## Root cause
+
+`scan_angle_assertion_body()` in `src/runtime/regex_parse_core.rs` (the scan that
+finds the closing `>` of a `< ... >` assertion) balances angles, parens, brackets
+*and* braces so that an inner `>` cannot terminate the assertion early. The
+`'<'` and `'>'` arms are correctly gated on `paren_depth == 0 && bracket_depth ==
+0 && brace_depth == 0`, and the quote opener is gated on `bracket_depth == 0` —
+but the `'('`, `')'`, `'{'` and `'}'` arms have **no `bracket_depth` guard at
+all**:
+
+```rust
+'{' => { brace_depth += 1; name.push(ch); }
+'}' => { brace_depth = brace_depth.saturating_sub(1); name.push(ch); }
+```
+
+Inside an enumerated char class `[...]` those four characters are ordinary
+literals — Raku's char-class slang has no brace or paren nesting. So scanning
+`<-[{]>+` goes: `[` → `bracket_depth = 1`; `{` → `brace_depth = 1`; `]` →
+`bracket_depth = 0`; `>` → the guard sees `brace_depth == 1` and refuses to
+close. The scan then runs to the end of the pattern and returns `closed: false`.
+The caller retries once with `honor_quotes` off (same result) and ends up
+treating the whole remainder as the assertion body, so `<-[{]>+ ` is parsed as a
+negated class over the characters `{ ] > +` — **and the `+` quantifier, plus
+every atom after the class, is silently swallowed**. That is why the match is one
+character long and why `<-[{]> .+` loses its `.+`.
+
+The `[` variant (`<-[[]>`) has the same shape via `bracket_depth` itself: a
+literal `[` inside the class bumps the depth so the closing `]` never brings it
+back to 0.
+
+## Impact — measured
+
+`Template::Jinja2` 0.2.0's lexer grammar is built on
+`token chunk:sym<text> { <-[{]>+ || \{ <!before [\%|\{|"#"]> }`. Under mutsu the
+`+` is lost, so every run of plain template text is chunked **one character per
+token**: `tokenize('Hello World')` returns 11 `TOKEN_TEXT` tokens whose values
+are `H`, `e`, `l`, … instead of a single `Hello World`. Escaping that one brace
+by hand in a scratch copy of the dist (`<-[\{]>`) takes
+`t/01-lexer.rakutest` from **0/15 to 15/15**, with no other change.
+
+Nothing else in the dist is touched by the workaround, so the interpreter fix
+alone unblocks that file. (The rest of the suite then hits a *different*
+blocker — see
+[qualified-private-method-call-uses-short-owner-name.md](qualified-private-method-call-uses-short-owner-name.md).)
+
+`<-[{]>` / `<-[(]>` are completely idiomatic in template and config grammars, so
+the blast radius is wider than one dist: any grammar that lexes "text up to the
+next opening delimiter" hits it.
+
+## Proposed fix
+
+Add the missing `bracket_depth == 0` guards, mirroring what the `<` / `>` / quote
+arms already do:
+
+```rust
+'(' if bracket_depth == 0 => { paren_depth += 1;  name.push(ch); }
+')' if bracket_depth == 0 => { paren_depth = paren_depth.saturating_sub(1); name.push(ch); }
+'{' if bracket_depth == 0 => { brace_depth += 1;  name.push(ch); }
+'}' if bracket_depth == 0 => { brace_depth = brace_depth.saturating_sub(1); name.push(ch); }
+```
+
+(with the unguarded characters falling through to the `_ => name.push(ch)` arm).
+That is the whole fix for the `{` / `(` cases and for the `Template::Jinja2`
+blocker.
+
+The literal-`[` case (`<-[[]>`) is a separate line in the same function and is
+optional to fix in the same PR. It cannot be handled by "never nest `[`", because
+`\c[LATIN SMALL LETTER A]` and `\x[263A]` legitimately put a bracketed argument
+inside a class and rely on the current nesting to find their `]` (verified: mutsu
+gets `<[\c[LATIN SMALL LETTER A]]>+` right today, and that must not regress). The
+narrow rule is: while `bracket_depth >= 1`, only bump `bracket_depth` for a `[`
+that immediately follows one of the bracket-taking escapes (`\c` `\C` `\x` `\X`),
+and otherwise push it as a literal.
+
+## Related, same theme, different scanner
+
+`/ <[x] + [{]>+ /` dies at *parse* time with `Regex not terminated.` — a
+source-level failure, before the runtime scanner ever sees the pattern.
+`skip_char_class()` in `src/parser/primary/regex/scan.rs` only accepts a compound
+class continuation when `+[` / `-[` follows the `]` **immediately**, with no
+intervening whitespace; on a space it gives up, control returns to the main
+delimiter scan, and the `{` in the second group is then mistaken for an embedded
+`{ ... }` code block whose search for a closing `}` runs off the end of the file.
+`<[x]+[{]>` (no spaces) parses, and `<[x] + [y]>` (spaces, no brace) parses, so it
+takes both conditions. Worth folding into the same PR: let `skip_char_class()`
+skip whitespace between a `]` and the following `+[` / `-[` / `>`.
+
+## Pins to add
+
+- `t/regex-char-class-literal-brace.t` — the six `~~` lines at the top of this
+  file, plus the grammar form (`token TOP { <chunk>* }` with
+  `token chunk:sym<text> { <-[{]>+ }` must produce **one** chunk for
+  `'Hello World'`, not eleven).
+- Keep an existing-behaviour assertion for `<[\c[LATIN SMALL LETTER A]]>+` so the
+  optional `[` refinement cannot regress the escape form.
+
+## Affected files
+
+- `src/runtime/regex_parse_core.rs` — `scan_angle_assertion_body()` (the guards).
+- `src/parser/primary/regex/scan.rs` — `skip_char_class()` (the related facet).


### PR DESCRIPTION
Design/investigation only — no `src/`, `t/` or `roast/` changes.

Worked item 2 of `todo/deep/template-engines-blocked-on-mutsu.md`'s "Order of work":
`Template::Jinja2`'s unreduced `01-lexer` "Correct value" assertion failure. It reduced
to a **one-function** interpreter bug, and a second one-function bug turned up behind it.

## 1. A literal `{` / `(` inside a char class swallows the rest of the regex

`todo/tickets/regex-brace-paren-inside-char-class-swallows-rest-of-pattern.md`

```raku
say ('Hello World' ~~ / <-[{]>+ /).Str;    # raku: Hello World   mutsu: H
say ('Hello World' ~~ / <-[(]>+ /).Str;    # raku: Hello World   mutsu: H
say ('Hello World' ~~ / <-[{]> .+ /).Str;  # raku: Hello World   mutsu: H
say ('{{{x'        ~~ / <[{]>+  /).Str;    # raku: {{{           mutsu: (no match)
```

`scan_angle_assertion_body()` (`src/runtime/regex_parse_core.rs`) balances angles,
parens, brackets and braces while looking for an assertion's closing `>`. The `<` /
`>` arms and the quote opener are correctly gated on `bracket_depth == 0`, but the
`(` / `)` / `{` / `}` arms are not — and inside an enumerated char class those are
plain literals. So `<-[{]>+` leaves `brace_depth == 1` when the real `>` arrives, the
scan runs to the end of the pattern, and the `+` plus every following atom is silently
swallowed.

Controls that delimit it exactly: `<-[}]>` and `<-[)]>` are fine (a lone closer
saturates at 0), `<-[{}]>` is fine (balanced), `<-[<]>` / `<-[>]>` are fine (already
guarded), `<-[\{]>` is fine (escape path). `<-[[]>` fails the same way via
`bracket_depth` itself.

**Impact, measured:** Jinja2's lexer is built on
`token chunk:sym<text> { <-[{]>+ || … }`, so under mutsu `tokenize('Hello World')`
returns 11 one-character `TOKEN_TEXT` tokens. Escaping that one brace by hand in a
scratch copy takes `t/01-lexer.rakutest` from **0/15 to 15/15** with no other change.
`<-[{]>+` ("text up to the next opening delimiter") is idiomatic in template and config
grammars, so this is not a one-dist bug.

**Proposed fix:** add the missing `bracket_depth == 0` guards to the four arms, mirroring
what `<` / `>` already do. The `<-[[]>` variant is a separate optional line in the same
function and must not regress `<[\c[LATIN SMALL LETTER A]]>`, which relies on the current
`[` nesting — the narrow rule is spelled out in the ticket. A related facet in the
*source-level* scanner (`skip_char_class()` in `src/parser/primary/regex/scan.rs` requires
`+[` / `-[` immediately after `]`, so `/ <[x] + [{]>+ /` dies with `Regex not terminated.`)
is documented for the same PR.

## 2. `$obj!Class::method` rejected when the class lives inside a module

`todo/tickets/qualified-private-method-call-uses-short-owner-name.md`

With (1) worked around, 22 of the 23 files still die at load. `use
Template::Jinja2::Renderer;` alone reproduces:

```raku
module Outer::Inner {
    class Renderer is export {
        method !secret($x) { "secret:$x" }
        method go($x) { my $r = self; return $r!Renderer::secret($x); }
    }
}
import Outer::Inner;
say Renderer.new.go(42);   # raku: secret:42   mutsu: Cannot call private method without permission
```

`validate_private_access_in_expr()` (`src/runtime/registration.rs`) splits the owner off
the source text (`Renderer`) and string-compares it with the caller's **fully-qualified**
registered name (`Outer::Inner::Renderer`). Controls: drop the `module` and it works;
write the owner fully qualified and it works. The `class_trusts` lookup is keyed on the
same raw name, so `trusts` can't rescue it either. Fix: canonicalise the owner through the
registry's package resolution before comparing (and key `class_trusts` on the canonical
name). Genuine violations still throwing, and `trusts` still permitting, are both verified
as current behaviour and specified as pins.

This is **not** the private-method-in-closure bug fixed in #5466 — that closure form works
now. The tracking doc's "Load blocker FIXED 2026-07-26" line was too optimistic and is
corrected here; the dist is still **0/23** on the current build.

## Doc updates

- `todo/deep/template-engines-blocked-on-mutsu.md` — Jinja2 row rewritten with both
  reductions, "Why this is a deep item" corrected, "Order of work" item 2 marked ready to
  implement (with the recommended order), item 3 (`Template6`) given its re-measured
  2026-08-19 state — confirmed a **different** root cause, still unreduced. Also added a
  recipe for rebuilding the gitignored `tmp/tmpl-survey.sh` from the local REA index, since
  it does not survive a fresh checkout.
- `docs/batteries/templates.md` — "First observed failure" row, the "Confirmed and
  separately filed" list, and the runner-up narrative updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
