### PR TITLE
fix(ci): name every spawned thread, stop retrying crashes, surface reports on green runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,15 @@ jobs:
         # some temp directory this step never looks at. Verified: with the
         # relative default, a `run(..., :cwd(...))` child's report lands under
         # that cwd instead.
-        if: failure()
+        #
+        # `always()` (not `failure()`): a report can exist on an otherwise
+        # green job -- a deliberately-provoked subprocess crash a test
+        # asserts on (see the allowlist in report-crash-reports.sh), or,
+        # before this existed, a genuine crash whose job still passed. The
+        # script itself now fails the job when a report is NOT on that
+        # allowlist, so this step is where an unexpected crash actually
+        # surfaces (todo/deep/procasync-stress-segv.md).
+        if: always()
         run: scripts/report-crash-reports.sh
 
       - name: Upload roast log
@@ -658,7 +666,9 @@ jobs:
           echo "No GC verify violations across the suite."
 
       - name: Crash reports (fatal signals, GC on)
-        if: failure()
+        # `always()`, not `failure()` -- see the "Crash reports (fatal
+        # signals)" step above for why (todo/deep/procasync-stress-segv.md).
+        if: always()
         run: scripts/report-crash-reports.sh
 
       - name: Upload GC stress crash reports
@@ -773,7 +783,9 @@ jobs:
         run: scripts/report-flaky-retries.sh
 
       - name: Crash reports (fatal signals, JIT on)
-        if: failure()
+        # `always()`, not `failure()` -- see the "Crash reports (fatal
+        # signals)" step above for why (todo/deep/procasync-stress-segv.md).
+        if: always()
         run: scripts/report-crash-reports.sh
 
       - name: Upload JIT stress crash reports

--- a/docs/flaky-test-policy.md
+++ b/docs/flaky-test-policy.md
@@ -125,6 +125,26 @@ Three properties worth stating explicitly:
    `tmp/flaky-retries.log`, and CI turns that into a `::warning::` annotation
    and a job-summary table. A quarantined test whose retry count climbs is
    getting worse, and that has to be visible.
+4. **A signal death is never retried, even inside a quarantined file.**
+   `flaky-retry.sh` checks the exit code of every attempt: a process killed by
+   a signal (SIGSEGV, SIGABRT, ...) exits with `rc = 128 + signum`, so `rc >=
+   128` fails the run immediately, with a `died of signal N -- NOT retried`
+   comment, instead of re-rolling. This enforces §3's "never quarantine a
+   crash" mechanically rather than relying on nobody ever listing a crashing
+   file. Before this check existed, `roast/integration/advent2014-day05.t`
+   (already quarantined for an unrelated timing reason) aborted with SIGABRT
+   from heap corruption, was silently retried, and the retry happened to pass
+   — a genuine memory-safety bug reached a green CI run undetected
+   (`todo/deep/procasync-stress-segv.md`). A companion allowlist in
+   `scripts/report-crash-reports.sh` catches the same class of bug even
+   *outside* a quarantined file's own process: that script now fails the job
+   whenever a crash report's `argv:` is not on a short list of known,
+   deliberately-provoked crashes (e.g. `roast/S29-os/system.t`'s
+   `NativeCall`/`strdup(0)` probe), and it now runs on every job (`if:
+   always()` in `ci.yml`) rather than only on an already-failing one — a
+   deliberately-crashed *subprocess* a test asserts on can otherwise leave the
+   overall job green while an unrelated genuine crash goes unnoticed the same
+   way.
 
 ## 5. Keeping the ledger honest
 

--- a/scripts/flaky-retry.sh
+++ b/scripts/flaky-retry.sh
@@ -56,6 +56,22 @@ while :; do
     printf '%s\n' "$output"
     exit 0
   fi
+  # A process killed by a signal (SIGSEGV, SIGABRT, ...) exits with
+  # rc = 128 + signum, so rc >= 128 means the interpreter crashed rather
+  # than merely failing an assertion. flaky-tests.txt's own preamble says
+  # "Crashes ... are never quarantined; they are bugs to fix" -- retrying
+  # a crash would silently launder memory-unsafety into a green run (see
+  # todo/deep/procasync-stress-segv.md). Fail immediately, never retry.
+  if [ $rc -ge 128 ]; then
+    mkdir -p "$(dirname "$FLAKY_RETRY_LOG")" 2>/dev/null
+    printf '%s attempt %d/%d died of signal %d (rc=%d) -- NOT retried\n' \
+      "$test_file" "$attempt" "$FLAKY_MAX_ATTEMPTS" "$((rc - 128))" "$rc" \
+      >> "$FLAKY_RETRY_LOG"
+    printf '# flaky-retry: %s died of signal %d -- NOT retried (see docs/flaky-test-policy.md)\n' \
+      "$test_file" "$((rc - 128))"
+    printf '%s\n' "$output"
+    exit $rc
+  fi
   mkdir -p "$(dirname "$FLAKY_RETRY_LOG")" 2>/dev/null
   printf '%s attempt %d/%d failed (rc=%d)\n' \
     "$test_file" "$attempt" "$FLAKY_MAX_ATTEMPTS" "$rc" >> "$FLAKY_RETRY_LOG"

--- a/scripts/report-crash-reports.sh
+++ b/scripts/report-crash-reports.sh
@@ -10,14 +10,34 @@
 #
 # A crash rare enough to appear once in several dozen CI runs has to yield its
 # evidence the one time it fires, so this prints every report into the job log
-# in addition to the artifact upload alongside it.
-#
-# Always exits 0: the crash itself has already failed the job that produced it.
+# in addition to the artifact upload alongside it. This step now runs with
+# `if: always()` (not just `if: failure()`), because a crash can happen inside
+# a subprocess a test deliberately provokes (see the allowlist below) while
+# the job that spawned it still goes green overall -- that combination is
+# exactly what buried the genuine `advent2014-day05.t` heap-corruption crash
+# for 19 days (todo/deep/procasync-stress-segv.md). So this script now FAILS
+# the job itself when it finds a report whose `argv:` is not on the
+# allowlist, instead of unconditionally exiting 0 -- a fatal signal outside a
+# handful of tests that deliberately trigger one is never expected, crash or
+# no other failure in the job.
 
 set -uo pipefail
 shopt -s nullglob
 
 DIR="${MUTSU_CRASH_DIR:-tmp/crash}"
+
+# Reports whose `argv:` CONTAINS one of these substrings are known,
+# deliberate crashes a test provokes on purpose (and asserts the resulting
+# behavior on) -- not evidence of a real bug. Keep this list small and add an
+# entry only when a specific test is documented to crash a subprocess on
+# purpose.
+ALLOWLISTED_ARGV_SUBSTRINGS=(
+  # roast/S29-os/system.t: "Exit with a segfault makes the Proc throw in
+  # sink context" -- rakudo#3149. Deliberately calls strdup(0) via
+  # NativeCall to segfault a spawned mutsu subprocess and asserts that the
+  # parent's `run()` reports it as X::Proc::Unsuccessful.
+  "-e use NativeCall; sub strdup(int64) is native(Str) {*}; strdup(0)"
+)
 
 reports=("$DIR"/*.txt)
 if [ ${#reports[@]} -eq 0 ]; then
@@ -27,10 +47,25 @@ fi
 
 echo "::error::${#reports[@]} mutsu process(es) died of a fatal signal. Reports below and in the crash-reports artifact."
 
+unexpected=0
 for f in "${reports[@]}"; do
   echo "::group::$f"
   cat "$f"
   echo "::endgroup::"
+
+  argv=$(sed -n 's/^argv: //p' "$f" | head -1)
+  allowlisted=0
+  for needle in "${ALLOWLISTED_ARGV_SUBSTRINGS[@]}"; do
+    case "$argv" in
+      *"$needle"*) allowlisted=1; break ;;
+    esac
+  done
+  if [ "$allowlisted" -eq 1 ]; then
+    echo "  -> known deliberate crash (argv matches the allowlist), not treated as a failure."
+  else
+    echo "::error::$(basename "$f") is NOT on the allowlist -- treating as a real, unexpected crash."
+    unexpected=$((unexpected + 1))
+  fi
 done
 
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
@@ -49,5 +84,20 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "Full reports are in the job log above and the \`crash-reports\` artifact."
     echo "Release builds carry no line tables, so resolve raw frames with"
     echo "\`addr2line -f -e target/release/mutsu <address>\`."
+    if [ "$unexpected" -gt 0 ]; then
+      echo
+      echo "**$unexpected report(s) are NOT on the allowlist in this script and were"
+      echo "treated as a real failure.** If a report is actually a known, deliberate"
+      echo "crash a test provokes on purpose, add its \`argv:\` substring to"
+      echo "\`ALLOWLISTED_ARGV_SUBSTRINGS\` in \`scripts/report-crash-reports.sh\`."
+    fi
   } >> "$GITHUB_STEP_SUMMARY"
 fi
+
+if [ "$unexpected" -gt 0 ]; then
+  echo "::error::$unexpected crash report(s) are not on the allowlist -- failing this step."
+  exit 1
+fi
+
+echo "All ${#reports[@]} crash report(s) match the allowlist (deliberate, expected crashes) -- not failing the job."
+exit 0

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,9 @@ fn main() {
     // recursion (each Raku-level call consumes a sizeable native frame, so
     // realistic recursive code — e.g. File::Directory::Tree's rmtree over a
     // 120-deep directory tree — needs far more than the default 8MB).
-    let builder = std::thread::Builder::new().stack_size(256 * 1024 * 1024);
+    let builder = std::thread::Builder::new()
+        .name("mutsu-main".to_string())
+        .stack_size(256 * 1024 * 1024);
     let handler = builder
         .spawn(run_main)
         .expect("failed to spawn main thread");

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -9,13 +9,18 @@ use std::sync::OnceLock;
 pub(crate) const USER_THREAD_STACK_SIZE: usize = 256 * 1024 * 1024;
 
 /// Spawn a worker thread with a large stack for running user code, so deep VM
-/// recursion does not overflow the default thread stack.
-pub(crate) fn spawn_user_thread<F, T>(f: F) -> crate::runtime::thread_compat::JoinHandle<T>
+/// recursion does not overflow the default thread stack. `name` becomes the
+/// OS thread name (see `thread_compat::spawn_thread`), so pick something that
+/// identifies the call site in a crash report's `thread:` field.
+pub(crate) fn spawn_user_thread<F, T>(
+    name: &str,
+    f: F,
+) -> crate::runtime::thread_compat::JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    spawn_registered_thread(Some(USER_THREAD_STACK_SIZE), f)
+    spawn_registered_thread(name, Some(USER_THREAD_STACK_SIZE), f)
 }
 
 /// Spawn a runtime service thread (timer, promise combinator, socket
@@ -32,15 +37,19 @@ where
 /// collect). Long blocking waits inside the closure (sleeps, blocking reads)
 /// must be wrapped in `gc::block_quiescent` so the thread does not starve the
 /// stop-the-world rendezvous.
-pub(crate) fn spawn_gc_helper_thread<F, T>(f: F) -> crate::runtime::thread_compat::JoinHandle<T>
+pub(crate) fn spawn_gc_helper_thread<F, T>(
+    name: &str,
+    f: F,
+) -> crate::runtime::thread_compat::JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    spawn_registered_thread(None, f)
+    spawn_registered_thread(name, None, f)
 }
 
 fn spawn_registered_thread<F, T>(
+    name: &str,
     stack_size: Option<usize>,
     f: F,
 ) -> crate::runtime::thread_compat::JoinHandle<T>
@@ -59,7 +68,7 @@ where
     // without this a spawn burst starves every stop-the-world attempt — see
     // `gc::stw::preregister_worker_quiescent`.
     crate::gc::preregister_worker_quiescent();
-    crate::runtime::thread_compat::spawn_thread(stack_size, move || {
+    crate::runtime::thread_compat::spawn_thread(name, stack_size, move || {
         struct WorkerGuard;
         impl Drop for WorkerGuard {
             fn drop(&mut self) {

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -398,7 +398,7 @@ impl Interpreter {
         // the VM -- HTTP::Server::Tiny). See `USER_THREAD_STACK_SIZE`.
         // Deliberately NOT pooled (ADR-0020 §3.6): a `Thread.start` thread has
         // user-visible identity (`$*THREAD.id`) stable for its whole lifetime.
-        let handle = crate::runtime::builtins_system::spawn_user_thread(move || {
+        let handle = crate::runtime::builtins_system::spawn_user_thread("raku-thread", move || {
             // Set the mutsu thread ID for $*THREAD.id consistency
             super::set_current_mutsu_thread_id(mutsu_tid);
             match thread_interp.call_sub_value(block, vec![], false) {

--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -248,7 +248,7 @@ impl Interpreter {
             // Registered spawn: `p.wait()` clones arbitrary result `Value`s
             // and the thread drops its promise handles at exit (the waits
             // themselves are already STW-aware / quiescent).
-            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+            crate::runtime::builtins_system::spawn_gc_helper_thread("promise-comb", move || {
                 for p in &promises {
                     p.wait();
                 }

--- a/src/runtime/native_io/native_io_path.rs
+++ b/src/runtime/native_io/native_io_path.rs
@@ -295,7 +295,7 @@ impl Interpreter {
                 // Registered spawn (emits `Value`s into a supply channel);
                 // the poll sleep is a quiescent safe region — see
                 // `spawn_gc_helper_thread`.
-                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+                crate::runtime::builtins_system::spawn_gc_helper_thread("io-path", move || {
                     let poll_interval = std::time::Duration::from_millis(10);
                     let mut last_state = fs::metadata(&watched_path).ok().map(|meta| {
                         let modified = meta

--- a/src/runtime/native_methods/interval_timer.rs
+++ b/src/runtime/native_methods/interval_timer.rs
@@ -70,7 +70,7 @@ fn timer_state() -> &'static TimerState {
         // clone/drop `Gc` values (a kept promise handle), so the driver is a
         // registered GC mutator; it parks quiescent while waiting.
         #[cfg(not(target_arch = "wasm32"))]
-        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+        crate::runtime::builtins_system::spawn_gc_helper_thread("timer", move || {
             let (heap, cvar) = state;
             let mut guard = heap.lock().unwrap();
             loop {

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -384,7 +384,7 @@ impl Interpreter {
                 // Registered spawn: it builds `Gc` values (the connection
                 // Instance) whose drop on a failed send must not race a cycle
                 // scan; the poll sleep is a quiescent safe region.
-                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+                crate::runtime::builtins_system::spawn_gc_helper_thread("sock-async", move || {
                     // Use a short timeout on accept so we can check the closed flag
                     // TcpListener doesn't have set_timeout, so we use non-blocking + sleep
                     let _ = tcp_listener.set_nonblocking(true);

--- a/src/runtime/native_methods/socket_async_conn.rs
+++ b/src/runtime/native_methods/socket_async_conn.rs
@@ -182,7 +182,7 @@ impl Interpreter {
                 // Registered spawn: emits freshly built `Gc` values (Buf
                 // instances) whose drops on a failed send must not race a
                 // cycle scan; the blocking read is a quiescent safe region.
-                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+                crate::runtime::builtins_system::spawn_gc_helper_thread("sock-conn", move || {
                     use std::io::Read;
                     let mut buf = [0u8; 4096];
                     // Text mode carries decoding state across reads: TCP splits

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -399,44 +399,48 @@ impl Interpreter {
                         // must be a registered GC mutator, with the blocking
                         // recv as a quiescent safe region. Runs no user VM
                         // code, so the default stack suffices.
-                        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
-                            if let Some(rx) = take_supply_channel(source_supply_id) {
-                                while let Ok(event) = crate::gc::block_quiescent(|| rx.recv()) {
-                                    match event {
-                                        SupplyEvent::Emit(value) => {
+                        crate::runtime::builtins_system::spawn_gc_helper_thread(
+                            "proc-in",
+                            move || {
+                                if let Some(rx) = take_supply_channel(source_supply_id) {
+                                    while let Ok(event) = crate::gc::block_quiescent(|| rx.recv()) {
+                                        match event {
+                                            SupplyEvent::Emit(value) => {
+                                                if let Ok(mut guard) = stdin_arc.lock()
+                                                    && let Some(ref mut stdin) = *guard
+                                                {
+                                                    let _ = stdin.write_all(
+                                                        value.to_string_value().as_bytes(),
+                                                    );
+                                                    let _ = stdin.flush();
+                                                }
+                                            }
+                                            SupplyEvent::Done | SupplyEvent::Quit(_) => break,
+                                        }
+                                    }
+                                } else {
+                                    loop {
+                                        if let Some(collected) =
+                                            get_supply_collected_output(source_supply_id)
+                                        {
                                             if let Ok(mut guard) = stdin_arc.lock()
                                                 && let Some(ref mut stdin) = *guard
                                             {
-                                                let _ = stdin
-                                                    .write_all(value.to_string_value().as_bytes());
+                                                let _ = stdin.write_all(collected.as_bytes());
                                                 let _ = stdin.flush();
                                             }
+                                            break;
                                         }
-                                        SupplyEvent::Done | SupplyEvent::Quit(_) => break,
+                                        crate::gc::block_quiescent(|| {
+                                            std::thread::sleep(std::time::Duration::from_millis(10))
+                                        });
                                     }
                                 }
-                            } else {
-                                loop {
-                                    if let Some(collected) =
-                                        get_supply_collected_output(source_supply_id)
-                                    {
-                                        if let Ok(mut guard) = stdin_arc.lock()
-                                            && let Some(ref mut stdin) = *guard
-                                        {
-                                            let _ = stdin.write_all(collected.as_bytes());
-                                            let _ = stdin.flush();
-                                        }
-                                        break;
-                                    }
-                                    crate::gc::block_quiescent(|| {
-                                        std::thread::sleep(std::time::Duration::from_millis(10))
-                                    });
+                                if let Ok(mut guard) = stdin_arc.lock() {
+                                    *guard = None;
                                 }
-                            }
-                            if let Ok(mut guard) = stdin_arc.lock() {
-                                *guard = None;
-                            }
-                        });
+                            },
+                        );
                     }
                 }
 
@@ -555,7 +559,7 @@ impl Interpreter {
                 // registered GC mutator; its child-wait / joins are quiescent.
                 // Runs no user VM code (`keep` dispatches waiters to a fresh
                 // user thread), so the default stack suffices.
-                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+                crate::runtime::builtins_system::spawn_gc_helper_thread("proc-wait", move || {
                     // Spawn stdout reader thread — streams raw chunks through channel
                     let stdout_handle = child_stdout.map(|stdout| {
                         let tx = stdout_channel;
@@ -564,60 +568,63 @@ impl Interpreter {
                         // Emits Buf `Value`s (Gc nodes): registered mutator,
                         // pipe reads quiescent. No user VM code — default
                         // stack.
-                        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
-                            use std::io::Read;
-                            let mut stdout = stdout;
-                            let mut collected = String::new();
-                            let mut raw: Vec<u8> = Vec::new();
-                            let mut buf = [0u8; 4096];
-                            let mut pending: Vec<u8> = Vec::new();
-                            let mut held_cr = false;
-                            let mut quit = false;
-                            loop {
-                                match crate::gc::block_quiescent(|| stdout.read(&mut buf)) {
-                                    Ok(0) => break,
-                                    Ok(n) => {
-                                        raw.extend_from_slice(&buf[..n]);
-                                        if bin_mode {
-                                            if let Some(ref tx) = tx {
-                                                let buf_val = make_buf_value(&buf[..n]);
-                                                let _ = tx.send(SupplyEvent::Emit(buf_val));
+                        crate::runtime::builtins_system::spawn_gc_helper_thread(
+                            "proc-out",
+                            move || {
+                                use std::io::Read;
+                                let mut stdout = stdout;
+                                let mut collected = String::new();
+                                let mut raw: Vec<u8> = Vec::new();
+                                let mut buf = [0u8; 4096];
+                                let mut pending: Vec<u8> = Vec::new();
+                                let mut held_cr = false;
+                                let mut quit = false;
+                                loop {
+                                    match crate::gc::block_quiescent(|| stdout.read(&mut buf)) {
+                                        Ok(0) => break,
+                                        Ok(n) => {
+                                            raw.extend_from_slice(&buf[..n]);
+                                            if bin_mode {
+                                                if let Some(ref tx) = tx {
+                                                    let buf_val = make_buf_value(&buf[..n]);
+                                                    let _ = tx.send(SupplyEvent::Emit(buf_val));
+                                                }
+                                            } else if feed_utf8_incremental(
+                                                &mut pending,
+                                                &buf[..n],
+                                                &tx,
+                                                &mut collected,
+                                                true,
+                                                &mut held_cr,
+                                            ) {
+                                                if let Some(ref tx) = tx {
+                                                    let _ = tx.send(SupplyEvent::Quit(
+                                                        malformed_utf8_quit_value(),
+                                                    ));
+                                                }
+                                                quit = true;
+                                                break;
                                             }
-                                        } else if feed_utf8_incremental(
-                                            &mut pending,
-                                            &buf[..n],
-                                            &tx,
-                                            &mut collected,
-                                            true,
-                                            &mut held_cr,
-                                        ) {
-                                            if let Some(ref tx) = tx {
-                                                let _ = tx.send(SupplyEvent::Quit(
-                                                    malformed_utf8_quit_value(),
-                                                ));
-                                            }
-                                            quit = true;
-                                            break;
                                         }
+                                        Err(_) => break,
                                     }
-                                    Err(_) => break,
                                 }
-                            }
-                            if !quit {
-                                flush_held_cr(held_cr, &tx, &mut collected);
-                                if let Some(ref tx) = tx {
-                                    let _ = tx.send(SupplyEvent::Done);
+                                if !quit {
+                                    flush_held_cr(held_cr, &tx, &mut collected);
+                                    if let Some(ref tx) = tx {
+                                        let _ = tx.send(SupplyEvent::Done);
+                                    }
                                 }
-                            }
-                            // Retain the raw bytes so the await-time replay can
-                            // decode them with the stream's effective encoding
-                            // (the channel/`collected` path above only handles the
-                            // default UTF-8 case).
-                            if let Some(sid) = sid {
-                                set_supply_collected_bytes(sid, raw);
-                            }
-                            collected
-                        })
+                                // Retain the raw bytes so the await-time replay can
+                                // decode them with the stream's effective encoding
+                                // (the channel/`collected` path above only handles the
+                                // default UTF-8 case).
+                                if let Some(sid) = sid {
+                                    set_supply_collected_bytes(sid, raw);
+                                }
+                                collected
+                            },
+                        )
                     });
 
                     // Spawn stderr reader thread — streams raw chunks through channel
@@ -627,53 +634,56 @@ impl Interpreter {
                         let sid = stderr_supply_id;
                         // Same as the stdout reader: registered + quiescent
                         // reads, no user VM code — default stack.
-                        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
-                            use std::io::Read;
-                            let mut stderr = stderr;
-                            let mut collected = String::new();
-                            let mut raw: Vec<u8> = Vec::new();
-                            let mut buf = [0u8; 4096];
-                            let mut pending: Vec<u8> = Vec::new();
-                            let mut held_cr = false;
-                            let mut quit = false;
-                            loop {
-                                match crate::gc::block_quiescent(|| stderr.read(&mut buf)) {
-                                    Ok(0) => break,
-                                    Ok(n) => {
-                                        raw.extend_from_slice(&buf[..n]);
-                                        if bin_mode {
-                                            if let Some(ref tx) = tx {
-                                                let buf_val = make_buf_value(&buf[..n]);
-                                                let _ = tx.send(SupplyEvent::Emit(buf_val));
+                        crate::runtime::builtins_system::spawn_gc_helper_thread(
+                            "proc-err",
+                            move || {
+                                use std::io::Read;
+                                let mut stderr = stderr;
+                                let mut collected = String::new();
+                                let mut raw: Vec<u8> = Vec::new();
+                                let mut buf = [0u8; 4096];
+                                let mut pending: Vec<u8> = Vec::new();
+                                let mut held_cr = false;
+                                let mut quit = false;
+                                loop {
+                                    match crate::gc::block_quiescent(|| stderr.read(&mut buf)) {
+                                        Ok(0) => break,
+                                        Ok(n) => {
+                                            raw.extend_from_slice(&buf[..n]);
+                                            if bin_mode {
+                                                if let Some(ref tx) = tx {
+                                                    let buf_val = make_buf_value(&buf[..n]);
+                                                    let _ = tx.send(SupplyEvent::Emit(buf_val));
+                                                }
+                                            } else if feed_utf8_incremental(
+                                                &mut pending,
+                                                &buf[..n],
+                                                &tx,
+                                                &mut collected,
+                                                false,
+                                                &mut held_cr,
+                                            ) {
+                                                if let Some(ref tx) = tx {
+                                                    let _ = tx.send(SupplyEvent::Quit(
+                                                        malformed_utf8_quit_value(),
+                                                    ));
+                                                }
+                                                quit = true;
+                                                break;
                                             }
-                                        } else if feed_utf8_incremental(
-                                            &mut pending,
-                                            &buf[..n],
-                                            &tx,
-                                            &mut collected,
-                                            false,
-                                            &mut held_cr,
-                                        ) {
-                                            if let Some(ref tx) = tx {
-                                                let _ = tx.send(SupplyEvent::Quit(
-                                                    malformed_utf8_quit_value(),
-                                                ));
-                                            }
-                                            quit = true;
-                                            break;
                                         }
+                                        Err(_) => break,
                                     }
-                                    Err(_) => break,
                                 }
-                            }
-                            if !quit && let Some(ref tx) = tx {
-                                let _ = tx.send(SupplyEvent::Done);
-                            }
-                            if let Some(sid) = sid {
-                                set_supply_collected_bytes(sid, raw);
-                            }
-                            collected
-                        })
+                                if !quit && let Some(ref tx) = tx {
+                                    let _ = tx.send(SupplyEvent::Done);
+                                }
+                                if let Some(sid) = sid {
+                                    set_supply_collected_bytes(sid, raw);
+                                }
+                                collected
+                            },
+                        )
                     });
 
                     // Wait for child to exit (quiescent for the GC's STW)

--- a/src/runtime/signal_watcher.rs
+++ b/src/runtime/signal_watcher.rs
@@ -45,7 +45,7 @@ mod unix_impl {
             // quiescent safe region so the daemon never stalls a
             // stop-the-world.
             let read_fd = fds[0];
-            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+            crate::runtime::builtins_system::spawn_gc_helper_thread("signal-rd", move || {
                 signal_reader_thread(read_fd)
             });
             (fds[0], fds[1])

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -540,11 +540,15 @@ impl Interpreter {
                     let (tx, rx) =
                         crate::runtime::native_methods::supply_channel::supply_event_channel();
                     let shared_clone = shared.clone();
-                    crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
-                        let (result, _, _) = shared_clone.wait();
-                        let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Emit(result));
-                        let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Done);
-                    });
+                    crate::runtime::builtins_system::spawn_gc_helper_thread(
+                        "promise-wait",
+                        move || {
+                            let (result, _, _) = shared_clone.wait();
+                            let _ =
+                                tx.send(crate::runtime::native_methods::SupplyEvent::Emit(result));
+                            let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Done);
+                        },
+                    );
                     react_subs.push(crate::runtime::subtest::ReactSubscription {
                         receiver: Some(rx),
                         promise: Some(shared.clone()),
@@ -734,7 +738,7 @@ impl Interpreter {
             self.supply_stream_consumers
                 .split_off(stream_consumers_base),
         );
-        crate::runtime::builtins_system::spawn_user_thread(move || {
+        crate::runtime::builtins_system::spawn_user_thread("react", move || {
             // The drive loop keeps/breaks `promise` directly as it runs (see
             // `drive_react_subscriptions_inner`'s `SupplyDrivePolicy::Promise`
             // handling); its `Result` here only carries Rust-level plumbing

--- a/src/runtime/thread_compat.rs
+++ b/src/runtime/thread_compat.rs
@@ -29,13 +29,18 @@ impl<T> JoinHandle<T> {
     }
 }
 
+/// Spawn a native OS thread named `name` (truncated to 15 bytes on Linux —
+/// the `pthread_setname_np` / comm limit), so a crash report's `thread:`
+/// field can actually identify which subsystem died instead of reading the
+/// unhelpful process name for every thread. See
+/// `todo/deep/procasync-stress-segv.md` §5.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn spawn_thread<F, T>(stack_size: Option<usize>, f: F) -> JoinHandle<T>
+pub(crate) fn spawn_thread<F, T>(name: &str, stack_size: Option<usize>, f: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    let mut builder = std::thread::Builder::new();
+    let mut builder = std::thread::Builder::new().name(name.to_string());
     if let Some(size) = stack_size {
         builder = builder.stack_size(size);
     }
@@ -45,9 +50,9 @@ where
 }
 
 /// Queue `f` on the single browser thread. The stack size is meaningless here
-/// (there is one stack) and is ignored.
+/// (there is one stack) and is ignored. There is no OS thread to name.
 #[cfg(target_arch = "wasm32")]
-pub(crate) fn spawn_thread<F, T>(_stack_size: Option<usize>, f: F) -> JoinHandle<T>
+pub(crate) fn spawn_thread<F, T>(_name: &str, _stack_size: Option<usize>, f: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,

--- a/src/runtime/worker_pool.rs
+++ b/src/runtime/worker_pool.rs
@@ -74,7 +74,7 @@ mod native {
         // `enter_mutator_worker`/`preregister_worker_quiescent` on the parent,
         // `worker_started` + `WorkerGuard` (drain -> unregister -> exit) in the
         // worker. The pool adds only the per-task boundary inside `worker_loop`.
-        crate::runtime::builtins_system::spawn_user_thread(worker_loop);
+        crate::runtime::builtins_system::spawn_user_thread("pool", worker_loop);
     }
 
     fn worker_loop() {
@@ -136,7 +136,7 @@ mod native {
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn submit(task: impl FnOnce() + Send + 'static) {
     if !native::pool_enabled() {
-        crate::runtime::builtins_system::spawn_user_thread(task);
+        crate::runtime::builtins_system::spawn_user_thread("pool", task);
         return;
     }
     crate::vm::vm_stats::record_pool_task();
@@ -161,7 +161,7 @@ pub(crate) fn submit(task: impl FnOnce() + Send + 'static) {
 /// wasm32: the cooperative scheduler is already a pool of one — queue the task.
 #[cfg(target_arch = "wasm32")]
 pub(crate) fn submit(task: impl FnOnce() + Send + 'static) {
-    crate::runtime::builtins_system::spawn_user_thread(task);
+    crate::runtime::builtins_system::spawn_user_thread("pool", task);
 }
 
 /// Handle on a pooled task whose completion (and result) the spawner waits
@@ -217,6 +217,6 @@ pub(crate) fn submit_joinable<T: Send + 'static>(
     task: impl FnOnce() -> T + Send + 'static,
 ) -> TaskHandle<T> {
     TaskHandle {
-        inner: crate::runtime::builtins_system::spawn_user_thread(task),
+        inner: crate::runtime::builtins_system::spawn_user_thread("pool", task),
     }
 }

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -498,15 +498,18 @@ impl Interpreter {
                         // result `Value` and the promise handle drops at
                         // thread exit — both are `Gc` mutations that must not
                         // race a cycle scan (the wait itself is STW-aware).
-                        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
-                            let (result, _, _) = shared_clone.wait();
-                            if shared_clone.status() == "Broken" {
-                                let _ = tx.send(SupplyEvent::Quit(result));
-                            } else {
-                                let _ = tx.send(SupplyEvent::Emit(result));
-                                let _ = tx.send(SupplyEvent::Done);
-                            }
-                        });
+                        crate::runtime::builtins_system::spawn_gc_helper_thread(
+                            "promise-wait",
+                            move || {
+                                let (result, _, _) = shared_clone.wait();
+                                if shared_clone.status() == "Broken" {
+                                    let _ = tx.send(SupplyEvent::Quit(result));
+                                } else {
+                                    let _ = tx.send(SupplyEvent::Emit(result));
+                                    let _ = tx.send(SupplyEvent::Done);
+                                }
+                            },
+                        );
                         react_subs.push(ReactSubscription {
                             receiver: Some(rx),
                             promise: Some(shared.clone()),

--- a/tests/flaky_retry.rs
+++ b/tests/flaky_retry.rs
@@ -52,6 +52,61 @@ fn attempts(dir: &Path) -> u32 {
         .unwrap_or(0)
 }
 
+/// A fake test command that dies of SIGABRT on every invocation, counting
+/// invocations in `counter` before it does. Used to prove a signal death is
+/// never retried, even for a quarantined file (see
+/// `todo/deep/procasync-stress-segv.md`).
+fn write_fake_crashing_test(dir: &Path) -> PathBuf {
+    let counter = dir.join("count");
+    let script = dir.join("fake-crash.sh");
+    fs::write(
+        &script,
+        format!(
+            "#!/bin/bash\n\
+             n=$(cat '{c}' 2>/dev/null || echo 0)\n\
+             n=$((n+1)); echo $n > '{c}'\n\
+             echo '1..1'\n\
+             echo \"ok 1 - attempt $n before the crash\"\n\
+             kill -ABRT $$\n\
+             exit 1\n",
+            c = counter.display(),
+        ),
+    )
+    .expect("write fake crashing test");
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(0o755);
+    }
+    fs::set_permissions(&script, perms).unwrap();
+    script
+}
+
+/// Like `run_retry`, but spawning `write_fake_crashing_test` instead of a
+/// script parameterized by `fail_first`.
+fn run_retry_crash(dir: &Path, test_path: &str, list_body: &str) -> (String, bool, u32, i32) {
+    let script = write_fake_crashing_test(dir);
+    let list = dir.join("flaky-tests.txt");
+    fs::write(&list, list_body).expect("write ledger");
+
+    let out = Command::new(repo_root().join("scripts/flaky-retry.sh"))
+        .current_dir(repo_root())
+        .arg(test_path)
+        .arg(&script)
+        .env("FLAKY_LIST", &list)
+        .env("FLAKY_RETRY_LOG", dir.join("retries.log"))
+        .output()
+        .expect("failed to spawn flaky-retry.sh");
+
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.success(),
+        attempts(dir),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
 /// Run flaky-retry.sh for `test_path`, with `list_body` as the ledger.
 fn run_retry(dir: &Path, test_path: &str, list_body: &str, fail_first: u32) -> (String, bool, u32) {
     let script = write_fake_test(dir, fail_first);
@@ -151,6 +206,42 @@ fn quarantined_test_that_always_fails_still_fails() {
     assert!(
         stdout.contains("not ok 1"),
         "the last attempt's diagnostic output must survive, got: {stdout}"
+    );
+}
+
+/// A crash (signal death, rc >= 128) must NEVER be retried, even for a
+/// quarantined file: retrying would launder a real memory-safety bug into a
+/// green run. This is the exact bug the crash-report investigation in
+/// `todo/deep/procasync-stress-segv.md` found: `advent2014-day05.t` aborted
+/// with SIGABRT and the retry silently passed, hiding heap corruption.
+#[test]
+fn quarantined_test_that_crashes_is_not_retried() {
+    let dir = scratch("crash-not-retried");
+    let (stdout, ok, attempts, code) = run_retry_crash(
+        &dir,
+        "t/known-flaky.t",
+        "t/known-flaky.t 2026-07-24 2026-10-22 synthetic entry for the test suite\n",
+    );
+    assert!(!ok, "a signal death must fail the run, not be retried away");
+    assert_eq!(
+        attempts, 1,
+        "a crash must fail on the FIRST attempt -- no retry"
+    );
+    assert_eq!(code, 134, "SIGABRT (6) => rc = 128 + 6 = 134");
+    assert!(
+        stdout.contains("died of signal 6") && stdout.contains("NOT retried"),
+        "the crash must be called out explicitly, got: {stdout}"
+    );
+
+    let log = fs::read_to_string(dir.join("retries.log")).expect("retry log");
+    assert_eq!(
+        log.lines().count(),
+        1,
+        "exactly one log line for the single (non-retried) attempt, got: {log}"
+    );
+    assert!(
+        log.contains("died of signal 6"),
+        "the retry log must record the signal death, got: {log}"
     );
 }
 

--- a/todo/deep/procasync-stress-segv.md
+++ b/todo/deep/procasync-stress-segv.md
@@ -240,7 +240,7 @@ the single most valuable missing bit.
 
 Four slices, in priority order. All are small and none needs an ADR.
 
-1. **DONE (2026-08-19).** **Name every thread** (`src/runtime/thread_compat.rs`). Gave `spawn_thread`
+1. **DONE (2026-08-19, #6695).** **Name every thread** (`src/runtime/thread_compat.rs`). Gave `spawn_thread`
    a `name: &str` parameter, threaded through `spawn_registered_thread` / `spawn_gc_helper_thread` /
    `spawn_user_thread` and every call site: `mutsu-main`, `proc-wait`, `proc-out`, `proc-err`,
    `proc-in`, `signal-rd`, `timer`, `react`, `pool`, `sock-async`, `sock-conn`, `io-path`,
@@ -248,14 +248,14 @@ Four slices, in priority order. All are small and none needs an ADR.
    `Proc::Async` react loop shows `mutsu-main`, `proc-wait`, `proc-out`, `proc-err`, `promise-wait` as
    distinct threads instead of all reading `mutsu`. The next occurrence's `thread:` line alone now
    says whether the fault is in the reaper, a reader, the timer, the react driver, or the pool.
-2. **DONE (2026-08-19).** **Stop retrying a signal death** (`scripts/flaky-retry.sh`). After `rc=$?`,
+2. **DONE (2026-08-19, #6695).** **Stop retrying a signal death** (`scripts/flaky-retry.sh`). After `rc=$?`,
    `rc -ge 128` now exits immediately with a
    `# flaky-retry: <file> died of signal N -- NOT retried (see docs/flaky-test-policy.md)` comment,
    no retry. Enforced by `tests/flaky_retry.rs::quarantined_test_that_crashes_is_not_retried`
    (a fake SIGABRT-killing test proves it fails on the first attempt, not the third). Documented in
    `docs/flaky-test-policy.md` §4. This is exactly what would have turned §2's abort into a red CI on
    the day it happened.
-3. **DONE (2026-08-19).** **Surface crash reports on green runs** (`.github/workflows/ci.yml`). The
+3. **DONE (2026-08-19, #6695).** **Surface crash reports on green runs** (`.github/workflows/ci.yml`). The
    three "Crash reports" steps are now `if: always()`, and `scripts/report-crash-reports.sh` fails the
    job (`exit 1`) when a report's `argv:` is not on `ALLOWLISTED_ARGV_SUBSTRINGS`, which today holds
    exactly the deliberate `strdup(0)` NativeCall probe (`roast/S29-os/system.t`). Manually verified
@@ -270,7 +270,7 @@ Four slices, in priority order. All are small and none needs an ADR.
 
 ### 6. Recommended next action
 
-~~Land slices 1-3 as one small PR.~~ **Done 2026-08-19** — see §5. What remains, in order:
+~~Land slices 1-3 as one small PR.~~ **Done 2026-08-19, #6695** — see §5. What remains, in order:
 
 1. **Slice 4** (§5.4): re-measure `roast/integration/advent2014-day05.t`'s `flaky-tests.txt` entry now
    that a signal death there can no longer be silently retried away. Either it stops needing

--- a/todo/deep/procasync-stress-segv.md
+++ b/todo/deep/procasync-stress-segv.md
@@ -240,34 +240,49 @@ the single most valuable missing bit.
 
 Four slices, in priority order. All are small and none needs an ADR.
 
-1. **Name every thread** (`src/runtime/thread_compat.rs`). Give `spawn_thread` a `&'static str` and
-   pass it through `spawn_registered_thread` / `spawn_gc_helper_thread` / `spawn_user_thread`. Linux
-   truncates the comm to 15 bytes, so use short names: `mutsu-main`, `proc-wait`, `proc-out`,
-   `proc-err`, `proc-in`, `signal-rd`, `timer`, `react`, `pool`, `sock-async`, `sock-conn`,
-   `io-path`. Roughly a dozen call sites (`git grep -n 'spawn_gc_helper_thread(\|spawn_user_thread('`).
-   After this, the next occurrence's `thread:` line alone says whether the fault is in the reaper,
-   a reader, the timer, the react driver, or the pool.
-2. **Stop retrying a signal death** (`scripts/flaky-retry.sh`). After `rc=$?`, treat `rc -ge 128` as
-   fatal: log it, print the attempt's output, exit `$rc` immediately with a
-   `# flaky-retry: <file> died of signal N -- NOT retried (see docs/flaky-test-policy.md)` comment.
-   This is not a new policy, it is the enforcement of the one `flaky-tests.txt` already states.
-   Record it in `docs/flaky-test-policy.md` too. Note that this alone would have turned §2's abort
-   into a red CI on the day it happened.
-3. **Surface crash reports on green runs** (`.github/workflows/ci.yml`). Flip the three "Crash
-   reports" steps from `if: failure()` to `if: always()` so the report reaches the job log (retained
-   far longer than the 7-day artifact), and have `scripts/report-crash-reports.sh` **fail the job**
-   when a report's `argv:` is not on a small allowlist. The allowlist needs exactly one entry today:
-   the deliberate `strdup(0)` NativeCall probe (105 of the 106 reports in the window). Without that
-   filter the signal is 99% noise and nobody will ever read it — which is exactly what happened.
-4. **Re-measure the `advent2014-day05.t` quarantine.** Its `flaky-tests.txt` reason attributes the
-   failures to CPU-contention timing; §2 is hard evidence that at least one of them was heap
-   corruption. Per the ledger's own bar the entry should be pulled (or at minimum re-justified) once
-   slice 2 lands and the crash stops being invisible.
+1. **DONE (2026-08-19).** **Name every thread** (`src/runtime/thread_compat.rs`). Gave `spawn_thread`
+   a `name: &str` parameter, threaded through `spawn_registered_thread` / `spawn_gc_helper_thread` /
+   `spawn_user_thread` and every call site: `mutsu-main`, `proc-wait`, `proc-out`, `proc-err`,
+   `proc-in`, `signal-rd`, `timer`, `react`, `pool`, `sock-async`, `sock-conn`, `io-path`,
+   `promise-wait`, `promise-comb`, `raku-thread`. Verified live: `ps -eLo pid,tid,comm` on a running
+   `Proc::Async` react loop shows `mutsu-main`, `proc-wait`, `proc-out`, `proc-err`, `promise-wait` as
+   distinct threads instead of all reading `mutsu`. The next occurrence's `thread:` line alone now
+   says whether the fault is in the reaper, a reader, the timer, the react driver, or the pool.
+2. **DONE (2026-08-19).** **Stop retrying a signal death** (`scripts/flaky-retry.sh`). After `rc=$?`,
+   `rc -ge 128` now exits immediately with a
+   `# flaky-retry: <file> died of signal N -- NOT retried (see docs/flaky-test-policy.md)` comment,
+   no retry. Enforced by `tests/flaky_retry.rs::quarantined_test_that_crashes_is_not_retried`
+   (a fake SIGABRT-killing test proves it fails on the first attempt, not the third). Documented in
+   `docs/flaky-test-policy.md` §4. This is exactly what would have turned §2's abort into a red CI on
+   the day it happened.
+3. **DONE (2026-08-19).** **Surface crash reports on green runs** (`.github/workflows/ci.yml`). The
+   three "Crash reports" steps are now `if: always()`, and `scripts/report-crash-reports.sh` fails the
+   job (`exit 1`) when a report's `argv:` is not on `ALLOWLISTED_ARGV_SUBSTRINGS`, which today holds
+   exactly the deliberate `strdup(0)` NativeCall probe (`roast/S29-os/system.t`). Manually verified
+   against a fabricated allowlisted report (exit 0) and a fabricated `advent2014-day05.t`-shaped
+   report (exit 1, `::error::` annotation).
+4. **Still open.** **Re-measure the `advent2014-day05.t` quarantine.** Its `flaky-tests.txt` reason
+   attributes the failures to CPU-contention timing; §2 is hard evidence that at least one of them was
+   heap corruption. Per the ledger's own bar the entry should be pulled (or at minimum re-justified)
+   now that slices 2-3 have landed and a recurrence can no longer hide. This needs the crash to
+   actually recur (or a deliberate repro) under the new, named-thread reporting before it can be
+   root-caused — nothing here reproduces it yet.
 
 ### 6. Recommended next action
 
-Land slices 1-3 as one small PR. Then **stop chasing this file directly**: it is a ~1-in-several-dozen
-CI event that survived ~96 targeted local runs across four configurations. The productive move is to
-make the next crash — in *any* file — self-diagnosing, and to un-mute the two mechanisms that are
-currently hiding crashes that already happen. A sanitizer job or core dumps are only worth building
-if a named-thread report still leaves the subsystem ambiguous.
+~~Land slices 1-3 as one small PR.~~ **Done 2026-08-19** — see §5. What remains, in order:
+
+1. **Slice 4** (§5.4): re-measure `roast/integration/advent2014-day05.t`'s `flaky-tests.txt` entry now
+   that a signal death there can no longer be silently retried away. Either it stops needing
+   quarantine at all (if the "CPU-contention timing" flake was actually always this crash), or its
+   reason needs to be rewritten to acknowledge the crash risk explicitly — the ledger's evidence
+   standard (`docs/flaky-test-policy.md` §2) does not currently cover "sometimes aborts with heap
+   corruption" as a quarantine-eligible cause, and §3 explicitly says a crash must never be
+   quarantined. This may mean the entry needs to come OFF the ledger and the underlying heap
+   corruption root-caused instead, once it recurs with the new diagnostics.
+2. **Stop chasing `roast/S17-procasync/stress.t` directly.** It is a ~1-in-several-dozen CI event that
+   survived ~96 targeted local runs across four configurations, and the productive move was always to
+   make the next crash — in *any* file — self-diagnosing rather than burn more cycles on a repro loop
+   that has not worked. That diagnostics work (named threads, non-launderable signal deaths, an
+   un-muted crash-report step) is now in place. A sanitizer job or core dumps are only worth building
+   if a future named-thread report still leaves the subsystem ambiguous.


### PR DESCRIPTION
## Summary

Implements diagnostics slices 1-3 from the 2026-08-19 investigation section of `todo/deep/procasync-stress-segv.md` (the `Proc::Async` stress-test SIGSEGV that has never reproduced locally in ~96 runs). That investigation did not root-cause the original crash, but it found something more actionable: sweeping a week of CI crash-report artifacts turned up **one genuine heap-corruption crash** (`abort` <- `malloc_printerr`, non-main thread) in `roast/integration/advent2014-day05.t`, and CI's own machinery **laundered it into a green run** -- `scripts/flaky-retry.sh` retried a signal death exactly like an ordinary assertion failure, even though `flaky-tests.txt`'s own preamble says crashes are never quarantined.

- **Slice 1 -- name every spawned thread.** `thread_compat::spawn_thread` now takes a `name: &str`, threaded through `spawn_registered_thread` / `spawn_gc_helper_thread` / `spawn_user_thread` and all ~15 call sites (`mutsu-main`, `proc-wait`, `proc-out`, `proc-err`, `proc-in`, `signal-rd`, `timer`, `react`, `pool`, `sock-async`, `sock-conn`, `io-path`, `promise-wait`, `promise-comb`, `raku-thread`). A future crash report's `thread:` field can now actually identify the culprit subsystem, instead of reading the unhelpful `mutsu` for every thread. Verified live with `ps -eLo pid,tid,comm` against a running `Proc::Async` react loop -- see test plan.
- **Slice 2 -- never retry a signal death.** `scripts/flaky-retry.sh` now treats `rc >= 128` (a process killed by a signal: `rc = 128 + signum`) as an immediate, non-retryable failure, with a `died of signal N -- NOT retried` comment. This is the enforcement of the policy `flaky-tests.txt`'s preamble already states.
- **Slice 3 -- surface crash reports on green runs.** `.github/workflows/ci.yml`'s three "Crash reports" steps flip from `if: failure()` to `if: always()`, and `scripts/report-crash-reports.sh` now fails the job when a report's `argv:` is not on a small allowlist (today: only the deliberate `strdup(0)` NativeCall probe in `roast/S29-os/system.t`, which is 105 of the 106 reports the investigation found).

Slice 4 (re-measuring the `advent2014-day05.t` quarantine now that crashes there can no longer hide) and the underlying `Proc::Async` segv root cause are explicitly out of scope here and remain open in the ticket.

## Test plan

- [x] `cargo build`, `cargo fmt`, `cargo clippy -- -D warnings` clean.
- [x] `cargo test --lib` (852 tests) and `cargo test --test flaky_retry` (6 tests, including a new `quarantined_test_that_crashes_is_not_retried` that fakes a SIGABRT-killing quarantined test and asserts it fails on the first attempt, never retries, and the retry log records the signal death).
- [x] Manually exercised `scripts/report-crash-reports.sh` against a fabricated allowlisted crash report (exit 0, "not treated as a failure") and a fabricated `advent2014-day05.t`-shaped report (exit 1, `::error::` annotation).
- [x] Relevant local suites green: `t/proc-async.t`, `t/native-proc-async-ctor.t`, `t/thread.t`, `t/thread-start-join.t`, `t/promise-combinator.t`, `t/timer-heap-threads.t`, `t/socket.t`, `t/native-socket-inet-ctor.t`, `t/signal-enum-complete.t`.
- [x] Verified thread naming live: launched a `Proc::Async` under a long-running `react` block and read `/proc/<pid>/task/*/comm` -- confirmed `mutsu-main`, `proc-wait`, `proc-out`, `proc-err`, `promise-wait` show up as distinct thread names.
- [x] `bash scripts/check-flaky-list.sh` still passes.
- [ ] CI (`make test` + `make roast`, all three configs) -- this PR changes the flaky-retry/crash-report machinery those jobs themselves rely on, so it needs to demonstrate it behaves correctly on its own run (ordinary flaky tests still retry normally; nothing spuriously fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)