### PR TITLE
perf: cache map/grep/.first inline-loop compiles by closure-literal identity

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -198,6 +198,33 @@ type CarrierCompileCache =
 
 const CARRIER_COMPILE_CACHE_MAX_CONTEXTS_PER_ID: usize = 4;
 
+/// Key for `map_grep_compile_cache`: pointer identity of a closure literal's
+/// pre-existing `compiled_code`, plus whether the call site is lexically
+/// inside a routine. Holds a clone of the `Arc` (not just its address) so the
+/// key stays alive for as long as its cache entry does — see the field's doc
+/// comment for why a bare pointer would be unsound.
+#[derive(Clone)]
+struct MapGrepCacheKey {
+    origin: Arc<CompiledCode>,
+    lexically_in_routine: bool,
+}
+
+impl PartialEq for MapGrepCacheKey {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.origin, &other.origin)
+            && self.lexically_in_routine == other.lexically_in_routine
+    }
+}
+
+impl Eq for MapGrepCacheKey {}
+
+impl std::hash::Hash for MapGrepCacheKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        (Arc::as_ptr(&self.origin) as usize).hash(state);
+        self.lexically_in_routine.hash(state);
+    }
+}
+
 mod accessors;
 mod accessors_misc;
 mod accessors_resolve;
@@ -1398,6 +1425,34 @@ pub struct Interpreter {
     /// `eval_block_value_cached`/`eval_test_block_value`'s `cache_id`
     /// parameter — starts empty per thread (pure recomputable optimization).
     carrier_compile_cache: CarrierCompileCache,
+    /// The map/grep/`.first` inline-loop fast paths (`resolution_map_grep.rs`)
+    /// compile the callback block once per `.map()`/`.grep()`/`.first()` CALL
+    /// and then run every item through the same compiled bytecode via
+    /// `run_reuse` -- cheap when one call processes many items, but a block
+    /// literal declared *inside* a loop (`for @blocks { @xs.map({ ... }) }`,
+    /// the shape `Digest::RIPEMD` hits once per compression round) is a fresh
+    /// `SubData` on every outer iteration, so the naive path recompiles its
+    /// AST from scratch every time even though the block's own source never
+    /// changes. `data.compiled_code` is already an `Arc<CompiledCode>` shared
+    /// across every instantiation of the same source closure literal (see
+    /// `vm_register_ops::resolve_closure_code` -- it is pulled from the
+    /// enclosing scope's `closure_compiled_codes`, baked once at that
+    /// enclosing scope's own compile time), so its pointer identity is a
+    /// free cache key for this fast path's own (differently-shaped,
+    /// tail-normalized) compile. `MapGrepCacheKey` HOLDS a clone of that
+    /// `Arc` (not just its address) so the key stays alive for as long as the
+    /// cache entry does — a bare `usize` pointer would go unsound the moment
+    /// the *original* Arc (e.g. one built fresh per call by a dynamic
+    /// `EVAL`/RakuAST closure, never otherwise retained) is dropped and its
+    /// address reused by an unrelated later `CompiledCode` allocation, which
+    /// would then collide with a stale cache entry
+    /// (`t/rakuast-eval-block-arg.t`'s chained `.map().grep()` on one line
+    /// caught this during development). Keyed additionally on
+    /// `lexically_in_routine` since that is the only other compiler input
+    /// drawn from ambient state here. Starts empty per thread (pure
+    /// recomputable optimization).
+    map_grep_compile_cache:
+        HashMap<MapGrepCacheKey, (std::sync::Arc<CompiledCode>, std::sync::Arc<CompiledFns>)>,
     /// Compiled bytecode for subset `where` predicates, keyed by subset name.
     /// A subset's predicate is a fixed `Expr`, so it is compiled once and reused
     /// across all type checks instead of recompiling + cloning the entire

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -213,6 +213,43 @@ pub(crate) fn push_block_declared_keys(
 }
 
 impl Interpreter {
+    /// Compile a map/grep/`.first` callback's tail-normalized body for the
+    /// inline-loop fast path, reusing a cached compile when this exact
+    /// closure literal was already compiled at this lexical nesting. See
+    /// `Interpreter::map_grep_compile_cache`'s doc comment for why the
+    /// `data.compiled_code` `Arc` pointer is a sound, free cache key. A block
+    /// with no `compiled_code` (an `EVAL`-built block, or another dynamic
+    /// construction) always compiles fresh — safe, just uncached.
+    pub(super) fn compile_loop_block_cached(
+        &mut self,
+        data: &SubData,
+        normalized_body: &[crate::ast::Stmt],
+    ) -> (
+        std::sync::Arc<crate::opcode::CompiledCode>,
+        std::sync::Arc<crate::opcode::CompiledFns>,
+    ) {
+        let lexically_in_routine = !self.routine_stack.is_empty();
+        let key = data.compiled_code.as_ref().map(|cc| MapGrepCacheKey {
+            origin: cc.clone(),
+            lexically_in_routine,
+        });
+        if let Some(key) = &key
+            && let Some((code, fns)) = self.map_grep_compile_cache.get(key)
+        {
+            return (code.clone(), fns.clone());
+        }
+        let mut compiler = crate::compiler::Compiler::new();
+        compiler.lexically_in_routine = lexically_in_routine;
+        let (code, fns) = compiler.compile(normalized_body);
+        let code = std::sync::Arc::new(code);
+        let fns = std::sync::Arc::new(fns);
+        if let Some(key) = key {
+            self.map_grep_compile_cache
+                .insert(key, (code.clone(), fns.clone()));
+        }
+        (code, fns)
+    }
+
     pub(super) fn eval_map_over_items(
         &mut self,
         func: Option<Value>,
@@ -367,13 +404,13 @@ impl Interpreter {
                 }
             }
 
-            // Compile once, reuse VM for every iteration.
-            // `return` inside this block should propagate up to the
-            // lexically enclosing routine (if any), so mark the fresh
-            // compiler as being lexically nested inside a routine whenever
-            // a routine is currently on the dynamic call stack.
-            let mut compiler = crate::compiler::Compiler::new();
-            compiler.lexically_in_routine = !self.routine_stack.is_empty();
+            // Compile once, reuse VM for every iteration (and reuse a cached
+            // compile across repeated calls to this same closure literal —
+            // see `compile_loop_block_cached`). `return` inside this block
+            // should propagate up to the lexically enclosing routine (if
+            // any); `compile_loop_block_cached` marks the compiler as
+            // lexically nested in a routine whenever one is currently on the
+            // dynamic call stack.
             // The map value is taken from the block's tail-expression result (or
             // the topic `$_` if none was left on the stack). A bare tail
             // `Stmt::Call` carrying named/slip args (how an imported sub call like
@@ -382,7 +419,7 @@ impl Interpreter {
             // tail into `Stmt::Expr(Expr::Call)` so its value is preserved.
             let normalized_body = normalize_tail_stmt_for_value(&data.body);
             let tail_is_when = tail_is_when_chain(&normalized_body);
-            let (code, compiled_fns) = compiler.compile(&normalized_body);
+            let (code, compiled_fns) = self.compile_loop_block_cached(&data, &normalized_body);
 
             let underscore = "_".to_string();
             let dollar_topic = "$_".to_string();
@@ -717,12 +754,11 @@ impl Interpreter {
         }
 
         // Compile once (mirrors grep: normalize the tail statement so the last
-        // expression lands on the stack as the predicate value).
-        let mut compiler = crate::compiler::Compiler::new();
-        compiler.lexically_in_routine = !self.routine_stack.is_empty();
+        // expression lands on the stack as the predicate value), reusing a
+        // cached compile across repeated calls to this same closure literal.
         let normalized_body = normalize_tail_stmt_for_value(&data.body);
         let tail_is_when = tail_is_when_chain(&normalized_body);
-        let (code, compiled_fns) = compiler.compile(&normalized_body);
+        let (code, compiled_fns) = self.compile_loop_block_cached(&data, &normalized_body);
 
         let underscore = "_".to_string();
         let dollar_topic = "$_".to_string();

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -419,17 +419,17 @@ impl Interpreter {
                 return Ok((Value::array(result), list_items));
             }
 
-            // Compile once, reuse VM for every iteration.
-            // `return` inside this block should propagate up to the
-            // lexically enclosing routine (if any), so mark the fresh
-            // compiler as being lexically nested inside a routine whenever
-            // a routine is currently on the dynamic call stack.
-            let mut compiler = crate::compiler::Compiler::new();
-            compiler.lexically_in_routine = !self.routine_stack.is_empty();
+            // Compile once, reuse VM for every iteration (and reuse a cached
+            // compile across repeated calls to this same closure literal —
+            // see `compile_loop_block_cached`). `return` inside this block
+            // should propagate up to the lexically enclosing routine (if
+            // any); `compile_loop_block_cached` marks the compiler as
+            // lexically nested in a routine whenever one is currently on the
+            // dynamic call stack.
             let normalized_body =
                 super::resolution_map_grep::normalize_tail_stmt_for_value(&data.body);
             let tail_is_when = super::resolution_map_grep::tail_is_when_chain(&normalized_body);
-            let (code, compiled_fns) = compiler.compile(&normalized_body);
+            let (code, compiled_fns) = self.compile_loop_block_cached(&data, &normalized_body);
 
             let underscore = "_".to_string();
             let dollar_topic = "$_".to_string();

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2835,6 +2835,7 @@ impl Interpreter {
             predictive_seq_iters: HashMap::new(),
             protect_block_cache: HashMap::new(),
             carrier_compile_cache: HashMap::new(),
+            map_grep_compile_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
             subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -530,6 +530,7 @@ impl Interpreter {
             predictive_seq_iters: self.predictive_seq_iters.clone(),
             protect_block_cache: HashMap::new(),
             carrier_compile_cache: HashMap::new(),
+            map_grep_compile_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),
             subset_where_fail: None,
             private_zeroarg_method_cache: HashMap::new(),

--- a/t/map-grep-first-compile-cache.t
+++ b/t/map-grep-first-compile-cache.t
@@ -1,0 +1,59 @@
+use v6;
+use Test;
+
+# `Interpreter::compile_loop_block_cached` (resolution_map_grep.rs) caches the
+# inline-loop fast path's compile of a .map/.grep/.first callback, keyed by
+# the closure literal's `compiled_code` Arc pointer identity, so a block
+# declared *inside* an outer loop reuses its compile across iterations
+# instead of recompiling a fresh `SubData` every time.
+
+plan 4;
+
+# Each outer iteration instantiates a fresh SubData for the SAME source
+# closure literal; the captured `$round` must still be read correctly from
+# each fresh instance's own env, not from a stale cached one.
+{
+    my @seen;
+    for ^4 -> $round {
+        @seen.push((1, 2, 3).map({ $_ + $round }).List);
+    }
+    is @seen.raku, [(1, 2, 3), (2, 3, 4), (3, 4, 5), (4, 5, 6)].raku,
+        'map in a loop reuses the compiled block correctly across fresh SubData instances';
+}
+
+{
+    my @seen;
+    for ^4 -> $round {
+        @seen.push((1, 2, 3, 4).grep({ $_ + $round > 3 }).List);
+    }
+    is @seen.raku, [(4,), (3, 4), (2, 3, 4), (1, 2, 3, 4)].raku,
+        'grep in a loop reuses the compiled block correctly across fresh SubData instances';
+}
+
+{
+    my @seen;
+    for ^4 -> $round {
+        @seen.push((1, 2, 3, 4).first({ $_ + $round > 3 }));
+    }
+    is @seen.raku, [4, 3, 2, 1].raku,
+        'first in a loop reuses the compiled block correctly across fresh SubData instances';
+}
+
+# A closure literal's `compiled_code` Arc may be dropped once its SubData
+# goes out of scope (true for a dynamically-built EVAL closure, which is
+# never retained in an enclosing scope's `closure_compiled_codes`); a cache
+# keyed by bare pointer address would risk a later, unrelated allocation
+# reusing that freed address and returning a stale cache hit. This loop
+# builds a DIFFERENT map/grep block via EVAL on every iteration to stress
+# that path (see `t/rakuast-eval-block-arg.t` for the chained-call case that
+# caught this during development).
+{
+    use MONKEY-SEE-NO-EVAL;
+    my @seen;
+    for ^6 -> $n {
+        my $src = '(1..5).map({ $_ + ' ~ $n ~ ' }).grep({ $_ %% 2 }).join(\',\')';
+        @seen.push(EVAL($src));
+    }
+    is @seen.join('|'), '2,4|2,4,6|4,6|4,6,8|6,8|6,8,10',
+        'repeated EVAL of distinct map/grep blocks never collides via compile-cache pointer reuse';
+}

--- a/todo/tickets/digest-ripemd-start-per-block-overhead.md
+++ b/todo/tickets/digest-ripemd-start-per-block-overhead.md
@@ -1,5 +1,57 @@
 # `Digest::RIPEMD` is 11x raku — a `start` per compression block
 
+> **Status update 5 (2026-08-20, map/grep/`.first` compile-cache lever
+> executed — general win confirmed, `t/ripemd.t` gate itself flat):** update
+> 4's closing note flagged "the `resolution_map_grep` map carrier still
+> recompiles per call/per map invocation" as an untried lever with the same
+> shape as the `reduce_items` compiled-first fix. Implemented it: the map/
+> grep/`.first` inline-loop fast paths (`resolution_map_grep.rs`,
+> `resolution_map_grep_rw.rs`) used to run `compiler.compile()` on the
+> callback block's (tail-normalized) body on every `.map()`/`.grep()`/
+> `.first()` CALL, even when that call site's closure literal is the exact
+> same source occurrence as a previous call (e.g. a block declared inside an
+> outer loop, called fresh each iteration with a brand-new `SubData`). A new
+> `Interpreter::compile_loop_block_cached` reuses a cached compile keyed by
+> the closure's pre-existing `compiled_code` `Arc` pointer identity (already
+> shared across every instantiation of the same source closure literal —
+> baked once into the enclosing scope's `closure_compiled_codes` at that
+> scope's own compile time — so the pointer is a free, stable cache key,
+> **not** a new id-minting scheme).
+>
+> **Correctness pitfall caught during development, now fixed:** an early
+> version keyed the cache on the bare pointer *address* (`usize`) without
+> retaining the Arc, which is unsound whenever the source Arc's only owner is
+> a short-lived `SubData` (true for a dynamically-built `EVAL`/RakuAST
+> closure, never retained in any `closure_compiled_codes` table) — once
+> dropped, a later unrelated `CompiledCode` allocation can reuse the same
+> address and collide with a stale cache entry. `t/rakuast-eval-block-arg.t`
+> caught this immediately (chained `.map().grep()` on one EVAL'd line
+> returned the wrong predicate's result). Fixed by making the cache key
+> (`MapGrepCacheKey`) hold a clone of the Arc itself (custom pointer-identity
+> `Hash`/`Eq`), so the key keeps the source `CompiledCode` alive for as long
+> as the cache entry does. Pinned by `t/map-grep-first-compile-cache.t`
+> (loop-redeclared blocks for map/grep/first, plus a repeated-distinct-EVAL
+> stress case for the pointer-reuse scenario specifically).
+>
+> **Measured, isolated general win** (release, synthetic "closure declared
+> inside an outer loop, few items per call" benchmarks — the exact shape this
+> lever targets): `.map()` ~2.18s → ~1.71s (~22% faster), `.grep()` ~2.93s →
+> ~2.43s (~17%), `.first()` ~1.42s → ~1.03s (~28%) over 200k outer
+> iterations. `cargo test`, the full `t/` suite (30223 tests), and the
+> map/grep/reduce/first roast files all pass with no behavior change.
+>
+> **`t/ripemd.t`'s own gate is flat**, though (release, same machine,
+> back-to-back A/B: ~139s before, ~146s after — within run-to-run noise, no
+> real change either way). This is consistent with update 4's own flat
+> profile finding "no single dominant item left" — the outer
+> `map -> [&f, $r, @K, $s] { start {...} }, zip(...)` this lever targets is
+> evidently not RIPEMD's dominant cost; the malloc/free, thread-local symbol
+> caches, and `call_compiled_closure_with_topic` items from that profile
+> remain unaddressed. Landing this anyway as a genuine, general, verified
+> interpreter improvement (independent of whether it moves any one ticket's
+> needle) — not re-attempting `t/ripemd.t` specifically without a fresh
+> profile pointing at a new dominant item.
+
 > **Status update 4 (2026-08-05, closure-setup + reduce compiled-first —
 > gate 28s → 12s, `t/ripemd.t` 295s → 119s):** two levers executed.
 > Slice 1 (#5941) landed the top closure-call setup allocations from the


### PR DESCRIPTION
## Summary
- Continues `todo/tickets/digest-ripemd-start-per-block-overhead.md`'s update-4 lead: the map/grep/`.first` inline-loop fast paths (`resolution_map_grep.rs`, `resolution_map_grep_rw.rs`) recompiled their callback block from AST on every call, even when the closure literal is the same source occurrence as a previous call (a block declared inside an outer loop, called fresh every iteration).
- `Interpreter::compile_loop_block_cached` reuses a cached compile keyed by the closure's pre-existing `compiled_code` `Arc` pointer identity -- already stable/shared across every instantiation of the same source closure literal, so no new id-minting scheme is needed.
- `MapGrepCacheKey` holds a clone of that `Arc` (not just its address) so the cache key stays alive as long as the entry does. An earlier bare-pointer version was unsound whenever the source Arc's only owner is a short-lived `SubData` (a dynamically-built `EVAL`/RakuAST closure) -- `t/rakuast-eval-block-arg.t` caught the resulting stale-cache-hit bug (chained `.map().grep()` on one EVAL'd line returned the wrong predicate's result) during development.
- Pinned by new `t/map-grep-first-compile-cache.t`.

## Measured
Synthetic "closure declared inside an outer loop" benchmarks (release, 200k outer iterations, few items per call -- the shape this lever targets):
- `.map()`: ~2.18s -> ~1.71s (~22% faster)
- `.grep()`: ~2.93s -> ~2.43s (~17% faster)
- `.first()`: ~1.42s -> ~1.03s (~28% faster)

`Digest::RIPEMD`'s own `t/ripemd.t` gate is flat (release, same machine, back-to-back A/B: ~139s before, ~146s after -- within noise). Consistent with that ticket's existing flat profile ("no single dominant item left") -- this specific lever isn't RIPEMD's bottleneck, but it's a genuine general interpreter improvement independent of that one file.

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` all clean
- [x] Full `t/` suite (3263 files, 30223 tests) passes (only the known pre-existing `t/compunit-can-install.t` root-writability environmental failure, unrelated)
- [x] Targeted map/grep/reduce/first roast files (31 files, 1210 tests) all pass
- [x] New `t/map-grep-first-compile-cache.t` verified to match `raku`'s output exactly