### PR TITLE
fix(runtime): make dynamics enumeration chain-aware (ADR-0035 slice 1)

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -1120,6 +1120,49 @@ mod tests {
     }
 
     #[test]
+    fn filtered_flat_chain_walk_respects_tombstones_and_shadowing() {
+        // `filtered_flat` is the chain-aware enumeration primitive ADR-0035
+        // Mechanism 1 relies on: a whole-env walk must see exactly the same
+        // entries `Env::get()` would for every key -- outermost tier first,
+        // nearer tiers overwriting, tombstoned keys suppressed. This is what
+        // `dynamic_pseudo_stash_entries` uses (instead of `iter()`, which is
+        // top-overlay-only) to enumerate `PROCESS::`/`DYNAMIC::` dynamics
+        // through the whole overlay-parent chain of every stacked caller env.
+        let mut root = Env::new();
+        root.insert("a".into(), Value::int(1));
+        root.insert("shadowed".into(), Value::int(100));
+        let mut mid = Env::scoped_child(root);
+        mid.insert("shadowed".into(), Value::int(2)); // shadows root's entry
+        mid.insert("b".into(), Value::int(3));
+        let mut leaf = Env::scoped_child(mid);
+        leaf.remove("a"); // tombstoned: must not survive into the merged view
+        leaf.insert("c".into(), Value::int(4));
+
+        let merged = leaf.filtered_flat(&|_, _| true);
+        assert!(!merged.is_scoped());
+        assert!(
+            merged.get_sym(s("a")).is_none(),
+            "tombstoned key must be suppressed"
+        );
+        assert_eq!(
+            merged.get_sym(s("shadowed")),
+            Some(&Value::int(2)),
+            "nearer tier must shadow the outer one"
+        );
+        assert_eq!(merged.get_sym(s("b")), Some(&Value::int(3)));
+        assert_eq!(merged.get_sym(s("c")), Some(&Value::int(4)));
+        // The merged view agrees with per-key `get_sym` on the source chain
+        // for every key -- the coherence property the helper exists for.
+        for key in ["a", "b", "c", "shadowed", "missing"] {
+            assert_eq!(
+                merged.get_sym(s(key)),
+                leaf.get_sym(s(key)),
+                "filtered_flat must agree with get_sym for {key:?}"
+            );
+        }
+    }
+
+    #[test]
     fn depth_is_bounded_under_deep_nesting() {
         // Chaining far past MAX_OVERLAY_DEPTH must keep the chain length bounded
         // (scoped_child flattens the parent at the limit) while still reading the

--- a/src/runtime/runtime_caller_env.rs
+++ b/src/runtime/runtime_caller_env.rs
@@ -219,7 +219,18 @@ impl Interpreter {
             .iter()
             .chain(std::iter::once(&self.env));
         for env in frames {
-            for (k, v) in env.iter() {
+            // Chain-aware: walk this frame's WHOLE overlay-parent chain
+            // (outermost tier first, nearer tiers overwriting, tombstoned
+            // keys suppressed) instead of `env.iter()`, which sees only the
+            // top overlay tier. Any frame that runs under a scoped overlay
+            // without pushing its own caller-env entry (every compiled
+            // method body, and two latent sub-side shapes -- a sub with a
+            // positional param, and a frameless overlay intermediate between
+            // writer and reader) otherwise hides dynamics living in its
+            // parent tiers from this walk even though `Env::get()` would
+            // find them. See ADR-0035 Mechanism 1 (docs/adr/0035-method-calls-observe-caller-frames.md).
+            let merged = env.filtered_flat(&|_, _| true);
+            for (k, v) in merged.iter() {
                 let key = k.resolve();
                 let spelled = if let Some(n) = key.strip_prefix("@*") {
                     format!("@*{n}")

--- a/t/adr0035-dynamics-chain-aware-enumeration.t
+++ b/t/adr0035-dynamics-chain-aware-enumeration.t
@@ -1,0 +1,37 @@
+use Test;
+
+# ADR-0035 (docs/adr/0035-method-calls-observe-caller-frames.md) Mechanism 1:
+# `dynamic_pseudo_stash_entries` (backing `PROCESS::`/`DYNAMIC::`) walked each
+# frame env with `Env::iter()`, which only sees the TOP overlay tier, while
+# `Env::get()` walks the whole parent chain (with tombstone suppression). Any
+# frame that runs under a scoped overlay without pushing its own caller-env
+# entry is therefore invisible-through: dynamics living in its parent tiers
+# were unreachable from the `PROCESS::`/`DYNAMIC::` stash walk even though a
+# direct `$*x`-style read of the SAME name would find them.
+#
+# Four shapes, all verified against raku directly (all print 42 there):
+#   - a flat method body (every compiled method runs under a scoped overlay
+#     and never pushed a caller-env entry -- broken for ALL methods)
+#   - a method body with an inner closure (worked by accident already, since
+#     both method executors skip the overlay entirely when the body has a
+#     closure -- must stay working)
+#   - a sub WITH a positional parameter (takes the positional-light path:
+#     scoped overlay, no caller-env push -- a latent sub-side gap)
+#   - a frameless overlay intermediate sitting between the writer and a
+#     reader sub that works fine when called directly (another latent gap)
+plan 4;
+
+PROCESS::<$X> = 42;
+
+class C1 { method reader() { PROCESS::<$X> } }
+is C1.new.reader(), 42, 'PROCESS:: is visible from a flat method body';
+
+class C2 { method reader() { my $f = { 1 }; PROCESS::<$X> } }
+is C2.new.reader(), 42, 'PROCESS:: stays visible from a closure-bearing method body';
+
+sub reader-with-positional($n) { PROCESS::<$X> }
+is reader-with-positional(1), 42, 'PROCESS:: is visible from a sub with a positional param';
+
+sub reader-plain() { PROCESS::<$X> }
+sub mid($n) { reader-plain() }
+is mid(1), 42, 'PROCESS:: is visible through a frameless overlay intermediate sub';

--- a/todo/deep/method-calls-never-push-caller-frame.md
+++ b/todo/deep/method-calls-never-push-caller-frame.md
@@ -5,6 +5,18 @@
 two compiled-method chokepoints; implementation slices listed there). The ADR
 also root-causes two latent sub-side `PROCESS::` gaps beyond the repros below.
 
+**Slice 1 (chain-aware dynamics enumeration) is implemented** — `Env::filtered_flat`
+(the existing chain-aware tier-walk primitive, `src/env.rs`) now backs
+`dynamic_pseudo_stash_entries` (`src/runtime/runtime_caller_env.rs`) in place of
+`Env::iter()` (which only saw the top overlay tier). This fixes `PROCESS::`/
+`DYNAMIC::` reads from a flat method body, a closure-bearing method body, a sub
+with a positional parameter, and a frameless overlay intermediate between
+writer and reader — all four repros verified fixed against raku's `42` output.
+Regression test: `t/adr0035-dynamics-chain-aware-enumeration.t`. `CALLER::` and
+`callframe()` from inside methods are still broken (Slice 2, frame-stack
+mechanism — unaffected by this slice, since Mechanism 1 only fixes env
+visibility, not frame observation).
+
 Reclassified from `todo/tickets/log-timeline-task-event-recording-empty.md`
 (originally filed as a narrow `Log::Timeline`/`given`/role-composed-method
 gap) after bisecting the real trigger. The original ticket's framing was


### PR DESCRIPTION
## Summary

Implements Slice 1 of [ADR-0035](docs/adr/0035-method-calls-observe-caller-frames.md) (Mechanism 1): `PROCESS::`/`DYNAMIC::` pseudo-stash reads were built by walking each frame env with `Env::iter()`, which only sees the **top overlay tier** — while `Env::get()` walks the whole parent chain with tombstone suppression. Any frame that runs under a scoped overlay without pushing its own caller-env entry was therefore invisible-through to the stash walk, even though a direct `$*x`-style read of the same name would find the value via `get()`.

This broke `PROCESS::`/`DYNAMIC::` reads from:
- every compiled method body (the ADR's headline repro — this blocked `Log::Timeline`)
- a sub with a positional parameter (takes the positional-light path: scoped overlay, no caller-env push)
- a frameless overlay intermediate sub sitting between the writer and a reader that works fine when called directly

- `src/env.rs`: no new helper needed — `Env::filtered_flat` (already existing) is exactly the chain-aware tier-walk (outermost tier first, nearer tiers overwriting, tombstoned keys suppressed) the ADR calls for. Added a `#[test]` (`filtered_flat_chain_walk_respects_tombstones_and_shadowing`) exercising tombstone/shadowing ordering directly and asserting agreement with per-key `get_sym`.
- `src/runtime/runtime_caller_env.rs`: `dynamic_pseudo_stash_entries` now uses `env.filtered_flat(&|_, _| true)` instead of `env.iter()`, for each `caller_env_stack` entry and for `self.env`.
- `t/adr0035-dynamics-chain-aware-enumeration.t`: regression test covering all four repros from the ADR (flat method, closure-bearing method, positional-param sub, frameless-intermediate sub) — all verified against `raku` (expect `42`).
- `todo/deep/method-calls-never-push-caller-frame.md`: noted Slice 1 done (Slice 2 `CALLER::`/`callframe()` and Slice 3 residue are separate, unaffected).

Confirmed the ADR's specifics exactly: `Env::filtered_flat` already implements the correct chain walk (used elsewhere at `registration_role_decl.rs:206`'s sibling `flatten()`), so no new primitive was needed — just wiring the existing one into the pseudo-stash enumeration.

## Test plan

- [x] New unit test `env::tests::filtered_flat_chain_walk_respects_tombstones_and_shadowing` passes
- [x] New `t/adr0035-dynamics-chain-aware-enumeration.t` passes (4/4), covering all four fixed shapes
- [x] Must-stay-green pins all pass: `t/process-stash-visible-across-sub-boundary.t`, `t/pseudo-dynamic-stash.t`, `t/process-register-dynamic.t`, `t/process-dynamic-nil-decay.t`, `t/pseudo-callers.t`
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean
- [x] `make test` passes (only failure: the known pre-existing `t/autoviv-index-guard.t` hang, unrelated — see `todo/tickets/autoviv-index-guard-hangs-locally.md`)
- [ ] CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)