### PR TITLE
fix(vm): a whenever body's die now quits its enclosing supply block

### DIFF
--- a/docs/adr/0031-supply-quit-ownership-and-cold-source-tapping.md
+++ b/docs/adr/0031-supply-quit-ownership-and-cold-source-tapping.md
@@ -1,6 +1,8 @@
 # ADR-0031: A supply block's quit belongs to its own emitter, and a cold `whenever` source is tapped rather than replayed
 
-- Status: Proposed (design complete; implementation not started)
+- Status: Partially implemented — Slice 1 (Decision A, quit ownership) shipped
+  2026-08-19; Slice 2 (Decision B, `supply_get_values` tap-and-drain) and
+  Slice 3 (retire the ticket) are not started. See "Outcome" below.
 - Date: 2026-08-19
 - Related: [ADR-0008](0008-push-based-supply-event-delivery.md) (the sink/waker
   primitives the drain in Decision B rides on), [ADR-0028](0028-supply-schedule-on-deferred-tap-delivery.md)
@@ -349,3 +351,65 @@ news/YYYY-MM/…` and rewrite as an accomplishment, per `todo/README.md`. Re-che
   `Cro::HTTP`'s error paths and `.list`/`.wait` feed its body coercions. Run the
   vendored Cro suites (`modules/`, `scripts/battery-testsuite.sh`) as part of
   Slice 1 and Slice 2 step 1, not only at the end.
+
+## Outcome
+
+### Slice 1 (Decision A), shipped 2026-08-19
+
+Implemented as designed, with one addition the design did not anticipate:
+
+1. `call_supply_tap` (`src/runtime/supply_promise.rs`) gained the non-control
+   `Err` → `$emitter.quit($reason)` arm, gated on the callback being stamped
+   and its emitter carrying a `supplier_id` — using the control-signal
+   exclusion list from `native_supplier_methods.rs` verbatim, as the ADR
+   specified.
+2. `run_whenever_with_value`'s `ValueView::Promise` arm (`src/runtime/subtest.rs`)
+   now calls the body through `call_supply_tap` instead of raw
+   `call_sub_value`. Preventing the whenever's own LAST phaser from *also*
+   firing after a converted die (both `ran.is_ok()` after the conversion)
+   needed an explicit post-call termination check — `emitter_supplier_id_of`
+   plus `supplier_snapshot(sid).2.is_some()` — that the ADR's text did not
+   spell out.
+3. `native_supply_mut_methods.rs`'s on-demand `"tap"|"act"` branch now
+   registers the tap's `quit =>` handler once on `emitter_supplier_id`,
+   before the marker walk; the old per-source registrations in b1 and b2 are
+   removed, exactly as designed.
+
+**Gap the ADR did not anticipate, found by testing probe6 case G (a source's
+own `.quit()` call, not a body die) and fixed in the same PR:** removing the
+b1/b2 per-source `quit =>` registrations broke every path that reaches the
+tap's `quit =>` handler *without* going through `call_supply_tap` — i.e. a
+`Supplier`'s own `"quit"` method (both the immutable and mutable native
+handlers in `native_supplier_methods.rs`) and `invoke_done_callback_or_quit`
+(the existing LAST-phaser-die-to-quit conversion in
+`native_supply_methods.rs`, pinned by
+`t/whenever-last-phaser-die-converts-to-quit.t` and
+`t/promise-supply-nested-quit-breaks.t`). Both used to find the downstream
+handler because the old b1 registration happened to live on the *source's*
+own `supplier_id` — the same id these two call sites already had in hand.
+Fixed with a new helper, `take_supplier_quit_callbacks_via_group`
+(`src/runtime/native_methods/state_supplier.rs`): drain the source's own
+`supplier_id` first (still correct for a direct `.tap(quit => ...)` with no
+`whenever` involved), then also drain via `supplier_serialize_group(sid)` —
+the source→emitter link `b1` already records for a different reason (the
+"only one whenever handler at a time" lock, ADR-0028). All four call sites
+that used to read `take_supplier_quit_callbacks(sid)` for a *whenever
+source's own* unhandled quit now go through this helper instead; the two
+plain-tap emit-dispatch fallbacks (which have no serialize group and were
+already correct) are untouched.
+
+Tests: `t/supply-whenever-body-die-quits-block.t` (new — the ticket's repro,
+probe3 B/C, probe6 F/G, all cross-checked against `raku` first) plus the full
+existing `t/supply-*.t` / `t/whenever-*.t` / `t/react-*.t` / `t/promise-supply-*.t`
+suites (113 files, 522 tests, all green) and every whitelisted `roast/S17-*`
+file on a release build (Files=58+15+..., all green). `cargo test` (852 unit
+tests) and `cargo clippy -- -D warnings` are clean.
+
+### Slice 2 (Decision B) and Slice 3 (retire the ticket): not started
+
+`supply_get_values` still replays; `replay_cold_whenever_capture` and
+`replay_static_whenever_promise` are unchanged. Defect B in the ticket
+(`todo/deep/cold-supply-whenever-source-replayed-not-tapped.md`) is therefore
+still open, and the ticket is not retired. A future session can pick up Slice
+2 directly from the "Mechanism" section above — nothing in Slice 1 changed
+its shape.

--- a/news/2026-08/supply-whenever-body-die-quits-enclosing-block.md
+++ b/news/2026-08/supply-whenever-body-die-quits-enclosing-block.md
@@ -1,0 +1,59 @@
+# A `whenever` body's `die` now quits the enclosing `supply` block, everywhere
+
+Implemented ADR-0031 Decision A / Slice 1
+(`docs/adr/0031-supply-quit-ownership-and-cold-source-tapping.md`): a `die`
+inside a `whenever` body now belongs to the `supply` block it is written in,
+not to whichever upstream source happened to dispatch the callback that ran
+it.
+
+Previously, mutsu attached a tap's `quit =>` handler to whichever *upstream*
+object each of the four `whenever`-source branches in the `"tap" | "act"`
+dispatch arm happened to have in hand. Two of the four (a direct
+supplier-backed source and a channel-backed source) worked, but only by
+accident: the die happened to unwind through the emit-dispatch code that
+routes a failed tap callback to the very supplier the handler was attached
+to. The other two — a `whenever` chained onto another on-demand supply, and a
+`whenever Promise.in(...)` registered from *inside* another whenever's body —
+had no such coincidence, so the die simply vanished: the enclosing supply
+kept running as if nothing had happened.
+
+The fix makes the enclosing supply block's own emitter own `quit`, the same
+way it already owns `emit`, `done`, and `CLOSE`:
+
+- `call_supply_tap` (the chokepoint every whenever/tap callback dispatch
+  already runs through) now converts a *stamped* callback's non-control `Err`
+  into `$emitter.quit($reason)` via the canonical `Supplier."quit"` — the
+  dual of the `done`-absorption it already did. A plain, unstamped
+  `.tap({ die ... })` is untouched: only a callback that is literally a
+  `whenever` body takes this path.
+- The tap's `quit =>` handler is now registered once, on the block's own
+  emitter, before the four whenever-source branches run — instead of
+  per-source, and instead of not at all for the previously-uncovered chained
+  branch.
+- The nested `whenever <Promise>` case (registered from inside another
+  whenever's body, after the enclosing block's own synchronous run is over)
+  now routes its body through `call_supply_tap` too, so its die converts the
+  same way.
+
+Fixing this surfaced a second, related gap: once the tap's `quit =>` handler
+moved off each source's own `supplier_id`, two existing mechanisms that used
+to find it *there* — a `Supplier`'s own `.quit()` method (a genuine external
+source quit, not a body die) and the existing LAST-phaser-die-to-quit
+conversion — stopped reaching it. Both are fixed with a new
+`take_supplier_quit_callbacks_via_group` helper that also checks the
+serialize-group link the supplier-backed branch already records for an
+unrelated reason (the "only one whenever handler at a time" lock).
+
+Two negative pins keep the two decision points from bleeding into each other:
+a body `die` does *not* run that same `whenever`'s own `QUIT` phaser (it goes
+straight to the tap's `quit =>`), while a *source* quit does run it first, and
+a handled one still suppresses the downstream `quit =>`.
+
+New test: `t/supply-whenever-body-die-quits-block.t`, covering the originating
+deep ticket's repro plus the ADR's probe3 B/C and probe6 F/G cases, all
+cross-checked against `raku` first.
+
+Decision B (`supply_get_values` taps and drains instead of replaying a cold
+source) and the ticket's retirement are follow-up work — see the updated
+`todo/deep/cold-supply-whenever-source-replayed-not-tapped.md` and ADR-0031's
+"Outcome" section.

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -71,11 +71,11 @@ pub(in crate::runtime) use state_supplier::{
     supplier_done_call_count, supplier_emit_callbacks, supplier_produce_update_acc,
     supplier_serialize_group, supplier_tap_count, supplier_unique_get_seen,
     supplier_unique_mark_seen, take_supplier_close_callbacks, take_supplier_done_callbacks,
-    take_supplier_quit_callbacks, take_supplier_reduce_results,
-    take_supplier_whenever_quit_callbacks, thread_supplier_done_count, update_classify_state,
-    whenever_done_group_decrement, whenever_done_group_increment, zip_buffer_value,
-    zip_latest_buffer_value, zip_latest_source_done, zip_latest_state_info, zip_source_done,
-    zip_state_info,
+    take_supplier_quit_callbacks, take_supplier_quit_callbacks_via_group,
+    take_supplier_reduce_results, take_supplier_whenever_quit_callbacks,
+    thread_supplier_done_count, update_classify_state, whenever_done_group_decrement,
+    whenever_done_group_increment, zip_buffer_value, zip_latest_buffer_value,
+    zip_latest_source_done, zip_latest_state_info, zip_source_done, zip_state_info,
 };
 pub(in crate::runtime) use state_supplier_merge::{
     get_supplier_merge_state_ids, merge_source_done, register_merge_source, register_merge_state,

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -1564,6 +1564,25 @@ pub(in crate::runtime) fn register_supplier_quit_callback(supplier_id: u64, quit
     }
 }
 
+/// ADR-0031 Decision A: a `whenever` source's own `Supplier."quit"` (an
+/// *external* quit — e.g. the source itself failing, not a `whenever` body
+/// dying) has no way to reach the tap `quit =>` handler registered on the
+/// enclosing supply block's emitter, since Decision A moved that
+/// registration off the source's own `supplier_id` and onto
+/// `emitter_supplier_id`. Reuse the serialize-group link the b1 whenever
+/// branch already records (`set_supplier_serialize_group`, originally for
+/// the "one whenever handler at a time" lock) to find that emitter and
+/// drain its quit callbacks too. A direct `.tap(quit => ...)` on a Supplier
+/// (not reached through a `whenever`) has no serialize group and keeps
+/// working exactly as before, via the direct `supplier_id` drain.
+pub(in crate::runtime) fn take_supplier_quit_callbacks_via_group(supplier_id: u64) -> Vec<Value> {
+    let mut cbs = take_supplier_quit_callbacks(supplier_id);
+    if let Some(group) = supplier_serialize_group(supplier_id) {
+        cbs.extend(take_supplier_quit_callbacks(group));
+    }
+    cbs
+}
+
 pub(in crate::runtime) fn take_supplier_whenever_quit_callbacks(supplier_id: u64) -> Vec<Value> {
     if let Ok(mut map) = supplier_subscriptions_map().lock() {
         if let Some(subs) = map.get_mut(&supplier_id) {

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -539,7 +539,15 @@ impl Interpreter {
                                 }
                             }
                         } else {
-                            for quit_cb in take_supplier_quit_callbacks(supplier_id) {
+                            // ADR-0031: the tap's `quit =>` handler for a
+                            // whenever-subscribed source lives on the
+                            // enclosing supply block's emitter, not on this
+                            // source's own `supplier_id` — reach it via the
+                            // serialize-group link the b1 whenever branch
+                            // records. A direct `.tap(quit => ...)` (no
+                            // `whenever` involved) has no group and is
+                            // covered by the direct drain as before.
+                            for quit_cb in take_supplier_quit_callbacks_via_group(supplier_id) {
                                 self.call_supply_quit_handler(quit_cb, reason.clone())?;
                             }
                             let _ = take_supplier_done_callbacks(supplier_id);
@@ -1077,7 +1085,11 @@ impl Interpreter {
                             }
                         }
                     } else {
-                        for quit_cb in take_supplier_quit_callbacks(sid) {
+                        // ADR-0031: see the matching comment in the immutable
+                        // "quit" arm above — reach a whenever-subscribed
+                        // source's enclosing supply block via the
+                        // serialize-group link.
+                        for quit_cb in take_supplier_quit_callbacks_via_group(sid) {
                             self.call_supply_quit_handler(quit_cb, reason.clone())?;
                         }
                         let _ = take_supplier_done_callbacks(sid);

--- a/src/runtime/native_supply_methods.rs
+++ b/src/runtime/native_supply_methods.rs
@@ -160,7 +160,12 @@ impl Interpreter {
                 .as_deref()
                 .cloned()
                 .unwrap_or_else(|| Value::str(err.message.clone()));
-            for qcb in take_supplier_quit_callbacks(supplier_id) {
+            // ADR-0031: the downstream tap's quit => handler for a
+            // whenever-subscribed source lives on the enclosing supply
+            // block's emitter (Decision A), not on this source's own
+            // `supplier_id` — reach it via the serialize-group link, same
+            // as the `Supplier."quit"` unhandled-QUIT-phaser arm.
+            for qcb in take_supplier_quit_callbacks_via_group(supplier_id) {
                 self.call_supply_quit_handler(qcb, reason.clone())?;
             }
             return Ok(true);

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -366,6 +366,19 @@ impl Interpreter {
                     // are found, to avoid double-delivery for plain `emit` calls.
                     let emitter_supplier_id = next_supplier_id();
                     close_supplier_id = Some(emitter_supplier_id);
+                    // ADR-0031 Decision A: this supply block's own emitter is
+                    // what "quit" means for this block — register the tap's
+                    // `quit =>` handler once, here, instead of per upstream
+                    // source (the old b1/b2 registrations below are removed).
+                    // `call_supply_tap` converts a stamped `whenever` body's
+                    // `die` into `$emitter.quit($reason)` regardless of which
+                    // of the four whenever-source branches below produced it,
+                    // so one registration on `emitter_supplier_id` covers all
+                    // of them — including the chained on-demand branch (b3),
+                    // which previously registered nowhere at all.
+                    if let Some(ref qf) = quit_cb {
+                        register_supplier_quit_callback(emitter_supplier_id, qf.clone());
+                    }
                     // When tapped by a nested `whenever` during a running react,
                     // register a done-signal promise BEFORE running the body so an
                     // async `start { emit; done }` body's later `done` (on a worker
@@ -572,9 +585,11 @@ impl Interpreter {
                                         self.call_sub_value(body_cb.clone(), vec![v], true)?;
                                     }
                                 }
-                                if let Some(ref qf) = quit_cb {
-                                    register_supplier_quit_callback(supplier_id, qf.clone());
-                                }
+                                // ADR-0031: the tap's `quit =>` is registered
+                                // once on `emitter_supplier_id` above, not
+                                // per-source here — this supplier_id is the
+                                // whenever's own QUIT phaser home (below), a
+                                // different concern.
                                 // Register the whenever's own LAST phaser
                                 // callbacks (arr[2]) as done callbacks on the
                                 // inner supplier, BEFORE the group marker, so
@@ -676,12 +691,9 @@ impl Interpreter {
                                         ]));
                                     }
                                 }
-                                if let Some(ref qf) = quit_cb {
-                                    register_supplier_quit_callback(
-                                        emitter_supplier_id,
-                                        qf.clone(),
-                                    );
-                                }
+                                // ADR-0031: `quit =>` is already registered
+                                // once on `emitter_supplier_id` above; no
+                                // per-branch registration needed here.
                                 // Point the outer Tap at the OS listener so
                                 // `$tap.close` stops listening (Raku closes the
                                 // upstream source when the downstream tap closes).

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -593,10 +593,28 @@ impl Interpreter {
             let last_cb = last_callbacks.first().cloned();
             let quit_cb = quit_callbacks.first().cloned();
             let marker = group_marker;
+            // ADR-0031 Decision A #3: run the body through `call_supply_tap`
+            // (not the raw `call_sub_value`) so a `die` in this nested
+            // `whenever <Promise>` body converts to `$emitter.quit($reason)`
+            // exactly like every other whenever-source shape — `callback` is
+            // already stamped with `own_emitter` above. When the conversion
+            // fires, the enclosing supply is now terminated, so this
+            // whenever's own LAST phaser must NOT also run — check that
+            // explicitly rather than trusting `ran.is_ok()`, since a
+            // converted die returns `Ok` too (the conversion absorbs it).
+            let emitter_supplier_id = own_emitter.as_ref().and_then(Self::emitter_supplier_id_of);
             shared.on_resolve(Box::new(move |status, result, _output, _stderr| {
                 if status == "Kept" {
-                    let ran = thread_interp.call_sub_value(callback, vec![result], true);
+                    let ran = thread_interp.call_supply_tap(callback, vec![result], true);
+                    let quit_fired = emitter_supplier_id
+                        .map(|sid| {
+                            crate::runtime::native_methods::supplier_snapshot(sid)
+                                .2
+                                .is_some()
+                        })
+                        .unwrap_or(false);
                     if ran.is_ok()
+                        && !quit_fired
                         && let Some(last_cb) = last_cb
                     {
                         let _ = thread_interp.call_sub_value(last_cb, Vec::new(), true);

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -89,7 +89,50 @@ impl Interpreter {
                 self.call_method_with_values(e, "done", vec![])?;
                 Ok(Value::NIL)
             }
+            // ADR-0031 Decision A: the dual of the `done` absorption above. A
+            // `die` (or any other non-control error) raised in a *stamped*
+            // `whenever` body belongs to the enclosing `supply` block, not to
+            // whichever upstream source happened to dispatch this callback —
+            // convert it to `$emitter.quit($reason)` via the canonical
+            // `Supplier."quit"` so the block's own quit-handling protocol
+            // (`QuitOutcome`, downstream `quit =>`) runs exactly once, on the
+            // right object. The control-signal exclusion list is copied
+            // verbatim from the emit-dispatch fallback this replaces
+            // (`native_supplier_methods.rs`) so `next`/`last`/`return`/`done`
+            // keep unwinding as control flow instead of tearing the supply
+            // down. When the stamped emitter carries no `supplier_id` (the
+            // replay path's `run_on_demand_body(cb, None)` shape) there is
+            // nothing to quit — fall through and return the error as-is.
+            (Err(err), true, Some(e))
+                if !(err.is_return()
+                    || err.return_value.is_some()
+                    || err.is_react_done()
+                    || err.is_last()
+                    || err.is_supply_body_done()
+                    || err.is_next()
+                    || err.is_redo())
+                    && Self::emitter_supplier_id_of(&e).is_some() =>
+            {
+                let reason = err
+                    .exception
+                    .as_deref()
+                    .cloned()
+                    .unwrap_or_else(|| Value::str(err.message));
+                self.call_method_with_values(e, "quit", vec![reason])?;
+                Ok(Value::NIL)
+            }
             (res, ..) => res,
+        }
+    }
+
+    /// `Some(supplier_id)` when `emitter` is a `Supplier` instance carrying a
+    /// `supplier_id` attribute (i.e. it stands for a live `supply` block's
+    /// emitter, as opposed to the id-less emitter `run_on_demand_body` mints
+    /// for the replay path, which has nothing registered against it to quit).
+    pub(crate) fn emitter_supplier_id_of(emitter: &Value) -> Option<u64> {
+        match emitter.view() {
+            ValueView::Instance { attributes, .. } => supplier_id_from_attrs(&attributes.as_map()),
+            _ => None,
         }
     }
 

--- a/t/supply-whenever-body-die-quits-block.t
+++ b/t/supply-whenever-body-die-quits-block.t
@@ -1,0 +1,127 @@
+use Test;
+
+plan 10;
+
+# ADR-0031: a `whenever` body's own `die` belongs to the enclosing `supply`
+# block's own emitter, not to whichever upstream source happened to dispatch
+# the callback. `call_supply_tap` converts a stamped whenever body's
+# non-control `Err` into `$emitter.quit($reason)` so every whenever-source
+# shape (supplier-backed, channel-backed, chained on-demand, and a nested
+# `whenever <Promise>`) tears the block down the same way, and a source's own
+# quit still runs that whenever's QUIT phaser first (unaffected).
+
+# The deep ticket's own repro (todo/deep/cold-supply-whenever-source-replayed-not-tapped.md).
+{
+    sub timeout($source, $timeout) {
+        supply {
+            whenever $source -> $value {
+                state $values++;
+                emit $value;
+                my $last-values = $values;
+                whenever Promise.in($timeout) {
+                    if $last-values == $values { die "Timed out" }
+                }
+            }
+        }
+    }
+
+    my $test-source = supply {
+        for 0.05, 0.10, 0.25 { whenever Promise.in($_) { emit 'badger' } }
+    }
+    my $timed-out = timeout($test-source, 0.10);
+    my @received;
+    my $died = False;
+    $timed-out.tap: { @received.push($_) }, quit => { $died = True }
+    sleep 0.5;
+    is @received, ['badger', 'badger'],
+        "the deep ticket repro delivers only the values before the timeout";
+    ok $died, "the deep ticket repro quits the tap";
+}
+
+# probe3 case C: die in a whenever body whose source is a cold on-demand supply
+# (the b3 "chained on-demand source" branch, which previously registered the
+# tap's quit => nowhere at all).
+{
+    my $cold = supply { emit 1; emit 2; emit 3; }
+    my $died = False;
+    my @received;
+    my $src = supply {
+        whenever $cold -> $v {
+            @received.push($v);
+            die "boom" if $v == 2;
+        }
+    }
+    $src.tap: {;}, quit => { $died = True }
+    is @received, [1, 2], "a body die stops a chained on-demand source after the dying value";
+    ok $died, "a body die on a chained on-demand source quits the tap";
+}
+
+# probe3 case B: die in a nested `whenever <Promise>` body — registered from
+# inside another whenever's body, after the enclosing supply block's own
+# synchronous run is over.
+{
+    my $died = False;
+    my $src = supply {
+        whenever Promise.in(0.5) { emit 'x' }
+        whenever Promise.in(0.05) {
+            whenever Promise.in(0.05) {
+                die "nested boom";
+            }
+        }
+    }
+    $src.tap: {;}, quit => { $died = True }
+    sleep 0.3;
+    ok $died, "a die in a nested whenever <Promise> body quits the enclosing block";
+}
+
+# probe6 case F (negative pin): a body die does NOT run that same whenever's
+# own QUIT phaser — it goes straight to the tap's `quit =>` handler.
+{
+    my $sup = Supplier.new;
+    my $quit-phaser-ran = False;
+    my $died = False;
+    my $src = supply {
+        whenever $sup.Supply -> $v {
+            die "boom";
+            QUIT { $quit-phaser-ran = True; }
+        }
+    }
+    $src.tap: {;}, quit => { $died = True }
+    $sup.emit(1);
+    sleep 0.1;
+    nok $quit-phaser-ran, "a body die does not run the whenever's own QUIT phaser";
+    ok $died, "a body die still reaches the tap's quit =>";
+}
+
+# probe6 case G (negative pin): a *source* quit does run the whenever's own
+# QUIT phaser first; when unhandled it still reaches the tap's quit =>, and
+# when handled it suppresses the downstream quit — proving the new
+# body-die-to-quit conversion did not also reroute genuine source quits.
+{
+    my $sup = Supplier.new;
+    my $quit-phaser-ran = False;
+    my $died = False;
+    my $src = supply {
+        whenever $sup.Supply -> $v {
+            QUIT { $quit-phaser-ran = True; }
+        }
+    }
+    $src.tap: {;}, quit => { $died = True }
+    $sup.quit("source boom");
+    sleep 0.1;
+    ok $quit-phaser-ran, "a source quit runs the whenever's own QUIT phaser";
+    ok $died, "an unhandled source-quit QUIT phaser still reaches the tap's quit =>";
+}
+{
+    my $sup = Supplier.new;
+    my $died = False;
+    my $src = supply {
+        whenever $sup.Supply -> $v {
+            QUIT { default { } }
+        }
+    }
+    $src.tap: {;}, quit => { $died = True }
+    $sup.quit("source boom");
+    sleep 0.1;
+    nok $died, "a handled source-quit QUIT phaser suppresses the tap's quit =>";
+}

--- a/todo/deep/cold-supply-whenever-source-replayed-not-tapped.md
+++ b/todo/deep/cold-supply-whenever-source-replayed-not-tapped.md
@@ -1,99 +1,80 @@
-# A cold `supply` used as a `whenever` source: the surviving gaps are quit propagation, plus `supply_get_values`'s replay
+# `supply_get_values` still replays a cold `whenever` source instead of tapping it
 
 Found 2026-07-25 in Test::Scheduler (`TODO_dist` T-037). Narrowed 2026-07-25
 after the *nested* half of it was fixed (pin `t/supply-nested-whenever-promise.t`).
-**Re-measured 2026-08-19 against `530ccf7dd`: half of the original analysis has
-evaporated, and the surviving half is a different bug than the title suggested.**
-The design that replaces this file's original root-cause section is
-[ADR-0031](../../docs/adr/0031-supply-quit-ownership-and-cold-source-tapping.md);
-read that before starting work. This file is kept only as the open-finding
-marker and the measurement log.
+**Re-measured 2026-08-19 against `530ccf7dd`: half of the original analysis had
+evaporated, and the surviving half was a different bug than the title
+suggested.** The design that replaced this file's original root-cause section
+is [ADR-0031](../../docs/adr/0031-supply-quit-ownership-and-cold-source-tapping.md).
 
-## Repro
+**Update 2026-08-19: Defect A (quit ownership) is fixed — ADR-0031 Slice 1
+shipped.** The ticket's own repro (below, previously mis-delivering a third
+`'badger'` and never quitting) now matches `raku` exactly (`["badger",
+"badger"]` / `died=True`), pinned by `t/supply-whenever-body-die-quits-block.t`.
+That fix also uncovered and closed a second gap in the same area: a
+`Supplier`'s own `.quit()` (a genuine *source* quit, not a whenever body die)
+stopped reaching a tap's `quit =>` handler once the per-source registration
+that used to carry it was removed — see the ADR's "Outcome" section for the
+`take_supplier_quit_callbacks_via_group` fix and its own pins
+(`t/whenever-last-phaser-die-converts-to-quit.t`,
+`t/promise-supply-nested-quit-breaks.t`).
+
+**What remains open, and what this file now tracks, is Defect B only:**
+`supply_get_values` (ADR-0031 Decision B, Slice 2) still replays a cold
+on-demand source synchronously instead of tapping it, so it silently drops a
+live inner subscription. Read ADR-0031's "Mechanism" section (Slice 2) before
+starting; nothing about that plan changed during Slice 1.
+
+## Repro (Defect B — probe5 case E from the ADR)
 
 ```raku
-sub timeout($source, $timeout) {
-    supply {
-        whenever $source -> $value {
-            state $values++;
-            emit $value;
-            my $last-values = $values;
-            whenever Promise.in($timeout) {
-                if $last-values == $values { die "Timed out" }
-            }
-        }
-    }
-}
-
-my $test-source = supply {
-    for 0.05, 0.10, 0.25 { whenever Promise.in($_) { emit 'badger' } }
-}
-my $timed-out = timeout($test-source, 0.10);
-my @received;
-my $died = False;
-$timed-out.tap: { @received.push($_) }, quit => { $died = True }
-sleep 0.5;
-say @received.raku;   # raku: ["badger", "badger"]   mutsu: ["badger", "badger", "badger"]
-say "died=$died";     # raku: True                   mutsu: False
+my $supE = Supplier.new;
+my $srcE = supply { whenever $supE.Supply -> $v { emit $v } }
+my $outE = supply { whenever $srcE   -> $v { emit $v } }
+start { sleep 0.05; $supE.emit('e1'); $supE.emit('e2'); $supE.done }
+say $outE.list;     # raku: (e1 e2)    mutsu: ()
 ```
 
-No virtual scheduler needed — this is plain real time. (Test::Scheduler is just
-the dist that surfaced it.)
+A related symptom on the same family's sibling path: `await` on a supply whose
+`whenever` source is a cold on-demand supply returns `Nil` where raku returns
+the last emitted value — `supply_promise_on_demand` still finishes through
+`replay_static_whenever_promise` in that shape.
 
-## What changed since the original filing
+## Root cause (detailed in ADR-0031 Decision B)
 
-- **The marker leak is gone.** The originally-recorded symptom ("six 4-element
-  marker arrays" instead of values) does not reproduce. `.list` on the same
-  shape also returns `("badger", "badger")`, matching raku. The value half was
-  fixed by `normalize_promise_whenever_markers` plus the chained-real-tap branch
-  at `src/runtime/native_supply_mut_methods.rs:739`.
-- **What is left in this repro is quit propagation**, not value delivery: the
-  `die "Timed out"` never reaches the tap's `quit =>` handler, so the supply is
-  never torn down and a third `'badger'` arrives.
-
-## Surviving root causes (both detailed in ADR-0031)
-
-1. **Quit ownership is attached to the wrong object.** The tap's `quit =>`
-   handler is registered per *upstream source* (b1 at
-   `native_supply_mut_methods.rs:575`, b2 at `:679`), not once on the supply
-   block's own emitter — and the chained on-demand branch (b3, `:739`) registers
-   it nowhere at all. Separately, `run_whenever_with_value`'s `ValueView::Promise`
-   arm (`src/runtime/subtest.rs:596-611`) discards the body's `Result`, so a
-   `die` in a nested `whenever <Promise>` body vanishes. Minimal probes:
-   `tmp/probe3.raku` cases B and C in the ADR (both `died=False` in mutsu,
-   `died=True` in raku).
-2. **`supply_get_values` still replays a cold source instead of tapping it**
-   (`src/runtime/supply_promise.rs:239`, with `replay_cold_whenever_capture`
-   `:676` and `replay_static_whenever_promise` `:789`). It drops any live inner
-   subscription (`if is_live { continue; }`, `:328-330`), so
-   `supply { whenever <cold supply whose own whenever is on a live Supplier> }`
-   `.list`s to `()` where raku gives the values. This affects only the
-   `supply_get_values` family (~20 combinator/`.list`/`.wait` call sites); the
-   `.tap`/`.act` and react/`.Promise` paths already chain real taps.
+`supply_get_values` (`src/runtime/supply_promise.rs:239`, with
+`replay_cold_whenever_capture` `:676` and `replay_static_whenever_promise`
+`:789`) still replays a cold source synchronously instead of tapping it. It
+drops any live inner subscription (`if is_live { continue; }`, `:328-330`), so
+`supply { whenever <cold supply whose own whenever is on a live Supplier> }`
+`.list`s to `()` where raku gives the values. This affects only the
+`supply_get_values` family (~20 combinator/`.list`/`.wait` call sites); the
+`.tap`/`.act` and react/`.Promise` paths already chain real taps (and, as of
+Slice 1, correctly quit too).
 
 ## Affected files
 
-- `src/runtime/supply_promise.rs` — `call_supply_tap`, `supply_get_values`,
+- `src/runtime/supply_promise.rs` — `supply_get_values`,
   `replay_cold_whenever_capture`, `replay_static_whenever_promise`.
-- `src/runtime/native_supply_mut_methods.rs` — the `"tap" | "act"` arm's four
-  whenever-source branches and their quit registrations.
-- `src/runtime/subtest.rs` — `run_whenever_with_value` (marker construction and
-  the Promise arm).
-- `src/runtime/native_supplier_methods.rs` — the emit-dispatch error routing
-  (`:107-151`) and the canonical `Supplier."quit"` (`:488`).
+- `src/runtime/methods_call_helpers.rs` — `supply_list_values`, the `.list`
+  feeder ADR-0031 names as Slice 2 step 1's pin.
+- `src/runtime/native_supply_dispatch.rs` — the `.sort` / `.squish` / `.head`
+  / `.flat` / `.produce` / `.batch` / `.rotor` / `.rotate` / `.comb` / `.snip`
+  / `.minmax` / `.zip` / `.start` / `.Channel` combinators (Slice 2 step 2).
+- `src/runtime/supply_transform.rs` — `.throttle` / `.stable` (Slice 2 step 2).
 
 ## Why it is large
 
-Quit ownership touches every whenever-source branch plus the emit-dispatch
-error path, and it must not disturb the `QUIT`-phaser protocol
-(`take_supplier_whenever_quit_callbacks` / `QuitOutcome`). Replacing the replay
-family changes ~20 call sites from a synchronous pull to a bounded drain, with a
-real hang risk when the producer runs on the calling thread. ADR-0031 slices
-both.
+Replacing the replay family changes ~20 call sites from a synchronous pull to
+a bounded drain, with a real hang risk when the producer runs on the calling
+thread (the deadlock class ADR-0028 documents) — ADR-0031's "Guarding against
+a new hang" subsection is the mitigation plan, and Slice 2 step 1 must probe
+that shape explicitly before the combinators follow.
 
 ## Impact
 
-`Test::Scheduler` (`TODO_dist` T-037), the last known blocker for that dist:
-`t/synopsis.rakutest` and `t/virtualized-time.rakutest` both depend on a
-`whenever` body's `die` quitting the enclosing supply. Cro's error paths and
-body coercions ride on the same two mechanisms.
+`Test::Scheduler` (`TODO_dist` T-037): `t/synopsis.rakutest` and
+`t/virtualized-time.rakutest` may still exercise this shape via `.list`/`.wait`
+on a supply built from a cold on-demand `whenever` source; re-check their
+counts once Slice 2 lands. Cro's body coercions ride on the same
+`supply_get_values` family.


### PR DESCRIPTION
## Summary

Implements ADR-0031 Decision A (Slice 1) — `docs/adr/0031-supply-quit-ownership-and-cold-source-tapping.md`.

- The enclosing `supply` block's own emitter supplier now owns `quit`, matching how it already owns `emit`/`done`/CLOSE. `call_supply_tap` converts a *stamped* whenever callback's non-control `Err` into `$emitter.quit($reason)` via the canonical `Supplier."quit"`, and the tap's `quit =>` handler is registered once on the emitter instead of per upstream source.
- This closes the two previously-uncovered whenever-source shapes: a `whenever` chained onto another on-demand supply, and a nested `whenever <Promise>` registered from inside another whenever's body — both previously let a body `die` vanish silently.
- A plain, unstamped `.tap({ die ... })` and a genuine *source*-triggered QUIT phaser are untouched (pinned as negative cases).
- **Regression found and fixed during implementation:** removing the old per-source `quit =>` registration broke two other mechanisms that used to find it there (a `Supplier`'s own `.quit()` method, and the existing LAST-phaser-die-to-quit conversion). Fixed with a new `take_supplier_quit_callbacks_via_group` helper that also checks the serialize-group link the supplier-backed branch already records for an unrelated reason (the "one whenever handler at a time" lock).

Slice 2 (`supply_get_values` taps-and-drains instead of replaying) and the ticket's retirement are follow-up work — tracked in the updated `todo/deep/cold-supply-whenever-source-replayed-not-tapped.md` and the ADR's new "Outcome" section.

## Test plan

- [x] New test `t/supply-whenever-body-die-quits-block.t` — the deep ticket's repro plus ADR-0031's probe3 B/C and probe6 F/G cases, all cross-checked against `raku` first, all green
- [x] Full `t/supply-*.t` / `t/whenever-*.t` / `t/react-*.t` / `t/promise-supply-*.t` etc. (113 files, 522 tests) — all green
- [x] All whitelisted `roast/S17-*` files on a release build (S17-supply 58 files/902 tests, plus channel/promise/procasync/scheduler/lowlevel) — all green
- [x] `cargo test` (852 unit tests) — all green
- [x] `cargo fmt` / `cargo clippy -- -D warnings` — clean
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)