### PR TITLE
fix(ci): pin canonical apt mirror to avoid azure.archive.ubuntu.com hangs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -59,6 +59,16 @@ jobs:
         with:
           shared-key: "ci-bench"
 
+      # See .github/workflows/ci.yml's "Use canonical apt mirror" step for why:
+      # the default runner apt-mirrors.txt (azure.archive.ubuntu.com first) has
+      # been observed hanging indefinitely.
+      - name: Use canonical apt mirror
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            echo 'http://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list 2>/dev/null || true
+
       - name: Install rakudo (for the ratio baseline)
         # Best-effort: if the package is unavailable the script records NA
         # ratios and the absolute mutsu numbers are still appended.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,19 @@ jobs:
           # from main without every PR writing its own entry and evicting others.
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # The default GitHub-hosted runner apt mirror config (mirror+file
+      # against /etc/apt/apt-mirrors.txt, azure.archive.ubuntu.com first) has
+      # been observed hanging indefinitely on noble-updates/backports/security
+      # until the job's own timeout cancels it (2026-08-19, PRs #6684 #6691) --
+      # with zero relation to the PR's diff. Pin the canonical archive instead
+      # of trusting the mirror list.
+      - name: Use canonical apt mirror
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            echo 'http://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list 2>/dev/null || true
+
       - name: Install prove + mold
         run: sudo apt-get update && sudo apt-get install -y perl mold
 
@@ -545,6 +558,19 @@ jobs:
           shared-key: "ci-linux"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # The default GitHub-hosted runner apt mirror config (mirror+file
+      # against /etc/apt/apt-mirrors.txt, azure.archive.ubuntu.com first) has
+      # been observed hanging indefinitely on noble-updates/backports/security
+      # until the job's own timeout cancels it (2026-08-19, PRs #6684 #6691) --
+      # with zero relation to the PR's diff. Pin the canonical archive instead
+      # of trusting the mirror list.
+      - name: Use canonical apt mirror
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            echo 'http://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list 2>/dev/null || true
+
       - name: Install prove + mold
         run: sudo apt-get update && sudo apt-get install -y perl mold
 
@@ -683,6 +709,19 @@ jobs:
         with:
           shared-key: "ci-linux"
           save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # The default GitHub-hosted runner apt mirror config (mirror+file
+      # against /etc/apt/apt-mirrors.txt, azure.archive.ubuntu.com first) has
+      # been observed hanging indefinitely on noble-updates/backports/security
+      # until the job's own timeout cancels it (2026-08-19, PRs #6684 #6691) --
+      # with zero relation to the PR's diff. Pin the canonical archive instead
+      # of trusting the mirror list.
+      - name: Use canonical apt mirror
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            echo 'http://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list 2>/dev/null || true
 
       - name: Install prove + mold
         run: sudo apt-get update && sudo apt-get install -y perl mold

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,6 +489,17 @@ jobs:
       - name: Run WASM concurrency tests
         run: node site/concurrency.test.mjs
 
+      # `playwright install --with-deps` shells out to apt-get internally, so
+      # it hits the same azure.archive.ubuntu.com mirror hang as the native
+      # jobs' explicit apt-get steps (see the "Use canonical apt mirror" step
+      # there) even though this job has no apt-get line of its own.
+      - name: Use canonical apt mirror
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            echo 'http://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list 2>/dev/null || true
+
       - name: Install Playwright
         run: |
           npm install playwright

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,17 @@ jobs:
         with:
           shared-key: ${{ matrix.target }}
 
+      # See .github/workflows/ci.yml's "Use canonical apt mirror" step for why:
+      # the default runner apt-mirrors.txt (azure.archive.ubuntu.com first) has
+      # been observed hanging indefinitely.
+      - name: Use canonical apt mirror
+        if: runner.os == 'Linux'
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            echo 'http://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list 2>/dev/null || true
+
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libpcre2-dev
@@ -126,6 +137,16 @@ jobs:
 
       # libpcre2 for building mutsu; libssl for the OpenSSL / IO::Socket::SSL
       # batteries' NativeCall at runtime.
+      # See .github/workflows/ci.yml's "Use canonical apt mirror" step for why:
+      # the default runner apt-mirrors.txt (azure.archive.ubuntu.com first) has
+      # been observed hanging indefinitely.
+      - name: Use canonical apt mirror
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            echo 'http://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list 2>/dev/null || true
+
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcre2-dev libssl-dev
 


### PR DESCRIPTION
## Summary
- The default GitHub-hosted runner apt mirror config (`/etc/apt/apt-mirrors.txt`, `azure.archive.ubuntu.com` first) has been observed hanging indefinitely on `noble-updates`/`backports`/`security` until the job's own timeout cancels it — seen twice today (2026-08-19) on PR #6684 and PR #6691, in both cases completely unrelated to the PR's actual diff (the job dies mid `apt-get update`, before any build/test output).
- Added a "Use canonical apt mirror" step before every `apt-get update` in `ci.yml` (test/gc-stress/jit-stress), `bench.yml`, and `release.yml`, pointing apt at `archive.ubuntu.com` directly instead of trusting the mirror list.

## Test plan
- [x] YAML syntax validated for all three edited workflow files
- [x] This PR's own CI run exercises the new step in `ci.yml` directly (test/gc-stress/jit-stress all run `apt-get update` early)

🤖 Generated with [Claude Code](https://claude.com/claude-code)