### PR TITLE
fix: push routine frames on the light sub-call paths (ADR-0037 Slice 1)

### DIFF
--- a/docs/adr/0037-eval-context-frame-owns-the-return-target.md
+++ b/docs/adr/0037-eval-context-frame-owns-the-return-target.md
@@ -1,6 +1,8 @@
 # ADR-0037: `EVAL ..., context => $frame` — the context frame owns the return target, and the routine chain must be dispatch-path-independent
 
-- Status: Proposed (design complete; implementation not started)
+- Status: Partially implemented — Slice 1 landed (see "Implementation status"
+  below); Slices 2-4 (the `context`-driven return classification and
+  targeting itself) are next
 - Date: 2026-08-20
 - Origin: `todo/deep/eval-context-frame-owns-the-return-target.md`
 - Related: [ADR-0035](0035-method-calls-observe-caller-frames.md) (same family —
@@ -392,3 +394,48 @@ Deep `CALLER::CALLER::` / `callframes()` chains through frameless intermediate
 subs — ADR-0035's inherited approximation. Slice 1 makes the *routine* stack
 faithful on the light paths; the `caller_env_stack`/`callframe_stack` pair is a
 separate mechanism and is not touched here.
+
+## 8. Implementation status (2026-08-20)
+
+**Slice 1 landed.** `call_compiled_function_positional_light`
+(`src/vm/vm_call_light.rs`) and `call_compiled_function_light_spec`
+(`src/vm/vm_call_light_typed.rs`, the implementation behind
+`call_compiled_function_light`) now push a `RoutineFrame` via
+`push_routine_with_location` right after entering the routine's declaring
+package/pragma state, and pop it immediately after the body-execution loop —
+mirroring `call_compiled_function_fast`'s (`src/vm/vm_call_fast.rs`) existing
+push/pop pairing exactly. Every early exit between the two functions' entry
+and the push (the arity-mismatch and type-mismatch bails) runs before any
+frame is pushed, so needs no matching pop; every exit after the push (the
+body's `return`/`fail`/error/natural-completion arms, and the post-loop
+return-type-check failure) funnels through the single pop site, so the pairing
+holds unconditionally.
+
+The delegate path in `call_compiled_function_light` for a hand-built chunk
+with no precomputed named-call plan (`cf.named_call_plan.is_none()`) falls
+through entirely to `call_compiled_function_named`, which already pushes its
+own frame — untouched.
+
+This fixes `enclosing_routine_exists()` (and every other `routine_stack`
+consumer — `caller_frame_package()`, `executing_source_file()`, backtrace
+rendering) for every sub shape that qualifies for either light path:
+mandatory-positional-only signatures and named-only signatures. Confirmed
+against the §1.3 measured matrix (`t/eval-return-across-dispatch-paths.t`,
+new): all six dispatch-path shapes now answer `1` for
+`EVAL 'return 1'; return 2`, matching raku, where `pos1($x)` and `named1(:$x)`
+previously escaped as an uncaught `X::ControlFlow::Return`. Also re-verified
+the closest pre-existing pin for this predicate,
+`t/eval-return-target-needs-a-real-routine.t`, and the roast pin the design
+called out by name, `roast/S04-statements/return.t` (test 15 specifically),
+both still green.
+
+Cost: confirmed via `MUTSU_VM_STATS=1` on a recursive positional-arg body
+(the exact path this slice touches) that the dual-store counters
+(`clone_env`, `env_deep_copies`, `env_flushes`) are unchanged at `0` —
+the push/pop is a plain `Vec<RoutineFrame>` operation with no `Env` clone, as
+§4 predicted. A bench-CI-measured wall-clock verdict (the §4 guard) is
+pending the next `bench-history.tsv` row past this change's merge commit.
+
+**Slices 2-4 (the `context`-driven return classification and targeting) are
+not started.** They build on Slice 1's now-sound `routine_stack` but are
+independent follow-up work.

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -4,17 +4,17 @@ use crate::symbol::Symbol;
 impl Interpreter {
     /// ADR-0024: `mainline_lexical_frame_active` (the read/write resolver for
     /// a mainline named sub's captured free variables) keys off the LAST
-    /// `routine_stack` frame. Every "light"/"fast" compiled-call path
-    /// (`call_compiled_function_fast`, `call_compiled_function_light[_spec]`,
-    /// `call_compiled_function_positional_light`) deliberately skips pushing
-    /// a `RoutineFrame` — that is precisely the overhead they exist to avoid
-    /// — so a mainline sub dispatched through one of them would run with
-    /// stale/no frame info and its captured cells would silently never
-    /// resolve. Force such a sub onto the frame-pushing path
-    /// (`call_compiled_function_named[_inner]`) by excluding it from every
-    /// light/fast eligibility check at the call site. `mainline_lexical_subs`
-    /// is empty for the overwhelmingly common program, so this is one
-    /// `is_empty` test beyond what those checks already do.
+    /// `routine_stack` frame. This predicate predates ADR-0037 Slice 1, which
+    /// made every "light"/"fast" compiled-call path (`call_compiled_function_fast`,
+    /// `call_compiled_function_light[_spec]`, `call_compiled_function_positional_light`)
+    /// push a `RoutineFrame` unconditionally, so the frame is no longer
+    /// missing on these paths. This exclusion has not been re-verified
+    /// against that; keep forcing a mainline-lexical-capturing sub onto the
+    /// frame-pushing path (`call_compiled_function_named[_inner]`) by
+    /// excluding it from every light/fast eligibility check at the call site
+    /// until it is. `mainline_lexical_subs` is empty for the overwhelmingly
+    /// common program, so this is one `is_empty` test beyond what those
+    /// checks already do.
     #[inline]
     fn light_call_blocked_by_mainline_capture(&self, name: &str) -> bool {
         !self.mainline_lexical_subs.is_empty() && self.mainline_lexical_subs.contains(name)

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -248,6 +248,26 @@ impl Interpreter {
         // Save and restore around the body so callee's `use fatal` never leaks.
         let saved_pragmas = self.save_pragma_state();
 
+        // Push a routine frame for the body's duration so `routine_stack`
+        // consumers (`enclosing_routine_exists()`, `CALLER::`,
+        // `caller_frame_package()`, backtraces) see this call -- mirroring
+        // `call_compiled_function_fast`'s push/pop pairing (see that
+        // function's doc comment). Without this, a sub taking this
+        // positional-light path ran "frameless": `enclosing_routine_exists()`
+        // wrongly answered `false` inside its body, so e.g. `EVAL 'return 1'`
+        // escaped uncaught instead of being caught by a `CATCH` around the
+        // `EVAL` (ADR-0037 Slice 1). `func_name` is interned here rather than
+        // threaded as a pre-interned `Symbol` from the call site -- a
+        // thread-local intern-cache hit on every call after the first for a
+        // given call site, per `push_routine_with_location`'s doc comment.
+        self.push_routine_with_location(
+            Symbol::intern(&cf.package),
+            Symbol::intern(func_name),
+            self.current_source_line(),
+            self.current_source_file_sym(),
+            cf.source_file.as_deref().map(Symbol::intern),
+        );
+
         // A routine (sub/method) body is its own topicalizer for a bare
         // `when`/`default`: a matching `when` sets the global `when_matched`
         // flag (and returns via the succeed signal, caught by the
@@ -317,6 +337,13 @@ impl Interpreter {
                 break;
             }
         }
+
+        // Pop the routine frame pushed above -- see its push site for the
+        // rationale. Paired unconditionally with the push: every loop exit
+        // above (explicit return / fail / error / natural fall-through)
+        // reaches this point, there is no early `return` between push and
+        // here.
+        self.pop_routine();
 
         // Restore the caller's `when_matched` — a bare `when` inside this
         // routine body must not leak its match state to an enclosing given/with.

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -465,6 +465,26 @@ impl Interpreter {
         // Save and restore around the body so callee's `use fatal` never leaks.
         let saved_pragmas = self.save_pragma_state();
 
+        // Push a routine frame for the body's duration so `routine_stack`
+        // consumers (`enclosing_routine_exists()`, `CALLER::`,
+        // `caller_frame_package()`, backtraces) see this call -- mirroring
+        // `call_compiled_function_fast`'s push/pop pairing (see that
+        // function's doc comment). Without this, a sub taking this light
+        // path ran "frameless": `enclosing_routine_exists()` wrongly answered
+        // `false` inside its body, so e.g. `EVAL 'return 1'` escaped uncaught
+        // instead of being caught by a `CATCH` around the `EVAL` (ADR-0037
+        // Slice 1). `func_name` is interned here rather than threaded as a
+        // pre-interned `Symbol` from the call site -- a thread-local
+        // intern-cache hit on every call after the first for a given call
+        // site, per `push_routine_with_location`'s doc comment.
+        self.push_routine_with_location(
+            Symbol::intern(&cf.package),
+            Symbol::intern(func_name),
+            self.current_source_line(),
+            self.current_source_file_sym(),
+            cf.source_file.as_deref().map(Symbol::intern),
+        );
+
         // A routine body is its own topicalizer for a bare `when`/`default`: a
         // matching `when` sets the global `when_matched` flag, which must not
         // leak to an enclosing `given`/`with` body (see vm_call_light.rs for the
@@ -521,6 +541,13 @@ impl Interpreter {
                 break;
             }
         }
+
+        // Pop the routine frame pushed above -- see its push site for the
+        // rationale. Paired unconditionally with the push: every loop exit
+        // above (explicit return / fail / error / natural fall-through)
+        // reaches this point, there is no early `return` between push and
+        // here.
+        self.pop_routine();
 
         // Restore the caller's `when_matched` — a bare `when` inside this
         // routine body must not leak its match state to an enclosing given/with.

--- a/t/eval-return-across-dispatch-paths.t
+++ b/t/eval-return-across-dispatch-paths.t
@@ -1,0 +1,43 @@
+use Test;
+
+plan 6;
+
+# ADR-0037 Slice 1: `push_routine_with_location` (which maintains
+# `routine_stack`, consulted by `enclosing_routine_exists()` and every other
+# `routine_stack` consumer) used to be called only from the 0-arg fast path
+# (`call_compiled_function_fast`) and the full named path
+# (`call_compiled_function_named_inner`). The two "light" sub-call paths --
+# `call_compiled_function_positional_light` (mandatory positional params) and
+# `call_compiled_function_light[_spec]` (named params) -- pushed no routine
+# frame at all, so `enclosing_routine_exists()` wrongly answered `false`
+# inside a sub taking either path, even though a routine plainly enclosed it.
+#
+# Concretely: `EVAL 'return 1'` inside such a sub's body incorrectly escaped
+# as an uncaught `X::ControlFlow::Return` instead of being treated as a real
+# non-local `return` -- the same behavior a 0-arg sub already got right. This
+# file pins one sub shape per dispatch path, matching the measured matrix in
+# docs/adr/0037-eval-context-frame-owns-the-return-target.md section 1.3;
+# raku answers `1` for every row (verified against `raku` on this machine).
+
+sub zero() { EVAL 'return 1'; return 2 }
+is zero(), 1, 'EVAL return in a 0-arg sub (fast path) returns from the sub';
+
+sub pos1($x) { EVAL 'return 1'; return 2 }
+is pos1(9), 1,
+    'EVAL return in a mandatory-positional sub (positional-light path) returns from the sub';
+
+sub named1(:$x) { EVAL 'return 1'; return 2 }
+is named1(:x(9)), 1,
+    'EVAL return in a named-param sub (light path) returns from the sub';
+
+sub arr(@x) { EVAL 'return 1'; return 2 }
+is arr([1, 2]), 1,
+    'EVAL return in an array-param sub (full named path) returns from the sub';
+
+sub opt($x?) { EVAL 'return 1'; return 2 }
+is opt(), 1,
+    'EVAL return in an optional-param sub (full named path) returns from the sub';
+
+sub slurp(*@x) { EVAL 'return 1'; return 2 }
+is slurp(1, 2), 1,
+    'EVAL return in a slurpy-param sub (full named path) returns from the sub';


### PR DESCRIPTION
## Summary

- `push_routine_with_location` (which maintains `routine_stack`, consulted by `enclosing_routine_exists()`, `caller_frame_package()`, `executing_source_file()`, and backtrace rendering) was only ever called from the 0-arg fast path (`call_compiled_function_fast`) and the full named path (`call_compiled_function_named_inner`). The two "light" sub-call paths -- `call_compiled_function_positional_light` (mandatory-positional signatures) and `call_compiled_function_light[_spec]` (named signatures) -- pushed no routine frame at all, so `enclosing_routine_exists()` wrongly answered `false` inside a sub taking either path, even though a routine plainly enclosed it.
- Concretely: `EVAL 'return 1'` inside such a sub's body escaped as an uncaught `X::ControlFlow::Return` instead of returning from the sub, unlike the 0-arg case which already got this right.
- Fix: push/pop a `RoutineFrame` in both light paths, mirroring `call_compiled_function_fast`'s existing pairing exactly -- push right after entering the routine's declaring package/pragma state, pop right after the body-execution loop (every loop exit -- explicit return / fail / error / natural fall-through -- funnels through the one pop site). Every early bail (arity mismatch, type-check mismatch) happens *before* the push, so needs no matching pop.
- This is Slice 1 of [ADR-0037](docs/adr/0037-eval-context-frame-owns-the-return-target.md), a prerequisite for Slices 2-4 (the `context`-driven return classification/targeting), which are follow-up work not touched here. ADR status updated with an "Implementation status" section.

## Test plan

- [x] New regression pin `t/eval-return-across-dispatch-paths.t`: the ADR's measured §1.3 matrix -- one sub shape per dispatch path (0-arg fast, mandatory-positional light, named light, array-param/optional-param/slurpy full-named), each body `{ EVAL 'return 1'; return 2 }`, all now answering `1` (verified against `raku` directly).
- [x] `roast/S04-statements/return.t` (26/26, including test 15 -- the recorded reason `enclosing_routine_exists()` exists at all)
- [x] `roast/S06-advanced/return.t`, `roast/S06-advanced/callframe.t`
- [x] `t/eval-caller-frames.t`, `t/caller-not-dynamic.t`, `t/callframe-*.t` (4 files), `t/module-file-var-and-callframe.t`, `t/backtrace-block-frames.t`, `t/eval-return-target-needs-a-real-routine.t`
- [x] Full `prove t/` (3266 files, 30235 tests): one unrelated failure, `t/compunit-can-install.t` test 4 (filesystem-permission-dependent, confirmed to fail identically on unmodified `main` in this container -- not caused by this change)
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` all clean
- [x] `MUTSU_VM_STATS=1` sanity check on a recursive positional-arg body (the exact path this touches): `clone_env=0 env_deep_copies=0 env_flushes=0`, confirming no dual-store cost increase -- just the plain `Vec<RoutineFrame>` push/pop the ADR predicted
- [ ] CI (`make test` + `make roast` + gc-stress/jit-stress) -- watching in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)