### PR TITLE
fix(vm): push caller-env frame at method chokepoints when uses_callframe (ADR-0035 slice 2)

### DIFF
--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -244,6 +244,18 @@ impl Interpreter {
             self.unmark_readonly("_");
         }
 
+        // ADR-0035 slice 2: a body that reads `CALLER::`/`callframe()` needs a
+        // caller-env frame pushed, mirroring `call_compiled_function_named_inner`
+        // on the sub side. Gated on `cc.uses_callframe` (already computed
+        // correctly for methods by the shared compiler) so the overwhelming
+        // majority of method calls, which never observe their caller, pay only
+        // this one boolean test. Pushed BEFORE the scoped-overlay install below
+        // so the pushed entry captures the caller's (unoverlaid) env.
+        let pushed_caller = cc.uses_callframe;
+        if pushed_caller {
+            self.push_caller_env();
+        }
+
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller (gated on no inner closures) so the
         // method's `self`/`?CLASS`/param/attr/local env setup writes land in a
@@ -452,6 +464,9 @@ impl Interpreter {
                             self.pop_method_class();
                             self.set_current_package(saved_package.clone());
                             self.stack.truncate(saved_stack_depth);
+                            if pushed_caller {
+                                self.pop_caller_env();
+                            }
                             let frame = self.pop_call_frame();
                             *self.env_mut() = frame.saved_env;
                             // :D/:U smiley mismatch → X::Parameter::InvalidConcreteness
@@ -599,6 +614,9 @@ impl Interpreter {
                 self.pop_method_class();
                 self.set_current_package(saved_package.clone());
                 self.stack.truncate(saved_stack_depth);
+                if pushed_caller {
+                    self.pop_caller_env();
+                }
                 let frame = self.pop_call_frame();
                 *self.env_mut() = frame.saved_env;
                 return Err(e);
@@ -865,6 +883,9 @@ impl Interpreter {
             // Take sole ownership of caller + callee envs (pop the frame for the
             // saved caller env, take the live callee env) so merge_method_env can
             // mutate the caller env in place without a deep copy.
+            if pushed_caller {
+                self.pop_caller_env();
+            }
             let frame = self.pop_call_frame();
             let current_env = self.take_env();
             let (mut merged_env, wrote_caller, changed_caller_locals) =
@@ -954,6 +975,9 @@ impl Interpreter {
             // No env writes possible -> the caller's slots stay coherent (pure).
             self.method_dispatch_pure = true;
             self.set_current_package(saved_package);
+            if pushed_caller {
+                self.pop_caller_env();
+            }
             let frame = self.pop_call_frame();
             *self.env_mut() = frame.saved_env;
         }
@@ -1301,6 +1325,13 @@ impl Interpreter {
         if !self.no_readonly_vars() {
             self.unmark_readonly("_");
         }
+        // ADR-0035 slice 2: see the matching comment in `call_compiled_method`.
+        // Pushed before the scoped-overlay install below so the pushed entry
+        // captures the caller's (unoverlaid) env.
+        let pushed_caller = cc.uses_callframe;
+        if pushed_caller {
+            self.push_caller_env();
+        }
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller so the `self`/`?CLASS`/param/attr
         // env writes below land in a fresh map (strong_count 1) instead of
@@ -1398,6 +1429,9 @@ impl Interpreter {
                         self.set_current_package(pkg);
                     }
                     self.stack.truncate(saved_stack_depth);
+                    if pushed_caller {
+                        self.pop_caller_env();
+                    }
                     let frame = self.pop_call_frame();
                     self.set_env(frame.saved_env);
                     return Err(RuntimeError::typecheck_binding_parameter(
@@ -1795,6 +1829,13 @@ impl Interpreter {
         self.pop_method_class();
         if let Some(pkg) = saved_package {
             self.set_current_package(pkg);
+        }
+
+        // ADR-0035 slice 2: both branches below unconditionally pop the call
+        // frame, so pop the caller-env entry once here (mirrors the paired push
+        // above) rather than duplicating the gate in each branch.
+        if pushed_caller {
+            self.pop_caller_env();
         }
 
         if can_skip_merge {

--- a/t/method-caller-frame-push.t
+++ b/t/method-caller-frame-push.t
@@ -1,0 +1,71 @@
+use Test;
+
+# ADR-0035 slice 2: method calls never pushed a caller-env frame, so
+# `CALLER::<$*x>` read Nil instead of the caller's dynamic value, and
+# `callframe(N)` inside a method body reported the method's own frame
+# instead of the caller's, no matter what N was. `CompiledCode::uses_callframe`
+# was already computed correctly for method bodies by the shared compiler
+# (`CALLER::<$*y>` compiles to `GetCallerVar`, `callframe(N)` to
+# `CallFuncNamed`) -- the bug was that neither `call_compiled_method` nor
+# `call_compiled_method_fast` ever consulted it. Fixed by pushing a
+# caller-env frame at both chokepoints, gated on `cc.uses_callframe`.
+# See docs/adr/0035-method-calls-observe-caller-frames.md.
+
+plan 5;
+
+# `CALLER::<$*y>` read from inside a method body must see the caller's
+# dynamic value.
+class CallerVarReader {
+    method reader() {
+        return CALLER::<$*y>;
+    }
+}
+sub outer-caller-var() {
+    my $*y = 42;
+    CallerVarReader.new.reader();
+}
+is outer-caller-var(), 42, 'CALLER::<$*y> read from a method sees the caller frame';
+
+# `callframe(1).line` from inside a method must report the CALL SITE's line,
+# not the method's own line.
+class CallSiteLineReader {
+    method reader() {
+        return callframe(1).line;
+    }
+}
+sub outer-call-site-line() {
+    return CallSiteLineReader.new.reader();   # <- line 37, the call site
+}
+is outer-call-site-line(), 37,
+    'callframe(1).line from a method reports the call-site line';
+
+# Depth-0/depth-1 sanity: callframe(0) must still describe the method's OWN
+# frame correctly -- the caller-env push must not disturb the existing
+# same-frame introspection.
+class DepthSanityReader {
+    method reader() {
+        my $own-line = callframe(0).line;   # <- line 47
+        my $caller-line = callframe(1).line;
+        return ($own-line, $caller-line);
+    }
+}
+sub outer-depth-sanity() {
+    return DepthSanityReader.new.reader();   # <- line 53, the call site
+}
+my ($own, $caller) = outer-depth-sanity();
+is $own, 47, 'callframe(0).line inside a method still describes its own frame';
+is $caller, 53, 'callframe(1).line from the same method reaches the call site';
+
+# The fast dispatch path (no `is rw`/aliasable-container params, all-positional
+# args) must observe the caller too -- `CALLER::` is not gated to the slow path.
+class FastPathCallerVarReader {
+    method reader($n) {
+        return CALLER::<$*z> + $n;
+    }
+}
+sub outer-fast-path() {
+    my $*z = 100;
+    FastPathCallerVarReader.new.reader(5);
+}
+is outer-fast-path(), 105,
+    'CALLER::<$*z> read from a fast-dispatch-eligible method sees the caller frame';

--- a/todo/deep/method-calls-never-push-caller-frame.md
+++ b/todo/deep/method-calls-never-push-caller-frame.md
@@ -5,17 +5,33 @@
 two compiled-method chokepoints; implementation slices listed there). The ADR
 also root-causes two latent sub-side `PROCESS::` gaps beyond the repros below.
 
-**Slice 1 (chain-aware dynamics enumeration) is implemented** — `Env::filtered_flat`
-(the existing chain-aware tier-walk primitive, `src/env.rs`) now backs
-`dynamic_pseudo_stash_entries` (`src/runtime/runtime_caller_env.rs`) in place of
-`Env::iter()` (which only saw the top overlay tier). This fixes `PROCESS::`/
-`DYNAMIC::` reads from a flat method body, a closure-bearing method body, a sub
-with a positional parameter, and a frameless overlay intermediate between
-writer and reader — all four repros verified fixed against raku's `42` output.
-Regression test: `t/adr0035-dynamics-chain-aware-enumeration.t`. `CALLER::` and
-`callframe()` from inside methods are still broken (Slice 2, frame-stack
-mechanism — unaffected by this slice, since Mechanism 1 only fixes env
-visibility, not frame observation).
+**Slice 1 (chain-aware dynamics enumeration) is implemented, PR #6703.** —
+`Env::filtered_flat` (the existing chain-aware tier-walk primitive,
+`src/env.rs`) now backs `dynamic_pseudo_stash_entries`
+(`src/runtime/runtime_caller_env.rs`) in place of `Env::iter()` (which only
+saw the top overlay tier). This fixes `PROCESS::`/`DYNAMIC::` reads from a
+flat method body, a closure-bearing method body, a sub with a positional
+parameter, and a frameless overlay intermediate between writer and reader —
+all four repros verified fixed against raku's `42` output. Regression test:
+`t/adr0035-dynamics-chain-aware-enumeration.t`.
+
+**Slice 2 (uses_callframe-gated push at the method chokepoints) is
+implemented, PR #6704.** `call_compiled_method` and
+`call_compiled_method_fast` (`src/vm/vm_method_dispatch.rs`) now push a
+caller-env frame in their prologue, gated on `cc.uses_callframe`, and pop it
+paired with every existing `pop_call_frame` exit site. This fixes the
+`CALLER::<$*y>` and `callframe(N).line` method repros above (both verified
+against `raku` as oracle; regression test `t/method-caller-frame-push.t`).
+The `emit()` detection-parity audit the ADR flagged (bareword
+`callframe`/`callframes` possibly compiling as `GetBareWord`) turned out to
+be a non-issue — `--dump-bytecode` confirms the parser always compiles those
+two names as `CallFuncNamed`, already covered by the existing detection; no
+detection change was needed.
+
+Both slices land together: `CALLER::`/`callframe()`/`PROCESS::`/`DYNAMIC::`
+are all now correctly observable from inside method bodies. Slice 3
+(tree-walk residue + `Log::Timeline` end-to-end acceptance) remains open —
+this file stays until it lands.
 
 Reclassified from `todo/tickets/log-timeline-task-event-recording-empty.md`
 (originally filed as a narrow `Log::Timeline`/`given`/role-composed-method


### PR DESCRIPTION
## Summary

Implements Slice 2 of [ADR-0035](docs/adr/0035-method-calls-observe-caller-frames.md): `CALLER::<$*x>` and `callframe(N)`/`callframes()` read from inside a method body previously reported the wrong frame, because no method-dispatch path ever pushed a caller-env frame.

- `CompiledCode::uses_callframe` was already correctly computed for method bodies by the shared compiler (`CALLER::<$*y>` compiles to `GetCallerVar`, `callframe(N)` to `CallFuncNamed`) -- confirmed empirically via `--dump-bytecode`.
- The bug: neither of the two compiled-execution chokepoints (`call_compiled_method`, `call_compiled_method_fast` in `src/vm/vm_method_dispatch.rs`) ever consulted the flag.
- Fix: in both chokepoints, push a caller-env frame in the prologue (before the scoped-overlay install, mirroring `call_compiled_function_named_inner`'s ordering on the sub side) gated on `cc.uses_callframe`, and pop it paired with every existing `pop_call_frame` exit site (4 sites in the slow path, 3 in the fast path -- one more exit site than the ADR's illustrative line numbers suggested, since the fast path has two distinct normal exits (`can_skip_merge` and the merge branch), collapsed here into one shared pop right before the `if can_skip_merge` split).
- Detection-parity audit (bareword `callframe`/`callframes` compiling as `GetBareWord`): turned out to be a non-issue. `--dump-bytecode` confirms the parser always compiles bareword `callframe`/`callframes` as `CallFuncNamed` (already covered by the existing detection), unlike `callsame`/`nextsame` which do sometimes compile as `GetBareWord`. No detection change was needed.

The majority case (a method that never observes its caller) pays only one extra boolean test per chokepoint entry/exit -- the same cost class as the existing `cc.uses_dispatcher` gate beside it. No allocation on the `uses_callframe == false` path.

## Test plan

- [x] New regression test `t/method-caller-frame-push.t` (5 assertions): `CALLER::<$*y>` read from a method, `callframe(1).line` reporting the call site, a depth-0/depth-1 sanity check, and the same `CALLER::` read through the fast-dispatch-eligible path -- all cross-checked against `raku` as oracle.
- [x] All must-stay-green pins green: `t/callframe-file-line-same-frame.t`, `t/callframe-for-block-frame.t`, `t/callframe-annotations-map.t`, `t/callframe-setting-frame.t`, `t/module-file-var-and-callframe.t`, `t/eval-caller-frames.t`, `t/caller-not-dynamic.t`, `t/caller-frame-write-slot-coherence.t`, `t/backtrace-block-frames.t`.
- [x] Whitelisted `roast/S06-advanced/callframe.t` stays green (`MUTSU_FUDGE=1 prove`).
- [x] `cargo clippy -- -D warnings` and `cargo fmt` clean.
- [x] `make test` locally: full pass except the known pre-existing `t/autoviv-index-guard.t` local hang (unrelated, documented in `todo/tickets/autoviv-index-guard-hangs-locally.md`).
- [ ] CI: `make roast` (this touches the hottest dispatch functions -- watching jit-stress in particular).

🤖 Generated with [Claude Code](https://claude.com/claude-code)