### PR TITLE
fix: anonymous container cell in-place-reassign silently aliased unrelated declarations

### DIFF
--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -975,7 +975,7 @@ impl Interpreter {
             && let Some(cell_val) = self.env().get(name).cloned()
             && let ValueView::ContainerRef(arc) = cell_val.view()
         {
-            Self::cell_store_preserving_container_identity(&arc, &value);
+            Self::cell_store_preserving_container_identity(name, &arc, &value);
             return;
         }
         // Slice B (docs/vm-single-store.md): while a carrier (EVAL / interpreter

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1495,7 +1495,7 @@ impl Interpreter {
                         // Preserve the inner container's identity (§3): a boxed
                         // captured `@a`/`%h` whole-reassigned here must keep its
                         // backing `Gc` so by-value holders observe the update.
-                        Self::cell_store_preserving_container_identity(&arc, &val);
+                        Self::cell_store_preserving_container_identity(&name, &arc, &val);
                         *ip += 1;
                         return Ok(());
                     }
@@ -1508,7 +1508,7 @@ impl Interpreter {
                         && let ValueView::ContainerRef(arc) = cell_val.view()
                     {
                         self.check_container_cell_constraint(&arc, &val)?;
-                        Self::cell_store_preserving_container_identity(&arc, &val);
+                        Self::cell_store_preserving_container_identity(&name, &arc, &val);
                         *ip += 1;
                         return Ok(());
                     }
@@ -1520,7 +1520,7 @@ impl Interpreter {
                         && let ValueView::ContainerRef(arc) = cell_val.view()
                     {
                         self.check_container_cell_constraint(&arc, &val)?;
-                        Self::cell_store_preserving_container_identity(&arc, &val);
+                        Self::cell_store_preserving_container_identity(&name, &arc, &val);
                         *ip += 1;
                         return Ok(());
                     }

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -536,7 +536,7 @@ impl Interpreter {
             // the cell with the inner container's identity preserved (contents
             // copied — `=` copy semantics — so a later `@foo[0]++` cannot reach
             // the RHS source array), and keep the CELL installed in env/locals.
-            Self::cell_store_preserving_container_identity(cell, &val);
+            Self::cell_store_preserving_container_identity(&name, cell, &val);
             let cell_val = Value::container_ref(cell.clone());
             self.update_local_if_exists(code, &name, &cell_val);
             self.set_env_with_main_alias(&name, cell_val);

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -365,7 +365,7 @@ impl Interpreter {
             && let ValueView::ContainerRef(arc) = existing.view()
         {
             self.check_container_cell_constraint(&arc, &value)?;
-            Self::cell_store_preserving_container_identity(&arc, &value);
+            Self::cell_store_preserving_container_identity(&store_name, &arc, &value);
             self.note_caller_env_write(&store_name);
             let result = if sigil == "$" {
                 Self::itemize_value(value)
@@ -426,7 +426,7 @@ impl Interpreter {
             && let ValueView::ContainerRef(arc) = existing.view()
         {
             self.check_container_cell_constraint(&arc, &value)?;
-            Self::cell_store_preserving_container_identity(&arc, &value);
+            Self::cell_store_preserving_container_identity(&store_name, &arc, &value);
             self.note_caller_env_write(&store_name);
             self.stack.push(value);
             return Ok(());

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -739,19 +739,38 @@ impl Interpreter {
     /// whole-reassigned from a nested frame otherwise orphans every by-value
     /// holder of the old backing `Gc` (e.g. `%h` captured into a list). Non
     /// matching shapes fall back to a plain store.
+    ///
+    /// Skips the in-place path (falling through to a plain store) when `name`
+    /// is one of the anonymous container slots (`@__ANON_ARRAY__`,
+    /// `%__ANON_HASH__`) that every bare `my @ = ...`/`my % = ...` expression
+    /// declaration shares: each such declaration is a DISTINCT logical
+    /// variable that merely reuses the slot NAME, so preserving the cell's
+    /// old backing `Gc` would incorrectly alias two unrelated declarations —
+    /// exactly the exclusion the sibling in-place-reassign call sites already
+    /// apply (`vm_var_assign_set_local.rs`'s `is_anon_container`,
+    /// `vm_exec_dispatch.rs`'s `SetGlobal` handler, `vm_misc_assign.rs`'s
+    /// array/hash guards). This cell-store path was the one exclusion missed
+    /// — reachable whenever an anonymous container's declaration is captured
+    /// into a `ContainerRef` cell (escape analysis promotes a
+    /// captured-and-mutated outer container to a cell), which silently
+    /// aliased two sibling `my @ = (^N).map(&callback)` results decoded in
+    /// separate recursive calls (`CBOR::Simple`'s `decode-array` on a nested
+    /// indefinite-length array).
     pub(super) fn cell_store_preserving_container_identity(
+        name: &str,
         arc: &crate::gc::Gc<std::sync::Mutex<Value>>,
         val: &Value,
     ) {
+        let is_anon_container = name.contains("__ANON");
         let mut inner = arc.lock().unwrap();
         let replacement = match (inner.view(), val.view()) {
             (ValueView::Hash(old_gc), ValueView::Hash(new_gc))
-                if !crate::gc::Gc::ptr_eq(&old_gc, &new_gc) =>
+                if !is_anon_container && !crate::gc::Gc::ptr_eq(&old_gc, &new_gc) =>
             {
                 Some(Self::hash_inplace_reassign(&old_gc, &new_gc))
             }
             (ValueView::Array(old_gc, _), ValueView::Array(new_gc, kind))
-                if !crate::gc::Gc::ptr_eq(&old_gc, &new_gc) =>
+                if !is_anon_container && !crate::gc::Gc::ptr_eq(&old_gc, &new_gc) =>
             {
                 Some(Self::array_inplace_reassign(&old_gc, &new_gc, kind))
             }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1673,7 +1673,7 @@ impl Interpreter {
                     // swapping the cell to a fresh pointer) so any other
                     // holder of the old container (e.g. the outer `%ao` a
                     // loop-var `%a` is aliased to) observes this mutation.
-                    Self::cell_store_preserving_container_identity(&arc, &val);
+                    Self::cell_store_preserving_container_identity(&name, &arc, &val);
                 }
                 self.flush_local_to_env(code, idx);
                 return Ok(());

--- a/t/anon-container-cell-inplace-reassign.t
+++ b/t/anon-container-cell-inplace-reassign.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+# `cell_store_preserving_container_identity` (vm_var_assign_ops.rs) mutates
+# an existing ContainerRef cell's backing container IN PLACE when a whole
+# array/hash reassignment reaches it, so aliases (`my @b := @a; @a = ...`)
+# observe the update. Anonymous containers (`my @ = EXPR`, `my % = EXPR`)
+# all compile to the single shared slot name `@__ANON_ARRAY__` /
+# `%__ANON_HASH__` -- each successive declaration is a DISTINCT logical
+# variable that merely reuses that name, so in-place-reassigning through a
+# cell there silently aliased two unrelated declarations together whenever
+# escape analysis had promoted the slot to a cell (reachable via a
+# recursively-invoked closure that reads/writes a captured free variable --
+# CBOR::Simple's `decode-array`, decoding a definite-length array nested
+# inside an indefinite-length one, hit this exactly).
+
+plan 3;
+
+# Minimal reproduction of the CBOR::Simple bug: a closure declared and
+# invoked once per recursive call of an outer sub, whose last expression is
+# a naked `my @ = ...` built from a captured free variable, must not leak
+# into a SIBLING invocation's result once both are collected together.
+{
+    sub cbor_like_decode(@bytes, $pos is rw) {
+        my &decode = {
+            my $b = @bytes[$pos++];
+            $b == 0 ?? decode-array() !! $b
+        };
+        my &decode-array = {
+            my $n = @bytes[$pos++];
+            False ?? Nil !! my @ = (^$n).map(&decode)
+        };
+        decode()
+    }
+    my @bytes = 0, 2, 10, 20, 0, 2, 30, 40;
+    my $pos = 0;
+    my @result;
+    @result.push(cbor_like_decode(@bytes, $pos));
+    @result.push(cbor_like_decode(@bytes, $pos));
+    is @result.raku, [[10, 20], [30, 40]].raku,
+        'sibling recursive calls collecting a naked my @ = ... result do not alias';
+}
+
+# The actual CBOR::Simple shape that surfaced this (decode-array.rakumod:690):
+# an indefinite-length array whose two elements are themselves definite-length
+# arrays, each decoded through a separate recursive `cbor-decode()` call.
+{
+    use CBOR::Simple;
+    sub hex-decode(Str:D $hex, $buf-type = buf8) {
+        $buf-type.new($hex.comb(2).map(*.parse-base(16)))
+    }
+    # Encoding an inline `my @ = ...` array first is what makes the anonymous
+    # slot escape-analysis-promote to a cell in the failing case (see the
+    # ticket for why -- not otherwise load-bearing for the fix itself).
+    cbor-encode((my @ = 1, 2, 3));
+    is-deeply cbor-decode(hex-decode('9f01820203820405ff')), $[1, [2, 3], [4, 5]],
+        'CBOR::Simple decode-array nested-array elements are not aliased';
+}
+
+# The same bug's downstream symptom (todo/tickets/cbor-simple-...): once the
+# aliasing corrupted the first result, decoding continued into a stack
+# overflow later in the same file. Run the actual upstream test file's
+# equivalent assertion sequence leading up to it to guard against a
+# regression reintroducing either half.
+{
+    use CBOR::Simple;
+    sub hex-decode(Str:D $hex, $buf-type = buf8) {
+        $buf-type.new($hex.comb(2).map(*.parse-base(16)))
+    }
+    is-deeply cbor-decode(hex-decode('9f018202039f0405ffff')), $[1, [2, 3], [4, 5]],
+        'a second, differently-shaped nested-indefinite decode right after the first stays correct';
+}

--- a/todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md
+++ b/todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md
@@ -1,5 +1,44 @@
 # `CBOR::Simple`'s own upstream suite fails broadly outside the narrow slice Cro::HTTP/Log::Timeline exercise
 
+> **Update (2026-08-20, second pass): test 68's nested-array decode aliasing bug (and the stack
+> overflow right after it) are ROOT-CAUSED and FIXED.** `01-basic.rakutest` now runs cleanly to
+> completion (74/74 attempted, only the 4 pre-existing unrelated float/unicode failures at tests
+> 24/27/28/53 remain — see the earlier 2026-08-18 update).
+>
+> **Root cause**: `cell_store_preserving_container_identity` (`vm_var_assign_ops.rs`) mutates an
+> existing `ContainerRef` cell's backing container IN PLACE when a whole array/hash reassignment
+> reaches it, so aliases (`my @b := @a; @a = ...`) observe the update — correct for a REAL
+> reassignment. But anonymous containers (`my @ = EXPR`, `my % = EXPR`) all compile to a single
+> shared slot name (`@__ANON_ARRAY__` / `%__ANON_HASH__`; see the `is_anon_container` comment in
+> `vm_var_assign_set_local.rs`), so each successive declaration is a DISTINCT logical variable that
+> merely reuses that name — and every OTHER in-place-reassign call site already excludes anon names
+> for exactly this reason (`vm_var_assign_set_local.rs`'s `SetLocal` handler, `vm_exec_dispatch.rs`'s
+> `SetGlobal` handler, `vm_misc_assign.rs`'s array/hash guards). `cell_store_preserving_container_identity`
+> was the one call site missing that exclusion. It only matters when the anonymous slot has been
+> promoted to a `ContainerRef` cell by escape analysis (a captured-and-mutated outer container) —
+> which is exactly `CBOR::Simple`'s `decode-array` shape: `!! my @ = (^read-uint).map(&decode)` is a
+> closure declared and invoked fresh per recursive `cbor-decode()` call, and `&decode` reading a
+> captured free variable is what triggers the promotion. Two sibling recursive calls (one per nested
+> definite-length array inside an indefinite-length one) then landed on the SAME cell, so the second
+> call's in-place reassign silently overwrote the first's still-referenced result — exactly the
+> `$[1, [4, 5], [4, 5]]` symptom, and the stack overflow shortly after was a downstream consequence
+> of decoding against corrupted state.
+>
+> **Fix**: threaded the variable name through `cell_store_preserving_container_identity`'s 7 call
+> sites and added the same `name.contains("__ANON")` exclusion its four siblings already have.
+> Pinned by `t/anon-container-cell-inplace-reassign.t` (a CBOR-independent mimic of the shape,
+> plus the actual CBOR::Simple repro and a second nested-indefinite case). Full `t/` suite (30219
+> tests), the map/grep/reduce/first/splice/state/closure/container roast files (91 files, ~3450
+> tests), and `Text::CSV`'s `79_callbacks.t` (the other file the surrounding code comments call out
+> as a past regression risk for this exact mechanism) all pass with no behavior change elsewhere.
+>
+> Two standalone (non-CBOR) mimics of the bug shape were tried during the investigation and neither
+> reproduced it even *before* the fix — the trigger needs `CBOR::Simple`'s specific closure/escape
+> shape (many free variables captured across `@decoders`'s dispatch table, `$pos`/`@bytes`/`$breakable`),
+> not just "closure declared fresh per recursive call, returns a naked `my @ = ...`". Not fully
+> reduced past that; not needed once the root cause was found via `MUTSU_DEBUG_ARRAY_ALLOC`-style
+> instrumented builds tracing every `array_inplace_reassign` call site rather than more guessing.
+
 > **Update (2026-08-20): test 68's nested-array decode aliasing bug reduced to a 4-line,
 > CBOR::Simple-scoped repro (previously thought to need the full file's accumulated state) —
 > root cause still open, filed as a lead for a follow-up `todo/deep`.** Bisecting the file


### PR DESCRIPTION
## Summary
- Root-causes and fixes the `todo/tickets/cbor-simple-typed-array-and-diagnostic-format-gaps.md` nested-array decode aliasing bug (`CBOR::Simple`'s `01-basic.rakutest` test 68, and the stack overflow shortly after it).
- `cell_store_preserving_container_identity` (`vm_var_assign_ops.rs`) mutates an existing `ContainerRef` cell's backing container **in place** when a whole array/hash reassignment reaches it -- correct for a real reassignment (`my @b := @a; @a = ...`). But anonymous containers (`my @ = EXPR`, `my % = EXPR`) all compile to a single shared slot name (`@__ANON_ARRAY__` / `%__ANON_HASH__`), so each successive declaration is a DISTINCT logical variable that merely reuses that name. Every other in-place-reassign call site already excludes anon names for this reason (`vm_var_assign_set_local.rs`'s `SetLocal` handler, `vm_exec_dispatch.rs`'s `SetGlobal` handler, `vm_misc_assign.rs`'s array/hash guards) -- this one call site was missed.
- Only surfaces when the anonymous slot is promoted to a `ContainerRef` cell by escape analysis (a captured-and-mutated outer container) -- exactly `CBOR::Simple`'s `decode-array`: a closure declared and invoked fresh per recursive `cbor-decode()` call, whose last expression is a naked `my @ = (^read-uint).map(&decode)`. Two sibling recursive calls (one per nested definite-length array inside an indefinite-length one) landed on the same cell, so the second call's in-place reassign silently overwrote the first's still-referenced result.
- Fix: threaded the variable name through the function's 7 call sites and added the same `name.contains("__ANON")` exclusion its four siblings already have.

## Measured
- `CBOR::Simple`'s `01-basic.rakutest` (previously died with wrong values at test 68 then a stack overflow) now runs cleanly to completion: 74/74 attempted, only 4 pre-existing unrelated float/unicode failures remain (tests 24/27/28/53, documented in the ticket).

## Test plan
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` all clean
- [x] Full `t/` suite (3263 files, 30222 tests) passes (only the known pre-existing `t/compunit-can-install.t` root-writability environmental failure, unrelated)
- [x] Targeted 58 splice/state/closure/container roast files + `Text::CSV`'s `79_callbacks.t` (called out by surrounding code comments as a past regression risk for this exact mechanism) all pass
- [x] New `t/anon-container-cell-inplace-reassign.t` verified against `raku` (matches exactly)