### PR TITLE
feat(parser,compiler): defer WhateverCode closure construction to the compiler (ADR-0033 Phase 1)

### DIFF
--- a/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
+++ b/docs/adr/0033-whatever-priming-leaf-and-derived-scope.md
@@ -1,6 +1,6 @@
 # ADR-0033: Whatever-priming is a leaf property plus a derived scope — defer `WhateverCode` construction out of the parser
 
-- **Status**: Proposed (2026-08-19). Design complete; implementation not started.
+- **Status**: Phase 1 shipped (2026-08-19). Phases 2-4 not started — see "Outcome" below.
 - **Scope**: Owns the `WhateverCode` item of
   [`todo/deep/rakuast-remaining.md`](../../todo/deep/rakuast-remaining.md) — both its
   read-direction half ("`* + 1` has no `.AST`") and its lowering half ("`EVAL` of a
@@ -388,6 +388,80 @@ family as `unless` → `if !`.
   `src/whatever_curry.rs` itself will be roughly the size of today's `whatever_wrap.rs` +
   `whatever_replace.rs` (~730 lines), so it should be created as a directory module
   (`src/whatever_curry/{mod,build,replace,plant}.rs`) from the start.
+
+## Outcome
+
+**Phase 1 shipped (2026-08-19).** `Expr::WhateverArg` and `Expr::WhateverCurry` were added
+to the AST; `src/whatever_curry/` (`mod.rs`, `build.rs`, `replace.rs`) now owns closure
+construction (`build_closure`, formerly `wrap_whatevercode`), placeholder replacement, and
+arity counting, invoked from exactly one place — the new `Expr::WhateverCurry` arm in
+`Compiler::compile_expr`. Every parser-side `wrap_whatevercode(&e)` call site now
+constructs `Expr::WhateverCurry(Box::new(e))` instead; `should_wrap_whatevercode` /
+`contains_whatever` (the scope decision) are byte-for-byte unchanged, so — as designed —
+this is a pure deferral with no behaviour change. `Expr::WhateverArg` is defined but not
+yet produced anywhere (that is Phase 2's leaf-splitting work); it compiles identically to
+`Expr::Whatever` so the arm is reachable-but-inert until then.
+
+`whatever_curry/{mod,build,replace}.rs` is a directory module as the Risks section
+anticipated; `plant.rs` is deferred to Phase 4, which is what actually needs a
+single-authority scope function (Phase 1 keeps the scope decision distributed across the
+existing ~50 call sites on purpose, per the "behaviour-preserving by construction"
+mandate).
+
+The mechanical site-by-site rewrite surfaced substantially more than the ~50 originally
+counted `wrap_whatevercode` call sites: every other parser/compiler/runtime pass that
+pattern-matched the *eagerly built* `Lambda { is_whatever_code: true, .. }` /
+`AnonSubParams { is_whatever_code: true, .. }` shape to detect "this subtree is already a
+WhateverCode" needed an `Expr::WhateverCurry` arm added too, since that shape no longer
+exists at parse time. Two of these were genuine correctness regressions caught before
+merge (both fixed in this same PR, not deferred):
+
+- `crate::ast::collect_ph_expr_shallow` (the placeholder-order collector that decides a
+  block's own implicit signature) didn't hoist a `$^name` placeholder out of a nested
+  WhateverCurry into the enclosing block's signature, undercounting its arity by one.
+  Reproduced via the YAMLish battery's `flatten-tags` helper
+  (`{ |$^value.kv.map($^namespace ~ * => *) }`), which silently mis-bound values before the
+  fix (see `t/placeholder-in-nested-whatevercode.t`, already pinning a simpler shape of the
+  same bug).
+- The expression-context `:=` bind fast path (`parser/expr/precedence/logic.rs`) and its
+  compiler-side `X::Bind::Slice` throw (`compiler/expr_closure.rs`) both matched only the
+  built `Lambda`/`AnonSubParams` shape to detect a Whatever-index bind (`@a[*-1] := 42`),
+  so it silently took the *valid*-bind fast path instead of throwing. Pinned by the
+  pre-existing `t/bind-to-whatever-index.t` / `t/indexed-bind-in-expression.t`.
+
+Roughly a dozen more sites (`outer_redecl.rs`, `sink_warn.rs`, `whenever_scope.rs`,
+`stmt/modifier.rs`, `stmt/class/attr_checks.rs`, `stmt/sub/param_validate.rs`,
+`primary/container/paren.rs`, `runtime/{undeclared_routines,system_eval_names,phasers,
+registration,registration_class_attr}.rs`, `runtime/types/type_matching.rs`'s `subset
+... where <WhateverCode>` predicate-callable check, and `compiler/{expr_call,
+helpers_call_args}.rs`'s `cas($var, * + delta)` atomic-add fast path and closure-escape
+detection) got the same treatment as a precaution — each recurses into the un-expanded
+`WhateverCurry` body the same way it already recursed into a real closure body, so a
+diagnostic, validation, or fast-path check that used to see the built closure still sees
+the (structurally equivalent, pre-substitution) un-curried one. None of these changed
+observable behaviour relative to `main`; they close latent gaps the deferral would
+otherwise have opened. A few sites were deliberately left alone: `stmt/assign/
+compound_expr.rs` and `precedence/{assign,comparison}.rs`'s hand-rolled `* op= value` /
+`* ~~ Type` / `Type ~~ *` autoprime constructions never called `wrap_whatevercode` (they
+build a closure directly), so leaving them eager is consistent with "keep the existing
+scope sites" and does not block Phase 2 (that already-eager path is no worse than
+`main`'s); `runtime/registration_class_augment.rs`'s `does *~~Role`-style helper is the
+same.
+
+Validated locally: `cargo test --workspace` (all binaries, including `gc_stress` and
+`lazy_match_no_eager_materialization`) green; the full `t/` TAP suite (3255 files) green
+except the pre-existing, already-ticketed `t/autoviv-index-guard.t` local hang
+(`todo/tickets/autoviv-index-guard-hangs-locally.md`, confirmed unrelated); `t/*whatever*.t`
+(35 files), `roast/S02-types/{whatever,hyperwhatever}.t`, `roast/S03-operators/
+composition.t`, and `roast/S12-subset/{multi-dispatch,subtypes,type-subset}.t` all green.
+
+**Phases 2-4 are not implemented by this PR** — deliberately scoped out per the ADR's own
+phasing ("Each phase is independently shippable and CI-gated"): Phase 1's mandate is a
+zero-behaviour-change deferral, verified above; Phase 4 (the thunk-barrier correctness fix
+that actually changes `&&`/`||`/`//`/ternary priming results) is a separate, higher-risk
+change that deserves its own PR and its own `t/whatever-thunky-operators.t`. Phases 2/3
+(RakuAST read/write for `* + 1`) remain open items in
+[`todo/deep/rakuast-remaining.md`](../../todo/deep/rakuast-remaining.md).
 
 ## References
 

--- a/news/2026-08/adr0033-whatever-priming-phase1-deferral.md
+++ b/news/2026-08/adr0033-whatever-priming-phase1-deferral.md
@@ -1,0 +1,43 @@
+# ADR-0033 Phase 1: WhateverCode closure construction moved out of the parser
+
+mutsu used to build the `WhateverCode` closure for a Whatever-curried expression (`* + 1`,
+`.grep(* > 3)`, `@a[* - 1]`) eagerly, in the parser, at roughly fifty call sites spread
+across thirteen files. This destroyed the pre-curry expression before any later consumer
+— the RakuAST converter, `.DEPARSE`, error messages — could see it, and left no single
+place owning the "which expression boundary does the `*` get captured within" rule.
+
+Per [ADR-0033](../../docs/adr/0033-whatever-priming-leaf-and-derived-scope.md), Phase 1
+defers closure construction to compile time without changing any observable behaviour.
+Two new AST nodes were added: `Expr::WhateverArg` (a `*` that participates in priming —
+not yet produced anywhere; that is Phase 2's leaf-splitting work) and `Expr::WhateverCurry`
+(a marker wrapping a maximal priming scope's un-curried body). Every parser site that used
+to call `wrap_whatevercode(&e)` to build the closure on the spot now constructs
+`Expr::WhateverCurry(Box::new(e))` instead; the scope-decision predicates
+(`should_wrap_whatevercode`, `contains_whatever`) are unchanged. The actual closure
+construction — `build_closure` (formerly `wrap_whatevercode`), placeholder substitution,
+and arity counting — moved to a new parser-independent module, `src/whatever_curry/`, and
+is now invoked from exactly one place: a new `Expr::WhateverCurry` arm in
+`Compiler::compile_expr`. The emitted bytecode is unchanged.
+
+The mechanical rewrite surfaced two genuine, pre-existing correctness gaps in code that
+pattern-matched the *eagerly built* closure shape to detect "this subtree is already a
+WhateverCode" — both fixed in the same PR:
+
+- `crate::ast::collect_ph_expr_shallow` (the placeholder-order collector) didn't hoist a
+  `$^name` placeholder out of a nested WhateverCurry into the enclosing block's implicit
+  signature, undercounting its arity by one — reproduced via the YAMLish battery's
+  `flatten-tags` helper, which silently mis-bound values.
+- The expression-context `:=` bind fast path and its `X::Bind::Slice` throw both matched
+  only the built closure shape to detect a Whatever-index bind (`@a[*-1] := 42`), so they
+  silently fell through to the *valid*-bind fast path instead of throwing.
+
+About a dozen other diagnostic/validation/fast-path sites across the parser, compiler, and
+runtime got a defensive `Expr::WhateverCurry` arm too, so they keep seeing (a
+structurally-equivalent, pre-substitution form of) what they used to see.
+
+Validated locally: `cargo test --workspace` green (all binaries), the full `t/` TAP suite
+(3255 files) green apart from the pre-existing, already-ticketed local
+`autoviv-index-guard.t` hang, and the whatever/composition/subset-focused roast files
+green. Phases 2-4 (RakuAST `.AST` support for `* + 1`, and the thunk-barrier fix for
+`(* > 3 && * < 8).arity`/`.grep(* > 3 && * < 8)`) are separate, not-yet-started follow-up
+work — see the ADR's Outcome section.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -381,6 +381,14 @@ pub(crate) enum Expr {
     /// boundaries to prevent incorrect junction flattening.
     Grouped(Box<Expr>),
     Whatever,
+    /// A `*` that participates in Whatever-priming (an "argument" `*`, in
+    /// Rakudo's `WhateverCode::Argument` terminology), as opposed to a bare
+    /// `Expr::Whatever` *value*. Not yet produced by the parser (ADR-0033
+    /// Phase 1 is a behaviour-preserving deferral only); `should_wrap_whatevercode`
+    /// /`contains_whatever` still decide priming the same way they always have.
+    /// Phase 2/4 will start emitting this from the leaf-splitting rule in
+    /// ADR-0033 §1 and give it real RakuAST/compiler semantics.
+    WhateverArg,
     HyperWhatever,
     BareWord(String),
     /// A function call that the parser resolved to a user-declared or imported
@@ -534,6 +542,17 @@ pub(crate) enum Expr {
         /// imaginary unit `i`), so the body binder marks it accordingly.
         param_sigilless: bool,
     },
+    /// Marks a maximal Whatever-priming scope (ADR-0033). Carries the
+    /// un-curried body — `Expr::Whatever`/`Expr::WhateverArg` leaves are still
+    /// in place. This is a marker only: it is not a closure and never reaches
+    /// the VM as itself. The compiler expands it into the same `Lambda` /
+    /// `AnonSubParams { is_whatever_code: true, .. }` that the parser used to
+    /// build eagerly (`whatever_curry::build_closure`), so emitted bytecode is
+    /// unchanged. `whatever_curry::plant` is the single authority for where
+    /// these markers get inserted; in ADR-0033 Phase 1 that authority is still
+    /// distributed across the parser's existing `wrap_whatevercode` call sites
+    /// (now constructing this marker instead of the closure directly).
+    WhateverCurry(Box<Expr>),
     ArrayLiteral(Vec<Expr>),
     /// A pair expression that was parenthesized, e.g. `(:a(3))`.
     /// At runtime this becomes a ValuePair so it is treated as a positional argument.
@@ -2175,7 +2194,11 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
         | Expr::Eager(expr)
         | Expr::Itemize(expr)
         | Expr::Grouped(expr)
-        | Expr::DeitemizeForBind(expr) => collect_ph_expr(expr, out),
+        | Expr::DeitemizeForBind(expr)
+        // ADR-0033: a not-yet-expanded WhateverCurry marker is transparent to
+        // the deep collector, same as every other closure kind it recurses
+        // into unconditionally above.
+        | Expr::WhateverCurry(expr) => collect_ph_expr(expr, out),
         Expr::HyperOp { left, right, .. }
         | Expr::HyperFuncOp { left, right, .. }
         | Expr::MetaOp { left, right, .. } => {
@@ -2519,6 +2542,11 @@ fn collect_ph_expr_shallow(expr: &Expr, out: &mut Vec<String>) {
         // which belong to the nearest enclosing *explicit* block. So descend
         // through it to attribute e.g. `$^namespace` in
         // `{ ... $^namespace ~ * => * }` to the outer block, matching Rakudo.
+        //
+        // ADR-0033 Phase 1: the parser no longer builds this closure eagerly —
+        // at this (pre-compile) stage a curry is still an un-expanded
+        // `WhateverCurry` marker, so descend into its body directly instead.
+        Expr::WhateverCurry(inner) => collect_ph_expr_shallow(inner, out),
         Expr::AnonSubParams {
             body,
             is_whatever_code: true,

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -52,9 +52,25 @@ impl Compiler {
                 let idx = self.code.add_constant(Value::WHATEVER);
                 self.code.emit(OpCode::LoadConst(idx));
             }
+            // Not yet produced by the parser (ADR-0033 Phase 1 defers only the
+            // closure-building step; leaf-splitting into a real `WhateverArg`
+            // producer is Phase 2/4). Compile identically to a bare `Whatever`
+            // so the arm is reachable-but-harmless until then.
+            Expr::WhateverArg => {
+                let idx = self.code.add_constant(Value::WHATEVER);
+                self.code.emit(OpCode::LoadConst(idx));
+            }
             Expr::HyperWhatever => {
                 let idx = self.code.add_constant(Value::HYPER_WHATEVER);
                 self.code.emit(OpCode::LoadConst(idx));
+            }
+            // ADR-0033: expand the marker into the same WhateverCode closure
+            // `wrap_whatevercode` used to build eagerly in the parser, then
+            // compile that closure exactly as before. No new OpCode, no new
+            // runtime path.
+            Expr::WhateverCurry(body) => {
+                let closure = crate::whatever_curry::build_closure(body);
+                self.compile_expr(&closure);
             }
             // A source-preserving literal compiles exactly like its inner value;
             // the recorded source text only matters to the sink-warning pass.

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -762,6 +762,36 @@ impl Compiler {
             && (args.len() == 2 || args.len() == 3)
             && let Some(var_name) = Self::atomic_target_name(&args[0])
         {
+            // ADR-0033 Phase 1: `cas($var, * + delta)` is still an un-expanded
+            // `WhateverCurry` at this point rather than the built `Lambda`
+            // the parser used to produce eagerly — its single placeholder
+            // `Expr::Whatever` leaf plays the role `param` played below,
+            // without needing a name to match against.
+            if args.len() == 2
+                && let Expr::WhateverCurry(body) = &args[1]
+                && let Expr::Binary { left, op, right } = body.as_ref()
+                && *op == TokenKind::Plus
+                && let delta = match (left.as_ref(), right.as_ref()) {
+                    (Expr::Whatever, rhs) => Some(rhs.clone()),
+                    (lhs, Expr::Whatever) => Some(lhs.clone()),
+                    _ => None,
+                }
+                && let Some(delta) = delta
+            {
+                let call_name_idx = self
+                    .code
+                    .add_constant(Value::str_from("__mutsu_atomic_add_var"));
+                self.note_atomic_env_sync_target(&var_name, true);
+                let name_idx = self.code.add_constant(Value::str(var_name.clone()));
+                self.code.emit(OpCode::LoadConst(name_idx));
+                self.compile_expr(&delta);
+                self.code.emit(OpCode::CallFunc {
+                    name_idx: call_name_idx,
+                    arity: 2,
+                    arg_sources_idx: None,
+                });
+                return;
+            }
             if args.len() == 2
                 && let Expr::Lambda { param, body, .. } = &args[1]
                 && let [Stmt::Expr(Expr::Binary { left, op, right })] = body.as_slice()
@@ -1279,6 +1309,26 @@ impl Compiler {
         else if name == "cas" && args.len() == 2 {
             let var_name = Self::atomic_target_name(&args[0]);
             if let Some(vname) = var_name {
+                // ADR-0033 Phase 1: see the sibling fast path above — a
+                // `cas($var, * + delta)` argument is still an un-expanded
+                // `WhateverCurry` here.
+                if let Expr::WhateverCurry(body) = &args[1]
+                    && let Expr::Binary { left, op, right } = body.as_ref()
+                    && *op == TokenKind::Plus
+                    && let delta = match (left.as_ref(), right.as_ref()) {
+                        (Expr::Whatever, rhs) => Some(rhs.clone()),
+                        (lhs, Expr::Whatever) => Some(lhs.clone()),
+                        _ => None,
+                    }
+                    && let Some(delta) = delta
+                {
+                    let atomic_add = Expr::Call {
+                        name: Symbol::intern("__mutsu_atomic_add_var"),
+                        args: vec![Expr::Literal(Value::str(vname.clone())), delta],
+                    };
+                    self.compile_expr(&atomic_add);
+                    return;
+                }
                 if let Expr::Lambda { param, body, .. } = &args[1]
                     && let [Stmt::Expr(Expr::Binary { left, op, right })] = body.as_slice()
                     && *op == TokenKind::Plus

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -551,10 +551,17 @@ impl Compiler {
             Expr::Call { name, .. } if *name == "__mutsu_bind_index_value"
         ) && matches!(
             index,
-            Expr::Lambda {
-                is_whatever_code: true,
-                ..
-            }
+            // ADR-0033 Phase 1: the index is still an un-expanded
+            // `WhateverCurry` marker here (this runs before the compiler's
+            // `Expr::WhateverCurry` arm would expand it) — check that
+            // directly rather than the built closure the parser used to
+            // produce eagerly. (The `Lambda` arm is kept as a
+            // belt-and-suspenders match; only reachable pre-ADR-0033.)
+            Expr::WhateverCurry(_)
+                | Expr::Lambda {
+                    is_whatever_code: true,
+                    ..
+                }
         ) {
             // A Whatever index is always positional, so the sliced container is
             // an Array. `type` and `message` mirror what rakudo's exception

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -142,6 +142,12 @@ impl Compiler {
                 | Expr::AnonSub { .. }
                 | Expr::AnonSubParams { .. }
                 | Expr::Lambda { .. }
+                // ADR-0033: a Whatever-curried argument (`.grep(* > $x)`) is a
+                // closure literal written at the call site exactly like a
+                // hand-written one — it just hasn't been expanded into its
+                // `Lambda`/`AnonSubParams` form yet (that happens when this
+                // argument itself gets compiled).
+                | Expr::WhateverCurry(_)
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod trace;
 pub(crate) mod type_id;
 mod value;
 mod vm;
+pub(crate) mod whatever_curry;
 
 pub use interpreter::Interpreter;
 pub use value::{RuntimeError, RuntimeErrorCode, Value};

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -4,7 +4,6 @@ mod postfix;
 pub(crate) mod precedence;
 mod precedence_meta_ops;
 mod whatever;
-mod whatever_replace;
 mod whatever_wrap;
 
 #[cfg(test)]
@@ -32,18 +31,18 @@ pub(in crate::parser) use postfix::without_pending_prefix;
 pub(in crate::parser) use postfix::{QuotedMethodName, parse_quoted_method_name};
 use precedence::ternary;
 
-// Re-exports for WhateverCode detection (`whatever.rs`).
+// Re-exports for WhateverCode priming-scope detection (`whatever.rs`). These
+// stay `pub(crate)`, not just `pub(in crate::parser)`, because
+// `crate::whatever_curry::build_closure` (the closure construction that moved
+// out of the parser per ADR-0033) also calls them.
 use whatever::fat_arrow_curries;
-pub(in crate::parser) use whatever::should_wrap_whatevercode;
-pub(super) use whatever::{contains_whatever, is_whatever};
-pub(crate) use whatever::{count_whatever, expr_contains_topic, exprs_structurally_eq};
+pub(crate) use whatever::{contains_whatever, is_whatever, should_wrap_whatevercode};
 
-// Re-exports for WhateverCode wrapping (`whatever_wrap.rs`).
-pub(in crate::parser) use whatever_wrap::wrap_whatevercode;
+// Re-exports for WhateverCode-adjacent AST shaping that stays in the parser
+// (`whatever_wrap.rs`): composing `o`/`∘` operands and threading a curried
+// CallOn target through a trailing method-call chain. Both now construct
+// `Expr::WhateverCurry` markers instead of eagerly building closures.
 use whatever_wrap::{try_wrap_whatevercode_call_chain, wrap_composition_operands};
-
-// Re-exports for WhateverCode body construction (`whatever_replace.rs`).
-pub(crate) use whatever_replace::{replace_whatever_numbered, replace_whatever_single};
 
 thread_local! {
     static EXPR_MEMO_TLS: RefCell<HashMap<MemoKey, MemoEntry<Expr>>> = RefCell::new(HashMap::new());
@@ -124,14 +123,14 @@ pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
                     if should_wrap_whatevercode(&target) && !args.iter().any(contains_whatever) =>
                 {
                     Expr::CallOn {
-                        target: Box::new(wrap_whatevercode(&target)),
+                        target: Box::new(Expr::WhateverCurry(target)),
                         args,
                     }
                 }
                 ref e if try_wrap_whatevercode_call_chain(e).is_some() => {
                     try_wrap_whatevercode_call_chain(&expr).unwrap()
                 }
-                other => wrap_whatevercode(&other),
+                other => Expr::WhateverCurry(Box::new(other)),
             };
         }
         Ok((rest, expr))
@@ -183,14 +182,14 @@ pub(in crate::parser) fn expression_no_assign(input: &str) -> PResult<'_, Expr> 
                 if should_wrap_whatevercode(&target) && !args.iter().any(contains_whatever) =>
             {
                 Expr::CallOn {
-                    target: Box::new(wrap_whatevercode(&target)),
+                    target: Box::new(Expr::WhateverCurry(target)),
                     args,
                 }
             }
             ref e if try_wrap_whatevercode_call_chain(e).is_some() => {
                 try_wrap_whatevercode_call_chain(&expr).unwrap()
             }
-            other => wrap_whatevercode(&other),
+            other => Expr::WhateverCurry(Box::new(other)),
         };
     }
     Ok((rest, expr))
@@ -244,14 +243,14 @@ pub(in crate::parser) fn expression_no_word_logical(input: &str) -> PResult<'_, 
                 if should_wrap_whatevercode(&target) && !args.iter().any(contains_whatever) =>
             {
                 Expr::CallOn {
-                    target: Box::new(wrap_whatevercode(&target)),
+                    target: Box::new(Expr::WhateverCurry(target)),
                     args,
                 }
             }
             ref e if try_wrap_whatevercode_call_chain(e).is_some() => {
                 try_wrap_whatevercode_call_chain(&expr).unwrap()
             }
-            other => wrap_whatevercode(&other),
+            other => Expr::WhateverCurry(Box::new(other)),
         };
     }
     Ok((rest, expr))
@@ -299,11 +298,11 @@ pub(in crate::parser) fn expression_no_sequence(input: &str) -> PResult<'_, Expr
                 if should_wrap_whatevercode(&target) && !args.iter().any(contains_whatever) =>
             {
                 Expr::CallOn {
-                    target: Box::new(wrap_whatevercode(&target)),
+                    target: Box::new(Expr::WhateverCurry(target)),
                     args,
                 }
             }
-            other => wrap_whatevercode(&other),
+            other => Expr::WhateverCurry(Box::new(other)),
         };
     }
     Ok((rest, expr))
@@ -324,14 +323,14 @@ fn wrap_finished_expr(expr: Expr) -> Expr {
             if should_wrap_whatevercode(&target) && !args.iter().any(contains_whatever) =>
         {
             Expr::CallOn {
-                target: Box::new(wrap_whatevercode(&target)),
+                target: Box::new(Expr::WhateverCurry(target)),
                 args,
             }
         }
         ref e if try_wrap_whatevercode_call_chain(e).is_some() => {
             try_wrap_whatevercode_call_chain(&expr).unwrap()
         }
-        other => wrap_whatevercode(&other),
+        other => Expr::WhateverCurry(Box::new(other)),
     }
 }
 
@@ -446,11 +445,11 @@ pub(in crate::parser) fn call_arg_expr(input: &str) -> PResult<'_, Expr> {
                 if should_wrap_whatevercode(&target) && !args.iter().any(contains_whatever) =>
             {
                 Expr::CallOn {
-                    target: Box::new(wrap_whatevercode(&target)),
+                    target: Box::new(Expr::WhateverCurry(target)),
                     args,
                 }
             }
-            other => wrap_whatevercode(&other),
+            other => Expr::WhateverCurry(Box::new(other)),
         };
     }
     Ok((rest, expr))
@@ -469,7 +468,7 @@ fn fat_arrow_result(is_bareword: bool, pair: Expr) -> Expr {
     if let Expr::Binary { left, right, .. } = &pair
         && fat_arrow_curries(left, right)
     {
-        return wrap_whatevercode(&pair);
+        return Expr::WhateverCurry(Box::new(pair));
     }
     Expr::PositionalPair(Box::new(pair))
 }

--- a/src/parser/expr/postfix/helpers.rs
+++ b/src/parser/expr/postfix/helpers.rs
@@ -118,6 +118,15 @@ pub(crate) fn is_angle_key_char(c: char) -> bool {
 /// instead of trying to numify the closure itself.
 pub(crate) fn compose_prefix_into_whatevercode(op: TokenKind, expr: Expr) -> Expr {
     match expr {
+        // ADR-0033 Phase 1: a currying operand is still an un-expanded
+        // `WhateverCurry` marker at this point (the closure isn't built until
+        // compile time), so compose the prefix into its un-curried body and
+        // re-wrap. Equivalent to composing into the built closure's last
+        // statement, since `build_closure` doesn't care whether the leaf is a
+        // literal `Expr::Whatever` or the already-substituted `$_`/`__wc_N`.
+        Expr::WhateverCurry(inner) => {
+            Expr::WhateverCurry(Box::new(Expr::Unary { op, expr: inner }))
+        }
         Expr::Lambda {
             param,
             mut body,

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -479,7 +479,7 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
             if crate::parser::expr::contains_whatever(&expr)
                 || crate::parser::expr::is_whatever(&expr)
             {
-                node = crate::parser::expr::wrap_whatevercode(&node);
+                node = Expr::WhateverCurry(Box::new(node));
             }
             return postfix_expr_continue(rest, node);
         }

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -13,13 +13,13 @@ use crate::value::Value;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use super::contains_whatever;
 use super::operators::*;
 use super::precedence_meta_ops::{
     BracketInfix, additive_expr, cannot_meta_ternary_error, concat_expr, multiplicative_expr,
     op_str_to_token_kind, parse_bracket_infix_op, parse_infix_func_op, parse_meta_op, power_expr,
     strip_sequence_op, structural_expr,
 };
-use super::{contains_whatever, wrap_whatevercode};
 
 static CHAIN_CMP_TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 

--- a/src/parser/expr/precedence/chain_cmp.rs
+++ b/src/parser/expr/precedence/chain_cmp.rs
@@ -89,7 +89,7 @@ pub(crate) fn wrap_smartmatch_rhs(right: Expr) -> Expr {
             right,
         } => {
             let value = if contains_whatever(&right) && !matches!(&*right, Expr::Whatever) {
-                wrap_whatevercode(&right)
+                Expr::WhateverCurry(right)
             } else {
                 *right
             };
@@ -101,7 +101,7 @@ pub(crate) fn wrap_smartmatch_rhs(right: Expr) -> Expr {
         }
         other => {
             if contains_whatever(&other) && !matches!(&other, Expr::Whatever) {
-                wrap_whatevercode(&other)
+                Expr::WhateverCurry(Box::new(other))
             } else {
                 other
             }

--- a/src/parser/expr/precedence/comparison.rs
+++ b/src/parser/expr/precedence/comparison.rs
@@ -321,7 +321,7 @@ pub(crate) fn comparison_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
             // SmartMatch suppresses top-level WhateverCode wrapping, but the LHS
             // should still be curried when it contains Whatever.
             if crate::parser::expr::should_wrap_whatevercode(&left) {
-                left = crate::parser::expr::wrap_whatevercode(&left);
+                left = Expr::WhateverCurry(Box::new(left));
             }
             // Bare `* ~~ Type` curries to WhateverCode `{ $_ ~~ Type }`.
             // This is only done here (not in should_curry_whatever) because at the

--- a/src/parser/expr/precedence/list_infix.rs
+++ b/src/parser/expr/precedence/list_infix.rs
@@ -121,10 +121,10 @@ pub(crate) fn sequence_only_expr(input: &str) -> PResult<'_, Expr> {
                     )
                 })?;
             if contains_whatever(&right) && !matches!(right, Expr::Whatever) {
-                right = wrap_whatevercode(&right);
+                right = Expr::WhateverCurry(Box::new(right));
             }
             if contains_whatever(&left) && !matches!(left, Expr::Whatever) {
-                left = wrap_whatevercode(&left);
+                left = Expr::WhateverCurry(Box::new(left));
             }
             left = wrap_left_exclusive_sequence(
                 op_str,
@@ -152,7 +152,7 @@ pub(crate) fn sequence_expr(input: &str) -> PResult<'_, Expr> {
     // Helper: wrap LHS WhateverCode before building the sequence node.
     fn maybe_wrap_lhs(left: &mut Expr) {
         if contains_whatever(left) && !matches!(left, Expr::Whatever) {
-            *left = wrap_whatevercode(left);
+            *left = Expr::WhateverCurry(Box::new(left.clone()));
         }
     }
 
@@ -181,7 +181,7 @@ pub(crate) fn sequence_expr(input: &str) -> PResult<'_, Expr> {
                 )
             })?;
             if contains_whatever(&right) && !matches!(right, Expr::Whatever) {
-                right = wrap_whatevercode(&right);
+                right = Expr::WhateverCurry(Box::new(right));
             }
             maybe_wrap_lhs(&mut left);
             left = wrap_left_exclusive_sequence(

--- a/src/parser/expr/precedence/list_infix_top.rs
+++ b/src/parser/expr/precedence/list_infix_top.rs
@@ -113,7 +113,7 @@ pub(crate) fn list_infix_top(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
 
     fn maybe_wrap_lhs(left: &mut Expr) {
         if contains_whatever(left) && !matches!(left, Expr::Whatever) {
-            *left = wrap_whatevercode(left);
+            *left = Expr::WhateverCurry(Box::new(left.clone()));
         }
     }
 
@@ -139,7 +139,7 @@ pub(crate) fn list_infix_top(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
                 )
             })?;
             if contains_whatever(&right) && !matches!(right, Expr::Whatever) {
-                right = wrap_whatevercode(&right);
+                right = Expr::WhateverCurry(Box::new(right));
             }
             maybe_wrap_lhs(&mut left);
             left = wrap_left_exclusive_sequence(

--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -361,6 +361,12 @@ pub(crate) fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
                     index.as_ref(),
                     Expr::ArrayLiteral(_)
                         | Expr::Whatever
+                        // ADR-0033 Phase 1: a Whatever-index (`@a[*-1] := ...`) is
+                        // still an un-expanded `WhateverCurry` marker at this
+                        // (pre-compile) parse-time point, not yet the built
+                        // `Lambda`/`AnonSubParams` closure below (kept as a
+                        // belt-and-suspenders match; only reachable pre-ADR-0033).
+                        | Expr::WhateverCurry(_)
                         | Expr::Lambda {
                             is_whatever_code: true,
                             ..

--- a/src/parser/expr/tests_meta.rs
+++ b/src/parser/expr/tests_meta.rs
@@ -250,14 +250,20 @@ fn parse_unicode_set_union_infix() {
 
 #[test]
 fn parse_whatever_with_unicode_set_union_infix() {
+    // ADR-0033 Phase 1: the parser defers WhateverCode closure construction to
+    // the compiler, so a currying expression now parses to a `WhateverCurry`
+    // marker wrapping the un-curried body (still literal `*` operands), not
+    // the built `AnonSubParams` closure directly.
     let (rest, expr) = expression("* ∪ *").unwrap();
     assert_eq!(rest, "");
     assert!(matches!(
         expr,
-        Expr::AnonSubParams { body, .. }
+        Expr::WhateverCurry(body)
             if matches!(
-                body.as_slice(),
-                [Stmt::Expr(Expr::Binary { op: TokenKind::SetUnion, .. })]
+                body.as_ref(),
+                Expr::Binary { op: TokenKind::SetUnion, left, right }
+                    if matches!(left.as_ref(), Expr::Whatever)
+                        && matches!(right.as_ref(), Expr::Whatever)
             )
     ));
 }

--- a/src/parser/expr/whatever.rs
+++ b/src/parser/expr/whatever.rs
@@ -1,8 +1,11 @@
 //! WhateverCode detection and inspection helpers.
 //!
 //! Pure, read-only predicates over the `Expr` tree used to decide whether an
-//! expression should be wrapped into a `WhateverCode` closure and, if so, how
-//! many `*` placeholders it contains.
+//! expression should be wrapped into an `Expr::WhateverCurry` priming-scope
+//! marker (ADR-0033) and, once decided, whether an operand already carries
+//! one. This module owns the priming-*scope* decision — deciding whether the
+//! actual closure gets built is `crate::whatever_curry::build_closure`,
+//! invoked later by the compiler.
 
 use crate::ast::Expr;
 use crate::token_kind::TokenKind;
@@ -81,7 +84,7 @@ pub(crate) fn should_wrap_whatevercode(expr: &Expr) -> bool {
 /// on `is_bareword` first.
 pub(crate) fn fat_arrow_curries(left: &Expr, right: &Expr) -> bool {
     fn operand_curries(e: &Expr) -> bool {
-        // A bare `*` or an already-wrapped `(* …)` closure does not wrap when it
+        // A bare `*` or an already-planted `(* …)` curry does not wrap when it
         // stands alone (that is why `should_wrap_whatevercode` excludes them),
         // but as a `=>` operand it does make the pair curry. Everything else
         // defers to the shared `should_wrap_whatevercode` opt-out logic (so `xx`,
@@ -136,25 +139,17 @@ pub(crate) fn is_whatever(expr: &Expr) -> bool {
     matches!(expr, Expr::Whatever)
 }
 
-/// True when `expr` is an already-wrapped WhateverCode closure (produced by a
-/// parenthesized curry such as `(* - 1)`). Such a closure is opaque as a *value*
-/// (e.g. when passed as an argument or stored in a variable), but when it appears
-/// as an *operand* of a further operator/method in the same expression, Raku
-/// composes it into a new, larger WhateverCode (`(* - 1) - 1`, `(^*).roll`,
-/// `1 +< (* - 1)`). The currying machinery (`count_whatever` /
-/// `replace_whatever_*`) already knows how to inline such a closure; this helper
-/// lets the composing operand positions detect it.
+/// True when `expr` is an already-planted WhateverCurry marker (produced by a
+/// parenthesized curry such as `(* - 1)`). Such a marker is opaque as a
+/// *value* (e.g. when passed as an argument or stored in a variable), but when
+/// it appears as an *operand* of a further operator/method in the same
+/// expression, Raku composes it into a new, larger WhateverCode (`(* - 1) -
+/// 1`, `(^*).roll`, `1 +< (* - 1)`). The currying machinery (`count_whatever` /
+/// `replace_whatever_*` in `crate::whatever_curry`) already knows how to
+/// inline such a marker; this helper lets the composing operand positions
+/// detect it.
 fn is_wrapped_whatevercode(expr: &Expr) -> bool {
-    matches!(
-        expr,
-        Expr::Lambda {
-            is_whatever_code: true,
-            ..
-        } | Expr::AnonSubParams {
-            is_whatever_code: true,
-            ..
-        }
-    )
+    matches!(expr, Expr::WhateverCurry(_))
 }
 
 pub(crate) fn contains_whatever(expr: &Expr) -> bool {
@@ -286,150 +281,6 @@ pub(crate) fn contains_whatever(expr: &Expr) -> bool {
                 || is_wrapped_whatevercode(left)
                 || is_wrapped_whatevercode(right)
         }
-        _ => false,
-    }
-}
-
-/// Count the number of distinct Whatever (`*`) placeholders in an expression.
-pub(crate) fn count_whatever(expr: &Expr) -> usize {
-    match expr {
-        e if is_whatever(e) => 1,
-        // A nested, already-wrapped WhateverCode operand (e.g. `(* - 1)` inside
-        // `(* - 1) - 1`) contributes its own placeholder count: a single-param
-        // `_`/`__wc_0` lambda counts as 1, a multi-param one as its arity.
-        Expr::Lambda {
-            is_whatever_code: true,
-            ..
-        } => 1,
-        Expr::AnonSubParams {
-            is_whatever_code: true,
-            params,
-            ..
-        } => params.len(),
-        Expr::Binary {
-            left,
-            op: TokenKind::AndAnd,
-            right,
-        } => {
-            if let (
-                Expr::Binary {
-                    left: ll,
-                    right: lr,
-                    ..
-                },
-                Expr::Binary {
-                    left: rl,
-                    right: rr,
-                    ..
-                },
-            ) = (left.as_ref(), right.as_ref())
-                && exprs_structurally_eq(lr, rl)
-                && count_whatever(lr) > 0
-            {
-                // Chained comparison `a OP m OP b` is expanded to
-                // `(a OP m) && (m OP b)` with the middle `m` duplicated. Count the
-                // shared middle's placeholders once so the WhateverCode arity is
-                // the number of distinct operands, not double the middle.
-                return count_whatever(ll) + count_whatever(lr) + count_whatever(rr);
-            }
-            count_whatever(left) + count_whatever(right)
-        }
-        // For range operators: count Whatever in endpoints only when
-        // the endpoint contains compound Whatever (not bare *).
-        Expr::Binary {
-            op:
-                TokenKind::DotDot
-                | TokenKind::DotDotCaret
-                | TokenKind::CaretDotDot
-                | TokenKind::CaretDotDotCaret,
-            left,
-            right,
-        } => {
-            let lc = if contains_whatever(left) && !is_whatever(left) {
-                count_whatever(left)
-            } else {
-                0
-            };
-            let rc = if contains_whatever(right) && !is_whatever(right) {
-                count_whatever(right)
-            } else {
-                0
-            };
-            lc + rc
-        }
-        Expr::Binary {
-            op: TokenKind::DotDotDot | TokenKind::DotDotDotCaret,
-            ..
-        } => 0,
-        // SmartMatch/BangTilde: Whatever on RHS is handled at runtime; only count LHS.
-        Expr::Binary {
-            op: TokenKind::SmartMatch | TokenKind::BangTilde,
-            left,
-            ..
-        } => count_whatever(left),
-        Expr::Binary { left, right, .. } => count_whatever(left) + count_whatever(right),
-        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => count_whatever(expr),
-        Expr::MethodCall { target, .. }
-        | Expr::DynamicMethodCall { target, .. }
-        | Expr::HyperMethodCall { target, .. }
-        | Expr::HyperMethodCallDynamic { target, .. } => count_whatever(target),
-        Expr::CallOn { target, .. } => {
-            // Only the *target* of an invocation curries. A Whatever passed as a
-            // call *argument* (`$sub(*)`, `&infix:<+>(*, 42)`) is a Whatever value
-            // handed to the callee, NOT a placeholder of the enclosing
-            // WhateverCode — so it must not add to the arity. This mirrors
-            // `contains_whatever`, which already only inspects the target.
-            count_whatever(target)
-        }
-        // Only check target, not index (subscript handles its own WhateverCode)
-        Expr::Index { target, .. } => count_whatever(target),
-        // User-defined infix operators
-        Expr::InfixFunc { left, right, .. } => {
-            count_whatever(left) + right.iter().map(count_whatever).sum::<usize>()
-        }
-        // R/X/Z meta-operators. R always curries on a Whatever operand; X/Z
-        // currying is decided at parse time in `container.rs` (a standalone `*`
-        // operand curries, a trailing `*` in a comma-list operand extends), but
-        // once the decision to wrap is made we must count placeholders here so
-        // the WhateverCode gets the right arity.
-        Expr::MetaOp {
-            meta, left, right, ..
-        } if matches!(meta.as_str(), "R" | "X" | "Z") => {
-            count_whatever(left) + count_whatever(right)
-        }
-        _ => 0,
-    }
-}
-
-/// Structural equality of two expressions, used to detect the shared middle
-/// term of an expanded chained comparison (`a OP m OP b` => `(a OP m) && (m OP
-/// b)`). `Expr` cannot derive `PartialEq` (it embeds `Value`), and this only runs
-/// while wrapping a WhateverCode, so a `Debug`-string comparison is sufficient.
-pub(crate) fn exprs_structurally_eq(a: &Expr, b: &Expr) -> bool {
-    format!("{a:?}") == format!("{b:?}")
-}
-
-/// Check if an expression contains a reference to $_ (the topic variable).
-/// Used to determine whether a WhateverCode lambda should avoid using $_ as its param.
-pub(crate) fn expr_contains_topic(expr: &Expr) -> bool {
-    match expr {
-        Expr::Var(name) if name == "_" => true,
-        Expr::Whatever => false,
-        Expr::Binary { left, right, .. } => expr_contains_topic(left) || expr_contains_topic(right),
-        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => expr_contains_topic(expr),
-        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
-            expr_contains_topic(target) || args.iter().any(expr_contains_topic)
-        }
-        Expr::CallOn { target, args } => {
-            expr_contains_topic(target) || args.iter().any(expr_contains_topic)
-        }
-        Expr::Index { target, index, .. } => {
-            expr_contains_topic(target) || expr_contains_topic(index)
-        }
-        Expr::InfixFunc { left, right, .. } => {
-            expr_contains_topic(left) || right.iter().any(expr_contains_topic)
-        }
-        Expr::MetaOp { left, right, .. } => expr_contains_topic(left) || expr_contains_topic(right),
         _ => false,
     }
 }

--- a/src/parser/expr/whatever_wrap.rs
+++ b/src/parser/expr/whatever_wrap.rs
@@ -1,8 +1,12 @@
-//! WhateverCode construction: wrapping expressions containing `*` placeholders
-//! into the appropriate `Lambda` / `AnonSubParams` closures, and composing
-//! `o`-operator operands.
+//! WhateverCode-adjacent AST shaping that stays parser-side (ADR-0033):
+//! composing `o`/`\u{2218}` operands, and threading a curried `CallOn` target
+//! through a trailing method-call chain. These decide *shape*, not closure
+//! construction — the un-curried operands are wrapped in `Expr::WhateverCurry`
+//! markers; `crate::whatever_curry::build_closure` expands those at compile
+//! time.
 
 use super::*;
+use crate::whatever_curry::make_wc_param;
 
 pub(crate) fn wrap_composition_operands(expr: Expr) -> Expr {
     match expr {
@@ -26,7 +30,7 @@ pub(crate) fn wrap_composition_operands(expr: Expr) -> Expr {
                         param_defs.push(make_wc_param(name.clone()));
                         Expr::Var(name)
                     } else if should_wrap_whatevercode(&left) {
-                        wrap_whatevercode(&left)
+                        Expr::WhateverCurry(Box::new(left))
                     } else {
                         left
                     };
@@ -36,7 +40,7 @@ pub(crate) fn wrap_composition_operands(expr: Expr) -> Expr {
                         param_defs.push(make_wc_param(name.clone()));
                         Expr::Var(name)
                     } else if should_wrap_whatevercode(&right) {
-                        wrap_whatevercode(&right)
+                        Expr::WhateverCurry(Box::new(right))
                     } else {
                         right
                     };
@@ -63,12 +67,12 @@ pub(crate) fn wrap_composition_operands(expr: Expr) -> Expr {
                     };
                 }
                 let left_wrapped = if should_wrap_whatevercode(&left) {
-                    wrap_whatevercode(&left)
+                    Expr::WhateverCurry(Box::new(left))
                 } else {
                     left
                 };
                 let right_wrapped = if should_wrap_whatevercode(&right) {
-                    wrap_whatevercode(&right)
+                    Expr::WhateverCurry(Box::new(right))
                 } else {
                     right
                 };
@@ -120,34 +124,9 @@ pub(crate) fn wrap_composition_operands(expr: Expr) -> Expr {
     }
 }
 
-fn make_wc_param(name: String) -> crate::ast::ParamDef {
-    crate::ast::ParamDef {
-        name,
-        default: None,
-        multi_invocant: true,
-        required: false,
-        named: false,
-        slurpy: false,
-        double_slurpy: false,
-        onearg: false,
-        sigilless: false,
-        type_constraint: None,
-        literal_value: None,
-        sub_signature: None,
-        where_constraint: None,
-        traits: Vec::new(),
-        optional_marker: false,
-        outer_sub_signature: None,
-        code_signature: None,
-        is_invocant: false,
-        shape_constraints: None,
-        block_param: false,
-    }
-}
-
 /// Try to detect and fix a chain of MethodCalls leading to a CallOn whose target
-/// contains Whatever. If found, wrap only the CallOn target as WhateverCode,
-/// leaving the outer method calls outside the lambda.
+/// contains Whatever. If found, wrap only the CallOn target as a WhateverCurry
+/// marker, leaving the outer method calls outside the curried scope.
 ///
 /// Handles patterns like: *.foo().(args).bar().baz()
 /// where only *.foo() should be wrapped as WhateverCode.
@@ -171,7 +150,9 @@ pub(crate) fn try_wrap_whatevercode_call_chain(expr: &Expr) -> Option<Expr> {
                 {
                     Some(Expr::MethodCall {
                         target: Box::new(Expr::CallOn {
-                            target: Box::new(wrap_whatevercode(inner_target)),
+                            target: Box::new(Expr::WhateverCurry(Box::new(
+                                (**inner_target).clone(),
+                            ))),
                             args: call_args.clone(),
                         }),
                         name: *name,
@@ -195,110 +176,5 @@ pub(crate) fn try_wrap_whatevercode_call_chain(expr: &Expr) -> Option<Expr> {
             }
         }
         _ => None,
-    }
-}
-
-/// Build a WhateverCode lambda from an expression containing Whatever placeholders.
-pub(crate) fn wrap_whatevercode(expr: &Expr) -> Expr {
-    if let Expr::CallOn { target, args } = expr
-        && should_wrap_whatevercode(target)
-        && !args.iter().any(contains_whatever)
-    {
-        return Expr::CallOn {
-            target: Box::new(wrap_whatevercode(target)),
-            args: args.clone(),
-        };
-    }
-
-    let wc_count = count_whatever(expr);
-
-    if wc_count <= 1 && !expr_contains_topic(expr) {
-        // Single-arg: use Lambda with param "_" for backward compat (this keeps the
-        // `deepmap`/hyper container-passing path working, which binds each leaf to
-        // the topic `_`). `compile_expr_lambda` marks `_` `is raw` when the body
-        // mutates the placeholder (`*++`, `* =:= $x`), so mutation/identity work.
-        // Use a special single-arg replacer that maps * and nested single-arg WC to $_
-        let body_expr = replace_whatever_single(expr);
-        Expr::Lambda {
-            param: "_".to_string(),
-            body: vec![Stmt::Expr(body_expr)],
-            is_whatever_code: true,
-            param_sigilless: false,
-        }
-    } else if wc_count <= 1 {
-        // Single-arg, but expression already contains $_ — use a numbered param
-        // to avoid shadowing the outer $_.
-        let mut counter = 0;
-        let body_expr = replace_whatever_numbered(expr, &mut counter);
-        let param_name = "__wc_0".to_string();
-        Expr::AnonSubParams {
-            params: vec![param_name.clone()],
-            param_defs: vec![crate::ast::ParamDef {
-                name: param_name,
-                default: None,
-                multi_invocant: true,
-                required: false,
-                named: false,
-                slurpy: false,
-                sigilless: false,
-                type_constraint: None,
-                literal_value: None,
-                sub_signature: None,
-                where_constraint: None,
-                // WhateverCode parameters are `is raw`, so `*++`/`*.=foo` can
-                // mutate the argument's container and write back to the caller.
-                traits: vec!["raw".to_string()],
-                double_slurpy: false,
-                onearg: false,
-                optional_marker: false,
-                outer_sub_signature: None,
-                code_signature: None,
-                is_invocant: false,
-                shape_constraints: None,
-                block_param: false,
-            }],
-            return_type: None,
-            body: vec![Stmt::Expr(body_expr)],
-            is_rw: false,
-            is_whatever_code: true,
-        }
-    } else {
-        // Multi-arg: use AnonSubParams with numbered params
-        let mut counter = 0;
-        let body_expr = replace_whatever_numbered(expr, &mut counter);
-        let params: Vec<String> = (0..counter).map(|i| format!("__wc_{}", i)).collect();
-        Expr::AnonSubParams {
-            params: params.clone(),
-            param_defs: params
-                .iter()
-                .map(|name| crate::ast::ParamDef {
-                    name: name.clone(),
-                    default: None,
-                    multi_invocant: true,
-                    required: false,
-                    named: false,
-                    slurpy: false,
-                    sigilless: false,
-                    type_constraint: None,
-                    literal_value: None,
-                    sub_signature: None,
-                    where_constraint: None,
-                    // WhateverCode parameters are `is raw` (mutable, write back).
-                    traits: vec!["raw".to_string()],
-                    double_slurpy: false,
-                    onearg: false,
-                    optional_marker: false,
-                    outer_sub_signature: None,
-                    code_signature: None,
-                    is_invocant: false,
-                    shape_constraints: None,
-                    block_param: false,
-                })
-                .collect(),
-            return_type: None,
-            body: vec![Stmt::Expr(body_expr)],
-            is_rw: false,
-            is_whatever_code: true,
-        }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,9 @@
 mod expr;
+// ADR-0033: `crate::whatever_curry::build_closure` (the WhateverCode closure
+// construction that moved out of the parser) needs these priming-scope
+// predicates, so re-export them at crate visibility without making the whole
+// `expr` module (and its many `pub(in crate::parser)`-typed internals) public.
+pub(crate) use expr::{contains_whatever, is_whatever, should_wrap_whatevercode};
 pub(crate) mod helpers;
 mod memo;
 mod outer_redecl;

--- a/src/parser/outer_redecl.rs
+++ b/src/parser/outer_redecl.rs
@@ -396,6 +396,13 @@ fn walk_expr(expr: &Expr, ctx: &mut Ctx) {
         Expr::Lambda { param, body, .. } => {
             walk_scoped_body_with_params(body, std::slice::from_ref(param), &[], ctx)
         }
+        // ADR-0033 Phase 1: an un-expanded WhateverCurry marker introduces no
+        // named bindings of its own yet (its body still has literal `*`
+        // placeholders, not the synthetic `__wc_N` params `build_closure`
+        // assigns later) — so unlike `Lambda`/`AnonSubParams` it opens no new
+        // scope here; walk its body transparently in the current scope so any
+        // *other* variable reference inside it still gets shadow-checked.
+        Expr::WhateverCurry(inner) => walk_expr(inner, ctx),
         Expr::Try { body, catch } => {
             walk_scoped_body(body, ctx);
             if let Some(c) = catch {

--- a/src/parser/primary/container/meta_ops.rs
+++ b/src/parser/primary/container/meta_ops.rs
@@ -1,7 +1,5 @@
 use crate::ast::{Expr, Stmt};
-use crate::parser::expr::{
-    contains_whatever, expression, expression_no_sequence, wrap_whatevercode,
-};
+use crate::parser::expr::{contains_whatever, expression, expression_no_sequence};
 use crate::parser::helpers::ws;
 use crate::parser::parse_result::{PError, PResult, parse_char};
 use crate::parser::stmt::keyword;
@@ -70,7 +68,7 @@ pub(crate) fn maybe_curry_xz_metaop(expr: Expr) -> Expr {
     if matches!(&expr, Expr::MetaOp { meta, .. } if meta == "X" || meta == "Z")
         && xz_metaop_curries(&expr)
     {
-        crate::parser::expr::wrap_whatevercode(&expr)
+        Expr::WhateverCurry(Box::new(expr))
     } else {
         expr
     }
@@ -98,19 +96,7 @@ fn operand_curries(e: &Expr) -> bool {
     match e {
         Expr::ArrayLiteral(_) => false,
         Expr::MetaOp { meta, .. } if meta == "X" || meta == "Z" => xz_metaop_curries(e),
-        _ => {
-            contains_whatever(e)
-                || matches!(
-                    e,
-                    Expr::Lambda {
-                        is_whatever_code: true,
-                        ..
-                    } | Expr::AnonSubParams {
-                        is_whatever_code: true,
-                        ..
-                    }
-                )
-        }
+        _ => contains_whatever(e) || matches!(e, Expr::WhateverCurry(_)),
     }
 }
 
@@ -514,7 +500,7 @@ pub(crate) fn starts_with_sequence_op(input: &str) -> bool {
 
 fn maybe_wrap_whatever(expr: Expr) -> Expr {
     if contains_whatever(&expr) && !matches!(expr, Expr::Whatever) {
-        wrap_whatevercode(&expr)
+        Expr::WhateverCurry(Box::new(expr))
     } else {
         expr
     }

--- a/src/parser/primary/container/paren.rs
+++ b/src/parser/primary/container/paren.rs
@@ -25,19 +25,13 @@ use super::meta_ops::{
     try_parse_sequence_in_paren,
 };
 
-/// True when `expr` is an already-built WhateverCode closure (e.g. from `*.so`
-/// or `* + 1`), which is the value an extra paren layer should freeze.
+/// True when `expr` is an already-planted WhateverCode priming scope (e.g.
+/// from `*.so` or `* + 1`), which is the value an extra paren layer should
+/// freeze. ADR-0033 Phase 1: the parser defers closure construction to the
+/// compiler, so this is now `Expr::WhateverCurry` rather than a built
+/// `Lambda`/`AnonSubParams`.
 fn is_whatevercode_closure(expr: &Expr) -> bool {
-    matches!(
-        expr,
-        Expr::Lambda {
-            is_whatever_code: true,
-            ..
-        } | Expr::AnonSubParams {
-            is_whatever_code: true,
-            ..
-        }
-    )
+    matches!(expr, Expr::WhateverCurry(_))
 }
 
 /// True when `s` is exactly one balanced parenthesis group spanning the whole
@@ -257,7 +251,12 @@ fn paren_expr_inner(input: &str) -> PResult<'_, Expr> {
         // a WhateverCode wrapping the nested meta-op, not a (non-curryable) `zip`
         // call. A non-currying meta-op still normalizes as before.
         let result = match maybe_curry_xz_metaop(first) {
-            curried @ (Expr::Lambda { .. } | Expr::AnonSubParams { .. }) => curried,
+            // ADR-0033 Phase 1: a curried result is now a `WhateverCurry`
+            // marker rather than a built `Lambda`/`AnonSubParams` closure;
+            // keep it out of `normalize_chained_zip_meta` just the same.
+            curried @ (Expr::WhateverCurry(_)
+            | Expr::Lambda { .. }
+            | Expr::AnonSubParams { .. }) => curried,
             other => normalize_chained_zip_meta(other),
         };
         // Wrap in Grouped so the compiler's chain-flattener can

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1,7 +1,6 @@
 use crate::ast::{Expr, Stmt, make_anon_sub};
 use crate::parser::expr::{
     expression, expression_no_sequence, parse_fat_arrow_value, should_wrap_whatevercode, term_expr,
-    wrap_whatevercode,
 };
 use crate::parser::helpers::{
     consume_unspace, is_loop_label_name, is_raku_identifier_start, normalize_raku_identifier, ws,
@@ -280,7 +279,7 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             // Wrap WhateverCode in the pair value (e.g. `foo => |*` should have
             // a WhateverCode as the value, not slip(Whatever)).
             if should_wrap_whatevercode(&value) {
-                value = wrap_whatevercode(&value);
+                value = Expr::WhateverCurry(Box::new(value));
             }
             // A qualified name (`Bool::True`, `Foo::Bar`) is NOT autoquoted — it
             // is evaluated to its value, so `Bool::True => "a"` has the Bool

--- a/src/parser/primary/regex/call_args.rs
+++ b/src/parser/primary/regex/call_args.rs
@@ -99,7 +99,7 @@ pub(in crate::parser) fn parse_call_arg_list(input: &str) -> PResult<'_, Vec<Exp
             };
             // Apply WhateverCode wrapping (e.g., `* *= 2` -> WhateverCode lambda)
             if crate::parser::expr::should_wrap_whatevercode(&compound_expr) {
-                compound_expr = crate::parser::expr::wrap_whatevercode(&compound_expr);
+                compound_expr = Expr::WhateverCurry(Box::new(compound_expr));
             }
             return Ok((r, compound_expr));
         }

--- a/src/parser/sink_warn.rs
+++ b/src/parser/sink_warn.rs
@@ -233,6 +233,9 @@ fn scan_gathers_expr(expr: &Expr) {
             }
         }
         Expr::DoStmt(stmt) => scan_gathers_stmt(stmt),
+        // ADR-0033: descend into an un-expanded WhateverCurry body the same
+        // way as the closure kinds above.
+        Expr::WhateverCurry(inner) => scan_gathers_expr(inner),
         _ => {}
     }
 }

--- a/src/parser/stmt/args.rs
+++ b/src/parser/stmt/args.rs
@@ -778,7 +778,7 @@ fn parse_single_call_arg_mode(input: &str, listop: bool) -> PResult<'_, CallArg>
         };
         // Apply WhateverCode wrapping (e.g., `* *= 2` → WhateverCode lambda)
         if crate::parser::expr::should_wrap_whatevercode(&compound_expr) {
-            compound_expr = crate::parser::expr::wrap_whatevercode(&compound_expr);
+            compound_expr = Expr::WhateverCurry(Box::new(compound_expr));
         }
         return Ok((r, CallArg::Positional(compound_expr)));
     }

--- a/src/parser/stmt/class/attr_checks.rs
+++ b/src/parser/stmt/class/attr_checks.rs
@@ -64,6 +64,9 @@ pub(crate) fn expr_uses_attr_twigil(expr: &Expr) -> bool {
         | Expr::AnonSub { body, .. }
         | Expr::AnonSubParams { body, .. }
         | Expr::Lambda { body, .. } => body.iter().any(stmt_uses_attr_twigil),
+        // ADR-0033: an un-expanded WhateverCurry body can still reference
+        // `$!attr` (e.g. `$!x + *`, `*.=foo` mutating an attribute).
+        Expr::WhateverCurry(inner) => expr_uses_attr_twigil(inner),
         Expr::Try { body, catch } => {
             body.iter().any(stmt_uses_attr_twigil)
                 || catch

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -544,7 +544,13 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
             return Ok(None);
         }
         let loop_stmt = match stmt {
-            Stmt::Expr(expr @ Expr::AnonSubParams { .. })
+            // ADR-0033 Phase 1: a bare Whatever-curried statement (`* + 1 for
+            // @a`) is now `WhateverCurry` rather than a built `Lambda`/
+            // `AnonSubParams`, but still needs the same "call it with $_"
+            // treatment as those, to keep `* + 1 for @a` meaning `($_ + 1)
+            // for @a` rather than discarding an uncalled closure value.
+            Stmt::Expr(expr @ Expr::WhateverCurry(_))
+            | Stmt::Expr(expr @ Expr::AnonSubParams { .. })
             | Stmt::Expr(expr @ Expr::Lambda { .. }) => {
                 let target = Expr::CallOn {
                     target: Box::new(expr),

--- a/src/parser/stmt/sub/param_validate.rs
+++ b/src/parser/stmt/sub/param_validate.rs
@@ -116,7 +116,11 @@ pub(crate) fn static_default_type(expr: &Expr) -> Option<String> {
         };
     }
     match expr {
-        Expr::AnonSub { .. } | Expr::AnonSubParams { .. } => Some("Callable".to_string()),
+        // ADR-0033: a Whatever-curried default (`$x = * + 1`) compiles to a
+        // Callable closure just like a hand-written one.
+        Expr::AnonSub { .. } | Expr::AnonSubParams { .. } | Expr::WhateverCurry(_) => {
+            Some("Callable".to_string())
+        }
         _ => None,
     }
 }

--- a/src/parser/stmt/sub_param/where_constraint.rs
+++ b/src/parser/stmt/sub_param/where_constraint.rs
@@ -143,15 +143,26 @@ fn stmt_leads_with_whatever(stmt: &Stmt) -> bool {
 fn expr_leads_with_whatever(expr: &Expr) -> bool {
     match expr {
         Expr::Whatever | Expr::HyperWhatever => true,
-        // A curried whatever placeholder reached as the leftmost leaf.
+        // A curried whatever placeholder reached as the leftmost leaf. Only
+        // reachable pre-ADR-0033 (a build_closure-substituted body); kept as a
+        // belt-and-suspenders match since it is harmless.
         Expr::Var(name) if name.starts_with("__wc_") => true,
+        // ADR-0033 Phase 1: the parser no longer builds the closure eagerly —
+        // `{ * > 2 }` / `{ * > 2 && * < 9 }` parse to `WhateverCurry` wrapping
+        // the un-curried body, still with literal `Expr::Whatever` leaves.
+        // Recursing into the body walks the same left spine `build_closure`
+        // would have produced a `__wc_N`/`Whatever` leaf from, so this gives
+        // the identical answer without needing the closure to be built.
+        Expr::WhateverCurry(inner) => expr_leads_with_whatever(inner),
         // Topic-param WhateverCode: only produced by a standalone leading `*`.
+        // Only reachable pre-ADR-0033; see the `WhateverCurry` arm above.
         Expr::Lambda {
             is_whatever_code: true,
             ..
         } => true,
         // `__wc_`-param WhateverCode: descend to its body's leftmost leaf, which
-        // is a `__wc_N` placeholder iff the block actually led with `*`.
+        // is a `__wc_N` placeholder iff the block actually led with `*`. Only
+        // reachable pre-ADR-0033; see the `WhateverCurry` arm above.
         Expr::AnonSubParams {
             is_whatever_code: true,
             body,

--- a/src/parser/whenever_scope.rs
+++ b/src/parser/whenever_scope.rs
@@ -134,6 +134,12 @@ fn walk_expr(expr: &Expr, in_scope: bool, line: &mut i64, found: &mut Option<i64
         }
         Expr::AnonSubParams { body, .. } => walk_stmts(body, in_scope, line, found),
 
+        // ADR-0033 Phase 1: an un-expanded WhateverCurry marker is, like the
+        // `Lambda`/`AnonSubParams` cases above, a purely lexical boundary —
+        // preserve the current scope and descend into its (still un-curried)
+        // body.
+        Expr::WhateverCurry(inner) => walk_expr(inner, in_scope, line, found),
+
         // Inline block-valued expressions preserve scope.
         Expr::Block(body) | Expr::Gather(body) => walk_stmts(body, in_scope, line, found),
         Expr::DoBlock { body, .. } => walk_stmts(body, in_scope, line, found),

--- a/src/placeholder_order.rs
+++ b/src/placeholder_order.rs
@@ -360,7 +360,10 @@ fn check_bare_var_expr(expr: &Expr, var_name: &str, found: &mut bool) {
         }
         // A WhateverCode owns only its `*`-derived params, not `$^name`
         // placeholders — descend through it (mirrors
-        // `collect_ph_expr_shallow`).
+        // `collect_ph_expr_shallow`). ADR-0033: at this (pre-compile) stage a
+        // curry is still an un-expanded `WhateverCurry` marker, not a built
+        // `AnonSubParams`/`Lambda`, so descend into its body directly.
+        Expr::WhateverCurry(body) => check_bare_var_expr(body, var_name, found),
         Expr::AnonSubParams {
             body,
             is_whatever_code: true,
@@ -657,6 +660,10 @@ fn order_check_expr(expr: &Expr, state: &mut OrderState) {
                 order_check_expr(e, state);
             }
         }
+        // ADR-0033: descend into an un-expanded WhateverCurry body the same
+        // way as an already-built WhateverCode (see `check_bare_var_expr`
+        // above for the matching rationale).
+        Expr::WhateverCurry(body) => order_check_expr(body, state),
         Expr::AnonSubParams {
             body,
             is_whatever_code: true,

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -171,6 +171,10 @@ impl Interpreter {
                 }
                 Expr::AssignExpr { expr, .. } => expr_contains_last(expr),
                 Expr::Lambda { body, .. } => body.iter().any(stmt_contains_last),
+                // A `last` cannot syntactically appear inside a Whatever-curry
+                // body (it is a pure expression, not a statement list), but
+                // descend for consistency with the other closure arms above.
+                Expr::WhateverCurry(inner) => expr_contains_last(inner),
                 Expr::Subst { .. }
                 | Expr::NonDestructiveSubst { .. }
                 | Expr::Transliterate { .. }

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -96,6 +96,9 @@ fn lift_begin_from_eval_expr(expr: &mut Expr, begin: &mut Vec<Stmt>) {
         Expr::Lambda { body, .. } => {
             extract_begin_from_stmts(body, begin);
         }
+        // ADR-0033: an un-expanded WhateverCurry body is transparent here,
+        // same as the closure kinds above.
+        Expr::WhateverCurry(inner) => lift_begin_from_eval_expr(inner, begin),
         _ => {}
     }
 }
@@ -569,6 +572,9 @@ fn lift_phasers_from_expr_inner(
         Expr::Lambda { body, .. } => {
             lift_phasers_from_closure_stmts(body, begin, check, init);
         }
+        // ADR-0033: an un-expanded WhateverCurry body is transparent here,
+        // same as the closure kinds above.
+        Expr::WhateverCurry(inner) => lift_phasers_from_expr(inner, begin, check, init),
         Expr::Try { body, catch } => {
             lift_phasers_from_closure_stmts(body, begin, check, init);
             if let Some(c) = catch {
@@ -1126,6 +1132,9 @@ fn recurse_into_expr(expr: &mut Expr) {
         Expr::Lambda { body, .. } => {
             reorder_recursive(body, false);
         }
+        // ADR-0033: an un-expanded WhateverCurry body is transparent here,
+        // same as the closure kinds above.
+        Expr::WhateverCurry(inner) => recurse_into_expr(inner),
         Expr::Try { body, catch } => {
             reorder_recursive(body, false);
             if let Some(c) = catch {

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -683,6 +683,11 @@ impl Interpreter {
             | Expr::Lambda { body, .. } => {
                 self.validate_private_access_in_stmts(caller_class, body)?
             }
+            // ADR-0033: an un-expanded WhateverCurry body can still contain a
+            // private-method access (`* !private-method`).
+            Expr::WhateverCurry(inner) => {
+                self.validate_private_access_in_expr(caller_class, inner)?
+            }
             Expr::Try { body: _, catch } => {
                 // Skip private access validation inside try blocks — unauthorized
                 // private access will produce a runtime error that try can catch.
@@ -910,6 +915,11 @@ impl Interpreter {
             }
             Expr::DoBlock { body, .. } => {
                 self.check_private_calls_exist(class_name, class_def, body)?;
+            }
+            // ADR-0033: an un-expanded WhateverCurry body can still contain a
+            // private-method call (`* !method`).
+            Expr::WhateverCurry(inner) => {
+                self.check_private_calls_exist_expr(class_name, class_def, inner)?
             }
             Expr::DoStmt(stmt) => {
                 self.check_private_calls_exist_stmt(class_name, class_def, stmt)?;

--- a/src/runtime/registration_class_attr.rs
+++ b/src/runtime/registration_class_attr.rs
@@ -203,6 +203,9 @@ impl Interpreter {
             | Expr::Lambda { body, .. } => {
                 Self::validate_attr_declared_in_class(ctx, body)?;
             }
+            // ADR-0033: an un-expanded WhateverCurry body can still reference
+            // an attribute (`$!x + *`).
+            Expr::WhateverCurry(inner) => Self::validate_attr_in_expr(ctx, inner)?,
             Expr::Try { body: _, catch } => {
                 // Skip attribute validation inside try blocks — accessing an
                 // undeclared attribute will produce a runtime error that the

--- a/src/runtime/system_eval_names.rs
+++ b/src/runtime/system_eval_names.rs
@@ -902,6 +902,12 @@ impl Interpreter {
             Expr::Lambda { body, .. } => body
                 .iter()
                 .find_map(|s| self.find_undeclared_name_in_stmt(s, local_classes, declared)),
+            // ADR-0033 Phase 1: the parser now defers building that lambda —
+            // at this point it is still an un-expanded `WhateverCurry` marker
+            // wrapping the un-curried body, so descend into it directly.
+            Expr::WhateverCurry(inner) => {
+                self.find_undeclared_name_in_expr(inner, local_classes, declared)
+            }
             _ => None,
         }
     }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -968,9 +968,18 @@ impl Interpreter {
                     let body = [Stmt::Expr(pred.clone())];
                     let compiled = self.compile_subset_predicate(constraint, &body);
                     // Check if the predicate is a block/lambda (AnonSub, AnonSubParams, etc.)
+                    // ADR-0033 Phase 1: a Whatever-curried predicate (`where *
+                    // < 1000`) is still an un-expanded `WhateverCurry` marker
+                    // at this point, not yet the `Lambda` the fast inline
+                    // path above matches — it must still be recognized as
+                    // callable here so it is invoked, not compared as a
+                    // literal value.
                     let is_callable_expr = matches!(
                         pred,
-                        Expr::AnonSub { .. } | Expr::AnonSubParams { .. } | Expr::Block(_)
+                        Expr::AnonSub { .. }
+                            | Expr::AnonSubParams { .. }
+                            | Expr::Block(_)
+                            | Expr::WhateverCurry(_)
                     );
                     if is_callable_expr {
                         // Evaluate to get a callable, then call with the value

--- a/src/runtime/undeclared_routines.rs
+++ b/src/runtime/undeclared_routines.rs
@@ -603,6 +603,10 @@ fn walk_expr(expr: &Expr, scan: &mut Scan) {
             scan.declare(param);
             walk_stmts(body, scan);
         }
+        // ADR-0033: an un-expanded WhateverCurry body has no named params of
+        // its own yet (still literal `*` placeholders), so just descend into
+        // it to still catch an undeclared routine call inside it.
+        Expr::WhateverCurry(inner) => walk_expr(inner, scan),
         Expr::Try { body, catch } => {
             walk_stmts(body, scan);
             if let Some(c) = catch {

--- a/src/whatever_curry/build.rs
+++ b/src/whatever_curry/build.rs
@@ -1,0 +1,242 @@
+//! WhateverCode closure construction: expanding an `Expr::WhateverCurry`
+//! marker's un-curried body into the `Lambda` / `AnonSubParams` closure the
+//! parser used to build eagerly (`wrap_whatevercode`, pre-ADR-0033).
+
+use super::replace::{replace_whatever_numbered, replace_whatever_single};
+use crate::ast::{Expr, ParamDef, Stmt};
+use crate::parser::{contains_whatever, is_whatever, should_wrap_whatevercode};
+use crate::token_kind::TokenKind;
+
+pub(crate) fn make_wc_param(name: String) -> ParamDef {
+    ParamDef {
+        name,
+        default: None,
+        multi_invocant: true,
+        required: false,
+        named: false,
+        slurpy: false,
+        double_slurpy: false,
+        onearg: false,
+        sigilless: false,
+        type_constraint: None,
+        literal_value: None,
+        sub_signature: None,
+        where_constraint: None,
+        traits: Vec::new(),
+        optional_marker: false,
+        outer_sub_signature: None,
+        code_signature: None,
+        is_invocant: false,
+        shape_constraints: None,
+        block_param: false,
+    }
+}
+
+/// A WhateverCode parameter (`__wc_N`) is `is raw`, so `*++`, `*.=foo` and
+/// `* =:= $x` write back to the caller's container.
+fn make_wc_param_raw(name: String) -> ParamDef {
+    ParamDef {
+        traits: vec!["raw".to_string()],
+        ..make_wc_param(name)
+    }
+}
+
+/// Build a WhateverCode lambda from an expression containing Whatever
+/// placeholders. This is the closure-construction step ADR-0033 defers out of
+/// the parser: the parser now wraps the un-curried body in
+/// `Expr::WhateverCurry`, and the compiler calls this from its
+/// `Expr::WhateverCurry` arm at compile time. The result is exactly what the
+/// parser used to build on the spot, so emitted bytecode is unchanged.
+pub(crate) fn build_closure(expr: &Expr) -> Expr {
+    if let Expr::CallOn { target, args } = expr
+        && should_wrap_whatevercode(target)
+        && !args.iter().any(contains_whatever)
+    {
+        return Expr::CallOn {
+            target: Box::new(build_closure(target)),
+            args: args.clone(),
+        };
+    }
+
+    let wc_count = count_whatever(expr);
+
+    if wc_count <= 1 && !expr_contains_topic(expr) {
+        // Single-arg: use Lambda with param "_" for backward compat (this keeps the
+        // `deepmap`/hyper container-passing path working, which binds each leaf to
+        // the topic `_`). `compile_expr_lambda` marks `_` `is raw` when the body
+        // mutates the placeholder (`*++`, `* =:= $x`), so mutation/identity work.
+        let body_expr = replace_whatever_single(expr);
+        Expr::Lambda {
+            param: "_".to_string(),
+            body: vec![Stmt::Expr(body_expr)],
+            is_whatever_code: true,
+            param_sigilless: false,
+        }
+    } else if wc_count <= 1 {
+        // Single-arg, but expression already contains $_ — use a numbered param
+        // to avoid shadowing the outer $_.
+        let mut counter = 0;
+        let body_expr = replace_whatever_numbered(expr, &mut counter);
+        let param_name = "__wc_0".to_string();
+        Expr::AnonSubParams {
+            params: vec![param_name.clone()],
+            param_defs: vec![make_wc_param_raw(param_name)],
+            return_type: None,
+            body: vec![Stmt::Expr(body_expr)],
+            is_rw: false,
+            is_whatever_code: true,
+        }
+    } else {
+        // Multi-arg: use AnonSubParams with numbered params
+        let mut counter = 0;
+        let body_expr = replace_whatever_numbered(expr, &mut counter);
+        let params: Vec<String> = (0..counter).map(|i| format!("__wc_{i}")).collect();
+        Expr::AnonSubParams {
+            params: params.clone(),
+            param_defs: params.iter().cloned().map(make_wc_param_raw).collect(),
+            return_type: None,
+            body: vec![Stmt::Expr(body_expr)],
+            is_rw: false,
+            is_whatever_code: true,
+        }
+    }
+}
+
+/// Count the number of distinct Whatever (`*`) placeholders in an expression.
+pub(crate) fn count_whatever(expr: &Expr) -> usize {
+    match expr {
+        e if is_whatever(e) => 1,
+        // A nested, already-planted WhateverCurry operand (e.g. `(* - 1)`
+        // inside `(* - 1) - 1`) contributes its own un-curried placeholder
+        // count. `count_whatever` already handles the chained-comparison
+        // dedup below, so recursing here yields exactly the arity
+        // `build_closure` would give it if built standalone.
+        Expr::WhateverCurry(inner) => count_whatever(inner),
+        Expr::Binary {
+            left,
+            op: TokenKind::AndAnd,
+            right,
+        } => {
+            if let (
+                Expr::Binary {
+                    left: ll,
+                    right: lr,
+                    ..
+                },
+                Expr::Binary {
+                    left: rl,
+                    right: rr,
+                    ..
+                },
+            ) = (left.as_ref(), right.as_ref())
+                && exprs_structurally_eq(lr, rl)
+                && count_whatever(lr) > 0
+            {
+                // Chained comparison `a OP m OP b` is expanded to
+                // `(a OP m) && (m OP b)` with the middle `m` duplicated. Count the
+                // shared middle's placeholders once so the WhateverCode arity is
+                // the number of distinct operands, not double the middle.
+                return count_whatever(ll) + count_whatever(lr) + count_whatever(rr);
+            }
+            count_whatever(left) + count_whatever(right)
+        }
+        // For range operators: count Whatever in endpoints only when
+        // the endpoint contains compound Whatever (not bare *).
+        Expr::Binary {
+            op:
+                TokenKind::DotDot
+                | TokenKind::DotDotCaret
+                | TokenKind::CaretDotDot
+                | TokenKind::CaretDotDotCaret,
+            left,
+            right,
+        } => {
+            let lc = if contains_whatever(left) && !is_whatever(left) {
+                count_whatever(left)
+            } else {
+                0
+            };
+            let rc = if contains_whatever(right) && !is_whatever(right) {
+                count_whatever(right)
+            } else {
+                0
+            };
+            lc + rc
+        }
+        Expr::Binary {
+            op: TokenKind::DotDotDot | TokenKind::DotDotDotCaret,
+            ..
+        } => 0,
+        // SmartMatch/BangTilde: Whatever on RHS is handled at runtime; only count LHS.
+        Expr::Binary {
+            op: TokenKind::SmartMatch | TokenKind::BangTilde,
+            left,
+            ..
+        } => count_whatever(left),
+        Expr::Binary { left, right, .. } => count_whatever(left) + count_whatever(right),
+        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => count_whatever(expr),
+        Expr::MethodCall { target, .. }
+        | Expr::DynamicMethodCall { target, .. }
+        | Expr::HyperMethodCall { target, .. }
+        | Expr::HyperMethodCallDynamic { target, .. } => count_whatever(target),
+        Expr::CallOn { target, .. } => {
+            // Only the *target* of an invocation curries. A Whatever passed as a
+            // call *argument* (`$sub(*)`, `&infix:<+>(*, 42)`) is a Whatever value
+            // handed to the callee, NOT a placeholder of the enclosing
+            // WhateverCode — so it must not add to the arity. This mirrors
+            // `contains_whatever`, which already only inspects the target.
+            count_whatever(target)
+        }
+        // Only check target, not index (subscript handles its own WhateverCode)
+        Expr::Index { target, .. } => count_whatever(target),
+        // User-defined infix operators
+        Expr::InfixFunc { left, right, .. } => {
+            count_whatever(left) + right.iter().map(count_whatever).sum::<usize>()
+        }
+        // R/X/Z meta-operators. R always curries on a Whatever operand; X/Z
+        // currying is decided at parse time in `container.rs` (a standalone `*`
+        // operand curries, a trailing `*` in a comma-list operand extends), but
+        // once the decision to wrap is made we must count placeholders here so
+        // the WhateverCode gets the right arity.
+        Expr::MetaOp {
+            meta, left, right, ..
+        } if matches!(meta.as_str(), "R" | "X" | "Z") => {
+            count_whatever(left) + count_whatever(right)
+        }
+        _ => 0,
+    }
+}
+
+/// Structural equality of two expressions, used to detect the shared middle
+/// term of an expanded chained comparison (`a OP m OP b` => `(a OP m) && (m OP
+/// b)`). `Expr` cannot derive `PartialEq` (it embeds `Value`), and this only runs
+/// while wrapping a WhateverCode, so a `Debug`-string comparison is sufficient.
+pub(crate) fn exprs_structurally_eq(a: &Expr, b: &Expr) -> bool {
+    format!("{a:?}") == format!("{b:?}")
+}
+
+/// Check if an expression contains a reference to $_ (the topic variable).
+/// Used to determine whether a WhateverCode lambda should avoid using $_ as its param.
+pub(crate) fn expr_contains_topic(expr: &Expr) -> bool {
+    match expr {
+        Expr::Var(name) if name == "_" => true,
+        Expr::Whatever | Expr::WhateverArg => false,
+        Expr::WhateverCurry(inner) => expr_contains_topic(inner),
+        Expr::Binary { left, right, .. } => expr_contains_topic(left) || expr_contains_topic(right),
+        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => expr_contains_topic(expr),
+        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
+            expr_contains_topic(target) || args.iter().any(expr_contains_topic)
+        }
+        Expr::CallOn { target, args } => {
+            expr_contains_topic(target) || args.iter().any(expr_contains_topic)
+        }
+        Expr::Index { target, index, .. } => {
+            expr_contains_topic(target) || expr_contains_topic(index)
+        }
+        Expr::InfixFunc { left, right, .. } => {
+            expr_contains_topic(left) || right.iter().any(expr_contains_topic)
+        }
+        Expr::MetaOp { left, right, .. } => expr_contains_topic(left) || expr_contains_topic(right),
+        _ => false,
+    }
+}

--- a/src/whatever_curry/mod.rs
+++ b/src/whatever_curry/mod.rs
@@ -1,0 +1,30 @@
+//! WhateverCode closure construction (ADR-0033).
+//!
+//! Historically mutsu built the `Lambda` / `AnonSubParams { is_whatever_code:
+//! true, .. }` closure eagerly in the parser, at the same site that decided
+//! *whether* to curry (`should_wrap_whatevercode` / `contains_whatever` in
+//! `crate::parser::expr::whatever`). That destroyed the pre-curry expression
+//! before any later consumer (RakuAST, `.DEPARSE`, error messages) could see
+//! it.
+//!
+//! ADR-0033 splits this into two steps: the parser still decides the priming
+//! *scope* (unchanged in Phase 1 — see `docs/adr/0033-whatever-priming-leaf-and-derived-scope.md`),
+//! but instead of building the closure on the spot it wraps the un-curried
+//! body in the marker node `Expr::WhateverCurry`. The actual closure
+//! construction — everything that used to live in
+//! `src/parser/expr/whatever_wrap.rs` / `whatever_replace.rs` — moves here,
+//! parser-independent, and is invoked from exactly one place:
+//! `Compiler::compile_expr`'s `Expr::WhateverCurry` arm. This is the module
+//! `src/rakuast/lower.rs`'s future `plant()` re-deriver will also depend on
+//! (Phase 3/4), which is why it lives at the crate root rather than under
+//! `src/parser/`.
+//!
+//! Phase 1 (this module's initial shape) is a pure relocation: `build_closure`
+//! is byte-for-byte the old `wrap_whatevercode`, and the parser's ~50 call
+//! sites now construct `Expr::WhateverCurry` instead of calling it directly.
+//! No runtime behaviour changes.
+
+mod build;
+mod replace;
+
+pub(crate) use build::{build_closure, make_wc_param};

--- a/src/whatever_curry/replace.rs
+++ b/src/whatever_curry/replace.rs
@@ -1,18 +1,29 @@
 //! WhateverCode body construction: replacing `*` placeholders with parameter
-//! variables (numbered or single `$_`) and renaming variables when inlining
-//! nested WhateverCode closures.
+//! variables (numbered or single `$_`).
+//!
+//! A nested, already-planted `Expr::WhateverCurry` operand (e.g. `(* - 1)`
+//! inside `(* - 1) - 1`) is inlined by recursing straight into its un-curried
+//! body — since that body still has literal `Expr::Whatever` placeholders (not
+//! yet turned into `$_`/`__wc_N` variables), no renaming pass is needed. This
+//! is simpler than the pre-ADR-0033 code, which had to unwrap an
+//! already-built `Lambda`/`AnonSubParams` closure and rename its parameter(s)
+//! to fit the enclosing numbering scheme.
 
-use super::*;
+use super::build::{count_whatever, exprs_structurally_eq};
+use crate::ast::Expr;
+use crate::parser::is_whatever;
+use crate::token_kind::TokenKind;
 
 /// Replace Whatever expressions with numbered parameter variables.
 /// `counter` tracks the next parameter index to assign.
 pub(crate) fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Expr {
     match expr {
         e if is_whatever(e) => {
-            let var_name = format!("__wc_{}", counter);
+            let var_name = format!("__wc_{counter}");
             *counter += 1;
             Expr::Var(var_name)
         }
+        Expr::WhateverCurry(inner) => replace_whatever_numbered(inner, counter),
         Expr::Binary {
             left,
             op: TokenKind::AndAnd,
@@ -59,37 +70,6 @@ pub(crate) fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Exp
                 op: TokenKind::AndAnd,
                 right: Box::new(replace_whatever_numbered(right, counter)),
             }
-        }
-        // Unwrap a nested WhateverCode lambda: reuse its body with renumbered params
-        Expr::Lambda { param, body, .. } if param == "_" => {
-            // Single-param WhateverCode: rename $_ to the next numbered param
-            let var_name = format!("__wc_{}", counter);
-            *counter += 1;
-            if let Some(Stmt::Expr(e)) = body.first() {
-                rename_var(e, "_", &var_name)
-            } else {
-                Expr::Var(var_name)
-            }
-        }
-        Expr::AnonSubParams { params, body, .. }
-            if params.iter().all(|p| p.starts_with("__wc_")) =>
-        {
-            // Multi-param WhateverCode: renumber all params
-            let mut renames = Vec::new();
-            for old_name in params {
-                let new_name = format!("__wc_{}", counter);
-                *counter += 1;
-                renames.push((old_name.clone(), new_name));
-            }
-            let mut body_expr = if let Some(Stmt::Expr(e)) = body.first() {
-                e.clone()
-            } else {
-                return expr.clone();
-            };
-            for (old, new) in &renames {
-                body_expr = rename_var(&body_expr, old, new);
-            }
-            body_expr
         }
         // SmartMatch: only replace Whatever on LHS; RHS is handled at runtime.
         Expr::Binary {
@@ -211,103 +191,11 @@ pub(crate) fn replace_whatever_numbered(expr: &Expr, counter: &mut usize) -> Exp
     }
 }
 
-/// Rename a variable in an expression tree.
-fn rename_var(expr: &Expr, old_name: &str, new_name: &str) -> Expr {
-    match expr {
-        Expr::Var(name) if name == old_name => Expr::Var(new_name.to_string()),
-        Expr::Binary { left, op, right } => Expr::Binary {
-            left: Box::new(rename_var(left, old_name, new_name)),
-            op: op.clone(),
-            right: Box::new(rename_var(right, old_name, new_name)),
-        },
-        Expr::Unary { op, expr } => Expr::Unary {
-            op: op.clone(),
-            expr: Box::new(rename_var(expr, old_name, new_name)),
-        },
-        Expr::PostfixOp { op, expr } => Expr::PostfixOp {
-            op: op.clone(),
-            expr: Box::new(rename_var(expr, old_name, new_name)),
-        },
-        Expr::MethodCall {
-            target,
-            name,
-            args,
-            modifier,
-            quoted,
-        } => Expr::MethodCall {
-            target: Box::new(rename_var(target, old_name, new_name)),
-            name: *name,
-            args: args
-                .iter()
-                .map(|a| rename_var(a, old_name, new_name))
-                .collect(),
-            modifier: *modifier,
-            quoted: *quoted,
-        },
-        Expr::HyperMethodCall {
-            target,
-            name,
-            args,
-            modifier,
-            quoted,
-        } => Expr::HyperMethodCall {
-            target: Box::new(rename_var(target, old_name, new_name)),
-            name: *name,
-            args: args
-                .iter()
-                .map(|a| rename_var(a, old_name, new_name))
-                .collect(),
-            modifier: *modifier,
-            quoted: *quoted,
-        },
-        Expr::CallOn { target, args } => Expr::CallOn {
-            target: Box::new(rename_var(target, old_name, new_name)),
-            args: args
-                .iter()
-                .map(|a| rename_var(a, old_name, new_name))
-                .collect(),
-        },
-        Expr::Index {
-            target,
-            index,
-            is_positional,
-            ..
-        } => Expr::Index {
-            target: Box::new(rename_var(target, old_name, new_name)),
-            index: Box::new(rename_var(index, old_name, new_name)),
-            is_positional: *is_positional,
-        },
-        _ => expr.clone(),
-    }
-}
-
 /// Replace Whatever and nested single-arg WhateverCode with $_ (for single-arg wrapping).
 pub(crate) fn replace_whatever_single(expr: &Expr) -> Expr {
     match expr {
         e if is_whatever(e) => Expr::Var("_".to_string()),
-        // A nested single-arg WhateverCode: unwrap and reuse body (already uses $_)
-        Expr::Lambda { param, body, .. } if param == "_" => {
-            if let Some(Stmt::Expr(e)) = body.first() {
-                e.clone()
-            } else {
-                Expr::Var("_".to_string())
-            }
-        }
-        // A nested single-param WhateverCode built as AnonSubParams (its body
-        // referenced $_, so it uses a numbered param): rename that param to $_
-        // so it shares the composed closure's single topic.
-        Expr::AnonSubParams {
-            params,
-            body,
-            is_whatever_code: true,
-            ..
-        } if params.len() == 1 => {
-            if let Some(Stmt::Expr(e)) = body.first() {
-                rename_var(e, &params[0], "_")
-            } else {
-                Expr::Var("_".to_string())
-            }
-        }
+        Expr::WhateverCurry(inner) => replace_whatever_single(inner),
         // SmartMatch: only replace Whatever on LHS; RHS is handled at runtime.
         Expr::Binary {
             left,

--- a/todo/deep/rakuast-remaining.md
+++ b/todo/deep/rakuast-remaining.md
@@ -52,7 +52,8 @@ an explicit design:
 - `constant`
 - associative subscripts
 - `CATCH` blocks
-- WhateverCode such as `* + 1` — **designed, see
+- WhateverCode such as `* + 1` — **Phase 1 (deferral) shipped, Phases 2-4 (RakuAST
+  read/write, thunk-barrier correctness fix) not started — see
   [ADR-0033](../../docs/adr/0033-whatever-priming-leaf-and-derived-scope.md)**
 - code-block interpolation
 - regexes
@@ -61,7 +62,7 @@ Pick these deliberately by user impact rather than treating them as another
 cadence of mechanical slices. Lower through the existing internal AST and
 compiler; do not add a second execution engine.
 
-### Designed: WhateverCode (ADR-0033)
+### Designed, Phase 1 shipped: WhateverCode (ADR-0033)
 
 `* + 1` was picked first because it is the highest-frequency construct on the list
 (`.map(* + 1)`, `.grep(* > 3)`, `@a[* - 1]`) and because investigating it surfaced a
@@ -77,6 +78,14 @@ Rakudo's model — a leaf split (`Expr::Whatever` value vs `Expr::WhateverArg` a
 an `Expr::WhateverCurry` scope marker, closure construction moved to the compiler, and a
 single `whatever_curry::plant` shared by the parser and `rakuast::lower` — in four
 phases, the first of which is behaviour-preserving.
+
+Phase 1 (the behaviour-preserving deferral) shipped 2026-08-19: `src/whatever_curry/`
+now owns closure construction, invoked from a single `Expr::WhateverCurry` compiler arm;
+the parser's ~50 `wrap_whatevercode` call sites construct that marker instead of building
+the closure eagerly, verified zero-behaviour-change against the full `t/` + targeted
+roast suites. `Q[* + 1].AST` still errors and the thunky-operator priming bug is still
+live — those are Phases 2-4, not started. See the ADR's own Outcome section for the full
+list of latent-bug fixes this deferral surfaced along the way.
 
 The remaining items on both lists above are still undesigned.
 


### PR DESCRIPTION
## Summary

Implements **Phase 1** of [ADR-0033](docs/adr/0033-whatever-priming-leaf-and-derived-scope.md) — a behaviour-preserving deferral that moves `WhateverCode` closure construction (`* + 1`, `.grep(* > 3)`, `@a[* - 1]`, ...) out of the parser's ~50 eager `wrap_whatevercode()` call sites and into the compiler.

- Adds `Expr::WhateverArg` (not yet produced — Phase 2's leaf-splitting work) and `Expr::WhateverCurry` (a marker wrapping a maximal priming scope's un-curried body).
- Every parser site that used to call `wrap_whatevercode(&e)` now constructs `Expr::WhateverCurry(Box::new(e))` instead. `should_wrap_whatevercode`/`contains_whatever` (the priming-scope decision) are byte-for-byte unchanged.
- Closure construction (`build_closure`, formerly `wrap_whatevercode`; `replace_whatever_*`; `count_whatever`) moved to a new parser-independent module `src/whatever_curry/`, invoked from exactly one place: a new `Expr::WhateverCurry` arm in `Compiler::compile_expr`. Emitted bytecode is unchanged.

**Two genuine pre-existing bugs found and fixed** while sweeping every site that pattern-matched the *eagerly built* closure shape to detect "this subtree is already a WhateverCode":
- `crate::ast::collect_ph_expr_shallow` (placeholder-order collector) undercounted a nested WhateverCurry's hoisted `$^name` arity by one (reproduced via the YAMLish battery's `flatten-tags` helper).
- The expression-context `:=` bind fast path and its `X::Bind::Slice` throw missed a Whatever-index bind (`@a[*-1] := 42`), silently taking the valid-bind path instead of throwing.

About a dozen other diagnostic/validation/fast-path sites (placeholder collection, sink-context scanning, `whenever`-scope checks, statement-modifier detection, attribute-twigil validation, private-access validation, `subset ... where <WhateverCode>` predicate dispatch, `cas($var, * + delta)` atomic-add fast path, closure-escape detection) got a defensive `Expr::WhateverCurry` arm for consistency — none change observable behaviour vs `main`.

**Out of scope (deliberately):** Phases 2-4 — RakuAST `.AST` support for `* + 1`, and the thunk-barrier correctness fix for `(* > 3 && * < 8).arity` / `.grep(* > 3 && * < 8)` — are separate, higher-risk follow-up PRs per the ADR's own phasing ("each phase is independently shippable"). See the ADR's new Outcome section.

## Test plan

- [x] `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings` clean
- [x] `cargo test --workspace` green (852 lib tests + all integration test binaries, incl. `gc_stress`, `jit_diff`, `lazy_match_no_eager_materialization`)
- [x] Full `t/` TAP suite (3255 files) green, apart from the pre-existing, already-ticketed local-only `t/autoviv-index-guard.t` hang (`todo/tickets/autoviv-index-guard-hangs-locally.md`, confirmed unrelated to this branch)
- [x] `t/*whatever*.t` (35 files, 353 tests) green
- [x] `roast/S02-types/whatever.t`, `roast/S02-types/hyperwhatever.t`, `roast/S03-operators/composition.t` green
- [x] `roast/S12-subset/{multi-dispatch,subtypes,type-subset}.t` green (subset `where <WhateverCode>` predicate path)
- [x] ADR-0033 Status/Outcome updated; `todo/deep/rakuast-remaining.md` updated to reflect Phase 1 shipped
- [ ] CI (`make test` + `make roast`) — watching in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)