### PR TITLE
docs: record two defects found while timing the t/ suite

### DIFF
--- a/todo/deep/cross-thread-captured-lexical-writes-invisible-until-teardown.md
+++ b/todo/deep/cross-thread-captured-lexical-writes-invisible-until-teardown.md
@@ -1,0 +1,99 @@
+# A captured lexical written from another thread stays invisible until scope teardown
+
+A closure running on one thread can increment a captured outer lexical, and a closure
+running on another thread reading that same lexical keeps seeing the pre-write value.
+The writes are not lost -- they appear all at once once the enclosing scope tears down --
+so the symptom is a *staleness* window, not a lost update.
+
+## Repro
+
+```raku
+my $closed = 0;
+my $sod = Supply.on-demand: -> $s { start { $s.emit(42); $s.done; } },
+                            closing => { $closed++ };
+my $ticks = 0;
+react {
+    whenever Supply.interval(0.05) {
+        $ticks++;
+        whenever $sod { };
+        note "tick $ticks sees closed=$closed";
+        done if $ticks >= 4;
+    }
+}
+say "after react: closed=$closed";
+```
+
+mutsu:
+
+```
+tick 1 sees closed=0
+tick 2 sees closed=0
+tick 3 sees closed=0
+tick 4 sees closed=0
+after react: closed=3
+```
+
+raku:
+
+```
+tick 1 sees closed=0
+tick 2 sees closed=1
+tick 3 sees closed=2
+tick 4 sees closed=3
+after react: closed=4
+```
+
+The `closing` callback fires and `$closed` reaches 3 either way. The difference is that
+mutsu's react thread cannot observe it while the react block is still running.
+
+## It is specifically cross-thread, not "closures in react"
+
+Change only the on-demand body so the `closing` callback runs on the react thread instead
+of a `start` thread (`-> $s { $s.emit(1); $s.done; }`, no `start`), and mutsu is correct:
+
+```
+tick 1 sees closed=0
+tick 2 sees closed=1
+tick 3 sees closed=2
+tick 4 sees closed=3
+```
+
+So the machinery for capturing and mutating `$closed` works; what fails is propagating a
+write made on thread A to a reader on thread B before the scope that owns the variable
+ends. This has the shape of the `env_dirty` dual store / per-thread env copy described in
+CLAUDE.md's architecture section -- each thread appears to work against its own view of
+the environment, reconciled only at teardown -- so it is high blast radius and needs a
+design decision (which is why this is filed under `todo/deep/`, not as a ticket).
+
+Compare `t/lock.t`'s history, where the same area produced a genuinely lost update
+(#4167): the fix routed shared-array pushes through a dedicated atomic store. That was a
+targeted patch for one construct; the general rule "a captured lexical is one cell shared
+by every thread that captured it" is still not established.
+
+## A live test is currently hiding this
+
+`t/react-nested-whenever-on-demand-close.t` subtest 1 is exactly this shape:
+
+```raku
+react {
+    whenever Supply.interval(0.02) {
+        whenever $sod { }
+        done if $closed;
+    }
+    whenever Promise.in(5) { done }
+}
+ok $closed, "async on-demand closing fires from a nested whenever (closed=$closed)";
+```
+
+`done if $closed` never fires because of the staleness, so the react runs until the 5s
+backstop and the interval ticks 250 times (`closed=250`). The final `ok $closed` then
+passes, because by then the scope has torn down and the writes are visible. The file
+therefore reports green while costing 5 seconds of every `make test` -- it was the 4th
+slowest of all 3261 files in a full timing sweep, and the whole 5.09 s is the backstop.
+Its own comment says the backstop exists so that "a genuine regression (closing never
+fires) fails cleanly with closed=0 rather than hanging"; in practice it is masking a
+different genuine defect instead.
+
+When this is fixed, subtest 1 should complete in ~0.04 s like the synchronous subtest 2
+does, and the file is worth tightening to assert that (e.g. bound the observed tick count)
+so the backstop cannot silently absorb a regression again.

--- a/todo/deep/lazy-array-element-assign-reifies-100k.md
+++ b/todo/deep/lazy-array-element-assign-reifies-100k.md
@@ -1,0 +1,75 @@
+# An element assign into a lazy array reifies 100,000 elements and drops laziness
+
+Writing a single element of a lazy `@`-array materializes a hard-coded 100,000-element
+prefix and converts the value to a plain `real_array`, so the array stops being lazy.
+raku reifies only up to the touched index and keeps the array lazy.
+
+```
+$ mutsu -e 'my @d = 1, 2, 3 ... Inf; @d[2] = 99; say @d.elems'
+100000
+$ raku  -e 'my @d = 1, 2, 3 ... Inf; @d[2] = 99; say @d.elems'
+Cannot .elems a lazy list
+```
+
+Two defects, one cause: the reified prefix is not bounded by what was touched, and the
+laziness marker is discarded along with the live tail.
+
+## Cost
+
+With a geometric sequence every one of those 100,000 elements is a `2**n` bigint, so a
+three-element write allocates hundreds of megabytes:
+
+```
+$ mutsu -e 'my @d = 1, 2, 4 ... Inf; @d[2] = 99; say "ok"'     # 1.18 s, 666 MB peak RSS
+$ mutsu -e 'my @d = 1, 2, 3 ... Inf; @d[2] = 99; say @d.elems' # 0.03 s,  47 MB peak RSS
+$ raku  -e 'my @d = 1, 2, 4 ... Inf; @d[2] = 99; say @d[^4]'   # 166 MB peak RSS
+```
+
+Found while timing the whole `t/` suite: `t/lazy-array-assign-preserve.t` was the single
+memory outlier at 670 MB peak, against a ~50 MB baseline for every other file (the next
+highest non-panic test is 117 MB). Bisecting its blocks pinned the cost to the one line
+`my @a = 1, 2, 4 ... Inf; @a[2] = 99;`.
+
+## Where
+
+`Interpreter::reify_lazy_array_slot` in `src/vm/vm_helpers_lazy.rs` (the `MAX_ARRAY_EXPAND
+= 100_000` inside it). Callers:
+
+- `src/vm/vm_var_assign_element.rs:418` -- element assign (`@a[i] = v`)
+- `src/vm/vm_var_delete_ops.rs:199` -- `:delete`
+
+The behaviour is deliberate and documented as an approximation: the function's own doc
+comment says "Front mutations collapse the list to its prefix (no worse than the pre-L2
+capped Array)", and `docs/lazy-arrays.md` lists `100_000` among "the capping points". So
+this is a known shortcut whose cost was never measured, not an oversight.
+
+## Why it is deep, not a ticket
+
+The cheap-looking fix -- reify only up to the touched index -- is not sufficient on its
+own, because the value that comes back must still *be* lazy: the tail has to stay live so
+that `@d.elems` keeps throwing `X::Cannot::Lazy` and a later `@d[10]` still reifies from
+the source. That means a mutated lazy array needs a representation with a mutable reified
+prefix over a live source, rather than today's "reify to a cap, then hand back a
+`real_array`". `LazyList` already carries a `cache`, so writing the override into the
+cache and returning the `LazyList` may well be the shape of the answer, but the semantics
+of every consumer that currently relies on getting a real Array back after a mutation
+have to be checked first -- including the `:delete` path, which has to express a hole in
+a lazy list.
+
+`docs/lazy-arrays.md` should be updated in the same change: its table and its "capping
+points" section describe the current approximation as the design.
+
+## Test that hides it today
+
+`t/lazy-array-assign-preserve.t` asserts
+
+```raku
+my @a = 1, 2, 4 ... Inf;
+@a[2] = 99;
+is-deeply @a[^4], (1, 2, 99, 8), 'element assign reifies a prefix, tail stays live';
+```
+
+which passes, because it only inspects the first four elements. The description claims
+"tail stays live" while the tail has in fact been flattened into a finite 100,000-element
+array. When this is fixed, extend that block to assert the array is still lazy
+(`@a.is-lazy`, or that `.elems` throws `X::Cannot::Lazy`) so the description becomes true.


### PR DESCRIPTION
Two `todo/deep/` records, no source or test changes. Both defects were surfaced by a full serial timing + peak-RSS sweep of all 3261 `t/` files (run after #6706 removed `t/autoviv-index-guard.t`), and **both currently pass their tests** — that is what makes them worth writing down.

## 1. `todo/deep/lazy-array-element-assign-reifies-100k.md`

An element assign into a lazy array materializes a hard-coded 100,000-element prefix and returns a plain `real_array`, so the array stops being lazy:

```
$ mutsu -e 'my @d = 1, 2, 3 ... Inf; @d[2] = 99; say @d.elems'
100000
$ raku  -e 'my @d = 1, 2, 3 ... Inf; @d[2] = 99; say @d.elems'
Cannot .elems a lazy list
```

With a geometric sequence those 100,000 elements are `2**n` bigints, so a three-element write costs **666 MB peak RSS and 1.18 s**. `t/lazy-array-assign-preserve.t` was the single memory outlier of the whole sweep (670 MB, against a ~50 MB baseline and a 117 MB next-highest), and it passes only because it inspects the first four elements — while its own description says "tail stays live".

Site is `Interpreter::reify_lazy_array_slot` in `src/vm/vm_helpers_lazy.rs`; the cap is documented as a deliberate approximation in `docs/lazy-arrays.md`, so this is a known shortcut whose cost was never measured. Filed as deep rather than a ticket because reifying only to the touched index is not enough on its own: the result must still *be* lazy (live tail, `.elems` still throwing `X::Cannot::Lazy`), which needs a representation for a mutated lazy array, and the `:delete` path has to express a hole in one.

## 2. `todo/deep/cross-thread-captured-lexical-writes-invisible-until-teardown.md`

A captured outer lexical incremented on one thread stays at its old value for a reader on another thread until the enclosing scope tears down. The writes are not lost — they all appear at once at the end.

| | mutsu | raku |
| --- | --- | --- |
| ticks 1-4 see | `0, 0, 0, 0` | `0, 1, 2, 3` |
| after the react | `closed=3` | `closed=4` |

It is specifically cross-thread: move the same callback onto the reading thread and mutsu reports `0, 1, 2, 3` correctly. Shape matches the `env_dirty` dual store / per-thread env view, hence deep rather than a ticket.

`t/react-nested-whenever-on-demand-close.t` subtest 1 is exactly this program, so its `done if $closed` never fires, the interval ticks 250 times, and the file burns its full 5 s backstop — the 4th slowest of all 3261 files — while still reporting green. Its comment says the backstop exists so a genuine regression fails cleanly rather than hanging; in practice it is absorbing a different genuine defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)